### PR TITLE
Disable slow unit test with sanitizers

### DIFF
--- a/src/QueryPipeline/tests/gtest_resize_transform.cpp
+++ b/src/QueryPipeline/tests/gtest_resize_transform.cpp
@@ -1,4 +1,6 @@
 #include <gtest/gtest.h>
+
+#include <base/defines.h>
 #include <Core/Block.h>
 #include <Columns/ColumnVector.h>
 #include <Processors/Sources/BlocksListSource.h>
@@ -106,6 +108,9 @@ static void testSplitResizeTransform(size_t instreams, size_t outstreams, size_t
 
 TEST(ResizeTransformTest, SplitResizeTest)
 {
+#if defined(THREAD_SANITIZER) || defined(MEMORY_SANITIZER) || defined(ADDRESS_SANITIZER)
+    GTEST_SKIP() << "Too slow with heavy sanitizers. Ok in release or UBSan";
+#else
     for (size_t instreams = 2; instreams < 100; ++instreams)
     {
         for (size_t outstreams = 1; outstreams < 100; ++outstreams)
@@ -120,4 +125,5 @@ TEST(ResizeTransformTest, SplitResizeTest)
             }
         }
     }
+#endif
 }

--- a/src/QueryPipeline/tests/gtest_resize_transform.cpp
+++ b/src/QueryPipeline/tests/gtest_resize_transform.cpp
@@ -37,7 +37,8 @@ static Pipe getInputStreams(const std::vector<std::string> & column_names, size_
     return Pipe::unitePipes(std::move(pipes));
 }
 
-static void testSplitResizeTransform(size_t instreams, size_t outstreams, size_t min_outstreams_per_resize_after_split, bool strict)
+[[maybe_unused]] static void
+testSplitResizeTransform(size_t instreams, size_t outstreams, size_t min_outstreams_per_resize_after_split, bool strict)
 {
     constexpr size_t rows_per_stream = 10;
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Unit tests are in the critical path of the CI, and this one is the slowest. We do not need to run it with the slow sanitizer's

Example: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=88814&sha=latest&name_0=PR&name_1=Unit+tests+%28tsan%29

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
