### PR TITLE
ci/integration: enable database disk only for "db disk" jobs

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -2007,7 +2007,7 @@ class ClickHouseCluster:
             with_remote_database_disk = False
 
         if with_remote_database_disk is None:
-            with_remote_database_disk = os.getenv("CLICKHOUSE_USE_DATABASE_DISK")
+            with_remote_database_disk = int(os.getenv("CLICKHOUSE_USE_DATABASE_DISK"))
 
         if with_remote_database_disk:
             logging.debug(f"Instance {name}, with_remote_database_disk enabled")


### PR DESCRIPTION
getenv(CLICKHOUSE_USE_DATABASE_DISK=0) returns str(0), which does not considered as False

Found while reviewing one PR

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
