### PR TITLE
Fix `Bad get: has Null` from skip index set.

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexSet.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexSet.cpp
@@ -700,9 +700,7 @@ bool MergeTreeIndexConditionSet::checkDAGUseless(const ActionsDAG::Node & node, 
     }
     if (node.column && isColumnConst(*node.column))
     {
-        Field literal;
-        node.column->get(0, literal);
-        return !atomic && literal.safeGet<bool>();
+        return !atomic && node.column->getBool(0);
     }
     if (node.type == ActionsDAG::ActionType::FUNCTION)
     {

--- a/tests/queries/0_stateless/03707_set_index_bad_get_null_bug.reference
+++ b/tests/queries/0_stateless/03707_set_index_bad_get_null_bug.reference
@@ -1,0 +1,14 @@
+Expression
+  Filter
+    ReadFromMergeTree
+    Indexes:
+      PrimaryKey
+        Condition: true
+        Parts: 1/1
+        Granules: 1/1
+      Skip
+        Name: v
+        Description: set GRANULARITY 1
+        Parts: 0/1
+        Granules: 0/1
+      Ranges: 0

--- a/tests/queries/0_stateless/03707_set_index_bad_get_null_bug.sql
+++ b/tests/queries/0_stateless/03707_set_index_bad_get_null_bug.sql
@@ -1,0 +1,13 @@
+drop table if exists test;
+CREATE table test
+(
+    `ts` Int64,
+    `v` LowCardinality(String),
+    INDEX v v TYPE set(0) GRANULARITY 1
+)
+ENGINE = MergeTree
+ORDER BY (ts);
+
+INSERT INTO test (v) FORMAT Values ('VALUE1');
+
+EXPLAIN indexes = 1, description=0 SELECT CAST(NULL, 'Nullable(String)') AS source, v AS v FROM test WHERE (source = 'VALUE1') OR (v ILIKE 'VALUE1');


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `Bad get` error that happened during `Set` index analysis in case the predicate contained `NULL` constant. Fixes #84856 and #82974

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

### Details

Resolves #84856 and #82974

<!-- ch-version-info:start -->
### Version info
- Merged into: `25.11.1.1034`
- Backported to: `25.11.3.53`, `25.8.22.7`
<!-- ch-version-info:end -->