### PR TITLE
Fix std::out_of_range in ApplyWithSubqueryVisitor with dictGet

### DIFF
--- a/src/Interpreters/ApplyWithSubqueryVisitor.cpp
+++ b/src/Interpreters/ApplyWithSubqueryVisitor.cpp
@@ -155,7 +155,6 @@ void ApplyWithSubqueryVisitor::visit(ASTFunction & func, const Data & data)
         auto & dict_name_arg = func.arguments->children.at(0);
         if (const auto * identifier = dict_name_arg->as<ASTIdentifier>(); identifier && identifier->isShort())
         {
-            LOG_TRACE(getLogger("visitor"), "identifier = {}", identifier->formatForLogging());
             auto name = identifier->shortName();
 
             auto literal_it = data.literals.find(name);

--- a/src/Interpreters/ApplyWithSubqueryVisitor.cpp
+++ b/src/Interpreters/ApplyWithSubqueryVisitor.cpp
@@ -150,7 +150,7 @@ void ApplyWithSubqueryVisitor::visit(ASTFunction & func, const Data & data)
         }
     }
     /// Rewrite dictionary name in dictGet*()
-    else if (functionIsDictGet(func.name))
+    else if (functionIsDictGet(func.name) && !func.arguments->children.empty())
     {
         auto & dict_name_arg = func.arguments->children.at(0);
         if (const auto * identifier = dict_name_arg->as<ASTIdentifier>(); identifier && identifier->isShort())

--- a/tests/queries/0_stateless/03741_dict_get_in_cte_with_no_arguments_old_analyzer.sql
+++ b/tests/queries/0_stateless/03741_dict_get_in_cte_with_no_arguments_old_analyzer.sql
@@ -1,0 +1,2 @@
+SELECT ( SELECT dictGet() ) settings enable_analyzer=0; -- {serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH}
+


### PR DESCRIPTION
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix std::out_of_range in CTE with dictGet with no arguments. Closes https://github.com/ClickHouse/ClickHouse/issues/91027

Fixes: #90860