### PR TITLE
Allow multiple authentication methods to be specified in users xml

### DIFF
--- a/docs/en/operations/settings/settings-users.md
+++ b/docs/en/operations/settings/settings-users.md
@@ -21,10 +21,12 @@ Structure of the `users` section:
 <users>
     <!-- If user name was not specified, 'default' user is used. -->
     <user_name>
+        <!-- Exactly one authentication method may be specified at the users.user_name level. For example: -->
         <password></password>
-        <!-- Or -->
+        <!-- Or (exclusive) -->
         <password_sha256_hex></password_sha256_hex>
-
+ 
+        <!-- Or (exclusive) (N.B. multiple SSH keys are allowed for backwards compatibility) -->
         <ssh_keys>
             <ssh_key>
                 <type>ssh-ed25519</type>
@@ -39,6 +41,20 @@ Structure of the `users` section:
                 <base64_key>AAAAB3NzaC1yc2EAAAADAQABAAABgQCpgqL1SHhPVBOTFlOm0pu+cYBbADzC2jL41sPMawYCJHDyHuq7t+htaVVh2fRgpAPmSEnLEC2d4BEIKMtPK3bfR8plJqVXlLt6Q8t4b1oUlnjb3VPA9P6iGcW7CV1FBkZQEVx8ckOfJ3F+kI5VsrRlEDgiecm/C1VPl0/9M2llW/mPUMaD65cM9nlZgM/hUeBrfxOEqM11gDYxEZm1aRSbZoY4dfdm3vzvpSQ6lrCrkjn3X2aSmaCLcOWJhfBWMovNDB8uiPuw54g3ioZ++qEQMlfxVsqXDGYhXCrsArOVuW/5RbReO79BvXqdssiYShfwo+GhQ0+aLWMIW/jgBkkqx/n7uKLzCMX7b2F+aebRYFh+/QXEj7SnihdVfr9ud6NN3MWzZ1ltfIczlEcFLrLJ1Yq57wW6wXtviWh59WvTWFiPejGjeSjjJyqqB49tKdFVFuBnIU5u/bch2DXVgiAEdQwUrIp1ACoYPq22HFFAYUJrL32y7RxX3PGzuAv3LOc=</base64_key>
             </ssh_key>
         </ssh_keys>
+
+        <!-- Or (exclusive) for multiple authentication methods: -->
+        <auth_methods>
+            <method1>
+                <password></password>
+            </method1>
+            <method2>
+                <password_sha256_hex></password_sha256_hex>
+            </method2>
+            <!-- ... -->
+            <methodN>
+                <!-- ... -->
+            </methodN>
+        </auth_methods>
 
         <access_management>0|1</access_management>
 
@@ -180,6 +196,94 @@ The `ssh_key` element is expected to be
 ```
 
 Substitute `ssh-ed25519` with `ssh-rsa` or `ecdsa-sha2-nistp256` for the other supported algorithms.
+
+### Multiple Authentication Methods {#multiple-authentication-methods}
+
+A single user can be configured with multiple authentication methods using the `<auth_methods>` element. This allows a user to authenticate with any one of the listed methods — for example, a user could have both a password and an LDAP credential, and logging in with either one would succeed.
+
+Each child element of `<auth_methods>` is an arbitrarily-named wrapper that contains exactly one authentication type. The wrapper name (e.g. `<method1>`, `<primary>`, `<a1>`) does not matter; only the inner authentication element is used.
+
+**Example: multiple passwords**
+
+```xml
+<users>
+    <my_user>
+        <auth_methods>
+            <primary>
+                <password>password_one</password>
+            </primary>
+            <secondary>
+                <password_sha256_hex>65e84be33532fb784c48129675f9eff3a682b27168c0ea744b2cf58ee02337c5</password_sha256_hex>
+            </secondary>
+        </auth_methods>
+    </my_user>
+</users>
+```
+
+**Example: mixed authentication types**
+
+```xml
+<users>
+    <my_user>
+        <auth_methods>
+            <a1>
+                <password>plaintext_pass</password>
+            </a1>
+            <a2>
+                <password_sha256_hex>e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855</password_sha256_hex>
+            </a2>
+            <a3>
+                <ldap>
+                    <server>my_ldap_server</server>
+                </ldap>
+            </a3>
+        </auth_methods>
+    </my_user>
+</users>
+```
+
+The following authentication types are supported inside `<auth_methods>`:
+
+- **`password`** — plaintext password
+- **`password_sha256_hex`** — SHA256 password hash
+- **`password_scram_sha256_hex`** — SCRAM-SHA-256 password hash
+- **`password_double_sha1_hex`** — double SHA1 password hash
+- **`ldap`** — LDAP server authentication
+- **`kerberos`** — Kerberos authentication
+- **`ssl_certificates`** — SSL certificate authentication
+- **`ssh_keys`** — SSH key authentication
+- **`http_authentication`** — HTTP authentication
+
+**Rules and restrictions:**
+
+- `<auth_methods>` **cannot** be used together with authentication methods specified at the user level. Use one style or the other, not both.
+- `<auth_methods>` must contain at least one authentication method.
+- Each wrapper element inside `<auth_methods>` must contain exactly one authentication type (with the exception of `<ssh_keys>`, which can contain multiple, for backwards compatibility).
+- TOTP (`<time_based_one_time_password>`) is specified at the user level (outside `<auth_methods>`) and applies to all password-based methods in the list. At least one password-based method is required when TOTP is enabled.
+
+**Example: `auth_methods` with TOTP**
+
+```xml
+<users>
+    <my_user>
+        <auth_methods>
+            <a1>
+                <password>my_password</password>
+            </a1>
+            <a2>
+                <ldap>
+                    <server>ldap_server_1</server>
+                </ldap>
+            </a2>
+        </auth_methods>
+        <time_based_one_time_password>
+            <secret>JBSWY3DPEHPK3PXP</secret>
+        </time_based_one_time_password>
+    </my_user>
+</users>
+```
+
+In this example, TOTP verification is applied to the password-based method (`<password>`), while the LDAP method authenticates against the external server independently.
 
 ### access_management {#access_management-user-setting}
 

--- a/src/Access/UsersConfigParser.cpp
+++ b/src/Access/UsersConfigParser.cpp
@@ -31,6 +31,7 @@
 #include <cstring>
 #include <base/FnTraits.h>
 #include <base/range.h>
+#include <string_view>
 #include <unordered_set>
 #include <boost/container/flat_set.hpp>
 
@@ -106,130 +107,145 @@ namespace
         }
     }
 
-    UserPtr parseUser(
+    /// Throws if any user-level/flat authentication fields (password, ldap, etc.) coexist
+    /// with <auth_methods> at the given config path.
+    void validateNoFlatAuthFields(
         const Poco::Util::AbstractConfiguration & config,
-        String user_name,
-        const std::unordered_set<UUID> & allowed_profile_ids,
-        const std::unordered_set<UUID> & role_ids_from_users_config,
-        const AccessControl & access_control,
-        bool allow_no_password,
-        bool allow_plaintext_password,
-        LoggerPtr log)
+        const String & config_path,
+        const String & user_name)
+    {
+        static const std::unordered_set<std::string_view> auth_type_keys = {
+            "no_password", "password", "password_sha256_hex", "password_scram_sha256_hex",
+            "password_double_sha1_hex", "ldap", "kerberos", "ssl_certificates",
+            "ssh_keys", "http_authentication"
+        };
+        Poco::Util::AbstractConfiguration::Keys user_keys;
+        config.keys(config_path, user_keys);
+        for (const auto & key : user_keys)
+        {
+            if (auth_type_keys.contains(key))
+                throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                    "Cannot specify both 'auth_methods' and '{}' for user {}. "
+                    "Use either 'auth_methods' or individual fields, not both.", key, user_name);
+        }
+    }
+
+    AuthenticationData createPasswordAuthData(
+        AuthenticationType type,
+        const String & password,
+        const std::optional<OneTimePasswordSecret> & otp_secret,
+        bool validate,
+        bool is_hash)
+    {
+        AuthenticationData auth_data(type);
+        if (is_hash)
+            auth_data.setPasswordHashHex(password, otp_secret, validate);
+        else
+            auth_data.setPassword(password, otp_secret, validate);
+        return auth_data;
+    }
+
+    AuthenticationData parseUserAuthMethod(
+        const Poco::Util::AbstractConfiguration & config,
+        const String & user_name,
+        const String & auth_method_path,
+        const std::optional<OneTimePasswordSecret> & otp_secret)
     {
         const bool validate = true;
-        auto user = std::make_shared<User>();
-        String user_config = "users." + user_name;
 
-        /// If the user name contains a dot, it is escaped with a backslash when parsed from the config file.
-        /// We need to remove the backslash to get the correct user name.
-        Poco::replaceInPlace(user_name, "\\.", ".");
-        user->setName(user_name);
+        bool has_no_password = config.has(auth_method_path + ".no_password");
 
-        bool has_no_password = config.has(user_config + ".no_password");
-        bool has_password_plaintext = config.has(user_config + ".password");
-        bool has_password_sha256_hex = config.has(user_config + ".password_sha256_hex");
-        bool has_scram_password_sha256_hex = config.has(user_config + ".password_scram_sha256_hex");
-        bool has_password_double_sha1_hex = config.has(user_config + ".password_double_sha1_hex");
-        bool has_ldap = config.has(user_config + ".ldap");
-        bool has_kerberos = config.has(user_config + ".kerberos");
+        const auto password_plaintext_config = auth_method_path + ".password";
+        bool has_password_plaintext = config.has(password_plaintext_config);
 
-        const auto certificates_config = user_config + ".ssl_certificates";
+        const auto password_sha256_hex_config = auth_method_path + ".password_sha256_hex";
+        bool has_password_sha256_hex = config.has(password_sha256_hex_config);
+
+        const auto scram_password_config = auth_method_path + ".password_scram_sha256_hex";
+        bool has_scram_password_sha256_hex = config.has(scram_password_config);
+
+        const auto password_double_sha1_hex_config = auth_method_path + ".password_double_sha1_hex";
+        bool has_password_double_sha1_hex = config.has(password_double_sha1_hex_config);
+
+        const auto ldap_config = auth_method_path + ".ldap";
+        bool has_ldap = config.has(ldap_config);
+
+        const auto kerberos_config = auth_method_path + ".kerberos";
+        bool has_kerberos = config.has(kerberos_config);
+
+        const auto certificates_config = auth_method_path + ".ssl_certificates";
         bool has_certificates = config.has(certificates_config);
 
-        const auto ssh_keys_config = user_config + ".ssh_keys";
+        const auto ssh_keys_config = auth_method_path + ".ssh_keys";
         bool has_ssh_keys = config.has(ssh_keys_config);
 
-        const auto http_auth_config = user_config + ".http_authentication";
+        const auto http_auth_config = auth_method_path + ".http_authentication";
         bool has_http_auth = config.has(http_auth_config);
 
-        size_t num_password_fields = has_no_password + has_password_plaintext + has_password_sha256_hex + has_password_double_sha1_hex
+        size_t num_authentication_types = has_no_password + has_password_plaintext + has_password_sha256_hex + has_password_double_sha1_hex
             + has_ldap + has_kerberos + has_certificates + has_ssh_keys + has_http_auth + has_scram_password_sha256_hex;
 
-        if (num_password_fields > 1)
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "More than one field of 'password', 'password_sha256_hex', "
-                            "'password_double_sha1_hex', 'no_password', 'ldap', 'kerberos', 'ssl_certificates', 'ssh_keys', "
-                            "'http_authentication' are used to specify authentication info for user {}. "
-                            "Must be only one of them.", user_name);
+        if (num_authentication_types > 1)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                "Cannot specify multiple authentication methods for user {} at {}. "
+                "Specify only one authentication method.", user_name, auth_method_path);
 
-        if (num_password_fields < 1)
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Either 'password' or 'password_sha256_hex' "
-                            "or 'password_double_sha1_hex' or 'no_password' or 'ldap' or 'kerberos "
-                            "or 'ssl_certificates' or 'ssh_keys' or 'http_authentication' must be specified for user {}.", user_name);
+        if (num_authentication_types < 1)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "At least one authentication type (one of 'password', "
+                "'password_sha256_hex', 'password_scram_sha256_hex', 'password_double_sha1_hex', 'no_password', 'ldap', 'kerberos', "
+                "'ssl_certificates', 'ssh_keys', 'http_authentication') must be specified for user {} in path {}.", user_name, auth_method_path);
 
-        std::optional<OneTimePasswordSecret> otp_secret;
-        if (config.has(user_config + ".time_based_one_time_password"))
-        {
-            bool is_password_based = has_no_password || has_password_plaintext || has_password_sha256_hex
-                || has_password_double_sha1_hex || has_scram_password_sha256_hex;
-            if (!is_password_based)
-                throw Exception(ErrorCodes::BAD_ARGUMENTS, "One-time password can be used only with password based authentication for user {}.", user_name);
-
-            String otp_secret_key = config.getString(user_config + ".time_based_one_time_password.secret");
-
-            std::optional<Int32> num_digits;
-            if (config.has(user_config + ".time_based_one_time_password.digits"))
-                num_digits = config.getInt(user_config + ".time_based_one_time_password.digits");
-
-            std::optional<Int32> period;
-            if (config.has(user_config + ".time_based_one_time_password.period"))
-                period = config.getInt(user_config + ".time_based_one_time_password.period");
-
-            std::optional<String> algorithm_name;
-            if (config.has(user_config + ".time_based_one_time_password.algorithm"))
-                algorithm_name = config.getString(user_config + ".time_based_one_time_password.algorithm");
-
-            otp_secret.emplace(otp_secret_key, OneTimePasswordParams(num_digits, period, algorithm_name));
-        }
+        AuthenticationData auth_data;
 
         if (has_no_password && otp_secret)
         {
-            user->authentication_methods.emplace_back(AuthenticationType::NO_PASSWORD);
-            user->authentication_methods.back().setPassword("", otp_secret, validate);
+            auth_data = createPasswordAuthData(AuthenticationType::NO_PASSWORD, "", otp_secret, validate, false);
+        }
+        else if (has_no_password)
+        {
+            auth_data = AuthenticationData(AuthenticationType::NO_PASSWORD);
         }
         else if (has_password_plaintext)
         {
-            user->authentication_methods.emplace_back(AuthenticationType::PLAINTEXT_PASSWORD);
-            user->authentication_methods.back().setPassword(config.getString(user_config + ".password"), otp_secret, validate);
+            const auto password = config.getString(password_plaintext_config);
+            auth_data = createPasswordAuthData(AuthenticationType::PLAINTEXT_PASSWORD, password, otp_secret, validate, false);
         }
         else if (has_password_sha256_hex)
         {
-            user->authentication_methods.emplace_back(AuthenticationType::SHA256_PASSWORD);
-            user->authentication_methods.back().setPasswordHashHex(config.getString(user_config + ".password_sha256_hex"), otp_secret, validate);
+            const auto password = config.getString(password_sha256_hex_config);
+            auth_data = createPasswordAuthData(AuthenticationType::SHA256_PASSWORD, password, otp_secret, validate, true);
         }
         else if (has_scram_password_sha256_hex)
         {
-            user->authentication_methods.emplace_back(AuthenticationType::SCRAM_SHA256_PASSWORD);
-            user->authentication_methods.back().setPasswordHashHex(config.getString(user_config + ".password_scram_sha256_hex"), otp_secret, validate);
+            const auto password = config.getString(scram_password_config);
+            auth_data = createPasswordAuthData(AuthenticationType::SCRAM_SHA256_PASSWORD, password, otp_secret, validate, true);
         }
         else if (has_password_double_sha1_hex)
         {
-            user->authentication_methods.emplace_back(AuthenticationType::DOUBLE_SHA1_PASSWORD);
-            user->authentication_methods.back().setPasswordHashHex(config.getString(user_config + ".password_double_sha1_hex"), otp_secret, validate);
+            const auto password = config.getString(password_double_sha1_hex_config);
+            auth_data = createPasswordAuthData(AuthenticationType::DOUBLE_SHA1_PASSWORD, password, otp_secret, validate, true);
         }
         else if (has_ldap)
         {
-            bool has_ldap_server = config.has(user_config + ".ldap.server");
-            if (!has_ldap_server)
+            if (!config.has(ldap_config + ".server"))
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "Missing mandatory 'server' in 'ldap', with LDAP server name, for user {}.", user_name);
 
-            const auto ldap_server_name = config.getString(user_config + ".ldap.server");
-            if (ldap_server_name.empty())
+            const auto server = config.getString(ldap_config + ".server");
+            if (server.empty())
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "LDAP server name cannot be empty for user {}.", user_name);
-
-            user->authentication_methods.emplace_back(AuthenticationType::LDAP);
-            user->authentication_methods.back().setLDAPServerName(ldap_server_name);
+            auth_data = AuthenticationData(AuthenticationType::LDAP);
+            auth_data.setLDAPServerName(server);
         }
         else if (has_kerberos)
         {
-            const auto realm = config.getString(user_config + ".kerberos.realm", "");
-
-            user->authentication_methods.emplace_back(AuthenticationType::KERBEROS);
-            user->authentication_methods.back().setKerberosRealm(realm);
+            const auto realm = config.getString(kerberos_config + ".realm", "");
+            auth_data = AuthenticationData(AuthenticationType::KERBEROS);
+            auth_data.setKerberosRealm(realm);
         }
         else if (has_certificates)
         {
 #if USE_SSL
-            user->authentication_methods.emplace_back(AuthenticationType::SSL_CERTIFICATE);
+            auth_data = AuthenticationData(AuthenticationType::SSL_CERTIFICATE);
 
             /// Fill list of allowed certificates.
             Poco::Util::AbstractConfiguration::Keys keys;
@@ -239,14 +255,14 @@ namespace
                 if (key.starts_with("common_name"))
                 {
                     String value = config.getString(certificates_config + "." + key);
-                    user->authentication_methods.back().addSSLCertificateSubject(X509Certificate::Subjects::Type::CN, std::move(value));
+                    auth_data.addSSLCertificateSubject(X509Certificate::Subjects::Type::CN, std::move(value));
                 }
                 else if (key.starts_with("subject_alt_name"))
                 {
                     String value = config.getString(certificates_config + "." + key);
                     if (value.empty())
                         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Expected ssl_certificates.subject_alt_name to not be empty");
-                    user->authentication_methods.back().addSSLCertificateSubject(X509Certificate::Subjects::Type::SAN, std::move(value));
+                    auth_data.addSSLCertificateSubject(X509Certificate::Subjects::Type::SAN, std::move(value));
                 }
                 else
                     throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unknown certificate pattern type: {}", key);
@@ -258,7 +274,7 @@ namespace
         else if (has_ssh_keys)
         {
 #if USE_SSH
-            user->authentication_methods.emplace_back(AuthenticationType::SSH_KEY);
+            auth_data = AuthenticationData(AuthenticationType::SSH_KEY);
 
             Poco::Util::AbstractConfiguration::Keys entries;
             config.keys(ssh_keys_config, entries);
@@ -296,26 +312,72 @@ namespace
                 else
                     throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unknown ssh_key entry pattern type: {}", entry);
             }
-            user->authentication_methods.back().setSSHKeys(std::move(keys));
+            auth_data.setSSHKeys(std::move(keys));
 #else
             throw Exception(ErrorCodes::SUPPORT_IS_DISABLED, "SSH is disabled, because ClickHouse is built without libssh");
 #endif
         }
         else if (has_http_auth)
         {
-            user->authentication_methods.emplace_back(AuthenticationType::HTTP);
-            user->authentication_methods.back().setHTTPAuthenticationServerName(config.getString(http_auth_config + ".server"));
-            auto scheme = config.getString(http_auth_config + ".scheme");
-            user->authentication_methods.back().setHTTPAuthenticationScheme(parseHTTPAuthenticationScheme(scheme));
-        }
-        else
-        {
-            user->authentication_methods.emplace_back();
+            bool has_server_elt = config.has(http_auth_config + ".server");
+            bool has_scheme_elt = config.has(http_auth_config + ".scheme");
+
+            if (has_server_elt && has_scheme_elt)
+            {
+                auto server = config.getString(http_auth_config + ".server");
+                auto scheme = config.getString(http_auth_config + ".scheme");
+
+                if (server.empty())
+                    throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                        "HTTP authentication server name cannot be empty for user {}.", user_name);
+
+                auth_data = AuthenticationData(AuthenticationType::HTTP);
+                auth_data.setHTTPAuthenticationServerName(server);
+                auth_data.setHTTPAuthenticationScheme(parseHTTPAuthenticationScheme(scheme));
+            }
+            else if (has_server_elt)
+            {
+                throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                    "Missing mandatory 'scheme' in 'http_authentication' for user {}.", user_name);
+            }
+            else if (has_scheme_elt)
+            {
+                throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                    "Missing mandatory 'server' in 'http_authentication' for user {}.", user_name);
+            }
+            else
+            {
+                throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                    "Missing mandatory 'server' and 'scheme' in 'http_authentication' for user {}.", user_name);
+            }
         }
 
-        for (const auto & authentication_method : user->authentication_methods)
+        return auth_data;
+    }
+
+    void validateUserAuthenticationMethods(
+        const std::vector<AuthenticationData> & authentication_methods,
+        const String & user_name,
+        bool allow_no_password,
+        bool allow_plaintext_password,
+        const std::optional<OneTimePasswordSecret> & otp_secret)
+    {
+        bool has_no_password = false;
+        bool has_password_method = false;
+        for (const auto & authentication_method : authentication_methods)
         {
             auto auth_type = authentication_method.getType();
+
+            if (auth_type == AuthenticationType::NO_PASSWORD)
+            {
+                has_no_password = true;
+            }
+
+            if (AuthenticationTypeInfo::get(auth_type).is_password || auth_type == AuthenticationType::NO_PASSWORD)
+            {
+                has_password_method = true;
+            }
+
             if (((auth_type == AuthenticationType::NO_PASSWORD) && !allow_no_password) ||
                 ((auth_type == AuthenticationType::PLAINTEXT_PASSWORD) && !allow_plaintext_password))
             {
@@ -324,6 +386,87 @@ namespace
                                 toString(auth_type), AuthenticationTypeInfo::get(auth_type).name);
             }
         }
+
+        if (has_no_password && authentication_methods.size() > 1)
+        {
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "'no_password' cannot be combined with other authentication methods for user {}.", user_name);
+        }
+
+        if (otp_secret && !has_password_method)
+        {
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "One-time password can be used only with password based authentication for user {}.", user_name);
+        }
+    }
+
+    UserPtr parseUser(
+        const Poco::Util::AbstractConfiguration & config,
+        String user_name,
+        const std::unordered_set<UUID> & allowed_profile_ids,
+        const std::unordered_set<UUID> & role_ids_from_users_config,
+        const AccessControl & access_control,
+        bool allow_no_password,
+        bool allow_plaintext_password,
+        LoggerPtr log)
+    {
+        auto user = std::make_shared<User>();
+        String user_config = "users." + user_name;
+
+        /// If the user name contains a dot, it is escaped with a backslash when parsed from the config file.
+        /// We need to remove the backslash to get the correct user name.
+        Poco::replaceInPlace(user_name, "\\.", ".");
+        user->setName(user_name);
+
+        const auto auth_methods_config = user_config + ".auth_methods";
+        bool has_auth_methods = config.has(auth_methods_config);
+
+        std::optional<OneTimePasswordSecret> otp_secret;
+        if (config.has(user_config + ".time_based_one_time_password"))
+        {
+            String otp_secret_key = config.getString(user_config + ".time_based_one_time_password.secret");
+
+            std::optional<Int32> num_digits;
+            if (config.has(user_config + ".time_based_one_time_password.digits"))
+                num_digits = config.getInt(user_config + ".time_based_one_time_password.digits");
+
+            std::optional<Int32> period;
+            if (config.has(user_config + ".time_based_one_time_password.period"))
+                period = config.getInt(user_config + ".time_based_one_time_password.period");
+
+            std::optional<String> algorithm_name;
+            if (config.has(user_config + ".time_based_one_time_password.algorithm"))
+                algorithm_name = config.getString(user_config + ".time_based_one_time_password.algorithm");
+
+            otp_secret.emplace(otp_secret_key, OneTimePasswordParams(num_digits, period, algorithm_name));
+        }
+
+        if (has_auth_methods)
+        {
+            validateNoFlatAuthFields(config, user_config, user_name);
+
+            Poco::Util::AbstractConfiguration::Keys auth_methods;
+            config.keys(auth_methods_config, auth_methods);
+            for (const auto & auth_method : auth_methods)
+            {
+                const String auth_method_path = auth_methods_config + "." + auth_method;
+                if (config.has(auth_method_path + ".time_based_one_time_password"))
+                    throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                        "'time_based_one_time_password' cannot be specified inside an individual authentication method for user {}. "
+                        "It must be configured at the user level, outside of 'auth_methods'.", user_name);
+                user->authentication_methods.emplace_back(parseUserAuthMethod(config, user_name, auth_method_path, otp_secret));
+            }
+
+            if (user->authentication_methods.empty())
+            {
+                throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                    "'auth_methods' must contain at least one authentication method for user {}.", user_name);
+            }
+        }
+        else
+        {
+            user->authentication_methods.emplace_back(parseUserAuthMethod(config, user_name, user_config, otp_secret));
+        }
+
+        validateUserAuthenticationMethods(user->authentication_methods, user_name, allow_no_password, allow_plaintext_password, otp_secret);
 
         const auto profile_name_config = user_config + ".profile";
         if (config.has(profile_name_config))
@@ -883,5 +1026,4 @@ std::unordered_set<UUID> UsersConfigParser::getAllowedIDs(
         ids.emplace(generateID(type, key));
     return ids;
 }
-
 }

--- a/src/Access/UsersConfigParser.cpp
+++ b/src/Access/UsersConfigParser.cpp
@@ -466,6 +466,8 @@ namespace
             user->authentication_methods.emplace_back(parseUserAuthMethod(config, user_name, user_config, otp_secret));
         }
 
+        chassert(!user->authentication_methods.empty());
+
         validateUserAuthenticationMethods(user->authentication_methods, user_name, allow_no_password, allow_plaintext_password, otp_secret);
 
         const auto profile_name_config = user_config + ".profile";

--- a/src/Access/tests/gtest_users_config_multiple_auth.cpp
+++ b/src/Access/tests/gtest_users_config_multiple_auth.cpp
@@ -1,0 +1,817 @@
+#include <Access/AccessControl.h>
+#include <Access/UsersConfigAccessStorage.h>
+#include <Access/User.h>
+#include <Common/Exception.h>
+#include <Poco/Util/XMLConfiguration.h>
+#include <gtest/gtest.h>
+#include <sstream>
+
+using namespace DB;
+
+namespace
+{
+    Poco::AutoPtr<Poco::Util::XMLConfiguration> createConfigFromXML(const std::string & xml_content)
+    {
+        std::istringstream xml_stream(xml_content);
+        Poco::AutoPtr<Poco::Util::XMLConfiguration> config = new Poco::Util::XMLConfiguration(xml_stream);
+        return config;
+    }
+}
+
+class UsersConfigMultipleAuthTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        access_control = std::make_unique<AccessControl>();
+        storage = std::make_unique<UsersConfigAccessStorage>("users_config_test", *access_control, false);
+    }
+
+    std::unique_ptr<AccessControl> access_control;
+    std::unique_ptr<UsersConfigAccessStorage> storage;
+};
+
+TEST_F(UsersConfigMultipleAuthTest, SinglePlaintextPassword)
+{
+    const std::string xml_config = R"(
+        <clickhouse>
+            <users>
+                <test_user>
+                    <password>plaintext_pass</password>
+                </test_user>
+            </users>
+        </clickhouse>
+    )";
+
+    auto config = createConfigFromXML(xml_config);
+    storage->setConfig(*config);
+    
+    auto user = storage->tryRead<User>("test_user");
+    ASSERT_TRUE(user);
+    ASSERT_EQ(user->authentication_methods.size(), 1);
+    EXPECT_EQ(user->authentication_methods[0].getType(), AuthenticationType::PLAINTEXT_PASSWORD);
+}
+
+TEST_F(UsersConfigMultipleAuthTest, FlatNoPassword)
+{
+    const std::string xml_config = R"(
+        <clickhouse>
+            <users>
+                <test_user>
+                    <no_password/>
+                </test_user>
+            </users>
+        </clickhouse>
+    )";
+
+    auto config = createConfigFromXML(xml_config);
+    storage->setConfig(*config);
+
+    auto user = storage->tryRead<User>("test_user");
+    ASSERT_TRUE(user);
+    ASSERT_EQ(user->authentication_methods.size(), 1);
+    EXPECT_EQ(user->authentication_methods[0].getType(), AuthenticationType::NO_PASSWORD);
+}
+
+TEST_F(UsersConfigMultipleAuthTest, MultiplePlaintextPasswords)
+{
+    const std::string xml_config = R"(
+        <clickhouse>
+            <users>
+                <test_user>
+                    <auth_methods>
+                        <a1><password>plaintext_pass1</password></a1>
+                        <a2><password>plaintext_pass2</password></a2>
+                        <a3><password>plaintext_pass3</password></a3>
+                    </auth_methods>
+                </test_user>
+            </users>
+        </clickhouse>
+    )";
+
+    auto config = createConfigFromXML(xml_config);
+    storage->setConfig(*config);
+
+    auto user = storage->tryRead<User>("test_user");
+    ASSERT_TRUE(user);
+    ASSERT_EQ(user->authentication_methods.size(), 3);
+
+    for (const auto & auth_method : user->authentication_methods)
+        EXPECT_EQ(auth_method.getType(), AuthenticationType::PLAINTEXT_PASSWORD);
+}
+
+TEST_F(UsersConfigMultipleAuthTest, MultipleSHA256Passwords)
+{
+    const std::string xml_config = R"(
+        <clickhouse>
+            <users>
+                <test_user>
+                    <auth_methods>
+                        <a1><password_sha256_hex>e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855</password_sha256_hex></a1>
+                        <a2><password_sha256_hex>d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2</password_sha256_hex></a2>
+                    </auth_methods>
+                </test_user>
+            </users>
+        </clickhouse>
+    )";
+
+    auto config = createConfigFromXML(xml_config);
+    storage->setConfig(*config);
+
+    auto user = storage->tryRead<User>("test_user");
+    ASSERT_TRUE(user);
+    ASSERT_EQ(user->authentication_methods.size(), 2);
+
+    for (const auto & auth_method : user->authentication_methods)
+        EXPECT_EQ(auth_method.getType(), AuthenticationType::SHA256_PASSWORD);
+}
+
+TEST_F(UsersConfigMultipleAuthTest, MultipleDoubleSHA1Passwords)
+{
+    const std::string xml_config = R"(
+        <clickhouse>
+            <users>
+                <test_user>
+                    <auth_methods>
+                        <a1><password_double_sha1_hex>eafbd9c4b3c8b40d509308e767b41671ee5bac68</password_double_sha1_hex></a1>
+                        <a2><password_double_sha1_hex>7e4ca4bb0df85c1106f39516a0753013b79b32ff</password_double_sha1_hex></a2>
+                    </auth_methods>
+                </test_user>
+            </users>
+        </clickhouse>
+    )";
+
+    auto config = createConfigFromXML(xml_config);
+    storage->setConfig(*config);
+
+    auto user = storage->tryRead<User>("test_user");
+    ASSERT_TRUE(user);
+    ASSERT_EQ(user->authentication_methods.size(), 2);
+
+    for (const auto & auth_method : user->authentication_methods)
+        EXPECT_EQ(auth_method.getType(), AuthenticationType::DOUBLE_SHA1_PASSWORD);
+}
+
+TEST_F(UsersConfigMultipleAuthTest, MultipleLDAPServers)
+{
+    const std::string xml_config = R"(
+        <clickhouse>
+            <users>
+                <test_user>
+                    <auth_methods>
+                        <a1><ldap><server>ldap_server_1</server></ldap></a1>
+                        <a2><ldap><server>ldap_server_2</server></ldap></a2>
+                    </auth_methods>
+                </test_user>
+            </users>
+        </clickhouse>
+    )";
+
+    auto config = createConfigFromXML(xml_config);
+    storage->setConfig(*config);
+
+    auto user = storage->tryRead<User>("test_user");
+    ASSERT_TRUE(user);
+    ASSERT_EQ(user->authentication_methods.size(), 2);
+
+    for (const auto & auth_method : user->authentication_methods)
+        EXPECT_EQ(auth_method.getType(), AuthenticationType::LDAP);
+}
+
+TEST_F(UsersConfigMultipleAuthTest, MultipleKerberosRealms)
+{
+    const std::string xml_config = R"(
+        <clickhouse>
+            <users>
+                <test_user>
+                    <auth_methods>
+                        <a1><kerberos><realm>EXAMPLE.COM</realm></kerberos></a1>
+                        <a2><kerberos><realm>TEST.ORG</realm></kerberos></a2>
+                    </auth_methods>
+                </test_user>
+            </users>
+        </clickhouse>
+    )";
+
+    auto config = createConfigFromXML(xml_config);
+    storage->setConfig(*config);
+
+    auto user = storage->tryRead<User>("test_user");
+    ASSERT_TRUE(user);
+    ASSERT_EQ(user->authentication_methods.size(), 2);
+
+    for (const auto & auth_method : user->authentication_methods)
+        EXPECT_EQ(auth_method.getType(), AuthenticationType::KERBEROS);
+}
+
+TEST_F(UsersConfigMultipleAuthTest, KerberosWithoutRealm)
+{
+    const std::string xml_config = R"(
+        <clickhouse>
+            <users>
+                <test_user>
+                    <kerberos/>
+                </test_user>
+            </users>
+        </clickhouse>
+    )";
+
+    auto config = createConfigFromXML(xml_config);
+    storage->setConfig(*config);
+
+    auto user = storage->tryRead<User>("test_user");
+    ASSERT_TRUE(user);
+    ASSERT_EQ(user->authentication_methods.size(), 1);
+    EXPECT_EQ(user->authentication_methods[0].getType(), AuthenticationType::KERBEROS);
+    EXPECT_EQ(user->authentication_methods[0].getKerberosRealm(), "");
+}
+
+TEST_F(UsersConfigMultipleAuthTest, SingleHTTPAuthentication)
+{
+    const std::string xml_config = R"(
+        <clickhouse>
+            <users>
+                <test_user>
+                    <http_authentication>
+                        <server>http_auth_server</server>
+                        <scheme>basic</scheme>
+                    </http_authentication>
+                </test_user>
+            </users>
+        </clickhouse>
+    )";
+
+    auto config = createConfigFromXML(xml_config);
+    storage->setConfig(*config);
+    
+    auto user = storage->tryRead<User>("test_user");
+    ASSERT_TRUE(user);
+    ASSERT_EQ(user->authentication_methods.size(), 1);
+    EXPECT_EQ(user->authentication_methods[0].getType(), AuthenticationType::HTTP);
+}
+
+TEST_F(UsersConfigMultipleAuthTest, MultipleHTTPAuthenticationMethods)
+{
+    const std::string xml_config = R"(
+        <clickhouse>
+            <users>
+                <test_user>
+                    <auth_methods>
+                        <a1><http_authentication><server>http_auth_server_1</server><scheme>basic</scheme></http_authentication></a1>
+                        <a2><http_authentication><server>http_auth_server_2</server><scheme>basic</scheme></http_authentication></a2>
+                    </auth_methods>
+                </test_user>
+            </users>
+        </clickhouse>
+    )";
+
+    auto config = createConfigFromXML(xml_config);
+    storage->setConfig(*config);
+
+    auto user = storage->tryRead<User>("test_user");
+    ASSERT_TRUE(user);
+    ASSERT_EQ(user->authentication_methods.size(), 2);
+
+    for (const auto & auth_method : user->authentication_methods)
+        EXPECT_EQ(auth_method.getType(), AuthenticationType::HTTP);
+}
+
+TEST_F(UsersConfigMultipleAuthTest, SingleHTTPAuthenticationWithWrapper)
+{
+    const std::string xml_config = R"(
+        <clickhouse>
+            <users>
+                <test_user>
+                    <auth_methods>
+                        <method1>
+                            <http_authentication>
+                                <server>http_auth_server</server>
+                                <scheme>basic</scheme>
+                            </http_authentication>
+                        </method1>
+                    </auth_methods>
+                </test_user>
+            </users>
+        </clickhouse>
+    )";
+
+    auto config = createConfigFromXML(xml_config);
+    storage->setConfig(*config);
+
+    auto user = storage->tryRead<User>("test_user");
+    ASSERT_TRUE(user);
+    ASSERT_EQ(user->authentication_methods.size(), 1);
+    EXPECT_EQ(user->authentication_methods[0].getType(), AuthenticationType::HTTP);
+    EXPECT_EQ(user->authentication_methods[0].getHTTPAuthenticationServerName(), "http_auth_server");
+    EXPECT_EQ(user->authentication_methods[0].getHTTPAuthenticationScheme(), HTTPAuthenticationScheme::BASIC);
+}
+
+TEST_F(UsersConfigMultipleAuthTest, HTTPAuthenticationMissingSchemeError)
+{
+    const std::string xml_config = R"(
+        <clickhouse>
+            <users>
+                <test_user>
+                    <http_authentication>
+                        <server>http_auth_server</server>
+                    </http_authentication>
+                </test_user>
+            </users>
+        </clickhouse>
+    )";
+
+    auto config = createConfigFromXML(xml_config);
+    EXPECT_THROW(storage->setConfig(*config), Exception);
+}
+
+TEST_F(UsersConfigMultipleAuthTest, HTTPAuthenticationMissingServerError)
+{
+    const std::string xml_config = R"(
+        <clickhouse>
+            <users>
+                <test_user>
+                    <http_authentication>
+                        <scheme>basic</scheme>
+                    </http_authentication>
+                </test_user>
+            </users>
+        </clickhouse>
+    )";
+
+    auto config = createConfigFromXML(xml_config);
+    EXPECT_THROW(storage->setConfig(*config), Exception);
+}
+
+TEST_F(UsersConfigMultipleAuthTest, HTTPAuthenticationEmptyError)
+{
+    const std::string xml_config = R"(
+        <clickhouse>
+            <users>
+                <test_user>
+                    <http_authentication/>
+                </test_user>
+            </users>
+        </clickhouse>
+    )";
+
+    auto config = createConfigFromXML(xml_config);
+    EXPECT_THROW(storage->setConfig(*config), Exception);
+}
+
+TEST_F(UsersConfigMultipleAuthTest, HTTPAuthenticationNestedMethodsWithoutServerSchemeError)
+{
+    const std::string xml_config = R"(
+        <clickhouse>
+            <users>
+                <test_user>
+                    <http_authentication>
+                        <method1>
+                            <server>http_auth_server</server>
+                            <scheme>basic</scheme>
+                        </method1>
+                    </http_authentication>
+                </test_user>
+            </users>
+        </clickhouse>
+    )";
+
+    auto config = createConfigFromXML(xml_config);
+    EXPECT_THROW(storage->setConfig(*config), Exception);
+}
+
+TEST_F(UsersConfigMultipleAuthTest, MultipleHTTPAuthenticationMissingSchemeError)
+{
+    const std::string xml_config = R"(
+        <clickhouse>
+            <users>
+                <test_user>
+                    <auth_methods>
+                        <a1>
+                            <http_authentication>
+                                <server>http_auth_server_1</server>
+                                <scheme>basic</scheme>
+                            </http_authentication>
+                        </a1>
+                        <a2>
+                            <http_authentication>
+                                <server>http_auth_server_2</server>
+                            </http_authentication>
+                        </a2>
+                    </auth_methods>
+                </test_user>
+            </users>
+        </clickhouse>
+    )";
+
+    auto config = createConfigFromXML(xml_config);
+    EXPECT_THROW(storage->setConfig(*config), Exception);
+}
+
+TEST_F(UsersConfigMultipleAuthTest, HTTPAuthenticationMixedSyntax)
+{
+    const std::string xml_config = R"(
+        <clickhouse>
+            <users>
+                <test_user>
+                    <http_authentication>
+                        <server>primary_server</server>
+                        <scheme>basic</scheme>
+                        <method1>
+                            <server>other_server</server>
+                            <scheme>basic</scheme>
+                        </method1>
+                    </http_authentication>
+                </test_user>
+            </users>
+        </clickhouse>
+    )";
+
+    auto config = createConfigFromXML(xml_config);
+    storage->setConfig(*config);
+    
+    auto user = storage->tryRead<User>("test_user");
+    ASSERT_TRUE(user);
+    // When un-nested server/scheme are present other http authn methods are ignored
+    ASSERT_EQ(user->authentication_methods.size(), 1);
+    EXPECT_EQ(user->authentication_methods[0].getHTTPAuthenticationServerName(), "primary_server");
+    EXPECT_EQ(user->authentication_methods[0].getHTTPAuthenticationScheme(), HTTPAuthenticationScheme::BASIC);
+    EXPECT_EQ(user->authentication_methods[0].getType(), AuthenticationType::HTTP);
+}
+
+TEST_F(UsersConfigMultipleAuthTest, MixedAuthenticationMethods)
+{
+    const std::string xml_config = R"(
+        <clickhouse>
+            <users>
+                <test_user>
+                    <auth_methods>
+                        <a1><password>plaintext_pass1</password></a1>
+                        <a2><password>plaintext_pass2</password></a2>
+                        <a3><password_sha256_hex>e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855</password_sha256_hex></a3>
+                        <a4><ldap><server>ldap_server_1</server></ldap></a4>
+                    </auth_methods>
+                </test_user>
+            </users>
+        </clickhouse>
+    )";
+
+    auto config = createConfigFromXML(xml_config);
+    storage->setConfig(*config);
+
+    auto user = storage->tryRead<User>("test_user");
+    ASSERT_TRUE(user);
+    ASSERT_EQ(user->authentication_methods.size(), 4);
+
+    int plaintext_count = 0;
+    int sha256_count = 0;
+    int ldap_count = 0;
+
+    for (const auto & auth_method : user->authentication_methods)
+    {
+        switch (auth_method.getType())
+        {
+            case AuthenticationType::PLAINTEXT_PASSWORD: 
+                plaintext_count++; 
+                break;
+            case AuthenticationType::SHA256_PASSWORD:    
+                sha256_count++;    
+                break;
+            case AuthenticationType::LDAP:               
+                ldap_count++;      
+                break;
+            default: 
+                FAIL() << "Unexpected authentication type";
+        }
+    }
+
+    EXPECT_EQ(plaintext_count, 2);
+    EXPECT_EQ(sha256_count, 1);
+    EXPECT_EQ(ldap_count, 1);
+}
+
+// ---------------------------------------------------------------------------
+// Nested auth_methods format tests
+// ---------------------------------------------------------------------------
+
+TEST_F(UsersConfigMultipleAuthTest, NestedNoPasswordInAuthMethods)
+{
+    const std::string xml_config = R"(
+        <clickhouse>
+            <users>
+                <test_user>
+                    <auth_methods>
+                        <auth1>
+                            <no_password/>
+                        </auth1>
+                    </auth_methods>
+                </test_user>
+            </users>
+        </clickhouse>
+    )";
+
+    auto config = createConfigFromXML(xml_config);
+    storage->setConfig(*config);
+
+    auto user = storage->tryRead<User>("test_user");
+    ASSERT_TRUE(user);
+    ASSERT_EQ(user->authentication_methods.size(), 1);
+    EXPECT_EQ(user->authentication_methods[0].getType(), AuthenticationType::NO_PASSWORD);
+}
+
+TEST_F(UsersConfigMultipleAuthTest, NestedNoPasswordInMultipleAuthMethodsIsDisallowed)
+{
+    const std::string xml_config = R"(
+        <clickhouse>
+            <users>
+                <test_user>
+                    <auth_methods>
+                        <auth1>
+                            <no_password/>
+                        </auth1>
+                        <auth2>
+                            <password>plaintext_pass1</password>
+                        </auth2>
+                    </auth_methods>
+                </test_user>
+            </users>
+        </clickhouse>
+    )";
+
+    auto config = createConfigFromXML(xml_config);
+    EXPECT_THROW(storage->setConfig(*config), Exception);
+}
+
+TEST_F(UsersConfigMultipleAuthTest, EmptyAuthMethodsIsDisallowed)
+{
+    const std::string xml_config = R"(
+        <clickhouse>
+            <users>
+                <test_user>
+                    <auth_methods/>
+                </test_user>
+            </users>
+        </clickhouse>
+    )";
+
+    auto config = createConfigFromXML(xml_config);
+    EXPECT_THROW(storage->setConfig(*config), Exception);
+}
+
+TEST_F(UsersConfigMultipleAuthTest, OTPInsideAuthMethodIsDisallowed)
+{
+    const std::string xml_config = R"(
+        <clickhouse>
+            <users>
+                <test_user>
+                    <auth_methods>
+                        <a1>
+                            <time_based_one_time_password>
+                                <secret>JBSWY3DPEHPK3PXP</secret>
+                            </time_based_one_time_password>
+                            <password>plaintext_pass1</password>
+                        </a1>
+                    </auth_methods>
+                </test_user>
+            </users>
+        </clickhouse>
+    )";
+
+    auto config = createConfigFromXML(xml_config);
+    EXPECT_THROW(storage->setConfig(*config), Exception);
+}
+
+TEST_F(UsersConfigMultipleAuthTest, NestedSinglePlaintextPassword)
+{
+    const std::string xml_config = R"(
+        <clickhouse>
+            <users>
+                <test_user>
+                    <auth_methods>
+                        <auth1>
+                            <password>plaintext_pass</password>
+                        </auth1>
+                    </auth_methods>
+                </test_user>
+            </users>
+        </clickhouse>
+    )";
+
+    auto config = createConfigFromXML(xml_config);
+    storage->setConfig(*config);
+
+    auto user = storage->tryRead<User>("test_user");
+    ASSERT_TRUE(user);
+    ASSERT_EQ(user->authentication_methods.size(), 1);
+    EXPECT_EQ(user->authentication_methods[0].getType(), AuthenticationType::PLAINTEXT_PASSWORD);
+}
+
+TEST_F(UsersConfigMultipleAuthTest, NestedMultiplePlaintextPasswords)
+{
+    const std::string xml_config = R"(
+        <clickhouse>
+            <users>
+                <test_user>
+                    <auth_methods>
+                        <auth1>
+                            <password>pass1</password>
+                        </auth1>
+                        <auth2>
+                            <password>pass2</password>
+                        </auth2>
+                        <auth3>
+                            <password>pass3</password>
+                        </auth3>
+                    </auth_methods>
+                </test_user>
+            </users>
+        </clickhouse>
+    )";
+
+    auto config = createConfigFromXML(xml_config);
+    storage->setConfig(*config);
+
+    auto user = storage->tryRead<User>("test_user");
+    ASSERT_TRUE(user);
+    ASSERT_EQ(user->authentication_methods.size(), 3);
+    for (const auto & auth_method : user->authentication_methods)
+        EXPECT_EQ(auth_method.getType(), AuthenticationType::PLAINTEXT_PASSWORD);
+}
+
+TEST_F(UsersConfigMultipleAuthTest, NestedMixedAuthenticationTypes)
+{
+    const std::string xml_config = R"(
+        <clickhouse>
+            <users>
+                <test_user>
+                    <auth_methods>
+                        <plain>
+                            <password>plaintext_pass</password>
+                        </plain>
+                        <sha256>
+                            <password_sha256_hex>e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855</password_sha256_hex>
+                        </sha256>
+                        <double_sha1>
+                            <password_double_sha1_hex>eafbd9c4b3c8b40d509308e767b41671ee5bac68</password_double_sha1_hex>
+                        </double_sha1>
+                    </auth_methods>
+                </test_user>
+            </users>
+        </clickhouse>
+    )";
+
+    auto config = createConfigFromXML(xml_config);
+    storage->setConfig(*config);
+
+    auto user = storage->tryRead<User>("test_user");
+    ASSERT_TRUE(user);
+    ASSERT_EQ(user->authentication_methods.size(), 3);
+
+    int plaintext_count = 0;
+    int sha256_count = 0;
+    int double_sha1_count = 0;
+    for (const auto & auth_method : user->authentication_methods)
+    {
+        switch (auth_method.getType())
+        {
+            case AuthenticationType::PLAINTEXT_PASSWORD: 
+                plaintext_count++; 
+                break;
+            case AuthenticationType::SHA256_PASSWORD:    
+                sha256_count++;    
+                break;
+            case AuthenticationType::DOUBLE_SHA1_PASSWORD: 
+                double_sha1_count++; 
+                break;
+            default: 
+                FAIL() << "Unexpected authentication type";
+        }
+    }
+    EXPECT_EQ(plaintext_count, 1);
+    EXPECT_EQ(sha256_count, 1);
+    EXPECT_EQ(double_sha1_count, 1);
+}
+
+TEST_F(UsersConfigMultipleAuthTest, NestedLDAPAuthentication)
+{
+    const std::string xml_config = R"(
+        <clickhouse>
+            <users>
+                <test_user>
+                    <auth_methods>
+                        <ldap_method>
+                            <ldap>
+                                <server>my_ldap_server</server>
+                            </ldap>
+                        </ldap_method>
+                    </auth_methods>
+                </test_user>
+            </users>
+        </clickhouse>
+    )";
+
+    auto config = createConfigFromXML(xml_config);
+    storage->setConfig(*config);
+
+    auto user = storage->tryRead<User>("test_user");
+    ASSERT_TRUE(user);
+    ASSERT_EQ(user->authentication_methods.size(), 1);
+    EXPECT_EQ(user->authentication_methods[0].getType(), AuthenticationType::LDAP);
+    EXPECT_EQ(user->authentication_methods[0].getLDAPServerName(), "my_ldap_server");
+}
+
+TEST_F(UsersConfigMultipleAuthTest, NestedAndFlatFormatsCannotBeMixed)
+{
+    const std::string xml_config = R"(
+        <clickhouse>
+            <users>
+                <test_user>
+                    <password>some_password</password>
+                    <auth_methods>
+                        <auth1>
+                            <password>another_password</password>
+                        </auth1>
+                    </auth_methods>
+                </test_user>
+            </users>
+        </clickhouse>
+    )";
+
+    auto config = createConfigFromXML(xml_config);
+    EXPECT_THROW(storage->setConfig(*config), Exception);
+}
+
+TEST_F(UsersConfigMultipleAuthTest, NestedMultipleTypesPerMethodIsError)
+{
+    const std::string xml_config = R"(
+        <clickhouse>
+            <users>
+                <test_user>
+                    <auth_methods>
+                        <auth1>
+                            <password>pass</password>
+                            <password_sha256_hex>e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855</password_sha256_hex>
+                        </auth1>
+                    </auth_methods>
+                </test_user>
+            </users>
+        </clickhouse>
+    )";
+
+    auto config = createConfigFromXML(xml_config);
+    EXPECT_THROW(storage->setConfig(*config), Exception);
+}
+
+TEST_F(UsersConfigMultipleAuthTest, OTPWithNonPasswordAuthIsError)
+{
+    const std::string xml_config = R"(
+        <clickhouse>
+            <users>
+                <test_user>
+                    <auth_methods>
+                        <a1>
+                            <ldap><server>ldap_server_1</server></ldap>
+                        </a1>
+                    </auth_methods>
+                    <time_based_one_time_password>
+                        <secret>JBSWY3DPEHPK3PXP</secret>
+                    </time_based_one_time_password>
+                </test_user>
+            </users>
+        </clickhouse>
+    )";
+
+    auto config = createConfigFromXML(xml_config);
+    EXPECT_THROW(storage->setConfig(*config), Exception);
+}
+
+TEST_F(UsersConfigMultipleAuthTest, OTPWithMixedAuthIncludingPassword)
+{
+    const std::string xml_config = R"(
+        <clickhouse>
+            <users>
+                <test_user>
+                    <auth_methods>
+                        <a1>
+                            <ldap><server>ldap_server_1</server></ldap>
+                        </a1>
+                        <a2>
+                            <password>plaintext_pass</password>
+                        </a2>
+                    </auth_methods>
+                    <time_based_one_time_password>
+                        <secret>JBSWY3DPEHPK3PXP</secret>
+                    </time_based_one_time_password>
+                </test_user>
+            </users>
+        </clickhouse>
+    )";
+
+    auto config = createConfigFromXML(xml_config);
+    storage->setConfig(*config);
+
+    auto user = storage->tryRead<User>("test_user");
+    ASSERT_TRUE(user);
+    ASSERT_EQ(user->authentication_methods.size(), 2);
+    EXPECT_EQ(user->authentication_methods[0].getType(), AuthenticationType::LDAP);
+    EXPECT_EQ(user->authentication_methods[1].getType(), AuthenticationType::PLAINTEXT_PASSWORD);
+}

--- a/tests/integration/test_multiple_authentication_methods/configs/users_multiple_auth.xml
+++ b/tests/integration/test_multiple_authentication_methods/configs/users_multiple_auth.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0"?>
+<clickhouse>
+    <profiles>
+        <default/>
+    </profiles>
+    <quotas>
+        <default/>
+    </quotas>
+
+    <users>
+        <default>
+            <password/>
+
+            <networks>
+                <ip>::/0</ip>
+            </networks>
+
+            <profile>default</profile>
+            <quota>default</quota>
+
+            <access_management>1</access_management>
+            <named_collection_control>1</named_collection_control>
+        </default>
+
+        <multi_plaintext>
+            <auth_methods>
+                <auth1>
+                    <password>pass1</password>
+                </auth1>
+                <auth2>
+                    <password>pass2</password>
+                </auth2>
+                <auth3>
+                    <password>pass3</password>
+                </auth3>
+            </auth_methods>
+            <networks>
+                <ip>::/0</ip>
+            </networks>
+            <profile>default</profile>
+            <quota>default</quota>
+        </multi_plaintext>
+
+        <multi_sha256>
+            <auth_methods>
+                <auth1>
+                    <password_sha256_hex>9dfac01df9d7d3cc3d6843deb5d9adbf4c8d58f717e804779f4765d96b6213ac</password_sha256_hex>
+                </auth1>
+                <auth2>
+                    <password_sha256_hex>fc8155c356bc956050cacb75e7c40b1cf93aa896305f687f421eaf65c839fa2d</password_sha256_hex>
+                </auth2>
+            </auth_methods>
+            <networks>
+                <ip>::/0</ip>
+            </networks>
+            <profile>default</profile>
+            <quota>default</quota>
+        </multi_sha256>
+
+        <mixed_auth>
+            <auth_methods>
+                <plain>
+                    <password>plain_pass</password>
+                </plain>
+                <dsha1_1>
+                    <password_double_sha1_hex>eafbd9c4b3c8b40d509308e767b41671ee5bac68</password_double_sha1_hex>
+                </dsha1_1>
+                <dsha1_2>
+                    <password_double_sha1_hex>7e4ca4bb0df85c1106f39516a0753013b79b32ff</password_double_sha1_hex>
+                </dsha1_2>
+            </auth_methods>
+            <networks>
+                <ip>::/0</ip>
+            </networks>
+            <profile>default</profile>
+            <quota>default</quota>
+        </mixed_auth>
+    </users>
+</clickhouse>

--- a/tests/integration/test_multiple_authentication_methods/test.py
+++ b/tests/integration/test_multiple_authentication_methods/test.py
@@ -1,0 +1,75 @@
+import pytest
+from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import TSV
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance(
+    "node",
+    user_configs=[
+        "configs/users_multiple_auth.xml",
+    ],
+)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_multiple_plaintext_passwords(started_cluster):
+    """User with multiple plaintext passwords can authenticate with any of them"""
+    for password in ["pass1", "pass2", "pass3"]:
+        result = node.query("SELECT currentUser()", user="multi_plaintext", password=password)
+        assert result.strip() == "multi_plaintext"
+
+    with pytest.raises(Exception):
+        node.query("SELECT currentUser()", user="multi_plaintext", password="wrong_pass")
+
+
+def test_multiple_sha256_passwords(started_cluster):
+    """User with multiple SHA256 passwords can authenticate with any of them"""
+    result = node.query("SELECT currentUser()", user="multi_sha256", password="sha256_pass_1")
+    assert result.strip() == "multi_sha256"
+
+    result = node.query("SELECT currentUser()", user="multi_sha256", password="sha256_pass_2")
+    assert result.strip() == "multi_sha256"
+
+    with pytest.raises(Exception):
+        node.query("SELECT currentUser()", user="multi_sha256", password="wrong_pass")
+
+
+def test_mixed_authentication_methods(started_cluster):
+    """User with mixed auth types (plaintext + double_sha1) can authenticate with any of them"""
+    result = node.query("SELECT currentUser()", user="mixed_auth", password="plain_pass")
+    assert result.strip() == "mixed_auth"
+
+    result = node.query("SELECT currentUser()", user="mixed_auth", password="double_sha1_pass_1")
+    assert result.strip() == "mixed_auth"
+
+    result = node.query("SELECT currentUser()", user="mixed_auth", password="double_sha1_pass_2")
+    assert result.strip() == "mixed_auth"
+
+    with pytest.raises(Exception):
+        node.query("SELECT currentUser()", user="mixed_auth", password="wrong_pass")
+
+
+def test_auth_types_in_system_table(started_cluster):
+    """system.users reflects the correct auth types for all users"""
+    result = node.query(
+        "SELECT arrayJoin(auth_type) AS auth_type FROM system.users WHERE name = 'multi_plaintext' ORDER BY auth_type"
+    )
+    assert TSV(result) == TSV([["plaintext_password"]] * 3)
+
+    result = node.query(
+        "SELECT arrayJoin(auth_type) AS auth_type FROM system.users WHERE name = 'multi_sha256' ORDER BY auth_type"
+    )
+    assert TSV(result) == TSV([["sha256_password"]] * 2)
+
+    result = node.query(
+        "SELECT arrayJoin(auth_type) AS auth_type FROM system.users WHERE name = 'mixed_auth' ORDER BY auth_type"
+    )
+    assert TSV(result) == TSV([["plaintext_password"], ["double_sha1_password"], ["double_sha1_password"]])

--- a/tests/integration/test_multiple_authentication_methods/test.py
+++ b/tests/integration/test_multiple_authentication_methods/test.py
@@ -58,18 +58,24 @@ def test_mixed_authentication_methods(started_cluster):
 
 
 def test_auth_types_in_system_table(started_cluster):
-    """system.users reflects the correct auth types for all users"""
+    """system.users reflects the correct auth types for all users.
+
+    auth_type is Enum8, so ORDER BY auth_type sorts by numeric enum value, not
+    alphabetically by name. The expected values below must match that ordering:
+      plaintext_password = 1, double_sha1_password = 3, sha256_password = 2.
+    """
     result = node.query(
-        "SELECT arrayJoin(auth_type) AS auth_type FROM system.users WHERE name = 'multi_plaintext' ORDER BY auth_type"
+        "SELECT arrayJoin(arraySort(auth_type)) AS auth_type FROM system.users WHERE name = 'multi_plaintext'"
     )
     assert TSV(result) == TSV([["plaintext_password"]] * 3)
 
     result = node.query(
-        "SELECT arrayJoin(auth_type) AS auth_type FROM system.users WHERE name = 'multi_sha256' ORDER BY auth_type"
+        "SELECT arrayJoin(arraySort(auth_type)) AS auth_type FROM system.users WHERE name = 'multi_sha256'"
     )
     assert TSV(result) == TSV([["sha256_password"]] * 2)
 
     result = node.query(
-        "SELECT arrayJoin(auth_type) AS auth_type FROM system.users WHERE name = 'mixed_auth' ORDER BY auth_type"
+        "SELECT arrayJoin(arraySort(auth_type)) AS auth_type FROM system.users WHERE name = 'mixed_auth'"
     )
+    # plaintext_password(1) < double_sha1_password(3), so plaintext comes first
     assert TSV(result) == TSV([["plaintext_password"], ["double_sha1_password"], ["double_sha1_password"]])

--- a/tests/integration/test_ssl_cert_authentication/configs/users_with_ssl_auth.xml
+++ b/tests/integration/test_ssl_cert_authentication/configs/users_with_ssl_auth.xml
@@ -28,5 +28,18 @@
         <jane>
             <password>qwe123</password>
         </jane>
+        <trurl>
+            <auth_methods>
+                <cert>
+                    <ssl_certificates>
+                        <subject_alt_name>URI:spiffe://foo.com/bar</subject_alt_name>
+                    </ssl_certificates>
+                </cert>
+                <pw>
+                    <!-- Hash of "mixed_sha_pass" -->
+                    <password_sha256_hex>944495bf3c516d8dd9d318a047cac2d15db940cd836f95bc8bbb3e83fe3f15ad</password_sha256_hex>
+                </pw>
+            </auth_methods>
+        </trurl>
     </users>
 </clickhouse>

--- a/tests/integration/test_ssl_cert_authentication/test.py
+++ b/tests/integration/test_ssl_cert_authentication/test.py
@@ -297,6 +297,30 @@ def test_https_non_ssl_auth():
     # TODO: Add non-flaky tests for:
     # - sending wrong cert
 
+def test_mixed_x509_san_password_support():
+    assert (
+        execute_query_https("SELECT currentUser()", user="trurl", cert_name="client4")
+        == "trurl\n"
+    )
+    assert (
+        execute_query_https("SELECT currentUser()", enable_ssl_auth=False, user="trurl", password="mixed_sha_pass")
+        == "trurl\n"
+    )
+
+    # Verify that system.users shows both auth methods (sha256_password + ssl_certificate)
+    # for user 'trurl'. Sort by auth_type name for a deterministic assertion regardless of
+    # config order. Both columns are extracted from a single sorted zip to keep them aligned.
+    assert (
+        instance.query(
+            "SELECT name, "
+            "arrayMap(x -> toString(x.1), s) AS auth_type, "
+            "arrayMap(x -> x.2, s) AS auth_params "
+            "FROM (SELECT name, arraySort(x -> toString(x.1), arrayZip(auth_type, auth_params)) AS s "
+            "FROM system.users WHERE name='trurl')"
+        )
+        == 'trurl\t[\'sha256_password\',\'ssl_certificate\']\t[\'{}\',\'{"subject_alt_names":["URI:spiffe:\\\\/\\\\/foo.com\\\\/bar"]}\']\n'
+    )
+    
 
 def test_create_user():
     instance.query("DROP USER IF EXISTS emma")

--- a/tests/integration/test_ssl_cert_authentication/test.py
+++ b/tests/integration/test_ssl_cert_authentication/test.py
@@ -3,6 +3,7 @@ import os.path
 import ssl
 import urllib.parse
 import urllib.request
+import uuid
 from os import remove
 
 import pytest
@@ -55,7 +56,7 @@ config = """<clickhouse>
 
 
 def execute_query_native(node, query, user, cert_name, password=None):
-    config_path = f"{SCRIPT_DIR}/configs/client.xml"
+    config_path = f"{SCRIPT_DIR}/configs/client_{uuid.uuid4().hex}.xml"
 
     formatted = config.format(
         certificateFile=f"{SCRIPT_DIR}/certs/{cert_name}-cert.pem",
@@ -76,12 +77,9 @@ def execute_query_native(node, query, user, cert_name, password=None):
     )
 
     try:
-        result = client.query(query, user=user, password=password)
+        return client.query(query, user=user, password=password)
+    finally:
         remove(config_path)
-        return result
-    except:
-        remove(config_path)
-        raise
 
 
 def test_native():


### PR DESCRIPTION
### Changelog category (leave one):

- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Users can now specify multiple authentication methods in users_xml configuration 
### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user authentication parsing and validation, which can affect login behavior and security-related configuration errors. Risk is mitigated by extensive new unit/integration coverage but misconfigurations may now be rejected differently.
> 
> **Overview**
> Adds support for specifying **multiple authentication methods per user** in `users.xml` via a new `<auth_methods>` section, appending each parsed method into `User::authentication_methods`.
> 
> Refactors auth parsing into `parseUserAuthMethod()` and tightens validation: forbids mixing `<auth_methods>` with flat auth fields, disallows `no_password` inside `<auth_methods>` (and combining it with other methods), enforces OTP usage only when at least one password-based method exists, and improves `http_authentication` required-field error handling.
> 
> Adds comprehensive gtests for multi-auth parsing and new integration tests covering multi-password/mixed auth logins plus an SSL+password mixed user scenario.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7423423d87dc9363261e2245647bd1ae5502f8d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.455`
<!-- ch-version-info:end -->