### PR TITLE
Check cancellation flag before each Keeper request

### DIFF
--- a/src/Common/ZooKeeper/ZooKeeperImpl.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperImpl.cpp
@@ -105,6 +105,11 @@ namespace
     }
 }
 
+namespace DB::ErrorCodes
+{
+    extern const int QUERY_WAS_CANCELLED;
+}
+
 /** ZooKeeper wire protocol.
 
 Debugging example:
@@ -1355,6 +1360,9 @@ void ZooKeeper::finalize(bool error_send, bool error_receive, const String & rea
 
 void ZooKeeper::pushRequest(RequestInfo && info)
 {
+    if (CurrentThread::isInitialized() && CurrentThread::get().isQueryCanceled())
+        throw DB::Exception(DB::ErrorCodes::QUERY_WAS_CANCELLED, "Query was cancelled");
+
     try
     {
         info.request->create_ts = clock::now();


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Details
Many queries perform some Keeper requests in a cycle until a condition is met, such as checking table and selects from system tables. It can be helpful to check the cancellation flag before making these requests.
