### PR TITLE
Do not save to history queries starting with a space

### DIFF
--- a/src/Client/LineReader.cpp
+++ b/src/Client/LineReader.cpp
@@ -214,7 +214,7 @@ String LineReader::readLine(const String & first_prompt, const String & second_p
             break;
     }
 
-    if (!line.empty() && line != prev_line)
+    if (!line.empty() && line != prev_line && !line.starts_with(" "))
     {
         addToHistory(line);
         prev_line = line;


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Queries starting with whitespace are no longer saved to history.

### Details
This change mimics the bash `HISTCONTROL` behavior where commands starting with a space are not saved to history.

Reference: https://www.gnu.org/software/bash/manual/html_node/Bash-Variables.html#index-HISTCONTROL
