### PR TITLE
Make s3Queue respect disable_insertion_and_mutation server setting

### DIFF
--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -340,6 +340,7 @@ namespace ServerSetting
     extern const ServerSettingsUInt64 background_pool_size;
     extern const ServerSettingsUInt64 background_schedule_pool_size;
     extern const ServerSettingsFloat background_schedule_pool_max_parallel_tasks_per_type_ratio;
+    extern const ServerSettingsBool disable_insertion_and_mutation;
     extern const ServerSettingsBool display_secrets_in_show_and_select;
     extern const ServerSettingsUInt64 max_backup_bandwidth_for_server;
     extern const ServerSettingsUInt64 max_build_vector_similarity_index_thread_pool_size;
@@ -4905,7 +4906,8 @@ void Context::setOSCPUOverloadSettings(double min_os_cpu_wait_time_ratio_to_drop
 bool Context::getS3QueueDisableStreaming() const
 {
     SharedLockGuard lock(shared->mutex);
-    return shared->server_settings[ServerSetting::s3queue_disable_streaming];
+    return shared->server_settings[ServerSetting::s3queue_disable_streaming]
+        || shared->server_settings[ServerSetting::disable_insertion_and_mutation];
 }
 
 void Context::setS3QueueDisableStreaming(bool s3queue_disable_streaming) const

--- a/tests/integration/test_storage_s3_queue/configs/read_only_mode.xml
+++ b/tests/integration/test_storage_s3_queue/configs/read_only_mode.xml
@@ -1,0 +1,3 @@
+<clickhouse>
+    <disable_insertion_and_mutation>true</disable_insertion_and_mutation>
+</clickhouse>

--- a/tests/integration/test_storage_s3_queue/test_5.py
+++ b/tests/integration/test_storage_s3_queue/test_5.py
@@ -138,6 +138,24 @@ def started_cluster():
             ],
             stay_alive=True,
         )
+        cluster.add_instance(
+            "readonly_instance",
+            with_minio=True,
+            with_azurite=True,
+            with_zookeeper=True,
+            main_configs=[
+                "configs/zookeeper.xml",
+                "configs/s3queue_log.xml",
+                "configs/remote_servers.xml",
+                "configs/disable_streaming.xml",
+                "configs/read_only_mode.xml",
+            ],
+            user_configs=[
+                "configs/users.xml",
+                "configs/enable_keeper_fault_injection.xml",
+            ],
+            stay_alive=True,
+        )
 
         logging.info("Starting cluster...")
         cluster.start()
@@ -850,6 +868,47 @@ def test_disable_streaming(started_cluster):
         time.sleep(1)
 
     assert expected_rows == get_count()
+
+
+def test_disable_insertion_and_mutation(started_cluster):
+    node = started_cluster.instances["readonly_instance"]
+
+    table_name = f"test_disable_insertion_and_mutation_{uuid.uuid4().hex[:8]}"
+    dst_table_name = f"{table_name}_dst"
+    keeper_path = f"/clickhouse/test_{table_name}"
+    files_path = f"{table_name}_data"
+    files_to_generate = 10
+
+    assert (
+            "true"
+            == node.query("SELECT getServerSetting('disable_insertion_and_mutation')").strip()
+    )
+
+    create_table(
+        started_cluster,
+        node,
+        table_name,
+        "ordered",
+        files_path,
+        additional_settings={
+            "processing_threads_num": 1,
+            "keeper_path": keeper_path,
+        },
+    )
+
+    generate_random_files(
+        started_cluster, files_path, files_to_generate, start_ind=0, row_num=1
+    )
+
+    create_mv(node, table_name, dst_table_name)
+
+    def get_count():
+        return int(node.query(f"SELECT count() FROM {dst_table_name}"))
+
+    assert node.contains_in_log(
+        f"StorageS3Queue (default.{table_name}): Streaming is disabled, rescheduling next check in 5000 ms"
+    )
+    assert 0 == get_count()
 
 
 def test_shutdown_logs(started_cluster):


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Make s3Queue respect disable_insertion_and_mutation server setting.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)
