### PR TITLE
Dynamic `backups.max_attempts_after_bad_version` to work on big clusters

### DIFF
--- a/src/Backups/BackupCoordinationStageSync.cpp
+++ b/src/Backups/BackupCoordinationStageSync.cpp
@@ -115,7 +115,8 @@ BackupCoordinationStageSync::BackupCoordinationStageSync(
     , failure_after_host_disconnected_for_seconds(with_retries.getKeeperSettings().failure_after_host_disconnected_for_seconds)
     , finish_timeout_after_error(with_retries.getKeeperSettings().finish_timeout_after_error)
     , sync_period_ms(with_retries.getKeeperSettings().sync_period_ms)
-    , max_attempts_after_bad_version(with_retries.getKeeperSettings().max_attempts_after_bad_version)
+    // all_hosts.size() is added to max_attempts_after_bad_version since each host change the num_hosts node once, and it's a valid case
+    , max_attempts_after_bad_version(with_retries.getKeeperSettings().max_attempts_after_bad_version + all_hosts.size())
     , zookeeper_path(zookeeper_path_)
     , root_zookeeper_path(zookeeper_path.parent_path().parent_path())
     , operation_zookeeper_path(zookeeper_path.parent_path())

--- a/tests/integration/test_backup_restore_on_cluster/concurrency_helper.py
+++ b/tests/integration/test_backup_restore_on_cluster/concurrency_helper.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+from typing import Callable, List
+
+from helpers.cluster import ClickHouseCluster, ClickHouseInstance
+
+
+def generate_cluster_def(file: str, num_nodes: int) -> str:
+    path = (
+        Path(__file__).parent / f"_gen/cluster_{Path(file).stem}_{num_nodes}_nodes.xml"
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    replicas = "\n".join(
+        f"""                <replica>
+                    <host>node{i}</host>
+                    <port>9000</port>
+                </replica>"""
+        for i in range(num_nodes)
+    )
+    path.write_text(
+        encoding="utf-8",
+        data=f"""<clickhouse>
+    <remote_servers>
+        <cluster>
+            <shard>
+{replicas}
+            </shard>
+        </cluster>
+    </remote_servers>
+</clickhouse>""",
+    )
+    return str(path.absolute())
+
+
+def add_nodes_to_cluster(
+    cluster: ClickHouseCluster,
+    num_nodes: int,
+    main_configs: List[str],
+    user_configs: List[str],
+) -> List[ClickHouseInstance]:
+    nodes = [
+        cluster.add_instance(
+            f"node{i}",
+            main_configs=main_configs,
+            user_configs=user_configs,
+            external_dirs=["/backups/"],
+            macros={"replica": f"node{i}", "shard": "shard1"},
+            with_zookeeper=True,
+        )
+        for i in range(num_nodes)
+    ]
+    return nodes
+
+
+def create_test_table(node: ClickHouseInstance) -> None:
+    node.query(
+        """CREATE TABLE tbl ON CLUSTER 'cluster' ( x UInt64 )
+ENGINE=ReplicatedMergeTree('/clickhouse/tables/tbl/', '{replica}')
+ORDER BY tuple()"""
+    )

--- a/tests/integration/test_backup_restore_on_cluster/test_huge_concurrent_restore.py
+++ b/tests/integration/test_backup_restore_on_cluster/test_huge_concurrent_restore.py
@@ -1,0 +1,78 @@
+from typing import List
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster, ClickHouseInstance
+from helpers.test_tools import TSV
+
+from .concurrency_helper import (
+    add_nodes_to_cluster,
+    create_test_table,
+    generate_cluster_def,
+)
+
+cluster = ClickHouseCluster(__file__)
+
+# Testing backups.max_attempts_after_bad_version is dynamic, and depends on num_nodes
+num_nodes = 20
+
+main_configs = [
+    "configs/backups_disk.xml",
+    generate_cluster_def(__file__, num_nodes),
+]
+# No [Zoo]Keeper retries for tests with concurrency
+user_configs = ["configs/allow_database_types.xml"]
+
+nodes = add_nodes_to_cluster(cluster, num_nodes, main_configs, user_configs)
+
+node0 = nodes[0]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+@pytest.fixture(autouse=True)
+def drop_after_test():
+    try:
+        yield
+    finally:
+        node0.query("DROP TABLE IF EXISTS tbl ON CLUSTER 'cluster' SYNC")
+        node0.query("DROP DATABASE IF EXISTS mydb ON CLUSTER 'cluster' SYNC")
+
+
+backup_id_counter = 0
+
+
+def new_backup_name():
+    global backup_id_counter
+    backup_id_counter += 1
+    return f"Disk('backups', '{backup_id_counter}')"
+
+
+def create_and_fill_table() -> None:
+    create_test_table(node0)
+    for i, node in enumerate(nodes):
+        node.query(f"INSERT INTO tbl VALUES ({i})")
+
+
+expected_sum = num_nodes * (num_nodes - 1) // 2
+
+
+def test_backup_restore_huge_cluster():
+    create_and_fill_table()
+
+    backup_name = new_backup_name()
+    node0.query(f"BACKUP TABLE tbl ON CLUSTER 'cluster' TO {backup_name}")
+
+    node0.query("DROP TABLE tbl ON CLUSTER 'cluster' SYNC")
+    node0.query(f"RESTORE TABLE tbl ON CLUSTER 'cluster' FROM {backup_name}")
+    node0.query("SYSTEM SYNC REPLICA ON CLUSTER 'cluster' tbl")
+
+    for i in range(num_nodes):
+        assert nodes[i].query("SELECT sum(x) FROM tbl") == TSV([expected_sum])


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Big clusters with node numbers > 10 have a high probability of failing the restore with error `[941] 67c45db4-4df4-4879-87c5-25b8d1e0d414 <Trace>: RestoreCoordinationOnCluster The version of node /clickhouse/backups/restore-7c551a77-bd76-404c-bad0-3213618ac58e/stage/num_hosts changed (attempt #9), will try again`. The `num_hosts` node is overwritten by many hosts at the same time. The fix makes the setting to control attempts dynamic. Closes #87721 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
