### PR TITLE
Mark 02346_text_index_function_hasAnyAllTokens as long

### DIFF
--- a/tests/queries/0_stateless/02346_text_index_function_hasAnyAllTokens.sql
+++ b/tests/queries/0_stateless/02346_text_index_function_hasAnyAllTokens.sql
@@ -1,4 +1,4 @@
--- Tags: no-parallel-replicas
+-- Tags: no-parallel-replicas, long
 
 SET enable_analyzer = 1;
 SET use_query_condition_cache = 0;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


[cidb](https://play.clickhouse.com/play?user=play&run=1#V0lUSAogICAgOTAgQVMgaW50ZXJ2YWxfZGF5cwpTRUxFQ1QKICAgIHRvU3RhcnRPZkRheShjaGVja19zdGFydF90aW1lKSBBUyBkYXksCiAgICBjb3VudCgpIEFTIGZhaWx1cmVzLAogICAgZ3JvdXBVbmlxQXJyYXkocHVsbF9yZXF1ZXN0X251bWJlcikgQVMgcHJzLAogICAgYW55KHJlcG9ydF91cmwpIEFTIHJlcG9ydF91cmwKRlJPTSBjaGVja3MKV0hFUkUgKG5vdygpIC0gdG9JbnRlcnZhbERheShpbnRlcnZhbF9kYXlzKSkgPD0gY2hlY2tfc3RhcnRfdGltZQogICAgQU5EIHRlc3RfbmFtZSA9ICcwMjM0Nl90ZXh0X2luZGV4X2Z1bmN0aW9uX2hhc0FueUFsbFRva2VucycKICAgIC0tIEFORCBjaGVja19uYW1lID0gJ1N0YXRlbGVzcyB0ZXN0cyAoYXJtX2FzYW4sIHRhcmdldGVkKScKICAgIEFORCB0ZXN0X3N0YXR1cyBJTiAoJ0ZBSUwnLCAnRVJST1InKQogICAgQU5EICgoaGVhZF9yZWYgPSAnbWFzdGVyJyBBTkQgcHVsbF9yZXF1ZXN0X251bWJlciA9IDApIE9SIHB1bGxfcmVxdWVzdF9udW1iZXIgIT0gMCkKR1JPVVAgQlkgZGF5Ck9SREVSIEJZIGRheSBERVNDCg==)

I don't want to disable it under sanitizers, so let's try to mark it as long first.