### PR TITLE
Fix reading Sparse String.size subcolumn from compact parts

### DIFF
--- a/src/DataTypes/IDataType.cpp
+++ b/src/DataTypes/IDataType.cpp
@@ -195,9 +195,9 @@ std::unique_ptr<IDataType::SubstreamData> IDataType::getSubcolumnData(
     return res;
 }
 
-bool IDataType::hasSubcolumn(std::string_view subcolumn_name) const
+bool IDataType::hasSubcolumn(std::string_view subcolumn_name, SerializationPtr override_default) const
 {
-    return tryGetSubcolumnType(subcolumn_name) != nullptr;
+    return tryGetSubcolumnType(subcolumn_name, override_default) != nullptr;
 }
 
 bool IDataType::hasDynamicSubcolumns() const
@@ -215,29 +215,29 @@ bool IDataType::hasDynamicSubcolumns() const
     return has_dynamic_subcolumns;
 }
 
-DataTypePtr IDataType::tryGetSubcolumnType(std::string_view subcolumn_name) const
+DataTypePtr IDataType::tryGetSubcolumnType(std::string_view subcolumn_name, SerializationPtr override_default) const
 {
-    auto data = SubstreamData(getDefaultSerialization()).withType(getPtr());
+    auto data = SubstreamData(getDefaultSerialization(override_default)).withType(getPtr());
     auto subcolumn_data = getSubcolumnData(subcolumn_name, data, false);
     return subcolumn_data ? subcolumn_data->type : nullptr;
 }
 
-DataTypePtr IDataType::getSubcolumnType(std::string_view subcolumn_name) const
+DataTypePtr IDataType::getSubcolumnType(std::string_view subcolumn_name, SerializationPtr override_default) const
 {
-    auto data = SubstreamData(getDefaultSerialization()).withType(getPtr());
+    auto data = SubstreamData(getDefaultSerialization(override_default)).withType(getPtr());
     return getSubcolumnData(subcolumn_name, data, true)->type;
 }
 
-ColumnPtr IDataType::tryGetSubcolumn(std::string_view subcolumn_name, const ColumnPtr & column) const
+ColumnPtr IDataType::tryGetSubcolumn(std::string_view subcolumn_name, const ColumnPtr & column, SerializationPtr override_default) const
 {
-    auto data = SubstreamData(getDefaultSerialization()).withType(getPtr()).withColumn(column);
+    auto data = SubstreamData(getDefaultSerialization(override_default)).withType(getPtr()).withColumn(column);
     auto subcolumn_data = getSubcolumnData(subcolumn_name, data, false);
     return subcolumn_data ? subcolumn_data->column : nullptr;
 }
 
-ColumnPtr IDataType::getSubcolumn(std::string_view subcolumn_name, const ColumnPtr & column) const
+ColumnPtr IDataType::getSubcolumn(std::string_view subcolumn_name, const ColumnPtr & column, SerializationPtr override_default) const
 {
-    auto data = SubstreamData(getDefaultSerialization()).withType(getPtr()).withColumn(column);
+    auto data = SubstreamData(getDefaultSerialization(override_default)).withType(getPtr()).withColumn(column);
     return getSubcolumnData(subcolumn_name, data, true)->column;
 }
 

--- a/src/DataTypes/IDataType.h
+++ b/src/DataTypes/IDataType.h
@@ -106,13 +106,13 @@ public:
     void updateHash(SipHash & hash) const;
     virtual void updateHashImpl(SipHash & hash) const = 0;
 
-    bool hasSubcolumn(std::string_view subcolumn_name) const;
+    bool hasSubcolumn(std::string_view subcolumn_name, SerializationPtr override_default = nullptr) const;
 
-    DataTypePtr tryGetSubcolumnType(std::string_view subcolumn_name) const;
-    DataTypePtr getSubcolumnType(std::string_view subcolumn_name) const;
+    DataTypePtr tryGetSubcolumnType(std::string_view subcolumn_name, SerializationPtr override_default = nullptr) const;
+    DataTypePtr getSubcolumnType(std::string_view subcolumn_name, SerializationPtr override_default = nullptr) const;
 
-    ColumnPtr tryGetSubcolumn(std::string_view subcolumn_name, const ColumnPtr & column) const;
-    ColumnPtr getSubcolumn(std::string_view subcolumn_name, const ColumnPtr & column) const;
+    ColumnPtr tryGetSubcolumn(std::string_view subcolumn_name, const ColumnPtr & column, SerializationPtr override_default = nullptr) const;
+    ColumnPtr getSubcolumn(std::string_view subcolumn_name, const ColumnPtr & column, SerializationPtr override_default = nullptr) const;
 
     SerializationPtr getSubcolumnSerialization(std::string_view subcolumn_name, const SerializationPtr & serialization) const;
 

--- a/src/Storages/MergeTree/MergeTreeReaderCompact.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderCompact.cpp
@@ -272,7 +272,7 @@ void MergeTreeReaderCompact::readData(
                         columns_cache_for_subcolumns->emplace(name_in_storage, temp_full_column);
                 }
 
-                auto subcolumn = type_in_storage->getSubcolumn(name_and_type.getSubcolumnName(), temp_full_column);
+                auto subcolumn = type_in_storage->getSubcolumn(name_and_type.getSubcolumnName(), temp_full_column, serialization);
 
                 /// TODO: Avoid extra copying.
                 if (column->empty())

--- a/tests/queries/0_stateless/03651_merge_tree_compact_read_string_size_subcolumn.reference
+++ b/tests/queries/0_stateless/03651_merge_tree_compact_read_string_size_subcolumn.reference
@@ -1,0 +1,8 @@
+-- { echo ON }
+
+DROP TABLE IF EXISTS t0;
+CREATE TABLE t0 (c0 String) ENGINE = MergeTree() ORDER BY (c0) SETTINGS write_marks_for_substreams_in_compact_parts = 0;
+INSERT INTO TABLE t0 (c0) VALUES('');
+SELECT c0.size FROM t0;
+0
+DROP TABLE t0;

--- a/tests/queries/0_stateless/03651_merge_tree_compact_read_string_size_subcolumn.sql
+++ b/tests/queries/0_stateless/03651_merge_tree_compact_read_string_size_subcolumn.sql
@@ -1,0 +1,11 @@
+-- { echo ON }
+
+DROP TABLE IF EXISTS t0;
+
+CREATE TABLE t0 (c0 String) ENGINE = MergeTree() ORDER BY (c0) SETTINGS write_marks_for_substreams_in_compact_parts = 0;
+
+INSERT INTO TABLE t0 (c0) VALUES('');
+
+SELECT c0.size FROM t0;
+
+DROP TABLE t0;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a bug that caused incorrect behavior when reading Sparse `.size` subcolumn of `String` columns from compact parts.  The issue was due to missing `serialization` context in `IDataType::getSubcolumn()` and related functions. Fixes #88167. Introduced in #82850 which is not released yet.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
