### PR TITLE
Fix race condition in projection index reading path.

### DIFF
--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -2801,14 +2801,14 @@ void ReadFromMergeTree::initializePipeline(QueryPipelineBuilder & pipeline, cons
             .total_query_nodes = 1,
         };
 
-        ProjectionIndexReaderByName readers;
+        ProjectionIndexReaderContextByName readers;
 
         /// Create a reader for each projection index based on its metadata and prewhere info.
         for (const auto & read_info : projection_index_read_desc.read_infos)
         {
             readers.emplace(
                 read_info.projection->name,
-                SingleProjectionIndexReader(
+                SingleProjectionIndexReaderContext(
                     std::make_shared<MergeTreeReadPoolProjectionIndex>(
                         empty_mutations_snapshot,
                         std::make_shared<StorageSnapshot>(storage_snapshot->storage, read_info.projection->metadata),

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -2801,12 +2801,12 @@ void ReadFromMergeTree::initializePipeline(QueryPipelineBuilder & pipeline, cons
             .total_query_nodes = 1,
         };
 
-        ProjectionIndexReaderContextByName readers;
+        ProjectionIndexReaderContextByName reader_contexts;
 
         /// Create a reader for each projection index based on its metadata and prewhere info.
         for (const auto & read_info : projection_index_read_desc.read_infos)
         {
-            readers.emplace(
+            reader_contexts.emplace(
                 read_info.projection->name,
                 SingleProjectionIndexReaderContext(
                     std::make_shared<MergeTreeReadPoolProjectionIndex>(
@@ -2824,7 +2824,7 @@ void ReadFromMergeTree::initializePipeline(QueryPipelineBuilder & pipeline, cons
                     reader_settings));
         }
 
-        projection_index_reader = std::make_shared<MergeTreeProjectionIndexReader>(std::move(readers));
+        projection_index_reader = std::make_shared<MergeTreeProjectionIndexReader>(std::move(reader_contexts));
     }
 
     if (skip_index_reader || projection_index_reader)

--- a/src/Storages/MergeTree/MergeTreeIndexReadResultPool.h
+++ b/src/Storages/MergeTree/MergeTreeIndexReadResultPool.h
@@ -151,7 +151,7 @@ struct SingleProjectionIndexReaderContext
     {
     }
     SingleProjectionIndexReaderPtr allocateReader();
-    void releaseReader(const SingleProjectionIndexReaderPtr reader);
+    void releaseReader(SingleProjectionIndexReaderPtr reader);
     void cancel();
 };
 

--- a/src/Storages/MergeTree/MergeTreeIndexReadResultPool.h
+++ b/src/Storages/MergeTree/MergeTreeIndexReadResultPool.h
@@ -135,6 +135,8 @@ struct SingleProjectionIndexReaderContext
     PrewhereInfoPtr prewhere_info;
     ExpressionActionsSettings actions_settings;
     MergeTreeReaderSettings reader_settings;
+    std::shared_ptr<std::mutex> allocated_readers_mutex = {};
+    std::unordered_set<SingleProjectionIndexReader*> allocated_readers;
 
     explicit SingleProjectionIndexReaderContext(
         std::shared_ptr<MergeTreeReadPoolProjectionIndex> pool_,
@@ -145,6 +147,7 @@ struct SingleProjectionIndexReaderContext
             , prewhere_info(prewhere_info_)
             , actions_settings(actions_settings_)
             , reader_settings(reader_settings_)
+            , allocated_readers_mutex(std::make_shared<std::mutex>())
     {
     }
     SingleProjectionIndexReaderPtr allocateReader();
@@ -152,7 +155,7 @@ struct SingleProjectionIndexReaderContext
     void cancel();
 };
 
-using ProjectionIndexReaderContextByName = std::unordered_map<String, SingleProjectionIndexContextReader>;
+using ProjectionIndexReaderContextByName = std::unordered_map<String, SingleProjectionIndexReaderContext>;
 
 class MergeTreeProjectionIndexReader
 {

--- a/tests/queries/0_stateless/03460_normal_projection_index_bug_race_conditions.reference
+++ b/tests/queries/0_stateless/03460_normal_projection_index_bug_race_conditions.reference
@@ -1,0 +1,25 @@
+-- { echo ON }
+
+SET max_threads=8;
+SET max_projection_rows_to_use_projection_index = 102400000;
+SET min_table_rows_to_use_projection_index = 0;
+SET allow_experimental_full_text_index = true;
+DROP TABLE IF EXISTS tab;
+CREATE TABLE tab
+(
+    `i` Int64,
+    `a` Int64,
+    `text` String,
+    PROJECTION by_text
+    (
+        SELECT _part_offset
+        ORDER BY text
+    )
+)
+ENGINE = MergeTree
+PARTITION BY i % 4
+ORDER BY a
+SETTINGS index_granularity = 8192;
+INSERT INTO tab SELECT number,number,toString(number) FROM numbers(8192 * 10);
+SELECT * FROM tab WHERE text='1000' SETTINGS use_skip_indexes = 0, use_query_condition_cache = 0,optimize_use_projections=1,optimize_use_projection_filtering=1;
+1000	1000	1000

--- a/tests/queries/0_stateless/03460_normal_projection_index_bug_race_conditions.sql
+++ b/tests/queries/0_stateless/03460_normal_projection_index_bug_race_conditions.sql
@@ -1,0 +1,26 @@
+-- { echo ON }
+
+SET max_threads=8;
+SET max_projection_rows_to_use_projection_index = 102400000;
+SET min_table_rows_to_use_projection_index = 0;
+SET allow_experimental_full_text_index = true;
+
+CREATE TABLE tab
+(
+    `i` Int64,
+    `a` Int64,
+    `text` String,
+    PROJECTION by_text
+    (
+        SELECT _part_offset
+        ORDER BY text
+    )
+)
+ENGINE = MergeTree
+PARTITION BY i % 4
+ORDER BY a
+SETTINGS index_granularity = 8192;
+
+INSERT INTO tab SELECT number,number,toString(number) FROM numbers(8192 * 10);
+
+SELECT * FROM tab WHERE text='1000' SETTINGS use_skip_indexes = 0, use_query_condition_cache = 0,optimize_use_projections=1,optimize_use_projection_filtering=1;

--- a/tests/queries/0_stateless/03460_normal_projection_index_bug_race_conditions.sql
+++ b/tests/queries/0_stateless/03460_normal_projection_index_bug_race_conditions.sql
@@ -5,6 +5,8 @@ SET max_projection_rows_to_use_projection_index = 102400000;
 SET min_table_rows_to_use_projection_index = 0;
 SET allow_experimental_full_text_index = true;
 
+DROP TABLE IF EXISTS tab;
+
 CREATE TABLE tab
 (
     `i` Int64,


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix race condition in projection index reading path. Resolves #89497

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

### Details

This PR fixes a race condition in the projection index reading path.

In the current implementation, MergeTreeIndexReadResultPool is designed to be thread-safe and follows a lazy, on-demand index construction/read model.
However, during the projection index reading process, when multiple threads concurrently read different parts of the same projection, they may share a single MergeTreeProjectionIndexReader instance.
Since this reader is not fully thread-safe for concurrent access across multiple parts, this leads to memory corruption and undefined behavior.


Resolves #89497

How to reproduce it?

```
SET max_threads=8;
SET max_projection_rows_to_use_projection_index = 102400000;
SET min_table_rows_to_use_projection_index = 0;
SET allow_experimental_full_text_index = true;

DROP TABLE IF EXISTS tab;

CREATE TABLE tab
(
    `i` Int64,
    `a` Int64,
    `text` String,
    PROJECTION by_text
    (
        SELECT _part_offset
        ORDER BY text
    )
)
ENGINE = MergeTree
PARTITION BY i % 4
ORDER BY a
SETTINGS index_granularity = 8192;

INSERT INTO tab SELECT number,number,toString(number) FROM numbers(8192 * 10);

SELECT * FROM tab WHERE text='1000' SETTINGS use_skip_indexes = 0, use_query_condition_cache = 0,optimize_use_projections=1,optimize_use_projection_filtering=1;
```

https://fiddle.clickhouse.com/9bd3cb57-f208-43ef-afad-2a9ce376ac1b