### PR TITLE
Revert "Modify `system.metric_log` settings to use less RAM for merges"

### DIFF
--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -1287,7 +1287,6 @@
         <buffer_size_rows_flush_threshold>524288</buffer_size_rows_flush_threshold>
         <collect_interval_milliseconds>1000</collect_interval_milliseconds>
         <flush_on_crash>false</flush_on_crash>
-        <settings>min_bytes_for_wide_part = 134217728, vertical_merge_algorithm_min_bytes_to_activate=134217728</settings>
     </metric_log>
 
     <!-- Error log contains rows with current values of errors collected with "collect_interval_milliseconds" interval. -->

--- a/tests/integration/test_system_logs_recreate/test.py
+++ b/tests/integration/test_system_logs_recreate/test.py
@@ -65,7 +65,6 @@ def test_system_logs_recreate():
                 <{table}>
                     <engine>ENGINE = Null</engine>
                     <partition_by remove='remove'/>
-                    <settings remove='remove'/>
                 </{table}>
             </clickhouse>
             " > /etc/clickhouse-server/config.d/zzz-override-{table}.xml

--- a/tests/integration/test_transposed_metric_log/config/metric_log_config.xml
+++ b/tests/integration/test_transposed_metric_log/config/metric_log_config.xml
@@ -14,6 +14,5 @@
     ORDER BY (event_date, event_time)
     SETTINGS ttl_only_drop_parts=1, merge_selecting_sleep_ms='50000'
     </engine>
-        <settings remove='remove'/>
     </metric_log>
 </clickhouse>


### PR DESCRIPTION
Reverts ClickHouse/ClickHouse#89811

@filimonov we have encountered this error in our dev environment, please use existing ways to change configuration of system tables

Error:
```
2025.12.03 10:27:29.008505 [ 111 ] {} <Error> Application: Code: 36. DB::Exception: If 'engine' is specified for system table, SETTINGS parameters should be specified directly inside 'engine' and 'settings' setting doesn't make sense. (BAD_ARGUMENTS), Stack trace (when copying this message, always include the lines below):

0. ./ci/tmp/build/./src/Common/Exception.cpp:131: DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x0000000013277150
1. DB::Exception::Exception(String&&, int, String, bool) @ 0x000000000cdabad8
2. DB::Exception::Exception(PreformattedMessage&&, int) @ 0x000000000cdab46c
3. DB::Exception::Exception<>(int, FormatStringHelperImpl<>) @ 0x000000000cdbc694
4. ./ci/tmp/build/./src/Interpreters/SystemLog.cpp:219: std::shared_ptr<DB::MetricLog> DB::(anonymous namespace)::createSystemLog<DB::MetricLog>(std::shared_ptr<DB::Context const>, String const&, String const&, Poco::Util::AbstractConfiguration const&, String const&, String const&) @ 0x00000000180302fc
5. ./ci/tmp/build/./src/Interpreters/SystemLog.cpp:357: DB::SystemLogs::SystemLogs(std::shared_ptr<DB::Context const>, Poco::Util::AbstractConfiguration const&) @ 0x000000001800c550
6. ./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:759: void std::__call_once_proxy[abi:ne210105]<std::tuple<DB::Context::initializeSystemLogs()::$_0&&>>(void*) (.llvm.10145558538851527571) @ 0x0000000017b6e9d4
7. ./ci/tmp/build/./contrib/llvm-project/libcxx/src/call_once.cpp:58: std::__call_once(unsigned long volatile&, void*, void (*)(void*)) @ 0x000000001f757b98
8. ./contrib/llvm-project/libcxx/include/__mutex/once_flag.h:132: DB::Server::main(std::vector<String, std::allocator<String>> const&) @ 0x0000000013618094
9. ./ci/tmp/build/./base/poco/Util/src/Application.cpp:315: Poco::Util::Application::run() @ 0x000000001e6b6a1c
10. ./ci/tmp/build/./programs/server/Server.cpp:678: DB::Server::run() @ 0x00000000135ff2d8
11. ./ci/tmp/build/./programs/server/Server.cpp:464: mainEntryClickHouseServer(int, char**) @ 0x00000000135fc3a8
12. ./ci/tmp/build/./programs/main.cpp:402: main @ 0x000000000cda3e48
13. ? @ 0x0000000000027400
14. __libc_start_main @ 0x00000000000274d8
 (version 25.12.1.521 (official build))

```

metric_log config:

```
    <metric_log>
        <database>system</database>
        <table>metric_log</table>
        <settings>min_bytes_for_wide_part = 134217728, vertical_merge_algorithm_min_bytes_to_activate=134217728</settings>
    <engine>
    ENGINE MergeTree
    PARTITION BY toYYYYMM(event_date)
    ORDER BY (event_date, event_time)
    TTL <REDACTED>
    SETTINGS <REDACTED>  </engine>
    </metric_log>
```