### PR TITLE
Add `--proto-caps` option to `clickhouse-benchmark`

### DIFF
--- a/docs/en/interfaces/cli.md
+++ b/docs/en/interfaces/cli.md
@@ -870,6 +870,13 @@ Default value: default
 
 Instead of the `--host`, `--port`, `--user` and `--password` options, the client also supports [connection strings](#connection_string).
 
+
+**`--proto-caps <value>`** 
+
+Enable/disable chunking in data transfer. 
+
+choices: `chunked_optional`, `notchunked,` `notchunked_optional,` `send_chunked,` `send_chunked_optional`, `send_notchunked`, `send_notchunked_optional`, `recv_chunked`, `recv_chunked_optional`, `recv_notchunked`, `recv_notchunked_optional`. 
+
 ### Query options {#command-line-options-query}
 
 **`--param_<name>=<value>`**

--- a/docs/en/interfaces/cli.md
+++ b/docs/en/interfaces/cli.md
@@ -877,6 +877,11 @@ Enable/disable chunking in data transfer.
 
 choices: `chunked_optional`, `notchunked,` `notchunked_optional,` `send_chunked,` `send_chunked_optional`, `send_notchunked`, `send_notchunked_optional`, `recv_chunked`, `recv_chunked_optional`, `recv_notchunked`, `recv_notchunked_optional`. 
 
+To have different options for send and receive, choices can be comma-separated:
+```bash
+$ clickhouse-client --proto-caps send_chunked_optional,recv_notchunked --query "SELECT 1"
+```
+
 ### Query options {#command-line-options-query}
 
 **`--param_<name>=<value>`**

--- a/docs/en/interfaces/cli.md
+++ b/docs/en/interfaces/cli.md
@@ -870,12 +870,11 @@ Default value: default
 
 Instead of the `--host`, `--port`, `--user` and `--password` options, the client also supports [connection strings](#connection_string).
 
+**`--proto-caps <value>`**  
 
-**`--proto-caps <value>`** 
+Enable/disable chunking in data transfer.  
 
-Enable/disable chunking in data transfer. 
-
-choices: `chunked_optional`, `notchunked,` `notchunked_optional,` `send_chunked,` `send_chunked_optional`, `send_notchunked`, `send_notchunked_optional`, `recv_chunked`, `recv_chunked_optional`, `recv_notchunked`, `recv_notchunked_optional`. 
+choices: `chunked_optional`, `notchunked`, `notchunked_optional`, `send_chunked`, `send_chunked_optional`, `send_notchunked`, `send_notchunked_optional`, `recv_chunked`, `recv_chunked_optional`, `recv_notchunked`, `recv_notchunked_optional`.  
 
 To have different options for send and receive, choices can be comma-separated:
 ```bash

--- a/docs/en/operations/utilities/clickhouse-benchmark.md
+++ b/docs/en/operations/utilities/clickhouse-benchmark.md
@@ -65,10 +65,11 @@ clickhouse-benchmark [keys] < queries_file;
 - `--stacktrace` — Stack traces output. When the key is set, `clickhouse-bencmark` outputs stack traces of exceptions.
 - `--stage=WORD` — Query processing stage at server. ClickHouse stops query processing and returns an answer to `clickhouse-benchmark` at the specified stage. Possible values: `complete`, `fetch_columns`, `with_mergeable_state`. Default value: `complete`.
 - `--roundrobin` — Instead of comparing queries for different `--host`/`--port` just pick one random `--host`/`--port` for every query and send query to it.
-- `--reconnect=N` - Control reconnection behaviour. Possible values 0 (never reconnect), 1 (reconnect for every query), or N (reconnect after every N queries). Default value: 0.
+- `--reconnect=N` — Control reconnection behaviour. Possible values 0 (never reconnect), 1 (reconnect for every query), or N (reconnect after every N queries). Default value: 0.
 - `--max-consecutive-errors=N` — Number of allowed consecutive errors. Default value: 0.
 - `--ignore-error`,`--continue_on_errors` — Continue testing even if queries failed.
 - `--client-side-time` — Display the time including network communication instead of server-side time; Note that for server versions before 22.8 we always display client-side time.
+- `--proto-caps` — Enable/disable chunking in data transfer. choices: `chunked_optional`, `notchunked,` `notchunked_optional,` `send_chunked,` `send_chunked_optional`, `send_notchunked`, `send_notchunked_optional`, `recv_chunked`, `recv_chunked_optional`, `recv_notchunked`, `recv_notchunked_optional`. Default value: `notchunked`.
 - `--help` — Shows the help message.
 - `--verbose` — Increase help message verbosity.
 

--- a/docs/en/operations/utilities/clickhouse-benchmark.md
+++ b/docs/en/operations/utilities/clickhouse-benchmark.md
@@ -69,7 +69,7 @@ clickhouse-benchmark [keys] < queries_file;
 - `--max-consecutive-errors=N` — Number of allowed consecutive errors. Default value: 0.
 - `--ignore-error`,`--continue_on_errors` — Continue testing even if queries failed.
 - `--client-side-time` — Display the time including network communication instead of server-side time; Note that for server versions before 22.8 we always display client-side time.
-- `--proto-caps` — Enable/disable chunking in data transfer. choices (can be comma-separated): `chunked_optional`, `notchunked,` `notchunked_optional,` `send_chunked,` `send_chunked_optional`, `send_notchunked`, `send_notchunked_optional`, `recv_chunked`, `recv_chunked_optional`, `recv_notchunked`, `recv_notchunked_optional`. Default value: `notchunked`.
+- `--proto-caps` — Enable/disable chunking in data transfer. choices (can be comma-separated): `chunked_optional`, `notchunked`, `notchunked_optional`, `send_chunked`, `send_chunked_optional`, `send_notchunked`, `send_notchunked_optional`, `recv_chunked`, `recv_chunked_optional`, `recv_notchunked`, `recv_notchunked_optional`. Default value: `notchunked`.
 - `--help` — Shows the help message.
 - `--verbose` — Increase help message verbosity.
 

--- a/docs/en/operations/utilities/clickhouse-benchmark.md
+++ b/docs/en/operations/utilities/clickhouse-benchmark.md
@@ -69,7 +69,7 @@ clickhouse-benchmark [keys] < queries_file;
 - `--max-consecutive-errors=N` — Number of allowed consecutive errors. Default value: 0.
 - `--ignore-error`,`--continue_on_errors` — Continue testing even if queries failed.
 - `--client-side-time` — Display the time including network communication instead of server-side time; Note that for server versions before 22.8 we always display client-side time.
-- `--proto-caps` — Enable/disable chunking in data transfer. choices: `chunked_optional`, `notchunked,` `notchunked_optional,` `send_chunked,` `send_chunked_optional`, `send_notchunked`, `send_notchunked_optional`, `recv_chunked`, `recv_chunked_optional`, `recv_notchunked`, `recv_notchunked_optional`. Default value: `notchunked`.
+- `--proto-caps` — Enable/disable chunking in data transfer. choices (can be comma-separated): `chunked_optional`, `notchunked,` `notchunked_optional,` `send_chunked,` `send_chunked_optional`, `send_notchunked`, `send_notchunked_optional`, `recv_chunked`, `recv_chunked_optional`, `recv_notchunked`, `recv_notchunked_optional`. Default value: `notchunked`.
 - `--help` — Shows the help message.
 - `--verbose` — Increase help message verbosity.
 

--- a/programs/benchmark/Benchmark.cpp
+++ b/programs/benchmark/Benchmark.cpp
@@ -871,7 +871,7 @@ int mainEntryClickHouseBenchmark(int argc, char ** argv)
             ("ignore-error,continue_on_errors", "continue testing even if a query fails")
             ("reconnect", value<size_t>()->default_value(0), "control reconnection behaviour: 0 (never reconnect), 1 (reconnect for every query), or N (reconnect after every N queries)")
             ("client-side-time", "display the time including network communication instead of server-side time; note that for server versions before 22.8 we always display client-side time")
-            ("proto_caps", value<std::string>(), "Enable/disable chunked protocol: chunked_optional, notchunked, notchunked_optional, send_chunked, send_chunked_optional, send_notchunked, send_notchunked_optional, recv_chunked, recv_chunked_optional, recv_notchunked, recv_notchunked_optional")
+            ("proto_caps", value<std::string>(), "Enable/disable chunked protocol (comma-separated): chunked_optional, notchunked, notchunked_optional, send_chunked, send_chunked_optional, send_notchunked, send_notchunked_optional, recv_chunked, recv_chunked_optional, recv_notchunked, recv_notchunked_optional")
         ;
 
         Settings settings;

--- a/programs/benchmark/Benchmark.cpp
+++ b/programs/benchmark/Benchmark.cpp
@@ -871,6 +871,7 @@ int mainEntryClickHouseBenchmark(int argc, char ** argv)
             ("ignore-error,continue_on_errors", "continue testing even if a query fails")
             ("reconnect", value<size_t>()->default_value(0), "control reconnection behaviour: 0 (never reconnect), 1 (reconnect for every query), or N (reconnect after every N queries)")
             ("client-side-time", "display the time including network communication instead of server-side time; note that for server versions before 22.8 we always display client-side time")
+            ("proto_caps", value<std::string>(), "Enable/disable chunked protocol: chunked_optional, notchunked, notchunked_optional, send_chunked, send_chunked_optional, send_notchunked, send_notchunked_optional, recv_chunked, recv_chunked_optional, recv_notchunked, recv_notchunked_optional")
         ;
 
         Settings settings;

--- a/tests/queries/0_stateless/03653_benchmark_proto_caps_option.reference
+++ b/tests/queries/0_stateless/03653_benchmark_proto_caps_option.reference
@@ -1,0 +1,3 @@
+Queries executed: 1.
+Queries executed: 1.
+Queries executed: 1.

--- a/tests/queries/0_stateless/03653_benchmark_proto_caps_option.sh
+++ b/tests/queries/0_stateless/03653_benchmark_proto_caps_option.sh
@@ -3,7 +3,8 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../shell_config.sh
 
+$CLICKHOUSE_BENCHMARK --proto-caps bad_value -i 1 --query "SELECT 1" |& grep -v 'proto_caps option is incorrect (bad_value)'
+
 $CLICKHOUSE_BENCHMARK --proto-caps notchunked -i 1 --query "SELECT 1" |& grep -F 'Queries executed'
 $CLICKHOUSE_BENCHMARK --proto-caps recv_notchunked,send_notchunked -i 1 --query "SELECT 1" |& grep -F 'Queries executed'
 $CLICKHOUSE_BENCHMARK --proto-caps recv_chunked,send_chunked,recv_chunked_optional,send_notchunked_optional -i 1 --query "SELECT 1" |& grep -F 'Queries executed'
-$CLICKHOUSE_BENCHMARK --proto-caps bad_value -i 1 --query "SELECT 1" |& grep -v 'proto_caps option is incorrect (bad_value)'

--- a/tests/queries/0_stateless/03653_benchmark_proto_caps_option.sh
+++ b/tests/queries/0_stateless/03653_benchmark_proto_caps_option.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. "$CURDIR"/../shell_config.sh
+
+$CLICKHOUSE_BENCHMARK --proto-caps notchunked -i 1 --query "SELECT 1" |& grep -F 'Queries executed'
+$CLICKHOUSE_BENCHMARK --proto-caps recv_notchunked,send_notchunked -i 1 --query "SELECT 1" |& grep -F 'Queries executed'
+$CLICKHOUSE_BENCHMARK --proto-caps recv_chunked,send_chunked,recv_chunked_optional,send_notchunked_optional -i 1 --query "SELECT 1" |& grep -F 'Queries executed'
+$CLICKHOUSE_BENCHMARK --proto-caps bad_value -i 1 --query "SELECT 1" |& grep -v 'proto_caps option is incorrect (bad_value)'


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

closes: #88394 