### PR TITLE
Tests: flush trace log for unchecked memory query

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -3762,6 +3762,8 @@ def main(args):
     else:
         print("All tests have finished.")
 
+    clickhouse_execute(args, "SYSTEM FLUSH LOGS trace_log")
+
     unchecked_memory = int(clickhouse_execute(args, f"""
     SELECT sum(size) FROM system.trace_log
     WHERE


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Details
Unless `prepare_system_log_tables_on_startup` is set, system.trace_log won't be created on MacOS even being configured due to disabled TraceCollector which writes to its log queue ([flag](https://github.com/ClickHouse/ClickHouse/blob/b108085beedb0cd6804ec31122f71519f3f5cb8f/programs/server/Server.cpp#L1263) + [PHDRCache](https://github.com/ClickHouse/ClickHouse/blob/b108085beedb0cd6804ec31122f71519f3f5cb8f/base/base/phdr_cache.cpp#L7) which is not implemented for MacOS).

Explicitly flushing trace_log to create this table will help with running selective tests locally (which don't run flush logs for all system log tables)
