### PR TITLE
Reduces memory usage during merges in system.metric_log table (Reapply #89811)

### DIFF
--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -1287,6 +1287,8 @@
         <buffer_size_rows_flush_threshold>524288</buffer_size_rows_flush_threshold>
         <collect_interval_milliseconds>1000</collect_interval_milliseconds>
         <flush_on_crash>false</flush_on_crash>
+        <!-- metric_log has over 1000 columns, which makes horizontal merges on wide parts expensive. -->
+        <!-- Setting the same 128MB limit for wide-part creation and vertical-merge activation avoids those merges and keeps memory usage low. -->
         <settings>min_bytes_for_wide_part = 134217728, vertical_merge_algorithm_min_bytes_to_activate=134217728</settings>
     </metric_log>
 

--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -1287,6 +1287,7 @@
         <buffer_size_rows_flush_threshold>524288</buffer_size_rows_flush_threshold>
         <collect_interval_milliseconds>1000</collect_interval_milliseconds>
         <flush_on_crash>false</flush_on_crash>
+        <settings>min_bytes_for_wide_part = 134217728, vertical_merge_algorithm_min_bytes_to_activate=134217728</settings>
     </metric_log>
 
     <!-- Error log contains rows with current values of errors collected with "collect_interval_milliseconds" interval. -->

--- a/src/Interpreters/SystemLog.cpp
+++ b/src/Interpreters/SystemLog.cpp
@@ -220,7 +220,7 @@ std::shared_ptr<TSystemLog> createSystemLog(
             LOG_ERROR(
                 getLogger("SystemLog"),
                 "Ignoring '{}.settings' because a custom 'engine' is specified. This usually happens when configs merge with defaults. "
-                "Move settings into the engine's SETTINGS clause and add <settings remove=\"remove\" /> to drop inherited settings, "
+                "Move settings into the 'engine' SETTINGS clause and add <settings remove=\"remove\" /> to drop inherited settings, "
                 "or omit <engine> and configure partition_by / ttl / order_by / storage_policy / settings sections instead.",
                 config_prefix);
         }

--- a/src/Interpreters/SystemLog.cpp
+++ b/src/Interpreters/SystemLog.cpp
@@ -216,9 +216,12 @@ std::shared_ptr<TSystemLog> createSystemLog(
                             "If 'engine' is specified for system table, SETTINGS storage_policy = '...' should "
                             "be specified directly inside 'engine' and 'storage_policy' setting doesn't make sense");
         if (config.has(config_prefix + ".settings"))
-            throw Exception(ErrorCodes::BAD_ARGUMENTS,
-                            "If 'engine' is specified for system table, SETTINGS parameters should "
-                            "be specified directly inside 'engine' and 'settings' setting doesn't make sense");
+        {
+            LOG_ERROR(
+                getLogger("SystemLog"),
+                "Ignoring '{}.settings' because 'engine' is specified for system table; SETTINGS must be defined inside the engine section",
+                config_prefix);
+        }
 
         log_settings.engine = config.getString(config_prefix + ".engine");
     }

--- a/src/Interpreters/SystemLog.cpp
+++ b/src/Interpreters/SystemLog.cpp
@@ -219,7 +219,9 @@ std::shared_ptr<TSystemLog> createSystemLog(
         {
             LOG_ERROR(
                 getLogger("SystemLog"),
-                "Ignoring '{}.settings' because 'engine' is specified for system table; SETTINGS must be defined inside the engine section",
+                "Ignoring '{}.settings' because a custom 'engine' is specified. This usually happens when configs merge with defaults. "
+                "Move settings into the engine's SETTINGS clause and add <settings remove=\"remove\" /> to drop inherited settings, "
+                "or omit <engine> and configure partition_by / ttl / order_by / storage_policy / settings sections instead.",
                 config_prefix);
         }
 


### PR DESCRIPTION
<!--- Disable AI PR formatting assistant: true -->
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Reduces memory usage during merges in `system.metric_log` table (enabled by default) by setting `min_bytes_for_wide_part` and `vertical_merge_algorithm_min_bytes_to_activate` to 128MB.

### Documentation entry for user-facing changes

Merges in `system.metric_log` could previously consume excessive memory due to wide parts being created (starting at 10MB or ~3.7K rows) before the vertical merge algorithm was enabled (128K rows or ~350MB). The new defaults synchronize these thresholds at 128 MB, allowing vertical merges to start earlier and significantly lowering memory requirements during background merges. (6GB -> 14MB)

Note: as discussed in #91388 we also now just print error to the logs when both engine & settings are defined (instead of exception), to avoid issues during upgrades.