### PR TITLE
Disable test `03657_gby_overflow_any_sparse` for parallel replicas

### DIFF
--- a/tests/parallel_replicas_blacklist.txt
+++ b/tests/parallel_replicas_blacklist.txt
@@ -369,6 +369,7 @@
 02402_merge_engine_with_view
     No order guarantee with group_by_overflow_mode='any'
 02180_group_by_lowcardinality
+03657_gby_overflow_any_sparse
 
     RMT zookeeper test
 01154_move_partition_long


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Closes #90857.
