### PR TITLE
Fix introduced in and add missing example for `dictGetKeys` function

### DIFF
--- a/src/Functions/FunctionDictGetKeys.cpp
+++ b/src/Functions/FunctionDictGetKeys.cpp
@@ -557,9 +557,9 @@ SELECT dictGetKeys('task_id_to_priority_dictionary', 'priority_level', 'high') A
 │ [4,2] │
 └───────┘
     )"}};
-    FunctionDocumentation::IntroducedIn introduced_in = {25, 11};
+    FunctionDocumentation::IntroducedIn introduced_in = {25, 12};
     FunctionDocumentation::Category category = FunctionDocumentation::Category::Dictionary;
-    FunctionDocumentation docs{description, syntax, arguments, returned_value, {}, introduced_in, category};
+    FunctionDocumentation docs{description, syntax, arguments, returned_value, examples, introduced_in, category};
 
     factory.registerFunction<FunctionDictGetKeys>(docs);
 }

--- a/src/Functions/FunctionDictGetKeys.cpp
+++ b/src/Functions/FunctionDictGetKeys.cpp
@@ -314,7 +314,6 @@ private:
                 missing_bucket_ids.push_back(bucket_id);
         }
 
-
         /// Step 3
         const auto key_types = structure.getKeyTypes();
         chassert(!key_types.empty());

--- a/src/Functions/FunctionDictGetKeys.cpp
+++ b/src/Functions/FunctionDictGetKeys.cpp
@@ -314,6 +314,7 @@ private:
                 missing_bucket_ids.push_back(bucket_id);
         }
 
+
         /// Step 3
         const auto key_types = structure.getKeyTypes();
         chassert(!key_types.empty());


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
