### PR TITLE
tests: fix 03403_distributed_merge_two_level_aggregation flakiness

### DIFF
--- a/tests/queries/0_stateless/03403_distributed_merge_two_level_aggregation.sql
+++ b/tests/queries/0_stateless/03403_distributed_merge_two_level_aggregation.sql
@@ -33,7 +33,7 @@ SELECT
 FROM remote('127.0.0.{1,1}', currentDatabase(), merge_test_table)
 GROUP BY 1
 FORMAT Null
-SETTINGS distributed_aggregation_memory_efficient = 1, max_threads = 4, optimize_aggregation_in_order = 0, prefer_localhost_replica = 1, async_socket_for_remote = 1, enable_analyzer = 0, enable_producing_buckets_out_of_order_in_aggregation = 0, enable_memory_bound_merging_of_aggregation_results = 0;
+SETTINGS distributed_aggregation_memory_efficient = 1, max_threads = 4, optimize_aggregation_in_order = 0, prefer_localhost_replica = 1, async_socket_for_remote = 1, enable_analyzer = 0, enable_producing_buckets_out_of_order_in_aggregation = 0, enable_memory_bound_merging_of_aggregation_results = 0, max_memory_usage='500Mi', group_by_two_level_threshold=1e6, group_by_two_level_threshold_bytes='500Mi';
 
 DROP TABLE merge_test_table;
 DROP TABLE dist_test_table_1;


### PR DESCRIPTION
CI: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=88379&sha=c06709215b3493ee8a3a74079e339a8e0d77cb45&name_0=PR&name_1=Stateless%20tests%20%28arm_binary%2C%20parallel%29

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Follow-up for: #87687 (cc: @nickitat @c-end)