### PR TITLE
CI: Add PyYAML dependency to stateless-test docker image

### DIFF
--- a/ci/docker/stateless-test/requirements.txt
+++ b/ci/docker/stateless-test/requirements.txt
@@ -7,6 +7,7 @@ pyarrow==22.0.0
 grpcio==1.60.0
 protobuf==4.25.8
 psutil
+PyYAML==6.0.2
 
 # for targeted job
 unidiff==0.7.5


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Details

Fixes SQL test job on master
`ModuleNotFoundError: No module named 'yaml'`
