### PR TITLE
make TCP and HTTP behavior consistent when duplicated external tables

### DIFF
--- a/src/Server/HTTP/HTTPServerRequest.h
+++ b/src/Server/HTTP/HTTPServerRequest.h
@@ -36,7 +36,7 @@ public:
     {
         std::lock_guard lock(get_stream_mutex);
         poco_check_ptr(stream);
-        LOG_DEBUG(getLogger("HTTPServerRequest"), "Returning request input stream with ref count {}", stream.use_count());
+        LOG_TEST(getLogger("HTTPServerRequest"), "Returning request input stream with ref count {}", stream.use_count());
         return stream;
     }
 

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -2357,8 +2357,8 @@ bool TCPHandler::processData(QueryState & state, bool scalar)
 
         NamesAndTypesList columns = block.getNamesAndTypesList();
         auto temporary_table = TemporaryTableHolder(state.query_context, ColumnsDescription{columns}, {});
-        state.query_context->addExternalTable(temporary_id.table_name, std::move(temporary_table));
         auto storage = temporary_table.getTable();
+        state.query_context->addExternalTable(temporary_id.table_name, std::move(temporary_table));
 
         // auto resolved = state.query_context->tryResolveStorageID(temporary_id, Context::ResolveExternal);
         // StoragePtr storage;

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -2355,20 +2355,26 @@ bool TCPHandler::processData(QueryState & state, bool scalar)
     {
         /// Data for external tables
 
-        auto resolved = state.query_context->tryResolveStorageID(temporary_id, Context::ResolveExternal);
-        StoragePtr storage;
-        /// If such a table does not exist, create it.
-        if (resolved)
-        {
-            storage = DatabaseCatalog::instance().getTable(resolved, state.query_context);
-        }
-        else
-        {
-            NamesAndTypesList columns = block.getNamesAndTypesList();
-            auto temporary_table = TemporaryTableHolder(state.query_context, ColumnsDescription{columns}, {});
-            storage = temporary_table.getTable();
-            state.query_context->addExternalTable(temporary_id.table_name, std::move(temporary_table));
-        }
+        NamesAndTypesList columns = block.getNamesAndTypesList();
+        auto temporary_table = TemporaryTableHolder(state.query_context, ColumnsDescription{columns}, {});
+        state.query_context->addExternalTable(temporary_id.table_name, std::move(temporary_table));
+        auto storage = temporary_table.getTable();
+
+        // auto resolved = state.query_context->tryResolveStorageID(temporary_id, Context::ResolveExternal);
+        // StoragePtr storage;
+        // /// If such a table does not exist, create it.
+        // if (resolved)
+        // {
+        //     storage = DatabaseCatalog::instance().getTable(resolved, state.query_context);
+        // }
+        // else
+        // {
+        //     NamesAndTypesList columns = block.getNamesAndTypesList();
+        //     auto temporary_table = TemporaryTableHolder(state.query_context, ColumnsDescription{columns}, {});
+        //     storage = temporary_table.getTable();
+        //     state.query_context->addExternalTable(temporary_id.table_name, std::move(temporary_table));
+        // }
+
         auto metadata_snapshot = storage->getInMemoryMetadataPtr();
         /// The data will be written directly to the table.
         QueryPipeline temporary_table_out(storage->write(ASTPtr(), metadata_snapshot, state.query_context, /*async_insert=*/false));

--- a/tests/queries/0_stateless/03636_TCP_HTTP_external_tables.reference
+++ b/tests/queries/0_stateless/03636_TCP_HTTP_external_tables.reference
@@ -4,7 +4,7 @@ HTTP POST with external table
 3	Bob	40
 4	Alice	28
 5	Tom	35
-TCP POST with external table
+TCP with external table
 1	John	30
 2	Jane	25
 3	Bob	40

--- a/tests/queries/0_stateless/03636_TCP_HTTP_external_tables.reference
+++ b/tests/queries/0_stateless/03636_TCP_HTTP_external_tables.reference
@@ -1,0 +1,9 @@
+HTTP POST with external table
+Code: 57. ... Temporary table external_table already exists. (TABLE_ALREADY_EXISTS) (version 25.10.1.1)
+TCP POST with external table
+1	John	30
+2	Jane	25
+3	Bob	40
+1	John	30
+2	Jane	25
+3	Bob	40

--- a/tests/queries/0_stateless/03636_TCP_HTTP_external_tables.reference
+++ b/tests/queries/0_stateless/03636_TCP_HTTP_external_tables.reference
@@ -1,9 +1,12 @@
 HTTP POST with external table
-Code: 57. ... Temporary table external_table already exists. (TABLE_ALREADY_EXISTS) (version 25.10.1.1)
+1	John	30
+2	Jane	25
+3	Bob	40
+4	Alice	28
+5	Tom	35
 TCP POST with external table
 1	John	30
 2	Jane	25
 3	Bob	40
-1	John	30
-2	Jane	25
-3	Bob	40
+4	Alice	28
+5	Tom	35

--- a/tests/queries/0_stateless/03636_TCP_HTTP_external_tables.sh
+++ b/tests/queries/0_stateless/03636_TCP_HTTP_external_tables.sh
@@ -21,7 +21,7 @@ cat >$tmp_file_2 <<EOF
 EOF
 
 echo "HTTP POST with external table"
-${CLICKHOUSE_CURL} -sS -X POST "${CLICKHOUSE_URL}&query=SELECT%20*%20FROM%20external_table" \
+${CLICKHOUSE_CURL} -sS -X POST "${CLICKHOUSE_URL}&query=SELECT%20*%20FROM%20external_table%20order%20by%20id" \
         -F "external_table_structure=id UInt32, name String, age UInt8" \
         -F "external_table_format=CSV" \
         -F "external_table=@$tmp_file_1" \
@@ -31,7 +31,7 @@ ${CLICKHOUSE_CURL} -sS -X POST "${CLICKHOUSE_URL}&query=SELECT%20*%20FROM%20exte
 
 echo "TCP with external table"
 ${CLICKHOUSE_CLIENT} \
-        --query "SELECT * FROM external_table" \
+        --query "SELECT * FROM external_table order by id" \
         --external \
         --file=$tmp_file_1 \
         --name=external_table \

--- a/tests/queries/0_stateless/03636_TCP_HTTP_external_tables.sh
+++ b/tests/queries/0_stateless/03636_TCP_HTTP_external_tables.sh
@@ -27,9 +27,9 @@ ${CLICKHOUSE_CURL} -sS -X POST "${CLICKHOUSE_URL}&query=SELECT%20*%20FROM%20exte
         -F "external_table=@$tmp_file_1" \
         -F "external_table_structure=id UInt32, name String, age UInt8" \
         -F "external_table_format=CSV" \
-        -F "external_table=@$tmp_file_2" | sed 's/DB::Exception:/.../'
+        -F "external_table=@$tmp_file_2"
 
-echo "TCP POST with external table"
+echo "TCP with external table"
 ${CLICKHOUSE_CLIENT} \
         --query "SELECT * FROM external_table" \
         --external \

--- a/tests/queries/0_stateless/03636_TCP_HTTP_external_tables.sh
+++ b/tests/queries/0_stateless/03636_TCP_HTTP_external_tables.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+
+test_name=$(basename "${BASH_SOURCE[0]}")
+tmp_file=${CLICKHOUSE_TMP}/${test_name}_data.csv
+
+cat >$tmp_file <<EOF
+1,John,30
+2,Jane,25
+3,Bob,40
+EOF
+
+echo "HTTP POST with external table"
+${CLICKHOUSE_CURL} -sS -X POST "${CLICKHOUSE_URL}?query=SELECT%20*%20FROM%20external_table" \
+        -F "external_table_structure=id UInt32, name String, age UInt8" \
+        -F "external_table_format=CSV" \
+        -F "external_table=@$tmp_file" \
+        -F "external_table_structure=id UInt32, name String, age UInt8" \
+        -F "external_table_format=CSV" \
+        -F "external_table=@$tmp_file" | grep TABLE_ALREADY_EXISTS | sed 's/DB::Exception:/.../'
+
+echo "TCP POST with external table"
+${CLICKHOUSE_CLIENT} \
+        --query "SELECT * FROM external_table" \
+        --external \
+        --file=$tmp_file \
+        --name=external_table \
+        --structure="id UInt32, name String, age UInt8" \
+        --format=CSV \
+        --external \
+        --file=$tmp_file \
+        --name=external_table \
+        --structure="id UInt32, name String, age UInt8" \
+        --format=CSV

--- a/tests/queries/0_stateless/03636_TCP_HTTP_external_tables.sh
+++ b/tests/queries/0_stateless/03636_TCP_HTTP_external_tables.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -7,33 +6,39 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 
 test_name=$(basename "${BASH_SOURCE[0]}")
-tmp_file=${CLICKHOUSE_TMP}/${test_name}_data.csv
 
-cat >$tmp_file <<EOF
+tmp_file_1=${CLICKHOUSE_TMP}/${test_name}_data_1.csv
+cat >$tmp_file_1 <<EOF
 1,John,30
 2,Jane,25
 3,Bob,40
 EOF
 
+tmp_file_2=${CLICKHOUSE_TMP}/${test_name}_data_2.csv
+cat >$tmp_file_2 <<EOF
+4,Alice,28
+5,Tom,35
+EOF
+
 echo "HTTP POST with external table"
-${CLICKHOUSE_CURL} -sS -X POST "${CLICKHOUSE_URL}?query=SELECT%20*%20FROM%20external_table" \
+${CLICKHOUSE_CURL} -sS -X POST "${CLICKHOUSE_URL}&query=SELECT%20*%20FROM%20external_table" \
         -F "external_table_structure=id UInt32, name String, age UInt8" \
         -F "external_table_format=CSV" \
-        -F "external_table=@$tmp_file" \
+        -F "external_table=@$tmp_file_1" \
         -F "external_table_structure=id UInt32, name String, age UInt8" \
         -F "external_table_format=CSV" \
-        -F "external_table=@$tmp_file" | grep TABLE_ALREADY_EXISTS | sed 's/DB::Exception:/.../'
+        -F "external_table=@$tmp_file_2" | sed 's/DB::Exception:/.../'
 
 echo "TCP POST with external table"
 ${CLICKHOUSE_CLIENT} \
         --query "SELECT * FROM external_table" \
         --external \
-        --file=$tmp_file \
+        --file=$tmp_file_1 \
         --name=external_table \
         --structure="id UInt32, name String, age UInt8" \
         --format=CSV \
         --external \
-        --file=$tmp_file \
+        --file=$tmp_file_2 \
         --name=external_table \
         --structure="id UInt32, name String, age UInt8" \
         --format=CSV


### PR DESCRIPTION
Related to https://github.com/ClickHouse/clickhouse-go/issues/1671

Firstly try to forbid duplicated external tables in TCP and check CI. --> No. Distributed queries send pieces of temporary tables several times. It is expected that the pieces are concatenated.
As a result I altered HTTP behavior. It accept temporary tables several times, its data is concatenated.


### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Make TCP and HTTP behavior consistent when there duplicated external tables are passed. HTTP allows a temporary table to be passed several times.


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
