### PR TITLE
Fix 03707_statistics_cache flakiness with parallel replicas

### DIFF
--- a/tests/queries/0_stateless/03707_statistics_cache.sql
+++ b/tests/queries/0_stateless/03707_statistics_cache.sql
@@ -7,6 +7,9 @@ SET log_query_settings = 1;
 SET mutations_sync = 2;
 SET max_execution_time = 60;
 
+-- test rely on local execution, - force parallel replicas to genearate local plan
+SET parallel_replicas_local_plan=1;
+
 DROP TABLE IF EXISTS sc_core SYNC;
 
 CREATE TABLE sc_core


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Details

Fixes https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=3e9556d9152e1effa29f675b6b27f394301886a7&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_binary%2C%20ParallelReplicas%2C%20s3%20storage%2C%20parallel%29&name_1=Stateless%20tests%20%28amd_binary%2C%20ParallelReplicas%2C%20s3%20storage%2C%20parallel%29
