### PR TITLE
Update doc on building ClickHouse on Linux

### DIFF
--- a/docs/en/development/build.md
+++ b/docs/en/development/build.md
@@ -38,7 +38,7 @@ You can optionally install ccache to let the build reuse already compiled object
 
 ```bash
 sudo apt-get update
-sudo apt-get install git cmake ccache python3 ninja-build nasm yasm gawk lsb-release wget software-properties-common gnupg
+sudo apt-get install build-essential git cmake ccache python3 ninja-build nasm yasm gawk lsb-release wget software-properties-common gnupg
 ```
 
 ## Install the Clang compiler {#install-the-clang-compiler}


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

If you try to build the ClickHouse binary without `build-essentials` on fresh ubuntu LTS, your cmake will fail as no pthread library is installed.

In my fresh Ubuntu 24.04 LTS I get following error even after following all the steps.
```
CMake Error at /usr/share/cmake-3.28/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find Threads (missing: Threads_FOUND)
Call Stack (most recent call first):
  /usr/share/cmake-3.28/Modules/FindPackageHandleStandardArgs.cmake:600 (_FPHSA_FAILURE_MESSAGE)
  /usr/share/cmake-3.28/Modules/FindThreads.cmake:226 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  cmake/linux/default_libs.cmake:39 (find_package)
  CMakeLists.txt:394 (include)
```
installing `build-essential` solved the problem. You can verify pthread using following command

```
ldconfig -p | grep pthread
```
