### PR TITLE
Show schema for parameterized_view

### DIFF
--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <Poco/UUID.h>
 #include <Poco/Util/Application.h>
+#include <Common/quoteString.h>
 #include <Common/setThreadName.h>
 #include <Common/ISlotControl.h>
 #include <Common/Scheduler/IResourceManager.h>
@@ -399,6 +400,7 @@ namespace ErrorCodes
     extern const int SET_NON_GRANTED_ROLE;
     extern const int UNKNOWN_DISK;
     extern const int UNKNOWN_READ_METHOD;
+    extern const int TYPE_MISMATCH;
 }
 
 #define SHUTDOWN(log, desc, ptr, method) do             \
@@ -2795,9 +2797,30 @@ StoragePtr Context::buildParameterizedViewStorage(const String & database_name, 
 
     auto view_context = original_view_metadata->getSQLSecurityOverriddenContext(shared_from_this());
     auto sample_block = InterpreterSelectQueryAnalyzer::getSampleBlock(query, view_context);
+
+    /* Check that the actual schema matches the defined one (if any) */
+    auto actual_names_and_types = sample_block->getNamesAndTypesList();
+    const auto original_defined_columns = original_view_metadata->getColumns();
+    if (!original_defined_columns.empty())
+    {
+        auto throw_schema_mismatch = [table_name]() {
+            throw Exception(ErrorCodes::TYPE_MISMATCH,
+            "After parameters substitution of parameterized view {} the actual schema does not match the defined one",
+            backQuote(table_name));
+        };
+        if (original_defined_columns.size() != actual_names_and_types.size())
+            throw_schema_mismatch();
+
+        for (auto [defined_column, actual_column] : llvm::zip(original_defined_columns.getAll(), actual_names_and_types))
+        {
+            if (defined_column.name != actual_column.name || defined_column.type->getName() != actual_column.type->getName())
+                throw_schema_mismatch();
+        }
+    }
+
     auto res = std::make_shared<StorageView>(StorageID(database_name, table_name),
                                                 create,
-                                                ColumnsDescription(sample_block->getNamesAndTypesList()),
+                                                ColumnsDescription(actual_names_and_types),
             /* comment */ "",
             /* is_parameterized_view */ true);
     res->startup();

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -2803,10 +2803,12 @@ StoragePtr Context::buildParameterizedViewStorage(const String & database_name, 
     const auto original_defined_columns = original_view_metadata->getColumns();
     if (!original_defined_columns.empty())
     {
-        auto throw_schema_mismatch = [table_name]() {
-            throw Exception(ErrorCodes::TYPE_MISMATCH,
-            "After parameters substitution of parameterized view {} the actual schema does not match the defined one",
-            backQuote(table_name));
+        auto throw_schema_mismatch = [table_name]()
+        {
+            throw Exception(
+                ErrorCodes::TYPE_MISMATCH,
+                "After parameters substitution of parameterized view {} the actual schema does not match the defined one",
+                backQuote(table_name));
         };
         if (original_defined_columns.size() != actual_names_and_types.size())
             throw_schema_mismatch();

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -2813,7 +2813,7 @@ StoragePtr Context::buildParameterizedViewStorage(const String & database_name, 
         if (original_defined_columns.size() != actual_names_and_types.size())
             throw_schema_mismatch();
 
-        for (auto [defined_column, actual_column] : llvm::zip(original_defined_columns.getAll(), actual_names_and_types))
+        for (const auto [defined_column, actual_column] : std::views::zip(original_defined_columns.getAll(), actual_names_and_types))
         {
             if (defined_column.name != actual_column.name || defined_column.type->getName() != actual_column.type->getName())
                 throw_schema_mismatch();

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -887,7 +887,19 @@ InterpreterCreateQuery::TableProperties InterpreterCreateQuery::getTableProperti
     else if (create.select)
     {
         if (create.isParameterizedView())
+        {
+            // For parameterized views, extract columns if explicitly declared
+            if (create.columns_list && create.columns_list->columns)
+            {
+                properties.columns = getColumnsDescription(
+                    *create.columns_list->columns,
+                    getContext(),
+                    mode,
+                    is_restore_from_backup
+                );
+            }
             return properties;
+        }
 
         if (create.aliases_list)
         {

--- a/src/Storages/StorageView.cpp
+++ b/src/Storages/StorageView.cpp
@@ -128,7 +128,8 @@ StorageView::StorageView(
     if (!is_parameterized_view_)
     {
         /// If CREATE query is to create parameterized view, then we dont want to set columns
-        if (!query.isParameterizedView())
+        /// if thed don't specified explicitly.
+        if (!query.isParameterizedView() || !columns_.empty())
             storage_metadata.setColumns(columns_);
     }
     else

--- a/src/Storages/StorageView.cpp
+++ b/src/Storages/StorageView.cpp
@@ -128,7 +128,7 @@ StorageView::StorageView(
     if (!is_parameterized_view_)
     {
         /// If CREATE query is to create parameterized view, then we dont want to set columns
-        /// if thed don't specified explicitly.
+        /// if they aren't specified explicitly.
         if (!query.isParameterizedView() || !columns_.empty())
             storage_metadata.setColumns(columns_);
     }

--- a/src/Storages/StorageView.cpp
+++ b/src/Storages/StorageView.cpp
@@ -125,14 +125,9 @@ StorageView::StorageView(
     : IStorage(table_id_)
 {
     StorageInMemoryMetadata storage_metadata;
-    if (!is_parameterized_view_)
-    {
-        /// If CREATE query is to create parameterized view, then we dont want to set columns
-        /// if they aren't specified explicitly.
-        if (!query.isParameterizedView() || !columns_.empty())
-            storage_metadata.setColumns(columns_);
-    }
-    else
+    // Set columns if provided (regardless of whether view is parameterized)
+    // For parameterized views without explicit columns, columns_ will be empty
+    if (!columns_.empty())
         storage_metadata.setColumns(columns_);
 
     storage_metadata.setComment(comment);

--- a/tests/queries/0_stateless/03721_parametrize_view_schema.reference
+++ b/tests/queries/0_stateless/03721_parametrize_view_schema.reference
@@ -1,0 +1,5 @@
+1
+n	UInt64	NO		\N	
+2
+3
+default	03271_parametrized_v_expl	n	UInt64	1			0	0	0		0	0	0	0		\N	64	2	0	\N	\N	

--- a/tests/queries/0_stateless/03721_parametrize_view_schema.reference
+++ b/tests/queries/0_stateless/03721_parametrize_view_schema.reference
@@ -1,5 +1,26 @@
-1
+SEPARATOR 1
 n	UInt64	NO		\N	
-2
-3
+SEPARATOR 2
+SEPARATOR 3
 default	03271_parametrized_v_expl	n	UInt64	1			0	0	0		0	0	0	0		\N	64	2	0	\N	\N	
+SEPARATOR 4
+SEPARATOR 5
+SelectWithUnionQuery (children 1)
+ ExpressionList (children 1)
+  SelectQuery (children 2)
+   ExpressionList (children 1)
+    Asterisk
+   TablesInSelectQuery (children 1)
+    TablesInSelectQueryElement (children 1)
+     TableExpression (children 1)
+      Function 03271_parametrized_v_expl_mismatch (children 1)
+       ExpressionList (children 1)
+        Function equals (children 1)
+         ExpressionList (children 2)
+          Identifier upper_bound
+          Literal UInt64_3
+SEPARATOR 6
+SEPARATOR 7
+0
+1
+2

--- a/tests/queries/0_stateless/03721_parametrize_view_schema.sql
+++ b/tests/queries/0_stateless/03721_parametrize_view_schema.sql
@@ -1,3 +1,5 @@
+SET enable_analyzer = 1;
+
 CREATE VIEW 03271_parametrized_v AS
 SELECT number AS n
 FROM numbers({upper_bound:UInt64});

--- a/tests/queries/0_stateless/03721_parametrize_view_schema.sql
+++ b/tests/queries/0_stateless/03721_parametrize_view_schema.sql
@@ -10,24 +10,53 @@ FROM numbers({upper_bound:UInt64});
 SHOW COLUMNS IN 03271_parametrized_v;
 
 -- Separator
-SELECT 1 AS separator;
+SELECT 'SEPARATOR 1';
 
 -- Should return one column 'n' of type 'UInt64'
 SHOW COLUMNS IN 03271_parametrized_v_expl;
 
 -- Separator
-SELECT 2 AS separator;
+SELECT 'SEPARATOR 2';
 
 SELECT *
 FROM system.columns
-WHERE table = '03271_parametrized_v';
+WHERE table = '03271_parametrized_v' AND database = currentDatabase();
 
 -- Separator
-SELECT 3 AS separator;
+SELECT 'SEPARATOR 3';
 
 SELECT *
 FROM system.columns
-WHERE table = '03271_parametrized_v_expl';
+WHERE table = '03271_parametrized_v_expl' AND database = currentDatabase();
+
+-- Separator
+SELECT 'SEPARATOR 4';
+
+-- Mismatched schema: should return error on query tree building
+CREATE VIEW 03271_parametrized_v_expl_mismatch (n UInt64, s String) AS
+SELECT number AS n
+FROM numbers({upper_bound:UInt64});
+
+SELECT *
+FROM 03271_parametrized_v_expl_mismatch(upper_bound = 3); -- { serverError TYPE_MISMATCH }
+
+-- Separator
+SELECT 'SEPARATOR 5';
+
+EXPLAIN AST SELECT *
+FROM 03271_parametrized_v_expl_mismatch(upper_bound = 3);
+
+-- Separator
+SELECT 'SEPARATOR 6';
+
+EXPLAIN QUERY TREE SELECT *
+FROM 03271_parametrized_v_expl_mismatch(upper_bound = 3); -- { serverError TYPE_MISMATCH }
+
+SELECT 'SEPARATOR 7';
+
+SELECT *
+FROM 03271_parametrized_v_expl(upper_bound = 3);
 
 DROP VIEW 03271_parametrized_v;
 DROP VIEW 03271_parametrized_v_expl;
+DROP VIEW 03271_parametrized_v_expl_mismatch;

--- a/tests/queries/0_stateless/03721_parametrize_view_schema.sql
+++ b/tests/queries/0_stateless/03721_parametrize_view_schema.sql
@@ -1,0 +1,33 @@
+CREATE VIEW 03271_parametrized_v AS
+SELECT number AS n
+FROM numbers({upper_bound:UInt64});
+
+CREATE VIEW 03271_parametrized_v_expl (n UInt64) AS
+SELECT number AS n
+FROM numbers({upper_bound:UInt64});
+
+-- Should return no columns
+SHOW COLUMNS IN 03271_parametrized_v;
+
+-- Separator
+SELECT 1 AS separator;
+
+-- Should return one column 'n' of type 'UInt64'
+SHOW COLUMNS IN 03271_parametrized_v_expl;
+
+-- Separator
+SELECT 2 AS separator;
+
+SELECT *
+FROM system.columns
+WHERE table = '03271_parametrized_v';
+
+-- Separator
+SELECT 3 AS separator;
+
+SELECT *
+FROM system.columns
+WHERE table = '03271_parametrized_v_expl';
+
+DROP VIEW 03271_parametrized_v;
+DROP VIEW 03271_parametrized_v_expl;


### PR DESCRIPTION
Show the schema of a parameterized view when it's explicitly specified.

<!--- Disable AI PR formatting assistant: false -->

### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
If the schema of parameterized view is specified explicitly it is shown. Close https://github.com/ClickHouse/ClickHouse/issues/88875, https://github.com/ClickHouse/ClickHouse/issues/81385

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.576`
<!-- ch-version-info:end -->