### PR TITLE
Parse settings for external http authentication as JSON values rather than dump format

### DIFF
--- a/docs/en/operations/external-authenticators/http.md
+++ b/docs/en/operations/external-authenticators/http.md
@@ -100,4 +100,4 @@ CREATE USER my_user IDENTIFIED WITH HTTP SERVER 'basic_server'
 
 ### Passing session settings {#passing-session-settings}
 
-If a response body from HTTP authentication server has JSON format and contains `settings` sub-object, ClickHouse will try parse its key: value pairs as string values and set them as session settings for authenticated user's current session. If parsing is failed, a response body from server will be ignored.
+If a response body from HTTP authentication server has JSON format and contains `settings` sub-object, ClickHouse will try parse its `key: value` pairs and set them as session settings for authenticated user's current session. The JSON object must be flat (not containing nested objects and arrays). If parsing is failed, a response body from server will be ignored.

--- a/tests/integration/test_external_http_authenticator/configs/users.xml
+++ b/tests/integration/test_external_http_authenticator/configs/users.xml
@@ -60,5 +60,16 @@
             <profile>default</profile>
             <quota>default</quota>
         </test_user_4>
+        <test_user_5>
+            <http_authentication>
+                <server>basic_server</server>
+                <scheme>basic</scheme>
+            </http_authentication>
+            <networks replace="replace">
+                <ip>::/0</ip>
+            </networks>
+            <profile>default</profile>
+            <quota>default</quota>
+        </test_user_5>
     </users>
 </clickhouse>

--- a/tests/integration/test_external_http_authenticator/http_auth_server.py
+++ b/tests/integration/test_external_http_authenticator/http_auth_server.py
@@ -4,11 +4,40 @@ import json
 from typing import List
 
 GOOD_PASSWORD = "good_password"
-USER_RESPONSES = {
-    "test_user_1": {"settings": {"auth_user": "'test_user'", "auth_num": "UInt64_15"}},
-    "test_user_2": {},
-    "test_user_3": "",
-    "test_user_4": "not json string",
+# See output format examples: 01418_custom_settings.sql
+TEST_CASES = {
+    "test_user_1": {
+        "response": {
+            "settings": {
+                "auth_str": "test_user",
+                "auth_int": 100,
+                "auth_signed": -100,
+                "auth_float": 100.1,
+                "auth_null": None,
+                "auth_bool": True,
+            }
+        },
+        "dump_settings": {
+            "auth_str": "'test_user'",
+            "auth_int": "Int64_100",
+            "auth_signed": "Int64_-100",
+            "auth_float": "Float64_100.1",
+            "auth_null": "NULL",
+            "auth_bool": "Bool_1",
+        },
+        "get_settings": {
+            "auth_str": "test_user",
+            "auth_int": "100",
+            "auth_signed": "-100",
+            "auth_float": "100.1",
+            "auth_null": "\\N",
+            "auth_bool": "true",
+        },
+    },
+    "test_user_2": {"response": {}},
+    "test_user_3": {"response": ""},
+    "test_user_4": {"response": "not json string"},
+    "test_user_5": {"response": {"settings": {"unexpected_nested_object": {}}}},
 }
 
 
@@ -26,7 +55,7 @@ class RequestHandler(http.server.BaseHTTPRequestHandler):
 
     def do_ACCESS_GRANTED(self, user: str) -> None:
         self.send_response(http.HTTPStatus.OK)
-        response = USER_RESPONSES.get(user)
+        response = TEST_CASES.get(user, {}).get("response")
 
         if isinstance(response, dict):
             body = json.dumps(response)


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Parse settings for external HTTP authentication as JSON values rather than as 'dump' format (e.g. `100` instead of `"UInt64_100"`). Resolves #88481.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

### Details
Parse settings for external HTTP authentication as JSON values rather than as 'dump' format (e.g. `100` instead of `"UInt64_100"`). Backward compatibility is not required here, as the feature is rather niche and this implementation is more correct.

Resolves #88481
