### PR TITLE
Docs: move documentation for missed functions into source code

### DIFF
--- a/src/Functions/FunctionGenerateRandomStructure.cpp
+++ b/src/Functions/FunctionGenerateRandomStructure.cpp
@@ -435,22 +435,49 @@ String FunctionGenerateRandomStructure::generateRandomStructure(size_t seed, con
 
 REGISTER_FUNCTION(GenerateRandomStructure)
 {
-    factory.registerFunction<FunctionGenerateRandomStructure>(FunctionDocumentation
-        {
-            .description=R"(
-Generates a random table structure.
-This function takes 2 optional constant arguments:
-the number of columns in the result structure (random by default) and random seed (random by default)
-The maximum number of columns is 128.
-The function returns a value of type String.
-)",
-            .examples{
-                {"random", "SELECT generateRandomStructure()", "c1 UInt32, c2 FixedString(25)"},
-                {"with specified number of columns", "SELECT generateRandomStructure(3)", "c1 String, c2 Array(Int32), c3 LowCardinality(String)"},
-                {"with specified seed", "SELECT generateRandomStructure(1, 42)", "c1 UInt128"},
-            },
-            .category = FunctionDocumentation::Category::RandomNumber
-        });
+    FunctionDocumentation::Description description = R"(
+Generates random table structure in the format `column1_name column1_type, column2_name column2_type, ...`.
+)";
+    FunctionDocumentation::Syntax syntax = "generateRandomStructure([number_of_columns, seed])";
+    FunctionDocumentation::Arguments arguments = {
+        {"number_of_columns", "The desired number of columns in the resultant table structure. If set to 0 or `Null`, the number of columns will be random from 1 to 128. Default value: `Null`.", {"UInt64"}},
+        {"seed", "Random seed to produce stable results. If seed is not specified or set to `Null`, it is randomly generated.", {"UInt64"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {"Randomly generated table structure.", {"String"}};
+    FunctionDocumentation::Examples examples = {
+    {
+        "Usage example",
+        R"(
+SELECT generateRandomStructure()
+        )",
+        R"(
+c1 Decimal32(5), c2 Date, c3 Tuple(LowCardinality(String), Int128, UInt64, UInt16, UInt8, IPv6), c4 Array(UInt128), c5 UInt32, c6 IPv4, c7 Decimal256(64), c8 Decimal128(3), c9 UInt256, c10 UInt64, c11 DateTime
+        )"
+    },
+    {
+        "with specified number of columns",
+        R"(
+SELECT generateRandomStructure(1)
+        )",
+        R"(
+c1 Map(UInt256, UInt16)
+        )"
+    },
+    {
+        "with specified seed",
+        R"(
+SELECT generateRandomStructure(NULL, 33)
+        )",
+        R"(
+c1 DateTime, c2 Enum8('c2V0' = 0, 'c2V1' = 1, 'c2V2' = 2, 'c2V3' = 3), c3 LowCardinality(Nullable(FixedString(30))), c4 Int16, c5 Enum8('c5V0' = 0, 'c5V1' = 1, 'c5V2' = 2, 'c5V3' = 3), c6 Nullable(UInt8), c7 String, c8 Nested(e1 IPv4, e2 UInt8, e3 UInt16, e4 UInt16, e5 Int32, e6 Map(Date, Decimal256(70)))
+        )"
+    }
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {23, 5};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Other;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
+
+    factory.registerFunction<FunctionGenerateRandomStructure>(documentation);
 }
 
 }

--- a/src/Functions/FunctionsCodingIP.cpp
+++ b/src/Functions/FunctionsCodingIP.cpp
@@ -1233,9 +1233,83 @@ SELECT IPv6NumToString(IPv4ToIPv6(IPv4StringToNum('192.168.0.1'))) AS addr;
 
     factory.registerFunction<FunctionIPv4ToIPv6>(documentation_ipv4toipv6);
 
-    factory.registerFunction<FunctionMACNumToString>();
-    factory.registerFunction<FunctionMACStringTo<ParseMACImpl>>();
-    factory.registerFunction<FunctionMACStringTo<ParseOUIImpl>>();
+    FunctionDocumentation::Description description_macnumtostring = R"(
+Interprets a [`UInt64`](/sql-reference/data-types/int-uint) number as a MAC address in big endian format.
+Returns the corresponding MAC address in format `AA:BB:CC:DD:EE:FF` (colon-separated numbers in hexadecimal form) as string.
+    )";
+    FunctionDocumentation::Syntax syntax_macnumtostring = "MACNumToString(num)";
+    FunctionDocumentation::Arguments arguments_macnumtostring = {
+        {"num", "UInt64 number.", {"UInt64"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value_macnumtostring = {"Returns a MAC address in format AA:BB:CC:DD:EE:FF.", {"String"}};
+    FunctionDocumentation::Examples examples_macnumtostring = {
+    {
+        "Usage example",
+        R"(
+SELECT MACNumToString(149809441867716) AS mac_address;
+        )",
+        R"(
+┌─mac_address───────┐
+│ 88:00:11:22:33:44 │
+└───────────────────┘
+        )"
+    }
+    };
+    FunctionDocumentation::IntroducedIn introduced_in_macnumtostring = {1, 1};
+    FunctionDocumentation::Category category_macnumtostring = FunctionDocumentation::Category::Other;
+    FunctionDocumentation documentation_macnumtostring = {description_macnumtostring, syntax_macnumtostring, arguments_macnumtostring, returned_value_macnumtostring, examples_macnumtostring, introduced_in_macnumtostring, category_macnumtostring};
+
+    factory.registerFunction<FunctionMACNumToString>(documentation_macnumtostring);
+
+    FunctionDocumentation::Description description_macstringtonum = R"(
+The inverse function of MACNumToString. If the MAC address has an invalid format, it returns 0.
+)";
+    FunctionDocumentation::Syntax syntax_macstringtonum = "MACStringToNum(s)";
+    FunctionDocumentation::Arguments arguments_macstringtonum = {
+        {"s", "MAC address string.", {"String"}}
+    };
+    FunctionDocumentation::Examples examples_macstringtonum = {
+    {
+        "Usage example",
+        R"(
+SELECT MACStringToNum('01:02:03:04:05:06') AS mac_numeric;
+        )",
+        R"(
+1108152157446
+        )"
+    }
+    };
+    FunctionDocumentation::ReturnedValue returned_value_macstringtonum = {"Returns a UInt64 number.", {"UInt64"}};
+    FunctionDocumentation::Category category_macstringtonum = FunctionDocumentation::Category::Other;
+    FunctionDocumentation::IntroducedIn introduced_in_macstringtonum = {1, 1};
+    FunctionDocumentation documentation_macstringtonum = {description_macstringtonum, syntax_macstringtonum, arguments_macstringtonum, returned_value_macstringtonum, examples_macstringtonum, introduced_in_macstringtonum, category_macstringtonum};
+
+    factory.registerFunction<FunctionMACStringTo<ParseMACImpl>>(documentation_macstringtonum);
+
+    FunctionDocumentation::Description description_macstringtooui = R"(
+Given a MAC address in format AA:BB:CC:DD:EE:FF (colon-separated numbers in hexadecimal form), returns the first three octets as a UInt64 number. If the MAC address has an invalid format, it returns 0.
+    )";
+    FunctionDocumentation::Syntax syntax_macstringtooui = "MACStringToOUI(s)";
+    FunctionDocumentation::Arguments arguments_macstringtooui = {
+        {"s", "MAC address string.", {"String"}}
+    };
+    FunctionDocumentation::Examples examples_macstringtooui = {
+    {
+        "Usage example",
+        R"(
+SELECT MACStringToOUI('00:50:56:12:34:56') AS oui;
+        )",
+        R"(
+20566
+        )"
+    }
+    };
+    FunctionDocumentation::ReturnedValue returned_value_macstringtooui = {"First three octets as UInt64 number.", {"UInt64"}};
+    FunctionDocumentation::Category category_macstringtooui = FunctionDocumentation::Category::Other;
+    FunctionDocumentation::IntroducedIn introduced_in_macstringtooui = {1, 1};
+    FunctionDocumentation documentation_macstringtooui = {description_macstringtooui, syntax_macstringtooui, arguments_macstringtooui, returned_value_macstringtooui, examples_macstringtooui, introduced_in_macstringtooui, category_macstringtooui};
+
+    factory.registerFunction<FunctionMACStringTo<ParseOUIImpl>>(documentation_macstringtooui);
 
     /// IPv6CIDRToRange function
     FunctionDocumentation::Description description_ipv6cidr = R"(

--- a/src/Functions/FunctionsTransactionCounters.cpp
+++ b/src/Functions/FunctionsTransactionCounters.cpp
@@ -114,8 +114,8 @@ ROLLBACK;
     FunctionDocumentation documentation_transactionID = {description_transactionID, syntax_transactionID, arguments_transactionID, returned_value_transactionID, examples_transactionID, introduced_in_transactionID, category_transactionID};
 
     factory.registerFunction<FunctionTransactionID>(documentation_transactionID);
-   
-    /// transactionLatestSnapshot 
+
+    /// transactionLatestSnapshot
     FunctionDocumentation::Description description_transactionLatestSnapshot = R"(
 <ExperimentalBadge/>
 <CloudNotSupportedBadge/>

--- a/src/Functions/FunctionsTransactionCounters.cpp
+++ b/src/Functions/FunctionsTransactionCounters.cpp
@@ -63,6 +63,7 @@ public:
 
 REGISTER_FUNCTION(TransactionCounters)
 {
+    /// transactionID
     FunctionDocumentation::Description description_transactionID = R"(
 <ExperimentalBadge/>
 <CloudNotSupportedBadge/>
@@ -113,8 +114,84 @@ ROLLBACK;
     FunctionDocumentation documentation_transactionID = {description_transactionID, syntax_transactionID, arguments_transactionID, returned_value_transactionID, examples_transactionID, introduced_in_transactionID, category_transactionID};
 
     factory.registerFunction<FunctionTransactionID>(documentation_transactionID);
-    factory.registerFunction<FunctionTransactionLatestSnapshot>();
-    factory.registerFunction<FunctionTransactionOldestSnapshot>();
+   
+    /// transactionLatestSnapshot 
+    FunctionDocumentation::Description description_transactionLatestSnapshot = R"(
+<ExperimentalBadge/>
+<CloudNotSupportedBadge/>
+Returns the newest snapshot (Commit Sequence Number) of a [transaction](/guides/developer/transactional#transactions-commit-and-rollback) that is available for reading.
+:::note
+This function is part of an experimental feature set. Enable experimental transaction support by adding this setting to your configuration:
+```xml
+<clickhouse>
+    <allow_experimental_transactions>1</allow_experimental_transactions>
+</clickhouse>
+```
+For more information see the page [Transactional (ACID) support](/guides/developer/transactional#transactions-commit-and-rollback).
+:::
+    )";
+    FunctionDocumentation::Syntax syntax_transactionLatestSnapshot = "transactionLatestSnapshot()";
+    FunctionDocumentation::Arguments arguments_transactionLatestSnapshot = {};
+    FunctionDocumentation::ReturnedValue returned_value_transactionLatestSnapshot = {"Returns the latest snapshot (CSN) of a transaction.", {"UInt64"}};
+    FunctionDocumentation::Examples examples_transactionLatestSnapshot = {
+    {
+        "Usage example",
+        R"(
+BEGIN TRANSACTION;
+SELECT transactionLatestSnapshot();
+ROLLBACK;
+        )",
+        R"(
+┌─transactionLatestSnapshot()─┐
+│                          32 │
+└─────────────────────────────┘
+        )"
+    }
+    };
+    FunctionDocumentation::IntroducedIn introduced_in_transactionLatestSnapshot = {22, 6};
+    FunctionDocumentation::Category category_transactionLatestSnapshot = FunctionDocumentation::Category::Other;
+    FunctionDocumentation documentation_transactionLatestSnapshot = {description_transactionLatestSnapshot, syntax_transactionLatestSnapshot, arguments_transactionLatestSnapshot, returned_value_transactionLatestSnapshot, examples_transactionLatestSnapshot, introduced_in_transactionLatestSnapshot, category_transactionLatestSnapshot};
+
+    factory.registerFunction<FunctionTransactionLatestSnapshot>(documentation_transactionLatestSnapshot);
+
+    /// transactionOldestSnapshot
+    FunctionDocumentation::Description description_transactionOldestSnapshot = R"(
+<ExperimentalBadge/>
+<CloudNotSupportedBadge/>
+Returns the oldest snapshot (Commit Sequence Number) that is visible for some running [transaction](/guides/developer/transactional#transactions-commit-and-rollback).
+:::note
+This function is part of an experimental feature set. Enable experimental transaction support by adding this setting to your configuration:
+```xml
+<clickhouse>
+    <allow_experimental_transactions>1</allow_experimental_transactions>
+</clickhouse>
+```
+For more information see the page [Transactional (ACID) support](/guides/developer/transactional#transactions-commit-and-rollback).
+:::
+    )";
+    FunctionDocumentation::Syntax syntax_transactionOldestSnapshot = "transactionOldestSnapshot()";
+    FunctionDocumentation::Arguments arguments_transactionOldestSnapshot = {};
+    FunctionDocumentation::ReturnedValue returned_value_transactionOldestSnapshot = {"Returns the oldest snapshot (CSN) of a transaction.", {"UInt64"}};
+    FunctionDocumentation::Examples examples_transactionOldestSnapshot = {
+    {
+        "Usage example",
+        R"(
+BEGIN TRANSACTION;
+SELECT transactionOldestSnapshot();
+ROLLBACK;
+        )",
+        R"(
+┌─transactionOldestSnapshot()─┐
+│                          32 │
+└─────────────────────────────┘
+        )"
+    }
+    };
+    FunctionDocumentation::IntroducedIn introduced_in_transactionOldestSnapshot = {22, 6};
+    FunctionDocumentation::Category category_transactionOldestSnapshot = FunctionDocumentation::Category::Other;
+    FunctionDocumentation documentation_transactionOldestSnapshot = {description_transactionOldestSnapshot, syntax_transactionOldestSnapshot, arguments_transactionOldestSnapshot, returned_value_transactionOldestSnapshot, examples_transactionOldestSnapshot, introduced_in_transactionOldestSnapshot, category_transactionOldestSnapshot};
+
+    factory.registerFunction<FunctionTransactionOldestSnapshot>(documentation_transactionOldestSnapshot);
 }
 
 }

--- a/src/Functions/catboostEvaluate.cpp
+++ b/src/Functions/catboostEvaluate.cpp
@@ -174,7 +174,50 @@ public:
 
 REGISTER_FUNCTION(CatBoostEvaluate)
 {
-    factory.registerFunction<FunctionCatBoostEvaluate>();
+    FunctionDocumentation::Description description = R"(
+Evaluate an external catboost model. [CatBoost](https://catboost.ai) is an open-source gradient boosting library developed by Yandex for machine learning.
+Accepts a path to a catboost model and model arguments (features).
+**Prerequisites**
+1. Build the catboost evaluation library
+Before evaluating catboost models, the `libcatboostmodel.<so|dylib>` library must be made available. See [CatBoost documentation](https://catboost.ai/docs/concepts/c-plus-plus-api_dynamic-c-pluplus-wrapper.html) how to compile it.
+Next, specify the path to `libcatboostmodel.<so|dylib>` in the clickhouse configuration:
+```xml
+<clickhouse>
+...
+    <catboost_lib_path>/path/to/libcatboostmodel.so</catboost_lib_path>
+...
+</clickhouse>
+```
+For security and isolation reasons, the model evaluation does not run in the server process but in the clickhouse-library-bridge process.
+At the first execution of `catboostEvaluate()`, the server starts the library bridge process if it is not running already. Both processes
+communicate using a HTTP interface. By default, port `9012` is used. A different port can be specified as follows - this is useful if port
+`9012` is already assigned to a different service.
+```xml
+<library_bridge>
+    <port>9019</port>
+</library_bridge>
+```
+2. Train a catboost model using libcatboost
+See [Training and applying models](https://catboost.ai/docs/features/training.html#training) for how to train catboost models from a training data set.
+)";
+    FunctionDocumentation::Syntax syntax = "catboostEvaluate(path_to_model, feature_1[, feature_2, ..., feature_n])";
+    FunctionDocumentation::Arguments arguments = {
+        {"path_to_model", "Path to catboost model.", {"const String"}},
+        {"feature", "One or more model features/arguments.", {"Float*"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the model evaluation result.", {"Float64"}};
+    FunctionDocumentation::Examples examples = {
+    {
+        "catboostEvaluate",
+        "SELECT catboostEvaluate('/root/occupy.bin', Temperature, Humidity, Light, CO2, HumidityRatio) AS prediction FROM occupancy LIMIT 1",
+        "4.695691092573497"
+    }
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {22, 9};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Other;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
+
+    factory.registerFunction<FunctionCatBoostEvaluate>(documentation);
 }
 
 }

--- a/src/Functions/countDigits.cpp
+++ b/src/Functions/countDigits.cpp
@@ -193,7 +193,7 @@ SELECT countDigits(toDecimal32(1, 9)), countDigits(toDecimal32(-1, 9)),
     }
     };
     FunctionDocumentation::IntroducedIn introduced_in_countDigits = {20, 8};
-    FunctionDocumentation::Category category_countDigits = FunctionDocumentation::Category::Decimal;
+    FunctionDocumentation::Category category_countDigits = FunctionDocumentation::Category::Other;
     FunctionDocumentation documentation_countDigits = {description_countDigits, syntax_countDigits, arguments_countDigits, returned_value_countDigits, examples_countDigits, introduced_in_countDigits, category_countDigits};
 
     factory.registerFunction<FunctionCountDigits>(documentation_countDigits);

--- a/src/Functions/getTypeSerializationStreams.cpp
+++ b/src/Functions/getTypeSerializationStreams.cpp
@@ -76,7 +76,24 @@ private:
 
 REGISTER_FUNCTION(GetTypeSerializationStreams)
 {
-    factory.registerFunction<FunctionGetTypeSerializationStreams>();
+    FunctionDocumentation::Description description = R"(
+Enumerates stream paths of a data type.
+This function is intended for developmental use.
+    )";
+    FunctionDocumentation::Syntax syntax = "getTypeSerializationStreams(col)";
+    FunctionDocumentation::Arguments arguments = {
+        {"col", "Column or string representation of a data-type from which the data type will be detected.", {"Any"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns an array with all the serialization sub-stream paths.", {"Array(String)"}};
+    FunctionDocumentation::Examples examples = {
+        {"tuple", "SELECT getTypeSerializationStreams(tuple('a', 1, 'b', 2))", "['{TupleElement(1), Regular}','{TupleElement(2), Regular}','{TupleElement(3), Regular}','{TupleElement(4), Regular}']"},
+        {"map", "SELECT getTypeSerializationStreams('Map(String, Int64)')", "['{ArraySizes}','{ArrayElements, TupleElement(keys), Regular}','{ArrayElements, TupleElement(values), Regular}']"}
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {22, 6};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Other;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
+
+    factory.registerFunction<FunctionGetTypeSerializationStreams>(documentation);
 }
 
 }

--- a/src/Functions/globalVariable.cpp
+++ b/src/Functions/globalVariable.cpp
@@ -91,7 +91,22 @@ private:
 
 REGISTER_FUNCTION(GlobalVariable)
 {
-    factory.registerFunction<FunctionGlobalVariable>();
+    FunctionDocumentation::Description description = R"(
+Takes a constant string argument and returns the value of the global variable with that name. This function is intended for compatibility with MySQL and not needed or useful for normal operation of ClickHouse. Only few dummy global variables are defined.
+    )";
+    FunctionDocumentation::Syntax syntax = "globalVariable(name)";
+    FunctionDocumentation::Arguments arguments = {
+        {"name", "Global variable name.", {"String"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the value of variable `name`.", {"Any"}};
+    FunctionDocumentation::Examples examples = {
+        {"globalVariable", "SELECT globalVariable('max_allowed_packet')", "67108864"}
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {20, 5};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Other;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
+
+    factory.registerFunction<FunctionGlobalVariable>(documentation);
 }
 
 }

--- a/src/Functions/isDecimalOverflow.cpp
+++ b/src/Functions/isDecimalOverflow.cpp
@@ -181,7 +181,7 @@ SELECT isDecimalOverflow(toDecimal32(1000000000, 0), 9),
     }
     };
     FunctionDocumentation::IntroducedIn introduced_in_isDecimalOverflow = {20, 8};
-    FunctionDocumentation::Category category_isDecimalOverflow = FunctionDocumentation::Category::Decimal;
+    FunctionDocumentation::Category category_isDecimalOverflow = FunctionDocumentation::Category::Other;
     FunctionDocumentation documentation_isDecimalOverflow = {description_isDecimalOverflow, syntax_isDecimalOverflow, arguments_isDecimalOverflow, returned_value_isDecimalOverflow, examples_isDecimalOverflow, introduced_in_isDecimalOverflow, category_isDecimalOverflow};
 
     factory.registerFunction<FunctionIsDecimalOverflow>(documentation_isDecimalOverflow);

--- a/src/Functions/lowCardinalityIndices.cpp
+++ b/src/Functions/lowCardinalityIndices.cpp
@@ -60,7 +60,48 @@ public:
 
 REGISTER_FUNCTION(LowCardinalityIndices)
 {
-    factory.registerFunction<FunctionLowCardinalityIndices>();
+    FunctionDocumentation::Description description = R"(
+Returns the position of a value in the dictionary of a [LowCardinality](../data-types/lowcardinality.md) column. Positions start at 1. Since LowCardinality have per-part dictionaries, this function may return different positions for the same value in different parts.
+    )";
+    FunctionDocumentation::Syntax syntax = "lowCardinalityIndices(col)";
+    FunctionDocumentation::Arguments arguments = {
+        {"col", "A low cardinality column.", {"LowCardinality"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {"The position of the value in the dictionary of the current part.", {"UInt64"}};
+    FunctionDocumentation::Examples examples = {
+    {
+        "Usage examples",
+        R"(
+DROP TABLE IF EXISTS test;
+CREATE TABLE test (s LowCardinality(String)) ENGINE = Memory;
+-- create two parts:
+INSERT INTO test VALUES ('ab'), ('cd'), ('ab'), ('ab'), ('df');
+INSERT INTO test VALUES ('ef'), ('cd'), ('ab'), ('cd'), ('ef');
+SELECT s, lowCardinalityIndices(s) FROM test;
+        )",
+        R"(
+┌─s──┬─lowCardinalityIndices(s)─┐
+│ ab │                        1 │
+│ cd │                        2 │
+│ ab │                        1 │
+│ ab │                        1 │
+│ df │                        3 │
+└────┴──────────────────────────┘
+┌─s──┬─lowCardinalityIndices(s)─┐
+│ ef │                        1 │
+│ cd │                        2 │
+│ ab │                        3 │
+│ cd │                        2 │
+│ ef │                        1 │
+└────┴──────────────────────────┘
+        )"
+    }
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {18, 12};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Other;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
+
+    factory.registerFunction<FunctionLowCardinalityIndices>(documentation);
 }
 
 }

--- a/src/Functions/lowCardinalityKeys.cpp
+++ b/src/Functions/lowCardinalityKeys.cpp
@@ -54,7 +54,50 @@ public:
 
 REGISTER_FUNCTION(LowCardinalityKeys)
 {
-    factory.registerFunction<FunctionLowCardinalityKeys>();
+    FunctionDocumentation::Description description = R"(
+Returns the dictionary values of a [LowCardinality](../data-types/lowcardinality.md) column.
+If the block is smaller or larger than the dictionary size, the result will be truncated or extended with default values.
+Since LowCardinality have per-part dictionaries, this function may return different dictionary values in different parts.
+    )";
+    FunctionDocumentation::Syntax syntax = "lowCardinalityKeys(col)";
+    FunctionDocumentation::Arguments arguments = {
+        {"col", "A low cardinality column.", {"LowCardinality"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the dictionary keys.", {"UInt64"}};
+    FunctionDocumentation::Examples examples = {
+    {
+        "lowCardinalityKeys",
+        R"(
+DROP TABLE IF EXISTS test;
+CREATE TABLE test (s LowCardinality(String)) ENGINE = Memory;
+-- create two parts:
+INSERT INTO test VALUES ('ab'), ('cd'), ('ab'), ('ab'), ('df');
+INSERT INTO test VALUES ('ef'), ('cd'), ('ab'), ('cd'), ('ef');
+SELECT s, lowCardinalityKeys(s) FROM test;
+        )",
+        R"(
+┌─s──┬─lowCardinalityKeys(s)─┐
+│ ef │                       │
+│ cd │ ef                    │
+│ ab │ cd                    │
+│ cd │ ab                    │
+│ ef │                       │
+└────┴───────────────────────┘
+┌─s──┬─lowCardinalityKeys(s)─┐
+│ ab │                       │
+│ cd │ ab                    │
+│ ab │ cd                    │
+│ ab │ df                    │
+│ df │                       │
+└────┴───────────────────────┘
+        )"
+    }
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {18, 12};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Other;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
+
+    factory.registerFunction<FunctionLowCardinalityKeys>(documentation);
 }
 
 }

--- a/src/Functions/minSampleSize.cpp
+++ b/src/Functions/minSampleSize.cpp
@@ -282,10 +282,67 @@ struct ConversionImpl
 
 REGISTER_FUNCTION(MinSampleSize)
 {
-    factory.registerFunction<FunctionMinSampleSize<ContinuousImpl>>();
+    FunctionDocumentation::Description description_continuous = R"(
+Calculates the minimum required sample size for an A/B test comparing means of a continuous metric in two samples.
+Uses the formula described in [this article](https://towardsdatascience.com/required-sample-size-for-a-b-testing-6f6608dd330a).
+Assumes equal sizes of treatment and control groups.
+Returns the required sample size for one group (i.e. the sample size required for the whole experiment is twice the returned value).
+Also assumes equal variance of the test metric in treatment and control groups.
+)";
+    FunctionDocumentation::Syntax syntax_continuous = "minSampleSizeContinuous(baseline, sigma, mde, power, alpha)";
+    FunctionDocumentation::Arguments arguments_continuous = {
+        {"baseline", "Baseline value of a metric.", {"(U)Int*", "Float*"}},
+        {"sigma", "Baseline standard deviation of a metric.", {"(U)Int*", "Float*"}},
+        {"mde", "Minimum detectable effect (MDE) as percentage of the baseline value (e.g. for a baseline value 112.25 the MDE 0.03 means an expected change to 112.25 ± 112.25*0.03).", {"(U)Int*", "Float*"}},
+        {"power", "Required statistical power of a test (1 - probability of Type II error).", {"(U)Int*", "Float*"}},
+        {"alpha", "Required significance level of a test (probability of Type I error).", {"(U)Int*", "Float*"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value_continuous = {
+        "Returns a named Tuple with 3 elements: `minimum_sample_size`, `detect_range_lower` and  `detect_range_upper`. These are respectively: the required sample size, the lower bound of the range of values not detectable with the returned required sample size, calculated as `baseline * (1 - mde)`, and the upper bound of the range of values not detectable with the returned required sample size, calculated as `baseline * (1 + mde)` (Float64).",
+        {"Tuple(Float64, Float64, Float64)"}
+    };
+    FunctionDocumentation::Examples examples_continuous = {
+    {
+        "minSampleSizeContinuous",
+        R"(
+SELECT minSampleSizeContinuous(112.25, 21.1, 0.03, 0.80, 0.05) AS sample_size
+        )",
+        R"(
+(616.2931945826209,108.8825,115.6175)
+        )"
+    }
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {23, 10};
+    FunctionDocumentation::Category category_continuous = FunctionDocumentation::Category::Other;
+    FunctionDocumentation documentation_continuous = {description_continuous, syntax_continuous, arguments_continuous, returned_value_continuous, examples_continuous, introduced_in, category_continuous};
+
+    factory.registerFunction<FunctionMinSampleSize<ContinuousImpl>>(documentation_continuous);
     /// Needed for backward compatibility
     factory.registerAlias("minSampleSizeContinous", FunctionMinSampleSize<ContinuousImpl>::name);
-    factory.registerFunction<FunctionMinSampleSize<ConversionImpl>>();
+
+        FunctionDocumentation::Description description_conversion = R"(
+Calculates minimum required sample size for an A/B test comparing conversions (proportions) in two samples.
+Uses the formula described in [this article](https://towardsdatascience.com/required-sample-size-for-a-b-testing-6f6608dd330a). Assumes equal sizes of treatment and control groups. Returns the sample size required for one group (i.e. the sample size required for the whole experiment is twice the returned value).
+)";
+    FunctionDocumentation::Syntax syntax_conversion = "minSampleSizeConversion(baseline, mde, power, alpha)";
+    FunctionDocumentation::Arguments arguments_conversion = {
+        {"baseline", "Baseline conversion.", {"Float*"}},
+        {"mde", "Minimum detectable effect (MDE) as percentage points (e.g. for a baseline conversion 0.25 the MDE 0.03 means an expected change to 0.25 ± 0.03).", {"Float*"}},
+        {"power", "Required statistical power of a test (1 - probability of Type II error).", {"Float*"}},
+        {"alpha", "Required significance level of a test (probability of Type I error).", {"Float*"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value_conversion = {
+        "Returns a named Tuple with 3 elements: `minimum_sample_size`, `detect_range_lower`, `detect_range_upper`. These are, respectively: the required sample size, the lower bound of the range of values not detectable with the returned required sample size, calculated as `baseline - mde`, the upper bound of the range of values not detectable with the returned required sample size, calculated as `baseline + mde`.",
+        {"Tuple(Float64, Float64, Float64)"}
+    };
+    FunctionDocumentation::Examples examples_conversion = {
+        {"minSampleSizeConversion", "SELECT minSampleSizeConversion(0.25, 0.03, 0.80, 0.05) AS sample_size", "(3396.077603219163,0.22,0.28)"}
+    };
+    FunctionDocumentation::IntroducedIn introduced_in_conversion = {22, 6};
+    FunctionDocumentation::Category category_conversion = FunctionDocumentation::Category::Other;
+    FunctionDocumentation documentation_conversion = {description_conversion, syntax_conversion, arguments_conversion, returned_value_conversion, examples_conversion, introduced_in_conversion, category_conversion};
+
+    factory.registerFunction<FunctionMinSampleSize<ConversionImpl>>(documentation_conversion);    
 }
 
 }

--- a/src/Functions/minSampleSize.cpp
+++ b/src/Functions/minSampleSize.cpp
@@ -342,7 +342,7 @@ Uses the formula described in [this article](https://towardsdatascience.com/requ
     FunctionDocumentation::Category category_conversion = FunctionDocumentation::Category::Other;
     FunctionDocumentation documentation_conversion = {description_conversion, syntax_conversion, arguments_conversion, returned_value_conversion, examples_conversion, introduced_in_conversion, category_conversion};
 
-    factory.registerFunction<FunctionMinSampleSize<ConversionImpl>>(documentation_conversion);    
+    factory.registerFunction<FunctionMinSampleSize<ConversionImpl>>(documentation_conversion);
 }
 
 }

--- a/src/Functions/variantElement.cpp
+++ b/src/Functions/variantElement.cpp
@@ -158,31 +158,39 @@ private:
 
 REGISTER_FUNCTION(VariantElement)
 {
-    factory.registerFunction<FunctionVariantElement>(FunctionDocumentation{
-        .description = R"(
+    FunctionDocumentation::Description description = R"(
 Extracts a column with specified type from a `Variant` column.
-)",
-        .syntax{"variantElement(variant, type_name, [, default_value])"},
-        .arguments{
-            {"variant", "Variant column"},
-            {"type_name", "The name of the variant type to extract"},
-            {"default_value", "The default value that will be used if variant doesn't have variant with specified type. Can be any type. Optional"}},
-        .examples{{{
-            "Example",
-            R"(
+    )";
+    FunctionDocumentation::Syntax syntax = "variantElement(variant, type_name[, default_value])";
+    FunctionDocumentation::Arguments arguments = {
+        {"variant", "Variant column.", {"Variant"}},
+        {"type_name", "The name of the variant type to extract.", {"String"}},
+        {"default_value", "The default value that will be used if variant doesn't have variant with specified type. Can be any type. Optional.", {"Any"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns a column with the specified variant type extracted from the Variant column.", {"Any"}};
+    FunctionDocumentation::Examples examples = {
+    {
+        "Usage example",
+        R"(
 CREATE TABLE test (v Variant(UInt64, String, Array(UInt64))) ENGINE = Memory;
 INSERT INTO test VALUES (NULL), (42), ('Hello, World!'), ([1, 2, 3]);
-SELECT v, variantElement(v, 'String'), variantElement(v, 'UInt64'), variantElement(v, 'Array(UInt64)') FROM test;)",
-            R"(
+SELECT v, variantElement(v, 'String'), variantElement(v, 'UInt64'), variantElement(v, 'Array(UInt64)') FROM test;
+         )",
+         R"(
 ┌─v─────────────┬─variantElement(v, 'String')─┬─variantElement(v, 'UInt64')─┬─variantElement(v, 'Array(UInt64)')─┐
 │ ᴺᵁᴸᴸ          │ ᴺᵁᴸᴸ                        │                        ᴺᵁᴸᴸ │ []                                 │
 │ 42            │ ᴺᵁᴸᴸ                        │                          42 │ []                                 │
 │ Hello, World! │ Hello, World!               │                        ᴺᵁᴸᴸ │ []                                 │
 │ [1,2,3]       │ ᴺᵁᴸᴸ                        │                        ᴺᵁᴸᴸ │ [1,2,3]                            │
 └───────────────┴─────────────────────────────┴─────────────────────────────┴────────────────────────────────────┘
-)"}}},
-        .category = FunctionDocumentation::Category::JSON,
-    });
+        )"
+    }
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {25, 2};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Other;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
+
+    factory.registerFunction<FunctionVariantElement>(documentation);
 }
 
 }

--- a/src/Functions/variantType.cpp
+++ b/src/Functions/variantType.cpp
@@ -84,28 +84,37 @@ public:
 
 REGISTER_FUNCTION(VariantType)
 {
-    factory.registerFunction<FunctionVariantType>(FunctionDocumentation{
-        .description = R"(
+    FunctionDocumentation::Description description = R"(
 Returns the variant type name for each row of `Variant` column. If row contains NULL, it returns 'None' for it.
-)",
-        .syntax = {"variantType(variant)"},
-        .arguments = {{"variant", "Variant column"}},
-        .examples = {{{
-            "Example",
-            R"(
+    )";
+    FunctionDocumentation::Syntax syntax = "variantType(variant)";
+    FunctionDocumentation::Arguments arguments = {
+        {"variant", "Variant column.", {"Variant"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns an Enum column with variant type name for each row.", {"Enum"}};
+    FunctionDocumentation::Examples examples = {
+    {
+        "Usage example",
+        R"(
 CREATE TABLE test (v Variant(UInt64, String, Array(UInt64))) ENGINE = Memory;
 INSERT INTO test VALUES (NULL), (42), ('Hello, World!'), ([1, 2, 3]);
-SELECT variantType(v) FROM test;)",
-            R"(
+SELECT variantType(v) FROM test;
+        )",
+        R"(
 ┌─variantType(v)─┐
 │ None           │
 │ UInt64         │
 │ String         │
 │ Array(UInt64)  │
 └────────────────┘
-)"}}},
-        .category = FunctionDocumentation::Category::JSON,
-    });
+        )"
+    }
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {24, 2};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Other;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
+
+    factory.registerFunction<FunctionVariantType>(documentation);
 }
 
 }

--- a/tests/queries/0_stateless/02415_all_new_functions_must_be_documented.reference
+++ b/tests/queries/0_stateless/02415_all_new_functions_must_be_documented.reference
@@ -1,8 +1,5 @@
 DATE
 JSONKey
-MACNumToString
-MACStringToNum
-MACStringToOUI
 URLHierarchy
 URLPathHierarchy
 _CAST
@@ -14,7 +11,6 @@ __bitWrapperFunc
 __getScalar
 __scalarSubqueryResult
 caseWithExpression
-catboostEvaluate
 countSubstrings
 countSubstringsCaseInsensitive
 countSubstringsCaseInsensitiveUTF8
@@ -23,7 +19,6 @@ dotProduct
 evalMLMethod
 firstSignificantSubdomainCustom
 firstSignificantSubdomainCustomRFC
-getTypeSerializationStreams
 globalIn
 globalInIgnoreSet
 globalNotIn
@@ -32,7 +27,6 @@ globalNotNullIn
 globalNotNullInIgnoreSet
 globalNullIn
 globalNullInIgnoreSet
-globalVariable
 hasSubsequenceCaseInsensitive
 hasSubsequenceCaseInsensitiveUTF8
 hasSubsequenceUTF8
@@ -40,16 +34,12 @@ ilike
 in
 inIgnoreSet
 like
-lowCardinalityIndices
-lowCardinalityKeys
 map
 mapAdd
 mapFromArrays
 mapPopulateSeries
 mapSubtract
 mapUpdate
-minSampleSizeContinuous
-minSampleSizeConversion
 moduloLegacy
 multiFuzzyMatchAllIndices
 multiFuzzyMatchAny
@@ -140,8 +130,6 @@ toUInt32OrDefault
 toUInt64OrDefault
 toUInt8OrDefault
 toUUIDOrDefault
-transactionLatestSnapshot
-transactionOldestSnapshot
 validateNestedArraySizes
 windowID
 wkt

--- a/tests/queries/0_stateless/02415_all_new_functions_must_have_version_information.reference
+++ b/tests/queries/0_stateless/02415_all_new_functions_must_have_version_information.reference
@@ -1,8 +1,5 @@
 DATE
 JSONKey
-MACNumToString
-MACStringToNum
-MACStringToOUI
 URLHierarchy
 URLPathHierarchy
 _CAST
@@ -14,7 +11,6 @@ __bitWrapperFunc
 __getScalar
 __scalarSubqueryResult
 caseWithExpression
-catboostEvaluate
 countSubstrings
 countSubstringsCaseInsensitive
 countSubstringsCaseInsensitiveUTF8
@@ -83,11 +79,9 @@ formatQuery
 formatQueryOrNull
 formatQuerySingleLine
 formatQuerySingleLineOrNull
-generateRandomStructure
 generateSerialID
 getMaxTableNameLengthForDatabase
 getSubcolumn
-getTypeSerializationStreams
 globalIn
 globalInIgnoreSet
 globalNotIn
@@ -96,7 +90,6 @@ globalNotNullIn
 globalNotNullInIgnoreSet
 globalNullIn
 globalNullInIgnoreSet
-globalVariable
 hasSubsequenceCaseInsensitive
 hasSubsequenceCaseInsensitiveUTF8
 hasSubsequenceUTF8
@@ -107,16 +100,12 @@ in
 inIgnoreSet
 isDynamicElementInSharedData
 like
-lowCardinalityIndices
-lowCardinalityKeys
 map
 mapAdd
 mapFromArrays
 mapPopulateSeries
 mapSubtract
 mapUpdate
-minSampleSizeContinuous
-minSampleSizeConversion
 moduloLegacy
 multiFuzzyMatchAllIndices
 multiFuzzyMatchAny
@@ -217,12 +206,8 @@ toUInt32OrDefault
 toUInt64OrDefault
 toUInt8OrDefault
 toUUIDOrDefault
-transactionLatestSnapshot
-transactionOldestSnapshot
 tuple
 tupleNames
 validateNestedArraySizes
-variantElement
-variantType
 windowID
 wkt


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
Moves a few functions I missed to source code and adds versions for a few which were documented but without a version. Attempt number 2 after https://github.com/ClickHouse/ClickHouse/pull/88125 consistently fails on `02003_memory_limit_in_client` 
### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
