### PR TITLE
Underline is better

### DIFF
--- a/src/Client/ClientBaseHelpers.cpp
+++ b/src/Client/ClientBaseHelpers.cpp
@@ -300,7 +300,7 @@ void highlight(const String & query, std::vector<replxx::Replxx::Color> & colors
 
                 while (identifiers_char_pos < range.end)
                 {
-                    colors[identifiers_code_point_pos] = replxx::color::bold(colors[identifiers_code_point_pos]);
+                    colors[identifiers_code_point_pos] = replxx::color::underline(colors[identifiers_code_point_pos]);
                     ++identifiers_code_point_pos;
                     identifiers_char_pos += UTF8::seqLength(*identifiers_char_pos);
                 }


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Underline is better for highlighting matching identifiers. Kudos to @thevar1able for noting this; the advice was golden!
