### PR TITLE
Docs: Clear up some confusion around setting 'max_threads'

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -245,9 +245,11 @@ For queries that are completed quickly because of a LIMIT, you can set a lower '
 For example, if the necessary number of entries are located in every block and max_threads = 8, then 8 blocks are retrieved, although it would have been enough to read just one.
 The smaller the `max_threads` value, the less memory is consumed.
 
-The `max_threads` setting by default matches the number of CPU cores available to ClickHouse.
-For Cloud users, the default value will display as `auto(N)` where N matches the vCPU size of your service e.g. 2vCPU/8GiB, 4vCPU/16GiB etc.
-See the settings tab in Cloud console for a list of all service sizes.
+The `max_threads` setting by default matches the number of hardware threads available to ClickHouse.
+Without SMT (e.g. Intel HyperThreading), this corresponds to the number of CPU cores.
+    
+For ClickHouse Cloud users, the default value will display as `auto(N)` where N matches the vCPU size of your service e.g. 2vCPU/8GiB, 4vCPU/16GiB etc.
+See the settings tab in the Cloud console for a list of all service sizes.
 )", 0) \
     DECLARE(Bool, use_concurrency_control, true, R"(
 Respect the server's concurrency control (see the `concurrent_threads_soft_limit_num` and `concurrent_threads_soft_limit_ratio_to_cores` global server settings). If disabled, it allows using a larger number of threads even if the server is overloaded (not recommended for normal usage, and needed mostly for tests).

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -247,7 +247,7 @@ The smaller the `max_threads` value, the less memory is consumed.
 
 The `max_threads` setting by default matches the number of hardware threads available to ClickHouse.
 Without SMT (e.g. Intel HyperThreading), this corresponds to the number of CPU cores.
-    
+
 For ClickHouse Cloud users, the default value will display as `auto(N)` where N matches the vCPU size of your service e.g. 2vCPU/8GiB, 4vCPU/16GiB etc.
 See the settings tab in the Cloud console for a list of all service sizes.
 )", 0) \

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -245,8 +245,8 @@ For queries that are completed quickly because of a LIMIT, you can set a lower '
 For example, if the necessary number of entries are located in every block and max_threads = 8, then 8 blocks are retrieved, although it would have been enough to read just one.
 The smaller the `max_threads` value, the less memory is consumed.
 
-The `max_threads` setting by default matches the number of cores (threads) of a single CPU available to ClickHouse.
-For Cloud users, the default value will display as `auto(N)` where N matches the vCPU size of your service e.g. 8GiB:2vCPU, 16GiB:4vCPU etc.
+The `max_threads` setting by default matches the number of CPU cores available to ClickHouse.
+For Cloud users, the default value will display as `auto(N)` where N matches the vCPU size of your service e.g. 2vCPU/8GiB, 4vCPU/16GiB etc.
 See the settings tab in Cloud console for a list of all service sizes.
 )", 0) \
     DECLARE(Bool, use_concurrency_control, true, R"(


### PR DESCRIPTION
https://github.com/ClickHouse/ClickHouse/pull/92296 improved the docs of setting `max_threads`. However, [this comment](https://github.com/ClickHouse/ClickHouse/pull/92296#issuecomment-3662991378) wrecked some havock on the correctness of the docs. This PR corrects this.

### Changelog category (leave one):
- Documentation (changelog entry is not required)