### PR TITLE
Adds asynchronous remote query cancellation support

### DIFF
--- a/src/Processors/Sources/RemoteSource.cpp
+++ b/src/Processors/Sources/RemoteSource.cpp
@@ -101,7 +101,8 @@ ISource::Status RemoteSource::prepare()
     /// RemoteQueryExecutor it should be finished explicitly.
     if (status == Status::Finished)
     {
-        switch (drain_status) {
+        switch (drain_status)
+        {
             case DrainStatus::NoDrain:
                 is_async_state = false;
                 drain_status = DrainStatus::NeedDrain;

--- a/src/Processors/Sources/RemoteSource.h
+++ b/src/Processors/Sources/RemoteSource.h
@@ -47,7 +47,18 @@ protected:
 
 private:
     std::atomic_bool was_query_sent = false;
-    bool need_drain = false;
+    enum class DrainStatus
+    {
+        /// Do not need to call the drain process
+        NoDrain,
+        /// The prepare function transitions status from NoDrain to NeedDrain, which the work function then reads and processes.
+        NeedDrain,
+        /// Changes status from NeedDrain to Draining, marking the transition where readAsync processes post-cancel packets.
+        Draining,
+        /// After consuming all post-cancel packets, the work function transitions drain_status to Drained, signaling drain completion
+        Drained,
+    };
+    DrainStatus drain_status = DrainStatus::NoDrain;
     bool executor_finished = false;
     bool add_aggregation_info = false;
     RemoteQueryExecutorPtr query_executor;

--- a/src/QueryPipeline/RemoteQueryExecutor.cpp
+++ b/src/QueryPipeline/RemoteQueryExecutor.cpp
@@ -858,7 +858,10 @@ bool RemoteQueryExecutor::finish()
         }
         return false;
     }
+
+#if defined (OS_LINUX)
     return true;
+#endif
 }
 
 void RemoteQueryExecutor::cancel()
@@ -1054,6 +1057,7 @@ bool RemoteQueryExecutor::processParallelReplicaPacketIfAny()
     return false;
 }
 
+#if defined(OS_LINUX)
 bool RemoteQueryExecutor::hasDrainingPackets()
 {
     chassert(connections);
@@ -1072,5 +1076,6 @@ void RemoteQueryExecutor::finalizeAsyncCancel()
     if (log)
         LOG_TRACE(log, "consumed all of the remaining packets after sendCancel from {}", connections_addresses);
 }
+#endif
 
 }

--- a/src/QueryPipeline/RemoteQueryExecutor.h
+++ b/src/QueryPipeline/RemoteQueryExecutor.h
@@ -187,7 +187,7 @@ public:
     /// It should be cancelled after read returned empty block.
     ///
     /// If async_cancel is set, it will not receive all remain packets. The remaining packets
-    /// shoule be received in the readAsync
+    /// should be received in the readAsync
     ///
     /// Returns true iff the remaining packets should be received in the readAsync
     bool finish();

--- a/src/QueryPipeline/RemoteQueryExecutor.h
+++ b/src/QueryPipeline/RemoteQueryExecutor.h
@@ -360,6 +360,7 @@ public:
     /// If it is set, it will cancel the remote query in fiber
     const bool async_cancel = false;
 
+#if defined(OS_LINUX)
     /// Used for logging in the finalizeAsyncCancel, because when finalizeAsyncCancel is called, all of
     /// the connections have dropped and we can not get the addresses info from the connections anymore
     String connections_addresses;
@@ -370,6 +371,7 @@ public:
     /// This function is called when all of the remaining packets after the async sendCancel have been consumed.
     /// Used to cancel the fiber task
     void finalizeAsyncCancel();
+#endif
 };
 
 }

--- a/src/QueryPipeline/RemoteQueryExecutorReadContext.cpp
+++ b/src/QueryPipeline/RemoteQueryExecutorReadContext.cpp
@@ -64,6 +64,13 @@ void RemoteQueryExecutorReadContext::Task::run(AsyncCallback async_callback, Sus
             read_context.has_read_packet_part = PacketPart::Type;
             suspend_callback();
         }
+        if (read_context.executor.async_cancel && read_context.isAsyncCancelled() && !read_context.is_async_cancel_sent)
+        {
+            auto & connections = read_context.executor.getConnections();
+            AsyncCallbackSetter<IConnections> async_setter(&connections, async_callback);
+            connections.sendCancel();
+            read_context.is_async_cancel_sent = true;
+        }
         read_context.packet = read_context.executor.getConnections().receivePacketUnlocked(async_callback);
         read_context.has_read_packet_part = PacketPart::Body;
         suspend_callback();

--- a/src/QueryPipeline/RemoteQueryExecutorReadContext.h
+++ b/src/QueryPipeline/RemoteQueryExecutorReadContext.h
@@ -108,6 +108,12 @@ private:
     bool suspend_when_query_sent = false;
     bool is_query_sent = false;
     const bool read_packet_type_separately = false;
+    bool is_async_cancel_sent = false;
+    std::atomic_bool is_async_cancelling = false;
+
+public:
+    void asyncCancel() { is_async_cancelling = true; }
+    bool isAsyncCancelled() { return is_async_cancelling; }
 };
 
 }

--- a/src/QueryPipeline/RemoteQueryExecutorReadContext.h
+++ b/src/QueryPipeline/RemoteQueryExecutorReadContext.h
@@ -113,7 +113,7 @@ private:
 
 public:
     void asyncCancel() { is_async_cancelling = true; }
-    bool isAsyncCancelled() { return is_async_cancelling; }
+    bool isAsyncCancelled() const { return is_async_cancelling; }
 };
 
 }


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Adds asynchronous remote query cancellation support. Resolves #77597

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

### Details

Currently, cancelling a remote query is a synchronous operation. The pipeline executor can cancel up to `max_threads` queries in parallel, but it must then drain the remaining packets from each connection (for reuse) serially. This draining process can be slow, creating a significant performance bottleneck when dealing with large clusters. Issue https://github.com/ClickHouse/ClickHouse/issues/77597 has also mentioned this problem.

This PR changes the cancellation process to be fully asynchronous. Instead of waiting for each connection to be drained serially after cancellation, the pipeline executor can now signal cancellation for all remote queries simultaneously and then drain the connections in parallel (up to `max_threads`).

**Key Changes:**
- The `sendCancel` request is now performed within the fiber coroutine.
- The subsequent draining of packets from the connection is handled by the pipeline-executor threads, allowing the coroutine to resume other work without blocking.
- This ensures that all cancellations are fired rapidly and the subsequent draining of connections happens concurrently, minimizing the overall delay.
