### PR TITLE
tests: fix 03734_client_receive_timeout_exit_code flakiness

### DIFF
--- a/tests/queries/0_stateless/03734_client_receive_timeout_exit_code.reference
+++ b/tests/queries/0_stateless/03734_client_receive_timeout_exit_code.reference
@@ -1,2 +1,2 @@
 159
-0
+Timeout exceeded

--- a/tests/queries/0_stateless/03734_client_receive_timeout_exit_code.sh
+++ b/tests/queries/0_stateless/03734_client_receive_timeout_exit_code.sh
@@ -8,9 +8,8 @@ set +e
 
 # Test that receive_timeout returns exit code 159 (TIMEOUT_EXCEEDED)
 # Set interactive_delay to a very large value to prevent progress packets from resetting the timeout
-$CLICKHOUSE_CLIENT --receive_timeout=1 --interactive_delay=10000000 --query="SELECT sleep(2) FORMAT Null" >/dev/null 2>&1
+$CLICKHOUSE_CLIENT --receive_timeout=1 --interactive_delay=10000000 --query="SELECT sleep(3) FORMAT Null" >/dev/null 2>&1
 echo $?
 
 # Verify the timeout error message is correctly printed (capture stderr)
-$CLICKHOUSE_CLIENT --receive_timeout=1 --interactive_delay=10000000 --query="SELECT sleep(2) FORMAT Null" 2>&1 | grep -q "Timeout exceeded"
-echo $?
+$CLICKHOUSE_CLIENT --receive_timeout=1 --interactive_delay=10000000 --query="SELECT sleep(3) FORMAT Null" 2>&1 | grep -o "Timeout exceeded"


### PR DESCRIPTION
CI found a failure [1], and indeed, it is possible that in case of
receive_timeout=1s, "Timeout exceeded while receiving data from server.
Waited for {} seconds, timeout is {} seconds." can be missed due to the
query may already finish at the second poll (since it will do only two
polls at 1 and 2 second).

So let's increase the sleep interval to 3 seconds, should be sufficient.

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=92117&sha=d19989de2a7bda411817c6d0b75b89bf1dab2420&name_0=PR&name_1=Stateless%20tests%20%28amd_binary%2C%20ParallelReplicas%2C%20s3%20storage%2C%20parallel%29

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)