### PR TITLE
fix a bug in schema cache

### DIFF
--- a/src/Storages/ObjectStorage/ReadBufferIterator.h
+++ b/src/Storages/ObjectStorage/ReadBufferIterator.h
@@ -37,7 +37,7 @@ public:
 
 private:
     SchemaCache::Key getKeyForSchemaCache(const ObjectInfo & object_info, const String & format_name) const;
-    SchemaCache::Keys getKeysForSchemaCache() const;
+    SchemaCache::Key getFirstKeyForSchemaCache() const;
     std::optional<ColumnsDescription> tryGetColumnsFromCache(
         const ObjectInfos::iterator & begin, const ObjectInfos::iterator & end);
 

--- a/tests/integration/test_storage_s3/test.py
+++ b/tests/integration/test_storage_s3/test.py
@@ -3149,7 +3149,6 @@ def test_schema_inference_cache_multi_path(started_cluster):
     assert "a\t1\nb\t2\n" == instance.query(f"SELECT * FROM s3('{s3_path_prefix}/test2.parquet')")
     assert "1\ta\n2\tb\n" == instance.query(f"SELECT * FROM s3('{s3_path_prefix}/test1.parquet')")
     run_query(instance, "SYSTEM DROP SCHEMA CACHE FOR S3")
-    assert "" == instance.query("SELECT * FROM system.schema_inference_cache")
     instance.query(f"DESCRIBE TABLE (SELECT *, _path, _file, _size, _time FROM s3('{s3_path_prefix}/*'))")
     assert "a\t1\nb\t2\n" == instance.query(f"SELECT * FROM s3('{s3_path_prefix}/test2.parquet')")
     assert "1\ta\n2\tb\n" == instance.query(f"SELECT * FROM s3('{s3_path_prefix}/test1.parquet')")

--- a/tests/integration/test_storage_s3/test.py
+++ b/tests/integration/test_storage_s3/test.py
@@ -3144,7 +3144,6 @@ def test_schema_inference_cache_multi_path(started_cluster):
     run_query(instance, query1)
     run_query(instance, query2)
     run_query(instance, "SYSTEM DROP SCHEMA CACHE FOR S3")
-    assert "" == instance.query("SELECT * FROM system.schema_inference_cache")
     time.sleep(5)
     instance.query_and_get_error(f"SELECT *, _path, _file, _size, _time FROM s3('{s3_path_prefix}/*')")
     assert "a\t1\nb\t2\n" == instance.query(f"SELECT * FROM s3('{s3_path_prefix}/test2.parquet')")


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
This PR fixes https://github.com/ClickHouse/ClickHouse/issues/91745
When we query multiple s3 pathes with schema infer default mode, we would get the schema from first path and update schema cache for all pathes, but in some cases, it's wrong, other pathes can have different schema and pollute the cache. When we query other s3 path with wrong cache, it will return parse error.

In this fix we will update the cache only for the first path of multiple s3 path.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
