### PR TITLE
Flush gzip buffer when cancelling http response buffer

### DIFF
--- a/src/Server/HTTP/WriteBufferFromHTTPServerResponse.cpp
+++ b/src/Server/HTTP/WriteBufferFromHTTPServerResponse.cpp
@@ -331,7 +331,10 @@ bool WriteBufferFromHTTPServerResponse::cancelWithException(HTTPServerRequest & 
 
             // this finish chunk with the error message in case of Transfer-Encoding: chunked
             if (use_compression_buffer)
+            {
                 compression_buffer->next();
+                compression_buffer->finalize();
+            }
             next();
 
             LOG_DEBUG(

--- a/tests/queries/0_stateless/02074_http_flush_compressed_buffers_on_cancel.reference
+++ b/tests/queries/0_stateless/02074_http_flush_compressed_buffers_on_cancel.reference
@@ -1,0 +1,2 @@
+zstd OK
+gzip OK

--- a/tests/queries/0_stateless/02074_http_flush_compressed_buffers_on_cancel.reference
+++ b/tests/queries/0_stateless/02074_http_flush_compressed_buffers_on_cancel.reference
@@ -1,2 +1,4 @@
 zstd OK
 gzip OK
+br OK
+deflate OK

--- a/tests/queries/0_stateless/02074_http_flush_compressed_buffers_on_cancel.sh
+++ b/tests/queries/0_stateless/02074_http_flush_compressed_buffers_on_cancel.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-random-settings
+# Tags: no-random-settings, long
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/02074_http_flush_compressed_buffers_on_cancel.sh
+++ b/tests/queries/0_stateless/02074_http_flush_compressed_buffers_on_cancel.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+echo "select throwIf(number > 10000000) + number check from numbers(10000005) format CSV" | ${CLICKHOUSE_CURL} "${CLICKHOUSE_URL}&query=&enable_http_compression=1" -H "Accept-Encoding: zstd" --compressed --data-binary @- | grep -q "__exception__" && echo 'zstd OK'
+echo "select throwIf(number > 10000000) + number check from numbers(10000005) format CSV" | ${CLICKHOUSE_CURL} "${CLICKHOUSE_URL}&query=&enable_http_compression=1" -H "Accept-Encoding: gzip" --compressed --data-binary @- | grep -q "__exception__" && echo 'gzip OK'

--- a/tests/queries/0_stateless/02074_http_flush_compressed_buffers_on_cancel.sh
+++ b/tests/queries/0_stateless/02074_http_flush_compressed_buffers_on_cancel.sh
@@ -7,3 +7,5 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 echo "select throwIf(number > 10000000) + number check from numbers(10000005) format CSV" | ${CLICKHOUSE_CURL} "${CLICKHOUSE_URL}&query=&enable_http_compression=1" -H "Accept-Encoding: zstd" --compressed --data-binary @- | grep -q "__exception__" && echo 'zstd OK'
 echo "select throwIf(number > 10000000) + number check from numbers(10000005) format CSV" | ${CLICKHOUSE_CURL} "${CLICKHOUSE_URL}&query=&enable_http_compression=1" -H "Accept-Encoding: gzip" --compressed --data-binary @- | grep -q "__exception__" && echo 'gzip OK'
+echo "select throwIf(number > 10000000) + number check from numbers(10000005) format CSV" | ${CLICKHOUSE_CURL} "${CLICKHOUSE_URL}&query=&enable_http_compression=1" -H "Accept-Encoding: br" --compressed --data-binary @- | grep -q "__exception__" && echo 'br OK'
+echo "select throwIf(number > 10000000) + number check from numbers(10000005) format CSV" | ${CLICKHOUSE_CURL} "${CLICKHOUSE_URL}&query=&enable_http_compression=1" -H "Accept-Encoding: deflate" --compressed --data-binary @- | grep -q "__exception__" && echo 'deflate OK'

--- a/tests/queries/0_stateless/02074_http_flush_compressed_buffers_on_cancel.sh
+++ b/tests/queries/0_stateless/02074_http_flush_compressed_buffers_on_cancel.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Tags: no-random-settings
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Flush buffers when sending an error in the middle of compressed stream in HTTP interface.

### Details
See https://github.com/ClickHouse/ClickHouse/issues/75175#issuecomment-3452255398

The problem is that `ZlibDeflatingWriteBuffer::nextImpl()` doesn't necessarily flush the buffer, we need to finalize it.
