### PR TITLE
Support inserts into Merge storage

### DIFF
--- a/src/Interpreters/InsertDependenciesBuilder.h
+++ b/src/Interpreters/InsertDependenciesBuilder.h
@@ -131,6 +131,7 @@ protected:
 
 private:
     bool isView(StorageIDMaybeEmpty id) const;
+    bool isMerge(StorageIDMaybeEmpty id) const;
 
     std::pair<ContextPtr, ContextPtr> createSelectInsertContext(const DependencyPath & path);
     bool observePath(const DependencyPath & path);
@@ -143,8 +144,12 @@ private:
     Chain createSink(StorageIDMaybeEmpty view_id) const;
     Chain createPostSink(StorageIDMaybeEmpty view_id) const;
 
-
     Chain createRetry(const std::vector<StorageIDMaybeEmpty> & path, StorageIDMaybeEmpty start_from, const std::string & partition) const;
+    Chain createPreSink(StorageIDPrivate view_id) const;
+    Chain createSelect(StorageIDPrivate view_id) const;
+    Chain createMergeSink(StorageIDPrivate merge_id) const;
+    Chain createSink(StorageIDPrivate view_id) const;
+    Chain createPostSink(StorageIDPrivate view_id) const;
 
     static QueryViewsLogElement::ViewStatus getQueryViewStatus(std::exception_ptr exception, bool before_start);
 
@@ -164,6 +169,7 @@ private:
 
     MapIdManyId dependent_views;
     MapIdId inner_tables;
+    MapIdId merge_tables;
     MapIdId source_tables;
     MapIdStorage storages;
     MapIdViewType view_types;

--- a/src/Interpreters/InsertDependenciesBuilder.h
+++ b/src/Interpreters/InsertDependenciesBuilder.h
@@ -141,15 +141,11 @@ private:
 
     Chain createPreSink(StorageIDMaybeEmpty view_id) const;
     Chain createSelect(StorageIDMaybeEmpty view_id) const;
+    Chain createMergePreSink(StorageIDMaybeEmpty merge_id) const;
     Chain createSink(StorageIDMaybeEmpty view_id) const;
     Chain createPostSink(StorageIDMaybeEmpty view_id) const;
 
     Chain createRetry(const std::vector<StorageIDMaybeEmpty> & path, StorageIDMaybeEmpty start_from, const std::string & partition) const;
-    Chain createPreSink(StorageIDPrivate view_id) const;
-    Chain createSelect(StorageIDPrivate view_id) const;
-    Chain createMergeSink(StorageIDPrivate merge_id) const;
-    Chain createSink(StorageIDPrivate view_id) const;
-    Chain createPostSink(StorageIDPrivate view_id) const;
 
     static QueryViewsLogElement::ViewStatus getQueryViewStatus(std::exception_ptr exception, bool before_start);
 

--- a/src/Interpreters/InterpreterInsertQuery.cpp
+++ b/src/Interpreters/InterpreterInsertQuery.cpp
@@ -24,7 +24,6 @@
 #include <Interpreters/ClusterProxy/executeQuery.h>
 #include <Interpreters/Context.h>
 #include <Parsers/ASTConstraintDeclaration.h>
-#include <Parsers/ASTIdentifier.h>
 #include <Interpreters/InsertDependenciesBuilder.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTInsertQuery.h>
@@ -35,7 +34,6 @@
 #include <Processors/Transforms/CountingTransform.h>
 #include <Processors/Transforms/ExpressionTransform.h>
 #include <Processors/Transforms/DeduplicationTokenTransforms.h>
-#include <Processors/Transforms/MaterializingTransform.h>
 #include <Processors/Transforms/PlanSquashingTransform.h>
 #include <Processors/Transforms/ApplySquashingTransform.h>
 #include <Processors/Transforms/getSourceFromASTInsertQuery.h>

--- a/src/Storages/StorageMerge.cpp
+++ b/src/Storages/StorageMerge.cpp
@@ -1,8 +1,9 @@
 #include <functional>
 #include <iterator>
+
 #include <Access/ContextAccess.h>
-#include <Analyzer/ConstantNode.h>
 #include <Analyzer/ColumnNode.h>
+#include <Analyzer/ConstantNode.h>
 #include <Analyzer/FunctionNode.h>
 #include <Analyzer/IdentifierNode.h>
 #include <Analyzer/InDepthQueryTreeVisitor.h>
@@ -10,24 +11,26 @@
 #include <Analyzer/QueryTreeBuilder.h>
 #include <Analyzer/TableNode.h>
 #include <Analyzer/Utils.h>
-#include <Common/quoteString.h>
 #include <Columns/ColumnString.h>
+#include <Core/NamesAndTypes.h>
 #include <Core/Settings.h>
 #include <DataTypes/DataTypeLowCardinality.h>
 #include <DataTypes/DataTypeString.h>
-#include <DataTypes/getLeastSupertype.h>
 #include <DataTypes/IDataType.h>
+#include <DataTypes/getLeastSupertype.h>
+#include <Functions/FunctionFactory.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/ExpressionActions.h>
 #include <Interpreters/IdentifierSemantic.h>
+#include <Interpreters/InsertDependenciesBuilder.h>
 #include <Interpreters/InterpreterSelectQuery.h>
 #include <Interpreters/InterpreterSelectQueryAnalyzer.h>
 #include <Interpreters/TreeRewriter.h>
+#include <Interpreters/addMissingDefaults.h>
 #include <Interpreters/addTypeConversionToAST.h>
 #include <Interpreters/evaluateConstantExpression.h>
 #include <Interpreters/getHeaderForProcessingStage.h>
 #include <Interpreters/replaceAliasColumnsInQuery.h>
-#include <Interpreters/addMissingDefaults.h>
 #include <Parsers/ASTExpressionList.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier.h>
@@ -36,16 +39,15 @@
 #include <Planner/PlannerActionsVisitor.h>
 #include <Planner/Utils.h>
 #include <Processors/QueryPlan/BuildQueryPipelineSettings.h>
-#include <Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.h>
-#include <Processors/QueryPlan/FilterStep.h>
 #include <Processors/QueryPlan/ExpressionStep.h>
+#include <Processors/QueryPlan/FilterStep.h>
+#include <Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.h>
 #include <Processors/QueryPlan/QueryPlan.h>
 #include <Processors/QueryPlan/ReadFromMergeTree.h>
 #include <Processors/Sources/NullSource.h>
 #include <Processors/Transforms/FilterTransform.h>
 #include <Processors/Transforms/MaterializingTransform.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
-#include <QueryPipeline/narrowPipe.h>
 #include <Storages/AlterCommands.h>
 #include <Storages/ReadInOrderOptimizer.h>
 #include <Storages/SelectQueryInfo.h>
@@ -58,9 +60,8 @@
 #include <Common/Exception.h>
 #include <Common/assert_cast.h>
 #include <Common/checkStackSize.h>
+#include <Common/quoteString.h>
 #include <Common/typeid_cast.h>
-#include <Core/NamesAndTypes.h>
-#include <Functions/FunctionFactory.h>
 
 
 namespace DB
@@ -84,7 +85,9 @@ extern const int SAMPLING_NOT_SUPPORTED;
 extern const int ALTER_OF_COLUMN_IS_FORBIDDEN;
 extern const int CANNOT_EXTRACT_TABLE_STRUCTURE;
 extern const int STORAGE_REQUIRES_PARAMETER;
+extern const int TABLE_IS_READ_ONLY;
 extern const int UNKNOWN_DATABASE;
+extern const int UNKNOWN_TABLE;
 }
 
 namespace
@@ -141,10 +144,13 @@ StorageMerge::DatabaseNameOrRegexp::DatabaseNameOrRegexp(
 StorageMerge::StorageMerge(
     const StorageID & table_id_,
     const ColumnsDescription & columns_,
+    const ConstraintsDescription & constraints_,
     const String & comment,
     const String & source_database_name_or_regexp_,
     bool database_is_regexp_,
     const DBToTableSetMap & source_databases_and_tables_,
+    const std::optional<String> & table_to_write_,
+    bool table_to_write_auto_,
     ContextPtr context_)
     : IStorage(table_id_)
     , WithContext(context_->getGlobalContext())
@@ -158,18 +164,23 @@ StorageMerge::StorageMerge(
     storage_metadata.setColumns(columns_.empty()
         ? getColumnsDescriptionFromSourceTables(context_)
         : columns_);
+    storage_metadata.setConstraints(constraints_);
     storage_metadata.setComment(comment);
     setInMemoryMetadata(storage_metadata);
     setVirtuals(createVirtuals());
+    setTableToWrite(table_to_write_, table_to_write_auto_, source_database_name_or_regexp_, database_is_regexp_);
 }
 
 StorageMerge::StorageMerge(
     const StorageID & table_id_,
     const ColumnsDescription & columns_,
+    const ConstraintsDescription & constraints_,
     const String & comment,
     const String & source_database_name_or_regexp_,
     bool database_is_regexp_,
     const String & source_table_regexp_,
+    const std::optional<String> & table_to_write_,
+    bool table_to_write_auto_,
     ContextPtr context_)
     : IStorage(table_id_)
     , WithContext(context_->getGlobalContext())
@@ -183,9 +194,11 @@ StorageMerge::StorageMerge(
     storage_metadata.setColumns(columns_.empty()
         ? getColumnsDescriptionFromSourceTables(context_)
         : columns_);
+    storage_metadata.setConstraints(constraints_);
     storage_metadata.setComment(comment);
     setInMemoryMetadata(storage_metadata);
     setVirtuals(createVirtuals());
+    setTableToWrite(table_to_write_, table_to_write_auto_, source_database_name_or_regexp_, database_is_regexp_);
 }
 
 StorageMerge::DatabaseTablesIterators StorageMerge::getDatabaseIterators(ContextPtr context_) const
@@ -256,6 +269,34 @@ ColumnsDescription StorageMerge::getColumnsDescriptionFromSourceTablesImpl(
     });
 
     return res;
+}
+
+StorageID StorageMerge::getTableToWrite(ContextPtr query_context) const
+{
+    if (table_to_write)
+        return table_to_write.value();
+
+    if (table_to_write_auto)
+    {
+        const auto access = query_context->getAccess();
+        std::optional<StorageID> chosen_table;
+        traverseTablesUntil([&](const StoragePtr & table)
+        {
+            auto tableID = table->getStorageID();
+            if (!chosen_table || tableID.getFullTableName() > chosen_table->getFullTableName())
+                if (access->isGranted(AccessType::SHOW_TABLES, tableID.database_name, tableID.table_name))
+                    chosen_table = tableID;
+
+            return false;
+        });
+
+        if (chosen_table)
+            return *chosen_table;
+
+        throw Exception(ErrorCodes::UNKNOWN_TABLE, "Can't find any table to write for storage {}", getStorageID().getNameForLogs());
+    }
+
+    throw Exception(ErrorCodes::TABLE_IS_READ_ONLY, "Inserts are not configured for Merge table {}", getStorageID().getNameForLogs());
 }
 
 template <typename F>
@@ -1747,6 +1788,60 @@ std::optional<UInt64> StorageMerge::totalRowsOrBytes(F && func) const
     return first_table ? std::nullopt : std::make_optional(total_rows_or_bytes);
 }
 
+void StorageMerge::setTableToWrite(
+    const std::optional<String> & table_to_write_,
+    bool table_to_write_auto_,
+    const String & source_database_name_or_regexp_,
+    bool database_is_regexp_)
+{
+    if (table_to_write_auto_)
+    {
+        table_to_write_auto = true;
+        return;
+    }
+    if (!table_to_write_)
+        return;
+
+    auto qualified_name = QualifiedTableName::parseFromString(*table_to_write_);
+
+    if (qualified_name.database.empty())
+    {
+        if (database_is_regexp_)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Argument 'table_to_write' must contain database if 'db_name' is regular expression");
+
+        qualified_name.database = source_database_name_or_regexp_;
+    }
+
+    if (database_name_or_regexp.source_databases_and_tables)
+    {
+        auto tables = database_name_or_regexp.source_databases_and_tables->find(qualified_name.database);
+        if (tables == database_name_or_regexp.source_databases_and_tables->end())
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "table_to_write database is not matching regexp");
+        if (!tables->second.contains(qualified_name.table))
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "table_to_write table is not matching regexp");
+    }
+    else
+    {
+        if (database_name_or_regexp.database_is_regexp)
+        {
+            if  (!database_name_or_regexp.source_database_regexp->match(qualified_name.database))
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "table_to_write database is not matching regexp");
+        }
+        else
+        {
+            if  (database_name_or_regexp.source_database_name_or_regexp != qualified_name.database)
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "table_to_write database is not matching");
+        }
+
+        chassert(database_name_or_regexp.source_table_regexp.has_value());
+        if (!database_name_or_regexp.source_table_regexp->match(qualified_name.table))
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "table_to_write is not matching table regexp");
+    }
+
+    source_table_to_write = qualified_name;
+    table_to_write = StorageID(source_table_to_write->database, source_table_to_write->table);
+}
+
 void registerStorageMerge(StorageFactory & factory)
 {
     factory.registerStorage("Merge", [](const StorageFactory::Arguments & args)
@@ -1757,11 +1852,11 @@ void registerStorageMerge(StorageFactory & factory)
 
         ASTs & engine_args = args.engine_args;
 
-        if (engine_args.size() != 2)
+        size_t size = engine_args.size();
+        if (size < 2 || size > 3)
             throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH,
-                            "Storage Merge requires exactly 2 parameters - name "
-                            "of source database and regexp for table names.");
-
+                            "Storage Merge requires 2 or 3 parameters - name "
+                            "of source database, regexp for table names, and optional table name for writing");
         auto [is_regexp, database_ast] = StorageMerge::evaluateDatabaseName(engine_args[0], args.getLocalContext());
 
         if (!is_regexp)
@@ -1772,8 +1867,25 @@ void registerStorageMerge(StorageFactory & factory)
         engine_args[1] = evaluateConstantExpressionAsLiteral(engine_args[1], args.getLocalContext());
         String table_name_regexp = checkAndGetLiteralArgument<String>(engine_args[1], "table_name_regexp");
 
+        std::optional<String> table_to_write = std::nullopt;
+        bool table_to_write_auto = false;
+        if (size == 3)
+        {
+            if (auto *identifier = engine_args[2]->as<ASTIdentifier>(); identifier && identifier->full_name == "auto")
+            {
+                table_to_write = identifier->full_name;
+                table_to_write_auto = true;
+            }
+            else
+            {
+                engine_args[2] = evaluateConstantExpressionOrIdentifierAsLiteral(engine_args[2], args.getLocalContext());
+                table_to_write = checkAndGetLiteralArgument<String>(engine_args[2], "table_to_write");
+            }
+        }
+
         return std::make_shared<StorageMerge>(
-            args.table_id, args.columns, args.comment, source_database_name_or_regexp, is_regexp, table_name_regexp, args.getLocalContext());
+            args.table_id, args.columns, args.constraints, args.comment, source_database_name_or_regexp, is_regexp,
+            table_name_regexp, table_to_write, table_to_write_auto, args.getLocalContext());
     },
     {
         .supports_schema_inference = true

--- a/src/Storages/StorageMerge.h
+++ b/src/Storages/StorageMerge.h
@@ -26,19 +26,25 @@ public:
     StorageMerge(
         const StorageID & table_id_,
         const ColumnsDescription & columns_,
+        const ConstraintsDescription & constraints_,
         const String & comment,
         const String & source_database_name_or_regexp_,
         bool database_is_regexp_,
         const DBToTableSetMap & source_databases_and_tables_,
+        const std::optional<String> & table_to_write_,
+        bool table_to_write_auto_,
         ContextPtr context_);
 
     StorageMerge(
         const StorageID & table_id_,
         const ColumnsDescription & columns_,
+        const ConstraintsDescription & constraints_,
         const String & comment,
         const String & source_database_name_or_regexp_,
         bool database_is_regexp_,
         const String & source_table_regexp_,
+        const std::optional<String> & table_to_write_,
+        bool table_to_write_auto_,
         ContextPtr context_);
 
     std::string getName() const override { return "Merge"; }
@@ -94,6 +100,8 @@ public:
         const String & source_table_regexp,
         size_t max_tables_to_look);
 
+    StorageID getTableToWrite(ContextPtr query_context) const;
+
 private:
     /// (Database, Table, Lock, TableName)
     using StorageWithLockAndName = std::tuple<String, StoragePtr, TableLockHolder, String>;
@@ -121,6 +129,10 @@ private:
     };
 
     DatabaseNameOrRegexp database_name_or_regexp;
+
+    std::optional<QualifiedTableName> source_table_to_write;
+    std::optional<StorageID> table_to_write;
+    bool table_to_write_auto = false;
 
     template <typename F>
     StoragePtr traverseTablesUntil(F && predicate) const;
@@ -150,6 +162,12 @@ private:
 
     template <typename F>
     std::optional<UInt64> totalRowsOrBytes(F && func) const;
+
+    void setTableToWrite(
+        const std::optional<String> & table_to_write_,
+        bool table_to_write_auto,
+        const String & source_database_name_or_regexp_,
+        bool database_is_regexp_);
 
     friend class ReadFromMerge;
 };

--- a/src/Storages/StorageMerge.h
+++ b/src/Storages/StorageMerge.h
@@ -59,6 +59,9 @@ public:
     bool supportsPrewhere() const override;
     std::optional<NameSet> supportedPrewhereColumns() const override;
 
+    // Would be checked for inner table during sink creation.
+    bool supportsSparseSerialization() const override { return true; }
+
     bool canMoveConditionsToPrewhere() const override;
 
     QueryProcessingStage::Enum

--- a/src/TableFunctions/TableFunctionMerge.cpp
+++ b/src/TableFunctions/TableFunctionMerge.cpp
@@ -144,10 +144,13 @@ StoragePtr TableFunctionMerge::executeImpl(const ASTPtr & /*ast_function*/, Cont
     auto res = std::make_shared<StorageMerge>(
         StorageID(getDatabaseName(), table_name),
         ColumnsDescription{},
+        ConstraintsDescription{},
         String{},
         source_database_name_or_regexp,
         database_is_regexp,
         source_table_regexp,
+        std::nullopt,
+        false,
         context);
 
     res->startup();

--- a/tests/queries/0_stateless/03702_insert_merge_storage.reference
+++ b/tests/queries/0_stateless/03702_insert_merge_storage.reference
@@ -1,0 +1,39 @@
+1	test_1
+2	test_2
+--- INSERT explicit
+1	test_1
+3	test_3
+--- INSERT explicit fully qualified
+2	test_2
+4	test_4
+--- explicit table to write is serialized as literal
+CREATE TABLE default.test_merge\n(\n    `a` Int64,\n    `b` String\n)\nENGINE = Merge(\'default\', \'test_mt_*\', \'default.test_mt_2\')
+--- INSERT auto
+2	test_2
+4	test_4
+5	test_5
+--- auto is serialized as identifier
+CREATE TABLE default.test_merge\n(\n    `a` Int64,\n    `b` String\n)\nENGINE = Merge(\'default\', \'test_mt_*\', auto)
+--- INSERT auto in the latest name
+6	test_6
+--- INSERT triggers Materialized view on inner table
+49	test_7
+--- INSERT triggers Materialized view on merge table
+64	test_8
+--- INSERT in chain of Merge tables
+6	test_6
+7	test_7
+8	test_8
+9	test_9
+--- INSERT in Merge with materialized view
+6	test_6
+7	test_7
+8	test_8
+9	test_9
+100	test_100
+--- Merge table defaults used
+1	1
+--- Inner table defaults are used
+1	2
+--- All constraints passed
+6

--- a/tests/queries/0_stateless/03702_insert_merge_storage.sql
+++ b/tests/queries/0_stateless/03702_insert_merge_storage.sql
@@ -1,0 +1,103 @@
+CREATE TABLE test_mt_1 (a Int32, b String) Engine=MergeTree ORDER BY a;
+CREATE TABLE test_mt_2 (a Int64, b String) Engine=MergeTree ORDER BY a;
+
+INSERT INTO test_mt_1 VALUES(1, 'test_1');
+INSERT INTO test_mt_2 VALUES(2, 'test_2');
+
+CREATE TABLE test_merge Engine=Merge(database(), 'test_mt_*');
+SELECT * FROM test_merge ORDER BY ALL;
+INSERT INTO test_merge VALUES (3, 'test_3'); -- { serverError TABLE_IS_READ_ONLY }
+
+SELECT '--- INSERT explicit';
+REPLACE TABLE test_merge Engine=Merge(database(), 'test_mt_*', test_mt_1);
+INSERT INTO test_merge VALUES (3, 'test_3');
+SELECT * FROM test_mt_1 ORDER BY ALL;
+
+SELECT '--- INSERT explicit fully qualified';
+REPLACE TABLE test_merge Engine=Merge(database(), 'test_mt_*', database() || '.test_mt_2');
+INSERT INTO test_merge VALUES (4, 'test_4');
+SELECT * FROM test_mt_2 ORDER BY ALL;
+SELECT '--- explicit table to write is serialized as literal';
+SHOW CREATE TABLE test_merge;
+
+-- INSERT table doesn't exists
+REPLACE TABLE test_merge Engine=Merge(database(), 'test_mt_*', test_mt_not_exists);
+INSERT INTO test_merge VALUES (0, 'failed'); -- { serverError UNKNOWN_TABLE }
+
+-- INSERT table doesn't match
+REPLACE TABLE test_merge Engine=Merge(database(), 'test_mt_*', invalid_db.test_mt_1); -- { serverError BAD_ARGUMENTS }
+REPLACE TABLE test_merge Engine=Merge(database(), 'test_mt_*', test_invalid); -- { serverError BAD_ARGUMENTS }
+
+-- database regexp with implicit insert database is forbidden
+REPLACE TABLE test_merge Engine=Merge(REGEXP({CLICKHOUSE_DATABASE:String}), 'test_mt_*', test_mt_1); -- { serverError BAD_ARGUMENTS }
+
+-- database regexp with fully qualified insert table
+REPLACE TABLE test_merge Engine=Merge(REGEXP({CLICKHOUSE_DATABASE:String}), 'test_mt_*', database() || '.test_mt_2');
+
+SELECT '--- INSERT auto';
+REPLACE TABLE test_merge Engine=Merge(database(), 'test_mt_*', auto);
+INSERT INTO test_merge VALUES (5, 'test_5');
+SELECT * FROM test_mt_2 ORDER BY ALL;
+SELECT '--- auto is serialized as identifier';
+SHOW CREATE TABLE test_merge;
+SELECT '--- INSERT auto in the latest name';
+CREATE TABLE test_mt_3 (a Int128, b String) Engine=MergeTree ORDER BY a;
+INSERT INTO test_merge VALUES (6, 'test_6');
+SELECT * FROM test_mt_3 ORDER BY ALL;
+
+SELECT '--- INSERT triggers Materialized view on inner table';
+CREATE MATERIALIZED VIEW test_mat_view_inner Engine=Memory AS SELECT a*a AS id, b AS val FROM test_mt_3;
+INSERT INTO test_merge VALUES (7, 'test_7');
+SELECT * FROM test_mat_view_inner ORDER BY ALL;
+
+SELECT '--- INSERT triggers Materialized view on merge table';
+CREATE MATERIALIZED VIEW test_mat_view_merge Engine=Memory AS SELECT a*a AS id, b AS val FROM test_merge;
+INSERT INTO test_merge VALUES (8, 'test_8');
+SELECT * FROM test_mat_view_merge ORDER BY ALL;
+
+SELECT '--- INSERT in chain of Merge tables';
+CREATE TABLE test_chain_merge Engine=Merge(database(), 'test_merge', auto);
+INSERT INTO test_chain_merge VALUES (9, 'test_9');
+SELECT * FROM test_mt_3 ORDER BY ALL;
+
+SELECT '--- INSERT in Merge with materialized view';
+CREATE TABLE test_source (a Int) Engine=Memory;
+CREATE MATERIALIZED VIEW test_mat_view_to_merge TO test_merge AS SELECT a*a AS a, 'test_' || toString(a) AS b FROM test_source;
+INSERT INTO test_source VALUES(10);
+SELECT * FROM test_mt_3 ORDER BY ALL;
+
+-- Detect insert loop
+CREATE TABLE test_cycle_1 (a Int) Engine=Merge(database(), 'test_cycle.*', test_cycle_2);
+CREATE TABLE test_cycle_2 Engine=Merge(database(), 'test_cycle.*', test_cycle_1);
+INSERT INTO test_cycle_1 VALUES (1); -- { serverError TOO_DEEP_RECURSION }
+
+-- Type check
+CREATE TABLE test_types_1 (name String) ORDER BY name;
+CREATE TABLE test_types_2 (name UInt32) ORDER BY name;
+CREATE TABLE merge_test_types ENGINE = Merge(database(), 'test_types_.*', auto);
+INSERT INTO merge_test_types VALUES('Mark'); -- { serverError CANNOT_PARSE_TEXT }
+
+SELECT '--- Merge table defaults used';
+CREATE TABLE test_merge_defaults_mt (a Int32, b String) Engine=MergeTree ORDER BY a;
+CREATE TABLE test_merge_defaults (a Int16 DEFAULT 1, b String DEFAULT toString(a)) Engine=Merge(database(), 'test_merge_defaults_mt', test_merge_defaults_mt);
+INSERT INTO test_merge_defaults (a) VALUES (NULL);
+SELECT * FROM test_merge_defaults_mt ORDER BY ALL;
+
+SELECT '--- Inner table defaults are used';
+CREATE TABLE test_inner_defaults_mt (a Int32, b String DEFAULT toString(a+1)) Engine=MergeTree ORDER BY a;
+CREATE TABLE test_inner_defaults (a Int16 DEFAULT 1) Engine=Merge(database(), 'test_inner_defaults_mt', test_inner_defaults_mt);
+INSERT INTO test_inner_defaults VALUES (NULL);
+SELECT * FROM test_inner_defaults_mt ORDER BY ALL;
+
+-- Inner constraints are validated
+CREATE TABLE test_constraints_1 (id Int, CONSTRAINT small_id CHECK  id < 10) ORDER BY id;
+CREATE TABLE test_merge_constraints (id Int) ENGINE = Merge(database(), 'test_constraints_*', auto);
+INSERT INTO test_merge_constraints VALUES (11); -- { serverError VIOLATED_CONSTRAINT }
+
+-- Merge constraints are validated
+REPLACE TABLE test_merge_constraints (id Int, CONSTRAINT small_id CHECK  id > 5) ENGINE = Merge(database(), 'test_constraints_*', auto);
+INSERT INTO test_merge_constraints VALUES (4); -- { serverError VIOLATED_CONSTRAINT }
+
+SELECT '--- All constraints passed';
+INSERT INTO test_merge_constraints VALUES (6);
+SELECT * FROM test_merge_constraints ORDER BY ALL;

--- a/tests/queries/0_stateless/03732_insert_merge_storage_access.reference
+++ b/tests/queries/0_stateless/03732_insert_merge_storage_access.reference
@@ -1,0 +1,25 @@
+-- insert in the explicit merge table
+1
+2
+-- insert in the latest auto table
+3
+-- insert into the materialized view with security context
+7
+-- insert in chain of merges
+1
+-- views permissions check
+default_view_user_2
+default.complex_merge_3
+default.complex_merge_4
+default_view_user_5
+default_view_user_4
+default_view_user_3
+default_view_user_1
+default.complex_merge_2
+-- check data written
+complex_table_1	7
+complex_table_2	7
+complex_table_3	7
+complex_table_4	7
+complex_table_5	7
+7

--- a/tests/queries/0_stateless/03732_insert_merge_storage_access.sh
+++ b/tests/queries/0_stateless/03732_insert_merge_storage_access.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+
+set -e
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+CLICKHOUSE_USER="user_03732_$CLICKHOUSE_DATABASE"
+CLICKHOUSE_USER_CLIENT="$CLICKHOUSE_CLIENT --user $CLICKHOUSE_USER --password user_password"
+
+$CLICKHOUSE_CLIENT --multiline -q """
+    CREATE TABLE test_table_1 (key UInt32) Engine=MergeTree() ORDER BY key;
+    CREATE TABLE test_table_2 (key UInt64) Engine=MergeTree() ORDER BY key;
+    CREATE TABLE test_table_3 (key Int32) Engine=MergeTree() ORDER BY key;
+    CREATE TABLE test_merge_ro Engine=Merge($CLICKHOUSE_DATABASE, 'test_table_\d+');
+    CREATE TABLE test_merge_explicit Engine=Merge($CLICKHOUSE_DATABASE, 'test_table_\d+', 'test_table_1');
+    CREATE TABLE test_merge_auto (key Int64) Engine=Merge($CLICKHOUSE_DATABASE, 'test_table_\d+', auto);
+    DROP USER IF EXISTS $CLICKHOUSE_USER;
+    CREATE USER $CLICKHOUSE_USER IDENTIFIED WITH plaintext_password BY 'user_password';
+    GRANT INSERT ON $CLICKHOUSE_DATABASE.test_merge_ro TO $CLICKHOUSE_USER;
+"""
+
+$CLICKHOUSE_USER_CLIENT --multiline -q """
+    INSERT INTO test_merge_ro VALUES (1); -- { serverError TABLE_IS_READ_ONLY }
+    INSERT INTO test_merge_explicit VALUES (2); -- { serverError ACCESS_DENIED }
+    INSERT INTO test_merge_auto VALUES (3); -- { serverError ACCESS_DENIED }
+"""
+
+# No access to inner table
+$CLICKHOUSE_CLIENT --multiline -q """
+    GRANT INSERT ON $CLICKHOUSE_DATABASE.test_merge_explicit TO $CLICKHOUSE_USER;
+    GRANT INSERT ON $CLICKHOUSE_DATABASE.test_merge_auto TO $CLICKHOUSE_USER;
+"""
+$CLICKHOUSE_USER_CLIENT --multiline -q """
+    INSERT INTO test_merge_explicit VALUES (2); -- { serverError ACCESS_DENIED }
+    INSERT INTO test_merge_auto VALUES (2); -- { serverError UNKNOWN_TABLE }
+"""
+
+# Has access to both tables
+$CLICKHOUSE_CLIENT -q "GRANT INSERT,SELECT ON $CLICKHOUSE_DATABASE.test_table_1 TO $CLICKHOUSE_USER;"
+$CLICKHOUSE_USER_CLIENT --multiline -q """
+    SELECT '-- insert in the explicit merge table';
+    INSERT INTO test_merge_explicit VALUES (1);
+    INSERT INTO test_merge_auto VALUES (2);
+    SELECT * FROM test_table_1 ORDER BY ALL;
+"""
+
+# Only SHOW access to the auto write table
+$CLICKHOUSE_CLIENT -q "GRANT SHOW ON $CLICKHOUSE_DATABASE.test_table_2 TO $CLICKHOUSE_USER;"
+$CLICKHOUSE_USER_CLIENT -q "INSERT INTO test_merge_auto VALUES (3); -- { serverError ACCESS_DENIED }"
+
+# Only SHOW access to the auto write table
+$CLICKHOUSE_CLIENT -q "GRANT INSERT,SELECT ON $CLICKHOUSE_DATABASE.test_table_3 TO $CLICKHOUSE_USER;"
+$CLICKHOUSE_USER_CLIENT --multiline -q """
+    INSERT INTO test_merge_auto VALUES (3);
+    SELECT '-- insert in the latest auto table';
+    SELECT * FROM test_table_3 ORDER BY ALL;
+"""
+
+CLICKHOUSE_VIEW_USER="view_user_03732_$CLICKHOUSE_DATABASE"
+$CLICKHOUSE_CLIENT --multiline -q """
+    CREATE TABLE inner_view (key UInt64) Engine=MergeTree() ORDER BY key;
+    DROP USER IF EXISTS $CLICKHOUSE_VIEW_USER;
+    CREATE USER $CLICKHOUSE_VIEW_USER IDENTIFIED WITH plaintext_password BY 'user_password';
+    GRANT SELECT ON $CLICKHOUSE_DATABASE.test_merge_explicit TO $CLICKHOUSE_VIEW_USER;
+    GRANT SELECT ON $CLICKHOUSE_DATABASE.inner_view TO $CLICKHOUSE_VIEW_USER;
+    CREATE MATERIALIZED VIEW test_mat_view TO inner_view DEFINER=$CLICKHOUSE_VIEW_USER SQL SECURITY DEFINER AS SELECT * FROM test_table_1;
+"""
+
+# View DEFINER has no source select access
+$CLICKHOUSE_USER_CLIENT -q "INSERT INTO test_merge_explicit VALUES (3) -- { serverError ACCESS_DENIED }"
+
+# View DEFINER has no write access
+$CLICKHOUSE_CLIENT -q "GRANT SELECT ON $CLICKHOUSE_DATABASE.test_table_1 TO $CLICKHOUSE_VIEW_USER;"
+$CLICKHOUSE_USER_CLIENT -q "INSERT INTO test_merge_explicit VALUES (3) -- { serverError ACCESS_DENIED }"
+
+# Insert in the materialize view with sql security context
+$CLICKHOUSE_CLIENT --multiline -q """
+    GRANT INSERT ON $CLICKHOUSE_DATABASE.inner_view TO $CLICKHOUSE_VIEW_USER;
+    GRANT SELECT ON $CLICKHOUSE_DATABASE.test_mat_view TO $CLICKHOUSE_USER;
+"""
+$CLICKHOUSE_USER_CLIENT --multiline -q """
+    SELECT '-- insert into the materialized view with security context';
+    INSERT INTO test_merge_explicit VALUES (7);
+    SELECT * FROM test_mat_view ORDER BY ALL;
+"""
+
+# Access in chain of merge tables checked
+$CLICKHOUSE_CLIENT --multiline -q """
+    CREATE TABLE test_chain_table (key UInt32) Engine=MergeTree() ORDER BY key;
+    CREATE TABLE test_merge_child Engine=Merge($CLICKHOUSE_DATABASE, 'test_chain_table', test_chain_table);
+    CREATE TABLE test_merge_parent Engine=Merge($CLICKHOUSE_DATABASE, 'test_merge_child', 'test_merge_child');
+    GRANT INSERT ON $CLICKHOUSE_DATABASE.test_merge_parent TO $CLICKHOUSE_USER;
+    GRANT SELECT ON $CLICKHOUSE_DATABASE.test_merge_child TO $CLICKHOUSE_USER;
+    GRANT INSERT,SELECT ON $CLICKHOUSE_DATABASE.test_chain_table TO $CLICKHOUSE_USER;
+"""
+$CLICKHOUSE_USER_CLIENT -q 'INSERT INTO test_merge_parent VALUES (1); -- { serverError ACCESS_DENIED }'
+$CLICKHOUSE_CLIENT -q "GRANT INSERT ON $CLICKHOUSE_DATABASE.test_merge_child TO $CLICKHOUSE_USER;"
+$CLICKHOUSE_USER_CLIENT --multiline -q """
+    SELECT '-- insert in chain of merges';
+    INSERT INTO test_merge_parent VALUES (1);
+    SELECT * FROM test_chain_table ORDER BY ALL;
+"""
+
+# Complex case with every materialized view use separate user
+#                                     |table3| <- |mat_view3|   |table6| <- |mat_view5|
+#                                                      |                        |
+# insert -> |merge1|  -> |table1| -> |mat_view2| -> |merge3| -> |merge4| -> |table4|
+#             |                                                    |
+#        |mat_view1| -> |merge2| -> |table2|     |table5| <- |mat_view4|
+
+$CLICKHOUSE_CLIENT --multiline -q """
+    CREATE TABLE complex_table_1 (a Int32) Engine=MergeTree() ORDER BY a;
+    CREATE TABLE complex_table_2 (a Int64) Engine=MergeTree() ORDER BY a;
+    CREATE TABLE complex_table_3 (a UInt32) Engine=MergeTree() ORDER BY a;
+    CREATE TABLE complex_table_4 (a Int16) Engine=MergeTree() ORDER BY a;
+    CREATE TABLE complex_table_5 (a Int128) Engine=MergeTree() ORDER BY a;
+    CREATE TABLE complex_table_6 (a String) Engine=MergeTree() ORDER BY a;
+
+    CREATE TABLE complex_merge_1 Engine=Merge($CLICKHOUSE_DATABASE, 'complex_table_1', complex_table_1);
+    CREATE TABLE complex_merge_2 (a UInt64) Engine=Merge($CLICKHOUSE_DATABASE, 'complex_table_2', auto);
+    CREATE TABLE complex_merge_3 (a UInt32) Engine=Merge($CLICKHOUSE_DATABASE, 'complex_merge_4', auto);
+    CREATE TABLE complex_merge_4 (a Int32) Engine=Merge($CLICKHOUSE_DATABASE, 'complex_table_4', auto);
+
+    CREATE USER ${CLICKHOUSE_DATABASE}_view_user_1 IDENTIFIED WITH plaintext_password BY 'user_password';
+    GRANT SELECT ON $CLICKHOUSE_DATABASE.complex_merge_1 TO ${CLICKHOUSE_DATABASE}_view_user_1;
+    CREATE MATERIALIZED VIEW complex_mat_view_1 TO complex_merge_2 DEFINER=${CLICKHOUSE_DATABASE}_view_user_1 SQL SECURITY DEFINER AS SELECT * FROM complex_merge_1;
+
+    CREATE USER ${CLICKHOUSE_DATABASE}_view_user_2 IDENTIFIED WITH plaintext_password BY 'user_password';
+    GRANT SELECT ON $CLICKHOUSE_DATABASE.complex_table_1 TO ${CLICKHOUSE_DATABASE}_view_user_2;
+    CREATE MATERIALIZED VIEW complex_mat_view_2 TO complex_merge_3 DEFINER=${CLICKHOUSE_DATABASE}_view_user_2 SQL SECURITY DEFINER AS SELECT * FROM complex_table_1;
+
+    CREATE USER ${CLICKHOUSE_DATABASE}_view_user_3 IDENTIFIED WITH plaintext_password BY 'user_password';
+    GRANT SELECT ON $CLICKHOUSE_DATABASE.complex_merge_3 TO ${CLICKHOUSE_DATABASE}_view_user_3;
+    CREATE MATERIALIZED VIEW complex_mat_view_3 TO complex_table_3 DEFINER=${CLICKHOUSE_DATABASE}_view_user_3 SQL SECURITY DEFINER AS SELECT * FROM complex_merge_3;
+
+    CREATE USER ${CLICKHOUSE_DATABASE}_view_user_4 IDENTIFIED WITH plaintext_password BY 'user_password';
+    GRANT SELECT ON $CLICKHOUSE_DATABASE.complex_merge_4 TO ${CLICKHOUSE_DATABASE}_view_user_4;
+    CREATE MATERIALIZED VIEW complex_mat_view_4 TO complex_table_5 DEFINER=${CLICKHOUSE_DATABASE}_view_user_4 SQL SECURITY DEFINER AS SELECT * FROM complex_merge_4;
+
+    CREATE USER ${CLICKHOUSE_DATABASE}_view_user_5 IDENTIFIED WITH plaintext_password BY 'user_password';
+    GRANT SELECT ON $CLICKHOUSE_DATABASE.complex_table_4 TO ${CLICKHOUSE_DATABASE}_view_user_5;
+    CREATE MATERIALIZED VIEW complex_mat_view_5 TO complex_table_6 DEFINER=${CLICKHOUSE_DATABASE}_view_user_5 SQL SECURITY DEFINER AS SELECT toString(a) a FROM complex_table_4;
+
+    GRANT INSERT ON $CLICKHOUSE_DATABASE.complex_merge_1 TO $CLICKHOUSE_USER;
+    GRANT INSERT ON $CLICKHOUSE_DATABASE.complex_table_1 TO $CLICKHOUSE_USER;
+
+    SELECT '-- views permissions check';
+"""
+
+# Check INSERT grants
+$CLICKHOUSE_USER_CLIENT -q "INSERT INTO complex_merge_1 VALUES (49)" 2>&1 | grep -o ${CLICKHOUSE_DATABASE}_view_user_2 | uniq || echo "NO ERROR"
+$CLICKHOUSE_CLIENT -q "GRANT INSERT ON $CLICKHOUSE_DATABASE.complex_merge_3 TO ${CLICKHOUSE_DATABASE}_view_user_2;"
+
+$CLICKHOUSE_USER_CLIENT -q "INSERT INTO complex_merge_1 VALUES (49)" 2>&1 | grep -o "${CLICKHOUSE_DATABASE}.complex_merge_3" | uniq || echo "NO ERROR"
+$CLICKHOUSE_CLIENT -q "GRANT INSERT ON $CLICKHOUSE_DATABASE.complex_merge_4 TO ${CLICKHOUSE_DATABASE}_view_user_2;"
+
+$CLICKHOUSE_USER_CLIENT -q "INSERT INTO complex_merge_1 VALUES (49)" 2>&1 | grep -o "${CLICKHOUSE_DATABASE}.complex_merge_4" | uniq || echo "NO ERROR"
+$CLICKHOUSE_CLIENT -q "GRANT INSERT ON $CLICKHOUSE_DATABASE.complex_table_4 TO ${CLICKHOUSE_DATABASE}_view_user_2;"
+
+$CLICKHOUSE_USER_CLIENT -q "INSERT INTO complex_merge_1 VALUES (49)" 2>&1 | grep -o ${CLICKHOUSE_DATABASE}_view_user_5 | uniq || echo "NO ERROR"
+$CLICKHOUSE_CLIENT -q "GRANT INSERT ON $CLICKHOUSE_DATABASE.complex_table_6 TO ${CLICKHOUSE_DATABASE}_view_user_5;"
+
+$CLICKHOUSE_USER_CLIENT -q "INSERT INTO complex_merge_1 VALUES (49)" 2>&1 | grep -o ${CLICKHOUSE_DATABASE}_view_user_4 | uniq || echo "NO ERROR"
+$CLICKHOUSE_CLIENT -q "GRANT INSERT ON $CLICKHOUSE_DATABASE.complex_table_5 TO ${CLICKHOUSE_DATABASE}_view_user_4;"
+
+$CLICKHOUSE_USER_CLIENT -q "INSERT INTO complex_merge_1 VALUES (49)" 2>&1 | grep -o ${CLICKHOUSE_DATABASE}_view_user_3 | uniq || echo "NO ERROR"
+$CLICKHOUSE_CLIENT -q "GRANT INSERT ON $CLICKHOUSE_DATABASE.complex_table_3 TO ${CLICKHOUSE_DATABASE}_view_user_3;"
+
+$CLICKHOUSE_USER_CLIENT -q "INSERT INTO complex_merge_1 VALUES (49)" 2>&1 | grep -o ${CLICKHOUSE_DATABASE}_view_user_1 | uniq || echo "NO ERROR"
+$CLICKHOUSE_CLIENT -q "GRANT INSERT ON $CLICKHOUSE_DATABASE.complex_merge_2 TO ${CLICKHOUSE_DATABASE}_view_user_1;"
+
+$CLICKHOUSE_USER_CLIENT -q "INSERT INTO complex_merge_1 VALUES (49)" 2>&1 | grep -o "${CLICKHOUSE_DATABASE}.complex_merge_2" | uniq || echo "NO ERROR"
+$CLICKHOUSE_CLIENT -q "GRANT INSERT ON $CLICKHOUSE_DATABASE.complex_table_2 TO ${CLICKHOUSE_DATABASE}_view_user_1;"
+
+$CLICKHOUSE_USER_CLIENT -q "INSERT INTO complex_merge_1 VALUES (7)"
+$CLICKHOUSE_CLIENT --multiline -q """
+    SELECT '-- check data written';
+    SELECT _table, * FROM merge($CLICKHOUSE_DATABASE, 'complex_table_[1-5]') ORDER BY ALL;
+    SELECT * FROM complex_table_6 ORDER BY ALL;
+"""
+
+$CLICKHOUSE_CLIENT --multiline -q """
+    DROP VIEW test_mat_view;
+    DROP USER $CLICKHOUSE_USER, $CLICKHOUSE_VIEW_USER;
+    DROP VIEW complex_mat_view_1, complex_mat_view_2, complex_mat_view_3, complex_mat_view_4, complex_mat_view_5;
+    DROP USER ${CLICKHOUSE_DATABASE}_view_user_1, ${CLICKHOUSE_DATABASE}_view_user_2, ${CLICKHOUSE_DATABASE}_view_user_3, ${CLICKHOUSE_DATABASE}_view_user_4, ${CLICKHOUSE_DATABASE}_view_user_5;
+"""


### PR DESCRIPTION
It may be incompatible with WindowView, but I'm not sure it's worth the time to support.
Probably, it makes sense to introduce a setting like `allow_experimental_insert_to_merge_storage` for some time

Rework of the reverted PR #77484
#64864
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- New Feature

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Support inserts into Merge storage

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)
