### PR TITLE
Userspace page cache: avoid spurious memory limit errors in MemoryTracker

### DIFF
--- a/src/Common/MemoryTracker.cpp
+++ b/src/Common/MemoryTracker.cpp
@@ -382,10 +382,7 @@ AllocationTrace MemoryTracker::allocImpl(Int64 size, bool throw_if_memory_exceed
             if (level == VariableContext::Global && (page_cache_ptr = page_cache.load(std::memory_order_relaxed)))
             {
                 ProfileEvents::increment(ProfileEvents::PageCacheOvercommitResize);
-                page_cache_ptr->autoResize(std::max(will_be, will_be_rss), current_hard_limit);
-                will_be = amount.load(std::memory_order_relaxed);
-                will_be_rss = rss.load(std::memory_order_relaxed);
-                if (will_be <= current_hard_limit && will_be_rss <= current_hard_limit)
+                if (page_cache_ptr->autoResize(std::max(will_be, will_be_rss), current_hard_limit))
                     overcommit_result = OvercommitResult::MEMORY_FREED;
             }
 

--- a/src/Common/PageCache.cpp
+++ b/src/Common/PageCache.cpp
@@ -151,7 +151,7 @@ void PageCache::Shard::onEntryRemoval(const size_t weight_loss, const MappedPtr 
     UNUSED(mapped_ptr);
 }
 
-void PageCache::autoResize(Int64 memory_usage_signed, size_t memory_limit)
+bool PageCache::autoResize(Int64 memory_usage_signed, size_t memory_limit)
 {
     /// Avoid recursion when called from MemoryTracker.
     MemoryTrackerBlockerInThread blocker(VariableContext::Global);
@@ -187,10 +187,16 @@ void PageCache::autoResize(Int64 memory_usage_signed, size_t memory_limit)
     target_size = std::clamp(target_size, min_size_in_bytes, max_size_in_bytes);
 
     size_t size_per_shard = (target_size + shards.size() - 1) / shards.size();
+    size_t new_cache_size = 0;
     for (const auto & shard : shards)
+    {
         shard->setMaxSizeInBytes(size_per_shard);
+        new_cache_size += shard->sizeInBytes();
+    }
 
     ProfileEvents::increment(ProfileEvents::PageCacheResized);
+
+    return memory_usage_signed - Int64(cache_size) + Int64(new_cache_size) <= Int64(memory_limit);
 }
 
 void PageCache::clear()

--- a/src/Common/PageCache.h
+++ b/src/Common/PageCache.h
@@ -123,7 +123,9 @@ public:
 
     bool contains(const PageCacheKey & key, bool inject_eviction) const;
 
-    void autoResize(Int64 memory_usage, size_t memory_limit);
+    /// Make the cache smaller by `memory_limit - memory_usage` bytes.
+    /// Returns true if succeeded, false if cache size was reduced as much as possible but it wasn't enough.
+    bool autoResize(Int64 memory_usage, size_t memory_limit);
 
     void clear();
     size_t sizeInBytes() const;


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed spurious memory limit errors when userspace page cache is enabled


---

MemoryTracker allocation path did this if memory limit is exceeded to try to evict from cache instead of failing:
```C++
                page_cache_ptr->autoResize(std::max(will_be, will_be_rss), current_hard_limit);
                will_be = amount.load(std::memory_order_relaxed);
                will_be_rss = rss.load(std::memory_order_relaxed);
                if (will_be <= current_hard_limit && will_be_rss <= current_hard_limit)
                    overcommit_result = OvercommitResult::MEMORY_FREED;
```

I.e. evict, then paranoidly check that the usage went below the limit, even if the cache was successfully shrunk by the full requested amount. If another thread increases `amount` or `rss` while we're shrinking the cache, the paranoid check may fail, and we may throw a `MEMORY_LIMIT_EXCEEDED` even if memory usage is actually fine and cache is not at minimum size. (The idea was that `page_cache_free_memory_ratio` would provide enough margin to avoid this, but maybe that's not the case.)

This PR changes this to check whether the cache was shrunk by the requested amount, without re-reading `amount` and `rss`. If another thread did increase `amount` or `rss` in parallel, that thread will make its own call to `page_cache_ptr->autoResize` before actually allocating memory.

A potential problem is that evicting from cache doesn't guarantee that the memory is freed because the cache has `shared_ptr`s to data; someone (`CachedInMemoryReadBufferFromFile`) may be holding another `shared_ptr` to the evicted cached chunk. Hopefully that's ok as chunks are not very big, and each `CachedInMemoryReadBufferFromFile` holds at most one.


<!-- ch-version-info:start -->
### Version info
- Merged into: `25.12.1.322`
- Backported to: `25.10.5.24`
<!-- ch-version-info:end -->