### PR TITLE
CI: Integration tests: support setting number of parallel workers for local run

### DIFF
--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -18,7 +18,6 @@ ncpu = Utils.cpu_count()
 mem_gb = round(Utils.physical_memory() / (1024**3), 1)
 MAX_CPUS_PER_WORKER = 4
 MAX_MEM_PER_WORKER = 7
-MAX_WORKERS = min(ncpu // MAX_CPUS_PER_WORKER, mem_gb // MAX_MEM_PER_WORKER) or 1
 
 
 def _start_docker_in_docker():
@@ -74,6 +73,12 @@ def parse_args():
         type=str,
         default="",
     )
+    parser.add_argument(
+        "--workers",
+        help="Optional. Number of parallel workers for pytest",
+        default=None,
+        type=int,
+    )
     return parser.parse_args()
 
 
@@ -82,7 +87,7 @@ FLAKY_CHECK_MODULE_REPEAT_COUNT = 2
 
 
 def tests_to_run(
-    batch_num: int, total_batches: int, args_test: List[str]
+    batch_num: int, total_batches: int, args_test: List[str], workers: int
 ) -> Tuple[List[str], List[str]]:
     if args_test:
         batch_num = 1
@@ -96,7 +101,7 @@ def tests_to_run(
     assert len(test_files) > 100
 
     parallel_test_modules, sequential_test_modules = get_optimal_test_batch(
-        test_files, total_batches, batch_num, MAX_WORKERS
+        test_files, total_batches, batch_num, workers
     )
     if not args_test:
         return parallel_test_modules, sequential_test_modules
@@ -162,7 +167,6 @@ def main():
             use_distributed_plan = True
         elif to == "flaky":
             is_flaky_check = True
-            args.count = FLAKY_CHECK_TEST_REPEAT_COUNT
         elif to == "parallel":
             is_parallel = True
         elif to == "sequential":
@@ -172,8 +176,15 @@ def main():
         else:
             assert False, f"Unknown job option [{to}]"
 
-    if args.count:
-        repeat_option = f"--count {args.count} --random-order"
+    if args.count or is_flaky_check:
+        repeat_option = (
+            f"--count {args.count or FLAKY_CHECK_TEST_REPEAT_COUNT} --random-order"
+        )
+
+    if args.workers:
+        workers = args.workers
+    else:
+        workers = min(ncpu // MAX_CPUS_PER_WORKER, mem_gb // MAX_MEM_PER_WORKER) or 1
 
     changed_test_modules = []
     if is_bugfix_validation or is_flaky_check:
@@ -235,7 +246,7 @@ def main():
     Shell.check("docker info > /dev/null", verbose=True, strict=True)
 
     parallel_test_modules, sequential_test_modules = tests_to_run(
-        batch_num, total_batches, args.test
+        batch_num, total_batches, args.test, workers
     )
 
     if is_bugfix_validation or is_flaky_check:
@@ -287,7 +298,7 @@ def main():
     if parallel_test_modules:
         for attempt in range(module_repeat_cnt):
             test_result_parallel = Result.from_pytest_run(
-                command=f"{' '.join(reversed(parallel_test_modules))} --report-log-exclude-logs-on-passed-tests -n {MAX_WORKERS} --dist=loadfile --tb=short {repeat_option}",
+                command=f"{' '.join(reversed(parallel_test_modules))} --report-log-exclude-logs-on-passed-tests -n {workers} --dist=loadfile --tb=short {repeat_option}",
                 cwd="./tests/integration/",
                 env=test_env,
                 pytest_report_file=f"{temp_path}/pytest_parallel.jsonl",

--- a/ci/praktika/__main__.py
+++ b/ci/praktika/__main__.py
@@ -92,6 +92,14 @@ def create_parser():
         default="",
     )
     run_parser.add_argument(
+        "--workers",
+        help=(
+            "Integer parameter forwarded to the job script (commonly used as number of parallel workers) (job script defines semantics). Useful for local tests"
+        ),
+        type=int,
+        default=None,
+    )
+    run_parser.add_argument(
         "--pr",
         help=(
             "PR number to fetch required artifacts from its CI run (for local runs). Optional"
@@ -186,6 +194,7 @@ def main():
                 debug=args.debug,
                 path=args.path,
                 path_1=args.path_1,
+                workers=args.workers,
             )
     else:
         parser.print_help()

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -250,6 +250,7 @@ class Runner:
         debug=False,
         path="",
         path_1="",
+        workers=None,
     ):
         # re-set envs for local run
         env = _Environment.get()
@@ -356,6 +357,9 @@ class Runner:
         if path_1:
             print(f"Custom --path_1 [{path_1}] will be passed to job's script")
             cmd += f" --path_1 {path_1}"
+        if workers is not None:
+            print(f"Custom --workers [{workers}] will be passed to job's script")
+            cmd += f" --workers {workers}"
         print(f"--- Run command [{cmd}]")
 
         with TeePopen(
@@ -723,6 +727,7 @@ class Runner:
         debug=False,
         path="",
         path_1="",
+        workers=None,
     ):
         res = True
         setup_env_code = -10
@@ -780,6 +785,7 @@ class Runner:
                     debug=debug,
                     path=path,
                     path_1=path_1,
+                    workers=workers,
                 )
                 res = run_code == 0
                 if not res:

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -40,9 +40,9 @@ python -m ci.praktika run "Integration tests (amd_binary, 4/5)" \
 ### Additional Customization Options
 - `--count N` to repeat each test N times (`--count` is passed to pytest with `--repeat-scope=function`).
 - `--debug` to open the Python debug console on exception (`--pdb` is passed to pytest).
-- `--path` custom ClickHouse server binary location (if not in default locations).
-- `--path_1` custom path to the ClickHouse server config directory (if not in `./programs/server/config/`).
-
+- `--path PATH` custom ClickHouse server binary location (if not in default locations).
+- `--path_1 PATH` custom path to the ClickHouse server config directory (if not in `./programs/server/config/`).
+- `--workers N` to override automatic calculation of the recommended maximum number of parallel pytest workers. The value is passed to pytest-xdist as `-n N`. Use a lower number on resource-constrained machines or increase it to utilize more CPU cores.
 ## Running Natively
 
 ### Prerequisites


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Details
Integration test job script calculates the number of parallel workers automatically based on available CPU and MEM.
This change allows overriding defaults with the --workers option. For example:
`python -m ci.praktika run "Integration tests (amd_asan, old analyzer, 1/6)" --test TEST --count 5 --workers 5`.
