### PR TITLE
Allow count as SimpleAggregateFunction

### DIFF
--- a/docs/en/sql-reference/data-types/simpleaggregatefunction.md
+++ b/docs/en/sql-reference/data-types/simpleaggregatefunction.md
@@ -51,6 +51,7 @@ The following aggregate functions are supported:
 - [`any_respect_nulls`](/sql-reference/aggregate-functions/reference/any)
 - [`anyLast`](/sql-reference/aggregate-functions/reference/anylast)
 - [`anyLast_respect_nulls`](/sql-reference/aggregate-functions/reference/anylast)
+- [`count`](/sql-reference/aggregate-functions/reference/count)
 - [`min`](/sql-reference/aggregate-functions/reference/min)
 - [`max`](/sql-reference/aggregate-functions/reference/max)
 - [`sum`](/sql-reference/aggregate-functions/reference/sum)

--- a/src/DataTypes/DataTypeCustomSimpleAggregateFunction.cpp
+++ b/src/DataTypes/DataTypeCustomSimpleAggregateFunction.cpp
@@ -36,6 +36,7 @@ void DataTypeCustomSimpleAggregateFunction::checkSupportedFunctions(const Aggreg
         "any_respect_nulls",
         "anyLast",
         "anyLast_respect_nulls",
+        "count",
         "min",
         "max",
         "sum",
@@ -154,7 +155,16 @@ static std::pair<DataTypePtr, DataTypeCustomDescPtr> create(const ASTPtr & argum
 
     DataTypeCustomSimpleAggregateFunction::checkSupportedFunctions(function);
 
-    DataTypePtr storage_type = DataTypeFactory::instance().get(argument_types[0]->getName());
+    DataTypePtr storage_type;
+    if (!argument_types.empty())
+    {
+        storage_type = DataTypeFactory::instance().get(argument_types[0]->getName());
+    }
+    else
+    {
+        // count does not require an argument, get UInt64 result type from the function
+        storage_type = function->getResultType();
+    }
 
     if (!function->getResultType()->equals(*removeLowCardinality(storage_type)))
     {

--- a/tests/queries/0_stateless/00915_simple_aggregate_function.reference
+++ b/tests/queries/0_stateless/00915_simple_aggregate_function.reference
@@ -39,7 +39,7 @@ SimpleAggregateFunction(sum, Float64)
 7	14
 8	16
 9	18
-1	1	\N	2	2.2.2.2	3	([1,2,3],[2,1,1])	([1,2,3],[1,1,2])	([1,2,3],[2,1,2])	[1,2,2,3,4]	[4,2,1,3]	{1:[2,1,3],2:[6,5,4]}
-10	2222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222	10	20	20.20.20.20	5	([2,3,4],[2,1,1])	([2,3,4],[3,3,4])	([2,3,4],[4,3,4])	[]	[]	{}
-SimpleAggregateFunction(anyLast, Nullable(String))	SimpleAggregateFunction(anyLast_respect_nulls, Nullable(String))	SimpleAggregateFunction(anyLast, LowCardinality(Nullable(String)))	SimpleAggregateFunction(anyLast, IPv4)	SimpleAggregateFunction(groupBitOr, UInt32)	SimpleAggregateFunction(sumMap, Tuple(Array(Int32), Array(Int64)))	SimpleAggregateFunction(minMap, Tuple(Array(Int32), Array(Int64)))	SimpleAggregateFunction(maxMap, Tuple(Array(Int32), Array(Int64)))	SimpleAggregateFunction(groupArrayArray, Array(Int32))	SimpleAggregateFunction(groupUniqArrayArray, Array(Int32))	SimpleAggregateFunction(groupUniqArrayArrayMap, Map(Int32, Array(Int64)))
+1	1	\N	2	2.2.2.2	3	([1,2,3],[2,1,1])	([1,2,3],[1,1,2])	([1,2,3],[2,1,2])	[1,2,2,3,4]	[4,2,1,3]	{1:[2,1,3],2:[6,5,4]}	2	2
+10	2222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222	10	20	20.20.20.20	5	([2,3,4],[2,1,1])	([2,3,4],[3,3,4])	([2,3,4],[4,3,4])	[]	[]	{}	2	2
+SimpleAggregateFunction(anyLast, Nullable(String))	SimpleAggregateFunction(anyLast_respect_nulls, Nullable(String))	SimpleAggregateFunction(anyLast, LowCardinality(Nullable(String)))	SimpleAggregateFunction(anyLast, IPv4)	SimpleAggregateFunction(groupBitOr, UInt32)	SimpleAggregateFunction(sumMap, Tuple(Array(Int32), Array(Int64)))	SimpleAggregateFunction(minMap, Tuple(Array(Int32), Array(Int64)))	SimpleAggregateFunction(maxMap, Tuple(Array(Int32), Array(Int64)))	SimpleAggregateFunction(groupArrayArray, Array(Int32))	SimpleAggregateFunction(groupUniqArrayArray, Array(Int32))	SimpleAggregateFunction(groupUniqArrayArrayMap, Map(Int32, Array(Int64)))	SimpleAggregateFunction(count)	SimpleAggregateFunction(count, UInt64)
 with_overflow	1	0

--- a/tests/queries/0_stateless/00915_simple_aggregate_function.sql
+++ b/tests/queries/0_stateless/00915_simple_aggregate_function.sql
@@ -33,16 +33,18 @@ create table simple (
     tup_max SimpleAggregateFunction(maxMap, Tuple(Array(Int32), Array(Int64))),
     arr SimpleAggregateFunction(groupArrayArray, Array(Int32)),
     uniq_arr SimpleAggregateFunction(groupUniqArrayArray, Array(Int32)),
-    map_uniq_arr SimpleAggregateFunction(groupUniqArrayArrayMap, Map(Int32, Array(Int64)))
+    map_uniq_arr SimpleAggregateFunction(groupUniqArrayArrayMap, Map(Int32, Array(Int64))),
+    count_noarg SimpleAggregateFunction(count),
+    count_arg SimpleAggregateFunction(count, UInt64)
 ) engine=AggregatingMergeTree order by id;
-insert into simple values(1,'1','1','1','1.1.1.1', 1, ([1,2], [1,1]), ([1,2], [1,1]), ([1,2], [1,1]), [1,2], [1,2], {1: [1,2], 2: [5,6]});
-insert into simple values(1,null,null,'2','2.2.2.2', 2, ([1,3], [1,1]), ([1,3], [2,2]), ([1,3], [2,2]), [2,3,4], [2,3,4], {1: [2,3], 2: [4,5,6]});
+insert into simple values(1,'1','1','1','1.1.1.1', 1, ([1,2], [1,1]), ([1,2], [1,1]), ([1,2], [1,1]), [1,2], [1,2], {1: [1,2], 2: [5,6]}, 1, 2);
+insert into simple values(1,null,null,'2','2.2.2.2', 2, ([1,3], [1,1]), ([1,3], [2,2]), ([1,3], [2,2]), [2,3,4], [2,3,4], {1: [2,3], 2: [4,5,6]}, 3, 4);
 -- String longer then MAX_SMALL_STRING_SIZE (actual string length is 100)
-insert into simple values(10,'10',null,'10','10.10.10.10', 4, ([2,3], [1,1]), ([2,3], [3,3]), ([2,3], [3,3]), [], [], {});
-insert into simple values(10,'2222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222','10','20','20.20.20.20', 1, ([2, 4], [1,1]), ([2, 4], [4,4]), ([2, 4], [4,4]), [], [], {});
+insert into simple values(10,'10',null,'10','10.10.10.10', 4, ([2,3], [1,1]), ([2,3], [3,3]), ([2,3], [3,3]), [], [], {}, 1, 2);
+insert into simple values(10,'2222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222','10','20','20.20.20.20', 1, ([2, 4], [1,1]), ([2, 4], [4,4]), ([2, 4], [4,4]), [], [], {}, 3, 4);
 
 select * from simple final order by id;
-select toTypeName(nullable_str),toTypeName(nullable_str_respect_nulls),toTypeName(low_str),toTypeName(ip),toTypeName(status), toTypeName(tup), toTypeName(tup_min), toTypeName(tup_max), toTypeName(arr), toTypeName(uniq_arr), toTypeName(map_uniq_arr) from simple limit 1;
+select toTypeName(nullable_str),toTypeName(nullable_str_respect_nulls),toTypeName(low_str),toTypeName(ip),toTypeName(status), toTypeName(tup), toTypeName(tup_min), toTypeName(tup_max), toTypeName(arr), toTypeName(uniq_arr), toTypeName(map_uniq_arr), toTypeName(count_noarg), toTypeName(count_arg) from simple limit 1;
 
 optimize table simple final;
 


### PR DESCRIPTION
Allow using `count` as a `SimpleAggregateFunction` as both:
- `SimpleAggregateFunction(count)`
- `SimpleAggregateFunction(count, UInt64)`

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description]
Allow using `count` as a `SimpleAggregateFunction`.