### PR TITLE
Fix check constraint for sparse columns

### DIFF
--- a/src/Processors/Transforms/CheckConstraintsTransform.cpp
+++ b/src/Processors/Transforms/CheckConstraintsTransform.cpp
@@ -63,7 +63,7 @@ void CheckConstraintsTransform::onConsume(Chunk chunk)
                 throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "Constraint {} does not return a value of type UInt8",
                     backQuote(constraint_ptr->name));
 
-            auto result_column = res_column.column->convertToFullColumnIfConst()->convertToFullColumnIfLowCardinality();
+            auto result_column = res_column.column->convertToFullIfNeeded();
 
             if (const auto * column_nullable = checkAndGetColumn<ColumnNullable>(&*result_column))
             {

--- a/tests/queries/0_stateless/03702_http_insert_sparse_with_constraint.reference
+++ b/tests/queries/0_stateless/03702_http_insert_sparse_with_constraint.reference
@@ -1,0 +1,2 @@
+false
+true

--- a/tests/queries/0_stateless/03702_http_insert_sparse_with_constraint.sh
+++ b/tests/queries/0_stateless/03702_http_insert_sparse_with_constraint.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+echo 'DROP TABLE IF EXISTS 03702_data'                       | ${CLICKHOUSE_CURL} -sSg "${CLICKHOUSE_URL}" -d @-
+echo 'CREATE TABLE 03702_data
+      (c Bool)
+      ENGINE = MergeTree
+      ORDER BY c
+      SETTINGS ratio_of_defaults_for_sparse_serialization=0' | ${CLICKHOUSE_CURL} -sSg "${CLICKHOUSE_URL}" -d @-
+# Inserting one row with default value to make the column sparse
+echo 'INSERT INTO 03702_data SELECT false'                   | ${CLICKHOUSE_CURL} -sSg "${CLICKHOUSE_URL}" -d @-
+# Adding constraint
+echo 'ALTER TABLE 03702_data ADD CONSTRAINT check_c CHECK c' | ${CLICKHOUSE_CURL} -sSg "${CLICKHOUSE_URL}" -d @-
+# Inserting another row that should pass constraint check
+echo 'INSERT INTO 03702_data FORMAT CSV true'                | ${CLICKHOUSE_CURL} -sSg "${CLICKHOUSE_URL}" -d @-
+echo 'SELECT * FROM 03702_data ORDER BY c'                   | ${CLICKHOUSE_CURL} -sSg "${CLICKHOUSE_URL}" -d @-


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix sparse columns processing by CHECK constraint. Closes #88637.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

### Details

In cases when the data is inlined into the insert query (e.g. http inserts), it may be parsed with serialization hints got from the table actual data, and therefore CheckConstraintTransform will receive sparse columns as an input.

This patch fixed sparse columns processing in CheckConstraintTransform.
