### PR TITLE
Not support transaction for tables with disks which do not support writing with append.

### DIFF
--- a/src/Disks/ObjectStorages/IMetadataStorage.h
+++ b/src/Disks/ObjectStorages/IMetadataStorage.h
@@ -326,6 +326,9 @@ public:
         const std::string & /* config_prefix */,
         ContextPtr /* context */) {}
 
+    /// Only support writing with Append if MetadataTransactionPtr created by `createTransaction` has `supportAddingBlobToMetadata`
+    virtual bool supportWritingWithAppend() const { return false; }
+
 protected:
     [[noreturn]] static void throwNotImplemented()
     {

--- a/src/Disks/ObjectStorages/MetadataStorageFromDisk.cpp
+++ b/src/Disks/ObjectStorages/MetadataStorageFromDisk.cpp
@@ -131,6 +131,12 @@ MetadataTransactionPtr MetadataStorageFromDisk::createTransaction()
     return std::make_shared<MetadataStorageFromDiskTransaction>(*this);
 }
 
+/// It supports writing with Append because `createTransaction` creates `MetadataStorageFromDiskTransaction` which has `supportAddingBlobToMetadata`
+bool MetadataStorageFromDisk::supportWritingWithAppend() const
+{
+    return true;
+}
+
 StoredObjects MetadataStorageFromDisk::getStorageObjects(const std::string & path) const
 {
     return readMetadata(path)->objects;

--- a/src/Disks/ObjectStorages/MetadataStorageFromDisk.h
+++ b/src/Disks/ObjectStorages/MetadataStorageFromDisk.h
@@ -27,6 +27,8 @@ public:
 
     MetadataTransactionPtr createTransaction() override;
 
+    bool supportWritingWithAppend() const override;
+
     const std::string & getPath() const override;
 
     MetadataStorageType getType() const override { return MetadataStorageType::Local; }

--- a/src/Storages/StorageMergeTree.h
+++ b/src/Storages/StorageMergeTree.h
@@ -176,7 +176,7 @@ private:
     std::map<Int64, PreparedSetsCachePtr::weak_type> mutation_prepared_sets_cache;
     PlainLightweightUpdatesSync lightweight_updates_sync;
 
-    bool support_transaction{true};
+    const bool support_transaction;
 
     void loadMutations();
 

--- a/src/Storages/StorageMergeTree.h
+++ b/src/Storages/StorageMergeTree.h
@@ -57,7 +57,7 @@ public:
 
     bool supportsParallelInsert() const override { return true; }
 
-    bool supportsTransactions() const override { return true; }
+    bool supportsTransactions() const override { return support_transaction; }
 
     void read(
         QueryPlan & query_plan,
@@ -175,6 +175,8 @@ private:
     std::mutex mutation_prepared_sets_cache_mutex;
     std::map<Int64, PreparedSetsCachePtr::weak_type> mutation_prepared_sets_cache;
     PlainLightweightUpdatesSync lightweight_updates_sync;
+
+    bool support_transaction{true};
 
     void loadMutations();
 

--- a/tests/config/config.d/storage_conf.xml
+++ b/tests/config/config.d/storage_conf.xml
@@ -42,6 +42,14 @@
                 <background_download_queue_size_limit>0</background_download_queue_size_limit>
                 <load_metadata_asynchronously>0</load_metadata_asynchronously>
             </s3_cache_02933>
+            <s3_plain_rewritable>
+                <type>object_storage</type>
+                <object_storage_type>s3</object_storage_type>
+                <metadata_type>plain_rewritable</metadata_type>
+                <endpoint>http://localhost:11111/test/s3_plain_rewritable/</endpoint>
+                <access_key_id>clickhouse</access_key_id>
+                <secret_access_key>clickhouse</secret_access_key>
+            </s3_plain_rewritable>
             <!-- local disks -->
             <local_disk>
                 <type>object_storage</type>
@@ -79,6 +87,12 @@
                 <max_size>22548578304</max_size>
                 <cache_on_write_operations>1</cache_on_write_operations>
             </local_cache_3>
+            <local_plain_rewritable>
+                <type>object_storage</type>
+                <object_storage_type>local</object_storage_type>
+                <path>disks/test/local_plain_rewritable/</path>
+                <metadata_type>plain_rewritable</metadata_type>
+            </local_plain_rewritable>
             <!-- multi layer cache -->
             <s3_cache_multi>
                 <type>cache</type>

--- a/tests/queries/0_stateless/03657_merge_tree_disk_support_transaction.sql
+++ b/tests/queries/0_stateless/03657_merge_tree_disk_support_transaction.sql
@@ -1,0 +1,41 @@
+-- Tags: no-ordinary-database, no-fasttest, no-encrypted-storage
+
+CREATE OR REPLACE TABLE t (x INT) ENGINE=MergeTree ORDER BY x;
+SET implicit_transaction=True;
+INSERT INTO TABLE t VALUES (1);
+SET implicit_transaction=False;
+
+CREATE OR REPLACE TABLE t (x INT) ENGINE=MergeTree ORDER BY x SETTINGS disk='local_disk';
+SET implicit_transaction=True;
+INSERT INTO TABLE t VALUES (2);
+SET implicit_transaction=False;
+
+CREATE OR REPLACE TABLE t (x INT) ENGINE=MergeTree ORDER BY x SETTINGS disk='local_disk_2';
+SET implicit_transaction=True;
+INSERT INTO TABLE t VALUES (3);
+SET implicit_transaction=False;
+
+CREATE OR REPLACE TABLE t (x INT) ENGINE=MergeTree ORDER BY x SETTINGS disk='local_disk_3';
+SET implicit_transaction=True;
+INSERT INTO TABLE t VALUES (4);
+SET implicit_transaction=False;
+
+CREATE OR REPLACE TABLE t (x INT) ENGINE=MergeTree ORDER BY x SETTINGS disk='s3_disk';
+SET implicit_transaction=True;
+INSERT INTO TABLE t VALUES (5);
+SET implicit_transaction=False;
+
+CREATE OR REPLACE TABLE t (x INT) ENGINE=MergeTree ORDER BY x SETTINGS disk='s3_plain_rewritable';
+SET implicit_transaction=True;
+INSERT INTO TABLE t VALUES (6); -- { serverError NOT_IMPLEMENTED }
+SET implicit_transaction=False;
+
+CREATE OR REPLACE TABLE t  (x INT) ENGINE=MergeTree ORDER BY x SETTINGS disk='s3_cache';
+SET implicit_transaction=True;
+INSERT INTO TABLE t VALUES (7);
+SET implicit_transaction=False;
+
+CREATE OR REPLACE TABLE t  (x INT) ENGINE=MergeTree ORDER BY x SETTINGS disk='local_plain_rewritable';
+SET implicit_transaction=True;
+INSERT INTO TABLE t VALUES (8); -- { serverError NOT_IMPLEMENTED }
+SET implicit_transaction=False;

--- a/tests/queries/0_stateless/03657_merge_tree_disk_support_transaction.sql
+++ b/tests/queries/0_stateless/03657_merge_tree_disk_support_transaction.sql
@@ -1,4 +1,4 @@
--- Tags: no-ordinary-database, no-fasttest, no-encrypted-storage
+-- Tags: no-ordinary-database, no-fasttest, no-encrypted-storage, no-async-insert
 
 CREATE OR REPLACE TABLE t (x INT) ENGINE=MergeTree ORDER BY x;
 SET implicit_transaction=True;


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):

For MergeTree tables using object storage which do not support writing with append, it will not support transactions. Closes #84669

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
