### PR TITLE
Refine min_free_disk_bytes/ratio_to_perform_insert implementation

### DIFF
--- a/tests/integration/test_stop_insert_when_disk_close_to_full/configs/config.d/storage_configuration_query_log.xml
+++ b/tests/integration/test_stop_insert_when_disk_close_to_full/configs/config.d/storage_configuration_query_log.xml
@@ -1,0 +1,27 @@
+<clickhouse>
+    <storage_configuration>
+        <disks>
+            <disk1>
+                <type>local</type>
+                <path>/disk1/</path>
+            </disk1>
+        </disks>
+        <policies>
+            <only_disk1>
+                <volumes>
+                    <main>
+                        <disk>disk1</disk>
+                    </main>
+                </volumes>
+            </only_disk1>
+        </policies>
+    </storage_configuration>
+    <query_log>
+        <database>system</database>
+        <table>query_log</table>
+        <storage_policy>only_disk1</storage_policy>
+    </query_log>
+    <merge_tree>
+        <min_free_disk_ratio_to_perform_insert>1.0</min_free_disk_ratio_to_perform_insert>
+    </merge_tree>
+</clickhouse>


### PR DESCRIPTION
This PR makes 2 slight changes to how `min_free_disk_ratio_to_perform_insert` and `min_free_disk_bytes_to_perform_insert` work:
* Use *unreserved* instead of *available* bytes to determine if an insert should be rejected. This is probably not crucial if the reservations are small compared to the configured thresholds, but it seems more correct to me.
* Don't apply these settings to system tables. The reasoning for this is that we still want tables like `query_log` to be updated. This helps a lot with debugging. Data written to system tables is usually small compared to actual data, so they should be able to continue for much longer with a reasonable `min_free_disk_ratio_to_perform_insert` threshold.

cc @marco-vb and @yariks5s who worked on the original implementation in https://github.com/ClickHouse/ClickHouse/pull/69755.

### Changelog category (leave one):

- Backward Incompatible Change


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Two slight changes to how `min_free_disk_ratio_to_perform_insert` and `min_free_disk_bytes_to_perform_insert` settings work: - use unreserved instead of available bytes to determine if an insert should be rejected. This is probably not crucial if the reservations for background merges and mutations are small compared to the configured thresholds, but it seems more correct. - Don't apply these settings to system tables. The reasoning for this is that we still want tables like `query_log` to be updated. This helps a lot with debugging. Data written to system tables is usually small compared to actual data, so they should be able to continue for much longer with a reasonable `min_free_disk_ratio_to_perform_insert` threshold.



### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
