### PR TITLE
Support inserting auxiliary zookeeper by system.zookeeper.

### DIFF
--- a/tests/queries/0_stateless/02311_system_zookeeper_insert.reference
+++ b/tests/queries/0_stateless/02311_system_zookeeper_insert.reference
@@ -25,3 +25,31 @@
 /default/2-insert-testz/c/cd	dd	
 /default/2-insert-testz/c/cd	testc	
 /default/2-insert-testz/c/cd/dd	testc	y
+------- Insert into auxiliary zookeeper --------
+/default/1-insert-testc	c	
+/default/1-insert-testc/c	c	
+/default/1-insert-testc/c/c	c	
+/default/1-insert-testc/c/c	d	
+/default/1-insert-testc/c/c	e	
+/default/1-insert-testc/c/c	f	
+/default/1-insert-testc/c/c	kk	
+/default/1-insert-testc/c/c/c	c	
+/default/1-insert-testc/c/c/c/c	c	
+/default/1-insert-testc/c/c/c/c/c	c	
+/default/1-insert-testc/c/c/c/c/c/c	c	9
+/default/1-insert-testc/c/c/c/c/c/c/c	c	10
+/default/1-insert-testc/c/c/d	e	10
+/default/1-insert-testc/c/c/d	f	11
+/default/1-insert-testc/c/c/d	g	12
+/default/1-insert-testc/c/c/e	g	13
+/default/1-insert-testc/c/c/f	g	14
+/default/1-insert-testc/c/c/kk	g	14
+-------------------------
+/default/2-insert-testx	testb	z
+/default/2-insert-testx	testc	x
+/default/2-insert-testx	testz	y
+/default/2-insert-testz	c	
+/default/2-insert-testz/c	cd	
+/default/2-insert-testz/c/cd	dd	
+/default/2-insert-testz/c/cd	testc	
+/default/2-insert-testz/c/cd/dd	testc	y

--- a/tests/queries/0_stateless/02311_system_zookeeper_insert.sql
+++ b/tests/queries/0_stateless/02311_system_zookeeper_insert.sql
@@ -44,6 +44,9 @@ drop table if exists test_zkinsert;
 
 SELECT '------- Insert into auxiliary zookeeper --------';
 
+-- prepare the root node for auxiliary zookeeper
+insert into system.zookeeper (name, path, value) values ('auxiliary_zookeeper2', '/test/chroot', '');
+
 create table test_zkinsert (
 	name String,
 	path String,
@@ -54,7 +57,7 @@ create table test_zkinsert (
 -- test recursive create and big transaction
 insert into test_zkinsert (name, path, value) values ('c', '/1-insert-testc/c/c/c/c/c/c', 11), ('e', '/1-insert-testc/c/c/d', 10), ('c', '/1-insert-testc/c/c/c/c/c/c/c', 10), ('c', '/1-insert-testc/c/c/c/c/c/c', 9), ('f', '/1-insert-testc/c/c/d', 11), ('g', '/1-insert-testc/c/c/d', 12), ('g', '/1-insert-testc/c/c/e', 13), ('g', '/1-insert-testc/c/c/f', 14), ('g', '/1-insert-testc/c/c/kk', 14);
 -- insert same value, suppose to have no side effects
-insert into system.zookeeper (name, path, value) SELECT name, '/' || currentDatabase() || path, value from test_zkinsert;
+insert into system.zookeeper (name, path, value, zookeeperName) SELECT name, '/' || currentDatabase() || path, value, zookeeperName from test_zkinsert;
 
 SELECT * FROM (SELECT path, name, value FROM system.zookeeper WHERE zookeeperName = 'zookeeper2' ORDER BY path, name) WHERE path LIKE '/' || currentDatabase() || '/1-insert-test%';
 
@@ -67,7 +70,7 @@ insert into test_zkinsert (name, path, value) values ('testc', '/2-insert-testz/
 insert into test_zkinsert (name, path) values ('testc', '/2-insert-testz//c/cd/');
 insert into test_zkinsert (name, value, path) values ('testb', 'z', '/2-insert-testx');
 
-insert into system.zookeeper (name, path, value) SELECT name, '/' || currentDatabase() || path, value from test_zkinsert;
+insert into system.zookeeper (name, path, value, zookeeperName) SELECT name, '/' || currentDatabase() || path, value, zookeeperName from test_zkinsert;
 
 SELECT * FROM (SELECT path, name, value FROM system.zookeeper WHERE zookeeperName = 'zookeeper2' ORDER BY path, name) WHERE path LIKE '/' || currentDatabase() || '/2-insert-test%';
 

--- a/tests/queries/0_stateless/02311_system_zookeeper_insert.sql
+++ b/tests/queries/0_stateless/02311_system_zookeeper_insert.sql
@@ -56,7 +56,7 @@ insert into test_zkinsert (name, path, value) values ('c', '/1-insert-testc/c/c/
 -- insert same value, suppose to have no side effects
 insert into system.zookeeper (name, path, value) SELECT name, '/' || currentDatabase() || path, value from test_zkinsert;
 
-SELECT * FROM (SELECT path, name, value FROM system.zookeeper ORDER BY path, name) WHERE path LIKE '/' || currentDatabase() || '/1-insert-test%';
+SELECT * FROM (SELECT path, name, value FROM system.zookeeper WHERE zookeeperName = 'zookeeper2' ORDER BY path, name) WHERE path LIKE '/' || currentDatabase() || '/1-insert-test%';
 
 SELECT '-------------------------';
 
@@ -69,6 +69,6 @@ insert into test_zkinsert (name, value, path) values ('testb', 'z', '/2-insert-t
 
 insert into system.zookeeper (name, path, value) SELECT name, '/' || currentDatabase() || path, value from test_zkinsert;
 
-SELECT * FROM (SELECT path, name, value FROM system.zookeeper ORDER BY path, name) WHERE path LIKE '/' || currentDatabase() || '/2-insert-test%';
+SELECT * FROM (SELECT path, name, value FROM system.zookeeper WHERE zookeeperName = 'zookeeper2' ORDER BY path, name) WHERE path LIKE '/' || currentDatabase() || '/2-insert-test%';
 
 drop table if exists test_zkinsert;

--- a/tests/queries/0_stateless/02311_system_zookeeper_insert.sql
+++ b/tests/queries/0_stateless/02311_system_zookeeper_insert.sql
@@ -30,7 +30,7 @@ insert into system.zookeeper (name, path, value) SELECT name, '/' || currentData
 
 SELECT * FROM (SELECT path, name, value FROM system.zookeeper ORDER BY path, name) WHERE path LIKE '/' || currentDatabase() || '/2-insert-test%';
 
--- test exceptions 
+-- test exceptions
 insert into system.zookeeper (name, value) values ('abc', 'y'); -- { serverError BAD_ARGUMENTS }
 insert into system.zookeeper (path, value) values ('a/b/c', 'y'); -- { serverError BAD_ARGUMENTS }
 insert into system.zookeeper (name, version) values ('abc', 111); -- { serverError ILLEGAL_COLUMN }
@@ -39,5 +39,36 @@ insert into system.zookeeper (name, path, value) values ('a/b/c', '/', 'y'); -- 
 insert into system.zookeeper (name, path, value) values ('/', '/a/b/c', 'z'); -- { serverError BAD_ARGUMENTS }
 insert into system.zookeeper (name, path, value) values ('', '/', 'y'); -- { serverError BAD_ARGUMENTS }
 insert into system.zookeeper (name, path, value) values ('abc', '/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc/abc', 'y'); -- { serverError BAD_ARGUMENTS }
+
+drop table if exists test_zkinsert;
+
+SELECT '------- Insert into auxiliary zookeeper --------';
+
+create table test_zkinsert (
+	name String,
+	path String,
+	value String,
+	zookeeperName String default 'zookeeper2'
+) ENGINE Memory;
+
+-- test recursive create and big transaction
+insert into test_zkinsert (name, path, value) values ('c', '/1-insert-testc/c/c/c/c/c/c', 11), ('e', '/1-insert-testc/c/c/d', 10), ('c', '/1-insert-testc/c/c/c/c/c/c/c', 10), ('c', '/1-insert-testc/c/c/c/c/c/c', 9), ('f', '/1-insert-testc/c/c/d', 11), ('g', '/1-insert-testc/c/c/d', 12), ('g', '/1-insert-testc/c/c/e', 13), ('g', '/1-insert-testc/c/c/f', 14), ('g', '/1-insert-testc/c/c/kk', 14);
+-- insert same value, suppose to have no side effects
+insert into system.zookeeper (name, path, value) SELECT name, '/' || currentDatabase() || path, value from test_zkinsert;
+
+SELECT * FROM (SELECT path, name, value FROM system.zookeeper ORDER BY path, name) WHERE path LIKE '/' || currentDatabase() || '/1-insert-test%';
+
+SELECT '-------------------------';
+
+-- test inserting into root path
+insert into test_zkinsert (name, path, value) values ('testc', '/2-insert-testx', 'x');
+insert into test_zkinsert (name, path, value) values ('testz', '/2-insert-testx', 'y');
+insert into test_zkinsert (name, path, value) values ('testc', '/2-insert-testz//c/cd/dd//', 'y');
+insert into test_zkinsert (name, path) values ('testc', '/2-insert-testz//c/cd/');
+insert into test_zkinsert (name, value, path) values ('testb', 'z', '/2-insert-testx');
+
+insert into system.zookeeper (name, path, value) SELECT name, '/' || currentDatabase() || path, value from test_zkinsert;
+
+SELECT * FROM (SELECT path, name, value FROM system.zookeeper ORDER BY path, name) WHERE path LIKE '/' || currentDatabase() || '/2-insert-test%';
 
 drop table if exists test_zkinsert;


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Support inserting auxiliary zookeeper by system.zookeeper.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
