### PR TITLE
Nth attempt to fix having zero bytes cache error

### DIFF
--- a/src/Disks/IO/AsynchronousBoundedReadBuffer.h
+++ b/src/Disks/IO/AsynchronousBoundedReadBuffer.h
@@ -50,6 +50,9 @@ public:
 
     off_t getPosition() override { return file_offset_of_buffer_end - available() + bytes_to_ignore; }
 
+    /// Used only for unit test.
+    const ImplPtr & getImpl() { return impl; }
+
 private:
     const ImplPtr impl;
     const ReadSettings read_settings;

--- a/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
+++ b/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
@@ -1048,7 +1048,9 @@ bool CachedOnDiskReadBufferFromFile::nextImplStep()
         bool download_current_segment_succeeded = false;
         if (download_current_segment)
         {
-            chassert(file_offset_of_buffer_end + size - 1 <= file_segment.range().right);
+            chassert(
+                file_offset_of_buffer_end + size - 1 <= file_segment.range().right,
+                fmt::format("Offset: {}, size: {}, file segment range: {}, impl offset: {}", file_offset_of_buffer_end, size, file_segment.range().toString(), implementation_buffer->getPosition()));
 
             std::string failure_reason;
             bool success = file_segment.reserve(size, settings.filesystem_cache_reserve_space_wait_lock_timeout_milliseconds, failure_reason);

--- a/src/IO/ReadBufferFromS3.cpp
+++ b/src/IO/ReadBufferFromS3.cpp
@@ -203,7 +203,6 @@ bool ReadBufferFromS3::nextImpl()
 
     ProfileEvents::increment(ProfileEvents::ReadBufferFromS3Bytes, working_buffer.size());
     offset += working_buffer.size();
-    chassert(offset <= read_until_position);
 
     // release result if possible to free pooled HTTP session for better reuse
     bool is_read_until_position = read_until_position && read_until_position == offset;

--- a/src/IO/ReadBufferFromS3.cpp
+++ b/src/IO/ReadBufferFromS3.cpp
@@ -140,7 +140,7 @@ bool ReadBufferFromS3::nextImpl()
             */
             impl->position() = position();
         }
-        assert(!impl->hasPendingData());
+        chassert(!impl->hasPendingData());
     }
 
     bool next_result = false;

--- a/src/IO/ReadBufferFromS3.cpp
+++ b/src/IO/ReadBufferFromS3.cpp
@@ -112,7 +112,10 @@ bool ReadBufferFromS3::nextImpl()
                     log, "Impl was released, but expected read range is not finished. "
                     "Current offset: {}, end offset: {}", offset.load(), read_until_position.load());
             }
-            stop_reason = fmt::format("Connection was released (read offset: {}/{})", offset.load(), read_until_position.load());
+            stop_reason = fmt::format(
+                "Connection was released (read offset: {}/{}, release reason: {})",
+                offset.load(), read_until_position.load(), release_reason);
+
             return false;
         }
 
@@ -136,8 +139,8 @@ bool ReadBufferFromS3::nextImpl()
             * sure there is no pending data which was not read.
             */
             impl->position() = position();
-            assert(!impl->hasPendingData());
         }
+        assert(!impl->hasPendingData());
     }
 
     bool next_result = false;
@@ -189,9 +192,10 @@ bool ReadBufferFromS3::nextImpl()
     if (!next_result)
     {
         read_all_range_successfully = true;
+        stop_reason = fmt::format("EOF (read offset: {}/{})", offset.load(), read_until_position.load());
+        release_reason = stop_reason;
         // release result to free pooled HTTP session for reuse
         impl->releaseResult();
-        stop_reason = fmt::format("EOF (read offset: {}/{})", offset.load(), read_until_position.load());
         return false;
     }
 
@@ -199,11 +203,19 @@ bool ReadBufferFromS3::nextImpl()
 
     ProfileEvents::increment(ProfileEvents::ReadBufferFromS3Bytes, working_buffer.size());
     offset += working_buffer.size();
+    chassert(offset <= read_until_position);
 
     // release result if possible to free pooled HTTP session for better reuse
     bool is_read_until_position = read_until_position && read_until_position == offset;
-    if (impl->isStreamEof() || is_read_until_position)
+    const bool stream_eof = impl->isStreamEof();
+    if (stream_eof || is_read_until_position)
+    {
+        release_reason = fmt::format(
+            "{} ({}/{})", stream_eof ? "stream EOF" : "read until position reached",
+            offset.load(), read_until_position.load());
+
         impl->releaseResult();
+    }
 
     stop_reason = "";
     return true;
@@ -311,6 +323,10 @@ off_t ReadBufferFromS3::seek(off_t offset_, int whence)
     if (offset_ < 0)
         throw Exception(ErrorCodes::SEEK_POSITION_OUT_OF_BOUND, "Seek position is out of bounds. Offset: {}", offset_);
 
+    LOG_TEST(
+        log, "Seek to {} (restricted seek: {}, impl: {}, working_buffer size: {})",
+        offset_, restricted_seek, bool(impl), working_buffer.size());
+
     if (!restricted_seek)
     {
         if (!working_buffer.empty()
@@ -414,6 +430,7 @@ bool ReadBufferFromS3::atEndOfRequestedRangeGuess()
 std::unique_ptr<S3::ReadBufferFromGetObjectResult> ReadBufferFromS3::initialize(size_t attempt)
 {
     stop_reason = "";
+    release_reason = "";
     read_all_range_successfully = false;
 
     /**
@@ -423,7 +440,8 @@ std::unique_ptr<S3::ReadBufferFromGetObjectResult> ReadBufferFromS3::initialize(
     if (read_until_position && offset >= read_until_position)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Attempt to read beyond right offset ({} > {})", offset.load(), read_until_position - 1);
 
-    auto read_result = sendRequest(attempt, offset, read_until_position ? std::make_optional(read_until_position - 1) : std::nullopt);
+    const auto right_offset = read_until_position ? std::make_optional(read_until_position - 1) : std::nullopt;
+    auto read_result = sendRequest(attempt, offset, right_offset);
 
     size_t buffer_size = use_external_buffer ? 0 : read_settings.remote_fs_buffer_size;
     return std::make_unique<S3::ReadBufferFromGetObjectResult>(std::move(read_result), buffer_size);

--- a/src/IO/ReadBufferFromS3.h
+++ b/src/IO/ReadBufferFromS3.h
@@ -35,6 +35,7 @@ private:
     std::atomic<off_t> offset = 0;
     std::atomic<off_t> read_until_position = 0;
     std::string stop_reason;
+    std::string release_reason;
 
     std::unique_ptr<S3::ReadBufferFromGetObjectResult> impl;
 

--- a/src/IO/ReadSettings.cpp
+++ b/src/IO/ReadSettings.cpp
@@ -47,10 +47,11 @@ ReadSettings ReadSettings::adjustBufferSize(size_t file_size) const
     return res;
 }
 
-ReadSettings ReadSettings::withNestedBuffer() const
+ReadSettings ReadSettings::withNestedBuffer(bool seekable) const
 {
     ReadSettings res = *this;
-    res.remote_read_buffer_restrict_seek = true;
+    if (!seekable)
+        res.remote_read_buffer_restrict_seek = true;
     res.remote_read_buffer_use_external_buffer = true;
     return res;
 }

--- a/src/IO/ReadSettings.h
+++ b/src/IO/ReadSettings.h
@@ -95,7 +95,7 @@ struct ReadSettings
     bool enable_hdfs_pread = true;
 
     ReadSettings adjustBufferSize(size_t file_size) const;
-    ReadSettings withNestedBuffer() const;
+    ReadSettings withNestedBuffer(bool seekable = false) const;
 };
 
 ReadSettings getReadSettings();

--- a/src/IO/tests/gtest_readbuffer_s3.cpp
+++ b/src/IO/tests/gtest_readbuffer_s3.cpp
@@ -5,8 +5,72 @@
 
 #if USE_AWS_S3
 
+#include <Core/ServerUUID.h>
 #include <IO/ReadBufferFromS3.h>
 #include <Poco/Net/HTTPBasicStreamBuf.h>
+#include <Storages/ObjectStorage/StorageObjectStorageSource.h>
+#include <Storages/ObjectStorage/Utils.h>
+#include <Disks/ObjectStorages/S3/S3ObjectStorage.h>
+#include <Disks/IO/AsynchronousBoundedReadBuffer.h>
+#include <Disks/IO/CachedOnDiskReadBufferFromFile.h>
+#include <Interpreters/Cache/FileCache.h>
+#include <Interpreters/Cache/FileCacheFactory.h>
+#include <Common/tests/gtest_global_context.h>
+#include <Common/Priority.h>
+#include <Poco/ConsoleChannel.h>
+#include <Core/Settings.h>
+
+static constexpr auto TEST_LOG_LEVEL = "debug";
+static fs::path caches_dir = fs::current_path() / "readbuffer_s3";
+static std::string cache_base_path = caches_dir / "cache1" / "";
+
+namespace DB::Setting
+{
+    extern const SettingsUInt64 max_read_buffer_size_remote_fs;
+    extern const SettingsString filesystem_cache_name;
+    extern const SettingsBool filesystem_cache_prefer_bigger_buffer_size;
+    extern const SettingsBool read_from_filesystem_cache_if_exists_otherwise_bypass_cache;
+    extern const SettingsUInt64 remote_read_min_bytes_for_seek;
+}
+
+namespace DB::FileCacheSetting
+{
+    extern const FileCacheSettingsString path;
+    extern const FileCacheSettingsUInt64 max_size;
+    extern const FileCacheSettingsUInt64 max_elements;
+    extern const FileCacheSettingsUInt64 max_file_segment_size;
+    extern const FileCacheSettingsUInt64 boundary_alignment;
+    extern const FileCacheSettingsUInt64 background_download_threads;
+}
+
+class ReadBufferFromS3Test : public ::testing::Test
+{
+public:
+    static void setupLogs(const std::string & level)
+    {
+        Poco::AutoPtr<Poco::ConsoleChannel> channel(new Poco::ConsoleChannel(std::cerr));
+        Poco::Logger::root().setChannel(channel);
+        Poco::Logger::root().setLevel(level);
+    }
+
+    void SetUp() override
+    {
+        if (const char * test_log_level = std::getenv("TEST_LOG_LEVEL")) // NOLINT(concurrency-mt-unsafe)
+            setupLogs(test_log_level);
+        else
+            setupLogs(TEST_LOG_LEVEL);
+
+        if (fs::exists(cache_base_path))
+            fs::remove_all(cache_base_path);
+        fs::create_directories(cache_base_path);
+    }
+
+    void TearDown() override
+    {
+        if (fs::exists(cache_base_path))
+            fs::remove_all(cache_base_path);
+    }
+};
 
 class CountedSession
 {
@@ -101,12 +165,12 @@ static void readAndAssert(DB::ReadBuffer & buf, const char * str)
     ASSERT_EQ(strncmp(tmp.data(), str, n), 0);
 }
 
-TEST(ReadBufferFromS3Test, RetainsSessionWhenPending)
+TEST_F(ReadBufferFromS3Test, RetainsSessionWhenPending)
 {
     const auto client = std::make_shared<ClientFake>();
-    DB::ReadSettings readSettings;
-    readSettings.remote_fs_buffer_size = 2;
-    auto subject = DB::ReadBufferFromS3(client, "test_bucket", "test_key", "test_version_id", DB::S3::S3RequestSettings(), readSettings);
+    DB::ReadSettings read_settings;
+    read_settings.remote_fs_buffer_size = 2;
+    auto subject = DB::ReadBufferFromS3(client, "test_bucket", "test_key", "test_version_id", DB::S3::S3RequestSettings(), read_settings);
 
     auto session = std::make_shared<CountedSession>();
     auto stream_buf = std::make_shared<StringHTTPBasicStreamBuf>("123456789");
@@ -121,12 +185,12 @@ TEST(ReadBufferFromS3Test, RetainsSessionWhenPending)
     ASSERT_EQ(CountedSession::OustandingObjects(), 1);
 }
 
-TEST(ReadBufferFromS3Test, ReleaseSessionWhenStreamEof)
+TEST_F(ReadBufferFromS3Test, ReleaseSessionWhenStreamEof)
 {
     const auto client = std::make_shared<ClientFake>();
-    DB::ReadSettings readSettings;
-    readSettings.remote_fs_buffer_size = 10;
-    auto subject = DB::ReadBufferFromS3(client, "test_bucket", "test_key", "test_version_id", DB::S3::S3RequestSettings(), readSettings);
+    DB::ReadSettings read_settings;
+    read_settings.remote_fs_buffer_size = 10;
+    auto subject = DB::ReadBufferFromS3(client, "test_bucket", "test_key", "test_version_id", DB::S3::S3RequestSettings(), read_settings);
 
     auto session = std::make_shared<CountedSession>();
     const auto stream_buf = std::make_shared<StringHTTPBasicStreamBuf>("1234");
@@ -141,12 +205,12 @@ TEST(ReadBufferFromS3Test, ReleaseSessionWhenStreamEof)
     ASSERT_FALSE(subject.nextImpl());
 }
 
-TEST(ReadBufferFromS3Test, ReleaseSessionWhenReadUntilPosition)
+TEST_F(ReadBufferFromS3Test, ReleaseSessionWhenReadUntilPosition)
 {
     const auto client = std::make_shared<ClientFake>();
-    DB::ReadSettings readSettings;
-    readSettings.remote_fs_buffer_size = 2;
-    auto subject = DB::ReadBufferFromS3(client, "test_bucket", "test_key", "test_version_id", DB::S3::S3RequestSettings(), readSettings);
+    DB::ReadSettings read_settings;
+    read_settings.remote_fs_buffer_size = 2;
+    auto subject = DB::ReadBufferFromS3(client, "test_bucket", "test_key", "test_version_id", DB::S3::S3RequestSettings(), read_settings);
 
     auto session = std::make_shared<CountedSession>();
     const auto stream_buf = std::make_shared<StringHTTPBasicStreamBuf>("123456");
@@ -162,4 +226,77 @@ TEST(ReadBufferFromS3Test, ReleaseSessionWhenReadUntilPosition)
     ASSERT_FALSE(subject.nextImpl());
 }
 
+TEST_F(ReadBufferFromS3Test, HavingZeroBytes)
+{
+    /// This test fails to reproduce "Having zero bytes..." exception,
+    /// but let's leave it here anyway as an example how to write tests with S3 engine source reader with enabled cache,
+    /// as it takes time to set up.
+
+    DB::ServerUUID::setRandomForUnitTests();
+    auto query_context = DB::Context::createCopy(getContext().context);
+    query_context->makeQueryContext();
+    std::string query_id = "query_id";
+    query_context->setCurrentQueryId(query_id);
+    const auto & settings = query_context->getSettingsRef();
+    const_cast<DB::Settings &>(settings)[DB::Setting::max_read_buffer_size_remote_fs] = 4;
+    const_cast<DB::Settings &>(settings)[DB::Setting::filesystem_cache_name] = "cache1";
+    const_cast<DB::Settings &>(settings)[DB::Setting::filesystem_cache_prefer_bigger_buffer_size] = false;
+    //const_cast<DB::Settings &>(settings)[DB::Setting::read_from_filesystem_cache_if_exists_otherwise_bypass_cache] = true;
+    const_cast<DB::Settings &>(settings)[DB::Setting::remote_read_min_bytes_for_seek] = 0;
+
+    DB::FileCacheSettings cache_settings;
+    cache_settings[DB::FileCacheSetting::path] = cache_base_path;
+    cache_settings[DB::FileCacheSetting::max_size] = 100;
+    cache_settings[DB::FileCacheSetting::max_elements] = 5;
+    cache_settings[DB::FileCacheSetting::boundary_alignment] = 5;
+    cache_settings[DB::FileCacheSetting::max_file_segment_size] = 100;
+    cache_settings[DB::FileCacheSetting::background_download_threads] = 0;
+    auto cache = DB::FileCacheFactory::instance().getOrCreate("cache1", cache_settings, "");
+    cache->initialize();
+    cache.reset();
+
+    std::unique_ptr<DB::S3::Client> client = std::make_unique<ClientFake>();
+    DB::S3::URI uri;
+    uri.bucket = "test_bucket";
+    DB::S3Capabilities cap;
+    String disk_name = "s3";
+    DB::ObjectStorageKeysGeneratorPtr gen;
+    auto object_storage = std::make_shared<DB::S3ObjectStorage>(
+        std::move(client), std::make_unique<DB::S3Settings>(), std::move(uri), cap, gen, disk_name);
+
+    auto log = getLogger("test");
+    DB::ObjectMetadata object_metadata;
+    std::string data = "12345678901234567890";
+    object_metadata.size_bytes = data.size();
+    object_metadata.etag = "tag1";
+    DB::ObjectInfo object("test_key", object_metadata);
+    auto buf = DB::createReadBuffer(object, object_storage, query_context, log);
+
+    auto session = std::make_shared<CountedSession>();
+    const auto stream_buf = std::make_shared<StringHTTPBasicStreamBuf>(data);
+    auto storage_client = object_storage->getS3StorageClient();
+    dynamic_cast<ClientFake *>(const_cast<DB::S3::Client *>(storage_client.get()))->setGetObjectSuccess(session, stream_buf.get());
+
+    auto * async_buf = dynamic_cast<DB::AsynchronousBoundedReadBuffer *>(buf.get());
+    auto * cached_buf = dynamic_cast<DB::CachedOnDiskReadBufferFromFile *>(async_buf->getImpl().get());
+    ASSERT_TRUE(async_buf);
+    ASSERT_TRUE(cached_buf);
+
+    async_buf->prefetch(Priority{0});
+    async_buf->next();
+    ASSERT_EQ(async_buf->available(), 4);
+    async_buf->position() = async_buf->buffer().end();
+    async_buf->prefetch(Priority{0});
+    async_buf->seek(16, SEEK_SET);
+    ASSERT_EQ(async_buf->available(), 0);
+    async_buf->prefetch(Priority{0});
+    async_buf->next();
+    ASSERT_EQ(async_buf->available(), 4);
+    async_buf->position() = async_buf->buffer().end();
+    async_buf->prefetch(Priority{0});
+    async_buf->next();
+    ASSERT_EQ(async_buf->available(), 0);
+
+    DB::FileCacheFactory::instance().clear();
+}
 #endif

--- a/src/Interpreters/Cache/FileSegment.cpp
+++ b/src/Interpreters/Cache/FileSegment.cpp
@@ -677,8 +677,7 @@ void FileSegment::shrinkFileSegmentToDownloadedSize(const LockedKey & locked_key
     if (!force_shrink_to_downloaded_size)
     {
         size_t aligned_downloaded_size = FileCacheUtils::roundUpToMultiple(downloaded_size, cache->getBoundaryAlignment());
-        if (aligned_downloaded_size <= range().size())
-            result_size = aligned_downloaded_size;
+        result_size = std::min(aligned_downloaded_size, range().size());
     }
 
     chassert(result_size <= range().size());


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Nth attempt to fix "having zero bytes error" with s3 table engine with enabled cache.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
