### PR TITLE
connectionId() is not deterministic

### DIFF
--- a/src/Functions/connectionId.cpp
+++ b/src/Functions/connectionId.cpp
@@ -17,6 +17,8 @@ public:
 
     static FunctionPtr create(ContextPtr context_) { return std::make_shared<FunctionConnectionId>(context_); }
 
+    bool isDeterministic() const override { return false; }
+
     String getName() const override { return name; }
 
     size_t getNumberOfArguments() const override { return 0; }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Long term - `isDeterministic`/`isDeterministicInScopeOfQuery` should be pure `virtual`