### PR TITLE
Use ReadNothingStep instead of ReadFromPreparedSource with NullSource

### DIFF
--- a/src/Planner/PlannerJoinTree.cpp
+++ b/src/Planner/PlannerJoinTree.cpp
@@ -55,6 +55,7 @@
 #include <Processors/QueryPlan/ReadFromMergeTree.h>
 #include <Processors/QueryPlan/ReadFromTableStep.h>
 #include <Processors/QueryPlan/ReadFromTableFunctionStep.h>
+#include <Processors/QueryPlan/ReadNothingStep.h>
 #include <Processors/QueryPlan/Optimizations/Utils.h>
 #include <Processors/Sources/SourceFromSingleChunk.h>
 
@@ -1311,10 +1312,9 @@ JoinTreeQueryPlan buildQueryPlanForTableExpression(QueryTreeNodePtr table_expres
                 /// Create step which reads from empty source if storage has no data.
                 const auto & column_names = table_expression_data.getColumnNames();
                 auto source_header = std::make_shared<const Block>(storage_snapshot->getSampleBlockForColumns(column_names));
-                Pipe pipe(std::make_shared<NullSource>(source_header));
-                auto read_from_pipe = std::make_unique<ReadFromPreparedSource>(std::move(pipe));
-                read_from_pipe->setStepDescription("Read from NullSource");
-                query_plan.addStep(std::move(read_from_pipe));
+                auto read_nothing = std::make_unique<ReadNothingStep>(source_header);
+                read_nothing->setStepDescription("Read from NullSource");
+                query_plan.addStep(std::move(read_nothing));
                 query_plan.setMaxThreads(max_threads_execute_query);
 
                 auto & alias_column_expressions = table_expression_data.getAliasColumnExpressions();
@@ -1335,10 +1335,9 @@ JoinTreeQueryPlan buildQueryPlanForTableExpression(QueryTreeNodePtr table_expres
             for (auto & projection_column : projection_columns)
                 source_header.insert(ColumnWithTypeAndName(projection_column.type, projection_column.name));
 
-            Pipe pipe(std::make_shared<NullSource>(std::make_shared<const Block>(source_header)));
-            auto read_from_pipe = std::make_unique<ReadFromPreparedSource>(std::move(pipe));
-            read_from_pipe->setStepDescription("Read from NullSource");
-            query_plan.addStep(std::move(read_from_pipe));
+            auto read_nothing = std::make_unique<ReadNothingStep>(std::make_shared<const Block>(source_header));
+            read_nothing->setStepDescription("Read from NullSource");
+            query_plan.addStep(std::move(read_nothing));
         }
         else
         {

--- a/src/Processors/QueryPlan/ReadNothingStep.cpp
+++ b/src/Processors/QueryPlan/ReadNothingStep.cpp
@@ -10,6 +10,11 @@ ReadNothingStep::ReadNothingStep(SharedHeader output_header_)
 {
 }
 
+QueryPlanStepPtr ReadNothingStep::clone() const
+{
+    return std::make_unique<ReadNothingStep>(getOutputHeader());
+}
+
 void ReadNothingStep::initializePipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings &)
 {
     pipeline.init(Pipe(std::make_shared<NullSource>(getOutputHeader())));

--- a/src/Processors/QueryPlan/ReadNothingStep.h
+++ b/src/Processors/QueryPlan/ReadNothingStep.h
@@ -12,6 +12,8 @@ public:
 
     String getName() const override { return "ReadNothing"; }
 
+    QueryPlanStepPtr clone() const override;
+
     void initializePipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings &) override;
 };
 

--- a/tests/queries/0_stateless/01095_tpch_like_smoke.reference
+++ b/tests/queries/0_stateless/01095_tpch_like_smoke.reference
@@ -1,7 +1,7 @@
 1
-2	fail: correlated subquery
+2
 3
-4	fail: exists
+4
 5
 6
 0
@@ -16,10 +16,11 @@
 0
 15	fail: correlated subquery
 16
-17	fail: correlated subquery
+17
+0
 18
 19
 0
-20	fail: correlated subquery
-21	fail: exists, not exists
-22	fail: not exists
+20
+21
+22

--- a/tests/queries/0_stateless/01095_tpch_like_smoke.sql
+++ b/tests/queries/0_stateless/01095_tpch_like_smoke.sql
@@ -8,7 +8,7 @@ DROP TABLE IF EXISTS nation;
 DROP TABLE IF EXISTS region;
 
 SET cross_to_inner_join_rewrite = 1;
-SET allow_experimental_correlated_subqueries = 0;
+SET allow_experimental_correlated_subqueries = 1;
 
 CREATE TABLE part
 (
@@ -137,7 +137,7 @@ order by
     l_returnflag,
     l_linestatus;
 
-select 2, 'fail: correlated subquery'; -- TODO: Missing columns: 'p_partkey'
+select 2;
 select
     s_acctbal,
     s_name,
@@ -181,7 +181,7 @@ order by
     n_name,
     s_name,
     p_partkey
-limit 100; -- { serverError UNSUPPORTED_METHOD, 47 }
+limit 100;
 
 select 3;
 select
@@ -208,28 +208,28 @@ order by
     o_orderdate
 limit 10;
 
-select 4, 'fail: exists'; -- TODO
--- select
---     o_orderpriority,
---     count(*) as order_count
--- from
---     orders
--- where
---     o_orderdate >= date '1993-07-01'
---     and o_orderdate < date '1993-07-01' + interval '3' month
---     and exists (
---         select
---             *
---         from
---             lineitem
---         where
---             l_orderkey = o_orderkey
---             and l_commitdate < l_receiptdate
---     )
--- group by
---     o_orderpriority
--- order by
---     o_orderpriority;
+select 4;
+select
+    o_orderpriority,
+    count(*) as order_count
+from
+    orders
+where
+    o_orderdate >= date '1993-07-01'
+    and o_orderdate < date '1993-07-01' + interval '3' month
+    and exists (
+        select
+            *
+        from
+            lineitem
+        where
+            l_orderkey = o_orderkey
+            and l_commitdate < l_receiptdate
+    )
+group by
+    o_orderpriority
+order by
+    o_orderpriority;
 
 select 5;
 select
@@ -582,7 +582,7 @@ order by
     p_type,
     p_size;
 
-select 17, 'fail: correlated subquery'; -- TODO: Missing columns: 'p_partkey'
+select 17;
 select
     sum(l_extendedprice) / 7.0 as avg_yearly
 from
@@ -599,7 +599,7 @@ where
             lineitem
         where
             l_partkey = p_partkey
-    ); -- { serverError UNSUPPORTED_METHOD, 47 }
+    );
 
 select 18;
 select
@@ -673,7 +673,7 @@ where
         and l_shipinstruct = 'DELIVER IN PERSON'
     );
 
-select 20, 'fail: correlated subquery'; -- TODO: Missing columns: 'ps_suppkey' 'ps_partkey'
+select 20;
 select
     s_name,
     s_address
@@ -710,88 +710,88 @@ where
     and s_nationkey = n_nationkey
     and n_name = 'CANADA'
 order by
-    s_name; -- { serverError UNSUPPORTED_METHOD, 47 }
+    s_name;
 
-select 21, 'fail: exists, not exists'; -- TODO
--- select
---     s_name,
---     count(*) as numwait
--- from
---     supplier,
---     lineitem l1,
---     orders,
---     nation
--- where
---     s_suppkey = l1.l_suppkey
---     and o_orderkey = l1.l_orderkey
---     and o_orderstatus = 'F'
---     and l1.l_receiptdate > l1.l_commitdate
---     and exists (
---         select
---             *
---         from
---             lineitem l2
---         where
---             l2.l_orderkey = l1.l_orderkey
---             and l2.l_suppkey <> l1.l_suppkey
---     )
---     and not exists (
---         select
---             *
---         from
---             lineitem l3
---         where
---             l3.l_orderkey = l1.l_orderkey
---             and l3.l_suppkey <> l1.l_suppkey
---             and l3.l_receiptdate > l3.l_commitdate
---     )
---     and s_nationkey = n_nationkey
---     and n_name = 'SAUDI ARABIA'
--- group by
---     s_name
--- order by
---     numwait desc,
---     s_name
--- limit 100;
+select 21;
+select
+    s_name,
+    count(*) as numwait
+from
+    supplier,
+    lineitem l1,
+    orders,
+    nation
+where
+    s_suppkey = l1.l_suppkey
+    and o_orderkey = l1.l_orderkey
+    and o_orderstatus = 'F'
+    and l1.l_receiptdate > l1.l_commitdate
+    and exists (
+        select
+            *
+        from
+            lineitem l2
+        where
+            l2.l_orderkey = l1.l_orderkey
+            and l2.l_suppkey <> l1.l_suppkey
+    )
+    and not exists (
+        select
+            *
+        from
+            lineitem l3
+        where
+            l3.l_orderkey = l1.l_orderkey
+            and l3.l_suppkey <> l1.l_suppkey
+            and l3.l_receiptdate > l3.l_commitdate
+    )
+    and s_nationkey = n_nationkey
+    and n_name = 'SAUDI ARABIA'
+group by
+    s_name
+order by
+    numwait desc,
+    s_name
+limit 100;
 
-select 22, 'fail: not exists'; -- TODO
--- select
---     cntrycode,
---     count(*) as numcust,
---     sum(c_acctbal) as totacctbal
--- from
---     (
---         select
---             substring(c_phone from 1 for 2) as cntrycode,
---             c_acctbal
---         from
---             customer
---         where
---             substring(c_phone from 1 for 2) in
---                 ('13', '31', '23', '29', '30', '18', '17')
---             and c_acctbal > (
---                 select
---                     avg(c_acctbal)
---                 from
---                     customer
---                 where
---                     c_acctbal > 0.00
---                     and substring(c_phone from 1 for 2) in
---                         ('13', '31', '23', '29', '30', '18', '17')
---             )
---             and not exists (
---                 select
---                     *
---                 from
---                     orders
---                 where
---                     o_custkey = c_custkey
---             )
---     ) as custsale
--- group by
---     cntrycode
--- order by
---     cntrycode;
+select 22;
+select
+    cntrycode,
+    count(*) as numcust,
+    sum(c_acctbal) as totacctbal
+from
+    (
+        select
+            substring(c_phone from 1 for 2) as cntrycode,
+            c_acctbal
+        from
+            customer
+        where
+            substring(c_phone from 1 for 2) in
+                ('13', '31', '23', '29', '30', '18', '17')
+            and c_acctbal > (
+                select
+                    avg(c_acctbal)
+                from
+                    customer
+                where
+                    c_acctbal > 0.00
+                    and substring(c_phone from 1 for 2) in
+                        ('13', '31', '23', '29', '30', '18', '17')
+            )
+            and not exists (
+                select
+                    *
+                from
+                    orders
+                where
+                    o_custkey = c_custkey
+            )
+    ) as custsale
+group by
+    cntrycode
+order by
+    cntrycode;
 
 DROP TABLE part;
 DROP TABLE supplier;

--- a/tests/queries/0_stateless/01095_tpch_like_smoke.sql
+++ b/tests/queries/0_stateless/01095_tpch_like_smoke.sql
@@ -181,7 +181,8 @@ order by
     n_name,
     s_name,
     p_partkey
-limit 100;
+limit 100
+SETTINGS enable_analyzer=1;
 
 select 3;
 select
@@ -229,7 +230,8 @@ where
 group by
     o_orderpriority
 order by
-    o_orderpriority;
+    o_orderpriority
+SETTINGS enable_analyzer=1;
 
 select 5;
 select
@@ -599,7 +601,8 @@ where
             lineitem
         where
             l_partkey = p_partkey
-    );
+    )
+SETTINGS enable_analyzer=1;
 
 select 18;
 select
@@ -710,7 +713,8 @@ where
     and s_nationkey = n_nationkey
     and n_name = 'CANADA'
 order by
-    s_name;
+    s_name
+SETTINGS enable_analyzer=1;
 
 select 21;
 select
@@ -752,7 +756,8 @@ group by
 order by
     numwait desc,
     s_name
-limit 100;
+limit 100
+SETTINGS enable_analyzer=1;
 
 select 22;
 select
@@ -791,7 +796,8 @@ from
 group by
     cntrycode
 order by
-    cntrycode;
+    cntrycode
+SETTINGS enable_analyzer=1;
 
 DROP TABLE part;
 DROP TABLE supplier;

--- a/tests/queries/0_stateless/03151_analyzer_view_read_only_necessary_columns.reference
+++ b/tests/queries/0_stateless/03151_analyzer_view_read_only_necessary_columns.reference
@@ -4,5 +4,5 @@ Header: sum(id) UInt64
   Header: sum(__table1.id) UInt64
     Expression ((Before GROUP BY + (Change column names to column identifiers + (Convert VIEW subquery result to VIEW table structure + (Materialize constants after VIEW subquery + (Project names + (Projection + (Change column names to column identifiers + (Project names + (Projection + Change column names to column identifiers))))))))))
     Header: __table1.id UInt64
-      ReadFromPreparedSource (Read from NullSource)
+      ReadNothing (Read from NullSource)
       Header: id UInt64


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
Also implement `ReadNothingStep::clone()` to enable doing correlated subqueries with empty tables.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)
