### PR TITLE
Adding simple HashJoin metrics

### DIFF
--- a/src/Common/CurrentMetrics.cpp
+++ b/src/Common/CurrentMetrics.cpp
@@ -451,6 +451,11 @@
     M(DropDistributedCacheThreads, "Number of threads in the threadpool for drop distributed cache query.") \
     M(DropDistributedCacheThreadsActive, "Number of active threads in the threadpool for drop distributed cache query.") \
     M(DropDistributedCacheThreadsScheduled, "Number of queued or active jobs in the threadpool for drop distributed cache.") \
+    \
+    M(HashJoinInMemoryBytes, "Total memory usage in bytes for hash tables and right table data in Hash Join operations") \
+    M(HashJoinInMemoryRows, "Total number of rows stored in memory from right table data in Hash Join operations") \
+    M(HashJoinInstancesCount, "Total number of active Hash Join instances") \
+
 
 #ifdef APPLY_FOR_EXTERNAL_METRICS
     #define APPLY_FOR_METRICS(M) APPLY_FOR_BUILTIN_METRICS(M) APPLY_FOR_EXTERNAL_METRICS(M)

--- a/src/Interpreters/HashJoin/HashJoin.cpp
+++ b/src/Interpreters/HashJoin/HashJoin.cpp
@@ -12,7 +12,6 @@
 #include <Common/StackTrace.h>
 #include <Common/logger_useful.h>
 
-
 #include <DataTypes/DataTypeLowCardinality.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypesNumber.h>
@@ -447,6 +446,9 @@ size_t HashJoin::getTotalRowCount() const
                 kind, strictness, map, prefer_use_maps_all, [&](auto, auto, auto & map_) { res += map_.getTotalRowCount(data->type); });
         }
     }
+
+    /// We call this function often enough, so keep metric up to date here.
+    data->metric_rows.changeTo(res);
     return res;
 }
 
@@ -503,6 +505,9 @@ size_t HashJoin::getTotalByteCount() const
                 [&](auto, auto, auto & map_) { res += map_.getTotalByteCountImpl(data->type); });
         }
     }
+
+    /// We call this function often enough, so keep metric up to date here.
+    data->metric_bytes.changeTo(res);
     return res;
 }
 
@@ -802,7 +807,6 @@ bool HashJoin::addBlockToJoin(const Block & block, ScatteredBlock::Selector sele
             if (!check_limits)
                 return true;
 
-            /// TODO: Do not calculate them every time
             total_rows = getTotalRowCount();
             total_bytes = getTotalByteCount();
         }
@@ -1830,4 +1834,5 @@ void HashJoin::onBuildPhaseFinish()
         LOG_DEBUG(log, "Promoting join strictness to RightAny, because all values in the right table are unique");
     }
 }
+
 }

--- a/src/Interpreters/HashJoin/HashJoin.h
+++ b/src/Interpreters/HashJoin/HashJoin.h
@@ -22,6 +22,15 @@
 #include <Common/HashTable/HashMap.h>
 #include <Common/HashTable/HashTableTraits.h>
 #include <Common/HashTable/TwoLevelHashMap.h>
+#include <Common/CurrentMetrics.h>
+
+
+namespace CurrentMetrics
+{
+    extern const Metric HashJoinInMemoryBytes;
+    extern const Metric HashJoinInMemoryRows;
+    extern const Metric HashJoinInstancesCount;
+}
 
 namespace DB
 {
@@ -392,6 +401,10 @@ public:
 
         /// Additional data - strings for string keys and continuation elements of single-linked lists of references to rows.
         Arena pool;
+
+        CurrentMetrics::Increment metric_bytes{CurrentMetrics::HashJoinInMemoryBytes, 0};
+        CurrentMetrics::Increment metric_rows{CurrentMetrics::HashJoinInMemoryRows, 0};
+        CurrentMetrics::Increment metric_instances{CurrentMetrics::HashJoinInstancesCount, 1};
 
         size_t allocated_size = 0;
         size_t nullmaps_allocated_size = 0;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Improvement



### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
* Added `HashJoinInMemoryBytes/HashJoinInMemoryRows/HashJoinInstancesCount` metrics for monitoring Hash Join memory usage and active instances. Note: Metrics may be inaccurate for Hash Join operations that complete faster than the metrics flush period (typically 1 second), as such short-lived joins may not be captured.


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
