### PR TITLE
Fix logical error caused by `Nothing` type in `caseWithExpression` function 

### DIFF
--- a/src/Functions/caseWithExpression.cpp
+++ b/src/Functions/caseWithExpression.cpp
@@ -29,7 +29,6 @@ public:
     bool isVariadic() const override { return true; }
     bool useDefaultImplementationForConstants() const override { return false; }
     bool useDefaultImplementationForNulls() const override { return false; }
-    bool useDefaultImplementationForNothing() const override { return false; }
     bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return false; }
     size_t getNumberOfArguments() const override { return 0; }
     String getName() const override { return name; }
@@ -62,14 +61,6 @@ public:
     /// Helper function to implement CASE WHEN equality semantics where NULL = NULL is true
     ColumnPtr caseWhenEquals(const ColumnWithTypeAndName & expr, const ColumnWithTypeAndName & when_value, size_t input_rows_count) const
     {
-        // handle Nothing type - it's an empty type that can't contain any values
-        // if either argument is Nothing, the result should be an empty column
-        if (expr.type->onlyNull() || when_value.type->onlyNull())
-        {
-            // return a constant false column
-            return DataTypeUInt8().createColumnConst(input_rows_count, 0u);
-        }
-
         // for CASE WHEN semantics, NULL should match NULL
         // we need: if (isNull(expr)) then (isNull(when)) else if (isNull(when)) then 0 else (expr = when)
 

--- a/tests/queries/0_stateless/03390_non_constant_case.sql
+++ b/tests/queries/0_stateless/03390_non_constant_case.sql
@@ -59,4 +59,10 @@ SELECT caseWithExpression(
     materialize(NULL),
     NULL,
     NULL
-); -- { serverError ILLEGAL_COLUMN }
+); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+
+SELECT caseWithExpression('C', 'A', true, 'B', false); -- { serverError BAD_ARGUMENTS }
+
+SELECT caseWithExpression(1, assumeNotNull(materialize(NULL)), 1, 1); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+
+SELECT count() WHERE caseWithExpression(1, assumeNotNull(materialize(NULL)), 1, 1); -- { serverError ILLEGAL_TYPE_OF_COLUMN_FOR_FILTER }

--- a/tests/queries/0_stateless/03444_case_with_expression_exception.sql
+++ b/tests/queries/0_stateless/03444_case_with_expression_exception.sql
@@ -1,1 +1,0 @@
-SELECT caseWithExpression('C', 'A', true, 'B', false); -- { serverError BAD_ARGUMENTS }


### PR DESCRIPTION
The following query has logical error:

```sql
SELECT caseWithExpression(1, assumeNotNull(materialize(NULL)), 1, 1);
```

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix logical error caused by using `Nothing` type in `caseWithExpression` function arguments . Closes https://github.com/ClickHouse/ClickHouse/issues/85354.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
