### PR TITLE
Text index: add array support for `hasAny/AllTokens`

### DIFF
--- a/docs/en/engines/table-engines/mergetree-family/invertedindexes.md
+++ b/docs/en/engines/table-engines/mergetree-family/invertedindexes.md
@@ -272,7 +272,7 @@ See the following examples for the usage of `Array(T)` and `Map(K, V)` with the 
 
 ### Examples for the text index `Array` and `Map` support. {#text-index-array-and-map-examples}
 
-#### Indexing Array(String) {#text-indexi-example-array}
+#### Indexing Array(String) {#text-index-example-array}
 
 In a simple blogging platform, authors assign keywords to their posts to categorize content.
 A common feature allows users to discover related content by clicking on keywords or searching for topics.

--- a/src/Functions/hasAnyAllTokens.cpp
+++ b/src/Functions/hasAnyAllTokens.cpp
@@ -70,16 +70,29 @@ void FunctionHasAnyAllTokens<HasTokensTraits>::setSearchTokens(const std::vector
 namespace
 {
 
+/// Function input accept string, fixed string, array of string or array of fixed strings.
+bool isStringOrFixedStringOrArrayOfStringOrFixedString(const IDataType & type)
+{
+    if (isStringOrFixedString(type))
+        return true;
+
+    if (const auto * array_type = checkAndGetDataType<DataTypeArray>(&type); array_type)
+    {
+        const DataTypePtr & nested_type = array_type->getNestedType();
+        return isStringOrFixedString(nested_type);
+    }
+
+    return false;
+}
+
 /// Functions accept needles string (will be tokenized) or array of string needles/tokens (used as-is)
 /// Also accepts Array(Nothing) which is the type of Array([])
 bool isStringOrArrayOfStringType(const IDataType & type)
 {
-    const auto * string_type = checkAndGetDataType<DataTypeString>(&type);
-    if (string_type)
+    if (isString(type))
         return true;
 
-    const auto * array_type = checkAndGetDataType<DataTypeArray>(&type);
-    if (array_type)
+    if (const auto * array_type = checkAndGetDataType<DataTypeArray>(&type); array_type)
     {
         const DataTypePtr & nested_type = array_type->getNestedType();
         return isString(nested_type) || isNothing(nested_type);
@@ -119,7 +132,7 @@ DataTypePtr FunctionHasAnyAllTokens<HasTokensTraits>::getReturnTypeImpl(const Co
             "Enable the setting 'allow_experimental_full_text_index' to use function {}", getName());
 
     FunctionArgumentDescriptors mandatory_args{
-        {"input", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isStringOrFixedString), nullptr, "String or FixedString"},
+        {"input", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isStringOrFixedStringOrArrayOfStringOrFixedString), nullptr, "String, FixedString, Array(String) or Array(FixedString)"},
         {"needles",
          static_cast<FunctionArgumentDescriptor::TypeValidator>(&isStringOrArrayOfStringType),
          isColumnConst,
@@ -132,42 +145,141 @@ DataTypePtr FunctionHasAnyAllTokens<HasTokensTraits>::getReturnTypeImpl(const Co
 
 namespace
 {
+struct HasAnyTokensMatcher
+{
+    template <Fn<void(void)> OnMatchCallback>
+    auto operator()(const TokensWithPosition & tokens, OnMatchCallback && onMatchCallback) const
+    {
+        return [&](const char * token_start, size_t token_len)
+        {
+            if (tokens.contains(std::string_view(token_start, token_len)))
+            {
+                onMatchCallback();
+                return true;
+            }
+
+            return false;
+        };
+    }
+};
+
+struct HasAllTokensMatcher
+{
+    template <Fn<void(void)> OnMatchCallback>
+    auto operator()(const TokensWithPosition & tokens, UInt64 & mask, const UInt64 & expected_mask, OnMatchCallback && onMatchCallback) const
+    {
+        return [&](const char * token_start, size_t token_len)
+        {
+            if (auto it = tokens.find(std::string_view(token_start, token_len)); it != tokens.end())
+            {
+                mask |= (1ULL << it->second);
+            }
+
+            if (mask == expected_mask)
+            {
+                onMatchCallback();
+                return true;
+            }
+
+            return false;
+        };
+    }
+};
+
 template <typename T>
 concept StringColumnType = std::same_as<T, ColumnString> || std::same_as<T, ColumnFixedString>;
+using ArrayOffset = ColumnArray::Offset;
 
+/// Execute on Array(String) or Array(FixedString) column
 void executeHasAnyTokens(
-    const ITokenExtractor * token_extractor,
-    const StringColumnType auto & col_input,
+    const ColumnArray::Offsets & offsets,
+    const StringColumnType auto & input_string,
+    PaddedPODArray<UInt8> & col_result,
     size_t input_rows_count,
-    const TokensWithPosition & tokens,
-    PaddedPODArray<UInt8> & col_result)
+    const ITokenExtractor * token_extractor,
+    const TokensWithPosition & tokens)
+{
+    ArrayOffset current_offset = 0;
+    for (size_t i = 0; i < input_rows_count; ++i)
+    {
+        const ArrayOffset array_size = offsets[i] - current_offset;
+        col_result[i] = false;
+
+        for (size_t j = 0; j < array_size; ++j)
+        {
+            std::string_view input = input_string.getDataAt(current_offset + j).toView();
+
+            forEachTokenPadded(*token_extractor, input.data(), input.size(), HasAnyTokensMatcher()(tokens, [&] { col_result[i] = true; }));
+
+            if (col_result[i])
+                break;
+        }
+
+        current_offset = offsets[i];
+    }
+}
+
+/// Execute on Array(String) or Array(FixedString) column
+void executeHasAllTokens(
+    const ColumnArray::Offsets & offsets,
+    const StringColumnType auto & input_string,
+    PaddedPODArray<UInt8> & col_result,
+    size_t input_rows_count,
+    const ITokenExtractor * token_extractor,
+    const TokensWithPosition & tokens)
+{
+    const size_t ns = tokens.size();
+    /// It is equivalent to ((2 ^ ns) - 1), but avoids overflow in case of ns = 64.
+    const UInt64 expected_mask = ((1ULL << (ns - 1)) + ((1ULL << (ns - 1)) - 1));
+
+    UInt64 mask;
+    ArrayOffset current_offset = 0;
+    for (size_t i = 0; i < input_rows_count; ++i)
+    {
+        const ArrayOffset array_size = offsets[i] - current_offset;
+        col_result[i] = false;
+        mask = 0;
+
+        for (size_t j = 0; j < array_size; ++j)
+        {
+            std::string_view input = input_string.getDataAt(current_offset + j).toView();
+
+            forEachTokenPadded(*token_extractor, input.data(), input.size(), HasAllTokensMatcher()(tokens, mask, expected_mask, [&] { col_result[i] = true; }));
+
+            if (col_result[i])
+                break;
+        }
+
+        current_offset = offsets[i];
+    }
+}
+
+/// Execute on String column
+void executeHasAnyTokens(
+    const StringColumnType auto & col_input,
+    PaddedPODArray<UInt8> & col_result,
+    size_t input_rows_count,
+    const ITokenExtractor * token_extractor,
+    const TokensWithPosition & tokens)
 {
     for (size_t i = 0; i < input_rows_count; ++i)
     {
         std::string_view input = col_input.getDataAt(i).toView();
         col_result[i] = false;
 
-        forEachTokenPadded(*token_extractor, input.data(), input.size(), [&](const char * token_start, size_t token_len)
-        {
-            if (tokens.contains(std::string_view(token_start, token_len)))
-            {
-                col_result[i] = true;
-                return true;
-            }
-
-            return false;
-        });
+        forEachTokenPadded(*token_extractor, input.data(), input.size(), HasAnyTokensMatcher()(tokens, [&] { col_result[i] = true; }));
     }
 }
 
+/// Execute on String column
 void executeHasAllTokens(
-    const ITokenExtractor * token_extractor,
     const StringColumnType auto & col_input,
+    PaddedPODArray<UInt8> & col_result,
     size_t input_rows_count,
-    const TokensWithPosition & needles,
-    PaddedPODArray<UInt8> & col_result)
+    const ITokenExtractor * token_extractor,
+    const TokensWithPosition & tokens)
 {
-    const size_t ns = needles.size();
+    const size_t ns = tokens.size();
     /// It is equivalent to ((2 ^ ns) - 1), but avoids overflow in case of ns = 64.
     const UInt64 expected_mask = ((1ULL << (ns - 1)) + ((1ULL << (ns - 1)) - 1));
 
@@ -178,33 +290,21 @@ void executeHasAllTokens(
         col_result[i] = false;
         mask = 0;
 
-        forEachTokenPadded(*token_extractor, input.data(), input.size(), [&](const char * token_start, size_t token_len)
-        {
-            if (auto it = needles.find(std::string_view(token_start, token_len)); it != needles.end())
-            {
-                mask |= (1ULL << it->second);
-            }
-
-            if (mask == expected_mask)
-            {
-                col_result[i] = true;
-                return true;
-            }
-
-            return false;
-        });
+        forEachTokenPadded(*token_extractor, input.data(), input.size(), HasAllTokensMatcher()(tokens, mask, expected_mask, [&] { col_result[i] = true; }));
     }
 }
 
 template <class HasTokensTraits>
-void execute(
-    const ITokenExtractor * token_extractor,
+void executeString(
     const StringColumnType auto & col_input,
+    PaddedPODArray<UInt8> & col_result,
     size_t input_rows_count,
-    const TokensWithPosition & needles,
-    PaddedPODArray<UInt8> & col_result)
+    const ITokenExtractor * token_extractor,
+    const TokensWithPosition & tokens)
 {
-    if (needles.empty())
+    col_result.resize(input_rows_count);
+
+    if (tokens.empty())
     {
         /// No needles mean we don't filter and all rows pass
         for (size_t i = 0; i < input_rows_count; ++i)
@@ -213,11 +313,65 @@ void execute(
     }
 
     if constexpr (HasTokensTraits::mode == HasAnyAllTokensMode::Any)
-        executeHasAnyTokens(token_extractor, col_input, input_rows_count, needles, col_result);
+        executeHasAnyTokens(col_input, col_result, input_rows_count, token_extractor, tokens);
     else if constexpr (HasTokensTraits::mode == HasAnyAllTokensMode::All)
-        executeHasAllTokens(token_extractor, col_input, input_rows_count, needles, col_result);
+        executeHasAllTokens(col_input, col_result, input_rows_count, token_extractor, tokens);
     else
         static_assert(false, "Unknown search mode value detected");
+}
+
+template <class HasTokensTraits>
+void executeArray(
+    const ColumnArray * array,
+    const StringColumnType auto & input_string,
+    PaddedPODArray<UInt8> & col_result,
+    const ITokenExtractor * token_extractor,
+    const TokensWithPosition & tokens)
+{
+    const auto & offsets = array->getOffsets();
+    const size_t input_size = offsets.size();
+    col_result.resize(input_size);
+
+    if (tokens.empty())
+    {
+        /// No needles mean we don't filter and all rows pass
+        for (size_t i = 0; i < input_size; ++i)
+            col_result[i] = true;
+        return;
+    }
+
+    if constexpr (HasTokensTraits::mode == HasAnyAllTokensMode::Any)
+        executeHasAnyTokens(offsets, input_string, col_result, input_size, token_extractor, tokens);
+    else if constexpr (HasTokensTraits::mode == HasAnyAllTokensMode::All)
+        executeHasAllTokens(offsets, input_string, col_result, input_size, token_extractor, tokens);
+    else
+        static_assert(false, "Unknown search mode value detected");
+}
+
+template <class HasTokensTraits>
+void execute(
+    ColumnPtr col_input,
+    PaddedPODArray<UInt8> & col_result,
+    size_t input_rows_count,
+    const ITokenExtractor * token_extractor,
+    const TokensWithPosition & tokens)
+{
+    /// String
+    if (const auto * col_input_string = checkAndGetColumn<ColumnString>(col_input.get()))
+        executeString<HasTokensTraits>(*col_input_string, col_result, input_rows_count, token_extractor, tokens);
+    /// FixedString
+    else if (const auto * col_input_fixedstring = checkAndGetColumn<ColumnFixedString>(col_input.get()))
+        executeString<HasTokensTraits>(*col_input_fixedstring, col_result, input_rows_count, token_extractor, tokens);
+    /// Array(String) or Array(FixedString)
+    else if (const auto * col_input_array = checkAndGetColumn<ColumnArray>(col_input.get()))
+    {
+        /// String)
+        if (const auto * input_string = checkAndGetColumn<ColumnString>(&col_input_array->getData()))
+            executeArray<HasTokensTraits>(col_input_array, *input_string, col_result, token_extractor, tokens);
+        /// FixedString
+        else if (const auto * input_fixedstring = checkAndGetColumn<ColumnFixedString>(&col_input_array->getData()))
+            executeArray<HasTokensTraits>(col_input_array, *input_fixedstring, col_result, token_extractor, tokens);
+    }
 }
 }
 
@@ -234,11 +388,11 @@ ColumnPtr FunctionHasAnyAllTokens<HasTokensTraits>::executeImpl(
     ColumnPtr col_input = arguments[arg_input].column;
     auto col_result = ColumnVector<UInt8>::create();
 
-    col_result->getData().resize(input_rows_count);
-
-    /// If token_extractor == nullptr, we do a brute force scan on a column without index
     if (token_extractor == nullptr)
     {
+        /// If token_extractor == nullptr, we do a full-table scan on a column without index
+        /// By default, the default tokenizer will be used to tokenizer the input column.
+        /// Additionally, the search tokens need to be extract from the needle argument.
         chassert(!search_tokens.has_value());
 
         /// Populate needles from function arguments
@@ -273,21 +427,14 @@ ColumnPtr FunctionHasAnyAllTokens<HasTokensTraits>::executeImpl(
         else
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Needles argument for function '{}' has unsupported type", getName());
 
-        DefaultTokenExtractor default_token_extractor;
+        static DefaultTokenExtractor default_token_extractor;
 
-        if (const auto * col_input_string = checkAndGetColumn<ColumnString>(col_input.get()))
-            execute<HasTokensTraits>(&default_token_extractor, *col_input_string, input_rows_count, search_tokens_from_args, col_result->getData());
-        else if (const auto * col_input_fixedstring = checkAndGetColumn<ColumnFixedString>(col_input.get()))
-            execute<HasTokensTraits>(&default_token_extractor, *col_input_fixedstring, input_rows_count, search_tokens_from_args, col_result->getData());
+        execute<HasTokensTraits>(col_input, col_result->getData(), input_rows_count, &default_token_extractor, search_tokens_from_args);
     }
     else
     {
         /// If token_extractor != nullptr, a text index exists and we are doing text index lookups
-        /// This path is only entered for parts that have no materialized text index
-        if (const auto * col_input_string = checkAndGetColumn<ColumnString>(col_input.get()))
-            execute<HasTokensTraits>(token_extractor.get(), *col_input_string, input_rows_count, search_tokens.value(), col_result->getData());
-        else if (const auto * col_input_fixedstring = checkAndGetColumn<ColumnFixedString>(col_input.get()))
-            execute<HasTokensTraits>(token_extractor.get(), *col_input_fixedstring, input_rows_count, search_tokens.value(), col_result->getData());
+        execute<HasTokensTraits>(col_input, col_result->getData(), input_rows_count, token_extractor.get(), search_tokens.value());
     }
 
     return col_result;

--- a/src/Functions/hasAnyAllTokens.cpp
+++ b/src/Functions/hasAnyAllTokens.cpp
@@ -467,13 +467,13 @@ For example, ['ClickHouse', 'ClickHouse'] is treated the same as ['ClickHouse'].
 hasAnyTokens(input, needles)
 )";
     FunctionDocumentation::Arguments arguments_hasAnyTokens = {
-        {"input", "The input column.", {"String", "FixedString"}},
+        {"input", "The input column.", {"String", "FixedString", "Array(String)", "Array(FixedString)"}},
         {"needles", "Tokens to be searched. Supports at most 64 tokens.", {"String", "Array(String)"}}
     };
     FunctionDocumentation::ReturnedValue returned_value_hasAnyTokens = {"Returns `1`, if there was at least one match. `0`, otherwise.", {"UInt8"}};
     FunctionDocumentation::Examples examples_hasAnyTokens = {
     {
-        "Usage example",
+        "Usage example for a string column",
         R"(
 CREATE TABLE table (
     id UInt32,
@@ -514,6 +514,59 @@ SELECT count() FROM table WHERE hasAnyTokens(msg, tokens('a()d', 'splitByString'
 │       3 │
 └─────────┘
         )"
+    },
+    {
+        "Usage examples for array and map columns",
+        R"(
+CREATE TABLE log (
+    id UInt32,
+    tags Array(String),
+    attributes Map(String, String),
+    INDEX idx_tags (tags) TYPE text(tokenizer = splitByNonAlpha),
+    INDEX idx_attributes_keys mapKeys(attributes) TYPE text(tokenizer = array),
+    INDEX idx_attributes_vals mapValues(attributes) TYPE text(tokenizer = array)
+)
+ENGINE = MergeTree
+ORDER BY id;
+
+INSERT INTO log VALUES
+    (1, ['clickhouse', 'clickhouse cloud'], {'address': '192.0.0.1', 'log_level': 'INFO'}),
+    (2, ['chdb'], {'embedded': 'true', 'log_level': 'DEBUG'});
+        )",
+        ""
+    },
+    {
+        "Example with an array column",
+        R"(
+SELECT count() FROM log WHERE hasAnyTokens(tags, 'clickhouse');
+        )",
+        R"(
+┌─count()─┐
+│       1 │
+└─────────┘
+        )"
+    },
+    {
+        "Example with mapKeys",
+        R"(
+SELECT count() FROM log WHERE hasAnyTokens(mapKeys(attributes), ['address', 'log_level']);
+        )",
+        R"(
+┌─count()─┐
+│       2 │
+└─────────┘
+        )"
+    },
+    {
+        "Example with mapValues",
+        R"(
+SELECT count() FROM log WHERE hasAnyTokens(mapValues(attributes), ['192.0.0.1', 'DEBUG']);
+        )",
+        R"(
+┌─count()─┐
+│       2 │
+└─────────┘
+        )"
     }
     };
     FunctionDocumentation::IntroducedIn introduced_in_hasAnyTokens = {25, 7};
@@ -548,13 +601,13 @@ For example, needles = ['ClickHouse', 'ClickHouse'] is treated the same as ['Cli
 hasAllTokens(input, needles)
 )";
     FunctionDocumentation::Arguments arguments_hasAllTokens = {
-        {"input", "The input column.", {"String", "FixedString"}},
+        {"input", "The input column.", {"String", "FixedString", "Array(String)", "Array(FixedString)"}},
         {"needles", "Tokens to be searched. Supports at most 64 tokens.", {"String", "Array(String)"}}
     };
     FunctionDocumentation::ReturnedValue returned_value_hasAllTokens = {"Returns 1, if all needles match. 0, otherwise.", {"UInt8"}};
     FunctionDocumentation::Examples examples_hasAllTokens = {
     {
-        "Usage example",
+        "Usage example for a string column",
         R"(
 CREATE TABLE table (
     id UInt32,
@@ -593,6 +646,59 @@ SELECT count() FROM table WHERE hasAllTokens(msg, tokens('a()d', 'splitByString'
         R"(
 ┌─count()─┐
 │       1 │
+└─────────┘
+        )"
+    },
+    {
+        "Usage examples for array and map columns",
+        R"(
+CREATE TABLE log (
+    id UInt32,
+    tags Array(String),
+    attributes Map(String, String),
+    INDEX idx_tags (tags) TYPE text(tokenizer = splitByNonAlpha),
+    INDEX idx_attributes_keys mapKeys(attributes) TYPE text(tokenizer = array),
+    INDEX idx_attributes_vals mapValues(attributes) TYPE text(tokenizer = array)
+)
+ENGINE = MergeTree
+ORDER BY id;
+
+INSERT INTO log VALUES
+    (1, ['clickhouse', 'clickhouse cloud'], {'address': '192.0.0.1', 'log_level': 'INFO'}),
+    (2, ['chdb'], {'embedded': 'true', 'log_level': 'DEBUG'});
+        )",
+        ""
+    },
+    {
+        "Example with an array column",
+        R"(
+SELECT count() FROM log WHERE hasAllTokens(tags, 'clickhouse');
+        )",
+        R"(
+┌─count()─┐
+│       1 │
+└─────────┘
+        )"
+    },
+    {
+        "Example with mapKeys",
+        R"(
+SELECT count() FROM log WHERE hasAllTokens(mapKeys(attributes), ['address', 'log_level']);
+        )",
+        R"(
+┌─count()─┐
+│       1 │
+└─────────┘
+        )"
+    },
+    {
+        "Example with mapValues",
+        R"(
+SELECT count() FROM log WHERE hasAllTokens(mapValues(attributes), ['192.0.0.1', 'DEBUG']);
+        )",
+        R"(
+┌─count()─┐
+│       0 │
 └─────────┘
         )"
     }

--- a/src/Functions/hasAnyAllTokens.cpp
+++ b/src/Functions/hasAnyAllTokens.cpp
@@ -334,7 +334,7 @@ void execute(
     /// Array(String) or Array(FixedString)
     else if (const auto * col_input_array = checkAndGetColumn<ColumnArray>(col_input.get()))
     {
-        /// String)
+        /// String
         if (const auto * input_string = checkAndGetColumn<ColumnString>(&col_input_array->getData()))
             executeArray<HasTokensTraits>(col_input_array, *input_string, col_result, token_extractor, tokens);
         /// FixedString
@@ -360,7 +360,7 @@ ColumnPtr FunctionHasAnyAllTokens<HasTokensTraits>::executeImpl(
     if (token_extractor == nullptr)
     {
         /// If token_extractor == nullptr, we do a full-table scan on a column without index
-        /// By default, the default tokenizer will be used to tokenizer the input column.
+        /// By default, the default tokenizer will be used to tokenize the input column.
         /// Additionally, the search tokens need to be extract from the needle argument.
         chassert(!search_tokens.has_value());
 

--- a/src/Functions/hasAnyAllTokens.h
+++ b/src/Functions/hasAnyAllTokens.h
@@ -56,7 +56,5 @@ private:
     const bool allow_experimental_full_text_index;
     std::unique_ptr<ITokenExtractor> token_extractor;
     std::optional<TokensWithPosition> search_tokens;
-
-    inline static const std::unique_ptr<ITokenExtractor> token_default_extractor = std::make_unique<DefaultTokenExtractor>();
 };
 }

--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
@@ -471,7 +471,7 @@ bool MergeTreeIndexConditionText::traverseFunctionNode(
             out.function = RPNElement::FUNCTION_HAS_ALL_TOKENS;
             out.text_search_queries.emplace_back(std::make_shared<TextSearchQuery>(function_name, TextSearchMode::All, search_tokens));
 
-                auto & search_function = typeid_cast<FunctionHasAnyAllTokens<traits::HasAllTokensTraits> &>(*adaptor->getFunction());
+            auto & search_function = typeid_cast<FunctionHasAnyAllTokens<traits::HasAllTokensTraits> &>(*adaptor->getFunction());
             search_function.setTokenExtractor(token_extractor->clone());
             search_function.setSearchTokens(search_tokens);
         }

--- a/tests/queries/0_stateless/02346_text_index_array_support.reference
+++ b/tests/queries/0_stateless/02346_text_index_array_support.reference
@@ -41,3 +41,85 @@ Granules: 3072/6144
 -- -- value does not exist in granules
 Description: text GRANULARITY 1
 Granules: 0/6144
+hasAnyTokens support
+-- with String
+3072
+3072
+5120
+-- with FixedString
+3072
+3072
+5120
+-- Check that the text index actually gets used (String)
+-- -- value exists only in 1024 granules
+Description: text GRANULARITY 1
+Granules: 1024/6144
+-- -- value exists only in 2048 granules
+Description: text GRANULARITY 1
+Granules: 2048/6144
+-- -- value exists only in 3072 granules
+Description: text GRANULARITY 1
+Granules: 3072/6144
+-- -- value exists only in 5120 granules
+Description: text GRANULARITY 1
+Granules: 5120/6144
+-- -- value does not exist in granules
+Description: text GRANULARITY 1
+Granules: 0/6144
+-- Check that the text index actually gets used (FixedString)
+-- -- value exists only in 1024 granules
+Description: text GRANULARITY 1
+Granules: 1024/6144
+-- -- value exists only in 2048 granules
+Description: text GRANULARITY 1
+Granules: 2048/6144
+-- -- value exists only in 3072 granules
+Description: text GRANULARITY 1
+Granules: 3072/6144
+-- -- value exists only in 5120 granules
+Description: text GRANULARITY 1
+Granules: 5120/6144
+-- -- value does not exist in granules
+Description: text GRANULARITY 1
+Granules: 0/6144
+hasAllTokens support
+-- with String
+3072
+3072
+1024
+-- with FixedString
+3072
+3072
+1024
+-- Check that the text index actually gets used (String)
+-- -- value exists only in 1024 granules
+Description: text GRANULARITY 1
+Granules: 1024/6144
+-- -- value exists only in 2048 granules
+Description: text GRANULARITY 1
+Granules: 2048/6144
+-- -- value exists only in 3072 granules
+Description: text GRANULARITY 1
+Granules: 3072/6144
+-- -- value exists only in 1024 granules
+Description: text GRANULARITY 1
+Granules: 1024/6144
+-- -- value does not exist in granules
+Description: text GRANULARITY 1
+Granules: 0/6144
+-- Check that the text index actually gets used (FixedString)
+-- -- value exists only in 1024 granules
+Description: text GRANULARITY 1
+Granules: 1024/6144
+-- -- value exists only in 2048 granules
+Description: text GRANULARITY 1
+Granules: 2048/6144
+-- -- value exists only in 3072 granules
+Description: text GRANULARITY 1
+Granules: 3072/6144
+-- -- value exists only in 1024 granules
+Description: text GRANULARITY 1
+Granules: 1024/6144
+-- -- value does not exist in granules
+Description: text GRANULARITY 1
+Granules: 0/6144

--- a/tests/queries/0_stateless/02346_text_index_array_support.reference
+++ b/tests/queries/0_stateless/02346_text_index_array_support.reference
@@ -1,125 +1,125 @@
 has support
 -- with String
-3072
-3072
-2048
+1536
+1536
+1024
 0
 -- with FixedString
-3072
-3072
-2048
+1536
+1536
+1024
 0
 -- Check that the text index actually gets used (String)
+-- -- value exists only in 512 granules
+Description: text GRANULARITY 1
+Granules: 512/3072
 -- -- value exists only in 1024 granules
 Description: text GRANULARITY 1
-Granules: 1024/6144
--- -- value exists only in 2048 granules
+Granules: 1024/3072
+-- -- value exists only in 1536 granules
 Description: text GRANULARITY 1
-Granules: 2048/6144
--- -- value exists only in 3072 granules
+Granules: 1536/3072
+-- -- value exists only in 1536 granules
 Description: text GRANULARITY 1
-Granules: 3072/6144
--- -- value exists only in 3072 granules
-Description: text GRANULARITY 1
-Granules: 3072/6144
+Granules: 1536/3072
 -- -- value does not exist in granules
 Description: text GRANULARITY 1
-Granules: 0/6144
+Granules: 0/3072
 -- Check that the text index actually gets used (FixedString)
+-- -- value exists only in 512 granules
+Description: text GRANULARITY 1
+Granules: 512/3072
 -- -- value exists only in 1024 granules
 Description: text GRANULARITY 1
-Granules: 1024/6144
--- -- value exists only in 2048 granules
+Granules: 1024/3072
+-- -- value exists only in 1536 granules
 Description: text GRANULARITY 1
-Granules: 2048/6144
--- -- value exists only in 3072 granules
+Granules: 1536/3072
+-- -- value exists only in 1536 granules
 Description: text GRANULARITY 1
-Granules: 3072/6144
--- -- value exists only in 3072 granules
-Description: text GRANULARITY 1
-Granules: 3072/6144
+Granules: 1536/3072
 -- -- value does not exist in granules
 Description: text GRANULARITY 1
-Granules: 0/6144
+Granules: 0/3072
 hasAnyTokens support
 -- with String
-3072
-3072
-5120
+1536
+1536
+2560
 -- with FixedString
-3072
-3072
-5120
+1536
+1536
+2560
 -- Check that the text index actually gets used (String)
+-- -- value exists only in 512 granules
+Description: text GRANULARITY 1
+Granules: 512/3072
 -- -- value exists only in 1024 granules
 Description: text GRANULARITY 1
-Granules: 1024/6144
--- -- value exists only in 2048 granules
+Granules: 1024/3072
+-- -- value exists only in 1536 granules
 Description: text GRANULARITY 1
-Granules: 2048/6144
--- -- value exists only in 3072 granules
+Granules: 1536/3072
+-- -- value exists only in 2560 granules
 Description: text GRANULARITY 1
-Granules: 3072/6144
--- -- value exists only in 5120 granules
-Description: text GRANULARITY 1
-Granules: 5120/6144
+Granules: 2560/3072
 -- -- value does not exist in granules
 Description: text GRANULARITY 1
-Granules: 0/6144
+Granules: 0/3072
 -- Check that the text index actually gets used (FixedString)
+-- -- value exists only in 512 granules
+Description: text GRANULARITY 1
+Granules: 512/3072
 -- -- value exists only in 1024 granules
 Description: text GRANULARITY 1
-Granules: 1024/6144
--- -- value exists only in 2048 granules
+Granules: 1024/3072
+-- -- value exists only in 1536 granules
 Description: text GRANULARITY 1
-Granules: 2048/6144
--- -- value exists only in 3072 granules
+Granules: 1536/3072
+-- -- value exists only in 2560 granules
 Description: text GRANULARITY 1
-Granules: 3072/6144
--- -- value exists only in 5120 granules
-Description: text GRANULARITY 1
-Granules: 5120/6144
+Granules: 2560/3072
 -- -- value does not exist in granules
 Description: text GRANULARITY 1
-Granules: 0/6144
+Granules: 0/3072
 hasAllTokens support
 -- with String
-3072
-3072
-1024
+1536
+1536
+512
 -- with FixedString
-3072
-3072
-1024
+1536
+1536
+512
 -- Check that the text index actually gets used (String)
+-- -- value exists only in 512 granules
+Description: text GRANULARITY 1
+Granules: 512/3072
 -- -- value exists only in 1024 granules
 Description: text GRANULARITY 1
-Granules: 1024/6144
--- -- value exists only in 2048 granules
+Granules: 1024/3072
+-- -- value exists only in 1536 granules
 Description: text GRANULARITY 1
-Granules: 2048/6144
--- -- value exists only in 3072 granules
+Granules: 1536/3072
+-- -- value exists only in 512 granules
 Description: text GRANULARITY 1
-Granules: 3072/6144
--- -- value exists only in 1024 granules
-Description: text GRANULARITY 1
-Granules: 1024/6144
+Granules: 512/3072
 -- -- value does not exist in granules
 Description: text GRANULARITY 1
-Granules: 0/6144
+Granules: 0/3072
 -- Check that the text index actually gets used (FixedString)
+-- -- value exists only in 512 granules
+Description: text GRANULARITY 1
+Granules: 512/3072
 -- -- value exists only in 1024 granules
 Description: text GRANULARITY 1
-Granules: 1024/6144
--- -- value exists only in 2048 granules
+Granules: 1024/3072
+-- -- value exists only in 1536 granules
 Description: text GRANULARITY 1
-Granules: 2048/6144
--- -- value exists only in 3072 granules
+Granules: 1536/3072
+-- -- value exists only in 512 granules
 Description: text GRANULARITY 1
-Granules: 3072/6144
--- -- value exists only in 1024 granules
-Description: text GRANULARITY 1
-Granules: 1024/6144
+Granules: 512/3072
 -- -- value does not exist in granules
 Description: text GRANULARITY 1
-Granules: 0/6144
+Granules: 0/3072

--- a/tests/queries/0_stateless/02346_text_index_array_support.sql
+++ b/tests/queries/0_stateless/02346_text_index_array_support.sql
@@ -21,12 +21,12 @@ ENGINE = MergeTree()
 ORDER BY (id)
 SETTINGS index_granularity = 1;
 
-INSERT INTO tab SELECT number, ['abc'], ['abc'] FROM numbers(1024);
-INSERT INTO tab SELECT number, ['foo'], ['foo'] FROM numbers(1024);
-INSERT INTO tab SELECT number, ['bar'], ['bar'] FROM numbers(1024);
-INSERT INTO tab SELECT number, ['foo', 'bar'], ['foo', 'bar'] FROM numbers(1024);
-INSERT INTO tab SELECT number, ['foo', 'baz'], ['foo', 'baz'] FROM numbers(1024);
-INSERT INTO tab SELECT number, ['bar', 'baz'], ['bar', 'baz'] FROM numbers(1024);
+INSERT INTO tab SELECT number, ['abc'], ['abc'] FROM numbers(512);
+INSERT INTO tab SELECT number, ['foo'], ['foo'] FROM numbers(512);
+INSERT INTO tab SELECT number, ['bar'], ['bar'] FROM numbers(512);
+INSERT INTO tab SELECT number, ['foo', 'bar'], ['foo', 'bar'] FROM numbers(512);
+INSERT INTO tab SELECT number, ['foo', 'baz'], ['foo', 'baz'] FROM numbers(512);
+INSERT INTO tab SELECT number, ['bar', 'baz'], ['bar', 'baz'] FROM numbers(512);
 
 SELECT 'has support';
 
@@ -59,16 +59,16 @@ CREATE VIEW explain_index_has AS (
     LIMIT 1, 2
 );
 
-SELECT '-- -- value exists only in 1024 granules';
+SELECT '-- -- value exists only in 512 granules';
 SELECT * FROM explain_index_has(use_idx_fixed = 0, filter = 'abc');
 
-SELECT '-- -- value exists only in 2048 granules';
+SELECT '-- -- value exists only in 1024 granules';
 SELECT * FROM explain_index_has(use_idx_fixed = 0, filter = 'baz');
 
-SELECT '-- -- value exists only in 3072 granules';
+SELECT '-- -- value exists only in 1536 granules';
 SELECT * FROM explain_index_has(use_idx_fixed = 0, filter = 'foo');
 
-SELECT '-- -- value exists only in 3072 granules';
+SELECT '-- -- value exists only in 1536 granules';
 SELECT * FROM explain_index_has(use_idx_fixed = 0, filter = 'bar');
 
 SELECT '-- -- value does not exist in granules';
@@ -76,16 +76,16 @@ SELECT * FROM explain_index_has(use_idx_fixed = 0, filter = 'def');
 
 SELECT '-- Check that the text index actually gets used (FixedString)';
 
-SELECT '-- -- value exists only in 1024 granules';
+SELECT '-- -- value exists only in 512 granules';
 SELECT * FROM explain_index_has(use_idx_fixed = 1, filter = toFixedString('abc', 3));
 
-SELECT '-- -- value exists only in 2048 granules';
+SELECT '-- -- value exists only in 1024 granules';
 SELECT * FROM explain_index_has(use_idx_fixed = 1, filter = toFixedString('baz', 3));
 
-SELECT '-- -- value exists only in 3072 granules';
+SELECT '-- -- value exists only in 1536 granules';
 SELECT * FROM explain_index_has(use_idx_fixed = 1, filter = toFixedString('foo', 3));
 
-SELECT '-- -- value exists only in 3072 granules';
+SELECT '-- -- value exists only in 1536 granules';
 SELECT * FROM explain_index_has(use_idx_fixed = 1, filter = toFixedString('bar', 3));
 
 SELECT '-- -- value does not exist in granules';
@@ -120,16 +120,16 @@ CREATE VIEW explain_index_has_any_tokens AS (
     LIMIT 1, 2
 );
 
-SELECT '-- -- value exists only in 1024 granules';
+SELECT '-- -- value exists only in 512 granules';
 SELECT * FROM explain_index_has_any_tokens(use_idx_fixed = 0, filter = 'abc');
 
-SELECT '-- -- value exists only in 2048 granules';
+SELECT '-- -- value exists only in 1024 granules';
 SELECT * FROM explain_index_has_any_tokens(use_idx_fixed = 0, filter = 'baz');
 
-SELECT '-- -- value exists only in 3072 granules';
+SELECT '-- -- value exists only in 1536 granules';
 SELECT * FROM explain_index_has_any_tokens(use_idx_fixed = 0, filter = 'foo');
 
-SELECT '-- -- value exists only in 5120 granules';
+SELECT '-- -- value exists only in 2560 granules';
 SELECT * FROM explain_index_has_any_tokens(use_idx_fixed = 0, filter = 'foo bar');
 
 SELECT '-- -- value does not exist in granules';
@@ -137,16 +137,16 @@ SELECT * FROM explain_index_has_any_tokens(use_idx_fixed = 0, filter = 'def');
 
 SELECT '-- Check that the text index actually gets used (FixedString)';
 
-SELECT '-- -- value exists only in 1024 granules';
+SELECT '-- -- value exists only in 512 granules';
 SELECT * FROM explain_index_has_any_tokens(use_idx_fixed = 1, filter = 'abc');
 
-SELECT '-- -- value exists only in 2048 granules';
+SELECT '-- -- value exists only in 1024 granules';
 SELECT * FROM explain_index_has_any_tokens(use_idx_fixed = 1, filter = 'baz');
 
-SELECT '-- -- value exists only in 3072 granules';
+SELECT '-- -- value exists only in 1536 granules';
 SELECT * FROM explain_index_has_any_tokens(use_idx_fixed = 1, filter = 'foo');
 
-SELECT '-- -- value exists only in 5120 granules';
+SELECT '-- -- value exists only in 2560 granules';
 SELECT * FROM explain_index_has_any_tokens(use_idx_fixed = 1, filter = 'foo bar');
 
 SELECT '-- -- value does not exist in granules';
@@ -181,16 +181,16 @@ CREATE VIEW explain_index_has_all_tokens AS (
     LIMIT 1, 2
 );
 
-SELECT '-- -- value exists only in 1024 granules';
+SELECT '-- -- value exists only in 512 granules';
 SELECT * FROM explain_index_has_all_tokens(use_idx_fixed = 0, filter = 'abc');
 
-SELECT '-- -- value exists only in 2048 granules';
+SELECT '-- -- value exists only in 1024 granules';
 SELECT * FROM explain_index_has_all_tokens(use_idx_fixed = 0, filter = 'baz');
 
-SELECT '-- -- value exists only in 3072 granules';
+SELECT '-- -- value exists only in 1536 granules';
 SELECT * FROM explain_index_has_all_tokens(use_idx_fixed = 0, filter = 'foo');
 
-SELECT '-- -- value exists only in 1024 granules';
+SELECT '-- -- value exists only in 512 granules';
 SELECT * FROM explain_index_has_all_tokens(use_idx_fixed = 0, filter = 'foo bar');
 
 SELECT '-- -- value does not exist in granules';
@@ -198,16 +198,16 @@ SELECT * FROM explain_index_has_all_tokens(use_idx_fixed = 0, filter = 'def');
 
 SELECT '-- Check that the text index actually gets used (FixedString)';
 
-SELECT '-- -- value exists only in 1024 granules';
+SELECT '-- -- value exists only in 512 granules';
 SELECT * FROM explain_index_has_all_tokens(use_idx_fixed = 1, filter = 'abc');
 
-SELECT '-- -- value exists only in 2048 granules';
+SELECT '-- -- value exists only in 1024 granules';
 SELECT * FROM explain_index_has_all_tokens(use_idx_fixed = 1, filter = 'baz');
 
-SELECT '-- -- value exists only in 3072 granules';
+SELECT '-- -- value exists only in 1536 granules';
 SELECT * FROM explain_index_has_all_tokens(use_idx_fixed = 1, filter = 'foo');
 
-SELECT '-- -- value exists only in 1024 granules';
+SELECT '-- -- value exists only in 512 granules';
 SELECT * FROM explain_index_has_all_tokens(use_idx_fixed = 1, filter = 'foo bar');
 
 SELECT '-- -- value does not exist in granules';

--- a/tests/queries/0_stateless/02346_text_index_array_support.sql
+++ b/tests/queries/0_stateless/02346_text_index_array_support.sql
@@ -91,5 +91,129 @@ SELECT * FROM explain_index_has(use_idx_fixed = 1, filter = toFixedString('bar',
 SELECT '-- -- value does not exist in granules';
 SELECT * FROM explain_index_has(use_idx_fixed = 1, filter = toFixedString('def', 3));
 
+SELECT 'hasAnyTokens support';
+
+SELECT '-- with String';
+SELECT count() FROM tab WHERE hasAnyTokens(arr, 'foo');
+SELECT count() FROM tab WHERE hasAnyTokens(arr, 'bar');
+SELECT count() FROM tab WHERE hasAnyTokens(arr, 'foo bar');
+
+SELECT '-- with FixedString';
+SELECT count() FROM tab WHERE hasAnyTokens(arr_fixed, 'foo');
+SELECT count() FROM tab WHERE hasAnyTokens(arr_fixed, 'bar');
+SELECT count() FROM tab WHERE hasAnyTokens(arr_fixed, 'foo bar');
+
+SELECT '-- Check that the text index actually gets used (String)';
+
+DROP VIEW IF EXISTS explain_index_has_any_tokens;
+CREATE VIEW explain_index_has_any_tokens AS (
+    SELECT trimLeft(explain) AS explain FROM (
+        EXPLAIN indexes = 1
+        SELECT count() FROM tab WHERE (
+            CASE
+                WHEN {use_idx_fixed:boolean} = 1 THEN hasAnyTokens(arr_fixed, {filter:String})
+                ELSE hasAnyTokens(arr, {filter:String})
+            END
+        )
+    )
+    WHERE explain LIKE '%Description:%' OR explain LIKE '%Granules:%'
+    LIMIT 1, 2
+);
+
+SELECT '-- -- value exists only in 1024 granules';
+SELECT * FROM explain_index_has_any_tokens(use_idx_fixed = 0, filter = 'abc');
+
+SELECT '-- -- value exists only in 2048 granules';
+SELECT * FROM explain_index_has_any_tokens(use_idx_fixed = 0, filter = 'baz');
+
+SELECT '-- -- value exists only in 3072 granules';
+SELECT * FROM explain_index_has_any_tokens(use_idx_fixed = 0, filter = 'foo');
+
+SELECT '-- -- value exists only in 5120 granules';
+SELECT * FROM explain_index_has_any_tokens(use_idx_fixed = 0, filter = 'foo bar');
+
+SELECT '-- -- value does not exist in granules';
+SELECT * FROM explain_index_has_any_tokens(use_idx_fixed = 0, filter = 'def');
+
+SELECT '-- Check that the text index actually gets used (FixedString)';
+
+SELECT '-- -- value exists only in 1024 granules';
+SELECT * FROM explain_index_has_any_tokens(use_idx_fixed = 1, filter = 'abc');
+
+SELECT '-- -- value exists only in 2048 granules';
+SELECT * FROM explain_index_has_any_tokens(use_idx_fixed = 1, filter = 'baz');
+
+SELECT '-- -- value exists only in 3072 granules';
+SELECT * FROM explain_index_has_any_tokens(use_idx_fixed = 1, filter = 'foo');
+
+SELECT '-- -- value exists only in 5120 granules';
+SELECT * FROM explain_index_has_any_tokens(use_idx_fixed = 1, filter = 'foo bar');
+
+SELECT '-- -- value does not exist in granules';
+SELECT * FROM explain_index_has_any_tokens(use_idx_fixed = 1, filter = 'def');
+
+SELECT 'hasAllTokens support';
+
+SELECT '-- with String';
+SELECT count() FROM tab WHERE hasAllTokens(arr, 'foo');
+SELECT count() FROM tab WHERE hasAllTokens(arr, 'bar');
+SELECT count() FROM tab WHERE hasAllTokens(arr, 'foo bar');
+
+SELECT '-- with FixedString';
+SELECT count() FROM tab WHERE hasAllTokens(arr_fixed, 'foo');
+SELECT count() FROM tab WHERE hasAllTokens(arr_fixed, 'bar');
+SELECT count() FROM tab WHERE hasAllTokens(arr_fixed, 'foo bar');
+
+SELECT '-- Check that the text index actually gets used (String)';
+
+DROP VIEW IF EXISTS explain_index_has_all_tokens;
+CREATE VIEW explain_index_has_all_tokens AS (
+    SELECT trimLeft(explain) AS explain FROM (
+        EXPLAIN indexes = 1
+        SELECT count() FROM tab WHERE (
+            CASE
+                WHEN {use_idx_fixed:boolean} = 1 THEN hasAllTokens(arr_fixed, {filter:String})
+                ELSE hasAllTokens(arr, {filter:String})
+            END
+        )
+    )
+    WHERE explain LIKE '%Description:%' OR explain LIKE '%Granules:%'
+    LIMIT 1, 2
+);
+
+SELECT '-- -- value exists only in 1024 granules';
+SELECT * FROM explain_index_has_all_tokens(use_idx_fixed = 0, filter = 'abc');
+
+SELECT '-- -- value exists only in 2048 granules';
+SELECT * FROM explain_index_has_all_tokens(use_idx_fixed = 0, filter = 'baz');
+
+SELECT '-- -- value exists only in 3072 granules';
+SELECT * FROM explain_index_has_all_tokens(use_idx_fixed = 0, filter = 'foo');
+
+SELECT '-- -- value exists only in 1024 granules';
+SELECT * FROM explain_index_has_all_tokens(use_idx_fixed = 0, filter = 'foo bar');
+
+SELECT '-- -- value does not exist in granules';
+SELECT * FROM explain_index_has_all_tokens(use_idx_fixed = 0, filter = 'def');
+
+SELECT '-- Check that the text index actually gets used (FixedString)';
+
+SELECT '-- -- value exists only in 1024 granules';
+SELECT * FROM explain_index_has_all_tokens(use_idx_fixed = 1, filter = 'abc');
+
+SELECT '-- -- value exists only in 2048 granules';
+SELECT * FROM explain_index_has_all_tokens(use_idx_fixed = 1, filter = 'baz');
+
+SELECT '-- -- value exists only in 3072 granules';
+SELECT * FROM explain_index_has_all_tokens(use_idx_fixed = 1, filter = 'foo');
+
+SELECT '-- -- value exists only in 1024 granules';
+SELECT * FROM explain_index_has_all_tokens(use_idx_fixed = 1, filter = 'foo bar');
+
+SELECT '-- -- value does not exist in granules';
+SELECT * FROM explain_index_has_all_tokens(use_idx_fixed = 1, filter = 'def');
+
 DROP VIEW explain_index_has;
+DROP VIEW explain_index_has_any_tokens;
+DROP VIEW explain_index_has_all_tokens;
 DROP TABLE tab;

--- a/tests/queries/0_stateless/02346_text_index_map_support.reference
+++ b/tests/queries/0_stateless/02346_text_index_map_support.reference
@@ -134,6 +134,96 @@ Granules: 2/2
 Description: text GRANULARITY 64
 Parts: 0/2
 Granules: 0/2
+-- hasAnyTokens support
+-- -- query with String
+2
+2
+1
+0
+-- -- query with FixedString
+2
+2
+1
+0
+-- -- Check that the text index actually gets used (String)
+-- -- -- keys exist in both granules
+Description: text GRANULARITY 64
+Parts: 2/2
+Granules: 2/2
+-- -- -- keys exist in both granules
+Description: text GRANULARITY 64
+Parts: 2/2
+Granules: 2/2
+-- -- -- keys exist only in the first granule
+Description: text GRANULARITY 64
+Parts: 1/2
+Granules: 1/2
+-- -- -- keys do not exist in granules
+Description: text GRANULARITY 64
+Parts: 0/2
+Granules: 0/2
+-- -- Check that the text index actually gets used (FixedString)
+-- -- -- keys exist in both granules
+Description: text GRANULARITY 64
+Parts: 2/2
+Granules: 2/2
+-- -- -- keys exist in both granules
+Description: text GRANULARITY 64
+Parts: 2/2
+Granules: 2/2
+-- -- -- keys exist only in the first granule
+Description: text GRANULARITY 64
+Parts: 1/2
+Granules: 1/2
+-- -- -- keys do not exist in granules
+Description: text GRANULARITY 64
+Parts: 0/2
+Granules: 0/2
+-- hasAllTokens support
+-- -- query with String
+1
+1
+0
+0
+-- -- query with FixedString
+1
+1
+0
+0
+-- -- Check that the text index actually gets used (String)
+-- -- -- keys exist in the first granule
+Description: text GRANULARITY 64
+Parts: 1/2
+Granules: 1/2
+-- -- -- keys exist in the second granule
+Description: text GRANULARITY 64
+Parts: 1/2
+Granules: 1/2
+-- -- -- keys do not exist in granules
+Description: text GRANULARITY 64
+Parts: 0/2
+Granules: 0/2
+-- -- -- keys do not exist in granules
+Description: text GRANULARITY 64
+Parts: 0/2
+Granules: 0/2
+-- -- Check that the text index actually gets used (FixedString)
+-- -- -- keys exist in the first granule
+Description: text GRANULARITY 64
+Parts: 1/2
+Granules: 1/2
+-- -- -- keys exist in the second granule
+Description: text GRANULARITY 64
+Parts: 1/2
+Granules: 1/2
+-- -- -- keys do not exist in granules
+Description: text GRANULARITY 64
+Parts: 0/2
+Granules: 0/2
+-- -- -- keys do not exist in granules
+Description: text GRANULARITY 64
+Parts: 0/2
+Granules: 0/2
 Function mapValues
 -- operator[] support
 -- -- query with String
@@ -211,6 +301,96 @@ Granules: 1/2
 Description: text GRANULARITY 64
 Parts: 2/2
 Granules: 2/2
+-- -- -- key does not exist in granules
+Description: text GRANULARITY 64
+Parts: 0/2
+Granules: 0/2
+-- hasAnyTokens support
+-- -- query with String
+2
+2
+1
+0
+-- -- query with FixedString
+2
+2
+1
+0
+-- -- Check that the text index actually gets used (String)
+-- -- -- key exists only in the first granule
+Description: text GRANULARITY 64
+Parts: 1/2
+Granules: 1/2
+-- -- -- key exists only in the second granule
+Description: text GRANULARITY 64
+Parts: 1/2
+Granules: 1/2
+-- -- -- key exists only in both granules
+Description: text GRANULARITY 64
+Parts: 2/2
+Granules: 2/2
+-- -- -- key does not exist in granules
+Description: text GRANULARITY 64
+Parts: 0/2
+Granules: 0/2
+-- -- Check that the text index actually gets used (FixedString)
+-- -- -- key exists only in the first granule
+Description: text GRANULARITY 64
+Parts: 1/2
+Granules: 1/2
+-- -- -- key exists only in the second granule
+Description: text GRANULARITY 64
+Parts: 1/2
+Granules: 1/2
+-- -- -- key exists only in both granules
+Description: text GRANULARITY 64
+Parts: 2/2
+Granules: 2/2
+-- -- -- key does not exist in granules
+Description: text GRANULARITY 64
+Parts: 0/2
+Granules: 0/2
+-- hasAllTokens support
+-- -- query with String
+1
+1
+0
+0
+-- -- query with FixedString
+1
+1
+0
+0
+-- -- Check that the text index actually gets used (String)
+-- -- -- key exists only in the first granule
+Description: text GRANULARITY 64
+Parts: 1/2
+Granules: 1/2
+-- -- -- key exists only in the second granule
+Description: text GRANULARITY 64
+Parts: 1/2
+Granules: 1/2
+-- -- -- key exists only in the first granules
+Description: text GRANULARITY 64
+Parts: 1/2
+Granules: 1/2
+-- -- -- key does not exist in granules
+Description: text GRANULARITY 64
+Parts: 0/2
+Granules: 0/2
+-- -- Check that the text index actually gets used (FixedString)
+-- -- -- key exists only in the first granule
+Description: text GRANULARITY 64
+Parts: 1/2
+Granules: 1/2
+-- -- -- key exists only in the second granule
+Description: text GRANULARITY 64
+Parts: 1/2
+Granules: 1/2
+-- -- -- key exists only in the first granules
+Description: text GRANULARITY 64
+Parts: 1/2
+Granules: 1/2
 -- -- -- key does not exist in granules
 Description: text GRANULARITY 64
 Parts: 0/2

--- a/tests/queries/0_stateless/02346_text_index_map_support.sql
+++ b/tests/queries/0_stateless/02346_text_index_map_support.sql
@@ -202,6 +202,127 @@ SELECT * FROM explain_index_has(use_idx_fixed = 1, filter = toFixedString('K1', 
 SELECT '-- -- -- key does not exist in granules';
 SELECT * FROM explain_index_has(use_idx_fixed = 1, filter = toFixedString('K3', 2));
 
+SELECT '-- hasAnyTokens support';
+
+SELECT '-- -- query with String';
+
+SELECT count() FROM tab WHERE hasAnyTokens(mapKeys(map), 'K0 K1');
+SELECT count() FROM tab WHERE hasAnyTokens(mapKeys(map), 'K1 K2');
+SELECT count() FROM tab WHERE hasAnyTokens(mapKeys(map), 'K2 K3');
+SELECT count() FROM tab WHERE hasAnyTokens(mapKeys(map), 'K3 K4');
+
+SELECT '-- -- query with FixedString';
+
+SELECT count() FROM tab WHERE hasAnyTokens(mapKeys(map_fixed), 'K0 K1');
+SELECT count() FROM tab WHERE hasAnyTokens(mapKeys(map_fixed), 'K1 K2');
+SELECT count() FROM tab WHERE hasAnyTokens(mapKeys(map_fixed), 'K2 K3');
+SELECT count() FROM tab WHERE hasAnyTokens(mapKeys(map_fixed), 'K3 K4');
+
+DROP VIEW IF EXISTS explain_index_has_any_tokens;
+CREATE VIEW explain_index_has_any_tokens AS (
+    SELECT trimLeft(explain) AS explain FROM (
+        EXPLAIN indexes=1
+        SELECT count() FROM tab WHERE (
+            CASE 
+                WHEN {use_idx_fixed:boolean} = 1 THEN hasAnyTokens(mapKeys(map_fixed), {filter:String})
+                ELSE hasAnyTokens(mapKeys(map), {filter:String})
+            END
+        )
+    )
+    WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+    LIMIT 2, 3
+);
+
+SELECT '-- -- Check that the text index actually gets used (String)';
+
+SELECT '-- -- -- keys exist in both granules';
+SELECT * FROM explain_index_has_any_tokens(use_idx_fixed = 0, filter = 'K0 K1');
+
+SELECT '-- -- -- keys exist in both granules';
+SELECT * FROM explain_index_has_any_tokens(use_idx_fixed = 0, filter = 'K1 K2');
+
+SELECT '-- -- -- keys exist only in the first granule';
+SELECT * FROM explain_index_has_any_tokens(use_idx_fixed = 0, filter = 'K2 K3');
+
+SELECT '-- -- -- keys do not exist in granules';
+SELECT * FROM explain_index_has_any_tokens(use_idx_fixed = 0, filter = 'K3 K4');
+
+SELECT '-- -- Check that the text index actually gets used (FixedString)';
+
+SELECT '-- -- -- keys exist in both granules';
+SELECT * FROM explain_index_has_any_tokens(use_idx_fixed = 1, filter = 'K0 K1');
+
+SELECT '-- -- -- keys exist in both granules';
+SELECT * FROM explain_index_has_any_tokens(use_idx_fixed = 1, filter = 'K1 K2');
+
+SELECT '-- -- -- keys exist only in the first granule';
+SELECT * FROM explain_index_has_any_tokens(use_idx_fixed = 1, filter = 'K2 K3');
+
+SELECT '-- -- -- keys do not exist in granules';
+SELECT * FROM explain_index_has_any_tokens(use_idx_fixed = 1, filter = 'K3 K4');
+
+SELECT '-- hasAllTokens support';
+
+SELECT '-- -- query with String';
+
+SELECT count() FROM tab WHERE hasAllTokens(mapKeys(map), 'K0 K1');
+SELECT count() FROM tab WHERE hasAllTokens(mapKeys(map), 'K1 K2');
+SELECT count() FROM tab WHERE hasAllTokens(mapKeys(map), 'K2 K3');
+SELECT count() FROM tab WHERE hasAllTokens(mapKeys(map), 'K3 K4');
+
+SELECT '-- -- query with FixedString';
+
+SELECT count() FROM tab WHERE hasAllTokens(mapKeys(map_fixed), 'K0 K1');
+SELECT count() FROM tab WHERE hasAllTokens(mapKeys(map_fixed), 'K1 K2');
+SELECT count() FROM tab WHERE hasAllTokens(mapKeys(map_fixed), 'K2 K3');
+SELECT count() FROM tab WHERE hasAllTokens(mapKeys(map_fixed), 'K3 K4');
+
+DROP VIEW IF EXISTS explain_index_has_all_tokens;
+CREATE VIEW explain_index_has_all_tokens AS (
+    SELECT trimLeft(explain) AS explain FROM (
+        EXPLAIN indexes=1
+        SELECT count() FROM tab WHERE (
+            CASE 
+                WHEN {use_idx_fixed:boolean} = 1 THEN hasAllTokens(mapKeys(map_fixed), {filter:String})
+                ELSE hasAllTokens(mapKeys(map), {filter:String})
+            END
+        )
+    )
+    WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+    LIMIT 2, 3
+);
+
+SELECT '-- -- Check that the text index actually gets used (String)';
+
+SELECT '-- -- -- keys exist in the first granule';
+SELECT * FROM explain_index_has_all_tokens(use_idx_fixed = 0, filter = 'K0 K1');
+
+SELECT '-- -- -- keys exist in the second granule';
+SELECT * FROM explain_index_has_all_tokens(use_idx_fixed = 0, filter = 'K1 K2');
+
+SELECT '-- -- -- keys do not exist in granules';
+SELECT * FROM explain_index_has_all_tokens(use_idx_fixed = 0, filter = 'K2 K3');
+
+SELECT '-- -- -- keys do not exist in granules';
+SELECT * FROM explain_index_has_all_tokens(use_idx_fixed = 0, filter = 'K3 K4');
+
+SELECT '-- -- Check that the text index actually gets used (FixedString)';
+
+SELECT '-- -- -- keys exist in the first granule';
+SELECT * FROM explain_index_has_all_tokens(use_idx_fixed = 1, filter = 'K0 K1');
+
+SELECT '-- -- -- keys exist in the second granule';
+SELECT * FROM explain_index_has_all_tokens(use_idx_fixed = 1, filter = 'K1 K2');
+
+SELECT '-- -- -- keys do not exist in granules';
+SELECT * FROM explain_index_has_all_tokens(use_idx_fixed = 1, filter = 'K2 K3');
+
+SELECT '-- -- -- keys do not exist in granules';
+SELECT * FROM explain_index_has_all_tokens(use_idx_fixed = 1, filter = 'K3 K4');
+
+DROP VIEW explain_index_has_any_tokens;
+DROP VIEW explain_index_has_all_tokens;
+
 SELECT 'Function mapValues';
 
 DROP TABLE tab;
@@ -309,7 +430,127 @@ SELECT * FROM explain_index_has(use_idx_fixed = 1, filter = 'V1');
 SELECT '-- -- -- key does not exist in granules';
 SELECT * FROM explain_index_has(use_idx_fixed = 1, filter = 'V3');
 
+SELECT '-- hasAnyTokens support';
+
+SELECT '-- -- query with String';
+
+SELECT count() FROM tab WHERE hasAnyTokens(mapValues(map), 'V0 V1');
+SELECT count() FROM tab WHERE hasAnyTokens(mapValues(map), 'V1 V2');
+SELECT count() FROM tab WHERE hasAnyTokens(mapValues(map), 'V2 V3');
+SELECT count() FROM tab WHERE hasAnyTokens(mapValues(map), 'V3 V4');
+
+SELECT '-- -- query with FixedString';
+
+SELECT count() FROM tab WHERE hasAnyTokens(mapValues(map_fixed), 'V0 V1');
+SELECT count() FROM tab WHERE hasAnyTokens(mapValues(map_fixed), 'V1 V2');
+SELECT count() FROM tab WHERE hasAnyTokens(mapValues(map_fixed), 'V2 V3');
+SELECT count() FROM tab WHERE hasAnyTokens(mapValues(map_fixed), 'V3 V4');
+
+DROP VIEW IF EXISTS explain_index_has_any_tokens;
+CREATE VIEW explain_index_has_any_tokens AS (
+    SELECT trimLeft(explain) AS explain FROM (
+        EXPLAIN indexes=1
+        SELECT count() FROM tab WHERE (
+            CASE 
+                WHEN {use_idx_fixed:boolean} = 1 THEN hasAnyTokens(mapValues(map_fixed), {filter:String})
+                ELSE hasAnyTokens(mapValues(map), {filter:String})
+            END
+        )
+    )
+    WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+    LIMIT 2, 3
+);
+
+SELECT '-- -- Check that the text index actually gets used (String)';
+
+SELECT '-- -- -- key exists only in the first granule';
+SELECT * FROM explain_index_has_any_tokens(use_idx_fixed = 0, filter = 'V0');
+
+SELECT '-- -- -- key exists only in the second granule';
+SELECT * FROM explain_index_has_any_tokens(use_idx_fixed = 0, filter = 'V2');
+
+SELECT '-- -- -- key exists only in both granules';
+SELECT * FROM explain_index_has_any_tokens(use_idx_fixed = 0, filter = 'V0 V1');
+
+SELECT '-- -- -- key does not exist in granules';
+SELECT * FROM explain_index_has_any_tokens(use_idx_fixed = 0, filter = 'V3');
+
+SELECT '-- -- Check that the text index actually gets used (FixedString)';
+
+SELECT '-- -- -- key exists only in the first granule';
+SELECT * FROM explain_index_has_any_tokens(use_idx_fixed = 1, filter = 'V0');
+
+SELECT '-- -- -- key exists only in the second granule';
+SELECT * FROM explain_index_has_any_tokens(use_idx_fixed = 1, filter = 'V2');
+
+SELECT '-- -- -- key exists only in both granules';
+SELECT * FROM explain_index_has_any_tokens(use_idx_fixed = 1, filter = 'V0 V1');
+
+SELECT '-- -- -- key does not exist in granules';
+SELECT * FROM explain_index_has_any_tokens(use_idx_fixed = 1, filter = 'V3');
+
+SELECT '-- hasAllTokens support';
+
+SELECT '-- -- query with String';
+
+SELECT count() FROM tab WHERE hasAllTokens(mapValues(map), 'V0 V1');
+SELECT count() FROM tab WHERE hasAllTokens(mapValues(map), 'V1 V2');
+SELECT count() FROM tab WHERE hasAllTokens(mapValues(map), 'V2 V3');
+SELECT count() FROM tab WHERE hasAllTokens(mapValues(map), 'V3 V4');
+
+SELECT '-- -- query with FixedString';
+
+SELECT count() FROM tab WHERE hasAllTokens(mapValues(map_fixed), 'V0 V1');
+SELECT count() FROM tab WHERE hasAllTokens(mapValues(map_fixed), 'V1 V2');
+SELECT count() FROM tab WHERE hasAllTokens(mapValues(map_fixed), 'V2 V3');
+SELECT count() FROM tab WHERE hasAllTokens(mapValues(map_fixed), 'V3 V4');
+
+DROP VIEW IF EXISTS explain_index_has_all_tokens;
+CREATE VIEW explain_index_has_all_tokens AS (
+    SELECT trimLeft(explain) AS explain FROM (
+        EXPLAIN indexes=1
+        SELECT count() FROM tab WHERE (
+            CASE 
+                WHEN {use_idx_fixed:boolean} = 1 THEN hasAllTokens(mapValues(map_fixed), {filter:String})
+                ELSE hasAllTokens(mapValues(map), {filter:String})
+            END
+        )
+    )
+    WHERE explain LIKE '%Description:%' OR explain LIKE '%Parts:%' OR explain LIKE '%Granules:%'
+    LIMIT 2, 3
+);
+
+SELECT '-- -- Check that the text index actually gets used (String)';
+
+SELECT '-- -- -- key exists only in the first granule';
+SELECT * FROM explain_index_has_all_tokens(use_idx_fixed = 0, filter = 'V0');
+
+SELECT '-- -- -- key exists only in the second granule';
+SELECT * FROM explain_index_has_all_tokens(use_idx_fixed = 0, filter = 'V2');
+
+SELECT '-- -- -- key exists only in the first granules';
+SELECT * FROM explain_index_has_all_tokens(use_idx_fixed = 0, filter = 'V0 V1');
+
+SELECT '-- -- -- key does not exist in granules';
+SELECT * FROM explain_index_has_all_tokens(use_idx_fixed = 0, filter = 'V3');
+
+SELECT '-- -- Check that the text index actually gets used (FixedString)';
+
+SELECT '-- -- -- key exists only in the first granule';
+SELECT * FROM explain_index_has_all_tokens(use_idx_fixed = 1, filter = 'V0');
+
+SELECT '-- -- -- key exists only in the second granule';
+SELECT * FROM explain_index_has_all_tokens(use_idx_fixed = 1, filter = 'V2');
+
+SELECT '-- -- -- key exists only in the first granules';
+SELECT * FROM explain_index_has_all_tokens(use_idx_fixed = 1, filter = 'V0 V1');
+
+SELECT '-- -- -- key does not exist in granules';
+SELECT * FROM explain_index_has_all_tokens(use_idx_fixed = 1, filter = 'V3');
+
 DROP VIEW explain_index_mapContains;
 DROP VIEW explain_index_equals;
 DROP VIEW explain_index_has;
+DROP VIEW explain_index_has_any_tokens;
+DROP VIEW explain_index_has_all_tokens;
 DROP TABLE tab;


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):

- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Support array of string as an input to the `hasAnyTokens` or `hasAllTokens` functions.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

### Details

Previously, only a string column was supported as an input to the `hasAnyTokens` and `hasAllTokens` functions. However, both `Array` and `Map` (via `mapKeys` and `mapValues`) input columns are already supported by the text index.

Since direct read from the text index is supported only by a handful functions, it was not possible to support the direct read for `Array` and `Map` columns with existing functions.

This change adds support for an array of string column as an input to both `hasAnyTokens` and `hasAllTokens` functions which led to having a direct read support for `Array` and `Map`.

NOTE: `Map` itself is not directly supported as an input, instead `mapKeys` or `mapValues` functions should be a wrapper around the `Map` column.
