### PR TITLE
Fix argument for "Lock was held for {} ms by thread {} in [{}]"

### DIFF
--- a/src/Common/LockGuardWithStopWatch.h
+++ b/src/Common/LockGuardWithStopWatch.h
@@ -51,14 +51,14 @@ struct TSA_SCOPED_LOCKABLE LockGuardWithStopWatch final
 
         if (wait_watch->elapsedMilliseconds() > THRESHOLD_MILLISECONDS)
         {
-            LOG_WARNING(log, "Lock acquisition took {} ms for thread {} in [{}], Stack trace (when copying this message, always include the lines below): \n {}",
+            LOG_WARNING(log, "Lock acquisition took {} ms for thread {} in [{}], Stack trace (when copying this message, always include the lines below):\n{}",
                 wait_watch->elapsedMilliseconds(), thread_id, caller, StackTrace().toString());
         }
 
         if (lock_watch->elapsedMilliseconds() > THRESHOLD_MILLISECONDS)
         {
-            LOG_WARNING(log, "Lock was held for {} ms by thread {} in [{}], Stack trace (when copying this message, always include the lines below): \n {}",
-                wait_watch->elapsedMilliseconds(), thread_id, caller, StackTrace().toString());
+            LOG_WARNING(log, "Lock was held for {} ms by thread {} in [{}], Stack trace (when copying this message, always include the lines below):\n{}",
+                lock_watch->elapsedMilliseconds(), thread_id, caller, StackTrace().toString());
         }
     }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)