### PR TITLE
tests: fix test_trace_log_memory_context flakiness

### DIFF
--- a/tests/integration/test_trace_log_memory_context/test.py
+++ b/tests/integration/test_trace_log_memory_context/test.py
@@ -29,13 +29,14 @@ def test_memory_context_in_trace_log(started_cluster):
     if node.is_built_with_sanitizer():
         pytest.skip("sanitizers built without jemalloc")
 
+    # Clean start (note, event_time >= now()-uptime(), can be flaky)
+    node.query("TRUNCATE TABLE IF EXISTS system.trace_log")
+
     def get_trace_events(memory_context, memory_blocked_context, trace_type, query_id=None):
         res = int(node.query(f"""
         SELECT count() FROM system.trace_log
         WHERE
-            /* Do not take into account data from other test runs */
-            event_time >= now()-uptime()
-            AND memory_context = '{memory_context}'
+            memory_context = '{memory_context}'
             AND memory_blocked_context = '{memory_blocked_context}'
             AND trace_type = '{trace_type}'
             AND {'empty(query_id)' if query_id is None else f"query_id = '{query_id}'"}


### PR DESCRIPTION
I did not added TRUNCATE at the beginning because I was worrying that we will loose server-wide events that we need, but a) I forgot that likely we will not loose anything, because likely there were no flushes yet, and b) now we have waiting until we will have all events

CI: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=88341&sha=2d06e23217700797f66415cfc38b1fd5e5e70d93&name_0=PR&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%203%2F4%29

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)