### PR TITLE
Avoid using lz4/zstd from rust crates

### DIFF
--- a/programs/CMakeLists.txt
+++ b/programs/CMakeLists.txt
@@ -78,7 +78,7 @@ macro(clickhouse_program_add_library name)
 
     set(_link ${CLICKHOUSE_${name_uc}_LINK}) # can't use ${} in if()
     if(_link)
-        target_link_libraries(clickhouse-${name}-lib ${CLICKHOUSE_${name_uc}_LINK})
+        target_link_libraries(clickhouse-${name}-lib PRIVATE ${CLICKHOUSE_${name_uc}_LINK})
     endif()
 
     target_include_directories (clickhouse-${name}-lib PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
@@ -113,7 +113,6 @@ add_subdirectory (static-files-disk-uploader)
 add_subdirectory (su)
 add_subdirectory (zookeeper-dump-tree)
 add_subdirectory (zookeeper-remove-by-list)
-
 if (ENABLE_CLICKHOUSE_KEEPER_CONVERTER)
     add_subdirectory (keeper-converter)
 endif()
@@ -170,22 +169,6 @@ endfunction()
 
 if (ENABLE_CLICKHOUSE_SELF_EXTRACTING)
     list(APPEND CLICKHOUSE_BUNDLE self-extracting)
-endif ()
-
-if (TARGET ch_rust::chdig)
-    clickhouse_program_alias(clickhouse-chdig)
-    clickhouse_program_alias(chdig)
-else()
-    message(STATUS "Adding dummy chdig targets (for nfpm)")
-    foreach (chdig_path ${CMAKE_BINARY_DIR}/chdig ${CMAKE_BINARY_DIR}/clickhouse-chdig)
-        file(GENERATE OUTPUT ${chdig_path} CONTENT "#!/usr/bin/env sh\necho chdig is not enabled in this ClickHouse build >&2 && exit 1\n")
-        install(FILES ${chdig_path}
-            DESTINATION ${CMAKE_INSTALL_BINDIR}
-            PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
-                        GROUP_READ GROUP_EXECUTE
-                        WORLD_READ WORLD_EXECUTE
-        )
-    endforeach()
 endif ()
 
 clickhouse_program_install(clickhouse-benchmark benchmark)
@@ -272,5 +255,25 @@ if (TARGET ch_contrib::protobuf)
     get_property(google_proto_files TARGET ch_contrib::protobuf PROPERTY google_proto_files)
     foreach (proto_file IN LISTS google_proto_files)
         install(FILES ${proto_file} DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/clickhouse/protos/google/protobuf)
+    endforeach()
+endif ()
+
+# FIXME: This should be at the end, to avoid using symbols from chdig if there
+# are the same in one of contribs (the problem was with lz4)
+if (TARGET ch_rust::chdig)
+    target_link_libraries (clickhouse PRIVATE ch_rust::chdig)
+
+    clickhouse_program_alias(clickhouse-chdig)
+    clickhouse_program_alias(chdig)
+else()
+    message(STATUS "Adding dummy chdig targets (for nfpm)")
+    foreach (chdig_path ${CMAKE_BINARY_DIR}/chdig ${CMAKE_BINARY_DIR}/clickhouse-chdig)
+        file(GENERATE OUTPUT ${chdig_path} CONTENT "#!/usr/bin/env sh\necho chdig is not enabled in this ClickHouse build >&2 && exit 1\n")
+        install(FILES ${chdig_path}
+            DESTINATION ${CMAKE_INSTALL_BINDIR}
+            PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                        GROUP_READ GROUP_EXECUTE
+                        WORLD_READ WORLD_EXECUTE
+        )
     endforeach()
 endif ()

--- a/programs/client/CMakeLists.txt
+++ b/programs/client/CMakeLists.txt
@@ -24,9 +24,6 @@ endif()
 if (TARGET ch_rust::skim)
     list(APPEND CLICKHOUSE_CLIENT_LINK PRIVATE ch_rust::skim)
 endif()
-if (TARGET ch_rust::chdig)
-    list(APPEND CLICKHOUSE_CLIENT_LINK PRIVATE ch_rust::chdig)
-endif()
 
 # Always use internal readpassphrase
 list(APPEND CLICKHOUSE_CLIENT_LINK PRIVATE readpassphrase)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -696,6 +696,12 @@ if (TARGET ch_contrib::google_cloud_cpp)
 endif()
 
 if (TARGET ch_rust::delta_kernel_rs)
+    # FIXME: This is a temporary hack to force cmake put delta_kernel_rs at the
+    # end of the dependencies list, so that the linker will use symbols from it
+    # only if there were no such symbols before.
+    #
+    # Without it some symbols for lz4/zstd can be used from crates instead of our contrib.
+    target_link_libraries(clickhouse_common_io PRIVATE ch_rust::delta_kernel_rs)
     target_link_libraries(dbms PRIVATE ch_rust::delta_kernel_rs)
 endif ()
 

--- a/tests/queries/0_stateless/03641_clickhouse_prefer_symbols_from_contrib_over_rust_crates.reference
+++ b/tests/queries/0_stateless/03641_clickhouse_prefer_symbols_from_contrib_over_rust_crates.reference
@@ -1,0 +1,2 @@
+contrib/lz4/lib/lz4.c
+contrib/zstd/lib/compress/zstd_compress.c

--- a/tests/queries/0_stateless/03641_clickhouse_prefer_symbols_from_contrib_over_rust_crates.sh
+++ b/tests/queries/0_stateless/03641_clickhouse_prefer_symbols_from_contrib_over_rust_crates.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Tags: long, no-msan
+
+# FIXME: Note, this is not a queries test at all, move it somewhere else
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+$CLICKHOUSE_LOCAL -q "
+SELECT replaceRegexpOne(unit_name, '.*(contrib)', '\1')
+FROM file('$(which $CLICKHOUSE_BINARY)', DWARF)
+WHERE name IN ('ZSTD_compressStream2', 'LZ4_compress_fast_extState') AND not(has(attr_name, 'declaration'))
+ORDER BY ALL
+SETTINGS max_threads=64
+"


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

There is a problem with linking order, that lead to the linker prefer symbols from crates (at least lz4/zstd are affected).

I spend some time to write ["smart" `cmake` code](https://github.com/azat/ClickHouse/commit/df20f40ea7b21c3f398cecdf2e22bd9fabf4b39d) that tries to put rust dependencies at the end, but it does not work, since it cannot respect dependencies of dependencies, and the dependecies are quiet complex (clickhouse_common_io vs dbms libs).

I've also tried to replace some `target_link_libraries()` with `target_include_directories(PRIVATE $<TARGET_PROPERTY:LIB,INTERFACE_INCLUDE_DIRECTORIES>)`, but this does not help either.

So this is a temporary workaround for a problem, at least it works [1].

  [1]: https://pastila.nl/?0038ca04/550fc6bd2b159b686d00e750dd82c045#+DGmFDWDhbHDfrdMhLfZqQ==

Refs: https://github.com/ClickHouse/ClickHouse/issues/88111