### PR TITLE
fix logical error when low cardinality use statistics

### DIFF
--- a/src/Storages/Statistics/StatisticsCountMinSketch.cpp
+++ b/src/Storages/Statistics/StatisticsCountMinSketch.cpp
@@ -26,7 +26,7 @@ static constexpr auto num_buckets = 2718uz;
 StatisticsCountMinSketch::StatisticsCountMinSketch(const SingleStatisticsDescription & description, const DataTypePtr & data_type_)
     : IStatistics(description)
     , sketch(num_hashes, num_buckets)
-    , data_type(removeNullable(data_type_))
+    , data_type(removeLowCardinalityAndNullable(data_type_))
 {
 }
 
@@ -89,8 +89,7 @@ void StatisticsCountMinSketch::deserialize(ReadBuffer & buf)
 
 bool countMinSketchStatisticsValidator(const SingleStatisticsDescription & /*description*/, const DataTypePtr & data_type)
 {
-    DataTypePtr inner_data_type = removeNullable(data_type);
-    inner_data_type = removeLowCardinalityAndNullable(inner_data_type);
+    DataTypePtr inner_data_type = removeLowCardinalityAndNullable(data_type);
     return inner_data_type->isValueRepresentedByNumber() || isStringOrFixedString(inner_data_type);
 }
 

--- a/tests/queries/0_stateless/03703_statistics_low_cardinality.sql
+++ b/tests/queries/0_stateless/03703_statistics_low_cardinality.sql
@@ -1,4 +1,6 @@
+-- Tags: no-fasttest
 set allow_statistics_optimize = 1;
+
 create table t (a Nullable(Int), b LowCardinality(Nullable(String))) Engine = MergeTree() ORDER BY () settings auto_statistics_types = 'minmax,uniq,tdigest,countmin';
 insert into t values (1 , '1'), (2, '2'), (3, '3');
 select * from t where a > 1 and b = '1';

--- a/tests/queries/0_stateless/03703_statistics_low_cardinality.sql
+++ b/tests/queries/0_stateless/03703_statistics_low_cardinality.sql
@@ -1,0 +1,4 @@
+set allow_statistics_optimize = 1;
+create table t (a Nullable(Int), b LowCardinality(Nullable(String))) Engine = MergeTree() ORDER BY () settings auto_statistics_types = 'minmax,uniq,tdigest,countmin';
+insert into t values (1 , '1'), (2, '2'), (3, '3');
+select * from t where a > 1 and b = '1';


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Fix Statistics countmin does not support estimate data type of LowCardinality(Nullable(String)) LOGICAL_ERROR.
