### PR TITLE
Fix `~` expansion in client's history file override

### DIFF
--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -258,8 +258,8 @@ void Client::initialize(Poco::Util::Application & self)
         if (overrides.history_file.has_value())
         {
             auto history_file = overrides.history_file.value();
-            if (history_file.starts_with("~") && !home_path.empty())
-                history_file = home_path / history_file.substr(1);
+            if (history_file.starts_with("~/") && !home_path.empty())
+                history_file = home_path / history_file.substr(2);
             configuration.setString("history_file", history_file);
         }
         if (overrides.history_max_entries.has_value())


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
Simply checking for `~/` should be enough, since we do not support anything except expanding current user's `$HOME` (i.e. we do not support `~another_user` syntax).

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Details

Fixes: https://github.com/ClickHouse/ClickHouse/pull/88538
