### PR TITLE
Improve error message for missing macro in cluster name 

### DIFF
--- a/src/Interpreters/Cluster.cpp
+++ b/src/Interpreters/Cluster.cpp
@@ -329,7 +329,16 @@ ClusterPtr Clusters::getCluster(const std::string & cluster_name) const
 {
     std::lock_guard lock(mutex);
 
-    auto expanded_cluster_name = macros_->expand(cluster_name);
+    std::string expanded_cluster_name;
+    try
+    {
+        expanded_cluster_name = macros_->expand(cluster_name);
+    }
+    catch (Exception & e)
+    {
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Failed to expand macros in cluster name: {}", e.message());
+    }
+
     auto it = impl.find(expanded_cluster_name);
     return (it != impl.end()) ? it->second : nullptr;
 }

--- a/tests/queries/0_stateless/02000_table_function_cluster_macros.sql
+++ b/tests/queries/0_stateless/02000_table_function_cluster_macros.sql
@@ -2,3 +2,8 @@ SELECT _shard_num FROM cluster("{default_cluster_macro}", system.one);
 SELECT _shard_num FROM cluster("{default_cluster_macro}");
 SELECT _shard_num FROM clusterAllReplicas("{default_cluster_macro}", system.one);
 SELECT _shard_num FROM clusterAllReplicas("{default_cluster_macro}");
+
+SELECT _shard_num FROM cluster("{nonexistent}"); -- { serverError BAD_ARGUMENTS }
+SELECT _shard_num FROM cluster("{nonexistent}", system.one); -- { serverError BAD_ARGUMENTS }
+SELECT _shard_num FROM clusterAllReplicas("{nonexistent}"); -- { serverError BAD_ARGUMENTS }
+SELECT _shard_num FROM clusterAllReplicas("{nonexistent}", system.one); -- { serverError BAD_ARGUMENTS }


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Improve error message when generic expansion is passed instead of cluster name to a -Cluster table function.
