### PR TITLE
WIP: Enable random ORDER BY injection (inject_random_order_for_select_without_order_by = 1) for SELECT queries lacking an ORDER BY clause in stateless and integration tests

### DIFF
--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -179,6 +179,7 @@ ln -sf $SRC_PATH/users.d/remote_queries.xml $DEST_SERVER_PATH/users.d/
 ln -sf $SRC_PATH/users.d/session_log_test.xml $DEST_SERVER_PATH/users.d/
 ln -sf $SRC_PATH/users.d/memory_profiler.xml $DEST_SERVER_PATH/users.d/
 ln -sf $SRC_PATH/users.d/no_fsync_metadata.xml $DEST_SERVER_PATH/users.d/
+ln -sf $SRC_PATH/users.d/inject_random_order.xml $DEST_SERVER_PATH/users.d/
 ln -sf $SRC_PATH/users.d/filelog.xml $DEST_SERVER_PATH/users.d/
 ln -sf $SRC_PATH/users.d/enable_blobs_check.xml $DEST_SERVER_PATH/users.d/
 ln -sf $SRC_PATH/users.d/marks.xml $DEST_SERVER_PATH/users.d/

--- a/tests/config/users.d/inject_random_order.xml
+++ b/tests/config/users.d/inject_random_order.xml
@@ -1,0 +1,7 @@
+<clickhouse>
+    <profiles>
+        <default>
+            <inject_random_order_for_select_without_order_by>1</inject_random_order_for_select_without_order_by>
+        </default>
+    </profiles>
+</clickhouse>

--- a/tests/integration/helpers/0_inject_random_order.xml
+++ b/tests/integration/helpers/0_inject_random_order.xml
@@ -1,0 +1,7 @@
+<clickhouse>
+    <profiles>
+        <default>
+            <inject_random_order_for_select_without_order_by>1</inject_random_order_for_select_without_order_by>
+        </default>
+    </profiles>
+</clickhouse>

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -5284,6 +5284,7 @@ class ClickHouseInstance:
 
         if not self.with_dolor:
             write_embedded_config("0_common_instance_users.xml", users_d_dir)
+            write_embedded_config("0_inject_random_order.xml", users_d_dir)
             if self.with_installed_binary:
                 # Ignore CPU overload in this case
                 write_embedded_config(


### PR DESCRIPTION
Catch more bugs by exposing hidden order dependencies and flaky assumptions in tests that rely on implicit row order. 

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
