### PR TITLE
Clarify Parquet file compression handling in S3 docs

### DIFF
--- a/docs/en/sql-reference/table-functions/s3.md
+++ b/docs/en/sql-reference/table-functions/s3.md
@@ -116,7 +116,7 @@ ClickHouse also can determine the compression method of the file. For example, i
 Parquet files with names like `*.parquet.snappy` or `*.parquet.zstd` can confuse ClickHouse and cause `TOO_LARGE_COMPRESSED_BLOCK` or `ZSTD_DECODER_FAILED` errors.
 This is because ClickHouse would attempt to read the entire file as Snappy or ZSTD-encoded data when, in fact, Parquet applies compression at the row-group and column level.
 
-Parquet metadata already specifies the per-column compression and so the file extension is superflous.
+Parquet metadata already specifies the per-column compression, and so the file extension is superfluous.
 You can just use `compression_method = 'none'` in such cases:
 
 ```sql

--- a/docs/en/sql-reference/table-functions/s3.md
+++ b/docs/en/sql-reference/table-functions/s3.md
@@ -114,7 +114,7 @@ ClickHouse also can determine the compression method of the file. For example, i
 
 :::note
 Parquet files with names like `*.parquet.snappy` or `*.parquet.zstd` can confuse ClickHouse and cause `TOO_LARGE_COMPRESSED_BLOCK` or `ZSTD_DECODER_FAILED` errors.
-This is because ClickHouse would attempt to read the entire file as Snappy or Zstd-encoded data when in fact Parquet applies compression at the row-group and column level.
+This is because ClickHouse would attempt to read the entire file as Snappy or ZSTD-encoded data when, in fact, Parquet applies compression at the row-group and column level.
 
 Parquet metadata already specifies the per-column compression and so the file extension is superflous.
 You can just use `compression_method = 'none'` in such cases:

--- a/docs/en/sql-reference/table-functions/s3.md
+++ b/docs/en/sql-reference/table-functions/s3.md
@@ -112,6 +112,22 @@ LIMIT 5;
 ClickHouse also can determine the compression method of the file. For example, if the file was zipped up with a `.csv.gz` extension, ClickHouse would decompress the file automatically.
 :::
 
+:::note
+Parquet files with names like `*.parquet.snappy` or `*.parquet.zstd` can confuse ClickHouse and cause `TOO_LARGE_COMPRESSED_BLOCK` or `ZSTD_DECODER_FAILED` errors.
+This is because ClickHouse would attempt to read the entire file as Snappy or Zstd-encoded data when in fact Parquet applies compression at the row-group and column level.
+
+Parquet metadata already specifies the per-column compression and so the file extension is superflous.
+You can just use `compression_method = 'none'` in such cases:
+
+```sql
+SELECT *
+FROM s3(
+  'https://<my-bucket>.s3.<my-region>.amazonaws.com/path/to/my-data.parquet.snappy',
+  compression_format = 'none'
+);
+```
+:::
+
 ## Usage {#usage}
 
 Suppose that we have several files with following URIs on S3:


### PR DESCRIPTION
Since #88817 and #54565 I think it's clear that the current behaviour can be surprising. 

I think we should document the behaviour so that its easy for users to self-correct.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

N/A

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
