### PR TITLE
Small fuzzer fixes

### DIFF
--- a/programs/client/FuzzLoop.cpp
+++ b/programs/client/FuzzLoop.cpp
@@ -649,7 +649,7 @@ bool Client::buzzHouse()
                 total_create_database_tries++;
             }
             else if (
-                gen.collectionHas<std::shared_ptr<BuzzHouse::SQLDatabase>>(gen.attached_databases) && total_create_table_tries < 100
+                gen.collectionHas<std::shared_ptr<BuzzHouse::SQLDatabase>>(gen.attached_databases) && total_create_table_tries < 150
                 && nsuccessfull_create_table < max_initial_tables)
             {
                 gen.generateNextCreateTable(

--- a/src/Client/BuzzHouse/AST/SQLProtoStr.cpp
+++ b/src/Client/BuzzHouse/AST/SQLProtoStr.cpp
@@ -660,6 +660,34 @@ CONV_FN(SpecialVal, val)
                 ret += "::DateTime64";
             }
             break;
+        case SpecialVal_SpecialValEnum::SpecialVal_SpecialValEnum_MIN_DOUBLE:
+            ret += std::to_string(std::numeric_limits<double>::min());
+            if (val.paren())
+            {
+                ret += "::Float64";
+            }
+            break;
+        case SpecialVal_SpecialValEnum::SpecialVal_SpecialValEnum_MAX_DOUBLE:
+            ret += std::to_string(std::numeric_limits<double>::max());
+            if (val.paren())
+            {
+                ret += "::Float64";
+            }
+            break;
+        case SpecialVal_SpecialValEnum::SpecialVal_SpecialValEnum_DENORM_MIN_DOUBLE:
+            ret += std::to_string(std::numeric_limits<double>::denorm_min());
+            if (val.paren())
+            {
+                ret += "::Float64";
+            }
+            break;
+        case SpecialVal_SpecialValEnum::SpecialVal_SpecialValEnum_LOWEST_DOUBLE:
+            ret += std::to_string(std::numeric_limits<double>::lowest());
+            if (val.paren())
+            {
+                ret += "::Float64";
+            }
+            break;
         case SpecialVal_SpecialValEnum::SpecialVal_SpecialValEnum_VAL_NULL_CHAR:
             ret += "'\\0'";
             break;

--- a/src/Client/BuzzHouse/AST/SQLProtoStr.cpp
+++ b/src/Client/BuzzHouse/AST/SQLProtoStr.cpp
@@ -2980,6 +2980,12 @@ CONV_FN(CreateDatabase, create_database)
         ret += "IF NOT EXISTS ";
     }
     DatabaseToString(ret, create_database.database());
+    if (create_database.has_uuid())
+    {
+        ret += " UUID '";
+        ret += create_database.uuid();
+        ret += "'";
+    }
     if (create_database.has_cluster())
     {
         ClusterToString(ret, true, create_database.cluster());
@@ -3449,6 +3455,12 @@ CONV_FN(CreateTable, create_table)
         ret += "IF NOT EXISTS ";
     }
     ExprSchemaTableToString(ret, create_table.est());
+    if (create_table.has_uuid())
+    {
+        ret += " UUID '";
+        ret += create_table.uuid();
+        ret += "'";
+    }
     if (create_table.has_cluster())
     {
         ClusterToString(ret, true, create_table.cluster());
@@ -3837,7 +3849,8 @@ CONV_FN(OptimizeTable, ot)
     }
     if (ot.final())
     {
-        ret += " FINAL";
+        ret += " ";
+        ret += ot.use_force() ? "FORCE" : "FINAL";
     }
     if (ot.has_dedup())
     {
@@ -3966,6 +3979,12 @@ CONV_FN(CreateView, create_view)
         ret += "IF NOT EXISTS ";
     }
     ExprSchemaTableToString(ret, create_view.est());
+    if (create_view.has_uuid())
+    {
+        ret += " UUID '";
+        ret += create_view.uuid();
+        ret += "'";
+    }
     if (create_view.has_cluster())
     {
         ClusterToString(ret, true, create_view.cluster());
@@ -4193,6 +4212,12 @@ CONV_FN(CreateDictionary, create_dictionary)
     if (create_dictionary.has_cluster())
     {
         ClusterToString(ret, true, create_dictionary.cluster());
+    }
+    if (create_dictionary.has_uuid())
+    {
+        ret += " UUID '";
+        ret += create_dictionary.uuid();
+        ret += "'";
     }
     ret += " (";
     DictionaryColumnToString(ret, create_dictionary.col());

--- a/src/Client/BuzzHouse/Generator/ExternalIntegrations.cpp
+++ b/src/Client/BuzzHouse/Generator/ExternalIntegrations.cpp
@@ -708,7 +708,7 @@ String PostgreSQLIntegration::columnTypeAsString(RandomGenerator & rg, const boo
         if (rg.nextSmallNumber() < 3)
         {
             /// Generate array type
-            const uint32_t ndimensions = rg.nextMediumNumber() < 81 ? 1 : (rg.nextMediumNumber() % 4) + 1;
+            const uint32_t ndimensions = rg.nextMediumNumber() < 81 ? 1 : rg.randomInt<uint32_t>(1, 4);
 
             for (uint32_t i = 0; i < ndimensions; i++)
             {
@@ -847,9 +847,9 @@ std::unique_ptr<SQLiteIntegration> SQLiteIntegration::testAndAddSQLiteIntegratio
 void RedisIntegration::setTableEngineDetails(RandomGenerator & rg, const SQLTable &, TableEngine * te)
 {
     te->add_params()->set_svalue(sc.server_hostname + ":" + std::to_string(sc.port));
-    te->add_params()->set_num(rg.nextBool() ? 0 : rg.nextLargeNumber() % 16);
+    te->add_params()->set_num(rg.nextBool() ? 0 : rg.randomInt<uint32_t>(0, 15));
     te->add_params()->set_svalue(sc.password);
-    te->add_params()->set_num(rg.nextBool() ? 16 : rg.nextLargeNumber() % 33);
+    te->add_params()->set_num(rg.nextBool() ? 16 : rg.randomInt<uint32_t>(0, 33));
 }
 
 bool RedisIntegration::performTableIntegration(RandomGenerator &, SQLTable &, const bool, std::vector<ColumnPathChain> &)

--- a/src/Client/BuzzHouse/Generator/ExternalIntegrations.cpp
+++ b/src/Client/BuzzHouse/Generator/ExternalIntegrations.cpp
@@ -225,7 +225,7 @@ bool ClickHouseIntegratedDatabase::performCreatePeerTable(
             newd.set_if_not_exists(true);
             deng->set_engine(t.db->deng);
             t.db->setName(newd.mutable_database());
-            t.db->finishDatabaseSpecification(deng);
+            t.db->finishDatabaseSpecification(deng, t.db->nparams > 0);
             CreateDatabaseToString(buf, newd);
             res &= !performQuery(buf + ";");
         }

--- a/src/Client/BuzzHouse/Generator/ExternalIntegrations.cpp
+++ b/src/Client/BuzzHouse/Generator/ExternalIntegrations.cpp
@@ -83,7 +83,15 @@ void ClickHouseIntegratedDatabase::swapTableDefinitions(RandomGenerator & rg, Cr
                     }
                     else
                     {
-                        sv.set_value(rg.pickRandomly(chs.oracle_values));
+                        const String ovalue = sv.value();
+                        String nvalue = rg.pickRandomly(chs.oracle_values);
+
+                        for (uint32_t j = 0; j < 4 && ovalue == nvalue; j++)
+                        {
+                            /// Pick another value until they are different
+                            nvalue = rg.pickRandomly(chs.oracle_values);
+                        }
+                        sv.set_value(nvalue);
                     }
                 }
             }
@@ -194,6 +202,7 @@ void ClickHouseIntegratedDatabase::swapTableDefinitions(RandomGenerator & rg, Cr
     }
     if (newt.has_cluster() && rg.nextSmallNumber() < 4)
     {
+        /// Remove cluster
         newt.clear_cluster();
     }
     else if (!fc.clusters.empty() && rg.nextSmallNumber() < 4)

--- a/src/Client/BuzzHouse/Generator/ExternalIntegrations.cpp
+++ b/src/Client/BuzzHouse/Generator/ExternalIntegrations.cpp
@@ -97,13 +97,13 @@ void ClickHouseIntegratedDatabase::swapTableDefinitions(RandomGenerator & rg, Cr
             }
         }
     }
+    if (te.has_partition_by() && rg.nextSmallNumber() < 5)
+    {
+        /// Remove partition by
+        te.clear_partition_by();
+    }
     if (teng >= TableEngineValues::MergeTree && teng <= TableEngineValues::VersionedCollapsingMergeTree)
     {
-        if (te.has_partition_by() && rg.nextSmallNumber() < 5)
-        {
-            /// Remove partition by
-            te.clear_partition_by();
-        }
         if (te.has_primary_key() && te.has_order() && rg.nextSmallNumber() < 5)
         {
             /// Remove primary key or order by clause
@@ -364,7 +364,7 @@ String MySQLIntegration::truncateStatement()
 bool MySQLIntegration::optimizeTableForOracle(const PeerTableDatabase pt, const SQLTable & t)
 {
     chassert(t.hasDatabasePeer());
-    if (is_clickhouse)
+    if (is_clickhouse && t.isMergeTreeFamily())
     {
         /// Sometimes the optimize step doesn't have to do anything, then throws error. Ignore it
         const auto u = performQueryOnServerOrRemote(pt, fmt::format("ALTER TABLE {} APPLY DELETED MASK;", getTableName(t.db, t.tname)));

--- a/src/Client/BuzzHouse/Generator/FuzzConfig.cpp
+++ b/src/Client/BuzzHouse/Generator/FuzzConfig.cpp
@@ -432,6 +432,10 @@ FuzzConfig::FuzzConfig(DB::ClientBase * c, const String & path)
             min_string_length,
             max_string_length);
     }
+    if (max_columns == 0)
+    {
+        throw DB::Exception(DB::ErrorCodes::BUZZHOUSE, "max_columns must be at least 1");
+    }
     for (const auto & entry : std::views::values(metrics))
     {
         measure_performance |= entry.enabled;

--- a/src/Client/BuzzHouse/Generator/QueryOracle.cpp
+++ b/src/Client/BuzzHouse/Generator/QueryOracle.cpp
@@ -977,7 +977,7 @@ void QueryOracle::processSecondOracleQueryResult(const int errcode, ExternalInte
                 || fc.oracle_ignore_error_codes.find(static_cast<uint32_t>(first_errcode ? first_errcode : errcode))
                     == fc.oracle_ignore_error_codes.end()))
         {
-            throw DB::Exception(DB::ErrorCodes::BUZZHOUSE, "{}: failed with different success results", oracle_name);
+            throw DB::Exception(DB::ErrorCodes::BUZZHOUSE, "{}: failed with different success results: {} vs {}", oracle_name, first_errcode, errcode);
         }
         if (!first_errcode && !errcode)
         {

--- a/src/Client/BuzzHouse/Generator/QueryOracle.cpp
+++ b/src/Client/BuzzHouse/Generator/QueryOracle.cpp
@@ -583,7 +583,7 @@ void QueryOracle::generateOracleSelectQuery(RandomGenerator & rg, const PeerQuer
     bool explain = false;
     Select * sel = nullptr;
     SelectParen * sparen = nullptr;
-    const uint32_t ncols = (rg.nextMediumNumber() % 5) + UINT32_C(1);
+    const uint32_t ncols = rg.randomInt<uint32_t>(1, 5);
 
     peer_query = pq;
     if (peer_query == PeerQuery::ClickHouseOnly && (fc.measure_performance || fc.compare_explains) && rg.nextBool())

--- a/src/Client/BuzzHouse/Generator/QueryOracle.cpp
+++ b/src/Client/BuzzHouse/Generator/QueryOracle.cpp
@@ -977,7 +977,8 @@ void QueryOracle::processSecondOracleQueryResult(const int errcode, ExternalInte
                 || fc.oracle_ignore_error_codes.find(static_cast<uint32_t>(first_errcode ? first_errcode : errcode))
                     == fc.oracle_ignore_error_codes.end()))
         {
-            throw DB::Exception(DB::ErrorCodes::BUZZHOUSE, "{}: failed with different success results: {} vs {}", oracle_name, first_errcode, errcode);
+            throw DB::Exception(
+                DB::ErrorCodes::BUZZHOUSE, "{}: failed with different success results: {} vs {}", oracle_name, first_errcode, errcode);
         }
         if (!first_errcode && !errcode)
         {

--- a/src/Client/BuzzHouse/Generator/SQLCatalog.cpp
+++ b/src/Client/BuzzHouse/Generator/SQLCatalog.cpp
@@ -1,17 +1,17 @@
-#include <string>
 #include <Client/BuzzHouse/Generator/SQLCatalog.h>
 
 namespace BuzzHouse
 {
 
-void SQLDatabase::finishDatabaseSpecification(DatabaseEngine * de) const
+void SQLDatabase::finishDatabaseSpecification(DatabaseEngine * de, const bool add_params)
 {
-    if (isReplicatedDatabase())
+    if (add_params && isReplicatedOrSharedDatabase())
     {
-        chassert(de->params_size() == 0);
+        chassert(de->params_size() == 0 && this->nparams == 0);
         de->add_params()->set_svalue("/clickhouse/path/" + this->getName());
         de->add_params()->set_svalue("{shard}");
         de->add_params()->set_svalue("{replica}");
+        this->nparams = 3;
     }
 }
 
@@ -394,4 +394,5 @@ String ColumnPathChain::columnPathRef() const
     res += "`";
     return res;
 }
+
 }

--- a/src/Client/BuzzHouse/Generator/SQLCatalog.h
+++ b/src/Client/BuzzHouse/Generator/SQLCatalog.h
@@ -242,10 +242,7 @@ public:
 
     bool isReplicatedOrSharedMergeTree() const { return isReplicatedMergeTree() || isSharedMergeTree(); }
 
-    bool isShared() const
-    {
-        return toption.has_value() && toption.value() == TableEngineOption::TShared;
-    }
+    bool isShared() const { return toption.has_value() && toption.value() == TableEngineOption::TShared; }
 
     bool isFileEngine() const { return teng == TableEngineValues::File; }
 

--- a/src/Client/BuzzHouse/Generator/SQLCatalog.h
+++ b/src/Client/BuzzHouse/Generator/SQLCatalog.h
@@ -146,7 +146,7 @@ struct SQLDatabase
 {
 public:
     bool random_engine = false;
-    uint32_t dname = 0;
+    uint32_t dname = 0, nparams = 0;
     DatabaseEngineValues deng;
     std::optional<String> cluster;
     DetachStatus attached = DetachStatus::ATTACHED;
@@ -190,7 +190,7 @@ public:
 
     void setDatabasePath(RandomGenerator & rg, const FuzzConfig & fc);
 
-    void finishDatabaseSpecification(DatabaseEngine * de) const;
+    void finishDatabaseSpecification(DatabaseEngine * de, bool add_params);
 };
 
 struct SQLBase

--- a/src/Client/BuzzHouse/Generator/SQLCatalog.h
+++ b/src/Client/BuzzHouse/Generator/SQLCatalog.h
@@ -242,6 +242,11 @@ public:
 
     bool isReplicatedOrSharedMergeTree() const { return isReplicatedMergeTree() || isSharedMergeTree(); }
 
+    bool isShared() const
+    {
+        return toption.has_value() && toption.value() == TableEngineOption::TShared;
+    }
+
     bool isFileEngine() const { return teng == TableEngineValues::File; }
 
     bool isJoinEngine() const { return teng == TableEngineValues::Join; }

--- a/src/Client/BuzzHouse/Generator/SQLExpression.cpp
+++ b/src/Client/BuzzHouse/Generator/SQLExpression.cpp
@@ -16,11 +16,11 @@ void StatementGenerator::addFieldAccess(RandomGenerator & rg, Expr * expr, const
         this->depth++;
         if (noption < 41)
         {
-            fa->set_array_index(rg.nextRandomUInt32() % 5);
+            fa->set_array_index(rg.randomInt<uint32_t>(1, 4));
         }
         else if (noption < 71)
         {
-            fa->set_tuple_index(rg.nextRandomUInt32() % 5);
+            fa->set_tuple_index(rg.randomInt<uint32_t>(1, 4));
         }
         else if (this->depth >= this->fc.max_depth || noption < 81)
         {
@@ -51,7 +51,7 @@ void StatementGenerator::addColNestedAccess(RandomGenerator & rg, ExprColumn * e
             TypeName * tpn = nullptr;
             JSONColumns * subcols = expr->mutable_subcols();
             const uint32_t noption = rg.nextMediumNumber();
-            const uint32_t nvalues = std::max(std::min(this->fc.max_width - this->width, rg.nextMediumNumber() % 4), UINT32_C(1));
+            const uint32_t nvalues = std::max(std::min(this->fc.max_width - this->width, rg.randomInt<uint32_t>(1, 3)), UINT32_C(1));
 
             for (uint32_t i = 0; i < nvalues; i++)
             {
@@ -116,7 +116,7 @@ void StatementGenerator::addColNestedAccess(RandomGenerator & rg, ExprColumn * e
         }
         else if (nsuboption < 24)
         {
-            cp.add_sub_cols()->set_column("size" + std::to_string(rg.nextMediumNumber() % 3));
+            cp.add_sub_cols()->set_column("size" + std::to_string(rg.randomInt<uint32_t>(0, 2)));
         }
         this->depth--;
     }
@@ -360,7 +360,7 @@ void StatementGenerator::generateLiteralValue(RandomGenerator & rg, const bool c
         /// Generate a few arrays/tuples with literal values
         ExprList * elist
             = (!complex || rg.nextBool()) ? expr->mutable_comp_expr()->mutable_array() : expr->mutable_comp_expr()->mutable_tuple();
-        const uint32_t nvalues = std::min(this->fc.max_width - this->width, rg.nextMediumNumber() % 8);
+        const uint32_t nvalues = std::min(this->fc.max_width - this->width, rg.randomInt<uint32_t>(0, 8));
 
         this->depth++;
         for (uint32_t i = 0; i < nvalues; i++)
@@ -502,7 +502,7 @@ Expr * StatementGenerator::generatePartialSearchExpr(RandomGenerator & rg, Expr 
     if (nfunc == SQLFunc::FUNChasAnyTokens || nfunc == SQLFunc::FUNChasAllTokens)
     {
         ExprList * elist = expr2->mutable_comp_expr()->mutable_array();
-        const uint32_t nvalues = std::min(this->fc.max_width - this->width, rg.nextMediumNumber() % 6) + 1;
+        const uint32_t nvalues = std::min(this->fc.max_width - this->width, rg.randomInt<uint32_t>(0, 5)) + 1;
 
         for (uint32_t i = 0; i < nvalues; i++)
         {
@@ -593,7 +593,7 @@ void StatementGenerator::generatePredicate(RandomGenerator & rg, Expr * expr)
         else if (in_expr && noption < (unary_expr + binary_expr + between_expr + in_expr + 1))
         {
             const uint32_t nopt2 = rg.nextSmallNumber();
-            const uint32_t nclauses = std::min(this->fc.max_width - this->width, (rg.nextMediumNumber() % 4) + 1);
+            const uint32_t nclauses = std::min(this->fc.max_width - this->width, rg.randomInt<uint32_t>(1, 4));
             ComplicatedExpr * cexpr = expr->mutable_comp_expr();
             ExprIn * ein = cexpr->mutable_expr_in();
             ExprList * elist = ein->mutable_expr();
@@ -774,7 +774,7 @@ void StatementGenerator::generateFuncCall(RandomGenerator & rg, const bool allow
         const uint32_t agg_max_args = std::min(agg.max_args, UINT32_C(5));
         const uint32_t max_args = std::min(this->fc.max_width - this->width, agg_max_args);
         const uint32_t ncombinators
-            = rg.nextSmallNumber() < 4 ? std::min(this->fc.max_width - this->width, (rg.nextSmallNumber() % 3) + 1) : 0;
+            = rg.nextSmallNumber() < 4 ? std::min(this->fc.max_width - this->width, rg.randomInt<uint32_t>(0, 2) + 1) : 0;
         const bool prev_inside_aggregate = this->levels[this->current_level].inside_aggregate;
         const bool prev_allow_window_funcs = this->levels[this->current_level].allow_window_funcs;
         std::uniform_int_distribution<uint32_t> comb_range(
@@ -910,7 +910,7 @@ void StatementGenerator::generateFuncCall(RandomGenerator & rg, const bool allow
 
         if (n_lambda > 0)
         {
-            generateLambdaCall(rg, rg.nextBool() ? 1 : ((rg.nextSmallNumber() % 3) + 1), func_call->add_args()->mutable_lambda());
+            generateLambdaCall(rg, rg.nextBool() ? 1 : rg.randomInt<uint32_t>(1, 3), func_call->add_args()->mutable_lambda());
             this->width++;
             generated_params++;
         }
@@ -955,7 +955,7 @@ void StatementGenerator::generateTableFuncCall(RandomGenerator & rg, SQLTableFun
     tfunc_call->set_func(static_cast<SQLTableFunc>(func.fnum));
     if (n_lambda > 0)
     {
-        generateLambdaCall(rg, rg.nextBool() ? 1 : ((rg.nextSmallNumber() % 3) + 1), tfunc_call->add_args()->mutable_lambda());
+        generateLambdaCall(rg, rg.nextBool() ? 1 : rg.randomInt<uint32_t>(1, 3), tfunc_call->add_args()->mutable_lambda());
         this->width++;
         generated_params++;
     }
@@ -1022,7 +1022,7 @@ void StatementGenerator::generateWindowDefinition(RandomGenerator & rg, WindowDe
 {
     if (this->width < this->fc.max_width && rg.nextSmallNumber() < 4)
     {
-        const uint32_t nclauses = std::min(this->fc.max_width - this->width, (rg.nextMediumNumber() % 4) + 1);
+        const uint32_t nclauses = std::min(this->fc.max_width - this->width, rg.randomInt<uint32_t>(1, 4));
 
         for (uint32_t i = 0; i < nclauses; i++)
         {
@@ -1196,7 +1196,7 @@ void StatementGenerator::generateExpression(RandomGenerator & rg, Expr * expr)
                + 1))
     {
         ExprCase * caseexp = expr->mutable_comp_expr()->mutable_expr_case();
-        const uint32_t nwhen = std::min(this->fc.max_width - this->width, rg.nextMediumNumber() % 4);
+        const uint32_t nwhen = std::min(this->fc.max_width - this->width, rg.randomInt<uint32_t>(0, 3));
 
         this->depth++;
         if (rg.nextSmallNumber() < 5)
@@ -1260,7 +1260,7 @@ void StatementGenerator::generateExpression(RandomGenerator & rg, Expr * expr)
                + subquery_expr + binary_expr + array_tuple_expr + 1))
     {
         ExprList * elist = rg.nextBool() ? expr->mutable_comp_expr()->mutable_array() : expr->mutable_comp_expr()->mutable_tuple();
-        const uint32_t nvalues = std::min(this->fc.max_width - this->width, rg.nextMediumNumber() % 8);
+        const uint32_t nvalues = std::min(this->fc.max_width - this->width, rg.randomInt<uint32_t>(0, 8));
 
         this->depth++;
         for (uint32_t i = 0; i < nvalues; i++)
@@ -1352,7 +1352,7 @@ void StatementGenerator::generateExpression(RandomGenerator & rg, Expr * expr)
                 case WINlagInFrame:
                 case WINlead:
                 case WINleadInFrame:
-                    nargs = std::min(this->fc.max_width - this->width, (rg.nextMediumNumber() % 3) + 1);
+                    nargs = std::min(this->fc.max_width - this->width, rg.randomInt<uint32_t>(1, 3));
                     break;
                 default:
                     break;
@@ -1399,7 +1399,7 @@ void StatementGenerator::generateExpression(RandomGenerator & rg, Expr * expr)
             < (literal_value + col_ref_expr + predicate_expr + cast_expr + unary_expr + interval_expr + columns_expr + cond_expr + case_expr
                + subquery_expr + binary_expr + array_tuple_expr + func_expr + window_func_expr + table_star_expr + lambda_expr + 1))
     {
-        const uint32_t nexprs = std::min(this->fc.max_width - this->width, rg.nextMediumNumber() % 4);
+        const uint32_t nexprs = std::min(this->fc.max_width - this->width, rg.randomInt<uint32_t>(0, 3));
 
         this->depth++;
         generateLambdaCall(rg, nexprs, expr->mutable_comp_expr()->mutable_lambda());

--- a/src/Client/BuzzHouse/Generator/SQLExpression.cpp
+++ b/src/Client/BuzzHouse/Generator/SQLExpression.cpp
@@ -16,11 +16,11 @@ void StatementGenerator::addFieldAccess(RandomGenerator & rg, Expr * expr, const
         this->depth++;
         if (noption < 41)
         {
-            fa->set_array_index(rg.randomInt<uint32_t>(1, 4));
+            fa->set_array_index(rg.randomInt<uint32_t>(0, 4));
         }
         else if (noption < 71)
         {
-            fa->set_tuple_index(rg.randomInt<uint32_t>(1, 4));
+            fa->set_tuple_index(rg.randomInt<uint32_t>(0, 4));
         }
         else if (this->depth >= this->fc.max_depth || noption < 81)
         {
@@ -51,7 +51,7 @@ void StatementGenerator::addColNestedAccess(RandomGenerator & rg, ExprColumn * e
             TypeName * tpn = nullptr;
             JSONColumns * subcols = expr->mutable_subcols();
             const uint32_t noption = rg.nextMediumNumber();
-            const uint32_t nvalues = std::max(std::min(this->fc.max_width - this->width, rg.randomInt<uint32_t>(1, 3)), UINT32_C(1));
+            const uint32_t nvalues = std::max(std::min(this->fc.max_width - this->width, rg.randomInt<uint32_t>(0, 3)), UINT32_C(1));
 
             for (uint32_t i = 0; i < nvalues; i++)
             {
@@ -774,7 +774,7 @@ void StatementGenerator::generateFuncCall(RandomGenerator & rg, const bool allow
         const uint32_t agg_max_args = std::min(agg.max_args, UINT32_C(5));
         const uint32_t max_args = std::min(this->fc.max_width - this->width, agg_max_args);
         const uint32_t ncombinators
-            = rg.nextSmallNumber() < 4 ? std::min(this->fc.max_width - this->width, rg.randomInt<uint32_t>(0, 2) + 1) : 0;
+            = rg.nextSmallNumber() < 4 ? std::min(this->fc.max_width - this->width, rg.randomInt<uint32_t>(1, 3)) : 0;
         const bool prev_inside_aggregate = this->levels[this->current_level].inside_aggregate;
         const bool prev_allow_window_funcs = this->levels[this->current_level].allow_window_funcs;
         std::uniform_int_distribution<uint32_t> comb_range(

--- a/src/Client/BuzzHouse/Generator/SQLQuery.cpp
+++ b/src/Client/BuzzHouse/Generator/SQLQuery.cpp
@@ -474,6 +474,7 @@ void StatementGenerator::setTableFunction(RandomGenerator & rg, const TableFunct
         const RemoteFunc_RName fname = (isPeer || rg.nextSmallNumber() < 8) ? RemoteFunc::remote : RemoteFunc::remoteSecure;
 
         rfunc->set_rname(fname);
+        t.setName(rfunc->mutable_tof()->mutable_est(), true);
         if (isPeer)
         {
             const ServerCredentials & sc = fc.clickhouse_server.value();
@@ -487,12 +488,11 @@ void StatementGenerator::setTableFunction(RandomGenerator & rg, const TableFunct
             rfunc->set_address(fc.getConnectionHostAndPort(fname == RemoteFunc::remoteSecure));
             rfunc->set_user("default");
             rfunc->set_password("");
-        }
-        t.setName(rfunc->mutable_tof()->mutable_est(), true);
-        if (rg.nextSmallNumber() < 4)
-        {
-            /// Optional sharding key
-            setRandomShardKey(rg, std::make_optional<SQLTable>(t), rfunc->mutable_sharding_key());
+            if (rg.nextSmallNumber() < 4)
+            {
+                /// Optional sharding key
+                setRandomShardKey(rg, std::make_optional<SQLTable>(t), rfunc->mutable_sharding_key());
+            }
         }
     }
     else

--- a/src/Client/BuzzHouse/Generator/SQLQuery.cpp
+++ b/src/Client/BuzzHouse/Generator/SQLQuery.cpp
@@ -677,7 +677,7 @@ bool StatementGenerator::joinedTableOrFunction(
         /// A derived query
         SQLRelation rel(rel_name);
         ExplainQuery * eq = tof->mutable_select();
-        const uint32_t ncols = std::min(this->fc.max_width - this->width, (rg.nextMediumNumber() % UINT32_C(5)) + 1);
+        const uint32_t ncols = std::min(this->fc.max_width - this->width, rg.randomInt<uint32_t>(1, 5));
 
         if (ncols == 1 && rg.nextMediumNumber() < 6)
         {
@@ -957,8 +957,8 @@ bool StatementGenerator::joinedTableOrFunction(
         SQLRelation rel(rel_name);
         std::unordered_map<uint32_t, QueryLevel> levels_backup;
         std::unordered_map<uint32_t, std::unordered_map<String, SQLRelation>> ctes_backup;
-        const uint32_t ncols = std::min<uint32_t>(this->fc.max_width - this->width, (rg.nextSmallNumber() % 3) + UINT32_C(1));
-        const uint32_t nrows = (rg.nextSmallNumber() % 3) + UINT32_C(1);
+        const uint32_t ncols = std::min<uint32_t>(this->fc.max_width - this->width, rg.randomInt<uint32_t>(1, 3));
+        const uint32_t nrows = rg.randomInt<uint32_t>(1, 3);
         ValuesStatement * vs = tof->mutable_tfunc()->mutable_values();
 
         chassert(ncols);
@@ -1260,7 +1260,7 @@ void StatementGenerator::generateJoinConstraint(RandomGenerator & rg, const bool
         if (!generated)
         {
             /// Joining clause
-            const uint32_t nclauses = std::min(this->fc.max_width - this->width, rg.nextSmallNumber() % 3) + UINT32_C(1);
+            const uint32_t nclauses = std::min(this->fc.max_width - this->width, rg.randomInt<uint32_t>(0, 2)) + UINT32_C(1);
             Expr * expr = jc->mutable_on_expr();
 
             for (uint32_t i = 0; i < nclauses; i++)
@@ -1558,7 +1558,7 @@ void StatementGenerator::generateWherePredicate(RandomGenerator & rg, Expr * exp
     this->depth++;
     if (!available_cols.empty() && noption < 8)
     {
-        const uint32_t nclauses = std::max(std::min(this->fc.max_width - this->width, (rg.nextMediumNumber() % 4) + 1), UINT32_C(1));
+        const uint32_t nclauses = std::max(std::min(this->fc.max_width - this->width, rg.randomInt<uint32_t>(0, 3)), UINT32_C(1));
 
         for (uint32_t i = 0; i < nclauses; i++)
         {
@@ -1630,7 +1630,7 @@ void StatementGenerator::generateWherePredicate(RandomGenerator & rg, Expr * exp
 uint32_t StatementGenerator::generateFromStatement(RandomGenerator & rg, const uint32_t allowed_clauses, FromStatement * ft)
 {
     JoinClause * jc = ft->mutable_tos()->mutable_join_clause();
-    const uint32_t njoined = std::min(this->fc.max_width - this->width, (rg.nextMediumNumber() % UINT32_C(4)) + 1);
+    const uint32_t njoined = std::min(this->fc.max_width - this->width, rg.randomInt<uint32_t>(1, 4));
 
     chassert(njoined > 0);
     this->depth++;
@@ -1695,7 +1695,7 @@ void StatementGenerator::generateGroupByExpr(
     {
         LiteralValue * lv = expr->mutable_lit_val();
 
-        lv->mutable_int_lit()->set_uint_lit((rg.nextRandomUInt64() % ncols) + 1);
+        lv->mutable_int_lit()->set_uint_lit(rg.randomInt<uint32_t>(1, ncols));
     }
     else
     {
@@ -1861,7 +1861,7 @@ void StatementGenerator::generateOrderBy(
             {
                 LiteralValue * lv = expr->mutable_lit_val();
 
-                lv->mutable_int_lit()->set_uint_lit((rg.nextRandomUInt64() % ncols) + 1);
+                lv->mutable_int_lit()->set_uint_lit(rg.randomInt<uint32_t>(1, ncols));
             }
             else
             {
@@ -1964,7 +1964,7 @@ void StatementGenerator::generateLimit(RandomGenerator & rg, const bool has_orde
         {
             LiteralValue * lv = expr->mutable_lit_val();
 
-            lv->mutable_int_lit()->set_uint_lit((rg.nextRandomUInt64() % ncols) + 1);
+            lv->mutable_int_lit()->set_uint_lit(rg.randomInt<uint32_t>(1, ncols));
         }
         else
         {
@@ -1992,7 +1992,7 @@ void StatementGenerator::generateOffset(RandomGenerator & rg, const bool has_ord
 
 void StatementGenerator::addCTEs(RandomGenerator & rg, const uint32_t allowed_clauses, CTEs * qctes)
 {
-    const uint32_t nclauses = std::min<uint32_t>(this->fc.max_width - this->width, (rg.nextRandomUInt32() % 3) + 1);
+    const uint32_t nclauses = std::min<uint32_t>(this->fc.max_width - this->width, rg.randomInt<uint32_t>(1, 3));
 
     this->depth++;
     for (uint32_t i = 0; i < nclauses; i++)
@@ -2005,7 +2005,7 @@ void StatementGenerator::addCTEs(RandomGenerator & rg, const uint32_t allowed_cl
             CTEquery * nqcte = scte->mutable_cte_query();
             const String name = fmt::format("cte{}d{}", this->levels[this->current_level].cte_counter++, this->current_level);
             SQLRelation rel(name);
-            const uint32_t ncols = std::min(this->fc.max_width - this->width, (rg.nextMediumNumber() % UINT32_C(5)) + 1);
+            const uint32_t ncols = std::min(this->fc.max_width - this->width, rg.randomInt<uint32_t>(1, 5));
             const bool recursive = fc.allow_infinite_tables && this->depth<this->fc.max_depth && this->fc.max_width> this->width + 1
                 && rg.nextSmallNumber() < 4;
 
@@ -2043,7 +2043,7 @@ void StatementGenerator::addCTEs(RandomGenerator & rg, const uint32_t allowed_cl
 void StatementGenerator::addWindowDefs(RandomGenerator & rg, SelectStatementCore * ssc)
 {
     /// Set windows for the query
-    const uint32_t nclauses = std::min<uint32_t>(this->fc.max_width - this->width, (rg.nextRandomUInt32() % 3) + 1);
+    const uint32_t nclauses = std::min<uint32_t>(this->fc.max_width - this->width, rg.randomInt<uint32_t>(1, 3));
 
     this->depth++;
     for (uint32_t i = 0; i < nclauses; i++)
@@ -2264,7 +2264,7 @@ void StatementGenerator::generateSelect(
 void StatementGenerator::generateTopSelect(
     RandomGenerator & rg, const bool force_global_agg, const uint32_t allowed_clauses, TopSelect * ts)
 {
-    const uint32_t ncols = std::max(std::min(this->fc.max_width - this->width, (rg.nextMediumNumber() % UINT32_C(5)) + 1), UINT32_C(1));
+    const uint32_t ncols = std::max(std::min(this->fc.max_width - this->width, rg.randomInt<uint32_t>(1, 5)), UINT32_C(1));
 
     this->levels[this->current_level] = QueryLevel(this->current_level);
     generateSelect(rg, true, force_global_agg, ncols, allowed_clauses, std::nullopt, ts->mutable_sel());
@@ -2286,7 +2286,7 @@ void StatementGenerator::generateTopSelect(
         }
         if (rg.nextSmallNumber() < 4)
         {
-            sif->set_level((rg.nextRandomUInt32() % 22) + 1);
+            sif->set_level(rg.randomInt<uint32_t>(1, 22));
         }
     }
 }

--- a/src/Client/BuzzHouse/Generator/SQLTable.cpp
+++ b/src/Client/BuzzHouse/Generator/SQLTable.cpp
@@ -1446,10 +1446,7 @@ void StatementGenerator::generateEngineDetails(
         {
             svs = svs ? svs : te->mutable_setting_values();
             SetValue * sv = svs->has_set_value() ? svs->add_other_values() : svs->mutable_set_value();
-            const String & pick
-                = (fc.storage_policies.empty() || ((b.isJoinEngine() || b.isSetEngine()) && b.isShared()) || rg.nextSmallNumber() < 8)
-                ? "disk"
-                : "storage_policy";
+            const String & pick = (fc.keeper_disks.empty() || rg.nextSmallNumber() < 3) ? "storage_policy" : "disk";
 
             sv->set_property(pick);
             sv->set_value("'" + rg.pickRandomly(pick == "storage_policy" ? fc.storage_policies : fc.keeper_disks) + "'");

--- a/src/Client/BuzzHouse/Generator/SQLTable.cpp
+++ b/src/Client/BuzzHouse/Generator/SQLTable.cpp
@@ -1701,7 +1701,7 @@ void StatementGenerator::addTableIndex(RandomGenerator & rg, SQLTable & t, const
         case IndexType::IDX_text: {
             String buf;
             bool has_paren = rg.nextSmallNumber() < 8;
-            static const DB::Strings & tokenizerVals = {"splitByNonAlpha", "splitByString", "ngrams", "array"};
+            static const DB::Strings & tokenizerVals = {"splitByNonAlpha", "splitByString", "ngrams", "array", "sparseGrams"};
             const String & next_tokenizer = rg.pickRandomly(tokenizerVals);
 
             buf += fmt::format("tokenizer = {}", next_tokenizer);
@@ -1732,6 +1732,14 @@ void StatementGenerator::addTableIndex(RandomGenerator & rg, SQLTable & t, const
                 }
                 buf2 += "]";
                 buf += buf2;
+            }
+            else if (has_paren && next_tokenizer == "sparseGrams" && rg.nextBool())
+            {
+                std::uniform_int_distribution<uint32_t> next_dist(0, rg.nextBool() ? 10 : 100);
+
+                buf += std::to_string(next_dist(rg.generator));
+                buf += ", ";
+                buf += std::to_string(next_dist(rg.generator));
             }
             buf += has_paren ? ")" : "";
             idef->add_params()->set_unescaped_sval(std::move(buf));

--- a/src/Client/BuzzHouse/Generator/SQLTable.cpp
+++ b/src/Client/BuzzHouse/Generator/SQLTable.cpp
@@ -1854,19 +1854,20 @@ void StatementGenerator::getNextPeerTableDatabase(RandomGenerator & rg, SQLBase 
     chassert(this->ids.empty());
     if (b.is_deterministic && b.teng != Set && b.teng != ExternalDistributed)
     {
-        if (b.teng != MySQL && connections.hasMySQLConnection())
+        if (!b.isMySQLEngine() && connections.hasMySQLConnection())
         {
             this->ids.emplace_back(static_cast<uint32_t>(PeerTableDatabase::MySQL));
         }
-        if (b.teng != PostgreSQL && b.teng != MaterializedPostgreSQL && connections.hasPostgreSQLConnection())
+        if (!b.isPostgreSQLEngine() && connections.hasPostgreSQLConnection())
         {
             this->ids.emplace_back(static_cast<uint32_t>(PeerTableDatabase::PostgreSQL));
         }
-        if (b.teng != SQLite && connections.hasSQLiteConnection())
+        if (!b.isSQLiteEngine() && connections.hasSQLiteConnection())
         {
             this->ids.emplace_back(static_cast<uint32_t>(PeerTableDatabase::SQLite));
         }
-        if (b.teng >= MergeTree && b.teng <= VersionedCollapsingMergeTree && connections.hasClickHouseExtraServerConnection())
+        if ((b.isMergeTreeFamily() || b.isLogFamily() || b.isRocksEngine() || b.isKeeperMapEngine() || b.isJoinEngine() || b.isSetEngine())
+            && connections.hasClickHouseExtraServerConnection())
         {
             this->ids.emplace_back(static_cast<uint32_t>(PeerTableDatabase::ClickHouse));
             this->ids.emplace_back(static_cast<uint32_t>(PeerTableDatabase::ClickHouse)); // give more probability

--- a/src/Client/BuzzHouse/Generator/SQLTable.cpp
+++ b/src/Client/BuzzHouse/Generator/SQLTable.cpp
@@ -1852,7 +1852,7 @@ void StatementGenerator::addTableConstraint(RandomGenerator & rg, SQLTable & t, 
 void StatementGenerator::getNextPeerTableDatabase(RandomGenerator & rg, SQLBase & b)
 {
     chassert(this->ids.empty());
-    if (b.is_deterministic && b.teng != Set && b.teng != ExternalDistributed)
+    if (b.is_deterministic && !b.is_temp && !b.isExternalDistributedEngine())
     {
         if (!b.isMySQLEngine() && connections.hasMySQLConnection())
         {

--- a/src/Client/BuzzHouse/Generator/SQLTable.cpp
+++ b/src/Client/BuzzHouse/Generator/SQLTable.cpp
@@ -1446,7 +1446,10 @@ void StatementGenerator::generateEngineDetails(
         {
             svs = svs ? svs : te->mutable_setting_values();
             SetValue * sv = svs->has_set_value() ? svs->add_other_values() : svs->mutable_set_value();
-            const String & pick = (fc.keeper_disks.empty() || rg.nextSmallNumber() < 3) ? "storage_policy" : "disk";
+            const String & pick
+                = (fc.storage_policies.empty() || ((b.isJoinEngine() || b.isSetEngine()) && b.isShared()) || rg.nextSmallNumber() < 8)
+                ? "disk"
+                : "storage_policy";
 
             sv->set_property(pick);
             sv->set_value("'" + rg.pickRandomly(pick == "storage_policy" ? fc.storage_policies : fc.keeper_disks) + "'");

--- a/src/Client/BuzzHouse/Generator/SQLTable.cpp
+++ b/src/Client/BuzzHouse/Generator/SQLTable.cpp
@@ -369,7 +369,7 @@ void StatementGenerator::generateNextStatistics(RandomGenerator & rg, ColumnStat
 
 void StatementGenerator::generateNextCodecs(RandomGenerator & rg, CodecList * cl)
 {
-    const uint32_t ncodecs = (rg.nextMediumNumber() % UINT32_C(3)) + 1;
+    const uint32_t ncodecs = rg.randomInt<uint32_t>(1, 3);
     std::uniform_int_distribution<uint32_t> codec_range(1, static_cast<uint32_t>(CompressionCodec_MAX));
 
     for (uint32_t i = 0; i < ncodecs; i++)
@@ -500,7 +500,7 @@ void StatementGenerator::generateTTLExpression(RandomGenerator & rg, const std::
 void StatementGenerator::generateNextTTL(
     RandomGenerator & rg, const std::optional<SQLTable> & t, const TableEngine * te, TTLExpr * ttl_expr)
 {
-    const uint32_t nttls = (rg.nextLargeNumber() % 3) + 1;
+    const uint32_t nttls = rg.randomInt<uint32_t>(1, 3);
 
     for (uint32_t i = 0; i < nttls; i++)
     {
@@ -806,7 +806,7 @@ void StatementGenerator::generateTableKey(
         if (rg.nextSmallNumber() < 3)
         {
             /// Generate a random key
-            const uint32_t nkeys = (rg.nextMediumNumber() % UINT32_C(3)) + UINT32_C(1);
+            const uint32_t nkeys = rg.randomInt<uint32_t>(1, 3);
 
             for (uint32_t i = 0; i < nkeys; i++)
             {
@@ -1802,7 +1802,7 @@ void StatementGenerator::addTableIndex(RandomGenerator & rg, SQLTable & t, const
         }
         else if (next_opt < 8)
         {
-            granularity = UINT32_C(1) << (rg.nextLargeNumber() % 21);
+            granularity = UINT32_C(1) << rg.randomInt<uint32_t>(0, 20);
         }
         idef->set_granularity(granularity);
     }
@@ -1812,7 +1812,7 @@ void StatementGenerator::addTableIndex(RandomGenerator & rg, SQLTable & t, const
 void StatementGenerator::addTableProjection(RandomGenerator & rg, SQLTable & t, const bool staged, ProjectionDef * pdef)
 {
     const uint32_t pname = t.proj_counter++;
-    const uint32_t ncols = std::max(std::min(this->fc.max_width - this->width, (rg.nextMediumNumber() % UINT32_C(3)) + 1), UINT32_C(1));
+    const uint32_t ncols = std::max(std::min(this->fc.max_width - this->width, rg.randomInt<uint32_t>(1, 3)), UINT32_C(1));
     auto & to_add = staged ? t.staged_projs : t.projs;
 
     pdef->mutable_proj()->set_projection("p" + std::to_string(pname));
@@ -2165,12 +2165,12 @@ void StatementGenerator::generateNextCreateTable(RandomGenerator & rg, const boo
         uint32_t added_sign = 0;
         uint32_t added_is_deleted = 0;
         uint32_t added_version = 0;
-        const uint32_t to_addcols = (rg.nextLargeNumber() % fc.max_columns) + UINT32_C(1);
+        const uint32_t to_addcols = rg.randomInt<uint32_t>(1, fc.max_columns);
         const uint32_t to_addidxs
-            = ((rg.nextMediumNumber() % 4) + UINT32_C(1)) * static_cast<uint32_t>(next.isMergeTreeFamily() && rg.nextSmallNumber() < 4);
+            = rg.randomInt<uint32_t>(1, 4) * static_cast<uint32_t>(next.isMergeTreeFamily() && rg.nextSmallNumber() < 4);
         const uint32_t to_addprojs
-            = ((rg.nextMediumNumber() % 3) + UINT32_C(1)) * static_cast<uint32_t>(next.isMergeTreeFamily() && rg.nextSmallNumber() < 5);
-        const uint32_t to_addconsts = ((rg.nextMediumNumber() % 3) + UINT32_C(1)) * static_cast<uint32_t>(rg.nextSmallNumber() < 3);
+            = rg.randomInt<uint32_t>(1, 3) * static_cast<uint32_t>(next.isMergeTreeFamily() && rg.nextSmallNumber() < 5);
+        const uint32_t to_addconsts = rg.randomInt<uint32_t>(1, 3) * static_cast<uint32_t>(rg.nextSmallNumber() < 3);
         const uint32_t to_add_sign = static_cast<uint32_t>(next.hasSignColumn());
         const uint32_t to_add_version = static_cast<uint32_t>(next.hasVersionColumn() || add_version_to_replacing);
         const uint32_t to_add_is_deleted = static_cast<uint32_t>(add_version_to_replacing && rg.nextSmallNumber() < 4);
@@ -2345,7 +2345,7 @@ void StatementGenerator::generateNextCreateDictionary(RandomGenerator & rg, Crea
     const DictionaryLayouts & dl = rg.pickRandomly(allDictionaryLayoutSettings);
     const bool isRange = dl == COMPLEX_KEY_RANGE_HASHED || dl == RANGE_HASHED;
     /// Range requires 2 cols for min and max
-    const uint32_t dictionary_ncols = std::max((rg.nextLargeNumber() % fc.max_columns) + UINT32_C(1), isRange ? UINT32_C(2) : UINT32_C(1));
+    const uint32_t dictionary_ncols = std::max(rg.randomInt<uint32_t>(1, fc.max_columns), isRange ? UINT32_C(2) : UINT32_C(1));
     SettingValues * svs = nullptr;
     DictionaryLayout * layout = cd->mutable_layout();
     const uint32_t type_mask_backup = this->next_type_mask;

--- a/src/Client/BuzzHouse/Generator/SQLTable.cpp
+++ b/src/Client/BuzzHouse/Generator/SQLTable.cpp
@@ -2301,6 +2301,10 @@ void StatementGenerator::generateNextCreateTable(RandomGenerator & rg, const boo
     generateEngineDetails(rg, createTableRelation(rg, true, "", next), next, !added_pkey, te);
     this->entries.clear();
 
+    if (rg.nextSmallNumber() < 4)
+    {
+        ct->set_uuid(rg.nextUUID());
+    }
     if (next.cluster.has_value())
     {
         ct->mutable_cluster()->set_cluster(next.cluster.value());
@@ -2529,6 +2533,11 @@ void StatementGenerator::generateNextCreateDictionary(RandomGenerator & rg, Crea
         }
         dc->set_is_object_id(rg.nextMediumNumber() < 3);
     }
+    if (rg.nextSmallNumber() < 4)
+    {
+        cd->set_uuid(rg.nextUUID());
+    }
+
     setClusterInfo(rg, next);
     if (next.cluster.has_value())
     {
@@ -2646,6 +2655,10 @@ void StatementGenerator::generateNextCreateDatabase(RandomGenerator & rg, Create
     SQLDatabase::setRandomDatabase(rg, next);
     next.deng = this->getNextDatabaseEngine(rg);
     deng->set_engine(next.deng);
+    if (rg.nextBool())
+    {
+        cd->set_uuid(rg.nextUUID());
+    }
     if (!next.isSharedDatabase() && !fc.clusters.empty() && rg.nextSmallNumber() < 4)
     {
         next.cluster = rg.pickRandomly(fc.clusters);

--- a/src/Client/BuzzHouse/Generator/SQLTable.cpp
+++ b/src/Client/BuzzHouse/Generator/SQLTable.cpp
@@ -2660,7 +2660,7 @@ void StatementGenerator::generateNextCreateDatabase(RandomGenerator & rg, Create
     }
     else
     {
-        next.finishDatabaseSpecification(deng);
+        next.finishDatabaseSpecification(deng, rg.nextBool());
     }
     next.setName(cd->mutable_database());
     if (rg.nextSmallNumber() < 3)

--- a/src/Client/BuzzHouse/Generator/SQLTable.cpp
+++ b/src/Client/BuzzHouse/Generator/SQLTable.cpp
@@ -298,7 +298,7 @@ SQLRelation StatementGenerator::createViewRelation(const String & rel_name, cons
 {
     SQLRelation rel(rel_name);
 
-    assert(!v.cols.empty());
+    chassert(!v.cols.empty());
     for (const auto & entry : v.cols)
     {
         rel.cols.emplace_back(SQLRelationCol(rel_name, {"c" + std::to_string(entry)}));

--- a/src/Client/BuzzHouse/Generator/SQLTable.cpp
+++ b/src/Client/BuzzHouse/Generator/SQLTable.cpp
@@ -1069,7 +1069,7 @@ void StatementGenerator::generateMergeTreeEngineDetails(
 void StatementGenerator::setClusterInfo(RandomGenerator & rg, SQLBase & b) const
 {
     /// Don't use on CLUSTER with ReplicatedMergeTrees or SharedMergeTrees
-    if (!fc.clusters.empty() && !b.isSharedMergeTree() && (!b.db || !b.db->isSharedDatabase()) && (b.db || !supports_cloud_features)
+    if (!fc.clusters.empty() && !b.isShared() && (!b.db || !b.db->isSharedDatabase()) && (b.db || !supports_cloud_features)
         && rg.nextSmallNumber() < (b.toption.has_value() ? 9 : 5))
     {
         if (b.db && b.db->cluster.has_value() && rg.nextSmallNumber() < 9)
@@ -1433,7 +1433,7 @@ void StatementGenerator::generateEngineDetails(
             sv->set_property("mode");
             sv->set_value(fmt::format("'{}ordered'", rg.nextBool() ? "un" : ""));
         }
-        if ((b.isMergeTreeFamily() || b.isLogFamily()) && (b.isSharedMergeTree() || rg.nextSmallNumber() < 3)
+        if ((b.isMergeTreeFamily() || b.isLogFamily() || b.isShared()) && (b.isShared() || rg.nextSmallNumber() < 3)
             && (!fc.storage_policies.empty() || !fc.keeper_disks.empty())
             && (!svs
                 || (svs->set_value().property() != "storage_policy" && svs->set_value().property() != "disk"

--- a/src/Client/BuzzHouse/Generator/SQLTable.cpp
+++ b/src/Client/BuzzHouse/Generator/SQLTable.cpp
@@ -1399,7 +1399,7 @@ void StatementGenerator::generateEngineDetails(
     {
         const auto & engineSettings = allTableSettings.at(b.teng);
 
-        if (!engineSettings.empty() && rg.nextBool())
+        if (!engineSettings.empty() && (!b.isJoinEngine() || !b.isShared()) && rg.nextBool())
         {
             /// Add table engine settings
             svs = svs ? svs : te->mutable_setting_values();

--- a/src/Client/BuzzHouse/Generator/SQLTypes.cpp
+++ b/src/Client/BuzzHouse/Generator/SQLTypes.cpp
@@ -1671,7 +1671,7 @@ SQLType * StatementGenerator::randomDecimalType(RandomGenerator & rg, const uint
                 precision = std::optional<uint32_t>(76);
                 break;
         }
-        scale = std::optional<uint32_t>(rg.nextRandomUInt32() % (precision.value() + 1));
+        scale = std::optional<uint32_t>(rg.randomInt<uint32_t>(0, precision.value()));
         if (dec)
         {
             DecimalN * dn = dec->mutable_decimaln();
@@ -1693,7 +1693,7 @@ SQLType * StatementGenerator::randomDecimalType(RandomGenerator & rg, const uint
             }
             if (rg.nextBool())
             {
-                scale = std::optional<uint32_t>(rg.nextRandomUInt32() % (precision.value() + 1));
+                scale = std::optional<uint32_t>(rg.randomInt<uint32_t>(0, precision.value()));
                 if (dec)
                 {
                     ds->set_scale(scale.value());
@@ -1883,7 +1883,7 @@ SQLType * StatementGenerator::bottomType(RandomGenerator & rg, const uint64_t al
         String desc;
         std::vector<JSubType> subcols;
         JSONDef * jdef = tp ? tp->mutable_jdef() : nullptr;
-        const uint32_t nclauses = rg.nextLargeNumber() % 7;
+        const uint32_t nclauses = rg.randomInt<uint32_t>(0, 6);
 
         if (nclauses)
         {
@@ -1924,7 +1924,7 @@ SQLType * StatementGenerator::bottomType(RandomGenerator & rg, const uint64_t al
             else
             {
                 uint32_t col_counter = 0;
-                const uint32_t ncols = (rg.nextMediumNumber() % 4) + 1;
+                const uint32_t ncols = rg.randomInt<uint32_t>(1, 4);
                 JSONPathType * jpt = tp ? jdi->mutable_path_type() : nullptr;
                 ColumnPath * cp = tp ? jpt->mutable_col() : nullptr;
                 String npath;
@@ -1978,7 +1978,7 @@ SQLType * StatementGenerator::bottomType(RandomGenerator & rg, const uint64_t al
 
         if (rg.nextBool())
         {
-            ntypes = std::optional<uint32_t>(rg.nextBool() ? rg.nextSmallNumber() : ((rg.nextRandomUInt32() % 100) + 1));
+            ntypes = std::optional<uint32_t>(rg.nextBool() ? rg.nextSmallNumber() : rg.randomInt<uint32_t>(1, 100));
             if (dyn)
             {
                 dyn->set_ntypes(ntypes.value());
@@ -2250,7 +2250,7 @@ String appendDecimal(RandomGenerator & rg, const bool use_func, const uint32_t l
 String strAppendGeoValue(RandomGenerator & rg, const GeoTypes & gt)
 {
     String ret;
-    const uint32_t limit = rg.nextLargeNumber() % 10;
+    const uint32_t limit = rg.randomInt<uint32_t>(0, 10);
 
     switch (gt)
     {
@@ -2275,7 +2275,7 @@ String strAppendGeoValue(RandomGenerator & rg, const GeoTypes & gt)
             ret += "[";
             for (uint32_t i = 0; i < limit; i++)
             {
-                const uint32_t nlines = rg.nextLargeNumber() % 10;
+                const uint32_t nlines = rg.randomInt<uint32_t>(0, 10);
 
                 if (i != 0)
                 {
@@ -2298,7 +2298,7 @@ String strAppendGeoValue(RandomGenerator & rg, const GeoTypes & gt)
             ret += "[";
             for (uint32_t i = 0; i < limit; i++)
             {
-                const uint32_t npoligons = rg.nextLargeNumber() % 10;
+                const uint32_t npoligons = rg.randomInt<uint32_t>(0, 10);
 
                 if (i != 0)
                 {
@@ -2307,7 +2307,7 @@ String strAppendGeoValue(RandomGenerator & rg, const GeoTypes & gt)
                 ret += "[";
                 for (uint32_t j = 0; j < npoligons; j++)
                 {
-                    const uint32_t nlines = rg.nextLargeNumber() % 10;
+                    const uint32_t nlines = rg.randomInt<uint32_t>(0, 10);
 
                     if (j != 0)
                     {

--- a/src/Client/BuzzHouse/Generator/SQLTypes.cpp
+++ b/src/Client/BuzzHouse/Generator/SQLTypes.cpp
@@ -180,9 +180,18 @@ String IntType::insertNumberEntry(RandomGenerator & rg, StatementGenerator & gen
     if (size > 8 && rg.nextSmallNumber() < 8)
     {
         String buf = "CAST(";
+        const bool negative = (!is_unsigned && rg.nextBool());
 
-        buf += (!is_unsigned && rg.nextBool()) ? "-" : "";
-        buf += "number AS ";
+        buf += negative ? "(-" : "";
+        buf += "number";
+        buf += negative ? ")" : "";
+        if (rg.nextSmallNumber() < 4)
+        {
+            /// Generate identical numbers
+            buf += " % ";
+            buf += std::to_string(rg.randomInt<uint32_t>(2, 100));
+        }
+        buf += " AS ";
         buf += typeName(false, false);
         buf += ")";
         return buf;
@@ -225,9 +234,17 @@ String FloatType::insertNumberEntry(RandomGenerator & rg, StatementGenerator & g
     if (rg.nextSmallNumber() < 8)
     {
         String buf = "CAST(";
+        const bool negative = rg.nextBool();
 
-        buf += rg.nextBool() ? "-" : "";
-        buf += "number AS ";
+        buf += negative ? "(-" : "";
+        buf += "number";
+        buf += negative ? ")" : "";
+        if (rg.nextSmallNumber() < 4)
+        {
+            buf += " % ";
+            buf += std::to_string(rg.randomInt<uint32_t>(2, 100));
+        }
+        buf += " AS ";
         buf += typeName(false, false);
         buf += ")";
         return buf;
@@ -476,9 +493,17 @@ String DecimalType::insertNumberEntry(RandomGenerator & rg, StatementGenerator &
     if (rg.nextSmallNumber() < 8)
     {
         String buf = "CAST(";
+        const bool negative = rg.nextBool();
 
-        buf += rg.nextBool() ? "-" : "";
-        buf += "number AS ";
+        buf += negative ? "(-" : "";
+        buf += "number";
+        buf += negative ? ")" : "";
+        if (rg.nextSmallNumber() < 4)
+        {
+            buf += " % ";
+            buf += std::to_string(rg.randomInt<uint32_t>(2, 100));
+        }
+        buf += " AS ";
         buf += typeName(false, false);
         buf += ")";
         return buf;

--- a/src/Client/BuzzHouse/Generator/SQLTypes.cpp
+++ b/src/Client/BuzzHouse/Generator/SQLTypes.cpp
@@ -1714,7 +1714,7 @@ SQLType * StatementGenerator::bottomType(RandomGenerator & rg, const uint64_t al
     const uint32_t date_type = 15 * static_cast<uint32_t>((allowed_types & allow_dates) != 0);
     const uint32_t datetime_type = 15 * static_cast<uint32_t>((allowed_types & allow_datetimes) != 0);
     const uint32_t string_type = 30 * static_cast<uint32_t>((allowed_types & allow_strings) != 0);
-    const uint32_t decimal_type = 20 * static_cast<uint32_t>((allowed_types & allow_decimals) != 0);
+    const uint32_t decimal_type = 20 * static_cast<uint32_t>(!low_card && (allowed_types & allow_decimals) != 0);
     const uint32_t bool_type = 20 * static_cast<uint32_t>((allowed_types & allow_bool) != 0);
     const uint32_t enum_type = 15 * static_cast<uint32_t>(!low_card && (allowed_types & allow_enum) != 0);
     const uint32_t uuid_type = 10 * static_cast<uint32_t>((allowed_types & allow_uuid) != 0);

--- a/src/Client/BuzzHouse/Generator/SessionSettings.cpp
+++ b/src/Client/BuzzHouse/Generator/SessionSettings.cpp
@@ -264,7 +264,6 @@ std::unordered_map<String, CHSetting> serverSettings = {
     {"allow_archive_path_syntax", trueOrFalseSettingNoOracle},
     {"allow_asynchronous_read_from_io_pool_for_merge_tree", trueOrFalseSetting},
     {"allow_changing_replica_until_first_data_packet", trueOrFalseSettingNoOracle},
-    {"allow_dynamic_metadata_for_data_lakes", trueOrFalseSettingNoOracle},
     {"allow_dynamic_type_in_join_keys", trueOrFalseSettingNoOracle},
     {"allow_experimental_delta_kernel_rs", trueOrFalseSettingNoOracle},
     {"allow_get_client_http_header", trueOrFalseSettingNoOracle},

--- a/src/Client/BuzzHouse/Generator/SessionSettings.cpp
+++ b/src/Client/BuzzHouse/Generator/SessionSettings.cpp
@@ -264,6 +264,7 @@ std::unordered_map<String, CHSetting> serverSettings = {
     {"allow_archive_path_syntax", trueOrFalseSettingNoOracle},
     {"allow_asynchronous_read_from_io_pool_for_merge_tree", trueOrFalseSetting},
     {"allow_changing_replica_until_first_data_packet", trueOrFalseSettingNoOracle},
+    {"allow_dynamic_metadata_for_data_lakes", trueOrFalseSettingNoOracle},
     {"allow_dynamic_type_in_join_keys", trueOrFalseSettingNoOracle},
     {"allow_experimental_delta_kernel_rs", trueOrFalseSettingNoOracle},
     {"allow_get_client_http_header", trueOrFalseSettingNoOracle},

--- a/src/Client/BuzzHouse/Generator/SessionSettings.cpp
+++ b/src/Client/BuzzHouse/Generator/SessionSettings.cpp
@@ -147,6 +147,7 @@ std::unordered_map<String, CHSetting> performanceSettings
        {"optimize_respect_aliases", trueOrFalseSetting},
        {"optimize_rewrite_aggregate_function_with_if", trueOrFalseSetting},
        {"optimize_rewrite_array_exists_to_has", trueOrFalseSetting},
+       {"optimize_rewrite_like_perfect_affix", trueOrFalseSetting},
        {"optimize_rewrite_regexp_functions", trueOrFalseSetting},
        {"optimize_rewrite_sum_if_to_count_if", trueOrFalseSetting},
        {"optimize_skip_merged_partitions", trueOrFalseSetting},

--- a/src/Client/BuzzHouse/Generator/SessionSettings.cpp
+++ b/src/Client/BuzzHouse/Generator/SessionSettings.cpp
@@ -85,7 +85,7 @@ std::unordered_map<String, CHSetting> performanceSettings
                 }
                 else
                 {
-                    const uint32_t nalgo = (rg.nextMediumNumber() % static_cast<uint32_t>(choices.size())) + 1;
+                    const uint32_t nalgo = rg.randomInt<uint32_t>(0, static_cast<uint32_t>(choices.size()));
 
                     std::shuffle(choices.begin(), choices.end(), rg.generator);
                     for (uint32_t i = 0; i < nalgo; i++)
@@ -469,7 +469,7 @@ std::unordered_map<String, CHSetting> serverSettings = {
          {
              String res;
              std::vector<uint32_t> choices = {0, 1, 2, 3, 4};
-             const uint32_t nchoices = (rg.nextMediumNumber() % static_cast<uint32_t>(choices.size())) + 1;
+             const uint32_t nchoices = rg.randomInt<uint32_t>(0, static_cast<uint32_t>(choices.size()));
 
              std::shuffle(choices.begin(), choices.end(), rg.generator);
              for (uint32_t i = 0; i < nchoices; i++)

--- a/src/Client/BuzzHouse/Generator/StatementGenerator.cpp
+++ b/src/Client/BuzzHouse/Generator/StatementGenerator.cpp
@@ -548,6 +548,10 @@ void StatementGenerator::generateNextCreateView(RandomGenerator & rg, CreateView
             next.cols.insert(i);
         }
     }
+    if (rg.nextSmallNumber() < 4)
+    {
+        cv->set_uuid(rg.nextUUID());
+    }
     setClusterInfo(rg, next);
     if (next.cluster.has_value())
     {
@@ -717,6 +721,7 @@ void StatementGenerator::generateNextOptimizeTableInternal(RandomGenerator & rg,
         ot->mutable_cluster()->set_cluster(cluster.value());
     }
     ot->set_final((t.supportsFinal() || t.isMergeTreeFamily() || rg.nextMediumNumber() < 21) && (strict || rg.nextSmallNumber() < 4));
+    ot->set_use_force(rg.nextBool());
     if (rg.nextSmallNumber() < 3)
     {
         generateSettingValues(rg, serverSettings, ot->mutable_setting_values());
@@ -734,6 +739,7 @@ void StatementGenerator::generateNextOptimizeTable(RandomGenerator & rg, Optimiz
         /// Optimize system table
         rg.pickRandomly(systemTables).setName(ot->mutable_est());
         ot->set_final(rg.nextBool());
+        ot->set_use_force(rg.nextBool());
         if (rg.nextBool())
         {
             DeduplicateExpr * dde = ot->mutable_dedup();
@@ -2490,6 +2496,10 @@ void StatementGenerator::generateAttach(RandomGenerator & rg, Attach * att)
     else
     {
         chassert(0);
+    }
+    if (rg.nextSmallNumber() < 4)
+    {
+        att->set_uuid(rg.nextUUID());
     }
     if (cluster.has_value())
     {

--- a/src/Client/BuzzHouse/Generator/StatementGenerator.cpp
+++ b/src/Client/BuzzHouse/Generator/StatementGenerator.cpp
@@ -517,7 +517,7 @@ void StatementGenerator::generateNextCreateView(RandomGenerator & rg, CreateView
                 }
                 if (nids.empty())
                 {
-                    nids.emplace_back(rg.pickRandomly(t.cols));
+                    nids.push_back(rg.pickRandomly(t.cols));
                 }
                 else if (rg.nextBool())
                 {

--- a/src/Client/BuzzHouse/Generator/StatementGenerator.cpp
+++ b/src/Client/BuzzHouse/Generator/StatementGenerator.cpp
@@ -515,11 +515,15 @@ void StatementGenerator::generateNextCreateView(RandomGenerator & rg, CreateView
                         nids.push_back(key);
                     }
                 }
-                if (rg.nextBool())
+                if (nids.empty())
+                {
+                    nids.emplace_back(rg.pickRandomly(t.cols));
+                }
+                else if (rg.nextBool())
                 {
                     std::shuffle(nids.begin(), nids.end(), rg.generator);
                 }
-                for (uint32_t i = 0; i < view_ncols; i++)
+                for (uint32_t i = 0; i < std::min(view_ncols, static_cast<uint32_t>(nids.size())); i++)
                 {
                     SQLColumn col = t.cols.at(nids[i]);
 

--- a/src/Client/BuzzHouse/Generator/StatementGenerator.cpp
+++ b/src/Client/BuzzHouse/Generator/StatementGenerator.cpp
@@ -313,7 +313,7 @@ void StatementGenerator::generateNextCreateFunction(RandomGenerator & rg, Create
     const bool prev_allow_not_deterministic = this->allow_not_deterministic;
 
     next.fname = fname;
-    next.nargs = std::min(this->fc.max_width - this->width, (rg.nextLargeNumber() % fc.max_columns) + UINT32_C(1));
+    next.nargs = std::min(this->fc.max_width - this->width, rg.randomInt<uint32_t>(1, fc.max_columns));
     next.is_deterministic = rg.nextBool();
     /// If this function is later called by an oracle, then don't call it
     this->allow_not_deterministic = !next.is_deterministic;
@@ -422,7 +422,7 @@ void StatementGenerator::generateNextCreateView(RandomGenerator & rg, CreateView
 {
     SQLView next;
     uint32_t tname = 0;
-    const uint32_t view_ncols = (rg.nextLargeNumber() % fc.max_columns) + UINT32_C(1);
+    const uint32_t view_ncols = rg.randomInt<uint32_t>(1, fc.max_columns);
     const bool prev_enforce_final = this->enforce_final;
     const bool prev_allow_not_deterministic = this->allow_not_deterministic;
     SelectParen * sparen = cv->mutable_select();
@@ -523,7 +523,10 @@ void StatementGenerator::generateNextCreateView(RandomGenerator & rg, CreateView
                 {
                     std::shuffle(nids.begin(), nids.end(), rg.generator);
                 }
-                for (uint32_t i = 0; i < std::min(view_ncols, static_cast<uint32_t>(nids.size())); i++)
+                const uint32_t limit = std::min(view_ncols, static_cast<uint32_t>(nids.size()));
+
+                chassert(limit > 0);
+                for (uint32_t i = 0; i < limit; i++)
                 {
                     SQLColumn col = t.cols.at(nids[i]);
 
@@ -928,7 +931,7 @@ void StatementGenerator::generateNextDescTable(RandomGenerator & rg, DescribeSta
                 rg,
                 false,
                 false,
-                (rg.nextLargeNumber() % 5) + 1,
+                rg.randomInt<uint32_t>(1, 5),
                 std::numeric_limits<uint32_t>::max(),
                 std::nullopt,
                 eq->mutable_inner_query()->mutable_select()->mutable_sel());
@@ -1040,7 +1043,7 @@ void StatementGenerator::generateNextInsert(RandomGenerator & rg, const bool in_
     }
     else if (random_values && nopt < (hardcoded_insert + random_values + 1))
     {
-        const uint32_t nrows = (rg.nextSmallNumber() % 3) + 1;
+        const uint32_t nrows = rg.randomInt<uint32_t>(1, 3);
         ValuesStatement * vs = ins->mutable_values();
 
         for (uint32_t i = 0; i < nrows; i++)
@@ -1477,8 +1480,7 @@ void StatementGenerator::generateAlter(RandomGenerator & rg, Alter * at)
             {
                 SelectParen * sparen = ati->mutable_modify_query();
 
-                v.staged_ncols
-                    = v.has_with_cols ? static_cast<uint32_t>(v.cols.size()) : ((rg.nextLargeNumber() % fc.max_columns) + UINT32_C(1));
+                v.staged_ncols = v.has_with_cols ? static_cast<uint32_t>(v.cols.size()) : rg.randomInt<uint32_t>(1, fc.max_columns);
                 sparen->set_paren(rg.nextSmallNumber() < 9);
                 this->levels[this->current_level] = QueryLevel(this->current_level);
                 this->allow_in_expression_alias = rg.nextSmallNumber() < 3;
@@ -4608,7 +4610,7 @@ void StatementGenerator::generateNextExplain(RandomGenerator & rg, bool in_paral
         }
         if (!this->ids.empty())
         {
-            const size_t noptions = (static_cast<size_t>(rg.nextRandomUInt32()) % this->ids.size()) + 1;
+            const size_t noptions = rg.randomInt<size_t>(1, this->ids.size());
             std::shuffle(ids.begin(), ids.end(), rg.generator);
 
             for (size_t i = 0; i < noptions; i++)

--- a/src/Client/BuzzHouse/Generator/StatementGenerator.cpp
+++ b/src/Client/BuzzHouse/Generator/StatementGenerator.cpp
@@ -4290,9 +4290,9 @@ void StatementGenerator::generateNextQuery(RandomGenerator & rg, const bool in_p
     const bool has_views = collectionHas<SQLView>(attached_views);
     const bool has_dictionaries = collectionHas<SQLDictionary>(attached_dictionaries);
 
-    const uint32_t create_table = 6 * static_cast<uint32_t>(static_cast<uint32_t>(tables.size()) < this->fc.max_tables);
-    const uint32_t create_view = 10 * static_cast<uint32_t>(static_cast<uint32_t>(views.size()) < this->fc.max_views);
-    const uint32_t drop = 2
+    const uint32_t create_table = 12 * static_cast<uint32_t>(static_cast<uint32_t>(tables.size()) < this->fc.max_tables);
+    const uint32_t create_view = 12 * static_cast<uint32_t>(static_cast<uint32_t>(views.size()) < this->fc.max_views);
+    const uint32_t drop = 1
         * static_cast<uint32_t>(
                               !in_parallel
                               && (collectionCount<SQLTable>(attached_tables) > 3 || collectionCount<SQLView>(attached_views) > 3
@@ -4315,7 +4315,7 @@ void StatementGenerator::generateNextQuery(RandomGenerator & rg, const bool in_p
                                 && (collectionHas<SQLTable>(detached_tables) || collectionHas<SQLView>(detached_views)
                                     || collectionHas<SQLDictionary>(detached_dictionaries)
                                     || collectionHas<std::shared_ptr<SQLDatabase>>(detached_databases)));
-    const uint32_t detach = 2
+    const uint32_t detach = 1
         * static_cast<uint32_t>(!in_parallel
                                 && (collectionCount<SQLTable>(attached_tables) > 3 || collectionCount<SQLView>(attached_views) > 3
                                     || collectionCount<SQLDictionary>(attached_dictionaries) > 3

--- a/src/Client/BuzzHouse/Generator/StatementGenerator.h
+++ b/src/Client/BuzzHouse/Generator/StatementGenerator.h
@@ -676,6 +676,7 @@ public:
 
     void updateGenerator(const SQLQuery & sq, ExternalIntegrations & ei, bool success);
     void setInTransaction(const bool value) { in_transaction = value; }
+    bool getAllowNotDetermistic() const { return allow_not_deterministic; }
 
     friend class QueryOracle;
 };

--- a/src/Client/BuzzHouse/Generator/TableSetttings.cpp
+++ b/src/Client/BuzzHouse/Generator/TableSetttings.cpp
@@ -53,6 +53,35 @@ static std::unordered_map<String, CHSetting> mergeTreeTableSettings = {
     {"apply_patches_on_merge", trueOrFalseSetting},
     {"assign_part_uuids", trueOrFalseSetting},
     {"async_insert", trueOrFalseSetting},
+    {"auto_statistics_types",
+     CHSetting(
+         [](RandomGenerator & rg, FuzzConfig &)
+         {
+             String res;
+             DB::Strings choices = {"tdigest", "countmin", "minmax", "uniq"};
+
+             if (rg.nextSmallNumber() < 3)
+             {
+                 res = rg.pickRandomly(choices);
+             }
+             else
+             {
+                 const uint32_t nopt = rg.randomInt<uint32_t>(0, static_cast<uint32_t>(choices.size()));
+
+                 std::shuffle(choices.begin(), choices.end(), rg.generator);
+                 for (uint32_t i = 0; i < nopt; i++)
+                 {
+                     if (i != 0)
+                     {
+                         res += ",";
+                     }
+                     res += choices[i];
+                 }
+             }
+             return "'" + res + "'";
+         },
+         {},
+         false)},
     {"cache_populated_by_fetch", trueOrFalseSetting},
     {"check_sample_column_is_correct", trueOrFalseSetting},
     {"cleanup_thread_preferred_points_per_iteration", rowsRangeSetting},
@@ -115,7 +144,7 @@ static std::unordered_map<String, CHSetting> mergeTreeTableSettings = {
          {
              String res;
              std::vector<uint32_t> choices = {0, 1, 2, 3, 4};
-             const uint32_t nchoices = (rg.nextMediumNumber() % static_cast<uint32_t>(choices.size())) + 1;
+             const uint32_t nchoices = rg.randomInt<uint32_t>(0, static_cast<uint32_t>(choices.size()));
 
              std::shuffle(choices.begin(), choices.end(), rg.generator);
              for (uint32_t i = 0; i < nchoices; i++)

--- a/src/Client/BuzzHouse/Generator/TableSetttings.cpp
+++ b/src/Client/BuzzHouse/Generator/TableSetttings.cpp
@@ -80,7 +80,7 @@ static std::unordered_map<String, CHSetting> mergeTreeTableSettings = {
              }
              return "'" + res + "'";
          },
-         {},
+         {"'tdigest'", "'countmin'", "'minmax'", "'uniq'"},
          false)},
     {"cache_populated_by_fetch", trueOrFalseSetting},
     {"check_sample_column_is_correct", trueOrFalseSetting},
@@ -203,13 +203,19 @@ static std::unordered_map<String, CHSetting> mergeTreeTableSettings = {
     {"max_parts_in_total", highRangeSetting},
     {"max_parts_to_merge_at_once",
      CHSetting(
-         [](RandomGenerator & rg, FuzzConfig &) { return std::to_string(rg.thresholdGenerator<uint64_t>(0.2, 0.2, 0, 1000)); }, {}, false)},
+         [](RandomGenerator & rg, FuzzConfig &) { return std::to_string(rg.thresholdGenerator<uint64_t>(0.2, 0.2, 0, 1000)); },
+         {"0", "1", "2", "8", "10", "100"},
+         false)},
     {"max_replicated_merges_in_queue",
      CHSetting(
-         [](RandomGenerator & rg, FuzzConfig &) { return std::to_string(rg.thresholdGenerator<uint64_t>(0.2, 0.2, 1, 100)); }, {}, false)},
+         [](RandomGenerator & rg, FuzzConfig &) { return std::to_string(rg.thresholdGenerator<uint64_t>(0.2, 0.2, 1, 100)); },
+         {"0", "1", "2", "8", "10", "100"},
+         false)},
     {"max_replicated_mutations_in_queue",
      CHSetting(
-         [](RandomGenerator & rg, FuzzConfig &) { return std::to_string(rg.thresholdGenerator<uint64_t>(0.2, 0.2, 1, 100)); }, {}, false)},
+         [](RandomGenerator & rg, FuzzConfig &) { return std::to_string(rg.thresholdGenerator<uint64_t>(0.2, 0.2, 1, 100)); },
+         {"0", "1", "2", "8", "10", "100"},
+         false)},
     {"max_suspicious_broken_parts", highRangeSetting},
     {"max_suspicious_broken_parts_bytes", bytesRangeSetting},
     {"max_uncompressed_bytes_in_patches", bytesRangeSetting},
@@ -238,7 +244,7 @@ static std::unordered_map<String, CHSetting> mergeTreeTableSettings = {
      CHSetting(
          [](RandomGenerator & rg, FuzzConfig &)
          { return std::to_string(rg.thresholdGenerator<uint64_t>(0.4, 0.2, 0, UINT32_C(10) * UINT32_C(1024) * UINT32_C(1024))); },
-         {},
+         {"0", "1"},
          false)},
     {"min_bytes_to_prewarm_caches", bytesRangeSetting},
     {"min_bytes_to_rebalance_partition_over_jbod", bytesRangeSetting},
@@ -249,27 +255,37 @@ static std::unordered_map<String, CHSetting> mergeTreeTableSettings = {
     /// ClickHouse cloud setting
     {"min_level_for_full_part_storage",
      CHSetting(
-         [](RandomGenerator & rg, FuzzConfig &) { return std::to_string(rg.thresholdGenerator<uint64_t>(0.2, 0.2, 0, 10)); }, {}, false)},
+         [](RandomGenerator & rg, FuzzConfig &) { return std::to_string(rg.thresholdGenerator<uint64_t>(0.2, 0.2, 0, 10)); },
+         {"0", "1"},
+         false)},
     {"min_level_for_wide_part",
      CHSetting(
-         [](RandomGenerator & rg, FuzzConfig &) { return std::to_string(rg.thresholdGenerator<uint64_t>(0.2, 0.2, 0, 10)); }, {}, false)},
+         [](RandomGenerator & rg, FuzzConfig &) { return std::to_string(rg.thresholdGenerator<uint64_t>(0.2, 0.2, 0, 10)); },
+         {"0", "1"},
+         false)},
     {"min_marks_to_honor_max_concurrent_queries", highRangeSetting},
     {"min_merge_bytes_to_use_direct_io", bytesRangeSetting},
     {"min_parts_to_merge_at_once",
      CHSetting(
-         [](RandomGenerator & rg, FuzzConfig &) { return std::to_string(rg.thresholdGenerator<uint64_t>(0.2, 0.2, 0, 128)); }, {}, false)},
+         [](RandomGenerator & rg, FuzzConfig &) { return std::to_string(rg.thresholdGenerator<uint64_t>(0.2, 0.2, 0, 128)); },
+         {"0", "1"},
+         false)},
     {"min_rows_for_compact_part", rowsRangeSetting},
     {"min_rows_for_full_part_storage",
      CHSetting(
-         [](RandomGenerator & rg, FuzzConfig &) { return std::to_string(rg.thresholdGenerator<uint64_t>(0.2, 0.2, 0, 1000)); }, {}, false)},
+         [](RandomGenerator & rg, FuzzConfig &) { return std::to_string(rg.thresholdGenerator<uint64_t>(0.2, 0.2, 0, 1000)); },
+         {"0", "1"},
+         false)},
     {"min_rows_for_wide_part",
      CHSetting(
          [](RandomGenerator & rg, FuzzConfig &) { return std::to_string(rg.thresholdGenerator<uint64_t>(0.4, 0.2, 0, UINT32_C(8192))); },
-         {},
+         {"0", "1"},
          false)},
     {"min_rows_to_fsync_after_merge",
      CHSetting(
-         [](RandomGenerator & rg, FuzzConfig &) { return std::to_string(rg.thresholdGenerator<uint64_t>(0.2, 0.2, 0, 1000)); }, {}, false)},
+         [](RandomGenerator & rg, FuzzConfig &) { return std::to_string(rg.thresholdGenerator<uint64_t>(0.2, 0.2, 0, 1000)); },
+         {"0", "1"},
+         false)},
     {"non_replicated_deduplication_window", rowsRangeSetting},
     /// ClickHouse cloud setting
     {"notify_newest_block_number", trueOrFalseSetting},
@@ -384,7 +400,9 @@ static std::unordered_map<String, CHSetting> mergeTreeTableSettings = {
     /// ClickHouse cloud setting
     {"shared_merge_tree_parts_load_batch_size",
      CHSetting(
-         [](RandomGenerator & rg, FuzzConfig &) { return std::to_string(rg.thresholdGenerator<uint64_t>(0.2, 0.2, 0, 128)); }, {}, false)},
+         [](RandomGenerator & rg, FuzzConfig &) { return std::to_string(rg.thresholdGenerator<uint64_t>(0.2, 0.2, 0, 128)); },
+         {"0", "1", "2", "8", "10", "100"},
+         false)},
     /// ClickHouse cloud setting
     {"shared_merge_tree_postpone_next_merge_for_locally_merged_parts_rows_threshold", rowsRangeSetting},
     /// ClickHouse cloud setting
@@ -403,7 +421,9 @@ static std::unordered_map<String, CHSetting> mergeTreeTableSettings = {
     {"shared_merge_tree_virtual_parts_discovery_batch", rowsRangeSetting},
     {"simultaneous_parts_removal_limit",
      CHSetting(
-         [](RandomGenerator & rg, FuzzConfig &) { return std::to_string(rg.thresholdGenerator<uint64_t>(0.2, 0.2, 0, 128)); }, {}, false)},
+         [](RandomGenerator & rg, FuzzConfig &) { return std::to_string(rg.thresholdGenerator<uint64_t>(0.2, 0.2, 0, 128)); },
+         {"0", "1", "2", "8", "10", "100"},
+         false)},
     {"string_serialization_version",
      CHSetting(
          [](RandomGenerator & rg, FuzzConfig &)
@@ -425,7 +445,9 @@ static std::unordered_map<String, CHSetting> mergeTreeTableSettings = {
     {"vertical_merge_algorithm_min_bytes_to_activate", bytesRangeSetting},
     {"vertical_merge_algorithm_min_columns_to_activate",
      CHSetting(
-         [](RandomGenerator & rg, FuzzConfig &) { return std::to_string(rg.thresholdGenerator<uint64_t>(0.2, 0.2, 1, 16)); }, {}, false)},
+         [](RandomGenerator & rg, FuzzConfig &) { return std::to_string(rg.thresholdGenerator<uint64_t>(0.2, 0.2, 1, 16)); },
+         {"0", "1"},
+         false)},
     {"vertical_merge_algorithm_min_rows_to_activate", rowsRangeSetting},
     {"vertical_merge_optimize_lightweight_delete", trueOrFalseSetting},
     {"vertical_merge_remote_filesystem_prefetch", trueOrFalseSetting},
@@ -440,37 +462,37 @@ std::unordered_map<TableEngineValues, std::unordered_map<String, CHSetting>> all
 std::unordered_map<DictionaryLayouts, std::unordered_map<String, CHSetting>> allDictionaryLayoutSettings;
 
 std::unordered_map<String, CHSetting> restoreSettings
-    = {{"allow_azure_native_copy", CHSetting(trueOrFalse, {}, false)},
-       {"allow_different_database_def", CHSetting(trueOrFalse, {}, false)},
-       {"allow_different_table_def", CHSetting(trueOrFalse, {}, false)},
-       {"allow_non_empty_tables", CHSetting(trueOrFalse, {}, false)},
-       {"allow_s3_native_copy", CHSetting(trueOrFalse, {}, false)},
-       {"async", CHSetting(trueOrFalse, {}, false)},
-       {"internal", CHSetting(trueOrFalse, {}, false)},
-       {"restore_broken_parts_as_detached", CHSetting(trueOrFalse, {}, false)},
-       {"skip_unresolved_access_dependencies", CHSetting(trueOrFalse, {}, false)},
-       {"structure_only", CHSetting(trueOrFalse, {}, false)},
-       {"update_access_entities_dependents", CHSetting(trueOrFalse, {}, false)},
-       {"use_same_password_for_base_backup", CHSetting(trueOrFalse, {}, false)},
-       {"use_same_s3_credentials_for_base_backup", CHSetting(trueOrFalse, {}, false)}};
+    = {{"allow_azure_native_copy", trueOrFalseSettingNoOracle},
+       {"allow_different_database_def", trueOrFalseSettingNoOracle},
+       {"allow_different_table_def", trueOrFalseSettingNoOracle},
+       {"allow_non_empty_tables", trueOrFalseSettingNoOracle},
+       {"allow_s3_native_copy", trueOrFalseSettingNoOracle},
+       {"async", trueOrFalseSettingNoOracle},
+       {"internal", trueOrFalseSettingNoOracle},
+       {"restore_broken_parts_as_detached", trueOrFalseSettingNoOracle},
+       {"skip_unresolved_access_dependencies", trueOrFalseSettingNoOracle},
+       {"structure_only", trueOrFalseSettingNoOracle},
+       {"update_access_entities_dependents", trueOrFalseSettingNoOracle},
+       {"use_same_password_for_base_backup", trueOrFalseSettingNoOracle},
+       {"use_same_s3_credentials_for_base_backup", trueOrFalseSettingNoOracle}};
 
 std::unordered_map<String, CHSetting> backupSettings
-    = {{"allow_azure_native_copy", CHSetting(trueOrFalse, {}, false)},
-       {"allow_backup_broken_projections", CHSetting(trueOrFalse, {}, false)},
-       {"allow_checksums_from_remote_paths", CHSetting(trueOrFalse, {}, false)},
-       {"allow_s3_native_copy", CHSetting(trueOrFalse, {}, false)},
-       {"async", CHSetting(trueOrFalse, {}, false)},
-       {"azure_attempt_to_create_container", CHSetting(trueOrFalse, {}, false)},
-       {"check_parts", CHSetting(trueOrFalse, {}, false)},
-       {"check_projection_parts", CHSetting(trueOrFalse, {}, false)},
-       {"decrypt_files_from_encrypted_disks", CHSetting(trueOrFalse, {}, false)},
-       {"deduplicate_files", CHSetting(trueOrFalse, {}, false)},
-       {"experimental_lightweight_snapshot", CHSetting(trueOrFalse, {}, false)},
-       {"internal", CHSetting(trueOrFalse, {}, false)},
-       {"read_from_filesystem_cache", CHSetting(trueOrFalse, {}, false)},
+    = {{"allow_azure_native_copy", trueOrFalseSettingNoOracle},
+       {"allow_backup_broken_projections", trueOrFalseSettingNoOracle},
+       {"allow_checksums_from_remote_paths", trueOrFalseSettingNoOracle},
+       {"allow_s3_native_copy", trueOrFalseSettingNoOracle},
+       {"async", trueOrFalseSettingNoOracle},
+       {"azure_attempt_to_create_container", trueOrFalseSettingNoOracle},
+       {"check_parts", trueOrFalseSettingNoOracle},
+       {"check_projection_parts", trueOrFalseSettingNoOracle},
+       {"decrypt_files_from_encrypted_disks", trueOrFalseSettingNoOracle},
+       {"deduplicate_files", trueOrFalseSettingNoOracle},
+       {"experimental_lightweight_snapshot", trueOrFalseSettingNoOracle},
+       {"internal", trueOrFalseSettingNoOracle},
+       {"read_from_filesystem_cache", trueOrFalseSettingNoOracle},
        {"s3_storage_class", CHSetting([](RandomGenerator &, FuzzConfig &) { return "'STANDARD'"; }, {}, false)},
-       {"structure_only", CHSetting(trueOrFalse, {}, false)},
-       {"write_access_entities_dependents", CHSetting(trueOrFalse, {}, false)}};
+       {"structure_only", trueOrFalseSettingNoOracle},
+       {"write_access_entities_dependents", trueOrFalseSettingNoOracle}};
 
 static std::unordered_map<String, CHSetting> flatLayoutSettings
     = {{"INITIAL_ARRAY_SIZE", CHSetting(bytesRange, {}, false)}, {"MAX_ARRAY_SIZE", CHSetting(bytesRange, {}, false)}};
@@ -495,7 +517,7 @@ static std::unordered_map<String, CHSetting> rangeHashedLayoutSettings = {
     {"RANGE_LOOKUP_STRATEGY", CHSetting([](RandomGenerator & rg, FuzzConfig &) { return rg.nextBool() ? "'min'" : "'max'"; }, {}, false)}};
 
 static std::unordered_map<String, CHSetting> cachedLayoutSettings
-    = {{"ALLOW_READ_EXPIRED_KEYS", CHSetting(trueOrFalse, {}, false)},
+    = {{"ALLOW_READ_EXPIRED_KEYS", trueOrFalseSettingNoOracle},
        {"MAX_THREADS_FOR_UPDATES", threadSetting},
        {"MAX_UPDATE_QUEUE_SIZE",
         CHSetting(
@@ -513,19 +535,19 @@ static std::unordered_map<String, CHSetting> ssdCachedLayoutSettings
        {"READ_BUFFER_SIZE", CHSetting(bytesRange, {}, false)},
        {"WRITE_BUFFER_SIZE", CHSetting(bytesRange, {}, false)}};
 
-static std::unordered_map<String, CHSetting> ipTreeLayoutSettings = {{"ACCESS_TO_KEY_FROM_ATTRIBUTES", CHSetting(trueOrFalse, {}, false)}};
+static std::unordered_map<String, CHSetting> ipTreeLayoutSettings = {{"ACCESS_TO_KEY_FROM_ATTRIBUTES", trueOrFalseSettingNoOracle}};
 
 static std::unordered_map<String, CHSetting> dataLakeSettings
     = {{"iceberg_format_version",
-        CHSetting([](RandomGenerator & rg, FuzzConfig &) { return std::to_string(rg.randomInt<uint32_t>(1, 3)); }, {}, false)},
-       {"iceberg_recent_metadata_file_by_last_updated_ms_field", CHSetting(trueOrFalse, {}, false)},
-       {"iceberg_use_version_hint", CHSetting(trueOrFalse, {}, false)}};
+        CHSetting([](RandomGenerator & rg, FuzzConfig &) { return std::to_string(rg.randomInt<uint32_t>(1, 3)); }, {"1", "2", "3"}, false)},
+       {"iceberg_recent_metadata_file_by_last_updated_ms_field", trueOrFalseSetting},
+       {"iceberg_use_version_hint", trueOrFalseSetting}};
 
 static std::unordered_map<String, CHSetting> fileTableSettings
-    = {{"engine_file_allow_create_multiple_files", CHSetting(trueOrFalse, {}, false)},
-       {"engine_file_empty_if_not_exists", CHSetting(trueOrFalse, {}, false)},
-       {"engine_file_skip_empty_files", CHSetting(trueOrFalse, {}, false)},
-       {"engine_file_truncate_on_insert", CHSetting(trueOrFalse, {}, false)},
+    = {{"engine_file_allow_create_multiple_files", trueOrFalseSettingNoOracle},
+       {"engine_file_empty_if_not_exists", trueOrFalseSettingNoOracle},
+       {"engine_file_skip_empty_files", trueOrFalseSettingNoOracle},
+       {"engine_file_truncate_on_insert", trueOrFalseSettingNoOracle},
        {"storage_file_read_method",
         CHSetting(
             [](RandomGenerator & rg, FuzzConfig &)
@@ -533,31 +555,31 @@ static std::unordered_map<String, CHSetting> fileTableSettings
                 static const DB::Strings & choices = {"'read'", "'pread'", "'mmap'"};
                 return rg.pickRandomly(choices);
             },
-            {},
+            {"'read'", "'pread'", "'mmap'"},
             false)}};
 
 static std::unordered_map<String, CHSetting> distributedTableSettings
-    = {{"background_insert_batch", CHSetting(trueOrFalse, {}, false)},
-       {"background_insert_split_batch_on_failure", CHSetting(trueOrFalse, {}, false)},
-       {"flush_on_detach", CHSetting(trueOrFalse, {}, false)},
-       {"fsync_after_insert", CHSetting(trueOrFalse, {}, false)},
-       {"fsync_directories", CHSetting(trueOrFalse, {}, false)},
-       {"skip_unavailable_shards", CHSetting(trueOrFalse, {}, false)}};
+    = {{"background_insert_batch", trueOrFalseSetting},
+       {"background_insert_split_batch_on_failure", trueOrFalseSetting},
+       {"flush_on_detach", trueOrFalseSetting},
+       {"fsync_after_insert", trueOrFalseSetting},
+       {"fsync_directories", trueOrFalseSetting},
+       {"skip_unavailable_shards", trueOrFalseSetting}};
 
 static std::unordered_map<String, CHSetting> memoryTableSettings
     = {{"min_bytes_to_keep", CHSetting(bytesRange, {}, false)},
        {"max_bytes_to_keep", CHSetting(bytesRange, {}, false)},
        {"min_rows_to_keep", CHSetting(rowsRange, {}, false)},
        {"max_rows_to_keep", CHSetting(rowsRange, {}, false)},
-       {"compress", CHSetting(trueOrFalse, {}, false)}};
+       {"compress", trueOrFalseSetting}};
 
-static std::unordered_map<String, CHSetting> setTableSettings = {{"persistent", CHSetting(trueOrFalse, {}, false)}};
+static std::unordered_map<String, CHSetting> setTableSettings = {{"persistent", trueOrFalseSettingNoOracle}};
 
-static std::unordered_map<String, CHSetting> joinTableSettings = {{"persistent", CHSetting(trueOrFalse, {}, false)}};
+static std::unordered_map<String, CHSetting> joinTableSettings = {{"persistent", trueOrFalseSettingNoOracle}};
 
 static std::unordered_map<String, CHSetting> embeddedRocksDBTableSettings = {
-    {"optimize_for_bulk_insert", CHSetting(trueOrFalse, {}, false)},
-    {"bulk_insert_block_size", CHSetting(highRange, {}, false)},
+    {"optimize_for_bulk_insert", trueOrFalseSetting},
+    {"bulk_insert_block_size", highRangeSetting},
 };
 
 static std::unordered_map<String, CHSetting> mySQLTableSettings
@@ -565,10 +587,10 @@ static std::unordered_map<String, CHSetting> mySQLTableSettings
         CHSetting([](RandomGenerator & rg, FuzzConfig &) { return std::to_string(UINT32_C(1) << (rg.nextLargeNumber() % 7)); }, {}, false)},
        {"connection_max_tries",
         CHSetting([](RandomGenerator & rg, FuzzConfig &) { return std::to_string(rg.randomInt<uint32_t>(1, 16)); }, {}, false)},
-       {"connection_auto_close", CHSetting(trueOrFalse, {}, false)}};
+       {"connection_auto_close", trueOrFalseSettingNoOracle}};
 
 static std::unordered_map<String, CHSetting> mergeTreeColumnSettings
-    = {{"min_compress_block_size", CHSetting(highRange, {}, false)}, {"max_compress_block_size", CHSetting(highRange, {}, false)}};
+    = {{"min_compress_block_size", highRangeSetting}, {"max_compress_block_size", highRangeSetting}};
 
 
 void loadFuzzerTableSettings(const FuzzConfig & fc)
@@ -616,18 +638,18 @@ void loadFuzzerTableSettings(const FuzzConfig & fc)
               },
               {},
               false)},
-         {"enable_hash_ring_filtering", CHSetting(trueOrFalse, {}, false)},
+         {"enable_hash_ring_filtering", trueOrFalseSetting},
          {"list_objects_batch_size",
           CHSetting(
               [](RandomGenerator & rg, FuzzConfig &) { return std::to_string(rg.thresholdGenerator<uint64_t>(0.2, 0.2, 0, 3000)); },
-              {},
+              {"0", "1", "2", "8", "10", "100", "1000"},
               false)},
          {"max_processed_bytes_before_commit", CHSetting(bytesRange, {}, false)},
          {"max_processed_files_before_commit", CHSetting(rowsRange, {}, false)},
          {"max_processed_rows_before_commit", CHSetting(rowsRange, {}, false)},
-         {"parallel_inserts", CHSetting(trueOrFalse, {}, false)},
+         {"parallel_inserts", trueOrFalseSetting},
          {"s3queue_buckets", bucketsRangeSetting},
-         {"s3queue_enable_logging_to_s3queue_log", CHSetting(trueOrFalse, {}, false)},
+         {"s3queue_enable_logging_to_s3queue_log", trueOrFalseSetting},
          {"s3queue_processing_threads_num", threadSetting},
          {"s3queue_tracked_files_limit", CHSetting(rowsRange, {}, false)}});
 

--- a/src/Client/BuzzHouse/Generator/TableSetttings.cpp
+++ b/src/Client/BuzzHouse/Generator/TableSetttings.cpp
@@ -246,16 +246,20 @@ static std::unordered_map<String, CHSetting> mergeTreeTableSettings = {
     {"min_compressed_bytes_to_fsync_after_fetch", bytesRangeSetting},
     {"min_compressed_bytes_to_fsync_after_merge", bytesRangeSetting},
     {"min_index_granularity_bytes", bytesRangeSetting},
+    /// ClickHouse cloud setting
+    {"min_level_for_full_part_storage",
+     CHSetting(
+         [](RandomGenerator & rg, FuzzConfig &) { return std::to_string(rg.thresholdGenerator<uint64_t>(0.2, 0.2, 0, 10)); }, {}, false)},
+    {"min_level_for_wide_part",
+     CHSetting(
+         [](RandomGenerator & rg, FuzzConfig &) { return std::to_string(rg.thresholdGenerator<uint64_t>(0.2, 0.2, 0, 10)); }, {}, false)},
     {"min_marks_to_honor_max_concurrent_queries", highRangeSetting},
-    {"min_rows_for_compact_part", rowsRangeSetting},
     {"min_merge_bytes_to_use_direct_io", bytesRangeSetting},
     {"min_parts_to_merge_at_once",
      CHSetting(
          [](RandomGenerator & rg, FuzzConfig &) { return std::to_string(rg.thresholdGenerator<uint64_t>(0.2, 0.2, 0, 128)); }, {}, false)},
+    {"min_rows_for_compact_part", rowsRangeSetting},
     {"min_rows_for_full_part_storage",
-     CHSetting(
-         [](RandomGenerator & rg, FuzzConfig &) { return std::to_string(rg.thresholdGenerator<uint64_t>(0.2, 0.2, 0, 1000)); }, {}, false)},
-    {"min_rows_to_fsync_after_merge",
      CHSetting(
          [](RandomGenerator & rg, FuzzConfig &) { return std::to_string(rg.thresholdGenerator<uint64_t>(0.2, 0.2, 0, 1000)); }, {}, false)},
     {"min_rows_for_wide_part",
@@ -263,6 +267,9 @@ static std::unordered_map<String, CHSetting> mergeTreeTableSettings = {
          [](RandomGenerator & rg, FuzzConfig &) { return std::to_string(rg.thresholdGenerator<uint64_t>(0.4, 0.2, 0, UINT32_C(8192))); },
          {},
          false)},
+    {"min_rows_to_fsync_after_merge",
+     CHSetting(
+         [](RandomGenerator & rg, FuzzConfig &) { return std::to_string(rg.thresholdGenerator<uint64_t>(0.2, 0.2, 0, 1000)); }, {}, false)},
     {"non_replicated_deduplication_window", rowsRangeSetting},
     /// ClickHouse cloud setting
     {"notify_newest_block_number", trueOrFalseSetting},

--- a/src/Client/BuzzHouse/Generator/TableSetttings.cpp
+++ b/src/Client/BuzzHouse/Generator/TableSetttings.cpp
@@ -582,12 +582,12 @@ static std::unordered_map<String, CHSetting> embeddedRocksDBTableSettings = {
     {"bulk_insert_block_size", highRangeSetting},
 };
 
-static std::unordered_map<String, CHSetting> mySQLTableSettings
-    = {{"connection_pool_size",
-        CHSetting([](RandomGenerator & rg, FuzzConfig &) { return std::to_string(UINT32_C(1) << (rg.nextLargeNumber() % 7)); }, {}, false)},
-       {"connection_max_tries",
-        CHSetting([](RandomGenerator & rg, FuzzConfig &) { return std::to_string(rg.randomInt<uint32_t>(1, 16)); }, {}, false)},
-       {"connection_auto_close", trueOrFalseSettingNoOracle}};
+static std::unordered_map<String, CHSetting> mySQLTableSettings = {
+    {"connection_pool_size",
+     CHSetting([](RandomGenerator & rg, FuzzConfig &) { return std::to_string(UINT32_C(1) << rg.randomInt<uint32_t>(0, 6)); }, {}, false)},
+    {"connection_max_tries",
+     CHSetting([](RandomGenerator & rg, FuzzConfig &) { return std::to_string(rg.randomInt<uint32_t>(1, 16)); }, {}, false)},
+    {"connection_auto_close", trueOrFalseSettingNoOracle}};
 
 static std::unordered_map<String, CHSetting> mergeTreeColumnSettings
     = {{"min_compress_block_size", highRangeSetting}, {"max_compress_block_size", highRangeSetting}};

--- a/src/Client/BuzzHouse/Proto/SQLGrammar.proto
+++ b/src/Client/BuzzHouse/Proto/SQLGrammar.proto
@@ -2920,10 +2920,11 @@ message DatabaseEngine {
 message CreateDatabase {
     optional bool if_not_exists = 1;
     required Database database = 2;
-    optional Cluster cluster = 3;
-    required DatabaseEngine dengine = 4;
-    optional SettingValues setting_values = 5;
-    optional string comment = 6;
+    optional string uuid = 3;
+    optional Cluster cluster = 4;
+    required DatabaseEngine dengine = 5;
+    optional SettingValues setting_values = 6;
+    optional string comment = 7;
 }
 
 message CreateFunction {
@@ -3357,15 +3358,16 @@ message CreateTable {
     optional bool is_temp = 2;
     optional bool if_not_exists = 3;
     required ExprSchemaTable est = 4;
-    optional Cluster cluster = 5;
+    optional string uuid = 5;
+    optional Cluster cluster = 6;
     oneof create_table_oneof {
-        TableDef table_def = 6;
-        CreateTableAs table_as = 7;
+        TableDef table_def = 7;
+        CreateTableAs table_as = 8;
     }
-    required TableEngine engine = 8;
-    optional TTLExpr ttl_expr = 9;
-    optional CreateTableSelect as_select_stmt = 10;
-    optional string comment = 11;
+    required TableEngine engine = 9;
+    optional TTLExpr ttl_expr = 10;
+    optional CreateTableSelect as_select_stmt = 11;
+    optional string comment = 12;
 }
 
 enum SQLObject {
@@ -3523,10 +3525,11 @@ message OptimizeTable {
     required ExprSchemaTable est = 1;
     optional Cluster cluster = 2;
     optional SinglePartitionExpr single_partition = 3;
-    optional bool final = 4;
-    optional DeduplicateExpr dedup = 5;
-    optional bool cleanup = 6;
-    optional SettingValues setting_values = 7;
+    optional bool use_force = 4;
+    optional bool final = 5;
+    optional DeduplicateExpr dedup = 6;
+    optional bool cleanup = 7;
+    optional SettingValues setting_values = 8;
 }
 
 message Exchange {
@@ -3665,14 +3668,15 @@ message CreateView {
     optional bool if_not_exists = 3;
     optional bool materialized = 4;
     required ExprSchemaTable est = 5;
-    optional Cluster cluster = 6;
-    optional RefreshableView refresh = 7;
-    optional CreateMatViewTo to = 8;
-    optional TableEngine engine = 9;
-    optional bool populate = 10;
-    optional bool empty = 11;
-    required SelectParen select = 12;
-    optional string comment = 13;
+    optional string uuid = 6;
+    optional Cluster cluster = 7;
+    optional RefreshableView refresh = 8;
+    optional CreateMatViewTo to = 9;
+    optional TableEngine engine = 10;
+    optional bool populate = 11;
+    optional bool empty = 12;
+    required SelectParen select = 13;
+    optional string comment = 14;
 }
 
 message DictionaryColumn {
@@ -3750,16 +3754,17 @@ message CreateDictionary {
     required CreateReplaceOption create_opt = 1;
     optional bool if_not_exists = 2;
     required ExprSchemaTable est = 3;
-    optional Cluster cluster = 4;
-    required DictionaryColumn col = 5;
-    repeated DictionaryColumn other_cols = 6;
-    required TableKey primary_key = 7;
-    optional DictionarySource source = 8;
-    required DictionaryLayout layout = 9;
-    optional DictionaryRange range = 10;
-    optional DictionaryLifetime lifetime = 11;
-    optional SettingValues setting_values = 12;
-    optional string comment = 13;
+    optional string uuid = 4;
+    optional Cluster cluster = 5;
+    required DictionaryColumn col = 6;
+    repeated DictionaryColumn other_cols = 7;
+    required TableKey primary_key = 8;
+    optional DictionarySource source = 9;
+    required DictionaryLayout layout = 10;
+    optional DictionaryRange range = 11;
+    optional DictionaryLifetime lifetime = 12;
+    optional SettingValues setting_values = 13;
+    optional string comment = 14;
 }
 
 message OptionalPartitionExpr {
@@ -3863,9 +3868,10 @@ message Alter {
 message Attach {
     required SQLObject sobject = 1;
     required SQLObjectName object = 2;
-    optional Cluster cluster = 3;
-    optional bool as_replicated = 4;
-    optional SettingValues setting_values = 5;
+    optional string uuid = 3;
+    optional Cluster cluster = 4;
+    optional bool as_replicated = 5;
+    optional SettingValues setting_values = 6;
 }
 
 message Detach {

--- a/src/Client/BuzzHouse/Proto/SQLGrammar.proto
+++ b/src/Client/BuzzHouse/Proto/SQLGrammar.proto
@@ -3932,24 +3932,24 @@ enum FailPoint {
     lazy_pipe_fds_fail_close = 42;
     infinite_sleep = 43;
     stop_moving_part_before_swap_with_active = 44;
-    replicated_merge_tree_all_replicas_stale = 46;
-    zero_copy_lock_zk_fail_before_op = 47;
-    zero_copy_lock_zk_fail_after_op = 48;
-    plain_object_storage_write_fail_on_directory_create = 49;
-    plain_object_storage_write_fail_on_directory_move = 50;
-    zero_copy_unlock_zk_fail_before_op = 51;
-    zero_copy_unlock_zk_fail_after_op = 52;
-    plain_rewritable_object_storage_azure_not_found_on_init = 53;
-    storage_merge_tree_background_clear_old_parts_pause = 54;
-    database_replicated_startup_pause = 55;
-    parallel_replicas_wait_for_unused_replicas = 56;
-    plain_object_storage_copy_fail_on_file_move = 57;
-    plain_object_storage_copy_temp_source_file_fail_on_file_move = 58;
-    plain_object_storage_copy_temp_target_file_fail_on_file_move = 59;
-    slowdown_parallel_replicas_local_plan_read = 60;
-    iceberg_writes_cleanup = 61;
-    smt_commit_exception_before_op = 62;
-    //keeper_leader_sets_invalid_digest = 60; The server aborts legitimately, can't be used
+    replicated_merge_tree_all_replicas_stale = 45;
+    zero_copy_lock_zk_fail_before_op = 46;
+    zero_copy_lock_zk_fail_after_op = 47;
+    plain_object_storage_write_fail_on_directory_create = 48;
+    plain_object_storage_write_fail_on_directory_move = 49;
+    zero_copy_unlock_zk_fail_before_op = 50;
+    zero_copy_unlock_zk_fail_after_op = 51;
+    plain_rewritable_object_storage_azure_not_found_on_init = 52;
+    storage_merge_tree_background_clear_old_parts_pause = 53;
+    database_replicated_startup_pause = 54;
+    parallel_replicas_wait_for_unused_replicas = 55;
+    plain_object_storage_copy_fail_on_file_move = 56;
+    plain_object_storage_copy_temp_source_file_fail_on_file_move = 57;
+    plain_object_storage_copy_temp_target_file_fail_on_file_move = 58;
+    slowdown_parallel_replicas_local_plan_read = 59;
+    iceberg_writes_cleanup = 60;
+    smt_commit_exception_before_op = 61;
+    //keeper_leader_sets_invalid_digest = 62; The server aborts legitimately, can't be used
 }
 
 message SystemCommand {

--- a/src/Client/BuzzHouse/Proto/SQLGrammar.proto
+++ b/src/Client/BuzzHouse/Proto/SQLGrammar.proto
@@ -1739,9 +1739,13 @@ message SpecialVal {
         MAX_DATETIME = 44;
         MIN_DATETIME64 = 45;
         MAX_DATETIME64 = 46;
-        VAL_NULL_CHAR = 47;
-        VAL_DEFAULT = 48;
-        VAL_STAR = 49;
+        MIN_DOUBLE = 47;
+        MAX_DOUBLE = 48;
+        DENORM_MIN_DOUBLE = 49;
+        LOWEST_DOUBLE = 50;
+        VAL_NULL_CHAR = 51;
+        VAL_DEFAULT = 52;
+        VAL_STAR = 53;
     }
     required SpecialValEnum val = 1;
     optional bool paren = 2;

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -132,7 +132,7 @@ namespace Setting
 namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;
-    extern const int CANNOT_PARSE_TEXT;
+    extern const int SYNTAX_ERROR;
     extern const int DEADLOCK_AVOIDED;
     extern const int CLIENT_OUTPUT_FORMAT_SPECIFIED;
     extern const int UNKNOWN_PACKET_FROM_SERVER;
@@ -2576,21 +2576,21 @@ bool ClientBase::executeMultiQuery(const String & all_queries_text)
             case MultiQueryProcessingStage::PARSING_FAILED:
             {
                 have_error |= buzz_house;
-                error_code = buzz_house ? ErrorCodes::CANNOT_PARSE_TEXT : error_code;
+                error_code = buzz_house ? ErrorCodes::SYNTAX_ERROR : error_code;
                 return true;
             }
             case MultiQueryProcessingStage::CONTINUE_PARSING:
             {
                 is_first = false;
                 have_error |= buzz_house;
-                error_code = buzz_house ? ErrorCodes::CANNOT_PARSE_TEXT : error_code;
+                error_code = buzz_house ? ErrorCodes::SYNTAX_ERROR : error_code;
                 continue;
             }
             case MultiQueryProcessingStage::PARSING_EXCEPTION:
             {
                 is_first = false;
                 have_error |= buzz_house;
-                error_code = buzz_house ? ErrorCodes::CANNOT_PARSE_TEXT : error_code;
+                error_code = buzz_house ? ErrorCodes::SYNTAX_ERROR : error_code;
                 this_query_end = find_first_symbols<'\n'>(this_query_end, all_queries_end);
 
                 // Try to find test hint for syntax error. We don't know where

--- a/tests/casa_del_dolor/dolor.py
+++ b/tests/casa_del_dolor/dolor.py
@@ -259,6 +259,12 @@ parser.add_argument(
     help="Add 'shared_database_catalog' settings",
 )
 parser.add_argument(
+    "--without-database-replicated",
+    action="store_false",
+    dest="add_database_replicated",
+    help="Add 'database_replicated' settings",
+)
+parser.add_argument(
     "--compare-table-dump-prob",
     type=int,
     default=50,

--- a/tests/casa_del_dolor/generators.py
+++ b/tests/casa_del_dolor/generators.py
@@ -55,9 +55,6 @@ class BuzzHouseGenerator(Generator):
 
         buzz_config["seed"] = random.randint(1, 18446744073709551615)
 
-        # Connect back to peer ClickHouse server running in the host machine
-        if "clickhouse" in buzz_config:
-            buzz_config["clickhouse"]["server_hostname"] = "host.docker.internal"
         # Set paths
         buzz_config["client_file_path"] = (
             f"{Path(cluster.instances_dir) / "node0" / "database" / "user_files"}"

--- a/tests/casa_del_dolor/properties.py
+++ b/tests/casa_del_dolor/properties.py
@@ -1215,7 +1215,7 @@ def modify_server_settings(
         selected_properties["shared_database_catalog"] = SharedCatalogPropertiesGroup()
 
     # Add Replicated databases settings
-    if args.database_replicated and root.find("database_replicated") is None:
+    if args.add_database_replicated and root.find("database_replicated") is None:
         selected_properties["database_replicated"] = DatabaseReplicatedGroup()
 
     # Shuffle selected properties and apply

--- a/tests/casa_del_dolor/properties.py
+++ b/tests/casa_del_dolor/properties.py
@@ -921,9 +921,13 @@ class SharedCatalogPropertiesGroup(PropertiesGroup):
 
 class LogTablePropertiesGroup(PropertiesGroup):
 
-    def __init__(self, _log_table: str):
+    def __init__(
+        self, _log_table: str, _def_max_size_rows: int, _def_reserved_size_rows: int
+    ):
         super().__init__()
         self.log_table: str = _log_table
+        self.def_max_size_rows: int = _def_max_size_rows
+        self.def_reserved_size_rows: int = _def_reserved_size_rows
 
     def apply_properties(
         self,
@@ -962,12 +966,12 @@ class LogTablePropertiesGroup(PropertiesGroup):
         reserved_size_rows_xml = property_element.find("reserved_size_rows")
         if max_size_rows_xml is not None or reserved_size_rows_xml is not None:
             max_size_rows_value = (
-                1048576
+                self.def_max_size_rows
                 if (max_size_rows_xml is None or max_size_rows_xml.text is None)
                 else int(max_size_rows_xml.text)
             )
             reserved_size_rows_value = (
-                8192
+                self.def_reserved_size_rows
                 if (
                     reserved_size_rows_xml is None
                     or reserved_size_rows_xml.text is None
@@ -1148,28 +1152,28 @@ def modify_server_settings(
     # Add log tables
     if args.add_log_tables:
         all_log_entries = [
-            "asynchronous_insert_log",
-            "asynchronous_metric_log",
-            "backup_log",
-            "blob_storage_log",
-            "crash_log",
-            "dead_letter_queue",
-            "error_log",
-            "iceberg_metadata_log",
-            "metric_log",
-            "opentelemetry_span_log",
-            "part_log",
-            "processors_profile_log",
-            "query_log",
-            "query_metric_log",
-            "query_thread_log",
-            "query_views_log",
-            "session_log",
-            "s3queue_log",
-            "text_log",
-            "trace_log",
-            "zookeeper_connection_log",
-            "zookeeper_log",
+            ("asynchronous_insert_log", 1048576, 8192),
+            ("asynchronous_metric_log", 1048576, 8192),
+            ("backup_log", 1048576, 8192),
+            ("blob_storage_log", 1048576, 8192),
+            ("crash_log", 1024, 1024),
+            ("dead_letter_queue", 1048576, 8192),
+            ("error_log", 1048576, 8192),
+            ("iceberg_metadata_log", 1048576, 8192),
+            ("metric_log", 1048576, 8192),
+            ("opentelemetry_span_log", 1048576, 8192),
+            ("part_log", 1048576, 8192),
+            ("processors_profile_log", 1048576, 8192),
+            ("query_log", 1048576, 8192),
+            ("query_metric_log", 1048576, 8192),
+            ("query_thread_log", 1048576, 8192),
+            ("query_views_log", 1048576, 8192),
+            ("session_log", 1048576, 8192),
+            ("s3queue_log", 1048576, 8192),
+            ("text_log", 1048576, 8192),
+            ("trace_log", 1048576, 8192),
+            ("zookeeper_connection_log", 1048576, 8192),
+            ("zookeeper_log", 1048576, 8192),
         ]
         if random.randint(1, 100) <= 70:
             all_log_entries = random.sample(
@@ -1177,8 +1181,10 @@ def modify_server_settings(
             )
         random.shuffle(all_log_entries)
         for entry in all_log_entries:
-            if root.find(entry) is None:
-                selected_properties[entry] = LogTablePropertiesGroup(entry)
+            if root.find(entry[0]) is None:
+                selected_properties[entry[0]] = LogTablePropertiesGroup(
+                    entry[0], entry[1], entry[2]
+                )
 
     # Add shared_database_catalog settings, required for shared catalog to work
     if (


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- Don't do `now()` calls in deterministic contexts (e.g., query oracles). It can lead to false positives.
- Fixed default values for `crash_log` system table.
- Fixed numbering of existing fail points.
- When generating an insert using the `numbers` table function, sometimes use modulo division to generate rows with the same value on integers.
- Don't always add column definitions in materialized views.
- Generate UUID in databases, tables, views, and dictionaries to trigger more edge cases.

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
