### PR TITLE
Docs: correct order of parameters for `JSONExtract`, `JSONExtractKeysAndValues `

### DIFF
--- a/src/Functions/FunctionsJSON.cpp
+++ b/src/Functions/FunctionsJSON.cpp
@@ -1416,11 +1416,11 @@ SELECT JSONExtractString('{"a": "hello", "b": [-100, 200.0, 300]}', 'a') AS res;
         FunctionDocumentation::Description description = R"(
 Parses JSON and extracts a value with given ClickHouse data type.
         )";
-        FunctionDocumentation::Syntax syntax = "JSONExtract(json, return_type[, indices_or_keys, ...])";
+        FunctionDocumentation::Syntax syntax = "JSONExtract(json[, indices_or_keys, ...], return_type)";
         FunctionDocumentation::Arguments arguments = {
             {"json", "JSON string to parse.", {"String"}},
-            {"return_type", "ClickHouse data type to return.", {"String"}},
-            {"indices_or_keys", "A list of zero or more arguments each of which can be either string or integer.", {"String", "(U)Int*"}}
+            {"indices_or_keys", "A list of zero or more arguments each of which can be either string or integer.", {"String", "(U)Int*"}},
+            {"return_type", "ClickHouse data type to return.", {"String"}}
         };
         FunctionDocumentation::ReturnedValue returned_value = {"Returns a value of specified ClickHouse data type if possible, otherwise returns the default value for that type.", {}};
         FunctionDocumentation::Examples examples = {
@@ -1447,11 +1447,11 @@ SELECT JSONExtract('{"a": "hello", "b": [-100, 200.0, 300]}', 'Tuple(String, Arr
         FunctionDocumentation::Description description = R"(
 Parses key-value pairs from a JSON where the values are of the given ClickHouse data type.
         )";
-        FunctionDocumentation::Syntax syntax = "JSONExtractKeysAndValues(json, value_type[, indices_or_keys, ...])";
+        FunctionDocumentation::Syntax syntax = "JSONExtractKeysAndValues(json[, indices_or_keys, ...], value_type)";
         FunctionDocumentation::Arguments arguments = {
             {"json", "JSON string to parse.", {"String"}},
-            {"value_type", "ClickHouse data type of the values.", {"String"}},
-            {"indices_or_keys", "A list of zero or more arguments each of which can be either string or integer.", {"String", "(U)Int*"}}
+            {"indices_or_keys", "A list of zero or more arguments each of which can be either string or integer.", {"String", "(U)Int*"}},
+            {"value_type", "ClickHouse data type of the values.", {"String"}}
         };
         FunctionDocumentation::ReturnedValue returned_value = {"Returns an array of tuples with the parsed key-value pairs.", {"Array(Tuple(String, value_type))"}};
         FunctionDocumentation::Examples examples = {


### PR DESCRIPTION
Corrects the order of parameters in the docs for `JSONExtract`, `JSONExtractKeysAndValues` which got reversed unintentionally.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
