### PR TITLE
Fix SET DEFINER access check for ephemeral users

### DIFF
--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -2506,8 +2506,10 @@ void InterpreterCreateQuery::processSQLSecurityOption(ContextMutablePtr context_
     if (sql_security.definer && !skip_check_permissions)
     {
         auto definer_name = sql_security.definer->toString();
-        auto & access_control = context_->getAccessControl();
+        if (definer_name != current_user_name)
+            context_->checkAccess(AccessType::SET_DEFINER, definer_name);
 
+        auto & access_control = context_->getAccessControl();
         const auto user = access_control.read<User>(definer_name);
         if (access_control.isEphemeral(access_control.getID<User>(definer_name)))
         {
@@ -2519,9 +2521,6 @@ void InterpreterCreateQuery::processSQLSecurityOption(ContextMutablePtr context_
             new_user->authentication_methods.emplace_back(AuthenticationType::NO_AUTHENTICATION);
             access_control.insertOrReplace(new_user);
         }
-
-        if (definer_name != current_user_name)
-            context_->checkAccess(AccessType::SET_DEFINER, definer_name);
     }
 
     if (sql_security.type == SQLSecurityType::NONE && !skip_check_permissions)

--- a/tests/queries/0_stateless/03701_check_ephemeral_set_definer_access.sh
+++ b/tests/queries/0_stateless/03701_check_ephemeral_set_definer_access.sh
@@ -19,7 +19,7 @@ CREATE TABLE $db.source (x Int64) ENGINE = MergeTree() ORDER BY x;
 EOF
 
 ${CLICKHOUSE_CLIENT} --user $user <<EOF
-CREATE MATERIALIZE VIEW $db.test_view
+CREATE MATERIALIZED VIEW $db.test_view
 (
     x Int64
 )

--- a/tests/queries/0_stateless/03701_check_ephemeral_set_definer_access.sh
+++ b/tests/queries/0_stateless/03701_check_ephemeral_set_definer_access.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Tags: no-replicated-database, no-async-insert, no-fasttest
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+user="user03701_${CLICKHOUSE_DATABASE}_$RANDOM"
+db=${CLICKHOUSE_DATABASE}
+
+${CLICKHOUSE_CLIENT} <<EOF
+-- Cleanup
+DROP USER IF EXISTS $user;
+CREATE USER $user IN memory;
+GRANT ALL ON *.* TO $user;
+REVOKE SET DEFINER ON * FROM $user;
+
+CREATE TABLE $db.source (x Int64) ENGINE = MergeTree() ORDER BY x;
+EOF
+
+${CLICKHOUSE_CLIENT} --user $user <<EOF
+CREATE MATERIALIZE VIEW $db.test_view
+(
+    x Int64
+)
+ENGINE = MergeTree() ORDER BY x
+DEFINER = CURRENT_USER SQL SECURITY DEFINER
+AS SELECT x FROM $db.source;
+EOF
+
+${CLICKHOUSE_CLIENT} <<EOF
+DROP USER IF EXISTS $user;
+EOF


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Do not check access `SET DEFINER <current_user>:definer` when creating a view with SQL SECURITY DEFINER.


<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
