### PR TITLE
Fix use-after-free crash if table was dropped during RMV refresh

### DIFF
--- a/src/Processors/Executors/PipelineExecutor.h
+++ b/src/Processors/Executors/PipelineExecutor.h
@@ -31,10 +31,13 @@ class PipelineExecutor
 public:
     /// Get pipeline as a set of processors.
     /// Processors should represent full graph. All ports must be connected, all connected nodes are mentioned in set.
-    /// Executor doesn't own processors, just stores reference.
     /// During pipeline execution new processors can appear. They will be added to existing set.
     ///
     /// Explicit graph representation is built in constructor. Throws if graph is not correct.
+    ///
+    /// PipelineExecutor must be destroyed before the corresponding QueryPipeline, because
+    /// QueryPlanResourceHolder may hold some resources referenced by processors and used in
+    /// processor destructors.
     explicit PipelineExecutor(std::shared_ptr<Processors> & processors, QueryStatusPtr elem);
     ~PipelineExecutor();
 

--- a/src/Storages/MaterializedView/RefreshTask.cpp
+++ b/src/Storages/MaterializedView/RefreshTask.cpp
@@ -736,30 +736,34 @@ std::optional<UUID> RefreshTask::executeRefreshUnlocked(bool append, int32_t roo
                 throw Exception(
                     ErrorCodes::LOGICAL_ERROR, "Pipeline for view {} refresh must be completed", view_storage_id.getFullTableName());
 
-            PipelineExecutor executor(pipeline.processors, pipeline.process_list_element);
-            executor.setReadProgressCallback(pipeline.getReadProgressCallback());
-
             {
-                std::unique_lock exec_lock(execution.executor_mutex);
+                PipelineExecutor executor(pipeline.processors, pipeline.process_list_element);
+                executor.setReadProgressCallback(pipeline.getReadProgressCallback());
+
+                {
+                    std::unique_lock exec_lock(execution.executor_mutex);
+                    if (execution.interrupt_execution.load())
+                        throw Exception(ErrorCodes::QUERY_WAS_CANCELLED, "Refresh for view {} cancelled", view_storage_id.getFullTableName());
+                    execution.executor = &executor;
+                }
+                SCOPE_EXIT({
+                    std::unique_lock exec_lock(execution.executor_mutex);
+                    execution.executor = nullptr;
+                });
+
+                executor.execute(pipeline.getNumThreads(), pipeline.getConcurrencyControl());
+
+                /// A cancelled PipelineExecutor may return without exception but with incomplete results.
+                /// In this case make sure to:
+                ///  * report exception rather than success,
+                ///  * do it before destroying the QueryPipeline; otherwise it may fail assertions about
+                ///    being unexpectedly destroyed before completion and without uncaught exception
+                ///    (specifically, the assert in ~WriteBuffer()).
                 if (execution.interrupt_execution.load())
                     throw Exception(ErrorCodes::QUERY_WAS_CANCELLED, "Refresh for view {} cancelled", view_storage_id.getFullTableName());
-                execution.executor = &executor;
+
+                /// `executor` must be destroyed before `pipeline`!
             }
-            SCOPE_EXIT({
-                std::unique_lock exec_lock(execution.executor_mutex);
-                execution.executor = nullptr;
-            });
-
-            executor.execute(pipeline.getNumThreads(), pipeline.getConcurrencyControl());
-
-            /// A cancelled PipelineExecutor may return without exception but with incomplete results.
-            /// In this case make sure to:
-            ///  * report exception rather than success,
-            ///  * do it before destroying the QueryPipeline; otherwise it may fail assertions about
-            ///    being unexpectedly destroyed before completion and without uncaught exception
-            ///    (specifically, the assert in ~WriteBuffer()).
-            if (execution.interrupt_execution.load())
-                throw Exception(ErrorCodes::QUERY_WAS_CANCELLED, "Refresh for view {} cancelled", view_storage_id.getFullTableName());
 
             logQueryFinish(*query_log_elem, refresh_context, refresh_query, std::move(pipeline), /*pulling_pipeline=*/false, query_span, QueryResultCacheUsage::None, /*internal=*/false);
             query_log_elem = std::nullopt;


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Refreshable materialized view: fixed rare server crash if source table was fully dropped during a refresh.

### Details

Turns out PipelineExecutor is not allowed to outlive the QueryPipeline. This PR just swaps destruction order of PipelineExecutor and QueryPipeline in RefreshTask. The destruction order was probably initially correct, then was inadvertently swapped by adding logQueryFinish call.

This was crashing like this:
```
2. ./ci/tmp/build/./src/Storages/MergeTree/MergeTreeData.cpp:2762: DB::MergeTreeData::getPrimaryIndexCache() const
3. ./ci/tmp/build/./src/Storages/MergeTree/IMergeTreeDataPart.cpp:667: DB::IMergeTreeDataPart::clearCaches()
4. ./ci/tmp/build/./src/Storages/MergeTree/IMergeTreeDataPart.cpp:710: DB::IMergeTreeDataPart::removeIfNeeded()
5. ./ci/tmp/build/./src/Storages/MergeTree/MergeTreeDataPartCompact.cpp:322: DB::MergeTreeDataPartCompact::~MergeTreeDataPartCompact()
6. ./contrib/llvm-project/libcxx/include/vector:530: std::vector<DB::RangesInDataPart, std::allocator<DB::RangesInDataPart>>::__destroy_vector::operator()[abi:ne190107]()
7. ./src/Storages/MergeTree/MergeTreeReadPoolBase.h:10: DB::MergeTreeReadPoolBase::~MergeTreeReadPoolBase()
8. ./src/Storages/MergeTree/MergeTreeSelectProcessor.h:57: DB::MergeTreeSelectProcessor::~MergeTreeSelectProcessor()
9. ./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:286: std::__shared_ptr_emplace<DB::MergeTreeSource, std::allocator<DB::MergeTreeSource>>::__on_zero_shared()
10. ./contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:286: std::__shared_ptr_emplace<std::vector<std::shared_ptr<DB::IProcessor>, std::allocator<std::shared_ptr<DB::IProcessor>>>, std::allocator<std::vector<std::shared_ptr<DB::IProcessor>, std::allocator<std::shared_ptr<DB::IProcessor>>>>>::__on_zero_shared()
11. ./src/Processors/Executors/ExecutingGraph.h:17: DB::ExecutingGraph::~ExecutingGraph()
12. ./ci/tmp/build/./src/Processors/Executors/PipelineExecutor.cpp:88: DB::PipelineExecutor::~PipelineExecutor()
13. ./ci/tmp/build/./src/Storages/MaterializedView/RefreshTask.cpp:758: DB::RefreshTask::executeRefreshUnlocked(bool, int, std::chrono::time_point<std::chrono::system_clock, std::chrono::duration<long long, std::ratio<1l, 1000000l>>>, Stopwatch const&, String const&, String&)
14. ./ci/tmp/build/./src/Storages/MaterializedView/RefreshTask.cpp:576: DB::RefreshTask::refreshTask()
15. ./ci/tmp/build/./src/Core/BackgroundSchedulePool.cpp:358: DB::BackgroundSchedulePool::threadFunction()
16. ./contrib/llvm-project/libcxx/include/__functional/function.h:610: ?
17. ./ci/tmp/build/./src/Common/ThreadPool.cpp:809: ThreadPoolImpl<std::thread>::ThreadFromThreadPool::worker()
18. ./contrib/llvm-project/libcxx/include/__thread/thread.h:201: void* std::__thread_proxy[abi:ne190107]<std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void (ThreadPoolImpl<std::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::thread>::ThreadFromThreadPool*>>(void*)
```
Presumably because ~PipelineExecutor() was calling ~IProcessor(), which was calling ~IMergeTreeDataPart(), which accessed IStorage by plain pointer, crashing with use-after-free. The corresponding StoragePtr is presumably held by QueryPlanResourceHolder in QueryPipeline.

I reproduced it by adding a sleep after logQueryFinish, then doing DROP TABLE src SYNC during that sleep. Not adding a test because there's nowhere to put that sleep anymore, with the order swapped.

It's a weird ownership situation in PipelineExecutor. Initially it wasn't weird: PipelineExecutor just didn't own IProcessor-s, so either destruction order worked. Then it was made to own the IProcessors but not the corresponding QueryPlanResourceHolder. We should probably refactor it to be less error-prone. And also check for other code sites with this bug (I see Connection::sendExternalTablesData seems to there seem to have it, though maybe it can't hit the crash because it doesn't read from MergeTree). But I'll leave that for another PR, so this one is nice and small and easy to backport.
