### PR TITLE
Fix redundant host resolution in DDL Worker

### DIFF
--- a/src/Interpreters/DDLWorker.cpp
+++ b/src/Interpreters/DDLWorker.cpp
@@ -1140,6 +1140,7 @@ bool DDLWorker::initializeMainThread()
             auto zookeeper = getAndSetZooKeeper();
             zookeeper->createAncestors(fs::path(queue_dir) / "");
             initializeReplication();
+            markReplicasActive(true);
             initialized = true;
             return true;
         }
@@ -1212,14 +1213,6 @@ void DDLWorker::runMainThread()
             }
 
             cleanup_event->set();
-            try
-            {
-                markReplicasActive(reinitialized);
-            }
-            catch (...)
-            {
-                tryLogCurrentException(log, "An error occurred when markReplicasActive: ");
-            }
             scheduleTasks(reinitialized);
             subsequent_errors_count = 0;
 
@@ -1298,23 +1291,20 @@ void DDLWorker::createReplicaDirs(const ZooKeeperPtr & zookeeper, const NameSet 
         zookeeper->createAncestors(fs::path(replicas_dir) / host_id / "");
 }
 
-void DDLWorker::markReplicasActive(bool reinitialized)
+void DDLWorker::markReplicasActive(bool /*reinitialized*/)
 {
     auto zookeeper = getZooKeeper();
 
-    if (reinitialized)
+    // Reset all active_node_holders
+    for (auto & it : active_node_holders)
     {
-        // Reset all active_node_holders
-        for (auto & it : active_node_holders)
-        {
-            auto & active_node_holder = it.second.second;
-            if (active_node_holder)
-                active_node_holder->setAlreadyRemoved();
-            active_node_holder.reset();
-        }
-
-        active_node_holders.clear();
+        auto & active_node_holder = it.second.second;
+        if (active_node_holder)
+            active_node_holder->setAlreadyRemoved();
+        active_node_holder.reset();
     }
+
+    active_node_holders.clear();
 
     for (auto it = active_node_holders.begin(); it != active_node_holders.end();)
     {
@@ -1395,7 +1385,12 @@ void DDLWorker::markReplicasActive(bool reinitialized)
         {
             zookeeper->deleteEphemeralNodeIfContentMatches(active_path, active_id);
         }
-        zookeeper->create(active_path, active_id, zkutil::CreateMode::Ephemeral);
+        Coordination::Requests ops;
+        ops.emplace_back(zkutil::makeCreateRequest(active_path, active_id, zkutil::CreateMode::Ephemeral));
+        /// To bump node mtime
+        ops.emplace_back(zkutil::makeSetRequest(fs::path(replicas_dir) / host_id, "", -1));
+        zookeeper->multi(ops);
+
         auto active_node_holder_zookeeper = zookeeper;
         auto active_node_holder = zkutil::EphemeralNodeHolder::existing(active_path, *active_node_holder_zookeeper);
         active_node_holders[host_id] = {active_node_holder_zookeeper, active_node_holder};


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Now `ON CLUSTER` queries will take less time in case of inactive replicas in cluster.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
