### PR TITLE
Fix crash in `dictGetDescendants` caused by `NULL` when dictionary type has Hierarchy support but no column is `HIERARCHICAL`

### DIFF
--- a/src/Functions/FunctionsExternalDictionaries.h
+++ b/src/Functions/FunctionsExternalDictionaries.h
@@ -1324,6 +1324,9 @@ public:
     FunctionBasePtr buildImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type) const override
     {
         auto dictionary = dictionary_helper->getDictionary(arguments[0].column);
+
+        FunctionDictHelper::checkDictionaryHierarchySupport(dictionary);
+
         auto hierarchical_parent_to_child_index = dictionary->getHierarchicalIndex();
 
         size_t level = Strategy::default_level;

--- a/src/Functions/FunctionsExternalDictionaries.h
+++ b/src/Functions/FunctionsExternalDictionaries.h
@@ -94,7 +94,7 @@ public:
         return getDictionary(dict_name_col->getValue<String>());
     }
 
-    static const DictionaryAttribute & getDictionaryHierarchicalAttribute(const std::shared_ptr<const IDictionary> & dictionary)
+    static void checkDictionaryHierarchySupport(const std::shared_ptr<const IDictionary> & dictionary)
     {
         const auto & dictionary_structure = dictionary->getStructure();
         auto hierarchical_attribute_index_optional = dictionary_structure.hierarchical_attribute_index;
@@ -103,6 +103,14 @@ public:
             throw Exception(ErrorCodes::UNSUPPORTED_METHOD,
                 "Dictionary {} does not support hierarchy",
                 dictionary->getFullName());
+    }
+
+    static const DictionaryAttribute & getDictionaryHierarchicalAttribute(const std::shared_ptr<const IDictionary> & dictionary)
+    {
+        checkDictionaryHierarchySupport(dictionary);
+
+        const auto & dictionary_structure = dictionary->getStructure();
+        auto hierarchical_attribute_index_optional = dictionary_structure.hierarchical_attribute_index;
 
         size_t hierarchical_attribute_index = *hierarchical_attribute_index_optional;
         const auto & hierarchical_attribute = dictionary_structure.attributes[hierarchical_attribute_index];

--- a/tests/queries/0_stateless/03749_dictionary_hierarchical_null.reference
+++ b/tests/queries/0_stateless/03749_dictionary_hierarchical_null.reference
@@ -1,0 +1,45 @@
+-- {echoOn }
+
+DROP DICTIONARY IF EXISTS d0;
+CREATE DICTIONARY d0 (c0 Int) PRIMARY KEY (c0) SOURCE(NULL()) LAYOUT(FLAT()) LIFETIME(1);
+SELECT dictGetDescendants('d0', 'c0', 1); -- { serverError UNSUPPORTED_METHOD }
+SELECT dictGetDescendants('d0', 'c0', NULL); -- { serverError UNSUPPORTED_METHOD }
+SELECT dictGetDescendants('d0', NULL, 1); -- { serverError UNSUPPORTED_METHOD }
+SELECT dictGetChildren('d0', 'c0'); -- { serverError UNSUPPORTED_METHOD }
+SELECT dictGetChildren('d0', NULL); -- { serverError UNSUPPORTED_METHOD }
+SELECT dictGetChildren(NULL, NULL); -- { serverError UNSUPPORTED_METHOD }
+DROP DICTIONARY IF EXISTS hierarchical_dictionary;
+DROP TABLE IF EXISTS hierarchy_source;
+CREATE TABLE hierarchy_source
+(
+  id UInt64,
+  parent_id UInt64,
+  name String
+) ENGINE = Memory;
+INSERT INTO hierarchy_source VALUES
+(0, 0, 'Root'),
+(1, 0, 'Level 1 - Node 1'),
+(2, 1, 'Level 2 - Node 2'),
+(3, 1, 'Level 2 - Node 3'),
+(4, 2, 'Level 3 - Node 4'),
+(5, 2, 'Level 3 - Node 5'),
+(6, 3, 'Level 3 - Node 6');
+CREATE DICTIONARY hierarchical_dictionary
+(
+    id UInt64,
+    parent_id UInt64 HIERARCHICAL,
+    name String
+)
+PRIMARY KEY id
+SOURCE(CLICKHOUSE(TABLE 'hierarchy_source'))
+LAYOUT(HASHED())
+LIFETIME(0);
+SELECT dictGetDescendants('hierarchical_dictionary', 1, 1);
+[3,2]
+SELECT dictGetDescendants('hierarchical_dictionary', NULL, 1);
+\N
+SELECT dictGetDescendants('hierarchical_dictionary', 1, NULL); -- { serverError BAD_ARGUMENTS }
+SELECT dictGetChildren('hierarchical_dictionary', 1);
+[3,2]
+SELECT dictGetChildren('hierarchical_dictionary', NULL);
+\N

--- a/tests/queries/0_stateless/03749_dictionary_hierarchical_null.sql
+++ b/tests/queries/0_stateless/03749_dictionary_hierarchical_null.sql
@@ -1,0 +1,58 @@
+-- {echoOn }
+
+DROP DICTIONARY IF EXISTS d0;
+CREATE DICTIONARY d0 (c0 Int) PRIMARY KEY (c0) SOURCE(NULL()) LAYOUT(FLAT()) LIFETIME(1);
+
+SELECT dictGetDescendants('d0', 'c0', 1); -- { serverError UNSUPPORTED_METHOD }
+
+SELECT dictGetDescendants('d0', 'c0', NULL); -- { serverError UNSUPPORTED_METHOD }
+
+SELECT dictGetDescendants('d0', NULL, 1); -- { serverError UNSUPPORTED_METHOD }
+
+SELECT dictGetChildren('d0', 'c0'); -- { serverError UNSUPPORTED_METHOD }
+
+SELECT dictGetChildren('d0', NULL); -- { serverError UNSUPPORTED_METHOD }
+
+SELECT dictGetChildren(NULL, NULL); -- { serverError UNSUPPORTED_METHOD }
+
+
+DROP DICTIONARY IF EXISTS hierarchical_dictionary;
+DROP TABLE IF EXISTS hierarchy_source;
+
+CREATE TABLE hierarchy_source
+(
+  id UInt64,
+  parent_id UInt64,
+  name String
+) ENGINE = Memory;
+
+INSERT INTO hierarchy_source VALUES
+(0, 0, 'Root'),
+(1, 0, 'Level 1 - Node 1'),
+(2, 1, 'Level 2 - Node 2'),
+(3, 1, 'Level 2 - Node 3'),
+(4, 2, 'Level 3 - Node 4'),
+(5, 2, 'Level 3 - Node 5'),
+(6, 3, 'Level 3 - Node 6');
+
+
+CREATE DICTIONARY hierarchical_dictionary
+(
+    id UInt64,
+    parent_id UInt64 HIERARCHICAL,
+    name String
+)
+PRIMARY KEY id
+SOURCE(CLICKHOUSE(TABLE 'hierarchy_source'))
+LAYOUT(HASHED())
+LIFETIME(0);
+
+SELECT dictGetDescendants('hierarchical_dictionary', 1, 1);
+
+SELECT dictGetDescendants('hierarchical_dictionary', NULL, 1);
+
+SELECT dictGetDescendants('hierarchical_dictionary', 1, NULL); -- { serverError BAD_ARGUMENTS }
+
+SELECT dictGetChildren('hierarchical_dictionary', 1);
+
+SELECT dictGetChildren('hierarchical_dictionary', NULL);


### PR DESCRIPTION
The following query crashes:

```sql
CREATE DICTIONARY d0 (c0 Int) PRIMARY KEY (c0) SOURCE(NULL()) LAYOUT(FLAT()) LIFETIME(1);
SELECT dictGetDescendants('d0', 'c0', NULL);
```

Normally check for `Hierarchy` support for the particular dictionary is done in `FunctionDictGetDescendantsOverloadResolverImpl::getReturnTypeImpl()`. But when one of the arguments is `NULL`, `getReturnTypeImpl()` call is skipped, leading to `nullopt` optional value reference in `buildImpl`.

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix crash in `dictGetDescendants` caused by `NULL` when dictionary type has Hierarchy support but no column is `HIERARCHICAL`. Closes #92026. Closes #92121.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
