### PR TITLE
Fix for opt-in AWS S3 regions when no explicit region is specified

### DIFF
--- a/src/IO/S3/Client.cpp
+++ b/src/IO/S3/Client.cpp
@@ -722,7 +722,7 @@ Client::doRequest(RequestType & request, RequestFn request_fn) const
 
         // we possibly got new location, need to try with that one
         auto new_uri = getURIFromError(error);
-        if (!new_uri && !new_region_detected)
+        if (!new_uri)
             return result;
 
         if (initial_endpoint.substr(11) == "amazonaws.com") // Check if user didn't mention any region

--- a/src/IO/S3/Client.cpp
+++ b/src/IO/S3/Client.cpp
@@ -692,22 +692,37 @@ Client::doRequest(RequestType & request, RequestFn request_fn) const
             continue;
         }
 
-        if (error.GetResponseCode() != Aws::Http::HttpResponseCode::MOVED_PERMANENTLY)
+        /// IllegalLocationConstraintException may indicate that we are working with an opt-in region (e.g. me-south-1)
+        /// In that case, we need to update the region and try again
+        if (error.GetResponseCode() != Aws::Http::HttpResponseCode::MOVED_PERMANENTLY && error.GetExceptionName() != "IllegalLocationConstraintException")
             return result;
 
         // maybe we detect a correct region
-        if (!detect_region)
+        bool new_region_detected = false;
+        if (!detect_region || error.GetExceptionName() == "IllegalLocationConstraintException")
         {
             if (auto region = GetErrorMarshaller()->ExtractRegion(error); !region.empty() && region != explicit_region)
             {
+                LOG_INFO(log, "Detected new region: {}", region);
                 request.overrideRegion(region);
                 insertRegionOverride(bucket, region);
+                new_region_detected = true;
             }
+        }
+
+        /// special handling for opt-in regions
+        if (new_region_detected && error.GetExceptionName() == "IllegalLocationConstraintException" && initial_endpoint.substr(11) == "amazonaws.com")
+        {
+            S3::URI new_uri(initial_endpoint);
+            new_uri.addRegionToURI(request.getRegionOverride());
+            found_new_endpoint = true;
+            request.overrideURI(new_uri);
+            continue;
         }
 
         // we possibly got new location, need to try with that one
         auto new_uri = getURIFromError(error);
-        if (!new_uri)
+        if (!new_uri && !new_region_detected)
             return result;
 
         if (initial_endpoint.substr(11) == "amazonaws.com") // Check if user didn't mention any region


### PR DESCRIPTION
Currently, CH fails to read from buckets that are located in [opt-in AWS regions](https://docs.aws.amazon.com/global-infrastructure/latest/regions/aws-regions.html) if region is not specified in query explicitly:
```                                                                                                                                                                     
SELECT DISTINCT _path                                                                                                                                                        
FROM s3('s3://aztest-mesouth/subfoldr/*', '<key-id>', '<secret>')                                                                
                                                                
Received exception from server (version 25.10.1):                                                                                                                            
Code: 499. DB::Exception: Received from localhost:9000. DB::Exception: Could not list objects in bucket 'aztest-mesouth' with prefix 'subfoldr/', S3 exception: `IllegalLocationConstraintException`, message: 'Unable to parse ExceptionName: IllegalLocationConstraintException Message: The me-south-1 location constraint is incompatible for the region specific endpoint this request was sent to.': The data format cannot be detected by the contents of the files. You can specify the format manually. (S3_ERROR)



SELECT DISTINCT _path                                                                                                                                                        
FROM s3('https://s3.me-south-1.amazonaws.com/aztest-mesouth/subfoldr/*', '<key-id>', '<secret>')                                 


   ┌─_path───────────────────────────────┐
1. │ aztest-mesouth/subfoldr/example.csv │
   └─────────────────────────────────────┘        
                                                                                                                           
```


### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Allow using opt-in AWS regions for S3 automatically when the region is not specified in the endpoint. Reference: [opt-in AWS regions](https://docs.aws.amazon.com/global-infrastructure/latest/regions/aws-regions.html).
