### PR TITLE
Support EXCHANGE in Alias

### DIFF
--- a/src/Storages/StorageAlias.h
+++ b/src/Storages/StorageAlias.h
@@ -13,15 +13,15 @@ public:
     StorageAlias(
         const StorageID & table_id_,
         ContextPtr context_,
-        const StorageID & target_table_id_,
+        const String & target_database_,
+        const String & target_table_,
         const ColumnsDescription & columns_,
         const String & comment);
 
     std::string getName() const override { return "Alias"; }
 
     /// Get the target storage this alias points to
-    StoragePtr getTargetTable() const { return DatabaseCatalog::instance().getTable(target_table_id, getContext()); }
-    StorageID getTargetTableId() const { return target_table_id; }
+    StoragePtr getTargetTable() const { return DatabaseCatalog::instance().getTable(StorageID(target_database, target_table), getContext()); }
 
     /// Read from target table
     void read(
@@ -124,9 +124,9 @@ public:
     /// Rename alias, not the target table
     void rename(const String & new_path_to_table_data, const StorageID & new_table_id) override;
 
-
 protected:
-    StorageID target_table_id = StorageID::createEmpty();
+    String target_database;
+    String target_table;
 };
 
 }

--- a/tests/queries/0_stateless/03636_storage_alias_access_rights.sh
+++ b/tests/queries/0_stateless/03636_storage_alias_access_rights.sh
@@ -25,8 +25,8 @@ echo "Test INSERT without permission"
 ${CLICKHOUSE_CLIENT} --user="${username}" --query "INSERT INTO test_alias VALUES (4, 'four');" 2>&1 | grep -o "ACCESS_DENIED" | uniq
 
 ${CLICKHOUSE_CLIENT} --query "
-    GRANT SELECT ON ${CLICKHOUSE_DATABASE}.test_alias TO ${username};
-    GRANT SELECT ON ${CLICKHOUSE_DATABASE}.test_table TO ${username};
+    GRANT SELECT ON test_alias TO ${username};
+    GRANT SELECT ON test_table TO ${username};
 "
 echo "Test SELECT with permission"
 ${CLICKHOUSE_CLIENT} --user="${username}" --query "SELECT count() FROM test_alias;"
@@ -36,8 +36,8 @@ echo "Test INSERT still fails"
 ${CLICKHOUSE_CLIENT} --user="${username}" --query "INSERT INTO test_alias VALUES (4, 'four');" 2>&1 | grep -o "ACCESS_DENIED" | uniq
 
 ${CLICKHOUSE_CLIENT} --query "
-    GRANT INSERT ON ${CLICKHOUSE_DATABASE}.test_alias TO ${username};
-    GRANT INSERT ON ${CLICKHOUSE_DATABASE}.test_table TO ${username};
+    GRANT INSERT ON test_alias TO ${username};
+    GRANT INSERT ON test_table TO ${username};
 "
 echo "Test INSERT with permission"
 ${CLICKHOUSE_CLIENT} --user="${username}" --query "INSERT INTO test_alias VALUES (4, 'four');"
@@ -48,8 +48,8 @@ echo "Test TRUNCATE without permission"
 ${CLICKHOUSE_CLIENT} --user="${username}" --query "TRUNCATE TABLE test_alias;" 2>&1 | grep -o "ACCESS_DENIED" | uniq
 
 ${CLICKHOUSE_CLIENT} --query "
-    GRANT TRUNCATE ON ${CLICKHOUSE_DATABASE}.test_alias TO ${username};
-    GRANT TRUNCATE ON ${CLICKHOUSE_DATABASE}.test_table TO ${username};
+    GRANT TRUNCATE ON test_alias TO ${username};
+    GRANT TRUNCATE ON test_table TO ${username};
 "
 echo "Test TRUNCATE with permission"
 ${CLICKHOUSE_CLIENT} --user="${username}" --query "TRUNCATE TABLE test_alias;"
@@ -58,15 +58,13 @@ ${CLICKHOUSE_CLIENT} --query "SELECT count() FROM test_table;"
 # Test: OPTIMIZE
 ${CLICKHOUSE_CLIENT} --query "
     INSERT INTO test_table VALUES (5, 'five');
-    REVOKE ALL ON ${CLICKHOUSE_DATABASE}.test_alias FROM ${username};
-    REVOKE ALL ON ${CLICKHOUSE_DATABASE}.test_table FROM ${username};
 "
 echo "Test OPTIMIZE without permission"
 ${CLICKHOUSE_CLIENT} --user="${username}" --query "OPTIMIZE TABLE test_alias;" 2>&1 | grep -o "ACCESS_DENIED" | uniq
 
 ${CLICKHOUSE_CLIENT} --query "
-    GRANT OPTIMIZE ON ${CLICKHOUSE_DATABASE}.test_alias TO ${username};
-    GRANT OPTIMIZE ON ${CLICKHOUSE_DATABASE}.test_table TO ${username};
+    GRANT OPTIMIZE ON test_alias TO ${username};
+    GRANT OPTIMIZE ON test_table TO ${username};
 "
 echo "Test OPTIMIZE with permission"
 ${CLICKHOUSE_CLIENT} --user="${username}" --query "OPTIMIZE TABLE test_alias FINAL;"
@@ -76,19 +74,20 @@ echo "Test ALTER without permission"
 ${CLICKHOUSE_CLIENT} --user="${username}" --query "ALTER TABLE test_alias ADD COLUMN status String DEFAULT 'active';" 2>&1 | grep -o "ACCESS_DENIED" | uniq
 
 ${CLICKHOUSE_CLIENT} --query "
-    GRANT ALL ON *.* TO ${username};
+    GRANT CURRENT GRANTS ON *.* TO ${username};
 "
+
 echo "Test ALTER with permission"
 ${CLICKHOUSE_CLIENT} --user="${username}" --query "ALTER TABLE test_alias ADD COLUMN status String DEFAULT 'active';"
 ${CLICKHOUSE_CLIENT} --query "SELECT count() FROM system.columns WHERE database = currentDatabase() AND table = 'test_table' AND name = 'status';"
 
-${CLICKHOUSE_CLIENT} --query " REVOKE DROP ON *.* FROM ${username};"
+${CLICKHOUSE_CLIENT} --query "REVOKE DROP ON *.* FROM ${username};"
 
 # Test: DROP alias
 echo "Test DROP alias without permission"
 ${CLICKHOUSE_CLIENT} --user="${username}" --query "DROP TABLE test_alias;" 2>&1 | grep -o "ACCESS_DENIED" | uniq
 
-${CLICKHOUSE_CLIENT} --query "GRANT DROP ON ${CLICKHOUSE_DATABASE}.test_alias TO ${username};"
+${CLICKHOUSE_CLIENT} --query "GRANT DROP ON test_alias TO ${username};"
 echo "Test DROP alias with permission"
 ${CLICKHOUSE_CLIENT} --user="${username}" --query "DROP TABLE test_alias;"
 

--- a/tests/queries/0_stateless/03636_storage_alias_basic.reference
+++ b/tests/queries/0_stateless/03636_storage_alias_basic.reference
@@ -67,3 +67,12 @@ Test DROP PARTITION
 2
 Test INSERT SELECT
 2
+Before EXCHANGE:
+from_a
+from_b
+After EXCHANGE alias tables:
+from_b
+from_a
+After EXCHANGE source tables:
+from_a
+from_b


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
* Fixed support for `EXCHANGE TABLES` operations on tables with the `Alias` engine. The engine now stores the target table as database and table names instead of a constant storage id, allowing it to correctly resolve the target after table exchanges. 

Related to #87965 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
