### PR TITLE
Fix `cherry_pick.py` by adding `update:>last_90_days`

### DIFF
--- a/ci/jobs/scripts/workflow_hooks/pr_labels_and_category.py
+++ b/ci/jobs/scripts/workflow_hooks/pr_labels_and_category.py
@@ -50,7 +50,6 @@ class Labels:
     DO_NOT_TEST = "do not test"
     NO_FAST_TESTS = "no-fast-tests"
     MUST_BACKPORT = "pr-must-backport"
-    MUST_BACKPORT_CLOUD = "pr-must-backport-cloud"
     JEPSEN_TEST = "jepsen-test"
     SKIP_MERGEABLE_CHECK = "skip mergeable check"
     PR_BACKPORT = "pr-backport"
@@ -156,7 +155,7 @@ def check_labels(category, info):
             pr_labels_to_add.append(Labels.SUBMODULE_CHANGED)
 
     if any(label in Labels.AUTO_BACKPORT for label in pr_labels_to_add):
-        backport_labels = [Labels.MUST_BACKPORT, Labels.MUST_BACKPORT_CLOUD]
+        backport_labels = [Labels.MUST_BACKPORT]
         pr_labels_to_add += [label for label in backport_labels if label not in labels]
         print(f"Add backport labels [{backport_labels}] for PR category [{category}]")
 

--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -507,9 +507,15 @@ class BackportPRs:
         # To not have a possible TZ issues
         tomorrow = date.today() + timedelta(days=1)
 
+        # The search API struggles to serve the heavy queries, so we limit the
+        # updated date to 90 days ago. It improves the response quality by an order of
+        # magnitude
+        updated = (date.today() - timedelta(days=90)).isoformat() + "..*"
+
         query_args = {
             "query": f"type:pr repo:{repo_name} -label:{backport_created_label}",
             "label": ",".join(labels_to_backport),
+            "updated": updated,
             "merged": [since_date, tomorrow],
         }
         logging.info("Query to find the backport PRs:\n %s", query_args)

--- a/tests/ci/ci_definitions.py
+++ b/tests/ci/ci_definitions.py
@@ -12,7 +12,6 @@ class Labels:
     CAN_BE_TESTED = "can be tested"
     DO_NOT_TEST = "do not test"
     MUST_BACKPORT = "pr-must-backport"
-    MUST_BACKPORT_CLOUD = "pr-must-backport-cloud"
     MUST_BACKPORT_SYNCED = "pr-must-backport-synced"
     JEPSEN_TEST = "jepsen-test"
     SKIP_MERGEABLE_CHECK = "skip mergeable check"


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Details

Fix cherry_pick.py by adding update:>last_90_days to the search query to avoid hitting GitHub API rate limits when searching for pull requests.
