### PR TITLE
Add ability to configure tasks duration threshold for system.background_schedule_pool_log

### DIFF
--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -1259,6 +1259,8 @@
         <reserved_size_rows>8192</reserved_size_rows>
         <buffer_size_rows_flush_threshold>524288</buffer_size_rows_flush_threshold>
         <flush_on_crash>false</flush_on_crash>
+        <!-- Only tasks longer then duration_threshold_ms will be logged. Zero means log everything -->
+        <duration_threshold_ms>0</duration_threshold_ms>
     </background_schedule_pool_log>
 
     <!-- Text log contains all information from usual server log but stores it in structured and efficient way.

--- a/src/Core/BackgroundSchedulePool.cpp
+++ b/src/Core/BackgroundSchedulePool.cpp
@@ -175,7 +175,8 @@ void BackgroundSchedulePoolTaskInfo::execute(BackgroundSchedulePool & pool)
     {
         if (auto context = Context::getGlobalContextInstance())
         {
-            if (auto background_schedule_pool_log = context->getBackgroundSchedulePoolLog())
+            auto background_schedule_pool_log = context->getBackgroundSchedulePoolLog();
+            if (background_schedule_pool_log && milliseconds >= background_schedule_pool_log->getDurationMillisecondsThreshold())
             {
                 BackgroundSchedulePoolLogElement elem;
 

--- a/src/Interpreters/BackgroundSchedulePoolLog.h
+++ b/src/Interpreters/BackgroundSchedulePoolLog.h
@@ -39,6 +39,11 @@ struct BackgroundSchedulePoolLogElement
 class BackgroundSchedulePoolLog : public SystemLog<BackgroundSchedulePoolLogElement>
 {
     using SystemLog<BackgroundSchedulePoolLogElement>::SystemLog;
+    size_t duration_milliseconds_threshold = 0;
+
+public:
+    void setDurationMillisecondsThreshold(size_t duration_milliseconds_threshold_) { duration_milliseconds_threshold = duration_milliseconds_threshold_; }
+    size_t getDurationMillisecondsThreshold() const { return duration_milliseconds_threshold; }
 };
 
 }

--- a/src/Interpreters/SystemLog.cpp
+++ b/src/Interpreters/SystemLog.cpp
@@ -423,6 +423,12 @@ SystemLogs::SystemLogs(ContextPtr global_context, const Poco::Util::AbstractConf
                                                                 DEFAULT_AGGREGATED_ZOOKEEPER_LOG_COLLECT_INTERVAL_MILLISECONDS);
         aggregated_zookeeper_log->startCollect(ThreadName::AGGREGATED_ZOOKEEPER_LOG, collect_interval_milliseconds);
     }
+
+    if (background_schedule_pool_log)
+    {
+        size_t duration_threshold_ms = config.getUInt64("background_schedule_pool_log.duration_threshold_ms", 0);
+        background_schedule_pool_log->setDurationMillisecondsThreshold(duration_threshold_ms);
+    }
 }
 
 std::vector<ISystemLog *> SystemLogs::getAllLogs() const


### PR DESCRIPTION
I've tested and in cloud it 80% of tasks takes 0 ms, so it maybe useful to have an option to exclude them.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Follow-up for: https://github.com/ClickHouse/ClickHouse/pull/91157