### PR TITLE
CI: Fix missing dmesg on 'OOM in dmesg' error

### DIFF
--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -464,7 +464,7 @@ def main():
     if not info.is_local_run:
         print("Dumping dmesg")
         Shell.check("dmesg -T > dmesg.log", verbose=True, strict=True)
-        failed_tests_files.append("dmesg.log")
+        files.append("./ci/tmp/dmesg.log")
         with open("dmesg.log", "rb") as dmesg:
             dmesg = dmesg.read()
             if (

--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -464,7 +464,7 @@ def main():
     if not info.is_local_run:
         print("Dumping dmesg")
         Shell.check("dmesg -T > dmesg.log", verbose=True, strict=True)
-        files.append("./ci/tmp/dmesg.log")
+        failed_tests_files.append("dmesg.log")
         with open("dmesg.log", "rb") as dmesg:
             dmesg = dmesg.read()
             if (


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

E.g.: https://d1k2gkhrlfqv31.cloudfront.net/clickhouse-test-reports-private/json.html?REF=master&sha=551050a78bc7bf4a67b96e7e399e4c2d88e969ee&name_0=MasterCI&name_1=Integration%20tests%20%28amd_asan%2C%20db%20disk%2C%201%2F4%29&name_1=Integration%20tests%20%28amd_asan%2C%20db%20disk%2C%201%2F4%29

It says "OOM in dmesg", but none of the attached files have a dmesg dump. Looks like this was broken when refactoring `integration_test_job.py`: line `failed_tests_files.append("dmesg.log")` was moved below the code that looks at `failed_tests_files`. This PR tries to fix it by adding `dmesg.log` as a separate file to upload, similar to `docker-in-docker.log` above it. (But I don't particularly know what I'm doing and didn't test it.)