### PR TITLE
Fix duplicate (U)Int128 mentions in aggregate function parameter binary encoding docs and comments

### DIFF
--- a/docs/en/sql-reference/data-types/data-types-binary-encoding.md
+++ b/docs/en/sql-reference/data-types/data-types-binary-encoding.md
@@ -102,8 +102,8 @@ The encoding of a parameter consists of 1 byte indicating the type of the parame
 | `Int64`                  | `0x02<var_int_value>`                                                                                                          |
 | `UInt128`                | `0x03<uint128_little_endian_value>`                                                                                            |
 | `Int128`                 | `0x04<int128_little_endian_value>`                                                                                             |
-| `UInt128`                | `0x05<uint128_little_endian_value>`                                                                                            |
-| `Int128`                 | `0x06<int128_little_endian_value>`                                                                                             |
+| `UInt256`                | `0x05<uint256_little_endian_value>`                                                                                            |
+| `Int256`                 | `0x06<int256_little_endian_value>`                                                                                             |
 | `Float64`                | `0x07<float64_little_endian_value>`                                                                                            |
 | `Decimal32`              | `0x08<var_uint_scale><int32_little_endian_value>`                                                                              |
 | `Decimal64`              | `0x09<var_uint_scale><int64_little_endian_value>`                                                                              |

--- a/src/Common/FieldBinaryEncoding.h
+++ b/src/Common/FieldBinaryEncoding.h
@@ -15,8 +15,8 @@ Binary encoding for Fields:
 | `Int64`                  | `0x02<var_int_value>`                                                                                                          |
 | `UInt128`                | `0x03<uint128_little_endian_value>`                                                                                            |
 | `Int128`                 | `0x04<int128_little_endian_value>`                                                                                             |
-| `UInt128`                | `0x05<uint128_little_endian_value>`                                                                                            |
-| `Int128`                 | `0x06<int128_little_endian_value>`                                                                                             |
+| `UInt256`                | `0x05<uint256_little_endian_value>`                                                                                            |
+| `Int256`                 | `0x06<int256_little_endian_value>`                                                                                             |
 | `Float64`                | `0x07<float64_little_endian_value>`                                                                                            |
 | `Decimal32`              | `0x08<var_uint_scale><int32_little_endian_value>`                                                                              |
 | `Decimal64`              | `0x09<var_uint_scale><int64_little_endian_value>`                                                                              |

--- a/src/DataTypes/DataTypesBinaryEncoding.h
+++ b/src/DataTypes/DataTypesBinaryEncoding.h
@@ -92,8 +92,8 @@ Aggregate function parameter binary encoding (binary encoding of a Field, see sr
 | Int64                  | 0x02<var_int_value>                                                                                                          |
 | UInt128                | 0x03<uint128_little_endian_value>                                                                                            |
 | Int128                 | 0x04<int128_little_endian_value>                                                                                             |
-| UInt128                | 0x05<uint128_little_endian_value>                                                                                            |
-| Int128                 | 0x06<int128_little_endian_value>                                                                                             |
+| UInt256                | 0x05<uint256_little_endian_value>                                                                                            |
+| Int256                 | 0x06<int256_little_endian_value>                                                                                             |
 | Float64                | 0x07<float64_little_endian_value>                                                                                            |
 | Decimal32              | 0x08<var_uint_scale><int32_little_endian_value>                                                                              |
 | Decimal64              | 0x09<var_uint_scale><int64_little_endian_value>                                                                              |


### PR DESCRIPTION
Fixes a typo in docs and comments.

### Changelog category (leave one):
- Documentation (changelog entry is not required)
