### PR TITLE
tests: atomically write config in test_disallow_concurrency (fixes remote database disk)

### DIFF
--- a/tests/integration/test_backup_restore_on_cluster/test_disallow_concurrency.py
+++ b/tests/integration/test_backup_restore_on_cluster/test_disallow_concurrency.py
@@ -20,7 +20,7 @@ def generate_cluster_def():
         "./_gen/cluster_for_test_disallow_concurrency.xml",
     )
     os.makedirs(os.path.dirname(path), exist_ok=True)
-    with open(path, "w") as f:
+    with open(path + ".tmp", "w") as f:
         f.write(
             """
         <clickhouse>
@@ -48,6 +48,7 @@ def generate_cluster_def():
         </clickhouse>
         """
         )
+    os.rename(path + ".tmp", path)
     return path
 
 


### PR DESCRIPTION
Remote database disk parsing those .xml files that is defined in main_configs, but our CI collecting tests in parallel, which means that if we are lucky enough we may got empty/partially written file.

Let's make it atomic to fix possible problems, like this (from CI):

    test_backup_restore_on_cluster/test_disallow_concurrency.py:61: in <module>
        cluster.add_instance(
    helpers/cluster.py:1995: in add_instance
        tree = ET.parse(config_file_path)
    /usr/lib/python3.10/xml/etree/ElementTree.py:1222: in parse
        tree.parse(source, parser)
    /usr/lib/python3.10/xml/etree/ElementTree.py:580: in parse
        self._root = parser._parse_whole(source)
    E   xml.etree.ElementTree.ParseError: no element found: line 1, column 0

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)