### PR TITLE
Docs: clarify meaning of `auto(N)` default value for `max_threads` setting

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -243,8 +243,9 @@ For example, when reading from a table, if it is possible to evaluate expression
 For queries that are completed quickly because of a LIMIT, you can set a lower 'max_threads'. For example, if the necessary number of entries are located in every block and max_threads = 8, then 8 blocks are retrieved, although it would have been enough to read just one.
 
 The smaller the `max_threads` value, the less memory is consumed.
-
-Cloud default value: `auto(3)`
+The `max_threads` setting by default matches the number of CPU cores available to ClickHouse on the server.
+For Cloud users, the default value will display as `auto(N)` where N matches the vCPU size of your service e.g. 8GiB:2vCPU, 16GiB:4vCPU etc.
+    You can find your service size udner the settings tab.
 )", 0) \
     DECLARE(Bool, use_concurrency_control, true, R"(
 Respect the server's concurrency control (see the `concurrent_threads_soft_limit_num` and `concurrent_threads_soft_limit_ratio_to_cores` global server settings). If disabled, it allows using a larger number of threads even if the server is overloaded (not recommended for normal usage, and needed mostly for tests).

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -235,15 +235,16 @@ Possible values:
 The maximum number of threads process indices.
 )", 0) \
     DECLARE(MaxThreads, max_threads, 0, R"(
-The maximum number of query processing threads, excluding threads for retrieving data from remote servers (see the 'max_distributed_connections' parameter).
+The maximum number of query processing threads, excluding threads for retrieving data from remote servers (see the ['max_distributed_connections'](/operations/settings/settings#max_distributed_connections) parameter).
 
 This parameter applies to threads that perform the same stages of the query processing pipeline in parallel.
-For example, when reading from a table, if it is possible to evaluate expressions with functions, filter with WHERE and pre-aggregate for GROUP BY in parallel using at least 'max_threads' number of threads, then 'max_threads' are used.
+For example, when reading from a table, if it is possible to evaluate expressions with functions, filter with `WHERE` and pre-aggregate for `GROUP BY` in parallel using at least 'max_threads' number of threads, then 'max_threads' are used.
 
-For queries that are completed quickly because of a LIMIT, you can set a lower 'max_threads'. For example, if the necessary number of entries are located in every block and max_threads = 8, then 8 blocks are retrieved, although it would have been enough to read just one.
-
+For queries that are completed quickly because of a LIMIT, you can set a lower 'max_threads'.
+For example, if the necessary number of entries are located in every block and max_threads = 8, then 8 blocks are retrieved, although it would have been enough to read just one.
 The smaller the `max_threads` value, the less memory is consumed.
-The `max_threads` setting by default matches the number of CPU cores available to ClickHouse on the server.
+
+The `max_threads` setting by default matches the number of cores (threads) of a single CPU available to ClickHouse.
 For Cloud users, the default value will display as `auto(N)` where N matches the vCPU size of your service e.g. 8GiB:2vCPU, 16GiB:4vCPU etc.
 See the settings tab in Cloud console for a list of all service sizes.
 )", 0) \

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -245,7 +245,7 @@ For queries that are completed quickly because of a LIMIT, you can set a lower '
 The smaller the `max_threads` value, the less memory is consumed.
 The `max_threads` setting by default matches the number of CPU cores available to ClickHouse on the server.
 For Cloud users, the default value will display as `auto(N)` where N matches the vCPU size of your service e.g. 8GiB:2vCPU, 16GiB:4vCPU etc.
-You can find your service size under the settings tab.
+See the settings tab in Cloud console for a list of all service sizes.
 )", 0) \
     DECLARE(Bool, use_concurrency_control, true, R"(
 Respect the server's concurrency control (see the `concurrent_threads_soft_limit_num` and `concurrent_threads_soft_limit_ratio_to_cores` global server settings). If disabled, it allows using a larger number of threads even if the server is overloaded (not recommended for normal usage, and needed mostly for tests).

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -245,7 +245,7 @@ For queries that are completed quickly because of a LIMIT, you can set a lower '
 The smaller the `max_threads` value, the less memory is consumed.
 The `max_threads` setting by default matches the number of CPU cores available to ClickHouse on the server.
 For Cloud users, the default value will display as `auto(N)` where N matches the vCPU size of your service e.g. 8GiB:2vCPU, 16GiB:4vCPU etc.
-    You can find your service size udner the settings tab.
+You can find your service size under the settings tab.
 )", 0) \
     DECLARE(Bool, use_concurrency_control, true, R"(
 Respect the server's concurrency control (see the `concurrent_threads_soft_limit_num` and `concurrent_threads_soft_limit_ratio_to_cores` global server settings). If disabled, it allows using a larger number of threads even if the server is overloaded (not recommended for normal usage, and needed mostly for tests).


### PR DESCRIPTION
Closes https://github.com/ClickHouse/clickhouse-docs/issues/4936.
Adds information clarifying what `auto(N)` actually means.
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
