### PR TITLE
CI: Fix GH auth in Finish check

### DIFF
--- a/ci/praktika/native_jobs.py
+++ b/ci/praktika/native_jobs.py
@@ -671,6 +671,7 @@ def _finish_workflow(workflow, job_name):
             continue
         if result.status == Result.Status.DROPPED:
             dropped_results.append(result.name)
+            continue
         if not result.is_completed():
             print(
                 f"ERROR: not finished job [{result.name}] in the workflow - set status to error"

--- a/ci/praktika/native_jobs.py
+++ b/ci/praktika/native_jobs.py
@@ -613,6 +613,13 @@ def _finish_workflow(workflow, job_name):
     )
     workflow_result = Result.from_fs(workflow.name)
 
+    if (
+        workflow.enable_merge_ready_status
+        or workflow.enable_open_issues_check
+        or workflow.post_hooks
+    ):
+        _GH_Auth(workflow)
+
     update_final_report = False
     results = []
     if workflow.post_hooks:
@@ -638,20 +645,20 @@ def _finish_workflow(workflow, job_name):
     if results and any(not result.is_ok() for result in results):
         failed_results.append("Workflow Post Hook")
 
-    if workflow.enable_flaky_tests_catalog and workflow.enable_merge_ready_status:
+    if workflow.enable_open_issues_check:
 
         def do():
             try:
                 _check_and_mark_flaky_tests(workflow_result)
             except Exception as e:
-                print(f"ERROR: failed to check flaky tests: {e}")
+                print(f"ERROR: failed to check open issues: {e}")
                 traceback.print_exc()
-                env.add_info("Flaky tests check failed")
+                env.add_info("Open issues check failed")
             return True  # make it always success for now
 
         results.append(
             Result.from_commands_run(
-                name="Flaky Tests Check", command=do, with_info=True
+                name="Open issues check", command=do, with_info=True
             )
         )
 
@@ -693,19 +700,16 @@ def _finish_workflow(workflow, job_name):
         if dropped_results:
             ready_for_merge_description += f", Dropped: {len(dropped_results)}"
 
-    if workflow.enable_merge_ready_status or workflow.enable_gh_summary_comment:
-        _GH_Auth(workflow)
-
-        if workflow.enable_merge_ready_status:
-            if not GH.post_commit_status(
-                name=Settings.READY_FOR_MERGE_CUSTOM_STATUS_NAME
-                or f"Ready For Merge [{workflow.name}]",
-                status=ready_for_merge_status,
-                description=ready_for_merge_description,
-                url="",
-            ):
-                print(f"ERROR: failed to set ReadyForMerge status")
-                env.add_info(ResultInfo.GH_STATUS_ERROR)
+    if workflow.enable_merge_ready_status:
+        if not GH.post_commit_status(
+            name=Settings.READY_FOR_MERGE_CUSTOM_STATUS_NAME
+            or f"Ready For Merge [{workflow.name}]",
+            status=ready_for_merge_status,
+            description=ready_for_merge_description,
+            url="",
+        ):
+            print(f"ERROR: failed to set ReadyForMerge status")
+            env.add_info(ResultInfo.GH_STATUS_ERROR)
 
     if update_final_report:
         _ResultS3.copy_result_to_s3_with_version(workflow_result, version + 1)

--- a/ci/praktika/validator.py
+++ b/ci/praktika/validator.py
@@ -211,10 +211,10 @@ class Validator:
                     Settings.DOCKERHUB_SECRET
                 ), f"Secret [{Settings.DOCKERHUB_SECRET}] must have configuration in workflow.secrets, workflow [{workflow.name}]"
 
-            if workflow.enable_flaky_tests_catalog:
+            if workflow.enable_open_issues_check:
                 cls.evaluate_check(
                     workflow.enable_merge_ready_status,
-                    f".enable_flaky_tests_catalog workflow setting is applicable with .enable_merge_ready_status=True",
+                    f".enable_open_issues_check workflow setting is applicable with .enable_merge_ready_status=True",
                     workflow_name=workflow.name,
                 )
 

--- a/ci/praktika/workflow.py
+++ b/ci/praktika/workflow.py
@@ -52,8 +52,8 @@ class Workflow:
         enable_dockers_manifest_merge: bool = False
         # If latest tag shpuld be added for merged docker manifest, enable with .enable_dockers_manifest_merge
         set_latest_for_docker_merged_manifest: bool = False
-        # if enabled, Finish job will fetch flaky check catalog and match failed tests with them
-        enable_flaky_tests_catalog: bool = False
+        # if enabled, Finish job will fetch open gh issues and match failed tests with them
+        enable_open_issues_check: bool = False
         # Job aliases for easy job reference with `praktika run job_alias --test TEST_NAME` in local environment
         job_aliases: Dict[str, str] = field(default_factory=dict)
 

--- a/ci/workflows/pull_request.py
+++ b/ci/workflows/pull_request.py
@@ -133,7 +133,7 @@ workflow = Workflow.Config(
     enable_merge_ready_status=True,
     enable_gh_summary_comment=True,
     enable_commit_status_on_failure=False,
-    enable_flaky_tests_catalog=True,
+    enable_open_issues_check=True,
     pre_hooks=[
         can_be_trusted,
         "python3 ./ci/jobs/scripts/workflow_hooks/store_data.py",


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

---
- Trigger GH auth in the beginning of the Finish check job as it may be required in job.post_hooks
- Rename ci feature `enable_flaky_check_catalog` to `enable_open_issues_check` as it has more generic scope than just flaky test check (broken tests, known ch issues: logical errors, etc.)
- Fix failure counting in Megreable check status description (before the fix dropped jobs fall into both buckets: failed and dropped)