### PR TITLE
add 03707_statistics_cache to parallel replica backlist

### DIFF
--- a/tests/parallel_replicas_blacklist.txt
+++ b/tests/parallel_replicas_blacklist.txt
@@ -454,3 +454,4 @@
 
     Produces different result:
 03658_joined_block_split_single_row_bytes
+03707_statistics_cache


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Details

The test `03707_statistics_cache` relies on checking some profile events from `query_log`, which will fail in parallel replica mode.
