### PR TITLE
`create_table_empty_primary_key_by_default` did not work for the default table engine

### DIFF
--- a/src/Storages/MergeTree/registerStorageMergeTree.cpp
+++ b/src/Storages/MergeTree/registerStorageMergeTree.cpp
@@ -220,7 +220,7 @@ static TableZnodeInfo extractZooKeeperPathAndReplicaNameFromEngineArgs(
 {
     chassert(isReplicated(engine_name));
 
-    bool is_extended_storage_def = isExtendedStorageDef(query);
+    bool is_extended_storage_def = engine_args.empty() || isExtendedStorageDef(query);
 
     if (is_extended_storage_def)
     {
@@ -248,7 +248,6 @@ static TableZnodeInfo extractZooKeeperPathAndReplicaNameFromEngineArgs(
     {
         bool is_replicated_database = local_context->getClientInfo().query_kind == ClientInfo::QueryKind::SECONDARY_QUERY &&
             DatabaseCatalog::instance().getDatabase(table_id.database_name)->getEngineName() == "Replicated";
-
 
         /// Get path and name from engine arguments
         auto * ast_zk_path = engine_args[arg_num]->as<ASTLiteral>();
@@ -392,7 +391,7 @@ static StoragePtr create(const StorageFactory::Arguments & args)
         *  - Additional MergeTreeSettings in the SETTINGS clause;
         */
 
-    bool is_extended_storage_def = isExtendedStorageDef(args.query);
+    bool is_extended_storage_def = args.engine_args.empty() || isExtendedStorageDef(args.query);
 
     const Settings & local_settings = args.getLocalContext()->getSettingsRef();
 

--- a/tests/queries/0_stateless/02184_default_table_engine.sql
+++ b/tests/queries/0_stateless/02184_default_table_engine.sql
@@ -8,7 +8,7 @@ SHOW CREATE TABLE table_02184;
 DROP TABLE table_02184;
 
 SET default_table_engine = 'MergeTree';
-CREATE TABLE table_02184 (x UInt8); --{serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH}
+CREATE TABLE table_02184 (x UInt8); --{serverError BAD_ARGUMENTS}
 CREATE TABLE table_02184 (x UInt8, PRIMARY KEY (x));
 SHOW CREATE TABLE table_02184;
 DROP TABLE table_02184;

--- a/tests/queries/0_stateless/02932_refreshable_materialized_views_2.sh
+++ b/tests/queries/0_stateless/02932_refreshable_materialized_views_2.sh
@@ -192,7 +192,7 @@ $CLICKHOUSE_CLIENT -q "
 
 # Failing to create inner table.
 $CLICKHOUSE_CLIENT -q "
-    create materialized view n refresh every 1 second (x Int64) engine MergeTree as select 1 as x from numbers(2); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH}"
+    create materialized view n refresh every 1 second (x Int64) engine MergeTree as select 1 as x from numbers(2); -- { serverError BAD_ARGUMENTS }"
 $CLICKHOUSE_CLIENT -q "
     create materialized view n refresh every 1 second (x Int64) engine MergeTree order by x as select 1 as x from numbers(2);
     drop table n;"

--- a/tests/queries/0_stateless/03704_default_empty_order_by.sql
+++ b/tests/queries/0_stateless/03704_default_empty_order_by.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS test;
+SET create_table_empty_primary_key_by_default = 1;
+CREATE TABLE test (x UInt8);


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
In previous versions, the setting `create_table_empty_primary_key_by_default` was ineffective when you didn't specify the table engine in the CREATE TABLE query.
