### PR TITLE
CI, libfuzzer bugfix

### DIFF
--- a/tests/ci/libfuzzer_test_check.py
+++ b/tests/ci/libfuzzer_test_check.py
@@ -149,8 +149,12 @@ def download_corpus(path):
     for zip_file in corpus_path.glob("*.zip"):
         target_dir = corpus_path / zip_file.stem
         target_dir.mkdir(exist_ok=True)
-        with zipfile.ZipFile(zip_file, "r") as zf:
-            zf.extractall(target_dir)
+        try:
+            with zipfile.ZipFile(zip_file, "r") as zf:
+                zf.extractall(target_dir)
+        except Exception:
+            logging.info("Failed to unzip %s", zip_file)
+            raise
         zip_file.unlink()
         units = len(list(target_dir.glob("*")))
         total_units += units

--- a/tests/ci/libfuzzer_test_check.py
+++ b/tests/ci/libfuzzer_test_check.py
@@ -173,11 +173,11 @@ def upload_corpus(path):
             zip_file_path = corpus_dir / f"{fuzzer_dir.name}.zip"
             with zipfile.ZipFile(zip_file_path, "w", zipfile.ZIP_DEFLATED) as zipf:
                 zipdir(fuzzer_dir, zipf)
-                s3.upload_file(
-                    bucket=S3_BUILDS_BUCKET,
-                    file_path=str(zip_file_path),
-                    s3_path=f"fuzzer/corpus/{zip_file_path.name}",
-                )
+            s3.upload_file(
+                bucket=S3_BUILDS_BUCKET,
+                file_path=str(zip_file_path),
+                s3_path=f"fuzzer/corpus/{zip_file_path.name}",
+            )
 
 
 # same as upload_corpus but without uploading - for testing purposes

--- a/tests/ci/libfuzzer_test_check.py
+++ b/tests/ci/libfuzzer_test_check.py
@@ -147,6 +147,7 @@ def download_corpus(path):
     total_units = 0
 
     for zip_file in corpus_path.glob("*.zip"):
+        logging.info("Deploying corpus %s", zip_file.stem)
         target_dir = corpus_path / zip_file.stem
         target_dir.mkdir(exist_ok=True)
         try:


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Details

It seems zip files produced by previous run can't be unzipped - investigating and fixing.
