### PR TITLE
Avoid 03176_check_timeout_in_index_analysis flakiness

### DIFF
--- a/tests/queries/0_stateless/03176_check_timeout_in_index_analysis.sql
+++ b/tests/queries/0_stateless/03176_check_timeout_in_index_analysis.sql
@@ -16,7 +16,7 @@ EXPLAIN indexes = 1 SELECT * FROM t_03176 ORDER BY k LIMIT 5 SETTINGS log_commen
 SYSTEM FLUSH LOGS query_log;
 
 -- Check that q1 was fast, q2 was slow and q3 had timeout
-SELECT log_comment, type = 'QueryFinish', intDiv(query_duration_ms, 2000), exception_code != 0, position('selectPartsToRead' IN stack_trace) > 0 AS has_selectPartsToRead
+SELECT log_comment, type = 'QueryFinish', intDiv(query_duration_ms, 2000), exception_code != 0, (position('selectPartsToRead' IN stack_trace) > 0 OR position('filterPartsByPartition' IN stack_trace) > 0) AS has_selectPartsToRead
 FROM system.query_log
 WHERE current_database = currentDatabase() AND log_comment LIKE '03176_q_' AND type IN ('QueryFinish', 'ExceptionBeforeStart')
 ORDER BY log_comment;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Avoid 03176_check_timeout_in_index_analysis flakiness

In some builds the function gets inlined and the it does not appear in the stacktrace.
Closes https://github.com/ClickHouse/ClickHouse/issues/88326

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
