### PR TITLE
Prohibit creation of different plain disks with the shared object storage paths

### DIFF
--- a/src/Disks/DiskSelector.cpp
+++ b/src/Disks/DiskSelector.cpp
@@ -36,21 +36,24 @@ void DiskSelector::recordDisk(const std::string & disk_name, DiskPtr disk)
                 continue;
 
             /// Same endpoint
-            if (disk->getObjectStorage()->getDescription() == saved_disk->getObjectStorage()->getDescription())
-            {
-                /// Same bucket
-                if (disk->getObjectStorage()->getObjectsNamespace() == saved_disk->getObjectStorage()->getObjectsNamespace())
-                {
-                    /// Nested common keys
-                    const auto new_prefix = disk->getObjectStorage()->getCommonKeyPrefix();
-                    const auto saved_prefix = saved_disk->getObjectStorage()->getCommonKeyPrefix();
-                    if (new_prefix.starts_with(saved_prefix) || saved_prefix.starts_with(new_prefix))
-                        if (disk->supportsCache() == saved_disk->supportsCache())
-                            throw Exception(ErrorCodes::BAD_ARGUMENTS,
-                                "It is not possible to register multiple plain-rewritable disks with the same object storage prefix. Disks '{}' and '{}'",
-                                disk_name, saved_disk_name);
-                }
-            }
+            if (disk->getObjectStorage()->getDescription() != saved_disk->getObjectStorage()->getDescription())
+                continue;
+
+            /// Same bucket
+            if (disk->getObjectStorage()->getObjectsNamespace() != saved_disk->getObjectStorage()->getObjectsNamespace())
+                continue;
+
+            /// Allow cache and non-cache versions of the same disk
+            if (disk->supportsCache() != saved_disk->supportsCache())
+                continue;
+
+            /// Nested common keys
+            const auto new_prefix = disk->getObjectStorage()->getCommonKeyPrefix();
+            const auto saved_prefix = saved_disk->getObjectStorage()->getCommonKeyPrefix();
+            if (new_prefix.starts_with(saved_prefix) || saved_prefix.starts_with(new_prefix))
+                throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                    "It is not possible to register multiple plain-rewritable disks with the same object storage prefix. Disks '{}' and '{}'",
+                    disk_name, saved_disk_name);
         }
     }
 

--- a/src/Disks/DiskSelector.cpp
+++ b/src/Disks/DiskSelector.cpp
@@ -45,9 +45,10 @@ void DiskSelector::recordDisk(const std::string & disk_name, DiskPtr disk)
                     const auto new_prefix = disk->getObjectStorage()->getCommonKeyPrefix();
                     const auto saved_prefix = saved_disk->getObjectStorage()->getCommonKeyPrefix();
                     if (new_prefix.starts_with(saved_prefix) || saved_prefix.starts_with(new_prefix))
-                        throw Exception(ErrorCodes::BAD_ARGUMENTS,
-                            "It is not possible to register multiple plain-rewritable disks with the same object storage prefix. Disks '{}' and '{}'",
-                            disk_name, saved_disk_name);
+                        if (disk->supportsCache() == saved_disk->supportsCache())
+                            throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                                "It is not possible to register multiple plain-rewritable disks with the same object storage prefix. Disks '{}' and '{}'",
+                                disk_name, saved_disk_name);
                 }
             }
         }

--- a/src/Disks/DiskSelector.cpp
+++ b/src/Disks/DiskSelector.cpp
@@ -28,7 +28,6 @@ void DiskSelector::assertInitialized() const
 
 void DiskSelector::recordDisk(const std::string & disk_name, DiskPtr disk)
 {
-    const auto new_prefix = disk->getObjectStorage()->getCommonKeyPrefix();
     if (disk->isPlain())
     {
         for (const auto & [_, saved_disk] : disks)
@@ -36,6 +35,7 @@ void DiskSelector::recordDisk(const std::string & disk_name, DiskPtr disk)
             if (!saved_disk->isPlain())
                 continue;
 
+            const auto new_prefix = disk->getObjectStorage()->getCommonKeyPrefix();
             const auto saved_prefix = saved_disk->getObjectStorage()->getCommonKeyPrefix();
             if (new_prefix.starts_with(saved_prefix) || saved_prefix.starts_with(new_prefix))
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "It is not possible to register multiple plain-rewritable disks with the same object storage prefix");

--- a/src/Disks/DiskSelector.cpp
+++ b/src/Disks/DiskSelector.cpp
@@ -1,5 +1,6 @@
 #include <Disks/DiskLocal.h>
 #include <Disks/DiskSelector.h>
+#include <Disks/ObjectStorages/IObjectStorage.h>
 
 #include <IO/WriteHelpers.h>
 #include <Common/escapeForFileName.h>
@@ -16,8 +17,8 @@ namespace ErrorCodes
     extern const int EXCESSIVE_ELEMENT_IN_CONFIG;
     extern const int UNKNOWN_DISK;
     extern const int LOGICAL_ERROR;
+    extern const int BAD_ARGUMENTS;
 }
-
 
 void DiskSelector::assertInitialized() const
 {
@@ -25,6 +26,24 @@ void DiskSelector::assertInitialized() const
         throw Exception(ErrorCodes::LOGICAL_ERROR, "DiskSelector not initialized");
 }
 
+void DiskSelector::recordDisk(const std::string & disk_name, DiskPtr disk)
+{
+    if (disk->isPlain())
+    {
+        for (const auto & [_, saved_disk] : disks)
+        {
+            if (!saved_disk->isPlain())
+                continue;
+
+            if (disk->getObjectStorage()->getCommonKeyPrefix() == saved_disk->getObjectStorage()->getCommonKeyPrefix())
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "It is not possible to register multiple plain-rewritable disks with the same object storage prefix");
+        }
+    }
+
+    const auto [_, inserted] = disks.emplace(disk_name, std::move(disk));
+    if (!inserted)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Disk with name `{}` is already in disks map", disk_name);
+}
 
 void DiskSelector::initialize(
     const Poco::Util::AbstractConfiguration & config, const String & config_prefix, ContextPtr context, DiskValidator disk_validator)
@@ -55,23 +74,21 @@ void DiskSelector::initialize(
             = factory.create(disk_name, config, disk_config_prefix, context, disks, /*attach*/ false, /*custom_disk*/ false, skip_types);
         if (created_disk.get())
         {
-            disks.emplace(disk_name, std::move(created_disk));
+            recordDisk(disk_name, std::move(created_disk));
         }
     }
     if (!has_default_disk)
     {
-        disks.emplace(
-            DEFAULT_DISK_NAME, std::make_shared<DiskLocal>(DEFAULT_DISK_NAME, context->getPath(), 0, context, config, config_prefix));
+        recordDisk(DEFAULT_DISK_NAME, std::make_shared<DiskLocal>(DEFAULT_DISK_NAME, context->getPath(), 0, context, config, config_prefix));
     }
 
     if (!has_local_disk && (context->getApplicationType() == Context::ApplicationType::DISKS))
     {
         throw_away_local_on_update = true;
-        disks.emplace(LOCAL_DISK_NAME, std::make_shared<DiskLocal>(LOCAL_DISK_NAME, "/", 0, context, config, config_prefix));
+        recordDisk(LOCAL_DISK_NAME, std::make_shared<DiskLocal>(LOCAL_DISK_NAME, "/", 0, context, config, config_prefix));
     }
     is_initialized = true;
 }
-
 
 DiskSelectorPtr DiskSelector::updateFromConfig(
     const Poco::Util::AbstractConfiguration & config, const String & config_prefix, ContextPtr context) const
@@ -153,7 +170,6 @@ DiskSelectorPtr DiskSelector::updateFromConfig(
     return result;
 }
 
-
 DiskPtr DiskSelector::tryGet(const String & name) const
 {
     assertInitialized();
@@ -177,15 +193,11 @@ const DisksMap & DiskSelector::getDisksMap() const
     return disks;
 }
 
-
 void DiskSelector::addToDiskMap(const String & name, DiskPtr disk)
 {
     assertInitialized();
-    auto [_, inserted] = disks.emplace(name, disk);
-    if (!inserted)
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Disk with name `{}` is already in disks map", name);
+    recordDisk(name, disk);
 }
-
 
 void DiskSelector::shutdown()
 {

--- a/src/Disks/DiskSelector.cpp
+++ b/src/Disks/DiskSelector.cpp
@@ -28,6 +28,7 @@ void DiskSelector::assertInitialized() const
 
 void DiskSelector::recordDisk(const std::string & disk_name, DiskPtr disk)
 {
+    const auto new_prefix = disk->getObjectStorage()->getCommonKeyPrefix();
     if (disk->isPlain())
     {
         for (const auto & [_, saved_disk] : disks)
@@ -35,7 +36,8 @@ void DiskSelector::recordDisk(const std::string & disk_name, DiskPtr disk)
             if (!saved_disk->isPlain())
                 continue;
 
-            if (disk->getObjectStorage()->getCommonKeyPrefix() == saved_disk->getObjectStorage()->getCommonKeyPrefix())
+            const auto saved_prefix = saved_disk->getObjectStorage()->getCommonKeyPrefix();
+            if (new_prefix.starts_with(saved_prefix) || saved_prefix.starts_with(new_prefix))
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "It is not possible to register multiple plain-rewritable disks with the same object storage prefix");
         }
     }

--- a/src/Disks/DiskSelector.h
+++ b/src/Disks/DiskSelector.h
@@ -54,6 +54,7 @@ private:
     bool is_initialized = false;
 
     void assertInitialized() const;
+    void recordDisk(const std::string & disk_name, DiskPtr disk);
 
     const std::unordered_set<String> skip_types;
 

--- a/tests/integration/test_database_disk_setting/test.py
+++ b/tests/integration/test_database_disk_setting/test.py
@@ -166,7 +166,7 @@ def test_attach_db_from_readonly_remote_disk(start_cluster):
     db_uuid = node1.query(
         f"SELECT uuid FROM system.databases WHERE database='{db_name}'"
     ).strip()
-    table_disk_setting = 'disk(type = "s3_plain_rewritable", endpoint = "http://minio1:9001/root/data/disks/disk_s3_plain_rewritable/", access_key_id="minio", secret_access_key = "ClickHouse_Minio_P@ssw0rd")'
+    table_disk_setting = "'s3_plain_rewritable'"
     node1.query(
         f"CREATE TABLE {db_name}.test (x INT, y INT) ENGINE=MergeTree ORDER BY x SETTINGS disk={table_disk_setting}"
     )

--- a/tests/integration/test_s3_plain_rewritable_rotate_tables/test.py
+++ b/tests/integration/test_s3_plain_rewritable_rotate_tables/test.py
@@ -69,7 +69,6 @@ def start_cluster():
         with_minio=True,
         env_variables={
             "ENDPOINT_SUBPATH": "node2",
-            "ROTATED_REPLICA_ENDPOINT_SUBPATH": "node1",
         },
         stay_alive=True,
         instance_env_variables=True,
@@ -172,3 +171,5 @@ def test_alter_partition_after_table_rotation(start_cluster, storage_policy, par
 
     node2.query(f"DROP TABLE {rotated_table} SYNC")
     node2.query(f"DROP TABLE {table2} SYNC")
+    node1.restart_clickhouse()
+    node2.restart_clickhouse()


### PR DESCRIPTION
`PlainRewritable` disks store their file system tree in memory. If another disk changes the object storage structure, the in-memory structure will not be updated, which will lead to invalid file system operations and possible no such key errors.

<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):
- Backward Incompatible Change

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Prohibit the creation of multiple `plain-rewritable` disks on top of the shared object storage path, as this can lead to undefined behavior during collisions of different metadata storage transactions.