### PR TITLE
fix 03658_joined_block_split_single_row_bytes

### DIFF
--- a/tests/parallel_replicas_blacklist.txt
+++ b/tests/parallel_replicas_blacklist.txt
@@ -457,3 +457,6 @@
 00443_optimize_final_vertical_merge
 01660_join_or_any
 01801_s3_cluster
+
+    Produces different result:
+03658_joined_block_split_single_row_bytes

--- a/tests/queries/0_stateless/03658_joined_block_split_single_row_bytes.sql
+++ b/tests/queries/0_stateless/03658_joined_block_split_single_row_bytes.sql
@@ -27,6 +27,7 @@ INSERT INTO t1 SELECT rand(), 2, repeat('aaa', 1_000_000);
 INSERT INTO t2 SELECT rand(), 2, repeat('bbb', 1_000_000) from numbers(10);
 
 SELECT
-    if(max(size) < 10_000_000, 'Ok', format('Error: max_size={} rows={}', max(size), argMax(rows, size)))
+    -- limit is 4M but minimum block size is 6Mb, so it will be single row block
+    if(argMax(rows, size) = 1 AND max(size) < 10_000_000, 'Ok', format('Error: max_size={} rows={}', max(size), argMax(rows, size)))
 FROM ( SELECT blockNumber() as bn, sum(byteSize(*)) as size, count() as rows FROM t1 INNER JOIN t2 ON t1.key = t2.key GROUP BY bn )
 SETTINGS joined_block_split_single_row = 1, max_joined_block_size_bytes = '4M';

--- a/tests/queries/0_stateless/03658_joined_block_split_single_row_bytes.sql
+++ b/tests/queries/0_stateless/03658_joined_block_split_single_row_bytes.sql
@@ -27,7 +27,6 @@ INSERT INTO t1 SELECT rand(), 2, repeat('aaa', 1_000_000);
 INSERT INTO t2 SELECT rand(), 2, repeat('bbb', 1_000_000) from numbers(10);
 
 SELECT
-    -- limit is 4M but minimum block size is 6Mb, so it will be single row block
-    if(argMax(rows, size) = 1 AND max(size) < 10_000_000, 'Ok', format('Error: max_size={} rows={}', max(size), argMax(rows, size)))
+    if(max(size) < 10_000_000, 'Ok', format('Error: max_size={} rows={}', max(size), argMax(rows, size)))
 FROM ( SELECT blockNumber() as bn, sum(byteSize(*)) as size, count() as rows FROM t1 INNER JOIN t2 ON t1.key = t2.key GROUP BY bn )
 SETTINGS joined_block_split_single_row = 1, max_joined_block_size_bytes = '4M';


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
