### PR TITLE
Fix crash when rewriting IN to EXISTS in some case

### DIFF
--- a/src/Analyzer/Resolve/resolveFunction.cpp
+++ b/src/Analyzer/Resolve/resolveFunction.cpp
@@ -387,7 +387,7 @@ ProjectionNames QueryAnalyzer::resolveFunction(QueryTreeNodePtr & node, Identifi
 
                     auto equals_function_node_ptr = std::make_shared<FunctionNode>("equals");
 
-                    auto & copy_of_in_first_parameter = function_in_arguments_nodes[0];
+                    auto copy_of_in_first_parameter = function_in_arguments_nodes[0];
 
                     auto subquery_projection = std::make_shared<IdentifierNode>(Identifier{unique_column_name});
 

--- a/tests/queries/0_stateless/03583_rewrite_in_to_join.reference
+++ b/tests/queries/0_stateless/03583_rewrite_in_to_join.reference
@@ -110,3 +110,16 @@ WITH
 SELECT *
 FROM numbers(8)
 WHERE (number+1, number+2, number+3) IN (t); -- {serverError NUMBER_OF_COLUMNS_DOESNT_MATCH,BAD_ARGUMENTS, ILLEGAL_TYPE_OF_ARGUMENT}
+-- Inside IF function condition and arguments
+SELECT c0 = ANY(SELECT 1) ? 1 : 2 FROM (SELECT 1 c0) tx;
+1
+SELECT if(dummy IN (SELECT 1) AS in_expression, 11, 22) FROM system.one;
+22
+SELECT if(dummy IN (SELECT 1) AS in_expression, 11, 22) FROM system.one;
+22
+SELECT if(dummy IN (SELECT 1) AS in_expression, in_expression, 22) FROM system.one;
+22
+SELECT if(dummy IN (SELECT 1) AS in_expression, 11, in_expression) FROM system.one;
+0
+SELECT if(dummy IN (SELECT 1) AS in_expression, in_expression, in_expression) FROM system.one;
+0

--- a/tests/queries/0_stateless/03583_rewrite_in_to_join.sql
+++ b/tests/queries/0_stateless/03583_rewrite_in_to_join.sql
@@ -78,4 +78,17 @@ SELECT *
 FROM numbers(8)
 WHERE (number+1, number+2, number+3) IN (t); -- {serverError NUMBER_OF_COLUMNS_DOESNT_MATCH,BAD_ARGUMENTS, ILLEGAL_TYPE_OF_ARGUMENT}
 
+-- Inside IF function condition and arguments
+SELECT c0 = ANY(SELECT 1) ? 1 : 2 FROM (SELECT 1 c0) tx;
+
+SELECT if(dummy IN (SELECT 1) AS in_expression, 11, 22) FROM system.one;
+
+SELECT if(dummy IN (SELECT 1) AS in_expression, 11, 22) FROM system.one;
+
+SELECT if(dummy IN (SELECT 1) AS in_expression, in_expression, 22) FROM system.one;
+
+SELECT if(dummy IN (SELECT 1) AS in_expression, 11, in_expression) FROM system.one;
+
+SELECT if(dummy IN (SELECT 1) AS in_expression, in_expression, in_expression) FROM system.one;
+
 --{echoOff}


### PR DESCRIPTION
Fixes #88569
The crash was caused by 1st argument of original `IN` function being reset to nullptr here:
https://github.com/ClickHouse/ClickHouse/blob/da741fb7c989cd4045741841b3ef4fdd324f0baf/src/Analyzer/Resolve/resolveFunction.cpp#L390-L395
Even though the function gets replaced in the query tree, in some case resolveFunction might be called again on a copy of the original FunctionNode pointer, e.g. in case when `IN` is in `IF` condition:
https://github.com/ClickHouse/ClickHouse/blob/da741fb7c989cd4045741841b3ef4fdd324f0baf/src/Analyzer/Resolve/resolveFunction.cpp#L250

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
