### PR TITLE
Use seconds for `refresh_certificates_task_interval` in ACME config

### DIFF
--- a/src/Server/ACME/Client.cpp
+++ b/src/Server/ACME/Client.cpp
@@ -155,8 +155,8 @@ void Client::initialize(const Poco::Util::AbstractConfiguration & config)
     auto default_refresh_certificates_task_interval = /* one hour, in seconds */ 60 * 60;
     auto default_refresh_certificates_before = /* one month, in seconds */ 60 * 60 * 24 * 30;
 
-    refresh_certificates_task_interval_ms = config.getInt("acme.refresh_certificates_task_interval", default_refresh_certificates_task_interval) * 1000;
-    refresh_certificates_before = config.getInt("acme.refresh_certificates_before", default_refresh_certificates_before);
+    refresh_certificates_task_interval_ms = config.getInt("acme.refresh_certificates_task_interval_seconds", default_refresh_certificates_task_interval) * 1000;
+    refresh_certificates_before_seconds = config.getInt("acme.refresh_certificates_before_seconds", default_refresh_certificates_before);
 
     acme_hostname = Poco::URI(directory_url).getHost();
     LOG_TEST(log, "ACME server hostname: {}", acme_hostname);
@@ -218,7 +218,7 @@ void Client::refreshCertificatesTask(const Poco::Util::AbstractConfiguration & c
 
             int tzd;
             auto expiration_date = Poco::DateTimeParser::parse("%y%m%d%H%M%S", x509_certificate.expiresOn(), tzd);
-            auto best_before = Poco::Timestamp() + Poco::Timespan(refresh_certificates_before * Poco::Timespan::SECONDS);
+            auto best_before = Poco::Timestamp() + Poco::Timespan(refresh_certificates_before_seconds * Poco::Timespan::SECONDS);
 
             if (expiration_date < best_before)
             {

--- a/src/Server/ACME/Client.cpp
+++ b/src/Server/ACME/Client.cpp
@@ -151,8 +151,12 @@ void Client::initialize(const Poco::Util::AbstractConfiguration & config)
         throw Exception(ErrorCodes::NO_ELEMENTS_IN_CONFIG, "List of domains handled by ACME client is empty, please check configuration.");
 
     domains = served_domains;
-    refresh_certificates_task_interval = config.getInt("acme.refresh_certificates_task_interval", /* one hour */ 1000 * 60 * 60);
-    refresh_certificates_before = config.getInt("acme.refresh_certificates_before", /* one month */ 60 * 60 * 24 * 30);
+
+    auto default_refresh_certificates_task_interval = /* one hour, in seconds */ 60 * 60;
+    auto default_refresh_certificates_before = /* one month, in seconds */ 60 * 60 * 24 * 30;
+
+    refresh_certificates_task_interval_ms = config.getInt("acme.refresh_certificates_task_interval", default_refresh_certificates_task_interval) * 1000;
+    refresh_certificates_before = config.getInt("acme.refresh_certificates_before", default_refresh_certificates_before);
 
     acme_hostname = Poco::URI(directory_url).getHost();
     LOG_TEST(log, "ACME server hostname: {}", acme_hostname);
@@ -230,7 +234,7 @@ void Client::refreshCertificatesTask(const Poco::Util::AbstractConfiguration & c
 
             CertificateReloader::instance().tryLoad(config);
 
-            refresh_certificates_task->scheduleAfter(refresh_certificates_task_interval);
+            refresh_certificates_task->scheduleAfter(refresh_certificates_task_interval_ms);
             return;
         }
 
@@ -326,7 +330,7 @@ void Client::refreshCertificatesTask(const Poco::Util::AbstractConfiguration & c
         {
             LOG_DEBUG(log, "Order {} is not ready yet (status: {}), retrying", order_url, order_data.status);
 
-            refresh_certificates_task->scheduleAfter(refresh_certificates_task_interval);
+            refresh_certificates_task->scheduleAfter(refresh_certificates_task_interval_ms);
             return;
         }
 
@@ -359,7 +363,7 @@ void Client::refreshCertificatesTask(const Poco::Util::AbstractConfiguration & c
         return;
     }
 
-    refresh_certificates_task->scheduleAfter(refresh_certificates_task_interval);
+    refresh_certificates_task->scheduleAfter(refresh_certificates_task_interval_ms);
 }
 
 void Client::authenticationTask()

--- a/src/Server/ACME/Client.h
+++ b/src/Server/ACME/Client.h
@@ -85,7 +85,7 @@ private:
     std::shared_ptr<zkutil::ZooKeeperLock> lock;
 
     std::vector<std::string> domains;
-    UInt64 refresh_certificates_task_interval;
+    UInt64 refresh_certificates_task_interval_ms;
     UInt64 refresh_certificates_before;
     std::optional<std::string> active_order;
 };

--- a/src/Server/ACME/Client.h
+++ b/src/Server/ACME/Client.h
@@ -86,7 +86,7 @@ private:
 
     std::vector<std::string> domains;
     UInt64 refresh_certificates_task_interval_ms;
-    UInt64 refresh_certificates_before;
+    UInt64 refresh_certificates_before_seconds;
     std::optional<std::string> active_order;
 };
 

--- a/tests/integration/test_acme_tls/configs/config.xml
+++ b/tests/integration/test_acme_tls/configs/config.xml
@@ -9,7 +9,7 @@
             <domain>single.integration-tests.clickhouse.com</domain>
         </domains>
         <directory_url>https://10.5.11.2:14000/dir</directory_url>
-        <refresh_certificates_task_interval>1000</refresh_certificates_task_interval>
+        <refresh_certificates_task_interval>1</refresh_certificates_task_interval>
         <refresh_certificates_before>86400</refresh_certificates_before> <!-- one day -->
     </acme>
     <openSSL>

--- a/tests/integration/test_acme_tls/configs/config.xml
+++ b/tests/integration/test_acme_tls/configs/config.xml
@@ -9,8 +9,8 @@
             <domain>single.integration-tests.clickhouse.com</domain>
         </domains>
         <directory_url>https://10.5.11.2:14000/dir</directory_url>
-        <refresh_certificates_task_interval>1</refresh_certificates_task_interval>
-        <refresh_certificates_before>86400</refresh_certificates_before> <!-- one day -->
+        <refresh_certificates_task_interval_seconds>1</refresh_certificates_task_interval_seconds>
+        <refresh_certificates_before_seconds>86400</refresh_certificates_before_seconds> <!-- one day -->
     </acme>
     <openSSL>
         <client>

--- a/tests/integration/test_acme_tls/configs/config_multi.xml
+++ b/tests/integration/test_acme_tls/configs/config_multi.xml
@@ -9,8 +9,8 @@
             <domain>multi.integration-tests.clickhouse.com</domain>
         </domains>
         <directory_url>https://10.5.11.2:14000/dir</directory_url>
-        <refresh_certificates_task_interval>1</refresh_certificates_task_interval>
-        <refresh_certificates_before>86400</refresh_certificates_before> <!-- one day -->
+        <refresh_certificates_task_interval_seconds>1</refresh_certificates_task_interval_seconds>
+        <refresh_certificates_before_seconds>86400</refresh_certificates_before_seconds> <!-- one day -->
     </acme>
     <openSSL>
         <client>

--- a/tests/integration/test_acme_tls/configs/config_multi.xml
+++ b/tests/integration/test_acme_tls/configs/config_multi.xml
@@ -9,7 +9,7 @@
             <domain>multi.integration-tests.clickhouse.com</domain>
         </domains>
         <directory_url>https://10.5.11.2:14000/dir</directory_url>
-        <refresh_certificates_task_interval>1000</refresh_certificates_task_interval>
+        <refresh_certificates_task_interval>1</refresh_certificates_task_interval>
         <refresh_certificates_before>86400</refresh_certificates_before> <!-- one day -->
     </acme>
     <openSSL>


### PR DESCRIPTION
### Changelog category (leave one):
- Backward Incompatible Change


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Renamed ACME configuration parameters `refresh_certificates_task_interval` to `refresh_certificates_task_interval_seconds` and `refresh_certificates_before to refresh_certificates_before_seconds`. The `refresh_certificates_task_interval_seconds` parameter now expects a value in seconds
