### PR TITLE
CI: Fix targeted check to skip common symbols instead of sampling tests

### DIFF
--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -214,7 +214,7 @@ def main():
         rerun_count = 50
     elif is_targeted_check:
         print(f"Rerun count set to 5 for targeted check")
-        rerun_count = 10
+        rerun_count = 5
 
     if not info.is_local_run:
         # TODO: find a way to work with Azure secret so it's ok for local tests as well, for now keep azure disabled

--- a/ci/jobs/scripts/find_tests.py
+++ b/ci/jobs/scripts/find_tests.py
@@ -4,7 +4,6 @@ import os
 import re
 import sys
 from pathlib import Path
-from random import sample
 
 sys.path.append("./")
 
@@ -223,7 +222,7 @@ class Targeting:
         """
         1. Makes a best effort to get changed symbols by reading the PR diff and the ClickHouse binary DWARF.
         2. Gets a list of tests that cover each found symbol from the coverage database.
-        3. Selects up to 'max_tests_per_symbol' random tests per symbol when there are more.
+        3. Skips symbols with more than 'max_tests_per_symbol' tests (too common code).
         4. Returns the unique tests and a Result with info about the findings.
         """
 
@@ -254,9 +253,9 @@ class Targeting:
             for (file_, line), (symbol, tests) in resolved_file_lines.items():
                 info += f"  {file_}:{line} -> symbol: {symbol[:70]}...\n"
                 if len(tests) > max_tests_per_symbol:
-                    info += f" select {max_tests_per_symbol} random tests out of {len(tests)}\n"
-                    tests = sample(tests, max_tests_per_symbol)
-                selected_tests.update(tests)
+                    info += f"    skipping {len(tests)} tests (too common code)\n"
+                else:
+                    selected_tests.update(tests)
             for test in tests[:10]:
                 info += f"  - {test}\n"
             if len(tests) > 10:


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

* if more than 100 tests found by symbol - skip it (too common symbol)
* reduce the number of run rounds from 10 to 5 - to not run for 2+ hours
