### PR TITLE
Fix: MaterializedPostgreSQL replication with uppercase column names

### DIFF
--- a/src/Storages/PostgreSQL/PostgreSQLReplicationHandler.cpp
+++ b/src/Storages/PostgreSQL/PostgreSQLReplicationHandler.cpp
@@ -476,7 +476,8 @@ StorageInfo PostgreSQLReplicationHandler::loadFromSnapshot(postgres::Connection 
         /// We should not use columns list from getTableAllowedColumns because it may have broken columns order
         Strings allowed_columns;
         for (const auto & column : table_structure->physical_columns->columns)
-            allowed_columns.push_back(column.name);
+            allowed_columns.push_back(doubleQuoteString(column.name));
+
         query_str = fmt::format("SELECT {} FROM ONLY {}", boost::algorithm::join(allowed_columns, ","), quoted_name);
     }
 


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix MaterializedPostgreSQL replication for tables with configured uppercase column names. Resolves #72363

### Details

MaterializedPostgreSQL replication configured for tables with a specific subset of columns containing uppercase letters (e.g., `Table(ID, createdAt)`) would fail with errors like `pqxx::undefined_column`, because column names would be passed to snapshot query as-is without quoting.

Related to #72363
