### PR TITLE
Fixes for temporary files settings and metrics

### DIFF
--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -47,11 +47,9 @@
 
 namespace ProfileEvents
 {
-    extern const Event ExternalAggregationWritePart;
     extern const Event ExternalAggregationCompressedBytes;
     extern const Event ExternalAggregationUncompressedBytes;
-    extern const Event ExternalProcessingCompressedBytesTotal;
-    extern const Event ExternalProcessingUncompressedBytesTotal;
+    extern const Event ExternalAggregationWritePart;
     extern const Event AggregationHashTablesInitializedAsTwoLevel;
     extern const Event OverflowThrow;
     extern const Event OverflowBreak;
@@ -550,7 +548,11 @@ Aggregator::Aggregator(const Block & header_, const Params & params_)
     : header(header_)
     , keys_positions(calculateKeysPositions(header, params_))
     , params(params_)
-    , tmp_data(params.tmp_data_scope ? params.tmp_data_scope->childScope(CurrentMetrics::TemporaryFilesForAggregation) : nullptr)
+    , tmp_data(params.tmp_data_scope ? params.tmp_data_scope->childScope({
+        .current_metric = CurrentMetrics::TemporaryFilesForAggregation,
+        .bytes_compressed = ProfileEvents::ExternalAggregationCompressedBytes,
+        .bytes_uncompressed = ProfileEvents::ExternalAggregationUncompressedBytes,
+        .num_files = ProfileEvents::ExternalAggregationWritePart}) : nullptr)
     , min_bytes_for_prefetch(getMinBytesForPrefetch())
     , thread_pool{
           CurrentMetrics::AggregatorThreads,
@@ -1863,8 +1865,6 @@ void Aggregator::writeToTemporaryFile(AggregatedDataVariants & data_variants, si
         return tmp_files.emplace_back(std::make_shared<const Block>(getHeader(false)), tmp_data, max_temp_file_size);
     }();
 
-    ProfileEvents::increment(ProfileEvents::ExternalAggregationWritePart);
-
     LOG_DEBUG(log, "Writing part of aggregation data into temporary file {}", out_stream.getHolder()->describeFilePath());
 
     /// Flush only two-level data and possibly overflow data.
@@ -1891,11 +1891,6 @@ void Aggregator::writeToTemporaryFile(AggregatedDataVariants & data_variants, si
     }
 
     auto stat = out_stream.finishWriting();
-
-    ProfileEvents::increment(ProfileEvents::ExternalAggregationCompressedBytes, stat.compressed_size);
-    ProfileEvents::increment(ProfileEvents::ExternalAggregationUncompressedBytes, stat.uncompressed_size);
-    ProfileEvents::increment(ProfileEvents::ExternalProcessingCompressedBytesTotal, stat.compressed_size);
-    ProfileEvents::increment(ProfileEvents::ExternalProcessingUncompressedBytesTotal, stat.uncompressed_size);
 
     double elapsed_seconds = watch.elapsedSeconds();
     double compressed_size = stat.compressed_size;

--- a/src/Interpreters/Cache/FileCacheSettings.cpp
+++ b/src/Interpreters/Cache/FileCacheSettings.cpp
@@ -232,7 +232,7 @@ void FileCacheSettings::validate()
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "`path` is required parameter of cache configuration");
 
     if (fs::path((*this)[FileCacheSetting::path].value).is_relative())
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "`path` was not normalized to absolute");
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "`path` was not normalized to absolute: {}", (*this)[FileCacheSetting::path].value);
 
     if (!settings[FileCacheSetting::max_size].changed && !settings[FileCacheSetting::max_size_ratio_to_total_space].changed)
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Either `max_size` or `max_size_ratio_to_total_space` must be defined in cache configuration");

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -1518,7 +1518,7 @@ void Context::setFilesystemCacheUser(const String & user)
 static void setupTmpPath(LoggerPtr log, const DiskPtr & disk)
 try
 {
-    LOG_DEBUG(log, "Setting up {}:{} to store temporary data in it", disk->getName(), disk->getPath());
+    LOG_DEBUG(log, "Setting up temporary data storage at disk '{}' with path '{}'", disk->getName(), disk->getPath());
 
     if (disk->existsDirectory(""))
     {

--- a/src/Interpreters/GraceHashJoin.cpp
+++ b/src/Interpreters/GraceHashJoin.cpp
@@ -23,6 +23,13 @@ namespace CurrentMetrics
     extern const Metric TemporaryFilesForJoin;
 }
 
+namespace ProfileEvents
+{
+    extern const Event ExternalJoinCompressedBytes;
+    extern const Event ExternalJoinUncompressedBytes;
+    extern const Event ExternalJoinWritePart;
+}
+
 namespace DB
 {
 
@@ -259,7 +266,12 @@ GraceHashJoin::GraceHashJoin(
     , max_num_buckets(max_num_buckets_)
     , left_key_names(table_join->getOnlyClause().key_names_left)
     , right_key_names(table_join->getOnlyClause().key_names_right)
-    , tmp_data(tmp_data_->childScope(CurrentMetrics::TemporaryFilesForJoin, table_join->temporaryFilesBufferSize()))
+    , tmp_data(tmp_data_->childScope({
+            .current_metric = CurrentMetrics::TemporaryFilesForJoin,
+            .bytes_compressed = ProfileEvents::ExternalJoinCompressedBytes,
+            .bytes_uncompressed = ProfileEvents::ExternalJoinUncompressedBytes,
+            .num_files = ProfileEvents::ExternalJoinWritePart,
+        }, table_join->temporaryFilesBufferSize(), table_join->temporaryFilesCodec()))
     , hash_join(makeInMemoryJoin("grace0"))
     , hash_join_sample_block(hash_join->savedBlockSample())
 {

--- a/src/Interpreters/ProcessList.cpp
+++ b/src/Interpreters/ProcessList.cpp
@@ -277,6 +277,7 @@ ProcessList::EntryPtr ProcessList::insert(
                     .max_size_on_disk = settings[Setting::max_temporary_data_on_disk_size_for_query],
                     .compression_codec = settings[Setting::temporary_files_codec],
                     .buffer_size = settings[Setting::temporary_files_buffer_size],
+                    .metrics = {}, /// Metrics are set by child scopes
                 };
                 query_context->setTempDataOnDisk(std::make_shared<TemporaryDataOnDiskScope>(
                     user_process_list.user_temp_data_on_disk, std::move(temporary_data_on_disk_settings)));
@@ -844,6 +845,7 @@ ProcessListForUser::ProcessListForUser(ContextPtr global_context, ProcessList * 
             .max_size_on_disk = settings[Setting::max_temporary_data_on_disk_size_for_user],
             .compression_codec = settings[Setting::temporary_files_codec],
             .buffer_size = settings[Setting::temporary_files_buffer_size],
+            .metrics = {}, /// Metrics are set by child scopes
         };
 
         user_temp_data_on_disk = std::make_shared<TemporaryDataOnDiskScope>(global_context->getSharedTempDataOnDisk(),

--- a/src/Interpreters/SortedBlocksWriter.cpp
+++ b/src/Interpreters/SortedBlocksWriter.cpp
@@ -8,12 +8,7 @@
 
 namespace ProfileEvents
 {
-    extern const Event ExternalJoinWritePart;
     extern const Event ExternalJoinMerge;
-    extern const Event ExternalJoinCompressedBytes;
-    extern const Event ExternalJoinUncompressedBytes;
-    extern const Event ExternalProcessingCompressedBytesTotal;
-    extern const Event ExternalProcessingUncompressedBytesTotal;
 }
 
 namespace DB
@@ -27,24 +22,11 @@ namespace ErrorCodes
 namespace
 {
 
-void updateProfileEvents(TemporaryDataBuffer::Stat stat)
-{
-    ProfileEvents::increment(ProfileEvents::ExternalProcessingCompressedBytesTotal, stat.compressed_size);
-    ProfileEvents::increment(ProfileEvents::ExternalProcessingUncompressedBytesTotal, stat.uncompressed_size);
-
-    ProfileEvents::increment(ProfileEvents::ExternalJoinCompressedBytes, stat.compressed_size);
-    ProfileEvents::increment(ProfileEvents::ExternalJoinUncompressedBytes, stat.uncompressed_size);
-    ProfileEvents::increment(ProfileEvents::ExternalJoinWritePart);
-}
-
 TemporaryBlockStreamHolder flushBlockToFile(const TemporaryDataOnDiskScopePtr & tmp_data, const Block & block)
 {
     TemporaryBlockStreamHolder stream_holder(std::make_shared<const Block>(block.cloneEmpty()), tmp_data);
     stream_holder->write(block);
-
-    auto stat = stream_holder.finishWriting();
-    updateProfileEvents(stat);
-
+    stream_holder.finishWriting();
     return stream_holder;
 }
 
@@ -60,9 +42,7 @@ TemporaryBlockStreamHolder flushToFile(const TemporaryDataOnDiskScopePtr & tmp_d
     while (executor.pull(block))
         stream_holder->write(block);
 
-    auto stat = stream_holder.finishWriting();
-    updateProfileEvents(stat);
-
+    stream_holder.finishWriting();
     return stream_holder;
 }
 

--- a/src/Interpreters/TableJoin.h
+++ b/src/Interpreters/TableJoin.h
@@ -21,11 +21,6 @@
 #include <unordered_map>
 #include <utility>
 
-namespace CurrentMetrics
-{
-    extern const Metric TemporaryFilesForJoin;
-}
-
 namespace DB
 {
 
@@ -278,7 +273,7 @@ public:
 
     bool enableAnalyzer() const { return enable_analyzer; }
     void assertEnableAnalyzer() const;
-    TemporaryDataOnDiskScopePtr getTempDataOnDisk() { return tmp_data ? tmp_data->childScope(CurrentMetrics::TemporaryFilesForJoin, temporary_files_buffer_size) : nullptr; }
+    TemporaryDataOnDiskScopePtr getTempDataOnDisk();
 
     ActionsDAG createJoinedBlockActions(ContextPtr context, PreparedSetsPtr prepared_sets) const;
 

--- a/src/Interpreters/TemporaryDataOnDisk.cpp
+++ b/src/Interpreters/TemporaryDataOnDisk.cpp
@@ -49,6 +49,8 @@ namespace CurrentMetrics
 namespace ProfileEvents
 {
     extern const Event ExternalProcessingFilesTotal;
+    extern const Event ExternalProcessingCompressedBytesTotal;
+    extern const Event ExternalProcessingUncompressedBytesTotal;
 
 #if ENABLE_DISTRIBUTED_CACHE
     extern const Event DistrCacheTemporaryFilesCreated;
@@ -73,17 +75,19 @@ namespace
 inline CompressionCodecPtr getCodec(const TemporaryDataOnDiskSettings & settings)
 {
     if (settings.compression_codec.empty())
-        return CompressionCodecFactory::instance().get("NONE");
+        return CompressionCodecFactory::instance().get("LZ4");
 
     return CompressionCodecFactory::instance().get(settings.compression_codec);
 }
 
 }
 
-TemporaryFileHolder::TemporaryFileHolder(CurrentMetrics::Metric current_metric_)
-    : metric_increment(current_metric_)
+TemporaryFileHolder::TemporaryFileHolder(const TemporaryDataMetrics & metrics)
+    : metric_increment(metrics.current_metric)
 {
     ProfileEvents::increment(ProfileEvents::ExternalProcessingFilesTotal);
+    if (metrics.num_files)
+        ProfileEvents::increment(metrics.num_files.value());
 }
 
 
@@ -92,10 +96,9 @@ class TemporaryFileInLocalCache : public TemporaryFileHolder
 public:
     explicit TemporaryFileInLocalCache(FileCache & file_cache,
                                        size_t reserve_size,
-                                       size_t buffer_size_,
-                                       CurrentMetrics::Metric current_metric_)
-        : TemporaryFileHolder(current_metric_)
-        , buffer_size(buffer_size_)
+                                       const TemporaryDataOnDiskSettings & settings)
+        : TemporaryFileHolder(settings.metrics)
+        , buffer_size(settings.buffer_size)
     {
         const auto key = FileSegment::Key::random();
         LOG_TRACE(getLogger("TemporaryFileInLocalCache"), "Creating temporary file in cache with key {}", key);
@@ -131,11 +134,10 @@ private:
 class TemporaryFileInDistributedCache final : public TemporaryFileHolder
 {
 public:
-    explicit TemporaryFileInDistributedCache(size_t buffer_size_ = DBMS_DEFAULT_BUFFER_SIZE,
-        CurrentMetrics::Metric current_metric_ = CurrentMetrics::TemporaryFilesUnknown)
-        : TemporaryFileHolder(current_metric_)
+    explicit TemporaryFileInDistributedCache(const TemporaryDataOnDiskSettings & settings)
+        : TemporaryFileHolder(settings.metrics)
         , file_key(fmt::format("__tmp_{}", toString(UUIDHelpers::generateV4())))
-        , buffer_size(buffer_size_)
+        , buffer_size(settings.buffer_size)
         , log(getLogger("TemporaryFileInDistributedCache"))
     {
         LOG_TRACE(log, "Creating temporary file in distributed cache: {}", file_key);
@@ -240,10 +242,10 @@ private:
 class TemporaryFileOnLocalDisk : public TemporaryFileHolder
 {
 public:
-    explicit TemporaryFileOnLocalDisk(VolumePtr volume, size_t reserve_size = 0, size_t buffer_size_ = DBMS_DEFAULT_BUFFER_SIZE, CurrentMetrics::Metric current_metric_ = CurrentMetrics::TemporaryFilesUnknown)
-        : TemporaryFileHolder(current_metric_)
+    explicit TemporaryFileOnLocalDisk(VolumePtr volume, size_t reserve_size = 0, const TemporaryDataOnDiskSettings & settings = {})
+        : TemporaryFileHolder(settings.metrics)
         , path_to_file("tmp" + toString(UUIDHelpers::generateV4()))
-        , buffer_size(buffer_size_)
+        , buffer_size(settings.buffer_size)
     {
         LOG_TRACE(getLogger("TemporaryFileOnLocalDisk"), "Creating temporary file '{}'", path_to_file);
         if (reserve_size > 0)
@@ -329,7 +331,7 @@ TemporaryFileProvider createTemporaryFileProvider(VolumePtr volume)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Volume is not initialized");
     return [volume](const TemporaryDataOnDiskSettings & settings, size_t max_size) -> std::unique_ptr<TemporaryFileHolder>
     {
-        return std::make_unique<TemporaryFileOnLocalDisk>(volume, max_size, settings.buffer_size, settings.current_metric);
+        return std::make_unique<TemporaryFileOnLocalDisk>(volume, max_size, settings);
     };
 }
 
@@ -339,7 +341,7 @@ TemporaryFileProvider createTemporaryFileProvider(FileCache * file_cache)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "File cache is not initialized");
     return [file_cache](const TemporaryDataOnDiskSettings & settings, size_t max_size) -> std::unique_ptr<TemporaryFileHolder>
     {
-        return std::make_unique<TemporaryFileInLocalCache>(*file_cache, max_size, settings.buffer_size, settings.current_metric);
+        return std::make_unique<TemporaryFileInLocalCache>(*file_cache, max_size, settings);
     };
 }
 
@@ -353,17 +355,19 @@ TemporaryFileProvider createTemporaryFileProvider(DistributedCacheTag)
         if (!DistributedCache::Registry::instance().isReady(read_settings.distributed_cache_settings.read_only_from_current_az))
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Distributed cache is not ready yet");
 
-        return std::make_unique<TemporaryFileInDistributedCache>(settings.buffer_size, settings.current_metric);
+        return std::make_unique<TemporaryFileInDistributedCache>(settings);
     };
 }
 #endif
 
-TemporaryDataOnDiskScopePtr TemporaryDataOnDiskScope::childScope(CurrentMetrics::Metric current_metric, UInt64 buffer_size_)
+TemporaryDataOnDiskScopePtr TemporaryDataOnDiskScope::childScope(TemporaryDataMetrics metrics_, UInt64 buffer_size_, String compression_codec_)
 {
     TemporaryDataOnDiskSettings child_settings = settings;
-    child_settings.current_metric = current_metric;
+    child_settings.metrics = metrics_;
     if (buffer_size_)
         child_settings.buffer_size = buffer_size_;
+    if (!compression_codec_.empty())
+        child_settings.compression_codec = compression_codec_;
     return std::make_shared<TemporaryDataOnDiskScope>(shared_from_this(), child_settings);
 }
 
@@ -391,6 +395,7 @@ TemporaryDataBuffer::TemporaryDataBuffer(std::shared_ptr<TemporaryDataOnDiskScop
     , parent(parent_)
     , file_holder(parent->file_provider(parent->getSettings(), reserve_size))
     , out_compressed_buf(file_holder->write(), getCodec(parent->getSettings()), parent->getSettings().buffer_size)
+    , metrics(parent->getSettings().metrics)
 {
     WriteBuffer::set(out_compressed_buf->buffer().begin(), out_compressed_buf->buffer().size());
 }
@@ -491,9 +496,18 @@ void TemporaryDataBuffer::updateAllocAndCheck()
             new_compressed_size, stat.compressed_size, new_uncompressed_size, stat.uncompressed_size);
     }
 
-    parent->deltaAllocAndCheck(new_compressed_size - stat.compressed_size, new_uncompressed_size - stat.uncompressed_size);
+    ssize_t compressed_delta = new_compressed_size - stat.compressed_size;
+    ssize_t uncompressed_delta = new_uncompressed_size - stat.uncompressed_size;
+    parent->deltaAllocAndCheck(compressed_delta, uncompressed_delta);
     stat.compressed_size = new_compressed_size;
     stat.uncompressed_size = new_uncompressed_size;
+
+    if (metrics.bytes_compressed)
+        ProfileEvents::increment(metrics.bytes_compressed.value(), compressed_delta);
+    if (metrics.bytes_uncompressed)
+        ProfileEvents::increment(metrics.bytes_uncompressed.value(), uncompressed_delta);
+    ProfileEvents::increment(ProfileEvents::ExternalProcessingCompressedBytesTotal, compressed_delta);
+    ProfileEvents::increment(ProfileEvents::ExternalProcessingUncompressedBytesTotal, uncompressed_delta);
 }
 
 

--- a/src/Interpreters/TemporaryDataOnDisk.cpp
+++ b/src/Interpreters/TemporaryDataOnDisk.cpp
@@ -41,11 +41,6 @@
 #include <Server/DistributedCache/DistributedCacheServerInstance.h>
 #endif
 
-namespace CurrentMetrics
-{
-    extern const Metric TemporaryFilesUnknown;
-}
-
 namespace ProfileEvents
 {
     extern const Event ExternalProcessingFilesTotal;

--- a/src/Interpreters/TemporaryDataOnDisk.h
+++ b/src/Interpreters/TemporaryDataOnDisk.h
@@ -38,19 +38,27 @@ class TemporaryFileHolder;
 
 class FileCache;
 
+struct TemporaryDataMetrics
+{
+    CurrentMetrics::Metric current_metric = CurrentMetrics::TemporaryFilesUnknown;
+    std::optional<ProfileEvents::Event> bytes_compressed = {};
+    std::optional<ProfileEvents::Event> bytes_uncompressed = {};
+    std::optional<ProfileEvents::Event> num_files = {};
+};
+
 struct TemporaryDataOnDiskSettings
 {
     /// Max size on disk, if 0 there will be no limit
     size_t max_size_on_disk = 0;
 
     /// Compression codec for temporary data, if empty no compression will be used. LZ4 by default
-    String compression_codec = "LZ4";
+    String compression_codec = "";
 
     /// Read/Write internal buffer size
     size_t buffer_size = DBMS_DEFAULT_BUFFER_SIZE;
 
-    /// Metrics counter to increment when temporary file in current scope are created
-    CurrentMetrics::Metric current_metric = CurrentMetrics::TemporaryFilesUnknown;
+    /// Counters to update when files are created or data is written
+    TemporaryDataMetrics metrics;
 };
 
 /// Creates temporary files located on specified resource (disk, fs_cache, etc.)
@@ -94,7 +102,7 @@ public:
         , settings(std::move(settings_))
     {}
 
-    TemporaryDataOnDiskScopePtr childScope(CurrentMetrics::Metric current_metric, UInt64 buffer_size_ = 0);
+    TemporaryDataOnDiskScopePtr childScope(TemporaryDataMetrics metrics_, UInt64 buffer_size_ = 0, String compression_codec_ = {});
 
     const TemporaryDataOnDiskSettings & getSettings() const { return settings; }
 protected:
@@ -161,7 +169,7 @@ protected:
 class TemporaryFileHolder
 {
 public:
-    explicit TemporaryFileHolder(CurrentMetrics::Metric current_metric_ = CurrentMetrics::TemporaryFilesUnknown);
+    explicit TemporaryFileHolder(const TemporaryDataMetrics &);
 
     virtual std::unique_ptr<WriteBuffer> write() = 0;
     virtual std::unique_ptr<SeekableReadBuffer> read(size_t buffer_size) const = 0;
@@ -230,11 +238,17 @@ private:
     std::once_flag write_finished;
 
     Stat stat;
+    TemporaryDataMetrics metrics;
 };
 
 
 /// High level interfaces for reading and writing temporary data by blocks.
-using TemporaryBlockStreamReaderHolder = WrapperGuard<NativeReader, ReadBuffer>;
+class TemporaryBlockStreamReaderHolder : public WrapperGuard<NativeReader, ReadBuffer>
+{
+public:
+    using WrapperGuard<NativeReader, ReadBuffer>::WrapperGuard;
+};
+
 
 class TemporaryBlockStreamHolder : public WrapperGuard<NativeWriter, TemporaryDataBuffer>
 {

--- a/src/Interpreters/TemporaryDataOnDisk.h
+++ b/src/Interpreters/TemporaryDataOnDisk.h
@@ -52,7 +52,7 @@ struct TemporaryDataOnDiskSettings
     size_t max_size_on_disk = 0;
 
     /// Compression codec for temporary data, if empty no compression will be used. LZ4 by default
-    String compression_codec = "";
+    String compression_codec = {};
 
     /// Read/Write internal buffer size
     size_t buffer_size = DBMS_DEFAULT_BUFFER_SIZE;

--- a/src/Planner/Planner.cpp
+++ b/src/Planner/Planner.cpp
@@ -161,6 +161,8 @@ namespace Setting
     extern const SettingsBool enable_parallel_blocks_marshalling;
     extern const SettingsBool use_variant_as_common_type;
     extern const SettingsBool serialize_string_in_memory_with_zero_byte;
+    extern const SettingsString temporary_files_codec;
+    extern const SettingsNonZeroUInt64 temporary_files_buffer_size;
 }
 
 namespace ServerSetting
@@ -598,7 +600,7 @@ Aggregator::Params getAggregatorParams(const PlannerContextPtr & planner_context
         settings[Setting::empty_result_for_aggregation_by_empty_set]
             || (settings[Setting::empty_result_for_aggregation_by_constant_keys_on_empty_set]
                 && aggregation_analysis_result.aggregation_keys.empty() && aggregation_analysis_result.group_by_with_constant_keys),
-        query_context->getTempDataOnDisk(),
+        query_context->getTempDataOnDisk()->childScope({}, settings[Setting::temporary_files_buffer_size], settings[Setting::temporary_files_codec]),
         settings[Setting::max_threads],
         settings[Setting::min_free_disk_space_for_temporary_data],
         settings[Setting::compile_aggregate_expressions],

--- a/src/Planner/Planner.cpp
+++ b/src/Planner/Planner.cpp
@@ -589,7 +589,7 @@ Aggregator::Params getAggregatorParams(const PlannerContextPtr & planner_context
 
     auto tmp_data_scope = query_context->getTempDataOnDisk();
     if (tmp_data_scope)
-        tmp_data_scope = tmp_data_scope->childScope({}, settings[Setting::temporary_files_buffer_size], settings[Setting::temporary_files_codec]);
+        tmp_data_scope = tmp_data_scope->childScope(/* metrics */{}, settings[Setting::temporary_files_buffer_size], settings[Setting::temporary_files_codec]);
     Aggregator::Params aggregator_params = Aggregator::Params(
         aggregation_analysis_result.aggregation_keys,
         aggregate_descriptions,

--- a/src/Planner/Planner.cpp
+++ b/src/Planner/Planner.cpp
@@ -587,6 +587,9 @@ Aggregator::Params getAggregatorParams(const PlannerContextPtr & planner_context
             aggregate_description.argument_names.clear();
     }
 
+    auto tmp_data_scope = query_context->getTempDataOnDisk();
+    if (tmp_data_scope)
+        tmp_data_scope = tmp_data_scope->childScope({}, settings[Setting::temporary_files_buffer_size], settings[Setting::temporary_files_codec]);
     Aggregator::Params aggregator_params = Aggregator::Params(
         aggregation_analysis_result.aggregation_keys,
         aggregate_descriptions,
@@ -600,7 +603,7 @@ Aggregator::Params getAggregatorParams(const PlannerContextPtr & planner_context
         settings[Setting::empty_result_for_aggregation_by_empty_set]
             || (settings[Setting::empty_result_for_aggregation_by_constant_keys_on_empty_set]
                 && aggregation_analysis_result.aggregation_keys.empty() && aggregation_analysis_result.group_by_with_constant_keys),
-        query_context->getTempDataOnDisk()->childScope({}, settings[Setting::temporary_files_buffer_size], settings[Setting::temporary_files_codec]),
+        tmp_data_scope,
         settings[Setting::max_threads],
         settings[Setting::min_free_disk_space_for_temporary_data],
         settings[Setting::compile_aggregate_expressions],

--- a/src/Processors/QueryPlan/SortingStep.cpp
+++ b/src/Processors/QueryPlan/SortingStep.cpp
@@ -29,6 +29,13 @@ namespace CurrentMetrics
     extern const Metric TemporaryFilesForSort;
 }
 
+namespace ProfileEvents
+{
+    extern const Event ExternalSortCompressedBytes;
+    extern const Event ExternalSortUncompressedBytes;
+    extern const Event ExternalSortWritePart;
+}
+
 namespace DB
 {
 namespace Setting
@@ -44,6 +51,8 @@ namespace Setting
     extern const SettingsBool read_in_order_use_buffering;
     extern const SettingsFloat remerge_sort_lowered_memory_bytes_ratio;
     extern const SettingsOverflowMode sort_overflow_mode;
+    extern const SettingsString temporary_files_codec;
+    extern const SettingsNonZeroUInt64 temporary_files_buffer_size;
 }
 
 namespace QueryPlanSerializationSetting
@@ -58,6 +67,8 @@ namespace QueryPlanSerializationSetting
     extern const QueryPlanSerializationSettingsUInt64 prefer_external_sort_block_bytes;
     extern const QueryPlanSerializationSettingsFloat remerge_sort_lowered_memory_bytes_ratio;
     extern const QueryPlanSerializationSettingsOverflowMode sort_overflow_mode;
+    extern const QueryPlanSerializationSettingsString temporary_files_codec;
+    extern const QueryPlanSerializationSettingsNonZeroUInt64 temporary_files_buffer_size;
 }
 
 namespace ErrorCodes
@@ -111,6 +122,8 @@ SortingStep::Settings::Settings(const DB::Settings & settings)
     min_free_disk_space = settings[Setting::min_free_disk_space_for_temporary_data];
     max_block_bytes = settings[Setting::prefer_external_sort_block_bytes];
     read_in_order_use_buffering = settings[Setting::read_in_order_use_buffering];
+    temporary_files_codec = settings[Setting::temporary_files_codec];
+    temporary_files_buffer_size = settings[Setting::temporary_files_buffer_size];
 }
 
 SortingStep::Settings::Settings(size_t max_block_size_)
@@ -132,6 +145,9 @@ SortingStep::Settings::Settings(const QueryPlanSerializationSettings & settings)
     min_free_disk_space = settings[QueryPlanSerializationSetting::min_free_disk_space_for_temporary_data];
     max_block_bytes = settings[QueryPlanSerializationSetting::prefer_external_sort_block_bytes];
     read_in_order_use_buffering = false; //settings.read_in_order_use_buffering;
+
+    temporary_files_codec = settings[QueryPlanSerializationSetting::temporary_files_codec];
+    temporary_files_buffer_size = settings[QueryPlanSerializationSetting::temporary_files_buffer_size];
 }
 
 void SortingStep::Settings::updatePlanSettings(QueryPlanSerializationSettings & settings) const
@@ -147,6 +163,8 @@ void SortingStep::Settings::updatePlanSettings(QueryPlanSerializationSettings & 
     settings[QueryPlanSerializationSetting::max_bytes_ratio_before_external_sort] = max_bytes_ratio_before_external_sort;
     settings[QueryPlanSerializationSetting::min_free_disk_space_for_temporary_data] = min_free_disk_space;
     settings[QueryPlanSerializationSetting::prefer_external_sort_block_bytes] = max_block_bytes;
+    settings[QueryPlanSerializationSetting::temporary_files_codec] = temporary_files_codec;
+    settings[QueryPlanSerializationSetting::temporary_files_buffer_size] = temporary_files_buffer_size;
 }
 
 static ITransformingStep::Traits getTraits(size_t limit)
@@ -365,7 +383,12 @@ void SortingStep::mergeSorting(
 
     TemporaryDataOnDiskScopePtr tmp_data_on_disk = nullptr;
     if (auto data = Context::getGlobalContextInstance()->getSharedTempDataOnDisk())
-        tmp_data_on_disk = data->childScope(CurrentMetrics::TemporaryFilesForSort);
+        tmp_data_on_disk = data->childScope({
+            .current_metric = CurrentMetrics::TemporaryFilesForSort,
+            .bytes_compressed = ProfileEvents::ExternalSortCompressedBytes,
+            .bytes_uncompressed = ProfileEvents::ExternalSortUncompressedBytes,
+            .num_files = ProfileEvents::ExternalSortWritePart},
+            sort_settings.temporary_files_buffer_size, sort_settings.temporary_files_codec);
 
     if (sort_settings.max_bytes_in_block_before_external_sort && tmp_data_on_disk == nullptr)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Temporary data storage for external sorting is not provided");

--- a/src/Processors/QueryPlan/SortingStep.h
+++ b/src/Processors/QueryPlan/SortingStep.h
@@ -42,6 +42,8 @@ public:
         size_t min_free_disk_space = 0;
         size_t max_block_bytes = 0;
         size_t read_in_order_use_buffering = 0;
+        size_t temporary_files_buffer_size = 0;
+        String temporary_files_codec = {};
 
         explicit Settings(const DB::Settings & settings);
         explicit Settings(size_t max_block_size_);

--- a/src/Processors/Transforms/MergeSortingTransform.cpp
+++ b/src/Processors/Transforms/MergeSortingTransform.cpp
@@ -17,12 +17,7 @@
 
 namespace ProfileEvents
 {
-    extern const Event ExternalSortWritePart;
     extern const Event ExternalSortMerge;
-    extern const Event ExternalSortCompressedBytes;
-    extern const Event ExternalSortUncompressedBytes;
-    extern const Event ExternalProcessingCompressedBytesTotal;
-    extern const Event ExternalProcessingUncompressedBytesTotal;
 }
 
 
@@ -44,7 +39,6 @@ public:
     {
         outputs.emplace_back(Block(), this);
         LOG_INFO(log, "Sorting and writing part of data into temporary file {}", tmp_stream.getHolder()->describeFilePath());
-        ProfileEvents::increment(ProfileEvents::ExternalSortWritePart);
     }
 
     Status prepare() override
@@ -66,12 +60,6 @@ public:
     void onFinish() override
     {
         auto stat = tmp_stream.finishWriting();
-
-        ProfileEvents::increment(ProfileEvents::ExternalProcessingCompressedBytesTotal, stat.compressed_size);
-        ProfileEvents::increment(ProfileEvents::ExternalProcessingUncompressedBytesTotal, stat.uncompressed_size);
-        ProfileEvents::increment(ProfileEvents::ExternalSortCompressedBytes, stat.compressed_size);
-        ProfileEvents::increment(ProfileEvents::ExternalSortUncompressedBytes, stat.uncompressed_size);
-
         LOG_INFO(log, "Done writing part of data into temporary file {}, compressed {}, uncompressed {} ",
             tmp_stream.getHolder()->describeFilePath(),
             ReadableSize(static_cast<double>(stat.compressed_size)), ReadableSize(static_cast<double>(stat.uncompressed_size)));

--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -175,7 +175,7 @@ public:
     static constexpr auto FILE_ID = "rows_sources";
 
     explicit RowsSourcesTemporaryFile(TemporaryDataOnDiskScopePtr temporary_data_on_disk_)
-        : temporary_data_on_disk(temporary_data_on_disk_->childScope(CurrentMetrics::TemporaryFilesForMerge))
+        : temporary_data_on_disk(temporary_data_on_disk_->childScope({CurrentMetrics::TemporaryFilesForMerge}))
     {
     }
 

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1174,6 +1174,7 @@ class SettingsRandomizer:
         "input_format_parquet_use_native_reader_v3": lambda: min(1, random.randint(0, 5)),
         "enable_lazy_columns_replication": lambda: random.randint(0, 1),
         "allow_special_serialization_kinds_in_output_formats": lambda: random.randint(0, 1),
+        "temporary_files_buffer_size": lambda: random.randint(1, 10 * 1024 * 1024),
         **randomize_external_sort_group_by(),
     }
 

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1174,7 +1174,7 @@ class SettingsRandomizer:
         "input_format_parquet_use_native_reader_v3": lambda: min(1, random.randint(0, 5)),
         "enable_lazy_columns_replication": lambda: random.randint(0, 1),
         "allow_special_serialization_kinds_in_output_formats": lambda: random.randint(0, 1),
-        "temporary_files_buffer_size": lambda: random.randint(1 * 1024 * 1024, 2 * 1024 * 1024),
+        # "temporary_files_buffer_size": lambda: random.randint(1 * 1024 * 1024, 2 * 1024 * 1024),
         **randomize_external_sort_group_by(),
     }
 

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1174,7 +1174,7 @@ class SettingsRandomizer:
         "input_format_parquet_use_native_reader_v3": lambda: min(1, random.randint(0, 5)),
         "enable_lazy_columns_replication": lambda: random.randint(0, 1),
         "allow_special_serialization_kinds_in_output_formats": lambda: random.randint(0, 1),
-        # "temporary_files_buffer_size": lambda: random.randint(1 * 1024 * 1024, 2 * 1024 * 1024),
+        "temporary_files_buffer_size": lambda: random.randint(800 * 1024, 1200 * 1024),
         **randomize_external_sort_group_by(),
     }
 

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1174,7 +1174,7 @@ class SettingsRandomizer:
         "input_format_parquet_use_native_reader_v3": lambda: min(1, random.randint(0, 5)),
         "enable_lazy_columns_replication": lambda: random.randint(0, 1),
         "allow_special_serialization_kinds_in_output_formats": lambda: random.randint(0, 1),
-        "temporary_files_buffer_size": lambda: random.randint(1, 10 * 1024 * 1024),
+        "temporary_files_buffer_size": lambda: random.randint(1 * 1024 * 1024, 2 * 1024 * 1024),
         **randomize_external_sort_group_by(),
     }
 

--- a/tests/integration/test_tmp_policy/test.py
+++ b/tests/integration/test_tmp_policy/test.py
@@ -41,10 +41,10 @@ def test_multiple_local_disk():
     }
 
     assert node_local.contains_in_log(
-        "Setting up .*disk1.* to store temporary data in it"
+        "Setting up temporary data storage at disk 'disk1'"
     )
     assert node_local.contains_in_log(
-        "Setting up .*disk2.* to store temporary data in it"
+        "Setting up temporary data storage at disk 'disk2'"
     )
 
     node_local.query(query, settings=settings)

--- a/tests/queries/0_stateless/02402_external_disk_metrics.reference
+++ b/tests/queries/0_stateless/02402_external_disk_metrics.reference
@@ -1,3 +1,4 @@
 ok
 ok
 ok
+ok

--- a/tests/queries/0_stateless/03514_grace_hash_join_logical_error.sql
+++ b/tests/queries/0_stateless/03514_grace_hash_join_logical_error.sql
@@ -3,8 +3,6 @@ DROP TABLE IF EXISTS A;
 create table A (A Int64, B Int64, S String) Engine=MergeTree order by A
 as select number,number, toString(arrayMap(i->cityHash64(i*number), range(10))) from numbers(1e6);
 
-SET temporary_files_buffer_size=725;
-
 SET join_algorithm = 'grace_hash', grace_hash_join_initial_buckets=128, grace_hash_join_max_buckets=256;
 
 select * from A a join A as b on a.A = b.A limit 1 FORMAT Null;

--- a/tests/queries/0_stateless/03514_grace_hash_join_logical_error.sql
+++ b/tests/queries/0_stateless/03514_grace_hash_join_logical_error.sql
@@ -1,7 +1,9 @@
 DROP TABLE IF EXISTS A;
 
-create table A (A Int64, B Int64, S String) Engine=MergeTree order by A 
+create table A (A Int64, B Int64, S String) Engine=MergeTree order by A
 as select number,number, toString(arrayMap(i->cityHash64(i*number), range(10))) from numbers(1e6);
+
+SET temporary_files_buffer_size=725;
 
 SET join_algorithm = 'grace_hash', grace_hash_join_initial_buckets=128, grace_hash_join_max_buckets=256;
 

--- a/tests/queries/0_stateless/03772_temporary_files_codec.reference
+++ b/tests/queries/0_stateless/03772_temporary_files_codec.reference
@@ -1,0 +1,4 @@
+03772_temporary_files_codec/agg	1	1	1
+03772_temporary_files_codec/grace_join	1	1	1
+03772_temporary_files_codec/partial_merge_join	1	1	1
+03772_temporary_files_codec/sort	1	1	1

--- a/tests/queries/0_stateless/03772_temporary_files_codec.sql
+++ b/tests/queries/0_stateless/03772_temporary_files_codec.sql
@@ -1,0 +1,76 @@
+SET max_bytes_before_external_sort = '1M';
+SET max_bytes_ratio_before_external_sort = 0;
+SET max_block_size = DEFAULT;
+SET max_bytes_before_external_group_by = '1M';
+SET max_bytes_ratio_before_external_group_by = 0;
+SET group_by_two_level_threshold = '100K';
+SET group_by_two_level_threshold_bytes = '50M';
+SET max_memory_usage = '1G';
+
+CREATE TEMPORARY TABLE start_ts AS ( SELECT now() AS ts );
+
+SELECT * FROM (SELECT number, 'payload' FROM numbers(2_000_000)) ORDER BY number
+SETTINGS log_comment='03772_temporary_files_codec/sort', temporary_files_codec = 'NONE'
+FORMAT Null;
+
+SELECT * FROM (SELECT number, 'payload' FROM numbers(2_000_000)) ORDER BY number
+SETTINGS log_comment='03772_temporary_files_codec/sort', temporary_files_codec = 'LZ4'
+FORMAT Null;
+
+SELECT key, sum(val) FROM (SELECT number AS key, number as val FROM numbers(2_000_000)) GROUP BY key
+SETTINGS log_comment='03772_temporary_files_codec/agg', temporary_files_codec = 'NONE'
+FORMAT Null;
+
+SELECT key, sum(val) FROM (SELECT number AS key, number as val FROM numbers(2_000_000)) GROUP BY key
+SETTINGS log_comment='03772_temporary_files_codec/agg', temporary_files_codec = 'LZ4'
+FORMAT Null;
+
+SELECT key, sum(val) FROM (SELECT number AS key, number as val FROM numbers(2_000_000)) GROUP BY key
+SETTINGS log_comment='03772_temporary_files_codec/agg', temporary_files_codec = 'NONE'
+FORMAT Null;
+
+SET max_bytes_in_join = '1M';
+SET join_algorithm = 'grace_hash', grace_hash_join_initial_buckets = 32, grace_hash_join_max_buckets = 32;
+
+SELECT * FROM (SELECT number AS key, number as val FROM numbers(200_000)) t1
+JOIN (SELECT number AS key FROM numbers(200_000)) t2
+USING key
+SETTINGS log_comment='03772_temporary_files_codec/grace_join', temporary_files_codec = 'NONE'
+FORMAT Null;
+
+SELECT * FROM (SELECT number AS key, number as val FROM numbers(200_000)) t1
+JOIN (SELECT number AS key FROM numbers(200_000)) t2
+USING key
+SETTINGS log_comment='03772_temporary_files_codec/grace_join', temporary_files_codec = 'LZ4'
+FORMAT Null;
+
+SET join_algorithm = 'partial_merge';
+
+SELECT * FROM (SELECT number AS key, number as val FROM numbers(200_000)) t1
+JOIN (SELECT number AS key FROM numbers(200_000)) t2
+USING key
+SETTINGS log_comment='03772_temporary_files_codec/partial_merge_join', temporary_files_codec = 'NONE'
+FORMAT Null;
+
+SELECT * FROM (SELECT number AS key, number as val FROM numbers(200_000)) t1
+JOIN (SELECT number AS key FROM numbers(200_000)) t2
+USING key
+SETTINGS log_comment='03772_temporary_files_codec/partial_merge_join', temporary_files_codec = 'LZ4'
+FORMAT Null;
+
+SYSTEM FLUSH LOGS system.query_log;
+
+SELECT
+    log_comment,
+    (sumIf(ProfileEvents['ExternalProcessingCompressedBytesTotal'], Settings['temporary_files_codec'] = 'LZ4') AS with_compression) > 0,
+    (sumIf(ProfileEvents['ExternalProcessingUncompressedBytesTotal'], Settings['temporary_files_codec'] = 'NONE') AS without_compression) > 0,
+    with_compression < without_compression
+FROM system.query_log
+WHERE event_date >= yesterday() AND event_time >= (SELECT ts FROM start_ts)
+    AND current_database = currentDatabase()
+    AND type != 1
+    AND log_comment like '03772_temporary_files_codec/%'
+GROUP BY log_comment
+ORDER BY log_comment
+;
+

--- a/tests/queries/0_stateless/03772_temporary_files_codec.sql
+++ b/tests/queries/0_stateless/03772_temporary_files_codec.sql
@@ -1,3 +1,4 @@
+-- Tags: long
 SET max_bytes_before_external_sort = '1M';
 SET max_bytes_ratio_before_external_sort = 0;
 SET max_block_size = DEFAULT;


### PR DESCRIPTION
### Changelog category (leave one):

- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
External aggregation/sorting/join now respect query setting temporary_files_codec in all contexts. Fixed missing profile events for grace hash join

Close https://github.com/ClickHouse/ClickHouse/issues/90174 (no issue there, we just cannot randomize `temporary_files_buffer_size` a lot, since in test run with s3 setup we have only 1G tmp storage and with small buffer size we flush a lot)