### PR TITLE
Using shared_ptr for QueryState in TCPHandler to detect if the state is invalid in setProgressCallback, setFileProgressCallback and setBlockMarshallingCallback

### DIFF
--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -524,7 +524,7 @@ void TCPHandler::runImpl()
         /// the MemoryTracker will be wrong for possible deallocations.
         /// (i.e. deallocations from the Aggregator with two-level aggregation)
         /// Also it resets socket's timeouts.
-        std::optional<QueryState> query_state;
+        std::shared_ptr<QueryState> query_state;
 
         try
         {
@@ -540,7 +540,7 @@ void TCPHandler::runImpl()
             if (part_uuids_to_ignore.has_value() && !receivePacketsExpectQuery(query_state))
                 continue;
 
-            chassert(query_state.has_value());
+            chassert(query_state);
 
             if (connectionLimitReached())
             {
@@ -558,7 +558,7 @@ void TCPHandler::runImpl()
             query_scope.emplace(query_state->query_context, /* fatal_error_callback */ [this, &query_state]
             {
                 std::lock_guard lock(callback_mutex);
-                sendLogs(query_state.value());
+                sendLogs(*query_state);
             });
 
             /// If query received, then settings in query_context has been updated.
@@ -569,7 +569,7 @@ void TCPHandler::runImpl()
             /// It should be reset at the end of query.
             query_state->timeout_setter = std::make_unique<TimeoutSetter>(socket(), send_timeout, receive_timeout);
 
-            SCOPE_EXIT(logQueryDuration(query_state.value()));
+            SCOPE_EXIT(logQueryDuration(*query_state));
 
             /// Should we send internal logs to client?
             const auto client_logs_level = query_state->query_context->getSettingsRef()[Setting::send_logs_level];
@@ -614,10 +614,10 @@ void TCPHandler::runImpl()
 
                 std::lock_guard lock(callback_mutex);
 
-                checkIfQueryCanceled(query_state.value());
+                checkIfQueryCanceled(*query_state);
 
                 /// Get blocks of temporary tables
-                readTemporaryTables(query_state.value());
+                readTemporaryTables(*query_state);
 
                 /// Reset the input stream, as we received an empty block while receiving external table data.
                 /// So, the stream has been marked as cancelled and we can't read from it anymore.
@@ -636,7 +636,7 @@ void TCPHandler::runImpl()
 
                 std::lock_guard lock(callback_mutex);
 
-                checkIfQueryCanceled(query_state.value());
+                checkIfQueryCanceled(*query_state);
 
                 query_state->need_receive_data_for_input = true;
 
@@ -644,13 +644,13 @@ void TCPHandler::runImpl()
                 if (client_tcp_protocol_version >= DBMS_MIN_REVISION_WITH_COLUMN_DEFAULTS_METADATA
                     && query_state->query_context->getSettingsRef()[Setting::input_format_defaults_for_omitted_fields])
                 {
-                    sendTableColumns(query_state.value(), metadata_snapshot->getColumns());
+                    sendTableColumns(*query_state, metadata_snapshot->getColumns());
                 }
 
                 /// Send block to the client - input storage structure.
                 query_state->input_header = metadata_snapshot->getSampleBlock();
-                sendData(query_state.value(), query_state->input_header);
-                sendTimezone(query_state.value());
+                sendData(*query_state, query_state->input_header);
+                sendTimezone(*query_state);
 
                 /// Update flag after reading external tables
                 query_state->read_all_data = false;
@@ -663,9 +663,9 @@ void TCPHandler::runImpl()
 
                 std::lock_guard lock(callback_mutex);
 
-                checkIfQueryCanceled(query_state.value());
+                checkIfQueryCanceled(*query_state);
 
-                if (receivePacketsExpectData(query_state.value()))
+                if (receivePacketsExpectData(*query_state))
                     return query_state->block_for_input;
 
                 query_state->block_in.reset();
@@ -683,13 +683,13 @@ void TCPHandler::runImpl()
 
                 std::lock_guard lock(callback_mutex);
 
-                checkIfQueryCanceled(query_state.value());
+                checkIfQueryCanceled(*query_state);
 
                 sendReadTaskRequest();
 
                 ProfileEvents::increment(ProfileEvents::ReadTaskRequestsSent);
 
-                auto res = receiveClusterFunctionReadTaskResponse(query_state.value());
+                auto res = receiveClusterFunctionReadTaskResponse(*query_state);
 
                 ProfileEvents::increment(ProfileEvents::ReadTaskRequestsSentElapsedMicroseconds, watch.elapsedMicroseconds());
 
@@ -703,9 +703,9 @@ void TCPHandler::runImpl()
 
                 std::lock_guard lock(callback_mutex);
 
-                checkIfQueryCanceled(query_state.value());
+                checkIfQueryCanceled(*query_state);
 
-                sendMergeTreeAllRangesAnnouncement(query_state.value(), announcement);
+                sendMergeTreeAllRangesAnnouncement(*query_state, announcement);
                 ProfileEvents::increment(ProfileEvents::MergeTreeAllRangesAnnouncementsSent);
                 ProfileEvents::increment(ProfileEvents::MergeTreeAllRangesAnnouncementsSentElapsedMicroseconds, watch.elapsedMicroseconds());
             });
@@ -722,7 +722,7 @@ void TCPHandler::runImpl()
                 sendMergeTreeReadTaskRequest(std::move(request));
 
                 ProfileEvents::increment(ProfileEvents::MergeTreeReadTaskRequestsSent);
-                auto res = receivePartitionMergeTreeReadTaskResponse(query_state.value());
+                auto res = receivePartitionMergeTreeReadTaskResponse(*query_state);
                 ProfileEvents::increment(ProfileEvents::MergeTreeReadTaskRequestsSentElapsedMicroseconds, watch.elapsedMicroseconds());
                 return res;
             });
@@ -750,12 +750,12 @@ void TCPHandler::runImpl()
             {
                 /// FIXME: check explicitly that insert query suggests to receive data via native protocol,
                 query_state->need_receive_data_for_insert = true;
-                processInsertQuery(query_state.value());
+                processInsertQuery(*query_state);
                 query_state->io.onFinish();
             }
             else if (query_state->io.pipeline.pulling())
             {
-                processOrdinaryQuery(query_state.value());
+                processOrdinaryQuery(*query_state);
                 query_state->io.onFinish();
             }
             else if (query_state->io.pipeline.completed())
@@ -770,14 +770,14 @@ void TCPHandler::runImpl()
                         {
                             std::lock_guard lock(callback_mutex);
 
-                            receivePacketsExpectCancel(query_state.value());
+                            receivePacketsExpectCancel(*query_state);
 
                             if (query_state->stop_read_return_partial_result)
                                 return true;
 
-                            sendProgress(query_state.value());
-                            sendSelectProfileEvents(query_state.value());
-                            sendLogs(query_state.value());
+                            sendProgress(*query_state);
+                            sendSelectProfileEvents(*query_state);
+                            sendLogs(*query_state);
                             return false;
                         };
 
@@ -794,8 +794,8 @@ void TCPHandler::runImpl()
                 /// NOTE: we cannot send Progress for regular INSERT (with VALUES)
                 /// without breaking protocol compatibility, but it can be done
                 /// by increasing revision.
-                sendProgress(query_state.value());
-                sendSelectProfileEvents(query_state.value());
+                sendProgress(*query_state);
+                sendSelectProfileEvents(*query_state);
             }
             else
             {
@@ -805,8 +805,8 @@ void TCPHandler::runImpl()
             /// Do it before sending end of stream, to have a chance to show log message in client.
             query_scope->logPeakMemoryUsage();
 
-            sendLogs(query_state.value());
-            sendEndOfStream(query_state.value());
+            sendLogs(*query_state);
+            sendEndOfStream(*query_state);
 
             query_state->finalizeOut(out);
         }
@@ -823,7 +823,7 @@ void TCPHandler::runImpl()
 #ifdef DEBUG_OR_SANITIZER_BUILD
         catch (const std::logic_error & e)
         {
-            if (query_state.has_value())
+            if (query_state)
                 query_state->io.onException();
             exception = std::make_unique<DB::Exception>(Exception::CreateFromSTDTag{}, e);
             sendException(*exception, send_exception_with_stack_trace);
@@ -843,7 +843,7 @@ void TCPHandler::runImpl()
         {
             auto exception_code = exception->code();
 
-            if (!query_state.has_value())
+            if (!query_state)
                 return;
 
             try
@@ -898,7 +898,7 @@ void TCPHandler::runImpl()
 
                 /// Try to send logs to client, but it could be risky too
                 /// Assume that we can't break output here
-                sendLogs(query_state.value());
+                sendLogs(*query_state);
             }
             catch (const Exception & e)
             {
@@ -924,7 +924,7 @@ void TCPHandler::runImpl()
                 std::lock_guard lock(callback_mutex);
 
                 if (exception_code == ErrorCodes::QUERY_WAS_CANCELLED_BY_CLIENT)
-                    sendEndOfStream(query_state.value());
+                    sendEndOfStream(*query_state);
                 else
                     sendException(*exception, send_exception_with_stack_trace);
             }
@@ -942,7 +942,7 @@ void TCPHandler::runImpl()
                 /// A query packet is always followed by one or more data packets.
                 /// If some of those data packets are left, try to skip them.
                 if (!query_state->read_all_data)
-                    skipData(query_state.value());
+                    skipData(*query_state);
             }
             catch (...)
             {
@@ -997,7 +997,7 @@ void TCPHandler::extractConnectionSettingsFromContext(const ContextPtr & context
 }
 
 
-bool TCPHandler::receivePacketsExpectQuery(std::optional<QueryState> & state)
+bool TCPHandler::receivePacketsExpectQuery(std::shared_ptr<QueryState> & state)
 {
     UInt64 packet_type = 0;
     readVarUInt(packet_type, *in);
@@ -2082,12 +2082,13 @@ void TCPHandler::processClusterNameAndSalt()
 }
 
 
-void TCPHandler::processQuery(std::optional<QueryState> & state)
+void TCPHandler::processQuery(std::shared_ptr<QueryState> & state)
 {
     UInt64 stage = 0;
     UInt64 compression = 0;
 
-    state.emplace();
+    chassert(!state);
+    state = std::make_shared<QueryState>();
 
     if (part_uuids_to_ignore.has_value())
         state->part_uuids_to_ignore = std::move(part_uuids_to_ignore);
@@ -2250,19 +2251,36 @@ void TCPHandler::processQuery(std::optional<QueryState> & state)
     if (state->part_uuids_to_ignore)
         state->query_context->getIgnoredPartUUIDs()->add(*state->part_uuids_to_ignore);
 
+    std::weak_ptr<QueryState> state_wptr = state;
+
     state->query_context->setProgressCallback(
-        [this, &state] (const Progress & value) { this->updateProgress(state.value(), value); });
+        [this, state_wptr](const Progress & value)
+        {
+            auto current_state = state_wptr.lock();
+            if (!current_state)
+                return;
+            this->updateProgress(*current_state, value);
+        });
     state->query_context->setFileProgressCallback(
-        [this, &state](const FileProgress & value) { this->updateProgress(state.value(), Progress(value)); });
+        [this, state_wptr](const FileProgress & value)
+        {
+            auto current_state = state_wptr.lock();
+            if (!current_state)
+                return;
+            this->updateProgress(*current_state, Progress(value));
+        });
 
     state->query_context->setBlockMarshallingCallback(
-        [this, &state](const Block & block)
+        [this, &state_wptr](const Block & block)
         {
+            auto current_state = state_wptr.lock();
+            if (!current_state)
+                return block;
             return convertColumnsToBLOBs(
                 block,
-                getCompressionCodec(state->query_context->getSettingsRef(), state->compression),
+                getCompressionCodec(current_state->query_context->getSettingsRef(), current_state->compression),
                 client_tcp_protocol_version,
-                getFormatSettings(state->query_context));
+                getFormatSettings(current_state->query_context));
         });
 
     ///

--- a/src/Server/TCPHandler.h
+++ b/src/Server/TCPHandler.h
@@ -275,7 +275,7 @@ private:
     void receiveHello();
     bool receiveQueryPlan(QueryState & state);
     void receiveAddendum();
-    bool receivePacketsExpectQuery(std::optional<QueryState> & state);
+    bool receivePacketsExpectQuery(std::shared_ptr<QueryState> & state);
     bool receivePacketsExpectData(QueryState & state) TSA_REQUIRES(callback_mutex);
     bool receivePacketsExpectDataConcurrentWithExecutor(QueryState & state);
     void receivePacketsExpectCancel(QueryState & state) TSA_REQUIRES(callback_mutex);
@@ -285,7 +285,7 @@ private:
     std::optional<ParallelReadResponse> receivePartitionMergeTreeReadTaskResponse(QueryState & state) TSA_REQUIRES(callback_mutex);
 
     void processCancel(QueryState & state) TSA_REQUIRES(callback_mutex);
-    void processQuery(std::optional<QueryState> & state);
+    void processQuery(std::shared_ptr<QueryState> & state);
     void processIgnoredPartUUIDs();
     bool processData(QueryState & state, bool scalar) TSA_REQUIRES(callback_mutex);
     void processClusterNameAndSalt();


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Using shared_ptr for QueryState in TCPHandler to detect if the state is invalid in setProgressCallback, setFileProgressCallback and setBlockMarshallingCallback.

### Details
The progress callback handler is reused in the background restoring job. But the state might be invalid as the initial query is already handled.

Closes https://github.com/ClickHouse/clickhouse-private/issues/37134
