### PR TITLE
deflake tests/integration/test_keeper_s3_snapshot using threshold-based assertions

### DIFF
--- a/tests/integration/test_keeper_s3_snapshot/test.py
+++ b/tests/integration/test_keeper_s3_snapshot/test.py
@@ -110,14 +110,11 @@ def test_s3_upload(started_cluster):
 
     # Keeper sends snapshots asynchornously, hence we need to retry.
     def _check_snapshots():
-        assert set(get_saved_snapshots()) == set(
-            [
-                "snapshot_50.bin.zstd",
-                "snapshot_100.bin.zstd",
-                "snapshot_150.bin.zstd",
-                "snapshot_200.bin.zstd",
-            ]
-        )
+        names = get_saved_snapshots()
+        idx = sorted(int(n.split("_")[1].split(".")[0]) for n in names)
+        assert len(idx) >= 4
+        for t in (50, 100, 150, 200):
+            assert any(i >= t for i in idx)
 
     retry(AssertionError, retries=10, delay=2, jitter=0, backoff=1)(_check_snapshots)
 

--- a/tests/integration/test_keeper_s3_snapshot/test.py
+++ b/tests/integration/test_keeper_s3_snapshot/test.py
@@ -110,11 +110,11 @@ def test_s3_upload(started_cluster):
 
     # Keeper sends snapshots asynchornously, hence we need to retry.
     def _check_snapshots():
-        names = get_saved_snapshots()
+        names = [n for n in get_saved_snapshots() if n.startswith("snapshot_")]
         idx = sorted(int(n.split("_")[1].split(".")[0]) for n in names)
         assert len(idx) >= 4
-        for t in (50, 100, 150, 200):
-            assert any(i >= t for i in idx)
+        for need, got in zip((50, 100, 150, 200), idx[:4]):
+            assert got >= need
 
     retry(AssertionError, retries=10, delay=2, jitter=0, backoff=1)(_check_snapshots)
 

--- a/tests/integration/test_keeper_s3_snapshot/test.py
+++ b/tests/integration/test_keeper_s3_snapshot/test.py
@@ -112,8 +112,8 @@ def test_s3_upload(started_cluster):
     def _check_snapshots():
         names = [n for n in get_saved_snapshots() if n.startswith("snapshot_")]
         idx = sorted(int(n.split("_")[1].split(".")[0]) for n in names)
-        assert len(idx) >= 4
-        for need, got in zip((50, 100, 150, 200), idx[:4]):
+        assert len(idx) == 4
+        for need, got in zip((50, 100, 150, 200), idx):
             assert got >= need
 
     retry(AssertionError, retries=10, delay=2, jitter=0, backoff=1)(_check_snapshots)


### PR DESCRIPTION
**Changes done:**
- Replace exact S3 filename equality with progress thresholds.
- Require ≥4 snapshots and indices reaching ≥50, ≥100, ≥150, ≥200.

**RCA:**
- **Assertion failed on exact names**
```
AssertionError: assert {'snapshot_103.bin.zstd','snapshot_153.bin.zstd','snapshot_203.bin.zstd', ...}
==          {'snapshot_100.bin.zstd','snapshot_150.bin.zstd','snapshot_200.bin.zstd', ...}
```
- **Leader/cadence at failure time**: node1 is leader with snapshot distance 50.
- **Evidence of legitimate drift on node1:**
```
23:24:48.752202 ... Successfully uploaded snapshot_50.bin.zstd to S3
23:24:48.799627 ... Successfully uploaded snapshot_103.bin.zstd to S3
23:24:48.983089 ... Successfully uploaded snapshot_153.bin.zstd to S3
23:24:49.175040 ... Successfully uploaded snapshot_203.bin.zstd to S3
23:24:49.155592 ... creating a snapshot for index 203
23:24:49.162295 ... snapshot idx 203 ... created
```
- **Expected reason for drift**: snapshot filenames encode the last included committed index at the moment of snapshot creation. With batching/async commit + async upload, the first snapshot after crossing 100/150/200 can be slightly higher (103/153/203). This is expected and rare, depending on timing.

Closes https://github.com/ClickHouse/ClickHouse/issues/90507

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
