### PR TITLE
Fix crash in `L2DistanceTransposed` when precision exceeds `QBit` element size

### DIFF
--- a/src/Functions/array/l2DistanceTransposed.cpp
+++ b/src/Functions/array/l2DistanceTransposed.cpp
@@ -150,7 +150,7 @@ public:
                 "The third argument (precision) of function {} must be in range [1, {}] for {} QBit, got {}",
                 getName(),
                 element_size,
-                element_size == 16 ? "BFloat16" : (element_size == 32 ? "Float32" : "Float64"),
+                zeroth_arg_type->getElementType()->getName(),
                 precision);
 
         return std::make_shared<DataTypeFloat64>();

--- a/src/Functions/array/l2DistanceTransposed.cpp
+++ b/src/Functions/array/l2DistanceTransposed.cpp
@@ -142,45 +142,18 @@ public:
                 precision_col.type->getName());
 
         const auto precision = precision_col.column->getUInt(0);
+        const auto element_size = zeroth_arg_type->getElementSize();
 
-        switch (first_arg_type->getNestedType()->getTypeId())
-        {
-            case TypeIndex::BFloat16:
-                if (precision == 0 || precision > 16)
-                    throw Exception(
-                        ErrorCodes::BAD_ARGUMENTS,
-                        "The third argument (precision) of function {} must be in range [1, 16] for BFloat16 QBit, got {}",
-                        getName(),
-                        precision);
-                return std::make_shared<DataTypeFloat64>();
+        if (precision == 0 || precision > element_size)
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "The third argument (precision) of function {} must be in range [1, {}] for {} QBit, got {}",
+                getName(),
+                element_size,
+                element_size == 16 ? "BFloat16" : (element_size == 32 ? "Float32" : "Float64"),
+                precision);
 
-            case TypeIndex::Float32:
-                if (precision == 0 || precision > 32)
-                    throw Exception(
-                        ErrorCodes::BAD_ARGUMENTS,
-                        "The third argument (precision) of function {} must be in range [1, 32] for Float32 QBit, got {}",
-                        getName(),
-                        precision);
-                return std::make_shared<DataTypeFloat64>();
-
-            case TypeIndex::Float64:
-                if (precision == 0 || precision > 64)
-                    throw Exception(
-                        ErrorCodes::BAD_ARGUMENTS,
-                        "The third argument (precision) function {} must be in range [1, 64] for Float64 QBit, got {}",
-                        getName(),
-                        precision);
-                return std::make_shared<DataTypeFloat64>();
-
-            default:
-                throw Exception(
-                    ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
-                    "Arguments of function {} have nested or unsupported type {}. The supported types are BFloat16, Float32 and Float64",
-                    getName(),
-                    first_arg_type->getNestedType()->getName());
-        }
-
-        UNREACHABLE();
+        return std::make_shared<DataTypeFloat64>();
     }
 
     /// Validates arguments for optimised L2DistanceTransposed(vec.1, ..., vec.p, qbit_size, ref_vec) case

--- a/tests/queries/0_stateless/03370_l2_distance_transposed_negative.sql.j2
+++ b/tests/queries/0_stateless/03370_l2_distance_transposed_negative.sql.j2
@@ -83,6 +83,6 @@ SELECT L2DistanceTransposed([1.0, 2.0, 3.0]::QBit(Float32, 3), range(rand() % 5 
 SELECT L2DistanceTransposed(''::FixedString(1), materialize(3), [1,2,3]::Array(Float32)); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
 
 -- https://github.com/ClickHouse/ClickHouse/issues/90401
-SELECT L2DistanceTransposed([2, 0, 0, 0, 0, 0, 0, 0]::QBit(Float32, 8), [42.], 33) AS dist settings allow_experimental_qbit_type=1; -- { serverError BAD_ARGUMENTS }
+SELECT L2DistanceTransposed([2, 0, 0, 0, 0, 0, 0, 0]::QBit(Float32, 8), [42.], 33) AS dist; -- { serverError BAD_ARGUMENTS }
 
 {% endfor -%}

--- a/tests/queries/0_stateless/03370_l2_distance_transposed_negative.sql.j2
+++ b/tests/queries/0_stateless/03370_l2_distance_transposed_negative.sql.j2
@@ -82,4 +82,7 @@ SELECT L2DistanceTransposed([1.0, 2.0, 3.0]::QBit(Float32, 3), range(rand() % 5 
 -- Do not allow non-constant size
 SELECT L2DistanceTransposed(''::FixedString(1), materialize(3), [1,2,3]::Array(Float32)); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
 
+-- https://github.com/ClickHouse/ClickHouse/issues/90401
+SELECT L2DistanceTransposed([2, 0, 0, 0, 0, 0, 0, 0]::QBit(Float32, 8), [42.], 33) AS dist settings allow_experimental_qbit_type=1; -- { serverError BAD_ARGUMENTS }
+
 {% endfor -%}


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a bug in `L2DistanceTransposed` that caused crashes when the precision argument exceeded valid range. Closes #90401.

### Details
Closes https://github.com/ClickHouse/ClickHouse/issues/90401
