### PR TITLE
Add cancellation point to isStorageTouchedByMutations

### DIFF
--- a/src/Interpreters/MutationsInterpreter.h
+++ b/src/Interpreters/MutationsInterpreter.h
@@ -29,7 +29,8 @@ IsStorageTouched isStorageTouchedByMutations(
     MergeTreeData::MutationsSnapshotPtr mutations_snapshot,
     const StorageMetadataPtr & metadata_snapshot,
     const std::vector<MutationCommand> & commands,
-    ContextPtr context
+    ContextPtr context,
+    std::function<void(const Progress & value)> check_operation_is_not_cancelled
 );
 
 ASTPtr getPartitionAndPredicateExpressionForMutationCommand(

--- a/src/Storages/MergeTree/MutateTask.cpp
+++ b/src/Storages/MergeTree/MutateTask.cpp
@@ -2361,7 +2361,14 @@ bool MutateTask::prepare()
         });
     }
 
-    auto is_storage_touched = isStorageTouchedByMutations(ctx->source_part, mutations_snapshot, ctx->metadata_snapshot, ctx->commands_for_part, context_for_reading);
+    auto is_storage_touched = isStorageTouchedByMutations(
+        ctx->source_part,
+        mutations_snapshot,
+        ctx->metadata_snapshot,
+        ctx->commands_for_part,
+        context_for_reading,
+        [&my_ctx = *ctx](const Progress &) { my_ctx.checkOperationIsNotCanceled(); }
+    );
 
     if (!is_storage_touched.any_rows_affected)
     {

--- a/tests/queries/0_stateless/03644_cancel_huge_mutation_subquery.sh
+++ b/tests/queries/0_stateless/03644_cancel_huge_mutation_subquery.sh
@@ -1,8 +1,8 @@
-#!/usr/bin/env sh
-#
-CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
-. "$CURDIR"/../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
 
 $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS cancel_huge_mutation_subquery"
 $CLICKHOUSE_CLIENT -n -q "

--- a/tests/queries/0_stateless/03644_cancel_huge_mutation_subquery.sh
+++ b/tests/queries/0_stateless/03644_cancel_huge_mutation_subquery.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env sh
+#
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS cancel_huge_mutation_subquery"
+$CLICKHOUSE_CLIENT -n -q "
+    CREATE TABLE cancel_huge_mutation_subquery (key Int, value String) Engine=MergeTree ORDER BY tuple();
+    INSERT INTO cancel_huge_mutation_subquery SELECT number, toString(number) FROM numbers(10000);"
+
+
+$CLICKHOUSE_CLIENT --enable_sharing_sets_for_mutations=0 --mutations_sync=2 -n -q "ALTER TABLE cancel_huge_mutation_subquery DELETE WHERE key IN (select number % 2 from numbers(10000000) where sleep(1) == 0)"   2>/dev/null &
+
+# wait until mutation started
+i=0
+while [ "$($CLICKHOUSE_CLIENT -q "SELECT count() FROM system.mutations WHERE table = 'cancel_huge_mutation_subquery' AND is_done = 0")" -ne 1 ]; do
+    sleep 0.5
+    i=$((i + 1))
+    if [ $i -gt 100 ]; then
+        echo "Mutation was not started in 5 seconds"
+        exit 1
+    fi
+done
+
+$CLICKHOUSE_CLIENT  --query "SYSTEM STOP MERGES cancel_huge_mutation_subquery"
+
+wait
+
+$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS cancel_huge_mutation_subquery"

--- a/tests/queries/0_stateless/03644_cancel_huge_mutation_subquery.sh
+++ b/tests/queries/0_stateless/03644_cancel_huge_mutation_subquery.sh
@@ -10,7 +10,7 @@ $CLICKHOUSE_CLIENT -n -q "
     INSERT INTO cancel_huge_mutation_subquery SELECT number, toString(number) FROM numbers(10000);"
 
 
-$CLICKHOUSE_CLIENT --enable_sharing_sets_for_mutations=0 --mutations_sync=2 -n -q "ALTER TABLE cancel_huge_mutation_subquery DELETE WHERE key IN (select number % 2 from numbers(10000000) where sleep(1) == 0)"   2>/dev/null &
+$CLICKHOUSE_CLIENT --mutations_sync=2 -n -q "ALTER TABLE cancel_huge_mutation_subquery DELETE WHERE key IN (select number % 2 from numbers(10000000) where sleep(1) == 0)"   2>/dev/null &
 
 # wait until mutation started
 i=0

--- a/tests/queries/0_stateless/03644_cancel_huge_mutation_subquery.sh
+++ b/tests/queries/0_stateless/03644_cancel_huge_mutation_subquery.sh
@@ -14,7 +14,7 @@ $CLICKHOUSE_CLIENT --enable_sharing_sets_for_mutations=0 --mutations_sync=2 -n -
 
 # wait until mutation started
 i=0
-while [ "$($CLICKHOUSE_CLIENT -q "SELECT count() FROM system.mutations WHERE table = 'cancel_huge_mutation_subquery' AND is_done = 0")" -ne 1 ]; do
+while [ "$($CLICKHOUSE_CLIENT -q "SELECT count() FROM system.mutations WHERE table = 'cancel_huge_mutation_subquery' and database='${CLICKHOUSE_DATABASE}' AND is_done = 0")" -ne 1 ]; do
     sleep 0.5
     i=$((i + 1))
     if [ $i -gt 100 ]; then

--- a/tests/queries/0_stateless/03644_cancel_huge_mutation_subquery.sh
+++ b/tests/queries/0_stateless/03644_cancel_huge_mutation_subquery.sh
@@ -10,7 +10,7 @@ $CLICKHOUSE_CLIENT -n -q "
     INSERT INTO cancel_huge_mutation_subquery SELECT number, toString(number) FROM numbers(10000);"
 
 
-$CLICKHOUSE_CLIENT --mutations_sync=2 -n -q "ALTER TABLE cancel_huge_mutation_subquery DELETE WHERE key IN (select number % 2 from numbers(10000000) where sleep(1) == 0)"   2>/dev/null &
+$CLICKHOUSE_CLIENT --mutations_sync=2 -n -q "ALTER TABLE cancel_huge_mutation_subquery DELETE WHERE key IN (select number % 2 from numbers(100000000) where sleep(1) == 0)"   2>/dev/null &
 
 # wait until mutation started
 i=0


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)



### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix bug that very heavy mutations with subqueries could stuck in prepare stage. Now it's possible to stop these mutations with `SYSTEM STOP MERGES`.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
