### PR TITLE
Fix flaky test_storage_s3_queue/test.py::test_failed_startup

### DIFF
--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
@@ -816,9 +816,15 @@ void ObjectStorageQueueMetadata::unregisterNonActive(const StorageID & storage_i
             bool node_exists = zk_client->tryGet(registry_path, registry_str, &stat);
             if (!node_exists)
             {
-                LOG_WARNING(log, "Cannot unregister: registry does not exist");
-                if (!is_retry)
+                if (is_retry)
+                {
+                    LOG_TRACE(log, "Table is unregistered after retry");
+                }
+                else
+                {
+                    LOG_WARNING(log, "Cannot unregister: registry does not exist");
                     chassert(false);
+                }
                 return;
             }
 

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
@@ -672,10 +672,18 @@ void ObjectStorageQueueMetadata::registerNonActive(const StorageID & storage_id,
             bool registry_exists = zk_client->tryGet(registry_path, registry_str, &stat);
             if (registry_exists)
             {
-                created_new_metadata = false;
-
                 Strings registered;
                 splitInto<','>(registered, registry_str);
+
+                if (zk_retries.isRetry() && registered.size() == 1 && (Info::deserialize(registered[0]) == self))
+                {
+                    LOG_TRACE(log, "Table {} is already registered after retry", self.table_id);
+                    created_new_metadata = true;
+                    code = Coordination::Error::ZOK;
+                    return;
+                }
+
+                created_new_metadata = false;
 
                 for (const auto & elem : registered)
                 {
@@ -685,7 +693,7 @@ void ObjectStorageQueueMetadata::registerNonActive(const StorageID & storage_id,
                     auto info = Info::deserialize(elem);
                     if (info == self)
                     {
-                        LOG_TRACE(log, "Table {} is already registered", self.table_id);
+                        LOG_TRACE(log, "Table {} is already registered ({})", self.table_id, registered.size());
                         code = Coordination::Error::ZOK;
                         return;
                     }

--- a/tests/integration/test_storage_s3_queue/test_5.py
+++ b/tests/integration/test_storage_s3_queue/test_5.py
@@ -1031,11 +1031,12 @@ def test_failed_startup(started_cluster):
     # Wait for table data to be removed.
     uuid = node.query(f"select uuid from system.tables where name = '{table_name}'").strip()
     wait_message = f"StorageObjectStorageQueue({keeper_path}): Table '{uuid}' has been removed from the registry"
+    wait_message_2 = f"StorageObjectStorageQueue({keeper_path}): Table is unregistered after retry"
     for _ in range(50):
-        if node.contains_in_log(wait_message):
+        if node.contains_in_log(wait_message) or node.contains_in_log(wait_message_2):
             break
         time.sleep(1)
-    assert node.contains_in_log(wait_message)
+    assert node.contains_in_log(wait_message) or node.contains_in_log(wait_message_2)
 
     try:
         zk.get(f"{keeper_path}")


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
