### PR TITLE
Disallow ALTERs for Object Storage table engines

### DIFF
--- a/src/Storages/ObjectStorage/StorageObjectStorageConfiguration.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorageConfiguration.h
@@ -219,14 +219,11 @@ public:
 
     virtual void checkAlterIsPossible(const AlterCommands & commands)
     {
-        /// Check if any of the alter commands is ADD_INDEX and throw immediately
-        const bool alter_adds_index
-            = std::ranges::any_of(commands, [](const AlterCommand & c) { return c.type == AlterCommand::ADD_INDEX; });
-        if (alter_adds_index)
+        for (const auto & command : commands)
         {
-            const auto & features = StorageFactory::instance().getStorageFeatures(getEngineName());
-            if (!features.supports_skipping_indices)
-                throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Engine {} doesn't support skipping indices.", getEngineName());
+            if (!command.isCommentAlter())
+                throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Alter of type '{}' is not supported by storage {}",
+                    command.type, getEngineName());
         }
     }
 

--- a/tests/queries/0_stateless/03629_storage_s3_disallow_index_alter.sql
+++ b/tests/queries/0_stateless/03629_storage_s3_disallow_index_alter.sql
@@ -1,9 +1,10 @@
 -- Tags: no-fasttest
 -- Tag no-fasttest: Depends on S3
 -- Issue: https://github.com/ClickHouse/ClickHouse/issues/87059
-    
+
 DROP TABLE IF EXISTS test_03629;
 CREATE TABLE test_03629 (a UInt64) ENGINE = S3(s3_conn, filename='test_03629_{_partition_id}', format='Native') PARTITION BY a;
 ALTER TABLE test_03629 ADD INDEX a_idx a TYPE set(0); -- { serverError NOT_IMPLEMENTED }
+ALTER TABLE test_03629 ADD PROJECTION a_proj (SELECT a + 1 ORDER BY a); -- { serverError NOT_IMPLEMENTED }
 
 DROP TABLE test_03629;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Disallow ALTERs for Object Storage table engines. For example, ALTER ADD PROJECTION could have led to an inability to restart the server, since Object Storage engines do not support projections.

Reference https://github.com/ClickHouse/ClickHouse/pull/85769

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
