### PR TITLE
Enable commit status on workflow failure for scheduled workflows

### DIFF
--- a/ci/workflows/hourly.py
+++ b/ci/workflows/hourly.py
@@ -20,6 +20,7 @@ workflow = Workflow.Config(
     secrets=SECRETS,
     enable_report=True,
     enable_cidb=False,
+    enable_commit_status_on_failure=True,
     cron_schedules=["0 */3 * * 1-5"],
 )
 

--- a/ci/workflows/nightly_fuzzers.py
+++ b/ci/workflows/nightly_fuzzers.py
@@ -29,6 +29,7 @@ workflow = Workflow.Config(
     enable_cache=True,
     enable_report=True,
     enable_cidb=True,
+    enable_commit_status_on_failure=True,
     cron_schedules=["13 3 * * *"],
 )
 

--- a/ci/workflows/nightly_jepsen.py
+++ b/ci/workflows/nightly_jepsen.py
@@ -40,6 +40,7 @@ workflow = Workflow.Config(
     enable_cache=True,
     enable_report=True,
     enable_cidb=True,
+    enable_commit_status_on_failure=True,
     cron_schedules=["13 4 * * *"],
     pre_hooks=["python3 ./ci/jobs/scripts/workflow_hooks/store_data.py"],
 )

--- a/ci/workflows/nightly_statistics.py
+++ b/ci/workflows/nightly_statistics.py
@@ -20,6 +20,7 @@ workflow = Workflow.Config(
     secrets=SECRETS,
     enable_report=True,
     enable_cidb=False,
+    enable_commit_status_on_failure=True,
     cron_schedules=["13 5 * * *"],
 )
 


### PR DESCRIPTION
Add enable_commit_status_on_failure=True to scheduled workflows to enable alerts when they fail. This addresses the TODO comments in:
- ci/workflows/hourly.py
- ci/workflows/nightly_fuzzers.py
- ci/workflows/nightly_jepsen.py
- ci/workflows/nightly_statistics.py

This brings these workflows in line with other workflows like master.py and release_branches.py that already have this feature enabled.

<!--- Disable AI PR formatting assistant: false -->

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Not applicable - CI infrastructure change only.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

Not applicable - this is an internal CI workflow configuration change with no user-facing impact.