### PR TITLE
hasAny/AllTokens: Remove support for Array(FixedString) needles

### DIFF
--- a/src/Functions/hasAnyAllTokens.cpp
+++ b/src/Functions/hasAnyAllTokens.cpp
@@ -82,7 +82,7 @@ bool isStringOrArrayOfStringType(const IDataType & type)
     if (array_type)
     {
         const DataTypePtr & nested_type = array_type->getNestedType();
-        return isString(nested_type) || isFixedString(nested_type) || isNothing(nested_type);
+        return isString(nested_type) || isNothing(nested_type);
     }
 
     return false;
@@ -144,10 +144,10 @@ void executeHasAnyTokens(
 {
     for (size_t i = 0; i < input_rows_count; ++i)
     {
-        std::string_view value = col_input.getDataAt(i).toView();
+        std::string_view input = col_input.getDataAt(i).toView();
         col_result[i] = false;
 
-        forEachTokenPadded(*token_extractor, value.data(), value.size(), [&](const char * token_start, size_t token_len)
+        forEachTokenPadded(*token_extractor, input.data(), input.size(), [&](const char * token_start, size_t token_len)
         {
             if (needles.contains(std::string_view(token_start, token_len)))
             {
@@ -174,11 +174,11 @@ void executeHasAllTokens(
     UInt64 mask;
     for (size_t i = 0; i < input_rows_count; ++i)
     {
-        std::string_view value = col_input.getDataAt(i).toView();
+        std::string_view input = col_input.getDataAt(i).toView();
         col_result[i] = false;
         mask = 0;
 
-        forEachTokenPadded(*token_extractor, value.data(), value.size(), [&](const char * token_start, size_t token_len)
+        forEachTokenPadded(*token_extractor, input.data(), input.size(), [&](const char * token_start, size_t token_len)
         {
             if (auto it = needles.find(std::string_view(token_start, token_len)); it != needles.end())
             {

--- a/src/Functions/hasAnyAllTokens.h
+++ b/src/Functions/hasAnyAllTokens.h
@@ -4,7 +4,6 @@
 #include <Interpreters/Context_fwd.h>
 #include <Interpreters/ITokenExtractor.h>
 #include <absl/container/flat_hash_map.h>
-#include <base/StringRef.h>
 
 namespace DB
 {

--- a/src/Functions/tokens.cpp
+++ b/src/Functions/tokens.cpp
@@ -87,7 +87,7 @@ std::unique_ptr<ITokenExtractor> createTokenizer(const ColumnsWithTypeAndName & 
 
     throw Exception(
         ErrorCodes::BAD_ARGUMENTS,
-        "Function '{}' supports only tokenizers 'splitByNonAlpha', 'ngrams', 'splitByString', and 'array'", name);
+        "Function '{}' supports only tokenizers 'splitByNonAlpha', 'ngrams', 'splitByString', 'array', and 'sparseGrams'", name);
 }
 
 class ExecutableFunctionTokens : public IExecutableFunction
@@ -135,9 +135,9 @@ private:
 
         for (size_t i = 0; i < input_rows_count; ++i)
         {
-            StringRef input = column_input.getDataAt(i);
+            std::string_view input = column_input.getDataAt(i).toView();
 
-            forEachTokenPadded(extractor, input.data, input.size, [&](const char * token_start, size_t token_len)
+            forEachTokenPadded(extractor, input.data(), input.size(), [&](const char * token_start, size_t token_len)
             {
                 column_result.insertData(token_start, token_len);
                 ++tokens_count;

--- a/tests/queries/0_stateless/02346_text_index_function_hasAnyAllTokens.reference
+++ b/tests/queries/0_stateless/02346_text_index_function_hasAnyAllTokens.reference
@@ -124,8 +124,6 @@ FixedString input columns
 [1,3,5]
 [1,3,5]
 []
-[1,2,3,4,5,6]
-[1,2,3,4,5,6]
 -- Ngram tokenizer
 [3,4,5]
 []

--- a/tests/queries/0_stateless/02346_text_index_function_hasAnyAllTokens.sql
+++ b/tests/queries/0_stateless/02346_text_index_function_hasAnyAllTokens.sql
@@ -196,14 +196,6 @@ SELECT groupArray(id) FROM tab WHERE hasAllTokens(message, 'foo-');
 SELECT groupArray(id) FROM tab WHERE hasAllTokens(message, 'abc+* foo+');
 SELECT groupArray(id) FROM tab WHERE hasAllTokens(message, 'abc ba');
 
---- Test for FixedString needles
---- Not a systematic test, just to see that FixedString needles work in principle
-SELECT groupArray(id) FROM tab WHERE hasAnyTokens(message, [toFixedString('abc', 3)]);
-SELECT groupArray(id) FROM tab WHERE hasAllTokens(message, [toFixedString('abc', 3)]);
-
-SELECT groupArray(id) FROM tab WHERE hasAnyTokens(message, toFixedString('abc', 3)); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
-SELECT groupArray(id) FROM tab WHERE hasAllTokens(message, toFixedString('abc', 3)); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
-
 DROP TABLE tab;
 
 SELECT '-- Ngram tokenizer';


### PR DESCRIPTION
`Array(FixedString)` needles in functions `hasAny/AllTokens` were undocumented and an obscurity. We don't need to support them.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)