### PR TITLE
Fix DatabaseReplicated to respect interserver_http_host config

### DIFF
--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -129,8 +129,9 @@ ZooKeeperPtr DatabaseReplicated::getZooKeeper() const
 
 static inline String getHostID(ContextPtr global_context, const UUID & db_uuid, bool secure)
 {
+    auto host_port = global_context->getInterserverIOAddress();
     UInt16 port = secure ? global_context->getTCPPortSecure().value_or(DBMS_DEFAULT_SECURE_PORT) : global_context->getTCPPort();
-    return Cluster::Address::toString(getFQDNOrHostName(), port) + ':' + toString(db_uuid);
+    return Cluster::Address::toString(host_port.first, port) + ':' + toString(db_uuid);
 }
 
 static inline UInt64 getMetadataHash(const String & table_name, const String & metadata)

--- a/tests/integration/test_replicated_database_interserver_host/configs/config.xml
+++ b/tests/integration/test_replicated_database_interserver_host/configs/config.xml
@@ -1,4 +1,5 @@
 <clickhouse>
+    <interserver_http_host>NODE_NAME</interserver_http_host>
     <interserver_http_port>9009</interserver_http_port>
     <async_load_databases>false</async_load_databases>
 </clickhouse>

--- a/tests/integration/test_replicated_database_interserver_host/configs/config.xml
+++ b/tests/integration/test_replicated_database_interserver_host/configs/config.xml
@@ -1,5 +1,4 @@
 <clickhouse>
     <interserver_http_port>9009</interserver_http_port>
-    <interserver_http_host>127.0.0.1</interserver_http_host>
     <async_load_databases>false</async_load_databases>
 </clickhouse>

--- a/tests/integration/test_replicated_database_interserver_host/configs/config.xml
+++ b/tests/integration/test_replicated_database_interserver_host/configs/config.xml
@@ -1,0 +1,5 @@
+<clickhouse>
+    <interserver_http_port>9009</interserver_http_port>
+    <interserver_http_host>127.0.0.1</interserver_http_host>
+    <async_load_databases>false</async_load_databases>
+</clickhouse>

--- a/tests/integration/test_replicated_database_interserver_host/test.py
+++ b/tests/integration/test_replicated_database_interserver_host/test.py
@@ -23,6 +23,41 @@ node2 = cluster.add_instance(
 def started_cluster():
     try:
         cluster.start()
+
+        # Replace NODE_NAME placeholder with actual IP addresses in config
+        import os
+        config_path = os.path.join(
+            os.path.dirname(__file__), "configs/config.xml"
+        )
+
+        for node in [node1, node2]:
+            config_content = open(config_path).read()
+            config_content = config_content.replace("NODE_NAME", node.ip_address)
+
+            # Debug: print the config and IP address
+            print(f"Configuring {node.name} with IP {node.ip_address}")
+            print(f"Config content:\n{config_content}")
+
+            node.exec_in_container(
+                ["bash", "-c", 'echo "${NEW_CONFIG}" > /etc/clickhouse-server/config.d/interserver_host.xml'],
+                environment={"NEW_CONFIG": config_content},
+            )
+
+            # Verify the file was written
+            result = node.exec_in_container(
+                ["cat", "/etc/clickhouse-server/config.d/interserver_host.xml"]
+            )
+            print(f"Verification - Config file on {node.name}:\n{result}")
+
+            # IMPORTANT: interserver_http_host is only loaded at startup, not by SYSTEM RELOAD CONFIG
+            # So we need to restart ClickHouse
+            print(f"Restarting ClickHouse on {node.name} to apply interserver_http_host config...")
+            node.restart_clickhouse()
+
+            # Verify the setting was applied
+            interserver_host = node.query("SELECT value FROM system.server_settings WHERE name = 'interserver_http_host'")
+            print(f"Verification - interserver_http_host setting on {node.name}: {interserver_host}")
+
         yield cluster
     finally:
         cluster.shutdown()

--- a/tests/integration/test_replicated_database_interserver_host/test.py
+++ b/tests/integration/test_replicated_database_interserver_host/test.py
@@ -9,6 +9,7 @@ node1 = cluster.add_instance(
     main_configs=["configs/config.xml"],
     with_zookeeper=True,
     macros={"replica": "node1"},
+    stay_alive=True,
 )
 
 node2 = cluster.add_instance(
@@ -16,6 +17,7 @@ node2 = cluster.add_instance(
     main_configs=["configs/config.xml"],
     with_zookeeper=True,
     macros={"replica": "node2"},
+    stay_alive=True,
 )
 
 

--- a/tests/integration/test_replicated_database_interserver_host/test.py
+++ b/tests/integration/test_replicated_database_interserver_host/test.py
@@ -1,0 +1,88 @@
+import pytest
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+
+node1 = cluster.add_instance(
+    "node1",
+    main_configs=["configs/config.xml"],
+    with_zookeeper=True,
+    macros={"replica": "node1"},
+)
+
+node2 = cluster.add_instance(
+    "node2",
+    main_configs=["configs/config.xml"],
+    with_zookeeper=True,
+    macros={"replica": "node2"},
+)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_replicated_database_uses_interserver_host(started_cluster):
+    """
+    Test that DatabaseReplicated uses interserver_http_host configuration
+    for replica registration in ZooKeeper instead of hostname.
+
+    This verifies the fix for issue #88361 where using IP addresses
+    in interserver_http_host should result in IP-based registration
+    in ZooKeeper, not hostname-based.
+    """
+
+    # Create replicated database on node1
+    node1.query(
+        "CREATE DATABASE test_db ENGINE = Replicated('/clickhouse/databases/test_db', 'shard1', 'node1')"
+    )
+
+    # Create replicated database on node2
+    node2.query(
+        "CREATE DATABASE test_db ENGINE = Replicated('/clickhouse/databases/test_db', 'shard1', 'node2')"
+    )
+
+    # Wait for both replicas to appear
+    node1.query("SYSTEM SYNC DATABASE REPLICA test_db")
+    node2.query("SYSTEM SYNC DATABASE REPLICA test_db")
+
+    # Check ZooKeeper to verify replicas are registered with IP address (127.0.0.1)
+    # not with hostname
+    zk_path = "/clickhouse/databases/test_db/replicas"
+    replicas = node1.query(
+        f"SELECT name, value FROM system.zookeeper WHERE path = '{zk_path}'"
+    )
+
+    # The replica value should contain '127.0.0.1' from interserver_http_host config
+    # not the container hostname like 'node1' or 'node2'
+    assert "127.0.0.1" in replicas, f"Expected IP address 127.0.0.1 in replica registration, got: {replicas}"
+
+    # Verify that hostname is NOT used
+    assert "node1" not in replicas or "127.0.0.1" in replicas, f"Hostname should not be used when interserver_http_host is set, got: {replicas}"
+
+    # Create a table on node1 and verify it replicates to node2
+    node1.query("CREATE TABLE test_db.test_table (id UInt32) ENGINE = ReplicatedMergeTree ORDER BY id")
+
+    # Wait for replication
+    node2.query("SYSTEM SYNC DATABASE REPLICA test_db")
+
+    # Verify table exists on node2
+    tables_on_node2 = node2.query("SHOW TABLES FROM test_db")
+    assert "test_table" in tables_on_node2, "Table should be replicated to node2"
+
+    # Insert data on node1
+    node1.query("INSERT INTO test_db.test_table VALUES (1), (2), (3)")
+
+    # Verify data replicates to node2
+    node2.query("SYSTEM SYNC REPLICA test_db.test_table")
+    count_on_node2 = node2.query("SELECT count() FROM test_db.test_table")
+    assert count_on_node2.strip() == "3", f"Expected 3 rows on node2, got: {count_on_node2}"
+
+    # Cleanup
+    node1.query("DROP DATABASE test_db SYNC")
+    node2.query("DROP DATABASE test_db SYNC")

--- a/tests/integration/test_replicated_database_interserver_host/test.py
+++ b/tests/integration/test_replicated_database_interserver_host/test.py
@@ -1,4 +1,5 @@
 import pytest
+import urllib.parse
 from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
@@ -28,61 +29,40 @@ def started_cluster():
 
 
 def test_replicated_database_uses_interserver_host(started_cluster):
-    """
-    Test that DatabaseReplicated uses interserver_http_host configuration
-    for replica registration in ZooKeeper instead of hostname.
+    """Test that DatabaseReplicated uses interserver_http_host for replica registration."""
 
-    This verifies the fix for issue #88361 where using IP addresses
-    in interserver_http_host should result in IP-based registration
-    in ZooKeeper, not hostname-based.
-    """
-
-    # Create replicated database on node1
     node1.query(
         "CREATE DATABASE test_db ENGINE = Replicated('/clickhouse/databases/test_db', 'shard1', 'node1')"
     )
-
-    # Create replicated database on node2
     node2.query(
         "CREATE DATABASE test_db ENGINE = Replicated('/clickhouse/databases/test_db', 'shard1', 'node2')"
     )
 
-    # Wait for both replicas to appear
     node1.query("SYSTEM SYNC DATABASE REPLICA test_db")
     node2.query("SYSTEM SYNC DATABASE REPLICA test_db")
 
-    # Check ZooKeeper to verify replicas are registered with IP address (127.0.0.1)
-    # not with hostname
     zk_path = "/clickhouse/databases/test_db/replicas"
     replicas = node1.query(
         f"SELECT name, value FROM system.zookeeper WHERE path = '{zk_path}'"
     )
+    replicas_decoded = urllib.parse.unquote(replicas)
 
-    # The replica value should contain '127.0.0.1' from interserver_http_host config
-    # not the container hostname like 'node1' or 'node2'
-    assert "127.0.0.1" in replicas, f"Expected IP address 127.0.0.1 in replica registration, got: {replicas}"
+    assert "127.0.0.1" in replicas_decoded, \
+        f"Expected IP address 127.0.0.1 in replica registration, got: {replicas}"
+    assert "node1" not in replicas_decoded and "node2" not in replicas_decoded, \
+        "Hostname should not be used when interserver_http_host is set"
 
-    # Verify that hostname is NOT used
-    assert "node1" not in replicas or "127.0.0.1" in replicas, f"Hostname should not be used when interserver_http_host is set, got: {replicas}"
-
-    # Create a table on node1 and verify it replicates to node2
     node1.query("CREATE TABLE test_db.test_table (id UInt32) ENGINE = ReplicatedMergeTree ORDER BY id")
-
-    # Wait for replication
     node2.query("SYSTEM SYNC DATABASE REPLICA test_db")
 
-    # Verify table exists on node2
     tables_on_node2 = node2.query("SHOW TABLES FROM test_db")
-    assert "test_table" in tables_on_node2, "Table should be replicated to node2"
+    assert "test_table" in tables_on_node2
 
-    # Insert data on node1
     node1.query("INSERT INTO test_db.test_table VALUES (1), (2), (3)")
-
-    # Verify data replicates to node2
     node2.query("SYSTEM SYNC REPLICA test_db.test_table")
-    count_on_node2 = node2.query("SELECT count() FROM test_db.test_table")
-    assert count_on_node2.strip() == "3", f"Expected 3 rows on node2, got: {count_on_node2}"
 
-    # Cleanup
+    count_on_node2 = node2.query("SELECT count() FROM test_db.test_table")
+    assert count_on_node2.strip() == "3"
+
     node1.query("DROP DATABASE test_db SYNC")
     node2.query("DROP DATABASE test_db SYNC")

--- a/tests/integration/test_replicated_database_interserver_host/test.py
+++ b/tests/integration/test_replicated_database_interserver_host/test.py
@@ -42,15 +42,13 @@ def test_replicated_database_uses_interserver_host(started_cluster):
     node2.query("SYSTEM SYNC DATABASE REPLICA test_db")
 
     zk_path = "/clickhouse/databases/test_db/replicas"
-    replicas = node1.query(
-        f"SELECT name, value FROM system.zookeeper WHERE path = '{zk_path}'"
+    host_ids = node1.query(
+        f"SELECT value FROM system.zookeeper WHERE path = '{zk_path}'"
     )
-    replicas_decoded = urllib.parse.unquote(replicas)
+    host_ids_decoded = urllib.parse.unquote(host_ids)
 
-    assert "127.0.0.1" in replicas_decoded, \
-        f"Expected IP address 127.0.0.1 in replica registration, got: {replicas}"
-    assert "node1" not in replicas_decoded and "node2" not in replicas_decoded, \
-        "Hostname should not be used when interserver_http_host is set"
+    assert "127.0.0.1:9000:" in host_ids_decoded, \
+        f"Expected IP address 127.0.0.1:9000: in host_id, got: {host_ids}"
 
     node1.query("CREATE TABLE test_db.test_table (id UInt32) ENGINE = ReplicatedMergeTree ORDER BY id")
     node2.query("SYSTEM SYNC DATABASE REPLICA test_db")

--- a/tests/integration/test_replicated_database_interserver_host/test.py
+++ b/tests/integration/test_replicated_database_interserver_host/test.py
@@ -47,8 +47,13 @@ def test_replicated_database_uses_interserver_host(started_cluster):
     )
     host_ids_decoded = urllib.parse.unquote(host_ids)
 
-    assert "127.0.0.1:9000:" in host_ids_decoded, \
-        f"Expected IP address 127.0.0.1:9000: in host_id, got: {host_ids}"
+    # Verify that IP addresses are used instead of hostnames
+    assert "node1" not in host_ids_decoded and "node2" not in host_ids_decoded, \
+        f"Expected IP addresses instead of hostnames, got: {host_ids_decoded}"
+
+    # Verify that TCP port (9000) is used, not interserver_http_port (9009)
+    assert ":9000:" in host_ids_decoded, \
+        f"Expected TCP port 9000 in host_id, got: {host_ids_decoded}"
 
     node1.query("CREATE TABLE test_db.test_table (id UInt32) ENGINE = ReplicatedMergeTree ORDER BY id")
     node2.query("SYSTEM SYNC DATABASE REPLICA test_db")


### PR DESCRIPTION
DatabaseReplicated ignored interserver_http_host when registering replicas in ZooKeeper, always using hostname instead. This prevented node replacements with same IP but different hostname from connecting to existing databases.

Now uses getInterserverIOAddress() like StorageReplicatedMergeTree does.

Fixes #88361

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)



### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed DatabaseReplicated to respect `interserver_http_host` configuration.

