### PR TITLE
ci: disable any caches for ci_logs_sender (avoid poluting caches on ci-logs)

### DIFF
--- a/tests/config/users.d/ci_logs_sender.yaml
+++ b/tests/config/users.d/ci_logs_sender.yaml
@@ -7,6 +7,9 @@ profiles:
         receive_timeout: 15
         # Disable async INSERT, since the batches should be big enough
         async_insert: 0
+        # Avoid polluting caches
+        enable_filesystem_cache_on_write_operations: 0
+        write_through_distributed_cache: 0
 users:
     ci_logs_sender:
         profile: ci_logs_sender


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Details

Note, that `write_through_distributed_cache` has been already disabled on `ci-logs` for the user.
