### PR TITLE
CI: Fix Functional tests results parsing with regex pattern matching

### DIFF
--- a/ci/jobs/scripts/functional_tests_results.py
+++ b/ci/jobs/scripts/functional_tests_results.py
@@ -1,4 +1,5 @@
 import dataclasses
+import re
 import traceback
 from typing import List
 
@@ -17,6 +18,14 @@ DATABASE_SIGN = "Database: "
 SUCCESS_FINISH_SIGNS = ["All tests have finished", "No tests were run"]
 
 RETRIES_SIGN = "Some tests were restarted"
+
+# Regex pattern to match test result lines
+# Format: "2025-10-21 04:08:13 test_name: [ STATUS ] time sec."
+# This ensures we only match actual test result lines, not patterns embedded in error messages
+# Note: Test names can contain letters, digits, underscores, hyphens, and dots
+TEST_RESULT_PATTERN = re.compile(
+    r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} ([\w\-\.]+):\s+(\[ (?:OK|FAIL|SKIPPED|UNKNOWN|Timeout!) \])\s+([\d.]+) sec\."
+)
 
 
 # def write_results(results_file, status_file, results, status):
@@ -76,11 +85,14 @@ class FTResultsProcessor:
                     server_died = True
                 if RETRIES_SIGN in line:
                     retries = True
-                if any(
-                    sign in line
-                    for sign in (OK_SIGN, FAIL_SIGN, UNKNOWN_SIGN, SKIPPED_SIGN)
-                ):
-                    test_name = line.split(" ")[2].split(":")[0]
+
+                # Use regex to match test result lines precisely
+                # This prevents false matches from error messages containing test patterns
+                match = TEST_RESULT_PATTERN.match(line)
+                if match:
+                    test_name = match.group(1)
+                    status_marker = match.group(2)
+                    test_time = match.group(3)
 
                     if test_name == "+":
                         # TODO: investigate and remove
@@ -90,29 +102,21 @@ class FTResultsProcessor:
                         )
                         continue
 
-                    test_time = None
-                    try:
-                        time_token = line.split("]")[1].strip().split()[0]
-                        float(time_token)
-                        test_time = time_token
-                    except:
-                        print(f"ERROR: Failed to parse time str from line [{line}]")
-
                     total += 1
-                    if TIMEOUT_SIGN in line:
+                    if TIMEOUT_SIGN in status_marker:
                         failed += 1
                         test_results.append((test_name, "Timeout", test_time, []))
-                    elif FAIL_SIGN in line:
+                    elif FAIL_SIGN in status_marker:
                         failed += 1
                         test_results.append((test_name, "FAIL", test_time, []))
-                    elif UNKNOWN_SIGN in line:
+                    elif UNKNOWN_SIGN in status_marker:
                         unknown += 1
                         test_results.append((test_name, "FAIL", test_time, []))
-                    elif SKIPPED_SIGN in line:
+                    elif SKIPPED_SIGN in status_marker:
                         skipped += 1
                         test_results.append((test_name, "SKIPPED", test_time, []))
                     else:
-                        success += int(OK_SIGN in line)
+                        success += int(OK_SIGN in status_marker)
                         test_results.append((test_name, "OK", test_time, []))
                     test_end = False
                 elif (


### PR DESCRIPTION
fixes error when   line like `2025-10-21 04:08:13 Code: 8. DB::Exception: Received from localhost:900 .... [ .. ] ...` being parsed as a test result, [report with example](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=88821&sha=972f939bb149ac5d83e9f9ac688cf4ce3413458d&name_0=PR&name_1=Stateless+tests+%28amd_binary%2C+ParallelReplicas%2C+s3+storage%2C+parallel%29)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

