### PR TITLE
Move `clickhouse-client` history file to `XDG_STATE_HOME`

### DIFF
--- a/docs/en/interfaces/cli.md
+++ b/docs/en/interfaces/cli.md
@@ -188,7 +188,8 @@ In interactive mode, by default whatever was entered is run when you press `Ente
 
 You can start the client with the `-m, --multiline` parameter. To enter a multiline query, enter a backslash `\` before the line feed. After you press `Enter`, you will be asked to enter the next line of the query. To run the query, end it with a semicolon and press `Enter`.
 
-ClickHouse Client is based on `replxx` (similar to `readline`) so it uses familiar keyboard shortcuts and keeps a history. The history is written to `~/.clickhouse-client-history` by default.
+ClickHouse Client is based on `replxx` (similar to `readline`) so it uses familiar keyboard shortcuts and keeps a history. The history is written to `~/.local/state/clickhouse/client-query-history`, in accordance with the [XDG Base Directories specification](https://specifications.freedesktop.org/basedir-spec/latest/index.html).
+For compatibility reasons, if `~/.clickhouse-client-history` is already present, it will be used instead.
 
 To exit the client, press `Ctrl+D`, or enter one of the following instead of a query: `exit`, `quit`, `logout`, `exit;`, `quit;`, `logout;`, `q`, `Q`, `:q`.
 

--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -917,15 +917,7 @@ void Client::processConfig()
         if (config().has("history_file"))
             history_file = config().getString("history_file");
         else
-        {
-            auto * history_file_from_env = getenv("CLICKHOUSE_HISTORY_FILE"); // NOLINT(concurrency-mt-unsafe)
-            if (history_file_from_env)
-                history_file = history_file_from_env;
-            else if (!XDGBaseDirectories::getConfigurationHome().empty())
-                history_file = fs::path(XDGBaseDirectories::getConfigurationHome()) / "query-history";
-            else if (!home_path.empty())
-                history_file = home_path + "/.clickhouse-client-history";
-        }
+            history_file = ClientBase::getHistoryFilePath();
     }
 
     pager = config().getString("pager", "");

--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -6,6 +6,7 @@
 #include <boost/program_options.hpp>
 #include <Common/Config/parseConnectionCredentials.h>
 #include <Common/ThreadStatus.h>
+#include <Common/XDGBaseDirectories.h>
 
 #include <Access/AccessControl.h>
 
@@ -920,6 +921,8 @@ void Client::processConfig()
             auto * history_file_from_env = getenv("CLICKHOUSE_HISTORY_FILE"); // NOLINT(concurrency-mt-unsafe)
             if (history_file_from_env)
                 history_file = history_file_from_env;
+            else if (!XDGBaseDirectories::getConfigurationHome().empty())
+                history_file = fs::path(XDGBaseDirectories::getConfigurationHome()) / "query-history";
             else if (!home_path.empty())
                 history_file = home_path + "/.clickhouse-client-history";
         }

--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -6,7 +6,6 @@
 #include <boost/program_options.hpp>
 #include <Common/Config/parseConnectionCredentials.h>
 #include <Common/ThreadStatus.h>
-#include <Common/XDGBaseDirectories.h>
 
 #include <Access/AccessControl.h>
 

--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -259,7 +259,7 @@ void Client::initialize(Poco::Util::Application & self)
         {
             auto history_file = overrides.history_file.value();
             if (history_file.starts_with("~") && !home_path.empty())
-                history_file = home_path + "/" + history_file.substr(1);
+                history_file = home_path / history_file.substr(1);
             configuration.setString("history_file", history_file);
         }
         if (overrides.history_max_entries.has_value())

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -3483,6 +3483,9 @@ void ClientBase::runInteractive()
             /// Avoid TOCTOU issue.
             try
             {
+                if (history_file.has_parent_path())
+                    fs::create_directories(history_file.parent_path());
+
                 FS::createFile(history_file);
             }
             catch (const ErrnoException & e)

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -3473,17 +3473,24 @@ void ClientBase::runInteractive()
     if (!isEmbeeddedClient())
     {
         /// Load command history if present.
+        bool should_create_parent_directories = false;
         if (getClientConfiguration().has("history_file"))
             history_file = getClientConfiguration().getString("history_file");
         else
+        {
             history_file = getHistoryFilePath();
+
+            /// Avoid creating parent directories
+            /// if history file path was specified explicitly in config.
+            should_create_parent_directories = true;
+        }
 
         if (!history_file.empty() && !fs::exists(history_file))
         {
             /// Avoid TOCTOU issue.
             try
             {
-                if (history_file.has_parent_path())
+                if (should_create_parent_directories && history_file.has_parent_path())
                     fs::create_directories(history_file.parent_path());
 
                 FS::createFile(history_file);

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -3746,7 +3746,11 @@ fs::path ClientBase::getHistoryFilePath()
             return path_in_home_dir;
     }
 
-    return XDGBaseDirectories::getStateHome() / "client-query-history";
+    auto xdg_state_home = XDGBaseDirectories::getStateHome();
+    if (!xdg_state_home.empty())
+        return xdg_state_home / "client-query-history";
+
+    throw Exception(ErrorCodes::CANNOT_OPEN_FILE, "Neither $CLICKHOUSE_HISTORY_FILE, $HOME nor $XDG_STATE_HOME is set; cannot place history file.");
 }
 
 

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -3740,7 +3740,7 @@ std::string ClientBase::getHistoryFilePath()
             return path_in_home_dir;
     }
 
-    return fs::path(XDGBaseDirectories::getDataHome()) / "query-history";
+    return fs::path(XDGBaseDirectories::getStateHome()) / "query-history";
 }
 
 

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -3746,7 +3746,7 @@ fs::path ClientBase::getHistoryFilePath()
             return path_in_home_dir;
     }
 
-    return fs::path(XDGBaseDirectories::getStateHome()) / "client-query-history";
+    return XDGBaseDirectories::getStateHome() / "client-query-history";
 }
 
 

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -100,6 +100,7 @@
 #include <boost/algorithm/string/split.hpp>
 
 #include <Common/config_version.h>
+#include <Common/XDGBaseDirectories.h>
 #include <base/find_symbols.h>
 
 
@@ -3479,6 +3480,8 @@ void ClientBase::runInteractive()
             auto * history_file_from_env = getenv("CLICKHOUSE_HISTORY_FILE"); // NOLINT(concurrency-mt-unsafe)
             if (history_file_from_env)
                 history_file = history_file_from_env;
+            else if (!XDGBaseDirectories::getConfigurationHome().empty())
+                history_file = fs::path(XDGBaseDirectories::getConfigurationHome()) / "query-history";
             else if (!home_path.empty())
                 history_file = home_path + "/.clickhouse-client-history";
         }

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -3725,12 +3725,15 @@ void ClientBase::runNonInteractive()
     }
 }
 
-std::string ClientBase::getHistoryFilePath()
+fs::path ClientBase::getHistoryFilePath()
 {
     auto * history_file_from_env = getenv("CLICKHOUSE_HISTORY_FILE"); // NOLINT(concurrency-mt-unsafe)
     if (history_file_from_env)
         return history_file_from_env;
 
+    /// Client query history was stored in ~/.clickhouse-client-history
+    /// before moving to $XDG_STATE_HOME/clickhouse/client-query-history.
+    /// We'll pick up the old file and use it if it is already present.
     auto * home_path = getenv("HOME"); // NOLINT(concurrency-mt-unsafe)
     if (home_path)
     {
@@ -3740,7 +3743,7 @@ std::string ClientBase::getHistoryFilePath()
             return path_in_home_dir;
     }
 
-    return fs::path(XDGBaseDirectories::getStateHome()) / "query-history";
+    return fs::path(XDGBaseDirectories::getStateHome()) / "client-query-history";
 }
 
 

--- a/src/Client/ClientBase.h
+++ b/src/Client/ClientBase.h
@@ -209,7 +209,7 @@ protected:
     /// Used to check certain things that are considered unsafe for the embedded client
     virtual bool isEmbeeddedClient() const = 0;
 
-    static std::string getHistoryFilePath();
+    static fs::path getHistoryFilePath();
 private:
     void receiveResult(ASTPtr parsed_query, Int32 signals_before_stop, bool partial_result_on_first_cancel);
     bool receiveAndProcessPacket(ASTPtr parsed_query, bool cancelled_);

--- a/src/Client/ClientBase.h
+++ b/src/Client/ClientBase.h
@@ -385,8 +385,8 @@ protected:
     std::unique_ptr<WriteBufferFromFileDescriptor> tty_buf;
     std::mutex tty_mutex;
 
-    String home_path;
-    String history_file; /// Path to a file containing command history.
+    fs::path home_path;
+    fs::path history_file; /// Path to a file containing command history.
     UInt32 history_max_entries; /// Maximum number of entries in the history file.
 
     UInt64 server_revision = 0;

--- a/src/Client/ClientBase.h
+++ b/src/Client/ClientBase.h
@@ -209,6 +209,7 @@ protected:
     /// Used to check certain things that are considered unsafe for the embedded client
     virtual bool isEmbeeddedClient() const = 0;
 
+    static std::string getHistoryFilePath();
 private:
     void receiveResult(ASTPtr parsed_query, Int32 signals_before_stop, bool partial_result_on_first_cancel);
     bool receiveAndProcessPacket(ASTPtr parsed_query, bool cancelled_);

--- a/src/Common/XDGBaseDirectories.cpp
+++ b/src/Common/XDGBaseDirectories.cpp
@@ -1,0 +1,37 @@
+#include "Common/XDGBaseDirectories.h"
+
+#include <filesystem>
+
+
+namespace fs = std::filesystem;
+
+namespace DB
+{
+
+std::string XDGBaseDirectories::getConfigurationHome()
+{
+    auto * xdg_config_home = getenv(ENV_XDG_CONFIG_HOME); // NOLINT(concurrency-mt-unsafe)
+    if (xdg_config_home)
+        return fs::path(xdg_config_home) / APP_NAME;
+
+    auto * home_path = getenv(ENV_HOME); // NOLINT(concurrency-mt-unsafe)
+    if (home_path)
+        return fs::path(home_path) / CONFIG_PATH_PREFIX / APP_NAME;
+
+    return "";
+}
+
+std::string XDGBaseDirectories::getDataHome()
+{
+    auto * xdg_data_home = getenv(ENV_XDG_DATA_HOME); // NOLINT(concurrency-mt-unsafe)
+    if (xdg_data_home)
+        return fs::path(xdg_data_home) / APP_NAME;
+
+    auto * home_path = getenv(ENV_HOME); // NOLINT(concurrency-mt-unsafe)
+    if (home_path)
+        return fs::path(home_path) / DATA_PATH_PREFIX / APP_NAME;
+
+    return "";
+}
+
+}

--- a/src/Common/XDGBaseDirectories.cpp
+++ b/src/Common/XDGBaseDirectories.cpp
@@ -8,43 +8,56 @@ namespace fs = std::filesystem;
 namespace DB
 {
 
-std::string XDGBaseDirectories::getConfigurationHome()
+namespace
 {
-    auto * xdg_config_home = getenv(ENV_XDG_CONFIG_HOME); // NOLINT(concurrency-mt-unsafe)
-    if (xdg_config_home)
-        return fs::path(xdg_config_home) / APP_NAME;
+    constexpr const char* ENV_XDG_CONFIG_HOME = "XDG_CONFIG_HOME";
+    constexpr const char* CONFIG_PATH_PREFIX = ".config";
 
-    auto * home_path = getenv(ENV_HOME); // NOLINT(concurrency-mt-unsafe)
-    if (home_path)
-        return fs::path(home_path) / CONFIG_PATH_PREFIX / APP_NAME;
+    constexpr const char* ENV_XDG_DATA_HOME = "XDG_DATA_HOME";
+    constexpr const char* DATA_PATH_PREFIX = ".local/share";
 
-    return "";
+    constexpr const char* ENV_XDG_STATE_HOME = "XDG_STATE_HOME";
+    constexpr const char* STATE_PATH_PREFIX = ".local/state";
+
+    constexpr const char* ENV_XDG_CACHE_HOME = "XDG_STATE_HOME";
+    constexpr const char* CACHE_PATH_PREFIX = ".cache";
+
+    constexpr const char* ENV_HOME = "HOME";
+
+    constexpr const char* APP_NAME = "clickhouse";
+
+    fs::path getPathFromEnvOrDefault(const char* env_var_name, const char* path_prefix)
+    {
+        auto * xdg_config_home = getenv(env_var_name); // NOLINT(concurrency-mt-unsafe)
+        if (xdg_config_home)
+            return fs::path(xdg_config_home) / APP_NAME;
+
+        auto * home_path = getenv(ENV_HOME); // NOLINT(concurrency-mt-unsafe)
+        if (home_path)
+            return fs::path(home_path) / path_prefix / APP_NAME;
+
+        return "";
+    }
 }
 
-std::string XDGBaseDirectories::getDataHome()
+fs::path XDGBaseDirectories::getConfigurationHome()
 {
-    auto * xdg_data_home = getenv(ENV_XDG_DATA_HOME); // NOLINT(concurrency-mt-unsafe)
-    if (xdg_data_home)
-        return fs::path(xdg_data_home) / APP_NAME;
-
-    auto * home_path = getenv(ENV_HOME); // NOLINT(concurrency-mt-unsafe)
-    if (home_path)
-        return fs::path(home_path) / DATA_PATH_PREFIX / APP_NAME;
-
-    return "";
+    return getPathFromEnvOrDefault(ENV_XDG_CONFIG_HOME, CONFIG_PATH_PREFIX);
 }
 
-std::string XDGBaseDirectories::getStateHome()
+fs::path XDGBaseDirectories::getDataHome()
 {
-    auto * xdg_data_home = getenv(ENV_XDG_STATE_HOME); // NOLINT(concurrency-mt-unsafe)
-    if (xdg_data_home)
-        return fs::path(xdg_data_home) / APP_NAME;
+    return getPathFromEnvOrDefault(ENV_XDG_DATA_HOME, DATA_PATH_PREFIX);
+}
 
-    auto * home_path = getenv(ENV_HOME); // NOLINT(concurrency-mt-unsafe)
-    if (home_path)
-        return fs::path(home_path) / STATE_PATH_PREFIX / APP_NAME;
+fs::path XDGBaseDirectories::getStateHome()
+{
+    return getPathFromEnvOrDefault(ENV_XDG_STATE_HOME, STATE_PATH_PREFIX);
+}
 
-    return "";
+fs::path XDGBaseDirectories::getCacheHome()
+{
+    return getPathFromEnvOrDefault(ENV_XDG_CACHE_HOME, CACHE_PATH_PREFIX);
 }
 
 }

--- a/src/Common/XDGBaseDirectories.cpp
+++ b/src/Common/XDGBaseDirectories.cpp
@@ -1,4 +1,4 @@
-#include "Common/XDGBaseDirectories.h"
+#include <Common/XDGBaseDirectories.h>
 
 #include <filesystem>
 

--- a/src/Common/XDGBaseDirectories.cpp
+++ b/src/Common/XDGBaseDirectories.cpp
@@ -34,4 +34,17 @@ std::string XDGBaseDirectories::getDataHome()
     return "";
 }
 
+std::string XDGBaseDirectories::getStateHome()
+{
+    auto * xdg_data_home = getenv(ENV_XDG_STATE_HOME); // NOLINT(concurrency-mt-unsafe)
+    if (xdg_data_home)
+        return fs::path(xdg_data_home) / APP_NAME;
+
+    auto * home_path = getenv(ENV_HOME); // NOLINT(concurrency-mt-unsafe)
+    if (home_path)
+        return fs::path(home_path) / STATE_PATH_PREFIX / APP_NAME;
+
+    return "";
+}
+
 }

--- a/src/Common/XDGBaseDirectories.h
+++ b/src/Common/XDGBaseDirectories.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <cstdlib>
+#include <string>
+#include <filesystem>
+
+
+namespace fs = std::filesystem;
+
+namespace DB
+{
+
+/// https://specifications.freedesktop.org/basedir-spec/latest/
+class XDGBaseDirectories
+{
+    static constexpr const char* ENV_XDG_CONFIG_HOME = "XDG_CONFIG_HOME";
+    static constexpr const char* ENV_HOME = "HOME";
+
+public:
+    static std::string getConfigurationHome()
+    {
+        auto * xdg_config_home = getenv(ENV_XDG_CONFIG_HOME); // NOLINT(concurrency-mt-unsafe)
+        if (xdg_config_home)
+            return fs::path(xdg_config_home) / "clickhouse";
+
+        auto * home_path = getenv(ENV_HOME); // NOLINT(concurrency-mt-unsafe)
+        if (home_path)
+            return std::string(home_path) + "/.config/clickhouse";
+
+        return "";
+    }
+
+};
+
+}

--- a/src/Common/XDGBaseDirectories.h
+++ b/src/Common/XDGBaseDirectories.h
@@ -2,10 +2,7 @@
 
 #include <cstdlib>
 #include <string>
-#include <filesystem>
 
-
-namespace fs = std::filesystem;
 
 namespace DB
 {
@@ -14,22 +11,18 @@ namespace DB
 class XDGBaseDirectories
 {
     static constexpr const char* ENV_XDG_CONFIG_HOME = "XDG_CONFIG_HOME";
+    static constexpr const char* CONFIG_PATH_PREFIX = ".config";
+
+    static constexpr const char* ENV_XDG_DATA_HOME = "XDG_DATA_HOME";
+    static constexpr const char* DATA_PATH_PREFIX = ".local/share";
+
     static constexpr const char* ENV_HOME = "HOME";
 
+    static constexpr const char* APP_NAME = "clickhouse";
+
 public:
-    static std::string getConfigurationHome()
-    {
-        auto * xdg_config_home = getenv(ENV_XDG_CONFIG_HOME); // NOLINT(concurrency-mt-unsafe)
-        if (xdg_config_home)
-            return fs::path(xdg_config_home) / "clickhouse";
-
-        auto * home_path = getenv(ENV_HOME); // NOLINT(concurrency-mt-unsafe)
-        if (home_path)
-            return std::string(home_path) + "/.config/clickhouse";
-
-        return "";
-    }
-
+    static std::string getConfigurationHome();
+    static std::string getDataHome();
 };
 
 }

--- a/src/Common/XDGBaseDirectories.h
+++ b/src/Common/XDGBaseDirectories.h
@@ -16,6 +16,9 @@ class XDGBaseDirectories
     static constexpr const char* ENV_XDG_DATA_HOME = "XDG_DATA_HOME";
     static constexpr const char* DATA_PATH_PREFIX = ".local/share";
 
+    static constexpr const char* ENV_XDG_STATE_HOME = "XDG_STATE_HOME";
+    static constexpr const char* STATE_PATH_PREFIX = ".local/state";
+
     static constexpr const char* ENV_HOME = "HOME";
 
     static constexpr const char* APP_NAME = "clickhouse";
@@ -23,6 +26,7 @@ class XDGBaseDirectories
 public:
     static std::string getConfigurationHome();
     static std::string getDataHome();
+    static std::string getStateHome();
 };
 
 }

--- a/src/Common/XDGBaseDirectories.h
+++ b/src/Common/XDGBaseDirectories.h
@@ -2,7 +2,10 @@
 
 #include <cstdlib>
 #include <string>
+#include <filesystem>
 
+
+namespace fs = std::filesystem;
 
 namespace DB
 {
@@ -10,23 +13,11 @@ namespace DB
 /// https://specifications.freedesktop.org/basedir-spec/latest/
 class XDGBaseDirectories
 {
-    static constexpr const char* ENV_XDG_CONFIG_HOME = "XDG_CONFIG_HOME";
-    static constexpr const char* CONFIG_PATH_PREFIX = ".config";
-
-    static constexpr const char* ENV_XDG_DATA_HOME = "XDG_DATA_HOME";
-    static constexpr const char* DATA_PATH_PREFIX = ".local/share";
-
-    static constexpr const char* ENV_XDG_STATE_HOME = "XDG_STATE_HOME";
-    static constexpr const char* STATE_PATH_PREFIX = ".local/state";
-
-    static constexpr const char* ENV_HOME = "HOME";
-
-    static constexpr const char* APP_NAME = "clickhouse";
-
 public:
-    static std::string getConfigurationHome();
-    static std::string getDataHome();
-    static std::string getStateHome();
+    static fs::path getConfigurationHome();
+    static fs::path getDataHome();
+    static fs::path getStateHome();
+    static fs::path getCacheHome();
 };
 
 }


### PR DESCRIPTION
Closes https://github.com/ClickHouse/ClickHouse/issues/10024


### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Store `clickhouse-client` files (e.g. query history) in places described by [XDG Base Directories](https://specifications.freedesktop.org/basedir-spec/latest/index.html) specification instead of root of home directory.
`~/.clickhouse-client-history` will still be used if it is already present.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)
