### PR TITLE
Add setting into_outfile_create_parent_directories to automatically create parent directories for INTO OUTFILE

### DIFF
--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -128,6 +128,7 @@ namespace Setting
     extern const SettingsString promql_database;
     extern const SettingsString promql_table;
     extern const SettingsFloatAuto promql_evaluation_time;
+    extern const SettingsBool into_outfile_create_parent_directories;
 }
 
 namespace ErrorCodes
@@ -150,6 +151,7 @@ namespace ErrorCodes
     extern const int USER_EXPIRED;
     extern const int SUPPORT_IS_DISABLED;
     extern const int CANNOT_WRITE_TO_FILE;
+    extern const int CANNOT_CREATE_DIRECTORY;
 }
 
 }
@@ -1193,6 +1195,28 @@ void ClientBase::processOrdinaryQuery(String query, ASTPtr parsed_query)
             {
                 out_file_if_truncated = out_file;
                 out_file = fmt::format("tmp_{}.{}", UUIDHelpers::generateV4(), out_file);
+            }
+
+            if (client_context->getSettingsRef()[Setting::into_outfile_create_parent_directories])
+            {
+                fs::path file_path(out_file);
+                fs::path parent_dir = file_path.parent_path();
+
+                if (!parent_dir.empty() && !fs::exists(parent_dir))
+                {
+                    try
+                    {
+                        fs::create_directories(parent_dir);
+                    }
+                    catch (const fs::filesystem_error & e)
+                    {
+                        throw Exception(
+                            ErrorCodes::CANNOT_CREATE_DIRECTORY,
+                            "Cannot create parent directories for INTO OUTFILE '{}': {}",
+                            parent_dir.string(),
+                            e.what());
+                    }
+                }
             }
 
             std::string compression_method_string;

--- a/src/Core/FormatFactorySettings.h
+++ b/src/Core/FormatFactorySettings.h
@@ -1465,6 +1465,9 @@ Use geo column parser to convert Array(UInt8) into Point/Linestring/Polygon/Mult
     DECLARE(Bool, output_format_parquet_geometadata, true, R"(
 Allow to write information about geo columns in parquet metadata and encode columns in WKB format.
 )", 0) \
+    DECLARE(Bool, into_outfile_create_parent_directories, false, R"(
+Automatically create parent directories when using INTO OUTFILE if they do not already exists.
+)", 0) \
 
 
 // End of FORMAT_FACTORY_SETTINGS

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -41,6 +41,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
         /// Note: please check if the key already exists to prevent duplicate entries.
         addSettingsChanges(settings_changes_history, "25.11",
         {
+            {"into_outfile_create_parent_directories", false, false, "New setting"},
             {"correlated_subqueries_default_join_kind", "left", "right", "New setting. Default join kind for decorrelated query plan."},
             {"use_statistics_cache", 0, 0, "New setting"},
         });

--- a/src/Formats/FormatFactory.cpp
+++ b/src/Formats/FormatFactory.cpp
@@ -288,6 +288,7 @@ FormatSettings getFormatSettings(const ContextPtr & context, const Settings & se
     format_settings.with_names_use_header = settings[Setting::input_format_with_names_use_header];
     format_settings.with_types_use_header = settings[Setting::input_format_with_types_use_header];
     format_settings.write_statistics = settings[Setting::output_format_write_statistics];
+    format_settings.into_outfile_create_parent_directories = settings[Setting::into_outfile_create_parent_directories];
     format_settings.arrow.low_cardinality_as_dictionary = settings[Setting::output_format_arrow_low_cardinality_as_dictionary];
     format_settings.arrow.use_signed_indexes_for_dictionary = settings[Setting::output_format_arrow_use_signed_indexes_for_dictionary];
     format_settings.arrow.use_64_bit_indexes_for_dictionary = settings[Setting::output_format_arrow_use_64_bit_indexes_for_dictionary];

--- a/src/Formats/FormatSettings.h
+++ b/src/Formats/FormatSettings.h
@@ -25,6 +25,7 @@ struct FormatSettings
     bool with_names_use_header = false;
     bool with_types_use_header = false;
     bool write_statistics = true;
+    bool into_outfile_create_parent_directories = false;
     bool import_nested_json = false;
     bool null_as_default = true;
     bool force_null_for_omitted_fields = false;

--- a/tests/queries/0_stateless/03669_into_outfile_create_parent_directories.sh
+++ b/tests/queries/0_stateless/03669_into_outfile_create_parent_directories.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. "$CUR_DIR"/../shell_config.sh
+
+BASE_DIR="${CUR_DIR}/${CLICKHOUSE_TEST_UNIQUE_NAME}"
+CLIENT_OUTDIR="${BASE_DIR}/client"
+
+rm -rf "$BASE_DIR" 2>/dev/null || true
+
+$CLICKHOUSE_CLIENT -q "
+DROP TABLE IF EXISTS test_outfile;
+CREATE TABLE test_outfile (id UInt32, value String) ENGINE = Memory;
+INSERT INTO test_outfile VALUES (1, 'test1'), (2, 'test2'), (3, 'test3');
+SET into_outfile_create_parent_directories = 1;
+
+SELECT * FROM test_outfile INTO OUTFILE '${CLIENT_OUTDIR}/level1/level2/output.csv' FORMAT CSV;
+SELECT * FROM test_outfile INTO OUTFILE '${CLIENT_OUTDIR}/a/b/c/d/output.tsv' FORMAT TSV;
+SELECT * FROM test_outfile INTO OUTFILE '${CLIENT_OUTDIR}/compressed/output.csv.gz' COMPRESSION 'gzip' FORMAT CSV;
+SELECT * FROM test_outfile INTO OUTFILE '${CLIENT_OUTDIR}/formats/output.json' FORMAT JSONEachRow;
+SELECT * FROM test_outfile WHERE id > 100 INTO OUTFILE '${CLIENT_OUTDIR}/empty/output.csv' FORMAT CSV;
+SELECT id, value, length(value) AS len FROM test_outfile ORDER BY id
+INTO OUTFILE '${CLIENT_OUTDIR}/complex/output.csv' FORMAT CSV;
+SELECT * FROM test_outfile INTO OUTFILE '${CLIENT_OUTDIR}/level1/../level1_sibling/output.csv' FORMAT CSV;
+
+DROP TABLE test_outfile;
+"
+
+rm -rf "$BASE_DIR" 2>/dev/null || true


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):
- New Feature

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):

Add setting into_outfile_create_parent_directories to automatically create parent directories for INTO OUTFILE, preventing errors when output paths do not exist. This simplifies workflows where queries write results to nested directories. Resolves #88610

### Documentation entry for user-facing changes

When enabled, ClickHouse will automatically create any missing parent directories for the output file path when using INTO OUTFILE. This prevents errors if the directories in the path do not exist and simplifies automated export workflows.

Motivation: ClickHouse previously required parent directories of output files to exist before using INTO OUTFILE. This new setting allows automatic creation of missing directories, improving usability in automated export pipelines.

Parameters: into_outfile_create_parent_directories (Boolean). Default: false. When set to true, ClickHouse will create all missing parent directories for the output file path before writing results.

Example use:

```sql
SET into_outfile_create_parent_directories = 1;

SELECT *
FROM system.numbers
LIMIT 5
INTO OUTFILE '/tmp/output/new_dir/result.csv'
FORMAT CSV;
```
