### PR TITLE
Make KAFKA_RESCHEDULE_MS a Kafka table setting

### DIFF
--- a/docs/en/engines/table-engines/integrations/kafka.md
+++ b/docs/en/engines/table-engines/integrations/kafka.md
@@ -49,6 +49,7 @@ SETTINGS
     [kafka_poll_timeout_ms = 0,]
     [kafka_poll_max_batch_size = 0,]
     [kafka_flush_interval_ms = 0,]
+    [kafka_consumer_reschedule_ms = 0,]
     [kafka_thread_per_consumer = 0,]
     [kafka_handle_error_mode = 'default',]
     [kafka_commit_on_select = false,]
@@ -80,6 +81,7 @@ Optional parameters:
 - `kafka_poll_timeout_ms` — Timeout for single poll from Kafka. Default: [stream_poll_timeout_ms](../../../operations/settings/settings.md#stream_poll_timeout_ms).
 - `kafka_poll_max_batch_size` — Maximum amount of messages to be polled in a single Kafka poll. Default: [max_block_size](/operations/settings/settings#max_block_size).
 - `kafka_flush_interval_ms` — Timeout for flushing data from Kafka. Default: [stream_flush_interval_ms](/operations/settings/settings#stream_flush_interval_ms).
+- `kafka_consumer_reschedule_ms` — Reschedule interval when Kafka stream processing is stalled (e.g., when no messages are available to consume). This setting controls the delay before the consumer retries polling. Must not exceed `kafka_consumers_pool_ttl_ms`. Default: `500` milliseconds.
 - `kafka_thread_per_consumer` — Provide independent thread for each consumer. When enabled, every consumer flush the data independently, in parallel (otherwise — rows from several consumers squashed to form one block). Default: `0`.
 - `kafka_handle_error_mode` — How to handle errors for Kafka engine. Possible values: default (the exception will be thrown if we fail to parse a message), stream (the exception message and raw message will be saved in virtual columns `_error` and `_raw_message`), dead_letter_queue (error related data will be saved in system.dead_letter_queue).
 - `kafka_commit_on_select` —  Commit messages when select query is made. Default: `false`.
@@ -127,7 +129,7 @@ Do not use this method in new projects. If possible, switch old projects to the 
 
 ```sql
 Kafka(kafka_broker_list, kafka_topic_list, kafka_group_name, kafka_format
-      [, kafka_row_delimiter, kafka_schema, kafka_num_consumers, kafka_max_block_size,  kafka_skip_broken_messages, kafka_commit_every_batch, kafka_client_id, kafka_poll_timeout_ms, kafka_poll_max_batch_size, kafka_flush_interval_ms, kafka_thread_per_consumer, kafka_handle_error_mode, kafka_commit_on_select, kafka_max_rows_per_message]);
+      [, kafka_row_delimiter, kafka_schema, kafka_num_consumers, kafka_max_block_size,  kafka_skip_broken_messages, kafka_commit_every_batch, kafka_client_id, kafka_poll_timeout_ms, kafka_poll_max_batch_size, kafka_flush_interval_ms, kafka_consumer_reschedule_ms, kafka_thread_per_consumer, kafka_handle_error_mode, kafka_commit_on_select, kafka_max_rows_per_message]);
 ```
 
 </details>

--- a/src/Storages/Kafka/KafkaSettings.h
+++ b/src/Storages/Kafka/KafkaSettings.h
@@ -13,7 +13,8 @@ namespace DB
 class ASTStorage;
 struct KafkaSettingsImpl;
 
-const auto KAFKA_RESCHEDULE_MS = 500;
+// How often we check for expired consumers in the pool
+const auto KAFKA_CONSUMERS_CLEANUP_CHECK_INTERVAL_MS = 500;
 // once per minute leave do reschedule (we can't lock threads in pool forever)
 const auto KAFKA_MAX_THREAD_WORK_DURATION_MS = 60000;
 // 10min

--- a/src/Storages/Kafka/StorageKafka.cpp
+++ b/src/Storages/Kafka/StorageKafka.cpp
@@ -79,6 +79,7 @@ namespace KafkaSetting
     extern const KafkaSettingsBool kafka_commit_on_select;
     extern const KafkaSettingsUInt64 kafka_consumers_pool_ttl_ms;
     extern const KafkaSettingsMilliseconds kafka_flush_interval_ms;
+    extern const KafkaSettingsMilliseconds kafka_consumer_reschedule_ms;
     extern const KafkaSettingsString kafka_format;
     extern const KafkaSettingsString kafka_group_name;
     extern const KafkaSettingsStreamingHandleErrorMode kafka_handle_error_mode;
@@ -485,7 +486,7 @@ void StorageKafka::cleanConsumersByTTL()
     UInt64 ttl_usec = (*kafka_settings)[KafkaSetting::kafka_consumers_pool_ttl_ms] * 1'000;
 
     std::unique_lock lock(mutex);
-    std::chrono::milliseconds timeout(KAFKA_RESCHEDULE_MS);
+    std::chrono::milliseconds timeout(KAFKA_CONSUMERS_CLEANUP_CHECK_INTERVAL_MS);
     while (!cleanup_cv.wait_for(lock, timeout, [this]() { return shutdown_called == true; }))
     {
         /// Copy consumers for closing to a new vector to close them without a lock
@@ -586,7 +587,7 @@ void StorageKafka::threadFunc(size_t idx)
                 auto some_stream_is_stalled = streamToViews();
                 if (some_stream_is_stalled)
                 {
-                    LOG_TRACE(log, "Stream(s) stalled. Reschedule.");
+                    LOG_TRACE(log, "Stream(s) stalled. Rescheduling in {} ms.", (*kafka_settings)[KafkaSetting::kafka_consumer_reschedule_ms].totalMilliseconds());
                     break;
                 }
 
@@ -594,7 +595,7 @@ void StorageKafka::threadFunc(size_t idx)
                 auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(ts-start_time);
                 if (duration.count() > KAFKA_MAX_THREAD_WORK_DURATION_MS)
                 {
-                    LOG_TRACE(log, "Thread work duration limit exceeded. Reschedule.");
+                    LOG_TRACE(log, "Thread work duration limit exceeded. Rescheduling in {} ms.", (*kafka_settings)[KafkaSetting::kafka_consumer_reschedule_ms].totalMilliseconds());
                     break;
                 }
             }
@@ -626,7 +627,7 @@ void StorageKafka::threadFunc(size_t idx)
 
     // Wait for attached views
     if (!task->stream_cancelled)
-        task->holder->scheduleAfter(KAFKA_RESCHEDULE_MS);
+        task->holder->scheduleAfter((*kafka_settings)[KafkaSetting::kafka_consumer_reschedule_ms].totalMilliseconds());
 }
 
 

--- a/src/Storages/Kafka/StorageKafka2.cpp
+++ b/src/Storages/Kafka/StorageKafka2.cpp
@@ -93,6 +93,7 @@ namespace KafkaSetting
     extern const KafkaSettingsString kafka_broker_list;
     extern const KafkaSettingsString kafka_client_id;
     extern const KafkaSettingsMilliseconds kafka_flush_interval_ms;
+    extern const KafkaSettingsMilliseconds kafka_consumer_reschedule_ms;
     extern const KafkaSettingsString kafka_format;
     extern const KafkaSettingsString kafka_group_name;
     extern const KafkaSettingsStreamingHandleErrorMode kafka_handle_error_mode;

--- a/src/Storages/Kafka/StorageKafka2.cpp
+++ b/src/Storages/Kafka/StorageKafka2.cpp
@@ -8,10 +8,10 @@
 #include <IO/EmptyReadBuffer.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/DatabaseCatalog.h>
-#include <Interpreters/DeadLetterQueue.h>
 #include <Interpreters/ExpressionActions.h>
 #include <Interpreters/InterpreterInsertQuery.h>
 #include <Interpreters/evaluateConstantExpression.h>
+#include <Interpreters/DeadLetterQueue.h>
 #include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTExpressionList.h>
 #include <Parsers/ASTIdentifier.h>
@@ -79,35 +79,34 @@ namespace DB
 {
 namespace Setting
 {
-extern const SettingsNonZeroUInt64 max_block_size;
-extern const SettingsNonZeroUInt64 max_insert_block_size;
-extern const SettingsUInt64 output_format_avro_rows_in_file;
-extern const SettingsMilliseconds stream_flush_interval_ms;
-extern const SettingsMilliseconds stream_poll_timeout_ms;
+    extern const SettingsNonZeroUInt64 max_block_size;
+    extern const SettingsNonZeroUInt64 max_insert_block_size;
+    extern const SettingsUInt64 output_format_avro_rows_in_file;
+    extern const SettingsMilliseconds stream_flush_interval_ms;
+    extern const SettingsMilliseconds stream_poll_timeout_ms;
 }
 
 namespace KafkaSetting
 {
-extern const KafkaSettingsUInt64 input_format_allow_errors_num;
-extern const KafkaSettingsFloat input_format_allow_errors_ratio;
-extern const KafkaSettingsString kafka_broker_list;
-extern const KafkaSettingsString kafka_client_id;
-extern const KafkaSettingsMilliseconds kafka_flush_interval_ms;
-extern const KafkaSettingsMilliseconds kafka_consumer_reschedule_ms;
-extern const KafkaSettingsString kafka_format;
-extern const KafkaSettingsString kafka_group_name;
-extern const KafkaSettingsStreamingHandleErrorMode kafka_handle_error_mode;
-extern const KafkaSettingsString kafka_keeper_path;
-extern const KafkaSettingsUInt64 kafka_max_block_size;
-extern const KafkaSettingsUInt64 kafka_max_rows_per_message;
-extern const KafkaSettingsUInt64 kafka_num_consumers;
-extern const KafkaSettingsUInt64 kafka_poll_max_batch_size;
-extern const KafkaSettingsMilliseconds kafka_poll_timeout_ms;
-extern const KafkaSettingsString kafka_replica_name;
-extern const KafkaSettingsString kafka_schema;
-extern const KafkaSettingsUInt64 kafka_schema_registry_skip_bytes;
-extern const KafkaSettingsBool kafka_thread_per_consumer;
-extern const KafkaSettingsString kafka_topic_list;
+    extern const KafkaSettingsUInt64 input_format_allow_errors_num;
+    extern const KafkaSettingsFloat input_format_allow_errors_ratio;
+    extern const KafkaSettingsString kafka_broker_list;
+    extern const KafkaSettingsString kafka_client_id;
+    extern const KafkaSettingsMilliseconds kafka_flush_interval_ms;
+    extern const KafkaSettingsString kafka_format;
+    extern const KafkaSettingsString kafka_group_name;
+    extern const KafkaSettingsStreamingHandleErrorMode kafka_handle_error_mode;
+    extern const KafkaSettingsString kafka_keeper_path;
+    extern const KafkaSettingsUInt64 kafka_max_block_size;
+    extern const KafkaSettingsUInt64 kafka_max_rows_per_message;
+    extern const KafkaSettingsUInt64 kafka_num_consumers;
+    extern const KafkaSettingsUInt64 kafka_poll_max_batch_size;
+    extern const KafkaSettingsMilliseconds kafka_poll_timeout_ms;
+    extern const KafkaSettingsString kafka_replica_name;
+    extern const KafkaSettingsString kafka_schema;
+    extern const KafkaSettingsUInt64 kafka_schema_registry_skip_bytes;
+    extern const KafkaSettingsBool kafka_thread_per_consumer;
+    extern const KafkaSettingsString kafka_topic_list;
 }
 
 namespace fs = std::filesystem;
@@ -142,8 +141,7 @@ StorageKafka2::StorageKafka2(
     , replica_path(keeper_path + "/replicas/" + (*kafka_settings_)[KafkaSetting::kafka_replica_name].value)
     , kafka_settings(std::move(kafka_settings_))
     , macros_info{.table_id = table_id_}
-    , topics(StorageKafkaUtils::parseTopics(
-          getContext()->getMacros()->expand((*kafka_settings)[KafkaSetting::kafka_topic_list].value, macros_info)))
+    , topics(StorageKafkaUtils::parseTopics(getContext()->getMacros()->expand((*kafka_settings)[KafkaSetting::kafka_topic_list].value, macros_info)))
     , brokers(getContext()->getMacros()->expand((*kafka_settings)[KafkaSetting::kafka_broker_list].value, macros_info))
     , group(getContext()->getMacros()->expand((*kafka_settings)[KafkaSetting::kafka_group_name].value, macros_info))
     , client_id(
@@ -161,7 +159,6 @@ StorageKafka2::StorageKafka2(
     , active_node_identifier(toString(ServerUUID::get()))
 {
     kafka_settings->sanityCheck(getContext());
-
     if ((*kafka_settings)[KafkaSetting::kafka_num_consumers] > 1 && !thread_per_consumer)
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "With multiple consumers, it is required to use `kafka_thread_per_consumer` setting");
 
@@ -286,6 +283,7 @@ bool StorageKafka2::activate()
             replica_is_active_node = nullptr;
             LOG_ERROR(log, "Couldn't start replica: {}. {}", e.what(), DB::getCurrentExceptionMessage(true));
             return false;
+
         }
         catch (const Exception & e)
         {
@@ -409,8 +407,7 @@ StorageKafka2::write(const ASTPtr &, const StorageMetadataPtr & metadata_snapsho
     /// Need for backward compatibility.
     if (format_name == "Avro" && local_context->getSettingsRef()[Setting::output_format_avro_rows_in_file].changed)
         max_rows = local_context->getSettingsRef()[Setting::output_format_avro_rows_in_file].value;
-    return std::make_shared<MessageQueueSink>(
-        std::make_shared<const Block>(std::move(header)), getFormatName(), max_rows, std::move(producer), getName(), modified_context);
+    return std::make_shared<MessageQueueSink>(std::make_shared<const Block>(std::move(header)), getFormatName(), max_rows, std::move(producer), getName(), modified_context);
 }
 
 void StorageKafka2::startup()
@@ -456,8 +453,7 @@ KafkaConsumer2Ptr StorageKafka2::createKafkaConsumer(size_t consumer_number)
     /// NOTE: we pass |stream_cancelled| by reference here, so the buffers should not outlive the storage.
     chassert((thread_per_consumer || num_consumers == 1) && "StorageKafka2 cannot handle multiple consumers on a single thread");
     auto & stream_cancelled = tasks[consumer_number]->stream_cancelled;
-    return std::make_shared<KafkaConsumer2>(
-        log, getPollMaxBatchSize(), getPollTimeoutMillisecond(), stream_cancelled, topics, getSchemaRegistrySkipBytes());
+    return std::make_shared<KafkaConsumer2>(log, getPollMaxBatchSize(), getPollTimeoutMillisecond(), stream_cancelled, topics, getSchemaRegistrySkipBytes());
 }
 
 cppkafka::Configuration StorageKafka2::getConsumerConfiguration(size_t consumer_number, IKafkaExceptionInfoSinkPtr exception_sink)
@@ -480,31 +476,31 @@ cppkafka::Configuration StorageKafka2::getConsumerConfiguration(size_t consumer_
 
 cppkafka::Configuration StorageKafka2::getProducerConfiguration()
 {
-    KafkaConfigLoader::ProducerConfigParams params{{getContext()->getConfigRef(), collection_name, topics, log}, brokers, client_id};
+    KafkaConfigLoader::ProducerConfigParams params{
+        {getContext()->getConfigRef(), collection_name, topics, log},
+        brokers,
+        client_id};
     return KafkaConfigLoader::getProducerConfiguration(*this, params);
 }
 
 size_t StorageKafka2::getMaxBlockSize() const
 {
-    return (*kafka_settings)[KafkaSetting::kafka_max_block_size].changed
-        ? (*kafka_settings)[KafkaSetting::kafka_max_block_size].value
-        : (getContext()->getSettingsRef()[Setting::max_insert_block_size].value / num_consumers);
+    return (*kafka_settings)[KafkaSetting::kafka_max_block_size].changed ? (*kafka_settings)[KafkaSetting::kafka_max_block_size].value
+                                                        : (getContext()->getSettingsRef()[Setting::max_insert_block_size].value / num_consumers);
 }
 
 size_t StorageKafka2::getPollMaxBatchSize() const
 {
-    size_t batch_size = (*kafka_settings)[KafkaSetting::kafka_poll_max_batch_size].changed
-        ? (*kafka_settings)[KafkaSetting::kafka_poll_max_batch_size].value
-        : getContext()->getSettingsRef()[Setting::max_block_size].value;
+    size_t batch_size = (*kafka_settings)[KafkaSetting::kafka_poll_max_batch_size].changed ? (*kafka_settings)[KafkaSetting::kafka_poll_max_batch_size].value
+                                                                          : getContext()->getSettingsRef()[Setting::max_block_size].value;
 
     return std::min(batch_size, getMaxBlockSize());
 }
 
 size_t StorageKafka2::getPollTimeoutMillisecond() const
 {
-    return (*kafka_settings)[KafkaSetting::kafka_poll_timeout_ms].changed
-        ? (*kafka_settings)[KafkaSetting::kafka_poll_timeout_ms].totalMilliseconds()
-        : getContext()->getSettingsRef()[Setting::stream_poll_timeout_ms].totalMilliseconds();
+    return (*kafka_settings)[KafkaSetting::kafka_poll_timeout_ms].changed ? (*kafka_settings)[KafkaSetting::kafka_poll_timeout_ms].totalMilliseconds()
+                                                         : getContext()->getSettingsRef()[Setting::stream_poll_timeout_ms].totalMilliseconds();
 }
 
 size_t StorageKafka2::getSchemaRegistrySkipBytes() const
@@ -743,8 +739,10 @@ void StorageKafka2::dropReplica()
     }
 }
 
-std::optional<StorageKafka2::BlocksAndGuard>
-StorageKafka2::pollConsumer(KeeperHandlingConsumer & consumer, const Stopwatch & watch, const ContextPtr & modified_context)
+std::optional<StorageKafka2::BlocksAndGuard> StorageKafka2::pollConsumer(
+    KeeperHandlingConsumer & consumer,
+    const Stopwatch & watch,
+    const ContextPtr & modified_context)
 {
     LOG_TEST(log, "Polling consumer");
     auto storage_snapshot = getStorageSnapshot(getInMemoryMetadataPtr(), getContext());
@@ -783,7 +781,8 @@ StorageKafka2::pollConsumer(KeeperHandlingConsumer & consumer, const Stopwatch &
 
         switch (getHandleKafkaErrorMode())
         {
-            case StreamingHandleErrorMode::STREAM: {
+            case StreamingHandleErrorMode::STREAM:
+            {
                 exception_message = e.message();
                 for (size_t i = 0; i < result_columns.size(); ++i)
                 {
@@ -795,7 +794,8 @@ StorageKafka2::pollConsumer(KeeperHandlingConsumer & consumer, const Stopwatch &
                 }
                 return 1;
             }
-            case StreamingHandleErrorMode::DEAD_LETTER_QUEUE: {
+            case StreamingHandleErrorMode::DEAD_LETTER_QUEUE:
+            {
                 exception_message = e.message();
                 for (size_t i = 0; i < result_columns.size(); ++i)
                 {
@@ -806,7 +806,8 @@ StorageKafka2::pollConsumer(KeeperHandlingConsumer & consumer, const Stopwatch &
                 is_dead_letter = true;
                 return 0;
             }
-            case StreamingHandleErrorMode::DEFAULT: {
+            case StreamingHandleErrorMode::DEFAULT:
+            {
                 e.addMessage(
                     "while parsing Kafka message (topic: {}, partition: {}, offset: {})'",
                     current_msg_info->currentTopic(),
@@ -837,8 +838,7 @@ StorageKafka2::pollConsumer(KeeperHandlingConsumer & consumer, const Stopwatch &
         return true;
     };
 
-    KeeperHandlingConsumer::MessageSinkFunction msg_sink
-        = [&](ReadBufferPtr buf, const KeeperHandlingConsumer::MessageInfo & msg_info, bool has_more_polled_messages, bool stalled) mutable
+    KeeperHandlingConsumer::MessageSinkFunction msg_sink = [&](ReadBufferPtr buf, const KeeperHandlingConsumer::MessageInfo & msg_info, bool has_more_polled_messages, bool stalled) mutable
     {
         size_t new_rows = 0;
         exception_message.reset();
@@ -920,19 +920,20 @@ StorageKafka2::pollConsumer(KeeperHandlingConsumer & consumer, const Stopwatch &
                 if (!dead_letter_queue)
                     LOG_WARNING(log, "Table system.dead_letter_queue is not configured, skipping message");
                 else
-                    dead_letter_queue->add(DeadLetterQueueElement{
-                        .table_engine = DeadLetterQueueElement::StreamType::Kafka,
-                        .event_time = timeInSeconds(time_now),
-                        .event_time_microseconds = timeInMicroseconds(time_now),
-                        .database = storage_id.database_name,
-                        .table = storage_id.table_name,
-                        .raw_message = msg_info.currentPayload(),
-                        .error = exception_message.value(),
-                        .details = DeadLetterQueueElement::KafkaDetails{
-                            .topic_name = msg_info.currentTopic(),
-                            .partition = msg_info.currentPartition(),
-                            .offset = msg_info.currentPartition(),
-                            .key = msg_info.currentKey()}});
+                    dead_letter_queue->add(
+                        DeadLetterQueueElement{
+                            .table_engine = DeadLetterQueueElement::StreamType::Kafka,
+                            .event_time = timeInSeconds(time_now),
+                            .event_time_microseconds = timeInMicroseconds(time_now),
+                            .database = storage_id.database_name,
+                            .table = storage_id.table_name,
+                            .raw_message = msg_info.currentPayload(),
+                            .error = exception_message.value(),
+                            .details = DeadLetterQueueElement::KafkaDetails{
+                                .topic_name = msg_info.currentTopic(),
+                                .partition = msg_info.currentPartition(),
+                                .offset = msg_info.currentPartition(),
+                                .key = msg_info.currentKey()}});
             }
 
             total_rows = total_rows + new_rows;
@@ -1085,7 +1086,8 @@ std::optional<StorageKafka2::StallKind> StorageKafka2::streamToViews(size_t idx)
         if (maybe_rows.has_value())
         {
             const auto milliseconds = watch.elapsedMilliseconds();
-            LOG_DEBUG(log, "Pushing {} rows took {} ms.", formatReadableQuantity(*maybe_rows), milliseconds);
+            LOG_DEBUG(
+                log, "Pushing {} rows took {} ms.", formatReadableQuantity(*maybe_rows), milliseconds);
         }
         else
         {

--- a/tests/integration/helpers/client.py
+++ b/tests/integration/helpers/client.py
@@ -221,17 +221,8 @@ class CommandRequest:
         if not stderr:
             return stderr
         lines = stderr.split("\n")
-        def _is_trash(msg):
-            return (
-                "completion_queue" in msg or
-                "Kick failed" in msg or
-                # Can be returned as a warning in VM setups. Reference
-                # https://github.com/ClickHouse/ClickHouse/issues/45770
-                "Number of CPUs detected is not deterministic" in msg
-            )
-
         lines = [
-            x for x in lines if not _is_trash(x)
+            x for x in lines if ("completion_queue" not in x and "Kick failed" not in x)
         ]
         return "\n".join(lines)
 

--- a/tests/integration/helpers/client.py
+++ b/tests/integration/helpers/client.py
@@ -221,8 +221,17 @@ class CommandRequest:
         if not stderr:
             return stderr
         lines = stderr.split("\n")
+        def _is_trash(msg):
+            return (
+                "completion_queue" in msg or 
+                "Kick failed" in msg or 
+                # Can be returned as a warning in VM setups. Reference
+                # https://github.com/ClickHouse/ClickHouse/issues/45770
+                "Number of CPUs detected is not deterministic" in msg
+            )
+
         lines = [
-            x for x in lines if ("completion_queue" not in x and "Kick failed" not in x)
+            x for x in lines if not _is_trash(x)
         ]
         return "\n".join(lines)
 

--- a/tests/integration/helpers/client.py
+++ b/tests/integration/helpers/client.py
@@ -223,8 +223,8 @@ class CommandRequest:
         lines = stderr.split("\n")
         def _is_trash(msg):
             return (
-                "completion_queue" in msg or 
-                "Kick failed" in msg or 
+                "completion_queue" in msg or
+                "Kick failed" in msg or
                 # Can be returned as a warning in VM setups. Reference
                 # https://github.com/ClickHouse/ClickHouse/issues/45770
                 "Number of CPUs detected is not deterministic" in msg

--- a/tests/integration/test_storage_kafka/test_batch_slow_7.py
+++ b/tests/integration/test_storage_kafka/test_batch_slow_7.py
@@ -1,0 +1,113 @@
+"""Long running tests, longer than 30 seconds"""
+
+from helpers.kafka.common_direct import *
+import helpers.kafka.common as k
+
+cluster = ClickHouseCluster(__file__)
+instance = cluster.add_instance(
+    "instance",
+    main_configs=["configs/kafka.xml", "configs/named_collection.xml"],
+    user_configs=["configs/users.xml"],
+    with_kafka=True,
+    with_zookeeper=True,  # For Kafka2
+    macros={
+        "kafka_broker": "kafka1",
+        "kafka_topic_old": k.KAFKA_TOPIC_OLD,
+        "kafka_group_name_old": k.KAFKA_CONSUMER_GROUP_OLD,
+        "kafka_topic_new": k.KAFKA_TOPIC_NEW,
+        "kafka_group_name_new": k.KAFKA_CONSUMER_GROUP_NEW,
+        "kafka_client_id": "instance",
+        "kafka_format_json_each_row": "JSONEachRow",
+    },
+    clickhouse_path_dir="clickhouse_path",
+)
+
+
+# Fixtures
+@pytest.fixture(scope="module")
+def kafka_cluster():
+    try:
+        cluster.start()
+        kafka_id = instance.cluster.kafka_docker_id
+        print(("kafka_id is {}".format(kafka_id)))
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+@pytest.fixture(autouse=True)
+def kafka_setup_teardown():
+    instance.query("DROP DATABASE IF EXISTS test SYNC; CREATE DATABASE test;")
+    admin_client = k.get_admin_client(cluster)
+
+    def get_topics_to_delete():
+        return [t for t in admin_client.list_topics() if not t.startswith("_")]
+
+    topics = get_topics_to_delete()
+    logging.debug(f"Deleting topics: {topics}")
+    result = admin_client.delete_topics(topics)
+    for topic, error in result.topic_error_codes:
+        if error != 0:
+            logging.warning(f"Received error {error} while deleting topic {topic}")
+        else:
+            logging.info(f"Deleted topic {topic}")
+
+    retries = 0
+    topics = get_topics_to_delete()
+    while len(topics) != 0:
+        logging.info(f"Existing topics: {topics}")
+        if retries >= 5:
+            raise Exception(f"Failed to delete topics {topics}")
+        retries += 1
+        time.sleep(0.5)
+    yield  # run test
+
+
+# Tests
+
+@pytest.mark.parametrize(
+    "create_query_generator",
+    [k.generate_old_create_table_query, k.generate_new_create_table_query],
+)
+def test_kafka_consumer_reschedule_logging(kafka_cluster, create_query_generator):
+    """
+    Introspect that kafka_consumer_reschedule_ms is used to reschedule consumers.
+    """
+    suffix = k.random_string(6)
+    kafka_table = f"kafka_reschedule_log_{suffix}"
+    topic_name = f"test_reschedule_logging_{suffix}"
+
+    test_reschedule_ms = 250
+
+    create_query = create_query_generator(
+        kafka_table,
+        "key UInt64, value UInt64",
+        topic_list=topic_name,
+        consumer_group=topic_name,
+        settings={
+            "kafka_max_block_size": 100,
+            "kafka_flush_interval_ms": 100,
+            "kafka_consumer_reschedule_ms": test_reschedule_ms,
+        },
+    )
+
+    instance.query(f"""
+        {create_query};
+
+        CREATE MATERIALIZED VIEW test.{kafka_table}_destination
+        ENGINE=MergeTree ORDER BY tuple() AS
+        SELECT key, value FROM test.{kafka_table};
+    """)
+
+    messages = [json.dumps({"key": j, "value": j}) for j in range(50)]
+    k.kafka_produce(kafka_cluster, topic_name, messages)
+
+    # Wait for consumption and stall
+    instance.wait_for_log_line(f"{kafka_table}.*Committed offset 50")
+
+    # Check that the log shows the correct reschedule interval
+    instance.wait_for_log_line(f"{kafka_table}.*Rescheduling in {test_reschedule_ms} ms")
+
+    # Verify messages consumed
+    result = int(instance.query(f"SELECT count() FROM test.{kafka_table}_destination"))
+    assert result == 50


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add `kafka_consumer_reschedule_ms` as a tunable `Kafka` table engine setting in order to adjust how long consumers sleep for new data. Resolves #89204

### Documentation entry for user-facing changes
- [x] Documentation is written (mandatory for new features)

### Details
This pull request is to address this issue that I reported: https://github.com/ClickHouse/ClickHouse/issues/89204

Essentially, if one were to set `kafka_flush_interval_ms` to be quite low (say, 250ms), one would expect that data would make its way to the downstream table in ~250ms. However, this is not the case, even if ingestion is happening very quickly. The reason is because there is a hardcoded 500ms stall that happens (a) when a consumer sees no messages or (b) when 1 minute passes.

This means that ingestion can happen much later than expected, as noted in my investigation. To fix, allow end users to tune this param while keeping the 500ms default.
