### PR TITLE
Fix flaky 02494_query_cache_ignore_output_settings

### DIFF
--- a/tests/queries/0_stateless/02494_query_cache_ignore_output_settings.sql
+++ b/tests/queries/0_stateless/02494_query_cache_ignore_output_settings.sql
@@ -1,3 +1,4 @@
+-- Tags: no-parallel-replicas
 -- no-parallel-replicas: the query from query_log errors due to missing columns.
 
 -- Checks that the query cache ignores output format related settings (settings starting with 'output_format_')


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Details

Follow-up for https://github.com/ClickHouse/ClickHouse/pull/90436/

Fixes failures of `02494_query_cache_ignore_output_settings` in parallel replica tests, example: [here](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=90519&sha=a65c3e794871dc555dd16eed622b7a6d8d9df33b&name_0=PR&name_1=Stateless%20tests%20%28amd_binary%2C%20ParallelReplicas%2C%20s3%20storage%2C%20parallel%29&name_1=Stateless%20tests%20%28amd_binary%2C%20ParallelReplicas%2C%20s3%20storage%2C%20parallel%29)

Resolves #90541
