### PR TITLE
Implement uniqMap

### DIFF
--- a/docs/en/sql-reference/aggregate-functions/reference/uniqmap.md
+++ b/docs/en/sql-reference/aggregate-functions/reference/uniqmap.md
@@ -1,0 +1,161 @@
+---
+description: 'Counts unique values in one or more `value` arrays according to the keys specified in the `key`
+  array. Returns a tuple of arrays: keys in sorted order, followed by counts of unique values
+  for the corresponding keys.'
+sidebar_position: 217
+slug: /sql-reference/aggregate-functions/reference/uniqmap
+title: 'uniqMap'
+doc_type: 'reference'
+---
+
+# uniqMap
+
+Counts the number of unique (distinct) values in one or more `value` arrays according to the keys specified in the `key` array. Returns a tuple of arrays: keys in sorted order, followed by counts of unique values for the corresponding keys.
+
+**Syntax**
+
+```sql
+uniqMap(key, value)
+uniqMap(key, value1[, value2, ...])
+uniqMap(Tuple(key, value))
+uniqMap(Tuple(key, value1[, value2, ...]))
+```
+
+**Arguments**
+
+- `key`: [Array](../../data-types/array.md) of keys.
+- `value`, `value1`, `value2`, ...: [Array](../../data-types/array.md) of values to count unique occurrences for each key.
+
+Passing a tuple of key and value arrays is a synonym to passing separately an array of keys and arrays of values.
+
+:::note
+The number of elements in `key` and all `value` arrays must be the same for each row that is aggregated.
+:::
+
+**Returned Value**
+
+- Returns a tuple of arrays: the first array contains the keys in sorted order, followed by arrays containing counts of unique values for the corresponding keys. The count arrays are always of type `UInt64`.
+
+**Example**
+
+First we create a table called `uniq_map` and insert some data into it. Arrays of keys and values are stored separately as a column called `statusMap` of [Nested](../../data-types/nested-data-structures/index.md) type, and together as a column called `statusMapTuple` of [tuple](../../data-types/tuple.md) type to illustrate the use of the two different syntaxes of this function described above.
+
+Query:
+
+```sql
+CREATE TABLE uniq_map(
+    date Date,
+    timeslot DateTime,
+    statusMap Nested(
+        status UInt16,
+        requests UInt64
+    ),
+    statusMapTuple Tuple(Array(Int32), Array(Int32))
+) ENGINE = Log;
+```
+
+```sql
+INSERT INTO uniq_map VALUES
+    ('2000-01-01', '2000-01-01 00:00:00', [1, 2, 3], [10, 10, 10], ([1, 2, 3], [10, 10, 10])),
+    ('2000-01-01', '2000-01-01 00:00:00', [3, 4, 5], [10, 10, 10], ([3, 4, 5], [10, 10, 10])),
+    ('2000-01-01', '2000-01-01 00:01:00', [4, 5, 6], [10, 10, 10], ([4, 5, 6], [10, 10, 10])),
+    ('2000-01-01', '2000-01-01 00:01:00', [6, 7, 8], [10, 10, 10], ([6, 7, 8], [10, 10, 10]));
+```
+
+Next, we query the table using the `uniqMap` function, making use of both array and tuple type syntaxes:
+
+Query:
+
+```sql
+SELECT
+    timeslot,
+    uniqMap(statusMap.status, statusMap.requests),
+    uniqMap(statusMapTuple)
+FROM uniq_map
+GROUP BY timeslot
+```
+
+Result:
+
+```text
+┌────────────timeslot─┬─uniqMap(statusMap.status, statusMap.requests)─┬─uniqMap(statusMapTuple)───┐
+│ 2000-01-01 00:00:00 │ ([1,2,3,4,5],[1,1,1,1,1])                     │ ([1,2,3,4,5],[1,1,1,1,1]) │
+│ 2000-01-01 00:01:00 │ ([4,5,6,7,8],[1,1,1,1,1])                     │ ([4,5,6,7,8],[1,1,1,1,1]) │
+└─────────────────────┴───────────────────────────────────────────────┴───────────────────────────┘
+```
+
+**Example with Counting Unique Values**
+
+This example demonstrates how `uniqMap` counts unique values when the same value appears multiple times:
+
+```sql title="Query"
+CREATE TABLE uniq_map_duplicates(
+    keys Array(UInt64),
+    values Array(UInt64)
+) ENGINE = MergeTree ORDER BY tuple();
+
+INSERT INTO uniq_map_duplicates VALUES
+    ([1, 2, 3], [100, 200, 300]),
+    ([1, 2, 3], [100, 200, 300]),
+    ([1, 2, 3], [100, 250, 300]),
+    ([4, 5], [400, 500]);
+
+SELECT uniqMap(keys, values) FROM uniq_map_duplicates;
+```
+
+```text title="Response"
+┌─uniqMap(keys, values)────┐
+│ ([1,2,3,4,5],[1,2,1,1,1]) │
+└──────────────────────────┘
+```
+
+In this example:
+- Key 1: 1 unique value (100)
+- Key 2: 2 unique values (200 and 250)
+- Key 3: 1 unique value (300)
+- Key 4: 1 unique value (400)
+- Key 5: 1 unique value (500)
+
+**Example with Multiple Value Arrays**
+
+`uniqMap` also supports counting unique values across multiple value arrays simultaneously.
+This is useful when you have related metrics that share the same keys.
+
+```sql title="Query"
+CREATE TABLE multi_metrics(
+    date Date,
+    browser_metrics Nested(
+        browser String,
+        impressions UInt32,
+        clicks UInt32
+    )
+)
+ENGINE = MergeTree()
+ORDER BY tuple();
+
+INSERT INTO multi_metrics VALUES
+    ('2000-01-01', ['Firefox', 'Chrome'], [100, 200], [10, 25]),
+    ('2000-01-01', ['Chrome', 'Safari'], [200, 50], [25, 5]),
+    ('2000-01-01', ['Firefox', 'Edge'], [100, 40], [15, 4]);
+
+SELECT
+    uniqMap(browser_metrics.browser, browser_metrics.impressions, browser_metrics.clicks) AS result
+FROM multi_metrics;
+```
+
+```text title="Response"
+┌─result──────────────────────────────────────────────────┐
+│ (['Chrome','Edge','Firefox','Safari'],[1,1,1,1],[1,1,2,1]) │
+└─────────────────────────────────────────────────────────┘
+```
+
+In this example:
+- The result tuple contains three arrays
+- First array: keys (browser names) in sorted order
+- Second array: count of unique impressions for each browser
+- Third array: count of unique clicks for each browser
+
+**See Also**
+
+- [Map combinator for Map datatype](../combinators.md#-map)
+- [sumMap](../reference/summap.md)

--- a/src/AggregateFunctions/AggregateFunctionUniqMap.cpp
+++ b/src/AggregateFunctions/AggregateFunctionUniqMap.cpp
@@ -1,0 +1,349 @@
+#include <AggregateFunctions/AggregateFunctionFactory.h>
+#include <Functions/FunctionHelpers.h>
+
+#include <IO/ReadHelpers.h>
+
+#include <DataTypes/DataTypeArray.h>
+#include <DataTypes/DataTypeTuple.h>
+#include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypesNumber.h>
+
+#include <Columns/ColumnArray.h>
+#include <Columns/ColumnTuple.h>
+
+#include <Common/assert_cast.h>
+#include <AggregateFunctions/IAggregateFunction.h>
+#include <AggregateFunctions/FactoryHelpers.h>
+#include <map>
+#include <set>
+
+
+namespace DB
+{
+
+struct Settings;
+
+namespace ErrorCodes
+{
+    extern const int BAD_ARGUMENTS;
+    extern const int ILLEGAL_TYPE_OF_ARGUMENT;
+    extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
+}
+
+namespace
+{
+
+/** Data structure for uniqMap that tracks unique values per key */
+struct AggregateFunctionUniqMapData
+{
+    // Map needs to be ordered to maintain function properties
+    // For each key, we store an array of sets (one set per value column) to track unique values
+    std::map<Field, std::vector<std::set<Field>>> merged_maps;
+};
+
+/** Aggregate function uniqMap - counts unique values for each key
+  * This is a specialized implementation that uses sets to track unique values
+  */
+template <bool tuple_argument>
+class AggregateFunctionUniqMap final : public IAggregateFunctionDataHelper<
+    AggregateFunctionUniqMapData, AggregateFunctionUniqMap<tuple_argument>>
+{
+private:
+    static constexpr auto STATE_VERSION_1_MIN_REVISION = 54452;
+
+    DataTypePtr keys_type;
+    SerializationPtr keys_serialization;
+    DataTypes values_types;
+    Serializations values_serializations;
+
+public:
+    using Base = IAggregateFunctionDataHelper<AggregateFunctionUniqMapData, AggregateFunctionUniqMap<tuple_argument>>;
+
+    AggregateFunctionUniqMap(const DataTypePtr & keys_type_,
+            const DataTypes & values_types_, const DataTypes & argument_types_,
+            const Array & params_)
+        : Base(argument_types_, {} /* parameters */, createResultType(keys_type_, values_types_))
+        , keys_type(keys_type_)
+        , keys_serialization(keys_type->getDefaultSerialization())
+        , values_types(values_types_)
+    {
+        assertNoParameters("uniqMap", params_);
+        values_serializations.reserve(values_types.size());
+        for (const auto & type : values_types)
+        {
+            values_serializations.emplace_back(type->getDefaultSerialization());
+        }
+    }
+
+    String getName() const override { return "uniqMap"; }
+
+    bool isVersioned() const override { return true; }
+
+    size_t getDefaultVersion() const override { return 1; }
+
+    size_t getVersionFromRevision(size_t revision) const override
+    {
+        if (revision >= STATE_VERSION_1_MIN_REVISION)
+            return 1;
+        return 0;
+    }
+
+    static DataTypePtr createResultType(
+        const DataTypePtr & keys_type_,
+        const DataTypes & values_types_)
+    {
+        DataTypes types;
+        types.emplace_back(std::make_shared<DataTypeArray>(keys_type_));
+
+        // Result type for counts is always UInt64
+        for (size_t i = 0; i < values_types_.size(); ++i)
+        {
+            types.emplace_back(std::make_shared<DataTypeArray>(std::make_shared<DataTypeUInt64>()));
+        }
+
+        return std::make_shared<DataTypeTuple>(types);
+    }
+
+    bool allocatesMemoryInArena() const override { return false; }
+
+    static auto getArgumentColumns(const IColumn ** columns)
+    {
+        if constexpr (tuple_argument)
+        {
+            return assert_cast<const ColumnTuple *>(columns[0])->getColumns();
+        }
+        else
+        {
+            return columns;
+        }
+    }
+
+    void add(AggregateDataPtr __restrict place, const IColumn ** columns_, const size_t row_num, Arena *) const override
+    {
+        const auto & columns = getArgumentColumns(columns_);
+
+        // Column 0 contains array of keys of known type
+        const auto & array_column0 = assert_cast<const ColumnArray &>(*columns[0]);
+        const auto & offsets0 = array_column0.getOffsets();
+        const auto & key_column = array_column0.getData();
+        const auto keys_vec_offset = offsets0[row_num - 1];
+        const auto keys_vec_size = (offsets0[row_num] - keys_vec_offset);
+
+        // Columns 1..n contain arrays of values to track for uniqueness
+        auto & merged_maps = this->data(place).merged_maps;
+        for (size_t col = 0, size = values_types.size(); col < size; ++col)
+        {
+            const auto & array_column = assert_cast<const ColumnArray &>(*columns[col + 1]);
+            const IColumn & value_column = array_column.getData();
+            const IColumn::Offsets & offsets = array_column.getOffsets();
+            const size_t values_vec_offset = offsets[row_num - 1];
+            const size_t values_vec_size = (offsets[row_num] - values_vec_offset);
+
+            // Expect key and value arrays to be of same length
+            if (keys_vec_size != values_vec_size)
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Sizes of keys and values arrays do not match");
+
+            // Insert column values for all keys
+            for (size_t i = 0; i < keys_vec_size; ++i)
+            {
+                Field value = value_column[values_vec_offset + i];
+                Field key = key_column[keys_vec_offset + i];
+
+                auto [it, inserted] = merged_maps.emplace(key, std::vector<std::set<Field>>());
+
+                if (inserted)
+                {
+                    it->second.resize(size);
+                }
+
+                // Add value to the set for this key and column (skip nulls)
+                if (!value.isNull())
+                {
+                    it->second[col].insert(value);
+                }
+            }
+        }
+    }
+
+    void merge(AggregateDataPtr __restrict place, ConstAggregateDataPtr rhs, Arena *) const override
+    {
+        auto & merged_maps = this->data(place).merged_maps;
+        const auto & rhs_maps = this->data(rhs).merged_maps;
+
+        for (const auto & elem : rhs_maps)
+        {
+            auto it = merged_maps.find(elem.first);
+            if (it != merged_maps.end())
+            {
+                // Merge sets for each column
+                for (size_t col = 0; col < values_types.size(); ++col)
+                {
+                    it->second[col].insert(elem.second[col].begin(), elem.second[col].end());
+                }
+            }
+            else
+            {
+                merged_maps[elem.first] = elem.second;
+            }
+        }
+    }
+
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    {
+        const auto & merged_maps = this->data(place).merged_maps;
+        size_t size = merged_maps.size();
+        writeVarUInt(size, buf);
+
+        for (const auto & elem : merged_maps)
+        {
+            keys_serialization->serializeBinary(elem.first, buf, {});
+
+            // Serialize each set of unique values
+            for (size_t col = 0; col < values_types.size(); ++col)
+            {
+                const auto & unique_values = elem.second[col];
+                writeVarUInt(unique_values.size(), buf);
+                for (const auto & val : unique_values)
+                {
+                    values_serializations[col]->serializeBinary(val, buf, {});
+                }
+            }
+        }
+    }
+
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> /* version */, Arena *) const override
+    {
+        auto & merged_maps = this->data(place).merged_maps;
+        size_t size = 0;
+        readVarUInt(size, buf);
+
+        FormatSettings format_settings;
+        for (size_t i = 0; i < size; ++i)
+        {
+            Field key;
+            keys_serialization->deserializeBinary(key, buf, format_settings);
+
+            std::vector<std::set<Field>> value_sets;
+            value_sets.resize(values_types.size());
+
+            for (size_t col = 0; col < values_types.size(); ++col)
+            {
+                size_t set_size = 0;
+                readVarUInt(set_size, buf);
+                for (size_t j = 0; j < set_size; ++j)
+                {
+                    Field value;
+                    values_serializations[col]->deserializeBinary(value, buf, format_settings);
+                    value_sets[col].insert(value);
+                }
+            }
+
+            merged_maps[key] = std::move(value_sets);
+        }
+    }
+
+    void insertResultInto(AggregateDataPtr __restrict place, IColumn & to, Arena *) const override
+    {
+        const auto & merged_maps = this->data(place).merged_maps;
+        size_t size = merged_maps.size();
+
+        auto & to_tuple = assert_cast<ColumnTuple &>(to);
+        auto & to_keys_arr = assert_cast<ColumnArray &>(to_tuple.getColumn(0));
+        auto & to_keys_col = to_keys_arr.getData();
+
+        // Advance column offsets
+        auto & to_keys_offsets = to_keys_arr.getOffsets();
+        to_keys_offsets.push_back(to_keys_offsets.back() + size);
+        to_keys_col.reserve(size);
+
+        for (size_t col = 0; col < values_types.size(); ++col)
+        {
+            auto & to_values_arr = assert_cast<ColumnArray &>(to_tuple.getColumn(col + 1));
+            auto & to_values_offsets = to_values_arr.getOffsets();
+            to_values_offsets.push_back(to_values_offsets.back() + size);
+            to_values_arr.getData().reserve(size);
+        }
+
+        // Write arrays of keys and counts
+        for (const auto & elem : merged_maps)
+        {
+            // Write array of keys into column
+            to_keys_col.insert(elem.first);
+
+            // Write counts of unique values for each column
+            for (size_t col = 0; col < values_types.size(); ++col)
+            {
+                auto & to_values_col = assert_cast<ColumnArray &>(to_tuple.getColumn(col + 1)).getData();
+                // Insert the count of unique values
+                to_values_col.insert(UInt64(elem.second[col].size()));
+            }
+        }
+    }
+};
+
+
+auto parseArguments(const std::string & name, const DataTypes & arguments)
+{
+    DataTypes args;
+    bool tuple_argument = false;
+
+    if (arguments.size() == 1)
+    {
+        // uniqMap state is fully given by its result, so it can be stored in
+        // SimpleAggregateFunction columns. There is a caveat: it must support
+        // uniqMap(uniqMap(...)), e.g. it must be able to accept its own output as
+        // an input. This is why it also accepts a Tuple(keys, values) argument.
+        const auto * tuple_type = checkAndGetDataType<DataTypeTuple>(arguments[0].get());
+        if (!tuple_type)
+            throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "When function {} gets one argument it must be a tuple", name);
+
+        const auto elems = tuple_type->getElements();
+        args.insert(args.end(), elems.begin(), elems.end());
+        tuple_argument = true;
+    }
+    else
+    {
+        args.insert(args.end(), arguments.begin(), arguments.end());
+        tuple_argument = false;
+    }
+
+    if (args.size() < 2)
+        throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH,
+            "Aggregate function {} requires at least two arguments of Array type or one argument of tuple of two arrays", name);
+
+    const auto * array_type = checkAndGetDataType<DataTypeArray>(args[0].get());
+    if (!array_type)
+        throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Argument #1 for function {} must be an array, not {}",
+            name, args[0]->getName());
+
+    DataTypePtr keys_type = array_type->getNestedType();
+
+    DataTypes values_types;
+    values_types.reserve(args.size() - 1);
+    for (size_t i = 1; i < args.size(); ++i)
+    {
+        array_type = checkAndGetDataType<DataTypeArray>(args[i].get());
+        if (!array_type)
+            throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Argument #{} for function {} must be an array, not {}",
+                i + 1, name, args[i]->getName());
+        values_types.push_back(array_type->getNestedType());
+    }
+
+    return std::tuple<DataTypePtr, DataTypes, bool>{std::move(keys_type), std::move(values_types), tuple_argument};
+}
+
+}
+
+void registerAggregateFunctionUniqMap(AggregateFunctionFactory & factory)
+{
+    factory.registerFunction("uniqMap", [](const std::string & name, const DataTypes & arguments, const Array & params, const Settings *) -> AggregateFunctionPtr
+    {
+        auto [keys_type, values_types, tuple_argument] = parseArguments(name, arguments);
+        if (tuple_argument)
+            return std::make_shared<AggregateFunctionUniqMap<true>>(keys_type, values_types, arguments, params);
+        return std::make_shared<AggregateFunctionUniqMap<false>>(keys_type, values_types, arguments, params);
+    });
+}
+
+}
+

--- a/src/AggregateFunctions/registerAggregateFunctions.cpp
+++ b/src/AggregateFunctions/registerAggregateFunctions.cpp
@@ -57,6 +57,7 @@ void registerAggregateFunctionsVarianceMatrix(AggregateFunctionFactory &);
 void registerAggregateFunctionSum(AggregateFunctionFactory &);
 void registerAggregateFunctionSumCount(AggregateFunctionFactory &);
 void registerAggregateFunctionSumMap(AggregateFunctionFactory &);
+void registerAggregateFunctionUniqMap(AggregateFunctionFactory &);
 void registerAggregateFunctionsUniq(AggregateFunctionFactory &);
 void registerAggregateFunctionUniqCombined(AggregateFunctionFactory &);
 void registerAggregateFunctionUniqUpTo(AggregateFunctionFactory &);
@@ -169,6 +170,7 @@ void registerAggregateFunctions()
         registerAggregateFunctionSum(factory);
         registerAggregateFunctionSumCount(factory);
         registerAggregateFunctionSumMap(factory);
+        registerAggregateFunctionUniqMap(factory);
         registerAggregateFunctionsUniq(factory);
         registerAggregateFunctionUniqCombined(factory);
         registerAggregateFunctionUniqUpTo(factory);

--- a/tests/queries/0_stateless/03301_uniq_map.reference
+++ b/tests/queries/0_stateless/03301_uniq_map.reference
@@ -1,0 +1,95 @@
+-- { echoOn }
+DROP TABLE IF EXISTS uniq_map;
+-- Test basic functionality with integers
+CREATE TABLE uniq_map(date Date, timeslot DateTime, statusMap Nested(status UInt16, requests UInt64)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO uniq_map VALUES 
+    ('2000-01-01', '2000-01-01 00:00:00', [1, 2, 3], [10, 10, 10]), 
+    ('2000-01-01', '2000-01-01 00:00:00', [3, 4, 5], [10, 10, 10]), 
+    ('2000-01-01', '2000-01-01 00:01:00', [4, 5, 6], [10, 10, 10]), 
+    ('2000-01-01', '2000-01-01 00:01:00', [6, 7, 8], [10, 10, 10]);
+-- Test basic uniqMap - should count unique values per key
+SELECT uniqMap(statusMap.status, statusMap.requests) FROM uniq_map;
+([1,2,3,4,5,6,7,8],[1,1,1,1,1,1,1,1])
+-- Test with tuple argument
+SELECT uniqMap((statusMap.status, statusMap.requests)) FROM uniq_map;
+([1,2,3,4,5,6,7,8],[1,1,1,1,1,1,1,1])
+-- Test grouped by timeslot
+SELECT timeslot, uniqMap(statusMap.status, statusMap.requests) FROM uniq_map GROUP BY timeslot ORDER BY timeslot;
+2000-01-01 00:00:00	([1,2,3,4,5],[1,1,1,1,1])
+2000-01-01 00:01:00	([4,5,6,7,8],[1,1,1,1,1])
+-- Test accessing tuple elements
+SELECT timeslot, uniqMap(statusMap.status, statusMap.requests).1, uniqMap(statusMap.status, statusMap.requests).2 FROM uniq_map GROUP BY timeslot ORDER BY timeslot;
+2000-01-01 00:00:00	[1,2,3,4,5]	[1,1,1,1,1]
+2000-01-01 00:01:00	[4,5,6,7,8]	[1,1,1,1,1]
+DROP TABLE uniq_map;
+-- Test with duplicate values to verify uniqueness counting
+DROP TABLE IF EXISTS uniq_map_duplicates;
+CREATE TABLE uniq_map_duplicates(keys Array(UInt64), values Array(UInt64)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO uniq_map_duplicates VALUES
+    ([1, 2, 3], [100, 200, 300]),
+    ([1, 2, 3], [100, 200, 300]),
+    ([1, 2, 3], [100, 250, 300]),
+    ([4, 5], [400, 500]);
+-- Key 1 should have 1 unique value (100)
+-- Key 2 should have 2 unique values (200, 250)
+-- Key 3 should have 1 unique value (300)
+-- Key 4 should have 1 unique value (400)
+-- Key 5 should have 1 unique value (500)
+SELECT uniqMap(keys, values) FROM uniq_map_duplicates;
+([1,2,3,4,5],[1,2,1,1,1])
+DROP TABLE uniq_map_duplicates;
+-- Test with multiple value arrays
+DROP TABLE IF EXISTS uniq_map_multi;
+CREATE TABLE uniq_map_multi(
+    date Date,
+    browser_metrics Nested(
+        browser String,
+        impressions UInt32,
+        clicks UInt32
+    )
+) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO uniq_map_multi VALUES
+    ('2000-01-01', ['Firefox', 'Chrome'], [100, 200], [10, 25]),
+    ('2000-01-01', ['Chrome', 'Safari'], [200, 50], [25, 5]),
+    ('2000-01-01', ['Firefox', 'Edge'], [100, 40], [15, 4]);
+-- Firefox: 1 unique impression (100), 2 unique clicks (10, 15)
+-- Chrome: 1 unique impression (200), 1 unique click (25)
+-- Safari: 1 unique impression (50), 1 unique click (5)
+-- Edge: 1 unique impression (40), 1 unique click (4)
+SELECT uniqMap(browser_metrics.browser, browser_metrics.impressions, browser_metrics.clicks) FROM uniq_map_multi;
+(['Chrome','Edge','Firefox','Safari'],[1,1,1,1],[1,1,2,1])
+DROP TABLE uniq_map_multi;
+-- Test with different data types
+select uniqMap(val, cnt) from ( SELECT [ CAST(1, 'UInt64') ] as val, [1] as cnt );
+([1],[1])
+select uniqMap(val, cnt) from ( SELECT [ CAST(1, 'Float64') ] as val, [1] as cnt );
+([1],[1])
+select uniqMap(val, cnt) from ( SELECT [ CAST('a', 'Enum16(\'a\'=1)') ] as val, [1] as cnt );
+(['a'],[1])
+-- Test with strings
+select uniqMap(val, cnt) from ( SELECT [ CAST('a', 'FixedString(1)'), CAST('b', 'FixedString(1)' ) ] as val, [1, 2] as cnt );
+(['a','b'],[1,1])
+select uniqMap(val, cnt) from ( SELECT [ CAST('abc', 'String'), CAST('ab', 'String'), CAST('a', 'String') ] as val, [1, 2, 3] as cnt );
+(['a','ab','abc'],[1,1,1])
+-- Test with nulls
+DROP TABLE IF EXISTS uniq_map_nulls;
+CREATE TABLE uniq_map_nulls(keys Array(UInt64), values Array(Nullable(UInt64))) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO uniq_map_nulls VALUES 
+    ([1, 2, 3], [100, 200, NULL]),
+    ([1, 2, 3], [100, NULL, 300]),
+    ([1, 2], [150, 200]);
+-- Key 1: 2 unique values (100, 150)
+-- Key 2: 1 unique value (200) - nulls are ignored
+-- Key 3: 1 unique value (300) - nulls are ignored
+SELECT uniqMap(keys, values) FROM uniq_map_nulls;
+([1,2,3],[2,1,1])
+DROP TABLE uniq_map_nulls;
+-- Test state functions
+DROP TABLE IF EXISTS uniq_map_state;
+CREATE TABLE uniq_map_state(keys Array(UInt64), values Array(UInt64)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO uniq_map_state VALUES 
+    ([1, 2], [100, 200]),
+    ([2, 3], [200, 300]);
+SELECT uniqMapMerge(s) FROM (SELECT uniqMapState(keys, values) AS s FROM uniq_map_state);
+([1,2,3],[1,1,1])
+DROP TABLE uniq_map_state;

--- a/tests/queries/0_stateless/03301_uniq_map.sql
+++ b/tests/queries/0_stateless/03301_uniq_map.sql
@@ -1,0 +1,108 @@
+SET send_logs_level = 'fatal';
+
+-- { echoOn }
+DROP TABLE IF EXISTS uniq_map;
+
+-- Test basic functionality with integers
+CREATE TABLE uniq_map(date Date, timeslot DateTime, statusMap Nested(status UInt16, requests UInt64)) ENGINE = MergeTree ORDER BY tuple();
+
+INSERT INTO uniq_map VALUES 
+    ('2000-01-01', '2000-01-01 00:00:00', [1, 2, 3], [10, 10, 10]), 
+    ('2000-01-01', '2000-01-01 00:00:00', [3, 4, 5], [10, 10, 10]), 
+    ('2000-01-01', '2000-01-01 00:01:00', [4, 5, 6], [10, 10, 10]), 
+    ('2000-01-01', '2000-01-01 00:01:00', [6, 7, 8], [10, 10, 10]);
+
+-- Test basic uniqMap - should count unique values per key
+SELECT uniqMap(statusMap.status, statusMap.requests) FROM uniq_map;
+
+-- Test with tuple argument
+SELECT uniqMap((statusMap.status, statusMap.requests)) FROM uniq_map;
+
+-- Test grouped by timeslot
+SELECT timeslot, uniqMap(statusMap.status, statusMap.requests) FROM uniq_map GROUP BY timeslot ORDER BY timeslot;
+
+-- Test accessing tuple elements
+SELECT timeslot, uniqMap(statusMap.status, statusMap.requests).1, uniqMap(statusMap.status, statusMap.requests).2 FROM uniq_map GROUP BY timeslot ORDER BY timeslot;
+
+DROP TABLE uniq_map;
+
+-- Test with duplicate values to verify uniqueness counting
+DROP TABLE IF EXISTS uniq_map_duplicates;
+CREATE TABLE uniq_map_duplicates(keys Array(UInt64), values Array(UInt64)) ENGINE = MergeTree ORDER BY tuple();
+
+INSERT INTO uniq_map_duplicates VALUES
+    ([1, 2, 3], [100, 200, 300]),
+    ([1, 2, 3], [100, 200, 300]),
+    ([1, 2, 3], [100, 250, 300]),
+    ([4, 5], [400, 500]);
+
+-- Key 1 should have 1 unique value (100)
+-- Key 2 should have 2 unique values (200, 250)
+-- Key 3 should have 1 unique value (300)
+-- Key 4 should have 1 unique value (400)
+-- Key 5 should have 1 unique value (500)
+SELECT uniqMap(keys, values) FROM uniq_map_duplicates;
+
+DROP TABLE uniq_map_duplicates;
+
+-- Test with multiple value arrays
+DROP TABLE IF EXISTS uniq_map_multi;
+CREATE TABLE uniq_map_multi(
+    date Date,
+    browser_metrics Nested(
+        browser String,
+        impressions UInt32,
+        clicks UInt32
+    )
+) ENGINE = MergeTree ORDER BY tuple();
+
+INSERT INTO uniq_map_multi VALUES
+    ('2000-01-01', ['Firefox', 'Chrome'], [100, 200], [10, 25]),
+    ('2000-01-01', ['Chrome', 'Safari'], [200, 50], [25, 5]),
+    ('2000-01-01', ['Firefox', 'Edge'], [100, 40], [15, 4]);
+
+-- Firefox: 1 unique impression (100), 2 unique clicks (10, 15)
+-- Chrome: 1 unique impression (200), 1 unique click (25)
+-- Safari: 1 unique impression (50), 1 unique click (5)
+-- Edge: 1 unique impression (40), 1 unique click (4)
+SELECT uniqMap(browser_metrics.browser, browser_metrics.impressions, browser_metrics.clicks) FROM uniq_map_multi;
+
+DROP TABLE uniq_map_multi;
+
+-- Test with different data types
+select uniqMap(val, cnt) from ( SELECT [ CAST(1, 'UInt64') ] as val, [1] as cnt );
+select uniqMap(val, cnt) from ( SELECT [ CAST(1, 'Float64') ] as val, [1] as cnt );
+select uniqMap(val, cnt) from ( SELECT [ CAST('a', 'Enum16(\'a\'=1)') ] as val, [1] as cnt );
+
+-- Test with strings
+select uniqMap(val, cnt) from ( SELECT [ CAST('a', 'FixedString(1)'), CAST('b', 'FixedString(1)' ) ] as val, [1, 2] as cnt );
+select uniqMap(val, cnt) from ( SELECT [ CAST('abc', 'String'), CAST('ab', 'String'), CAST('a', 'String') ] as val, [1, 2, 3] as cnt );
+
+-- Test with nulls
+DROP TABLE IF EXISTS uniq_map_nulls;
+CREATE TABLE uniq_map_nulls(keys Array(UInt64), values Array(Nullable(UInt64))) ENGINE = MergeTree ORDER BY tuple();
+
+INSERT INTO uniq_map_nulls VALUES 
+    ([1, 2, 3], [100, 200, NULL]),
+    ([1, 2, 3], [100, NULL, 300]),
+    ([1, 2], [150, 200]);
+
+-- Key 1: 2 unique values (100, 150)
+-- Key 2: 1 unique value (200) - nulls are ignored
+-- Key 3: 1 unique value (300) - nulls are ignored
+SELECT uniqMap(keys, values) FROM uniq_map_nulls;
+
+DROP TABLE uniq_map_nulls;
+
+-- Test state functions
+DROP TABLE IF EXISTS uniq_map_state;
+CREATE TABLE uniq_map_state(keys Array(UInt64), values Array(UInt64)) ENGINE = MergeTree ORDER BY tuple();
+
+INSERT INTO uniq_map_state VALUES 
+    ([1, 2], [100, 200]),
+    ([2, 3], [200, 300]);
+
+SELECT uniqMapMerge(s) FROM (SELECT uniqMapState(keys, values) AS s FROM uniq_map_state);
+
+DROP TABLE uniq_map_state;
+


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- New Feature

### Changelog entry
Added the aggregate function `uniqMap`, which counts the number of unique values for each key across multiple arrays.


### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

### Motivation
Find the number of unique items per category.
It is analogous to `sumMap` but performs a count of distinct values instead of a sum. 

Closes https://github.com/ClickHouse/ClickHouse/issues/21628