### PR TITLE
Implement dynamic dispatch to convert column to bool

### DIFF
--- a/src/Columns/FilterDescription.cpp
+++ b/src/Columns/FilterDescription.cpp
@@ -6,30 +6,49 @@
 #include <Columns/ColumnNullable.h>
 #include <Columns/ColumnConst.h>
 #include <Columns/ColumnSparse.h>
+#include <Common/TargetSpecific.h>
 #include <Core/ColumnWithTypeAndName.h>
 
 
 namespace DB
 {
-
 namespace ErrorCodes
 {
-    extern const int ILLEGAL_TYPE_OF_COLUMN_FOR_FILTER;
+extern const int ILLEGAL_TYPE_OF_COLUMN_FOR_FILTER;
 }
 
+MULTITARGET_FUNCTION_AVX512BW_AVX2(
+MULTITARGET_FUNCTION_HEADER(
 template <typename T>
-bool tryConvertColumnToBool(const IColumn & column, IColumnFilter & res)
+void), convertColumnToBoolImpl, MULTITARGET_FUNCTION_BODY((const typename ColumnVector<T>::Container & data, IColumnFilter & res)
+{
+    for (size_t i = 0; i < res.size(); ++i)
+        res[i] = static_cast<bool>(data[i]);
+})
+);
+
+template <typename T>
+ALWAYS_INLINE bool tryConvertColumnToBool(const IColumn & column, IColumnFilter & res)
 {
     const auto * column_typed = checkAndGetColumn<ColumnVector<T>>(&column);
     if (!column_typed)
         return false;
-
+    chassert(res.size() == column.size());
 
     auto & data = column_typed->getData();
-    size_t data_size = data.size();
-    res.resize(data_size);
-    for (size_t i = 0; i < data_size; ++i)
-        res[i] = static_cast<bool>(data[i]);
+#if USE_MULTITARGET_CODE
+    if (isArchSupported(TargetArch::AVX512BW))
+    {
+        convertColumnToBoolImplAVX512BW<T>(data, res);
+        return true;
+    }
+    if (isArchSupported(TargetArch::AVX2))
+    {
+        convertColumnToBoolImplAVX2<T>(data, res);
+        return true;
+    }
+#endif
+    convertColumnToBoolImpl<T>(data, res);
 
     return true;
 }

--- a/src/Functions/FunctionsLogical.cpp
+++ b/src/Functions/FunctionsLogical.cpp
@@ -658,7 +658,7 @@ ColumnPtr basicExecuteImpl(ColumnRawPtrs arguments, size_t input_rows_count)
         }
         else
         {
-            auto converted_column = ColumnUInt8::create();
+            auto converted_column = ColumnUInt8::create(column->size());
             if (!tryConvertAnyColumnToBool(*column, converted_column->getData()))
                 throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Unexpected type of column: {}", column->getName());
             uint8_args.push_back(converted_column.get());

--- a/src/Interpreters/JoinUtils.cpp
+++ b/src/Interpreters/JoinUtils.cpp
@@ -484,8 +484,7 @@ ColumnPtr castToBoolColumn(ColumnPtr column)
 {
     if (!typeid_cast<const ColumnUInt8 *>(column.get()))
     {
-        auto casted_column = ColumnUInt8::create();
-        casted_column->getData().resize(column->size());
+        auto casted_column = ColumnUInt8::create(column->size());
         if (!tryConvertAnyColumnToBool(*column, casted_column->getData()))
             throw Exception(ErrorCodes::LOGICAL_ERROR,
                 "Illegal type {} of column for JOIN filter. Must be Number or Nullable(Number).", column->getName());


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Speed up converting columns to bool (in WHERE clauses) via dynamic dispatch

Comes from https://github.com/ClickHouse/ClickHouse/pull/90043

Example:
```
clickhouse benchmark --port 49000 --query "SELECT count() FROM (SELECT materialize(0) AS x1, materialize(toUInt32(0)) AS x2, materialize(toUInt64(0)) AS x3 FROM zeros(100000000)) WHERE NOT ignore(and(x1,x2,x3))" -i 100
```
* Before: 0.0.0.0:49000, queries: 200, QPS: 15.726, RPS: 1572765030.671, MiB/s: 1499.906, result RPS: 15.726, result MiB/s: 0.000.
* After: 0.0.0.0:49000, queries: 200, QPS: 22.871, RPS: 2287370870.783, MiB/s: 2181.407, result RPS: 22.871, result MiB/s: 0.000.


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
