### PR TITLE
Text index: Add direct read support for array function `has`

### DIFF
--- a/docs/en/engines/table-engines/mergetree-family/invertedindexes.md
+++ b/docs/en/engines/table-engines/mergetree-family/invertedindexes.md
@@ -302,7 +302,6 @@ SELECT count() FROM tab WHERE hasAllTokens(comment, ['clickhouse', 'olap']);
 #### `has` {#functions-example-has}
 
 Array function [has](/sql-reference/functions/array-functions#has) matches against a single token in the array of strings.
-This function also takes advantage of the [Direct Read](#direct-read) optimization.
 
 Example:
 

--- a/docs/en/engines/table-engines/mergetree-family/invertedindexes.md
+++ b/docs/en/engines/table-engines/mergetree-family/invertedindexes.md
@@ -302,6 +302,7 @@ SELECT count() FROM tab WHERE hasAllTokens(comment, ['clickhouse', 'olap']);
 #### `has` {#functions-example-has}
 
 Array function [has](/sql-reference/functions/array-functions#has) matches against a single token in the array of strings.
+This function also takes advantage of the [Direct Read](#direct-read) optimization.
 
 Example:
 
@@ -448,7 +449,7 @@ Direct read is controlled by two settings:
 Also, the text index must be fully materialized to use direct reading (use `ALTER TABLE ... MATERIALIZE INDEX` for that).
 
 **Supported functions**
-The direct read optimization supports functions `hasToken`, `hasAllTokens`, and `hasAnyTokens`.
+The direct read optimization supports functions `hasToken`, `hasAllTokens` and `hasAnyTokens` for text columns and `has` for Array(String) and Array(FixedString) columns.
 These functions can also be combined by AND, OR, and NOT operators.
 The WHERE clause can also contain additional non-text-search-functions filters (for text columns or other columns) - in that case, the direct read optimization will still be used but less effective (it only applies to the supported text search functions).
 

--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
@@ -106,7 +106,8 @@ bool MergeTreeIndexConditionText::isSupportedFunctionForDirectRead(const String 
 {
     return function_name == "hasToken"
         || function_name == "hasAnyTokens"
-        || function_name == "hasAllTokens";
+        || function_name == "hasAllTokens"
+        || function_name == "has";
 }
 
 bool MergeTreeIndexConditionText::isSupportedFunction(const String & function_name)

--- a/tests/queries/0_stateless/02346_text_index_direct_read_array.reference
+++ b/tests/queries/0_stateless/02346_text_index_direct_read_array.reference
@@ -1,0 +1,27 @@
+- Test direct read optimization from text log
+has support
+-- with String
+64
+64
+64
+64
+-- with FixedString
+64
+64
+64
+Added: [__text_index_array_idx_has_c4a68c2ce23f89654d4a300ffd1608fd], Removed: [arr]
+Added: [__text_index_array_idx_has_fd524b4383cdf00d8ac1dbd21287a802], Removed: [arr]
+Added: [__text_index_array_idx_has_0fc9fd0129434693589f4df4eea8aad0], Removed: [arr]
+Added: [__text_index_array_idx_has_6721de899fed06851f6b29c44e5140bd], Removed: [arr]
+Added: [__text_index_array_fixed_idx_has_c4a68c2ce23f89654d4a300ffd1608fd], Removed: [arr_fixed]
+Added: [__text_index_array_fixed_idx_has_fd524b4383cdf00d8ac1dbd21287a802], Removed: [arr_fixed]
+Added: [__text_index_array_fixed_idx_has_0fc9fd0129434693589f4df4eea8aad0], Removed: [arr_fixed]
+- Test direct read optimization with EXPLAIN
+Filter column: __text_index_array_idx_has_c4a68c2ce23f89654d4a300ffd1608fd (removed)
+Filter column: __text_index_array_fixed_idx_has_c4a68c2ce23f89654d4a300ffd1608fd (removed)
+- Test some corner cases (just in case)
+64
+64
+64
+64
+0

--- a/tests/queries/0_stateless/02346_text_index_direct_read_array.sql
+++ b/tests/queries/0_stateless/02346_text_index_direct_read_array.sql
@@ -1,0 +1,89 @@
+-- Tags: no-parallel, no-parallel-replicas
+-- Tag no-parallel -- due to access to the system.text_log
+-- Tag no-parallel-replicas -- direct read is not compatible with parallel replicas
+
+SET log_queries = 1;
+
+-- Affects the number of read rows.
+SET allow_experimental_full_text_index = 1;
+SET use_skip_indexes_on_data_read = 1;
+SET query_plan_direct_read_from_text_index = 1;
+SET max_rows_to_read = 0; -- system.text_log can be really big
+SET enable_analyzer = 0; -- To produce consistent explain outputs
+
+----------------------------------------------------
+SELECT '- Test direct read optimization from text log';
+
+DROP TABLE IF EXISTS tab;
+
+CREATE TABLE tab
+(
+    id UInt32,
+    arr Array(String),
+    arr_fixed Array(FixedString(3)),
+    INDEX array_idx(arr) TYPE text(tokenizer = 'splitByNonAlpha') GRANULARITY 1,
+    INDEX array_fixed_idx(arr_fixed) TYPE text(tokenizer = 'splitByNonAlpha') GRANULARITY 1,
+)
+ENGINE = MergeTree()
+ORDER BY (id)
+SETTINGS index_granularity = 1;
+
+INSERT INTO tab SELECT 2 * number, ['foo', 'bar'], ['foo', 'bar'] FROM numbers(64);
+INSERT INTO tab SELECT 2 * number + 1, ['baz def'], ['baz'] FROM numbers(64);
+
+SELECT 'has support';
+
+SELECT '-- with String';
+SELECT count() FROM tab WHERE has(arr, 'foo');
+SELECT count() FROM tab WHERE has(arr, 'bar');
+SELECT count() FROM tab WHERE has(arr, 'baz');
+SELECT count() FROM tab WHERE has(arr, 'def');
+
+SELECT '-- with FixedString';
+SELECT count() FROM tab WHERE has(arr_fixed, toFixedString('foo', 3));
+SELECT count() FROM tab WHERE has(arr_fixed, toFixedString('bar', 3));
+SELECT count() FROM tab WHERE has(arr_fixed, toFixedString('baz', 3));
+
+----------------------------------------------------
+-- Now check the logs all at once (one by one is too slow)
+----------------------------------------------------
+SYSTEM FLUSH LOGS text_log;
+
+SELECT message
+FROM (
+     SELECT event_time_microseconds, message FROM system.text_log
+     WHERE logger_name = 'optimizeDirectReadFromTextIndex' AND startsWith(message, 'Added:')
+     ORDER BY event_time_microseconds DESC LIMIT 7
+)
+ORDER BY event_time_microseconds ASC;
+
+----------------------------------------------------
+-- Now check that EXPLAIN produces the expected output for the same queries.
+-- So this AFTER checking the text_log otherwise the entries will be duplicated.
+----------------------------------------------------
+SELECT '- Test direct read optimization with EXPLAIN';
+
+SELECT trim(explain) FROM
+(
+    EXPLAIN actions = 1 SELECT count() FROM tab WHERE has(arr, 'foo') SETTINGS use_skip_indexes_on_data_read = 1
+) WHERE explain LIKE '%Filter column:%';
+
+
+SELECT trim(explain) FROM
+(
+    EXPLAIN actions = 1 SELECT count() FROM tab WHERE has(arr_fixed, toFixedString('foo', 3)) SETTINGS use_skip_indexes_on_data_read = 1
+) WHERE explain LIKE '%Filter column:%';
+
+
+SELECT '- Test some corner cases (just in case)';
+-- This at the end, after we checked the logs
+SELECT count() FROM tab WHERE has(arr, 'foo') AND has(arr, 'bar'); -- all foo contain bar
+SELECT count() FROM tab WHERE has(arr, 'foo') OR has(arr, 'bar'); -- only the foo contain bar
+
+SELECT count() FROM tab WHERE has(arr, 'baz') AND has(arr, 'def'); -- all baz contain def, but throw tokenizer
+SELECT count() FROM tab WHERE has(arr, 'baz') OR has(arr, 'def'); -- only baz contain def, but throw tokenizer
+
+SELECT count() FROM tab WHERE has(arr, 'foo') AND has(arr, 'def'); -- no foo contain def
+
+
+DROP TABLE tab;


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
The text index now supports direct read for array function `has`.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)
