### PR TITLE
Introduce per-table cache of ColumnsDescription for parts to reduce memory usage

### DIFF
--- a/src/Common/CurrentMetrics.cpp
+++ b/src/Common/CurrentMetrics.cpp
@@ -353,6 +353,7 @@
     M(MergeJoinBlocksCacheCount, "Total cached blocks in MergeJoin") \
     M(BcryptCacheBytes, "Total size of the bcrypt authentication cache in bytes") \
     M(BcryptCacheSize, "Total number of entries in the bcrypt authentication cache") \
+    M(ColumnsDescriptionsCacheSize, "Size of ColumnsDescriptions cache (per-table cache)") \
     M(S3Requests, "S3 requests count") \
     M(KeeperAliveConnections, "Number of alive connections") \
     M(KeeperOutstandingRequests, "Number of outstanding requests") \

--- a/src/Storages/MergeTree/IMergeTreeDataPart.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.h
@@ -142,8 +142,8 @@ public:
     void writeMetadataVersion(ContextPtr local_context, int32_t metadata_version, bool sync);
 
     const NamesAndTypesList & getColumns() const { return columns; }
-    const ColumnsDescription & getColumnsDescription() const { return columns_description; }
-    const ColumnsDescription & getColumnsDescriptionWithCollectedNested() const { return columns_description_with_collected_nested; }
+    const ColumnsDescription & getColumnsDescription() const { return *columns_description; }
+    const ColumnsDescription & getColumnsDescriptionWithCollectedNested() const { return *columns_description_with_collected_nested; }
     const ColumnsSubstreams & getColumnsSubstreams() const { return columns_substreams; }
     StorageMetadataPtr getMetadataSnapshot() const;
 
@@ -715,11 +715,11 @@ private:
 
     /// Columns description for more convenient access
     /// to columns by name and getting subcolumns.
-    ColumnsDescription columns_description;
+    std::shared_ptr<const ColumnsDescription> columns_description;
 
     /// The same as above but after call of Nested::collect().
     /// It is used while reading from wide parts.
-    ColumnsDescription columns_description_with_collected_nested;
+    std::shared_ptr<const ColumnsDescription> columns_description_with_collected_nested;
 
     /// Small state of finalized statistics for suitable statistics types.
     /// Lazily initialized on a first access.

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -114,6 +114,7 @@
 #include <unordered_set>
 #include <filesystem>
 
+#include <boost/container_hash/hash.hpp>
 #include <fmt/format.h>
 #include <Poco/Logger.h>
 #include <Poco/Net/NetException.h>
@@ -164,6 +165,7 @@ namespace CurrentMetrics
     extern const Metric FreezePartThreads;
     extern const Metric FreezePartThreadsActive;
     extern const Metric FreezePartThreadsScheduled;
+    extern const Metric ColumnsDescriptionsCacheSize;
 }
 
 
@@ -619,6 +621,7 @@ MergeTreeData::MergeTreeData(
     , format_version(date_column_name.empty() ? MERGE_TREE_DATA_MIN_FORMAT_VERSION_WITH_CUSTOM_PARTITIONING : MERGE_TREE_DATA_OLD_FORMAT_VERSION)
     , merging_params(merging_params_)
     , require_part_metadata(require_part_metadata_)
+    , columns_descriptions_metric_handle(CurrentMetrics::ColumnsDescriptionsCacheSize)
     , broken_part_callback(broken_part_callback_)
     , log(table_id_.getNameForLogs())
     , storage_settings(std::move(storage_settings_))
@@ -10246,6 +10249,59 @@ void MergeTreeData::verifySortingKey(const KeyDescription & sorting_key)
             throw Exception(ErrorCodes::DATA_TYPE_CANNOT_BE_USED_IN_KEY, "Column with type {} is not allowed in key expression", data_type->getCustomName()->getName());
     }
 }
+
+size_t MergeTreeData::NamesAndTypesListHash::operator()(const NamesAndTypesList & list) const noexcept
+{
+    size_t hash = 0;
+    for (const auto & name_type : list)
+        boost::hash_combine(hash, StringRefHash{}(std::string_view(name_type.name)));
+    return hash;
+}
+
+MergeTreeData::ColumnsDescriptionCache MergeTreeData::getColumnsDescriptionForColumns(const NamesAndTypesList & columns) const
+{
+    std::lock_guard lock(columns_descriptions_cache_mutex);
+    if (auto it = columns_descriptions_cache.find(columns); it != columns_descriptions_cache.end())
+        return it->second;
+
+    ColumnsDescriptionCache cache
+    {
+        .original = std::make_shared<ColumnsDescription>(columns),
+        .with_collected_nested = std::make_shared<ColumnsDescription>(Nested::collect(columns)),
+    };
+    if (*cache.with_collected_nested == *cache.original)
+        cache.with_collected_nested = cache.original;
+    auto [_, inserted] = columns_descriptions_cache.emplace(columns, cache);
+    columns_descriptions_metric_handle.add(inserted);
+    return cache;
+}
+
+void MergeTreeData::decrefColumnsDescriptionForColumns(const NamesAndTypesList & columns) const
+{
+    std::lock_guard lock(columns_descriptions_cache_mutex);
+    if (auto it = columns_descriptions_cache.find(columns); it != columns_descriptions_cache.end())
+    {
+        if (it->second.original.use_count() != it->second.with_collected_nested.use_count())
+        {
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Reference count for columns description cache does not match (original: {}, with_collected_nested: {})",
+                it->second.original.use_count(),
+                it->second.with_collected_nested.use_count());
+        }
+        /// 1 in the container + 1 in the iterator
+        if (it->second.original.use_count() == 2)
+        {
+            columns_descriptions_cache.erase(it);
+            columns_descriptions_metric_handle.sub(1);
+        }
+    }
+}
+
+size_t MergeTreeData::getColumnsDescriptionsCacheSize() const
+{
+    std::lock_guard lock(columns_descriptions_cache_mutex);
+    return columns_descriptions_cache.size();
+}
+
 
 static void updateMutationsCounters(MutationCounters & mutation_counters, const MutationCommands & commands, Int64 increment)
 {

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <mutex>
+#include <tuple>
 #include <base/defines.h>
+#include <Common/AggregatedMetrics.h>
 #include <Common/SimpleIncrement.h>
 #include <Common/SharedMutex.h>
 #include <Common/MultiVersion.h>
@@ -1365,6 +1367,26 @@ protected:
         are_columns_and_secondary_indices_sizes_calculated = false;
     }
 
+private:
+    struct NamesAndTypesListHash
+    {
+        size_t operator()(const NamesAndTypesList & list) const noexcept;
+    };
+    struct ColumnsDescriptionCache
+    {
+        std::shared_ptr<const ColumnsDescription> original;
+        std::shared_ptr<const ColumnsDescription> with_collected_nested;
+    };
+    mutable AggregatedMetrics::MetricHandle columns_descriptions_metric_handle;
+    mutable std::mutex columns_descriptions_cache_mutex;
+    mutable std::unordered_map<NamesAndTypesList, ColumnsDescriptionCache, NamesAndTypesListHash> columns_descriptions_cache TSA_GUARDED_BY(columns_descriptions_cache_mutex);
+
+public:
+    ColumnsDescriptionCache getColumnsDescriptionForColumns(const NamesAndTypesList & columns) const;
+    void decrefColumnsDescriptionForColumns(const NamesAndTypesList & columns) const;
+    size_t getColumnsDescriptionsCacheSize() const;
+
+protected:
     /// Engine-specific methods
     BrokenPartCallback broken_part_callback;
 

--- a/src/Storages/System/StorageSystemTables.cpp
+++ b/src/Storages/System/StorageSystemTables.cpp
@@ -211,6 +211,7 @@ StorageSystemTables::StorageSystemTables(const StorageID & table_id_)
         {"active_on_fly_data_mutations", std::make_shared<DataTypeUInt64>(), "Total number of active data mutations (UPDATEs and DELETEs) suitable for applying on the fly."},
         {"active_on_fly_alter_mutations", std::make_shared<DataTypeUInt64>(), "Total number of active alter mutations (MODIFY COLUMNs) suitable for applying on the fly."},
         {"active_on_fly_metadata_mutations", std::make_shared<DataTypeUInt64>(), "Total number of active metadata mutations (RENAMEs) suitable for applying on the fly."},
+        {"columns_descriptions_cache_size", std::make_shared<DataTypeUInt64>(), "Size of columns description cache for *MergeTree tables"},
         {"lifetime_rows", std::make_shared<DataTypeNullable>(std::make_shared<DataTypeUInt64>()),
             "Total number of rows INSERTed since server start (only for Buffer tables)."
         },
@@ -764,6 +765,15 @@ protected:
                         if (columns_mask[src_index++])
                             res_columns[res_index++]->insertDefault();
                     }
+                }
+
+                // columns_descriptions_cache_size
+                if (columns_mask[src_index++])
+                {
+                    if (table_merge_tree)
+                        res_columns[res_index++]->insert(table_merge_tree->getColumnsDescriptionsCacheSize());
+                    else
+                        res_columns[res_index++]->insertDefault();
                 }
 
                 if (columns_mask[src_index++])

--- a/tests/queries/0_stateless/02117_show_create_table_system.reference
+++ b/tests/queries/0_stateless/02117_show_create_table_system.reference
@@ -1156,6 +1156,7 @@ CREATE TABLE system.tables
     `active_on_fly_data_mutations` UInt64,
     `active_on_fly_alter_mutations` UInt64,
     `active_on_fly_metadata_mutations` UInt64,
+    `columns_descriptions_cache_size` UInt64,
     `lifetime_rows` Nullable(UInt64),
     `lifetime_bytes` Nullable(UInt64),
     `comment` String,

--- a/tests/queries/0_stateless/03673_columns_description_cache.reference
+++ b/tests/queries/0_stateless/03673_columns_description_cache.reference
@@ -1,0 +1,32 @@
+0
+-- { echoOn }
+create table t_mt (key Int) engine=MergeTree() order by ();
+select columns_descriptions_cache_size from system.tables where database = currentDatabase() and table = 't_mt';
+0
+insert into t_mt values (1);
+select columns_descriptions_cache_size from system.tables where database = currentDatabase() and table = 't_mt';
+1
+insert into t_mt values (2);
+select columns_descriptions_cache_size from system.tables where database = currentDatabase() and table = 't_mt';
+1
+alter table t_mt add column value String settings mutations_sync=2;
+insert into t_mt values (10, '10');
+select columns_descriptions_cache_size from system.tables where database = currentDatabase() and table = 't_mt';
+2
+insert into t_mt values (20, '20');
+select columns_descriptions_cache_size from system.tables where database = currentDatabase() and table = 't_mt';
+2
+-- now let's try to remove ColumnsDescription with old structure
+alter table t_mt detach part 'all_1_1_0';
+alter table t_mt detach part 'all_2_2_0';
+select columns_descriptions_cache_size from system.tables where database = currentDatabase() and table = 't_mt';
+1
+-- reattach
+detach table t_mt;
+select columns_descriptions_cache_size from system.tables where database = currentDatabase() and table = 't_mt';
+attach table t_mt;
+select columns_descriptions_cache_size from system.tables where database = currentDatabase() and table = 't_mt';
+1
+-- system.metrics
+select value > 0 from system.metrics where metric = 'ColumnsDescriptionsCacheSize';
+1

--- a/tests/queries/0_stateless/03673_columns_description_cache.sql
+++ b/tests/queries/0_stateless/03673_columns_description_cache.sql
@@ -1,0 +1,31 @@
+-- Cache is only for MergeTree
+drop table if exists t_mem;
+create table t_mem (key Int) engine=Memory();
+insert into t_mem values (1);
+select columns_descriptions_cache_size from system.tables where database = currentDatabase() and table = 't_mem';
+
+-- MergeTree
+drop table if exists t_mt;
+-- { echoOn }
+create table t_mt (key Int) engine=MergeTree() order by ();
+select columns_descriptions_cache_size from system.tables where database = currentDatabase() and table = 't_mt';
+insert into t_mt values (1);
+select columns_descriptions_cache_size from system.tables where database = currentDatabase() and table = 't_mt';
+insert into t_mt values (2);
+select columns_descriptions_cache_size from system.tables where database = currentDatabase() and table = 't_mt';
+alter table t_mt add column value String settings mutations_sync=2;
+insert into t_mt values (10, '10');
+select columns_descriptions_cache_size from system.tables where database = currentDatabase() and table = 't_mt';
+insert into t_mt values (20, '20');
+select columns_descriptions_cache_size from system.tables where database = currentDatabase() and table = 't_mt';
+-- now let's try to remove ColumnsDescription with old structure
+alter table t_mt detach part 'all_1_1_0';
+alter table t_mt detach part 'all_2_2_0';
+select columns_descriptions_cache_size from system.tables where database = currentDatabase() and table = 't_mt';
+-- reattach
+detach table t_mt;
+select columns_descriptions_cache_size from system.tables where database = currentDatabase() and table = 't_mt';
+attach table t_mt;
+select columns_descriptions_cache_size from system.tables where database = currentDatabase() and table = 't_mt';
+-- system.metrics
+select value > 0 from system.metrics where metric = 'ColumnsDescriptionsCacheSize';


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Introduce a per-table cache of `ColumnsDescription` for parts, reducing memory usage when tables contain many parts and many columns.

### Details
Each `part` currently stores its own `ColumnsDescription` (information about all columns). This includes not only full column metadata (including comments), but also `IHints`, which are used for correcting user input and are not trivial to decouple.

When a table has many columns, this structure becomes large, and storing a full copy for every part leads to significant memory consumption.

In one production setup, **12 GiB** out of **73 GiB** of memory was occupied by `ColumnsDescription` objects for **20 K parts with 6.5 M part columns**.

As another example, even on an empty server with merges stopped, `metric_log` alone could cause the server to consume roughly **512 MiB** over a few hours while doing almost nothing.