### PR TITLE
Add missing checks for canContainMergeTreeTables() into system tables

### DIFF
--- a/src/Databases/DataLake/DatabaseDataLake.cpp
+++ b/src/Databases/DataLake/DatabaseDataLake.cpp
@@ -508,7 +508,6 @@ DatabaseTablesIteratorPtr DatabaseDataLake::getTablesIterator(
                     }
                     catch (...)
                     {
-                        tryLogCurrentException(log, fmt::format("Ignoring table {}", table_name));
                         promise->set_exception(std::current_exception());
                     }
                 });
@@ -595,7 +594,7 @@ DatabaseTablesIteratorPtr DatabaseDataLake::getLightweightTablesIterator(
                     }
                     catch (...)
                     {
-                        tryLogCurrentException(log, fmt::format("ignoring table {}", table_name));
+                        tryLogCurrentException(log, fmt::format("Ignoring table {}", table_name));
                     }
                     promise->set_value(storage);
                 });

--- a/src/Storages/System/StorageSystemDataSkippingIndices.cpp
+++ b/src/Storages/System/StorageSystemDataSkippingIndices.cpp
@@ -266,6 +266,8 @@ void ReadFromSystemDataSkippingIndices::initializePipeline(QueryPipelineBuilder 
     {
         if (database_name == DatabaseCatalog::TEMPORARY_DATABASE)
             continue;
+        if (!database->canContainMergeTreeTables())
+            continue;
 
         /// Lazy database can contain only very primitive tables,
         /// it cannot contain tables with data skipping indices.

--- a/src/Storages/System/StorageSystemProjections.cpp
+++ b/src/Storages/System/StorageSystemProjections.cpp
@@ -253,6 +253,8 @@ void ReadFromSystemProjections::initializePipeline(QueryPipelineBuilder & pipeli
     {
         if (database_name == DatabaseCatalog::TEMPORARY_DATABASE)
             continue;
+        if (!database->canContainMergeTreeTables())
+            continue;
 
         /// Lazy database can contain only very primitive tables, it cannot contain tables with projections.
         /// Skip it to avoid unnecessary tables loading in the Lazy database.


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Avoid trying to initialize DataLake databases while accessing `system.projections` and `system.data_skipping_indices`

_Note, that this is only a patch for backport, we need to polish the `IDatabase` interface - https://github.com/ClickHouse/ClickHouse/issues/88331._