### PR TITLE
Fix build under clang 21 again

### DIFF
--- a/src/DataTypes/Serializations/SerializationDynamic.cpp
+++ b/src/DataTypes/Serializations/SerializationDynamic.cpp
@@ -16,8 +16,6 @@
 #include <Interpreters/castColumn.h>
 #include <Formats/EscapingRuleUtils.h>
 
-#include <re2/re2.h>
-
 namespace DB
 {
 

--- a/src/Functions/MatchImpl.h
+++ b/src/Functions/MatchImpl.h
@@ -9,7 +9,6 @@
 #include <Functions/Regexps.h>
 
 #include "config.h"
-#include <re2/re2.h>
 
 
 namespace DB

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -132,7 +132,6 @@
 #include <Interpreters/TransactionLog.h>
 #include <Interpreters/ZooKeeperConnectionLog.h>
 #include <filesystem>
-#include <re2/re2.h>
 #include <Storages/StorageView.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/FunctionParameterValuesVisitor.h>


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Details

We're supposed to use `#include <Common/re2.h>` instead of `#include <re2/re2.h>`. The former is a wrapper around the latter that adds some `#pragma`s to avoid compiler warnings. This PR fixes a few occurrences of `<re2/re2.h>` (by removing them; one was unused, the other two didn't do anything because `<re2_st/re2.h>` was already transitively included).

(The public repo actually built fine, presumably because of transitive includes. The real fix is in the private sync PR.)
