### PR TITLE
Use allocator that respects MemoryTracker in LazyOutput of HashJoin

### DIFF
--- a/src/Columns/IColumn.cpp
+++ b/src/Columns/IColumn.cpp
@@ -568,9 +568,11 @@ void IColumnHelper<Derived, Parent>::fillFromRowRefs(const DataTypePtr & type, s
 /// Fills column values from list of blocks and row numbers
 /// Implementation with concrete column type allows to de-virtualize col->insertFrom() calls
 template <typename ColumnType>
-static void fillColumnFromBlocksAndRowNumbers(ColumnType * col, const DataTypePtr & type, size_t source_column_index_in_block, const std::vector<const ColumnsInfo *> & columns, const std::vector<UInt32> & row_nums)
+static void fillColumnFromBlocksAndRowNumbers(ColumnType * col, const DataTypePtr & type, size_t source_column_index_in_block, ColumnsWithRowNumbers columns_with_row_numbers)
 {
-    chassert(columns.size() == row_nums.size());
+    const auto & columns = columns_with_row_numbers.columns;
+    const auto & row_numbers = columns_with_row_numbers.row_numbers;
+    chassert(columns.size() == row_numbers.size());
 
     col->reserve(col->size() + columns.size());
     for (size_t j = 0; j < columns.size(); ++j)
@@ -578,9 +580,9 @@ static void fillColumnFromBlocksAndRowNumbers(ColumnType * col, const DataTypePt
         if (columns[j])
         {
             if (const auto * source_replicated = columns[j]->replicated_columns[source_column_index_in_block])
-                col->insertFrom(*source_replicated->getNestedColumn(), source_replicated->getIndexes().getIndexAt(row_nums[j]));
+                col->insertFrom(*source_replicated->getNestedColumn(), source_replicated->getIndexes().getIndexAt(row_numbers[j]));
             else
-                col->insertFrom(*columns[j]->columns[source_column_index_in_block], row_nums[j]);
+                col->insertFrom(*columns[j]->columns[source_column_index_in_block], row_numbers[j]);
         }
         else
         {
@@ -590,17 +592,17 @@ static void fillColumnFromBlocksAndRowNumbers(ColumnType * col, const DataTypePt
 }
 
 /// Fills column values from list of blocks and row numbers
-void IColumn::fillFromBlocksAndRowNumbers(const DataTypePtr & type, size_t source_column_index_in_block, const std::vector<const ColumnsInfo *> & columns, const std::vector<UInt32> & row_nums)
+void IColumn::fillFromBlocksAndRowNumbers(const DataTypePtr & type, size_t source_column_index_in_block, ColumnsWithRowNumbers columns_with_row_numbers)
 {
-    fillColumnFromBlocksAndRowNumbers(this, type, source_column_index_in_block, columns, row_nums);
+    fillColumnFromBlocksAndRowNumbers(this, type, source_column_index_in_block, columns_with_row_numbers);
 }
 
 /// Fills column values from list of blocks and row numbers
 template <typename Derived, typename Parent>
-void IColumnHelper<Derived, Parent>::fillFromBlocksAndRowNumbers(const DataTypePtr & type, size_t source_column_index_in_block, const std::vector<const ColumnsInfo *> & columns, const std::vector<UInt32> & row_nums)
+void IColumnHelper<Derived, Parent>::fillFromBlocksAndRowNumbers(const DataTypePtr & type, size_t source_column_index_in_block, ColumnsWithRowNumbers columns_with_row_numbers)
 {
     auto & self = static_cast<Derived &>(*this);
-    fillColumnFromBlocksAndRowNumbers(&self, type, source_column_index_in_block, columns, row_nums);
+    fillColumnFromBlocksAndRowNumbers(&self, type, source_column_index_in_block, columns_with_row_numbers);
 }
 
 template <typename Derived, typename Parent>

--- a/src/Interpreters/HashJoin/AddedColumns.cpp
+++ b/src/Interpreters/HashJoin/AddedColumns.cpp
@@ -102,8 +102,10 @@ size_t LazyOutput::buildOutputFromBlocksLimitAndOffset(
 {
     if (columns.empty())
         return rows_limit;
-    std::vector<const ColumnsInfo *> many_columns;
-    std::vector<UInt32> row_nums;
+
+    ColumnsWithRowNumbers columns_with_row_numbers;
+    auto & many_columns = columns_with_row_numbers.columns;
+    auto & row_nums = columns_with_row_numbers.row_numbers;
     many_columns.reserve(rows_limit);
     row_nums.reserve(rows_limit);
 
@@ -163,7 +165,7 @@ size_t LazyOutput::buildOutputFromBlocksLimitAndOffset(
 
     for (size_t i = 0; i < columns.size(); ++i)
     {
-        columns[i]->fillFromBlocksAndRowNumbers(type_name[i].type, right_indexes[i], many_columns, row_nums);
+        columns[i]->fillFromBlocksAndRowNumbers(type_name[i].type, right_indexes[i], columns_with_row_numbers);
     }
     return row_nums.size();
 }
@@ -174,8 +176,10 @@ void LazyOutput::buildOutputFromBlocks(size_t size_to_reserve, MutableColumns & 
 {
     if (columns.empty())
         return;
-    std::vector<const ColumnsInfo *> many_columns;
-    std::vector<UInt32> row_nums;
+
+    ColumnsWithRowNumbers columns_with_row_numbers;
+    auto & many_columns = columns_with_row_numbers.columns;
+    auto & row_nums = columns_with_row_numbers.row_numbers;
     many_columns.reserve(size_to_reserve);
     row_nums.reserve(size_to_reserve);
     for (const UInt64 * row_ref_i = row_refs_begin; row_ref_i != row_refs_end; ++row_ref_i)
@@ -206,7 +210,7 @@ void LazyOutput::buildOutputFromBlocks(size_t size_to_reserve, MutableColumns & 
     }
     for (size_t i = 0; i < columns.size(); ++i)
     {
-        columns[i]->fillFromBlocksAndRowNumbers(type_name[i].type, right_indexes[i], many_columns, row_nums);
+        columns[i]->fillFromBlocksAndRowNumbers(type_name[i].type, right_indexes[i], columns_with_row_numbers);
     }
 }
 


### PR DESCRIPTION
<!---AI changelog entry and formatting assistance: false-->

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Improved memory tracking in hash joins result generation. Previously, temporary allocations during generating join result were not properly tracked, which could lead to memory limit overruns

I noticed that this is one of the major contributors to MemoryAllocatedWithoutCheck:

    :) select arrayStringConcat(symbols, '\n'), sum(size), count(), sum(size)/count() from trace_log_3407706798345528581 where toYYYYMM(event_date) = 202509 and trace_type = 'MemoryAllocatedWithoutCheck' group by all order by 2 limit -5\G
    Row 5:
    ──────
    arrayStringConcat(symbols, '\n'): StackTrace::StackTrace()
    incrementAllocationWithoutCheck(long)
    MemoryTracker::allocImpl(long, bool, MemoryTracker*, double)
    MemoryTracker::allocImpl(long, bool, MemoryTracker*, double)
    MemoryTracker::allocImpl(long, bool, MemoryTracker*, double)
    CurrentMemoryTracker::allocImpl(long, bool)
    operator new(unsigned long)
    DB::LazyOutput::buildOutputFromBlocksLimitAndOffset(std::__1::vector<COW<DB::IColumn>::mutable_ptr<DB::IColumn>, std::__1::allocator<COW<DB::IColumn>::mutable_ptr<DB::IColumn>>>&, unsigned long const*, unsigned long const*, unsigned long, unsigned long) const
    DB::generateBlock(std::__1::unique_ptr<DB::HashJoinResult::GenerateCurrentRowState, std::__1::default_delete<DB::HashJoinResult::GenerateCurrentRowState>>&, DB::PODArray<char8_t, 4096ul, Allocator<false, false>, 63ul, 64ul> const&, DB::LazyOutput const&, DB::HashJoinResult::Properties const&)
    DB::HashJoinResult::next()
    DB::JoiningTransform::readExecute(DB::Chunk&)
    DB::JoiningTransform::transform(DB::Chunk&)
    DB::JoiningTransform::work()
    DB::ExecutionThreadContext::executeTask()
    DB::PipelineExecutor::executeStepImpl(unsigned long, DB::IAcquiredSlot*, std::__1::atomic<bool>*)
    DB::PipelineExecutor::executeSingleThread(unsigned long, DB::IAcquiredSlot*)
    DB::PipelineExecutor::executeImpl(unsigned long, bool)
    DB::PipelineExecutor::execute(unsigned long, bool)
    void std::__1::__function::__policy_invoker<void ()>::__call_impl[abi:se190107]<std::__1::__function::__default_alloc_func<ThreadFromGlobalPoolImpl<true, true>::ThreadFromGlobalPoolImpl<DB::PullingAsyncPipelineExecutor::pull(DB::Chunk&, unsigned long)::$_0>(DB::PullingAsyncPipelineExecutor::pull(DB::Chunk&, unsigned long)::$_0&&)::'lambda'(), void ()>>(std::__1::__function::__policy_storage const*)
    ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::worker()
    void* std::__1::__thread_proxy[abi:se190107]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::__1::thread>::ThreadFromThreadPool*>>(void*)

    sum(size):                        46713843640832 -- 46.71 trillion
    count():                          77856
    divide(sum(size), count()):       600003129.377723 -- 600.00 million
