### PR TITLE
Fix incorrect skip indexes breaking Replicated Database

### DIFF
--- a/src/Storages/extractKeyExpressionList.cpp
+++ b/src/Storages/extractKeyExpressionList.cpp
@@ -21,7 +21,7 @@ namespace DB
 
         /// Primary key consists of one column.
         auto res = std::make_shared<ASTExpressionList>();
-        res->children.push_back(node);
+        res->children.push_back(node->clone());
         return res;
     }
 }

--- a/tests/integration/test_replicated_database/test.py
+++ b/tests/integration/test_replicated_database/test.py
@@ -1864,6 +1864,20 @@ def test_block_system_database_replicas(started_cluster):
     )
 
 
+def test_correct_skip_indexes(started_cluster):
+    competing_node.query("DROP DATABASE IF EXISTS correct_skip_indexes")
+    dummy_node.query("DROP DATABASE IF EXISTS correct_skip_indexes")
+
+    competing_node.query(
+        "CREATE DATABASE correct_skip_indexes ENGINE = Replicated('/clickhouse/databases/correct_skip_indexes', 'shard1', 'replica1');"
+        "CREATE TABLE correct_skip_indexes.test (`id` UInt64, `a` String, `b` String ALIAS a, INDEX bf_a assumeNotNull(b) TYPE bloom_filter(0.01) GRANULARITY 1) ENGINE = ReplicatedMergeTree ORDER BY (id);"
+    )
+    dummy_node.query(
+        "CREATE DATABASE correct_skip_indexes ENGINE = Replicated('/clickhouse/databases/correct_skip_indexes', 'shard1', 'replica2');"
+        "SYSTEM SYNC DATABASE REPLICA correct_skip_indexes;"
+    )
+
+
 def test_implicit_index(started_cluster):
     competing_node.query("DROP DATABASE IF EXISTS implicit_index")
     dummy_node.query("DROP DATABASE IF EXISTS implicit_index")


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix incorrect formatting of certain skip indexes in the table definition, causing `METADATA_MISMATCH` and breaking creation of new replicas in the Replicated Database.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)
