### PR TITLE
Prevent crash when connecting to mongodb with named collections

### DIFF
--- a/src/Parsers/FunctionSecretArgumentsFinder.h
+++ b/src/Parsers/FunctionSecretArgumentsFinder.h
@@ -179,7 +179,9 @@ protected:
                 return;
 
             /// MongoDB(named_collection, ..., uri = 'mongodb://username:password@127.0.0.1:27017', ...)
-            findNamedArgument(&uri, "uri", 1);
+            if (findNamedArgument(&uri, "uri", 1) == -1)
+                return;
+
             result.are_named = true;
             result.start = 1;
         }
@@ -785,7 +787,7 @@ protected:
 
     /// Looks for an argument with a specified name. This function looks for arguments in format `key=value` where the key is specified.
     /// Returns -1 if no argument was found.
-    ssize_t findNamedArgument(String * res, const std::string_view & key, size_t start = 0)
+    ssize_t findNamedArgument(String * res, std::string_view key, size_t start = 0)
     {
         for (size_t i = start; i < function->arguments->size(); ++i)
         {
@@ -813,7 +815,7 @@ protected:
 
     /// Looks for a secret argument with a specified name. This function looks for arguments in format `key=value` where the key is specified.
     /// If the argument is found, it is marked as a secret.
-    bool findSecretNamedArgument(const std::string_view & key, size_t start = 0)
+    bool findSecretNamedArgument(std::string_view key, size_t start = 0)
     {
         ssize_t arg_idx = findNamedArgument(nullptr, key, start);
         if (arg_idx >= 0)

--- a/tests/queries/0_stateless/03756_mongodb_secret_arguments.sql
+++ b/tests/queries/0_stateless/03756_mongodb_secret_arguments.sql
@@ -1,0 +1,3 @@
+-- Tags: no-fasttest
+
+SELECT * FROM mongodb(some_named_collection, now()); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Prevent crash when connecting to mongodb with named collections.

Caught by BuzzHouse https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=91888&sha=16e83fb6dd2735a4e9b8098c68351fee13ddd3f3&name_0=PR&name_1=BuzzHouse%20%28amd_ubsan%29

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
