### PR TITLE
Fix Logical error: 'Inconsistent AST formatting' for AccessRightsElement

### DIFF
--- a/src/Access/Common/AccessRightsElement.cpp
+++ b/src/Access/Common/AccessRightsElement.cpp
@@ -204,7 +204,7 @@ void AccessRightsElement::formatONClause(WriteBuffer & buffer) const
         if (columns.empty() && wildcard)
             buffer << "*";
     }
-    else
+    else if (!database.empty())
     {
         buffer << backQuoteIfNeed(database);
 
@@ -213,6 +213,8 @@ void AccessRightsElement::formatONClause(WriteBuffer & buffer) const
 
         buffer << ".*";
     }
+    else
+        buffer << "*";
 }
 
 

--- a/src/Access/Common/AccessRightsElement.cpp
+++ b/src/Access/Common/AccessRightsElement.cpp
@@ -214,7 +214,9 @@ void AccessRightsElement::formatONClause(WriteBuffer & buffer) const
         buffer << ".*";
     }
     else
+    {
         buffer << "*";
+    }
 }
 
 

--- a/tests/queries/0_stateless/03732_format_grant_select.sh
+++ b/tests/queries/0_stateless/03732_format_grant_select.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+readonly test_user=test_user_03732_${CLICKHOUSE_DATABASE}
+
+$CLICKHOUSE_CLIENT -q "
+    DROP USER IF EXISTS $user;
+    CREATE USER $user;
+    GRANT SELECT ON * to $test_user;
+"
+USER

--- a/tests/queries/0_stateless/03732_format_grant_select.sh
+++ b/tests/queries/0_stateless/03732_format_grant_select.sh
@@ -10,4 +10,6 @@ $CLICKHOUSE_CLIENT -q "
     DROP USER IF EXISTS $test_user;
     CREATE USER $test_user;
     GRANT SELECT ON * to $test_user;
+    DROP USER IF EXISTS $test_user;
 "
+

--- a/tests/queries/0_stateless/03732_format_grant_select.sh
+++ b/tests/queries/0_stateless/03732_format_grant_select.sh
@@ -7,8 +7,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 readonly test_user=test_user_03732_${CLICKHOUSE_DATABASE}
 
 $CLICKHOUSE_CLIENT -q "
-    DROP USER IF EXISTS $user;
-    CREATE USER $user;
+    DROP USER IF EXISTS $test_user;
+    CREATE USER $test_user;
     GRANT SELECT ON * to $test_user;
 "
-USER

--- a/tests/queries/0_stateless/03732_format_grant_select.sql
+++ b/tests/queries/0_stateless/03732_format_grant_select.sql
@@ -1,4 +1,0 @@
-DROP USER IF EXISTS test_user_03732;
-CREATE USER test_user_03732;
-
-GRANT SELECT ON * to test_user_03732;

--- a/tests/queries/0_stateless/03732_format_grant_select.sql
+++ b/tests/queries/0_stateless/03732_format_grant_select.sql
@@ -1,0 +1,4 @@
+DROP USER IF EXISTS test_user_03732;
+CREATE USER test_user_03732;
+
+GRANT SELECT ON * to test_user_03732;


### PR DESCRIPTION
Fix Logical error: 'Inconsistent AST formatting' for AccessRightsElement when using the default database without any table
From test_named_collections integration test:

```
Logical error: 'Inconsistent AST formatting: the query:
GRANT SELECT ON ``.* TO koko
cannot parse query back from GRANT select ON * TO koko'.
```

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix Logical error: 'Inconsistent AST formatting' for AccessRightsElement when using the default database without any table

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
