### PR TITLE
Fix forward incompatible protocol for cluster functions

### DIFF
--- a/src/Client/Connection.cpp
+++ b/src/Client/Connection.cpp
@@ -616,6 +616,10 @@ void Connection::receiveHello(const Poco::Timespan & handshake_timeout)
         if (server_revision >= DBMS_MIN_REVISION_WITH_VERSIONED_CLUSTER_FUNCTION_PROTOCOL)
         {
             readVarUInt(worker_cluster_function_protocol_version, *in);
+            worker_cluster_function_protocol_version = std::min(
+                    worker_cluster_function_protocol_version,
+                    static_cast<UInt64>(DBMS_CLUSTER_PROCESSING_PROTOCOL_VERSION)
+            );
         }
     }
     else if (packet_type == Protocol::Server::Exception)


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Avoid using cluster function worker version higher than initiator version.
