### PR TITLE
Fix flaky 00906_low_cardinality_cache

### DIFF
--- a/tests/queries/0_stateless/00906_low_cardinality_cache.sql
+++ b/tests/queries/0_stateless/00906_low_cardinality_cache.sql
@@ -1,10 +1,8 @@
 -- Tags: long
 
 SET max_rows_to_read = '100M', max_execution_time = 600;
--- INSERT performance optimization
-SET max_insert_threads=6, max_threads=4;
 drop table if exists lc_00906;
 create table lc_00906 (b LowCardinality(String)) engine=MergeTree order by b SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi', vertical_merge_algorithm_min_rows_to_activate=100000000;
-insert into lc_00906 select '0123456789' from numbers(100000000);
+insert into lc_00906 select '0123456789' from numbers(100000000) SETTINGS max_insert_threads=6, max_threads=4;
 select count(), b from lc_00906 group by b;
 drop table if exists lc_00906;

--- a/tests/queries/0_stateless/00906_low_cardinality_cache.sql
+++ b/tests/queries/0_stateless/00906_low_cardinality_cache.sql
@@ -1,8 +1,10 @@
 -- Tags: long
 
 SET max_rows_to_read = '100M', max_execution_time = 600;
+-- INSERT performance optimization
+SET max_insert_threads=6, max_threads=4;
 drop table if exists lc_00906;
-create table lc_00906 (b LowCardinality(String)) engine=MergeTree order by b SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+create table lc_00906 (b LowCardinality(String)) engine=MergeTree order by b SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi', vertical_merge_algorithm_min_rows_to_activate=100000000;
 insert into lc_00906 select '0123456789' from numbers(100000000);
 select count(), b from lc_00906 group by b;
 drop table if exists lc_00906;


### PR DESCRIPTION
Close https://github.com/ClickHouse/ClickHouse/issues/91024
[CIDB](https://play.clickhouse.com/play?user=play&run=1#V0lUSAogICAgOTAgQVMgaW50ZXJ2YWxfZGF5cwpTRUxFQ1QKICAgIHRvU3RhcnRPZkRheShjaGVja19zdGFydF90aW1lKSBBUyBkYXksCiAgICBjb3VudCgpIEFTIGZhaWx1cmVzLAogICAgZ3JvdXBVbmlxQXJyYXkocHVsbF9yZXF1ZXN0X251bWJlcikgQVMgcHJzLAogICAgYW55KHJlcG9ydF91cmwpIEFTIHJlcG9ydF91cmwKRlJPTSBjaGVja3MKV0hFUkUgKG5vdygpIC0gdG9JbnRlcnZhbERheShpbnRlcnZhbF9kYXlzKSkgPD0gY2hlY2tfc3RhcnRfdGltZQogICAgQU5EIHRlc3RfbmFtZSA9ICcwMDkwNl9sb3dfY2FyZGluYWxpdHlfY2FjaGUnCiAgICAtLSBBTkQgY2hlY2tfbmFtZSA9ICdTdGF0ZWxlc3MgdGVzdHMgKGFtZF9tc2FuLCBwYXJhbGxlbCknCiAgICBBTkQgdGVzdF9zdGF0dXMgSU4gKCdGQUlMJywgJ0VSUk9SJykKICAgIEFORCAoKGhlYWRfcmVmID0gJ21hc3RlcicgQU5EIHB1bGxfcmVxdWVzdF9udW1iZXIgPSAwKSBPUiBwdWxsX3JlcXVlc3RfbnVtYmVyICE9IDApCkdST1VQIEJZIGRheQpPUkRFUiBCWSBkYXkgREVTQwo=)

Test failing with error
```
2025-12-11 17:43:56 Reason: return code:  160
2025-12-11 17:43:56 [d5a9c726ee24] 2025.12.11 18:43:42.531310 [ 1074893 ] {ac8c8ad8-4936-4da8-b2d8-bb89c4099753} <Error> executeQuery: Code: 160. DB::Exception: Estimated query execution time (778.76271 seconds) is too long. Maximum: 600. Estimated rows to process: 100000000 (38535385 read in 300.09921 seconds): While executing NumbersRange. (TOO_SLOW) (version 25.12.1.450) (from [::1]:37188) (comment: 00906_low_cardinality_cache.sql-test_u9huuo15) (query 4, line 6) (in query: insert into lc_00906 select '0123456789' from numbers(100000000);), Stack trace (when copying this message, always include the lines below):
2025-12-11 17:43:56 
2025-12-11 17:43:56 0. ./contrib/llvm-project/libcxx/include/__exception/exception.h:113: Poco::Exception::Exception(String const&, int) @ 0x000000002e98bee0
2025-12-11 17:43:56 1. ./ci/tmp/build/./src/Common/Exception.cpp:131: DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x0000000015fb52b4
2025-12-11 17:43:56 2. DB::Exception::Exception(String&&, int, String, bool) @ 0x0000000009b94c2e
2025-12-11 17:43:56 3. DB::Exception::Exception(PreformattedMessage&&, int) @ 0x0000000009b944c9
2025-12-11 17:43:56 4. ./src/Common/Exception.h:141: DB::Exception::Exception<double&, int, unsigned long&, unsigned long&, double&>(int, FormatStringHelperImpl<std::type_identity<double&>::type, std::type_identity<int>::type, std::type_identity<unsigned long&>::type, std::type_identity<unsigned long&>::type, std::type_identity<double&>::type>, double&, int&&, unsigned long&, unsigned long&, double&) @ 0x000000001e09635c
2025-12-11 17:43:56 5. ./ci/tmp/build/./src/QueryPipeline/ExecutionSpeedLimits.cpp:87: DB::ExecutionSpeedLimits::throttle(unsigned long, unsigned long, unsigned long, unsigned long, DB::OverflowMode) const @ 0x000000001e095e8a
2025-12-11 17:43:56 6. ./ci/tmp/build/./src/QueryPipeline/ReadProgressCallback.cpp:107: DB::ReadProgressCallback::onProgress(unsigned long, unsigned long, std::list<DB::StorageLimits, std::allocator<DB::StorageLimits>> const&) @ 0x000000001e0953c1
2025-12-11 17:43:56 7. ./ci/tmp/build/./src/Processors/Executors/ExecutionThreadContext.cpp:68: DB::ExecutionThreadContext::executeTask() @ 0x00000000262dd33a
2025-12-11 17:43:56 8. ./ci/tmp/build/./src/Processors/Executors/PipelineExecutor.cpp:351: DB::PipelineExecutor::executeStepImpl(unsigned long, DB::IAcquiredSlot*, std::atomic<bool>*) @ 0x00000000262c95d9
2025-12-11 17:43:56 9. ./ci/tmp/build/./src/Processors/Executors/PipelineExecutor.cpp:279: DB::PipelineExecutor::executeImpl(unsigned long, bool) @ 0x00000000262c879e
2025-12-11 17:43:56 10. ./ci/tmp/build/./src/Processors/Executors/PipelineExecutor.cpp:136: DB::PipelineExecutor::execute(unsigned long, bool) @ 0x00000000262c81ea
2025-12-11 17:43:56 11. ./ci/tmp/build/./src/Processors/Executors/CompletedPipelineExecutor.cpp:42: void std::__function::__policy_func<void ()>::__call_func[abi:ne210105]<ThreadFromGlobalPoolImpl<true, true>::ThreadFromGlobalPoolImpl<DB::CompletedPipelineExecutor::execute()::$_0>(DB::CompletedPipelineExecutor::execute()::$_0&&)::'lambda'()>(std::__function::__policy_storage const*) @ 0x00000000262c6db2
2025-12-11 17:43:56 12. ./contrib/llvm-project/libcxx/include/__functional/function.h:508: ? @ 0x0000000016183131
2025-12-11 17:43:56 13. ./contrib/llvm-project/libcxx/include/__type_traits/invoke.h:0: void* std::__thread_proxy[abi:ne210105]<std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void (ThreadPoolImpl<std::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::thread>::ThreadFromThreadPool*>>(void*) @ 0x000000001618d21c
2025-12-11 17:43:56 14. __tsan_thread_start_func @ 0x0000000009affab8
2025-12-11 17:43:56 15. ? @ 0x0000000000094ac3
2025-12-11 17:43:56 16. ? @ 0x00000000001268c0
2025-12-11 17:43:56 
2025-12-11 17:43:56 Received exception from server (version 25.12.1):
2025-12-11 17:43:56 Code: 160. DB::Exception: Received from localhost:9000. DB::Exception: Estimated query execution time (778.76271 seconds) is too long. Maximum: 600. Estimated rows to process: 100000000 (38535385 read in 300.09921 seconds): While executing NumbersRange. (TOO_SLOW)
2025-12-11 17:43:56 (query: insert into lc_00906 select '0123456789' from numbers(100000000);)

```

I've analyzed 10 reports and found out that it fail most of the time when settings `max_threads`, `max_insert_threads` and/or `vertical_merge_algorithm_min_rows_to_activate` set to 1.
 
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix flaky 00906_low_cardinality_cache


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
