### PR TITLE
Disable `plain-rewritable` disks for `test_replicated_database_recover_digest_mismatch`

### DIFF
--- a/tests/integration/test_replicated_database_recover_digest_mismatch/test.py
+++ b/tests/integration/test_replicated_database_recover_digest_mismatch/test.py
@@ -12,6 +12,7 @@ main_node = cluster.add_instance(
     user_configs=["configs/settings.xml"],
     with_zookeeper=True,
     stay_alive=True,
+    with_remote_database_disk=False,
     macros={"shard": 1, "replica": 1},
 )
 dummy_node = cluster.add_instance(
@@ -20,6 +21,7 @@ dummy_node = cluster.add_instance(
     user_configs=["configs/settings2.xml"],
     with_zookeeper=True,
     stay_alive=True,
+    with_remote_database_disk=False,
     macros={"shard": 1, "replica": 2},
 )
 


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Plain rewritable disks do not allow the removal of arbitrary directories by design, so removing the `store/` folder is not supported and will not be.
