### PR TITLE
CI: Change secret name for copilot

### DIFF
--- a/ci/jobs/pr_formatter_job.py
+++ b/ci/jobs/pr_formatter_job.py
@@ -66,7 +66,7 @@ Header: "### Details"
     results = []
 
     os.environ["GH_TOKEN"] = Secret.Config(
-        name="/github-tokens/robot-2-copilot", type=Secret.Type.AWS_SSM_PARAMETER
+        name="/ci/robot-ch-test-poll-copilot", type=Secret.Type.AWS_SSM_PARAMETER
     ).get_value()
     if res:
         results.append(


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Details

Change AWS secret name to avoid conflict in get_robot_token logic.
