### PR TITLE
Activate checks for harmful functions in sanitizer builds

### DIFF
--- a/base/base/defines.h
+++ b/base/base/defines.h
@@ -1,18 +1,7 @@
 #pragma once
 
-/// __has_feature supported only by clang.
-///
-/// But libcxx/libcxxabi overrides it to 0,
-/// thus the checks for __has_feature will be wrong.
-///
-/// NOTE:
-/// - __has_feature cannot be simply undefined,
-///   since this will be broken if some C++ header will be included after
-///   including <base/defines.h>
-/// - it should not have fallback to 0,
-///   since this may create false-positive detection (common problem)
-#if defined(__has_feature)
-#    define ch_has_feature __has_feature
+#if !defined(__x86_64__) && !defined(__aarch64__) && !defined(__PPC__) && !defined(__s390x__) && !(defined(__loongarch64)) && !(defined(__riscv) && (__riscv_xlen == 64)) && !defined(__e2k__)
+#    error "The only supported platforms are x86_64 and AArch64, PowerPC (work in progress), s390x (work in progress), loongarch64 (experimental), RISC-V 64 (experimental) and E2K (experimental, work in progress)"
 #endif
 
 #if !defined(likely)
@@ -28,73 +17,7 @@
 #define NO_INLINE __attribute__((__noinline__))
 #define MAY_ALIAS __attribute__((__may_alias__))
 
-#if !defined(__x86_64__) && !defined(__aarch64__) && !defined(__PPC__) && !defined(__s390x__) && !(defined(__loongarch64)) && !(defined(__riscv) && (__riscv_xlen == 64)) && !defined(__e2k__)
-#    error "The only supported platforms are x86_64 and AArch64, PowerPC (work in progress), s390x (work in progress), loongarch64 (experimental), RISC-V 64 (experimental) and E2K (experimental, work in progress)"
-#endif
-
-/// Check for presence of address sanitizer
-#if !defined(ADDRESS_SANITIZER)
-#    if defined(ch_has_feature)
-#        if ch_has_feature(address_sanitizer)
-#            define ADDRESS_SANITIZER 1
-#        endif
-#    elif defined(__SANITIZE_ADDRESS__)
-#        define ADDRESS_SANITIZER 1
-#    endif
-#endif
-
-#if !defined(THREAD_SANITIZER)
-#    if defined(ch_has_feature)
-#        if ch_has_feature(thread_sanitizer)
-#            define THREAD_SANITIZER 1
-#        endif
-#    elif defined(__SANITIZE_THREAD__)
-#        define THREAD_SANITIZER 1
-#    endif
-#endif
-
-#if !defined(MEMORY_SANITIZER)
-#    if defined(ch_has_feature)
-#        if ch_has_feature(memory_sanitizer)
-#            define MEMORY_SANITIZER 1
-#        endif
-#    elif defined(__MEMORY_SANITIZER__)
-#        define MEMORY_SANITIZER 1
-#    endif
-#endif
-
-#if !defined(UNDEFINED_BEHAVIOR_SANITIZER)
-#    if defined(__has_feature)
-#        if __has_feature(undefined_behavior_sanitizer)
-#            define UNDEFINED_BEHAVIOR_SANITIZER 1
-#        endif
-#    elif defined(__UNDEFINED_BEHAVIOR_SANITIZER__)
-#        define UNDEFINED_BEHAVIOR_SANITIZER 1
-#    endif
-#endif
-
-/// Explicitly allow undefined behaviour for certain functions. Use it as a function attribute.
-/// It is useful in case when compiler cannot see (and exploit) it, but UBSan can.
-/// Example: multiplication of signed integers with possibility of overflow when both sides are from user input.
-#define NO_SANITIZE_UNDEFINED __attribute__((__no_sanitize__("undefined")))
-#define NO_SANITIZE_ADDRESS __attribute__((__no_sanitize__("address")))
-#define NO_SANITIZE_THREAD __attribute__((__no_sanitize__("thread")))
-#define ALWAYS_INLINE_NO_SANITIZE_UNDEFINED __attribute__((__always_inline__, __no_sanitize__("undefined")))
-#define DISABLE_SANITIZER_INSTRUMENTATION __attribute__((disable_sanitizer_instrumentation))
-
-#if !__has_include(<sanitizer/asan_interface.h>) || !defined(ADDRESS_SANITIZER)
-#   define ASAN_UNPOISON_MEMORY_REGION(a, b)
-#   define ASAN_POISON_MEMORY_REGION(a, b)
-#endif
-
-/// We used to have only ABORT_ON_LOGICAL_ERROR macro, but most of its uses were actually in places where we didn't care about logical errors
-/// but wanted to check exactly if the current build type is debug or with sanitizer. This new macro is introduced to fix those places.
-#if !defined(DEBUG_OR_SANITIZER_BUILD)
-#    if !defined(NDEBUG) || defined(ADDRESS_SANITIZER) || defined(THREAD_SANITIZER) || defined(MEMORY_SANITIZER) \
-        || defined(UNDEFINED_BEHAVIOR_SANITIZER)
-#        define DEBUG_OR_SANITIZER_BUILD
-#    endif
-#endif
+#include <base/sanitizer_defs.h>
 
 /// chassert(x) is similar to assert(x), but:
 ///     - works in builds with sanitizers, not only in debug builds

--- a/base/base/sanitizer_defs.h
+++ b/base/base/sanitizer_defs.h
@@ -1,0 +1,80 @@
+#pragma once
+
+/// __has_feature supported only by clang.
+///
+/// But libcxx/libcxxabi overrides it to 0,
+/// thus the checks for __has_feature will be wrong.
+///
+/// NOTE:
+/// - __has_feature cannot be simply undefined,
+///   since this will be broken if some C++ header will be included after
+///   including <base/defines.h>
+/// - it should not have fallback to 0,
+///   since this may create false-positive detection (common problem)
+#if defined(__has_feature)
+#    define ch_has_feature __has_feature
+#endif
+
+/// Check for presence of address sanitizer
+#if !defined(ADDRESS_SANITIZER)
+#    if defined(ch_has_feature)
+#        if ch_has_feature(address_sanitizer)
+#            define ADDRESS_SANITIZER 1
+#        endif
+#    elif defined(__SANITIZE_ADDRESS__)
+#        define ADDRESS_SANITIZER 1
+#    endif
+#endif
+
+#if !defined(THREAD_SANITIZER)
+#    if defined(ch_has_feature)
+#        if ch_has_feature(thread_sanitizer)
+#            define THREAD_SANITIZER 1
+#        endif
+#    elif defined(__SANITIZE_THREAD__)
+#        define THREAD_SANITIZER 1
+#    endif
+#endif
+
+#if !defined(MEMORY_SANITIZER)
+#    if defined(ch_has_feature)
+#        if ch_has_feature(memory_sanitizer)
+#            define MEMORY_SANITIZER 1
+#        endif
+#    elif defined(__MEMORY_SANITIZER__)
+#        define MEMORY_SANITIZER 1
+#    endif
+#endif
+
+#if !defined(UNDEFINED_BEHAVIOR_SANITIZER)
+#    if defined(ch_has_feature)
+#        if ch_has_feature(undefined_behavior_sanitizer)
+#            define UNDEFINED_BEHAVIOR_SANITIZER 1
+#        endif
+#    elif defined(__UNDEFINED_BEHAVIOR_SANITIZER__)
+#        define UNDEFINED_BEHAVIOR_SANITIZER 1
+#    endif
+#endif
+
+/// We used to have only ABORT_ON_LOGICAL_ERROR macro, but most of its uses were actually in places where we didn't care about logical errors
+/// but wanted to check exactly if the current build type is debug or with sanitizer. This new macro is introduced to fix those places.
+#if !defined(DEBUG_OR_SANITIZER_BUILD)
+#    if !defined(NDEBUG) || defined(ADDRESS_SANITIZER) || defined(THREAD_SANITIZER) || defined(MEMORY_SANITIZER) \
+        || defined(UNDEFINED_BEHAVIOR_SANITIZER)
+#        define DEBUG_OR_SANITIZER_BUILD
+#    endif
+#endif
+
+/// Explicitly allow undefined behaviour for certain functions. Use it as a function attribute.
+/// It is useful in case when compiler cannot see (and exploit) it, but UBSan can.
+/// Example: multiplication of signed integers with possibility of overflow when both sides are from user input.
+#define NO_SANITIZE_UNDEFINED __attribute__((__no_sanitize__("undefined")))
+#define NO_SANITIZE_ADDRESS __attribute__((__no_sanitize__("address")))
+#define NO_SANITIZE_THREAD __attribute__((__no_sanitize__("thread")))
+#define ALWAYS_INLINE_NO_SANITIZE_UNDEFINED __attribute__((__always_inline__, __no_sanitize__("undefined")))
+#define DISABLE_SANITIZER_INSTRUMENTATION __attribute__((disable_sanitizer_instrumentation))
+
+#if !__has_include(<sanitizer/asan_interface.h>) || !defined(ADDRESS_SANITIZER)
+#   define ASAN_UNPOISON_MEMORY_REGION(a, b)
+#   define ASAN_POISON_MEMORY_REGION(a, b)
+#endif

--- a/base/harmful/CMakeLists.txt
+++ b/base/harmful/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_library(harmful harmful.c)
+target_include_directories(harmful PRIVATE ..)

--- a/base/harmful/harmful.c
+++ b/base/harmful/harmful.c
@@ -3,17 +3,7 @@
   * (by terminating the program immediately).
   */
 
-#if !defined(DEBUG_OR_SANITIZER_BUILD)
-#    if !defined(NDEBUG) || defined(ADDRESS_SANITIZER) || defined(THREAD_SANITIZER) || defined(MEMORY_SANITIZER) || defined(UNDEFINED_BEHAVIOR_SANITIZER)
-#        define DEBUG_OR_SANITIZER_BUILD
-#    elif defined(__has_feature)
-#        if __has_feature(address_sanitizer) || __has_feature(thread_sanitizer) || __has_feature(memory_sanitizer) || __has_feature(undefined_behavior_sanitizer)
-#            define DEBUG_OR_SANITIZER_BUILD
-#        endif
-#    elif defined(__SANITIZE_ADDRESS__) || defined(__SANITIZE_THREAD__) || defined(__MEMORY_SANITIZER__) || defined(__UNDEFINED_BEHAVIOR_SANITIZER__)
-#        define DEBUG_OR_SANITIZER_BUILD
-#    endif
-#endif
+#include "../base/sanitizer_defs.h"
 
 /// We check for "harmful" functions if it's a debug build or with a sanitizer.
 #if defined(DEBUG_OR_SANITIZER_BUILD)

--- a/base/harmful/harmful.c
+++ b/base/harmful/harmful.c
@@ -3,8 +3,20 @@
   * (by terminating the program immediately).
   */
 
-/// It is only enabled in debug build (its intended use is for CI checks).
-#if !defined(NDEBUG)
+#if !defined(DEBUG_OR_SANITIZER_BUILD)
+#    if !defined(NDEBUG) || defined(ADDRESS_SANITIZER) || defined(THREAD_SANITIZER) || defined(MEMORY_SANITIZER) || defined(UNDEFINED_BEHAVIOR_SANITIZER)
+#        define DEBUG_OR_SANITIZER_BUILD
+#    elif defined(__has_feature)
+#        if __has_feature(address_sanitizer) || __has_feature(thread_sanitizer) || __has_feature(memory_sanitizer) || __has_feature(undefined_behavior_sanitizer)
+#            define DEBUG_OR_SANITIZER_BUILD
+#        endif
+#    elif defined(__SANITIZE_ADDRESS__) || defined(__SANITIZE_THREAD__) || defined(__MEMORY_SANITIZER__) || defined(__UNDEFINED_BEHAVIOR_SANITIZER__)
+#        define DEBUG_OR_SANITIZER_BUILD
+#    endif
+#endif
+
+/// We check for "harmful" functions if it's a debug build or with a sanitizer.
+#if defined(DEBUG_OR_SANITIZER_BUILD)
 
 #pragma clang diagnostic ignored "-Wincompatible-library-redeclaration"
 

--- a/base/harmful/harmful.c
+++ b/base/harmful/harmful.c
@@ -3,7 +3,7 @@
   * (by terminating the program immediately).
   */
 
-#include "../base/sanitizer_defs.h"
+#include <base/sanitizer_defs.h>
 
 /// We check for "harmful" functions if it's a debug build or with a sanitizer.
 #if defined(DEBUG_OR_SANITIZER_BUILD)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Activate checks for harmful functions in sanitizer builds.

Previously harmful functions were checked only in the debug build. However CI doesn't run integration tests in the debug build (because it would be too slow), so in order to check the code used in integration tests only we can enable these traps in sanitizer builds too.