### PR TITLE
Avoid timeouts in 03356_analyzer_unused_scalar_subquery

### DIFF
--- a/tests/queries/0_stateless/03356_analyzer_unused_scalar_subquery.sql
+++ b/tests/queries/0_stateless/03356_analyzer_unused_scalar_subquery.sql
@@ -1,16 +1,16 @@
 set enable_analyzer = 1;
 
 WITH (
-        SELECT sleepEachRow(2)
+        SELECT sleepEachRow(3)
     ) AS res
 SELECT *
 FROM system.one
 FORMAT Null
-SETTINGS max_execution_time = 1;
+SETTINGS max_execution_time = 2;
 
-WITH sleepEachRow(2) AS res
+WITH sleepEachRow(3) AS res
 SELECT *
 FROM system.one
 FORMAT Null
-SETTINGS max_execution_time = 1;
+SETTINGS max_execution_time = 2;
 


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Sometimes under sanitizers query is executed slightly more than 1 second. 2 seconds should be enough. Closes https://github.com/ClickHouse/ClickHouse/issues/89202

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
