### PR TITLE
Revert "Enable `enable_time_time64_type` by default"

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -1106,9 +1106,9 @@ When enabled, allows to use legacy toTime function, which converts a date with t
 Otherwise, uses a new toTime function, that converts different type of data into the Time type.
 The old legacy function is also unconditionally accessible as toTimeWithFixedDate.
 )", 0) \
-    DECLARE_WITH_ALIAS(Bool, enable_time_time64_type, true, R"(
+    DECLARE_WITH_ALIAS(Bool, allow_experimental_time_time64_type, false, R"(
 Allows creation of [Time](../../sql-reference/data-types/time.md) and [Time64](../../sql-reference/data-types/time64.md) data types.
-)", 0, allow_experimental_time_time64_type) \
+)", EXPERIMENTAL, enable_time_time64_type) \
     DECLARE(Bool, function_locate_has_mysql_compatible_argument_order, true, R"(
 Controls the order of arguments in function [locate](../../sql-reference/functions/string-search-functions.md/#locate).
 

--- a/src/Interpreters/parseColumnsListForTableFunction.cpp
+++ b/src/Interpreters/parseColumnsListForTableFunction.cpp
@@ -16,7 +16,7 @@ namespace DB
 {
 namespace Setting
 {
-    extern const SettingsBool enable_time_time64_type;
+    extern const SettingsBool allow_experimental_time_time64_type;
     extern const SettingsBool allow_experimental_qbit_type;
     extern const SettingsBool allow_suspicious_fixed_string_types;
     extern const SettingsBool allow_suspicious_low_cardinality_types;
@@ -40,7 +40,7 @@ DataTypeValidationSettings::DataTypeValidationSettings(const DB::Settings & sett
     , allow_suspicious_fixed_string_types(settings[Setting::allow_suspicious_fixed_string_types])
     , allow_suspicious_variant_types(settings[Setting::allow_suspicious_variant_types])
     , validate_nested_types(settings[Setting::validate_experimental_and_suspicious_types_inside_nested_types])
-    , enable_time_time64_type(settings[Setting::enable_time_time64_type])
+    , enable_time_time64_type(settings[Setting::allow_experimental_time_time64_type])
     , allow_experimental_qbit_type(settings[Setting::allow_experimental_qbit_type])
 {
 }


### PR DESCRIPTION
Reverts ClickHouse/ClickHouse#89345

https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=8999e2e112c90042b53b053a5c60935f847492c2&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_debug%2C%20AsyncInsert%2C%20s3%20storage%2C%20parallel%29&name_1=Stateless%20tests%20%28amd_debug%2C%20AsyncInsert%2C%20s3%20storage%2C%20parallel%29


https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=44354b2159efee896f5981f178d082891b75523f&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_binary%2C%20old%20analyzer%2C%20s3%20storage%2C%20DatabaseReplicated%2C%20parallel%29&name_1=Stateless%20tests%20%28amd_binary%2C%20old%20analyzer%2C%20s3%20storage%2C%20DatabaseReplicated%2C%20parallel%29

And many more failures. cc @alexey-milovidov 