### PR TITLE
Add null check for elem->column

### DIFF
--- a/src/Interpreters/getColumnFromBlock.cpp
+++ b/src/Interpreters/getColumnFromBlock.cpp
@@ -21,9 +21,8 @@ ColumnPtr tryGetColumnFromBlock(const Block & block, const NameAndTypePair & req
     auto elem_type = elem->type;
 
     if (!elem->column)
-    {
         return nullptr;
-    }
+
     auto elem_column = elem->column->decompress();
 
     if (requested_column.isSubcolumn())

--- a/src/Interpreters/getColumnFromBlock.cpp
+++ b/src/Interpreters/getColumnFromBlock.cpp
@@ -19,6 +19,11 @@ ColumnPtr tryGetColumnFromBlock(const Block & block, const NameAndTypePair & req
         return nullptr;
 
     auto elem_type = elem->type;
+
+    if (!elem->column)
+    {
+        return nullptr;
+    }
     auto elem_column = elem->column->decompress();
 
     if (requested_column.isSubcolumn())


### PR DESCRIPTION
Add null check for column in getColumnFromBlock function

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
