### PR TITLE
Disable ThreadFuzzer in non server binaries by default

### DIFF
--- a/src/Common/ThreadFuzzer.cpp
+++ b/src/Common/ThreadFuzzer.cpp
@@ -52,7 +52,8 @@ namespace ErrorCodes
 ThreadFuzzer::ThreadFuzzer()
 {
     initConfiguration();
-    start();
+    if (isEffective())
+        started.store(true, std::memory_order_relaxed);
 }
 
 template <typename T>

--- a/src/Common/ThreadFuzzer.cpp
+++ b/src/Common/ThreadFuzzer.cpp
@@ -52,13 +52,7 @@ namespace ErrorCodes
 ThreadFuzzer::ThreadFuzzer()
 {
     initConfiguration();
-
-    if (!isEffective())
-    {
-        /// It has no effect - disable it
-        stop();
-        return;
-    }
+    start();
 }
 
 template <typename T>

--- a/src/Common/ThreadFuzzer.h
+++ b/src/Common/ThreadFuzzer.h
@@ -71,7 +71,7 @@ private:
     double explicit_sleep_probability = 0;
     double explicit_memory_exception_probability = 0;
 
-    inline static std::atomic<bool> started{true};
+    inline static std::atomic<bool> started{false};
 
     ThreadFuzzer();
 


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Disable ThreadFuzzer in non-server binaries by default.

### Details
This improves performance in non-server binaries like clickhouse local. Previously, ThreadFuzzer was started by default in all binaries and only disabled later when the constructor determined it wasn't effective. This meant other binaries were running the injectionImpl code unnecessarily, even though everything was disabled because it wasn't set up.
