### PR TITLE
Open Policy Agent support

### DIFF
--- a/src/Access/Common/HTTPAuthenticationScheme.cpp
+++ b/src/Access/Common/HTTPAuthenticationScheme.cpp
@@ -22,7 +22,7 @@ HTTPAuthenticationScheme parseHTTPAuthenticationScheme(const String & scheme_str
 {
     auto scheme = magic_enum::enum_cast<HTTPAuthenticationScheme>(Poco::toUpper(scheme_str));
     if (!scheme)
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unknown HTTP authentication scheme: {}. Possible value is 'BASIC'", scheme_str);
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unknown HTTP authentication scheme: {}. Possible values are 'BASIC', 'BEARER'", scheme_str);
     return *scheme;
 }
 

--- a/src/Access/Common/HTTPAuthenticationScheme.h
+++ b/src/Access/Common/HTTPAuthenticationScheme.h
@@ -8,6 +8,7 @@ namespace DB
 enum class HTTPAuthenticationScheme
 {
     BASIC,
+    BEARER
 };
 
 

--- a/src/Access/ExternalAuthenticators.cpp
+++ b/src/Access/ExternalAuthenticators.cpp
@@ -561,13 +561,28 @@ bool ExternalAuthenticators::checkHTTPBasicCredentials(
     const String & server, const BasicCredentials & credentials, const ClientInfo & client_info, SettingsChanges & settings) const
 {
     auto params = getHTTPAuthenticationParams(server);
-    HTTPBasicAuthClient<SettingsAuthResponseParser> client(params);
+    HTTPAuthClient<SettingsAuthResponseParser> client(params);
 
-    auto [is_ok, settings_from_auth_server] = client.authenticate(credentials.getUserName(), credentials.getPassword(), client_info.http_headers);
+    auto [is_ok, settings_from_auth_server] = client.authenticateBasic(credentials.getUserName(), credentials.getPassword(), client_info.http_headers);
 
     if (is_ok)
         std::ranges::move(settings_from_auth_server, std::back_inserter(settings));
 
     return is_ok;
 }
+
+bool ExternalAuthenticators::checkHTTPBearerCredentials(
+    const String & server, const String & token, const ClientInfo & client_info, SettingsChanges & settings) const
+{
+    auto params = getHTTPAuthenticationParams(server);
+    HTTPAuthClient<SettingsAuthResponseParser> client(params);
+
+    auto [is_ok, settings_from_auth_server] = client.authenticateBearer(token, client_info.http_headers);
+
+    if (is_ok)
+        std::ranges::move(settings_from_auth_server, std::back_inserter(settings));
+
+    return is_ok;
+}
+
 }

--- a/src/Access/ExternalAuthenticators.cpp
+++ b/src/Access/ExternalAuthenticators.cpp
@@ -266,6 +266,25 @@ HTTPAuthClientParams parseHTTPAuthParams(const Poco::Util::AbstractConfiguration
 
 }
 
+HTTPAuthClientParams HTTPAuthClientParams::createDefault(const String & uri_, size_t max_tries_)
+{
+    constexpr size_t connection_timeout_ms = 1000;
+    constexpr size_t receive_timeout_ms = 1000;
+    constexpr size_t send_timeout_ms = 1000;
+
+    return HTTPAuthClientParams{
+        .uri = Poco::URI(uri_),
+        .timeouts = ConnectionTimeouts()
+                        .withConnectionTimeout(Poco::Timespan(connection_timeout_ms * 1000))
+                        .withReceiveTimeout(Poco::Timespan(receive_timeout_ms * 1000))
+                        .withSendTimeout(Poco::Timespan(send_timeout_ms * 1000)),
+        .max_tries = max_tries_,
+        .retry_initial_backoff_ms = 50,
+        .retry_max_backoff_ms = 1000,
+        .forward_headers = {}
+    };
+}
+
 void parseLDAPRoleSearchParams(LDAPClient::RoleSearchParams & params, const Poco::Util::AbstractConfiguration & config, const String & prefix)
 {
     parseLDAPSearchParams(params, config, prefix);

--- a/src/Access/ExternalAuthenticators.h
+++ b/src/Access/ExternalAuthenticators.h
@@ -44,6 +44,7 @@ public:
         const LDAPClient::RoleSearchParamsList * role_search_params = nullptr, LDAPClient::SearchResultsList * role_search_results = nullptr) const;
     bool checkKerberosCredentials(const String & realm, const GSSAcceptorContext & credentials) const;
     bool checkHTTPBasicCredentials(const String & server, const BasicCredentials & credentials, const ClientInfo & client_info, SettingsChanges & settings) const;
+    bool checkHTTPBearerCredentials(const String & server, const String & token, const ClientInfo & client_info, SettingsChanges & settings) const;
 
     GSSAcceptorContext::Params getKerberosParams() const;
 

--- a/src/Access/OpenPolicyAgentAccess.cpp
+++ b/src/Access/OpenPolicyAgentAccess.cpp
@@ -1,0 +1,273 @@
+#include <Access/HTTPAuthClient.h>
+#include <Access/OpenPolicyAgentAccess.h>
+#include <Access/User.h>
+#include <Interpreters/Context.h>
+#include <Common/Exception.h>
+#include <Common/config_version.h>
+
+#include <Poco/Util/AbstractConfiguration.h>
+#include <Poco/JSON/Object.h>
+#include <Poco/JSON/Parser.h>
+#include <Poco/JSON/Stringifier.h>
+
+#include <cassert>
+
+
+namespace DB
+{
+namespace ErrorCodes
+{
+extern const int ACCESS_DENIED;
+extern const int NOT_IMPLEMENTED;
+}
+
+namespace
+{
+
+class OPAResponseParser
+{
+public:
+    using Result = bool;
+    static constexpr const char * granted_json_field = "result";
+
+    bool parse(const Poco::Net::HTTPResponse & response, std::istream * body_stream) const
+    {
+        if (response.getStatus() != Poco::Net::HTTPResponse::HTTPStatus::HTTP_OK)
+        {
+            LOG_DEBUG(getLogger("OPA"), "HTTP status: {}", static_cast<UInt32>(response.getStatus()));
+            return false;
+        }
+
+        if (!body_stream)
+        {
+            LOG_DEBUG(getLogger("OPA"), "No response body");
+            return false;
+        }
+
+        String error;
+        try
+        {
+            Poco::JSON::Parser parser;
+            const Poco::Dynamic::Var json = parser.parse(*body_stream);
+            if (json.isEmpty())
+            {
+                LOG_DEBUG(getLogger("OPA"), "Response is not a JSON");
+                return false;
+            }
+
+            const Poco::JSON::Object::Ptr & obj = json.extract<Poco::JSON::Object::Ptr>();
+            if (!obj)
+            {
+                LOG_DEBUG(getLogger("OPA"), "Wrong root JSON object");
+                return false;
+            }
+
+            const Poco::Dynamic::Var allow = obj->get(granted_json_field);
+            return !allow.isEmpty() && allow.convert<bool>();
+        }
+        catch (const std::exception & ex)
+        {
+            error = ex.what();
+        }
+
+        if (!error.empty())
+            LOG_DEBUG(getLogger("OPA"), "Error: {}", error);
+        return false;
+    }
+};
+
+String makeAccessJSON(const AccessRightsElement & el, UserPtr user)
+{
+    Poco::JSON::Object json;
+    Poco::JSON::Object input;
+    {
+        Poco::JSON::Object context;
+        {
+            context.set("ClickHouseVersion", VERSION_STRING);
+
+            Poco::JSON::Object identity;
+            {
+                if (user)
+                    identity.set("user", user->getName());
+            }
+            context.set("identity", identity);
+        }
+        input.set("context", context);
+
+        if (!el.access_flags.isEmpty())
+        {
+            Poco::JSON::Array grants;
+            for (auto grant : el.access_flags.toAccessTypes())
+                grants.add(toString(grant));
+            input.set("grants", grants);
+        }
+
+        Poco::JSON::Object access;
+        {
+            if (!el.database.empty())
+                access.set("database", el.database);
+            if (!el.table.empty())
+                access.set("table", el.table);
+            if (!el.columns.empty())
+            {
+                Poco::JSON::Array columns;
+                for (auto & column_name : el.columns)
+                    columns.add(column_name);
+                access.set("columns", columns);
+            }
+        }
+        input.set("access", access);
+    }
+    json.set("input", input);
+
+    std::ostringstream oss; // STYLE_CHECK_ALLOW_STD_STRING_STREAM
+    oss.exceptions(std::ios::failbit);
+    Poco::JSON::Stringifier::stringify(json, oss);
+    return oss.str();
+}
+
+}
+
+std::shared_ptr<const OpenPolicyAgentAccess> OpenPolicyAgentAccess::create(ContextPtr context)
+{
+    static const String prefix = "open_policy_agent";
+
+    const auto & config = context->getConfigRef();
+    if (!config.has(prefix))
+    {
+        LOG_INFO(getLogger("OPA"), "No Open Policy Agent in config. Disabled.");
+        return {};
+    }
+
+    String url;
+    if (config.has(prefix + ".address"))
+        url = config.getString(prefix + ".address");
+
+    String token;
+    if (config.has(prefix + ".token"))
+        token = config.getString(prefix + ".token");
+
+    String role_name;
+    if (config.has(prefix + ".role"))
+        role_name = config.getString(prefix + ".role");
+
+    if (role_name.empty() || url.empty())
+    {
+        LOG_WARNING(getLogger("OPA"), "No role or address for Open Policy Agent in config. Disabled.");
+        return {};
+    }
+
+    return std::make_shared<const OpenPolicyAgentAccess>(role_name, url, token);
+}
+
+OpenPolicyAgentAccess::OpenPolicyAgentAccess(const String & role_, const String & url_, const String & service_token_)
+    : role(role_)
+    , url(url_)
+    , service_token(service_token_)
+{
+}
+
+OpenPolicyAgentAccess::OpenPolicyAgentAccess(const String & role_, const String & url_, const std::pair<String, String> & basic_auth_)
+    : role(role_)
+    , url(url_)
+    , basic_auth(basic_auth_)
+{
+}
+
+OpenPolicyAgentAccess::~OpenPolicyAgentAccess() = default;
+
+
+AccessRightsElement OpenPolicyAgentAccess::normalizeRightsElement(const AccessRightsElement & el, const String & current_database)
+{
+    if (el.wildcard)
+        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "OPA: Wildcard access is not supported, needed grant {}", el.toStringWithoutOptions());
+
+    if (el.grant_option)
+        throw Exception(
+            ErrorCodes::NOT_IMPLEMENTED, "OPA: Grant option access is not supported, needed grant {}", el.toStringWithoutOptions());
+
+    AccessRightsElement element = el.isGlobalWithParameter()
+        ? (el.anyParameter() ? AccessRightsElement(el.access_flags) : AccessRightsElement(el.access_flags, el.parameter))
+        : el;
+    element.replaceEmptyDatabase(current_database);
+    return element;
+}
+
+void OpenPolicyAgentAccess::checkAccess(ContextPtr context, const AccessRightsElement & el) const
+{
+    const AccessRightsElement element = normalizeRightsElement(el, context->getCurrentDatabase());
+
+    const String data = makeAccessJSON(el, context->getUser());
+
+    HTTPAuthClient<OPAResponseParser> client(HTTPAuthClientParams::createDefault(url, max_tries));
+
+    String poco_error;
+    try
+    {
+        bool granted = false;
+        if (!service_token.empty())
+            granted = client.authenticateBearer(service_token, {}, data);
+        else if (basic_auth)
+            granted = client.authenticateBasic(basic_auth->first, basic_auth->second, {}, data);
+
+        context->addQueryPrivilegesInfo(element.toStringWithoutOptions(), granted);
+        if (granted)
+            return;
+    }
+    catch (const Poco::Exception & ex)
+    {
+        poco_error = String(" (Poco: ") + ex.what() + ")";
+    }
+
+    throw Exception(
+        ErrorCodes::ACCESS_DENIED,
+        "OPA: Not enough privileges. To execute this query, it's necessary to have the grant {}",
+        (element.toStringWithoutOptions() + poco_error));
+}
+
+void OpenPolicyAgentAccess::checkAccess(ContextPtr context, const AccessRightsElements & elements) const
+{
+    for (const auto & el : elements)
+        checkAccess(context, el);
+}
+
+void OpenPolicyAgentAccess::checkAccess(ContextPtr context, const AccessFlags & flags) const
+{
+    checkAccess(context, AccessRightsElement{flags});
+}
+
+void OpenPolicyAgentAccess::checkAccess(ContextPtr context, const AccessFlags & flags, std::string_view database) const
+{
+    checkAccess(context, AccessRightsElement{flags, database});
+}
+
+void OpenPolicyAgentAccess::checkAccess(
+    ContextPtr context, const AccessFlags & flags, std::string_view database, std::string_view table) const
+{
+    checkAccess(context, AccessRightsElement{flags, database, table});
+}
+
+void OpenPolicyAgentAccess::checkAccess(
+    ContextPtr context, const AccessFlags & flags, std::string_view database, std::string_view table, std::string_view column) const
+{
+    checkAccess(context, AccessRightsElement{flags, database, table, column});
+}
+
+void OpenPolicyAgentAccess::checkAccess(
+    ContextPtr context,
+    const AccessFlags & flags,
+    std::string_view database,
+    std::string_view table,
+    const std::vector<std::string_view> & columns) const
+{
+    checkAccess(context, AccessRightsElement{flags, database, table, columns});
+}
+
+void OpenPolicyAgentAccess::checkAccess(
+    ContextPtr context, const AccessFlags & flags, std::string_view database, std::string_view table, const Strings & columns) const
+{
+    checkAccess(context, AccessRightsElement{flags, database, table, columns});
+}
+
+
+}

--- a/src/Access/OpenPolicyAgentAccess.h
+++ b/src/Access/OpenPolicyAgentAccess.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <memory>
+#include <optional>
+
+#include <Access/AccessRights.h>
+#include <Access/ContextAccessParams.h>
+
+
+namespace DB
+{
+class Context;
+using ContextPtr = std::shared_ptr<const Context>;
+
+class OpenPolicyAgentAccess : public std::enable_shared_from_this<OpenPolicyAgentAccess>
+{
+public:
+    static constexpr size_t max_tries = 1;
+
+    static std::shared_ptr<const OpenPolicyAgentAccess> create(ContextPtr context);
+
+    explicit OpenPolicyAgentAccess(const String & role, const String & url_, const String & service_token_ = {});
+    explicit OpenPolicyAgentAccess(const String & role, const String & url_, const std::pair<String, String> & basic_auth_);
+    ~OpenPolicyAgentAccess();
+
+    /// Checks if a specified access is granted, and throws an exception if not.
+    /// Empty database means the current database.
+    void checkAccess(ContextPtr context, const AccessRightsElement & element) const;
+    void checkAccess(ContextPtr context, const AccessRightsElements & elements) const;
+
+    // Helpers: convert arguments into AccessRightsElement
+    void checkAccess(ContextPtr context, const AccessFlags & flags) const;
+    void checkAccess(ContextPtr context, const AccessFlags & flags, std::string_view database) const;
+    void checkAccess(ContextPtr context, const AccessFlags & flags, std::string_view database, std::string_view table) const;
+    void checkAccess(
+        ContextPtr context, const AccessFlags & flags, std::string_view database, std::string_view table, std::string_view column) const;
+    void checkAccess(
+        ContextPtr context,
+        const AccessFlags & flags,
+        std::string_view database,
+        std::string_view table,
+        const std::vector<std::string_view> & columns) const;
+    void checkAccess(
+        ContextPtr context, const AccessFlags & flags, std::string_view database, std::string_view table, const Strings & columns) const;
+
+    const String & getRole() const { return role; }
+
+private:
+    const String role;
+    const String url;
+    const String service_token;
+    const std::optional<std::pair<String, String>> basic_auth;
+
+    static AccessRightsElement normalizeRightsElement(const AccessRightsElement & element, const String & current_database);
+};
+
+}

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -80,6 +80,7 @@
 #include <Access/SettingsConstraintsAndProfileIDs.h>
 #include <Access/ExternalAuthenticators.h>
 #include <Access/GSSAcceptor.h>
+#include <Access/OpenPolicyAgentAccess.h>
 #include <Backups/BackupsWorker.h>
 #include <Dictionaries/Embedded/GeoDictionariesLoader.h>
 #include <Interpreters/EmbeddedDictionaries.h>
@@ -1124,6 +1125,8 @@ ContextData::ContextData(const ContextData &o) :
     settings_constraints_and_current_profiles(o.settings_constraints_and_current_profiles),
     access(o.access),
     need_recalculate_access(o.need_recalculate_access),
+    opa_enabled(o.opa_enabled),
+    open_policy_agent(o.open_policy_agent),
     current_database(o.current_database),
     settings(std::make_unique<Settings>(*o.settings)),
     progress_callback(o.progress_callback),
@@ -1871,7 +1874,10 @@ ALWAYS_INLINE inline void contextSanityClampSettings(const Context & context, Se
 template <typename... Args>
 void Context::checkAccessImpl(const Args &... args) const
 {
-    return getAccess()->checkAccess(args...);
+    if (auto opa = getOpenPolicyAgent())
+        opa->checkAccess(shared_from_this(), args...);
+
+    getAccess()->checkAccess(args...);
 }
 
 void Context::checkAccess(const AccessFlags & flags) const { checkAccessImpl(flags); }
@@ -1886,6 +1892,27 @@ void Context::checkAccess(const AccessFlags & flags, const StorageID & table_id,
 void Context::checkAccess(const AccessFlags & flags, const StorageID & table_id, const Strings & columns) const { checkAccessImpl(flags, table_id.getDatabaseName(), table_id.getTableName(), columns); }
 void Context::checkAccess(const AccessRightsElement & element) const { checkAccessImpl(element); }
 void Context::checkAccess(const AccessRightsElements & elements) const { checkAccessImpl(elements); }
+
+std::shared_ptr<const OpenPolicyAgentAccess> Context::getOpenPolicyAgent() const
+{
+    if (!opa_enabled)
+        return {};
+
+    if (!open_policy_agent)
+    {
+        open_policy_agent = OpenPolicyAgentAccess::create(shared_from_this());
+        opa_enabled = open_policy_agent.get();
+    }
+
+    if (open_policy_agent && getRolesInfo())
+    {
+        auto roles = getRolesInfo()->getEnabledRolesNames();
+        const bool has_opa_role = roles.end() != std::find(roles.begin(), roles.end(), open_policy_agent->getRole());
+        return has_opa_role ? open_policy_agent : std::shared_ptr<const OpenPolicyAgentAccess>{};
+    }
+
+    return {};
+}
 
 std::shared_ptr<const ContextAccessWrapper> Context::getAccess() const
 {

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -184,6 +184,7 @@ class AsyncLoader;
 class HTTPHeaderFilter;
 struct AsyncReadCounters;
 struct ICgroupsReader;
+class OpenPolicyAgentAccess;
 
 struct TemporaryTableHolder;
 using TemporaryTablesMapping = std::map<String, std::shared_ptr<TemporaryTableHolder>>;
@@ -339,6 +340,8 @@ protected:
     std::shared_ptr<const SettingsConstraintsAndProfileIDs> settings_constraints_and_current_profiles;
     mutable std::shared_ptr<const ContextAccess> access;
     mutable bool need_recalculate_access = true;
+    mutable bool opa_enabled = true;
+    mutable std::shared_ptr<const OpenPolicyAgentAccess> open_policy_agent;
     String current_database;
     std::unique_ptr<Settings> settings{};  /// Setting for query execution.
 
@@ -801,6 +804,7 @@ public:
     void checkAccess(const AccessRightsElements & elements) const;
 
     std::shared_ptr<const ContextAccessWrapper> getAccess() const;
+    std::shared_ptr<const OpenPolicyAgentAccess> getOpenPolicyAgent() const;
 
     RowPolicyFilterPtr getRowPolicyFilter(const String & database, const String & table_name, RowPolicyFilterType filter_type) const;
 

--- a/tests/integration/helpers/http_server.py
+++ b/tests/integration/helpers/http_server.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import argparse
 import csv
+import json
 import socket
 import ssl
 import logging
@@ -8,25 +9,62 @@ import signal
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 
+# Example OPA src JSONs
+# {"input": {"context": {"identity": {"user": "default"}}, "access": {"database": "system", "table": "one", "columns": ["dummy"] }}}
+# {"input": {"context": {"identity": {"user": "default"}}, "access": {"database": "system", "table": "numbers", "columns": ["number"] }}}
+# {"input": {"context": {"identity": {"user": "default"}}, "access": {"database": "system", "table": "licenses", "columns": ["library_name", "license_type"] }}}
+def opa_check_rules(src_json):
+    try:
+        return (
+            src_json["input"]["context"]["identity"]["user"] != ""
+            and src_json["input"]["access"]["database"] == "system"
+            and src_json["input"]["access"]["table"] in ["one", "numbers", "licenses"]
+            and all(not col.startswith("license") for col in src_json["input"]["access"]["columns"])
+        )
+    except Exception as e:
+        print(type(e).__name__, e)
+        return None
+
+
+def opa_result_json(allow):
+    if allow:
+        return """{ "result": true }"""
+    else:
+        return """{}"""
+
+
+def check_header_auth(headers, token):
+    auth_header = headers.get("authorization", None)
+    return auth_header and (auth_header == ("Basic " + token) or auth_header == ("Bearer " + token))
+
+
+def check_header_api_key(headers, require_api_key):
+    if not require_api_key:
+        return True
+    api_key = headers.get("api-key", None)
+    return api_key and api_key == "secret"
+
+
 # Decorator used to see if authentication works for external dictionary who use a HTTP source.
-def check_auth(fn):
-    def wrapper(req):
-        auth_header = req.headers.get("authorization", None)
-        api_key = req.headers.get("api-key", None)
-        if (
-            not auth_header
-            or auth_header != "Basic Zm9vOmJhcg=="
-            or not api_key
-            or api_key != "secret"
-        ):
-            req.send_response(401)
-        else:
-            fn(req)
+def check_auth(token, require_api_key):
+    def check_auth_impl(fn):
+        def wrapper(req):
+            if (
+                not check_header_auth(req.headers, token)
+                or not check_header_api_key(req.headers, require_api_key)
+            ):
+                req.send_response(401)
+                req.send_header("WWW-Authenticate", "Basic")
+                req.send_header("WWW-Authenticate", "Bearer")
+                req.end_headers()
+            else:
+                fn(req)
 
-    return wrapper
+        return wrapper
+    return check_auth_impl
 
 
-def start_server(server_address, data_path, schema, cert_path, address_family):
+def start_server(server_address, data_path, schema, cert_path, address_family, token, is_opa):
     class TSVHTTPHandler(BaseHTTPRequestHandler):
         def log_message(self, format, *args):
             logging.info(
@@ -37,23 +75,37 @@ def start_server(server_address, data_path, schema, cert_path, address_family):
                 format % args,
             )
 
-        @check_auth
+        @check_auth(token, require_api_key=(not is_opa))
         def do_GET(self):
             self.log_message("Processing '%s'", self.requestline)
-            self.__send_headers()
-            self.__send_data()
+            if is_opa:
+                dst_json_str = opa_result_json(False)
+                self.__send_headers("application/json")
+                self.__send_string(dst_json_str)
+            else:
+                self.__send_headers()
+                self.__send_data()
 
-        @check_auth
+        @check_auth(token, require_api_key=(not is_opa))
         def do_POST(self):
             self.log_message("Processing '%s'", self.requestline)
-            ids = self.__read_and_decode_post_ids()
-            print("ids=", ids)
-            self.__send_headers()
-            self.__send_data(ids)
+            if is_opa:
+                src_json = self.__read_json()
+                self.log_message("src json '%s'", json.dumps(src_json, indent=2))
+                allow = opa_check_rules(src_json)
+                dst_json_str = opa_result_json(allow)
+                self.log_message("dst json '%s'", dst_json_str)
+                self.__send_headers("application/json")
+                self.__send_string(dst_json_str)
+            else:
+                ids = self.__read_and_decode_post_ids()
+                print("ids=", ids)
+                self.__send_headers()
+                self.__send_data(ids)
 
-        def __send_headers(self):
+        def __send_headers(self, content_type="text/tsv"):
             self.send_response(200)
-            self.send_header("Content-type", "text/tsv")
+            self.send_header("Content-type", content_type)
             self.end_headers()
 
         def __send_data(self, only_ids=None):
@@ -62,6 +114,9 @@ def start_server(server_address, data_path, schema, cert_path, address_family):
                 for row in reader:
                     if not only_ids or (row[0] in only_ids):
                         self.wfile.write(("\t".join(row) + "\n").encode())
+
+        def __send_string(self, result_str):
+            self.wfile.write(result_str.encode())
 
         def __read_and_decode_post_ids(self):
             data = self.__read_and_decode_post_data()
@@ -83,13 +138,23 @@ def start_server(server_address, data_path, schema, cert_path, address_family):
                 decoded = self.rfile.read(content_length).decode()
             return decoded
 
+        def __read_json(self):
+            try:
+                content_length = int(self.headers.get("Content-Length", 0))
+                json_data = self.rfile.read(content_length)
+                return json.loads(json_data)
+            except json.JSONDecodeError as e:
+                print(type(e).__name__, e)
+                return None
+
     if address_family == "ipv6":
         HTTPServer.address_family = socket.AF_INET6
     httpd = HTTPServer(server_address, TSVHTTPHandler)
     if schema == "https":
-        httpd.socket = ssl.wrap_socket(
-            httpd.socket, certfile=cert_path, server_side=True
-        )
+        ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        #ssl_context.load_cert_chain(cert_path)
+        ssl_context.load_verify_locations(cert_path)
+        httpd.socket = ssl_context.wrap_socket(httpd.socket, server_side=True)
     logging.info("Starting serving on %s", httpd.server_address)
     httpd.serve_forever()
     # Never reaches here
@@ -110,6 +175,8 @@ if __name__ == "__main__":
     parser.add_argument("--schema", choices=("http", "https"), required=True)
     parser.add_argument("--cert-path", default="./fake_cert.pem")
     parser.add_argument("--address-family", choices=("ipv4", "ipv6"), default="ipv4")
+    parser.add_argument("--token", default="Zm9vOmJhcg==")
+    parser.add_argument("--mode", choices=("ids", "opa"), default="ids")
 
     args = parser.parse_args()
 
@@ -119,4 +186,6 @@ if __name__ == "__main__":
         args.schema,
         args.cert_path,
         args.address_family,
+        args.token,
+        args.mode == "opa"
     )


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: false -->

### Changelog category (leave one):
- Experimental Feature

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
experimental support for Open Policy Agent

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

Closes #72994 (there's more description there)

### Details

The feature adds additional `accessCheck()` for queries if user grants special role. In this `accessCheck()` CH goes to OPA server over HTTP and checks access rights with registered REGO policy. There're sample JSONs which go between systems below.

In current version there would be one request to OPA per table. It's clear that it would be better to have one request per query instead to prevent OPAs overload. But for now it's too complicated to make such access batching in code.

Example use:
1. Add open section into config.xml
```
<open_policy_agent>
    <address>http://127.0.0.1:8181/v1/data/clickhouse/auth/allow</address>
    <token>opa_access_token_if_needed</token>
    <role>opa</role>
</open_policy_agent>
```
2. Add `opa` role (defined in config.xml as `open_policy_agent.role`) into users.xml with max permissive grants (OPA will add restrictions to them)
```
<roles>
    <opa>
        <grants>
            <query>GRANT SHOW ON system.*</query>
        </grants>
    </opa>
</roles>
```
3. Add `opa` role to user
```
<users>
    <user_x>
        ...
        <grants>
            <query>GRANT opa</query>
        </grants>
    </user_x>
</users>
```
4. Run OPA server on `open_policy_agent.address` from config.xml
```
docker run -it --rm -p 8181:8181 openpolicyagent/opa run --server --addr :8181 --log-format=json-pretty
```
5. Register policy. I.E. ch-pr.rego. NOTE: `package` and variable name (`allow`) would be a part of access URI from `open_policy_agent.address`
```
package clickhouse.auth

default allow := false

allow if {
	input.context.identity.user != ""
	input.access.database == "system"
	input.access.table in ["one", "numbers", "licenses"]
	every column in input.access.columns { not startswith(column, "license") }
}
```
```
curl -sX PUT 127.0.0.1:8181/v1/policies/42 -H "Content-Type: text/plain" --data-binary @ch-pr.rego
```
6. (Optional) Test OPA policy with samples ch-pr.json (`SELECT library_name FROM system.licenses`) and ch-pr-deny.json (`SELECT library_name, license_type FROM system.licenses`)
```
{
  "input": {
    "access": {
      "columns": [
        "library_name"
      ],
      "database": "system",
      "table": "licenses"
    },
    "context": {
      "ClickHouseVersion": "25.11.1.1",
      "identity": {
        "user": "user_jwt"
      }
    },
    "operations": [
      "SelectQueryAnalyzer"
    ]
  }
}
```
```
curl -s 127.0.0.1:8181/v1/data/clickhouse/auth/allow -H "Content-Type: application/json" -d @ch-pr.json
{"result":true}
```
```
{
  "input": {
    "access": {
      "columns": [
        "library_name",
        "license_type",
      ],
      "database": "system",
      "table": "licenses"
    },
    "context": {
      "ClickHouseVersion": "25.11.1.1",
      "identity": {
        "user": "user_jwt"
      }
    },
    "operations": [
      "SelectQueryAnalyzer"
    ]
  }
}
```
```
curl -s 127.0.0.1:8181/v1/data/clickhouse/auth/allow -H "Content-Type: application/json" -d @ch-pr-deny.json
{"result":false}
```
7. Run clickhouse-server, login with specified user and run queries. They lead to exceptions if OPA returns false.
```
Code: 497. DB::Exception: Received from localhost:9000. DB::Exception: OPA: Not enough privileges. To execute this query, it's necessary to have the grant SELECT(library_name, license_type) ON system.licenses. (ACCESS_DENIED)
```

It's also possible to run `tests/integration/helpers/http_server.py` in opa mode instead of real OPA server for tests:
```
python3 ./bin/http_server.py --data-path x --schema http --mode opa --host localhost --port 8181 --token "<actual token from config.xml>"
```

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
