### PR TITLE
Fix hive partitioning bug in 25.8

### DIFF
--- a/src/Storages/HivePartitioningUtils.cpp
+++ b/src/Storages/HivePartitioningUtils.cpp
@@ -154,6 +154,10 @@ void sanityCheckSchemaAndHivePartitionColumns(
         }
     }
 
+    /// Check by names, not just by sized, because if table structure
+    /// was manually specified and check_contained_in_schema == false,
+    /// then partition columns might not be fully contained in schema (storage_columns)
+    /// (which we allow for compatibility).
     if (storage_columns.getOrdinary().getNameSet() == hive_partition_columns_to_read_from_file_path.getNameSet())
     {
         throw Exception(

--- a/tests/integration/test_storage_s3/test.py
+++ b/tests/integration/test_storage_s3/test.py
@@ -132,7 +132,7 @@ def started_cluster():
             with_minio=True,
             with_installed_binary=True,
             image="clickhouse/clickhouse-server",
-            tag="25.3.3.42",
+            tag="25.6.13.41",
             stay_alive=True,
             main_configs=[
                 "configs/remote_servers.xml",
@@ -2928,7 +2928,7 @@ def test_file_pruning_with_hive_style_partitioning(started_cluster):
 
     query_id = f"{table_name}_query_6"
     node_old = started_cluster.instances["dummy_old"]
-    if "25.3" not in node_old.query("SELECT version()"):
+    if "25.6" not in node_old.query("SELECT version()"):
         node_old.restart_with_original_version(clear_data_dir=True)
 
     node_old.query(
@@ -2959,6 +2959,7 @@ def test_file_pruning_with_hive_style_partitioning(started_cluster):
     )
     check_read_files(5, query_id, node_old)
     node_old.restart_clickhouse()
+
 
 
 def test_partition_by_without_wildcard(started_cluster):
@@ -3039,3 +3040,86 @@ def test_object_tags(started_cluster):
     query_id = uuid.uuid4().hex
     instance.query(f"select * from s3('http://{started_cluster.minio_host}:{started_cluster.minio_port}/{bucket}/{table_name_with_tags}.tsv', auto, 'x UInt64')", query_id=query_id)
     assert read_s3_tags_events(query_id) == (0, 0)
+
+
+def test_file_pruning_with_hive_style_partitioning_2(started_cluster):
+    node = started_cluster.instances["dummy"]
+    table_name = f"test_pruning_with_hive_style_partitioning_{generate_random_string()}"
+    bucket = started_cluster.minio_bucket
+    minio = started_cluster.minio_client
+
+    url = f"http://{started_cluster.minio_host}:{started_cluster.minio_port}/{bucket}/{table_name}"
+    node.query(
+        f"""
+    CREATE TABLE {table_name} (a Int32, b Int32, c String, d Int32) ENGINE = S3('{url}', format = 'Parquet', partition_strategy = 'hive')
+    PARTITION BY (b, c)
+    """
+    )
+    node.query(
+        f"INSERT INTO {table_name} SELECT number, number % 5, toString(number % 2), number FROM numbers(20)",
+        settings={"use_hive_partitioning": True},
+    )
+
+    objects = []
+    for obj in list(
+        minio.list_objects(
+            started_cluster.minio_bucket,
+            prefix=table_name,
+            recursive=True,
+        )
+    ):
+        objects.append(obj.object_name)
+
+    objects.sort()
+    assert len(objects) == 10
+
+    prefixes = []
+    for object in objects:
+        assert object.endswith(".parquet")
+        path = Path(object)
+        prefixes.append(str(path.parent))
+
+    assert len(prefixes) == 10
+    assert prefixes == [
+        f"{table_name}/b=0/c=0",
+        f"{table_name}/b=0/c=1",
+        f"{table_name}/b=1/c=0",
+        f"{table_name}/b=1/c=1",
+        f"{table_name}/b=2/c=0",
+        f"{table_name}/b=2/c=1",
+        f"{table_name}/b=3/c=0",
+        f"{table_name}/b=3/c=1",
+        f"{table_name}/b=4/c=0",
+        f"{table_name}/b=4/c=1",
+    ]
+
+    def check_read_files(expected, query_id, current_node):
+        current_node.query("SYSTEM FLUSH LOGS")
+        assert expected == int(
+            current_node.query(
+                f"SELECT ProfileEvents['EngineFileLikeReadFiles'] FROM system.query_log WHERE query_id = '{query_id}' AND type='QueryFinish'"
+            )
+        )
+
+    node_old = started_cluster.instances["dummy_old"]
+    if "25.6" not in node_old.query("SELECT version()"):
+        node_old.restart_with_original_version(clear_data_dir=True)
+
+    node_old.query(
+        f"""
+    CREATE TABLE {table_name}_1 (a Int32, d Int32) ENGINE = S3('{url}/**', 'Parquet')
+    """
+    )
+    query_id = f"{table_name}_query_1"
+    assert 5 == int(
+        node_old.query(f"SELECT uniqExact(_path) FROM {table_name}_1 WHERE c == '0'", settings={"use_hive_partitioning": 1}, query_id=query_id)
+    )
+    check_read_files(5, query_id, node_old)
+
+    node_old.restart_with_latest_version()
+    query_id = f"{table_name}_query_2"
+    assert 5 == int(
+        node_old.query(f"SELECT uniqExact(_path) FROM {table_name}_1 WHERE c == '0'", settings={"use_hive_partitioning": 1}, query_id=query_id)
+    )
+    check_read_files(5, query_id, node_old)
+    node_old.restart_clickhouse()

--- a/tests/integration/test_storage_s3/test.py
+++ b/tests/integration/test_storage_s3/test.py
@@ -132,7 +132,7 @@ def started_cluster():
             with_minio=True,
             with_installed_binary=True,
             image="clickhouse/clickhouse-server",
-            tag="25.6.13.41",
+            tag="25.3.3.42",
             stay_alive=True,
             main_configs=[
                 "configs/remote_servers.xml",
@@ -2928,7 +2928,7 @@ def test_file_pruning_with_hive_style_partitioning(started_cluster):
 
     query_id = f"{table_name}_query_6"
     node_old = started_cluster.instances["dummy_old"]
-    if "25.6" not in node_old.query("SELECT version()"):
+    if "25.3" not in node_old.query("SELECT version()"):
         node_old.restart_with_original_version(clear_data_dir=True)
 
     node_old.query(
@@ -3102,7 +3102,7 @@ def test_file_pruning_with_hive_style_partitioning_2(started_cluster):
         )
 
     node_old = started_cluster.instances["dummy_old"]
-    if "25.6" not in node_old.query("SELECT version()"):
+    if "25.3" not in node_old.query("SELECT version()"):
         node_old.restart_with_original_version(clear_data_dir=True)
 
     node_old.query(

--- a/tests/queries/0_stateless/03363_hive_style_partition.reference
+++ b/tests/queries/0_stateless/03363_hive_style_partition.reference
@@ -34,4 +34,5 @@ test/t_03363_function/year=2025/country=/<snowflakeid>.parquet	11
 1
 3
 USA	2022	1
+0
 1

--- a/tests/queries/0_stateless/03363_hive_style_partition.sql
+++ b/tests/queries/0_stateless/03363_hive_style_partition.sql
@@ -77,16 +77,20 @@ INSERT INTO FUNCTION s3(s3_conn, filename='t_03363_parquet', format=Parquet, par
 INSERT INTO FUNCTION s3(s3_conn, filename='half_baked', format=Parquet, partition_strategy='hive') PARTITION BY year SELECT 1 AS key, 2020 AS year;
 
 -- Should fail because contains only partition columns in schema and `use_hive_partitioning=1`
-CREATE TABLE s3_table_half_schema_with_format (key UInt64) engine=S3(s3_conn, filename='half_baked/**.parquet', format=Parquet) SETTINGS use_hive_partitioning=1; -- {serverError INCORRECT_DATA}
+CREATE TABLE s3_table_half_schema_with_format (year UInt64) engine=S3(s3_conn, filename='half_baked/**.parquet', format=Parquet) SETTINGS use_hive_partitioning=1; -- {serverError INCORRECT_DATA}
 
 -- Should succeed because hive is off
-CREATE TABLE s3_table_half_schema_with_format (key UInt64) engine=S3(s3_conn, filename='half_baked/**.parquet', format=Parquet) SETTINGS use_hive_partitioning=0;
+CREATE TABLE s3_table_half_schema_with_format (year UInt64) engine=S3(s3_conn, filename='half_baked/**.parquet', format=Parquet) SETTINGS use_hive_partitioning=0;
 
--- Should succeed and not return hive columns. Distinct because maybe MinIO isn't cleaned up
+-- Should succeed and not return hive columns (as nothing else is in schema - then no columns at all). Distinct because maybe MinIO isn't cleaned up
 SELECT DISTINCT * FROM s3_table_half_schema_with_format;
 
+CREATE TABLE s3_table_half_schema_with_format_2 (key UInt64) engine=S3(s3_conn, filename='half_baked/**.parquet', format=Parquet) SETTINGS use_hive_partitioning=0;
+
+SELECT DISTINCT * FROM s3_table_half_schema_with_format_2;
+
 -- Should fail because the column year does not exist
-SELECT year, * FROM s3_table_half_schema_with_format; -- {serverError UNKNOWN_IDENTIFIER}
+SELECT key, * FROM s3_table_half_schema_with_format; -- {serverError UNKNOWN_IDENTIFIER}
 
 -- hive with partition id placeholder
 CREATE TABLE t_03363_s3_sink (year UInt16, country String, counter UInt8)


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix hive partitioning bug in 25.8 which can lead to incorrectly thrown exception `A hive partitioned file can't contain only partition columns`.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
