### PR TITLE
Fixes absolute address to symbol conversion in findSymbol (coverage use case)

### DIFF
--- a/src/Common/SymbolIndex.h
+++ b/src/Common/SymbolIndex.h
@@ -38,7 +38,7 @@ public:
         std::shared_ptr<Elf> elf;
     };
 
-    const Symbol * findSymbol(const void * offset) const;
+    const Symbol * findSymbol(const void * address) const;
     const Object * findObject(const void * address) const;
     const Object * thisObject() const;
 


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Details

1. **Added address-to-offset conversion in findSymbol()**
   - Symbols now store file offsets (per PR #82809 for ASLR security)
   - findSymbol auto-detects if input is absolute address or file offset
   - Absolute addresses (coverage, most traces) → converted to offsets
   - File offsets (system.stack_trace) → used directly
   - Maintains ASLR benefits while fixing coverage resolution
  
2. **Fixed inverted loop logic in collectSymbolsFromProgramHeaders**
   - Loop exited on first non-Null entry, skipping GNU_HASH processing
   - Now correctly iterates until Null terminator is found
   - This bug was introduced in PR #82809
