### PR TITLE
CI: Wrap logs collection in try/catch

### DIFF
--- a/ci/docker/integration/arrowflight/flight_server.py
+++ b/ci/docker/integration/arrowflight/flight_server.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 
-import pyarrow as pa
-import pyarrow.flight as fl
 import argparse
 import base64
 import json
+
+import pyarrow as pa
+import pyarrow.flight as fl
 
 
 class FlightServer(fl.FlightServerBase):

--- a/ci/jobs/clickbench.py
+++ b/ci/jobs/clickbench.py
@@ -11,13 +11,14 @@ def main():
     results = []
     stop_watch = Utils.Stopwatch()
     ch = ClickHouseProc()
+    info = Info()
 
     if res:
         print("Install ClickHouse")
 
         def install():
             res = ch.install_clickbench_config()
-            if Info().is_local_run:
+            if info.is_local_run:
                 return res
             return res and ch.create_log_export_config()
 
@@ -31,7 +32,7 @@ def main():
 
         def start():
             res = ch.start_light()
-            if Info().is_local_run:
+            if info.is_local_run:
                 return res
             return res and ch.start_log_exports(check_start_time=stop_watch.start_time)
 
@@ -96,7 +97,9 @@ def main():
     )
 
     Result.create_from(
-        results=results, stopwatch=stop_watch, files=ch.prepare_logs(all=False)
+        results=results,
+        stopwatch=stop_watch,
+        files=ch.prepare_logs(all=False, info=info),
     ).complete_job()
 
 

--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -418,7 +418,7 @@ def main():
         print("Collect logs")
 
         def collect_logs():
-            CH.prepare_logs(all=test_result and not test_result.is_ok())
+            CH.prepare_logs(all=test_result and not test_result.is_ok(), info=info)
 
         results.append(
             Result.from_commands_run(

--- a/ci/jobs/fuzzers_job.py
+++ b/ci/jobs/fuzzers_job.py
@@ -2,6 +2,7 @@ from praktika.result import Result
 from praktika.utils import Shell, Utils
 
 from ci.jobs.scripts.clickhouse_proc import ClickHouseProc
+from ci.praktika.info import Info
 
 temp_dir = f"{Utils.cwd()}/ci/tmp/"
 
@@ -11,6 +12,7 @@ def main():
     results = []
     stop_watch = Utils.Stopwatch()
     ch = ClickHouseProc()
+    info = Info()
 
     if res:
         print("Install ClickHouse")
@@ -53,7 +55,7 @@ def main():
     )
 
     Result.create_from(
-        results=results, stopwatch=stop_watch, files=[ch.prepare_logs()]
+        results=results, stopwatch=stop_watch, files=[ch.prepare_logs(info=info)]
     ).complete_job()
 
 

--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -692,27 +692,35 @@ clickhouse-client --query "SELECT count() FROM test.visits"
 
         return self
 
-    def prepare_logs(self, all=False):
-        res = self._get_logs_archives_server()
-        res += self._get_jemalloc_profiles()
-        if Path(self.GDB_LOG).exists():
-            res.append(self.GDB_LOG)
-        if all:
-            res += self.debug_artifacts
-            res += self.dump_system_tables()
-            res += self._collect_core_dumps()
-            res += self._get_logs_archive_coordination()
-            if Path(self.MINIO_LOG).exists():
-                res.append(self.MINIO_LOG)
-            if Path(self.AZURITE_LOG).exists():
-                res.append(self.AZURITE_LOG)
-            if Path(self.DMESG_LOG).exists():
-                res.append(self.DMESG_LOG)
-            if Path(self.CH_LOCAL_ERR_LOG).exists():
-                res.append(self.CH_LOCAL_ERR_LOG)
-            if Path(self.CH_LOCAL_LOG).exists():
-                res.append(self.CH_LOCAL_LOG)
-        self.logs = res
+    def prepare_logs(self, info, all=False):
+        res = []
+        try:
+            res = self._get_logs_archives_server()
+            res += self._get_jemalloc_profiles()
+            if Path(self.GDB_LOG).exists():
+                res.append(self.GDB_LOG)
+            if all:
+                res += self.debug_artifacts
+                res += self.dump_system_tables()
+                res += self._collect_core_dumps()
+                res += self._get_logs_archive_coordination()
+                if Path(self.MINIO_LOG).exists():
+                    res.append(self.MINIO_LOG)
+                if Path(self.AZURITE_LOG).exists():
+                    res.append(self.AZURITE_LOG)
+                if Path(self.DMESG_LOG).exists():
+                    res.append(self.DMESG_LOG)
+                if Path(self.CH_LOCAL_ERR_LOG).exists():
+                    res.append(self.CH_LOCAL_ERR_LOG)
+                if Path(self.CH_LOCAL_LOG).exists():
+                    res.append(self.CH_LOCAL_LOG)
+            self.logs = res
+        except Exception as e:
+            print(f"WARNING: Failed to collect logs: {e}")
+            traceback.print_exc()
+            info.add_workflow_report_message(
+                f"Failed to collect all logs in job [{info.job_name}], ex [{e}], see job.log"
+            )
         return res
 
     def _collect_core_dumps(self):

--- a/ci/jobs/vector_search_stress_tests.py
+++ b/ci/jobs/vector_search_stress_tests.py
@@ -2,16 +2,18 @@
 # Documentation : https://clickhouse.com/docs/engines/table-engines/mergetree-family/annindexes
 
 import os
-import sys
-import traceback
-import clickhouse_connect
 import random
-import time
+import sys
 import threading
+import time
+import traceback
+
+import clickhouse_connect
 import numpy as np
-from ci.praktika.result import Result
+
 from ci.jobs.scripts.clickhouse_proc import ClickHouseProc
 from ci.praktika.info import Info
+from ci.praktika.result import Result
 from ci.praktika.utils import Shell, Utils
 
 temp_dir = f"{Utils.cwd()}/ci/tmp/"
@@ -177,6 +179,7 @@ test_params_hackernews_10m = {
     OTHER_SETTINGS: None,
     CONCURRENCY_TEST: True,
 }
+
 
 def get_new_connection():
     chclient = clickhouse_connect.get_client(send_receive_timeout=1800)
@@ -598,7 +601,7 @@ TESTS_TO_RUN = [
         "Test using the hackernews dataset",
         dataset_hackernews_openai,
         test_params_hackernews_10m,
-    )
+    ),
 ]
 
 


### PR DESCRIPTION
Logs collection in FTests has a lot of logic which can have bugs or other unexpected errors - add try catch to terminate job gracefully on exception there and keep artifacts that could be collected.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
