### PR TITLE
force log `CORRUPTED_DATA` exceptions

### DIFF
--- a/src/Common/Exception.cpp
+++ b/src/Common/Exception.cpp
@@ -40,6 +40,7 @@ namespace ErrorCodes
     extern const int CANNOT_ALLOCATE_MEMORY;
     extern const int CANNOT_MREMAP;
     extern const int POTENTIALLY_BROKEN_DATA_PART;
+    extern const int CORRUPTED_DATA;
 }
 
 void abortOnFailedAssertion(const String & description, void * const * trace, size_t trace_offset, size_t trace_size)
@@ -297,7 +298,8 @@ bool Exception::isErrorCodeImportant() const
 {
     const int error_code = code();
     return error_code == ErrorCodes::LOGICAL_ERROR
-        || error_code == ErrorCodes::POTENTIALLY_BROKEN_DATA_PART;
+        || error_code == ErrorCodes::POTENTIALLY_BROKEN_DATA_PART
+        || error_code == ErrorCodes::CORRUPTED_DATA;
 }
 
 Exception::~Exception()


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
