### PR TITLE
Print thread name string, not enum

### DIFF
--- a/src/Core/BackgroundSchedulePool.cpp
+++ b/src/Core/BackgroundSchedulePool.cpp
@@ -131,7 +131,7 @@ void BackgroundSchedulePoolTaskInfo::execute(BackgroundSchedulePool & pool)
     }
 
     /// Using this tmp query_id storage to prevent bad_alloc thrown under the try/catch.
-    std::string task_query_id = fmt::format("{}::{}", pool.thread_name, UUIDHelpers::generateV4());
+    std::string task_query_id = fmt::format("{}::{}", toString(pool.thread_name), UUIDHelpers::generateV4());
 
     try
     {


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Print thread name string, not enum

It seems that after https://github.com/ClickHouse/ClickHouse/pull/89475 we were printing `BACKGROUND_SCHEDULE_POOL::ad9a7c56-d815-487d-a078-dd7156f71f50` which is too verbose. Go back to `BgSchPool::4fb74df6-ad6e-45b1-a82b-39d4557f13a4` style


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
