### PR TITLE
Docs: remove markdown for time window functions in favour of autogenerated docs

### DIFF
--- a/docs/en/sql-reference/functions/time-window-functions.md
+++ b/docs/en/sql-reference/functions/time-window-functions.md
@@ -1,9 +1,10 @@
 ---
-description: 'Documentation for Time Window Functions'
-sidebar_label: 'Time-window'
+description: 'Documentation for time window functions'
+sidebar_label: 'Time window'
 slug: /sql-reference/functions/time-window-functions
-title: 'Time Window Functions'
+title: 'Time window functions'
 doc_type: 'reference'
+keywords: ['time window']
 ---
 
 import ExperimentalBadge from '@theme/badges/ExperimentalBadge';
@@ -14,238 +15,8 @@ import CloudNotSupportedBadge from '@theme/badges/CloudNotSupportedBadge';
 <ExperimentalBadge/>
 <CloudNotSupportedBadge/>
 
-Time window functions return the inclusive lower and exclusive upper bound of the corresponding window. The functions for working with [WindowView](/sql-reference/statements/create/view#window-view) are listed below:
-
-## tumble {#tumble}
-
-A tumbling time window assigns records to non-overlapping, continuous windows with a fixed duration (`interval`).
-
-**Syntax**
-
-```sql
-tumble(time_attr, interval [, timezone])
-```
-
-**Arguments**
-- `time_attr` — Date and time. [DateTime](../data-types/datetime.md).
-- `interval` — Window interval in [Interval](../data-types/special-data-types/interval.md).
-- `timezone` — [Timezone name](../../operations/server-configuration-parameters/settings.md#timezone) (optional).
-
-**Returned values**
-
-- The inclusive lower and exclusive upper bound of the corresponding tumbling window. [Tuple](../data-types/tuple.md)([DateTime](../data-types/datetime.md), [DateTime](../data-types/datetime.md)).
-
-**Example**
-
-Query:
-
-```sql
-SELECT tumble(now(), toIntervalDay('1'));
-```
-
-Result:
-
-```text
-┌─tumble(now(), toIntervalDay('1'))─────────────┐
-│ ('2024-07-04 00:00:00','2024-07-05 00:00:00') │
-└───────────────────────────────────────────────┘
-```
-
-## tumbleStart {#tumblestart}
-
-Returns the inclusive lower bound of the corresponding [tumbling window](#tumble).
-
-**Syntax**
-
-```sql
-tumbleStart(time_attr, interval [, timezone]);
-```
-
-**Arguments**
-
-- `time_attr` — Date and time. [DateTime](../data-types/datetime.md).
-- `interval` — Window interval in [Interval](../data-types/special-data-types/interval.md).
-- `timezone` — [Timezone name](../../operations/server-configuration-parameters/settings.md#timezone) (optional).
-
-**Returned values**
-
-- The inclusive lower bound of the corresponding tumbling window. [DateTime](../data-types/datetime.md), [Tuple](../data-types/tuple.md) or [UInt32](../data-types/int-uint.md).
-
-**Example**
-
-Query:
-
-```sql
-SELECT tumbleStart(now(), toIntervalDay('1'));
-```
-
-Result:
-
-```response
-┌─tumbleStart(now(), toIntervalDay('1'))─┐
-│                    2024-07-04 00:00:00 │
-└────────────────────────────────────────┘
-```
-
-## tumbleEnd {#tumbleend}
-
-Returns the exclusive upper bound of the corresponding [tumbling window](#tumble).
-
-**Syntax**
-
-```sql
-tumbleEnd(time_attr, interval [, timezone]);
-```
-
-**Arguments**
-
-- `time_attr` — Date and time. [DateTime](../data-types/datetime.md).
-- `interval` — Window interval in [Interval](../data-types/special-data-types/interval.md).
-- `timezone` — [Timezone name](../../operations/server-configuration-parameters/settings.md#timezone) (optional).
-
-**Returned values**
-
-- The inclusive lower bound of the corresponding tumbling window. [DateTime](../data-types/datetime.md), [Tuple](../data-types/tuple.md) or [UInt32](../data-types/int-uint.md).
-
-**Example**
-
-Query:
-
-```sql
-SELECT tumbleEnd(now(), toIntervalDay('1'));
-```
-
-Result:
-
-```response
-┌─tumbleEnd(now(), toIntervalDay('1'))─┐
-│                  2024-07-05 00:00:00 │
-└──────────────────────────────────────┘
-```
-
-## hop {#hop}
-
-A hopping time window has a fixed duration (`window_interval`) and hops by a specified hop interval (`hop_interval`). If the `hop_interval` is smaller than the `window_interval`, hopping windows are overlapping. Thus, records can be assigned to multiple windows.
-
-```sql
-hop(time_attr, hop_interval, window_interval [, timezone])
-```
-
-**Arguments**
-
-- `time_attr` — Date and time. [DateTime](../data-types/datetime.md).
-- `hop_interval` — Positive Hop interval. [Interval](../data-types/special-data-types/interval.md).
-- `window_interval` — Positive Window interval. [Interval](../data-types/special-data-types/interval.md).
-- `timezone` — [Timezone name](../../operations/server-configuration-parameters/settings.md#timezone) (optional).
-
-**Returned values**
-
-- The inclusive lower and exclusive upper bound of the corresponding hopping window. [Tuple](../data-types/tuple.md)([DateTime](../data-types/datetime.md), [DateTime](../data-types/datetime.md))`.
-
-:::note
-Since one record can be assigned to multiple hop windows, the function only returns the bound of the **first** window when hop function is used **without** `WINDOW VIEW`.
-:::
-
-**Example**
-
-Query:
-
-```sql
-SELECT hop(now(), INTERVAL '1' DAY, INTERVAL '2' DAY);
-```
-
-Result:
-
-```text
-┌─hop(now(), toIntervalDay('1'), toIntervalDay('2'))─┐
-│ ('2024-07-03 00:00:00','2024-07-05 00:00:00')      │
-└────────────────────────────────────────────────────┘
-```
-
-## hopStart {#hopstart}
-
-Returns the inclusive lower bound of the corresponding [hopping window](#hop).
-
-**Syntax**
-
-```sql
-hopStart(time_attr, hop_interval, window_interval [, timezone]);
-```
-**Arguments**
-
-- `time_attr` — Date and time. [DateTime](../data-types/datetime.md).
-- `hop_interval` — Positive Hop interval. [Interval](../data-types/special-data-types/interval.md).
-- `window_interval` — Positive Window interval. [Interval](../data-types/special-data-types/interval.md).
-- `timezone` — [Timezone name](../../operations/server-configuration-parameters/settings.md#timezone) (optional).
-
-**Returned values**
-
-- The inclusive lower bound of the corresponding hopping window. [DateTime](../data-types/datetime.md), [Tuple](../data-types/tuple.md) or [UInt32](../data-types/int-uint.md).
-
-:::note
-Since one record can be assigned to multiple hop windows, the function only returns the bound of the **first** window when hop function is used **without** `WINDOW VIEW`.
-:::
-
-**Example**
-
-Query:
-
-```sql
-SELECT hopStart(now(), INTERVAL '1' DAY, INTERVAL '2' DAY);
-```
-
-Result:
-
-```text
-┌─hopStart(now(), toIntervalDay('1'), toIntervalDay('2'))─┐
-│                                     2024-07-03 00:00:00 │
-└─────────────────────────────────────────────────────────┘
-```
-
-## hopEnd {#hopend}
-
-Returns the exclusive upper bound of the corresponding [hopping window](#hop).
-
-**Syntax**
-
-```sql
-hopEnd(time_attr, hop_interval, window_interval [, timezone]);
-```
-**Arguments**
-
-- `time_attr` — Date and time. [DateTime](../data-types/datetime.md).
-- `hop_interval` — Positive Hop interval. [Interval](../data-types/special-data-types/interval.md).
-- `window_interval` — Positive Window interval. [Interval](../data-types/special-data-types/interval.md).
-- `timezone` — [Timezone name](../../operations/server-configuration-parameters/settings.md#timezone) (optional).
-
-**Returned values**
-
-- The exclusive upper bound of the corresponding hopping window. [DateTime](../data-types/datetime.md), [Tuple](../data-types/tuple.md) or [UInt32](../data-types/int-uint.md).
-
-:::note
-Since one record can be assigned to multiple hop windows, the function only returns the bound of the **first** window when hop function is used **without** `WINDOW VIEW`.
-:::
-
-**Example**
-
-Query:
-
-```sql
-SELECT hopEnd(now(), INTERVAL '1' DAY, INTERVAL '2' DAY);
-```
-
-Result:
-
-```text
-┌─hopEnd(now(), toIntervalDay('1'), toIntervalDay('2'))─┐
-│                                   2024-07-05 00:00:00 │
-└───────────────────────────────────────────────────────┘
-
-```
-
-## Related content {#related-content}
-
-- Blog: [Working with time series data in ClickHouse](https://clickhouse.com/blog/working-with-time-series-data-and-functions-ClickHouse)
+Time window functions return the inclusive lower and exclusive upper bound of the corresponding window.
+The functions for working with [WindowView](/sql-reference/statements/create/view#window-view) are listed below:
 
 <!-- 
 The inner content of the tags below are replaced at doc framework build time with 
@@ -255,3 +26,8 @@ See: https://github.com/ClickHouse/clickhouse-docs/blob/main/contribute/autogene
 
 <!--AUTOGENERATED_START-->
 <!--AUTOGENERATED_END-->
+
+
+## Related content {#related-content}
+
+- [Time-series use-case guides](/use-cases/time-series)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
Removes markdown docs for the time window category, in favour of autogenerated docs following https://github.com/ClickHouse/clickhouse-docs/pull/4530
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
