### PR TITLE
Fix a logical error in MergeTreeDeduplicationLog for a table with S3 plain disk.

### DIFF
--- a/src/Storages/MergeTree/MergeTreeDeduplicationLog.cpp
+++ b/src/Storages/MergeTree/MergeTreeDeduplicationLog.cpp
@@ -100,7 +100,14 @@ MergeTreeDeduplicationLog::MergeTreeDeduplicationLog(
 void MergeTreeDeduplicationLog::load()
 {
     if (!disk->existsDirectory(logs_dir))
-        return;
+    {
+        if (auto * object_storage = dynamic_cast<DiskObjectStorage *>(disk.get()))
+        {
+            // MetadataStorageType::Plain does not have directory concept. When checking `logs_dir` existence, it might return false.
+            if (object_storage->getMetadataStorage()->getType() != MetadataStorageType::Plain)
+                return;
+        }
+    }
 
     for (auto it = disk->iterateDirectory(logs_dir); it->isValid(); it->next())
     {

--- a/tests/config/config.d/storage_conf_03755.xml
+++ b/tests/config/config.d/storage_conf_03755.xml
@@ -1,0 +1,34 @@
+<clickhouse>
+    <storage_configuration>
+        <disks>
+            <disk_03755_0>
+                <type>object_storage</type>
+                <object_storage_type>s3</object_storage_type>
+                <metadata_type>plain</metadata_type>
+                <endpoint>http://localhost:11111/test/data0</endpoint>
+                <access_key_id>clickhouse</access_key_id>
+                <secret_access_key>clickhouse</secret_access_key>
+            </disk_03755_0>
+            <disk_03755_1>
+                <type>object_storage</type>
+                <object_storage_type>s3</object_storage_type>
+                <metadata_type>local</metadata_type>
+                <endpoint>http://localhost:11111/test/data1</endpoint>
+                <access_key_id>clickhouse</access_key_id>
+                <secret_access_key>clickhouse</secret_access_key>
+            </disk_03755_1>
+        </disks>
+        <policies>
+            <policy_03755>
+                <volumes>
+                    <volume0>
+                        <disk>disk_03755_0</disk>
+                    </volume0>
+                    <volume1>
+                        <disk>disk_03755_1</disk>
+                    </volume1>
+                </volumes>
+            </policy_03755>
+        </policies>
+    </storage_configuration>
+</clickhouse>

--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -339,6 +339,7 @@ if [[ "$EXPORT_S3_STORAGE_POLICIES" == "1" ]]; then
     ln -sf $SRC_PATH/config.d/storage_conf_02963.xml $DEST_SERVER_PATH/config.d/
     ln -sf $SRC_PATH/config.d/storage_conf_02961.xml $DEST_SERVER_PATH/config.d/
     ln -sf $SRC_PATH/config.d/storage_conf_03517.xml $DEST_SERVER_PATH/config.d/
+    ln -sf $SRC_PATH/config.d/storage_conf_03755.xml $DEST_SERVER_PATH/config.d/
     ln -sf $SRC_PATH/users.d/s3_cache.xml $DEST_SERVER_PATH/users.d/
     ln -sf $SRC_PATH/users.d/s3_cache_new.xml $DEST_SERVER_PATH/users.d/
 fi

--- a/tests/queries/0_stateless/03755_create_merge_tree_with_s3_plain.sql
+++ b/tests/queries/0_stateless/03755_create_merge_tree_with_s3_plain.sql
@@ -1,0 +1,7 @@
+-- Tags: no-fasttest
+
+CREATE OR REPLACE TABLE t0 (c0 Int) ENGINE = MergeTree() ORDER BY tuple() SETTINGS storage_policy = 'policy_03755';
+INSERT INTO TABLE t0 (c0) VALUES (1); -- { serverError NOT_IMPLEMENTED }
+
+CREATE OR REPLACE TABLE t1 (c0 Int) ENGINE = MergeTree() ORDER BY tuple() SETTINGS non_replicated_deduplication_window = 2, storage_policy = 'policy_03755';
+INSERT INTO TABLE t1 (c0) VALUES (1); -- { serverError NOT_IMPLEMENTED }


### PR DESCRIPTION


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

In MergeTreeDeduplicationLog::load, if the disk is a storage object with Plain metadata, skip the check for logs_dir existence.
Because `Plain` metadata does not have the concept of directories.

Closes https://github.com/ClickHouse/ClickHouse/issues/86189



### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
