### PR TITLE
Fix max_cpu_share setting when used without max_cpus

### DIFF
--- a/src/Common/Scheduler/WorkloadSettings.cpp
+++ b/src/Common/Scheduler/WorkloadSettings.cpp
@@ -232,7 +232,7 @@ void WorkloadSettings::initFromChanges(CostUnit unit_, const ASTCreateWorkloadQu
         if (share_limit > 0)
         {
             Float64 value = share_limit * getNumberOfCPUCoresToUse();
-            if (value > 0 && value < limit)
+            if (value > 0 && (limit == 0 || value < limit))
                 limit = value;
         }
         max_cpus = limit;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Fix `max_cpu_share` workload setting not working when used without `max_cpus`. Previously, setting only `max_cpu_share` would result in unlimited CPU usage instead of applying the percentage limit.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

**Bug Fix:**
When using `CREATE WORKLOAD ... SETTINGS max_cpu_share = 0.5` without also setting `max_cpus`, the CPU limit was incorrectly ignored.

**Root Cause:**
The condition `if (value > 0 && value < limit)` at line 235 failed when `limit = 0` (the default value when `max_cpus` is not set), preventing the share-based limit from being applied.

**Fix:**
Changed to `if (value > 0 && (limit == 0 || value < limit))` to handle both scenarios:
- When only `max_cpu_share` is set (limit = 0) → apply the share limit
- When both are set → use the minimum of the two

**Testing:**
```sql
-- Now correctly limits CPU to 50%
CREATE RESOURCE cpu (MASTER THREAD, WORKER THREAD);
CREATE WORKLOAD all;
CREATE WORKLOAD test SETTINGS max_cpu_share = 0.5;