### PR TITLE
Fix a segfault when the `system.dead_letter_queue` is not configured

### DIFF
--- a/src/Storages/Kafka/KafkaSettings.h
+++ b/src/Storages/Kafka/KafkaSettings.h
@@ -6,6 +6,8 @@
 #include <Common/NamedCollections/NamedCollections_fwd.h>
 #include <Common/SettingsChanges.h>
 
+#include <Interpreters/Context_fwd.h>
+
 namespace DB
 {
 class ASTStorage;
@@ -65,7 +67,7 @@ struct KafkaSettings
 
     SettingsChanges getFormatSettings() const;
 
-    void sanityCheck() const;
+    void sanityCheck(ContextPtr global_context) const;
 
     static bool hasBuiltin(std::string_view name);
 

--- a/src/Storages/Kafka/KafkaSource.cpp
+++ b/src/Storages/Kafka/KafkaSource.cpp
@@ -258,20 +258,20 @@ Chunk KafkaSource::generateImpl()
                 auto dead_letter_queue = context->getDeadLetterQueue();
                 if (!dead_letter_queue)
                     LOG_WARNING(log, "Table system.dead_letter_queue is not configured, skipping message");
-
-                dead_letter_queue->add(DeadLetterQueueElement{
-                        .table_engine = DeadLetterQueueElement::StreamType::Kafka,
-                        .event_time = timeInSeconds(time_now),
-                        .event_time_microseconds = timeInMicroseconds(time_now),
-                        .database = storage_id.database_name,
-                        .table = storage_id.table_name,
-                        .raw_message = consumer->currentPayload(),
-                        .error = exception_message.value(),
-                        .details = DeadLetterQueueElement::KafkaDetails{
-                            .topic_name = consumer->currentTopic(),
-                            .partition = consumer->currentPartition(),
-                            .offset = consumer->currentPartition(),
-                            .key = consumer->currentKey()}});
+                else
+                    dead_letter_queue->add(DeadLetterQueueElement{
+                            .table_engine = DeadLetterQueueElement::StreamType::Kafka,
+                            .event_time = timeInSeconds(time_now),
+                            .event_time_microseconds = timeInMicroseconds(time_now),
+                            .database = storage_id.database_name,
+                            .table = storage_id.table_name,
+                            .raw_message = consumer->currentPayload(),
+                            .error = exception_message.value(),
+                            .details = DeadLetterQueueElement::KafkaDetails{
+                                .topic_name = consumer->currentTopic(),
+                                .partition = consumer->currentPartition(),
+                                .offset = consumer->currentPartition(),
+                                .key = consumer->currentKey()}});
             }
 
             total_rows = total_rows + new_rows;

--- a/src/Storages/Kafka/KafkaSource.cpp
+++ b/src/Storages/Kafka/KafkaSource.cpp
@@ -256,6 +256,9 @@ Chunk KafkaSource::generateImpl()
                 auto storage_id = storage.getStorageID();
 
                 auto dead_letter_queue = context->getDeadLetterQueue();
+                if (!dead_letter_queue)
+                    LOG_WARNING(log, "Table system.dead_letter_queue is not configured, skipping message");
+
                 dead_letter_queue->add(DeadLetterQueueElement{
                         .table_engine = DeadLetterQueueElement::StreamType::Kafka,
                         .event_time = timeInSeconds(time_now),

--- a/src/Storages/Kafka/StorageKafka.cpp
+++ b/src/Storages/Kafka/StorageKafka.cpp
@@ -190,7 +190,7 @@ StorageKafka::StorageKafka(
     , thread_per_consumer((*kafka_settings)[KafkaSetting::kafka_thread_per_consumer].value)
     , collection_name(collection_name_)
 {
-    kafka_settings->sanityCheck();
+    kafka_settings->sanityCheck(getContext());
 
     if (auto mode = getStreamingHandleErrorMode();
         mode == StreamingHandleErrorMode::STREAM || mode == StreamingHandleErrorMode::DEAD_LETTER_QUEUE)

--- a/src/Storages/RabbitMQ/RabbitMQSource.cpp
+++ b/src/Storages/RabbitMQ/RabbitMQSource.cpp
@@ -288,25 +288,27 @@ Chunk RabbitMQSource::generateImpl()
                 auto storage_id = storage.getStorageID();
 
                 auto dead_letter_queue = context->getDeadLetterQueue();
-                dead_letter_queue->add(
-                    DeadLetterQueueElement{
-                        .table_engine = DeadLetterQueueElement::StreamType::RabbitMQ,
-                        .event_time = timeInSeconds(time_now),
-                        .event_time_microseconds = timeInMicroseconds(time_now),
-                        .database = storage_id.database_name,
-                        .table = storage_id.table_name,
-                        .raw_message = message.message,
-                        .error = exception_message.value(),
-                        .details = DeadLetterQueueElement::RabbitMQDetails{
-                            .exchange_name = exchange_name,
-                            .message_id = message.message_id,
-                            .timestamp = message.timestamp,
-                            .redelivered = message.redelivered,
-                            .delivery_tag = message.delivery_tag,
-                            .channel_id = message.channel_id
-                        }
-
-                    });
+                if (!dead_letter_queue)
+                    LOG_WARNING(log, "Table system.dead_letter_queue is not configured, skipping message");
+                else
+                    dead_letter_queue->add(
+                        DeadLetterQueueElement{
+                            .table_engine = DeadLetterQueueElement::StreamType::RabbitMQ,
+                            .event_time = timeInSeconds(time_now),
+                            .event_time_microseconds = timeInMicroseconds(time_now),
+                            .database = storage_id.database_name,
+                            .table = storage_id.table_name,
+                            .raw_message = message.message,
+                            .error = exception_message.value(),
+                            .details = DeadLetterQueueElement::RabbitMQDetails{
+                                .exchange_name = exchange_name,
+                                .message_id = message.message_id,
+                                .timestamp = message.timestamp,
+                                .redelivered = message.redelivered,
+                                .delivery_tag = message.delivery_tag,
+                                .channel_id = message.channel_id
+                            }
+                        });
             }
 
             total_rows += new_rows;

--- a/tests/integration/test_storage_kafka_sasl/test.py
+++ b/tests/integration/test_storage_kafka_sasl/test.py
@@ -109,7 +109,7 @@ def test_kafka_sasl_settings_precedence(kafka_cluster):
 # broken messages to a dead letter queue, while the table
 # system.dead_letter_queue is not configured.
 def test_dead_letter_segfault(kafka_cluster):
-    instance.query(
+    res = instance.query_and_get_error(
         f"""
         DROP DATABASE IF EXISTS segfault SYNC;
         CREATE DATABASE segfault;
@@ -125,21 +125,7 @@ def test_dead_letter_segfault(kafka_cluster):
                      kafka_group_name = 'group1',
                      kafka_format = 'JSONEachRow',
                      kafka_handle_error_mode = 'dead_letter_queue';
-
-        CREATE TABLE segfault.messages (key int, value String) ENGINE = MergeTree ORDER BY key;
-
-        CREATE MATERIALIZED VIEW segfault.kafka_consumer TO segfault.messages (key int, value String)
-        AS SELECT key, value FROM segfault.kafka_sasl;
         """
     )
 
-    producer = get_kafka_producer(kafka_cluster.kafka_sasl_port)
-    producer.send(topic="topic1", value='{"key":1, "value":"test123"}')
-    producer.send(topic="topic1", value='{"ping":"pong", "answer":42}')
-    producer.send(topic="topic1", value='1')
-    producer.send(topic="topic1", value='2')
-    producer.send(topic="topic1", value='3')
-
-    producer.flush()
-
-    instance.query("SELECT * FROM segfault.messages")
+    assert "The table system.dead_letter_queue is not configured on the server" in res


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

In case when Kafka table was created with a setting `kafka_handle_error_mode = 'dead_letter_queue'` and the table `system.dead_letter_queue` is not configured the server may have crashed. This behaviour is fixed. Resolves #87573.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)
