### PR TITLE
Disable some e2k-Clang-specific warnings

### DIFF
--- a/cmake/warnings.cmake
+++ b/cmake/warnings.cmake
@@ -45,3 +45,9 @@ no_warning(unsafe-buffer-usage) # too aggressive
 no_warning(switch-default) # conflicts with "defaults in a switch covering all enum values"
 no_warning(nrvo) # not eliding copy on return - too aggressive
 no_warning(missing-noreturn) # too aggressive with no clear benefit, see https://github.com/ClickHouse/ClickHouse/pull/86416
+if (ARCH_E2K)
+    # disable "__builtin_ia32_pcmpestric128 / __builtin_ia32_pcmpestri128 is deprecated: The function may be slow due to inefficient implementation" warning
+    no_warning(deprecated-declarations)
+    # disable "use of GNU statement expression extension from macro expansion" warning
+    no_warning(gnu-statement-expression-from-macro-expansion)
+endif ()


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Disable "**__builtin_ia32_pcmpestric128 / __builtin_ia32_pcmpestri128 is deprecated: The function may be slow due to inefficient implementation**" and "**use of GNU statement expression extension from macro expansion**" warnings on e2k-Clang (too aggressive).