### PR TITLE
Disable the new parquet reader in the CI

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1170,8 +1170,6 @@ class SettingsRandomizer:
         "use_skip_indexes_if_final": lambda: random.randint(0, 1),
         "use_skip_indexes_on_data_read": lambda: random.randint(0, 1),
         "optimize_rewrite_like_perfect_affix": lambda: random.randint(0, 1),
-        # Use the new reader most of the time.
-        "input_format_parquet_use_native_reader_v3": lambda: min(1, random.randint(0, 5)),
         **randomize_external_sort_group_by(),
     }
 


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

### Details

The test is extremely flaky. Resolves #88893
