### PR TITLE
Update RapidJSONParser.h

### DIFF
--- a/src/Common/JSONParsers/RapidJSONParser.h
+++ b/src/Common/JSONParsers/RapidJSONParser.h
@@ -35,16 +35,23 @@ struct RapidJSONParser
         {
             switch (ptr->GetType())
             {
-                case rapidjson::kNumberType: return ptr->IsDouble() ? ElementType::DOUBLE : (ptr->IsUint64() ? ElementType::UINT64 : ElementType::INT64);
+                case rapidjson::kNumberType:
+                    if (ptr->IsDouble()) {
+                        // проверка на переполненние 2^53
+                        if (ptr->GetDouble() > 9007199254740992.0)
+                            return ElementType::STRING; 
+                        return ElementType::DOUBLE;
+                    }
+                    return ptr->IsUint64() ? ElementType::UINT64 : ElementType::INT64;
+        
                 case rapidjson::kStringType: return ElementType::STRING;
-                case rapidjson::kArrayType: return ElementType::ARRAY;
+                case rapidjson::kArrayType:  return ElementType::ARRAY;
                 case rapidjson::kObjectType: return ElementType::OBJECT;
-                case rapidjson::kTrueType: return ElementType::BOOL;
+                case rapidjson::kTrueType:
                 case rapidjson::kFalseType: return ElementType::BOOL;
-                case rapidjson::kNullType: return ElementType::NULL_VALUE;
+                case rapidjson::kNullType:   return ElementType::NULL_VALUE;
             }
         }
-
         ALWAYS_INLINE bool isInt64() const { return ptr->IsInt64(); }
         ALWAYS_INLINE bool isUInt64() const { return ptr->IsUint64(); }
         ALWAYS_INLINE bool isDouble() const { return ptr->IsDouble(); }

--- a/src/Common/JSONParsers/RapidJSONParser.h
+++ b/src/Common/JSONParsers/RapidJSONParser.h
@@ -38,7 +38,7 @@ struct RapidJSONParser
                 case rapidjson::kNumberType:
                     if (ptr->IsDouble()) {
                         // проверка на переполненние 2^53
-                        if (ptr->GetDouble() > 9007199254740992.0)
+                        if (ptr->GetDouble() > 9007199254740992.0 || ptr->GetDouble() < -9007199254740992.0)
                             return ElementType::STRING; 
                         return ElementType::DOUBLE;
                     }

--- a/src/Common/JSONParsers/RapidJSONParser.h
+++ b/src/Common/JSONParsers/RapidJSONParser.h
@@ -30,6 +30,7 @@ enum ParseFlag {
     kParseNumbersAsStringsFlag = 64,    //!< Parse all numbers (ints/doubles) as strings.
     kParseTrailingCommasFlag = 128, //!< Allow trailing commas at the end of objects and arrays.
     kParseNanAndInfFlag = 256,      //!< Allow parsing NaN, Inf, Infinity, -Inf and -Infinity as doubles.
+    kParseDefaultFlags = RAPIDJSON_PARSE_DEFAULT_FLAGS  //!< Default parse flags. Can be customized by defining RAPIDJSON_PARSE_DEFAULT_FLAGS
 };
 
 

--- a/src/Common/JSONParsers/RapidJSONParser.h
+++ b/src/Common/JSONParsers/RapidJSONParser.h
@@ -4,8 +4,35 @@
 
 #if USE_RAPIDJSON
 
-/// Prevent stack overflow:
-#define RAPIDJSON_PARSE_DEFAULT_FLAGS (kParseIterativeFlag)
+// ParseFlag
+
+/*! \def RAPIDJSON_PARSE_DEFAULT_FLAGS
+    \ingroup RAPIDJSON_CONFIG
+    \brief User-defined kParseDefaultFlags definition.
+
+    User can define this as any \c ParseFlag combinations.
+*/
+#ifndef RAPIDJSON_PARSE_DEFAULT_FLAGS
+#define RAPIDJSON_PARSE_DEFAULT_FLAGS kParseIterativeFlag
+#endif
+
+//! Combination of parseFlags
+/*! \see Reader::Parse, Document::Parse, Document::ParseInsitu, Document::ParseStream
+ */
+enum ParseFlag {
+    kParseNoFlags = 0,              //!< No flags are set.
+    kParseInsituFlag = 1,           //!< In-situ(destructive) parsing.
+    kParseValidateEncodingFlag = 2, //!< Validate encoding of JSON strings.
+    kParseIterativeFlag = 4,        //!< Iterative(constant complexity in terms of function call stack size) parsing.
+    kParseStopWhenDoneFlag = 8,     //!< After parsing a complete JSON root from stream, stop further processing the rest of stream. When this flag is used, parser will not generate kParseErrorDocumentRootNotSingular error.
+    kParseFullPrecisionFlag = 16,   //!< Parse number in full precision (but slower).
+    kParseCommentsFlag = 32,        //!< Allow one-line (//) and multi-line (/**/) comments.
+    kParseNumbersAsStringsFlag = 64,    //!< Parse all numbers (ints/doubles) as strings.
+    kParseTrailingCommasFlag = 128, //!< Allow trailing commas at the end of objects and arrays.
+    kParseNanAndInfFlag = 256,      //!< Allow parsing NaN, Inf, Infinity, -Inf and -Infinity as doubles.
+};
+
+
 
 #include <base/types.h>
 #include <base/defines.h>
@@ -35,23 +62,17 @@ struct RapidJSONParser
         {
             switch (ptr->GetType())
             {
-                case rapidjson::kNumberType:
-                    if (ptr->IsDouble()) {
-                        // проверка на переполненние 2^53
-                        if (ptr->GetDouble() > 9007199254740992.0 || ptr->GetDouble() < -9007199254740992.0)
-                            return ElementType::STRING; 
-                        return ElementType::DOUBLE;
-                    }
-                    return ptr->IsUint64() ? ElementType::UINT64 : ElementType::INT64;
-        
+                case rapidjson::kNumberType: return ptr->IsDouble() ? ElementType::DOUBLE : (ptr->IsUint64() ? ElementType::UINT64 : ElementType::INT64);
                 case rapidjson::kStringType: return ElementType::STRING;
-                case rapidjson::kArrayType:  return ElementType::ARRAY;
+                case rapidjson::kArrayType: return ElementType::ARRAY;
                 case rapidjson::kObjectType: return ElementType::OBJECT;
-                case rapidjson::kTrueType:
+                case rapidjson::kTrueType: return ElementType::BOOL;
                 case rapidjson::kFalseType: return ElementType::BOOL;
-                case rapidjson::kNullType:   return ElementType::NULL_VALUE;
+                case rapidjson::kNullType: return ElementType::NULL_VALUE;
             }
         }
+
+
         ALWAYS_INLINE bool isInt64() const { return ptr->IsInt64(); }
         ALWAYS_INLINE bool isUInt64() const { return ptr->IsUint64(); }
         ALWAYS_INLINE bool isDouble() const { return ptr->IsDouble(); }


### PR DESCRIPTION
fix 
https://github.com/ClickHouse/ClickHouse/issues/49895

<!---AI changelog entry and formatting assistance: true-->

### Changelog category (leave one):
- Improvement

When JSON contains large integer-like numbers without fractional parts, converting them to Float64 may lose precision.
This can be a problem when such numbers represent IDs.
This change detects values exceeding 2^53 and treats them as strings to preserve accuracy.

- Example use: A query or command.

before 

SELECT JSONExtractRaw('{"a": 1234567891234456456556789123456789}')  as b SETTINGS allow_simdjson = 0;
┬─b───────────────────────────┐
│ {"a":1234567891234456456000000000} │
└─────────────────────────────┴
after 

SELECT JSONExtractRaw('{"a": 1234567891234456456556789123456789}')  as b SETTINGS allow_simdjson = 0;
┬─b───────────────────────────┐
│ {"a":"1234567891234456456556789123456789"} │
└─────────────────────────────┴
