### PR TITLE
Get back PageCacheMaxBytes metric

### DIFF
--- a/src/Interpreters/ServerAsynchronousMetrics.cpp
+++ b/src/Interpreters/ServerAsynchronousMetrics.cpp
@@ -13,6 +13,7 @@
 
 #include <IO/UncompressedCache.h>
 #include <IO/MMappedFileCache.h>
+#include <Common/PageCache.h>
 #include <Common/quoteString.h>
 
 #include "config.h"
@@ -91,6 +92,12 @@ void ServerAsynchronousMetrics::updateImpl(TimePoint update_time, TimePoint curr
             "Total capacity in the `cache` virtual filesystem. This cache is hold on disk." };
         new_values["FilesystemCacheFiles"] = { total_files,
             "Total number of cached file segments in the `cache` virtual filesystem. This cache is hold on disk." };
+    }
+
+    if (auto page_cache = getContext()->getPageCache())
+    {
+        new_values["PageCacheMaxBytes"] = { page_cache->maxSizeInBytes(),
+            "Current limit on the size of userspace page cache, in bytes." };
     }
 
     new_values["Uptime"] = { getContext()->getUptimeSeconds(),


### PR DESCRIPTION
Unlike other caches (for most of them you can get current value from system.server_settings), this one is not a trivial metric, since user space page cache may got shrinked if the server is under memory pressure. So it make sense to expose it to user.

_Though note, that other `PageCache` related metrics are in `system.metrics`/`metric_log`_.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Get back `PageCacheMaxBytes` metric

_(Removed in #81023)_
Cc: @primeroz