### PR TITLE
Fix flaky tests in test_filesystem_cache

### DIFF
--- a/tests/integration/test_filesystem_cache/test.py
+++ b/tests/integration/test_filesystem_cache/test.py
@@ -135,7 +135,7 @@ def test_parallel_cache_loading_on_startup(cluster, node_name):
     node.query(
         """
         SYSTEM DROP FILESYSTEM CACHE;
-        INSERT INTO test SELECT * FROM generateRandom('a Int32, b String') LIMIT 1000000;
+        INSERT INTO test SELECT * FROM generateRandom('a Int32, b String') LIMIT 100000;
         SELECT * FROM test FORMAT Null;
         """
     )

--- a/tests/integration/test_filesystem_cache/test.py
+++ b/tests/integration/test_filesystem_cache/test.py
@@ -461,8 +461,7 @@ def test_force_filesystem_cache_on_merges(cluster):
         node.query(
             """
             SYSTEM DROP FILESYSTEM CACHE;
-            INSERT INTO test SELECT * FROM generateRandom('a Int32, b String') LIMIT 1000000;
-            INSERT INTO test SELECT * FROM generateRandom('a Int32, b String') LIMIT 1000000;
+            INSERT INTO test SELECT * FROM generateRandom('a Int32, b String') LIMIT 100000;
             """
         )
         assert int(node.query("SELECT count() FROM system.filesystem_cache")) > 0

--- a/tests/integration/test_filesystem_cache/test.py
+++ b/tests/integration/test_filesystem_cache/test.py
@@ -135,7 +135,7 @@ def test_parallel_cache_loading_on_startup(cluster, node_name):
     node.query(
         """
         SYSTEM DROP FILESYSTEM CACHE;
-        INSERT INTO test SELECT * FROM generateRandom('a Int32, b String') LIMIT 100000;
+        INSERT INTO test SELECT * FROM generateRandom('a Int32, b String') LIMIT 1000;
         SELECT * FROM test FORMAT Null;
         """
     )
@@ -461,7 +461,7 @@ def test_force_filesystem_cache_on_merges(cluster):
         node.query(
             """
             SYSTEM DROP FILESYSTEM CACHE;
-            INSERT INTO test SELECT * FROM generateRandom('a Int32, b String') LIMIT 100000;
+            INSERT INTO test SELECT * FROM generateRandom('a Int32, b String') LIMIT 1000;
             """
         )
         assert int(node.query("SELECT count() FROM system.filesystem_cache")) > 0


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

The error is:
```
E   helpers.client.QueryRuntimeException: Client failed! Return code: 76, stderr: Received exception from server (version 25.12.1):
E   Code: 76. DB::Exception: Received from 172.16.1.5:9000. DB::ErrnoException. DB::ErrnoException: Cannot open file /sys/kyvhqjsnylgmlnaiixafkjatfpkgt: , errno: 30, strerror: Read-only file system. Stack trace:
```
It ran out of disk space.
Closes https://github.com/ClickHouse/ClickHouse/issues/91414
Closes https://github.com/ClickHouse/ClickHouse/issues/91387

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
