### PR TITLE
Replace LOGICAL_ERROR in evaluateConstantExpression with NUMBER_OF_ARGUMENTS_DOESNT_MATCH

### DIFF
--- a/src/Interpreters/evaluateConstantExpression.cpp
+++ b/src/Interpreters/evaluateConstantExpression.cpp
@@ -61,6 +61,7 @@ namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
     extern const int BAD_ARGUMENTS;
+    extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
 }
 
 static EvaluateConstantExpressionResult getFieldAndDataTypeFromLiteral(ASTLiteral * literal)
@@ -130,7 +131,8 @@ std::optional<EvaluateConstantExpressionResult> evaluateConstantExpressionImpl(c
 
         if (actions.getOutputs().size() != 1)
         {
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "ActionsDAG contains more than 1 output for expression: {}", ast->formatForLogging());
+            // Expression can return more than one column using untuple()
+            throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Constant expression returns more than 1 column: {}", ast->formatForLogging());
         }
 
         const auto & output = actions.getOutputs()[0];

--- a/tests/queries/0_stateless/03752_constant_expression_with_untuple.sql
+++ b/tests/queries/0_stateless/03752_constant_expression_with_untuple.sql
@@ -1,0 +1,10 @@
+-- untuple is not available without analyzer
+SET enable_analyzer=1;
+
+CREATE TABLE test Engine=Merge(default, untuple((1,1))); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
+
+-- Fuzzed
+DESCRIBE TABLE format(untuple((toIntervalQuarter(1), assumeNotNull(8) IS NOT NULL, isNullable(7) % 1, 4, materialize('hola'), 4)), JSONEachRow)
+    FINAL
+    SETTINGS schema_inference_hints = 'ð(Œ¼ð(Œ¼ð(Œ¼ð(Œ¼ð(Œ¼ð(Œ¼ð(Œ¼ð(Œ¼ð(Œ¼ð(Œ¼ð(Œ¼ð(Œ¼ð(Œ¼ð(Œ¼ð(Œ¼ð(Œ¼';  -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
+DESCRIBE TABLE format(untuple(((SELECT DISTINCT 1 GROUP BY or(isNullable(1048576), 1), or(1048576, 1 AS x, 10, isNull(isNullable(1))) WITH ROLLUP), 1)), JSONEachRow);  -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }


### PR DESCRIPTION
It is not LOGICAL_ERROR anymore as a valid expression with `untuple` can produce a DAG with multiple outputs
Closes: #73087
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix LOGICAL_ERROR when untuple is used in the constant expression
