### PR TITLE
Set max message size on parquet v3 reader

### DIFF
--- a/src/Processors/Formats/Impl/Parquet/ThriftUtil.cpp
+++ b/src/Processors/Formats/Impl/Parquet/ThriftUtil.cpp
@@ -48,8 +48,7 @@ size_t deserializeThriftStruct(T & out, const char * buf, size_t limit)
 
         /// Set max message size to avoid 'apache::thrift::transport::TTransportException: MaxMessageSize reached' on big files
         /// Similar to https://github.com/ClickHouse/arrow/blob/5cfccd8ea65f33d4517e7409815d761c7650b45d/cpp/src/parquet/thrift_internal.h#L437
-        auto configuration = std::make_shared<apache::thrift::TConfiguration>();
-        configuration->setMaxMessageSize(std::numeric_limits<int>::max());
+        static auto configuration = std::make_shared<apache::thrift::TConfiguration>(/*maxMessageSize=*/ std::numeric_limits<int>::max());
 
         auto trans = std::make_shared<apache::thrift::transport::TMemoryBuffer>(cast_buf, uint32_t(limit), apache::thrift::transport::TMemoryBuffer::OBSERVE, configuration);
         apache::thrift::protocol::TCompactProtocolT<apache::thrift::transport::TMemoryBuffer> proto(trans);

--- a/src/Processors/Formats/Impl/Parquet/ThriftUtil.cpp
+++ b/src/Processors/Formats/Impl/Parquet/ThriftUtil.cpp
@@ -45,7 +45,13 @@ size_t deserializeThriftStruct(T & out, const char * buf, size_t limit)
         /// TMemoryBuffer promises to not write to the buffer (in OBSERVE mode),
         /// so it should be ok to const_cast.
         uint8_t * cast_buf = const_cast<uint8_t *>(reinterpret_cast<const uint8_t *>(buf));
-        auto trans = std::make_shared<apache::thrift::transport::TMemoryBuffer>(cast_buf, uint32_t(limit));
+
+	/// Set max message size to avoid 'apache::thrift::transport::TTransportException: MaxMessageSize reached' on big files
+	/// Similar to https://github.com/ClickHouse/arrow/blob/5cfccd8ea65f33d4517e7409815d761c7650b45d/cpp/src/parquet/thrift_internal.h#L437
+        auto configuration = std::make_shared<apache::thrift::TConfiguration>();
+        configuration->setMaxMessageSize(std::numeric_limits<int>::max());
+
+        auto trans = std::make_shared<apache::thrift::transport::TMemoryBuffer>(cast_buf, uint32_t(limit), apache::thrift::transport::TMemoryBuffer::OBSERVE, configuration);
         apache::thrift::protocol::TCompactProtocolT<apache::thrift::transport::TMemoryBuffer> proto(trans);
         uint32_t bytes_read = out.read(&proto);
         chassert(size_t(bytes_read + trans->available_read()) == limit);

--- a/src/Processors/Formats/Impl/Parquet/ThriftUtil.cpp
+++ b/src/Processors/Formats/Impl/Parquet/ThriftUtil.cpp
@@ -46,8 +46,8 @@ size_t deserializeThriftStruct(T & out, const char * buf, size_t limit)
         /// so it should be ok to const_cast.
         uint8_t * cast_buf = const_cast<uint8_t *>(reinterpret_cast<const uint8_t *>(buf));
 
-	/// Set max message size to avoid 'apache::thrift::transport::TTransportException: MaxMessageSize reached' on big files
-	/// Similar to https://github.com/ClickHouse/arrow/blob/5cfccd8ea65f33d4517e7409815d761c7650b45d/cpp/src/parquet/thrift_internal.h#L437
+        /// Set max message size to avoid 'apache::thrift::transport::TTransportException: MaxMessageSize reached' on big files
+        /// Similar to https://github.com/ClickHouse/arrow/blob/5cfccd8ea65f33d4517e7409815d761c7650b45d/cpp/src/parquet/thrift_internal.h#L437
         auto configuration = std::make_shared<apache::thrift::TConfiguration>();
         configuration->setMaxMessageSize(std::numeric_limits<int>::max());
 


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Set max message size on parquet v3 reader to avoid getting `DB::Exception: apache::thrift::transport::TTransportException: MaxMessageSize reached`

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
