### PR TITLE
Fix crash on nested `QBit` deserialization

### DIFF
--- a/src/DataTypes/DataTypeQBit.cpp
+++ b/src/DataTypes/DataTypeQBit.cpp
@@ -27,6 +27,13 @@ DataTypeQBit::DataTypeQBit(const DataTypePtr & element_type_, const size_t dimen
     : element_type(element_type_)
     , dimension(dimension_)
 {
+    /// Prevents maliciously crafted byte streams from being deserialized into illegal types, which could be exploited to crash the server
+    if (element_type_->getTypeId() != TypeIndex::BFloat16 && element_type_->getTypeId() != TypeIndex::Float32
+        && element_type_->getTypeId() != TypeIndex::Float64)
+        throw Exception(
+            ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
+            "QBit data type only supports BFloat16, Float32, or Float64 as element type. Got: {}",
+            element_type_->getName());
 }
 
 std::string DataTypeQBit::doGetName() const

--- a/src/DataTypes/Serializations/tests/gtest_qbit_serialization.cpp
+++ b/src/DataTypes/Serializations/tests/gtest_qbit_serialization.cpp
@@ -53,3 +53,9 @@ TEST(QBitSerialization, FieldBinarySerializationFloat32)
         ASSERT_EQ(fixed_string[0], static_cast<char>(i));
     }
 }
+
+TEST(QBitSerialization, RejectInvalidElementType)
+{
+    auto int32_type = DataTypeFactory::instance().get("Int32");
+    EXPECT_THROW(std::make_shared<DataTypeQBit>(int32_type, 5), DB::Exception);
+}

--- a/src/DataTypes/Serializations/tests/gtest_qbit_serialization.cpp
+++ b/src/DataTypes/Serializations/tests/gtest_qbit_serialization.cpp
@@ -11,22 +11,12 @@
 
 using namespace DB;
 
-class QBitSerializationTest : public ::testing::Test
+TEST(QBitSerialization, FieldBinarySerializationFloat32)
 {
-protected:
-    void SetUp() override
-    {
-        auto float32_type = DataTypeFactory::instance().get("Float32");
-        qbit_type_float32 = std::static_pointer_cast<DataTypeQBit>(std::make_shared<DataTypeQBit>(float32_type, 5));
-        serialization_float32 = qbit_type_float32->getDefaultSerialization();
-    }
+    auto float32_type = DataTypeFactory::instance().get("Float32");
+    auto qbit_type_float32 = std::static_pointer_cast<DataTypeQBit>(std::make_shared<DataTypeQBit>(float32_type, 5));
+    auto serialization_float32 = qbit_type_float32->getDefaultSerialization();
 
-    std::shared_ptr<DataTypeQBit> qbit_type_float32;
-    SerializationPtr serialization_float32;
-};
-
-TEST_F(QBitSerializationTest, FieldBinarySerializationFloat32)
-{
     const size_t bytes_per_fixedstring = 1;
 
     Tuple tuple_elements;

--- a/src/DataTypes/Serializations/tests/gtest_qbit_serialization.cpp
+++ b/src/DataTypes/Serializations/tests/gtest_qbit_serialization.cpp
@@ -4,12 +4,28 @@
 #include <Formats/FormatSettings.h>
 #include <IO/ReadBufferFromString.h>
 #include <IO/WriteBufferFromString.h>
+#include <Common/ErrorCodes.h>
 
 #include <base/types.h>
 #include <gtest/gtest.h>
 
 
-using namespace DB;
+#define EXPECT_THROW_ERROR_CODE(statement, expected_exception, expected_code) \
+    EXPECT_THROW( \
+        try { statement; } catch (const expected_exception & e) { \
+            EXPECT_EQ(expected_code, e.code()); \
+            throw; \
+        }, \
+        expected_exception)
+
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+extern const int ILLEGAL_TYPE_OF_ARGUMENT;
+}
 
 TEST(QBitSerialization, FieldBinarySerializationFloat32)
 {
@@ -57,5 +73,7 @@ TEST(QBitSerialization, FieldBinarySerializationFloat32)
 TEST(QBitSerialization, RejectInvalidElementType)
 {
     auto int32_type = DataTypeFactory::instance().get("Int32");
-    EXPECT_THROW(std::make_shared<DataTypeQBit>(int32_type, 5), DB::Exception);
+    EXPECT_THROW_ERROR_CODE(std::make_shared<DataTypeQBit>(int32_type, 5), Exception, ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
+}
+
 }


### PR DESCRIPTION
It is not possible to have `QBit` within `QBit`. But, as `libfuzzer` has found [[1](https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=4f998ad3f12c99c272982b3e81867c63d28f8afb&name_0=NightlyFuzzers&name_1=libFuzzer%20tests&name_1=libFuzzer%20tests), [2](https://s3.amazonaws.com/clickhouse-test-reports/REFs/master/4f998ad3f12c99c272982b3e81867c63d28f8afb//libfuzzer_tests/data_type_deserialization_fuzzer/out.txt)], it is possible to manually craft a byte stream that would deserialize into `QBit(QBit(...), d)` and send it to ClickHouse. It would then crash. Resolves https://github.com/ClickHouse/ClickHouse/issues/91326

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a crash when maliciously crafted byte streams deserialize into nested QBit types, which should be impossible but could be exploited to crash the server.