### PR TITLE
Fix infinite loop in AzureObjectStorage::listObjects

### DIFF
--- a/src/Disks/DiskObjectStorage/ObjectStorages/AzureBlobStorage/AzureObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/AzureBlobStorage/AzureObjectStorage.cpp
@@ -189,7 +189,6 @@ void AzureObjectStorage::listObjects(const std::string & path, RelativePathsWith
         if (client_ptr->IsClientForDisk())
             ProfileEvents::increment(ProfileEvents::DiskAzureListObjects);
 
-        blob_list_response = client_ptr->ListBlobs(options);
         const auto & blobs_list = blob_list_response.Blobs;
 
         for (const auto & blob : blobs_list)

--- a/src/Disks/DiskObjectStorage/ObjectStorages/AzureBlobStorage/AzureObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/AzureBlobStorage/AzureObjectStorage.cpp
@@ -205,13 +205,8 @@ void AzureObjectStorage::listObjects(const std::string & path, RelativePathsWith
                     {}}));
         }
 
-        if (max_keys)
-        {
-            ssize_t keys_left = static_cast<ssize_t>(max_keys) - children.size();
-            if (keys_left <= 0)
-                break;
-            options.PageSizeHint = keys_left;
-        }
+        if (max_keys && children.size() >= max_keys)
+            break;
     }
 }
 


### PR DESCRIPTION
The loop calls `client_ptr->ListBlobs(options)` inside the body on every iteration, overwriting `blob_list_response` with the first page. 
This cancels out the pagination logic (`MoveToNextPage()`) in the loop. If the first page returns `HasPage()` == `true`, for example, when the first page is empty, this leads to an infinite loop:
https://pastila.clickhouse.com/?00079d20/bac6ffc01386edeba163db1798cf2832#zb4gt9R5wmh4zOzbk3PbeA==

Azurite does not reproduce this.
I’ve tried to reproduce the bug using gtest mocks (e.g., for the AzureBlobStorage::ContainerClient), but haven’t succeeded yet.

For reference, the SDK demonstrates blob iteration as follows:
https://github.com/ClickHouse/azure-sdk-for-cpp/blob/0f7a2013f7d79058047fc4bd35e94d20578c0d2b/sdk/storage/azure-storage-blobs/test/ut/blob_container_client_test.cpp#L299-L306

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix possible infinite loop in azure list blobs.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
