### PR TITLE
Add a test for database_disk in clickhouse-local

### DIFF
--- a/tests/queries/0_stateless/03642_clickhouse_local_database_disk.local.yaml
+++ b/tests/queries/0_stateless/03642_clickhouse_local_database_disk.local.yaml
@@ -1,0 +1,9 @@
+database_disk:
+  disk: local
+
+storage_configuration:
+  disks:
+    local:
+      type: local
+      path:
+        "@from_env": CLICKHOUSE_LOCAL_DISK_PATH

--- a/tests/queries/0_stateless/03642_clickhouse_local_database_disk.reference
+++ b/tests/queries/0_stateless/03642_clickhouse_local_database_disk.reference
@@ -1,0 +1,2 @@
+CREATE TABLE system.foo\n(\n    `key` Int32\n)\nENGINE = `Null`
+CREATE TABLE system.foo\n(\n    `key` Int32\n)\nENGINE = `Null`

--- a/tests/queries/0_stateless/03642_clickhouse_local_database_disk.sh
+++ b/tests/queries/0_stateless/03642_clickhouse_local_database_disk.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+config=$CUR_DIR/03642_clickhouse_local_database_disk.local.yaml
+
+export CLICKHOUSE_LOCAL_DISK_PATH=$CLICKHOUSE_TEST_UNIQUE_NAME/local-disk/
+path=$CLICKHOUSE_TEST_UNIQUE_NAME/local-database/
+
+system_database_uuid=$($CLICKHOUSE_LOCAL -q "select generateUUIDv4()")
+
+mkdir -p "$CLICKHOUSE_LOCAL_DISK_PATH/metadata"
+cat > "$CLICKHOUSE_LOCAL_DISK_PATH/metadata/system.sql" <<EOL
+ATTACH DATABASE _ UUID '$system_database_uuid'
+ENGINE = Atomic
+EOL
+
+$CLICKHOUSE_LOCAL --config-file "$config" --path "$path" -q "create table system.foo (key Int) engine=Null()"
+$CLICKHOUSE_LOCAL --config-file "$config" --path "$path" -q "show create system.foo"
+$CLICKHOUSE_LOCAL --config-file "$config" --path "$path" --only-system-tables -q "show create system.foo"
+
+rm -fr "${CLICKHOUSE_TEST_UNIQUE_NAME:?}"


### PR DESCRIPTION
While I was looking why scraping of system.*_log tables does not work in private I wrote this test, but everything is OK here the problem there is different - s3_with_keeper disk (and a hack for it).

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
