### PR TITLE
Sanitize Context usage in Functions

### DIFF
--- a/ci/jobs/scripts/check_style/various_checks.sh
+++ b/ci/jobs/scripts/check_style/various_checks.sh
@@ -86,6 +86,49 @@ find $ROOT_PATH/{src,base,programs,utils,tests,docs,cmake} -name '*.md' -or -nam
 find $ROOT_PATH/{src,base,programs,utils,tests,docs,cmake} -name '*.md' -or -name '*.cpp' -or -name '*.h' | xargs grep -l -F $'\xFF\xFE' | grep -P '.' && echo "Files should not have UTF-16LE BOM"
 find $ROOT_PATH/{src,base,programs,utils,tests,docs,cmake} -name '*.md' -or -name '*.cpp' -or -name '*.h' | xargs grep -l -F $'\xFE\xFF' | grep -P '.' && echo "Files should not have UTF-16BE BOM"
 
+# Ensure that functions do not hold copy of ContextPtr
+#
+# ContextPtr holds lots of different stuff, including some caches, so prefer to
+# use weak_ptr or copy relevant info from Context, to avoid extending lifetime
+# of other objects.
+#
+# NOTE: most of the excludes here needs context to call another function, which
+# is easy to fix.
+FUNCTIONS_CONTEXT_PTR_EXCEPTIONS=(
+    -e /trap.cpp
+    -e /toInterval.cpp
+    -e /structureToFormatSchema.cpp
+    -e /splitByRegexp.cpp
+    -e /reverse.cpp
+    -e /nullIf.cpp
+    -e /midpoint.h
+    -e /ifNull.cpp
+    -e /ifNotFinite.cpp
+    -e /generateSerialID.cpp
+    -e /formatRow.cpp
+    -e /filesystem.cpp
+    -e /evalMLMethod.cpp
+    -e /date_trunc.cpp
+    -e /currentRoles.cpp
+    -e /currentProfiles.cpp
+    -e /concat.cpp
+    -e /caseWithExpression.cpp
+    -e /CastOverloadResolver.cpp
+    -e /array/arrayRemove.h
+    -e /array/arrayJaccardIndex.cpp
+    -e /array/arrayIntersect.cpp
+    -e /array/arrayElement.cpp
+    -e /UserDefined/
+    -e /LeastGreatestGeneric.h
+    -e /Kusto/KqlArraySort.cpp
+    -e /FunctionsOpDate.cpp
+    -e /FunctionUnaryArithmetic.h
+    -e /FunctionNaiveBayesClassifier.cpp
+    -e /FunctionBinaryArithmetic.h
+    -e /ITupleFunction.h
+)
+find $ROOT_PATH/src/Functions -type f | xargs grep -l 'ContextPtr [a-z_]*;' | grep -v "${FUNCTIONS_CONTEXT_PTR_EXCEPTIONS[@]}" | grep -P '.' && echo "Avoid holding a copy of ContextPtr in Functions"
+
 # Conflict markers
 find $ROOT_PATH/{src,base,programs,utils,tests,docs,cmake} -name '*.md' -or -name '*.cpp' -or -name '*.h' |
     xargs grep -P '^(<<<<<<<|=======|>>>>>>>)$' | grep -P '.' && echo "Conflict markers are found in files"

--- a/src/Functions/FunctionDictGetKeys.cpp
+++ b/src/Functions/FunctionDictGetKeys.cpp
@@ -194,7 +194,7 @@ private:
         Names column_names = structure.getKeysNames();
         column_names.push_back(attr_name);
 
-        auto pipe = dict->read(column_names, helper.getContext()->getSettingsRef()[Setting::max_block_size], 1);
+        auto pipe = dict->read(column_names, helper.context->getSettingsRef()[Setting::max_block_size], 1);
         QueryPipeline pipeline(std::move(pipe));
         PullingPipelineExecutor executor(pipeline);
 
@@ -297,7 +297,7 @@ private:
         }
 
         /// Step 2
-        auto & cache = helper.getContext()->getQueryContext()->getReverseLookupCache();
+        auto & cache = helper.context->getQueryContext()->getReverseLookupCache();
         std::vector<SerializedKeysPtr> bucket_cached_bytes(num_buckets);
         std::vector<size_t> missing_bucket_ids;
         missing_bucket_ids.reserve(num_buckets);
@@ -448,7 +448,7 @@ private:
         chassert(column_names.size() == num_keys);
         column_names.push_back(attr_name);
 
-        auto pipe = dict->read(column_names, helper.getContext()->getSettingsRef()[Setting::max_block_size], 1);
+        auto pipe = dict->read(column_names, helper.context->getSettingsRef()[Setting::max_block_size], 1);
         QueryPipeline pipeline(std::move(pipe));
         PullingPipelineExecutor executor(pipeline);
 

--- a/src/Functions/FunctionFile.cpp
+++ b/src/Functions/FunctionFile.cpp
@@ -27,12 +27,11 @@ namespace ErrorCodes
 }
 
 /// A function to read file as a string.
-class FunctionFile : public IFunction, WithContext
+class FunctionFile : public IFunction
 {
 public:
     static constexpr auto name = "file";
-    static FunctionPtr create(ContextPtr context_) { return std::make_shared<FunctionFile>(context_); }
-    explicit FunctionFile(ContextPtr context_) : WithContext(context_) {}
+    static FunctionPtr create(ContextPtr) { return std::make_shared<FunctionFile>(); }
 
     bool isVariadic() const override { return true; }
     String getName() const override { return name; }
@@ -114,11 +113,12 @@ public:
 
         res_offsets.resize(input_rows_count);
 
-        fs::path user_files_absolute_path = fs::canonical(fs::path(getContext()->getUserFilesPath()));
+        const auto & context = Context::getGlobalContextInstance();
+        fs::path user_files_absolute_path = fs::canonical(fs::path(context->getUserFilesPath()));
         std::string user_files_absolute_path_string = user_files_absolute_path.string();
 
         // If run in Local mode, no need for path checking.
-        bool need_check = getContext()->getApplicationType() != Context::ApplicationType::LOCAL;
+        bool need_check = context->getApplicationType() != Context::ApplicationType::LOCAL;
 
         for (size_t row = 0; row < input_rows_count; ++row)
         {

--- a/src/Functions/FunctionJoinGet.cpp
+++ b/src/Functions/FunctionJoinGet.cpp
@@ -31,14 +31,14 @@ namespace
 {
 
 template <bool or_null>
-class ExecutableFunctionJoinGet final : public IExecutableFunction, WithContext
+class ExecutableFunctionJoinGet final : public IExecutableFunction
 {
 public:
     ExecutableFunctionJoinGet(ContextPtr context_,
                               TableLockHolder table_lock_,
                               StorageJoinPtr storage_join_,
                               const DB::Block & result_columns_)
-        : WithContext(context_)
+        : context(context_)
         , table_lock(std::move(table_lock_))
         , storage_join(std::move(storage_join_))
         , result_columns(result_columns_)
@@ -55,13 +55,14 @@ public:
     String getName() const override { return name; }
 
 private:
+    ContextPtr context;
     TableLockHolder table_lock;
     StorageJoinPtr storage_join;
     DB::Block result_columns;
 };
 
 template <bool or_null>
-class FunctionJoinGet final : public IFunctionBase, WithContext
+class FunctionJoinGet final : public IFunctionBase
 {
 public:
     static constexpr auto name = or_null ? "joinGetOrNull" : "joinGet";
@@ -70,7 +71,7 @@ public:
                     TableLockHolder table_lock_,
                     StorageJoinPtr storage_join_, String attr_name_,
                     DataTypes argument_types_, DataTypePtr return_type_)
-        : WithContext(context_)
+        : context(context_)
         , table_lock(std::move(table_lock_))
         , storage_join(storage_join_)
         , attr_name(std::move(attr_name_))
@@ -89,6 +90,7 @@ public:
     ExecutableFunctionPtr prepare(const ColumnsWithTypeAndName &) const override;
 
 private:
+    ContextPtr context;
     TableLockHolder table_lock;
     StorageJoinPtr storage_join;
     const String attr_name;
@@ -129,14 +131,14 @@ ColumnPtr ExecutableFunctionJoinGet<or_null>::executeImpl(const ColumnsWithTypeA
         auto key = arguments[i];
         keys.emplace_back(std::move(key));
     }
-    return storage_join->joinGet(keys, result_columns, getContext()).column;
+    return storage_join->joinGet(keys, result_columns, context).column;
 }
 
 template <bool or_null>
 ExecutableFunctionPtr FunctionJoinGet<or_null>::prepare(const ColumnsWithTypeAndName &) const
 {
     Block result_columns {{return_type->createColumn(), return_type, attr_name}};
-    return std::make_unique<ExecutableFunctionJoinGet<or_null>>(getContext(), table_lock, storage_join, result_columns);
+    return std::make_unique<ExecutableFunctionJoinGet<or_null>>(context, table_lock, storage_join, result_columns);
 }
 
 std::pair<std::shared_ptr<StorageJoin>, String>

--- a/src/Functions/FunctionsExternalDictionaries.h
+++ b/src/Functions/FunctionsExternalDictionaries.h
@@ -65,19 +65,18 @@ namespace ErrorCodes
   */
 
 
-class FunctionDictHelper : public WithContext
+class FunctionDictHelper
 {
 public:
-    explicit FunctionDictHelper(ContextPtr context_) : WithContext(context_) {}
+    explicit FunctionDictHelper(ContextPtr context_) : context(context_) {}
 
     std::shared_ptr<const IDictionary> getDictionary(const String & dictionary_name)
     {
-        auto current_context = getContext();
-        auto dict = current_context->getExternalDictionariesLoader().getDictionary(dictionary_name, current_context);
+        auto dict = context->getExternalDictionariesLoader().getDictionary(dictionary_name, context);
 
         if (!access_checked)
         {
-            current_context->checkAccess(AccessType::dictGet, dict->getDatabaseOrNoDatabaseTag(), dict->getDictionaryID().getTableName());
+            context->checkAccess(AccessType::dictGet, dict->getDatabaseOrNoDatabaseTag(), dict->getDictionaryID().getTableName());
             access_checked = true;
         }
 
@@ -143,8 +142,10 @@ public:
 
     DictionaryStructure getDictionaryStructure(const String & dictionary_name) const
     {
-        return getContext()->getExternalDictionariesLoader().getDictionaryStructure(dictionary_name, getContext());
+        return context->getExternalDictionariesLoader().getDictionaryStructure(dictionary_name, context);
     }
+
+    const ContextPtr context;
 
 private:
     /// Access cannot be not granted, since in this case checkAccess() will throw and access_checked will not be updated.
@@ -643,7 +644,7 @@ private:
         ColumnPtr mask_column,
         const DataTypePtr & result_type) const
     {
-        auto if_func = FunctionFactory::instance().get("if", helper.getContext());
+        auto if_func = FunctionFactory::instance().get("if", helper.context);
         ColumnsWithTypeAndName if_args =
         {
             {mask_column, std::make_shared<DataTypeUInt8>(), {}},

--- a/src/Functions/TimeSeries/timeSeriesIdToTags.cpp
+++ b/src/Functions/TimeSeries/timeSeriesIdToTags.cpp
@@ -24,13 +24,13 @@ namespace ErrorCodes
 
 /// Function timeSeriesIdToTags(<id>) returns Array(Tuple(String, String)) containing the names and values of tags associated with
 /// a specified identifier <id>.
-class FunctionTimeSeriesIdToTags : public IFunction, private WithContext
+class FunctionTimeSeriesIdToTags : public IFunction
 {
 public:
     static constexpr auto name = "timeSeriesIdToTags";
 
     static FunctionPtr create(ContextPtr context_) { return std::make_shared<FunctionTimeSeriesIdToTags>(context_); }
-    explicit FunctionTimeSeriesIdToTags(ContextPtr context_) : WithContext(context_) {}
+    explicit FunctionTimeSeriesIdToTags(ContextPtr context_) : context(context_) {}
 
     String getName() const override { return name; }
 
@@ -149,7 +149,7 @@ public:
     std::vector<TagNamesAndValuesPtr> getTagsImpl(const IColumn & column_ids) const
     {
         auto ids = extractIDs<IDType>(column_ids);
-        return getContext()->getQueryContext()->getTimeSeriesTagsCollector().getTagsById(ids);
+        return context->getQueryContext()->getTimeSeriesTagsCollector().getTagsById(ids);
     }
 
     /// Extracts identifiers from the column.
@@ -161,6 +161,9 @@ public:
         const IDType * begin = reinterpret_cast<const IDType *>(data.data());
         return std::vector<IDType>(begin, begin + column_ids.size());
     }
+
+private:
+    const ContextPtr context;
 };
 
 

--- a/src/Functions/TimeSeries/timeSeriesIdToTagsGroup.cpp
+++ b/src/Functions/TimeSeries/timeSeriesIdToTagsGroup.cpp
@@ -19,13 +19,13 @@ namespace ErrorCodes
 
 /// Function timeSeriesIdToTagsGroup(<id>) converts the specified identifier of a time series to its group index.
 /// Group indices are numbers 0, 1, 2, 3 associated with each unique set of tags in the context of the currently executed query.
-class FunctionTimeSeriesIdToTagsGroup : public IFunction, private WithContext
+class FunctionTimeSeriesIdToTagsGroup : public IFunction
 {
 public:
     static constexpr auto name = "timeSeriesIdToTagsGroup";
 
     static FunctionPtr create(ContextPtr context_) { return std::make_shared<FunctionTimeSeriesIdToTagsGroup>(context_); }
-    explicit FunctionTimeSeriesIdToTagsGroup(ContextPtr context_) : WithContext(context_) {}
+    explicit FunctionTimeSeriesIdToTagsGroup(ContextPtr context_) : context(context_) {}
 
     String getName() const override { return name; }
 
@@ -122,7 +122,7 @@ public:
     std::vector<size_t> getGroupsImpl(const IColumn & column_ids) const
     {
         auto ids = extractIDs<IDType>(column_ids);
-        return getContext()->getQueryContext()->getTimeSeriesTagsCollector().getGroupById(ids);
+        return context->getQueryContext()->getTimeSeriesTagsCollector().getGroupById(ids);
     }
 
     /// Extracts identifiers from the column.
@@ -134,6 +134,9 @@ public:
         const IDType * begin = reinterpret_cast<const IDType *>(data.data());
         return std::vector<IDType>(begin, begin + column_ids.size());
     }
+
+private:
+    const ContextPtr context;
 };
 
 

--- a/src/Functions/TimeSeries/timeSeriesStoreTags.cpp
+++ b/src/Functions/TimeSeries/timeSeriesStoreTags.cpp
@@ -33,13 +33,13 @@ namespace ErrorCodes
 /// Function timeSeriesStoreTags(<id>, [('tag1_name', 'tag1_value'), ...], 'tag2_name', 'tag2_value', ...) returns <id>
 /// and stores the mapping between the identifier of a time series and its tags in the query context so that
 /// they can later be extracted by function timeSeriesIdToTags().
-class FunctionTimeSeriesStoreTags : public IFunction, private WithContext
+class FunctionTimeSeriesStoreTags : public IFunction
 {
 public:
     static constexpr auto name = "timeSeriesStoreTags";
 
     static FunctionPtr create(ContextPtr context_) { return std::make_shared<FunctionTimeSeriesStoreTags>(context_); }
-    explicit FunctionTimeSeriesStoreTags(ContextPtr context_) : WithContext(context_) {}
+    explicit FunctionTimeSeriesStoreTags(ContextPtr context_) : context(context_) {}
 
     String getName() const override { return name; }
 
@@ -395,7 +395,7 @@ public:
     void extractIDsAndStoreTagsImpl(const IColumn & column_ids, std::vector<TagNamesAndValues> && tags_vector) const
     {
         auto ids = extractIDs<IDType>(column_ids);
-        getContext()->getQueryContext()->getTimeSeriesTagsCollector().add(ids, makeTagsPtrVector(std::move(tags_vector)));
+        context->getQueryContext()->getTimeSeriesTagsCollector().add(ids, makeTagsPtrVector(std::move(tags_vector)));
     }
 
     /// Extracts identifiers from the column.
@@ -419,6 +419,9 @@ public:
         }
         return res;
     }
+
+private:
+    const ContextPtr context;
 };
 
 

--- a/src/Functions/TimeSeries/timeSeriesTagsGroupToTags.cpp
+++ b/src/Functions/TimeSeries/timeSeriesTagsGroupToTags.cpp
@@ -23,13 +23,13 @@ namespace ErrorCodes
 
 /// Function timeSeriesIdToTags(<group>) returns Array(Tuple(String, String)) containing the names and values of tags associated with
 /// a specified group.
-class FunctionTimeSeriesTagsGroupToTags : public IFunction, private WithContext
+class FunctionTimeSeriesTagsGroupToTags : public IFunction
 {
 public:
     static constexpr auto name = "timeSeriesTagsGroupToTags";
 
     static FunctionPtr create(ContextPtr context_) { return std::make_shared<FunctionTimeSeriesTagsGroupToTags>(context_); }
-    explicit FunctionTimeSeriesTagsGroupToTags(ContextPtr context_) : WithContext(context_) {}
+    explicit FunctionTimeSeriesTagsGroupToTags(ContextPtr context_) : context(context_) {}
 
     String getName() const override { return name; }
 
@@ -112,7 +112,7 @@ public:
         if (checkColumn<ColumnUInt64>(&column_groups))
         {
             auto groups = extractGroups(column_groups);
-            return getContext()->getQueryContext()->getTimeSeriesTagsCollector().getTagsByGroup(groups);
+            return context->getQueryContext()->getTimeSeriesTagsCollector().getTagsByGroup(groups);
         }
 
         /// The argument can be wrapped in ColumnConst or ColumnLowCardinality.
@@ -135,6 +135,9 @@ public:
         const UInt64 * begin = reinterpret_cast<const UInt64 *>(data.data());
         return std::vector<size_t>(begin, begin + column_groups.size());
     }
+
+private:
+    const ContextPtr context;
 };
 
 

--- a/src/Functions/array/arrayElement.cpp
+++ b/src/Functions/array/arrayElement.cpp
@@ -16,7 +16,7 @@
 #include <Functions/FunctionHelpers.h>
 #include <Functions/IFunction.h>
 #include <Functions/castTypeToEither.h>
-#include <Interpreters/Context.h>
+#include <Interpreters/Context_fwd.h>
 #include <Common/assert_cast.h>
 #include <Common/typeid_cast.h>
 
@@ -181,8 +181,6 @@ private:
     template <typename Matcher>
     static void
     executeMatchConstKeyToIndex(size_t num_rows, size_t num_values, PaddedPODArray<UInt64> & matched_idxs, const Matcher & matcher);
-
-    ContextPtr context;
 };
 
 

--- a/src/Functions/catboostEvaluate.cpp
+++ b/src/Functions/catboostEvaluate.cpp
@@ -36,7 +36,7 @@ private:
 public:
     static constexpr auto name = "catboostEvaluate";
 
-    static FunctionPtr create(ContextPtr context_) { return std::make_shared<FunctionCatBoostEvaluate>(context_); }
+    static FunctionPtr create(ContextPtr context_) { return std::make_shared<FunctionCatBoostEvaluate>(context_->getGlobalContext()); }
 
     explicit FunctionCatBoostEvaluate(ContextPtr context_) : WithContext(context_) {}
     String getName() const override { return name; }

--- a/src/Functions/coalesce.cpp
+++ b/src/Functions/coalesce.cpp
@@ -29,9 +29,8 @@ public:
         return std::make_shared<FunctionCoalesce>(context);
     }
 
-    explicit FunctionCoalesce(ContextPtr context_)
-        : context(context_)
-        , is_not_null(FunctionFactory::instance().get("isNotNull", context))
+    explicit FunctionCoalesce(ContextPtr context)
+        : is_not_null(FunctionFactory::instance().get("isNotNull", context))
         , assume_not_null(FunctionFactory::instance().get("assumeNotNull", context))
         , if_function(FunctionFactory::instance().get("if", context))
         , multi_if_function(FunctionFactory::instance().get("multiIf", context))
@@ -169,7 +168,6 @@ public:
     }
 
 private:
-    ContextPtr context;
     FunctionOverloadResolverPtr is_not_null;
     FunctionOverloadResolverPtr assume_not_null;
     FunctionOverloadResolverPtr if_function;

--- a/src/Functions/extractAllGroups.h
+++ b/src/Functions/extractAllGroups.h
@@ -51,14 +51,14 @@ enum class ExtractAllGroupsResultKind : uint8_t
 template <typename Impl>
 class FunctionExtractAllGroups : public IFunction
 {
-    ContextPtr context;
+    const UInt64 regexp_max_matches_per_row;
 
 public:
     static constexpr auto Kind = Impl::Kind;
     static constexpr auto name = Impl::Name;
 
-    explicit FunctionExtractAllGroups(ContextPtr context_)
-        : context(context_)
+    explicit FunctionExtractAllGroups(ContextPtr context)
+        : regexp_max_matches_per_row(context->getSettingsRef()[Setting::regexp_max_matches_per_row].value)
     {}
 
     static FunctionPtr create(ContextPtr context) { return std::make_shared<FunctionExtractAllGroups>(context); }
@@ -158,9 +158,6 @@ public:
         }
         else
         {
-            /// Additional limit to fail fast on supposedly incorrect usage.
-            const auto max_matches_per_row = context->getSettingsRef()[Setting::regexp_max_matches_per_row].value;
-
             PODArray<std::string_view, 0> all_matches;
             /// Number of times RE matched on each row of haystack column.
             PODArray<size_t, 0> number_of_matches_per_row;
@@ -188,10 +185,11 @@ public:
                         all_matches.push_back(matched_groups[group]);
 
                     ++matches_per_row;
-                    if (matches_per_row > max_matches_per_row)
+                    /// Additional limit to fail fast on supposedly incorrect usage.
+                    if (matches_per_row > regexp_max_matches_per_row)
                         throw Exception(ErrorCodes::TOO_LARGE_ARRAY_SIZE,
                                 "Too many matches per row (> {}) in the result of function {}",
-                                max_matches_per_row, getName());
+                                regexp_max_matches_per_row, getName());
 
                     pos = matched_groups[0].data() + std::max<size_t>(1, matched_groups[0].size());
                 }

--- a/src/Functions/extractKeyValuePairs.cpp
+++ b/src/Functions/extractKeyValuePairs.cpp
@@ -48,11 +48,10 @@ class ExtractKeyValuePairs : public IFunction
             builder.withQuotingCharacter(parsed_arguments.quoting_character.value());
         }
 
-        bool is_number_of_pairs_unlimited = context->getSettingsRef()[Setting::extract_key_value_pairs_max_pairs_per_row] == 0;
-
+        bool is_number_of_pairs_unlimited = extract_key_value_pairs_max_pairs_per_row == 0;
         if (!is_number_of_pairs_unlimited)
         {
-            builder.withMaxNumberOfPairs(context->getSettingsRef()[Setting::extract_key_value_pairs_max_pairs_per_row]);
+            builder.withMaxNumberOfPairs(extract_key_value_pairs_max_pairs_per_row);
         }
 
         if (parsed_arguments.unexpected_quoting_character_strategy)
@@ -108,7 +107,9 @@ class ExtractKeyValuePairs : public IFunction
     }
 
 public:
-    explicit ExtractKeyValuePairs(ContextPtr context_) : context(context_) {}
+    explicit ExtractKeyValuePairs(ContextPtr context)
+        : extract_key_value_pairs_max_pairs_per_row(context->getSettingsRef()[Setting::extract_key_value_pairs_max_pairs_per_row])
+    {}
 
     static constexpr auto name = Name::name;
 
@@ -157,7 +158,7 @@ public:
     }
 
 private:
-    ContextPtr context;
+    const UInt64 extract_key_value_pairs_max_pairs_per_row;
 };
 
 struct NameExtractKeyValuePairs

--- a/src/Functions/getMaxTableNameLength.cpp
+++ b/src/Functions/getMaxTableNameLength.cpp
@@ -20,28 +20,14 @@ namespace ErrorCodes
     extern const int INCORRECT_DATA;
 }
 
-class FunctionGetMaxTableNameLengthForDatabase : public IFunction, WithContext
+class FunctionGetMaxTableNameLengthForDatabase : public IFunction
 {
 public:
     static constexpr auto name = "getMaxTableNameLengthForDatabase";
-    static FunctionPtr create(ContextPtr context_)
-    {
-        return std::make_shared<FunctionGetMaxTableNameLengthForDatabase>(context_);
-    }
-
-    explicit FunctionGetMaxTableNameLengthForDatabase(ContextPtr context_) : WithContext(context_)
-    {
-    }
-
-    String getName() const override
-    {
-        return name;
-    }
-
-    size_t getNumberOfArguments() const override
-    {
-        return 1;
-    }
+    static FunctionPtr create(ContextPtr) { return std::make_shared<FunctionGetMaxTableNameLengthForDatabase>(); }
+    String getName() const override { return name; }
+    size_t getNumberOfArguments() const override { return 1; }
+    bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return false; }
 
     DataTypePtr getReturnTypeImpl(const DataTypes & arguments) const override
     {
@@ -56,8 +42,6 @@ public:
 
         return std::make_shared<DataTypeUInt64>();
     }
-
-    bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return false; }
 
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t input_rows_count) const override
     {
@@ -75,7 +59,7 @@ public:
         if (database_name.empty())
             throw Exception(ErrorCodes::INCORRECT_DATA, "Incorrect name for a database. It shouldn't be empty");
 
-        allowed_max_length = computeMaxTableNameLength(database_name, getContext());
+        allowed_max_length = computeMaxTableNameLength(database_name, Context::getGlobalContextInstance());
         return DataTypeUInt64().createColumnConst(input_rows_count, allowed_max_length);
     }
 

--- a/src/Functions/getServerPort.cpp
+++ b/src/Functions/getServerPort.cpp
@@ -71,7 +71,7 @@ private:
     DataTypePtr return_type;
 };
 
-class GetServerPortOverloadResolver : public IFunctionOverloadResolver, WithContext
+class GetServerPortOverloadResolver : public IFunctionOverloadResolver
 {
 public:
     static constexpr auto name = "getServerPort";
@@ -83,7 +83,9 @@ public:
         return std::make_unique<GetServerPortOverloadResolver>(context_);
     }
 
-    explicit GetServerPortOverloadResolver(ContextPtr context_) : WithContext(context_) {}
+    explicit GetServerPortOverloadResolver(ContextPtr context)
+        : is_distributed(context->isDistributed())
+    {}
 
     size_t getNumberOfArguments() const override { return 1; }
     ColumnNumbers getArgumentsThatAreAlwaysConstant() const override { return {0}; }
@@ -116,12 +118,15 @@ public:
                 getName());
 
         String port_name{column->getDataAt(0)};
-        auto port = getContext()->getServerPort(port_name);
+        auto port = Context::getGlobalContextInstance()->getServerPort(port_name);
 
         DataTypes argument_types;
         argument_types.emplace_back(arguments.back().type);
-        return std::make_unique<FunctionBaseGetServerPort>(getContext()->isDistributed(), port, argument_types, return_type);
+        return std::make_unique<FunctionBaseGetServerPort>(is_distributed, port, argument_types, return_type);
     }
+
+private:
+    const bool is_distributed;
 };
 
 }

--- a/src/Functions/getServerSetting.cpp
+++ b/src/Functions/getServerSetting.cpp
@@ -19,13 +19,12 @@ namespace ErrorCodes
 namespace
 {
 
-class FunctionGetServerSetting : public IFunction, WithContext
+class FunctionGetServerSetting : public IFunction
 {
 public:
     static constexpr auto name = "getServerSetting";
 
-    static FunctionPtr create(ContextPtr context_) { return std::make_shared<FunctionGetServerSetting>(context_); }
-    explicit FunctionGetServerSetting(ContextPtr context_) : WithContext(context_) {}
+    static FunctionPtr create(ContextPtr) { return std::make_shared<FunctionGetServerSetting>(); }
 
     String getName() const override { return name; }
 
@@ -71,7 +70,7 @@ private:
 
         std::string_view setting_name{column->getDataAt(0)};
 
-        return getContext()->getServerSettings().get(setting_name);
+        return Context::getGlobalContextInstance()->getServerSettings().get(setting_name);
     }
 };
 

--- a/src/Functions/map.cpp
+++ b/src/Functions/map.cpp
@@ -44,9 +44,8 @@ class FunctionMap : public IFunction
 public:
     static constexpr auto name = "map";
 
-    explicit FunctionMap(ContextPtr context_)
-        : context(context_)
-        , use_variant_as_common_type(context->getSettingsRef()[Setting::use_variant_as_common_type])
+    explicit FunctionMap(ContextPtr context)
+        : use_variant_as_common_type(context->getSettingsRef()[Setting::use_variant_as_common_type])
         , function_array(FunctionFactory::instance().get("array", context))
         , function_map_from_arrays(FunctionFactory::instance().get("mapFromArrays", context))
     {
@@ -144,7 +143,6 @@ public:
     }
 
 private:
-    ContextPtr context;
     bool use_variant_as_common_type = false;
     FunctionOverloadResolverPtr function_array;
     FunctionOverloadResolverPtr function_map_from_arrays;

--- a/src/Functions/printf.cpp
+++ b/src/Functions/printf.cpp
@@ -30,7 +30,6 @@ namespace
 class FunctionPrintf : public IFunction
 {
 private:
-    ContextPtr context;
     FunctionOverloadResolverPtr function_concat;
 
     struct Instruction
@@ -157,8 +156,9 @@ public:
 
     static FunctionPtr create(ContextPtr context) { return std::make_shared<FunctionPrintf>(context); }
 
-    explicit FunctionPrintf(ContextPtr context_)
-        : context(context_), function_concat(FunctionFactory::instance().get("concat", context)) { }
+    explicit FunctionPrintf(ContextPtr context)
+        : function_concat(FunctionFactory::instance().get("concat", context))
+    {}
 
     String getName() const override { return name; }
 

--- a/src/Functions/toBool.cpp
+++ b/src/Functions/toBool.cpp
@@ -14,8 +14,6 @@ namespace
     class FunctionToBool : public IFunction
     {
     private:
-        ContextPtr context;
-
         static String getReturnTypeName(const DataTypePtr & argument)
         {
             return argument->isNullable() ? "Nullable(Bool)" : "Bool";


### PR DESCRIPTION
### Changelog category (leave one):
- Not For Changelog

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Sanitize Context usage in Functions

Context holds a lot, that may include some caches, by holding a copy to `ContextPtr` the lifetime of this caches will be extended.

This may be a problem when functions are used in `MergeTree` (`ORDER BY`/`PARTITON BY` or regular `MATERIALIZED`/`DEFAULT` expressions), since `MergeTree` storage will hold function that uses expired context (and you can see it [here](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=92168&sha=d941a3cf1d20d49ded134877fda8add695ecf0cf&name_0=PR&name_1=Fast+test), after `ContextPtr` has been removed from `FunctionsConversion.h`, it immediately leads to `Context has expired` in `dictGet`)

This patch does two things:
- adds a style check to avoid such problems in future (for holding `ContextPtr` copy and for `WithContext` usage)
- removes `ContextPtr` whenever it is possible
  - for some it is enough to extract some settings/members
  - others can simply use global context
- replace `WithContext` with holding a copy of `ContextPtr` when it is a must, i.e. `dictGet`

**Note**: another option can be to add `ContextPtr` for `execute` method, but it may be overkill, since most of the functions are OK, but I'm open to suggestions here

_P.S. even though it should not be a user visible change, I'm marking it as `Backward Incompatible Change`, since it may lead to `Context has expired` errors for some very obscure cases_