### PR TITLE
CI: Build script should not overwrite job timer set by praktika

### DIFF
--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -251,6 +251,7 @@ class JobConfigs:
                 ArtifactNames.TGZ_AMD_RELEASE,
             ],
             runs_on=RunnerLabels.AMD_LARGE,
+            timeout=3 * 3600,
         ),
         Job.ParamSet(
             parameter=BuildTypes.ARM_RELEASE,

--- a/ci/jobs/build_clickhouse.py
+++ b/ci/jobs/build_clickhouse.py
@@ -86,8 +86,6 @@ def run_shell(name, command, **kwargs):
 def main():
     args = parse_args()
 
-    stop_watch = Utils.Stopwatch()
-
     stages = list(JobStages)
     stage = args.param or JobStages.CHECKOUT_SUBMODULES
     if stage:
@@ -269,9 +267,7 @@ def main():
         )
         res = results[-1].is_ok()
 
-    Result.create_from(
-        results=results, stopwatch=stop_watch, files=files
-    ).complete_job()
+    Result.create_from(results=results, files=files).complete_job()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Details

The build script sets its own job timer, overriding the timer set by Praktika and thus dropping the time used by the ci infrastructure (pulling the build image). This change removes the job's internal timer, so the entire job execution time is tracked in CI report and in CIDB
