### PR TITLE
Fix memory tracker inaccuracy on macOS with jemalloc disabled

### DIFF
--- a/src/Common/memory.h
+++ b/src/Common/memory.h
@@ -172,6 +172,9 @@ inline ALWAYS_INLINE size_t untrackMemory(void * ptr [[maybe_unused]], Allocatio
         /// It's innaccurate resource free for sanitizers. malloc_usable_size() result is greater or equal to allocated size.
         else
             actual_size = malloc_usable_size(ptr);
+#    elif defined(OS_DARWIN)
+        else
+            actual_size = malloc_size(ptr);
 #    endif
 #endif
         trace = CurrentMemoryTracker::free(actual_size);


### PR DESCRIPTION
When jemalloc is disabled on macOS, the corresponding memory size may not be accurately untracked when memory is released in certain scenarios. Specifically, the `untrackMemory` function does not calculate the actual memory size for macOS environments. This leads to accumulation over time and may eventually trigger false positive errors indicating memory limit exceeded.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.876`
<!-- ch-version-info:end -->