### PR TITLE
Do not throw logical error when fallback to greedy join order algorithm is not specified

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/joinOrder.cpp
+++ b/src/Processors/QueryPlan/Optimizations/joinOrder.cpp
@@ -33,6 +33,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
+    extern const int EXPERIMENTAL_FEATURE_ERROR;
 }
 
 DPJoinEntry::DPJoinEntry(size_t id, std::optional<UInt64> rows)
@@ -223,6 +224,8 @@ std::shared_ptr<DPJoinEntry> JoinOrderOptimizer::solve()
                 break;
             case JoinOrderAlgorithm::GREEDY:
                 best_plan = solveGreedy();
+                if (!best_plan)
+                    throw Exception(ErrorCodes::LOGICAL_ERROR, "Failed to find a valid join order with greedy algorithm");
                 break;
         }
 
@@ -231,7 +234,8 @@ std::shared_ptr<DPJoinEntry> JoinOrderOptimizer::solve()
     }
 
     if (!best_plan)
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Failed to find a valid join order");
+        throw Exception(ErrorCodes::EXPERIMENTAL_FEATURE_ERROR,
+            "Failed to find a valid join order, try adding 'greedy' algorithm as fallback to query_plan_optimize_join_order_algorithm setting.");
 
     LOG_TRACE(log, "Optimized join order in {:.2f} ms, best plan cost: {}, estimated cardinality: {}",
         watch.elapsed() / 1000.0, best_plan->cost, best_plan->estimated_rows ? toString(*best_plan->estimated_rows) : "unknown");

--- a/tests/queries/0_stateless/03733_join_order_dp.reference
+++ b/tests/queries/0_stateless/03733_join_order_dp.reference
@@ -46,3 +46,6 @@ Expression ((Project names + (Projection + )))
               Expression ((WHERE + Change column names to column identifiers))
                 ReadFromMergeTree (default.R4)
 5684007341784604324
+===========================================
+Fallback to greedy
+1

--- a/tests/queries/0_stateless/03733_join_order_dp.sql
+++ b/tests/queries/0_stateless/03733_join_order_dp.sql
@@ -130,3 +130,15 @@ WHERE
     AND T1.A_Description = 'Type H'
     AND T4.D_LookupCode = 'Lookup S'
 SETTINGS query_plan_optimize_join_order_algorithm = 'dpsize';
+
+
+SELECT '===========================================';
+SELECT 'Fallback to greedy';
+
+SELECT 1 FROM (SELECT 1 c0) t0 LEFT JOIN (SELECT 1 c0) t1 ON t0.c0 = t1.c0
+SETTINGS query_plan_optimize_join_order_algorithm = 'dpsize'; --{serverError EXPERIMENTAL_FEATURE_ERROR}
+
+SELECT 1 FROM (SELECT 1 c0) t0 LEFT JOIN (SELECT 1 c0) t1 ON t0.c0 = t1.c0
+SETTINGS query_plan_optimize_join_order_algorithm = 'dpsize,greedy';
+
+

--- a/tests/queries/0_stateless/03733_join_order_dp.sql
+++ b/tests/queries/0_stateless/03733_join_order_dp.sql
@@ -136,9 +136,9 @@ SELECT '===========================================';
 SELECT 'Fallback to greedy';
 
 SELECT 1 FROM (SELECT 1 c0) t0 LEFT JOIN (SELECT 1 c0) t1 ON t0.c0 = t1.c0
-SETTINGS query_plan_optimize_join_order_algorithm = 'dpsize'; --{serverError EXPERIMENTAL_FEATURE_ERROR}
+SETTINGS query_plan_optimize_join_order_algorithm = 'dpsize', enable_parallel_replicas=0; --{serverError EXPERIMENTAL_FEATURE_ERROR}
 
 SELECT 1 FROM (SELECT 1 c0) t0 LEFT JOIN (SELECT 1 c0) t1 ON t0.c0 = t1.c0
-SETTINGS query_plan_optimize_join_order_algorithm = 'dpsize,greedy';
+SETTINGS query_plan_optimize_join_order_algorithm = 'dpsize,greedy', enable_parallel_replicas=0;
 
 


### PR DESCRIPTION
Fixes #91907

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
