### PR TITLE
Make Alias more stable

### DIFF
--- a/src/Storages/IStorage.h
+++ b/src/Storages/IStorage.h
@@ -185,6 +185,7 @@ public:
     using ColumnSizeByName = std::unordered_map<std::string, ColumnSize>;
     virtual ColumnSizeByName getColumnSizes() const { return {}; }
 
+    /// Same as getColumnSizes() but may return nullopt in some specific engines like Merge/Alias
     virtual std::optional<ColumnSizeByName> tryGetColumnSizes() const { return getColumnSizes(); }
 
     /// Optional size information of each secondary index.
@@ -205,6 +206,7 @@ public:
         return metadata.get();
     }
 
+    /// Same as getInMemoryMetadataPtr() but may return nullopt in some specific engines like Alias
     virtual std::optional<StorageMetadataPtr> tryGetInMemoryMetadataPtr() const { return getInMemoryMetadataPtr(); }
 
     /// Update storage metadata. Used in ALTER or initialization of Storage.
@@ -292,6 +294,7 @@ public:
     /// Returns hints for serialization of columns accorsing to statistics accumulated by storage.
     virtual SerializationInfoByName getSerializationHints() const { return SerializationInfoByName{{}}; }
 
+    /// Same as getSerializationHints() but may return nullopt in some specific engines like Alias
     virtual std::optional<SerializationInfoByName> tryGetSerializationHints() const { return getSerializationHints(); }
 
     /// Add engine args that were inferred during storage creation to create query to avoid the same
@@ -679,11 +682,13 @@ public:
     /// Returns data paths if storage supports it, empty vector otherwise.
     virtual Strings getDataPaths() const { return {}; }
 
+    /// Same as getDataPaths() but may return nullopt in some specific engines like Alias
     virtual std::optional<Strings> tryGetDataPaths() const { return getDataPaths(); }
 
     /// Returns storage policy if storage supports it.
     virtual StoragePolicyPtr getStoragePolicy() const { return {}; }
 
+    /// Same as getStoragePolicy() but may return nullopt in some specific engines like Alias
     virtual std::optional<StoragePolicyPtr> tryGetStoragePolicy() const { return getStoragePolicy(); }
 
     /// Returns true if all disks of storage are read-only or write-once.
@@ -730,6 +735,7 @@ public:
     /// Does not take the underlying Storage (if any) into account.
     virtual std::optional<UInt64> lifetimeRows() const { return {}; }
 
+    /// Same as lifetimeRows() but may return nullopt in some specific engines like Alias
     virtual std::optional<std::optional<UInt64>> tryLifetimeRows() const { return lifetimeRows(); }
 
     /// Number of bytes INSERTed since server start.
@@ -737,6 +743,7 @@ public:
     /// Does not take the underlying Storage (if any) into account.
     virtual std::optional<UInt64> lifetimeBytes() const { return {}; }
 
+    /// Same as lifetimeBytes() but may return nullopt in some specific engines like Alias
     virtual std::optional<std::optional<UInt64>> tryLifetimeBytes() const { return lifetimeBytes(); }
 
     /// Creates a storage snapshot from given metadata.

--- a/src/Storages/IStorage.h
+++ b/src/Storages/IStorage.h
@@ -185,17 +185,7 @@ public:
     using ColumnSizeByName = std::unordered_map<std::string, ColumnSize>;
     virtual ColumnSizeByName getColumnSizes() const { return {}; }
 
-    virtual std::expected<ColumnSizeByName, Exception> tryGetColumnSizes() const
-    {
-        try
-        {
-            return getColumnSizes();
-        }
-        catch (const Exception & e)
-        {
-            return std::unexpected(e);
-        }
-    }
+    virtual std::optional<ColumnSizeByName> tryGetColumnSizes() const { return getColumnSizes(); }
 
     /// Optional size information of each secondary index.
     /// Valid only for MergeTree family.
@@ -215,17 +205,7 @@ public:
         return metadata.get();
     }
 
-    virtual std::expected<StorageMetadataPtr, Exception> tryGetInMemoryMetadataPtr() const
-    {
-        try
-        {
-            return getInMemoryMetadataPtr();
-        }
-        catch (const Exception & e)
-        {
-            return std::unexpected(e);
-        }
-    }
+    virtual std::optional<StorageMetadataPtr> tryGetInMemoryMetadataPtr() const { return getInMemoryMetadataPtr(); }
 
     /// Update storage metadata. Used in ALTER or initialization of Storage.
     /// Metadata object is multiversion, so this method can be called without
@@ -312,17 +292,7 @@ public:
     /// Returns hints for serialization of columns accorsing to statistics accumulated by storage.
     virtual SerializationInfoByName getSerializationHints() const { return SerializationInfoByName{{}}; }
 
-    virtual std::expected<SerializationInfoByName, Exception> tryGetSerializationHints() const
-    {
-        try
-        {
-            return getSerializationHints();
-        }
-        catch (const Exception & e)
-        {
-            return std::unexpected(e);
-        }
-    }
+    virtual std::optional<SerializationInfoByName> tryGetSerializationHints() const { return getSerializationHints(); }
 
     /// Add engine args that were inferred during storage creation to create query to avoid the same
     /// inference on server restart. For example - data format inference in File/URL/S3/etc engines.
@@ -709,32 +679,12 @@ public:
     /// Returns data paths if storage supports it, empty vector otherwise.
     virtual Strings getDataPaths() const { return {}; }
 
-    virtual std::expected<Strings, Exception> tryGetDataPaths() const
-    {
-        try
-        {
-            return getDataPaths();
-        }
-        catch (const Exception & e)
-        {
-            return std::unexpected(e);
-        }
-    }
+    virtual std::optional<Strings> tryGetDataPaths() const { return getDataPaths(); }
 
     /// Returns storage policy if storage supports it.
     virtual StoragePolicyPtr getStoragePolicy() const { return {}; }
 
-    virtual std::expected<StoragePolicyPtr, Exception> tryGetStoragePolicy() const
-    {
-        try
-        {
-            return getStoragePolicy();
-        }
-        catch (const Exception & e)
-        {
-            return std::unexpected(e);
-        }
-    }
+    virtual std::optional<StoragePolicyPtr> tryGetStoragePolicy() const { return getStoragePolicy(); }
 
     /// Returns true if all disks of storage are read-only or write-once.
     /// NOTE: write-once also does not support INSERTs/merges/... for MergeTree
@@ -780,34 +730,14 @@ public:
     /// Does not take the underlying Storage (if any) into account.
     virtual std::optional<UInt64> lifetimeRows() const { return {}; }
 
-    virtual std::expected<std::optional<UInt64>, Exception> tryLifetimeRows() const
-    {
-        try
-        {
-            return lifetimeRows();
-        }
-        catch (const Exception & e)
-        {
-            return std::unexpected(e);
-        }
-    }
+    virtual std::optional<std::optional<UInt64>> tryLifetimeRows() const { return lifetimeRows(); }
 
     /// Number of bytes INSERTed since server start.
     ///
     /// Does not take the underlying Storage (if any) into account.
     virtual std::optional<UInt64> lifetimeBytes() const { return {}; }
 
-    virtual std::expected<std::optional<UInt64>, Exception> tryLifetimeBytes() const
-    {
-        try
-        {
-            return lifetimeBytes();
-        }
-        catch (const Exception & e)
-        {
-            return std::unexpected(e);
-        }
-    }
+    virtual std::optional<std::optional<UInt64>> tryLifetimeBytes() const { return lifetimeBytes(); }
 
     /// Creates a storage snapshot from given metadata.
     virtual StorageSnapshotPtr getStorageSnapshot(const StorageMetadataPtr & metadata_snapshot, ContextPtr /*query_context*/) const

--- a/src/Storages/IStorage.h
+++ b/src/Storages/IStorage.h
@@ -185,6 +185,18 @@ public:
     using ColumnSizeByName = std::unordered_map<std::string, ColumnSize>;
     virtual ColumnSizeByName getColumnSizes() const { return {}; }
 
+    virtual std::expected<ColumnSizeByName, Exception> tryGetColumnSizes() const
+    {
+        try
+        {
+            return getColumnSizes();
+        }
+        catch (const Exception & e)
+        {
+            return std::unexpected(e);
+        }
+    }
+
     /// Optional size information of each secondary index.
     /// Valid only for MergeTree family.
     using IndexSizeByName = std::unordered_map<std::string, IndexSize>;
@@ -201,6 +213,18 @@ public:
     virtual StorageMetadataPtr getInMemoryMetadataPtr(bool /*bypass_metadata_cache*/ = false) const // NOLINT
     {
         return metadata.get();
+    }
+
+    virtual std::expected<StorageMetadataPtr, Exception> tryGetInMemoryMetadataPtr() const
+    {
+        try
+        {
+            return getInMemoryMetadataPtr();
+        }
+        catch (const Exception & e)
+        {
+            return std::unexpected(e);
+        }
     }
 
     /// Update storage metadata. Used in ALTER or initialization of Storage.
@@ -287,6 +311,18 @@ public:
 
     /// Returns hints for serialization of columns accorsing to statistics accumulated by storage.
     virtual SerializationInfoByName getSerializationHints() const { return SerializationInfoByName{{}}; }
+
+    virtual std::expected<SerializationInfoByName, Exception> tryGetSerializationHints() const
+    {
+        try
+        {
+            return getSerializationHints();
+        }
+        catch (const Exception & e)
+        {
+            return std::unexpected(e);
+        }
+    }
 
     /// Add engine args that were inferred during storage creation to create query to avoid the same
     /// inference on server restart. For example - data format inference in File/URL/S3/etc engines.
@@ -673,8 +709,32 @@ public:
     /// Returns data paths if storage supports it, empty vector otherwise.
     virtual Strings getDataPaths() const { return {}; }
 
+    virtual std::expected<Strings, Exception> tryGetDataPaths() const
+    {
+        try
+        {
+            return getDataPaths();
+        }
+        catch (const Exception & e)
+        {
+            return std::unexpected(e);
+        }
+    }
+
     /// Returns storage policy if storage supports it.
     virtual StoragePolicyPtr getStoragePolicy() const { return {}; }
+
+    virtual std::expected<StoragePolicyPtr, Exception> tryGetStoragePolicy() const
+    {
+        try
+        {
+            return getStoragePolicy();
+        }
+        catch (const Exception & e)
+        {
+            return std::unexpected(e);
+        }
+    }
 
     /// Returns true if all disks of storage are read-only or write-once.
     /// NOTE: write-once also does not support INSERTs/merges/... for MergeTree
@@ -720,10 +780,34 @@ public:
     /// Does not take the underlying Storage (if any) into account.
     virtual std::optional<UInt64> lifetimeRows() const { return {}; }
 
+    virtual std::expected<std::optional<UInt64>, Exception> tryLifetimeRows() const
+    {
+        try
+        {
+            return lifetimeRows();
+        }
+        catch (const Exception & e)
+        {
+            return std::unexpected(e);
+        }
+    }
+
     /// Number of bytes INSERTed since server start.
     ///
     /// Does not take the underlying Storage (if any) into account.
     virtual std::optional<UInt64> lifetimeBytes() const { return {}; }
+
+    virtual std::expected<std::optional<UInt64>, Exception> tryLifetimeBytes() const
+    {
+        try
+        {
+            return lifetimeBytes();
+        }
+        catch (const Exception & e)
+        {
+            return std::unexpected(e);
+        }
+    }
 
     /// Creates a storage snapshot from given metadata.
     virtual StorageSnapshotPtr getStorageSnapshot(const StorageMetadataPtr & metadata_snapshot, ContextPtr /*query_context*/) const

--- a/src/Storages/StorageAlias.cpp
+++ b/src/Storages/StorageAlias.cpp
@@ -44,6 +44,11 @@ StorageAlias::StorageAlias(
     StorageID target_id(target_database, target_table);
     if (table_id_ == target_id)
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Alias table cannot refer to itself");
+
+    // Disallow target is also an alias
+    auto target_storage = DatabaseCatalog::instance().tryGetTable(target_id, context_);
+    if (target_storage && target_storage->getName() == "Alias")
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Alias table cannot refer to another Alias table");
 }
 
 StoragePtr StorageAlias::getTargetTable(std::optional<TargetAccess> access_check) const

--- a/src/Storages/StorageAlias.cpp
+++ b/src/Storages/StorageAlias.cpp
@@ -303,7 +303,7 @@ void registerStorageAlias(StorageFactory & factory)
         // Storage Alias does not support explicit column definitions
         // Columns are always dynamically fetched from the target table
         // Only check for CREATE, not for ATTACH/RESTORE
-        if (!args.columns.empty() && args.mode < LoadingStrictnessLevel::ATTACH)
+        if (!args.columns.empty() && args.mode == LoadingStrictnessLevel::CREATE)
         {
             throw Exception(ErrorCodes::BAD_ARGUMENTS,
                 "Storage Alias does not support explicit column definitions");

--- a/src/Storages/StorageAlias.h
+++ b/src/Storages/StorageAlias.h
@@ -159,8 +159,8 @@ public:
     SerializationInfoByName getSerializationHints() const override { return getTargetTable()->getSerializationHints(); }
     ActionLock getActionLock(StorageActionBlockType type) override { return getTargetTable()->getActionLock(type); }
 
-    TableLockHolder lockForShare(const String & query_id, const std::chrono::milliseconds & acquire_timeout) { return getTargetTable()->lockForShare(query_id, acquire_timeout); }
-    TableLockHolder tryLockForShare(const String & query_id, const std::chrono::milliseconds & acquire_timeout) {return getTargetTable()->tryLockForShare(query_id, acquire_timeout); }
+    TableLockHolder lockForShare(const String & query_id, const std::chrono::milliseconds & acquire_timeout) const { return getTargetTable()->lockForShare(query_id, acquire_timeout); }
+    TableLockHolder tryLockForShare(const String & query_id, const std::chrono::milliseconds & acquire_timeout) const {return getTargetTable()->tryLockForShare(query_id, acquire_timeout); }
 
     std::optional<UInt64> totalRows(ContextPtr query_context) const override { return getTargetTable()->totalRows(query_context); }
     std::optional<UInt64> totalBytes(ContextPtr query_context) const override { return getTargetTable()->totalBytes(query_context); }

--- a/src/Storages/StorageAlias.h
+++ b/src/Storages/StorageAlias.h
@@ -28,6 +28,7 @@ public:
 
     /// Get the target storage this alias points to
     StoragePtr getTargetTable(std::optional<TargetAccess> access_check = std::nullopt) const;
+    StoragePtr tryGetTargetTable() const { return DatabaseCatalog::instance().tryGetTable(StorageID(target_database, target_table), getContext()); }
 
     /// Read from target table
     void read(
@@ -106,6 +107,15 @@ public:
     void checkTableCanBeDropped(ContextPtr /*query_context*/) const override {}
     StorageInMemoryMetadata getInMemoryMetadata() const override { return getTargetTable()->getInMemoryMetadata(); }
     StorageMetadataPtr getInMemoryMetadataPtr(bool bypass_metadata_cache) const override { return getTargetTable()->getInMemoryMetadataPtr(bypass_metadata_cache); }
+    std::optional<StorageMetadataPtr> tryGetInMemoryMetadataPtr() const override
+    {
+        auto target = tryGetTargetTable();
+        if (!target)
+            return std::nullopt;
+
+        return target->getInMemoryMetadataPtr();
+    }
+
     StorageSnapshotPtr getStorageSnapshot(const StorageMetadataPtr & metadata_snapshot, ContextPtr query_context) const override;
     StorageSnapshotPtr getStorageSnapshotForQuery(const StorageMetadataPtr & metadata_snapshot, const ASTPtr & query, ContextPtr query_context) const override;
     StorageSnapshotPtr getStorageSnapshotWithoutData(const StorageMetadataPtr & metadata_snapshot, ContextPtr query_context) const override;
@@ -151,23 +161,83 @@ public:
         SelectQueryInfo & query_info) const override;
 
     Strings getDataPaths() const override { return getTargetTable()->getDataPaths(); }
+    std::optional<Strings> tryGetDataPaths() const override
+    {
+        auto target = tryGetTargetTable();
+        if (!target)
+            return std::nullopt;
+
+        return target->getDataPaths();
+    }
 
     /// Alias does not store data on disk
     bool storesDataOnDisk() const override { return false; }
 
     StoragePolicyPtr getStoragePolicy() const override { return getTargetTable()->getStoragePolicy(); }
+    std::optional<StoragePolicyPtr> tryGetStoragePolicy() const override
+    {
+        auto target = tryGetTargetTable();
+        if (!target)
+            return std::nullopt;
+
+        return target->getStoragePolicy();
+    }
+
     SerializationInfoByName getSerializationHints() const override { return getTargetTable()->getSerializationHints(); }
+    std::optional<SerializationInfoByName> tryGetSerializationHints() const override
+    {
+        auto target = tryGetTargetTable();
+        if (!target)
+            return std::nullopt;
+
+        return target->getSerializationHints();
+    }
+
     ActionLock getActionLock(StorageActionBlockType type) override { return getTargetTable()->getActionLock(type); }
 
     TableLockHolder lockForShare(const String & query_id, const std::chrono::milliseconds & acquire_timeout) const { return getTargetTable()->lockForShare(query_id, acquire_timeout); }
-    TableLockHolder tryLockForShare(const String & query_id, const std::chrono::milliseconds & acquire_timeout) const {return getTargetTable()->tryLockForShare(query_id, acquire_timeout); }
+    TableLockHolder tryLockForShare(const String & query_id, const std::chrono::milliseconds & acquire_timeout) const
+    {
+        auto target = tryGetTargetTable();
+        if (!target)
+            return nullptr;
+
+        return target->tryLockForShare(query_id, acquire_timeout);
+    }
 
     std::optional<UInt64> totalRows(ContextPtr query_context) const override { return getTargetTable()->totalRows(query_context); }
     std::optional<UInt64> totalBytes(ContextPtr query_context) const override { return getTargetTable()->totalBytes(query_context); }
     std::optional<UInt64> totalBytesUncompressed(const Settings & settings) const override { return getTargetTable()->totalBytesUncompressed(settings); }
     std::optional<UInt64> lifetimeRows() const override { return getTargetTable()->lifetimeRows(); }
+    std::optional<std::optional<UInt64>> tryLifetimeRows() const override
+    {
+        auto target = tryGetTargetTable();
+        if (!target)
+            return std::nullopt;
+
+        return target->lifetimeRows();
+    }
+
     std::optional<UInt64> lifetimeBytes() const override { return getTargetTable()->lifetimeBytes(); }
+    std::optional<std::optional<UInt64>> tryLifetimeBytes() const override
+    {
+        auto target = tryGetTargetTable();
+        if (!target)
+            return std::nullopt;
+
+        return target->lifetimeBytes();
+    }
+
     ColumnSizeByName getColumnSizes() const override { return getTargetTable()->getColumnSizes(); }
+    std::optional<ColumnSizeByName> tryGetColumnSizes() const override
+    {
+        auto target = tryGetTargetTable();
+        if (!target)
+            return std::nullopt;
+
+        return target->getColumnSizes();
+    }
+
     IndexSizeByName getSecondaryIndexSizes() const override { return getTargetTable()->getSecondaryIndexSizes(); }
 
     CancellationCode killPartMoveToShard(const UUID & task_uuid) override;

--- a/src/Storages/StorageAlias.h
+++ b/src/Storages/StorageAlias.h
@@ -129,6 +129,9 @@ public:
     bool isRemote() const override { return getTargetTable()->isRemote(); }
     bool isSharedStorage() const override { return getTargetTable()->isSharedStorage(); }
 
+    /// This is important for DatabaseReplicated, avoid not supported by distributed DDL
+    bool supportsReplication() const override { return false; }
+
     bool hasLightweightDeletedMask() const override { return getTargetTable()->hasLightweightDeletedMask(); }
     bool supportsLightweightDelete() const override { return getTargetTable()->supportsLightweightDelete(); }
     std::expected<void, PreformattedMessage> supportsLightweightUpdate() const override { return getTargetTable()->supportsLightweightUpdate(); }
@@ -149,10 +152,21 @@ public:
 
     Strings getDataPaths() const override { return getTargetTable()->getDataPaths(); }
 
+    /// Alias does not store data on disk
+    bool storesDataOnDisk() const override { return false; }
+
+    StoragePolicyPtr getStoragePolicy() const override { return getTargetTable()->getStoragePolicy(); }
+    SerializationInfoByName getSerializationHints() const override { return getTargetTable()->getSerializationHints(); }
     ActionLock getActionLock(StorageActionBlockType type) override { return getTargetTable()->getActionLock(type); }
+
+    TableLockHolder lockForShare(const String & query_id, const std::chrono::milliseconds & acquire_timeout) { return getTargetTable()->lockForShare(query_id, acquire_timeout); }
+    TableLockHolder tryLockForShare(const String & query_id, const std::chrono::milliseconds & acquire_timeout) {return getTargetTable()->tryLockForShare(query_id, acquire_timeout); }
 
     std::optional<UInt64> totalRows(ContextPtr query_context) const override { return getTargetTable()->totalRows(query_context); }
     std::optional<UInt64> totalBytes(ContextPtr query_context) const override { return getTargetTable()->totalBytes(query_context); }
+    std::optional<UInt64> totalBytesUncompressed(const Settings & settings) const override { return getTargetTable()->totalBytesUncompressed(settings); }
+    std::optional<UInt64> lifetimeRows() const override { return getTargetTable()->lifetimeRows(); }
+    std::optional<UInt64> lifetimeBytes() const override { return getTargetTable()->lifetimeBytes(); }
     ColumnSizeByName getColumnSizes() const override { return getTargetTable()->getColumnSizes(); }
     IndexSizeByName getSecondaryIndexSizes() const override { return getTargetTable()->getSecondaryIndexSizes(); }
 

--- a/src/Storages/StorageMerge.cpp
+++ b/src/Storages/StorageMerge.cpp
@@ -84,6 +84,7 @@ extern const int SAMPLING_NOT_SUPPORTED;
 extern const int ALTER_OF_COLUMN_IS_FORBIDDEN;
 extern const int CANNOT_EXTRACT_TABLE_STRUCTURE;
 extern const int STORAGE_REQUIRES_PARAMETER;
+extern const int UNKNOWN_DATABASE;
 }
 
 namespace
@@ -1680,6 +1681,20 @@ IStorage::ColumnSizeByName StorageMerge::getColumnSizes() const
     });
 
     return column_sizes;
+}
+
+std::optional<IStorage::ColumnSizeByName> StorageMerge::tryGetColumnSizes() const
+{
+    try
+    {
+        return getColumnSizes();
+    }
+    catch (const Exception & e)
+    {
+        if (e.code() == ErrorCodes::UNKNOWN_DATABASE)
+            return std::nullopt;
+        throw;
+    }
 }
 
 

--- a/src/Storages/StorageMerge.h
+++ b/src/Storages/StorageMerge.h
@@ -140,6 +140,8 @@ private:
 
     ColumnSizeByName getColumnSizes() const override;
 
+    std::optional<ColumnSizeByName> tryGetColumnSizes() const override;
+
     ColumnsDescription getColumnsDescriptionFromSourceTables(const ContextPtr & context) const;
 
     static VirtualColumnsDescription createVirtuals();

--- a/src/Storages/System/StorageSystemColumns.cpp
+++ b/src/Storages/System/StorageSystemColumns.cpp
@@ -29,11 +29,6 @@ namespace Setting
     extern const SettingsSeconds lock_acquire_timeout;
     extern const SettingsBool show_data_lake_catalogs_in_system_tables;
 }
-namespace ErrorCodes
-{
-    extern const int UNKNOWN_DATABASE;
-    extern const int UNKNOWN_TABLE;
-}
 
 StorageSystemColumns::StorageSystemColumns(const StorageID & table_id_)
     : IStorage(table_id_)
@@ -141,55 +136,24 @@ protected:
 
             {
                 StoragePtr storage = storages.at(std::make_pair(database_name, table_name));
-                TableLockHolder table_lock;
-                StorageMetadataPtr metadata_snapshot;
+                TableLockHolder table_lock = storage->tryLockForShare(query_id, lock_acquire_timeout);
 
-                /// Can throw UNKNOWN_DATABASE/UNKNOWN_TABLE in case of Alias table
-                try
+                if (table_lock == nullptr)
                 {
-                    table_lock = storage->tryLockForShare(query_id, lock_acquire_timeout);
-
-                    if (table_lock == nullptr)
-                    {
-                        // Table was dropped while acquiring the lock, skipping table
-                        continue;
-                    }
-                }
-                catch (const Exception & e)
-                {
-                    if (storage->getName() != "Alias" || (e.code() != ErrorCodes::UNKNOWN_DATABASE && e.code() != ErrorCodes::UNKNOWN_TABLE))
-                        throw;
-                    tryLogCurrentException(getLogger("SystemColumns"), fmt::format("Cannot find target database/table for {}", storage->getStorageID().getNameForLogs()), LogsLevel::debug);
+                    // Table was dropped while acquiring the lock, skipping table
+                    continue;
                 }
 
-                auto metadata_result = storage->tryGetInMemoryMetadataPtr();
-                if (metadata_result.has_value())
-                {
-                    metadata_snapshot = std::move(*metadata_result);
-                }
-                else
-                {
-                    metadata_snapshot = std::make_shared<StorageInMemoryMetadata>();
-                    LOG_DEBUG(getLogger("SystemColumns"), "Failed to get inmemory metadata for {}: {}", storage->getStorageID().getNameForLogs(), metadata_result.error().message());
-                }
-
-                auto hints_result = storage->tryGetSerializationHints();
-                if (hints_result.has_value())
-                    serialization_hints = std::move(*hints_result);
-                else
-                    LOG_DEBUG(getLogger("SystemColumns"), "Failed to get serialization hints for {}: {}", storage->getStorageID().getNameForLogs(), hints_result.error().message());
-
+                auto metadata_snapshot = storage->tryGetInMemoryMetadataPtr().value_or(std::make_shared<StorageInMemoryMetadata>());
                 columns = metadata_snapshot->getColumns();
+                if (auto hints = storage->tryGetSerializationHints())
+                    serialization_hints = std::move(*hints);
 
                 /// Certain information about a table - should be calculated only when the corresponding columns are queried.
                 if (columns_mask[7] || columns_mask[8] || columns_mask[9])
                 {
-                    /// Can throw UNKNOWN_DATABASE in case of Merge table
-                    auto column_sizes_result = storage->tryGetColumnSizes();
-                    if (column_sizes_result.has_value())
-                        column_sizes = std::move(*column_sizes_result);
-                    else
-                        LOG_DEBUG(getLogger("SystemColumns"), "Failed to get column sizes for {}: {}", storage->getStorageID().getNameForLogs(), column_sizes_result.error().message());
+                    if (auto sizes = storage->tryGetColumnSizes())
+                        column_sizes = std::move(*sizes);
                 }
 
                 if (columns_mask[11])

--- a/src/Storages/System/StorageSystemColumns.cpp
+++ b/src/Storages/System/StorageSystemColumns.cpp
@@ -141,18 +141,20 @@ protected:
 
             {
                 StoragePtr storage = storages.at(std::make_pair(database_name, table_name));
-                TableLockHolder table_lock = storage->tryLockForShare(query_id, lock_acquire_timeout);
-
-                if (table_lock == nullptr)
-                {
-                    // Table was dropped while acquiring the lock, skipping table
-                    continue;
-                }
-
+                TableLockHolder table_lock;
                 StorageMetadataPtr metadata_snapshot;
+
                 /// Can throw UNKNOWN_DATABASE/UNKNOWN_TABLE in case of Alias table
                 try
                 {
+                    table_lock = storage->tryLockForShare(query_id, lock_acquire_timeout);
+
+                    if (table_lock == nullptr)
+                    {
+                        // Table was dropped while acquiring the lock, skipping table
+                        continue;
+                    }
+
                     metadata_snapshot = storage->getInMemoryMetadataPtr();
                     serialization_hints = storage->getSerializationHints();
                 }

--- a/src/Storages/System/StorageSystemCompletions.cpp
+++ b/src/Storages/System/StorageSystemCompletions.cpp
@@ -89,19 +89,11 @@ void fillDataWithTableColumns(
     if (table_lock == nullptr)
         return; // table was dropped while acquiring the lock
 
-    StorageMetadataPtr snapshot;
-    auto snapshot_result = table->tryGetInMemoryMetadataPtr();
-    if (snapshot_result.has_value())
-    {
-        snapshot = std::move(*snapshot_result);
-    }
-    else
-    {
-        LOG_DEBUG(getLogger("SystemCompletions"), "Failed to get inmemory metadata for {}: {}", table->getStorageID().getNameForLogs(), snapshot_result.error().message());
+    auto snapshot = table->tryGetInMemoryMetadataPtr();
+    if (!snapshot)
         return;
-    }
 
-    const auto & columns = snapshot->getColumns();
+    const auto & columns = (*snapshot)->getColumns();
     for (const auto & column : columns)
     {
         if (!access->isGranted(AccessType::SHOW_COLUMNS, database_name, table_name, column.name))

--- a/src/Storages/System/StorageSystemTables.cpp
+++ b/src/Storages/System/StorageSystemTables.cpp
@@ -842,11 +842,11 @@ protected:
                 {
                     try
                     {
-                    auto lifetime_bytes = table ? table->lifetimeBytes() : std::nullopt;
-                    if (lifetime_bytes)
-                        res_columns[res_index]->insert(*lifetime_bytes);
-                    else
-                        res_columns[res_index]->insertDefault();
+                        auto lifetime_bytes = table ? table->lifetimeBytes() : std::nullopt;
+                        if (lifetime_bytes)
+                            res_columns[res_index]->insert(*lifetime_bytes);
+                        else
+                            res_columns[res_index]->insertDefault();
                     }
                     catch (const Exception &)
                     {

--- a/src/Storages/System/StorageSystemTables.cpp
+++ b/src/Storages/System/StorageSystemTables.cpp
@@ -693,11 +693,21 @@ protected:
 
                 if (columns_mask[src_index++])
                 {
-                    auto policy = table ? table->getStoragePolicy() : nullptr;
-                    if (policy)
-                        res_columns[res_index++]->insert(policy->getName());
-                    else
-                        res_columns[res_index++]->insertDefault();
+                    try
+                    {
+                        auto policy = table ? table->getStoragePolicy() : nullptr;
+                        if (policy)
+                            res_columns[res_index]->insert(policy->getName());
+                        else
+                            res_columns[res_index]->insertDefault();
+                    }
+                    catch (const Exception &)
+                    {
+                        /// Even if the method throws, it should not prevent querying system.tables.
+                        tryLogCurrentException("StorageSystemTables");
+                        res_columns[res_index]->insertDefault();
+                    }
+                    ++res_index;
                 }
 
                 ContextMutablePtr context_copy = Context::createCopy(context);
@@ -811,20 +821,40 @@ protected:
 
                 if (columns_mask[src_index++])
                 {
-                    auto lifetime_rows = table ? table->lifetimeRows() : std::nullopt;
-                    if (lifetime_rows)
-                        res_columns[res_index++]->insert(*lifetime_rows);
-                    else
-                        res_columns[res_index++]->insertDefault();
+                    try
+                    {
+                        auto lifetime_rows = table ? table->lifetimeRows() : std::nullopt;
+                        if (lifetime_rows)
+                            res_columns[res_index]->insert(*lifetime_rows);
+                        else
+                            res_columns[res_index]->insertDefault();
+                    }
+                    catch (const Exception &)
+                    {
+                        /// Even if the method throws, it should not prevent querying system.tables.
+                        tryLogCurrentException("StorageSystemTables");
+                        res_columns[res_index]->insertDefault();
+                    }
+                    ++res_index;
                 }
 
                 if (columns_mask[src_index++])
                 {
+                    try
+                    {
                     auto lifetime_bytes = table ? table->lifetimeBytes() : std::nullopt;
                     if (lifetime_bytes)
-                        res_columns[res_index++]->insert(*lifetime_bytes);
+                        res_columns[res_index]->insert(*lifetime_bytes);
                     else
-                        res_columns[res_index++]->insertDefault();
+                        res_columns[res_index]->insertDefault();
+                    }
+                    catch (const Exception &)
+                    {
+                        /// Even if the method throws, it should not prevent querying system.tables.
+                        tryLogCurrentException("StorageSystemTables");
+                        res_columns[res_index]->insertDefault();
+                    }
+                    ++res_index;
                 }
 
                 if (columns_mask[src_index++])

--- a/src/Storages/System/StorageSystemTables.cpp
+++ b/src/Storages/System/StorageSystemTables.cpp
@@ -41,6 +41,11 @@ namespace Setting
     extern const SettingsBool show_table_uuid_in_table_create_query_if_not_nil;
     extern const SettingsBool show_data_lake_catalogs_in_system_tables;
 }
+namespace ErrorCodes
+{
+extern const int UNKNOWN_DATABASE;
+extern const int UNKNOWN_TABLE;
+}
 
 namespace
 {
@@ -283,7 +288,21 @@ protected:
     {
         if (table)
         {
-            StorageMetadataPtr metadata_snapshot = table->getInMemoryMetadataPtr();
+            StorageMetadataPtr metadata_snapshot;
+            /// Can throw UNKNOWN_DATABASE/UNKNOWN_TABLE in case of Alias table
+            try
+            {
+                metadata_snapshot = table->getInMemoryMetadataPtr();
+            }
+            catch (const Exception & e)
+            {
+                if (table->getName() != "Alias" || (e.code() == ErrorCodes::UNKNOWN_DATABASE || e.code() == ErrorCodes::UNKNOWN_TABLE))
+                {
+                    columns[res_index++]->insertDefault();
+                    return;
+                }
+                throw;
+            }
 
             NameToNameMap query_parameters_array = getSelectParamters(metadata_snapshot);
             if (!query_parameters_array.empty())
@@ -519,10 +538,22 @@ protected:
                 {
                     chassert(lock != nullptr);
                     Array table_paths_array;
-                    auto paths = table->getDataPaths();
-                    table_paths_array.reserve(paths.size());
-                    for (const String & path : paths)
-                        table_paths_array.push_back(path);
+
+                    /// Can throw UNKNOWN_DATABASE/UNKNOWN_TABLE in case of Alias table
+                    try
+                    {
+                        auto paths = table->getDataPaths();
+                        table_paths_array.reserve(paths.size());
+                        for (const String & path : paths)
+                            table_paths_array.push_back(path);
+                    }
+                    catch (const Exception & e)
+                    {
+                        if (table->getName() != "Alias" || (e.code() != ErrorCodes::UNKNOWN_DATABASE && e.code() != ErrorCodes::UNKNOWN_TABLE))
+                            throw;
+                        tryLogCurrentException(getLogger("StorageSystemTables"), fmt::format("While obtaining data paths for {}", table->getStorageID().getNameForLogs()), LogsLevel::debug);
+                    }
+
                     res_columns[res_index++]->insert(table_paths_array);
                     /// We don't need the lock anymore
                     lock = nullptr;
@@ -536,7 +567,19 @@ protected:
 
                 StorageMetadataPtr metadata_snapshot;
                 if (table)
-                    metadata_snapshot = table->getInMemoryMetadataPtr();
+                {
+                    /// Can throw UNKNOWN_DATABASE/UNKNOWN_TABLE in case of Alias table
+                    try
+                    {
+                        metadata_snapshot = table->getInMemoryMetadataPtr();
+                    }
+                    catch (const Exception & e)
+                    {
+                        if (table->getName() != "Alias" || (e.code() != ErrorCodes::UNKNOWN_DATABASE && e.code() != ErrorCodes::UNKNOWN_TABLE))
+                            throw;
+                        tryLogCurrentException(getLogger("StorageSystemTables"), fmt::format("Cannot find target database/table for {}", table->getStorageID().getNameForLogs()), LogsLevel::debug);
+                    }
+                }
 
                 if (columns_mask[src_index++])
                 {
@@ -842,8 +885,8 @@ protected:
 
                 if (columns_mask[src_index++])
                 {
-                    if (table && table->getInMemoryMetadataPtr()->sql_security_type == SQLSecurityType::DEFINER)
-                        res_columns[res_index++]->insert(*table->getInMemoryMetadataPtr()->definer);
+                    if (metadata_snapshot && metadata_snapshot->sql_security_type == SQLSecurityType::DEFINER)
+                        res_columns[res_index++]->insert(*metadata_snapshot->definer);
                     else
                         res_columns[res_index++]->insertDefault();
                 }

--- a/tests/queries/0_stateless/03636_storage_alias_basic.reference
+++ b/tests/queries/0_stateless/03636_storage_alias_basic.reference
@@ -1,49 +1,116 @@
+-- { echo }
+
+DROP TABLE IF EXISTS source_table;
+DROP TABLE IF EXISTS alias_1;
+DROP TABLE IF EXISTS alias_2;
+DROP TABLE IF EXISTS alias_3;
+DROP TABLE IF EXISTS alias_4;
+SET allow_experimental_alias_table_engine = 1;
+-- Create source table
+CREATE TABLE source_table (id UInt32, value String) ENGINE = MergeTree ORDER BY id;
+INSERT INTO source_table VALUES (1, 'one'), (2, 'two'), (3, 'three');
+-- Test: Basic alias creation
+SELECT 'Test Basic alias creation';
 Test Basic alias creation
+CREATE TABLE alias_1 ENGINE = Alias('source_table');
+SELECT * FROM alias_1 ORDER BY id;
 1	one
 2	two
 3	three
+-- Test: Alias with database name
+SELECT 'Test Alias with database name';
 Test Alias with database name
+CREATE TABLE alias_2 ENGINE = Alias(currentDatabase(), 'source_table');
+SELECT * FROM alias_2 ORDER BY id;
 1	one
 2	two
 3	three
+-- Test: Insert through alias
+SELECT 'Test Insert through alias_1';
 Test Insert through alias_1
+INSERT INTO alias_1 VALUES (4, 'four');
+SELECT * FROM source_table ORDER BY id;
 1	one
 2	two
 3	three
 4	four
+-- Test: Insert through alias_2
+SELECT 'Test Insert through alias_2';
 Test Insert through alias_2
+INSERT INTO alias_2 VALUES (5, 'five');
+SELECT * FROM source_table ORDER BY id;
 1	one
 2	two
 3	three
 4	four
 5	five
+-- Test: ALTER ADD COLUMN
+SELECT 'Test ALTER ADD COLUMN';
 Test ALTER ADD COLUMN
+ALTER TABLE alias_1 ADD COLUMN status String DEFAULT 'active';
+SELECT id, value, status FROM source_table ORDER BY id;
 1	one	active
 2	two	active
 3	three	active
 4	four	active
 5	five	active
+-- Test: INSERT with new column
+SELECT 'Test Insert with new column';
 Test Insert with new column
+INSERT INTO alias_1 VALUES (6, 'six', 'inactive');
+SELECT * FROM source_table ORDER BY id;
 1	one	active
 2	two	active
 3	three	active
 4	four	active
 5	five	active
 6	six	inactive
+-- Test: Truncate
+SELECT 'Test TRUNCATE';
 Test TRUNCATE
+TRUNCATE TABLE alias_1;
+SELECT count() FROM source_table;
 0
+-- Re-insert data
+INSERT INTO source_table VALUES (1, 'one', 'active'), (2, 'two', 'active');
+-- Test: Rename alias
+SELECT 'Test RENAME alias';
 Test RENAME alias
+RENAME TABLE alias_1 TO alias_3;
+SELECT * FROM alias_3 ORDER BY id;
 1	one	active
 2	two	active
+-- Test: Drop alias (should not affect source table)
+SELECT 'Test DROP alias';
 Test DROP alias
+DROP TABLE alias_2;
+DROP TABLE alias_3;
+SELECT count() FROM source_table;
 2
+-- Test: Create alias
+SELECT 'Test Create alias';
 Test Create alias
+CREATE TABLE alias_4 ENGINE = Alias('source_table');
+SELECT * FROM alias_4 ORDER BY id;
 1	one	active
 2	two	active
+-- Test: OPTIMIZE through alias
+SELECT 'Test OPTIMIZE';
 Test OPTIMIZE
+INSERT INTO alias_4 VALUES (10, 'ten', 'active');
+INSERT INTO alias_4 VALUES (11, 'eleven', 'active');
+INSERT INTO alias_4 VALUES (12, 'twelve', 'active');
+OPTIMIZE TABLE alias_4 FINAL;
+SELECT count() AS parts_after FROM system.parts
+WHERE database = currentDatabase() AND table = 'source_table' AND active;
 1
+SELECT count() FROM alias_4;
 5
+-- Test: ALTER MODIFY SETTING
+SELECT 'Test ALTER MODIFY SETTING';
 Test ALTER MODIFY SETTING
+ALTER TABLE alias_4 MODIFY SETTING max_bytes_to_merge_at_max_space_in_pool = 1000000;
+SHOW CREATE TABLE source_table FORMAT TSVRaw;
 CREATE TABLE default.source_table
 (
     `id` UInt32,
@@ -53,64 +120,206 @@ CREATE TABLE default.source_table
 ENGINE = MergeTree
 ORDER BY id
 SETTINGS index_granularity = 8192, max_bytes_to_merge_at_max_space_in_pool = 1000000
+-- Test: UPDATE through alias
+SELECT 'Test UPDATE (mutate)';
 Test UPDATE (mutate)
+ALTER TABLE alias_4 UPDATE value = 'updated' WHERE id = 1 SETTINGS mutations_sync = 1;
+SELECT id, value, status FROM source_table WHERE id = 1;
 1	updated	active
+-- Test: DELETE through alias
+SELECT 'Test DELETE (mutate)';
 Test DELETE (mutate)
+ALTER TABLE alias_4 DELETE WHERE id = 2 SETTINGS mutations_sync = 1;
+SELECT count() FROM source_table WHERE id = 2;
 0
+-- Test: Partition operations
+SELECT 'Test Partition operations';
 Test Partition operations
+DROP TABLE IF EXISTS source_partitioned;
+DROP TABLE IF EXISTS alias_part;
+CREATE TABLE source_partitioned (date Date, id UInt32, value String)
+ENGINE = MergeTree PARTITION BY toYYYYMM(date) ORDER BY id;
+CREATE TABLE alias_part ENGINE = Alias('source_partitioned');
+INSERT INTO alias_part VALUES ('2024-01-15', 1, 'january'), ('2024-02-15', 2, 'february'), ('2024-03-15', 3, 'march');
+SELECT count() FROM alias_part;
 3
+-- Test: DETACH PARTITION
+SELECT 'Test DETACH PARTITION';
 Test DETACH PARTITION
+ALTER TABLE alias_part DETACH PARTITION '202401';
+SELECT count() FROM alias_part;
 2
+-- Test: ATTACH PARTITION
+SELECT 'Test ATTACH PARTITION';
 Test ATTACH PARTITION
+ALTER TABLE alias_part ATTACH PARTITION '202401';
+SELECT count() FROM alias_part;
 3
+-- Test: DROP PARTITION
+SELECT 'Test DROP PARTITION';
 Test DROP PARTITION
+ALTER TABLE alias_part DROP PARTITION '202403';
+SELECT count() FROM alias_part;
 2
+-- Test: INSERT SELECT
+SELECT 'Test INSERT SELECT';
 Test INSERT SELECT
+INSERT INTO alias_4 SELECT id + 100, value, status FROM source_table WHERE id <= 10;
+SELECT count() FROM source_table WHERE id > 100;
 2
+-- Test: EXCHANGE TABLES
+DROP TABLE IF EXISTS table_a_exchange;
+DROP TABLE IF EXISTS table_b_exchange;
+DROP TABLE IF EXISTS alias_a_exchange;
+DROP TABLE IF EXISTS alias_b_exchange;
+CREATE TABLE table_a_exchange (value String) ENGINE = MergeTree() ORDER BY value;
+CREATE TABLE table_b_exchange (value String) ENGINE = MergeTree() ORDER BY value;
+INSERT INTO table_a_exchange VALUES ('from_a');
+INSERT INTO table_b_exchange VALUES ('from_b');
+CREATE TABLE alias_a_exchange ENGINE = Alias(table_a_exchange);
+CREATE TABLE alias_b_exchange ENGINE = Alias(table_b_exchange);
+SELECT 'Before EXCHANGE';
 Before EXCHANGE
+SELECT * FROM alias_a_exchange ORDER BY value;
 from_a
+SELECT * FROM alias_b_exchange ORDER BY value;
 from_b
+-- EXCHANGE the alias
+EXCHANGE TABLES alias_a_exchange AND alias_b_exchange;
+SELECT 'After EXCHANGE alias tables';
 After EXCHANGE alias tables
+SELECT * FROM alias_a_exchange ORDER BY value;  -- Should show 'from_b'
 from_b
+SELECT * FROM alias_b_exchange ORDER BY value;  -- Should show 'from_a'
 from_a
+-- EXCHANGE the source tables
+EXCHANGE TABLES table_a_exchange AND table_b_exchange;
+SELECT 'After EXCHANGE source tables';
 After EXCHANGE source tables
+SELECT * FROM alias_a_exchange ORDER BY value;  -- Should show 'from_a'
 from_a
+SELECT * FROM alias_b_exchange ORDER BY value;  -- Should show 'from_b'
 from_b
+DROP TABLE alias_a_exchange;
+DROP TABLE alias_b_exchange;
+DROP TABLE table_a_exchange;
+DROP TABLE table_b_exchange;
+-- Test: DETACH and ATTACH TABLE
+SELECT 'Test DETACH and ATTACH TABLE';
 Test DETACH and ATTACH TABLE
+DROP TABLE IF EXISTS source_attach;
+DROP TABLE IF EXISTS alias_attach;
+CREATE TABLE source_attach (id UInt32, data String) ENGINE = MergeTree ORDER BY id;
+INSERT INTO source_attach VALUES (1, 'data1'), (2, 'data2');
+CREATE TABLE alias_attach ENGINE = Alias('source_attach');
+SELECT * FROM alias_attach ORDER BY id;
 1	data1
 2	data2
+SELECT * FROM source_attach ORDER BY id;
 1	data1
 2	data2
+-- DETACH the alias table
+DETACH TABLE alias_attach;
+-- ATTACH the table back
+ATTACH TABLE alias_attach;
+-- Verify it works after ATTACH
+SELECT 'After ATTACH';
 After ATTACH
+SELECT * FROM alias_attach ORDER BY id;
 1	data1
 2	data2
+SELECT * FROM source_attach ORDER BY id;
 1	data1
 2	data2
+-- Insert through alias after ATTACH
+INSERT INTO alias_attach VALUES (3, 'data3');
+SELECT * FROM alias_attach ORDER BY id;
 1	data1
 2	data2
 3	data3
+SELECT * FROM source_attach ORDER BY id;
 1	data1
 2	data2
 3	data3
+DROP TABLE alias_attach;
+DROP TABLE source_attach;
+-- Test: Circular reference check
+SELECT 'Test circular reference prevention';
 Test circular reference prevention
+CREATE TABLE self_ref_test ENGINE = Alias('self_ref_test'); -- { serverError BAD_ARGUMENTS }
+SELECT 'Test ALTER target directly';
 Test ALTER target directly
+CREATE TABLE metadata_target (id UInt32, value String) ENGINE = MergeTree ORDER BY id;
+CREATE TABLE metadata_alias ENGINE = Alias('metadata_target');
+INSERT INTO metadata_target VALUES (1, 'one'), (2, 'two');
+SELECT * FROM metadata_alias ORDER BY id;
 1	one
 2	two
+-- ALTER target table DIRECTLY (not through alias)
+ALTER TABLE metadata_target ADD COLUMN extra String DEFAULT 'data1';
+-- Alias should immediately see the new column (dynamic metadata fetch)
+SELECT 'After ALTER target';
 After ALTER target
+SELECT name FROM system.columns WHERE database = currentDatabase() AND table = 'metadata_alias' ORDER BY name;
 extra
 id
 value
+-- INSERT through alias with new column should work
+INSERT INTO metadata_alias VALUES (3, 'three', 'data3');
+SELECT * FROM metadata_alias ORDER BY id;
 1	one	data1
 2	two	data1
 3	three	data3
+ALTER TABLE metadata_target ADD COLUMN num UInt32 DEFAULT 0;
+ALTER TABLE metadata_target MODIFY COLUMN extra String DEFAULT 'data2';
+SELECT 'After multiple ALTERs';
 After multiple ALTERs
+SELECT name FROM system.columns WHERE database = currentDatabase() AND table = 'metadata_alias' ORDER BY name;
 extra
 id
 num
 value
+-- Insert with all columns
+INSERT INTO metadata_alias VALUES (4, 'four', DEFAULT, 100);
+SELECT id, value, extra, num FROM metadata_alias WHERE id = 4;
 4	four	data2	100
+-- DROP COLUMN on target
+ALTER TABLE metadata_target DROP COLUMN num;
+-- Alias should not show dropped column
+SELECT 'After DROP';
 After DROP
+SELECT name FROM system.columns WHERE database = currentDatabase() AND table = 'metadata_alias' ORDER BY name;
 extra
 id
 value
+-- INSERT after DROP should work (without dropped column)
+INSERT INTO metadata_alias VALUES (5, 'five', 'data5');
+SELECT id, value, extra FROM metadata_alias WHERE id = 5;
 5	five	data5
+DROP TABLE metadata_alias;
+DROP TABLE metadata_target;
+SELECT 'Test alias with missing target table';
+Test alias with missing target table
+DROP TABLE IF EXISTS alias_with_missing_target;
+DROP TABLE IF EXISTS temp_target;
+CREATE TABLE temp_target (id UInt32, value String) ENGINE = MergeTree ORDER BY id;
+INSERT INTO temp_target VALUES (1, 'data1'), (2, 'data2');
+CREATE TABLE alias_with_missing_target ENGINE = Alias('temp_target');
+SELECT * FROM alias_with_missing_target ORDER BY id;
+1	data1
+2	data2
+DROP TABLE temp_target;
+SELECT name, engine FROM system.tables WHERE database = currentDatabase() AND name = 'alias_with_missing_target';
+alias_with_missing_target	Alias
+SELECT arraySort(groupUniqArray(name)) FROM system.tables WHERE database = currentDatabase();
+['alias_4','alias_part','alias_with_missing_target','source_partitioned','source_table']
+SELECT arraySort(groupUniqArray(name)) FROM system.columns WHERE database = currentDatabase() AND table = 'alias_with_missing_target';
+[]
+SELECT database, table, name FROM system.columns
+WHERE database = currentDatabase() AND table = 'alias_with_missing_target'
+ORDER BY name;
+SELECT name, engine, total_rows, total_bytes, data_paths
+FROM system.tables
+WHERE database = currentDatabase() AND name = 'alias_with_missing_target';
+alias_with_missing_target	Alias	\N	\N	[]
+DROP TABLE alias_with_missing_target;

--- a/tests/queries/0_stateless/03636_storage_alias_basic.reference
+++ b/tests/queries/0_stateless/03636_storage_alias_basic.reference
@@ -1,4 +1,5 @@
 -- { echo }
+-- Tags: long
 
 DROP TABLE IF EXISTS source_table;
 DROP TABLE IF EXISTS alias_1;
@@ -138,7 +139,7 @@ Test Partition operations
 DROP TABLE IF EXISTS source_partitioned;
 DROP TABLE IF EXISTS alias_part;
 CREATE TABLE source_partitioned (date Date, id UInt32, value String)
-ENGINE = MergeTree PARTITION BY toYYYYMM(date) ORDER BY id;
+    ENGINE = MergeTree PARTITION BY toYYYYMM(date) ORDER BY id;
 CREATE TABLE alias_part ENGINE = Alias('source_partitioned');
 INSERT INTO alias_part VALUES ('2024-01-15', 1, 'january'), ('2024-02-15', 2, 'february'), ('2024-03-15', 3, 'march');
 SELECT count() FROM alias_part;

--- a/tests/queries/0_stateless/03636_storage_alias_basic.sql
+++ b/tests/queries/0_stateless/03636_storage_alias_basic.sql
@@ -1,4 +1,5 @@
 -- Tags: long
+-- { echo }
 
 DROP TABLE IF EXISTS source_table;
 DROP TABLE IF EXISTS alias_1;
@@ -73,7 +74,7 @@ INSERT INTO alias_4 VALUES (10, 'ten', 'active');
 INSERT INTO alias_4 VALUES (11, 'eleven', 'active');
 INSERT INTO alias_4 VALUES (12, 'twelve', 'active');
 OPTIMIZE TABLE alias_4 FINAL;
-SELECT count() AS parts_after FROM system.parts 
+SELECT count() AS parts_after FROM system.parts
 WHERE database = currentDatabase() AND table = 'source_table' AND active;
 SELECT count() FROM alias_4;
 
@@ -96,8 +97,8 @@ SELECT count() FROM source_table WHERE id = 2;
 SELECT 'Test Partition operations';
 DROP TABLE IF EXISTS source_partitioned;
 DROP TABLE IF EXISTS alias_part;
-CREATE TABLE source_partitioned (date Date, id UInt32, value String) 
-ENGINE = MergeTree PARTITION BY toYYYYMM(date) ORDER BY id;
+CREATE TABLE source_partitioned (date Date, id UInt32, value String)
+    ENGINE = MergeTree PARTITION BY toYYYYMM(date) ORDER BY id;
 CREATE TABLE alias_part ENGINE = Alias('source_partitioned');
 INSERT INTO alias_part VALUES ('2024-01-15', 1, 'january'), ('2024-02-15', 2, 'february'), ('2024-03-15', 3, 'march');
 SELECT count() FROM alias_part;
@@ -236,3 +237,30 @@ SELECT id, value, extra FROM metadata_alias WHERE id = 5;
 
 DROP TABLE metadata_alias;
 DROP TABLE metadata_target;
+
+SELECT 'Test alias with missing target table';
+DROP TABLE IF EXISTS alias_with_missing_target;
+DROP TABLE IF EXISTS temp_target;
+
+CREATE TABLE temp_target (id UInt32, value String) ENGINE = MergeTree ORDER BY id;
+INSERT INTO temp_target VALUES (1, 'data1'), (2, 'data2');
+
+CREATE TABLE alias_with_missing_target ENGINE = Alias('temp_target');
+SELECT * FROM alias_with_missing_target ORDER BY id;
+
+DROP TABLE temp_target;
+
+SELECT name, engine FROM system.tables WHERE database = currentDatabase() AND name = 'alias_with_missing_target';
+
+SELECT arraySort(groupUniqArray(name)) FROM system.tables WHERE database = currentDatabase();
+SELECT arraySort(groupUniqArray(name)) FROM system.columns WHERE database = currentDatabase() AND table = 'alias_with_missing_target';
+
+SELECT database, table, name FROM system.columns
+WHERE database = currentDatabase() AND table = 'alias_with_missing_target'
+ORDER BY name;
+
+SELECT name, engine, total_rows, total_bytes, data_paths
+FROM system.tables
+WHERE database = currentDatabase() AND name = 'alias_with_missing_target';
+
+DROP TABLE alias_with_missing_target;

--- a/tests/queries/0_stateless/03636_storage_alias_basic.sql
+++ b/tests/queries/0_stateless/03636_storage_alias_basic.sql
@@ -1,5 +1,5 @@
--- Tags: long
 -- { echo }
+-- Tags: long
 
 DROP TABLE IF EXISTS source_table;
 DROP TABLE IF EXISTS alias_1;

--- a/tests/queries/0_stateless/03636_storage_alias_basic.sql
+++ b/tests/queries/0_stateless/03636_storage_alias_basic.sql
@@ -5,7 +5,6 @@ DROP TABLE IF EXISTS alias_1;
 DROP TABLE IF EXISTS alias_2;
 DROP TABLE IF EXISTS alias_3;
 DROP TABLE IF EXISTS alias_4;
-DROP TABLE IF EXISTS source_other;
 
 SET allow_experimental_alias_table_engine = 1;
 

--- a/tests/queries/0_stateless/03636_storage_alias_syntax.reference
+++ b/tests/queries/0_stateless/03636_storage_alias_syntax.reference
@@ -1,14 +1,50 @@
+-- { echo }
+
+DROP TABLE IF EXISTS source_table;
+DROP TABLE IF EXISTS alias_syntax_1;
+DROP TABLE IF EXISTS alias_syntax_2;
+SET allow_experimental_alias_table_engine = 1;
+-- Create source table
+CREATE TABLE source_table (id UInt32, name String, value Float64)
+ENGINE = MergeTree ORDER BY id;
+INSERT INTO source_table VALUES (1, 'one', 10.1), (2, 'two', 20.2), (3, 'three', 30.3);
+-- Syntax: ENGINE = Alias(table)
+SELECT 'Test ENGINE = Alias(table)';
 Test ENGINE = Alias(table)
+CREATE TABLE alias_syntax_1 ENGINE = Alias('source_table');
+SELECT * FROM alias_syntax_1 ORDER BY id;
 1	one	10.1
 2	two	20.2
 3	three	30.3
+-- Syntax: ENGINE = Alias(db, table)
+SELECT 'Test ENGINE = Alias(db, table)';
 Test ENGINE = Alias(db, table)
+CREATE TABLE alias_syntax_2 ENGINE = Alias(currentDatabase(), 'source_table');
+SELECT * FROM alias_syntax_2 ORDER BY id;
 1	one	10.1
 2	two	20.2
 3	three	30.3
+-- Test: All aliases work identically
+SELECT 'Test All aliases work identically';
 Test All aliases work identically
+INSERT INTO alias_syntax_1 VALUES (4, 'four', 40.4);
+SELECT count() FROM source_table;
 4
+SELECT count() FROM alias_syntax_1;
 4
+SELECT count() FROM alias_syntax_2;
 4
+INSERT INTO alias_syntax_2 VALUES (5, 'five', 50.5);
+SELECT count() FROM source_table;
 5
+-- Test: with explicit columns (should fail)
+SELECT 'Test Explicit columns should fail';
 Test Explicit columns should fail
+CREATE TABLE alias_syntax_3 (id UInt32, name String, value Float64) ENGINE = Alias('source_table'); -- { serverError BAD_ARGUMENTS }
+-- Test: Alias to alias
+DROP TABLE IF EXISTS base_table;
+DROP TABLE IF EXISTS alias_1;
+DROP TABLE IF EXISTS alias_2;
+CREATE TABLE base_table (id UInt32, value String) ENGINE = MergeTree ORDER BY id;
+CREATE TABLE alias_1 ENGINE = Alias('base_table');
+CREATE TABLE alias_2 ENGINE = Alias('alias_1'); -- { serverError BAD_ARGUMENTS }

--- a/tests/queries/0_stateless/03636_storage_alias_syntax.sql
+++ b/tests/queries/0_stateless/03636_storage_alias_syntax.sql
@@ -1,3 +1,5 @@
+-- { echo }
+
 DROP TABLE IF EXISTS source_table;
 DROP TABLE IF EXISTS alias_syntax_1;
 DROP TABLE IF EXISTS alias_syntax_2;
@@ -5,7 +7,7 @@ DROP TABLE IF EXISTS alias_syntax_2;
 SET allow_experimental_alias_table_engine = 1;
 
 -- Create source table
-CREATE TABLE source_table (id UInt32, name String, value Float64) 
+CREATE TABLE source_table (id UInt32, name String, value Float64)
 ENGINE = MergeTree ORDER BY id;
 
 INSERT INTO source_table VALUES (1, 'one', 10.1), (2, 'two', 20.2), (3, 'three', 30.3);
@@ -33,3 +35,13 @@ SELECT count() FROM source_table;
 -- Test: with explicit columns (should fail)
 SELECT 'Test Explicit columns should fail';
 CREATE TABLE alias_syntax_3 (id UInt32, name String, value Float64) ENGINE = Alias('source_table'); -- { serverError BAD_ARGUMENTS }
+
+-- Test: Alias to alias
+DROP TABLE IF EXISTS base_table;
+DROP TABLE IF EXISTS alias_1;
+DROP TABLE IF EXISTS alias_2;
+
+CREATE TABLE base_table (id UInt32, value String) ENGINE = MergeTree ORDER BY id;
+CREATE TABLE alias_1 ENGINE = Alias('base_table');
+CREATE TABLE alias_2 ENGINE = Alias('alias_1'); -- { serverError BAD_ARGUMENTS }
+


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix Alias stability issues: Fix StrictnessLevel with SharedDatabaseCatalog, disallow target is also an alias, and implement additional interfaces (getSerializationHints, supportsReplication, getStoragePolicy, totalBytesUncompressed, lifetimeRows, lifetimeBytes, storesDataOnDisk, tryLockForShare, lockForShare). Resolves #89106

### Details

This PR addresses several stability issues with Alias:

1. Fix #89106
2. Fix `StrictnessLevel` with `SharedDatabaseCatalog`
3. Disallow target is also an alias
4. Implement more interfaces:
    - getSerializationHints
    - supportsReplication with explicit return false
    - getStoragePolicy
    - totalBytesUncompressed
    - lifetimeRows
    - lifetimeBytes
    - storesDataOnDisk with explicit return false
    - tryLockForShare
    - lockForShare

Resolves: #89106
Resolves: https://github.com/ClickHouse/ClickHouse/issues/85363