### PR TITLE
Fix potential heap-use-after-free in projections analysis after #72102

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -8229,7 +8229,8 @@ Block MergeTreeData::getMinMaxCountProjectionBlock(
         {
             for (const auto & part : real_parts)
             {
-                const auto & primary_key_column = *part->getIndex()->at(0);
+                auto index = part->getIndex();
+                const auto & primary_key_column = *index->at(0);
                 auto & min_column = assert_cast<ColumnAggregateFunction &>(*partition_minmax_count_columns[pos]);
                 insert(min_column, primary_key_column[0]);
             }
@@ -8240,7 +8241,8 @@ Block MergeTreeData::getMinMaxCountProjectionBlock(
         {
             for (const auto & part : real_parts)
             {
-                const auto & primary_key_column = *part->getIndex()->at(0);
+                auto index = part->getIndex();
+                const auto & primary_key_column = *index->at(0);
                 auto & max_column = assert_cast<ColumnAggregateFunction &>(*partition_minmax_count_columns[pos]);
                 insert(max_column, primary_key_column[primary_key_column.size() - 1]);
             }


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Details

The code in the projection analysis used a reference to PK without holding the ownership. This became possible after #72102, when unloading of PK became possible.

Reference: https://github.com/ClickHouse/ClickHouse/blob/f97cad2603ca9bb6a20b120b3dd7bc2690e35100/src/Storages/MergeTree/IMergeTreeDataPart.cpp#L449

Example of msan report: https://pastila.clickhouse.com/?001f9e74/a89113af1320e10120962200f4b3cc95#frgk+agY1FZ9YRQTl9ZIsw==
