### PR TITLE
Order aware LIMIT BY transform

### DIFF
--- a/src/Core/SortDescription.cpp
+++ b/src/Core/SortDescription.cpp
@@ -1,4 +1,5 @@
 #include <Core/Block.h>
+#include <Core/Names.h>
 #include <Core/SortDescription.h>
 #include <IO/Operators.h>
 #include <Columns/IColumn.h>
@@ -63,6 +64,22 @@ bool SortDescription::hasPrefix(const SortDescription & prefix) const
     for (size_t i = 0; i < prefix.size(); ++i)
     {
         if ((*this)[i] != prefix[i])
+            return false;
+    }
+    return true;
+}
+
+bool SortDescription::hasPrefix(const Names & prefix) const
+{
+    if (prefix.empty())
+        return true;
+
+    if (prefix.size() > size())
+        return false;
+
+    for (size_t i = 0; i < prefix.size(); ++i)
+    {
+        if ((*this)[i].column_name != prefix[i])
             return false;
     }
     return true;

--- a/src/Core/SortDescription.h
+++ b/src/Core/SortDescription.h
@@ -127,6 +127,7 @@ public:
     bool compile_sort_description = false;
 
     bool hasPrefix(const SortDescription & prefix) const;
+    bool hasPrefix(const Names & prefix) const;
 };
 
 /// Returns a copy of lhs containing only the prefix of columns matching rhs's columns.

--- a/src/Processors/QueryPlan/LimitByStep.cpp
+++ b/src/Processors/QueryPlan/LimitByStep.cpp
@@ -44,7 +44,7 @@ void LimitByStep::transformPipeline(QueryPipelineBuilder & pipeline, const Build
         if (stream_type != QueryPipelineBuilder::StreamType::Main)
             return nullptr;
 
-        return std::make_shared<LimitByTransform>(header, group_length, group_offset, columns);
+        return std::make_shared<LimitByTransform>(header, group_length, group_offset, in_order, columns);
     });
 }
 
@@ -111,6 +111,11 @@ std::unique_ptr<IQueryPlanStep> LimitByStep::deserialize(Deserialization & ctx)
         readStringBinary(column, ctx.in);
 
     return std::make_unique<LimitByStep>(ctx.input_headers.front(), group_length, group_offset, std::move(columns));
+}
+
+void LimitByStep::applyOrder(SortDescription sort_description)
+{
+    in_order = sort_description.hasPrefix(columns);
 }
 
 void registerLimitByStep(QueryPlanStepRegistry & registry)

--- a/src/Processors/QueryPlan/LimitByStep.h
+++ b/src/Processors/QueryPlan/LimitByStep.h
@@ -24,6 +24,7 @@ public:
 
     static std::unique_ptr<IQueryPlanStep> deserialize(Deserialization & ctx);
 
+    void applyOrder(SortDescription sort_desc);
 private:
     void updateOutputHeader() override
     {
@@ -32,7 +33,10 @@ private:
 
     size_t group_length;
     size_t group_offset;
+
     Names columns;
+
+    bool in_order = false;
 };
 
 }

--- a/src/Processors/QueryPlan/Optimizations/applyOrder.cpp
+++ b/src/Processors/QueryPlan/Optimizations/applyOrder.cpp
@@ -5,6 +5,7 @@
 #include <Processors/QueryPlan/DistinctStep.h>
 #include <Processors/QueryPlan/ExpressionStep.h>
 #include <Processors/QueryPlan/FilterStep.h>
+#include <Processors/QueryPlan/LimitByStep.h>
 #include <Processors/QueryPlan/MergingAggregatedStep.h>
 #include <Processors/QueryPlan/UnionStep.h>
 #include <Processors/QueryPlan/ReadFromMergeTree.h>
@@ -134,6 +135,11 @@ SortingProperty applyOrder(QueryPlan::Node * parent, SortingProperty * propertie
 
         auto scope = sorting_step->hasPartitions() ? SortingProperty::SortScope::Stream : SortingProperty::SortScope::Global;
         return {sorting_step->getSortDescription(), scope};
+    }
+
+    if (auto * limit_by_step = typeid_cast<LimitByStep *>(parent->step.get()))
+    {
+        limit_by_step->applyOrder(properties->sort_description);
     }
 
     if (auto * transforming = dynamic_cast<ITransformingStep *>(parent->step.get()))

--- a/src/Processors/Transforms/LimitByTransform.h
+++ b/src/Processors/Transforms/LimitByTransform.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <Columns/IColumn.h>
 #include <Processors/ISimpleTransform.h>
 #include <Processors/RowsBeforeStepCounter.h>
 #include <Common/HashTable/HashMap.h>
@@ -11,9 +12,9 @@ namespace DB
 class LimitByTransform : public ISimpleTransform
 {
 public:
-    LimitByTransform(SharedHeader header, UInt64 group_length_, UInt64 group_offset_, const Names & columns);
+    LimitByTransform(SharedHeader header, UInt64 group_length_, UInt64 group_offset_, bool in_order_, const Names & columns);
 
-    String getName() const override { return "LimitByTransform"; }
+    String getName() const override;
 
     void setRowsBeforeLimitCounter(RowsBeforeStepCounterPtr counter) override { rows_before_limit_at_least.swap(counter); }
 
@@ -21,12 +22,21 @@ protected:
     void transform(Chunk & chunk) override;
 
 private:
+    void transformCommon(Chunk & chunk);
+    void transformInOrder(Chunk & chunk);
+    void finalizeChunk(Chunk & chunk, Columns && columns, const IColumn::Filter & filter, UInt64 num_rows, UInt64 inserted_count);
+
     using MapHashed = HashMap<UInt128, UInt64, UInt128TrivialHash>;
 
     MapHashed keys_counts;
     std::vector<size_t> key_positions;
     const UInt64 group_length;
     const UInt64 group_offset;
+    const bool in_order;
+
+    UInt128 current_key;
+    UInt64 current_key_count = 0;
+    bool first_row = true;
 
     RowsBeforeStepCounterPtr rows_before_limit_at_least;
 };

--- a/tests/queries/0_stateless/03701_limit_by_in_order.reference
+++ b/tests/queries/0_stateless/03701_limit_by_in_order.reference
@@ -1,0 +1,75 @@
+Unsorted ORDER BY key LIMIT BY key: LimitByTransform (InOrder)
+Unsorted ORDER BY key DESC LIMIT BY key: LimitByTransform (InOrder)
+Unsorted ORDER BY key, val LIMIT BY key: LimitByTransform (InOrder)
+Unsorted ORDER BY val LIMIT BY key: LimitByTransform
+Unsorted ORDER BY val, key LIMIT BY key: LimitByTransform
+Unsorted ORDER BY key LIMIT BY key, val: LimitByTransform
+Unsorted ORDER BY key, dt LIMIT BY key, val: LimitByTransform
+Unsorted w/o ORDER BY: LimitByTransform
+
+-- Unsorted with LIMIT 1 BY
+0
+1
+2
+3
+4
+10
+11
+12
+50
+51
+-- Unsorted with LIMIT 2 BY
+0
+0
+1
+1
+2
+2
+3
+3
+4
+4
+10
+10
+11
+11
+12
+12
+
+Sorted ORDER BY key LIMIT BY key: LimitByTransform (InOrder)
+Sorted ORDER BY key DESC LIMIT BY key: LimitByTransform (InOrder)
+Sorted ORDER BY key, val LIMIT BY key: LimitByTransform (InOrder)
+Sorted ORDER BY val LIMIT BY key: LimitByTransform
+Sorted ORDER BY val, key LIMIT BY key: LimitByTransform
+Sorted ORDER BY key LIMIT BY key, val: LimitByTransform
+Sorted ORDER BY key, dt LIMIT BY key, val: LimitByTransform
+Sorted w/o ORDER BY: LimitByTransform
+
+-- Sorted with LIMIT 1 BY
+0
+1
+2
+3
+4
+10
+11
+12
+50
+51
+-- Sorted with LIMIT 2 BY
+0
+0
+1
+1
+2
+2
+3
+3
+4
+4
+10
+10
+11
+11
+12
+12

--- a/tests/queries/0_stateless/03701_limit_by_in_order.sql
+++ b/tests/queries/0_stateless/03701_limit_by_in_order.sql
@@ -1,0 +1,103 @@
+-- In order version of LIMIT BY works only if analyzer enabled
+SET enable_analyzer = 1;
+
+DROP TABLE IF EXISTS 03701_unsorted, 03701_sorted;
+
+CREATE TABLE 03701_unsorted (key UInt32, val UInt32, dt Date) engine=MergeTree ORDER BY tuple();
+
+INSERT INTO 03701_unsorted SELECT intDiv(number, 2), number, '2025-05-05' FROM numbers(10);
+INSERT INTO 03701_unsorted SELECT intDiv(number, 3) + 10, number, '2025-05-06' FROM numbers(9);
+INSERT INTO 03701_unsorted SELECT number + 50, number, '2025-05-07' FROM numbers(500);
+
+-- DISTINCT for explain outputs are required due to parallel replicas tests, as there
+-- are created multiple LimitByTransforms (pushed down to replicas and the global one)
+
+SELECT DISTINCT 'Unsorted ORDER BY key LIMIT BY key: ' || trim(BOTH ' ' FROM explain)
+FROM (EXPLAIN PIPELINE SELECT key FROM 03701_unsorted ORDER BY key LIMIT 1 BY key LIMIT 10)
+WHERE explain LIKE '%LimitByTransform%';
+
+SELECT DISTINCT 'Unsorted ORDER BY key DESC LIMIT BY key: ' || trim(BOTH ' ' FROM explain)
+FROM (EXPLAIN PIPELINE SELECT key FROM 03701_unsorted ORDER BY key DESC LIMIT 1 BY key LIMIT 10)
+WHERE explain LIKE '%LimitByTransform%';
+
+SELECT DISTINCT 'Unsorted ORDER BY key, val LIMIT BY key: ' || trim(BOTH ' ' FROM explain)
+FROM (EXPLAIN PIPELINE SELECT key FROM 03701_unsorted ORDER BY key, val LIMIT 1 BY key LIMIT 10)
+WHERE explain LIKE '%LimitByTransform%';
+
+SELECT DISTINCT 'Unsorted ORDER BY val LIMIT BY key: ' || trim(BOTH ' ' FROM explain)
+FROM (EXPLAIN PIPELINE SELECT key FROM 03701_unsorted ORDER BY val LIMIT 1 BY key LIMIT 10)
+WHERE explain LIKE '%LimitByTransform%';
+
+SELECT DISTINCT 'Unsorted ORDER BY val, key LIMIT BY key: ' || trim(BOTH ' ' FROM explain)
+FROM (EXPLAIN PIPELINE SELECT key FROM 03701_unsorted ORDER BY val, key LIMIT 1 BY key LIMIT 10)
+WHERE explain LIKE '%LimitByTransform%';
+
+SELECT DISTINCT 'Unsorted ORDER BY key LIMIT BY key, val: ' || trim(BOTH ' ' FROM explain)
+FROM (EXPLAIN PIPELINE SELECT key FROM 03701_unsorted ORDER BY key LIMIT 1 BY key, val LIMIT 10)
+WHERE explain LIKE '%LimitByTransform%';
+
+SELECT DISTINCT 'Unsorted ORDER BY key, dt LIMIT BY key, val: ' || trim(BOTH ' ' FROM explain)
+FROM (EXPLAIN PIPELINE SELECT key FROM 03701_unsorted ORDER BY key, dt LIMIT 1 BY key, val LIMIT 10)
+WHERE explain LIKE '%LimitByTransform%';
+
+SELECT DISTINCT 'Unsorted w/o ORDER BY: ' || trim(BOTH ' ' FROM explain)
+FROM (EXPLAIN PIPELINE SELECT key FROM 03701_unsorted LIMIT 1 BY key LIMIT 10)
+WHERE explain LIKE '%LimitByTransform%';
+
+SELECT '';
+
+SELECT '-- Unsorted with LIMIT 1 BY';
+SELECT key FROM 03701_unsorted ORDER BY key LIMIT 1 BY key LIMIT 10;
+SELECT '-- Unsorted with LIMIT 2 BY';
+SELECT key FROM 03701_unsorted ORDER BY key LIMIT 2 BY key LIMIT 16;
+
+DROP TABLE 03701_unsorted;
+
+CREATE TABLE 03701_sorted (key UInt32, val UInt32, dt Date) engine=MergeTree ORDER BY key;
+
+INSERT INTO 03701_sorted SELECT intDiv(number, 2), number, '2025-05-05' FROM numbers(10);
+INSERT INTO 03701_sorted SELECT intDiv(number, 3) + 10, number, '2025-05-06' FROM numbers(9);
+INSERT INTO 03701_sorted SELECT number + 50, number, '2025-05-07' FROM numbers(500);
+
+SELECT '';
+
+SELECT DISTINCT 'Sorted ORDER BY key LIMIT BY key: ' || trim(BOTH ' ' FROM explain)
+FROM (EXPLAIN PIPELINE SELECT key FROM 03701_sorted ORDER BY key LIMIT 1 BY key LIMIT 10)
+WHERE explain LIKE '%LimitByTransform%';
+
+SELECT DISTINCT 'Sorted ORDER BY key DESC LIMIT BY key: ' || trim(BOTH ' ' FROM explain)
+FROM (EXPLAIN PIPELINE SELECT key FROM 03701_sorted ORDER BY key DESC LIMIT 1 BY key LIMIT 10)
+WHERE explain LIKE '%LimitByTransform%';
+
+SELECT DISTINCT 'Sorted ORDER BY key, val LIMIT BY key: ' || trim(BOTH ' ' FROM explain)
+FROM (EXPLAIN PIPELINE SELECT key FROM 03701_sorted ORDER BY key, val LIMIT 1 BY key LIMIT 10)
+WHERE explain LIKE '%LimitByTransform%';
+
+SELECT DISTINCT 'Sorted ORDER BY val LIMIT BY key: ' || trim(BOTH ' ' FROM explain)
+FROM (EXPLAIN PIPELINE SELECT key FROM 03701_sorted ORDER BY val LIMIT 1 BY key LIMIT 10)
+WHERE explain LIKE '%LimitByTransform%';
+
+SELECT DISTINCT 'Sorted ORDER BY val, key LIMIT BY key: ' || trim(BOTH ' ' FROM explain)
+FROM (EXPLAIN PIPELINE SELECT key FROM 03701_sorted ORDER BY val, key LIMIT 1 BY key LIMIT 10)
+WHERE explain LIKE '%LimitByTransform%';
+
+SELECT DISTINCT 'Sorted ORDER BY key LIMIT BY key, val: ' || trim(BOTH ' ' FROM explain)
+FROM (EXPLAIN PIPELINE SELECT key FROM 03701_sorted ORDER BY key LIMIT 1 BY key, val LIMIT 10)
+WHERE explain LIKE '%LimitByTransform%';
+
+SELECT DISTINCT 'Sorted ORDER BY key, dt LIMIT BY key, val: ' || trim(BOTH ' ' FROM explain)
+FROM (EXPLAIN PIPELINE SELECT key FROM 03701_sorted ORDER BY key, dt LIMIT 1 BY key, val LIMIT 10)
+WHERE explain LIKE '%LimitByTransform%';
+
+SELECT DISTINCT 'Sorted w/o ORDER BY: ' || trim(BOTH ' ' FROM explain)
+FROM (EXPLAIN PIPELINE SELECT key FROM 03701_sorted LIMIT 1 BY key LIMIT 10)
+WHERE explain LIKE '%LimitByTransform%';
+
+SELECT '';
+
+SELECT '-- Sorted with LIMIT 1 BY';
+SELECT key FROM 03701_sorted ORDER BY key LIMIT 1 BY key LIMIT 10;
+SELECT '-- Sorted with LIMIT 2 BY';
+SELECT key FROM 03701_sorted ORDER BY key LIMIT 2 BY key LIMIT 16;
+
+DROP TABLE 03701_sorted;


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
Alternative transform variation for LIMIT BY, which allows to process input without storing all processed values in case it's already sorted by LIMIT BY key columns.

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Run streaming LIMIT BY transform in cases when input sort order matches LIMIT BY keys.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)
