### PR TITLE
tests/integration: use more lightweight backtrace capturing

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -4719,7 +4719,7 @@ class ClickHouseInstance:
                         [
                             "bash",
                             "-c",
-                            f"gdb -batch -ex 'thread apply all bt full' -p {pid} > /var/log/clickhouse-server/stdout.log",
+                            f"gdb -batch -ex 'thread apply all bt' -p {pid} > /var/log/clickhouse-server/stdout.log",
                         ],
                         user="root",
                     )
@@ -4813,7 +4813,7 @@ class ClickHouseInstance:
         pid = self.get_process_pid("clickhouse")
         if pid is not None:
             self.exec_in_container(
-                ["bash", "-c", f"gdb -batch -ex 'thread apply all bt full' -p {pid}"],
+                ["bash", "-c", f"gdb -batch -ex 'thread apply all bt' -p {pid}"],
                 user="root",
             )
         if last_err is not None:
@@ -4836,7 +4836,7 @@ class ClickHouseInstance:
         pid = self.get_process_pid("clickhouse")
         if pid is not None:
             self.exec_in_container(
-                ["bash", "-c", f"gdb -batch -ex 'thread apply all bt full' -p {pid}"],
+                ["bash", "-c", f"gdb -batch -ex 'thread apply all bt' -p {pid}"],
                 user="root",
             )
         raise Exception(

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -4688,9 +4688,9 @@ class ClickHouseInstance:
             )
         try:
             ps_clickhouse = self.exec_in_container(
-                ["bash", "-c", "ps -C clickhouse"], nothrow=True, user="root"
+                ["bash", "-c", "ps --no-header -C clickhouse"], nothrow=True, user="root"
             )
-            if ps_clickhouse == "  PID TTY      STAT   TIME COMMAND":
+            if not ps_clickhouse:
                 logging.warning("ClickHouse process already stopped")
                 return
 


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Details

There are reports when test_s3_plain_rewritable hungs, interesting logs there are:

    [2025-11-21 14:32:04] 2025-11-21 13:51:09.171000 [ 503 ] WARNING : Force kill clickhouse in stop_clickhouse. ps:10 (cluster.py:4868, stop_clickhouse)
    [2025-11-21 14:32:04] 2025-11-21 13:56:09.526000 [ 503 ] WARNING : Stop ClickHouse raised an error Command '[&#39;docker&#39;, &#39;exec&#39;, &#39;-u&#39;, &#39;root&#39;, &#39;roottests3plainrewritable-gw3-node1-1&#39;, &#39;bash&#39;, &#39;-c&#39;, &#34;gdb -batch -ex &#39;thread apply all bt full&#39; -p 9 &gt; /var/log/clickhouse-server/stdout.log&#34;]&#39; timed out after 300 seconds (cluster.py:4889, stop_clickhouse)

But, at the same time on the server:

   2025.11.21 13:50:10.910910 [ 15 ] {}  BaseDaemon: Received signal -2
   2025.11.21 13:50:10.910942 [ 15 ] {}  BaseDaemon: Stop SignalListener thread

And gdb log:

    Thread 1 (process 9 &#34;clickhouse&#34;)
    [Inferior 1 (process 9) detached]

So apparently it hunged somewhere in destructors.

Though this is very unlikely that gdb cannot collect stacktrace in 5 minutes, although when I tried I found that full bt can take 4+ minutes, but AFAIR it was printing at least something in the file (i.e. first few frames).
