### PR TITLE
Fix backup of KeeperMap and Memory tables

### DIFF
--- a/src/Storages/StorageKeeperMap.cpp
+++ b/src/Storages/StorageKeeperMap.cpp
@@ -1157,7 +1157,9 @@ void StorageKeeperMap::backupData(BackupEntriesCollector & backup_entries_collec
         }
 
         TemporaryDataOnDiskSettings tmp_data_settings;
-        tmp_data_settings.buffer_size = backup_entries_collector.getContext()->getSettingsRef()[Setting::max_compress_block_size];
+        auto max_compress_block_size = backup_entries_collector.getContext()->getSettingsRef()[Setting::max_compress_block_size];
+        tmp_data_settings.buffer_size = max_compress_block_size ? max_compress_block_size : DBMS_DEFAULT_BUFFER_SIZE;
+
         auto tmp_data = std::make_shared<TemporaryDataOnDiskScope>(backup_entries_collector.getContext()->getTempDataOnDisk(), tmp_data_settings);
 
         auto with_retries = std::make_shared<WithRetries>

--- a/src/Storages/StorageMemory.cpp
+++ b/src/Storages/StorageMemory.cpp
@@ -483,7 +483,8 @@ void StorageMemory::backupData(BackupEntriesCollector & backup_entries_collector
     }
 
     TemporaryDataOnDiskSettings tmp_data_settings;
-    tmp_data_settings.buffer_size = backup_entries_collector.getContext()->getSettingsRef()[Setting::max_compress_block_size];
+    auto max_compress_block_size = backup_entries_collector.getContext()->getSettingsRef()[Setting::max_compress_block_size];
+    tmp_data_settings.buffer_size = max_compress_block_size ? max_compress_block_size : DBMS_DEFAULT_BUFFER_SIZE;
     auto tmp_data = std::make_shared<TemporaryDataOnDiskScope>(backup_entries_collector.getContext()->getTempDataOnDisk(), tmp_data_settings);
     const auto & read_settings = backup_entries_collector.getReadSettings();
 

--- a/tests/queries/0_stateless/02973_backup_of_in_memory_compressed.sh
+++ b/tests/queries/0_stateless/02973_backup_of_in_memory_compressed.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-parallel, no-fasttest, memory-engine
+# Tags: no-fasttest, memory-engine
 # Because we are creating a backup with fixed path.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
@@ -11,9 +11,9 @@ DROP TABLE IF EXISTS test;
 CREATE TABLE test (x String) ENGINE = Memory SETTINGS compress = 1;
 INSERT INTO test SELECT 'Hello, world' FROM numbers(1000000);
 "
-
+backup_path="$CLICKHOUSE_DATABASE"_02973_backup_of_in_memory_compressed
 $CLICKHOUSE_CLIENT "
-BACKUP TABLE test TO File('test.zip');
+BACKUP TABLE test TO File('$backup_path.zip');
 " --format Null
 
 $CLICKHOUSE_CLIENT "
@@ -22,7 +22,7 @@ SELECT count() FROM test;
 "
 
 $CLICKHOUSE_CLIENT "
-RESTORE TABLE test FROM File('test.zip');
+RESTORE TABLE test FROM File('$backup_path.zip');
 " --format Null
 
 $CLICKHOUSE_CLIENT "

--- a/tests/queries/0_stateless/03760_backup_keepermap_memory.sql
+++ b/tests/queries/0_stateless/03760_backup_keepermap_memory.sql
@@ -1,0 +1,9 @@
+SET max_compress_block_size = 0;
+
+CREATE TABLE 03760_backup_memory (c0 Int) ENGINE = Memory;
+INSERT INTO TABLE 03760_backup_memory (c0) VALUES (1);
+BACKUP TABLE 03760_backup_memory TO Null FORMAT Null;
+
+CREATE TABLE 03760_backup_keepermap (c0 Int) ENGINE = KeeperMap('/' || currentDatabase() || '/test03760_backup') PRIMARY KEY (c0);
+INSERT INTO TABLE 03760_backup_keepermap (c0) VALUES (1);
+BACKUP TABLE 03760_backup_keepermap TO Null FORMAT Null;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix backup of KeeperMap and Memory tables. Creating backup of tables using one of those two engines with `max_compress_block_size` set to `0` could lead to a crash.

Close https://github.com/ClickHouse/ClickHouse/issues/92045
Thanks BuzzHouse!

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
