### PR TITLE
Add profiling and logging on merge destruction

### DIFF
--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -407,6 +407,27 @@
     M(MergeTreeBackgroundExecutorTaskResetMicroseconds, "Time spent resetting underlying task (shared_ptr reset) in MergeTreeBackgroundExecutor.", ValueType::Microseconds) \
     M(MergeTreeBackgroundExecutorWaitMicroseconds, "Time spent waiting for task completion (is_done.wait) in MergeTreeBackgroundExecutor.", ValueType::Microseconds) \
     \
+    /* Per-executor background executor task timings */ \
+    M(MergeMutateBackgroundExecutorTaskExecuteStepMicroseconds, "Time spent in executeStep() for MergeMutate executor tasks.", ValueType::Microseconds) \
+    M(MergeMutateBackgroundExecutorTaskCancelMicroseconds, "Time spent in cancel() for MergeMutate executor tasks.", ValueType::Microseconds) \
+    M(MergeMutateBackgroundExecutorTaskResetMicroseconds, "Time spent resetting task for MergeMutate executor.", ValueType::Microseconds) \
+    M(MergeMutateBackgroundExecutorWaitMicroseconds, "Time spent waiting for completion in MergeMutate executor.", ValueType::Microseconds) \
+    \
+    M(MoveBackgroundExecutorTaskExecuteStepMicroseconds, "Time spent in executeStep() for Move executor tasks.", ValueType::Microseconds) \
+    M(MoveBackgroundExecutorTaskCancelMicroseconds, "Time spent in cancel() for Move executor tasks.", ValueType::Microseconds) \
+    M(MoveBackgroundExecutorTaskResetMicroseconds, "Time spent resetting task for Move executor.", ValueType::Microseconds) \
+    M(MoveBackgroundExecutorWaitMicroseconds, "Time spent waiting for completion in Move executor.", ValueType::Microseconds) \
+    \
+    M(FetchBackgroundExecutorTaskExecuteStepMicroseconds, "Time spent in executeStep() for Fetch executor tasks.", ValueType::Microseconds) \
+    M(FetchBackgroundExecutorTaskCancelMicroseconds, "Time spent in cancel() for Fetch executor tasks.", ValueType::Microseconds) \
+    M(FetchBackgroundExecutorTaskResetMicroseconds, "Time spent resetting task for Fetch executor.", ValueType::Microseconds) \
+    M(FetchBackgroundExecutorWaitMicroseconds, "Time spent waiting for completion in Fetch executor.", ValueType::Microseconds) \
+    \
+    M(CommonBackgroundExecutorTaskExecuteStepMicroseconds, "Time spent in executeStep() for Common executor tasks.", ValueType::Microseconds) \
+    M(CommonBackgroundExecutorTaskCancelMicroseconds, "Time spent in cancel() for Common executor tasks.", ValueType::Microseconds) \
+    M(CommonBackgroundExecutorTaskResetMicroseconds, "Time spent resetting task for Common executor.", ValueType::Microseconds) \
+    M(CommonBackgroundExecutorWaitMicroseconds, "Time spent waiting for completion in Common executor.", ValueType::Microseconds) \
+    \
     M(MergeTreeDataWriterSkipIndicesCalculationMicroseconds, "Time spent calculating skip indices", ValueType::Microseconds) \
     M(MergeTreeDataWriterStatisticsCalculationMicroseconds, "Time spent calculating statistics", ValueType::Microseconds) \
     M(MergeTreeDataWriterSortingBlocksMicroseconds, "Time spent sorting blocks", ValueType::Microseconds) \

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -402,6 +402,11 @@
     M(MergeTreeDataWriterBlocks, "Number of blocks INSERTed to MergeTree tables. Each block forms a data part of level zero.", ValueType::Number) \
     M(MergeTreeDataWriterBlocksAlreadySorted, "Number of blocks INSERTed to MergeTree tables that appeared to be already sorted.", ValueType::Number) \
     \
+    M(MergeTreeBackgroundExecutorTaskExecuteStepMicroseconds, "Time spent in IExecutableTask::executeStep() for tasks executed by MergeTreeBackgroundExecutor.", ValueType::Microseconds) \
+    M(MergeTreeBackgroundExecutorTaskCancelMicroseconds, "Time spent in IExecutableTask::cancel() for tasks executed by MergeTreeBackgroundExecutor.", ValueType::Microseconds) \
+    M(MergeTreeBackgroundExecutorTaskResetMicroseconds, "Time spent resetting underlying task (shared_ptr reset) in MergeTreeBackgroundExecutor.", ValueType::Microseconds) \
+    M(MergeTreeBackgroundExecutorWaitMicroseconds, "Time spent waiting for task completion (is_done.wait) in MergeTreeBackgroundExecutor.", ValueType::Microseconds) \
+    \
     M(MergeTreeDataWriterSkipIndicesCalculationMicroseconds, "Time spent calculating skip indices", ValueType::Microseconds) \
     M(MergeTreeDataWriterStatisticsCalculationMicroseconds, "Time spent calculating statistics", ValueType::Microseconds) \
     M(MergeTreeDataWriterSortingBlocksMicroseconds, "Time spent sorting blocks", ValueType::Microseconds) \

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -402,11 +402,6 @@
     M(MergeTreeDataWriterBlocks, "Number of blocks INSERTed to MergeTree tables. Each block forms a data part of level zero.", ValueType::Number) \
     M(MergeTreeDataWriterBlocksAlreadySorted, "Number of blocks INSERTed to MergeTree tables that appeared to be already sorted.", ValueType::Number) \
     \
-    M(MergeTreeBackgroundExecutorTaskExecuteStepMicroseconds, "Time spent in IExecutableTask::executeStep() for tasks executed by MergeTreeBackgroundExecutor.", ValueType::Microseconds) \
-    M(MergeTreeBackgroundExecutorTaskCancelMicroseconds, "Time spent in IExecutableTask::cancel() for tasks executed by MergeTreeBackgroundExecutor.", ValueType::Microseconds) \
-    M(MergeTreeBackgroundExecutorTaskResetMicroseconds, "Time spent resetting underlying task (shared_ptr reset) in MergeTreeBackgroundExecutor.", ValueType::Microseconds) \
-    M(MergeTreeBackgroundExecutorWaitMicroseconds, "Time spent waiting for task completion (is_done.wait) in MergeTreeBackgroundExecutor.", ValueType::Microseconds) \
-    \
     /* Per-executor background executor task timings */ \
     M(MergeMutateBackgroundExecutorTaskExecuteStepMicroseconds, "Time spent in executeStep() for MergeMutate executor tasks.", ValueType::Microseconds) \
     M(MergeMutateBackgroundExecutorTaskCancelMicroseconds, "Time spent in cancel() for MergeMutate executor tasks.", ValueType::Microseconds) \

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -169,6 +169,26 @@ namespace ProfileEvents
     extern const Event QueryRemoteWriteThrottlerSleepMicroseconds;
     extern const Event QueryBackupThrottlerBytes;
     extern const Event QueryBackupThrottlerSleepMicroseconds;
+
+    extern const Event MergeMutateBackgroundExecutorTaskExecuteStepMicroseconds;
+    extern const Event MergeMutateBackgroundExecutorTaskCancelMicroseconds;
+    extern const Event MergeMutateBackgroundExecutorTaskResetMicroseconds;
+    extern const Event MergeMutateBackgroundExecutorWaitMicroseconds;
+
+    extern const Event MoveBackgroundExecutorTaskExecuteStepMicroseconds;
+    extern const Event MoveBackgroundExecutorTaskCancelMicroseconds;
+    extern const Event MoveBackgroundExecutorTaskResetMicroseconds;
+    extern const Event MoveBackgroundExecutorWaitMicroseconds;
+
+    extern const Event FetchBackgroundExecutorTaskExecuteStepMicroseconds;
+    extern const Event FetchBackgroundExecutorTaskCancelMicroseconds;
+    extern const Event FetchBackgroundExecutorTaskResetMicroseconds;
+    extern const Event FetchBackgroundExecutorWaitMicroseconds;
+
+    extern const Event CommonBackgroundExecutorTaskExecuteStepMicroseconds;
+    extern const Event CommonBackgroundExecutorTaskCancelMicroseconds;
+    extern const Event CommonBackgroundExecutorTaskResetMicroseconds;
+    extern const Event CommonBackgroundExecutorWaitMicroseconds;
 }
 
 namespace CurrentMetrics
@@ -6545,6 +6565,10 @@ void Context::initializeBackgroundExecutorsIfNeeded()
         /*max_tasks_count*/background_pool_max_tasks_count,
         CurrentMetrics::BackgroundMergesAndMutationsPoolTask,
         CurrentMetrics::BackgroundMergesAndMutationsPoolSize,
+        ProfileEvents::MergeMutateBackgroundExecutorTaskExecuteStepMicroseconds,
+        ProfileEvents::MergeMutateBackgroundExecutorTaskCancelMicroseconds,
+        ProfileEvents::MergeMutateBackgroundExecutorTaskResetMicroseconds,
+        ProfileEvents::MergeMutateBackgroundExecutorWaitMicroseconds,
         background_merges_mutations_scheduling_policy
     );
     LOG_INFO(shared->log, "Initialized background executor for merges and mutations with num_threads={}, num_tasks={}, scheduling_policy={}",
@@ -6556,7 +6580,11 @@ void Context::initializeBackgroundExecutorsIfNeeded()
         background_move_pool_size,
         background_move_pool_size,
         CurrentMetrics::BackgroundMovePoolTask,
-        CurrentMetrics::BackgroundMovePoolSize
+        CurrentMetrics::BackgroundMovePoolSize,
+        ProfileEvents::MoveBackgroundExecutorTaskExecuteStepMicroseconds,
+        ProfileEvents::MoveBackgroundExecutorTaskCancelMicroseconds,
+        ProfileEvents::MoveBackgroundExecutorTaskResetMicroseconds,
+        ProfileEvents::MoveBackgroundExecutorWaitMicroseconds
     );
     LOG_INFO(shared->log, "Initialized background executor for move operations with num_threads={}, num_tasks={}", background_move_pool_size, background_move_pool_size);
 
@@ -6566,7 +6594,11 @@ void Context::initializeBackgroundExecutorsIfNeeded()
         background_fetches_pool_size,
         background_fetches_pool_size,
         CurrentMetrics::BackgroundFetchesPoolTask,
-        CurrentMetrics::BackgroundFetchesPoolSize
+        CurrentMetrics::BackgroundFetchesPoolSize,
+        ProfileEvents::FetchBackgroundExecutorTaskExecuteStepMicroseconds,
+        ProfileEvents::FetchBackgroundExecutorTaskCancelMicroseconds,
+        ProfileEvents::FetchBackgroundExecutorTaskResetMicroseconds,
+        ProfileEvents::FetchBackgroundExecutorWaitMicroseconds
     );
     LOG_INFO(shared->log, "Initialized background executor for fetches with num_threads={}, num_tasks={}", background_fetches_pool_size, background_fetches_pool_size);
 
@@ -6576,7 +6608,11 @@ void Context::initializeBackgroundExecutorsIfNeeded()
         background_common_pool_size,
         background_common_pool_size,
         CurrentMetrics::BackgroundCommonPoolTask,
-        CurrentMetrics::BackgroundCommonPoolSize
+        CurrentMetrics::BackgroundCommonPoolSize,
+        ProfileEvents::CommonBackgroundExecutorTaskExecuteStepMicroseconds,
+        ProfileEvents::CommonBackgroundExecutorTaskCancelMicroseconds,
+        ProfileEvents::CommonBackgroundExecutorTaskResetMicroseconds,
+        ProfileEvents::CommonBackgroundExecutorWaitMicroseconds
     );
     LOG_INFO(shared->log, "Initialized background executor for common operations (e.g. clearing old parts) with num_threads={}, num_tasks={}", background_common_pool_size, background_common_pool_size);
 

--- a/src/Storages/MergeTree/MergeTreeBackgroundExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeBackgroundExecutor.cpp
@@ -9,7 +9,6 @@
 #include <Common/Exception.h>
 #include <Common/noexcept_scope.h>
 #include <Common/logger_useful.h>
-#include "base/types.h"
 
 
 namespace CurrentMetrics

--- a/src/Storages/MergeTree/MergeTreeBackgroundExecutor.h
+++ b/src/Storages/MergeTree/MergeTreeBackgroundExecutor.h
@@ -14,6 +14,7 @@
 
 #include <Storages/MergeTree/IExecutableTask.h>
 #include <base/defines.h>
+#include "Common/ElapsedTimeProfileEventIncrement.h"
 #include <Common/CurrentMetrics.h>
 #include <Common/Logger.h>
 #include <Common/ProfileEvents.h>
@@ -58,27 +59,26 @@ struct TaskRuntimeData
 
     void cancel() const
     {
-        ProfileEventTimeIncrement<Microseconds> watch(ProfileEvents::events.cancel_ms);
+        ProfileEventTimeIncrement<Microseconds> watch(events.cancel_ms);
         if (task)
             task->cancel();
     }
 
     void wait()
     {
-        ProfileEventTimeIncrement<Microseconds> watch(ProfileEvents::events.wait_ms);
+        ProfileEventTimeIncrement<Microseconds> watch(events.wait_ms);
         is_done.wait();
     }
 
     bool executeStep() const
     {
-        ProfileEventTimeIncrement<Microseconds> watch(ProfileEvents::events.execute_ms);
-        bool res = task->executeStep();
-        return res;
+        ProfileEventTimeIncrement<Microseconds> watch(events.execute_ms);
+        return task->executeStep();
     }
 
     void resetTask()
     {
-        ProfileEventTimeIncrement<Microseconds> watch(ProfileEvents::events.reset_ms);
+        ProfileEventTimeIncrement<Microseconds> watch(events.reset_ms);
         if (task)
             task.reset();
     }
@@ -346,11 +346,6 @@ private:
     std::atomic<size_t> max_tasks_count = 0;
     CurrentMetrics::Metric metric;
     CurrentMetrics::Increment max_tasks_metric;
-
-    ProfileEvents::Event execute_profile_event = ProfileEvents::end();
-    ProfileEvents::Event cancel_profile_event = ProfileEvents::end();
-    ProfileEvents::Event reset_profile_event = ProfileEvents::end();
-    ProfileEvents::Event wait_profile_event = ProfileEvents::end();
 
     void routine(TaskRuntimeDataPtr item);
 

--- a/src/Storages/MergeTree/MergeTreeBackgroundExecutor.h
+++ b/src/Storages/MergeTree/MergeTreeBackgroundExecutor.h
@@ -58,33 +58,29 @@ struct TaskRuntimeData
 
     void cancel() const
     {
-        Stopwatch sw;
+        ProfileEventTimeIncrement<Microseconds> watch(ProfileEvents::events.cancel_ms);
         if (task)
             task->cancel();
-        ProfileEvents::incrementNoTrace(events.cancel_ms, sw.elapsedMicroseconds());
     }
 
     void wait()
     {
-        Stopwatch sw;
+        ProfileEventTimeIncrement<Microseconds> watch(ProfileEvents::events.wait_ms);
         is_done.wait();
-        ProfileEvents::incrementNoTrace(events.wait_ms, sw.elapsedMicroseconds());
     }
 
     bool executeStep() const
     {
-        Stopwatch sw;
+        ProfileEventTimeIncrement<Microseconds> watch(ProfileEvents::events.execute_ms);
         bool res = task->executeStep();
-        ProfileEvents::incrementNoTrace(events.execute_ms, sw.elapsedMicroseconds());
         return res;
     }
 
     void resetTask()
     {
-        Stopwatch sw;
+        ProfileEventTimeIncrement<Microseconds> watch(ProfileEvents::events.reset_ms);
         if (task)
             task.reset();
-        ProfileEvents::incrementNoTrace(events.reset_ms, sw.elapsedMicroseconds());
     }
 
     ExecutableTaskPtr task;

--- a/src/Storages/MergeTree/MergeTreeBackgroundExecutor.h
+++ b/src/Storages/MergeTree/MergeTreeBackgroundExecutor.h
@@ -26,10 +26,10 @@ namespace DB
 struct TaskRuntimeData;
 struct TaskProfileEvents
 {
-    ProfileEvents::Event execute_ms{};
-    ProfileEvents::Event cancel_ms{};
-    ProfileEvents::Event reset_ms{};
-    ProfileEvents::Event wait_ms{};
+    ProfileEvents::Event execute_ms = ProfileEvents::end();
+    ProfileEvents::Event cancel_ms = ProfileEvents::end();
+    ProfileEvents::Event reset_ms = ProfileEvents::end();
+    ProfileEvents::Event wait_ms = ProfileEvents::end();
 };
 using TaskRuntimeDataPtr = std::shared_ptr<TaskRuntimeData>;
 
@@ -351,10 +351,10 @@ private:
     CurrentMetrics::Metric metric;
     CurrentMetrics::Increment max_tasks_metric;
 
-    ProfileEvents::Event execute_profile_event{};
-    ProfileEvents::Event cancel_profile_event{};
-    ProfileEvents::Event reset_profile_event{};
-    ProfileEvents::Event wait_profile_event{};
+    ProfileEvents::Event execute_profile_event = ProfileEvents::end();
+    ProfileEvents::Event cancel_profile_event = ProfileEvents::end();
+    ProfileEvents::Event reset_profile_event = ProfileEvents::end();
+    ProfileEvents::Event wait_profile_event = ProfileEvents::end();
 
     void routine(TaskRuntimeDataPtr item);
 

--- a/src/Storages/MergeTree/MergeTreeBackgroundExecutor.h
+++ b/src/Storages/MergeTree/MergeTreeBackgroundExecutor.h
@@ -59,7 +59,7 @@ struct TaskRuntimeData
         CurrentMetrics::values[metric].fetch_sub(1);
     }
 
-    void cancel()
+    void cancel() const
     {
         Stopwatch sw;
         if (task)
@@ -74,7 +74,7 @@ struct TaskRuntimeData
         ProfileEvents::incrementNoTrace(ProfileEvents::MergeTreeBackgroundExecutorWaitMicroseconds, sw.elapsedMicroseconds());
     }
 
-    bool executeStep()
+    bool executeStep() const
     {
         Stopwatch sw;
         bool res = task->executeStep();

--- a/src/Storages/MergeTree/MergeTreeBackgroundExecutor.h
+++ b/src/Storages/MergeTree/MergeTreeBackgroundExecutor.h
@@ -14,7 +14,7 @@
 
 #include <Storages/MergeTree/IExecutableTask.h>
 #include <base/defines.h>
-#include "Common/ElapsedTimeProfileEventIncrement.h"
+#include <Common/ElapsedTimeProfileEventIncrement.h>
 #include <Common/CurrentMetrics.h>
 #include <Common/Logger.h>
 #include <Common/ProfileEvents.h>

--- a/src/Storages/MergeTree/tests/gtest_executor.cpp
+++ b/src/Storages/MergeTree/tests/gtest_executor.cpp
@@ -19,6 +19,14 @@ namespace CurrentMetrics
     extern const Metric BackgroundMergesAndMutationsPoolSize;
 }
 
+namespace ProfileEvents
+{
+    extern const Event CommonBackgroundExecutorTaskExecuteStepMicroseconds;
+    extern const Event CommonBackgroundExecutorTaskCancelMicroseconds;
+    extern const Event CommonBackgroundExecutorTaskResetMicroseconds;
+    extern const Event CommonBackgroundExecutorWaitMicroseconds;
+}
+
 std::random_device device;
 
 class FakeExecutableTask : public IExecutableTask
@@ -111,7 +119,11 @@ TEST(Executor, Simple)
         1, // threads
         100, // max_tasks
         CurrentMetrics::BackgroundMergesAndMutationsPoolTask,
-        CurrentMetrics::BackgroundMergesAndMutationsPoolSize
+        CurrentMetrics::BackgroundMergesAndMutationsPoolSize,
+        ProfileEvents::CommonBackgroundExecutorTaskExecuteStepMicroseconds,
+        ProfileEvents::CommonBackgroundExecutorTaskCancelMicroseconds,
+        ProfileEvents::CommonBackgroundExecutorTaskResetMicroseconds,
+        ProfileEvents::CommonBackgroundExecutorWaitMicroseconds
     );
 
     String schedule; // mutex is not required because we have a single worker
@@ -154,7 +166,11 @@ TEST(Executor, RemoveTasks)
         tasks_kinds,
         tasks_kinds * batch,
         CurrentMetrics::BackgroundMergesAndMutationsPoolTask,
-        CurrentMetrics::BackgroundMergesAndMutationsPoolSize
+        CurrentMetrics::BackgroundMergesAndMutationsPoolSize,
+        ProfileEvents::CommonBackgroundExecutorTaskExecuteStepMicroseconds,
+        ProfileEvents::CommonBackgroundExecutorTaskCancelMicroseconds,
+        ProfileEvents::CommonBackgroundExecutorTaskResetMicroseconds,
+        ProfileEvents::CommonBackgroundExecutorWaitMicroseconds
     );
 
     for (size_t i = 0; i < batch; ++i)
@@ -195,7 +211,11 @@ TEST(Executor, RemoveTasksStress)
         tasks_kinds,
         tasks_kinds * batch * (schedulers_count + removers_count),
         CurrentMetrics::BackgroundMergesAndMutationsPoolTask,
-        CurrentMetrics::BackgroundMergesAndMutationsPoolSize
+        CurrentMetrics::BackgroundMergesAndMutationsPoolSize,
+        ProfileEvents::CommonBackgroundExecutorTaskExecuteStepMicroseconds,
+        ProfileEvents::CommonBackgroundExecutorTaskCancelMicroseconds,
+        ProfileEvents::CommonBackgroundExecutorTaskResetMicroseconds,
+        ProfileEvents::CommonBackgroundExecutorWaitMicroseconds
     );
 
     std::barrier<std::__empty_completion> barrier(schedulers_count + removers_count);
@@ -246,7 +266,11 @@ TEST(Executor, UpdatePolicy)
         1, // threads
         100, // max_tasks
         CurrentMetrics::BackgroundMergesAndMutationsPoolTask,
-        CurrentMetrics::BackgroundMergesAndMutationsPoolSize
+        CurrentMetrics::BackgroundMergesAndMutationsPoolSize,
+        ProfileEvents::CommonBackgroundExecutorTaskExecuteStepMicroseconds,
+        ProfileEvents::CommonBackgroundExecutorTaskCancelMicroseconds,
+        ProfileEvents::CommonBackgroundExecutorTaskResetMicroseconds,
+        ProfileEvents::CommonBackgroundExecutorWaitMicroseconds
     );
 
     String schedule; // mutex is not required because we have a single worker


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
