### PR TITLE
CI: Set custom CIDB URL for reading statistics from CIDB

### DIFF
--- a/ci/praktika/cidb.py
+++ b/ci/praktika/cidb.py
@@ -55,7 +55,7 @@ class CIDB:
         }
 
     def get_link_to_test_case_statistics(
-        self, test_name: str, job_name: Optional[str] = None, user: Optional[str] = None
+        self, test_name: str, job_name: Optional[str] = None, url="", user=""
     ) -> str:
         """
         Build a link to query CI DB statistics for a specific test case.
@@ -87,7 +87,7 @@ ORDER BY day DESC
 """
 
         # Compose base URL, optionally attaching user parameter
-        base = self.url or ""
+        base = url or self.url or ""
         if user:
             sep = "&" if "?" in base else "?"
             base = f"{base}/play{sep}user={urllib.parse.quote(user, safe='')}&run=1"

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -566,7 +566,9 @@ class Runner:
                             test_case_result.set_clickable_label(
                                 "cidb",
                                 ci_db.get_link_to_test_case_statistics(
-                                    test_case_result.name, user=Settings.CI_DB_READ_USER
+                                    test_case_result.name,
+                                    url=Settings.CI_DB_READ_URL,
+                                    user=Settings.CI_DB_READ_USER,
                                 ),
                             )
                     result.dump()

--- a/ci/praktika/settings.py
+++ b/ci/praktika/settings.py
@@ -104,6 +104,7 @@ class _Settings:
 
     # to post links for reading statistics in html report (with read-only user)
     CI_DB_READ_USER: str = ""
+    CI_DB_READ_URL: str = ""
 
 
 _USER_DEFINED_SETTINGS = [
@@ -149,6 +150,7 @@ _USER_DEFINED_SETTINGS = [
     "DEFAULT_LOCAL_TEST_WORKFLOW",
     "COMPRESS_THRESHOLD_MB",
     "CI_DB_READ_USER",
+    "CI_DB_READ_URL",
 ]
 
 

--- a/ci/settings/settings.py
+++ b/ci/settings/settings.py
@@ -61,3 +61,4 @@ DEFAULT_LOCAL_TEST_WORKFLOW = "pull_request.py"
 READY_FOR_MERGE_CUSTOM_STATUS_NAME = "Mergeable Check"
 
 CI_DB_READ_USER = "play"
+CI_DB_READ_URL = ""


### PR DESCRIPTION
* Support new setting CIDB_READ_URL in praktika to allow a different URL for reading and writing data whenever needed


<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

