### PR TITLE
Fix `plain-rewritable` move fs tree operation

### DIFF
--- a/src/Disks/ObjectStorages/InMemoryDirectoryPathMap.h
+++ b/src/Disks/ObjectStorages/InMemoryDirectoryPathMap.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <ranges>
 #include <set>
 #include <map>
 #include <mutex>
@@ -195,22 +196,26 @@ public:
         return num_removed;
     }
 
-    void iterateFiles(const std::string & path, std::function<void(const std::string &)> callback) const
+    std::vector<std::string> listFiles(const std::string & path) const
     {
         auto base_path = path;
         if (base_path.ends_with('/'))
             base_path.pop_back();
 
         std::lock_guard lock(mutex);
-        auto it = map.find(base_path);
-        if (it != map.end())
-            for (const auto & file : it->second.files)
-                callback(file);
+
+        std::vector<std::string> files;
+        if (auto it = map.find(base_path); it != map.end())
+            files.append_range(it->second.files);
+
+        return files;
     }
 
-    void iterateSubdirectories(const std::string & path, std::function<void(const std::string &)> callback) const
+    std::vector<std::string> listSubdirectories(const std::string & path) const
     {
         std::lock_guard lock(mutex);
+
+        std::vector<std::string> subdirectories;
         for (auto it = map.lower_bound(path); it != map.end(); ++it)
         {
             const auto & subdirectory = it->first.string();
@@ -225,8 +230,10 @@ public:
             if (slash_num != 0)
                 break;
 
-            callback(std::string(subdirectory.begin() + path.size(), subdirectory.end()) + "/");
+            subdirectories.push_back(std::string(subdirectory.begin() + path.size(), subdirectory.end()) + "/");
         }
+
+        return subdirectories;
     }
 
     void moveDirectory(const std::string & from, const std::string & to)

--- a/src/Disks/ObjectStorages/MetadataStorageFromPlainRewritableObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/MetadataStorageFromPlainRewritableObjectStorage.cpp
@@ -9,6 +9,7 @@
 #include <iterator>
 #include <optional>
 #include <unordered_set>
+#include <vector>
 #include <IO/ReadHelpers.h>
 #include <IO/S3Common.h>
 #include <IO/SharedThreadPools.h>
@@ -308,8 +309,7 @@ bool MetadataStorageFromPlainRewritableObjectStorage::existsDirectory(const std:
 
 std::vector<std::string> MetadataStorageFromPlainRewritableObjectStorage::listDirectory(const std::string & path) const
 {
-    std::unordered_set<std::string> result = getDirectChildrenOnDisk(fs::path(path) / "");
-    return std::vector<std::string>(std::make_move_iterator(result.begin()), std::make_move_iterator(result.end()));
+    return getDirectChildrenOnDisk(fs::path(path) / "");
 }
 
 std::optional<Poco::Timestamp> MetadataStorageFromPlainRewritableObjectStorage::getLastModifiedIfExists(const String & path) const
@@ -324,12 +324,11 @@ std::optional<Poco::Timestamp> MetadataStorageFromPlainRewritableObjectStorage::
     return std::nullopt;
 }
 
-std::unordered_set<std::string>
-MetadataStorageFromPlainRewritableObjectStorage::getDirectChildrenOnDisk(const fs::path & local_path) const
+std::vector<std::string> MetadataStorageFromPlainRewritableObjectStorage::getDirectChildrenOnDisk(const fs::path & local_path) const
 {
-    std::unordered_set<std::string> result;
-    path_map->iterateSubdirectories(local_path, [&](const auto & elem){ result.emplace(elem); });
-    path_map->iterateFiles(local_path, [&](const auto & elem){ result.emplace(elem); });
+    std::vector<std::string> result;
+    result.append_range(path_map->listSubdirectories(local_path));
+    result.append_range(path_map->listFiles(local_path));
     return result;
 }
 

--- a/src/Disks/ObjectStorages/MetadataStorageFromPlainRewritableObjectStorage.h
+++ b/src/Disks/ObjectStorages/MetadataStorageFromPlainRewritableObjectStorage.h
@@ -63,7 +63,7 @@ private:
 
     std::string getMetadataKeyPrefix() const override { return metadata_key_prefix; }
     std::shared_ptr<InMemoryDirectoryPathMap> getPathMap() const override { return path_map; }
-    std::unordered_set<std::string> getDirectChildrenOnDisk(const std::filesystem::path & local_path) const;
+    std::vector<std::string> getDirectChildrenOnDisk(const std::filesystem::path & local_path) const;
 };
 
 }

--- a/src/Disks/tests/gtest_metadata_plain_rewritable_disk.cpp
+++ b/src/Disks/tests/gtest_metadata_plain_rewritable_disk.cpp
@@ -184,13 +184,17 @@ TEST_F(MetadataPlainRewritableDiskTest, MoveTree)
     /// This is a bug. Should be MOVED everywhere
     EXPECT_EQ(readObject(object_storage, a_path), "MOVED/");
     EXPECT_EQ(readObject(object_storage, ab_path), "MOVED/B/");
-    EXPECT_EQ(readObject(object_storage, abc_path), "A/B/C/");
-    EXPECT_EQ(readObject(object_storage, abcd_path), "A/B/C/D/");
+    EXPECT_EQ(readObject(object_storage, abc_path), "MOVED/B/C/");
+    EXPECT_EQ(readObject(object_storage, abcd_path), "MOVED/B/C/D/");
 
     EXPECT_FALSE(metadata->existsDirectory("A"));
     EXPECT_FALSE(metadata->existsDirectory("A/B"));
-    EXPECT_TRUE(metadata->existsDirectory("A/B/C"));
-    EXPECT_TRUE(metadata->existsDirectory("A/B/C/D"));
+    EXPECT_FALSE(metadata->existsDirectory("A/B/C"));
+    EXPECT_FALSE(metadata->existsDirectory("A/B/C/D"));
+    EXPECT_TRUE(metadata->existsDirectory("MOVED"));
+    EXPECT_TRUE(metadata->existsDirectory("MOVED/B"));
+    EXPECT_TRUE(metadata->existsDirectory("MOVED/B/C"));
+    EXPECT_TRUE(metadata->existsDirectory("MOVED/B/C/D"));
 }
 
 TEST_F(MetadataPlainRewritableDiskTest, MoveUndo)

--- a/src/Disks/tests/gtest_metadata_plain_rewritable_disk.cpp
+++ b/src/Disks/tests/gtest_metadata_plain_rewritable_disk.cpp
@@ -181,7 +181,6 @@ TEST_F(MetadataPlainRewritableDiskTest, MoveTree)
         tx->commit();
     }
 
-    /// This is a bug. Should be MOVED everywhere
     EXPECT_EQ(readObject(object_storage, a_path), "MOVED/");
     EXPECT_EQ(readObject(object_storage, ab_path), "MOVED/B/");
     EXPECT_EQ(readObject(object_storage, abc_path), "MOVED/B/C/");


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
This patch fixes the move operation of `plain-rewritable` disks for folders of arbitrary depth.
