### PR TITLE
Fix ALTER MODIFY QUERY with dictGet() and dictionary name in Common Subexpresseion Elimination for Shared Catalog

### DIFF
--- a/tests/queries/0_stateless/03740_alter_modify_query_dict_name_in_cse.sql
+++ b/tests/queries/0_stateless/03740_alter_modify_query_dict_name_in_cse.sql
@@ -1,0 +1,10 @@
+drop table if exists mv;
+drop table if exists dst;
+drop table if exists src;
+drop dictionary if exists dict;
+
+create table src (key Int) engine=MergeTree order by ();
+create table dst (key Int) engine=MergeTree order by ();
+create dictionary dict (key Int, value Int) primary key key layout(direct) source(clickhouse(query 'select 0 key, 0 value'));
+create materialized view mv to dst as select * from src;
+alter table mv modify query with 'dict' as dict_name select dictGetInt32(dict_name, 'value', key) from src;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix ALTER MODIFY QUERY with dictGet() and dictionary name in CSE for SharedCatalog (cloud only feature)

Otherwise the query like this may fail in SharedCatalog:

    ALTER MODIFY QUERY WITH 'dict' AS dict_name SELECT dictGet(dict_name)

Note, that the newly added test will not reproduce any problems, it has been added just in case, the real test will be added in private.