### PR TITLE
Remove unused curl extension

### DIFF
--- a/contrib/curl-cmake/curl_config.h
+++ b/contrib/curl-cmake/curl_config.h
@@ -3,6 +3,8 @@
 #define CURL_DISABLE_TFTP
 #define CURL_DISABLE_LDAP
 #define CURL_DISABLE_SMB
+#define CURL_DISABLE_POP3
+#define CURL_DISABLE_SMTP
 #define CURL_EXTERN_SYMBOL __attribute__ ((__visibility__ ("default")))
 
 #define SIZEOF_SHORT 2


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Details

There is no use for these curl functions in ClickHouse and we don't call it anywhere so let's trim it.
