### PR TITLE
Add ability to tweak exponent in merge-widths lowering curve

### DIFF
--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -971,6 +971,7 @@ const VersionToSettingsChangesMap & getMergeTreeSettingsChangesHistory()
         {
             {"alter_column_secondary_index_mode", "compatibility", "rebuild", "Change the behaviour to allow ALTER `column` when they have dependent secondary indices"},
             {"merge_selector_enable_heuristic_to_lower_max_parts_to_merge_at_once", false, false, "New setting"},
+            {"merge_selector_heuristic_to_lower_max_parts_to_merge_at_once_exponent", 5, 5, "New setting"},
             {"nullable_serialization_version", "basic", "basic", "New setting"},
         });
         addSettingsChanges(merge_tree_settings_changes_history, "25.11",

--- a/src/Storages/MergeTree/Compaction/MergeSelectorApplier.cpp
+++ b/src/Storages/MergeTree/Compaction/MergeSelectorApplier.cpp
@@ -26,6 +26,7 @@ namespace MergeTreeSetting
     extern const MergeTreeSettingsMergeSelectorAlgorithm merge_selector_algorithm;
     extern const MergeTreeSettingsBool merge_selector_enable_heuristic_to_remove_small_parts_at_right;
     extern const MergeTreeSettingsBool merge_selector_enable_heuristic_to_lower_max_parts_to_merge_at_once;
+    extern const MergeTreeSettingsUInt64 merge_selector_heuristic_to_lower_max_parts_to_merge_at_once_exponent;
     extern const MergeTreeSettingsFloat merge_selector_base;
     extern const MergeTreeSettingsUInt64 min_parts_to_merge_at_once;
     extern const MergeTreeSettingsBool apply_patches_on_merge;
@@ -112,6 +113,7 @@ SimpleMergeSelector::Settings fillSimpleSettings(const ChooseContext & ctx)
     simple_merge_settings.min_parts_to_merge_at_once = ctx.merge_tree_settings[MergeTreeSetting::min_parts_to_merge_at_once];
 
     simple_merge_settings.enable_heuristic_to_lower_max_parts_to_merge_at_once = ctx.merge_tree_settings[MergeTreeSetting::merge_selector_enable_heuristic_to_lower_max_parts_to_merge_at_once];
+    simple_merge_settings.heuristic_to_lower_max_parts_to_merge_at_once_exponent = ctx.merge_tree_settings[MergeTreeSetting::merge_selector_heuristic_to_lower_max_parts_to_merge_at_once_exponent];
     simple_merge_settings.parts_to_throw_insert = ctx.merge_tree_settings[MergeTreeSetting::parts_to_throw_insert];
     simple_merge_settings.partitions_stats = &ctx.partitions_stats;
 

--- a/src/Storages/MergeTree/Compaction/MergeSelectors/SimpleMergeSelector.cpp
+++ b/src/Storages/MergeTree/Compaction/MergeSelectors/SimpleMergeSelector.cpp
@@ -252,9 +252,10 @@ void selectWithinPartsRange(
         else
         {
             /// Partition is not fully filled but but may be approaching it. Let's lower max parts to merge according to the fullness.
+            size_t exponent = settings.heuristic_to_lower_max_parts_to_merge_at_once_exponent;
             max_parts_to_merge_at_once = static_cast<size_t>(
                 settings.base +
-                (max_parts_to_merge_at_once - settings.base) * (1.0 - std::pow((partition_stats.part_count - settings.base) / (settings.parts_to_throw_insert - settings.base), 5))
+                (max_parts_to_merge_at_once - settings.base) * (1.0 - std::pow((partition_stats.part_count - settings.base) / (settings.parts_to_throw_insert - settings.base), exponent))
             );
         }
     }

--- a/src/Storages/MergeTree/Compaction/MergeSelectors/SimpleMergeSelector.h
+++ b/src/Storages/MergeTree/Compaction/MergeSelectors/SimpleMergeSelector.h
@@ -172,6 +172,7 @@ public:
           * Lower max_parts_to_merge_at_once automatically when number of parts in partition approaching parts_to_throw_insert
           */
         bool enable_heuristic_to_lower_max_parts_to_merge_at_once = false;
+        size_t heuristic_to_lower_max_parts_to_merge_at_once_exponent = 5;
         const PartitionsStatistics * partitions_stats = nullptr;
     };
 

--- a/src/Storages/MergeTree/MergeTreeSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeSettings.cpp
@@ -730,6 +730,10 @@ namespace ErrorCodes
     By doing so number of concurrent merges will increase which can help with TOO_MANY_PARTS
     errors but at the same time this will increase the write amplification.
     )", EXPERIMENTAL) \
+    DECLARE(UInt64, merge_selector_heuristic_to_lower_max_parts_to_merge_at_once_exponent, 5, R"(
+    Controls the exponent value used in formulae building lowering curve. Lowering exponent will
+    lower merge widths which will trigger increase in write amplification. The reverse is also true.
+    )", EXPERIMENTAL) \
     DECLARE(Bool, merge_selector_enable_heuristic_to_remove_small_parts_at_right, true, R"(
     Enable heuristic for selecting parts for merge which removes parts from right
     side of range, if their size is less than specified ratio (0.01) of sum_size.


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Follow up for https://github.com/ClickHouse/ClickHouse/pull/91163
