### PR TITLE
Negative bars in the Web UI

### DIFF
--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -49,6 +49,7 @@
             --element-color-ok: #080;
             --element-background-color-fail: #FEE;
             --bar-color: #FF8; /* Light bar in background of table cells. */
+            --bar-color-negative: #FEE;
             --border-color: #CCC;
             --shadow-color: rgba(0, 0, 0, 0.1);
             --button-color: #FF0;
@@ -81,6 +82,7 @@
             --element-color-ok: #8F8;
             --element-background-color-fail: #300;
             --bar-color: #320;
+            --bar-color-negative: #311;
             --border-color: #444;
             --shadow-color: rgba(0, 0, 0, 0.1);
             --text-color: #CCC;
@@ -1059,14 +1061,14 @@ password_elem.addEventListener('paste', () => setTimeout(checkCredentials, 100))
 
 
 function queryToColor(str) {
-    let hash = 0;
+    let hash = 2166136261;
     for (let i = 0; i < str.length; i++) {
-        hash = ((hash << 5) - hash) + str.charCodeAt(i);
-        hash = hash & hash;
+        hash ^= str.charCodeAt(i);
+        hash = Math.imul(hash, 16777619);
     }
 
     /// Limited range to avoid violet colors.
-    return 50 + Math.abs(hash % 200);
+    return 50 + ((hash >>> 0) % 200);
 }
 
 function toBase64(str) {
@@ -1889,19 +1891,51 @@ function renderExtremes() {
             && extremes.min[name] !== undefined && extremes.max[name] !== undefined
             && Number(extremes.max[name]) > Number(extremes.min[name])) {
             let table = document.getElementById('data-table');
+
+            const double_sided = extremes.min[name] < 0;
+            const ratio_positive = extremes.max[name] / (extremes.max[name] - extremes.min[name]);
+            const ratio_negative = 1 - ratio_positive;
+
             for (let row of table.rows) {
                 let cell = row.cells[col_idx];
                 let value = +cell.innerText;
-                if (value > 0) {
-                    const ratio = 100 * value / extremes.max[name];
 
-                    cell.style.cssText = `
-                        background-size: 100% 50%;
-                        background-position: center;
-                        background-repeat: no-repeat;
-                        background: linear-gradient(to right,
-                            var(--bar-color) 0%, var(--bar-color) ${ratio}%,
-                            var(--element-background-color) ${ratio}%, var(--element-background-color) 100%)`;
+                if (!double_sided) {
+                    if (value > 0) {
+                        const ratio = value / extremes.max[name];
+
+                        cell.style.cssText = `
+                            background-size: 100% 50%;
+                            background-position: center;
+                            background-repeat: no-repeat;
+                            background: linear-gradient(to right,
+                                var(--bar-color) 0%, var(--bar-color) ${100 * ratio}%,
+                                var(--element-background-color) ${100 * ratio}%, var(--element-background-color) 100%)`;
+                    }
+                } else {
+                    if (value > 0) {
+                        const ratio = value / extremes.max[name];
+
+                        cell.style.cssText = `
+                            background-size: 100% 50%;
+                            background-position: center;
+                            background-repeat: no-repeat;
+                            background: linear-gradient(to right,
+                                var(--element-background-color) 0%, var(--element-background-color) ${100 * ratio_negative}%,
+                                var(--bar-color) ${100 * ratio_negative}%, var(--bar-color) ${100 * (ratio_negative + ratio * ratio_positive)}%,
+                                var(--element-background-color) ${100 * (ratio_negative + ratio * ratio_positive)}%, var(--element-background-color) 100%)`;
+                    } else if (value < 0) {
+                        const ratio = value / extremes.min[name];
+
+                        cell.style.cssText = `
+                            background-size: 100% 50%;
+                            background-position: center;
+                            background-repeat: no-repeat;
+                            background: linear-gradient(to right,
+                                var(--element-background-color) 0%, var(--element-background-color) ${100 * (1 - ratio) * ratio_negative}%,
+                                var(--bar-color-negative) ${100 * (1 - ratio) * ratio_negative}%, var(--bar-color-negative) ${100 * ratio_negative}%,
+                                var(--element-background-color) ${100 * ratio_negative}%, var(--element-background-color) 100%)`;
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Web UI will display bars in the table even when the values are negative. So it can display a double-sided bar chart with different colors of bars on the negative and positive sides.

<img width="1230" height="969" alt="Screenshot_20251027_064411" src="https://github.com/user-attachments/assets/af03584c-3f64-43af-82c9-59cd1d01d01d" />

<img width="1232" height="967" alt="Screenshot_20251027_064424" src="https://github.com/user-attachments/assets/a0a93ae4-f3e2-4070-8344-bd2b1ad1efda" />
