### PR TITLE
Fix build under clang-21

### DIFF
--- a/src/Processors/Transforms/BuildRuntimeFilterTransform.cpp
+++ b/src/Processors/Transforms/BuildRuntimeFilterTransform.cpp
@@ -26,7 +26,6 @@ BuildRuntimeFilterTransform::BuildRuntimeFilterTransform(
     , filter_column_original_type(header_->getByPosition(filter_column_position).type)
     , filter_column_target_type(filter_column_type_)
     , filter_name(filter_name_)
-    , filters_to_merge(filters_to_merge_)
 {
     const auto & filter_column = header_->getByPosition(filter_column_position);
     if (!filter_column_target_type->equals(*filter_column_original_type))

--- a/src/Processors/Transforms/BuildRuntimeFilterTransform.h
+++ b/src/Processors/Transforms/BuildRuntimeFilterTransform.h
@@ -39,8 +39,6 @@ private:
     const DataTypePtr filter_column_target_type;
     const String filter_name;
 
-    const size_t filters_to_merge;
-
     FunctionBasePtr cast_to_target_type;
 
     UniqueRuntimeFilterPtr built_filter;


### PR DESCRIPTION
clang-21:

    /src/ch/clickhouse/src/Processors/Transforms/BuildRuntimeFilterTransform.h:42:18: error: private field 'filters_to_merge' is not used [-Werror,-Wunused-private-field]
       42 |     const size_t filters_to_merge;

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Follow-up for: #89710