### PR TITLE
Cancel query on Ctrl-C when --pager used

### DIFF
--- a/ci/docker/fasttest/Dockerfile
+++ b/ci/docker/fasttest/Dockerfile
@@ -43,7 +43,7 @@ RUN curl -s https://apt.kitware.com/keys/kitware-archive-latest.asc | gpg --dear
     echo "deb [signed-by=/etc/apt/trusted.gpg.d/kitware.gpg] https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main" >> /etc/apt/sources.list.d/kitware.list
 
 # moreutils - provides ts fo FT
-# expect, bzip2 - requried by FT
+# expect, bzip2, less - requried by FT
 # bsdmainutils - provides hexdump for FT
 # nasm - nasm copiler for one of submodules, required from normal build
 # yasm - asssembler for libhdfs3, required from normal build
@@ -63,6 +63,7 @@ RUN apt-get update \
         python3-pip \
         zstd \
         moreutils \
+        less \
         expect \
         bsdmainutils \
         pv \

--- a/ci/docker/test-base/Dockerfile
+++ b/ci/docker/test-base/Dockerfile
@@ -56,6 +56,7 @@ RUN apt-get update \
         git \
         gperf \
         moreutils \
+        less \
         nasm \
         pigz \
         rename \

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -1,4 +1,3 @@
-#include <csignal>
 #include "config.h"
 
 #include <Client/ClientBase.h>
@@ -96,6 +95,7 @@
 #include <mutex>
 #include <string_view>
 #include <unordered_map>
+#include <csignal>
 #include <boost/algorithm/string/case_conv.hpp>
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/algorithm/string/split.hpp>

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -1654,6 +1654,7 @@ void ClientBase::resetOutput()
     if (pager_cmd)
     {
         pager_cmd->in.close();
+        /// The process will terminated in destructor anyway (due to terminate_in_destructor_strategy.terminate_in_destructor=true)
         if (!cancelled)
             pager_cmd->wait();
 

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -1,3 +1,4 @@
+#include <csignal>
 #include "config.h"
 
 #include <Client/ClientBase.h>
@@ -651,18 +652,13 @@ try
         {
             if (SIG_ERR == signal(SIGPIPE, SIG_IGN))
                 throw ErrnoException(ErrorCodes::CANNOT_SET_SIGNAL_HANDLER, "Cannot set signal handler for SIGPIPE");
-            /// We need to reset signals that had been installed in the
-            /// setupSignalHandler() since terminal will send signals to both
-            /// processes and so signals will be delivered to the
-            /// clickhouse-client/local as well, which will be terminated when
-            /// signal will be delivered second time.
-            if (SIG_ERR == signal(SIGINT, SIG_IGN))
-                throw ErrnoException(ErrorCodes::CANNOT_SET_SIGNAL_HANDLER, "Cannot set signal handler for SIGINT");
             if (SIG_ERR == signal(SIGQUIT, SIG_IGN))
                 throw ErrnoException(ErrorCodes::CANNOT_SET_SIGNAL_HANDLER, "Cannot set signal handler for SIGQUIT");
 
             ShellCommand::Config config(pager);
             config.pipe_stdin_only = true;
+            config.terminate_in_destructor_strategy.terminate_in_destructor = true;
+            config.terminate_in_destructor_strategy.termination_signal = SIGTERM;
             pager_cmd = ShellCommand::execute(config);
             out_buf = &pager_cmd->in;
         }
@@ -1658,12 +1654,11 @@ void ClientBase::resetOutput()
     if (pager_cmd)
     {
         pager_cmd->in.close();
-        pager_cmd->wait();
+        if (!cancelled)
+            pager_cmd->wait();
 
         if (SIG_ERR == signal(SIGPIPE, SIG_DFL))
             throw ErrnoException(ErrorCodes::CANNOT_SET_SIGNAL_HANDLER, "Cannot set signal handler for SIGPIPE");
-        if (SIG_ERR == signal(SIGINT, SIG_DFL))
-            throw ErrnoException(ErrorCodes::CANNOT_SET_SIGNAL_HANDLER, "Cannot set signal handler for SIGINT");
         if (SIG_ERR == signal(SIGQUIT, SIG_DFL))
             throw ErrnoException(ErrorCodes::CANNOT_SET_SIGNAL_HANDLER, "Cannot set signal handler for SIGQUIT");
 

--- a/tests/queries/0_stateless/03701_pager_proper_termination.expect
+++ b/tests/queries/0_stateless/03701_pager_proper_termination.expect
@@ -1,7 +1,7 @@
 #!/usr/bin/expect -f
 
 # This test is about interaction with pager and proper handling of
-# SIGINT (Ctrl-C) sent to the pager.
+# SIGINT (Ctrl-C) sent to the pager and cancelling the query.
 #
 # https://github.com/ClickHouse/ClickHouse/issues/80778
 
@@ -29,9 +29,23 @@ expect_after {
 spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CLIENT_BINARY \$CLICKHOUSE_CLIENT_EXPECT_OPT --history_file=$history_file --pager=less"
 expect "\n:) "
 
-send -- "SELECT sleepEachRow(1) FROM numbers(30) SETTINGS max_block_size=1, function_sleep_max_microseconds_per_block=30e6"
-send \x03
-expect "\n:)"
+send -- "SELECT sleepEachRow(1) FROM numbers(180) SETTINGS max_block_size=1, function_sleep_max_microseconds_per_block=180e6"
+
+# Ctrl+C
+send "\3"
+
+# We should make sure, the query is terminated
+set timeout 30
+expect "\n:) "
+
+# There should be no extra output from pager
+expect {
+    "\n" {
+        exit 1
+    }
+    default {
+    }
+}
 
 # Ctrl+D
 send -- "\4"

--- a/tests/queries/0_stateless/03701_pager_proper_termination.expect
+++ b/tests/queries/0_stateless/03701_pager_proper_termination.expect
@@ -26,7 +26,10 @@ expect_after {
     -i $any_spawn_id timeout { exit 1 }
 }
 
-spawn bash -c "source $basedir/../shell_config.sh ; TERM=xterm \$CLICKHOUSE_CLIENT_BINARY \$CLICKHOUSE_CLIENT_EXPECT_OPT --history_file=$history_file --pager=less"
+# Override some envs:
+# - TERM - do not rely on env (i.e. avoids "WARNING: terminal is not fully functional")
+# - LESS - remove any default options that may change less behavior (i.e. when it does not require Q for quiting if amount of output is less then screen size)
+spawn bash -c "source $basedir/../shell_config.sh ; TERM=xterm LESS= \$CLICKHOUSE_CLIENT_BINARY \$CLICKHOUSE_CLIENT_EXPECT_OPT --history_file=$history_file --pager=less"
 expect ":) "
 
 send -- "SELECT 'foobar' || number::String, sleepEachRow(.1) FROM numbers(1000) FORMAT LineAsString SETTINGS max_block_size=1\r"
@@ -40,6 +43,10 @@ set timeout 30
 expect "Query was cancelled."
 expect " in set."
 expect ":) "
+
+# Exit from less - q + Ctrl-C (just in case)
+send "q"
+send "\3"
 
 # Ctrl+D
 send -- "\4"

--- a/tests/queries/0_stateless/03701_pager_proper_termination.expect
+++ b/tests/queries/0_stateless/03701_pager_proper_termination.expect
@@ -1,0 +1,38 @@
+#!/usr/bin/expect -f
+
+# This test is about interaction with pager and proper handling of
+# SIGINT (Ctrl-C) sent to the pager.
+#
+# https://github.com/ClickHouse/ClickHouse/issues/80778
+
+set basedir [file dirname $argv0]
+set basename [file tail $argv0]
+if {[info exists env(CLICKHOUSE_TMP)]} {
+    set CLICKHOUSE_TMP $env(CLICKHOUSE_TMP)
+} else {
+    set CLICKHOUSE_TMP "."
+}
+exp_internal -f $CLICKHOUSE_TMP/$basename.debuglog 0
+set history_file $CLICKHOUSE_TMP/$basename.history
+
+log_user 0
+set timeout 60
+match_max 100000
+
+expect_after {
+    # Do not ignore eof from expect
+    -i $any_spawn_id eof { exp_continue }
+    # A default timeout action is to do nothing, change it to fail
+    -i $any_spawn_id timeout { exit 1 }
+}
+
+spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CLIENT_BINARY \$CLICKHOUSE_CLIENT_EXPECT_OPT --history_file=$history_file --pager=less"
+expect "\n:) "
+
+send -- "SELECT sleepEachRow(1) FROM numbers(30) SETTINGS max_block_size=1, function_sleep_max_microseconds_per_block=30e6"
+send \x03
+expect "\n:)"
+
+# Ctrl+D
+send -- "\4"
+expect eof

--- a/tests/queries/0_stateless/03701_pager_proper_termination.expect
+++ b/tests/queries/0_stateless/03701_pager_proper_termination.expect
@@ -27,25 +27,19 @@ expect_after {
 }
 
 spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CLIENT_BINARY \$CLICKHOUSE_CLIENT_EXPECT_OPT --history_file=$history_file --pager=less"
-expect "\n:) "
+expect ":) "
 
-send -- "SELECT sleepEachRow(1) FROM numbers(180) SETTINGS max_block_size=1, function_sleep_max_microseconds_per_block=180e6"
-
-# Ctrl+C
+send -- "SELECT 'foobar' || number::String, sleepEachRow(.1) FROM numbers(1000) FORMAT LineAsString SETTINGS max_block_size=1\r"
+# Wait for the first line
+expect "foobar0"
+# Cancel the query with Ctrl+C
 send "\3"
 
 # We should make sure, the query is terminated
 set timeout 30
-expect "\n:) "
-
-# There should be no extra output from pager
-expect {
-    "\n" {
-        exit 1
-    }
-    default {
-    }
-}
+expect "Query was cancelled."
+expect " in set."
+expect ":) "
 
 # Ctrl+D
 send -- "\4"

--- a/tests/queries/0_stateless/03701_pager_proper_termination.expect
+++ b/tests/queries/0_stateless/03701_pager_proper_termination.expect
@@ -26,7 +26,7 @@ expect_after {
     -i $any_spawn_id timeout { exit 1 }
 }
 
-spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CLIENT_BINARY \$CLICKHOUSE_CLIENT_EXPECT_OPT --history_file=$history_file --pager=less"
+spawn bash -c "source $basedir/../shell_config.sh ; TERM=xterm \$CLICKHOUSE_CLIENT_BINARY \$CLICKHOUSE_CLIENT_EXPECT_OPT --history_file=$history_file --pager=less"
 expect ":) "
 
 send -- "SELECT 'foobar' || number::String, sleepEachRow(.1) FROM numbers(1000) FORMAT LineAsString SETTINGS max_block_size=1\r"

--- a/tests/queries/0_stateless/03701_pager_proper_termination.expect
+++ b/tests/queries/0_stateless/03701_pager_proper_termination.expect
@@ -44,10 +44,29 @@ expect "Query was cancelled."
 expect " in set."
 expect ":) "
 
-# Exit from less - q + Ctrl-C (just in case)
-send "q"
-send "\3"
-
-# Ctrl+D
-send -- "\4"
-expect eof
+# Try to exit from less and client in a loop, since client will hang if less is still alive
+set is_done 0
+set timeout 1
+set total_wait 0
+while {$is_done == 0 && $total_wait < 60} {
+    # Exit from less with q + Ctrl-C (just in case)
+    send "q"
+    send "\3"
+    # And try to exit from client (will hang if less is still alive)
+    send -- "\4"
+    expect {
+        eof {
+            set is_done 1
+        }
+        timeout {
+            incr total_wait 1
+        }
+        default {
+            # Reset the expect_after
+        }
+    }
+}
+if {$is_done == 0} {
+    send_user "less did not quit\n"
+    exit 1
+}


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
User can now cancel the query by pressing Ctrl-C when the pager is running. Resolves #80778

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

### Details

Trying to process SIGINT query and terminate the pager. I have great concerns about what should be done: different pagers behave differently. Some could pass-through the signal, some -- not. Different signals could be handled differently, etc. The patch is more like a fast-and-dirty fix of particular use cases:

pagers: `more`, `less`
queries:
  - `SELECT 3`
  - `SELECT * FROM numbers(1e12) format Null`
  - `SELECT * FROM numbers(300)`

behavior:
  - try to wait for result (for short queries) and exit from pager
  - for long-running queries, try cancel and then assert that pager is terminated

Resolves #80778
