### PR TITLE
Fix potential crash when executing mutations with subqueries and allow_statistics_optimize=1

### DIFF
--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -813,10 +813,12 @@ InterpreterSelectQuery::InterpreterSelectQuery(
                 Names queried_columns = syntax_analyzer_result->requiredSourceColumns();
                 const auto & supported_prewhere_columns = storage->supportedPrewhereColumns();
 
+                const auto parts = assert_cast<const MergeTreeData::SnapshotData &>(*storage_snapshot->data).parts;
+
                 MergeTreeWhereOptimizer where_optimizer{
                     std::move(column_compressed_sizes),
                     storage_snapshot,
-                    storage->getConditionSelectivityEstimator(*assert_cast<const MergeTreeData::SnapshotData &>(*storage_snapshot->data).parts, context),
+                    storage->getConditionSelectivityEstimator(parts ? *parts : RangesInDataParts{}, context),
                     queried_columns,
                     supported_prewhere_columns,
                     log};

--- a/tests/queries/0_stateless/03731_null_parts_in_storage_snapshot_with_only_analyze.sql
+++ b/tests/queries/0_stateless/03731_null_parts_in_storage_snapshot_with_only_analyze.sql
@@ -1,0 +1,14 @@
+-- Possible crash in case of mutations contains subquery, that will use
+-- InterpreterSelectQuery() with only_analyze=true, which uses
+-- getStorageSnapshotWithoutData(), and may crash in
+-- getConditionSelectivityEstimator() since parts was nullptr
+
+drop table if exists t0;
+drop table if exists t1;
+
+create table t0 (key Int) engine=MergeTree order by () settings auto_statistics_types='';
+create table t1 (key Int) engine=MergeTree order by () settings auto_statistics_types='';
+insert into t0 values (1);
+insert into t1 values (1);
+
+alter table t1 update key = 0 where 1 or not(not exists (select key from t0 where key > 0)) settings mutations_sync=2, allow_experimental_analyzer=0, query_plan_optimize_prewhere=0, query_plan_enable_optimizations=0, allow_statistics_optimize=1;


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix potential crash when executing mutations with subqueries and `allow_statistics_optimize=1`. Resolves #90626

### Details
The problem was that with subqueries in mutations it is possible to call InterpreterSelectQuery with only_analyze=1, which creates snapshot with getStorageSnapshotWithoutData() that does not have "parts" set, while those are required for getConditionSelectivityEstimator().

Fixes: #90626
Fixes: #85535
