### PR TITLE
use re-sizable buffer for hadoop snappy decoder

### DIFF
--- a/src/IO/HadoopSnappyReadBuffer.h
+++ b/src/IO/HadoopSnappyReadBuffer.h
@@ -5,6 +5,7 @@
 #if USE_SNAPPY
 
 #include <memory>
+#include <vector>
 #include <IO/ReadBuffer.h>
 #include <IO/CompressedReadBufferWrapper.h>
 
@@ -32,7 +33,10 @@ public:
         TOO_LARGE_COMPRESSED_BLOCK = 4,
     };
 
-    HadoopSnappyDecoder() = default;
+    HadoopSnappyDecoder()
+    {
+        buffer.reserve(DBMS_DEFAULT_BUFFER_SIZE);
+    }
     ~HadoopSnappyDecoder() = default;
 
     Status readBlock(size_t * avail_in, const char ** next_in, size_t * avail_out, char ** next_out);
@@ -52,6 +56,7 @@ private:
     inline static bool checkAvailIn(size_t avail_in, int min);
 
     inline void copyToBuffer(size_t * avail_in, const char ** next_in);
+    inline void ensureBufferCapacity(size_t required_size);
 
     inline static uint32_t readLength(const char * in);
     inline Status readLength(size_t * avail_in, const char ** next_in, int * length);
@@ -59,7 +64,7 @@ private:
     inline Status readCompressedLength(size_t * avail_in, const char ** next_in);
     inline Status readCompressedData(size_t * avail_in, const char ** next_in, size_t * avail_out, char ** next_out);
 
-    char buffer[DBMS_DEFAULT_BUFFER_SIZE] = {0};
+    std::vector<char> buffer;
     int buffer_length = 0;
 
     int block_length = -1;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Use a dynamically re-sizable buffer for reading snappy blocks.

### Documentation entry for user-facing changes

- [ ] ~Documentation is written (mandatory for new features)~ not a new feature

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

fixes #88817 