### PR TITLE
Fix `CurrentMetrics::ConcurrentQueryAcquired`

### DIFF
--- a/src/Interpreters/QuerySlot.cpp
+++ b/src/Interpreters/QuerySlot.cpp
@@ -42,6 +42,7 @@ QuerySlot::QuerySlot(ResourceLink link_)
 
 QuerySlot::~QuerySlot()
 {
+    acquired_slot_increment.reset();
     if (granted)
         finish();
 }


### PR DESCRIPTION
There was a race between the release of the slot and the actual update of the metric. The slot was released before the metric decrement, and in case it was reacquired quickly, the metric would have exceeded the limit. This led to test failures sometimes.

Fixes https://github.com/ClickHouse/ClickHouse/issues/88232

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
