### PR TITLE
Fix test_storage_s3_queue/test_2.py::test_shards

### DIFF
--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueOrderedFileMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueOrderedFileMetadata.cpp
@@ -295,6 +295,7 @@ std::pair<bool, ObjectStorageQueueIFileMetadata::FileStatus::State> ObjectStorag
         std::optional<NodeMetadata> processed_node;
         Coordination::Stat processed_node_stat;
         std::optional<std::pair<bool, ObjectStorageQueueIFileMetadata::FileStatus::State>> result;
+        zk_retry.resetFailures();
         zk_retry.retryLoop([&]
         {
             bool is_multi_read_enabled = zk_client->isFeatureEnabled(DB::KeeperFeatureFlag::MULTI_READ);

--- a/tests/integration/test_storage_s3_queue/configs/enable_keeper_fault_injection.xml
+++ b/tests/integration/test_storage_s3_queue/configs/enable_keeper_fault_injection.xml
@@ -1,9 +1,6 @@
 <clickhouse>
     <profiles>
         <default>
-            <keeper_max_retries>16</keeper_max_retries>
-            <keeper_retry_initial_backoff_ms>10</keeper_retry_initial_backoff_ms>
-            <keeper_retry_max_backoff_ms>10</keeper_retry_max_backoff_ms>
             <s3queue_keeper_fault_injection_probability>0.05</s3queue_keeper_fault_injection_probability>
         </default>
     </profiles>

--- a/tests/integration/test_storage_s3_queue/configs/keeper_retries.xml
+++ b/tests/integration/test_storage_s3_queue/configs/keeper_retries.xml
@@ -1,0 +1,9 @@
+<clickhouse>
+    <profiles>
+        <default>
+            <keeper_max_retries>16</keeper_max_retries>
+            <keeper_retry_initial_backoff_ms>10</keeper_retry_initial_backoff_ms>
+            <keeper_retry_max_backoff_ms>10</keeper_retry_max_backoff_ms>
+        </default>
+    </profiles>
+</clickhouse>

--- a/tests/integration/test_storage_s3_queue/configs/users.xml
+++ b/tests/integration/test_storage_s3_queue/configs/users.xml
@@ -5,7 +5,6 @@
             <s3queue_enable_logging_to_s3queue_log>1</s3queue_enable_logging_to_s3queue_log>
             <s3queue_allow_experimental_sharded_mode>1</s3queue_allow_experimental_sharded_mode>
             <function_sleep_max_microseconds_per_block>100000000</function_sleep_max_microseconds_per_block>
-            <keeper_max_retries>6</keeper_max_retries>
         </default>
     </profiles>
 </clickhouse>

--- a/tests/integration/test_storage_s3_queue/test_0.py
+++ b/tests/integration/test_storage_s3_queue/test_0.py
@@ -63,6 +63,7 @@ def started_cluster():
             user_configs=[
                 "configs/users.xml",
                 "configs/enable_keeper_fault_injection.xml",
+                "configs/keeper_retries.xml",
             ],
             with_minio=True,
             with_azurite=True,

--- a/tests/integration/test_storage_s3_queue/test_1.py
+++ b/tests/integration/test_storage_s3_queue/test_1.py
@@ -64,6 +64,7 @@ def started_cluster():
             user_configs=[
                 "configs/users.xml",
                 "configs/enable_keeper_fault_injection.xml",
+                "configs/keeper_retries.xml",
             ],
             with_minio=True,
             with_azurite=True,
@@ -80,6 +81,7 @@ def started_cluster():
             user_configs=[
                 "configs/users.xml",
                 "configs/enable_keeper_fault_injection.xml",
+                "configs/keeper_retries.xml",
             ],
             with_minio=True,
             with_zookeeper=True,

--- a/tests/integration/test_storage_s3_queue/test_2.py
+++ b/tests/integration/test_storage_s3_queue/test_2.py
@@ -61,6 +61,7 @@ def started_cluster():
             user_configs=[
                 "configs/users.xml",
                 "configs/enable_keeper_fault_injection.xml",
+                "configs/keeper_retries.xml",
             ],
             with_minio=True,
             with_azurite=True,
@@ -77,6 +78,7 @@ def started_cluster():
             user_configs=[
                 "configs/users.xml",
                 "configs/enable_keeper_fault_injection.xml",
+                "configs/keeper_retries.xml",
             ],
             with_minio=True,
             with_zookeeper=True,

--- a/tests/integration/test_storage_s3_queue/test_3.py
+++ b/tests/integration/test_storage_s3_queue/test_3.py
@@ -62,6 +62,7 @@ def started_cluster():
             user_configs=[
                 "configs/users.xml",
                 "configs/enable_keeper_fault_injection.xml",
+                "configs/keeper_retries.xml",
             ],
             with_minio=True,
             with_azurite=True,
@@ -78,6 +79,7 @@ def started_cluster():
             user_configs=[
                 "configs/users.xml",
                 "configs/enable_keeper_fault_injection.xml",
+                "configs/keeper_retries.xml",
             ],
             with_minio=True,
             with_zookeeper=True,

--- a/tests/integration/test_storage_s3_queue/test_4.py
+++ b/tests/integration/test_storage_s3_queue/test_4.py
@@ -56,6 +56,7 @@ def started_cluster():
             user_configs=[
                 "configs/users.xml",
                 "configs/enable_keeper_fault_injection.xml",
+                "configs/keeper_retries.xml",
             ],
             with_minio=True,
             with_azurite=True,
@@ -72,6 +73,7 @@ def started_cluster():
             user_configs=[
                 "configs/users.xml",
                 "configs/enable_keeper_fault_injection.xml",
+                "configs/keeper_retries.xml",
             ],
             with_minio=True,
             with_zookeeper=True,

--- a/tests/integration/test_storage_s3_queue/test_5.py
+++ b/tests/integration/test_storage_s3_queue/test_5.py
@@ -1319,10 +1319,10 @@ def test_persistent_processing_failed_commit_retries(started_cluster, mode):
     node.query(f"SYSTEM DISABLE FAILPOINT object_storage_queue_fail_commit_once")
 
     assert node.contains_in_log(
-        f"StorageS3Queue (default.{table_name}): Failed to commit processed files at try 1/6"
+        f"StorageS3Queue (default.{table_name}): Failed to commit processed files at try 1"
     )
     assert not node.contains_in_log(
-        f"StorageS3Queue (default.{table_name}): Failed to commit processed files at try 5/6"
+        f"StorageS3Queue (default.{table_name}): Failed to commit processed files at try 5"
     )
 
     nodes = zk.get_children(f"{keeper_path}/processing")
@@ -1344,7 +1344,7 @@ def test_persistent_processing_failed_commit_retries(started_cluster, mode):
     assert found
 
     assert node.contains_in_log(
-        f"StorageS3Queue (default.{table_name}): Failed to commit processed files at try 6/6"
+        f"StorageS3Queue (default.{table_name}): Failed to commit processed files at try 10"
     )
 
     found = False

--- a/tests/integration/test_storage_s3_queue/test_5.py
+++ b/tests/integration/test_storage_s3_queue/test_5.py
@@ -72,6 +72,7 @@ def started_cluster():
             user_configs=[
                 "configs/users.xml",
                 "configs/enable_keeper_fault_injection.xml",
+                "configs/keeper_retries.xml",
             ],
             stay_alive=True,
         )
@@ -80,6 +81,7 @@ def started_cluster():
             user_configs=[
                 "configs/users.xml",
                 "configs/enable_keeper_fault_injection.xml",
+                "configs/keeper_retries.xml",
             ],
             with_minio=True,
             with_zookeeper=True,
@@ -135,6 +137,7 @@ def started_cluster():
             ],
             user_configs=[
                 "configs/users.xml",
+                "configs/keeper_retries.xml",
             ],
             stay_alive=True,
         )
@@ -153,6 +156,7 @@ def started_cluster():
             user_configs=[
                 "configs/users.xml",
                 "configs/enable_keeper_fault_injection.xml",
+                "configs/keeper_retries.xml",
             ],
             stay_alive=True,
         )


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
