### PR TITLE
CI: Summary comment in backports

### DIFF
--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -595,6 +595,7 @@ class Runner:
                                     test_case_result.name,
                                     url=Settings.CI_DB_READ_URL,
                                     user=Settings.CI_DB_READ_USER,
+                                    job_name=job.name,
                                 ),
                             )
                     result.dump()

--- a/ci/workflows/backport_branches.py
+++ b/ci/workflows/backport_branches.py
@@ -52,6 +52,7 @@ workflow = Workflow.Config(
     enable_automerge=True,
     enable_cidb=True,
     enable_commit_status_on_failure=True,
+    enable_gh_summary_comment=True,
     pre_hooks=[
         "python3 ./ci/jobs/scripts/workflow_hooks/store_data.py",
         "python3 ./ci/jobs/scripts/workflow_hooks/version_log.py",

--- a/ci/workflows/pull_request.py
+++ b/ci/workflows/pull_request.py
@@ -41,7 +41,10 @@ workflow = Workflow.Config(
         JobConfigs.fast_test,
         *JobConfigs.tidy_build_arm_jobs,
         *[job.set_dependency(STYLE_AND_FAST_TESTS) for job in JobConfigs.build_jobs],
-        *[job.set_dependency(STYLE_AND_FAST_TESTS) for job in JobConfigs.extra_validation_build_jobs],
+        *[
+            job.set_dependency(STYLE_AND_FAST_TESTS)
+            for job in JobConfigs.extra_validation_build_jobs
+        ],
         *[
             job.set_dependency(FUNCTIONAL_TESTS_PARALLEL_BLOCKING_JOB_NAMES)
             for job in JobConfigs.release_build_jobs


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Details

* Adds comment with CI summary to backport PRs
* Minor fix for CIDB link on failed tests
