### PR TITLE
disable running test in parallel to reduce thread starvation issues

### DIFF
--- a/tests/queries/0_stateless/00705_drop_create_merge_tree.sh
+++ b/tests/queries/0_stateless/00705_drop_create_merge_tree.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-msan, no-flaky-check
+# Tags: no-fasttest, no-msan, no-flaky-check, no-parallel
 # msan: too slow
+# no-parallel: thread starvation leads to flakiness
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Details:

Fixes #89736 

In rare occasions when this test fails, it is either complete thread starvation when sh does not even manage to send a single command out through clickhouse_client or test times out waiting on the lock. By adding no-parallel tag, it makes this test to run by itself which will reduce probability of thread starvation at the cost of longer test run duration.