### PR TITLE
Support `send_profile_events` settings to reduce network flow

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -2059,6 +2059,17 @@ Max number of HTTP GET redirects hops allowed. Ensures additional security measu
 Use client timezone for interpreting DateTime string values, instead of adopting server timezone.
 )", 0) \
     \
+    DECLARE(Bool, send_profile_events, true, R"(
+Enables or disables sending of [ProfileEvents](/native-protocol/server.md#profile-events) packets to the client.
+
+This can be disabled to reduce network traffic for clients that do not require profile events.
+
+Possible values:
+
+- 0 — Disabled.
+- 1 — Enabled.
+)", 0) \
+    \
     DECLARE(Bool, send_progress_in_http_headers, false, R"(
 Enables or disables `X-ClickHouse-Progress` HTTP response headers in `clickhouse-server` responses.
 

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -41,6 +41,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
         /// Note: please check if the key already exists to prevent duplicate entries.
         addSettingsChanges(settings_changes_history, "25.11",
         {
+            {"send_profile_events", false, true, "New setting. Whether to send profile events to the clients."},
             {"into_outfile_create_parent_directories", false, false, "New setting"},
             {"correlated_subqueries_default_join_kind", "left", "right", "New setting. Default join kind for decorrelated query plan."},
             {"use_statistics_cache", 0, 0, "New setting"},

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -41,7 +41,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
         /// Note: please check if the key already exists to prevent duplicate entries.
         addSettingsChanges(settings_changes_history, "25.11",
         {
-            {"send_profile_events", false, true, "New setting. Whether to send profile events to the clients."},
+            {"send_profile_events", true, true, "New setting. Whether to send profile events to the clients."},
             {"into_outfile_create_parent_directories", false, false, "New setting"},
             {"correlated_subqueries_default_join_kind", "left", "right", "New setting. Default join kind for decorrelated query plan."},
             {"use_statistics_cache", 0, 0, "New setting"},

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -115,6 +115,7 @@ namespace Setting
     extern const SettingsUInt64 poll_interval;
     extern const SettingsSeconds receive_timeout;
     extern const SettingsLogsLevel send_logs_level;
+    extern const SettingsBool send_profile_events;
     extern const SettingsString send_logs_source_regexp;
     extern const SettingsSeconds send_timeout;
     extern const SettingsTimezone session_timezone;
@@ -584,7 +585,8 @@ void TCPHandler::runImpl()
                 CurrentThread::attachInternalTextLogsQueue(query_state->logs_queue, client_logs_level);
             }
 
-            if (client_tcp_protocol_version >= DBMS_MIN_PROTOCOL_VERSION_WITH_INCREMENTAL_PROFILE_EVENTS)
+            const auto send_profile_events = query_state->query_context->getSettingsRef()[Setting::send_profile_events];
+            if (client_tcp_protocol_version >= DBMS_MIN_PROTOCOL_VERSION_WITH_INCREMENTAL_PROFILE_EVENTS && send_profile_events)
             {
                 query_state->profile_queue = std::make_shared<InternalProfileEventsQueue>(std::numeric_limits<int>::max());
                 CurrentThread::attachInternalProfileEventsQueue(query_state->profile_queue);
@@ -1588,6 +1590,9 @@ void TCPHandler::sendExtremes(QueryState & state, const Block & extremes)
 
 void TCPHandler::sendProfileEvents(QueryState & state)
 {
+    if (!state.query_context->getSettingsRef()[Setting::send_profile_events])
+        return;
+
     Stopwatch stopwatch;
     Block block = ProfileEvents::getProfileEvents(host_name, state.profile_queue, state.last_sent_snapshots);
     if (block.rows() != 0)

--- a/tests/queries/0_stateless/03418_send_profile_events_setting.reference
+++ b/tests/queries/0_stateless/03418_send_profile_events_setting.reference
@@ -1,0 +1,3 @@
+default OK
+enabled OK
+disabled OK

--- a/tests/queries/0_stateless/03418_send_profile_events_setting.sh
+++ b/tests/queries/0_stateless/03418_send_profile_events_setting.sh
@@ -9,10 +9,10 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../shell_config.sh
 
 # default should send profile events without any explicit setting.
-${CLICKHOUSE_CLIENT} -q 'SELECT 1' --print-profile-events 2>&1 | grep -q "MemoryTrackerUsage:" && echo "default OK" 
+${CLICKHOUSE_CLIENT} -q 'SELECT 1' --print-profile-events 2>&1 | grep -q "Query" && echo "default OK" 
 # enabled with explicit setting.
-${CLICKHOUSE_CLIENT} -q 'SELECT 1 SETTINGS send_profile_events=1' --print-profile-events 2>&1 | grep -q "MemoryTrackerUsage:" && echo "enabled OK" 
+${CLICKHOUSE_CLIENT} -q 'SELECT 1 SETTINGS send_profile_events=1' --print-profile-events 2>&1 | grep -q "Query" && echo "enabled OK" 
 
 # disabled with explicit setting.
-${CLICKHOUSE_CLIENT} -q 'SELECT 1 SETTINGS send_profile_events=0' --print-profile-events 2>&1 | grep -v "MemoryTrackerUsage:" | grep -q "1" && echo "disabled OK" 
+${CLICKHOUSE_CLIENT} -q 'SELECT 1 SETTINGS send_profile_events=0' --print-profile-events 2>&1 | grep -v "Query" | grep -q "1" && echo "disabled OK" 
 

--- a/tests/queries/0_stateless/03418_send_profile_events_setting.sh
+++ b/tests/queries/0_stateless/03418_send_profile_events_setting.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# default should send profile events without any explicit setting
+${CLICKHOUSE_CLIENT} -q 'SELECT 1' --print-profile-events 2>&1 | grep -q "MemoryTrackerUsage:" && echo "default OK" 
+# enabled with explicit setting
+${CLICKHOUSE_CLIENT} -q 'SELECT 1 SETTINGS send_profile_events=1' --print-profile-events 2>&1 | grep -q "MemoryTrackerUsage:" && echo "enabled OK" 
+
+# disabled with explicit setting
+${CLICKHOUSE_CLIENT} -q 'SELECT 1 SETTINGS send_profile_events=0' --print-profile-events 2>&1 | grep -v "MemoryTrackerUsage:" | grep -q "1" && echo "disabled OK" 
+

--- a/tests/queries/0_stateless/03418_send_profile_events_setting.sh
+++ b/tests/queries/0_stateless/03418_send_profile_events_setting.sh
@@ -9,10 +9,10 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../shell_config.sh
 
 # default should send profile events without any explicit setting.
-${CLICKHOUSE_CLIENT} -q 'SELECT 1' --print-profile-events 2>&1 | grep -q "Query" && echo "default OK" 
+${CLICKHOUSE_CLIENT} -q 'SELECT 1' --profile-events-delay-ms=-1 --print-profile-events 2>&1 | grep -q "Query" && echo "default OK" 
 # enabled with explicit setting.
-${CLICKHOUSE_CLIENT} -q 'SELECT 1 SETTINGS send_profile_events=1' --print-profile-events 2>&1 | grep -q "Query" && echo "enabled OK" 
+${CLICKHOUSE_CLIENT} -q 'SELECT 1 SETTINGS send_profile_events=1' --profile-events-delay-ms=-1 --print-profile-events 2>&1 | grep -q "Query" && echo "enabled OK" 
 
 # disabled with explicit setting.
-${CLICKHOUSE_CLIENT} -q 'SELECT 1 SETTINGS send_profile_events=0' --print-profile-events 2>&1 | grep -v "Query" | grep -q "1" && echo "disabled OK" 
+${CLICKHOUSE_CLIENT} -q 'SELECT 1 SETTINGS send_profile_events=0' --profile-events-delay-ms=-1 --print-profile-events 2>&1 | grep -v "Query" | grep -q "1" && echo "disabled OK" 
 

--- a/tests/queries/0_stateless/03418_send_profile_events_setting.sh
+++ b/tests/queries/0_stateless/03418_send_profile_events_setting.sh
@@ -6,11 +6,11 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
-# default should send profile events without any explicit setting
+# default should send profile events without any explicit setting.
 ${CLICKHOUSE_CLIENT} -q 'SELECT 1' --print-profile-events 2>&1 | grep -q "MemoryTrackerUsage:" && echo "default OK" 
-# enabled with explicit setting
+# enabled with explicit setting.
 ${CLICKHOUSE_CLIENT} -q 'SELECT 1 SETTINGS send_profile_events=1' --print-profile-events 2>&1 | grep -q "MemoryTrackerUsage:" && echo "enabled OK" 
 
-# disabled with explicit setting
+# disabled with explicit setting.
 ${CLICKHOUSE_CLIENT} -q 'SELECT 1 SETTINGS send_profile_events=0' --print-profile-events 2>&1 | grep -v "MemoryTrackerUsage:" | grep -q "1" && echo "disabled OK" 
 

--- a/tests/queries/0_stateless/03418_send_profile_events_setting.sh
+++ b/tests/queries/0_stateless/03418_send_profile_events_setting.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Tags: no-random-settings
+
 set -euo pipefail
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- New Feature

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Added `send_profile_events` setting which allows clients to reduce network traffic when profile events are unused.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

### Details

Built on top of https://github.com/ClickHouse/ClickHouse/pull/80761 preserving original author's (@SpencerTorres) commits.

(NOTE: I was unable edit the original PR because I don't have permission on author's fork and not a maintainer to edit the PR as is. Hence the new PR)

For users who are doing many small async inserts over Native, it's possible that more data will be received from the server than sent by the client. The ProfileEvents packet was identified to be a large portion of this. To help reduce traffic, I have added a boolean setting called `send_profile_events` that defaults to 1. Clients can choose to disable profile events to reduce traffic. In the Go client for example, this data isn't used. It's parsed and immediately ignored. This can be applied per-query.

#### With profile events enabled

```
$ clickhouse-client --query "SELECT 1 SETTINGS send_profile_events=1" --print-profile-events 2>&1 | head -n 10
1
[clickbox] 2025.11.05 17:29:58 [ 0 ] Query: 1 (increment)
[clickbox] 2025.11.05 17:29:58 [ 0 ] SelectQuery: 1 (increment)
[clickbox] 2025.11.05 17:29:58 [ 0 ] InitialQuery: 1 (increment)
[clickbox] 2025.11.05 17:29:58 [ 0 ] QueriesWithSubqueries: 1 (increment)
[clickbox] 2025.11.05 17:29:58 [ 0 ] SelectQueriesWithSubqueries: 1 (increment)
[clickbox] 2025.11.05 17:29:58 [ 0 ] NetworkSendElapsedMicroseconds: 87 (increment)
[clickbox] 2025.11.05 17:29:58 [ 0 ] NetworkSendBytes: 67 (increment)
[clickbox] 2025.11.05 17:29:58 [ 0 ] GlobalThreadPoolJobs: 1 (increment)
[clickbox] 2025.11.05 17:29:58 [ 0 ] QueryPlanOptimizeMicroseconds: 34 (increment)
```

#### With profile events disabled

```
$ clickhouse-client --query "SELECT 1 SETTINGS send_profile_events=0" --print-profile-events 2>&1 | head -n 10
1
```
