### PR TITLE
Listing only relevant objects in table functions

### DIFF
--- a/src/Storages/VirtualColumnUtils.h
+++ b/src/Storages/VirtualColumnUtils.h
@@ -79,6 +79,22 @@ std::optional<ActionsDAG> createPathAndFileFilterDAG(const ActionsDAG::Node * pr
 
 ColumnPtr getFilterByPathAndFileIndexes(const std::vector<String> & paths, const ExpressionActionsPtr & actions, const NamesAndTypesList & virtual_columns, const NamesAndTypesList & hive_columns, const ContextPtr & context);
 
+/// Represents a filter on a specific path component
+struct PathComponentFilter
+{
+    size_t component_index; /// Position in the path after splitting by '/'
+    std::vector<String> allowed_values;
+};
+
+/// Extract filters on path components from predicates like splitByChar('/', _path)[N] = 'value'
+/// Returns map of component index to allowed values
+std::vector<PathComponentFilter> extractPathComponentFilters(const ActionsDAG::Node * predicate);
+
+/// Expand glob pattern using path component filters
+/// For example: pattern="bucket/*/data/*", filters={0: ["proj1", "proj2"]}
+/// Returns: ["bucket/proj1/data/*", "bucket/proj2/data/*"]
+std::vector<std::string> expandGlobWithPrefixFilters(const String & pattern, const std::vector<PathComponentFilter> & filters);
+
 template <typename T>
 void filterByPathOrFile(std::vector<T> & sources, const std::vector<String> & paths, const ExpressionActionsPtr & actions, const NamesAndTypesList & virtual_columns, const NamesAndTypesList & hive_columns, const ContextPtr & context)
 {


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: false -->

Optimizes S3/GCS/Azure queries by extracting equality filters from WHERE clause and using them to construct more specific glob patterns before listing objects.

Example: `WHERE splitByChar('/', _path)[2] = 'project-123'` transforms pattern `'bucket/*/data/*.parquet'` into `'bucket/project-123/data/*.parquet'`, listing only relevant objects instead of filtering millions in memory.

Provides speedup for queries with path component filters on large buckets.

### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
