### PR TITLE
Fix `01782_field_oom (arm_asan, targeted)` flakiness

### DIFF
--- a/tests/queries/0_stateless/01782_field_oom.sql
+++ b/tests/queries/0_stateless/01782_field_oom.sql
@@ -1,2 +1,2 @@
-SET max_memory_usage = '500M';
+SET max_memory_usage = '200M';
 SELECT sumMap([number], [number]) FROM system.numbers_mt; -- { serverError MEMORY_LIMIT_EXCEEDED }


### PR DESCRIPTION
Closes https://github.com/ClickHouse/ClickHouse/issues/91997. The test runs too long with thread fuzzer, causing client-side timeouts. There are three options:

1. Make `sumMap` faster
2. Reduce `max_memory_usage` to trigger OOM sooner
3. Add `no-flaky-check` to skip tests that use thread fuzzer

For option 1, I created https://github.com/ClickHouse/ClickHouse/issues/92093. However, the optimisation goal there is to eliminate the slow `Field`, which is exactly what this test is designed to trigger OOM in. Option 3 is last resort as we want to preserve this test in flaky checks and stateless targeted job. I verified that OOM still occurs in the intended location (`Field` allocation) with limit of 200MB and went with option 2. 

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)