### PR TITLE
Fix `plain-rewritable` in case of corrupted disk

### DIFF
--- a/src/Disks/ObjectStorages/InMemoryDirectoryTree.cpp
+++ b/src/Disks/ObjectStorages/InMemoryDirectoryTree.cpp
@@ -3,7 +3,8 @@
 #include <Common/CurrentMetrics.h>
 #include <Common/Exception.h>
 
-#include <deque>
+#include <base/scope_guard.h>
+
 #include <mutex>
 #include <filesystem>
 #include <memory>
@@ -110,6 +111,21 @@ std::filesystem::path InMemoryDirectoryTree::determineNodePath(std::shared_ptr<I
     return nodes_path;
 }
 
+std::shared_ptr<InMemoryDirectoryTree::INode> InMemoryDirectoryTree::trimDanglingVirtualPath(std::shared_ptr<INode> node)
+{
+    while (!node->isRoot() && node->isVirtual())
+    {
+        if (!node->subdirectories.empty())
+            break;
+
+        auto parent = node->parent.lock();
+        parent->subdirectories.erase(node->last_directory_name);
+        node = parent;
+    }
+
+    return node;
+}
+
 InMemoryDirectoryTree::InMemoryDirectoryTree(CurrentMetrics::Metric metric_directories_name, CurrentMetrics::Metric metric_files_name)
     : remote_layout_directories_count(metric_directories_name)
     , remote_layout_files_count(metric_files_name)
@@ -212,6 +228,7 @@ void InMemoryDirectoryTree::unlinkTree(const std::string & path)
 
     auto inode_parent = inode->parent.lock();
     inode_parent->subdirectories.erase(normalized_path.filename());
+    trimDanglingVirtualPath(inode_parent);
 }
 
 void InMemoryDirectoryTree::moveDirectory(const std::string & from, const std::string & to)
@@ -221,7 +238,7 @@ void InMemoryDirectoryTree::moveDirectory(const std::string & from, const std::s
     const auto normalized_to = normalizePath(to);
 
     const auto inode_from = walk(normalized_from);
-    const auto inode_to_parent = walk(normalized_to.parent_path());
+    const auto inode_to_parent = walk(normalized_to.parent_path(), /*create_missing=*/true);
 
     if (!inode_from)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Directory '{}' does not exist", normalized_from.string());
@@ -229,8 +246,9 @@ void InMemoryDirectoryTree::moveDirectory(const std::string & from, const std::s
     if (inode_from->isRoot())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Directory '{}' is root", normalized_from.string());
 
-    if (!inode_to_parent)
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Directory '{}' does not exist", normalized_to.parent_path().string());
+    const auto inode_from_parent = inode_from->parent.lock();
+    scope_guard trim_from = [&]() TSA_REQUIRES(mutex) { trimDanglingVirtualPath(inode_from_parent); };
+    scope_guard trim_to = [&]() TSA_REQUIRES(mutex) { trimDanglingVirtualPath(inode_to_parent); };
 
     if (inode_to_parent->subdirectories.contains(normalized_to.filename()))
         throw Exception(ErrorCodes::LOGICAL_ERROR, "There is a subdirectory '{}' under the path '{}', can't move", normalized_to.filename().string(), normalized_to.parent_path().string());
@@ -239,7 +257,6 @@ void InMemoryDirectoryTree::moveDirectory(const std::string & from, const std::s
         if (inode_to_parent->remote_info->file_names.contains(normalized_to.filename()))
             throw Exception(ErrorCodes::LOGICAL_ERROR, "There is a file '{}' under the path '{}', can't move", normalized_to.filename().string(), normalized_to.parent_path().string());
 
-    const auto inode_from_parent = inode_from->parent.lock();
     inode_from_parent->subdirectories.erase(normalized_from.filename());
     inode_to_parent->subdirectories.emplace(normalized_to.filename(), inode_from);
 

--- a/src/Disks/ObjectStorages/InMemoryDirectoryTree.cpp
+++ b/src/Disks/ObjectStorages/InMemoryDirectoryTree.cpp
@@ -197,9 +197,6 @@ void InMemoryDirectoryTree::unlinkTree(const std::string & path)
     if (!inode)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Directory '{}' does not exist", normalized_path.string());
 
-    if (inode->isVirtual())
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Directory '{}' is virtual", normalized_path.string());
-
     if (inode->isRoot())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Directory '{}' is root", normalized_path.string());
 
@@ -228,9 +225,6 @@ void InMemoryDirectoryTree::moveDirectory(const std::string & from, const std::s
 
     if (!inode_from)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Directory '{}' does not exist", normalized_from.string());
-
-    if (inode_from->isVirtual())
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Directory '{}' is virtual", normalized_from.string());
 
     if (inode_from->isRoot())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Directory '{}' is root", normalized_from.string());

--- a/src/Disks/ObjectStorages/InMemoryDirectoryTree.h
+++ b/src/Disks/ObjectStorages/InMemoryDirectoryTree.h
@@ -44,6 +44,9 @@ class InMemoryDirectoryTree
     /// Constructs path which can be resolved (walked) to node.
     std::filesystem::path determineNodePath(std::shared_ptr<INode> node) const TSA_REQUIRES(mutex);
 
+    /// Removes all parents of node while the parent should not exist. Node should exist if some physical node exists in it's subtree.
+    std::shared_ptr<INode> trimDanglingVirtualPath(std::shared_ptr<INode> node) TSA_REQUIRES(mutex);
+
 public:
     InMemoryDirectoryTree(CurrentMetrics::Metric metric_directories_name, CurrentMetrics::Metric metric_files_name);
     void apply(std::unordered_map<std::string, DirectoryRemoteInfo> remote_layout);

--- a/src/Disks/ObjectStorages/MetadataStorageFromPlainRewritableObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/MetadataStorageFromPlainRewritableObjectStorage.cpp
@@ -304,10 +304,11 @@ std::optional<Poco::Timestamp> MetadataStorageFromPlainRewritableObjectStorage::
 {
     if (auto [exists, remote_info] = fs_tree->existsDirectory(path); exists)
     {
-        if (!remote_info)
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "Directory '{}' is virtual", path);
+        if (remote_info)
+            return Poco::Timestamp::fromEpochTime(remote_info->last_modified);
 
-        return Poco::Timestamp::fromEpochTime(remote_info->last_modified);
+        /// Let's return something in this case to unblock fs garbage cleanup.
+        return Poco::Timestamp::fromEpochTime(0);
     }
 
     if (auto object_metadata = getObjectMetadataEntryWithCache(path))

--- a/src/Disks/tests/gtest_metadata_plain_rewritable_disk.cpp
+++ b/src/Disks/tests/gtest_metadata_plain_rewritable_disk.cpp
@@ -1415,3 +1415,117 @@ TEST_F(MetadataPlainRewritableDiskTest, CreateHardLinkRootFiles)
         "./CreateHardLinkRootFiles/__root/f2",
     }));
 }
+
+TEST_F(MetadataPlainRewritableDiskTest, MoveVirtual)
+{
+    thread_local_rng.seed(42);
+
+    auto metadata = getMetadataStorage("MoveVirtual");
+    auto object_storage = getObjectStorage("MoveVirtual");
+
+    {
+        auto tx = metadata->createTransaction();
+        tx->createDirectoryRecursive("/A/B/C/D/E");
+        tx->createDirectoryRecursive("/A/B/C/X/Y");
+        tx->commit();
+    }
+
+    EXPECT_TRUE(metadata->existsDirectory("/A/B/C"));
+    EXPECT_TRUE(metadata->existsDirectory("/A/B/C/D"));
+    EXPECT_TRUE(metadata->existsDirectory("/A/B/C/X"));
+
+    EXPECT_EQ(listAllBlobs("MoveVirtual"), std::vector<std::string>({
+        "./MoveVirtual/__meta/faefxnlkbtfqgxcbfqfjtztsocaqrnqn/prefix.path",
+        "./MoveVirtual/__meta/ykwvvchguqasvfnkikaqtiebknfzafwv/prefix.path",
+    }));
+
+    {
+        auto tx = metadata->createTransaction();
+        tx->moveDirectory("/A/B/C", "/A/B/H");
+        tx->commit();
+    }
+
+    EXPECT_FALSE(metadata->existsDirectory("/A/B/C"));
+    EXPECT_FALSE(metadata->existsDirectory("/A/B/C/D"));
+    EXPECT_FALSE(metadata->existsDirectory("/A/B/C/X"));
+    EXPECT_TRUE(metadata->existsDirectory("/A/B/H"));
+    EXPECT_TRUE(metadata->existsDirectory("/A/B/H/D"));
+    EXPECT_TRUE(metadata->existsDirectory("/A/B/H/X"));
+
+    metadata = restartMetadataStorage("MoveVirtual");
+    EXPECT_FALSE(metadata->existsDirectory("/A/B/C"));
+    EXPECT_FALSE(metadata->existsDirectory("/A/B/C/D"));
+    EXPECT_FALSE(metadata->existsDirectory("/A/B/C/X"));
+    EXPECT_TRUE(metadata->existsDirectory("/A/B/H"));
+    EXPECT_TRUE(metadata->existsDirectory("/A/B/H/D"));
+    EXPECT_TRUE(metadata->existsDirectory("/A/B/H/X"));
+
+    EXPECT_EQ(listAllBlobs("MoveVirtual"), std::vector<std::string>({
+        "./MoveVirtual/__meta/faefxnlkbtfqgxcbfqfjtztsocaqrnqn/prefix.path",
+        "./MoveVirtual/__meta/ykwvvchguqasvfnkikaqtiebknfzafwv/prefix.path",
+    }));
+}
+
+TEST_F(MetadataPlainRewritableDiskTest, RemoveRecursiveVirtual)
+{
+    thread_local_rng.seed(42);
+
+    auto metadata = getMetadataStorage("RemoveRecursiveVirtual");
+    auto object_storage = getObjectStorage("RemoveRecursiveVirtual");
+
+    {
+        auto tx = metadata->createTransaction();
+        tx->createDirectoryRecursive("/A/B/C/D/E");
+        tx->createDirectoryRecursive("/A/B/C/X/Y");
+        tx->createDirectoryRecursive("/A/B/C/K/L");
+        tx->commit();
+    }
+
+    EXPECT_TRUE(metadata->existsDirectory("/A/B/C"));
+    EXPECT_TRUE(metadata->existsDirectory("/A/B/C/D"));
+    EXPECT_TRUE(metadata->existsDirectory("/A/B/C/X"));
+    EXPECT_TRUE(metadata->existsDirectory("/A/B/C/K"));
+
+    EXPECT_EQ(listAllBlobs("RemoveRecursiveVirtual"), std::vector<std::string>({
+        "./RemoveRecursiveVirtual/__meta/faefxnlkbtfqgxcbfqfjtztsocaqrnqn/prefix.path",
+        "./RemoveRecursiveVirtual/__meta/wcageakzukwtfkvkwibqrfhzrrlubsbg/prefix.path",
+        "./RemoveRecursiveVirtual/__meta/ykwvvchguqasvfnkikaqtiebknfzafwv/prefix.path",
+    }));
+
+    {
+        auto tx = metadata->createTransaction();
+        tx->removeRecursive("/A/B/C/D");
+        tx->commit();
+    }
+
+    EXPECT_TRUE(metadata->existsDirectory("/A/B/C"));
+    EXPECT_FALSE(metadata->existsDirectory("/A/B/C/D"));
+    EXPECT_FALSE(metadata->existsDirectory("/A/B/C/D/E"));
+    EXPECT_TRUE(metadata->existsDirectory("/A/B/C/X"));
+    EXPECT_TRUE(metadata->existsDirectory("/A/B/C/K"));
+
+    metadata = restartMetadataStorage("RemoveRecursiveVirtual");
+    EXPECT_TRUE(metadata->existsDirectory("/A/B/C"));
+    EXPECT_FALSE(metadata->existsDirectory("/A/B/C/D"));
+    EXPECT_FALSE(metadata->existsDirectory("/A/B/C/D/E"));
+    EXPECT_TRUE(metadata->existsDirectory("/A/B/C/X"));
+    EXPECT_TRUE(metadata->existsDirectory("/A/B/C/K"));
+
+    EXPECT_EQ(listAllBlobs("RemoveRecursiveVirtual"), std::vector<std::string>({
+        "./RemoveRecursiveVirtual/__meta/wcageakzukwtfkvkwibqrfhzrrlubsbg/prefix.path",
+        "./RemoveRecursiveVirtual/__meta/ykwvvchguqasvfnkikaqtiebknfzafwv/prefix.path",
+    }));
+
+    {
+        auto tx = metadata->createTransaction();
+        tx->removeRecursive("/A/B/C");
+        tx->commit();
+    }
+
+    EXPECT_FALSE(metadata->existsDirectory("/A/B/C"));
+
+    metadata = restartMetadataStorage("RemoveRecursiveVirtual");
+    EXPECT_FALSE(metadata->existsDirectory("/A/B/C"));
+
+    EXPECT_EQ(listAllBlobs("RemoveRecursiveVirtual"), std::vector<std::string>({}));
+}

--- a/src/Disks/tests/gtest_metadata_plain_rewritable_disk.cpp
+++ b/src/Disks/tests/gtest_metadata_plain_rewritable_disk.cpp
@@ -1523,9 +1523,11 @@ TEST_F(MetadataPlainRewritableDiskTest, RemoveRecursiveVirtual)
     }
 
     EXPECT_FALSE(metadata->existsDirectory("/A/B/C"));
+    EXPECT_FALSE(metadata->existsDirectory("/A/B"));
 
     metadata = restartMetadataStorage("RemoveRecursiveVirtual");
     EXPECT_FALSE(metadata->existsDirectory("/A/B/C"));
+    EXPECT_FALSE(metadata->existsDirectory("/A/B"));
 
     EXPECT_EQ(listAllBlobs("RemoveRecursiveVirtual"), std::vector<std::string>({}));
 }

--- a/tests/integration/test_plain_rewritable_backward_compatibility/test.py
+++ b/tests/integration/test_plain_rewritable_backward_compatibility/test.py
@@ -185,7 +185,7 @@ def test_backward_compatibility_bug_80393(start_cluster):
     node_master.query("DROP TABLE mt SYNC")
     node_master.stop_clickhouse()
 
-    for node in [node_25_4, node_master]:
+    for node in [node_25_4]:
         node.exec_in_container(["rm", "/var/lib/clickhouse/metadata/default/mt.sql"])
 
     blobs = [obj.object_name for obj in cluster.minio_client.list_objects(cluster.minio_bucket, 'data/', recursive=True)]

--- a/tests/integration/test_plain_rewritable_backward_compatibility/test.py
+++ b/tests/integration/test_plain_rewritable_backward_compatibility/test.py
@@ -164,12 +164,14 @@ def test_backward_compatibility_bug_80393(start_cluster):
     node_25_4.start_clickhouse()
     node_25_4.query(create_table_query)
     node_25_4.query("INSERT INTO mt VALUES ('25.4')")
+    table_uuid = node_25_4.query("SELECT uuid FROM system.tables WHERE table = 'mt'").strip()
     assert node_25_4.query("SELECT version FROM mt").split() == ["25.4"]
     node_25_4.stop_clickhouse()
 
     blobs = [obj.object_name for obj in cluster.minio_client.list_objects(cluster.minio_bucket, 'data/', recursive=True)]
     data = [cluster.minio_client.get_object(cluster.minio_bucket, blob).data for blob in blobs]
     print(*zip(blobs, data))
+    assert (f"store/{table_uuid[:3]}/{table_uuid}/tmp_insert_all_1_1_0/prj.proj/").encode('ascii') in data
 
     table_attach_query = node_25_4.exec_in_container(["cat", "/var/lib/clickhouse/metadata/default/mt.sql"])
     table_attach_query_b64 = base64.b64encode(table_attach_query.encode()).decode()
@@ -184,6 +186,10 @@ def test_backward_compatibility_bug_80393(start_cluster):
     node_master.stop_clickhouse()
 
     blobs = [obj.object_name for obj in cluster.minio_client.list_objects(cluster.minio_bucket, 'data/', recursive=True)]
+    data = [cluster.minio_client.get_object(cluster.minio_bucket, blob).data for blob in blobs]
+    print(*zip(blobs, data))
+    assert (f"store/{table_uuid[:3]}/{table_uuid}/tmp_insert_all_1_1_0/prj.proj/").encode('ascii') not in data
+
     if len(blobs) != 0:
         to_remove = [DeleteObject(blob) for blob in blobs]
         errors = cluster.minio_client.remove_objects(cluster.minio_bucket, to_remove)

--- a/tests/integration/test_plain_rewritable_backward_compatibility/test.py
+++ b/tests/integration/test_plain_rewritable_backward_compatibility/test.py
@@ -16,6 +16,7 @@ setup_settings = {
     'stay_alive': True,
     'with_remote_database_disk': False,
 }
+node_25_4 = cluster.add_instance("node_25_4", image="clickhouse/clickhouse-server", tag="25.4", with_installed_binary=True, **setup_settings)
 node_25_6 = cluster.add_instance("node_25_6", image="clickhouse/clickhouse-server", tag="25.6", with_installed_binary=True, **setup_settings)
 node_25_8 = cluster.add_instance("node_25_8", image="clickhouse/clickhouse-server", tag="25.8", with_installed_binary=True, **setup_settings)
 node_25_10 = cluster.add_instance("node_25_10", image="clickhouse/clickhouse-server", tag="25.10", with_installed_binary=True, **setup_settings)
@@ -30,11 +31,13 @@ def start_cluster():
         cluster.start()
 
         # We are making tmp table here to force creation of metadata symlink
+        node_25_4.query(f"CREATE TABLE tmp (version String) ENGINE = MergeTree ORDER BY ()")
         node_25_6.query(f"CREATE TABLE tmp (version String) ENGINE = MergeTree ORDER BY ()")
         node_25_8.query(f"CREATE TABLE tmp (version String) ENGINE = MergeTree ORDER BY ()")
         node_25_10.query(f"CREATE TABLE tmp (version String) ENGINE = MergeTree ORDER BY ()")
         node_master.query(f"CREATE TABLE tmp (version String) ENGINE = MergeTree ORDER BY ()")
 
+        node_25_4.stop_clickhouse()
         node_25_6.stop_clickhouse()
         node_25_8.stop_clickhouse()
         node_25_10.stop_clickhouse()
@@ -148,6 +151,39 @@ def test_backward_compatibility_readonly_tables(start_cluster):
 
     blobs = [obj.object_name for obj in cluster.minio_client.list_objects(cluster.minio_bucket, 'data/', recursive=True)]
     print(blobs)
+    if len(blobs) != 0:
+        to_remove = [DeleteObject(blob) for blob in blobs]
+        errors = cluster.minio_client.remove_objects(cluster.minio_bucket, to_remove)
+        for error in errors:
+            logging.error(f"Error occurred when deleting object {error}")
+
+# https://github.com/ClickHouse/ClickHouse/pull/80393
+def test_backward_compatibility_bug_80393(start_cluster):
+    create_table_query = f"CREATE TABLE mt (version String, PROJECTION prj (SELECT version ORDER BY version)) ENGINE = MergeTree ORDER BY () SETTINGS disk = 's3_plain_rewritable', merge_tree_clear_old_temporary_directories_interval_seconds=0"
+
+    node_25_4.start_clickhouse()
+    node_25_4.query(create_table_query)
+    node_25_4.query("INSERT INTO mt VALUES ('25.4')")
+    assert node_25_4.query("SELECT version FROM mt").split() == ["25.4"]
+    node_25_4.stop_clickhouse()
+
+    blobs = [obj.object_name for obj in cluster.minio_client.list_objects(cluster.minio_bucket, 'data/', recursive=True)]
+    data = [cluster.minio_client.get_object(cluster.minio_bucket, blob).data for blob in blobs]
+    print(*zip(blobs, data))
+
+    table_attach_query = node_25_4.exec_in_container(["cat", "/var/lib/clickhouse/metadata/default/mt.sql"])
+    table_attach_query_b64 = base64.b64encode(table_attach_query.encode()).decode()
+    node_master.exec_in_container(["bash", "-lc", f"printf %s {shlex.quote(table_attach_query_b64)} | base64 -d > /var/lib/clickhouse/metadata/default/mt.sql"])
+    assert node_master.exec_in_container(["ls", "/var/lib/clickhouse/metadata/default"]).split() == ["mt.sql", "tmp.sql"]
+    assert node_master.exec_in_container(["cat", "/var/lib/clickhouse/metadata/default/mt.sql"]) == table_attach_query
+
+    node_master.start_clickhouse()
+    assert node_master.query("SHOW TABLES").split() == ["mt", "tmp"]
+    assert node_master.query("SELECT version FROM mt ORDER BY version").split() == ["25.4"]
+    node_master.query("DROP TABLE mt SYNC")
+    node_master.stop_clickhouse()
+
+    blobs = [obj.object_name for obj in cluster.minio_client.list_objects(cluster.minio_bucket, 'data/', recursive=True)]
     if len(blobs) != 0:
         to_remove = [DeleteObject(blob) for blob in blobs]
         errors = cluster.minio_client.remove_objects(cluster.minio_bucket, to_remove)

--- a/tests/integration/test_plain_rewritable_backward_compatibility/test.py
+++ b/tests/integration/test_plain_rewritable_backward_compatibility/test.py
@@ -185,6 +185,9 @@ def test_backward_compatibility_bug_80393(start_cluster):
     node_master.query("DROP TABLE mt SYNC")
     node_master.stop_clickhouse()
 
+    for node in [node_25_4, node_master]:
+        node.exec_in_container(["rm", "/var/lib/clickhouse/metadata/default/mt.sql"])
+
     blobs = [obj.object_name for obj in cluster.minio_client.list_objects(cluster.minio_bucket, 'data/', recursive=True)]
     data = [cluster.minio_client.get_object(cluster.minio_bucket, blob).data for blob in blobs]
     print(*zip(blobs, data))


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Before https://github.com/ClickHouse/ClickHouse/pull/80393, projections were not moved to the resulting directory during part commit. Let's skip these parts during the old parts cleanup.
