### PR TITLE
Fix sporadic llvm-project compilation errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,20 @@
 cmake_minimum_required(VERSION 3.25)
 
+# Some CMakeLists.txt in contrib/ are not being good citizens and change cmake cache variables
+# globally. This policy prevents such *cache* variable assignments from altering *normal* variables
+# that we've set.
+#
+# Example: suppose our root CMakeLists.txt assigns a normal variable:
+#   set(CMAKE_CXX_STANDARD 23)
+# then llvm-project assigns cache variable with the same name:
+#   set(CMAKE_CXX_STANDARD 17 CACHE STRING "...")
+# The latter assignment doesn't affect the normal variable, so llvm-project effectively uses C++23.
+#
+# Without this policy, the behavior is nonlocal and brittle: if the cache variable doesn't exists,
+# the normal variable is unset; otherwise it's left alone. So the effective value would depend e.g.
+# on the order in which contrib/ libraries are traversed.
+set (CMAKE_POLICY_DEFAULT_CMP0126 NEW)
+
 project(ClickHouse LANGUAGES C CXX ASM)
 
 # If turned off: e.g. when ENABLE_FOO is ON, but FOO tool was not found, the CMake will continue.

--- a/contrib/llvm-project-cmake/CMakeLists.txt
+++ b/contrib/llvm-project-cmake/CMakeLists.txt
@@ -25,7 +25,9 @@ set (LLVM_INCLUDE_DIRS
     "${ClickHouse_BINARY_DIR}/contrib/llvm-project/llvm/include"
 )
 set (LLVM_LIBRARY_DIRS "${ClickHouse_BINARY_DIR}/contrib/llvm-project/llvm")
-set (CMAKE_CXX_STANDARD 23)
+
+# There are compilation errors with C++23.
+set (CMAKE_CXX_STANDARD 17)
 
 if (ARCH_AMD64)
     set (LLVM_TARGETS_TO_BUILD "X86" CACHE INTERNAL "")


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Symptom:
```
[410/15847] Building CXX object contrib/llvm-project/llvm/lib/Support/CMakeFiles/LLVMSupport.dir/Caching.cpp.o
FAILED: [code=1] contrib/llvm-project/llvm/lib/Support/CMakeFiles/LLVMSupport.dir/Caching.cpp.o 
/usr/bin/ccache /usr/bin/clang++ --target=x86_64-linux-gnu --sysroot=/home/al13n/ClickHouse/cmake/linux/../../contrib/sysroot/linux-x86_64/x86_64-linux-gnu/libc -DEXPERIMENTAL_KEY_INSTRUCTIONS -DSTD_EXCEPTION_HAS_STACK_TRACE=1 -D_DEBUG -D_GLIBCXX_ASSERTIONS -D_GNU_SOURCE -D_LARGEFILE64_SOURCE -D_LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS -D_LIBUNWIND_IS_NATIVE_ONLY -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I/home/al13n/ClickHouse/build/contrib/llvm-project/llvm/lib/Support -I/home/al13n/ClickHouse/contrib/llvm-project/llvm/lib/Support -I/home/al13n/ClickHouse/build/contrib/llvm-project/llvm/include -I/home/al13n/ClickHouse/contrib/llvm-project/llvm/include -I/home/al13n/ClickHouse/build/contrib/llvm-project/libcxx/include/c++/v1 -I/home/al13n/ClickHouse/contrib/llvm-project/libc -I/home/al13n/ClickHouse/base/glibc-compatibility/memcpy -isystem /home/al13n/ClickHouse/contrib/llvm-project/llvm/../third-party/siphash/include -isystem /home/al13n/ClickHouse/contrib/llvm-project/libcxx/include -isystem /home/al13n/ClickHouse/contrib/llvm-project/libcxxabi/include -isystem /home/al13n/ClickHouse/contrib/llvm-project/libunwind/include --gcc-toolchain=/home/al13n/ClickHouse/cmake/linux/../../contrib/sysroot/linux-x86_64 -fdiagnostics-color=always -Xclang -fuse-ctor-homing -fsized-deallocation  -gdwarf-aranges -pipe -mssse3 -msse4.1 -msse4.2 -mpclmul -mpopcnt -fasynchronous-unwind-tables -falign-functions=64 -mbranches-within-32B-boundaries -ffp-contract=off  -fdiagnostics-absolute-paths -fstrict-vtable-pointers -fPIC -w -ffunction-sections -fdata-sections -fvisibility-inlines-hidden -Werror=date-time -Werror=unguarded-availability-new -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -pedantic -Wno-long-long -Wc++98-compat-extra-semi -Wimplicit-fallthrough -Wcovered-switch-default -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wsuggest-override -Wstring-conversion -Wmisleading-indentation -Wctad-maybe-unsupported -fdiagnostics-color  -g -Og -g  -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE -std=c++23   -D OS_LINUX -Werror -Wno-deprecated-declarations -Wno-poison-system-directories -nostdinc++ -MD -MT contrib/llvm-project/llvm/lib/Support/CMakeFiles/LLVMSupport.dir/Caching.cpp.o -MF contrib/llvm-project/llvm/lib/Support/CMakeFiles/LLVMSupport.dir/Caching.cpp.o.d -o contrib/llvm-project/llvm/lib/Support/CMakeFiles/LLVMSupport.dir/Caching.cpp.o -c /home/al13n/ClickHouse/contrib/llvm-project/llvm/lib/Support/Caching.cpp
In file included from /home/al13n/ClickHouse/contrib/llvm-project/llvm/lib/Support/Caching.cpp:15:
In file included from /home/al13n/ClickHouse/contrib/llvm-project/llvm/include/llvm/Support/Caching.h:19:
In file included from /home/al13n/ClickHouse/contrib/llvm-project/llvm/include/llvm/Support/Error.h:17:
In file included from /home/al13n/ClickHouse/contrib/llvm-project/llvm/include/llvm/ADT/Twine.h:12:
In file included from /home/al13n/ClickHouse/contrib/llvm-project/llvm/include/llvm/ADT/SmallVector.h:19:
In file included from /home/al13n/ClickHouse/contrib/llvm-project/libcxx/include/algorithm:1865:
In file included from /home/al13n/ClickHouse/contrib/llvm-project/libcxx/include/__algorithm/inplace_merge.h:27:
/home/al13n/ClickHouse/contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:75:19: error: invalid application of 'sizeof' to an incomplete type 'llvm::MemoryBuffer'
   75 |     static_assert(sizeof(_Tp) >= 0, "cannot delete an incomplete type");
      |                   ^~~~~~~~~~~
/home/al13n/ClickHouse/contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:290:7: note: in instantiation of member function 'std::default_delete<llvm::MemoryBuffer>::operator()' requested here
  290 |       __deleter_(__tmp);
      |       ^
/home/al13n/ClickHouse/contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:259:71: note: in instantiation of member function 'std::unique_ptr<llvm::MemoryBuffer>::reset' requested here
  259 |   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 ~unique_ptr() { reset(); }
      |                                                                       ^
/home/al13n/ClickHouse/contrib/llvm-project/llvm/include/llvm/Support/Caching.h:121:62: note: in instantiation of member function 'std::unique_ptr<llvm::MemoryBuffer>::~unique_ptr' requested here
  121 |                                std::unique_ptr<MemoryBuffer> MB) {});
      |                                                              ^
/home/al13n/ClickHouse/contrib/llvm-project/llvm/include/llvm/Support/Caching.h:23:7: note: forward declaration of 'llvm::MemoryBuffer'
   23 | class MemoryBuffer;
      |       ^
1 error generated.
```

---

TIL a lot about cmake.

Our root CMakeLists.txt does:
```
set (CMAKE_CXX_STANDARD 23)
```
Then `contrib/llvm-project/llvm/CMakeLists.txt` does:
```
set(CMAKE_CXX_STANDARD ${LLVM_REQUIRED_CXX_STANDARD} CACHE STRING "C++ standard to conform to")
```
, where `LLVM_REQUIRED_CXX_STANDARD` = 17.

For arcane cmake reasons, this usually, but not always, changed the effective value of variable `CMAKE_CXX_STANDARD` from 23 to 17. So llvm-project was usually compiled as C++17, but under some rare unidentified conditions it could switch to C++23. I didn't figure out the exact conditions and what goes wrong. This PR sets an arcane cmake option to make this consistently leave the effective value *unchanged*, so that llvm-project consistently uses C++ standard of our choice. Then this PR also changes this choice (for llvm-project only) from C++23 to C++17 because llvm-project fails to compile with C++23.

---

More details: `set (CMAKE_CXX_STANDARD 23)` assigns a *normal* variable. `set(CMAKE_CXX_STANDARD 17 CACHE STRING "")` assigns *cache* variable with the same name. Usually the latter doesn't change the normal variable, if it exists. But cmake <3.21 had more complex behavior for compatibility: if the cache variable didn't exist, the cache variable assignment removes the normal variable, so the effective value changes to the cache variable's value: https://cmake.org/cmake/help/latest/policy/CMP0126.html

---

llvm-project's cmake files are sprawling and seem careless about hygiene (there are lots of cache variable assignments, not just the one above). Maybe we should try to make our own cmake files for llvm-project, like we normally do for submodules? But I imagine it's difficult.

Btw, I checked what other cmake files from submodules we use, and they're all fine, they all have tiny trivial CMakeLists.txt that don't use any global state. List: bech32, cityhash102, consistent-hashing, libfarmhash, libmetrohash, murmurhash.

Btw, I learned how to debug this type of thing: do `cmake --trace-expand [...] 2>trace`, then look at `trace`.