### PR TITLE
Clarifier description of some columns in `system.view_refreshes`

### DIFF
--- a/tests/integration/test_refreshable_mv/test.py
+++ b/tests/integration/test_refreshable_mv/test.py
@@ -6,7 +6,7 @@ import pytest
 
 from helpers.cluster import ClickHouseCluster, QueryRuntimeException
 from helpers.network import PartitionManager
-from helpers.test_tools import assert_eq_with_retry, assert_logs_contain
+from helpers.test_tools import TSV, assert_eq_with_retry, assert_logs_contain
 
 cluster = ClickHouseCluster(__file__)
 
@@ -581,3 +581,36 @@ def test_replicated_db_startup_race(started_cluster, cleanup):
     node1.query("system disable failpoint database_replicated_startup_pause")
     _, err = drop_query_handle.get_answer_and_error()
     assert err == ""
+
+
+def test_system_view_refreshes_on_not_running_replica(started_cluster):
+    for node in nodes:
+        node.query("DROP DATABASE IF EXISTS test SYNC")
+        node.query(
+            r"CREATE DATABASE test ENGINE = Replicated('/db/test', '{shard}', '{replica}')"
+        )
+
+    node1.query(
+        "CREATE MATERIALIZED VIEW test.rmv REFRESH EVERY 1 HOUR (x Int64) ENGINE ReplicatedMergeTree ORDER BY x AS SELECT number*10 AS x FROM numbers(2)"
+    )
+    node1.query("SYSTEM REFRESH VIEW test.rmv")
+
+    def get_view_refresh_value(node, column_name: str):
+        return node.query(
+            f"SELECT {column_name} FROM system.view_refreshes WHERE view='rmv' SETTINGS format_tsv_null_representation='NULL'"
+        ).strip()
+
+    assert get_view_refresh_value(node1, "read_rows") != "NULL"
+    assert get_view_refresh_value(node1, "read_bytes") != "NULL"
+    assert get_view_refresh_value(node1, "total_rows") != "NULL"
+    assert get_view_refresh_value(node1, "written_rows") != "NULL"
+    assert get_view_refresh_value(node1, "written_bytes") != "NULL"
+
+    assert get_view_refresh_value(node2, "read_rows") == "NULL"
+    assert get_view_refresh_value(node2, "read_bytes") == "NULL"
+    assert get_view_refresh_value(node2, "total_rows") == "NULL"
+    assert get_view_refresh_value(node2, "written_rows") == "NULL"
+    assert get_view_refresh_value(node2, "written_bytes") == "NULL"
+
+    for node in nodes:
+        node.query("DROP DATABASE IF EXISTS test SYNC")


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):

- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Clarified description of some columns in `system.view_refreshes`.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

### Details

In table `system.view_refreshes`, make columns `progress`, `read_rows`, `read_bytes`, `total_rows`, `written_rows`, `written_bytes` nullable.

If the currently running or most recently completed refresh is at the other replica, the values of these columns will be NULL.
