### PR TITLE
The `distinct` operation can be executed in parallel on a per-partition basis

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -7224,7 +7224,7 @@ Specifies the name of a TimeSeries table used by the 'promql' dialect.
     DECLARE_WITH_ALIAS(FloatAuto, promql_evaluation_time, Field("auto"), R"(
 Sets the evaluation time to be used with promql dialect. 'auto' means the current time.
 )", EXPERIMENTAL, evaluation_time) \
-    DECLARE(Bool, enable_partition_distinct, false, R"(
+    DECLARE(Bool, enable_partition_distinct, true, R"(
 Specifies whether partitioned distinct processing is enabled. When enabled, blocks are partitioned based on distinct keys, and partitions are processed in parallel.
 )", EXPERIMENTAL) \
     \

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -7224,6 +7224,9 @@ Specifies the name of a TimeSeries table used by the 'promql' dialect.
     DECLARE_WITH_ALIAS(FloatAuto, promql_evaluation_time, Field("auto"), R"(
 Sets the evaluation time to be used with promql dialect. 'auto' means the current time.
 )", EXPERIMENTAL, evaluation_time) \
+    DECLARE(Bool, enable_partition_distinct, false, R"(
+Specifies whether partitioned distinct processing is enabled. When enabled, blocks are partitioned based on distinct keys, and partitions are processed in parallel.
+)", EXPERIMENTAL) \
     \
     /* ####################################################### */ \
     /* ############ END OF EXPERIMENTAL FEATURES ############# */ \

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -44,7 +44,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"correlated_subqueries_default_join_kind", "left", "right", "New setting. Default join kind for decorrelated query plan."},
             {"use_statistics_cache", 0, 0, "New setting"},
             {"s3_retry_attempts", 500, 500, "Changed the value of the obsolete setting"},
-            {"enable_partition_distinct", false, false, "Add new setting to enable partitioned distinct processing."},
+            {"enable_partition_distinct", false, true, "Add new setting to enable partitioned distinct processing."},
         });
         addSettingsChanges(settings_changes_history, "25.10",
         {

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -44,6 +44,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"correlated_subqueries_default_join_kind", "left", "right", "New setting. Default join kind for decorrelated query plan."},
             {"use_statistics_cache", 0, 0, "New setting"},
             {"s3_retry_attempts", 500, 500, "Changed the value of the obsolete setting"},
+            {"enable_partition_distinct", false, false, "Add new setting to enable partitioned distinct processing."},
         });
         addSettingsChanges(settings_changes_history, "25.10",
         {

--- a/src/Interpreters/SetVariants.cpp
+++ b/src/Interpreters/SetVariants.cpp
@@ -146,6 +146,8 @@ typename SetVariantsTemplate<Variant>::Type SetVariantsTemplate<Variant>::choose
     }
 
     /// If the keys fit in N bits, we will use a hash table for N-bit-packed keys
+    if (all_fixed && keys_bytes <= 8)
+        return Type::keys64;
     if (all_fixed && keys_bytes <= 16)
         return Type::keys128;
     if (all_fixed && keys_bytes <= 32)

--- a/src/Interpreters/SetVariants.h
+++ b/src/Interpreters/SetVariants.h
@@ -196,6 +196,7 @@ struct NonClearableSet
     std::unique_ptr<SetMethodOneNumber<UInt64, HashSet<UInt64, HashCRC32<UInt64>>>>          key64;
     std::unique_ptr<SetMethodString<HashSetWithSavedHash<StringRef>>>                        key_string;
     std::unique_ptr<SetMethodFixedString<HashSetWithSavedHash<StringRef>>>                   key_fixed_string;
+    std::unique_ptr<SetMethodKeysFixed<HashSet<UInt64,HashCRC32<UInt64>>>>                   keys64;
     std::unique_ptr<SetMethodKeysFixed<HashSet<UInt128, UInt128HashCRC32>>>                  keys128;
     std::unique_ptr<SetMethodKeysFixed<HashSet<UInt256, UInt256HashCRC32>>>                  keys256;
     std::unique_ptr<SetMethodHashed<HashSet<UInt128, UInt128TrivialHash>>>                   hashed;
@@ -218,6 +219,7 @@ struct ClearableSet
     std::unique_ptr<SetMethodOneNumber<UInt64, ClearableHashSet<UInt64, HashCRC32<UInt64>>>>         key64;
     std::unique_ptr<SetMethodString<ClearableHashSetWithSavedHash<StringRef>>>                       key_string;
     std::unique_ptr<SetMethodFixedString<ClearableHashSetWithSavedHash<StringRef>>>                  key_fixed_string;
+    std::unique_ptr<SetMethodKeysFixed<ClearableHashSet<UInt64, HashCRC32<UInt64>>>>                 keys64;
     std::unique_ptr<SetMethodKeysFixed<ClearableHashSet<UInt128, UInt128HashCRC32>>>                 keys128;
     std::unique_ptr<SetMethodKeysFixed<ClearableHashSet<UInt256, UInt256HashCRC32>>>                 keys256;
     std::unique_ptr<SetMethodHashed<ClearableHashSet<UInt128, UInt128TrivialHash>>>                  hashed;
@@ -243,6 +245,7 @@ struct SetVariantsTemplate: public Variant
         M(key64)                \
         M(key_string)           \
         M(key_fixed_string)     \
+        M(keys64)               \
         M(keys128)              \
         M(keys256)              \
         M(nullable_keys128)     \

--- a/src/Processors/QueryPlan/PartitionedDistinctStep.cpp
+++ b/src/Processors/QueryPlan/PartitionedDistinctStep.cpp
@@ -1,0 +1,200 @@
+#include <IO/Operators.h>
+#include <Processors/QueryPlan/PartitionedDistinctStep.h>
+#include <Processors/QueryPlan/QueryPlanSerializationSettings.h>
+#include <Processors/QueryPlan/QueryPlanStepRegistry.h>
+#include <Processors/QueryPlan/Serialization.h>
+#include <Processors/Transforms/PartitionedDistinctTransform.h>
+#include <QueryPipeline/QueryPipelineBuilder.h>
+#include <Common/BitHelpers.h>
+#include <Common/JSONBuilder.h>
+
+namespace DB
+{
+
+namespace QueryPlanSerializationSetting
+{
+extern const QueryPlanSerializationSettingsOverflowMode distinct_overflow_mode;
+extern const QueryPlanSerializationSettingsUInt64 max_bytes_in_distinct;
+extern const QueryPlanSerializationSettingsUInt64 max_rows_in_distinct;
+}
+
+namespace ErrorCodes
+{
+extern const int INCORRECT_DATA;
+}
+
+static ITransformingStep::Traits getTraits()
+{
+    return ITransformingStep::Traits{
+        {
+            .returns_single_stream = false,
+            .preserves_number_of_streams = true,
+            .preserves_sorting = true,
+        },
+        {
+            .preserves_number_of_rows = false,
+        }};
+}
+
+PartitionedDistinctStep::PartitionedDistinctStep(
+    const SharedHeader & input_header_,
+    const Names & columns_,
+    const SizeLimits & set_size_limits_,
+    UInt64 limit_hint_,
+    size_t partitions_num_)
+    : ITransformingStep(input_header_, input_header_, getTraits())
+    , set_size_limits(set_size_limits_)
+    , limit_hint(limit_hint_)
+    , columns(columns_)
+    , partitions_num(roundUpToPowerOfTwoOrZero(partitions_num_))
+{
+}
+
+void PartitionedDistinctStep::transformPipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings &)
+{
+    auto prev_streams_num = pipeline.getNumStreams();
+    size_t streams = partitions_num;
+    pipeline.resize(streams);
+
+    /// PartitionDistinctMapTransform hash one chunk into N parts.
+    /// PartitionDistinctReduceTransform does distinct on each part.
+    auto pipeline_transform = [&](OutputPortRawPtrs ports)
+    {
+        Processors processors;
+        Processors map_processors;
+        std::vector<OutputPort *> map_output_ports;
+        Processors reduce_processors;
+        std::vector<InputPort *> reduce_input_ports;
+        // size_t num_ports = ports.size();
+        // assert(num_ports == streams);
+        auto header = ports[0]->getSharedHeader();
+        for (size_t i = 0; i < streams; ++i)
+        {
+            map_processors.push_back(std::make_shared<PartitionDistinctMapTransform>(header, columns, streams));
+            auto & map_outputs = map_processors.back()->getOutputs();
+            for (auto & port : map_outputs)
+            {
+                map_output_ports.push_back(&port);
+            }
+
+            reduce_processors.push_back(std::make_shared<PartitionDistinctReduceTransform>(header, columns, streams));
+            auto & reduce_inputs = reduce_processors.back()->getInputs();
+            for (auto & port : reduce_inputs)
+            {
+                reduce_input_ports.push_back(&port);
+            }
+
+            processors.push_back(map_processors.back());
+            processors.push_back(reduce_processors.back());
+        }
+        for (size_t i = 0; i < streams; ++i)
+        {
+            auto & output_port = *ports[i];
+            auto & input_port = map_processors[i]->getInputs().front();
+            connect(output_port, input_port);
+        }
+        for (size_t i = 0; i < streams; ++i)
+        {
+            for (size_t j = 0; j < streams; ++j)
+            {
+                auto & map_output_port = *map_output_ports[i * streams + j];
+                auto & reduce_input_port = *reduce_input_ports[j * streams + i];
+                connect(map_output_port, reduce_input_port);
+            }
+        }
+        return processors;
+    };
+    pipeline.transform(pipeline_transform);
+
+    pipeline.resize(prev_streams_num);
+}
+
+
+void PartitionedDistinctStep::serializeSettings(QueryPlanSerializationSettings & settings) const
+{
+    settings[QueryPlanSerializationSetting::max_rows_in_distinct] = set_size_limits.max_rows;
+    settings[QueryPlanSerializationSetting::max_bytes_in_distinct] = set_size_limits.max_bytes;
+    settings[QueryPlanSerializationSetting::distinct_overflow_mode] = set_size_limits.overflow_mode;
+}
+
+void PartitionedDistinctStep::describeActions(FormatSettings & settings) const
+{
+    String prefix(settings.offset, ' ');
+    settings.out << prefix << "Columns: ";
+
+    if (columns.empty())
+        settings.out << "none";
+    else
+    {
+        bool first = true;
+        for (const auto & column : columns)
+        {
+            if (!first)
+                settings.out << ", ";
+            first = false;
+
+            settings.out << column;
+        }
+    }
+
+    settings.out << '\n';
+}
+
+void PartitionedDistinctStep::describeActions(JSONBuilder::JSONMap & map) const
+{
+    auto columns_array = std::make_unique<JSONBuilder::JSONArray>();
+    for (const auto & column : columns)
+        columns_array->add(column);
+
+    map.add("Columns", std::move(columns_array));
+}
+
+void PartitionedDistinctStep::updateLimitHint(UInt64 hint)
+{
+    if (hint && limit_hint)
+        /// Both limits are set - take the min
+        limit_hint = std::min(hint, limit_hint);
+    else
+        /// Some limit is not set - take the other one
+        limit_hint = std::max(hint, limit_hint);
+}
+
+void PartitionedDistinctStep::updateOutputHeader()
+{
+    output_header = input_headers.front();
+}
+
+void PartitionedDistinctStep::serialize(Serialization & ctx) const
+{
+    writeVarUInt(columns.size(), ctx.out);
+    for (const auto & column : columns)
+        writeStringBinary(column, ctx.out);
+    writeVarUInt(partitions_num, ctx.out);
+}
+
+std::unique_ptr<IQueryPlanStep> PartitionedDistinctStep::deserialize(Deserialization & ctx)
+{
+    if (ctx.input_headers.size() != 1)
+        throw Exception(ErrorCodes::INCORRECT_DATA, "DistinctStep must have one input stream");
+
+    size_t columns_size;
+    readVarUInt(columns_size, ctx.in);
+    Names column_names(columns_size);
+    for (size_t i = 0; i < columns_size; ++i)
+        readStringBinary(column_names[i], ctx.in);
+    size_t partitions_num_ = 0;
+    readVarUInt(partitions_num_, ctx.in);
+
+    SizeLimits size_limits;
+    size_limits.max_rows = ctx.settings[QueryPlanSerializationSetting::max_rows_in_distinct];
+    size_limits.max_bytes = ctx.settings[QueryPlanSerializationSetting::max_bytes_in_distinct];
+    size_limits.overflow_mode = ctx.settings[QueryPlanSerializationSetting::distinct_overflow_mode];
+
+    return std::make_unique<PartitionedDistinctStep>(ctx.input_headers.front(), column_names, size_limits, 0, partitions_num_);
+}
+
+void registerPartitionedDistinctStep(QueryPlanStepRegistry & factory)
+{
+    factory.registerStep("PartitionedDistinct", PartitionedDistinctStep::deserialize);
+}
+}

--- a/src/Processors/QueryPlan/PartitionedDistinctStep.h
+++ b/src/Processors/QueryPlan/PartitionedDistinctStep.h
@@ -1,0 +1,46 @@
+#pragma once
+#include <Processors/QueryPlan/ITransformingStep.h>
+#include <QueryPipeline/SizeLimits.h>
+
+namespace DB
+{
+/// Execute DISTINCT for specified columns in parallel manner.
+class PartitionedDistinctStep : public ITransformingStep
+{
+public:
+    PartitionedDistinctStep(
+        const SharedHeader & input_header_,
+        const Names & columns_,
+        const SizeLimits & set_size_limits_,
+        UInt64 limit_hint_,
+        size_t partitions_num_);
+
+    String getName() const override { return "PartitionedDistinct"; }
+
+    String getSerializationName() const override { return "PartitionedDistinct"; }
+
+    void transformPipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings &) override;
+
+    void describeActions(JSONBuilder::JSONMap & map) const override;
+    void describeActions(FormatSettings & settings) const override;
+
+    UInt64 getLimitHint() const { return limit_hint; }
+    void updateLimitHint(UInt64 hint);
+
+    void serializeSettings(QueryPlanSerializationSettings & settings) const override;
+    void serialize(Serialization & ctx) const override;
+    bool isSerializable() const override { return true; }
+
+    static std::unique_ptr<IQueryPlanStep> deserialize(Deserialization & ctx);
+
+    const SizeLimits & getSetSizeLimits() const { return set_size_limits; }
+
+private:
+    SizeLimits set_size_limits;
+    UInt64 limit_hint;
+    const Names columns;
+    size_t partitions_num;
+
+    void updateOutputHeader() override;
+};
+}

--- a/src/Processors/Transforms/PartitionedDistinctTransform.cpp
+++ b/src/Processors/Transforms/PartitionedDistinctTransform.cpp
@@ -1,0 +1,500 @@
+#include <iterator>
+#include <memory>
+#include <mutex>
+#include <Core/ColumnWithTypeAndName.h>
+#include <Processors/Transforms/PartitionedDistinctTransform.h>
+#include <Common/BitHelpers.h>
+#include <Common/logger_useful.h>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+extern const int SET_SIZE_LIMIT_EXCEEDED;
+extern const int LOGICAL_ERROR;
+}
+
+class PartitionedChunkInfo : public ChunkInfo
+{
+public:
+    using SelectorPtr = std::shared_ptr<detail::Selector>;
+    using RefCount = std::shared_ptr<std::atomic<size_t>>;
+    using FilterPtr = std::shared_ptr<IColumn::Filter>;
+
+    explicit PartitionedChunkInfo(const SelectorPtr & selector_, RefCount ref_count_, FilterPtr filter_)
+        : selector(selector_)
+        , ref_count(ref_count_)
+        , filter(filter_)
+    {
+    }
+
+    ChunkInfo::Ptr clone() const override
+    { 
+        return std::make_shared<PartitionedChunkInfo>(selector, ref_count, filter);
+    }
+
+    SelectorPtr selector;
+    RefCount ref_count;
+    FilterPtr filter;
+};
+
+PartitionDistinctTransformBase::PartitionDistinctTransformBase(SharedHeader header_, size_t input_streams_, size_t output_streams_)
+    : IProcessor(InputPorts(input_streams_, header_), OutputPorts(output_streams_, header_))
+    , header(std::move(header_))
+    , input_streams(input_streams_)
+    , output_streams(output_streams_)
+    , input_chunks(input_streams_)
+    , output_chunks(output_streams_)
+{
+}
+
+
+IProcessor::Status PartitionDistinctTransformBase::prepare(const PortNumbers & updated_input_ports, const PortNumbers & updated_output_ports)
+{
+    if (input_ports.empty() || output_ports.empty()) [[unlikely]]
+    {
+        for (auto & output : outputs)
+            output_ports.emplace_back(&output, PortStatus::NotActive);
+        for (auto & input : inputs)
+            input_ports.emplace_back(&input, PortStatus::NotActive);
+    }
+
+    for (const auto & num : updated_output_ports)
+    {
+        auto & output_port = output_ports[num];
+        if (output_port.port->isFinished())
+        {
+            if (output_port.status != PortStatus::Finished)
+            {
+                finished_output_ports += 1;
+                output_port.status = PortStatus::Finished;
+            }
+            continue;
+        }
+        if (output_port.port->canPush())
+        {
+            if (output_port.status != PortStatus::NeedData)
+            {
+                waiting_output_ports.push(num);
+                output_port.status = PortStatus::NeedData;
+            }
+        }
+    }
+
+    bool all_output_finished = finished_output_ports == output_ports.size();
+    if (all_output_finished)
+    {
+        for (auto & input_port : input_ports)
+        {
+            input_port.port->close();
+            input_port.status = PortStatus::Finished;
+        }
+        return Status::Finished;
+    }
+
+    for (const auto & num : updated_input_ports)
+    {
+        auto & input_port = input_ports[num];
+        if (input_port.port->isFinished())
+        {
+            if (input_port.status != PortStatus::Finished)
+            {
+                finished_input_ports += 1;
+                input_port.status = PortStatus::Finished;
+            }
+            continue;
+        }
+        if (input_port.port->hasData())
+        {
+            ChunkQueue & chunk_queue = input_chunks[num];
+            Chunk chunk = input_port.port->pull();
+            chunk_queue.push(std::move(chunk));
+            input_port.status = PortStatus::Blocked;
+            pending_input_chunks_num += 1;
+        }
+    }
+
+    bool all_inputs_finished = finished_input_ports == input_ports.size();
+    if (all_inputs_finished)
+    {
+        // No inputs and outputs, finish this processor.
+        if (!pending_output_chunks_num && !pending_input_chunks_num)
+        {
+            for (auto & output : output_ports)
+            {
+                output.port->finish();
+                output.status = PortStatus::Finished;
+            }
+            return Status::Finished;
+        }
+    }
+
+    std::queue<size_t> temp_waiting_output_ports;
+    while (!waiting_output_ports.empty())
+    {
+        auto output_port_index = waiting_output_ports.front();
+        waiting_output_ports.pop();
+        auto & chunk_queue = output_chunks[output_port_index];
+        auto & output_port = output_ports[output_port_index];
+
+        if (output_port.port->isFinished())
+        {
+            output_port.status = PortStatus::Finished;
+            continue;
+        }
+        if (!output_port.port->canPush())
+        {
+            output_port.status = PortStatus::Blocked;
+            continue;
+        }
+
+        if (!chunk_queue.empty())
+        {
+            auto & chunk = chunk_queue.front();
+            output_port.port->push(std::move(chunk));
+            --pending_output_chunks_num;
+            output_port.status = PortStatus::Blocked;
+            chunk_queue.pop();
+        }
+        else
+        {
+            temp_waiting_output_ports.push(output_port_index);
+        }
+    }
+    waiting_output_ports.swap(temp_waiting_output_ports);
+
+    if (pending_input_chunks_num)
+        return Status::Ready;
+
+    if (!waiting_output_ports.empty())
+    {
+        for (auto & input_port : input_ports)
+        {
+            if (!input_port.port->isFinished())
+            {
+                input_port.port->setNeeded();
+                input_port.status = PortStatus::NeedData;
+            }
+        }
+        return Status::NeedData;
+    }
+
+    return Status::PortFull;
+}
+
+static ColumnNumbers getColumnsPositions(const Block & header, const Names & column_names)
+{
+    ColumnNumbers positions;
+    positions.reserve(column_names.size());
+    for (const auto & name : column_names)
+    {
+        positions.push_back(header.getPositionByName(name));
+    }
+    return positions;
+}
+
+PartitionDistinctMapTransform::PartitionDistinctMapTransform(SharedHeader header_, const Names & key_columns_names_, size_t output_streams_)
+    : PartitionDistinctTransformBase(header_, 1, output_streams_)
+    , key_columns_pos(getColumnsPositions(*header_, key_columns_names_))
+{
+    constexpr auto threshold = sizeof(IColumn::Selector::value_type);
+    const auto & data_types = header_->getDataTypes();
+    use_copy_scatter = std::accumulate(
+                           data_types.begin(),
+                           data_types.end(),
+                           0u,
+                           [](size_t sum, const DataTypePtr & type)
+                           { return sum + (type->haveMaximumSizeOfValue() ? type->getMaximumSizeOfValueInMemory() : threshold + 1); })
+        <= threshold;
+}
+
+std::vector<std::shared_ptr<detail::Selector>> PartitionDistinctMapTransform::scatterBlock(const Block & block)
+{
+    size_t rows = block.rows();
+    WeakHash32 hash(rows);
+    const auto & columns = block.getColumnsWithTypeAndName();
+    for (const auto & pos : key_columns_pos)
+    {
+        hash.update(columns[pos].column->getWeakHash32());
+    }
+
+    std::vector<ScatteredBlock::IndexesPtr> indexes(output_streams);
+    for (size_t i = 0; i < output_streams; ++i)
+    {
+        indexes[i] = ScatteredBlock::Indexes::create();
+        indexes[i]->reserve(rows / output_streams + 1);
+    }
+    if (isPowerOf2(output_streams))
+    {
+        for (size_t i = 0; i < rows; ++i)
+        {
+            const auto & hash_value = hash.getData()[i];
+            size_t part = hash_value & (output_streams - 1);
+            indexes[part]->getData().push_back(i);
+        }
+    }
+    else
+    {
+        for (size_t i = 0; i < rows; ++i)
+        {
+            const auto & hash_value = hash.getData()[i];
+            size_t part = hash_value % output_streams;
+            indexes[part]->getData().push_back(i);
+        }
+    }
+
+    std::vector<std::shared_ptr<detail::Selector>> selectors;
+    selectors.reserve(output_streams);
+    for (size_t i = 0; i < output_streams; ++i)
+    {
+        selectors.emplace_back(std::make_shared<detail::Selector>(std::move(indexes[i])));
+    }
+    return selectors;
+}
+
+Blocks PartitionDistinctMapTransform::scatterBlockByCopying(const ColumnNumbers & key_columns_pos_, const Block & block)
+{
+    size_t rows = block.rows();
+    WeakHash32 hash(rows);
+    const auto & columns = block.getColumnsWithTypeAndName();
+    for (const auto & pos : key_columns_pos_)
+    {
+        hash.update(columns[pos].column->getWeakHash32());
+    }
+
+    IColumn::Selector selector(rows);
+    if (isPowerOf2(output_streams))
+    {
+        for (size_t i = 0; i < rows; ++i)
+        {
+            selector[i] = hash.getData()[i] & (output_streams - 1);
+        }
+    }
+    else
+    {
+        for (size_t i = 0; i < rows; ++i)
+        {
+            selector[i] = hash.getData()[i] % output_streams;
+        }
+    }
+
+    Blocks blocks(output_streams);
+    for (size_t i = 0; i < output_streams; ++i)
+    {
+        blocks[i] = block.cloneEmpty();
+    }
+    for (size_t i = 0; i < block.columns(); ++i)
+    {
+        auto dispatched_columns = block.getByPosition(i).column->scatter(output_streams, selector);
+        chassert(blocks.size() == dispatched_columns.size());
+        for (size_t block_index = 0; block_index < output_streams; ++block_index)
+        {
+            blocks[block_index].getByPosition(i).column = std::move(dispatched_columns[block_index]);
+        }
+    }
+    return blocks;
+}
+
+void PartitionDistinctMapTransform::work()
+{
+    if (!pending_input_chunks_num)
+        return;
+
+    Chunk pending_chunk(std::move(input_chunks[0].front()));
+    input_chunks[0].pop();
+    pending_input_chunks_num--;
+    if (unlikely(!pending_chunk.hasRows()))
+        return;
+    convertToFullIfSparse(pending_chunk);
+    convertToFullIfConst(pending_chunk);
+
+    size_t rows = pending_chunk.getNumRows();
+    auto columns = pending_chunk.detachColumns();
+
+    auto block = header->cloneWithColumns(columns);
+
+    if (use_copy_scatter)
+    {
+        auto scattered_blocks = scatterBlockByCopying(key_columns_pos, block);
+        for (size_t i = 0; i < output_streams; ++i)
+        {
+            Chunk output_chunk(scattered_blocks[i].getColumns(), scattered_blocks[i].rows());
+            output_chunks[i].push(std::move(output_chunk));
+            pending_output_chunks_num++;
+        }
+    }
+    else
+    {
+        auto selectors = scatterBlock(block);
+        auto ref_count = std::make_shared<std::atomic<size_t>>(output_streams);
+        auto filter = std::make_shared<IColumn::Filter>(rows, 0);
+        for (size_t i = 0; i < output_streams; ++i)
+        {
+            Chunk output_chunk(columns, rows);
+            output_chunk.getChunkInfos().add(std::make_shared<PartitionedChunkInfo>(selectors[i], ref_count, filter));
+            output_chunks[i].push(std::move(output_chunk));
+            pending_output_chunks_num++;
+        }
+    }
+}
+
+template <typename Method>
+void buildFilter(
+    Method & method,
+    const ColumnRawPtrs & columns,
+    const ScatteredBlock::Selector * selector,
+    IColumn::Filter & filter,
+    SetVariants & variants,
+    Sizes & column_sizes)
+{
+    typename Method::State state(columns, column_sizes, nullptr);
+
+    if (!selector)
+    {
+        auto columns_rows = columns[0]->size();
+        for (size_t i = 0; i < columns_rows; ++i)
+        {
+            const auto emplace_result = state.emplaceKey(method.data, i, variants.string_pool);
+            filter[i] = emplace_result.isInserted();
+        }
+    }
+    else
+    {
+        if (selector->isContinuousRange())
+        {
+            const auto range = selector->getRange();
+            for (size_t i = range.first; i < range.second; ++i)
+            {
+                const auto emplace_result = state.emplaceKey(method.data, i, variants.string_pool);
+                filter[i] = emplace_result.isInserted();
+            }
+        }
+        else
+        {
+            size_t partition_rows = selector->size();
+            const auto & indexes = selector->getIndexes().getData();
+            for (size_t i = 0; i < partition_rows; ++i)
+            {
+                size_t row = indexes[i];
+                const auto emplace_result = state.emplaceKey(method.data, row, variants.string_pool);
+                filter[row] = emplace_result.isInserted();
+            }
+        }
+    }
+}
+
+PartitionDistinctReduceTransform::PartitionDistinctReduceTransform(
+    SharedHeader header_, const Names & key_columns_names_, size_t input_streams_)
+    : PartitionDistinctTransformBase(header_, input_streams_, 1)
+    , key_columns_pos(getColumnsPositions(*header_, key_columns_names_))
+{
+    ColumnRawPtrs column_ptrs;
+    for (const auto & pos : key_columns_pos)
+    {
+        const auto & col = header_->getByPosition(pos).column;
+        column_ptrs.emplace_back(col.get());
+    }
+    set_variants.init(SetVariants::chooseMethod(column_ptrs, key_column_sizes));
+}
+
+void PartitionDistinctReduceTransform::work()
+{
+    if (!pending_input_chunks_num)
+        return;
+
+    Chunk input_chunk;
+    for (size_t i = next_input_stream; i < input_streams + next_input_stream; ++i)
+    {
+        size_t index = i % input_streams;
+        auto & queue = input_chunks[index];
+        if (!queue.empty())
+        {
+            input_chunk.swap(queue.front());
+            queue.pop();
+            pending_input_chunks_num--;
+            next_input_stream = (index + 1) % input_streams;
+            break;
+        }
+    }
+    auto columns = input_chunk.detachColumns();
+    auto block = header->cloneWithColumns(columns);
+    ColumnRawPtrs key_columns;
+    for (const auto & pos : key_columns_pos)
+    {
+        const auto & col = block.getByPosition(pos).column;
+        key_columns.emplace_back(col.get());
+        if (!key_columns.back())
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Key column is nullptr");
+    }
+
+    auto chunk_info = input_chunk.getChunkInfos().get<PartitionedChunkInfo>();
+    if (!chunk_info)
+    {
+        IColumn::Filter filter(columns[0]->size(), 0);
+        switch (set_variants.type)
+        {
+            case SetVariants::Type::EMPTY:
+                break;
+#define M(NAME) \
+            case SetVariants::Type::NAME: \
+                buildFilter(*(set_variants.NAME), key_columns, nullptr, filter, set_variants, key_column_sizes); \
+                break;
+            APPLY_FOR_SET_VARIANTS(M)
+#undef M
+        }
+        Columns filtered_columns;
+        size_t rows = 0;
+        filtered_columns.push_back(columns[0]->filter(filter, -1));
+        rows = filtered_columns[0]->size();
+        if (!rows)
+            return;
+        for (size_t i = 1; i < columns.size(); ++i)
+        {
+            filtered_columns.push_back(columns[i]->filter(filter, rows));
+        }
+        Chunk output_chunk(std::move(filtered_columns), rows);
+        output_chunks[0].push(std::move(output_chunk));
+        pending_output_chunks_num++;
+        return;
+    }
+    else
+    {
+        auto & filter = chunk_info->filter;
+        auto & ref_count = chunk_info->ref_count;
+        auto & selector = chunk_info->selector;
+
+        switch (set_variants.type)
+        {
+            case SetVariants::Type::EMPTY:
+                break;
+#define M(NAME) \
+            case SetVariants::Type::NAME: \
+                buildFilter(*(set_variants.NAME), key_columns, selector.get(), *filter, set_variants, key_column_sizes); \
+                break;
+            APPLY_FOR_SET_VARIANTS(M)
+#undef M
+        }
+
+        auto prev_count = ref_count->fetch_sub(1);
+        if (prev_count == 1)
+        {
+            // The last node to handle this chunk, produce output.
+            Columns filtered_columns;
+            size_t rows = 0;
+            filtered_columns.push_back(columns[0]->filter(*filter, -1));
+            rows = filtered_columns[0]->size();
+            if (!rows)
+                return;
+            for (size_t i = 1; i < columns.size(); ++i)
+            {
+                filtered_columns.push_back(columns[i]->filter(*filter, rows));
+            }
+            Chunk output_chunk(std::move(filtered_columns), rows);
+            output_chunks[0].push(std::move(output_chunk));
+            pending_output_chunks_num++;
+        }
+    }
+}
+
+}

--- a/src/Processors/Transforms/PartitionedDistinctTransform.h
+++ b/src/Processors/Transforms/PartitionedDistinctTransform.h
@@ -1,0 +1,102 @@
+#pragma once
+
+#include <condition_variable>
+#include <mutex>
+#include <queue>
+#include <Core/Block.h>
+#include <Core/ColumnNumbers.h>
+#include <Interpreters/HashJoin/ScatteredBlock.h>
+#include <Interpreters/SetVariants.h>
+#include <Processors/ISimpleTransform.h>
+#include <QueryPipeline/SizeLimits.h>
+#include <sys/types.h>
+
+namespace DB
+{
+
+class PartitionDistinctTransformBase : public IProcessor
+{
+public:
+    enum class PortStatus : uint8_t
+    {
+        NotActive,
+        NeedData,
+        Blocked,
+        Finished,
+    };
+    template <typename T>
+    struct PortWithStatus
+    {
+        T * port = nullptr;
+        PortStatus status = PortStatus::NotActive;
+        PortWithStatus(T * port_, PortStatus status_)
+            : port(port_)
+            , status(status_)
+        {
+        }
+        PortWithStatus() = default;
+    };
+    using InputPortWithStatus = PortWithStatus<InputPort>;
+    using OutputPortWithStatus = PortWithStatus<OutputPort>;
+    using ChunkQueue = std::queue<Chunk>;
+    using Status = IProcessor::Status;
+
+    PartitionDistinctTransformBase(SharedHeader header_, size_t input_streams_, size_t output_streams_);
+    virtual ~PartitionDistinctTransformBase() override = default;
+    virtual String getName() const override { return "PartitionDistinctTransformBase"; }
+    Status prepare(const PortNumbers & updated_input_ports, const PortNumbers & updated_output_ports) override;
+    virtual void work() override { }
+
+protected:
+    SharedHeader header;
+    size_t input_streams;
+    size_t output_streams;
+
+    std::vector<ChunkQueue> input_chunks;
+    std::vector<ChunkQueue> output_chunks;
+
+    std::vector<InputPortWithStatus> input_ports;
+    size_t finished_input_ports = 0;
+    size_t pending_input_chunks_num = 0;
+
+    std::vector<OutputPortWithStatus> output_ports;
+    std::queue<size_t> waiting_output_ports;
+    size_t finished_output_ports = 0;
+    size_t pending_output_chunks_num = 0;
+};
+
+
+// One input, multiple output streams transform to do partitioned distinct.
+class PartitionDistinctMapTransform : public PartitionDistinctTransformBase
+{
+public:
+    PartitionDistinctMapTransform(SharedHeader header_, const Names & key_columns_names_, size_t output_streams_);
+    ~PartitionDistinctMapTransform() override = default;
+    String getName() const override { return "PartitionDistinctMapTransform"; }
+
+    void work() override;
+
+private:
+    ColumnNumbers key_columns_pos;
+
+    std::vector<std::shared_ptr<detail::Selector>> scatterBlock(const Block & block);
+    Blocks scatterBlockByCopying(const ColumnNumbers & key_columns_pos, const Block & block);
+    bool use_copy_scatter = true;
+};
+
+class PartitionDistinctReduceTransform : public PartitionDistinctTransformBase
+{
+public:
+    using Status = IProcessor::Status;
+    PartitionDistinctReduceTransform(SharedHeader header_, const Names & key_columns_names_, size_t input_streams_);
+    ~PartitionDistinctReduceTransform() override = default;
+    String getName() const override { return "PartitionDistinctReduceTransform"; }
+    void work() override;
+
+private:
+    ColumnNumbers key_columns_pos;
+    Sizes key_column_sizes;
+    SetVariants set_variants;
+    size_t next_input_stream = 0;
+};
+}

--- a/tests/queries/0_stateless/03702_partition_distinct.reference
+++ b/tests/queries/0_stateless/03702_partition_distinct.reference
@@ -1,0 +1,23 @@
+-- { echoOn }
+select distinct a, b from t_partition_distinct order by a, b;
+0	0
+1	1
+2	2
+3	3
+4	4
+5	0
+6	1
+7	2
+8	3
+9	4
+select distinct a, c from t_partition_distinct order by a, c;
+0	xxxxxxxxxx0
+1	xxxxxxxxxx1
+2	xxxxxxxxxx2
+3	xxxxxxxxxx3
+4	xxxxxxxxxx4
+5	xxxxxxxxxx0
+6	xxxxxxxxxx1
+7	xxxxxxxxxx2
+8	xxxxxxxxxx3
+9	xxxxxxxxxx4

--- a/tests/queries/0_stateless/03702_partition_distinct.sql
+++ b/tests/queries/0_stateless/03702_partition_distinct.sql
@@ -1,0 +1,17 @@
+set enable_partition_distinct=1;
+
+create table if not exists t_partition_distinct
+(
+    a UInt64,
+    b String,
+    c String
+) engine=Memory;
+
+
+insert into t_partition_distinct select number % 10, toString(number % 5), 'xxxxxxxxxx' ||toString(number % 5) from numbers(2000) settings max_block_size=512;
+-- { echoOn }
+select distinct a, b from t_partition_distinct order by a, b;
+select distinct a, c from t_partition_distinct order by a, c;
+-- { echoOff }
+
+drop table if exists t_partition_distinct;


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: true-->

### Changelog category (leave one):
- Performance Improvement



### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Partition the data and process each partition in parallel to perform the distinct operation. when the distinct columns have high cardinality, this approach is faster than the current implementation and a group by.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
