### PR TITLE
Fix rows_before_aggregation for aggregation in order

### DIFF
--- a/src/Processors/Transforms/AggregatingInOrderTransform.cpp
+++ b/src/Processors/Transforms/AggregatingInOrderTransform.cpp
@@ -82,8 +82,6 @@ void AggregatingInOrderTransform::consume(Chunk chunk)
         is_consume_started = true;
     }
 
-    if (rows_before_aggregation)
-        rows_before_aggregation->add(rows);
     src_rows += rows;
     src_bytes += chunk.bytes();
 
@@ -190,6 +188,8 @@ void AggregatingInOrderTransform::consume(Chunk chunk)
                         = params->aggregator.prepareBlockAndFillSingleLevel</* return_single_block */ true>(variants, /* final= */ false);
                 cur_block_bytes += current_memory_usage;
                 finalizeCurrentChunk(std::move(chunk), key_end);
+                if (rows_before_aggregation)
+                    rows_before_aggregation->add(key_end);
                 return;
             }
 
@@ -200,6 +200,9 @@ void AggregatingInOrderTransform::consume(Chunk chunk)
 
         key_begin = key_end;
     }
+
+    if (rows_before_aggregation)
+        rows_before_aggregation->add(rows);
 
     cur_block_bytes += current_memory_usage;
     block_end_reached = false;

--- a/tests/queries/0_stateless/03644_rows_before_aggregation_in_order.reference
+++ b/tests/queries/0_stateless/03644_rows_before_aggregation_in_order.reference
@@ -1,0 +1,18 @@
+{
+	"meta":
+	[
+		{
+			"name": "i",
+			"type": "UInt32"
+		}
+	],
+
+	"data":
+	[
+
+	],
+
+	"rows": 0,
+
+	"rows_before_aggregation": 10000
+}

--- a/tests/queries/0_stateless/03644_rows_before_aggregation_in_order.sql
+++ b/tests/queries/0_stateless/03644_rows_before_aggregation_in_order.sql
@@ -1,0 +1,23 @@
+-- Tags: no-parallel-replicas, no-random-merge-tree-settings
+-- no-parallel-replicas: always returns rows_before_limit_counter in response
+
+drop table if exists 03644_data;
+
+create table 03644_data (i UInt32) engine = MergeTree order by i
+as
+select number from numbers(10000);
+
+select i
+from 03644_data
+group by i
+having count() > 1
+settings
+    rows_before_aggregation = 1,
+    exact_rows_before_limit = 1,
+    output_format_write_statistics = 0,
+    max_block_size = 100,
+    aggregation_in_order_max_block_bytes = 8,
+    optimize_aggregation_in_order=1
+format JSONCompact;
+
+drop table 03644_data;


### PR DESCRIPTION
Closes #87927 

Current implementation sets rows_before_aggregation to consumed chunk number of rows. In cases when in order aggregation block in limited, and transformation splits the chunk to process it in more than one iteration, the counter starts to double account input rows.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
