### PR TITLE
Use implicit key columns from projections

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/optimizeUseNormalProjection.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeUseNormalProjection.cpp
@@ -207,7 +207,7 @@ std::optional<String> optimizeUseNormalProjections(
     {
         for (const auto & col : required_columns)
         {
-            if (!projection->sample_block.has(col) && !projection_virtuals->has(col))
+            if (!projection->metadata->columns.hasColumnOrSubcolumn(GetColumnsOptions::All, col) && !projection_virtuals->has(col))
                 return false;
         }
 

--- a/tests/queries/0_stateless/03722_normal_projection_key_columns.reference
+++ b/tests/queries/0_stateless/03722_normal_projection_key_columns.reference
@@ -1,0 +1,2 @@
+ReadFromMergeTree (region_url_proj)
+https://example.com/page1

--- a/tests/queries/0_stateless/03722_normal_projection_key_columns.sql
+++ b/tests/queries/0_stateless/03722_normal_projection_key_columns.sql
@@ -1,0 +1,34 @@
+SET enable_analyzer = 1;
+-- enable projection for parallel replicas
+SET parallel_replicas_local_plan = 1;
+SET optimize_aggregation_in_order = 0;
+-- avoid using projection index
+SET min_table_rows_to_use_projection_index = 1000000;
+
+CREATE TABLE test_projection
+(
+    id UInt64,
+    event_date Date,
+    user_id UInt32,
+    url String,
+    region String,
+    PROJECTION region_url_proj
+    (
+        SELECT _part_offset ORDER BY region, url
+    )
+)
+ENGINE = MergeTree
+ORDER BY (event_date, id)
+SETTINGS
+    index_granularity = 1, min_bytes_for_wide_part = 0,
+    min_bytes_for_full_part_storage = 0, enable_vertical_merge_algorithm = 0;
+
+INSERT INTO test_projection VALUES (1, '2023-01-01', 101, 'https://example.com/page1', 'europe');
+INSERT INTO test_projection VALUES (2, '2023-01-01', 102, 'https://example.com/page2', 'us_west');
+
+OPTIMIZE TABLE test_projection FINAL;
+
+SELECT trimLeft(explain)
+FROM (EXPLAIN projections = 1 SELECT url FROM test_projection WHERE region = 'europe')
+WHERE explain LIKE '%ReadFromMergeTree%';
+SELECT url FROM test_projection WHERE region = 'europe' ORDER BY ALL;


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix usage of normal projections with complex sorting key

### Details
If the projection sorting key consists of multiple columns, "sample_block" contains a tuple of them. Despite that all key columns are stored in the projection, it is currently not used because "has_all_required_columns" fails to match.

In cases like [that](https://fiddle.clickhouse.com/52f0b44f-a256-4b0c-8329-6b3971528d00) it allows to use both projections
