### PR TITLE
CI: Support for passing custom envs into integration test job via --params

### DIFF
--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -80,6 +80,15 @@ def parse_args():
         default=None,
         type=int,
     )
+    parser.add_argument(
+        "--param",
+        help=(
+            "Optional. Comma-separated KEY=VALUE pairs to inject as environment "
+            "variables for pytest (e.g. --param PYTEST_ADDOPTS=-vv,CUSTOM_FLAG=1)"
+        ),
+        type=str,
+        default="",
+    )
     return parser.parse_args()
 
 
@@ -150,6 +159,16 @@ def main():
     is_parallel = False
     is_sequential = False
     is_targeted_check = False
+
+    if args.param:
+        for item in args.param.split(","):
+            print(f"Setting env variable: {item}")
+            key, _, value = item.partition("=")
+            key = key.strip()
+            if not key:
+                continue
+            os.environ[key] = value.strip()
+
     java_path = Shell.get_output(
         "update-alternatives --config java | sed -n 's/.*(providing \/usr\/bin\/java): //p'",
         verbose=True,

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -43,6 +43,7 @@ python -m ci.praktika run "Integration tests (amd_binary, 4/5)" \
 - `--path PATH` custom ClickHouse server binary location (if not in default locations).
 - `--path_1 PATH` custom path to the ClickHouse server config directory (if not in `./programs/server/config/`).
 - `--workers N` to override automatic calculation of the recommended maximum number of parallel pytest workers. The value is passed to pytest-xdist as `-n N`. Use a lower number on resource-constrained machines or increase it to utilize more CPU cores.
+- `--param KEY=VALUE[,KEY=VALUE...]` to inject custom environment variables for pytest. Pass comma-separated KEY=VALUE pairs (e.g., `--param PYTEST_ADDOPTS=-vv,CUSTOM_FLAG=1`).
 ## Running Natively
 
 ### Prerequisites


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

For instance
`--param PYTESTADDOPTS=-vv` to increase verbosity in pytests


