### PR TITLE
Fix test comments

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1473,7 +1473,7 @@ class TestCase:
         )
 
         testcase_args.testcase_client = (
-            f"{testcase_args.client} --log_comment f'{testcase_args.testcase_basename}-{testcase_args.testcase_database}'"
+            f"{testcase_args.client} --log_comment '{testcase_args.testcase_basename}-{testcase_args.testcase_database}'"
         )
 
         return testcase_args


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Now, log_comment for test queries starts with f, like `f02989_replicated_merge_tree_invalid_metadata_version.sql-test_kq50vskn`, should be just the name of the test + database. This can break CI history analysis.
