### PR TITLE
Docs: update hasAnyAllTokens.cpp version to account for naming

### DIFF
--- a/src/Functions/hasAnyAllTokens.cpp
+++ b/src/Functions/hasAnyAllTokens.cpp
@@ -549,7 +549,7 @@ SELECT count() FROM log WHERE hasAnyTokens(mapValues(attributes), ['192.0.0.1', 
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in_hasAnyTokens = {25, 7};
+    FunctionDocumentation::IntroducedIn introduced_in_hasAnyTokens = {25, 10};
     FunctionDocumentation::Category category_hasAnyTokens = FunctionDocumentation::Category::StringSearch;
     FunctionDocumentation documentation_hasAnyTokens = {description_hasAnyTokens, syntax_hasAnyTokens, arguments_hasAnyTokens, returned_value_hasAnyTokens, examples_hasAnyTokens, introduced_in_hasAnyTokens, category_hasAnyTokens};
 
@@ -683,7 +683,7 @@ SELECT count() FROM log WHERE hasAllTokens(mapValues(attributes), ['192.0.0.1', 
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in_hasAllTokens = {25, 7};
+    FunctionDocumentation::IntroducedIn introduced_in_hasAllTokens = {25, 10};
     FunctionDocumentation::Category category_hasAllTokens = FunctionDocumentation::Category::StringSearch;
     FunctionDocumentation documentation_hasAllTokens = {description_hasAllTokens, syntax_hasAllTokens, arguments_hasAllTokens, returned_value_hasAllTokens, examples_hasAllTokens, introduced_in_hasAllTokens, category_hasAllTokens};
 


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
https://github.com/ClickHouse/ClickHouse/pull/88109 renamed searchAny/All --> hasAny/AllTokens. User in slack reported being confused because hasAnyTokens, hasAllTokens doesn't work from 25,7 as specified. (searchAny, searchAll do).
Version should be updated here.
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
