### PR TITLE
CI: Fix unbalanced trailing quote in a logical error name

### DIFF
--- a/ci/jobs/scripts/log_parser.py
+++ b/ci/jobs/scripts/log_parser.py
@@ -128,7 +128,7 @@ class FuzzerLogParser:
                 if start_idx != -1:
                     substring = line[start_idx + len("Format string: ") :]
                     # Remove quotes and trailing period
-                    substring = substring.strip().strip("'\"").rstrip(".")
+                    substring = substring.strip().rstrip(".").strip("'\"")
                     format_message = substring
                 break
         # keep all lines before next log line


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fix for `Logical error: Function A expects argument B to have C type but receives D after running E pass' `, [report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=91616&sha=8b476cfc675fc7e05ade47fa3e714b1ed21748ba&name_0=PR&name_1=AST%20fuzzer%20%28arm_asan%29&name_1=AST%20fuzzer%20%28arm_asan%29)
