### PR TITLE
Fix: do not attempt to convert constants in LIMIT/OFFSET expression to scalar.

### DIFF
--- a/src/Storages/buildQueryTreeForShard.cpp
+++ b/src/Storages/buildQueryTreeForShard.cpp
@@ -284,6 +284,16 @@ public:
             if (function_node->getParametersNode() == child)
                 return false;
         }
+
+        if (auto * query_node = parent->as<QueryNode>())
+        {
+            // Do not visit LIMIT and OFFSET nodes
+            if (query_node->hasLimit() && query_node->getLimit() == child)
+                return false;
+            if (query_node->hasOffset() && query_node->getOffset() == child)
+                return false;
+        }
+
         return true;
     }
 

--- a/tests/queries/0_stateless/03720_const_limit_to_scalar.sql
+++ b/tests/queries/0_stateless/03720_const_limit_to_scalar.sql
@@ -1,0 +1,17 @@
+-- Tags: distributed
+
+-- https://github.com/ClickHouse/ClickHouse/issues/89607
+
+DROP TABLE IF EXISTS t0;
+DROP TABLE IF EXISTS t1;
+
+CREATE TABLE t0 (c0 Int) ENGINE = MergeTree() ORDER BY tuple();
+CREATE TABLE t1 ENGINE = Distributed(test_shard_localhost, currentDatabase(), 't0');
+
+SELECT c0 FROM t1 OFFSET -10 ROWS SETTINGS optimize_const_name_size = 1;
+SELECT c0 FROM t1 OFFSET 10 ROWS SETTINGS optimize_const_name_size = 1;
+SELECT c0 FROM t1 LIMIT -10 SETTINGS optimize_const_name_size = 1;
+SELECT c0 FROM t1 LIMIT 10 SETTINGS optimize_const_name_size = 1;
+
+DROP TABLE IF EXISTS t0;
+DROP TABLE IF EXISTS t1;


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Do not apply constant node optimization to LIMIT/OFFSET expression. Fixes #89607.

### Details
Fixes #89607
