### PR TITLE
[small doc fix] Fix precision in supported range for DateTime64

### DIFF
--- a/docs/en/sql-reference/data-types/datetime64.md
+++ b/docs/en/sql-reference/data-types/datetime64.md
@@ -23,7 +23,7 @@ DateTime64(precision, [timezone])
 
 Internally, stores data as a number of 'ticks' since epoch start (1970-01-01 00:00:00 UTC) as Int64. The tick resolution is determined by the precision parameter. Additionally, the `DateTime64` type can store time zone that is the same for the entire column, that affects how the values of the `DateTime64` type values are displayed in text format and how the values specified as strings are parsed ('2020-01-01 05:00:01.000'). The time zone is not stored in the rows of the table (or in resultset), but is stored in the column metadata. See details in [DateTime](../../sql-reference/data-types/datetime.md).
 
-Supported range of values: \[1900-01-01 00:00:00, 2299-12-31 23:59:59.99999999\]
+Supported range of values: \[1900-01-01 00:00:00, 2299-12-31 23:59:59.999999999\]
 
 The number of digits after the decimal point depends on the precision parameter.
 


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)

### Details

There were only 8 9s. But DateTime64 supports 9 9s.
