### PR TITLE
docs: fix incorrect documentation describing bitmapAndnot

### DIFF
--- a/src/Functions/FunctionsBitmap.cpp
+++ b/src/Functions/FunctionsBitmap.cpp
@@ -478,7 +478,7 @@ Changes up to N bits in a bitmap by swapping specific bit values in `from_array`
     factory.registerFunction<FunctionBitmapXor>(documentation_bitmapXor);
 
     /// Documentation for bitmapAndnot
-    FunctionDocumentation::Description description_bitmapAndnot = "Computes the logical conjunction of two bitmaps and negates the result (AND-NOT).";
+    FunctionDocumentation::Description description_bitmapAndnot = "Computes the set difference A AND-NOT B of two bitmaps.";
     FunctionDocumentation::Syntax syntax_bitmapAndnot = "bitmapAndnot(bitmap1, bitmap2)";
     FunctionDocumentation::Arguments arguments_bitmapAndnot = {
         {"bitmap1", "First bitmap object. [`AggregateFunction(groupBitmap, T)`](/sql-reference/data-types/aggregatefunction)."},


### PR DESCRIPTION
Currently, `bitmapAndnot` incorrectly states that the operation computes the logical conjunction (`AND`) and then negates the result (`NOT`). This is `NOT(A AND B)`. The actual operation computed is `A AND NOT B` or `A - B`. This PR updates the documentation to reflect the correct logic.

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
