### PR TITLE
fix a crash when delete a statistics and load it again

### DIFF
--- a/src/Storages/Statistics/Statistics.h
+++ b/src/Storages/Statistics/Statistics.h
@@ -75,7 +75,7 @@ using Estimates = std::unordered_map<String, Estimate>;
 class ColumnStatistics
 {
 public:
-    explicit ColumnStatistics(const ColumnStatisticsDescription & stats_desc_, const String & column_name_);
+    explicit ColumnStatistics(const ColumnStatisticsDescription & stats_desc_, const String & column_name_, DataTypePtr data_type_);
 
     void serialize(WriteBuffer & buf);
     void deserialize(ReadBuffer & buf);
@@ -101,6 +101,7 @@ private:
     friend class MergeTreeStatisticsFactory;
     ColumnStatisticsDescription stats_desc;
     String column_name;
+    DataTypePtr data_type;
     std::map<StatisticsType, StatisticsPtr> stats;
     UInt64 rows = 0; /// the number of rows in the column
 };
@@ -120,8 +121,9 @@ public:
     using Creator = std::function<StatisticsPtr(const SingleStatisticsDescription & stats, const DataTypePtr & data_type)>;
 
     ColumnStatisticsPtr get(const ColumnDescription & column_desc) const;
-    ColumnStatisticsPtr get(const ColumnStatisticsDescription & stats_desc) const;
     ColumnsStatistics getMany(const ColumnsDescription & columns) const;
+
+    StatisticsPtr getSingleStats(const SingleStatisticsDescription & stats_desc, DataTypePtr data_type) const;
 
     void registerValidator(StatisticsType type, Validator validator);
     void registerCreator(StatisticsType type, Creator creator);

--- a/tests/queries/0_stateless/03743_fix_estimator_crash.sql
+++ b/tests/queries/0_stateless/03743_fix_estimator_crash.sql
@@ -1,0 +1,8 @@
+-- Tags: no-fasttest
+
+CREATE TABLE t0 (c0 Int) ENGINE = MergeTree() ORDER BY tuple();
+SET query_plan_enable_optimizations = 0;
+ALTER TABLE t0 MODIFY STATISTICS c0 TYPE Uniq, CountMin;
+INSERT INTO TABLE t0 (c0) VALUES (1);
+ALTER TABLE t0 MODIFY STATISTICS c0 TYPE CountMin;
+ALTER TABLE t0 APPLY DELETED MASK IN PARTITION ID '1';


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)



### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
fix https://github.com/ClickHouse/ClickHouse/issues/91206
when we create a table with statistics and write someting and drop one statistics, it will crash when we read it again. because we assume the serialize and deserialize will have same types statistics. In this fix, we will check if the current metadata contains the serialized statistics, if not, we make a mock statistics and deserialize only to skip it. 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
