### PR TITLE
Fix use-after-free in ForkWriteBuffer

### DIFF
--- a/src/IO/ForkWriteBuffer.cpp
+++ b/src/IO/ForkWriteBuffer.cpp
@@ -34,6 +34,7 @@ void ForkWriteBuffer::nextImpl()
             buffer->next();
         }
         source_buffer->next();
+        set(sources.front()->buffer().begin(), sources.front()->buffer().size());
     }
     catch (Exception & exception)
     {


### PR DESCRIPTION
When `next()` is called on the buffer, it can decide to relocate its internal in-memory buffer. In this case, `ForkWriteBuffer` should update its pointers to be able to continue writing to the first source buffer.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
This patch fixes a `use-after-free` after the underlying buffer rellocation in `ForkWriteBuffer`.