### PR TITLE
fixing multiple joins with using and join_use_nulls

### DIFF
--- a/tests/queries/0_stateless/03716_multiple_joins_using_top_level_identifier.reference
+++ b/tests/queries/0_stateless/03716_multiple_joins_using_top_level_identifier.reference
@@ -2,3 +2,10 @@ a_1	v
 b_1	w
 _1	v
 b_1	w
+\N	v
+b_1	w
+b_1	w
+\N	\N
+\N	v
+b_1	w
+\N	\N

--- a/tests/queries/0_stateless/03716_multiple_joins_using_top_level_identifier.sql
+++ b/tests/queries/0_stateless/03716_multiple_joins_using_top_level_identifier.sql
@@ -14,16 +14,11 @@ INSERT INTO t3 VALUES ('a_1', 'c'), ('b_1', 'd');
 
 SET enable_analyzer = 1;
 
--- TODO: join_use_nulls reveals another issue in stress tests
--- Mute for now and track bug in
--- https://github.com/ClickHouse/ClickHouse/issues/87016
-
 SELECT t1.id || '_1' AS id, t1.val
 FROM t1
 LEFT JOIN t2 ON t1.id = t2.id
 LEFT JOIN t3 USING (id)
 ORDER BY t1.val
-SETTINGS join_use_nulls = 0
 ;
 
 SELECT t2.id || '_1' AS id, t1.val
@@ -31,7 +26,30 @@ FROM t1
 LEFT JOIN t2 ON t1.id = t2.id
 LEFT JOIN t3 USING (id)
 ORDER BY t1.val
-SETTINGS join_use_nulls = 0
+;
+
+SELECT t2.id || '_1' AS id, t1.val
+FROM t1
+LEFT JOIN t2 ON t1.id = t2.id
+LEFT JOIN t3 USING (id)
+ORDER BY t1.val
+SETTINGS join_use_nulls = 1
+;
+
+SELECT t2.id || '_1' AS id, t1.val
+FROM t1
+RIGHT JOIN t2 ON t1.id = t2.id
+RIGHT JOIN t3 USING (id)
+ORDER BY t1.val
+SETTINGS join_use_nulls = 1
+;
+
+SELECT t2.id || '_1' AS id, t1.val
+FROM t1
+FULL JOIN t2 ON t1.id = t2.id
+FULL JOIN t3 USING (id)
+ORDER BY t1.val
+SETTINGS join_use_nulls = 1
 ;
 
 SELECT t1.id || t2.id || '_1' AS id, t1.val
@@ -39,5 +57,4 @@ FROM t1
 INNER JOIN t2 ON t1.id = t2.id
 LEFT JOIN t3 USING (id)
 ORDER BY t1.val
-SETTINGS join_use_nulls = 0
 ; -- { serverError AMBIGUOUS_IDENTIFIER }


### PR DESCRIPTION
### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
* Fix logical error for queries with multiple JOINs with `USING` clause and `join_use_nulls`.


Close [#92173](https://github.com/ClickHouse/ClickHouse/issues/92173)