### PR TITLE
Deflake test_zookeeper_connection_log

### DIFF
--- a/tests/integration/test_zookeeper_connection_log/test.py
+++ b/tests/integration/test_zookeeper_connection_log/test.py
@@ -108,7 +108,7 @@ def test_zookeeper_connection_log(started_cluster):
                 logging.debug(
                     f"Checking for 8 rows in zookeeper_connection_log, got: {res}"
                 )
-                return res == "8\n"
+                return int(res) >= 8
 
             node1.query_with_retry(
                 f"SELECT count() FROM system.zookeeper_connection_log WHERE event_time_microseconds >= '{test_start_time}'",
@@ -123,10 +123,31 @@ def test_zookeeper_connection_log(started_cluster):
 
             logging.debug(
                 node1.query(
-                    """SELECT event_time_microseconds, hostname, type, name, host, port, index, keeper_api_version, enabled_feature_flags, reason
+                    """SELECT event_time_microseconds, client_id, hostname, type, name, host, port, index, keeper_api_version, enabled_feature_flags, reason
                                FROM system.zookeeper_connection_log  ORDER BY event_time_microseconds"""
                 )
             )
+            logging.debug(
+                node1.query(
+                    f"""SELECT hostname, type, name, host, port, reason, count() AS cnt,
+                               groupArray(client_id) AS client_ids
+                           FROM system.zookeeper_connection_log
+                          WHERE event_time_microseconds >= '{test_start_time}'
+                          GROUP BY hostname, type, name, host, port, reason
+                          ORDER BY min(event_time_microseconds)"""
+                )
+            )
+            normalized_rows = node1.query(
+                f"""SELECT hostname, type, name, host, port, index, keeper_api_version,
+                               arrayFilter(x -> has(enabled_feature_flags, x),
+                                           ['FILTERED_LIST','MULTI_READ','CHECK_NOT_EXISTS','CREATE_IF_NOT_EXISTS','REMOVE_RECURSIVE','MULTI_WATCHES']) AS enabled_feature_flags,
+                               reason
+                          FROM system.zookeeper_connection_log
+                         WHERE event_time_microseconds >= '{test_start_time}'
+                         ORDER BY event_time_microseconds
+                         LIMIT 1 BY hostname, type, name, host, port, reason"""
+            )
+            logging.debug("Normalized rows used in comparison:\n" + normalized_rows)
             expected = TSV(
                 """node1	Connected	default	zoo1	2181	0	0	['FILTERED_LIST','MULTI_READ','CHECK_NOT_EXISTS','CREATE_IF_NOT_EXISTS','REMOVE_RECURSIVE','MULTI_WATCHES']	Initialization
 node1	Connected	zk_conn_log_test_2	zoo2	2181	0	0	['FILTERED_LIST','MULTI_READ','CHECK_NOT_EXISTS','CREATE_IF_NOT_EXISTS','REMOVE_RECURSIVE','MULTI_WATCHES']	Initialization
@@ -139,17 +160,7 @@ node1	Disconnected	zk_conn_log_test_3	zoo3	2181	0	0	['FILTERED_LIST','MULTI_READ
 node1	Connected	zk_conn_log_test_4	zoo2	2181	0	0	['FILTERED_LIST','MULTI_READ','CHECK_NOT_EXISTS','CREATE_IF_NOT_EXISTS','REMOVE_RECURSIVE','MULTI_WATCHES']	Initialization"""
             )
 
-            assert (
-                TSV(
-                    node1.query(
-                        f"""SELECT hostname, type, name, host, port, index, keeper_api_version, enabled_feature_flags, reason
-                               FROM system.zookeeper_connection_log
-                               WHERE event_time_microseconds >= '{test_start_time}'
-                               ORDER BY event_time_microseconds"""
-                    )
-                )
-                == expected
-            )
+            assert TSV(normalized_rows) == expected
             assert (
                 int(
                     node1.query(


### PR DESCRIPTION
Deflakes tests/integration/test_zookeeper_connection_log/test.py by tolerating nondeterminism (duplicate identical connection events, env-only feature flags).

**Root Cause (from CI logs):**
- Duplicate initial connect row (same logical event twice):
```
node1 Connected default zoo1 … Initialization
node1 Connected default zoo1 … Initialization   <-- duplicate in actual
node1 Connected zk_conn_log_test_2 zoo2 … Initialization
```

- Feature flags drift (env/build-specific):
```
ACTUAL:   ['FILTERED_LIST','MULTI_READ','CHECK_NOT_EXISTS','CREATE_IF_NOT_EXISTS','REMOVE_RECURSIVE','MULTI_WATCHES','CREATE_WITH_STATS']
EXPECTED: ['FILTERED_LIST','MULTI_READ','CHECK_NOT_EXISTS','CREATE_IF_NOT_EXISTS','REMOVE_RECURSIVE','MULTI_WATCHES']
```

- Unstable Connection explains duplicates:
```
Zookeeper connection established, state: CONNECTED
Connection dropped: socket connection broken
Transition to CONNECTING
Zookeeper connection lost
…
Zookeeper connection established, state: CONNECTED
```

Closes https://github.com/ClickHouse/ClickHouse/issues/91028

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
