### PR TITLE
Support XDG-compliant locations for the ClickHouse Client config file

### DIFF
--- a/docs/en/interfaces/cli.md
+++ b/docs/en/interfaces/cli.md
@@ -423,8 +423,10 @@ clickhouse-client
 #### Configuration file {#ai-sql-generation-configuration-file}
 
 For more control over AI settings, configure them in your ClickHouse Client configuration file located at:
-- `~/.clickhouse-client/config.xml` (XML format)
-- `~/.clickhouse-client/config.yaml` (YAML format)
+- `$XDG_CONFIG_HOME/clickhouse/config.xml` (or `~/.config/clickhouse/config.xml` if `XDG_CONFIG_HOME` is not set) (XML format)
+- `$XDG_CONFIG_HOME/clickhouse/config.yaml` (or `~/.config/clickhouse/config.yaml` if `XDG_CONFIG_HOME` is not set) (YAML format)
+- `~/.clickhouse-client/config.xml` (XML format, legacy location)
+- `~/.clickhouse-client/config.yaml` (YAML format, legacy location)
 - Or specify a custom location with `--config-file`
 
 <Tabs>
@@ -772,6 +774,7 @@ ClickHouse Client uses the first existing file of the following:
 
 - A file that is defined with the `-c [ -C, --config, --config-file ]` parameter.
 - `./clickhouse-client.[xml|yaml|yml]`
+- `$XDG_CONFIG_HOME/clickhouse/config.[xml|yaml|yml]` (or `~/.config/clickhouse/config.[xml|yaml|yml]` if `XDG_CONFIG_HOME` is not set)
 - `~/.clickhouse-client/config.[xml|yaml|yml]`
 - `/etc/clickhouse-client/config.[xml|yaml|yml]`
 

--- a/src/Common/Config/getClientConfigPath.cpp
+++ b/src/Common/Config/getClientConfigPath.cpp
@@ -1,4 +1,5 @@
 #include <Common/Config/getClientConfigPath.h>
+#include <Common/XDGBaseDirectories.h>
 
 #include <filesystem>
 #include <vector>
@@ -15,8 +16,14 @@ std::optional<std::string> getClientConfigPath(const std::string & home_path)
 
     std::vector<std::string> names;
     names.emplace_back("./clickhouse-client");
+
+    auto xdg_config_home = XDGBaseDirectories::getConfigurationHome();
+    if (!xdg_config_home.empty())
+        names.emplace_back(xdg_config_home / "config");
+
     if (!home_path.empty())
         names.emplace_back(home_path + "/.clickhouse-client/config");
+
     names.emplace_back("/etc/clickhouse-client/config");
 
     for (const auto & name : names)


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add support for loading ClickHouse Client configuration from XDG Base Directory paths (e.g., `~/.config/clickhouse/config.xml`) in addition to the legacy `~/.clickhouse-client/` location. Resolves #89882

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

### Details

Resolves #89882.

This PR makes ClickHouse Client compliant with the [XDG Base Directory specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).

#### Configuration Search Order
The client now searches for configuration files in the following order of precedence:

1. **Current directory:** `./.clickhouse-client/config.xml` (Unchanged)
2. **[New] XDG config home:** `$XDG_CONFIG_HOME/clickhouse/config.xml` (defaults to `~/.config/clickhouse/config.xml` if the env var is not set)
3. **Legacy home directory:** `~/.clickhouse-client/config.xml` (Unchanged, for backward compatibility)
4. **System global:** `/etc/clickhouse-client/config.xml` (Unchanged)

#### Related Changes

I have also submitted a corresponding PR to the `chdig` submodule to support XDG paths there as well.
- **Related chdig PR:** https://github.com/azat/chdig/pull/169

**Note** that this PR does not update the submodule pointer yet.
