### PR TITLE
feature: Add AWS MSK IAM Authentication Support for Kafka Engine

### DIFF
--- a/ci/jobs/scripts/check_style/aspell-ignore/en/aspell-dict.txt
+++ b/ci/jobs/scripts/check_style/aspell-ignore/en/aspell-dict.txt
@@ -813,6 +813,7 @@ NumberOfTables
 NumericIndexedVector
 NumericIndexedVectors
 OAuth
+OAUTHBEARER
 ODBCDriver
 OFNS
 OKLCH
@@ -964,6 +965,7 @@ PrettySpaceNoEscapes
 PrettySpaceNoEscapesMonoBlock
 Prewhere
 PrivateKeyPassphraseHandler
+PrivateLink
 PrivatePreviewBadge
 ProfileEvents
 Profiler
@@ -1109,6 +1111,7 @@ SelfManaged
 Sematext
 SendExternalTables
 SendScalars
+Serverless
 ServerSettings
 SetOperationMode
 ShareAlike

--- a/contrib/librdkafka-cmake/CMakeLists.txt
+++ b/contrib/librdkafka-cmake/CMakeLists.txt
@@ -110,9 +110,15 @@ if(TARGET ch_contrib::sasl2)
 endif()
 
 set(WITH_SSL 1)
+# CRITICAL FIX: Enable OAUTHBEARER independently of SASL_CYRUS
+# OAUTHBEARER (RFC 7628) only requires OpenSSL for crypto operations,
+# it does NOT require Cyrus SASL library. By enabling it unconditionally
+# when WITH_SSL is set, we can support AWS MSK IAM authentication and
+# other OAUTHBEARER mechanisms without needing the full Cyrus SASL stack.
+set(WITH_SASL_OAUTHBEARER 1)
+
 if(WITH_SASL_CYRUS)
    set(WITH_SASL_SCRAM 1)
-   set(WITH_SASL_OAUTHBEARER 1)
 endif()
 add_definitions(-DOPENSSL_NO_ENGINE)
 list(APPEND SRCS "${RDKAFKA_SOURCE_DIR}/rdkafka_ssl.c")

--- a/src/IO/WriteBufferFromString.h
+++ b/src/IO/WriteBufferFromString.h
@@ -41,7 +41,7 @@ class WriteBufferFromOwnString : public detail::StringHolder, public WriteBuffer
 {
     using Base = WriteBufferFromVectorImpl<std::string>;
 public:
-    WriteBufferFromOwnString()
+    WriteBufferFromOwnString() // NOLINT(modernize-use-equals-default, hicpp-use-equals-default)
         : Base(value)
     {
     }

--- a/src/Storages/Kafka/AWSMSKIAMAuth.cpp
+++ b/src/Storages/Kafka/AWSMSKIAMAuth.cpp
@@ -1,0 +1,306 @@
+#include <Storages/Kafka/AWSMSKIAMAuth.h>
+
+#include "config.h"
+
+#if USE_AWS_S3
+
+#include <Common/Base64.h>
+#include <Common/Exception.h>
+#include <Common/logger_useful.h>
+#include <Common/re2.h>
+#include <Core/SettingsFields.h>
+#include <Poco/Util/AbstractConfiguration.h>
+#include <Poco/URI.h>
+#include <boost/algorithm/string/trim.hpp>
+#include <cppkafka/configuration.h>
+#include <librdkafka/rdkafka.h>
+#include <IO/S3/Client.h>
+#include <IO/S3/Credentials.h>
+#include <IO/ReadBufferFromString.h>
+#include <IO/ReadHelpers.h>
+#include <IO/WriteBufferFromString.h>
+#include <IO/WriteHelpers.h>
+#include <aws/core/auth/AWSCredentialsProvider.h>
+#include <aws/core/auth/signer/AWSAuthV4Signer.h>
+#include <aws/core/http/HttpRequest.h>
+#include <aws/core/http/URI.h>
+#include <aws/core/utils/memory/stl/AWSStreamFwd.h>
+#include <chrono>
+#include <mutex>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int BAD_ARGUMENTS;
+    extern const int AWS_ERROR;
+}
+
+namespace AWSMSKIAMAuth
+{
+
+namespace
+{
+    constexpr std::chrono::seconds TOKEN_LIFETIME{300};
+    constexpr std::chrono::seconds PRESIGNED_URL_EXPIRY{900};
+
+    String generateAWSMSKToken(
+        const String & region,
+        const Aws::Auth::AWSCredentials & credentials)
+    {
+        try
+        {
+            String service_host = "kafka." + region + ".amazonaws.com";
+
+            Aws::Http::URI uri;
+            uri.SetScheme(Aws::Http::Scheme::HTTPS);
+            uri.SetAuthority(service_host);
+            uri.SetPath("/");
+            uri.AddQueryStringParameter("Action", "kafka-cluster:Connect");
+
+            auto request = Aws::Http::CreateHttpRequest(
+                uri,
+                Aws::Http::HttpMethod::HTTP_GET,
+                Aws::Utils::Stream::DefaultResponseStreamFactoryMethod);
+
+            Aws::Client::AWSAuthV4Signer signer(
+                std::make_shared<Aws::Auth::SimpleAWSCredentialsProvider>(credentials),
+                "kafka-cluster",
+                region,
+                Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never,
+                true);
+
+            if (!signer.PresignRequest(*request, PRESIGNED_URL_EXPIRY.count()))
+            {
+                throw Exception(ErrorCodes::AWS_ERROR, "Failed to presign AWS MSK IAM request");
+            }
+
+            String presigned_url = request->GetURIString();
+
+            if (presigned_url.empty() || !presigned_url.contains("Action=kafka-cluster%3AConnect"))
+            {
+                throw Exception(ErrorCodes::AWS_ERROR,
+                    "Invalid presigned URL generated: missing required Action parameter");
+            }
+
+            // Add User-Agent parameter AFTER signature (not included in signing)
+            presigned_url += "&User-Agent=clickhouse-msk-iam";
+
+            // AWS MSK requires Base64-URL encoding (RFC 4648 §5): + → -, / → _, remove padding
+            return base64Encode(presigned_url, /* url_encoding */ true, /* no_padding */ true);
+        }
+        catch (const std::exception & e)
+        {
+            throw Exception(ErrorCodes::AWS_ERROR, "Failed to generate AWS MSK token: {}", e.what());
+        }
+    }
+
+    void oauthBearerTokenRefreshCallback(
+        rd_kafka_t * rk,
+        const char * oauthbearer_config,
+        void * /* opaque */)
+    {
+        LoggerPtr log = getLogger("AWSMSKIAMAuth");
+        std::shared_ptr<S3::S3CredentialsProviderChain> provider;
+        String region;
+
+        // NOTE: We cannot use the global 'opaque' pointer because it is used by cppkafka
+        // to store the Consumer/Producer instance. Overwriting it would break cppkafka callbacks.
+        // Instead, we pass the context pointer address in the configuration string.
+
+        OAuthBearerTokenRefreshContext * ctx = nullptr;
+
+        if (oauthbearer_config && oauthbearer_config[0] != '\0')
+        {
+            try
+            {
+                Poco::URI uri;
+                uri.setQuery(oauthbearer_config);
+                auto params = uri.getQueryParameters();
+
+                for (const auto & [key, value] : params)
+                {
+                    if (key == "context_ptr")
+                    {
+                        uintptr_t ptr_val = 0;
+                        ReadBufferFromString rb(value);
+                        if (tryReadIntText(ptr_val, rb))
+                            ctx = reinterpret_cast<OAuthBearerTokenRefreshContext *>(ptr_val);
+                    }
+                }
+            }
+            catch (...)
+            {
+                // Ignore parsing errors, will fall back to default behavior (error)
+                tryLogCurrentException(log, "Failed to parse OAuth bearer config");
+            }
+        }
+
+        if (ctx)
+        {
+            if (ctx->log)
+            {
+                log = ctx->log;
+            }
+            provider = ctx->provider;
+            region = ctx->region;
+        }
+
+        try
+        {
+            if (!provider)
+            {
+                LOG_ERROR(log, "Token refresh callback called without credentials provider context");
+                rd_kafka_oauthbearer_set_token_failure(rk, "Internal error: missing credentials provider context");
+                return;
+            }
+
+            auto credentials = provider->GetAWSCredentials();
+
+            if (credentials.IsEmpty())
+            {
+                LOG_ERROR(log, "AWS credentials are empty");
+                rd_kafka_oauthbearer_set_token_failure(rk, "No AWS credentials available");
+                return;
+            }
+
+            String token = generateAWSMSKToken(region, credentials);
+
+            auto now = std::chrono::system_clock::now();
+            auto expiry_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                (now + TOKEN_LIFETIME).time_since_epoch()).count();
+
+            char errstr[512];
+            rd_kafka_resp_err_t err = rd_kafka_oauthbearer_set_token(
+                rk, token.c_str(), expiry_ms, credentials.GetAWSAccessKeyId().c_str(),
+                nullptr, 0, errstr, sizeof(errstr));
+
+            if (err != RD_KAFKA_RESP_ERR_NO_ERROR)
+            {
+                LOG_ERROR(log, "Failed to set OAuth token: {}", errstr);
+                rd_kafka_oauthbearer_set_token_failure(rk, errstr);
+            }
+        }
+        catch (const std::exception & e)
+        {
+            LOG_ERROR(log, "Token refresh failed: {}", e.what());
+            rd_kafka_oauthbearer_set_token_failure(rk, e.what());
+        }
+        catch (...)
+        {
+            tryLogCurrentException(log, "Token refresh failed");
+            rd_kafka_oauthbearer_set_token_failure(rk, "Unexpected exception");
+        }
+    }
+}
+
+bool isValidAWSRegion(const String & region)
+{
+    if (region.empty())
+        return false;
+
+    static const RE2 region_format_pattern(R"(^[a-z]{2,3}-[a-z]+-\d+$)");
+    return RE2::FullMatch(region, region_format_pattern);
+}
+
+String extractRegionFromBroker(const String & broker_address)
+{
+    if (broker_address.empty())
+        return "";
+
+    String broker_host = broker_address;
+    if (size_t colon_pos = broker_host.find(':'); colon_pos != String::npos)
+    {
+        if (colon_pos == 0)
+            return "";
+        broker_host = broker_host.substr(0, colon_pos);
+    }
+
+    static const RE2 region_pattern(R"((?i)\.kafka(?:-serverless)?\.([a-z0-9-]+)\.(?:vpce\.)?amazonaws\.com$)");
+    std::string region;
+    if (RE2::PartialMatch(broker_host, region_pattern, &region))
+        return region;
+
+    return "";
+}
+
+void setupAuthentication(
+    cppkafka::Configuration & kafka_config,
+    const Poco::Util::AbstractConfiguration & config,
+    const String & region,
+    const String & broker_list,
+    LoggerPtr log,
+    std::shared_ptr<OAuthBearerTokenRefreshContext> & context_holder)
+{
+    String effective_region = region;
+
+    if (effective_region.empty() && !broker_list.empty())
+    {
+        size_t comma_pos = broker_list.find(',');
+        String first_broker = (comma_pos != String::npos) ? broker_list.substr(0, comma_pos) : broker_list;
+        boost::trim(first_broker);
+        effective_region = extractRegionFromBroker(first_broker);
+        if (!effective_region.empty())
+            LOG_DEBUG(log, "Auto-detected AWS region '{}' from broker address '{}'", effective_region, first_broker);
+    }
+
+    if (effective_region.empty())
+        throw Exception(ErrorCodes::BAD_ARGUMENTS,
+            "Cannot auto-detect AWS region from broker list '{}'. "
+            "Or set kafka_aws_region explicitly in table SETTINGS.", broker_list);
+
+    if (!isValidAWSRegion(effective_region))
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Invalid AWS region format: '{}'", effective_region);
+
+    bool use_environment_credentials = config.getBool("kafka.use_environment_credentials", false);
+
+    Poco::URI::QueryParameters params;
+    params.emplace_back("region", effective_region);
+    params.emplace_back("use_environment_credentials", use_environment_credentials ? "1" : "0");
+
+    Poco::URI uri;
+    uri.setQueryParameters(params);
+
+    kafka_config.set("sasl.oauthbearer.config", uri.getRawQuery());
+    kafka_config.set("sasl.mechanism", "OAUTHBEARER");
+    kafka_config.set("security.protocol", "SASL_SSL");
+
+    // Enable SASL queue to allow background authentication callbacks
+    rd_kafka_conf_enable_sasl_queue(kafka_config.get_handle(), 1);
+
+    if (!context_holder)
+    {
+        auto aws_client_configuration = DB::S3::ClientFactory::instance().createClientConfiguration(
+            effective_region, {}, 0, {}, false, false, false, false, {}, {});
+
+        S3::CredentialsConfiguration credentials_configuration;
+        credentials_configuration.use_environment_credentials = use_environment_credentials;
+
+        auto provider = std::make_shared<S3::S3CredentialsProviderChain>(
+            aws_client_configuration, Aws::Auth::AWSCredentials{}, credentials_configuration);
+
+        context_holder = std::make_shared<OAuthBearerTokenRefreshContext>();
+        context_holder->log = log;
+        context_holder->provider = provider;
+        context_holder->region = effective_region;
+    }
+
+    // Pass context pointer in the configuration string to avoid using 'opaque' which is used by cppkafka.
+    WriteBufferFromOwnString wb;
+    writeText(reinterpret_cast<uintptr_t>(context_holder.get()), wb);
+    params.emplace_back("context_ptr", wb.str());
+
+    // Update query parameters with the new context_ptr
+    uri.setQueryParameters(params);
+    kafka_config.set("sasl.oauthbearer.config", uri.getRawQuery());
+
+    rd_kafka_conf_set_oauthbearer_token_refresh_cb(
+        kafka_config.get_handle(), oauthBearerTokenRefreshCallback);
+}
+
+}
+
+}
+
+#endif // USE_AWS_S3

--- a/src/Storages/Kafka/AWSMSKIAMAuth.cpp
+++ b/src/Storages/Kafka/AWSMSKIAMAuth.cpp
@@ -101,7 +101,6 @@ namespace
         const char * oauthbearer_config,
         void * /* opaque */)
     {
-        LoggerPtr log = getLogger("AWSMSKIAMAuth");
         std::shared_ptr<S3::S3CredentialsProviderChain> provider;
         String region;
 
@@ -133,16 +132,15 @@ namespace
             catch (...)
             {
                 // Ignore parsing errors, will fall back to default behavior (error)
-                tryLogCurrentException(log, "Failed to parse OAuth bearer config");
+                if (ctx && ctx->log)
+                    tryLogCurrentException(ctx->log, "Failed to parse OAuth bearer config");
             }
         }
 
+        LoggerPtr log;
         if (ctx)
         {
-            if (ctx->log)
-            {
-                log = ctx->log;
-            }
+            log = ctx->log;
             provider = ctx->provider;
             region = ctx->region;
         }
@@ -255,14 +253,6 @@ void setupAuthentication(
 
     bool use_environment_credentials = config.getBool("kafka.use_environment_credentials", false);
 
-    Poco::URI::QueryParameters params;
-    params.emplace_back("region", effective_region);
-    params.emplace_back("use_environment_credentials", use_environment_credentials ? "1" : "0");
-
-    Poco::URI uri;
-    uri.setQueryParameters(params);
-
-    kafka_config.set("sasl.oauthbearer.config", uri.getRawQuery());
     kafka_config.set("sasl.mechanism", "OAUTHBEARER");
     kafka_config.set("security.protocol", "SASL_SSL");
 
@@ -289,9 +279,11 @@ void setupAuthentication(
     // Pass context pointer in the configuration string to avoid using 'opaque' which is used by cppkafka.
     WriteBufferFromOwnString wb;
     writeText(reinterpret_cast<uintptr_t>(context_holder.get()), wb);
+    
+    Poco::URI::QueryParameters params;
     params.emplace_back("context_ptr", wb.str());
-
-    // Update query parameters with the new context_ptr
+    
+    Poco::URI uri;
     uri.setQueryParameters(params);
     kafka_config.set("sasl.oauthbearer.config", uri.getRawQuery());
 

--- a/src/Storages/Kafka/AWSMSKIAMAuth.h
+++ b/src/Storages/Kafka/AWSMSKIAMAuth.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "config.h"
+
+#if USE_AWS_S3
+
+#include <base/types.h>
+#include <Common/Logger.h>
+#include <cppkafka/configuration.h>
+#include <Poco/Util/AbstractConfiguration.h>
+
+namespace DB::S3 { class S3CredentialsProviderChain; }
+
+namespace DB::AWSMSKIAMAuth
+{
+
+struct OAuthBearerTokenRefreshContext
+{
+    LoggerPtr log;
+    std::shared_ptr<S3::S3CredentialsProviderChain> provider;
+    String region;
+};
+
+/// Extract AWS region from MSK broker hostname
+/// Matches patterns: *.kafka[-serverless].<region>[.vpce].amazonaws.com
+String extractRegionFromBroker(const String & broker_address);
+
+/// Setup AWS MSK IAM authentication for Kafka
+/// This configures librdkafka to use OAUTHBEARER with a callback
+/// that generates AWS MSK IAM tokens on-demand from configuration
+///
+/// @param kafka_config cppkafka Configuration object to modify
+/// @param config ClickHouse server configuration
+/// @param region AWS region (if empty, will auto-detect from broker_list)
+/// @param broker_list Comma-separated broker addresses (for region auto-detection)
+/// @param log Logger instance
+/// @param context_holder Shared pointer to hold the context, ensuring its lifetime matches the storage
+void setupAuthentication(
+    cppkafka::Configuration & kafka_config,
+    const Poco::Util::AbstractConfiguration & config,
+    const String & region,
+    const String & broker_list,
+    LoggerPtr log,
+    std::shared_ptr<OAuthBearerTokenRefreshContext> & context_holder);
+
+}
+
+#endif // USE_AWS_S3

--- a/src/Storages/Kafka/KafkaConfigLoader.cpp
+++ b/src/Storages/Kafka/KafkaConfigLoader.cpp
@@ -394,8 +394,15 @@ void updateConfigurationFromConfig(
                 ? kafka_config.get("metadata.broker.list")
                 : "";
 
-            AWSMSKIAMAuth::setupAuthentication(
-                kafka_config, params.config, aws_region, broker_list, params.log, storage.getOAuthContext());
+            // Check if OAuth context already exists to avoid recreating it
+            if (!storage.getOAuthContextPtr())
+            {
+                // First time: create and store the context
+                std::shared_ptr<AWSMSKIAMAuth::OAuthBearerTokenRefreshContext> new_context;
+                AWSMSKIAMAuth::setupAuthentication(
+                    kafka_config, params.config, aws_region, broker_list, params.log, new_context);
+                storage.setOAuthContext(std::move(new_context));
+            }
 #else
             throw Exception(ErrorCodes::SUPPORT_IS_DISABLED,
                 "AWS MSK IAM authentication is not supported in this build. "

--- a/src/Storages/Kafka/KafkaConsumer.cpp
+++ b/src/Storages/Kafka/KafkaConsumer.cpp
@@ -81,6 +81,14 @@ void KafkaConsumer::createConsumer(cppkafka::Configuration consumer_config)
     consumer = std::make_shared<cppkafka::Consumer>(std::move(consumer_config));
     consumer->set_destroy_flags(RD_KAFKA_DESTROY_F_NO_CONSUMER_CLOSE);
 
+    // Enable background SASL callbacks for OAUTHBEARER authentication.
+    if (auto * error = rd_kafka_sasl_background_callbacks_enable(consumer->get_handle()))
+    {
+        // If SASL background callbacks cannot be enabled (e.g., not configured or not supported),
+        // we still continue since this is not a critical error for basic Kafka functionality
+        rd_kafka_error_destroy(error);
+    }
+
     // called (synchronously, during poll) when we enter the consumer group
     consumer->set_assignment_callback([this](const cppkafka::TopicPartitionList & topic_partitions)
     {

--- a/src/Storages/Kafka/KafkaSettings.cpp
+++ b/src/Storages/Kafka/KafkaSettings.cpp
@@ -46,9 +46,10 @@ namespace ErrorCodes
     DECLARE(String, kafka_keeper_path, "", "The path to the table in ClickHouse Keeper", 0) \
     DECLARE(String, kafka_replica_name, "", "The replica name in ClickHouse Keeper", 0) \
     DECLARE(String, kafka_security_protocol, "", "Protocol used to communicate with brokers.", 0) \
-    DECLARE(String, kafka_sasl_mechanism, "", "SASL mechanism to use for authentication. Supported: GSSAPI, PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER.", 0) \
+    DECLARE(String, kafka_sasl_mechanism, "", "SASL mechanism to use for authentication. Supported: GSSAPI, PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER, AWS_MSK_IAM.", 0) \
     DECLARE(String, kafka_sasl_username, "", "SASL username for use with the PLAIN and SASL-SCRAM-.. mechanisms", 0) \
     DECLARE(String, kafka_sasl_password, "", "SASL password for use with the PLAIN and SASL-SCRAM-.. mechanisms", 0) \
+    DECLARE(String, kafka_aws_region, "", "AWS region for MSK IAM authentication. Auto-detected from broker address if not specified. Required for PrivateLink or custom DNS.", 0) \
     DECLARE(String, kafka_compression_codec, "", "Compression codec used for producing messages. Supported: empty string, none, gzip, snappy, lz4, zstd. In case of empty string the compression codec is not set by the table, thus values from the config files or default value from `librdkafka` will be used.", 0) \
     DECLARE(Int64, kafka_compression_level, -1, "Compression level parameter for algorithm selected by kafka_compression_codec. Higher values will result in better compression at the cost of more CPU usage. Usable range is algorithm-dependent: [0-9] for gzip; [0-12] for lz4; only 0 for snappy; [0-12] for zstd; -1 = codec-dependent default compression level.", 0) \
     DECLARE(UInt64, kafka_schema_registry_skip_bytes, 0, "Number of bytes to skip from the beginning of each Kafka message (e.g., 5 for Confluent Schema Registry, 19 for AWS Glue Schema Registry envelope header). Maximum: 255 bytes.", 0) \

--- a/src/Storages/Kafka/StorageKafka.h
+++ b/src/Storages/Kafka/StorageKafka.h
@@ -20,6 +20,8 @@
 namespace DB
 {
 
+namespace AWSMSKIAMAuth { struct OAuthBearerTokenRefreshContext; }
+
 struct KafkaSettings;
 class ReadFromStorageKafka;
 class ThreadStatus;
@@ -98,6 +100,8 @@ public:
 
     const KafkaSettings & getKafkaSettings() const { return *kafka_settings; }
 
+    std::shared_ptr<AWSMSKIAMAuth::OAuthBearerTokenRefreshContext> & getOAuthContext() { return oauth_context; }
+
 private:
     friend class ReadFromStorageKafka;
 
@@ -117,6 +121,7 @@ private:
     const SettingsChanges settings_adjustments;
 
     std::atomic<bool> mv_attached = false;
+    std::shared_ptr<AWSMSKIAMAuth::OAuthBearerTokenRefreshContext> oauth_context;
 
     std::vector<KafkaConsumerPtr> consumers;
 

--- a/src/Storages/Kafka/StorageKafka.h
+++ b/src/Storages/Kafka/StorageKafka.h
@@ -100,7 +100,8 @@ public:
 
     const KafkaSettings & getKafkaSettings() const { return *kafka_settings; }
 
-    std::shared_ptr<AWSMSKIAMAuth::OAuthBearerTokenRefreshContext> & getOAuthContext() { return oauth_context; }
+    AWSMSKIAMAuth::OAuthBearerTokenRefreshContext * getOAuthContextPtr() { return oauth_context.get(); }
+    void setOAuthContext(std::shared_ptr<AWSMSKIAMAuth::OAuthBearerTokenRefreshContext> context) { oauth_context = std::move(context); }
 
 private:
     friend class ReadFromStorageKafka;

--- a/src/Storages/Kafka/StorageKafka2.h
+++ b/src/Storages/Kafka/StorageKafka2.h
@@ -30,6 +30,8 @@ class Configuration;
 namespace DB
 {
 
+namespace AWSMSKIAMAuth { struct OAuthBearerTokenRefreshContext; }
+
 struct KafkaSettings;
 template <typename TStorageKafka>
 struct KafkaInterceptors;
@@ -111,6 +113,8 @@ public:
 
     const KafkaSettings & getKafkaSettings() const { return *kafka_settings; }
 
+    std::shared_ptr<AWSMSKIAMAuth::OAuthBearerTokenRefreshContext> & getOAuthContext() { return oauth_context; }
+
     SafeConsumers getSafeConsumers() { return {shared_from_this(), std::unique_lock(consumers_mutex), consumers}; }
 
 private:
@@ -152,6 +156,7 @@ private:
     /// Can differ from num_consumers in case of exception in startup() (or if startup() hasn't been called).
     /// In this case we still need to be able to shutdown() properly.
     size_t num_created_consumers = 0; /// number of actually created consumers.
+    std::shared_ptr<AWSMSKIAMAuth::OAuthBearerTokenRefreshContext> oauth_context;
 
     std::mutex consumers_mutex;
     std::condition_variable cv;

--- a/src/Storages/Kafka/StorageKafka2.h
+++ b/src/Storages/Kafka/StorageKafka2.h
@@ -113,7 +113,8 @@ public:
 
     const KafkaSettings & getKafkaSettings() const { return *kafka_settings; }
 
-    std::shared_ptr<AWSMSKIAMAuth::OAuthBearerTokenRefreshContext> & getOAuthContext() { return oauth_context; }
+    AWSMSKIAMAuth::OAuthBearerTokenRefreshContext * getOAuthContextPtr() { return oauth_context.get(); }
+    void setOAuthContext(std::shared_ptr<AWSMSKIAMAuth::OAuthBearerTokenRefreshContext> context) { oauth_context = std::move(context); }
 
     SafeConsumers getSafeConsumers() { return {shared_from_this(), std::unique_lock(consumers_mutex), consumers}; }
 


### PR DESCRIPTION
### Changelog category (leave one):
- New Feature

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Add support for AWS MSK IAM authentication for Kafka.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

### Description

This PR implements AWS MSK IAM authentication support for the Kafka Table Engine.
It allows ClickHouse to authenticate with Amazon Managed Streaming for Apache Kafka (MSK) using IAM roles.

**Motivation:**
Many users running ClickHouse on AWS want to connect to MSK using the standard IAM authentication method for better security and management, rather than managing SASL/SCRAM credentials or mTLS certificates.

**Changes:**
- Added `AWSMSKIAMAuth` class (`src/Storages/Kafka/AWSMSKIAMAuth.cpp/h`) to handle IAM authentication logic.
- Updated `StorageKafka` and `KafkaConsumer` to use the new authentication mechanism.
- Added configuration settings for AWS MSK IAM auth.
- Updated `librdkafka-cmake` to support the necessary build options.
- Updated documentation with usage examples.