### PR TITLE
Resolve CVE-2025-5318

### DIFF
--- a/contrib/libssh-cmake/CMakeLists.txt
+++ b/contrib/libssh-cmake/CMakeLists.txt
@@ -35,6 +35,7 @@ set(libssh_SRCS
     ${LIB_SOURCE_DIR}/src/external/blowfish.c
     ${LIB_SOURCE_DIR}/src/external/chacha.c
     ${LIB_SOURCE_DIR}/src/external/poly1305.c
+    ${LIB_SOURCE_DIR}/src/external/sntrup761.c
     ${LIB_SOURCE_DIR}/src/getpass.c
     ${LIB_SOURCE_DIR}/src/init.c
     ${LIB_SOURCE_DIR}/src/kdf.c
@@ -61,6 +62,7 @@ set(libssh_SRCS
     ${LIB_SOURCE_DIR}/src/string.c
     ${LIB_SOURCE_DIR}/src/threads.c
     ${LIB_SOURCE_DIR}/src/token.c
+    ${LIB_SOURCE_DIR}/src/ttyopts.c
     ${LIB_SOURCE_DIR}/src/wrapper.c
     # some files of libssh/src/ are missing - why?
 
@@ -69,15 +71,21 @@ set(libssh_SRCS
     # files missing - why?
 
     # LIBCRYPT specific
+    ${LIB_SOURCE_DIR}/src/crypto_common.c
+    ${LIB_SOURCE_DIR}/src/curve25519_crypto.c
     ${LIB_SOURCE_DIR}/src/dh_crypto.c
     ${LIB_SOURCE_DIR}/src/ecdh_crypto.c
+    ${LIB_SOURCE_DIR}/src/getrandom_crypto.c
+    ${LIB_SOURCE_DIR}/src/gzip.c
     ${LIB_SOURCE_DIR}/src/libcrypto.c
+    ${LIB_SOURCE_DIR}/src/md_crypto.c
     ${LIB_SOURCE_DIR}/src/pki_crypto.c
+    ${LIB_SOURCE_DIR}/src/pki_context.c
+    ${LIB_SOURCE_DIR}/src/sntrup761.c
     ${LIB_SOURCE_DIR}/src/threads/libcrypto.c
 
     ${LIB_SOURCE_DIR}/src/bind.c
     ${LIB_SOURCE_DIR}/src/bind_config.c
-    ${LIB_SOURCE_DIR}/src/options.c
     ${LIB_SOURCE_DIR}/src/server.c
 )
 

--- a/contrib/libssh-cmake/linux/x86-64/config.h
+++ b/contrib/libssh-cmake/linux/x86-64/config.h
@@ -82,63 +82,36 @@
 /* Define to 1 if you have the <pthread.h> header file. */
 #define HAVE_PTHREAD_H 1
 
-/* Define to 1 if you have eliptic curve cryptography in openssl */
+/* Define to 1 if you have elliptic curve cryptography in openssl */
 #define HAVE_OPENSSL_ECC 1
 
-/* Define to 1 if you have eliptic curve cryptography in gcrypt */
+/* Define to 1 if you have elliptic curve cryptography in gcrypt */
 /* #undef HAVE_GCRYPT_ECC */
 
-/* Define to 1 if you have eliptic curve cryptography */
+/* Define to 1 if you have elliptic curve cryptography */
 #define HAVE_ECC 1
 
-/* Define to 1 if you have DSA */
-/* #undef HAVE_DSA */
-
-/* Define to 1 if you have gl_flags as a glob_t sturct member */
+/* Define to 1 if you have gl_flags as a glob_t struct member */
 #define HAVE_GLOB_GL_FLAGS_MEMBER 1
 
-/* Define to 1 if you have OpenSSL with Ed25519 support */
-#define HAVE_OPENSSL_ED25519 1
+/* Define to 1 if you have gcrypt with ChaCha20/Poly1305 support */
+/* #undef HAVE_GCRYPT_CHACHA_POLY */
 
-/* Define to 1 if you have OpenSSL with X25519 support */
-#define HAVE_OPENSSL_X25519 1
+/* Define to 1 if you have gcrypt with curve25519 support */
+/* #undef HAVE_GCRYPT_CURVE25519 */
 
 /*************************** FUNCTIONS ***************************/
 
-/* Define to 1 if you have the `EVP_aes128_ctr' function. */
-#define HAVE_OPENSSL_EVP_AES_CTR 1
+/* Define to 1 if you have the `EVP_chacha20' function. */
+#define HAVE_OPENSSL_EVP_CHACHA20 1
 
-/* Define to 1 if you have the `EVP_aes128_cbc' function. */
-#define HAVE_OPENSSL_EVP_AES_CBC 1
-
-/* Define to 1 if you have the `EVP_aes128_gcm' function. */
-/* #undef HAVE_OPENSSL_EVP_AES_GCM */
-
-/* Define to 1 if you have the `CRYPTO_THREADID_set_callback' function. */
-#define HAVE_OPENSSL_CRYPTO_THREADID_SET_CALLBACK 1
-
-/* Define to 1 if you have the `CRYPTO_ctr128_encrypt' function. */
-#define HAVE_OPENSSL_CRYPTO_CTR128_ENCRYPT 1
-
-/* Define to 1 if you have the `EVP_CIPHER_CTX_new' function. */
-#define HAVE_OPENSSL_EVP_CIPHER_CTX_NEW 1
-
-/* Define to 1 if you have the `EVP_KDF_CTX_new_id' function. */
-/* #undef HAVE_OPENSSL_EVP_KDF_CTX_NEW_ID */
+/* Define to 1 if you have the `EVP_KDF_CTX_new_id' or `EVP_KDF_CTX_new` function. */
+#define HAVE_OPENSSL_EVP_KDF_CTX 1
 
 /* Define to 1 if you have the `FIPS_mode' function. */
 #if USE_BORINGSSL
 #define HAVE_OPENSSL_FIPS_MODE 1
 #endif
-
-/* Define to 1 if you have the `EVP_DigestSign' function. */
-#define HAVE_OPENSSL_EVP_DIGESTSIGN 1
-
-/* Define to 1 if you have the `EVP_DigestVerify' function. */
-#define HAVE_OPENSSL_EVP_DIGESTVERIFY 1
-
-/* Define to 1 if you have the `OPENSSL_ia32cap_loc' function. */
-/* #undef HAVE_OPENSSL_IA32CAP_LOC */
 
 /* Define to 1 if you have the `snprintf' function. */
 #define HAVE_SNPRINTF 1
@@ -212,6 +185,12 @@
 /* Define to 1 if you have the `cmocka_set_test_filter' function. */
 /* #undef HAVE_CMOCKA_SET_TEST_FILTER */
 
+/* Define to 1 if we have support for blowfish */
+/* #undef HAVE_BLOWFISH */
+
+/* Define to 1 if we have support for ML-KEM */
+/* #undef HAVE_MLKEM */
+
 /*************************** LIBRARIES ***************************/
 
 /* Define to 1 if you have the `crypto' library (-lcrypto). */
@@ -229,6 +208,10 @@
 /* Define to 1 if you have the `cmocka' library (-lcmocka). */
 /* #undef HAVE_CMOCKA */
 
+/* Define to 1 if you have the `libfido2' library (-lfido2).
+ * This is required for interacting with FIDO2/U2F devices over USB-HID. */
+/* #undef HAVE_LIBFIDO2 */
+
 /**************************** OPTIONS ****************************/
 
 #define HAVE_GCC_THREAD_LOCAL_STORAGE 1
@@ -236,6 +219,7 @@
 
 #define HAVE_FALLTHROUGH_ATTRIBUTE 1
 #define HAVE_UNUSED_ATTRIBUTE 1
+/* #undef HAVE_WEAK_ATTRIBUTE */
 
 #define HAVE_CONSTRUCTOR_ATTRIBUTE 1
 #define HAVE_DESTRUCTOR_ATTRIBUTE 1
@@ -262,6 +246,14 @@
 /* Define to 1 if you want to enable DH group exchange algorithms */
 /* #undef WITH_GEX */
 
+/* Define to 1 if you want to enable insecure none cipher and MAC */
+/* #undef WITH_INSECURE_NONE */
+
+/* Define to 1 if you want to allow libssh to execute arbitrary commands from
+ * configuration files or options (match exec, proxy commands and OpenSSH-based
+ * proxy-jumps). */
+/* #undef WITH_EXEC */
+
 /* Define to 1 if you want to enable blowfish cipher support */
 /* #undef WITH_BLOWFISH_CIPHER */
 
@@ -279,6 +271,15 @@
 
 /* Define to 1 if you want to enable NaCl support */
 /* #undef WITH_NACL */
+
+/* Define to 1 if you want to enable PKCS #11 URI support */
+/* #undef WITH_PKCS11_URI */
+
+/* Define to 1 if we want to build a support for PKCS #11 provider. */
+/* #undef WITH_PKCS11_PROVIDER */
+
+/* Define to 1 if you want to enable FIDO2/U2F support */
+/* #undef WITH_FIDO2 */
 
 /*************************** ENDIAN *****************************/
 

--- a/src/Server/SSH/SSHPtyHandler.cpp
+++ b/src/Server/SSH/SSHPtyHandler.cpp
@@ -479,7 +479,9 @@ SSHPtyHandler::~SSHPtyHandler()
 void SSHPtyHandler::run()
 {
     ::ssh::SSHEvent event;
-    SessionCallback sdata(session, server, socket().peerAddress(), options);
+    auto peer_addr = socket().peerAddress();
+    socket().close();
+    SessionCallback sdata(session, server, peer_addr, options);
     session.handleKeyExchange();
     event.addSession(session);
     int max_iterations = options.auth_timeout_seconds * 1000 / options.event_poll_interval_milliseconds;

--- a/src/Server/SSH/SSHSession.cpp
+++ b/src/Server/SSH/SSHSession.cpp
@@ -64,14 +64,6 @@ void SSHSession::disableDefaultConfig()
         throw DB::Exception(DB::ErrorCodes::SSH_EXCEPTION, "Failed disabling default config for ssh session due due to {}", getError());
 }
 
-void SSHSession::disableSocketOwning()
-{
-    bool owns_socket = false;
-    int rc = ssh_options_set(session, SSH_OPTIONS_OWNS_SOCKET, &owns_socket);
-    if (rc != SSH_OK)
-        throw DB::Exception(DB::ErrorCodes::SSH_EXCEPTION, "Failed disabling socket owning for ssh session due to {}", getError());
-}
-
 void SSHSession::setPeerHost(const String & host)
 {
     int rc = ssh_options_set(session, SSH_OPTIONS_HOST, host.c_str());

--- a/src/Server/SSH/SSHSession.h
+++ b/src/Server/SSH/SSHSession.h
@@ -30,8 +30,6 @@ public:
 
     /// Disable reading default libssh configuration
     void disableDefaultConfig();
-    /// Disable session from closing socket. Can be used when a socket is passed.
-    void disableSocketOwning();
 
     /// Connect / disconnect
     void connect();


### PR DESCRIPTION
This is an amalgamation of
- https://github.com/ClickHouse/ClickHouse/pull/90362 and
- https://github.com/ClickHouse/ClickHouse/pull/90612

The first PR bumps libssh from 0.9.8 to dev (future 0.12). This fixes CVE-2025-5318.

The second PR resolves a TSAN failure (*) that the first PR introduced.

(*) https://github.com/ClickHouse/ClickHouse/issues/90663

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Resolved CVE-2025-5318 in ClickHouse's libssh.