### PR TITLE
Add setting to prevent large partitions count

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -6985,7 +6985,7 @@ Max rows of iceberg parquet data file on insert operation.
 Max bytes of iceberg parquet data file on insert operation.
 )", 0) \
     DECLARE(UInt64, iceberg_insert_max_partitions, 100, R"(
-Max allowed partitions count per one insert operation.
+Max allowed partitions count per one insert operation for Iceberg table engine.
 )", 0) \
     DECLARE(Float, min_os_cpu_wait_time_ratio_to_throw, 0.0, "Min ratio between OS CPU wait (OSCPUWaitMicroseconds metric) and busy (OSCPUVirtualTimeMicroseconds metric) times to consider rejecting queries. Linear interpolation between min and max ratio is used to calculate the probability, the probability is 0 at this point.", 0) \
     DECLARE(Float, max_os_cpu_wait_time_ratio_to_throw, 0.0, "Max ratio between OS CPU wait (OSCPUWaitMicroseconds metric) and busy (OSCPUVirtualTimeMicroseconds metric) times to consider rejecting queries. Linear interpolation between min and max ratio is used to calculate the probability, the probability is 1 at this point.", 0) \

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -6984,6 +6984,9 @@ Max rows of iceberg parquet data file on insert operation.
     DECLARE(UInt64, iceberg_insert_max_bytes_in_data_file, 1_GiB, R"(
 Max bytes of iceberg parquet data file on insert operation.
 )", 0) \
+    DECLARE(UInt64, iceberg_insert_max_partitions, 100, R"(
+Max allowed partitions count per one insert operation.
+)", 0) \
     DECLARE(Float, min_os_cpu_wait_time_ratio_to_throw, 0.0, "Min ratio between OS CPU wait (OSCPUWaitMicroseconds metric) and busy (OSCPUVirtualTimeMicroseconds metric) times to consider rejecting queries. Linear interpolation between min and max ratio is used to calculate the probability, the probability is 0 at this point.", 0) \
     DECLARE(Float, max_os_cpu_wait_time_ratio_to_throw, 0.0, "Max ratio between OS CPU wait (OSCPUWaitMicroseconds metric) and busy (OSCPUVirtualTimeMicroseconds metric) times to consider rejecting queries. Linear interpolation between min and max ratio is used to calculate the probability, the probability is 1 at this point.", 0) \
     DECLARE(Bool, enable_producing_buckets_out_of_order_in_aggregation, true, R"(

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -63,6 +63,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"enable_lazy_columns_replication", false, true, "Enable lazy columns replication in JOIN and ARRAY JOIN by default"},
             {"allow_special_serialization_kinds_in_output_formats", false, true, "Enable direct output of special columns representations like Sparse/Replicated in some output formats"},
             {"allow_experimental_alias_table_engine", false, false, "New setting"},
+            {"iceberg_insert_max_partitions", 100, 100, "New setting."},
             {"input_format_parquet_local_time_as_utc", false, true, "Use more appropriate type DateTime64(..., 'UTC') for parquet 'local time without timezone' type."},
             {"input_format_parquet_verify_checksums", true, true, "New setting."},
             {"output_format_parquet_write_checksums", false, true, "New setting."},

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/ChunkPartitioner.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/ChunkPartitioner.h
@@ -41,6 +41,8 @@ private:
     std::vector<std::optional<size_t>> function_params;
     std::vector<String> columns_to_apply;
     std::vector<DataTypePtr> result_data_types;
+
+    size_t max_partitions_count;
 };
 
 #endif

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
@@ -641,6 +641,8 @@ void IcebergStorageSink::consume(Chunk & chunk)
 
     for (const auto & [partition_key, part_chunk] : partition_result)
     {
+        if (!part_chunk.hasRows())
+            continue;
         if (!writer_per_partition_key.contains(partition_key))
         {
             auto writer = MultipleFileWriter(

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
@@ -641,8 +641,6 @@ void IcebergStorageSink::consume(Chunk & chunk)
 
     for (const auto & [partition_key, part_chunk] : partition_result)
     {
-        if (!part_chunk.hasRows())
-            continue;
         if (!writer_per_partition_key.contains(partition_key))
         {
             auto writer = MultipleFileWriter(


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add setting to prevent large partitions count

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

### Details

Motivation: MergeTree contains the same setting. This prevents the user from using a large amount of RAM. Example:

```
:) CREATE TABLE foo2 (x Int32) ENGINE = MergeTree() ORDER BY x PARTITION BY icebergBucket(1000, x) SETTINGS iceberg_insert_max_rows_in_data_file=10000;

CREATE TABLE foo2
(
    `x` Int32
)
ENGINE = MergeTree
PARTITION BY icebergBucket(1000, x)
ORDER BY x
SETTINGS iceberg_insert_max_rows_in_data_file = 10000

Query id: da0f4fce-f5c1-4f91-a924-2b7a9c51783a

Ok.

0 rows in set. Elapsed: 0.036 sec. 

:) INSERT INTO foo2 SELECT 1000 * sin(number)
FROM numbers(1, 99999999) SETTINGS iceberg_insert_max_rows_in_data_file=10000;

INSERT INTO foo2
SETTINGS iceberg_insert_max_rows_in_data_file = 10000
SELECT 1000 * sin(number)
FROM numbers(1, 99999999)
SETTINGS iceberg_insert_max_rows_in_data_file = 10000

Query id: 975d9b18-c543-4368-859c-be659a00ac41


Elapsed: 0.043 sec. 

Received exception:
Code: 252. DB::Exception: Too many partitions for single INSERT block (more than 100). The limit is controlled by 'max_partitions_per_insert_block' setting. Large number of partitions is a common misconception. It will lead to severe negative performance impact, including slow server startup, slow INSERT queries and slow SELECT queries. Recommended total number of partitions for a table is under 1000..10000. Please note, that partitioning is not intended to speed up SELECT queries (ORDER BY key is sufficient to make range queries fast). Partitions are intended for data manipulation (DROP PARTITION, etc). (TOO_MANY_PARTS)

:) INSERT INTO foo2 SELECT 1000 * sin(number)
FROM numbers(1, 99999999) SETTINGS iceberg_insert_max_rows_in_data_file=10000, max_partitions_per_insert_block=100000000;

INSERT INTO foo2
SETTINGS iceberg_insert_max_rows_in_data_file = 10000, max_partitions_per_insert_block = 100000000
SELECT 1000 * sin(number)
FROM numbers(1, 99999999)
SETTINGS iceberg_insert_max_rows_in_data_file = 10000, max_partitions_per_insert_block = 100000000

Query id: d0a2ee7e-2aab-42d7-8608-9084f17d3a64

Ok.

99999999 rows in set. Elapsed: 74.035 sec. Processed 100.00 million rows, 800.00 MB (1.35 million rows/s., 10.81 MB/s.)
Peak memory usage: 572.88 MiB.

```
