### PR TITLE
feat(json): add type_json_skip_invalid_typed_paths setting

### DIFF
--- a/src/Core/FormatFactorySettings.h
+++ b/src/Core/FormatFactorySettings.h
@@ -563,6 +563,16 @@ Possible values:
 + 0 — Disable.
 + 1 — Enable.
 )", 0) \
+    DECLARE(Bool, type_json_skip_invalid_typed_paths, false, R"(
+When enabled, fields with values that cannot be coerced to their declared type in JSON type columns with typed paths are skipped instead of throwing an error. Skipped fields are treated as missing and will use default/null values based on the typed path definition.
+
+This setting only applies to JSON type columns (e.g., JSON(a Int64, b String)) where specific paths have declared types. It does not apply to regular JSON input formats like JSONEachRow when inserting into regular typed columns.
+
+Possible values:
+
++ 0 — Disable (throw error on type mismatch).
++ 1 — Enable (skip field on type mismatch).
+)", 0) \
     DECLARE(Bool, input_format_try_infer_integers, true, R"(
 If enabled, ClickHouse will try to infer integers instead of floats in schema inference for text formats. If all numbers in the column from input data are integers, the result type will be `Int64`, if at least one number is float, the result type will be `Float64`.
 

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -58,6 +58,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"delta_lake_snapshot_end_version", -1, -1, "New setting."},
             {"serialize_string_in_memory_with_zero_byte", true, true, "New setting"},
             {"optimize_inverse_dictionary_lookup", false, true, "New setting"},
+            {"type_json_skip_invalid_typed_paths", false, false, "Allow skipping typed paths that fail type coercion in JSON columns"},
         });
         addSettingsChanges(settings_changes_history, "25.11",
         {

--- a/src/DataTypes/Serializations/SerializationJSON.cpp
+++ b/src/DataTypes/Serializations/SerializationJSON.cpp
@@ -274,6 +274,7 @@ void SerializationJSON<Parser>::deserializeObject(IColumn & column, std::string_
     String error;
     JSONExtractInsertSettings insert_settings;
     insert_settings.escape_dots_in_json_keys = settings.json.json_type_escape_dots_in_keys;
+    insert_settings.skip_invalid_typed_paths = settings.json.type_json_skip_invalid_typed_paths;
     if (!json_extract_tree->insertResultToColumn(column, document, insert_settings, settings, error))
         throw Exception(ErrorCodes::INCORRECT_DATA, "Cannot insert data into JSON column: {}", error);
 }

--- a/src/Formats/FormatFactory.cpp
+++ b/src/Formats/FormatFactory.cpp
@@ -180,6 +180,7 @@ FormatSettings getFormatSettings(const ContextPtr & context, const Settings & se
     format_settings.json.throw_on_bad_escape_sequence = settings[Setting::input_format_json_throw_on_bad_escape_sequence];
     format_settings.json.ignore_unnecessary_fields = settings[Setting::input_format_json_ignore_unnecessary_fields];
     format_settings.json.empty_as_default = settings[Setting::input_format_json_empty_as_default];
+    format_settings.json.type_json_skip_invalid_typed_paths = settings[Setting::type_json_skip_invalid_typed_paths];
     format_settings.json.type_json_skip_duplicated_paths = settings[Setting::type_json_skip_duplicated_paths];
     format_settings.json.pretty_print = settings[Setting::output_format_json_pretty_print];
     format_settings.json.infer_array_of_dynamic_from_array_of_different_values = settings[Setting::input_format_json_infer_array_of_dynamic_from_array_of_different_types];

--- a/src/Formats/FormatSettings.h
+++ b/src/Formats/FormatSettings.h
@@ -255,6 +255,7 @@ struct FormatSettings
         bool throw_on_bad_escape_sequence = true;
         bool ignore_unnecessary_fields = true;
         bool empty_as_default = false;
+        bool type_json_skip_invalid_typed_paths = false;
         bool type_json_skip_duplicated_paths = false;
         bool pretty_print = true;
         char pretty_print_indent = ' ';

--- a/src/Formats/JSONExtractTree.h
+++ b/src/Formats/JSONExtractTree.h
@@ -22,6 +22,10 @@ struct JSONExtractInsertSettings
     bool try_existing_variants_in_dynamic_first = true;
     /// If true, during constructing the JSON path dots in keys will be escaped.
     bool escape_dots_in_json_keys = false;
+    /// If true, skip typed paths where type coercion fails instead of throwing error.
+    /// Skipped fields are treated as missing and use default/null values.
+    /// Only applies to JSON type columns with typed paths, not general JSON parsing.
+    bool skip_invalid_typed_paths = false;
 };
 
 template <typename JSONParser>

--- a/tests/queries/0_stateless/03711_json_skip_invalid_fields.reference
+++ b/tests/queries/0_stateless/03711_json_skip_invalid_fields.reference
@@ -1,0 +1,3 @@
+Test 1: Skip invalid typed path - string cannot be coerced to Int64
+{"a":0,"b":"valid","c":123}
+Test 2: Verify error thrown when setting disabled

--- a/tests/queries/0_stateless/03711_json_skip_invalid_fields.sql
+++ b/tests/queries/0_stateless/03711_json_skip_invalid_fields.sql
@@ -1,0 +1,12 @@
+-- Test type_json_skip_invalid_typed_paths setting
+
+-- Test 1: JSON type column with typed paths - skip invalid field where type conversion fails
+SELECT 'Test 1: Skip invalid typed path - string cannot be coerced to Int64';
+SELECT '{"a": "not_an_int", "b": "valid", "c": 123}'::JSON(a Int64, b String, c Int32)
+SETTINGS type_json_skip_invalid_typed_paths = 1;
+
+-- Test 2: JSON type column - verify error is thrown when setting is disabled
+
+SELECT 'Test 2: Verify error thrown when setting disabled';
+SELECT '{"a": "not_an_int", "b": "valid", "c": 123}'::JSON(a Int64, b String, c Int32)
+SETTINGS type_json_skip_invalid_typed_paths = 0; -- { serverError INCORRECT_DATA }


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- New Feature

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add setting `type_json_skip_invalid_typed_paths` to disable exceptions for inserts/type casts to JSON type when input JSON cannot be cast to explicit typed paths in JSON type. Falls back to null/zero value of typed path. Closes https://github.com/ClickHouse/ClickHouse/issues/86917

### Documentation entry for user-facing changes
- [x] Documentation is written (mandatory for new features)

### Details
Adds `type_json_skip_invalid_typed_paths` setting so you can gracefully handle unknown input data when you want to always have a specific type for a given path:

```SQL
select '{"some_field": "asdf", "foo": 1}'::JSON(some_field UInt64) SETTINGS type_json_skip_invalid_typed_paths=1
-- result: {"some_field: 0, "foo": 1}
```
