### PR TITLE
Fix flaky 02117_custom_separated_with_names_and_types

### DIFF
--- a/tests/queries/0_stateless/02117_custom_separated_with_names_and_types.sh
+++ b/tests/queries/0_stateless/02117_custom_separated_with_names_and_types.sh
@@ -89,7 +89,7 @@ $CLICKHOUSE_CLIENT -q "SELECT toUInt32(1) AS x, [[1, 2, 3], [4, 5], []] as a FOR
 $CLICKHOUSE_CLIENT -q "SELECT * FROM test_02117"
 $CLICKHOUSE_CLIENT -q "TRUNCATE TABLE test_02117"
 
-TMP_FILE=$CURDIR/test_02117
+TMP_FILE="${CLICKHOUSE_TMP}/test_02117"
 $CLICKHOUSE_CLIENT -q "SELECT 'text' AS x, toDate('2020-01-01') AS y, toUInt32(1) AS z FORMAT CustomSeparatedWithNamesAndTypes $CUSTOM_SETTINGS" > $TMP_FILE
 cat $TMP_FILE | $CLICKHOUSE_CLIENT --input_format_with_names_use_header=1 --input_format_with_types_use_header=1 -q "INSERT INTO test_02117 $CUSTOM_SETTINGS FORMAT CustomSeparatedWithNamesAndTypes" 2>&1 | \
     grep -F -q "INCORRECT_DATA" && echo 'OK' || echo 'FAIL'


### PR DESCRIPTION
Use CLICKHOUSE_TMP instead of CURDIR variable to avoid using the same temp file in parallel tests. 

See [ci-db](https://play.clickhouse.com/play?user=play&run=1#V0lUSAogICAgOTAgQVMgaW50ZXJ2YWxfZGF5cwpTRUxFQ1QKICAgIHRvU3RhcnRPZkRheShjaGVja19zdGFydF90aW1lKSBBUyBkYXksCiAgICBjb3VudCgpIEFTIGZhaWx1cmVzLAogICAgZ3JvdXBVbmlxQXJyYXkocHVsbF9yZXF1ZXN0X251bWJlcikgQVMgcHJzLAogICAgYW55KHJlcG9ydF91cmwpIEFTIHJlcG9ydF91cmwKRlJPTSBjaGVja3MKV0hFUkUgKG5vdygpIC0gdG9JbnRlcnZhbERheShpbnRlcnZhbF9kYXlzKSkgPD0gY2hlY2tfc3RhcnRfdGltZQogICAgQU5EIHRlc3RfbmFtZSA9ICcwMjExN19jdXN0b21fc2VwYXJhdGVkX3dpdGhfbmFtZXNfYW5kX3R5cGVzJwogICAgLS0gQU5EIGNoZWNrX25hbWUgPSAnU3RhdGVsZXNzIHRlc3RzIChhcm1fYXNhbiwgdGFyZ2V0ZWQpJwogICAgQU5EIHRlc3Rfc3RhdHVzIElOICgnRkFJTCcsICdFUlJPUicpCiAgICBBTkQgKChoZWFkX3JlZiA9ICdtYXN0ZXInIEFORCBwdWxsX3JlcXVlc3RfbnVtYmVyID0gMCkgT1IgcHVsbF9yZXF1ZXN0X251bWJlciAhPSAwKQpHUk9VUCBCWSBkYXkKT1JERVIgQlkgZGF5IERFU0MK)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

