### PR TITLE
Disable explicit column definitions in Alias

### DIFF
--- a/docs/en/engines/table-engines/special/alias.md
+++ b/docs/en/engines/table-engines/special/alias.md
@@ -14,16 +14,20 @@ The `Alias` engine creates a proxy to another table. All read and write operatio
 ## Creating a Table {#creating-a-table}
 
 ```sql
-CREATE TABLE [db_name.]alias_name [columns]
+CREATE TABLE [db_name.]alias_name
 ENGINE = Alias(target_table)
 ```
 
 Or with explicit database name:
 
 ```sql
-CREATE TABLE [db_name.]alias_name [columns]
+CREATE TABLE [db_name.]alias_name
 ENGINE = Alias(target_db, target_table)
 ```
+
+:::note
+The `Alias` table does not support explicit column definitions. Columns are automatically inherited from the target table. This ensures that the alias always matches the target table's schema.
+:::
 
 ## Engine Parameters {#engine-parameters}
 

--- a/src/Storages/StorageAlias.h
+++ b/src/Storages/StorageAlias.h
@@ -2,7 +2,8 @@
 
 #include <Storages/IStorage.h>
 #include <Interpreters/DatabaseCatalog.h>
-
+#include <Access/Common/AccessType.h>
+#include <optional>
 
 namespace DB
 {
@@ -10,6 +11,13 @@ namespace DB
 class StorageAlias final : public IStorage, WithContext
 {
 public:
+    struct TargetAccess
+    {
+        ContextPtr context;
+        AccessType access_type;
+        Names column_names = {};
+    };
+
     StorageAlias(
         const StorageID & table_id_,
         ContextPtr context_,
@@ -19,7 +27,7 @@ public:
     std::string getName() const override { return "Alias"; }
 
     /// Get the target storage this alias points to
-    StoragePtr getTargetTable() const { return DatabaseCatalog::instance().getTable(StorageID(target_database, target_table), getContext()); }
+    StoragePtr getTargetTable(std::optional<TargetAccess> access_check = std::nullopt) const;
 
     /// Read from target table
     void read(

--- a/src/Storages/StorageAlias.h
+++ b/src/Storages/StorageAlias.h
@@ -14,9 +14,7 @@ public:
         const StorageID & table_id_,
         ContextPtr context_,
         const String & target_database_,
-        const String & target_table_,
-        const ColumnsDescription & columns_,
-        const String & comment);
+        const String & target_table_);
 
     std::string getName() const override { return "Alias"; }
 
@@ -40,6 +38,9 @@ public:
         const StorageMetadataPtr & metadata_snapshot,
         ContextPtr local_context,
         bool async_insert) override;
+
+    /// Distributed write to target table
+    std::optional<QueryPipeline> distributedWrite(const ASTInsertQuery & query, ContextPtr local_context) override;
 
     void checkAlterIsPossible(const AlterCommands & commands, ContextPtr local_context) const override { getTargetTable()->checkAlterIsPossible(commands, local_context); }
 
@@ -86,21 +87,49 @@ public:
         const MutationCommands & commands,
         ContextPtr local_context) override;
 
+    /// Lightweight update on target table
+    QueryPipeline updateLightweight(const MutationCommands & commands, ContextPtr local_context) override;
+
+    CancellationCode killMutation(const String & mutation_id) override;
+    void waitForMutation(const String & mutation_id, bool wait_for_another_mutation) override;
+    void setMutationCSN(const String & mutation_id, UInt64 csn) override;
+
+    void updateExternalDynamicMetadataIfExists(ContextPtr local_context) override;
     void checkTableCanBeDropped(ContextPtr /*query_context*/) const override {}
+    StorageInMemoryMetadata getInMemoryMetadata() const override { return getTargetTable()->getInMemoryMetadata(); }
+    StorageMetadataPtr getInMemoryMetadataPtr() const override { return getTargetTable()->getInMemoryMetadataPtr(); }
+    StorageSnapshotPtr getStorageSnapshot(const StorageMetadataPtr & metadata_snapshot, ContextPtr query_context) const override;
+    StorageSnapshotPtr getStorageSnapshotForQuery(const StorageMetadataPtr & metadata_snapshot, const ASTPtr & query, ContextPtr query_context) const override;
+    StorageSnapshotPtr getStorageSnapshotWithoutData(const StorageMetadataPtr & metadata_snapshot, ContextPtr query_context) const override;
 
-    void checkTableCanBeRenamed(const StorageID & /*new_name*/) const override {}
-
-    /// Proxy to target table
     bool supportsSampling() const override { return getTargetTable()->supportsSampling(); }
     bool supportsFinal() const override { return getTargetTable()->supportsFinal(); }
     bool supportsSubcolumns() const override { return getTargetTable()->supportsSubcolumns(); }
     bool supportsDynamicSubcolumns() const override { return getTargetTable()->supportsDynamicSubcolumns(); }
+    bool supportsDynamicSubcolumnsDeprecated() const override { return getTargetTable()->supportsDynamicSubcolumnsDeprecated(); }
     bool supportsPrewhere() const override { return getTargetTable()->supportsPrewhere(); }
-    bool supportsReplication() const override { return getTargetTable()->supportsReplication(); }
+    std::optional<NameSet> supportedPrewhereColumns() const override { return getTargetTable()->supportedPrewhereColumns(); }
+    bool canMoveConditionsToPrewhere() const override { return getTargetTable()->canMoveConditionsToPrewhere(); }
+    bool supportsOptimizationToSubcolumns() const override { return getTargetTable()->supportsOptimizationToSubcolumns(); }
     bool supportsParallelInsert() const override { return getTargetTable()->supportsParallelInsert(); }
     bool supportsDeduplication() const override { return getTargetTable()->supportsDeduplication(); }
     bool supportsTransactions() const override { return getTargetTable()->supportsTransactions(); }
+    bool noPushingToViewsOnInserts() const override { return getTargetTable()->noPushingToViewsOnInserts(); }
+    bool hasEvenlyDistributedRead() const override { return getTargetTable()->hasEvenlyDistributedRead(); }
+    bool prefersLargeBlocks() const override { return getTargetTable()->prefersLargeBlocks(); }
+    bool areAsynchronousInsertsEnabled() const override { return getTargetTable()->areAsynchronousInsertsEnabled(); }
     bool isRemote() const override { return getTargetTable()->isRemote(); }
+    bool isSharedStorage() const override { return getTargetTable()->isSharedStorage(); }
+
+    bool hasLightweightDeletedMask() const override { return getTargetTable()->hasLightweightDeletedMask(); }
+    bool supportsLightweightDelete() const override { return getTargetTable()->supportsLightweightDelete(); }
+    std::expected<void, PreformattedMessage> supportsLightweightUpdate() const override { return getTargetTable()->supportsLightweightUpdate(); }
+    bool supportsDelete() const override { return getTargetTable()->supportsDelete(); }
+    bool hasProjection() const override { return getTargetTable()->hasProjection(); }
+    bool supportsSparseSerialization() const override { return getTargetTable()->supportsSparseSerialization(); }
+    bool supportsTrivialCountOptimization(const StorageSnapshotPtr & storage_snapshot, ContextPtr query_context) const override { return getTargetTable()->supportsTrivialCountOptimization(storage_snapshot, query_context); }
+    bool supportsPartitionBy() const override { return getTargetTable()->supportsPartitionBy(); }
+    bool supportsTTL() const override { return getTargetTable()->supportsTTL(); }
 
     NamesAndTypesList getVirtuals() const { return getTargetTable()->getVirtualsList(); }
 
@@ -116,6 +145,10 @@ public:
 
     std::optional<UInt64> totalRows(ContextPtr query_context) const override { return getTargetTable()->totalRows(query_context); }
     std::optional<UInt64> totalBytes(ContextPtr query_context) const override { return getTargetTable()->totalBytes(query_context); }
+    ColumnSizeByName getColumnSizes() const override { return getTargetTable()->getColumnSizes(); }
+    IndexSizeByName getSecondaryIndexSizes() const override { return getTargetTable()->getSecondaryIndexSizes(); }
+
+    CancellationCode killPartMoveToShard(const UUID & task_uuid) override;
 
     /// These operations are not proxied (executed on alias itself)
     /// Drop alias, not the target table

--- a/tests/integration/test_storage_alias_replicated/configs/remote_servers.xml
+++ b/tests/integration/test_storage_alias_replicated/configs/remote_servers.xml
@@ -1,0 +1,16 @@
+<clickhouse>
+    <remote_servers>
+        <test_cluster>
+            <shard>
+                <replica>
+                    <host>node1</host>
+                    <port>9000</port>
+                </replica>
+                <replica>
+                    <host>node2</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </test_cluster>
+    </remote_servers>
+</clickhouse>

--- a/tests/integration/test_storage_alias_replicated/test.py
+++ b/tests/integration/test_storage_alias_replicated/test.py
@@ -1,0 +1,54 @@
+import pytest
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+
+node1 = cluster.add_instance(
+    "node1",
+    main_configs=["configs/remote_servers.xml"],
+    with_zookeeper=True,
+    macros={"replica": "node1"},
+)
+
+node2 = cluster.add_instance(
+    "node2",
+    main_configs=["configs/remote_servers.xml"],
+    with_zookeeper=True,
+    macros={"replica": "node2"},
+)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+def test_alias_with_replicated(started_cluster):
+    node1.query("CREATE DATABASE test_rmt ENGINE = Replicated('/clickhouse/databases/test_rmt', 'shard1', 'node1')")
+    node2.query("CREATE DATABASE test_rmt ENGINE = Replicated('/clickhouse/databases/test_rmt', 'shard1', 'node2')")
+
+    node1.query("CREATE TABLE test_rmt.rmt_table (id UInt32, value String) ENGINE = ReplicatedMergeTree ORDER BY id")
+    node1.query("CREATE TABLE test_rmt.alias_rmt ENGINE = Alias('rmt_table')")
+
+    node1.query("INSERT INTO test_rmt.alias_rmt VALUES (1, 'one')")
+
+    assert node2.query("SELECT * FROM test_rmt.rmt_table") == "1\tone\n"
+
+    node1.query("ALTER TABLE test_rmt.alias_rmt ADD COLUMN time DateTime DEFAULT now()")
+
+    node2.query("SYSTEM SYNC REPLICA test_rmt.rmt_table")
+
+    assert "time" in node1.query("DESCRIBE test_rmt.alias_rmt")
+    assert "time" in node2.query("DESCRIBE test_rmt.rmt_table")
+    assert "time" in node2.query("DESCRIBE test_rmt.alias_rmt")
+
+    node2.query("INSERT INTO test_rmt.alias_rmt VALUES (2, 'two', now())")
+
+    assert "2\ttwo" in node1.query("SELECT id, value FROM test_rmt.rmt_table WHERE id = 2")
+    assert "2\ttwo" in node2.query("SELECT id, value FROM test_rmt.alias_rmt WHERE id = 2")
+
+    node1.query("DROP DATABASE test_rmt SYNC")
+    node2.query("DROP DATABASE test_rmt SYNC")

--- a/tests/queries/0_stateless/03636_storage_alias_basic.reference
+++ b/tests/queries/0_stateless/03636_storage_alias_basic.reference
@@ -37,7 +37,7 @@ Test RENAME alias
 2	two	active
 Test DROP alias
 2
-Test Alias with explicit columns
+Test Create alias
 1	one	active
 2	two	active
 Test OPTIMIZE
@@ -76,3 +76,19 @@ from_a
 After EXCHANGE source tables:
 from_a
 from_b
+Test DETACH and ATTACH TABLE
+1	data1
+2	data2
+1	data1
+2	data2
+After ATTACH
+1	data1
+2	data2
+1	data1
+2	data2
+1	data1
+2	data2
+3	data3
+1	data1
+2	data2
+3	data3

--- a/tests/queries/0_stateless/03636_storage_alias_basic.reference
+++ b/tests/queries/0_stateless/03636_storage_alias_basic.reference
@@ -67,13 +67,13 @@ Test DROP PARTITION
 2
 Test INSERT SELECT
 2
-Before EXCHANGE:
+Before EXCHANGE
 from_a
 from_b
-After EXCHANGE alias tables:
+After EXCHANGE alias tables
 from_b
 from_a
-After EXCHANGE source tables:
+After EXCHANGE source tables
 from_a
 from_b
 Test DETACH and ATTACH TABLE
@@ -92,3 +92,25 @@ After ATTACH
 1	data1
 2	data2
 3	data3
+Test circular reference prevention
+Test ALTER target directly
+1	one
+2	two
+After ALTER target
+extra
+id
+value
+1	one	data1
+2	two	data1
+3	three	data3
+After multiple ALTERs
+extra
+id
+num
+value
+4	four	data2	100
+After DROP
+extra
+id
+value
+5	five	data5

--- a/tests/queries/0_stateless/03636_storage_alias_basic.sql
+++ b/tests/queries/0_stateless/03636_storage_alias_basic.sql
@@ -59,9 +59,9 @@ DROP TABLE alias_2;
 DROP TABLE alias_3;
 SELECT count() FROM source_table;
 
--- Test: Explicit columns
-SELECT 'Test Alias with explicit columns';
-CREATE TABLE alias_4 (id UInt32, value String, status String) ENGINE = Alias('source_table');
+-- Test: Create alias
+SELECT 'Test Create alias';
+CREATE TABLE alias_4 ENGINE = Alias('source_table');
 SELECT * FROM alias_4 ORDER BY id;
 
 -- Test: OPTIMIZE through alias
@@ -156,3 +156,34 @@ DROP TABLE alias_a_exchange;
 DROP TABLE alias_b_exchange;
 DROP TABLE table_a_exchange;
 DROP TABLE table_b_exchange;
+
+-- Test: DETACH and ATTACH TABLE
+SELECT 'Test DETACH and ATTACH TABLE';
+DROP TABLE IF EXISTS source_attach;
+DROP TABLE IF EXISTS alias_attach;
+
+CREATE TABLE source_attach (id UInt32, data String) ENGINE = MergeTree ORDER BY id;
+INSERT INTO source_attach VALUES (1, 'data1'), (2, 'data2');
+
+CREATE TABLE alias_attach ENGINE = Alias('source_attach');
+SELECT * FROM alias_attach ORDER BY id;
+SELECT * FROM source_attach ORDER BY id;
+
+-- DETACH the alias table
+DETACH TABLE alias_attach;
+
+-- ATTACH the table back
+ATTACH TABLE alias_attach;
+
+-- Verify it works after ATTACH
+SELECT 'After ATTACH';
+SELECT * FROM alias_attach ORDER BY id;
+SELECT * FROM source_attach ORDER BY id;
+
+-- Insert through alias after ATTACH
+INSERT INTO alias_attach VALUES (3, 'data3');
+SELECT * FROM alias_attach ORDER BY id;
+SELECT * FROM source_attach ORDER BY id;
+
+DROP TABLE alias_attach;
+DROP TABLE source_attach;

--- a/tests/queries/0_stateless/03636_storage_alias_syntax.reference
+++ b/tests/queries/0_stateless/03636_storage_alias_syntax.reference
@@ -6,13 +6,9 @@ Test ENGINE = Alias(db, table)
 1	one	10.1
 2	two	20.2
 3	three	30.3
-Test With columns
-1	one	10.1
-2	two	20.2
-3	three	30.3
 Test All aliases work identically
 4
 4
 4
-4
 5
+Test Explicit columns should fail

--- a/tests/queries/0_stateless/03636_storage_alias_syntax.sql
+++ b/tests/queries/0_stateless/03636_storage_alias_syntax.sql
@@ -1,7 +1,6 @@
 DROP TABLE IF EXISTS source_table;
 DROP TABLE IF EXISTS alias_syntax_1;
 DROP TABLE IF EXISTS alias_syntax_2;
-DROP TABLE IF EXISTS alias_syntax_3;
 
 -- Create source table
 CREATE TABLE source_table (id UInt32, name String, value Float64) 
@@ -19,19 +18,16 @@ SELECT 'Test ENGINE = Alias(db, table)';
 CREATE TABLE alias_syntax_2 ENGINE = Alias(currentDatabase(), 'source_table');
 SELECT * FROM alias_syntax_2 ORDER BY id;
 
--- Syntax: with columns
-SELECT 'Test With columns';
-CREATE TABLE alias_syntax_3 (id UInt32, name String, value Float64) 
-ENGINE = Alias('source_table');
-SELECT * FROM alias_syntax_3 ORDER BY id;
-
 -- Test: All aliases work identically
 SELECT 'Test All aliases work identically';
 INSERT INTO alias_syntax_1 VALUES (4, 'four', 40.4);
 SELECT count() FROM source_table;
 SELECT count() FROM alias_syntax_1;
 SELECT count() FROM alias_syntax_2;
-SELECT count() FROM alias_syntax_3;
 
 INSERT INTO alias_syntax_2 VALUES (5, 'five', 50.5);
 SELECT count() FROM source_table;
+
+-- Test: with explicit columns (should fail)
+SELECT 'Test Explicit columns should fail';
+CREATE TABLE alias_syntax_3 (id UInt32, name String, value Float64) ENGINE = Alias('source_table'); -- { serverError BAD_ARGUMENTS }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix #88426 
1. Disallow explicit column definitions in Alias and columns are automatically load from the target table. 
This ensures that the alias always matches the target table's schema.
2. Proxy more methods from the IStorage


<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
