### PR TITLE
Change order of heuristic application in `SimpleMergeSelector`

### DIFF
--- a/src/Storages/MergeTree/Compaction/MergeSelectors/SimpleMergeSelector.cpp
+++ b/src/Storages/MergeTree/Compaction/MergeSelectors/SimpleMergeSelector.cpp
@@ -45,6 +45,10 @@ public:
 
     void consider(RangesIterator range_it, PartsIterator begin, PartsIterator end, size_t sum_size, size_t size_prev_at_left, const SimpleMergeSelector::Settings & settings)
     {
+        if (settings.enable_heuristic_to_remove_small_parts_at_right)
+            while (end >= begin + 3 && (end - 1)->size < settings.heuristic_to_remove_small_parts_at_right_max_ratio * sum_size)
+                --end;
+
         double current_score = score(end - begin, sum_size, settings.size_fixed_cost_to_add);
 
         if (settings.enable_heuristic_to_align_parts
@@ -55,10 +59,6 @@ public:
                 current_score *= interpolateLinear(settings.heuristic_to_align_parts_max_score_adjustment, 1,
                     difference / settings.heuristic_to_align_parts_max_absolute_difference_in_powers_of_two);
         }
-
-        if (settings.enable_heuristic_to_remove_small_parts_at_right)
-            while (end >= begin + 3 && (end - 1)->size < settings.heuristic_to_remove_small_parts_at_right_max_ratio * sum_size)
-                --end;
 
         ranges.emplace_back(range_it, begin, end, sum_size, current_score);
     }


### PR DESCRIPTION
This works better for this scenario:

```
(echo "4106250 4106250"; clickhouse local -q "select 12719 from numbers(200)") | ./src/Storages/examples/merge_selector
```

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
After this patch, heuristic `to_remove_small_parts_at_right` will be executed before the calculation of the merge range score. Before that, the merge selector was choosing the wide merge, and after that, it filtered its suffix. Fixes: https://github.com/ClickHouse/ClickHouse/issues/85374
