### PR TITLE
Fix inconsistent AST formatting in `UPDATE` and `ALTER` queries

### DIFF
--- a/src/Parsers/ParserAlterQuery.cpp
+++ b/src/Parsers/ParserAlterQuery.cpp
@@ -858,6 +858,10 @@ bool ParserAlterCommand::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
                 if (!parser_exp_elem.parse(pos, command_predicate, expected))
                     return false;
 
+                /// Aliases are not allowed in the predicate.
+                if (!command_predicate->tryGetAlias().empty())
+                    return false;
+
                 command->type = ASTAlterCommand::DELETE;
             }
             else if (s_update.ignore(pos, expected))
@@ -875,6 +879,10 @@ bool ParserAlterCommand::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
                     return false;
 
                 if (!parser_exp_elem.parse(pos, command_predicate, expected))
+                    return false;
+
+                /// Aliases are not allowed in the predicate.
+                if (!command_predicate->tryGetAlias().empty())
                     return false;
 
                 command->type = ASTAlterCommand::UPDATE;

--- a/src/Parsers/ParserUpdateQuery.cpp
+++ b/src/Parsers/ParserUpdateQuery.cpp
@@ -60,6 +60,10 @@ bool ParserUpdateQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     if (!parser_exp_elem.parse(pos, query->predicate, expected))
         return false;
 
+    /// Aliases are not allowed in the predicate.
+    if (!query->predicate->tryGetAlias().empty())
+        return false;
+
     if (s_settings.ignore(pos, expected))
     {
         ParserSetQuery parser_settings(true);

--- a/tests/queries/0_stateless/03558_no_alias_in_single_expressions.sql
+++ b/tests/queries/0_stateless/03558_no_alias_in_single_expressions.sql
@@ -5,3 +5,10 @@ CREATE TABLE t0 (c0 Int) ENGINE = MergeTree() ORDER BY c0 AS x; -- { clientError
 CREATE TABLE t0 (c0 Int) ENGINE = MergeTree() ORDER BY c0 AS x DESC; -- { clientError SYNTAX_ERROR }
 DELETE FROM t0 WHERE (true AS a0); -- { clientError SYNTAX_ERROR }
 DELETE FROM t0 WHERE true AS a0; -- { clientError SYNTAX_ERROR }
+
+UPDATE t0 SET c0 = 1 WHERE (true AS x); -- { clientError SYNTAX_ERROR }
+UPDATE t0 SET c0 = 1 WHERE true AS x; -- { clientError SYNTAX_ERROR }
+ALTER TABLE t0 UPDATE c0 = 1 WHERE (true AS x); -- { clientError SYNTAX_ERROR }
+ALTER TABLE t0 UPDATE c0 = 1 WHERE true AS x; -- { clientError SYNTAX_ERROR }
+ALTER TABLE t0 DELETE WHERE (true AS x); -- { clientError SYNTAX_ERROR }
+ALTER TABLE t0 DELETE WHERE true AS x; -- { clientError SYNTAX_ERROR }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes #90002. Addition to #82839.