### PR TITLE
Set compatibility setting to previous version in Upgrade check to avoid falures with known backward-incompatible changes

### DIFF
--- a/tests/docker_scripts/upgrade_runner.sh
+++ b/tests/docker_scripts/upgrade_runner.sh
@@ -89,6 +89,7 @@ function save_major_version()
 save_settings_clean 'old_settings.native'
 save_mergetree_settings_clean 'old_merge_tree_settings.native'
 save_major_version 'old_version.native'
+old_major_version=$(clickhouse-local -q "select a[1] || '.' || a[2] from (select splitByChar('.', version()) as a)")
 
 # Initial run without S3 to create system.*_log on local file system to make it
 # available for dump via clickhouse-local
@@ -265,6 +266,17 @@ fi
 # Just in case previous version left some garbage in zk
 sudo sed -i "s|>1<|>0<|g" /etc/clickhouse-server/config.d/lost_forever_check.xml \
 rm /etc/clickhouse-server/config.d/filesystem_caches_path.xml
+
+# Set compatibility setting to previous version, so we won't fail due to known backward incompatible changes.
+echo "<clickhouse>
+    <profiles>
+        <default>
+            <compatibility>$old_major_version</compatibility>
+        </default>
+    </profiles>
+</clickhouse>" > /etc/clickhouse-server/users.d/compatibility.xml
+
+cat /etc/clickhouse-server/users.d/compatibility.xml
 
 start_server 500 || (echo "Failed to start server" && exit 1)
 clickhouse-client --query "SELECT 'Server successfully started', 'OK', NULL, ''" >> /test_output/test_results.tsv \


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

### Details

Set compatibility setting to previous version in Upgrade check to avoid failures with known backward-incompatible changes.
