### PR TITLE
Disable positional arguments when defining projections

### DIFF
--- a/tests/queries/0_stateless/03651_positional_argument_agg_projection.sql
+++ b/tests/queries/0_stateless/03651_positional_argument_agg_projection.sql
@@ -1,0 +1,20 @@
+DROP TABLE IF EXISTS test;
+
+CREATE TABLE test
+(
+    `a` UInt64,
+    `b` String
+)
+ENGINE = MergeTree
+ORDER BY a;
+
+ALTER TABLE test
+    ADD PROJECTION test_projection
+    (
+        SELECT
+            0 AS bug,
+            max(a)
+        GROUP BY bug
+    );
+
+DROP TABLE test;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Positional arguments are now explicitly disabled in the context of defining Projections, as they are not sensible in this internal query stage. This fixes #48604 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
