### PR TITLE
Fix inserting into CoalescingMergeTree column with Tuple of JSON/Dynamic and LowCardinality

### DIFF
--- a/src/Processors/Merges/Algorithms/SummingSortedAlgorithm.cpp
+++ b/src/Processors/Merges/Algorithms/SummingSortedAlgorithm.cpp
@@ -503,7 +503,7 @@ static void postprocessChunk(
         if (!desc.aggregate_all_columns && !desc.is_agg_func_type && !desc.is_simple_agg_func_type && isTuple(desc.function->getResultType()))
         {
             /// Unpack tuple into block.
-            size_t tuple_size = desc.column_numbers.size();
+            const size_t tuple_size = desc.column_numbers.size();
             for (size_t i = 0; i < tuple_size; ++i)
                res_columns[desc.column_numbers[i]] = assert_cast<const ColumnTuple &>(*column).getColumnPtr(i);
         }
@@ -585,7 +585,7 @@ void SummingSortedAlgorithm::SummingMergedData::initialize(const DB::Block & hea
         // Wrap aggregated columns in a tuple to match function signature
         if (!desc.aggregate_all_columns && !desc.is_agg_func_type && !desc.is_simple_agg_func_type && isTuple(desc.function->getResultType()))
         {
-            size_t tuple_size = desc.column_numbers.size();
+            const size_t tuple_size = desc.column_numbers.size();
             MutableColumns tuple_columns(tuple_size);
             for (size_t i = 0; i < tuple_size; ++i)
                 tuple_columns[i] = std::move(columns[desc.column_numbers[i]]);

--- a/src/Processors/Merges/Algorithms/SummingSortedAlgorithm.cpp
+++ b/src/Processors/Merges/Algorithms/SummingSortedAlgorithm.cpp
@@ -500,19 +500,12 @@ static void postprocessChunk(
         auto column = std::move(columns[next_column]);
         ++next_column;
 
-        if (!desc.is_agg_func_type && !desc.is_simple_agg_func_type && isTuple(desc.function->getResultType()))
+        if (!desc.aggregate_all_columns && !desc.is_agg_func_type && !desc.is_simple_agg_func_type && isTuple(desc.function->getResultType()))
         {
-            if (desc.aggregate_all_columns)
-            {
-                res_columns[desc.column_numbers[0]] = column;
-            }
-            else
-            {
-                /// Unpack tuple into block.
-                size_t tuple_size = desc.column_numbers.size();
-                for (size_t i = 0; i < tuple_size; ++i)
-                   res_columns[desc.column_numbers[i]] = assert_cast<const ColumnTuple &>(*column).getColumnPtr(i);
-            }
+            /// Unpack tuple into block.
+            size_t tuple_size = desc.column_numbers.size();
+            for (size_t i = 0; i < tuple_size; ++i)
+               res_columns[desc.column_numbers[i]] = assert_cast<const ColumnTuple &>(*column).getColumnPtr(i);
         }
         else if (desc.nested_type)
         {
@@ -590,26 +583,14 @@ void SummingSortedAlgorithm::SummingMergedData::initialize(const DB::Block & hea
     for (const auto & desc : def.columns_to_aggregate)
     {
         // Wrap aggregated columns in a tuple to match function signature
-        if (!desc.is_agg_func_type && !desc.is_simple_agg_func_type && isTuple(desc.function->getResultType()))
+        if (!desc.aggregate_all_columns && !desc.is_agg_func_type && !desc.is_simple_agg_func_type && isTuple(desc.function->getResultType()))
         {
-            if (desc.aggregate_all_columns)
-            {
-                auto column = desc.real_type->createColumn();
-                size_t tuple_size = static_cast<const ColumnTuple &>(*column).tupleSize();
-                MutableColumns tuple_columns(tuple_size);
-                for (size_t i = 0; i < tuple_size; ++i)
-                    tuple_columns[i] = static_cast<const ColumnTuple &>(*column).getColumnPtr(i)->cloneEmpty();
-                new_columns.emplace_back(ColumnTuple::create(std::move(tuple_columns)));
-            }
-            else
-            {
-                size_t tuple_size = desc.column_numbers.size();
-                MutableColumns tuple_columns(tuple_size);
-                for (size_t i = 0; i < tuple_size; ++i)
-                    tuple_columns[i] = std::move(columns[desc.column_numbers[i]]);
+            size_t tuple_size = desc.column_numbers.size();
+            MutableColumns tuple_columns(tuple_size);
+            for (size_t i = 0; i < tuple_size; ++i)
+                tuple_columns[i] = std::move(columns[desc.column_numbers[i]]);
 
-                new_columns.emplace_back(ColumnTuple::create(std::move(tuple_columns)));
-            }
+            new_columns.emplace_back(ColumnTuple::create(std::move(tuple_columns)));
         }
         else
         {

--- a/tests/queries/0_stateless/03748_coalescing_merge_tree_tuple_low_cardinality_and_dynamic.reference
+++ b/tests/queries/0_stateless/03748_coalescing_merge_tree_tuple_low_cardinality_and_dynamic.reference
@@ -1,0 +1,3 @@
+Dynamic paths
+a
+Shared data parhs

--- a/tests/queries/0_stateless/03748_coalescing_merge_tree_tuple_low_cardinality_and_dynamic.sql
+++ b/tests/queries/0_stateless/03748_coalescing_merge_tree_tuple_low_cardinality_and_dynamic.sql
@@ -1,0 +1,11 @@
+drop table if exists test;
+create table test (id UInt64, t Tuple(a LowCardinality(String), json JSON)) engine=CoalescingMergeTree order by id settings min_bytes_for_wide_part=1, min_rows_for_wide_part=1, index_granularity=32, merge_max_block_size=32;
+insert into test select number, tuple('str', '{}') from numbers(100);
+alter table test update t = tuple('str', '{"a" : 42}') where id > 90;
+optimize table test final;
+select 'Dynamic paths';
+select distinct arrayJoin(JSONDynamicPaths(t.json)) from test;
+select 'Shared data parhs';
+select distinct arrayJoin(JSONSharedDataPaths(t.json)) from test;
+drop table test;
+

--- a/tests/queries/0_stateless/03748_coalescing_merge_tree_tuple_low_cardinality_and_dynamic.sql
+++ b/tests/queries/0_stateless/03748_coalescing_merge_tree_tuple_low_cardinality_and_dynamic.sql
@@ -1,3 +1,4 @@
+set mutations_sync=1;
 drop table if exists test;
 create table test (id UInt64, t Tuple(a LowCardinality(String), json JSON)) engine=CoalescingMergeTree order by id settings min_bytes_for_wide_part=1, min_rows_for_wide_part=1, index_granularity=32, merge_max_block_size=32;
 insert into test select number, tuple('str', '{}') from numbers(100);


### PR DESCRIPTION
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix inserting into CoalescingMergeTree column with Tuple of JSON/Dynamic and LowCardinality. Closes https://github.com/ClickHouse/ClickHouse/issues/91215

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
