### PR TITLE
Improve `min_free_disk_bytes_to_perform_insert` for JBOD volumes

### DIFF
--- a/src/Disks/DiskBackup.cpp
+++ b/src/Disks/DiskBackup.cpp
@@ -64,6 +64,11 @@ ReservationPtr DiskBackup::reserve(UInt64)
     throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "DiskBackup does not support reserve method");
 }
 
+ReservationPtr DiskBackup::reserve(UInt64, const ReservationConstraints &)
+{
+    throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "DiskBackup does not support reserve method");
+}
+
 std::optional<UInt64> DiskBackup::getTotalSpace() const
 {
     return backup->getTotalSize();

--- a/src/Disks/DiskBackup.h
+++ b/src/Disks/DiskBackup.h
@@ -42,6 +42,8 @@ public:
 
     ReservationPtr reserve(UInt64 bytes) override;
 
+    ReservationPtr reserve(UInt64 bytes, const ReservationConstraints & constraints) override;
+
     std::optional<UInt64> getTotalSpace() const override;
     std::optional<UInt64> getAvailableSpace() const override;
     std::optional<UInt64> getUnreservedSpace() const override;

--- a/src/Disks/DiskEncrypted.cpp
+++ b/src/Disks/DiskEncrypted.cpp
@@ -350,6 +350,14 @@ ReservationPtr DiskEncrypted::reserve(UInt64 bytes)
     return std::make_unique<DiskEncryptedReservation>(std::static_pointer_cast<DiskEncrypted>(shared_from_this()), std::move(reservation));
 }
 
+ReservationPtr DiskEncrypted::reserve(UInt64 bytes, const ReservationConstraints & constraints)
+{
+    auto reservation = delegate->reserve(bytes, constraints);
+    if (!reservation)
+        return {};
+    return std::make_unique<DiskEncryptedReservation>(std::static_pointer_cast<DiskEncrypted>(shared_from_this()), std::move(reservation));
+}
+
 
 void DiskEncrypted::copyDirectoryContent(
     const String & from_dir,

--- a/src/Disks/DiskEncrypted.h
+++ b/src/Disks/DiskEncrypted.h
@@ -32,6 +32,8 @@ public:
 
     ReservationPtr reserve(UInt64 bytes) override;
 
+    ReservationPtr reserve(UInt64 bytes, const ReservationConstraints & constraints) override;
+
     bool existsFile(const String & path) const override
     {
         auto wrapped_path = wrappedPath(path);

--- a/src/Disks/DiskLocal.cpp
+++ b/src/Disks/DiskLocal.cpp
@@ -150,7 +150,7 @@ private:
 
 ReservationPtr DiskLocal::reserve(UInt64 bytes)
 {
-    auto unreserved_space = tryReserve(bytes);
+    auto unreserved_space = tryReserve(bytes, std::nullopt);
     if (!unreserved_space.has_value())
         return {};
     return std::make_unique<DiskLocalReservation>(
@@ -158,7 +158,17 @@ ReservationPtr DiskLocal::reserve(UInt64 bytes)
         bytes, unreserved_space.value());
 }
 
-std::optional<UInt64> DiskLocal::tryReserve(UInt64 bytes)
+ReservationPtr DiskLocal::reserve(UInt64 bytes, const ReservationConstraints & constraints)
+{
+    auto unreserved_space = tryReserve(bytes, constraints);
+    if (!unreserved_space.has_value())
+        return {};
+    return std::make_unique<DiskLocalReservation>(
+        std::static_pointer_cast<DiskLocal>(shared_from_this()),
+        bytes, unreserved_space.value());
+}
+
+std::optional<UInt64> DiskLocal::tryReserve(UInt64 bytes, const std::optional<ReservationConstraints> & constraints)
 {
     std::lock_guard lock(DiskLocal::reservation_mutex);
 
@@ -167,6 +177,41 @@ std::optional<UInt64> DiskLocal::tryReserve(UInt64 bytes)
     UInt64 unreserved_space = available_space
         ? *available_space - std::min(*available_space, reserved_bytes)
         : std::numeric_limits<UInt64>::max();
+
+    /// Check constraints if specified
+    if (constraints.has_value())
+    {
+        auto total_space = getTotalSpace();
+
+        if (available_space.has_value() && total_space.has_value())
+        {
+            /// Not enough space for reservation itself
+            if (bytes > unreserved_space)
+                return {};
+
+            UInt64 free_bytes_after = unreserved_space - bytes;
+
+            /// Check min_bytes constraint
+            if (constraints->min_bytes > 0 && free_bytes_after < constraints->min_bytes)
+            {
+                LOG_TRACE(logger, "Could not reserve {} on disk {}. Free space after reservation ({}) would be less than min_bytes ({})",
+                    ReadableSize(bytes), backQuote(name), ReadableSize(free_bytes_after), ReadableSize(constraints->min_bytes));
+                return {};
+            }
+
+            /// Check min_ratio constraint
+            if (constraints->min_ratio > 0.0)
+            {
+                UInt64 min_bytes_from_ratio = static_cast<UInt64>(constraints->min_ratio * (*total_space));
+                if (free_bytes_after < min_bytes_from_ratio)
+                {
+                    LOG_TRACE(logger, "Could not reserve {} on disk {}. Free space after reservation ({}) would be less than min_ratio requirement ({})",
+                        ReadableSize(bytes), backQuote(name), ReadableSize(free_bytes_after), ReadableSize(min_bytes_from_ratio));
+                    return {};
+                }
+            }
+        }
+    }
 
     if (bytes == 0)
     {
@@ -201,7 +246,6 @@ std::optional<UInt64> DiskLocal::tryReserve(UInt64 bytes)
     }
 
     LOG_TRACE(logger, "Could not reserve {} on local disk {}. Not enough unreserved space", ReadableSize(bytes), backQuote(name));
-
 
     return {};
 }

--- a/src/Disks/DiskLocal.cpp
+++ b/src/Disks/DiskLocal.cpp
@@ -194,8 +194,8 @@ std::optional<UInt64> DiskLocal::tryReserve(UInt64 bytes, const std::optional<Re
             /// Check min_bytes constraint
             if (constraints->min_bytes > 0 && free_bytes_after < constraints->min_bytes)
             {
-                LOG_TRACE(logger, "Could not reserve {} on disk {}. Free space after reservation ({}) would be less than min_bytes ({})",
-                    ReadableSize(bytes), backQuote(name), ReadableSize(free_bytes_after), ReadableSize(constraints->min_bytes));
+                LOG_TRACE(logger, "Could not reserve {} ({} bytes) on disk {}. Free space after reservation {} bytes ({}) would be less than min_bytes {} bytes ({})",
+                    ReadableSize(bytes), bytes, backQuote(name), free_bytes_after, ReadableSize(free_bytes_after), constraints->min_bytes, ReadableSize(constraints->min_bytes));
                 return {};
             }
 
@@ -205,8 +205,8 @@ std::optional<UInt64> DiskLocal::tryReserve(UInt64 bytes, const std::optional<Re
                 UInt64 min_bytes_from_ratio = static_cast<UInt64>(constraints->min_ratio * (*total_space));
                 if (free_bytes_after < min_bytes_from_ratio)
                 {
-                    LOG_TRACE(logger, "Could not reserve {} on disk {}. Free space after reservation ({}) would be less than min_ratio requirement ({})",
-                        ReadableSize(bytes), backQuote(name), ReadableSize(free_bytes_after), ReadableSize(min_bytes_from_ratio));
+                    LOG_TRACE(logger, "Could not reserve {} ({} bytes) on disk {}. Free space after reservation {} bytes ({}) would be less than min_ratio requirement {} bytes ({}) (ratio: {}, total: {} bytes)",
+                        ReadableSize(bytes), bytes, backQuote(name), free_bytes_after, ReadableSize(free_bytes_after), min_bytes_from_ratio, ReadableSize(min_bytes_from_ratio), constraints->min_ratio, *total_space);
                     return {};
                 }
             }

--- a/src/Disks/DiskLocal.h
+++ b/src/Disks/DiskLocal.h
@@ -36,6 +36,8 @@ public:
 
     ReservationPtr reserve(UInt64 bytes) override;
 
+    ReservationPtr reserve(UInt64 bytes, const ReservationConstraints & constraints) override;
+
     std::optional<UInt64> getTotalSpace() const override;
     std::optional<UInt64> getAvailableSpace() const override;
     std::optional<UInt64> getUnreservedSpace() const override;
@@ -159,7 +161,7 @@ protected:
     void checkAccessImpl(const String & path) override;
 
 private:
-    std::optional<UInt64> tryReserve(UInt64 bytes);
+    std::optional<UInt64> tryReserve(UInt64 bytes, const std::optional<ReservationConstraints> & constraints = std::nullopt);
 
     /// Setup disk for healthy check.
     /// Throw exception if it's not possible to setup necessary files and directories.

--- a/src/Disks/DiskObjectStorage/DiskObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/DiskObjectStorage.cpp
@@ -471,11 +471,96 @@ void DiskObjectStorage::startupImpl()
 
 ReservationPtr DiskObjectStorage::reserve(UInt64 bytes)
 {
-    if (!tryReserve(bytes))
+    if (!tryReserve(bytes, std::nullopt))
         return {};
 
     return std::make_unique<DiskObjectStorageReservation>(
         std::static_pointer_cast<DiskObjectStorage>(shared_from_this()), bytes);
+}
+
+ReservationPtr DiskObjectStorage::reserve(UInt64 bytes, const ReservationConstraints & constraints)
+{
+    if (!tryReserve(bytes, constraints))
+        return {};
+
+    return std::make_unique<DiskObjectStorageReservation>(
+        std::static_pointer_cast<DiskObjectStorage>(shared_from_this()), bytes);
+}
+
+bool DiskObjectStorage::tryReserve(UInt64 bytes, const std::optional<ReservationConstraints> & constraints)
+{
+    std::lock_guard lock(reservation_mutex);
+
+    auto available_space = getAvailableSpace();
+
+    /// Check constraints if specified
+    if (constraints.has_value())
+    {
+        auto total_space = getTotalSpace();
+
+        if (available_space.has_value() && total_space.has_value())
+        {
+            UInt64 unreserved_space = *available_space - std::min(*available_space, reserved_bytes);
+
+            /// Not enough space for reservation itself
+            if (bytes > unreserved_space)
+                return false;
+
+            UInt64 free_bytes_after = unreserved_space - bytes;
+
+            /// Check min_bytes constraint
+            if (constraints->min_bytes > 0 && free_bytes_after < constraints->min_bytes)
+            {
+                LOG_TRACE(log, "Could not reserve {} on disk {}. Free space after reservation ({}) would be less than min_bytes ({})",
+                    ReadableSize(bytes), backQuote(name), ReadableSize(free_bytes_after), ReadableSize(constraints->min_bytes));
+                return false;
+            }
+
+            /// Check min_ratio constraint
+            if (constraints->min_ratio > 0.0)
+            {
+                UInt64 min_bytes_from_ratio = static_cast<UInt64>(constraints->min_ratio * (*total_space));
+                if (free_bytes_after < min_bytes_from_ratio)
+                {
+                    LOG_TRACE(log, "Could not reserve {} on disk {}. Free space after reservation ({}) would be less than min_ratio requirement ({})",
+                        ReadableSize(bytes), backQuote(name), ReadableSize(free_bytes_after), ReadableSize(min_bytes_from_ratio));
+                    return false;
+                }
+            }
+        }
+    }
+
+    if (!available_space)
+    {
+        ++reservation_count;
+        reserved_bytes += bytes;
+        return true;
+    }
+
+    UInt64 unreserved_space = *available_space - std::min(*available_space, reserved_bytes);
+
+    if (bytes == 0)
+    {
+        LOG_TRACE(log, "Reserved 0 bytes on remote disk {}", backQuote(name));
+        ++reservation_count;
+        return true;
+    }
+
+    if (unreserved_space >= bytes)
+    {
+        LOG_TRACE(
+            log,
+            "Reserved {} on remote disk {}, having unreserved {}.",
+            ReadableSize(bytes),
+            backQuote(name),
+            ReadableSize(unreserved_space));
+        ++reservation_count;
+        reserved_bytes += bytes;
+        return true;
+    }
+
+    LOG_TRACE(log, "Could not reserve {} on remote disk {}. Not enough unreserved space", ReadableSize(bytes), backQuote(name));
+    return false;
 }
 
 void DiskObjectStorage::removeSharedFileIfExists(const String & path, bool delete_metadata_only)
@@ -550,46 +635,6 @@ void DiskObjectStorage::removeSharedRecursiveWithLimit(
 
     traverse_metadata_recursive(path);
     remove();
-}
-
-bool DiskObjectStorage::tryReserve(UInt64 bytes)
-{
-    std::lock_guard lock(reservation_mutex);
-
-    auto available_space = getAvailableSpace();
-    if (!available_space)
-    {
-        ++reservation_count;
-        reserved_bytes += bytes;
-        return true;
-    }
-
-    UInt64 unreserved_space = *available_space - std::min(*available_space, reserved_bytes);
-
-    if (bytes == 0)
-    {
-        LOG_TRACE(log, "Reserved 0 bytes on remote disk {}", backQuote(name));
-        ++reservation_count;
-        return true;
-    }
-
-    if (unreserved_space >= bytes)
-    {
-        LOG_TRACE(
-            log,
-            "Reserved {} on remote disk {}, having unreserved {}.",
-            ReadableSize(bytes),
-            backQuote(name),
-            ReadableSize(unreserved_space));
-        ++reservation_count;
-        reserved_bytes += bytes;
-        return true;
-    }
-
-    LOG_TRACE(log, "Could not reserve {} on remote disk {}. Not enough unreserved space", ReadableSize(bytes), backQuote(name));
-
-
-    return false;
 }
 
 bool DiskObjectStorage::supportsCache() const

--- a/src/Disks/DiskObjectStorage/DiskObjectStorage.h
+++ b/src/Disks/DiskObjectStorage/DiskObjectStorage.h
@@ -147,6 +147,8 @@ public:
 
     ReservationPtr reserve(UInt64 bytes) override;
 
+    ReservationPtr reserve(UInt64 bytes, const ReservationConstraints & constraints) override;
+
     std::unique_ptr<ReadBufferFromFileBase> readFile(
         const String & path,
         const ReadSettings & settings,
@@ -256,7 +258,7 @@ private:
     UInt64 reservation_count = 0;
     std::mutex reservation_mutex;
 
-    bool tryReserve(UInt64 bytes);
+    bool tryReserve(UInt64 bytes, const std::optional<ReservationConstraints> & constraints = std::nullopt);
     void sendMoveMetadata(const String & from_path, const String & to_path);
 
     mutable std::mutex resource_mutex;

--- a/src/Disks/IDisk.h
+++ b/src/Disks/IDisk.h
@@ -75,6 +75,20 @@ using ObjectAttributes = std::map<std::string, std::string>;
 struct PartitionCommand;
 
 /**
+ * Constraints for disk space reservation to avoid filling up disks.
+ */
+struct ReservationConstraints
+{
+    /// Min free bytes that must remain on the disk after reservation
+    UInt64 min_bytes = 0;
+    /// Min free space ratio that must remain on the disk after reservation
+    Float32 min_ratio = 0.0;
+
+    ReservationConstraints(UInt64 min_bytes_, Float32 min_ratio_)
+        : min_bytes(min_bytes_), min_ratio(min_ratio_) {}
+};
+
+/**
  * Provide interface for reservation.
  */
 class Space : public std::enable_shared_from_this<Space>
@@ -86,6 +100,10 @@ public:
     /// Reserve the specified number of bytes.
     /// Returns valid reservation or nullptr when failure.
     virtual ReservationPtr reserve(UInt64 bytes) = 0;
+
+    /// Reserve the specified number of bytes with constraints.
+    /// Returns valid reservation or nullptr when failure (including when constraints are not met).
+    virtual ReservationPtr reserve(UInt64 bytes, const ReservationConstraints & constraints) = 0;
 
     /// Whether this is a disk or a volume.
     virtual bool isDisk() const { return false; }

--- a/src/Disks/IVolume.h
+++ b/src/Disks/IVolume.h
@@ -66,6 +66,8 @@ public:
 
     ReservationPtr reserve(UInt64 bytes) override = 0;
 
+    ReservationPtr reserve(UInt64 bytes, const ReservationConstraints & constraints) override = 0;
+
     /// This is a volume.
     bool isVolume() const override { return true; }
 

--- a/src/Disks/ReadOnlyDiskWrapper.h
+++ b/src/Disks/ReadOnlyDiskWrapper.h
@@ -107,6 +107,7 @@ public:
     void removeFile(const String &) override { throwNotAllowed(); }
     void removeFileIfExists(const String &) override { throwNotAllowed(); }
     ReservationPtr reserve(UInt64 /*bytes*/) override { throwNotAllowed(); }
+    ReservationPtr reserve(UInt64 /*bytes*/, const ReservationConstraints & /*constraints*/) override { throwNotAllowed(); }
     void removeRecursive(const String &) override { throwNotAllowed(); }
     void removeSharedFile(const String &, bool) override { throwNotAllowed(); }
     void removeSharedFileIfExists(const String &, bool) override { throwNotAllowed(); }

--- a/src/Disks/SingleDiskVolume.h
+++ b/src/Disks/SingleDiskVolume.h
@@ -19,6 +19,13 @@ public:
         return disks[0]->reserve(bytes);
     }
 
+    ReservationPtr reserve(UInt64 bytes, const ReservationConstraints & constraints) override
+    {
+        if (disks[0]->isReadOnly())
+            return {};
+        return disks[0]->reserve(bytes, constraints);
+    }
+
     VolumeType getType() const override { return VolumeType::SINGLE_DISK; }
 
 };

--- a/src/Disks/VolumeJBOD.h
+++ b/src/Disks/VolumeJBOD.h
@@ -62,6 +62,10 @@ public:
     /// Returns valid reservation or nullptr if there is no space left on any disk.
     ReservationPtr reserve(UInt64 bytes) override;
 
+    /// Reserve with constraints. Checks free space requirements before making reservation.
+    /// Returns valid reservation or nullptr if constraints are not met on any disk.
+    ReservationPtr reserve(UInt64 bytes, const ReservationConstraints & constraints) override;
+
     bool areMergesAvoided() const override;
 
     void setAvoidMergesUserOverride(bool avoid) override;
@@ -70,6 +74,8 @@ public:
     bool are_merges_avoided = true;
 
 private:
+    ReservationPtr reserveImpl(UInt64 bytes, const std::optional<ReservationConstraints> & constraints);
+
     struct DiskWithSize
     {
         DiskPtr disk;

--- a/src/Storages/MergeTree/MergeTreeDataWriter.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataWriter.cpp
@@ -759,11 +759,12 @@ MergeTreeTemporaryPartPtr MergeTreeDataWriter::writeTempPartImpl(
             throw Exception(
                 ErrorCodes::NOT_ENOUGH_SPACE,
                 "Could not perform insert. "
-                "None of the disks in volume have enough free space to meet the configured threshold. "
+                "None of the disks in volume '{}' have enough free space to meet the configured threshold. "
                 "The threshold can be configured either in MergeTree settings or User settings, "
                 "using the following settings: "
                 "(1) `min_free_disk_bytes_to_perform_insert` = {} "
                 "(2) `min_free_disk_ratio_to_perform_insert` = {}",
+                volume->getName(),
                 min_bytes_to_perform_insert,
                 min_ratio_to_perform_insert);
         }

--- a/src/Storages/MergeTree/MergeTreeDataWriter.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataWriter.cpp
@@ -758,6 +758,7 @@ MergeTreeTemporaryPartPtr MergeTreeDataWriter::writeTempPartImpl(
         {
             throw Exception(
                 ErrorCodes::NOT_ENOUGH_SPACE,
+                "Could not perform insert. "
                 "None of the disks in volume have enough free space to meet the configured threshold. "
                 "The threshold can be configured either in MergeTree settings or User settings, "
                 "using the following settings: "

--- a/src/Storages/MergeTree/MergeTreeDataWriter.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataWriter.cpp
@@ -784,7 +784,8 @@ MergeTreeTemporaryPartPtr MergeTreeDataWriter::writeTempPartImpl(
         first_failed_disk = primary_disk;
 
         const auto & disks = volume->getDisks();
-        if (!primary_disk_suitable && disks.size() > 1) {
+        if (!primary_disk_suitable && disks.size() > 1)
+        {
 
             for (const auto & disk : disks)
             {
@@ -822,6 +823,11 @@ MergeTreeTemporaryPartPtr MergeTreeDataWriter::writeTempPartImpl(
                 backQuote(first_failed_disk->getName()),
                 formatReadableSizeWithBinarySuffix(first_failed_disk_info.total_bytes));
         }
+    }
+    else
+    {
+        /// No free space check needed, use default reservation
+        reservation = data.reserveSpacePreferringTTLRules(metadata_snapshot, expected_size, move_ttl_infos, time(nullptr), 0, true);
     }
 
     VolumePtr data_part_volume = createVolumeFromReservation(reservation, volume);

--- a/tests/integration/test_stop_insert_when_disk_close_to_full/configs/config.d/storage_configuration.xml
+++ b/tests/integration/test_stop_insert_when_disk_close_to_full/configs/config.d/storage_configuration.xml
@@ -5,6 +5,16 @@
                 <type>local</type>
                 <path>/test_stop_insert_when_disk1/</path>
             </disk1>
+            <jbod_disk1>
+                <type>local</type>
+                <path>/jbod_disk1/</path>
+                <priority>1</priority>
+            </jbod_disk1>
+            <jbod_disk2>
+                <type>local</type>
+                <path>/jbod_disk2/</path>
+                <priority>2</priority>
+            </jbod_disk2>
         </disks>
         <policies>
             <only_disk1>
@@ -14,6 +24,14 @@
                     </main>
                 </volumes>
             </only_disk1>
+            <jbod_policy>
+                <volumes>
+                    <main>
+                        <disk>jbod_disk1</disk>
+                        <disk>jbod_disk2</disk>
+                    </main>
+                </volumes>
+            </jbod_policy>
         </policies>
     </storage_configuration>
 </clickhouse>

--- a/tests/integration/test_stop_insert_when_disk_close_to_full/test.py
+++ b/tests/integration/test_stop_insert_when_disk_close_to_full/test.py
@@ -125,8 +125,9 @@ def test_insert_stops_when_disk_full(start_cluster):
         msg = str(e)
         assert any(
             s in msg
-            for s in ("Could not perform insert", "Cannot reserve", "NOT_ENOUGH_SPACE", "None of the disks in volume have enough free space")
+            for s in ("Could not perform insert", "Cannot reserve", "NOT_ENOUGH_SPACE")
         )
+        assert "None of the disks in volume 'main' have enough free space" in msg
 
     free_space = int(
         node.query("SELECT free_space FROM system.disks WHERE name = 'disk1'").strip()

--- a/tests/integration/test_stop_insert_when_disk_close_to_full/test.py
+++ b/tests/integration/test_stop_insert_when_disk_close_to_full/test.py
@@ -125,9 +125,8 @@ def test_insert_stops_when_disk_full(start_cluster):
         msg = str(e)
         assert any(
             s in msg
-            for s in ("Could not perform insert", "Cannot reserve", "NOT_ENOUGH_SPACE")
+            for s in ("Could not perform insert", "Cannot reserve", "NOT_ENOUGH_SPACE", "None of the disks in volume have enough free space")
         )
-        assert "The amount of free space" in msg or "not enough space" in msg.lower()
 
     free_space = int(
         node.query("SELECT free_space FROM system.disks WHERE name = 'disk1'").strip()
@@ -183,7 +182,7 @@ def test_jbod_disk_failover(start_cluster):
     count = 0
     jbod_disk1_free = 0
 
-    for i in range(100000):
+    for i in range(10000):
         jbod_disk1_free = int(
             node_jbod.query(
                 "SELECT free_space FROM system.disks WHERE name = 'jbod_disk1'"

--- a/tests/integration/test_stop_insert_when_disk_close_to_full/test.py
+++ b/tests/integration/test_stop_insert_when_disk_close_to_full/test.py
@@ -181,6 +181,7 @@ def test_jbod_disk_failover(start_cluster):
 
     count = 0
     jbod_disk1_free = 0
+    approx_one_insert_reservation = 15 * 1024
 
     for i in range(10000):
         jbod_disk1_free = int(
@@ -189,7 +190,7 @@ def test_jbod_disk_failover(start_cluster):
             ).strip()
         )
 
-        if jbod_disk1_free < min_free_bytes:
+        if jbod_disk1_free < (min_free_bytes + approx_one_insert_reservation):
             break
 
         try:
@@ -207,8 +208,8 @@ def test_jbod_disk_failover(start_cluster):
     )
 
     assert (
-        jbod_disk1_free < min_free_bytes
-    ), f"jbod_disk1 should be below threshold: {jbod_disk1_free} < {min_free_bytes}"
+        jbod_disk1_free < (min_free_bytes + approx_one_insert_reservation)
+    ), f"jbod_disk1 should be below threshold: {jbod_disk1_free} < {min_free_bytes + approx_one_insert_reservation}"
     assert (
         jbod_disk2_free > min_free_bytes
     ), f"jbod_disk2 should be above threshold: {jbod_disk2_free} > {min_free_bytes}"
@@ -242,8 +243,8 @@ def test_jbod_disk_failover(start_cluster):
         ).strip()
     )
     assert (
-        jbod_disk1_free_after < min_free_bytes
-    ), f"jbod_disk1 should still be below threshold ({jbod_disk1_free_after} < {min_free_bytes})"
+        jbod_disk1_free_after < (min_free_bytes + approx_one_insert_reservation)
+    ), f"jbod_disk1 should still be below threshold ({jbod_disk1_free_after} < {min_free_bytes + approx_one_insert_reservation})"
     # Allow small difference due to metadata
     assert (
         abs(jbod_disk1_free_after - jbod_disk1_free) < 100 * 1024


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Improve `min_free_disk_bytes_to_perform_insert` setting to work correctly with JBOD volumes. 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

### Details

Currently, when using JBOD volumes with multiple disks, the `min_free_disk_bytes_to_perform_insert` check only validates a single disk. This causes inconsistent insert behavior: the same insert query may randomly succeed or fail depending on which disk the load balancer selects. When one disk is nearly full but others have space, inserts become unpredictable and fail unnecessarily.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.794`
<!-- ch-version-info:end -->