### PR TITLE
Forbid empty `ORDER BY` key in special `MergeTree` storages

### DIFF
--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -282,20 +282,17 @@ void MergeTask::ExecuteAndFinalizeHorizontalPart::extractMergingAndGatheringColu
             key_columns.insert(String(Nested::getColumnFromSubcolumn(name, storage_columns)));
     }
 
-    /// Force sign column for Collapsing mode
-    if (global_ctx->merging_params.mode == MergeTreeData::MergingParams::Collapsing)
+    /// Force sign column for Collapsing mode and VersionedCollapsing mode
+    if (!global_ctx->merging_params.sign_column.empty())
         key_columns.emplace(global_ctx->merging_params.sign_column);
+
+    /// Force is_deleted column for Replacing mode
+    if (!global_ctx->merging_params.is_deleted_column.empty())
+        key_columns.emplace(global_ctx->merging_params.is_deleted_column);
 
     /// Force version column for Replacing mode
-    if (global_ctx->merging_params.mode == MergeTreeData::MergingParams::Replacing)
-    {
-        key_columns.emplace(global_ctx->merging_params.is_deleted_column);
+    if (!global_ctx->merging_params.version_column.empty())
         key_columns.emplace(global_ctx->merging_params.version_column);
-    }
-
-    /// Force sign column for VersionedCollapsing mode. Version is already in primary key.
-    if (global_ctx->merging_params.mode == MergeTreeData::MergingParams::VersionedCollapsing)
-        key_columns.emplace(global_ctx->merging_params.sign_column);
 
     /// Force to merge at least one column in case of empty key
     if (key_columns.empty())

--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -290,7 +290,7 @@ void MergeTask::ExecuteAndFinalizeHorizontalPart::extractMergingAndGatheringColu
     if (!global_ctx->merging_params.is_deleted_column.empty())
         key_columns.emplace(global_ctx->merging_params.is_deleted_column);
 
-    /// Force version column for Replacing mode
+    /// Force version column for Replacing mode and VersionedCollapsing mode
     if (!global_ctx->merging_params.version_column.empty())
         key_columns.emplace(global_ctx->merging_params.version_column);
 

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -10336,7 +10336,7 @@ size_t MergeTreeData::unloadPrimaryKeysAndClearCachesOfOutdatedParts()
     return parts_to_clear.size();
 }
 
-void MergeTreeData::verifySortingKey(const KeyDescription & sorting_key)
+void MergeTreeData::verifySortingKey(const KeyDescription & sorting_key, const MergeTreeData::MergingParams & merging_params)
 {
     /// Aggregate functions already forbidden, but SimpleAggregateFunction are not
     for (const auto & data_type : sorting_key.data_types)
@@ -10344,6 +10344,9 @@ void MergeTreeData::verifySortingKey(const KeyDescription & sorting_key)
         if (dynamic_cast<const DataTypeCustomSimpleAggregateFunction *>(data_type->getCustomName()))
             throw Exception(ErrorCodes::DATA_TYPE_CANNOT_BE_USED_IN_KEY, "Column with type {} is not allowed in key expression", data_type->getCustomName()->getName());
     }
+
+    if (sorting_key.data_types.empty() && merging_params.mode != MergingParams::Mode::Ordinary)
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Sorting key cannot be empty for MergeTree table with {} merging mode", merging_params.mode);
 }
 
 size_t MergeTreeData::NamesAndTypesListHash::operator()(const NamesAndTypesList & list) const noexcept

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -961,7 +961,7 @@ public:
         AlterLockHolder & table_lock_holder);
 
     static std::pair<String, bool> getNewImplicitStatisticsTypes(const StorageInMemoryMetadata & new_metadata, const MergeTreeSettings & old_settings);
-    static void verifySortingKey(const KeyDescription & sorting_key);
+    static void verifySortingKey(const KeyDescription & sorting_key, const MergeTreeData::MergingParams & merging_params);
 
     /// Should be called if part data is suspected to be corrupted.
     /// Has the ability to check all other parts

--- a/src/Storages/MergeTree/registerStorageMergeTree.cpp
+++ b/src/Storages/MergeTree/registerStorageMergeTree.cpp
@@ -675,8 +675,9 @@ static StoragePtr create(const StorageFactory::Arguments & args)
         /// column if sorting key will be changed.
         metadata.sorting_key = KeyDescription::getSortingKeyFromAST(
             args.storage_def->order_by->ptr(), metadata.columns, context, merging_param_key_arg);
+
         if (!local_settings[Setting::allow_suspicious_primary_key] && args.mode <= LoadingStrictnessLevel::CREATE)
-            MergeTreeData::verifySortingKey(metadata.sorting_key);
+            MergeTreeData::verifySortingKey(metadata.sorting_key, merging_params);
 
         /// If primary key explicitly defined, than get it from AST
         if (args.storage_def->primary_key)
@@ -816,8 +817,9 @@ static StoragePtr create(const StorageFactory::Arguments & args)
         /// column if sorting key will be changed.
         metadata.sorting_key
             = KeyDescription::getSortingKeyFromAST(engine_args[arg_num], metadata.columns, context, merging_param_key_arg);
+
         if (!local_settings[Setting::allow_suspicious_primary_key] && args.mode <= LoadingStrictnessLevel::CREATE)
-            MergeTreeData::verifySortingKey(metadata.sorting_key);
+            MergeTreeData::verifySortingKey(metadata.sorting_key, merging_params);
 
         /// In old syntax primary_key always equals to sorting key.
         metadata.primary_key = KeyDescription::getKeyFromAST(engine_args[arg_num], metadata.columns, context);

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -412,7 +412,7 @@ void StorageMergeTree::alter(
     addImplicitStatistics(new_metadata.columns, auto_statistics_types);
 
     if (!query_settings[Setting::allow_suspicious_primary_key])
-        MergeTreeData::verifySortingKey(new_metadata.sorting_key);
+        MergeTreeData::verifySortingKey(new_metadata.sorting_key, merging_params);
 
     /// This alter can be performed at new_metadata level only
     if (commands.isSettingsAlter())

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -6503,7 +6503,7 @@ void StorageReplicatedMergeTree::alter(
 
     if (!query_settings[Setting::allow_suspicious_primary_key])
     {
-        MergeTreeData::verifySortingKey(future_metadata.sorting_key);
+        MergeTreeData::verifySortingKey(future_metadata.sorting_key, merging_params);
     }
 
     {

--- a/tests/integration/test_parallel_replicas_protocol/test.py
+++ b/tests/integration/test_parallel_replicas_protocol/test.py
@@ -81,11 +81,10 @@ def test_mark_segment_size_communicated_correctly(
 
 
 def test_final_on_parallel_replicas(start_cluster):
+    nodes[0].query("DROP TABLE IF EXISTS t0")
     nodes[0].query(
-        "DROP TABLE IF EXISTS t0"
-    )
-    nodes[0].query(
-        "CREATE TABLE t0 (c0 Int) ENGINE = SummingMergeTree() ORDER BY tuple()"
+        "CREATE TABLE t0 (c0 Int) ENGINE = SummingMergeTree() ORDER BY tuple()",
+        settings={"allow_suspicious_primary_key": 1},
     )
     nodes[0].query("INSERT INTO t0 VALUES (1)")
     nodes[0].query("OPTIMIZE TABLE t0 FINAL")
@@ -101,9 +100,7 @@ def test_final_on_parallel_replicas(start_cluster):
 
 
 def test_insert_cluster_parallel_replicas(start_cluster):
-    nodes[0].query(
-        "DROP TABLE IF EXISTS t0 ON CLUSTER 'test_cluster_two_shards'"
-    )
+    nodes[0].query("DROP TABLE IF EXISTS t0 ON CLUSTER 'test_cluster_two_shards'")
     nodes[0].query(
         "CREATE TABLE t0 ON CLUSTER 'test_cluster_two_shards' (c0 Int) ENGINE = Log()"
     )

--- a/tests/queries/0_stateless/00578_merge_trees_without_primary_key.sql
+++ b/tests/queries/0_stateless/00578_merge_trees_without_primary_key.sql
@@ -13,7 +13,7 @@ SELECT * FROM unsorted;
 
 DROP TABLE unsorted;
 
-
+SET allow_suspicious_primary_key = 1;
 SELECT '*** ReplacingMergeTree ***';
 
 DROP TABLE IF EXISTS unsorted_replacing;

--- a/tests/queries/0_stateless/00752_low_cardinality_mv_1.sql
+++ b/tests/queries/0_stateless/00752_low_cardinality_mv_1.sql
@@ -5,6 +5,7 @@ create table lc_00752 (str LowCardinality(String)) engine = MergeTree order by t
 
 insert into lc_00752 values ('a'), ('bbb'), ('ab'), ('accccc'), ('baasddas'), ('bcde');
 
+SET allow_suspicious_primary_key = 1;
 CREATE MATERIALIZED VIEW lc_mv_00752 ENGINE = AggregatingMergeTree() ORDER BY tuple() populate AS SELECT substring(str, 1, 1) as letter, min(length(str)) AS min_len, max(length(str)) AS max_len FROM lc_00752 GROUP BY substring(str, 1, 1);
 
 insert into lc_00752 values ('a'), ('bbb'), ('ab'), ('accccc'), ('baasddas'), ('bcde');

--- a/tests/queries/0_stateless/02177_sum_if_not_found.sql
+++ b/tests/queries/0_stateless/02177_sum_if_not_found.sql
@@ -22,6 +22,8 @@ SELECT
 FROM data
 GROUP BY t; -- { serverError UNKNOWN_FUNCTION}
 
+SET allow_suspicious_primary_key = 1;
+
 CREATE TABLE agg
 ENGINE = AggregatingMergeTree
 ORDER BY tuple() AS

--- a/tests/queries/0_stateless/02995_preliminary_filters_duplicated_columns.sql
+++ b/tests/queries/0_stateless/02995_preliminary_filters_duplicated_columns.sql
@@ -1,4 +1,5 @@
 -- It is special because actions cannot be reused for SimpleAggregateFunction (see https://github.com/ClickHouse/ClickHouse/pull/54436)
+SET allow_suspicious_primary_key = 1;
 drop table if exists data;
 create table data (key Int) engine=AggregatingMergeTree() order by tuple();
 insert into data values (0);

--- a/tests/queries/0_stateless/02995_preliminary_filters_duplicated_columns_SimpleAggregateFunction.sql
+++ b/tests/queries/0_stateless/02995_preliminary_filters_duplicated_columns_SimpleAggregateFunction.sql
@@ -1,4 +1,5 @@
 -- It is special because actions cannot be reused for SimpleAggregateFunction (see https://github.com/ClickHouse/ClickHouse/pull/54436)
+set allow_suspicious_primary_key = 1;
 drop table if exists data;
 create table data (key SimpleAggregateFunction(max, Int)) engine=AggregatingMergeTree() order by tuple();
 insert into data values (0);

--- a/tests/queries/0_stateless/03210_optimize_rewrite_aggregate_function_with_if_return_type_bug.sql
+++ b/tests/queries/0_stateless/03210_optimize_rewrite_aggregate_function_with_if_return_type_bug.sql
@@ -1,4 +1,5 @@
 SET enable_analyzer = 1;
+SET allow_suspicious_primary_key = 1;
 
 -- For function count, rewrite countState to countStateIf changes the type from AggregateFunction(count, Nullable(UInt64)) to AggregateFunction(count, UInt64)
 -- We can cast AggregateFunction(count, UInt64) back to AggregateFunction(count, Nullable(UInt64)) with additional _CAST

--- a/tests/queries/0_stateless/03230_subcolumns_mv.sql
+++ b/tests/queries/0_stateless/03230_subcolumns_mv.sql
@@ -3,6 +3,7 @@ DROP TABLE IF EXISTS raw_to_attributes_mv;
 DROP TABLE IF EXISTS attributes;
 
 SET optimize_functions_to_subcolumns = 1;
+SET allow_suspicious_primary_key = 1;
 
 CREATE TABLE rawtable
 (

--- a/tests/queries/0_stateless/03261_sort_cursor_crash.sql
+++ b/tests/queries/0_stateless/03261_sort_cursor_crash.sql
@@ -3,6 +3,8 @@
 DROP TABLE IF EXISTS t0;
 DROP TABLE IF EXISTS t1;
 
+SET allow_suspicious_primary_key = 1;
+
 CREATE TABLE t0 (c0 Int) ENGINE = AggregatingMergeTree() ORDER BY tuple();
 INSERT INTO TABLE t0 (c0) VALUES (1);
 SELECT 42 FROM t0 FINAL PREWHERE t0.c0 = 1;

--- a/tests/queries/0_stateless/03291_collapsing_invalid_sign.sql
+++ b/tests/queries/0_stateless/03291_collapsing_invalid_sign.sql
@@ -1,4 +1,5 @@
 SET send_logs_level = 'fatal';
+SET allow_suspicious_primary_key = 1;
 
 DROP TABLE IF EXISTS t_03291_collapsing_invalid_sign;
 

--- a/tests/queries/0_stateless/03325_count_summing_merge_tree_order_by_tuple.sql
+++ b/tests/queries/0_stateless/03325_count_summing_merge_tree_order_by_tuple.sql
@@ -1,4 +1,6 @@
 SET enable_analyzer = 1;
+SET allow_suspicious_primary_key = 1;
+
 CREATE TABLE t0 (c0 Nullable(Int)) ENGINE = SummingMergeTree() ORDER BY tuple() PARTITION BY (c0) SETTINGS allow_nullable_key = 1;
 INSERT INTO TABLE t0 (c0) VALUES (NULL);
 SELECT * FROM t0 FINAL;

--- a/tests/queries/0_stateless/03411_summing_merge_tree_dynamic_values.sql
+++ b/tests/queries/0_stateless/03411_summing_merge_tree_dynamic_values.sql
@@ -1,4 +1,5 @@
 DROP TABLE IF EXISTS t0;
+SET allow_suspicious_primary_key = 1;
 CREATE TABLE t0 (c0 Dynamic) ENGINE = SummingMergeTree() ORDER BY tuple();
 INSERT INTO TABLE t0 (c0) VALUES ('a'::Enum('a' = 1)), (2);
 SELECT c0 FROM t0 FINAL;

--- a/tests/queries/0_stateless/03463_numeric_indexed_vector_overflow.sql
+++ b/tests/queries/0_stateless/03463_numeric_indexed_vector_overflow.sql
@@ -49,6 +49,8 @@ SELECT numericIndexedVectorToMap(numericIndexedVectorPointwiseGreaterEqual(vec_1
 
 DROP TABLE uin_value_details;
 
+SET allow_suspicious_primary_key = 1;
+
 -- https://github.com/ClickHouse/ClickHouse/issues/82239
 SELECT 'Test with NaN, INFs and Nulls' AS test;
 

--- a/tests/queries/0_stateless/03521_long_partition_column_name.sql
+++ b/tests/queries/0_stateless/03521_long_partition_column_name.sql
@@ -3,7 +3,7 @@ DROP TABLE IF EXISTS t_long_partition_column_name;
 CREATE TABLE t_long_partition_column_name (
 `一个非常非常非常非常非常非常非常非常非常非常非常长的中文字符串` Int,
 )
-ENGINE = ReplacingMergeTree()
+ENGINE = MergeTree()
 PARTITION BY `一个非常非常非常非常非常非常非常非常非常非常非常长的中文字符串`
 ORDER BY tuple()
 SETTINGS replace_long_file_name_to_hash = 1, max_file_name_length = 127;

--- a/tests/queries/0_stateless/03532_dynamic_flattened_serialization_bug.sql
+++ b/tests/queries/0_stateless/03532_dynamic_flattened_serialization_bug.sql
@@ -1,6 +1,7 @@
 -- Tags: no-fasttest
 
 SET type_json_skip_duplicated_paths=1;
+SET allow_suspicious_primary_key=1;
 
 DROP TABLE IF EXISTS t0;
 CREATE TABLE t0 (c0 Variant(Int,JSON(max_dynamic_paths=3, max_dynamic_types=13))) ENGINE = SummingMergeTree() ORDER BY tuple();

--- a/tests/queries/0_stateless/03551_no_alter_for_columns_to_sum.sql
+++ b/tests/queries/0_stateless/03551_no_alter_for_columns_to_sum.sql
@@ -1,4 +1,5 @@
 DROP TABLE IF EXISTS t0;
+SET allow_suspicious_primary_key = 1;
 CREATE TABLE t0 (c0 Int) ENGINE = SummingMergeTree((c0)) ORDER BY tuple();
 ALTER TABLE t0 RENAME COLUMN c0 TO c1; -- { serverError ALTER_OF_COLUMN_IS_FORBIDDEN }
 DROP TABLE t0;

--- a/tests/queries/0_stateless/03562_parallel_replicas_subquery_has_final.sql
+++ b/tests/queries/0_stateless/03562_parallel_replicas_subquery_has_final.sql
@@ -1,3 +1,5 @@
+SET allow_suspicious_primary_key = 1;
+
 CREATE OR REPLACE TABLE t0 (c0 Int) ENGINE = SummingMergeTree() ORDER BY tuple();
 INSERT INTO t0 VALUES (1);
 

--- a/tests/queries/0_stateless/03594_coalescing_merge_tree_segfault.sql
+++ b/tests/queries/0_stateless/03594_coalescing_merge_tree_segfault.sql
@@ -1,3 +1,4 @@
+SET allow_suspicious_primary_key = 1;
 CREATE TABLE t0 (c0 String) ENGINE = CoalescingMergeTree() ORDER BY tuple();
 INSERT INTO TABLE t0 (c0) VALUES ('playl哪国人[]美国认识你很高兴');
 SELECT * FROM t0;

--- a/tests/queries/0_stateless/03652_coalescing_merge_tree_fix_empty_tuple.sql
+++ b/tests/queries/0_stateless/03652_coalescing_merge_tree_fix_empty_tuple.sql
@@ -1,3 +1,5 @@
+SET allow_suspicious_primary_key = 1;
+
 DROP TABLE IF EXISTS t0;
 
 CREATE TABLE t0 (c0 Tuple(a Int32, b Nullable(Int32)), c1 Int32) ENGINE = SummingMergeTree() ORDER BY c1;

--- a/tests/queries/0_stateless/03751_summing_coalescing_merge_tree_sparse_columns_in_header.sql
+++ b/tests/queries/0_stateless/03751_summing_coalescing_merge_tree_sparse_columns_in_header.sql
@@ -1,3 +1,4 @@
+set allow_suspicious_primary_key = 1;
 drop table if exists src;
 create table src (x UInt64) engine=MergeTree order by tuple();
 insert into src select 0 from numbers(1000000);

--- a/tests/queries/0_stateless/03753_replacing_empty_order_by.reference
+++ b/tests/queries/0_stateless/03753_replacing_empty_order_by.reference
@@ -1,0 +1,2 @@
+foo	bar
+foo	bar

--- a/tests/queries/0_stateless/03753_replacing_empty_order_by.sql
+++ b/tests/queries/0_stateless/03753_replacing_empty_order_by.sql
@@ -1,0 +1,23 @@
+DROP TABLE IF EXISTS t_empty_order_key;
+
+SET allow_suspicious_primary_key = 0;
+
+-- CREATE TABLE t_empty_order_key(c0 String, c1 String) ENGINE = ReplacingMergeTree() ORDER BY tuple(); -- { serverError BAD_ARGUMENTS }
+
+SET allow_suspicious_primary_key = 1;
+
+CREATE TABLE t_empty_order_key(c0 String, c1 String) ENGINE = ReplacingMergeTree() ORDER BY tuple();
+
+INSERT INTO TABLE t_empty_order_key (c0, c1) VALUES ('foo', 'bar');
+OPTIMIZE TABLE t_empty_order_key FINAL;
+SELECT * FROM t_empty_order_key ORDER BY c0;
+DROP TABLE t_empty_order_key;
+
+-- Check with forced vertical merge
+CREATE TABLE t_empty_order_key(c0 String, c1 String) ENGINE = ReplacingMergeTree() ORDER BY tuple()
+SETTINGS min_bytes_for_wide_part = 0, vertical_merge_algorithm_min_bytes_to_activate = 1, vertical_merge_algorithm_min_rows_to_activate = 0, index_granularity = 1, vertical_merge_algorithm_min_columns_to_activate = 1;
+
+INSERT INTO TABLE t_empty_order_key (c0, c1) VALUES ('foo', 'bar');
+OPTIMIZE TABLE t_empty_order_key FINAL;
+SELECT * FROM t_empty_order_key ORDER BY c0;
+DROP TABLE t_empty_order_key;


### PR DESCRIPTION
### Changelog category (leave one):
- Backward Incompatible Change

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
It is now forbidden to create special `MergeTree` tables (such as `ReplacingMergeTree`, `CollapsingMergeTree`, etc.) with an empty `ORDER BY` key, since merge behavior in these tables is undefined.  If you still need to create such a table, enable the `allow_suspicious_primary_key` setting.  

Fixes #88633.
