### PR TITLE
Docs: correction to source code docs categories

### DIFF
--- a/src/Functions/overlay.cpp
+++ b/src/Functions/overlay.cpp
@@ -718,7 +718,7 @@ Replaces part of the string `input` with another string `replace`, starting at t
     }
     };
     FunctionDocumentation::IntroducedIn introduced_in = {24, 9};
-    FunctionDocumentation::Category category = FunctionDocumentation::Category::String;
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::StringReplacement;
     FunctionDocumentation overlay_documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
 
     factory.registerFunction<FunctionOverlay<false>>(overlay_documentation, FunctionFactory::Case::Insensitive);

--- a/src/Functions/regexpQuoteMeta.cpp
+++ b/src/Functions/regexpQuoteMeta.cpp
@@ -121,7 +121,7 @@ REGISTER_FUNCTION(RegexpQuoteMeta)
 Adds a backslash before these characters with special meaning in regular expressions: `\0`, `\\`, `|`, `(`, `)`, `^`, `$`, `.`, `[`, `]`, `?`, `*`, `+`, `{`, `:`, `-`.
 This implementation slightly differs from re2::RE2::QuoteMeta.
 It escapes zero byte as `\0` instead of `\x00` and it escapes only required characters.
-)";
+    )";
     FunctionDocumentation::Syntax syntax = "regexpQuoteMeta(s)";
     FunctionDocumentation::Arguments arguments = {
         {"s", "The input string containing characters to be escaped for regex.", {"String"}}
@@ -139,7 +139,7 @@ It escapes zero byte as `\0` instead of `\x00` and it escapes only required char
     }
     };
     FunctionDocumentation::IntroducedIn introduced_in = {20, 1};
-    FunctionDocumentation::Category category = FunctionDocumentation::Category::String;
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::StringReplacement;
     FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
 
     factory.registerFunction<FunctionRegexpQuoteMeta>(documentation);

--- a/src/Functions/repeat.cpp
+++ b/src/Functions/repeat.cpp
@@ -283,16 +283,23 @@ REGISTER_FUNCTION(Repeat)
 {
     FunctionDocumentation::Description description = R"(
 Concatenates a string as many times with itself as specified.
-
-)";
+    )";
     FunctionDocumentation::Syntax syntax = "repeat(s, n)";
     FunctionDocumentation::Arguments arguments = {
         {"s", "The string to repeat.", {"String"}},
         {"n", "The number of times to repeat the string.", {"(U)Int*"}}
     };
-    FunctionDocumentation::ReturnedValue returned_value = {"A string containing string `s` repeated `n` times. If `n` <= 0, the function returns the empty string.", {"String"}};
+    FunctionDocumentation::ReturnedValue returned_value = {"A string containing string `s` repeated `n` times. If `n` \<= 0, the function returns the empty string.", {"String"}};
     FunctionDocumentation::Examples examples = {
-        {"Usage example", "SELECT repeat('abc', 10)", "┌─repeat('abc', 10)──────────────┐\n│ abcabcabcabcabcabcabcabcabcabc │\n└────────────────────────────────┘"}
+    {
+        "Usage example",
+        "SELECT repeat('abc', 10)",
+        R"(
+┌─repeat('abc', 10)──────────────┐
+│ abcabcabcabcabcabcabcabcabcabc │
+└────────────────────────────────┘
+    )"
+    }
     };
     FunctionDocumentation::IntroducedIn introduced_in = {20, 1};
     FunctionDocumentation::Category category = FunctionDocumentation::Category::String;

--- a/src/Functions/repeat.cpp
+++ b/src/Functions/repeat.cpp
@@ -289,7 +289,7 @@ Concatenates a string as many times with itself as specified.
         {"s", "The string to repeat.", {"String"}},
         {"n", "The number of times to repeat the string.", {"(U)Int*"}}
     };
-    FunctionDocumentation::ReturnedValue returned_value = {"A string containing string `s` repeated `n` times. If `n` \<= 0, the function returns the empty string.", {"String"}};
+    FunctionDocumentation::ReturnedValue returned_value = {"A string containing string `s` repeated `n` times. If `n` is negative, the function returns the empty string.", {"String"}};
     FunctionDocumentation::Examples examples = {
     {
         "Usage example",

--- a/src/Functions/replaceOne.cpp
+++ b/src/Functions/replaceOne.cpp
@@ -21,7 +21,7 @@ REGISTER_FUNCTION(ReplaceOne)
 {
     FunctionDocumentation::Description description = R"(
 Replaces the first occurrence of the substring `pattern` in `haystack` by the `replacement` string.
-)";
+    )";
     FunctionDocumentation::Syntax syntax = "replaceOne(haystack, pattern, replacement)";
     FunctionDocumentation::Arguments arguments = {
         {"haystack", "The input string to search in.", {"String"}},
@@ -41,7 +41,7 @@ Replaces the first occurrence of the substring `pattern` in `haystack` by the `r
     }
     };
     FunctionDocumentation::IntroducedIn introduced_in = {1, 1};
-    FunctionDocumentation::Category category = FunctionDocumentation::Category::String;
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::StringReplacement;
     FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
 
     factory.registerFunction<FunctionReplaceOne>(documentation);


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
These should be StringReplacement. Required such that the number of autogenerated functions matches the number of existing functions in the markdown docs: https://github.com/ClickHouse/clickhouse-docs/pull/4583.
Also escapes a `<` which breaks the docs build for generating the String functions category.
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
