### PR TITLE
Fail `plain-rewritable` tx in case of missing parent directory

### DIFF
--- a/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorageOperations.cpp
+++ b/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorageOperations.cpp
@@ -137,17 +137,19 @@ MetadataStorageFromPlainObjectStorageCreateDirectoryRecursiveOperation::Metadata
         subdirectories_creators.push_back(std::move(create_subdirectory_op));
         path_prefix = path_prefix.parent_path();
     }
+
+    std::reverse(subdirectories_creators.begin(), subdirectories_creators.end());
 }
 
 void MetadataStorageFromPlainObjectStorageCreateDirectoryRecursiveOperation::execute()
 {
-    for (auto & creator : subdirectories_creators | std::views::reverse)
+    for (auto & creator : subdirectories_creators)
         creator->execute();
 }
 
 void MetadataStorageFromPlainObjectStorageCreateDirectoryRecursiveOperation::undo()
 {
-    for (auto & creator : subdirectories_creators)
+    for (auto & creator : subdirectories_creators | std::views::reverse)
         creator->undo();
 }
 

--- a/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorageOperations.cpp
+++ b/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorageOperations.cpp
@@ -24,6 +24,7 @@ namespace DB
 namespace ErrorCodes
 {
 extern const int FILE_DOESNT_EXIST;
+extern const int DIRECTORY_DOESNT_EXIST;
 extern const int FILE_ALREADY_EXISTS;
 extern const int INCORRECT_DATA;
 extern const int FAULT_INJECTED;
@@ -70,6 +71,10 @@ void MetadataStorageFromPlainObjectStorageCreateDirectoryOperation::execute()
     const auto base_path = path.parent_path();
     if (path_map.existsLocalPath(base_path))
         return;
+
+    const auto parent_path = base_path.parent_path();
+    if (!parent_path.empty() && !path_map.existsLocalPath(base_path.parent_path()))
+        throw Exception(ErrorCodes::DIRECTORY_DOESNT_EXIST, "Parent directory '{}' does not exist", parent_path);
 
     auto metadata_object_key = createMetadataObjectKey(object_key_prefix, metadata_key_prefix);
 

--- a/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorageOperations.h
+++ b/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorageOperations.h
@@ -23,7 +23,7 @@ private:
 public:
     MetadataStorageFromPlainObjectStorageCreateDirectoryOperation(
         /// path_ must end with a trailing '/'.
-        std::filesystem::path && path_,
+        std::filesystem::path path_,
         InMemoryDirectoryPathMap & path_map_,
         ObjectStoragePtr object_storage_,
         const std::string & metadata_key_prefix_);
@@ -32,6 +32,27 @@ public:
     void undo() override;
 };
 
+class MetadataStorageFromPlainObjectStorageCreateDirectoryRecursiveOperation final : public IMetadataOperation
+{
+private:
+    std::filesystem::path path;
+    InMemoryDirectoryPathMap & path_map;
+    ObjectStoragePtr object_storage;
+    const std::string metadata_key_prefix;
+
+    std::vector<std::unique_ptr<MetadataStorageFromPlainObjectStorageCreateDirectoryOperation>> subdirectories_creators;
+
+public:
+    MetadataStorageFromPlainObjectStorageCreateDirectoryRecursiveOperation(
+        /// path_ must end with a trailing '/'.
+        std::filesystem::path path_,
+        InMemoryDirectoryPathMap & path_map_,
+        ObjectStoragePtr object_storage_,
+        const std::string & metadata_key_prefix_);
+
+    void execute() override;
+    void undo() override;
+};
 
 class MetadataStorageFromPlainObjectStorageMoveDirectoryOperation final : public IMetadataOperation
 {
@@ -48,8 +69,8 @@ private:
 public:
     MetadataStorageFromPlainObjectStorageMoveDirectoryOperation(
         /// Both path_from_ and path_to_ must end with a trailing '/'.
-        std::filesystem::path && path_from_,
-        std::filesystem::path && path_to_,
+        std::filesystem::path path_from_,
+        std::filesystem::path path_to_,
         InMemoryDirectoryPathMap & path_map_,
         ObjectStoragePtr object_storage_,
         const std::string & metadata_key_prefix_);
@@ -74,7 +95,7 @@ private:
 public:
     MetadataStorageFromPlainObjectStorageRemoveDirectoryOperation(
         /// path_ must end with a trailing '/'.
-        std::filesystem::path && path_,
+        std::filesystem::path path_,
         InMemoryDirectoryPathMap & path_map_,
         ObjectStoragePtr object_storage_,
         const std::string & metadata_key_prefix_);
@@ -114,7 +135,7 @@ private:
 
 public:
     MetadataStorageFromPlainObjectStorageUnlinkMetadataFileOperation(
-        std::filesystem::path && path_, InMemoryDirectoryPathMap & path_map_, ObjectStoragePtr object_storage_);
+        std::filesystem::path path_, InMemoryDirectoryPathMap & path_map_, ObjectStoragePtr object_storage_);
 
     void execute() override;
     void undo() override;

--- a/src/Disks/tests/gtest_metadata_plain_rewritable_disk.cpp
+++ b/src/Disks/tests/gtest_metadata_plain_rewritable_disk.cpp
@@ -348,3 +348,20 @@ TEST_F(MetadataPlainRewritableDiskTest, MoveFileUndo)
 
     EXPECT_EQ(path_1, path_2);
 }
+
+TEST_F(MetadataPlainRewritableDiskTest, CreateDirectoryRecursive)
+{
+    auto metadata = getMetadataStorage("CreateDirectoryRecursive");
+    auto object_storage = getObjectStorage("CreateDirectoryRecursive");
+
+    {
+        auto tx = metadata->createTransaction();
+        tx->createDirectoryRecursive("A/B/C/D");
+        tx->commit();
+    }
+
+    EXPECT_TRUE(metadata->existsDirectory("A"));
+    EXPECT_TRUE(metadata->existsDirectory("A/B"));
+    EXPECT_TRUE(metadata->existsDirectory("A/B/C"));
+    EXPECT_TRUE(metadata->existsDirectory("A/B/C/D"));
+}

--- a/src/Disks/tests/gtest_metadata_plain_rewritable_disk.cpp
+++ b/src/Disks/tests/gtest_metadata_plain_rewritable_disk.cpp
@@ -231,13 +231,12 @@ TEST_F(MetadataPlainRewritableDiskTest, CreateNotFromRoot)
     {
         auto tx = metadata->createTransaction();
         tx->createDirectory("A/B/C");
-        tx->commit();
+        EXPECT_ANY_THROW(tx->commit());
     }
 
-    /// It is a bug. It should not be possible to create folder unlinked from root.
-    EXPECT_TRUE(metadata->existsDirectory("A/B/C"));
     EXPECT_FALSE(metadata->existsDirectory("A"));
     EXPECT_FALSE(metadata->existsDirectory("A/B"));
+    EXPECT_FALSE(metadata->existsDirectory("A/B/C"));
 }
 
 TEST_F(MetadataPlainRewritableDiskTest, RemoveDirectory)


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
It should not be possible to create a folder unlinked from the root.
