### PR TITLE
fixed: apply_random_settings_limits bug

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1534,10 +1534,10 @@ class TestCase:
         for setting in random_settings:
             if setting in self.random_settings_limits:
                 min_value = self.random_settings_limits[setting][0]
-                if min_value and random_settings[setting] < min_value:
+                if min_value != None and random_settings[setting] < min_value:
                     random_settings[setting] = min_value
                 max_value = self.random_settings_limits[setting][1]
-                if max_value and random_settings[setting] > max_value:
+                if max_value != None and random_settings[setting] > max_value:
                     random_settings[setting] = max_value
 
     def __init__(self, suite: "TestSuite", case: str, args, is_concurrent: bool):

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1534,9 +1534,11 @@ class TestCase:
         for setting in random_settings:
             if setting in self.random_settings_limits:
                 min_value = self.random_settings_limits[setting][0]
+                # min_value can be 0
                 if min_value != None and random_settings[setting] < min_value:
                     random_settings[setting] = min_value
                 max_value = self.random_settings_limits[setting][1]
+                # max_value can be 0
                 if max_value != None and random_settings[setting] > max_value:
                     random_settings[setting] = max_value
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

The current version cannot make the following configuration take effect:
`# Random settings limits: use_skip_indexes_on_data_read=(0, 0)`

Because '0' will cause the update logic to be skipped.

https://github.com/ClickHouse/ClickHouse/blob/70da6bfa9f227e0525b3c53f193015a490d68e00/tests/clickhouse-test#L1444-L1452