### PR TITLE
Ignore 'curl: (18) transfer closed with outstanding read data remaining'

### DIFF
--- a/tests/queries/0_stateless/03308_json_with_progress_frequency.sh
+++ b/tests/queries/0_stateless/03308_json_with_progress_frequency.sh
@@ -5,6 +5,20 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
+ch_curl() {
+  ${CLICKHOUSE_CURL} -sS "$@" 2> >(grep -v "transfer closed with outstanding read data remaining" >&2)
+  code=$?
+  # Treat "curl: (18) transfer closed with outstanding read data remaining" as success
+  [ "$code" -eq 18 ] && return 0
+  return "$code"
+}
+
 # Usually not more than one progress event per 100 ms:
-${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&default_format=JSONEachRowWithProgress&max_execution_time=1&interactive_delay=100000" -d "SELECT count() FROM system.numbers" | 
-    grep -F '"progress"' | wc -l | ${CLICKHOUSE_LOCAL} --input-format TSV --query "SELECT c1 < 20 FROM table"
+response=$(ch_curl "${CLICKHOUSE_URL}&default_format=JSONEachRowWithProgress&max_execution_time=1&interactive_delay=100000" -d "SELECT count() FROM system.numbers")
+rc=$?
+if [ "$rc" -ne 0 ]; then
+  echo "unknown error, response: $response"
+  exit $rc
+fi
+
+echo "$response" | grep -F '"progress"' | wc -l | ${CLICKHOUSE_LOCAL} --input-format TSV --query "SELECT c1 < 20 FROM table"


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Details

[Link](https://play.clickhouse.com/play?user=play#U0VMRUNUIHRlc3RfbmFtZSwgY2hlY2tfc3RhcnRfdGltZSwgcmVwb3J0X3VybApGUk9NIGNoZWNrcwpXSEVSRSAxCiAgICBBTkQgY2hlY2tfc3RhcnRfdGltZSA+PSBub3coKSAtIElOVEVSVkFMIDI1NjAwIEhPVVIKICAgIEFORCAoaGVhZF9yZWYgPSAnbWFzdGVyJyBBTkQgc3RhcnRzV2l0aChoZWFkX3JlcG8sICdDbGlja0hvdXNlLycpKQogICAgQU5EIHRlc3Rfc3RhdHVzICE9ICdTS0lQUEVEJwogICAgQU5EICh0ZXN0X3N0YXR1cyBMSUtFICdGJScgT1IgdGVzdF9zdGF0dXMgTElLRSAnRSUnKSAKICAgIEFORCBjaGVja19zdGF0dXMgIT0gJ3N1Y2Nlc3MnCiAgICBhbmQgdGVzdF9uYW1lID0gJzAzMzA4X2pzb25fd2l0aF9wcm9ncmVzc19mcmVxdWVuY3knCgpvcmRlciBieSAyIERFU0M=) to all failures.

Example failure:
```
2025-11-21 17:24:45 Reason: having stderror:  
2025-11-21 17:24:45 curl: (18) transfer closed with outstanding read data remaining
2025-11-21 17:24:45 
2025-11-21 17:24:45 stdout:
2025-11-21 17:24:45 1
2025-11-21 17:24:45 
2025-11-21 17:24:45 /home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/tests/queries/0_stateless/test_43yr2oxz/03308_json_with_progress_frequency.sh.debuglog:
2025-11-21 17:24:45 + [2025-11-21 17:24:44] [:9] curl -q -s --max-time 120 -sS 'http://localhost:8123/?database=test_43yr2oxz&log_comment=03308_json_with_progress_frequency.sh-test_43yr2oxz&default_format=JSONEachRowWithProgress&max_execution_time=1&interactive_delay=100000' -d 'SELECT count() FROM system.numbers'
2025-11-21 17:24:45 + [2025-11-21 17:24:44] [:10] grep -F '"progress"'
2025-11-21 17:24:45 + [2025-11-21 17:24:44] [:10] wc -l
2025-11-21 17:24:45 + [2025-11-21 17:24:44] [:10] /home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/ci/tmp/clickhouse-local --input-format TSV --query 'SELECT c1 < 20 FROM table'
2025-11-21 17:24:45 
2025-11-21 17:24:45 
2025-11-21 17:24:45 Database: test_43yr2oxz
```

After merging [PR #89998](https://github.com/ClickHouse/ClickHouse/pull/89998) the test is broken since `curl` doesn't expect the end of data. This PR suppresses only this error message. Also relates to [PR #88818](https://github.com/ClickHouse/ClickHouse/pull/88818).
