### PR TITLE
[DOCS] - update s3 queue engine docs

### DIFF
--- a/docs/en/engines/table-engines/integrations/s3queue.md
+++ b/docs/en/engines/table-engines/integrations/s3queue.md
@@ -89,6 +89,14 @@ SETTINGS
 
 To get a list of settings, configured for the table, use `system.s3_queue_settings` table. Available from `24.10`.
 
+:::note Setting Names (24.7+)
+Starting from version 24.7, S3Queue settings can be specified with or without the `s3queue_` prefix:
+- **Modern syntax** (24.7+): `processing_threads_num`, `tracked_file_ttl_sec`, etc.
+- **Legacy syntax** (all versions): `s3queue_processing_threads_num`, `s3queue_tracked_file_ttl_sec`, etc.
+
+Both forms are supported in 24.7+. The examples on this page use the modern unprefixed syntax.
+:::
+
 ### Mode {#mode}
 
 Possible values:
@@ -213,7 +221,7 @@ Possible values:
 
 Default value: `/`.
 
-### `s3queue_loading_retries` {#loading_retries}
+### `loading_retries` {#loading_retries}
 
 Retry file loading up to specified number of times. By default, there are no retries.
 Possible values:
@@ -222,13 +230,13 @@ Possible values:
 
 Default value: `0`.
 
-### `s3queue_processing_threads_num` {#processing_threads_num}
+### `processing_threads_num` {#processing_threads_num}
 
 Number of threads to perform processing. Applies only for `Unordered` mode.
 
 Default value: Number of CPUs or 16.
 
-### `s3queue_parallel_inserts` {#parallel_inserts}
+### `parallel_inserts` {#parallel_inserts}
 
 By default `processing_threads_num` will produce one `INSERT`, so it will only download files and parse in multiple threads.
 But this limits the parallelism, so for better throughput use `parallel_inserts=true`, this will allow to insert data in parallel (but keep in mind that it will result in higher number of generated data parts for MergeTree family).
@@ -239,13 +247,13 @@ But this limits the parallelism, so for better throughput use `parallel_inserts=
 
 Default value: `false`.
 
-### `s3queue_enable_logging_to_s3queue_log` {#enable_logging_to_s3queue_log}
+### `enable_logging_to_s3queue_log` {#enable_logging_to_s3queue_log}
 
 Enable logging to `system.s3queue_log`.
 
 Default value: `0`.
 
-### `s3queue_polling_min_timeout_ms` {#polling_min_timeout_ms}
+### `polling_min_timeout_ms` {#polling_min_timeout_ms}
 
 Specifies the minimum time, in milliseconds, that ClickHouse waits before making the next polling attempt.
 
@@ -255,7 +263,7 @@ Possible values:
 
 Default value: `1000`.
 
-### `s3queue_polling_max_timeout_ms` {#polling_max_timeout_ms}
+### `polling_max_timeout_ms` {#polling_max_timeout_ms}
 
 Defines the maximum time, in milliseconds, that ClickHouse waits before initiating the next polling attempt.
 
@@ -265,7 +273,7 @@ Possible values:
 
 Default value: `10000`.
 
-### `s3queue_polling_backoff_ms` {#polling_backoff_ms}
+### `polling_backoff_ms` {#polling_backoff_ms}
 
 Determines the additional wait time added to the previous polling interval when no new files are found. The next poll occurs after the sum of the previous interval and this backoff value, or the maximum interval, whichever is lower.
 
@@ -275,7 +283,7 @@ Possible values:
 
 Default value: `0`.
 
-### `s3queue_tracked_files_limit` {#tracked_files_limit}
+### `tracked_files_limit` {#tracked_files_limit}
 
 Allows to limit the number of Zookeeper nodes if the 'unordered' mode is used, does nothing for 'ordered' mode.
 If limit reached the oldest processed files will be deleted from ZooKeeper node and processed again.
@@ -286,7 +294,7 @@ Possible values:
 
 Default value: `1000`.
 
-### `s3queue_tracked_file_ttl_sec` {#tracked_file_ttl_sec}
+### `tracked_file_ttl_sec` {#tracked_file_ttl_sec}
 
 Maximum number of seconds to store processed files in ZooKeeper node (store forever by default) for 'unordered' mode, does nothing for 'ordered' mode.
 After the specified number of seconds, the file will be re-imported.
@@ -297,21 +305,21 @@ Possible values:
 
 Default value: `0`.
 
-### `s3queue_cleanup_interval_min_ms` {#cleanup_interval_min_ms}
+### `cleanup_interval_min_ms` {#cleanup_interval_min_ms}
 
 For 'Ordered' mode. Defines a minimum boundary for reschedule interval for a background task, which is responsible for maintaining tracked file TTL and maximum tracked files set.
 
 Default value: `10000`.
 
-### `s3queue_cleanup_interval_max_ms` {#cleanup_interval_max_ms}
+### `cleanup_interval_max_ms` {#cleanup_interval_max_ms}
 
 For 'Ordered' mode. Defines a maximum boundary for reschedule interval for a background task, which is responsible for maintaining tracked file TTL and maximum tracked files set.
 
 Default value: `30000`.
 
-### `s3queue_buckets` {#buckets}
+### `buckets` {#buckets}
 
-For 'Ordered' mode. Available since `24.6`. If there are several replicas of S3Queue table, each working with the same metadata directory in keeper, the value of `s3queue_buckets` needs to be equal to at least the number of replicas. If `s3queue_processing_threads` setting is used as well, it makes sense to increase the value of `s3queue_buckets` setting even further, as it defines the actual parallelism of `S3Queue` processing.
+For 'Ordered' mode. Available since `24.6`. If there are several replicas of S3Queue table, each working with the same metadata directory in keeper, the value of `buckets` needs to be equal to at least the number of replicas. If `processing_threads` setting is used as well, it makes sense to increase the value of `buckets` setting even further, as it defines the actual parallelism of `S3Queue` processing.
 
 ### `use_persistent_processing_nodes` {#use_persistent_processing_nodes}
 

--- a/docs/en/engines/table-engines/integrations/s3queue.md
+++ b/docs/en/engines/table-engines/integrations/s3queue.md
@@ -94,7 +94,7 @@ Starting from version 24.7, S3Queue settings can be specified with or without th
 - **Modern syntax** (24.7+): `processing_threads_num`, `tracked_file_ttl_sec`, etc.
 - **Legacy syntax** (all versions): `s3queue_processing_threads_num`, `s3queue_tracked_file_ttl_sec`, etc.
 
-Both forms are supported in 24.7+. The examples on this page use the modern unprefixed syntax.
+Both forms are supported in 24.7+. The examples on this page use the modern syntax with no prefix.
 :::
 
 ### Mode {#mode}


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)
