### PR TITLE
Fix flaky `00076_system_columns_bytes`

### DIFF
--- a/tests/queries/0_stateless/00076_system_columns_bytes.sql
+++ b/tests/queries/0_stateless/00076_system_columns_bytes.sql
@@ -2,4 +2,16 @@
 -- NOTE:
 -- - database = currentDatabase() is not mandatory
 -- - Merge tables may cause UNKNOWN_DATABASE/CANNOT_EXTRACT_TABLE_STRUCTURE from StorageMerge::getColumnSizes() since the table/database can be removed
-SELECT sum(data_compressed_bytes) > 0, sum(data_uncompressed_bytes) > 0, sum(marks_bytes) > 0 FROM system.columns WHERE (database, table) IN (SELECT database, table FROM system.tables WHERE engine != 'Merge');
+-- - StorageProxy can wrap any table function
+SELECT
+    sum(data_compressed_bytes) > 0,
+    sum(data_uncompressed_bytes) > 0,
+    sum(marks_bytes) > 0
+FROM system.columns
+WHERE (database, `table`) IN (
+    SELECT
+        database,
+        `table`
+    FROM system.tables
+    WHERE engine != 'Merge' AND (engine != 'StorageProxy' OR create_table_query NOT ILIKE '%merge%')
+)

--- a/tests/queries/0_stateless/00076_system_columns_bytes.sql
+++ b/tests/queries/0_stateless/00076_system_columns_bytes.sql
@@ -2,7 +2,7 @@
 -- NOTE:
 -- - database = currentDatabase() is not mandatory
 -- - Merge tables may cause UNKNOWN_DATABASE/CANNOT_EXTRACT_TABLE_STRUCTURE from StorageMerge::getColumnSizes() since the table/database can be removed
--- - StorageProxy can wrap any table function
+-- - StorageProxy can wrap any table function, so they also have to be excluded if their nested table function is merge
 SELECT
     sum(data_compressed_bytes) > 0,
     sum(data_uncompressed_bytes) > 0,


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Details

The test can fail with `CANNOT_EXTRACT_TABLE_STRUCTURE` error. Merge tables already excluded, but `StorageProxy` can wrap any table functions, so they also have to be excluded.
