### PR TITLE
Fix identifier quoting for parameterized views

### DIFF
--- a/src/Databases/DatabaseOnDisk.cpp
+++ b/src/Databases/DatabaseOnDisk.cpp
@@ -168,7 +168,11 @@ String getObjectDefinitionFromCreateQuery(const ASTPtr & query)
         create->setTable(TABLE_WITH_UUID_NAME_PLACEHOLDER);
 
     WriteBufferFromOwnString statement_buf;
-    IAST::FormatSettings format_settings(/*one_line=*/false);
+    IAST::FormatSettings format_settings(
+        /*one_line=*/false, 
+        /*hilite=*/false, 
+        /*identifier_quoting_rule=*/IdentifierQuotingRule::Always
+    );
     create->format(statement_buf, format_settings);
     writeChar('\n', statement_buf);
     return statement_buf.str();
@@ -902,7 +906,11 @@ void DatabaseOnDisk::modifySettingsMetadata(const SettingsChanges & settings_cha
     create->if_not_exists = false;
 
     WriteBufferFromOwnString statement_buf;
-    IAST::FormatSettings format_settings(/*one_line=*/false);
+    IAST::FormatSettings format_settings(
+        /*one_line=*/false, 
+        /*hilite=*/false, 
+        /*identifier_quoting_rule=*/IdentifierQuotingRule::Always
+    );
     create->format(statement_buf, format_settings);
     writeChar('\n', statement_buf);
     String statement = statement_buf.str();


### PR DESCRIPTION
- What happens:

First view works perfectly:

Create a parameterized view with backticks in the name: WH.Clickhouse Test``
The view works correctly, can be queried: SELECT * FROM WH.Clickhouse Test(client_code = 'CL00001')
SHOW CREATE VIEW displays correctly
Metadata file saved correctly with backticks


Second view breaks on restart:

Create a second parameterized view that references the first view
The view is created successfully and can be queried initially
BUT when ClickHouse saves it to the metadata file, it removes the backticks from Clickhouse Test
The metadata file contains: FROM WH.Clickhouse Test(client_code = {client_code:String}) instead of FROM WH.Clickhouse Test(client_code = {client_code:String})
When ClickHouse restarts and tries to load this metadata file, it fails with a syntax error because Clickhouse Test (without backticks) is invalid SQL due to the space in the name



Key point: The bug only occurs when a parameterized view references another parameterized view. The backticks are stripped from the referenced view name in the metadata file.

- Root Cause
The problem is in DatabaseOnDisk.cpp:170 in the getObjectDefinitionFromCreateQuery() function:
cppIAST::FormatSettings format_settings(/*one_line=*/false, /*hilite*/false);
create->format(statement_buf, format_settings);
What happens internally:

When saving the view definition to the metadata file, ClickHouse calls getObjectDefinitionFromCreateQuery()
This function creates FormatSettings with default parameters
The third parameter identifier_quoting_rule defaults to IdentifierQuotingRule::WhenNecessary
When formatting the identifier `Clickhouse Test` followed by parameters (client_code = {client_code:String}), the formatter incorrectly decides that backticks are "not necessary"
It removes the backticks, resulting in: WH.Clickhouse Test(client_code = ...)
This produces invalid SQL because the space in the name requires backticks

Why it works for the first view but not the second:
When there are no parameters following the view name, the formatter correctly determines that backticks are needed (due to the space) and preserves them. However, when parameters are present immediately after the view name, the logic that decides whether quotes are necessary malfunctions and incorrectly removes them.

- Solution
In DatabaseOnDisk.cpp:170 and DatabaseOnDisk.cpp:901, change:
cppIAST::FormatSettings format_settings(/*one_line=*/false, /*hilite*/false);
To:
cppIAST::FormatSettings format_settings(
    /*one_line=*/false, 
    /*hilite*/false,
    /*identifier_quoting_rule=*/IdentifierQuotingRule::Always
);
This forces all identifiers to always be written with backticks in the metadata files, preventing the syntax errors when ClickHouse restarts and reloads the view definitions.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description]
Fix identifier quoting for parameterized views

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
