### PR TITLE
Fix running ClickHouse w/o cgroups

### DIFF
--- a/src/Common/AsynchronousMetrics.cpp
+++ b/src/Common/AsynchronousMetrics.cpp
@@ -154,6 +154,7 @@ AsynchronousMetrics::AsynchronousMetrics(
     if (!cgroupcpu_stat)
         openFileIfExists("/sys/fs/cgroup/cpuacct/cpuacct.stat", cgroupcpuacct_stat);
 
+    try
     {
         const auto [cgroup_path, version] = ICgroupsReader::getCgroupsPath();
         LOG_INFO(getLogger("AsynchronousMetrics"),
@@ -161,6 +162,10 @@ AsynchronousMetrics::AsynchronousMetrics(
             cgroup_path,
             (version == ICgroupsReader::CgroupsVersion::V1) ? "v1" : "v2");
         cgroupmem_reader = ICgroupsReader::createCgroupsReader(version, cgroup_path);
+    }
+    catch (...)
+    {
+        tryLogCurrentException(getLogger("AsynchronousMetrics"), "cgroups are not available");
     }
 
 


### PR DESCRIPTION
Follow-up for: #88092

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix running ClickHouse w/o cgroups (accidentally cgroups became a requirement for asynchronous metrics)