### PR TITLE
CI: Integration flaky test job: fix behaviour

### DIFF
--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -101,7 +101,7 @@ def main():
             use_distributed_plan = True
         elif to == "flaky":
             is_flaky_check = True
-            repeat_option = f"--count {FLAKY_CHECK_TEST_REPEAT_COUNT} --random-order --session-timeout {3600*4}"
+            repeat_option = f"--count {FLAKY_CHECK_TEST_REPEAT_COUNT} --random-order"
         elif to == "parallel":
             is_parallel = True
         elif to == "sequential":
@@ -269,7 +269,7 @@ def main():
                     cwd="./tests/integration/",
                     pytest_report_file=f"{temp_path}/pytest_sequential.jsonl",
                 )
-                if not test_result_parallel.is_ok():
+                if not test_result_sequential.is_ok():
                     print(
                         f"Flaky check: Test run fails after attempt [{attempt+1}/{module_repeat_cnt}] - break"
                     )

--- a/tests/integration/test_system_logs/test_system_logs.py
+++ b/tests/integration/test_system_logs/test_system_logs.py
@@ -143,7 +143,6 @@ def test_max_size_0(start_cluster):
     )
     node1.restart_clickhouse()
 
-
 def test_reserved_size_greater_max_size(start_cluster):
     node1.exec_in_container(
         [


### PR DESCRIPTION
Restore previous flaky check behavior in integration tests, follow up https://github.com/ClickHouse/ClickHouse/pull/88190:
- run each test case 3 times
- random order within the module
- rerun each module 2 times

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

