### PR TITLE
Catch exceptions when async logging fails to prevent program aborts

### DIFF
--- a/src/Loggers/OwnSplitChannel.cpp
+++ b/src/Loggers/OwnSplitChannel.cpp
@@ -488,20 +488,40 @@ void OwnAsyncSplitChannel::runChannel(size_t i)
 
     while (is_open)
     {
-        log_notification(notification);
-        notification = queues[i]->waitDequeueMessage();
+        try
+        {
+            log_notification(notification);
+            notification = queues[i]->waitDequeueMessage();
+        }
+        catch (...)
+        {
+            const std::string & exception_message = getCurrentExceptionMessage(true);
+            writeRetry(STDERR_FILENO, "Cannot log message in OwnAsyncSplitChannel channel: ");
+            writeRetry(STDERR_FILENO, exception_message.data(), exception_message.size());
+            writeRetry(STDERR_FILENO, "\n");
+        }
     }
 
-    /// Flush everything before closing
-    log_notification(notification);
-
-    /// We want to process only what's currently in the queue and not block other logging
-    auto queue = queues[i]->getCurrentQueueAndClear();
-    while (!queue.empty())
+    try
     {
-        notification = queue.front();
-        queue.pop_front();
+        /// Flush everything before closing
         log_notification(notification);
+
+        /// We want to process only what's currently in the queue and not block other logging
+        auto queue = queues[i]->getCurrentQueueAndClear();
+        while (!queue.empty())
+        {
+            notification = queue.front();
+            queue.pop_front();
+            log_notification(notification);
+        }
+    }
+    catch (...)
+    {
+        const std::string & exception_message = getCurrentExceptionMessage(true);
+        writeRetry(STDERR_FILENO, "Cannot flush messages in OwnAsyncSplitChannel channel: ");
+        writeRetry(STDERR_FILENO, exception_message.data(), exception_message.size());
+        writeRetry(STDERR_FILENO, "\n");
     }
 }
 
@@ -531,40 +551,59 @@ void OwnAsyncSplitChannel::runTextLog()
     auto notification = text_log_queue.waitDequeueMessage();
     while (is_open)
     {
-        if (flush_text_logs)
+        try
         {
-            auto text_log_locked = text_log.lock();
-            if (!text_log_locked)
-                return;
+            if (flush_text_logs)
+            {
+                auto text_log_locked = text_log.lock();
+                if (!text_log_locked)
+                    return;
 
-            if (notification)
+                if (notification)
+                    log_notification(notification, text_log_locked);
+
+                flush_queue(text_log_locked);
+
+                flush_text_logs = false;
+                flush_text_logs.notify_all();
+            }
+            else if (notification)
+            {
+                auto text_log_locked = text_log.lock();
+                if (!text_log_locked)
+                    return;
                 log_notification(notification, text_log_locked);
+            }
 
-            flush_queue(text_log_locked);
-
-            flush_text_logs = false;
-            flush_text_logs.notify_all();
+            notification = text_log_queue.waitDequeueMessage();
         }
-        else if (notification)
+        catch (...)
         {
-            auto text_log_locked = text_log.lock();
-            if (!text_log_locked)
-                return;
-            log_notification(notification, text_log_locked);
+            const std::string & exception_message = getCurrentExceptionMessage(true);
+            writeRetry(STDERR_FILENO, "Cannot log message in OwnAsyncSplitChannel text log: ");
+            writeRetry(STDERR_FILENO, exception_message.data(), exception_message.size());
+            writeRetry(STDERR_FILENO, "\n");
         }
-
-        notification = text_log_queue.waitDequeueMessage();
     }
 
-    /// We want to flush everything already in the queue before closing so all messages are logged
-    auto text_log_locked = text_log.lock();
-    if (!text_log_locked)
-        return;
+    try
+    {
+        /// We want to flush everything already in the queue before closing so all messages are logged
+        auto text_log_locked = text_log.lock();
+        if (!text_log_locked)
+            return;
 
-    if (notification)
-        log_notification(notification, text_log_locked);
-
-    flush_queue(text_log_locked);
+        if (notification)
+            log_notification(notification, text_log_locked);
+        flush_queue(text_log_locked);
+    }
+    catch (...)
+    {
+        const std::string & exception_message = getCurrentExceptionMessage(true);
+        writeRetry(STDERR_FILENO, "Cannot flush queue in OwnAsyncSplitChannel text log: ");
+        writeRetry(STDERR_FILENO, exception_message.data(), exception_message.size());
+        writeRetry(STDERR_FILENO, "\n");
+    }
 }
 
 void OwnAsyncSplitChannel::setChannelProperty(const std::string & channel_name, const std::string & name, const std::string & value)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Catch exceptions when async logging fails to prevent program aborts

If there is a disk failure when logging, the async threads did not catch the exception and the program aborted.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
