### PR TITLE
CI: Add stack trace ID to Logical errors

### DIFF
--- a/ci/jobs/scripts/check_ci.py
+++ b/ci/jobs/scripts/check_ci.py
@@ -600,7 +600,7 @@ def main():
         known_failures = []
         unknown_failures = []
 
-        for resut in workflow_result.results:
+        for result in workflow_result.results:
             if result.has_label("issue"):
                 known_failures.append((result.name, result))
                 result.set_comment("ISSUE EXISTS")

--- a/ci/jobs/scripts/log_parser.py
+++ b/ci/jobs/scripts/log_parser.py
@@ -168,6 +168,11 @@ class FuzzerLogParser:
                     )
                     letter_index += 1
                 result_name = f"Logical error: {format_message}"
+            # For most logical errors, the Stack Trace ID is redundant since the error message
+            # is sufficient to identify the issue. However, for certain errors, different stack
+            # traces may indicate different root causes - include STID in the failure name to
+            # distinguish them.
+            result_name += f" (STID: {stack_trace_id})"
         elif is_killed_by_signal or is_segfault:
             result_name += f" (STID: {stack_trace_id})"
         elif is_memory_limit_exceeded:
@@ -278,9 +283,6 @@ class FuzzerLogParser:
         # return all lines after Sanitizer error starting with "    #DIGITS "
         def _extract_sanitizer_trace(log_file):
             lines = []
-            sanitizer_pattern = re.compile(
-                r"(SUMMARY|ERROR|WARNING): [a-zA-Z]+Sanitizer:"
-            )
             stack_frame_pattern = re.compile(r"^\s+#\d+\s+")
             stack_frame_pattern_1st_line = re.compile(r"^\s+#0\s")
             # Pattern to remove ANSI escape codes (colors from tools like ripgrep)

--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -865,6 +865,7 @@ class ResultInfo:
     TIMEOUT = "Timeout"
 
     GH_STATUS_ERROR = "Failed to set GH commit status"
+    OPEN_ISSUES_CHECK_ERROR = "Failed to check open issues"
 
     NOT_FINALIZED = (
         "Job failed to produce Result due to a script error or CI runner issue"


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

---
* Adds a Stack Trace ID for logical error findings to distinguish failures with different root causes (stack traces)
* Fixes the open-issues check in CI by moving it before job results are uploaded to S3 (fixes missing "issue" label in CI report/comment)
