### PR TITLE
ci: fix collecting artifacts for integration tests

### DIFF
--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -310,6 +310,7 @@ def main():
     if not info.is_local_run:
         print("Dumping dmesg")
         Shell.check("dmesg -T > dmesg.log", verbose=True, strict=True)
+        files.append("dmesg.log")
         with open("dmesg.log", "rb") as dmesg:
             dmesg = dmesg.read()
             if (

--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -331,11 +331,7 @@ def main():
                 failed_suits.append(test_result.name.split("/")[0])
         failed_suits = list(set(failed_suits))
         for failed_suit in failed_suits:
-            files.extend(
-                Shell.get_output(
-                    f"find ./tests/integration/{failed_suit} -name '*.log*'"
-                ).splitlines()
-            )
+            files.append(f"tests/integration/{failed_suit}")
 
         files = [Utils.compress_files_gz(files, f"{temp_path}/logs.tar.gz")]
 

--- a/ci/praktika/utils.py
+++ b/ci/praktika/utils.py
@@ -700,7 +700,7 @@ class Utils:
             os.path.relpath(file) if os.path.isabs(file) else file for file in files
         ]
         for file in files:
-            assert Path(file).is_file(), f"File does not exist [{file}]"
+            assert Path(file).exists(), f"Path does not exist [{file}]"
 
         with tempfile.NamedTemporaryFile() as f:
             f.write("\n".join(files).encode())


### PR DESCRIPTION
After #88493, we may have folders in artifacts, let's fix assertion

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)