### PR TITLE
Allow external table writes with disable_insertion_and_mutation

### DIFF
--- a/src/Core/ServerSettings.cpp
+++ b/src/Core/ServerSettings.cpp
@@ -1041,7 +1041,7 @@ The policy on how to perform a scheduling of CPU slots specified by `concurrent_
     )", 0) \
     DECLARE(Bool, memory_worker_use_cgroup, true, "Use current cgroup memory usage information to correct memory tracking.", 0) \
     DECLARE(Bool, disable_insertion_and_mutation, false, R"(
-    Disable all insert/alter/delete queries. This setting will be enabled if someone needs read-only nodes to prevent insertion and mutation affect reading performance.
+    Disable insert/alter/delete queries. This setting will be enabled if someone needs read-only nodes to prevent insertion and mutation affect reading performance. Inserts into external engines (S3, DataLake, MySQL, PostrgeSQL, Kafka, etc) are allowed despite this setting.
     )", 0) \
     DECLARE(UInt64, parts_kill_delay_period, 30, R"(
     Period to completely remove parts for SharedMergeTree. Only available in ClickHouse Cloud

--- a/src/Interpreters/InterpreterInsertQuery.cpp
+++ b/src/Interpreters/InterpreterInsertQuery.cpp
@@ -850,14 +850,23 @@ BlockIO InterpreterInsertQuery::execute()
     const Settings & settings = context->getSettingsRef();
     auto & query = query_ptr->as<ASTInsertQuery &>();
 
+    StoragePtr table = getTable(query);
+
     if (context->getServerSettings()[ServerSetting::disable_insertion_and_mutation]
         && query.table_id.database_name != DatabaseCatalog::SYSTEM_DATABASE
         && query.table_id.database_name != DatabaseCatalog::TEMPORARY_DATABASE)
     {
-        throw Exception(ErrorCodes::QUERY_IS_PROHIBITED, "Insert queries are prohibited");
-    }
+        /// Allow inserts into external table engines (object storage, message queues, external databases)
+        /// as they don't create merge tasks on the server replica
+        bool is_external_storage =
+            table->isObjectStorage() ||     /// S3, Azure, GCS, HDFS, etc.
+            table->isDataLake() ||           /// Iceberg, DeltaLake, Hudi
+            table->isMessageQueue() ||       /// Kafka, RabbitMQ, NATS
+            table->isExternalDatabase();     /// MySQL, PostgreSQL, MongoDB, Hive, YTsaurus
 
-    StoragePtr table = getTable(query);
+        if (!is_external_storage)
+            throw Exception(ErrorCodes::QUERY_IS_PROHIBITED, "Insert queries are prohibited");
+    }
 
     checkStorageSupportsTransactionsIfNeeded(table, getContext());
 

--- a/src/Storages/Hive/StorageHive.h
+++ b/src/Storages/Hive/StorageHive.h
@@ -40,6 +40,8 @@ public:
 
     String getName() const override { return "Hive"; }
 
+    bool isExternalDatabase() const override { return true; }
+
     bool supportsSubcolumns() const override { return true; }
 
     void read(

--- a/src/Storages/IStorage.h
+++ b/src/Storages/IStorage.h
@@ -100,6 +100,15 @@ public:
 
     virtual bool isDataLake() const { return false; }
 
+    /// Returns true if the storage is an external database (MySQL, PostgreSQL, MongoDB, etc.)
+    virtual bool isExternalDatabase() const { return false; }
+
+    /// Returns true if the storage is object storage (S3, Azure, GCS, HDFS, etc.)
+    virtual bool isObjectStorage() const { return false; }
+
+    /// Returns true if the storage is a message queue (Kafka, RabbitMQ, NATS)
+    virtual bool isMessageQueue() const { return false; }
+
     /// Returns true if the storage receives data from a remote server or servers.
     virtual bool isRemote() const { return false; }
 

--- a/src/Storages/Kafka/StorageKafka.h
+++ b/src/Storages/Kafka/StorageKafka.h
@@ -51,6 +51,8 @@ public:
 
     std::string getName() const override { return Kafka::TABLE_ENGINE_NAME; }
 
+    bool isMessageQueue() const override { return true; }
+
     bool noPushingToViewsOnInserts() const override { return true; }
 
     void startup() override;

--- a/src/Storages/Kafka/StorageKafka2.h
+++ b/src/Storages/Kafka/StorageKafka2.h
@@ -78,6 +78,8 @@ public:
 
     std::string getName() const override { return Kafka::TABLE_ENGINE_NAME; }
 
+    bool isMessageQueue() const override { return true; }
+
     bool noPushingToViewsOnInserts() const override { return true; }
 
     void startup() override;

--- a/src/Storages/NATS/StorageNATS.h
+++ b/src/Storages/NATS/StorageNATS.h
@@ -39,6 +39,8 @@ public:
 
     std::string getName() const override { return NATS::TABLE_ENGINE_NAME; }
 
+    bool isMessageQueue() const override { return true; }
+
     bool noPushingToViewsOnInserts() const override { return true; }
 
     void startup() override;

--- a/src/Storages/ObjectStorage/StorageObjectStorage.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorage.h
@@ -96,6 +96,8 @@ public:
 
     bool isDataLake() const override { return configuration->isDataLakeConfiguration(); }
 
+    bool isObjectStorage() const override { return true; }
+
     bool supportsReplication() const override { return configuration->isDataLakeConfiguration(); }
 
     /// Things required for PREWHERE.

--- a/src/Storages/RabbitMQ/StorageRabbitMQ.h
+++ b/src/Storages/RabbitMQ/StorageRabbitMQ.h
@@ -35,6 +35,8 @@ public:
 
     std::string getName() const override { return RabbitMQ::TABLE_ENGINE_NAME; }
 
+    bool isMessageQueue() const override { return true; }
+
     bool noPushingToViewsOnInserts() const override { return true; }
 
     void startup() override;

--- a/src/Storages/StorageMongoDB.h
+++ b/src/Storages/StorageMongoDB.h
@@ -73,6 +73,7 @@ public:
 
     std::string getName() const override { return "MongoDB"; }
     bool isRemote() const override { return true; }
+    bool isExternalDatabase() const override { return true; }
 
     Pipe read(
         const Names & column_names,

--- a/src/Storages/StorageMySQL.h
+++ b/src/Storages/StorageMySQL.h
@@ -39,6 +39,8 @@ public:
 
     std::string getName() const override { return "MySQL"; }
 
+    bool isExternalDatabase() const override { return true; }
+
     Pipe read(
         const Names & column_names,
         const StorageSnapshotPtr & storage_snapshot,

--- a/src/Storages/StoragePostgreSQL.h
+++ b/src/Storages/StoragePostgreSQL.h
@@ -37,6 +37,8 @@ public:
 
     String getName() const override { return "PostgreSQL"; }
 
+    bool isExternalDatabase() const override { return true; }
+
     void read(
         QueryPlan & query_plan,
         const Names & column_names,

--- a/src/Storages/YTsaurus/StorageYTsaurus.h
+++ b/src/Storages/YTsaurus/StorageYTsaurus.h
@@ -38,6 +38,7 @@ public:
 
     std::string getName() const override { return "YTsaurus"; }
     bool isRemote() const override { return true; }
+    bool isExternalDatabase() const override { return true; }
 
     Pipe read(
         const Names & column_names,

--- a/tests/integration/test_disable_insertion_and_mutation/test.py
+++ b/tests/integration/test_disable_insertion_and_mutation/test.py
@@ -5,6 +5,7 @@ import pytest
 
 from helpers.client import QueryRuntimeException
 from helpers.cluster import ClickHouseCluster
+from helpers.config_cluster import minio_secret_key
 
 cluster = ClickHouseCluster(__file__)
 
@@ -94,3 +95,28 @@ def test_disable_insertion_and_mutation(started_cluster):
     assert "new_column\tString" in writing_node.query("DESC my_table")
     
     writing_node.query("DROP TABLE IF EXISTS my_table ON CLUSTER default SYNC")
+
+
+def test_disable_insertion_and_mutation_with_external_tables(started_cluster):
+    """Test that inserts into external tables (S3, Kafka, MySQL, PostgreSQL) are allowed
+    even when disable_insertion_and_mutation is set to true"""
+
+    # Test S3 table insert - should be allowed
+    # Use unique path to avoid conflicts between test runs
+    unique_id = str(uuid.uuid4())
+    reading_node.query("DROP TABLE IF EXISTS s3_table")
+    reading_node.query(
+        f"""
+        CREATE TABLE s3_table (key UInt64, value String)
+        ENGINE=S3('http://minio1:9001/root/data/test_external_{unique_id}.csv', 'minio', '{minio_secret_key}', 'CSV')
+        """
+    )
+
+    # This should succeed even on reading_node with disable_insertion_and_mutation=true
+    reading_node.query("INSERT INTO s3_table VALUES (1, 'hello'), (2, 'world')")
+
+    # Verify data was written
+    result = reading_node.query("SELECT count() FROM s3_table")
+    assert "2" in result
+
+    reading_node.query("DROP TABLE IF EXISTS s3_table")


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Allow inserting into remote and data lake tables when `disable_insertion_and_mutation` is enabled

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
