### PR TITLE
Speed up test_refreshable_mv_skip_old_temp_table_ddls

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -114,12 +114,12 @@ static struct InitFiu
     REGULAR(slowdown_parallel_replicas_local_plan_read) \
     ONCE(iceberg_writes_cleanup) \
     ONCE(backup_add_empty_memory_table) \
-    REGULAR(refresh_task_delay_update_coordination_state_running) \
+    REGULAR(refresh_task_stop_racing_for_running_refresh) \
     REGULAR(sleep_in_logs_flush) \
     ONCE(smt_commit_exception_before_op) \
     ONCE(disk_object_storage_fail_commit_metadata_transaction) \
     ONCE(database_replicated_drop_before_removing_keeper_failed) \
-    ONCE(database_replicated_drop_after_removing_keeper_failed) \
+    ONCE(database_replicated_drop_after_removing_keeper_failed)
 
 
 namespace FailPoints

--- a/tests/integration/test_refreshable_mv_skip_old_temp_table_ddls/test.py
+++ b/tests/integration/test_refreshable_mv_skip_old_temp_table_ddls/test.py
@@ -80,9 +80,7 @@ def test_refreshable_mv_skip_old_temp_tables_ddls(
     node1.query(f"DROP DATABASE IF EXISTS {db_name} SYNC")
     node2.query(f"DROP DATABASE IF EXISTS {db_name}  SYNC")
     # Make sure that the MV is refreshed on node1
-    node2.query(
-        "SYSTEM ENABLE FAILPOINT refresh_task_delay_update_coordination_state_running"
-    )
+    node2.query("SYSTEM ENABLE FAILPOINT refresh_task_stop_racing_for_running_refresh")
     node2.query("SYSTEM ENABLE FAILPOINT database_replicated_delay_entry_execution")
 
     node1.query(
@@ -98,11 +96,11 @@ def test_refreshable_mv_skip_old_temp_tables_ddls(
             f"CREATE TABLE {db_name}.target (x DateTime) ENGINE ReplicatedMergeTree ORDER BY x"
         )
         node1.query(
-            f"CREATE MATERIALIZED VIEW {db_name}.mv REFRESH EVERY 1 SECOND {append_clause} TO {db_name}.target AS SELECT now() AS x"
+            f"CREATE MATERIALIZED VIEW {db_name}.mv REFRESH EVERY 1 HOUR {append_clause} TO {db_name}.target AS SELECT now() AS x"
         )
     else:
         node1.query(
-            f"CREATE MATERIALIZED VIEW {db_name}.mv REFRESH EVERY 1 SECOND {append_clause} (x DateTime) ENGINE ReplicatedMergeTree ORDER BY x AS SELECT now() AS x"
+            f"CREATE MATERIALIZED VIEW {db_name}.mv REFRESH EVERY 1 HOUR {append_clause} (x DateTime) ENGINE ReplicatedMergeTree ORDER BY x AS SELECT now() AS x"
         )
 
     node2.query(
@@ -122,10 +120,7 @@ def test_refreshable_mv_skip_old_temp_tables_ddls(
 
     last_log_ts = get_last_ddl_worker_log_ts(node2, db_name)
 
-    # Wait for node1 to refresh the view several times
-    time.sleep(5)
-
-    node1.query(f"ALTER TABLE {db_name}.mv MODIFY REFRESH EVERY 1 HOUR {append_clause}")
+    node1.query(f"SYSTEM REFRESH VIEW {db_name}.mv")
 
     # Make sure that the view is not refreshing, and it is scheduled to be refreshed in at least 10 minutes
     node1.query_with_retry(
@@ -135,9 +130,7 @@ def test_refreshable_mv_skip_old_temp_tables_ddls(
         > datetime.timedelta(minutes=10),
     )
 
-    node2.query(
-        "SYSTEM DISABLE FAILPOINT refresh_task_delay_update_coordination_state_running"
-    )
+    node2.query("SYSTEM DISABLE FAILPOINT refresh_task_stop_racing_for_running_refresh")
     node2.query("SYSTEM DISABLE FAILPOINT database_replicated_delay_entry_execution")
 
     table_info1 = node1.query(f"SELECT uuid, name FROM system.tables WHERE database='{db_name}'")


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Speed up test_refreshable_mv_skip_old_temp_table_ddls

### Details
Reduce running time to avoid test timeout.

[test failure](https://d1k2gkhrlfqv31.cloudfront.net/clickhouse-test-reports-private/json.html?REF=master&sha=610fd7c4bc900158feaf94074d1afcdfe138d2f9&name_0=MasterCI&name_1=Integration%20tests%20%28amd_asan%2C%202%2F4%29&name_1=Integration%20tests%20%28amd_asan%2C%202%2F4%29)
