### PR TITLE
Revert "Fix permanent blocked distributed sends if DROP of distributed table fails"

### DIFF
--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -1516,15 +1516,13 @@ void StorageDistributed::initializeFromDisk()
 
 void StorageDistributed::shutdown(bool)
 {
-    auto holder = async_insert_blocker.cancel();
+    async_insert_blocker.cancelForever();
 
     std::lock_guard lock(cluster_nodes_mutex);
 
     LOG_DEBUG(log, "Joining background threads for async INSERT");
     cluster_nodes_data.clear();
     LOG_DEBUG(log, "Background threads for async INSERT joined");
-
-    async_insert_blocker.cancelForever();
 }
 
 void StorageDistributed::drop()


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Reverts ClickHouse/ClickHouse#69843

This does not fixes anything at all, since the `clear` is `noexcept` anyway, I don't have context anymore, but let's assume that it stopped if `DROP` fails