### PR TITLE
Fix segfault on query with EXISTS function in join on section

### DIFF
--- a/src/Planner/PlannerJoins.cpp
+++ b/src/Planner/PlannerJoins.cpp
@@ -274,7 +274,15 @@ void buildJoinClauseImpl(
     std::string function_name;
     auto * function_node = join_expression->as<FunctionNode>();
     if (function_node)
-        function_name = function_node->getFunction()->getName();
+    {
+        function_name = function_node->getFunctionName();
+        if (!function_node->isOrdinaryFunction())
+        {
+            throw Exception(ErrorCodes::INVALID_JOIN_ON_EXPRESSION,
+                "Unexpected function '{}' in JOIN ON section, only ordinary functions are supported, in expression: {}",
+                function_name, function_node->formatASTForErrorMessage());
+        }
+    }
 
     auto asof_inequality = getASOFJoinInequality(function_name);
     bool is_asof_join_inequality = join_node.getStrictness() == JoinStrictness::Asof && asof_inequality != ASOFJoinInequality::None;
@@ -470,7 +478,15 @@ void buildJoinClause(
     std::string function_name;
     auto * function_node = join_expression->as<FunctionNode>();
     if (function_node)
-        function_name = function_node->getFunction()->getName();
+    {
+        function_name = function_node->getFunctionName();
+        if (!function_node->isOrdinaryFunction())
+        {
+            throw Exception(ErrorCodes::INVALID_JOIN_ON_EXPRESSION,
+                "Unexpected function '{}' in JOIN ON section, only ordinary functions are supported, in expression: {}",
+                function_name, function_node->formatASTForErrorMessage());
+        }
+    }
 
     /// For 'and' function go into children
     if (function_name == "and")
@@ -679,7 +695,7 @@ std::pair<JoinClauses, bool /*is_inequal_join*/> buildAllJoinClauses(
 
     bool has_residual_filters = false;
     JoinClauses join_clauses;
-    const auto & function_name = function_node.getFunction()->getName();
+    const auto & function_name = function_node.getFunctionName();
     if (function_name == "or")
     {
         for (const auto & child : function_node.getArguments())

--- a/src/Planner/PlannerJoinsLogical.cpp
+++ b/src/Planner/PlannerJoinsLogical.cpp
@@ -258,7 +258,15 @@ void buildJoinCondition(const QueryTreeNodePtr & node, JoinOperatorBuildContext 
     std::string function_name;
     const auto * function_node = node->as<FunctionNode>();
     if (function_node)
-        function_name = function_node->getFunction()->getName();
+    {
+        function_name = function_node->getFunctionName();
+        if (!function_node->isOrdinaryFunction())
+        {
+            throw Exception(ErrorCodes::INVALID_JOIN_ON_EXPRESSION,
+                "Unexpected function '{}' in JOIN ON section, only ordinary functions are supported, in expression: {}",
+                function_name, function_node->formatASTForErrorMessage());
+        }
+    }
 
     if (function_name == "and")
     {
@@ -278,7 +286,7 @@ void buildDisjunctiveJoinConditions(const QueryTreeNodePtr & node, JoinOperatorB
             "JOIN {} join expression expected function",
             node->formatASTForErrorMessage());
 
-    const auto & function_name = function_node->getFunction()->getName();
+    const auto & function_name = function_node->getFunctionName();
 
     if (function_name == "or")
     {

--- a/tests/queries/0_stateless/03732_join_on_exists_bug.sql
+++ b/tests/queries/0_stateless/03732_join_on_exists_bug.sql
@@ -1,0 +1,13 @@
+DROP TABLE IF EXISTS t0;
+
+CREATE TABLE t0 (c0 Int) ENGINE = Memory;
+INSERT INTO t0 VALUES (1), (2), (3);
+
+SELECT 1 FROM t0 ASOF JOIN t0 tx ON EXISTS (SELECT 1) JOIN t0 ty ON t0.c0 = ty.c0
+; -- { serverError INVALID_JOIN_ON_EXPRESSION }
+
+SELECT 1 FROM t0 ASOF JOIN t0 tx ON EXISTS (SELECT 1) JOIN t0 ty ON t0.c0 = ty.c0
+SETTINGS allow_general_join_planning = 0; -- { serverError INVALID_JOIN_ON_EXPRESSION }
+
+SELECT 1 FROM t0 ASOF JOIN t0 tx ON EXISTS (SELECT 1) JOIN t0 ty ON t0.c0 = ty.c0
+SETTINGS query_plan_use_new_logical_join_step = 0; -- { serverError INVALID_JOIN_ON_EXPRESSION }


### PR DESCRIPTION
### Changelog category (leave one):

- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

- Fix segfault on query with EXISTS function in join on section. Now query simply returns `INVALID_JOIN_ON_EXPRESSION` error. Close https://github.com/ClickHouse/ClickHouse/issues/90698 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
