### PR TITLE
Fix misleading comment: these flags enable (1=allow) plaintext/no_password

### DIFF
--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -594,7 +594,7 @@
     <!-- NOTE: all files with `tmp` prefix will be removed at server startup -->
     <tmp_path>/var/lib/clickhouse/tmp/</tmp_path>
 
-    <!-- Disable AuthType plaintext_password and no_password for ACL. -->
+    <!-- Enable AuthType plaintext_password and no_password for ACL (1 = allow, 0 = forbid). -->
     <allow_plaintext_password>1</allow_plaintext_password>
     <allow_no_password>1</allow_no_password>
     <allow_implicit_no_password>1</allow_implicit_no_password>


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Details

The configuration comment currently says "Disable AuthType plaintext_password and no_password", but the flags set to 1 actually "enable" these auth types. Updated the comment to accurately state that 1 = allow and 0 = forbid.

Fixes #87964
