### PR TITLE
Fix failing assertion while altering column comment of KeeperMap

### DIFF
--- a/tests/queries/0_stateless/03655_keeper_map_alter_comment.reference
+++ b/tests/queries/0_stateless/03655_keeper_map_alter_comment.reference
@@ -1,0 +1,6 @@
+-- Before ALTER:
+local:	`k` UInt64
+keeper:	`k` UInt64
+-- After ALTER:
+local:	`k` UInt64 COMMENT \'some comment\'
+keeper:	`k` UInt64 COMMENT \'some comment\'

--- a/tests/queries/0_stateless/03655_keeper_map_alter_comment.sql
+++ b/tests/queries/0_stateless/03655_keeper_map_alter_comment.sql
@@ -1,0 +1,20 @@
+-- Tags: zookeeper
+SET distributed_ddl_output_mode = 'none';
+
+DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE:Identifier};
+CREATE DATABASE {CLICKHOUSE_DATABASE:Identifier} ENGINE=Replicated('/clickhouse/databases/{database}', 'shard1', 'replica1');
+USE {CLICKHOUSE_DATABASE:Identifier};
+
+CREATE TABLE 03655_keepermap (k UInt64) ENGINE = KeeperMap('/' || currentDatabase() || '/03655_keepermap') PRIMARY KEY (k);
+
+SELECT '-- Before ALTER:';
+SELECT 'local:', regexpExtract(create_table_query, '(`k`.+?)(\n|\))', 1) FROM system.tables WHERE database = currentDatabase() AND table = '03655_keepermap';
+SELECT 'keeper:', regexpExtract(value, '(`k`.+?)(\n|\))', 1) FROM system.zookeeper WHERE path = '/clickhouse/databases/' || currentDatabase() || '/metadata';
+
+ALTER TABLE 03655_keepermap COMMENT COLUMN k 'some comment';
+
+SELECT '-- After ALTER:';
+SELECT 'local:', regexpExtract(create_table_query, '(`k`.+?)(\n|\))', 1) FROM system.tables WHERE database = currentDatabase() AND table = '03655_keepermap';
+SELECT 'keeper:', regexpExtract(value, '(`k`.+?)(\n|\))', 1) FROM system.zookeeper WHERE path = '/clickhouse/databases/' || currentDatabase() || '/metadata';
+
+DROP DATABASE {CLICKHOUSE_DATABASE:Identifier} SYNC;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

* Make `ALTER COLUMN ... COMMENT` commands for KeeperMap tables replicated so they are committed to Replicated database metadata and propagated across all replicas. Closes #88077 


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

