### PR TITLE
tests: fix 03141_fetches_errors_stress

### DIFF
--- a/tests/queries/0_stateless/03141_fetches_errors_stress.reference
+++ b/tests/queries/0_stateless/03141_fetches_errors_stress.reference
@@ -2,7 +2,7 @@
 select table, errorCodeToName(error), count() from system.part_log where
     database = currentDatabase()
     and error > 0
-    and errorCodeToName(error) not in ('FAULT_INJECTED', 'NO_REPLICA_HAS_PART', 'ATTEMPT_TO_READ_AFTER_EOF')
+    and errorCodeToName(error) not in ('FAULT_INJECTED', 'NO_REPLICA_HAS_PART', 'ATTEMPT_TO_READ_AFTER_EOF', 'CHECKSUM_DOESNT_MATCH')
     and (errorCodeToName(error) != 'POCO_EXCEPTION' or exception not like '%Malformed message: Unexpected EOF%')
     group by 1, 2
     order by 1, 2;


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Details

It is also possible to get CHECKSUM_DOESNT_MATCH with enabled replicated_sends_failpoint, since we send some data before.

Fixes: https://github.com/ClickHouse/ClickHouse/issues/83373
