### PR TITLE
In DDLWorker, mark replicas as active periodically

### DIFF
--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -5257,25 +5257,32 @@ void Context::startClusterDiscovery()
 /// On repeating calls updates existing clusters and adds new clusters, doesn't delete old clusters
 void Context::setClustersConfig(const ConfigurationPtr & config, bool enable_discovery, const String & config_name)
 {
-    std::lock_guard lock(shared->clusters_mutex);
-    if (ConfigHelper::getBool(*config, "allow_experimental_cluster_discovery") && enable_discovery && !shared->cluster_discovery)
     {
-        shared->cluster_discovery = std::make_unique<ClusterDiscovery>(*config, getGlobalContext(), getMacros());
+        std::lock_guard lock(shared->clusters_mutex);
+        if (ConfigHelper::getBool(*config, "allow_experimental_cluster_discovery") && enable_discovery && !shared->cluster_discovery)
+        {
+            shared->cluster_discovery = std::make_unique<ClusterDiscovery>(*config, getGlobalContext(), getMacros());
+        }
+
+        /// Do not update clusters if this part of config wasn't changed.
+        if (shared->clusters && isSameConfiguration(*config, *shared->clusters_config, config_name))
+            return;
+
+        auto old_clusters_config = shared->clusters_config;
+        shared->clusters_config = config;
+
+        if (!shared->clusters)
+            shared->clusters = std::make_shared<Clusters>(*shared->clusters_config, *settings, getMacros(), config_name);
+        else
+            shared->clusters->updateClusters(*shared->clusters_config, *settings, config_name, old_clusters_config);
+
+        ++shared->clusters_version;
     }
-
-    /// Do not update clusters if this part of config wasn't changed.
-    if (shared->clusters && isSameConfiguration(*config, *shared->clusters_config, config_name))
-        return;
-
-    auto old_clusters_config = shared->clusters_config;
-    shared->clusters_config = config;
-
-    if (!shared->clusters)
-        shared->clusters = std::make_shared<Clusters>(*shared->clusters_config, *settings, getMacros(), config_name);
-    else
-        shared->clusters->updateClusters(*shared->clusters_config, *settings, config_name, old_clusters_config);
-
-    ++shared->clusters_version;
+    {
+        SharedLockGuard lock(shared->mutex);
+        if (shared->ddl_worker)
+            shared->ddl_worker->notifyHostIDsUpdated();
+    }
 }
 
 size_t Context::getClustersVersion() const

--- a/src/Interpreters/DDLWorker.h
+++ b/src/Interpreters/DDLWorker.h
@@ -1,7 +1,10 @@
 #pragma once
 
+#include <Core/Names.h>
+#include <Interpreters/Context_fwd.h>
 #include <Parsers/IAST_fwd.h>
 #include <Storages/IStorage_fwd.h>
+#include <Poco/Event.h>
 #include <Common/CurrentMetrics.h>
 #include <Common/CurrentThread.h>
 #include <Common/DNSResolver.h>
@@ -9,8 +12,6 @@
 #include <Common/ThreadPool_fwd.h>
 #include <Common/ZooKeeper/IKeeper.h>
 #include <Common/ZooKeeper/ZooKeeper.h>
-#include <Interpreters/Context_fwd.h>
-#include <Poco/Event.h>
 
 #include <atomic>
 #include <list>
@@ -94,6 +95,8 @@ public:
     /// Should be called in `initializeMainThread` only, so if it is expired, `runMainThread` will reinitialized the state.
     ZooKeeperPtr getAndSetZooKeeper();
 
+    void notifyHostIDsUpdated();
+
 protected:
 
     class ConcurrentSet
@@ -173,6 +176,8 @@ protected:
     void runMainThread();
     void runCleanupThread();
 
+    NameSet getAllHostIDsFromClusters() const;
+
     ContextMutablePtr context;
     LoggerPtr log;
 
@@ -210,6 +215,7 @@ protected:
     /// Cleaning starts after new node event is received if the last cleaning wasn't made sooner than N seconds ago
     Int64 cleanup_delay_period = 60; // minute (in seconds)
     Int64 mark_replicas_active_interval_seconds = 60;
+    std::atomic_bool host_ids_updated{false};
     /// Delete node if its age is greater than that
     Int64 task_max_lifetime = 7 * 24 * 60 * 60; // week (in seconds)
     /// How many tasks could be in the queue

--- a/src/Interpreters/DDLWorker.h
+++ b/src/Interpreters/DDLWorker.h
@@ -209,6 +209,7 @@ protected:
 
     /// Cleaning starts after new node event is received if the last cleaning wasn't made sooner than N seconds ago
     Int64 cleanup_delay_period = 60; // minute (in seconds)
+    Int64 mark_replicas_active_interval_seconds = 60;
     /// Delete node if its age is greater than that
     Int64 task_max_lifetime = 7 * 24 * 60 * 60; // week (in seconds)
     /// How many tasks could be in the queue

--- a/tests/integration/test_distributed_ddl_on_database_cluster/configs/config.d/remote_servers.xml
+++ b/tests/integration/test_distributed_ddl_on_database_cluster/configs/config.d/remote_servers.xml
@@ -1,0 +1,4 @@
+<clickhouse>
+    <remote_servers>
+    </remote_servers>
+</clickhouse>

--- a/tests/integration/test_distributed_ddl_on_database_cluster/configs/config.d/settings.xml
+++ b/tests/integration/test_distributed_ddl_on_database_cluster/configs/config.d/settings.xml
@@ -1,0 +1,9 @@
+<clickhouse>
+    <distributed_ddl>
+        <path>/clickhouse/task_queue/ddl</path>
+        <max_tasks_in_queue>10</max_tasks_in_queue>
+        <task_max_lifetime>3600</task_max_lifetime>
+        <cleanup_delay_period>5</cleanup_delay_period>
+        <mark_replicas_active_interval_seconds>5</mark_replicas_active_interval_seconds>
+    </distributed_ddl>
+</clickhouse>

--- a/tests/integration/test_distributed_ddl_on_database_cluster/configs/users.d/query_log.xml
+++ b/tests/integration/test_distributed_ddl_on_database_cluster/configs/users.d/query_log.xml
@@ -1,0 +1,9 @@
+<clickhouse>
+    <profiles>
+        <!-- Default profile settings. -->
+        <default>
+            <log_queries>1</log_queries>
+            <allow_deprecated_syntax_for_merge_tree>1</allow_deprecated_syntax_for_merge_tree>
+        </default>
+    </profiles>
+</clickhouse>

--- a/tests/integration/test_distributed_ddl_on_database_cluster/test.py
+++ b/tests/integration/test_distributed_ddl_on_database_cluster/test.py
@@ -1,0 +1,73 @@
+import os
+import sys
+import time
+import uuid
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import assert_eq_with_retry
+
+from helpers.test_tools import TSV
+
+cluster = ClickHouseCluster(__file__)
+
+node1 = cluster.add_instance(
+    "node1",
+    main_configs=["configs/config.d/settings.xml"],
+    user_configs=["configs/users.d/query_log.xml"],
+    with_zookeeper=True,
+    macros={"shard": 1, "replica": 1},
+)
+node2 = cluster.add_instance(
+    "node2",
+    main_configs=["configs/config.d/settings.xml"],
+    user_configs=["configs/users.d/query_log.xml"],
+    with_zookeeper=True,
+    macros={"shard": 1, "replica": 2},
+)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+
+def test_waiting_replicated_database_hosts(started_cluster):
+    node1.query(
+        "CREATE DATABASE db ENGINE=Replicated('/test/db', '{shard}', '{replica}')"
+    )
+    node2.query(
+        "CREATE DATABASE db ENGINE=Replicated('/test/db', '{shard}', '{replica}')"
+    )
+
+    # Wait for the host id is updated
+    time.sleep(5)
+    tmp = node1.query(
+        "SELECT name, value FROM system.zookeeper WHERE path='/clickhouse/task_queue/ddl'"
+    )
+
+    query_id = str(uuid.uuid4())
+    node1.query(
+        "CREATE TABLE t ON CLUSTER 'db' (x INT, y INT) ENGINE=MergeTree ORDER BY x",
+        settings={"distributed_ddl_output_mode": "throw_only_active"},
+        query_id=query_id,
+    )
+    assert (
+        node2.query("SELECT count() FROM system.tables WHERE name='t'").strip() == "1"
+    )
+    node1.query("SYSTEM FLUSH LOGS")
+    assert (
+        node1.query(
+            f"SELECT count() FROM system.text_log WHERE query_id='{query_id}' AND level='Warning' AND message LIKE '%Did not find active hosts%'"
+        ).strip()
+        == "0"
+    )
+
+    node1.query("DROP DATABASE db SYNC")
+    node2.query("DROP DATABASE db SYNC")


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

In DDLWorker, mark replicas as active periodically to avoid not marking any active replica due to address resolution failure:
- It periodically marks replicas as active (default 1 minute, configurable).
- When `markReplicasActive` is called with `reinitialized=false`, it does not clear `active_node_holders` entirely. It only removes host_ids which are not self-hosts.


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
