### PR TITLE
Fix skipping system metadata files restoration

### DIFF
--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -1087,7 +1087,7 @@ quit
             self.system_table_sql_map[system_table_sql_file] = sql_content
 
     def restore_system_metadata_files_from_remote_database_disk(self):
-        if self.system_db_uuid is None:
+        if not hasattr(self, "system_db_uuid") or self.system_db_uuid is None:
             return
 
         # Ensure no remote database disk config


### PR DESCRIPTION
If `system_db_uuid` is not assigned at all, even `self.system_db_uuid is None` will raise an error. Here is the example to play with:
```
class A:
  def __init__(self, set_value):
    if set_value:
      self.value = 'asd'

  def trial_bad(self):
    if self.value is None:
      print("None")
    print("not None")

  def trial_good(self):
    if (not hasattr(self,"value")) or self.value is None:
      print("None")
    print("not None")

a = A(True)
a.trial_good()
a.trial_bad()
a = A(False)
a.trial_good()
a.trial_bad()
```

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
