### PR TITLE
Text index: simplify accessing to the postings cache

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexText.cpp
@@ -381,7 +381,7 @@ void MergeTreeIndexGranuleText::analyzeBloomFilter(const IMergeTreeIndexConditio
 
 namespace
 {
-DictionaryBlock deserializeDictionaryBlock(ReadBuffer & istr, const MergeTreeIndexDeserializationState & state)
+DictionaryBlock deserializeDictionaryBlock(ReadBuffer & istr)
 {
     ProfileEvents::increment(ProfileEvents::TextIndexReadDictionaryBlocks);
 
@@ -426,7 +426,6 @@ DictionaryBlock deserializeDictionaryBlock(ReadBuffer & istr, const MergeTreeInd
             readVarUInt(offset_in_file, istr);
             token_infos.emplace_back(
                 TokenPostingsInfo::FuturePostings{
-                    .state = state,
                     .header = header,
                     .offset_in_file = offset_in_file,
                     .cardinality = cardinality,
@@ -467,7 +466,7 @@ void MergeTreeIndexGranuleText::analyzeDictionary(MergeTreeIndexReaderStream & s
         {
             UInt64 offset_in_file = header->sparseIndex().getOffsetInFile(block_id);
             compressed_buffer->seek(offset_in_file, 0);
-            return std::make_shared<TextIndexDictionaryBlockCacheEntry>(deserializeDictionaryBlock(*data_buffer, state));
+            return std::make_shared<TextIndexDictionaryBlockCacheEntry>(deserializeDictionaryBlock(*data_buffer));
         };
 
         if (condition_text.useDictionaryBlockCache())

--- a/src/Storages/MergeTree/MergeTreeIndexText.h
+++ b/src/Storages/MergeTree/MergeTreeIndexText.h
@@ -146,7 +146,6 @@ public:
     /// Information required to read the posting list.
     struct FuturePostings
     {
-        MergeTreeIndexDeserializationState state;
         UInt64 header = 0;
         UInt64 offset_in_file = 0;
         UInt32 cardinality = 0;

--- a/src/Storages/MergeTree/MergeTreeReaderTextIndex.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderTextIndex.cpp
@@ -209,7 +209,7 @@ size_t MergeTreeReaderTextIndex::readRows(
         }
         else
         {
-            readPostingsIfNeeded(granule);
+            readPostingsIfNeeded(granule, index_mark);
 
             const auto & index_granularity = data_part_info_for_read->getIndexGranularity();
             size_t mark_at_index_granule = index_mark * granularity;
@@ -247,7 +247,7 @@ void MergeTreeReaderTextIndex::createEmptyColumns(Columns & columns) const
     }
 }
 
-void MergeTreeReaderTextIndex::readPostingsIfNeeded(Granule & granule)
+void MergeTreeReaderTextIndex::readPostingsIfNeeded(Granule & granule, size_t index_mark)
 {
     if (!granule.need_read_postings)
         return;
@@ -258,6 +258,10 @@ void MergeTreeReaderTextIndex::readPostingsIfNeeded(Granule & granule)
     auto * postings_stream = index_reader->getStreams().at(MergeTreeIndexSubstream::Type::TextIndexPostings);
     auto * data_buffer = postings_stream->getDataBuffer();
     auto * compressed_buffer = postings_stream->getCompressedDataBuffer();
+
+    const auto & condition_text = typeid_cast<const MergeTreeIndexConditionText &>(*index.condition);
+    const auto & data_path = data_part_info_for_read->getDataPartStorage()->getFullPath();
+    const auto & index_name = index.index->getFileName();
 
     PostingListPtr posting_list = nullptr;
     for (const auto & [token, postings] : remaining_tokens)
@@ -270,7 +274,6 @@ void MergeTreeReaderTextIndex::readPostingsIfNeeded(Granule & granule)
         else
         {
             const auto & future_postings = postings.getFuturePostings();
-            const auto & condition_text = typeid_cast<const MergeTreeIndexConditionText &>(*future_postings.state.condition);
             const auto load_postings = [&]() -> PostingListPtr
             {
                 ProfileEvents::increment(ProfileEvents::TextIndexReadPostings);
@@ -280,7 +283,14 @@ void MergeTreeReaderTextIndex::readPostingsIfNeeded(Granule & granule)
 
             posting_list = condition_text.usePostingsCache()
                 ? condition_text.postingsCache()->getOrSet(
-                    TextIndexPostingsCache::hash(future_postings.state.path_to_data_part, future_postings.state.index_name, future_postings.state.index_mark, token.toView()),
+                    TextIndexPostingsCache::hash(
+                        data_path,
+                        index_name,
+                        index_mark,
+                        future_postings.cardinality,
+                        future_postings.offset_in_file,
+                        token.toView()
+                    ),
                     load_postings)
                 : load_postings();
         }

--- a/src/Storages/MergeTree/MergeTreeReaderTextIndex.h
+++ b/src/Storages/MergeTree/MergeTreeReaderTextIndex.h
@@ -49,7 +49,7 @@ private:
 
     void updateAllIndexRanges();
     void createEmptyColumns(Columns & columns) const;
-    void readPostingsIfNeeded(Granule & granule);
+    void readPostingsIfNeeded(Granule & granule, size_t index_mark);
     void fillSkippedColumn(IColumn & column, size_t num_rows);
     void fillColumn(IColumn & column, Granule & granule, const String & column_name, size_t granule_offset, size_t num_rows);
 

--- a/src/Storages/MergeTree/TextIndexCache.h
+++ b/src/Storages/MergeTree/TextIndexCache.h
@@ -145,7 +145,16 @@ public:
     }
 };
 
-class TextIndexPostingsCache : public CacheBase<UInt128, PostingList, UInt128TrivialHash>
+/// Estimate of the memory usage (bytes) of a text index posting list in cache
+struct TextIndexPostingsWeightFunction
+{
+    size_t operator()(const PostingList & postings) const
+    {
+        return postings.getSizeInBytes();
+    }
+};
+
+class TextIndexPostingsCache : public CacheBase<UInt128, PostingList, UInt128TrivialHash, TextIndexPostingsWeightFunction>
 {
 public:
     TextIndexPostingsCache(const String & cache_policy, size_t max_size_in_bytes, size_t max_count, double size_ratio)

--- a/tests/queries/0_stateless/02346_text_index_postings_cache.sql
+++ b/tests/queries/0_stateless/02346_text_index_postings_cache.sql
@@ -24,6 +24,7 @@ SETTINGS index_granularity = 128;
 
 INSERT INTO tab SELECT number, 'text_pl_1' FROM numbers(64);
 INSERT INTO tab SELECT number, 'text_pl_2' FROM numbers(64);
+INSERT INTO tab SELECT number, 'text_pl_3' FROM numbers(64);
 
 DROP VIEW IF EXISTS text_index_cache_stats;
 CREATE VIEW text_index_cache_stats AS (
@@ -66,12 +67,12 @@ SELECT '--- no profile events when cache is disabled.';
 
 SET use_text_index_postings_cache = 0;
 
-SELECT count() FROM tab WHERE hasAnyTokens(message, 'text_pl_1');
+SELECT count() FROM tab WHERE hasAnyTokens(message, 'text_pl_3');
 
 SET use_text_index_postings_cache = 1;
 
 SYSTEM FLUSH LOGS query_log;
-SELECT * FROM text_index_cache_stats(filter = 'text_pl_1');
+SELECT * FROM text_index_cache_stats(filter = 'text_pl_3');
 
 SELECT 'Clear text index postings cache';
 


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)

### Details

Previously, the state was copied and passed to the reader to access the postings cache. This was unnecessary since the reading can access the index info and postings cache directly.

Also, add missing weight function for the postings to estimate byte size in the cache.
