### PR TITLE
Add a test for mutations serialization format

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -9399,7 +9399,7 @@ QueryPipeline MergeTreeData::updateLightweightImpl(const MutationCommands & comm
     if (it != commands.end())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Got unexpected command with type {} in lightweight update", it->type);
 
-    LOG_DEBUG(log, "Executing lightweight update with commands: {}", commands.toString());
+    LOG_DEBUG(log, "Executing lightweight update with commands: {}", commands.toString(false));
 
     MutationCommands commands_to_run;
     const auto & system_columns = getPatchPartSystemColumns();

--- a/src/Storages/MergeTree/MergeTreeMutationEntry.cpp
+++ b/src/Storages/MergeTree/MergeTreeMutationEntry.cpp
@@ -134,7 +134,7 @@ MergeTreeMutationEntry::MergeTreeMutationEntry(DiskPtr disk_, const String & pat
         create_time_dt.hour(), create_time_dt.minute(), create_time_dt.second());
 
     *buf >> "commands: ";
-    commands->readText(*buf);
+    commands->readText(*buf, false);
     *buf >> "\n";
 
     if (buf->eof())

--- a/src/Storages/MergeTree/MutateFromLogEntryTask.cpp
+++ b/src/Storages/MergeTree/MutateFromLogEntryTask.cpp
@@ -130,7 +130,7 @@ ReplicatedMergeMutateTaskBase::PrepareResult MutateFromLogEntryTask::prepare()
     Strings mutation_ids;
     commands = std::make_shared<MutationCommands>(storage.queue.getMutationCommands(source_part, new_part_info.mutation, mutation_ids));
     LOG_TRACE(log, "Mutating part {} with mutation commands from {} mutations ({}): {}",
-              entry.new_part_name, commands->size(), fmt::join(mutation_ids, ", "), commands->toString());
+              entry.new_part_name, commands->size(), fmt::join(mutation_ids, ", "), commands->toString(true));
 
     /// Once we mutate part, we must reserve space on the same disk, because mutations can possibly create hardlinks.
     /// Can throw an exception.
@@ -236,7 +236,14 @@ ReplicatedMergeMutateTaskBase::PrepareResult MutateFromLogEntryTask::prepare()
 bool MutateFromLogEntryTask::finalize(ReplicatedMergeMutateTaskBase::PartLogWriter write_part_log)
 {
     new_part = mutate_task->getFuture().get();
+
     auto & data_part_storage = new_part->getDataPartStorage();
+
+#if CLICKHOUSE_CLOUD
+    new_part->is_prewarmed = true;
+    data_part_storage.setPreferredFileOrder(new_part->getPreferredFileOrder());
+#endif
+
     if (data_part_storage.hasActiveTransaction())
         data_part_storage.precommitTransaction();
 

--- a/src/Storages/MergeTree/ReplicatedMergeTreeMutationEntry.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeMutationEntry.cpp
@@ -55,7 +55,7 @@ void ReplicatedMergeTreeMutationEntry::readText(ReadBuffer & in)
     }
 
     in >> "commands: ";
-    commands.readText(in);
+    commands.readText(in, false);
     if (checkString("\nalter version: ", in))
         in >> alter_version;
 }

--- a/src/Storages/MergeTree/tests/gtest_mutation_commands.cpp
+++ b/src/Storages/MergeTree/tests/gtest_mutation_commands.cpp
@@ -1,0 +1,20 @@
+#include <gtest/gtest.h>
+
+#include <Storages/MutationCommands.h>
+#include <IO/ReadBufferFromString.h>
+#include <IO/WriteBufferFromString.h>
+
+
+using namespace DB;
+
+/// This ensures we didn't break compatibility with the serialization format.
+TEST(MutationsCommands, Deserialization)
+{
+    std::string_view str{"MODIFY TTL timestamp + toIntervalMonth(3), MATERIALIZE TTL"};
+    ReadBufferFromString in(str);
+    MutationCommands commands;
+    commands.readText(in);
+    WriteBufferFromOwnString out;
+    commands.writeText(out, true);
+    EXPECT_EQ(out.str(), "(MODIFY TTL timestamp + toIntervalMonth(3)), (MATERIALIZE TTL)");
+}

--- a/src/Storages/MergeTree/tests/gtest_mutation_commands.cpp
+++ b/src/Storages/MergeTree/tests/gtest_mutation_commands.cpp
@@ -13,7 +13,7 @@ TEST(MutationsCommands, Deserialization)
     std::string_view str{"MODIFY TTL timestamp + toIntervalMonth(3), MATERIALIZE TTL"};
     ReadBufferFromString in(str);
     MutationCommands commands;
-    commands.readText(in);
+    commands.readText(in, true);
     WriteBufferFromOwnString out;
     commands.writeText(out, true);
     EXPECT_EQ(out.str(), "(MODIFY TTL timestamp + toIntervalMonth(3)), (MATERIALIZE TTL)");

--- a/src/Storages/MutationCommands.cpp
+++ b/src/Storages/MutationCommands.cpp
@@ -30,6 +30,25 @@ bool MutationCommand::isBarrierCommand() const
     return type == RENAME_COLUMN;
 }
 
+bool MutationCommand::isPureMetadataCommand() const
+{
+    return type == ALTER_WITHOUT_MUTATION;
+}
+
+bool MutationCommand::isEmptyCommand() const
+{
+    return type == EMPTY;
+}
+
+bool MutationCommand::isDropOrRename() const
+{
+    return type == Type::DROP_COLUMN
+        || type == Type::DROP_INDEX
+        || type == Type::DROP_PROJECTION
+        || type == Type::DROP_STATISTICS
+        || type == Type::RENAME_COLUMN;
+}
+
 bool MutationCommand::affectsAllColumns() const
 {
     return type == DELETE
@@ -37,8 +56,16 @@ bool MutationCommand::affectsAllColumns() const
         || type == REWRITE_PARTS;
 }
 
-std::optional<MutationCommand> MutationCommand::parse(ASTAlterCommand * command, bool parse_alter_commands)
+std::optional<MutationCommand> MutationCommand::parse(ASTAlterCommand * command, bool parse_alter_commands, bool with_pure_metadata_commands)
 {
+    if (with_pure_metadata_commands)
+    {
+        MutationCommand res;
+        res.ast = command->ptr();
+        res.type = ALTER_WITHOUT_MUTATION;
+        return res;
+    }
+
     if (command->type == ASTAlterCommand::DELETE)
     {
         MutationCommand res;
@@ -237,7 +264,7 @@ std::shared_ptr<ASTExpressionList> MutationCommands::ast(bool with_pure_metadata
     auto res = std::make_shared<ASTExpressionList>();
     for (const MutationCommand & command : *this)
     {
-        if (command.type != MutationCommand::ALTER_WITHOUT_MUTATION || with_pure_metadata_commands)
+        if (!command.isPureMetadataCommand() || with_pure_metadata_commands)
             res->children.push_back(command.ast->clone());
     }
     return res;
@@ -249,7 +276,7 @@ void MutationCommands::writeText(WriteBuffer & out, bool with_pure_metadata_comm
     writeEscapedString(ast(with_pure_metadata_commands)->formatWithSecretsOneLine(), out);
 }
 
-void MutationCommands::readText(ReadBuffer & in)
+void MutationCommands::readText(ReadBuffer & in, bool with_pure_metadata_commands)
 {
     String commands_str;
     readEscapedString(commands_str, in);
@@ -261,16 +288,16 @@ void MutationCommands::readText(ReadBuffer & in)
     for (const auto & child : commands_ast->children)
     {
         auto * command_ast = child->as<ASTAlterCommand>();
-        auto command = MutationCommand::parse(command_ast, true);
+        auto command = MutationCommand::parse(command_ast, true, with_pure_metadata_commands);
         if (!command)
             throw Exception(ErrorCodes::UNKNOWN_MUTATION_COMMAND, "Unknown mutation command type: {}", DB::toString<int>(command_ast->type));
         push_back(std::move(*command));
     }
 }
 
-std::string MutationCommands::toString() const
+std::string MutationCommands::toString(bool with_pure_metadata_commands) const
 {
-    return ast()->formatWithSecretsOneLine();
+    return ast(with_pure_metadata_commands)->formatWithSecretsOneLine();
 }
 
 
@@ -278,7 +305,7 @@ bool MutationCommands::hasNonEmptyMutationCommands() const
 {
     for (const auto & command : *this)
     {
-        if (command.type != MutationCommand::Type::EMPTY && command.type != MutationCommand::Type::ALTER_WITHOUT_MUTATION)
+        if (!command.isEmptyCommand() && !command.isPureMetadataCommand())
             return true;
     }
     return false;

--- a/src/Storages/MutationCommands.h
+++ b/src/Storages/MutationCommands.h
@@ -82,10 +82,13 @@ struct MutationCommand
     bool read_for_patch = false;
 
     /// If parse_alter_commands, than consider more Alter commands as mutation commands
-    static std::optional<MutationCommand> parse(ASTAlterCommand * command, bool parse_alter_commands = false);
+    static std::optional<MutationCommand> parse(ASTAlterCommand * command, bool parse_alter_commands = false, bool with_pure_metadata_commands = false);
 
     /// This command shouldn't stick with other commands
     bool isBarrierCommand() const;
+    bool isPureMetadataCommand() const;
+    bool isEmptyCommand() const;
+    bool isDropOrRename() const;
     bool affectsAllColumns() const;
 };
 
@@ -96,8 +99,8 @@ public:
     std::shared_ptr<ASTExpressionList> ast(bool with_pure_metadata_commands = false) const;
 
     void writeText(WriteBuffer & out, bool with_pure_metadata_commands) const;
-    void readText(ReadBuffer & in);
-    std::string toString() const;
+    void readText(ReadBuffer & in, bool with_pure_metadata_commands);
+    std::string toString(bool with_pure_metadata_commands) const;
     bool hasNonEmptyMutationCommands() const;
 
     bool hasAnyUpdateCommand() const;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Prerequisite for #85749.