### PR TITLE
Fix SYSTEM DROP FILESYSTEM CACHE ON CLUSTER

### DIFF
--- a/src/Parsers/ASTSystemQuery.cpp
+++ b/src/Parsers/ASTSystemQuery.cpp
@@ -163,7 +163,13 @@ void ASTSystemQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & setti
 
     print_keyword("SYSTEM") << " ";
     print_keyword(typeToString(type));
-    if (!cluster.empty())
+
+    std::unordered_set<Type> queries_with_on_cluster_at_end = {
+        Type::DROP_FILESYSTEM_CACHE,
+        Type::SYNC_FILESYSTEM_CACHE,
+    };
+
+    if (!queries_with_on_cluster_at_end.contains(type) && !cluster.empty())
         formatOnCluster(ostr, settings);
 
     switch (type)
@@ -523,6 +529,9 @@ void ASTSystemQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & setti
         case Type::END:
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Unknown SYSTEM command");
     }
+
+    if (queries_with_on_cluster_at_end.contains(type) && !cluster.empty())
+        formatOnCluster(ostr, settings);
 }
 
 

--- a/tests/queries/0_stateless/03643_system_drop_filesystem_cache_on_cluster.reference
+++ b/tests/queries/0_stateless/03643_system_drop_filesystem_cache_on_cluster.reference
@@ -1,0 +1,2 @@
+localhost	9000	0		0	0
+localhost	9000	0		0	0

--- a/tests/queries/0_stateless/03643_system_drop_filesystem_cache_on_cluster.sh
+++ b/tests/queries/0_stateless/03643_system_drop_filesystem_cache_on_cluster.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest, no-parallel, no-object-storage, no-random-settings
+
+# set -x
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+
+disk_name="${CLICKHOUSE_TEST_UNIQUE_NAME}"
+$CLICKHOUSE_CLIENT -m --query """
+DROP TABLE IF EXISTS test;
+CREATE TABLE test (a Int32, b String)
+ENGINE = MergeTree() ORDER BY tuple()
+SETTINGS disk = disk(name = '$disk_name', type = cache, max_size = '100Ki', path = ${CLICKHOUSE_TEST_UNIQUE_NAME}, disk = s3_disk);
+
+INSERT INTO test SELECT 1, 'test';
+"""
+
+$CLICKHOUSE_CLIENT --query """
+SYSTEM SYNC FILESYSTEM CACHE '$disk_name' ON CLUSTER 'test_shard_localhost';
+"""
+
+$CLICKHOUSE_CLIENT --query """
+SYSTEM DROP FILESYSTEM CACHE '$disk_name' ON CLUSTER 'test_shard_localhost';
+"""
+
+$CLICKHOUSE_CLIENT --query """
+DROP TABLE IF EXISTS test;
+"""


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix SYSTEM DROP FILESYSTEM CACHE ON CLUSTER

### Documentation entry for user-facing changes
Parser expects query

```
SYSTEM DROP FILESYSTEM CACHE 'cache_name' ON CLUSTER `cluster_name`
```

but in DDL cluster name is at end:

```
SYSTEM DROP FILESYSTEM CACHE ON CLUSTER `cluster_name` 'cache_name'
```

and query failed with error

```
clickhouse1 :) SYSTEM DROP FILESYSTEM CACHE 'cache' ON CLUSTER `clickhouse-cluster`

SYSTEM DROP FILESYSTEM CACHE ON CLUSTER `clickhouse-cluster` 'cache'

Query id: 48c41c7b-bb81-4b9e-a49a-fcd8b5a537cb

Row 1:
──────
host:                clickhouse2
port:                9000
status:              62
error:               Code: 62. DB::Exception: Syntax error: failed at position 62 ('cache'): 'cache'. Expected one of: ParallelWithClause, PARALLEL WITH, end of query. (SYNTAX_ERROR) (version 25.8.10.7 (official build))
num_hosts_remaining: 2
num_hosts_active:    0

Row 2:
──────
host:                clickhouse1
port:                9000
status:              62
error:               Code: 62. DB::Exception: Syntax error: failed at position 62 ('cache'): 'cache'. Expected one of: ParallelWithClause, PARALLEL WITH, end of query. (SYNTAX_ERROR) (version 25.8.10.7 (official build))
num_hosts_remaining: 1
num_hosts_active:    0

Row 3:
──────
host:                clickhouse3
port:                9000
status:              62
error:               Code: 62. DB::Exception: Syntax error: failed at position 62 ('cache'): 'cache'. Expected one of: ParallelWithClause, PARALLEL WITH, end of query. (SYNTAX_ERROR) (version 25.8.10.7 (official build))
num_hosts_remaining: 0
num_hosts_active:    0

3 rows in set. Elapsed: 0.099 sec.

Received exception from server (version 25.8.10):
Code: 62. DB::Exception: Received from localhost:9000. DB::Exception: There was an error on [clickhouse2:9000]: Code: 62. DB::Exception: Syntax error: failed at position 62 ('cache'): 'cache'. Expected one of: ParallelWithClause, PARALLEL WITH, end of query. (SYNTAX_ERROR) (version 25.8.10.7 (official build)). (SYNTAX_ERROR)
```

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
