### PR TITLE
tests: make CLICKHOUSE_USE_DATABASE_DISK env optional for integration tests

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -2011,7 +2011,7 @@ class ClickHouseCluster:
             with_remote_database_disk = False
 
         if not with_dolor and with_remote_database_disk is None:
-            with_remote_database_disk = int(os.getenv("CLICKHOUSE_USE_DATABASE_DISK"))
+            with_remote_database_disk = int(os.getenv("CLICKHOUSE_USE_DATABASE_DISK", "0"))
 
         if with_remote_database_disk:
             logging.debug(f"Instance {name}, with_remote_database_disk enabled")


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
