### PR TITLE
Relocate the binary before other threads are started

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -1032,7 +1032,7 @@ try
 
 #if defined(OS_LINUX)
     std::string executable_path = getExecutablePath();
-    /// Remap before creating other threads (like TraceCollector or anything that might collect traces) to prevent crashes
+    /// Remap before creating other threads to prevent crashes
     if (config().getBool("remap_executable", false))
     {
         LOG_DEBUG(log, "Will remap executable in memory.");

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -1033,6 +1033,7 @@ try
 #if defined(OS_LINUX)
     std::string executable_path = getExecutablePath();
     /// Remap before creating other threads (like TraceCollector or anything that might collect traces) to prevent crashing when
+    /// the code section of the executable is moved while they collect traces
     if (config().getBool("remap_executable", false))
     {
         LOG_DEBUG(log, "Will remap executable in memory.");

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -1032,8 +1032,7 @@ try
 
 #if defined(OS_LINUX)
     std::string executable_path = getExecutablePath();
-    /// Remap before creating other threads (like TraceCollector or anything that might collect traces) to prevent crashing when
-    /// the code section of the executable is moved while they collect traces
+    /// Remap before creating other threads (like TraceCollector or anything that might collect traces) to prevent crashes
     if (config().getBool("remap_executable", false))
     {
         LOG_DEBUG(log, "Will remap executable in memory.");

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -1028,8 +1028,52 @@ try
 #endif
 
     Stopwatch startup_watch;
-
     Poco::Logger * log = &logger();
+
+#if defined(OS_LINUX)
+    std::string executable_path = getExecutablePath();
+    /// Remap before creating other threads (like TraceCollector or anything that might collect traces) to prevent crashing when
+    if (config().getBool("remap_executable", false))
+    {
+        LOG_DEBUG(log, "Will remap executable in memory.");
+        size_t size = remapExecutable();
+        LOG_DEBUG(log, "The code ({}) in memory has been successfully remapped.", ReadableSize(size));
+    }
+
+    if (config().getBool("mlock_executable", false))
+    {
+        if (hasLinuxCapability(CAP_IPC_LOCK))
+        {
+            try
+            {
+                /// Get the memory area with (current) code segment.
+                /// It's better to lock only the code segment instead of calling "mlockall",
+                /// because otherwise debug info will be also locked in memory, and it can be huge.
+                auto [addr, len] = getMappedArea(reinterpret_cast<void *>(mainEntryClickHouseServer));
+
+                LOG_TRACE(log, "Will do mlock to prevent executable memory from being paged out. It may take a few seconds.");
+                if (0 != mlock(addr, len))
+                    LOG_WARNING(log, "Failed mlock: {}", errnoToString());
+                else
+                    LOG_TRACE(log, "The memory map of clickhouse executable has been mlock'ed, total {}", ReadableSize(len));
+            }
+            catch (...)
+            {
+                LOG_WARNING(log, "Cannot mlock: {}", getCurrentExceptionMessage(false));
+            }
+        }
+        else
+        {
+            LOG_INFO(
+                log,
+                "It looks like the process has no CAP_IPC_LOCK capability, binary mlock will be disabled."
+                " It could happen due to incorrect ClickHouse package installation."
+                " You could resolve the problem manually with 'sudo setcap cap_ipc_lock=+ep {}'."
+                " Note that it will not work on 'nosuid' mounted filesystems.",
+                executable_path.empty() ? "/usr/bin/clickhouse" : executable_path);
+        }
+    }
+#endif
 
     // If the startup_level is set in the config, we override the root logger level.
     // Specific loggers can still override it.
@@ -1490,8 +1534,6 @@ try
     server_settings.loadSettingsFromConfig(config());
 
 #if defined(OS_LINUX)
-    std::string executable_path = getExecutablePath();
-
     if (server_settings[ServerSetting::skip_binary_checksum_checks])
     {
         LOG_WARNING(log, "Binary checksum checks disabled due to skip_binary_checksum_checks - not recommended for production deployments");
@@ -1547,49 +1589,6 @@ try
                         stored_binary_hash,
                         executable_path);
                 }
-            }
-        }
-    }
-    else
-        executable_path = "/usr/bin/clickhouse";    /// It is used for information messages.
-
-    /// After full config loaded
-    {
-        if (config().getBool("remap_executable", false))
-        {
-            LOG_DEBUG(log, "Will remap executable in memory.");
-            size_t size = remapExecutable();
-            LOG_DEBUG(log, "The code ({}) in memory has been successfully remapped.", ReadableSize(size));
-        }
-
-        if (config().getBool("mlock_executable", false))
-        {
-            if (hasLinuxCapability(CAP_IPC_LOCK))
-            {
-                try
-                {
-                    /// Get the memory area with (current) code segment.
-                    /// It's better to lock only the code segment instead of calling "mlockall",
-                    /// because otherwise debug info will be also locked in memory, and it can be huge.
-                    auto [addr, len] = getMappedArea(reinterpret_cast<void *>(mainEntryClickHouseServer));
-
-                    LOG_TRACE(log, "Will do mlock to prevent executable memory from being paged out. It may take a few seconds.");
-                    if (0 != mlock(addr, len))
-                        LOG_WARNING(log, "Failed mlock: {}", errnoToString());
-                    else
-                        LOG_TRACE(log, "The memory map of clickhouse executable has been mlock'ed, total {}", ReadableSize(len));
-                }
-                catch (...)
-                {
-                    LOG_WARNING(log, "Cannot mlock: {}", getCurrentExceptionMessage(false));
-                }
-            }
-            else
-            {
-                LOG_INFO(log, "It looks like the process has no CAP_IPC_LOCK capability, binary mlock will be disabled."
-                    " It could happen due to incorrect ClickHouse package installation."
-                    " You could resolve the problem manually with 'sudo setcap cap_ipc_lock=+ep {}'."
-                    " Note that it will not work on 'nosuid' mounted filesystems.", executable_path);
             }
         }
     }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Relocate the binary before other threads are started

If the global profiler was on and it run during the relocation of the binary it would crash. We want to keep the global profiler for all threads (except those who opt-out, like async loggers) so we can relocate the binary earlier in the process. The one drawback I see is that the config is not fully read (from keeper for example), but this option is meant only for performance tests and LTO so it seems ok.

Closes https://github.com/ClickHouse/ClickHouse/issues/88539

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
