### PR TITLE
Disable parallel inserts if any sink in chain do not support it

### DIFF
--- a/src/Interpreters/InsertDependenciesBuilder.cpp
+++ b/src/Interpreters/InsertDependenciesBuilder.cpp
@@ -758,8 +758,10 @@ InsertDependenciesBuilder::InsertDependenciesBuilder(
     LOG_TEST(logger, "InsertDependenciesBuilder created for table {} with query: {}, debugTree:\n{}",
         init_table_id.getFullTableName(), init_query->formatForLogging(), debugTree());
 
-    if (settings[Setting::parallel_view_processing] || !isViewsInvolved())
-        sink_stream_size = init_storage->supportsParallelInsert() ? max_insert_threads : 1;
+    auto all_sinks_support_parallel_insert = std::ranges::all_of(storages, [&] (auto storage)
+        { return isView(storage.first) || storage.second->supportsParallelInsert();});
+    if (all_sinks_support_parallel_insert && (settings[Setting::parallel_view_processing] || !isViewsInvolved()))
+        sink_stream_size = max_insert_threads;
 }
 
 namespace

--- a/src/Interpreters/InterpreterExplainQuery.cpp
+++ b/src/Interpreters/InterpreterExplainQuery.cpp
@@ -665,7 +665,7 @@ QueryPipeline InterpreterExplainQuery::executeImpl()
                     /* allow_materialized */ false,
                     /* no_squash */ false,
                     /* no_destination */ false,
-                    /* async_isnert */ false);
+                    /* async_insert */ false);
                 auto io = insert.execute();
                 printPipeline(io.pipeline.getProcessors(), buf);
                 // we do not need it anymore, it would be executed

--- a/tests/queries/0_stateless/03749_materialized_view_not_supports_parallel_write.reference
+++ b/tests/queries/0_stateless/03749_materialized_view_not_supports_parallel_write.reference
@@ -1,0 +1,51 @@
+digraph
+{
+  rankdir="LR";
+  { node [shape = rect]
+    n0[label="NumbersRange_0"];
+    n1[label="ExpressionTransform_1"];
+    n2[label="ExpressionTransform_2"];
+    n3[label="CountingTransform_3"];
+    n4[label="PlanSquashingTransform_4"];
+    n5[label="DeduplicationToken::AddTokenInfoTransform_5"];
+    n6[label="ApplySquashingTransform_21"];
+    n7[label="ConvertingTransform_6"];
+    n8[label="RemovingReplicatedColumnsTransform_7"];
+    n9[label="NestedElementsValidationTransform_8"];
+    n10[label="MergeTreeSink_9"];
+    n11[label="Copy_18"];
+    n12[label="BeginingViewsTransform_10"];
+    n13[label="ExecutingInnerQueryFromView_13"];
+    n14[label="CountingTransform_12"];
+    n15[label="PlanSquashingTransform_20"];
+    n16[label="ApplySquashingTransform_11"];
+    n17[label="RemovingReplicatedColumnsTransform_14"];
+    n18[label="NestedElementsValidationTransform_15"];
+    n19[label="RemovingSparseTransform_16"];
+    n20[label="SetOrJoinSink_17"];
+    n21[label="FinalizingViewsTransform_19"];
+    n22[label="EmptySink_22"];
+  }
+  n0 -> n1;
+  n1 -> n2;
+  n2 -> n3;
+  n3 -> n4;
+  n4 -> n5;
+  n5 -> n6;
+  n6 -> n7;
+  n7 -> n8;
+  n8 -> n9;
+  n9 -> n10;
+  n10 -> n11;
+  n11 -> n12;
+  n12 -> n13;
+  n13 -> n14;
+  n14 -> n15;
+  n15 -> n16;
+  n16 -> n17;
+  n17 -> n18;
+  n18 -> n19;
+  n19 -> n20;
+  n20 -> n21;
+  n21 -> n22;
+}

--- a/tests/queries/0_stateless/03749_materialized_view_not_supports_parallel_write.sql
+++ b/tests/queries/0_stateless/03749_materialized_view_not_supports_parallel_write.sql
@@ -1,0 +1,16 @@
+-- Tags: no-debug, no-debug, no-asan, no-tsan, no-msan, no-ubsan, no-sanitize-coverage, no-parallel-replicas, no-flaky-check
+-- - debug build adds CheckTokenTransform
+
+SET parallel_view_processing = 1, max_insert_threads = 2;
+
+CREATE TABLE test_set (c0 Int) ENGINE = Set;
+CREATE TABLE test_table (c0 Int) ENGINE = MergeTree ORDER BY c0 PARTITION BY c0;
+CREATE MATERIALIZED VIEW merge_tree_to_set TO test_set (c0 Int) AS (SELECT * FROM test_table);
+-- Expect the single insert chain
+EXPLAIN PIPELINE INSERT INTO TABLE test_table SELECT 1 FROM numbers(10);
+
+-- Fuzzed
+CREATE TABLE t0 (c0 Int) ENGINE = Log;
+CREATE TABLE t1 (c0 Int) ENGINE = Memory;
+CREATE MATERIALIZED VIEW v0 TO t0 (c0 Int) AS (SELECT t1.* IS NULL c0 FROM t1);
+INSERT INTO TABLE t1 (c0) SELECT c0 FROM generateRandom('c0 Int', 1, 1, 0) LIMIT 1;


### PR DESCRIPTION
Closes: #79419
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed parallel writes triggered by MaterializedView inserts into storages that do not support them.
