### PR TITLE
tests: fix 02935_http_content_type_with_http_headers_progress flakiness

### DIFF
--- a/tests/queries/0_stateless/02935_http_content_type_with_http_headers_progress.sh
+++ b/tests/queries/0_stateless/02935_http_content_type_with_http_headers_progress.sh
@@ -10,6 +10,10 @@ for format in TSV TabSeparatedWithNamesAndTypes CSV CSVWithNames Null Native Row
 do
   echo $format
   url="${CLICKHOUSE_URL}&http_headers_progress_interval_ms=1&send_progress_in_http_headers=true&query=select+sleepEachRow(0.01)from+numbers(10)+FORMAT+${format}"
-  (seq 1 ${THREADS} | xargs --max-args=1 -P"${THREADS}" -Ixxx curl -Ss -v -o /dev/null ${url} 2>&1 | grep -P -o " Content-Type:.*$") | strings | sort -u
+  (
+    for _ in seq 1 ${THREADS}; do
+      curl -Ss -v -o /dev/null ${url} 2>&1 | grep -P -o " Content-Type:.*$" &
+    done
+    wait
+  ) | strings | sort -u
 done
-


### PR DESCRIPTION
CI found a failure in [1], the problem was `xargs -Ixxx` part, and that the database contains `xxx`.

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=91992&sha=32b7e4be77cbff3470ea4230656e77c97bb91ade&name_0=PR&name_1=Stateless%20tests%20%28amd_binary%2C%20old%20analyzer%2C%20s3%20storage%2C%20DatabaseReplicated%2C%20parallel%29

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

**Requires: https://github.com/ClickHouse/ClickHouse/pull/92115**

Fixes: https://github.com/ClickHouse/ClickHouse/issues/72535