### PR TITLE
CI: Fix status inversion for bugfix validation in functional tests

### DIFF
--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -237,7 +237,11 @@ def main():
         if not info.is_local_run or not (Path(temp_dir) / "clickhouse").is_file():
             link_arch = "aarch64" if Utils.is_arm() else "amd64"
             link_to_master_head_binary = f"https://clickhouse-builds.s3.us-east-1.amazonaws.com/master/{link_arch}/clickhouse"
-            Shell.run(f"wget -nv -P {temp_dir} {link_to_master_head_binary}", verbose=True, strict=True)
+            Shell.run(
+                f"wget -nv -P {temp_dir} {link_to_master_head_binary}",
+                verbose=True,
+                strict=True,
+            )
     elif args.path:
         assert Path(args.path).is_dir(), f"Path [{args.path}] is not a directory"
         ch_path = str(Path(args.path).absolute())
@@ -265,7 +269,9 @@ def main():
         stages.remove(JobStages.COLLECT_COVERAGE)
     else:
         stages.remove(JobStages.COLLECT_LOGS)
-    if not is_bugfix_validation and not info.is_local_run:
+    if is_coverage or is_bugfix_validation or info.is_local_run:
+        # not needed for these job flavors
+        # moreover it updates/rewrites inverted Tests status for bugfix validation check which should stay inverted
         stages.remove(JobStages.CHECK_ERRORS)
     if info.is_local_run:
         if JobStages.COLLECT_LOGS in stages:
@@ -422,9 +428,9 @@ def main():
         if not info.is_local_run:
             CH.stop_log_exports()
         ft_res_processor = FTResultsProcessor(wd=temp_dir)
-        results.append(ft_res_processor.run())
+        test_result = ft_res_processor.run()
         debug_files += ft_res_processor.debug_files
-        test_result = results[-1]
+        results.append(test_result)
 
         # invert result status for bugfix validation
         if is_bugfix_validation:


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Details

Inverted status for Tests job stage got wrongly rewritten in "Check errors" job stage.
