### PR TITLE
new keeper metrics

### DIFF
--- a/docs/en/operations/system-tables/histogram_metrics.md
+++ b/docs/en/operations/system-tables/histogram_metrics.md
@@ -39,6 +39,12 @@ FORMAT Prometheus
 ### keeper_response_time_ms_bucket {#keeper_response_time_ms_bucket}
 The response time of Keeper, in milliseconds.
 
+### keeper_batch_size_elements_bucket {#keeper_batch_size_elements_bucket}
+Batch size sent to Raft, in elements.
+
+### keeper_batch_size_bytes_bucket {#keeper_batch_size_bytes_bucket}
+Batch size sent to Raft, in bytes.
+
 **See Also**
 - [system.asynchronous_metrics](/operations/system-tables/asynchronous_metrics) — Contains periodically calculated metrics.
 - [system.events](/operations/system-tables/events) — Contains a number of events that occurred.

--- a/src/Common/HistogramMetrics.cpp
+++ b/src/Common/HistogramMetrics.cpp
@@ -121,7 +121,7 @@ namespace HistogramMetrics
     MetricFamily & KeeperBatchSizeElementsMetricFamily = Factory::instance().registerMetric(
         "keeper_batch_size_elements",
         "Size of batch sent to Raft in elements.",
-        {1, 4, 16, 64, 99},
+        {4, 8, 16, 32, 64, 128, 256, 299},
         {}
     );
     Metric & KeeperCurrentBatchSizeElements = KeeperBatchSizeElementsMetricFamily.withLabels({});
@@ -129,7 +129,7 @@ namespace HistogramMetrics
     MetricFamily & KeeperBatchSizeBytesMetricFamily = Factory::instance().registerMetric(
         "keeper_batch_size_bytes",
         "Size of batch sent to Raft in bytes.",
-        {1024, 4 * 1024, 16 * 1024, 64 * 1024, 99 * 1024},
+        {1 << 12, 1 << 13, 1 << 14, 1 << 15, 1 << 16, 1 << 17, 1 << 18, 307199},
         {}
     );
     Metric & KeeperCurrentBatchSizeBytes = KeeperBatchSizeBytesMetricFamily.withLabels({});

--- a/src/Common/HistogramMetrics.cpp
+++ b/src/Common/HistogramMetrics.cpp
@@ -118,6 +118,21 @@ namespace HistogramMetrics
     );
     Metric & KeeperServerSendDuration = KeeperServerSendDurationMetricFamily.withLabels({});
 
+    MetricFamily & KeeperBatchSizeElementsMetricFamily = Factory::instance().registerMetric(
+        "keeper_batch_size_elements",
+        "Size of batch sent to Raft in elements.",
+        {1, 4, 16, 64, 99},
+        {}
+    );
+    Metric & KeeperCurrentBatchSizeElements = KeeperBatchSizeElementsMetricFamily.withLabels({});
+
+    MetricFamily & KeeperBatchSizeBytesMetricFamily = Factory::instance().registerMetric(
+        "keeper_batch_size_bytes",
+        "Size of batch sent to Raft in bytes.",
+        {1024, 4 * 1024, 16 * 1024, 64 * 1024, 99 * 1024},
+        {}
+    );
+    Metric & KeeperCurrentBatchSizeBytes = KeeperBatchSizeBytesMetricFamily.withLabels({});
 
     Metric::Metric(const Buckets & buckets_)
         : buckets(buckets_)

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -1143,6 +1143,10 @@ The server successfully detected this situation and will download merged part fr
     M(KeeperLogsEntryReadFromCommitCache, "Number of log entries in Keeper being read from commit logs cache", ValueType::Number) \
     M(KeeperLogsEntryReadFromFile, "Number of log entries in Keeper being read directly from the changelog file", ValueType::Number) \
     M(KeeperLogsPrefetchedEntries, "Number of log entries in Keeper being prefetched from the changelog file", ValueType::Number) \
+    M(KeeperChangelogWrittenBytes, "Number of bytes written to the changelog in Keeper", ValueType::Bytes) \
+    M(KeeperChangelogFileSyncMicroseconds, "Time spent in fsync for Keeper changelog (uncompressed logs only)", ValueType::Microseconds) \
+    M(KeeperSnapshotWrittenBytes, "Number of bytes written to snapshot files in Keeper", ValueType::Bytes) \
+    M(KeeperSnapshotFileSyncMicroseconds, "Time spent in fsync for Keeper snapshot files", ValueType::Microseconds) \
     \
     M(StorageConnectionsCreated, "Number of created connections for storages", ValueType::Number) \
     M(StorageConnectionsReused, "Number of reused connections for storages", ValueType::Number) \

--- a/src/Coordination/KeeperConstants.cpp
+++ b/src/Coordination/KeeperConstants.cpp
@@ -273,6 +273,10 @@
     M(KeeperCheckWatchRequest) \
     M(KeeperAddWatchRequest) \
     M(KeeperRemoveWatchRequest) \
+    M(KeeperChangelogWrittenBytes) \
+    M(KeeperChangelogFileSyncMicroseconds) \
+    M(KeeperSnapshotWrittenBytes) \
+    M(KeeperSnapshotFileSyncMicroseconds) \
 \
     M(IOUringSQEsSubmitted) \
     M(IOUringSQEsResubmitsAsync) \
@@ -406,6 +410,7 @@ extern const std::vector<Metric> keeper_metrics
     M(KeeperServerProcessRequestDuration) \
     M(KeeperServerQueueDurationMetricFamily) \
     M(KeeperServerSendDurationMetricFamily) \
+    M(KeeperBatchSizeBytesMetricFamily) \
 
 
 namespace HistogramMetrics

--- a/src/Coordination/KeeperDispatcher.cpp
+++ b/src/Coordination/KeeperDispatcher.cpp
@@ -5,6 +5,7 @@
 #include <Poco/Util/AbstractConfiguration.h>
 
 #include <base/hex.h>
+#include <Common/HistogramMetrics.h>
 #include <Common/ZooKeeper/IKeeper.h>
 #include <Common/ZooKeeper/ZooKeeperCommon.h>
 #include <Common/setThreadName.h>
@@ -39,6 +40,12 @@ namespace ProfileEvents
     extern const Event KeeperBatchMaxCount;
     extern const Event KeeperBatchMaxTotalSize;
     extern const Event KeeperRequestRejectedDueToSoftMemoryLimitCount;
+}
+
+namespace HistogramMetrics
+{
+    extern Metric & KeeperCurrentBatchSizeElements;
+    extern Metric & KeeperCurrentBatchSizeBytes;
 }
 
 using namespace std::chrono_literals;
@@ -269,6 +276,9 @@ void KeeperDispatcher::requestThread()
                         ProfileEvents::increment(ProfileEvents::KeeperBatchMaxTotalSize, 1);
 
                     LOG_TEST(log, "Processing requests batch, size: {}, bytes: {}", current_batch.size(), current_batch_bytes_size);
+
+                    HistogramMetrics::observe(HistogramMetrics::KeeperCurrentBatchSizeElements, current_batch.size());
+                    HistogramMetrics::observe(HistogramMetrics::KeeperCurrentBatchSizeBytes, current_batch_bytes_size);
 
                     auto result = server->putRequestBatch(current_batch);
 

--- a/src/Coordination/KeeperSnapshotManager.cpp
+++ b/src/Coordination/KeeperSnapshotManager.cpp
@@ -22,6 +22,14 @@
 #include <Common/ZooKeeper/ZooKeeperCommon.h>
 #include <Common/ZooKeeper/ZooKeeperIO.h>
 #include <Common/logger_useful.h>
+#include <Common/ProfileEvents.h>
+#include <Common/Stopwatch.h>
+
+namespace ProfileEvents
+{
+    extern const Event KeeperSnapshotWrittenBytes;
+    extern const Event KeeperSnapshotFileSyncMicroseconds;
+}
 
 namespace DB
 {
@@ -725,7 +733,14 @@ SnapshotFileInfoPtr KeeperSnapshotManager<Storage>::serializeSnapshotBufferToDis
 
     auto plain_buf = disk->writeFile(snapshot_file_name);
     copyData(reader, *plain_buf);
+
+    const size_t bytes_written = plain_buf->count();
+    ProfileEvents::increment(ProfileEvents::KeeperSnapshotWrittenBytes, bytes_written);
+
+    Stopwatch watch;
     plain_buf->sync();
+    ProfileEvents::increment(ProfileEvents::KeeperSnapshotFileSyncMicroseconds, watch.elapsedMicroseconds());
+
     plain_buf->finalize();
 
     disk->removeFile(tmp_snapshot_file_name);
@@ -912,9 +927,16 @@ SnapshotFileInfoPtr KeeperSnapshotManager<Storage>::serializeSnapshotToDisk(cons
     else
         compressed_writer = std::make_unique<CompressedWriteBuffer>(*writer);
 
+    const size_t bytes_before = compressed_writer->count();
     KeeperStorageSnapshot<Storage>::serialize(snapshot, *compressed_writer, keeper_context);
+    const size_t bytes_written = compressed_writer->count() - bytes_before;
+    ProfileEvents::increment(ProfileEvents::KeeperSnapshotWrittenBytes, bytes_written);
+
     compressed_writer->finalize();
+
+    Stopwatch watch;
     compressed_writer->sync();
+    ProfileEvents::increment(ProfileEvents::KeeperSnapshotFileSyncMicroseconds, watch.elapsedMicroseconds());
 
     disk->removeFile(tmp_snapshot_file_name);
 


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add new metrics for the keeper: `KeeperChangelogWrittenBytes`, `KeeperChangelogFileSyncMicroseconds`, `KeeperSnapshotWrittenBytes` and `KeeperSnapshotFileSyncMicroseconds` profile events as well as `KeeperBatchSizeElements` and `KeeperBatchSizeBytes` histogram metrics.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.441`
<!-- ch-version-info:end -->