### PR TITLE
Check and mark the interserver IO address active in DDL worker

### DIFF
--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -318,15 +318,11 @@ ClusterPtr DatabaseReplicated::tryGetAllGroupsCluster() const
 
 void DatabaseReplicated::setCluster(ClusterPtr && new_cluster, bool all_groups)
 {
-    {
-        std::lock_guard lock{mutex};
-        if (all_groups)
-            cluster_all_groups = std::move(new_cluster);
-        else
-            cluster = std::move(new_cluster);
-    }
-    DDLWorker & shared_ddl_worker = getContext()->getDDLWorker();
-    shared_ddl_worker.notifyHostIDsUpdated();
+    std::lock_guard lock{mutex};
+    if (all_groups)
+        cluster_all_groups = std::move(new_cluster);
+    else
+        cluster = std::move(new_cluster);
 }
 
 ClusterPtr DatabaseReplicated::getClusterImpl(bool all_groups) const

--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -318,11 +318,15 @@ ClusterPtr DatabaseReplicated::tryGetAllGroupsCluster() const
 
 void DatabaseReplicated::setCluster(ClusterPtr && new_cluster, bool all_groups)
 {
-    std::lock_guard lock{mutex};
-    if (all_groups)
-        cluster_all_groups = std::move(new_cluster);
-    else
-        cluster = std::move(new_cluster);
+    {
+        std::lock_guard lock{mutex};
+        if (all_groups)
+            cluster_all_groups = std::move(new_cluster);
+        else
+            cluster = std::move(new_cluster);
+    }
+    DDLWorker & shared_ddl_worker = getContext()->getDDLWorker();
+    shared_ddl_worker.notifyHostIDsUpdated();
 }
 
 ClusterPtr DatabaseReplicated::getClusterImpl(bool all_groups) const

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -5250,25 +5250,32 @@ void Context::startClusterDiscovery()
 /// On repeating calls updates existing clusters and adds new clusters, doesn't delete old clusters
 void Context::setClustersConfig(const ConfigurationPtr & config, bool enable_discovery, const String & config_name)
 {
-    std::lock_guard lock(shared->clusters_mutex);
-    if (ConfigHelper::getBool(*config, "allow_experimental_cluster_discovery") && enable_discovery && !shared->cluster_discovery)
     {
-        shared->cluster_discovery = std::make_unique<ClusterDiscovery>(*config, getGlobalContext(), getMacros());
+        std::lock_guard lock(shared->clusters_mutex);
+        if (ConfigHelper::getBool(*config, "allow_experimental_cluster_discovery") && enable_discovery && !shared->cluster_discovery)
+        {
+            shared->cluster_discovery = std::make_unique<ClusterDiscovery>(*config, getGlobalContext(), getMacros());
+        }
+
+        /// Do not update clusters if this part of config wasn't changed.
+        if (shared->clusters && isSameConfiguration(*config, *shared->clusters_config, config_name))
+            return;
+
+        auto old_clusters_config = shared->clusters_config;
+        shared->clusters_config = config;
+
+        if (!shared->clusters)
+            shared->clusters = std::make_shared<Clusters>(*shared->clusters_config, *settings, getMacros(), config_name);
+        else
+            shared->clusters->updateClusters(*shared->clusters_config, *settings, config_name, old_clusters_config);
+
+        ++shared->clusters_version;
     }
-
-    /// Do not update clusters if this part of config wasn't changed.
-    if (shared->clusters && isSameConfiguration(*config, *shared->clusters_config, config_name))
-        return;
-
-    auto old_clusters_config = shared->clusters_config;
-    shared->clusters_config = config;
-
-    if (!shared->clusters)
-        shared->clusters = std::make_shared<Clusters>(*shared->clusters_config, *settings, getMacros(), config_name);
-    else
-        shared->clusters->updateClusters(*shared->clusters_config, *settings, config_name, old_clusters_config);
-
-    ++shared->clusters_version;
+    {
+        SharedLockGuard lock(shared->mutex);
+        if (shared->ddl_worker)
+            shared->ddl_worker->notifyHostIDsUpdated();
+    }
 }
 
 size_t Context::getClustersVersion() const

--- a/src/Interpreters/DDLWorker.cpp
+++ b/src/Interpreters/DDLWorker.cpp
@@ -2,13 +2,13 @@
 #include <Core/ServerSettings.h>
 #include <Core/ServerUUID.h>
 #include <Core/Settings.h>
+#include <Databases/DatabaseReplicated.h>
 #include <IO/NullWriteBuffer.h>
 #include <IO/ReadBufferFromString.h>
 #include <IO/ReadHelpers.h>
 #include <IO/WriteHelpers.h>
 #include <Interpreters/Cluster.h>
 #include <Interpreters/Context.h>
-#include <Interpreters/DDLTask.h>
 #include <Interpreters/DDLWorker.h>
 #include <Interpreters/DatabaseCatalog.h>
 #include <Interpreters/ZooKeeperLog.h>
@@ -189,6 +189,26 @@ ZooKeeperPtr DDLWorker::getAndSetZooKeeper()
     return current_zookeeper;
 }
 
+void DDLWorker::notifyHostIDsUpdated()
+{
+    LOG_INFO(log, "Host IDs updated");
+    host_ids_updated = true;
+}
+
+void DDLWorker::updateHostIDs(const std::vector<HostID> & hosts)
+{
+    std::lock_guard lock{checked_host_id_set_mutex};
+    for (const auto & host : hosts)
+    {
+        if (!checked_host_id_set.contains(host.toString()))
+        {
+            LOG_INFO(log, "Found new host ID: {}", host.toString());
+            notifyHostIDsUpdated();
+            return;
+        }
+    }
+}
+
 
 DDLTaskPtr DDLWorker::initAndCheckTask(const String & entry_name, String & out_reason, const ZooKeeperPtr & zookeeper, bool /*dry_run*/)
 {
@@ -224,6 +244,7 @@ DDLTaskPtr DDLWorker::initAndCheckTask(const String & entry_name, String & out_r
     {
         /// Stage 1: parse entry
         task->entry.parse(node_data);
+        updateHostIDs(task->entry.hosts);
     }
     catch (...)
     {
@@ -1142,7 +1163,7 @@ bool DDLWorker::initializeMainThread()
             auto zookeeper = getAndSetZooKeeper();
             zookeeper->createAncestors(fs::path(queue_dir) / "");
             initializeReplication();
-            markReplicasActive(true);
+            markReplicasActive(/*reinitialized=*/true);
             initialized = true;
             return true;
         }
@@ -1197,8 +1218,7 @@ void DDLWorker::runMainThread()
 
 
     DB::setThreadName(ThreadName::DDL_WORKER);
-    LOG_DEBUG(log, "Starting DDLWorker thread");
-
+    LOG_INFO(log, "Starting DDLWorker thread");
     while (!stop_flag)
     {
         try
@@ -1206,13 +1226,17 @@ void DDLWorker::runMainThread()
             bool reinitialized = !initialized;
 
             /// Reinitialize DDLWorker state (including ZooKeeper connection) if required
-            if (!initialized)
+            if (reinitialized)
             {
                 /// Stopped
                 if (!initializeMainThread())
                     break;
+
                 LOG_DEBUG(log, "Initialized DDLWorker thread");
             }
+
+            if (host_ids_updated.exchange(false))
+                markReplicasActive(/*reinitialized=*/false);
 
             cleanup_event->set();
             scheduleTasks(reinitialized);
@@ -1272,41 +1296,37 @@ void DDLWorker::runMainThread()
 void DDLWorker::initializeReplication()
 {
     auto zookeeper = getZooKeeper();
-
     zookeeper->createAncestors(fs::path(replicas_dir) / "");
-
-    NameSet host_id_set;
-    for (const auto & it : context->getClusters())
-    {
-        auto cluster = it.second;
-        for (const auto & host_ids : cluster->getHostIDs())
-            for (const auto & host_id : host_ids)
-                host_id_set.emplace(host_id);
-    }
-
-    createReplicaDirs(zookeeper, host_id_set);
 }
 
 void DDLWorker::createReplicaDirs(const ZooKeeperPtr & zookeeper, const NameSet & host_ids)
 {
     for (const auto & host_id : host_ids)
+    {
+        LOG_INFO(log, "Creating replica dir for host id {}", host_id);
         zookeeper->createAncestors(fs::path(replicas_dir) / host_id / "");
+    }
 }
 
-void DDLWorker::markReplicasActive(bool /*reinitialized*/)
+void DDLWorker::markReplicasActive(bool reinitialized)
 {
     auto zookeeper = getZooKeeper();
 
-    // Reset all active_node_holders
-    for (auto & it : active_node_holders)
-    {
-        auto & active_node_holder = it.second.second;
-        if (active_node_holder)
-            active_node_holder->setAlreadyRemoved();
-        active_node_holder.reset();
-    }
+    auto all_host_ids = getAllHostIDsFromClusters();
+    createReplicaDirs(zookeeper, all_host_ids);
 
-    active_node_holders.clear();
+    if (reinitialized)
+    {
+        // Reset all active_node_holders
+        for (auto & it : active_node_holders)
+        {
+            auto & active_node_holder = it.second.second;
+            if (active_node_holder)
+                active_node_holder->setAlreadyRemoved();
+            active_node_holder.reset();
+        }
+        active_node_holders.clear();
+    }
 
     const auto maybe_secure_port = context->getTCPPortSecure();
     const auto port = context->getTCPPort();
@@ -1314,17 +1334,44 @@ void DDLWorker::markReplicasActive(bool /*reinitialized*/)
     Coordination::Stat replicas_stat;
     Strings host_ids = zookeeper->getChildren(replicas_dir, &replicas_stat);
     NameSet local_host_ids;
+    NameSet checking_host_ids;
+    checking_host_ids.reserve(host_ids.size());
     for (const auto & host_id : host_ids)
     {
+        bool is_self_host = false;
         try
         {
             HostID host = HostID::fromString(host_id);
-            if (DDLTask::isSelfHostID(log, host, maybe_secure_port, port))
-                local_host_ids.emplace(host_id);
+            checking_host_ids.insert(host.toString());
+
+            is_self_host = DDLTask::isSelfHostID(log, host, maybe_secure_port, port);
         }
         catch (const Exception & e)
         {
             LOG_WARNING(log, "Unable to check if host {} is a local address, exception: {}", host_id, e.displayText());
+            continue;
+        }
+
+        LOG_INFO(log, "Self host_id ({}) = {}", host_id, is_self_host);
+        if (is_self_host)
+        {
+            local_host_ids.emplace(host_id);
+            continue;
+        }
+
+        if (!reinitialized)
+        {
+            /// Remove this host_id from active_node_holders
+            auto it = active_node_holders.find(host_id);
+            if (it != active_node_holders.end())
+            {
+                auto & active_node_holder = it->second.second;
+                if (active_node_holder)
+                    active_node_holder->setAlreadyRemoved();
+                active_node_holder.reset();
+
+                active_node_holders.erase(it);
+            }
             continue;
         }
     }
@@ -1379,12 +1426,17 @@ void DDLWorker::markReplicasActive(bool /*reinitialized*/)
         }
         else
         {
-            LOG_DEBUG(log, "Marked a replica active: active_path={}, active_id={}", active_path, active_id);
+            LOG_INFO(log, "Marked a replica active: active_path={}, active_id={}", active_path, active_id);
         }
 
         auto active_node_holder_zookeeper = zookeeper;
         auto active_node_holder = zkutil::EphemeralNodeHolder::existing(active_path, *active_node_holder_zookeeper);
         active_node_holders[host_id] = {active_node_holder_zookeeper, active_node_holder};
+    }
+
+    {
+        std::lock_guard lock{checked_host_id_set_mutex};
+        checked_host_id_set = checking_host_ids;
     }
 
     if (active_node_holders.empty())
@@ -1464,4 +1516,31 @@ void DDLWorker::runCleanupThread()
     }
 }
 
+NameSet DDLWorker::getAllHostIDsFromClusters() const
+{
+    NameSet host_id_set;
+    for (const auto & it : context->getClusters())
+    {
+        auto cluster = it.second;
+        for (const auto & host_ids : cluster->getHostIDs())
+            for (const auto & host_id : host_ids)
+                host_id_set.emplace(host_id);
+    }
+
+    auto databases = DatabaseCatalog::instance().getDatabases(GetDatabasesOptions{.with_datalake_catalogs = false});
+    for (const auto & database : databases)
+    {
+        if (const auto * replicated_db = dynamic_cast<const DatabaseReplicated *>(database.second.get()))
+        {
+            auto cluster = replicated_db->tryGetAllGroupsCluster();
+            if (!cluster)
+                continue;
+
+            for (const auto & host_ids : cluster->getHostIDs())
+                for (const auto & host_id : host_ids)
+                    host_id_set.emplace(host_id);
+        }
+    }
+    return host_id_set;
+}
 }

--- a/src/Interpreters/DDLWorker.h
+++ b/src/Interpreters/DDLWorker.h
@@ -1,7 +1,11 @@
 #pragma once
 
+#include <Core/Names.h>
+#include <Interpreters/Context_fwd.h>
+#include <Interpreters/DDLTask.h>
 #include <Parsers/IAST_fwd.h>
 #include <Storages/IStorage_fwd.h>
+#include <Poco/Event.h>
 #include <Common/CurrentMetrics.h>
 #include <Common/CurrentThread.h>
 #include <Common/DNSResolver.h>
@@ -9,8 +13,6 @@
 #include <Common/ThreadPool_fwd.h>
 #include <Common/ZooKeeper/IKeeper.h>
 #include <Common/ZooKeeper/ZooKeeper.h>
-#include <Interpreters/Context_fwd.h>
-#include <Poco/Event.h>
 
 #include <atomic>
 #include <list>
@@ -94,6 +96,9 @@ public:
     /// Should be called in `initializeMainThread` only, so if it is expired, `runMainThread` will reinitialized the state.
     ZooKeeperPtr getAndSetZooKeeper();
 
+    void notifyHostIDsUpdated();
+    void updateHostIDs(const std::vector<HostID> & hosts);
+
 protected:
 
     class ConcurrentSet
@@ -173,6 +178,8 @@ protected:
     void runMainThread();
     void runCleanupThread();
 
+    NameSet getAllHostIDsFromClusters() const;
+
     ContextMutablePtr context;
     LoggerPtr log;
 
@@ -209,6 +216,7 @@ protected:
 
     /// Cleaning starts after new node event is received if the last cleaning wasn't made sooner than N seconds ago
     Int64 cleanup_delay_period = 60; // minute (in seconds)
+    std::atomic_bool host_ids_updated{false};
     /// Delete node if its age is greater than that
     Int64 task_max_lifetime = 7 * 24 * 60 * 60; // week (in seconds)
     /// How many tasks could be in the queue
@@ -220,6 +228,10 @@ protected:
 
     std::atomic_uint64_t subsequent_errors_count = 0;
     String last_unexpected_error;
+
+    mutable std::mutex checked_host_id_set_mutex;
+    NameSet checked_host_id_set TSA_GUARDED_BY(checked_host_id_set_mutex);
+
 
     const CurrentMetrics::Metric * max_entry_metric;
     const CurrentMetrics::Metric * max_pushed_entry_metric;

--- a/src/Interpreters/DistributedQueryStatusSource.cpp
+++ b/src/Interpreters/DistributedQueryStatusSource.cpp
@@ -102,7 +102,8 @@ NameSet DistributedQueryStatusSource::getOfflineHosts(const NameSet & hosts_to_w
     if (offline.size() == hosts_to_wait.size())
     {
         /// Avoid reporting that all hosts are offline
-        LOG_WARNING(log, "Did not find active hosts, will wait for all {} hosts. This should not happen often", offline.size());
+        LOG_WARNING(
+            log, "Did not find active hosts, will wait for all hosts: {}. This should not happen often", fmt::join(hosts_to_wait, ", "));
         return {};
     }
 

--- a/src/Interpreters/executeDDLQueryOnCluster.cpp
+++ b/src/Interpreters/executeDDLQueryOnCluster.cpp
@@ -200,6 +200,7 @@ BlockIO executeDDLQueryOnCluster(const ASTPtr & query_ptr_, ContextPtr context, 
         entry.initiator_user = context->getUserName();
         entry.initiator_user_roles = context->getAccessControl().tryReadNames(context->getCurrentRoles());
     }
+    ddl_worker.updateHostIDs(entry.hosts);
     String node_path = ddl_worker.enqueueQuery(entry, params.retries_info);
 
     return getDDLOnClusterStatus(node_path, ddl_worker.getReplicasDir(), entry, context);

--- a/tests/integration/test_distributed_ddl_on_database_cluster/configs/config.d/remote_servers.xml
+++ b/tests/integration/test_distributed_ddl_on_database_cluster/configs/config.d/remote_servers.xml
@@ -1,0 +1,4 @@
+<clickhouse>
+    <remote_servers>
+    </remote_servers>
+</clickhouse>

--- a/tests/integration/test_distributed_ddl_on_database_cluster/configs/config.d/settings.xml
+++ b/tests/integration/test_distributed_ddl_on_database_cluster/configs/config.d/settings.xml
@@ -1,0 +1,8 @@
+<clickhouse>
+    <distributed_ddl>
+        <path>/clickhouse/task_queue/ddl</path>
+        <max_tasks_in_queue>10</max_tasks_in_queue>
+        <task_max_lifetime>3600</task_max_lifetime>
+        <cleanup_delay_period>5</cleanup_delay_period>
+    </distributed_ddl>
+</clickhouse>

--- a/tests/integration/test_distributed_ddl_on_database_cluster/configs/users.d/query_log.xml
+++ b/tests/integration/test_distributed_ddl_on_database_cluster/configs/users.d/query_log.xml
@@ -1,0 +1,9 @@
+<clickhouse>
+    <profiles>
+        <!-- Default profile settings. -->
+        <default>
+            <log_queries>1</log_queries>
+            <allow_deprecated_syntax_for_merge_tree>1</allow_deprecated_syntax_for_merge_tree>
+        </default>
+    </profiles>
+</clickhouse>

--- a/tests/integration/test_distributed_ddl_on_database_cluster/test.py
+++ b/tests/integration/test_distributed_ddl_on_database_cluster/test.py
@@ -1,0 +1,76 @@
+import os
+import sys
+import time
+import uuid
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import assert_eq_with_retry
+
+from helpers.test_tools import TSV
+
+cluster = ClickHouseCluster(__file__)
+
+node1 = cluster.add_instance(
+    "node1",
+    main_configs=["configs/config.d/settings.xml"],
+    user_configs=["configs/users.d/query_log.xml"],
+    with_zookeeper=True,
+    macros={"shard": 1, "replica": 1},
+)
+node2 = cluster.add_instance(
+    "node2",
+    main_configs=["configs/config.d/settings.xml"],
+    user_configs=["configs/users.d/query_log.xml"],
+    with_zookeeper=True,
+    macros={"shard": 1, "replica": 2},
+)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+
+def test_waiting_replicated_database_hosts(started_cluster):
+    node1.query("DROP DATABASE IF EXISTS db SYNC")
+    node2.query("DROP DATABASE IF EXISTS  db SYNC")
+
+    node1.query("DROP TABLE IF EXISTS t SYNC")
+    node2.query("DROP TABLE IF EXISTS t SYNC")
+
+    node1.query(
+        "CREATE DATABASE db ENGINE=Replicated('/test/db', '{shard}', '{replica}')"
+    )
+    node2.query(
+        "CREATE DATABASE db ENGINE=Replicated('/test/db', '{shard}', '{replica}')"
+    )
+
+    query_id = str(uuid.uuid4())
+    node1.query(
+        "CREATE TABLE t ON CLUSTER 'db' (x INT, y INT) ENGINE=MergeTree ORDER BY x",
+        settings={"distributed_ddl_output_mode": "throw_only_active"},
+        query_id=query_id,
+    )
+    assert (
+        node2.query("SELECT count() FROM system.tables WHERE name='t'").strip() == "1"
+    )
+    node1.query("SYSTEM FLUSH LOGS")
+    assert (
+        node1.query(
+            f"SELECT count() FROM system.text_log WHERE query_id='{query_id}' AND level='Warning' AND message LIKE '%Did not find active hosts%'"
+        ).strip()
+        == "0"
+    )
+
+    node1.query("DROP DATABASE IF EXISTS db SYNC")
+    node2.query("DROP DATABASE IF EXISTS  db SYNC")
+
+    node1.query("DROP TABLE IF EXISTS t SYNC")
+    node2.query("DROP TABLE IF EXISTS t SYNC")


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Related issue #https://github.com/ClickHouse/support-escalation/issues/6365

Previously, when marking replica active, we don't check the interserver IO address. This address is used for cluster created by Replicated DBs.

In this PR:
- It checks and marks the interserver IO address as active in DDLWorker::markReplicasActive
- Notify DDLWorker when host IDs are updated when cluster config updated. This is a separate fix to let DDLWorker runs `markReplicaActive` again when the host IDs are updated in `remoter_servers` config.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.742`
- Backported to: `25.12.4.38`, `25.11.10.20`, `25.8.17.32`
<!-- ch-version-info:end -->