### PR TITLE
Add setting allow_reorder_row_policy_and_prewhere

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -7168,7 +7168,9 @@ Number of hash functions in a bloom filter used as JOIN runtime filter (see enab
     DECLARE(Bool, rewrite_in_to_join, false, R"(
 Rewrite expressions like 'x IN subquery' to JOIN. This might be useful for optimizing the whole query with join reordering.
 )", EXPERIMENTAL) \
-    \
+    DECLARE(Bool, allow_reorder_row_policy_and_prewhere, false, R"(
+        Allow reorder ROW POLICY and PREWHERE conditions if PREWHERE expressin cannot throw an exception
+)", EXPERIMENTAL) \
     /** Experimental timeSeries* aggregate functions. */ \
     DECLARE_WITH_ALIAS(Bool, allow_experimental_time_series_aggregate_functions, false, R"(
 Experimental timeSeries* aggregate functions for Prometheus-like timeseries resampling, rate, delta calculation.

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -48,6 +48,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"use_join_disjunctions_push_down", false, false, "New setting."},
             {"join_runtime_bloom_filter_hash_functions", 3, 3, "New setting"},
             {"rewrite_in_to_join", false, false, "New experimental setting"},
+            {"allow_reorder_row_policy_and_prewhere", false, false, "New experimental setting"},
             {"iceberg_insert_max_rows_in_data_file", 100000, 1000000, "New setting."},
             {"iceberg_insert_max_bytes_in_data_file", 100000000, 100000000, "New setting."},
             {"delta_lake_insert_max_rows_in_data_file", 100000, 1000000, "New setting."},

--- a/src/Databases/enableAllExperimentalSettings.cpp
+++ b/src/Databases/enableAllExperimentalSettings.cpp
@@ -66,6 +66,7 @@ void enableAllExperimentalSettings(ContextMutablePtr context)
     context->setSetting("allow_experimental_iceberg_compaction", 1);
     context->setSetting("allow_experimental_delta_lake_writes", 1);
     context->setSetting("allow_dynamic_type_in_join_keys", 1);
+    context->setSetting("allow_reorder_row_policy_and_prewhere", 1);
 
     /// clickhouse-private settings
     context->setSetting("allow_experimental_shared_set_join", 1);

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -2202,14 +2202,15 @@ bool ReadFromMergeTree::readsInOrder() const
     return reader_settings.read_in_order;
 }
 
-void ReadFromMergeTree::updatePrewhereInfo(const PrewhereInfoPtr & prewhere_info_value)
+void ReadFromMergeTree::updatePrewhereInfo(const PrewhereInfoPtr & prewhere_info_value, const FilterDAGInfoPtr & row_level_filter_value)
 {
+    query_info.row_level_filter = row_level_filter_value;
     query_info.prewhere_info = prewhere_info_value;
 
     output_header = std::make_shared<const Block>(MergeTreeSelectProcessor::transformHeader(
         storage_snapshot->getSampleBlockForColumns(all_column_names),
         lazily_read_info,
-        query_info.row_level_filter,
+        row_level_filter_value,
         prewhere_info_value));
 
     updateSortDescription();

--- a/src/Processors/QueryPlan/ReadFromMergeTree.h
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.h
@@ -226,7 +226,7 @@ public:
     const InputOrderInfoPtr & getInputOrder() const { return query_info.input_order_info; }
     const SortDescription & getSortDescription() const override { return result_sort_description; }
 
-    void updatePrewhereInfo(const PrewhereInfoPtr & prewhere_info_value) override;
+    void updatePrewhereInfo(const PrewhereInfoPtr & prewhere_info_value, const FilterDAGInfoPtr & row_level_filter_value) override;
     void updateLazilyReadInfo(const LazilyReadInfoPtr & lazily_read_info_value);
     bool isQueryWithSampling() const;
 

--- a/src/Processors/QueryPlan/ReadFromObjectStorageStep.cpp
+++ b/src/Processors/QueryPlan/ReadFromObjectStorageStep.cpp
@@ -58,9 +58,10 @@ void ReadFromObjectStorageStep::applyFilters(ActionDAGNodes added_filter_nodes)
     SourceStepWithFilter::applyFilters(std::move(added_filter_nodes));
 }
 
-void ReadFromObjectStorageStep::updatePrewhereInfo(const PrewhereInfoPtr & prewhere_info_value)
+void ReadFromObjectStorageStep::updatePrewhereInfo(const PrewhereInfoPtr & prewhere_info_value, const FilterDAGInfoPtr & row_level_filter_value)
 {
-    info = updateFormatPrewhereInfo(info, query_info.row_level_filter, prewhere_info_value);
+    info = updateFormatPrewhereInfo(info, row_level_filter_value, prewhere_info_value);
+    query_info.row_level_filter = row_level_filter_value;
     query_info.prewhere_info = prewhere_info_value;
     output_header = std::make_shared<const Block>(info.source_header);
 }

--- a/src/Processors/QueryPlan/ReadFromObjectStorageStep.h
+++ b/src/Processors/QueryPlan/ReadFromObjectStorageStep.h
@@ -30,7 +30,7 @@ public:
     std::string getName() const override { return STEP_NAME; }
 
     void applyFilters(ActionDAGNodes added_filter_nodes) override;
-    void updatePrewhereInfo(const PrewhereInfoPtr & prewhere_info_value) override;
+    void updatePrewhereInfo(const PrewhereInfoPtr & prewhere_info_value, const FilterDAGInfoPtr & row_level_filter_value) override;
 
     void initializePipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings &) override;
 

--- a/src/Processors/QueryPlan/SourceStepWithFilter.cpp
+++ b/src/Processors/QueryPlan/SourceStepWithFilter.cpp
@@ -91,9 +91,10 @@ void SourceStepWithFilter::applyFilters(ActionDAGNodes added_filter_nodes)
     filter_actions_dag = dag ? std::make_shared<const ActionsDAG>(std::move(*dag)) : nullptr;
 }
 
-void SourceStepWithFilter::updatePrewhereInfo(const PrewhereInfoPtr & prewhere_info_value)
+void SourceStepWithFilter::updatePrewhereInfo(const PrewhereInfoPtr & prewhere_info_value, const FilterDAGInfoPtr & row_level_filter_value)
 {
     query_info.prewhere_info = prewhere_info_value;
+    query_info.row_level_filter = row_level_filter_value;
     output_header = std::make_shared<const Block>(applyPrewhereActions(*output_header, query_info.row_level_filter, query_info.prewhere_info));
 }
 

--- a/src/Processors/QueryPlan/SourceStepWithFilter.h
+++ b/src/Processors/QueryPlan/SourceStepWithFilter.h
@@ -123,7 +123,7 @@ public:
 
     void applyFilters(ActionDAGNodes added_filter_nodes) override;
 
-    virtual void updatePrewhereInfo(const PrewhereInfoPtr & prewhere_info_value);
+    virtual void updatePrewhereInfo(const PrewhereInfoPtr & prewhere_info_value, const FilterDAGInfoPtr & row_level_filter_value);
 
     void describeActions(FormatSettings & format_settings) const override;
 

--- a/src/Storages/MergeTree/MergeTreeWhereOptimizer.cpp
+++ b/src/Storages/MergeTree/MergeTreeWhereOptimizer.cpp
@@ -148,8 +148,8 @@ void MergeTreeWhereOptimizer::optimize(SelectQueryInfo & select_query_info, cons
         select.prewhere()->formatForLogging(context->getSettingsRef()[Setting::log_queries_cut_to_length]));
 }
 
-MergeTreeWhereOptimizer::FilterActionsOptimizeResult MergeTreeWhereOptimizer::optimize(const ActionsDAG & filter_dag,
-    const std::string & filter_column_name,
+MergeTreeWhereOptimizer::FilterActionsOptimizeResult MergeTreeWhereOptimizer::optimize(
+    const ActionsDAG::Node * predicate,
     const ContextPtr & context,
     bool is_final)
 {
@@ -164,7 +164,7 @@ MergeTreeWhereOptimizer::FilterActionsOptimizeResult MergeTreeWhereOptimizer::op
     where_optimizer_context.use_statistics = context->getSettingsRef()[Setting::allow_statistics_optimize] && estimator != nullptr;
 
     RPNBuilderTreeContext tree_context(context);
-    RPNBuilderTreeNode node(&filter_dag.findInOutputs(filter_column_name), tree_context);
+    RPNBuilderTreeNode node(predicate, tree_context);
 
     auto optimize_result = optimizeImpl(node, where_optimizer_context);
     if (!optimize_result)

--- a/src/Storages/MergeTree/MergeTreeWhereOptimizer.h
+++ b/src/Storages/MergeTree/MergeTreeWhereOptimizer.h
@@ -51,10 +51,7 @@ public:
         bool fully_moved_to_prewhere = false;
     };
 
-    FilterActionsOptimizeResult optimize(const ActionsDAG & filter_dag,
-        const std::string & filter_column_name,
-        const ContextPtr & context,
-        bool is_final);
+    FilterActionsOptimizeResult optimize(const ActionsDAG::Node * predicate, const ContextPtr & context, bool is_final);
 
 private:
     struct Condition

--- a/src/Storages/StorageFile.cpp
+++ b/src/Storages/StorageFile.cpp
@@ -1622,7 +1622,7 @@ public:
     std::string getName() const override { return "ReadFromFile"; }
     void initializePipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings &) override;
     void applyFilters(ActionDAGNodes added_filter_nodes) override;
-    void updatePrewhereInfo(const PrewhereInfoPtr & prewhere_info_value) override;
+    void updatePrewhereInfo(const PrewhereInfoPtr & prewhere_info_value, const FilterDAGInfoPtr & row_level_filter_value) override;
 
     ReadFromFile(
         const Names & column_names_,
@@ -1667,9 +1667,10 @@ void ReadFromFile::applyFilters(ActionDAGNodes added_filter_nodes)
     createIterator(predicate);
 }
 
-void ReadFromFile::updatePrewhereInfo(const PrewhereInfoPtr & prewhere_info_value)
+void ReadFromFile::updatePrewhereInfo(const PrewhereInfoPtr & prewhere_info_value, const FilterDAGInfoPtr & row_level_filter_value)
 {
-    info = updateFormatPrewhereInfo(info, query_info.row_level_filter, prewhere_info_value);
+    info = updateFormatPrewhereInfo(info, row_level_filter_value, prewhere_info_value);
+    query_info.row_level_filter = row_level_filter_value;
     query_info.prewhere_info = prewhere_info_value;
     output_header = std::make_shared<const Block>(info.source_header);
 }

--- a/src/Storages/StorageURL.cpp
+++ b/src/Storages/StorageURL.cpp
@@ -1120,7 +1120,7 @@ public:
     std::string getName() const override { return "ReadFromURL"; }
     void initializePipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings &) override;
     void applyFilters(ActionDAGNodes added_filter_nodes) override;
-    void updatePrewhereInfo(const PrewhereInfoPtr & prewhere_info_value) override;
+    void updatePrewhereInfo(const PrewhereInfoPtr & prewhere_info_value, const FilterDAGInfoPtr & row_level_filter_value) override;
 
     ReadFromURL(
         const Names & column_names_,
@@ -1180,9 +1180,10 @@ void ReadFromURL::applyFilters(ActionDAGNodes added_filter_nodes)
     createIterator(predicate);
 }
 
-void ReadFromURL::updatePrewhereInfo(const PrewhereInfoPtr & prewhere_info_value)
+void ReadFromURL::updatePrewhereInfo(const PrewhereInfoPtr & prewhere_info_value, const FilterDAGInfoPtr & row_level_filter_value)
 {
-    info = updateFormatPrewhereInfo(info, query_info.row_level_filter, prewhere_info_value);
+    info = updateFormatPrewhereInfo(info, row_level_filter_value, prewhere_info_value);
+    query_info.row_level_filter = row_level_filter_value;
     query_info.prewhere_info = prewhere_info_value;
     output_header = std::make_shared<const Block>(info.source_header);
 }

--- a/tests/queries/0_stateless/03652_allow_reorder_row_policy_and_prewhere.reference
+++ b/tests/queries/0_stateless/03652_allow_reorder_row_policy_and_prewhere.reference
@@ -1,0 +1,106 @@
+Expression ((Project names + Projection))
+Actions: INPUT : 0 -> __table1.heavy String : 0
+         INPUT : 1 -> __table1.light Int32 : 1
+         ALIAS __table1.heavy :: 0 -> heavy String : 2
+         ALIAS __table1.light :: 1 -> light Int32 : 0
+Positions: 0 2
+  Expression ((WHERE + Change column names to column identifiers))
+  Actions: INPUT : 0 -> heavy String : 0
+           INPUT : 1 -> light Int32 : 1
+           ALIAS heavy :: 0 -> __table1.heavy String : 2
+           ALIAS light :: 1 -> __table1.light Int32 : 0
+  Positions: 2 0
+    ReadFromMergeTree (default.test_table)
+    ReadType: Default
+    Parts: 1
+    Granules: 123
+    Prewhere info
+    Need filter: 1
+      Prewhere filter
+      Prewhere filter column: and(greaterOrEquals(__table1.light, 100000_UInt32), less(__table1.light, 100500_UInt32)) (removed)
+      Actions: INPUT : 0 -> light Int32 : 0
+               COLUMN Const(UInt32) -> 100000_UInt32 UInt32 : 1
+               COLUMN Const(UInt32) -> 100500_UInt32 UInt32 : 2
+               FUNCTION greaterOrEquals(light : 0, 100000_UInt32 :: 1) -> greaterOrEquals(__table1.light, 100000_UInt32) UInt8 : 3
+               FUNCTION less(light : 0, 100500_UInt32 :: 2) -> less(__table1.light, 100500_UInt32) UInt8 : 1
+               FUNCTION and(greaterOrEquals(__table1.light, 100000_UInt32) :: 3, less(__table1.light, 100500_UInt32) :: 1) -> and(greaterOrEquals(__table1.light, 100000_UInt32), less(__table1.light, 100500_UInt32)) UInt8 : 2
+      Positions: 0 2
+      Row level filter
+      Row level filter column: like(heavy, \'%_aaa\'_String) (removed)
+      Actions: INPUT : 0 -> heavy String : 0
+               COLUMN Const(String) -> \'%_aaa\'_String String : 1
+               FUNCTION like(heavy : 0, \'%_aaa\'_String :: 1) -> like(heavy, \'%_aaa\'_String) UInt8 : 2
+      Positions: 2 0
+Expression ((Project names + Projection))
+Actions: INPUT : 0 -> __table1.heavy String : 0
+         INPUT : 1 -> __table1.light Int32 : 1
+         ALIAS __table1.heavy :: 0 -> heavy String : 2
+         ALIAS __table1.light :: 1 -> light Int32 : 0
+Positions: 0 2
+  Expression ((WHERE + Change column names to column identifiers))
+  Actions: INPUT : 0 -> heavy String : 0
+           INPUT : 1 -> light Int32 : 1
+           ALIAS heavy :: 0 -> __table1.heavy String : 2
+           ALIAS light :: 1 -> __table1.light Int32 : 0
+  Positions: 2 0
+    ReadFromMergeTree (default.test_table)
+    ReadType: Default
+    Parts: 1
+    Granules: 123
+    Prewhere info
+    Need filter: 1
+      Prewhere filter
+      Prewhere filter column: and(greaterOrEquals(__table1.light, 100000_UInt32), less(__table1.light, 100500_UInt32), like(heavy, \'%_aaa\'_String)) (removed)
+      Actions: INPUT : 0 -> heavy String : 0
+               COLUMN Const(String) -> \'%_aaa\'_String String : 1
+               INPUT : 1 -> light Int32 : 2
+               COLUMN Const(UInt32) -> 100000_UInt32 UInt32 : 3
+               COLUMN Const(UInt32) -> 100500_UInt32 UInt32 : 4
+               FUNCTION like(heavy : 0, \'%_aaa\'_String :: 1) -> like(heavy, \'%_aaa\'_String) UInt8 : 5
+               FUNCTION greaterOrEquals(light : 2, 100000_UInt32 :: 3) -> greaterOrEquals(__table1.light, 100000_UInt32) UInt8 : 1
+               FUNCTION less(light : 2, 100500_UInt32 :: 4) -> less(__table1.light, 100500_UInt32) UInt8 : 3
+               FUNCTION and(greaterOrEquals(__table1.light, 100000_UInt32) :: 1, less(__table1.light, 100500_UInt32) :: 3, like(heavy, \'%_aaa\'_String) :: 5) -> and(greaterOrEquals(__table1.light, 100000_UInt32), less(__table1.light, 100500_UInt32), like(heavy,... UInt8 : 4
+      Positions: 0 2 4
+Expression ((Project names + Projection))
+Actions: INPUT :: 0 -> count() UInt64 : 0
+Positions: 0
+  Aggregating
+  Keys:
+  Aggregates:
+      count()
+        Function: count() → UInt64
+        Arguments: none
+  Skip merging: 0
+    Expression (Before GROUP BY)
+    Positions:
+      Expression ((WHERE + Change column names to column identifiers))
+      Actions: INPUT :: 0 -> light Int32 : 0
+      Positions:
+        ReadFromMergeTree (default.test_table)
+        ReadType: Default
+        Parts: 1
+        Granules: 123
+        Prewhere info
+        Need filter: 1
+          Prewhere filter
+          Prewhere filter column: and(equals(throwIf(equals(modulo(__table1.light, 2_UInt8), 0_UInt8)), 0_UInt8), greaterOrEquals(__table1.light, 100000_UInt32), less(__table1.light, 100500_UInt32)) (removed)
+          Actions: INPUT : 0 -> light Int32 : 0
+                   COLUMN Const(UInt8) -> 2_UInt8 UInt8 : 1
+                   COLUMN Const(UInt8) -> 0_UInt8 UInt8 : 2
+                   COLUMN Const(UInt32) -> 100000_UInt32 UInt32 : 3
+                   COLUMN Const(UInt32) -> 100500_UInt32 UInt32 : 4
+                   FUNCTION modulo(light : 0, 2_UInt8 :: 1) -> modulo(__table1.light, 2_UInt8) Int16 : 5
+                   FUNCTION greaterOrEquals(light : 0, 100000_UInt32 :: 3) -> greaterOrEquals(__table1.light, 100000_UInt32) UInt8 : 1
+                   FUNCTION less(light : 0, 100500_UInt32 :: 4) -> less(__table1.light, 100500_UInt32) UInt8 : 3
+                   FUNCTION equals(modulo(__table1.light, 2_UInt8) :: 5, 0_UInt8 : 2) -> equals(modulo(__table1.light, 2_UInt8), 0_UInt8) UInt8 : 4
+                   FUNCTION throwIf(equals(modulo(__table1.light, 2_UInt8), 0_UInt8) :: 4) -> throwIf(equals(modulo(__table1.light, 2_UInt8), 0_UInt8)) UInt8 : 5
+                   FUNCTION equals(throwIf(equals(modulo(__table1.light, 2_UInt8), 0_UInt8)) :: 5, 0_UInt8 :: 2) -> equals(throwIf(equals(modulo(__table1.light, 2_UInt8), 0_UInt8)), 0_UInt8) UInt8 : 4
+                   FUNCTION and(equals(throwIf(equals(modulo(__table1.light, 2_UInt8), 0_UInt8)), 0_UInt8) :: 4, greaterOrEquals(__table1.light, 100000_UInt32) :: 1, less(__table1.light, 100500_UInt32) :: 3) -> and(equals(throwIf(equals(modulo(__table1.light, 2_UInt8), 0_UInt8)), 0_UInt8), greaterOrEquals(__ta... UInt8 : 2
+          Positions: 0 2
+          Row level filter
+          Row level filter column: like(heavy, \'%_aaa\'_String) (removed)
+          Actions: INPUT : 0 -> heavy String : 0
+                   COLUMN Const(String) -> \'%_aaa\'_String String : 1
+                   FUNCTION like(heavy :: 0, \'%_aaa\'_String :: 1) -> like(heavy, \'%_aaa\'_String) UInt8 : 2
+          Positions: 2
+250

--- a/tests/queries/0_stateless/03652_allow_reorder_row_policy_and_prewhere.sql
+++ b/tests/queries/0_stateless/03652_allow_reorder_row_policy_and_prewhere.sql
@@ -1,0 +1,22 @@
+-- Tags: no-random-merge-tree-settings
+
+DROP ROW POLICY IF EXISTS test_filter_policy ON test_table;
+DROP TABLE IF EXISTS test_table;
+
+create table test_table (light Int32, heavy String codec(NONE)) engine = MergeTree order by tuple();
+insert into test_table select number, toString(range(number % 100)) || '_' || if(number % 2, 'aaa', 'bbb') from numbers(1e6);
+
+CREATE ROW POLICY test_filter_policy ON test_table USING (heavy like '%_aaa') TO ALL;
+
+set optimize_move_to_prewhere=1, enable_multiple_prewhere_read_steps=1, allow_reorder_prewhere_conditions=1;
+
+explain actions = 1 select * from test_table where light >= 100000 and light < 100500 settings allow_reorder_row_policy_and_prewhere=0;
+
+explain actions = 1 select * from test_table where light >= 100000 and light < 100500 settings allow_reorder_row_policy_and_prewhere=1;
+
+explain actions = 1 select count() from test_table where throwIf(light % 2 = 0) = 0 and light >= 100000 and light < 100500 settings allow_reorder_row_policy_and_prewhere=1;
+
+select count() from test_table where throwIf(light % 2 = 0) = 0 and light >= 100000 and light < 100500 settings allow_reorder_row_policy_and_prewhere=1;
+
+DROP ROW POLICY IF EXISTS test_filter_policy ON test_table;
+DROP TABLE IF EXISTS test_table;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Experimental Feature


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Allow reordering ROW POLICY and PREWHERE when PREWHERE does not throw an exception.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
