### PR TITLE
Fix flaky `test_scheduler_cpu_preemptive/test.py::test_downscaling[cpu-slot-preemption-timeout-1ms]`

### DIFF
--- a/tests/integration/test_scheduler_cpu_preemptive/test.py
+++ b/tests/integration/test_scheduler_cpu_preemptive/test.py
@@ -390,6 +390,9 @@ class DynamicQueryPool:
     indirect=True,
 )
 def test_downscaling(with_custom_config):
+    if node.is_built_with_address_sanitizer():
+        pytest.skip("doesn't fit in timeouts due to heavy workload")
+
     node.query(
         f"""
         create resource cpu (master thread, worker thread);


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Details

Fix flaky `test_scheduler_cpu_preemptive/test.py::test_downscaling[cpu-slot-preemption-timeout-1ms]` test by disabling it under ASAN builds where timing is less predictable.
