### PR TITLE
tests: fix port overlap in ytsaurus tests

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -864,7 +864,7 @@ class ClickHouseCluster:
         self.prometheus_remote_write_handlers = []
         self.prometheus_remote_read_handlers = []
 
-        self.ytsaurus_port = 80
+        self._ytsaurus_port = None
 
         self.docker_client: docker.DockerClient = None
         self.is_up = False
@@ -901,6 +901,12 @@ class ClickHouseCluster:
             return self._nginx_port
         self._nginx_port = self.port_pool.get_port()
         return self._nginx_port
+
+    @property
+    def ytsaurus_port(self):
+        if not self._ytsaurus_port:
+            self._ytsaurus_port = self.port_pool.get_port()
+        return self._ytsaurus_port
 
     @property
     def kafka_port(self):


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

CI: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=88105&sha=7a9ea0741cd64ec11f96818b9c8d02fb296c87ce&name_0=PR&name_1=Integration%20tests%20%28amd_binary%2C%204%2F5%29
Cc @MikhailBurdukov