### PR TITLE
Prevent false positive error on empty LowCardinality indexes

### DIFF
--- a/src/Columns/ColumnLowCardinality.cpp
+++ b/src/Columns/ColumnLowCardinality.cpp
@@ -240,6 +240,8 @@ static void checkIndexesAreLimited(const IColumn & indexes, UInt64 limit)
 
         const auto & data = column_ptr->getData();
         size_t num_rows = data.size();
+        if (num_rows == 0)
+            return true;
         UInt64 max_position = 0;
         for (size_t i = 0; i < num_rows; ++i)
             max_position = std::max<UInt64>(max_position, data[i]);

--- a/src/Columns/tests/gtest_low_cardinality.cpp
+++ b/src/Columns/tests/gtest_low_cardinality.cpp
@@ -62,3 +62,25 @@ TEST(ColumnLowCardinality, Clone)
     ASSERT_TRUE(assert_cast<const ColumnLowCardinality &>(*nullable_column).nestedIsNullable());
     ASSERT_FALSE(assert_cast<const ColumnLowCardinality &>(*column).nestedIsNullable());
 }
+
+TEST(ColumnLowCardinality, EmptyDictionaryEmptyIndexes)
+{
+    /// Test edge case: empty dictionary (size=0) with empty indexes (num_rows=0)
+    /// This should not throw an error, as empty indexes are always valid
+    /// Regression test for bug where check was: if (max_position >= limit)
+    /// When num_rows=0, max_position stays 0, and with limit=0, this incorrectly threw
+    
+    auto data_type = std::make_shared<DataTypeUInt32>();
+    auto low_cardinality_type = std::make_shared<DataTypeLowCardinality>(data_type);
+    auto column = low_cardinality_type->createColumn();
+    auto & lc_column = assert_cast<ColumnLowCardinality &>(*column);
+    
+    // Create empty keys and indexes columns
+    auto empty_keys = ColumnUInt32::create();
+    auto empty_indexes = ColumnUInt8::create();
+    
+    // This should NOT throw an exception
+    ASSERT_NO_THROW(lc_column.insertRangeFromDictionaryEncodedColumn(*empty_keys, *empty_indexes));
+    
+    ASSERT_EQ(column->size(), 0);
+}


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Details

- Added check for num_rows > 0 before validating max_position against limit
- Added regression test for empty dictionary with empty indexes edge case

Fixes an error where LowCardinality indexes validation would incorrectly fail on empty dictionaries:

```
2025-11-06 15:54:59 Reason: having stderror:  
2025-11-06 15:54:59 [686a78018d7d] 2025.11.06 23:54:54.479737 [ 323427 ] {4b294cba-8e1f-4c0f-aa03-d151cfcf8eb3} <Error> executeQuery: Code: 117. DB::Exception: Index for LowCardinality is out of range. Dictionary size is 0, but found index with value 0: (while reading column used_privileges): (while reading from part /home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/ci/tmp/run_r0/store/1cb/1cb87ea3-df7d-4fa6-8a91-b142a9dd1fd1/202511_176_219_4/ in table system.query_log (1cb87ea3-df7d-4fa6-8a91-b142a9dd1fd1) located on disk default of type local, from mark 8 with max_rows_to_read = 1, offset = 6767). (INCORRECT_DATA) (version 25.11.1.1590) (from [::1]:45222) (comment: 03315_query_log_privileges_backup_restore.sh-test_wwy9dd40) (query 1, line 1) (in query: select used_privileges, missing_privileges from system.query_log where query ilike 'backup table d_03315_query_log to %' and type = 'QueryFinish' and current_database = currentDatabase() order by event_time desc limit 1), Stack trace (when copying this message, always include the lines below):
```

See [cidb reports](https://play.clickhouse.com/play?user=play&run=1#V0lUSAogICAgOTAgQVMgaW50ZXJ2YWxfZGF5cwpTRUxFQ1QKICAgIHRvU3RhcnRPZkRheShjaGVja19zdGFydF90aW1lKSBBUyBkYXksCiAgICBjb3VudCgpIEFTIGZhaWx1cmVzLAogICAgZ3JvdXBVbmlxQXJyYXkocHVsbF9yZXF1ZXN0X251bWJlcikgQVMgcHJzLAogICAgYW55KHJlcG9ydF91cmwpIEFTIHJlcG9ydF91cmwKRlJPTSBjaGVja3MKV0hFUkUgKG5vdygpIC0gdG9JbnRlcnZhbERheShpbnRlcnZhbF9kYXlzKSkgPD0gY2hlY2tfc3RhcnRfdGltZQogICAgQU5EIHRlc3RfbmFtZSA9ICcwMzMxNV9xdWVyeV9sb2dfcHJpdmlsZWdlc19iYWNrdXBfcmVzdG9yZScKICAgIC0tIEFORCBjaGVja19uYW1lID0gJ05vbmUnCiAgICBBTkQgdGVzdF9zdGF0dXMgSU4gKCdGQUlMJywgJ0VSUk9SJykKICAgIEFORCAoKGhlYWRfcmVmID0gJ21hc3RlcicgQU5EIHB1bGxfcmVxdWVzdF9udW1iZXIgPSAwKSBPUiBwdWxsX3JlcXVlc3RfbnVtYmVyICE9IDApCkdST1VQIEJZIGRheQpPUkRFUiBCWSBkYXkgREVTQwo=) for more details on test failures.
