### PR TITLE
Clear vector index cache when table is dropped

### DIFF
--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -468,6 +468,14 @@ void IMergeTreeDataPart::removeIndexFromCache(PrimaryIndexCache * index_cache) c
     index_cache->remove(key);
 }
 
+void IMergeTreeDataPart::removeFromVectorIndexCache(VectorSimilarityIndexCache * vector_similarity_index_cache) const
+{
+    if (!vector_similarity_index_cache)
+        return;
+
+    vector_similarity_index_cache->removeEntriesFromCache(getRelativePathOfActivePart());
+}
+
 void IMergeTreeDataPart::setIndex(Columns index_columns)
 {
     std::scoped_lock lock(index_mutex);
@@ -692,6 +700,9 @@ void IMergeTreeDataPart::clearCaches()
     /// even if the overall index size is much less.
     removeMarksFromCache(storage.getContext()->getMarkCache().get());
     removeIndexFromCache(storage.getPrimaryIndexCache().get());
+
+    /// Remove from other caches of secondary indexes
+    removeFromVectorIndexCache(storage.getContext()->getVectorSimilarityIndexCache().get());
 }
 
 bool IMergeTreeDataPart::mayStoreDataInCaches() const

--- a/src/Storages/MergeTree/IMergeTreeDataPart.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.h
@@ -23,6 +23,7 @@
 #include <Storages/MergeTree/KeyCondition.h>
 #include <Storages/MergeTree/MergeTreeDataPartBuilder.h>
 #include <Storages/MergeTree/ColumnsSubstreams.h>
+#include <Storages/MergeTree/VectorSimilarityIndexCache.h>
 #include <Storages/ColumnsDescription.h>
 #include <Interpreters/TransactionVersionMetadata.h>
 #include <DataTypes/Serializations/SerializationInfo.h>
@@ -390,6 +391,8 @@ public:
     IndexPtr loadIndexToCache(PrimaryIndexCache & index_cache) const;
     void moveIndexToCache(PrimaryIndexCache & index_cache);
     void removeIndexFromCache(PrimaryIndexCache * index_cache) const;
+
+    void removeFromVectorIndexCache(VectorSimilarityIndexCache * vector_similarity_index_cache) const;
 
     void setIndex(Columns index_columns);
     void unloadIndex();

--- a/src/Storages/MergeTree/MergeTreeIndexReader.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexReader.cpp
@@ -165,10 +165,9 @@ void MergeTreeIndexReader::read(size_t mark, const IMergeTreeIndexCondition * co
     /// would create too much lock contention in the cache (this was learned the hard way).
     if (index->isVectorSimilarityIndex())
     {
-        UInt128 key = VectorSimilarityIndexCache::hash(
-            part->getDataPartStorage().getFullPath(),
-            index->getFileName(),
-            mark);
+        VectorSimilarityIndexCacheKey key{part->getDataPartStorage().getFullPath(),
+                                          index->getFileName(),
+                                          mark};
 
         granule = vector_similarity_index_cache->getOrSet(key, load_func);
     }

--- a/tests/queries/0_stateless/02354_vector_search_drop_table_clear_cache.reference
+++ b/tests/queries/0_stateless/02354_vector_search_drop_table_clear_cache.reference
@@ -1,0 +1,22 @@
+5
+6
+7
+Expression (Project names)
+  LazilyRead (Lazily Read)
+    Limit (preliminary LIMIT)
+      Sorting (Sorting for ORDER BY)
+        Expression ((Before ORDER BY + (Projection + Change column names to column identifiers)))
+          ReadFromMergeTree (default.tab)
+          Indexes:
+            PrimaryKey
+              Condition: true
+              Parts: 1/1
+              Granules: 1/1
+            Skip
+              Name: idx
+              Description: vector_similarity GRANULARITY 100000000
+              Parts: 1/1
+              Granules: 1/1
+            Ranges: 1
+VectorSimilarityIndexCacheBytes	Good
+VectorSimilarityIndexCacheBytes	0

--- a/tests/queries/0_stateless/02354_vector_search_drop_table_clear_cache.sql
+++ b/tests/queries/0_stateless/02354_vector_search_drop_table_clear_cache.sql
@@ -1,0 +1,42 @@
+-- Tags: no-fasttest, no-ordinary-database, no-parallel, no-parallel-replicas
+-- no-parallel: Vector index cache should not be touched by another test
+-- no-parallel-replicas: EXPLAIN plan stability
+
+-- Verify that vector similarity index cache is cleared when table with vector index is dropped.
+
+SET enable_analyzer = 1;
+SET parallel_replicas_local_plan = 1; -- this setting is randomized, set it explicitly to force local plan for parallel replicas
+
+DROP TABLE IF EXISTS tab;
+
+SYSTEM DROP VECTOR SIMILARITY INDEX CACHE;
+
+CREATE TABLE tab(id Int32, vec Array(Float32), INDEX idx vec TYPE vector_similarity('hnsw', 'L2Distance', 2)) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 8192;
+INSERT INTO tab VALUES (0, [1.0, 0.0]), (1, [1.1, 0.0]), (2, [1.2, 0.0]), (3, [1.3, 0.0]), (4, [1.4, 0.0]), (5, [0.0, 2.0]), (6, [0.0, 2.1]), (7, [0.0, 2.2]), (8, [0.0, 2.3]), (9, [0.0, 2.4]);
+
+-- Make sure vector index is loaded and used
+WITH [0.0, 2.0] AS reference_vec
+SELECT id
+FROM tab
+ORDER BY L2Distance(vec, reference_vec)
+LIMIT 3;
+
+EXPLAIN indexes = 1
+WITH [0.0, 2.0] AS reference_vec
+SELECT id, vec, L2Distance(vec, reference_vec)
+FROM tab
+ORDER BY L2Distance(vec, reference_vec)
+LIMIT 3;
+
+-- Make sure vector index cache is utilized.
+SELECT name, IF(value > 0, 'Good', 'Zero') FROM system.metrics where name like '%VectorSimilarityIndexCacheBytes%';
+
+-- SYNC is important to drop the table/parts/caches immediately
+DROP TABLE tab SYNC;
+
+-- Should be 0
+SELECT name, value FROM system.metrics where name like '%VectorSimilarityIndexCacheBytes%';
+
+-- ALTER TABLE ... DROP INDEX <vector index> and MERGE PARTS will also clear
+-- any corresponding loaded granules in the vector index cache. These happen
+-- in the background as mutations and unused parts are deleted after "old_parts_lifetime"


### PR DESCRIPTION
This is a re-submit of https://github.com/ClickHouse/ClickHouse/pull/90750 which was reverted by https://github.com/ClickHouse/ClickHouse/pull/90898

@shankar-iyer 

### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Entries in the vector similarity index cache are now removed when table parts are dropped or replaced by newer parts. Prior to this, these would be cleared only lazily by cache eviction.