### PR TITLE
ACME: halt if list of served domains is empty

### DIFF
--- a/src/Server/ACME/Client.cpp
+++ b/src/Server/ACME/Client.cpp
@@ -39,18 +39,18 @@
 #include <fmt/core.h>
 #include <fmt/ranges.h>
 
-#include <filesystem>
 #include <memory>
 #include <mutex>
 
 
+namespace DB
+{
+
 namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
+    extern const int NO_ELEMENTS_IN_CONFIG;
 }
-
-namespace DB
-{
 
 namespace ACME
 {
@@ -91,7 +91,7 @@ std::optional<VersionedCertificate> Client::requestCertificate() const
     std::string certificate;
 
     if (domains.empty())
-        LOG_FATAL(log, "List of domains handled by ACME client is empty, please check configuration.");
+        throw Exception(ErrorCodes::NO_ELEMENTS_IN_CONFIG, "List of domains handled by ACME client is empty, please check configuration.");
 
     /// All domains have the same certificate
     std::string domain = domains.front();
@@ -148,7 +148,7 @@ void Client::initialize(const Poco::Util::AbstractConfiguration & config)
         served_domains.push_back(config.getString("acme.domains." + key));
 
     if (served_domains.empty())
-        LOG_FATAL(log, "List of domains handled by ACME client is empty, please check configuration.");
+        throw Exception(ErrorCodes::NO_ELEMENTS_IN_CONFIG, "List of domains handled by ACME client is empty, please check configuration.");
 
     domains = served_domains;
     refresh_certificates_task_interval = config.getInt("acme.refresh_certificates_task_interval", /* one hour */ 1000 * 60 * 60);

--- a/src/Server/ACME/Client.cpp
+++ b/src/Server/ACME/Client.cpp
@@ -144,7 +144,8 @@ void Client::initialize(const Poco::Util::AbstractConfiguration & config)
     for (const auto & key : domains_keys)
         served_domains.push_back(config.getString("acme.domains." + key));
 
-    chassert(!served_domains.empty());
+    if (served_domains.empty())
+        LOG_FATAL(log, "List of domains handled by ACME client is empty, please check configuration.");
 
     domains = served_domains;
     refresh_certificates_task_interval = config.getInt("acme.refresh_certificates_task_interval", /* one hour */ 1000 * 60 * 60);

--- a/src/Server/ACME/Client.cpp
+++ b/src/Server/ACME/Client.cpp
@@ -90,6 +90,9 @@ std::optional<VersionedCertificate> Client::requestCertificate() const
     std::string pkey;
     std::string certificate;
 
+    if (domains.empty())
+        LOG_FATAL(log, "List of domains handled by ACME client is empty, please check configuration.");
+
     /// All domains have the same certificate
     std::string domain = domains.front();
 


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Halt if ACME client is enabled, but list of served domains is empty
