### PR TITLE
Remove `FindPackage` from CMake

### DIFF
--- a/cmake/darwin/default_libs.cmake
+++ b/cmake/darwin/default_libs.cmake
@@ -10,10 +10,8 @@ set(CMAKE_C_STANDARD_LIBRARIES ${DEFAULT_LIBS})
 # Minimal supported SDK version
 set(CMAKE_OSX_DEPLOYMENT_TARGET 10.15)
 
-# Unfortunately '-pthread' doesn't work with '-nodefaultlibs'.
-# Just make sure we have pthreads at all.
-set(THREADS_PREFER_PTHREAD_FLAG ON)
-find_package(Threads REQUIRED)
+add_library(Threads::Threads INTERFACE IMPORTED)
+set_target_properties(Threads::Threads PROPERTIES INTERFACE_LINK_LIBRARIES pthread)
 
 if(NOT CMAKE_CROSSCOMPILING)
     execute_process(

--- a/cmake/freebsd/default_libs.cmake
+++ b/cmake/freebsd/default_libs.cmake
@@ -33,10 +33,8 @@ message(STATUS "Default libraries: ${DEFAULT_LIBS}")
 set(CMAKE_CXX_STANDARD_LIBRARIES ${DEFAULT_LIBS})
 set(CMAKE_C_STANDARD_LIBRARIES ${DEFAULT_LIBS})
 
-# Unfortunately '-pthread' doesn't work with '-nodefaultlibs'.
-# Just make sure we have pthreads at all.
-set(THREADS_PREFER_PTHREAD_FLAG ON)
-find_package(Threads REQUIRED)
+add_library(Threads::Threads INTERFACE IMPORTED)
+set_target_properties(Threads::Threads PROPERTIES INTERFACE_LINK_LIBRARIES pthread)
 
 include (cmake/unwind.cmake)
 include (cmake/cxx.cmake)

--- a/cmake/linux/default_libs.cmake
+++ b/cmake/linux/default_libs.cmake
@@ -33,10 +33,8 @@ message(STATUS "Default libraries: ${DEFAULT_LIBS}")
 set(CMAKE_CXX_STANDARD_LIBRARIES ${DEFAULT_LIBS})
 set(CMAKE_C_STANDARD_LIBRARIES ${DEFAULT_LIBS})
 
-# Unfortunately '-pthread' doesn't work with '-nodefaultlibs'.
-# Just make sure we have pthreads at all.
-set(THREADS_PREFER_PTHREAD_FLAG ON)
-find_package(Threads REQUIRED)
+add_library(Threads::Threads INTERFACE IMPORTED)
+set_target_properties(Threads::Threads PROPERTIES INTERFACE_LINK_LIBRARIES pthread)
 
 include (cmake/unwind.cmake)
 include (cmake/cxx.cmake)


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->

### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Remove the remaining use of `FindPackage` from CMake. Builds should not depend on the system packages.