### PR TITLE
Revert bump libssh to master

### DIFF
--- a/contrib/libssh-cmake/CMakeLists.txt
+++ b/contrib/libssh-cmake/CMakeLists.txt
@@ -62,7 +62,6 @@ set(libssh_SRCS
     ${LIB_SOURCE_DIR}/src/string.c
     ${LIB_SOURCE_DIR}/src/threads.c
     ${LIB_SOURCE_DIR}/src/token.c
-    ${LIB_SOURCE_DIR}/src/ttyopts.c
     ${LIB_SOURCE_DIR}/src/wrapper.c
     # some files of libssh/src/ are missing - why?
 

--- a/contrib/libssh-cmake/CMakeLists.txt
+++ b/contrib/libssh-cmake/CMakeLists.txt
@@ -35,7 +35,6 @@ set(libssh_SRCS
     ${LIB_SOURCE_DIR}/src/external/blowfish.c
     ${LIB_SOURCE_DIR}/src/external/chacha.c
     ${LIB_SOURCE_DIR}/src/external/poly1305.c
-    ${LIB_SOURCE_DIR}/src/external/sntrup761.c
     ${LIB_SOURCE_DIR}/src/getpass.c
     ${LIB_SOURCE_DIR}/src/init.c
     ${LIB_SOURCE_DIR}/src/kdf.c
@@ -70,21 +69,15 @@ set(libssh_SRCS
     # files missing - why?
 
     # LIBCRYPT specific
-    ${LIB_SOURCE_DIR}/src/crypto_common.c
-    ${LIB_SOURCE_DIR}/src/curve25519_crypto.c
     ${LIB_SOURCE_DIR}/src/dh_crypto.c
     ${LIB_SOURCE_DIR}/src/ecdh_crypto.c
-    ${LIB_SOURCE_DIR}/src/getrandom_crypto.c
-    ${LIB_SOURCE_DIR}/src/gzip.c
     ${LIB_SOURCE_DIR}/src/libcrypto.c
-    ${LIB_SOURCE_DIR}/src/md_crypto.c
     ${LIB_SOURCE_DIR}/src/pki_crypto.c
-    ${LIB_SOURCE_DIR}/src/pki_context.c
-    ${LIB_SOURCE_DIR}/src/sntrup761.c
     ${LIB_SOURCE_DIR}/src/threads/libcrypto.c
 
     ${LIB_SOURCE_DIR}/src/bind.c
     ${LIB_SOURCE_DIR}/src/bind_config.c
+    ${LIB_SOURCE_DIR}/src/options.c
     ${LIB_SOURCE_DIR}/src/server.c
 )
 

--- a/contrib/libssh-cmake/linux/x86-64/config.h
+++ b/contrib/libssh-cmake/linux/x86-64/config.h
@@ -82,36 +82,63 @@
 /* Define to 1 if you have the <pthread.h> header file. */
 #define HAVE_PTHREAD_H 1
 
-/* Define to 1 if you have elliptic curve cryptography in openssl */
+/* Define to 1 if you have eliptic curve cryptography in openssl */
 #define HAVE_OPENSSL_ECC 1
 
-/* Define to 1 if you have elliptic curve cryptography in gcrypt */
+/* Define to 1 if you have eliptic curve cryptography in gcrypt */
 /* #undef HAVE_GCRYPT_ECC */
 
-/* Define to 1 if you have elliptic curve cryptography */
+/* Define to 1 if you have eliptic curve cryptography */
 #define HAVE_ECC 1
 
-/* Define to 1 if you have gl_flags as a glob_t struct member */
+/* Define to 1 if you have DSA */
+/* #undef HAVE_DSA */
+
+/* Define to 1 if you have gl_flags as a glob_t sturct member */
 #define HAVE_GLOB_GL_FLAGS_MEMBER 1
 
-/* Define to 1 if you have gcrypt with ChaCha20/Poly1305 support */
-/* #undef HAVE_GCRYPT_CHACHA_POLY */
+/* Define to 1 if you have OpenSSL with Ed25519 support */
+#define HAVE_OPENSSL_ED25519 1
 
-/* Define to 1 if you have gcrypt with curve25519 support */
-/* #undef HAVE_GCRYPT_CURVE25519 */
+/* Define to 1 if you have OpenSSL with X25519 support */
+#define HAVE_OPENSSL_X25519 1
 
 /*************************** FUNCTIONS ***************************/
 
-/* Define to 1 if you have the `EVP_chacha20' function. */
-#define HAVE_OPENSSL_EVP_CHACHA20 1
+/* Define to 1 if you have the `EVP_aes128_ctr' function. */
+#define HAVE_OPENSSL_EVP_AES_CTR 1
 
-/* Define to 1 if you have the `EVP_KDF_CTX_new_id' or `EVP_KDF_CTX_new` function. */
-#define HAVE_OPENSSL_EVP_KDF_CTX 1
+/* Define to 1 if you have the `EVP_aes128_cbc' function. */
+#define HAVE_OPENSSL_EVP_AES_CBC 1
+
+/* Define to 1 if you have the `EVP_aes128_gcm' function. */
+/* #undef HAVE_OPENSSL_EVP_AES_GCM */
+
+/* Define to 1 if you have the `CRYPTO_THREADID_set_callback' function. */
+#define HAVE_OPENSSL_CRYPTO_THREADID_SET_CALLBACK 1
+
+/* Define to 1 if you have the `CRYPTO_ctr128_encrypt' function. */
+#define HAVE_OPENSSL_CRYPTO_CTR128_ENCRYPT 1
+
+/* Define to 1 if you have the `EVP_CIPHER_CTX_new' function. */
+#define HAVE_OPENSSL_EVP_CIPHER_CTX_NEW 1
+
+/* Define to 1 if you have the `EVP_KDF_CTX_new_id' function. */
+/* #undef HAVE_OPENSSL_EVP_KDF_CTX_NEW_ID */
 
 /* Define to 1 if you have the `FIPS_mode' function. */
 #if USE_BORINGSSL
 #define HAVE_OPENSSL_FIPS_MODE 1
 #endif
+
+/* Define to 1 if you have the `EVP_DigestSign' function. */
+#define HAVE_OPENSSL_EVP_DIGESTSIGN 1
+
+/* Define to 1 if you have the `EVP_DigestVerify' function. */
+#define HAVE_OPENSSL_EVP_DIGESTVERIFY 1
+
+/* Define to 1 if you have the `OPENSSL_ia32cap_loc' function. */
+/* #undef HAVE_OPENSSL_IA32CAP_LOC */
 
 /* Define to 1 if you have the `snprintf' function. */
 #define HAVE_SNPRINTF 1
@@ -185,12 +212,6 @@
 /* Define to 1 if you have the `cmocka_set_test_filter' function. */
 /* #undef HAVE_CMOCKA_SET_TEST_FILTER */
 
-/* Define to 1 if we have support for blowfish */
-/* #undef HAVE_BLOWFISH */
-
-/* Define to 1 if we have support for ML-KEM */
-/* #undef HAVE_MLKEM */
-
 /*************************** LIBRARIES ***************************/
 
 /* Define to 1 if you have the `crypto' library (-lcrypto). */
@@ -208,10 +229,6 @@
 /* Define to 1 if you have the `cmocka' library (-lcmocka). */
 /* #undef HAVE_CMOCKA */
 
-/* Define to 1 if you have the `libfido2' library (-lfido2).
- * This is required for interacting with FIDO2/U2F devices over USB-HID. */
-/* #undef HAVE_LIBFIDO2 */
-
 /**************************** OPTIONS ****************************/
 
 #define HAVE_GCC_THREAD_LOCAL_STORAGE 1
@@ -219,7 +236,6 @@
 
 #define HAVE_FALLTHROUGH_ATTRIBUTE 1
 #define HAVE_UNUSED_ATTRIBUTE 1
-/* #undef HAVE_WEAK_ATTRIBUTE */
 
 #define HAVE_CONSTRUCTOR_ATTRIBUTE 1
 #define HAVE_DESTRUCTOR_ATTRIBUTE 1
@@ -246,14 +262,6 @@
 /* Define to 1 if you want to enable DH group exchange algorithms */
 /* #undef WITH_GEX */
 
-/* Define to 1 if you want to enable insecure none cipher and MAC */
-/* #undef WITH_INSECURE_NONE */
-
-/* Define to 1 if you want to allow libssh to execute arbitrary commands from
- * configuration files or options (match exec, proxy commands and OpenSSH-based
- * proxy-jumps). */
-/* #undef WITH_EXEC */
-
 /* Define to 1 if you want to enable blowfish cipher support */
 /* #undef WITH_BLOWFISH_CIPHER */
 
@@ -271,15 +279,6 @@
 
 /* Define to 1 if you want to enable NaCl support */
 /* #undef WITH_NACL */
-
-/* Define to 1 if you want to enable PKCS #11 URI support */
-/* #undef WITH_PKCS11_URI */
-
-/* Define to 1 if we want to build a support for PKCS #11 provider. */
-/* #undef WITH_PKCS11_PROVIDER */
-
-/* Define to 1 if you want to enable FIDO2/U2F support */
-/* #undef WITH_FIDO2 */
 
 /*************************** ENDIAN *****************************/
 

--- a/src/Common/SSHWrapper.cpp
+++ b/src/Common/SSHWrapper.cpp
@@ -21,10 +21,6 @@ namespace ErrorCodes
 
 namespace
 {
-struct SSHStringDeleter
-{
-    void operator()(char * ptr) const { ssh_string_free_char(ptr); }
-};
 struct CStringDeleter
 {
     void operator()(char * ptr) const { std::free(ptr); }
@@ -100,7 +96,7 @@ String SSHKey::signString(std::string_view input) const
     char * signature = nullptr;
     if (int rc = sshsig_sign(input.data(), input.size(), key, nullptr, "clickhouse", SSHSIG_DIGEST_SHA2_256, &signature); rc != SSH_OK)
         throw Exception(ErrorCodes::LIBSSH_ERROR, "Error signing with ssh key");
-    std::unique_ptr<char, SSHStringDeleter> sig_ptr(signature);
+    std::unique_ptr<char, CStringDeleter> sig_ptr(signature);
     return String(sig_ptr.get());
 }
 

--- a/src/Common/SSHWrapper.cpp
+++ b/src/Common/SSHWrapper.cpp
@@ -21,10 +21,36 @@ namespace ErrorCodes
 
 namespace
 {
-struct CStringDeleter
+
+class SSHString
 {
-    void operator()(char * ptr) const { std::free(ptr); }
+public:
+    explicit SSHString(std::string_view input)
+    {
+        if (string = ssh_string_new(input.size()); string == nullptr)
+            throw Exception(ErrorCodes::LIBSSH_ERROR, "Can't create SSHString");
+        if (int rc = ssh_string_fill(string, input.data(), input.size()); rc != SSH_OK)
+            throw Exception(ErrorCodes::LIBSSH_ERROR, "Can't create SSHString");
+    }
+
+    explicit SSHString(ssh_string other) { string = other; }
+
+    ssh_string get() { return string; }
+
+    String toString()
+    {
+        return {ssh_string_get_char(string), ssh_string_len(string)};
+    }
+
+    ~SSHString()
+    {
+        ssh_string_free(string);
+    }
+
+private:
+    ssh_string string;
 };
+
 }
 
 SSHKey SSHKeyFactory::makePrivateKeyFromFile(String filename, String passphrase)
@@ -93,20 +119,19 @@ bool SSHKey::isEqual(const SSHKey & other) const
 
 String SSHKey::signString(std::string_view input) const
 {
-    char * signature = nullptr;
-    if (int rc = sshsig_sign(input.data(), input.size(), key, nullptr, "clickhouse", SSHSIG_DIGEST_SHA2_256, &signature); rc != SSH_OK)
-        throw Exception(ErrorCodes::LIBSSH_ERROR, "Error signing with ssh key");
-    std::unique_ptr<char, CStringDeleter> sig_ptr(signature);
-    return String(sig_ptr.get());
+    SSHString input_str(input);
+    ssh_string output = nullptr;
+    if (int rc = pki_sign_string(key, input_str.get(), &output); rc != SSH_OK)
+        throw Exception(ErrorCodes::LIBSSH_ERROR, "Error singing with ssh key");
+    SSHString output_str(output);
+    return output_str.toString();
 }
 
 bool SSHKey::verifySignature(std::string_view signature, std::string_view original) const
 {
-    ssh_key verify_key = nullptr;
-    String sig_str(signature);
-    int rc = sshsig_verify(original.data(), original.size(), sig_str.c_str(), "clickhouse", &verify_key);
-    if (verify_key != nullptr)
-        ssh_key_free(verify_key);
+    SSHString sig(signature);
+    SSHString orig(original);
+    int rc = pki_verify_string(key, sig.get(), orig.get());
     return rc == SSH_OK;
 }
 
@@ -118,6 +143,14 @@ bool SSHKey::isPrivate() const
 bool SSHKey::isPublic() const
 {
     return ssh_key_is_public(key);
+}
+
+namespace
+{
+    struct CStringDeleter
+    {
+        void operator()(char * ptr) const { std::free(ptr); }
+    };
 }
 
 String SSHKey::getBase64() const

--- a/src/Common/SSHWrapper.cpp
+++ b/src/Common/SSHWrapper.cpp
@@ -109,19 +109,9 @@ bool SSHKey::verifySignature(std::string_view signature, std::string_view origin
     ssh_key verify_key = nullptr;
     String sig_str(signature);
     int rc = sshsig_verify(original.data(), original.size(), sig_str.c_str(), "clickhouse", &verify_key);
-    if (rc != SSH_OK)
-    {
-        if (verify_key != nullptr)
-            ssh_key_free(verify_key);
-        return false;
-    }
-    bool keys_match = false;
     if (verify_key != nullptr)
-    {
-        keys_match = (ssh_key_cmp(key, verify_key, SSH_KEY_CMP_PUBLIC) == 0);
         ssh_key_free(verify_key);
-    }
-    return keys_match;
+    return rc == SSH_OK;
 }
 
 bool SSHKey::isPrivate() const

--- a/src/Server/SSH/SSHPtyHandler.cpp
+++ b/src/Server/SSH/SSHPtyHandler.cpp
@@ -478,9 +478,7 @@ SSHPtyHandler::~SSHPtyHandler()
 void SSHPtyHandler::run()
 {
     ::ssh::SSHEvent event;
-    auto peer_addr = socket().peerAddress();
-    socket().close();
-    SessionCallback sdata(session, server, peer_addr, options);
+    SessionCallback sdata(session, server, socket().peerAddress(), options);
     session.handleKeyExchange();
     event.addSession(session);
     int max_iterations = options.auth_timeout_seconds * 1000 / options.event_poll_interval_milliseconds;

--- a/src/Server/SSH/SSHPtyHandlerFactory.h
+++ b/src/Server/SSH/SSHPtyHandlerFactory.h
@@ -5,7 +5,6 @@
 #if USE_SSH && defined(OS_LINUX)
 
 #include <optional>
-#include <unistd.h>
 
 #include <Core/ServerSettings.h>
 #include <Server/SSH/SSHPtyHandler.h>
@@ -29,7 +28,6 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;
-    extern const int SSH_EXCEPTION;
 }
 
 class SSHPtyHandlerFactory : public TCPServerConnectionFactory
@@ -82,10 +80,7 @@ public:
         ::ssh::libsshLogger::initialize();
         ::ssh::SSHSession session;
         session.disableDefaultConfig();
-        int duplicated_fd = dup(socket.sockfd());
-        if (duplicated_fd == -1)
-            throw Exception(ErrorCodes::SSH_EXCEPTION, "Failed to duplicate socket file descriptor");
-        ssh_bind.acceptFd(session, duplicated_fd);
+        ssh_bind.acceptFd(session, socket.sockfd());
 
         auto options = SSHPtyHandler::Options
         {

--- a/src/Server/SSH/SSHPtyHandlerFactory.h
+++ b/src/Server/SSH/SSHPtyHandlerFactory.h
@@ -79,6 +79,7 @@ public:
         LOG_TRACE(log, "TCP Request. Address: {}", socket.peerAddress().toString());
         ::ssh::libsshLogger::initialize();
         ::ssh::SSHSession session;
+        session.disableSocketOwning();
         session.disableDefaultConfig();
         ssh_bind.acceptFd(session, socket.sockfd());
 

--- a/src/Server/SSH/SSHSession.cpp
+++ b/src/Server/SSH/SSHSession.cpp
@@ -64,6 +64,14 @@ void SSHSession::disableDefaultConfig()
         throw DB::Exception(DB::ErrorCodes::SSH_EXCEPTION, "Failed disabling default config for ssh session due due to {}", getError());
 }
 
+void SSHSession::disableSocketOwning()
+{
+    bool owns_socket = false;
+    int rc = ssh_options_set(session, SSH_OPTIONS_OWNS_SOCKET, &owns_socket);
+    if (rc != SSH_OK)
+        throw DB::Exception(DB::ErrorCodes::SSH_EXCEPTION, "Failed disabling socket owning for ssh session due to {}", getError());
+}
+
 void SSHSession::setPeerHost(const String & host)
 {
     int rc = ssh_options_set(session, SSH_OPTIONS_HOST, host.c_str());

--- a/src/Server/SSH/SSHSession.h
+++ b/src/Server/SSH/SSHSession.h
@@ -30,6 +30,8 @@ public:
 
     /// Disable reading default libssh configuration
     void disableDefaultConfig();
+    /// Disable session from closing socket. Can be used when a socket is passed.
+    void disableSocketOwning();
 
     /// Connect / disconnect
     void connect();


### PR DESCRIPTION
Reverts
- https://github.com/ClickHouse/ClickHouse/pull/90362
- https://github.com/ClickHouse/ClickHouse/pull/90612

because these PRs caused a TSAN error in [a backport PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=90812&sha=latest&name_0=BackportPR):

```

E           Exception: Sanitizer assert found for instance ==================
E           WARNING: ThreadSanitizer: data race (pid=8)
E             Write of size 4 at 0x55f75c825f98 by thread T6:
E               #0 ssh_disconnect ci/tmp/build/./contrib/libssh/src/client.c:817:26 (clickhouse+0x2b5d494c) (BuildId: 16c5c75a5bdcbe68f67a863a6f6512a4d7ce0e80)
E               #1 ssh::SSHSession::disconnect() ci/tmp/build/./src/Server/SSH/SSHSession.cpp:101:5 (clickhouse+0x222cdc61) (BuildId: 16c5c75a5bdcbe68f67a863a6f6512a4d7ce0e80)
E               #2 DB::SSHPtyHandler::~SSHPtyHandler() ci/tmp/build/./src/Server/SSH/SSHPtyHandler.cpp:476:13 (clickhouse+0x222bf3f7) (BuildId: 16c5c75a5bdcbe68f67a863a6f6512a4d7ce0e80)
E               #3 DB::SSHPtyHandler::~SSHPtyHandler() ci/tmp/build/./src/Server/SSH/SSHPtyHandler.cpp:475:1 (clickhouse+0x222bf459) (BuildId: 16c5c75a5bdcbe68f67a863a6f6512a4d7ce0e80)
E               #4 std::__1::default_delete<Poco::Net::TCPServerConnection>::operator()[abi:ne190107](Poco::Net::TCPServerConnection*) const ci/tmp/build/./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:80:5 (clickhouse+0x2b48a4c3) (BuildId: 16c5c75a5bdcbe68f67a863a6f6512a4d7ce0e80)
E               #5 std::__1::unique_ptr<Poco::Net::TCPServerConnection, std::__1::default_delete<Poco::Net::TCPServerConnection>>::reset[abi:ne190107](Poco::Net::TCPServerConnection*) ci/tmp/build/./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:292:7 (clickhouse+0x2b48a4c3)
E               #6 std::__1::unique_ptr<Poco::Net::TCPServerConnection, std::__1::default_delete<Poco::Net::TCPServerConnection>>::~unique_ptr[abi:ne190107]() ci/tmp/build/./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:261:71 (clickhouse+0x2b48a4c3)
E               #7 Poco::Net::TCPServerDispatcher::run() ci/tmp/build/./base/poco/Net/src/TCPServerDispatcher.cpp:116:21 (clickhouse+0x2b48a4c3)
E               #8 Poco::PooledThread::run() ci/tmp/build/./base/poco/Foundation/src/ThreadPool.cpp:205:14 (clickhouse+0x2b3f9150) (BuildId: 16c5c75a5bdcbe68f67a863a6f6512a4d7ce0e80)
E               #9 Poco::(anonymous namespace)::RunnableHolder::run() ci/tmp/build/./base/poco/Foundation/src/Thread.cpp:45:11 (clickhouse+0x2b3f732f) (BuildId: 16c5c75a5bdcbe68f67a863a6f6512a4d7ce0e80)
E               #10 Poco::ThreadImpl::runnableEntry(void*) ci/tmp/build/./base/poco/Foundation/src/Thread_POSIX.cpp:341:27 (clickhouse+0x2b3f5589) (BuildId: 16c5c75a5bdcbe68f67a863a6f6512a4d7ce0e80)
E           
E             Previous write of size 4 at 0x55f75c825f98 by thread T7:
E               #0 ssh_disconnect ci/tmp/build/./contrib/libssh/src/client.c:817:26 (clickhouse+0x2b5d494c) (BuildId: 16c5c75a5bdcbe68f67a863a6f6512a4d7ce0e80)
E               #1 ssh::SSHSession::disconnect() ci/tmp/build/./src/Server/SSH/SSHSession.cpp:101:5 (clickhouse+0x222cdc61) (BuildId: 16c5c75a5bdcbe68f67a863a6f6512a4d7ce0e80)
E               #2 DB::SSHPtyHandler::~SSHPtyHandler() ci/tmp/build/./src/Server/SSH/SSHPtyHandler.cpp:476:13 (clickhouse+0x222bf3f7) (BuildId: 16c5c75a5bdcbe68f67a863a6f6512a4d7ce0e80)
E               #3 DB::SSHPtyHandler::~SSHPtyHandler() ci/tmp/build/./src/Server/SSH/SSHPtyHandler.cpp:475:1 (clickhouse+0x222bf459) (BuildId: 16c5c75a5bdcbe68f67a863a6f6512a4d7ce0e80)
E               #4 std::__1::default_delete<Poco::Net::TCPServerConnection>::operator()[abi:ne190107](Poco::Net::TCPServerConnection*) const ci/tmp/build/./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:80:5 (clickhouse+0x2b48a4c3) (BuildId: 16c5c75a5bdcbe68f67a863a6f6512a4d7ce0e80)
E               #5 std::__1::unique_ptr<Poco::Net::TCPServerConnection, std::__1::default_delete<Poco::Net::TCPServerConnection>>::reset[abi:ne190107](Poco::Net::TCPServerConnection*) ci/tmp/build/./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:292:7 (clickhouse+0x2b48a4c3)
E               #6 std::__1::unique_ptr<Poco::Net::TCPServerConnection, std::__1::default_delete<Poco::Net::TCPServerConnection>>::~unique_ptr[abi:ne190107]() ci/tmp/build/./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:261:71 (clickhouse+0x2b48a4c3)
E               #7 Poco::Net::TCPServerDispatcher::run() ci/tmp/build/./base/poco/Net/src/TCPServerDispatcher.cpp:116:21 (clickhouse+0x2b48a4c3)
E               #8 Poco::PooledThread::run() ci/tmp/build/./base/poco/Foundation/src/ThreadPool.cpp:205:14 (clickhouse+0x2b3f9150) (BuildId: 16c5c75a5bdcbe68f67a863a6f6512a4d7ce0e80)
E               #9 Poco::(anonymous namespace)::RunnableHolder::run() ci/tmp/build/./base/poco/Foundation/src/Thread.cpp:45:11 (clickhouse+0x2b3f732f) (BuildId: 16c5c75a5bdcbe68f67a863a6f6512a4d7ce0e80)
E               #10 Poco::ThreadImpl::runnableEntry(void*) ci/tmp/build/./base/poco/Foundation/src/Thread_POSIX.cpp:341:27 (clickhouse+0x2b3f5589) (BuildId: 16c5c75a5bdcbe68f67a863a6f6512a4d7ce0e80)
```

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)