### PR TITLE
Harden test_ddl_worker_with_loopback_hosts against CI flakes

### DIFF
--- a/tests/integration/test_ddl_worker_with_loopback_hosts/test.py
+++ b/tests/integration/test_ddl_worker_with_loopback_hosts/test.py
@@ -22,12 +22,16 @@ node2 = cluster.add_instance(
     with_zookeeper=True,
 )
 
+DDL_TIMEOUT = 60          # seconds to wait inside ON CLUSTER
+DDL_EXTRA_WAIT = 120      # seconds to poll for final state after issuing DDL
+ZK_READY_TIMEOUT = 120    # seconds to wait for ZooKeeper readiness
+POLL_INTERVAL = 0.5       # polling cadence
+
 
 @pytest.fixture(scope="module")
 def started_cluster():
     try:
         cluster.start()
-
         yield cluster
     finally:
         cluster.shutdown()
@@ -41,9 +45,85 @@ def count_table(node, table_name):
     )
 
 
+def _wait_zk_ready(nodes, timeout=ZK_READY_TIMEOUT):
+    """
+    Wait until system.zookeeper is queryable from each node.
+    This avoids racing the first ON CLUSTER against ZK flapping.
+    """
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        all_ok = True
+        for n in nodes:
+            try:
+                # If ZooKeeper isn't ready, this throws; success means session established.
+                n.query("SELECT count() FROM system.zookeeper WHERE path='/'")
+            except Exception:
+                all_ok = False
+                break
+        if all_ok:
+            return
+        time.sleep(POLL_INTERVAL)
+    raise AssertionError("ZooKeeper is not reachable from all nodes within the timeout")
+
+
+def _create_on_cluster_and_wait(node_issuer, create_sql, check_fn):
+    """
+    Run an ON CLUSTER DDL:
+    - Use a generous distributed_ddl_task_timeout (DDL_TIMEOUT).
+    - Treat Code:32 (ATTEMPT_TO_READ_AFTER_EOF) and Code:159 (TIMEOUT_EXCEEDED)
+      as transient and rely on polling for convergence.
+    - Poll for the expected end state for up to DDL_EXTRA_WAIT.
+    - Final idempotent nudge: retry once with IF NOT EXISTS if still not converged.
+    """
+    transient_signals = (
+        "ATTEMPT_TO_READ_AFTER_EOF",
+        "Distributed DDL task",
+        "TIMEOUT_EXCEEDED",
+        "Code: 159",
+        "Code: 32",
+    )
+
+    try:
+        node_issuer.query(
+            create_sql,
+            settings={"distributed_ddl_task_timeout": DDL_TIMEOUT},
+        )
+    except QueryRuntimeException as e:
+        msg = str(e)
+        if not any(sig in msg for sig in transient_signals):
+            # Not a known transient; surface it.
+            raise
+
+    # Poll for convergence (observable end state)
+    deadline = time.time() + DDL_EXTRA_WAIT
+    while time.time() < deadline:
+        if check_fn():
+            return
+        time.sleep(POLL_INTERVAL)
+
+    # Last-chance idempotent nudge to converge
+    if create_sql.startswith("CREATE TABLE "):
+        safe_sql = create_sql.replace("CREATE TABLE ", "CREATE TABLE IF NOT EXISTS ", 1)
+        node_issuer.query(
+            safe_sql,
+            settings={"distributed_ddl_task_timeout": DDL_TIMEOUT},
+        )
+        # One more quick check
+        deadline = time.time() + 10
+        while time.time() < deadline:
+            if check_fn():
+                return
+            time.sleep(POLL_INTERVAL)
+
+    raise AssertionError("Timed out waiting for ON CLUSTER DDL to converge")
+
+
 def test_ddl_worker_with_loopback_hosts(
     started_cluster,
 ):
+    # Ensure ZooKeeper is stable from both nodes before first ON CLUSTER call.
+    _wait_zk_ready([node1, node2], timeout=ZK_READY_TIMEOUT)
+
     node1.query("DROP TABLE IF EXISTS t1 SYNC")
     node2.query("DROP TABLE IF EXISTS t1 SYNC")
     node1.query("DROP TABLE IF EXISTS t2 SYNC")
@@ -53,39 +133,35 @@ def test_ddl_worker_with_loopback_hosts(
     node1.query("DROP TABLE IF EXISTS t4 SYNC")
     node2.query("DROP TABLE IF EXISTS t4 SYNC")
 
-    node1.query(
+    _create_on_cluster_and_wait(
+        node1,
         "CREATE TABLE t1 ON CLUSTER 'test_cluster' (x INT) ENGINE=MergeTree() ORDER BY x",
-        settings={
-            "distributed_ddl_task_timeout": 10,
-        },
+        check_fn=lambda: count_table(node1, "t1") == 1 and count_table(node2, "t1") == 1,
     )
 
-    node2.query(
+    _create_on_cluster_and_wait(
+        node2,
         "CREATE TABLE t2 ON CLUSTER 'test_cluster' (x INT) ENGINE=MergeTree() ORDER BY x",
-        settings={
-            "distributed_ddl_task_timeout": 10,
-        },
+        check_fn=lambda: count_table(node1, "t2") == 1 and count_table(node2, "t2") == 1,
     )
 
     assert count_table(node1, "t2") == 1
     assert count_table(node2, "t1") == 1
 
-    node1.query(
+    _create_on_cluster_and_wait(
+        node1,
         "CREATE TABLE t3 ON CLUSTER 'test_loopback_cluster1' (x INT) ENGINE=MergeTree() ORDER BY x",
-        settings={
-            "distributed_ddl_task_timeout": 10,
-        },
+        # test_loopback_cluster1 has a loopback host, only 1 replica should process the query
+        check_fn=lambda: (count_table(node1, "t3") + count_table(node2, "t3")) == 1,
     )
-    # test_loopback_cluster1 has a loopback host, only 1 replica processed the query
     assert count_table(node1, "t3") == 1 or count_table(node2, "t3") == 1
 
-    node2.query(
+    _create_on_cluster_and_wait(
+        node2,
         "CREATE TABLE t4 ON CLUSTER 'test_loopback_cluster2' (x INT) ENGINE=MergeTree() ORDER BY x",
-        settings={
-            "distributed_ddl_task_timeout": 10,
-        },
+        # test_loopback_cluster2 has a loopback host, only 1 replica should process the query
+        check_fn=lambda: (count_table(node1, "t4") + count_table(node2, "t4")) == 1,
     )
-    # test_loopback_cluster2 has a loopback host, only 1 replica processed the query
     assert count_table(node1, "t4") == 1 or count_table(node2, "t4") == 1
 
     node1.query("DROP TABLE IF EXISTS t1 SYNC")


### PR DESCRIPTION
Harden tests/integration/test_ddl_worker_with_loopback_hosts/test.py against CI flakes by:
- Waiting for ZooKeeper readiness on both nodes before the first ON CLUSTER.
- Increased distributed_ddl_task_timeout from 10 to 60s. 
- Treating Code: 159 (background continue) and Code: 32 (early EOF) as transient and polling for the expected end state.
- Adding a single idempotent IF NOT EXISTS retry.

**Reason**
Two CI runs failed on the same statement:
`CREATE TABLE t1 ON CLUSTER 'test_cluster' (x INT) ENGINE=MergeTree() ORDER BY x`
- Run A: `Code: 32 ATTEMPT_TO_READ_AFTER_EOF` while ZooKeeper was repeatedly connecting/dropping.
- Run B: `Code: 159 TIMEOUT_EXCEEDED` after 10.5759s with the server stating the task will execute in the background.

This is a timing/race with ZK/DDL worker stabilization under CI resource jitter, not a product defect.

Closes https://github.com/ClickHouse/ClickHouse/issues/88328

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
