### PR TITLE
Fuzzers: select_parser_fuzzer - change max_parser_backtracks to 10.000 (was 1.000.000)

### DIFF
--- a/src/Parsers/fuzzers/select_parser_fuzzer.cpp
+++ b/src/Parsers/fuzzers/select_parser_fuzzer.cpp
@@ -14,7 +14,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * data, size_t size)
         DB::ParserQueryWithOutput parser(input.data() + input.size());
 
         const UInt64 max_parser_depth = 1000;
-        const UInt64 max_parser_backtracks = 1000000;
+        const UInt64 max_parser_backtracks = 10000;
         DB::ASTPtr ast = parseQuery(parser, input.data(), input.data() + input.size(), "", 0, max_parser_depth, max_parser_backtracks);
 
         const UInt64 max_ast_depth = 1000;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

closes #92282
