### PR TITLE
Fix three assertion failures in `InverseDictionaryLookupPass`

### DIFF
--- a/src/Analyzer/Passes/InverseDictionaryLookupPass.cpp
+++ b/src/Analyzer/Passes/InverseDictionaryLookupPass.cpp
@@ -216,7 +216,9 @@ public:
         }
 
         const String attr_col_name = dictget_function_info.attr_col_name_node->getValue().safeGet<String>();
-        chassert(dict_structure.hasAttribute(attr_col_name) && "Attribute not found in dictionary structure of dictionary");
+
+        if (!dict_structure.hasAttribute(attr_col_name))
+            return;
 
         DataTypePtr dict_attr_col_type = dict_structure.getAttribute(attr_col_name).type;
 

--- a/tests/queries/0_stateless/03701_optimize_inverse_dictionary_lookup_basic.sql
+++ b/tests/queries/0_stateless/03701_optimize_inverse_dictionary_lookup_basic.sql
@@ -442,3 +442,54 @@ ORDER BY color_id;
 CREATE DICTIONARY `dict` (`c0` UInt128) PRIMARY KEY (`c0`) SOURCE(NULL()) LAYOUT(FLAT()) LIFETIME(0);
 
 SELECT *, dictGetUInt16('dict', 'c0', `t1`.`c0`) = TRUE FROM `dict` AS t1; -- { serverError BAD_ARGUMENTS }
+
+
+-- Make sure return type of the replacement expression matches the original one
+
+DROP DICTIONARY IF EXISTS colors;
+DROP TABLE IF EXISTS t__fuzz_0;
+
+CREATE TABLE t__fuzz_0 (`color_id` UInt64, `payload` String)
+ENGINE = MergeTree ORDER BY color_id;
+
+CREATE DICTIONARY colors
+(
+  color_id   UInt64,
+  payload String
+)
+PRIMARY KEY color_id
+SOURCE(CLICKHOUSE(TABLE 't__fuzz_0'))
+LAYOUT(HASHED())
+LIFETIME(0);
+
+SELECT equals(materialize(9), CAST('red' AS Nullable(String)) = dictGetString('colors', 'payload', color_id))
+FROM t__fuzz_0;
+
+
+SET allow_suspicious_low_cardinality_types = 1;
+
+DROP DICTIONARY IF EXISTS dictionary_all;
+DROP TABLE IF EXISTS ref_table_all;
+DROP TABLE IF EXISTS tab__fuzz_24;
+
+CREATE TABLE tab__fuzz_24
+(`id` LowCardinality(UInt16), `payload` LowCardinality(Nullable(Int8)))
+ENGINE = MergeTree ORDER BY id;
+
+INSERT INTO tab__fuzz_24 FORMAT Values (1,'x'), (2,'y'), (99,'z');
+
+CREATE TABLE ref_table_all
+(`id` UInt64, `name` String, `i8` String, `i16` String, `i32` String, `i64` String, `u8` String, `u16` String, `u32` String, `u64` String, `f32` String, `f64` String, `d` String, `dt` String, `uid` String, `ip4` String, `ip6` String)
+ENGINE = MergeTree ORDER BY id;
+
+CREATE DICTIONARY dictionary_all
+(`id` UInt64, `name` String, `i8` String, `i16` String, `i32` String, `i64` String, `u8` String, `u16` String, `u32` String, `u64` String, `f32` String, `f64` String, `d` String, `dt` String, `uid` String, `ip4` String, `ip6` String)
+PRIMARY KEY id
+SOURCE(CLICKHOUSE(TABLE 'ref_table_all'))
+LIFETIME(MIN 0 MAX 0)
+LAYOUT(HASHED());
+
+SELECT DISTINCT 13, *, or(-32 = dictGetInt32(toFixedString('dictionary_all', toLowCardinality(14)), toFixedString('i32', 3), id), isNotDistinctFrom(1, 9223372036854775806), toLowCardinality(19), not(equals(payload, 9223372036854775806))), isNotNull('dictGetFloat64 - plan'), id, isNotNull(1)
+FROM tab__fuzz_24 PREWHERE equals(9223372036854775806, payload)
+WHERE isNotDistinctFrom(id, isNotDistinctFrom(9223372036854775806, equals(1, isNotNull(9223372036854775806)))) QUALIFY and(NULL, equals(1, isZeroOrNull(1)))
+ORDER BY payload DESC;

--- a/tests/queries/0_stateless/03701_optimize_inverse_dictionary_lookup_basic.sql
+++ b/tests/queries/0_stateless/03701_optimize_inverse_dictionary_lookup_basic.sql
@@ -436,3 +436,9 @@ SELECT color_id
 FROM t
 WHERE dictGetString('colors', 'name', color_id) = payload
 ORDER BY color_id;
+
+
+-- Validation of attribute name
+CREATE DICTIONARY `dict` (`c0` UInt128) PRIMARY KEY (`c0`) SOURCE(NULL()) LAYOUT(FLAT()) LIFETIME(0);
+
+SELECT *, dictGetUInt16('dict', 'c0', `t1`.`c0`) = TRUE FROM `dict` AS t1; -- { serverError BAD_ARGUMENTS }

--- a/tests/queries/0_stateless/03703_optimize_inverse_dictionary_lookup_dictget_family.reference
+++ b/tests/queries/0_stateless/03703_optimize_inverse_dictionary_lookup_dictget_family.reference
@@ -133,9 +133,9 @@ SELECT
     __table1.id AS id,
     __table1.payload AS payload
 FROM default.tab AS __table1
-WHERE __table1.id IN (SELECT __table1.id AS id
+WHERE _CAST(__table1.id IN (SELECT __table1.id AS id
 FROM dictionary(\'dictionary_all\') AS __table1
-WHERE _CAST(__table1.name, \'Nullable(String)\') = \'alpha\')
+WHERE _CAST(__table1.name, \'Nullable(String)\') = \'alpha\'), \'Nullable(UInt8)\')
 ORDER BY
     __table1.id ASC,
     __table1.payload ASC


### PR DESCRIPTION
The following queries has assertion failure:

```sql
CREATE DICTIONARY `dict` (`c0` UInt128) PRIMARY KEY (`c0`) SOURCE(NULL()) LAYOUT(FLAT()) LIFETIME(0);

SELECT *, dictGetUInt16('dict', 'c0', `t1`.`c0`) = TRUE FROM `dict` AS t1;
```

I assumed dictionary arguments would be validated before the pass; but it's not the case always.

The following two also have logical error because the return type of the original node and the replacement expression did not match (e.g. `Nullable(UInt8)` vs `UInt8`).

```sql
CREATE TABLE t__fuzz_0 (`color_id` UInt64, `payload` String)
ENGINE = MergeTree ORDER BY color_id;

CREATE DICTIONARY colors
(
  color_id   UInt64,
  payload String
)
PRIMARY KEY color_id
SOURCE(CLICKHOUSE(TABLE 't__fuzz_0'))
LAYOUT(HASHED())
LIFETIME(0);

SELECT equals(materialize(9), CAST('red' AS Nullable(String)) = dictGetString('colors', 'payload', color_id))
FROM t__fuzz_0;
```

```sql
CREATE TABLE tab__fuzz_24
(`id` LowCardinality(UInt16), `payload` LowCardinality(Nullable(Int8)))
ENGINE = MergeTree ORDER BY id;

INSERT INTO tab__fuzz_24 FORMAT Values (1,'x'), (2,'y'), (99,'z');

CREATE TABLE ref_table_all
(`id` UInt64, `name` String, `i8` String, `i16` String, `i32` String, `i64` String, `u8` String, `u16` String, `u32` String, `u64` String, `f32` String, `f64` String, `d` String, `dt` String, `uid` String, `ip4` String, `ip6` String)
ENGINE = MergeTree ORDER BY id;

CREATE DICTIONARY dictionary_all
(`id` UInt64, `name` String, `i8` String, `i16` String, `i32` String, `i64` String, `u8` String, `u16` String, `u32` String, `u64` String, `f32` String, `f64` String, `d` String, `dt` String, `uid` String, `ip4` String, `ip6` String)
PRIMARY KEY id
SOURCE(CLICKHOUSE(TABLE 'ref_table_all'))
LIFETIME(MIN 0 MAX 0)
LAYOUT(HASHED());

SELECT DISTINCT 13, *, or(-32 = dictGetInt32(toFixedString('dictionary_all', toLowCardinality(14)), toFixedString('i32', 3), id), isNotDistinctFrom(1, 9223372036854775806), toLowCardinality(19), not(equals(payload, 9223372036854775806))), isNotNull('dictGetFloat64 - plan'), id, isNotNull(1)
FROM tab__fuzz_24 PREWHERE equals(9223372036854775806, payload)
WHERE isNotDistinctFrom(id, isNotDistinctFrom(9223372036854775806, equals(1, isNotNull(9223372036854775806)))) QUALIFY and(NULL, equals(1, isZeroOrNull(1)))
ORDER BY payload DESC;
```

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
