### PR TITLE
ci: fix restoring metadata files for clickhouse-local in case of remote database disk

### DIFF
--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -99,6 +99,7 @@ class ClickHouseProc:
         self.extra_tests_results = []
         self.logs = []
         self.log_export_host, self.log_export_password = None, None
+        self.system_db_uuid = None
 
         Utils.set_env("CLICKHOUSE_CONFIG_DIR", self.ch_config_dir)
         Utils.set_env("CLICKHOUSE_CONFIG", self.config_file)


### PR DESCRIPTION
CI: https://s3.amazonaws.com/clickhouse-test-reports/PRs/88182/a48222c8e47affea01676433c19667fa370af084//stateless_tests_arm_binary_parallel/job.log

Trace:

      File "/home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/ci/jobs/scripts/clickhouse_proc.py", line 1089, in restore_system_metadata_files_from_remote_database_disk
        if self.system_db_uuid is None:
    AttributeError: 'ClickHouseProc' object has no attribute 'system_db_uuid'

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)