### PR TITLE
docs: clarify nested Avro schema handling in s3 table function

### DIFF
--- a/docs/en/sql-reference/table-functions/s3.md
+++ b/docs/en/sql-reference/table-functions/s3.md
@@ -377,6 +377,31 @@ Peak memory usage: 192.27 KiB.
 - [s3_create_new_file_on_insert](operations/settings/settings.md#s3_create_new_file_on_insert) - allows to create a new file on each insert if format has suffix. Disabled by default.
 - [s3_skip_empty_files](operations/settings/settings.md#s3_skip_empty_files) - allows to skip empty files while reading. Enabled by default.
 
+## Nested Avro Schemas {#nested-avro-schemas}
+
+When reading Avro files that contain **nested records** which diverge across files (for example, some files have an extra field inside a nested object), ClickHouse may return an error such as:
+
+> The number of leaves in record doesn't match the number of elements in tuple...
+
+This happens because ClickHouse expects all nested record structures to match the same schema.  
+To handle this scenario, you can:
+
+- Use `schema_inference_mode='union'` to merge different nested record schemas, or  
+- Manually align your nested structures and enable  
+  `use_structure_from_insertion_table_in_table_functions=1`.
+
+**Performance note:**  
+`schema_inference_mode='union'` may take longer on very large S3 datasets because it must scan each file to infer schema.
+
+**Example**
+```sql
+INSERT INTO data_stage
+SELECT
+    id,
+    data
+FROM s3('https://bucket-name/*.avro', 'Avro')
+SETTINGS schema_inference_mode='union';
+
 ## Related {#related}
 
 - [S3 engine](../../engines/table-engines/integrations/s3.md)

--- a/docs/en/sql-reference/table-functions/s3.md
+++ b/docs/en/sql-reference/table-functions/s3.md
@@ -390,8 +390,9 @@ To handle this scenario, you can:
 - Manually align your nested structures and enable  
   `use_structure_from_insertion_table_in_table_functions=1`.
 
-**Performance note:**  
-`schema_inference_mode='union'` may take longer on very large S3 datasets because it must scan each file to infer schema.
+:::note[Performance note]
+`schema_inference_mode='union'` may take longer on very large S3 datasets because it must scan each file to infer the schema.
+:::
 
 **Example**
 ```sql


### PR DESCRIPTION
Adds a short documentation section describing how to handle nested Avro schemas  that diverge across files using `schema_inference_mode='union'` or  `use_structure_from_insertion_table_in_table_functions=1`.  References issue #88661.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
