### PR TITLE
Fix duplicate `plain-rewritable` check

### DIFF
--- a/src/Disks/DiskSelector.cpp
+++ b/src/Disks/DiskSelector.cpp
@@ -32,7 +32,7 @@ void DiskSelector::recordDisk(const std::string & disk_name, DiskPtr disk)
     {
         for (const auto & [saved_disk_name, saved_disk] : disks)
         {
-            if (!saved_disk->isPlain() || disk->isReadOnly() || disk->isWriteOnce())
+            if (!saved_disk->isPlain() || saved_disk->isReadOnly() || saved_disk->isWriteOnce())
                 continue;
 
             /// Same endpoint


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
We should skip `read-only` and `write-once` disks during duplicate search
