### PR TITLE
Safer hints for missing grants in exception messages

### DIFF
--- a/src/Access/ContextAccess.cpp
+++ b/src/Access/ContextAccess.cpp
@@ -75,6 +75,53 @@ namespace
         return ids;
     }
 
+    /// Filter access-denied hint output (the "required grant"/"missing permissions" text in ACCESS_DENIED errors)
+    /// to avoid exposing column names when they come from implicit expansion (e.g. SELECT *),
+    /// while keeping database/table names that the user already specified in the query.
+    AccessRightsElement filterAccessElementForHints(const AccessRightsElement & element, const AccessRights & access)
+    {
+        if (element.isGlobalWithParameter())
+            return element;
+
+        AccessRightsElement res = element;
+
+        if (!res.table.empty())
+        {
+            const bool has_show_columns_global = access.isGranted(AccessType::SHOW_COLUMNS);
+            if (!res.columns.empty() && !has_show_columns_global)
+            {
+                const size_t original_columns = res.columns.size();
+                if (!access.isGranted(AccessType::SHOW_COLUMNS, res.database, res.table))
+                {
+                    Strings filtered;
+                    filtered.reserve(res.columns.size());
+                    for (const auto & column : res.columns)
+                    {
+                        if (access.isGranted(AccessType::SHOW_COLUMNS, res.database, res.table, column))
+                            filtered.push_back(column);
+                    }
+                    res.columns = std::move(filtered);
+                }
+                if (res.columns.size() != original_columns)
+                    res.columns.clear();
+            }
+        }
+
+        if (res.table.empty())
+            res.columns.clear();
+
+        return res;
+    }
+
+    AccessRightsElements filterAccessElementsForHints(const AccessRightsElements & elements, const AccessRights & access)
+    {
+        AccessRightsElements filtered;
+        filtered.reserve(elements.size());
+        for (const auto & element : elements)
+            filtered.push_back(filterAccessElementForHints(element, access));
+        return filtered;
+    }
+
     /// Helper for using in templates.
     std::string_view getDatabase() { return {}; }
 
@@ -687,6 +734,17 @@ bool ContextAccess::checkAccessImplHelper(const ContextPtr & context, AccessFlag
 
     if (!granted)
     {
+        auto format_required_access = [&](AccessFlags access_flags, const auto & ... fmt_args)
+        {
+            AccessRightsElement required_access{access_flags, fmt_args...};
+            return filterAccessElementForHints(required_access, *acs).toStringWithoutOptions();
+        };
+
+        auto format_missing_permissions = [&](const AccessRights & difference)
+        {
+            return filterAccessElementsForHints(difference.getElements(), *acs).toStringWithoutOptions();
+        };
+
         auto access_denied_no_grant = [&]<typename... FmtArgs>(AccessFlags access_flags, FmtArgs && ...fmt_args)
         {
             if (grant_option && acs->isGranted(access_flags, fmt_args...))
@@ -695,7 +753,7 @@ bool ContextAccess::checkAccessImplHelper(const ContextPtr & context, AccessFlag
                     "{}: Not enough privileges. "
                     "The required privileges have been granted, but without grant option. "
                     "To execute this query, it's necessary to have the grant {} WITH GRANT OPTION",
-                    AccessRightsElement{access_flags, fmt_args...}.toStringWithoutOptions());
+                    format_required_access(access_flags, fmt_args...));
             }
 
             if constexpr (!throw_if_denied)
@@ -711,14 +769,14 @@ bool ContextAccess::checkAccessImplHelper(const ContextPtr & context, AccessFlag
                 {
                     return access_denied(ErrorCodes::ACCESS_DENIED,
                         "{}: Not enough privileges. To execute this query, it's necessary to have the grant {}",
-                        AccessRightsElement{access_flags, fmt_args...}.toStringWithoutOptions() + (grant_option ? " WITH GRANT OPTION" : ""));
+                        format_required_access(access_flags, fmt_args...) + (grant_option ? " WITH GRANT OPTION" : ""));
                 }
 
                 return access_denied(ErrorCodes::ACCESS_DENIED,
                     "{}: Not enough privileges. To execute this query, it's necessary to have the grant {}. "
                     "(Missing permissions: {}){}",
-                    AccessRightsElement{access_flags, fmt_args...}.toStringWithoutOptions() + (grant_option ? " WITH GRANT OPTION" : ""),
-                    difference.getElements().toStringWithoutOptions(),
+                    format_required_access(access_flags, fmt_args...) + (grant_option ? " WITH GRANT OPTION" : ""),
+                    format_missing_permissions(difference),
                     grant_option ? ". You can try to use the `GRANT CURRENT GRANTS(...)` statement" : "");
             }
         };

--- a/tests/integration/test_access_denied_hint_sanitized/__init__.py
+++ b/tests/integration/test_access_denied_hint_sanitized/__init__.py
@@ -1,0 +1,1 @@
+# Make this directory a package to avoid pytest module name clashes with other test.py files.

--- a/tests/integration/test_access_denied_hint_sanitized/test.py
+++ b/tests/integration/test_access_denied_hint_sanitized/test.py
@@ -1,0 +1,85 @@
+import pytest
+
+import re
+
+from helpers.cluster import ClickHouseCluster
+
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance("node")
+
+
+@pytest.fixture(scope="module", autouse=True)
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def extract_access_denied_hint(err: str) -> str:
+    match = re.search(r"Not enough privileges\.[\s\S]*", err)
+    if not match:
+        return err
+    hint = match.group(0)
+    for marker in ("Stack trace:", " (query:", "\nQuery:"):
+        pos = hint.find(marker)
+        if pos != -1:
+            hint = hint[:pos]
+    return hint
+
+def test_hint_filters_columns_by_show_privilege():
+    node.query("DROP TABLE IF EXISTS t_cols")
+    node.query(
+        "CREATE TABLE t_cols(col_alpha UInt32, col_beta UInt32) ENGINE = Memory"
+    )
+    node.query("CREATE USER OR REPLACE u_cols")
+    node.query("GRANT SHOW TABLES ON default.t_cols TO u_cols")
+    node.query("GRANT SHOW COLUMNS(col_alpha) ON default.t_cols TO u_cols")
+    node.query("GRANT SELECT(col_alpha) ON default.t_cols TO u_cols")
+
+    err = node.query_and_get_error(
+        "SELECT col_alpha, col_beta FROM t_cols", user="u_cols"
+    )
+    hint = extract_access_denied_hint(err)
+    assert "necessary to have the grant SELECT" in hint
+    assert "Missing permissions" in hint
+    assert "t_cols" in hint
+    assert "col_alpha" not in hint
+    assert "col_beta" not in hint
+
+
+def test_hint_keeps_table_name_from_query():
+    node.query("DROP DATABASE IF EXISTS db_hint")
+    node.query("CREATE DATABASE db_hint")
+    node.query("DROP TABLE IF EXISTS db_hint.t_hidden")
+    node.query("CREATE TABLE db_hint.t_hidden(x UInt32) ENGINE = Memory")
+    node.query("CREATE USER OR REPLACE u_table")
+
+    err = node.query_and_get_error(
+        "SELECT * FROM db_hint.t_hidden", user="u_table"
+    )
+    hint = extract_access_denied_hint(err)
+    assert "necessary to have the grant SELECT" in hint
+    assert "db_hint" in hint
+    assert "t_hidden" in hint
+
+
+def test_hint_keeps_database_name_from_query():
+    node.query("CREATE USER OR REPLACE u_db")
+
+    err = node.query_and_get_error("CREATE DATABASE db_no_show", user="u_db")
+    hint = extract_access_denied_hint(err)
+    assert "necessary to have the grant CREATE DATABASE" in hint
+    assert "db_no_show" in hint
+
+
+def test_hint_hides_system_clusters_columns_without_show():
+    node.query("CREATE USER OR REPLACE u_system")
+
+    err = node.query_and_get_error("SELECT * FROM system.clusters", user="u_system")
+    hint = extract_access_denied_hint(err)
+    assert "necessary to have the grant SELECT" in hint
+    assert "system.clusters" in hint
+    assert "shard_num" not in hint

--- a/tests/integration/test_backup_restore_new/test.py
+++ b/tests/integration/test_backup_restore_new/test.py
@@ -1597,7 +1597,7 @@ def test_restore_table_not_evaluate_table_defaults():
     )
 
     # INSERT needs dictionary `test2.dict` and it will cause loading it.
-    error = "necessary to have the grant SELECT(key, value) ON test2.src"  # User `u1` has no privileges for reading `test2.src`
+    error = "necessary to have the grant SELECT ON test2.src"  # User `u1` has no privileges for reading `test2.src`
     assert error in instance.query_and_get_error(
         "INSERT INTO test2.tbl (a, b) SELECT number, number + 1 FROM numbers(5, 5)"
     )

--- a/tests/integration/test_select_access_rights/test_from_system_tables.py
+++ b/tests/integration/test_select_access_rights/test_from_system_tables.py
@@ -140,9 +140,7 @@ def test_information_schema():
         == "1\n"
     )
 
-    expected_error = (
-        "necessary to have the grant SELECT(table_name) ON information_schema.tables"
-    )
+    expected_error = "necessary to have the grant SELECT ON information_schema.tables"
     assert expected_error in node.query_and_get_error(
         "SELECT count() FROM information_schema.tables WHERE table_name='table1'",
         user="another",
@@ -162,9 +160,7 @@ def test_information_schema():
     )
 
     node.query("GRANT SELECT ON information_schema.* TO sqluser")
-    expected_error = (
-        "necessary to have the grant SELECT(database, `table`) ON system.parts"
-    )
+    expected_error = "necessary to have the grant SELECT ON system.parts"
     assert expected_error in node.query_and_get_error(
         "SELECT count() FROM information_schema.tables WHERE table_name='table1'",
         user="sqluser",

--- a/tests/integration/test_select_access_rights/test_main.py
+++ b/tests/integration/test_select_access_rights/test_main.py
@@ -21,6 +21,7 @@ def started_cluster():
 def cleanup_after_test():
     instance.query("CREATE USER OR REPLACE A")
     yield
+    instance.query("DROP ROW POLICY IF EXISTS pol1 ON table1")
     instance.query("DROP TABLE IF EXISTS table1")
     instance.query("DROP TABLE IF EXISTS table2")
 

--- a/tests/integration/test_table_functions_access_rights/test.py
+++ b/tests/integration/test_table_functions_access_rights/test.py
@@ -58,10 +58,9 @@ def test_merge():
     instance.query("REVOKE ALL ON default.* FROM A")
     instance.query("GRANT SELECT ON default.table1 TO A")
     instance.query("GRANT INSERT ON default.table2 TO A")
-    assert (
-        "it's necessary to have the grant SELECT(x) ON default.table2"
-        in instance.query_and_get_error(select_query, user="A")
-    )
+    err = instance.query_and_get_error(select_query, user="A")
+    # INSERT on table2 implies SHOW_COLUMNS, so the hint is allowed to include column names.
+    assert "it's necessary to have the grant SELECT(x) ON default.table2" in err
 
     instance.query("REVOKE ALL ON default.* FROM A")
     describe_query = f"DESCRIBE TABLE {merge_spec}"


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
ACCESS_DENIED hints no longer reveal column names unless the user can show all required columns; database/table names remain visible in the hint.

### Documentation entry for user-facing changes

ACCESS_DENIED error hints no longer expose column names unless the user has SHOW_COLUMNS visibility for all required columns. Hints still include database/table names from the query. This reduces schema leakage while keeping grant guidance readable.

Example of the issue:
```
Code: 497. DB::Exception: foo: Not enough privileges. To execute this query, it's necessary to have the grant SELECT(cluster, shard_num, shard_name, shard_weight, internal_replication, replica_num, host_name, host_address, port, is_local, user, default_database, errors_count, slowdowns_count, estimated_recovery_time, database_shard_name, database_replica_name, is_active, unsynced_after_recovery, replication_lag, recovery_time) ON system.clusters. (ACCESS_DENIED)
```

- [x] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the formatting of `ACCESS_DENIED` hint text in a security-sensitive area (privilege visibility), which may affect clients/tests that rely on exact error messages.
> 
> **Overview**
> **Sanitizes `ACCESS_DENIED` hints** so the “required grant” and “missing permissions” text no longer includes column names unless the user has `SHOW_COLUMNS` for *all* referenced columns; database/table names from the query remain visible.
> 
> Adds a new integration test suite (`test_access_denied_hint_sanitized`) and updates multiple existing integration tests to reflect the new hint behavior (often expecting `SELECT ON db.table` until `SHOW COLUMNS` is granted).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f6a04c0f006fa26d4f84ec5efd195476cbbf4694. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.501`
<!-- ch-version-info:end -->