### PR TITLE
update statistics format version to avoid incompability

### DIFF
--- a/src/Storages/Statistics/Statistics.cpp
+++ b/src/Storages/Statistics/Statistics.cpp
@@ -38,6 +38,7 @@ namespace ErrorCodes
 enum StatisticsFileVersion : UInt16
 {
     V0 = 0,
+    V1 = 1, /// modify the format of uniq, https://github.com/ClickHouse/ClickHouse/pull/90311
 };
 
 std::optional<Float64> StatisticsUtils::tryConvertToFloat64(const Field & value, const DataTypePtr & data_type)
@@ -231,7 +232,7 @@ Estimate ColumnStatistics::getEstimate() const
 
 void ColumnStatistics::serialize(WriteBuffer & buf)
 {
-    writeIntBinary(V0, buf);
+    writeIntBinary(V1, buf);
 
     UInt64 stat_types_mask = 0;
     for (const auto & [type, _]: stats)
@@ -250,7 +251,7 @@ void ColumnStatistics::deserialize(ReadBuffer &buf)
 {
     UInt16 version;
     readIntBinary(version, buf);
-    if (version != V0)
+    if (version != V1)
         throw Exception(ErrorCodes::CORRUPTED_DATA, "Unknown file format version: {}", version);
 
     UInt64 stat_types_mask = 0;

--- a/src/Storages/Statistics/Statistics.cpp
+++ b/src/Storages/Statistics/Statistics.cpp
@@ -252,7 +252,7 @@ void ColumnStatistics::deserialize(ReadBuffer &buf)
     UInt16 version;
     readIntBinary(version, buf);
     if (version != V1)
-        throw Exception(ErrorCodes::CORRUPTED_DATA, "Unknown file format version: {}", version);
+        throw Exception(ErrorCodes::CORRUPTED_DATA, "Unknown file format version: {}. We should run `ALTER TABLE [db.]table MATERIALIZE STATISTICS ALL` to regenerate the statistics", version);
 
     UInt64 stat_types_mask = 0;
     readIntBinary(stat_types_mask, buf);

--- a/src/Storages/Statistics/Statistics.cpp
+++ b/src/Storages/Statistics/Statistics.cpp
@@ -28,7 +28,6 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;
-    extern const int CORRUPTED_DATA;
     extern const int ILLEGAL_STATISTICS;
     extern const int INCORRECT_QUERY;
     extern const int LOGICAL_ERROR;
@@ -251,8 +250,9 @@ void ColumnStatistics::deserialize(ReadBuffer &buf)
 {
     UInt16 version;
     readIntBinary(version, buf);
+    /// TODO: we should check the version of statistics format when we start clickhouse server, and do materialize statistics automatically.
     if (version != V1)
-        throw Exception(ErrorCodes::CORRUPTED_DATA, "Unknown file format version: {}. We should run `ALTER TABLE [db.]table MATERIALIZE STATISTICS ALL` to regenerate the statistics", version);
+        throw Exception(ErrorCodes::ILLEGAL_STATISTICS, "We try to read stale file format version: {}. Please run `ALTER TABLE [db.]table MATERIALIZE STATISTICS ALL` to regenerate the statistics", version);
 
     UInt64 stat_types_mask = 0;
     readIntBinary(stat_types_mask, buf);


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement



### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Due to https://github.com/ClickHouse/ClickHouse/pull/90311 , the format of statisticis has changed, the server will crash if we have statistics with old format. This PR will fix the crash, and throw exception when the existing statisticis uses legacy format. To avoid exception, we should run `ALTER TABLE [db.]table MATERIALIZE STATISTICS ALL` to regenerate the statistics` to fix it.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
