### PR TITLE
Allow clickhouse-client config file in XDG-compliant location

### DIFF
--- a/docs/en/interfaces/cli.md
+++ b/docs/en/interfaces/cli.md
@@ -422,10 +422,22 @@ clickhouse-client
 
 #### Configuration file {#ai-sql-generation-configuration-file}
 
-For more control over AI settings, configure them in your ClickHouse Client configuration file located at:
+For more control over AI settings, configure them in your ClickHouse Client configuration file.
+The client now follows the XDG Base Directory Specification by default:
+
+If set, $XDG_CONFIG_HOME is used:
+- `$XDG_CONFIG_HOME/clickhouse-client/config.xml` (XML format)
+- `$XDG_CONFIG_HOME/clickhouse-client/config.yaml` (YAML format)
+  
+If `$XDG_CONFIG_HOME` is not set, ClickHouse will use:
+- `~/.config/clickhouse-client/config.xml` (XML format)
+- `~/.config/clickhouse-client/config.yaml` (YAML format)
+  
+Legacy fallback (still supported for backward compatibility):
 - `~/.clickhouse-client/config.xml` (XML format)
-- `~/.clickhouse-client/config.yaml` (YAML format)
-- Or specify a custom location with `--config-file`
+- `~/.clickhouse-client/config.yaml` (YAML format)`
+  
+You can always override the configuration path manually using `--config-file`
 
 <Tabs>
   <TabItem value="xml" label="XML" default>

--- a/src/Common/Config/getClientConfigPath.cpp
+++ b/src/Common/Config/getClientConfigPath.cpp
@@ -15,7 +15,7 @@ std::optional<std::string> getClientConfigPath(const std::string & home_path)
 
     std::vector<std::string> names;
     names.emplace_back("./clickhouse-client");
-    const char* xdg_config_home = std::getenv("XDG_CONFIG_HOME");
+    const char* xdg_config_home = std::getenv("XDG_CONFIG_HOME"); // NOLINT(concurrency-mt-unsafe)
     if (xdg_config_home && xdg_config_home[0] != '\0')
     {
         names.emplace_back(std::string(xdg_config_home) + "/clickhouse-client/config");

--- a/src/Common/Config/getClientConfigPath.cpp
+++ b/src/Common/Config/getClientConfigPath.cpp
@@ -25,8 +25,6 @@ std::optional<std::string> getClientConfigPath(const std::string & home_path)
         names.emplace_back(home_path + "/.config/clickhouse-client/config");
         names.emplace_back(home_path + "/.clickhouse-client/config");
     }
-    if (!home_path.empty())
-        names.emplace_back(home_path + "/.clickhouse-client/config");
     names.emplace_back("/etc/clickhouse-client/config");
 
     for (const auto & name : names)

--- a/src/Common/Config/getClientConfigPath.cpp
+++ b/src/Common/Config/getClientConfigPath.cpp
@@ -15,6 +15,16 @@ std::optional<std::string> getClientConfigPath(const std::string & home_path)
 
     std::vector<std::string> names;
     names.emplace_back("./clickhouse-client");
+    const char* xdg_config_home = std::getenv("XDG_CONFIG_HOME");
+    if (xdg_config_home && xdg_config_home[0] != '\0')
+    {
+        names.emplace_back(std::string(xdg_config_home) + "/clickhouse-client/config");
+    }
+    if (!home_path.empty())
+    {
+        names.emplace_back(home_path + "/.config/clickhouse-client/config");
+        names.emplace_back(home_path + "/.clickhouse-client/config");
+    }
     if (!home_path.empty())
         names.emplace_back(home_path + "/.clickhouse-client/config");
     names.emplace_back("/etc/clickhouse-client/config");


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Allow clickhouse-client config file in XDG-compliant location. Resolves #89882.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)
