### PR TITLE
A simple improvement for ProjectionIndexBitmap::appendToFilter

### DIFF
--- a/src/Storages/CMakeLists.txt
+++ b/src/Storages/CMakeLists.txt
@@ -7,3 +7,7 @@ endif()
 if (ENABLE_FUZZING)
     add_subdirectory(fuzzers)
 endif()
+
+if (ENABLE_BENCHMARKS)
+    add_subdirectory(MergeTree/benchmarks)
+endif()

--- a/src/Storages/MergeTree/MergeTreeIndexReadResultPool.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexReadResultPool.cpp
@@ -253,7 +253,6 @@ bool ProjectionIndexBitmap::rangeAllZero(size_t begin, size_t end) const
     }
 }
 
-
 bool ProjectionIndexBitmap::appendToFilter(PaddedPODArray<UInt8> & filter, size_t starting_row, size_t num_rows) const
 {
     size_t old_size = filter.size();
@@ -263,6 +262,11 @@ bool ProjectionIndexBitmap::appendToFilter(PaddedPODArray<UInt8> & filter, size_
 
     if (type == BitmapType::Bitmap32)
     {
+        if (roaring::api::roaring_bitmap_contains_range(data.bitmap32, starting_row, ending_row))
+        {
+            memset(pos, 1, num_rows);
+            return true;
+        }
         roaring::api::roaring_uint32_iterator_t it;
         roaring_iterator_init(data.bitmap32, &it);
         if (!roaring_uint32_iterator_move_equalorlarger(&it, starting_row))
@@ -281,6 +285,11 @@ bool ProjectionIndexBitmap::appendToFilter(PaddedPODArray<UInt8> & filter, size_
     else
     {
         chassert(type == BitmapType::Bitmap64);
+        if (roaring::api::roaring64_bitmap_contains_range(data.bitmap64, starting_row, ending_row))
+        {
+            memset(pos, 1, num_rows);
+            return true;
+        }
         /// NOTE: roaring64 requires a heap-allocated opaque iterator (unlike 32-bit)
         auto * it = roaring::api::roaring64_iterator_create(data.bitmap64);
         /// There is no way to recover a failed allocation inside roaring64.

--- a/src/Storages/MergeTree/benchmarks/CMakeLists.txt
+++ b/src/Storages/MergeTree/benchmarks/CMakeLists.txt
@@ -1,0 +1,4 @@
+clickhouse_add_executable(benchmark_projection_index_bitmap projection_index_bitmap.cpp)
+target_link_libraries (benchmark_projection_index_bitmap PRIVATE
+    ch_contrib::gbenchmark_all
+    dbms)

--- a/src/Storages/MergeTree/benchmarks/projection_index_bitmap.cpp
+++ b/src/Storages/MergeTree/benchmarks/projection_index_bitmap.cpp
@@ -1,0 +1,369 @@
+#include <Storages/MergeTree/MergeTreeIndexReadResultPool.h>
+#include <benchmark/benchmark.h>
+#include <random>
+#include <memory>
+
+using namespace DB;
+
+constexpr size_t BENCHMARK_NUM_ROWS = 8192;
+constexpr size_t BENCHMARK_NUM_ITERATIONS = 100;
+
+/// Helper function to create a bitmap with specific filter rate
+/// @param filter_rate percentage of rows that should pass the filter (0.0 to 1.0)
+/// @param starting_row the starting row number for the filter range
+/// @param num_rows number of rows in the filter range (should be BENCHMARK_NUM_ROWS)
+/// @param num_iterations number of times to repeat the pattern (default 100)
+/// @param seed random seed for reproducibility
+template <typename Offset>
+static ProjectionIndexBitmapPtr createBitmapWithFilterRate(
+    double filter_rate,
+    Offset starting_row,
+    size_t num_rows,
+    size_t num_iterations,
+    unsigned seed)
+{
+    std::mt19937_64 rng(seed);
+    std::uniform_real_distribution<double> dist(0.0, 1.0);
+
+    ProjectionIndexBitmapPtr bitmap;
+    if constexpr (std::is_same_v<Offset, UInt32>)
+        bitmap = ProjectionIndexBitmap::create32();
+    else
+        bitmap = ProjectionIndexBitmap::create64();
+
+    std::vector<Offset> values;
+    values.reserve(static_cast<size_t>(num_rows * num_iterations * filter_rate * 1.2)); // Reserve slightly more
+
+    /// Generate values based on filter rate for multiple iterations
+    for (size_t iter = 0; iter < num_iterations; ++iter)
+    {
+        Offset iter_offset = static_cast<Offset>(iter * num_rows);
+        for (size_t i = 0; i < num_rows; ++i)
+        {
+            if (dist(rng) < filter_rate)
+            {
+                values.push_back(static_cast<Offset>(starting_row + iter_offset + i));
+            }
+        }
+    }
+
+    if (!values.empty())
+        bitmap->addBulk<Offset>(values.data(), values.size());
+
+    return bitmap;
+}
+
+/// Benchmark appendToFilter with 32-bit bitmap, filter rate 0.1% (very sparse)
+static void BM_AppendToFilter_32bit_FilterRate_0_1(benchmark::State & state)
+{
+    const double filter_rate = 0.001;
+    const size_t total_rows = BENCHMARK_NUM_ITERATIONS * BENCHMARK_NUM_ROWS;
+
+    auto bitmap = createBitmapWithFilterRate<UInt32>(filter_rate, 0, BENCHMARK_NUM_ROWS, BENCHMARK_NUM_ITERATIONS, 42);
+
+    for (auto _ : state)
+    {
+        PaddedPODArray<UInt8> filter;
+        for (size_t i = 0; i < BENCHMARK_NUM_ITERATIONS; ++i)
+        {
+            UInt32 iter_start = static_cast<UInt32>(i * BENCHMARK_NUM_ROWS);
+            bool result = bitmap->appendToFilter(filter, iter_start, BENCHMARK_NUM_ROWS);
+            benchmark::DoNotOptimize(result);
+        }
+        benchmark::DoNotOptimize(filter);
+    }
+
+    state.SetItemsProcessed(state.iterations() * total_rows);
+    state.SetLabel("filter_rate=0.1%,iterations=100");
+}
+
+/// Benchmark appendToFilter with 32-bit bitmap, filter rate 1% (sparse)
+static void BM_AppendToFilter_32bit_FilterRate_1(benchmark::State & state)
+{
+    const double filter_rate = 0.01;
+    const size_t total_rows = BENCHMARK_NUM_ITERATIONS * BENCHMARK_NUM_ROWS;
+
+    auto bitmap = createBitmapWithFilterRate<UInt32>(filter_rate, 0, BENCHMARK_NUM_ROWS, BENCHMARK_NUM_ITERATIONS, 42);
+
+    for (auto _ : state)
+    {
+        PaddedPODArray<UInt8> filter;
+        for (size_t i = 0; i < BENCHMARK_NUM_ITERATIONS; ++i)
+        {
+            UInt32 iter_start = static_cast<UInt32>(i * BENCHMARK_NUM_ROWS);
+            bool result = bitmap->appendToFilter(filter, iter_start, BENCHMARK_NUM_ROWS);
+            benchmark::DoNotOptimize(result);
+        }
+        benchmark::DoNotOptimize(filter);
+    }
+
+    state.SetItemsProcessed(state.iterations() * total_rows);
+    state.SetLabel("filter_rate=1%,iterations=100");
+}
+
+/// Benchmark appendToFilter with 32-bit bitmap, filter rate 10% (medium sparse)
+static void BM_AppendToFilter_32bit_FilterRate_10(benchmark::State & state)
+{
+    const double filter_rate = 0.10;
+    const size_t total_rows = BENCHMARK_NUM_ITERATIONS * BENCHMARK_NUM_ROWS;
+
+    auto bitmap = createBitmapWithFilterRate<UInt32>(filter_rate, 0, BENCHMARK_NUM_ROWS, BENCHMARK_NUM_ITERATIONS, 42);
+
+    for (auto _ : state)
+    {
+        PaddedPODArray<UInt8> filter;
+        for (size_t i = 0; i < BENCHMARK_NUM_ITERATIONS; ++i)
+        {
+            UInt32 iter_start = static_cast<UInt32>(i * BENCHMARK_NUM_ROWS);
+            bool result = bitmap->appendToFilter(filter, iter_start, BENCHMARK_NUM_ROWS);
+            benchmark::DoNotOptimize(result);
+        }
+        benchmark::DoNotOptimize(filter);
+    }
+
+    state.SetItemsProcessed(state.iterations() * total_rows);
+    state.SetLabel("filter_rate=10%,iterations=100");
+}
+
+/// Benchmark appendToFilter with 32-bit bitmap, filter rate 50% (medium dense)
+static void BM_AppendToFilter_32bit_FilterRate_50(benchmark::State & state)
+{
+    const double filter_rate = 0.50;
+    const size_t total_rows = BENCHMARK_NUM_ITERATIONS * BENCHMARK_NUM_ROWS;
+
+    auto bitmap = createBitmapWithFilterRate<UInt32>(filter_rate, 0, BENCHMARK_NUM_ROWS, BENCHMARK_NUM_ITERATIONS, 42);
+
+    for (auto _ : state)
+    {
+        PaddedPODArray<UInt8> filter;
+        for (size_t i = 0; i < BENCHMARK_NUM_ITERATIONS; ++i)
+        {
+            UInt32 iter_start = static_cast<UInt32>(i * BENCHMARK_NUM_ROWS);
+            bool result = bitmap->appendToFilter(filter, iter_start, BENCHMARK_NUM_ROWS);
+            benchmark::DoNotOptimize(result);
+        }
+        benchmark::DoNotOptimize(filter);
+    }
+
+    state.SetItemsProcessed(state.iterations() * total_rows);
+    state.SetLabel("filter_rate=50%,iterations=100");
+}
+
+/// Benchmark appendToFilter with 32-bit bitmap, filter rate 90% (dense)
+static void BM_AppendToFilter_32bit_FilterRate_90(benchmark::State & state)
+{
+    const double filter_rate = 0.90;
+    const size_t total_rows = BENCHMARK_NUM_ITERATIONS * BENCHMARK_NUM_ROWS;
+
+    auto bitmap = createBitmapWithFilterRate<UInt32>(filter_rate, 0, BENCHMARK_NUM_ROWS, BENCHMARK_NUM_ITERATIONS, 42);
+
+    for (auto _ : state)
+    {
+        PaddedPODArray<UInt8> filter;
+        for (size_t i = 0; i < BENCHMARK_NUM_ITERATIONS; ++i)
+        {
+            UInt32 iter_start = static_cast<UInt32>(i * BENCHMARK_NUM_ROWS);
+            bool result = bitmap->appendToFilter(filter, iter_start, BENCHMARK_NUM_ROWS);
+            benchmark::DoNotOptimize(result);
+        }
+        benchmark::DoNotOptimize(filter);
+    }
+
+    state.SetItemsProcessed(state.iterations() * total_rows);
+    state.SetLabel("filter_rate=90%,iterations=100");
+}
+
+/// Benchmark appendToFilter with 32-bit bitmap, filter rate 99% (dense)
+static void BM_AppendToFilter_32bit_FilterRate_99(benchmark::State & state)
+{
+    const double filter_rate = 0.99;
+    const size_t total_rows = BENCHMARK_NUM_ITERATIONS * BENCHMARK_NUM_ROWS;
+
+    auto bitmap = createBitmapWithFilterRate<UInt32>(filter_rate, 0, BENCHMARK_NUM_ROWS, BENCHMARK_NUM_ITERATIONS, 42);
+
+    for (auto _ : state)
+    {
+        PaddedPODArray<UInt8> filter;
+        for (size_t i = 0; i < BENCHMARK_NUM_ITERATIONS; ++i)
+        {
+            UInt32 iter_start = static_cast<UInt32>(i * BENCHMARK_NUM_ROWS);
+            bool result = bitmap->appendToFilter(filter, iter_start, BENCHMARK_NUM_ROWS);
+            benchmark::DoNotOptimize(result);
+        }
+        benchmark::DoNotOptimize(filter);
+    }
+
+    state.SetItemsProcessed(state.iterations() * total_rows);
+    state.SetLabel("filter_rate=99%,iterations=100");
+}
+
+
+/// Benchmark appendToFilter with 64-bit bitmap, filter rate 1% (sparse)
+static void BM_AppendToFilter_64bit_FilterRate_1(benchmark::State & state)
+{
+    const double filter_rate = 0.01;
+    const size_t total_rows = BENCHMARK_NUM_ITERATIONS * BENCHMARK_NUM_ROWS;
+
+    auto bitmap = createBitmapWithFilterRate<UInt64>(filter_rate, 0, BENCHMARK_NUM_ROWS, BENCHMARK_NUM_ITERATIONS, 42);
+
+    for (auto _ : state)
+    {
+        PaddedPODArray<UInt8> filter;
+        for (size_t i = 0; i < BENCHMARK_NUM_ITERATIONS; ++i)
+        {
+            UInt64 iter_start = static_cast<UInt64>(i * BENCHMARK_NUM_ROWS);
+            bool result = bitmap->appendToFilter(filter, iter_start, BENCHMARK_NUM_ROWS);
+            benchmark::DoNotOptimize(result);
+        }
+        benchmark::DoNotOptimize(filter);
+    }
+
+    state.SetItemsProcessed(state.iterations() * total_rows);
+    state.SetLabel("filter_rate=1%,iterations=100");
+}
+
+/// Benchmark appendToFilter with 64-bit bitmap, filter rate 50% (medium dense)
+static void BM_AppendToFilter_64bit_FilterRate_50(benchmark::State & state)
+{
+    const double filter_rate = 0.50;
+    const size_t total_rows = BENCHMARK_NUM_ITERATIONS * BENCHMARK_NUM_ROWS;
+
+    auto bitmap = createBitmapWithFilterRate<UInt64>(filter_rate, 0, BENCHMARK_NUM_ROWS, BENCHMARK_NUM_ITERATIONS, 42);
+
+    for (auto _ : state)
+    {
+        PaddedPODArray<UInt8> filter;
+        for (size_t i = 0; i < BENCHMARK_NUM_ITERATIONS; ++i)
+        {
+            UInt64 iter_start = static_cast<UInt64>(i * BENCHMARK_NUM_ROWS);
+            bool result = bitmap->appendToFilter(filter, iter_start, BENCHMARK_NUM_ROWS);
+            benchmark::DoNotOptimize(result);
+        }
+        benchmark::DoNotOptimize(filter);
+    }
+
+    state.SetItemsProcessed(state.iterations() * total_rows);
+    state.SetLabel("filter_rate=50%,iterations=100");
+}
+
+/// Benchmark appendToFilter with 32-bit bitmap, all zeros (empty bitmap)
+static void BM_AppendToFilter_32bit_AllZeros(benchmark::State & state)
+{
+    const size_t total_rows = BENCHMARK_NUM_ITERATIONS * BENCHMARK_NUM_ROWS;
+
+    auto bitmap = ProjectionIndexBitmap::create32();
+
+    for (auto _ : state)
+    {
+        PaddedPODArray<UInt8> filter;
+        for (size_t i = 0; i < BENCHMARK_NUM_ITERATIONS; ++i)
+        {
+            UInt32 iter_start = static_cast<UInt32>(i * BENCHMARK_NUM_ROWS);
+            bool result = bitmap->appendToFilter(filter, iter_start, BENCHMARK_NUM_ROWS);
+            benchmark::DoNotOptimize(result);
+        }
+        benchmark::DoNotOptimize(filter);
+    }
+
+    state.SetItemsProcessed(state.iterations() * total_rows);
+    state.SetLabel("all_zeros,iterations=100");
+}
+
+/// Benchmark appendToFilter with 64-bit bitmap, all zeros (empty bitmap)
+static void BM_AppendToFilter_64bit_AllZeros(benchmark::State & state)
+{
+    const size_t total_rows = BENCHMARK_NUM_ITERATIONS * BENCHMARK_NUM_ROWS;
+
+    auto bitmap = ProjectionIndexBitmap::create64();
+
+    for (auto _ : state)
+    {
+        PaddedPODArray<UInt8> filter;
+        for (size_t i = 0; i < BENCHMARK_NUM_ITERATIONS; ++i)
+        {
+            UInt64 iter_start = static_cast<UInt64>(i * BENCHMARK_NUM_ROWS);
+            bool result = bitmap->appendToFilter(filter, iter_start, BENCHMARK_NUM_ROWS);
+            benchmark::DoNotOptimize(result);
+        }
+        benchmark::DoNotOptimize(filter);
+    }
+
+    state.SetItemsProcessed(state.iterations() * total_rows);
+    state.SetLabel("all_zeros,iterations=100");
+}
+
+/// Benchmark appendToFilter with 32-bit bitmap, all ones (full bitmap)
+static void BM_AppendToFilter_32bit_AllOnes(benchmark::State & state)
+{
+    const size_t total_rows = BENCHMARK_NUM_ITERATIONS * BENCHMARK_NUM_ROWS;
+
+    auto bitmap = ProjectionIndexBitmap::create32();
+    std::vector<UInt32> values;
+    values.reserve(total_rows);
+    for (size_t i = 0; i < total_rows; ++i)
+        values.push_back(static_cast<UInt32>(i));
+    bitmap->addBulk<UInt32>(values.data(), values.size());
+
+    for (auto _ : state)
+    {
+        PaddedPODArray<UInt8> filter;
+        for (size_t i = 0; i < BENCHMARK_NUM_ITERATIONS; ++i)
+        {
+            UInt32 iter_start = static_cast<UInt32>(i * BENCHMARK_NUM_ROWS);
+            bool result = bitmap->appendToFilter(filter, iter_start, BENCHMARK_NUM_ROWS);
+            benchmark::DoNotOptimize(result);
+        }
+        benchmark::DoNotOptimize(filter);
+    }
+
+    state.SetItemsProcessed(state.iterations() * total_rows);
+    state.SetLabel("all_ones,iterations=100");
+}
+
+/// Benchmark appendToFilter with 64-bit bitmap, all ones (full bitmap)
+static void BM_AppendToFilter_64bit_AllOnes(benchmark::State & state)
+{
+    const size_t total_rows = BENCHMARK_NUM_ITERATIONS * BENCHMARK_NUM_ROWS;
+
+    auto bitmap = ProjectionIndexBitmap::create64();
+    std::vector<UInt64> values;
+    values.reserve(total_rows);
+    for (size_t i = 0; i < total_rows; ++i)
+        values.push_back(static_cast<UInt64>(i));
+    bitmap->addBulk<UInt64>(values.data(), values.size());
+
+    for (auto _ : state)
+    {
+        PaddedPODArray<UInt8> filter;
+        for (size_t i = 0; i < BENCHMARK_NUM_ITERATIONS; ++i)
+        {
+            UInt64 iter_start = static_cast<UInt64>(i * BENCHMARK_NUM_ROWS);
+            bool result = bitmap->appendToFilter(filter, iter_start, BENCHMARK_NUM_ROWS);
+            benchmark::DoNotOptimize(result);
+        }
+        benchmark::DoNotOptimize(filter);
+    }
+
+    state.SetItemsProcessed(state.iterations() * total_rows);
+    state.SetLabel("all_ones,iterations=100");
+}
+
+// Register benchmarks - 32-bit bitmap with different filter rates
+BENCHMARK(BM_AppendToFilter_32bit_FilterRate_0_1);
+BENCHMARK(BM_AppendToFilter_32bit_FilterRate_1);
+BENCHMARK(BM_AppendToFilter_32bit_FilterRate_10);
+BENCHMARK(BM_AppendToFilter_32bit_FilterRate_50);
+BENCHMARK(BM_AppendToFilter_32bit_FilterRate_90);
+BENCHMARK(BM_AppendToFilter_32bit_FilterRate_99);
+
+// Register benchmarks - 64-bit bitmap with different filter rates
+BENCHMARK(BM_AppendToFilter_64bit_FilterRate_1);
+BENCHMARK(BM_AppendToFilter_64bit_FilterRate_50);
+
+// Register benchmarks - appendToFilter with all zeros (empty bitmap)
+BENCHMARK(BM_AppendToFilter_32bit_AllZeros);
+BENCHMARK(BM_AppendToFilter_64bit_AllZeros);
+
+// Register benchmarks - appendToFilter with all ones (full bitmap)
+BENCHMARK(BM_AppendToFilter_32bit_AllOnes);
+BENCHMARK(BM_AppendToFilter_64bit_AllOnes);

--- a/src/Storages/MergeTree/tests/gtest_projection_index_bitmap.cpp
+++ b/src/Storages/MergeTree/tests/gtest_projection_index_bitmap.cpp
@@ -308,3 +308,71 @@ TEST(ProjectionIndexBitmapTest, DuplicateValues)
     EXPECT_EQ(bitmap->cardinality(), 1); // Should still have cardinality 1
     EXPECT_TRUE(bitmap->contains<UInt32>(10));
 }
+
+// Test appendToFilter with all ones (full bitmap) for 32-bit
+TEST(ProjectionIndexBitmapTest, AppendToFilterAllOnes32)
+{
+    auto bitmap = ProjectionIndexBitmap::create32();
+
+    // Define range [100, 110)
+    UInt32 start = 100;
+    size_t size = 10;
+
+    // Add all values in the range
+    for (UInt32 i = start; i < start + size; ++i)
+    {
+        bitmap->add<UInt32>(i);
+    }
+
+    // Verify all values are present
+    EXPECT_EQ(bitmap->cardinality(), size);
+
+    PaddedPODArray<UInt8> buffer;
+
+    // Append to filter
+    bool has_values = bitmap->appendToFilter(buffer, start, size);
+
+    // Check result
+    EXPECT_TRUE(has_values);
+    EXPECT_EQ(buffer.size(), size);
+
+    // All values should be 1
+    for (size_t i = 0; i < size; ++i)
+    {
+        EXPECT_EQ(buffer[i], 1) << "Expected all ones at position " << i;
+    }
+}
+
+// Test appendToFilter with all ones (full bitmap) for 64-bit
+TEST(ProjectionIndexBitmapTest, AppendToFilterAllOnes64)
+{
+    auto bitmap = ProjectionIndexBitmap::create64();
+
+    // Define range with large 64-bit values
+    UInt64 start = 10000000000000ULL;
+    size_t size = 10;
+
+    // Add all values in the range
+    for (UInt64 i = start; i < start + size; ++i)
+    {
+        bitmap->add<UInt64>(i);
+    }
+
+    // Verify all values are present
+    EXPECT_EQ(bitmap->cardinality(), size);
+
+    PaddedPODArray<UInt8> buffer;
+
+    // Append to filter
+    bool has_values = bitmap->appendToFilter(buffer, start, size);
+
+    // Check result
+    EXPECT_TRUE(has_values);
+    EXPECT_EQ(buffer.size(), size);
+
+    // All values should be 1
+    for (size_t i = 0; i < size; ++i)
+    {
+        EXPECT_EQ(buffer[i], 1) << "Expected all ones at position " << i;
+    }
+}


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: false -->

### Changelog category (leave one):

- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

A simple improvement for `ProjectionIndexBitmap::appendToFilter` when all the bits within the range are ones.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

### Details

- This PR adds a simple improvement for `ProjectionIndexBitmap::appendToFilter` (implemented in #81021) when all the bits within the range are 1.
- This PR also adds benchmark for `ProjectionIndexBitmap::appendToFilter`.

Here is the benchmark result.

`BM_AppendToFilter*` are for the old implementation, `BM_AppendToFilterV2*` are for the new one. As we can see,
there is almost no performance degration for normal cases, while the benefit is considerable if all bits within a range are ones.

```
------------------------------------------------
Benchmark                                         Time             CPU   Iterations UserCounters...
---------------------------------------------------------------------------------------------------
BM_AppendToFilter_32bit_FilterRate_0_1        48521 ns        48519 ns        14300 items_per_second=16.8841G/s filter_rate=0.1%,iterations=100
BM_AppendToFilterV2_32bit_FilterRate_0_1      51448 ns        51447 ns        13729 items_per_second=15.9232G/s filter_rate=0.1%,iterations=100
BM_AppendToFilter_32bit_FilterRate_1          82663 ns        82660 ns         8522 items_per_second=9.91051G/s filter_rate=1%,iterations=100
BM_AppendToFilterV2_32bit_FilterRate_1        84566 ns        84561 ns         8177 items_per_second=9.68765G/s filter_rate=1%,iterations=100
BM_AppendToFilter_32bit_FilterRate_10        763338 ns       763305 ns          926 items_per_second=1073.23M/s filter_rate=10%,iterations=100
BM_AppendToFilterV2_32bit_FilterRate_10      761675 ns       761586 ns          923 items_per_second=1075.65M/s filter_rate=10%,iterations=100
BM_AppendToFilter_32bit_FilterRate_50       3109074 ns      3108966 ns          225 items_per_second=263.496M/s filter_rate=50%,iterations=100
BM_AppendToFilterV2_32bit_FilterRate_50     3109856 ns      3109781 ns          225 items_per_second=263.427M/s filter_rate=50%,iterations=100
BM_AppendToFilter_32bit_FilterRate_90       5461085 ns      5460963 ns          128 items_per_second=150.01M/s filter_rate=90%,iterations=100
BM_AppendToFilterV2_32bit_FilterRate_90     5462938 ns      5462574 ns          128 items_per_second=149.966M/s filter_rate=90%,iterations=100
BM_AppendToFilter_32bit_FilterRate_99       5987860 ns      5987724 ns          117 items_per_second=136.813M/s filter_rate=99%,iterations=100
BM_AppendToFilterV2_32bit_FilterRate_99     6001952 ns      6001559 ns          117 items_per_second=136.498M/s filter_rate=99%,iterations=100
BM_AppendToFilter_64bit_FilterRate_1          92700 ns        92692 ns         7526 items_per_second=8.8379G/s filter_rate=1%,iterations=100
BM_AppendToFilterV2_64bit_FilterRate_1        95253 ns        95228 ns         7340 items_per_second=8.60253G/s filter_rate=1%,iterations=100
BM_AppendToFilter_64bit_FilterRate_50       3353834 ns      3353454 ns          209 items_per_second=244.285M/s filter_rate=50%,iterations=100
BM_AppendToFilterV2_64bit_FilterRate_50     3327457 ns      3327293 ns          210 items_per_second=246.206M/s filter_rate=50%,iterations=100
BM_AppendToFilter_32bit_AllZeros              33335 ns        33333 ns        20912 items_per_second=24.576G/s all_zeros,iterations=100
BM_AppendToFilterV2_32bit_AllZeros            34086 ns        34084 ns        20493 items_per_second=24.0345G/s all_zeros,iterations=100
BM_AppendToFilter_64bit_AllZeros              37994 ns        37993 ns        18478 items_per_second=21.5618G/s all_zeros,iterations=100
BM_AppendToFilterV2_64bit_AllZeros            38702 ns        38699 ns        18050 items_per_second=21.1684G/s all_zeros,iterations=100
BM_AppendToFilter_32bit_AllOnes             6038867 ns      6038652 ns          116 items_per_second=135.659M/s all_ones,iterations=100
BM_AppendToFilterV2_32bit_AllOnes             43980 ns        43977 ns        15953 items_per_second=18.6277G/s all_ones,iterations=100
BM_AppendToFilter_64bit_AllOnes             7395726 ns      7395126 ns           96 items_per_second=110.776M/s all_ones,iterations=100
BM_AppendToFilterV2_64bit_AllOnes             44585 ns        44575 ns        15799 items_per_second=18.378G/s all_ones,iterations=100
```
