### PR TITLE
CI: Skip no-flaky-check tests in targeted job

### DIFF
--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -118,6 +118,7 @@ OPTIONS_TO_TEST_RUNNER_ARGUMENTS = {
     "parallel": "--no-sequential",
     "sequential": "--no-parallel",
     "flaky check": "--flaky-check",
+    "targeted": "--flaky-check",  # to disable tests not compatible with the thread fuzzer
 }
 
 
@@ -147,12 +148,7 @@ def main():
         elif to in OPTIONS_TO_INSTALL_ARGUMENTS:
             print(f"NOTE: Enabled config option [{OPTIONS_TO_INSTALL_ARGUMENTS[to]}]")
             config_installs_args += f" {OPTIONS_TO_INSTALL_ARGUMENTS[to]}"
-        elif (
-            to.startswith("amd_")
-            or to.startswith("arm_")
-            or "flaky" in to
-            or "targeted" in to
-        ):
+        elif to.startswith("amd_") or to.startswith("arm_"):
             pass
         elif to in OPTIONS_TO_TEST_RUNNER_ARGUMENTS:
             print(


### PR DESCRIPTION


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Some  "no-flaky-check" tests are not compatible with thread fuzzer and fail in targeted check. Skip all no-flaky-check tests in targeted job as a quick fix
