### PR TITLE
add lock in commit part

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -2488,7 +2488,11 @@ try
                 auto part_lock = lockParts();
                 Transaction transaction(*this, nullptr);
                 preparePartForCommit(res.part, transaction, part_lock, false, false);
+<<<<<<< HEAD
                 transaction.commit();
+=======
+                transaction.commit(&part_lock);
+>>>>>>> 9ab8c0bd58f (fix lock)
             }
 
             bool is_adaptive = res.part->index_granularity_info.mark_type.adaptive;

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -2484,9 +2484,12 @@ try
         }
         else
         {
-            Transaction transaction(*this, nullptr);
-            preparePartForCommit(res.part, transaction, part_lock, false, false);
-            transaction.commit();
+            {
+                auto part_lock = lockParts();
+                Transaction transaction(*this, nullptr);
+                preparePartForCommit(res.part, transaction, part_lock, false, false);
+                transaction.commit();
+            }
 
             bool is_adaptive = res.part->index_granularity_info.mark_type.adaptive;
             have_non_adaptive_parts |= !is_adaptive;

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -2485,7 +2485,7 @@ try
         else
         {
             Transaction transaction(*this, nullptr);
-            preparePartForCommit(res.part, transaction, false, false);
+            preparePartForCommit(res.part, transaction, part_lock, false, false);
             transaction.commit();
 
             bool is_adaptive = res.part->index_granularity_info.mark_type.adaptive;
@@ -4774,7 +4774,7 @@ void MergeTreeData::checkPartDynamicColumns(MutableDataPartPtr & part, DataParts
     }
 }
 
-void MergeTreeData::preparePartForCommit(MutableDataPartPtr & part, Transaction & out_transaction, bool need_rename, bool rename_in_transaction)
+void MergeTreeData::preparePartForCommit(MutableDataPartPtr & part, Transaction & out_transaction, DataPartsLock & /*lock*/, bool need_rename, bool rename_in_transaction)
 {
     part->is_temp = false;
     part->setState(DataPartState::PreActive);
@@ -4826,7 +4826,7 @@ bool MergeTreeData::addTempPart(
 
     /// All checks are passed. Now we can rename the part on disk.
     /// So, we maintain invariant: if a non-temporary part in filesystem then it is in data_parts
-    preparePartForCommit(part, out_transaction, /* need_rename = */false);
+    preparePartForCommit(part, out_transaction, lock, /* need_rename = */false);
 
     if (out_covered_parts)
     {
@@ -4884,7 +4884,7 @@ bool MergeTreeData::renameTempPartAndReplaceImpl(
 
     /// All checks are passed. Now we can rename the part on disk.
     /// So, we maintain invariant: if a non-temporary part in filesystem then it is in data_parts
-    preparePartForCommit(part, out_transaction, /* need_rename= */ true, rename_in_transaction);
+    preparePartForCommit(part, out_transaction, lock, /* need_rename= */ true, rename_in_transaction);
 
     if (out_covered_parts)
     {

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -2484,15 +2484,11 @@ try
         }
         else
         {
+            Transaction transaction(*this, nullptr);
             {
                 auto part_lock = lockParts();
-                Transaction transaction(*this, nullptr);
                 preparePartForCommit(res.part, transaction, part_lock, false, false);
-<<<<<<< HEAD
-                transaction.commit();
-=======
                 transaction.commit(&part_lock);
->>>>>>> 9ab8c0bd58f (fix lock)
             }
 
             bool is_adaptive = res.part->index_granularity_info.mark_type.adaptive;

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -1793,7 +1793,7 @@ private:
     ///
     /// @param need_rename - rename the part
     /// @param rename_in_transaction - if set, the rename will be done as part of transaction (without holding DataPartsLock), otherwise inplace (when it does not make sense).
-    void preparePartForCommit(MutableDataPartPtr & part, Transaction & out_transaction, bool need_rename, bool rename_in_transaction = false);
+    void preparePartForCommit(MutableDataPartPtr & part, Transaction & out_transaction, DataPartsLock & lock, bool need_rename, bool rename_in_transaction = false);
 
     /// Low-level method for preparing parts for commit (in-memory).
     /// FIXME Merge MergeTreeTransaction and Transaction


### PR DESCRIPTION
Add parameter **DataPartsLock & lock** to the function **preparePartForCommit**

All current callers of this function already acquire the lock before invoking it, so this parameter does not change logic or behavior.
The explicit parameter improves interface clarity and prevents accidental misuse, making lock requirements visible in the API and easier to enforce in future changes.
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)



### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
