### PR TITLE
Reduce overhead of HashSetTable::merge

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionUniq.h
+++ b/src/AggregateFunctions/AggregateFunctionUniq.h
@@ -144,7 +144,8 @@ struct AggregateFunctionUniqExactData
     using Key = T;
 
     /// When creating, the hash table must be small.
-    using SingleLevelSet = HashSet<Key, HashCRC32<Key>, HashTableGrower<4>, HashTableAllocatorWithStackMemory<sizeof(Key) * (1 << 4)>>;
+    static constexpr size_t initial_size_degree = 4;
+    using SingleLevelSet = HashSetWithStackMemory<Key, HashCRC32<Key>, initial_size_degree>;
     using TwoLevelSet = TwoLevelHashSet<Key, HashCRC32<Key>>;
     using Set = UniqExactSet<SingleLevelSet, TwoLevelSet>;
 
@@ -164,7 +165,8 @@ struct AggregateFunctionUniqExactData<String, is_able_to_parallelize_merge_>
     using Key = UInt128;
 
     /// When creating, the hash table must be small.
-    using SingleLevelSet = HashSet<Key, UInt128TrivialHash, HashTableGrower<3>, HashTableAllocatorWithStackMemory<sizeof(Key) * (1 << 3)>>;
+    static constexpr size_t initial_size_degree = 3;
+    using SingleLevelSet = HashSetWithStackMemory<Key, UInt128TrivialHash, initial_size_degree>;
     using TwoLevelSet = TwoLevelHashSet<Key, UInt128TrivialHash>;
     using Set = UniqExactSet<SingleLevelSet, TwoLevelSet>;
 
@@ -184,7 +186,8 @@ struct AggregateFunctionUniqExactData<IPv6, is_able_to_parallelize_merge_>
     using Key = UInt128;
 
     /// When creating, the hash table must be small.
-    using SingleLevelSet = HashSet<Key, UInt128TrivialHash, HashTableGrower<3>, HashTableAllocatorWithStackMemory<sizeof(Key) * (1 << 3)>>;
+    static constexpr size_t initial_size_degree = 3;
+    using SingleLevelSet = HashSetWithStackMemory<Key, UInt128TrivialHash, initial_size_degree>;
     using TwoLevelSet = TwoLevelHashSet<Key, UInt128TrivialHash>;
     using Set = UniqExactSet<SingleLevelSet, TwoLevelSet>;
 

--- a/src/Common/HashTable/HashSet.h
+++ b/src/Common/HashTable/HashSet.h
@@ -151,6 +151,13 @@ template <
     typename Allocator = HashTableAllocator>
 using HashSetWithSavedHash = HashSetTable<Key, HashSetCellWithSavedHash<Key, Hash>, Hash, Grower, Allocator>;
 
+template <
+    typename Key,
+    typename Hash = DefaultHash<Key>,
+    typename Grower = TwoLevelHashTableGrower<>,
+    typename Allocator = HashTableAllocator>
+using TwoLevelHashSetWithSavedHash = TwoLevelHashSetTable<Key, HashSetCellWithSavedHash<Key, Hash>, Hash, Grower, Allocator>;
+
 template <typename Key, typename Hash, size_t initial_size_degree>
 using HashSetWithSavedHashWithStackMemory = HashSetWithSavedHash<
     Key,

--- a/src/Common/HashTable/HashSet.h
+++ b/src/Common/HashTable/HashSet.h
@@ -29,7 +29,7 @@ template <
     typename Hash = DefaultHash<Key>,
     typename Grower = HashTableGrowerWithPrecalculation<>,
     typename Allocator = HashTableAllocator>
-class HashSetTable : public HashTable<Key, TCell, Hash, Grower, Allocator>
+class HashSetTable final : public HashTable<Key, TCell, Hash, Grower, Allocator>
 {
 public:
     using Self = HashSetTable;
@@ -75,7 +75,7 @@ template <
     typename Hash = DefaultHash<Key>,
     typename Grower = TwoLevelHashTableGrower<>,
     typename Allocator = HashTableAllocator>
-class TwoLevelHashSetTable
+class TwoLevelHashSetTable final
     : public TwoLevelHashTable<Key, TCell, Hash, Grower, Allocator, HashSetTable<Key, TCell, Hash, Grower, Allocator>>
 {
 public:

--- a/src/Common/HashTable/HashSet.h
+++ b/src/Common/HashTable/HashSet.h
@@ -42,6 +42,20 @@ public:
 
     void merge(const Self & rhs)
     {
+        if (rhs.empty())
+            return;
+
+        if (Base::empty())
+        {
+            *this = rhs;
+            return;
+        }
+
+        /// We know 100% we will need to resize so let's do it preemtively and add enough to hold all elements even in the case
+        /// there are no duplicates (might use more memory than needed in case of many duplicates between the 2 tables).
+        if (rhs.grower.bufSize() > Base::grower.bufSize())
+            Base::resize(rhs.size() + Base::size());
+
         if (!this->hasZero() && rhs.hasZero())
         {
             this->setHasZero();
@@ -50,7 +64,7 @@ public:
 
         for (size_t i = 0; i < rhs.grower.bufSize(); ++i)
             if (!rhs.buf[i].isZero(*this))
-                this->insert(rhs.buf[i].getValue());
+                this->insert(rhs.buf[i]);
     }
 };
 
@@ -74,7 +88,16 @@ public:
     void merge(const HashSetTable<Key, Args...> & rhs)
     {
         for (auto it = rhs.begin(), end = rhs.end(); it != end; ++it)
-            this->insert(it->getValue());
+            this->insert(*it);
+    }
+
+    void merge(const Self & rhs)
+    {
+        if (rhs.empty())
+            return;
+
+        for (size_t i = 0; i < Base::NUM_BUCKETS; ++i)
+            this->impls[i].merge(rhs.impls[i]);
     }
 
     /// Writes its content in a way that it will be correctly read by HashSetTable.

--- a/src/Common/HashTable/HashTable.h
+++ b/src/Common/HashTable/HashTable.h
@@ -749,6 +749,9 @@ public:
 
     HashTable & operator=(const HashTable & rhs) noexcept
     {
+        if (this == &rhs)
+            return *this;
+
         size_t new_buffer_size = rhs.getBufferSizeInBytes();
         size_t old_buffer_size = getBufferSizeInBytes();
         destroyElements();

--- a/src/Common/HashTable/HashTable.h
+++ b/src/Common/HashTable/HashTable.h
@@ -749,13 +749,19 @@ public:
 
     HashTable & operator=(const HashTable & rhs) noexcept
     {
+        size_t new_buffer_size = rhs.getBufferSizeInBytes();
+        size_t old_buffer_size = getBufferSizeInBytes();
         destroyElements();
-        free();
+        if (new_buffer_size != old_buffer_size)
+        {
+            free();
+            buf = reinterpret_cast<Cell *>(Allocator::alloc(new_buffer_size));
+        }
 
         grower = rhs.grower;
         m_size = rhs.m_size;
-        buf = reinterpret_cast<Cell *>(Allocator::alloc(rhs.grower.bufSize()));
-        std::memcpy(buf, rhs.buf, m_size);
+        static_assert(std::is_trivially_copyable_v<Cell>);
+        std::memcpy(buf, rhs.buf, new_buffer_size);
 
         Hash::operator=(rhs);
         Cell::State::operator=(rhs);

--- a/src/Common/HashTable/TwoLevelHashTable.h
+++ b/src/Common/HashTable/TwoLevelHashTable.h
@@ -229,6 +229,19 @@ public:
         return res;
     }
 
+    std::pair<LookupResult, bool> ALWAYS_INLINE insert(const Cell & cell)
+    {
+        auto hash_value = cell.getHash(*this);
+
+        std::pair<LookupResult, bool> res;
+        emplace(cell.getKey(), res.first, res.second, hash_value);
+
+        if (res.second)
+            res.first->setMapped(cell.getValue());
+
+        return res;
+    }
+
     template <typename KeyHolder>
     void ALWAYS_INLINE prefetch(KeyHolder && key_holder) const
     {


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Slightly speed up some countDistinct operations by reducing the overhead of HashSetTable::merge

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

### Details

The first commit is cosmetic, but it was simpler for me to understand and iterate with the proper names.

The second commit improves merging of HashSets by:
* In the case of single level: If the left size is empty, just copy the right size.
* Copy by cell instead of copy by value. In the general case this doesn't matter (cell == value), but it's important when using `HashSetWithSavedHash` since this avoids the need to recalculate the hash (the cell already has it).
* Preemptively resize the left table. If we know 100% for sure we will have to resize the table (the right side itself does not fit in the current left side size), then do it at once to avoid having to move the elements inserted from the right side while iterating.
* In the case of two level HashSets: Implement the optimized merge by merging each internal hash table. Currently this is not used since `UniqExactSet` implements it on top and does not call it, but it makes it simpler to use `TwoLevelHashSet` correctly.

The impact I see is low (let's see the performance tests), but it helps iterating for other changes and I think this is self contained and easier to review on its own.
