### PR TITLE
Fix handling of empty parts with non-empty projections during merge

### DIFF
--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -1443,16 +1443,6 @@ bool MergeTask::MergeProjectionsStage::mergeMinMaxIndexAndPrepareProjections() c
             projection_parts.front()->name,
             projection_parts.back()->name);
 
-        /// Skip parts with empty parent parts.
-        chassert(global_ctx->future_part->parts.size() == projection_parts.size());
-        std::erase_if(
-            projection_parts,
-            [&](const auto & part)
-            {
-                size_t index = &part - projection_parts.data();
-                return global_ctx->future_part->parts[index]->isEmpty();
-            });
-
         auto projection_future_part = std::make_shared<FutureMergedMutatedPart>();
         projection_future_part->assign(std::move(projection_parts), /*patch_parts_=*/ {});
         projection_future_part->name = projection->name;

--- a/tests/queries/0_stateless/03707_empty_parts_with_non_empty_projections_merge.reference
+++ b/tests/queries/0_stateless/03707_empty_parts_with_non_empty_projections_merge.reference
@@ -1,0 +1,9 @@
+-- { echoOn }
+
+drop table if exists mt1;
+create table mt1 (time DateTime, projection proj (select min(time))) engine MergeTree order by () TTL time + interval 1 second settings remove_empty_parts=0, merge_with_ttl_timeout=0, deduplicate_merge_projection_mode='ignore';
+system stop merges mt1;
+insert into mt1 select number from numbers(4) settings max_block_size=1, min_insert_block_size_bytes=1;
+system start merges mt1;
+optimize table mt1 final;
+optimize table mt1 final;

--- a/tests/queries/0_stateless/03707_empty_parts_with_non_empty_projections_merge.sql
+++ b/tests/queries/0_stateless/03707_empty_parts_with_non_empty_projections_merge.sql
@@ -1,0 +1,15 @@
+-- { echoOn }
+
+drop table if exists mt1;
+
+create table mt1 (time DateTime, projection proj (select min(time))) engine MergeTree order by () TTL time + interval 1 second settings remove_empty_parts=0, merge_with_ttl_timeout=0, deduplicate_merge_projection_mode='ignore';
+
+system stop merges mt1;
+
+insert into mt1 select number from numbers(4) settings max_block_size=1, min_insert_block_size_bytes=1;
+
+system start merges mt1;
+
+optimize table mt1 final;
+
+optimize table mt1 final;


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed incorrect merge handling of TTL-emptied parts with non-empty projections when using `deduplicate_merge_projection_mode='ignore'`. Resolves #89430.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

### Details

This PR fixes a critical bug in merge handling where TTL-emptied parts with non-empty projections were incorrectly processed when using `deduplicate_merge_projection_mode='ignore'`.

Resolves #89430
