### PR TITLE
Disable -fsanitize-memory-track-origins for libcxxabi to make demangle ~20% faster

### DIFF
--- a/cmake/sanitize.cmake
+++ b/cmake/sanitize.cmake
@@ -24,6 +24,7 @@ if (SANITIZE)
         set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SAN_FLAGS} ${MSAN_FLAGS}")
         set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${SAN_FLAGS} ${MSAN_FLAGS}")
 
+        # NOTE: See also libcxxabi cmake rules
     elseif (SANITIZE STREQUAL "thread")
         set (TSAN_FLAGS "-fsanitize=thread")
         set (TSAN_FLAGS "${TSAN_FLAGS} -fsanitize-ignorelist=${PROJECT_SOURCE_DIR}/tests/tsan_ignorelist.txt")

--- a/contrib/libcxxabi-cmake/CMakeLists.txt
+++ b/contrib/libcxxabi-cmake/CMakeLists.txt
@@ -37,6 +37,10 @@ target_compile_definitions(cxxabi PRIVATE -D_LIBCPP_BUILDING_LIBRARY -DHAS_THREA
 target_compile_options(cxxabi PRIVATE -nostdinc++ -fno-sanitize=undefined -Wno-macro-redefined)
 # Demangling is very slow under MSan due to frame-pointers, it is OK to omit them for cxxabi anyway
 target_compile_options(cxxabi PRIVATE -fomit-frame-pointer -momit-leaf-frame-pointer)
+# We sacrifice origins tracking here to make demangling faster (unlikely that the origin will be here anyway)
+if (SANITIZE STREQUAL "memory")
+    target_compile_options(cxxabi PRIVATE -fno-sanitize-memory-track-origins)
+endif()
 target_link_libraries(cxxabi PUBLIC unwind)
 
 # Enable capturing stack traces for all exceptions.

--- a/contrib/libcxxabi-cmake/CMakeLists.txt
+++ b/contrib/libcxxabi-cmake/CMakeLists.txt
@@ -1,8 +1,5 @@
 set(LIBCXXABI_SOURCE_DIR "${ClickHouse_SOURCE_DIR}/contrib/llvm-project/libcxxabi")
 
-set(LIBCXX_SOURCE_DIR "${ClickHouse_SOURCE_DIR}/contrib/llvm-project/libcxx")
-set(LIBCXX_BINARY_DIR "${ClickHouse_BINARY_DIR}/contrib/llvm-project/libcxx")
-
 set(SRCS
 "${LIBCXXABI_SOURCE_DIR}/src/abort_message.cpp"
 "${LIBCXXABI_SOURCE_DIR}/src/cxa_aux_runtime.cpp"


### PR DESCRIPTION
Benchmark:

    # default
    :) select demangle('_ZNK2DB24IAggregateFunctionHelperINS_20AggregateFunctionSumImmNS_24AggregateFunctionSumDataImEEEEE19addBatchSinglePlaceEmPcPPKNS_7IColumnEPNS_5ArenaE.' || number::String) from numbers(100e3) format Null
    0 rows in set. Elapsed: 1.248 sec. Processed 100.00 thousand rows, 800.00 KB (80.15 thousand rows/s., 641.21 KB/s.)

    # -fno-sanitize-memory-track-origins
    :) select demangle('_ZNK2DB24IAggregateFunctionHelperINS_20AggregateFunctionSumImmNS_24AggregateFunctionSumDataImEEEEE19addBatchSinglePlaceEmPcPPKNS_7IColumnEPNS_5ArenaE.' || number::String) from numbers(100e3) format Null
    0 rows in set. Elapsed: 0.873 sec. Processed 100.00 thousand rows, 800.00 KB (114.60 thousand rows/s., 916.84 KB/s.)

    # -fomit-frame-pointer -momit-leaf-frame-pointer
    :) select demangle('_ZNK2DB24IAggregateFunctionHelperINS_20AggregateFunctionSumImmNS_24AggregateFunctionSumDataImEEEEE19addBatchSinglePlaceEmPcPPKNS_7IColumnEPNS_5ArenaE.' || number::String) from numbers(100e3) format Null
    0 rows in set. Elapsed: 0.973 sec. Processed 100.00 thousand rows, 800.00 KB (102.74 thousand rows/s., 821.89 KB/s.)

    # -fomit-frame-pointer -momit-leaf-frame-pointer -fno-sanitize-memory-track-origins
    :) select demangle('_ZNK2DB24IAggregateFunctionHelperINS_20AggregateFunctionSumImmNS_24AggregateFunctionSumDataImEEEEE19addBatchSinglePlaceEmPcPPKNS_7IColumnEPNS_5ArenaE.' || number::String) from numbers(100e3) format Null
    0 rows in set. Elapsed: 0.739 sec. Processed 100.00 thousand rows, 800.00 KB (135.34 thousand rows/s., 1.08 MB/s.)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Disable -fsanitize-memory-track-origins for libcxxabi to make demangle ~20% faster

Refs: https://github.com/ClickHouse/ClickHouse/issues/91410