### PR TITLE
Docs: consistently label table engine titles

### DIFF
--- a/docs/en/engines/table-engines/integrations/ExternalDistributed.md
+++ b/docs/en/engines/table-engines/integrations/ExternalDistributed.md
@@ -5,9 +5,11 @@ description: 'The `ExternalDistributed` engine allows to perform `SELECT` querie
 sidebar_label: 'ExternalDistributed'
 sidebar_position: 55
 slug: /engines/table-engines/integrations/ExternalDistributed
-title: 'ExternalDistributed'
+title: 'ExternalDistributed table engine'
 doc_type: 'reference'
 ---
+
+# ExternalDistributed table engine
 
 The `ExternalDistributed` engine allows to perform `SELECT` queries on data that is stored on a remote servers MySQL or PostgreSQL. Accepts [MySQL](../../../engines/table-engines/integrations/mysql.md) or [PostgreSQL](../../../engines/table-engines/integrations/postgresql.md) engines as an argument so sharding is possible.
 

--- a/docs/en/engines/table-engines/integrations/arrowflight.md
+++ b/docs/en/engines/table-engines/integrations/arrowflight.md
@@ -3,11 +3,11 @@ description: 'The engine allows querying remote datasets via Apache Arrow Flight
 sidebar_label: 'ArrowFlight'
 sidebar_position: 186
 slug: /engines/table-engines/integrations/arrowflight
-title: 'ArrowFlight'
+title: 'ArrowFlight table engine'
 doc_type: 'reference'
 ---
 
-# ArrowFlight
+# ArrowFlight table engine
 
 The ArrowFlight table engine enables ClickHouse to query remote datasets via the [Apache Arrow Flight](https://arrow.apache.org/docs/format/Flight.html) protocol.
 This integration allows ClickHouse to fetch data from external Flight-enabled servers in a columnar Arrow format with high performance.

--- a/docs/en/engines/table-engines/integrations/azure-queue.md
+++ b/docs/en/engines/table-engines/integrations/azure-queue.md
@@ -4,7 +4,7 @@ description: 'This engine provides an integration with the Azure Blob Storage ec
 sidebar_label: 'AzureQueue'
 sidebar_position: 181
 slug: /engines/table-engines/integrations/azure-queue
-title: 'AzureQueue Table Engine'
+title: 'AzureQueue table engine'
 doc_type: 'reference'
 ---
 

--- a/docs/en/engines/table-engines/integrations/azureBlobStorage.md
+++ b/docs/en/engines/table-engines/integrations/azureBlobStorage.md
@@ -3,7 +3,7 @@ description: 'This engine provides an integration with Azure Blob Storage ecosys
 sidebar_label: 'Azure Blob Storage'
 sidebar_position: 10
 slug: /engines/table-engines/integrations/azureBlobStorage
-title: 'AzureBlobStorage Table Engine'
+title: 'AzureBlobStorage table engine'
 doc_type: 'reference'
 ---
 

--- a/docs/en/engines/table-engines/integrations/deltalake.md
+++ b/docs/en/engines/table-engines/integrations/deltalake.md
@@ -4,7 +4,7 @@ description: 'This engine provides a read-only integration with existing Delta L
 sidebar_label: 'DeltaLake'
 sidebar_position: 40
 slug: /engines/table-engines/integrations/deltalake
-title: 'DeltaLake Table Engine'
+title: 'DeltaLake table engine'
 doc_type: 'reference'
 ---
 

--- a/docs/en/engines/table-engines/integrations/embedded-rocksdb.md
+++ b/docs/en/engines/table-engines/integrations/embedded-rocksdb.md
@@ -3,13 +3,13 @@ description: 'This engine allows integrating ClickHouse with RocksDB'
 sidebar_label: 'EmbeddedRocksDB'
 sidebar_position: 50
 slug: /engines/table-engines/integrations/embedded-rocksdb
-title: 'EmbeddedRocksDB Engine'
+title: 'EmbeddedRocksDB table engine'
 doc_type: 'reference'
 ---
 
 import CloudNotSupportedBadge from '@theme/badges/CloudNotSupportedBadge';
 
-# EmbeddedRocksDB engine
+# EmbeddedRocksDB table engine
 
 <CloudNotSupportedBadge />
 

--- a/docs/en/engines/table-engines/integrations/hdfs.md
+++ b/docs/en/engines/table-engines/integrations/hdfs.md
@@ -5,13 +5,13 @@ description: 'This engine provides integration with the Apache Hadoop ecosystem 
 sidebar_label: 'HDFS'
 sidebar_position: 80
 slug: /engines/table-engines/integrations/hdfs
-title: 'HDFS'
+title: 'HDFS table engine'
 doc_type: 'reference'
 ---
 
 import CloudNotSupportedBadge from '@theme/badges/CloudNotSupportedBadge';
 
-# HDFS
+# HDFS table engine
 
 <CloudNotSupportedBadge/>
 

--- a/docs/en/engines/table-engines/integrations/hive.md
+++ b/docs/en/engines/table-engines/integrations/hive.md
@@ -4,13 +4,13 @@ description: 'The Hive engine allows you to perform `SELECT` queries on HDFS Hiv
 sidebar_label: 'Hive'
 sidebar_position: 84
 slug: /engines/table-engines/integrations/hive
-title: 'Hive'
+title: 'Hive table engine'
 doc_type: 'guide'
 ---
 
 import CloudNotSupportedBadge from '@theme/badges/CloudNotSupportedBadge';
 
-# Hive
+# Hive table engine
 
 <CloudNotSupportedBadge/>
 

--- a/docs/en/engines/table-engines/integrations/hudi.md
+++ b/docs/en/engines/table-engines/integrations/hudi.md
@@ -4,7 +4,7 @@ description: 'This engine provides a read-only integration with existing Apache 
 sidebar_label: 'Hudi'
 sidebar_position: 86
 slug: /engines/table-engines/integrations/hudi
-title: 'Hudi Table Engine'
+title: 'Hudi table engine'
 doc_type: 'reference'
 ---
 

--- a/docs/en/engines/table-engines/integrations/iceberg.md
+++ b/docs/en/engines/table-engines/integrations/iceberg.md
@@ -4,7 +4,7 @@ description: 'This engine provides a read-only integration with existing Apache 
 sidebar_label: 'Iceberg'
 sidebar_position: 90
 slug: /engines/table-engines/integrations/iceberg
-title: 'Iceberg Table Engine'
+title: 'Iceberg table engine'
 doc_type: 'reference'
 ---
 

--- a/docs/en/engines/table-engines/integrations/jdbc.md
+++ b/docs/en/engines/table-engines/integrations/jdbc.md
@@ -3,13 +3,13 @@ description: 'Allows ClickHouse to connect to external databases via JDBC.'
 sidebar_label: 'JDBC'
 sidebar_position: 100
 slug: /engines/table-engines/integrations/jdbc
-title: 'JDBC'
+title: 'JDBC table engine'
 doc_type: 'reference'
 ---
 
 import CloudNotSupportedBadge from '@theme/badges/CloudNotSupportedBadge';
 
-# JDBC
+# JDBC table engine
 
 <CloudNotSupportedBadge/>
 

--- a/docs/en/engines/table-engines/integrations/kafka.md
+++ b/docs/en/engines/table-engines/integrations/kafka.md
@@ -11,11 +11,10 @@ doc_type: 'guide'
 ---
 
 import ExperimentalBadge from '@theme/badges/ExperimentalBadge';
-import CloudNotSupportedBadge from '@theme/badges/CloudNotSupportedBadge';
 
 # Kafka table engine
 
-:::note
+:::tip
 If you're on ClickHouse Cloud, we recommend using [ClickPipes](/integrations/clickpipes) instead. ClickPipes natively supports private network connections, scaling ingestion and cluster resources independently, and comprehensive monitoring for streaming Kafka data into ClickHouse.
 :::
 

--- a/docs/en/engines/table-engines/integrations/materialized-postgresql.md
+++ b/docs/en/engines/table-engines/integrations/materialized-postgresql.md
@@ -4,14 +4,14 @@ description: 'Creates a ClickHouse table with an initial data dump of a PostgreS
 sidebar_label: 'MaterializedPostgreSQL'
 sidebar_position: 130
 slug: /engines/table-engines/integrations/materialized-postgresql
-title: 'MaterializedPostgreSQL'
+title: 'MaterializedPostgreSQL table engine'
 doc_type: 'guide'
 ---
 
 import ExperimentalBadge from '@theme/badges/ExperimentalBadge';
 import CloudNotSupportedBadge from '@theme/badges/CloudNotSupportedBadge';
 
-# MaterializedPostgreSQL
+# MaterializedPostgreSQL table engine
 
 <ExperimentalBadge/>
 <CloudNotSupportedBadge/>
@@ -24,6 +24,7 @@ Creates ClickHouse table with an initial data dump of PostgreSQL table and start
 
 :::note
 This table engine is experimental. To use it, set `allow_experimental_materialized_postgresql_table` to 1 in your configuration files or by using the `SET` command:
+
 ```sql
 SET allow_experimental_materialized_postgresql_table=1
 ```

--- a/docs/en/engines/table-engines/integrations/mongodb.md
+++ b/docs/en/engines/table-engines/integrations/mongodb.md
@@ -4,11 +4,11 @@ description: 'MongoDB engine is read-only table engine which allows to read data
 sidebar_label: 'MongoDB'
 sidebar_position: 135
 slug: /engines/table-engines/integrations/mongodb
-title: 'MongoDB'
-doc_type: 'guide'
+title: 'MongoDB table engine'
+doc_type: 'reference'
 ---
 
-# MongoDB
+# MongoDB table engine
 
 MongoDB engine is read-only table engine which allows to read data from a remote [MongoDB](https://www.mongodb.com/) collection.
 

--- a/docs/en/engines/table-engines/integrations/mysql.md
+++ b/docs/en/engines/table-engines/integrations/mysql.md
@@ -3,8 +3,7 @@ description: 'Documentation for MySQL Table Engine'
 sidebar_label: 'MySQL'
 sidebar_position: 138
 slug: /engines/table-engines/integrations/mysql
-title: 'The MySQL engine allows you to perform `SELECT` and `INSERT` queries on data
-  that is stored on a remote MySQL server.'
+title: 'MySQL table engine'
 doc_type: 'reference'
 ---
 

--- a/docs/en/engines/table-engines/integrations/nats.md
+++ b/docs/en/engines/table-engines/integrations/nats.md
@@ -4,11 +4,11 @@ description: 'This engine allows integrating ClickHouse with NATS to publish or 
 sidebar_label: 'NATS'
 sidebar_position: 140
 slug: /engines/table-engines/integrations/nats
-title: 'NATS Engine'
+title: 'NATS table engine'
 doc_type: 'guide'
 ---
 
-# NATS engine {#redisstreams-engine}
+# NATS table engine {#redisstreams-engine}
 
 This engine allows integrating ClickHouse with [NATS](https://nats.io/).
 

--- a/docs/en/engines/table-engines/integrations/odbc.md
+++ b/docs/en/engines/table-engines/integrations/odbc.md
@@ -3,13 +3,13 @@ description: 'Allows ClickHouse to connect to external databases via ODBC.'
 sidebar_label: 'ODBC'
 sidebar_position: 150
 slug: /engines/table-engines/integrations/odbc
-title: 'ODBC'
+title: 'ODBC table engine'
 doc_type: 'reference'
 ---
 
 import CloudNotSupportedBadge from '@theme/badges/CloudNotSupportedBadge';
 
-# ODBC
+# ODBC table engine
 
 <CloudNotSupportedBadge/>
 

--- a/docs/en/engines/table-engines/integrations/postgresql.md
+++ b/docs/en/engines/table-engines/integrations/postgresql.md
@@ -4,9 +4,11 @@ description: 'The PostgreSQL engine allows `SELECT` and `INSERT` queries on data
 sidebar_label: 'PostgreSQL'
 sidebar_position: 160
 slug: /engines/table-engines/integrations/postgresql
-title: 'PostgreSQL Table Engine'
+title: 'PostgreSQL table Engine'
 doc_type: 'guide'
 ---
+
+# PostgreSQL table engine
 
 The PostgreSQL engine allows `SELECT` and `INSERT` queries on data stored on a remote PostgreSQL server.
 
@@ -14,7 +16,7 @@ The PostgreSQL engine allows `SELECT` and `INSERT` queries on data stored on a r
 Currently, only PostgreSQL versions 12 and up are supported.
 :::
 
-:::note
+:::tip
 ClickHouse Cloud users are recommended to use [ClickPipes](/integrations/clickpipes) for streaming Postgres data into ClickHouse. This natively supports high-performance insertion while ensuring the separation of concerns with the ability to scale ingestion and cluster resources independently.
 :::
 

--- a/docs/en/engines/table-engines/integrations/rabbitmq.md
+++ b/docs/en/engines/table-engines/integrations/rabbitmq.md
@@ -3,11 +3,11 @@ description: 'This engine allows integrating ClickHouse with RabbitMQ.'
 sidebar_label: 'RabbitMQ'
 sidebar_position: 170
 slug: /engines/table-engines/integrations/rabbitmq
-title: 'RabbitMQ Engine'
+title: 'RabbitMQ table engine'
 doc_type: 'guide'
 ---
 
-# RabbitMQ engine
+# RabbitMQ table engine
 
 This engine allows integrating ClickHouse with [RabbitMQ](https://www.rabbitmq.com).
 

--- a/docs/en/engines/table-engines/integrations/redis.md
+++ b/docs/en/engines/table-engines/integrations/redis.md
@@ -3,11 +3,11 @@ description: 'This engine allows integrating ClickHouse with Redis.'
 sidebar_label: 'Redis'
 sidebar_position: 175
 slug: /engines/table-engines/integrations/redis
-title: 'Redis'
+title: 'Redis table engine'
 doc_type: 'guide'
 ---
 
-# Redis
+# Redis table engine
 
 This engine allows integrating ClickHouse with [Redis](https://redis.io/). For Redis takes kv model, we strongly recommend you only query it in a point way, such as `where k=xx` or `where k in (xx, xx)`.
 

--- a/docs/en/engines/table-engines/integrations/s3.md
+++ b/docs/en/engines/table-engines/integrations/s3.md
@@ -4,7 +4,7 @@ description: 'This engine provides integration with the Amazon S3 ecosystem. Sim
 sidebar_label: 'S3'
 sidebar_position: 180
 slug: /engines/table-engines/integrations/s3
-title: 'S3 Table Engine'
+title: 'S3 table engine'
 doc_type: 'reference'
 ---
 

--- a/docs/en/engines/table-engines/integrations/s3queue.md
+++ b/docs/en/engines/table-engines/integrations/s3queue.md
@@ -5,7 +5,7 @@ description: 'This engine provides integration with the Amazon S3 ecosystem and 
 sidebar_label: 'S3Queue'
 sidebar_position: 181
 slug: /engines/table-engines/integrations/s3queue
-title: 'S3Queue Table Engine'
+title: 'S3Queue table engine'
 doc_type: 'reference'
 ---
 

--- a/docs/en/engines/table-engines/integrations/sqlite.md
+++ b/docs/en/engines/table-engines/integrations/sqlite.md
@@ -4,13 +4,13 @@ description: 'The engine allows to import and export data to SQLite and supports
 sidebar_label: 'SQLite'
 sidebar_position: 185
 slug: /engines/table-engines/integrations/sqlite
-title: 'SQLite'
+title: 'SQLite table engine'
 doc_type: 'reference'
 ---
 
 import CloudNotSupportedBadge from '@theme/badges/CloudNotSupportedBadge';
 
-# SQLite
+# SQLite table engine
 
 <CloudNotSupportedBadge/>
 

--- a/docs/en/engines/table-engines/integrations/time-series.md
+++ b/docs/en/engines/table-engines/integrations/time-series.md
@@ -4,14 +4,14 @@ description: 'A table engine storing time series, i.e. a set of values associate
 sidebar_label: 'TimeSeries'
 sidebar_position: 60
 slug: /engines/table-engines/special/time_series
-title: 'TimeSeries Engine'
+title: 'TimeSeries table engine'
 doc_type: 'reference'
 ---
 
 import ExperimentalBadge from '@theme/badges/ExperimentalBadge';
 import CloudNotSupportedBadge from '@theme/badges/CloudNotSupportedBadge';
 
-# TimeSeries engine
+# TimeSeries table engine
 
 <ExperimentalBadge/>
 <CloudNotSupportedBadge/>

--- a/docs/en/engines/table-engines/integrations/ytsaurus.md
+++ b/docs/en/engines/table-engines/integrations/ytsaurus.md
@@ -3,7 +3,7 @@ description: 'Table engine that allows importing data from a YTsaurus cluster.'
 sidebar_label: 'YTsaurus'
 sidebar_position: 185
 slug: /engines/table-engines/integrations/ytsaurus
-title: 'YTsaurus'
+title: 'YTsaurus table engine'
 keywords: ['YTsaurus', 'table engine']
 doc_type: 'reference'
 ---
@@ -11,7 +11,7 @@ doc_type: 'reference'
 import CloudNotSupportedBadge from '@theme/badges/CloudNotSupportedBadge';
 import ExperimentalBadge from '@theme/badges/ExperimentalBadge';
 
-# YTsaurus
+# YTsaurus table engine
 
 <ExperimentalBadge/>
 <CloudNotSupportedBadge/>

--- a/docs/en/engines/table-engines/log-family/index.md
+++ b/docs/en/engines/table-engines/log-family/index.md
@@ -1,13 +1,17 @@
 ---
-description: 'Documentation for Log Engine Family'
-sidebar_label: 'Log Family'
+description: 'Documentation for the Log engine family'
+sidebar_label: 'Log family'
 sidebar_position: 20
 slug: /engines/table-engines/log-family/
-title: 'Log Engine Family'
+title: 'Log engine family'
 doc_type: 'guide'
 ---
 
-# Log engine family
+import CloudNotSupportedBadge from '@theme/badges/CloudNotSupportedBadge';
+
+# Log table engine family
+
+<CloudNotSupportedBadge/>
 
 These engines were developed for scenarios when you need to quickly write many small tables (up to about 1 million rows) and read them later as a whole.
 

--- a/docs/en/engines/table-engines/log-family/log.md
+++ b/docs/en/engines/table-engines/log-family/log.md
@@ -3,11 +3,15 @@ description: 'Documentation for Log'
 slug: /engines/table-engines/log-family/log
 toc_priority: 33
 toc_title: 'Log'
-title: 'Log'
+title: 'Log table engine'
 doc_type: 'reference'
 ---
 
-# Log
+import CloudNotSupportedBadge from '@theme/badges/CloudNotSupportedBadge';
+
+# Log table engine
+
+<CloudNotSupportedBadge/>
 
 The engine belongs to the family of `Log` engines. See the common properties of `Log` engines and their differences in the [Log Engine Family](../../../engines/table-engines/log-family/index.md) article.
 

--- a/docs/en/engines/table-engines/log-family/stripelog.md
+++ b/docs/en/engines/table-engines/log-family/stripelog.md
@@ -1,13 +1,17 @@
 ---
-description: 'Documentation for StripeLog'
+description: 'Documentation for the StripeLog table engine'
 slug: /engines/table-engines/log-family/stripelog
 toc_priority: 32
 toc_title: 'StripeLog'
-title: 'StripeLog'
+title: 'StripeLog table engine'
 doc_type: 'reference'
 ---
 
-# StripeLog
+import CloudNotSupportedBadge from '@theme/badges/CloudNotSupportedBadge';
+
+# StripeLog table engine
+
+<CloudNotSupportedBadge/>
 
 This engine belongs to the family of log engines. See the common properties of log engines and their differences in the [Log Engine Family](../../../engines/table-engines/log-family/index.md) article.
 

--- a/docs/en/engines/table-engines/log-family/tinylog.md
+++ b/docs/en/engines/table-engines/log-family/tinylog.md
@@ -1,13 +1,17 @@
 ---
-description: 'Documentation for TinyLog'
+description: 'Documentation for the TinyLog table engine'
 slug: /engines/table-engines/log-family/tinylog
 toc_priority: 34
 toc_title: 'TinyLog'
-title: 'TinyLog'
+title: 'TinyLog table engine'
 doc_type: 'reference'
 ---
 
-# TinyLog
+import CloudNotSupportedBadge from '@theme/badges/CloudNotSupportedBadge';
+
+# TinyLog table engine
+
+<CloudNotSupportedBadge/>
 
 The engine belongs to the log engine family. See [Log Engine Family](../../../engines/table-engines/log-family/index.md) for common properties of log engines and their differences.
 

--- a/docs/en/engines/table-engines/mergetree-family/aggregatingmergetree.md
+++ b/docs/en/engines/table-engines/mergetree-family/aggregatingmergetree.md
@@ -6,11 +6,11 @@ description: 'Replaces all rows with the same primary key (or more accurately, w
 sidebar_label: 'AggregatingMergeTree'
 sidebar_position: 60
 slug: /engines/table-engines/mergetree-family/aggregatingmergetree
-title: 'AggregatingMergeTree'
+title: 'AggregatingMergeTree table engine'
 doc_type: 'reference'
 ---
 
-# AggregatingMergeTree
+# AggregatingMergeTree table engine
 
 The engine inherits from [MergeTree](/engines/table-engines/mergetree-family/versionedcollapsingmergetree), altering the logic for data parts merging. ClickHouse replaces all rows with the same primary key (or more accurately, with the same [sorting key](../../../engines/table-engines/mergetree-family/mergetree.md)) with a single row (within a single data part) that stores a combination of states of aggregate functions.
 

--- a/docs/en/engines/table-engines/mergetree-family/coalescingmergetree.md
+++ b/docs/en/engines/table-engines/mergetree-family/coalescingmergetree.md
@@ -4,13 +4,13 @@ description: 'CoalescingMergeTree inherits from the MergeTree engine. Its key fe
 sidebar_label: 'CoalescingMergeTree'
 sidebar_position: 50
 slug: /engines/table-engines/mergetree-family/coalescingmergetree
-title: 'CoalescingMergeTree'
+title: 'CoalescingMergeTree table engine'
 keywords: ['CoalescingMergeTree']
 show_related_blogs: true
 doc_type: 'reference'
 ---
 
-# CoalescingMergeTree
+# CoalescingMergeTree table engine
 
 :::note Available from version 25.6
 This table engine is available from version 25.6 and higher in both OSS and Cloud.

--- a/docs/en/engines/table-engines/mergetree-family/collapsingmergetree.md
+++ b/docs/en/engines/table-engines/mergetree-family/collapsingmergetree.md
@@ -5,11 +5,11 @@ keywords: ['updates', 'collapsing']
 sidebar_label: 'CollapsingMergeTree'
 sidebar_position: 70
 slug: /engines/table-engines/mergetree-family/collapsingmergetree
-title: 'CollapsingMergeTree'
+title: 'CollapsingMergeTree table engine'
 doc_type: 'guide'
 ---
 
-# CollapsingMergeTree
+# CollapsingMergeTree table engine
 
 ## Description {#description}
 

--- a/docs/en/engines/table-engines/mergetree-family/graphitemergetree.md
+++ b/docs/en/engines/table-engines/mergetree-family/graphitemergetree.md
@@ -3,11 +3,11 @@ description: 'Designed for thinning and aggregating/averaging (rollup) Graphite 
 sidebar_label: 'GraphiteMergeTree'
 sidebar_position: 90
 slug: /engines/table-engines/mergetree-family/graphitemergetree
-title: 'GraphiteMergeTree'
+title: 'GraphiteMergeTree table engine'
 doc_type: 'guide'
 ---
 
-# GraphiteMergeTree
+# GraphiteMergeTree table engine
 
 This engine is designed for thinning and aggregating/averaging (rollup) [Graphite](http://graphite.readthedocs.io/en/latest/index.html) data. It may be helpful to developers who want to use ClickHouse as a data store for Graphite.
 

--- a/docs/en/engines/table-engines/mergetree-family/mergetree.md
+++ b/docs/en/engines/table-engines/mergetree-family/mergetree.md
@@ -4,14 +4,14 @@ description: '`MergeTree`-family table engines are designed for high data ingest
 sidebar_label: 'MergeTree'
 sidebar_position: 11
 slug: /engines/table-engines/mergetree-family/mergetree
-title: 'MergeTree'
+title: 'MergeTree table engine'
 doc_type: 'reference'
 ---
 
 import ExperimentalBadge from '@theme/badges/ExperimentalBadge';
 import CloudNotSupportedBadge from '@theme/badges/CloudNotSupportedBadge';
 
-# MergeTree
+# MergeTree table engine
 
 The `MergeTree` engine and other engines of the `MergeTree` family (e.g. `ReplacingMergeTree`, `AggregatingMergeTree` ) are the most commonly used and most robust table engines in ClickHouse.
 

--- a/docs/en/engines/table-engines/mergetree-family/replacingmergetree.md
+++ b/docs/en/engines/table-engines/mergetree-family/replacingmergetree.md
@@ -4,11 +4,11 @@ description: 'differs from MergeTree in that it removes duplicate entries with t
 sidebar_label: 'ReplacingMergeTree'
 sidebar_position: 40
 slug: /engines/table-engines/mergetree-family/replacingmergetree
-title: 'ReplacingMergeTree'
+title: 'ReplacingMergeTree table engine'
 doc_type: 'reference'
 ---
 
-# ReplacingMergeTree
+# ReplacingMergeTree table engine
 
 The engine differs from [MergeTree](/engines/table-engines/mergetree-family/versionedcollapsingmergetree) in that it removes duplicate entries with the same [sorting key](../../../engines/table-engines/mergetree-family/mergetree.md) value (`ORDER BY` table section, not `PRIMARY KEY`).
 

--- a/docs/en/engines/table-engines/mergetree-family/replication.md
+++ b/docs/en/engines/table-engines/mergetree-family/replication.md
@@ -1,13 +1,13 @@
 ---
-description: 'Overview of Data Replication in ClickHouse'
-sidebar_label: 'Data Replication'
+description: 'Overview of data replication with the Replicated* family of table engines in ClickHouse'
+sidebar_label: 'Replicated*'
 sidebar_position: 20
 slug: /engines/table-engines/mergetree-family/replication
-title: 'Data Replication'
+title: 'Replicated* table engines'
 doc_type: 'reference'
 ---
 
-# Data replication
+# Replicated* table engines
 
 :::note
 In ClickHouse Cloud replication is managed for you. Please create your tables without adding arguments.  For example, in the text below you would replace:

--- a/docs/en/engines/table-engines/mergetree-family/summingmergetree.md
+++ b/docs/en/engines/table-engines/mergetree-family/summingmergetree.md
@@ -4,11 +4,11 @@ description: 'SummingMergeTree inherits from the MergeTree engine. Its key featu
 sidebar_label: 'SummingMergeTree'
 sidebar_position: 50
 slug: /engines/table-engines/mergetree-family/summingmergetree
-title: 'SummingMergeTree'
+title: 'SummingMergeTree table engine'
 doc_type: 'reference'
 ---
 
-# SummingMergeTree
+# SummingMergeTree table engine
 
 The engine inherits from [MergeTree](/engines/table-engines/mergetree-family/versionedcollapsingmergetree). The difference is that when merging data parts for `SummingMergeTree` tables ClickHouse replaces all the rows with the same primary key (or more accurately, with the same [sorting key](../../../engines/table-engines/mergetree-family/mergetree.md)) with one row which contains summed values for the columns with the numeric data type. If the sorting key is composed in a way that a single key value corresponds to large number of rows, this significantly reduces storage volume and speeds up data selection.
 

--- a/docs/en/engines/table-engines/mergetree-family/versionedcollapsingmergetree.md
+++ b/docs/en/engines/table-engines/mergetree-family/versionedcollapsingmergetree.md
@@ -4,11 +4,11 @@ description: 'Allows for quick writing of object states that are continually cha
 sidebar_label: 'VersionedCollapsingMergeTree'
 sidebar_position: 80
 slug: /engines/table-engines/mergetree-family/versionedcollapsingmergetree
-title: 'VersionedCollapsingMergeTree'
+title: 'VersionedCollapsingMergeTree table engine'
 doc_type: 'reference'
 ---
 
-# VersionedCollapsingMergeTree
+# VersionedCollapsingMergeTree table engine
 
 This engine:
 

--- a/docs/en/engines/table-engines/special/alias.md
+++ b/docs/en/engines/table-engines/special/alias.md
@@ -3,11 +3,11 @@ description: 'The Alias table engine creates a transparent proxy to another tabl
 sidebar_label: 'Alias'
 sidebar_position: 5
 slug: /engines/table-engines/special/alias
-title: 'Alias Table Engine'
+title: 'Alias table engine'
 doc_type: 'reference'
 ---
 
-# Alias Table Engine
+# Alias table engine
 
 The `Alias` engine creates a proxy to another table. All read and write operations are forwarded to the target table, while the alias itself stores no data and only maintains a reference to the target table.
 

--- a/docs/en/engines/table-engines/special/buffer.md
+++ b/docs/en/engines/table-engines/special/buffer.md
@@ -5,7 +5,7 @@ description: 'Buffers the data to write in RAM, periodically flushing it to anot
 sidebar_label: 'Buffer'
 sidebar_position: 120
 slug: /engines/table-engines/special/buffer
-title: 'Buffer Table Engine'
+title: 'Buffer table engine'
 doc_type: 'reference'
 ---
 

--- a/docs/en/engines/table-engines/special/dictionary.md
+++ b/docs/en/engines/table-engines/special/dictionary.md
@@ -4,7 +4,7 @@ description: 'The `Dictionary` engine displays the dictionary data as a ClickHou
 sidebar_label: 'Dictionary'
 sidebar_position: 20
 slug: /engines/table-engines/special/dictionary
-title: 'Dictionary Table Engine'
+title: 'Dictionary table engine'
 doc_type: 'reference'
 ---
 

--- a/docs/en/engines/table-engines/special/distributed.md
+++ b/docs/en/engines/table-engines/special/distributed.md
@@ -6,7 +6,7 @@ description: 'Tables with Distributed engine do not store any data of their own,
 sidebar_label: 'Distributed'
 sidebar_position: 10
 slug: /engines/table-engines/special/distributed
-title: 'Distributed Table Engine'
+title: 'Distributed table engine'
 doc_type: 'reference'
 ---
 

--- a/docs/en/engines/table-engines/special/executable.md
+++ b/docs/en/engines/table-engines/special/executable.md
@@ -2,14 +2,14 @@
 description: 'The `Executable` and `ExecutablePool` table engines allow you to define
   a table whose rows are generated from a script that you define (by writing rows
   to **stdout**).'
-sidebar_label: 'Executable'
+sidebar_label: 'Executable/ExecutablePool'
 sidebar_position: 40
 slug: /engines/table-engines/special/executable
-title: 'Executable and ExecutablePool Table Engines'
+title: 'Executable and ExecutablePool table engines'
 doc_type: 'reference'
 ---
 
-# `Executable` and `ExecutablePool` table engines
+# Executable and ExecutablePool table engines
 
 The `Executable` and `ExecutablePool` table engines allow you to define a table whose rows are generated from a script that you define (by writing rows to **stdout**). The executable script is stored in the `users_scripts` directory and can read data from any source.
 

--- a/docs/en/engines/table-engines/special/external-data.md
+++ b/docs/en/engines/table-engines/special/external-data.md
@@ -2,10 +2,10 @@
 description: 'ClickHouse allows sending a server the data that is needed for processing
   a query, together with a `SELECT` query. This data is put in a temporary table and
   can be used in the query (for example, in `IN` operators).'
-sidebar_label: 'External Data'
+sidebar_label: 'External data for query processing'
 sidebar_position: 130
 slug: /engines/table-engines/special/external-data
-title: 'External Data for Query Processing'
+title: 'External data for query processing'
 doc_type: 'reference'
 ---
 

--- a/docs/en/engines/table-engines/special/file.md
+++ b/docs/en/engines/table-engines/special/file.md
@@ -4,11 +4,11 @@ description: 'The File table engine keeps the data in a file in one of the suppo
 sidebar_label: 'File'
 sidebar_position: 40
 slug: /engines/table-engines/special/file
-title: 'File Table Engine'
+title: 'File table engine'
 doc_type: 'reference'
 ---
 
-# `File` table engine
+# File table engine
 
 The File table engine keeps the data in a file in one of the supported [file formats](/interfaces/formats#formats-overview) (`TabSeparated`, `Native`, etc.).
 

--- a/docs/en/engines/table-engines/special/filelog.md
+++ b/docs/en/engines/table-engines/special/filelog.md
@@ -4,11 +4,11 @@ description: 'This engine allows processing of application log files as a stream
 sidebar_label: 'FileLog'
 sidebar_position: 160
 slug: /engines/table-engines/special/filelog
-title: 'FileLog Engine'
+title: 'FileLog table engine'
 doc_type: 'reference'
 ---
 
-# `FileLog` engine {#filelog-engine}
+# FileLog table engine {#filelog-engine}
 
 This engine allows processing of application log files as a stream of records.
 

--- a/docs/en/engines/table-engines/special/generate.md
+++ b/docs/en/engines/table-engines/special/generate.md
@@ -4,9 +4,11 @@ description: 'The GenerateRandom table engine produces random data for given tab
 sidebar_label: 'GenerateRandom'
 sidebar_position: 140
 slug: /engines/table-engines/special/generate
-title: 'GenerateRandom Table Engine'
+title: 'GenerateRandom table engine'
 doc_type: 'reference'
 ---
+
+# GenerateRandom table engine
 
 The GenerateRandom table engine produces random data for given table schema.
 

--- a/docs/en/engines/table-engines/special/index.md
+++ b/docs/en/engines/table-engines/special/index.md
@@ -3,7 +3,7 @@ description: 'Documentation for Special Table Engines'
 sidebar_label: 'Special'
 sidebar_position: 50
 slug: /engines/table-engines/special/
-title: 'Special Table Engines'
+title: 'Special table engines'
 doc_type: 'reference'
 ---
 

--- a/docs/en/engines/table-engines/special/join.md
+++ b/docs/en/engines/table-engines/special/join.md
@@ -3,17 +3,13 @@ description: 'Optional prepared data structure for usage in JOIN operations.'
 sidebar_label: 'Join'
 sidebar_position: 70
 slug: /engines/table-engines/special/join
-title: 'Join Table Engine'
+title: 'Join table engine'
 doc_type: 'reference'
 ---
 
-# `Join` table engine
+# Join table engine
 
 Optional prepared data structure for usage in [JOIN](/sql-reference/statements/select/join) operations.
-
-:::note
-This is not an article about the [JOIN clause](/sql-reference/statements/select/join) itself.
-:::
 
 :::note
 In ClickHouse Cloud, if your service was created with a version earlier than 25.4, you will need to set the compatibility to at least 25.4 using  `SET compatibility=25.4`.

--- a/docs/en/engines/table-engines/special/keepermap.md
+++ b/docs/en/engines/table-engines/special/keepermap.md
@@ -4,11 +4,11 @@ description: 'This engine allows you to use Keeper/ZooKeeper cluster as consiste
 sidebar_label: 'KeeperMap'
 sidebar_position: 150
 slug: /engines/table-engines/special/keeper-map
-title: 'KeeperMap'
+title: 'KeeperMap table engine'
 doc_type: 'reference'
 ---
 
-# KeeperMap {#keepermap}
+# KeeperMap table engine
 
 This engine allows you to use Keeper/ZooKeeper cluster as consistent key-value store with linearizable writes and sequentially consistent reads.
 

--- a/docs/en/engines/table-engines/special/memory.md
+++ b/docs/en/engines/table-engines/special/memory.md
@@ -5,7 +5,7 @@ description: 'The Memory engine stores data in RAM, in uncompressed form. Data i
 sidebar_label: 'Memory'
 sidebar_position: 110
 slug: /engines/table-engines/special/memory
-title: 'Memory Table Engine'
+title: 'Memory table engine'
 doc_type: 'reference'
 ---
 

--- a/docs/en/engines/table-engines/special/merge.md
+++ b/docs/en/engines/table-engines/special/merge.md
@@ -4,7 +4,7 @@ description: 'The `Merge` engine (not to be confused with `MergeTree`) does not 
 sidebar_label: 'Merge'
 sidebar_position: 30
 slug: /engines/table-engines/special/merge
-title: 'Merge Table Engine'
+title: 'Merge table engine'
 doc_type: 'reference'
 ---
 

--- a/docs/en/engines/table-engines/special/null.md
+++ b/docs/en/engines/table-engines/special/null.md
@@ -16,5 +16,3 @@ When reading from a `Null` table, the response is empty.
 The `Null` table engine is useful for data transformations where you no longer need the original data after it has been transformed.
 For this purpose you can create a materialized view on a `Null` table.
 The data written to the table will be consumed by the view, but the original raw data will be discarded.
-
-

--- a/docs/en/engines/table-engines/special/null.md
+++ b/docs/en/engines/table-engines/special/null.md
@@ -4,14 +4,17 @@ description: 'When writing to a `Null` table, data is ignored. When reading from
 sidebar_label: 'Null'
 sidebar_position: 50
 slug: /engines/table-engines/special/null
-title: 'Null Table Engine'
+title: 'Null table engine'
 doc_type: 'reference'
 ---
 
-# `Null` table engine
+# Null table engine 
 
-When writing to a `Null` table, data is ignored. When reading from a `Null` table, the response is empty.
+When writing data to a `Null` table, data is ignored.
+When reading from a `Null` table, the response is empty.
 
-:::note
-If you are wondering why this is useful, note that you can create a materialized view on a `Null` table. So the data written to the table will end up affecting the view, but original raw data will still be discarded.
-:::
+The `Null` table engine is useful for data transformations where you no longer need the original data after it has been transformed.
+For this purpose you can create a materialized view on a `Null` table.
+The data written to the table will be consumed by the view, but the original raw data will be discarded.
+
+

--- a/docs/en/engines/table-engines/special/set.md
+++ b/docs/en/engines/table-engines/special/set.md
@@ -4,7 +4,7 @@ description: 'A data set that is always in RAM. It is intended for use on the ri
 sidebar_label: 'Set'
 sidebar_position: 60
 slug: /engines/table-engines/special/set
-title: 'Set Table Engine'
+title: 'Set table engine'
 doc_type: 'reference'
 ---
 

--- a/docs/en/engines/table-engines/special/url.md
+++ b/docs/en/engines/table-engines/special/url.md
@@ -4,11 +4,11 @@ description: 'Queries data to/from a remote HTTP/HTTPS server. This engine is si
 sidebar_label: 'URL'
 sidebar_position: 80
 slug: /engines/table-engines/special/url
-title: 'URL Table Engine'
+title: 'URL table engine'
 doc_type: 'reference'
 ---
 
-# `URL` table engine
+# URL table engine
 
 Queries data to/from a remote HTTP/HTTPS server. This engine is similar to the [File](../../../engines/table-engines/special/file.md) engine.
 

--- a/docs/en/engines/table-engines/special/view.md
+++ b/docs/en/engines/table-engines/special/view.md
@@ -6,7 +6,7 @@ description: 'Used for implementing views (for more information, see the `CREATE
 sidebar_label: 'View'
 sidebar_position: 90
 slug: /engines/table-engines/special/view
-title: 'View Table Engine'
+title: 'View table engine'
 doc_type: 'reference'
 ---
 


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

### Details

Consistent casing and style for table engine titles
