### PR TITLE
Use / instead of | in endpoints

### DIFF
--- a/tests/config/config.d/remote_database_disk.xml
+++ b/tests/config/config.d/remote_database_disk.xml
@@ -8,7 +8,7 @@
                 <type>object_storage</type>
                 <object_storage_type>s3</object_storage_type>
                 <metadata_type>plain_rewritable</metadata_type>
-                <endpoint>http://localhost:11111/test/test-{shard}|{replica}</endpoint>
+                <endpoint>http://localhost:11111/test/test-{shard}/{replica}</endpoint>
                 <access_key_id>clickhouse</access_key_id>
                 <secret_access_key>clickhouse</secret_access_key>
             </disk_db_remote>

--- a/tests/integration/helpers/remote_database_disk.xml
+++ b/tests/integration/helpers/remote_database_disk.xml
@@ -5,7 +5,7 @@
                 <type>object_storage</type>
                 <object_storage_type>s3</object_storage_type>
                 <metadata_type>plain_rewritable</metadata_type>
-                <endpoint>http://{host}:{port}/{bucket}/test-{shard}|{replica}</endpoint>
+                <endpoint>http://{host}:{port}/{bucket}/test-{shard}/{replica}</endpoint>
                 <access_key_id>minio</access_key_id>
                 <secret_access_key>ClickHouse_Minio_P@ssw0rd</secret_access_key>
             </disk_db_remote>

--- a/tests/queries/0_stateless/03001_matview_columns_after_modify_query.xml
+++ b/tests/queries/0_stateless/03001_matview_columns_after_modify_query.xml
@@ -5,7 +5,7 @@
                 <type>object_storage</type>
                 <object_storage_type>s3</object_storage_type>
                 <metadata_type>plain_rewritable</metadata_type>
-                <endpoint>http://localhost:11111/test/test-{shard}|{replica}</endpoint>
+                <endpoint>http://localhost:11111/test/test-{shard}/{replica}</endpoint>
                 <access_key_id>clickhouse</access_key_id>
                 <secret_access_key>clickhouse</secret_access_key>
             </disk_db_remote>


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
This is a blocker for prefix generator deprecation, because with regex template generation it will be this kind of mask: `test-01|example01-01-1/[a-z]{3}/[a-z]{29}` which can produce keys like `test-01` and `example01-01-1/ayf/zsyuaqpfppmljohuhrpbcuafyygvx`

Needed for https://github.com/ClickHouse/ClickHouse/pull/91520
