### PR TITLE
ci: skip debug-symbol tests when debug symbols are missing

### DIFF
--- a/tests/queries/0_stateless/02420_stracktrace_debug_symbols.sh
+++ b/tests/queries/0_stateless/02420_stracktrace_debug_symbols.sh
@@ -5,6 +5,17 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
+# Check for DISABLE_ALL_DEBUG_SYMBOLS
+if [ $($CLICKHOUSE_LOCAL -q "SELECT value LIKE '%-g0%' FROM system.build_options WHERE name = 'CXX_FLAGS'") -eq 1 ]; then
+    echo "@@SKIP@@: No debug symbols"
+    exit 0
+fi
+# MacOS does not have file:line (backtrace_symbols() does not provide this info)
+if [ $($CLICKHOUSE_LOCAL -q "SELECT value = 'Darwin' FROM system.build_options WHERE name = 'SYSTEM'") -eq 1 ]; then
+    echo "@@SKIP@@: MacOS does not have file:line in stacktraces"
+    exit 0
+fi
+
 # NOTE: that this test uses stacktrace instead of addressToLineWithInlines() or
 # similar, since that code (use / might use) different code path in Dwarf
 # parser.

--- a/tests/queries/0_stateless/03641_clickhouse_prefer_symbols_from_contrib_over_rust_crates.sh
+++ b/tests/queries/0_stateless/03641_clickhouse_prefer_symbols_from_contrib_over_rust_crates.sh
@@ -7,6 +7,17 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
+# Check for DISABLE_ALL_DEBUG_SYMBOLS
+if [ $($CLICKHOUSE_LOCAL -q "SELECT value LIKE '%-g0%' FROM system.build_options WHERE name = 'CXX_FLAGS'") -eq 1 ]; then
+    echo "@@SKIP@@: No debug symbols"
+    exit 0
+fi
+# MacOS does not have file:line (backtrace_symbols() does not provide this info)
+if [ $($CLICKHOUSE_LOCAL -q "SELECT value = 'Darwin' FROM system.build_options WHERE name = 'SYSTEM'") -eq 1 ]; then
+    echo "@@SKIP@@: MacOS does not have file:line in stacktraces"
+    exit 0
+fi
+
 $CLICKHOUSE_LOCAL -q "
 SELECT replaceRegexpOne(unit_name, '.*(contrib)', '\1')
 FROM file('$(which $CLICKHOUSE_BINARY)', DWARF)


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Details

- The part about `-g0` will fix this tests in backport PRs (since they uses binaries with DISABLE_ALL_DEBUG_SYMBOLS)
- The part about DARWIN, will skip on MacOS

Follow-up for: https://github.com/ClickHouse/ClickHouse/pull/88585
