### PR TITLE
Fix background flush of Buffer in case of frequent INSERTs

### DIFF
--- a/src/Storages/StorageBuffer.cpp
+++ b/src/Storages/StorageBuffer.cpp
@@ -139,6 +139,11 @@ StoragePtr StorageBuffer::getDestinationTable() const
 }
 
 
+std::string StorageBuffer::Thresholds::toString() const
+{
+    return fmt::format("time={}, rows={}, bytes={}", time, rows, bytes);
+}
+
 StorageBuffer::StorageBuffer(
     const StorageID & table_id_,
     const ColumnsDescription & columns_,
@@ -183,6 +188,8 @@ StorageBuffer::StorageBuffer(
             num_shards, 0, num_shards);
     }
     flush_handle = bg_pool.createTask(log->name() + "/Bg", [this]{ backgroundFlush(); });
+
+    LOG_TRACE(log, "Buffer(flush: ({}), min: ({}), max: ({}))", flush_thresholds.toString(), min_thresholds.toString(), max_thresholds.toString());
 }
 
 
@@ -1120,6 +1127,7 @@ void StorageBuffer::reschedule()
 {
     time_t min_first_write_time = std::numeric_limits<time_t>::max();
     size_t rows = 0;
+    size_t processed_buffers = 0;
 
     for (auto & buffer : buffers)
     {
@@ -1135,6 +1143,7 @@ void StorageBuffer::reschedule()
         std::unique_lock lock(buffer.tryLock());
         if (lock.owns_lock())
         {
+            ++processed_buffers;
             if (!buffer.data.empty())
             {
                 min_first_write_time = std::min(min_first_write_time, buffer.first_write_time);
@@ -1145,22 +1154,28 @@ void StorageBuffer::reschedule()
 
     /// will be rescheduled via INSERT
     if (!rows)
+    {
+        LOG_TRACE(log, "Skipping reschedule (processed buffers: {})", processed_buffers);
         return;
+    }
 
     time_t current_time = time(nullptr);
     time_t time_passed = current_time - min_first_write_time;
 
     size_t min = std::max<ssize_t>(min_thresholds.time - time_passed, 1);
     size_t max = std::max<ssize_t>(max_thresholds.time - time_passed, 1);
+    size_t reschedule_sec = 0;
     if (flush_thresholds.time)
     {
         size_t flush = std::max<ssize_t>(flush_thresholds.time - time_passed, 1);
-        flush_handle->scheduleAfter(std::min({min, max, flush}) * 1000);
+        reschedule_sec = std::min({min, max, flush});
     }
     else
     {
-        flush_handle->scheduleAfter(std::min({min, max}) * 1000);
+        reschedule_sec = std::min({min, max});
     }
+    flush_handle->scheduleAfter(reschedule_sec * 1000);
+    LOG_TRACE(log, "Reschedule in {} sec (processed buffers: {}, rows in processed buffers: {}, time passed: {})", reschedule_sec, processed_buffers, rows, time_passed);
 }
 
 void StorageBuffer::checkAlterIsPossible(const AlterCommands & commands, ContextPtr local_context) const

--- a/src/Storages/StorageBuffer.cpp
+++ b/src/Storages/StorageBuffer.cpp
@@ -1152,8 +1152,15 @@ void StorageBuffer::reschedule()
 
     size_t min = std::max<ssize_t>(min_thresholds.time - time_passed, 1);
     size_t max = std::max<ssize_t>(max_thresholds.time - time_passed, 1);
-    size_t flush = std::max<ssize_t>(flush_thresholds.time - time_passed, 1);
-    flush_handle->scheduleAfter(std::min({min, max, flush}) * 1000);
+    if (flush_thresholds.time)
+    {
+        size_t flush = std::max<ssize_t>(flush_thresholds.time - time_passed, 1);
+        flush_handle->scheduleAfter(std::min({min, max, flush}) * 1000);
+    }
+    else
+    {
+        flush_handle->scheduleAfter(std::min({min, max}) * 1000);
+    }
 }
 
 void StorageBuffer::checkAlterIsPossible(const AlterCommands & commands, ContextPtr local_context) const

--- a/src/Storages/StorageBuffer.cpp
+++ b/src/Storages/StorageBuffer.cpp
@@ -1119,7 +1119,7 @@ void StorageBuffer::backgroundFlush()
 void StorageBuffer::reschedule()
 {
     time_t min_first_write_time = std::numeric_limits<time_t>::max();
-    time_t rows = 0;
+    size_t rows = 0;
 
     for (auto & buffer : buffers)
     {

--- a/src/Storages/StorageBuffer.h
+++ b/src/Storages/StorageBuffer.h
@@ -52,6 +52,8 @@ public:
         time_t time = 0;  /// The number of seconds from the insertion of the first row into the block.
         size_t rows = 0;  /// The number of rows in the block.
         size_t bytes = 0; /// The number of (uncompressed) bytes in the block.
+
+        std::string toString() const;
     };
 
     /** num_shards - the level of internal parallelism (the number of independent buffers)


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix background flush of Buffer in case of frequent INSERTs

The problem was that we always schedule the task in 1 second, and it
never scheduled, because INSERTs are frequent.

Simple repo:

    CREATE TABLE default.buffer (`key` Int32) ENGINE = Buffer('default', 'data', 4, 5, 30, 100000, 1000000, 10000000000., 10000000000., 15);
    CREATE TABLE default.data (`key` Int32) ENGINE = `Null`

And run benchmark:

    clickhouse-benchmark -q "insert into buffer values (1)"

And you will see logs like:

    Reschedule at 1 sec (processed buffers: 4, rows in processed buffers: 13859, time passed: 15)
    ...
    Reschedule at 1 sec (processed buffers: 4, rows in processed buffers: 27738, time passed: 38)
    Flushing buffer with 6934 rows, 27736 bytes, age 38 seconds, took 0 ms (direct).

While with this patch:

    2025-11-26 14:25:30.001781 Flushing buffer with 3311 rows, 13244 bytes, age 16 seconds, took 0 ms (bg).
    2025-11-26 14:25:46.000809 Flushing buffer with 3603 rows, 14412 bytes, age 16 seconds, took 0 ms (bg).