### PR TITLE
Speed up single numeric block sorting via dynamic dispatch

### DIFF
--- a/src/Columns/ColumnVector.cpp
+++ b/src/Columns/ColumnVector.cpp
@@ -256,15 +256,15 @@ void), compareColumnImpl, MULTITARGET_FUNCTION_BODY((
 {
     auto * result_data = compare_results.data();
     size_t num_rows = data.size();
-    if (direction)
+    if (direction < 0)
     {
         for (size_t row = 0; row < num_rows; row++)
-            result_data[row] = static_cast<Int8>(CompareHelper<T>::compare(data[row], value, nan_direction_hint));
+            result_data[row] = static_cast<Int8>(CompareHelper<T>::compare(value, data[row], nan_direction_hint));
     }
     else
     {
         for (size_t row = 0; row < num_rows; row++)
-            result_data[row] = static_cast<Int8>(CompareHelper<T>::compare(value, data[row], nan_direction_hint));
+            result_data[row] = static_cast<Int8>(CompareHelper<T>::compare(data[row], value, nan_direction_hint));
     }
 })
 )
@@ -292,11 +292,11 @@ void ColumnVector<T>::compareColumn(
     {
         auto * result_data = compare_results.data();
         UInt64 * next_index = row_indexes->data();
-        if (direction)
+        if (direction < 0)
         {
             for (auto row : *row_indexes)
             {
-                result_data[row] = static_cast<Int8>(CompareHelper<T>::compare(data[row], value, nan_direction_hint));
+                result_data[row] = static_cast<Int8>(CompareHelper<T>::compare(value, data[row], nan_direction_hint));
                 if (result_data[row] == 0)
                 {
                     *next_index = row;
@@ -308,7 +308,7 @@ void ColumnVector<T>::compareColumn(
         {
             for (auto row : *row_indexes)
             {
-                result_data[row] = static_cast<Int8>(CompareHelper<T>::compare(value, data[row], nan_direction_hint));
+                result_data[row] = static_cast<Int8>(CompareHelper<T>::compare(data[row], value, nan_direction_hint));
                 if (result_data[row] == 0)
                 {
                     *next_index = row;

--- a/src/Columns/ColumnVector.cpp
+++ b/src/Columns/ColumnVector.cpp
@@ -244,6 +244,98 @@ llvm::Value * ColumnVector<T>::compileComparator(llvm::IRBuilderBase & builder, 
 
 #endif
 
+MULTITARGET_FUNCTION_AVX512BW_AVX2(
+MULTITARGET_FUNCTION_HEADER(
+template <typename T>
+void), compareColumnImpl, MULTITARGET_FUNCTION_BODY((
+    const typename ColumnVector<T>::Container & data,
+    T value,
+    PaddedPODArray<Int8> & compare_results,
+    int direction,
+    int nan_direction_hint)
+{
+    auto * result_data = compare_results.data();
+    size_t num_rows = data.size();
+    if (direction)
+    {
+        for (size_t row = 0; row < num_rows; row++)
+            result_data[row] = static_cast<Int8>(CompareHelper<T>::compare(data[row], value, nan_direction_hint));
+    }
+    else
+    {
+        for (size_t row = 0; row < num_rows; row++)
+            result_data[row] = static_cast<Int8>(CompareHelper<T>::compare(value, data[row], nan_direction_hint));
+    }
+})
+)
+
+template <typename T>
+void ColumnVector<T>::compareColumn(
+    const IColumn & rhs,
+    size_t rhs_row_num,
+    PaddedPODArray<UInt64> * row_indexes,
+    PaddedPODArray<Int8> & compare_results,
+    int direction,
+    int nan_direction_hint) const
+{
+    size_t num_rows = size();
+    if (compare_results.empty())
+        compare_results.resize(num_rows);
+    else if (compare_results.size() != num_rows)
+        throw Exception(
+            ErrorCodes::LOGICAL_ERROR, "Size of compare_results: {} doesn't match rows_num: {}", compare_results.size(), num_rows);
+
+    const auto & rhs_derived = static_cast<const ColumnVector<T> &>(rhs);
+    T value = rhs_derived.data[rhs_row_num];
+
+    if (row_indexes)
+    {
+        auto * result_data = compare_results.data();
+        UInt64 * next_index = row_indexes->data();
+        if (direction)
+        {
+            for (auto row : *row_indexes)
+            {
+                result_data[row] = static_cast<Int8>(CompareHelper<T>::compare(data[row], value, nan_direction_hint));
+                if (result_data[row] == 0)
+                {
+                    *next_index = row;
+                    ++next_index;
+                }
+            }
+        }
+        else
+        {
+            for (auto row : *row_indexes)
+            {
+                result_data[row] = static_cast<Int8>(CompareHelper<T>::compare(value, data[row], nan_direction_hint));
+                if (result_data[row] == 0)
+                {
+                    *next_index = row;
+                    ++next_index;
+                }
+            }
+        }
+
+        size_t equal_row_indexes_size = next_index - row_indexes->data();
+        row_indexes->resize(equal_row_indexes_size);
+    }
+
+#if USE_MULTITARGET_CODE
+    if (isArchSupported(TargetArch::AVX512BW))
+    {
+        compareColumnImplAVX512BW<T>(data, value, compare_results, direction, nan_direction_hint);
+        return;
+    }
+    if (isArchSupported(TargetArch::AVX2))
+    {
+        compareColumnImplAVX2<T>(data, value, compare_results, direction, nan_direction_hint);
+        return;
+    }
+#endif
+    compareColumnImpl<T>(data, value, compare_results, direction, nan_direction_hint);
+}
+
 template <typename T>
 void ColumnVector<T>::getPermutation(IColumn::PermutationSortDirection direction, IColumn::PermutationSortStability stability,
                                     size_t limit, int nan_direction_hint, IColumn::Permutation & res) const

--- a/src/Columns/ColumnVector.h
+++ b/src/Columns/ColumnVector.h
@@ -165,6 +165,10 @@ public:
 
 #endif
 
+    void compareColumn(const IColumn & rhs, size_t rhs_row_num,
+        PaddedPODArray<UInt64> * row_indexes, PaddedPODArray<Int8> & compare_results,
+        int direction, int nan_direction_hint) const override;
+
     void getPermutation(IColumn::PermutationSortDirection direction, IColumn::PermutationSortStability stability,
                     size_t limit, int nan_direction_hint, IColumn::Permutation & res) const override;
 

--- a/src/Columns/IColumn.cpp
+++ b/src/Columns/IColumn.cpp
@@ -329,7 +329,7 @@ void IColumnHelper<Derived, Parent>::gather(ColumnGathererStream & gatherer)
 }
 
 template <typename Derived, bool reversed>
-void compareImpl(
+void compareColumnImpl(
     const Derived & lhs,
     const Derived & rhs,
     size_t rhs_row_num,
@@ -414,7 +414,7 @@ void IColumnHelper<Derived, Parent>::compareColumn(
         if (row_indexes)
             compareWithIndexImpl<Derived, true>(lhs, rhs, rhs_row_num, row_indexes, compare_results, nan_direction_hint);
         else
-            compareImpl<Derived, true>(lhs, rhs, rhs_row_num, row_indexes, compare_results, nan_direction_hint);
+            compareColumnImpl<Derived, true>(lhs, rhs, rhs_row_num, row_indexes, compare_results, nan_direction_hint);
     }
     else if (row_indexes)
     {
@@ -422,7 +422,7 @@ void IColumnHelper<Derived, Parent>::compareColumn(
     }
     else
     {
-        compareImpl<Derived, false>(lhs, rhs, rhs_row_num, row_indexes, compare_results, nan_direction_hint);
+        compareColumnImpl<Derived, false>(lhs, rhs, rhs_row_num, row_indexes, compare_results, nan_direction_hint);
     }
 }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Speed up sorting of single numeric block via dynamic dispatch

Comes from https://github.com/ClickHouse/ClickHouse/pull/90043

`clickhouse benchmark --port 49000 --query "SELECT number AS n FROM numbers_mt(200000000) ORDER BY n DESC LIMIT 10000 FORMAT Null"`
* Before: 0.0.0.0:49000, queries: 1000, QPS: 37.353, RPS: 7470553862.072, MiB/s: 56995.803, result RPS: 0.000, result MiB/s: 0.000.
* After: 0.0.0.0:49000, queries: 1000, QPS: 43.957, RPS: 8791327419.256, MiB/s: 67072.505, result RPS: 0.000, result MiB/s: 0.000.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
