### PR TITLE
CI: Stress tests: fix stderr log path

### DIFF
--- a/ci/jobs/scripts/check_ci.py
+++ b/ci/jobs/scripts/check_ci.py
@@ -296,6 +296,9 @@ Test output:
         if self.job_type in (JobTypes.FINISH_WORKFLOW):
             print("This issue should be fixed before merge - cannot handle it")
             return False
+        if "OOM" in self.test_name:
+            print("Cannot handle OOM errors - continue")
+            return False
         return True
 
     def check_issue(self):


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes:
```
Traceback (most recent call last):

  File "/home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/./ci/jobs/stress_job.py", line 264, in <module>

    run_stress_test()

  File "/home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/./ci/jobs/stress_job.py", line 244, in run_stress_test

    name, description = log_parser.parse_failure()

  File "/home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/ci/jobs/scripts/log_parser.py", line 101, in parse_failure

    assert self.stderr_log

AssertionError
```