### PR TITLE
Implement missing parts of ArrowFlight server

### DIFF
--- a/ci/docker/integration/arrowflight/flight_server.py
+++ b/ci/docker/integration/arrowflight/flight_server.py
@@ -47,9 +47,15 @@ class FlightServer(fl.FlightServerBase):
         return fl.FlightDescriptor.for_command("Action executed")
 
     def get_flight_info(self, context, descriptor):
-        path_0 = descriptor.path[0].decode()
-        dataset = json.loads(path_0)["dataset"]
-        endpoints = [pa.flight.FlightEndpoint(dataset, [self._location])]
+        descriptor_ok = (descriptor.descriptor_type == fl.DescriptorType.PATH) and (
+            len(descriptor.path) == 1
+        )
+        if not descriptor_ok:
+            raise fl.FlightServerError(
+                f"Descriptor {descriptor} is not supported. Only single-component path descriptors are supported"
+            )
+        ticket = descriptor.path[0]
+        endpoints = [pa.flight.FlightEndpoint(ticket, [self._location])]
         return fl.FlightInfo(self._schema, descriptor, endpoints)
 
 

--- a/ci/docker/integration/runner/requirements.txt
+++ b/ci/docker/integration/runner/requirements.txt
@@ -70,8 +70,7 @@ psycopg-binary==3.2.4
 psycopg2-binary==2.9.6
 psycopg==3.2.4
 py4j==0.10.9.7
-pyarrow-hotfix==0.6
-pyarrow==17.0.0
+pyarrow==22.0.0
 pycparser==2.22
 pycryptodome==3.20.0
 pydantic==2.9.2

--- a/ci/docker/stateless-test/requirements.txt
+++ b/ci/docker/stateless-test/requirements.txt
@@ -3,7 +3,7 @@ numpy==1.26.4
 requests==2.32.4
 pandas==1.5.3
 scipy==1.12.0
-pyarrow==18.0.0
+pyarrow==22.0.0
 grpcio==1.60.0
 protobuf==4.25.8
 

--- a/src/Processors/Formats/Impl/CHColumnToArrowColumn.cpp
+++ b/src/Processors/Formats/Impl/CHColumnToArrowColumn.cpp
@@ -1150,7 +1150,8 @@ namespace DB
     {
         std::vector<arrow::ArrayVector> table_data(columns_num);
 
-        const Chunk * chunk_to_initialize_schema = chunks.empty() ? nullptr : &chunks[0];
+        /// We use the first chunk to initialize the arrow schema.
+        const Chunk * chunk_to_initialize_schema = chunks.empty() ? nullptr : chunks.data();
         initializeArrowSchema(chunk_to_initialize_schema, columns_num, column_to_field_id);
 
         for (const auto & chunk : chunks)

--- a/src/Processors/Formats/Impl/CHColumnToArrowColumn.cpp
+++ b/src/Processors/Formats/Impl/CHColumnToArrowColumn.cpp
@@ -1064,20 +1064,82 @@ namespace DB
     }
 
     CHColumnToArrowColumn::CHColumnToArrowColumn(const Block & header, const std::string & format_name_, const Settings & settings_)
-        : format_name(format_name_), settings(settings_)
+        : CHColumnToArrowColumn(header.getColumnsWithTypeAndName(), format_name_, settings_)
     {
-        arrow_fields.reserve(header.columns());
-        header_columns.reserve(header.columns());
-        for (auto column : header.getColumnsWithTypeAndName())
+    }
+
+    CHColumnToArrowColumn::CHColumnToArrowColumn(
+        const ColumnsWithTypeAndName & header_columns_, const std::string & format_name_, const Settings & settings_)
+        : format_name(format_name_)
+        , settings(settings_)
+    {
+        header_columns.reserve(header_columns_.size());
+        for (auto column : header_columns_)
         {
             if (!settings.low_cardinality_as_dictionary)
             {
                 column.type = recursiveRemoveLowCardinality(column.type);
                 column.column = recursiveRemoveLowCardinality(column.column);
             }
-
             header_columns.emplace_back(std::move(column));
         }
+    }
+
+    std::unique_ptr<CHColumnToArrowColumn> CHColumnToArrowColumn::clone(bool copy_arrow_schema) const
+    {
+        auto res = std::make_unique<CHColumnToArrowColumn>(header_columns, format_name, settings);
+        if (copy_arrow_schema)
+            res->arrow_schema = arrow_schema;
+        return res;
+    }
+
+    void CHColumnToArrowColumn::initializeArrowSchema(
+        const Chunk * chunk, std::optional<size_t> columns_num, const std::optional<std::unordered_map<String, Int64>> & column_to_field_id)
+    {
+        if (arrow_schema)
+            return;
+
+        if (!columns_num)
+            columns_num = header_columns.size();
+
+        std::vector<std::shared_ptr<arrow::Field>> arrow_fields;
+        arrow_fields.reserve(*columns_num);
+
+        for (size_t column_i = 0; column_i < *columns_num; ++column_i)
+        {
+            const ColumnWithTypeAndName & header_column = header_columns[column_i];
+            auto column = chunk ? chunk->getColumns()[column_i] : header_column.column;
+
+            if (!settings.low_cardinality_as_dictionary)
+                column = recursiveRemoveLowCardinality(column);
+
+            bool is_column_nullable = false;
+            auto arrow_type = getArrowType(
+                header_column.type,
+                column,
+                header_column.name,
+                format_name,
+                settings,
+                &is_column_nullable);
+            if (column_to_field_id && column_to_field_id->contains(header_column.name))
+            {
+                Int64 field_id = column_to_field_id->at(header_column.name);
+                auto key_value_metadata = arrow::key_value_metadata({"PARQUET:field_id"},
+                            {std::to_string(field_id)});
+                arrow_fields.emplace_back(std::make_shared<arrow::Field>(header_column.name, arrow_type, is_column_nullable, key_value_metadata));
+            }
+            else
+                arrow_fields.emplace_back(std::make_shared<arrow::Field>(header_column.name, arrow_type, is_column_nullable));
+        }
+
+        arrow_schema = std::make_shared<arrow::Schema>(arrow_fields);
+    }
+
+    std::shared_ptr<arrow::Schema> CHColumnToArrowColumn::getArrowSchema() const
+    {
+        if (!arrow_schema)
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Arrow schema is not initialized");
+        return arrow_schema;
     }
 
     void CHColumnToArrowColumn::chChunkToArrowTable(
@@ -1086,12 +1148,14 @@ namespace DB
         size_t columns_num,
         const std::optional<std::unordered_map<String, Int64>> & column_to_field_id)
     {
-        std::shared_ptr<arrow::Schema> arrow_schema;
         std::vector<arrow::ArrayVector> table_data(columns_num);
+
+        const Chunk * chunk_to_initialize_schema = chunks.empty() ? nullptr : &chunks[0];
+        initializeArrowSchema(chunk_to_initialize_schema, columns_num, column_to_field_id);
 
         for (const auto & chunk : chunks)
         {
-            /// For arrow::Schema and arrow::Table creation
+            /// For arrow::Table creation
             for (size_t column_i = 0; column_i < columns_num; ++column_i)
             {
                 const ColumnWithTypeAndName & header_column = header_columns[column_i];
@@ -1100,29 +1164,8 @@ namespace DB
                 if (!settings.low_cardinality_as_dictionary)
                     column = recursiveRemoveLowCardinality(column);
 
-                if (!is_arrow_fields_initialized)
-                {
-                    bool is_column_nullable = false;
-                    auto arrow_type = getArrowType(
-                        header_column.type,
-                        column,
-                        header_column.name,
-                        format_name,
-                        settings,
-                        &is_column_nullable);
-                    if (column_to_field_id && column_to_field_id->contains(header_column.name))
-                    {
-                        Int64 field_id = column_to_field_id->at(header_column.name);
-                        auto key_value_metadata = arrow::key_value_metadata({"PARQUET:field_id"},
-                                  {std::to_string(field_id)});
-                        arrow_fields.emplace_back(std::make_shared<arrow::Field>(header_column.name, arrow_type, is_column_nullable, key_value_metadata));
-                    }
-                    else
-                        arrow_fields.emplace_back(std::make_shared<arrow::Field>(header_column.name, arrow_type, is_column_nullable));
-                }
-
                 std::unique_ptr<arrow::ArrayBuilder> array_builder;
-                arrow::Status status = MakeBuilder(arrow::default_memory_pool(), arrow_fields[column_i]->type(), &array_builder);
+                arrow::Status status = MakeBuilder(arrow::default_memory_pool(), arrow_schema->field(column_i)->type(), &array_builder);
                 checkStatus(status, column->getName(), format_name);
 
                 fillArrowArray(
@@ -1143,10 +1186,6 @@ namespace DB
 
                 table_data.at(column_i).emplace_back(std::move(arrow_array));
             }
-
-            is_arrow_fields_initialized = true;
-            if (!arrow_schema)
-                arrow_schema = std::make_shared<arrow::Schema>(arrow_fields);
         }
 
         std::vector<std::shared_ptr<arrow::ChunkedArray>> columns;
@@ -1156,7 +1195,6 @@ namespace DB
 
         res = arrow::Table::Make(arrow_schema, columns);
     }
-
 }
 
 #endif

--- a/src/Processors/Formats/Impl/CHColumnToArrowColumn.cpp
+++ b/src/Processors/Formats/Impl/CHColumnToArrowColumn.cpp
@@ -1073,14 +1073,16 @@ namespace DB
         : format_name(format_name_)
         , settings(settings_)
     {
+        if (settings.low_cardinality_as_dictionary)
+        {
+            header_columns = header_columns_;
+            return;
+        }
         header_columns.reserve(header_columns_.size());
         for (auto column : header_columns_)
         {
-            if (!settings.low_cardinality_as_dictionary)
-            {
-                column.type = recursiveRemoveLowCardinality(column.type);
-                column.column = recursiveRemoveLowCardinality(column.column);
-            }
+            column.type = recursiveRemoveLowCardinality(column.type);
+            column.column = recursiveRemoveLowCardinality(column.column);
             header_columns.emplace_back(std::move(column));
         }
     }

--- a/src/Processors/Formats/Impl/CHColumnToArrowColumn.h
+++ b/src/Processors/Formats/Impl/CHColumnToArrowColumn.h
@@ -34,6 +34,23 @@ public:
     };
 
     CHColumnToArrowColumn(const Block & header, const std::string & format_name_, const Settings & settings_);
+    CHColumnToArrowColumn(const ColumnsWithTypeAndName & header_columns_, const std::string & format_name_, const Settings & settings_);
+
+    /// Makes a copy of this converter.
+    /// This can be useful to prepare for conversion in multiple threads.
+    std::unique_ptr<CHColumnToArrowColumn> clone(bool copy_arrow_schema = false) const;
+
+    /// Initializes the arrow schema.
+    /// It's not done in the constructor because LowCardinality column from header always has indexes type UInt8,
+    /// so we should get proper indexes type from the first chunk of data.
+    /// If the arrow schema is already initialized this function does nothing.
+    void initializeArrowSchema(
+        const Chunk * chunk = nullptr,
+        std::optional<size_t> columns_num = std::nullopt,
+        const std::optional<std::unordered_map<String, Int64>> & column_to_field_id = std::nullopt);
+
+    /// Returns the arrow schema (if it's not initialized yet this function will initialize it from the header columns).
+    std::shared_ptr<arrow::Schema> getArrowSchema() const;
 
     void chChunkToArrowTable(
         std::shared_ptr<arrow::Table> & res,
@@ -43,19 +60,18 @@ public:
 
 private:
     ColumnsWithTypeAndName header_columns;
-    std::vector<std::shared_ptr<arrow::Field>> arrow_fields;
     const std::string format_name;
-    Settings settings;
+    const Settings settings;
+
+    /// We should initialize arrow schema on first call of chChunkToArrowTable, not in constructor
+    /// because LowCardinality column from header always has indexes type UInt8, so, we should get
+    /// proper indexes type from first chunk of data.
+    std::shared_ptr<arrow::Schema> arrow_schema;
 
     /// Map {column name : arrow dictionary}.
     /// To avoid converting dictionary from LowCardinality to Arrow
     /// Dictionary every chunk we save it and reuse.
     std::unordered_map<std::string, MutableColumnPtr> dictionary_values;
-
-    /// We should initialize arrow fields on first call of chChunkToArrowTable, not in constructor
-    /// because LowCardinality column from header always has indexes type UInt8, so, we should get
-    /// proper indexes type from first chunk of data.
-    bool is_arrow_fields_initialized = false;
 };
 
 }

--- a/src/Processors/Formats/Impl/CHColumnToArrowColumn.h
+++ b/src/Processors/Formats/Impl/CHColumnToArrowColumn.h
@@ -40,16 +40,20 @@ public:
     /// This can be useful to prepare for conversion in multiple threads.
     std::unique_ptr<CHColumnToArrowColumn> clone(bool copy_arrow_schema = false) const;
 
-    /// Initializes the arrow schema.
-    /// It's not done in the constructor because LowCardinality column from header always has indexes type UInt8,
-    /// so we should get proper indexes type from the first chunk of data.
-    /// If the arrow schema is already initialized this function does nothing.
+    /// Initializes the arrow schema if it is not initialized yet.
+    /// We can't do this in the constructor because the type of indexes for LowCardinality column can change between different chunks of data
+    /// but we must use the same arrow schema for all chunks.
+    /// So we use the type of indexes from the first chunk of data to generate the arrow schema
+    /// because it's better than getting the type of indexes from the header where it's always UInt8).
+    /// Anyway we use at least 32 bit for arrow indexes (see getArrowTypeForLowCardinalityIndexes) which should be enough for most cases.
     void initializeArrowSchema(
         const Chunk * chunk = nullptr,
         std::optional<size_t> columns_num = std::nullopt,
         const std::optional<std::unordered_map<String, Int64>> & column_to_field_id = std::nullopt);
 
     /// Returns the arrow schema (if it's not initialized yet this function will initialize it from the header columns).
+    /// Arrow schemas are immutable (all members of class arrow::Schema are const), so
+    /// it's safe to pass `std::shared_ptr<arrow::Schema>` to other threads.
     std::shared_ptr<arrow::Schema> getArrowSchema() const;
 
     void chChunkToArrowTable(

--- a/src/Processors/Sources/ArrowFlightSource.cpp
+++ b/src/Processors/Sources/ArrowFlightSource.cpp
@@ -1,18 +1,10 @@
 #include <Processors/Sources/ArrowFlightSource.h>
 
 #if USE_ARROWFLIGHT
-#include <Columns/ColumnNullable.h>
-#include <Columns/ColumnString.h>
-#include <Columns/ColumnsNumber.h>
-#include <Processors/Chunk.h>
-#include <Processors/Executors/PullingPipelineExecutor.h>
-#include <Processors/Formats/Impl/ArrowBufferedStreams.h>
 #include <Processors/Formats/Impl/ArrowColumnToCHColumn.h>
 #include <Storages/ArrowFlight/ArrowFlightConnection.h>
-#include <arrow/array.h>
-#include <base/range.h>
-#include <Common/assert_cast.h>
-#include <Common/logger_useful.h>
+#include <arrow/table.h>
+
 
 namespace DB
 {

--- a/src/Processors/Sources/ArrowFlightSource.cpp
+++ b/src/Processors/Sources/ArrowFlightSource.cpp
@@ -26,25 +26,24 @@ extern const int ARROWFLIGHT_INTERNAL_ERROR;
 
 ArrowFlightSource::ArrowFlightSource(
     std::shared_ptr<ArrowFlightConnection> connection_,
-    const std::string & query_,
+    const String & dataset_,
     const Block & sample_block_,
     const std::vector<std::string> & column_names_,
     UInt64 /*max_block_size_*/)
     : ISource(std::make_shared<const Block>(sample_block_.cloneEmpty()))
     , connection(connection_)
-    , query(query_)
     , sample_block(sample_block_)
     , column_names(column_names_)
 {
-    initializeStream();
+    initializeStream(dataset_);
 }
 
-void ArrowFlightSource::initializeStream()
+void ArrowFlightSource::initializeStream(const String & dataset_)
 {
     auto client = connection->getClient();
     auto options = connection->getOptions();
 
-    arrow::flight::FlightDescriptor descriptor = arrow::flight::FlightDescriptor::Path({query});
+    arrow::flight::FlightDescriptor descriptor = arrow::flight::FlightDescriptor::Path({dataset_});
 
     auto flight_info_result = client->GetFlightInfo(*options, descriptor);
     if (!flight_info_result.ok())

--- a/src/Processors/Sources/ArrowFlightSource.cpp
+++ b/src/Processors/Sources/ArrowFlightSource.cpp
@@ -26,75 +26,129 @@ extern const int ARROWFLIGHT_INTERNAL_ERROR;
 
 ArrowFlightSource::ArrowFlightSource(
     std::shared_ptr<ArrowFlightConnection> connection_,
-    const String & dataset_,
-    const Block & sample_block_,
-    const std::vector<std::string> & column_names_,
-    UInt64 /*max_block_size_*/)
+    const String & dataset_name_,
+    const Block & sample_block_)
     : ISource(std::make_shared<const Block>(sample_block_.cloneEmpty()))
     , connection(connection_)
     , sample_block(sample_block_)
-    , column_names(column_names_)
 {
-    initializeStream(dataset_);
+    initializeEndpoints(dataset_name_);
 }
 
-void ArrowFlightSource::initializeStream(const String & dataset_)
+ArrowFlightSource::ArrowFlightSource(
+    std::shared_ptr<ArrowFlightConnection> connection_,
+    std::vector<arrow::flight::FlightEndpoint> endpoints_,
+    const Block & sample_block_)
+    : ISource(std::make_shared<const Block>(sample_block_.cloneEmpty()))
+    , connection(connection_)
+    , sample_block(sample_block_)
+    , endpoints(std::move(endpoints_))
+{
+}
+
+ArrowFlightSource::ArrowFlightSource(
+    std::unique_ptr<arrow::flight::MetadataRecordBatchReader> stream_reader_,
+    const Block & sample_block_)
+    : ISource(std::make_shared<const Block>(sample_block_.cloneEmpty()))
+    , sample_block(sample_block_)
+    , stream_reader(std::move(stream_reader_))
+{
+    initializeSchema();
+}
+
+
+ArrowFlightSource::~ArrowFlightSource() = default;
+
+
+void ArrowFlightSource::initializeEndpoints(const String & dataset_name_)
 {
     auto client = connection->getClient();
     auto options = connection->getOptions();
 
-    arrow::flight::FlightDescriptor descriptor = arrow::flight::FlightDescriptor::Path({dataset_});
+    arrow::flight::FlightDescriptor descriptor = arrow::flight::FlightDescriptor::Path({dataset_name_});
 
-    auto flight_info_result = client->GetFlightInfo(*options, descriptor);
-    if (!flight_info_result.ok())
+    auto flight_info_res = client->GetFlightInfo(*options, descriptor);
+    if (!flight_info_res.ok())
     {
         throw Exception(
             ErrorCodes::ARROWFLIGHT_FETCH_SCHEMA_ERROR,
             "Failed to get FlightInfo from Arrow Flight server: {}",
-            flight_info_result.status().ToString());
+            flight_info_res.status().ToString());
     }
 
-    std::unique_ptr<arrow::flight::FlightInfo> flight_info = std::move(flight_info_result).ValueOrDie();
+    std::unique_ptr<arrow::flight::FlightInfo> flight_info = std::move(flight_info_res).ValueOrDie();
 
     if (flight_info->endpoints().empty())
-    {
         throw Exception(ErrorCodes::ARROWFLIGHT_FETCH_SCHEMA_ERROR, "FlightInfo returned with no endpoints");
-    }
 
-    arrow::flight::Ticket ticket = flight_info->endpoints()[0].ticket;
+    endpoints = flight_info->endpoints();
+}
 
-    auto result = client->DoGet(*options, ticket);
-    if (!result.ok())
+
+bool ArrowFlightSource::nextEndpoint()
+{
+    if (current_endpoint >= endpoints.size())
+        return false;
+
+    const auto & endpoint = endpoints[current_endpoint];
+
+    auto client = connection->getClient();
+    auto options = connection->getOptions();
+
+    arrow::flight::Ticket ticket = endpoint.ticket;
+
+    auto stream_reader_res = client->DoGet(*options, ticket);
+    if (!stream_reader_res.ok())
     {
         throw Exception(
-            ErrorCodes::ARROWFLIGHT_CONNECTION_FAILURE, "Failed to initialize Arrow Flight stream: {}", result.status().ToString());
+            ErrorCodes::ARROWFLIGHT_CONNECTION_FAILURE, "Failed to initialize Arrow Flight stream: {}", stream_reader_res.status().ToString());
     }
 
-    stream_reader = std::move(result.ValueOrDie());
+    stream_reader = std::move(stream_reader_res.ValueOrDie());
+    initializeSchema();
 
-    auto result_schema = stream_reader->GetSchema();
-    if (!result_schema.ok())
-    {
-        throw Exception(ErrorCodes::ARROWFLIGHT_FETCH_SCHEMA_ERROR, "Failed to get table schema: {}", result_schema.status().ToString());
-    }
-    schema = result_schema.ValueOrDie();
+    ++current_endpoint;
+    return true;
 }
+
+
+void ArrowFlightSource::initializeSchema()
+{
+    if (stream_reader)
+    {
+        auto schema_res = stream_reader->GetSchema();
+        if (!schema_res.ok())
+            throw Exception(ErrorCodes::ARROWFLIGHT_FETCH_SCHEMA_ERROR, "Failed to get table schema: {}", schema_res.status().ToString());
+
+        schema = schema_res.ValueOrDie();
+    }
+}
+
 
 Chunk ArrowFlightSource::generate()
 {
-    auto status = stream_reader->Next();
-
-    if (!status.ok())
+    arrow::flight::FlightStreamChunk chunk;
+    while (!chunk.data)
     {
-        throw Exception(ErrorCodes::ARROWFLIGHT_INTERNAL_ERROR, "Arrow Flight internal error: {}", status.status().ToString());
-    }
+        if (!stream_reader && !nextEndpoint())
+        {
+            /// No more endpoints, we've read everything.
+            return {};
+        }
 
-    const auto & chunk = status.ValueOrDie();
-    auto batch = chunk.data;
+        chassert(stream_reader);
 
-    if (!batch)
-    {
-        return {};
+        auto chunk_res = stream_reader->Next();
+        if (!chunk_res.ok())
+            throw Exception(ErrorCodes::ARROWFLIGHT_INTERNAL_ERROR, "Arrow Flight internal error: {}", chunk_res.status().ToString());
+
+        chunk = chunk_res.ValueOrDie();
+
+        if (!chunk.data)
+        {
+            /// We've finished reading from this stream reader, now it's time to try the next endpoint.
+            stream_reader = nullptr;
+        }
     }
 
     MutableColumns columns;
@@ -108,18 +162,14 @@ Chunk ArrowFlightSource::generate()
                                     FormatSettings::DateTimeOverflowBehavior::Throw,
                                     /* allow_geoparquet_parser = */ false);
 
-    auto batch_result = arrow::Table::FromRecordBatches({batch});
-    if (!batch_result.ok())
+    auto table_res = arrow::Table::FromRecordBatches({chunk.data});
+    if (!table_res.ok())
     {
-        throw Exception(ErrorCodes::ARROWFLIGHT_INTERNAL_ERROR, "Arrow Flight internal error: {}", batch_result.status().ToString());
+        throw Exception(ErrorCodes::ARROWFLIGHT_INTERNAL_ERROR, "Arrow Flight internal error: {}", table_res.status().ToString());
     }
-    auto table = std::move(batch_result).ValueOrDie();
-    auto ch_chunk = converter.arrowTableToCHChunk(table, batch->num_rows(), nullptr, nullptr);
-    for (const auto & col : ch_chunk.getColumns())
-        columns.push_back(IColumn::mutate(col->cloneResized(batch->num_rows())));
+    auto table = std::move(table_res).ValueOrDie();
 
-    Chunk filled_chunk(std::move(columns), batch->num_rows());
-    return filled_chunk;
+    return converter.arrowTableToCHChunk(table, chunk.data->num_rows(), nullptr, nullptr);
 }
 
 }

--- a/src/Processors/Sources/ArrowFlightSource.h
+++ b/src/Processors/Sources/ArrowFlightSource.h
@@ -3,10 +3,9 @@
 #include "config.h"
 
 #if USE_ARROWFLIGHT
-#include <DataTypes/DataTypeFactory.h>
 #include <Processors/ISource.h>
-#include <arrow/flight/api.h>
-#include <arrow/table.h>
+#include <arrow/flight/types.h>
+
 
 namespace DB
 {

--- a/src/Processors/Sources/ArrowFlightSource.h
+++ b/src/Processors/Sources/ArrowFlightSource.h
@@ -17,7 +17,7 @@ class ArrowFlightSource : public ISource
 public:
     ArrowFlightSource(
         std::shared_ptr<ArrowFlightConnection> connection_,
-        const std::string & query_,
+        const String & dataset_,
         const Block & sample_block_,
         const std::vector<std::string> & column_names_,
         UInt64 max_block_size_);
@@ -31,14 +31,13 @@ protected:
 
 private:
     std::shared_ptr<ArrowFlightConnection> connection;
-    std::string query;
 
     Block sample_block;
     std::unique_ptr<arrow::flight::FlightStreamReader> stream_reader;
     std::shared_ptr<arrow::Schema> schema;
     std::vector<std::string> column_names;
 
-    void initializeStream();
+    void initializeStream(const String & dataset_);
 };
 
 }

--- a/src/Processors/Sources/ArrowFlightSource.h
+++ b/src/Processors/Sources/ArrowFlightSource.h
@@ -15,29 +15,28 @@ class ArrowFlightConnection;
 class ArrowFlightSource : public ISource
 {
 public:
-    ArrowFlightSource(
-        std::shared_ptr<ArrowFlightConnection> connection_,
-        const String & dataset_,
-        const Block & sample_block_,
-        const std::vector<std::string> & column_names_,
-        UInt64 max_block_size_);
+    ArrowFlightSource(std::shared_ptr<ArrowFlightConnection> connection_, const String & dataset_name_, const Block & sample_block_);
+    ArrowFlightSource(std::shared_ptr<ArrowFlightConnection> connection_, std::vector<arrow::flight::FlightEndpoint> endpoints_, const Block & sample_block_);
+    ArrowFlightSource(std::unique_ptr<arrow::flight::MetadataRecordBatchReader> stream_reader_, const Block & sample_block_);
 
-    ~ArrowFlightSource() override = default;
-
+    ~ArrowFlightSource() override;
     String getName() const override { return "ArrowFlightSource"; }
 
 protected:
     Chunk generate() override;
 
 private:
+    void initializeEndpoints(const String & dataset_name_);
+    bool nextEndpoint();
+    void initializeSchema();
+
     std::shared_ptr<ArrowFlightConnection> connection;
 
     Block sample_block;
-    std::unique_ptr<arrow::flight::FlightStreamReader> stream_reader;
+    std::vector<arrow::flight::FlightEndpoint> endpoints;
+    size_t current_endpoint = 0;
+    std::unique_ptr<arrow::flight::MetadataRecordBatchReader> stream_reader;
     std::shared_ptr<arrow::Schema> schema;
-    std::vector<std::string> column_names;
-
-    void initializeStream(const String & dataset_);
 };
 
 }

--- a/src/Server/ArrowFlightHandler.cpp
+++ b/src/Server/ArrowFlightHandler.cpp
@@ -1,62 +1,31 @@
 #include <Server/ArrowFlightHandler.h>
 
 #if USE_ARROWFLIGHT
-#include <memory>
-#include <arrow/compute/api.h>
-#include <arrow/flight/api.h>
-#include <arrow/flight/types.h>
-#include <arrow/ipc/api.h>
-#include <arrow/memory_pool.h>
-#include <arrow/result.h>
-#include <arrow/status.h>
-#include <arrow/table.h>
-#include <arrow/util/macros.h>
 
-#include <fstream>
-#include <sstream>
-#include <Access/Credentials.h>
-#include <Core/Block.h>
-#include <IO/ReadBufferFromString.h>
-#include <IO/WriteBufferFromString.h>
+#include <Common/Base64.h>
+#include <Common/CurrentThread.h>
+#include <Common/logger_useful.h>
+#include <Common/setThreadName.h>
+#include <Common/quoteString.h>
 #include <Interpreters/Context.h>
-#include <Interpreters/DatabaseCatalog.h>
-#include <Interpreters/InterpreterInsertQuery.h>
 #include <Interpreters/Session.h>
 #include <Interpreters/executeQuery.h>
-#include <Parsers/ASTExpressionList.h>
-#include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTInsertQuery.h>
 #include <Parsers/ASTQueryWithOutput.h>
-#include <Parsers/ParserInsertQuery.h>
-#include <Parsers/parseQuery.h>
 #include <Processors/Executors/CompletedPipelineExecutor.h>
-#include <Processors/Executors/PipelineExecutor.h>
 #include <Processors/Executors/PullingPipelineExecutor.h>
-#include <Processors/Formats/Impl/ArrowBufferedStreams.h>
-#include <Processors/Formats/Impl/ArrowColumnToCHColumn.h>
 #include <Processors/Formats/Impl/CHColumnToArrowColumn.h>
-#include <Processors/ISource.h>
-#include <Processors/Sinks/SinkToStorage.h>
 #include <Processors/Sinks/NullSink.h>
-#include <Processors/Sources/SourceFromSingleChunk.h>
 #include <Processors/Sources/ArrowFlightSource.h>
-#include <QueryPipeline/Chain.h>
+#include <QueryPipeline/BlockIO.h>
 #include <QueryPipeline/Pipe.h>
-#include <QueryPipeline/QueryPipeline.h>
-#include <QueryPipeline/QueryPipelineBuilder.h>
 #include <Server/IServer.h>
-#include <Storages/IStorage.h>
-#include <arrow/flight/server.h>
-#include <arrow/flight/server_middleware.h>
+#include <base/EnumReflection.h>
 #include <Poco/FileStream.h>
 #include <Poco/StreamCopier.h>
+#include <Poco/URI.h>
 #include <Poco/Util/LayeredConfiguration.h>
-#include <Common/Base64.h>
-#include <Common/Exception.h>
-#include <Common/SettingsChanges.h>
-#include <Common/logger_useful.h>
-
-#include <Common/quoteString.h>
+#include <arrow/flight/server_middleware.h>
 
 
 namespace DB
@@ -233,7 +202,7 @@ namespace
                 return cmd;
             }
             default:
-                return arrow::Status::TypeError("Flight descriptor has unknown type ", toString(descriptor.type));
+                return arrow::Status::TypeError("Flight descriptor has unknown type ", magic_enum::enum_name(descriptor.type));
         }
     }
 

--- a/src/Server/ArrowFlightHandler.cpp
+++ b/src/Server/ArrowFlightHandler.cpp
@@ -37,7 +37,9 @@
 #include <Processors/Formats/Impl/CHColumnToArrowColumn.h>
 #include <Processors/ISource.h>
 #include <Processors/Sinks/SinkToStorage.h>
+#include <Processors/Sinks/NullSink.h>
 #include <Processors/Sources/SourceFromSingleChunk.h>
+#include <Processors/Sources/ArrowFlightSource.h>
 #include <QueryPipeline/Chain.h>
 #include <QueryPipeline/Pipe.h>
 #include <QueryPipeline/QueryPipeline.h>
@@ -54,107 +56,105 @@
 #include <Common/SettingsChanges.h>
 #include <Common/logger_useful.h>
 
-const std::string AUTHORIZATION_HEADER = "authorization";
-const std::string AUTHORIZATION_MIDDLEWARE_NAME = "arrow_flight_authorization";
+#include <Common/quoteString.h>
 
-class AuthMiddleware : public arrow::flight::ServerMiddleware
-{
-public:
-    explicit AuthMiddleware(const std::string & token, const std::string & username, const std::string & password)
-        : token_(token)
-        , username_(username)
-        , password_(password)
-    {
-    }
-
-    const std::string & username() const { return username_; }
-    const std::string & password() const { return password_; }
-
-    std::string name() const override { return AUTHORIZATION_MIDDLEWARE_NAME; }
-
-    void SendingHeaders(arrow::flight::AddCallHeaders * outgoing_headers) override
-    {
-        outgoing_headers->AddHeader(AUTHORIZATION_HEADER, "Bearer " + token_);
-    }
-
-    void CallCompleted(const arrow::Status & /*status*/) override { }
-
-private:
-    const std::string token_;
-    const std::string username_;
-    const std::string password_;
-};
-
-class AuthMiddlewareFactory : public arrow::flight::ServerMiddlewareFactory
-{
-public:
-    arrow::Status StartCall(
-        const arrow::flight::CallInfo & /*info*/,
-        const arrow::flight::ServerCallContext & context,
-        std::shared_ptr<arrow::flight::ServerMiddleware> * middleware) override
-    {
-        const auto & headers = context.incoming_headers();
-
-        auto it = headers.find(AUTHORIZATION_HEADER);
-        if (it == headers.end())
-        {
-            return arrow::Status::IOError("Missing Authorization header");
-        }
-
-        auto auth_header = std::string(it->second);
-
-        std::string token;
-
-        const std::string prefix_basic = "Basic ";
-        if (auth_header.starts_with(prefix_basic))
-        {
-            token = auth_header.substr(prefix_basic.size());
-        }
-
-        const std::string prefix_bearer = "Bearer ";
-        if (auth_header.starts_with(prefix_bearer))
-        {
-            token = auth_header.substr(prefix_bearer.size());
-        }
-
-        if (token.empty())
-        {
-            return arrow::Status::IOError("Expected Basic auth scheme");
-        }
-
-        std::string credentials = DB::base64Decode(token, true);
-        auto pos = credentials.find(':');
-        if (pos == std::string::npos)
-        {
-            return arrow::Status::IOError("Malformed credentials");
-        }
-
-        auto user = credentials.substr(0, pos);
-        auto password = credentials.substr(pos + 1);
-
-        *middleware = std::make_unique<AuthMiddleware>(token, user, password);
-        return arrow::Status::OK();
-    }
-};
-
-String readFile(const String & filepath)
-{
-    Poco::FileInputStream ifs(filepath);
-    String buf;
-    Poco::StreamCopier::copyToString(ifs, buf);
-    return buf;
-}
 
 namespace DB
 {
 
 namespace ErrorCodes
 {
-extern const int UNKNOWN_EXCEPTION;
+    extern const int UNKNOWN_EXCEPTION;
 }
 
 namespace
 {
+    const std::string AUTHORIZATION_HEADER = "authorization";
+    const std::string AUTHORIZATION_MIDDLEWARE_NAME = "authorization_middleware";
+
+    class AuthMiddleware : public arrow::flight::ServerMiddleware
+    {
+    public:
+        explicit AuthMiddleware(const std::string & token, const std::string & username, const std::string & password)
+            : token_(token)
+            , username_(username)
+            , password_(password)
+        {
+        }
+
+        static AuthMiddleware & get(const arrow::flight::ServerCallContext & context)
+        {
+            return *static_cast<AuthMiddleware *>(context.GetMiddleware(AUTHORIZATION_MIDDLEWARE_NAME));
+        }
+
+        const std::string & username() const { return username_; }
+        const std::string & password() const { return password_; }
+
+        void SendingHeaders(arrow::flight::AddCallHeaders * outgoing_headers) override
+        {
+            outgoing_headers->AddHeader(AUTHORIZATION_HEADER, "Bearer " + token_);
+        }
+
+        void CallCompleted(const arrow::Status & /*status*/) override { }
+
+        std::string name() const override { return AUTHORIZATION_MIDDLEWARE_NAME; }
+
+    private:
+        const std::string token_;
+        const std::string username_;
+        const std::string password_;
+    };
+
+    class AuthMiddlewareFactory : public arrow::flight::ServerMiddlewareFactory
+    {
+    public:
+        arrow::Status StartCall(
+            const arrow::flight::CallInfo & /*info*/,
+            const arrow::flight::ServerCallContext & context,
+            std::shared_ptr<arrow::flight::ServerMiddleware> * middleware) override
+        {
+            const auto & headers = context.incoming_headers();
+
+            auto it = headers.find(AUTHORIZATION_HEADER);
+            if (it == headers.end())
+                return arrow::Status::IOError("Missing Authorization header");
+
+            auto auth_header = std::string(it->second);
+
+            std::string token;
+
+            const std::string prefix_basic = "Basic ";
+            if (auth_header.starts_with(prefix_basic))
+                token = auth_header.substr(prefix_basic.size());
+
+            const std::string prefix_bearer = "Bearer ";
+            if (auth_header.starts_with(prefix_bearer))
+                token = auth_header.substr(prefix_bearer.size());
+
+            if (token.empty())
+                return arrow::Status::IOError("Expected Basic auth scheme");
+
+            std::string credentials = base64Decode(token, true);
+            auto pos = credentials.find(':');
+            if (pos == std::string::npos)
+                return arrow::Status::IOError("Malformed credentials");
+
+            auto user = credentials.substr(0, pos);
+            auto password = credentials.substr(pos + 1);
+
+            *middleware = std::make_unique<AuthMiddleware>(token, user, password);
+            return arrow::Status::OK();
+        }
+    };
+
+    String readFile(const String & filepath)
+    {
+        Poco::FileInputStream ifs(filepath);
+        String buf;
+        Poco::StreamCopier::copyToString(ifs, buf);
+        return buf;
+    }
+
     arrow::flight::Location addressToArrowLocation(const Poco::Net::SocketAddress & address_to_listen, bool use_tls)
     {
         auto ip_to_listen = address_to_listen.host();
@@ -180,23 +180,313 @@ namespace
 
         return std::move(parse_location_status).ValueOrDie();
     }
+
+    /// Extracts the client's address from the call context.
+    Poco::Net::SocketAddress getClientAddress(const arrow::flight::ServerCallContext & context)
+    {
+        /// Returns a string like ipv4:127.0.0.1:55930 or ipv6:%5B::1%5D:55930
+        String uri_encoded_peer = context.peer();
+
+        constexpr const std::string_view ipv4_prefix = "ipv4:";
+        constexpr const std::string_view ipv6_prefix = "ipv6:";
+
+        bool ipv4 = uri_encoded_peer.starts_with(ipv4_prefix);
+        bool ipv6 = uri_encoded_peer.starts_with(ipv6_prefix);
+
+        if (!ipv4 && !ipv6)
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Expected ipv4 or ipv6 protocol in peer address, got {}", uri_encoded_peer);
+
+        auto prefix = ipv4 ? ipv4_prefix : ipv6_prefix;
+        auto family = ipv4 ? Poco::Net::AddressFamily::Family::IPv4 : Poco::Net::AddressFamily::Family::IPv6;
+
+        uri_encoded_peer= uri_encoded_peer.substr(prefix.length());
+
+        String peer;
+        Poco::URI::decode(uri_encoded_peer, peer);
+
+        return Poco::Net::SocketAddress{family, peer};
+    }
+
+    /// Extracts an SQL queryt from a flight descriptor.
+    [[nodiscard]] arrow::Result<String> convertDescriptorToSQL(const arrow::flight::FlightDescriptor & descriptor, bool for_put_operation)
+    {
+        switch (descriptor.type)
+        {
+            case arrow::flight::FlightDescriptor::PATH:
+            {
+                const auto & path = descriptor.path;
+                if (path.size() != 1)
+                    return arrow::Status::Invalid("Flight descriptor's path should be one-component (got ", path.size(), " components)");
+                if (path[0].empty())
+                    return arrow::Status::Invalid("Flight descriptor's path should specify the name of a table");
+                const String & table_name = path[0];
+                if (for_put_operation)
+                    return "INSERT INTO " + backQuoteIfNeed(table_name) + " FORMAT Arrow";
+                else
+                    return "SELECT * FROM " + backQuoteIfNeed(table_name);
+            }
+            case arrow::flight::FlightDescriptor::CMD:
+            {
+                const auto & cmd = descriptor.cmd;
+                if (cmd.empty())
+                    return arrow::Status::Invalid("Flight descriptor's command should specify a SQL query");
+                return cmd;
+            }
+            default:
+                return arrow::Status::TypeError("Flight descriptor has unknown type ", toString(descriptor.type));
+        }
+    }
+
+    [[nodiscard]] arrow::Result<String> convertGetDescriptorToSQL(const arrow::flight::FlightDescriptor & descriptor)
+    {
+        return convertDescriptorToSQL(descriptor, /* for_put_operation = */ false);
+    }
+
+    [[nodiscard]] arrow::Result<String> convertPutDescriptorToSQL(const arrow::flight::FlightDescriptor & descriptor)
+    {
+        return convertDescriptorToSQL(descriptor, /* for_put_operation = */ true);
+    }
+
+    /// For method doGet() the pipeline should have an output.
+    [[nodiscard]] arrow::Status checkPipelineIsPulling(const QueryPipeline & pipeline)
+    {
+        if (!pipeline.pulling())
+            return arrow::Status::Invalid("Query doesn't allow pulling data, use method doPut() with this kind of query");
+        return arrow::Status::OK();
+    }
+
+    /// We don't allow custom formats except "Arrow" because they can't work with ArrowFlight.
+    [[nodiscard]] arrow::Status checkNoCustomFormat(ASTPtr ast)
+    {
+        if (const auto * ast_with_output = dynamic_cast<const ASTQueryWithOutput *>(ast.get()))
+        {
+            if (ast_with_output->format_ast)
+                return arrow::Status::ExecutionError("FORMAT clause not supported by Arrow Flight");
+        }
+        else if (const auto * insert = dynamic_cast<const ASTInsertQuery *>(ast.get()))
+        {
+            if (!insert->format.empty() && insert->format != "Arrow")
+                return arrow::Status::Invalid("DoPut failed: invalid format value, only 'Arrow' custom format supported");
+        }
+        return arrow::Status::OK();
+    }
+
+    using Timestamp = std::chrono::system_clock::time_point;
+    using Duration = std::chrono::system_clock::duration;
+
+    Timestamp now()
+    {
+        return std::chrono::system_clock::now();
+    }
+
+    /// We generate tickets with this prefix.
+    /// Method DoGet() accepts a ticket which is either 1) a ticket with this prefix; or 2) a SQL query.
+    /// A valid SQL query can't start with this prefix so method DoGet() can distinguish those cases.
+    const String TICKET_PREFIX = "--#TICKET-";
+
+    bool hasTicketPrefix(const String & ticket)
+    {
+        return ticket.starts_with(TICKET_PREFIX);
+    }
+
+    /// A ticket name with its expiration time.
+    struct TicketWithExpirationTime
+    {
+        String ticket;
+        /// When the ticket expires.
+        /// std::nullopt means that the ticket expires after using it in DoGet().
+        std::optional<Timestamp> expiration_time;
+    };
+
+    /// Keeps a block associated with a ticket.
+    struct TicketInfo : public TicketWithExpirationTime
+    {
+        ConstBlockPtr block;
+        std::shared_ptr<const CHColumnToArrowColumn> ch_to_arrow_converter;
+    };
+
+    /// Creates a converter from ClickHouse blocks to the Arrow format.
+    std::shared_ptr<CHColumnToArrowColumn> createCHToArrowConverter(const Block & header)
+    {
+        CHColumnToArrowColumn::Settings arrow_settings;
+        arrow_settings.output_string_as_string = true;
+        auto ch_to_arrow_converter = std::make_shared<CHColumnToArrowColumn>(header, "Arrow", arrow_settings);
+        ch_to_arrow_converter->initializeArrowSchema();
+        return ch_to_arrow_converter;
+    }
 }
+
+
+/// Keeps information about calls - e.g. blocks extracted from pipelines and tickets.
+class ArrowFlightHandler::CallsData
+{
+public:
+    CallsData(std::optional<Duration> tickets_lifetime_)
+        : tickets_lifetime(tickets_lifetime_)
+    {
+    }
+
+    ~CallsData() = default;
+
+    /// Creates a ticket for a specified block.
+    std::shared_ptr<const TicketInfo> createTicket(ConstBlockPtr block, std::shared_ptr<const CHColumnToArrowColumn> ch_to_arrow_converter)
+    {
+        String ticket = generateTicketName();
+        Timestamp current_time = now();
+        auto expiration_time = calculateTicketExpirationTime(current_time);
+        auto info = std::make_shared<TicketInfo>();
+        info->ticket = ticket;
+        info->expiration_time = expiration_time;
+        info->block = block;
+        info->ch_to_arrow_converter = ch_to_arrow_converter;
+        std::lock_guard lock{mutex};
+        tickets[ticket] = info;
+        if (expiration_time)
+        {
+            tickets_by_expiration_time.emplace(*expiration_time, ticket);
+            updateNextExpirationTime();
+        }
+        return info;
+    }
+
+    /// Returns the information about a ticket.
+    [[nodiscard]] arrow::Result<std::shared_ptr<const TicketInfo>> getTicketInfo(const String & ticket) const
+    {
+        std::lock_guard lock{mutex};
+        auto it = tickets.find(ticket);
+        if (it == tickets.end())
+            return arrow::Status::KeyError("Ticket ", quoteString(ticket), " not found");
+        return it->second;
+    }
+
+    /// Extends the expiration time of a ticket.
+    [[nodiscard]] arrow::Status extendTicketExpirationTime(const String & ticket)
+    {
+        if (!tickets_lifetime)
+            return arrow::Status::OK();
+        Timestamp current_time = now();
+        std::lock_guard lock{mutex};
+        auto it = tickets.find(ticket);
+        if (it == tickets.end())
+            return arrow::Status::KeyError("Ticket ", quoteString(ticket), " not found");
+        auto info = it->second;
+        auto old_expiration_time = info->expiration_time;
+        auto new_expiration_time = calculateTicketExpirationTime(current_time);
+        auto new_info = std::make_shared<TicketInfo>(*info);
+        new_info->expiration_time = new_expiration_time;
+        it->second = new_info;
+        tickets_by_expiration_time.erase(std::make_pair(*old_expiration_time, ticket));
+        tickets_by_expiration_time.emplace(*new_expiration_time, ticket);
+        updateNextExpirationTime();
+        return arrow::Status::OK();
+    }
+
+    /// Cancels a ticket to free memory.
+    void cancelTicket(const String & ticket)
+    {
+        std::lock_guard lock{mutex};
+        auto it = tickets.find(ticket);
+        if (it != tickets.end())
+        {
+            auto info = it->second;
+            tickets.erase(it);
+            if (info->expiration_time)
+            {
+                tickets_by_expiration_time.erase(std::make_pair(*info->expiration_time, ticket));
+                updateNextExpirationTime();
+            }
+        }
+    }
+
+    /// Cancels tickets if `current_time` is greater than their expiration time.
+    void cancelExpired()
+    {
+        auto current_time = now();
+        std::lock_guard lock{mutex};
+        while (!tickets_by_expiration_time.empty())
+        {
+            auto it = tickets_by_expiration_time.begin();
+            if (current_time <= it->first)
+                break;
+            tickets.erase(it->second);
+            tickets_by_expiration_time.erase(it);
+        }
+        updateNextExpirationTime();
+    }
+
+    /// Waits until it's time to cancel expired tickets.
+    void waitNextExpirationTime() const
+    {
+        auto current_time = now();
+        std::unique_lock lock{mutex};
+        auto is_ready = [&]
+        {
+            if (stop_waiting_next_expiration_time)
+                return true;
+            current_time = now();
+            return next_expiration_time && (current_time > *next_expiration_time);
+        };
+        if (next_expiration_time)
+        {
+            if (current_time < *next_expiration_time)
+                next_expiration_time_decreased.wait_for(lock, *next_expiration_time - current_time, is_ready);
+        }
+        else
+        {
+            next_expiration_time_decreased.wait(lock, is_ready);
+        }
+    }
+
+    void stopWaitingNextExpirationTime()
+    {
+        std::lock_guard lock{mutex};
+        stop_waiting_next_expiration_time = true;
+    }
+
+private:
+    static String generateTicketName()
+    {
+        return TICKET_PREFIX + toString(UUIDHelpers::generateV4());
+    }
+
+    std::optional<Timestamp> calculateTicketExpirationTime(Timestamp current_time) const
+    {
+        if (!tickets_lifetime)
+            return std::nullopt;
+        return current_time + *tickets_lifetime;
+    }
+
+    void updateNextExpirationTime() TSA_REQUIRES(mutex)
+    {
+        auto old_value = next_expiration_time;
+        next_expiration_time.reset();
+        if (!tickets_by_expiration_time.empty())
+            next_expiration_time = tickets_by_expiration_time.begin()->first;
+        if (next_expiration_time && (!old_value || next_expiration_time < *old_value))
+            next_expiration_time_decreased.notify_all();
+    }
+
+    const std::optional<Duration> tickets_lifetime;
+    mutable std::mutex mutex;
+    std::unordered_map<String, std::shared_ptr<const TicketInfo>> tickets TSA_GUARDED_BY(mutex);
+    std::condition_variable evaluation_ended;
+    std::set<std::pair<Timestamp, String>> tickets_by_expiration_time TSA_GUARDED_BY(mutex);
+    std::optional<Timestamp> next_expiration_time;
+    mutable std::condition_variable next_expiration_time_decreased;
+    bool stop_waiting_next_expiration_time = false;
+};
+
 
 ArrowFlightHandler::ArrowFlightHandler(IServer & server_, const Poco::Net::SocketAddress & address_to_listen_)
     : server(server_)
     , log(getLogger("ArrowFlightHandler"))
     , address_to_listen(address_to_listen_)
+    , tickets_lifetime_seconds(server.config().getUInt("arrowflight.tickets_lifetime_seconds", 600))
+    , cancel_ticket_after_do_get(server.config().getBool("arrowflight.cancel_ticket_after_do_get", false))
+    , calls_data(
+          std::make_unique<CallsData>(
+              tickets_lifetime_seconds ? std::make_optional(std::chrono::seconds{tickets_lifetime_seconds}) : std::optional<Duration>{}))
 {
-}
-
-std::unique_ptr<Session> ArrowFlightHandler::createSession(const arrow::flight::ServerCallContext & context)
-{
-    AuthMiddleware * auth = static_cast<AuthMiddleware *>(context.GetMiddleware(AUTHORIZATION_MIDDLEWARE_NAME));
-    std::string login = auth->username();
-    std::string password = auth->password();
-    auto session = std::make_unique<Session>(server.context(), ClientInfo::Interface::ARROW_FLIGHT);
-    session->authenticate(login, password, address_to_listen);
-    return session;
 }
 
 void ArrowFlightHandler::start()
@@ -246,6 +536,26 @@ void ArrowFlightHandler::start()
             tryLogCurrentException(log, "Failed to serve Arrow Flight");
         }
     });
+
+    if (tickets_lifetime_seconds)
+    {
+        cleanup_thread.emplace([this]
+        {
+            try
+            {
+                setThreadName("ArrowFlightExpr");
+                while (!stopped)
+                {
+                    calls_data->waitNextExpirationTime();
+                    calls_data->cancelExpired();
+                }
+            }
+            catch (...)
+            {
+                tryLogCurrentException(log, "Failed to cleanup");
+            }
+        });
+    }
 }
 
 ArrowFlightHandler::~ArrowFlightHandler() = default;
@@ -272,6 +582,13 @@ void ArrowFlightHandler::stop()
             server_thread->join();
             server_thread.reset();
         }
+
+        calls_data->stopWaitingNextExpirationTime();
+        if (cleanup_thread)
+        {
+            cleanup_thread->join();
+            cleanup_thread.reset();
+        }
     }
 }
 
@@ -280,137 +597,198 @@ UInt16 ArrowFlightHandler::portNumber() const
     return address_to_listen.port();
 }
 
-arrow::Status ArrowFlightHandler::ListFlights(
-    const arrow::flight::ServerCallContext &, const arrow::flight::Criteria *, std::unique_ptr<arrow::flight::FlightListing> * listings)
-{
-    std::vector<arrow::flight::FlightInfo> flights;
-    *listings = std::make_unique<arrow::flight::SimpleFlightListing>(std::move(flights));
-    return arrow::Status::OK();
-}
-
 arrow::Status ArrowFlightHandler::GetFlightInfo(
-    const arrow::flight::ServerCallContext & /*context*/,
-    const arrow::flight::FlightDescriptor & /*request*/,
-    std::unique_ptr<arrow::flight::FlightInfo> * /*info*/)
+    const arrow::flight::ServerCallContext & context,
+    const arrow::flight::FlightDescriptor & request,
+    std::unique_ptr<arrow::flight::FlightInfo> * info)
 {
-    return arrow::Status::OK();
+    setThreadName("ArrowFlight");
+    ThreadStatus thread_status;
+
+    try
+    {
+        std::vector<arrow::flight::FlightEndpoint> endpoints;
+        int64_t total_rows = 0;
+        int64_t total_bytes = 0;
+        std::shared_ptr<const CHColumnToArrowColumn> ch_to_arrow_converter;
+
+        auto sql_res = convertGetDescriptorToSQL(request);
+        ARROW_RETURN_NOT_OK(sql_res);
+        const String & sql = sql_res.ValueOrDie();
+
+        Session session{server.context(), ClientInfo::Interface::ARROW_FLIGHT};
+
+        const auto & auth = AuthMiddleware::get(context);
+        session.authenticate(auth.username(), auth.password(), getClientAddress(context));
+
+        auto query_context = session.makeQueryContext();
+        query_context->setCurrentQueryId(""); /// Empty string means the query id will be autogenerated.
+        CurrentThread::QueryScope query_scope{query_context};
+
+        auto [ast, block_io] = executeQuery(sql, query_context, QueryFlags{}, QueryProcessingStage::Complete);
+        ARROW_RETURN_NOT_OK(checkNoCustomFormat(ast));
+        ARROW_RETURN_NOT_OK(checkPipelineIsPulling(block_io.pipeline));
+
+        PullingPipelineExecutor executor{block_io.pipeline};
+        ch_to_arrow_converter = createCHToArrowConverter(executor.getHeader());
+
+        Block block;
+        while (executor.pull(block))
+        {
+            if (!block.empty())
+            {
+                total_rows += block.rows();
+                total_bytes += block.bytes();
+                auto ticket_info = calls_data->createTicket(std::make_shared<Block>(std::move(block)), ch_to_arrow_converter);
+                arrow::flight::FlightEndpoint endpoint;
+                endpoint.ticket = arrow::flight::Ticket{.ticket = ticket_info->ticket};
+                endpoint.expiration_time = ticket_info->expiration_time;
+                endpoints.emplace_back(endpoint);
+            }
+        }
+
+        auto flight_info_res = arrow::flight::FlightInfo::Make(
+            *ch_to_arrow_converter->getArrowSchema(),
+            request,
+            endpoints,
+            total_rows,
+            total_bytes,
+            /* ordered = */ true);
+
+        ARROW_RETURN_NOT_OK(flight_info_res);
+        *info = std::make_unique<arrow::flight::FlightInfo>(std::move(flight_info_res).ValueOrDie());
+
+        return arrow::Status::OK();
+    }
+    catch (const Exception & e)
+    {
+        return arrow::Status::ExecutionError("GetFlightInfo failed: ", e.displayText());
+    }
 }
 
-arrow::Status ArrowFlightHandler::PollFlightInfo(
-    const arrow::flight::ServerCallContext & arrow_context,
-    const arrow::flight::FlightDescriptor & request,
-    std::unique_ptr<arrow::flight::PollInfo> * info)
-{
-    (void)arrow_context;
-    (void)request;
-    (void)info;
-    return arrow::Status::OK();
-}
 
 arrow::Status ArrowFlightHandler::GetSchema(
     const arrow::flight::ServerCallContext & context,
-    const arrow::flight::FlightDescriptor & /*request*/,
-    std::unique_ptr<arrow::flight::SchemaResult> * /*schema*/)
+    const arrow::flight::FlightDescriptor & request,
+    std::unique_ptr<arrow::flight::SchemaResult> * schema)
 {
-    auto session = createSession(context);
-    session->makeSessionContext();
+    setThreadName("ArrowFlight");
+    ThreadStatus thread_status;
 
-    return arrow::Status::OK();
+    try
+    {
+        std::shared_ptr<const CHColumnToArrowColumn> ch_to_arrow_converter;
+
+        auto sql_res = convertGetDescriptorToSQL(request);
+        ARROW_RETURN_NOT_OK(sql_res);
+        const String & sql = sql_res.ValueOrDie();
+
+        Session session{server.context(), ClientInfo::Interface::ARROW_FLIGHT};
+
+        const auto & auth = AuthMiddleware::get(context);
+        session.authenticate(auth.username(), auth.password(), getClientAddress(context));
+
+        auto query_context = session.makeQueryContext();
+        query_context->setCurrentQueryId(""); /// Empty string means the query id will be autogenerated.
+        CurrentThread::QueryScope query_scope{query_context};
+
+        auto [ast, block_io] = executeQuery(sql, query_context, QueryFlags{}, QueryProcessingStage::Complete);
+        ARROW_RETURN_NOT_OK(checkNoCustomFormat(ast));
+        ARROW_RETURN_NOT_OK(checkPipelineIsPulling(block_io.pipeline));
+
+        ch_to_arrow_converter = createCHToArrowConverter(block_io.pipeline.getHeader());
+
+        auto schema_res = arrow::flight::SchemaResult::Make(*ch_to_arrow_converter->getArrowSchema());
+        ARROW_RETURN_NOT_OK(schema_res);
+        *schema = std::make_unique<arrow::flight::SchemaResult>(*std::move(schema_res).ValueOrDie());
+
+        return arrow::Status::OK();
+    }
+    catch (const Exception & e)
+    {
+        return arrow::Status::ExecutionError("GetSchema failed: ", e.displayText());
+    }
 }
+
+
+arrow::Status ArrowFlightHandler::PollFlightInfo(
+    const arrow::flight::ServerCallContext & /*context*/,
+    const arrow::flight::FlightDescriptor & /*request*/,
+    std::unique_ptr<arrow::flight::PollInfo> * /*info*/)
+{
+    return arrow::Status::NotImplemented("NYI");
+}
+
 
 arrow::Status ArrowFlightHandler::DoGet(
     const arrow::flight::ServerCallContext & context,
     const arrow::flight::Ticket & request,
     std::unique_ptr<arrow::flight::FlightDataStream> * stream)
 {
+    setThreadName("ArrowFlight");
+    ThreadStatus thread_status;
+
     try
     {
-        setThreadName("ArrowFlight");
-
-        auto session = createSession(context);
-        session->makeSessionContext();
-        const std::string sql = request.ticket;
-
-        DB::ThreadStatus thread_status;
-        auto query_ctx = session->makeQueryContext();
-        query_ctx->setCurrentQueryId(""); /// Empty string means the query id will be autogenerated.
-        CurrentThread::QueryScope query_scope(query_ctx);
-
-        DB::QueryFlags flags;
-        auto [ast, io] = DB::executeQuery(sql, query_ctx, flags, DB::QueryProcessingStage::Complete);
-        if (!io.pipeline.pulling())
+        Block header;
+        std::vector<Chunk> chunks;
+        std::shared_ptr<CHColumnToArrowColumn> ch_to_arrow_converter;
+        bool should_cancel_ticket = false;
+    
+        if (hasTicketPrefix(request.ticket))
         {
-            return arrow::Status::ExecutionError("DoGet failed: pipeline is not in pulling state");
+            auto ticket_info_res = calls_data->getTicketInfo(request.ticket);
+            ARROW_RETURN_NOT_OK(ticket_info_res);
+            const auto & ticket_info = ticket_info_res.ValueOrDie();
+            chunks.emplace_back(Chunk(ticket_info->block->getColumns(), ticket_info->block->rows()));
+            header = ticket_info->block->cloneEmpty();
+            ch_to_arrow_converter = ticket_info->ch_to_arrow_converter->clone(/* copy_arrow_schema = */ true);
+            should_cancel_ticket = cancel_ticket_after_do_get;
         }
-        const auto * ast_with_output = dynamic_cast<const DB::ASTQueryWithOutput *>(ast.get());
-        if (!ast_with_output)
+        else
         {
-            return arrow::Status::ExecutionError("DoGet failed: unsupported query type (expected SELECT)");
-        }
-        if (ast_with_output->format_ast)
-        {
-            return arrow::Status::ExecutionError("FORMAT clause not supported by Arrow Flight");
-        }
-        auto executor = std::make_unique<DB::PullingPipelineExecutor>(io.pipeline);
+            const String & sql = request.ticket;
 
-        const DB::Block header = executor->getHeader();
+            Session session{server.context(), ClientInfo::Interface::ARROW_FLIGHT};
 
-        DB::CHColumnToArrowColumn::Settings arrow_settings;
-        arrow_settings.output_string_as_string = true;
+            const auto & auth = AuthMiddleware::get(context);
+            session.authenticate(auth.username(), auth.password(), getClientAddress(context));
 
-        DB::CHColumnToArrowColumn converter(header, "Arrow", arrow_settings);
+            auto query_context = session.makeQueryContext();
+            query_context->setCurrentQueryId(""); /// Empty string means the query id will be autogenerated.
+            CurrentThread::QueryScope query_scope{query_context};
 
-        std::vector<DB::Chunk> chunks;
-        DB::Block block;
+            auto [ast, block_io] = executeQuery(sql, query_context, QueryFlags{}, QueryProcessingStage::Complete);
+            ARROW_RETURN_NOT_OK(checkNoCustomFormat(ast));
+            ARROW_RETURN_NOT_OK(checkPipelineIsPulling(block_io.pipeline));
 
-        while (executor->pull(block))
-        {
-            chunks.emplace_back(DB::Chunk(block.getColumns(), block.rows()));
+            PullingPipelineExecutor executor{block_io.pipeline};
+
+            Block block;
+            while (executor.pull(block))
+                chunks.emplace_back(Chunk(block.getColumns(), block.rows()));
+
+            header = executor.getHeader();
+            ch_to_arrow_converter = createCHToArrowConverter(header);
         }
 
         std::shared_ptr<arrow::Table> arrow_table;
-        converter.chChunkToArrowTable(arrow_table, chunks, header.columns());
+        ch_to_arrow_converter->chChunkToArrowTable(arrow_table, chunks, header.columns());
 
-        auto maybe_combined = arrow_table->CombineChunks();
-        if (!maybe_combined.ok())
-        {
-            return arrow::Status::IOError("DoGet failed: cannot combine chunks: " + maybe_combined.status().ToString());
-        }
+        auto stream_res = arrow::RecordBatchReader::MakeFromIterator(
+            arrow::Iterator<std::shared_ptr<arrow::RecordBatch>>{arrow::TableBatchReader{arrow_table}},
+            ch_to_arrow_converter->getArrowSchema());
+        ARROW_RETURN_NOT_OK(stream_res);
+        *stream = std::make_unique<arrow::flight::RecordBatchStream>(stream_res.ValueOrDie());
 
-        const auto & combined_table = maybe_combined.ValueOrDie();
-        arrow::TableBatchReader reader(combined_table);
+        if (should_cancel_ticket)
+            calls_data->cancelTicket(request.ticket);
 
-        std::vector<std::shared_ptr<arrow::RecordBatch>> batches;
-        std::shared_ptr<arrow::RecordBatch> batch;
-
-        while (true)
-        {
-            auto st = reader.ReadNext(&batch);
-            if (!st.ok())
-                return arrow::Status::IOError("DoGet failed while reading batch: " + st.ToString());
-
-            if (!batch)
-                break;
-
-            batches.emplace_back(std::move(batch));
-        }
-
-        if (batches.empty())
-            return arrow::Status::Invalid("DoGet failed: no data produced");
-
-        auto schema = batches.front()->schema();
-        auto reader_result = arrow::RecordBatchReader::Make(batches, schema);
-        if (!reader_result.ok())
-        {
-            return arrow::Status::IOError("DoGet failed: " + reader_result.status().ToString());
-        }
-
-        *stream = std::make_unique<arrow::flight::RecordBatchStream>(reader_result.ValueOrDie());
         return arrow::Status::OK();
     }
-    catch (const DB::Exception & e)
+    catch (const Exception & e)
     {
-        return arrow::Status::IOError("DoGet failed: " + e.displayText());
+        return arrow::Status::ExecutionError("DoGet failed: ", e.displayText());
     }
 }
 
@@ -420,173 +798,51 @@ arrow::Status ArrowFlightHandler::DoPut(
     std::unique_ptr<arrow::flight::FlightMessageReader> reader,
     std::unique_ptr<arrow::flight::FlightMetadataWriter> /*writer*/)
 {
+    setThreadName("ArrowFlight");
+    ThreadStatus thread_status;
+
     try
     {
-        setThreadName("ArrowFlight");
-
-        auto session = createSession(context);
-        session->makeSessionContext();
-
-        DB::ThreadStatus thread_status;
-        auto query_context = session->makeQueryContext();
-        query_context->setCurrentQueryId(""); /// Empty string means the query id will be autogenerated.
-        CurrentThread::QueryScope query_scope(query_context);
-
-        auto schema_result = reader->GetSchema();
-        if (!schema_result.ok())
-        {
-            return arrow::Status::Invalid("Failed to receive schema: " + schema_result.status().ToString());
-        }
-        const auto & schema = schema_result.ValueOrDie();
-
         const auto & descriptor = reader->descriptor();
-        if (descriptor.type == arrow::flight::FlightDescriptor::CMD)
+        auto sql_res = convertPutDescriptorToSQL(descriptor);
+        ARROW_RETURN_NOT_OK(sql_res);
+        const String & sql = sql_res.ValueOrDie();
+
+        Session session{server.context(), ClientInfo::Interface::ARROW_FLIGHT};
+
+        const auto & auth = AuthMiddleware::get(context);
+        session.authenticate(auth.username(), auth.password(), getClientAddress(context));
+
+        auto query_context = session.makeQueryContext();
+        query_context->setCurrentQueryId(""); /// Empty string means the query id will be autogenerated.
+        CurrentThread::QueryScope query_scope{query_context};
+
+        auto [ast, block_io] = executeQuery(sql, query_context, QueryFlags{}, QueryProcessingStage::Complete);
+        ARROW_RETURN_NOT_OK(checkNoCustomFormat(ast));
+        auto & pipeline = block_io.pipeline;
+
+        if (pipeline.pushing())
         {
-            auto insert_context = Context::createCopy(query_context);
-
-            std::string sql = descriptor.cmd;
-            DB::QueryFlags flags;
-            auto [ast, io] = DB::executeQuery(sql, insert_context, flags, DB::QueryProcessingStage::Complete);
-
-            auto * insert = dynamic_cast<DB::ASTInsertQuery *>(ast.get());
-            if (!insert)
-            {
-                return arrow::Status::Invalid("DoPut failed: only INSERT is allowed");
-            }
-
-            if (!insert->format.empty() && insert->format != "Arrow")
-            {
-                return arrow::Status::Invalid("DoPut failed: invalid format value, only 'Arrow' custom format supported");
-            }
-            if (io.pipeline.completed())
-            {
-                CompletedPipelineExecutor executor(io.pipeline);
-                executor.execute();
-
-                return arrow::Status::OK();
-            }
-            if (!io.pipeline.pushing())
-            {
-                return arrow::Status::ExecutionError("DoPut failed: pipeline is not in pushing state");
-            }
-            Block header = io.pipeline.getHeader();
-
-            ArrowColumnToCHColumn converter(header, "Arrow",
-                                            /* format_settings= */ {},
-                                            /* parquet_columns_to_clickhouse= */ std::nullopt,
-                                            /* clickhouse_columns_to_parquet= */ std::nullopt,
-                                            /* allow_missing_columns = */ true,
-                                            /* null_as_default = */ true,
-                                            FormatSettings::DateTimeOverflowBehavior::Throw,
-                                            /* allow_geoparquet_parser = */ false);
-
-            while (true)
-            {
-                auto payload = reader->Next();
-                if (!payload.ok())
-                {
-                    return arrow::Status::IOError("Failed to read batch: " + payload.status().ToString());
-                }
-                auto batch = std::move(payload.ValueOrDie().data);
-                if (!batch)
-                    break;
-
-                auto batch_result = arrow::Table::FromRecordBatches(schema, {batch});
-                if (!batch_result.ok())
-                {
-                    return arrow::Status::IOError("Failed to read batch: " + batch_result.status().ToString());
-                }
-                const auto & arrow_table = batch_result.ValueOrDie();
-                auto chunk = converter.arrowTableToCHChunk(arrow_table, batch->num_rows(), nullptr, nullptr);
-
-                auto input = std::make_shared<SourceFromSingleChunk>(std::make_shared<const Block>(header), std::move(chunk));
-                io.pipeline.complete(Pipe(std::move(input)));
-
-                CompletedPipelineExecutor executor(io.pipeline);
-                executor.execute();
-            }
-
-            return arrow::Status::OK();
+            Block header = pipeline.getHeader();
+            auto input = std::make_shared<ArrowFlightSource>(std::move(reader), header);
+            pipeline.complete(Pipe(std::move(input)));
         }
-        else if (descriptor.type != arrow::flight::FlightDescriptor::PATH || descriptor.path.empty())
+        else if (pipeline.pulling())
         {
-            return arrow::Status::IOError("DoPut failed: Invalid descriptor");
+            Block header = pipeline.getHeader();
+            auto output = std::make_shared<NullSink>(std::make_shared<Block>(header));
+            pipeline.complete(Pipe(std::move(output)));
         }
 
-        auto dataset_name = descriptor.path[0];
-        const auto & table_id = StorageID(query_context->getCurrentDatabase(), dataset_name);
-        auto table = DatabaseCatalog::instance().getTable(table_id, query_context);
-        auto metadata_snapshot = table->getInMemoryMetadataPtr();
-        auto sink = table->write({}, metadata_snapshot, query_context, false);
-
-        Block header = metadata_snapshot->getSampleBlock();
-
-        ArrowColumnToCHColumn converter(header, "Arrow",
-                                        /* format_settings= */ {},
-                                        /* parquet_columns_to_clickhouse= */ std::nullopt,
-                                        /* clickhouse_columns_to_parquet= */ std::nullopt,
-                                        /* allow_missing_columns = */ true,
-                                        /* null_as_default = */ true,
-                                        FormatSettings::DateTimeOverflowBehavior::Throw,
-                                        /* allow_geoparquet_parser = */ false);
-
-        while (true)
-        {
-            auto status = reader->Next();
-            if (!status.ok())
-                return arrow::Status::IOError("Failed to read batch: " + status.status().ToString());
-            auto batch = std::move(status.ValueOrDie().data);
-            if (!batch)
-                break;
-            auto batch_result = arrow::Table::FromRecordBatches(schema, {batch});
-            if (!batch_result.ok())
-            {
-                return arrow::Status::IOError("Failed to read batch: " + batch_result.status().ToString());
-            }
-            const auto & arrow_table = batch_result.ValueOrDie();
-            auto chunk = converter.arrowTableToCHChunk(arrow_table, batch->num_rows(), nullptr, nullptr);
-
-            auto insert_context = Context::createCopy(query_context);
-
-            auto insert = std::make_shared<ASTInsertQuery>();
-            insert->table_id = table_id;
-
-            insert->columns = std::make_shared<ASTExpressionList>();
-            const auto & columns = metadata_snapshot->getColumns().getOrdinary();
-            for (const auto & column : columns)
-                insert->columns->children.emplace_back(std::make_shared<ASTIdentifier>(column.name));
-
-
-            InterpreterInsertQuery interpreter(
-                insert,
-                insert_context,
-                /* allow_materialized */ true,
-                /* no_squash */ false,
-                /* no_destination */ false,
-                /* async_isnert */ false);
-            auto io = interpreter.execute();
-            auto input = std::make_shared<SourceFromSingleChunk>(std::make_shared<const Block>(header), std::move(chunk));
-
-            io.pipeline.complete(Pipe(std::move(input)));
-
-            CompletedPipelineExecutor executor(io.pipeline);
-            executor.execute();
-        }
+        CompletedPipelineExecutor executor(pipeline);
+        executor.execute();
 
         return arrow::Status::OK();
     }
-    catch (const DB::Exception & e)
+    catch (const Exception & e)
     {
-        return arrow::Status::ExecutionError("DoPut failed: " + e.displayText());
+        return arrow::Status::ExecutionError("DoPut failed: ", e.displayText());
     }
-}
-
-arrow::Status ArrowFlightHandler::DoExchange(
-    const arrow::flight::ServerCallContext & /*context*/,
-    std::unique_ptr<arrow::flight::FlightMessageReader> /*reader*/,
-    std::unique_ptr<arrow::flight::FlightMessageWriter> /*writer*/)
-{
-    return arrow::Status::NotImplemented("DoExchange is not implemented");
 }
 
 arrow::Status ArrowFlightHandler::DoAction(
@@ -594,13 +850,7 @@ arrow::Status ArrowFlightHandler::DoAction(
     const arrow::flight::Action & /*action*/,
     std::unique_ptr<arrow::flight::ResultStream> * /*result*/)
 {
-    return arrow::Status::OK();
-}
-
-arrow::Status
-ArrowFlightHandler::ListActions(const arrow::flight::ServerCallContext & /*context*/, std::vector<arrow::flight::ActionType> * /*actions*/)
-{
-    return arrow::Status::OK();
+    return arrow::Status::NotImplemented("NYI");
 }
 
 }

--- a/src/Server/ArrowFlightHandler.cpp
+++ b/src/Server/ArrowFlightHandler.cpp
@@ -169,7 +169,7 @@ namespace
         auto prefix = ipv4 ? ipv4_prefix : ipv6_prefix;
         auto family = ipv4 ? Poco::Net::AddressFamily::Family::IPv4 : Poco::Net::AddressFamily::Family::IPv6;
 
-        uri_encoded_peer= uri_encoded_peer.substr(prefix.length());
+        uri_encoded_peer = uri_encoded_peer.substr(prefix.length());
 
         String peer;
         Poco::URI::decode(uri_encoded_peer, peer);
@@ -177,7 +177,7 @@ namespace
         return Poco::Net::SocketAddress{family, peer};
     }
 
-    /// Extracts an SQL queryt from a flight descriptor.
+    /// Extracts an SQL query from a flight descriptor.
     [[nodiscard]] arrow::Result<String> convertDescriptorToSQL(const arrow::flight::FlightDescriptor & descriptor, bool for_put_operation)
     {
         switch (descriptor.type)
@@ -316,17 +316,17 @@ namespace
         /// A success or error error.
         std::optional<arrow::Status> status;
 
-        /// A new ticket. Along with tickets from previous infos (previous->info, previous_info->previous_info, etc.)
+        /// A new ticket. Along with tickets from previous infos (previous_info, previous_info->previous_info, etc.)
         /// represents all tickets associated with this poll descriptor.
         /// Can be unset if there is no block; or it can specify an already expired ticket.
         std::optional<String> ticket;
 
-        /// Adds rows. Along with added rows from previous infos (previous->info, previous_info->previous_info, etc.)
+        /// Adds rows. Along with added rows from previous infos (previous_info, previous_info->previous_info, etc.)
         /// represents the total number of rows associated with this poll descriptor.
         /// Can be unset if there is no rows added.
         std::optional<size_t> rows;
 
-        /// Adds bytes. Along with added bytes from previous infos (previous->info, previous_info->previous_info, etc.)
+        /// Adds bytes. Along with added bytes from previous infos (previous_info, previous_info->previous_info, etc.)
         /// represents the total number of bytes associated with this poll descriptor.
         /// Can be unset if there is no bytes added.
         std::optional<size_t> bytes;
@@ -400,8 +400,7 @@ public:
     {
         String ticket = generateTicketName();
         LOG_DEBUG(log, "Creating ticket {}", ticket);
-        Timestamp current_time = now();
-        auto expiration_time = calculateTicketExpirationTime(current_time);
+        auto expiration_time = calculateTicketExpirationTime(now());
         auto info = std::make_shared<TicketInfo>();
         info->ticket = ticket;
         info->expiration_time = expiration_time;
@@ -445,14 +444,13 @@ public:
     {
         if (!tickets_lifetime)
             return arrow::Status::OK();
-        Timestamp current_time = now();
         std::lock_guard lock{mutex};
         auto it = tickets.find(ticket);
         if (it == tickets.end())
             return arrow::Status::KeyError("Ticket ", quoteString(ticket), " not found");
         auto info = it->second;
         auto old_expiration_time = info->expiration_time;
-        auto new_expiration_time = calculateTicketExpirationTime(current_time);
+        auto new_expiration_time = calculateTicketExpirationTime(now());
         auto new_info = std::make_shared<TicketInfo>(*info);
         new_info->expiration_time = new_expiration_time;
         it->second = new_info;

--- a/src/Server/ArrowFlightHandler.cpp
+++ b/src/Server/ArrowFlightHandler.cpp
@@ -916,29 +916,7 @@ arrow::Status ArrowFlightHandler::GetFlightInfo(
 
         if ((request.type == arrow::flight::FlightDescriptor::CMD) && hasPollDescriptorPrefix(request.cmd))
         {
-            const String & poll_descriptor = request.cmd;
-            ARROW_RETURN_NOT_OK(evaluatePollDescriptor(poll_descriptor));
-            ARROW_RETURN_NOT_OK(calls_data->extendPollDescriptorExpirationTime(poll_descriptor));
-            auto poll_info_res = calls_data->getPollDescriptorInfo(poll_descriptor);
-            ARROW_RETURN_NOT_OK(poll_info_res);
-            auto poll_info = poll_info_res.ValueOrDie();
-            ch_to_arrow_converter = poll_info->ch_to_arrow_converter;
-            while (poll_info)
-            {
-                if (poll_info->ticket)
-                {
-                    arrow::flight::FlightEndpoint endpoint;
-                    endpoint.ticket = arrow::flight::Ticket{.ticket = *poll_info->ticket};
-                    endpoint.expiration_time = calls_data->getTicketExpirationTime(*poll_info->ticket);
-                    endpoints.emplace_back(endpoint);
-                }
-                if (poll_info->rows)
-                    total_rows += *poll_info->rows;
-                if (poll_info->bytes)
-                    total_bytes += *poll_info->bytes;
-                poll_info = poll_info->previous_info;
-            }
-            std::reverse(endpoints.begin(), endpoints.end());
+            return arrow::Status::Invalid("Method GetFlightInfo cannot be called with a flight descriptor returned by method PollFlightInfo");
         }
         else
         {

--- a/src/Server/ArrowFlightHandler.h
+++ b/src/Server/ArrowFlightHandler.h
@@ -52,11 +52,6 @@ public:
 
     size_t currentConnections() const override { return 0; } // TODO
 
-    arrow::Status ListFlights(
-        const arrow::flight::ServerCallContext &,
-        const arrow::flight::Criteria *,
-        std::unique_ptr<arrow::flight::FlightListing> * listings) override;
-
     arrow::Status GetFlightInfo(
         const arrow::flight::ServerCallContext & context,
         const arrow::flight::FlightDescriptor & request,
@@ -82,28 +77,27 @@ public:
         std::unique_ptr<arrow::flight::FlightMessageReader> reader,
         std::unique_ptr<arrow::flight::FlightMetadataWriter> writer) override;
 
-    arrow::Status DoExchange(
-        const arrow::flight::ServerCallContext & context,
-        std::unique_ptr<arrow::flight::FlightMessageReader> reader,
-        std::unique_ptr<arrow::flight::FlightMessageWriter> writer) override;
-
     arrow::Status DoAction(
         const arrow::flight::ServerCallContext & context,
         const arrow::flight::Action & action,
         std::unique_ptr<arrow::flight::ResultStream> * result) override;
-
-    arrow::Status ListActions(const arrow::flight::ServerCallContext & context, std::vector<arrow::flight::ActionType> * actions) override;
 
 private:
     IServer & server;
     LoggerPtr log;
     const Poco::Net::SocketAddress address_to_listen;
     std::optional<ThreadFromGlobalPool> server_thread;
+    std::optional<ThreadFromGlobalPool> cleanup_thread;
     bool initialized = false;
     std::atomic<bool> stopped = false;
 
-    virtual std::unique_ptr<Session> createSession(const arrow::flight::ServerCallContext & context);
+    const UInt64 tickets_lifetime_seconds;
+    const bool cancel_ticket_after_do_get;
+
+    class CallsData;
+    std::unique_ptr<CallsData> calls_data;
 };
+
 }
 
 #endif

--- a/src/Server/ArrowFlightHandler.h
+++ b/src/Server/ArrowFlightHandler.h
@@ -59,6 +59,7 @@ public:
         std::unique_ptr<arrow::flight::ResultStream> * result) override;
 
 private:
+    arrow::Status tryRunAndLogIfError(std::string_view method_name, std::function<arrow::Status()> && func) const;
     arrow::Status evaluatePollDescriptor(const String & poll_descriptor);
 
     IServer & server;

--- a/src/Server/ArrowFlightHandler.h
+++ b/src/Server/ArrowFlightHandler.h
@@ -83,6 +83,8 @@ public:
         std::unique_ptr<arrow::flight::ResultStream> * result) override;
 
 private:
+    arrow::Status evaluatePollDescriptor(const String & poll_descriptor);
+
     IServer & server;
     LoggerPtr log;
     const Poco::Net::SocketAddress address_to_listen;
@@ -93,6 +95,8 @@ private:
 
     const UInt64 tickets_lifetime_seconds;
     const bool cancel_ticket_after_do_get;
+    const UInt64 poll_descriptors_lifetime_seconds;
+    const bool cancel_poll_descriptor_after_poll_flight_info;
 
     class CallsData;
     std::unique_ptr<CallsData> calls_data;

--- a/src/Server/ArrowFlightHandler.h
+++ b/src/Server/ArrowFlightHandler.h
@@ -3,34 +3,10 @@
 #include "config.h"
 
 #if USE_ARROWFLIGHT
-#include <atomic>
-#include <memory>
-#include <IO/ReadBufferFromPocoSocket.h>
-#include <IO/ReadBufferFromString.h>
-#include <IO/ReadHelpers.h>
-#include <IO/WriteBuffer.h>
-#include <IO/WriteBufferFromPocoSocket.h>
-#include <Interpreters/Session.h>
-#include <Interpreters/executeQuery.h>
-#include <Parsers/parseQuery.h>
-#include <Server/GRPCServer.h>
-#include <Server/IServer.h>
-#include <Server/TCPServer.h>
-#include <Server/TCPServerConnectionFactory.h>
-#include <arrow/array.h>
-#include <arrow/buffer.h>
-#include <arrow/builder.h>
-#include <arrow/flight/client.h>
-#include <arrow/flight/server.h>
-#include <arrow/record_batch.h>
-#include <arrow/type.h>
-#include <base/scope_guard.h>
-#include <pcg_random.hpp>
-#include <Common/CurrentThread.h>
-#include <Common/config_version.h>
-#include <Common/randomSeed.h>
-#include <Common/setThreadName.h>
 #include <Common/ThreadPool.h>
+#include <Server/GRPCServer.h>
+#include <arrow/flight/server.h>
+
 
 namespace DB
 {

--- a/src/Storages/ArrowFlight/ArrowFlightConnection.cpp
+++ b/src/Storages/ArrowFlight/ArrowFlightConnection.cpp
@@ -94,6 +94,31 @@ String ArrowFlightConnection::loadCertificate(const String & path)
     return str;
 }
 
+std::shared_ptr<ArrowFlightConnection> ArrowFlightConnection::clone() const
+{
+    return std::shared_ptr<ArrowFlightConnection>{new ArrowFlightConnection(*this)};
+}
+
+std::shared_ptr<ArrowFlightConnection> ArrowFlightConnection::cloneWithHostAndPort(const String & host_, int port_) const
+{
+    auto res = clone();
+    res->host = host_;
+    res->port = port_;
+    return res;
+}
+
+ArrowFlightConnection::ArrowFlightConnection(const ArrowFlightConnection & src)
+    : host(src.host)
+    , port(src.port)
+    , use_basic_authentication(src.use_basic_authentication)
+    , username(src.username)
+    , password(src.password)
+    , enable_ssl(src.enable_ssl)
+    , ssl_ca(src.ssl_ca)
+    , ssl_override_hostname(src.ssl_override_hostname)
+{
+}
+
 }
 
 #endif

--- a/src/Storages/ArrowFlight/ArrowFlightConnection.h
+++ b/src/Storages/ArrowFlight/ArrowFlightConnection.h
@@ -13,15 +13,26 @@ class ArrowFlightConnection
 public:
     explicit ArrowFlightConnection(const StorageArrowFlight::Configuration & config);
 
+    const String & getHost() const { return host; }
+    int getPort() const { return port; }
+
     std::shared_ptr<arrow::flight::FlightClient> getClient() const;
     std::shared_ptr<const arrow::flight::FlightCallOptions> getOptions() const;
+
+    /// Makes another connection with the same parameters.
+    std::shared_ptr<ArrowFlightConnection> clone() const;
+
+    /// Makes another connection with the same parameters except for the host and port.
+    std::shared_ptr<ArrowFlightConnection> cloneWithHostAndPort(const String & host_, int port_) const;
 
 private:
     void connect() const TSA_REQUIRES(mutex);
     static String loadCertificate(const String & path);
 
-    const String host;
-    const int port;
+    ArrowFlightConnection(const ArrowFlightConnection & src);
+
+    String host;
+    int port;
     const bool use_basic_authentication;
     const String username;
     const String password;

--- a/src/Storages/ArrowFlight/ArrowFlightConnection.h
+++ b/src/Storages/ArrowFlight/ArrowFlightConnection.h
@@ -4,6 +4,8 @@
 
 #if USE_ARROWFLIGHT
 #include <Storages/StorageArrowFlight.h>
+#include <arrow/flight/client.h>
+
 
 namespace DB
 {

--- a/src/Storages/StorageArrowFlight.cpp
+++ b/src/Storages/StorageArrowFlight.cpp
@@ -97,6 +97,8 @@ StorageArrowFlight::Configuration StorageArrowFlight::processNamedCollectionResu
     configuration.host = named_collection.getAnyOrDefault<String>({"host", "hostname"}, "");
     configuration.port = static_cast<UInt16>(named_collection.get<UInt64>("port"));
 
+    configuration.dataset_name = named_collection.get<String>("dataset");
+
     configuration.use_basic_authentication = named_collection.getOrDefault<bool>("use_basic_authentication", true);
     bool is_username_set = named_collection.has("username") || named_collection.has("user");
     if (configuration.use_basic_authentication && !is_username_set)

--- a/src/Storages/StorageArrowFlight.cpp
+++ b/src/Storages/StorageArrowFlight.cpp
@@ -177,7 +177,7 @@ Pipe StorageArrowFlight::read(
     SelectQueryInfo & /*query_info*/,
     ContextPtr /*context*/,
     QueryProcessingStage::Enum,
-    size_t max_block_size,
+    size_t /*max_block_size*/,
     size_t /*num_streams*/)
 {
     storage_snapshot->check(column_names);
@@ -189,7 +189,7 @@ Pipe StorageArrowFlight::read(
         sample_block.insert({column_data.type, column_data.name});
     }
 
-    return Pipe(std::make_shared<ArrowFlightSource>(connection, dataset_name, sample_block, column_names, max_block_size));
+    return Pipe(std::make_shared<ArrowFlightSource>(connection, dataset_name, sample_block));
 }
 
 class ArrowFlightSink : public SinkToStorage

--- a/src/Storages/StorageArrowFlight.cpp
+++ b/src/Storages/StorageArrowFlight.cpp
@@ -210,7 +210,7 @@ public:
         {
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Cannot convert chunk to arrow stream: {}", reader_res.status().ToString());
         }
-        auto reader = reader_res.ValueOrDie();
+        const auto & reader = reader_res.ValueOrDie();
 
         std::shared_ptr<arrow::RecordBatch> batch;
         bool first_batch = true;

--- a/src/Storages/StorageArrowFlight.cpp
+++ b/src/Storages/StorageArrowFlight.cpp
@@ -146,26 +146,6 @@ StorageArrowFlight::StorageArrowFlight(
     setInMemoryMetadata(storage_metadata);
 }
 
-std::string buildArrowFlightQueryString(const std::vector<std::string> & column_names, const std::string & dataset_name)
-{
-    std::ostringstream oss; // STYLE_CHECK_ALLOW_STD_STRING_STREAM
-    oss << "{";
-    oss << R"("dataset": ")" << dataset_name << R"(", )";
-    oss << "\"columns\": [";
-
-    for (size_t i = 0; i < column_names.size(); ++i)
-    {
-        oss << "\"" << column_names[i] << "\"";
-        if (i + 1 != column_names.size())
-            oss << ", ";
-    }
-
-    oss << "]";
-    oss << "}";
-
-    return oss.str();
-}
-
 ColumnsDescription StorageArrowFlight::getTableStructureFromData(
     std::shared_ptr<ArrowFlightConnection> connection_,
     const String & dataset_name_)
@@ -209,8 +189,7 @@ Pipe StorageArrowFlight::read(
         sample_block.insert({column_data.type, column_data.name});
     }
 
-    return Pipe(std::make_shared<ArrowFlightSource>(
-        connection, buildArrowFlightQueryString(column_names, dataset_name), sample_block, column_names, max_block_size));
+    return Pipe(std::make_shared<ArrowFlightSource>(connection, dataset_name, sample_block, column_names, max_block_size));
 }
 
 class ArrowFlightSink : public SinkToStorage

--- a/src/Storages/StorageArrowFlight.cpp
+++ b/src/Storages/StorageArrowFlight.cpp
@@ -1,42 +1,20 @@
 #include <Storages/StorageArrowFlight.h>
 
 #if USE_ARROWFLIGHT
-#include <sstream>
-#include <Analyzer/ColumnNode.h>
-#include <Analyzer/ConstantNode.h>
-#include <Analyzer/FunctionNode.h>
-#include <Analyzer/IdentifierNode.h>
-#include <Analyzer/JoinNode.h>
-#include <Analyzer/QueryNode.h>
-#include <Analyzer/SortNode.h>
-#include <Analyzer/TableNode.h>
-#include <Analyzer/Utils.h>
-#include <Core/Names.h>
-#include <DataTypes/DataTypeString.h>
-#include <Formats/FormatFactory.h>
+#include <Common/parseAddress.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/evaluateConstantExpression.h>
-#include <Parsers/ASTCreateQuery.h>
-#include <Parsers/ASTIdentifier.h>
-#include <Parsers/ASTLiteral.h>
 #include <Processors/Formats/Impl/ArrowColumnToCHColumn.h>
 #include <Processors/Formats/Impl/CHColumnToArrowColumn.h>
 #include <Processors/Sinks/SinkToStorage.h>
 #include <Processors/Sources/ArrowFlightSource.h>
 #include <QueryPipeline/Pipe.h>
-#include <Storages/SelectQueryInfo.h>
-#include <Storages/checkAndGetLiteralArgument.h>
 #include <Storages/ArrowFlight/ArrowFlightConnection.h>
 #include <Storages/NamedCollectionsHelpers.h>
-#include <arrow/array.h>
-#include <arrow/buffer.h>
-#include <arrow/builder.h>
+#include <Storages/StorageFactory.h>
+#include <Storages/checkAndGetLiteralArgument.h>
 #include <arrow/flight/client.h>
-#include <arrow/record_batch.h>
-#include <arrow/type.h>
-#include <Common/logger_useful.h>
-#include <Common/parseAddress.h>
-#include <boost/algorithm/string/predicate.hpp>
+
 
 const int ARROWFLIGHT_DEFAULT_PORT = 8815;
 

--- a/src/Storages/StorageArrowFlight.h
+++ b/src/Storages/StorageArrowFlight.h
@@ -3,21 +3,19 @@
 #include "config.h"
 
 #if USE_ARROWFLIGHT
-#include <Core/Names.h>
 #include <Storages/IStorage.h>
-#include <Storages/StorageConfiguration.h>
-#include <Storages/StorageFactory.h>
-#include <arrow/flight/client.h>
+
 
 namespace DB
 {
 class ArrowFlightConnection;
 class NamedCollection;
+class StorageFactory;
 
 class StorageArrowFlight : public IStorage, protected WithContext
 {
 public:
-    struct Configuration : public StatelessTableEngineConfiguration
+    struct Configuration
     {
         String host;
         int port;

--- a/tests/integration/test_arrowflight_interface/configs/small_ticket_lifetime.xml
+++ b/tests/integration/test_arrowflight_interface/configs/small_ticket_lifetime.xml
@@ -1,0 +1,5 @@
+<clickhouse>
+    <arrowflight>
+        <tickets_lifetime_seconds>2</tickets_lifetime_seconds>
+    </arrowflight>
+</clickhouse>

--- a/tests/integration/test_arrowflight_interface/test.py
+++ b/tests/integration/test_arrowflight_interface/test.py
@@ -504,9 +504,12 @@ def test_table_function():
 
     node.query("INSERT INTO mytable VALUES (1, 'a'), (2, 'b')")
 
-    # FIXME
-    assert "Failed to get table schema" in node.query_and_get_error(
-        "SELECT * FROM arrowFlight(flight1, dataset = 'mytable')"
-    )
+    assert node.query(
+          "SELECT * FROM arrowFlight(flight1, dataset = 'mytable') ORDER BY id") == TSV([[1, 'a'], [2, 'b']])
+    
+    node.query("INSERT INTO FUNCTION arrowFlight(flight1, dataset = 'mytable') VALUES (3, 'c')")
+
+    assert node.query(
+          "SELECT * FROM arrowFlight(flight1, dataset = 'mytable') ORDER BY id") == TSV([[1, 'a'], [2, 'b'], [3, 'c']])
 
     node.query("DROP TABLE mytable")

--- a/tests/integration/test_arrowflight_interface/test.py
+++ b/tests/integration/test_arrowflight_interface/test.py
@@ -4,6 +4,8 @@ import os
 import pytest
 import pyarrow as pa
 import pyarrow.flight as flight
+import random
+import string
 
 from helpers.cluster import ClickHouseCluster, get_docker_compose_path
 from helpers.test_tools import TSV
@@ -52,10 +54,18 @@ def start_cluster():
         cluster.shutdown()
 
 
+@pytest.fixture(autouse=True)
+def cleanup_after_test():
+    try:
+        yield
+    finally:
+        node.query("DROP TABLE IF EXISTS mytable SYNC")
+
+
 def test_doput():
     node.query(
         """
-        CREATE TABLE doput_test (
+        CREATE TABLE mytable (
             id Int64,
             name String
         )
@@ -76,18 +86,16 @@ def test_doput():
         ],
         schema=schema,
     )
-    descriptor = flight.FlightDescriptor.for_path("doput_test")
+    descriptor = flight.FlightDescriptor.for_path("mytable")
     writer, _ = client.do_put(descriptor, schema, options)
     writer.write_batch(batch)
     writer.close()
 
-    result = node.query(f"SELECT * FROM doput_test;")
-    assert TSV(result) == TSV("1\tAlice\n2\tBob\n3\tCharlie\n")
-
-    node.query("DROP TABLE IF EXISTS doput_test SYNC")
+    result = node.query("SELECT * FROM mytable")
+    assert result == TSV([[1, 'Alice'], [2, 'Bob'], [3, 'Charlie']])
 
 
-def test_doput_unexisting_table():
+def test_doput_nonexisting_table():
     client, options = get_client()
     schema = pa.schema(
         [
@@ -102,20 +110,22 @@ def test_doput_unexisting_table():
         ],
         schema=schema,
     )
+
+    descriptor = flight.FlightDescriptor.for_path("nonexisting_table")
+    writer, _ = client.do_put(descriptor, schema, options)
+    writer.write_batch(batch)
+
     try:
-        descriptor = flight.FlightDescriptor.for_path("unexisting_table")
-        writer, _ = client.do_put(descriptor, schema, options)
-        writer.write_batch(batch)
         writer.close()
-        assert False, "Expected error but query succeeded: insert into unexisting table"
+        assert False, "Expected error but query succeeded: insert into nonexisting table"
     except flight.FlightServerError as e:
-        assert "Table default.unexisting_table does not exist" in str(e)
+        assert "Table default.nonexisting_table does not exist" in str(e)
 
 
-def test_doput_cmd_descriptor():
+def test_doput_cmd_insert():
     node.query(
         """
-        CREATE TABLE doput_test_cmd_descriptor (
+        CREATE TABLE mytable (
             id   Int64,
             name String
         ) ORDER BY id
@@ -138,26 +148,96 @@ def test_doput_cmd_descriptor():
         schema=schema,
     )
 
-    # Testing here where descriptor constains INSERT QUERY.
-    # This may be useful where some columns of the table have default values
-    # And we do not need to pass them
-    descriptor = flight.FlightDescriptor.for_command(
-        "INSERT INTO doput_test_cmd_descriptor FORMAT Arrow"
-    )
+    descriptor = flight.FlightDescriptor.for_command("INSERT INTO mytable FORMAT Arrow")
     writer, _ = client.do_put(descriptor, schema, options)
     writer.write_batch(batch)
     writer.close()
 
-    result = node.query("SELECT * FROM doput_test_cmd_descriptor ORDER BY id")
-    assert TSV(result) == TSV("1\tAlice\n2\tBob\n3\tCharlie\n")
-
-    node.query("DROP TABLE IF EXISTS doput_test_cmd_descriptor SYNC")
+    result = node.query("SELECT * FROM mytable ORDER BY id")
+    assert result == TSV([[1, 'Alice'], [2, 'Bob'], [3, 'Charlie']])
 
 
-def test_doput_cmd_descriptor_with_data():
+# INSERT queries with any format different from "Arrow" cannot be executed.
+def test_doput_cmd_insert_invalid_format():
     node.query(
         """
-        CREATE TABLE doput_test_cmd_descriptor_with_data (
+        CREATE TABLE mytable (
+            id   Int64,
+            name String
+        ) ORDER BY id
+    """
+    )
+
+    client, options = get_client()
+
+    schema = pa.schema(
+        [
+            ("id", pa.int64()),
+            ("name", pa.string()),
+        ]
+    )
+    batch = pa.record_batch(
+        [
+            pa.array([1, 2, 3], type=pa.int64()),
+            pa.array(["Alice", "Bob", "Charlie"], type=pa.string()),
+        ],
+        schema=schema,
+    )
+
+    descriptor = flight.FlightDescriptor.for_command("INSERT INTO mytable FORMAT JSON")
+    writer, _ = client.do_put(descriptor, schema, options)
+    writer.write_batch(batch)
+
+    try:
+        writer.close()
+        assert False, "Expected to fail because of a wrong format but succeeded"
+    except flight.FlightServerError as e:
+        assert "Invalid format, only 'Arrow' format is supported" in str(e)
+
+
+# INSERT queries without the FORMAT clause are considered invalid.
+def test_doput_cmd_insert_no_format():
+    node.query(
+        """
+        CREATE TABLE mytable (
+            id   Int64,
+            name String
+        ) ORDER BY id
+    """
+    )
+
+    client, options = get_client()
+
+    schema = pa.schema(
+        [
+            ("id", pa.int64()),
+            ("name", pa.string()),
+        ]
+    )
+    batch = pa.record_batch(
+        [
+            pa.array([1, 2, 3], type=pa.int64()),
+            pa.array(["Alice", "Bob", "Charlie"], type=pa.string()),
+        ],
+        schema=schema,
+    )
+
+    descriptor = flight.FlightDescriptor.for_command("INSERT INTO mytable")
+    writer, _ = client.do_put(descriptor, schema, options)
+    writer.write_batch(batch)
+
+    try:
+        writer.close()
+        assert False, "Expected to fail because of no format but succeeded"
+    except flight.FlightServerError as e:
+        assert "Syntax error" in str(e)
+
+
+# INSERT SELECT queries can be executed via method doput.
+def test_doput_cmd_insert_select():
+    node.query(
+        """
+        CREATE TABLE mytable (
             id   Int64,
             name String DEFAULT 'unknown'
         ) ORDER BY id
@@ -180,26 +260,23 @@ def test_doput_cmd_descriptor_with_data():
         schema=schema,
     )
 
-    # Testing here where descriptor constains INSERT QUERY.
-    # This may be useful where some columns of the table have default values
-    # And we do not need to pass them
+    # While inserting we set only column 'id', and column 'name' is set by default to 'unknown'.
     descriptor = flight.FlightDescriptor.for_command(
-        "INSERT INTO doput_test_cmd_descriptor_with_data (id) SELECT number FROM numbers(3)"
+        "INSERT INTO mytable (id) SELECT number FROM numbers(3)"
     )
     writer, _ = client.do_put(descriptor, schema, options)
     writer.write_batch(batch)
     writer.close()
 
-    result = node.query("SELECT * FROM doput_test_cmd_descriptor_with_data ORDER BY id")
-    assert TSV(result) == TSV("0\tunknown\n1\tunknown\n2\tunknown\n")
-
-    node.query("DROP TABLE IF EXISTS doput_test_cmd_descriptor_with_data SYNC")
+    result = node.query("SELECT * FROM mytable ORDER BY id")
+    assert result == TSV([[0, 'unknown'], [1, 'unknown'], [2, 'unknown']])
 
 
-def test_doput_cmd_descriptor_with_default():
+# It's allowed to read only some columns from arrow table while inserting.
+def test_doput_cmd_insert_from_smaller_schema():
     node.query(
         """
-        CREATE TABLE IF NOT EXISTS doput_test_cmd_descriptor_default (
+        CREATE TABLE mytable (
             id   Int64,
             name String DEFAULT 'unknown'
         ) ORDER BY id
@@ -208,6 +285,7 @@ def test_doput_cmd_descriptor_with_default():
 
     client, options = get_client()
 
+    # This arrow schema doesn't contain field 'name', so the 'name' column will be set by default to 'unknown'.
     schema = pa.schema(
         [
             ("id", pa.int64()),
@@ -220,24 +298,30 @@ def test_doput_cmd_descriptor_with_default():
         schema=schema,
     )
 
-    # Testing here where descriptor constains INSERT QUERY.
-    # This may be useful where some columns of the table have default values
-    # And we do not need to pass them
     descriptor = flight.FlightDescriptor.for_command(
-        "INSERT INTO doput_test_cmd_descriptor_default (id) FORMAT Arrow"
+        "INSERT INTO mytable (id) FORMAT Arrow"
     )
     writer, _ = client.do_put(descriptor, schema, options)
     writer.write_batch(batch)
     writer.close()
 
-    result = node.query("SELECT * FROM doput_test_cmd_descriptor_default ORDER BY id")
-    assert TSV(result) == TSV("10\tunknown\n" "20\tunknown\n" "30\tunknown\n")
-
-    node.query("DROP TABLE IF EXISTS doput_test_cmd_descriptor_default SYNC")
+    result = node.query("SELECT * FROM mytable ORDER BY id")
+    assert result == TSV([[10, 'unknown'], [20, 'unknown'], [30, 'unknown']])
 
 
-def test_doput_invalid_query():
+# It's allowed to read only some columns from arrow table while inserting.
+def test_doput_cmd_insert_from_bigger_schema():
+    node.query(
+        """
+        CREATE TABLE mytable (
+            id   Int64,
+        ) ORDER BY id
+    """
+    )
+
     client, options = get_client()
+
+    # This arrow schema doesn't contain field 'name', so the 'name' column will be set by default to 'unknown'.
     schema = pa.schema(
         [
             ("id", pa.int64()),
@@ -251,67 +335,76 @@ def test_doput_invalid_query():
         ],
         schema=schema,
     )
+
+    descriptor = flight.FlightDescriptor.for_command(
+        "INSERT INTO mytable (id) FORMAT Arrow"
+    )
+    writer, _ = client.do_put(descriptor, schema, options)
+    writer.write_batch(batch)
+    writer.close()
+
+    result = node.query("SELECT * FROM mytable ORDER BY id")
+    assert result == TSV([1, 2, 3])
+
+
+# Method doput allows SELECT queries, but doesn't return any results (i.e. it works like SELECT ... FORMAT NULL).
+def test_doput_cmd_select():
+    client, options = get_client()
+
+    name = "".join(
+        random.choice(string.ascii_uppercase + string.digits) for _ in range(4)
+    )
+
+    query = f"SELECT '{name}'"
+    escaped_query = query.replace("'", "\\'")
+
+    descriptor = flight.FlightDescriptor.for_command(query)
+    writer, _ = client.do_put(descriptor, pa.schema([]), options)
+    writer.close()
+
+    node.query("SYSTEM FLUSH LOGS query_log")
+
+    print(
+        node.query(
+            f"""
+        SELECT * FROM system.query_log WHERE query = '{escaped_query}'
+        """
+        )
+    )
+
+    assert 2 == int(
+        node.query(
+            f"""
+        SELECT count() FROM system.query_log WHERE query = '{escaped_query}'
+        """
+        )
+    )
+
+
+# Invalid queries are handled too.
+def test_doput_invalid_query():
+    client, options = get_client()
+    descriptor = flight.FlightDescriptor.for_command("BAD QUERY")
+    writer, _ = client.do_put(descriptor, pa.schema([]), options)
     try:
-        # SELECT clause in DoPut query is forbidden
-        descriptor = flight.FlightDescriptor.for_command("SELECT * FROM my_table")
-        writer, _ = client.do_put(descriptor, schema, options)
-        writer.write_batch(batch)
         writer.close()
         assert False, "Expected error but query succeeded"
     except flight.FlightServerError as e:
-        assert (
-            "Unknown table expression identifier 'my_table' in scope SELECT * FROM my_table"
-            in str(e)
-        )
+        assert "Syntax error: failed at position 1 (BAD): BAD QUERY" in str(e)
 
 
 def test_doget():
-    node.query(
-        """
-        CREATE TABLE doget_test (
-            id Int64,
-            name String
-        )
-        ORDER BY id
-        """
-    )
-    node.query(
-        """
-            INSERT INTO doget_test VALUES(10, 'abc'), (20, 'cde')
-        """
-    )
+    node.query("CREATE TABLE mytable (id Int64, name String) ORDER BY id")
+    node.query("INSERT INTO mytable VALUES (10, 'abc'), (20, 'cde')")
 
     client, options = get_client()
 
-    try:
-        incorrect_ticket = flight.Ticket(
-            b"INSERT INTO doget_test_insert SELECT number, toString(number) FROM numbers(10)"
-        )
-        _ = client.do_get(incorrect_ticket, options)
-    except flight.FlightServerError as e:
-        assert "Table default.doget_test_insert does not exist" in str(e)
-    else:
-        assert False, "INSERT clause in DoGet query is forbidden, but query succeeded"
+    descriptor = flight.FlightDescriptor.for_path("mytable")
+    flight_info = client.get_flight_info(descriptor, options)
+    assert len(flight_info.endpoints) == 1
+    ticket = flight_info.endpoints[0].ticket
 
-    try:
-        incorrect_ticket = flight.Ticket(b"some incorrect query")
-        _ = client.do_get(incorrect_ticket, options)
-
-    except flight.FlightServerError as e:
-        assert "Syntax error" in str(e)
-    else:
-        assert False, "Query is incorrect, but succeeded"
-
-    try:
-        incorrect_ticket = flight.Ticket(b"SELECT * FROM unexisting_table")
-        _ = client.do_get(incorrect_ticket, options)
-    except flight.FlightServerError as e:
-        assert "Unknown table expression identifier 'unexisting_table'" in str(e)
-    else:
-        assert False, "Table is unexisting, but query succeeded"
-
-    real_ticket = flight.Ticket(b"SELECT * FROM doget_test")
-    reader = client.do_get(real_ticket, options)
+    reader = client.do_get(ticket, options)
     actual = reader.read_all()
 
     expected_schema = pa.schema(
@@ -324,170 +417,221 @@ def test_doget():
     expected_names = pa.chunked_array([pa.array(["abc", "cde"], type=pa.string())])
 
     assert actual.schema == expected_schema
-
     assert actual.column("id").equals(expected_ids)
     assert actual.column("name").equals(expected_names)
 
-    # Testing taking only part of the columns in the query
-    real_ticket = flight.Ticket(b"SELECT id FROM doget_test")
-    reader = client.do_get(real_ticket, options)
+
+def test_doget_nonexisting_table():
+    client, options = get_client()
+
+    descriptor = flight.FlightDescriptor.for_path("nonexisting_table")
+
+    try:
+        client.get_flight_info(descriptor, options)
+        assert False, "Expected error but query succeeded: select from nonexisting table"
+    except flight.FlightServerError as e:
+        assert "Unknown table expression identifier 'nonexisting_table'" in str(e)
+
+
+def test_doget_cmd_select():
+    node.query("CREATE TABLE mytable (id Int64, name String) ORDER BY id")
+    node.query("INSERT INTO mytable VALUES (10, 'abc'), (20, 'cde')")
+
+    client, options = get_client()
+
+    descriptor = flight.FlightDescriptor.for_command("SELECT * FROM mytable")
+    flight_info = client.get_flight_info(descriptor, options)
+    assert len(flight_info.endpoints) == 1
+    ticket = flight_info.endpoints[0].ticket
+
+    reader = client.do_get(ticket, options)
     actual = reader.read_all()
 
     expected_schema = pa.schema(
         [
             pa.field("id", pa.int64(), nullable=False),
+            pa.field("name", pa.string(), nullable=False),
         ]
     )
     expected_ids = pa.chunked_array([pa.array([10, 20], type=pa.int64())])
+    expected_names = pa.chunked_array([pa.array(["abc", "cde"], type=pa.string())])
 
     assert actual.schema == expected_schema
-
     assert actual.column("id").equals(expected_ids)
+    assert actual.column("name").equals(expected_names)
 
-    node.query("DROP TABLE IF EXISTS doget_test SYNC")
 
-
-def test_doget_custom_db():
-    node.query("CREATE DATABASE IF NOT EXISTS test_db")
-    node.query("CREATE DATABASE IF NOT EXISTS another_db")
-
-    node.query(
-        """
-        USE test_db;
-
-        CREATE TABLE doget_test_custom_db (
-            id Int64,
-            name String
-        )
-        ORDER BY id;
-
-        INSERT INTO doget_test_custom_db VALUES(10, 'abc'), (20, 'cde');
-        """
-    )
+# Tickets can be either returned by method get_flight_info or built directly from a query,
+# see flight.Ticket(b"SELECT * FROM mytable") in this test.
+def test_doget_ticket_from_select():
+    node.query("CREATE TABLE mytable (id Int64, name String) ORDER BY id")
+    node.query("INSERT INTO mytable VALUES (10, 'abc'), (20, 'cde')")
 
     client, options = get_client()
 
+    ticket = flight.Ticket(b"SELECT * FROM mytable")
+    reader = client.do_get(ticket, options)
+    actual = reader.read_all()
+
+    expected_schema = pa.schema(
+        [
+            pa.field("id", pa.int64(), nullable=False),
+            pa.field("name", pa.string(), nullable=False),
+        ]
+    )
+    expected_ids = pa.chunked_array([pa.array([10, 20], type=pa.int64())])
+    expected_names = pa.chunked_array([pa.array(["abc", "cde"], type=pa.string())])
+
+    assert actual.schema == expected_schema
+    assert actual.column("id").equals(expected_ids)
+    assert actual.column("name").equals(expected_names)
+
+
+# If a query outputs multiple chunks the method get_flight_info returns multiple tickets.
+def test_doget_multiple_chunks():
+    node.query("CREATE TABLE mytable (id Int64, name String) ORDER BY id")
+    node.query("SYSTEM STOP MERGES mytable")
+    node.query("INSERT INTO mytable VALUES (10, 'abc')")
+    node.query("INSERT INTO mytable VALUES (20, 'cde')")
+
+    client, options = get_client()
+
+    descriptor = flight.FlightDescriptor.for_command("SELECT * FROM mytable ORDER BY id")
+    flight_info = client.get_flight_info(descriptor, options)
+    assert len(flight_info.endpoints) == 2
+    tickets = [endpoint.ticket for endpoint in flight_info.endpoints]
+
+    readers = [client.do_get(ticket, options) for ticket in tickets]
+    actual = [reader.read_all() for reader in readers]
+
+    expected_schema = pa.schema(
+        [
+            pa.field("id", pa.int64(), nullable=False),
+            pa.field("name", pa.string(), nullable=False),
+        ]
+    )
+
+    assert actual[0].schema == expected_schema
+    assert actual[1].schema == expected_schema
+    assert actual[0].column("id").equals(pa.chunked_array([pa.array([10], type=pa.int64())]))
+    assert actual[1].column("id").equals(pa.chunked_array([pa.array([20], type=pa.int64())]))
+    assert actual[0].column("name").equals(pa.chunked_array([pa.array(["abc"], type=pa.string())]))
+    assert actual[1].column("name").equals(pa.chunked_array([pa.array(["cde"], type=pa.string())]))
+
+
+# We don't support any formats different from "Arrow".
+def test_doget_cmd_select_invalid_format():
+    node.query("CREATE TABLE mytable (id Int64, name String) ORDER BY id")
+    node.query("INSERT INTO mytable VALUES (10, 'abc'), (20, 'cde')")
+
+    client, options = get_client()
+
+    descriptor = flight.FlightDescriptor.for_command("SELECT * FROM mytable FORMAT JSON")
     try:
-        # Table in test_db, but we use another_db
-        incorrect_ticket = flight.Ticket(
-            b"SELECT * FROM another_db.doget_test_custom_db"
-        )
-        _ = client.do_get(incorrect_ticket, options)
+        client.get_flight_info(descriptor, options)
+        assert False, "Expected to fail because of a wrong format but succeeded"
     except flight.FlightServerError as e:
-        assert (
-            "Unknown table expression identifier 'another_db.doget_test_custom_db'"
-            in str(e)
-        )
-    else:
-        assert False, "Table is unexisting, but query succeeded"
+        assert "Invalid format, only 'Arrow' format is supported" in str(e)
 
-    real_ticket = flight.Ticket(b"SELECT * FROM test_db.doget_test_custom_db")
-    reader = client.do_get(real_ticket, options)
-    reader.read_all()
-
-    node.query(
-        """
-               DROP DATABASE IF EXISTS test_db SYNC;
-               DROP DATABASE IF EXISTS another_db SYNC;
-               """
-    )
+    ticket = flight.Ticket(b"SELECT * FROM mytable FORMAT JSON")
+    try:
+        reader = client.do_get(ticket, options)
+        assert False, "Expected to fail because of a wrong format but succeeded"
+    except flight.FlightServerError as e:
+        assert "Invalid format, only 'Arrow' format is supported" in str(e)
 
 
-def test_doget_format_json():
-    node.query(
-        """
-        CREATE TABLE doget_test_format_json (
-            id Int64,
-            name String
-        )
-        ORDER BY id
-        """
-    )
-    node.query(
-        """
-            INSERT INTO doget_test_format_json VALUES(10, 'abc'), (20, 'cde')
-        """
-    )
+def test_doget_cmd_select_arrow_format():
+    node.query("CREATE TABLE mytable (id Int64, name String) ORDER BY id")
+    node.query("INSERT INTO mytable VALUES (10, 'abc'), (20, 'cde')")
 
     client, options = get_client()
 
-    # Format JSON and other custom format options are forbidden
-    # For DoPut only Arrow and default format are allowed
+    descriptor = flight.FlightDescriptor.for_command("SELECT * FROM mytable FORMAT Arrow")
+    flight_info = client.get_flight_info(descriptor, options)
+    assert len(flight_info.endpoints) == 1
+    ticket = flight_info.endpoints[0].ticket
 
-    try:
-        real_ticket = flight.Ticket(b"SELECT * FROM doget_test_format_json FORMAT JSON")
-        reader = client.do_get(real_ticket, options)
-        reader.read_all()
-    except Exception as e:
-        assert "FORMAT clause not supported by Arrow Flight" in str(e)
-    else:
-        assert False, "Expected a query with FORMAT JSON clause to be failed"
+    reader = client.do_get(ticket, options)
+    actual = reader.read_all()
 
-    try:
-        schema = pa.schema(
-            [
-                ("id", pa.int64()),
-                ("name", pa.string()),
-            ]
-        )
-        batch = pa.record_batch(
-            [
-                pa.array([1, 2, 3], type=pa.int64()),
-                pa.array(["Alice", "Bob", "Charlie"], type=pa.string()),
-            ],
-            schema=schema,
-        )
-        descriptor = flight.FlightDescriptor.for_command(
-            "INSERT INTO doget_test_format_json FORMAT JSON"
-        )
-        writer, _ = client.do_put(descriptor, schema, options)
-        writer.write_batch(batch)
-        writer.close()
-    except Exception as e:
-        assert "DoPut failed: invalid format value" in str(e)
-    else:
-        assert False, "Expected a query with FORMAT JSON clause to be failed"
-
-    node.query("DROP TABLE IF EXISTS doget_test_format_json SYNC")
-
-
-def test_doget_invalid_user():
-    node.query(
-        """
-        CREATE TABLE doget_test_invalid_user (
-            id Int64,
-            name String
-        )
-        ORDER BY id
-        """
+    expected_schema = pa.schema(
+        [
+            pa.field("id", pa.int64(), nullable=False),
+            pa.field("name", pa.string(), nullable=False),
+        ]
     )
-    node.query(
-        """
-            INSERT INTO doget_test_invalid_user VALUES(10, 'abc'), (20, 'cde')
-        """
-    )
+    expected_ids = pa.chunked_array([pa.array([10, 20], type=pa.int64())])
+    expected_names = pa.chunked_array([pa.array(["abc", "cde"], type=pa.string())])
+
+    assert actual.schema == expected_schema
+    assert actual.column("id").equals(expected_ids)
+    assert actual.column("name").equals(expected_names)
+
+    ticket = flight.Ticket(b"SELECT * FROM mytable")
+    reader = client.do_get(ticket, options)
+    actual = reader.read_all()
+
+    assert actual.schema == expected_schema
+    assert actual.column("id").equals(expected_ids)
+    assert actual.column("name").equals(expected_names)
+
+
+# Invalid queries are handled too.
+def test_doget_invalid_query():
+    client, options = get_client()
+
+    descriptor = flight.FlightDescriptor.for_command("BAD QUERY")
+    try:
+        client.get_flight_info(descriptor, options)
+        assert False, "Expected error but query succeeded"
+    except flight.FlightServerError as e:
+        assert "Syntax error: failed at position 1 (BAD): BAD QUERY" in str(e)
+
+    ticket = flight.Ticket(b"BAD QUERY")
+    try:
+        client.do_get(ticket, options)
+        assert False, "Expected error but query succeeded"
+    except flight.FlightServerError as e:
+        assert "Syntax error: failed at position 1 (BAD): BAD QUERY" in str(e)
+
+
+# Method doget doesn't work with INSERT queries.
+def test_doget_invalid_query_insert():
+    node.query("CREATE TABLE mytable (id Int64, name String) ORDER BY id")
+
+    client, options = get_client()
+
+    descriptor = flight.FlightDescriptor.for_command("INSERT INTO mytable FORMAT Arrow")
+    try:
+        client.get_flight_info(descriptor, options)
+        assert False, "Expected error but query succeeded"
+    except pa.lib.ArrowInvalid as e:
+        assert "Query doesn't allow pulling data, use method doPut() with this kind of query" in str(e)
+
+    ticket = flight.Ticket(b"INSERT INTO mytable FORMAT Arrow")
+    try:
+        client.do_get(ticket, options)
+        assert False, "Expected error but query succeeded"
+    except pa.lib.ArrowInvalid as e:
+        assert "Query doesn't allow pulling data, use method doPut() with this kind of query" in str(e)
+
+
+def test_invalid_user():
     client = flight.FlightClient(
         f"grpc+tls://{node.ip_address}:8888", disable_server_verification=True
     )
+    token = client.authenticate_basic_token(b"invalid", b"password")
+    options = flight.FlightCallOptions(headers=[token])
+    ticket = flight.Ticket(b"SELECT * FROM mytable")
     try:
-        token = client.authenticate_basic_token(b"invalid", b"password")
-        options = flight.FlightCallOptions(headers=[token])
-        real_ticket = flight.Ticket(b"SELECT * FROM doget_test_invalid_user")
-        client.do_get(real_ticket, options)
-    except Exception as e:
+        client.do_get(ticket, options)
+        assert False, "Expected authentication failure (login and password are not correct) but succeeded"
+    except flight.FlightServerError as e:
         assert (
             "Authentication failed: password is incorrect, or there is no user with such name"
             in str(e)
         )
-    else:
-        assert False, "Expected call to fail: login and password are not correct"
-
-    result = node.query("SELECT * FROM doget_test_invalid_user")
-
-    # This data was in the table initially
-    assert TSV(result) == TSV("10\tabc\n20\tcde\n")
-
-    node.query("DROP TABLE IF EXISTS doget_test_invalid_user SYNC")
 
 
 def test_table_function():
@@ -505,11 +649,13 @@ def test_table_function():
     node.query("INSERT INTO mytable VALUES (1, 'a'), (2, 'b')")
 
     assert node.query(
-          "SELECT * FROM arrowFlight(flight1, dataset = 'mytable') ORDER BY id") == TSV([[1, 'a'], [2, 'b']])
-    
-    node.query("INSERT INTO FUNCTION arrowFlight(flight1, dataset = 'mytable') VALUES (3, 'c')")
+        "SELECT * FROM arrowFlight(flight1, dataset = 'mytable') ORDER BY id"
+    ) == TSV([[1, "a"], [2, "b"]])
+
+    node.query(
+        "INSERT INTO FUNCTION arrowFlight(flight1, dataset = 'mytable') VALUES (3, 'c')"
+    )
 
     assert node.query(
-          "SELECT * FROM arrowFlight(flight1, dataset = 'mytable') ORDER BY id") == TSV([[1, 'a'], [2, 'b'], [3, 'c']])
-
-    node.query("DROP TABLE mytable")
+        "SELECT * FROM arrowFlight(flight1, dataset = 'mytable') ORDER BY id"
+    ) == TSV([[1, "a"], [2, "b"], [3, "c"]])

--- a/tests/integration/test_arrowflight_interface/test_ticket_expiration.py
+++ b/tests/integration/test_arrowflight_interface/test_ticket_expiration.py
@@ -1,0 +1,84 @@
+# coding: utf-8
+
+import pytest
+import pyarrow as pa
+import pyarrow.flight as flight
+import time
+from datetime import datetime, timezone
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance(
+    "node",
+    main_configs=[
+        "configs/flight_port.xml",
+        "configs/small_ticket_lifetime.xml",
+    ],
+    user_configs=["configs/users.xml"],
+)
+
+
+def get_client():
+    client = flight.FlightClient(f"grpc://{node.ip_address}:8888")
+    token = client.authenticate_basic_token("user1", "qwe123")
+    options = flight.FlightCallOptions(headers=[token])
+    return client, options
+
+
+@pytest.fixture(scope="module", autouse=True)
+def start_cluster():
+    try:
+        cluster.start()
+        node.wait_until_port_is_ready(8888, timeout=10)
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_ticket_expiration():
+    node.query("CREATE TABLE mytable (id Int64, name String) ORDER BY id")
+    node.query("INSERT INTO mytable VALUES (10, 'abc'), (20, 'cde')")
+
+    client, options = get_client()
+
+    descriptor = flight.FlightDescriptor.for_path("mytable")
+    flight_info = client.get_flight_info(descriptor, options)
+    assert len(flight_info.endpoints) == 1
+    ticket = flight_info.endpoints[0].ticket
+    expiration_time = flight_info.endpoints[0].expiration_time.as_py()
+
+    ticket_lifetime_sec = (expiration_time - datetime.now(timezone.utc)).total_seconds()
+    assert 0 < ticket_lifetime_sec and ticket_lifetime_sec < 2
+
+    expected_schema = pa.schema(
+        [
+            pa.field("id", pa.int64(), nullable=False),
+            pa.field("name", pa.string(), nullable=False),
+        ]
+    )
+    expected_ids = pa.chunked_array([pa.array([10, 20], type=pa.int64())])
+    expected_names = pa.chunked_array([pa.array(["abc", "cde"], type=pa.string())])
+
+    reader = client.do_get(ticket, options)
+    actual = reader.read_all()
+    assert actual.schema == expected_schema
+    assert actual.column("id").equals(expected_ids)
+    assert actual.column("name").equals(expected_names)
+
+    # The same ticket can be used again.
+    reader = client.do_get(ticket, options)
+    actual = reader.read_all()
+    assert actual.schema == expected_schema
+    assert actual.column("id").equals(expected_ids)
+    assert actual.column("name").equals(expected_names)
+
+    time.sleep(3)
+
+    # The ticket is expected to be expired now.
+    try:
+        reader = client.do_get(ticket, options)
+        assert False, "Ticket is expected to expire, but still valid"
+    except pa.lib.ArrowKeyError as e:
+        expected_error = f"Ticket '{ticket.ticket.decode()}' not found"
+        assert expected_error in str(e)

--- a/tests/integration/test_arrowflight_interface/test_ticket_expiration.py
+++ b/tests/integration/test_arrowflight_interface/test_ticket_expiration.py
@@ -82,3 +82,5 @@ def test_ticket_expiration():
     except pa.lib.ArrowKeyError as e:
         expected_error = f"Ticket '{ticket.ticket.decode()}' not found"
         assert expected_error in str(e)
+
+    node.query("DROP TABLE mytable SYNC")


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Implement missing parts of ArrowFlight server.

### Details
This PR fixes the issue with ClickHouse as an ArrowFlight server that when connecting from ClickHouse itself it always gives error:

```sql
CREATE TABLE mytable (x UInt64) ENGINE=MergeTree ORDER BY x;
SELECT * FROM arrowFlight('localhost:1234', 'mytable', 'default', '');
```

```
Received exception:
Code: 752. DB::Exception: Failed to get table schema: Key error: Flight returned not found error, with message: Flight not found. (ARROWFLIGHT_FETCH_SCHEMA_ERROR)
```

This PR also fixes overriding the name of a dataset when using named collections:
```
SELECT * FROM arrowFlight(named_collection_1, dataset = 'mytable')
```

Resolves https://github.com/ClickHouse/marketing/issues/1163#issuecomment-3338393815
