### PR TITLE
Add documentation about ytsaurus dictionary source

### DIFF
--- a/docs/en/sql-reference/dictionaries/index.md
+++ b/docs/en/sql-reference/dictionaries/index.md
@@ -1900,9 +1900,9 @@ The `table` or `where` fields cannot be used together with the `query` field. An
 
 :::info
 This is an experimental feature that may change in backwards-incompatible ways in future releases.
-Enable usage of the YTsaurus dicitonary source
+Enable usage of the YTsaurus dictionary source
 using setting [`allow_experimental_ytsaurus_dictionary_source`](/operations/settings/settings#allow_experimental_ytsaurus_dictionary_source).
-
+:::
 
 Example of settings:
 

--- a/docs/en/sql-reference/dictionaries/index.md
+++ b/docs/en/sql-reference/dictionaries/index.md
@@ -10,6 +10,7 @@ doc_type: 'reference'
 import SelfManaged from '@site/docs/_snippets/_self_managed_only_no_roadmap.md';
 import CloudDetails from '@site/docs/sql-reference/dictionaries/_snippet_dictionary_in_cloud.md';
 import CloudNotSupportedBadge from '@theme/badges/CloudNotSupportedBadge';
+import ExperimentalBadge from '@theme/badges/ExperimentalBadge';
 
 # Dictionaries
 
@@ -1108,6 +1109,7 @@ Types of sources (`source_type`):
   - [Redis](#redis)
   - [Cassandra](#cassandra)
   - [PostgreSQL](#postgresql)
+  - [YTsaurus](#ytsaurus)
 
 ### Local File {#local-file}
 
@@ -1890,6 +1892,47 @@ Setting fields:
 :::note
 The `table` or `where` fields cannot be used together with the `query` field. And either one of the `table` or `query` fields must be declared.
 :::
+
+### YTsaurus {#ytsaurus}
+
+<ExperimentalBadge/>
+<CloudNotSupportedBadge/>
+
+:::info
+This is an experimental feature that may change in backwards-incompatible ways in future releases.
+Enable usage of the YTsaurus dicitonary source
+using setting [`allow_experimental_ytsaurus_dictionary_source`](/operations/settings/settings#allow_experimental_ytsaurus_dictionary_source).
+
+
+Example of settings:
+
+```xml
+<source>
+    <ytsaurus>
+        <http_proxy_urls>http://localhost:8000</http_proxy_urls>
+        <cypress_path>//tmp/test</cypress_path>
+        <oauth_token>password</oauth_token>
+        <check_table_schema>1</check_table_schema>
+    </ytsaurus>
+</source>
+```
+
+or
+
+```sql
+SOURCE(YTSAURUS(
+    http_proxy_urls 'http://localhost:8000'
+    cypress_path '//tmp/test'
+    oauth_token 'password'
+))
+```
+
+Setting fields:
+
+- `http_proxy_urls` –  URL to the YTsaurus http proxy.
+- `cypress_path` – Cypress path to the table source.
+- `oauth_token` –  OAuth token.
+
 
 ### Null {#null}
 

--- a/docs/en/sql-reference/dictionaries/index.md
+++ b/docs/en/sql-reference/dictionaries/index.md
@@ -1933,7 +1933,6 @@ Setting fields:
 - `cypress_path` – Cypress path to the table source.
 - `oauth_token` –  OAuth token.
 
-
 ### Null {#null}
 
 A special source that can be used to create dummy (empty) dictionaries. Such dictionaries can useful for tests or with setups with separated data and query nodes at nodes with Distributed tables.


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
