### PR TITLE
s3queue: add setting commit_on_select, fix check for attached mv during select

### DIFF
--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueSettings.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueSettings.cpp
@@ -39,6 +39,7 @@ namespace ErrorCodes
     DECLARE(UInt32, cleanup_interval_min_ms, 60000, "For unordered mode. Polling backoff min for cleanup", 0) \
     DECLARE(UInt32, cleanup_interval_max_ms, 60000, "For unordered mode. Polling backoff max for cleanup", 0) \
     DECLARE(Bool, use_persistent_processing_nodes, true, "This setting is deprecated", 0) \
+    DECLARE(Bool, commit_on_select, false, "Whether select query needs to commit data and apply after_processing action", 0) \
     DECLARE(UInt32, persistent_processing_node_ttl_seconds, 60 * 60, "Cleanup period for abandoned processing nodes", 0) \
     DECLARE(UInt64, buckets, 0, "Number of buckets for Ordered mode parallel processing", 0) \
     DECLARE(UInt64, list_objects_batch_size, 1000, "Size of a list batch in object storage", 0) \

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueSettings.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueSettings.cpp
@@ -39,7 +39,7 @@ namespace ErrorCodes
     DECLARE(UInt32, cleanup_interval_min_ms, 60000, "For unordered mode. Polling backoff min for cleanup", 0) \
     DECLARE(UInt32, cleanup_interval_max_ms, 60000, "For unordered mode. Polling backoff max for cleanup", 0) \
     DECLARE(Bool, use_persistent_processing_nodes, true, "This setting is deprecated", 0) \
-    DECLARE(Bool, commit_on_select, false, "Whether select query needs to commit data and apply after_processing action", 0) \
+    DECLARE(Bool, commit_on_select, false, "Whether SELECT query from queue table (not materialized view, but direct select from a queue table) needs to commit data and apply after_processing action. See also profile level setting stream_like_engine_allow_direct_select, which needs to be enabled if you want to use direct SELECT queries", 0) \
     DECLARE(UInt32, persistent_processing_node_ttl_seconds, 60 * 60, "Cleanup period for abandoned processing nodes", 0) \
     DECLARE(UInt64, buckets, 0, "Number of buckets for Ordered mode parallel processing", 0) \
     DECLARE(UInt64, list_objects_batch_size, 1000, "Size of a list batch in object storage", 0) \

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
@@ -539,7 +539,7 @@ void StorageObjectStorageQueue::read(
                         "To enable use setting `stream_like_engine_allow_direct_select`");
     }
 
-    if (mv_attached)
+    if (getDependencies() > 0)
     {
         throw Exception(ErrorCodes::QUERY_NOT_ALLOWED,
                         "Cannot read from {} with attached materialized views", getName());
@@ -692,9 +692,6 @@ void StorageObjectStorageQueue::threadFunc(size_t streaming_tasks_index)
             const size_t dependencies_count = getDependencies();
             if (dependencies_count)
             {
-                mv_attached.store(true);
-                SCOPE_EXIT({ mv_attached.store(false); });
-
                 LOG_DEBUG(log, "Started streaming to {} attached views", dependencies_count);
 
                 files_metadata->registerActive(storage_id);

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
@@ -127,7 +127,6 @@ namespace ErrorCodes
     extern const int NOT_IMPLEMENTED;
     extern const int FAULT_INJECTED;
     extern const int KEEPER_EXCEPTION;
-    extern const int TABLE_ALREADY_EXISTS;
 }
 
 namespace

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.h
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.h
@@ -107,6 +107,7 @@ private:
     /// it needs to be available in Keeper metadata for older server versions.
     /// Therefore it is not in AfterProcessingSettings.
     AfterProcessingSettings after_processing_settings TSA_GUARDED_BY(mutex);
+    bool commit_on_select TSA_GUARDED_BY(mutex);
 
     size_t min_insert_block_size_rows_for_materialized_views TSA_GUARDED_BY(mutex);
     size_t min_insert_block_size_bytes_for_materialized_views TSA_GUARDED_BY(mutex);

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.h
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.h
@@ -121,7 +121,6 @@ private:
 
     UInt64 reschedule_processing_interval_ms TSA_GUARDED_BY(mutex);
 
-    std::atomic<bool> mv_attached = false;
     std::atomic<bool> shutdown_called = false;
     std::atomic<bool> startup_finished = false;
     std::atomic<bool> table_is_being_dropped = false;

--- a/tests/integration/test_storage_s3_queue/test_0.py
+++ b/tests/integration/test_storage_s3_queue/test_0.py
@@ -508,6 +508,14 @@ def test_direct_select_file(started_cluster, mode):
         for l in node.query(f"SELECT * FROM {table_name}_1").splitlines()
     ] == values
 
+    for i in range(3):
+        node.query(f"ALTER TABLE {table_name}_{i + 1} MODIFY SETTING commit_on_select=true")
+
+    assert [
+        list(map(int, l.split()))
+        for l in node.query(f"SELECT * FROM {table_name}_1").splitlines()
+    ] == values
+
     assert [
         list(map(int, l.split()))
         for l in node.query(f"SELECT * FROM {table_name}_2").splitlines()
@@ -528,6 +536,7 @@ def test_direct_select_file(started_cluster, mode):
         additional_settings={
             "keeper_path": keeper_path,
             "s3queue_processing_threads_num": 1,
+            "commit_on_select": 1
         },
     )
 
@@ -547,6 +556,7 @@ def test_direct_select_file(started_cluster, mode):
         additional_settings={
             "keeper_path": keeper_path,
             "s3queue_processing_threads_num": 1,
+            "commit_on_select": 1
         },
     )
 
@@ -593,7 +603,7 @@ def test_direct_select_multiple_files(started_cluster, mode):
         table_name,
         mode,
         files_path,
-        additional_settings={"keeper_path": keeper_path, "processing_threads_num": 3},
+        additional_settings={"keeper_path": keeper_path, "processing_threads_num": 3, "commit_on_select": 1},
     )
     for i in range(5):
         rand_values = [[random.randint(0, 50) for _ in range(3)] for _ in range(10)]

--- a/tests/integration/test_storage_s3_queue/test_1.py
+++ b/tests/integration/test_storage_s3_queue/test_1.py
@@ -491,6 +491,7 @@ def test_max_set_size(started_cluster):
             "s3queue_cleanup_interval_min_ms": 0,
             "s3queue_cleanup_interval_max_ms": 0,
             "s3queue_processing_threads_num": 1,
+            "commit_on_select": 1
         },
     )
     total_values = generate_random_files(

--- a/tests/integration/test_storage_s3_queue/test_4.py
+++ b/tests/integration/test_storage_s3_queue/test_4.py
@@ -328,6 +328,13 @@ def test_alter_settings(started_cluster):
             f"SELECT value FROM system.s3_queue_settings WHERE name = 'enable_hash_ring_filtering' and table = '{table_name}'"
         ).strip()
     )
+    assert (
+        "false"
+        == node1.query(
+            f"SELECT value FROM system.s3_queue_settings WHERE name = 'commit_on_select' and table = '{table_name}'"
+        ).strip()
+    )
+
 
     node1.query(
         f"""
@@ -353,7 +360,8 @@ def test_alter_settings(started_cluster):
         min_insert_block_size_bytes_for_materialized_views=321,
         cleanup_interval_min_ms=34500,
         cleanup_interval_max_ms=45600,
-        persistent_processing_node_ttl_seconds=89
+        persistent_processing_node_ttl_seconds=89,
+        commit_on_select=true
     """
     )
 
@@ -383,6 +391,9 @@ def test_alter_settings(started_cluster):
         "after_processing_tag_key": "tagkey",
         "after_processing_tag_value": "tagvalue",
     }
+    bool_settings = {
+        "commit_on_select": "true",
+    }
 
     def check_alterable(setting):
         if setting.startswith("s3queue_"):
@@ -401,6 +412,9 @@ def test_alter_settings(started_cluster):
         check_alterable(setting)
 
     for setting, _ in string_settings.items():
+        check_alterable(setting)
+
+    for setting, _ in bool_settings.items():
         check_alterable(setting)
 
     assert 0 == int(
@@ -448,6 +462,7 @@ def test_alter_settings(started_cluster):
 
     for node in [node1, node2]:
         check_int_settings(node, int_settings)
+        check_int_settings(node, bool_settings)
         check_string_settings(node, string_settings)
 
         node.restart_clickhouse()


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
In storage S3(Azure)Queue add setting `commit_on_select` (to define whether processed data needs to be committed and whether to apply `after_processing` action). The default value is `false`, fix check for attached mv during select

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
