### PR TITLE
Set max retries for failed `S3` requests to 500

### DIFF
--- a/src/IO/S3/PocoHTTPClient.h
+++ b/src/IO/S3/PocoHTTPClient.h
@@ -46,7 +46,7 @@ struct PocoHTTPClientConfiguration : public Aws::Client::ClientConfiguration
 {
     struct RetryStrategy
     {
-        unsigned int max_retries = 10;
+        unsigned int max_retries = 500;
         unsigned int initial_delay_ms = 25;
         unsigned int max_delay_ms = 5000;
         double jitter_factor = 0;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
To match the default value on 25.6 and master: 500