### PR TITLE
Highlight matching identifiers

### DIFF
--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -3487,10 +3487,12 @@ void ClientBase::runInteractive()
     replxx::Replxx::highlighter_callback_with_pos_t highlight_callback{};
 
     if (getClientConfiguration().getBool("highlight", true))
+    {
         highlight_callback = [this](const String & query, std::vector<replxx::Replxx::Color> & colors, int pos)
         {
             highlight(query, colors, *client_context, pos);
         };
+    }
 
     /// Don't allow embedded client to read from and write to any file on the server's filesystem.
     String actual_history_file_path;

--- a/src/Client/ClientBaseHelpers.cpp
+++ b/src/Client/ClientBaseHelpers.cpp
@@ -223,6 +223,13 @@ void highlight(const String & query, std::vector<replxx::Replxx::Color> & colors
         return;
     }
 
+    /// Also if the cursor is at an identifier or alias, highlight all identifiers and aliases with the same name
+    const char * cursor_char_position = cursor_position >= 0
+        ? begin + UTF8::computeBytesBeforeCodePoint(
+            reinterpret_cast<const UInt8 *>(begin), query.size(), cursor_position)
+        : end;
+    const HighlightedRange * highlight_matching_identifiers = nullptr;
+
     /// We have to map from byte positions to Unicode positions.
     size_t code_point_pos = 0;
     const char * char_pos = begin;
@@ -241,6 +248,13 @@ void highlight(const String & query, std::vector<replxx::Replxx::Color> & colors
             {
                 ++code_point_pos;
                 char_pos += UTF8::seqLength(*char_pos);
+            }
+
+            if (!highlight_matching_identifiers
+                && range.begin <= cursor_char_position && cursor_char_position < range.end
+                && (range.highlight == Highlight::identifier || range.highlight == Highlight::alias))
+            {
+                highlight_matching_identifiers = &range;
             }
 
             int escaped = 0;
@@ -265,6 +279,31 @@ void highlight(const String & query, std::vector<replxx::Replxx::Color> & colors
 
                 ++code_point_pos;
                 char_pos += UTF8::seqLength(*char_pos);
+            }
+        }
+    }
+
+    if (highlight_matching_identifiers)
+    {
+        const char * identifiers_char_pos = begin;
+        size_t identifiers_code_point_pos = 0;
+        for (const auto & range : expected.highlights)
+        {
+            if ((range.highlight == Highlight::identifier || range.highlight == Highlight::alias)
+                && std::string_view(range.begin, range.end) == std::string_view(highlight_matching_identifiers->begin, highlight_matching_identifiers->end))
+            {
+                while (identifiers_char_pos < range.begin)
+                {
+                    ++identifiers_code_point_pos;
+                    identifiers_char_pos += UTF8::seqLength(*identifiers_char_pos);
+                }
+
+                while (identifiers_char_pos < range.end)
+                {
+                    colors[identifiers_code_point_pos] = replxx::color::bold(colors[identifiers_code_point_pos]);
+                    ++identifiers_code_point_pos;
+                    identifiers_char_pos += UTF8::seqLength(*identifiers_char_pos);
+                }
             }
         }
     }
@@ -302,8 +341,7 @@ void highlight(const String & query, std::vector<replxx::Replxx::Color> & colors
     IParser::Pos highlight_token_iterator(
         tokens,
         static_cast<uint32_t>(context.getSettingsRef()[Setting::max_parser_depth]),
-        static_cast<uint32_t>(context.getSettingsRef()[Setting::max_parser_backtracks])
-    );
+        static_cast<uint32_t>(context.getSettingsRef()[Setting::max_parser_backtracks]));
 
     try
     {

--- a/src/Common/SignalHandlers.cpp
+++ b/src/Common/SignalHandlers.cpp
@@ -7,7 +7,6 @@
 #include <Daemon/BaseDaemon.h>
 #include <Daemon/CrashWriter.h>
 #include <base/sleep.h>
-#include <base/getThreadId.h>
 #include <IO/WriteBufferFromFileDescriptor.h>
 #include <IO/ReadBufferFromFileDescriptor.h>
 #include <IO/WriteBufferFromFileDescriptorDiscardOnFailure.h>

--- a/src/Common/UTF8Helpers.cpp
+++ b/src/Common/UTF8Helpers.cpp
@@ -222,6 +222,24 @@ size_t computeBytesBeforeWidth(const UInt8 * data, size_t size, size_t prefix, s
 }
 
 
+size_t computeBytesBeforeCodePoint(const UInt8 * data, size_t size, size_t limit) noexcept
+{
+    size_t code_point = 0;
+    size_t bytes = 0;
+
+    while (bytes < size && code_point < limit)
+    {
+        bytes += seqLength(data[bytes]);
+        ++code_point;
+    }
+
+    if (bytes > size)
+        bytes = size;
+
+    return bytes;
+}
+
+
 size_t convertCodePointToUTF8(int code_point, char * out_bytes, size_t out_length)
 {
     static const Poco::UTF8Encoding utf8;

--- a/src/Common/UTF8Helpers.cpp
+++ b/src/Common/UTF8Helpers.cpp
@@ -233,10 +233,7 @@ size_t computeBytesBeforeCodePoint(const UInt8 * data, size_t size, size_t limit
         ++code_point;
     }
 
-    if (bytes > size)
-        bytes = size;
-
-    return bytes;
+    return std::min(bytes, size);
 }
 
 

--- a/src/Common/UTF8Helpers.h
+++ b/src/Common/UTF8Helpers.h
@@ -111,6 +111,10 @@ size_t computeWidth(const UInt8 * data, size_t size, size_t prefix = 0) noexcept
   */
 size_t computeBytesBeforeWidth(const UInt8 * data, size_t size, size_t prefix, size_t limit) noexcept;
 
+/** Calculate the number of bytes before limit-th code point.
+  */
+size_t computeBytesBeforeCodePoint(const UInt8 * data, size_t size, size_t limit) noexcept;
+
 }
 
 }


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
`clickhouse-client` and `clickhouse-local` in the interactive mode will highlight identifiers in the command line that have the same name as the current one under the cursor.
