### PR TITLE
Exception joined_block_split_single_row&max_joined_block_rows=0

### DIFF
--- a/src/Interpreters/HashJoin/HashJoin.cpp
+++ b/src/Interpreters/HashJoin/HashJoin.cpp
@@ -156,6 +156,13 @@ HashJoin::HashJoin(
     , instance_log_id(!instance_id_.empty() ? "(" + instance_id_ + ") " : "")
     , log(getLogger("HashJoin"))
 {
+    if (joined_block_split_single_row && max_joined_block_rows == 0)
+    {
+        throw Exception(ErrorCodes::NOT_IMPLEMENTED,
+            "Setting `joined_block_split_single_row` is set to true, but `max_joined_block_rows` is 0 (no limit). "
+            "Set max_joined_block_rows > 0 or use `max_joined_block_bytes` with default `max_joined_block_rows` (by default equals to block size).");
+    }
+
     for (auto & column : right_sample_block)
     {
         if (!column.column)

--- a/tests/queries/0_stateless/01062_pm_all_join_with_block_continuation.sql
+++ b/tests/queries/0_stateless/01062_pm_all_join_with_block_continuation.sql
@@ -1,9 +1,11 @@
--- Tags: no-asan
+-- Tags: no-asan, long
 -- test is slow to pass flaky check when changed
 
 SET max_memory_usage = 50000000;
 SET join_algorithm = 'partial_merge';
 SET analyzer_compatibility_join_using_top_level_identifier = 1;
+SET joined_block_split_single_row = 0;
+
 SELECT 'defaults';
 
 SELECT count(1) FROM (

--- a/tests/queries/0_stateless/03569_max_joined_block_size_rows_bug.sql
+++ b/tests/queries/0_stateless/03569_max_joined_block_size_rows_bug.sql
@@ -1,2 +1,3 @@
 set enable_analyzer=1;
-select * from system.one, system.one settings max_joined_block_size_rows=0 format Null;
+select * from system.one, system.one settings max_joined_block_size_rows=0, joined_block_split_single_row = 0 format Null;
+select * from system.one, system.one settings max_joined_block_size_rows=0, joined_block_split_single_row = 1 format Null; -- { serverError NOT_IMPLEMENTED }


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)
