### PR TITLE
Fix T64 codec crash when input size is not aligned to element size

### DIFF
--- a/src/Compression/CompressionCodecT64.cpp
+++ b/src/Compression/CompressionCodecT64.cpp
@@ -10,6 +10,7 @@
 #include <IO/WriteHelpers.h>
 #include <Core/Types.h>
 #include <bit>
+
 namespace DB
 {
 
@@ -508,7 +509,7 @@ UInt32 compressData(const char * src, UInt32 bytes_size, char * dst)
         throw Exception(ErrorCodes::CANNOT_COMPRESS, "Cannot compress with T64 codec, data size {} is not aligned to {}", bytes_size, sizeof(T));
 
     if (bytes_size == 0)
-        return header_size + bytes_to_skip;
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Compressing a buffer of size 0 is not expected.");
 
     UInt32 src_size = bytes_size / sizeof(T);
     UInt32 num_full = src_size / matrix_size;

--- a/src/Compression/CompressionCodecT64.cpp
+++ b/src/Compression/CompressionCodecT64.cpp
@@ -505,11 +505,8 @@ UInt32 compressData(const char * src, UInt32 bytes_size, char * dst)
     src += bytes_to_skip;
     dst += bytes_to_skip;
 
-    if (bytes_size % sizeof(T) != 0)
-        throw Exception(ErrorCodes::CANNOT_COMPRESS, "Cannot compress with T64 codec, data size {} is not aligned to {}", bytes_size, sizeof(T));
-
     if (bytes_size == 0)
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Compressing a buffer of size 0 is not expected.");
+        return bytes_to_skip;
 
     UInt32 src_size = bytes_size / sizeof(T);
     UInt32 num_full = src_size / matrix_size;

--- a/src/Compression/CompressionCodecT64.cpp
+++ b/src/Compression/CompressionCodecT64.cpp
@@ -504,6 +504,12 @@ UInt32 compressData(const char * src, UInt32 bytes_size, char * dst)
     src += bytes_to_skip;
     dst += bytes_to_skip;
 
+    if (bytes_size % sizeof(T) != 0)
+        throw Exception(ErrorCodes::CANNOT_COMPRESS, "Cannot compress with T64 codec, data size {} is not aligned to {}", bytes_size, sizeof(T));
+
+    if (bytes_size == 0)
+        return header_size + bytes_to_skip;
+
     UInt32 src_size = bytes_size / sizeof(T);
     UInt32 num_full = src_size / matrix_size;
     UInt32 tail = src_size % matrix_size;
@@ -563,6 +569,14 @@ void decompressData(const char * src, UInt32 bytes_size, char * dst, UInt32 unco
     bytes_size -= bytes_to_skip;
     src += bytes_to_skip;
     dst += bytes_to_skip;
+
+    if (uncompressed_size % sizeof(T) != 0)
+        throw Exception(ErrorCodes::CANNOT_DECOMPRESS, "Cannot decompress T64-encoded data, unexpected uncompressed size ({})"
+                        " isn't a multiple of the data type size ({})",
+                        uncompressed_size, sizeof(T));
+
+    if (uncompressed_size == 0)
+        return;
 
     UInt64 num_elements = uncompressed_size / sizeof(T);
     MinMaxType min;

--- a/src/Compression/CompressionCodecT64.cpp
+++ b/src/Compression/CompressionCodecT64.cpp
@@ -528,7 +528,7 @@ UInt32 compressData(const char * src, UInt32 bytes_size, char * dst)
 
     UInt32 num_bits = getValuableBitsNumber(min64, max64);
     if (!num_bits)
-        return header_size;
+        return header_size + bytes_to_skip;
 
     T buf[matrix_size];
     UInt32 src_shift = sizeof(T) * matrix_size;

--- a/src/Compression/CompressionCodecT64.cpp
+++ b/src/Compression/CompressionCodecT64.cpp
@@ -10,7 +10,6 @@
 #include <IO/WriteHelpers.h>
 #include <Core/Types.h>
 #include <bit>
-
 namespace DB
 {
 
@@ -505,13 +504,9 @@ UInt32 compressData(const char * src, UInt32 bytes_size, char * dst)
     src += bytes_to_skip;
     dst += bytes_to_skip;
 
-    if (bytes_size % sizeof(T))
-        throw Exception(ErrorCodes::CANNOT_COMPRESS, "Cannot compress with T64 codec, data size {} is not multiplier of {}",
-                        bytes_size, sizeof(T));
     UInt32 src_size = bytes_size / sizeof(T);
     UInt32 num_full = src_size / matrix_size;
     UInt32 tail = src_size % matrix_size;
-
     T min;
     T max;
     findMinMax<T>(src, bytes_size, min, max);
@@ -568,15 +563,6 @@ void decompressData(const char * src, UInt32 bytes_size, char * dst, UInt32 unco
     bytes_size -= bytes_to_skip;
     src += bytes_to_skip;
     dst += bytes_to_skip;
-
-    if (bytes_size < header_size)
-        throw Exception(ErrorCodes::CANNOT_DECOMPRESS, "Cannot decompress T64-encoded data, data size ({}) is less than the size of T64 header",
-                        bytes_size);
-
-    if (uncompressed_size % sizeof(T))
-        throw Exception(ErrorCodes::CANNOT_DECOMPRESS, "Cannot decompress T64-encoded data, unexpected uncompressed size ({})"
-                        " isn't a multiple of the data type size ({})",
-                        uncompressed_size, sizeof(T));
 
     UInt64 num_elements = uncompressed_size / sizeof(T);
     MinMaxType min;

--- a/src/Compression/tests/gtest_compressionCodec.cpp
+++ b/src/Compression/tests/gtest_compressionCodec.cpp
@@ -1367,4 +1367,45 @@ TEST(DoubleDeltaTest, TranscodeRawInput)
     }
 }
 
+TEST(T64Test, TranscodeRawInput)
+{
+    std::vector<DataTypePtr> types = {
+        std::make_shared<DataTypeInt8>(),
+        std::make_shared<DataTypeInt16>(),
+        std::make_shared<DataTypeInt32>(),
+        std::make_shared<DataTypeInt64>(),
+        std::make_shared<DataTypeUInt8>(),
+        std::make_shared<DataTypeUInt16>(),
+        std::make_shared<DataTypeUInt32>(),
+        std::make_shared<DataTypeUInt64>(),
+    };
+
+    for (const auto & type : types)
+    {
+        for (size_t buffer_size = 1; buffer_size < 2000; buffer_size++)
+        {
+            DB::Memory<> source_memory;
+            source_memory.resize(buffer_size);
+
+            for (size_t i = 0; i < buffer_size; ++i)
+                source_memory.data()[i] = i;
+
+            DB::Memory<> memory_for_compression;
+            auto codec = makeCodec("T64", type);
+
+            memory_for_compression.resize(codec->getCompressedReserveSize(buffer_size));
+
+            auto compressed = codec->compress(source_memory.data(), UInt32(source_memory.size()), memory_for_compression.data());
+
+            DB::Memory<> memory_for_decompression;
+            memory_for_decompression.resize(buffer_size);
+            auto decompressed = codec->decompress(memory_for_compression.data(), compressed, memory_for_decompression.data());
+
+            ASSERT_EQ(decompressed, source_memory.size());
+            for (size_t i = 0; i < decompressed; ++i)
+                ASSERT_EQ(memory_for_decompression.data()[i], source_memory.data()[i]) << "with data type " << type->getName() << " with buffer size " << buffer_size << " at position " << i;
+        }
+    }
+}
+
 }

--- a/src/Compression/tests/gtest_compressionCodec.cpp
+++ b/src/Compression/tests/gtest_compressionCodec.cpp
@@ -1382,7 +1382,7 @@ TEST(T64Test, TranscodeRawInput)
 
     for (const auto & type : types)
     {
-        for (size_t buffer_size = 1; buffer_size < 2000; buffer_size++)
+        for (size_t buffer_size = 8; buffer_size < 2000; buffer_size++)
         {
             DB::Memory<> source_memory;
             source_memory.resize(buffer_size);
@@ -1404,6 +1404,39 @@ TEST(T64Test, TranscodeRawInput)
             ASSERT_EQ(decompressed, source_memory.size());
             for (size_t i = 0; i < decompressed; ++i)
                 ASSERT_EQ(memory_for_decompression.data()[i], source_memory.data()[i]) << "with data type " << type->getName() << " with buffer size " << buffer_size << " at position " << i;
+        }
+    }
+}
+
+TEST(T64Test, CompressZeroBufferThrows)
+{
+    std::vector<DataTypePtr> types = {
+        std::make_shared<DataTypeInt8>(),
+        std::make_shared<DataTypeInt16>(),
+        std::make_shared<DataTypeInt32>(),
+        std::make_shared<DataTypeInt64>(),
+        std::make_shared<DataTypeUInt8>(),
+        std::make_shared<DataTypeUInt16>(),
+        std::make_shared<DataTypeUInt32>(),
+        std::make_shared<DataTypeUInt64>(),
+    };
+
+    for (const auto & type : types)
+    {
+        for (size_t buffer_size = 0; buffer_size < type->getSizeOfValueInMemory(); buffer_size++)
+        {
+            DB::Memory<> source_memory;
+            source_memory.resize(buffer_size);
+
+            for (size_t i = 0; i < buffer_size; ++i)
+                source_memory.data()[i] = i;
+
+            DB::Memory<> memory_for_compression;
+            auto codec = makeCodec("T64", type);
+
+            memory_for_compression.resize(codec->getCompressedReserveSize(buffer_size));
+
+            ASSERT_THROW(codec->compress(source_memory.data(), UInt32(source_memory.size()), memory_for_compression.data()), Exception);
         }
     }
 }

--- a/tests/queries/0_stateless/03705_fix_compression_T64_unaligned.sql
+++ b/tests/queries/0_stateless/03705_fix_compression_T64_unaligned.sql
@@ -1,0 +1,12 @@
+DROP TABLE IF EXISTS compression_estimate_example;
+CREATE TABLE IF NOT EXISTS compression_estimate_example (
+    number UInt64
+)
+ENGINE = MergeTree()
+ORDER BY number;
+
+INSERT INTO compression_estimate_example
+SELECT number FROM system.numbers LIMIT 100_000;
+
+SELECT estimateCompressionRatio('DoubleDelta, T64, ZSTD')(number) AS estimate FROM compression_estimate_example FORMAT Null;
+DROP TABLE IF EXISTS compression_estimate_example;


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Backward Incompatible Change

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `Fatal` when compressing data with size not aligned to element size (in T64 codec). Resolves #89282

### Details

Resolves #89282
