### PR TITLE
Reduce a number of server restarts and kill the test if it cannot res…

### DIFF
--- a/tests/docker_scripts/stress_tests.lib
+++ b/tests/docker_scripts/stress_tests.lib
@@ -249,7 +249,7 @@ function stop_server()
 function start_server()
 {
     counter=0
-    max_attempt=${1:-120}
+    max_attempt=${1:-5}
     until clickhouse-client --query "SELECT 1"
     do
         if [ "$counter" -gt "$max_attempt" ]
@@ -260,7 +260,7 @@ function start_server()
             cat /var/log/clickhouse-server/stdout.log
             tail -n100 /var/log/clickhouse-server/stderr.log
             tail -n100000 /var/log/clickhouse-server/clickhouse-server.log | rg -F -v -e '<Warning> RaftInstance:' -e '<Information> RaftInstance' | tail -n100
-            break
+            exit 1
         fi
         # use root to match with current uid
         clickhouse start --user root >/var/log/clickhouse-server/stdout.log 2>>/var/log/clickhouse-server/stderr.log

--- a/tests/docker_scripts/stress_tests.lib
+++ b/tests/docker_scripts/stress_tests.lib
@@ -264,7 +264,7 @@ function start_server()
         fi
         # use root to match with current uid
         clickhouse start --user root >/var/log/clickhouse-server/stdout.log 2>>/var/log/clickhouse-server/stderr.log
-        sleep 0.5
+        sleep 60
         counter=$((counter + 1))
     done
 


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Reduce number of server restarts in stress tests to 5, it does make little sense spending 2 hours by restarting the server 120 times

### Details
Reduce a number of server restarts and kill the test if it cannot restart the server.
