### PR TITLE
Explicitly set `ClientInfo::Interface::LOCAL` for local connection

### DIFF
--- a/src/Client/LocalConnection.cpp
+++ b/src/Client/LocalConnection.cpp
@@ -141,7 +141,9 @@ void LocalConnection::sendQuery(
         query_context = session->makeQueryContext(*client_info);
     else
         query_context = session->makeQueryContext();
+
     query_context->setCurrentQueryId(query_id);
+    query_context->setClientInterface(ClientInfo::Interface::LOCAL);
 
     if (send_progress)
     {


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `client_info.interface` being set to `TCP` for local connections.


