### PR TITLE
remove assert

### DIFF
--- a/src/Disks/ObjectStorages/MetadataStorageFromPlainRewritableObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/MetadataStorageFromPlainRewritableObjectStorage.cpp
@@ -355,7 +355,6 @@ std::optional<StoredObjects> MetadataStorageFromPlainRewritableObjectStorage::ge
     if (auto object_size = getFileSizeIfExists(path))
     {
         auto object_key = object_storage->generateObjectKeyForPath(path, /*key_prefix=*/std::nullopt);
-        chassert(object_size == object_storage->getObjectMetadata(object_key.serialize(), /*with_tags=*/false).size_bytes);
         return StoredObjects{StoredObject(object_key.serialize(), path, *object_size)};
     }
 


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Details

Race condition is possible:
`getFileSizeIfExists(path))` sees file in memory,
other thread removes file from S3,
`object_storage->getObjectMetadata` receive 404.
