### PR TITLE
Fix Inconsistent AST formatting for UPDATE query

### DIFF
--- a/src/Parsers/ParserDeleteQuery.cpp
+++ b/src/Parsers/ParserDeleteQuery.cpp
@@ -18,7 +18,7 @@ bool ParserDeleteQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     ParserKeyword s_from(Keyword::FROM);
     ParserKeyword s_in_partition(Keyword::IN_PARTITION);
     ParserKeyword s_where(Keyword::WHERE);
-    ParserExpressionWithOptionalAlias parser_exp_elem(/*allow_alias_without_as_keyword_=*/false);
+    ParserExpression parser_exp_elem;
     ParserKeyword s_settings(Keyword::SETTINGS);
     ParserKeyword s_on{Keyword::ON};
 

--- a/src/Parsers/ParserDeleteQuery.cpp
+++ b/src/Parsers/ParserDeleteQuery.cpp
@@ -18,7 +18,7 @@ bool ParserDeleteQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     ParserKeyword s_from(Keyword::FROM);
     ParserKeyword s_in_partition(Keyword::IN_PARTITION);
     ParserKeyword s_where(Keyword::WHERE);
-    ParserExpression parser_exp_elem;
+    ParserExpressionWithOptionalAlias parser_exp_elem(/*allow_alias_without_as_keyword_=*/false);
     ParserKeyword s_settings(Keyword::SETTINGS);
     ParserKeyword s_on{Keyword::ON};
 

--- a/src/Parsers/ParserUpdateQuery.cpp
+++ b/src/Parsers/ParserUpdateQuery.cpp
@@ -60,6 +60,18 @@ bool ParserUpdateQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     if (!parser_exp_elem.parse(pos, query->predicate, expected))
         return false;
 
+    /// ParserExpression, in contrast to ParserExpressionWithOptionalAlias,
+    /// does not expect an alias after the expression. However, in certain cases,
+    /// it uses ParserExpressionWithOptionalAlias recursively, and use its result.
+    /// This is the case when it parses a single expression in parentheses, e.g.,
+    /// it does not allow
+    /// 1 AS x
+    /// but it can parse
+    /// (1 AS x)
+    /// which we should not allow as well.
+    if (!query->predicate->tryGetAlias().empty())
+        return false;
+
     if (s_settings.ignore(pos, expected))
     {
         ParserSetQuery parser_settings(true);

--- a/tests/queries/0_stateless/03756_update_query_formatting.sql
+++ b/tests/queries/0_stateless/03756_update_query_formatting.sql
@@ -1,0 +1,4 @@
+CREATE TABLE 03756_update_query_formatting (a UInt64, b UInt64) Engine = MergeTree ORDER BY a SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1;
+UPDATE 03756_update_query_formatting SET b = 2 WHERE (NOT a)[0] AS a0; -- { clientError SYNTAX_ERROR }
+ALTER TABLE 03756_update_query_formatting UPDATE b = 2 WHERE (NOT a)[0] AS a0; -- { clientError SYNTAX_ERROR }
+ALTER TABLE 03756_update_query_formatting DELETE WHERE (NOT a)[0] AS a0; -- { clientError SYNTAX_ERROR }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fix errors like https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=91847&sha=d4459e3e08d742314b9c83f9be79e552f4a7e31c&name_0=PR&name_1=BuzzHouse%20%28amd_debug%29

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
