### PR TITLE
Disable read-in-order optimization for Iceberg if manifest files are not sorted

### DIFF
--- a/src/Processors/QueryPlan/ReadFromObjectStorageStep.cpp
+++ b/src/Processors/QueryPlan/ReadFromObjectStorageStep.cpp
@@ -182,7 +182,7 @@ static InputOrderInfoPtr convertSortingKeyToInputOrder(const KeyDescription & ke
 
 bool ReadFromObjectStorageStep::requestReadingInOrder(InputOrderInfoPtr order_info_) const
 {
-    return isPrefixInputOrder(order_info_, getDataOrder());
+    return isPrefixInputOrder(order_info_, getDataOrder()) && configuration->isDataSortedBySortingKey(storage_snapshot->metadata, getContext());
 }
 
 InputOrderInfoPtr ReadFromObjectStorageStep::getDataOrder() const

--- a/src/Storages/KeyDescription.cpp
+++ b/src/Storages/KeyDescription.cpp
@@ -32,6 +32,7 @@ KeyDescription::KeyDescription(const KeyDescription & other)
     , reverse_flags(other.reverse_flags)
     , data_types(other.data_types)
     , additional_column(other.additional_column)
+    , sort_order_id(other.sort_order_id)
 {
     if (other.expression)
         expression = other.expression->clone();
@@ -66,6 +67,7 @@ KeyDescription & KeyDescription::operator=(const KeyDescription & other)
     if (additional_column.has_value() && !other.additional_column.has_value())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Wrong key assignment, losing additional_column");
     additional_column = other.additional_column;
+    sort_order_id = other.sort_order_id;
     return *this;
 }
 

--- a/src/Storages/KeyDescription.h
+++ b/src/Storages/KeyDescription.h
@@ -45,7 +45,7 @@ struct KeyDescription
     /// but added to expression_list_ast and all its derivatives.
     std::optional<String> additional_column;
 
-    /// ID of this specific order by key, make sense for enginers which allow to change sorting key
+    /// ID of this specific order by key, make sense for engines which allow to change sorting key
     /// for example Iceberg.
     std::optional<Int32> sort_order_id;
 

--- a/src/Storages/KeyDescription.h
+++ b/src/Storages/KeyDescription.h
@@ -45,6 +45,10 @@ struct KeyDescription
     /// but added to expression_list_ast and all its derivatives.
     std::optional<String> additional_column;
 
+    /// ID of this specific order by key, make sense for enginers which allow to change sorting key
+    /// for example Iceberg.
+    std::optional<Int32> sort_order_id;
+
     /// Parse key structure from key definition. Requires all columns, available
     /// in storage.
     static KeyDescription getKeyFromAST(

--- a/src/Storages/ObjectStorage/DataLakes/DataLakeConfiguration.h
+++ b/src/Storages/ObjectStorage/DataLakes/DataLakeConfiguration.h
@@ -190,6 +190,12 @@ public:
         return current_metadata->totalBytes(local_context);
     }
 
+    bool isDataSortedBySortingKey(StorageMetadataPtr metadata_snapshot, ContextPtr local_context) const override
+    {
+        assertInitialized();
+        return current_metadata->isDataSortedBySortingKey(metadata_snapshot, local_context);
+    }
+
     std::shared_ptr<NamesAndTypesList> getInitialSchemaByPath(ContextPtr local_context, ObjectInfoPtr object_info) const override
     {
         assertInitialized();

--- a/src/Storages/ObjectStorage/DataLakes/IDataLakeMetadata.h
+++ b/src/Storages/ObjectStorage/DataLakes/IDataLakeMetadata.h
@@ -88,6 +88,12 @@ public:
     virtual std::optional<size_t> totalRows(ContextPtr) const { return {}; }
     virtual std::optional<size_t> totalBytes(ContextPtr) const { return {}; }
 
+    /// Data which we are going to read is sorted by sorting key specified in StorageMetadataPtr.
+    /// For example in Iceberg it's a valid query to change sort_order for table, but older files will
+    /// not be rewritten and will be left unsorted or with previous sort order.
+    /// In this case we shouldn't use read in order optimization.
+    virtual bool isDataSortedBySortingKey(StorageMetadataPtr, ContextPtr) const { return false; }
+
     /// Some data lakes specify information for reading files from disks.
     /// For example, Iceberg has Parquet schema field ids in its metadata for reading files.
     virtual ColumnMapperPtr getColumnMapperForObject(ObjectInfoPtr /**/) const { return nullptr; }

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Constant.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Constant.h
@@ -138,4 +138,5 @@ DEFINE_ICEBERG_FIELD_COMPOUND(data_file, null_value_counts);
 DEFINE_ICEBERG_FIELD_COMPOUND(data_file, lower_bounds);
 DEFINE_ICEBERG_FIELD_COMPOUND(data_file, upper_bounds);
 DEFINE_ICEBERG_FIELD_COMPOUND(data_file, referenced_data_file);
+DEFINE_ICEBERG_FIELD_COMPOUND(data_file, sort_order_id);
 }

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.h
@@ -84,6 +84,7 @@ public:
     std::optional<size_t> totalRows(ContextPtr Local_context) const override;
     std::optional<size_t> totalBytes(ContextPtr Local_context) const override;
 
+    bool isDataSortedBySortingKey(StorageMetadataPtr storage_metadata_snapshot, ContextPtr context) const override;
 
     ColumnMapperPtr getColumnMapperForObject(ObjectInfoPtr object_info) const override;
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFile.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFile.cpp
@@ -196,6 +196,7 @@ ManifestFileContent::ManifestFileContent(
             "Cannot read Iceberg table: manifest file '{}' doesn't have field '{}' in its metadata",
             manifest_file_name,
             f_schema);
+
     Poco::Dynamic::Var json = parser.parse(*schema_json_string);
     const Poco::JSON::Object::Ptr & schema_object = json.extract<Poco::JSON::Object::Ptr>();
     Int32 manifest_schema_id = schema_object->getValue<int>(f_schema_id);
@@ -414,6 +415,16 @@ ManifestFileContent::ManifestFileContent(
                     break;
             }
         }
+        std::optional<Int32> sort_order_id = std::nullopt;
+        if (manifest_file_deserializer.hasPath(c_data_file_sort_order_id))
+        {
+             auto sort_order_id_value = manifest_file_deserializer.getValueFromRowByName(i, c_data_file_sort_order_id);
+            if (sort_order_id_value.isNull())
+                sort_order_id = std::nullopt;
+            else
+                sort_order_id = sort_order_id_value.safeGet<Int32>();
+        }
+
         switch (content_type)
         {
             case FileContentType::DATA:
@@ -430,7 +441,8 @@ ManifestFileContent::ManifestFileContent(
                     columns_infos,
                     file_format,
                     /*reference_data_file = */ std::nullopt,
-                    /*equality_ids*/ std::nullopt);
+                    /*equality_ids*/ std::nullopt,
+                    sort_order_id);
                 break;
             case FileContentType::POSITION_DELETE:
             {
@@ -541,6 +553,17 @@ bool ManifestFileContent::hasBoundsInfoInManifests() const
 const std::set<Int32> & ManifestFileContent::getColumnsIDsWithBounds() const
 {
     return column_ids_which_have_bounds;
+}
+
+bool ManifestFileContent::areAllDataFilesSortedBySortOrderID(Int32 sort_order_id) const
+{
+    for (const auto & file : data_files_without_deleted)
+    {
+        if (!file.sort_order_id.has_value() || (*file.sort_order_id != sort_order_id))
+            return false;
+    }
+    return true;
+
 }
 
 size_t ManifestFileContent::getSizeInMemory() const

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFile.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFile.cpp
@@ -559,6 +559,10 @@ bool ManifestFileContent::areAllDataFilesSortedBySortOrderID(Int32 sort_order_id
 {
     for (const auto & file : data_files_without_deleted)
     {
+        // Treat missing sort_order_id as "not sorted by the expected order".
+        // This can happen if:
+        // 1. The field is not present in older Iceberg format versions.
+        // 2. The data file was written without sort order information.
         if (!file.sort_order_id.has_value() || (*file.sort_order_id != sort_order_id))
             return false;
     }

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFile.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFile.cpp
@@ -418,7 +418,7 @@ ManifestFileContent::ManifestFileContent(
         std::optional<Int32> sort_order_id;
         if (manifest_file_deserializer.hasPath(c_data_file_sort_order_id))
         {
-             auto sort_order_id_value = manifest_file_deserializer.getValueFromRowByName(i, c_data_file_sort_order_id);
+            auto sort_order_id_value = manifest_file_deserializer.getValueFromRowByName(i, c_data_file_sort_order_id);
             if (sort_order_id_value.isNull())
                 sort_order_id = std::nullopt;
             else

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFile.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFile.cpp
@@ -566,6 +566,7 @@ bool ManifestFileContent::areAllDataFilesSortedBySortOrderID(Int32 sort_order_id
         if (!file.sort_order_id.has_value() || (*file.sort_order_id != sort_order_id))
             return false;
     }
+    /// Empty manifest (no data files) is considered sorted by definition
     return true;
 
 }

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFile.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFile.cpp
@@ -415,7 +415,7 @@ ManifestFileContent::ManifestFileContent(
                     break;
             }
         }
-        std::optional<Int32> sort_order_id = std::nullopt;
+        std::optional<Int32> sort_order_id;
         if (manifest_file_deserializer.hasPath(c_data_file_sort_order_id))
         {
              auto sort_order_id_value = manifest_file_deserializer.getValueFromRowByName(i, c_data_file_sort_order_id);

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFile.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFile.h
@@ -77,6 +77,7 @@ struct ManifestFileEntry
     std::optional<String> reference_data_file_path; // For position delete files only.
     std::optional<std::vector<Int32>> equality_ids;
 
+    /// Data file is sorted with this sort_order_id (can be read from metadata.json)
     std::optional<Int32> sort_order_id;
 };
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFile.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFile.h
@@ -76,6 +76,8 @@ struct ManifestFileEntry
     String file_format;
     std::optional<String> reference_data_file_path; // For position delete files only.
     std::optional<std::vector<Int32>> equality_ids;
+
+    std::optional<Int32> sort_order_id;
 };
 
 /**
@@ -135,6 +137,8 @@ public:
     bool hasBoundsInfoInManifests() const;
     const std::set<Int32> & getColumnsIDsWithBounds() const;
     const String & getPathToManifestFile() const { return path_to_manifest_file; }
+
+    bool areAllDataFilesSortedBySortOrderID(Int32 sort_order_id) const;
 
     ManifestFileContent(ManifestFileContent &&) = delete;
     ManifestFileContent & operator=(ManifestFileContent &&) = delete;

--- a/src/Storages/ObjectStorage/StorageObjectStorageConfiguration.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorageConfiguration.h
@@ -139,6 +139,7 @@ public:
 
     virtual std::optional<size_t> totalRows(ContextPtr) { return {}; }
     virtual std::optional<size_t> totalBytes(ContextPtr) { return {}; }
+    virtual bool isDataSortedBySortingKey(StorageMetadataPtr, ContextPtr) const { return false; }
 
     // This function is used primarily for datalake storages to check if we need to update metadata
     // snapshot before executing operation (SELECT, INSERT, etc) to enforce that schema in operation metadata snapshot

--- a/src/Storages/ObjectStorage/StorageObjectStorageConfiguration.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorageConfiguration.h
@@ -139,6 +139,9 @@ public:
 
     virtual std::optional<size_t> totalRows(ContextPtr) { return {}; }
     virtual std::optional<size_t> totalBytes(ContextPtr) { return {}; }
+    /// NOTE: In this function we are going to check is data which we are goint to read sorted by sorting key specified in StorageMetadataPtr.
+    /// It may look confusing that his function checks only StorageMetadataPtr, and not StorageSnapshot.
+    /// However snapshot_id is specified in StorageMetadataPtr, so we can extract necessary information from it.
     virtual bool isDataSortedBySortingKey(StorageMetadataPtr, ContextPtr) const { return false; }
 
     // This function is used primarily for datalake storages to check if we need to update metadata

--- a/src/Storages/ObjectStorage/StorageObjectStorageConfiguration.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorageConfiguration.h
@@ -139,8 +139,8 @@ public:
 
     virtual std::optional<size_t> totalRows(ContextPtr) { return {}; }
     virtual std::optional<size_t> totalBytes(ContextPtr) { return {}; }
-    /// NOTE: In this function we are going to check is data which we are goint to read sorted by sorting key specified in StorageMetadataPtr.
-    /// It may look confusing that his function checks only StorageMetadataPtr, and not StorageSnapshot.
+    /// NOTE: In this function we are going to check is data which we are going to read sorted by sorting key specified in StorageMetadataPtr.
+    /// It may look confusing that this function checks only StorageMetadataPtr, and not StorageSnapshot.
     /// However snapshot_id is specified in StorageMetadataPtr, so we can extract necessary information from it.
     virtual bool isDataSortedBySortingKey(StorageMetadataPtr, ContextPtr) const { return false; }
 

--- a/tests/integration/test_storage_iceberg_no_spark/conftest.py
+++ b/tests/integration/test_storage_iceberg_no_spark/conftest.py
@@ -30,6 +30,7 @@ def started_cluster_iceberg_no_spark():
             with_minio=True,
             with_azurite=True,
             stay_alive=True,
+            with_iceberg_catalog=True,
         )
         cluster.add_instance(
             "node2",

--- a/tests/integration/test_storage_iceberg_no_spark/test_read_in_order_with_pyiceberg.py
+++ b/tests/integration/test_storage_iceberg_no_spark/test_read_in_order_with_pyiceberg.py
@@ -4,7 +4,7 @@ from pyiceberg.catalog import load_catalog
 from helpers.config_cluster import minio_secret_key, minio_access_key
 import uuid
 import pyarrow as pa
-from datetime import date, timedelta, time, datetime
+from datetime import date, timedelta
 from pyiceberg.schema import Schema, NestedField
 import random
 from pyiceberg.types import (

--- a/tests/integration/test_storage_iceberg_no_spark/test_read_in_order_with_pyiceberg.py
+++ b/tests/integration/test_storage_iceberg_no_spark/test_read_in_order_with_pyiceberg.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+
+from pyiceberg.catalog import load_catalog
+from helpers.config_cluster import minio_secret_key, minio_access_key
+import uuid
+import pyarrow as pa
+from datetime import date, timedelta, time, datetime
+from pyiceberg.schema import Schema, NestedField
+import random
+from pyiceberg.types import (
+    StringType,
+    IntegerType,
+    LongType,
+    FloatType,
+    DoubleType,
+    TimestampType,
+    BooleanType,
+    TimestamptzType,
+    DateType,
+    TimeType,
+    UUIDType,
+    BinaryType,
+    DecimalType,
+    StructType,
+    ListType,
+    MapType,
+)
+from pyiceberg.partitioning import PartitionSpec, PartitionField
+from pyiceberg.table.sorting import SortOrder, SortField
+from pyiceberg.transforms import IdentityTransform
+
+BASE_URL = "http://rest:8181/v1"
+BASE_URL_LOCAL = "http://localhost:8182/v1"
+BASE_URL_LOCAL_RAW = "http://localhost:8182"
+
+CATALOG_NAME = "demo"
+
+def load_catalog_impl(started_cluster):
+    return load_catalog(
+        CATALOG_NAME,
+        **{
+            "uri": BASE_URL_LOCAL_RAW,
+            "type": "rest",
+            "s3.endpoint": f"http://{started_cluster.get_instance_ip('minio')}:9000",
+            "s3.access-key-id": minio_access_key,
+            "s3.secret-access-key": minio_secret_key,
+        },
+    )
+
+def create_table(
+    catalog,
+    namespace,
+    table,
+    schema,
+    partition_spec,
+    sort_order
+):
+    return catalog.create_table(
+        identifier=f"{namespace}.{table}",
+        schema=schema,
+        location=f"s3://warehouse-rest/data",
+        partition_spec=partition_spec,
+        sort_order=sort_order,
+    )
+
+def create_clickhouse_iceberg_database(
+    started_cluster, node, name, additional_settings={}
+):
+    settings = {
+        "catalog_type": "rest",
+        "warehouse": "demo",
+        "storage_endpoint": "http://minio:9000/warehouse-rest",
+    }
+
+    settings.update(additional_settings)
+
+    node.query(
+        f"""
+DROP DATABASE IF EXISTS {name};
+SET allow_database_iceberg=true;
+SET write_full_path_in_iceberg_metadata=1;
+CREATE DATABASE {name} ENGINE = DataLakeCatalog('{BASE_URL}', 'minio', '{minio_secret_key}')
+SETTINGS {",".join((k+"="+repr(v) for k, v in settings.items()))}
+    """
+    )
+    show_result = node.query(f"SHOW DATABASE {name}")
+    assert minio_secret_key not in show_result
+    assert "HIDDEN" in show_result
+
+
+def test_sort_order(started_cluster_iceberg_no_spark):
+    instance = started_cluster_iceberg_no_spark.instances["node1"]
+    root_namespace = f"clickhouse_{uuid.uuid4()}"
+    catalog = load_catalog_impl(started_cluster_iceberg_no_spark)
+
+    schema = Schema(
+        NestedField(
+            field_id=1, name="boolean_col", field_type=BooleanType(), required=False
+        ),
+        NestedField(field_id=2, name="long_col", field_type=LongType(), required=False),
+        NestedField(
+            field_id=3, name="double_col", field_type=DoubleType(), required=False
+        ),
+        NestedField(
+            field_id=4, name="string_col", field_type=StringType(), required=False
+        ),
+        NestedField(field_id=5, name="date_col", field_type=DateType(), required=False),
+    )
+
+    partition_spec = PartitionSpec()
+
+    sort_order = SortOrder(SortField(source_id=4, transform=IdentityTransform()))
+    table = create_table(catalog, root_namespace, "test", schema, partition_spec, sort_order)
+
+    data = []
+    for _ in range(100):
+        data.append(
+            {
+                "boolean_col": random.choice([True, False]),
+                "long_col": random.randint(1000, 10000),
+                "double_col": round(random.uniform(1.0, 500.0), 2),
+                "string_col": f"User{random.randint(1, 1000)}",
+                "date_col": date.today()
+                - timedelta(days=random.randint(0, 3650)),
+            }
+        )
+
+    df = pa.Table.from_pylist(data)
+    table.append(df)
+
+    create_clickhouse_iceberg_database(started_cluster_iceberg_no_spark, instance, CATALOG_NAME)
+    print(instance.query(f"SHOW TABLES FROM {CATALOG_NAME};"))
+
+    result = instance.query(f"SELECT string_col FROM {CATALOG_NAME}.`{root_namespace}.test` ORDER BY string_col SETTINGS optimize_read_in_order=0").strip().split("\n")
+    assert result == list(sorted(result))
+
+    result = instance.query(f"SELECT string_col FROM {CATALOG_NAME}.`{root_namespace}.test` ORDER BY string_col SETTINGS optimize_read_in_order=1").strip().split("\n")
+    assert result == list(sorted(result))

--- a/tests/integration/test_storage_iceberg_no_spark/test_read_in_order_with_pyiceberg.py
+++ b/tests/integration/test_storage_iceberg_no_spark/test_read_in_order_with_pyiceberg.py
@@ -109,6 +109,7 @@ def test_sort_order(started_cluster_iceberg_no_spark):
 
     partition_spec = PartitionSpec()
 
+    # NOTE pyiceberg ignore sort order when writing data, so writes data unsorted
     sort_order = SortOrder(SortField(source_id=4, transform=IdentityTransform()))
     table = create_table(catalog, root_namespace, "test", schema, partition_spec, sort_order)
 
@@ -131,6 +132,7 @@ def test_sort_order(started_cluster_iceberg_no_spark):
     create_clickhouse_iceberg_database(started_cluster_iceberg_no_spark, instance, CATALOG_NAME)
     print(instance.query(f"SHOW TABLES FROM {CATALOG_NAME};"))
 
+    # NOTE Read in order optimization shouldn't work because data is not sorted
     result = instance.query(f"SELECT string_col FROM {CATALOG_NAME}.`{root_namespace}.test` ORDER BY string_col SETTINGS optimize_read_in_order=0").strip().split("\n")
     assert result == list(sorted(result))
 

--- a/tests/integration/test_storage_iceberg_no_spark/test_read_in_order_with_pyiceberg.py
+++ b/tests/integration/test_storage_iceberg_no_spark/test_read_in_order_with_pyiceberg.py
@@ -25,7 +25,7 @@ from pyiceberg.types import (
     ListType,
     MapType,
 )
-from pyiceberg.partitioning import PartitionSpec, PartitionField
+from pyiceberg.partitioning import PartitionSpec
 from pyiceberg.table.sorting import SortOrder, SortField
 from pyiceberg.transforms import IdentityTransform
 

--- a/tests/integration/test_storage_iceberg_no_spark/test_read_in_order_with_pyiceberg.py
+++ b/tests/integration/test_storage_iceberg_no_spark/test_read_in_order_with_pyiceberg.py
@@ -126,7 +126,7 @@ def test_sort_order(started_cluster_iceberg_no_spark):
     assert result == list(sorted(result))
     assert 'PartialSortingTransform' in (
         instance.query(
-            f"SELECT string_col FROM {CATALOG_NAME}.`{root_namespace}.test` ORDER BY string_col SETTINGS optimize_read_in_order=0"
+            f"EXPLAIN PIPELINE SELECT string_col FROM {CATALOG_NAME}.`{root_namespace}.test` ORDER BY string_col SETTINGS optimize_read_in_order=0"
         )
     )
 

--- a/tests/integration/test_storage_iceberg_no_spark/test_read_in_order_with_pyiceberg.py
+++ b/tests/integration/test_storage_iceberg_no_spark/test_read_in_order_with_pyiceberg.py
@@ -109,7 +109,7 @@ def test_sort_order(started_cluster_iceberg_no_spark):
 
     partition_spec = PartitionSpec()
 
-    # NOTE pyiceberg ignore sort order when writing data, so writes data unsorted
+    # NOTE pyiceberg ignores sort order when writing data, so writes data unsorted
     sort_order = SortOrder(SortField(source_id=4, transform=IdentityTransform()))
     table = create_table(catalog, root_namespace, "test", schema, partition_spec, sort_order)
 

--- a/tests/integration/test_storage_iceberg_no_spark/test_read_in_order_with_pyiceberg.py
+++ b/tests/integration/test_storage_iceberg_no_spark/test_read_in_order_with_pyiceberg.py
@@ -9,21 +9,10 @@ from pyiceberg.schema import Schema, NestedField
 import random
 from pyiceberg.types import (
     StringType,
-    IntegerType,
     LongType,
-    FloatType,
     DoubleType,
-    TimestampType,
     BooleanType,
-    TimestamptzType,
     DateType,
-    TimeType,
-    UUIDType,
-    BinaryType,
-    DecimalType,
-    StructType,
-    ListType,
-    MapType,
 )
 from pyiceberg.partitioning import PartitionSpec
 from pyiceberg.table.sorting import SortOrder, SortField

--- a/tests/integration/test_storage_iceberg_no_spark/test_read_in_order_with_pyiceberg.py
+++ b/tests/integration/test_storage_iceberg_no_spark/test_read_in_order_with_pyiceberg.py
@@ -124,6 +124,17 @@ def test_sort_order(started_cluster_iceberg_no_spark):
     # NOTE Read in order optimization shouldn't work because data is not sorted
     result = instance.query(f"SELECT string_col FROM {CATALOG_NAME}.`{root_namespace}.test` ORDER BY string_col SETTINGS optimize_read_in_order=0").strip().split("\n")
     assert result == list(sorted(result))
+    assert 'PartialSortingTransform' in (
+        instance.query(
+            f"SELECT string_col FROM {CATALOG_NAME}.`{root_namespace}.test` ORDER BY string_col SETTINGS optimize_read_in_order=0"
+        )
+    )
 
     result = instance.query(f"SELECT string_col FROM {CATALOG_NAME}.`{root_namespace}.test` ORDER BY string_col SETTINGS optimize_read_in_order=1").strip().split("\n")
+    assert 'PartialSortingTransform' in (
+        instance.query(
+            f"SELECT string_col FROM {CATALOG_NAME}.`{root_namespace}.test` ORDER BY string_col SETTINGS optimize_read_in_order=1"
+        )
+    )
+
     assert result == list(sorted(result))

--- a/tests/integration/test_storage_iceberg_no_spark/test_read_in_order_with_pyiceberg.py
+++ b/tests/integration/test_storage_iceberg_no_spark/test_read_in_order_with_pyiceberg.py
@@ -133,7 +133,7 @@ def test_sort_order(started_cluster_iceberg_no_spark):
     result = instance.query(f"SELECT string_col FROM {CATALOG_NAME}.`{root_namespace}.test` ORDER BY string_col SETTINGS optimize_read_in_order=1").strip().split("\n")
     assert 'PartialSortingTransform' in (
         instance.query(
-            f"SELECT string_col FROM {CATALOG_NAME}.`{root_namespace}.test` ORDER BY string_col SETTINGS optimize_read_in_order=1"
+            f"EXPLAIN PIPELINE SELECT string_col FROM {CATALOG_NAME}.`{root_namespace}.test` ORDER BY string_col SETTINGS optimize_read_in_order=1"
         )
     )
 

--- a/tests/integration/test_storage_iceberg_with_spark/test_read_in_order.py
+++ b/tests/integration/test_storage_iceberg_with_spark/test_read_in_order.py
@@ -15,7 +15,6 @@ def get_array(query_result: str):
 
 @pytest.mark.parametrize("storage_type", ["s3", "azure", "local"])
 def test_read_in_order(started_cluster_iceberg_with_spark,  storage_type):
-    pytest.skip("Disabled because spark cannot correctly set sort_order_id for manifest files, issue https://github.com/apache/iceberg/issues/13634")
     instance = started_cluster_iceberg_with_spark.instances["node1"]
     spark = started_cluster_iceberg_with_spark.spark_session
     TABLE_NAME = "test_read_in_order_" + storage_type + "_" + get_uuid_str()
@@ -34,6 +33,27 @@ def test_read_in_order(started_cluster_iceberg_with_spark,  storage_type):
 
     spark.sql(f"INSERT INTO {TABLE_NAME} VALUES (1,'a'), (3, 'c')")
     spark.sql(f"INSERT INTO {TABLE_NAME} VALUES (2,'d'), (4, 'f')")
+
+    # HACK This is terribly ugly hack, because of the issue:https://github.com/apache/iceberg/issues/13634
+    # Iceberg sort order looks relativy new feature. There are no writer implementations which support it properly.
+    # For example pyiceberg doesn't support it at all, you can specify sort order, but data will be written unsorted.
+    # Spark implementation supports it, i.e. write sorted data, but doesn't write proper sort_order_id in manifest files (always write 0).
+    # Here we manually modify metadata file to set actual sort order to id 0.
+    with open(f"/var/lib/clickhouse/user_files/iceberg_data/default/{TABLE_NAME}/metadata/v4.metadata.json", "rb") as f:
+        content = json.load(f)
+        for order in content['sort-orders']:
+            if order['order-id'] == 1:
+                order_found = order
+                break
+        else:
+            raise Exception("Sort order with id 1 not found")
+        order_found['order-id'] = 0
+        content['sort-orders'] = [order_found]
+        content['default-sort-order-id'] = 0
+
+        with open(f"/var/lib/clickhouse/user_files/iceberg_data/default/{TABLE_NAME}/metadata/v4.metadata.json", "w") as out_f:
+            json.dump(content, out_f)
+    # HACK END
 
     files = default_upload_directory(
         started_cluster_iceberg_with_spark,

--- a/tests/integration/test_storage_iceberg_with_spark/test_read_in_order.py
+++ b/tests/integration/test_storage_iceberg_with_spark/test_read_in_order.py
@@ -37,7 +37,7 @@ def test_read_in_order(started_cluster_iceberg_with_spark,  storage_type):
     # HACK This is terribly ugly hack, because of the issue:https://github.com/apache/iceberg/issues/13634
     # Iceberg sort order looks relatively new feature. There are no writer implementations which support it properly.
     # For example pyiceberg doesn't support it at all, you can specify sort order, but data will be written unsorted.
-    # Spark implementation supports it, i.e. write sorted data, but doesn't write proper sort_order_id in manifest files (always write 0).
+    # Spark implementation supports it, i.e. writes sorted data, but doesn't write proper sort_order_id in manifest files (always writes 0).
     # Here we manually modify metadata file to set actual sort order to id 0.
     with open(f"/var/lib/clickhouse/user_files/iceberg_data/default/{TABLE_NAME}/metadata/v4.metadata.json", "rb") as f:
         content = json.load(f)

--- a/tests/integration/test_storage_iceberg_with_spark/test_read_in_order.py
+++ b/tests/integration/test_storage_iceberg_with_spark/test_read_in_order.py
@@ -35,7 +35,7 @@ def test_read_in_order(started_cluster_iceberg_with_spark,  storage_type):
     spark.sql(f"INSERT INTO {TABLE_NAME} VALUES (2,'d'), (4, 'f')")
 
     # HACK This is terribly ugly hack, because of the issue:https://github.com/apache/iceberg/issues/13634
-    # Iceberg sort order looks relativy new feature. There are no writer implementations which support it properly.
+    # Iceberg sort order looks relatively new feature. There are no writer implementations which support it properly.
     # For example pyiceberg doesn't support it at all, you can specify sort order, but data will be written unsorted.
     # Spark implementation supports it, i.e. write sorted data, but doesn't write proper sort_order_id in manifest files (always write 0).
     # Here we manually modify metadata file to set actual sort order to id 0.

--- a/tests/integration/test_storage_iceberg_with_spark/test_read_in_order.py
+++ b/tests/integration/test_storage_iceberg_with_spark/test_read_in_order.py
@@ -1,4 +1,5 @@
 import pytest
+import json
 
 from helpers.iceberg_utils import (
     default_upload_directory,
@@ -14,9 +15,10 @@ def get_array(query_result: str):
 
 @pytest.mark.parametrize("storage_type", ["s3", "azure", "local"])
 def test_read_in_order(started_cluster_iceberg_with_spark,  storage_type):
+    pytest.skip("Disabled because spark cannot correctly set sort_order_id for manifest files, issue https://github.com/apache/iceberg/issues/13634")
     instance = started_cluster_iceberg_with_spark.instances["node1"]
     spark = started_cluster_iceberg_with_spark.spark_session
-    TABLE_NAME = "test_position_deletes_" + storage_type + "_" + get_uuid_str()
+    TABLE_NAME = "test_read_in_order_" + storage_type + "_" + get_uuid_str()
 
     spark.sql(f"""
         CREATE TABLE {TABLE_NAME} (


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Now ClickHouse will not use read-in-order optimization for iceberg if sort order is not specified manifest files (or not the same) with default_sort_order in table. Fixes #89178.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)
