### PR TITLE
Don't use metadata cache in iceberg history table

### DIFF
--- a/src/Storages/System/StorageSystemIcebergHistory.cpp
+++ b/src/Storages/System/StorageSystemIcebergHistory.cpp
@@ -31,6 +31,7 @@ namespace DB
 namespace Setting
 {
     extern const SettingsSeconds lock_acquire_timeout;
+    extern const SettingsBool use_iceberg_metadata_files_cache;
 }
 
 ColumnsDescription StorageSystemIcebergHistory::getColumnsDescription()
@@ -49,7 +50,12 @@ ColumnsDescription StorageSystemIcebergHistory::getColumnsDescription()
 void StorageSystemIcebergHistory::fillData([[maybe_unused]] MutableColumns & res_columns, [[maybe_unused]] ContextPtr context, const ActionsDAG::Node *, std::vector<UInt8>) const
 {
 #if USE_AVRO
-    const auto access = context->getAccess();
+    ContextMutablePtr context_copy = Context::createCopy(context);
+    Settings settings_copy = context_copy->getSettingsCopy();
+    settings_copy[Setting::use_iceberg_metadata_files_cache] = false;
+    context_copy->setSettings(settings_copy);
+
+    const auto access = context_copy->getAccess();
 
     auto add_history_record = [&](const DatabaseTablesIteratorPtr & it, StorageObjectStorage * object_storage)
     {
@@ -60,9 +66,9 @@ void StorageSystemIcebergHistory::fillData([[maybe_unused]] MutableColumns & res
         /// to handle properly all possible errors which we can get when attempting to read metadata of iceberg table
         try
         {
-            if (IcebergMetadata * iceberg_metadata = dynamic_cast<IcebergMetadata *>(object_storage->getExternalMetadata(context)); iceberg_metadata)
+            if (IcebergMetadata * iceberg_metadata = dynamic_cast<IcebergMetadata *>(object_storage->getExternalMetadata(context_copy)); iceberg_metadata)
             {
-                IcebergMetadata::IcebergHistory iceberg_history_items = iceberg_metadata->getHistory(context);
+                IcebergMetadata::IcebergHistory iceberg_history_items = iceberg_metadata->getHistory(context_copy);
 
                 for (auto & iceberg_history_item : iceberg_history_items)
                 {
@@ -87,15 +93,15 @@ void StorageSystemIcebergHistory::fillData([[maybe_unused]] MutableColumns & res
 
     if (show_tables_granted)
     {
-        auto databases = DatabaseCatalog::instance().getDatabases(GetDatabasesOptions{.with_datalake_catalogs = true});
+        auto databases = DatabaseCatalog::instance().getDatabases();
         for (const auto & db: databases)
         {
             /// with last flag we are filtering out all non iceberg table
-            for (auto iterator = db.second->getLightweightTablesIterator(context, {}, true); iterator->isValid(); iterator->next())
+            for (auto iterator = db.second->getLightweightTablesIterator(context_copy, {}, true); iterator->isValid(); iterator->next())
             {
                 StoragePtr storage = iterator->table();
 
-                TableLockHolder lock = storage->tryLockForShare(context->getCurrentQueryId(), context->getSettingsRef()[Setting::lock_acquire_timeout]);
+                TableLockHolder lock = storage->tryLockForShare(context_copy->getCurrentQueryId(), context_copy->getSettingsRef()[Setting::lock_acquire_timeout]);
                 if (!lock)
                     // Table was dropped while acquiring the lock, skipping table
                     continue;

--- a/src/Storages/System/StorageSystemIcebergHistory.cpp
+++ b/src/Storages/System/StorageSystemIcebergHistory.cpp
@@ -93,7 +93,7 @@ void StorageSystemIcebergHistory::fillData([[maybe_unused]] MutableColumns & res
 
     if (show_tables_granted)
     {
-        auto databases = DatabaseCatalog::instance().getDatabases();
+        auto databases = DatabaseCatalog::instance().getDatabases(GetDatabasesOptions{.with_datalake_catalogs = true});
         for (const auto & db: databases)
         {
             /// with last flag we are filtering out all non iceberg table


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


I don't know how to reproduce in tests, but there are incorrect results on cloud instance.

Example:

```
clickhouse-cloud :) SELECT * FROM system.iceberg_history;

SELECT *
FROM system.iceberg_history

Query id: 1faea7fd-de87-48e2-834e-039c12491b63

   ┌─database─┬─table──────────────────────┬─────────made_current_at─┬─────────snapshot_id─┬─parent_id─┬─is_current_ancestor─┐
1. │ demo     │ iceberg_benchmark.supplier │ 2025-04-24 00:26:24.684 │ 6064979558040146583 │         0 │                   1 │
2. │ demona   │ iceberg_benchmark.supplier │ 2025-04-24 00:26:24.684 │ 6064979558040146583 │         0 │                   1 │
   └──────────┴────────────────────────────┴─────────────────────────┴─────────────────────┴───────────┴─────────────────────┘

2 rows in set. Elapsed: 5.790 sec. 

clickhouse-cloud :) SHOW TABLES FROM demo;


SHOW TABLES FROM demo

Query id: ad5b5169-d4d0-481d-b6bb-dbdbf75a612d

    ┌─name───────────────────────────┐
 1. │ default.iceberg_table          │
 2. │ iceberg_benchmark.customer     │
 3. │ iceberg_benchmark.lineitem     │
 4. │ iceberg_benchmark.minmax_test  │
 5. │ iceberg_benchmark.nation       │
 6. │ iceberg_benchmark.orders       │
 7. │ iceberg_benchmark.part         │
 8. │ iceberg_benchmark.partsupp     │
 9. │ iceberg_benchmark.region       │
10. │ iceberg_benchmark.supplier     │
11. │ iceberg_benchmark.tmp_customer │
12. │ iceberg_benchmark.tmp_lineitem │
13. │ iceberg_benchmark.tmp_nation   │
14. │ iceberg_benchmark.tmp_orders   │
15. │ iceberg_benchmark.tmp_part     │
16. │ iceberg_benchmark.tmp_partsupp │
17. │ iceberg_benchmark.tmp_region   │
18. │ iceberg_benchmark.tmp_supplier │
    └────────────────────────────────┘

19 rows in set. Elapsed: 4.355 sec. 
```

The problem is in the iceberg metadata cache:

```
clickhouse-cloud :) SELECT * FROM system.iceberg_history;

SELECT *
FROM system.iceberg_history

Query id: fcd8abeb-9f32-4acd-9fed-3b86fe11c15d

Ok.

0 rows in set. Elapsed: 6.888 sec. 

clickhouse-cloud :) SELECT * FROM demo.`iceberg_benchmark.nation`;

SELECT *
FROM demo.`iceberg_benchmark.nation`

Query id: 900da3a5-7308-4397-be6a-6f5a132170a1

<SOME RESULT>
25 rows in set. Elapsed: 0.872 sec. 

clickhouse-cloud :) SELECT * FROM system.iceberg_history;

SELECT *
FROM system.iceberg_history

Query id: f7437810-4c7b-4cb2-8856-594851cf21ce

   ┌─database─┬─table────────────────────┬─────────made_current_at─┬─────────snapshot_id─┬─parent_id─┬─is_current_ancestor─┐
1. │ demo     │ iceberg_benchmark.nation │ 2025-04-24 00:21:33.606 │ 6393331569208561908 │         0 │                   1 │
2. │ demona   │ iceberg_benchmark.nation │ 2025-04-24 00:21:33.606 │ 6393331569208561908 │         0 │                   1 │
   └──────────┴──────────────────────────┴─────────────────────────┴─────────────────────┴───────────┴─────────────────────┘

2 rows in set. Elapsed: 6.144 sec. 

clickhouse-cloud :) SYSTEM DROP ICEBERG METADATA CACHE

SYSTEM DROP ICEBERG METADATA CACHE

Query id: 74cf4936-f28b-4dfa-8124-9a3447459132

Ok.

0 rows in set. Elapsed: 0.242 sec. 

clickhouse-cloud :) SELECT * FROM system.iceberg_history;

SELECT *
FROM system.iceberg_history

Query id: 1b18900c-d39b-44b5-8921-b656023ec254

Ok.

0 rows in set. Elapsed: 6.803 sec. 

clickhouse-cloud :) 
```

So let's disable it in iceberg history table