### PR TITLE
Disable join_use_nulls for 03716_multiple_joins_using_top_level

### DIFF
--- a/tests/queries/0_stateless/03716_multiple_joins_using_top_level_identifier.sql
+++ b/tests/queries/0_stateless/03716_multiple_joins_using_top_level_identifier.sql
@@ -14,11 +14,16 @@ INSERT INTO t3 VALUES ('a_1', 'c'), ('b_1', 'd');
 
 SET enable_analyzer = 1;
 
+-- TODO: join_use_nulls reveals another issue in stress tests
+-- Mute for now and track bug in
+-- https://github.com/ClickHouse/ClickHouse/issues/87016
+
 SELECT t1.id || '_1' AS id, t1.val
 FROM t1
 LEFT JOIN t2 ON t1.id = t2.id
 LEFT JOIN t3 USING (id)
 ORDER BY t1.val
+SETTINGS join_use_nulls = 0
 ;
 
 SELECT t2.id || '_1' AS id, t1.val
@@ -26,6 +31,7 @@ FROM t1
 LEFT JOIN t2 ON t1.id = t2.id
 LEFT JOIN t3 USING (id)
 ORDER BY t1.val
+SETTINGS join_use_nulls = 0
 ;
 
 SELECT t1.id || t2.id || '_1' AS id, t1.val
@@ -33,4 +39,5 @@ FROM t1
 INNER JOIN t2 ON t1.id = t2.id
 LEFT JOIN t3 USING (id)
 ORDER BY t1.val
+SETTINGS join_use_nulls = 0
 ; -- { serverError AMBIGUOUS_IDENTIFIER }


### PR DESCRIPTION

### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

Ref https://github.com/ClickHouse/ClickHouse/issues/87016, revert after bug is fixed