### PR TITLE
Handle null values  for the Ytsaurus xml dictionaries.

### DIFF
--- a/src/Core/YTsaurus/YTsaurusClient.cpp
+++ b/src/Core/YTsaurus/YTsaurusClient.cpp
@@ -244,7 +244,7 @@ YTsaurusClient::SchemaDescription YTsaurusClient::getTableSchema(const String & 
     return {true, std::move(yt_columns)};
 }
 
-bool YTsaurusClient::checkSchemaCompatibility(const String & table_path, const SharedHeader & sample_block, String & reason)
+bool YTsaurusClient::checkSchemaCompatibility(const String & table_path, const SharedHeader & sample_block, String & reason, bool allow_nullable)
 {
     auto yt_schema = getTableSchema(table_path);
 
@@ -260,12 +260,7 @@ bool YTsaurusClient::checkSchemaCompatibility(const String & table_path, const S
             return false;
         }
         auto yt_column_type = iter->second;
-
-        if (
-            yt_column_type->getColumnType() != TypeIndex::Dynamic &&
-            column_type_with_name.type->getColumnType() != TypeIndex::Dynamic &&
-            column_type_with_name.type->getColumnType() != yt_column_type->getColumnType()
-        )
+        if (!isYTSaurusTypesCompatible(column_type_with_name.type, yt_column_type, allow_nullable))
         {
             reason = fmt::format("Column {} types mismatch. YtSaurus converted type {} table column type {}", column_type_with_name.name, yt_column_type->getName(), column_type_with_name.type->getName());
             return false;

--- a/src/Core/YTsaurus/YTsaurusClient.h
+++ b/src/Core/YTsaurus/YTsaurusClient.h
@@ -72,7 +72,7 @@ public:
 
     SchemaDescription getTableSchema(const String & cypress_path);
 
-    bool checkSchemaCompatibility(const String & table_path, const SharedHeader & sample_block, String & reason);
+    bool checkSchemaCompatibility(const String & table_path, const SharedHeader & sample_block, String & reason, bool allow_nullable);
 private:
     Poco::JSON::Object::Ptr getTableInfo(const String & cypress_path);
 

--- a/src/DataTypes/convertYTsaurusDataType.cpp
+++ b/src/DataTypes/convertYTsaurusDataType.cpp
@@ -395,4 +395,18 @@ DataTypePtr convertYTSchema(const Poco::JSON::Object::Ptr & json)
         throw Exception(ErrorCodes::INCORRECT_DATA, "Couldn't parse type_v3 from YT metadata: {}", e.what());
     }
 }
+
+bool isYTSaurusTypesCompatible(std::shared_ptr<const IDataType> ch_type, std::shared_ptr<const IDataType> yt_type, bool allow_nullable)
+{
+
+    return yt_type->getColumnType() == TypeIndex::Dynamic ||
+        ch_type->getColumnType() == TypeIndex::Dynamic ||
+        ch_type->getColumnType() == yt_type->getColumnType() ||
+        (
+            allow_nullable &&
+            yt_type->getColumnType() == TypeIndex::Nullable &&
+            ch_type->getColumnType() == dynamic_cast<const DataTypeNullable *>(yt_type.get())->getNestedType()->getColumnType()
+        );
+}
+
 }

--- a/src/DataTypes/convertYTsaurusDataType.cpp
+++ b/src/DataTypes/convertYTsaurusDataType.cpp
@@ -404,7 +404,7 @@ bool isYTSaurusTypesCompatible(std::shared_ptr<const IDataType> ch_type, std::sh
         (
             allow_nullable &&
             yt_type->getColumnType() == TypeIndex::Nullable &&
-            ch_type->equals(*dynamic_cast<const DataTypeNullable *>(yt_type.get())->getNestedType())
+            ch_type->equals(*assert_cast<const DataTypeNullable *>(yt_type.get())->getNestedType())
         );
 }
 

--- a/src/DataTypes/convertYTsaurusDataType.cpp
+++ b/src/DataTypes/convertYTsaurusDataType.cpp
@@ -398,14 +398,13 @@ DataTypePtr convertYTSchema(const Poco::JSON::Object::Ptr & json)
 
 bool isYTSaurusTypesCompatible(std::shared_ptr<const IDataType> ch_type, std::shared_ptr<const IDataType> yt_type, bool allow_nullable)
 {
-
     return yt_type->getColumnType() == TypeIndex::Dynamic ||
         ch_type->getColumnType() == TypeIndex::Dynamic ||
-        ch_type->getColumnType() == yt_type->getColumnType() ||
+        ch_type->equals(*yt_type) ||
         (
             allow_nullable &&
             yt_type->getColumnType() == TypeIndex::Nullable &&
-            ch_type->getColumnType() == dynamic_cast<const DataTypeNullable *>(yt_type.get())->getNestedType()->getColumnType()
+            ch_type->equals(*dynamic_cast<const DataTypeNullable *>(yt_type.get())->getNestedType())
         );
 }
 

--- a/src/DataTypes/convertYTsaurusDataType.h
+++ b/src/DataTypes/convertYTsaurusDataType.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <base/types.h>
 #include <Core/MultiEnum.h>
 #include <DataTypes/IDataType.h>
@@ -20,4 +21,7 @@ DataTypePtr convertYTTuple(const Poco::JSON::Object::Ptr & json);
 DataTypePtr convertYTVariant(const Poco::JSON::Object::Ptr & json);
 DataTypePtr convertYTDict(const Poco::JSON::Object::Ptr & json);
 DataTypePtr convertYTTagged(const Poco::JSON::Object::Ptr & json);
+
+bool isYTSaurusTypesCompatible(std::shared_ptr<const IDataType> ch_type, std::shared_ptr<const IDataType> yt_type, bool allow_nullable);
+
 }

--- a/src/Dictionaries/YTsaurusDictionarySource.cpp
+++ b/src/Dictionaries/YTsaurusDictionarySource.cpp
@@ -136,7 +136,7 @@ YTsarususDictionarySource::~YTsarususDictionarySource() = default;
 BlockIO YTsarususDictionarySource::loadAll()
 {
     BlockIO io;
-    io.pipeline = QueryPipeline(YTsaurusSourceFactory::createSource(client, {.cypress_path = configuration->cypress_path, .settings = configuration->settings}, sample_block, max_block_size));
+    io.pipeline = QueryPipeline(YTsaurusSourceFactory::createSource(client, {.cypress_path = configuration->cypress_path, .settings = configuration->settings, .check_types_allow_nullable = true}, sample_block, max_block_size));
     return io;
 }
 
@@ -151,7 +151,7 @@ BlockIO YTsarususDictionarySource::loadIds(const std::vector<UInt64> & ids)
     auto block = blockForIds(dict_struct, ids);
 
     BlockIO io;
-    io.pipeline = QueryPipeline(YTsaurusSourceFactory::createSource(client, {.cypress_path = configuration->cypress_path, .settings = configuration->settings, .lookup_input_block = std::move(block)}, sample_block, max_block_size));
+    io.pipeline = QueryPipeline(YTsaurusSourceFactory::createSource(client, {.cypress_path = configuration->cypress_path, .settings = configuration->settings, .lookup_input_block = std::move(block), .check_types_allow_nullable = true}, sample_block, max_block_size));
     return io;
 }
 
@@ -169,7 +169,7 @@ BlockIO YTsarususDictionarySource::loadKeys(const Columns & key_columns, const s
     auto block = blockForKeys(dict_struct, key_columns, requested_rows);
 
     BlockIO io;
-    io.pipeline = QueryPipeline(YTsaurusSourceFactory::createSource(client, {.cypress_path = configuration->cypress_path, .settings = configuration->settings, .lookup_input_block = std::move(block)}, sample_block, max_block_size));
+    io.pipeline = QueryPipeline(YTsaurusSourceFactory::createSource(client, {.cypress_path = configuration->cypress_path, .settings = configuration->settings, .lookup_input_block = std::move(block), .check_types_allow_nullable = true}, sample_block, max_block_size));
     return io;
 }
 

--- a/src/Processors/Sources/YTsaurusSource.cpp
+++ b/src/Processors/Sources/YTsaurusSource.cpp
@@ -58,7 +58,7 @@ std::shared_ptr<ISource> YTsaurusSourceFactory::createSource(YTsaurusClientPtr c
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Cypress path are empty for ytsarurus source factory.");
     }
     String reason;
-    if (source_options.settings[YTsaurusSetting::check_table_schema] && !client->checkSchemaCompatibility(source_options.cypress_path, sample_block, reason))
+    if (source_options.settings[YTsaurusSetting::check_table_schema] && !client->checkSchemaCompatibility(source_options.cypress_path, sample_block, reason, source_options.check_types_allow_nullable))
     {
         throw Exception(ErrorCodes::INCORRECT_DATA, "ClickHouse table schema doesn't match with yt table. Reason: {}", reason);
     }

--- a/src/Processors/Sources/YTsaurusSource.h
+++ b/src/Processors/Sources/YTsaurusSource.h
@@ -19,6 +19,7 @@ struct YTsaurusTableSourceOptions
     const String cypress_path;
     YTsaurusSettings settings;
     std::optional<Block> lookup_input_block = std::nullopt;
+    bool check_types_allow_nullable = false;
 };
 
 class YTsaurusTableSourceStaticTable final : public ISource

--- a/tests/integration/test_ytsaurus/configs/display_secrets.xml
+++ b/tests/integration/test_ytsaurus/configs/display_secrets.xml
@@ -1,3 +1,4 @@
 <clickhouse>
     <display_secrets_in_show_and_select>1</display_secrets_in_show_and_select>
+    <dictionaries_config>/etc/clickhouse-server/dictionaries/*.xml</dictionaries_config>
 </clickhouse>

--- a/tests/integration/test_ytsaurus/yt_helpers.py
+++ b/tests/integration/test_ytsaurus/yt_helpers.py
@@ -37,7 +37,12 @@ class YTsaurusCLI:
         return table_table + "_r1"
 
     def _generate_table_attributes_str(
-        self, dynamic, schema=None, sorted_columns=None, upstream_replica=None
+        self,
+        dynamic,
+        schema=None,
+        sorted_columns=None,
+        upstream_replica=None,
+        strict_schema=True,
     ):
         if not schema:
             return ""
@@ -47,7 +52,7 @@ class YTsaurusCLI:
             + (f'upstream_replica_id="{upstream_replica}";' if upstream_replica else "")
             + "schema= ["
             + ";".join(
-                f"{{required = true; name = {name}; type = {type}; {'sort_order=ascending' if name in sorted_columns else ''}}}"
+                f"{{required = {'true' if strict_schema else 'false'}; name = {name}; type = {type}; {'sort_order=ascending' if name in sorted_columns else ''}}}"
                 for name, type in schema.items()
             )
             + "]}'"
@@ -62,12 +67,15 @@ class YTsaurusCLI:
         sorted_columns=set(),
         retry_count=100,
         time_to_sleep=0.5,
+        strict_schema=True,
     ):
         replica_path = self._generate_replica_name(table_path)
 
         create_replicated_table_cmd = (
             f"yt create replicated_table {table_path} "
-            + self._generate_table_attributes_str(True, schema, sorted_columns)
+            + self._generate_table_attributes_str(
+                True, schema, sorted_columns, strict_schema=strict_schema
+            )
         )
         self.exec(create_replicated_table_cmd, retry_count, time_to_sleep)
 
@@ -108,9 +116,14 @@ class YTsaurusCLI:
         retry_count=100,
         time_to_sleep=0.5,
         upstream_replica=None,
+        strict_schema=True,
     ):
         schema_arribute = self._generate_table_attributes_str(
-            dynamic, schema, sorted_columns, upstream_replica
+            dynamic,
+            schema,
+            sorted_columns,
+            upstream_replica,
+            strict_schema=strict_schema,
         )
 
         create_table_cmd = "yt create table {} {}".format(table_path, schema_arribute)


### PR DESCRIPTION
Generally it is fine to have `optional(<type>)` column in YTSaurus and `<type>` column in clickhouse for xml-based dictionaries because `<null_value>` is [required for attributes](https://clickhouse.com/docs/sql-reference/dictionaries#attributes). 
Without the fix, comparison of schemes `ch`/`ytsaurus`  will not work in such case.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Handle null values for Ytsaurus xml dictionaries.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
