### PR TITLE
Add `column_structure` option to explain query

### DIFF
--- a/docs/en/sql-reference/statements/explain.md
+++ b/docs/en/sql-reference/statements/explain.md
@@ -184,6 +184,7 @@ Settings:
 - `actions` — Prints detailed information about step actions. Default: 0.
 - `json` — Prints query plan steps as a row in [JSON](/interfaces/formats/JSON) format. Default: 0. It is recommended to use [TabSeparatedRaw (TSVRaw)](/interfaces/formats/TabSeparatedRaw) format to avoid unnecessary escaping.
 - `input_headers` - Prints input headers for step. Default: 0. Mostly useful only for developers to debug issues related to input-output header mismatch.
+- `column_structure` - Prints also the structure of columns in headers on top of their name and type. Default: 0. Mostly useful only for developers to debug issues related to input-output header mismatch.
 
 When `json=1` step names will contain an additional suffix with unique step identifier.
 

--- a/src/Interpreters/InterpreterExplainQuery.cpp
+++ b/src/Interpreters/InterpreterExplainQuery.cpp
@@ -269,6 +269,7 @@ struct QueryPlanSettings
             {"distributed", query_plan_options.distributed},
             {"keep_logical_steps", keep_logical_steps},
             {"input_headers", query_plan_options.input_headers},
+            {"column_structure", query_plan_options.column_structure},
     };
 
     std::unordered_map<std::string, std::reference_wrapper<Int64>> integer_settings;

--- a/src/Processors/QueryPlan/Optimizations/optimizeTree.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeTree.cpp
@@ -123,7 +123,7 @@ void optimizeTreeFirstPass(const QueryPlanOptimizationSettings & optimization_se
             if (update_depth)
             {
 #if defined(DEBUG_OR_SANITIZER_BUILD)
-                checkHeaders(*frame.node, String("after optimization") + optimization.name, update_depth);
+                checkHeaders(*frame.node, String("after optimization ") + optimization.name, update_depth);
 #endif
                 ++total_applied_optimizations;
             }

--- a/src/Processors/QueryPlan/QueryPlan.cpp
+++ b/src/Processors/QueryPlan/QueryPlan.cpp
@@ -41,6 +41,8 @@ SettingsChanges ExplainPlanOptions::toSettingsChanges() const
     changes.emplace_back("projections", int(projections));
     changes.emplace_back("sorting", int(sorting));
     changes.emplace_back("distributed", int(distributed));
+    changes.emplace_back("input_headers", int(input_headers));
+    changes.emplace_back("column_structure", int(column_structure));
 
     return changes;
 }
@@ -358,9 +360,13 @@ static void explainStep(
 
     settings.out.write('\n');
 
-    const auto dump_column = [&out = settings.out](const ColumnWithTypeAndName & column)
+    const auto dump_column = [&out = settings.out, dump_structure = options.column_structure](const ColumnWithTypeAndName & column)
     {
-        column.dumpNameAndType(out);
+        if (dump_structure)
+            column.dumpStructure(out);
+        else
+            column.dumpNameAndType(out);
+
         if (column.column && isColumnLazy(*column.column.get()))
             out << " (Lazy)";
     };

--- a/src/Processors/QueryPlan/QueryPlan.h
+++ b/src/Processors/QueryPlan/QueryPlan.h
@@ -62,6 +62,8 @@ struct ExplainPlanOptions
     bool distributed = false;
     /// Add input headers to step.
     bool input_headers = false;
+    /// Print structure of columns instead of just their names and types.
+    bool column_structure = false;
 
     SettingsChanges toSettingsChanges() const;
 };

--- a/tests/queries/0_stateless/03728_explain_column_structure.reference
+++ b/tests/queries/0_stateless/03728_explain_column_structure.reference
@@ -1,0 +1,12 @@
+Header: 1 UInt8
+Input headers: #0
+               dummy UInt8
+  ReadFromStorage (SystemOne)
+  Header: dummy UInt8
+  Input headers: No input headers
+Header: 1 UInt8 Const(size = 0, UInt8(size = 1))
+Input headers: #0
+               dummy UInt8 UInt8(size = 0)
+  ReadFromStorage (SystemOne)
+  Header: dummy UInt8 UInt8(size = 0)
+  Input headers: No input headers

--- a/tests/queries/0_stateless/03728_explain_column_structure.sql
+++ b/tests/queries/0_stateless/03728_explain_column_structure.sql
@@ -1,0 +1,2 @@
+SELECT * FROM (EXPLAIN PLAN header = 1, input_headers = 1 SELECT 1) WHERE explain NOT LIKE 'Expression%';
+SELECT * FROM (EXPLAIN PLAN header = 1, input_headers = 1, column_structure = 1 SELECT 1) WHERE explain NOT LIKE 'Expression%';


### PR DESCRIPTION
I think the option is only relevant for developers, thus I don't think it requires a changelog entry.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
