### PR TITLE
Fix logical error in DDSketch remapping

### DIFF
--- a/src/AggregateFunctions/DDSketch.h
+++ b/src/AggregateFunctions/DDSketch.h
@@ -225,10 +225,9 @@ private:
 
         auto remap_store = [this, &new_mapping](DDSketchDenseStore & old_store, std::unique_ptr<DDSketchDenseStore> & target_store)
         {
-            for (int i = 0; i < old_store.length(); ++i)
+            for (int old_index = old_store.min_key; old_index <= old_store.max_key; ++old_index)
             {
-                int old_index = i + old_store.offset;
-                Float64 old_bin_count = old_store.bins[i];
+                Float64 old_bin_count = old_store.bins[old_index - old_store.offset];
 
                 Float64 in_lower_bound = this->mapping->lowerBound(old_index);
                 Float64 in_upper_bound = this->mapping->lowerBound(old_index + 1);


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: false -->

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Don't read padding bins unnecessarily from the sketch store and avoid spurious `add(key, 0.0)` calls. Otherwise, the serialised state becomes invalid and throws an error.
