### PR TITLE
Remove flaky OS_DARWIN_SDK_VERSION detection

### DIFF
--- a/cmake/darwin/default_libs.cmake
+++ b/cmake/darwin/default_libs.cmake
@@ -13,20 +13,5 @@ set(CMAKE_OSX_DEPLOYMENT_TARGET 10.15)
 add_library(Threads::Threads INTERFACE IMPORTED)
 set_target_properties(Threads::Threads PROPERTIES INTERFACE_LINK_LIBRARIES pthread)
 
-if(NOT CMAKE_CROSSCOMPILING)
-    execute_process(
-        COMMAND readlink -f /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
-        OUTPUT_VARIABLE ACTUAL_SDK_PATH
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-    string(REGEX MATCH "MacOSX([0-9]+\\.[0-9]+)" _ ${ACTUAL_SDK_PATH})
-    set(OS_DARWIN_SDK_VERSION ${CMAKE_MATCH_1})
-    if(${OS_DARWIN_SDK_VERSION} MATCHES "^[0-9]+\\.[0-9]+")
-        message(STATUS "Detected OSX SDK Version: ${OS_DARWIN_SDK_VERSION}")
-    else ()
-        message(WARNING "Unexpected OSX SDK Version: ${OS_DARWIN_SDK_VERSION}")
-    endif()
-endif()
-
 include (cmake/unwind.cmake)
 include (cmake/cxx.cmake)

--- a/contrib/postgres-cmake/CMakeLists.txt
+++ b/contrib/postgres-cmake/CMakeLists.txt
@@ -82,13 +82,6 @@ if (OS_DARWIN OR OS_FREEBSD OR USE_MUSL)
     target_compile_definitions(_libpq PRIVATE -DSTRERROR_R_INT=1)
 endif()
 
-# Mac 15.4 / Xcode 16.3 started defining srtchrnul
-# Could be cleaned up if properly resolved in upstream
-# https://www.postgresql.org/message-id/flat/385134.1743523038%40sss.pgh.pa.us
-if (OS_DARWIN AND OS_DARWIN_SDK_VERSION AND OS_DARWIN_SDK_VERSION VERSION_GREATER_EQUAL 15.4)
-    target_compile_definitions(_libpq PRIVATE -DHAVE_STRCHRNUL)
-endif()
-
 target_link_libraries (_libpq PRIVATE OpenSSL::SSL)
 
 add_library(ch_contrib::libpq ALIAS _libpq)


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Remove flaky OS_DARWIN_SDK_VERSION detection

It's no longer needed: https://github.com/postgres/postgres/commit/6da2ba1d8a031984eb016fed6741bb2ac945f19d

Backporting to 25.11 to fix Nix build.
Closes https://github.com/ClickHouse/ClickHouse/pull/90299


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
