### PR TITLE
Save system metadata files from remote database disks to the local disk earlier

### DIFF
--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -1116,10 +1116,6 @@ quit
         if self.system_db_uuid is None:
             return
 
-        if self.is_valid_uuid(self.system_db_uuid):
-            print(f"system_db_uuid is not valid: '{self.system_db_uuid}'")
-            return
-
         # Ensure no remote database disk config
         if os.path.exists("/etc/clickhouse-server/config.d/remote_database_disk.xml"):
             os.remove("/etc/clickhouse-server/config.d/remote_database_disk.xml")

--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -6,6 +6,7 @@ import time
 import traceback
 from collections import defaultdict
 from pathlib import Path
+import uuid
 
 from ci.praktika import Secret
 from ci.praktika.info import Info
@@ -248,6 +249,8 @@ class ClickHouseProc:
             print(f"ClickHouse server ready")
         else:
             print(f"ClickHouse server NOT ready")
+
+        self.save_system_metadata_files_from_remote_database_disk()
         return res
 
     def install_clickbench_config(self):
@@ -481,6 +484,8 @@ profiles:
         res = True
         if self.is_db_replicated and replica_num == 0:
             res = self.start(replica_num=1) and self.start(replica_num=2)
+
+        self.save_system_metadata_files_from_remote_database_disk()
 
         return res
 
@@ -1052,6 +1057,14 @@ quit
                     res = False
         return [f for f in glob.glob(f"{temp_dir}/system_tables/*.tsv")]
 
+    @staticmethod
+    def is_valid_uuid(val):
+        try:
+            uuid_obj = uuid.UUID(val)
+            return str(uuid_obj) == val.lower()
+        except ValueError:
+            return False
+
     def save_system_metadata_files_from_remote_database_disk(self):
         if not os.path.exists(
             "/etc/clickhouse-server/config.d/remote_database_disk.xml"
@@ -1059,16 +1072,26 @@ quit
             return
 
         # Store system database and table metadata files
-        self.system_db_uuid = Shell.get_output(
+        system_db_uuid = Shell.get_output(
             "clickhouse disks -C /etc/clickhouse-server/config.xml --disk disk_db_remote -q 'read metadata/system.sql' | grep -F UUID | awk -F\"'\" '{print $2}'",
             verbose=True,
         )
+        if not self.is_valid_uuid(system_db_uuid):
+            print(f"invalid system_db_uuid: '{system_db_uuid}'")
+            return
+
+        if self.system_db_sql != None and self.system_db_sql != system_db_uuid:
+            print(
+                f"system_db_uuid changed: '{self.system_db_sql}' -> '{system_db_uuid}'"
+            )
+
+        self.system_db_sql = system_db_uuid
         self.system_db_sql = Shell.get_output(
             "clickhouse disks -C /etc/clickhouse-server/config.xml --disk disk_db_remote -q 'read metadata/system.sql'",
             verbose=True,
         )
-        print(f"system_db_uuid = {self.system_db_uuid}")
-        print(f"system_db_sql = {self.system_db_sql}")
+        print(f"system_db_uuid = '{self.system_db_uuid}'")
+        print(f"system_db_sql = '{self.system_db_sql}'")
 
         system_table_sql_files = (
             Shell.get_output(
@@ -1080,6 +1103,7 @@ quit
         )
         self.system_table_sql_map = {}
         for system_table_sql_file in system_table_sql_files:
+            print(f"system_table_sql_file = '{system_table_sql_file}'")
             sql_content = Shell.get_output(
                 f"clickhouse disks -C /etc/clickhouse-server/config.xml --disk disk_db_remote -q 'read store/{self.system_db_uuid[:3]}/{self.system_db_uuid}/{system_table_sql_file}'",
                 verbose=True,
@@ -1090,6 +1114,10 @@ quit
         if self.system_db_uuid is None:
             return
 
+        if self.is_valid_uuid(self.system_db_uuid):
+            print(f"system_db_uuid is not valid: '{self.system_db_uuid}'")
+            return
+
         # Ensure no remote database disk config
         if os.path.exists("/etc/clickhouse-server/config.d/remote_database_disk.xml"):
             os.remove("/etc/clickhouse-server/config.d/remote_database_disk.xml")
@@ -1097,7 +1125,7 @@ quit
         # Restore system database and table metadata files for `clickhouse local`
         with open(f"{self.run_path0}/metadata/system.sql", "w") as file:
             file.write(self.system_db_sql)
-        res = Shell.check(
+        Shell.check(
             f"mkdir -p {self.run_path0}/store/{self.system_db_uuid[:3]}/{self.system_db_uuid}",
             verbose=True,
         )

--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -1082,12 +1082,12 @@ quit
             print(f"invalid system_db_uuid: '{system_db_uuid}'")
             return
 
-        if self.system_db_sql != None and self.system_db_sql != system_db_uuid:
+        if self.system_db_uuid != None and self.system_db_uuid != system_db_uuid:
             print(
-                f"system_db_uuid changed: '{self.system_db_sql}' -> '{system_db_uuid}'"
+                f"system_db_uuid changed: '{self.system_db_uuid}' -> '{system_db_uuid}'"
             )
 
-        self.system_db_sql = system_db_uuid
+        self.system_db_uuid = system_db_uuid
         self.system_db_sql = Shell.get_output(
             "clickhouse disks -C /etc/clickhouse-server/config.xml --disk disk_db_remote -q 'read metadata/system.sql'",
             verbose=True,

--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -250,6 +250,7 @@ class ClickHouseProc:
         else:
             print(f"ClickHouse server NOT ready")
 
+        self._flush_system_logs()
         self.save_system_metadata_files_from_remote_database_disk()
         return res
 
@@ -485,6 +486,7 @@ profiles:
         if self.is_db_replicated and replica_num == 0:
             res = self.start(replica_num=1) and self.start(replica_num=2)
 
+        self._flush_system_logs()
         self.save_system_metadata_files_from_remote_database_disk()
 
         return res


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Save system metadata files from remote database disks to the local disk earlier.

If the server dies, `clickhouse local` still has metadata files of system tables to scrape logs.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
