### PR TITLE
Add some debugging HTTP connection drain

### DIFF
--- a/src/IO/ReadBuffer.h
+++ b/src/IO/ReadBuffer.h
@@ -117,9 +117,9 @@ public:
         return bytes_ignored;
     }
 
-    void ignoreAll()
+    size_t ignoreAll()
     {
-        tryIgnore(std::numeric_limits<size_t>::max());
+        return tryIgnore(std::numeric_limits<size_t>::max());
     }
 
     /// Peeks a single byte.

--- a/src/Server/HTTP/sendExceptionToHTTPClient.cpp
+++ b/src/Server/HTTP/sendExceptionToHTTPClient.cpp
@@ -19,6 +19,9 @@ void drainRequestIfNeeded(HTTPServerRequest & request, HTTPServerResponse & resp
         return;
     }
 
+    LOG_DEBUG(getLogger("sendExceptionToHTTPClient"), "Draining connection ({}, Transfer-Encoding: {}, Content-Length: {}, Keep-Alive: {})",
+              request.getVersion(), request.getTransferEncoding(), request.getContentLength(), request.getKeepAlive());
+
     /// If HTTP method is POST and Keep-Alive is turned on, we should try to read the whole request body
     /// to avoid reading part of the current request body in the next request.
     /// Or we have to close connection after this request.
@@ -37,7 +40,10 @@ void drainRequestIfNeeded(HTTPServerRequest & request, HTTPServerResponse & resp
             try
             {
                 if (!input_stream->eof())
-                    input_stream->ignoreAll();
+                {
+                    size_t ignored_bytes = input_stream->ignoreAll();
+                    LOG_DEBUG(getLogger("sendExceptionToHTTPClient"), "Drained {} bytes", ignored_bytes);
+                }
             }
             catch (...)
             {

--- a/tests/queries/0_stateless/01848_http_insert_segfault.reference
+++ b/tests/queries/0_stateless/01848_http_insert_segfault.reference
@@ -1,1 +1,1 @@
-Ok.
+Table default.non_existing_table does not exist

--- a/tests/queries/0_stateless/01848_http_insert_segfault.sh
+++ b/tests/queries/0_stateless/01848_http_insert_segfault.sh
@@ -9,8 +9,8 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 {
   ${CLICKHOUSE_LOCAL} --query "select col1, initializeAggregation('argMaxState', col2, insertTime) as col2, now() as insertTime FROM generateRandom('col1 String, col2 Array(Float64)') LIMIT 1000000 FORMAT CSV"
 } | {
-  ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&query=INSERT%20INTO%20non_existing_table%20SELECT%20col1%2C%20initializeAggregation(%27argMaxState%27%2C%20col2%2C%20insertTime)%20as%20col2%2C%20now()%20as%20insertTime%20FROM%20input(%27col1%20String%2C%20col2%20Array(Float64)%27)%20FORMAT%20CSV" --data-binary @-
+  ${CLICKHOUSE_CURL} --http1.1 -sS "${CLICKHOUSE_URL}&query=INSERT%20INTO%20non_existing_table%20SELECT%20col1%2C%20initializeAggregation(%27argMaxState%27%2C%20col2%2C%20insertTime)%20as%20col2%2C%20now()%20as%20insertTime%20FROM%20input(%27col1%20String%2C%20col2%20Array(Float64)%27)%20FORMAT%20CSV" --data-binary @-
 } | {
-  grep -q "Table $CLICKHOUSE_DATABASE.non_existing_table does not exist" && echo 'Ok.' || echo 'FAIL'
+  grep -o "Table $CLICKHOUSE_DATABASE.non_existing_table does not exist"
 }
 exit 0


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Sometimes 01848_http_insert_segfault fails with `curl: (55) Send failure: Connection reset by peer` which says that the server already closed the connection while the clien was reading the data, let's add more debugging about draining to get more info.

Refs: https://github.com/ClickHouse/ClickHouse/issues/88384