### PR TITLE
Fix create statement when using default minmax indicies

### DIFF
--- a/src/Databases/DatabasesCommon.cpp
+++ b/src/Databases/DatabasesCommon.cpp
@@ -104,7 +104,7 @@ void validateCreateQuery(const ASTCreateQuery & query, ContextPtr context)
     if (columns.indices)
     {
         for (const auto & child : columns.indices->children)
-            IndexDescription::getIndexFromAST(child, columns_desc, context);
+            IndexDescription::getIndexFromAST(child, columns_desc, /* is_implicitly_created */ false, context);
     }
     if (columns.constraints)
     {

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -515,7 +515,8 @@ ASTPtr InterpreterCreateQuery::formatIndices(const IndicesDescription & indices)
     auto res = std::make_shared<ASTExpressionList>();
 
     for (const auto & index : indices)
-        res->children.push_back(index.definition_ast->clone());
+        if (!index.isImplicitlyCreated())
+            res->children.push_back(index.definition_ast->clone());
 
     return res;
 }

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -774,7 +774,7 @@ InterpreterCreateQuery::TableProperties InterpreterCreateQuery::getTableProperti
         if (create.columns_list->indices)
             for (const auto & index : create.columns_list->indices->children)
             {
-                IndexDescription index_desc = IndexDescription::getIndexFromAST(index->clone(), properties.columns, getContext());
+                IndexDescription index_desc = IndexDescription::getIndexFromAST(index->clone(), properties.columns, /* is_implicitly_created */ false, getContext());
                 if (properties.indices.has(index_desc.name))
                     throw Exception(ErrorCodes::ILLEGAL_INDEX, "Duplicated index name {} is not allowed. Please use a different index name", backQuoteIfNeed(index_desc.name));
 

--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -1319,7 +1319,7 @@ void AlterCommands::apply(StorageInMemoryMetadata & metadata, ContextPtr context
     {
         try
         {
-            index = IndexDescription::getIndexFromAST(index.definition_ast, metadata_copy.columns, context);
+            index = IndexDescription::getIndexFromAST(index.definition_ast, metadata_copy.columns, context, index.isImplicitlyCreated());
         }
         catch (Exception & exception)
         {

--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -550,47 +550,11 @@ void AlterCommand::apply(StorageInMemoryMetadata & metadata, ContextPtr context)
             metadata.columns.add(column, after_column, first);
         }
 
-        /// Try to add "implicit" minmax index for new column
-        if (metadata.settings_changes
-            && ((isNumber(column.type) && metadata.settings_changes->as<ASTSetQuery &>().changes.tryGet("add_minmax_index_for_numeric_columns"))
-                || (isString(column.type) && metadata.settings_changes->as<ASTSetQuery &>().changes.tryGet("add_minmax_index_for_string_columns"))))
-        {
-            bool minmax_index_exists = false;
-            for (const auto & index: metadata.secondary_indices)
-            {
-                if (index.column_names.front() == column.name && index.type == "minmax")
-                {
-                    minmax_index_exists = true;
-                    break;
-                }
-            }
-
-            if (!minmax_index_exists)
-            {
-                auto new_index = createImplicitMinMaxIndexDescription(column.name, metadata.columns, context);
-                metadata.secondary_indices.push_back(new_index);
-            }
-        }
+        metadata.addImplicitIndicesForColumn(column, context);
     }
     else if (type == DROP_COLUMN)
     {
-        const auto * column = metadata.columns.tryGet(column_name);
-        if (column && metadata.settings_changes
-            && ((isNumber(column->type) && metadata.settings_changes->as<ASTSetQuery &>().changes.tryGet("add_minmax_index_for_numeric_columns"))
-                || (isString(column->type) && metadata.settings_changes->as<ASTSetQuery &>().changes.tryGet("add_minmax_index_for_string_columns"))))
-        {
-            for (auto index_it = metadata.secondary_indices.begin();
-                     index_it != metadata.secondary_indices.end();)
-            {
-                if (index_it->name == IMPLICITLY_ADDED_MINMAX_INDEX_PREFIX + column_name)
-                {
-                    index_it = metadata.secondary_indices.erase(index_it);
-                    break;
-                }
-                else
-                    ++index_it;
-            }
-        }
+        metadata.dropImplicitIndicesForColumn(column_name);
 
         /// Otherwise just clear data on disk
         if (!clear && !partition)
@@ -640,7 +604,12 @@ void AlterCommand::apply(StorageInMemoryMetadata & metadata, ContextPtr context)
                     column.ttl = ttl;
 
                 if (data_type)
+                {
                     column.type = data_type;
+                    /// The type changed, so assume that implicit indices may change too
+                    metadata.dropImplicitIndicesForColumn(column_name);
+                    metadata.addImplicitIndicesForColumn(column, context);
+                }
 
                 if (!settings_changes.empty())
                 {
@@ -723,9 +692,7 @@ void AlterCommand::apply(StorageInMemoryMetadata & metadata, ContextPtr context)
         }
 
         if (index_name.starts_with(IMPLICITLY_ADDED_MINMAX_INDEX_PREFIX)
-            && metadata.settings_changes
-            && (metadata.settings_changes->as<ASTSetQuery &>().changes.tryGet("add_minmax_index_for_numeric_columns")
-                || metadata.settings_changes->as<ASTSetQuery &>().changes.tryGet("add_minmax_index_for_string_columns")))
+            && (metadata.add_minmax_index_for_numeric_columns || metadata.add_minmax_index_for_string_columns))
         {
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Cannot add index {} because it uses a reserved index name", index_name);
         }
@@ -998,17 +965,10 @@ void AlterCommand::apply(StorageInMemoryMetadata & metadata, ContextPtr context)
 
         for (auto & index : metadata.secondary_indices)
         {
-            if (index.name == IMPLICITLY_ADDED_MINMAX_INDEX_PREFIX + column_name
-                && metadata.settings_changes
-                && (metadata.settings_changes->as<ASTSetQuery &>().changes.tryGet("add_minmax_index_for_numeric_columns")
-                    ||  metadata.settings_changes->as<ASTSetQuery &>().changes.tryGet("add_minmax_index_for_string_columns")))
-            {
+            if (index.isImplicitlyCreated() && index.column_names.front() == column_name)
                 index.definition_ast = createImplicitMinMaxIndexAST(rename_to);
-            }
             else
-            {
                 rename_visitor.visit(index.definition_ast);
-            }
         }
     }
     else if (type == MODIFY_SQL_SECURITY)

--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -757,7 +757,7 @@ void AlterCommand::apply(StorageInMemoryMetadata & metadata, ContextPtr context)
             ++insert_it;
         }
 
-        metadata.secondary_indices.emplace(insert_it, IndexDescription::getIndexFromAST(index_decl, metadata.columns, context));
+        metadata.secondary_indices.emplace(insert_it, IndexDescription::getIndexFromAST(index_decl, metadata.columns, /* is_implicitly_created */ false, context));
     }
     else if (type == DROP_INDEX)
     {
@@ -1319,7 +1319,7 @@ void AlterCommands::apply(StorageInMemoryMetadata & metadata, ContextPtr context
     {
         try
         {
-            index = IndexDescription::getIndexFromAST(index.definition_ast, metadata_copy.columns, context, index.isImplicitlyCreated());
+            index = IndexDescription::getIndexFromAST(index.definition_ast, metadata_copy.columns, index.isImplicitlyCreated(), context);
         }
         catch (Exception & exception)
         {

--- a/src/Storages/IndicesDescription.cpp
+++ b/src/Storages/IndicesDescription.cpp
@@ -75,7 +75,7 @@ IndexDescription & IndexDescription::operator=(const IndexDescription & other)
     return *this;
 }
 
-IndexDescription IndexDescription::getIndexFromAST(const ASTPtr & definition_ast, const ColumnsDescription & columns, ContextPtr context, bool is_implicitly_created)
+IndexDescription IndexDescription::getIndexFromAST(const ASTPtr & definition_ast, const ColumnsDescription & columns, bool is_implicitly_created, ContextPtr context)
 {
     const auto * index_definition = definition_ast->as<ASTIndexDeclaration>();
     if (!index_definition)
@@ -121,7 +121,7 @@ IndexDescription IndexDescription::getIndexFromAST(const ASTPtr & definition_ast
 
 void IndexDescription::recalculateWithNewColumns(const ColumnsDescription & new_columns, ContextPtr context)
 {
-    *this = getIndexFromAST(definition_ast, new_columns, context);
+    *this = getIndexFromAST(definition_ast, new_columns, /* is_implicitly_created */ false, context);
 }
 
 void IndexDescription::initExpressionInfo(ASTPtr index_expression, const ColumnsDescription & columns, ContextPtr context)
@@ -209,7 +209,7 @@ IndicesDescription IndicesDescription::parse(const String & str, const ColumnsDe
     ASTPtr list = parseQuery(parser, str, 0, DBMS_DEFAULT_MAX_PARSER_DEPTH, DBMS_DEFAULT_MAX_PARSER_BACKTRACKS);
 
     for (const auto & index : list->children)
-        result.emplace_back(IndexDescription::getIndexFromAST(index, columns, context));
+        result.emplace_back(IndexDescription::getIndexFromAST(index, columns, /* is_implicitly_created */ false, context));
 
     return result;
 }
@@ -250,7 +250,7 @@ ASTPtr createImplicitMinMaxIndexAST(const String & column_name)
 IndexDescription createImplicitMinMaxIndexDescription(const String & column_name, const ColumnsDescription & columns, ContextPtr context)
 {
     auto index_ast = createImplicitMinMaxIndexAST(column_name);
-    return IndexDescription::getIndexFromAST(index_ast, columns, context, /* is_implicitly_created */ true);
+    return IndexDescription::getIndexFromAST(index_ast, columns, /* is_implicitly_created */ true, context);
 }
 
 }

--- a/src/Storages/IndicesDescription.cpp
+++ b/src/Storages/IndicesDescription.cpp
@@ -121,7 +121,7 @@ IndexDescription IndexDescription::getIndexFromAST(const ASTPtr & definition_ast
 
 void IndexDescription::recalculateWithNewColumns(const ColumnsDescription & new_columns, ContextPtr context)
 {
-    *this = getIndexFromAST(definition_ast, new_columns, /* is_implicitly_created */ false, context);
+    *this = getIndexFromAST(definition_ast, new_columns, is_implicitly_created, context);
 }
 
 void IndexDescription::initExpressionInfo(ASTPtr index_expression, const ColumnsDescription & columns, ContextPtr context)
@@ -186,7 +186,22 @@ bool IndicesDescription::hasType(const String & type) const
     return false;
 }
 
-String IndicesDescription::toString() const
+String IndicesDescription::explicitToString() const
+{
+    if (empty())
+        return {};
+
+    ASTExpressionList list;
+    for (const auto & index : *this)
+    {
+        if (!index.isImplicitlyCreated())
+            list.children.push_back(index.definition_ast);
+    }
+
+    return list.formatWithSecretsOneLine();
+}
+
+String IndicesDescription::allToString() const
 {
     if (empty())
         return {};

--- a/src/Storages/IndicesDescription.cpp
+++ b/src/Storages/IndicesDescription.cpp
@@ -36,6 +36,7 @@ IndexDescription::IndexDescription(const IndexDescription & other)
     , data_types(other.data_types)
     , sample_block(other.sample_block)
     , granularity(other.granularity)
+    , is_implicitly_created(other.is_implicitly_created)
 {
     if (other.expression)
         expression = other.expression->clone();
@@ -70,10 +71,11 @@ IndexDescription & IndexDescription::operator=(const IndexDescription & other)
     data_types = other.data_types;
     sample_block = other.sample_block;
     granularity = other.granularity;
+    is_implicitly_created = other.is_implicitly_created;
     return *this;
 }
 
-IndexDescription IndexDescription::getIndexFromAST(const ASTPtr & definition_ast, const ColumnsDescription & columns, ContextPtr context)
+IndexDescription IndexDescription::getIndexFromAST(const ASTPtr & definition_ast, const ColumnsDescription & columns, ContextPtr context, bool is_implicitly_created)
 {
     const auto * index_definition = definition_ast->as<ASTIndexDeclaration>();
     if (!index_definition)
@@ -94,6 +96,7 @@ IndexDescription IndexDescription::getIndexFromAST(const ASTPtr & definition_ast
     result.name = index_definition->name;
     result.type = Poco::toLower(index_type->name);
     result.granularity = index_definition->granularity;
+    result.is_implicitly_created = is_implicitly_created;
 
     result.initExpressionInfo(index_definition->getExpression(), columns, context);
 
@@ -247,7 +250,7 @@ ASTPtr createImplicitMinMaxIndexAST(const String & column_name)
 IndexDescription createImplicitMinMaxIndexDescription(const String & column_name, const ColumnsDescription & columns, ContextPtr context)
 {
     auto index_ast = createImplicitMinMaxIndexAST(column_name);
-    return IndexDescription::getIndexFromAST(index_ast, columns, context);
+    return IndexDescription::getIndexFromAST(index_ast, columns, context, /* is_implicitly_created */ true);
 }
 
 }

--- a/src/Storages/IndicesDescription.h
+++ b/src/Storages/IndicesDescription.h
@@ -50,11 +50,11 @@ struct IndexDescription
     /// Index granularity, make sense for skip indices
     size_t granularity;
 
-    /// This is set when index is created using add_minmax_index_for_numeric_columns and add_minmax_index_for_string_columns
-    bool is_implicitly_created = false;
+    /// True if index is created implicitly using settings add_minmax_index_for_numeric_columns or add_minmax_index_for_string_columns
+    bool is_implicitly_created;
 
     /// Parse index from definition AST
-    static IndexDescription getIndexFromAST(const ASTPtr & definition_ast, const ColumnsDescription & columns, ContextPtr context, bool is_implicitly_created = false);
+    static IndexDescription getIndexFromAST(const ASTPtr & definition_ast, const ColumnsDescription & columns, bool is_implicitly_created, ContextPtr context);
 
     IndexDescription() = default;
 

--- a/src/Storages/IndicesDescription.h
+++ b/src/Storages/IndicesDescription.h
@@ -82,8 +82,14 @@ struct IndicesDescription : public std::vector<IndexDescription>, IHints<>
     bool has(const String & name) const;
     /// Index with type exists
     bool hasType(const String & type) const;
-    /// Convert description to string
-    String toString() const;
+
+    /// Convert description to string. Includes only explicitly created indices
+    String explicitToString() const;
+
+    /// Convert description to string. Includes all indices.
+    /// It should only used for compatibility or debugging. Otherwise prefer explicitToString()
+    String allToString() const;
+
     /// Parse description from string
     static IndicesDescription parse(const String & str, const ColumnsDescription & columns, ContextPtr context);
 

--- a/src/Storages/IndicesDescription.h
+++ b/src/Storages/IndicesDescription.h
@@ -50,8 +50,11 @@ struct IndexDescription
     /// Index granularity, make sense for skip indices
     size_t granularity;
 
+    /// This is set when index is created using add_minmax_index_for_numeric_columns and add_minmax_index_for_string_columns
+    bool is_implicitly_created = false;
+
     /// Parse index from definition AST
-    static IndexDescription getIndexFromAST(const ASTPtr & definition_ast, const ColumnsDescription & columns, ContextPtr context);
+    static IndexDescription getIndexFromAST(const ASTPtr & definition_ast, const ColumnsDescription & columns, ContextPtr context, bool is_implicitly_created = false);
 
     IndexDescription() = default;
 

--- a/src/Storages/IndicesDescription.h
+++ b/src/Storages/IndicesDescription.h
@@ -67,7 +67,7 @@ struct IndexDescription
     /// if something change in columns.
     void recalculateWithNewColumns(const ColumnsDescription & new_columns, ContextPtr context);
 
-    bool isImplicitlyCreated() const { return name.starts_with(IMPLICITLY_ADDED_MINMAX_INDEX_PREFIX); }
+    bool isImplicitlyCreated() const { return is_implicitly_created; }
 
     void initExpressionInfo(ASTPtr index_expression, const ColumnsDescription & columns, ContextPtr context);
 

--- a/src/Storages/MergeTree/MergeTreeIndices.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndices.cpp
@@ -85,29 +85,33 @@ MergeTreeIndices MergeTreeIndexFactory::getMany(const std::vector<IndexDescripti
     return result;
 }
 
+void MergeTreeIndexFactory::implicitValidation(const IndexDescription & index)
+{
+    if (index.expression->hasArrayJoin())
+        throw Exception(ErrorCodes::INCORRECT_QUERY, "Secondary index '{}' cannot contain array joins", index.name);
+
+    try
+    {
+        index.expression->assertDeterministic();
+    }
+    catch (Exception & e)
+    {
+        e.addMessage(fmt::format("for secondary index '{}'", index.name));
+        throw;
+    }
+
+    for (const auto & elem : index.sample_block)
+        if (elem.column && (isColumnConst(*elem.column) || elem.column->isDummy()))
+            throw Exception(ErrorCodes::INCORRECT_QUERY, "Secondary index '{}' cannot contain constants", index.name);
+}
+
+
 void MergeTreeIndexFactory::validate(const IndexDescription & index, bool attach) const
 {
     /// Do not allow constant and non-deterministic expressions.
     /// Do not throw on attach for compatibility.
     if (!attach)
-    {
-        if (index.expression->hasArrayJoin())
-            throw Exception(ErrorCodes::INCORRECT_QUERY, "Secondary index '{}' cannot contain array joins", index.name);
-
-        try
-        {
-            index.expression->assertDeterministic();
-        }
-        catch (Exception & e)
-        {
-            e.addMessage(fmt::format("for secondary index '{}'", index.name));
-            throw;
-        }
-
-        for (const auto & elem : index.sample_block)
-            if (elem.column && (isColumnConst(*elem.column) || elem.column->isDummy()))
-                throw Exception(ErrorCodes::INCORRECT_QUERY, "Secondary index '{}' cannot contain constants", index.name);
-    }
+        implicitValidation(index);
 
     auto it = validators.find(index.type);
     if (it == validators.end())

--- a/src/Storages/MergeTree/MergeTreeIndices.h
+++ b/src/Storages/MergeTree/MergeTreeIndices.h
@@ -356,6 +356,7 @@ public:
 
     using Validator = std::function<void(const IndexDescription & index, bool attach)>;
 
+    static void implicitValidation(const IndexDescription & index);
     void validate(const IndexDescription & index, bool attach) const;
 
     MergeTreeIndexPtr get(const IndexDescription & index) const;

--- a/src/Storages/MergeTree/PatchParts/RangesInPatchParts.cpp
+++ b/src/Storages/MergeTree/PatchParts/RangesInPatchParts.cpp
@@ -254,10 +254,10 @@ MaybeMinMaxStats getPatchMinMaxStats(const DataPartPtr & patch_part, const MarkR
     auto metadata_snapshot = patch_part->getMetadataSnapshot();
     const auto & secondary_indices = metadata_snapshot->getSecondaryIndices();
 
-    auto it = std::ranges::find_if(secondary_indices, [&](const auto & index)
-    {
-        return index.name == IMPLICITLY_ADDED_MINMAX_INDEX_PREFIX + column_name;
-    });
+    auto it = std::ranges::find_if(
+        secondary_indices,
+        [&](const auto & index)
+        { return index.isImplicitlyCreated() && index.name == IMPLICITLY_ADDED_MINMAX_INDEX_PREFIX + column_name; });
 
     if (it == secondary_indices.end())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Expected minmax index for {} column", column_name);

--- a/src/Storages/MergeTree/ReplicatedMergeTreeTableMetadata.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeTableMetadata.cpp
@@ -97,7 +97,8 @@ ReplicatedMergeTreeTableMetadata::ReplicatedMergeTreeTableMetadata(const MergeTr
 
     ttl_table = formattedASTNormalized(metadata_snapshot->getTableTTLs().definition_ast);
 
-    skip_indices = metadata_snapshot->getSecondaryIndices().toString();
+    /// We only store skip indices that are explicitly defined by user
+    skip_indices = metadata_snapshot->getSecondaryIndices().explicitToString();
 
     projections = metadata_snapshot->getProjections().toString();
 
@@ -369,11 +370,15 @@ bool ReplicatedMergeTreeTableMetadata::checkEquals(
         is_equal = false;
     }
 
-    String parsed_zk_skip_indices = IndicesDescription::parse(from_zk.skip_indices, columns, context).toString();
+    String parsed_zk_skip_indices = IndicesDescription::parse(from_zk.skip_indices, columns, context).explicitToString();
     if (skip_indices != parsed_zk_skip_indices)
     {
-        handleTableMetadataMismatch(table_name_for_error_message, "skip indexes", from_zk.skip_indices, parsed_zk_skip_indices, skip_indices, strict_check, logger);
-        is_equal = false;
+        String all_parsed_zk_skip_indices = IndicesDescription::parse(from_zk.skip_indices, columns, context).allToString();
+        if (skip_indices != all_parsed_zk_skip_indices)
+        {
+            handleTableMetadataMismatch(table_name_for_error_message, "skip indexes", from_zk.skip_indices, parsed_zk_skip_indices, skip_indices, strict_check, logger);
+            is_equal = false;
+        }
     }
 
     String parsed_zk_projections = ProjectionsDescription::parse(from_zk.projections, columns, context).toString();

--- a/src/Storages/MergeTree/ReplicatedMergeTreeTableMetadata.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeTableMetadata.cpp
@@ -374,6 +374,8 @@ bool ReplicatedMergeTreeTableMetadata::checkEquals(
     if (skip_indices != parsed_zk_skip_indices)
     {
         String all_parsed_zk_skip_indices = IndicesDescription::parse(from_zk.skip_indices, columns, context).allToString();
+        // Backward compatibility: older replicas included implicit indices in metadata,
+        // while newer ones exclude them. This check allows comparison between both formats.
         if (skip_indices != all_parsed_zk_skip_indices)
         {
             handleTableMetadataMismatch(table_name_for_error_message, "skip indexes", from_zk.skip_indices, parsed_zk_skip_indices, skip_indices, strict_check, logger);

--- a/src/Storages/MergeTree/registerStorageMergeTree.cpp
+++ b/src/Storages/MergeTree/registerStorageMergeTree.cpp
@@ -725,10 +725,11 @@ static StoragePtr create(const StorageFactory::Arguments & args)
             {
                 metadata.secondary_indices.push_back(IndexDescription::getIndexFromAST(index, columns, context));
                 auto index_name = index->as<ASTIndexDeclaration>()->name;
-                if (args.mode <= LoadingStrictnessLevel::CREATE && (
+
+                if (args.mode <= LoadingStrictnessLevel::CREATE &&
                     ((*storage_settings)[MergeTreeSetting::add_minmax_index_for_numeric_columns]
                     || (*storage_settings)[MergeTreeSetting::add_minmax_index_for_string_columns])
-                    && index_name.starts_with(IMPLICITLY_ADDED_MINMAX_INDEX_PREFIX)))
+                    && index_name.starts_with(IMPLICITLY_ADDED_MINMAX_INDEX_PREFIX))
                 {
                     throw Exception(ErrorCodes::BAD_ARGUMENTS, "Cannot create table because index {} uses a reserved index name", index_name);
                 }

--- a/src/Storages/MergeTree/registerStorageMergeTree.cpp
+++ b/src/Storages/MergeTree/registerStorageMergeTree.cpp
@@ -719,6 +719,8 @@ static StoragePtr create(const StorageFactory::Arguments & args)
             metadata.settings_changes = args.storage_def->settings->ptr();
         }
 
+        metadata.add_minmax_index_for_numeric_columns = (*storage_settings)[MergeTreeSetting::add_minmax_index_for_numeric_columns];
+        metadata.add_minmax_index_for_string_columns = (*storage_settings)[MergeTreeSetting::add_minmax_index_for_string_columns];
         if (args.query.columns_list && args.query.columns_list->indices)
         {
             for (const auto & index : args.query.columns_list->indices->children)
@@ -726,9 +728,8 @@ static StoragePtr create(const StorageFactory::Arguments & args)
                 metadata.secondary_indices.push_back(IndexDescription::getIndexFromAST(index, columns, /* is_implicitly_created */ false, context));
                 auto index_name = index->as<ASTIndexDeclaration>()->name;
 
-                if (args.mode <= LoadingStrictnessLevel::CREATE &&
-                    ((*storage_settings)[MergeTreeSetting::add_minmax_index_for_numeric_columns]
-                    || (*storage_settings)[MergeTreeSetting::add_minmax_index_for_string_columns])
+                if (args.mode <= LoadingStrictnessLevel::CREATE
+                    && (metadata.add_minmax_index_for_numeric_columns || metadata.add_minmax_index_for_string_columns)
                     && index_name.starts_with(IMPLICITLY_ADDED_MINMAX_INDEX_PREFIX))
                 {
                     throw Exception(ErrorCodes::BAD_ARGUMENTS, "Cannot create table because index {} uses a reserved index name", index_name);
@@ -739,26 +740,7 @@ static StoragePtr create(const StorageFactory::Arguments & args)
         /// Try to add "implicit" min-max indexes on all columns
         for (const auto & column : metadata.columns)
         {
-            if ((isNumber(column.type) && (*storage_settings)[MergeTreeSetting::add_minmax_index_for_numeric_columns])
-                || (isString(column.type) && (*storage_settings)[MergeTreeSetting::add_minmax_index_for_string_columns]))
-            {
-                bool minmax_index_exists = false;
-
-                for (const auto & index : metadata.secondary_indices)
-                {
-                    if (index.column_names.front() == column.name && index.type == "minmax")
-                    {
-                        minmax_index_exists = true;
-                        break;
-                    }
-                }
-
-                if (minmax_index_exists)
-                    continue;
-
-                auto new_index = createImplicitMinMaxIndexDescription(column.name, columns, context);
-                metadata.secondary_indices.push_back(std::move(new_index));
-            }
+            metadata.addImplicitIndicesForColumn(column, context);
         }
 
         String statistics_types_str = (*storage_settings)[MergeTreeSetting::auto_statistics_types];

--- a/src/Storages/MergeTree/registerStorageMergeTree.cpp
+++ b/src/Storages/MergeTree/registerStorageMergeTree.cpp
@@ -723,7 +723,7 @@ static StoragePtr create(const StorageFactory::Arguments & args)
         {
             for (const auto & index : args.query.columns_list->indices->children)
             {
-                metadata.secondary_indices.push_back(IndexDescription::getIndexFromAST(index, columns, context));
+                metadata.secondary_indices.push_back(IndexDescription::getIndexFromAST(index, columns, /* is_implicitly_created */ false, context));
                 auto index_name = index->as<ASTIndexDeclaration>()->name;
 
                 if (args.mode <= LoadingStrictnessLevel::CREATE &&

--- a/src/Storages/StorageInMemoryMetadata.cpp
+++ b/src/Storages/StorageInMemoryMetadata.cpp
@@ -818,6 +818,9 @@ NameSet StorageInMemoryMetadata::getColumnsWithoutDefaultExpressions(const Names
 
 void StorageInMemoryMetadata::addImplicitIndicesForColumn(const ColumnDescription & column, ContextPtr context)
 {
+    // Ephemeral columns are excluded from implicit indices because they are not persisted;
+    // this is a key behavioral change (see PR description) to avoid creating indices for columns
+    // that do not exist in storage and cannot be indexed.
     if (column.default_desc.kind == ColumnDefaultKind::Ephemeral)
         return;
 

--- a/src/Storages/StorageInMemoryMetadata.h
+++ b/src/Storages/StorageInMemoryMetadata.h
@@ -29,6 +29,8 @@ struct StorageInMemoryMetadata
     /// defaults, comments, etc. All table engines have columns.
     ColumnsDescription columns;
     /// Table indices. Currently supported for MergeTree only.
+    bool add_minmax_index_for_numeric_columns = false;
+    bool add_minmax_index_for_string_columns = false;
     IndicesDescription secondary_indices;
     /// Table constraints. Currently supported for MergeTree only.
     ConstraintsDescription constraints;
@@ -297,6 +299,9 @@ struct StorageInMemoryMetadata
 
     /// Elements of `columns` that have `default_desc.expression == nullptr`.
     NameSet getColumnsWithoutDefaultExpressions(const NamesAndTypesList & exclude) const;
+
+    void addImplicitIndicesForColumn(const ColumnDescription & column, ContextPtr context);
+    void dropImplicitIndicesForColumn(const String & column_name);
 };
 
 using StorageMetadataPtr = std::shared_ptr<const StorageInMemoryMetadata>;

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -6581,8 +6581,8 @@ void StorageReplicatedMergeTree::alter(
                 future_metadata_in_zk.ttl_table = "";
         }
 
-        String new_indices_str = future_metadata.secondary_indices.toString();
-        if (new_indices_str != current_metadata->secondary_indices.toString())
+        String new_indices_str = future_metadata.secondary_indices.explicitToString();
+        if (new_indices_str != current_metadata->secondary_indices.explicitToString())
             future_metadata_in_zk.skip_indices = new_indices_str;
 
         String new_projections_str = future_metadata.projections.toString();

--- a/tests/queries/0_stateless/03632_default_minmax_indices_alter.reference
+++ b/tests/queries/0_stateless/03632_default_minmax_indices_alter.reference
@@ -1,0 +1,2 @@
+CREATE TABLE default.t\n(\n    `a` UInt64,\n    `s` String\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS add_minmax_index_for_numeric_columns = 1, index_granularity = 8192
+CREATE TABLE default.t\n(\n    `a` UInt64\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS add_minmax_index_for_numeric_columns = 1, index_granularity = 8192

--- a/tests/queries/0_stateless/03632_default_minmax_indices_alter.sql
+++ b/tests/queries/0_stateless/03632_default_minmax_indices_alter.sql
@@ -1,0 +1,11 @@
+drop table if exists t;
+
+create table t (a UInt64, s String) engine = MergeTree order by tuple() settings add_minmax_index_for_numeric_columns = 1;
+
+show create table t;
+
+alter table t drop column s;
+
+show create table t;
+
+drop table t;

--- a/tests/queries/0_stateless/03632_default_minmax_indices_alter.sql
+++ b/tests/queries/0_stateless/03632_default_minmax_indices_alter.sql
@@ -1,3 +1,5 @@
+-- Test for issue #75677
+
 drop table if exists t;
 
 create table t (a UInt64, s String) engine = MergeTree order by tuple() settings add_minmax_index_for_numeric_columns = 1;

--- a/tests/queries/0_stateless/03748_default_minmax_indices_alter.reference
+++ b/tests/queries/0_stateless/03748_default_minmax_indices_alter.reference
@@ -1,18 +1,50 @@
+-- { echoOn }
+DROP TABLE IF EXISTS t_implicit;
+CREATE TABLE t_implicit (a UInt64, s String) ENGINE = MergeTree ORDER BY tuple() SETTINGS add_minmax_index_for_numeric_columns = 1;
+SHOW CREATE TABLE t_implicit;
 CREATE TABLE default.t_implicit\n(\n    `a` UInt64,\n    `s` String\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS add_minmax_index_for_numeric_columns = 1, index_granularity = 8192
+SELECT * FROM system.data_skipping_indices WHERE database = current_database() AND table = 't_implicit';
 default	t_implicit	auto_minmax_index_a	minmax	minmax()	a	1	0	0	0
+ALTER TABLE t_implicit DROP COLUMN s;
+SHOW CREATE TABLE t_implicit;
 CREATE TABLE default.t_implicit\n(\n    `a` UInt64\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS add_minmax_index_for_numeric_columns = 1, index_granularity = 8192
+SELECT * FROM system.data_skipping_indices WHERE database = current_database() AND table = 't_implicit';
 default	t_implicit	auto_minmax_index_a	minmax	minmax()	a	1	0	0	0
+ALTER TABLE t_implicit ADD COLUMN s2 String;
+SHOW CREATE TABLE t_implicit;
 CREATE TABLE default.t_implicit\n(\n    `a` UInt64,\n    `s2` String\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS add_minmax_index_for_numeric_columns = 1, index_granularity = 8192
+SELECT * FROM system.data_skipping_indices WHERE database = current_database() AND table = 't_implicit';
 default	t_implicit	auto_minmax_index_a	minmax	minmax()	a	1	0	0	0
+ALTER TABLE t_implicit ADD COLUMN a2 UInt64;
+SHOW CREATE TABLE t_implicit;
 CREATE TABLE default.t_implicit\n(\n    `a` UInt64,\n    `s2` String,\n    `a2` UInt64\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS add_minmax_index_for_numeric_columns = 1, index_granularity = 8192
+SELECT * FROM system.data_skipping_indices WHERE database = current_database() AND table = 't_implicit';
 default	t_implicit	auto_minmax_index_a	minmax	minmax()	a	1	0	0	0
 default	t_implicit	auto_minmax_index_a2	minmax	minmax()	a2	1	0	0	0
+ALTER TABLE t_implicit RENAME COLUMN a2 TO a_renamed;
+SHOW CREATE TABLE t_implicit;
 CREATE TABLE default.t_implicit\n(\n    `a` UInt64,\n    `s2` String,\n    `a_renamed` UInt64\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS add_minmax_index_for_numeric_columns = 1, index_granularity = 8192
+SELECT * FROM system.data_skipping_indices WHERE database = current_database() AND table = 't_implicit';
 default	t_implicit	auto_minmax_index_a	minmax	minmax()	a	1	0	0	0
 default	t_implicit	auto_minmax_index_a_renamed	minmax	minmax()	a_renamed	1	0	0	0
-CREATE TABLE default.t_implicit\n(\n    `a` UInt64,\n    `s2` String,\n    `a_renamed` String\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS add_minmax_index_for_numeric_columns = 1, index_granularity = 8192
+DETACH TABLE t_implicit;
+ATTACH TABLE t_implicit;
+SHOW CREATE TABLE t_implicit;
+CREATE TABLE default.t_implicit\n(\n    `a` UInt64,\n    `s2` String,\n    `a_renamed` UInt64\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS add_minmax_index_for_numeric_columns = 1, index_granularity = 8192
+SELECT * FROM system.data_skipping_indices WHERE database = current_database() AND table = 't_implicit';
 default	t_implicit	auto_minmax_index_a	minmax	minmax()	a	1	0	0	0
 default	t_implicit	auto_minmax_index_a_renamed	minmax	minmax()	a_renamed	1	0	0	0
-CREATE TABLE default.t_implicit\n(\n    `a` UInt64,\n    `s2` String,\n    `a_renamed` String\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS add_minmax_index_for_numeric_columns = 1, index_granularity = 8192
+ALTER TABLE t_implicit MODIFY COLUMN s2 UInt32;
+SHOW CREATE TABLE t_implicit;
+CREATE TABLE default.t_implicit\n(\n    `a` UInt64,\n    `s2` UInt32,\n    `a_renamed` UInt64\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS add_minmax_index_for_numeric_columns = 1, index_granularity = 8192
+SELECT * FROM system.data_skipping_indices WHERE database = current_database() AND table = 't_implicit';
 default	t_implicit	auto_minmax_index_a	minmax	minmax()	a	1	0	0	0
 default	t_implicit	auto_minmax_index_a_renamed	minmax	minmax()	a_renamed	1	0	0	0
+default	t_implicit	auto_minmax_index_s2	minmax	minmax()	s2	1	0	0	0
+ALTER TABLE t_implicit MODIFY COLUMN a_renamed String;
+SHOW CREATE TABLE t_implicit;
+CREATE TABLE default.t_implicit\n(\n    `a` UInt64,\n    `s2` UInt32,\n    `a_renamed` String\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS add_minmax_index_for_numeric_columns = 1, index_granularity = 8192
+SELECT * FROM system.data_skipping_indices WHERE database = current_database() AND table = 't_implicit';
+default	t_implicit	auto_minmax_index_a	minmax	minmax()	a	1	0	0	0
+default	t_implicit	auto_minmax_index_s2	minmax	minmax()	s2	1	0	0	0
+DROP TABLE t_implicit;

--- a/tests/queries/0_stateless/03748_default_minmax_indices_alter.reference
+++ b/tests/queries/0_stateless/03748_default_minmax_indices_alter.reference
@@ -1,0 +1,18 @@
+CREATE TABLE default.t_implicit\n(\n    `a` UInt64,\n    `s` String\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS add_minmax_index_for_numeric_columns = 1, index_granularity = 8192
+default	t_implicit	auto_minmax_index_a	minmax	minmax()	a	1	0	0	0
+CREATE TABLE default.t_implicit\n(\n    `a` UInt64\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS add_minmax_index_for_numeric_columns = 1, index_granularity = 8192
+default	t_implicit	auto_minmax_index_a	minmax	minmax()	a	1	0	0	0
+CREATE TABLE default.t_implicit\n(\n    `a` UInt64,\n    `s2` String\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS add_minmax_index_for_numeric_columns = 1, index_granularity = 8192
+default	t_implicit	auto_minmax_index_a	minmax	minmax()	a	1	0	0	0
+CREATE TABLE default.t_implicit\n(\n    `a` UInt64,\n    `s2` String,\n    `a2` UInt64\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS add_minmax_index_for_numeric_columns = 1, index_granularity = 8192
+default	t_implicit	auto_minmax_index_a	minmax	minmax()	a	1	0	0	0
+default	t_implicit	auto_minmax_index_a2	minmax	minmax()	a2	1	0	0	0
+CREATE TABLE default.t_implicit\n(\n    `a` UInt64,\n    `s2` String,\n    `a_renamed` UInt64\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS add_minmax_index_for_numeric_columns = 1, index_granularity = 8192
+default	t_implicit	auto_minmax_index_a	minmax	minmax()	a	1	0	0	0
+default	t_implicit	auto_minmax_index_a_renamed	minmax	minmax()	a_renamed	1	0	0	0
+CREATE TABLE default.t_implicit\n(\n    `a` UInt64,\n    `s2` String,\n    `a_renamed` String\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS add_minmax_index_for_numeric_columns = 1, index_granularity = 8192
+default	t_implicit	auto_minmax_index_a	minmax	minmax()	a	1	0	0	0
+default	t_implicit	auto_minmax_index_a_renamed	minmax	minmax()	a_renamed	1	0	0	0
+CREATE TABLE default.t_implicit\n(\n    `a` UInt64,\n    `s2` String,\n    `a_renamed` String\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS add_minmax_index_for_numeric_columns = 1, index_granularity = 8192
+default	t_implicit	auto_minmax_index_a	minmax	minmax()	a	1	0	0	0
+default	t_implicit	auto_minmax_index_a_renamed	minmax	minmax()	a_renamed	1	0	0	0

--- a/tests/queries/0_stateless/03748_default_minmax_indices_alter.sql
+++ b/tests/queries/0_stateless/03748_default_minmax_indices_alter.sql
@@ -1,3 +1,4 @@
+-- { echoOn }
 DROP TABLE IF EXISTS t_implicit;
 
 CREATE TABLE t_implicit (a UInt64, s String) ENGINE = MergeTree ORDER BY tuple() SETTINGS add_minmax_index_for_numeric_columns = 1;
@@ -23,10 +24,14 @@ SELECT * FROM system.data_skipping_indices WHERE database = current_database() A
 DETACH TABLE t_implicit;
 ATTACH TABLE t_implicit;
 
-ALTER TABLE t_implicit MODIFY COLUMN a_renamed String;
 SHOW CREATE TABLE t_implicit;
 SELECT * FROM system.data_skipping_indices WHERE database = current_database() AND table = 't_implicit';
 
+ALTER TABLE t_implicit MODIFY COLUMN s2 UInt32;
+SHOW CREATE TABLE t_implicit;
+SELECT * FROM system.data_skipping_indices WHERE database = current_database() AND table = 't_implicit';
+
+ALTER TABLE t_implicit MODIFY COLUMN a_renamed String;
 SHOW CREATE TABLE t_implicit;
 SELECT * FROM system.data_skipping_indices WHERE database = current_database() AND table = 't_implicit';
 

--- a/tests/queries/0_stateless/03748_default_minmax_indices_alter.sql
+++ b/tests/queries/0_stateless/03748_default_minmax_indices_alter.sql
@@ -1,0 +1,33 @@
+DROP TABLE IF EXISTS t_implicit;
+
+CREATE TABLE t_implicit (a UInt64, s String) ENGINE = MergeTree ORDER BY tuple() SETTINGS add_minmax_index_for_numeric_columns = 1;
+SHOW CREATE TABLE t_implicit;
+SELECT * FROM system.data_skipping_indices WHERE database = current_database() AND table = 't_implicit';
+
+ALTER TABLE t_implicit DROP COLUMN s;
+SHOW CREATE TABLE t_implicit;
+SELECT * FROM system.data_skipping_indices WHERE database = current_database() AND table = 't_implicit';
+
+ALTER TABLE t_implicit ADD COLUMN s2 String;
+SHOW CREATE TABLE t_implicit;
+SELECT * FROM system.data_skipping_indices WHERE database = current_database() AND table = 't_implicit';
+
+ALTER TABLE t_implicit ADD COLUMN a2 UInt64;
+SHOW CREATE TABLE t_implicit;
+SELECT * FROM system.data_skipping_indices WHERE database = current_database() AND table = 't_implicit';
+
+ALTER TABLE t_implicit RENAME COLUMN a2 TO a_renamed;
+SHOW CREATE TABLE t_implicit;
+SELECT * FROM system.data_skipping_indices WHERE database = current_database() AND table = 't_implicit';
+
+DETACH TABLE t_implicit;
+ATTACH TABLE t_implicit;
+
+ALTER TABLE t_implicit MODIFY COLUMN a_renamed String;
+SHOW CREATE TABLE t_implicit;
+SELECT * FROM system.data_skipping_indices WHERE database = current_database() AND table = 't_implicit';
+
+SHOW CREATE TABLE t_implicit;
+SELECT * FROM system.data_skipping_indices WHERE database = current_database() AND table = 't_implicit';
+
+DROP TABLE t_implicit;

--- a/tests/queries/0_stateless/03749_implicit_index_ephemeral_alias.reference
+++ b/tests/queries/0_stateless/03749_implicit_index_ephemeral_alias.reference
@@ -1,0 +1,2 @@
+test_string	auto_minmax_index_id
+test_string_alias	auto_minmax_index_id

--- a/tests/queries/0_stateless/03749_implicit_index_ephemeral_alias.sql
+++ b/tests/queries/0_stateless/03749_implicit_index_ephemeral_alias.sql
@@ -1,0 +1,24 @@
+DROP TABLE IF EXISTS test_string;
+DROP TABLE IF EXISTS test_string_alias;
+CREATE OR REPLACE TABLE test_string
+(
+    id UInt64,
+    unhexed String EPHEMERAL,
+    hexed FixedString(4) DEFAULT unhex(unhexed)
+)
+ENGINE = MergeTree
+ORDER BY id settings add_minmax_index_for_numeric_columns=1, add_minmax_index_for_string_columns=1;
+
+CREATE OR REPLACE TABLE test_string_alias
+(
+    id UInt64,
+    unhexed String ALIAS 'abc',
+    hexed FixedString(4) DEFAULT unhex(unhexed)
+)
+ENGINE = MergeTree
+ORDER BY id settings add_minmax_index_for_numeric_columns=1, add_minmax_index_for_string_columns=1;
+
+SELECT table, name FROM system.data_skipping_indices WHERE database = currentDatabase() ORDER BY table, name;
+
+DROP TABLE test_string;
+DROP TABLE test_string_alias;


### PR DESCRIPTION
### Changelog category (leave one):
- Backward Incompatible Change

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Multiple fixes around implicit indices. The schema shown or stored (keeper metadata) won't include implicit indices, such as the ones created by settings `add_minmax_index_for_numeric_columns` or `add_minmax_index_for_string_columns`. This might cause metadata errors when a ReplicatedMergeTree table is created or updated in a newer version, while there is a replica in an older release. For those cases send DDLs to the old replica until the cluster is upgraded completely. 

This PR:
* Extends and slightly simplifies https://github.com/ClickHouse/ClickHouse/pull/87723.
* Fixes implicit indices when the column type changes (related to https://github.com/ClickHouse/ClickHouse/pull/89335)
* Fixes implicit indices with ephemeral or alias columns
* Fixes ReplicatedMergeTree metadata sharing with implicit indices, so it does not include them (as they are not included in disk metadata). This is necessary to treat them properly as implicitly. It creates a minor incompatibility between versions.

Closes https://github.com/ClickHouse/ClickHouse/issues/87286.
Closes https://github.com/ClickHouse/ClickHouse/pull/87723

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
