### PR TITLE
Fix delta lake setting delta_lake_snapshot_version

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
@@ -447,7 +447,12 @@ void TableSnapshot::updateSettings(const DB::ContextPtr & context)
     enable_expression_visitor_logging = settings[DB::Setting::delta_lake_enable_expression_visitor_logging];
     throw_on_engine_visitor_error = settings[DB::Setting::delta_lake_throw_on_engine_predicate_error];
     enable_engine_predicate = settings[DB::Setting::delta_lake_enable_engine_predicate];
-    if (settings[DB::Setting::delta_lake_snapshot_version].value != LATEST_SNAPSHOT_VERSION)
+
+    if (settings[DB::Setting::delta_lake_snapshot_version].value == LATEST_SNAPSHOT_VERSION)
+    {
+        snapshot_version_to_read = std::nullopt;
+    }
+    else
     {
         if (settings[DB::Setting::delta_lake_snapshot_version].value < 0)
             throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Snapshot version cannot be a negative value");

--- a/tests/integration/test_storage_delta/test.py
+++ b/tests/integration/test_storage_delta/test.py
@@ -2441,13 +2441,18 @@ deltaLake(
             ).strip()
         )
 
-    def check_data(expected, version):
-        assert (
-            expected
-            == node.query(
-                f"SELECT * FROM {delta_function} ORDER BY all SETTINGS delta_lake_snapshot_version = {version}"
-            ).strip()
-        )
+    def check_data(expected, version, table=None):
+        if table is None:
+            table = delta_function
+        if version is not None:
+            assert (
+                expected
+                == node.query(
+                    f"SELECT * FROM {table} ORDER BY all SETTINGS delta_lake_snapshot_version = {version}"
+                ).strip()
+            )
+        else:
+            assert expected == node.query(f"SELECT * FROM {table} ORDER BY all").strip()
 
     def append_data(df):
         df.write.option("mergeSchema", "true").mode("append").format(
@@ -2500,6 +2505,31 @@ deltaLake(
             f"SELECT naam FROM {delta_function} WHERE age = 51",
             settings={"delta_lake_snapshot_version": 2},
         ).strip()
+    )
+    node.query(
+        f"""
+CREATE TABLE {table_name} (naam String, age Int32) ENGINE = DeltaLake(
+        'http://{started_cluster.minio_ip}:{started_cluster.minio_port}/root/{table_name}' ,
+        '{minio_access_key}',
+        '{minio_secret_key}')
+    """
+    )
+    df = spark.createDataFrame([("cap", 91), ("cip", 92), ("cop", 93)]).toDF(
+        "naam", "age"
+    )
+    append_data(df)
+    check_data(
+        "aelin\t51\nalice\t47\nanora\t23\nbill\t33\nbob\t12\nbober\t49\ncap\t91\ncip\t92\ncop\t93",
+        3,
+        table_name,
+    )
+    check_data(
+        "aelin\t51\nalice\t47\nanora\t23\nbill\t33\nbob\t12\nbober\t49", 2, table_name
+    )
+    check_data(
+        "aelin\t51\nalice\t47\nanora\t23\nbill\t33\nbob\t12\nbober\t49\ncap\t91\ncip\t92\ncop\t93",
+        None,
+        table_name,
     )
 
 
@@ -3838,7 +3868,9 @@ def test_truncate(started_cluster):
     instance.query(
         f"CREATE TABLE {table_name} (id Int32, name String) ENGINE = DeltaLake('http://{started_cluster.minio_ip}:{started_cluster.minio_port}/{bucket}/{result_file}/', 'minio', '{minio_secret_key}')"
     )
-    instance.query(f"INSERT INTO {table_name} SELECT number as name, toString(number) as id from numbers(10)")
+    instance.query(
+        f"INSERT INTO {table_name} SELECT number as name, toString(number) as id from numbers(10)"
+    )
 
     assert 10 == int(instance.query(f"SELECT count() FROM {table_name}"))
 
@@ -3852,5 +3884,7 @@ def test_truncate(started_cluster):
         return count
 
     assert count_files() == 3
-    assert "not supported" in instance.query_and_get_error(f"TRUNCATE TABLE {table_name}")
+    assert "not supported" in instance.query_and_get_error(
+        f"TRUNCATE TABLE {table_name}"
+    )
     assert count_files() == 3


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix delta lake setting `delta_lake_snapshot_version` which could give incorrect result when used with table engine (not table function) and value -1 (disabled) after snapshot version was used before that. Closes https://github.com/ClickHouse/ClickHouse/issues/87676

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
