### PR TITLE
Log parts events in system.part_log for system.*_log

### DIFF
--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -5396,18 +5396,12 @@ std::shared_ptr<QueryViewsLog> Context::getQueryViewsLog() const
     return shared->system_logs->query_views_log;
 }
 
-std::shared_ptr<PartLog> Context::getPartLog(const String & part_database) const
+std::shared_ptr<PartLog> Context::getPartLog() const
 {
     SharedLockGuard lock(shared->mutex);
 
     /// No part log or system logs are shutting down.
     if (!shared->system_logs)
-        return {};
-
-    /// Will not log operations on system tables (including part_log itself).
-    /// It doesn't make sense and not allow to destruct PartLog correctly due to infinite logging and flushing,
-    /// and also make troubles on startup.
-    if (part_database == DatabaseCatalog::SYSTEM_DATABASE)
         return {};
 
     return shared->system_logs->part_log;

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -1445,7 +1445,7 @@ public:
 
     /// Returns an object used to log operations with parts if it possible.
     /// Provide table name to make required checks.
-    std::shared_ptr<PartLog> getPartLog(const String & part_database) const;
+    std::shared_ptr<PartLog> getPartLog() const;
 
     std::shared_ptr<BackgroundSchedulePoolLog> getBackgroundSchedulePoolLog() const;
 

--- a/src/Interpreters/PartLog.cpp
+++ b/src/Interpreters/PartLog.cpp
@@ -236,7 +236,7 @@ bool PartLog::addNewPartsImpl(
     try
     {
         auto table_id = parts.front().part->storage.getStorageID();
-        part_log = current_context->getPartLog(table_id.database_name); // assume parts belong to the same table
+        part_log = current_context->getPartLog(); // assume parts belong to the same table
         if (!part_log)
             return false;
 

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -3327,7 +3327,7 @@ void MergeTreeData::removePartsFinally(const MergeTreeData::DataPartsVector & pa
     /// NOTE: There is no need to log parts deletion somewhere else, all deleting parts pass through this function and pass away
 
     auto table_id = getStorageID();
-    if (auto part_log = getContext()->getPartLog(table_id.database_name))
+    if (auto part_log = getContext()->getPartLog())
     {
         PartLogElement part_log_elem;
 
@@ -9096,7 +9096,7 @@ void MergeTreeData::writePartLog(
 try
 {
     auto table_id = getStorageID();
-    auto part_log = getContext()->getPartLog(table_id.database_name);
+    auto part_log = getContext()->getPartLog();
     if (!part_log)
         return;
 

--- a/tests/integration/test_part_log_table/test.py
+++ b/tests/integration/test_part_log_table/test.py
@@ -1,4 +1,5 @@
 import fnmatch
+import uuid
 
 import pytest
 
@@ -29,17 +30,19 @@ def start_cluster():
 
 
 def test_config_without_part_log(start_cluster):
+    table_name = f"test_table_{uuid.uuid4().hex}"
+
     resp = node1.query_and_get_error("SELECT * FROM system.part_log")
     assert fnmatch.fnmatch(resp, "*DB::Exception:*system.part_log*UNKNOWN_TABLE*"), resp
 
     node1.query(
-        "CREATE TABLE test_table(word String, value UInt64) ENGINE=MergeTree() ORDER BY value"
+        f"CREATE TABLE {table_name}(word String, value UInt64) ENGINE=MergeTree() ORDER BY value"
     )
     resp = node1.query_and_get_error("SELECT * FROM system.part_log")
     assert fnmatch.fnmatch(resp, "*DB::Exception:*system.part_log*UNKNOWN_TABLE*"), resp
 
-    node1.query("INSERT INTO test_table VALUES ('name', 1)")
-    node1.query("SYSTEM FLUSH LOGS")
+    node1.query(f"INSERT INTO {table_name} VALUES ('name', 1)")
+    node1.query("SYSTEM FLUSH LOGS part_log")
 
     resp = node1.query_and_get_error("SELECT * FROM system.part_log")
     assert fnmatch.fnmatch(resp, "*DB::Exception:*system.part_log*UNKNOWN_TABLE*"), resp
@@ -49,59 +52,60 @@ def test_config_without_part_log(start_cluster):
 
 
 def test_config_with_standard_part_log(start_cluster):
-    node2.query(
-        "CREATE TABLE test_table(word String, value UInt64) ENGINE=MergeTree() Order by value"
-    )
-    node2.query("INSERT INTO test_table VALUES ('name', 1)")
-    node2.query("SYSTEM FLUSH LOGS")
-    assert node2.query("SELECT * FROM system.part_log WHERE database = 'default' AND table = 'test_table'") != ""
+    table_name = f"test_table_{uuid.uuid4().hex}"
+
+    node2.query(f"CREATE TABLE {table_name}(word String, value UInt64) ENGINE=MergeTree() Order by value")
+    node2.query(f"INSERT INTO {table_name} VALUES ('name', 1)")
+    node2.query("SYSTEM FLUSH LOGS part_log")
+    assert node2.query(f"SELECT * FROM system.part_log WHERE database = 'default' AND table = '{table_name}'") != ""
 
 
 def test_part_log_contains_partition(start_cluster):
+    table_name = f"test_partition_table_{uuid.uuid4().hex}"
+
+    node2.query(f"CREATE TABLE {table_name} (date Date, word String, value UInt64) ENGINE=MergeTree() PARTITION BY toYYYYMM(date) Order by value")
     node2.query(
-        "CREATE TABLE test_partition_table (date Date, word String, value UInt64) ENGINE=MergeTree() "
-        + "PARTITION BY toYYYYMM(date) Order by value"
-    )
-    node2.query(
-        "INSERT INTO test_partition_table VALUES "
+        f"INSERT INTO {table_name} VALUES "
         + "('2023-06-20', 'a', 10), ('2023-06-21', 'b', 11),"
         + "('2023-05-20', 'cc', 14),('2023-05-21', 'd1', 15);"
     )
-    node2.query("SYSTEM FLUSH LOGS")
+    node2.query("SYSTEM FLUSH LOGS part_log")
     resp = node2.query(
-        "SELECT partition from system.part_log where table = 'test_partition_table'"
+        f"SELECT partition from system.part_log where table = '{table_name}'"
     )
     assert resp == "202306\n202305\n"
 
 
+def test_system_log_tables_in_part_log(start_cluster):
+    table_name = f"tmp_table_{uuid.uuid4().hex}"
+
+    node2.query(f"CREATE TABLE {table_name}(key Int) ENGINE=MergeTree() ORDER BY ()")
+    node2.query(f"INSERT INTO {table_name} VALUES (1)")
+    node2.query("SYSTEM FLUSH LOGS part_log")
+    node2.query("OPTIMIZE TABLE system.part_log FINAL")
+    node2.query("SYSTEM FLUSH LOGS part_log")
+    assert node2.query("SELECT DISTINCT event_type FROM system.part_log WHERE database = 'system' AND table = 'part_log' ORDER BY ALL") == "NewPart\nMergeParts\nMergePartsStart\n"
+
+
 def test_config_with_non_standard_part_log(start_cluster):
-    node3.query(
-        "CREATE TABLE test_table(word String, value UInt64) ENGINE=MergeTree() Order by value"
-    )
-    node3.query("INSERT INTO test_table VALUES ('name', 1)")
-    node3.query("SYSTEM FLUSH LOGS")
-    assert node3.query("SELECT * FROM system.own_part_log") != ""
+    table_name = f"test_table_{uuid.uuid4().hex}"
+
+    node3.query(f"CREATE TABLE {table_name}(word String, value UInt64) ENGINE=MergeTree() Order by value")
+    node3.query(f"INSERT INTO {table_name} VALUES ('name', 1)")
+    node3.query("SYSTEM FLUSH LOGS part_log")
+    assert node3.query(f"SELECT * FROM system.own_part_log WHERE table = '{table_name}'") != ""
 
 
 def test_config_disk_name_test(start_cluster):
-    node4.query(
-        "CREATE TABLE test_table1(word String, value UInt64) ENGINE = MergeTree() ORDER BY word SETTINGS storage_policy = 'test1'"
-    )
-    node4.query("INSERT INTO test_table1(*) VALUES ('test1', 2)")
-    node4.query(
-        "CREATE TABLE test_table2(word String, value UInt64) ENGINE = MergeTree() ORDER BY word SETTINGS storage_policy = 'test2'"
-    )
-    node4.query("INSERT INTO test_table2(*) VALUES ('test2', 3)")
-    node4.query("SYSTEM FLUSH LOGS")
+    table_name1 = f"test_table1_{uuid.uuid4().hex}"
+    table_name2 = f"test_table2_{uuid.uuid4().hex}"
+
+    node4.query(f"CREATE TABLE {table_name1}(word String, value UInt64) ENGINE = MergeTree() ORDER BY word SETTINGS storage_policy = 'test1'")
+    node4.query(f"INSERT INTO {table_name1}(*) VALUES ('test1', 2)")
+    node4.query(f"CREATE TABLE {table_name2}(word String, value UInt64) ENGINE = MergeTree() ORDER BY word SETTINGS storage_policy = 'test2'")
+    node4.query(f"INSERT INTO {table_name2}(*) VALUES ('test2', 3)")
+    node4.query("SYSTEM FLUSH LOGS part_log")
     assert (
-        node4.query("SELECT DISTINCT disk_name FROM system.part_log WHERE database = 'default' AND table IN ('test_table1', 'test_table2') ORDER by disk_name")
+        node4.query(f"SELECT DISTINCT disk_name FROM system.part_log WHERE database = 'default' AND table IN ('{table_name1}', '{table_name2}') ORDER by disk_name")
         == "test1\ntest2\n"
     )
-
-def test_system_log_tables_in_part_log(start_cluster):
-    node2.query("CREATE TABLE tmp_table(key Int) ENGINE=MergeTree() ORDER BY ()")
-    node2.query("INSERT INTO tmp_table VALUES (1)")
-    node2.query("SYSTEM FLUSH LOGS system.part_log")
-    node2.query("OPTIMIZE TABLE system.part_log FINAL")
-    node2.query("SYSTEM FLUSH LOGS system.part_log")
-    assert node2.query("SELECT DISTINCT event_type FROM system.part_log WHERE database = 'system' AND table = 'part_log' ORDER BY ALL") == "NewPart\nMergeParts\nMergePartsStart\n"


### PR DESCRIPTION
I think it was a problem long time ago (back in afbbd780e388c85806717c8b8f23f1106580fa57 / 1e4906816c46c2454e415d8279c7cb3ee0c5da7e), now it should be OK (we have such "recursion" for text_log as well - we have logging while flushing to system.text_log).

Fixes: https://github.com/ClickHouse/ClickHouse/issues/77910

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Log parts events in `system.part_log` for `system.*_log`