### PR TITLE
Fix flaky test_jbod_balancer test

### DIFF
--- a/tests/integration/test_jbod_balancer/test.py
+++ b/tests/integration/test_jbod_balancer/test.py
@@ -78,7 +78,7 @@ def check_balance(node, table):
 
 
 def wait_until_fully_merged(node, table):
-    for i in range(20):
+    for i in range(200):
         # Wait in-flight merges to finish
         merges_count_query = (
             f"select count() from system.merges where table = '{table}'"


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
The `test_jbod_balancer` test occasionally fails with "There are still merges on-going after 20 assignments". It's likely due to recent changes in merge strategy which may result in more merge iterations needed to fully merge parts. Since the test performs 200 inserts, increase the merge attempt limit from 20 to 200 should be enough. The test still exits early when `optimize_throw_if_noop` confirms no more merges are possible, so this doesn't affect normal test time.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
