### PR TITLE
*: avoid use of unqualified pow().

### DIFF
--- a/src/Common/tests/gtest_dns_reverse_resolve.cpp
+++ b/src/Common/tests/gtest_dns_reverse_resolve.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include <thread>
+#include <cmath>
 #include <Common/DNSPTRResolverProvider.h>
 #include <Common/DNSResolver.h>
 #include <Poco/Net/IPAddress.h>
@@ -19,10 +20,10 @@ TEST(Common, ReverseDNS)
             auto & dns_resolver_instance = DNSResolver::instance();
             dns_resolver_instance.setDisableCacheFlag();
 
-            auto val1 = rnd1() % static_cast<uint32_t>((pow(2, 31) - 1));
-            auto val2 = rnd1() % static_cast<uint32_t>((pow(2, 31) - 1));
-            auto val3 = rnd1() % static_cast<uint32_t>((pow(2, 31) - 1));
-            auto val4 = rnd1() % static_cast<uint32_t>((pow(2, 31) - 1));
+            auto val1 = rnd1() % static_cast<uint32_t>((std::pow(2, 31) - 1));
+            auto val2 = rnd1() % static_cast<uint32_t>((std::pow(2, 31) - 1));
+            auto val3 = rnd1() % static_cast<uint32_t>((std::pow(2, 31) - 1));
+            auto val4 = rnd1() % static_cast<uint32_t>((std::pow(2, 31) - 1));
 
             uint32_t ipv4_buffer[1] = {
                 static_cast<uint32_t>(val1)

--- a/src/Core/MySQL/MySQLUtils.cpp
+++ b/src/Core/MySQL/MySQLUtils.cpp
@@ -1,11 +1,11 @@
 #include <Core/MySQL/MySQLUtils.h>
-
 #include <Common/assert_cast.h>
 #include <Columns/ColumnNullable.h>
 #include <Columns/ColumnsDateTime.h>
 #include <Core/DecimalFunctions.h>
 #include <DataTypes/IDataType.h>
 
+#include <cmath>
 
 namespace DB
 {
@@ -36,7 +36,7 @@ DecimalUtils::DecimalComponents<DateTime64> getNormalizedDateTime64Components(Da
         if (scale > 6)
         {
             // MySQL Timestamp has max scale of 6
-            components.fractional /= static_cast<int>(pow(10, scale - 6));
+            components.fractional /= static_cast<int>(std::pow(10, scale - 6));
         }
         else
         {
@@ -47,7 +47,7 @@ DecimalUtils::DecimalComponents<DateTime64> getNormalizedDateTime64Components(Da
             // Scale 4 = 000100
             // Scale 5 = 000010
             // Scale 6 = 000001
-            components.fractional *= static_cast<int>(pow(10, 6 - scale));
+            components.fractional *= static_cast<int>(std::pow(10, 6 - scale));
         }
     }
 

--- a/src/Functions/array/arrayDistance.cpp
+++ b/src/Functions/array/arrayDistance.cpp
@@ -8,6 +8,8 @@
 #include <Functions/FunctionFactory.h>
 #include <Functions/FunctionHelpers.h>
 
+#include <cmath>
+
 #if USE_MULTITARGET_CODE
 #include <immintrin.h>
 #endif
@@ -189,7 +191,7 @@ struct LpDistance
     template <typename ResultType>
     static void accumulate(State<ResultType> & state, ResultType x, ResultType y, const ConstParams & params)
     {
-        state.sum += static_cast<ResultType>(pow(fabs(x - y), params.power));
+        state.sum += static_cast<ResultType>(std::pow(fabs(x - y), params.power));
     }
 
     template <typename ResultType>
@@ -201,7 +203,7 @@ struct LpDistance
     template <typename ResultType>
     static ResultType finalize(const State<ResultType> & state, const ConstParams & params)
     {
-        return static_cast<ResultType>(pow(state.sum, params.inverted_power));
+        return static_cast<ResultType>(std::pow(state.sum, params.inverted_power));
     }
 };
 

--- a/src/Functions/makeDate.cpp
+++ b/src/Functions/makeDate.cpp
@@ -500,7 +500,7 @@ public:
 
         const auto & date_lut = DateLUT::instance(timezone);
 
-        const auto max_fraction = pow(10, precision) - 1;
+        const auto max_fraction = std::pow(10, precision) - 1;
         const auto min_date_time = minDateTime(date_lut);
         const auto max_date_time = maxDateTime(date_lut);
 

--- a/src/Parsers/Kusto/ParserKQLDateTypeTimespan.cpp
+++ b/src/Parsers/Kusto/ParserKQLDateTypeTimespan.cpp
@@ -193,7 +193,7 @@ bool ParserKQLDateTypeTimespan ::parseConstKQLTimespan(const String & text)
         }
     }
     auto exponent = 9 - sec_scale_len; // max supported length of fraction of seconds is 9
-    nanoseconds = nanoseconds * pow(10, exponent);
+    nanoseconds = nanoseconds * std::pow(10, exponent);
 
     if (sign)
         time_span = -(days * 86400 + hours * 3600 + minutes * 60 + seconds + (nanoseconds / 1000000000));


### PR DESCRIPTION
libc implementations *may* include pow() in the global namespace when we include cmath, but this isn't guaranteed. To ensure portability with libc implementations that don't place pow() in the global namespace, replace unqualified pow() with std::pow(). Also explicitly include cmath where used so that we don't rely on transitive includes.

For context, Oxide currently builds ClickHouse to run on Illumos using a [collection of patches](https://github.com/oxidecomputer/garbage-compactor/tree/master/clickhouse/patches). This is brittle, and we'd like to upstream patches where it makes sense, with the eventual goal of making upstream ClickHouse fully compatible with Illumos.

cc @bnaecker

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
