### PR TITLE
Fix `trim`, `ltrim`, `rtrim` functions not working with two arguments

### DIFF
--- a/src/Parsers/ExpressionListParsers.cpp
+++ b/src/Parsers/ExpressionListParsers.cpp
@@ -1757,6 +1757,12 @@ public:
 
         if (state == 2)
         {
+            if (ParserToken(TokenType::Comma).ignore(pos, expected))
+            {
+                action = Action::OPERAND;
+                return mergeElement();
+            }
+
             if (ParserToken(TokenType::ClosingRoundBracket).ignore(pos, expected))
             {
                 if (!mergeElement())

--- a/tests/queries/0_stateless/03722_function_trim_ltrim_rtrim_alias.reference
+++ b/tests/queries/0_stateless/03722_function_trim_ltrim_rtrim_alias.reference
@@ -1,0 +1,44 @@
+-- { echoOn }
+
+SELECT ltrim('   leading   '), trimLeft('   leading   ');
+leading   	leading   
+SELECT ltrim('xxleadingxx', 'x'), trimLeft('xxleadingxx', 'x');
+leadingxx	leadingxx
+SELECT rtrim('   trailing   '), trimRight('   trailing   ');
+   trailing	   trailing
+SELECT rtrim('xxtrailingxx', 'x'), trimRight('xxtrailingxx', 'x');
+xxtrailing	xxtrailing
+SELECT trim('   both   '), trimBoth('   both   ');
+both	both
+SELECT trim('$$both$$', '$'), trimBoth('$$both$$', '$');
+both	both
+SELECT TRIM('   both   '), trimBoth('   both   ');
+both	both
+SELECT TRIM(BOTH '$' FROM '$$both$$'), trimBoth('$$both$$', '$');
+both	both
+SELECT TRIM(LEADING '$' FROM '$$both$$'), trimLeft('$$both$$', '$');
+both$$	both$$
+SELECT TRIM(TRAILING '$' FROM '$$both$$'), trimRight('$$both$$', '$');
+$$both	$$both
+SELECT TRIM(BOTH '' FROM 'xx'), trimBoth('xx', '');
+xx	xx
+SELECT TRIM(LEADING '' FROM 'xx'), trimLeft('xx', '');
+xx	xx
+SELECT TRIM(TRAILING '' FROM 'xx'), trimRight('xx', '');
+xx	xx
+SELECT TRIM(BOTH concat('$', '$') FROM '$$both$$'), trimBoth('$$both$$', '$$');
+both	both
+SELECT ltrim('\t  abc', '\t '), trimLeft('\t  abc', '\t ');
+abc	abc
+SELECT rtrim('abc\t  ', '\t '), trimRight('abc\t  ', '\t ');
+abc	abc
+SELECT TrIm('  x  '), trimBoth('  x  ');
+x	x
+SELECT LTRIM('  x  '), trimLeft('  x  ');
+x  	x  
+SELECT LtRiM('  x  '), trimLeft('  x  ');
+x  	x  
+SELECT RTRIM('  x  '), trimRight('  x  ');
+  x	  x
+SELECT RtRiM('  x  '), trimRight('  x  ');
+  x	  x

--- a/tests/queries/0_stateless/03722_function_trim_ltrim_rtrim_alias.sql
+++ b/tests/queries/0_stateless/03722_function_trim_ltrim_rtrim_alias.sql
@@ -1,0 +1,30 @@
+-- { echoOn }
+
+SELECT ltrim('   leading   '), trimLeft('   leading   ');
+SELECT ltrim('xxleadingxx', 'x'), trimLeft('xxleadingxx', 'x');
+
+SELECT rtrim('   trailing   '), trimRight('   trailing   ');
+SELECT rtrim('xxtrailingxx', 'x'), trimRight('xxtrailingxx', 'x');
+
+SELECT trim('   both   '), trimBoth('   both   ');
+SELECT trim('$$both$$', '$'), trimBoth('$$both$$', '$');
+SELECT TRIM('   both   '), trimBoth('   both   ');
+
+SELECT TRIM(BOTH '$' FROM '$$both$$'), trimBoth('$$both$$', '$');
+SELECT TRIM(LEADING '$' FROM '$$both$$'), trimLeft('$$both$$', '$');
+SELECT TRIM(TRAILING '$' FROM '$$both$$'), trimRight('$$both$$', '$');
+SELECT TRIM(BOTH '' FROM 'xx'), trimBoth('xx', '');
+SELECT TRIM(LEADING '' FROM 'xx'), trimLeft('xx', '');
+SELECT TRIM(TRAILING '' FROM 'xx'), trimRight('xx', '');
+SELECT TRIM(BOTH concat('$', '$') FROM '$$both$$'), trimBoth('$$both$$', '$$');
+
+SELECT ltrim('\t  abc', '\t '), trimLeft('\t  abc', '\t ');
+SELECT rtrim('abc\t  ', '\t '), trimRight('abc\t  ', '\t ');
+
+SELECT TrIm('  x  '), trimBoth('  x  ');
+
+SELECT LTRIM('  x  '), trimLeft('  x  ');
+SELECT LtRiM('  x  '), trimLeft('  x  ');
+
+SELECT RTRIM('  x  '), trimRight('  x  ');
+SELECT RtRiM('  x  '), trimRight('  x  ');


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `trim`, `ltrim`, `rtrim` functions not working with two arguments. Closes https://github.com/ClickHouse/ClickHouse/issues/90170.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

### Details

The following query does not work:

```sql
SELECT trim(' ClickHouse ', ' ');
```

Resolves #90170.
