### PR TITLE
Fix flaky 03629_create_or_replace_as_select_with_progress_tcp

### DIFF
--- a/src/QueryPipeline/ReadProgressCallback.cpp
+++ b/src/QueryPipeline/ReadProgressCallback.cpp
@@ -51,31 +51,7 @@ bool ReadProgressCallback::onProgress(uint64_t read_rows, uint64_t read_bytes, c
             return false;
     }
 
-    size_t rows_approx = 0;
-    if ((rows_approx = total_rows_approx.exchange(0)) != 0)
-    {
-        Progress total_rows_progress = {0, 0, rows_approx};
-
-        if (progress_callback)
-            progress_callback(total_rows_progress);
-
-        if (process_list_elem)
-            process_list_elem->updateProgressIn(total_rows_progress);
-    }
-
-    size_t bytes = 0;
-    if ((bytes = total_bytes.exchange(0)) != 0)
-    {
-        Progress total_bytes_progress = {0, 0, 0, bytes};
-
-        if (progress_callback)
-            progress_callback(total_bytes_progress);
-
-        if (process_list_elem)
-            process_list_elem->updateProgressIn(total_bytes_progress);
-    }
-
-    Progress value {read_rows, read_bytes};
+    Progress value {read_rows, read_bytes, total_rows_approx.exchange(0), total_bytes.exchange(0)};
 
     if (progress_callback)
         progress_callback(value);

--- a/tests/queries/0_stateless/00416_pocopatch_progress_in_http_headers.reference
+++ b/tests/queries/0_stateless/00416_pocopatch_progress_in_http_headers.reference
@@ -1,19 +1,16 @@
 &output_format_parallel_formatting=0&max_block_size=5&send_progress_in_http_headers=1&http_headers_progress_interval_ms=0
-< X-ClickHouse-Progress: {"total_rows_to_read":"10"}
 < X-ClickHouse-Progress: {"read_rows":"5","read_bytes":"40","total_rows_to_read":"10"}
 < X-ClickHouse-Progress: {"read_rows":"10","read_bytes":"80","total_rows_to_read":"10"}
 < X-ClickHouse-Progress: {"read_rows":"10","read_bytes":"80","total_rows_to_read":"10","result_rows":"1","result_bytes":"136"}
 < X-ClickHouse-Summary: {"read_rows":"10","read_bytes":"80","written_rows":"0","written_bytes":"0","total_rows_to_read":"10","result_rows":"1","result_bytes":"136"}
 9
 &output_format_parallel_formatting=1&max_block_size=5&send_progress_in_http_headers=1&http_headers_progress_interval_ms=0
-< X-ClickHouse-Progress: {"total_rows_to_read":"10"}
 < X-ClickHouse-Progress: {"read_rows":"5","read_bytes":"40","total_rows_to_read":"10"}
 < X-ClickHouse-Progress: {"read_rows":"10","read_bytes":"80","total_rows_to_read":"10"}
 < X-ClickHouse-Progress: {"read_rows":"10","read_bytes":"80","total_rows_to_read":"10","result_rows":"1","result_bytes":"136"}
 < X-ClickHouse-Summary: {"read_rows":"10","read_bytes":"80","written_rows":"0","written_bytes":"0","total_rows_to_read":"10","result_rows":"1","result_bytes":"136"}
 9
 &max_block_size=1&send_progress_in_http_headers=1&http_headers_progress_interval_ms=0
-< X-ClickHouse-Progress: {"total_rows_to_read":"10"}
 < X-ClickHouse-Progress: {"read_rows":"1","read_bytes":"8","total_rows_to_read":"10"}
 < X-ClickHouse-Progress: {"read_rows":"2","read_bytes":"16","total_rows_to_read":"10"}
 < X-ClickHouse-Progress: {"read_rows":"3","read_bytes":"24","total_rows_to_read":"10"}

--- a/tests/queries/0_stateless/02136_scalar_progress.reference
+++ b/tests/queries/0_stateless/02136_scalar_progress.reference
@@ -1,7 +1,5 @@
-< X-ClickHouse-Progress: {"total_rows_to_read":"100000"}
 < X-ClickHouse-Progress: {"read_rows":"65505","read_bytes":"524040","total_rows_to_read":"100000"}
 < X-ClickHouse-Progress: {"read_rows":"100000","read_bytes":"800000","total_rows_to_read":"100000"}
-< X-ClickHouse-Progress: {"read_rows":"100000","read_bytes":"800000","total_rows_to_read":"100001"}
 < X-ClickHouse-Progress: {"read_rows":"100001","read_bytes":"800001","total_rows_to_read":"100001"}
 < X-ClickHouse-Progress: {"read_rows":"100001","read_bytes":"800001","total_rows_to_read":"100001","result_rows":"1","result_bytes":"272"}
 < X-ClickHouse-Summary: {"read_rows":"100001","read_bytes":"800001","written_rows":"0","written_bytes":"0","total_rows_to_read":"100001","result_rows":"1","result_bytes":"272"}

--- a/tests/queries/0_stateless/02457_insert_select_progress_http.reference
+++ b/tests/queries/0_stateless/02457_insert_select_progress_http.reference
@@ -1,4 +1,3 @@
-< X-ClickHouse-Progress: {"total_rows_to_read":"5"}
 < X-ClickHouse-Progress: {"read_rows":"1","read_bytes":"8","total_rows_to_read":"5"}
 < X-ClickHouse-Progress: {"read_rows":"1","read_bytes":"8","written_rows":"1","written_bytes":"4","total_rows_to_read":"5"}
 < X-ClickHouse-Progress: {"read_rows":"2","read_bytes":"16","written_rows":"1","written_bytes":"4","total_rows_to_read":"5"}


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Details

It fixes `03629_create_or_replace_as_select_with_progress_tcp` by removing separate progress callback and updateProgressIn calls with a progress which consist only of totals.

I couldn't come up with a reason why we keep this calls separate. There is a suspension point (waiting on cond_var inside updateProgressIn call if this query is a low priority one) and instead of once we might call it twice but I don't think is matter.
