### PR TITLE
Fix loading tables with incorrect sparse serialization for tuple itself

### DIFF
--- a/src/DataTypes/DataTypeTuple.cpp
+++ b/src/DataTypes/DataTypeTuple.cpp
@@ -379,7 +379,10 @@ SerializationPtr DataTypeTuple::getSerialization(const SerializationInfo & info)
         serializations[i] = std::make_shared<SerializationNamed>(serialization, elem_name, SubstreamType::TupleElement);
     }
 
-    return IDataType::getSerialization(info.getKindStack(), std::make_shared<SerializationTuple>(std::move(serializations), has_explicit_names));
+    auto kinds = info.getKindStack();
+    /// Compatibility with older version that may propagate Sparse serialization for Tuple itself (in serialization.json)
+    std::erase(kinds, ISerialization::Kind::SPARSE);
+    return IDataType::getSerialization(kinds, std::make_shared<SerializationTuple>(std::move(serializations), has_explicit_names));
 }
 
 MutableSerializationInfoPtr DataTypeTuple::createSerializationInfo(const SerializationInfoSettings & settings) const


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix loading tables with incorrect sparse serialization for tuple itself (that is written by older ClickHouse versions)

Tuple itself cannot be Sparse, but some previous ClickHouse versions may write this into the serialization.json, and such tables will not be able to be loaded.

### Details
Follow-up for: #88752
