### PR TITLE
Fix Nullable return from hashing functions

### DIFF
--- a/src/Functions/FunctionsHashing.h
+++ b/src/Functions/FunctionsHashing.h
@@ -1400,6 +1400,7 @@ public:
     size_t getNumberOfArguments() const override { return 0; }
     bool useDefaultImplementationForConstants() const override { return true; }
     bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return true; }
+    bool useDefaultImplementationForNulls() const override { return false; }
 
     DataTypePtr getReturnTypeImpl(const DataTypes & /*arguments*/) const override
     {


### PR DESCRIPTION
### Changelog category:
- CI Fix or Improvement (changelog entry is not required)

### Motivation

CI-Error: 
> Logical error: 'Unexpected return type from sipHash64. Expected Nullable(UInt64). Got UInt64. Action:[cidb](https://play.clickhouse.com/play?user=play&run=1#V0lUSAogICAgOTAgQVMgaW50ZXJ2YWxfZGF5cwpTRUxFQ1QKICAgIHRvU3RhcnRPZkRheShjaGVja19zdGFydF90aW1lKSBBUyBkYXksCiAgICBjb3VudCgpIEFTIGZhaWx1cmVzLAogICAgZ3JvdXBVbmlxQXJyYXkocHVsbF9yZXF1ZXN0X251bWJlcikgQVMgcHJzLAogICAgYW55KHJlcG9ydF91cmwpIEFTIHJlcG9ydF91cmwKRlJPTSBjaGVja3MKV0hFUkUgKG5vdygpIC0gdG9JbnRlcnZhbERheShpbnRlcnZhbF9kYXlzKSkgPD0gY2hlY2tfc3RhcnRfdGltZQogICAgQU5EIHRlc3RfbmFtZSA9ICdMb2dpY2FsIGVycm9yOiAnJ1VuZXhwZWN0ZWQgcmV0dXJuIHR5cGUgZnJvbSBzaXBIYXNoNjQuIEV4cGVjdGVkIE51bGxhYmxlKFVJbnQ2NCkuIEdvdCBVSW50NjQuIEFjdGlvbjonCiAgICAtLSBBTkQgY2hlY2tfbmFtZSA9ICdOb25lJwogICAgQU5EIHRlc3Rfc3RhdHVzIElOICgnRkFJTCcsICdFUlJPUicpCiAgICBBTkQgKChoZWFkX3JlZiA9ICdtYXN0ZXInIEFORCBwdWxsX3JlcXVlc3RfbnVtYmVyID0gMCkgT1IgcHVsbF9yZXF1ZXN0X251bWJlciAhPSAwKQpHUk9VUCBCWSBkYXkKT1JERVIgQlkgZGF5IERFU0MK)

See: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=88102&sha=latest&name_0=PR&name_1=AST+fuzzer+%28arm_asan%29

**I couldn't test this locally!**