### PR TITLE
CI: Remove dumping result file in check ci script

### DIFF
--- a/ci/jobs/scripts/check_ci.py
+++ b/ci/jobs/scripts/check_ci.py
@@ -131,7 +131,7 @@ CIDB statistics: [cidb]({result.get_hlabel_link('cidb')})
 
 Test output:
 ```
-{result.get_info_truncated(truncate_from_top=False, max_info_lines_cnt=50, max_line_length=200)}
+{result.get_info_truncated(truncate_from_top=False, max_info_lines_cnt=50, max_line_length=0)}
 ```
 """
         labels = [IssueLabels.CI_ISSUE, IssueLabels.FLAKY_TEST]

--- a/ci/jobs/scripts/check_ci.py
+++ b/ci/jobs/scripts/check_ci.py
@@ -600,7 +600,6 @@ def main():
         known_failures = []
         unknown_failures = []
 
-        workflow_result.dump()
         for result in workflow_result.results:
             if result.has_label("issue"):
                 known_failures.append((result.name, result))

--- a/ci/jobs/scripts/check_ci.py
+++ b/ci/jobs/scripts/check_ci.py
@@ -195,7 +195,7 @@ Test output:
             truncate_from_top=False, max_info_lines_cnt=20, max_line_length=200
         )
         res += f"\n - flags: {', '.join(result.get_labels()) or 'not flaged'}"
-        res += f"\n - cidb: {result.get_hlabel_link("cidb") or 'not found'}"
+        res += f"\n - cidb: {result.get_hlabel_link('cidb') or 'not found'}"
         return res
 
     @classmethod
@@ -600,7 +600,7 @@ def main():
         known_failures = []
         unknown_failures = []
 
-        for result in workflow_result.results:
+        for resut in workflow_result.results:
             if result.has_label("issue"):
                 known_failures.append((result.name, result))
                 result.set_comment("ISSUE EXISTS")


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

---
- Dumping result file may fail in check_ci script if temp directory does not exist, since it's not required there - remove it
- Do not truncate lines in issue body
- Syntax fix in formatted line