### PR TITLE
LockGuard that can measure time

### DIFF
--- a/src/Common/LockGuardWithStopWatch.h
+++ b/src/Common/LockGuardWithStopWatch.h
@@ -9,10 +9,10 @@ namespace DB
 
 struct TSA_SCOPED_LOCKABLE LockGuardWithStopWatch final
 {
-#if defined(SANITIZER)
-    static constexpr auto THRESHOLD_MILLISECONDS = 10000;
-#else
+#ifndef NDEBUG
     static constexpr auto THRESHOLD_MILLISECONDS = 1000;
+#else
+    static constexpr auto THRESHOLD_MILLISECONDS = 10000;
 #endif
 
     const char * caller{nullptr};

--- a/src/Common/LockGuardWithStopWatch.h
+++ b/src/Common/LockGuardWithStopWatch.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <Common/logger_useful.h>
+#include <Common/Stopwatch.h>
+#include <Common/CurrentThread.h>
+
+namespace DB
+{
+
+struct TSA_SCOPED_LOCKABLE LockGuardWithStopWatch final
+{
+    const char * caller{nullptr};
+    LoggerRawPtr log;
+    UInt64 thread_id{0};
+
+    std::optional<Stopwatch> wait_watch;
+    std::optional<std::lock_guard<std::mutex>> lock;
+    std::optional<Stopwatch> lock_watch;
+
+    explicit LockGuardWithStopWatch(std::mutex & mutex_, LoggerRawPtr log_, const char * caller_) TSA_ACQUIRE(mutex_)
+        : caller(caller_)
+        , log(log_)
+    {
+        if (CurrentThread::isInitialized())
+            thread_id = CurrentThread::get().thread_id;
+
+        wait_watch.emplace(CLOCK_MONOTONIC);
+        lock.emplace(mutex_);
+        lock_watch.emplace(CLOCK_MONOTONIC);
+    }
+
+    explicit LockGuardWithStopWatch(std::mutex & mutex_, LoggerPtr log_, const char * caller_) TSA_ACQUIRE(mutex_)
+        : LockGuardWithStopWatch(mutex_, log_.get(), caller_)
+    {
+    }
+
+    ~LockGuardWithStopWatch() TSA_RELEASE()
+    {
+        ALLOW_ALLOCATIONS_IN_SCOPE;
+
+        /// Must be destroyed first.
+        lock.reset();
+
+        if (wait_watch.has_value() && lock_watch.has_value() &&
+            wait_watch->elapsedMilliseconds() - lock_watch->elapsedMilliseconds() > 1000)
+        {
+            LOG_WARNING(log, "Lock acquisition took {} ms for thread {} in [{}], Stack trace (when copying this message, always include the lines below): \n {}",
+                wait_watch->elapsedMilliseconds() - lock_watch->elapsedMilliseconds(), thread_id, caller, StackTrace().toString());
+        }
+
+        if (lock_watch.has_value() && lock_watch->elapsedMilliseconds() > 1000)
+        {
+            LOG_WARNING(log, "Lock was held for {} ms by thread {} in [{}], Stack trace (when copying this message, always include the lines below): \n {}",
+                wait_watch->elapsedMilliseconds(), thread_id, caller, StackTrace().toString());
+        }
+    }
+
+    LockGuardWithStopWatch(LockGuardWithStopWatch const &) = delete;
+    LockGuardWithStopWatch& operator=(LockGuardWithStopWatch const&) = delete;
+};
+
+}

--- a/src/Common/LockGuardWithStopWatch.h
+++ b/src/Common/LockGuardWithStopWatch.h
@@ -9,10 +9,10 @@ namespace DB
 
 struct TSA_SCOPED_LOCKABLE LockGuardWithStopWatch final
 {
-#ifndef NDEBUG
-    static constexpr auto THRESHOLD_MILLISECONDS = 1000;
+#if defined(SANITIZER) || !defined(NDEBUG)
+    static constexpr auto THRESHOLD_MILLISECONDS = 10 * 1000;
 #else
-    static constexpr auto THRESHOLD_MILLISECONDS = 10000;
+    static constexpr auto THRESHOLD_MILLISECONDS = 1000;
 #endif
 
     const char * caller{nullptr};

--- a/src/Common/LockGuardWithStopWatch.h
+++ b/src/Common/LockGuardWithStopWatch.h
@@ -32,6 +32,7 @@ struct TSA_SCOPED_LOCKABLE LockGuardWithStopWatch final
 
         wait_watch.emplace(CLOCK_MONOTONIC);
         lock.emplace(mutex_);
+        wait_watch->stop();
         lock_watch.emplace(CLOCK_MONOTONIC);
     }
 
@@ -46,13 +47,12 @@ struct TSA_SCOPED_LOCKABLE LockGuardWithStopWatch final
 
         /// Must be destroyed first.
         lock.reset();
-        wait_watch->stop();
         lock_watch->stop();
 
-        if (wait_watch->elapsedMilliseconds() - lock_watch->elapsedMilliseconds() > THRESHOLD_MILLISECONDS)
+        if (wait_watch->elapsedMilliseconds() > THRESHOLD_MILLISECONDS)
         {
             LOG_WARNING(log, "Lock acquisition took {} ms for thread {} in [{}], Stack trace (when copying this message, always include the lines below): \n {}",
-                wait_watch->elapsedMilliseconds() - lock_watch->elapsedMilliseconds(), thread_id, caller, StackTrace().toString());
+                wait_watch->elapsedMilliseconds(), thread_id, caller, StackTrace().toString());
         }
 
         if (lock_watch->elapsedMilliseconds() > THRESHOLD_MILLISECONDS)

--- a/src/Storages/MergeTree/BackgroundJobsAssignee.cpp
+++ b/src/Storages/MergeTree/BackgroundJobsAssignee.cpp
@@ -1,6 +1,7 @@
 #include <Storages/MergeTree/BackgroundJobsAssignee.h>
 #include <Storages/MergeTree/MergeTreeData.h>
 #include <Common/CurrentMetrics.h>
+#include <Common/LockGuardWithStopWatch.h>
 #include <Common/randomSeed.h>
 #include <Core/BackgroundSchedulePool.h>
 #include <Interpreters/Context.h>

--- a/src/Storages/MergeTree/MergeMutateSelectedEntry.h
+++ b/src/Storages/MergeTree/MergeMutateSelectedEntry.h
@@ -32,7 +32,7 @@ struct CurrentlyMergingPartsTagger
 
     /// The finalize() method acquires the `currently_processing_in_background_mutex` lock
     /// to remove the parts from the `currently_merging_mutating_parts` set.
-    /// This might take a lot of time and it's important not to do it in the des
+    /// This might take a lot of time and it's important not to do it in the destructor.
     void finalize();
     ~CurrentlyMergingPartsTagger();
 };

--- a/src/Storages/MergeTree/MergeMutateSelectedEntry.h
+++ b/src/Storages/MergeTree/MergeMutateSelectedEntry.h
@@ -21,6 +21,7 @@ struct CurrentlyMergingPartsTagger
     StorageMergeTree & storage;
     // Optional tagger to maintain volatile parts for the JBOD balancer
     std::optional<CurrentlySubmergingEmergingTagger> tagger;
+    bool finalized{false};
 
     CurrentlyMergingPartsTagger(
         FutureMergedMutatedPartPtr future_part_,
@@ -29,6 +30,10 @@ struct CurrentlyMergingPartsTagger
         const StorageMetadataPtr & metadata_snapshot,
         bool is_mutation);
 
+    /// The finalize() method acquires the `currently_processing_in_background_mutex` lock
+    /// to remove the parts from the `currently_merging_mutating_parts` set.
+    /// This might take a lot of time and it's important not to do it in the des
+    void finalize();
     ~CurrentlyMergingPartsTagger();
 };
 
@@ -40,6 +45,7 @@ struct MergeMutateSelectedEntry
     CurrentlyMergingPartsTaggerPtr tagger;
     MutationCommandsConstPtr commands;
     MergeTreeTransactionPtr txn;
+    bool finalized{false};
     MergeMutateSelectedEntry(FutureMergedMutatedPartPtr future_part_, CurrentlyMergingPartsTaggerPtr tagger_,
                              MutationCommandsConstPtr commands_, const MergeTreeTransactionPtr & txn_ = NO_TRANSACTION_PTR)
         : future_part(future_part_)
@@ -47,6 +53,9 @@ struct MergeMutateSelectedEntry
         , commands(commands_)
         , txn(txn_)
     {}
+
+    void finalize();
+    ~MergeMutateSelectedEntry();
 };
 
 using MergeMutateSelectedEntryPtr = std::shared_ptr<MergeMutateSelectedEntry>;

--- a/src/Storages/MergeTree/MergePlainMergeTreeTask.cpp
+++ b/src/Storages/MergeTree/MergePlainMergeTreeTask.cpp
@@ -180,6 +180,8 @@ void MergePlainMergeTreeTask::finish()
         ThreadFuzzer::maybeInjectSleep();
         ThreadFuzzer::maybeInjectMemoryLimitException();
     }
+
+    merge_mutate_entry->finalize();
 }
 
 void MergePlainMergeTreeTask::cancel() noexcept

--- a/src/Storages/MergeTree/MergePlainMergeTreeTask.cpp
+++ b/src/Storages/MergeTree/MergePlainMergeTreeTask.cpp
@@ -191,6 +191,9 @@ void MergePlainMergeTreeTask::cancel() noexcept
 
     if (new_part)
         new_part->removeIfNeeded();
+
+    if (merge_mutate_entry)
+        merge_mutate_entry->finalize();
 }
 
 ContextMutablePtr MergePlainMergeTreeTask::createTaskContext() const

--- a/src/Storages/MergeTree/MergeTreeBackgroundExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeBackgroundExecutor.cpp
@@ -271,10 +271,10 @@ void MergeTreeBackgroundExecutor<Queue>::routine(TaskRuntimeDataPtr item)
         item_->is_done.set();
         item_.reset();
 
-#ifndef NDEBUG
-        static constexpr auto THRESHOLD_MILLISECONDS = 1000ULL;
-#else
+#if defined(SANITIZER) || !defined(NDEBUG)
         static constexpr auto THRESHOLD_MILLISECONDS = 10 * 1000ULL;
+#else
+        static constexpr auto THRESHOLD_MILLISECONDS = 1000ULL;
 #endif
         UInt64 elapsed_ms = destruction_watch.elapsedMilliseconds();
         NOEXCEPT_SCOPE({

--- a/src/Storages/MergeTree/MergeTreeBackgroundExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeBackgroundExecutor.cpp
@@ -9,6 +9,7 @@
 #include <Common/Exception.h>
 #include <Common/noexcept_scope.h>
 #include <Common/logger_useful.h>
+#include <Common/LockGuardWithStopWatch.h>
 
 
 namespace CurrentMetrics
@@ -90,7 +91,7 @@ template <class Queue>
 void MergeTreeBackgroundExecutor<Queue>::wait()
 {
     {
-        std::lock_guard lock(mutex);
+        LockGuardWithStopWatch lock(mutex, log, __PRETTY_FUNCTION__);
         shutdown = true;
         has_tasks.notify_all();
     }
@@ -101,7 +102,7 @@ void MergeTreeBackgroundExecutor<Queue>::wait()
 template <class Queue>
 void MergeTreeBackgroundExecutor<Queue>::increaseThreadsAndMaxTasksCount(size_t new_threads_count, size_t new_max_tasks_count)
 {
-    std::lock_guard lock(mutex);
+    LockGuardWithStopWatch lock(mutex, log, __PRETTY_FUNCTION__);
 
     /// Do not throw any exceptions from global pool. Just log a warning and silently return.
     if (new_threads_count < threads_count)
@@ -136,7 +137,7 @@ void MergeTreeBackgroundExecutor<Queue>::increaseThreadsAndMaxTasksCount(size_t 
 template <class Queue>
 size_t MergeTreeBackgroundExecutor<Queue>::getMaxThreads() const
 {
-    std::lock_guard lock(mutex);
+    LockGuardWithStopWatch lock(mutex, log, __PRETTY_FUNCTION__);
     return threads_count;
 }
 
@@ -149,7 +150,7 @@ size_t MergeTreeBackgroundExecutor<Queue>::getMaxTasksCount() const
 template <class Queue>
 bool MergeTreeBackgroundExecutor<Queue>::trySchedule(ExecutableTaskPtr task)
 {
-    std::lock_guard lock(mutex);
+    LockGuardWithStopWatch lock(mutex, log, __PRETTY_FUNCTION__);
 
     if (shutdown)
         return false;
@@ -205,7 +206,7 @@ void MergeTreeBackgroundExecutor<Queue>::removeTasksCorrespondingToStorage(Stora
     std::vector<TaskRuntimeDataPtr> tasks_to_cancel;
     std::vector<TaskRuntimeDataPtr> tasks_to_wait;
     {
-        std::lock_guard lock(mutex);
+        LockGuardWithStopWatch lock(mutex, log, __PRETTY_FUNCTION__);
 
         /// Erase storage related tasks from pending and select active tasks to wait for
         tasks_to_cancel = pending.removeTasks(id);
@@ -273,10 +274,10 @@ void MergeTreeBackgroundExecutor<Queue>::routine(TaskRuntimeDataPtr item)
         UInt64 elapsed_ms = destruction_watch.elapsedMilliseconds();
         NOEXCEPT_SCOPE({
             ALLOW_ALLOCATIONS_IN_SCOPE;
-            if (elapsed_ms > 60ULL * 1000ULL)
+            if (elapsed_ms > 1000ULL)
             {
                 LOG_WARNING(log,
-                    "Releasing background task runtime data took {:.3f} seconds (> 60s), executor={}, storage={}, query_id={}, deleting={}",
+                    "Releasing background task runtime data took {:.3f} seconds (> 1s), executor={}, storage={}, query_id={}, deleting={}",
                     static_cast<double>(elapsed_ms) / 1000.0,
                     name,
                     captured_storage_id.value_or("unknown"),
@@ -289,44 +290,54 @@ void MergeTreeBackgroundExecutor<Queue>::routine(TaskRuntimeDataPtr item)
     /// No TSA because of unique_lock
     auto restart_task = [this, &erase_from_active, &release_task] (TaskRuntimeDataPtr && item_) TSA_NO_THREAD_SAFETY_ANALYSIS
     {
-        std::unique_lock<std::mutex> guard(mutex);
-        erase_from_active(item_);
-
-        if (item_->is_currently_deleting)
         {
-            guard.unlock();
+            LockGuardWithStopWatch lock(mutex, log, __PRETTY_FUNCTION__);
+            erase_from_active(item_);
+
+            if (!item_->is_currently_deleting)
             {
-                ALLOW_ALLOCATIONS_IN_SCOPE;
-                item_->cancel();
+                /// After the `guard` destruction `item` has to be in moved from state
+                /// Not to own the object it points to.
+                /// Otherwise the destruction of the task won't be ordered with the destruction of the
+                /// storage.
+                pending.push(std::move(item_));
+                has_tasks.notify_one();
+                return;
             }
-            guard.lock();
-            release_task(std::move(item_));
-            return;
         }
 
-        /// After the `guard` destruction `item` has to be in moved from state
-        /// Not to own the object it points to.
-        /// Otherwise the destruction of the task won't be ordered with the destruction of the
-        /// storage.
-        pending.push(std::move(item_));
-        has_tasks.notify_one();
+        /// No lock here.
+        {
+            ALLOW_ALLOCATIONS_IN_SCOPE;
+            item_->cancel();
+        }
+
+        LockGuardWithStopWatch lock(mutex, log, __PRETTY_FUNCTION__);
+        release_task(std::move(item_));
     };
 
     String query_id;
 
     auto complete_task = [this, &erase_from_active, &release_task] (TaskRuntimeDataPtr && item_)
     {
-        std::lock_guard guard(mutex);
+        LockGuardWithStopWatch lock(mutex, log, __PRETTY_FUNCTION__);
 
         erase_from_active(item_);
         has_tasks.notify_one();
 
         {
+            Stopwatch watch_on_completed;
             ALLOW_ALLOCATIONS_IN_SCOPE;
             /// In a situation of a lack of memory this method can throw an exception,
             /// because it may interact somehow with BackgroundSchedulePool, which may allocate memory
             /// But it is rather safe, because we have try...catch block here, and another one in ThreadPool.
             item_->task->onCompleted();
+
+            if (watch_on_completed.elapsedMilliseconds() > 1000)
+            {
+                LOG_WARNING(log, "Execution of callback took {} ms for thread {} in [{}], Stack trace (when copying this message, always include the lines below): \n {}",
+                    watch_on_completed.elapsedMilliseconds(), CurrentThread::get().thread_id, __PRETTY_FUNCTION__, StackTrace().toString());
+            }
         }
 
         release_task(std::move(item_));
@@ -366,7 +377,7 @@ void MergeTreeBackgroundExecutor<Queue>::routine(TaskRuntimeDataPtr item)
 
         /// Release the task with exception context.
         /// An exception context is needed to proper delete write buffers without finalization
-        std::lock_guard guard(mutex);
+        LockGuardWithStopWatch lock(mutex, log, __PRETTY_FUNCTION__);
         erase_from_active(item);
         has_tasks.notify_one();
         release_task(std::move(item));
@@ -392,6 +403,7 @@ void MergeTreeBackgroundExecutor<Queue>::threadFunction()
         {
             TaskRuntimeDataPtr item;
             {
+                /// The only place without lock tracing.
                 std::unique_lock lock(mutex);
                 has_tasks.wait(lock, [this]() TSA_REQUIRES(mutex) { return !pending.empty() || shutdown; });
 

--- a/src/Storages/MergeTree/MergeTreeBackgroundExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeBackgroundExecutor.cpp
@@ -271,10 +271,10 @@ void MergeTreeBackgroundExecutor<Queue>::routine(TaskRuntimeDataPtr item)
         item_->is_done.set();
         item_.reset();
 
-#if defined(SANITIZER)
-        static constexpr auto THRESHOLD_MILLISECONDS = 10 * 1000ULL;
-#else
+#ifndef NDEBUG
         static constexpr auto THRESHOLD_MILLISECONDS = 1000ULL;
+#else
+        static constexpr auto THRESHOLD_MILLISECONDS = 10 * 1000ULL;
 #endif
         UInt64 elapsed_ms = destruction_watch.elapsedMilliseconds();
         NOEXCEPT_SCOPE({

--- a/src/Storages/MergeTree/MutatePlainMergeTreeTask.cpp
+++ b/src/Storages/MergeTree/MutatePlainMergeTreeTask.cpp
@@ -162,6 +162,9 @@ void MutatePlainMergeTreeTask::cancel() noexcept
 
     if (new_part)
         new_part->removeIfNeeded();
+
+    if (merge_mutate_entry)
+        merge_mutate_entry->finalize();
 }
 
 

--- a/src/Storages/MergeTree/MutatePlainMergeTreeTask.cpp
+++ b/src/Storages/MergeTree/MutatePlainMergeTreeTask.cpp
@@ -75,6 +75,11 @@ void MutatePlainMergeTreeTask::prepare()
             time(nullptr), task_context, merge_mutate_entry->txn, merge_mutate_entry->tagger->reserved_space, table_lock_holder);
 }
 
+void MutatePlainMergeTreeTask::finish()
+{
+    if (merge_mutate_entry)
+        merge_mutate_entry->finalize();
+}
 
 bool MutatePlainMergeTreeTask::executeStep()
 {
@@ -137,6 +142,7 @@ bool MutatePlainMergeTreeTask::executeStep()
         case State::NEED_FINISH:
         {
             // Nothing to do
+            finish();
             state = State::SUCCESS;
             return false;
         }

--- a/src/Storages/MergeTree/MutatePlainMergeTreeTask.h
+++ b/src/Storages/MergeTree/MutatePlainMergeTreeTask.h
@@ -48,8 +48,8 @@ public:
     String getQueryId() const override { return getStorageID().getShortName() + "::" + merge_mutate_entry->future_part->name; }
 
 private:
-
     void prepare();
+    void finish();
 
     enum class State : uint8_t
     {

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -565,9 +565,11 @@ CurrentlyMergingPartsTagger::CurrentlyMergingPartsTagger(
     storage.currently_merging_mutating_parts.insert(future_part->parts.begin(), future_part->parts.end());
 }
 
-CurrentlyMergingPartsTagger::~CurrentlyMergingPartsTagger()
+
+void CurrentlyMergingPartsTagger::finalize()
 {
     std::lock_guard lock(storage.currently_processing_in_background_mutex);
+    finalized = true;
 
     for (const auto & part : future_part->parts)
     {
@@ -577,6 +579,31 @@ CurrentlyMergingPartsTagger::~CurrentlyMergingPartsTagger()
     }
 
     storage.currently_processing_in_background_condition.notify_all();
+}
+
+CurrentlyMergingPartsTagger::~CurrentlyMergingPartsTagger()
+{
+    if (!finalized)
+    {
+        LOG_WARNING(getLogger("CurrentlyMergingPartsTagger"), "CurrentlyMergingPartsTagger was not finalized, the finalization will happen in the destructor");
+        finalize();
+    }
+
+}
+
+void MergeMutateSelectedEntry::finalize()
+{
+    finalized = true;
+    tagger->finalize();
+}
+
+MergeMutateSelectedEntry::~MergeMutateSelectedEntry()
+{
+    if (!finalized)
+    {
+        LOG_WARNING(getLogger("MergeMutateSelectedEntry"), "MergeMutateSelectedEntry was not finalized, the finalization will happen in the destructor");
+        finalize();
+    }
 }
 
 Int64 StorageMergeTree::startMutation(const MutationCommands & commands, ContextPtr query_context)


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Introduced a `LockGuardWithStopWatch` class and used it in the background pool for executing merges. In case a mutex was held for a second or some thread was struggling to get it within a second a warning message will be printed.
Moved the heavy code from the destructor of `MergeMutateSelectedEntry` to `finalize()` method to avoid holding the lock in `MergeTreeBackground` executor for too long. 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)
