### PR TITLE
test_keeper_persistent_watches: add coverage for persistent watch event fields

### DIFF
--- a/tests/integration/test_keeper_persistent_watches/test.py
+++ b/tests/integration/test_keeper_persistent_watches/test.py
@@ -247,7 +247,7 @@ def test_persistent_recursive_watch_event_fields(started_cluster):
     CHILD_NODE = f"{NODE_PATH}/child"
     OTHER_PATH = "/testEventFieldsOther2"
 
-    for path in [NODE_PATH, CHILD_NODE, OTHER_PATH]:
+    for path in [CHILD_NODE, NODE_PATH, OTHER_PATH]:
         if client.exists(path):
             client.delete(path)
 

--- a/tests/integration/test_keeper_persistent_watches/test.py
+++ b/tests/integration/test_keeper_persistent_watches/test.py
@@ -291,6 +291,7 @@ def test_persistent_recursive_watch_event_fields(started_cluster):
     time.sleep(0.5)
     assert len(events) == 2
 
+@pytest.mark.skip(reason="https://github.com/ClickHouse/ClickHouse/issues/92480")
 def test_persistent_watches_cleanup_on_close(started_cluster):
     node1.restart_clickhouse()
     keeper_utils.wait_until_connected(cluster, node1)

--- a/tests/integration/test_keeper_persistent_watches/test.py
+++ b/tests/integration/test_keeper_persistent_watches/test.py
@@ -190,3 +190,128 @@ def test_persistent_recursive_watch(started_cluster):
     client.delete(CHILD_NODE)
     client.delete(NODE_PATH)
     client.delete(FAKE_PATH)
+
+def test_persistent_watch_event_fields(started_cluster):
+    node1.restart_clickhouse()
+    keeper_utils.wait_until_connected(cluster, node1)
+
+    client = get_fake_zk(node1)
+    NODE_PATH = "/testEventFields1"
+    OTHER_PATH = "/testEventFieldsOther1"
+
+    for path in [NODE_PATH, OTHER_PATH]:
+        if client.exists(path):
+            client.delete(path)
+
+    client.create(NODE_PATH, b"1")
+    client.create(OTHER_PATH, b"1")
+
+    events = []
+    event_lock = threading.Event()
+
+    def cb(event):
+        events.append(dict(type=event.type, path=event.path, state=getattr(event, "state", None)))
+        event_lock.set()
+
+    client.add_watch(NODE_PATH, cb, AddWatchMode.PERSISTENT)
+
+    event_lock.clear()
+    client.set(NODE_PATH, b"2")
+    event_lock.wait(5)
+    assert len(events) == 1
+    assert events[-1]["type"] == "CHANGED"
+    assert events[-1]["path"] == NODE_PATH
+    assert events[-1]["state"] == "CONNECTED"
+
+    event_lock.clear()
+    client.set(NODE_PATH, b"3")
+    event_lock.wait(5)
+    assert len(events) == 2
+    assert events[-1]["type"] == "CHANGED"
+    assert events[-1]["path"] == NODE_PATH
+    assert events[-1]["state"] == "CONNECTED"
+
+    client.set(OTHER_PATH, b"9")
+    time.sleep(0.3)
+    assert len(events) == 2
+
+    client.remove_all_watches(NODE_PATH, WatcherType.ANY)
+    client.set(NODE_PATH, b"after")
+    time.sleep(0.5)
+    assert len(events) == 2
+
+def test_persistent_recursive_watch_event_fields(started_cluster):
+    node1.restart_clickhouse()
+    keeper_utils.wait_until_connected(cluster, node1)
+
+    client = get_fake_zk(node1)
+    NODE_PATH = "/testEventFields2"
+    CHILD_NODE = f"{NODE_PATH}/child"
+    OTHER_PATH = "/testEventFieldsOther2"
+
+    for path in [NODE_PATH, CHILD_NODE, OTHER_PATH]:
+        if client.exists(path):
+            client.delete(path)
+
+    client.create(NODE_PATH, b"1")
+    client.create(CHILD_NODE, b"1")
+    client.create(OTHER_PATH, b"1")
+
+    events = []
+    event_lock = threading.Event()
+
+    def cb(event):
+        events.append(dict(type=event.type, path=event.path, state=getattr(event, "state", None)))
+        event_lock.set()
+
+    client.add_watch(NODE_PATH, cb, AddWatchMode.PERSISTENT_RECURSIVE)
+
+    event_lock.clear()
+    client.set(NODE_PATH, b"2")
+    event_lock.wait(5)
+    assert len(events) == 1
+    assert events[-1]["path"] == NODE_PATH
+    assert events[-1]["type"] == "CHANGED"
+    assert events[-1]["state"] == "CONNECTED"
+
+    event_lock.clear()
+    client.set(CHILD_NODE, b"3")
+    event_lock.wait(5)
+    assert len(events) == 2
+    assert events[-1]["path"] == NODE_PATH
+    assert events[-1]["type"] == "CHANGED"
+    assert events[-1]["state"] == "CONNECTED"
+
+    event_lock.clear()
+    client.set(OTHER_PATH, b"x")
+    time.sleep(0.3)
+    assert len(events) == 2
+
+    client.remove_all_watches(NODE_PATH, WatcherType.ANY)
+    client.set(NODE_PATH, b"after")
+    client.set(CHILD_NODE, b"after2")
+    time.sleep(0.5)
+    assert len(events) == 2
+
+def test_persistent_watches_cleanup_on_close(started_cluster):
+    node1.restart_clickhouse()
+    keeper_utils.wait_until_connected(cluster, node1)
+
+    client = get_fake_zk(node1)
+    NODE_PATH = "/testPersistentCleanup"
+
+    if client.exists(NODE_PATH):
+        client.delete(NODE_PATH)
+    client.create(NODE_PATH, b"1")
+
+    def cb(_):
+        pass
+
+    client.add_watch(NODE_PATH, cb, AddWatchMode.PERSISTENT)
+    client.add_watch(NODE_PATH, cb, AddWatchMode.PERSISTENT_RECURSIVE)
+
+    destroy_zk_client(client)
+    time.sleep(1)
+
+    data = keeper_utils.send_4lw_cmd(cluster, node1, cmd="mntr")
+    assert "zk_watch_count\t0" in data

--- a/tests/integration/test_keeper_persistent_watches/test.py
+++ b/tests/integration/test_keeper_persistent_watches/test.py
@@ -238,6 +238,11 @@ def test_persistent_watch_event_fields(started_cluster):
     time.sleep(0.5)
     assert len(events) == 2
 
+    if client.exists(NODE_PATH):
+        client.delete(NODE_PATH)
+    if client.exists(OTHER_PATH):
+        client.delete(OTHER_PATH)
+
 def test_persistent_recursive_watch_event_fields(started_cluster):
     node1.restart_clickhouse()
     keeper_utils.wait_until_connected(cluster, node1)
@@ -290,6 +295,13 @@ def test_persistent_recursive_watch_event_fields(started_cluster):
     client.set(CHILD_NODE, b"after2")
     time.sleep(0.5)
     assert len(events) == 2
+
+    if client.exists(CHILD_NODE):
+        client.delete(CHILD_NODE)
+    if client.exists(NODE_PATH):
+        client.delete(NODE_PATH)
+    if client.exists(OTHER_PATH):
+        client.delete(OTHER_PATH)
 
 @pytest.mark.skip(reason="https://github.com/ClickHouse/ClickHouse/issues/92480")
 def test_persistent_watches_cleanup_on_close(started_cluster):

--- a/tests/integration/test_keeper_session/test.py
+++ b/tests/integration/test_keeper_session/test.py
@@ -193,12 +193,41 @@ def test_create2(started_cluster):
     node1_zk = None
     node1_zk = get_fake_zk(node1.name)
     uid = str(uuid.uuid4()).replace('-', '')
-    _, stats = node1_zk.create(f'/tea_{uid}', include_data=True)
+    path = f"/tea_{uid}"
+    _, stats = node1_zk.create(path, include_data=True)
     assert stats is not None
+    data, stats_get = node1_zk.get(path)
+    stats_exists = node1_zk.exists(path)
+    assert stats_get is not None
+    assert stats_exists is not None
+
     assert stats.numChildren == 0
     assert stats.ephemeralOwner == 0
     assert stats.version == 0
 
+    assert stats_get.numChildren == stats.numChildren
+    assert stats_get.ephemeralOwner == stats.ephemeralOwner
+    assert stats_get.version == stats.version
+    assert stats_get.czxid == stats.czxid
+    assert stats_get.mzxid == stats.mzxid
+    assert stats_get.pzxid == stats.pzxid
+    assert stats_get.ctime == stats.ctime
+    assert stats_get.mtime == stats.mtime
+    assert stats_get.cversion == stats.cversion
+    assert stats_get.aversion == stats.aversion
+
+    assert stats_exists.czxid == stats.czxid
+    assert stats_exists.mzxid == stats.mzxid
+    assert stats_exists.pzxid == stats.pzxid
+    assert stats_exists.ctime == stats.ctime
+    assert stats_exists.mtime == stats.mtime
+    assert stats_exists.version == stats.version
+    assert stats_exists.cversion == stats.cversion
+    assert stats_exists.aversion == stats.aversion
+    assert stats_exists.ephemeralOwner == stats.ephemeralOwner
+    assert stats_exists.numChildren == stats.numChildren
+
+    assert stats_get.dataLength == len(data)
 
 def test_create2_stats_match_get_and_exists(started_cluster):
     wait_nodes()


### PR DESCRIPTION
Summary
- Add precise validations for PERSISTENT and PERSISTENT_RECURSIVE watch behavior.
- Ensure teardown deletes child before parent to avoid NotEmptyError.
- Introduce a cleanup-on-close test that detects leaked persistent watches via 4LW metrics; skipped with an issue link.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
