### PR TITLE
Bug fix: handle implicit conversion from string in logical expression optimizer

### DIFF
--- a/src/Analyzer/Passes/LogicalExpressionOptimizerPass.cpp
+++ b/src/Analyzer/Passes/LogicalExpressionOptimizerPass.cpp
@@ -6,13 +6,14 @@
 #include <Analyzer/InDepthQueryTreeVisitor.h>
 #include <Analyzer/JoinNode.h>
 #include <Analyzer/Utils.h>
+#include <Common/FieldAccurateComparison.h>
 #include <Core/Settings.h>
 #include <DataTypes/DataTypeLowCardinality.h>
+#include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypeTuple.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <Functions/FunctionFactory.h>
-
-#include <iostream>
+#include <Interpreters/convertFieldToType.h>
 
 namespace DB
 {
@@ -931,12 +932,32 @@ private:
 
             if (function_name == "equals")
             {
+                /*
+                 * This function checks a pattern of `col = X and col = Y` such that if there are two different constant values are assigned for the same expression.
+                 * That pattern always yields to `FALSE`, except implicit conversion from a string to an integer / a boolean
+                 * which the pattern could be `col = X and col = 'X'`. In such cases, constant values are same.
+                 */
                 const auto has_and_with_different_constant = [&](const QueryTreeNodePtr & expression, const ConstantNode * constant)
                 {
+                    /// This is an implicit conversion from a string to the type of an constant node (`expected`).
+                    const auto convert_and_check_equals = [](const ConstantNode * string_value, const ConstantNode * expected)
+                    {
+                        Field converted = tryConvertFieldToType(string_value->getValue(), *expected->getResultType());
+                        if (!converted.isNull())
+                            return accurateEquals(converted, expected->getValue());
+                        return false;
+                    };
+
                     if (auto it = equals_node_to_constants.find(expression); it != equals_node_to_constants.end())
                     {
                         if (!it->second->isEqual(*constant))
+                        {
+                            if (it->second->getResultType()->equals(DataTypeString()) && convert_and_check_equals(it->second, constant))
+                                return false;
+                            else if (constant->getResultType()->equals(DataTypeString()) && convert_and_check_equals(constant, it->second))
+                                return false;
                             return true;
+                        }
                     }
                     else
                     {

--- a/tests/queries/0_stateless/02477_logical_expressions_optimizer_issue_89803.reference
+++ b/tests/queries/0_stateless/02477_logical_expressions_optimizer_issue_89803.reference
@@ -1,0 +1,26 @@
+Integer
+Negative checks
+0
+0
+0
+Positive checks
+1
+1
+1
+1
+1
+1
+Boolean
+Negative checks
+0
+0
+0
+Positive checks
+1
+1
+1
+1
+1
+1
+1
+1

--- a/tests/queries/0_stateless/02477_logical_expressions_optimizer_issue_89803.sql
+++ b/tests/queries/0_stateless/02477_logical_expressions_optimizer_issue_89803.sql
@@ -1,0 +1,61 @@
+-- Github issue 89803
+
+SELECT 'Integer';
+
+DROP TABLE IF EXISTS tab_int;
+CREATE TABLE tab_int
+(
+    `col_int` UInt64
+)
+ENGINE = MergeTree
+ORDER BY tuple();
+
+INSERT INTO tab_int VALUES (1), (2);
+
+SELECT 'Negative checks';
+SELECT count() FROM tab_int WHERE col_int = 1 AND col_int = 2;
+SELECT count() FROM tab_int WHERE col_int = 1 AND col_int = '2';
+SELECT count() FROM tab_int WHERE col_int = '1' AND col_int = 2;
+
+SELECT 'Positive checks';
+SELECT count() FROM tab_int WHERE col_int = 1;
+SELECT count() FROM tab_int WHERE col_int = '1';
+
+SELECT count() FROM tab_int WHERE col_int = 1 AND col_int = '1';
+SELECT count() FROM tab_int WHERE col_int = '1' AND col_int = 1;
+
+SELECT count() FROM tab_int WHERE col_int = '1' AND (col_int = 1 OR col_int = 2);
+SELECT count() FROM tab_int WHERE (col_int = 1 OR col_int = 2) AND col_int = '1';
+
+DROP TABLE tab_int;
+
+SELECT 'Boolean';
+
+DROP TABLE IF EXISTS tab_bool;
+CREATE TABLE tab_bool
+(
+    `col_bool` Boolean
+)
+ENGINE = MergeTree
+ORDER BY tuple();
+
+INSERT INTO tab_bool VALUES (true), (false);
+
+SELECT 'Negative checks';
+SELECT count() FROM tab_bool WHERE col_bool = true AND col_bool = false;
+SELECT count() FROM tab_bool WHERE col_bool = true AND col_bool = 'false';
+SELECT count() FROM tab_bool WHERE col_bool = 'true' AND col_bool = false;
+
+SELECT 'Positive checks';
+SELECT count() FROM tab_bool WHERE col_bool = true;
+SELECT count() FROM tab_bool WHERE col_bool = 'true';
+SELECT count() FROM tab_bool WHERE col_bool = false;
+SELECT count() FROM tab_bool WHERE col_bool = 'false';
+
+SELECT count() FROM tab_bool WHERE col_bool = true AND col_bool = 'true';
+SELECT count() FROM tab_bool WHERE col_bool = 'true' AND col_bool = true;
+
+SELECT count() FROM tab_bool WHERE col_bool = false AND col_bool = 'false';
+SELECT count() FROM tab_bool WHERE col_bool = 'false' AND col_bool = false;
+
+DROP TABLE tab_bool;


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Handle implicit conversion from a string to an integer or a boolean in `LogicalExpressionOptimizerPass`. Resolves #89803

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

### Details

The pattern of `col = X and col = Y` is assumed to yield to `ALWAYS_FALSE` which is true for almost all cases. However, in case of an implicit conversion from a string to an integer or a boolean that assumption drops since `col = X and col = 'X'` should be the same.

Fixes #89803
