### PR TITLE
fix a race when HTTP_CONNECTION_LIMIT_REACHED is thrown

### DIFF
--- a/src/Common/HTTPConnectionPool.cpp
+++ b/src/Common/HTTPConnectionPool.cpp
@@ -190,15 +190,15 @@ public:
         return total_connections_in_group >= limits.store_limit;
     }
 
-    bool isHardLimitReached() const
+    void atConnectionCreate(std::string host, UInt16 port)
     {
         std::lock_guard lock(mutex);
-        return limits.hard_limit > 0 && total_connections_in_group >= limits.hard_limit;
-    }
 
-    void atConnectionCreate()
-    {
-        std::lock_guard lock(mutex);
+        if (isHardLimitReached())
+            throw Exception(
+                ErrorCodes::HTTP_CONNECTION_LIMIT_REACHED,
+                "Cannot create new connection to {}:{}, hard limit {} for connections in group {} is reached",
+                host, port, limits.hard_limit, getType());
 
         ++total_connections_in_group;
 
@@ -230,6 +230,11 @@ public:
     const IHTTPConnectionPoolForEndpoint::Metrics & getMetrics() const { return metrics; }
 
 private:
+    bool isHardLimitReached() const TSA_REQUIRES(mutex)
+    {
+        return limits.hard_limit > 0 && total_connections_in_group >= limits.hard_limit;
+    }
+
     const HTTPConnectionGroupType type;
     const IHTTPConnectionPoolForEndpoint::Metrics metrics;
 
@@ -499,8 +504,10 @@ private:
             , group(group_)
             , metrics(std::move(metrics_))
         {
+            // atConnectionCreate can throw, when it does, no destructor is called
+            // so we increment active_count only after successful atConnectionCreate call
+            group->atConnectionCreate(Session::getHost(), Session::getPort());
             CurrentMetrics::add(metrics.active_count);
-            group->atConnectionCreate();
         }
 
         template <class... Args>
@@ -677,12 +684,6 @@ private:
 
     ConnectionPtr prepareNewConnection(const ConnectionTimeouts & timeouts, UInt64 * connect_time)
     {
-        if (group->isHardLimitReached())
-            throw Exception(
-                ErrorCodes::HTTP_CONNECTION_LIMIT_REACHED,
-                "Cannot create new connection to {}:{}, hard limit {} for connections in group {} is reached",
-                host, port, group->getLimits().hard_limit, group->getType());
-
         auto connection = PooledConnection::create(this->getWeakFromThis(), group, getMetrics(), host, port);
 
         connection->setKeepAlive(true);

--- a/src/Common/HTTPConnectionPool.cpp
+++ b/src/Common/HTTPConnectionPool.cpp
@@ -504,8 +504,8 @@ private:
             , group(group_)
             , metrics(std::move(metrics_))
         {
-            // atConnectionCreate can throw, when it does, no destructor is called
-            // so we increment active_count only after successful atConnectionCreate call
+            // atConnectionCreate can throw. If it does, this object's constructor fails and its destructor won't be called,
+            // so we must call atConnectionCreate before incrementing active_count to avoid leaking the metric increment.
             group->atConnectionCreate(Session::getHost(), Session::getPort());
             CurrentMetrics::add(metrics.active_count);
         }


### PR DESCRIPTION
Otherwise we do not see the connections which are about to be created concurrently. 

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
