### PR TITLE
Fix one more bug in JSON when path can be both in shared data and dynamic paths

### DIFF
--- a/src/DataTypes/DataTypeObject.cpp
+++ b/src/DataTypes/DataTypeObject.cpp
@@ -352,6 +352,7 @@ std::unique_ptr<ISerialization::SubstreamData> DataTypeObject::getDynamicSubcolu
                 if (path.starts_with(prefix))
                     result_dynamic_paths.emplace_back(path.substr(prefix.size()), column);
             }
+            result_object_column.setMaxDynamicPaths(result_dynamic_paths.size());
             result_object_column.setDynamicPaths(result_dynamic_paths);
 
             const auto & shared_data_offsets = object_column.getSharedDataOffsets();

--- a/src/DataTypes/Serializations/SerializationSubObject.cpp
+++ b/src/DataTypes/Serializations/SerializationSubObject.cpp
@@ -187,7 +187,10 @@ void SerializationSubObject::deserializeBinaryBulkWithMultipleStreams(
     auto & column_object = assert_cast<ColumnObject &>(*mutable_column);
     /// If it's a new object column, set dynamic paths and statistics.
     if (column_object.empty())
+    {
+        column_object.setMaxDynamicPaths(sub_object_state->dynamic_sub_paths.size());
         column_object.setDynamicPaths(sub_object_state->dynamic_sub_paths);
+    }
 
     auto & typed_paths = column_object.getTypedPaths();
     auto & dynamic_paths = column_object.getDynamicPaths();

--- a/tests/queries/0_stateless/03732_json_duplicated_path_in_dynamic_paths_and_shared_data_compact_part_bug.sql
+++ b/tests/queries/0_stateless/03732_json_duplicated_path_in_dynamic_paths_and_shared_data_compact_part_bug.sql
@@ -1,0 +1,5 @@
+drop table if exists test;
+create table test (id UInt64, json JSON(max_dynamic_paths=1)) engine=MergeTree order by tuple() settings min_bytes_for_wide_part='100G', write_marks_for_substreams_in_compact_parts=0;
+insert into test select number, '{"a" : 42, "b" : {"c" : 42}}' from numbers(100000);
+select json.^b from test order by id format Null;
+drop table test;


### PR DESCRIPTION
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix bug in JSON when path can be both in shared data and dynamic paths during sub-object reading in Compact parts with disabled `write_marks_for_substreams_in_compact_parts`.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
