### PR TITLE
CI: Stress tests: refactor errors check

### DIFF
--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -82,6 +82,7 @@ common_stress_job_config = Job.Config(
             "./tests/docker_scripts/",
             "./ci/docker/stress-test",
             "./ci/jobs/scripts/clickhouse_proc.py",
+            "./ci/jobs/scripts/log_parser.py",
         ],
     ),
     allow_merge_on_failure=True,
@@ -688,6 +689,7 @@ class JobConfigs:
                 "./ci/jobs/scripts/stress/stress.py",
                 "./tests/docker_scripts/",
                 "./ci/docker/stress-test",
+                "./ci/jobs/scripts/log_parser.py",
             ]
         ),
         allow_merge_on_failure=True,

--- a/ci/jobs/ast_fuzzer_job.py
+++ b/ci/jobs/ast_fuzzer_job.py
@@ -73,11 +73,12 @@ def run_fuzz_job(check_name: str):
     dmesg_log = workspace_path / "dmesg.log"
     fatal_log = workspace_path / "fatal.log"
     server_log = workspace_path / "server.log"
+    stderr_log = workspace_path / "stderr.log"
     paths = [
         workspace_path / "core.zst",
         workspace_path / "dmesg.log",
         fatal_log,
-        workspace_path / "stderr.log",
+        stderr_log,
         server_log,
         fuzzer_log,
         dmesg_log,
@@ -168,8 +169,11 @@ def run_fuzz_job(check_name: str):
     if is_failed and status != Result.Status.ERROR:
         # died server - lets fetch failure from log
         fuzzer_log_parser = FuzzerLogParser(
-            str(server_log),
-            str(workspace_path / "fuzzerout.sql" if buzzhouse else fuzzer_log),
+            server_log=str(server_log),
+            stderr_log=str(stderr_log),
+            fuzzer_log=str(
+                workspace_path / "fuzzerout.sql" if buzzhouse else fuzzer_log
+            ),
         )
         parsed_name, parsed_info = fuzzer_log_parser.parse_failure()
 

--- a/ci/jobs/scripts/log_parser.py
+++ b/ci/jobs/scripts/log_parser.py
@@ -46,9 +46,10 @@ class FuzzerLogParser:
         "SET",
     ]
 
-    def __init__(self, server_log, fuzzer_log, stack_trace_str=None):
+    def __init__(self, server_log, fuzzer_log="", stderr_log="", stack_trace_str=None):
         self.server_log = server_log
         self.fuzzer_log = fuzzer_log
+        self.stderr_log = stderr_log
         self.stack_trace_str = stack_trace_str
 
     def parse_failure(self):
@@ -89,17 +90,24 @@ class FuzzerLogParser:
 
         error_output = None
         for name, flag_name, pattern in error_patterns:
-            if self.server_log:
-                output = Shell.get_output(
-                    f"rg --text -A 10 -o '{pattern}' {self.server_log} | head -n10",
-                    strict=True,
-                )
-            else:
-                assert self.stack_trace_str
+            output = ""
+            if self.stack_trace_str:
                 output = Shell.get_output(
                     f"echo '{self.stack_trace_str}' | rg --text -A 10 -o '{pattern}' | head -n10",
                     strict=True,
                 )
+            else:
+                if flag_name == "is_sanitizer_error":
+                    assert self.stderr_log
+                    file = self.stderr_log
+                else:
+                    assert self.server_log
+                    file = self.server_log
+                output = Shell.get_output(
+                    f"rg --text -A 10 -o '{pattern}' {file} | head -n10",
+                    strict=True,
+                )
+
             if output:
                 error_output = output
                 if flag_name == "is_sanitizer_error":
@@ -265,31 +273,43 @@ class FuzzerLogParser:
 
     def get_sanitizer_stack_trace(self):
         # return all lines after Sanitizer error starting with "    #DIGITS "
+        def _extract_sanitizer_trace(log_file):
+            lines = []
+            sanitizer_pattern = re.compile(
+                r"(SUMMARY|ERROR|WARNING): [a-zA-Z]+Sanitizer:"
+            )
+            stack_frame_pattern = re.compile(r"^\s+#\d+\s+")
+            stack_frame_pattern_1st_line = re.compile(r"^\s+#0\s")
+            # Pattern to remove ANSI escape codes (colors from tools like ripgrep)
+            ansi_escape = re.compile(r"\x1b\[[0-9;]*m")
+
+            with open(log_file, "r", errors="replace") as file:
+                all_lines = file.readlines()
+
+            in_sanitizer_trace = False
+            for line in all_lines:
+                # Strip ANSI color codes before pattern matching
+                clean_line = ansi_escape.sub("", line)
+
+                if not in_sanitizer_trace:
+                    if stack_frame_pattern_1st_line.search(clean_line):
+                        in_sanitizer_trace = True
+                        lines.append(clean_line.strip())
+                else:
+                    if stack_frame_pattern.match(clean_line):
+                        lines.append(clean_line.strip())
+                    elif in_sanitizer_trace:
+                        # End of stack trace
+                        break
+            return lines
+
         lines = []
-        sanitizer_pattern = re.compile(r"(SUMMARY|ERROR|WARNING): [a-zA-Z]+Sanitizer:")
-        stack_frame_pattern = re.compile(r"^\s+#\d+\s+")
-        stack_frame_pattern_1st_line = re.compile(r"^\s+#0\s")
-        # Pattern to remove ANSI escape codes (colors from tools like ripgrep)
-        ansi_escape = re.compile(r"\x1b\[[0-9;]*m")
 
-        with open(self.server_log, "r", errors="replace") as file:
-            all_lines = file.readlines()
+        if self.stderr_log:
+            lines = _extract_sanitizer_trace(self.stderr_log)
+        else:
+            assert False, "No stderr log provided"
 
-        in_sanitizer_trace = False
-        for line in all_lines:
-            # Strip ANSI color codes before pattern matching
-            clean_line = ansi_escape.sub("", line)
-
-            if not in_sanitizer_trace:
-                if stack_frame_pattern_1st_line.search(clean_line):
-                    in_sanitizer_trace = True
-                    lines.append(clean_line.strip())
-            else:
-                if stack_frame_pattern.match(clean_line):
-                    lines.append(clean_line.strip())
-                elif in_sanitizer_trace:
-                    # End of stack trace
-                    break
         return "\n".join(lines) if lines else None
 
     def get_stack_trace(self):
@@ -497,6 +517,7 @@ class FuzzerLogParser:
         return commands_to_reproduce
 
     def _get_all_fuzzer_commands(self):
+        assert self.fuzzer_log, "Fuzzer log is not provided"
         error_logs = [
             "Fuzzing step",
             "Query succeeded",

--- a/ci/jobs/scripts/stress/stress.py
+++ b/ci/jobs/scripts/stress/stress.py
@@ -419,13 +419,16 @@ def main():
                     tee.stdin.close()
             if res != 0 and have_long_running_queries:
                 logging.info("Hung check failed with exit code %d", res)
-            else:
-                hung_check_status = "No queries hung\tOK\t\\N\t\n"
+                hung_check_status = (
+                    "Hung check failed, possible deadlock found\tFAIL\t\\N\t\n"
+                )
                 with open(
                     args.output_folder / "test_results.tsv", "w+", encoding="utf-8"
                 ) as results:
                     results.write(hung_check_status)
                     hung_check_log.unlink()
+            else:
+                logging.info("No queries hung")
 
     logging.info("Stress test finished")
 

--- a/ci/jobs/stress_job.py
+++ b/ci/jobs/stress_job.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import List, Tuple
 
 from ci.jobs.scripts.docker_image import DockerImage
+from ci.jobs.scripts.log_parser import FuzzerLogParser
 from ci.praktika.info import Info
 from ci.praktika.result import Result
 from ci.praktika.utils import Shell, Utils
@@ -205,15 +206,55 @@ def run_stress_test(upgrade_check: bool = False) -> None:
 
     subprocess.check_call(f"sudo chown -R ubuntu:ubuntu {temp_path}", shell=True)
 
-    state, description, test_results, additional_logs = process_results(
+    is_oom = False
+
+    if Path(result_path / "dmesg.log").is_file():
+        is_oom = Shell.check(
+            "grep -q -F -e 'Out of memory: Killed process' -e 'oom_reaper: reaped process' -e 'oom-kill:constraint=CONSTRAINT_NONE' "
+            f"{result_path}/dmesg.log"
+        )
+
+    # Check for OOM (signal 9) in server logs
+    if server_log_path.exists():
+        server_log_oom = Shell.check(
+            f"rg -Fqa ' <Fatal> Application: Child process was terminated by signal 9' "
+            f"{server_log_path}/clickhouse-server*.log"
+        )
+        is_oom = is_oom or server_log_oom
+
+    _state, _description, test_results, additional_logs = process_results(
         result_path, server_log_path
     )
 
+    server_died = False
+    for test_result in test_results:
+        if test_result.name == "Server died":
+            # error from stress.py
+            server_died = True
+    test_results = [r for r in test_results if not r.is_ok()]
+
+    if server_died:
+        server_err_log = server_log_path / "clickhouse-server.err.log"
+        stderr_log = server_log_path / "stderr.log"
+        log_parser = FuzzerLogParser(
+            server_log=server_err_log,
+            stderr_log=stderr_log if stderr_log.exists() else "",
+            fuzzer_log="",
+        )
+        name, description = log_parser.parse_failure()
+        test_results.append(
+            Result.create_from(name=name, info=description, status=Result.Status.FAILED)
+        )
+
     r = Result.create_from(
         results=test_results,
+        status=Result.Status.SUCCESS if not test_results else "",
         stopwatch=stopwatch,
-        info=description,
     )
+    if not r.is_ok() and is_oom:
+        r.set_status(Result.Status.SUCCESS)
+        r.set_info("OOM error (allowed in stress tests)")
+
     if not r.is_ok():
         r.set_files(additional_logs)
     r.complete_job()

--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -83,6 +83,9 @@ class Result(MetaClasses.Serializable):
         if isinstance(status, bool):
             status = Result.Status.SUCCESS if status else Result.Status.FAILED
         if not results and not status:
+            print(
+                "WARNING: No results and no status provided - setting status to error"
+            )
             status = Result.Status.ERROR
         if not name:
             name = _Environment.get().JOB_NAME

--- a/tests/docker_scripts/stress_runner.sh
+++ b/tests/docker_scripts/stress_runner.sh
@@ -10,10 +10,6 @@ dmesg --clear
 
 ln -s /repo/tests/clickhouse-test /usr/bin/clickhouse-test
 
-# Stress tests and upgrade check uses similar code that was placed
-# in a separate bash library. See tests/ci/stress_tests.lib
-# shellcheck source=../stateless/attach_gdb.lib
-source /repo/tests/docker_scripts/attach_gdb.lib
 # shellcheck source=../stateless/stress_tests.lib
 source /repo/tests/docker_scripts/stress_tests.lib
 
@@ -309,10 +305,6 @@ cd /repo/tests/ || exit 1  # clickhouse-test can find queries dir from there
 python3 /repo/ci/jobs/scripts/stress/stress.py --hung-check --drop-databases --output-folder /test_output --skip-func-tests "$SKIP_TESTS_OPTION" --global-time-limit 1200 --encrypted-storage "$USE_ENCRYPTED_STORAGE" \
     && echo -e "Test script exit code$OK" >> /test_output/test_results.tsv \
     || echo -e "Test script failed$FAIL script exit code: $?" >> /test_output/test_results.tsv
-
-# NOTE Hung check is implemented in docker/tests/stress/stress
-rg -Fa "No queries hung" /test_output/test_results.tsv | grep -Fa "OK" \
-  || echo -e "Hung check failed, possible deadlock found (see hung_check.log)$FAIL$(head_escaped /test_output/hung_check.log)" >> /test_output/test_results.tsv
 
 stop_server
 mv /var/log/clickhouse-server/clickhouse-server.log /var/log/clickhouse-server/clickhouse-server.stress.log

--- a/tests/docker_scripts/stress_tests.lib
+++ b/tests/docker_scripts/stress_tests.lib
@@ -262,8 +262,6 @@ function start_server()
         sleep 60
         counter=$((counter + 1))
     done
-
-    attach_gdb_to_clickhouse
 }
 
 function check_server_start()
@@ -279,25 +277,6 @@ function check_server_start()
 
 function check_logs_for_critical_errors()
 {
-    # Sanitizer asserts
-    sed -n '/WARNING:.*anitizer/,/^$/p' /var/log/clickhouse-server/stderr*.log >> /test_output/tmp
-    rg -Fav -e "ASan doesn't fully support makecontext/swapcontext functions" -e "DB::Exception" /test_output/tmp > /dev/null \
-        && echo -e "Sanitizer assert (in stderr.log)$FAIL$(head_escaped /test_output/tmp)" >> /test_output/test_results.tsv \
-        || echo -e "No sanitizer asserts$OK" >> /test_output/test_results.tsv
-    rm -f /test_output/tmp
-
-    # OOM
-    rg -Fa " <Fatal> Application: Child process was terminated by signal 9" /var/log/clickhouse-server/clickhouse-server*.log > /dev/null \
-        && echo -e "Signal 9 in clickhouse-server.log$FAIL" >> /test_output/test_results.tsv \
-        || echo -e "No OOM messages in clickhouse-server.log$OK" >> /test_output/test_results.tsv
-
-    # Logical errors
-    rg -Fa "Code: 49. DB::Exception: " /var/log/clickhouse-server/clickhouse-server*.log > /test_output/logical_errors.txt \
-        && echo -e "Logical error thrown (see clickhouse-server.log or logical_errors.txt)$FAIL$(head_escaped /test_output/logical_errors.txt)" >> /test_output/test_results.tsv \
-        || echo -e "No logical errors$OK" >> /test_output/test_results.tsv
-    # Remove file logical_errors.txt if it's empty
-    [ -s /test_output/logical_errors.txt ] || rm /test_output/logical_errors.txt
-
     # ignore:
     #  - a.myext which is used in 02724_database_s3.sh and does not exist
     #  - "DistributedCacheTCPHandler" and "caller id: None:DistribCache" because they happen inside distributed cache server
@@ -315,38 +294,10 @@ function check_logs_for_critical_errors()
     # Remove file no_such_key_errors.txt if it's empty
     [ -s /test_output/no_such_key_errors.txt ] || rm /test_output/no_such_key_errors.txt
 
-    # Crash. This must have fewer '#'s than the command below, otherwise the command below will match
-    # the echo of this command (if set -x is enabled, and this script's stdout is sent
-    # to /test_output/run.log).
-    rg -Fa "#######################################" /var/log/clickhouse-server/clickhouse-server*.log > /dev/null \
-        && echo -e "Killed by signal (in clickhouse-server.log)$FAIL" >> /test_output/test_results.tsv \
-        || echo -e "Not crashed$OK" >> /test_output/test_results.tsv
-
-    # It also checks for crash without stacktrace (printed by watchdog)
-    rg -Fa " <Fatal> " /var/log/clickhouse-server/clickhouse-server*.log > /test_output/fatal_messages.txt \
-        && echo -e "Fatal message in clickhouse-server.log (see fatal_messages.txt)$FAIL$(trim_server_logs fatal_messages.txt)" >> /test_output/test_results.tsv \
-        || echo -e "No fatal messages in clickhouse-server.log$OK" >> /test_output/test_results.tsv
-
     # Remove file fatal_messages.txt if it's empty
     [ -s /test_output/fatal_messages.txt ] || rm /test_output/fatal_messages.txt
 
-    rg -Faz "########################################" /test_output/* | rg -v "rg -Faz " > /dev/null \
-      && echo -e "Killed by signal (output files)$FAIL" >> /test_output/test_results.tsv
-
-    function get_gdb_log_context()
-    {
-        rg -A50 -Fa " received signal " /test_output/gdb.log | head_escaped
-    }
-
-    rg -Fa " received signal " /test_output/gdb.log > /dev/null \
-        && echo -e "Found signal in gdb.log$FAIL$(get_gdb_log_context)" >> /test_output/test_results.tsv
-
     dmesg -T > /test_output/dmesg.log
-
-    # OOM in dmesg -- those are real
-    grep -q -F -e 'Out of memory: Killed process' -e 'oom_reaper: reaped process' -e 'oom-kill:constraint=CONSTRAINT_NONE' /test_output/dmesg.log \
-        && echo -e "OOM in dmesg$FAIL$(head_escaped /test_output/dmesg.log)" >> /test_output/test_results.tsv \
-        || echo -e "No OOM in dmesg$OK" >> /test_output/test_results.tsv
 }
 
 function collect_query_and_trace_logs()

--- a/tests/docker_scripts/upgrade_runner.sh
+++ b/tests/docker_scripts/upgrade_runner.sh
@@ -382,10 +382,5 @@ rowNumberInAllBlocks()
 LIMIT 1" < /test_output/test_results.tsv > /test_output/check_status.tsv || echo -e "failure\tCannot parse test_results.tsv" > /test_output/check_status.tsv
 [ -s /test_output/check_status.tsv ] || echo -e "success\tNo errors found" > /test_output/check_status.tsv
 
-# But OOMs in stress test are allowed
-if rg 'OOM in dmesg|Signal 9' /test_output/check_status.tsv
-then
-    sed -i 's/failure/success/' /test_output/check_status.tsv
-fi
 
 collect_core_dumps


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Goal: Unify all segfaults, sanitizer, logical errors in CI, so that they can be matched across all jobs.

- Logical error must have fully qualified name
- Segfault or sanitizer error - must have stack trace id
- Drop all OK results in job report
