### PR TITLE
Avoid loosing uncompressed checksums for statistics on mutations

### DIFF
--- a/src/Storages/MergeTree/MergeTreeDataPartChecksum.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartChecksum.cpp
@@ -244,6 +244,11 @@ void MergeTreeDataPartChecksums::addFile(const String & file_name, UInt64 file_s
     files[file_name] = Checksum(file_size, file_hash);
 }
 
+void MergeTreeDataPartChecksums::addFile(const String & file_name, const Checksum & checksum)
+{
+    files[file_name] = checksum;
+}
+
 void MergeTreeDataPartChecksums::add(MergeTreeDataPartChecksums && rhs_checksums)
 {
     for (auto && checksum : rhs_checksums.files)

--- a/src/Storages/MergeTree/MergeTreeDataPartChecksum.h
+++ b/src/Storages/MergeTree/MergeTreeDataPartChecksum.h
@@ -50,6 +50,7 @@ struct MergeTreeDataPartChecksums
     FileChecksums files;
 
     void addFile(const String & file_name, UInt64 file_size, Checksum::uint128 file_hash);
+    void addFile(const String & file_name, const Checksum & checksum);
 
     void add(MergeTreeDataPartChecksums && rhs_checksums);
 

--- a/src/Storages/MergeTree/MutateTask.cpp
+++ b/src/Storages/MergeTree/MutateTask.cpp
@@ -1626,7 +1626,7 @@ private:
                         break;
 
                     entries_to_hardlink.insert(it->first);
-                    ctx->existing_indices_stats_checksums.addFile(it->first, it->second.file_size, it->second.file_hash);
+                    ctx->existing_indices_stats_checksums.addFile(it->first, it->second);
                     ++it;
                 }
             }
@@ -1652,7 +1652,7 @@ private:
                 {
                     const auto & checksum = ctx->source_part->checksums.files.at(*stat_filename);
                     entries_to_hardlink.insert(*stat_filename);
-                    ctx->existing_indices_stats_checksums.addFile(*stat_filename, checksum.file_size, checksum.file_hash);
+                    ctx->existing_indices_stats_checksums.addFile(*stat_filename, checksum);
                 }
             }
         }
@@ -1705,7 +1705,7 @@ private:
                     hardlinked_files.insert(it->name());
                     /// Also we need to "rename" checksums to finalize correctly.
                     const auto & check_sum = ctx->source_part->checksums.files.at(it->name());
-                    ctx->existing_indices_stats_checksums.addFile(renamed_stats.at(it->name()), check_sum.file_size, check_sum.file_hash);
+                    ctx->existing_indices_stats_checksums.addFile(renamed_stats.at(it->name()), check_sum);
                 }
             }
             else if (it->isFile())

--- a/tests/queries/0_stateless/03706_statistics_preserve_checksums_on_mutations.reference
+++ b/tests/queries/0_stateless/03706_statistics_preserve_checksums_on_mutations.reference
@@ -1,0 +1,12 @@
+-- { echo }
+select count() from mt;
+10000
+-- { echo }
+alter table mt rewrite parts settings mutations_sync=2;
+select count() from mt;
+10000
+detach table mt;
+attach table mt;
+select count() from mt;
+10000
+Hashes are the same

--- a/tests/queries/0_stateless/03706_statistics_preserve_checksums_on_mutations.sh
+++ b/tests/queries/0_stateless/03706_statistics_preserve_checksums_on_mutations.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+# - no-fasttest - CountMinSketch is not compiled
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT -nm -q "
+drop table if exists mt;
+create table mt (key Int, value String) engine=MergeTree() order by key settings
+  index_granularity=100,
+  min_bytes_for_wide_part=0,
+  -- otherwise sparse info will be different, since for INSERTs the sparse ratio is calculated for the whole block, while for mutations for each granula (FIXME?)
+  ratio_of_defaults_for_sparse_serialization=1,
+  -- This uncovers the bug
+  auto_statistics_types='uniq,minmax,countmin,tdigest'
+;
+insert into mt select number, repeat('a', number) from numbers(10e3) settings max_block_size=1e6;
+-- { echo }
+select count() from mt;
+"
+
+hashes="$($CLICKHOUSE_CLIENT -q "select (hash_of_all_files, hash_of_uncompressed_files, uncompressed_hash_of_compressed_files) from system.parts where database = currentDatabase() and table = 'mt'")"
+$CLICKHOUSE_CLIENT -nm -q "
+-- { echo }
+alter table mt rewrite parts settings mutations_sync=2;
+select count() from mt;
+detach table mt;
+attach table mt;
+select count() from mt;
+"
+
+new_hashes="$($CLICKHOUSE_CLIENT -q "select (hash_of_all_files, hash_of_uncompressed_files, uncompressed_hash_of_compressed_files) from system.parts where database = currentDatabase() and table = 'mt' and active")"
+if [ "$hashes" != "$new_hashes" ]; then
+  echo "Hashes does not matches: '$hashes' vs '$new_hashes'"
+else
+  echo "Hashes are the same"
+fi


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Avoid losing uncompressed checksums for statistics on mutations
