### PR TITLE
Fix flaky `02346_text_index_function_hasAnyAllTokens`

### DIFF
--- a/tests/queries/0_stateless/02346_text_index_function_hasAnyAllTokens.sql
+++ b/tests/queries/0_stateless/02346_text_index_function_hasAnyAllTokens.sql
@@ -1,4 +1,5 @@
--- Tags: no-parallel-replicas
+-- Tags: no-parallel-replicas, no-asan
+-- no-asan: runs too long
 
 SET enable_analyzer = 1;
 SET use_query_condition_cache = 0;


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Details

`02346_text_index_function_hasAnyAllTokens` fails the flaky check on asan builds in the private repository.
