### PR TITLE
Add prefilter by uuid column in system.tables

### DIFF
--- a/tests/queries/0_stateless/03656_system_tables_uuid.reference
+++ b/tests/queries/0_stateless/03656_system_tables_uuid.reference
@@ -1,0 +1,1 @@
+default	test

--- a/tests/queries/0_stateless/03656_system_tables_uuid.sh
+++ b/tests/queries/0_stateless/03656_system_tables_uuid.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT -q "create table test (key Int) engine=Null"
+uuid=$($CLICKHOUSE_CLIENT -q "select uuid from system.tables where name = 'test' and database = '$CLICKHOUSE_DATABASE'")
+$CLICKHOUSE_CLIENT -q "select database, name from system.tables where uuid = '$uuid'"


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Avoid full scan for `system.tables` with filter by `uuid` (Can be useful if you have only UUID from logs or zookeeper path)