### PR TITLE
Fix Kafka SASL settings precedence

### DIFF
--- a/src/Storages/Kafka/KafkaConfigLoader.cpp
+++ b/src/Storages/Kafka/KafkaConfigLoader.cpp
@@ -358,8 +358,8 @@ void updateConfigurationFromConfig(
 {
     loadFromConfig(kafka_config, params, KafkaConfigLoader::CONFIG_KAFKA_TAG);
 
-    /// We have to set these settings before taking the values from the consumer/producer specific configuration,
-    /// because otherwise we would introduce a breaking change.
+    specific_config_updater(kafka_config, params);
+
     auto kafka_settings = storage.getKafkaSettings();
     if (!kafka_settings[KafkaSetting::kafka_security_protocol].value.empty())
         kafka_config.set("security.protocol", kafka_settings[KafkaSetting::kafka_security_protocol]);
@@ -369,9 +369,6 @@ void updateConfigurationFromConfig(
         kafka_config.set("sasl.username", kafka_settings[KafkaSetting::kafka_sasl_username]);
     if (!kafka_settings[KafkaSetting::kafka_sasl_password].value.empty())
         kafka_config.set("sasl.password", kafka_settings[KafkaSetting::kafka_sasl_password]);
-
-    specific_config_updater(kafka_config, params);
-
     if (!kafka_settings[KafkaSetting::kafka_compression_codec].value.empty())
         kafka_config.set("compression.codec", kafka_settings[KafkaSetting::kafka_compression_codec]);
 

--- a/tests/integration/test_storage_kafka_sasl/configs/sasl_settings.xml
+++ b/tests/integration/test_storage_kafka_sasl/configs/sasl_settings.xml
@@ -1,0 +1,3 @@
+<clickhouse>
+        <!-- the content will be replaced in the test -->
+</clickhouse>


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):
- Backward Incompatible Change

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixes Kafka storage SASL settings precedence. Table-level SASL settings specified in CREATE TABLE queries now correctly override consumer/producer-specific settings from configuration files.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

### Details

This is a backward incompatible change, because if somebody used proper settings in consumer/producer specific configs and specified invalid settings in the create query, it will stop working. However:
- The chance that somebody did that is very low, therefore the chance to actually break any workflows is very low
- Even if we break some workflows, the current setup is the reasonable one, so it is better to bite the bullet now than later on
