### PR TITLE
Refine marks cache metrics to track only queries

### DIFF
--- a/src/IO/ReadSettings.h
+++ b/src/IO/ReadSettings.h
@@ -43,8 +43,6 @@ struct ReadSettings
     /// For 'pread_threadpool'/'io_uring' method. Lower value is higher priority.
     Priority priority;
 
-    bool load_marks_asynchronously = true;
-
     size_t remote_fs_read_max_backoff_ms = 10000;
     size_t remote_fs_read_backoff_max_tries = 4;
 

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -287,7 +287,6 @@ namespace Setting
     extern const SettingsUInt64 hsts_max_age;
     extern const SettingsString local_filesystem_read_method;
     extern const SettingsBool local_filesystem_read_prefetch;
-    extern const SettingsBool load_marks_asynchronously;
     extern const SettingsUInt64 max_backup_bandwidth;
     extern const SettingsUInt64 max_local_read_bandwidth;
     extern const SettingsUInt64 max_local_write_bandwidth;
@@ -6992,8 +6991,6 @@ ReadSettings Context::getReadSettings() const
 
     res.local_fs_prefetch = settings_ref[Setting::local_filesystem_read_prefetch];
     res.remote_fs_prefetch = settings_ref[Setting::remote_filesystem_read_prefetch];
-
-    res.load_marks_asynchronously = settings_ref[Setting::load_marks_asynchronously];
 
     res.enable_filesystem_read_prefetches_log = settings_ref[Setting::enable_filesystem_read_prefetches_log];
 

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -308,7 +308,7 @@ ReadFromMergeTree::ReadFromMergeTree(
         {},
         query_info_.row_level_filter,
         query_info_.prewhere_info)), all_column_names_, query_info_, storage_snapshot_, context_)
-    , reader_settings(MergeTreeReaderSettings::create(context_, *data_.getSettings(), query_info_))
+    , reader_settings(MergeTreeReaderSettings::createForQuery(context_, *data_.getSettings(), query_info_))
     , prepared_parts(std::move(parts_))
     , mutations_snapshot(std::move(mutations_))
     , all_column_names(std::move(all_column_names_))
@@ -2101,7 +2101,7 @@ ReadFromMergeTree::AnalysisResultPtr ReadFromMergeTree::selectRangesToRead(
 
         MergeTreeDataSelectExecutor::filterPartsByQueryConditionCache(res_parts, query_info_, vector_search_parameters, mutations_snapshot, context_, log);
 
-        auto reader_settings = MergeTreeReaderSettings::create(context_, *data.getSettings(), query_info_);
+        auto reader_settings = MergeTreeReaderSettings::createForQuery(context_, *data.getSettings(), query_info_);
         result.parts_with_ranges = MergeTreeDataSelectExecutor::filterPartsByPrimaryKeyAndSkipIndexes(
             res_parts,
             metadata_snapshot,

--- a/src/Storages/MarkCache.h
+++ b/src/Storages/MarkCache.h
@@ -51,13 +51,23 @@ public:
     /// Calculate key from path to file.
     static UInt128 hash(const String & path_to_file);
 
-    MappedPtr get(const Key & key)
+    MappedPtr get(const Key & key) = delete;
+
+    MappedPtr getForAsyncLoading(const Key & key)
     {
         auto result = Base::get(key);
         if (result)
             ProfileEvents::increment(ProfileEvents::MarkCacheHits);
-        else
-            ProfileEvents::increment(ProfileEvents::MarkCacheMisses);
+        /// Note: MarkCacheMisses is not incremented for async marks loading since cache misses will be handled by getOrSet()
+        return result;
+    }
+
+    /// Use this method when you do not need to update MarkCacheMisses/MarkCacheHits, i.e.:
+    /// - merges/mutations - they do not affect queries and marks are typically not cached for them.
+    /// - parts loading
+    MappedPtr getWithoutMetrics(const Key & key)
+    {
+        auto result = Base::get(key);
         return result;
     }
 

--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -1679,7 +1679,7 @@ UInt64 IMergeTreeDataPart::readExistingRowsCount()
         /*uncompressed_cache=*/{},
         storage.getContext()->getMarkCache().get(),
         nullptr,
-        MergeTreeReaderSettings{},
+        MergeTreeReaderSettings::createFromSettings(),
         ValueSizeMap{},
         ReadBufferFromFileBase::ProfileCallback{});
 
@@ -2738,10 +2738,10 @@ ColumnPtr IMergeTreeDataPart::getColumnSample(const NameAndTypePair & column) co
 
     StorageMetadataPtr metadata_ptr = storage.getInMemoryMetadataPtr();
     StorageSnapshotPtr storage_snapshot_ptr = std::make_shared<StorageSnapshot>(storage, metadata_ptr);
-    MergeTreeReaderSettings settings;
+
     /// We need to read only prefixes, so no data will be read.
     /// Use read settings without prefetches/filesystem cache/etc.
-    settings.read_settings = getReadSettingsForMetadata();
+    MergeTreeReaderSettings settings = MergeTreeReaderSettings::createFromSettings(getReadSettingsForMetadata());
     settings.can_read_part_without_marks = true;
     /// Use prefixes deserialization thread pool to read prefixes faster.
     /// In JSON type there might be hundreds of small files that needs to be read.

--- a/src/Storages/MergeTree/MergeTreeBlockReadUtils.cpp
+++ b/src/Storages/MergeTree/MergeTreeBlockReadUtils.cpp
@@ -477,7 +477,7 @@ MergeTreeReadTaskColumns getReadTaskColumnsForMerge(
         mutation_steps,
         /*index_read_tasks*/ {},
         /*actions_settings=*/ {},
-        /*reader_settings=*/ {},
+        /*reader_settings=*/ MergeTreeReaderSettings::createFromSettings(),
         storage_snapshot->storage.supportsSubcolumns());
 }
 

--- a/src/Storages/MergeTree/MergeTreeDataPartCompact.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartCompact.cpp
@@ -161,8 +161,6 @@ void MergeTreeDataPartCompact::loadMarksToCache(const Names & column_names, Mark
         return;
 
     auto context = storage.getContext();
-    auto read_settings = context->getReadSettings();
-    auto * load_marks_threadpool = read_settings.load_marks_asynchronously ? &context->getLoadMarksThreadpool() : nullptr;
     auto info_for_read = std::make_shared<LoadedMergeTreeDataPartInfoForReader>(shared_from_this(), std::make_shared<AlterConversions>());
 
     LOG_TEST(getLogger("MergeTreeDataPartCompact"), "Loading marks into mark cache for columns {} of part {}", toString(column_names), name);
@@ -174,8 +172,8 @@ void MergeTreeDataPartCompact::loadMarksToCache(const Names & column_names, Mark
         index_granularity->getMarksCount(),
         index_granularity_info,
         /*save_marks_in_cache=*/ true,
-        read_settings,
-        load_marks_threadpool,
+        context->getReadSettings(),
+        /*load_marks_threadpool_=*/ nullptr,
         index_granularity_info.mark_type.with_substreams ? columns_substreams.getTotalSubstreams() : columns.size());
 
     loader.loadMarks();

--- a/src/Storages/MergeTree/MergeTreeDataPartWide.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartWide.cpp
@@ -239,7 +239,6 @@ void MergeTreeDataPartWide::loadMarksToCache(const Names & column_names, MarkCac
 
     auto context = storage.getContext();
     auto read_settings = context->getReadSettings();
-    auto * load_marks_threadpool = read_settings.load_marks_asynchronously ? &context->getLoadMarksThreadpool() : nullptr;
     auto info_for_read = std::make_shared<LoadedMergeTreeDataPartInfoForReader>(shared_from_this(), std::make_shared<AlterConversions>());
 
     LOG_TEST(getLogger("MergeTreeDataPartWide"), "Loading marks into mark cache for columns {} of part {}", toString(column_names), name);
@@ -264,7 +263,7 @@ void MergeTreeDataPartWide::loadMarksToCache(const Names & column_names, MarkCac
                 index_granularity_info,
                 /*save_marks_in_cache=*/ true,
                 read_settings,
-                load_marks_threadpool,
+                /*load_marks_threadpool=*/ nullptr,
                 /*num_columns_in_mark=*/ 1));
 
             loaders.back()->startAsyncLoad();

--- a/src/Storages/MergeTree/MergeTreeIOSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeIOSettings.cpp
@@ -26,6 +26,7 @@ namespace Setting
     extern const SettingsUInt64 max_streams_for_merge_tree_reading;
     extern const SettingsBool use_query_condition_cache;
     extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool load_marks_asynchronously;
     extern const SettingsBool query_condition_cache_store_conditions_as_plaintext;
     extern const SettingsBool merge_tree_use_deserialization_prefixes_cache;
     extern const SettingsBool merge_tree_use_prefixes_deserialization_thread_pool;
@@ -113,6 +114,7 @@ MergeTreeReaderSettings MergeTreeReaderSettings::createForQuery(const ContextPtr
     result.merge_tree_min_rows_for_seek = settings[Setting::merge_tree_min_rows_for_seek];
     result.filesystem_prefetches_limit = settings[Setting::filesystem_prefetches_limit];
     result.enable_analyzer = settings[Setting::allow_experimental_analyzer];
+    result.load_marks_asynchronously = settings[Setting::load_marks_asynchronously];
     return result;
 }
 
@@ -120,7 +122,7 @@ MergeTreeReaderSettings MergeTreeReaderSettings::createForMergeMutation(ReadSett
 {
     MergeTreeReaderSettings result;
     result.read_settings = std::move(read_settings);
-    result.read_settings.load_marks_asynchronously = false;
+    result.load_marks_asynchronously = false;
     result.save_marks_in_cache = false;
     result.can_read_part_without_marks = true;
     return result;
@@ -130,6 +132,7 @@ MergeTreeReaderSettings MergeTreeReaderSettings::createFromSettings(ReadSettings
 {
     MergeTreeReaderSettings result;
     result.read_settings = std::move(read_settings);
+    result.load_marks_asynchronously = false;
     return result;
 }
 

--- a/src/Storages/MergeTree/MergeTreeIOSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeIOSettings.cpp
@@ -91,7 +91,7 @@ MergeTreeWriterSettings::MergeTreeWriterSettings(
 {
 }
 
-MergeTreeReaderSettings MergeTreeReaderSettings::createForQuery(const ContextPtr & context, const MergeTreeSettings & /*storage_settings*/, const SelectQueryInfo & query_info)
+MergeTreeReaderSettings MergeTreeReaderSettings::createFromContext(const ContextPtr & context)
 {
     const auto & settings = context->getSettingsRef();
 
@@ -99,7 +99,6 @@ MergeTreeReaderSettings MergeTreeReaderSettings::createForQuery(const ContextPtr
     result.read_settings = context->getReadSettings();
     result.save_marks_in_cache = true;
     result.checksum_on_read = settings[Setting::checksum_on_read];
-    result.read_in_order = query_info.input_order_info != nullptr;
     result.apply_deleted_mask = settings[Setting::apply_deleted_mask];
     result.use_asynchronous_read_from_pool = settings[Setting::allow_asynchronous_read_from_io_pool_for_merge_tree]
         && (settings[Setting::max_streams_to_max_threads_ratio] > 1 || settings[Setting::max_streams_for_merge_tree_reading] > 1);
@@ -115,6 +114,13 @@ MergeTreeReaderSettings MergeTreeReaderSettings::createForQuery(const ContextPtr
     result.filesystem_prefetches_limit = settings[Setting::filesystem_prefetches_limit];
     result.enable_analyzer = settings[Setting::allow_experimental_analyzer];
     result.load_marks_asynchronously = settings[Setting::load_marks_asynchronously];
+    return result;
+}
+
+MergeTreeReaderSettings MergeTreeReaderSettings::createForQuery(const ContextPtr & context, const MergeTreeSettings & /*storage_settings*/, const SelectQueryInfo & query_info)
+{
+    auto result = createFromContext(context);
+    result.read_in_order = query_info.input_order_info != nullptr;
     return result;
 }
 

--- a/src/Storages/MergeTree/MergeTreeIOSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeIOSettings.cpp
@@ -120,6 +120,7 @@ MergeTreeReaderSettings MergeTreeReaderSettings::createForMergeMutation(ReadSett
 {
     MergeTreeReaderSettings result;
     result.read_settings = std::move(read_settings);
+    result.read_settings.load_marks_asynchronously = false;
     result.save_marks_in_cache = false;
     result.can_read_part_without_marks = true;
     return result;

--- a/src/Storages/MergeTree/MergeTreeIOSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeIOSettings.cpp
@@ -90,29 +90,46 @@ MergeTreeWriterSettings::MergeTreeWriterSettings(
 {
 }
 
-MergeTreeReaderSettings MergeTreeReaderSettings::create(const ContextPtr & context, const MergeTreeSettings & /*storage_settings*/, const SelectQueryInfo & query_info)
+MergeTreeReaderSettings MergeTreeReaderSettings::createForQuery(const ContextPtr & context, const MergeTreeSettings & /*storage_settings*/, const SelectQueryInfo & query_info)
 {
     const auto & settings = context->getSettingsRef();
-    return {
-        .read_settings = context->getReadSettings(),
-        .save_marks_in_cache = true,
-        .checksum_on_read = settings[Setting::checksum_on_read],
-        .read_in_order = query_info.input_order_info != nullptr,
-        .apply_deleted_mask = settings[Setting::apply_deleted_mask],
-        .use_asynchronous_read_from_pool = settings[Setting::allow_asynchronous_read_from_io_pool_for_merge_tree]
-            && (settings[Setting::max_streams_to_max_threads_ratio] > 1 || settings[Setting::max_streams_for_merge_tree_reading] > 1),
-        .enable_multiple_prewhere_read_steps = settings[Setting::enable_multiple_prewhere_read_steps],
-        .force_short_circuit_execution = settings[Setting::query_plan_merge_filters],
-        .use_query_condition_cache = settings[Setting::use_query_condition_cache] && settings[Setting::allow_experimental_analyzer],
-        .query_condition_cache_store_conditions_as_plaintext = settings[Setting::query_condition_cache_store_conditions_as_plaintext],
-        .use_deserialization_prefixes_cache = settings[Setting::merge_tree_use_deserialization_prefixes_cache],
-        .use_prefixes_deserialization_thread_pool = settings[Setting::merge_tree_use_prefixes_deserialization_thread_pool],
-        .secondary_indices_enable_bulk_filtering = settings[Setting::secondary_indices_enable_bulk_filtering],
-        .merge_tree_min_bytes_for_seek = settings[Setting::merge_tree_min_bytes_for_seek],
-        .merge_tree_min_rows_for_seek = settings[Setting::merge_tree_min_rows_for_seek],
-        .filesystem_prefetches_limit = settings[Setting::filesystem_prefetches_limit],
-        .enable_analyzer = settings[Setting::allow_experimental_analyzer],
-    };
+
+    MergeTreeReaderSettings result;
+    result.read_settings = context->getReadSettings();
+    result.save_marks_in_cache = true;
+    result.checksum_on_read = settings[Setting::checksum_on_read];
+    result.read_in_order = query_info.input_order_info != nullptr;
+    result.apply_deleted_mask = settings[Setting::apply_deleted_mask];
+    result.use_asynchronous_read_from_pool = settings[Setting::allow_asynchronous_read_from_io_pool_for_merge_tree]
+        && (settings[Setting::max_streams_to_max_threads_ratio] > 1 || settings[Setting::max_streams_for_merge_tree_reading] > 1);
+    result.enable_multiple_prewhere_read_steps = settings[Setting::enable_multiple_prewhere_read_steps];
+    result.force_short_circuit_execution = settings[Setting::query_plan_merge_filters];
+    result.use_query_condition_cache = settings[Setting::use_query_condition_cache] && settings[Setting::allow_experimental_analyzer];
+    result.query_condition_cache_store_conditions_as_plaintext = settings[Setting::query_condition_cache_store_conditions_as_plaintext];
+    result.use_deserialization_prefixes_cache = settings[Setting::merge_tree_use_deserialization_prefixes_cache];
+    result.use_prefixes_deserialization_thread_pool = settings[Setting::merge_tree_use_prefixes_deserialization_thread_pool];
+    result.secondary_indices_enable_bulk_filtering = settings[Setting::secondary_indices_enable_bulk_filtering];
+    result.merge_tree_min_bytes_for_seek = settings[Setting::merge_tree_min_bytes_for_seek];
+    result.merge_tree_min_rows_for_seek = settings[Setting::merge_tree_min_rows_for_seek];
+    result.filesystem_prefetches_limit = settings[Setting::filesystem_prefetches_limit];
+    result.enable_analyzer = settings[Setting::allow_experimental_analyzer];
+    return result;
+}
+
+MergeTreeReaderSettings MergeTreeReaderSettings::createForMergeMutation(ReadSettings read_settings)
+{
+    MergeTreeReaderSettings result;
+    result.read_settings = std::move(read_settings);
+    result.save_marks_in_cache = false;
+    result.can_read_part_without_marks = true;
+    return result;
+}
+
+MergeTreeReaderSettings MergeTreeReaderSettings::createFromSettings(ReadSettings read_settings)
+{
+    MergeTreeReaderSettings result;
+    result.read_settings = std::move(read_settings);
+    return result;
 }
 
 }

--- a/src/Storages/MergeTree/MergeTreeIOSettings.h
+++ b/src/Storages/MergeTree/MergeTreeIOSettings.h
@@ -68,6 +68,7 @@ struct MergeTreeReaderSettings
     bool enable_analyzer = false;
     bool load_marks_asynchronously = false;
 
+    static MergeTreeReaderSettings createFromContext(const ContextPtr & context);
     /// Note storage_settings used only in private, do not remove
     static MergeTreeReaderSettings createForQuery(const ContextPtr & context, const MergeTreeSettings & storage_settings, const SelectQueryInfo & query_info);
     static MergeTreeReaderSettings createForMergeMutation(ReadSettings read_settings);

--- a/src/Storages/MergeTree/MergeTreeIOSettings.h
+++ b/src/Storages/MergeTree/MergeTreeIOSettings.h
@@ -68,7 +68,12 @@ struct MergeTreeReaderSettings
     bool enable_analyzer = false;
 
     /// Note storage_settings used only in private, do not remove
-    static MergeTreeReaderSettings create(const ContextPtr & context, const MergeTreeSettings & storage_settings, const SelectQueryInfo & query_info);
+    static MergeTreeReaderSettings createForQuery(const ContextPtr & context, const MergeTreeSettings & storage_settings, const SelectQueryInfo & query_info);
+    static MergeTreeReaderSettings createForMergeMutation(ReadSettings read_settings);
+    static MergeTreeReaderSettings createFromSettings(ReadSettings read_settings = {});
+
+private:
+    MergeTreeReaderSettings() = default;
 };
 
 struct MergeTreeWriterSettings

--- a/src/Storages/MergeTree/MergeTreeIOSettings.h
+++ b/src/Storages/MergeTree/MergeTreeIOSettings.h
@@ -66,6 +66,7 @@ struct MergeTreeReaderSettings
     UInt64 merge_tree_min_rows_for_seek = 0;
     size_t filesystem_prefetches_limit = 0;
     bool enable_analyzer = false;
+    bool load_marks_asynchronously = false;
 
     /// Note storage_settings used only in private, do not remove
     static MergeTreeReaderSettings createForQuery(const ContextPtr & context, const MergeTreeSettings & storage_settings, const SelectQueryInfo & query_info);

--- a/src/Storages/MergeTree/MergeTreeIndexReader.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexReader.cpp
@@ -37,7 +37,7 @@ std::unique_ptr<MergeTreeReaderStream> makeIndexReaderStream(
     MergeTreeReaderSettings settings)
 {
     auto context = part->storage.getContext();
-    auto * load_marks_threadpool = settings.read_settings.load_marks_asynchronously ? &context->getLoadMarksThreadpool() : nullptr;
+    auto * load_marks_threadpool = settings.load_marks_asynchronously ? &context->getLoadMarksThreadpool() : nullptr;
 
     auto marks_loader = std::make_shared<MergeTreeMarksLoader>(
         std::make_shared<LoadedMergeTreeDataPartInfoForReader>(part, std::make_shared<AlterConversions>()),

--- a/src/Storages/MergeTree/MergeTreeLazilyReader.cpp
+++ b/src/Storages/MergeTree/MergeTreeLazilyReader.cpp
@@ -262,12 +262,8 @@ void MergeTreeLazilyReader::transformLazyColumns(
     chassert(row_num_column->size() == part_num_column->size());
     const size_t rows_size = row_num_column->size();
 
-    ReadSettings read_settings;
-    MergeTreeReaderSettings reader_settings =
-    {
-        .read_settings = read_settings,
-        .save_marks_in_cache = true,
-    };
+    MergeTreeReaderSettings reader_settings = MergeTreeReaderSettings::createFromSettings();
+    reader_settings.save_marks_in_cache = true;
 
     MutableColumns lazily_read_columns;
     lazily_read_columns.resize(columns_size);

--- a/src/Storages/MergeTree/MergeTreeLazilyReader.cpp
+++ b/src/Storages/MergeTree/MergeTreeLazilyReader.cpp
@@ -87,12 +87,13 @@ MergeTreeLazilyReader::MergeTreeLazilyReader(
     const MergeTreeData & storage_,
     const StorageSnapshotPtr & storage_snapshot_,
     const LazilyReadInfoPtr & lazily_read_info_,
-    const ContextPtr & context_,
+    const ContextPtr & context,
     const AliasToName & alias_index_)
     : storage(storage_)
     , data_part_infos(lazily_read_info_->data_part_infos)
     , storage_snapshot(storage_snapshot_)
-    , use_uncompressed_cache(context_->getSettingsRef()[Setting::use_uncompressed_cache])
+    , use_uncompressed_cache(context->getSettingsRef()[Setting::use_uncompressed_cache])
+    , reader_settings(MergeTreeReaderSettings::createFromContext(context))
 {
     NameSet columns_name_set;
 
@@ -114,10 +115,7 @@ MergeTreeLazilyReader::MergeTreeLazilyReader(
     }
 }
 
-void MergeTreeLazilyReader::readLazyColumns(
-    const MergeTreeReaderSettings & reader_settings,
-    const PartIndexToRowOffsets & part_to_row_offsets,
-    MutableColumns & lazily_read_columns)
+void MergeTreeLazilyReader::readLazyColumns(const PartIndexToRowOffsets & part_to_row_offsets, MutableColumns & lazily_read_columns)
 {
     const auto columns_size = lazily_read_columns.size();
 
@@ -262,9 +260,6 @@ void MergeTreeLazilyReader::transformLazyColumns(
     chassert(row_num_column->size() == part_num_column->size());
     const size_t rows_size = row_num_column->size();
 
-    MergeTreeReaderSettings reader_settings = MergeTreeReaderSettings::createFromSettings();
-    reader_settings.save_marks_in_cache = true;
-
     MutableColumns lazily_read_columns;
     lazily_read_columns.resize(columns_size);
 
@@ -283,7 +278,7 @@ void MergeTreeLazilyReader::transformLazyColumns(
     matchDataPartToRowOffsets(row_num_column, part_num_column, part_to_row_offsets, permutation);
 
     /// Actually read the lazily materialized column data from MergeTree.
-    readLazyColumns(reader_settings, part_to_row_offsets, lazily_read_columns);
+    readLazyColumns(part_to_row_offsets, lazily_read_columns);
 
     /// Restore the original order of the rows.
     for (size_t i = 0; i < lazily_read_columns.size(); ++i)

--- a/src/Storages/MergeTree/MergeTreeLazilyReader.h
+++ b/src/Storages/MergeTree/MergeTreeLazilyReader.h
@@ -29,7 +29,7 @@ public:
         const MergeTreeData & storage_,
         const StorageSnapshotPtr & storage_snapshot_,
         const LazilyReadInfoPtr & lazily_read_info_,
-        const ContextPtr & context_,
+        const ContextPtr & context,
         const AliasToName & alias_index_);
 
     void transformLazyColumns(
@@ -37,10 +37,7 @@ public:
         ColumnsWithTypeAndName & res_columns);
 
 private:
-    void readLazyColumns(
-        const MergeTreeReaderSettings & reader_settings,
-        const PartIndexToRowOffsets & part_to_row_offsets,
-        MutableColumns & lazily_read_columns);
+    void readLazyColumns(const PartIndexToRowOffsets & part_to_row_offsets, MutableColumns & lazily_read_columns);
 
     const MergeTreeData & storage;
     DataPartInfoByIndexPtr data_part_infos;
@@ -48,6 +45,7 @@ private:
     bool use_uncompressed_cache;
     Names requested_column_names;
     ColumnsWithTypeAndName lazy_columns;
+    MergeTreeReaderSettings reader_settings;
 };
 
 using MergeTreeLazilyReaderPtr = std::unique_ptr<MergeTreeLazilyReader>;

--- a/src/Storages/MergeTree/MergeTreeMarksLoader.cpp
+++ b/src/Storages/MergeTree/MergeTreeMarksLoader.cpp
@@ -240,7 +240,7 @@ MarkCache::MappedPtr MergeTreeMarksLoader::loadMarksSync()
         }
         else
         {
-            loaded_marks = mark_cache->get(key);
+            loaded_marks = mark_cache->getWithoutMetrics(key);
             if (!loaded_marks)
                 loaded_marks = loadMarksImpl();
         }
@@ -264,7 +264,7 @@ std::future<MarkCache::MappedPtr> MergeTreeMarksLoader::loadMarksAsync()
     /// Avoid queueing jobs into thread pool if marks are in cache
     auto data_part_storage = data_part_reader->getDataPartStorage();
     auto key = MarkCache::hash(fs::path(data_part_storage->getFullPath()) / mrk_path);
-    if (MarkCache::MappedPtr loaded_marks = mark_cache->get(key))
+    if (MarkCache::MappedPtr loaded_marks = mark_cache->getForAsyncLoading(key))
     {
         ProfileEvents::increment(ProfileEvents::MarksTasksFromCache);
         auto promise = std::promise<MarkCache::MappedPtr>();

--- a/src/Storages/MergeTree/MergeTreeReadTask.h
+++ b/src/Storages/MergeTree/MergeTreeReadTask.h
@@ -129,7 +129,7 @@ public:
         UncompressedCache * uncompressed_cache = nullptr;
         MarkCache * mark_cache = nullptr;
         PatchJoinCache * patch_join_cache = nullptr;
-        MergeTreeReaderSettings reader_settings{};
+        MergeTreeReaderSettings reader_settings;
         StorageSnapshotPtr storage_snapshot{};
         ValueSizeMap value_size_map{};
         ReadBufferFromFileBase::ProfileCallback profile_callback{};

--- a/src/Storages/MergeTree/MergeTreeReaderCompact.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderCompact.cpp
@@ -50,8 +50,7 @@ MergeTreeReaderCompact::MergeTreeReaderCompact(
         data_part_info_for_read_->getIndexGranularityInfo(),
         settings.save_marks_in_cache,
         settings.read_settings,
-        settings_.read_settings.load_marks_asynchronously
-            ? &data_part_info_for_read_->getContext()->getLoadMarksThreadpool() : nullptr,
+        settings_.load_marks_asynchronously ? &data_part_info_for_read_->getContext()->getLoadMarksThreadpool() : nullptr,
         data_part_info_for_read_->getIndexGranularityInfo().mark_type.with_substreams
             ? columns_substreams.getTotalSubstreams() : data_part_info_for_read_->getColumns().size()))
     , profile_callback(profile_callback_)

--- a/src/Storages/MergeTree/MergeTreeReaderWide.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderWide.cpp
@@ -277,7 +277,7 @@ void MergeTreeReaderWide::addStreams(
 MergeTreeReaderWide::FileStreams::iterator MergeTreeReaderWide::addStream(const ISerialization::SubstreamPath & substream_path, const String & stream_name)
 {
     auto context = data_part_info_for_read->getContext();
-    auto * load_marks_threadpool = settings.read_settings.load_marks_asynchronously ? &context->getLoadMarksThreadpool() : nullptr;
+    auto * load_marks_threadpool = settings.load_marks_asynchronously ? &context->getLoadMarksThreadpool() : nullptr;
     size_t num_marks_in_part = data_part_info_for_read->getMarksCount();
 
     auto marks_loader = std::make_shared<MergeTreeMarksLoader>(

--- a/src/Storages/MergeTree/MergeTreeSequentialSource.cpp
+++ b/src/Storages/MergeTree/MergeTreeSequentialSource.cpp
@@ -171,18 +171,11 @@ MergeTreeSequentialSource::MergeTreeSequentialSource(
             break;
     }
 
-    MergeTreeReaderSettings reader_settings =
-    {
-        .read_settings = read_settings,
-        .save_marks_in_cache = false,
-        .can_read_part_without_marks = true,
-    };
-
     MergeTreeReadTask::Extras extras =
     {
         .mark_cache = mark_cache.get(),
         .patch_join_cache = patch_join_cache.get(),
-        .reader_settings = reader_settings,
+        .reader_settings = MergeTreeReaderSettings::createForMergeMutation(std::move(read_settings)),
         .storage_snapshot = storage_snapshot,
     };
 

--- a/src/Storages/MergeTree/checkDataPart.cpp
+++ b/src/Storages/MergeTree/checkDataPart.cpp
@@ -432,7 +432,6 @@ IMergeTreeDataPart::Checksums checkDataPart(
         read_settings.enable_filesystem_cache_log = false;
         read_settings.enable_filesystem_read_prefetches_log = false;
         read_settings.page_cache = nullptr;
-        read_settings.load_marks_asynchronously = false;
         read_settings.remote_fs_prefetch = false;
         read_settings.page_cache_inject_eviction = false;
         read_settings.use_page_cache_for_disks_without_file_cache = false;

--- a/tests/queries/0_stateless/03759_marks_cache_events.reference
+++ b/tests/queries/0_stateless/03759_marks_cache_events.reference
@@ -1,5 +1,5 @@
 "query_kind","load_marks_asynchronously","hits","misses"
-"Insert","",0,0
+"Insert","0",0,0
 "Select","0",0,1
 "Select","0",1,0
 "Select","1",0,1

--- a/tests/queries/0_stateless/03759_marks_cache_events.reference
+++ b/tests/queries/0_stateless/03759_marks_cache_events.reference
@@ -1,0 +1,9 @@
+"query_kind","load_marks_asynchronously","hits","misses"
+"Insert","",0,0
+"Select","0",0,1
+"Select","0",1,0
+"Select","1",0,1
+"Select","1",1,0
+"part_name","hits","misses"
+"all_1_1_1",0,0
+"all_1_1_2",0,0

--- a/tests/queries/0_stateless/03759_marks_cache_events.sql
+++ b/tests/queries/0_stateless/03759_marks_cache_events.sql
@@ -1,0 +1,37 @@
+drop table if exists data;
+create table data (key Int) engine=MergeTree() order by () settings prewarm_mark_cache=0;
+insert into data values (1);
+--
+-- SELECTs
+--
+select * from data format Null settings load_marks_asynchronously=0;
+select * from data format Null settings load_marks_asynchronously=0;
+-- drop marks cache
+detach table data;
+attach table data;
+select * from data format Null settings load_marks_asynchronously=1;
+select * from data format Null settings load_marks_asynchronously=1;
+
+system flush logs query_log;
+select query_kind, Settings['load_marks_asynchronously'] load_marks_asynchronously, ProfileEvents['MarkCacheHits'] hits, ProfileEvents['MarkCacheMisses'] misses
+  from system.query_log
+  where current_database = currentDatabase() and query_kind in ('Select', 'Insert') and type != 'QueryStart'
+  order by event_time_microseconds
+  format CSVWithNames;
+
+--
+-- metrics for merges
+--
+-- only hits
+optimize table data final;
+-- drop marks cache to trigger misses
+detach table data;
+attach table data;
+optimize table data final;
+
+system flush logs part_log;
+select part_name, ProfileEvents['MarkCacheHits'] hits, ProfileEvents['MarkCacheMisses'] misses
+  from system.part_log
+  where database = currentDatabase() and event_type = 'MergeParts'
+  order by event_time_microseconds
+  format CSVWithNames;

--- a/tests/queries/0_stateless/03759_marks_cache_events.sql
+++ b/tests/queries/0_stateless/03759_marks_cache_events.sql
@@ -1,5 +1,8 @@
 drop table if exists data;
 create table data (key Int) engine=MergeTree() order by () settings prewarm_mark_cache=0;
+
+set load_marks_asynchronously=0;
+
 insert into data values (1);
 --
 -- SELECTs

--- a/tests/queries/0_stateless/03759_marks_cache_events.sql
+++ b/tests/queries/0_stateless/03759_marks_cache_events.sql
@@ -1,3 +1,5 @@
+-- Tags: no-parallel-replicas
+
 drop table if exists data;
 create table data (key Int) engine=MergeTree() order by () settings prewarm_mark_cache=0;
 


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Refine marks cache metrics to track only queries (after #83415 `MarkCacheHits`/`MarkCacheMisses` was updated for merges as well, this PR will revert this behavior back)

These metrics measure query performance and should only track user-facing operations, not background tasks.

There are 3 different users of marks:
- queries - always fill marks cache and should update both metrics, since this directly impacts query performance
- async marks loader - should not update miss metric since this is a background task; the counter will be updated on `getOrSet` anyway
- merges/mutations - do not affect query performance and marks are typically not cached for them, so avoid updating metrics

Also update MergeTreeReaderSettings interface to sanitize all users: make the ctor private and introduce separate create*() methods, but keep properties public (not ideal, but should be acceptable).

Fixes: https://github.com/ClickHouse/ClickHouse/issues/88787