### PR TITLE
Docs: Full-text search is in private preview

### DIFF
--- a/docs/en/engines/table-engines/mergetree-family/invertedindexes.md
+++ b/docs/en/engines/table-engines/mergetree-family/invertedindexes.md
@@ -7,12 +7,12 @@ title: 'Full-text Search using Text Indexes'
 doc_type: 'reference'
 ---
 
-import ExperimentalBadge from '@theme/badges/ExperimentalBadge';
+import PrivatePreviewBadge from '@theme/badges/PrivatePreviewBadge';
 import CloudNotSupportedBadge from '@theme/badges/CloudNotSupportedBadge';
 
 # Full-text search using text indexes
 
-<ExperimentalBadge/>
+<PrivatePreviewBadge/>
 <CloudNotSupportedBadge/>
 
 Text indexes in ClickHouse (also known as ["inverted indexes"](https://en.wikipedia.org/wiki/Inverted_index)) provide fast full-text capabilities on string data.


### PR DESCRIPTION
Reverts https://github.com/ClickHouse/ClickHouse/pull/86456

### Changelog category (leave one):
- Experimental Feature

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Full-text search is now in private preview (from a previously experimental stage).