### PR TITLE
Make it possible to specify `storage_class_name` in named collections

### DIFF
--- a/src/Storages/ObjectStorage/S3/Configuration.cpp
+++ b/src/Storages/ObjectStorage/S3/Configuration.cpp
@@ -102,6 +102,7 @@ static const std::unordered_set<std::string_view> optional_configuration_keys =
     "no_sign_request",
     "partition_strategy",
     "partition_columns_in_data_file",
+    "storage_class_name",
     /// Private configuration options
     "role_arn", /// for extra_credentials
     "role_session_name", /// for extra_credentials
@@ -1010,4 +1011,3 @@ void StorageS3Configuration::addStructureAndFormatToArgsIfNeeded(
 }
 
 #endif
-

--- a/tests/integration/test_storage_s3_intelligent_tier/test.py
+++ b/tests/integration/test_storage_s3_intelligent_tier/test.py
@@ -1,4 +1,3 @@
-
 import os
 import logging
 
@@ -58,21 +57,29 @@ def test_s3_storage_class(started_cluster):
         )
 
 
-
 def test_s3_storage_class_with_name_collection(started_cluster):
+    postfix = generate_random_string()
     node = started_cluster.instances["node"]
-    table_name = f"test_s3_storage_class_{generate_random_string()}"
+    table_name = f"test_s3_storage_class_{postfix}"
+    collection_name = f"s3_with_storage_class_{postfix}"
     bucket = started_cluster.minio_bucket
 
     url = f"http://{started_cluster.minio_host}:{started_cluster.minio_port}/{bucket}/{table_name}"
 
     node.query(
         f"""
-        CREATE NAMED COLLECTION s3_with_storage_class AS url = '{url}', access_key_id = 'minio', secret_access_key='ClickHouse_Minio_P@ssw0rd', format = 'Parquet', storage_class_name='STANDARD';
-        CREATE TABLE {table_name} (a Int32, b Int32, c String) ENGINE = S3(s3_with_storage_class)
+        CREATE NAMED COLLECTION {collection_name} AS url = '{url}', access_key_id = 'minio', secret_access_key='ClickHouse_Minio_P@ssw0rd', format = 'Parquet', storage_class_name='STANDARD';
+        CREATE TABLE {table_name} (a Int32, b Int32, c String) ENGINE = S3({collection_name});
     """
     )
 
     node.query(f"INSERT INTO {table_name} VALUES (1, 2, '3')")
 
     assert node.query("SELECT b FROM {}".format(table_name)).strip() == "2"
+
+    node.query(
+        f"""
+        DROP TABLE {table_name};
+        DROP NAMED COLLECTION {collection_name};
+    """
+    )


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Make it possible to specify `storage_class_name` setting in named collections for `S3` table engine and `s3` table function.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
