### PR TITLE
It is no longer possible to use the old Azure client

### DIFF
--- a/src/Client/BuzzHouse/Generator/SessionSettings.cpp
+++ b/src/Client/BuzzHouse/Generator/SessionSettings.cpp
@@ -299,7 +299,6 @@ std::unordered_map<String, CHSetting> serverSettings = {
     {"async_insert_use_adaptive_busy_timeout", trueOrFalseSettingNoOracle},
     {"async_query_sending_for_remote", trueOrFalseSetting},
     {"async_socket_for_remote", trueOrFalseSetting},
-    {"azure_sdk_use_native_client", trueOrFalseSetting},
     {"cache_warmer_threads", threadSetting},
     {"calculate_text_stack_trace", trueOrFalseSettingNoOracle},
     {"cancel_http_readonly_queries_on_client_close", trueOrFalseSettingNoOracle},

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -592,9 +592,6 @@ Idleness timeout for sending and receiving data to/from azure. Fail if a single 
     DECLARE(UInt64, azure_connect_timeout_ms, S3::DEFAULT_CONNECT_TIMEOUT_MS, R"(
 Connection timeout for host from azure disks.
 )", 0) \
-    DECLARE(Bool, azure_sdk_use_native_client, true, R"(
-Use clickhouse native HTTP client for Azure SDK.
-)", 0) \
     DECLARE(Bool, s3_validate_request_settings, true, R"(
 Enables s3 request settings validation.
 Possible values:
@@ -7287,7 +7284,8 @@ Sets the evaluation time to be used with promql dialect. 'auto' means the curren
     MAKE_OBSOLETE(M, Bool, enable_dynamic_type, true) \
     MAKE_OBSOLETE(M, Bool, enable_json_type, true) \
     MAKE_OBSOLETE(M, Bool, s3_slow_all_threads_after_retryable_error, false) \
-    \
+    MAKE_OBSOLETE(M, Bool, azure_sdk_use_native_client, true) \
+\
     /* moved to config.xml: see also src/Core/ServerSettings.h */ \
     MAKE_DEPRECATED_BY_SERVER_CONFIG(M, UInt64, background_buffer_flush_schedule_pool_size, 16) \
     MAKE_DEPRECATED_BY_SERVER_CONFIG(M, UInt64, background_pool_size, 16) \

--- a/src/Disks/ObjectStorages/AzureBlobStorage/AzureBlobStorageCommon.cpp
+++ b/src/Disks/ObjectStorages/AzureBlobStorage/AzureBlobStorageCommon.cpp
@@ -6,8 +6,6 @@
 #include <azure/identity/workload_identity_credential.hpp>
 #include <azure/storage/blobs/blob_options.hpp>
 #include <azure/storage/blobs/blob_responses.hpp>
-#include <azure/storage/blobs/rest_client.hpp>
-#include <azure/core/credentials/credentials.hpp>
 
 #endif
 
@@ -585,20 +583,6 @@ std::unique_ptr<RequestSettings> getRequestSettings(const Poco::Util::AbstractCo
     settings->sdk_retry_max_backoff_ms = config.getUInt64(config_prefix + ".retry_max_backoff_ms", settings_ref[Setting::azure_sdk_retry_max_backoff_ms]);
 
     settings->check_objects_after_upload = config.getBool(config_prefix + ".check_objects_after_upload", settings_ref[Setting::azure_check_objects_after_upload]);
-
-
-#if USE_AZURE_BLOB_STORAGE
-    if (config.has(config_prefix + ".curl_ip_resolve"))
-    {
-        auto value = config.getString(config_prefix + ".curl_ip_resolve");
-        if (value == "ipv4")
-            settings->curl_ip_resolve = RequestSettings::CurlOptions::CURL_IPRESOLVE_V4;
-        else if (value == "ipv6")
-            settings->curl_ip_resolve = RequestSettings::CurlOptions::CURL_IPRESOLVE_V6;
-        else
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unexpected value for option 'curl_ip_resolve': {}. Expected one of 'ipv4' or 'ipv6'", value);
-    }
-#endif
 
     return settings;
 }

--- a/src/Disks/ObjectStorages/AzureBlobStorage/AzureBlobStorageCommon.cpp
+++ b/src/Disks/ObjectStorages/AzureBlobStorage/AzureBlobStorageCommon.cpp
@@ -77,8 +77,6 @@ namespace Setting
     extern const SettingsUInt64 http_max_fields;
     extern const SettingsUInt64 http_max_field_name_size;
     extern const SettingsUInt64 http_max_field_value_size;
-    extern const SettingsBool azure_sdk_use_native_client;
-
     extern const SettingsUInt64 azure_max_get_rps;
     extern const SettingsUInt64 azure_max_get_burst;
     extern const SettingsUInt64 azure_max_put_rps;
@@ -349,76 +347,66 @@ BlobClientOptions getClientOptions(
     client_options.Retry = retry_options;
     client_options.ClickhouseOptions = Azure::Storage::Blobs::ClickhouseClientOptions{.IsClientForDisk=for_disk};
 
-    if (settings[Setting::azure_sdk_use_native_client])
+    // Initialize HTTP request throttling
+    HTTPRequestThrottler request_throttler;
+
+    if (settings[Setting::azure_max_get_rps] > 0 || settings[Setting::azure_max_get_burst] > 0)
     {
-        // Initialize HTTP request throttling
-        HTTPRequestThrottler request_throttler;
+        request_throttler.get_throttler = std::make_shared<Throttler>(
+            settings[Setting::azure_max_get_rps],
+            settings[Setting::azure_max_get_burst],
+            ProfileEvents::AzureGetRequestThrottlerCount,
+            ProfileEvents::AzureGetRequestThrottlerSleepMicroseconds);
+        request_throttler.get_blocked = ProfileEvents::AzureGetRequestThrottlerBlocked;
 
-        if (settings[Setting::azure_max_get_rps] > 0 || settings[Setting::azure_max_get_burst] > 0)
+        // Update additional profile events for DiskAzure
+        if (for_disk)
         {
-            request_throttler.get_throttler = std::make_shared<Throttler>(
-                settings[Setting::azure_max_get_rps],
-                settings[Setting::azure_max_get_burst],
-                ProfileEvents::AzureGetRequestThrottlerCount,
-                ProfileEvents::AzureGetRequestThrottlerSleepMicroseconds);
-            request_throttler.get_blocked = ProfileEvents::AzureGetRequestThrottlerBlocked;
-
-            // Update additional profile events for DiskAzure
-            if (for_disk)
-            {
-                request_throttler.disk_get_amount = ProfileEvents::DiskAzureGetRequestThrottlerCount;
-                request_throttler.disk_get_blocked = ProfileEvents::DiskAzureGetRequestThrottlerBlocked;
-                request_throttler.disk_get_sleep_us = ProfileEvents::DiskAzureGetRequestThrottlerSleepMicroseconds;
-            }
+            request_throttler.disk_get_amount = ProfileEvents::DiskAzureGetRequestThrottlerCount;
+            request_throttler.disk_get_blocked = ProfileEvents::DiskAzureGetRequestThrottlerBlocked;
+            request_throttler.disk_get_sleep_us = ProfileEvents::DiskAzureGetRequestThrottlerSleepMicroseconds;
         }
-
-        if (settings[Setting::azure_max_put_rps] > 0 || settings[Setting::azure_max_put_burst] > 0)
-        {
-            request_throttler.put_throttler = std::make_shared<Throttler>(
-                settings[Setting::azure_max_put_rps],
-                settings[Setting::azure_max_put_burst],
-                ProfileEvents::AzurePutRequestThrottlerCount,
-                ProfileEvents::AzurePutRequestThrottlerSleepMicroseconds);
-            request_throttler.put_blocked = ProfileEvents::AzurePutRequestThrottlerBlocked;
-
-            // Update additional profile events for DiskAzure
-            if (for_disk)
-            {
-                request_throttler.disk_put_amount = ProfileEvents::DiskAzurePutRequestThrottlerCount;
-                request_throttler.disk_put_blocked = ProfileEvents::DiskAzurePutRequestThrottlerBlocked;
-                request_throttler.disk_put_sleep_us = ProfileEvents::DiskAzurePutRequestThrottlerSleepMicroseconds;
-            }
-        }
-
-        auto http_keep_alive_seconds = static_cast<size_t>(context->getServerSettings()[ServerSetting::keep_alive_timeout].totalSeconds());
-        auto tcp_keep_alive_milliseconds = static_cast<size_t>(settings[Setting::tcp_keep_alive_timeout].totalMilliseconds());
-
-        PocoAzureHTTPClientConfiguration conf{
-            .remote_host_filter = context->getRemoteHostFilter(),
-            .max_redirects = settings[Setting::azure_max_redirects],
-            .for_disk_azure = for_disk,
-            .request_throttler = request_throttler,
-            .extra_headers = HTTPHeaderEntries{}, /// No extra headers so far
-            .connect_timeout_ms = settings[Setting::azure_connect_timeout_ms],
-            .request_timeout_ms = settings[Setting::azure_request_timeout_ms],
-            .tcp_keep_alive_interval_ms = tcp_keep_alive_milliseconds,
-            .use_adaptive_timeouts = settings[Setting::azure_use_adaptive_timeouts],
-            .http_keep_alive_timeout = http_keep_alive_seconds, // Convert seconds to milliseconds
-            .http_keep_alive_max_requests = context->getServerSettings()[ServerSetting::max_keep_alive_requests],
-            .http_max_fields = settings[Setting::http_max_fields],
-            .http_max_field_name_size = settings[Setting::http_max_field_name_size],
-            .http_max_field_value_size = settings[Setting::http_max_field_value_size]};
-
-        client_options.Transport.Transport = std::make_shared<PocoAzureHTTPClient>(conf);
-    }
-    else /// TODO (alesapin) Remove Curl client in future releases
-    {
-        Azure::Core::Http::CurlTransportOptions curl_options;
-        curl_options.NoSignal = true;
-        curl_options.IPResolve = request_settings.curl_ip_resolve;
-        client_options.Transport.Transport = std::make_shared<Azure::Core::Http::CurlTransport>(curl_options);
     }
 
+    if (settings[Setting::azure_max_put_rps] > 0 || settings[Setting::azure_max_put_burst] > 0)
+    {
+        request_throttler.put_throttler = std::make_shared<Throttler>(
+            settings[Setting::azure_max_put_rps],
+            settings[Setting::azure_max_put_burst],
+            ProfileEvents::AzurePutRequestThrottlerCount,
+            ProfileEvents::AzurePutRequestThrottlerSleepMicroseconds);
+        request_throttler.put_blocked = ProfileEvents::AzurePutRequestThrottlerBlocked;
+
+        // Update additional profile events for DiskAzure
+        if (for_disk)
+        {
+            request_throttler.disk_put_amount = ProfileEvents::DiskAzurePutRequestThrottlerCount;
+            request_throttler.disk_put_blocked = ProfileEvents::DiskAzurePutRequestThrottlerBlocked;
+            request_throttler.disk_put_sleep_us = ProfileEvents::DiskAzurePutRequestThrottlerSleepMicroseconds;
+        }
+    }
+
+    auto http_keep_alive_seconds = static_cast<size_t>(context->getServerSettings()[ServerSetting::keep_alive_timeout].totalSeconds());
+    auto tcp_keep_alive_milliseconds = static_cast<size_t>(settings[Setting::tcp_keep_alive_timeout].totalMilliseconds());
+
+    PocoAzureHTTPClientConfiguration conf
+    {
+        .remote_host_filter = context->getRemoteHostFilter(),
+        .max_redirects = settings[Setting::azure_max_redirects],
+        .for_disk_azure = for_disk,
+        .request_throttler = request_throttler,
+        .extra_headers = HTTPHeaderEntries{}, /// No extra headers so far
+        .connect_timeout_ms = settings[Setting::azure_connect_timeout_ms],
+        .request_timeout_ms = settings[Setting::azure_request_timeout_ms],
+        .tcp_keep_alive_interval_ms = tcp_keep_alive_milliseconds,
+        .use_adaptive_timeouts = settings[Setting::azure_use_adaptive_timeouts],
+        .http_keep_alive_timeout = http_keep_alive_seconds, // Convert seconds to milliseconds
+        .http_keep_alive_max_requests = context->getServerSettings()[ServerSetting::max_keep_alive_requests],
+        .http_max_fields = settings[Setting::http_max_fields],
+        .http_max_field_name_size = settings[Setting::http_max_field_name_size],
+        .http_max_field_value_size = settings[Setting::http_max_field_value_size]};
+
+    client_options.Transport.Transport = std::make_shared<PocoAzureHTTPClient>(conf);
     return client_options;
 }
 

--- a/src/Disks/ObjectStorages/AzureBlobStorage/AzureBlobStorageCommon.h
+++ b/src/Disks/ObjectStorages/AzureBlobStorage/AzureBlobStorageCommon.h
@@ -8,7 +8,6 @@
 #include <azure/storage/blobs/blob_client.hpp>
 #include <azure/storage/blobs/blob_options.hpp>
 #include <azure/storage/blobs/blob_service_client.hpp>
-#include <azure/core/http/curl_transport.hpp>
 
 #endif
 
@@ -16,7 +15,7 @@
 #include <Poco/Util/AbstractConfiguration.h>
 #include <Disks/ObjectStorages/IObjectStorage.h>
 #include <Interpreters/Context_fwd.h>
-#include <base/strong_typedef.h>
+
 #include <filesystem>
 #include <variant>
 
@@ -56,11 +55,6 @@ struct RequestSettings
     bool read_only = false;
     size_t http_keep_alive_timeout = DEFAULT_HTTP_KEEP_ALIVE_TIMEOUT;
     size_t http_keep_alive_max_requests = DEFAULT_HTTP_KEEP_ALIVE_MAX_REQUEST;
-
-#if USE_AZURE_BLOB_STORAGE
-    using CurlOptions = Azure::Core::Http::CurlTransportOptions;
-    CurlOptions::CurlOptIPResolve curl_ip_resolve = CurlOptions::CURL_IPRESOLVE_WHATEVER;
-#endif
 };
 
 struct Endpoint


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Since 25.11, the Azure Blob Storage client uses the new implementation unconditionally.
