### PR TITLE
Fix incorrect code in the `Backup` database engine

### DIFF
--- a/src/Common/quoteString.cpp
+++ b/src/Common/quoteString.cpp
@@ -7,7 +7,7 @@ namespace DB
 {
 String quoteString(std::string_view x)
 {
-    String res(x.size(), '\0');
+    String res(2 + x.size(), '\0');
     WriteBufferFromString wb(res);
     writeQuotedString(x, wb);
     return res;
@@ -15,7 +15,7 @@ String quoteString(std::string_view x)
 
 String quoteStringSingleQuoteWithSingleQuote(std::string_view x)
 {
-    String res(x.size(), '\0');
+    String res(2 + x.size(), '\0');
     WriteBufferFromString wb(res);
     writeQuotedStringPostgreSQL(x, wb);
     return res;
@@ -24,7 +24,7 @@ String quoteStringSingleQuoteWithSingleQuote(std::string_view x)
 
 String doubleQuoteString(StringRef x)
 {
-    String res(x.size, '\0');
+    String res(2 + x.size, '\0');
     WriteBufferFromString wb(res);
     writeDoubleQuotedString(x, wb);
     return res;
@@ -33,7 +33,7 @@ String doubleQuoteString(StringRef x)
 
 String backQuote(StringRef x)
 {
-    String res(x.size, '\0');
+    String res(2 + x.size, '\0');
     {
         WriteBufferFromString wb(res);
         writeBackQuotedString(x, wb);
@@ -44,7 +44,7 @@ String backQuote(StringRef x)
 
 String backQuoteIfNeed(StringRef x)
 {
-    String res(x.size, '\0');
+    String res(2 + x.size, '\0');
     {
         WriteBufferFromString wb(res);
         writeProbablyBackQuotedString(x, wb);
@@ -55,7 +55,7 @@ String backQuoteIfNeed(StringRef x)
 
 String backQuoteMySQL(StringRef x)
 {
-    String res(x.size, '\0');
+    String res(2 + x.size, '\0');
     {
         WriteBufferFromString wb(res);
         writeBackQuotedStringMySQL(x, wb);

--- a/src/Databases/DatabaseBackup.cpp
+++ b/src/Databases/DatabaseBackup.cpp
@@ -411,11 +411,8 @@ ASTPtr DatabaseBackup::getCreateDatabaseQuery() const
 {
     const auto & settings = getContext()->getSettingsRef();
 
-    std::string creation_args;
-    creation_args += fmt::format("'{}'", config.database_name);
-    creation_args += fmt::format(", '{}'", config.backup_info.toString());
-
-    const String query = fmt::format("CREATE DATABASE {} ENGINE = Backup({})", backQuoteIfNeed(getDatabaseName()), creation_args);
+    const String query = fmt::format("CREATE DATABASE {} ENGINE = Backup({}, {})",
+        backQuoteIfNeed(getDatabaseName()), quoteString(config.database_name), quoteString(config.backup_info.toString()));
 
     ParserCreateQuery parser;
     ASTPtr ast = parseQuery(parser,


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix incorrect code in the Backup database engine when it can generate an invalid query with SHOW CREATE DATABASE or when querying engine_full from system.databases. Closes #89477.

### Details
This is a rarely used feature not related to actual backups. The fix addresses a SQL self-injection vulnerability in the Backup database engine.
