### PR TITLE
Make tokenizer naming more consistent

### DIFF
--- a/src/Functions/hasAnyAllTokens.cpp
+++ b/src/Functions/hasAnyAllTokens.cpp
@@ -403,7 +403,7 @@ ColumnPtr FunctionHasAnyAllTokens<HasTokensTraits>::executeImpl(
     else
     {
         /// If token_extractor != nullptr, a text index exists and we are doing text index lookups
-        if (token_extractor->getType() == ITokenExtractor::Type::SparseGram)
+        if (token_extractor->getType() == ITokenExtractor::Type::SparseGrams)
         {
             /// The sparse gram token extractor stores an internal state which modified during the execution.
             /// This leads to an error while executing this function multi-threaded because that state is not protected.

--- a/src/Functions/hasAnyAllTokens.cpp
+++ b/src/Functions/hasAnyAllTokens.cpp
@@ -104,7 +104,7 @@ bool isStringOrArrayOfStringType(const IDataType & type)
 
 TokensWithPosition extractTokensFromString(std::string_view value)
 {
-    DefaultTokenExtractor default_token_extractor;
+    SplitByNonAlphaTokenExtractor default_token_extractor;
 
     size_t cur = 0;
     size_t token_start = 0;
@@ -396,7 +396,7 @@ ColumnPtr FunctionHasAnyAllTokens<HasTokensTraits>::executeImpl(
         else
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Needles argument for function '{}' has unsupported type", getName());
 
-        static DefaultTokenExtractor default_token_extractor;
+        static SplitByNonAlphaTokenExtractor default_token_extractor;
 
         execute<HasTokensTraits>(col_input, col_result->getData(), input_rows_count, &default_token_extractor, search_tokens_from_args);
     }

--- a/src/Functions/ngrams.cpp
+++ b/src/Functions/ngrams.cpp
@@ -68,7 +68,7 @@ public:
         arguments[1].column->get(0, ngram_argument_value);
         auto ngram_value = ngram_argument_value.safeGet<UInt64>();
 
-        NgramTokenExtractor extractor(ngram_value);
+        NgramsTokenExtractor extractor(ngram_value);
 
         auto result_column_string = ColumnString::create();
 
@@ -119,12 +119,12 @@ private:
 REGISTER_FUNCTION(Ngrams)
 {
     FunctionDocumentation::Description description = R"(
-Splits a UTF-8 string into n-grams of `ngramsize` symbols.
+Splits a UTF-8 string into n-grams of length `N`.
 )";
-    FunctionDocumentation::Syntax syntax = "ngrams(s, ngram_size)";
+    FunctionDocumentation::Syntax syntax = "ngrams(s, N)";
     FunctionDocumentation::Arguments arguments = {
         {"s", "Input string.", {"String", "FixedString"}},
-        {"ngram_size", "The size of an n-gram.", {"const UInt8/16/32/64"}}
+        {"N", "The n-gram length.", {"const UInt8/16/32/64"}}
     };
     FunctionDocumentation::ReturnedValue returned_value = {"Returns an array with n-grams.", {"Array(String)"}};
     FunctionDocumentation::Examples examples = {

--- a/src/Functions/tokens.cpp
+++ b/src/Functions/tokens.cpp
@@ -73,7 +73,7 @@ std::unique_ptr<ITokenExtractor> createTokenizer(const ColumnsWithTypeAndName & 
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Ngrams argument of function {} should be between 2 and 8, got: {}", name, ngrams);
         return std::make_unique<NgramsTokenExtractor>(ngrams);
     }
-    if (tokenizer_arg == SparseGramTokenExtractor::getExternalName())
+    if (tokenizer_arg == SparseGramsTokenExtractor::getExternalName())
     {
         auto min_length = arguments.size() < 3 ? 3
             : arguments[2].column->getUInt(0);
@@ -82,7 +82,7 @@ std::unique_ptr<ITokenExtractor> createTokenizer(const ColumnsWithTypeAndName & 
         auto min_cutoff_length = arguments.size() < 5 ? std::nullopt
             : std::optional(arguments[4].column->getUInt(0));
 
-        return std::make_unique<SparseGramTokenExtractor>(min_length, max_length, min_cutoff_length);
+        return std::make_unique<SparseGramsTokenExtractor>(min_length, max_length, min_cutoff_length);
     }
 
     throw Exception(
@@ -112,7 +112,7 @@ public:
         if (input_rows_count == 0)
             return ColumnArray::create(std::move(col_result), std::move(col_offsets));
 
-        if (token_extractor->getType() == ITokenExtractor::Type::SparseGram)
+        if (token_extractor->getType() == ITokenExtractor::Type::SparseGrams)
         {
             /// The sparse gram token extractor stores an internal state which modified during the execution.
             /// This leads to an error while executing this function multi-threaded because that state is not protected.
@@ -241,7 +241,7 @@ public:
             {
                 const auto tokenizer = arguments[arg_tokenizer].column->getDataAt(0).toString();
 
-                if (tokenizer == SparseGramTokenExtractor::getExternalName())
+                if (tokenizer == SparseGramsTokenExtractor::getExternalName())
                 {
                     optional_args.emplace_back("min_length", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isUInt8), isColumnConst, "UInt8");
                     optional_args.emplace_back("max_length", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isUInt8), isColumnConst, "UInt8");

--- a/src/Functions/tokens.cpp
+++ b/src/Functions/tokens.cpp
@@ -66,12 +66,12 @@ std::unique_ptr<ITokenExtractor> createTokenizer(const ColumnsWithTypeAndName & 
     {
         return std::make_unique<NoOpTokenExtractor>();
     }
-    if (tokenizer_arg == NgramTokenExtractor::getExternalName())
+    if (tokenizer_arg == NgramsTokenExtractor::getExternalName())
     {
         auto ngrams = (arguments.size() < 3) ? 3 : arguments[arg_ngrams].column->getUInt(0);
         if (ngrams < 2 || ngrams > 8)
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Ngrams argument of function {} should be between 2 and 8, got: {}", name, ngrams);
-        return std::make_unique<NgramTokenExtractor>(ngrams);
+        return std::make_unique<NgramsTokenExtractor>(ngrams);
     }
     if (tokenizer_arg == SparseGramTokenExtractor::getExternalName())
     {
@@ -231,7 +231,7 @@ public:
             {
                 const auto tokenizer = arguments[arg_tokenizer].column->getDataAt(0).toString();
 
-                if (tokenizer == NgramTokenExtractor::getExternalName())
+                if (tokenizer == NgramsTokenExtractor::getExternalName())
                     optional_args.emplace_back("ngrams", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isUInt8), isColumnConst, "const UInt8");
                 else if (tokenizer == SplitTokenExtractor::getExternalName())
                     optional_args.emplace_back("separators", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isArray), isColumnConst, "const Array");

--- a/src/Functions/tokens.cpp
+++ b/src/Functions/tokens.cpp
@@ -35,7 +35,7 @@ std::unique_ptr<ITokenExtractor> createTokenizer(const ColumnsWithTypeAndName & 
     {
         return std::make_unique<SplitByNonAlphaTokenExtractor>();
     }
-    if (tokenizer_arg == SplitTokenExtractor::getExternalName())
+    if (tokenizer_arg == SplitByStringTokenExtractor::getExternalName())
     {
         std::vector<String> separators;
         if (arguments.size() < 3)
@@ -60,7 +60,7 @@ std::unique_ptr<ITokenExtractor> createTokenizer(const ColumnsWithTypeAndName & 
                 separators.emplace_back(separator.safeGet<String>());
         }
 
-        return std::make_unique<SplitTokenExtractor>(separators);
+        return std::make_unique<SplitByStringTokenExtractor>(separators);
     }
     if (tokenizer_arg == NoOpTokenExtractor::getExternalName())
     {
@@ -233,7 +233,7 @@ public:
 
                 if (tokenizer == NgramsTokenExtractor::getExternalName())
                     optional_args.emplace_back("ngrams", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isUInt8), isColumnConst, "const UInt8");
-                else if (tokenizer == SplitTokenExtractor::getExternalName())
+                else if (tokenizer == SplitByStringTokenExtractor::getExternalName())
                     optional_args.emplace_back("separators", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isArray), isColumnConst, "const Array");
             }
 

--- a/src/Functions/tokens.cpp
+++ b/src/Functions/tokens.cpp
@@ -28,12 +28,12 @@ constexpr size_t arg_separators = 2;
 
 std::unique_ptr<ITokenExtractor> createTokenizer(const ColumnsWithTypeAndName & arguments, std::string_view name)
 {
-    const auto tokenizer_arg = arguments.size() < 2 ? DefaultTokenExtractor::getExternalName()
+    const auto tokenizer_arg = arguments.size() < 2 ? SplitByNonAlphaTokenExtractor::getExternalName()
                                                         : arguments[arg_tokenizer].column->getDataAt(0).toView();
 
-    if (tokenizer_arg == DefaultTokenExtractor::getExternalName())
+    if (tokenizer_arg == SplitByNonAlphaTokenExtractor::getExternalName())
     {
-        return std::make_unique<DefaultTokenExtractor>();
+        return std::make_unique<SplitByNonAlphaTokenExtractor>();
     }
     if (tokenizer_arg == SplitTokenExtractor::getExternalName())
     {

--- a/src/Functions/tokens.cpp
+++ b/src/Functions/tokens.cpp
@@ -62,9 +62,9 @@ std::unique_ptr<ITokenExtractor> createTokenizer(const ColumnsWithTypeAndName & 
 
         return std::make_unique<SplitByStringTokenExtractor>(separators);
     }
-    if (tokenizer_arg == NoOpTokenExtractor::getExternalName())
+    if (tokenizer_arg == ArrayTokenExtractor::getExternalName())
     {
-        return std::make_unique<NoOpTokenExtractor>();
+        return std::make_unique<ArrayTokenExtractor>();
     }
     if (tokenizer_arg == NgramsTokenExtractor::getExternalName())
     {

--- a/src/Interpreters/ITokenExtractor.cpp
+++ b/src/Interpreters/ITokenExtractor.cpp
@@ -341,13 +341,13 @@ bool ArrayTokenExtractor::nextInStringLike(const char * /*data*/, size_t /*lengt
     throw Exception(ErrorCodes::NOT_IMPLEMENTED, "ArrayTokenExtractor::nextInStringLike is not implemented");
 }
 
-SparseGramTokenExtractor::SparseGramTokenExtractor(size_t min_length, size_t max_length, std::optional<size_t> min_cutoff_length_)
-    : ITokenExtractorHelper(Type::SparseGram)
+SparseGramsTokenExtractor::SparseGramsTokenExtractor(size_t min_length, size_t max_length, std::optional<size_t> min_cutoff_length_)
+    : ITokenExtractorHelper(Type::SparseGrams)
     , sparse_grams_iterator(min_length, max_length, min_cutoff_length_)
 {
 }
 
-bool SparseGramTokenExtractor::nextInString(const char * data, size_t length, size_t * __restrict pos, size_t * __restrict token_start, size_t * __restrict token_length) const
+bool SparseGramsTokenExtractor::nextInString(const char * data, size_t length, size_t * __restrict pos, size_t * __restrict token_start, size_t * __restrict token_length) const
 {
     if (std::tie(data, length) != std::tie(previous_data, previous_len))
     {
@@ -371,7 +371,7 @@ bool SparseGramTokenExtractor::nextInString(const char * data, size_t length, si
     return true;
 }
 
-bool SparseGramTokenExtractor::nextInStringLike(const char * data, size_t length, size_t * pos, String & token) const
+bool SparseGramsTokenExtractor::nextInStringLike(const char * data, size_t length, size_t * pos, String & token) const
 {
     if (std::tie(data, length) != std::tie(previous_data, previous_len))
     {

--- a/src/Interpreters/ITokenExtractor.cpp
+++ b/src/Interpreters/ITokenExtractor.cpp
@@ -20,7 +20,7 @@ namespace ErrorCodes
 namespace DB
 {
 
-bool NgramTokenExtractor::nextInString(const char * data, size_t length, size_t * __restrict pos, size_t * __restrict token_start, size_t * __restrict token_length) const
+bool NgramsTokenExtractor::nextInString(const char * data, size_t length, size_t * __restrict pos, size_t * __restrict token_start, size_t * __restrict token_length) const
 {
     *token_start = *pos;
     *token_length = 0;
@@ -34,7 +34,7 @@ bool NgramTokenExtractor::nextInString(const char * data, size_t length, size_t 
     return code_points == n;
 }
 
-bool NgramTokenExtractor::nextInStringLike(const char * data, size_t length, size_t * pos, String & token) const
+bool NgramsTokenExtractor::nextInStringLike(const char * data, size_t length, size_t * pos, String & token) const
 {
     token.clear();
 

--- a/src/Interpreters/ITokenExtractor.cpp
+++ b/src/Interpreters/ITokenExtractor.cpp
@@ -324,7 +324,7 @@ bool SplitByStringTokenExtractor::nextInStringLike(const char * /*data*/, size_t
     throw Exception(ErrorCodes::NOT_IMPLEMENTED, "StringTokenExtractor::nextInStringLike is not implemented");
 }
 
-bool NoOpTokenExtractor::nextInString(const char * /*data*/, size_t length, size_t * pos, size_t * token_start, size_t * token_length) const
+bool ArrayTokenExtractor::nextInString(const char * /*data*/, size_t length, size_t * pos, size_t * token_start, size_t * token_length) const
 {
     if (*pos == 0)
     {
@@ -336,9 +336,9 @@ bool NoOpTokenExtractor::nextInString(const char * /*data*/, size_t length, size
     return false;
 }
 
-bool NoOpTokenExtractor::nextInStringLike(const char * /*data*/, size_t /*length*/, size_t * /*token_start*/, String & /*token_length*/) const
+bool ArrayTokenExtractor::nextInStringLike(const char * /*data*/, size_t /*length*/, size_t * /*token_start*/, String & /*token_length*/) const
 {
-    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "NoOpTokenExtractor::nextInStringLike is not implemented");
+    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "ArrayTokenExtractor::nextInStringLike is not implemented");
 }
 
 SparseGramTokenExtractor::SparseGramTokenExtractor(size_t min_length, size_t max_length, std::optional<size_t> min_cutoff_length_)

--- a/src/Interpreters/ITokenExtractor.cpp
+++ b/src/Interpreters/ITokenExtractor.cpp
@@ -82,7 +82,7 @@ bool NgramsTokenExtractor::nextInStringLike(const char * data, size_t length, si
     return false;
 }
 
-bool DefaultTokenExtractor::nextInString(const char * data, size_t length, size_t * __restrict pos, size_t * __restrict token_start, size_t * __restrict token_length) const
+bool SplitByNonAlphaTokenExtractor::nextInString(const char * data, size_t length, size_t * __restrict pos, size_t * __restrict token_start, size_t * __restrict token_length) const
 {
     *token_start = *pos;
     *token_length = 0;
@@ -107,7 +107,7 @@ bool DefaultTokenExtractor::nextInString(const char * data, size_t length, size_
     return *token_length > 0;
 }
 
-bool DefaultTokenExtractor::nextInStringPadded(const char * data, size_t length, size_t * __restrict pos, size_t * __restrict token_start, size_t * __restrict token_length) const
+bool SplitByNonAlphaTokenExtractor::nextInStringPadded(const char * data, size_t length, size_t * __restrict pos, size_t * __restrict token_start, size_t * __restrict token_length) const
 {
     *token_start = *pos;
     *token_length = 0;
@@ -198,7 +198,7 @@ bool DefaultTokenExtractor::nextInStringPadded(const char * data, size_t length,
     return *token_length > 0;
 }
 
-bool DefaultTokenExtractor::nextInStringLike(const char * data, size_t length, size_t * pos, String & token) const
+bool SplitByNonAlphaTokenExtractor::nextInStringLike(const char * data, size_t length, size_t * pos, String & token) const
 {
     token.clear();
     bool bad_token = false; // % or _ before token
@@ -241,7 +241,7 @@ bool DefaultTokenExtractor::nextInStringLike(const char * data, size_t length, s
     return !bad_token && !token.empty();
 }
 
-void DefaultTokenExtractor::substringToBloomFilter(const char * data, size_t length, BloomFilter & bloom_filter, bool is_prefix, bool is_suffix) const
+void SplitByNonAlphaTokenExtractor::substringToBloomFilter(const char * data, size_t length, BloomFilter & bloom_filter, bool is_prefix, bool is_suffix) const
 {
     size_t cur = 0;
     size_t token_start = 0;
@@ -256,7 +256,7 @@ void DefaultTokenExtractor::substringToBloomFilter(const char * data, size_t len
     }
 }
 
-void DefaultTokenExtractor::substringToTokens(const char * data, size_t length, std::vector<String> & tokens, bool is_prefix, bool is_suffix) const
+void SplitByNonAlphaTokenExtractor::substringToTokens(const char * data, size_t length, std::vector<String> & tokens, bool is_prefix, bool is_suffix) const
 {
     size_t cur = 0;
     size_t token_start = 0;

--- a/src/Interpreters/ITokenExtractor.cpp
+++ b/src/Interpreters/ITokenExtractor.cpp
@@ -292,7 +292,7 @@ bool startsWithSeparator(const char * data, size_t length, size_t pos, const std
 
 }
 
-bool SplitTokenExtractor::nextInString(const char * data, size_t length, size_t * pos, size_t * token_start, size_t * token_length) const
+bool SplitByStringTokenExtractor::nextInString(const char * data, size_t length, size_t * pos, size_t * token_start, size_t * token_length) const
 {
     size_t i = *pos;
     std::string matched_separators;
@@ -319,7 +319,7 @@ bool SplitTokenExtractor::nextInString(const char * data, size_t length, size_t 
     return true;
 }
 
-bool SplitTokenExtractor::nextInStringLike(const char * /*data*/, size_t /*length*/, size_t * /*token_start*/, String & /*token_length*/) const
+bool SplitByStringTokenExtractor::nextInStringLike(const char * /*data*/, size_t /*length*/, size_t * /*token_start*/, String & /*token_length*/) const
 {
     throw Exception(ErrorCodes::NOT_IMPLEMENTED, "StringTokenExtractor::nextInStringLike is not implemented");
 }

--- a/src/Interpreters/ITokenExtractor.h
+++ b/src/Interpreters/ITokenExtractor.h
@@ -19,7 +19,7 @@ public:
         SplitByNonAlpha,
         Ngrams,
         SplitByString,
-        NoOp,
+        Array,
         SparseGram,
     };
 
@@ -212,9 +212,9 @@ private:
 };
 
 /// Parser doing "no operation". Returns the entire input as a single token.
-struct NoOpTokenExtractor final : public ITokenExtractorHelper<NoOpTokenExtractor>
+struct ArrayTokenExtractor final : public ITokenExtractorHelper<ArrayTokenExtractor>
 {
-    NoOpTokenExtractor() : ITokenExtractorHelper(Type::NoOp) {}
+    ArrayTokenExtractor() : ITokenExtractorHelper(Type::Array) {}
 
     static const char * getName() { return "array"; }
     static const char * getExternalName() { return getName(); }
@@ -304,7 +304,7 @@ void forEachTokenCase(const ITokenExtractor & extractor, const char * __restrict
             forEachTokenImpl<is_padded>(split_by_string_extractor, data, length, callback);
             return;
         }
-        case ITokenExtractor::Type::NoOp:
+        case ITokenExtractor::Type::Array:
         {
             callback(data, length);
             return;

--- a/src/Interpreters/ITokenExtractor.h
+++ b/src/Interpreters/ITokenExtractor.h
@@ -17,7 +17,7 @@ public:
     enum class Type
     {
         Default,
-        Ngram,
+        Ngrams,
         Split,
         NoOp,
         SparseGram,
@@ -160,9 +160,9 @@ private:
 
 
 /// Parser extracting all ngrams from string.
-struct NgramTokenExtractor final : public ITokenExtractorHelper<NgramTokenExtractor>
+struct NgramsTokenExtractor final : public ITokenExtractorHelper<NgramsTokenExtractor>
 {
-    explicit NgramTokenExtractor(size_t n_) : ITokenExtractorHelper(Type::Ngram), n(n_) {}
+    explicit NgramsTokenExtractor(size_t n_) : ITokenExtractorHelper(Type::Ngrams), n(n_) {}
 
     static const char * getName() { return "ngrambf_v1"; }
     static const char * getExternalName() { return "ngrams"; }
@@ -288,14 +288,14 @@ void forEachTokenCase(const ITokenExtractor & extractor, const char * __restrict
             forEachTokenImpl<is_padded>(default_extractor, data, length, callback);
             return;
         }
-        case ITokenExtractor::Type::Ngram:
+        case ITokenExtractor::Type::Ngrams:
         {
-            const auto & ngram_extractor = assert_cast<const NgramTokenExtractor &>(extractor);
+            const auto & ngrams_tokenizer = assert_cast<const NgramsTokenExtractor &>(extractor);
 
-            if (length < ngram_extractor.getN())
+            if (length < ngrams_tokenizer.getN())
                 return;
 
-            forEachTokenImpl<is_padded>(ngram_extractor, data, length, callback);
+            forEachTokenImpl<is_padded>(ngrams_tokenizer, data, length, callback);
             return;
         }
         case ITokenExtractor::Type::Split:

--- a/src/Interpreters/ITokenExtractor.h
+++ b/src/Interpreters/ITokenExtractor.h
@@ -18,7 +18,7 @@ public:
     {
         SplitByNonAlpha,
         Ngrams,
-        Split,
+        SplitByString,
         NoOp,
         SparseGram,
     };
@@ -196,9 +196,9 @@ struct SplitByNonAlphaTokenExtractor final : public ITokenExtractorHelper<SplitB
 
 /// Parser extracting tokens which are separated by certain strings.
 /// Allows to emulate e.g. BigQuery's LOG_ANALYZER.
-struct SplitTokenExtractor final : public ITokenExtractorHelper<SplitTokenExtractor>
+struct SplitByStringTokenExtractor final : public ITokenExtractorHelper<SplitByStringTokenExtractor>
 {
-    explicit SplitTokenExtractor(const std::vector<String> & separators_) : ITokenExtractorHelper(Type::Split), separators(separators_) {}
+    explicit SplitByStringTokenExtractor(const std::vector<String> & separators_) : ITokenExtractorHelper(Type::SplitByString), separators(separators_) {}
 
     static const char * getName() { return "splitByString"; }
     static const char * getExternalName() { return getName(); }
@@ -298,10 +298,10 @@ void forEachTokenCase(const ITokenExtractor & extractor, const char * __restrict
             forEachTokenImpl<is_padded>(ngrams_tokenizer, data, length, callback);
             return;
         }
-        case ITokenExtractor::Type::Split:
+        case ITokenExtractor::Type::SplitByString:
         {
-            const auto & split_extractor = assert_cast<const SplitTokenExtractor &>(extractor);
-            forEachTokenImpl<is_padded>(split_extractor, data, length, callback);
+            const auto & split_by_string_extractor = assert_cast<const SplitByStringTokenExtractor &>(extractor);
+            forEachTokenImpl<is_padded>(split_by_string_extractor, data, length, callback);
             return;
         }
         case ITokenExtractor::Type::NoOp:

--- a/src/Interpreters/ITokenExtractor.h
+++ b/src/Interpreters/ITokenExtractor.h
@@ -20,7 +20,7 @@ public:
         Ngrams,
         SplitByString,
         Array,
-        SparseGram,
+        SparseGrams,
     };
 
     ITokenExtractor() = default;
@@ -227,9 +227,9 @@ struct ArrayTokenExtractor final : public ITokenExtractorHelper<ArrayTokenExtrac
 
 /// Parser extracting sparse grams (the same as function sparseGrams).
 /// See sparseGrams.h for more details.
-struct SparseGramTokenExtractor final : public ITokenExtractorHelper<SparseGramTokenExtractor>
+struct SparseGramsTokenExtractor final : public ITokenExtractorHelper<SparseGramsTokenExtractor>
 {
-    explicit SparseGramTokenExtractor(size_t min_length = 3, size_t max_length = 100, std::optional<size_t> min_cutoff_length_ = std::nullopt);
+    explicit SparseGramsTokenExtractor(size_t min_length = 3, size_t max_length = 100, std::optional<size_t> min_cutoff_length_ = std::nullopt);
 
     static const char * getBloomFilterIndexName() { return "sparse_grams"; }
     static const char * getName() { return "sparseGrams"; }
@@ -309,10 +309,10 @@ void forEachTokenCase(const ITokenExtractor & extractor, const char * __restrict
             callback(data, length);
             return;
         }
-        case ITokenExtractor::Type::SparseGram:
+        case ITokenExtractor::Type::SparseGrams:
         {
-            const auto & sparse_gram_extractor = assert_cast<const SparseGramTokenExtractor &>(extractor);
-            forEachTokenImpl<is_padded>(sparse_gram_extractor, data, length, callback);
+            const auto & sparse_grams_extractor = assert_cast<const SparseGramsTokenExtractor &>(extractor);
+            forEachTokenImpl<is_padded>(sparse_grams_extractor, data, length, callback);
             return;
         }
     }

--- a/src/Interpreters/ITokenExtractor.h
+++ b/src/Interpreters/ITokenExtractor.h
@@ -16,7 +16,7 @@ struct ITokenExtractor
 public:
     enum class Type
     {
-        Default,
+        SplitByNonAlpha,
         Ngrams,
         Split,
         NoOp,
@@ -178,9 +178,9 @@ private:
 };
 
 /// Parser extracting tokens which consist of alphanumeric ASCII characters or Unicode characters (not necessarily alphanumeric)
-struct DefaultTokenExtractor final : public ITokenExtractorHelper<DefaultTokenExtractor>
+struct SplitByNonAlphaTokenExtractor final : public ITokenExtractorHelper<SplitByNonAlphaTokenExtractor>
 {
-    DefaultTokenExtractor() : ITokenExtractorHelper(Type::Default) {}
+    SplitByNonAlphaTokenExtractor() : ITokenExtractorHelper(Type::SplitByNonAlpha) {}
 
     static const char * getName() { return "tokenbf_v1"; }
     static const char * getExternalName() { return "splitByNonAlpha"; }
@@ -282,10 +282,10 @@ void forEachTokenCase(const ITokenExtractor & extractor, const char * __restrict
 
     switch (extractor.getType())
     {
-        case ITokenExtractor::Type::Default:
+        case ITokenExtractor::Type::SplitByNonAlpha:
         {
-            const auto & default_extractor = assert_cast<const DefaultTokenExtractor &>(extractor);
-            forEachTokenImpl<is_padded>(default_extractor, data, length, callback);
+            const auto & split_by_non_alpha_extractor = assert_cast<const SplitByNonAlphaTokenExtractor &>(extractor);
+            forEachTokenImpl<is_padded>(split_by_non_alpha_extractor, data, length, callback);
             return;
         }
         case ITokenExtractor::Type::Ngrams:

--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.cpp
@@ -782,12 +782,12 @@ MergeTreeIndexPtr bloomFilterIndexTextCreator(
 
         return std::make_shared<MergeTreeIndexBloomFilterText>(index, params, std::move(tokenizer));
     }
-    if (index.type == DefaultTokenExtractor::getName())
+    if (index.type == SplitByNonAlphaTokenExtractor::getName())
     {
         BloomFilterParameters params(
             index.arguments[0].safeGet<size_t>(), index.arguments[1].safeGet<size_t>(), index.arguments[2].safeGet<size_t>());
 
-        auto tokenizer = std::make_unique<DefaultTokenExtractor>();
+        auto tokenizer = std::make_unique<SplitByNonAlphaTokenExtractor>();
 
         return std::make_shared<MergeTreeIndexBloomFilterText>(index, params, std::move(tokenizer));
     }
@@ -855,7 +855,7 @@ void bloomFilterIndexTextValidator(const IndexDescription & index, bool /*attach
         if (index.arguments.size() != 4)
             throw Exception(ErrorCodes::INCORRECT_QUERY, "`ngrambf` index must have exactly 4 arguments.");
     }
-    else if (index.type == DefaultTokenExtractor::getName())
+    else if (index.type == SplitByNonAlphaTokenExtractor::getName())
     {
         if (index.arguments.size() != 3)
             throw Exception(ErrorCodes::INCORRECT_QUERY, "`tokenbf` index must have exactly 3 arguments.");

--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.cpp
@@ -770,7 +770,7 @@ MergeTreeIndexConditionPtr MergeTreeIndexBloomFilterText::createIndexCondition(
 MergeTreeIndexPtr bloomFilterIndexTextCreator(
     const IndexDescription & index)
 {
-    if (index.type == NgramTokenExtractor::getName())
+    if (index.type == NgramsTokenExtractor::getName())
     {
         size_t n = index.arguments[0].safeGet<size_t>();
         BloomFilterParameters params(
@@ -778,7 +778,7 @@ MergeTreeIndexPtr bloomFilterIndexTextCreator(
             index.arguments[2].safeGet<size_t>(),
             index.arguments[3].safeGet<size_t>());
 
-        auto tokenizer = std::make_unique<NgramTokenExtractor>(n);
+        auto tokenizer = std::make_unique<NgramsTokenExtractor>(n);
 
         return std::make_shared<MergeTreeIndexBloomFilterText>(index, params, std::move(tokenizer));
     }
@@ -850,7 +850,7 @@ void bloomFilterIndexTextValidator(const IndexDescription & index, bool /*attach
                 "Ngram and token bloom filter indexes can only be used with column types `String`, `FixedString`, `LowCardinality(String)`, `LowCardinality(FixedString)`, `Array(String)` or `Array(FixedString)`");
     }
 
-    if (index.type == NgramTokenExtractor::getName())
+    if (index.type == NgramsTokenExtractor::getName())
     {
         if (index.arguments.size() != 4)
             throw Exception(ErrorCodes::INCORRECT_QUERY, "`ngrambf` index must have exactly 4 arguments.");

--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.cpp
@@ -791,7 +791,7 @@ MergeTreeIndexPtr bloomFilterIndexTextCreator(
 
         return std::make_shared<MergeTreeIndexBloomFilterText>(index, params, std::move(tokenizer));
     }
-    if (index.type == SparseGramTokenExtractor::getBloomFilterIndexName())
+    if (index.type == SparseGramsTokenExtractor::getBloomFilterIndexName())
     {
         if (index.arguments.size() == 5)
         {
@@ -803,7 +803,7 @@ MergeTreeIndexPtr bloomFilterIndexTextCreator(
                 index.arguments[3].safeGet<size_t>(),
                 index.arguments[4].safeGet<size_t>());
 
-            auto tokenizer = std::make_unique<SparseGramTokenExtractor>(min_ngram_length, max_ngram_length);
+            auto tokenizer = std::make_unique<SparseGramsTokenExtractor>(min_ngram_length, max_ngram_length);
 
             return std::make_shared<MergeTreeIndexBloomFilterText>(index, params, std::move(tokenizer));
         }
@@ -818,7 +818,7 @@ MergeTreeIndexPtr bloomFilterIndexTextCreator(
                 index.arguments[4].safeGet<size_t>(),
                 index.arguments[5].safeGet<size_t>());
 
-            auto tokenizer = std::make_unique<SparseGramTokenExtractor>(min_ngram_length, max_ngram_length, min_cutoff_length);
+            auto tokenizer = std::make_unique<SparseGramsTokenExtractor>(min_ngram_length, max_ngram_length, min_cutoff_length);
 
             return std::make_shared<MergeTreeIndexBloomFilterText>(index, params, std::move(tokenizer));
 
@@ -860,7 +860,7 @@ void bloomFilterIndexTextValidator(const IndexDescription & index, bool /*attach
         if (index.arguments.size() != 3)
             throw Exception(ErrorCodes::INCORRECT_QUERY, "`tokenbf` index must have exactly 3 arguments.");
     }
-    else if (index.type == SparseGramTokenExtractor::getBloomFilterIndexName())
+    else if (index.type == SparseGramsTokenExtractor::getBloomFilterIndexName())
     {
         if (index.arguments.size() != 5 && index.arguments.size() != 6)
             throw Exception(ErrorCodes::INCORRECT_QUERY, "`sparseGrams` index must have exactly 5 or 6 arguments.");

--- a/src/Storages/MergeTree/MergeTreeIndexText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexText.cpp
@@ -1209,9 +1209,9 @@ MergeTreeIndexPtr textIndexCreator(const IndexDescription & index)
         auto separators = extractSplitByStringParam(params);
         token_extractor = std::make_unique<SplitByStringTokenExtractor>(separators);
     }
-    else if (tokenizer == NoOpTokenExtractor::getExternalName())
+    else if (tokenizer == ArrayTokenExtractor::getExternalName())
     {
-        token_extractor = std::make_unique<NoOpTokenExtractor>();
+        token_extractor = std::make_unique<ArrayTokenExtractor>();
     }
     else if (tokenizer == SparseGramTokenExtractor::getExternalName())
     {
@@ -1253,7 +1253,7 @@ void textIndexValidator(const IndexDescription & index, bool /*attach*/)
     const bool is_supported_tokenizer = (tokenizer == SplitByNonAlphaTokenExtractor::getExternalName()
                                       || tokenizer == NgramsTokenExtractor::getExternalName()
                                       || tokenizer == SplitByStringTokenExtractor::getExternalName()
-                                      || tokenizer == NoOpTokenExtractor::getExternalName()
+                                      || tokenizer == ArrayTokenExtractor::getExternalName()
                                       || tokenizer == SparseGramTokenExtractor::getExternalName());
     if (!is_supported_tokenizer)
     {
@@ -1264,7 +1264,7 @@ void textIndexValidator(const IndexDescription & index, bool /*attach*/)
             tokenizer);
     }
 
-    if (tokenizer == SplitByNonAlphaTokenExtractor::getExternalName() || tokenizer == NoOpTokenExtractor::getExternalName())
+    if (tokenizer == SplitByNonAlphaTokenExtractor::getExternalName() || tokenizer == ArrayTokenExtractor::getExternalName())
     {
         assertParamsCount(tokenizer, params.size(), 0);
     }

--- a/src/Storages/MergeTree/MergeTreeIndexText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexText.cpp
@@ -1154,7 +1154,7 @@ UInt64 extractNgramParam(const std::vector<Field> & params)
 
 std::vector<String> extractSplitByStringParam(const std::vector<Field> & params)
 {
-    assertParamsCount(SplitTokenExtractor::getExternalName(), params.size(), 1);
+    assertParamsCount(SplitByStringTokenExtractor::getExternalName(), params.size(), 1);
     if (params.empty())
         return std::vector<String>{" "};
 
@@ -1204,10 +1204,10 @@ MergeTreeIndexPtr textIndexCreator(const IndexDescription & index)
         auto ngram_size = extractNgramParam(params);
         token_extractor = std::make_unique<NgramsTokenExtractor>(ngram_size);
     }
-    else if (tokenizer == SplitTokenExtractor::getExternalName())
+    else if (tokenizer == SplitByStringTokenExtractor::getExternalName())
     {
         auto separators = extractSplitByStringParam(params);
-        token_extractor = std::make_unique<SplitTokenExtractor>(separators);
+        token_extractor = std::make_unique<SplitByStringTokenExtractor>(separators);
     }
     else if (tokenizer == NoOpTokenExtractor::getExternalName())
     {
@@ -1252,7 +1252,7 @@ void textIndexValidator(const IndexDescription & index, bool /*attach*/)
     /// Check that tokenizer is supported
     const bool is_supported_tokenizer = (tokenizer == SplitByNonAlphaTokenExtractor::getExternalName()
                                       || tokenizer == NgramsTokenExtractor::getExternalName()
-                                      || tokenizer == SplitTokenExtractor::getExternalName()
+                                      || tokenizer == SplitByStringTokenExtractor::getExternalName()
                                       || tokenizer == NoOpTokenExtractor::getExternalName()
                                       || tokenizer == SparseGramTokenExtractor::getExternalName());
     if (!is_supported_tokenizer)
@@ -1279,7 +1279,7 @@ void textIndexValidator(const IndexDescription & index, bool /*attach*/)
                 tokenizer, ngram_size);
         }
     }
-    else if (tokenizer == SplitTokenExtractor::getExternalName())
+    else if (tokenizer == SplitByStringTokenExtractor::getExternalName())
     {
         auto separators = extractSplitByStringParam(params);
 

--- a/src/Storages/MergeTree/MergeTreeIndexText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexText.cpp
@@ -1169,7 +1169,7 @@ std::vector<String> extractSplitByStringParam(const std::vector<Field> & params)
 
 std::tuple<UInt64, UInt64, std::optional<UInt64>> extractSparseGramsParams(const std::vector<Field> & params)
 {
-    assertParamsCount(SparseGramTokenExtractor::getExternalName(), params.size(), 3);
+    assertParamsCount(SparseGramsTokenExtractor::getExternalName(), params.size(), 3);
 
     UInt64 min_length = DEFAULT_SPARSE_GRAMS_MIN_LENGTH;
     UInt64 max_length = DEFAULT_SPARSE_GRAMS_MAX_LENGTH;
@@ -1213,10 +1213,10 @@ MergeTreeIndexPtr textIndexCreator(const IndexDescription & index)
     {
         token_extractor = std::make_unique<ArrayTokenExtractor>();
     }
-    else if (tokenizer == SparseGramTokenExtractor::getExternalName())
+    else if (tokenizer == SparseGramsTokenExtractor::getExternalName())
     {
         auto [min_length, max_length, min_cutoff_length] = extractSparseGramsParams(params);
-        token_extractor = std::make_unique<SparseGramTokenExtractor>(min_length, max_length, min_cutoff_length);
+        token_extractor = std::make_unique<SparseGramsTokenExtractor>(min_length, max_length, min_cutoff_length);
     }
     else
     {
@@ -1254,7 +1254,7 @@ void textIndexValidator(const IndexDescription & index, bool /*attach*/)
                                       || tokenizer == NgramsTokenExtractor::getExternalName()
                                       || tokenizer == SplitByStringTokenExtractor::getExternalName()
                                       || tokenizer == ArrayTokenExtractor::getExternalName()
-                                      || tokenizer == SparseGramTokenExtractor::getExternalName());
+                                      || tokenizer == SparseGramsTokenExtractor::getExternalName());
     if (!is_supported_tokenizer)
     {
         throw Exception(
@@ -1290,7 +1290,7 @@ void textIndexValidator(const IndexDescription & index, bool /*attach*/)
                 tokenizer);
         }
     }
-    else if (tokenizer == SparseGramTokenExtractor::getExternalName())
+    else if (tokenizer == SparseGramsTokenExtractor::getExternalName())
     {
         auto [min_length, max_length, min_cutoff_length] = extractSparseGramsParams(params);
 

--- a/src/Storages/MergeTree/MergeTreeIndexText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexText.cpp
@@ -1195,9 +1195,9 @@ MergeTreeIndexPtr textIndexCreator(const IndexDescription & index)
     const auto [tokenizer, params] = extractTokenizer(options);
     std::unique_ptr<ITokenExtractor> token_extractor;
 
-    if (tokenizer == DefaultTokenExtractor::getExternalName())
+    if (tokenizer == SplitByNonAlphaTokenExtractor::getExternalName())
     {
-        token_extractor = std::make_unique<DefaultTokenExtractor>();
+        token_extractor = std::make_unique<SplitByNonAlphaTokenExtractor>();
     }
     else if (tokenizer == NgramsTokenExtractor::getExternalName())
     {
@@ -1250,7 +1250,7 @@ void textIndexValidator(const IndexDescription & index, bool /*attach*/)
     const auto [tokenizer, params] = extractTokenizer(options);
 
     /// Check that tokenizer is supported
-    const bool is_supported_tokenizer = (tokenizer == DefaultTokenExtractor::getExternalName()
+    const bool is_supported_tokenizer = (tokenizer == SplitByNonAlphaTokenExtractor::getExternalName()
                                       || tokenizer == NgramsTokenExtractor::getExternalName()
                                       || tokenizer == SplitTokenExtractor::getExternalName()
                                       || tokenizer == NoOpTokenExtractor::getExternalName()
@@ -1264,7 +1264,7 @@ void textIndexValidator(const IndexDescription & index, bool /*attach*/)
             tokenizer);
     }
 
-    if (tokenizer == DefaultTokenExtractor::getExternalName() || tokenizer == NoOpTokenExtractor::getExternalName())
+    if (tokenizer == SplitByNonAlphaTokenExtractor::getExternalName() || tokenizer == NoOpTokenExtractor::getExternalName())
     {
         assertParamsCount(tokenizer, params.size(), 0);
     }

--- a/src/Storages/MergeTree/MergeTreeIndexText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexText.cpp
@@ -1148,7 +1148,7 @@ std::pair<String, std::vector<Field>> extractTokenizer(std::unordered_map<String
 
 UInt64 extractNgramParam(const std::vector<Field> & params)
 {
-    assertParamsCount(NgramTokenExtractor::getExternalName(), params.size(), 1);
+    assertParamsCount(NgramsTokenExtractor::getExternalName(), params.size(), 1);
     return params.empty() ? DEFAULT_NGRAM_SIZE : castAs<UInt64>(params.at(0), "ngram_size");
 }
 
@@ -1199,10 +1199,10 @@ MergeTreeIndexPtr textIndexCreator(const IndexDescription & index)
     {
         token_extractor = std::make_unique<DefaultTokenExtractor>();
     }
-    else if (tokenizer == NgramTokenExtractor::getExternalName())
+    else if (tokenizer == NgramsTokenExtractor::getExternalName())
     {
         auto ngram_size = extractNgramParam(params);
-        token_extractor = std::make_unique<NgramTokenExtractor>(ngram_size);
+        token_extractor = std::make_unique<NgramsTokenExtractor>(ngram_size);
     }
     else if (tokenizer == SplitTokenExtractor::getExternalName())
     {
@@ -1251,7 +1251,7 @@ void textIndexValidator(const IndexDescription & index, bool /*attach*/)
 
     /// Check that tokenizer is supported
     const bool is_supported_tokenizer = (tokenizer == DefaultTokenExtractor::getExternalName()
-                                      || tokenizer == NgramTokenExtractor::getExternalName()
+                                      || tokenizer == NgramsTokenExtractor::getExternalName()
                                       || tokenizer == SplitTokenExtractor::getExternalName()
                                       || tokenizer == NoOpTokenExtractor::getExternalName()
                                       || tokenizer == SparseGramTokenExtractor::getExternalName());
@@ -1268,7 +1268,7 @@ void textIndexValidator(const IndexDescription & index, bool /*attach*/)
     {
         assertParamsCount(tokenizer, params.size(), 0);
     }
-    else if (tokenizer == NgramTokenExtractor::getExternalName())
+    else if (tokenizer == NgramsTokenExtractor::getExternalName())
     {
         auto ngram_size = extractNgramParam(params);
 

--- a/src/Storages/tests/gtest_SplitByNonAlphaTokenExtractor.cpp
+++ b/src/Storages/tests/gtest_SplitByNonAlphaTokenExtractor.cpp
@@ -1,3 +1,4 @@
+#include <Interpreters/ITokenExtractor.h>
 #include <Storages/MergeTree/MergeTreeIndexBloomFilterText.h>
 
 #include <Common/PODArray.h>
@@ -15,19 +16,19 @@ using namespace DB;
 using namespace std::literals::string_literals;
 }
 
-struct DefaultTokenExtractorTestCase
+struct SplitByNonAlphaTokenExtractorTestCase
 {
     const std::string_view description;
     const std::string source;
     const std::vector<std::string> tokens;
 };
 
-std::ostream & operator<<(std::ostream & ostr, const DefaultTokenExtractorTestCase & test_case)
+std::ostream & operator<<(std::ostream & ostr, const SplitByNonAlphaTokenExtractorTestCase & test_case)
 {
     return ostr << test_case.description;
 }
 
-class DefaultTokenExtractorTest : public ::testing::TestWithParam<DefaultTokenExtractorTestCase>
+class SplitByNonAlphaTokenExtractorTest : public ::testing::TestWithParam<SplitByNonAlphaTokenExtractorTestCase>
 {
 public:
     void SetUp() override
@@ -46,11 +47,11 @@ public:
     std::unique_ptr<PaddedPODArray<char>> data;
 };
 
-TEST_P(DefaultTokenExtractorTest, next)
+TEST_P(SplitByNonAlphaTokenExtractorTest, next)
 {
     const auto & param = GetParam();
 
-    DefaultTokenExtractor token_extractor;
+    SplitByNonAlphaTokenExtractor token_extractor;
 
     size_t i = 0;
 
@@ -72,8 +73,8 @@ TEST_P(DefaultTokenExtractorTest, next)
 }
 
 INSTANTIATE_TEST_SUITE_P(NoTokens,
-    DefaultTokenExtractorTest,
-    ::testing::ValuesIn(std::initializer_list<DefaultTokenExtractorTestCase>{
+    SplitByNonAlphaTokenExtractorTest,
+    ::testing::ValuesIn(std::initializer_list<SplitByNonAlphaTokenExtractorTestCase>{
         {
             "Empty input sequence produces no tokens.",
             "",
@@ -93,8 +94,8 @@ INSTANTIATE_TEST_SUITE_P(NoTokens,
 );
 
 INSTANTIATE_TEST_SUITE_P(ShortSingleToken,
-    DefaultTokenExtractorTest,
-    ::testing::ValuesIn(std::initializer_list<DefaultTokenExtractorTestCase>{
+    SplitByNonAlphaTokenExtractorTest,
+    ::testing::ValuesIn(std::initializer_list<SplitByNonAlphaTokenExtractorTestCase>{
         {
             "Short single token",
             "foo",
@@ -109,8 +110,8 @@ INSTANTIATE_TEST_SUITE_P(ShortSingleToken,
 );
 
 INSTANTIATE_TEST_SUITE_P(UTF8,
-    DefaultTokenExtractorTest,
-    ::testing::ValuesIn(std::initializer_list<DefaultTokenExtractorTestCase>{
+    SplitByNonAlphaTokenExtractorTest,
+    ::testing::ValuesIn(std::initializer_list<SplitByNonAlphaTokenExtractorTestCase>{
         {
             "Single token with mixed ASCII and UTF-8 chars",
             "abc\u0442" "123\u0447XYZ\u043A",
@@ -125,8 +126,8 @@ INSTANTIATE_TEST_SUITE_P(UTF8,
 );
 
 INSTANTIATE_TEST_SUITE_P(MultipleTokens,
-    DefaultTokenExtractorTest,
-    ::testing::ValuesIn(std::initializer_list<DefaultTokenExtractorTestCase>{
+    SplitByNonAlphaTokenExtractorTest,
+    ::testing::ValuesIn(std::initializer_list<SplitByNonAlphaTokenExtractorTestCase>{
         {
             "Multiple tokens separated by whitespace",
             "\nabc 123\tXYZ\r",
@@ -169,8 +170,8 @@ INSTANTIATE_TEST_SUITE_P(MultipleTokens,
 
 
 INSTANTIATE_TEST_SUITE_P(SIMD_Cases,
-    DefaultTokenExtractorTest,
-    ::testing::ValuesIn(std::initializer_list<DefaultTokenExtractorTestCase>{
+    SplitByNonAlphaTokenExtractorTest,
+    ::testing::ValuesIn(std::initializer_list<SplitByNonAlphaTokenExtractorTestCase>{
         {
             "First 16 bytes are empty, then a shor token",
             "                abcdef",


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Details

This PR renames the internal names of the tokenizers to the external ones.

See the individual commits for details.
