### PR TITLE
Better cherry_pick catch, fixed `GitHub.get_release_pulls`

### DIFF
--- a/tests/ci/github_helper.py
+++ b/tests/ci/github_helper.py
@@ -137,6 +137,8 @@ class GitHub(github.Github):
             order="asc",
             label="release",
         )
+        # All PRs should belong to the repo_name
+        prs = [pr for pr in prs if pr.head.repo.full_name == repo_name]
         # Ensure that the answer from GitHub is correct (we should always have some releases)
         assert prs
         return prs


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix Slack alerts for broken cherry_pick.py, fix broken cherry_pick.py for the PRs from forks.
