### PR TITLE
Stream system.filesystem_cache

### DIFF
--- a/src/Interpreters/Cache/FileCache.cpp
+++ b/src/Interpreters/Cache/FileCache.cpp
@@ -1277,6 +1277,11 @@ void FileCache::iterate(IterateFunc && func, const UserID & user_id)
     }, user_id);
 }
 
+FileCache::CacheIteratorPtr FileCache::getCacheIterator(const UserID & user_id)
+{
+    return metadata.getIterator(user_id);
+}
+
 void FileCache::removeKey(const Key & key, const UserID & user_id)
 {
     assertInitialized();

--- a/src/Interpreters/Cache/FileCache.h
+++ b/src/Interpreters/Cache/FileCache.h
@@ -210,6 +210,9 @@ public:
     using IterateFunc = std::function<void(const FileSegmentInfo &)>;
     void iterate(IterateFunc && func, const UserID & user_id);
 
+    using CacheIteratorPtr = CacheMetadata::IteratorPtr;
+    CacheIteratorPtr getCacheIterator(const UserID & user_id);
+
     void applySettingsIfPossible(const FileCacheSettings & new_settings, FileCacheSettings & actual_settings);
 
     void freeSpaceRatioKeepingThreadFunc();

--- a/src/Interpreters/Cache/Metadata.cpp
+++ b/src/Interpreters/Cache/Metadata.cpp
@@ -338,6 +338,85 @@ void CacheMetadata::iterate(IterateFunc && func, const KeyMetadata::UserID & use
     }
 }
 
+class CacheMetadata::IteratorImpl
+{
+public:
+    IteratorImpl(MetadataBuckets & metadata_buckets_, const UserID & user_id_)
+        : user_id(user_id_)
+        , metadata_buckets(metadata_buckets_)
+        , bucket_it(metadata_buckets_.begin())
+    {
+    }
+
+    bool next(Iterator::OnFileSegmentFunc func)
+    {
+        while (true)
+        {
+            if (bucket_it == metadata_buckets.end())
+                return false;
+
+            if (!bucket_lock)
+                bucket_lock = bucket_it->lock();
+
+            if (!key_it.has_value())
+                key_it = bucket_it->begin();
+
+            if (key_it.value() == bucket_it->end())
+            {
+                ++bucket_it;
+                bucket_lock.reset();
+
+                key_it.reset();
+                key_lock.reset();
+
+                file_segment_it.reset();
+                continue;
+            }
+
+            const auto & key = key_it.value()->second;
+
+            if (!key_lock)
+                key_lock = key->lock();
+
+            if (!file_segment_it.has_value())
+                file_segment_it = key->begin();
+
+            if (file_segment_it.value() == key->end())
+            {
+                ++key_it.value();
+                key_lock.reset();
+
+                file_segment_it.reset();
+                continue;
+            }
+
+            func(FileSegment::getInfo(file_segment_it.value()->second->file_segment));
+            ++(file_segment_it.value());
+            return true;
+        }
+    }
+
+private:
+    const UserID user_id;
+    MetadataBuckets & metadata_buckets;
+    MetadataBuckets::iterator bucket_it;
+    std::optional<MetadataBucket::iterator> key_it;
+    std::optional<KeyMetadata::iterator> file_segment_it;
+
+    std::optional<CacheMetadataGuard::Lock> bucket_lock;
+    LockedKeyPtr key_lock;
+};
+
+bool CacheMetadata::Iterator::next(OnFileSegmentFunc func)
+{
+    return impl->next(func);
+}
+
+CacheMetadata::IteratorPtr CacheMetadata::getIterator(const UserID & user_id)
+{
+    return std::make_unique<Iterator>(std::make_shared<IteratorImpl>(metadata_buckets, user_id));
+}
+
 void CacheMetadata::removeAllKeys(bool if_releasable, const UserID & user_id)
 {
     for (auto & bucket : metadata_buckets)

--- a/src/Interpreters/Cache/Metadata.h
+++ b/src/Interpreters/Cache/Metadata.h
@@ -283,8 +283,6 @@ private:
 
 class CacheMetadata::Iterator
 {
-    friend IteratorPtr CacheMetadata::getIterator(const UserID &);
-    friend class CacheMetadata;
 public:
     using ImplPtr = std::shared_ptr<CacheMetadata::IteratorImpl>;
     explicit Iterator(ImplPtr impl_) : impl(std::move(impl_)) {}

--- a/src/Interpreters/Cache/Metadata.h
+++ b/src/Interpreters/Cache/Metadata.h
@@ -162,6 +162,8 @@ using KeyMetadataPtr = std::shared_ptr<KeyMetadata>;
 class CacheMetadata : private boost::noncopyable
 {
     friend struct KeyMetadata;
+    class IteratorImpl;
+
 public:
     using Key = FileCacheKey;
     using IterateFunc = std::function<void(LockedKey &)>;
@@ -189,6 +191,10 @@ public:
         const UserInfo & user) const;
 
     void iterate(IterateFunc && func, const UserID & user_id);
+
+    class Iterator;
+    using IteratorPtr = std::unique_ptr<Iterator>;
+    IteratorPtr getIterator(const UserID & user_id);
 
     enum class KeyNotFoundPolicy : uint8_t
     {
@@ -239,8 +245,8 @@ private:
     private:
         mutable CacheMetadataGuard guard;
     };
-
-    std::vector<MetadataBucket> metadata_buckets{buckets_num};
+    using MetadataBuckets = std::vector<MetadataBucket>;
+    MetadataBuckets metadata_buckets{buckets_num};
 
     struct DownloadThread
     {
@@ -275,6 +281,20 @@ private:
     void cleanupThreadFunc();
 };
 
+class CacheMetadata::Iterator
+{
+    friend IteratorPtr CacheMetadata::getIterator(const UserID &);
+    friend class CacheMetadata;
+public:
+    using ImplPtr = std::shared_ptr<CacheMetadata::IteratorImpl>;
+    explicit Iterator(ImplPtr impl_) : impl(std::move(impl_)) {}
+
+    using OnFileSegmentFunc = std::function<void(const FileSegmentInfo &)>;
+    bool next(OnFileSegmentFunc func);
+
+protected:
+    ImplPtr impl;
+};
 
 /**
  * `LockedKey` is an object which makes sure that as long as it exists the following is true:

--- a/src/Storages/System/StorageSystemFilesystemCache.cpp
+++ b/src/Storages/System/StorageSystemFilesystemCache.cpp
@@ -1,6 +1,10 @@
 #include <Storages/System/StorageSystemFilesystemCache.h>
 
 #include <Columns/IColumn.h>
+#include <Columns/ColumnString.h>
+#include <Columns/ColumnsNumber.h>
+#include <Columns/ColumnNullable.h>
+#include <Columns/ColumnsDateTime.h>
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/DataTypeNullable.h>
@@ -8,16 +12,221 @@
 #include <Interpreters/Cache/FileCache.h>
 #include <Interpreters/Cache/FileSegment.h>
 #include <Interpreters/Cache/FileCacheFactory.h>
+#include <Processors/QueryPlan/QueryPlan.h>
+#include <Processors/ISource.h>
+#include <Processors/QueryPlan/SourceStepWithFilter.h>
+#include <QueryPipeline/QueryPipelineBuilder.h>
 #include <Disks/IDisk.h>
 
 
 namespace DB
 {
-
-ColumnsDescription StorageSystemFilesystemCache::getColumnsDescription()
+namespace
 {
-    /// TODO: Fill in all the comments.
-    return ColumnsDescription
+class SystemFilesystemCacheSource : public ISource, private WithContext
+{
+public:
+    SystemFilesystemCacheSource(
+        SharedHeader header_,
+        UInt64 max_block_size_,
+        ContextPtr context_)
+        : ISource(header_)
+        , WithContext(context_)
+        , max_block_size(max_block_size_)
+        , user_id(FileCache::getCommonUser().user_id)
+    {
+        auto caches_by_name = FileCacheFactory::instance().getAll();
+        for (const auto & [cache_name, cache_data] : caches_by_name)
+        {
+            unique_caches.insert(cache_data);
+            caches_by_instance[cache_data].push_back(cache_name);
+        }
+
+        current_cache = unique_caches.begin();
+    }
+
+    String getName() const override { return "SystemFilesystemCacheSource"; }
+
+protected:
+    Chunk generate() override
+    {
+        MutableColumnPtr col_cache_name = ColumnString::create();
+        MutableColumnPtr col_cache_base_path = ColumnString::create();
+        MutableColumnPtr col_path = ColumnString::create();
+        MutableColumnPtr col_key = ColumnString::create();
+        MutableColumnPtr col_range_begin = ColumnUInt64::create();
+        MutableColumnPtr col_range_end = ColumnUInt64::create();
+        MutableColumnPtr col_size = ColumnUInt64::create();
+        MutableColumnPtr col_state = ColumnString::create();
+        MutableColumnPtr col_finished_download_time = ColumnDateTime::create();
+        MutableColumnPtr col_hits = ColumnUInt64::create();
+        MutableColumnPtr col_references = ColumnUInt64::create();
+        MutableColumnPtr col_downloaded_size = ColumnUInt64::create();
+        MutableColumnPtr col_kind = ColumnString::create();
+        MutableColumnPtr col_unbound = ColumnUInt8::create();
+        MutableColumnPtr col_user_id = ColumnString::create();
+        MutableColumnPtr col_file_size = ColumnNullable::create(ColumnUInt64::create(), ColumnUInt8::create());
+
+        auto get_total_size = [&] -> size_t
+        {
+            return col_cache_name->byteSize() +
+                col_cache_base_path->byteSize() +
+                col_path->byteSize() +
+                col_key->byteSize() +
+                col_range_begin->byteSize() +
+                col_range_end->byteSize() +
+                col_size->byteSize() +
+                col_state->byteSize() +
+                col_finished_download_time->byteSize() +
+                col_hits->byteSize() +
+                col_references->byteSize() +
+                col_downloaded_size->byteSize() +
+                col_kind->byteSize() +
+                col_unbound->byteSize() +
+                col_user_id->byteSize();
+        };
+
+        size_t num_rows = 0;
+        auto on_file_segment = [&](const FileSegmentInfo & file_segment)
+        {
+            const auto & cache_data = (*current_cache);
+            const auto & cache = cache_data->cache;
+
+            /// There can be several cache names pointing to the same cache object.
+            /// We need to add them all to the output.
+            for (const auto & cache_name : caches_by_instance.at(cache_data))
+            {
+                col_cache_name->insert(cache_name);
+                col_cache_base_path->insert(cache->getBasePath());
+
+                /// Do not use `file_segment->getPath` here because it will lead to nullptr dereference
+                /// (because file_segments in getSnapshot do not have `cache` field set)
+                const auto path = cache->getFileSegmentPath(
+                    file_segment.key, file_segment.offset, file_segment.kind,
+                    FileCache::UserInfo(file_segment.user_id, file_segment.user_weight));
+
+                col_path->insert(path);
+                col_key->insert(file_segment.key.toString());
+                col_range_begin->insert(file_segment.range_left);
+                col_range_end->insert(file_segment.range_right);
+                col_size->insert(file_segment.size);
+                col_state->insert(FileSegment::stateToString(file_segment.state));
+                col_finished_download_time->insert(file_segment.download_finished_time);
+                col_hits->insert(file_segment.cache_hits);
+                col_references->insert(file_segment.references);
+                col_downloaded_size->insert(file_segment.downloaded_size);
+                col_kind->insert(toString(file_segment.kind));
+                col_unbound->insert(file_segment.is_unbound);
+                col_user_id->insert(file_segment.user_id);
+
+                std::error_code ec;
+                auto size = fs::file_size(path, ec);
+                if (!ec)
+                    col_file_size->insert(size);
+                else
+                    col_file_size->insertDefault();
+
+                ++num_rows;
+            }
+        };
+
+        while (true)
+        {
+            if (num_rows && max_block_size && get_total_size() > max_block_size)
+                break;
+
+            if (current_cache == unique_caches.end())
+                break;
+
+            const auto & cache = (*current_cache)->cache;
+            if (!cache->isInitialized())
+            {
+                ++current_cache;
+                current_cache_iterator = nullptr;
+                continue;
+            }
+
+            if (!current_cache_iterator)
+                current_cache_iterator = cache->getCacheIterator(user_id);
+
+            if (!current_cache_iterator->next(on_file_segment))
+            {
+                ++current_cache;
+                current_cache_iterator = nullptr;
+                continue;
+            }
+        }
+
+        if (!num_rows)
+            return {};
+
+        Columns columns{
+            std::move(col_cache_name), std::move(col_cache_base_path), std::move(col_path),
+            std::move(col_key), std::move(col_range_begin), std::move(col_range_end), std::move(col_size),
+            std::move(col_state), std::move(col_finished_download_time), std::move(col_hits),
+            std::move(col_references), std::move(col_downloaded_size), std::move(col_kind), std::move(col_unbound),
+            std::move(col_user_id), std::move(col_file_size)};
+
+        return Chunk(std::move(columns), num_rows);
+    }
+
+private:
+    const UInt64 max_block_size;
+    const FileCacheUserInfo::UserID user_id;
+
+    using CachesSet = std::unordered_set<FileCacheFactory::FileCacheDataPtr>;
+    CachesSet unique_caches;
+    std::unordered_map<FileCacheFactory::FileCacheDataPtr, std::vector<std::string>> caches_by_instance;
+
+    CachesSet::iterator current_cache;
+    FileCache::CacheIteratorPtr current_cache_iterator;
+};
+
+class ReadFromSystemFilesystemCache final : public SourceStepWithFilter
+{
+public:
+    ReadFromSystemFilesystemCache(
+        const Names & column_names_,
+        const SelectQueryInfo & query_info_,
+        const StorageSnapshotPtr & storage_snapshot_,
+        const ContextPtr & context_,
+        const Block & header,
+        UInt64 max_block_size_)
+        : SourceStepWithFilter(
+            std::make_shared<const Block>(header),
+            column_names_,
+            query_info_,
+            storage_snapshot_,
+            context_)
+        , storage_limits(query_info.storage_limits)
+        , max_block_size(max_block_size_)
+    {
+    }
+
+    String getName() const override { return "ReadFromSystemFilesystemCache"; }
+
+    void initializePipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings &) override
+    {
+        auto source = std::make_shared<SystemFilesystemCacheSource>(getOutputHeader(), max_block_size, context);
+        source->setStorageLimits(storage_limits);
+        processors.emplace_back(source);
+        pipeline.init(Pipe(std::move(source)));
+    }
+
+    /// TODO: void applyFilters(ActionDAGNodes added_filter_nodes) can be implemented to filter out cache names
+
+private:
+    std::shared_ptr<const StorageLimitsList> storage_limits;
+    const UInt64 max_block_size;
+};
+
+}
+
+StorageSystemFilesystemCache::StorageSystemFilesystemCache(const StorageID & table_id_)
+    : IStorage(table_id_)
+{
+    StorageInMemoryMetadata storage_metadata;
+    storage_metadata.setColumns(ColumnsDescription(
     {
         {"cache_name", std::make_shared<DataTypeString>(), "Name of the cache object. Can be used in `SYSTEM DESCRIBE FILESYSTEM CACHE <name>`, `SYSTEM DROP FILESYSTEM CACHE <name>` commands"},
         {"cache_base_path", std::make_shared<DataTypeString>(), "Path to the base directory where all caches files (of a cache identidied by `cache_name`) are stored."},
@@ -35,67 +244,30 @@ ColumnsDescription StorageSystemFilesystemCache::getColumnsDescription()
         {"unbound", std::make_shared<DataTypeNumber<UInt8>>(), "Internal implementation flag"},
         {"user_id", std::make_shared<DataTypeString>(), "User id of the user which created the file segment"},
         {"file_size", std::make_shared<DataTypeNullable>(std::make_shared<DataTypeUInt64>()), "File size of the file to which current file segment belongs"},
-    };
+    }));
+    setInMemoryMetadata(storage_metadata);
 }
 
-StorageSystemFilesystemCache::StorageSystemFilesystemCache(const StorageID & table_id_)
-    : IStorageSystemOneBlock(table_id_, getColumnsDescription())
+void StorageSystemFilesystemCache::read(
+    QueryPlan & query_plan,
+    const Names & column_names,
+    const StorageSnapshotPtr & storage_snapshot,
+    SelectQueryInfo & query_info,
+    ContextPtr context,
+    QueryProcessingStage::Enum /*processed_stage*/,
+    const size_t max_block_size,
+    const size_t /*num_streams*/)
 {
-}
-
-void StorageSystemFilesystemCache::fillData(MutableColumns & res_columns, ContextPtr, const ActionsDAG::Node *, std::vector<UInt8>) const
-{
-    auto caches_by_name = FileCacheFactory::instance().getAll();
-    std::unordered_set<FileCacheFactory::FileCacheDataPtr> caches;
-    for (const auto & [_, cache_data] : caches_by_name)
-        caches.insert(cache_data);
-    std::unordered_map<FileCacheFactory::FileCacheDataPtr, std::vector<std::string>> caches_by_instance;
-    for (const auto & [cache_name, cache_data] : caches_by_name)
-        caches_by_instance[cache_data].push_back(cache_name);
-
-    for (const auto & cache_data : caches)
-    {
-        const auto & cache = cache_data->cache;
-        if (!cache->isInitialized())
-            continue;
-
-        cache->iterate([&](const FileSegment::Info & file_segment)
-        {
-            for (const auto & cache_name : caches_by_instance.at(cache_data))
-            {
-                size_t i = 0;
-                res_columns[i++]->insert(cache_name);
-                res_columns[i++]->insert(cache->getBasePath());
-
-                /// Do not use `file_segment->getPath` here because it will lead to nullptr dereference
-                /// (because file_segments in getSnapshot doesn't have `cache` field set)
-
-                const auto path = cache->getFileSegmentPath(
-                    file_segment.key, file_segment.offset, file_segment.kind,
-                    FileCache::UserInfo(file_segment.user_id, file_segment.user_weight));
-                res_columns[i++]->insert(path);
-                res_columns[i++]->insert(file_segment.key.toString());
-                res_columns[i++]->insert(file_segment.range_left);
-                res_columns[i++]->insert(file_segment.range_right);
-                res_columns[i++]->insert(file_segment.size);
-                res_columns[i++]->insert(FileSegment::stateToString(file_segment.state));
-                res_columns[i++]->insert(file_segment.download_finished_time);
-                res_columns[i++]->insert(file_segment.cache_hits);
-                res_columns[i++]->insert(file_segment.references);
-                res_columns[i++]->insert(file_segment.downloaded_size);
-                res_columns[i++]->insert(toString(file_segment.kind));
-                res_columns[i++]->insert(file_segment.is_unbound);
-                res_columns[i++]->insert(file_segment.user_id);
-
-                std::error_code ec;
-                auto size = fs::file_size(path, ec);
-                if (!ec)
-                    res_columns[i++]->insert(size);
-                else
-                    res_columns[i++]->insertDefault();
-            }
-        }, FileCache::getCommonUser().user_id);
-    }
+    storage_snapshot->check(column_names);
+    auto header = storage_snapshot->metadata->getSampleBlockWithVirtuals(getVirtualsList());
+    auto read_step = std::make_unique<ReadFromSystemFilesystemCache>(
+        column_names,
+        query_info,
+        storage_snapshot,
+        context,
+        header,
+        max_block_size);
+    query_plan.addStep(std::move(read_step));
 }
 
 }

--- a/src/Storages/System/StorageSystemFilesystemCache.h
+++ b/src/Storages/System/StorageSystemFilesystemCache.h
@@ -29,17 +29,24 @@ namespace DB
  * FORMAT Vertical
  */
 
-class StorageSystemFilesystemCache final : public IStorageSystemOneBlock
+class StorageSystemFilesystemCache final : public IStorage
 {
 public:
     explicit StorageSystemFilesystemCache(const StorageID & table_id_);
 
     std::string getName() const override { return "SystemFilesystemCache"; }
 
-    static ColumnsDescription getColumnsDescription();
+    bool isSystemStorage() const override { return true; }
 
-protected:
-    void fillData(MutableColumns & res_columns, ContextPtr, const ActionsDAG::Node *, std::vector<UInt8>) const override;
+    void read(
+        QueryPlan & query_plan,
+        const Names & column_names,
+        const StorageSnapshotPtr & storage_snapshot,
+        SelectQueryInfo & query_info,
+        ContextPtr context,
+        QueryProcessingStage::Enum processed_stage,
+        size_t max_block_size,
+        size_t num_streams) override;
 };
 
 }


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Stream chunks in `system.filesystem_cache` table instead of creating a single chunk with all cache state. Reading filesystem cache state can take a long time for large caches and consume a lot of memory, so streaming it is indispensable for large deployments.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)
