### PR TITLE
Tests: Add coverage for hasAnyTokens/hasAllTokens on non-indexed FixedString

### DIFF
--- a/tests/queries/0_stateless/02346_text_index_function_hasAnyAllTokens.reference
+++ b/tests/queries/0_stateless/02346_text_index_function_hasAnyAllTokens.reference
@@ -31,8 +31,12 @@ SELECT hasAllToken('a b', ['c']);
 0
 1
 2
+3
 1
 2
+Testing edge cases on non-indexed column
+3
+3
 FixedString input columns
 [1]
 [1]
@@ -234,3 +238,12 @@ Text index should choose 25% of granules
 Description: text GRANULARITY 1
 Parts: 1/1
 Granules: 256/1024
+Test hasAnyTokens and hasAllTokens on a non-indexed FixedString column
+1
+3
+2
+3
+2
+1
+2
+3


### PR DESCRIPTION
This PR improves the test coverage for the brute-force fallback mechanism in `hasAnyTokens` and `hasAllTokens` when they are used on columns without a text index.

Specifically, this change adds:

1. A test case for non-indexed FixedString columns to ensure all supported string types are validated.
2. Edge case validation for empty needle arrays ([]).

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
