### PR TITLE
Fix `too many open files` errors in integration tests

### DIFF
--- a/tests/integration/helpers/client.py
+++ b/tests/integration/helpers/client.py
@@ -192,9 +192,9 @@ class CommandRequest:
         self, command, stdin=None, timeout=None, ignore_error=False, parse=False, stdout_file_path=None, stderr_file_path=None, env = {}
     ):
         # Write data to tmp file to avoid PIPEs and execution blocking
-        stdin_file = tempfile.TemporaryFile(mode="w+")
-        stdin_file.write(stdin)
-        stdin_file.seek(0)
+        self.stdin_file = tempfile.TemporaryFile(mode="w+")
+        self.stdin_file.write(stdin)
+        self.stdin_file.seek(0)
         self.stdout_file = tempfile.TemporaryFile() if stdout_file_path is None else stdout_file_path
         self.stderr_file = tempfile.TemporaryFile() if stderr_file_path is None else stderr_file_path
         self.ignore_error = ignore_error
@@ -207,7 +207,7 @@ class CommandRequest:
         env["TSAN_OPTIONS"] = "use_sigaltstack=0 verbosity=0"
         self.process = sp.Popen(
             command,
-            stdin=stdin_file,
+            stdin=self.stdin_file,
             stdout=self.stdout_file,
             stderr=self.stderr_file,
             env=env,
@@ -243,6 +243,10 @@ class CommandRequest:
 
         stdout = self.stdout_file.read().decode("utf-8", errors="replace")
         stderr = self.stderr_file.read().decode("utf-8", errors="replace")
+
+        self.stdin_file.close()
+        self.stdout_file.close()
+        self.stderr_file.close()
 
         if (
             self.timer is not None
@@ -282,6 +286,10 @@ class CommandRequest:
         stdout = self.stdout_file.read().decode("utf-8", errors="replace")
         stderr = self.stderr_file.read().decode("utf-8", errors="replace")
 
+        self.stdin_file.close()
+        self.stdout_file.close()
+        self.stderr_file.close()
+
         if (
             self.timer is not None
             and not self.process_finished_before_timeout
@@ -305,6 +313,10 @@ class CommandRequest:
 
         stdout = self.stdout_file.read().decode("utf-8", errors="replace")
         stderr = self.stderr_file.read().decode("utf-8", errors="replace")
+
+        self.stdin_file.close()
+        self.stdout_file.close()
+        self.stderr_file.close()
 
         if (
             self.timer is not None

--- a/tests/integration/helpers/client.py
+++ b/tests/integration/helpers/client.py
@@ -236,17 +236,24 @@ class CommandRequest:
         ]
         return "\n".join(lines)
 
+    def wait_and_read_output(self):
+        try:
+            self.process.wait(timeout=DEFAULT_QUERY_TIMEOUT)
+            self.stdout_file.seek(0)
+            self.stderr_file.seek(0)
+
+            stdout = self.stdout_file.read().decode("utf-8", errors="replace")
+            stderr = self.stderr_file.read().decode("utf-8", errors="replace")
+
+            return stdout, stderr
+
+        finally:
+            self.stdin_file.close()
+            self.stdout_file.close()
+            self.stderr_file.close()
+
     def get_answer(self):
-        self.process.wait(timeout=DEFAULT_QUERY_TIMEOUT)
-        self.stdout_file.seek(0)
-        self.stderr_file.seek(0)
-
-        stdout = self.stdout_file.read().decode("utf-8", errors="replace")
-        stderr = self.stderr_file.read().decode("utf-8", errors="replace")
-
-        self.stdin_file.close()
-        self.stdout_file.close()
-        self.stderr_file.close()
+        stdout, stderr = self.wait_and_read_output()
 
         if (
             self.timer is not None
@@ -279,16 +286,7 @@ class CommandRequest:
         return stdout
 
     def get_error(self):
-        self.process.wait(timeout=DEFAULT_QUERY_TIMEOUT)
-        self.stdout_file.seek(0)
-        self.stderr_file.seek(0)
-
-        stdout = self.stdout_file.read().decode("utf-8", errors="replace")
-        stderr = self.stderr_file.read().decode("utf-8", errors="replace")
-
-        self.stdin_file.close()
-        self.stdout_file.close()
-        self.stderr_file.close()
+        stdout, stderr = self.wait_and_read_output()
 
         if (
             self.timer is not None
@@ -307,16 +305,7 @@ class CommandRequest:
         return stderr
 
     def get_answer_and_error(self):
-        self.process.wait(timeout=DEFAULT_QUERY_TIMEOUT)
-        self.stdout_file.seek(0)
-        self.stderr_file.seek(0)
-
-        stdout = self.stdout_file.read().decode("utf-8", errors="replace")
-        stderr = self.stderr_file.read().decode("utf-8", errors="replace")
-
-        self.stdin_file.close()
-        self.stdout_file.close()
-        self.stderr_file.close()
+        stdout, stderr = self.wait_and_read_output()
 
         if (
             self.timer is not None


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Probably `ulimit -n` setting was recently changed in the integration tests runner, and this fd leak started to become visible.
