### PR TITLE
Docs: Update merge table function docs

### DIFF
--- a/docs/en/engines/table-engines/special/merge.md
+++ b/docs/en/engines/table-engines/special/merge.md
@@ -58,12 +58,28 @@ CREATE TABLE all_visitors (id UInt32) ENGINE=Merge(REGEXP('ABC_*'), 'visitors');
 Let's say you have an old table `WatchLog_old` and decided to change partitioning without moving data to a new table `WatchLog_new`, and you need to see data from both tables.
 
 ```sql
-CREATE TABLE WatchLog_old(date Date, UserId Int64, EventType String, Cnt UInt64)
-    ENGINE=MergeTree(date, (UserId, EventType), 8192);
+CREATE TABLE WatchLog_old(
+    date Date,
+    UserId Int64,
+    EventType String,
+    Cnt UInt64
+)
+ENGINE=MergeTree
+ORDER BY (date, UserId, EventType);
+
 INSERT INTO WatchLog_old VALUES ('2018-01-01', 1, 'hit', 3);
 
-CREATE TABLE WatchLog_new(date Date, UserId Int64, EventType String, Cnt UInt64)
-    ENGINE=MergeTree PARTITION BY date ORDER BY (UserId, EventType) SETTINGS index_granularity=8192;
+CREATE TABLE WatchLog_new(
+    date Date,
+    UserId Int64,
+    EventType String,
+    Cnt UInt64
+)
+ENGINE=MergeTree
+PARTITION BY date
+ORDER BY (UserId, EventType)
+SETTINGS index_granularity=8192;
+
 INSERT INTO WatchLog_new VALUES ('2018-01-02', 2, 'hit', 3);
 
 CREATE TABLE WatchLog AS WatchLog_old ENGINE=Merge(currentDatabase(), '^WatchLog');
@@ -82,9 +98,11 @@ SELECT * FROM WatchLog;
 
 ## Virtual columns {#virtual-columns}
 
-- `_table` — Contains the name of the table from which data was read. Type: [String](../../../sql-reference/data-types/string.md).
+- `_table` — The name of the table from which data was read. Type: [String](../../../sql-reference/data-types/string.md).
 
-    You can set the constant conditions on `_table` in the `WHERE/PREWHERE` clause (for example, `WHERE _table='xyz'`). In this case the read operation is performed only for that tables where the condition on `_table` is satisfied, so the `_table` column acts as an index.
+    If you filter on `_table`, (for example `WHERE _table='xyz'`) only tables which satisfy the filter condition are read.
+
+- `_database` — Contains the name of the database from which data was read. Type: [String](../../../sql-reference/data-types/string.md).
 
 **See Also**
 

--- a/docs/en/sql-reference/table-functions/merge.md
+++ b/docs/en/sql-reference/table-functions/merge.md
@@ -9,7 +9,9 @@ doc_type: 'reference'
 
 # merge Table Function
 
-Creates a temporary [Merge](../../engines/table-engines/special/merge.md) table. The structure will be derived from underlying tables by using a union of their columns and by deriving common types.
+Creates a temporary [Merge](../../engines/table-engines/special/merge.md) table.
+The table schema is derived from underlying tables by using a union of their columns and by deriving common types.
+The same virtual columns are available as for the [Merge](../../engines/table-engines/special/merge.md) table engine.
 
 ## Syntax {#syntax}
 


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Details
- Replace deprecated MergeTree syntax by modern syntax
- Add _database as virtual column
- Mention that the merge table function exhibits the same virtual columns as the merge table engine
