### PR TITLE
Fix "invalid parse_numprocesses value" error in CI

### DIFF
--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -15,7 +15,7 @@ temp_path = f"{repo_dir}/ci/tmp"
 MAX_FAILS_BEFORE_DROP = 5
 OOM_IN_DMESG_TEST_NAME = "OOM in dmesg"
 ncpu = Utils.cpu_count()
-mem_gb = round(Utils.physical_memory() / (1024**3), 1)
+mem_gb = round(Utils.physical_memory() // (1024**3), 1)
 MAX_CPUS_PER_WORKER = 4
 MAX_MEM_PER_WORKER = 7
 


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Details

`sudo python3 -m ci.praktika run "Integration tests (amd_binary, 1/5)"` is not working on my machine. The error is:
```
pytest: error: argument -n/--numprocesses: invalid parse_numprocesses value: '4.0'
```

This PR fixes the rounding of the variable.
