### PR TITLE
Fix crash in mortonEncode/hilbertEncode with empty tuple

### DIFF
--- a/src/Functions/FunctionSpaceFillingCurve.h
+++ b/src/Functions/FunctionSpaceFillingCurve.h
@@ -47,6 +47,10 @@ public:
             vector_start_index = 1;
             const auto * type_tuple = typeid_cast<const DataTypeTuple *>(arguments[0].get());
             auto tuple_size = type_tuple->getElements().size();
+            if (tuple_size == 0)
+                throw Exception(ErrorCodes::TOO_FEW_ARGUMENTS_FOR_FUNCTION,
+                                "Empty tuple is not allowed for function {}",
+                                getName());
             if (tuple_size != (arguments.size() - 1))
                 throw Exception(ErrorCodes::ARGUMENT_OUT_OF_BOUND,
                                 "Illegal argument {} for function {}, tuple size should be equal to number of UInt arguments",

--- a/src/Functions/FunctionSpaceFillingCurve.h
+++ b/src/Functions/FunctionSpaceFillingCurve.h
@@ -48,7 +48,7 @@ public:
             const auto * type_tuple = typeid_cast<const DataTypeTuple *>(arguments[0].get());
             auto tuple_size = type_tuple->getElements().size();
             if (tuple_size == 0)
-                throw Exception(ErrorCodes::TOO_FEW_ARGUMENTS_FOR_FUNCTION,
+                throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
                                 "Empty tuple is not allowed for function {}",
                                 getName());
             if (tuple_size != (arguments.size() - 1))

--- a/tests/queries/0_stateless/03647_morton_encode_empty_tuple.sql
+++ b/tests/queries/0_stateless/03647_morton_encode_empty_tuple.sql
@@ -1,0 +1,5 @@
+-- Test for issue #87840: mortonEncode with empty tuple should fail gracefully
+SELECT mortonEncode(()); -- { serverError TOO_FEW_ARGUMENTS_FOR_FUNCTION }
+
+-- hilbertEncode should also reject empty tuple (uses same base class)
+SELECT hilbertEncode(()); -- { serverError TOO_FEW_ARGUMENTS_FOR_FUNCTION }

--- a/tests/queries/0_stateless/03647_morton_encode_empty_tuple.sql
+++ b/tests/queries/0_stateless/03647_morton_encode_empty_tuple.sql
@@ -1,5 +1,5 @@
 -- Test for issue #87840: mortonEncode with empty tuple should fail gracefully
-SELECT mortonEncode(()); -- { serverError TOO_FEW_ARGUMENTS_FOR_FUNCTION }
+SELECT mortonEncode(()); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
 
 -- hilbertEncode should also reject empty tuple (uses same base class)
-SELECT hilbertEncode(()); -- { serverError TOO_FEW_ARGUMENTS_FOR_FUNCTION }
+SELECT hilbertEncode(()); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Fixed crash in `mortonEncode` and `hilbertEncode` functions when called with empty tuple argument.

---

## Description

Fixes #87840

Empty tuple `()` passed to `mortonEncode()` or `hilbertEncode()` caused a crash due to out-of-bounds array access.

**Root cause**: The crash occurs in `executeImpl`. When `mortonEncode(())` is called with an empty tuple:
   - `arguments.size() == 1` (only the empty tuple)
   - `mask->tupleSize() == 0`, `vectorStartIndex = 1`
   - `EXTRACT_VECTOR(0)` at mortonEncode.cpp:73 expands to `non_const_arguments[0 + 1].column`
   - This accesses `[1]` when array size is only 1 → **out-of-bounds crash**
   
   Similarly, hilbertEncode.cpp:65 accesses `arguments[0 + vector_start_index]` with same issue.
The empty tuple check in getReturnTypeImpl prevents the crash by rejecting empty tuples during type checking before execution.

**Fix**: Added validation in `FunctionSpaceFillingCurveEncode::getReturnTypeImpl` to reject empty tuples at the type-checking stage with a clear error message.

**Error before**: Crash with `vector[] index out of bounds`  
**Error after**: `Code: 35. DB::Exception: Empty tuple is not allowed for function mortonEncode`

## Testing

Added test file `03647_morton_encode_empty_tuple.sql` covering:
- `mortonEncode(())` - rejects with `TOO_FEW_ARGUMENTS_FOR_FUNCTION`
- `hilbertEncode(())` - rejects with `TOO_FEW_ARGUMENTS_FOR_FUNCTION`

Note: `mortonDecode` and `hilbertDecode` already have proper validation (`tuple_size < 1` check).