### PR TITLE
Add --settings and --merge-tree-settings options to easily reproduce CI test settings locally

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1255,7 +1255,6 @@ def replace_in_file_re(filename, what, with_what):
 
 
 def _coerce_value(v: str):
-    # ints, floats, booleans; leave "32Mi" etc. as strings
     vl = v.lower()
     if vl in ("true", "false"):
         return vl == "true"
@@ -1460,10 +1459,10 @@ class TestCase:
     def has_show_create_table_in_test(self):
         return not subprocess.call(["grep", "-iq", "show create", self.case_file])
 
-    def add_random_settings(self, client_options):
+    def add_effective_settings(self, client_options):
         new_options = ""
-        if self.randomize_settings:
-            http_params = self.http_format_settings(self.random_settings)
+        if self.effective_settings:
+            http_params = self.http_format_settings(self.effective_settings)
             if len(self.base_url_params) == 0:
                 os.environ["CLICKHOUSE_URL_PARAMS"] = http_params
             else:
@@ -1471,10 +1470,10 @@ class TestCase:
                     self.base_url_params + "&" + http_params
                 )
 
-            new_options += f" {self.cli_format_settings(self.random_settings)}"
+            new_options += f" {self.cli_format_settings(self.effective_settings)}"
 
-        if self.randomize_merge_tree_settings:
-            new_options += f" --allow_merge_tree_settings {self.cli_format_settings(self.merge_tree_random_settings)}"
+        if self.effective_merge_tree_settings:
+            new_options += f" --allow_merge_tree_settings {self.cli_format_settings(self.effective_merge_tree_settings)}"
 
         if new_options != "":
             new_options += " --allow_repeated_settings"
@@ -1486,15 +1485,15 @@ class TestCase:
 
         return client_options + new_options
 
-    def remove_random_settings_from_env(self):
+    def remove_settings_from_env(self):
         os.environ["CLICKHOUSE_URL_PARAMS"] = self.base_url_params
         os.environ["CLICKHOUSE_CLIENT_OPT"] = self.base_client_options
 
     def add_info_about_settings(self, description):
-        if self.randomize_settings:
-            description += f"\nSettings used in the test: {self.cli_format_settings(self.random_settings)}"
-        if self.randomize_merge_tree_settings:
-            description += f"\n\nMergeTree settings used in test: {self.cli_format_settings(self.merge_tree_random_settings)}"
+        if self.effective_settings:
+            description += f"\nSettings used in the test: {self.cli_format_settings(self.effective_settings)}"
+        if self.effective_merge_tree_settings:
+            description += f"\n\nMergeTree settings used in test: {self.cli_format_settings(self.effective_merge_tree_settings)}"
 
         return description + "\n"
 
@@ -1538,43 +1537,40 @@ class TestCase:
         self.runs_count = 0
 
         has_no_random_settings_tag = self.tags and "no-random-settings" in self.tags
-
-        self.randomize_settings = not (
-            args.no_random_settings or has_no_random_settings_tag
-        )
-
         has_no_random_merge_tree_settings_tag = (
             self.tags and "no-random-merge-tree-settings" in self.tags
         )
 
+        allow_random_settings = not (args.no_random_settings or has_no_random_settings_tag)
         # If test contains SHOW CREATE TABLE do not
         # randomize merge tree settings, because
         # they will be added to table definition and test will fail
-        self.randomize_merge_tree_settings = not (
+        allow_random_mt_settings = not (
             args.no_random_merge_tree_settings
             or has_no_random_settings_tag
             or has_no_random_merge_tree_settings_tag
             or self.has_show_create_table_in_test()
         )
 
-        # If user supplied explicit settings, use exactly those (no randomization)
-        if getattr(args, "fixed_settings_dict", None):
-            self.randomize_settings = True
-            self.random_settings = dict(args.fixed_settings_dict)
-        if getattr(args, "fixed_merge_tree_settings_dict", None):
-            self.randomize_merge_tree_settings = True
-            self.merge_tree_random_settings = dict(args.fixed_merge_tree_settings_dict)
+        # Base randomized dicts (or empty if not allowed)
+        base_settings = {}
+        if allow_random_settings:
+            base_settings = SettingsRandomizer.get_random_settings(args)
+            self.apply_random_settings_limits(base_settings)
 
+        base_mt_settings = {}
+        if allow_random_mt_settings:
+            base_mt_settings = MergeTreeSettingsRandomizer.get_random_settings(args)
+            self.apply_random_settings_limits(base_mt_settings)
 
-        if self.randomize_settings and not getattr(args, "fixed_settings_dict", None):
-            self.random_settings = SettingsRandomizer.get_random_settings(args)
-            self.apply_random_settings_limits(self.random_settings)
+        # User-specified fixed dicts
+        fixed_settings = dict(args.fixed_settings or {})
+        fixed_mt_settings = dict(args.fixed_merge_tree_settings or {})
 
-        if self.randomize_merge_tree_settings and not getattr(args, "fixed_merge_tree_settings_dict", None):
-            self.merge_tree_random_settings = (
-                MergeTreeSettingsRandomizer.get_random_settings(args)
-            )
-            self.apply_random_settings_limits(self.merge_tree_random_settings)
+        # - If user passed fixed settings, use them exclusively.
+        # - Otherwise, use randomized (if allowed), else empty.
+        self.effective_settings = fixed_settings if fixed_settings else base_settings
+        self.effective_merge_tree_settings = fixed_mt_settings if fixed_mt_settings else base_mt_settings
 
         self.base_url_params = (
             os.environ["CLICKHOUSE_URL_PARAMS"]
@@ -2223,7 +2219,7 @@ class TestCase:
                 args, self.case_file, suite.suite_tmp_path
             )
 
-            client_options = self.add_random_settings(client_options)
+            client_options = self.add_effective_settings(client_options)
 
             if not is_valid_utf_8(self.case_file) or (
                 self.reference_file and not is_valid_utf_8(self.reference_file)
@@ -2345,7 +2341,7 @@ class TestCase:
                 self.get_description_from_exception_info(sys.exc_info()),
             )
         finally:
-            self.remove_random_settings_from_env()
+            self.remove_settings_from_env()
 
     def _cleanup(self, passed):
         args = self.testcase_args
@@ -4218,21 +4214,21 @@ if __name__ == "__main__":
         sys.exit(1)
 
     # Collect explicit settings (if any)
-    args.fixed_settings_dict = {}
-    args.fixed_merge_tree_settings_dict = {}
+    args.fixed_settings = {}
+    args.fixed_merge_tree_settings = {}
     try:
         if getattr(args, "settings_file", None):
-            args.fixed_settings_dict.update(
+            args.fixed_settings.update(
                 load_settings_from_file(args.settings_file, kind="settings")
             )
         if getattr(args, "settings", None):
-            args.fixed_settings_dict.update(parse_settings_cli_blob(args.settings))
+            args.fixed_settings.update(parse_settings_cli_blob(args.settings))
         if getattr(args, "merge_tree_settings_file", None):
-            args.fixed_merge_tree_settings_dict.update(
+            args.fixed_merge_tree_settings.update(
                 load_settings_from_file(args.merge_tree_settings_file, kind="merge-tree settings")
             )
         if getattr(args, "merge_tree_settings", None):
-            args.fixed_merge_tree_settings_dict.update(
+            args.fixed_merge_tree_settings.update(
                 parse_settings_cli_blob(args.merge_tree_settings)
             )
     except Exception as _e:

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -32,6 +32,7 @@ import socket
 import string
 import subprocess
 import sys
+import shlex
 import traceback
 import urllib.parse
 
@@ -1253,6 +1254,62 @@ def replace_in_file_re(filename, what, with_what):
     os.system(f"LC_ALL=C sed -i -e 's/{what}/{with_what}/' {filename}")
 
 
+def _coerce_value(v: str):
+    # ints, floats, booleans; leave "32Mi" etc. as strings
+    vl = v.lower()
+    if vl in ("true", "false"):
+        return vl == "true"
+    try:
+        if "." in v:
+            return float(v)
+        return int(v)
+    except ValueError:
+        return v
+
+
+def parse_settings_cli_blob(blob: str) -> Dict[str, object]:
+    """
+    Accepts strings like:
+      "--max_threads 1 --fsync_metadata 1 --http_wait_end_of_query True"
+    Returns dict: {"max_threads": 1, "fsync_metadata": 1, "http_wait_end_of_query": True}
+    """
+    if not blob:
+        return {}
+    tokens = shlex.split(blob)
+    out: Dict[str, object] = {}
+    i = 0
+    while i < len(tokens):
+        key = tokens[i].lstrip("-")
+        if not key:
+            i += 1
+            continue
+        # value may be missing → treat as boolean flag
+        if i + 1 >= len(tokens) or tokens[i + 1].startswith("--"):
+            out[key] = True
+            i += 1
+            continue
+        out[key] = _coerce_value(tokens[i + 1])
+        i += 2
+    return out
+
+
+def load_settings_from_file(path: str, *, kind: str) -> Dict[str, object]:
+    """
+    File must contain ONLY the inner blob (space-separated `--k v` pairs),
+    NOT the outer `--settings "..."` or `--merge-tree-settings "..."`.
+    """
+    with open(path, "r", encoding="utf-8") as f:
+        content = f.read().strip()
+    bad_prefixes = ("--settings", "--merge-tree-settings")
+    for p in bad_prefixes:
+        if content.startswith(p):
+            raise ValueError(
+                f"{kind} file '{path}' must NOT include the leading '{p}'; "
+                "put only the inner space-separated --key value pairs."
+            )
+    return parse_settings_cli_blob(content)
+
+
 # unlike functools.cache() ignore args
 # (since args can be non-hashable)
 def cache_ignore_args(func):
@@ -1500,11 +1557,20 @@ class TestCase:
             or self.has_show_create_table_in_test()
         )
 
-        if self.randomize_settings:
+        # If user supplied explicit settings, use exactly those (no randomization)
+        if getattr(args, "fixed_settings_dict", None):
+            self.randomize_settings = True
+            self.random_settings = dict(args.fixed_settings_dict)
+        if getattr(args, "fixed_merge_tree_settings_dict", None):
+            self.randomize_merge_tree_settings = True
+            self.merge_tree_random_settings = dict(args.fixed_merge_tree_settings_dict)
+
+
+        if self.randomize_settings and not getattr(args, "fixed_settings_dict", None):
             self.random_settings = SettingsRandomizer.get_random_settings(args)
             self.apply_random_settings_limits(self.random_settings)
 
-        if self.randomize_merge_tree_settings:
+        if self.randomize_merge_tree_settings and not getattr(args, "fixed_merge_tree_settings_dict", None):
             self.merge_tree_random_settings = (
                 MergeTreeSettingsRandomizer.get_random_settings(args)
             )
@@ -3889,6 +3955,30 @@ def parse_args():
         default=False,
         help="Disable MergeTree settings randomization",
     )
+    # Explicit, non-random settings (copy-paste friendly)
+    parser.add_argument(
+        "--settings",
+        type=str,
+        help='Explicit ClickHouse settings to use. Paste the CI blob inside quotes, e.g.: '
+             '--settings "--max_threads 1 --fsync_metadata 1 ..."',
+    )
+    parser.add_argument(
+        "--settings-file",
+        type=str,
+        help="Path to a file containing ONLY the inner space-separated settings blob "
+             '(e.g. "--max_threads 1 --fsync_metadata 1 ...").',
+    )
+    parser.add_argument(
+        "--merge-tree-settings",
+        type=str,
+        help='Explicit MergeTree settings to use. Paste the CI blob inside quotes, e.g.: '
+             '--merge-tree-settings "--index_granularity 8192 ..."',
+    )
+    parser.add_argument(
+        "--merge-tree-settings-file",
+        type=str,
+        help="Path to a file containing ONLY the inner space-separated MergeTree settings blob."
+    )
     parser.add_argument(
         "--run-by-hash-num",
         type=int,
@@ -4125,6 +4215,28 @@ if __name__ == "__main__":
         args = parse_args()
     except Exception as e:
         print(e, file=sys.stderr)
+        sys.exit(1)
+
+    # Collect explicit settings (if any)
+    args.fixed_settings_dict = {}
+    args.fixed_merge_tree_settings_dict = {}
+    try:
+        if getattr(args, "settings_file", None):
+            args.fixed_settings_dict.update(
+                load_settings_from_file(args.settings_file, kind="settings")
+            )
+        if getattr(args, "settings", None):
+            args.fixed_settings_dict.update(parse_settings_cli_blob(args.settings))
+        if getattr(args, "merge_tree_settings_file", None):
+            args.fixed_merge_tree_settings_dict.update(
+                load_settings_from_file(args.merge_tree_settings_file, kind="merge-tree settings")
+            )
+        if getattr(args, "merge_tree_settings", None):
+            args.fixed_merge_tree_settings_dict.update(
+                parse_settings_cli_blob(args.merge_tree_settings)
+            )
+    except Exception as _e:
+        print(f"Failed to parse provided settings: {_e}", file=sys.stderr)
         sys.exit(1)
 
     if args.queries and not os.path.isdir(args.queries):


### PR DESCRIPTION
This change allows to copy the exact settings from CI logs and run tests locally with the same configuration.
It improves productivity and makes debugging test failures easier by ensuring local test runs match the exact settings used in CI jobs.

**Use case**
In CI, test logs include large `--settings` and `--merge-tree-settings` blocks that define the ClickHouse and MergeTree configuration used during the run.
Until now, reproducing these locally required manually editing the script.
With this change, you can simply copy and paste the CI settings line and run the test locally with the same parameters.

**Example**
```
# Copy-paste the settings line from CI directly:
tests/clickhouse-test 03212_variant_dynamic_cast_or_default \
  --settings "--max_threads 1 --group_by_two_level_threshold 1 ..." \
  --merge-tree-settings "--index_granularity 8192 --enable_block_number_column 1 ..."
```

**Or store them in files:**
```
tests/clickhouse-test \
  --settings-file settings.txt \
  --merge-tree-settings-file mergetree.txt \
  --print-settings
```

**Implementation details**
- Added new CLI arguments:
   - --settings / --settings-file
   - --merge-tree-settings / --merge-tree-settings-file
- When provided:
   - Randomized settings are skipped.
   - These fixed settings are used for the test.

Cases Tested:

1. no randomization, no settings - no additional settings added
2. no randomization, settings - only specified settings added
3. randomization, no settings - only randomized settings added
4. randomization, settings - settings from --settings override randomized settings

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
