### PR TITLE
Docs: Sync embedded and markdown docs for `hasAny/AllTokens`

### DIFF
--- a/src/Functions/hasAnyAllTokens.cpp
+++ b/src/Functions/hasAnyAllTokens.cpp
@@ -338,7 +338,7 @@ ORDER BY id;
 
 INSERT INTO table VALUES (1, '()a,\\bc()d'), (2, '()\\a()bc\\d'), (3, ',()a\\,bc,(),d,');
 
-SELECT count() FROM table WHERE hasAnyTokens(msg, 'a\\d()'
+SELECT count() FROM table WHERE hasAnyTokens(msg, 'a\\d()');
         )",
         R"(
 ┌─count()─┐


### PR DESCRIPTION
We only updated the in-source docs for these two functions but forgot to update the markdown docs. In the long run, the latter will be generated from the former but for now, let's keep both in sync.


### Changelog category (leave one):
- Documentation (changelog entry is not required)