### PR TITLE
Revert "libssh forward to master 17-11-2025 with socket duplication logic to resolve test case failure"

### DIFF
--- a/src/Server/SSH/SSHPtyHandler.cpp
+++ b/src/Server/SSH/SSHPtyHandler.cpp
@@ -478,9 +478,7 @@ SSHPtyHandler::~SSHPtyHandler()
 void SSHPtyHandler::run()
 {
     ::ssh::SSHEvent event;
-    auto peer_addr = socket().peerAddress();
-    socket().close();
-    SessionCallback sdata(session, server, peer_addr, options);
+    SessionCallback sdata(session, server, socket().peerAddress(), options);
     session.handleKeyExchange();
     event.addSession(session);
     int max_iterations = options.auth_timeout_seconds * 1000 / options.event_poll_interval_milliseconds;

--- a/src/Server/SSH/SSHPtyHandlerFactory.h
+++ b/src/Server/SSH/SSHPtyHandlerFactory.h
@@ -5,7 +5,6 @@
 #if USE_SSH && defined(OS_LINUX)
 
 #include <optional>
-#include <unistd.h>
 
 #include <Core/ServerSettings.h>
 #include <Server/SSH/SSHPtyHandler.h>
@@ -29,7 +28,6 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;
-    extern const int SSH_EXCEPTION;
 }
 
 class SSHPtyHandlerFactory : public TCPServerConnectionFactory
@@ -82,10 +80,7 @@ public:
         ::ssh::libsshLogger::initialize();
         ::ssh::SSHSession session;
         session.disableDefaultConfig();
-        int duplicated_fd = dup(socket.sockfd());
-        if (duplicated_fd == -1)
-            throw Exception(ErrorCodes::SSH_EXCEPTION, "Failed to duplicate socket file descriptor");
-        ssh_bind.acceptFd(session, duplicated_fd);
+        ssh_bind.acceptFd(session, socket.sockfd());
 
         auto options = SSHPtyHandler::Options
         {


### PR DESCRIPTION
Reverts ClickHouse/ClickHouse#90612

There were new SSH-related TSAN errors ([here](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=90812&sha=latest&name_0=BackportPR) in a backport PR (all of which were reverted).

```
E           Exception: Sanitizer assert found for instance ==================
E           WARNING: ThreadSanitizer: data race (pid=8)
E             Write of size 4 at 0x55f75c825f98 by thread T6:
E               #0 ssh_disconnect ci/tmp/build/./contrib/libssh/src/client.c:817:26 (clickhouse+0x2b5d494c) (BuildId: 16c5c75a5bdcbe68f67a863a6f6512a4d7ce0e80)
E               #1 ssh::SSHSession::disconnect() ci/tmp/build/./src/Server/SSH/SSHSession.cpp:101:5 (clickhouse+0x222cdc61) (BuildId: 16c5c75a5bdcbe68f67a863a6f6512a4d7ce0e80)
E               #2 DB::SSHPtyHandler::~SSHPtyHandler() ci/tmp/build/./src/Server/SSH/SSHPtyHandler.cpp:476:13 (clickhouse+0x222bf3f7) (BuildId: 16c5c75a5bdcbe68f67a863a6f6512a4d7ce0e80)
E               #3 DB::SSHPtyHandler::~SSHPtyHandler() ci/tmp/build/./src/Server/SSH/SSHPtyHandler.cpp:475:1 (clickhouse+0x222bf459) (BuildId: 16c5c75a5bdcbe68f67a863a6f6512a4d7ce0e80)
E               #4 std::__1::default_delete<Poco::Net::TCPServerConnection>::operator()[abi:ne190107](Poco::Net::TCPServerConnection*) const ci/tmp/build/./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:80:5 (clickhouse+0x2b48a4c3) (BuildId: 16c5c75a5bdcbe68f67a863a6f6512a4d7ce0e80)
E               #5 std::__1::unique_ptr<Poco::Net::TCPServerConnection, std::__1::default_delete<Poco::Net::TCPServerConnection>>::reset[abi:ne190107](Poco::Net::TCPServerConnection*) ci/tmp/build/./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:292:7 (clickhouse+0x2b48a4c3)
E               #6 std::__1::unique_ptr<Poco::Net::TCPServerConnection, std::__1::default_delete<Poco::Net::TCPServerConnection>>::~unique_ptr[abi:ne190107]() ci/tmp/build/./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:261:71 (clickhouse+0x2b48a4c3)
E               #7 Poco::Net::TCPServerDispatcher::run() ci/tmp/build/./base/poco/Net/src/TCPServerDispatcher.cpp:116:21 (clickhouse+0x2b48a4c3)
E               #8 Poco::PooledThread::run() ci/tmp/build/./base/poco/Foundation/src/ThreadPool.cpp:205:14 (clickhouse+0x2b3f9150) (BuildId: 16c5c75a5bdcbe68f67a863a6f6512a4d7ce0e80)
E               #9 Poco::(anonymous namespace)::RunnableHolder::run() ci/tmp/build/./base/poco/Foundation/src/Thread.cpp:45:11 (clickhouse+0x2b3f732f) (BuildId: 16c5c75a5bdcbe68f67a863a6f6512a4d7ce0e80)
E               #10 Poco::ThreadImpl::runnableEntry(void*) ci/tmp/build/./base/poco/Foundation/src/Thread_POSIX.cpp:341:27 (clickhouse+0x2b3f5589) (BuildId: 16c5c75a5bdcbe68f67a863a6f6512a4d7ce0e80)
E           
E             Previous write of size 4 at 0x55f75c825f98 by thread T7:
E               #0 ssh_disconnect ci/tmp/build/./contrib/libssh/src/client.c:817:26 (clickhouse+0x2b5d494c) (BuildId: 16c5c75a5bdcbe68f67a863a6f6512a4d7ce0e80)
E               #1 ssh::SSHSession::disconnect() ci/tmp/build/./src/Server/SSH/SSHSession.cpp:101:5 (clickhouse+0x222cdc61) (BuildId: 16c5c75a5bdcbe68f67a863a6f6512a4d7ce0e80)
E               #2 DB::SSHPtyHandler::~SSHPtyHandler() ci/tmp/build/./src/Server/SSH/SSHPtyHandler.cpp:476:13 (clickhouse+0x222bf3f7) (BuildId: 16c5c75a5bdcbe68f67a863a6f6512a4d7ce0e80)
E               #3 DB::SSHPtyHandler::~SSHPtyHandler() ci/tmp/build/./src/Server/SSH/SSHPtyHandler.cpp:475:1 (clickhouse+0x222bf459) (BuildId: 16c5c75a5bdcbe68f67a863a6f6512a4d7ce0e80)
E               #4 std::__1::default_delete<Poco::Net::TCPServerConnection>::operator()[abi:ne190107](Poco::Net::TCPServerConnection*) const ci/tmp/build/./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:80:5 (clickhouse+0x2b48a4c3) (BuildId: 16c5c75a5bdcbe68f67a863a6f6512a4d7ce0e80)
E               #5 std::__1::unique_ptr<Poco::Net::TCPServerConnection, std::__1::default_delete<Poco::Net::TCPServerConnection>>::reset[abi:ne190107](Poco::Net::TCPServerConnection*) ci/tmp/build/./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:292:7 (clickhouse+0x2b48a4c3)
E               #6 std::__1::unique_ptr<Poco::Net::TCPServerConnection, std::__1::default_delete<Poco::Net::TCPServerConnection>>::~unique_ptr[abi:ne190107]() ci/tmp/build/./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:261:71 (clickhouse+0x2b48a4c3)
E               #7 Poco::Net::TCPServerDispatcher::run() ci/tmp/build/./base/poco/Net/src/TCPServerDispatcher.cpp:116:21 (clickhouse+0x2b48a4c3)
E               #8 Poco::PooledThread::run() ci/tmp/build/./base/poco/Foundation/src/ThreadPool.cpp:205:14 (clickhouse+0x2b3f9150) (BuildId: 16c5c75a5bdcbe68f67a863a6f6512a4d7ce0e80)
E               #9 Poco::(anonymous namespace)::RunnableHolder::run() ci/tmp/build/./base/poco/Foundation/src/Thread.cpp:45:11 (clickhouse+0x2b3f732f) (BuildId: 16c5c75a5bdcbe68f67a863a6f6512a4d7ce0e80)
E               #10 Poco::ThreadImpl::runnableEntry(void*) ci/tmp/build/./base/poco/Foundation/src/Thread_POSIX.cpp:341:27 (clickhouse+0x2b3f5589) (BuildId: 16c5c75a5bdcbe68f67a863a6f6512a4d7ce0e80)
```