### PR TITLE
fix `02434_cancel_insert_when_client_dies`

### DIFF
--- a/tests/queries/0_stateless/02434_cancel_insert_when_client_dies.sh
+++ b/tests/queries/0_stateless/02434_cancel_insert_when_client_dies.sh
@@ -95,6 +95,7 @@ wait
 
 $CLICKHOUSE_CLIENT -q 'select count() from dedup_test'
 
+$CLICKHOUSE_CLIENT -q "system flush distributed dedup_dist"
 $CLICKHOUSE_CLIENT -q 'system flush logs text_log'
 
 # Ensure that thread_cancel actually did something


### PR DESCRIPTION
Add a flush command for distributed deduplication logs.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Flush distributed table in the end of the test, so DROP DATABSE will not wait for it and will not block other tests:
https://pastila.nl/?0027b4c3/2513d4d65a7f7b1366d30b214fb290fa#uUO2ufEAbOKfy5aFAqRPLA==

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=88204&sha=f85d4c0d0273f25e7d83271c4b5654c7695e916d&name_0=PR&name_1=Stateless+tests+%28amd_binary%2C+old+analyzer%2C+s3+storage%2C+DatabaseReplicated%2C+parallel%29

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
