### PR TITLE
Allow compiling without `xray/xray_interface.h` header when XRay is disabled

### DIFF
--- a/src/Interpreters/InstrumentationManager.h
+++ b/src/Interpreters/InstrumentationManager.h
@@ -3,13 +3,7 @@
 #include "config.h"
 #include <base/types.h>
 
-#if USE_XRAY
-#include <xray/xray_interface.h>
-#endif
-
-namespace DB
-{
-namespace Instrumentation
+namespace DB::Instrumentation
 {
 
 enum class EntryType : UInt8
@@ -19,12 +13,6 @@ enum class EntryType : UInt8
     ENTRY_AND_EXIT
 };
 
-#if USE_XRAY
-EntryType fromXRayEntryType(XRayEntryType entry_type);
-String entryTypeToString(EntryType entry_type);
-#endif
-
-}
 }
 
 #if USE_XRAY
@@ -38,12 +26,21 @@ String entryTypeToString(EntryType entry_type);
 #include <boost/multi_index/hashed_index.hpp>
 #include <boost/multi_index/member.hpp>
 #include <boost/multi_index/ordered_index.hpp>
+#include <xray/xray_interface.h>
 
 #include <vector>
 #include <variant>
 
 namespace DB
 {
+
+namespace Instrumentation
+{
+
+EntryType fromXRayEntryType(XRayEntryType entry_type);
+String entryTypeToString(EntryType entry_type);
+
+}
 
 struct TraceLogElement;
 

--- a/src/Interpreters/InstrumentationManager.h
+++ b/src/Interpreters/InstrumentationManager.h
@@ -2,7 +2,10 @@
 
 #include "config.h"
 #include <base/types.h>
+
+#if USE_XRAY
 #include <xray/xray_interface.h>
+#endif
 
 namespace DB
 {
@@ -16,8 +19,10 @@ enum class EntryType : UInt8
     ENTRY_AND_EXIT
 };
 
+#if USE_XRAY
 EntryType fromXRayEntryType(XRayEntryType entry_type);
 String entryTypeToString(EntryType entry_type);
+#endif
 
 }
 }

--- a/src/Parsers/ASTSystemQuery.cpp
+++ b/src/Parsers/ASTSystemQuery.cpp
@@ -6,7 +6,10 @@
 #include <Common/quoteString.h>
 #include <IO/WriteBuffer.h>
 #include <IO/Operators.h>
+
+#if USE_XRAY
 #include <xray/xray_interface.h>
+#endif
 
 namespace DB
 {

--- a/src/Parsers/ASTSystemQuery.cpp
+++ b/src/Parsers/ASTSystemQuery.cpp
@@ -4,12 +4,9 @@
 #include <Parsers/ASTSystemQuery.h>
 #include <Poco/String.h>
 #include <Common/quoteString.h>
+#include <Interpreters/InstrumentationManager.h>
 #include <IO/WriteBuffer.h>
 #include <IO/Operators.h>
-
-#if USE_XRAY
-#include <xray/xray_interface.h>
-#endif
 
 namespace DB
 {


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Allow compiling without `xray/xray_interface.h` header when XRay is disabled.


