### PR TITLE
Update introduced in versions

### DIFF
--- a/src/Functions/isDistinctFrom.cpp
+++ b/src/Functions/isDistinctFrom.cpp
@@ -45,7 +45,7 @@ SELECT
         )"}
     };
 
-    FunctionDocumentation::IntroducedIn introduced_in = {25, 9};
+    FunctionDocumentation::IntroducedIn introduced_in = {25, 11};
 
     FunctionDocumentation::Category category = FunctionDocumentation::Category::Comparison;
 

--- a/src/Functions/isNotDistinctFrom.cpp
+++ b/src/Functions/isNotDistinctFrom.cpp
@@ -43,7 +43,7 @@ SELECT
         )"}
     };
 
-    FunctionDocumentation::IntroducedIn introduced_in = {25, 9};
+    FunctionDocumentation::IntroducedIn introduced_in = {25, 10};
 
     FunctionDocumentation::Category category = FunctionDocumentation::Category::Comparison;
 


### PR DESCRIPTION
`isNotDistinctFrom` got its full implementation with PR #88155 in 25.10. `isDistinctFrom` was introduced by #87581 in 25.11.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
