### PR TITLE
Expose peak_threads_usage in system.processes (like in system.query_log)

### DIFF
--- a/src/Storages/System/StorageSystemProcesses.cpp
+++ b/src/Storages/System/StorageSystemProcesses.cpp
@@ -68,6 +68,7 @@ ColumnsDescription StorageSystemProcesses::getColumnsDescription()
         {"query_kind", std::make_shared<DataTypeString>(), "The type of the query - SELECT, INSERT, etc."},
 
         {"thread_ids", std::make_shared<DataTypeArray>(std::make_shared<DataTypeUInt64>()), "The list of identifiers of all threads which participated in this query."},
+        {"peak_threads_usage", std::make_shared<DataTypeUInt64>(), "Maximum count of simultaneous threads executing the query."},
         {"ProfileEvents", std::make_shared<DataTypeMap>(std::make_shared<DataTypeString>(), std::make_shared<DataTypeUInt64>()), "ProfileEvents calculated for this query."},
         {"Settings", std::make_shared<DataTypeMap>(std::make_shared<DataTypeString>(), std::make_shared<DataTypeString>()), "The list of modified user-level settings."},
 
@@ -145,6 +146,8 @@ void StorageSystemProcesses::fillData(MutableColumns & res_columns, ContextPtr c
                 threads_array.emplace_back(thread_id);
             res_columns[i++]->insert(threads_array);
         }
+
+        res_columns[i++]->insert(process.peak_threads_usage);
 
         {
             IColumn * column = res_columns[i++].get();

--- a/tests/queries/0_stateless/02117_show_create_table_system.reference
+++ b/tests/queries/0_stateless/02117_show_create_table_system.reference
@@ -660,6 +660,7 @@ CREATE TABLE system.processes
     `normalized_query_hash` UInt64,
     `query_kind` String,
     `thread_ids` Array(UInt64),
+    `peak_threads_usage` UInt64,
     `ProfileEvents` Map(String, UInt64),
     `Settings` Map(String, String),
     `current_database` String,


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Expose `peak_threads_usage` in `system.processes` (like in `system.query_log`).

### Details
Will be used in `chdig` to show correct number of threads.

Follow-up for: https://github.com/ClickHouse/ClickHouse/pull/54335
