### PR TITLE
Add table setting to change compression codec used for Kafka table engines

### DIFF
--- a/docs/en/engines/table-engines/integrations/kafka.md
+++ b/docs/en/engines/table-engines/integrations/kafka.md
@@ -84,7 +84,7 @@ Optional parameters:
 - `kafka_handle_error_mode` — How to handle errors for Kafka engine. Possible values: default (the exception will be thrown if we fail to parse a message), stream (the exception message and raw message will be saved in virtual columns `_error` and `_raw_message`), dead_letter_queue (error related data will be saved in system.dead_letter_queue).
 - `kafka_commit_on_select` —  Commit messages when select query is made. Default: `false`.
 - `kafka_max_rows_per_message` — The maximum number of rows written in one kafka message for row-based formats. Default : `1`.
-- `kafka_compression_codec` — Compression codec used for producing messages. Supported: `none`, `gzip`, `snappy`, `lz4`, `zstd`. Default: `none`.
+- `kafka_compression_codec` — Compression codec used for producing messages. Supported: empty string, `none`, `gzip`, `snappy`, `lz4`, `zstd`. In case of empty string the compression codec is not set by the table, thus values from the config files or default value from `librdkafka` will be used. Default: empty string.
 - `kafka_compression_level` — Compression level parameter for algorithm selected by kafka_compression_codec. Higher values will result in better compression at the cost of more CPU usage. Usable range is algorithm-dependent: `[0-9]` for `gzip`; `[0-12]` for `lz4`; only `0` for `snappy`; `[0-12]` for `zstd`; `-1` = codec-dependent default compression level. Default: `-1`.
 
 Examples:

--- a/docs/en/engines/table-engines/integrations/kafka.md
+++ b/docs/en/engines/table-engines/integrations/kafka.md
@@ -53,7 +53,9 @@ SETTINGS
     [kafka_thread_per_consumer = 0,]
     [kafka_handle_error_mode = 'default',]
     [kafka_commit_on_select = false,]
-    [kafka_max_rows_per_message = 1];
+    [kafka_max_rows_per_message = 1,]
+    [kafka_compression_codec = '',]
+    [kafka_compression_level = -1];
 ```
 
 Required parameters:
@@ -82,6 +84,8 @@ Optional parameters:
 - `kafka_handle_error_mode` — How to handle errors for Kafka engine. Possible values: default (the exception will be thrown if we fail to parse a message), stream (the exception message and raw message will be saved in virtual columns `_error` and `_raw_message`), dead_letter_queue (error related data will be saved in system.dead_letter_queue).
 - `kafka_commit_on_select` —  Commit messages when select query is made. Default: `false`.
 - `kafka_max_rows_per_message` — The maximum number of rows written in one kafka message for row-based formats. Default : `1`.
+- `kafka_compression_codec` — Compression codec used for producing messages. Supported: `none`, `gzip`, `snappy`, `lz4`, `zstd`.
+- `kafka_compression_level` — Compression level parameter for algorithm selected by kafka_compression_codec. Higher values will result in better compression at the cost of more CPU usage. Usable range is algorithm-dependent: `[0-9]` for `gzip`; `[0-12]` for `lz4`; only `0` for `snappy`; `[0-12]` for `zstd`; `-1` = codec-dependent default compression level.
 
 Examples:
 

--- a/docs/en/engines/table-engines/integrations/kafka.md
+++ b/docs/en/engines/table-engines/integrations/kafka.md
@@ -54,7 +54,7 @@ SETTINGS
     [kafka_handle_error_mode = 'default',]
     [kafka_commit_on_select = false,]
     [kafka_max_rows_per_message = 1,]
-    [kafka_compression_codec = '',]
+    [kafka_compression_codec = 'none',]
     [kafka_compression_level = -1];
 ```
 
@@ -84,8 +84,8 @@ Optional parameters:
 - `kafka_handle_error_mode` — How to handle errors for Kafka engine. Possible values: default (the exception will be thrown if we fail to parse a message), stream (the exception message and raw message will be saved in virtual columns `_error` and `_raw_message`), dead_letter_queue (error related data will be saved in system.dead_letter_queue).
 - `kafka_commit_on_select` —  Commit messages when select query is made. Default: `false`.
 - `kafka_max_rows_per_message` — The maximum number of rows written in one kafka message for row-based formats. Default : `1`.
-- `kafka_compression_codec` — Compression codec used for producing messages. Supported: `none`, `gzip`, `snappy`, `lz4`, `zstd`.
-- `kafka_compression_level` — Compression level parameter for algorithm selected by kafka_compression_codec. Higher values will result in better compression at the cost of more CPU usage. Usable range is algorithm-dependent: `[0-9]` for `gzip`; `[0-12]` for `lz4`; only `0` for `snappy`; `[0-12]` for `zstd`; `-1` = codec-dependent default compression level.
+- `kafka_compression_codec` — Compression codec used for producing messages. Supported: `none`, `gzip`, `snappy`, `lz4`, `zstd`. Default: `none`.
+- `kafka_compression_level` — Compression level parameter for algorithm selected by kafka_compression_codec. Higher values will result in better compression at the cost of more CPU usage. Usable range is algorithm-dependent: `[0-9]` for `gzip`; `[0-12]` for `lz4`; only `0` for `snappy`; `[0-12]` for `zstd`; `-1` = codec-dependent default compression level. Default: `-1`.
 
 Examples:
 

--- a/docs/en/engines/table-engines/integrations/kafka.md
+++ b/docs/en/engines/table-engines/integrations/kafka.md
@@ -54,7 +54,7 @@ SETTINGS
     [kafka_handle_error_mode = 'default',]
     [kafka_commit_on_select = false,]
     [kafka_max_rows_per_message = 1,]
-    [kafka_compression_codec = 'none',]
+    [kafka_compression_codec = '',]
     [kafka_compression_level = -1];
 ```
 

--- a/src/Storages/Kafka/KafkaConfigLoader.cpp
+++ b/src/Storages/Kafka/KafkaConfigLoader.cpp
@@ -32,6 +32,7 @@ namespace KafkaSetting
     extern const KafkaSettingsString kafka_sasl_mechanism;
     extern const KafkaSettingsString kafka_sasl_username;
     extern const KafkaSettingsString kafka_sasl_password;
+    extern const KafkaSettingsString kafka_compression_codec;
 }
 
 namespace ErrorCodes
@@ -342,7 +343,13 @@ void loadProducerConfig(cppkafka::Configuration & kafka_config, const KafkaConfi
 }
 
 template <typename TKafkaStorage>
-void updateGlobalConfiguration(
+using SpecificConfigUpdaterFunc = void (*)(
+    cppkafka::Configuration & kafka_config,
+    const KafkaConfigLoader::LoadConfigParams & params);
+
+template <typename TKafkaStorage>
+void updateConfigurationFromConfig(
+    SpecificConfigUpdaterFunc<TKafkaStorage> specific_config_updater,
     cppkafka::Configuration & kafka_config,
     TKafkaStorage & storage,
     const KafkaConfigLoader::LoadConfigParams & params,
@@ -350,6 +357,8 @@ void updateGlobalConfiguration(
 {
     loadFromConfig(kafka_config, params, KafkaConfigLoader::CONFIG_KAFKA_TAG);
 
+    /// We have to set these settings before taking the values from the consumer/producer specific configuration,
+    /// because otherwise we would introduce a breaking change.
     auto kafka_settings = storage.getKafkaSettings();
     if (!kafka_settings[KafkaSetting::kafka_security_protocol].value.empty())
         kafka_config.set("security.protocol", kafka_settings[KafkaSetting::kafka_security_protocol]);
@@ -359,6 +368,11 @@ void updateGlobalConfiguration(
         kafka_config.set("sasl.username", kafka_settings[KafkaSetting::kafka_sasl_username]);
     if (!kafka_settings[KafkaSetting::kafka_sasl_password].value.empty())
         kafka_config.set("sasl.password", kafka_settings[KafkaSetting::kafka_sasl_password]);
+
+    specific_config_updater(kafka_config, params);
+
+    if (!kafka_settings[KafkaSetting::kafka_compression_codec].value.empty())
+        kafka_config.set("compression.codec", kafka_settings[KafkaSetting::kafka_compression_codec]);
 
 #if USE_KRB5
     if (kafka_config.has_property("sasl.kerberos.kinit.cmd"))
@@ -468,8 +482,7 @@ cppkafka::Configuration KafkaConfigLoader::getConsumerConfiguration(TKafkaStorag
     conf.set(
         "queued.min.messages", std::min(std::max(params.max_block_size, default_queued_min_messages), max_allowed_queued_min_messages));
 
-    updateGlobalConfiguration(conf, storage, params, exception_info_sink_ptr);
-    loadConsumerConfig(conf, params);
+    updateConfigurationFromConfig(loadConsumerConfig, conf, storage, params, exception_info_sink_ptr);
 
     // those settings should not be changed by users.
     conf.set("enable.auto.commit", "false"); // We manually commit offsets after a stream successfully finished
@@ -498,8 +511,7 @@ cppkafka::Configuration KafkaConfigLoader::getProducerConfiguration(TKafkaStorag
     conf.set("client.software.name", VERSION_NAME);
     conf.set("client.software.version", VERSION_DESCRIBE);
 
-    updateGlobalConfiguration(conf, storage, params);
-    loadProducerConfig(conf, params);
+    updateConfigurationFromConfig(loadProducerConfig, conf, storage, params);
 
     for (auto & property : conf.get_all())
     {

--- a/src/Storages/Kafka/KafkaSettings.cpp
+++ b/src/Storages/Kafka/KafkaSettings.cpp
@@ -47,8 +47,8 @@ namespace ErrorCodes
     DECLARE(String, kafka_sasl_mechanism, "", "SASL mechanism to use for authentication. Supported: GSSAPI, PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER.", 0) \
     DECLARE(String, kafka_sasl_username, "", "SASL username for use with the PLAIN and SASL-SCRAM-.. mechanisms", 0) \
     DECLARE(String, kafka_sasl_password, "", "SASL password for use with the PLAIN and SASL-SCRAM-.. mechanisms", 0) \
-    DECLARE(String, kafka_compression_codec, "", "Compression codec used for consuming messages. Supported: none, gzip, snappy, lz4, zstd.", 0) \
-    DECLARE(Int64, kafka_compression_level, -1, "Compression level parameter for algorithm selected by kafka_compression_codec.", 0) \
+    DECLARE(String, kafka_compression_codec, "", "Compression codec used for producing messages. Supported: none, gzip, snappy, lz4, zstd.", 0) \
+    DECLARE(Int64, kafka_compression_level, -1, "Compression level parameter for algorithm selected by kafka_compression_codec. Higher values will result in better compression at the cost of more CPU usage. Usable range is algorithm-dependent: [0-9] for gzip; [0-12] for lz4; only 0 for snappy; [0-12] for zstd; -1 = codec-dependent default compression level.", 0) \
 
 #define OBSOLETE_KAFKA_SETTINGS(M, ALIAS) \
     MAKE_OBSOLETE(M, Char, kafka_row_delimiter, '\0') \

--- a/src/Storages/Kafka/KafkaSettings.cpp
+++ b/src/Storages/Kafka/KafkaSettings.cpp
@@ -48,6 +48,7 @@ namespace ErrorCodes
     DECLARE(String, kafka_sasl_username, "", "SASL username for use with the PLAIN and SASL-SCRAM-.. mechanisms", 0) \
     DECLARE(String, kafka_sasl_password, "", "SASL password for use with the PLAIN and SASL-SCRAM-.. mechanisms", 0) \
     DECLARE(String, kafka_compression_codec, "", "Compression codec used for consuming messages. Supported: none, gzip, snappy, lz4, zstd.", 0) \
+    DECLARE(Int64, kafka_compression_level, -1, "Compression level parameter for algorithm selected by kafka_compression_codec.", 0) \
 
 #define OBSOLETE_KAFKA_SETTINGS(M, ALIAS) \
     MAKE_OBSOLETE(M, Char, kafka_row_delimiter, '\0') \

--- a/src/Storages/Kafka/KafkaSettings.cpp
+++ b/src/Storages/Kafka/KafkaSettings.cpp
@@ -47,6 +47,7 @@ namespace ErrorCodes
     DECLARE(String, kafka_sasl_mechanism, "", "SASL mechanism to use for authentication. Supported: GSSAPI, PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER.", 0) \
     DECLARE(String, kafka_sasl_username, "", "SASL username for use with the PLAIN and SASL-SCRAM-.. mechanisms", 0) \
     DECLARE(String, kafka_sasl_password, "", "SASL password for use with the PLAIN and SASL-SCRAM-.. mechanisms", 0) \
+    DECLARE(String, kafka_compression_codec, "", "Compression codec used for consuming messages. Supported: none, gzip, snappy, lz4, zstd.", 0) \
 
 #define OBSOLETE_KAFKA_SETTINGS(M, ALIAS) \
     MAKE_OBSOLETE(M, Char, kafka_row_delimiter, '\0') \

--- a/src/Storages/Kafka/KafkaSettings.cpp
+++ b/src/Storages/Kafka/KafkaSettings.cpp
@@ -47,7 +47,7 @@ namespace ErrorCodes
     DECLARE(String, kafka_sasl_mechanism, "", "SASL mechanism to use for authentication. Supported: GSSAPI, PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER.", 0) \
     DECLARE(String, kafka_sasl_username, "", "SASL username for use with the PLAIN and SASL-SCRAM-.. mechanisms", 0) \
     DECLARE(String, kafka_sasl_password, "", "SASL password for use with the PLAIN and SASL-SCRAM-.. mechanisms", 0) \
-    DECLARE(String, kafka_compression_codec, "none", "Compression codec used for producing messages. Supported: none, gzip, snappy, lz4, zstd.", 0) \
+    DECLARE(String, kafka_compression_codec, "", "Compression codec used for producing messages. Supported: empty string, none, gzip, snappy, lz4, zstd. In case of empty string the compression codec is not set by the table, thus values from the config files or default value from `librdkafka` will be used.", 0) \
     DECLARE(Int64, kafka_compression_level, -1, "Compression level parameter for algorithm selected by kafka_compression_codec. Higher values will result in better compression at the cost of more CPU usage. Usable range is algorithm-dependent: [0-9] for gzip; [0-12] for lz4; only 0 for snappy; [0-12] for zstd; -1 = codec-dependent default compression level.", 0) \
 
 #define OBSOLETE_KAFKA_SETTINGS(M, ALIAS) \

--- a/src/Storages/Kafka/KafkaSettings.cpp
+++ b/src/Storages/Kafka/KafkaSettings.cpp
@@ -47,7 +47,7 @@ namespace ErrorCodes
     DECLARE(String, kafka_sasl_mechanism, "", "SASL mechanism to use for authentication. Supported: GSSAPI, PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER.", 0) \
     DECLARE(String, kafka_sasl_username, "", "SASL username for use with the PLAIN and SASL-SCRAM-.. mechanisms", 0) \
     DECLARE(String, kafka_sasl_password, "", "SASL password for use with the PLAIN and SASL-SCRAM-.. mechanisms", 0) \
-    DECLARE(String, kafka_compression_codec, "", "Compression codec used for producing messages. Supported: none, gzip, snappy, lz4, zstd.", 0) \
+    DECLARE(String, kafka_compression_codec, "none", "Compression codec used for producing messages. Supported: none, gzip, snappy, lz4, zstd.", 0) \
     DECLARE(Int64, kafka_compression_level, -1, "Compression level parameter for algorithm selected by kafka_compression_codec. Higher values will result in better compression at the cost of more CPU usage. Usable range is algorithm-dependent: [0-9] for gzip; [0-12] for lz4; only 0 for snappy; [0-12] for zstd; -1 = codec-dependent default compression level.", 0) \
 
 #define OBSOLETE_KAFKA_SETTINGS(M, ALIAS) \

--- a/src/Storages/Kafka/KafkaSettings.h
+++ b/src/Storages/Kafka/KafkaSettings.h
@@ -17,7 +17,7 @@ const auto KAFKA_MAX_THREAD_WORK_DURATION_MS = 60000;
 // 10min
 const auto KAFKA_CONSUMERS_POOL_TTL_MS_MAX = 600'000;
 
-/// List of available types supported in RabbitMQSettings object
+/// List of available types supported in KafkaSettings object
 #define KAFKA_SETTINGS_SUPPORTED_TYPES(CLASS_NAME, M) \
     M(CLASS_NAME, ArrowCompression) \
     M(CLASS_NAME, Bool) \

--- a/tests/integration/helpers/kafka/common.py
+++ b/tests/integration/helpers/kafka/common.py
@@ -298,7 +298,7 @@ def avro_confluent_message(schema_registry_client, value):
 
 
 def create_settings_string(settings):
-    if settings is None:
+    if settings is None or len(settings) == 0:
         return ""
 
     def format_value(value):

--- a/tests/integration/helpers/kafka/common.py
+++ b/tests/integration/helpers/kafka/common.py
@@ -490,6 +490,31 @@ def describe_consumer_group(kafka_cluster, name):
         res.append(member_info)
     return res
 
+def clean_test_database_and_topics(instance, cluster):
+    instance.query("DROP DATABASE IF EXISTS test SYNC; CREATE DATABASE test;")
+    admin_client = get_admin_client(cluster)
+
+    def get_topics_to_delete():
+        return [t for t in admin_client.list_topics() if not t.startswith("_")]
+
+    topics = get_topics_to_delete()
+    logging.debug(f"Deleting topics: {topics}")
+    result = admin_client.delete_topics(topics)
+    for topic, error in result.topic_error_codes:
+        if error != 0:
+            logging.warning(f"Received error {error} while deleting topic {topic}")
+        else:
+            logging.info(f"Deleted topic {topic}")
+
+    retries = 0
+    topics = get_topics_to_delete()
+    while len(topics) != 0:
+        logging.info(f"Existing topics: {topics}")
+        if retries >= 5:
+            raise Exception(f"Failed to delete topics {topics}")
+        retries += 1
+        time.sleep(0.5)
+
 
 KAFKA_TOPIC_OLD = "old_t"
 KAFKA_CONSUMER_GROUP_OLD = "old_cg"

--- a/tests/integration/test_storage_kafka/configs/compression_codec.xml
+++ b/tests/integration/test_storage_kafka/configs/compression_codec.xml
@@ -1,0 +1,5 @@
+<clickhouse>
+    <kafka>
+        <!-- <compression_codec>lz4</compression_codec> -->
+    </kafka>
+</clickhouse>

--- a/tests/integration/test_storage_kafka/test_compression_codec.py
+++ b/tests/integration/test_storage_kafka/test_compression_codec.py
@@ -1,0 +1,216 @@
+"""Tests for kafka_compression_codec setting"""
+
+import json
+import logging
+import time
+
+import pytest
+from kafka import KafkaAdminClient
+
+from helpers.cluster import ClickHouseCluster, is_arm
+from helpers.kafka.common_direct import *
+import helpers.kafka.common as k
+from helpers.test_tools import TSV
+
+cluster = ClickHouseCluster(__file__)
+instance = cluster.add_instance(
+    "instance",
+    main_configs=["configs/kafka.xml", "configs/compression_codec.xml"],
+    user_configs=["configs/users.xml"],
+    with_kafka=True,
+    with_zookeeper=True,
+    stay_alive=True,
+    macros={
+        "kafka_broker": "kafka1",
+        "kafka_format_json_each_row": "JSONEachRow",
+    },
+    clickhouse_path_dir="clickhouse_path",
+)
+
+
+# Fixtures
+@pytest.fixture(scope="module")
+def kafka_cluster():
+    try:
+        cluster.start()
+        kafka_id = instance.cluster.kafka_docker_id
+        print(("kafka_id is {}".format(kafka_id)))
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+@pytest.fixture(autouse=True)
+def kafka_setup_teardown():
+    k.clean_test_database_and_topics(instance, cluster)
+    yield  # run test
+
+
+def assert_compression_codec_in_logs(instance, table_name, compression_codec):
+    maybe_uuid_regex = "( \([a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}\))?"
+    instance.wait_for_log_line(f"StorageKafka2? \(test\.{table_name}{maybe_uuid_regex}\): Producer set property compression\.codec:{compression_codec}")
+
+# Test for different compression codec values
+@pytest.mark.parametrize(
+    "compression_codec",
+    ["none", "gzip", "snappy", "lz4", "zstd"],
+)
+@pytest.mark.parametrize(
+    "create_query_generator",
+    [k.generate_old_create_table_query, k.generate_new_create_table_query],
+)
+def test_kafka_compression_codec(kafka_cluster, compression_codec, create_query_generator):
+    """Test that kafka_compression_codec setting works correctly for both producing and consuming messages"""
+    storage_version = create_query_generator.__name__.replace("generate_", "").replace("_create_table_query", "")
+    # It is better to use a random string, because it makes logs more unique and avoids false positive test runs
+    suffix = f"{storage_version}_{compression_codec}_{k.random_string(6)}"
+    kafka_table_producer = f"kafka_producer_{suffix}"
+    kafka_table_consumer = f"kafka_consumer_{suffix}"
+    topic_name = f"compression_codec_{suffix}"
+
+    admin_client = k.get_admin_client(kafka_cluster)
+
+    with k.kafka_topic(admin_client, topic_name):
+        logging.debug(f"Testing compression codec: {compression_codec}")
+
+        # Create producer table with compression codec using generator
+        producer_create_query = create_query_generator(
+            kafka_table_producer,
+            "key UInt64, value String",
+            topic_list=topic_name,
+            consumer_group=f"{topic_name}_producer",
+            settings={"kafka_compression_codec": compression_codec}
+        )
+        instance.query(producer_create_query)
+
+        # Create consumer table with compression codec using generator
+        consumer_create_query = create_query_generator(
+            kafka_table_consumer,
+            "key UInt64, value String",
+            topic_list=topic_name,
+            consumer_group=f"{topic_name}_consumer",
+            settings={
+                "kafka_compression_codec": compression_codec,
+                "kafka_commit_on_select": 1
+            }
+        )
+        instance.query(consumer_create_query)
+
+        # Create materialized view to store consumed data
+        instance.query(f"""
+            CREATE TABLE test.{kafka_table_consumer}_view (key UInt64, value String)
+                ENGINE = MergeTree()
+                ORDER BY key;
+            CREATE MATERIALIZED VIEW test.{kafka_table_consumer}_mv TO test.{kafka_table_consumer}_view AS
+                SELECT * FROM test.{kafka_table_consumer};
+        """)
+
+        # Insert test data into producer table
+        messages_count = 20
+        values = []
+        expected_data = []
+        for i in range(messages_count):
+            test_value = f"test_message_{compression_codec}_{i}"
+            values.append(f"({i}, '{test_value}')")
+            expected_data.append(f"{i}\t{test_value}")
+
+        values_str = ",".join(values)
+        instance.query(f"INSERT INTO test.{kafka_table_producer} VALUES {values_str}")
+
+        # Unfortunately there is no way to directly verify the compression codec using the python client
+        assert_compression_codec_in_logs(instance, kafka_table_producer, compression_codec)
+
+        # Wait for messages to be consumed
+        expected_result = "\n".join(expected_data)
+        result = instance.query_with_retry(
+            f"SELECT * FROM test.{kafka_table_consumer}_view ORDER BY key",
+            check_callback=lambda res: res.count("\n") == messages_count,
+            retry_count=30,
+            sleep_time=1
+        )
+
+        assert TSV(result) == TSV(expected_result)
+
+        # Clean up
+        instance.query(f"DROP TABLE test.{kafka_table_producer}")
+        instance.query(f"DROP TABLE test.{kafka_table_consumer}")
+        instance.query(f"DROP TABLE test.{kafka_table_consumer}_mv")
+        instance.query(f"DROP TABLE test.{kafka_table_consumer}_view")
+
+
+@pytest.mark.parametrize(
+    "create_query_generator",
+    [k.generate_old_create_table_query, k.generate_new_create_table_query],
+)
+def test_settings_precedence(kafka_cluster, create_query_generator):
+    # The precedence of settings in general:
+    # 1. Settings in create query (gzip)
+    # 2. Settings in producer/consumer specific settings (snappy)
+    # 3. Settings in the general kafka settings from config (lz4)
+    # It is not optimal (probably the settings from the create query should have absolute precedence), but changing this would be a breaking change,
+    # thus it doesn't make sense until there is a very good reason and an actual use case that requires it.
+    storage_version = create_query_generator.__name__.replace("generate_", "").replace("_create_table_query", "")
+    suffix = f"{storage_version}_{k.random_string(6)}"
+    topic_name = f"settings_precedence_{suffix}"
+    table_name = f"{topic_name}"
+
+    general_kafka_config = """
+    <clickhouse>
+    <kafka>
+        <compression_codec>lz4</compression_codec>
+    </kafka>
+</clickhouse>
+"""
+
+    producer_specific_config = """
+    <clickhouse>
+    <kafka>
+        <compression_codec>lz4</compression_codec>
+        <producer>
+            <compression_codec>snappy</compression_codec>
+        </producer>
+    </kafka>
+</clickhouse>
+"""
+    config_file_path = "/etc/clickhouse-server/config.d/compression_codec.xml"
+
+    # The topic doesn't need to be created, because we only check the applied compression codec in producer creation logs
+    with instance.with_replace_config(config_file_path, producer_specific_config):
+        instance.restart_clickhouse()
+
+        instance.query(create_query_generator(
+            table_name,
+            "key UInt64, value String",
+            topic_list=topic_name,
+            consumer_group=f"{topic_name}_consumer",
+            settings={"kafka_compression_codec": "gzip"}
+        ))
+
+        instance.query(f"INSERT INTO test.{table_name} VALUES (1, 'test_message')")
+        # The value from the create query takes precedence over the setting in general kafka section
+        assert_compression_codec_in_logs(instance, table_name, "gzip")
+
+        instance.query(f"DROP TABLE test.{table_name} SYNC")
+
+        # Let's create a table without kafka_compression_codec setting in the create query
+        instance.query(create_query_generator(
+            table_name,
+            "key UInt64, value String",
+            topic_list=topic_name,
+            consumer_group=f"{topic_name}_consumer",
+        ))
+        instance.query(f"INSERT INTO test.{table_name} VALUES (2, 'test_message 2')")
+        assert_compression_codec_in_logs(instance, table_name, "snappy")
+
+    with instance.with_replace_config(config_file_path, general_kafka_config):
+        instance.restart_clickhouse()
+        instance.query(f"INSERT INTO test.{table_name} VALUES (3, 'test_message 3')")
+        assert_compression_codec_in_logs(instance, table_name, "lz4")
+
+    instance.query(f"DROP TABLE test.{table_name} SYNC")
+
+
+if __name__ == "__main__":
+    cluster.start()
+    input("Cluster created, press any key to destroy...")
+    cluster.shutdown()

--- a/tests/integration/test_storage_kafka/test_compression_codec.py
+++ b/tests/integration/test_storage_kafka/test_compression_codec.py
@@ -72,6 +72,7 @@ def assert_compression_codec_in_logs(instance, table_name, compression_codec):
 def assert_compression_level_in_logs(instance, table_name, compression_level):
     assert_producer_property_set_in_logs(instance, table_name, r"compression\.level", compression_level)
 
+
 # Test for different compression codec values
 @pytest.mark.parametrize(
     "compression_codec",


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

The `kafka_compression_codec` and `kafka_compression_level` settings can now be used to specify the compression for Kafka producers in both Kafka engines.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)
