### PR TITLE
Revert "Set correct default in config.xml (concurrent_threads_soft_limit_ratio_to_cores=0)"

### DIFF
--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -399,7 +399,7 @@
          Query can upscale to desired number of threads during execution if more threads become available.
     -->
     <concurrent_threads_soft_limit_num>0</concurrent_threads_soft_limit_num>
-    <concurrent_threads_soft_limit_ratio_to_cores>0</concurrent_threads_soft_limit_ratio_to_cores>
+    <concurrent_threads_soft_limit_ratio_to_cores>2</concurrent_threads_soft_limit_ratio_to_cores>
     <concurrent_threads_scheduler>fair_round_robin</concurrent_threads_scheduler>
 
     <!-- Maximum number of concurrent queries. -->


### PR DESCRIPTION
Reverts ClickHouse/ClickHouse#86516

Fix https://github.com/ClickHouse/ClickHouse/issues/89540