### PR TITLE
ci: wait for sanitizers reports in integration tests

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -4710,6 +4710,10 @@ class ClickHouseInstance:
                     time.sleep(1)
 
             if not stopped:
+                # Some sanitizer report in progress?
+                while self.get_process_pid("llvm-symbolizer") is not None:
+                    time.sleep(1)
+
                 pid = self.get_process_pid("clickhouse")
                 if pid is not None:
                     logging.warning(


### PR DESCRIPTION
Sanitizers uses llvm-symbolizer to symbolize stacktraces, but it can be quite time consuming, and anyway during this, gdb will fail to collect stacktraces [1], so let's wait for it.

  [1]: https://pastila.nl/?0003fd8f/57b5504d1b4d0e8a3a9c0b5abec08c98#+aGQ1X1fU/e9uj52P3nIEw==

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
