### PR TITLE
fs cache: change default of keep_free_space_remove_batch

### DIFF
--- a/src/Interpreters/Cache/FileCache_fwd.h
+++ b/src/Interpreters/Cache/FileCache_fwd.h
@@ -15,7 +15,7 @@ static constexpr int FILECACHE_DEFAULT_MAX_ELEMENTS = 10000000;
 static constexpr size_t FILECACHE_BYPASS_THRESHOLD = 256 * 1024 * 1024;
 static constexpr double FILECACHE_DEFAULT_FREE_SPACE_SIZE_RATIO = 0; /// Disabled.
 static constexpr double FILECACHE_DEFAULT_FREE_SPACE_ELEMENTS_RATIO = 0; /// Disabled.
-static constexpr int FILECACHE_DEFAULT_FREE_SPACE_REMOVE_BATCH = 10;
+static constexpr int FILECACHE_DEFAULT_FREE_SPACE_REMOVE_BATCH = 100;
 static constexpr auto FILECACHE_DEFAULT_CONFIG_PATH = "filesystem_caches";
 
 static constexpr auto FILECACHE_DEFAULT_CACHE_POLICY = FileCachePolicy::SLRU;

--- a/tests/queries/0_stateless/02344_describe_cache.reference
+++ b/tests/queries/0_stateless/02344_describe_cache.reference
@@ -1,2 +1,2 @@
 1
-02344_describe_cache_test	/var/lib/clickhouse/filesystem_caches/02344_describe_cache_test	102400	10000000	33554432	4194304	0	slru	0.6	5	5000	4194304	16	0	0	0	10	0	0	0	268435456	0	0	0	1	0	0
+02344_describe_cache_test	/var/lib/clickhouse/filesystem_caches/02344_describe_cache_test	102400	10000000	33554432	4194304	0	slru	0.6	5	5000	4194304	16	0	0	0	100	0	0	0	268435456	0	0	0	1	0	0


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Changed default of filesystem cache setting `keep_free_space_remove_batch` from 10 to 100, because it is more optimal.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)
