### PR TITLE
Disable enable_shared_storage_snapshot_in_query (leads to memory leaks)

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -5123,7 +5123,7 @@ Possible values:
 - 0 - Disabled
 - 1 - Enabled
 )", 0) \
-    DECLARE(Bool, enable_shared_storage_snapshot_in_query, true, R"(
+    DECLARE(Bool, enable_shared_storage_snapshot_in_query, false, R"(
 If enabled, all subqueries within a single query will share the same StorageSnapshot for each table.
 This ensures a consistent view of the data across the entire query, even if the same table is accessed multiple times.
 

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -60,7 +60,6 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"into_outfile_create_parent_directories", false, false, "New setting"},
             {"correlated_subqueries_default_join_kind", "left", "right", "New setting. Default join kind for decorrelated query plan."},
             {"use_statistics_cache", 0, 0, "New setting"},
-            {"enable_shared_storage_snapshot_in_query", false, true, "Better consistency guarantees."},
             {"input_format_parquet_use_native_reader_v3", false, true, "Seems stable"},
             {"max_projection_rows_to_use_projection_index", 1'000'000, 1'000'000, "New setting"},
             {"min_table_rows_to_use_projection_index", 1'000'000, 1'000'000, "New setting"},

--- a/tests/queries/0_stateless/02995_settings_25_11_1.tsv
+++ b/tests/queries/0_stateless/02995_settings_25_11_1.tsv
@@ -391,7 +391,7 @@ enable_reads_from_query_cache	1
 enable_s3_requests_logging	0
 enable_scalar_subquery_optimization	1
 enable_scopes_for_with_statement	1
-enable_shared_storage_snapshot_in_query	1
+enable_shared_storage_snapshot_in_query	0
 enable_sharing_sets_for_mutations	1
 enable_software_prefetch_in_aggregation	1
 enable_time_time64_type	0


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Disable `enable_shared_storage_snapshot_in_query` (leads to memory leaks)

Some functions stores a copy of `ContextPtr` (not a `weak_ptr` as it should be, but `shared_ptr`), i.e. [`modulo`](https://github.com/ClickHouse/ClickHouse/blob/407e33a47cf707155d1c4f3f12d2bb2291c80009/src/Functions/FunctionBinaryArithmetic.h#L827), but this `IFunction` itself can be stored in `KeyDescription`, which is part of `StorageInMemoryMetadata`.

And with metadata cache (`enable_shared_storage_snapshot_in_query=1`) this will create memory leaks (since this `Context` will never be destroyed)

As @Michicosun has been told, this cache should never be part of `Context` (but we abuse it often).

(Another issue is `IFunction` holds a `ContextPtr` not a `ContextWeakPtr`, but this is another story)

Anyway, let's disable it for now (backported to 25.11 is a must).

<details>

<summary>Repro</summary>

```sql
drop table if exists test;
create table test (id Int, key String) engine=MergeTree order by id % 10;
insert into test select number, number::String from numbers(3);
alter table test modify comment 'new description';
-- to gracefully terminate the server
quit
```

And terminate the server - it will trigger same ASan report

</details>

Reverts: https://github.com/ClickHouse/ClickHouse/pull/82634
Refs: https://github.com/ClickHouse/ClickHouse/pull/79471 (cc @amosbird )