### PR TITLE
Fixing BuzzHouse CI runs

### DIFF
--- a/ci/jobs/ast_fuzzer_job.py
+++ b/ci/jobs/ast_fuzzer_job.py
@@ -24,7 +24,7 @@ def get_run_command(
     buzzhouse: bool,
 ) -> str:
     envs = [
-        f"-e FUZZER_TO_RUN='{"BuzzHouse" if buzzhouse else "AST Fuzzer"}'",
+        f"-e FUZZER_TO_RUN='{'BuzzHouse' if buzzhouse else 'AST Fuzzer'}'",
     ]
 
     env_str = " ".join(envs)

--- a/ci/jobs/ast_fuzzer_job.py
+++ b/ci/jobs/ast_fuzzer_job.py
@@ -56,7 +56,7 @@ def run_fuzz_job(check_name: str):
     workspace_path = temp_dir / "workspace"
     workspace_path.mkdir(parents=True, exist_ok=True)
 
-    run_command = get_run_command(workspace_path, docker_image, check_name)
+    run_command = get_run_command(workspace_path, docker_image, buzzhouse)
     logging.info("Going to run %s", run_command)
 
     info = Info()

--- a/ci/jobs/ast_fuzzer_job.py
+++ b/ci/jobs/ast_fuzzer_job.py
@@ -21,13 +21,10 @@ cwd = Utils.cwd()
 def get_run_command(
     workspace_path: Path,
     image: DockerImage,
-    check_name: str,
+    buzzhouse: bool,
 ) -> str:
-    fuzzer_name = (
-        "BuzzHouse" if check_name.lower().startswith("buzzhouse") else "AST Fuzzer"
-    )
     envs = [
-        f"-e FUZZER_TO_RUN='{fuzzer_name}'",
+        f"-e FUZZER_TO_RUN='{"BuzzHouse" if buzzhouse else "AST Fuzzer"}'",
     ]
 
     env_str = " ".join(envs)
@@ -49,6 +46,7 @@ def get_run_command(
 
 def run_fuzz_job(check_name: str):
     logging.basicConfig(level=logging.INFO)
+    buzzhouse: bool = check_name.lower().startswith("buzzhouse")
 
     temp_dir = Path(f"{cwd}/ci/tmp/")
     assert Path(f"{temp_dir}/clickhouse").exists(), "ClickHouse binary not found"
@@ -85,6 +83,8 @@ def run_fuzz_job(check_name: str):
         fuzzer_log,
         dmesg_log,
     ]
+    if buzzhouse:
+        paths.extend([workspace_path / "fuzzer_out.sql", workspace_path / "fuzz.json"])
 
     try:
         with open(workspace_path / "status.txt", "r", encoding="utf-8") as status_f:

--- a/ci/jobs/ast_fuzzer_job.py
+++ b/ci/jobs/ast_fuzzer_job.py
@@ -116,12 +116,15 @@ def run_fuzz_job(check_name: str):
             error_output = "\n".join(error_lines)
             info += f"Error:\n{error_output}\n"
 
-        if result.results and result.results[-1].name in [
+        patterns = [
             "Let op!",
             "Killed",
             "Unknown error",
             "BuzzHouse fuzzer exception",
-        ]:
+        ]
+        if result.results and any(
+            pattern in result.results[-1].name for pattern in patterns
+        ):
             info += "---\n\nFuzzer log (last 30 lines):\n"
             info += Shell.get_output(f"tail -n30 {fuzzer_log}", verbose=False) + "\n"
         else:

--- a/ci/jobs/ast_fuzzer_job.py
+++ b/ci/jobs/ast_fuzzer_job.py
@@ -124,8 +124,8 @@ def run_fuzz_job(check_name: str):
         if result.results and any(
             pattern in result.results[-1].name for pattern in patterns
         ):
-            info += "---\n\nFuzzer log (last 30 lines):\n"
-            info += Shell.get_output(f"tail -n30 {fuzzer_log}", verbose=False) + "\n"
+            info += "---\n\nFuzzer log (last 200 lines):\n"
+            info += Shell.get_output(f"tail -n200 {fuzzer_log}", verbose=False) + "\n"
         else:
             try:
                 fuzzer_test_generator = FuzzerTestGenerator(

--- a/ci/jobs/ast_fuzzer_job.py
+++ b/ci/jobs/ast_fuzzer_job.py
@@ -79,7 +79,6 @@ def run_fuzz_job(check_name: str):
         fatal_log,
         workspace_path / "stderr.log",
         server_log,
-        workspace_path / "fuzzer_out.sql",
         fuzzer_log,
         dmesg_log,
     ]

--- a/ci/jobs/ast_fuzzer_job.py
+++ b/ci/jobs/ast_fuzzer_job.py
@@ -83,7 +83,7 @@ def run_fuzz_job(check_name: str):
         dmesg_log,
     ]
     if buzzhouse:
-        paths.extend([workspace_path / "fuzzer_out.sql", workspace_path / "fuzz.json"])
+        paths.extend([workspace_path / "fuzzerout.sql", workspace_path / "fuzz.json"])
 
     try:
         with open(workspace_path / "status.txt", "r", encoding="utf-8") as status_f:

--- a/ci/jobs/ast_fuzzer_job.py
+++ b/ci/jobs/ast_fuzzer_job.py
@@ -120,6 +120,7 @@ def run_fuzz_job(check_name: str):
             "Let op!",
             "Killed",
             "Unknown error",
+            "BuzzHouse fuzzer exception",
         ]:
             info += "---\n\nFuzzer log (last 30 lines):\n"
             info += Shell.get_output(f"tail -n30 {fuzzer_log}", verbose=False) + "\n"

--- a/ci/jobs/buzzhouse_job.py
+++ b/ci/jobs/buzzhouse_job.py
@@ -157,7 +157,7 @@ def main():
         "allow_infinite_tables": False,  # Creating too many issues
         "allow_hardcoded_inserts": random.choice([True, False]),
         # These are the error codes that I disallow at the moment
-        "disallowed_error_codes": "9,11,13,15,99,100,101,102,108,127,162,165,166,167,168,172,209,230,231,234,235,246,256,257,261,271,272,273,274,275,305,307,521,635,637,638,639,640,641,642,645,647,718,1003",
+        "disallowed_error_codes": "9,11,13,15,99,100,101,102,108,127,162,165,166,167,168,172,230,231,234,235,246,256,257,261,271,272,273,274,275,305,307,521,635,637,638,639,640,641,642,645,647,718,1003",
         "oracle_ignore_error_codes": "1,36,43,47,48,53,59,210,262,321,386,403,467",
         "client_file_path": "/var/lib/clickhouse/user_files",
         "server_file_path": "/var/lib/clickhouse/user_files",

--- a/ci/jobs/buzzhouse_job.py
+++ b/ci/jobs/buzzhouse_job.py
@@ -11,12 +11,9 @@ from ci.praktika.utils import Utils
 def main():
     temp_dir = Path(f"{Utils.cwd()}/ci/tmp/")
     workspace_path = temp_dir / "workspace"
-    buzz_out = workspace_path / "fuzzer_out.sql"
     buzz_config_file = workspace_path / "fuzz.json"
 
     workspace_path.mkdir(parents=True, exist_ok=True)
-    buzz_out.touch()
-    buzz_config_file.touch()
 
     # Sometimes disallow SQL types to reduce number of combinations
     disabled_types_str = ""
@@ -161,7 +158,7 @@ def main():
         "oracle_ignore_error_codes": "1,36,43,47,48,53,59,210,262,321,386,403,467",
         "client_file_path": "/var/lib/clickhouse/user_files",
         "server_file_path": "/var/lib/clickhouse/user_files",
-        "log_path": str(buzz_out),
+        "log_path": "/workspace/fuzzerout.sql",
         "read_log": False,
         "allow_memory_tables": random.choice([True, False]),
         "allow_client_restarts": random.choice([True, False]),

--- a/ci/jobs/buzzhouse_job.py
+++ b/ci/jobs/buzzhouse_job.py
@@ -148,13 +148,13 @@ def main():
         "enable_fault_injection_settings": random.choice([True, False]),
         "enable_force_settings": random.choice([True, False]),
         # Don't compare for correctness yet, false positives maybe
-        "use_dump_table_oracle": random.randint(0, 3) == 1,
+        "use_dump_table_oracle": random.randint(1, 3) == 1,
         "test_with_fill": False,  # Creating too many issues
         "compare_success_results": False,  # This can give false positives, so disable it
         "allow_infinite_tables": False,  # Creating too many issues
         "allow_hardcoded_inserts": random.choice([True, False]),
         # These are the error codes that I disallow at the moment
-        "disallowed_error_codes": "9,11,13,15,99,100,101,102,108,127,162,165,166,167,168,172,230,231,234,235,246,256,257,261,271,272,273,274,275,305,307,521,635,637,638,639,640,641,642,645,647,718,1003",
+        "disallowed_error_codes": "9,11,13,15,99,100,101,102,108,127,162,165,166,167,168,172,230,231,234,235,246,256,257,261,272,273,274,275,305,307,521,635,637,638,639,640,641,642,645,647,718,1003",
         "oracle_ignore_error_codes": "1,36,43,47,48,53,59,210,262,321,386,403,467",
         "client_file_path": "/var/lib/clickhouse/user_files",
         "server_file_path": "/var/lib/clickhouse/user_files",

--- a/ci/jobs/buzzhouse_job.py
+++ b/ci/jobs/buzzhouse_job.py
@@ -148,7 +148,7 @@ def main():
         "enable_fault_injection_settings": random.choice([True, False]),
         "enable_force_settings": random.choice([True, False]),
         # Don't compare for correctness yet, false positives maybe
-        "use_dump_table_oracle": random.randint(0, 1),
+        "use_dump_table_oracle": random.randint(0, 3) == 1,
         "test_with_fill": False,  # Creating too many issues
         "compare_success_results": False,  # This can give false positives, so disable it
         "allow_infinite_tables": False,  # Creating too many issues

--- a/ci/jobs/scripts/fuzzer/run-fuzzer.sh
+++ b/ci/jobs/scripts/fuzzer/run-fuzzer.sh
@@ -322,9 +322,11 @@ function fuzz
         # BuzzHouse exception, it means a query oracle failed, or
         # an unwanted exception was found
         task_exit_code=$fuzzer_exit_code
-        echo "FAIL" > status.txt
         if ! rg --text -o 'DB::Exception: Found disallowed error code' fuzzer.log > description.txt; then
+            echo "ERROR" > status.txt
             echo "BuzzHouse fuzzer exception not found, fuzzer issue?" > description.txt
+        else
+            echo "FAIL" > status.txt
         fi
     elif [ "$fuzzer_exit_code" == "137" ]
     then

--- a/ci/jobs/scripts/fuzzer/run-fuzzer.sh
+++ b/ci/jobs/scripts/fuzzer/run-fuzzer.sh
@@ -289,7 +289,7 @@ function fuzz
     if [ "$server_died" == 1 ]
     then
         # Prioritize Logical error and assertion lines over "Received signal"
-        if rg --text -o 'Logical error.*|Assertion.*failed|Failed assertion.*|.*runtime error: .*|.*is located.*|(SUMMARY|ERROR): [a-zA-Z]+Sanitizer:.*|.*_LIBCPP_ASSERT.*' server.log > description.txt || \
+        if rg --text -o 'Logical error.*|Assertion.*failed|Failed assertion.*|.*runtime error: .*|.*is located.*|(SUMMARY|ERROR|WARNING): [a-zA-Z]+Sanitizer:.*|.*_LIBCPP_ASSERT.*' server.log > description.txt || \
            rg --text -o 'Received signal.*|.*Child process was terminated by signal 9.*' server.log > description.txt; then
             # Save the stack trace of the server to the description file and preserve in raw text output.
             rg --text '\s<Fatal>\s' server.log >> fatal.log || :

--- a/ci/jobs/scripts/fuzzer/run-fuzzer.sh
+++ b/ci/jobs/scripts/fuzzer/run-fuzzer.sh
@@ -317,6 +317,13 @@ function fuzz
         task_exit_code=0
         echo "OK" > status.txt
         echo "OK" > description.txt
+    elif [ "$fuzzer_exit_code" == "227" ]
+    then
+        # BuzzHouse exception, it means a query oracle failed, or
+        # an unwanted exception was found
+        task_exit_code=$fuzzer_exit_code
+        echo "FAIL" > status.txt
+        echo "BuzzHouse fuzzer exception" > description.txt
     elif [ "$fuzzer_exit_code" == "137" ]
     then
         # Killed.

--- a/ci/jobs/scripts/fuzzer/run-fuzzer.sh
+++ b/ci/jobs/scripts/fuzzer/run-fuzzer.sh
@@ -288,9 +288,9 @@ function fuzz
     task_exit_code=$fuzzer_exit_code
     if [ "$server_died" == 1 ]
     then
-        # The server has died.
-        if rg --text -o 'Received signal.*|Logical error.*|Assertion.*failed|Failed assertion.*|.*runtime error: .*|.*is located.*|(SUMMARY|ERROR): [a-zA-Z]+Sanitizer:.*|.*_LIBCPP_ASSERT.*|.*Child process was terminated by signal 9.*' server.log > description.txt
-        then
+        # Prioritize Logical error and assertion lines over "Received signal"
+        if rg --text -o 'Logical error.*|Assertion.*failed|Failed assertion.*|.*runtime error: .*|.*is located.*|(SUMMARY|ERROR): [a-zA-Z]+Sanitizer:.*|.*_LIBCPP_ASSERT.*' server.log > description.txt || \
+           rg --text -o 'Received signal.*|.*Child process was terminated by signal 9.*' server.log > description.txt; then
             # Save the stack trace of the server to the description file and preserve in raw text output.
             rg --text '\s<Fatal>\s' server.log >> fatal.log || :
         else
@@ -323,7 +323,9 @@ function fuzz
         # an unwanted exception was found
         task_exit_code=$fuzzer_exit_code
         echo "FAIL" > status.txt
-        echo "BuzzHouse fuzzer exception" > description.txt
+        if ! rg --text -o 'DB::Exception: Found disallowed error code' fuzzer.log > description.txt; then
+            echo "BuzzHouse fuzzer exception not found, fuzzer issue?" > description.txt
+        fi
     elif [ "$fuzzer_exit_code" == "137" ]
     then
         # Killed.

--- a/src/Client/BuzzHouse/Generator/QueryOracle.cpp
+++ b/src/Client/BuzzHouse/Generator/QueryOracle.cpp
@@ -34,9 +34,9 @@ const std::vector<std::vector<OutFormat>> QueryOracle::oracleFormats
        {OutFormat::OUT_Values}};
 
 /// Correctness query oracle
-/// SELECT COUNT(*) FROM <FROM_CLAUSE> [PRE]WHERE <PRED>;
+/// SELECT COUNT(*) FROM <FROM_CLAUSE> WHERE <PRED>;
 /// or
-/// SELECT COUNT(*) FROM <FROM_CLAUSE> [PRE]WHERE <PRED1> GROUP BY <GROUP_BY CLAUSE> HAVING <PRED2>;
+/// SELECT COUNT(*) FROM <FROM_CLAUSE> WHERE <PRED1> GROUP BY <GROUP_BY CLAUSE> HAVING <PRED2>;
 void QueryOracle::generateCorrectnessTestFirstQuery(RandomGenerator & rg, StatementGenerator & gen, SQLQuery & sq1)
 {
     TopSelect * ts = sq1.mutable_single_query()->mutable_explain()->mutable_inner_query()->mutable_select();
@@ -59,8 +59,7 @@ void QueryOracle::generateCorrectnessTestFirstQuery(RandomGenerator & rg, Statem
     gen.levels[gen.current_level].allow_aggregates = gen.levels[gen.current_level].allow_window_funcs = false;
     if (combination != 1)
     {
-        WhereStatement * wexpr = rg.nextSmallNumber() < 8 ? ssc->mutable_where() : ssc->mutable_pre_where();
-        BinaryExpr * bexpr = wexpr->mutable_expr()->mutable_expr()->mutable_comp_expr()->mutable_binary_expr();
+        BinaryExpr * bexpr = ssc->mutable_where()->mutable_expr()->mutable_expr()->mutable_comp_expr()->mutable_binary_expr();
 
         bexpr->set_op(BinaryOperator::BINOP_EQ);
         bexpr->mutable_rhs()->mutable_lit_val()->mutable_special_val()->set_val(
@@ -92,7 +91,7 @@ void QueryOracle::generateCorrectnessTestFirstQuery(RandomGenerator & rg, Statem
 
 /// SELECT ifNull(SUM(PRED),0) FROM <FROM_CLAUSE>;
 /// or
-/// SELECT ifNull(SUM(PRED2),0) FROM <FROM_CLAUSE> [PRE]WHERE <PRED1> GROUP BY <GROUP_BY CLAUSE>;
+/// SELECT ifNull(SUM(PRED2),0) FROM <FROM_CLAUSE> WHERE <PRED1> GROUP BY <GROUP_BY CLAUSE>;
 void QueryOracle::generateCorrectnessTestSecondQuery(SQLQuery & sq1, SQLQuery & sq2)
 {
     TopSelect * ts = sq2.mutable_single_query()->mutable_explain()->mutable_inner_query()->mutable_select();
@@ -119,8 +118,7 @@ void QueryOracle::generateCorrectnessTestSecondQuery(SQLQuery & sq1, SQLQuery & 
     }
     else
     {
-        const WhereStatement & wexpr = ssc1.has_where() ? ssc1.where() : ssc1.pre_where();
-        ExprComparisonHighProbability & expr = const_cast<ExprComparisonHighProbability &>(wexpr.expr());
+        ExprComparisonHighProbability & expr = const_cast<ExprComparisonHighProbability &>(ssc1.where().expr());
 
         sfc2->add_args()->set_allocated_expr(expr.release_expr());
     }


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Details

- Add missing files to BuzzHouse job to CI output.
- Improve BuzzHouse and AST Fuzzer CI job description errors.
- Don't use PREWHERE on the correctness oracle, because it's not equivalent.
- Don't swap PREWHERE and WHERE because PREWHERE always runs before joins, while WHERE may not (eg, FULL JOIN), thus giving different results.
- When not comparing query results, never read output files because they may not exist.
- Added debugging information when BuzzHouse unexpectedly fails.
