### PR TITLE
Fix `arrayFilter` function not working with `Nothing` return type for new analyzer

### DIFF
--- a/src/Functions/isNotNull.cpp
+++ b/src/Functions/isNotNull.cpp
@@ -47,6 +47,11 @@ public:
         if (!use_analyzer)
             return nullptr;
 
+        /// SELECT arrayFilter(x -> (x IS NOT NULL), []) can trigger `defaultImplementationForNothing()`
+        /// which will give return type Nothing. We cannot create constant column of type Nothing so return nullptr.
+        if (isNothing(result_type))
+            return nullptr;
+
         const ColumnWithTypeAndName & elem = arguments[0];
         if (elem.type->onlyNull())
             return result_type->createColumnConst(1, UInt8(0));

--- a/src/Functions/isNull.cpp
+++ b/src/Functions/isNull.cpp
@@ -29,6 +29,11 @@ ColumnPtr FunctionIsNull::getConstantResultForNonConstArguments(const ColumnsWit
     if (!use_analyzer)
         return nullptr;
 
+    /// SELECT arrayFilter(x -> (x IS NULL), []) can trigger `defaultImplementationForNothing()`
+    /// which will give return type Nothing. We cannot create constant column of type Nothing so return nullptr.
+    if (isNothing(result_type))
+        return nullptr;
+
     const ColumnWithTypeAndName & elem = arguments[0];
     if (elem.type->onlyNull())
         return result_type->createColumnConst(1, UInt8(1));

--- a/tests/queries/0_stateless/03742_array_filter_is_null_empty_array.reference
+++ b/tests/queries/0_stateless/03742_array_filter_is_null_empty_array.reference
@@ -1,0 +1,14 @@
+-- { echoOn }
+
+SELECT arrayFilter(x -> (x IS NOT NULL), []);
+[]
+SELECT arrayFilter(x -> (x IS NOT NULL), [NULL]);
+[]
+SELECT arrayFilter(x -> (x IS NOT NULL), [1]);
+[1]
+SELECT arrayFilter(x -> (x IS NULL), []);
+[]
+SELECT arrayFilter(x -> (x IS NULL), [NULL]);
+[NULL]
+SELECT arrayFilter(x -> (x IS NULL), [1]);
+[]

--- a/tests/queries/0_stateless/03742_array_filter_is_null_empty_array.sql
+++ b/tests/queries/0_stateless/03742_array_filter_is_null_empty_array.sql
@@ -1,0 +1,13 @@
+-- { echoOn }
+
+SELECT arrayFilter(x -> (x IS NOT NULL), []);
+
+SELECT arrayFilter(x -> (x IS NOT NULL), [NULL]);
+
+SELECT arrayFilter(x -> (x IS NOT NULL), [1]);
+
+SELECT arrayFilter(x -> (x IS NULL), []);
+
+SELECT arrayFilter(x -> (x IS NULL), [NULL]);
+
+SELECT arrayFilter(x -> (x IS NULL), [1]);


### PR DESCRIPTION
Currently the following query does not work for new analyzer, but should:

```sql
SELECT arrayFilter(x -> (x IS NOT NULL), []);
```

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `arrayFilter` function not working when using empty array and `isNull` function. Closes https://github.com/ClickHouse/ClickHouse/issues/73849.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
