### PR TITLE
Fix query optimizer bug with ANY LEFT JOIN, QUALIFY

### DIFF
--- a/ci/jobs/queries/00006_any_left_join_qualify_header_order.sql
+++ b/ci/jobs/queries/00006_any_left_join_qualify_header_order.sql
@@ -1,0 +1,22 @@
+-- FIXME: Logical error: 'Input header is not a subset of output header'.
+
+-- Test for query optimizer bug with ANY LEFT JOIN + QUALIFY + expressions
+-- Bug: addDiscardingExpressionStepIfNeeded in removeUnusedColumns.cpp incorrectly assumed
+-- that input and output headers have columns in the same order.
+--
+-- When processing a query with:
+--   1. ANY LEFT JOIN with expression-based join condition (e.g., b + 1 = c + 1)
+--   2. Expression in SELECT from the right table (e.g., d + 1)
+--   3. QUALIFY clause with an expression (e.g., 2 % 1)
+--
+-- The query optimizer creates headers with different column orderings, causing the
+-- original algorithm to fail with: "Input header is not a subset of output header"
+--
+-- The fix requires checking column membership by name (using a set) rather than
+-- assuming sequential order when comparing input and output headers.
+
+CREATE TABLE t1 (a Int32, b Int32) ENGINE = MergeTree ORDER BY a
+CREATE TABLE t2 (c Int32, d Int32) ENGINE = MergeTree ORDER BY c
+SELECT d + 1, c FROM t1 ANY LEFT JOIN t2 ON b + 1 = c + 1 QUALIFY 2 % 1
+DROP TABLE t1
+DROP TABLE t2


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add me

* Added test to reproduce `Logical error: 'Input header is not a subset of output header'`
