### PR TITLE
tests: fix 03164_materialize_skip_index_on_merge flakiness

### DIFF
--- a/tests/queries/0_stateless/03164_materialize_skip_index_on_merge.sql
+++ b/tests/queries/0_stateless/03164_materialize_skip_index_on_merge.sql
@@ -25,7 +25,7 @@ SELECT count() FROM tab WHERE a >= 110 AND a < 130 AND b = 2;
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes = 1 SELECT count() FROM tab WHERE a >= 110 AND a < 130 AND b = 2
 )
-WHERE explain ILIKE '%Skip%' OR explain ILIKE '%Name:%' OR explain ILIKE '%Granules:%';
+WHERE explain LIKE '%Skip%' OR explain LIKE '%Name:%' OR explain LIKE '%Granules:%';
 
 SELECT database, table, name, data_compressed_bytes FROM system.data_skipping_indices WHERE database = currentDatabase() AND table = 'tab';
 
@@ -44,7 +44,7 @@ SELECT count() FROM tab WHERE a >= 110 AND a < 130 AND b = 2;
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes = 1 SELECT count() FROM tab WHERE a >= 110 AND a < 130 AND b = 2
 )
-WHERE explain ILIKE '%Skip%' OR explain ILIKE '%Name:%' OR explain ILIKE '%Granules:%';
+WHERE explain LIKE '%Skip%' OR explain LIKE '%Name:%' OR explain LIKE '%Granules:%';
 
 SELECT database, table, name, data_compressed_bytes FROM system.data_skipping_indices WHERE database = currentDatabase() AND table = 'tab';
 
@@ -65,7 +65,7 @@ SELECT count() FROM tab WHERE a >= 110 AND a < 130 AND b = 2;
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes = 1 SELECT count() FROM tab WHERE a >= 110 AND a < 130 AND b = 2
 )
-WHERE explain ILIKE '%Skip%' OR explain ILIKE '%Name:%' OR explain ILIKE '%Granules:%';
+WHERE explain LIKE '%Skip%' OR explain LIKE '%Name:%' OR explain LIKE '%Granules:%';
 SELECT database, table, name, data_compressed_bytes FROM system.data_skipping_indices WHERE database = currentDatabase() AND table = 'tab';
 
 SELECT 'Merge after resetting materialize_skip_indexes_on_merge to default';
@@ -81,7 +81,7 @@ SELECT count() FROM tab WHERE a >= 110 AND a < 130 AND b = 2;
 SELECT trimLeft(explain) AS explain FROM (
     EXPLAIN indexes = 1 SELECT count() FROM tab WHERE a >= 110 AND a < 130 AND b = 2
 )
-WHERE explain ILIKE '%Skip%' OR explain ILIKE '%Name:%' OR explain ILIKE '%Granules:%';
+WHERE explain LIKE '%Skip%' OR explain LIKE '%Name:%' OR explain LIKE '%Granules:%';
 SELECT database, table, name, data_compressed_bytes FROM system.data_skipping_indices WHERE database = currentDatabase() AND table = 'tab';
 
 DROP TABLE tab;


### PR DESCRIPTION
It is possible that randomly generated database will contain "skip", and the test will fail, since it will also match "ReadFromMergeTree (default.tab)" (where "default" is the name of the random database).

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)