### PR TITLE
Revert "Bump libssh to master 2025-11-17"

### DIFF
--- a/contrib/libssh-cmake/CMakeLists.txt
+++ b/contrib/libssh-cmake/CMakeLists.txt
@@ -35,7 +35,6 @@ set(libssh_SRCS
     ${LIB_SOURCE_DIR}/src/external/blowfish.c
     ${LIB_SOURCE_DIR}/src/external/chacha.c
     ${LIB_SOURCE_DIR}/src/external/poly1305.c
-    ${LIB_SOURCE_DIR}/src/external/sntrup761.c
     ${LIB_SOURCE_DIR}/src/getpass.c
     ${LIB_SOURCE_DIR}/src/init.c
     ${LIB_SOURCE_DIR}/src/kdf.c
@@ -62,7 +61,6 @@ set(libssh_SRCS
     ${LIB_SOURCE_DIR}/src/string.c
     ${LIB_SOURCE_DIR}/src/threads.c
     ${LIB_SOURCE_DIR}/src/token.c
-    ${LIB_SOURCE_DIR}/src/ttyopts.c
     ${LIB_SOURCE_DIR}/src/wrapper.c
     # some files of libssh/src/ are missing - why?
 
@@ -71,21 +69,15 @@ set(libssh_SRCS
     # files missing - why?
 
     # LIBCRYPT specific
-    ${LIB_SOURCE_DIR}/src/crypto_common.c
-    ${LIB_SOURCE_DIR}/src/curve25519_crypto.c
     ${LIB_SOURCE_DIR}/src/dh_crypto.c
     ${LIB_SOURCE_DIR}/src/ecdh_crypto.c
-    ${LIB_SOURCE_DIR}/src/getrandom_crypto.c
-    ${LIB_SOURCE_DIR}/src/gzip.c
     ${LIB_SOURCE_DIR}/src/libcrypto.c
-    ${LIB_SOURCE_DIR}/src/md_crypto.c
     ${LIB_SOURCE_DIR}/src/pki_crypto.c
-    ${LIB_SOURCE_DIR}/src/pki_context.c
-    ${LIB_SOURCE_DIR}/src/sntrup761.c
     ${LIB_SOURCE_DIR}/src/threads/libcrypto.c
 
     ${LIB_SOURCE_DIR}/src/bind.c
     ${LIB_SOURCE_DIR}/src/bind_config.c
+    ${LIB_SOURCE_DIR}/src/options.c
     ${LIB_SOURCE_DIR}/src/server.c
 )
 

--- a/contrib/libssh-cmake/linux/x86-64/config.h
+++ b/contrib/libssh-cmake/linux/x86-64/config.h
@@ -82,36 +82,63 @@
 /* Define to 1 if you have the <pthread.h> header file. */
 #define HAVE_PTHREAD_H 1
 
-/* Define to 1 if you have elliptic curve cryptography in openssl */
+/* Define to 1 if you have eliptic curve cryptography in openssl */
 #define HAVE_OPENSSL_ECC 1
 
-/* Define to 1 if you have elliptic curve cryptography in gcrypt */
+/* Define to 1 if you have eliptic curve cryptography in gcrypt */
 /* #undef HAVE_GCRYPT_ECC */
 
-/* Define to 1 if you have elliptic curve cryptography */
+/* Define to 1 if you have eliptic curve cryptography */
 #define HAVE_ECC 1
 
-/* Define to 1 if you have gl_flags as a glob_t struct member */
+/* Define to 1 if you have DSA */
+/* #undef HAVE_DSA */
+
+/* Define to 1 if you have gl_flags as a glob_t sturct member */
 #define HAVE_GLOB_GL_FLAGS_MEMBER 1
 
-/* Define to 1 if you have gcrypt with ChaCha20/Poly1305 support */
-/* #undef HAVE_GCRYPT_CHACHA_POLY */
+/* Define to 1 if you have OpenSSL with Ed25519 support */
+#define HAVE_OPENSSL_ED25519 1
 
-/* Define to 1 if you have gcrypt with curve25519 support */
-/* #undef HAVE_GCRYPT_CURVE25519 */
+/* Define to 1 if you have OpenSSL with X25519 support */
+#define HAVE_OPENSSL_X25519 1
 
 /*************************** FUNCTIONS ***************************/
 
-/* Define to 1 if you have the `EVP_chacha20' function. */
-#define HAVE_OPENSSL_EVP_CHACHA20 1
+/* Define to 1 if you have the `EVP_aes128_ctr' function. */
+#define HAVE_OPENSSL_EVP_AES_CTR 1
 
-/* Define to 1 if you have the `EVP_KDF_CTX_new_id' or `EVP_KDF_CTX_new` function. */
-#define HAVE_OPENSSL_EVP_KDF_CTX 1
+/* Define to 1 if you have the `EVP_aes128_cbc' function. */
+#define HAVE_OPENSSL_EVP_AES_CBC 1
+
+/* Define to 1 if you have the `EVP_aes128_gcm' function. */
+/* #undef HAVE_OPENSSL_EVP_AES_GCM */
+
+/* Define to 1 if you have the `CRYPTO_THREADID_set_callback' function. */
+#define HAVE_OPENSSL_CRYPTO_THREADID_SET_CALLBACK 1
+
+/* Define to 1 if you have the `CRYPTO_ctr128_encrypt' function. */
+#define HAVE_OPENSSL_CRYPTO_CTR128_ENCRYPT 1
+
+/* Define to 1 if you have the `EVP_CIPHER_CTX_new' function. */
+#define HAVE_OPENSSL_EVP_CIPHER_CTX_NEW 1
+
+/* Define to 1 if you have the `EVP_KDF_CTX_new_id' function. */
+/* #undef HAVE_OPENSSL_EVP_KDF_CTX_NEW_ID */
 
 /* Define to 1 if you have the `FIPS_mode' function. */
 #if USE_BORINGSSL
 #define HAVE_OPENSSL_FIPS_MODE 1
 #endif
+
+/* Define to 1 if you have the `EVP_DigestSign' function. */
+#define HAVE_OPENSSL_EVP_DIGESTSIGN 1
+
+/* Define to 1 if you have the `EVP_DigestVerify' function. */
+#define HAVE_OPENSSL_EVP_DIGESTVERIFY 1
+
+/* Define to 1 if you have the `OPENSSL_ia32cap_loc' function. */
+/* #undef HAVE_OPENSSL_IA32CAP_LOC */
 
 /* Define to 1 if you have the `snprintf' function. */
 #define HAVE_SNPRINTF 1
@@ -185,12 +212,6 @@
 /* Define to 1 if you have the `cmocka_set_test_filter' function. */
 /* #undef HAVE_CMOCKA_SET_TEST_FILTER */
 
-/* Define to 1 if we have support for blowfish */
-/* #undef HAVE_BLOWFISH */
-
-/* Define to 1 if we have support for ML-KEM */
-/* #undef HAVE_MLKEM */
-
 /*************************** LIBRARIES ***************************/
 
 /* Define to 1 if you have the `crypto' library (-lcrypto). */
@@ -208,10 +229,6 @@
 /* Define to 1 if you have the `cmocka' library (-lcmocka). */
 /* #undef HAVE_CMOCKA */
 
-/* Define to 1 if you have the `libfido2' library (-lfido2).
- * This is required for interacting with FIDO2/U2F devices over USB-HID. */
-/* #undef HAVE_LIBFIDO2 */
-
 /**************************** OPTIONS ****************************/
 
 #define HAVE_GCC_THREAD_LOCAL_STORAGE 1
@@ -219,7 +236,6 @@
 
 #define HAVE_FALLTHROUGH_ATTRIBUTE 1
 #define HAVE_UNUSED_ATTRIBUTE 1
-/* #undef HAVE_WEAK_ATTRIBUTE */
 
 #define HAVE_CONSTRUCTOR_ATTRIBUTE 1
 #define HAVE_DESTRUCTOR_ATTRIBUTE 1
@@ -246,14 +262,6 @@
 /* Define to 1 if you want to enable DH group exchange algorithms */
 /* #undef WITH_GEX */
 
-/* Define to 1 if you want to enable insecure none cipher and MAC */
-/* #undef WITH_INSECURE_NONE */
-
-/* Define to 1 if you want to allow libssh to execute arbitrary commands from
- * configuration files or options (match exec, proxy commands and OpenSSH-based
- * proxy-jumps). */
-/* #undef WITH_EXEC */
-
 /* Define to 1 if you want to enable blowfish cipher support */
 /* #undef WITH_BLOWFISH_CIPHER */
 
@@ -271,15 +279,6 @@
 
 /* Define to 1 if you want to enable NaCl support */
 /* #undef WITH_NACL */
-
-/* Define to 1 if you want to enable PKCS #11 URI support */
-/* #undef WITH_PKCS11_URI */
-
-/* Define to 1 if we want to build a support for PKCS #11 provider. */
-/* #undef WITH_PKCS11_PROVIDER */
-
-/* Define to 1 if you want to enable FIDO2/U2F support */
-/* #undef WITH_FIDO2 */
 
 /*************************** ENDIAN *****************************/
 

--- a/src/Common/SSHWrapper.cpp
+++ b/src/Common/SSHWrapper.cpp
@@ -21,14 +21,36 @@ namespace ErrorCodes
 
 namespace
 {
-struct SSHStringDeleter
+
+class SSHString
 {
-    void operator()(char * ptr) const { ssh_string_free_char(ptr); }
+public:
+    explicit SSHString(std::string_view input)
+    {
+        if (string = ssh_string_new(input.size()); string == nullptr)
+            throw Exception(ErrorCodes::LIBSSH_ERROR, "Can't create SSHString");
+        if (int rc = ssh_string_fill(string, input.data(), input.size()); rc != SSH_OK)
+            throw Exception(ErrorCodes::LIBSSH_ERROR, "Can't create SSHString");
+    }
+
+    explicit SSHString(ssh_string other) { string = other; }
+
+    ssh_string get() { return string; }
+
+    String toString()
+    {
+        return {ssh_string_get_char(string), ssh_string_len(string)};
+    }
+
+    ~SSHString()
+    {
+        ssh_string_free(string);
+    }
+
+private:
+    ssh_string string;
 };
-struct CStringDeleter
-{
-    void operator()(char * ptr) const { std::free(ptr); }
-};
+
 }
 
 SSHKey SSHKeyFactory::makePrivateKeyFromFile(String filename, String passphrase)
@@ -97,31 +119,20 @@ bool SSHKey::isEqual(const SSHKey & other) const
 
 String SSHKey::signString(std::string_view input) const
 {
-    char * signature = nullptr;
-    if (int rc = sshsig_sign(input.data(), input.size(), key, nullptr, "clickhouse", SSHSIG_DIGEST_SHA2_256, &signature); rc != SSH_OK)
-        throw Exception(ErrorCodes::LIBSSH_ERROR, "Error signing with ssh key");
-    std::unique_ptr<char, SSHStringDeleter> sig_ptr(signature);
-    return String(sig_ptr.get());
+    SSHString input_str(input);
+    ssh_string output = nullptr;
+    if (int rc = pki_sign_string(key, input_str.get(), &output); rc != SSH_OK)
+        throw Exception(ErrorCodes::LIBSSH_ERROR, "Error singing with ssh key");
+    SSHString output_str(output);
+    return output_str.toString();
 }
 
 bool SSHKey::verifySignature(std::string_view signature, std::string_view original) const
 {
-    ssh_key verify_key = nullptr;
-    String sig_str(signature);
-    int rc = sshsig_verify(original.data(), original.size(), sig_str.c_str(), "clickhouse", &verify_key);
-    if (rc != SSH_OK)
-    {
-        if (verify_key != nullptr)
-            ssh_key_free(verify_key);
-        return false;
-    }
-    bool keys_match = false;
-    if (verify_key != nullptr)
-    {
-        keys_match = (ssh_key_cmp(key, verify_key, SSH_KEY_CMP_PUBLIC) == 0);
-        ssh_key_free(verify_key);
-    }
-    return keys_match;
+    SSHString sig(signature);
+    SSHString orig(original);
+    int rc = pki_verify_string(key, sig.get(), orig.get());
+    return rc == SSH_OK;
 }
 
 bool SSHKey::isPrivate() const
@@ -132,6 +143,14 @@ bool SSHKey::isPrivate() const
 bool SSHKey::isPublic() const
 {
     return ssh_key_is_public(key);
+}
+
+namespace
+{
+    struct CStringDeleter
+    {
+        void operator()(char * ptr) const { std::free(ptr); }
+    };
 }
 
 String SSHKey::getBase64() const

--- a/src/Server/SSH/SSHPtyHandlerFactory.h
+++ b/src/Server/SSH/SSHPtyHandlerFactory.h
@@ -79,6 +79,7 @@ public:
         LOG_TRACE(log, "TCP Request. Address: {}", socket.peerAddress().toString());
         ::ssh::libsshLogger::initialize();
         ::ssh::SSHSession session;
+        session.disableSocketOwning();
         session.disableDefaultConfig();
         ssh_bind.acceptFd(session, socket.sockfd());
 

--- a/src/Server/SSH/SSHSession.cpp
+++ b/src/Server/SSH/SSHSession.cpp
@@ -64,6 +64,14 @@ void SSHSession::disableDefaultConfig()
         throw DB::Exception(DB::ErrorCodes::SSH_EXCEPTION, "Failed disabling default config for ssh session due due to {}", getError());
 }
 
+void SSHSession::disableSocketOwning()
+{
+    bool owns_socket = false;
+    int rc = ssh_options_set(session, SSH_OPTIONS_OWNS_SOCKET, &owns_socket);
+    if (rc != SSH_OK)
+        throw DB::Exception(DB::ErrorCodes::SSH_EXCEPTION, "Failed disabling socket owning for ssh session due to {}", getError());
+}
+
 void SSHSession::setPeerHost(const String & host)
 {
     int rc = ssh_options_set(session, SSH_OPTIONS_HOST, host.c_str());

--- a/src/Server/SSH/SSHSession.h
+++ b/src/Server/SSH/SSHSession.h
@@ -30,6 +30,8 @@ public:
 
     /// Disable reading default libssh configuration
     void disableDefaultConfig();
+    /// Disable session from closing socket. Can be used when a socket is passed.
+    void disableSocketOwning();
 
     /// Connect / disconnect
     void connect();


### PR DESCRIPTION
Resolves https://github.com/ClickHouse/ClickHouse/issues/90663

Reverts ClickHouse/ClickHouse#90362

I noticed that [one of the backport PRs](https://github.com/ClickHouse/ClickHouse/pull/90518) of above^^ PR had a tsan crash in `test_ssh/test.py::test_paramiko_password` ([here](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=90518&sha=latest&name_0=BackportPR)):

```
File: test_ssh/test.py:143 - in test_paramiko_password
    instance.query("CREATE USER OR REPLACE mister IDENTIFIED BY 'P@$$WORD';")
File: helpers/cluster.py:4388 - in query
    return self.client.query(
File: helpers/client.py:40 - in wrap
    return func(self, *args, **kwargs)
File: helpers/client.py:80 - in query
    ).get_answer()
File: helpers/client.py:248 - in get_answer
    raise QueryRuntimeException(
E   helpers.client.QueryRuntimeException: Client failed! Return code: 210, stderr: Code: 210. DB::NetException: Net Exception: Connection reset by peer (172.16.2.6:9000, local address: 172.16.2.1:64814). (NETWORK_ERROR)
[teardown]
File: test_ssh/test.py:26 - in started_cluster
    cluster.shutdown()
File: helpers/cluster.py:3944 - in shutdown
    raise Exception(
E   Exception: Sanitizer assert found for instance ==================
E   WARNING: ThreadSanitizer: data race (pid=8)
E     Write of size 8 at 0x72b000010640 by thread T6:
E       #0 close <null> (clickhouse+0x992d689) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
E       #1 Poco::Net::SocketImpl::close() ci/tmp/build/./base/poco/Net/src/SocketImpl.cpp:247:3 (clickhouse+0x2b87c5c9) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
E       #2 Poco::Net::SocketImpl::~SocketImpl() ci/tmp/build/./base/poco/Net/src/SocketImpl.cpp:86:2 (clickhouse+0x2b87c5c9)
E       #3 Poco::Net::StreamSocketImpl::~StreamSocketImpl() ci/tmp/build/./base/poco/Net/src/StreamSocketImpl.cpp:52:1 (clickhouse+0x2b888219) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
E       #4 Poco::Net::StreamSocketImpl::~StreamSocketImpl() ci/tmp/build/./base/poco/Net/src/StreamSocketImpl.cpp:51:1 (clickhouse+0x2b888259) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
E       #5 Poco::RefCountedObject::release() const ci/tmp/build/./base/poco/Foundation/include/Poco/RefCountedObject.h:88:13 (clickhouse+0x2b8765e2) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
E       #6 Poco::Net::Socket::~Socket() ci/tmp/build/./base/poco/Net/src/Socket.cpp:68:10 (clickhouse+0x2b8765e2)
E       #7 Poco::Net::StreamSocket::~StreamSocket() ci/tmp/build/./base/poco/Net/src/StreamSocket.cpp:63:1 (clickhouse+0x2b885999) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
E       #8 Poco::Net::TCPConnectionNotification::~TCPConnectionNotification() ci/tmp/build/./base/poco/Net/src/TCPServerDispatcher.cpp:43:5 (clickhouse+0x2b88c4b4) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
E       #9 Poco::Net::TCPConnectionNotification::~TCPConnectionNotification() ci/tmp/build/./base/poco/Net/src/TCPServerDispatcher.cpp:42:5 (clickhouse+0x2b88c4b4)
E       #10 Poco::RefCountedObject::release() const ci/tmp/build/./base/poco/Foundation/include/Poco/RefCountedObject.h:88:13 (clickhouse+0x2b88a803) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
E       #11 Poco::AutoPtr<Poco::Notification>::~AutoPtr() ci/tmp/build/./base/poco/Foundation/include/Poco/AutoPtr.h:91:19 (clickhouse+0x2b88a803)
E       #12 Poco::Net::TCPServerDispatcher::run() ci/tmp/build/./base/poco/Net/src/TCPServerDispatcher.cpp:122:9 (clickhouse+0x2b88a803)
E       #13 Poco::PooledThread::run() ci/tmp/build/./base/poco/Foundation/src/ThreadPool.cpp:205:14 (clickhouse+0x2b7f49d0) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
E       #14 Poco::(anonymous namespace)::RunnableHolder::run() ci/tmp/build/./base/poco/Foundation/src/Thread.cpp:45:11 (clickhouse+0x2b7f2baf) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
E       #15 Poco::ThreadImpl::runnableEntry(void*) ci/tmp/build/./base/poco/Foundation/src/Thread_POSIX.cpp:341:27 (clickhouse+0x2b7f0f49) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
E   
E     Previous write of size 8 at 0x72b000010640 by thread T673:
E       #0 accept <null> (clickhouse+0x99444d7) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
E       #1 Poco::Net::SocketImpl::acceptConnection(Poco::Net::SocketAddress&) ci/tmp/build/./base/poco/Net/src/SocketImpl.cpp:100:8 (clickhouse+0x2b87c735) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
E       #2 Poco::Net::ServerSocket::acceptConnection() ci/tmp/build/./base/poco/Net/src/ServerSocket.cpp:154:30 (clickhouse+0x2b876104) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
E       #3 Poco::Net::TCPServer::run() ci/tmp/build/./base/poco/Net/src/TCPServer.cpp:137:47 (clickhouse+0x2b889520) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
E       #4 Poco::(anonymous namespace)::RunnableHolder::run() ci/tmp/build/./base/poco/Foundation/src/Thread.cpp:45:11 (clickhouse+0x2b7f2baf) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
E       #5 Poco::ThreadImpl::runnableEntry(void*) ci/tmp/build/./base/poco/Foundation/src/Thread_POSIX.cpp:341:27 (clickhouse+0x2b7f0f49) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
E   
E     Location is file descriptor 50 created by thread T673 at:
E       #0 accept <null> (clickhouse+0x99444d7) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
E       #1 Poco::Net::SocketImpl::acceptConnection(Poco::Net::SocketAddress&) ci/tmp/build/./base/poco/Net/src/SocketImpl.cpp:100:8 (clickhouse+0x2b87c735) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
E       #2 Poco::Net::ServerSocket::acceptConnection() ci/tmp/build/./base/poco/Net/src/ServerSocket.cpp:154:30 (clickhouse+0x2b876104) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
E       #3 Poco::Net::TCPServer::run() ci/tmp/build/./base/poco/Net/src/TCPServer.cpp:137:47 (clickhouse+0x2b889520) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
E       #4 Poco::(anonymous namespace)::RunnableHolder::run() ci/tmp/build/./base/poco/Foundation/src/Thread.cpp:45:11 (clickhouse+0x2b7f2baf) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
E       #5 Poco::ThreadImpl::runnableEntry(void*) ci/tmp/build/./base/poco/Foundation/src/Thread_POSIX.cpp:341:27 (clickhouse+0x2b7f0f49) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
E   
E     Thread T6 (tid=15, running) created by main thread at:
E       #0 pthread_create <null> (clickhouse+0x9927501) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
E       #1 Poco::ThreadImpl::startImpl(Poco::SharedPtr<Poco::Runnable, Poco::ReferenceCounter, Poco::ReleasePolicy<Poco::Runnable>>) ci/tmp/build/./base/poco/Foundation/src/Thread_POSIX.cpp:203:7 (clickhouse+0x2b7f0807) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
E       #2 Poco::Thread::start(Poco::Runnable&) ci/tmp/build/./base/poco/Foundation/src/Thread.cpp:118:2 (clickhouse+0x2b7f24af) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
E       #3 Poco::PooledThread::start() ci/tmp/build/./base/poco/Foundation/src/ThreadPool.cpp:91:10 (clickhouse+0x2b7f4f3e) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
E       #4 Poco::ThreadPool::ThreadPool(int, int, int, int, unsigned long, unsigned long) ci/tmp/build/./base/poco/Foundation/src/ThreadPool.cpp:258:12 (clickhouse+0x2b7f4f3e)
E       #5 DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&) ci/tmp/build/./programs/server/Server.cpp:1332:22 (clickhouse+0x145e41ec) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
E       #6 Poco::Util::Application::run() ci/tmp/build/./base/poco/Util/src/Application.cpp:315:8 (clickhouse+0x2b8c1f3e) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
E       #7 DB::Server::run() ci/tmp/build/./programs/server/Server.cpp:652:25 (clickhouse+0x145d7b16) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
E       #8 Poco::Util::ServerApplication::run(int, char**) ci/tmp/build/./base/poco/Util/src/ServerApplication.cpp:131:9 (clickhouse+0x2b8e0ba0) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
E       #9 mainEntryClickHouseServer(int, char**) ci/tmp/build/./programs/server/Server.cpp:439:20 (clickhouse+0x145d46cc) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
E       #10 main ci/tmp/build/./programs/main.cpp:380:21 (clickhouse+0x99abb40) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
E   
E     Thread T673 (tid=682, running) created by main thread at:
E       #0 pthread_create <null> (clickhouse+0x9927501) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
E       #1 Poco::ThreadImpl::startImpl(Poco::SharedPtr<Poco::Runnable, Poco::ReferenceCounter, Poco::ReleasePolicy<Poco::Runnable>>) ci/tmp/build/./base/poco/Foundation/src/Thread_POSIX.cpp:203:7 (clickhouse+0x2b7f0807) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
E       #2 Poco::Thread::start(Poco::Runnable&) ci/tmp/build/./base/poco/Foundation/src/Thread.cpp:118:2 (clickhouse+0x2b7f24af) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
E       #3 Poco::Net::TCPServer::start() ci/tmp/build/./base/poco/Net/src/TCPServer.cpp:111:13 (clickhouse+0x2b8893a6) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
E       #4 DB::ProtocolServerAdapter::TCPServerAdapterImpl::start() ci/tmp/build/./src/Server/ProtocolServerAdapter.cpp:17:41 (clickhouse+0x237502e3) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
E       #5 DB::ProtocolServerAdapter::start() ci/tmp/build/./src/Server/ProtocolServerAdapter.h:41:26 (clickhouse+0x145f73a6) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
E       #6 DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&) ci/tmp/build/./programs/server/Server.cpp:2875:24 (clickhouse+0x145f73a6)
E       #7 Poco::Util::Application::run() ci/tmp/build/./base/poco/Util/src/Application.cpp:315:8 (clickhouse+0x2b8c1f3e) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
E       #8 DB::Server::run() ci/tmp/build/./programs/server/Server.cpp:652:25 (clickhouse+0x145d7b16) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
E       #9 Poco::Util::ServerApplication::run(int, char**) ci/tmp/build/./base/poco/Util/src/ServerApplication.cpp:131:9 (clickhouse+0x2b8e0ba0) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
E       #10 mainEntryClickHouseServer(int, char**) ci/tmp/build/./programs/server/Server.cpp:439:20 (clickhouse+0x145d46cc) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
E       #11 main ci/tmp/build/./programs/main.cpp:380:21 (clickhouse+0x99abb40) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
E   
E   SUMMARY: ThreadSanitizer: data race (/usr/bin/clickhouse+0x992d689) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2) in close
E   ==================
===== Captured stderr teardown =====
Sanitizer in instance node log ==================
WARNING: ThreadSanitizer: data race (pid=8)
  Write of size 8 at 0x72b000010640 by thread T6:
    #0 close <null> (clickhouse+0x992d689) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
    #1 Poco::Net::SocketImpl::close() ci/tmp/build/./base/poco/Net/src/SocketImpl.cpp:247:3 (clickhouse+0x2b87c5c9) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
    #2 Poco::Net::SocketImpl::~SocketImpl() ci/tmp/build/./base/poco/Net/src/SocketImpl.cpp:86:2 (clickhouse+0x2b87c5c9)
    #3 Poco::Net::StreamSocketImpl::~StreamSocketImpl() ci/tmp/build/./base/poco/Net/src/StreamSocketImpl.cpp:52:1 (clickhouse+0x2b888219) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
    #4 Poco::Net::StreamSocketImpl::~StreamSocketImpl() ci/tmp/build/./base/poco/Net/src/StreamSocketImpl.cpp:51:1 (clickhouse+0x2b888259) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
    #5 Poco::RefCountedObject::release() const ci/tmp/build/./base/poco/Foundation/include/Poco/RefCountedObject.h:88:13 (clickhouse+0x2b8765e2) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
    #6 Poco::Net::Socket::~Socket() ci/tmp/build/./base/poco/Net/src/Socket.cpp:68:10 (clickhouse+0x2b8765e2)
    #7 Poco::Net::StreamSocket::~StreamSocket() ci/tmp/build/./base/poco/Net/src/StreamSocket.cpp:63:1 (clickhouse+0x2b885999) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
    #8 Poco::Net::TCPConnectionNotification::~TCPConnectionNotification() ci/tmp/build/./base/poco/Net/src/TCPServerDispatcher.cpp:43:5 (clickhouse+0x2b88c4b4) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
    #9 Poco::Net::TCPConnectionNotification::~TCPConnectionNotification() ci/tmp/build/./base/poco/Net/src/TCPServerDispatcher.cpp:42:5 (clickhouse+0x2b88c4b4)
    #10 Poco::RefCountedObject::release() const ci/tmp/build/./base/poco/Foundation/include/Poco/RefCountedObject.h:88:13 (clickhouse+0x2b88a803) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
    #11 Poco::AutoPtr<Poco::Notification>::~AutoPtr() ci/tmp/build/./base/poco/Foundation/include/Poco/AutoPtr.h:91:19 (clickhouse+0x2b88a803)
    #12 Poco::Net::TCPServerDispatcher::run() ci/tmp/build/./base/poco/Net/src/TCPServerDispatcher.cpp:122:9 (clickhouse+0x2b88a803)
    #13 Poco::PooledThread::run() ci/tmp/build/./base/poco/Foundation/src/ThreadPool.cpp:205:14 (clickhouse+0x2b7f49d0) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
    #14 Poco::(anonymous namespace)::RunnableHolder::run() ci/tmp/build/./base/poco/Foundation/src/Thread.cpp:45:11 (clickhouse+0x2b7f2baf) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
    #15 Poco::ThreadImpl::runnableEntry(void*) ci/tmp/build/./base/poco/Foundation/src/Thread_POSIX.cpp:341:27 (clickhouse+0x2b7f0f49) (BuildId: c82202ce8d9568b6324511d2c13e155d73840ca2)
[...]
```

Turns out that the same test started to fail in nightly tsan builds on the `master` branch ([test case history](https://play.clickhouse.com/play?user=play#U0VMRUNUIGhlYWRfcmVmLCBiYXNlX3JlcG8sIHB1bGxfcmVxdWVzdF9udW1iZXIgYXMgcHIsIGNoZWNrX3N0YXJ0X3RpbWUsIGNoZWNrX2R1cmF0aW9uX21zLzEwMDAgQVMgcnVudGltZV9zZWMsIGNoZWNrX25hbWUsIHRlc3RfbmFtZSwgdGVzdF9zdGF0dXMsIHJlcG9ydF91cmwtLSwgdGVzdF9jb250ZXh0X3JhdwpGUk9NIGNoZWNrcwpXSEVSRSAxCiAgICAtLUFORCBwdWxsX3JlcXVlc3RfbnVtYmVyID0gMCBBTkQgaGVhZF9yZWYgPSAnbWFzdGVyJwogICAgQU5EIHRlc3Rfc3RhdHVzIElOICgnRkFJTCcsICdFUlJPUicsICdCUk9LRU4nKQogICAgQU5EIHRvRGF0ZShjaGVja19zdGFydF90aW1lKSA+ICcyMDI1LTExLTAxJwogICAgLS1BTkQgdGVzdF9uYW1lIGxpa2UgJyUwMzcwNF9ybXZfbG9nZ2luZ19pbnRlcm5hbF9xdWVyaWVzJScKICAgIEFORCB0ZXN0X2NvbnRleHRfcmF3IExJS0UgJyVTb2NrZXRJbXBsOjpjbG9zZSUnCk9SREVSIEJZIGNoZWNrX3N0YXJ0X3RpbWUgREVTQwpTRVRUSU5HUyByZWFkX3Rocm91Z2hfZGlzdHJpYnV0ZWRfY2FjaGU9MA==)).

The error did _not_ occur in the original PR.

Sorry, I need to roll this back for now.