### PR TITLE
Use `ubuntu:24.04` as base container image

### DIFF
--- a/ci/docker/fasttest/Dockerfile
+++ b/ci/docker/fasttest/Dockerfile
@@ -1,5 +1,5 @@
 # docker build -t clickhouse/fasttest .
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 # ARG for quick switch to a given ubuntu mirror
 ARG apt_archive="http://archive.ubuntu.com"

--- a/ci/docker/install/deb/Dockerfile
+++ b/ci/docker/install/deb/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 # The Dockerfile is nicely borrowed from
 # https://github.com/lionelnicolas/docker-ubuntu-systemd/blob/83aa3249146f5df264fe45353f79fc76eb1e42d7/Dockerfile

--- a/ci/docker/integration/mysql_dotnet_client/Dockerfile
+++ b/ci/docker/integration/mysql_dotnet_client/Dockerfile
@@ -1,6 +1,6 @@
 # docker build -t clickhouse/mysql_dotnet_client .
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 WORKDIR /testapp
 

--- a/ci/docker/sqlancer-test/Dockerfile
+++ b/ci/docker/sqlancer-test/Dockerfile
@@ -1,5 +1,5 @@
 # docker build -t clickhouse/sqlancer-test .
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 # ARG for quick switch to a given ubuntu mirror
 ARG apt_archive="http://archive.ubuntu.com"

--- a/ci/docker/style-test/Dockerfile
+++ b/ci/docker/style-test/Dockerfile
@@ -1,5 +1,5 @@
 # docker build -t clickhouse/style-test .
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install --yes \
         aspell \

--- a/ci/docker/test-base/Dockerfile
+++ b/ci/docker/test-base/Dockerfile
@@ -1,6 +1,6 @@
 # rebuild in #33610
 # docker build -t clickhouse/test-base .
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 # ARG for quick switch to a given ubuntu mirror
 ARG apt_archive="http://archive.ubuntu.com"

--- a/docker/keeper/Dockerfile
+++ b/docker/keeper/Dockerfile
@@ -1,7 +1,7 @@
 # The Dockerfile.ubuntu exists for the tests/ci/docker_server.py script
 # If the image is built from Dockerfile.alpine, then the `-alpine` suffix is added automatically,
 # so the only purpose of Dockerfile.ubuntu is to push `latest`, `head` and so on w/o suffixes
-FROM ubuntu:22.04 AS glibc-donor
+FROM ubuntu:24.04 AS glibc-donor
 ARG TARGETARCH
 
 RUN arch=${TARGETARCH:-amd64} \

--- a/docker/server/Dockerfile.alpine
+++ b/docker/server/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04 AS glibc-donor
+FROM ubuntu:24.04 AS glibc-donor
 ARG TARGETARCH
 
 RUN arch=${TARGETARCH:-amd64} \

--- a/docker/server/Dockerfile.ubuntu
+++ b/docker/server/Dockerfile.ubuntu
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 # see https://github.com/moby/moby/issues/4032#issuecomment-192327844
 # It could be removed after we move on a version 23:04+


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Use ubuntu:24.04 as a base for server image.
