### PR TITLE
Fix flaky `03175_sparse_and_skip_index`

### DIFF
--- a/tests/queries/0_stateless/03175_sparse_and_skip_index.reference
+++ b/tests/queries/0_stateless/03175_sparse_and_skip_index.reference
@@ -1,4 +1,4 @@
 key	Sparse
 value	Sparse
-1000
+300
 1

--- a/tests/queries/0_stateless/03175_sparse_and_skip_index.sql
+++ b/tests/queries/0_stateless/03175_sparse_and_skip_index.sql
@@ -23,14 +23,14 @@ INSERT INTO t_bloom_filter
 SELECT
     number % 100 as key, -- 100 unique keys
     rand() % 100 as value -- 100 unique values
-FROM numbers(50_000);
+FROM numbers(15_000);
 
 -- And another part
 INSERT INTO t_bloom_filter
 SELECT
     number % 100 as key, -- 100 unique keys
     rand() % 100 as value -- 100 unique values
-FROM numbers(50_000, 50_000);
+FROM numbers(15_000, 15_000);
 
 SYSTEM START MERGES t_bloom_filter;
 


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Details

With MSAN builds and index granularity set to 1 by the settings randomizer, the test might time out, because the super low index granularity increase the test's runtime more than 40x.

Fixes #41684.
