### PR TITLE
JIT: Avoid extra initialization of result column

### DIFF
--- a/src/DataTypes/DataTypeNullable.cpp
+++ b/src/DataTypes/DataTypeNullable.cpp
@@ -45,7 +45,7 @@ MutableColumnPtr DataTypeNullable::createColumn() const
 
 MutableColumnPtr DataTypeNullable::createUninitializedColumnWithSize(size_t size) const
 {
-    return ColumnNullable::create(nested_data_type->createUninitializedColumnWithSize(size), ColumnUInt8::create());
+    return ColumnNullable::create(nested_data_type->createUninitializedColumnWithSize(size), ColumnUInt8::create(size));
 }
 
 Field DataTypeNullable::getDefault() const

--- a/src/DataTypes/DataTypeNullable.cpp
+++ b/src/DataTypes/DataTypeNullable.cpp
@@ -43,6 +43,11 @@ MutableColumnPtr DataTypeNullable::createColumn() const
     return ColumnNullable::create(nested_data_type->createColumn(), ColumnUInt8::create());
 }
 
+MutableColumnPtr DataTypeNullable::createUninitializedColumnWithSize(size_t size) const
+{
+    return ColumnNullable::create(nested_data_type->createUninitializedColumnWithSize(size), ColumnUInt8::create());
+}
+
 Field DataTypeNullable::getDefault() const
 {
     return Null();

--- a/src/DataTypes/DataTypeNullable.h
+++ b/src/DataTypes/DataTypeNullable.h
@@ -20,6 +20,7 @@ public:
     void updateHashImpl(SipHash & hash) const override;
 
     MutableColumnPtr createColumn() const override;
+    MutableColumnPtr createUninitializedColumnWithSize(size_t size) const override;
 
     Field getDefault() const override;
 

--- a/src/DataTypes/DataTypeNumberBase.cpp
+++ b/src/DataTypes/DataTypeNumberBase.cpp
@@ -18,6 +18,12 @@ MutableColumnPtr DataTypeNumberBase<T>::createColumn() const
 }
 
 template <typename T>
+MutableColumnPtr DataTypeNumberBase<T>::createUninitializedColumnWithSize(size_t size) const
+{
+    return ColumnVector<T>::create(size);
+}
+
+template <typename T>
 bool DataTypeNumberBase<T>::isValueRepresentedByInteger() const
 {
     return is_integer<T>;

--- a/src/DataTypes/DataTypeNumberBase.h
+++ b/src/DataTypes/DataTypeNumberBase.h
@@ -30,6 +30,7 @@ public:
     Field getDefault() const override;
 
     MutableColumnPtr createColumn() const override;
+    MutableColumnPtr createUninitializedColumnWithSize(size_t size) const override;
 
     bool isParametric() const override { return false; }
     bool haveSubtypes() const override { return false; }

--- a/src/DataTypes/IDataType.cpp
+++ b/src/DataTypes/IDataType.cpp
@@ -77,6 +77,13 @@ void IDataType::updateAvgValueSizeHint(const IColumn & column, double & avg_valu
     }
 }
 
+
+MutableColumnPtr IDataType::createUninitializedColumnWithSize(size_t size) const
+{
+    auto column = createColumn();
+    return column->cloneResized(size);
+}
+
 MutableColumnPtr IDataType::createColumn(const ISerialization & serialization) const
 {
     auto kind_stack = serialization.getKindStack();

--- a/src/DataTypes/IDataType.h
+++ b/src/DataTypes/IDataType.h
@@ -172,7 +172,7 @@ public:
 
     /** Creates a column with specified size, without initializing values.
       * This is useful when you need to create a large column to fill later (e.g. the result of a function)
-      * Default implementation use createColumn and cloneResized.
+      * Default implementation uses createColumn and cloneResized.
       */
     virtual MutableColumnPtr createUninitializedColumnWithSize(size_t size) const;
 

--- a/src/DataTypes/IDataType.h
+++ b/src/DataTypes/IDataType.h
@@ -170,6 +170,12 @@ public:
       */
     virtual MutableColumnPtr createColumn() const = 0;
 
+    /** Creates a column with specified size, without initializing values.
+      * This is useful when you need to create a large column to fill later (e.g. the result of a function)
+      * Default implementation use createColumn and cloneResized.
+      */
+    virtual MutableColumnPtr createUninitializedColumnWithSize(size_t size) const;
+
     /** Create empty column for corresponding type and serialization.
      */
     virtual MutableColumnPtr createColumn(const ISerialization & serialization) const;

--- a/src/Interpreters/ExpressionJIT.cpp
+++ b/src/Interpreters/ExpressionJIT.cpp
@@ -79,12 +79,10 @@ public:
         if (!canBeNativeType(*result_type))
             throw Exception(ErrorCodes::LOGICAL_ERROR, "LLVMExecutableFunction unexpected result type in: {}", result_type->getName());
 
-        auto result_column = result_type->createColumn();
+        auto result_column = result_type->createUninitializedColumnWithSize(input_rows_count);
 
         if (input_rows_count)
         {
-            result_column = result_column->cloneResized(input_rows_count);
-
             std::vector<ColumnData> columns(arguments.size() + 1);
             std::vector<ColumnPtr> columns_backup;
 


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Improve JIT function performing by not initializing the result column to zero unnecessarily

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

### Details

Comes from https://github.com/ClickHouse/ClickHouse/pull/90043

While reviewing the changes I noticed that in the case of using JIT some queries were becoming faster because initializing memory was faster. AFAICT we shouldn't need to initialize to 0 the memory of the result column, as it's later written by the functions themselves when they generate the result values.

Example from benchmarks:

`SELECT any(-1 * (((-2 * (number * -3)) * -4) * -5)) FROM numbers(200000000)`

* Before: 0.0.0.0:49000, queries: 200, QPS: 16.549, RPS: 3309746753.517, MiB/s: 25251.364, result RPS: 16.549, result MiB/s: 0.000.
* After: 0.0.0.0:49000, queries: 200, QPS: 20.950, RPS: 4189950729.593, MiB/s: 31966.787, result RPS: 20.950, result MiB/s: 0.000.
