### PR TITLE
Format negate operator outer parentheses even if inner are enabled

### DIFF
--- a/src/Parsers/ASTFunction.cpp
+++ b/src/Parsers/ASTFunction.cpp
@@ -342,7 +342,9 @@ void ASTFunction::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSetting
                 /// We DO need parentheses around a single literal
                 /// For example, SELECT (NOT 0) + (NOT 0) cannot be transformed into SELECT NOT 0 + NOT 0, since
                 /// this is equal to SELECT NOT (0 + NOT 0)
-                bool outside_parens = frame.need_parens && !inside_parens;
+                /// We need it even if inside parentheses are eanbled
+                /// Otherwise SELECT (-(1)).1 becomes SELECT -(1).1 which is equal to SELECT -(1.1)
+                bool outside_parens = frame.need_parens;
 
                 /// Do not add extra parentheses for functions inside negate, i.e. -(-toUInt64(-(1)))
                 if (inside_parens)
@@ -513,7 +515,7 @@ void ASTFunction::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSetting
                 }
 
                 // It can be printed in a form of 'x.1' only if right hand side
-                // is an unsigned integer lineral. We also allow nonnegative
+                // is an unsigned integer literal. We also allow nonnegative
                 // signed integer literals, because the fuzzer sometimes inserts
                 // them, and we want to have consistent formatting.
                 if (tuple_arguments_valid && lit_right)

--- a/src/Parsers/ExpressionListParsers.cpp
+++ b/src/Parsers/ExpressionListParsers.cpp
@@ -2333,7 +2333,7 @@ std::unique_ptr<Layer> getFunctionLayer(ASTPtr identifier, bool is_table_functio
 
     /// NOT is always parsed as an operator, because there is no difference between
     /// the operator form: NOT (1 + 2), and the functional form: not(1 + 2), when the operand has to be in parentheses.
-    if (function_name_lowercase == "not" && !is_table_function)
+    if (function_name_lowercase == "not")
         return std::make_unique<FunctionLayer>(function_name_lowercase, allow_function_parameters_, false, true);
 
     return std::make_unique<FunctionLayer>(function_name, allow_function_parameters_, identifier->as<ASTIdentifier>()->compound());

--- a/tests/queries/0_stateless/03755_format_negate_operator.reference
+++ b/tests/queries/0_stateless/03755_format_negate_operator.reference
@@ -1,0 +1,8 @@
+SELECT (-(2)).1
+FROM system.one
+SELECT (-(\'a\')).1
+FROM system.one
+SELECT 1
+FROM foo(bar[NOT (2 > 1)])
+SELECT (-(-foo))[bar]
+FROM system.one

--- a/tests/queries/0_stateless/03755_format_negate_operator.sql
+++ b/tests/queries/0_stateless/03755_format_negate_operator.sql
@@ -1,3 +1,6 @@
+-- Old analyzer performs type checks and explain queries throw errors
+SET enable_analyzer=1;
+
 EXPLAIN SYNTAX SELECT (-(2)).1;
 EXPLAIN SYNTAX SELECT (-'a').1;
 EXPLAIN SYNTAX SELECT 1 FROM foo(bar[NOT 2 > 1]);

--- a/tests/queries/0_stateless/03755_format_negate_operator.sql
+++ b/tests/queries/0_stateless/03755_format_negate_operator.sql
@@ -1,0 +1,32 @@
+EXPLAIN SYNTAX SELECT (-(2)).1;
+EXPLAIN SYNTAX SELECT (-'a').1;
+EXPLAIN SYNTAX SELECT 1 FROM foo(bar[NOT 2 > 1]);
+EXPLAIN SYNTAX SELECT (-(-foo))[bar];
+
+-- Fuzzed
+SELECT aggThrow(`t0d0`.`c1`), (-'你们').5
+FROM d1.`t26` AS t0d0
+    LEFT ARRAY JOIN `t0d0`.`c0.size0` AS `a0`,
+    `t0d0`.`c0.null` AS `a1`
+    ARRAY JOIN `t0d0`.`c0`[4] AS `a2`
+QUALIFY addSeconds(now(), 56)::Time IS NULL
+ORDER BY emptyArrayUInt32() ASC NULLS LAST
+INTO OUTFILE '/var/lib/clickhouse/user_files/file.data' TRUNCATE
+FORMAT Null; -- { serverError UNKNOWN_DATABASE }
+
+SELECT 0.13.5, `t3d0`.`c3`
+FROM generate_series(35::Int64, 306601) AS t0d0
+    PASTE JOIN deltaLakeCluster(IPv4NumToString(`t0d0`.`generate_series`), '-501:48:29'::Time, (`t0d0`.`generate_series`[(NOT `t0d0`.`generate_series` > ALL(SELECT toRelativeYearNum(`t0d0`.`generate_series`).5 LIMIT 5))] AS `a0`)) AS t1d0
+    RIGHT JOIN d0.`t17` AS t3d0 ON `t1d0`.`c1` = `t3d0`.`c0` AND equals(`t1d0`.`c1`, `t3d0`.`c2.size0`[313594649253062377481]) AND (NOT `t0d0`.`generate_series` = `t3d0`.`c2.values`)
+    ANTI RIGHT JOIN d0.`t0` AS t4d0 ON or(`t3d0`.`c2.size0` = `t4d0`.`c0`, `a0` = `t4d0`.`c0`)
+GROUP BY ROLLUP(`t3d0`.`c3`, 1, `a0`, randBinomial(26::Int64, max(`t3d0`.`c2.values`)), `t4d0`.`c0`.`Float64`) WITH TOTALS
+ORDER BY 2 DESC NULLS FIRST, randBinomial(26::Int64, max(`t3d0`.`c2.values`)) ASC NULLS FIRST, `a0` ASC NULLS LAST
+INTO OUTFILE '/var/lib/clickhouse/user_files/file.data' TRUNCATE COMPRESSION 'snappy' FORMAT Null; -- { serverError UNKNOWN_DATABASE }
+
+SELECT '2066-01-26'::Date, (-(-`t0d0`.`c1.null`))[`t0d0`.`c1.null`]
+FROM d0.`t2` AS t0d0
+    FULL JOIN d0.`t2` AS t1d0 ON (NOT `t1d0`.`c1.null` = `t0d0`.`c1`)
+PREWHERE `t0d0`.`c1.null` = `t1d0`.`c1`.`Tuple(Decimal)`
+WHERE equals(`t1d0`.`c1.null`, addSeconds(now(), 68)::Time)
+GROUP BY ROLLUP(`t0d0`.`c1.null`, `t0d0`.`_table`)
+HAVING 37::Int16 < `t0d0`.`_table`; -- { serverError UNKNOWN_DATABASE }


### PR DESCRIPTION
Closes: #91542
Closes: #91832


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `negate` operator formatting
