### PR TITLE
Docs: add page for shared database engine

### DIFF
--- a/docs/en/engines/database-engines/shared.md
+++ b/docs/en/engines/database-engines/shared.md
@@ -1,0 +1,39 @@
+---
+description: 'Page describing the `Shared` database engine, available in ClickHouse Cloud'
+sidebar_label: 'Shared'
+sidebar_position: 10
+slug: /engines/database-engines/shared
+title: 'Shared'
+doc_type: 'reference'
+---
+
+import CloudOnlyBadge from '@theme/badges/CloudOnlyBadge';
+
+<CloudOnlyBadge/>
+
+# Shared database engine
+
+The `Shared` database engine works in conjunction with Shared Catalog to manage databases whose tables use stateless table engines such as [`SharedMergeTree`](/cloud/reference/shared-merge-tree).
+These table engines do not write persistent state to disk and are compatible with dynamic compute environments.
+
+The `Shared` database engine in Cloud removes the dependency for local disks. It is  a purely in-memory engine, requiring only CPU and memory.
+
+## How does it work? {#how-it-works}
+
+The `Shared` database engine stores all database and table definitions in a central Shared Catalog backed by Keeper. Instead of writing to local disk, it maintains a single versioned global state shared across all compute nodes.
+
+Each node tracks only the last applied version and, on startup, fetches the latest state without the need for local files or manual setup.
+
+## Syntax {#syntax}
+
+For end users, using Shared Catalog and the Shared database engine requires no additional configuration. Database creation is the same as always:
+
+```sql
+CREATE DATABASE my_database;
+```
+
+ClickHouse Cloud automatically assigns the Shared database engine to databases. Any tables created within such a database using stateless engines will automatically benefit from Shared Catalog’s replication and coordination capabilities.
+
+:::tip
+For more information on Shared Catalog and it's benefits, see ["Shared catalog and shared database engine"](/cloud/reference/shared-catalog) in the Cloud reference section.
+:::

--- a/docs/en/engines/database-engines/shared.md
+++ b/docs/en/engines/database-engines/shared.md
@@ -16,7 +16,8 @@ import CloudOnlyBadge from '@theme/badges/CloudOnlyBadge';
 The `Shared` database engine works in conjunction with Shared Catalog to manage databases whose tables use stateless table engines such as [`SharedMergeTree`](/cloud/reference/shared-merge-tree).
 These table engines do not write persistent state to disk and are compatible with dynamic compute environments.
 
-The `Shared` database engine in Cloud removes the dependency for local disks. It is  a purely in-memory engine, requiring only CPU and memory.
+The `Shared` database engine in Cloud removes the dependency for local disks.
+It is a purely in-memory engine, requiring only CPU and memory.
 
 ## How does it work? {#how-it-works}
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
Closes https://github.com/ClickHouse/clickhouse-docs/issues/4576. We have a page for Shared catalog in the Cloud section but it makes sense to add it here as well I think. This page provides a brief overview and points to the Cloud section for further details.
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
