### PR TITLE
CI: AST Fuzzer: Fetch commands for reproduction, improve ci report

### DIFF
--- a/ci/jobs/ast_fuzzer_job.py
+++ b/ci/jobs/ast_fuzzer_job.py
@@ -6,6 +6,7 @@ import sys
 from pathlib import Path
 
 from ci.jobs.scripts.docker_image import DockerImage
+from ci.jobs.scripts.generate_test import FuzzerTestGenerator
 from ci.jobs.scripts.stack_trace_reader import StackTraceReader
 from ci.praktika.info import Info
 from ci.praktika.result import Result
@@ -77,12 +78,13 @@ def main():
     fuzzer_log = workspace_path / "fuzzer.log"
     dmesg_log = workspace_path / "dmesg.log"
     fatal_log = workspace_path / "fatal.log"
+    server_log = workspace_path / "server.log"
     paths = [
         workspace_path / "core.zst",
         workspace_path / "dmesg.log",
         fatal_log,
         workspace_path / "stderr.log",
-        workspace_path / "server.log",
+        server_log,
         workspace_path / "fuzzer_out.sql",
         fuzzer_log,
         dmesg_log,
@@ -107,22 +109,52 @@ def main():
         ]
 
     if not result.is_ok():
-        info = f"Error: {result.name}\n"
-        info += "---\n\n"
+        info = ""
+        error_output = Shell.get_output(
+            f"rg --text -A 10 -o 'Received signal.*|Logical error.*|Assertion.*failed|Failed assertion.*|.*runtime error: .*|.*is located.*|(SUMMARY|ERROR): [a-zA-Z]+Sanitizer:.*|.*_LIBCPP_ASSERT.*|.*Child process was terminated by signal 9.*' {server_log} | head -n50"
+        )
+        if error_output:
+            error_lines = error_output.splitlines()
+            for i, line in enumerate(error_lines):
+                if "] {" in line and "} <" in line:
+                    error_lines = error_lines[:i]
+                    break
+            error_output = "\n".join(error_lines)
+            info += f"Error:\n{error_output}\n"
+
         if fuzzer_log.exists():
             fuzzer_query = StackTraceReader.get_fuzzer_query(fuzzer_log)
             if fuzzer_query:
-                info += f"Query: {fuzzer_query}"
                 info += "---\n\n"
+                info += f"Query: {fuzzer_query}\n"
 
-            info = "Fuzzer log (last 30 lines):\n" + Shell.get_output(
-                f"tail -n30 {fuzzer_log}", verbose=False
-            )
             info += "---\n\n"
+            info += (
+                "Fuzzer log (last 30 lines):\n"
+                + Shell.get_output(f"tail -n30 {fuzzer_log}", verbose=False)
+                + "\n"
+            )
+
         if fatal_log.exists():
             stack_trace = StackTraceReader.get_stack_trace(fatal_log)
             if stack_trace:
-                info += "Stack trace:\n" + stack_trace
+                info += "---\n\n"
+                info += "Stack trace:\n" + stack_trace + "\n"
+
+        info += "---\n\n"
+        try:
+            fuzzer_test_generator = FuzzerTestGenerator(
+                str(server_log), str(fuzzer_log)
+            )
+            reproduce_commands = fuzzer_test_generator.get_reproduce_commands()
+            if reproduce_commands:
+                info += (
+                    "Reproduce commands (in-progress, if not successful, please ping ci-team or fix yourself):\n"
+                    + "\n".join(reproduce_commands)
+                )
+        except Exception as e:
+            info += "Failed to generate reproduce commands: " + str(e)
+
         if result.results:
             result.results[-1].info = info
         else:

--- a/ci/jobs/ast_fuzzer_job.py
+++ b/ci/jobs/ast_fuzzer_job.py
@@ -149,7 +149,7 @@ def main():
             reproduce_commands = fuzzer_test_generator.get_reproduce_commands()
             if reproduce_commands:
                 info += (
-                    "Reproduce commands (in-progress, if not successful, please ping ci-team or fix yourself):\n"
+                    "Reproduce commands (auto-generated; may require manual adjustment). If you encounter issues, please contact the ci-team:\n"
                     + "\n".join(reproduce_commands)
                 )
         except Exception as e:

--- a/ci/jobs/scripts/generate_test.py
+++ b/ci/jobs/scripts/generate_test.py
@@ -1,0 +1,162 @@
+import re
+import sys
+
+sys.path.append(".")
+from ci.praktika.utils import Shell
+
+
+class FuzzerTestGenerator:
+    SQL_COMMANDS = [
+        "SELECT",
+        "INSERT",
+        "UPDATE",
+        "DELETE",
+        "CREATE",
+        "DROP",
+        "ALTER",
+        "WITH",
+        "EXPLAIN",
+        "DESCRIBE",
+        "SHOW",
+        "SET",
+        "OPTIMIZE",
+        "SYSTEM",
+        "DETACH",
+        "ATTACH",
+        "FUNCTION",
+    ]
+
+    def __init__(self, server_log, fuzzer_log):
+        self.server_log = server_log
+        self.fuzzer_log = fuzzer_log
+
+    def get_reproduce_commands(self):
+
+        # get query command
+        failure_output = Shell.get_output(
+            f"cat {self.server_log} | grep -A10 'Logical error:'"
+        )
+        assert failure_output, "No failure found in server log"
+        failure_first_line = failure_output.splitlines()[0]
+        assert failure_first_line, "No failure first line found in server log"
+        query_id = failure_first_line.split(" ] {")[1].split("}")[0]
+        assert query_id, "No query id found in server log"
+        query_comand = Shell.get_output(
+            f"cat {self.server_log} | grep '{query_id}' | head -n1"
+        )
+        assert query_comand, "No query command found in server log"
+        query_comand = query_comand.split(" (stage:")[0]
+        sql_keywords = [
+            "SELECT",
+            "INSERT",
+            "UPDATE",
+            "DELETE",
+            "CREATE",
+            "DROP",
+            "ALTER",
+            "WITH",
+            "EXPLAIN",
+            "DESCRIBE",
+            "SHOW",
+            "SET",
+        ]
+        for keyword in sql_keywords:
+            if keyword in query_comand:
+                keyword_pos = query_comand.find(keyword)
+                query_comand = query_comand[keyword_pos:]
+                break
+        else:
+            raise Exception("No SQL keyword found in query command")
+
+        all_fuzzer_commands = self._get_all_fuzzer_commands()
+        assert all_fuzzer_commands, "No fuzzer commands found"
+        assert (
+            query_comand in all_fuzzer_commands
+        ), f"Query command '{query_comand}' not found in fuzzer log"
+        all_fuzzer_commands = all_fuzzer_commands[
+            : list.index(all_fuzzer_commands, query_comand)
+        ]
+
+        # get all tabels from the command
+        # Match table names after FROM and various JOIN types (LEFT JOIN, RIGHT JOIN, INNER JOIN, etc.)
+        tabeles = set()
+        from_pattern = r"\bFROM\s+([a-zA-Z0-9_]+)"
+        join_pattern = r"\bJOIN\s+([a-zA-Z0-9_]+)"
+        from_matches = re.findall(from_pattern, query_comand, re.IGNORECASE)
+        join_matches = re.findall(join_pattern, query_comand, re.IGNORECASE)
+        tabeles.update(from_matches)
+        tabeles.update(join_matches)
+        assert tabeles, "No tables found in query command"
+
+        # get all write commands for found tabels
+        commands_to_reproduce = []
+        for table in tabeles:
+            for command in all_fuzzer_commands:
+                if any(
+                    command.startswith(read_cmd) for read_cmd in ["SELECT", "EXPLAIN"]
+                ):
+                    continue
+                if f" {table} " in command:
+                    commands_to_reproduce.append(command)
+        assert commands_to_reproduce, "No write commands found for tables"
+        commands_to_reproduce.append(query_comand)
+
+        # add table drop commands
+        for table in tabeles:
+            commands_to_reproduce.append(f"DROP TABLE {table}")
+
+        return commands_to_reproduce
+
+    def _get_all_fuzzer_commands(self):
+        lines = Shell.get_output(f"cat {self.fuzzer_log}").splitlines()
+        result = []
+        for line in lines:
+            if line.startswith("Error") or line.startswith("[") or not line.strip():
+                continue
+            if re.match(r"^\d+\.", line):
+                continue
+            if any(
+                line.startswith(cmd)
+                for cmd in [
+                    "Fuzzing step",
+                    "Query succeeded",
+                    "Dump of fuzzed AST",
+                    "Got boring AST",
+                    "Using seed",
+                    "Left type:",
+                    "Timeout exceeded",
+                    "input block structure:",
+                    "Code:",
+                ]
+            ):
+                continue
+            result.append(line)
+
+        result_with_joned_multiline_commands = []
+        for line in result:
+            if any(line.startswith(cmd) for cmd in self.SQL_COMMANDS):
+                result_with_joned_multiline_commands.append(line)
+            elif line.startswith("("):
+                result_with_joned_multiline_commands[-1] += " " + line
+            else:
+                assert (
+                    False
+                ), f"Unknown line: '{line}' | '{result_with_joned_multiline_commands[-1]}'"
+
+        # sanity check
+        for command in result_with_joned_multiline_commands:
+            assert any(
+                command.startswith(sql_cmd) for sql_cmd in self.SQL_COMMANDS
+            ), f"No SQL command found in command: {command}"
+        return result_with_joned_multiline_commands
+
+    def generate_test(self):
+        pass
+
+
+if __name__ == "__main__":
+    fuzzer_log = "fuzzer.log"
+    server_log = "server.log"
+    print(
+        "\n".join(FuzzerTestGenerator(server_log, fuzzer_log).get_reproduce_commands())
+    )

--- a/ci/jobs/scripts/stack_trace_reader.py
+++ b/ci/jobs/scripts/stack_trace_reader.py
@@ -49,9 +49,21 @@ class StackTraceReader(object):
         last_lines = all_lines[-max_lines:] if len(all_lines) > max_lines else all_lines
 
         # Read backwards to find the last line that starts with SELECT
+        sql_keywords = (
+            "SELECT",
+            "INSERT",
+            "UPDATE",
+            "DELETE",
+            "CREATE",
+            "DROP",
+            "ALTER",
+            "TRUNCATE",
+            "WITH",
+        )
         for line in reversed(last_lines):
-            if line.strip().startswith("SELECT"):
-                return line.strip()
+            stripped = line.strip()
+            if any(stripped.startswith(keyword) for keyword in sql_keywords):
+                return stripped
         return None
 
 

--- a/ci/jobs/scripts/stack_trace_reader.py
+++ b/ci/jobs/scripts/stack_trace_reader.py
@@ -11,7 +11,7 @@ class StackTraceReader(object):
         lines = []
         stack_trace_pattern = re.compile(r"<Fatal> BaseDaemon: \d{1,2}\. ")
 
-        with open(file_path, "r") as file:
+        with open(file_path, "r", errors="replace") as file:
             all_lines = file.readlines()
 
         # Only process last max_lines lines
@@ -42,7 +42,7 @@ class StackTraceReader(object):
     def get_fuzzer_query(fuzzer_log, max_lines=200):
         assert Path(fuzzer_log).is_file(), f"File {fuzzer_log} does not exist"
 
-        with open(fuzzer_log, "r") as file:
+        with open(fuzzer_log, "r", errors="replace") as file:
             all_lines = file.readlines()
 
         # Only process last max_lines lines


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Details
Fetches fatal query and queries required to prepare data from server and fuzzer log.
Prints commnd in the report.
Applies following format for AST fuzzer error in CI report:
```
Error: ...
---

Query: ...
---

Fuzzer log (last 30 lines):
...
---

Stack trace:
...
---

Reproduction commands:
...
---
```
