### PR TITLE
Experiment with running docker containers as `clickhouse` user by default

### DIFF
--- a/docker/keeper/Dockerfile
+++ b/docker/keeper/Dockerfile
@@ -95,5 +95,6 @@ RUN clickhouse-keeper --version \
 # /var/lib/clickhouse is necessary due to the current default configuration for Keeper
 VOLUME "${DEFAULT_DATA_DIR}" /var/lib/clickhouse
 EXPOSE 2181 10181 44444 9181
+USER clickhouse
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/server/Dockerfile.alpine
+++ b/docker/server/Dockerfile.alpine
@@ -98,5 +98,6 @@ RUN mkdir -p \
 
 VOLUME "${DEFAULT_DATA_DIR}"
 EXPOSE 9000 8123 9009
+USER clickhouse
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/server/Dockerfile.ubuntu
+++ b/docker/server/Dockerfile.ubuntu
@@ -15,9 +15,11 @@ ARG apt_archive="http://archive.ubuntu.com"
 # We do that in advance at the begining of Dockerfile before any packages will be
 # installed to prevent picking those uid / gid by some unrelated software.
 # The same uid / gid (101) is used both for alpine and ubuntu.
+ARG DEFAULT_UID="101"
+ARG DEFAULT_GID="101"
 RUN sed -i "s|http://archive.ubuntu.com|${apt_archive}|g" /etc/apt/sources.list \
-    && groupadd -r clickhouse --gid=101 \
-    && useradd -r -g clickhouse --uid=101 --home-dir=/var/lib/clickhouse --shell=/bin/bash clickhouse \
+    && groupadd -r clickhouse --gid="$DEFAULT_UID" \
+    && useradd -r -g clickhouse --uid="$DEFAULT_GID" --home-dir=/var/lib/clickhouse --shell=/bin/bash clickhouse \
     && apt-get update \
     && apt-get install --yes --no-install-recommends \
         busybox \
@@ -137,6 +139,7 @@ COPY entrypoint.sh /entrypoint.sh
 
 EXPOSE 9000 8123 9009
 VOLUME /var/lib/clickhouse
+USER clickhouse
 
 ENV CLICKHOUSE_CONFIG=/etc/clickhouse-server/config.xml
 

--- a/docker/server/README.md
+++ b/docker/server/README.md
@@ -153,7 +153,7 @@ When you use the image with local directories mounted, you probably want to spec
 ### Start server from root (useful in case of enabled user namespace)
 
 ```bash
-docker run --rm -e CLICKHOUSE_RUN_AS_ROOT=1 --name clickhouse-server-userns -v "$PWD/logs/clickhouse:/var/log/clickhouse-server" -v "$PWD/data/clickhouse:/var/lib/clickhouse" clickhouse/clickhouse-server
+docker run --rm --user 0:0 -e CLICKHOUSE_RUN_AS_ROOT=1 --name clickhouse-server-userns -v "$PWD/logs/clickhouse:/var/log/clickhouse-server" -v "$PWD/data/clickhouse:/var/lib/clickhouse" clickhouse/clickhouse-server
 ```
 
 ### How to create default database and user on starting

--- a/docker/server/README.src/content.md
+++ b/docker/server/README.src/content.md
@@ -147,7 +147,7 @@ When you use the image with local directories mounted, you probably want to spec
 ### Start server from root (useful in case of enabled user namespace)
 
 ```bash
-docker run --rm -e CLICKHOUSE_RUN_AS_ROOT=1 --name clickhouse-server-userns -v "$PWD/logs/clickhouse:/var/log/clickhouse-server" -v "$PWD/data/clickhouse:/var/lib/clickhouse" %%IMAGE%%
+docker run --rm --user 0:0 -e CLICKHOUSE_RUN_AS_ROOT=1 --name clickhouse-server-userns -v "$PWD/logs/clickhouse:/var/log/clickhouse-server" -v "$PWD/data/clickhouse:/var/lib/clickhouse" %%IMAGE%%
 ```
 
 ### How to create default database and user on starting


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Change default USER for clickhouse-server and clickhouse-keeper containers to `clickhouse` to decrease default permissions.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

### Details

This PR changes the default user for clickhouse-server and clickhouse-keeper Docker containers from root to the `clickhouse` user. This reduces the default permissions and improves security by following the principle of least privilege.
