### PR TITLE
Fix crash in `IN` function when lambda and non-const tuple arguments are used

### DIFF
--- a/tests/queries/0_stateless/03749_in_function_rewrite_lambda_lhs_non_const_rhs.reference
+++ b/tests/queries/0_stateless/03749_in_function_rewrite_lambda_lhs_non_const_rhs.reference
@@ -1,0 +1,7 @@
+-- { echoOn }
+
+SET enable_analyzer = 1;
+SELECT (y -> 1) IN (1, 1); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT (y -> 1) IN (materialize(1), 2); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT (y -> 1) IN [materialize(1), 2]; -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT 1 WHERE (y -> 1) IN (materialize(1), 1); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }

--- a/tests/queries/0_stateless/03749_in_function_rewrite_lambda_lhs_non_const_rhs.sql
+++ b/tests/queries/0_stateless/03749_in_function_rewrite_lambda_lhs_non_const_rhs.sql
@@ -1,0 +1,11 @@
+-- { echoOn }
+
+SET enable_analyzer = 1;
+
+SELECT (y -> 1) IN (1, 1); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+
+SELECT (y -> 1) IN (materialize(1), 2); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+
+SELECT (y -> 1) IN [materialize(1), 2]; -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+
+SELECT 1 WHERE (y -> 1) IN (materialize(1), 1); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }


### PR DESCRIPTION
The following query crashes due to NULL pointer dereference:

```sql
SELECT (y -> 1) IN (materialize(1), 2);
```

The crash happens during `convertTupleToArray` because lambda's result type is `nullptr` and dereferenced.

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix crash in `IN` function when lambda and non-const tuple arguments are used. Closes https://github.com/ClickHouse/ClickHouse/issues/91379.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
