### PR TITLE
Fix incorrect min(PK)/max(PK) result when PK is in reverse order.

### DIFF
--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -1306,9 +1306,8 @@ void AlterCommands::apply(StorageInMemoryMetadata & metadata, ContextPtr context
             auto minmax_columns = metadata_copy.getColumnsRequiredForPartitionKey();
             auto partition_key = metadata_copy.partition_key.expression_list_ast->clone();
             FunctionNameNormalizer::visit(partition_key.get());
-            auto primary_key_asts = metadata_copy.primary_key.expression_list_ast->children;
             metadata_copy.minmax_count_projection.emplace(ProjectionDescription::getMinMaxCountProjection(
-                metadata_copy.columns, partition_key, minmax_columns, primary_key_asts, context));
+                metadata_copy.columns, partition_key, minmax_columns, metadata_copy.primary_key, context));
         }
     }
 

--- a/src/Storages/MergeTree/registerStorageMergeTree.cpp
+++ b/src/Storages/MergeTree/registerStorageMergeTree.cpp
@@ -695,9 +695,8 @@ static StoragePtr create(const StorageFactory::Arguments & args)
         auto minmax_columns = metadata.getColumnsRequiredForPartitionKey();
         auto partition_key = metadata.partition_key.expression_list_ast->clone();
         FunctionNameNormalizer::visit(partition_key.get());
-        auto primary_key_asts = metadata.primary_key.expression_list_ast->children;
         metadata.minmax_count_projection.emplace(ProjectionDescription::getMinMaxCountProjection(
-            columns, partition_key, minmax_columns, primary_key_asts, context));
+            columns, partition_key, minmax_columns, metadata.primary_key, context));
 
         if (args.storage_def->sample_by)
             metadata.sampling_key = KeyDescription::getKeyFromAST(args.storage_def->sample_by->ptr(), metadata.columns, context);
@@ -832,9 +831,8 @@ static StoragePtr create(const StorageFactory::Arguments & args)
         auto minmax_columns = metadata.getColumnsRequiredForPartitionKey();
         auto partition_key = metadata.partition_key.expression_list_ast->clone();
         FunctionNameNormalizer::visit(partition_key.get());
-        auto primary_key_asts = metadata.primary_key.expression_list_ast->children;
         metadata.minmax_count_projection.emplace(ProjectionDescription::getMinMaxCountProjection(
-            columns, partition_key, minmax_columns, primary_key_asts, context));
+            columns, partition_key, minmax_columns, metadata.primary_key, context));
 
         const auto * ast = engine_args[arg_num]->as<ASTLiteral>();
         if (ast && ast->value.getType() == Field::Types::UInt64)

--- a/src/Storages/ProjectionsDescription.cpp
+++ b/src/Storages/ProjectionsDescription.cpp
@@ -341,7 +341,7 @@ ProjectionDescription ProjectionDescription::getMinMaxCountProjection(
     const ColumnsDescription & columns,
     ASTPtr partition_columns,
     const Names & minmax_columns,
-    const ASTs & primary_key_asts,
+    const KeyDescription & primary_key,
     ContextPtr query_context)
 {
     ProjectionDescription result;
@@ -353,10 +353,20 @@ ProjectionDescription ProjectionDescription::getMinMaxCountProjection(
         select_expression_list->children.push_back(makeASTFunction("min", std::make_shared<ASTIdentifier>(column)));
         select_expression_list->children.push_back(makeASTFunction("max", std::make_shared<ASTIdentifier>(column)));
     }
+
+    auto primary_key_asts = primary_key.expression_list_ast->children;
     if (!primary_key_asts.empty())
     {
-        select_expression_list->children.push_back(makeASTFunction("min", primary_key_asts.front()->clone()));
-        select_expression_list->children.push_back(makeASTFunction("max", primary_key_asts.front()->clone()));
+        if (!primary_key.reverse_flags.empty() && primary_key.reverse_flags[0])
+        {
+            select_expression_list->children.push_back(makeASTFunction("max", primary_key_asts.front()->clone()));
+            select_expression_list->children.push_back(makeASTFunction("min", primary_key_asts.front()->clone()));
+        }
+        else
+        {
+            select_expression_list->children.push_back(makeASTFunction("min", primary_key_asts.front()->clone()));
+            select_expression_list->children.push_back(makeASTFunction("max", primary_key_asts.front()->clone()));
+        }
     }
     select_expression_list->children.push_back(makeASTFunction("count"));
     select_query->setExpression(ASTProjectionSelectQuery::Expression::SELECT, std::move(select_expression_list));

--- a/src/Storages/ProjectionsDescription.h
+++ b/src/Storages/ProjectionsDescription.h
@@ -20,6 +20,8 @@ using StorageMetadataPtr = std::shared_ptr<const StorageInMemoryMetadata>;
 
 using IColumnPermutation = PaddedPODArray<size_t>;
 
+struct KeyDescription;
+
 /// Description of projections for Storage
 struct ProjectionDescription
 {
@@ -76,7 +78,7 @@ struct ProjectionDescription
         const ColumnsDescription & columns,
         ASTPtr partition_columns,
         const Names & minmax_columns,
-        const ASTs & primary_key_asts,
+        const KeyDescription & primary_key,
         ContextPtr query_context);
 
     ProjectionDescription() = default;

--- a/tests/queries/0_stateless/03669_min_max_projection_with_reverse_order_key.reference
+++ b/tests/queries/0_stateless/03669_min_max_projection_with_reverse_order_key.reference
@@ -1,0 +1,8 @@
+-- { echo ON }
+
+DROP TABLE IF EXISTS desc_pk;
+CREATE TABLE desc_pk (`a` UInt32) ENGINE = MergeTree ORDER BY (a DESC) SETTINGS allow_experimental_reverse_key = 1;
+INSERT INTO desc_pk SELECT * FROM numbers(10);
+SELECT min(a), max(a) FROM desc_pk;
+0	9
+DROP TABLE desc_pk;

--- a/tests/queries/0_stateless/03669_min_max_projection_with_reverse_order_key.sql
+++ b/tests/queries/0_stateless/03669_min_max_projection_with_reverse_order_key.sql
@@ -1,0 +1,11 @@
+-- { echo ON }
+
+DROP TABLE IF EXISTS desc_pk;
+
+CREATE TABLE desc_pk (`a` UInt32) ENGINE = MergeTree ORDER BY (a DESC) SETTINGS allow_experimental_reverse_key = 1;
+
+INSERT INTO desc_pk SELECT * FROM numbers(10);
+
+SELECT min(a), max(a) FROM desc_pk;
+
+DROP TABLE desc_pk;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix incorrect min(PK)/max(PK) result when PK is in reverse order. This fixes #83619.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
