### PR TITLE
Make `SYSTEM FLUSH LOGS` query wait for table creation even when the logs are empty

### DIFF
--- a/src/Common/SystemLogBase.cpp
+++ b/src/Common/SystemLogBase.cpp
@@ -171,10 +171,14 @@ void SystemLogQueue<LogElement>::waitFlush(SystemLogQueue<LogElement>::Index exp
     // In theory it should be possible to wait only for prepared_tables, but:
     // 1. It reflects the logic more precisely
     // 2. One extra comparison shouldn't matter here
-    auto result = confirm_event.wait_for(lock, std::chrono::seconds(timeout_seconds), [&]
-    {
-        return (flushed_index >= expected_flushed_index && prepared_tables >= expected_flushed_index) || is_shutdown;
-    });
+    auto result = confirm_event.wait_for(
+        lock,
+        std::chrono::seconds(timeout_seconds),
+        [&]
+        {
+            return (flushed_index >= expected_flushed_index && (!should_prepare_tables_anyway || prepared_tables >= expected_flushed_index))
+                || is_shutdown;
+        });
 
     if (!result)
     {

--- a/src/Common/SystemLogBase.cpp
+++ b/src/Common/SystemLogBase.cpp
@@ -167,9 +167,13 @@ void SystemLogQueue<LogElement>::waitFlush(SystemLogQueue<LogElement>::Index exp
     // there is no obligation to call notifyFlush before waitFlush, than we have to be sure that flush_event has been triggered before we wait the result
     notifyFlushUnlocked(expected_flushed_index, should_prepare_tables_anyway);
 
+    // prepared_tables starts from -1, so we need to wait for prepared_tables >= 0 when expected_flushed_index == 0 to make sure the table is created
+    // In theory it should be possible to wait only for prepared_tables, but:
+    // 1. It reflects the logic more precisely
+    // 2. One extra comparison shouldn't matter here
     auto result = confirm_event.wait_for(lock, std::chrono::seconds(timeout_seconds), [&]
     {
-        return (flushed_index >= expected_flushed_index) || is_shutdown;
+        return (flushed_index >= expected_flushed_index && prepared_tables >= expected_flushed_index) || is_shutdown;
     });
 
     if (!result)

--- a/src/Common/SystemLogBase.h
+++ b/src/Common/SystemLogBase.h
@@ -171,7 +171,7 @@ private:
     // Flushed log up to this index, exclusive
     Index flushed_index = 0;
 
-    // The same logic for the prepare tables: if requested_prepar_tables > prepared_tables we need to do prepare
+    // The same logic for the prepare tables: if requested_prepare_tables > prepared_tables we need to do prepare
     // except that initial prepared_tables is -1
     // it is due to the difference: when no logs have been written and we call flush logs
     // it becomes in the state: requested_flush_index = 0 and flushed_index = 0 -- we do not want to do anything

--- a/src/Interpreters/SystemLog.cpp
+++ b/src/Interpreters/SystemLog.cpp
@@ -477,7 +477,7 @@ void SystemLogs::flushImpl(const Strings & names, bool should_prepare_tables_any
             log->flushBufferToLog(std::chrono::system_clock::now());
 
             auto last_log_index = log->getLastLogIndex();
-            logs_to_wait.push_back({log, log->getLastLogIndex()});
+            logs_to_wait.push_back({log, last_log_index});
             log->notifyFlush(last_log_index, should_prepare_tables_anyway);
         }
     }

--- a/tests/integration/test_log_query_probability/test.py
+++ b/tests/integration/test_log_query_probability/test.py
@@ -17,7 +17,7 @@ def start_cluster():
         cluster.shutdown()
 
 
-def test_log_quries_probability_one(start_cluster):
+def test_log_queries_probability_one(start_cluster):
     for i in range(100):
         node1.query("SELECT 12345", settings={"log_queries_probability": 0.5})
 
@@ -45,7 +45,7 @@ def test_log_quries_probability_one(start_cluster):
     node1.query("TRUNCATE TABLE system.query_log")
 
 
-def test_log_quries_probability_two(start_cluster):
+def test_log_queries_probability_two(start_cluster):
     for i in range(100):
         node1.query(
             "SELECT 12345 FROM remote('node2', system, one)",


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


Motivation: fix [flaky](https://play.clickhouse.com/play?user=play&run=1#V0lUSAogICAgOTAgQVMgaW50ZXJ2YWxfZGF5cwpTRUxFQ1QKICAgIHRvU3RhcnRPZkRheShjaGVja19zdGFydF90aW1lKSBBUyBkYXksCiAgICBjb3VudCgpIEFTIGZhaWx1cmVzLAogICAgZ3JvdXBVbmlxQXJyYXkocHVsbF9yZXF1ZXN0X251bWJlcikgQVMgcHJzLAogICAgYW55KHJlcG9ydF91cmwpIEFTIHJlcG9ydF91cmwKRlJPTSBjaGVja3MKV0hFUkUgKG5vdygpIC0gdG9JbnRlcnZhbERheShpbnRlcnZhbF9kYXlzKSkgPD0gY2hlY2tfc3RhcnRfdGltZQogICAgQU5EIHRlc3RfbmFtZSA9ICd0ZXN0X2xvZ19xdWVyeV9wcm9iYWJpbGl0eS90ZXN0LnB5Ojp0ZXN0X2xvZ19xdXJpZXNfcHJvYmFiaWxpdHlfdHdvJwogICAgLS0gQU5EIGNoZWNrX25hbWUgPSAnTm9uZScKICAgIEFORCB0ZXN0X3N0YXR1cyBJTiAoJ0ZBSUwnLCAnRVJST1InKQogICAgQU5EICgoaGVhZF9yZWYgPSAnbWFzdGVyJyBBTkQgcHVsbF9yZXF1ZXN0X251bWJlciA9IDApIE9SIHB1bGxfcmVxdWVzdF9udW1iZXIgIT0gMCkKR1JPVVAgQlkgZGF5Ck9SREVSIEJZIGRheSBERVNDCg==) test 