### PR TITLE
CI: ASTFuzzer: fix exception on no SQL query found

### DIFF
--- a/ci/jobs/scripts/log_parser.py
+++ b/ci/jobs/scripts/log_parser.py
@@ -396,7 +396,8 @@ class FuzzerLogParser:
                 keyword_pos = query_command.find(keyword)
                 min_pos = min(min_pos, keyword_pos)
         if min_pos == len(query_command):
-            raise Exception("No SQL keyword found in query command")
+            print(f"No SQL keyword found in query command [{query_command}]")
+            return None
         query_command = query_command[min_pos:]
         return query_command
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)



Fixes:
```Traceback (most recent call last):
File "/home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/./ci/jobs/ast_fuzzer_job.py", line 195, in
run_fuzz_job(check_name)
File "/home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/./ci/jobs/ast_fuzzer_job.py", line 160, in run_fuzz_job
result_name, info = fuzzer_log_parser.parse_failure()
File "/home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/ci/jobs/scripts/log_parser.py", line 125, in parse_failure
failed_query = self.get_failed_query()
File "/home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/ci/jobs/scripts/log_parser.py", line 399, in get_failed_query
raise Exception("No SQL keyword found in query command")```
