### PR TITLE
[do not merge] [experiment] [need ci run] assert database_name == database.getDatabaseName()

### DIFF
--- a/src/Databases/IDatabase.h
+++ b/src/Databases/IDatabase.h
@@ -437,11 +437,12 @@ public:
 
     virtual ~IDatabase();
 
+    String database_name TSA_GUARDED_BY(mutex);
+
 protected:
     virtual ASTPtr getCreateTableQueryImpl(const String & /*name*/, ContextPtr /*context*/, bool throw_on_error) const;
 
     mutable std::mutex mutex;
-    String database_name TSA_GUARDED_BY(mutex);
     String comment TSA_GUARDED_BY(mutex);
 };
 

--- a/src/Interpreters/DatabaseCatalog.cpp
+++ b/src/Interpreters/DatabaseCatalog.cpp
@@ -776,6 +776,7 @@ DatabasePtr DatabaseCatalog::getDatabase(const String & database_name) const
             backQuoteIfNeed(database_name),
             backQuoteIfNeed(names[0]));
     }
+    assert(database_name == db->getDatabaseName());
     return db;
 }
 
@@ -786,6 +787,7 @@ DatabasePtr DatabaseCatalog::tryGetDatabase(const String & database_name) const
     auto it = databases.find(database_name);
     if (it == databases.end())
         return {};
+    assert(database_name == it->second->getDatabaseName());
     return it->second;
 }
 

--- a/src/Interpreters/DatabaseCatalog.cpp
+++ b/src/Interpreters/DatabaseCatalog.cpp
@@ -776,7 +776,7 @@ DatabasePtr DatabaseCatalog::getDatabase(const String & database_name) const
             backQuoteIfNeed(database_name),
             backQuoteIfNeed(names[0]));
     }
-    assert(database_name == db->getDatabaseName());
+    chassert(database_name == db->getDatabaseName());
     return db;
 }
 
@@ -787,7 +787,7 @@ DatabasePtr DatabaseCatalog::tryGetDatabase(const String & database_name) const
     auto it = databases.find(database_name);
     if (it == databases.end())
         return {};
-    assert(database_name == it->second->getDatabaseName());
+    chassert(database_name == it->second->getDatabaseName());
     return it->second;
 }
 

--- a/src/Interpreters/DatabaseCatalog.cpp
+++ b/src/Interpreters/DatabaseCatalog.cpp
@@ -776,7 +776,7 @@ DatabasePtr DatabaseCatalog::getDatabase(const String & database_name) const
             backQuoteIfNeed(database_name),
             backQuoteIfNeed(names[0]));
     }
-    chassert(database_name == db->getDatabaseName());
+    chassert(database_name == TSA_SUPPRESS_WARNING_FOR_READ(db->database_name));
     return db;
 }
 
@@ -787,7 +787,7 @@ DatabasePtr DatabaseCatalog::tryGetDatabase(const String & database_name) const
     auto it = databases.find(database_name);
     if (it == databases.end())
         return {};
-    chassert(database_name == it->second->getDatabaseName());
+    chassert(database_name == TSA_SUPPRESS_WARNING_FOR_READ(it->second->database_name));
     return it->second;
 }
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

Just want to make sure that database object always has actual name, and we can trust it.
Currently, in most cases IDatabase.getDatabaseName() is not used after lookup in the catalog, so theoretically it can be incorrect/outdated/empty.

Need `can be tested` tag.