### PR TITLE
tests: (in attempt to) fix 00596_limit_on_expanded_ast flakiness

### DIFF
--- a/tests/queries/0_stateless/00596_limit_on_expanded_ast.sh
+++ b/tests/queries/0_stateless/00596_limit_on_expanded_ast.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Tags: no-parallel
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/00596_limit_on_expanded_ast.sh
+++ b/tests/queries/0_stateless/00596_limit_on_expanded_ast.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-parallel
+# Tags: no-parallel, long
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
Looks like it was always slow [1]

  [1]: https://play.clickhouse.com/play?user=play#U0VMRUNUIGNoZWNrX3N0YXJ0X3RpbWUsIGNoZWNrX25hbWUsIGluc3RhbmNlX3R5cGUsIHRlc3RfbmFtZSwgdGVzdF9zdGF0dXMsIHRlc3RfZHVyYXRpb25fbXMsIHJlcG9ydF91cmwKRlJPTSBjaGVja3MKV0hFUkUgY2hlY2tfc3RhcnRfdGltZSA+PSBub3coKSAtIElOVEVSVkFMIDI0IGRheQogICAgQU5EIChoZWFkX3JlZiA9ICdtYXN0ZXInIEFORCBzdGFydHNXaXRoKGhlYWRfcmVwbywgJ0NsaWNrSG91c2UvJykpCiAgICAvL0FORCB0ZXN0X3N0YXR1cyAhPSAnU0tJUFBFRCcKICAgIC8vQU5EICh0ZXN0X3N0YXR1cyBMSUtFICdGJScgT1IgdGVzdF9zdGF0dXMgTElLRSAnRSUnKSAKICAgIC8vQU5EIGNoZWNrX3N0YXR1cyAhPSAnc3VjY2VzcycKICAgIEFORCBwb3NpdGlvbih0ZXN0X25hbWUsICcwMDU5Nl9saW1pdF9vbl9leHBhbmRlZF9hc3QnKSA+IDAKICAgIC8vYW5kIGNoZWNrX25hbWUgPSAnU3RhdGVsZXNzIHRlc3RzIChhbWRfbXNhbiwgcGFyYWxsZWwpJwogICAgYW5kIGNoZWNrX25hbWUgbGlrZSAnJWFtZF9tc2FuJScKT1JERVIgQlkgY2hlY2tfc3RhcnRfdGltZQ==

And the reason is started to fail more frequently is targeted check.

As for why it started to fail in `Stateless tests (amd_msan, parallel)`, maybe because after the job got merged (before it was splitted into 2 jobs) more tests was running in parallel, which can affect this test duration.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes: #90721