### PR TITLE
Fix direct read from text index with `LowCardinality` columns

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/optimizeDirectReadFromTextIndex.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeDirectReadFromTextIndex.cpp
@@ -206,8 +206,8 @@ private:
         if (function_node.type != ActionsDAG::ActionType::FUNCTION || !function_node.function || !function_node.function_base)
             return std::nullopt;
 
-        /// If function returns not UInt8 type, it is not a predicate and cannot be optimized by the text index.
-        if (!WhichDataType(function_node.result_type).isUInt8())
+        /// Skip if function is not a predicate. It doesn't make sense to analyze it.
+        if (!function_node.result_type->canBeUsedInBooleanContext())
             return std::nullopt;
 
         struct SelectedCondition

--- a/tests/queries/0_stateless/03702_text_index_hint_low_cardinality.reference
+++ b/tests/queries/0_stateless/03702_text_index_hint_low_cardinality.reference
@@ -1,0 +1,4 @@
+1
+Filter column: __text_index_i_equals_888efda921680e32e66fe44752bfa9ba (removed)
+1
+Filter column: __text_index_i_hasToken_3acc763368028663e66c262e993962ad (removed)

--- a/tests/queries/0_stateless/03702_text_index_hint_low_cardinality.sql
+++ b/tests/queries/0_stateless/03702_text_index_hint_low_cardinality.sql
@@ -1,0 +1,33 @@
+-- Tags: no-parallel-replicas
+
+DROP TABLE IF EXISTS t_direct_read_lc;
+SET allow_experimental_full_text_index = 1;
+
+CREATE OR REPLACE TABLE t_direct_read_lc
+(
+    c LowCardinality(String),
+    INDEX i c type text(tokenizer='array')
+)
+ENGINE = MergeTree ORDER BY tuple();
+
+INSERT INTO t_direct_read_lc VALUES ('config');
+
+SELECT count() FROM t_direct_read_lc WHERE c = 'config';
+
+SELECT trim(explain) FROM
+(
+    EXPLAIN actions = 1 SELECT count() FROM t_direct_read_lc WHERE c = 'config'
+    SETTINGS use_skip_indexes_on_data_read = 1, query_plan_text_index_add_hint = 1
+)
+WHERE explain LIKE '%Filter column:%';
+
+SELECT count() FROM t_direct_read_lc WHERE hasToken(c, 'config');
+
+SELECT trim(explain) FROM
+(
+    EXPLAIN actions = 1 SELECT count() FROM t_direct_read_lc WHERE hasToken(c, 'config')
+    SETTINGS use_skip_indexes_on_data_read = 1, query_plan_text_index_add_hint = 1
+)
+WHERE explain LIKE '%Filter column:%';
+
+DROP TABLE t_direct_read_lc;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes #90778.
A follow-up to #88550.
