### PR TITLE
test: fix flakiness of test_async_load_databases (pushing to MV reordered and lack of proper cleanup)

### DIFF
--- a/tests/integration/test_async_load_databases/test.py
+++ b/tests/integration/test_async_load_databases/test.py
@@ -142,6 +142,8 @@ def dependent_tables_assert():
 
 def test_dependent_tables(started_cluster):
     query = node1.query
+    query("drop database if exists a")
+    query("drop database if exists lazy")
     query("create database lazy engine=Lazy(10)")
     query("create database a")
     query("create table lazy.src (n int, m int) engine=Log")
@@ -257,6 +259,7 @@ def test_async_load_system_database(started_cluster):
 
 def test_materialized_views(started_cluster):
     query = node1.query
+    query("drop database if exists test_mv")
     query("create database test_mv")
     query("create table test_mv.t (Id UInt64) engine=MergeTree order by Id")
     query("create table test_mv.a (Id UInt64) engine=MergeTree order by Id")
@@ -279,6 +282,7 @@ def test_materialized_views(started_cluster):
 
 def test_materialized_views_cascaded(started_cluster):
     query = node1.query
+    query("drop database if exists test_mv")
     query("create database test_mv")
     query("create table test_mv.t (Id UInt64) engine=MergeTree order by Id")
     query("create table test_mv.a (Id UInt64) engine=MergeTree order by Id")
@@ -301,6 +305,7 @@ def test_materialized_views_cascaded(started_cluster):
 
 def test_materialized_views_cascaded_multiple(started_cluster):
     query = node1.query
+    query("drop database if exists test_mv")
     query("create database test_mv")
     query("create table test_mv.t (Id UInt64) engine=MergeTree order by Id")
     query("create table test_mv.a (Id UInt64) engine=MergeTree order by Id")
@@ -354,6 +359,7 @@ def test_materialized_views_replicated(started_cluster):
     for node in [node1, node2]:
         node.query(
             f"""
+            DROP DATABASE IF EXISTS test_mv;
             CREATE DATABASE test_mv;
             CREATE TABLE test_mv.test_table_H(id UInt32)
             ENGINE = ReplicatedMergeTree('/clickhouse/tables/test_table_H', '{nodenum}')

--- a/tests/integration/test_async_load_databases/test.py
+++ b/tests/integration/test_async_load_databases/test.py
@@ -335,7 +335,10 @@ def test_materialized_views_cascaded_multiple(started_cluster):
     query("insert into to_join values(42, 4200)")
 
     node1.restart_clickhouse()
-    query("insert into test_mv.t values(42)")
+    query("insert into test_mv.t values(42)", settings={
+        # Make sure that pushing to MVs are not reordered
+        "max_threads": 1
+    })
     assert query("select * from test_mv.a Format CSV") == "42\n"
     assert query("select * from test_mv.x Format CSV") == '"42"\n'
     assert query("select * from test_mv.z Format CSV") == "42,2\n"


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes: https://github.com/ClickHouse/ClickHouse/issues/88572
Introduced in: https://github.com/ClickHouse/ClickHouse/pull/88339


<!-- ch-version-info:start -->
### Version info
- Backported to: `25.8.30.10`
<!-- ch-version-info:end -->