### PR TITLE
ci: create tables with use_const_adaptive_granularity=1 on ci-logs

### DIFF
--- a/ci/jobs/scripts/functional_tests/setup_log_cluster.sh
+++ b/ci/jobs/scripts/functional_tests/setup_log_cluster.sh
@@ -95,7 +95,7 @@ function setup_logs_replication()
         )
         ENGINE = MergeTree
         ORDER BY test_name
-        SETTINGS use_const_adaptive_granularity=1
+        SETTINGS use_const_adaptive_granularity = 1
         COMMENT 'Contains information about per-test coverage from the CI, but used only for exporting to the CI cluster'
     "
 

--- a/ci/jobs/scripts/functional_tests/setup_log_cluster.sh
+++ b/ci/jobs/scripts/functional_tests/setup_log_cluster.sh
@@ -92,7 +92,11 @@ function setup_logs_replication()
             time DateTime COMMENT 'The time of test run',
             test_name String COMMENT 'The name of the test',
             coverage Array(UInt64) COMMENT 'An array of addresses of the code (a subset of addresses instrumented for coverage) that were encountered during the test run'
-        ) ENGINE = MergeTree ORDER BY test_name COMMENT 'Contains information about per-test coverage from the CI, but used only for exporting to the CI cluster'
+        )
+        ENGINE = MergeTree
+        ORDER BY test_name
+        SETTINGS use_const_adaptive_granularity=1
+        COMMENT 'Contains information about per-test coverage from the CI, but used only for exporting to the CI cluster'
     "
 
     # For each system log table:
@@ -123,7 +127,10 @@ function setup_logs_replication()
             s/^ORDER BY (([^\(].+?)|\((.+?)\))$/ORDER BY ('"$EXTRA_ORDER_BY_COLUMNS"', \2\3)/;
             s/^CREATE TABLE system\.\w+_log$/CREATE TABLE IF NOT EXISTS '"$table"'_'"$hash"'/;
             /^TTL /d
+            /^SETTINGS /d
+            /^COMMENT /d
             ')
+        statement+=" SETTINGS use_const_adaptive_granularity=1"
 
         echo -e "Creating remote destination table ${table}_${hash} with statement:" >&2
 

--- a/ci/jobs/scripts/functional_tests/setup_log_cluster.sh
+++ b/ci/jobs/scripts/functional_tests/setup_log_cluster.sh
@@ -130,7 +130,7 @@ function setup_logs_replication()
             /^SETTINGS /d
             /^COMMENT /d
             ')
-        statement+=" SETTINGS use_const_adaptive_granularity=1"
+        statement+=" SETTINGS use_const_adaptive_granularity = 1"
 
         echo -e "Creating remote destination table ${table}_${hash} with statement:" >&2
 


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Refs: https://github.com/ClickHouse/clickhouse-private/issues/41022