### PR TITLE
CI: Support custom option for Integration Tests job

### DIFF
--- a/ci/praktika/__main__.py
+++ b/ci/praktika/__main__.py
@@ -45,6 +45,18 @@ def create_parser():
         default=[],
     )
     run_parser.add_argument(
+        "--count",
+        help="Custom INT parameter to pass into a job script, it's up to job script how to use it (default: number of test reruns), for local test",
+        type=int,
+        default=None,
+    )
+    run_parser.add_argument(
+        "--debug",
+        help="Custom parameter to pass into a job script, it's up to job script how to use it, for local test",
+        action="store_true",
+        default="",
+    )
+    run_parser.add_argument(
         "--pr",
         help="PR number. Optional parameter for local run. Set if you want an required artifact to be uploaded from CI run in that PR",
         type=int,
@@ -128,6 +140,8 @@ def main():
                 pr=args.pr,
                 branch=args.branch,
                 sha=args.sha,
+                count=args.count,
+                debug=args.debug,
             )
     else:
         parser.print_help()

--- a/ci/praktika/cidb.py
+++ b/ci/praktika/cidb.py
@@ -4,10 +4,19 @@ import json
 import urllib
 from typing import Optional
 
-import requests
-
 from ._environment import _Environment
 from .info import Info
+
+try:
+    import requests
+except ImportError as ex:
+    if not Info().is_local_run:
+        raise ex
+    else:
+        print(
+            f"WARNING: 'requests' module is not installed: {ex}. CIDB will not work - ok for local runs only."
+        )
+
 from .result import Result
 from .settings import Settings
 from .usage import ComputeUsage, StorageUsage

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -227,7 +227,17 @@ class Runner:
 
         return 0
 
-    def _run(self, workflow, job, docker="", no_docker=False, param=None, test=""):
+    def _run(
+        self,
+        workflow,
+        job,
+        docker="",
+        no_docker=False,
+        param=None,
+        test="",
+        count=None,
+        debug=False,
+    ):
         # re-set envs for local run
         env = _Environment.get()
         env.JOB_NAME = job.name
@@ -307,6 +317,12 @@ class Runner:
         if test:
             print(f"Custom --test [{test}] will be passed to job's script")
             cmd += f" --test {test}"
+        if count is not None:
+            print(f"Custom --count [{count}] will be passed to job's script")
+            cmd += f" --count {count}"
+        if debug:
+            print(f"Custom --debug will be passed to job's script")
+            cmd += f" --debug"
         print(f"--- Run command [{cmd}]")
 
         with TeePopen(
@@ -644,6 +660,8 @@ class Runner:
         pr=None,
         sha=None,
         branch=None,
+        count=None,
+        debug=False,
     ):
         res = True
         setup_env_code = -10
@@ -697,6 +715,8 @@ class Runner:
                     no_docker=no_docker,
                     param=param,
                     test=test,
+                    count=count,
+                    debug=debug,
                 )
                 res = run_code == 0
                 if not res:

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -24,6 +24,11 @@ You can reproduce CI integration test jobs locally using the same orchestration 
     ```bash
     python -m ci.praktika run "Integration tests (amd_binary, 1/5)"
     ```
+  - If searching for the exact job name in the CI report is inconvenient, you can use a keyword or substring of the job name. For example:
+    ```bash
+    python -m ci.praktika run "integration"
+    ```
+    If the job cannot be determined unambiguously, the tool will print a list of matching jobs.
 
 - **Run a specific test within a CI job**
   ```bash
@@ -36,6 +41,10 @@ You can reproduce CI integration test jobs locally using the same orchestration 
     python -m ci.praktika run "Integration tests (amd_binary, 4/5)" \
       --test "test_named_collections/test.py::test_default_access" "test_multiple_disks/"
     ```
+
+- **Additional customization options for local run:**
+  - `--count N` to repeat each test N times (`--count` will be passed to pytest with `--repeat-scope=function`).
+  - `--debug` to open the Python debug console on exception (`--pdb` will be passed to pytest).
 
 No other dependencies are required beyond Python 3 and Docker.
 


### PR DESCRIPTION
Adds support for passing --count to integration tests in local run
Adds support for passing --debug to integration tests in local run to debug pytest with PDB
Removes praktika's requests dependency for local run
Fixes integration tests docs

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
