### PR TITLE
Don't build qatlib with `-march=native` as it breaks during crosscompilation

### DIFF
--- a/contrib/qatlib-cmake/CMakeLists.txt
+++ b/contrib/qatlib-cmake/CMakeLists.txt
@@ -190,7 +190,6 @@ target_include_directories(_qatlib PRIVATE
 target_link_libraries(_qatlib PRIVATE _qatmgr _osal OpenSSL::SSL ch_contrib::isal)
 target_compile_definitions(_qatlib PRIVATE -DUSER_SPACE -DLAC_BYTE_ORDER=__LITTLE_ENDIAN -DOSAL_ENSURE_ON)
 target_link_options(_qatlib PRIVATE -pie -z relro -z now -z noexecstack)
-target_compile_options(_qatlib PRIVATE -march=native)
 add_library (ch_contrib::qatlib ALIAS _qatlib)
 
 # _usdm

--- a/contrib/qatlib-cmake/CMakeLists.txt
+++ b/contrib/qatlib-cmake/CMakeLists.txt
@@ -190,6 +190,8 @@ target_include_directories(_qatlib PRIVATE
 target_link_libraries(_qatlib PRIVATE _qatmgr _osal OpenSSL::SSL ch_contrib::isal)
 target_compile_definitions(_qatlib PRIVATE -DUSER_SPACE -DLAC_BYTE_ORDER=__LITTLE_ENDIAN -DOSAL_ENSURE_ON)
 target_link_options(_qatlib PRIVATE -pie -z relro -z now -z noexecstack)
+# -mcx16: Needed to avoid link failure "undefined symbol: __atomic_compare_exchange_16"
+target_compile_options(_qatlib PRIVATE -mcx16)
 add_library (ch_contrib::qatlib ALIAS _qatlib)
 
 # _usdm


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Don't build qatlib with -march=native as it breaks during cross-compilation

`arch=native` refers to the host CPU, so if you try to crossbuild with an ARM machine you get a message like:
```
/usr/bin/ccache /usr/bin/clang --target=x86_64-linux-musl --sysroot=/home/ubuntu/ClickHouse/cmake/linux/../../contrib/sysroot/linux-x86_64-musl -DLAC_BYTE_ORDER=__LITTLE_ENDIAN -DOSAL_ENSURE_ON -DSTD_EXCEPTION_HAS_STACK_TRACE=1 -DUSER_SPACE -DUSE_MUSL=1 -D_LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS -D_LIBCPP_HAS_MUSL_LIBC -D_LIBCPP_HAS_MUSL_LIBC=1 -D_LIBUNWIND_IS_NATIVE_ONLY -D__MUSL__=1 -I/home/ubuntu/ClickHouse/cmake/linux/../../contrib/sysroot/linux-x86_64-musl/usr/include -I/home/ubuntu/ClickHouse/contrib/qatlib/quickassist/lookaside/access_layer/include -I/home/ubuntu/ClickHouse/contrib/qatlib/quickassist/utilities/libusdm_drv -I/home/ubuntu/ClickHouse/contrib/qatlib/quickassist/utilities/osal/include -I/home/ubuntu/ClickHouse/contrib/qatlib/quickassist/utilities/osal/src/linux/user_space/include -I/home/ubuntu/ClickHouse/contrib/qatlib/quickassist/include -I/home/ubuntu/ClickHouse/contrib/qatlib/quickassist/include/lac -I/home/ubuntu/ClickHouse/contrib/qatlib/quickassist/include/dc -I/home/ubuntu/ClickHouse/contrib/qatlib/quickassist/qat/drivers/crypto/qat/qat_common -I/home/ubuntu/ClickHouse/contrib/qatlib/quickassist/lookaside/access_layer/src/common/compression/include -I/home/ubuntu/ClickHouse/contrib/qatlib/quickassist/lookaside/access_layer/src/common/crypto/sym/include -I/home/ubuntu/ClickHouse/contrib/qatlib/quickassist/lookaside/access_layer/src/common/crypto/asym/include -I/home/ubuntu/ClickHouse/contrib/qatlib/quickassist/lookaside/firmware/include -I/home/ubuntu/ClickHouse/contrib/qatlib/quickassist/lookaside/access_layer/src/common/include -I/home/ubuntu/ClickHouse/contrib/qatlib/quickassist/lookaside/access_layer/src/qat_direct/include -I/home/ubuntu/ClickHouse/contrib/qatlib/quickassist/lookaside/access_layer/src/qat_direct/common/include -I/home/ubuntu/ClickHouse/contrib/qatlib/quickassist/lookaside/access_layer/src/qat_direct/vfio -I/home/ubuntu/ClickHouse/contrib/qatlib/quickassist/utilities/osal/src/linux/user_space -I/home/ubuntu/ClickHouse/build_amd_musl/contrib/llvm-project/libcxx/include/c++/v1 -I/home/ubuntu/ClickHouse/contrib/llvm-project/libc -I/home/ubuntu/ClickHouse/contrib/isa-l/include -I/home/ubuntu/ClickHouse/contrib/isa-l/igzip -I/home/ubuntu/ClickHouse/contrib/isa-l/crc -I/home/ubuntu/ClickHouse/contrib/isa-l/erasure_code -isystem /home/ubuntu/ClickHouse/contrib/llvm-project/libcxxabi/include -isystem /home/ubuntu/ClickHouse/contrib/llvm-project/libunwind/include -isystem /home/ubuntu/ClickHouse/contrib/openssl-cmake/common/include -isystem /home/ubuntu/ClickHouse/contrib/openssl/include --gcc-toolchain=/home/ubuntu/ClickHouse/cmake/linux/../../contrib/sysroot/linux-x86_64-musl -fdiagnostics-color=always -Xclang -fuse-ctor-homing  -gdwarf-aranges -pipe -mssse3 -msse4.1 -msse4.2 -mpclmul -mpopcnt -fasynchronous-unwind-tables -ffile-prefix-map=/home/ubuntu/ClickHouse=. -falign-functions=64 -mbranches-within-32B-boundaries -ffp-contract=off  -fdiagnostics-absolute-paths -fPIC -w -ffunction-sections -fdata-sections -O2 -g -DNDEBUG -O3 -g  -std=gnu11   -D OS_LINUX -march=native -Werror -Wno-deprecated-declarations -Wno-poison-system-directories -MD -MT contrib/qatlib-cmake/CMakeFiles/_qatlib.dir/__/qatlib/quickassist/lookaside/access_layer/src/qat_direct/common/adf_user_transport_ctrl.c.o -MF contrib/qatlib-cmake/CMakeFiles/_qatlib.dir/__/qatlib/quickassist/lookaside/access_layer/src/qat_direct/common/adf_user_transport_ctrl.c.o.d -o contrib/qatlib-cmake/CMakeFiles/_qatlib.dir/__/qatlib/quickassist/lookaside/access_layer/src/qat_direct/common/adf_user_transport_ctrl.c.o -c /home/ubuntu/ClickHouse/contrib/qatlib/quickassist/lookaside/access_layer/src/qat_direct/common/adf_user_transport_ctrl.c
error: unknown target CPU 'neoverse-v2'
```

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
