### PR TITLE
Save system database and table metadata files from remote database disk and restore them to scrape system table logs with clickhouse local

### DIFF
--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -668,6 +668,36 @@ clickhouse-client --query "SELECT count() FROM test.visits"
             )
 
         self._flush_system_logs()
+
+        if os.path.exists("/etc/clickhouse-server/config.d/remote_database_disk.xml"):
+            # Store system database and table metadata files
+            self.system_db_uuid = Shell.get_output(
+                "clickhouse disks -C /etc/clickhouse-server/config.xml --disk disk_db_remote -q 'read metadata/system.sql' | grep -F UUID | awk -F\"'\" '{print $2}'",
+                verbose=True,
+            )
+            self.system_db_sql = Shell.get_output(
+                "clickhouse disks -C /etc/clickhouse-server/config.xml --disk disk_db_remote -q 'read metadata/system.sql'",
+                verbose=True,
+            )
+            print(f"system_db_uuid = {self.system_db_uuid}")
+            print(f"system_db_sql = {self.system_db_sql}")
+
+            system_table_sql_files = (
+                Shell.get_output(
+                    f"clickhouse disks -C /etc/clickhouse-server/config.xml --disk disk_db_remote -q 'ls store/{self.system_db_uuid[:3]}/{self.system_db_uuid}/'",
+                    verbose=True,
+                )
+                .strip()
+                .split("\n")
+            )
+            self.system_table_sql_map = {}
+            for system_table_sql_file in system_table_sql_files:
+                sql_content = Shell.get_output(
+                    f"clickhouse disks -C /etc/clickhouse-server/config.xml --disk disk_db_remote -q 'read store/{self.system_db_uuid[:3]}/{self.system_db_uuid}/{system_table_sql_file}'",
+                    verbose=True,
+                )
+                self.system_table_sql_map[system_table_sql_file] = sql_content
+
         print("Terminate ClickHouse processes")
 
         Shell.check(f"ps -ef | grep  clickhouse")
@@ -1004,6 +1034,25 @@ quit
             f"rm -rf {temp_dir}/system_tables && mkdir -p {temp_dir}/system_tables"
         )
         res = True
+
+        if self.system_db_uuid is not None:
+            # Ensure no remote database disk config
+            if os.path.exists("/etc/clickhouse-server/config.d/remote_database_disk.xml"):
+                os.remove("/etc/clickhouse-server/config.d/remote_database_disk.xml")
+            
+            # Restore system database and table metadata files for `clickhouse local`
+            with open(f"{self.run_path0}/metadata/system.sql", "w") as file:
+                file.write(self.system_db_sql)
+            res = Shell.check(
+                f"mkdir -p {self.run_path0}/store/{self.system_db_uuid[:3]}/{self.system_db_uuid}",
+                verbose=True,
+            )
+            for system_table_sql_file, content in self.system_table_sql_map.items():
+                with open(
+                    f"{self.run_path0}/store/{self.system_db_uuid[:3]}/{self.system_db_uuid}/{system_table_sql_file}",
+                    "w",
+                ) as file:
+                    file.write(content)
 
         for table in TABLES:
             path_arg = f" --path {self.run_path0}"


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Save system database and table metadata files from the remote database disk and restore them to scrape system table logs with clickhouse local.

Closes https://github.com/ClickHouse/clickhouse-private/issues/39340

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
