### PR TITLE
Disable use_query_condition_cache and run all tests

### DIFF
--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -179,6 +179,7 @@ ln -sf $SRC_PATH/users.d/remote_queries.xml $DEST_SERVER_PATH/users.d/
 ln -sf $SRC_PATH/users.d/session_log_test.xml $DEST_SERVER_PATH/users.d/
 ln -sf $SRC_PATH/users.d/memory_profiler.xml $DEST_SERVER_PATH/users.d/
 ln -sf $SRC_PATH/users.d/no_fsync_metadata.xml $DEST_SERVER_PATH/users.d/
+ln -sf $SRC_PATH/users.d/use_query_condition_cache.xml $DEST_SERVER_PATH/users.d/
 ln -sf $SRC_PATH/users.d/filelog.xml $DEST_SERVER_PATH/users.d/
 ln -sf $SRC_PATH/users.d/enable_blobs_check.xml $DEST_SERVER_PATH/users.d/
 ln -sf $SRC_PATH/users.d/marks.xml $DEST_SERVER_PATH/users.d/

--- a/tests/config/users.d/use_query_condition_cache.xml
+++ b/tests/config/users.d/use_query_condition_cache.xml
@@ -1,0 +1,7 @@
+<clickhouse>
+    <profiles>
+        <default>
+            <use_query_condition_cache>0</use_query_condition_cache>
+        </default>
+    </profiles>
+</clickhouse>

--- a/tests/integration/helpers/0_use_query_condition_cache.xml
+++ b/tests/integration/helpers/0_use_query_condition_cache.xml
@@ -1,0 +1,7 @@
+<clickhouse>
+    <profiles>
+        <default>
+            <use_query_condition_cache>0</use_query_condition_cache>
+        </default>
+    </profiles>
+</clickhouse>

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -1919,6 +1919,8 @@ class ClickHouseCluster:
                 f"Can't add instance '{name}': there is already an instance with the same name in [{self.instances.keys()}]"
             )
 
+        tag_explicit = tag is not None
+
         if tag is None:
             tag = DOCKER_BASE_TAG
         else:
@@ -2038,6 +2040,7 @@ class ClickHouseCluster:
             use_docker_init_flag=use_docker_init_flag,
             with_dolor=with_dolor,
             extra_parameters=extra_parameters,
+            tag_explicit=tag_explicit,
         )
 
         docker_compose_yml_dir = get_docker_compose_path()
@@ -4063,6 +4066,7 @@ class ClickHouseInstance:
         use_docker_init_flag=False,
         with_dolor=False,
         extra_parameters=None,
+        tag_explicit=False,
     ):
         self.name = name
         self.base_cmd = cluster.base_cmd
@@ -4201,6 +4205,7 @@ class ClickHouseInstance:
         self.client = None
         self.image = image
         self.tag = tag
+        self.tag_explicit = tag_explicit
         self.stay_alive = stay_alive
         self.ipv4_address = ipv4_address
         self.ipv6_address = ipv6_address
@@ -5284,7 +5289,8 @@ class ClickHouseInstance:
 
         if not self.with_dolor:
             write_embedded_config("0_common_instance_users.xml", users_d_dir)
-            write_embedded_config("0_use_query_condition_cache.xml", users_d_dir)
+            if not self.tag_explicit:
+                write_embedded_config("0_use_query_condition_cache.xml", users_d_dir)
             if self.with_installed_binary:
                 # Ignore CPU overload in this case
                 write_embedded_config(

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -5284,6 +5284,7 @@ class ClickHouseInstance:
 
         if not self.with_dolor:
             write_embedded_config("0_common_instance_users.xml", users_d_dir)
+            write_embedded_config("0_use_query_condition_cache.xml", users_d_dir)
             if self.with_installed_binary:
                 # Ignore CPU overload in this case
                 write_embedded_config(


### PR DESCRIPTION
Disable use_query_condition_cache and execute all tests to verify if disabling this setting causes any issues, as it is now enabled by default now

**Note** - This PR is not going to be merged. This is just for experimentation

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
