### PR TITLE
Optimize prewhere functions to subcolumns for strings

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.cpp
+++ b/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.cpp
@@ -12,6 +12,7 @@ namespace Setting
     extern const SettingsBool force_optimize_projection;
     extern const SettingsBool optimize_aggregation_in_order;
     extern const SettingsBool optimize_distinct_in_order;
+    extern const SettingsBool optimize_functions_to_subcolumns;
     extern const SettingsBool optimize_read_in_order;
     extern const SettingsBool optimize_sorting_by_input_stream_properties;
     extern const SettingsBool optimize_use_implicit_projections;
@@ -179,6 +180,7 @@ QueryPlanOptimizationSettings::QueryPlanOptimizationSettings(
 
     optimize_lazy_materialization = from[Setting::query_plan_optimize_lazy_materialization] && from[Setting::allow_experimental_analyzer];
     max_limit_for_lazy_materialization = from[Setting::query_plan_max_limit_for_lazy_materialization];
+    optimize_functions_to_subcolumns = from[Setting::optimize_functions_to_subcolumns];
 
     max_limit_for_vector_search_queries = from[Setting::max_limit_for_vector_search_queries].value;
     vector_search_with_rescoring = from[Setting::vector_search_with_rescoring];

--- a/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.h
+++ b/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.h
@@ -113,6 +113,7 @@ struct QueryPlanOptimizationSettings
     /// If lazy materialization optimisation is enabled
     bool optimize_lazy_materialization = false;
     size_t max_limit_for_lazy_materialization = 0;
+    bool optimize_functions_to_subcolumns = false;
 
     /// Vector-search-related settings
     size_t max_limit_for_vector_search_queries;

--- a/src/Processors/QueryPlan/Optimizations/actionsDAGUtils.cpp
+++ b/src/Processors/QueryPlan/Optimizations/actionsDAGUtils.cpp
@@ -620,4 +620,33 @@ bool allOutputsDependsOnlyOnAllowedNodes(
     return res;
 }
 
+const ActionsDAG::Node * replaceNodes(ActionsDAG & dag, const ActionsDAG::Node * node, const NodeReplacementMap & replacements)
+{
+    if (auto it = replacements.find(node); it != replacements.end())
+    {
+        return it->second;
+    }
+    else if (node->type == ActionsDAG::ActionType::ALIAS)
+    {
+        const auto * old_child = node->children[0];
+        const auto * new_child = replaceNodes(dag, old_child, replacements);
+
+        if (old_child != new_child)
+            return &dag.addAlias(*new_child, node->result_name);
+    }
+    else if (node->type == ActionsDAG::ActionType::FUNCTION)
+    {
+        auto old_children = node->children;
+        std::vector<const ActionsDAG::Node *> new_children;
+
+        for (const auto & child : old_children)
+            new_children.push_back(replaceNodes(dag, child, replacements));
+
+        if (new_children != old_children)
+            return &dag.addFunction(node->function_base, new_children, "");
+    }
+
+    return node;
+}
+
 }

--- a/src/Processors/QueryPlan/Optimizations/actionsDAGUtils.h
+++ b/src/Processors/QueryPlan/Optimizations/actionsDAGUtils.h
@@ -7,6 +7,7 @@ namespace DB
 
 using NodeSet = std::unordered_set<const ActionsDAG::Node *>;
 using NodeMap = std::unordered_map<const ActionsDAG::Node *, bool>;
+using NodeReplacementMap = std::unordered_map<const ActionsDAG::Node *, const ActionsDAG::Node *>;
 
 /// This structure stores a node mapping from one DAG to another.
 /// The rule is following:
@@ -98,5 +99,8 @@ bool allOutputsDependsOnlyOnAllowedNodes(
     const ActionsDAG & partition_actions, const NodeSet & irreducible_nodes, const MatchedTrees::Matches & matches);
 bool allOutputsDependsOnlyOnAllowedNodes(
     const NodeSet & irreducible_nodes, const MatchedTrees::Matches & matches, const ActionsDAG::Node * node, NodeMap & visited);
+
+/// Recursively replaces nodes in ActionsDAG using the provided replacement map
+const ActionsDAG::Node * replaceNodes(ActionsDAG & dag, const ActionsDAG::Node * node, const NodeReplacementMap & replacements);
 
 }

--- a/src/Processors/QueryPlan/Optimizations/optimizeDirectReadFromTextIndex.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeDirectReadFromTextIndex.cpp
@@ -3,6 +3,7 @@
 #include <Interpreters/Context.h>
 #include <Processors/QueryPlan/FilterStep.h>
 #include <Processors/QueryPlan/Optimizations/Optimizations.h>
+#include <Processors/QueryPlan/Optimizations/actionsDAGUtils.h>
 #include <Processors/QueryPlan/QueryPlan.h>
 #include <Processors/QueryPlan/ReadFromMergeTree.h>
 #include <Storages/MergeTree/MergeTreeIndexConditionText.h>
@@ -18,7 +19,6 @@ namespace
 {
 
 using IndexConditionsMap = absl::flat_hash_map<String, const MergeTreeIndexWithCondition *>;
-using NodesReplacementMap = absl::flat_hash_map<const ActionsDAG::Node *, const ActionsDAG::Node *>;
 
 String getNameWithoutAliases(const ActionsDAG::Node * node)
 {
@@ -41,35 +41,6 @@ String getNameWithoutAliases(const ActionsDAG::Node * node)
     }
 
     return node->result_name;
-}
-
-const ActionsDAG::Node * replaceNodes(ActionsDAG & dag, const ActionsDAG::Node * node, const NodesReplacementMap & replacements)
-{
-    if (auto it = replacements.find(node); it != replacements.end())
-    {
-        return it->second;
-    }
-    else if (node->type == ActionsDAG::ActionType::ALIAS)
-    {
-        const auto * old_child = node->children[0];
-        const auto * new_child = replaceNodes(dag, old_child, replacements);
-
-        if (old_child != new_child)
-            return &dag.addAlias(*new_child, node->result_name);
-    }
-    else if (node->type == ActionsDAG::ActionType::FUNCTION)
-    {
-        auto old_children = node->children;
-        std::vector<const ActionsDAG::Node *> new_children;
-
-        for (const auto & child : old_children)
-            new_children.push_back(replaceNodes(dag, child, replacements));
-
-        if (new_children != old_children)
-            return &dag.addFunction(node->function_base, new_children, "");
-    }
-
-    return node;
 }
 
 String optimizationInfoToString(const IndexReadColumns & added_columns, const Names & removed_columns)
@@ -179,7 +150,7 @@ public:
     ResultReplacement replace(const ContextPtr & context, const String & filter_column_name)
     {
         ResultReplacement result;
-        NodesReplacementMap replacements;
+        NodeReplacementMap replacements;
         Names original_inputs = actions_dag.getRequiredColumnsNames();
         const auto * filter_node = &actions_dag.findInOutputs(filter_column_name);
 

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -2409,6 +2409,18 @@ void ReadFromMergeTree::updatePrewhereInfo(const PrewhereInfoPtr & prewhere_info
     updateSortDescription();
 }
 
+void ReadFromMergeTree::addColumnsToRead(const NameSet & columns)
+{
+    for (const auto & column_name : columns)
+    {
+            auto it = std::ranges::find(all_column_names, column_name);
+            if (it != all_column_names.end())
+                continue;
+
+            all_column_names.push_back(column_name);
+    }
+}
+
 void ReadFromMergeTree::replaceVectorColumnWithDistanceColumn(const String & vector_column)
 {
     if (isVectorColumnReplaced())

--- a/src/Processors/QueryPlan/ReadFromMergeTree.h
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.h
@@ -312,6 +312,7 @@ public:
     const SortDescription & getSortDescription() const override { return result_sort_description; }
 
     void updatePrewhereInfo(const PrewhereInfoPtr & prewhere_info_value) override;
+    void addColumnsToRead(const NameSet & columns);
     bool isQueryWithSampling() const;
 
     /// Special stuff for vector search - replace vector column in read list with virtual "_distance" column

--- a/tests/queries/0_stateless/03760_prewhere_to_subcolumns.reference
+++ b/tests/queries/0_stateless/03760_prewhere_to_subcolumns.reference
@@ -1,0 +1,115 @@
+-- No lazy materialization
+Prewhere filter column: empty(__table1.str) (removed)
+0	2025-01-01	
+2	2025-01-03	
+4	2025-01-05	
+6	2025-01-07	
+8	2025-01-09	
+-- With lazy materialization
+Prewhere filter column: equals(str.size, 0_UInt64) (removed)
+0	2025-01-01	
+2	2025-01-03	
+4	2025-01-05	
+-- Rewrite to subcolumns disabled
+Prewhere filter column: empty(__table1.str) (removed)
+0	2025-01-01	
+2	2025-01-03	
+4	2025-01-05	
+-- Mixed conditions, no lazy materialization
+Prewhere filter column: or(empty(__table1.str), equals(__table1.str, \'foo\'_String)) (removed)
+0	2025-01-01	
+2	2025-01-03	
+4	2025-01-05	
+6	2025-01-07	
+8	2025-01-09	
+-- Mixed conditions, with lazy materialization
+Prewhere filter column: or(empty(__table1.str), equals(__table1.str, \'foo\'_String)) (removed)
+0	2025-01-01	
+2	2025-01-03	
+4	2025-01-05	
+-- Prewhere column not removed
+Prewhere filter column: empty(__table1.str)
+0	2025-01-01		1
+2	2025-01-03		1
+4	2025-01-05		1
+-- Prewhere column removed, expression over lazy column
+Prewhere filter column: equals(str.size, 0_UInt64) (removed)
+0	2025-01-01		0
+2	2025-01-03		0
+4	2025-01-05		0
+-- Prewhere disabled
+Filter column: empty(__table1.str) (removed)
+0	2025-01-01	
+2	2025-01-03	
+4	2025-01-05	
+-- Prewhere DAG output reused
+Prewhere filter column: and(empty(__table1.str), less(__table1.key, 15_UInt8)) (removed)
+0	2025-01-01		1
+2	2025-01-03		1
+4	2025-01-05		1
+-- Lazy materialization with aliases
+Prewhere filter column: equals(str.size, 0_UInt64) (removed)
+0	2025-01-01	
+2	2025-01-03	
+4	2025-01-05	
+-- Mixed conditions with aliases
+Prewhere filter column: or(empty(__table1.str), equals(__table1.str, \'foo\'_String)) (removed)
+0	2025-01-01	
+2	2025-01-03	
+4	2025-01-05	
+-- Prewhere DAG output reused with aliases
+Prewhere filter column: and(empty(__table1.str), less(__table1.key, 15_UInt8)) (removed)
+0	2025-01-01		1
+2	2025-01-03		1
+4	2025-01-05		1
+-- notEmpty String, no lazy materializaton
+Prewhere filter column: notEmpty(__table1.str) (removed)
+1	2025-01-02	str-1
+3	2025-01-04	str-3
+5	2025-01-06	str-5
+7	2025-01-08	str-7
+9	2025-01-10	str-9
+-- notEmpty String, with lazy materializaton
+Prewhere filter column: notEquals(str.size, 0_UInt64) (removed)
+1	2025-01-02	str-1
+3	2025-01-04	str-3
+5	2025-01-06	str-5
+-- length String, no lazy materializaton
+Prewhere filter column: equals(length(__table1.str), 0_UInt8) (removed)
+0	2025-01-01	
+2	2025-01-03	
+4	2025-01-05	
+6	2025-01-07	
+8	2025-01-09	
+-- length String, with lazy materializaton
+Prewhere filter column: equals(str.size, 0_UInt8) (removed)
+0	2025-01-01	
+2	2025-01-03	
+4	2025-01-05	
+-- length String gt, no lazy materializaton
+Prewhere filter column: greater(length(__table1.str), 0_UInt8) (removed)
+1	2025-01-02	str-1
+3	2025-01-04	str-3
+5	2025-01-06	str-5
+7	2025-01-08	str-7
+9	2025-01-10	str-9
+-- length String gt, with lazy materializaton
+Prewhere filter column: greater(str.size, 0_UInt8) (removed)
+1	2025-01-02	str-1
+3	2025-01-04	str-3
+5	2025-01-06	str-5
+-- empty String, with name conflict
+Prewhere filter column: empty(__table1.str) (removed)
+0	2025-01-01		100
+2	2025-01-03		100
+4	2025-01-05		100
+-- notEmpty String, with name conflict
+Prewhere filter column: notEmpty(__table1.str) (removed)
+1	2025-01-02	str-1	100
+3	2025-01-04	str-3	100
+5	2025-01-06	str-5	100
+-- length String, with name conflict
+Prewhere filter column: greater(length(__table1.str), 0_UInt8) (removed)
+1	2025-01-02	str-1	100
+3	2025-01-04	str-3	100
+5	2025-01-06	str-5	100

--- a/tests/queries/0_stateless/03760_prewhere_to_subcolumns.sql
+++ b/tests/queries/0_stateless/03760_prewhere_to_subcolumns.sql
@@ -1,0 +1,185 @@
+SET query_plan_max_limit_for_lazy_materialization = 3,
+    optimize_functions_to_subcolumns = 1,
+    enable_analyzer = 1,
+    parallel_replicas_local_plan = 1;
+
+DROP TABLE IF EXISTS 03760_data, 03760_name_conflict;
+
+CREATE TABLE 03760_data (
+    key UInt32,
+    dt Date,
+    str String
+)
+ENGINE = MergeTree
+ORDER BY key
+AS
+SELECT number, toDate('2025-01-01') + number, if(number % 2 = 0, '', 'str-' || number)
+FROM numbers(10);
+
+SELECT '-- No lazy materialization';
+SELECT trimLeft(explain)
+FROM ( EXPLAIN actions = 1 SELECT * FROM 03760_data WHERE str = '' ORDER BY dt )
+WHERE trimLeft(explain) LIKE 'Prewhere filter column: %';
+
+SELECT * FROM 03760_data WHERE str = '' ORDER BY dt;
+
+SELECT '-- With lazy materialization';
+SELECT trimLeft(explain)
+FROM ( EXPLAIN actions = 1 SELECT * FROM 03760_data WHERE str = '' ORDER BY dt LIMIT 3 )
+WHERE trimLeft(explain) LIKE 'Prewhere filter column: %';
+
+SELECT * FROM 03760_data WHERE str = '' ORDER BY dt LIMIT 3;
+
+SELECT '-- Rewrite to subcolumns disabled';
+SELECT trimLeft(explain)
+FROM ( EXPLAIN actions = 1 SELECT * FROM 03760_data WHERE str = '' ORDER BY dt LIMIT 3 SETTINGS optimize_functions_to_subcolumns = 0 )
+WHERE trimLeft(explain) LIKE 'Prewhere filter column: %';
+
+SELECT * FROM 03760_data WHERE str = '' ORDER BY dt LIMIT 3 SETTINGS optimize_functions_to_subcolumns = 0;
+
+SELECT '-- Mixed conditions, no lazy materialization';
+SELECT trimLeft(explain)
+FROM ( EXPLAIN actions = 1 SELECT * FROM 03760_data WHERE str = '' OR str = 'foo' ORDER BY dt )
+WHERE trimLeft(explain) LIKE 'Prewhere filter column: %';
+
+SELECT * FROM 03760_data WHERE str = '' OR str = 'foo' ORDER BY dt;
+
+SELECT '-- Mixed conditions, with lazy materialization';
+SELECT trimLeft(explain)
+FROM ( EXPLAIN actions = 1 SELECT * FROM 03760_data WHERE str = '' OR str = 'foo' ORDER BY dt LIMIT 3 )
+WHERE trimLeft(explain) LIKE 'Prewhere filter column: %';
+
+SELECT * FROM 03760_data WHERE str = '' OR str = 'foo' ORDER BY dt LIMIT 3;
+
+SELECT '-- Prewhere column not removed';
+SELECT trimLeft(explain)
+FROM ( EXPLAIN actions = 1 SELECT *, str = '' FROM 03760_data WHERE str = '' ORDER BY dt LIMIT 3)
+WHERE trimLeft(explain) LIKE 'Prewhere filter column: %';
+
+SELECT *, str = '' FROM 03760_data WHERE str = '' ORDER BY dt LIMIT 3;
+
+SELECT '-- Prewhere column removed, expression over lazy column';
+SELECT trimLeft(explain)
+FROM ( EXPLAIN actions = 1 SELECT *, str != '' FROM 03760_data WHERE str = '' ORDER BY dt LIMIT 3)
+WHERE trimLeft(explain) LIKE 'Prewhere filter column: %';
+
+SELECT *, str != '' FROM 03760_data WHERE str = '' ORDER BY dt LIMIT 3;
+
+SELECT '-- Prewhere disabled';
+SELECT trimLeft(explain)
+FROM ( EXPLAIN actions = 1 SELECT * FROM 03760_data WHERE str = '' ORDER BY dt LIMIT 3 SETTINGS optimize_move_to_prewhere = 0)
+WHERE trimLeft(explain) LIKE 'Prewhere filter column: %'
+   OR trimLeft(explain) LIKE 'Filter column: %';
+
+SELECT * FROM 03760_data WHERE str = '' ORDER BY dt LIMIT 3 SETTINGS optimize_move_to_prewhere = 0;
+
+SELECT '-- Prewhere DAG output reused';
+SELECT trimLeft(explain)
+FROM ( EXPLAIN actions = 1 SELECT *, str = '' FROM 03760_data WHERE str = '' AND key < 15 ORDER BY dt LIMIT 3)
+WHERE trimLeft(explain) LIKE 'Prewhere filter column: %';
+
+SELECT *, str = '' FROM 03760_data WHERE str = '' AND key < 15 ORDER BY dt LIMIT 3;
+
+SELECT '-- Lazy materialization with aliases';
+SELECT trimLeft(explain)
+FROM ( EXPLAIN actions = 1 SELECT key, dt, str AS s FROM 03760_data WHERE s = '' ORDER BY dt LIMIT 3)
+WHERE trimLeft(explain) LIKE 'Prewhere filter column: %';
+
+SELECT key, dt, str AS s FROM 03760_data WHERE s = '' ORDER BY dt LIMIT 3;
+
+SELECT '-- Mixed conditions with aliases';
+SELECT trimLeft(explain)
+FROM ( EXPLAIN actions = 1 SELECT key, dt, str AS s FROM 03760_data WHERE s = '' OR s = 'foo' ORDER BY dt LIMIT 3)
+WHERE trimLeft(explain) LIKE 'Prewhere filter column: %';
+
+SELECT key, dt, str AS s FROM 03760_data WHERE s = '' OR s = 'foo' ORDER BY dt LIMIT 3;
+
+SELECT '-- Prewhere DAG output reused with aliases';
+SELECT trimLeft(explain)
+FROM ( EXPLAIN actions = 1 SELECT key, dt, str AS s, s = '' FROM 03760_data WHERE s = '' AND key < 15 ORDER BY dt LIMIT 3)
+WHERE trimLeft(explain) LIKE 'Prewhere filter column: %';
+
+SELECT key, dt, str AS s, s = '' FROM 03760_data WHERE s = '' AND key < 15 ORDER BY dt LIMIT 3;
+
+SELECT '-- notEmpty String, no lazy materializaton';
+SELECT trimLeft(explain)
+FROM ( EXPLAIN actions = 1 SELECT * FROM 03760_data WHERE str != '' ORDER BY dt)
+WHERE trimLeft(explain) LIKE 'Prewhere filter column: %'
+   OR trimLeft(explain) LIKE 'Filter column: %';
+
+SELECT * FROM 03760_data WHERE str != '' ORDER BY dt;
+
+SELECT '-- notEmpty String, with lazy materializaton';
+SELECT trimLeft(explain)
+FROM ( EXPLAIN actions = 1 SELECT * FROM 03760_data WHERE str != '' ORDER BY dt LIMIT 3)
+WHERE trimLeft(explain) LIKE 'Prewhere filter column: %'
+   OR trimLeft(explain) LIKE 'Filter column: %';
+
+SELECT * FROM 03760_data WHERE str != '' ORDER BY dt LIMIT 3;
+
+SELECT '-- length String, no lazy materializaton';
+SELECT trimLeft(explain)
+FROM ( EXPLAIN actions = 1 SELECT * FROM 03760_data WHERE length(str) = 0 ORDER BY dt)
+WHERE trimLeft(explain) LIKE 'Prewhere filter column: %'
+   OR trimLeft(explain) LIKE 'Filter column: %';
+
+SELECT * FROM 03760_data WHERE length(str) = 0 ORDER BY dt;
+
+SELECT '-- length String, with lazy materializaton';
+SELECT trimLeft(explain)
+FROM ( EXPLAIN actions = 1 SELECT * FROM 03760_data WHERE length(str) = 0 ORDER BY dt LIMIT 3)
+WHERE trimLeft(explain) LIKE 'Prewhere filter column: %'
+   OR trimLeft(explain) LIKE 'Filter column: %';
+
+SELECT * FROM 03760_data WHERE length(str) = 0 ORDER BY dt LIMIT 3;
+
+SELECT '-- length String gt, no lazy materializaton';
+SELECT trimLeft(explain)
+FROM ( EXPLAIN actions = 1 SELECT * FROM 03760_data WHERE length(str) > 0 ORDER BY dt)
+WHERE trimLeft(explain) LIKE 'Prewhere filter column: %'
+   OR trimLeft(explain) LIKE 'Filter column: %';
+
+SELECT * FROM 03760_data WHERE length(str) > 0 ORDER BY dt;
+
+SELECT '-- length String gt, with lazy materializaton';
+SELECT trimLeft(explain)
+FROM ( EXPLAIN actions = 1 SELECT * FROM 03760_data WHERE length(str) > 0 ORDER BY dt LIMIT 3)
+WHERE trimLeft(explain) LIKE 'Prewhere filter column: %'
+   OR trimLeft(explain) LIKE 'Filter column: %';
+
+SELECT * FROM 03760_data WHERE length(str) > 0 ORDER BY dt LIMIT 3;
+
+CREATE TABLE 03760_name_conflict (
+    key UInt32,
+    dt Date,
+    str String,
+    `str.size` UInt64
+)
+ENGINE = MergeTree
+ORDER BY key
+AS
+SELECT number, toDate('2025-01-01') + number, if(number % 2 = 0, '', 'str-' || number), 100
+FROM numbers(10);
+
+SELECT '-- empty String, with name conflict';
+SELECT trimLeft(explain)
+FROM ( EXPLAIN actions = 1 SELECT * FROM 03760_name_conflict WHERE str = '' ORDER BY dt LIMIT 3)
+WHERE trimLeft(explain) LIKE 'Prewhere filter column: %';
+
+SELECT * FROM 03760_name_conflict WHERE str = '' ORDER BY dt LIMIT 3;
+
+SELECT '-- notEmpty String, with name conflict';
+SELECT trimLeft(explain)
+FROM ( EXPLAIN actions = 1 SELECT * FROM 03760_name_conflict WHERE str != '' ORDER BY dt LIMIT 3)
+WHERE trimLeft(explain) LIKE 'Prewhere filter column: %';
+
+SELECT * FROM 03760_name_conflict WHERE str != '' ORDER BY dt LIMIT 3;
+
+SELECT '-- length String, with name conflict';
+SELECT trimLeft(explain)
+FROM ( EXPLAIN actions = 1 SELECT * FROM 03760_name_conflict WHERE length(str) > 0 ORDER BY dt LIMIT 3)
+WHERE trimLeft(explain) LIKE 'Prewhere filter column: %';
+
+SELECT * FROM 03760_name_conflict WHERE length(str) > 0 ORDER BY dt LIMIT 3;
+
+DROP TABLE 03760_data, 03760_name_conflict;


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Rewrite prewhere string functions to use subcolumns for lazy materialization queries if `optimize_functions_to_subcolumns` enabled

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

### Details
In general, rewriting prewhere to subcolumns doesn't seem beneficial due to potentially low predicate selectivity  and query condition cache hits  -- in both cases, it leads to ~double reading of the size subcolumn.

However, for lazy reading, there's a guarantee that the amount of rows read is negligibly small (being limited by `query_plan_max_limit_for_lazy_materialization`), so the double reading .size for that fixed amount of rows is acceptable, while the size of data read in prewhere is noticeably reduced. This optimization is therefore tightly coupled with lazy materialization and applied only when it's enabled.