### PR TITLE
Fix append to system.zookeeper_connection_log

### DIFF
--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -4604,7 +4604,8 @@ static void reloadZooKeeperIfChangedImpl(
 
         if (zk_concection_log)
         {
-            zk_concection_log->addDisconnected(keeper_name, *old_zk, reason);
+            if (old_zk)
+                zk_concection_log->addDisconnected(keeper_name, *old_zk, reason);
             zk_concection_log->addConnected(keeper_name, *zk, reason);
         }
 

--- a/tests/integration/test_zookeeper_connection_log/configs/enable_keeper.xml
+++ b/tests/integration/test_zookeeper_connection_log/configs/enable_keeper.xml
@@ -1,0 +1,28 @@
+<clickhouse>
+    <keeper_server>
+        <use_cluster>0</use_cluster>
+        <tcp_port>9181</tcp_port>
+        <server_id>1</server_id>
+        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
+        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
+
+        <coordination_settings>
+            <operation_timeout_ms>5000</operation_timeout_ms>
+            <session_timeout_ms>10000</session_timeout_ms>
+            <raft_logs_level>trace</raft_logs_level>
+            <force_sync>false</force_sync>
+            <!-- For instant start in single node configuration -->
+            <heart_beat_interval_ms>0</heart_beat_interval_ms>
+            <election_timeout_lower_bound_ms>0</election_timeout_lower_bound_ms>
+            <election_timeout_upper_bound_ms>0</election_timeout_upper_bound_ms>
+        </coordination_settings>
+
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>localhost</hostname>
+                <port>9234</port>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+</clickhouse>

--- a/tests/integration/test_zookeeper_connection_log/test.py
+++ b/tests/integration/test_zookeeper_connection_log/test.py
@@ -4,17 +4,28 @@ import logging
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
 
-cluster = ClickHouseCluster(__file__, zookeeper_config_path="configs/zookeeper_config.xml")
-node = cluster.add_instance(
-    "node",
+cluster = ClickHouseCluster(
+    __file__, zookeeper_config_path="configs/zookeeper_config.xml"
+)
+node1 = cluster.add_instance(
+    "node1",
     with_zookeeper=True,
     stay_alive=True,
     main_configs=[
         "configs/zookeeper_connection_log.xml",
         "configs/auxiliary_zookeepers.xml",
-        "configs/config_reloader.xml",],
+        "configs/config_reloader.xml",
+    ],
     keeper_randomize_feature_flags=False,
 )
+
+node2 = cluster.add_instance(
+    "node2",
+    main_configs=["configs/enable_keeper.xml"],
+    stay_alive=True,
+    keeper_randomize_feature_flags=False,
+)
+
 
 @pytest.fixture(scope="module")
 def started_cluster():
@@ -26,33 +37,33 @@ def started_cluster():
 
 
 def test_zookeeper_connection_log(started_cluster):
-    node.query("DROP TABLE IF EXISTS simple SYNC")
-    node.query("DROP TABLE IF EXISTS simple2 SYNC")
+    node1.query("DROP TABLE IF EXISTS simple SYNC")
+    node1.query("DROP TABLE IF EXISTS simple2 SYNC")
 
-    test_start_time = node.query("SELECT now64()").strip()
+    test_start_time = node1.query("SELECT now64()").strip()
     logging.debug(f"Test start time is {test_start_time}")
 
     # Let's restart ClickHouse to make sure there are log entries for initialization.
     # By restarting we can also make sure there won't be any config reloads in case of repeated runs.
     # The previous run would revert the config, but we need to reset the state of config.
-    node.restart_clickhouse()
+    node1.restart_clickhouse()
 
-    node.query(
+    node1.query(
         "CREATE TABLE simple (date Date, id UInt32) ENGINE = ReplicatedMergeTree('/clickhouse/tables/0/simple', 'node') ORDER BY tuple() PARTITION BY date;"
     )
-    node.query("INSERT INTO simple VALUES ('2020-08-27', 1)")
-    node.query("INSERT INTO simple VALUES ('2020-08-28', 1)")
-    node.query("INSERT INTO simple VALUES ('2020-08-29', 1)")
+    node1.query("INSERT INTO simple VALUES ('2020-08-27', 1)")
+    node1.query("INSERT INTO simple VALUES ('2020-08-28', 1)")
+    node1.query("INSERT INTO simple VALUES ('2020-08-29', 1)")
 
-    node.query(
+    node1.query(
         "CREATE TABLE simple2 (date Date, id UInt32) ENGINE = ReplicatedMergeTree('/clickhouse/tables/1/simple', 'node') ORDER BY tuple() PARTITION BY date;"
     )
 
-    node.query(
+    node1.query(
         "ALTER TABLE simple2 FETCH PARTITION '2020-08-27' FROM 'zk_conn_log_test_2:/clickhouse/tables/0/simple';"
     )
 
-    node.query(
+    node1.query(
         "ALTER TABLE simple2 FETCH PARTITION '2020-08-28' FROM 'zk_conn_log_test_3:/clickhouse/tables/0/simple';"
     )
 
@@ -83,39 +94,83 @@ def test_zookeeper_connection_log(started_cluster):
     </zookeeper>
 </clickhouse>"""
 
-    with node.with_replace_config("/etc/clickhouse-server/conf.d/zookeeper_config.xml", new_config):
-        with node.with_replace_config("/etc/clickhouse-server/config.d/auxiliary_zookeepers.xml", new_auxiliary_config):
+    with node1.with_replace_config(
+        "/etc/clickhouse-server/conf.d/zookeeper_config.xml", new_config
+    ):
+        with node1.with_replace_config(
+            "/etc/clickhouse-server/config.d/auxiliary_zookeepers.xml",
+            new_auxiliary_config,
+        ):
 
-            node.query("SYSTEM RELOAD CONFIG")
+            node1.query("SYSTEM RELOAD CONFIG")
 
             def check_8_rows(res):
-                logging.debug(f"Checking for 8 rows in zookeeper_connection_log, got: {res}")
+                logging.debug(
+                    f"Checking for 8 rows in zookeeper_connection_log, got: {res}"
+                )
                 return res == "8\n"
 
-            node.query_with_retry(f"SELECT count() FROM system.zookeeper_connection_log WHERE event_time_microseconds >= '{test_start_time}'", check_callback=check_8_rows)
+            node1.query_with_retry(
+                f"SELECT count() FROM system.zookeeper_connection_log WHERE event_time_microseconds >= '{test_start_time}'",
+                check_callback=check_8_rows,
+            )
 
-            node.query(
+            node1.query(
                 "ALTER TABLE simple2 FETCH PARTITION '2020-08-29' FROM 'zk_conn_log_test_4:/clickhouse/tables/0/simple';"
             )
 
-            node.query("SYSTEM FLUSH LOGS")
+            node1.query("SYSTEM FLUSH LOGS")
 
-            logging.debug(node.query("""SELECT event_time_microseconds, hostname, type, name, host, port, index, keeper_api_version, enabled_feature_flags, reason
-                               FROM system.zookeeper_connection_log  ORDER BY event_time_microseconds"""))
-            expected = TSV("""node	Connected	default	zoo1	2181	0	0	['FILTERED_LIST','MULTI_READ','CHECK_NOT_EXISTS','CREATE_IF_NOT_EXISTS','REMOVE_RECURSIVE','MULTI_WATCHES']	Initialization
-node	Connected	zk_conn_log_test_2	zoo2	2181	0	0	['FILTERED_LIST','MULTI_READ','CHECK_NOT_EXISTS','CREATE_IF_NOT_EXISTS','REMOVE_RECURSIVE','MULTI_WATCHES']	Initialization
-node	Connected	zk_conn_log_test_3	zoo3	2181	0	0	['FILTERED_LIST','MULTI_READ','CHECK_NOT_EXISTS','CREATE_IF_NOT_EXISTS','REMOVE_RECURSIVE','MULTI_WATCHES']	Initialization
-node	Disconnected	default	zoo1	2181	0	0	['FILTERED_LIST','MULTI_READ','CHECK_NOT_EXISTS','CREATE_IF_NOT_EXISTS','REMOVE_RECURSIVE','MULTI_WATCHES']	Config changed
-node	Connected	default	zoo2	2181	0	0	['FILTERED_LIST','MULTI_READ','CHECK_NOT_EXISTS','CREATE_IF_NOT_EXISTS','REMOVE_RECURSIVE','MULTI_WATCHES']	Config changed
-node	Disconnected	zk_conn_log_test_2	zoo2	2181	0	0	['FILTERED_LIST','MULTI_READ','CHECK_NOT_EXISTS','CREATE_IF_NOT_EXISTS','REMOVE_RECURSIVE','MULTI_WATCHES']	Config changed
-node	Connected	zk_conn_log_test_2	zoo3	2181	0	0	['FILTERED_LIST','MULTI_READ','CHECK_NOT_EXISTS','CREATE_IF_NOT_EXISTS','REMOVE_RECURSIVE','MULTI_WATCHES']	Config changed
-node	Disconnected	zk_conn_log_test_3	zoo3	2181	0	0	['FILTERED_LIST','MULTI_READ','CHECK_NOT_EXISTS','CREATE_IF_NOT_EXISTS','REMOVE_RECURSIVE','MULTI_WATCHES']	Removed from config
-node	Connected	zk_conn_log_test_4	zoo2	2181	0	0	['FILTERED_LIST','MULTI_READ','CHECK_NOT_EXISTS','CREATE_IF_NOT_EXISTS','REMOVE_RECURSIVE','MULTI_WATCHES']	Initialization""")
+            logging.debug(
+                node1.query(
+                    """SELECT event_time_microseconds, hostname, type, name, host, port, index, keeper_api_version, enabled_feature_flags, reason
+                               FROM system.zookeeper_connection_log  ORDER BY event_time_microseconds"""
+                )
+            )
+            expected = TSV(
+                """node1	Connected	default	zoo1	2181	0	0	['FILTERED_LIST','MULTI_READ','CHECK_NOT_EXISTS','CREATE_IF_NOT_EXISTS','REMOVE_RECURSIVE','MULTI_WATCHES']	Initialization
+node1	Connected	zk_conn_log_test_2	zoo2	2181	0	0	['FILTERED_LIST','MULTI_READ','CHECK_NOT_EXISTS','CREATE_IF_NOT_EXISTS','REMOVE_RECURSIVE','MULTI_WATCHES']	Initialization
+node1	Connected	zk_conn_log_test_3	zoo3	2181	0	0	['FILTERED_LIST','MULTI_READ','CHECK_NOT_EXISTS','CREATE_IF_NOT_EXISTS','REMOVE_RECURSIVE','MULTI_WATCHES']	Initialization
+node1	Disconnected	default	zoo1	2181	0	0	['FILTERED_LIST','MULTI_READ','CHECK_NOT_EXISTS','CREATE_IF_NOT_EXISTS','REMOVE_RECURSIVE','MULTI_WATCHES']	Config changed
+node1	Connected	default	zoo2	2181	0	0	['FILTERED_LIST','MULTI_READ','CHECK_NOT_EXISTS','CREATE_IF_NOT_EXISTS','REMOVE_RECURSIVE','MULTI_WATCHES']	Config changed
+node1	Disconnected	zk_conn_log_test_2	zoo2	2181	0	0	['FILTERED_LIST','MULTI_READ','CHECK_NOT_EXISTS','CREATE_IF_NOT_EXISTS','REMOVE_RECURSIVE','MULTI_WATCHES']	Config changed
+node1	Connected	zk_conn_log_test_2	zoo3	2181	0	0	['FILTERED_LIST','MULTI_READ','CHECK_NOT_EXISTS','CREATE_IF_NOT_EXISTS','REMOVE_RECURSIVE','MULTI_WATCHES']	Config changed
+node1	Disconnected	zk_conn_log_test_3	zoo3	2181	0	0	['FILTERED_LIST','MULTI_READ','CHECK_NOT_EXISTS','CREATE_IF_NOT_EXISTS','REMOVE_RECURSIVE','MULTI_WATCHES']	Removed from config
+node1	Connected	zk_conn_log_test_4	zoo2	2181	0	0	['FILTERED_LIST','MULTI_READ','CHECK_NOT_EXISTS','CREATE_IF_NOT_EXISTS','REMOVE_RECURSIVE','MULTI_WATCHES']	Initialization"""
+            )
 
-            assert TSV(
-                node.query(f"""SELECT hostname, type, name, host, port, index, keeper_api_version, enabled_feature_flags, reason
+            assert (
+                TSV(
+                    node1.query(
+                        f"""SELECT hostname, type, name, host, port, index, keeper_api_version, enabled_feature_flags, reason
                                FROM system.zookeeper_connection_log
                                WHERE event_time_microseconds >= '{test_start_time}'
-                               ORDER BY event_time_microseconds""")
-                ) == expected
-            assert int(node.query("SELECT max(event_per_client_id) FROM (SELECT client_id, count() AS event_per_client_id FROM system.zookeeper_connection_log GROUP BY client_id)")) == 2
+                               ORDER BY event_time_microseconds"""
+                    )
+                )
+                == expected
+            )
+            assert (
+                int(
+                    node1.query(
+                        "SELECT max(event_per_client_id) FROM (SELECT client_id, count() AS event_per_client_id FROM system.zookeeper_connection_log GROUP BY client_id)"
+                    )
+                )
+                == 2
+            )
+
+
+def test_connect_on_reload(started_cluster, request):
+    node2.replace_in_config(
+        "/etc/clickhouse-server/config.d/enable_keeper.xml",
+        "use_cluster>1",
+        "use_cluster>0",
+    )
+    node2.restart_clickhouse()
+    node2.replace_in_config(
+        "/etc/clickhouse-server/config.d/enable_keeper.xml",
+        "use_cluster>0",
+        "use_cluster>1",
+    )
+    node2.query("SYSTEM RELOAD CONFIG")
+    node2.query("SELECT 1")


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix appending to `system.zookeeper_connection_log` in case ClickHouse connects for the first time after config reload.

Crash from CI
```
2025.10.16 18:25:45.647098 [ 1671 ] {} <Fatal> BaseDaemon: ########## Short fault info ############
2025.10.16 18:25:45.647114 [ 1671 ] {} <Fatal> BaseDaemon: (version 25.10.1.3200 (official build), build id: 0913ADCC541DD9FB260B57A2610DD790426F4F0C, git hash: 75e1dc8fd0ccfba3ad78cf825e02b8cb67099f9b, architecture: aarch64) (from thread 2353) Received signal 11
2025.10.16 18:25:45.647120 [ 1671 ] {} <Fatal> BaseDaemon: Signal description: Segmentation fault
2025.10.16 18:25:45.647125 [ 1671 ] {} <Fatal> BaseDaemon: Address: NULL pointer. Access: <not available>. Address not mapped to object.
2025.10.16 18:25:45.647139 [ 1671 ] {} <Fatal> BaseDaemon: Stack trace: 0x0000aba3a114d941 0x0000aba39da122dc 0x0000aba39d564690 0x0000aba39d5641f8 0x0000aba398760d68 0x0000aba39875e5b4 0x0000aba3a1115808 0x0000aba3a11172e4 0x0000aba3a1118660 0x0000aba3985941ac 0x0000aba398599388 0x0000ffd0b51fd5b8 0x0000ffd0b5265edc
2025.10.16 18:25:45.647144 [ 1671 ] {} <Fatal> BaseDaemon: ########################################
2025.10.16 18:25:45.647147 [ 1671 ] {} <Fatal> BaseDaemon: (version 25.10.1.3200 (official build), build id: 0913ADCC541DD9FB260B57A2610DD790426F4F0C, git hash: 75e1dc8fd0ccfba3ad78cf825e02b8cb67099f9b) (from thread 2353) (no query) Received signal Segmentation fault (11)
2025.10.16 18:25:45.647152 [ 1671 ] {} <Fatal> BaseDaemon: Address: NULL pointer. Access: <not available>. Address not mapped to object.
2025.10.16 18:25:45.647152 [ 1671 ] {} <Fatal> BaseDaemon: Stack trace: 0x0000aba3a114d941 0x0000aba39da122dc 0x0000aba39d564690 0x0000aba39d5641f8 0x0000aba398760d68 0x0000aba39875e5b4 0x0000aba3a1115808 0x0000aba3a11172e4 0x0000aba3a1118660 0x0000aba3985941ac 0x0000aba398599388 0x0000ffd0b51fd5b8 0x0000ffd0b5265edc
2025.10.16 18:25:45.676358 [ 1671 ] {} <Fatal> BaseDaemon: 3.0. inlined from ./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:272: std::unique_ptr<Coordination::IKeeper, std::default_delete<Coordination::IKeeper>>::operator->[abi:ne190107]() const
2025.10.16 18:25:45.676374 [ 1671 ] {} <Fatal> BaseDaemon: 3. ./ci/tmp/build/./src/Common/ZooKeeper/ZooKeeper.cpp:1566: zkutil::ZooKeeper::getConnectedHostPort() const @ 0x000000001758d941
2025.10.16 18:25:45.683373 [ 1671 ] {} <Fatal> BaseDaemon: 4. ./ci/tmp/build/./src/Interpreters/ZooKeeperConnectionLog.cpp:128: DB::ZooKeeperConnectionLog::addWithEventType(DB::ZooKeeperConnectionLogElement::EventType, std::basic_string_view<char, std::char_traits<char>>, zkutil::ZooKeeper const&, std::basic_string_view<char, std::char_traits<char>>) @ 0x0000000013e522dc
2025.10.16 18:25:45.777415 [ 1671 ] {} <Fatal> BaseDaemon: 5. ./ci/tmp/build/./src/Interpreters/Context.cpp:4597: DB::reloadZooKeeperIfChangedImpl(Poco::AutoPtr<Poco::Util::AbstractConfiguration> const&, std::basic_string_view<char, std::char_traits<char>>, String const&, std::shared_ptr<zkutil::ZooKeeper>&, std::shared_ptr<DB::ZooKeeperLog>, std::shared_ptr<DB::ZooKeeperConnectionLog>, std::shared_ptr<DB::AggregatedZooKeeperLog>, bool, int) @ 0x00000000139a4690
2025.10.16 18:25:45.852914 [ 1671 ] {} <Fatal> BaseDaemon: 6. ./ci/tmp/build/./src/Interpreters/Context.cpp:4613: DB::Context::reloadZooKeeperIfChanged(Poco::AutoPtr<Poco::Util::AbstractConfiguration> const&) const @ 0x00000000139a41f8
2025.10.16 18:25:45.891915 [ 1671 ] {} <Fatal> BaseDaemon: 7. ./ci/tmp/build/./programs/server/Server.cpp:2196: DB::Server::main(std::vector<String, std::allocator<String>> const&)::$_1::operator()(Poco::AutoPtr<Poco::Util::AbstractConfiguration>, bool) const @ 0x000000000eba0d68
2025.10.16 18:25:45.930359 [ 1671 ] {} <Fatal> BaseDaemon: 8.0. inlined from ./contrib/llvm-project/libcxx/include/__type_traits/invoke.h:149: decltype(std::declval<DB::Server::main(std::vector<String, std::allocator<String>> const&)::$_1&>()(std::declval<Poco::AutoPtr<Poco::Util::AbstractConfiguration>>(), std::declval<bool>())) std::__invoke[abi:ne190107]<DB::Server::main(std::vector<String, std::allocator<String>> const&)::$_1&, Poco::AutoPtr<Poco::Util::AbstractConfiguration>, bool>(DB::Server::main(std::vector<String, std::allocator<String>> const&)::$_1&, Poco::AutoPtr<Poco::Util::AbstractConfiguration>&&, bool&&)
2025.10.16 18:25:45.930382 [ 1671 ] {} <Fatal> BaseDaemon: 8.1. inlined from ./contrib/llvm-project/libcxx/include/__type_traits/invoke.h:224: void std::__invoke_void_return_wrapper<void, true>::__call[abi:ne190107]<DB::Server::main(std::vector<String, std::allocator<String>> const&)::$_1&, Poco::AutoPtr<Poco::Util::AbstractConfiguration>, bool>(DB::Server::main(std::vector<String, std::allocator<String>> const&)::$_1&, Poco::AutoPtr<Poco::Util::AbstractConfiguration>&&, bool&&)
2025.10.16 18:25:45.930387 [ 1671 ] {} <Fatal> BaseDaemon: 8.2. inlined from ./contrib/llvm-project/libcxx/include/__functional/function.h:210: ?
2025.10.16 18:25:45.930389 [ 1671 ] {} <Fatal> BaseDaemon: 8. ./contrib/llvm-project/libcxx/include/__functional/function.h:610: ? @ 0x000000000eb9e5b4
2025.10.16 18:25:45.936757 [ 1671 ] {} <Fatal> BaseDaemon: 9.0. inlined from ./contrib/llvm-project/libcxx/include/__functional/function.h:716: ?
2025.10.16 18:25:45.936778 [ 1671 ] {} <Fatal> BaseDaemon: 9.1. inlined from ./contrib/llvm-project/libcxx/include/__functional/function.h:989: ?
2025.10.16 18:25:45.936786 [ 1671 ] {} <Fatal> BaseDaemon: 9. ./ci/tmp/build/./src/Common/Config/ConfigReloader.cpp:180: DB::ConfigReloader::reloadIfNewer(bool, bool, bool, bool) @ 0x0000000017555808
2025.10.16 18:25:45.943944 [ 1671 ] {} <Fatal> BaseDaemon: 10. ./ci/tmp/build/./src/Common/Config/ConfigReloader.cpp:98: DB::ConfigReloader::run() @ 0x00000000175572e4
2025.10.16 18:25:45.949572 [ 1671 ] {} <Fatal> BaseDaemon: 11.0. inlined from ./contrib/llvm-project/libcxx/include/__type_traits/invoke.h:117: decltype(*std::declval<DB::ConfigReloader*&>().*std::declval<void (DB::ConfigReloader::*&)()>()()) std::__invoke[abi:ne190107]<void (DB::ConfigReloader::*&)(), DB::ConfigReloader*&, void>(void (DB::ConfigReloader::*&)(), DB::ConfigReloader*&)
2025.10.16 18:25:45.949591 [ 1671 ] {} <Fatal> BaseDaemon: 11.1. inlined from ./contrib/llvm-project/libcxx/include/tuple:1354: decltype(auto) std::__apply_tuple_impl[abi:ne190107]<void (DB::ConfigReloader::*&)(), std::tuple<DB::ConfigReloader*>&, 0ul>(void (DB::ConfigReloader::*&)(), std::tuple<DB::ConfigReloader*>&, std::__tuple_indices<0ul>)
2025.10.16 18:25:45.949599 [ 1671 ] {} <Fatal> BaseDaemon: 11.2. inlined from ./contrib/llvm-project/libcxx/include/tuple:1358: decltype(auto) std::apply[abi:ne190107]<void (DB::ConfigReloader::*&)(), std::tuple<DB::ConfigReloader*>&>(void (DB::ConfigReloader::*&)(), std::tuple<DB::ConfigReloader*>&)
2025.10.16 18:25:45.949602 [ 1671 ] {} <Fatal> BaseDaemon: 11. ./src/Common/ThreadPool.h:312: ThreadFromGlobalPoolImpl<true, true>::ThreadFromGlobalPoolImpl<void (DB::ConfigReloader::*)(), DB::ConfigReloader*>(void (DB::ConfigReloader::*&&)(), DB::ConfigReloader*&&)::'lambda'()::operator()() @ 0x0000000017558660
2025.10.16 18:25:45.955567 [ 1671 ] {} <Fatal> BaseDaemon: 12.0. inlined from ./contrib/llvm-project/libcxx/include/__functional/function.h:716: ?
2025.10.16 18:25:45.955581 [ 1671 ] {} <Fatal> BaseDaemon: 12.1. inlined from ./contrib/llvm-project/libcxx/include/__functional/function.h:989: ?
2025.10.16 18:25:45.955587 [ 1671 ] {} <Fatal> BaseDaemon: 12. ./ci/tmp/build/./src/Common/ThreadPool.cpp:812: ThreadPoolImpl<std::thread>::ThreadFromThreadPool::worker() @ 0x000000000e9d41ac
2025.10.16 18:25:45.965871 [ 1671 ] {} <Fatal> BaseDaemon: 13.0. inlined from ./contrib/llvm-project/libcxx/include/__type_traits/invoke.h:117: decltype(*std::declval<ThreadPoolImpl<std::thread>::ThreadFromThreadPool*>().*std::declval<void (ThreadPoolImpl<std::thread>::ThreadFromThreadPool::*)()>()()) std::__invoke[abi:ne190107]<void (ThreadPoolImpl<std::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::thread>::ThreadFromThreadPool*, void>(void (ThreadPoolImpl<std::thread>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<std::thread>::ThreadFromThreadPool*&&)
2025.10.16 18:25:45.965898 [ 1671 ] {} <Fatal> BaseDaemon: 13.1. inlined from ./contrib/llvm-project/libcxx/include/__thread/thread.h:192: void std::__thread_execute[abi:ne190107]<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void (ThreadPoolImpl<std::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::thread>::ThreadFromThreadPool*, 2ul>(std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void (ThreadPoolImpl<std::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::thread>::ThreadFromThreadPool*>&, std::__tuple_indices<2ul>)
2025.10.16 18:25:45.965910 [ 1671 ] {} <Fatal> BaseDaemon: 13. ./contrib/llvm-project/libcxx/include/__thread/thread.h:201: void* std::__thread_proxy[abi:ne190107]<std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void (ThreadPoolImpl<std::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::thread>::ThreadFromThreadPool*>>(void*) @ 0x000000000e9d9388
2025.10.16 18:25:45.965947 [ 1671 ] {} <Fatal> BaseDaemon: 14. ? @ 0x000000000007d5b8
2025.10.16 18:25:45.965959 [ 1671 ] {} <Fatal> BaseDaemon: 15. ? @ 0x00000000000e5edc
2025.10.16 18:25:45.965973 [ 1671 ] {} <Fatal> BaseDaemon: Integrity check of the executable skipped because the reference checksum could not be read.
2025.10.16 18:25:47.333475 [ 1671 ] {} <Fatal> BaseDaemon: Report this error to https://github.com/ClickHouse/ClickHouse/issues
```
Fix https://github.com/ClickHouse/ClickHouse/issues/88443

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
