### PR TITLE
Flaky test fix: Retry ZooKeeper znode creation and metric collection in test_keeper_memory_soft_limit

### DIFF
--- a/tests/integration/test_keeper_memory_soft_limit/test.py
+++ b/tests/integration/test_keeper_memory_soft_limit/test.py
@@ -92,12 +92,12 @@ def test_soft_limit_create(started_cluster):
 
         txn.create(f"{test_path}/node_1000001_{i}", b"abcde")
         txn.commit()
-        node.query("SYSTEM FLUSH LOGS metric_log")
 
         # Retry fetching metric to make it stable
         retries = 5
         wait_seconds = 1
         for _ in range(5):
+            node.query("SYSTEM FLUSH LOGS metric_log")
             result = int(
                 node.query(
                     "SELECT sum(ProfileEvent_ZooKeeperHardwareExceptions) FROM system.metric_log"


### PR DESCRIPTION
This PR addresses intermittent CI failures in test_keeper_memory_soft_limit/test.py::test_soft_limit_create by introducing retries for operations that occasionally hang due to Keeper startup delays or slow metric registration.

**Changes:**
1. Retry initial znode creation
- Sometimes the Keeper instance is not fully ready when the test starts, causing kazoo_client.create() to hang or timeout (~900s).
- We now forcefully timeout the create operation after 30 s and retry the /test_soft_limit znode creation up to 5 times.
- Note: This is a theoretical fix, as test failure could not be reproduced on local machines.

2. Retry metric collection after OOM
- Previously, CI could fail intermittently if the ProfileEvent_ZooKeeperHardwareExceptions metric was not registered immediately after an OOM.
- Metric fetching is now retried up to 5 times (with a small delay of 1s) to improve stability.

**Impact:**
These changes reduce CI flakiness caused by ZooKeeper hang issues and slow metric propagation and should potentially fix the observed instability.

Closes https://github.com/ClickHouse/ClickHouse/issues/87877

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
