### PR TITLE
Fix data race on os_cpu_wait_time in context

### DIFF
--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -4897,7 +4897,7 @@ double Context::getMaxOSCPUWaitTimeRatioToDropConnection() const
 
 void Context::setOSCPUOverloadSettings(double min_os_cpu_wait_time_ratio_to_drop_connection, double max_os_cpu_wait_time_ratio_to_drop_connection)
 {
-    SharedLockGuard lock(shared->mutex);
+    std::lock_guard lock(shared->mutex);
     shared->min_os_cpu_wait_time_ratio_to_drop_connection = min_os_cpu_wait_time_ratio_to_drop_connection;
     shared->max_os_cpu_wait_time_ratio_to_drop_connection = max_os_cpu_wait_time_ratio_to_drop_connection;
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixes:

```
WARNING: ThreadSanitizer: data race (pid=1667)
  Read of size 8 at 0x728400004a30 by thread T787:
    #0 DB::Context::getMaxOSCPUWaitTimeRatioToDropConnection() const ci/tmp/build/./src/Interpreters/Context.cpp:4895:20 (clickhouse+0x1cc12604) (BuildId: 87255100a22109624a29206efbbe1ac75225d67a)
    #1 DB::Server::createServers(Poco::Util::AbstractConfiguration&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&, bool, Poco::ThreadPool&, DB::AsynchronousMetrics&, std::__1::vector<DB::ProtocolServerAdapter, std::__1::allocator<DB::ProtocolServerAdapter>>&, bool, DB::ServerType const&)::$_0::operator()() const ci/tmp/build/./programs/server/Server.cpp:3032:33 (clickhouse+0x142d2141) (BuildId: 87255100a22109624a29206efbbe1ac75225d67a)
    #2 decltype(std::declval<DB::Server::createServers(Poco::Util::AbstractConfiguration&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&, bool, Poco::ThreadPool&, DB::AsynchronousMetrics&, std::__1::vector<DB::ProtocolServerAdapter, std::__1::allocator<DB::ProtocolServerAdapter>>&, bool, DB::ServerType const&)::$_0&>()()) std::__1::__invoke[abi:ne190107]<DB::Server::createServers(Poco::Util::AbstractConfiguration&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&, bool, Poco::ThreadPool&, DB::AsynchronousMetrics&, std::__1::vector<DB::ProtocolServerAdapter, std::__1::allocator<DB::ProtocolServerAdapter>>&, bool, DB::ServerType const&)::$_0&>(DB::Server::createServers(Poco::Util::AbstractConfiguration&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&, bool, Poco::ThreadPool&, DB::AsynchronousMetrics&, std::__1::vector<DB::ProtocolServerAdapter, std::__1::allocator<DB::ProtocolServerAdapter>>&, bool, DB::ServerType const&)::$_0&) ci/tmp/build/./contrib/llvm-project/libcxx/include/__type_traits/invoke.h:149:25 (clickhouse+0x142d2141)
    #3 bool std::__1::__invoke_void_return_wrapper<bool, false>::__call[abi:ne190107]<DB::Server::createServers(Poco::Util::AbstractConfiguration&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&, bool, Poco::ThreadPool&, DB::AsynchronousMetrics&, std::__1::vector<DB::ProtocolServerAdapter, std::__1::allocator<DB::ProtocolServerAdapter>>&, bool, DB::ServerType const&)::$_0&>(DB::Server::createServers(Poco::Util::AbstractConfiguration&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&, bool, Poco::ThreadPool&, DB::AsynchronousMetrics&, std::__1::vector<DB::ProtocolServerAdapter, std::__1::allocator<DB::ProtocolServerAdapter>>&, bool, DB::ServerType const&)::$_0&) ci/tmp/build/./contrib/llvm-project/libcxx/include/__type_traits/invoke.h:216:12 (clickhouse+0x142d2141)
    #4 std::__1::__function::__default_alloc_func<DB::Server::createServers(Poco::Util::AbstractConfiguration&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&, bool, Poco::ThreadPool&, DB::AsynchronousMetrics&, std::__1::vector<DB::ProtocolServerAdapter, std::__1::allocator<DB::ProtocolServerAdapter>>&, bool, DB::ServerType const&)::$_0, bool ()>::operator()[abi:ne190107]() ci/tmp/build/./contrib/llvm-project/libcxx/include/__functional/function.h:210:12 (clickhouse+0x142d2141)
    #5 bool std::__1::__function::__policy_invoker<bool ()>::__call_impl[abi:ne190107]<std::__1::__function::__default_alloc_func<DB::Server::createServers(Poco::Util::AbstractConfiguration&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&, bool, Poco::ThreadPool&, DB::AsynchronousMetrics&, std::__1::vector<DB::ProtocolServerAdapter, std::__1::allocator<DB::ProtocolServerAdapter>>&, bool, DB::ServerType const&)::$_0, bool ()>>(std::__1::__function::__policy_storage const*) ci/tmp/build/./contrib/llvm-project/libcxx/include/__functional/function.h:610:12 (clickhouse+0x142d2141)
    #6 std::__1::__function::__policy_func<bool ()>::operator()[abi:ne190107]() const ci/tmp/build/./contrib/llvm-project/libcxx/include/__functional/function.h:716:12 (clickhouse+0x142e71a5) (BuildId: 87255100a22109624a29206efbbe1ac75225d67a)
    #7 std::__1::function<bool ()>::operator()() const ci/tmp/build/./contrib/llvm-project/libcxx/include/__functional/function.h:989:10 (clickhouse+0x142e71a5)
    #8 DB::TCPServerConnectionFilter::accept(Poco::Net::StreamSocket const&) ci/tmp/build/./src/Server/TCPServer.h:22:68 (clickhouse+0x142e71a5)
    #9 Poco::Net::TCPServer::run() ci/tmp/build/./base/poco/Net/src/TCPServer.cpp:139:68 (clickhouse+0x2a91d5cc) (BuildId: 87255100a22109624a29206efbbe1ac75225d67a)
    #10 Poco::(anonymous namespace)::RunnableHolder::run() ci/tmp/build/./base/poco/Foundation/src/Thread.cpp:45:11 (clickhouse+0x2a88b62f) (BuildId: 87255100a22109624a29206efbbe1ac75225d67a)
    #11 Poco::ThreadImpl::runnableEntry(void*) ci/tmp/build/./base/poco/Foundation/src/Thread_POSIX.cpp:341:27 (clickhouse+0x2a889889) (BuildId: 87255100a22109624a29206efbbe1ac75225d67a)

  Previous write of size 8 at 0x728400004a30 by thread T6922 (mutexes: write M0):
    #0 DB::Context::setOSCPUOverloadSettings(double, double) ci/tmp/build/./src/Interpreters/Context.cpp:4902:59 (clickhouse+0x1cc126e8) (BuildId: 87255100a22109624a29206efbbe1ac75225d67a)
    #1 DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&)::$_1::operator()(Poco::AutoPtr<Poco::Util::AbstractConfiguration>, bool) const ci/tmp/build/./programs/server/Server.cpp:2057:29 (clickhouse+0x142c2b7d) (BuildId: 87255100a22109624a29206efbbe1ac75225d67a)
    #2 decltype(std::declval<DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&)::$_1&>()(std::declval<Poco::AutoPtr<Poco::Util::AbstractConfiguration>>(), std::declval<bool>())) std::__1::__invoke[abi:ne190107]<DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&)::$_1&, Poco::AutoPtr<Poco::Util::AbstractConfiguration>, bool>(DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&)::$_1&, Poco::AutoPtr<Poco::Util::AbstractConfiguration>&&, bool&&) ci/tmp/build/./contrib/llvm-project/libcxx/include/__type_traits/invoke.h:149:25 (clickhouse+0x142c0a69) (BuildId: 87255100a22109624a29206efbbe1ac75225d67a)
    #3 void std::__1::__invoke_void_return_wrapper<void, true>::__call[abi:ne190107]<DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&)::$_1&, Poco::AutoPtr<Poco::Util::AbstractConfiguration>, bool>(DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&)::$_1&, Poco::AutoPtr<Poco::Util::AbstractConfiguration>&&, bool&&) ci/tmp/build/./contrib/llvm-project/libcxx/include/__type_traits/invoke.h:224:5 (clickhouse+0x142c0a69)
    #4 std::__1::__function::__default_alloc_func<DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&)::$_1, void (Poco::AutoPtr<Poco::Util::AbstractConfiguration>, bool)>::operator()[abi:ne190107](Poco::AutoPtr<Poco::Util::AbstractConfiguration>&&, bool&&) ci/tmp/build/./contrib/llvm-project/libcxx/include/__functional/function.h:210:12 (clickhouse+0x142c0a69)
    #5 void std::__1::__function::__policy_invoker<void (Poco::AutoPtr<Poco::Util::AbstractConfiguration>, bool)>::__call_impl[abi:ne190107]<std::__1::__function::__default_alloc_func<DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&)::$_1, void (Poco::AutoPtr<Poco::Util::AbstractConfiguration>, bool)>>(std::__1::__function::__policy_storage const*, Poco::AutoPtr<Poco::Util::AbstractConfiguration>&&, bool) ci/tmp/build/./contrib/llvm-project/libcxx/include/__functional/function.h:610:12 (clickhouse+0x142c0a69)
    #6 std::__1::__function::__policy_func<void (Poco::AutoPtr<Poco::Util::AbstractConfiguration>, bool)>::operator()[abi:ne190107](Poco::AutoPtr<Poco::Util::AbstractConfiguration>&&, bool&&) const ci/tmp/build/./contrib/llvm-project/libcxx/include/__functional/function.h:716:12 (clickhouse+0x23e75c9e) (BuildId: 87255100a22109624a29206efbbe1ac75225d67a)
    #7 std::__1::function<void (Poco::AutoPtr<Poco::Util::AbstractConfiguration>, bool)>::operator()(Poco::AutoPtr<Poco::Util::AbstractConfiguration>, bool) const ci/tmp/build/./contrib/llvm-project/libcxx/include/__functional/function.h:989:10 (clickhouse+0x23e75c9e)
    #8 DB::ConfigReloader::reloadIfNewer(bool, bool, bool, bool) ci/tmp/build/./src/Common/Config/ConfigReloader.cpp:180:13 (clickhouse+0x23e75c9e)
    #9 DB::ConfigReloader::reload() ci/tmp/build/./src/Common/Config/ConfigReloader.h:46:21 (clickhouse+0x142ce687) (BuildId: 87255100a22109624a29206efbbe1ac75225d67a)
    #10 DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&)::$_15::operator()() const ci/tmp/build/./programs/server/Server.cpp:2471:31 (clickhouse+0x142ce687)
    #11 decltype(std::declval<DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&)::$_15&>()()) std::__1::__invoke[abi:ne190107]<DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&)::$_15&>(DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&)::$_15&) ci/tmp/build/./contrib/llvm-project/libcxx/include/__type_traits/invoke.h:149:25 (clickhouse+0x142ce687)
    #12 void std::__1::__invoke_void_return_wrapper<void, true>::__call[abi:ne190107]<DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&)::$_15&>(DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&)::$_15&) ci/tmp/build/./contrib/llvm-project/libcxx/include/__type_traits/invoke.h:224:5 (clickhouse+0x142ce687)
    #13 std::__1::__function::__default_alloc_func<DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&)::$_15, void ()>::operator()[abi:ne190107]() ci/tmp/build/./contrib/llvm-project/libcxx/include/__functional/function.h:210:12 (clickhouse+0x142ce687)
    #14 void std::__1::__function::__policy_invoker<void ()>::__call_impl[abi:ne190107]<std::__1::__function::__default_alloc_func<DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&)::$_15, void ()>>(std::__1::__function::__policy_storage const*) ci/tmp/build/./contrib/llvm-project/libcxx/include/__functional/function.h:610:12 (clickhouse+0x142ce687)
    #15 std::__1::__function::__policy_func<void ()>::operator()[abi:ne190107]() const ci/tmp/build/./contrib/llvm-project/libcxx/include/__functional/function.h:716:12 (clickhouse+0x1cc1cc60) (BuildId: 87255100a22109624a29206efbbe1ac75225d67a)
    #16 std::__1::function<void ()>::operator()() const ci/tmp/build/./contrib/llvm-project/libcxx/include/__functional/function.h:989:10 (clickhouse+0x1cc1cc60)
    #17 DB::Context::reloadConfig() const ci/tmp/build/./src/Interpreters/Context.cpp:5857:5 (clickhouse+0x1cc1cc60)
    #18 DB::InterpreterSystemQuery::execute() ci/tmp/build/./src/Interpreters/InterpreterSystemQuery.cpp:685:29 (clickhouse+0x1d46d934) (BuildId: 87255100a22109624a29206efbbe1ac75225d67a)
    #19 DB::executeQueryImpl(char const*, char const*, std::__1::shared_ptr<DB::Context>, DB::QueryFlags, DB::QueryProcessingStage::Enum, std::__1::unique_ptr<DB::ReadBuffer, std::__1::default_delete<DB::ReadBuffer>>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::ImplicitTransactionControlExecutor>, std::__1::function<void ()>) ci/tmp/build/./src/Interpreters/executeQuery.cpp:1603:40 (clickhouse+0x1d4275c0) (BuildId: 87255100a22109624a29206efbbe1ac75225d67a)
    #20 DB::executeQuery(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<DB::Context>, DB::QueryFlags, DB::QueryProcessingStage::Enum) ci/tmp/build/./src/Interpreters/executeQuery.cpp:1812:11 (clickhouse+0x1d42134d) (BuildId: 87255100a22109624a29206efbbe1ac75225d67a)
    #21 DB::TCPHandler::runImpl() ci/tmp/build/./src/Server/TCPHandler.cpp:744:68 (clickhouse+0x22f7b6af) (BuildId: 87255100a22109624a29206efbbe1ac75225d67a)
    #22 DB::TCPHandler::run() ci/tmp/build/./src/Server/TCPHandler.cpp:2818:9 (clickhouse+0x22fa4ae7) (BuildId: 87255100a22109624a29206efbbe1ac75225d67a)
    #23 Poco::Net::TCPServerConnection::start() ci/tmp/build/./base/poco/Net/src/TCPServerConnection.cpp:40:3 (clickhouse+0x2a91df62) (BuildId: 87255100a22109624a29206efbbe1ac75225d67a)
    #24 Poco::Net::TCPServerDispatcher::run() ci/tmp/build/./base/poco/Net/src/TCPServerDispatcher.cpp:115:38 (clickhouse+0x2a91e831) (BuildId: 87255100a22109624a29206efbbe1ac75225d67a)
    #25 Poco::PooledThread::run() ci/tmp/build/./base/poco/Foundation/src/ThreadPool.cpp:205:14 (clickhouse+0x2a88d450) (BuildId: 87255100a22109624a29206efbbe1ac75225d67a)
    #26 Poco::(anonymous namespace)::RunnableHolder::run() ci/tmp/build/./base/poco/Foundation/src/Thread.cpp:45:11 (clickhouse+0x2a88b62f) (BuildId: 87255100a22109624a29206efbbe1ac75225d67a)
    #27 Poco::ThreadImpl::runnableEntry(void*) ci/tmp/build/./base/poco/Foundation/src/Thread_POSIX.cpp:341:27 (clickhouse+0x2a889889) (BuildId: 87255100a22109624a29206efbbe1ac75225d67a)
```
