### PR TITLE
Fix crash with wrong group in timeSeriesTagsGroupToTags().

### DIFF
--- a/src/Interpreters/ContextTimeSeriesTagsCollector.cpp
+++ b/src/Interpreters/ContextTimeSeriesTagsCollector.cpp
@@ -168,6 +168,13 @@ std::vector<TagNamesAndValuesPtr> ContextTimeSeriesTagsCollector::getTagsByGroup
 
 TagNamesAndValuesPtr ContextTimeSeriesTagsCollector::getTagsByGroupNoLock(size_t group) const
 {
+    if (group >= groups.size())
+    {
+        if (groups.empty())
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "No groups exist");
+        else
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Group {} is out of bounds, must be between 0 and {}", group, groups.size() - 1);
+    }
     return groups[group].tags;
 }
 

--- a/tests/queries/0_stateless/03756_time_series_wrong_tags_group.sql
+++ b/tests/queries/0_stateless/03756_time_series_wrong_tags_group.sql
@@ -1,0 +1,2 @@
+SELECT timeSeriesTagsGroupToTags(toUInt64(0)); -- { serverError BAD_ARGUMENTS }
+SELECT timeSeriesTagsGroupToTags(toUInt64(1)); -- { serverError BAD_ARGUMENTS }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix crash with wrong group in `timeSeriesTagsGroupToTags()`.
Closes https://github.com/ClickHouse/ClickHouse/issues/91905