### PR TITLE
tests: fix flakiness of 02676_analyzer_limit_offset

### DIFF
--- a/tests/queries/0_stateless/02676_analyzer_limit_offset.sql
+++ b/tests/queries/0_stateless/02676_analyzer_limit_offset.sql
@@ -8,27 +8,27 @@ OPTIMIZE TABLE test FINAL;
 
 -- Only set limit
 SET limit = 5;
-SELECT * FROM test; -- 5 rows
-SELECT * FROM test OFFSET 20; -- 5 rows
-SELECT * FROM (SELECT i FROM test LIMIT 10 OFFSET 50) TMP; -- 5 rows
-SELECT * FROM test LIMIT 4 OFFSET 192; -- 4 rows
-SELECT * FROM test LIMIT 10 OFFSET 195; -- 5 rows
+SELECT * FROM test ORDER BY i; -- 5 rows
+SELECT * FROM test ORDER BY i OFFSET 20; -- 5 rows
+SELECT * FROM (SELECT i FROM test LIMIT 10 OFFSET 50) TMP ORDER BY i; -- 5 rows
+SELECT * FROM test ORDER BY i LIMIT 4 OFFSET 192; -- 4 rows
+SELECT * FROM test ORDER BY i LIMIT 10 OFFSET 195; -- 5 rows
 
 -- Only set offset
 SET limit = 0;
 SET offset = 195;
-SELECT * FROM test; -- 5 rows
-SELECT * FROM test OFFSET 20; -- no result
-SELECT * FROM test LIMIT 100; -- no result
+SELECT * FROM test ORDER BY i; -- 5 rows
+SELECT * FROM test ORDER BY i OFFSET 20; -- no result
+SELECT * FROM test ORDER BY i LIMIT 100; -- no result
 SET offset = 10;
-SELECT * FROM test LIMIT 20 OFFSET 100; -- 10 rows
-SELECT * FROM test LIMIT 11 OFFSET 100; -- 1 rows
+SELECT * FROM test ORDER BY i LIMIT 20 OFFSET 100; -- 10 rows
+SELECT * FROM test ORDER BY i LIMIT 11 OFFSET 100; -- 1 rows
 
 -- offset and limit together
 SET limit = 10;
-SELECT * FROM test LIMIT 50 OFFSET 50; -- 10 rows
-SELECT * FROM test LIMIT 50 OFFSET 190; -- 0 rows
-SELECT * FROM test LIMIT 50 OFFSET 185; -- 5 rows
-SELECT * FROM test LIMIT 18 OFFSET 5; -- 8 rows
+SELECT * FROM test ORDER BY i LIMIT 50 OFFSET 50; -- 10 rows
+SELECT * FROM test ORDER BY i LIMIT 50 OFFSET 190; -- 0 rows
+SELECT * FROM test ORDER BY i LIMIT 50 OFFSET 185; -- 5 rows
+SELECT * FROM test ORDER BY i LIMIT 18 OFFSET 5; -- 8 rows
 
 DROP TABLE test;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

CI: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=8e4ce0ab1c05b2cf352c546fca863c5db23baa43&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_binary%2C%20old%20analyzer%2C%20s3%20storage%2C%20DatabaseReplicated%2C%20parallel%29&name_1=Stateless%20tests%20%28amd_binary%2C%20old%20analyzer%2C%20s3%20storage%2C%20DatabaseReplicated%2C%20parallel%29
CI: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=8e4ce0ab1c05b2cf352c546fca863c5db23baa43&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_binary%2C%20old%20analyzer%2C%20s3%20storage%2C%20DatabaseReplicated%2C%20parallel%29&name_1=Stateless%20tests%20%28amd_binary%2C%20old%20analyzer%2C%20s3%20storage%2C%20DatabaseReplicated%2C%20parallel%29