### PR TITLE
Remove no active host exception in DDL worker

### DIFF
--- a/src/Interpreters/DDLWorker.cpp
+++ b/src/Interpreters/DDLWorker.cpp
@@ -77,7 +77,6 @@ namespace ErrorCodes
     extern const int NOT_IMPLEMENTED;
     extern const int TOO_MANY_SIMULTANEOUS_QUERIES;
     extern const int NO_ZOOKEEPER;
-    extern const int INVALID_CONFIG_PARAMETER;
 }
 
 constexpr const char * TASK_PROCESSED_OUT_REASON = "Task has been already processed";
@@ -1394,8 +1393,10 @@ void DDLWorker::markReplicasActive(bool /*reinitialized*/)
         {
             const auto & cluster = it.second;
             if (!cluster->getHostIDs().empty())
-                throw Exception(
-                    ErrorCodes::INVALID_CONFIG_PARAMETER, "There are clusters with host ids but no local host found for this replica.");
+            {
+                LOG_WARNING(log, "There are clusters with host ids but no local host found for this replica.");
+                break;
+            }
         }
     }
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
in `DDLWorker::markReplicasActive`, if there is no active host found, and the `remote_servers` has some host_ids, we print a warning log instead of throwing an exception.

Because `remote_servers` might be used by Distributed engine, it's possible to have config with the case above

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
