### PR TITLE
tests: avoid using global SYSTEM FLUSH LOGS

### DIFF
--- a/ci/jobs/scripts/check_style/various_checks.sh
+++ b/ci/jobs/scripts/check_style/various_checks.sh
@@ -95,3 +95,5 @@ find $ROOT_PATH/{base,src,programs,utils,docs} -name '*.md' -or -name '*.h' -or 
 # Check for misuse of timeout in .sh tests
 find $ROOT_PATH/tests/queries -name '*.sh' | grep -vP '02835_drop_user_during_session|02922_deduplication_with_zero_copy|00738_lock_for_inner_table|shared_merge_tree|_sc_' |
     xargs grep -l -P 'export -f' | xargs grep -l -F 'timeout' && echo ".sh tests cannot use the 'timeout' command, because it leads to race conditions, when the timeout is expired, and waiting for the command is done, but the server still runs some queries"
+
+find $ROOT_PATH/tests/queries -iname '*.sql' -or -iname '*.sh' -or -iname '*.py' -or -iname '*.j2' | xargs grep --with-filename -i -E -e 'system\s*flush\s*logs\s*(;|$|")' && echo "Please use SYSTEM FLUSH LOGS log_name over global SYSTEM FLUSH LOGS"

--- a/tests/queries/0_stateless/01198_client_quota_key.sh
+++ b/tests/queries/0_stateless/01198_client_quota_key.sh
@@ -5,4 +5,4 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
-$CLICKHOUSE_CLIENT --quota_key Hello --query_id test_quota_key --log_queries 1 --query "SELECT 1; SYSTEM FLUSH LOGS query_log; SELECT DISTINCT quota_key FROM system.query_log WHERE current_database = currentDatabase() AND event_date >= yesterday() AND event_time >= now() - 300 AND query_id = 'test_quota_key'"
+$CLICKHOUSE_CLIENT --quota_key Hello --query_id test_quota_key-$CLICKHOUSE_DATABASE --log_queries 1 --query "SELECT 1; SYSTEM FLUSH LOGS query_log; SELECT DISTINCT quota_key FROM system.query_log WHERE current_database = currentDatabase() AND event_date >= yesterday() AND event_time >= now() - 300 AND query_id = 'test_quota_key-$CLICKHOUSE_DATABASE'"

--- a/tests/queries/0_stateless/01198_client_quota_key.sh
+++ b/tests/queries/0_stateless/01198_client_quota_key.sh
@@ -5,4 +5,4 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
-$CLICKHOUSE_CLIENT --quota_key Hello --query_id test_quota_key --log_queries 1 --query "SELECT 1; SYSTEM FLUSH LOGS; SELECT DISTINCT quota_key FROM system.query_log WHERE current_database = currentDatabase() AND event_date >= yesterday() AND event_time >= now() - 300 AND query_id = 'test_quota_key'"
+$CLICKHOUSE_CLIENT --quota_key Hello --query_id test_quota_key --log_queries 1 --query "SELECT 1; SYSTEM FLUSH LOGS query_log; SELECT DISTINCT quota_key FROM system.query_log WHERE current_database = currentDatabase() AND event_date >= yesterday() AND event_time >= now() - 300 AND query_id = 'test_quota_key'"

--- a/tests/queries/0_stateless/02903_rmt_retriable_merge_exception.sh
+++ b/tests/queries/0_stateless/02903_rmt_retriable_merge_exception.sh
@@ -63,7 +63,7 @@ for _ in {0..50}; do
     if [[ $no_active_repilica_messages -gt 0 ]]; then
         break
     fi
-    # too frequent "system flush logs" causes troubles
+    # too frequent "system flush logs text_log" causes troubles
     sleep 1
 done
 

--- a/tests/queries/0_stateless/02906_force_optimize_projection_name.sql
+++ b/tests/queries/0_stateless/02906_force_optimize_projection_name.sql
@@ -26,7 +26,7 @@ SELECT name FROM test SETTINGS force_optimize_projection_name='projection_name';
 INSERT INTO test SELECT number, 'test' FROM numbers(1, 100) SETTINGS force_optimize_projection_name='projection_name';
 SELECT 1 SETTINGS force_optimize_projection_name='projection_name';
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SELECT read_rows FROM system.query_log
 WHERE current_database = currentDatabase()

--- a/tests/queries/0_stateless/02992_all_columns_should_have_comment.sql
+++ b/tests/queries/0_stateless/02992_all_columns_should_have_comment.sql
@@ -1,4 +1,4 @@
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS /* all tables */;
 SELECT 'Column ' || name || ' from table ' || concat(database, '.', table) || ' should have a comment'
 FROM system.columns
 WHERE (database = 'system') AND

--- a/tests/queries/0_stateless/03096_order_by_system_tables.sql
+++ b/tests/queries/0_stateless/03096_order_by_system_tables.sql
@@ -1,4 +1,4 @@
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS /* all tables */;
 
 -- Check for system tables which have non-default sorting key
 WITH

--- a/tests/queries/0_stateless/03100_lwu_01_basics.sql
+++ b/tests/queries/0_stateless/03100_lwu_01_basics.sql
@@ -36,7 +36,7 @@ ALTER TABLE t_shared APPLY PATCHES SETTINGS mutations_sync = 2;
 SELECT * FROM t_shared ORDER BY id;
 SELECT name, rows FROM system.parts WHERE database = currentDatabase() AND table = 't_shared' ORDER BY name;
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SELECT ProfileEvents['ReadTasksWithAppliedPatches']
 FROM system.query_log

--- a/tests/queries/0_stateless/03100_lwu_03_join.sql
+++ b/tests/queries/0_stateless/03100_lwu_03_join.sql
@@ -1,4 +1,4 @@
--- Tags: no-parallel-replicas, no-replicated-database
+-- Tags: no-parallel-replicas, no-replicated-database, long
 -- no-parallel-replicas: profile events may differ with parallel replicas.
 -- no-replicated-database: fails due to additional shard.
 

--- a/tests/queries/0_stateless/03100_lwu_03_join.sql
+++ b/tests/queries/0_stateless/03100_lwu_03_join.sql
@@ -39,7 +39,7 @@ SELECT * FROM t_shared ORDER BY id;
 
 DROP TABLE t_shared SYNC;
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SELECT mapSort(mapFilter((k, v) -> k IN ('ReadTasksWithAppliedPatches', 'PatchesAppliedInAllReadTasks', 'PatchesMergeAppliedInAllReadTasks', 'PatchesJoinAppliedInAllReadTasks'), ProfileEvents))
 FROM system.query_log

--- a/tests/queries/0_stateless/03100_lwu_23_apply_patches.sql
+++ b/tests/queries/0_stateless/03100_lwu_23_apply_patches.sql
@@ -1,4 +1,4 @@
--- Tags: no-replicated-database
+-- Tags: no-replicated-database, long
 -- Tag no-replicated-database: profile events for mutations may differ because of additional replicas.
 
 DROP TABLE IF EXISTS t_apply_patches SYNC;

--- a/tests/queries/0_stateless/03100_lwu_23_apply_patches.sql
+++ b/tests/queries/0_stateless/03100_lwu_23_apply_patches.sql
@@ -30,7 +30,7 @@ ALTER TABLE t_apply_patches APPLY PATCHES;
 
 SELECT b, c, count() FROM t_apply_patches GROUP BY b, c ORDER BY b, c SETTINGS apply_patch_parts = 0;
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS part_log;
 
 SELECT
     ProfileEvents['MutationSomePartColumns'],
@@ -62,7 +62,7 @@ ALTER TABLE t_apply_patches_smt APPLY PATCHES;
 
 SELECT b, c, count() FROM t_apply_patches GROUP BY b, c ORDER BY b, c SETTINGS apply_patch_parts = 0;
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS part_log;
 
 SELECT
     ProfileEvents['MutationSomePartColumns'],

--- a/tests/queries/0_stateless/03100_lwu_35_lock_profile_events.sql
+++ b/tests/queries/0_stateless/03100_lwu_35_lock_profile_events.sql
@@ -12,7 +12,7 @@ INSERT INTO t_lwu_lock_profile_events SELECT number FROM numbers(100000);
 DELETE FROM t_lwu_lock_profile_events WHERE id < 10000;
 
 SELECT count() FROM t_lwu_lock_profile_events;
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SELECT ProfileEvents['PatchesAcquireLockTries'], ProfileEvents['PatchesAcquireLockMicroseconds'] > 0
 FROM system.query_log

--- a/tests/queries/0_stateless/03100_lwu_deletes_4_index.sql
+++ b/tests/queries/0_stateless/03100_lwu_deletes_4_index.sql
@@ -16,7 +16,7 @@ SET lightweight_delete_mode = 'lightweight_update_force';
 DELETE FROM t_lwd_index WHERE id = 200;
 DELETE FROM t_lwd_index WHERE id IN (100, 110, 120, 130);
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SELECT read_rows FROM system.query_log
 WHERE type = 'QueryFinish' AND query like 'DELETE FROM t_lwd_index%' AND current_database = currentDatabase()

--- a/tests/queries/0_stateless/03100_lwu_deletes_5_vertical_merge.sql
+++ b/tests/queries/0_stateless/03100_lwu_deletes_5_vertical_merge.sql
@@ -37,7 +37,7 @@ OPTIMIZE TABLE t_lwu_deletes_vertical FINAL;
 SELECT count() FROM t_lwu_deletes_vertical;
 SELECT count() FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_lwu_deletes_vertical' AND active AND partition_id = 'all' AND column = '_row_exists';
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS part_log;
 
 SELECT
     merge_algorithm,

--- a/tests/queries/0_stateless/03221_mutation_analyzer_skip_part.sh
+++ b/tests/queries/0_stateless/03221_mutation_analyzer_skip_part.sh
@@ -23,7 +23,7 @@ ${CLICKHOUSE_CLIENT} --query "
 # Mutation query may return before the entry is added to part log.
 # So, we may have to retry the flush of logs until all entries are actually flushed.
 for _ in {1..10}; do
-    ${CLICKHOUSE_CLIENT} --query "SYSTEM FLUSH LOGS"
+    ${CLICKHOUSE_CLIENT} --query "SYSTEM FLUSH LOGS part_log"
     res=$(${CLICKHOUSE_CLIENT} --query "SELECT count() FROM system.part_log WHERE database = currentDatabase() AND table = 't_mutate_skip_part' AND event_type = 'MutatePart'")
 
     if [[ $res -eq 4 ]]; then

--- a/tests/queries/0_stateless/03356_system_flush_logs_individual.sh
+++ b/tests/queries/0_stateless/03356_system_flush_logs_individual.sh
@@ -6,7 +6,7 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 CLICKHOUSE_CLIENT_WITH_LOGS=$(echo ${CLICKHOUSE_CLIENT} | sed 's/'"--send_logs_level=${CLICKHOUSE_CLIENT_SERVER_LOGS_LEVEL}"'/--send_logs_level=debug/g')
 
-$CLICKHOUSE_FORMAT --query "SYSTEM FLUSH LOGS"
+$CLICKHOUSE_FORMAT --query "SYSTEM FLUSH LOGS /* all tables */"
 $CLICKHOUSE_FORMAT --query "SYSTEM FLUSH LOGS ON CLUSTER default"
 $CLICKHOUSE_FORMAT --query "SYSTEM FLUSH LOGS query_log"
 $CLICKHOUSE_FORMAT --query "SYSTEM FLUSH LOGS query_log, query_views_log"

--- a/tests/queries/0_stateless/03362_join_on_filterpushdown.sql
+++ b/tests/queries/0_stateless/03362_join_on_filterpushdown.sql
@@ -67,7 +67,7 @@ FORMAT Null
 SETTINGS log_comment = '03362_join_on_filterpushdown_full'
 ;
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SELECT
     if(ProfileEvents['JoinProbeTableRowCount'] == 100, 'ok', 'fail: ' || toString(ProfileEvents['JoinProbeTableRowCount'])),

--- a/tests/queries/0_stateless/03442_alter_delete_empty_part.sql
+++ b/tests/queries/0_stateless/03442_alter_delete_empty_part.sql
@@ -12,7 +12,7 @@ ALTER TABLE t_delete_empty_part DELETE WHERE a = 2 OR b < 500;
 
 SELECT count() FROM t_delete_empty_part;
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS part_log;
 
 SELECT
     part_name,

--- a/tests/queries/0_stateless/03540_system_dashboards.sh
+++ b/tests/queries/0_stateless/03540_system_dashboards.sh
@@ -12,7 +12,7 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # - replace default with test_shard_localhost (CI does not have default cluster)
 # - replace log_ with log$ to avoid reading all tables matching $log_ pattern, since this also includes distributed tables from ci-logs
 mapfile queries <<<"$($CLICKHOUSE_CURL -sSk "${CLICKHOUSE_URL}&default_format=LineAsString" -d "SELECT encodeURLComponent(formatQuerySingleLine(replace(replace(query, '(default', '(test_shard_localhost'), '_log', '_log$'))) FROM system.dashboards")"
-$CLICKHOUSE_CURL -sSk "${CLICKHOUSE_URL}" -d "SYSTEM FLUSH LOGS"
+$CLICKHOUSE_CURL -sSk "${CLICKHOUSE_URL}" -d "SYSTEM FLUSH LOGS /* all tables */"
 for q in "${queries[@]}"; do
   # Test each query with seconds
   echo "${CLICKHOUSE_URL}&param_rounding=60&param_seconds=600&param_from=&param_to=&serialize_query_plan=0&default_format=Null&query=$q"

--- a/tests/queries/0_stateless/03550_analyzer_remote_view_columns.sql
+++ b/tests/queries/0_stateless/03550_analyzer_remote_view_columns.sql
@@ -26,7 +26,7 @@ SELECT max(i1)
 FROM remote('localhost', currentDatabase(), test_view)
 SETTINGS log_comment = 'THIS IS A COMMENT TO MARK THE INITIAL QUERY';
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SELECT columns
 FROM system.query_log

--- a/tests/queries/0_stateless/03568_mutation_affected_rows_counter.sql
+++ b/tests/queries/0_stateless/03568_mutation_affected_rows_counter.sql
@@ -8,7 +8,7 @@ INSERT INTO t_mutation_rows_counter SELECT number FROM numbers(1000);
 ALTER TABLE t_mutation_rows_counter UPDATE x = x + 1 WHERE x = 150;
 
 SELECT x, count() FROM t_mutation_rows_counter GROUP BY x HAVING count() > 1;
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS part_log;
 
 SELECT
     ProfileEvents['MutatedRows'],

--- a/tests/queries/0_stateless/03578_merges_with_and_without_ttl.sh
+++ b/tests/queries/0_stateless/03578_merges_with_and_without_ttl.sh
@@ -28,7 +28,7 @@ $CLICKHOUSE_CLIENT --query "SYSTEM START MERGES test_with_ttl"
 
 iterations=30
 for _ in $(seq 1 $iterations); do
-    $CLICKHOUSE_CLIENT --query "SYSTEM FLUSH LOGS"
+    $CLICKHOUSE_CLIENT --query "SYSTEM FLUSH LOGS part_log"
     merge_type=$($CLICKHOUSE_CLIENT --query "SELECT merge_algorithm FROM system.part_log WHERE table = 'test_with_ttl' and database='${CLICKHOUSE_DATABASE}' and event_type = 'MergeParts' LIMIT 1")
     if [[ "$merge_type" != "" && "$merge_type" != "Undecided" ]]; then
         break;

--- a/tests/queries/0_stateless/03581_read_in_order_use_virtual_row_WHERE.sql
+++ b/tests/queries/0_stateless/03581_read_in_order_use_virtual_row_WHERE.sql
@@ -9,7 +9,7 @@ select _part, min(x), max(x) from tab group by _part order by _part ;
 
 select x from tab where bitAnd(y, 1023) == 0 order by x limit 10 settings read_in_order_use_virtual_row=1, log_processors_profiles=1, optimize_move_to_prewhere=0, max_threads=2;
 
-system flush logs;
+system flush logs query_log, processors_profile_log;
 
 WITH
     (

--- a/tests/queries/0_stateless/03593_any_join_swap_tables.sql
+++ b/tests/queries/0_stateless/03593_any_join_swap_tables.sql
@@ -19,7 +19,7 @@ ON lhs.a = rhs.a
 FORMAT Null
 SETTINGS log_comment = '03593_any_join_swap_tables';
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS query_log;
 
 SELECT ProfileEvents['JoinBuildTableRowCount'] AS build_table_size
 FROM system.query_log

--- a/tests/queries/0_stateless/03599_lightweight_delete_vertical_merge.sql
+++ b/tests/queries/0_stateless/03599_lightweight_delete_vertical_merge.sql
@@ -37,7 +37,7 @@ OPTIMIZE TABLE t_lwd_vertical FINAL;
 SELECT count() FROM t_lwd_vertical;
 SELECT count() FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_lwd_vertical' AND active AND partition_id = 'all' AND column = '_row_exists';
 
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS part_log;
 
 SELECT
     merge_algorithm,

--- a/tests/queries/0_stateless/03622_ttl_infos_where.sql
+++ b/tests/queries/0_stateless/03622_ttl_infos_where.sql
@@ -43,7 +43,7 @@ ATTACH TABLE users;
 
 -- Check that expired TTL doesn't affect the vertical merge algorithm
 OPTIMIZE TABLE users FINAL;
-SYSTEM FLUSH LOGS;
+SYSTEM FLUSH LOGS part_log;
 SELECT merge_algorithm FROM system.part_log WHERE database = currentDatabase() AND table = 'users' AND event_type = 'MergeParts' ORDER BY event_time_microseconds DESC LIMIT 1;
 
 DROP TABLE IF EXISTS users;

--- a/tests/queries/0_stateless/03640_load_marks_synchronously.sql
+++ b/tests/queries/0_stateless/03640_load_marks_synchronously.sql
@@ -10,7 +10,7 @@ attach table data;
 select * from data settings load_marks_asynchronously=1 format Null /* 1 */;
 select * from data settings load_marks_asynchronously=1 format Null /* 2 */;
 
-system flush logs;
+system flush logs query_log;
 select query, ProfileEvents['BackgroundLoadingMarksTasks']>0 async, ProfileEvents['MarksTasksFromCache']>0 sync
 from system.query_log
 where current_database = currentDatabase() and query_kind = 'Select' and type != 'QueryStart'


### PR DESCRIPTION
Replace all usage of `SYSTEM FLUSH LOGS` in tests, and also add a style check to avoid further cases.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)