### PR TITLE
Fix possible inconsistent dynamic structure during writing in compact parts

### DIFF
--- a/src/Columns/ColumnArray.h
+++ b/src/Columns/ColumnArray.h
@@ -216,6 +216,7 @@ public:
     bool hasDynamicStructure() const override { return getData().hasDynamicStructure(); }
     void takeDynamicStructureFromSourceColumns(const Columns & source_columns, std::optional<size_t> max_dynamic_subcolumns) override;
     void takeDynamicStructureFromColumn(const ColumnPtr & source_column) override;
+    void fixDynamicStructure() override { data->fixDynamicStructure(); }
 
     bool dynamicStructureEquals(const IColumn & rhs) const override
     {

--- a/src/Columns/ColumnBLOB.h
+++ b/src/Columns/ColumnBLOB.h
@@ -201,6 +201,7 @@ public:
     bool hasDynamicStructure() const override { throwInapplicable(); }
     void takeDynamicStructureFromSourceColumns(const Columns &, std::optional<size_t>) override { throwInapplicable(); }
     void takeDynamicStructureFromColumn(const ColumnPtr &) override { throwInapplicable(); }
+    void fixDynamicStructure() override { throwInapplicable(); }
 
 private:
     /// Compressed and serialized representation of the wrapped column.

--- a/src/Columns/ColumnCompressed.h
+++ b/src/Columns/ColumnCompressed.h
@@ -137,6 +137,7 @@ public:
     bool hasDynamicStructure() const override { throwMustBeDecompressed(); }
     void takeDynamicStructureFromSourceColumns(const Columns &, std::optional<size_t>) override { throwMustBeDecompressed(); }
     void takeDynamicStructureFromColumn(const ColumnPtr &) override { throwMustBeDecompressed(); }
+    void fixDynamicStructure() override { throwMustBeDecompressed(); }
 
 protected:
     size_t rows;

--- a/src/Columns/ColumnDynamic.cpp
+++ b/src/Columns/ColumnDynamic.cpp
@@ -1425,6 +1425,15 @@ void ColumnDynamic::takeDynamicStructureFromColumn(const ColumnPtr & source_colu
         variant_col.getVariantByGlobalDiscriminator(i).takeDynamicStructureFromColumn(source_variant_column.getVariantPtrByGlobalDiscriminator(i));
 }
 
+void ColumnDynamic::fixDynamicStructure()
+{
+    /// Reduce max_dynamic_types to the number of selected variants, so there will be no possibility
+    /// to extend selected variants on inserts into this column.
+    /// -1 because we don't count shared variant in the limit.
+    max_dynamic_types = variant_info.variant_names.size() - 1;
+    getVariantColumn().fixDynamicStructure();
+}
+
 void ColumnDynamic::applyNullMap(const ColumnVector<UInt8>::Container & null_map)
 {
     variant_column_ptr->applyNullMap(null_map);

--- a/src/Columns/ColumnDynamic.h
+++ b/src/Columns/ColumnDynamic.h
@@ -387,6 +387,7 @@ public:
     bool dynamicStructureEquals(const IColumn & rhs) const override;
     void takeDynamicStructureFromSourceColumns(const Columns & source_columns, std::optional<size_t> max_dynamic_subcolumns) override;
     void takeDynamicStructureFromColumn(const ColumnPtr & source_column) override;
+    void fixDynamicStructure() override;
 
     const StatisticsPtr & getStatistics() const { return statistics; }
     void setStatistics(const StatisticsPtr & statistics_) { statistics = statistics_; }

--- a/src/Columns/ColumnMap.h
+++ b/src/Columns/ColumnMap.h
@@ -128,6 +128,7 @@ public:
     bool dynamicStructureEquals(const IColumn & rhs) const override;
     void takeDynamicStructureFromSourceColumns(const Columns & source_columns, std::optional<size_t> max_dynamic_subcolumns) override;
     void takeDynamicStructureFromColumn(const ColumnPtr & source_column) override;
+    void fixDynamicStructure() override { nested->fixDynamicStructure(); }
 };
 
 }

--- a/src/Columns/ColumnNullable.h
+++ b/src/Columns/ColumnNullable.h
@@ -233,6 +233,7 @@ public:
     bool hasDynamicStructure() const override { return nested_column->hasDynamicStructure(); }
     void takeDynamicStructureFromSourceColumns(const Columns & source_columns, std::optional<size_t> max_dynamic_subcolumns) override;
     void takeDynamicStructureFromColumn(const ColumnPtr & source_column) override;
+    void fixDynamicStructure() override { nested_column->fixDynamicStructure(); }
     bool dynamicStructureEquals(const IColumn & rhs) const override;
 
 private:

--- a/src/Columns/ColumnObject.cpp
+++ b/src/Columns/ColumnObject.cpp
@@ -1871,6 +1871,13 @@ void ColumnObject::takeDynamicStructureFromColumn(const ColumnPtr & source_colum
     statistics = source_object.getStatistics();
 }
 
+void ColumnObject::fixDynamicStructure()
+{
+    /// Set max_dynamic_paths to the number of dynamic paths.
+    /// It's needed to avoid adding new unexpected dynamic paths during later inserts into this column.
+    max_dynamic_paths = dynamic_paths.size();
+}
+
 size_t ColumnObject::findPathLowerBoundInSharedData(std::string_view path, const ColumnString & shared_data_paths, size_t start, size_t end)
 {
     /// Simple random access iterator over values in ColumnString in specified range.

--- a/src/Columns/ColumnObject.h
+++ b/src/Columns/ColumnObject.h
@@ -205,6 +205,7 @@ public:
     bool dynamicStructureEquals(const IColumn & rhs) const override;
     void takeDynamicStructureFromSourceColumns(const Columns & source_columns, std::optional<size_t> max_dynamic_subcolumns) override;
     void takeDynamicStructureFromColumn(const ColumnPtr & source_column) override;
+    void fixDynamicStructure() override;
 
     const PathToColumnMap & getTypedPaths() const { return typed_paths; }
     PathToColumnMap & getTypedPaths() { return typed_paths; }

--- a/src/Columns/ColumnReplicated.h
+++ b/src/Columns/ColumnReplicated.h
@@ -186,6 +186,7 @@ public:
     bool hasDynamicStructure() const override { return nested_column->hasDynamicStructure(); }
     void takeDynamicStructureFromSourceColumns(const Columns & source_columns, std::optional<size_t> max_dynamic_subcolumns) override;
     void takeDynamicStructureFromColumn(const ColumnPtr & source_column) override;
+    void fixDynamicStructure() override { nested_column->fixDynamicStructure(); }
 
     const ColumnIndex & getIndexes() const { return indexes; }
     ColumnIndex & getIndexes() { return indexes; }

--- a/src/Columns/ColumnSparse.h
+++ b/src/Columns/ColumnSparse.h
@@ -172,6 +172,7 @@ public:
     bool hasDynamicStructure() const override { return values->hasDynamicStructure(); }
     void takeDynamicStructureFromSourceColumns(const Columns & source_columns, std::optional<size_t> max_dynamic_subcolumns) override;
     void takeDynamicStructureFromColumn(const ColumnPtr & source_column) override;
+    void fixDynamicStructure() override { values->fixDynamicStructure(); }
 
     size_t getNumberOfTrailingDefaults() const
     {

--- a/src/Columns/ColumnTuple.cpp
+++ b/src/Columns/ColumnTuple.cpp
@@ -924,6 +924,11 @@ void ColumnTuple::takeDynamicStructureFromColumn(const ColumnPtr & source_column
         columns[i]->takeDynamicStructureFromColumn(source_elements[i]);
 }
 
+void ColumnTuple::fixDynamicStructure()
+{
+    for (size_t i = 0; i != columns.size(); ++i)
+        columns[i]->fixDynamicStructure();
+}
 
 ColumnPtr ColumnTuple::compress(bool force_compression) const
 {

--- a/src/Columns/ColumnTuple.cpp
+++ b/src/Columns/ColumnTuple.cpp
@@ -926,8 +926,8 @@ void ColumnTuple::takeDynamicStructureFromColumn(const ColumnPtr & source_column
 
 void ColumnTuple::fixDynamicStructure()
 {
-    for (size_t i = 0; i != columns.size(); ++i)
-        columns[i]->fixDynamicStructure();
+    for (auto & column : columns)
+        column->fixDynamicStructure();
 }
 
 ColumnPtr ColumnTuple::compress(bool force_compression) const

--- a/src/Columns/ColumnTuple.h
+++ b/src/Columns/ColumnTuple.h
@@ -150,6 +150,7 @@ public:
     bool dynamicStructureEquals(const IColumn & rhs) const override;
     void takeDynamicStructureFromSourceColumns(const Columns & source_columns, std::optional<size_t> max_dynamic_subcolumns) override;
     void takeDynamicStructureFromColumn(const ColumnPtr & source_column) override;
+    void fixDynamicStructure() override;
 
     /// Empty tuple needs a public method to manage its size.
     void addSize(size_t delta) { column_length += delta; }

--- a/src/Columns/ColumnVariant.cpp
+++ b/src/Columns/ColumnVariant.cpp
@@ -1781,5 +1781,11 @@ void ColumnVariant::takeDynamicStructureFromColumn(const ColumnPtr & source_colu
         getVariantByGlobalDiscriminator(i).takeDynamicStructureFromColumn(source_variant.getVariantPtrByGlobalDiscriminator(i));
 }
 
+void ColumnVariant::fixDynamicStructure()
+{
+    for (auto & variant : variants)
+        variant->fixDynamicStructure();
+}
+
 
 }

--- a/src/Columns/ColumnVariant.h
+++ b/src/Columns/ColumnVariant.h
@@ -346,6 +346,7 @@ public:
     bool dynamicStructureEquals(const IColumn & rhs) const override;
     void takeDynamicStructureFromSourceColumns(const Columns & source_columns, std::optional<size_t> max_dynamic_subcolumns) override;
     void takeDynamicStructureFromColumn(const ColumnPtr & source_column) override;
+    void fixDynamicStructure() override;
 
 private:
     void insertFromImpl(const IColumn & src_, size_t n, const std::vector<ColumnVariant::Discriminator> * global_discriminators_mapping);

--- a/src/Columns/IColumn.h
+++ b/src/Columns/IColumn.h
@@ -692,6 +692,8 @@ public:
     virtual void takeDynamicStructureFromSourceColumns(const std::vector<Ptr> & /*source_columns*/, std::optional<size_t> /*max_dynamic_subcolumns*/) {}
     /// For columns with dynamic subcolumns this method takes the exact dynamic structure from provided column.
     virtual void takeDynamicStructureFromColumn(const ColumnPtr & /*source_column*/) {}
+    /// For columns with dynamic subcolumns fix current dynamic structure so later inserts into this column won't change it.
+    virtual void fixDynamicStructure() {}
 
     /** Some columns can contain another columns inside.
       * So, we have a tree of columns. But not all combinations are possible.

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterCompact.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterCompact.cpp
@@ -503,7 +503,11 @@ void MergeTreeDataPartWriterCompact::ColumnsBuffer::add(MutableColumns && column
     else
     {
         for (size_t i = 0; i < columns.size(); ++i)
+        {
+            /// Fix dynamic structure so it won't changed after insertion of new rows.
+            accumulated_columns[i]->fixDynamicStructure();
             accumulated_columns[i]->insertRangeFrom(*columns[i], 0, columns[i]->size());
+        }
     }
 }
 

--- a/tests/queries/0_stateless/03745_fix_dynamic_structure_in_compact_part.sql
+++ b/tests/queries/0_stateless/03745_fix_dynamic_structure_in_compact_part.sql
@@ -1,15 +1,6 @@
 drop table if exists test;
-create table test (id UInt64, json JSON) engine=CoalescingMergeTree order by id settings min_bytes_for_wide_part='100G', merge_max_block_size=333, index_granularity=8128;
-insert into test select number, '{}' from numbers(100000);
-alter table test update json = '{"a" : 42}' where id > 90000 settings mutations_sync=1;
+create table test (id UInt64, json JSON) engine=CoalescingMergeTree order by id settings min_bytes_for_wide_part='100G', merge_max_block_size=33, index_granularity=800;
+insert into test select number, '{}' from numbers(10000);
+alter table test update json = '{"a" : 42}' where id > 9000 settings mutations_sync=1;
 optimize table test final;
 drop table test;
-
--- Second table with no fixed merge_max_block_size and index_granularity for randomization.
-drop table if exists test;
-create table test (id UInt64, json JSON) engine=CoalescingMergeTree order by id settings min_bytes_for_wide_part='100G';
-insert into test select number, '{}' from numbers(100000);
-alter table test update json = '{"a" : 42}' where id > 90000 settings mutations_sync=1;
-optimize table test final;
-drop table test;
-

--- a/tests/queries/0_stateless/03745_fix_dynamic_structure_in_compact_part.sql
+++ b/tests/queries/0_stateless/03745_fix_dynamic_structure_in_compact_part.sql
@@ -1,0 +1,15 @@
+drop table if exists test;
+create table test (id UInt64, json JSON) engine=CoalescingMergeTree order by id settings min_bytes_for_wide_part='100G', merge_max_block_size=333, index_granularity=8128;
+insert into test select number, '{}' from numbers(100000);
+alter table test update json = '{"a" : 42}' where id > 90000 settings mutations_sync=1;
+optimize table test final;
+drop table test;
+
+-- Second table with no fixed merge_max_block_size and index_granularity for randomization.
+drop table if exists test;
+create table test (id UInt64, json JSON) engine=CoalescingMergeTree order by id settings min_bytes_for_wide_part='100G';
+insert into test select number, '{}' from numbers(100000);
+alter table test update json = '{"a" : 42}' where id > 90000 settings mutations_sync=1;
+optimize table test final;
+drop table test;
+


### PR DESCRIPTION
<!-- Fixes issue link part, do not remove -->
## Linked issues
- fixes https://github.com/ClickHouse/clickhouse-core-incidents/issues/1436
<!-- End of fixes issue link part, do not remove -->

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix possible inconsistent dynamic structure during writing in compact parts that could lead to segfault.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
