### PR TITLE
Update topK documentation about N

### DIFF
--- a/docs/en/sql-reference/aggregate-functions/reference/approxtopk.md
+++ b/docs/en/sql-reference/aggregate-functions/reference/approxtopk.md
@@ -18,7 +18,7 @@ approx_top_k(N, reserved)(column)
 
 This function does not provide a guaranteed result. In certain situations, errors might occur and it might return frequent values that aren't the most frequent values.
 
-We recommend using the `N < 10` value; performance is reduced with large `N` values. Maximum value of `N = 65536`.
+Maximum value of `N = 65536`.
 
 **Parameters**
 

--- a/docs/en/sql-reference/aggregate-functions/reference/approxtopsum.md
+++ b/docs/en/sql-reference/aggregate-functions/reference/approxtopsum.md
@@ -18,7 +18,7 @@ approx_top_sum(N, reserved)(column, weight)
 
 This function does not provide a guaranteed result. In certain situations, errors might occur and it might return frequent values that aren't the most frequent values.
 
-We recommend using the `N < 10` value; performance is reduced with large `N` values. Maximum value of `N = 65536`.
+Maximum value of `N = 65536`.
 
 **Parameters**
 

--- a/docs/en/sql-reference/aggregate-functions/reference/topk.md
+++ b/docs/en/sql-reference/aggregate-functions/reference/topk.md
@@ -22,7 +22,7 @@ topK(N, load_factor, 'counts')(column)
 
 This function does not provide a guaranteed result. In certain situations, errors might occur and it might return frequent values that aren't the most frequent values.
 
-We recommend using the `N < 10` value; performance is reduced with large `N` values. Maximum value of `N = 65536`.
+Maximum value of `N = 65536`.
 
 **Parameters**
 


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Update topK documentation about N

After https://github.com/ClickHouse/ClickHouse/pull/90091 this is no longer  true. The performance is pretty much the same independently of the value of `N` (because N can't be extremely high):

```
:) SELECT length(topK(10)(number)) FROM numbers(100_000_000)

SELECT length(topK(10)(number))
FROM numbers(100000000)

Query id: d8caaea5-7703-4d27-b2e0-35182e2cce0c

   ┌─length(topK(10)(number))─┐
1. │                       10 │
   └──────────────────────────┘

1 row in set. Elapsed: 1.200 sec. Processed 91.90 million rows, 735.20 MB (76.56 million rows/s., 612.52 MB/s.)
Peak memory usage: 76.91 KiB.

:) SELECT length(topK(10000)(number)) FROM numbers(100_000_000)

SELECT length(topK(10000)(number))
FROM numbers(100000000)

Query id: 3dbfb71a-4f21-445b-92b6-e25d1e1a9bba

   ┌─length(topK(10000)(number))─┐
1. │                       10000 │
   └─────────────────────────────┘

1 row in set. Elapsed: 1.232 sec. Processed 97.59 million rows, 780.72 MB (79.23 million rows/s., 633.87 MB/s.)
Peak memory usage: 14.33 MiB.
```


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
