### PR TITLE
Add check `SHOW TABLES` access for `CREATE TABLE ... AS ...` queries.

### DIFF
--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -800,6 +800,7 @@ InterpreterCreateQuery::TableProperties InterpreterCreateQuery::getTableProperti
     else if (!create.as_table.empty())
     {
         String as_database_name = getContext()->resolveDatabase(create.as_database);
+        getContext()->checkAccess(AccessType::SHOW_TABLES, as_database_name, create.as_table);
         StoragePtr as_storage = DatabaseCatalog::instance().getTable({as_database_name, create.as_table}, getContext());
 
         /// as_storage->getColumns() and setEngine(...) must be called under structure lock of other_table for CREATE ... AS other_table.

--- a/tests/queries/0_stateless/03702_check_show_grant_in_create_as_query.sh
+++ b/tests/queries/0_stateless/03702_check_show_grant_in_create_as_query.sh
@@ -15,7 +15,7 @@ CREATE TABLE $db.test_table (x int) ORDER BY x;
 GRANT CREATE TABLE ON *.* TO $user;
 EOF
 
-${CLICKHOUSE_CLIENT} --user $user --query "CREATE TABLE $db.test_copy AS test_table; -- { serverError ACCESS_DENIED }";
+${CLICKHOUSE_CLIENT} --user $user --query "CREATE TABLE $db.test_copy AS $db.test_table; -- { serverError ACCESS_DENIED }";
 
 ${CLICKHOUSE_CLIENT} <<EOF
 DROP USER IF EXISTS $user;

--- a/tests/queries/0_stateless/03702_check_show_grant_in_create_as_query.sh
+++ b/tests/queries/0_stateless/03702_check_show_grant_in_create_as_query.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Tags: no-replicated-database
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+user="user03701_${CLICKHOUSE_DATABASE}_$RANDOM"
+db=${CLICKHOUSE_DATABASE}
+
+${CLICKHOUSE_CLIENT} <<EOF
+DROP USER IF EXISTS $user;
+CREATE USER $user;
+CREATE TABLE $db.test_table (x int) ORDER BY x;
+GRANT CREATE TABLE ON *.* TO $user;
+EOF
+
+${CLICKHOUSE_CLIENT} --user $user --query "CREATE TABLE $db.test_copy AS test_table; -- { serverError ACCESS_DENIED }";
+
+${CLICKHOUSE_CLIENT} <<EOF
+DROP USER IF EXISTS $user;
+EOF

--- a/tests/queries/0_stateless/03702_check_show_grant_in_create_as_query.sh
+++ b/tests/queries/0_stateless/03702_check_show_grant_in_create_as_query.sh
@@ -5,7 +5,7 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
-user="user03701_${CLICKHOUSE_DATABASE}_$RANDOM"
+user="user03702_${CLICKHOUSE_DATABASE}_$RANDOM"
 db=${CLICKHOUSE_DATABASE}
 
 ${CLICKHOUSE_CLIENT} <<EOF


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Now ClickHouse checks for SHOW TABLES table access when running queries like CREATE TABLE table_new AS table.
