### PR TITLE
Add array_group_by_mode setting for GROUP BY array comparison

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -1108,6 +1108,27 @@ See also:
 
 - [GROUP BY clause](/sql-reference/statements/select/group-by)
 )", 0) \
+    DECLARE(ArrayGroupByMode, array_group_by_mode, ArrayGroupByMode::ORDERED, R"(
+Controls how arrays are compared for equality in GROUP BY operations.
+
+Possible values:
+
+- `ordered` — Default. Arrays are compared element-by-element in order. `[1,2,3]` and `[3,2,1]` are different groups.
+- `multiset` — Arrays are compared as multisets (unordered, duplicates count). `[1,2,3]` and `[3,2,1]` are the same group, but `[1,1,2]` and `[1,2,2]` are different.
+- `set` — Arrays are compared as sets (unordered, duplicates ignored). `[1,2,3]`, `[3,2,1]`, and `[1,1,2,3]` are all the same group.
+
+**Example**
+
+```sql
+SET array_group_by_mode = 'multiset';
+SELECT arr, COUNT(*) FROM (SELECT [1,2,3] AS arr UNION ALL SELECT [3,2,1]) GROUP BY arr;
+-- Returns 1 row with count 2
+
+SET array_group_by_mode = 'ordered';
+SELECT arr, COUNT(*) FROM (SELECT [1,2,3] AS arr UNION ALL SELECT [3,2,1]) GROUP BY arr;
+-- Returns 2 rows with count 1 each
+```
+)", 0) \
     \
     DECLARE(Bool, skip_unavailable_shards, false, R"(
 Enables or disables silently skipping of unavailable shards.

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -44,6 +44,7 @@ class WriteBuffer;
 /// List of available types supported in Settings object (!= MergeTreeSettings, MySQLSettings, etc)
 #define COMMON_SETTINGS_SUPPORTED_TYPES(CLASS_NAME, M) \
     M(CLASS_NAME, ArrowCompression) \
+    M(CLASS_NAME, ArrayGroupByMode) \
     M(CLASS_NAME, Bool) \
     M(CLASS_NAME, BoolAuto) \
     M(CLASS_NAME, CapnProtoEnumComparingMode) \

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -56,6 +56,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"s3_slow_all_threads_after_retryable_error", false, false, "Disable the setting by default"},
             {"backup_slow_all_threads_after_retryable_s3_error", false, false, "Disable the setting by default"},
             {"schema_inference_make_columns_nullable", 1, 3, "Take nullability information from Parquet/ORC/Arrow metadata by default, instead of making everything nullable."},
+            {"array_group_by_mode", "ordered", "ordered", "New setting to control how arrays are compared in GROUP BY (ordered, multiset, set)."},
         });
         addSettingsChanges(settings_changes_history, "25.9",
         {

--- a/src/Core/SettingsEnums.cpp
+++ b/src/Core/SettingsEnums.cpp
@@ -365,4 +365,11 @@ IMPLEMENT_SETTING_ENUM(
      {"manifest_list_entry", IcebergMetadataLogLevel::ManifestListEntry},
      {"manifest_file_metadata", IcebergMetadataLogLevel::ManifestFileMetadata},
      {"manifest_file_entry", IcebergMetadataLogLevel::ManifestFileEntry}})
+
+IMPLEMENT_SETTING_ENUM(
+    ArrayGroupByMode,
+    ErrorCodes::BAD_ARGUMENTS,
+    {{"ordered", ArrayGroupByMode::ORDERED},
+     {"multiset", ArrayGroupByMode::MULTISET},
+     {"set", ArrayGroupByMode::SET}})
 }

--- a/src/Core/SettingsEnums.h
+++ b/src/Core/SettingsEnums.h
@@ -385,6 +385,15 @@ enum class GroupArrayActionWhenLimitReached : uint8_t
 };
 DECLARE_SETTING_ENUM(GroupArrayActionWhenLimitReached)
 
+/// How arrays are compared in GROUP BY
+enum class ArrayGroupByMode : uint8_t
+{
+    ORDERED,   /// Default: [1,2,3] != [3,2,1]
+    MULTISET,  /// Unordered with duplicates: [1,2,3] == [3,2,1], [1,1,2] != [1,2,2]
+    SET,       /// Unordered without duplicates: [1,2,3] == [3,2,1] == [1,1,2,3]
+};
+DECLARE_SETTING_ENUM(ArrayGroupByMode)
+
 DECLARE_SETTING_ENUM(MergeSelectorAlgorithm)
 
 enum class DatabaseDataLakeCatalogType : uint8_t

--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -12,6 +12,7 @@
 #include <AggregateFunctions/Combinators/AggregateFunctionArray.h>
 #include <AggregateFunctions/Combinators/AggregateFunctionState.h>
 #include <Columns/ColumnAggregateFunction.h>
+#include <Columns/ColumnArray.h>
 #include <Columns/ColumnSparse.h>
 #include <Columns/ColumnTuple.h>
 #include <Compression/CompressedWriteBuffer.h>
@@ -185,6 +186,85 @@ UInt64 & getInlineCountState(DB::AggregateDataPtr & ptr)
 namespace DB
 {
 
+namespace
+{
+
+/// Normalize an array column for GROUP BY based on the comparison mode.
+/// For ORDERED mode, returns the column unchanged.
+/// For MULTISET mode, sorts each array's elements.
+/// For SET mode, sorts and removes duplicates from each array.
+ColumnPtr normalizeArrayColumnForGroupBy(const ColumnPtr & column, ArrayGroupByMode mode)
+{
+    if (mode == ArrayGroupByMode::ORDERED)
+        return column;
+
+    const auto * col_array = typeid_cast<const ColumnArray *>(column.get());
+    if (!col_array)
+        return column;
+
+    const auto & offsets = col_array->getOffsets();
+    const auto & data = col_array->getData();
+    const size_t num_rows = offsets.size();
+
+    auto result_data = data.cloneEmpty();
+    auto result_offsets = ColumnArray::ColumnOffsets::create(num_rows);
+    auto & result_offsets_data = result_offsets->getData();
+
+    IColumn::Offset current_offset = 0;
+
+    for (size_t row = 0; row < num_rows; ++row)
+    {
+        const size_t array_offset = row > 0 ? offsets[row - 1] : 0;
+        const size_t array_size = offsets[row] - array_offset;
+
+        if (array_size == 0)
+        {
+            result_offsets_data[row] = current_offset;
+            continue;
+        }
+
+        /// Create a permutation for sorting
+        IColumn::Permutation perm(array_size);
+        for (size_t i = 0; i < array_size; ++i)
+            perm[i] = i;
+
+        /// Sort the permutation based on element values
+        ::sort(perm.begin(), perm.end(), [&](size_t a, size_t b)
+        {
+            return data.compareAt(array_offset + a, array_offset + b, data, 1) < 0;
+        });
+
+        if (mode == ArrayGroupByMode::SET)
+        {
+            /// Insert unique elements only
+            for (size_t i = 0; i < array_size; ++i)
+            {
+                size_t elem_idx = array_offset + perm[i];
+                /// Skip duplicates
+                if (i > 0 && data.compareAt(array_offset + perm[i - 1], elem_idx, data, 1) == 0)
+                    continue;
+                result_data->insertFrom(data, elem_idx);
+                ++current_offset;
+            }
+        }
+        else /// MULTISET
+        {
+            /// Insert all elements in sorted order
+            for (size_t i = 0; i < array_size; ++i)
+            {
+                result_data->insertFrom(data, array_offset + perm[i]);
+                ++current_offset;
+            }
+        }
+
+        result_offsets_data[row] = current_offset;
+    }
+
+    return ColumnArray::create(std::move(result_data), std::move(result_offsets));
+}
+
+}
+
 Block Aggregator::getHeader(bool final) const
 {
     return params.getHeader(header, final);
@@ -211,7 +291,8 @@ Aggregator::Params::Params(
     bool optimize_group_by_constant_keys_,
     float min_hit_rate_to_use_consecutive_keys_optimization_,
     const StatsCollectingParams & stats_collecting_params_,
-    bool enable_producing_buckets_out_of_order_in_aggregation_)
+    bool enable_producing_buckets_out_of_order_in_aggregation_,
+    ArrayGroupByMode array_group_by_mode_)
     : keys(keys_)
     , keys_size(keys.size())
     , aggregates(aggregates_)
@@ -235,6 +316,7 @@ Aggregator::Params::Params(
     , min_hit_rate_to_use_consecutive_keys_optimization(min_hit_rate_to_use_consecutive_keys_optimization_)
     , stats_collecting_params(stats_collecting_params_)
     , enable_producing_buckets_out_of_order_in_aggregation(enable_producing_buckets_out_of_order_in_aggregation_)
+    , array_group_by_mode(array_group_by_mode_)
 {
 }
 
@@ -1688,6 +1770,17 @@ bool Aggregator::executeOnBlock(Columns columns,
             if (column_no_lc.get() != key_columns[i])
             {
                 materialized_columns.emplace_back(std::move(column_no_lc));
+                key_columns[i] = materialized_columns.back().get();
+            }
+        }
+
+        /// Normalize array columns based on array_group_by_mode setting
+        if (params.array_group_by_mode != ArrayGroupByMode::ORDERED)
+        {
+            auto normalized = normalizeArrayColumnForGroupBy(key_columns[i]->getPtr(), params.array_group_by_mode);
+            if (normalized.get() != key_columns[i])
+            {
+                materialized_columns.emplace_back(std::move(normalized));
                 key_columns[i] = materialized_columns.back().get();
             }
         }

--- a/src/Interpreters/Aggregator.h
+++ b/src/Interpreters/Aggregator.h
@@ -10,6 +10,7 @@
 #include <Core/Block.h>
 #include <Core/Block_fwd.h>
 #include <Core/ColumnNumbers.h>
+#include <Core/SettingsEnums.h>
 #include <Common/ThreadPool.h>
 #include <Common/filesystemHelpers.h>
 
@@ -119,6 +120,9 @@ public:
 
         bool enable_producing_buckets_out_of_order_in_aggregation = true;
 
+        /// How to compare arrays in GROUP BY keys
+        ArrayGroupByMode array_group_by_mode = ArrayGroupByMode::ORDERED;
+
         static size_t getMaxBytesBeforeExternalGroupBy(size_t max_bytes_before_external_group_by, double max_bytes_ratio_before_external_group_by);
 
         Params(
@@ -142,7 +146,8 @@ public:
             bool optimize_group_by_constant_keys_,
             float min_hit_rate_to_use_consecutive_keys_optimization_,
             const StatsCollectingParams & stats_collecting_params_,
-            bool enable_producing_buckets_out_of_order_in_aggregation_);
+            bool enable_producing_buckets_out_of_order_in_aggregation_,
+            ArrayGroupByMode array_group_by_mode_ = ArrayGroupByMode::ORDERED);
 
         /// Only parameters that matter during merge.
         Params(

--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -121,6 +121,7 @@ namespace Setting
     extern const SettingsUInt64 aggregation_in_order_max_block_bytes;
     extern const SettingsUInt64 aggregation_memory_efficient_merge_threads;
     extern const SettingsUInt64 allow_experimental_parallel_reading_from_replicas;
+    extern const SettingsArrayGroupByMode array_group_by_mode;
     extern const SettingsBool allow_experimental_query_deduplication;
     extern const SettingsBool async_socket_for_remote;
     extern const SettingsBool collect_hash_table_stats_during_aggregation;
@@ -2819,7 +2820,8 @@ static Aggregator::Params getAggregatorParams(
         settings[Setting::optimize_group_by_constant_keys],
         settings[Setting::min_hit_rate_to_use_consecutive_keys_optimization],
         stats_collecting_params,
-        settings[Setting::enable_producing_buckets_out_of_order_in_aggregation]};
+        settings[Setting::enable_producing_buckets_out_of_order_in_aggregation],
+        settings[Setting::array_group_by_mode]};
 }
 
 void InterpreterSelectQuery::executeAggregation(

--- a/src/Planner/Planner.cpp
+++ b/src/Planner/Planner.cpp
@@ -104,6 +104,7 @@ namespace Setting
     extern const SettingsUInt64 aggregation_in_order_max_block_bytes;
     extern const SettingsUInt64 aggregation_memory_efficient_merge_threads;
     extern const SettingsUInt64 allow_experimental_parallel_reading_from_replicas;
+    extern const SettingsArrayGroupByMode array_group_by_mode;
     extern const SettingsBool collect_hash_table_stats_during_aggregation;
     extern const SettingsOverflowMode distinct_overflow_mode;
     extern const SettingsBool distributed_aggregation_memory_efficient;
@@ -522,7 +523,8 @@ Aggregator::Params getAggregatorParams(const PlannerContextPtr & planner_context
         settings[Setting::optimize_group_by_constant_keys],
         settings[Setting::min_hit_rate_to_use_consecutive_keys_optimization],
         stats_collecting_params,
-        settings[Setting::enable_producing_buckets_out_of_order_in_aggregation]);
+        settings[Setting::enable_producing_buckets_out_of_order_in_aggregation],
+        settings[Setting::array_group_by_mode]);
 
     return aggregator_params;
 }

--- a/tests/queries/0_stateless/03632_array_group_by_mode.reference
+++ b/tests/queries/0_stateless/03632_array_group_by_mode.reference
@@ -1,0 +1,18 @@
+ordered mode (default):
+[1,2,3]	2
+[3,2,1]	1
+multiset mode:
+[1,2,3]	3
+multiset mode with duplicates:
+[1,1,2]	2
+[1,2,2]	1
+set mode:
+[1,2,3]	3
+set mode with duplicates:
+[1,2]	4
+empty arrays:
+[]	2
+multiset with GROUP BY ALL:
+[1,2,3]	2
+string arrays in multiset mode:
+['a','b','c']	3

--- a/tests/queries/0_stateless/03632_array_group_by_mode.sql
+++ b/tests/queries/0_stateless/03632_array_group_by_mode.sql
@@ -1,0 +1,70 @@
+-- Tests for array_group_by_mode setting
+
+-- Test default (ordered) mode - [1,2,3] and [3,2,1] are different groups
+SELECT 'ordered mode (default):';
+SELECT arr, count() AS c FROM (
+    SELECT [1, 2, 3] AS arr
+    UNION ALL SELECT [3, 2, 1] AS arr
+    UNION ALL SELECT [1, 2, 3] AS arr
+) GROUP BY arr ORDER BY arr;
+
+-- Test multiset mode - [1,2,3] and [3,2,1] are the same group, but [1,1,2] and [1,2,2] are different
+SELECT 'multiset mode:';
+SET array_group_by_mode = 'multiset';
+SELECT arr, count() AS c FROM (
+    SELECT [1, 2, 3] AS arr
+    UNION ALL SELECT [3, 2, 1] AS arr
+    UNION ALL SELECT [1, 2, 3] AS arr
+) GROUP BY arr ORDER BY arr;
+
+SELECT 'multiset mode with duplicates:';
+SELECT arr, count() AS c FROM (
+    SELECT [1, 1, 2] AS arr
+    UNION ALL SELECT [1, 2, 1] AS arr
+    UNION ALL SELECT [1, 2, 2] AS arr
+) GROUP BY arr ORDER BY arr;
+
+-- Test set mode - [1,2,3], [3,2,1], and [1,1,2,3] are all the same group
+SELECT 'set mode:';
+SET array_group_by_mode = 'set';
+SELECT arr, count() AS c FROM (
+    SELECT [1, 2, 3] AS arr
+    UNION ALL SELECT [3, 2, 1] AS arr
+    UNION ALL SELECT [1, 2, 3] AS arr
+) GROUP BY arr ORDER BY arr;
+
+SELECT 'set mode with duplicates:';
+SELECT arr, count() AS c FROM (
+    SELECT [1, 1, 2] AS arr
+    UNION ALL SELECT [1, 2, 1] AS arr
+    UNION ALL SELECT [1, 2, 2] AS arr
+    UNION ALL SELECT [1, 2] AS arr
+) GROUP BY arr ORDER BY arr;
+
+-- Test empty arrays
+SELECT 'empty arrays:';
+SET array_group_by_mode = 'multiset';
+SELECT arr, count() AS c FROM (
+    SELECT [] AS arr
+    UNION ALL SELECT [] AS arr
+) GROUP BY arr;
+
+-- Test with GROUP BY ALL
+SELECT 'multiset with GROUP BY ALL:';
+SET array_group_by_mode = 'multiset';
+SELECT arr, count() AS c FROM (
+    SELECT [1, 2, 3] AS arr
+    UNION ALL SELECT [3, 2, 1] AS arr
+) GROUP BY ALL ORDER BY arr;
+
+-- Test with string arrays
+SELECT 'string arrays in multiset mode:';
+SET array_group_by_mode = 'multiset';
+SELECT arr, count() AS c FROM (
+    SELECT ['a', 'b', 'c'] AS arr
+    UNION ALL SELECT ['c', 'b', 'a'] AS arr
+    UNION ALL SELECT ['a', 'b', 'c'] AS arr
+) GROUP BY arr ORDER BY arr;
+
+-- Reset to default
+SET array_group_by_mode = 'ordered';


### PR DESCRIPTION
Implements a new setting `array_group_by_mode` with three modes:
- ordered (default): Arrays compared element-by-element in order
- multiset: Arrays compared as multisets (unordered, duplicates count)
- set: Arrays compared as sets (unordered, duplicates ignored)

This allows GROUP BY to treat [1,2,3] and [3,2,1] as the same group when using multiset or set mode.

### Changelog category (leave one):
- New Feature

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):

Add `array_group_by_mode` setting to control how arrays are compared in GROUP BY. Supports three modes: `ordered` (default, element-by-element comparison), `multiset` (order-independent, preserves duplicate counts), and `set` (order-independent, ignores duplicates).

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

**Motivation:** When grouping by array columns, users often want to treat arrays with the same elements but different order as equivalent. For example, grouping user tags `['sports', 'music']` and `['music', 'sports']` together. Previously this required workarounds like `arraySort()` in the GROUP BY clause.

**Setting:** `array_group_by_mode`

**Values:**
| Mode | Description |
|------|-------------|
| `ordered` (default) | Arrays compared element-by-element in order. `[1,2,3]` ≠ `[3,2,1]` |
| `multiset` | Arrays compared as multisets (order ignored, duplicates count). `[1,2,3]` = `[3,2,1]`, but `[1,1,2]` ≠ `[1,2,2]` |
| `set` | Arrays compared as sets (order ignored, duplicates ignored). `[1,2,3]` = `[3,2,1]` = `[1,1,2,3]` |

**Example use:**

```sql
-- Default: [1,2,3] and [3,2,1] are different groups
SELECT arr, count() FROM (
    SELECT [1, 2, 3] AS arr UNION ALL SELECT [3, 2, 1]
) GROUP BY arr;
-- Returns 2 rows

-- Multiset mode: same elements = same group
SET array_group_by_mode = 'multiset';
SELECT arr, count() FROM (
    SELECT [1, 2, 3] AS arr UNION ALL SELECT [3, 2, 1]
) GROUP BY arr;
-- Returns 1 row with count=2

-- Set mode: [1,1,2] and [1,2] are the same group
SET array_group_by_mode = 'set';
SELECT arr, count() FROM (
    SELECT [1, 1, 2] AS arr UNION ALL SELECT [1, 2]
) GROUP BY arr;
-- Returns 1 row with count=2
```
