### PR TITLE
ci: add complete database directory into artifacts for failed tests

### DIFF
--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -328,12 +328,7 @@ def main():
                 failed_suits.append(test_result.name.split("/")[0])
         failed_suits = list(set(failed_suits))
         for failed_suit in failed_suits:
-            files.extend(
-                Shell.get_output(
-                    f"find ./tests/integration/{failed_suit} -name '*.log*'"
-                ).splitlines()
-            )
-
+            files.extend(f"tests/integration/{failed_suit}")
         files = [Utils.compress_files_gz(files, f"{temp_path}/logs.tar.gz")]
 
     R = Result.create_from(results=test_results, stopwatch=sw, files=files)


### PR DESCRIPTION
This has been changed during refactoring, let's get it back, it is useful.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)