### PR TITLE
CI: Pytest parser fix

### DIFF
--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -274,7 +274,7 @@ def main():
                     env=test_env,
                     pytest_report_file=f"{temp_path}/pytest_parallel.jsonl",
                 )
-                if not test_result_parallel.is_ok():
+                if is_flaky_check and not test_result_parallel.is_ok():
                     print(
                         f"Flaky check: Test run fails after attempt [{attempt+1}/{module_repeat_cnt}] - break"
                     )
@@ -299,7 +299,7 @@ def main():
                     cwd="./tests/integration/",
                     pytest_report_file=f"{temp_path}/pytest_sequential.jsonl",
                 )
-                if not test_result_sequential.is_ok():
+                if is_flaky_check and not test_result_sequential.is_ok():
                     print(
                         f"Flaky check: Test run fails after attempt [{attempt+1}/{module_repeat_cnt}] - break"
                     )

--- a/ci/jobs/scripts/workflow_hooks/new_tests_check.py
+++ b/ci/jobs/scripts/workflow_hooks/new_tests_check.py
@@ -1,4 +1,5 @@
 import sys
+from pathlib import Path
 
 from ci.praktika.info import Info
 
@@ -14,7 +15,11 @@ def has_new_functional_tests(changed_files):
 def has_new_integration_tests(changed_files):
     for file in changed_files:
         file = file.removeprefix(".").removeprefix("/")
-        if file.startswith("tests/integration/test_"):
+        if (
+            file.startswith("tests/integration/test_")
+            and Path(file).name.startswith("test")
+            and file.endswith(".py")
+        ):
             return True
     return False
 


### PR DESCRIPTION
Praktika runner completely misses run erros related to invalid syntax, as they go into a separate tab inside the pytest report.
This fixes praktika pytest parser to handle syntax errors in test files and fail the run with an error if found.
If such an error found - the entire file added as a test in the report with status ERROR

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

