### PR TITLE
Check credentials in the Web UI only on pasting

### DIFF
--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -1044,8 +1044,18 @@ function checkCredentials() {
     });
 }
 
-user_elem.addEventListener('input', checkCredentials);
-password_elem.addEventListener('input', checkCredentials);
+function resetCredentialsStatus() {
+    [user_elem, password_elem].forEach(e => { e.classList.remove('ok'); e.classList.remove('fail'); });
+}
+
+user_elem.addEventListener('input', resetCredentialsStatus);
+password_elem.addEventListener('input', resetCredentialsStatus);
+
+/// The password is usually copy-pasted.
+/// To not worry about extracting the clipboard data, but use the value instead,
+/// and not worry too much about input/paste race, add the timeout.
+user_elem.addEventListener('paste', () => setTimeout(checkCredentials, 100));
+password_elem.addEventListener('paste', () => setTimeout(checkCredentials, 100));
 
 
 function queryToColor(str) {


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Check credentials in the Web UI only on pasting, rather than on every key press. This avoids a problem with misconfigured LDAP servers. This closes #85777.