### PR TITLE
Prevent crash with invalid second parameter of File Engine

### DIFF
--- a/src/Storages/StorageFile.cpp
+++ b/src/Storages/StorageFile.cpp
@@ -2434,6 +2434,9 @@ void registerStorageFile(StorageFactory & factory)
             if (0 <= source_fd) /// File descriptor
                 return std::make_shared<StorageFile>(source_fd, storage_args);
 
+            if (!file_source)
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Second argument must be path or file descriptor");
+
             /// User's file
             return std::make_shared<StorageFile>(*file_source, storage_args);
         },

--- a/tests/queries/0_stateless/03720_file_engine_second_crash.sql
+++ b/tests/queries/0_stateless/03720_file_engine_second_crash.sql
@@ -1,0 +1,2 @@
+-- Fuzzer. Second argument is some complex expression.
+CREATE TABLE `t141` (`c0` Date) ENGINE = File(`c0`, (+`c0`.2) >= ANY(SELECT '307:21:40.753024937'::Time64(3)::Time64(3) OFFSET 0 ROWS)); -- {serverError BAD_ARGUMENTS}


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Details:
Prevent crash with invalid second parameter of File Engine

Seen in this BuzzHouse report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=90276&sha=4f44eac4c3bd888c6885bf5a0e1240104357b72e&name_0=PR&name_1=BuzzHouse%20%28amd_ubsan%29

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
