### PR TITLE
Fix multiple dataraces in Context

### DIFF
--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -4881,49 +4881,49 @@ size_t Context::getMaxDatabaseNumToWarn() const
 
 void Context::setMaxPendingMutationsToWarn(size_t max_pending_mutations_to_warn)
 {
-    SharedLockGuard lock(shared->mutex);
+    std::lock_guard lock(shared->mutex);
     shared->max_pending_mutations_to_warn = max_pending_mutations_to_warn;
 }
 
 void Context::setMaxPendingMutationsExecutionTimeToWarn(size_t max_pending_mutations_execution_time_to_warn)
 {
-    SharedLockGuard lock(shared->mutex);
+    std::lock_guard lock(shared->mutex);
     shared->max_pending_mutations_execution_time_to_warn = max_pending_mutations_execution_time_to_warn;
 }
 
 void Context::setMaxPartNumToWarn(size_t max_part_to_warn)
 {
-    SharedLockGuard lock(shared->mutex);
+    std::lock_guard lock(shared->mutex);
     shared->max_part_num_to_warn = max_part_to_warn;
 }
 
 void Context::setMaxNamedCollectionNumToWarn(size_t max_named_collection_to_warn)
 {
-    SharedLockGuard lock(shared->mutex);
+    std::lock_guard lock(shared->mutex);
     shared->max_named_collection_num_to_warn = max_named_collection_to_warn;
 }
 
 void Context::setMaxTableNumToWarn(size_t max_table_to_warn)
 {
-    SharedLockGuard lock(shared->mutex);
+    std::lock_guard lock(shared->mutex);
     shared->max_table_num_to_warn = max_table_to_warn;
 }
 
 void Context::setMaxViewNumToWarn(size_t max_view_to_warn)
 {
-    SharedLockGuard lock(shared->mutex);
+    std::lock_guard lock(shared->mutex);
     shared->max_view_num_to_warn = max_view_to_warn;
 }
 
 void Context::setMaxDictionaryNumToWarn(size_t max_dictionary_to_warn)
 {
-    SharedLockGuard lock(shared->mutex);
+    std::lock_guard lock(shared->mutex);
     shared->max_dictionary_num_to_warn = max_dictionary_to_warn;
 }
 
 void Context::setMaxDatabaseNumToWarn(size_t max_database_to_warn)
 {
-    SharedLockGuard lock(shared->mutex);
+    std::lock_guard lock(shared->mutex);
     shared->max_database_num_to_warn = max_database_to_warn;
 }
 
@@ -6595,7 +6595,7 @@ void Context::setAsynchronousInsertQueue(const std::shared_ptr<AsynchronousInser
 {
     AsynchronousInsertQueue::validateSettings(*settings, getLogger("Context"));
 
-    SharedLockGuard lock(shared->mutex);
+    std::lock_guard lock(shared->mutex);
 
     if (std::chrono::milliseconds(getSettingsRef()[Setting::async_insert_poll_timeout_ms]) == std::chrono::milliseconds::zero())
         throw Exception(ErrorCodes::INVALID_SETTING_VALUE, "Setting async_insert_poll_timeout_ms can't be zero");


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Details

Fixes error like this

```
        if sanitizer_assert_instance is not None:
>           raise Exception(
                "Sanitizer assert found for instance {}".format(
                    sanitizer_assert_instance
                )
            )
E           Exception: Sanitizer assert found for instance ==================
E           WARNING: ThreadSanitizer: data race (pid=1)
E             Write of size 8 at 0x728400000f30 by thread T3 (mutexes: write M0):
E               #0 DB::Context::setMaxPendingMutationsToWarn(unsigned long) ci/tmp/build/./src/Interpreters/Context.cpp:4683:43 (clickhouse+0x19efffc6) (BuildId: b39cdc6fd0b702df1e21475018409d10dda103a2)
E               #1 DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&)::$_0::operator()(Poco::AutoPtr<Poco::Util::AbstractConfiguration>, bool) const ci/tmp/build/./programs/server/Server.cpp:2101:29 (clickhouse+0x1216094e) (BuildId: b39cdc6fd0b702df1e21475018409d10dda103a2)
E               #2 decltype(std::declval<DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&)::$_0&>()(std::declval<Poco::AutoPtr<Poco::Util::AbstractConfiguration>>(), std::declval<bool>())) std::__1::__invoke[abi:ne190107]<DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&)::$_0&, Poco::AutoPtr<Poco::Util::AbstractConfiguration>, bool>(DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&)::$_0&, Poco::AutoPtr<Poco::Util::AbstractConfiguration>&&, bool&&) ci/tmp/build/./contrib/llvm-project/libcxx/include/__type_traits/invoke.h:149:25 (clickhouse+0x1215e989) (BuildId: b39cdc6fd0b702df1e21475018409d10dda103a2)
E               #3 void std::__1::__invoke_void_return_wrapper<void, true>::__call[abi:ne190107]<DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&)::$_0&, Poco::AutoPtr<Poco::Util::AbstractConfiguration>, bool>(DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&)::$_0&, Poco::AutoPtr<Poco::Util::AbstractConfiguration>&&, bool&&) ci/tmp/build/./contrib/llvm-project/libcxx/include/__type_traits/invoke.h:224:5 (clickhouse+0x1215e989)
E               #4 std::__1::__function::__default_alloc_func<DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&)::$_0, void (Poco::AutoPtr<Poco::Util::AbstractConfiguration>, bool)>::operator()[abi:ne190107](Poco::AutoPtr<Poco::Util::AbstractConfiguration>&&, bool&&) ci/tmp/build/./contrib/llvm-project/libcxx/include/__functional/function.h:210:12 (clickhouse+0x1215e989)
E               #5 void std::__1::__function::__policy_invoker<void (Poco::AutoPtr<Poco::Util::AbstractConfiguration>, bool)>::__call_impl[abi:ne190107]<std::__1::__function::__default_alloc_func<DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&)::$_0, void (Poco::AutoPtr<Poco::Util::AbstractConfiguration>, bool)>>(std::__1::__function::__policy_storage const*, Poco::AutoPtr<Poco::Util::AbstractConfiguration>&&, bool) ci/tmp/build/./contrib/llvm-project/libcxx/include/__functional/function.h:610:12 (clickhouse+0x1215e989)
E               #6 std::__1::__function::__policy_func<void (Poco::AutoPtr<Poco::Util::AbstractConfiguration>, bool)>::operator()[abi:ne190107](Poco::AutoPtr<Poco::Util::AbstractConfiguration>&&, bool&&) const ci/tmp/build/./contrib/llvm-project/libcxx/include/__functional/function.h:716:12 (clickhouse+0x1e9ce077) (BuildId: b39cdc6fd0b702df1e21475018409d10dda103a2)
E               #7 std::__1::function<void (Poco::AutoPtr<Poco::Util::AbstractConfiguration>, bool)>::operator()(Poco::AutoPtr<Poco::Util::AbstractConfiguration>, bool) const ci/tmp/build/./contrib/llvm-project/libcxx/include/__functional/function.h:989:10 (clickhouse+0x1e9ce077)
E               #8 DB::ConfigReloader::reloadIfNewer(bool, bool, bool, bool) ci/tmp/build/./src/Common/Config/ConfigReloader.cpp:179:13 (clickhouse+0x1e9ce077)
E               #9 DB::ConfigReloader::reload() ci/tmp/build/./src/Common/Config/ConfigReloader.h:50:21 (clickhouse+0x1216d907) (BuildId: b39cdc6fd0b702df1e21475018409d10dda103a2)
E               #10 DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&)::$_21::operator()() const ci/tmp/build/./programs/server/Server.cpp:2543:31 (clickhouse+0x1216d907)
E               #11 decltype(std::declval<DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&)::$_21&>()()) std::__1::__invoke[abi:ne190107]<DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&)::$_21&>(DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&)::$_21&) ci/tmp/build/./contrib/llvm-project/libcxx/include/__type_traits/invoke.h:149:25 (clickhouse+0x1216d907)
E               #12 void std::__1::__invoke_void_return_wrapper<void, true>::__call[abi:ne190107]<DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&)::$_21&>(DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&)::$_21&) ci/tmp/build/./contrib/llvm-project/libcxx/include/__type_traits/invoke.h:224:5 (clickhouse+0x1216d907)
E               #13 std::__1::__function::__default_alloc_func<DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&)::$_21, void ()>::operator()[abi:ne190107]() ci/tmp/build/./contrib/llvm-project/libcxx/include/__functional/function.h:210:12 (clickhouse+0x1216d907)
E               #14 void std::__1::__function::__policy_invoker<void ()>::__call_impl[abi:ne190107]<std::__1::__function::__default_alloc_func<DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&)::$_21, void ()>>(std::__1::__function::__policy_storage const*) ci/tmp/build/./contrib/llvm-project/libcxx/include/__functional/function.h:610:12 (clickhouse+0x1216d907)
E               #15 std::__1::__function::__policy_func<void ()>::operator()[abi:ne190107]() const ci/tmp/build/./contrib/llvm-project/libcxx/include/__functional/function.h:716:12 (clickhouse+0x19f0a760) (BuildId: b39cdc6fd0b702df1e21475018409d10dda103a2)
E               #16 std::__1::function<void ()>::operator()() const ci/tmp/build/./contrib/llvm-project/libcxx/include/__functional/function.h:989:10 (clickhouse+0x19f0a760)
E               #17 DB::Context::reloadConfig() const ci/tmp/build/./src/Interpreters/Context.cpp:5730:5 (clickhouse+0x19f0a760)
E               #18 DB::InterpreterSystemQuery::execute() ci/tmp/build/./src/Interpreters/InterpreterSystemQuery.cpp:805:29 (clickhouse+0x1a7f74bc) (BuildId: b39cdc6fd0b702df1e21475018409d10dda103a2)
E               #19 DB::executeQueryImpl(char const*, char const*, std::__1::shared_ptr<DB::Context>, DB::QueryFlags, DB::QueryProcessingStage::Enum, DB::ReadBuffer*, std::__1::shared_ptr<DB::IAST>&) ci/tmp/build/./src/Interpreters/executeQuery.cpp:1530:40 (clickhouse+0x1a7ba830) (BuildId: b39cdc6fd0b702df1e21475018409d10dda103a2)
E               #20 DB::executeQuery(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<DB::Context>, DB::QueryFlags, DB::QueryProcessingStage::Enum) ci/tmp/build/./src/Interpreters/executeQuery.cpp:1722:11 (clickhouse+0x1a7b341b) (BuildId: b39cdc6fd0b702df1e21475018409d10dda103a2)
E               #21 DB::TCPHandler::runImpl() ci/tmp/build/./src/Server/TCPHandler.cpp:721:68 (clickhouse+0x1dba47e8) (BuildId: b39cdc6fd0b702df1e21475018409d10dda103a2)
E               #22 DB::TCPHandler::run() ci/tmp/build/./src/Server/TCPHandler.cpp:2761:9 (clickhouse+0x1dbccf27) (BuildId: b39cdc6fd0b702df1e21475018409d10dda103a2)
E               #23 Poco::Net::TCPServerConnection::start() ci/tmp/build/./base/poco/Net/src/TCPServerConnection.cpp:40:3 (clickhouse+0x22f26ea2) (BuildId: b39cdc6fd0b702df1e21475018409d10dda103a2)
E               #24 Poco::Net::TCPServerDispatcher::run() ci/tmp/build/./base/poco/Net/src/TCPServerDispatcher.cpp:115:38 (clickhouse+0x22f27711) (BuildId: b39cdc6fd0b702df1e21475018409d10dda103a2)
E               #25 Poco::PooledThread::run() ci/tmp/build/./base/poco/Foundation/src/ThreadPool.cpp:205:14 (clickhouse+0x22e8a602) (BuildId: b39cdc6fd0b702df1e21475018409d10dda103a2)
E               #26 Poco::(anonymous namespace)::RunnableHolder::run() ci/tmp/build/./base/poco/Foundation/src/Thread.cpp:45:11 (clickhouse+0x22e889af) (BuildId: b39cdc6fd0b702df1e21475018409d10dda103a2)
E               #27 Poco::ThreadImpl::runnableEntry(void*) ci/tmp/build/./base/poco/Foundation/src/Thread_POSIX.cpp:335:27 (clickhouse+0x22e86d69) (BuildId: b39cdc6fd0b702df1e21475018409d10dda103a2)
E           
E             Previous read of size 8 at 0x728400000f30 by thread T664 (mutexes: write M1):
E               #0 DB::Context::getMaxPendingMutationsToWarn() const ci/tmp/build/./src/Interpreters/Context.cpp:4641:20 (clickhouse+0x19effba0) (BuildId: b39cdc6fd0b702df1e21475018409d10dda103a2)
E               #1 DB::AsynchronousMetrics::processWarningForMutationStats(std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, DB::AsynchronousMetricValue, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const, DB::AsynchronousMetricValue>>> const&) const ci/tmp/build/./src/Common/AsynchronousMetrics.cpp:753:51 (clickhouse+0x11f132b3) (BuildId: b39cdc6fd0b702df1e21475018409d10dda103a2)
E               #2 DB::AsynchronousMetrics::update(std::__1::chrono::time_point<std::__1::chrono::system_clock, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000l>>>, bool) ci/tmp/build/./src/Common/AsynchronousMetrics.cpp:2011:9 (clickhouse+0x11f0db02) (BuildId: b39cdc6fd0b702df1e21475018409d10dda103a2)
E               #3 DB::AsynchronousMetrics::run() ci/tmp/build/./src/Common/AsynchronousMetrics.cpp:397:13 (clickhouse+0x11f0fe1f) (BuildId: b39cdc6fd0b702df1e21475018409d10dda103a2)
E               #4 DB::AsynchronousMetrics::start()::$_0::operator()() const ci/tmp/build/./src/Common/AsynchronousMetrics.cpp:305:62 (clickhouse+0x11f14f4d) (BuildId: b39cdc6fd0b702df1e21475018409d10dda103a2)
E               #5 decltype(std::declval<DB::AsynchronousMetrics::start()::$_0&>()()) std::__1::__invoke[abi:ne190107]<DB::AsynchronousMetrics::start()::$_0&>(DB::AsynchronousMetrics::start()::$_0&) ci/tmp/build/./contrib/llvm-project/libcxx/include/__type_traits/invoke.h:149:25 (clickhouse+0x11f14f4d)
E               #6 decltype(auto) std::__1::__apply_tuple_impl[abi:ne190107]<DB::AsynchronousMetrics::start()::$_0&, std::__1::tuple<>&>(DB::AsynchronousMetrics::start()::$_0&, std::__1::tuple<>&, std::__1::__tuple_indices<...>) ci/tmp/build/./contrib/llvm-project/libcxx/include/tuple:1354:5 (clickhouse+0x11f14f4d)
E               #7 decltype(auto) std::__1::apply[abi:ne190107]<DB::AsynchronousMetrics::start()::$_0&, std::__1::tuple<>&>(DB::AsynchronousMetrics::start()::$_0&, std::__1::tuple<>&) ci/tmp/build/./contrib/llvm-project/libcxx/include/tuple:1358:5 (clickhouse+0x11f14f4d)
E               #8 ThreadFromGlobalPoolImpl<true, true>::ThreadFromGlobalPoolImpl<DB::AsynchronousMetrics::start()::$_0>(DB::AsynchronousMetrics::start()::$_0&&)::'lambda'()::operator()() ci/tmp/build/./src/Common/ThreadPool.h:312:13 (clickhouse+0x11f14f4d)
E               #9 decltype(std::declval<DB::AsynchronousMetrics::start()::$_0>()()) std::__1::__invoke[abi:ne190107]<ThreadFromGlobalPoolImpl<true, true>::ThreadFromGlobalPoolImpl<DB::AsynchronousMetrics::start()::$_0>(DB::AsynchronousMetrics::start()::$_0&&)::'lambda'()&>(DB::AsynchronousMetrics::start()::$_0&&) ci/tmp/build/./contrib/llvm-project/libcxx/include/__type_traits/invoke.h:149:25 (clickhouse+0x11f14f4d)
E               #10 void std::__1::__invoke_void_return_wrapper<void, true>::__call[abi:ne190107]<ThreadFromGlobalPoolImpl<true, true>::ThreadFromGlobalPoolImpl<DB::AsynchronousMetrics::start()::$_0>(DB::AsynchronousMetrics::start()::$_0&&)::'lambda'()&>(ThreadFromGlobalPoolImpl<true, true>::ThreadFromGlobalPoolImpl<DB::AsynchronousMetrics::start()::$_0>(DB::AsynchronousMetrics::start()::$_0&&)::'lambda'()&) ci/tmp/build/./contrib/llvm-project/libcxx/include/__type_traits/invoke.h:224:5 (clickhouse+0x11f14f4d)
E               #11 std::__1::__function::__default_alloc_func<ThreadFromGlobalPoolImpl<true, true>::ThreadFromGlobalPoolImpl<DB::AsynchronousMetrics::start()::$_0>(DB::AsynchronousMetrics::start()::$_0&&)::'lambda'(), void ()>::operator()[abi:ne190107]() ci/tmp/build/./contrib/llvm-project/libcxx/include/__functional/function.h:210:12 (clickhouse+0x11f14f4d)
E               #12 void std::__1::__function::__policy_invoker<void ()>::__call_impl[abi:ne190107]<std::__1::__function::__default_alloc_func<ThreadFromGlobalPoolImpl<true, true>::ThreadFromGlobalPoolImpl<DB::AsynchronousMetrics::start()::$_0>(DB::AsynchronousMetrics::start()::$_0&&)::'lambda'(), void ()>>(std::__1::__function::__policy_storage const*) ci/tmp/build/./contrib/llvm-project/libcxx/include/__functional/function.h:610:12 (clickhouse+0x11f14f4d)
E               #13 std::__1::__function::__policy_func<void ()>::operator()[abi:ne190107]() const ci/tmp/build/./contrib/llvm-project/libcxx/include/__functional/function.h:716:12 (clickhouse+0x11e52f42) (BuildId: b39cdc6fd0b702df1e21475018409d10dda103a2)
E               #14 std::__1::function<void ()>::operator()() const ci/tmp/build/./contrib/llvm-project/libcxx/include/__functional/function.h:989:10 (clickhouse+0x11e52f42)
E               #15 ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::worker() ci/tmp/build/./src/Common/ThreadPool.cpp:809:17 (clickhouse+0x11e52f42)
E               #16 decltype(*std::declval<ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*>().*std::declval<void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*)()>()()) std::__1::__invoke[abi:ne190107]<void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*, void>(void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*&&) ci/tmp/build/./contrib/llvm-project/libcxx/include/__type_traits/invoke.h:117:25 (clickhouse+0x11e5bc9b) (BuildId: b39cdc6fd0b702df1e21475018409d10dda103a2)
E               #17 void std::__1::__thread_execute[abi:ne190107]<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*, 2ul>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*>&, std::__1::__tuple_indices<2ul>) ci/tmp/build/./contrib/llvm-project/libcxx/include/__thread/thread.h:192:3 (clickhouse+0x11e5bc9b)
E               #18 void* std::__1::__thread_proxy[abi:ne190107]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*>>(void*) ci/tmp/build/./contrib/llvm-project/libcxx/include/__thread/thread.h:201:3 (clickhouse+0x11e5bc9b)

```
