### PR TITLE
Log RuntimeFilter statistics at the end of query

### DIFF
--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -82,6 +82,7 @@
 #include <Processors/Sources/WaitForAsyncInsertSource.h>
 #include <Processors/QueryPlan/BuildQueryPipelineSettings.h>
 #include <Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.h>
+#include <Processors/QueryPlan/RuntimeFilterLookup.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
 
 #include <Poco/Net/SocketAddress.h>
@@ -715,6 +716,8 @@ void logQueryFinishImpl(
                 rows_per_second,
                 ReadableSize(elem.read_bytes / elapsed_seconds));
         }
+
+        context->getRuntimeFilterLookup()->logStats();
 
         elem.query_result_cache_usage = query_result_cache_usage;
 

--- a/src/Processors/QueryPlan/Optimizations/joinRuntimeFilter.cpp
+++ b/src/Processors/QueryPlan/Optimizations/joinRuntimeFilter.cpp
@@ -157,6 +157,9 @@ bool tryAddJoinRuntimeFilter(QueryPlan::Node & node, QueryPlan::Nodes & nodes, c
                 common_type = join_key_build_side.type;
             }
 
+            LOG_TRACE(getLogger("joinRuntimeFilter"), "Runtime filter '{}' will be built from `{}` and applied to `{}`",
+                filter_name, join_key_build_side.name, join_key_probe_side.name);
+
             /// Add filter lookup to the probe subtree
             all_filter_conditions.push_back(&createRuntimeFilterCondition(filter_dag, filter_name, join_key_probe_side, common_type));
 


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

### Details

This PR logs RuntimeFilter statistics at the end of query execution.
