### PR TITLE
Refactor text index code a bit

### DIFF
--- a/src/Storages/IndicesDescription.cpp
+++ b/src/Storages/IndicesDescription.cpp
@@ -133,6 +133,7 @@ void IndexDescription::initExpressionInfo(ASTPtr index_expression, const Columns
 
     ReplaceAliasToExprVisitor::Data data{columns};
     ReplaceAliasToExprVisitor{data}.visit(expr_list);
+
     expression_list_ast = expr_list->clone();
 
     TreeRewriterResultPtr syntax = TreeRewriter(context).analyze(

--- a/src/Storages/IndicesDescription.cpp
+++ b/src/Storages/IndicesDescription.cpp
@@ -16,6 +16,7 @@
 #include <Core/Defines.h>
 #include <Common/Exception.h>
 
+#include <Storages/MergeTree/MergeTreeIndexText.h>
 
 namespace DB
 {
@@ -23,78 +24,6 @@ namespace ErrorCodes
 {
     extern const int INCORRECT_QUERY;
     extern const int LOGICAL_ERROR;
-}
-
-namespace
-{
-using ReplaceAliasToExprVisitor = InDepthNodeVisitor<ReplaceAliasByExpressionMatcher, true>;
-
-
-Tuple parseTextIndexArgumentFromAST(const ASTPtr & arguments)
-{
-    Tuple parameter;
-
-    /// Parse parameter name. It can be Identifier.
-    {
-        if (const auto * identifier = arguments->children[0]->as<ASTIdentifier>(); identifier != nullptr)
-            parameter.emplace_back(identifier->name());
-        else
-            throw Exception(ErrorCodes::INCORRECT_QUERY, "Text index parameter name: Expected identifier");
-    }
-
-    /// Parse parameter value. It can be Literal, Identifier or Function.
-    {
-        if (const auto * literal = arguments->children[1]->as<ASTLiteral>(); literal != nullptr)
-        {
-            parameter.emplace_back(literal->value);
-        }
-        else if (const auto * identifier = arguments->children[1]->as<ASTIdentifier>(); identifier != nullptr)
-        {
-            parameter.emplace_back(identifier->name());
-        }
-        else if (const auto * function = arguments->children[1]->as<ASTFunction>(); function != nullptr)
-        {
-            Tuple tuple;
-            tuple.emplace_back(function->name);
-            for (const auto & argument : function->arguments->children)
-            {
-                if (const auto * arg = argument->as<ASTLiteral>(); arg != nullptr)
-                    tuple.emplace_back(arg->value);
-                else
-                    throw Exception(ErrorCodes::INCORRECT_QUERY, "Text index function argument: Expected literal");
-            }
-            parameter.emplace_back(tuple);
-        }
-        else
-        {
-            throw Exception(ErrorCodes::INCORRECT_QUERY, "Text index parameter value: Expected literal, identifier or function");
-        }
-    }
-
-    return parameter;
-}
-
-bool parseTextIndexArgumentsFromAST(const ASTPtr & arguments, FieldVector & parsed_arguments)
-{
-    parsed_arguments.reserve(arguments->children.size());
-
-    for (const auto & argument : arguments->children)
-    {
-        if (const auto * ast_function = argument->as<ASTFunction>();
-            ast_function && ast_function->name == "equals" && ast_function->arguments->children.size() == 2)
-        {
-            parsed_arguments.emplace_back(parseTextIndexArgumentFromAST(ast_function->arguments));
-        }
-        else
-        {
-            if (!parsed_arguments.empty())
-                throw Exception(ErrorCodes::INCORRECT_QUERY, "Cannot mix key-value pair and single argument as text index arguments");
-            return false;
-        }
-    }
-
-    return true;
-}
 }
 
 IndexDescription::IndexDescription(const IndexDescription & other)
@@ -166,24 +95,7 @@ IndexDescription IndexDescription::getIndexFromAST(const ASTPtr & definition_ast
     result.type = Poco::toLower(index_type->name);
     result.granularity = index_definition->granularity;
 
-    ASTPtr expr_list;
-    if (auto index_expression = index_definition->getExpression())
-    {
-        expr_list = extractKeyExpressionList(index_expression);
-
-        ReplaceAliasToExprVisitor::Data data{columns};
-        ReplaceAliasToExprVisitor{data}.visit(expr_list);
-
-        result.expression_list_ast = expr_list->clone();
-    }
-    else
-    {
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Expression is not set");
-    }
-
-    auto syntax = TreeRewriter(context).analyze(expr_list, columns.get(GetColumnsOptions(GetColumnsOptions::AllPhysical).withSubcolumns()));
-    result.expression = ExpressionAnalyzer(expr_list, syntax, context).getActions(true);
-    result.sample_block = result.expression->getSampleBlock();
+    result.initExpressionInfo(index_definition->getExpression(), columns, context);
 
     for (auto & elem : result.sample_block)
     {
@@ -196,22 +108,9 @@ IndexDescription IndexDescription::getIndexFromAST(const ASTPtr & definition_ast
 
     if (index_type && index_type->arguments)
     {
-        bool is_text_index = index_type->name == TEXT_INDEX_NAME;
-        if (is_text_index && parseTextIndexArgumentsFromAST(index_type->arguments, result.arguments))
-            return result;
-
-        for (size_t i = 0; i < index_type->arguments->children.size(); ++i)
-        {
-            const auto & child = index_type->arguments->children[i];
-            if (const auto * ast_literal = child->as<ASTLiteral>(); ast_literal != nullptr)
-                /// E.g. INDEX index_name column_name TYPE vector_similarity('hnsw', 'f32')
-                result.arguments.emplace_back(ast_literal->value);
-            else if (const auto * ast_identifier = child->as<ASTIdentifier>(); ast_identifier != nullptr)
-                /// E.g. INDEX index_name column_name TYPE vector_similarity(hnsw, f32)
-                result.arguments.emplace_back(ast_identifier->name());
-            else
-                throw Exception(ErrorCodes::INCORRECT_QUERY, "Only literals can be skip index arguments");
-        }
+        result.arguments = (index_type->name == TEXT_INDEX_NAME)
+            ? MergeTreeIndexText::parseArgumentsListFromAST(index_type->arguments)
+            : IndexDescription::parsePositionalArgumentsFromAST(index_type->arguments);
     }
 
     return result;
@@ -221,6 +120,51 @@ void IndexDescription::recalculateWithNewColumns(const ColumnsDescription & new_
 {
     *this = getIndexFromAST(definition_ast, new_columns, context);
 }
+
+void IndexDescription::initExpressionInfo(ASTPtr index_expression, const ColumnsDescription & columns, ContextPtr context)
+{
+    chassert(index_expression != nullptr);
+
+    using ReplaceAliasToExprVisitor = InDepthNodeVisitor<ReplaceAliasByExpressionMatcher, true>;
+
+    ASTPtr expr_list = extractKeyExpressionList(index_expression);
+    if (expr_list == nullptr)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Expression is not set");
+
+    ReplaceAliasToExprVisitor::Data data{columns};
+    ReplaceAliasToExprVisitor{data}.visit(expr_list);
+    expression_list_ast = expr_list->clone();
+
+    TreeRewriterResultPtr syntax = TreeRewriter(context).analyze(
+        expr_list,
+        columns.get(GetColumnsOptions(GetColumnsOptions::AllPhysical).withSubcolumns())
+    );
+
+    expression = ExpressionAnalyzer(expr_list, syntax, context).getActions(true);
+
+    sample_block = expression->getSampleBlock();
+}
+
+FieldVector IndexDescription::parsePositionalArgumentsFromAST(const ASTPtr & arguments)
+{
+    FieldVector result;
+
+    for (size_t i = 0; i < arguments->children.size(); ++i)
+    {
+        const auto & child = arguments->children[i];
+        if (const auto * ast_literal = child->as<ASTLiteral>(); ast_literal != nullptr)
+            /// E.g. INDEX index_name column_name TYPE vector_similarity('hnsw', 'f32')
+            result.emplace_back(ast_literal->value);
+        else if (const auto * ast_identifier = child->as<ASTIdentifier>(); ast_identifier != nullptr)
+            /// E.g. INDEX index_name column_name TYPE vector_similarity(hnsw, f32)
+            result.emplace_back(ast_identifier->name());
+        else
+            throw Exception(ErrorCodes::INCORRECT_QUERY, "Only literals can be skip index arguments");
+    }
+
+    return result;
+}
+
 
 bool IndicesDescription::has(const String & name) const
 {

--- a/src/Storages/IndicesDescription.h
+++ b/src/Storages/IndicesDescription.h
@@ -65,6 +65,11 @@ struct IndexDescription
     void recalculateWithNewColumns(const ColumnsDescription & new_columns, ContextPtr context);
 
     bool isImplicitlyCreated() const { return name.starts_with(IMPLICITLY_ADDED_MINMAX_INDEX_PREFIX); }
+
+    void initExpressionInfo(ASTPtr index_expression, const ColumnsDescription & columns, ContextPtr context);
+
+private:
+    static FieldVector parsePositionalArgumentsFromAST(const ASTPtr & arguments);
 };
 
 /// All secondary indices in storage

--- a/src/Storages/MergeTree/MergeTreeIndexText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexText.cpp
@@ -1,26 +1,26 @@
-#include <Storages/MergeTree/MergeTreeDataPartChecksum.h>
 #include <Storages/MergeTree/MergeTreeIndexText.h>
 
-#include <Storages/MergeTree/IDataPartStorage.h>
-#include <Storages/MergeTree/MergeTreeWriterStream.h>
-#include <Storages/MergeTree/MergeTreeIndexConditionText.h>
-#include <Columns/ColumnsNumber.h>
 #include <Columns/ColumnString.h>
-#include <DataTypes/Serializations/SerializationNumber.h>
-#include <DataTypes/Serializations/SerializationString.h>
-#include <Interpreters/BloomFilterHash.h>
+#include <Columns/ColumnsNumber.h>
 #include <Common/ElapsedTimeProfileEventIncrement.h>
 #include <Common/HashTable/HashSet.h>
 #include <Common/formatReadable.h>
 #include <Common/logger_useful.h>
+#include <DataTypes/Serializations/SerializationNumber.h>
+#include <DataTypes/Serializations/SerializationString.h>
+#include <Interpreters/BloomFilterHash.h>
 #include <Interpreters/ITokenExtractor.h>
-#include <base/range.h>
-#include <fmt/ranges.h>
-
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier.h>
-#include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTIndexDeclaration.h>
+#include <Parsers/ASTLiteral.h>
+#include <Storages/MergeTree/IDataPartStorage.h>
+#include <Storages/MergeTree/MergeTreeDataPartChecksum.h>
+#include <Storages/MergeTree/MergeTreeIndexConditionText.h>
+#include <Storages/MergeTree/MergeTreeWriterStream.h>
+
+#include <base/range.h>
+#include <fmt/ranges.h>
 
 namespace ProfileEvents
 {

--- a/src/Storages/MergeTree/MergeTreeIndexText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexText.cpp
@@ -1314,9 +1314,10 @@ void textIndexValidator(const IndexDescription & index, bool /*attach*/)
 
 }
 
-/// Static helper functions here.
+namespace
+{
 
-Tuple MergeTreeIndexText::parseNamedArgumentFromAST(const ASTFunction * ast_equal_function)
+Tuple parseNamedArgumentFromAST(const ASTFunction * ast_equal_function)
 {
     if (ast_equal_function == nullptr
         || ast_equal_function->name != "equals"
@@ -1366,17 +1367,17 @@ Tuple MergeTreeIndexText::parseNamedArgumentFromAST(const ASTFunction * ast_equa
     return result;
 }
 
+}
+
 FieldVector MergeTreeIndexText::parseArgumentsListFromAST(const ASTPtr & arguments)
 {
     FieldVector result;
-
     result.reserve(arguments->children.size());
 
     for (const auto & argument : arguments->children)
     {
         const auto * ast_equal_function = argument->as<ASTFunction>();
-
-        result.emplace_back(MergeTreeIndexText::parseNamedArgumentFromAST(ast_equal_function));
+        result.emplace_back(parseNamedArgumentFromAST(ast_equal_function));
     }
 
     return result;

--- a/src/Storages/MergeTree/MergeTreeIndexText.h
+++ b/src/Storages/MergeTree/MergeTreeIndexText.h
@@ -312,7 +312,6 @@ struct MergeTreeIndexAggregatorText final : IMergeTreeIndexAggregator
     MergeTreeIndexTextGranuleBuilder granule_builder;
 };
 
-class ASTFunction;
 class MergeTreeIndexText final : public IMergeTreeIndex
 {
 public:

--- a/src/Storages/MergeTree/MergeTreeIndexText.h
+++ b/src/Storages/MergeTree/MergeTreeIndexText.h
@@ -1,7 +1,4 @@
 #pragma once
-#include <algorithm>
-#include <functional>
-#include <vector>
 #include <Storages/MergeTree/MergeTreeIndices.h>
 #include <Storages/MergeTree/MergeTreeIndexConditionText.h>
 #include <Columns/IColumn.h>
@@ -13,6 +10,8 @@
 #include <Interpreters/BloomFilter.h>
 #include <Interpreters/ITokenExtractor.h>
 #include <absl/container/flat_hash_map.h>
+
+#include <vector>
 
 #include <roaring.hh>
 
@@ -316,7 +315,6 @@ struct MergeTreeIndexAggregatorText final : IMergeTreeIndexAggregator
 class ASTFunction;
 class MergeTreeIndexText final : public IMergeTreeIndex
 {
-    static Tuple parseNamedArgumentFromAST(const ASTFunction * ast_equal_function);
 public:
     MergeTreeIndexText(
         const IndexDescription & index_,
@@ -333,10 +331,10 @@ public:
     MergeTreeIndexAggregatorPtr createIndexAggregator(const MergeTreeWriterSettings & settings) const override;
     MergeTreeIndexConditionPtr createIndexCondition(const ActionsDAG::Node * predicate, ContextPtr context) const override;
 
-    /// This function performs text index specific arguments parsing because text index has a special syntax and more complex arguments.
-    /// 1. It expects only named arguments like: argument = value
-    /// 2. The tokenizer argument can be strings (like other indices), but also function names (literals) or a function-like
-    /// expression (i.e: ngram(5))
+    /// This function parses the arguments of a text index. Text indexes have a special syntax with complex arguments.
+    /// 1. Arguments are named, e.g.: argument = value
+    /// 2. The tokenizer argument can be a string, a function name (literal) or a function-like expression, e.g.: ngram(5)
+    /// 3. The preprocessor argument is a generic expression, e.g. lower(extractTextFromHTML(col)))
     static FieldVector parseArgumentsListFromAST(const ASTPtr & arguments);
 
     MergeTreeIndexTextParams params;


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Details

Refactors the TextIndex code to make it more localized. This is a preparation for another PR.

Changes made to `src/Storages/IndicesDescription.{h,cpp}` and `src/Storages/MergeTree/MergeTreeIndexText.{h,cpp}`:
- parseTextIndexArgumentFromAST moved to MergeTreeIndexText::parseArgumentsListFromAST
- parseTextIndexArgumentsFromAST removed
- getIndexFromAST now uses the new function MergeTreeIndexText::parseArgumentsListFromAST
- initExpressionInfo: New function to group needed actions to initialize expression
- parsePositionalArgumentsFromAST: New function to encapsulate generic arguments parsing
- parseNamedArgumentFromAST and parseArgumentsListFromAST: New functions
