### PR TITLE
CI: Do not run targeted job in flaky mode (all tests N times in parallel)

### DIFF
--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -442,11 +442,11 @@ def main():
         # Mode (2): N consequent runs for chosen tests
         #   - Drawback: Might eliminate mode (1) issues but potentially catches fewer problems
         #
-        # Currently using Mode (1):
-        run_sets_cnt = 1
-        # To use Mode (2), uncomment:
-        # run_sets_cnt = rerun_count if is_targeted_check else 1
-        # rerun_count = 1 if is_targeted_check else rerun_count
+        # Mode (1):
+        # run_sets_cnt = 1
+        # Mode (2):
+        run_sets_cnt = rerun_count if is_targeted_check else 1
+        rerun_count = 1 if is_targeted_check else rerun_count
 
         ft_res_processor = FTResultsProcessor(wd=temp_dir)
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Reverts https://github.com/ClickHouse/ClickHouse/pull/90634 that made targeted check producing noise (failures from tests that are not supposed to be run in parallel with themselves)
for example [1](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=80264&sha=8fb6932f1b25429337dfac9bd9dc36b88a6b8588&name_0=PR&name_1=Stateless%20tests%20%28arm_asan%2C%20targeted%29&name_1=Stateless%20tests%20%28arm_asan%2C%20targeted%29), [2](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=91288&sha=4ba6c989085323c6f9544707afee5d25d115145f&name_0=PR&name_1=Stateless%20tests%20%28arm_asan%2C%20targeted%29&name_1=Stateless%20tests%20%28arm_asan%2C%20targeted%29), [3](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=91304&sha=a79097ec5ae4beaac726933c0f3fd626fae0c73d&name_0=PR&name_1=Stateless%20tests%20%28arm_asan%2C%20targeted%29&name_1=Stateless%20tests%20%28arm_asan%2C%20targeted%29)

