### PR TITLE
Batch removed objects during object storage tx undo

### DIFF
--- a/src/Disks/ObjectStorages/DiskObjectStorageTransaction.cpp
+++ b/src/Disks/ObjectStorages/DiskObjectStorageTransaction.cpp
@@ -104,7 +104,7 @@ struct PureMetadataObjectStorageOperation final : public IDiskObjectStorageOpera
         on_execute(transaction);
     }
 
-    void undo() override
+    void undo(StoredObjects & /*to_remove*/) override
     {
     }
 
@@ -191,9 +191,8 @@ struct RemoveObjectStorageOperation final : public IDiskObjectStorageOperation
         }
     }
 
-    void undo() override
+    void undo(StoredObjects & /*to_remove*/) override
     {
-
     }
 
     void finalize(StoredObjects & to_remove) override
@@ -294,7 +293,7 @@ struct RemoveManyObjectStorageOperation final : public IDiskObjectStorageOperati
         }
     }
 
-    void undo() override
+    void undo(StoredObjects & /*to_remove*/) override
     {
     }
 
@@ -418,7 +417,7 @@ struct RemoveRecursiveObjectStorageOperation final : public IDiskObjectStorageOp
         }
     }
 
-    void undo() override
+    void undo(StoredObjects & /*to_remove*/) override
     {
     }
 
@@ -494,9 +493,8 @@ struct ReplaceFileObjectStorageOperation final : public IDiskObjectStorageOperat
             tx->moveFile(path_from, path_to);
     }
 
-    void undo() override
+    void undo(StoredObjects & /*to_remove*/) override
     {
-
     }
 
     void finalize(StoredObjects & to_remove) override
@@ -566,11 +564,11 @@ struct WriteFileObjectStorageOperation final : public IDiskObjectStorageOperatio
         }
     }
 
-    void undo() override
+    void undo(StoredObjects & to_remove) override
     {
         LOG_DEBUG(getLogger("DiskObjectStorageTransaction"), "Undoing WriteFileObjectStorageOperation for path {}, key {}", object->local_path, object->remote_path);
         /// If the file was created, we need to remove it
-        object_storage.removeObjectIfExists(*object);
+        to_remove.push_back(*object);
     }
 
     void finalize(StoredObjects & /*to_remove*/) override
@@ -640,9 +638,9 @@ struct CopyFileObjectStorageOperation final : public IDiskObjectStorageOperation
     }
 
 
-    void undo() override
+    void undo(StoredObjects & to_remove) override
     {
-         destination_object_storage.removeObjectsIfExist(created_objects);
+        to_remove.append_range(created_objects);
     }
 
     void finalize(StoredObjects & /*to_remove*/) override
@@ -708,9 +706,8 @@ struct TruncateFileObjectStorageOperation final : public IDiskObjectStorageOpera
     }
 
 
-    void undo() override
+    void undo(StoredObjects & /*to_remove*/) override
     {
-        // no op
     }
 
     void finalize(StoredObjects & to_remove) override
@@ -750,9 +747,9 @@ struct CreateEmptyFileObjectStorageOperation final : public IDiskObjectStorageOp
         buf->finalize();
     }
 
-    void undo() override
+    void undo(StoredObjects & to_remove) override
     {
-        object_storage.removeObjectIfExists(object);
+        to_remove.push_back(object);
     }
 
     void finalize(StoredObjects & /*to_remove*/) override
@@ -1234,18 +1231,17 @@ void DiskObjectStorageTransaction::undo() noexcept
         return;
     }
 
+    StoredObjects objects_to_remove;
     for (const auto & operation : operations_to_execute | std::views::reverse)
+        operation->undo(objects_to_remove);
+
+    try
     {
-        try
-        {
-            operation->undo();
-        }
-        catch (...)
-        {
-            tryLogCurrentException(
-                        getLogger("DiskObjectStorageTransaction"),
-                        fmt::format("An error occurred while undoing transaction's operation #({})", operation->getInfoForLog()));
-        }
+        object_storage.removeObjectsIfExist(objects_to_remove);
+    }
+    catch (...)
+    {
+        tryLogCurrentException(getLogger("DiskObjectStorageTransaction"), "An error occurred during transaction cleanup");
     }
 
     operations_to_execute.clear();

--- a/src/Disks/ObjectStorages/DiskObjectStorageTransaction.cpp
+++ b/src/Disks/ObjectStorages/DiskObjectStorageTransaction.cpp
@@ -1128,20 +1128,7 @@ TransactionCommitOutcomeVariant DiskObjectStorageTransaction::tryCommit(const Tr
             ex.addMessage(fmt::format("While executing operation #{}", i));
 
             if (needRollbackBlobs(options))
-            {
-                for (int64_t j = i; j >= 0; --j)
-                {
-                    try
-                    {
-                        operations_to_execute[j]->undo();
-                    }
-                    catch (Exception & rollback_ex)
-                    {
-                        rollback_ex.addMessage(fmt::format("While undoing operation #{}", i));
-                        throw;
-                    }
-                }
-            }
+                undo();
 
             throw;
         }

--- a/src/Disks/ObjectStorages/DiskObjectStorageTransaction.h
+++ b/src/Disks/ObjectStorages/DiskObjectStorageTransaction.h
@@ -28,7 +28,7 @@ public:
     /// It is called if something went wrong before commit of metadata transaction
     /// It is called in reverse order of execution of operations for all operations
     /// even if they were not executed at all
-    virtual void undo() = 0;
+    virtual void undo(StoredObjects & to_remove) = 0;
     /// Action to execute after metadata transaction successfully committed.
     /// Useful when it's impossible to revert operation
     /// like removal of blobs. Such implementation can lead to garbage.


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Let's collect all objects that need to be removed after the disk object storage transaction revert into a single removal batch to perform a single S3 interaction.

### Details
This PR optimizes the object removal process during disk object storage transaction undo by batching all objects that need to be removed into a single removal batch, reducing the number of S3 interactions from multiple calls to a single batch operation.
