### PR TITLE
Allow granting SQL roles to XML users

### DIFF
--- a/src/Access/AccessControl.cpp
+++ b/src/Access/AccessControl.cpp
@@ -396,7 +396,6 @@ void AccessControl::addDiskStorage(const String & storage_name_, const String & 
         }
     }
     auto new_storage = std::make_shared<DiskAccessStorage>(storage_name_, directory_, *changes_notifier, readonly_, allow_backup_);
-    new_storage->reload(ReloadMode::ALL);
     addStorage(new_storage);
     LOG_DEBUG(getLogger(), "Added {} access storage '{}', path: {}", String(new_storage->getStorageType()), new_storage->getStorageName(), new_storage->getPath());
 }
@@ -492,7 +491,6 @@ void AccessControl::addStoragesFromMainConfig(
     const String & config_path,
     const zkutil::GetZooKeeper & get_zookeeper_function)
 {
-    /// Add disk storage first so that entities can be referenced in other storages (e.g. to grant roles in users.xml)
     String disk_storage_dir = config.getString("access_control_path", "");
     if (!disk_storage_dir.empty())
         addDiskStorage(DiskAccessStorage::STORAGE_TYPE, disk_storage_dir, /* readonly= */ false, /* allow_backup= */ true);

--- a/src/Access/UsersConfigAccessStorage.cpp
+++ b/src/Access/UsersConfigAccessStorage.cpp
@@ -82,11 +82,11 @@ void UsersConfigAccessStorage::parseFromConfig(const Poco::Util::AbstractConfigu
     {
         UsersConfigParser parser{access_control};
         auto allowed_profile_ids = UsersConfigParser::getAllowedIDs(config, "profiles", AccessEntityType::SETTINGS_PROFILE);
-        auto allowed_role_ids = UsersConfigParser::getAllowedIDs(config, "roles", AccessEntityType::ROLE);
+        auto role_ids_from_users_config = UsersConfigParser::getAllowedIDs(config, "roles", AccessEntityType::ROLE);
 
         std::vector<std::pair<UUID, AccessEntityPtr>> all_entities;
 
-        for (const auto & entity : parser.parseUsers(config, allowed_profile_ids, allowed_role_ids))
+        for (const auto & entity : parser.parseUsers(config, allowed_profile_ids, role_ids_from_users_config))
             all_entities.emplace_back(UsersConfigParser::generateID(*entity), entity);
 
         for (const auto & entity : parser.parseQuotas(config))
@@ -98,7 +98,7 @@ void UsersConfigAccessStorage::parseFromConfig(const Poco::Util::AbstractConfigu
         for (const auto & entity : parser.parseSettingsProfiles(config, allowed_profile_ids))
             all_entities.emplace_back(UsersConfigParser::generateID(*entity), entity);
 
-        for (const auto & entity : parser.parseRoles(config, allowed_role_ids))
+        for (const auto & entity : parser.parseRoles(config, role_ids_from_users_config))
             all_entities.emplace_back(UsersConfigParser::generateID(*entity), entity);
 
         memory_storage.setAll(all_entities);

--- a/src/Access/UsersConfigAccessStorage.h
+++ b/src/Access/UsersConfigAccessStorage.h
@@ -17,6 +17,8 @@ class AccessControl;
 class ConfigReloader;
 
 /// Implementation of IAccessStorage which loads all from users.xml periodically.
+/// Should be initialized after disk storage was added to AccessControl so that roles can be
+/// referenced in users.xml grants.
 class UsersConfigAccessStorage : public IAccessStorage
 {
 public:

--- a/src/Access/UsersConfigParser.h
+++ b/src/Access/UsersConfigParser.h
@@ -25,11 +25,11 @@ public:
     std::vector<AccessEntityPtr> parseUsers(
         const Poco::Util::AbstractConfiguration & config,
         const std::unordered_set<UUID> & allowed_profile_ids,
-        const std::unordered_set<UUID> & allowed_role_ids) const;
+        const std::unordered_set<UUID> & role_ids_from_users_config) const;
 
     std::vector<AccessEntityPtr> parseRoles(
         const Poco::Util::AbstractConfiguration & config,
-        const std::unordered_set<UUID> & allowed_role_ids) const;
+        const std::unordered_set<UUID> & role_ids_from_users_config) const;
 
     std::vector<AccessEntityPtr> parseQuotas(const Poco::Util::AbstractConfiguration & config) const;
     std::vector<AccessEntityPtr> parseRowPolicies(const Poco::Util::AbstractConfiguration & config) const;
@@ -48,6 +48,7 @@ public:
 
 private:
     AccessControl & access_control;
+    LoggerPtr log;
 };
 
 }

--- a/tests/integration/test_sql_roles_for_xml_users/configs/access_control_path.xml
+++ b/tests/integration/test_sql_roles_for_xml_users/configs/access_control_path.xml
@@ -1,0 +1,3 @@
+<clickhouse>
+    <access_control_path>/var/lib/clickhouse/access/</access_control_path>
+</clickhouse>

--- a/tests/integration/test_sql_roles_for_xml_users/configs/users.xml
+++ b/tests/integration/test_sql_roles_for_xml_users/configs/users.xml
@@ -1,0 +1,8 @@
+<clickhouse>
+    <users>
+        <user1>
+            <password></password>
+            <grants></grants>
+        </user1>
+    </users>
+</clickhouse>

--- a/tests/integration/test_sql_roles_for_xml_users/test.py
+++ b/tests/integration/test_sql_roles_for_xml_users/test.py
@@ -31,11 +31,20 @@ def test_user_grants():
     instance.query("system reload users")
     instance.wait_for_log_line("performing update on configuration")
     assert instance.query("show grants for user1") == ""
+    
     instance.query("create role if not exists role1")
     instance.replace_in_config("/etc/clickhouse-server/users.d/users.xml", "<grants></grants>", "<grants><query>GRANT role1</query></grants>")
     instance.query("system reload users")
     instance.wait_for_log_line("performing update on configuration")
     assert instance.query("show grants for user1") == "GRANT role1 TO user1\n"
+
     # Make sure that assigning roles created in SQL to XML users works after restart
     instance.restart_clickhouse()
     assert instance.query("show grants for user1") == "GRANT role1 TO user1\n"
+
+    # Removing the role via SQL should be handled gracefully with a warning in the log
+    instance.query("drop role role1")
+    instance.query("system reload users")
+    instance.wait_for_log_line("performing update on configuration")
+    instance.wait_for_log_line("Role role1 is not defined and will be ignored for grant query 'GRANT role1'.")
+    assert instance.query("show grants for user1") == "GRANT NONE TO user1\n"

--- a/tests/integration/test_sql_roles_for_xml_users/test.py
+++ b/tests/integration/test_sql_roles_for_xml_users/test.py
@@ -1,0 +1,25 @@
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+instance = cluster.add_instance("instance", user_configs=["configs/users.xml"])
+
+
+@pytest.fixture(scope="module", autouse=True)
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+
+def test_user_grants():
+    assert instance.query("show grants for user1") == ""
+    instance.query("create role role1")
+    instance.replace_in_config("/etc/clickhouse-server/users.d/users.xml", "<grants></grants>", "<grants><query>GRANT role1</query></grants>")
+    instance.query("system reload users")
+    instance.wait_for_log_line("performing update on configuration")
+    assert instance.query("show grants for user1") == "GRANT role1 TO user1\n"

--- a/tests/integration/test_sql_roles_for_xml_users/test.py
+++ b/tests/integration/test_sql_roles_for_xml_users/test.py
@@ -31,7 +31,7 @@ def test_user_grants():
     instance.query("system reload users")
     instance.wait_for_log_line("performing update on configuration")
     assert instance.query("show grants for user1") == ""
-    instance.query("create role role1")
+    instance.query("create role if not exists role1")
     instance.replace_in_config("/etc/clickhouse-server/users.d/users.xml", "<grants></grants>", "<grants><query>GRANT role1</query></grants>")
     instance.query("system reload users")
     instance.wait_for_log_line("performing update on configuration")

--- a/tests/integration/test_user_directories/test.py
+++ b/tests/integration/test_user_directories/test.py
@@ -39,15 +39,15 @@ def test_old_style():
     assert node.query("SELECT * FROM system.user_directories") == TSV(
         [
             [
-                "users_xml",
-                "users_xml",
-                '{"path":"\\\\/etc\\\\/clickhouse-server\\\\/users2.xml"}',
-                1,
-            ],
-            [
                 "local_directory",
                 "local_directory",
                 '{"path":"\\\\/var\\\\/lib\\\\/clickhouse\\\\/access2\\\\/"}',
+                1,
+            ],
+            [
+                "users_xml",
+                "users_xml",
+                '{"path":"\\\\/etc\\\\/clickhouse-server\\\\/users2.xml"}',
                 2,
             ],
         ]
@@ -130,15 +130,15 @@ def test_mixed_style():
     assert node.query("SELECT * FROM system.user_directories") == TSV(
         [
             [
-                "users_xml",
-                "users_xml",
-                '{"path":"\\\\/etc\\\\/clickhouse-server\\\\/users6.xml"}',
-                1,
-            ],
-            [
                 "local_directory",
                 "local_directory",
                 '{"path":"\\\\/var\\\\/lib\\\\/clickhouse\\\\/access6\\\\/"}',
+                1,
+            ],
+            [
+                "users_xml",
+                "users_xml",
+                '{"path":"\\\\/etc\\\\/clickhouse-server\\\\/users6.xml"}',
                 2,
             ],
             [
@@ -161,15 +161,15 @@ def test_duplicates():
     assert node.query("SELECT * FROM system.user_directories") == TSV(
         [
             [
-                "users_xml",
-                "users_xml",
-                '{"path":"\\\\/etc\\\\/clickhouse-server\\\\/users7.xml"}',
-                1,
-            ],
-            [
                 "local_directory",
                 "local_directory",
                 '{"path":"\\\\/var\\\\/lib\\\\/clickhouse\\\\/access7\\\\/"}',
+                1,
+            ],
+            [
+                "users_xml",
+                "users_xml",
+                '{"path":"\\\\/etc\\\\/clickhouse-server\\\\/users7.xml"}',
                 2,
             ],
         ]


### PR DESCRIPTION
Fixes https://github.com/ClickHouse/ClickHouse/issues/73244

### Changelog category (leave one):

- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Roles defined in SQL can now be granted to users defined in `users.xml`.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
