### PR TITLE
update numeric literals section in syntax reference to match code

### DIFF
--- a/docs/en/sql-reference/syntax.md
+++ b/docs/en/sql-reference/syntax.md
@@ -172,15 +172,32 @@ In string literals, you need to escape at least `'` and `\` using escape codes `
 
 Numeric literals are parsed as follows:
 
-- First, as a 64-bit signed number, using the [strtoull](https://en.cppreference.com/w/cpp/string/byte/strtoul) function.
-- If unsuccessful, as a 64-bit unsigned number, using the [strtoll](https://en.cppreference.com/w/cpp/string/byte/strtol) function.
-- If unsuccessful, as a floating-point number using the [strtod](https://en.cppreference.com/w/cpp/string/byte/strtof) function.
+- If the literal is prefixed with a minus sign `-`, the token is skipped and the result is negated after parsing.
+- The numeric literal is first parsed as a 64-bit unsigned integer, using the [strtoull](https://en.cppreference.com/w/cpp/string/byte/strtoul) function.
+  - If the value is prefixed with `0b` or `0x`/`0X`, the number is parsed as binary or hexadecimal, respectively.
+  - If the value is negative and the absolute magnitude is greater than 2<sup>63</sup>, an error is returned.
+- If unsuccessful, the value is next parsed as a floating-point number using the [strtod](https://en.cppreference.com/w/cpp/string/byte/strtof) function.
 - Otherwise, an error is returned.
 
 Literal values are cast to the smallest type that the value fits in.
 For example:
 - `1` is parsed as `UInt8`
 - `256` is parsed as `UInt16`. 
+
+:::note Important
+Integer values wider than 64-bit (`UInt128`, `Int128`, `UInt256`, `Int256`) must be cast to a larger type to parse properly:
+
+```sql
+-170141183460469231731687303715884105728::Int128
+340282366920938463463374607431768211455::UInt128
+-57896044618658097711785492504343953926634992332820282019728792003956564819968::Int256
+115792089237316195423570985008687907853269984665640564039457584007913129639935::UInt256
+```
+
+This bypasses the above algorithm and parses the integer with a routine that supports arbitrary precision.
+
+Otherwise, the literal will be parsed as a floating-point number and thus subject to loss of precision due to truncation.
+:::
 
 For more information, see [Data types](../sql-reference/data-types/index.md).
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->

https://github.com/ClickHouse/clickhouse-docs/issues/4553

I just did a deep dive through the ClickHouse code to get a better understanding of how integer literals are parsed for https://github.com/ClickHouse/clickhouse-rs/pull/322 and I noticed some discrepancies with the current documentation: https://github.com/ClickHouse/ClickHouse/blob/3886ed3398b2c2f4caf167879ab216b07fc9f0f1/docs/en/sql-reference/syntax.md?plain=1#L175-L178

1. I think `strtoull` and `strtoll` are swapped here, since the former parses _unsigned_ integers and the latter parses signed integers.
2. The code [only ever actually calls `strtoull`](https://github.com/ClickHouse/ClickHouse/blob/3886ed3398b2c2f4caf167879ab216b07fc9f0f1/src/Parsers/ExpressionElementParsers.cpp#L1020). For signed integers (edit: and even floats, I think), it eats the minus sign then parses the value as unsigned and casts to signed.
3. It doesn't mention that 128-bit and 256-bit literals actually need the cast operator to parse properly, which has confused some users: https://github.com/ClickHouse/ClickHouse/issues/61349, https://github.com/ClickHouse/ClickHouse/issues/38480
    * Casting causes the expression to be parsed using a completely different code path which ends up in [this routine](https://github.com/ClickHouse/ClickHouse/blob/3886ed3398b2c2f4caf167879ab216b07fc9f0f1/src/IO/readIntText.h#L26).

---

If we'd prefer not to make the description match _too_ closely to the code, in case those details change in the future, that's fine; I'd be happy to revert that part and just swap `strtoull` and `strtoll`. The more important part, and the reason I'm proposing this change, is the note about 128- and 256-bit literals.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):


### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
