### PR TITLE
Backport fix 03644_object_storage_correlated_subqueries to release br…

### DIFF
--- a/tests/queries/0_stateless/03644_object_storage_correlated_subqueries.sql
+++ b/tests/queries/0_stateless/03644_object_storage_correlated_subqueries.sql
@@ -12,6 +12,5 @@ WHERE n1.c1 > (
     SELECT AVG(n2.c1)
     FROM s3('http://localhost:11111/test/test-data-03644_object_storage.csv', 'test', 'testtest') AS n2
     WHERE n2.c1 < n1.c1
-)
-ORDER BY n1.c1
+) ORDER BY n1.c1
 SETTINGS allow_experimental_correlated_subqueries = 1;


### PR DESCRIPTION
…anches

### Changelog category (leave one):

- Not for changelog (changelog entry is not required)



This is dummy PR to trigger backport with the change in the test to fix it in release branches