### PR TITLE
no-parallel-replicas for 03711_deduplication_blocks_part_log

### DIFF
--- a/tests/queries/0_stateless/03711_deduplication_blocks_part_log.sql
+++ b/tests/queries/0_stateless/03711_deduplication_blocks_part_log.sql
@@ -1,4 +1,6 @@
--- Tags: no-parallel
+-- Tags: no-parallel, no-parallel-replicas
+
+-- no-parallel-replicas -- https://github.com/ClickHouse/ClickHouse/issues/90063
 
 DROP DATABASE IF EXISTS 03710_database;
 CREATE DATABASE 03710_database;


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Details

https://github.com/ClickHouse/ClickHouse/issues/90063

It is not a fix, it is a mute.
