### PR TITLE
tests: warn on MemoryAllocatedWithoutCheck only above threshold

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -3541,6 +3541,7 @@ def main(args):
     runner_process_killed = multiprocessing.Event()
     multiprocessing_manager = multiprocessing.Manager()
     restarted_tests = multiprocessing_manager.list()
+    tests_start_time = time()
 
     if not check_server_started(args):
         msg = "Server is not responding. Cannot execute 'SELECT 1' query."
@@ -3761,9 +3762,32 @@ def main(args):
     else:
         print("All tests have finished.")
 
-    unchecked_memory = int(clickhouse_execute(args, "SELECT sum(value) FROM system.events WHERE event = 'MemoryAllocatedWithoutCheckBytes'"))
+    unchecked_memory = int(clickhouse_execute(args, f"""
+    SELECT sum(size) FROM system.trace_log
+    WHERE
+        trace_type = 'MemoryAllocatedWithoutCheck'
+        AND event_date >= toDate(fromUnixTimestamp({int(tests_start_time)}))
+        AND event_time >= fromUnixTimestamp({int(tests_start_time)})
+    """))
     if unchecked_memory > 1e9:
-        print(f"Too much memory has been allocated without checking for memory limits: {unchecked_memory/1024/1024/1024} GiB")
+        print(f"""
+        Too much memory has been allocated without checking for memory limits: {unchecked_memory/1024/1024/1024} GiB.
+        Take a look at:
+
+        SELECT arrayStringConcat(symbols, '\\n'), sum(size)
+        FROM system.trace_log
+        WHERE trace_type = 'MemoryAllocatedWithoutCheck'
+            AND event_date >= toDate(fromUnixTimestamp({int(tests_start_time)}))
+            AND event_time >= fromUnixTimestamp({int(tests_start_time)})
+        GROUP BY 1
+        ORDER BY 2
+        LIMIT -10
+        FORMAT Vertical
+
+        See also at
+        - MemoryTrackerDebugBlockerInThread
+        - AllocatorWithMemoryTracking
+        """)
 
     if args.report_logs_stats:
         try:


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Details

Previously it was using system.events, which:
a) contains only total counter since server start
b) does not respect 16MiB threshold (tiny allocations w/o MemoryTracker is OK)

Reported-by: @antaljanosbenjamin
