### PR TITLE
Speed up T64 decompression via dynamic dispatch

### DIFF
--- a/src/Compression/CompressionCodecT64.cpp
+++ b/src/Compression/CompressionCodecT64.cpp
@@ -1,5 +1,6 @@
 #include <cstring>
 
+#include <Common/TargetSpecific.h>
 #include <Common/SipHash.h>
 #include <Compression/ICompressionCodec.h>
 #include <Compression/CompressionFactory.h>
@@ -396,9 +397,10 @@ void transpose(const T * src, char * dst, UInt32 num_bits, UInt32 tail = 64)
     }
 }
 
-/// UInt64[N] transposed matrix -> UIntX[64]
+MULTITARGET_FUNCTION_AVX512BW_AVX2(
+MULTITARGET_FUNCTION_HEADER(
 template <typename T, bool full = false>
-void reverseTranspose(const char * src, T * buf, UInt32 num_bits, UInt32 tail = 64)
+void), reverseTransposeImpl, MULTITARGET_FUNCTION_BODY((const char * src, T * buf, UInt32 num_bits, UInt32 tail)
 {
     UInt64 matrix[64] = {};
     memcpy(matrix, src, num_bits * sizeof(UInt64));
@@ -422,6 +424,28 @@ void reverseTranspose(const char * src, T * buf, UInt32 num_bits, UInt32 tail = 
     clear(buf);
     for (UInt32 col = 0; col < tail; ++col)
         reverseTransposeBytes(matrix, col, buf[col]);
+})
+)
+
+/// UInt64[N] transposed matrix -> UIntX[64]
+template <typename T, bool full = false>
+ALWAYS_INLINE void reverseTranspose(const char * src, T * buf, UInt32 num_bits, UInt32 tail = 64)
+{
+#if USE_MULTITARGET_CODE
+    if (isArchSupported(TargetArch::AVX512BW))
+    {
+        reverseTransposeImplAVX512BW(src, buf, num_bits, tail);
+        return;
+    }
+    if (isArchSupported(TargetArch::AVX2))
+    {
+        reverseTransposeImplAVX2(src, buf, num_bits, tail);
+        return;
+    }
+#endif
+    {
+        reverseTransposeImpl(src, buf, num_bits, tail);
+    }
 }
 
 template <typename T, typename MinMaxT = std::conditional_t<is_signed_v<T>, Int64, UInt64>>

--- a/src/Compression/CompressionCodecT64.cpp
+++ b/src/Compression/CompressionCodecT64.cpp
@@ -399,7 +399,7 @@ void transpose(const T * src, char * dst, UInt32 num_bits, UInt32 tail = 64)
 
 MULTITARGET_FUNCTION_AVX512BW_AVX2(
 MULTITARGET_FUNCTION_HEADER(
-template <typename T, bool full = false>
+template <typename T, bool full>
 void), reverseTransposeImpl, MULTITARGET_FUNCTION_BODY((const char * src, T * buf, UInt32 num_bits, UInt32 tail)
 {
     UInt64 matrix[64] = {};
@@ -434,17 +434,17 @@ ALWAYS_INLINE void reverseTranspose(const char * src, T * buf, UInt32 num_bits, 
 #if USE_MULTITARGET_CODE
     if (isArchSupported(TargetArch::AVX512BW))
     {
-        reverseTransposeImplAVX512BW(src, buf, num_bits, tail);
+        reverseTransposeImplAVX512BW<T, full>(src, buf, num_bits, tail);
         return;
     }
     if (isArchSupported(TargetArch::AVX2))
     {
-        reverseTransposeImplAVX2(src, buf, num_bits, tail);
+        reverseTransposeImplAVX2<T, full>(src, buf, num_bits, tail);
         return;
     }
 #endif
     {
-        reverseTransposeImpl(src, buf, num_bits, tail);
+        reverseTransposeImpl<T, full>(src, buf, num_bits, tail);
     }
 }
 

--- a/tests/queries/0_stateless/00872_t64_bit_codec.reference
+++ b/tests/queries/0_stateless/00872_t64_bit_codec.reference
@@ -1,3 +1,9 @@
+-- { echoOn }
+
+INSERT INTO t64 SELECT number AS x, x, x, x, x, x, x, x FROM numbers(1);
+INSERT INTO t64 SELECT number AS x, x, x, x, x, x, x, x FROM numbers(2);
+INSERT INTO t64 SELECT 42 AS x, x, x, x, x, x, x, x FROM numbers(4);
+SELECT * FROM t64 ORDER BY u64;
 0	0	0	0	0	0	0	0
 0	0	0	0	0	0	0	0
 1	1	1	1	1	1	1	1
@@ -5,3 +11,74 @@
 42	42	42	42	42	42	42	42
 42	42	42	42	42	42	42	42
 42	42	42	42	42	42	42	42
+INSERT INTO t64 SELECT number AS x, x, x, x, x, x, x, x FROM numbers(intExp2(8));
+INSERT INTO t64 SELECT number AS x, x, x, x, x, x, x, x FROM numbers(intExp2(9));
+SELECT * FROM t64 WHERE u8 != t_u8;
+SELECT * FROM t64 WHERE u16 != t_u16;
+SELECT * FROM t64 WHERE u32 != t_u32;
+SELECT * FROM t64 WHERE u64 != t_u64;
+INSERT INTO t64 SELECT (intExp2(16) - 10 + number) AS x, x, x, x, x, x, x, x FROM numbers(10);
+INSERT INTO t64 SELECT (intExp2(16) - 10 + number) AS x, x, x, x, x, x, x, x FROM numbers(11);
+INSERT INTO t64 SELECT (intExp2(16) - 64 + number) AS x, x, x, x, x, x, x, x FROM numbers(64);
+INSERT INTO t64 SELECT (intExp2(16) - 64 + number) AS x, x, x, x, x, x, x, x FROM numbers(65);
+INSERT INTO t64 SELECT (intExp2(16) - 1 + number) AS x, x, x, x, x, x, x, x FROM numbers(65);
+SELECT * FROM t64 WHERE u8 != t_u8;
+SELECT * FROM t64 WHERE u16 != t_u16;
+SELECT * FROM t64 WHERE u32 != t_u32;
+SELECT * FROM t64 WHERE u64 != t_u64;
+INSERT INTO t64 SELECT (intExp2(24) - 10 + number) AS x, x, x, x, x, x, x, x FROM numbers(10);
+INSERT INTO t64 SELECT (intExp2(24) - 10 + number) AS x, x, x, x, x, x, x, x FROM numbers(11);
+INSERT INTO t64 SELECT (intExp2(24) - 64 + number) AS x, x, x, x, x, x, x, x FROM numbers(128);
+INSERT INTO t64 SELECT (intExp2(24) - 64 + number) AS x, x, x, x, x, x, x, x FROM numbers(129);
+INSERT INTO t64 SELECT (intExp2(24) - 1 + number) AS x, x, x, x, x, x, x, x FROM numbers(129);
+SELECT * FROM t64 WHERE u8 != t_u8;
+SELECT * FROM t64 WHERE u16 != t_u16;
+SELECT * FROM t64 WHERE u32 != t_u32;
+SELECT * FROM t64 WHERE u64 != t_u64;
+INSERT INTO t64 SELECT (intExp2(32) - 10 + number) AS x, x, x, x, x, x, x, x FROM numbers(10);
+INSERT INTO t64 SELECT (intExp2(32) - 10 + number) AS x, x, x, x, x, x, x, x FROM numbers(20);
+INSERT INTO t64 SELECT (intExp2(32) - 64 + number) AS x, x, x, x, x, x, x, x FROM numbers(256);
+INSERT INTO t64 SELECT (intExp2(32) - 64 + number) AS x, x, x, x, x, x, x, x FROM numbers(257);
+INSERT INTO t64 SELECT (intExp2(32) - 1 + number) AS x, x, x, x, x, x, x, x FROM numbers(257);
+SELECT * FROM t64 WHERE u8 != t_u8;
+SELECT * FROM t64 WHERE u16 != t_u16;
+SELECT * FROM t64 WHERE u32 != t_u32;
+SELECT * FROM t64 WHERE u64 != t_u64;
+INSERT INTO t64 SELECT (intExp2(40) - 10 + number) AS x, x, x, x, x, x, x, x FROM numbers(10);
+INSERT INTO t64 SELECT (intExp2(40) - 10 + number) AS x, x, x, x, x, x, x, x FROM numbers(20);
+INSERT INTO t64 SELECT (intExp2(40) - 64 + number) AS x, x, x, x, x, x, x, x FROM numbers(512);
+INSERT INTO t64 SELECT (intExp2(40) - 64 + number) AS x, x, x, x, x, x, x, x FROM numbers(513);
+INSERT INTO t64 SELECT (intExp2(40) - 1 + number) AS x, x, x, x, x, x, x, x FROM numbers(513);
+SELECT * FROM t64 WHERE u8 != t_u8;
+SELECT * FROM t64 WHERE u16 != t_u16;
+SELECT * FROM t64 WHERE u32 != t_u32;
+SELECT * FROM t64 WHERE u64 != t_u64;
+INSERT INTO t64 SELECT (intExp2(48) - 10 + number) AS x, x, x, x, x, x, x, x FROM numbers(10);
+INSERT INTO t64 SELECT (intExp2(48) - 10 + number) AS x, x, x, x, x, x, x, x FROM numbers(20);
+INSERT INTO t64 SELECT (intExp2(48) - 64 + number) AS x, x, x, x, x, x, x, x FROM numbers(1024);
+INSERT INTO t64 SELECT (intExp2(48) - 64 + number) AS x, x, x, x, x, x, x, x FROM numbers(1025);
+INSERT INTO t64 SELECT (intExp2(48) - 1 + number) AS x, x, x, x, x, x, x, x FROM numbers(1025);
+SELECT * FROM t64 WHERE u8 != t_u8;
+SELECT * FROM t64 WHERE u16 != t_u16;
+SELECT * FROM t64 WHERE u32 != t_u32;
+SELECT * FROM t64 WHERE u64 != t_u64;
+INSERT INTO t64 SELECT (intExp2(56) - 10 + number) AS x, x, x, x, x, x, x, x FROM numbers(10);
+INSERT INTO t64 SELECT (intExp2(56) - 10 + number) AS x, x, x, x, x, x, x, x FROM numbers(20);
+INSERT INTO t64 SELECT (intExp2(56) - 64 + number) AS x, x, x, x, x, x, x, x FROM numbers(2048);
+INSERT INTO t64 SELECT (intExp2(56) - 64 + number) AS x, x, x, x, x, x, x, x FROM numbers(2049);
+INSERT INTO t64 SELECT (intExp2(56) - 1 + number) AS x, x, x, x, x, x, x, x FROM numbers(2049);
+SELECT * FROM t64 WHERE u8 != t_u8;
+SELECT * FROM t64 WHERE u16 != t_u16;
+SELECT * FROM t64 WHERE u32 != t_u32;
+SELECT * FROM t64 WHERE u64 != t_u64;
+INSERT INTO t64 SELECT (intExp2(63) + number * intExp2(62)) AS x, x, x, x, x, x, x, x FROM numbers(10);
+SELECT * FROM t64 WHERE u8 != t_u8;
+SELECT * FROM t64 WHERE u16 != t_u16;
+SELECT * FROM t64 WHERE u32 != t_u32;
+SELECT * FROM t64 WHERE u64 != t_u64;
+OPTIMIZE TABLE t64 FINAL;
+SELECT * FROM t64 WHERE u8 != t_u8;
+SELECT * FROM t64 WHERE u16 != t_u16;
+SELECT * FROM t64 WHERE u32 != t_u32;
+SELECT * FROM t64 WHERE u64 != t_u64;
+DROP TABLE t64;

--- a/tests/queries/0_stateless/00872_t64_bit_codec.sql
+++ b/tests/queries/0_stateless/00872_t64_bit_codec.sql
@@ -12,6 +12,8 @@ CREATE TABLE t64
     t_u64 UInt64 Codec(T64('bit'), LZ4)
 ) ENGINE MergeTree() ORDER BY tuple();
 
+-- { echoOn }
+
 INSERT INTO t64 SELECT number AS x, x, x, x, x, x, x, x FROM numbers(1);
 INSERT INTO t64 SELECT number AS x, x, x, x, x, x, x, x FROM numbers(2);
 INSERT INTO t64 SELECT 42 AS x, x, x, x, x, x, x, x FROM numbers(4);


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Speed up T64 decompression via dynamic dispatch

### Details
Comes from https://github.com/ClickHouse/ClickHouse/pull/90043.

Easily 2x+ as fast (with local CPU with 512BW):
`SELECT count(n) FROM codec_seq_UInt64_T64 WHERE ignore(n) == 0 LIMIT 20000000 SETTINGS max_threads=1;`
* Before: 0.0.0.0:49000, queries: 200, QPS: 16.504, RPS: 330077530.024, MiB/s: 2518.292, result RPS: 16.504, result MiB/s: 0.000.
* After: 0.0.0.0:49000, queries: 200, QPS: 37.334, RPS: 746685862.706, MiB/s: 5696.761, result RPS: 37.334, result MiB/s: 0.000.
