### PR TITLE
Revert "Fix(Hive): Fix thread-safety race condition in static extractor"

### DIFF
--- a/src/Storages/HivePartitioningUtils.cpp
+++ b/src/Storages/HivePartitioningUtils.cpp
@@ -35,7 +35,7 @@ static auto makeExtractor()
 
 HivePartitioningKeysAndValues parseHivePartitioningKeysAndValues(const String & path)
 {
-    thread_local auto extractor = makeExtractor();
+    static auto extractor = makeExtractor();
 
     HivePartitioningKeysAndValues key_values;
 


### PR DESCRIPTION
After [this comment](https://github.com/ClickHouse/ClickHouse/pull/90474#issuecomment-3570679805) and the following https://github.com/ClickHouse/ClickHouse/pull/90744 is crystal clear the class doesn't modify any member. So, what was intended to be a fix for a crash was really not really such a thing.

Reverts ClickHouse/ClickHouse#90474