### PR TITLE
03570_limit_by_all.sql: add extended coverage for LIMIT BY and LIMIT BY ALL semantics

### DIFF
--- a/tests/queries/0_stateless/03570_limit_by_all.reference
+++ b/tests/queries/0_stateless/03570_limit_by_all.reference
@@ -34,7 +34,8 @@
 SELECT
     id,
     category,
-    value
+    value,
+    rand() AS r
 FROM test_limit_by_all
 ORDER BY
     id ASC,
@@ -74,12 +75,96 @@ QUERY id: 0
 1	A	100	1
 1	A	200	2
 1	B	300	1
-2	A	400	3
-2	A	500	4
-2	B	600	2
-3	C	700	1
 1	B	300
 2	A	400
 2	A	500
 2	B	600
 3	C	700
+1	A
+1	B
+2	A
+2	B
+3	C
+1	A	100	item1
+1	A	200	item2
+1	B	300	item3
+2	A	400	item4
+2	A	500	item5
+2	B	600	item6
+3	C	700	item7
+1
+2
+3
+1	A
+1	B
+2025-01-01 00:00:00	A	2
+2025-01-01 00:00:00	B	2
+2025-01-01 00:00:00	C	1
+1	A
+2	A
+1	A
+2	A
+3	C
+2	B
+SELECT
+    t.id,
+    tag,
+    sum(value) AS s
+FROM test_limit_by_all AS t
+ALL LEFT JOIN test_limit_by_all_tags AS g USING (id)
+ARRAY JOIN g.tags AS tag
+GROUP BY
+    t.id,
+    tag
+ORDER BY
+    t.id ASC,
+    tag ASC
+LIMIT 1 BY ALL
+1	x
+1	y
+2	y
+3	z
+2025-01-01 12:00:00	A
+2025-01-01 12:00:00	B
+2025-01-01 12:00:00	C
+1	A	200
+1	B	300
+2	A	500
+2	B	600
+1	A	200
+1	B	300
+2	A	500
+2	B	600
+SELECT
+    id,
+    category,
+    value
+FROM test_limit_by_all
+ORDER BY
+    1 ASC,
+    2 ASC,
+    3 ASC
+LIMIT 2 BY
+    1,
+    2
+SETTINGS enable_positional_arguments = 1
+2	B	600
+3	C	700
+2	A	500
+2	B	600
+1	A	100
+1	A	200
+1	B	300
+2	A	400
+2	A	500
+2	B	600
+3	C	700
+1	2
+2	2
+3	1
+1	A
+1	B
+2	A
+2	B
+3	C
+4	

--- a/tests/queries/0_stateless/03570_limit_by_all.sql
+++ b/tests/queries/0_stateless/03570_limit_by_all.sql
@@ -3,6 +3,8 @@ SET max_insert_threads = 1;
 SET max_block_size = 65536;
 SET allow_experimental_analyzer = 1;
 
+DROP TABLE IF EXISTS test_limit_by_all;
+
 CREATE TABLE test_limit_by_all (
     id Int32,
     category String,
@@ -52,7 +54,7 @@ LIMIT 1 BY id, category, value;
 
 -- Test 6: EXPLAIN SYNTAX test
 EXPLAIN SYNTAX 
-SELECT id, category, value 
+SELECT id, category, value, rand() AS r
 FROM test_limit_by_all 
 ORDER BY id, category, value 
 LIMIT 1 BY ALL;
@@ -68,13 +70,151 @@ LIMIT 1 BY ALL;
 SELECT id, category, value, row_number() OVER (PARTITION BY category ORDER BY value) AS rn
 FROM test_limit_by_all
 ORDER BY id, category, value, rn 
-LIMIT 1 BY ALL;
+LIMIT 1 BY ALL LIMIT 3;
 
 -- Test 9: LIMIT BY ALL with WHERE clause - make deterministic
 SELECT id, category, value 
 FROM test_limit_by_all 
 WHERE value > 200
 ORDER BY id, category, value  -- Add value to ordering for deterministic results
+LIMIT 1 BY ALL;
+
+SELECT id AS k, category
+FROM test_limit_by_all
+ORDER BY k, category, value
+LIMIT 1 BY ALL;
+
+SELECT *
+FROM test_limit_by_all
+ORDER BY id, category, value, name
+LIMIT 1 BY ALL;
+
+SELECT id
+FROM (SELECT DISTINCT id, category FROM test_limit_by_all)
+ORDER BY id, category
+LIMIT 1 BY ALL;
+
+SELECT DISTINCT id, category
+FROM test_limit_by_all
+ORDER BY id, category
+LIMIT 1 BY ALL
+LIMIT 2;
+
+SELECT d, category, count() AS c
+FROM
+(
+    WITH toStartOfDay(toDateTime('2025-01-01 12:00:00')) AS d
+    SELECT d, category
+    FROM test_limit_by_all
+    ORDER BY d, category, value, name
+    LIMIT 2 BY ALL
+    SETTINGS enable_positional_arguments = 0
+)
+GROUP BY d, category
+ORDER BY d, category;
+
+SELECT id, category
+FROM test_limit_by_all
+ORDER BY id, category, value
+LIMIT 1,2 BY ALL;
+
+SELECT id, category
+FROM test_limit_by_all
+ORDER BY id, category, value
+LIMIT 2 OFFSET 1 BY ALL;
+
+SELECT id, category
+FROM test_limit_by_all
+ORDER BY value DESC
+LIMIT 1 BY ALL
+LIMIT 2;
+
+-- Only-aggregate SELECT -> expect syntax error 62
+SELECT count()
+FROM test_limit_by_all
+LIMIT 1 BY ALL; -- { serverError 62 }
+
+-- JOIN + ARRAY JOIN
+DROP TABLE IF EXISTS test_limit_by_all_tags;
+CREATE TABLE test_limit_by_all_tags (id Int32, tags Array(String)) ENGINE = Memory;
+INSERT INTO test_limit_by_all_tags VALUES (1, ['x','y']), (2, ['y']), (3, ['z']);
+
+EXPLAIN SYNTAX
+SELECT t.id, tag, sum(value) AS s
+FROM test_limit_by_all AS t
+LEFT JOIN test_limit_by_all_tags AS g USING (id)
+ARRAY JOIN g.tags AS tag
+GROUP BY t.id, tag
+ORDER BY t.id, tag
+LIMIT 1 BY ALL;
+
+SELECT t.id, tag
+FROM test_limit_by_all AS t
+LEFT JOIN test_limit_by_all_tags AS g USING (id)
+ARRAY JOIN g.tags AS tag
+ORDER BY t.id, tag, value
+LIMIT 1 BY ALL;
+
+DROP TABLE test_limit_by_all_tags;
+
+WITH toStartOfHour(toDateTime('2025-01-01 12:00:00')) AS h
+SELECT h, category
+FROM test_limit_by_all
+ORDER BY h, category, value
+LIMIT 1 BY ALL
+SETTINGS enable_positional_arguments = 0;
+
+SELECT id, category, value
+FROM test_limit_by_all
+ORDER BY id, category, value
+LIMIT 1,2 BY id;
+
+SELECT id, category, value
+FROM test_limit_by_all
+ORDER BY id, category, value
+LIMIT 2 OFFSET 1 BY id;
+
+EXPLAIN SYNTAX
+SELECT id, category, value
+FROM test_limit_by_all
+ORDER BY 1, 2, 3
+LIMIT 2 BY 1, 2
+SETTINGS enable_positional_arguments=1;
+
+SELECT id, category, value
+FROM test_limit_by_all
+ORDER BY id, category, value
+LIMIT -2;
+
+SELECT id, category, value
+FROM test_limit_by_all
+ORDER BY id, category, value
+LIMIT -2 OFFSET -1;
+
+SELECT id, category, value
+FROM test_limit_by_all
+ORDER BY id, category, value
+LIMIT -1 BY id;
+
+-- Should give no result
+SELECT id, category, value
+FROM test_limit_by_all
+ORDER BY id, category, value
+LIMIT 0 BY ALL;
+
+SELECT id, count() AS c
+FROM test_limit_by_all
+GROUP BY id, category
+HAVING c >= 1
+ORDER BY id, c DESC, category
+LIMIT 1 BY ALL;
+
+-- NULL key handling
+INSERT INTO test_limit_by_all VALUES (4, NULL, 10, 'n1'), (4, NULL, 20, 'n2');
+
+SELECT id, category
+FROM test_limit_by_all
+ORDER BY id, category NULLS FIRST, value
 LIMIT 1 BY ALL;
 
 DROP TABLE test_limit_by_all;


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

### Details

Added tests covering:
* Various LIMIT BY ALL and LIMIT BY cases
* Alias, ORDER BY, WHERE, HAVING, DISTINCT, and computed columns
* offset syntax variants (LIMIT a,b BY vs LIMIT b OFFSET a BY)
* GROUP BY ALL, aggregates, and WITH aliases
* JOIN + ARRAY JOIN interaction
* NULL-key handling and boundary cases (LIMIT 0, negative limits)

This builds on the coverage introduced in https://github.com/ClickHouse/ClickHouse/pull/84079
