### PR TITLE
Fix flaky test `03652_threads_count_insert` 

### DIFF
--- a/tests/queries/0_stateless/03652_threads_count_insert.reference
+++ b/tests/queries/0_stateless/03652_threads_count_insert.reference
@@ -1,8 +1,8 @@
 max_threads: 1 max_insert_threads: 1
 1
-max_threads: 1 max_insert_threads: 5
+max_threads: 1 max_insert_threads: 4
 1
-max_threads: 10 max_insert_threads: 1
-10
-max_threads: 10 max_insert_threads: 5
-10
+max_threads: 7 max_insert_threads: 1
+7
+max_threads: 7 max_insert_threads: 4
+7

--- a/tests/queries/0_stateless/03652_threads_count_insert.sh
+++ b/tests/queries/0_stateless/03652_threads_count_insert.sh
@@ -22,8 +22,8 @@ create materialized view testXB engine=MergeTree order by tuple() as select slee
 create materialized view testXC engine=MergeTree order by tuple() as select sleep(0.1) from testX;
 EOF
 
-for max_threads in 1 10; do
-    for max_insert_threads in 1 5; do
+for max_threads in 1 7; do
+    for max_insert_threads in 1 4; do
         echo "max_threads: $max_threads max_insert_threads: $max_insert_threads"
 
         QUERY_ID="03652_query_id_$RANDOM"
@@ -38,13 +38,13 @@ for max_threads in 1 10; do
         SETTINGS="$SETTINGS --log_queries=1 "
         SETTINGS="$SETTINGS --send_logs_level=error "
 
-        $CLICKHOUSE_CLIENT -q 'select * from numbers(50) format TSV' | $CLICKHOUSE_CLIENT $SETTINGS -q 'insert into testX FORMAT TSV'
+        $CLICKHOUSE_CLIENT -q 'select * from numbers(200) format TSV' | $CLICKHOUSE_CLIENT $SETTINGS -q 'insert into testX FORMAT TSV'
 
         $CLICKHOUSE_CLIENT -q 'system flush logs system.query_log;'
 
         cat <<EOF | $CLICKHOUSE_CLIENT
 select
-    if(peak_threads_usage >= 10, 10, peak_threads_usage),
+    if(peak_threads_usage >= 6, 7, peak_threads_usage),
 from system.query_log where
     current_database = currentDatabase() and
     type != 'QueryStart' and


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Details

- decrease max threads from 10 to 7
- increase the number of rows from 50 to 200

Both of these changes should increase the chance that the query can utilize all threads.

Furthermore, we also accept if the query utilizes one less thread. It is still more than `max_insert_threads`, so it still effectively checks that `max_insert_threads` doesn't constrain the number of threads. See https://github.com/ClickHouse/ClickHouse/pull/88339#discussion_r2421274268 for more information.
