### PR TITLE
Startup clickhouse-keeper on boot

### DIFF
--- a/packages/clickhouse-keeper.postinstall
+++ b/packages/clickhouse-keeper.postinstall
@@ -28,6 +28,25 @@ if [ "$1" = configure ] || [ -n "$not_deb_os" ]; then
             "${KEEPER_USER}"
     fi
 
+    if [ -x "/bin/systemctl" ] && [ -f /lib/systemd/system/clickhouse-keeper.service ] && [ -d /run/systemd/system ]; then
+        # if old rc.d service present - remove it
+        if [ -x "/etc/init.d/clickhouse-keeper" ] && [ -x "/usr/sbin/update-rc.d" ]; then
+            /usr/sbin/update-rc.d clickhouse-keeper remove
+        fi
+
+        /bin/systemctl daemon-reload
+        /bin/systemctl enable clickhouse-keeper
+    else
+        # If you downgrading to version older than 1.1.54336 run: systemctl disable clickhouse-keeper
+        if [ -x "/etc/init.d/clickhouse-keeper" ]; then
+            if [ -x "/usr/sbin/update-rc.d" ]; then
+                /usr/sbin/update-rc.d clickhouse-keeper defaults 19 19 >/dev/null || exit $?
+            else
+                echo # Other OS
+            fi
+        fi
+    fi
+
     chown -R "${KEEPER_USER}:${KEEPER_GROUP}" "${KEEPER_CONFDIR}"
     chmod 0755 "${KEEPER_CONFDIR}"
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add a step to postinstall script for `clickhouse-keeper` which enables starting on boot.

After running the ClickHouse service installed via rpm for more than two months, the server lost power. I found that clickhouse-server can automatically start at boot, but clickhouse-keeper does not. Comparing the rpm build files of server and keeper, I noticed that the postinstall script for keeper does not include a startup script for boot. I think it should be added.
