### PR TITLE
tests: fix test_failed_async_inserts flakiness in private (disable remote database disk)

### DIFF
--- a/tests/integration/test_failed_async_inserts/test.py
+++ b/tests/integration/test_failed_async_inserts/test.py
@@ -7,7 +7,10 @@ from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance(
-    "node", main_configs=["configs/config.xml"], with_zookeeper=True
+    "node", main_configs=["configs/config.xml"],
+    with_zookeeper=True,
+    # Server is very short on memory and may fail while initializing remote database disk
+    with_remote_database_disk=False,
 )
 
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
