### PR TITLE
tests: fix 03644_cancel_huge_mutation_subquery flakiness

### DIFF
--- a/tests/queries/0_stateless/03644_cancel_huge_mutation_subquery.sh
+++ b/tests/queries/0_stateless/03644_cancel_huge_mutation_subquery.sh
@@ -6,7 +6,7 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS cancel_huge_mutation_subquery"
 $CLICKHOUSE_CLIENT -n -q "
-    CREATE TABLE cancel_huge_mutation_subquery (key Int, value String) Engine=MergeTree ORDER BY tuple();
+    CREATE TABLE cancel_huge_mutation_subquery (key Int, value String) Engine=MergeTree ORDER BY tuple() SETTINGS number_of_free_entries_in_pool_to_execute_mutation=0;
     INSERT INTO cancel_huge_mutation_subquery SELECT number, toString(number) FROM numbers(10000);"
 
 


### PR DESCRIPTION
Mutation can be delayed due to:

    2025.10.12 20:08:36.315005 [ 1796 ] {BgSchPool::d0117562-dd21-46d9-b282-83de2b71f10d} <Debug> test_ztu10mud.cancel_huge_mutation_subquery (1d604793-56cb-4e2e-8dee-4968d2939251): Not enough idle threads to apply mutations at the moment. See settings 'number_of_free_entries_in_pool_to_execute_mutation' and 'background_pool_size'

CI: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=88407&sha=f8b65699495fd77458d47db3511259731d30ae75&name_0=PR&name_1=Stateless%20tests%20%28amd_debug%2C%20AsyncInsert%2C%20s3%20storage%2C%20parallel%29

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)