### PR TITLE
Fix logical error in `concatWithSeparator` function when using const non-string column

### DIFF
--- a/tests/queries/0_stateless/03727_concat_with_separator_subquery.reference
+++ b/tests/queries/0_stateless/03727_concat_with_separator_subquery.reference
@@ -1,0 +1,76 @@
+-- { echoOn}
+
+SELECT concatWithSeparator(c0, 'b', 1) FROM (SELECT 'a' c0) tx;
+ba1
+SELECT concatWithSeparator(c0, 1) FROM (SELECT 'a' AS c0) tx;
+1
+SELECT concatWithSeparator(c0, 'b', 1) FROM (SELECT CAST(NULL AS Nullable(String)) AS c0) tx;
+\N
+SELECT concatWithSeparator('a', c1, 'b') FROM (SELECT 1 AS c1) tx;
+1ab
+SELECT concatWithSeparator('a', c1, 'b') FROM (SELECT CAST(1 AS Nullable(UInt8)) AS c1) tx;
+1ab
+SELECT concatWithSeparator('+-*/', c0, c1, c2) FROM (SELECT 'a' AS c0) t0 CROSS JOIN (SELECT 'b' AS c1) t1 CROSS JOIN (SELECT 1 AS c2) t2;
+a+-*/b+-*/1
+SELECT concatWithSeparator(c0, c1, c2)
+FROM
+(
+    SELECT
+        'a' AS c0,
+        toString(number) AS c1,
+        number + 9 AS c2
+    FROM numbers(5)
+);
+0a9
+1a10
+2a11
+3a12
+4a13
+SELECT concatWithSeparator('-', [1, 2, 3], [4, 5, 6]) FROM numbers(3);
+[1,2,3]-[4,5,6]
+[1,2,3]-[4,5,6]
+[1,2,3]-[4,5,6]
+SELECT concatWithSeparator('-', (1, 'a'), (2, 'b')) FROM numbers(3);
+(1,\'a\')-(2,\'b\')
+(1,\'a\')-(2,\'b\')
+(1,\'a\')-(2,\'b\')
+SELECT concatWithSeparator(c0, c1, c2)
+FROM
+(
+    SELECT
+        '+' AS c0,
+        (toString(number), number + 1) AS c1,
+        [number + 9, number + 3, number + 2] AS c2
+    FROM numbers(5)
+);
+(\'0\',1)+[9,3,2]
+(\'1\',2)+[10,4,3]
+(\'2\',3)+[11,5,4]
+(\'3\',4)+[12,6,5]
+(\'4\',5)+[13,7,6]
+SELECT concatWithSeparator('+', c1, c2)
+FROM
+(
+    SELECT
+        (toString(number), number + 1) AS c1,
+        [number + 9, number + 3, number + 2] AS c2
+    FROM numbers(5)
+);
+(\'0\',1)+[9,3,2]
+(\'1\',2)+[10,4,3]
+(\'2\',3)+[11,5,4]
+(\'3\',4)+[12,6,5]
+(\'4\',5)+[13,7,6]
+SELECT concatWithSeparator('+', c1, c2, 'zz')
+FROM
+(
+    SELECT
+        (toString(number), number + 1) AS c1,
+        [number + 9, number + 3, number + 2] AS c2
+    FROM numbers(5)
+);
+(\'0\',1)+[9,3,2]+zz
+(\'1\',2)+[10,4,3]+zz
+(\'2\',3)+[11,5,4]+zz
+(\'3\',4)+[12,6,5]+zz
+(\'4\',5)+[13,7,6]+zz

--- a/tests/queries/0_stateless/03727_concat_with_separator_subquery.sql
+++ b/tests/queries/0_stateless/03727_concat_with_separator_subquery.sql
@@ -1,0 +1,56 @@
+-- { echoOn}
+
+SELECT concatWithSeparator(c0, 'b', 1) FROM (SELECT 'a' c0) tx;
+
+SELECT concatWithSeparator(c0, 1) FROM (SELECT 'a' AS c0) tx;
+
+SELECT concatWithSeparator(c0, 'b', 1) FROM (SELECT CAST(NULL AS Nullable(String)) AS c0) tx;
+
+SELECT concatWithSeparator('a', c1, 'b') FROM (SELECT 1 AS c1) tx;
+
+SELECT concatWithSeparator('a', c1, 'b') FROM (SELECT CAST(1 AS Nullable(UInt8)) AS c1) tx;
+
+SELECT concatWithSeparator('+-*/', c0, c1, c2) FROM (SELECT 'a' AS c0) t0 CROSS JOIN (SELECT 'b' AS c1) t1 CROSS JOIN (SELECT 1 AS c2) t2;
+
+SELECT concatWithSeparator(c0, c1, c2)
+FROM
+(
+    SELECT
+        'a' AS c0,
+        toString(number) AS c1,
+        number + 9 AS c2
+    FROM numbers(5)
+);
+
+SELECT concatWithSeparator('-', [1, 2, 3], [4, 5, 6]) FROM numbers(3);
+
+SELECT concatWithSeparator('-', (1, 'a'), (2, 'b')) FROM numbers(3);
+
+SELECT concatWithSeparator(c0, c1, c2)
+FROM
+(
+    SELECT
+        '+' AS c0,
+        (toString(number), number + 1) AS c1,
+        [number + 9, number + 3, number + 2] AS c2
+    FROM numbers(5)
+);
+
+SELECT concatWithSeparator('+', c1, c2)
+FROM
+(
+    SELECT
+        (toString(number), number + 1) AS c1,
+        [number + 9, number + 3, number + 2] AS c2
+    FROM numbers(5)
+);
+
+
+SELECT concatWithSeparator('+', c1, c2, 'zz')
+FROM
+(
+    SELECT
+        (toString(number), number + 1) AS c1,
+        [number + 9, number + 3, number + 2] AS c2
+    FROM numbers(5)
+);


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix logical error in `concatWithSeparator` function when using const non-string column. Closes https://github.com/ClickHouse/ClickHouse/issues/90596.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

### Details

The following query has assertion failure in debug build:

```sql
SELECT concatWithSeparator(c0, 'b', 1) FROM (SELECT 'a' c0) tx;
```

Resolves #90596
