### PR TITLE
Prevent unblocking a higher-level MemoryTracker and add some guard rails

### DIFF
--- a/src/Common/tests/gtest_memory_tracker_blocker_in_thread.cpp
+++ b/src/Common/tests/gtest_memory_tracker_blocker_in_thread.cpp
@@ -31,14 +31,36 @@ TEST(MemoryTrackerBlockerInThread, Nested)
         {
             MemoryTrackerBlockerInThread blocker_user(VariableContext::User);
             ASSERT_TRUE(MemoryTrackerBlockerInThread::isBlocked(VariableContext::User));
-            ASSERT_FALSE(MemoryTrackerBlockerInThread::isBlocked(VariableContext::Global));
-            ASSERT_EQ(MemoryTrackerBlockerInThread::getLevel(), VariableContext::User);
+            ASSERT_TRUE(MemoryTrackerBlockerInThread::isBlocked(VariableContext::Global));
+            ASSERT_EQ(MemoryTrackerBlockerInThread::getLevel(), VariableContext::Global);
         }
         ASSERT_TRUE(MemoryTrackerBlockerInThread::isBlocked(VariableContext::Global));
         ASSERT_EQ(MemoryTrackerBlockerInThread::getLevel(), VariableContext::Global);
     }
     ASSERT_FALSE(MemoryTrackerBlockerInThread::isBlocked(VariableContext::Process));
     ASSERT_EQ(MemoryTrackerBlockerInThread::getLevel(), VariableContext::Max);
+}
+
+TEST(MemoryTrackerBlockerInThread, DeeplyNested)
+{
+    MemoryTrackerBlockerInThread b(VariableContext::User);
+    {
+        MemoryTrackerBlockerInThread b1(VariableContext::Global);
+        {
+            MemoryTrackerBlockerInThread b2(VariableContext::User);
+            {
+                MemoryTrackerBlockerInThread b3(VariableContext::Global);
+                {
+                    MemoryTrackerBlockerInThread b4(VariableContext::User);
+                    ASSERT_EQ(MemoryTrackerBlockerInThread::getLevel(), VariableContext::Global);
+                }
+                ASSERT_EQ(MemoryTrackerBlockerInThread::getLevel(), VariableContext::Global);
+            }
+            ASSERT_EQ(MemoryTrackerBlockerInThread::getLevel(), VariableContext::Global);
+        }
+        ASSERT_EQ(MemoryTrackerBlockerInThread::getLevel(), VariableContext::Global);
+    }
+    ASSERT_EQ(MemoryTrackerBlockerInThread::getLevel(), VariableContext::User);
 }
 
 TEST(MemoryTrackerBlockerInThread, Move)

--- a/src/Common/tests/gtest_memory_tracker_blocker_in_thread.cpp
+++ b/src/Common/tests/gtest_memory_tracker_blocker_in_thread.cpp
@@ -1,0 +1,56 @@
+#include <gtest/gtest.h>
+
+#include <Common/MemoryTracker.h>
+#include <Common/CurrentThread.h>
+#include <Common/MemoryTrackerBlockerInThread.h>
+#include <Common/VariableContext.h>
+
+using namespace DB;
+
+TEST(MemoryTrackerBlockerInThread, Default)
+{
+    ASSERT_FALSE(MemoryTrackerBlockerInThread::isBlocked(VariableContext::Process));
+    MemoryTrackerBlockerInThread blocker;
+    ASSERT_TRUE(MemoryTrackerBlockerInThread::isBlocked(VariableContext::User));
+    ASSERT_FALSE(MemoryTrackerBlockerInThread::isBlocked(VariableContext::Global));
+    ASSERT_EQ(MemoryTrackerBlockerInThread::getLevel(), VariableContext::User);
+}
+
+TEST(MemoryTrackerBlockerInThread, Global)
+{
+    ASSERT_FALSE(MemoryTrackerBlockerInThread::isBlocked(VariableContext::Process));
+    MemoryTrackerBlockerInThread blocker(VariableContext::Global);
+    ASSERT_TRUE(MemoryTrackerBlockerInThread::isBlocked(VariableContext::Global));
+    ASSERT_EQ(MemoryTrackerBlockerInThread::getLevel(), VariableContext::Global);
+}
+
+TEST(MemoryTrackerBlockerInThread, Nested)
+{
+    {
+        MemoryTrackerBlockerInThread blocker_global(VariableContext::Global);
+        {
+            MemoryTrackerBlockerInThread blocker_user(VariableContext::User);
+            ASSERT_TRUE(MemoryTrackerBlockerInThread::isBlocked(VariableContext::User));
+            ASSERT_FALSE(MemoryTrackerBlockerInThread::isBlocked(VariableContext::Global));
+            ASSERT_EQ(MemoryTrackerBlockerInThread::getLevel(), VariableContext::User);
+        }
+        ASSERT_TRUE(MemoryTrackerBlockerInThread::isBlocked(VariableContext::Global));
+        ASSERT_EQ(MemoryTrackerBlockerInThread::getLevel(), VariableContext::Global);
+    }
+    ASSERT_FALSE(MemoryTrackerBlockerInThread::isBlocked(VariableContext::Process));
+    ASSERT_EQ(MemoryTrackerBlockerInThread::getLevel(), VariableContext::Max);
+}
+
+TEST(MemoryTrackerBlockerInThread, Move)
+{
+    {
+        MemoryTrackerBlockerInThread blocker_global(VariableContext::Global);
+        MemoryTrackerBlockerInThread blocker_user(VariableContext::User);
+
+        blocker_user = std::move(blocker_global);
+        ASSERT_TRUE(MemoryTrackerBlockerInThread::isBlocked(VariableContext::Global));
+        ASSERT_EQ(MemoryTrackerBlockerInThread::getLevel(), VariableContext::Global);
+    }
+    ASSERT_FALSE(MemoryTrackerBlockerInThread::isBlocked(VariableContext::Process));
+    ASSERT_EQ(MemoryTrackerBlockerInThread::getLevel(), VariableContext::Max);
+}

--- a/tests/queries/0_stateless/02117_show_create_table_system.reference
+++ b/tests/queries/0_stateless/02117_show_create_table_system.reference
@@ -1077,6 +1077,7 @@ CREATE TABLE system.stack_trace
     `thread_name` String,
     `thread_id` UInt64,
     `query_id` String,
+    `memory_blocked_context` Enum8('Unknown' = -1, 'Global' = 0, 'User' = 1, 'Process' = 2, 'Thread' = 3, 'Max' = 4),
     `trace` Array(UInt64)
 )
 ENGINE = SystemStackTrace

--- a/tests/queries/0_stateless/03570_system_stack_trace_memory_blocked_context.reference
+++ b/tests/queries/0_stateless/03570_system_stack_trace_memory_blocked_context.reference
@@ -1,0 +1,2 @@
+Global
+Max

--- a/tests/queries/0_stateless/03570_system_stack_trace_memory_blocked_context.sql
+++ b/tests/queries/0_stateless/03570_system_stack_trace_memory_blocked_context.sql
@@ -1,0 +1,1 @@
+select distinct memory_blocked_context from system.stack_trace where memory_blocked_context in ('Global', 'Max') order by all;


### PR DESCRIPTION
**Note, it is a draft for now since I want to test it first, and then I will replace `abort` with `chassert`**

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Prevent unblocking a higher-level MemoryTracker and add some guard rails

I'm debugging one problem where I see lots of allocations allocated with
memory_blocked_context == Global in trace_log (I've extened it recently
to include this information), I've looked into this a lot already and
don't have any other ideas, so let's catch them.

_@al13n321 maybe you will be curios to look_