### PR TITLE
CI: Fix tweak calculation in legacy version helper

### DIFF
--- a/tests/ci/git_helper.py
+++ b/tests/ci/git_helper.py
@@ -257,7 +257,7 @@ class Git:
         self.latest_tag = self.run("git describe --tags --abbrev=0", stderr=stderr)
         # Format should be: {latest_tag}-{commits_since_tag}-g{sha_short}
         self.commits_since_latest = int(
-            self.run(f"git rev-list {self.latest_tag}..HEAD --count")
+            self.run(f"git rev-list {self.latest_tag}..HEAD --first-parent --count")
         )
         if self.latest_tag.endswith("-new"):
             # We won't change the behaviour of the the "latest_tag"
@@ -268,7 +268,7 @@ class Git:
                 stderr=stderr,
             )
             self.commits_since_new = int(
-                self.run(f"git rev-list {self.new_tag}..HEAD --count")
+                self.run(f"git rev-list {self.new_tag}..HEAD --first-parent --count")
             )
 
     @staticmethod


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fix legacy version helper which is still used by CreateRelease workflow and causing tweak mismatch
Follow up after https://github.com/ClickHouse/ClickHouse/pull/89098. 