### PR TITLE
Rename background_schedule_pool_log.duration_threshold_ms to duration_threshold_milliseconds

### DIFF
--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -1259,8 +1259,8 @@
         <reserved_size_rows>8192</reserved_size_rows>
         <buffer_size_rows_flush_threshold>524288</buffer_size_rows_flush_threshold>
         <flush_on_crash>false</flush_on_crash>
-        <!-- Only tasks longer then duration_threshold_ms will be logged. Zero means log everything -->
-        <duration_threshold_ms>0</duration_threshold_ms>
+        <!-- Only tasks longer then duration_threshold_milliseconds will be logged. Zero means log everything -->
+        <duration_threshold_milliseconds>0</duration_threshold_milliseconds>
     </background_schedule_pool_log>
 
     <!-- Text log contains all information from usual server log but stores it in structured and efficient way.

--- a/src/Interpreters/SystemLog.cpp
+++ b/src/Interpreters/SystemLog.cpp
@@ -426,8 +426,8 @@ SystemLogs::SystemLogs(ContextPtr global_context, const Poco::Util::AbstractConf
 
     if (background_schedule_pool_log)
     {
-        size_t duration_threshold_ms = config.getUInt64("background_schedule_pool_log.duration_threshold_ms", 0);
-        background_schedule_pool_log->setDurationMillisecondsThreshold(duration_threshold_ms);
+        size_t duration_threshold_milliseconds = config.getUInt64("background_schedule_pool_log.duration_threshold_milliseconds", 0);
+        background_schedule_pool_log->setDurationMillisecondsThreshold(duration_threshold_milliseconds);
     }
 }
 


### PR DESCRIPTION
Similar to collect_interval_milliseconds/flush_interval_milliseconds

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Follow-up: https://github.com/ClickHouse/ClickHouse/pull/91305