### PR TITLE
Enable debug symbols for ARM release builds in PRs

### DIFF
--- a/ci/jobs/build_clickhouse.py
+++ b/ci/jobs/build_clickhouse.py
@@ -143,7 +143,6 @@ def main():
     # For PRs we prefer to build without debug symbols to save space and time (LTO is much faster)
     if info.pr_number != 0 and build_type in (
         BuildTypes.AMD_RELEASE,
-        BuildTypes.ARM_RELEASE,
     ):
         cmake_cmd += " -DDISABLE_ALL_DEBUG_SYMBOLS=1"
 


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Details

Release build for ARM is not that slow, it is only 2168.28 secs (amd release 6270.62 secs), while stripped version for ARM is 1509.07 secs, yes faster, but amd release stripped takes 2889.78 secs, so it does not make a lot of sense to speed up ARM release build only.

Follow-up for: https://github.com/ClickHouse/ClickHouse/pull/88585
