### PR TITLE
CI: Fix indentation bug in test selection logic in targeted job

### DIFF
--- a/ci/jobs/scripts/find_tests.py
+++ b/ci/jobs/scripts/find_tests.py
@@ -256,7 +256,7 @@ class Targeting:
                 if len(tests) > max_tests_per_symbol:
                     info += f" select {max_tests_per_symbol} random tests out of {len(tests)}\n"
                     tests = sample(tests, max_tests_per_symbol)
-            selected_tests.update(tests)
+                selected_tests.update(tests)
             for test in tests[:10]:
                 info += f"  - {test}\n"
             if len(tests) > 10:


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

the targeted job selected fewer tests than were actually found

