### PR TITLE
exclude the test from sanitizers suites and disable flaky check

### DIFF
--- a/tests/queries/0_stateless/03208_array_of_json_read_subcolumns_2_memory.sql
+++ b/tests/queries/0_stateless/03208_array_of_json_read_subcolumns_2_memory.sql
@@ -1,3 +1,5 @@
+-- Tags: no-msan
+-- no-msan: too slow for memory sanitizer
 
 SET enable_json_type = 1;
 set allow_experimental_variant_type = 1;

--- a/tests/queries/0_stateless/03208_array_of_json_read_subcolumns_2_memory.sql
+++ b/tests/queries/0_stateless/03208_array_of_json_read_subcolumns_2_memory.sql
@@ -1,5 +1,5 @@
--- Tags: no-msan
--- no-msan: too slow for memory sanitizer
+-- Tags: no-asan, no-tsan, no-msan, no-flaky-check
+-- too slow for sanitizers and flaky check
 
 SET enable_json_type = 1;
 set allow_experimental_variant_type = 1;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Details:

Fixes #92125

msan running this test in parallel sometimes does not make it all the way through before 10 minute timeout kicks in. one alternative would be to add no-parallel to it, but in my opinion this test is just too heavy for sanitizer tests.