### PR TITLE
Add perf test for recent perf degradation (25.10)

### DIFF
--- a/tests/performance/joins_in_memory.xml
+++ b/tests/performance/joins_in_memory.xml
@@ -40,5 +40,35 @@
     <query short='1' tag='CROSS'>SELECT COUNT() FROM ints l CROSS JOIN (SELECT number as i64 FROM numbers(4)) r WHERE i32 = 42</query>
     <query short='1' tag='CROSS KEY'>SELECT COUNT() FROM ints l CROSS JOIN (SELECT number as i64 FROM numbers(4)) r WHERE i32 = 42</query>
 
+    <query>
+        SELECT count()
+        FROM
+        (
+            SELECT
+                t1.col_1 AS col_1,
+                t1.col_2 AS col_2,
+                t1.col_3 AS col_3,
+                t2.col_5 AS col_4
+            FROM
+            (
+                SELECT *
+                FROM VALUES('col_1 DateTime64(6), col_2 LowCardinality(String), col_3 UUID, col_10 UUID',
+                    ('1993-01-01', 'x', '75d076fd-84f3-4684-b830-090eca3d33a3', '75d076fd-84f3-4684-b830-090eca3d33a3'))
+            ) AS t1
+            ANY LEFT JOIN
+            (
+                SELECT *
+                FROM VALUES('id UUID, col_5 String', ('75d076fd-84f3-4684-b830-090eca3d33a3', 'x'))
+            ) AS t2 ON t2.id = t1.col_3
+            ANY LEFT JOIN
+            (
+                SELECT *
+                FROM VALUES('id UUID', '75d076fd-84f3-4684-b830-090eca3d33a3')
+            ) AS t3 ON t3.id = t1.col_10
+            WHERE col_2 IN ('qqq')
+        ) AS t
+        WHERE (col_1 > 0) AND (length(col_4) > 0)
+    </query>
+
     <drop_query>DROP TABLE IF EXISTS ints</drop_query>
 </test>


### PR DESCRIPTION
This query stuck for 16 seconds but was fixed in https://github.com/ClickHouse/ClickHouse/pull/90288 

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
