### PR TITLE
Fix bad exception message in Hive partitioning

### DIFF
--- a/src/Storages/HivePartitioningUtils.cpp
+++ b/src/Storages/HivePartitioningUtils.cpp
@@ -123,8 +123,8 @@ void addPartitionColumnsToChunk(
         {
             throw Exception(
                 ErrorCodes::INCORRECT_DATA,
-                "Expected to find hive partitioning column {} in the path {}."
-                "Try it with hive partitioning disabled (partition_strategy='wildcard' and/or use_hive_partitioning=0",
+                "Expected to find hive partitioning column {} in the path {}. "
+                "Try it with hive partitioning disabled (partition_strategy = 'wildcard' and/or use_hive_partitioning = 0",
                 column_name,
                 path);
         }


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix bad exception message in Hive partitioning: it was missing a space.