### PR TITLE
CI: Run integration tests locally with job alias

### DIFF
--- a/ci/praktika/workflow.py
+++ b/ci/praktika/workflow.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 from . import Artifact, Job
 from .docker import Docker
@@ -52,6 +52,8 @@ class Workflow:
         enable_dockers_manifest_merge: bool = False
         # If latest tag shpuld be added for merged docker manifest, enable with .enable_dockers_manifest_merge
         set_latest_for_docker_merged_manifest: bool = False
+        # Job aliases for easy job reference with `praktika run job_alias --test TEST_NAME` in local environment
+        job_aliases: Dict[str, str] = field(default_factory=dict)
 
         def is_event_pull_request(self):
             return self.event == Workflow.Event.PULL_REQUEST
@@ -75,6 +77,11 @@ class Workflow:
             return jobs[0]
 
         def find_jobs(self, name, lazy=False):
+            if self.job_aliases and name in self.job_aliases:
+                print(
+                    f"NOTE: job alias [{name}] refers to job [{self.job_aliases[name]}]"
+                )
+                name = self.job_aliases[name]
             name = str(name)
             res = []
             for job in self.jobs:

--- a/ci/workflows/pull_request.py
+++ b/ci/workflows/pull_request.py
@@ -20,6 +20,10 @@ FUNCTIONAL_TESTS_PARALLEL_BLOCKING_JOB_NAMES = [
 
 REGULAR_BUILD_NAMES = [job.name for job in JobConfigs.build_jobs]
 
+PLAIN_FUNCTIONAL_TEST_JOB = [
+    j for j in JobConfigs.functional_tests_jobs if "amd_debug, parallel" in j.name
+][0]
+
 workflow = Workflow.Config(
     name="PR",
     event=Workflow.Event.PULL_REQUEST,
@@ -138,6 +142,12 @@ workflow = Workflow.Config(
         "python3 ./ci/jobs/scripts/workflow_hooks/new_tests_check.py",
         "python3 ./ci/jobs/scripts/workflow_hooks/can_be_merged.py",
     ],
+    job_aliases={
+        "integration": JobConfigs.integration_test_jobs_non_required[
+            0
+        ].name,  # plain integration test job, no old analyzer, no dist plan
+        "functional": PLAIN_FUNCTIONAL_TEST_JOB.name,
+    },
 )
 
 WORKFLOWS = [

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,233 +1,170 @@
-## ClickHouse integration tests
+# ClickHouse Integration Tests
 
-This directory contains tests that involve several ClickHouse instances, custom configs, ZooKeeper, etc.
+This directory contains integration tests for ClickHouse, involving multiple instances, custom configurations, ZooKeeper, and more. These tests help ensure robust distributed behavior and compatibility with external systems.
 
-### Running integration tests locally as CI job {#running-integration-tests-locally-as-ci-job}
+## Running Integration Tests Locally as CI Job
 
-You can reproduce CI integration test jobs locally using the same orchestration that CI uses.
+You can reproduce CI integration test jobs locally using the same orchestration as CI.
 
-- **Prerequisites**
-  - Python 3
-  - Docker
-  - A ClickHouse server binary available to the job. The runner looks for a binary in this order and uses the first one it finds:
-    - `./ci/tmp/clickhouse`
-    - `./build/programs/clickhouse`
-    - `./clickhouse`
-    Tip: place or symlink your built binary to one of these paths.
+### Prerequisites
+- Python 3 (standard library only)
+- Docker
+- ClickHouse server binary available to the job. The runner searches in this order and uses the first found:
+  - `./ci/tmp/clickhouse`
+  - `./build/programs/clickhouse`
+  - `./clickhouse`
 
-- **Run a CI job locally**
-  ```bash
-  python -m ci.praktika run "<JOB_NAME>"
-  ```
-  - Always quote the job name exactly as it appears in the CI report (it contains spaces and commas), for example: `"Integration tests (amd_asan, 1/5)"`.
-  - If the job name is not unique across workflows, disambiguate with the workflow name:
-    ```bash
-    python -m ci.praktika run "Integration tests (amd_binary, 1/5)"
-    ```
-  - If searching for the exact job name in the CI report is inconvenient, you can use a keyword or substring of the job name. For example:
-    ```bash
-    python -m ci.praktika run "integration"
-    ```
-    If the job cannot be determined unambiguously, the tool will print a list of matching jobs.
+### Run a CI Job Locally
+```bash
+python -m ci.praktika run "<JOB_NAME>"
+```
+- Always quote the job name exactly as in the CI report (it may contain spaces and commas), e.g.: `"Integration tests (amd_asan, 1/5)"`.
 
-- **Run a specific test within a CI job**
+### Run a Specific Test Within a CI Job
+```bash
+python -m ci.praktika run "Integration tests (amd_binary, 4/5)" \
+  --test "test_named_collections/"
+```
+- With `--test`, the batch index in the job name (e.g., `4/5`) is irrelevant locally, but the job name must match an actual CI job to select the right configuration.
+- You can pass multiple test selectors:
   ```bash
   python -m ci.praktika run "Integration tests (amd_binary, 4/5)" \
-    --test "test_named_collections/"
+    --test "test_named_collections/test.py::test_default_access" "test_multiple_disks/"
   ```
-  - With `--test` specified, the batch index in the job name (e.g., `4/5`) is irrelevant locally, but the job name must still match an actual CI job to select the right configuration.
-  - You can pass multiple test selectors (they will be combined and forwarded to the job):
-    ```bash
-    python -m ci.praktika run "Integration tests (amd_binary, 4/5)" \
-      --test "test_named_collections/test.py::test_default_access" "test_multiple_disks/"
-    ```
+- Tip: For local runs with `--test`, the batch index and build flavor are not required. You can use the alias `integration`:
+  ```bash
+  python -m ci.praktika run "integration" --test <selectors>
+  ```
+  Praktika will pick a suitable job configuration for individual tests. Note: jobs with old analyzer or distributed plan still require the full, exact CI job name.
 
-- **Additional customization options for local run:**
-  - `--count N` to repeat each test N times (`--count` will be passed to pytest with `--repeat-scope=function`).
-  - `--debug` to open the Python debug console on exception (`--pdb` will be passed to pytest).
-  - `--path` custom ClickHouse server binary location (if not in one of the default locations).
-  - `--path_1` custom path to the ClickHouse server config directory (if not in `./programs/server/config/`).
+### Additional Customization Options
+- `--count N` to repeat each test N times (`--count` is passed to pytest with `--repeat-scope=function`).
+- `--debug` to open the Python debug console on exception (`--pdb` is passed to pytest).
+- `--path` custom ClickHouse server binary location (if not in default locations).
+- `--path_1` custom path to the ClickHouse server config directory (if not in `./programs/server/config/`).
 
-No other dependencies are required beyond Python 3 and Docker.
+## Running Natively
 
-### Running natively {#running-natively}
+### Prerequisites
+- Ubuntu 20.04 (Focal) or higher
+- [Docker](https://www.docker.com/community-edition#/download) (API version ≥ 1.25; check with `docker version`).
+- Latest Docker from [official docs](https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/#set-up-the-repository). Do not use system repository Docker.
+- [pip](https://pypi.python.org/pypi/pip) and `libpq-dev`. Install with:
+  ```bash
+  sudo apt-get install python3-pip libpq-dev zlib1g-dev libcrypto++-dev libssl-dev libkrb5-dev python3-dev openjdk-17-jdk requests urllib3
+  ```
+- [pytest](https://docs.pytest.org/) testing framework:
+  ```bash
+  sudo -H pip install pytest
+  ```
+- [docker compose](https://docs.docker.com/compose/) and additional Python libraries:
+  ```bash
+  sudo -H pip install \
+      PyMySQL avro cassandra-driver confluent-kafka dicttoxml docker grpcio grpcio-tools kafka-python kazoo minio lz4 protobuf psycopg2-binary pymongo pytz pytest pytest-timeout redis tzlocal==2.1 urllib3 requests-kerberos dict2xml hypothesis pika nats-py pandas numpy jinja2 pytest-xdist==2.4.0 pyspark azure-storage-blob delta paramiko psycopg pyarrow boto3 deltalake snappy pyiceberg python-snappy thrift
+  ```
+- For Spark tests, install Spark and add its `bin` directory to your `PATH`. See `ci/docker/integration/runner/Dockerfile` for details. Set `JAVA_PATH` to the Java binary path.
+- To run tests as a non-privileged user, add the user to the `docker` group:
+  ```bash
+  sudo usermod -aG docker $USER
+  # Re-login or restart your computer
+  ```
+  Check Docker access with `docker ps`.
 
-Prerequisites:
-* Ubuntu 20.04 (Focal) or higher.
-* [docker](https://www.docker.com/community-edition#/download). Minimum required API version: 1.25, check with `docker version`.
-
-Install the latest Docker from:
-https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/#set-up-the-repository
-Do not use Docker from your system repository.
-
-* [pip](https://pypi.python.org/pypi/pip) and `libpq-dev`. To install: `sudo apt-get install python3-pip libpq-dev zlib1g-dev libcrypto++-dev libssl-dev libkrb5-dev python3-dev openjdk-17-jdk requests urllib3`
-* [py.test](https://docs.pytest.org/) testing framework. To install: `sudo -H pip install pytest`
-* [docker compose](https://docs.docker.com/compose/) and additional Python libraries. To install:
-
-```bash
-sudo -H pip install \
-    PyMySQL \
-    avro \
-    cassandra-driver \
-    confluent-kafka \
-    dicttoxml \
-    docker \
-    grpcio \
-    grpcio-tools \
-    kafka-python \
-    kazoo \
-    minio \
-    lz4 \
-    protobuf \
-    psycopg2-binary \
-    pymongo \
-    pytz \
-    pytest \
-    pytest-timeout \
-    redis \
-    tzlocal==2.1 \
-    urllib3 \
-    requests-kerberos \
-    dict2xml \
-    hypothesis \
-    pika \
-    nats-py \
-    pandas \
-    numpy \
-    jinja2 \
-    pytest-xdist==2.4.0 \
-    pyspark \
-    azure-storage-blob \
-    delta \
-    paramiko \
-    psycopg \
-    pyarrow \
-    boto3 \
-    deltalake \
-    snappy \
-    pyiceberg \
-    python-snappy \
-    thrift
-```
-
-If you run tests with Spark, install Spark and add its `bin` directory to your `PATH`. See `ci/docker/integration/runner/Dockerfile` for details. Also set `JAVA_PATH` to the path of the Java binary.
-
-If you want to run the tests under a non-privileged user, you must add this user to the `docker` group: `sudo usermod -aG docker $USER` and re-login.
-(You must close all your sessions (for example, restart your computer))
-To check that you have access to Docker, run `docker ps`.
-
-Run the tests with the `pytest` command. Examples and useful flags:
+### Running Tests
+Run tests with `pytest`. Examples and useful flags:
 ```bash
 pytest <tests_or_paths> \
   [-k <expr>] \
   [-n <numprocesses> --dist=loadfile] \
   [--count <count> --repeat-scope=function]
 ```
+- `-n <numprocesses>`: Number of parallel processes (CI uses 4 for parallelizable tests, 1 for others). Use `--dist=loadfile` for parallel runs to keep tests in a file on the same worker. See [pytest-xdist](https://pytest-xdist.readthedocs.io/en/stable/distribution.html).
+- `--count <count>`: Repeat a test multiple times; use with `--repeat-scope=function`. See [pytest-repeat](https://pypi.org/project/pytest-repeat/).
 
-`-n <numprocesses>` — number of processes to run tests in parallel (CI uses 4 for parallelizable tests and 1 for the rest). Use `--dist=loadfile` when running in parallel. This guarantees that all tests in a file run on the same worker (tests within a file are not executed in parallel). See [pytest-xdist](https://pytest-xdist.readthedocs.io/en/stable/distribution.html) for details.
-`--count <count>` — repeat a test multiple times; use with `--repeat-scope=function`. See [pytest-repeat](https://pypi.org/project/pytest-repeat/) for details.
+Tests locate the server binary in the repository root and configs in `./programs/server/`. You can override paths with these environment variables:
+- `CLICKHOUSE_TESTS_SERVER_BIN_PATH`
+- `CLICKHOUSE_TESTS_ODBC_BRIDGE_BIN_PATH` (path to `clickhouse-odbc-bridge` binary)
+- `CLICKHOUSE_TESTS_CLIENT_BIN_PATH`
+- `CLICKHOUSE_TESTS_BASE_CONFIG_DIR` (path to `config.xml` and `users.xml`)
 
-Tests try to locate the server binary in the repository root and configs in `./programs/server/`. You can modify paths by setting these environment variables:
-* `CLICKHOUSE_TESTS_SERVER_BIN_PATH`
-* `CLICKHOUSE_TESTS_ODBC_BRIDGE_BIN_PATH` (path to `clickhouse-odbc-bridge` binary)
-* `CLICKHOUSE_TESTS_CLIENT_BIN_PATH`
-* `CLICKHOUSE_TESTS_BASE_CONFIG_DIR` (path to `config.xml` and `users.xml`)
+If using a separate build (`ENABLE_CLICKHOUSE_ALL=OFF`), build all required components (e.g., `ENABLE_CLICKHOUSE_KEEPER=ON`). Using `ENABLE_CLICKHOUSE_ALL=ON` is easier.
 
-Please note that if you use a separate build (`ENABLE_CLICKHOUSE_ALL=OFF`), you need to build different components, including but not limited to `ENABLE_CLICKHOUSE_KEEPER=ON`. It's easier to use `ENABLE_CLICKHOUSE_ALL=ON`.
+## Adding New Tests
 
+To add a new test named `foo`, create a directory `test_foo` with an empty `__init__.py` and a `test.py` file containing your tests. All functions starting with `test` are test cases.
 
-### Adding new tests
+The `helpers` directory provides utilities for:
+- Launching a ClickHouse cluster (with/without ZooKeeper) in Docker containers.
+- Sending queries to instances.
+- Simulating network failures (e.g., severing links between instances).
 
-To add new test named `foo`, create a directory `test_foo` with an empty `__init__.py` and a file
-named `test.py` containing tests in it. All functions with names starting with `test` will become test cases.
+To compare TSV files, wrap them in the `TSV` class and use `assert`, e.g.:
+```python
+assert TSV(result) == TSV(reference)
+```
+On failure, pytest shows a concise diff.
 
-`helpers` directory contains utilities for:
-* Launching a ClickHouse cluster with or without ZooKeeper in docker containers.
-* Sending queries to launched instances.
-* Introducing network failures such as severing network link between two instances.
+## Using pdb to Break on Assert
 
-To assert that two TSV files must be equal, wrap them in the `TSV` class and use the regular `assert`
-statement. Example: `assert TSV(result) == TSV(reference)`. In case the assertion fails, `pytest`
-will automagically detect the types of variables and only the small diff of two files is printed.
-
-### Using pdb to break on assert
-
-It is very handy to stop the test on assertion failure and play with it in
-`python`, this can be done with `--pdb` switch, it will spawn `python`
-interpreter in case of failures.
-
-For native runs, simply `pytest --pdb <tests and other options>`
-
-### Debug mode
-
-Use this mode to attach a low‑level debugger to the ClickHouse server that runs inside the integration test containers.
-
-1. Put a statically linked debugger binary at the root of your ClickHouse repository. We recommend [nnd](https://github.com/al13n321/nnd) (the only supported option currently).
-   - Download: `curl -L -o nnd 'https://github.com/al13n321/nnd/releases/latest/download/nnd' && chmod +x nnd`
-   - Note: nnd currently supports x86_64 only.
-
-2. Add a `breakpoint()` to your test (e.g. in `test.py`) at the point you want to pause. This keeps the test (and server) alive so you can attach a debugger.
-
-3. Run the test via the praktika CI wrapper (see [Running integration tests locally as CI job](#running-integration-tests-locally-as-ci-job)) and specify your test(s). For interactive debugging with pdb, make sure you run from a real TTY.
-
-4. When the test hits the `breakpoint()`, you’ll see a Python pdb prompt similar to:
+To stop on assertion failure and debug interactively, use the `--pdb` switch:
 ```bash
-   >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> PDB set_trace (IO-capturing turned off) >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
-> /ClickHouse/tests/integration/test_throttling/test.py(493)test_write_throttling()
--> assert_took(took, should_take)
-(Pdb)
+pytest --pdb <tests and options>
 ```
 
-5. In a second terminal, source helper commands, then use the provided helpers:
-```bash
-   source /path/to/ClickHouse/tests/integration/runner-env.sh
+## Debug Mode
 
-USAGE:
-   runner-client - Run clickhouse client inside an integration test
-   runner-bash   - Open shell on a node inside an integration test
-   runner-nnd    - Attach nnd debugger to a clickhouse server on a node inside an integration test
-```
+Use debug mode to attach a low-level debugger to the ClickHouse server inside integration test containers.
 
-6. Use either a Container ID or a container name to connect to a node (the helper will list running containers and prompt you). Example:
+1. Place a statically linked debugger binary (recommended: [nnd](https://github.com/al13n321/nnd), x86_64 only) at the repository root:
    ```bash
-   runner-client
-CONTAINER ID   IMAGE                                      COMMAND                  CREATED          STATUS          PORTS                                                            NAMES
-   867c67cc9957   clickhouse/integration-test:latest         "..."                    2s ago           Up 1s                                                                      rootteststoragedelta-node1-1
-   ...
-Enter ClickHouse Node CONTAINER ID or NAME (default: 867c67cc9957):
+   curl -L -o nnd 'https://github.com/al13n321/nnd/releases/latest/download/nnd' && chmod +x nnd
    ```
-
+2. Add a `breakpoint()` in your test (e.g., in `test.py`) where you want to pause.
+3. Run the test via the praktika CI wrapper and specify your test(s). For interactive debugging, use a real TTY.
+4. When the test hits `breakpoint()`, you'll see a Python pdb prompt:
+5. In a second terminal, source helper commands and use the provided helpers:
+   ```bash
+   source /path/to/ClickHouse/tests/integration/runner-env.sh
+   # USAGE:
+   # runner-client - Run clickhouse client inside an integration test
+   # runner-bash   - Open shell on a node inside an integration test
+   # runner-nnd    - Attach nnd debugger to a clickhouse server on a node inside an integration test
+   ```
+6. Use a container ID or name to connect to a node (the helper lists running containers and prompts you):
+    ```bash
+   runner-client
+    CONTAINER ID   IMAGE                                      COMMAND                  CREATED          STATUS          PORTS                                                            NAMES
+    867c67cc9957   clickhouse/integration-test:latest         "..."                    2s ago           Up 1s                                                                      rootteststoragedelta-node1-1
+    ...
+    Enter ClickHouse Node CONTAINER ID or NAME (default: 867c67cc9957):
+    ```
    After selecting a node, you can query it:
    ```sql
    node1 :) SELECT 1;
    ┌─1─┐
    │ 1 │
    └───┘
-```
+   ```
 
-### Troubleshooting
+## Troubleshooting
 
-If tests failing for mysterious reasons, this may help:
-
+If tests fail for mysterious reasons:
 ```bash
 sudo service docker stop
 sudo bash -c 'rm -rf /var/lib/docker/*'
 sudo service docker start
 ```
 
-#### `iptables-nft`
-
-On Ubuntu 20.10 and later in host network mode (default) one may encounter problem with nested containers not seeing each other. It happens because legacy and nftables rules are out of sync. Problem can be solved by:
-
+### iptables-nft Issue
+On Ubuntu 20.10+ in host network mode, nested containers may not see each other due to legacy/nftables rule sync issues. Fix with:
 ```bash
 sudo iptables -P FORWARD ACCEPT
 ```
 
-### Slow internet connection problem
+### Slow Internet Connection
 
-To download all dependencies, you can run `docker pull` manually. This will allow all dependencies to be downloaded without timeouts interrupting the tests.
-
-```
+To download all dependencies in advance:
+```bash
 export KERBERIZED_KAFKA_DIR=/tmp
 export KERBERIZED_KAFKA_EXTERNAL_PORT=8080
 export MYSQL_ROOT_HOST=%
@@ -255,12 +192,12 @@ export PROMETHEUS_READER_PORT=8080
 docker compose $(find ${HOME}/ClickHouse/tests/integration -name '*compose*yml' -exec echo --file {} ' ' \; ) pull
 ```
 
+### IPv6 Problem
 
-### IPv6 problem
-
-If you have problems with network access to docker hub or other resources, then in this case you need to disable ipv6. To do this, open `sudo vim /etc/docker/daemon.json` and add:
-
-```
+If you have network access issues to Docker Hub or other resources, disable IPv6:
+```bash
+sudo vim /etc/docker/daemon.json
+# Add:
 {
   "ipv6": false
 }


### PR DESCRIPTION
Adds notion of job aliases in praktika's workflow config and new aliases for **Integration test** and **Statless tests** jobs to simplify command for local run:

`python -m ci.praktika run integration --test "test_replicated_database"` to avoid typing full job name e.g.: `"Integration tests (build_type, batch/index)"`

Updates docs

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

