### PR TITLE
Fix watch callback for Keeper integration tests

### DIFF
--- a/tests/integration/test_keeper_back_to_back/test.py
+++ b/tests/integration/test_keeper_back_to_back/test.py
@@ -254,6 +254,8 @@ def test_watchers(started_cluster, request):
         genuine_data_watch_data = None
 
         def genuine_callback(event):
+            if not keeper_utils.is_znode_watch_event(event):
+                return
             print("Genuine data watch called")
             nonlocal genuine_data_watch_data
             genuine_data_watch_data = event
@@ -261,6 +263,8 @@ def test_watchers(started_cluster, request):
         fake_data_watch_data = None
 
         def fake_callback(event):
+            if not keeper_utils.is_znode_watch_event(event):
+                return
             print("Fake data watch called")
             nonlocal fake_data_watch_data
             fake_data_watch_data = event
@@ -284,6 +288,8 @@ def test_watchers(started_cluster, request):
         genuine_children = None
 
         def genuine_child_callback(event):
+            if not keeper_utils.is_znode_watch_event(event):
+                return
             print("Genuine child watch called")
             nonlocal genuine_children
             genuine_children = event
@@ -291,6 +297,8 @@ def test_watchers(started_cluster, request):
         fake_children = None
 
         def fake_child_callback(event):
+            if not keeper_utils.is_znode_watch_event(event):
+                return
             print("Fake child watch called")
             nonlocal fake_children
             fake_children = event
@@ -327,6 +335,8 @@ def test_watchers(started_cluster, request):
         genuine_children_delete = None
 
         def genuine_child_delete_callback(event):
+            if not keeper_utils.is_znode_watch_event(event):
+                return
             print("Genuine child watch called")
             nonlocal genuine_children_delete
             genuine_children_delete = event
@@ -334,6 +344,8 @@ def test_watchers(started_cluster, request):
         fake_children_delete = None
 
         def fake_child_delete_callback(event):
+            if not keeper_utils.is_znode_watch_event(event):
+                return
             print("Fake child watch called")
             nonlocal fake_children_delete
             fake_children_delete = event
@@ -341,6 +353,8 @@ def test_watchers(started_cluster, request):
         genuine_child_delete = None
 
         def genuine_own_delete_callback(event):
+            if not keeper_utils.is_znode_watch_event(event):
+                return
             print("Genuine child watch called")
             nonlocal genuine_child_delete
             genuine_child_delete = event
@@ -348,6 +362,8 @@ def test_watchers(started_cluster, request):
         fake_child_delete = None
 
         def fake_own_delete_callback(event):
+            if not keeper_utils.is_znode_watch_event(event):
+                return
             print("Fake child watch called")
             nonlocal fake_child_delete
             fake_child_delete = event
@@ -614,6 +630,8 @@ def test_end_of_session(started_cluster, request):
         fake_ephemeral_event = None
 
         def fake_ephemeral_callback(event):
+            if not keeper_utils.is_znode_watch_event(event):
+                return
             print("Fake watch triggered")
             nonlocal fake_ephemeral_event
             fake_ephemeral_event = event
@@ -621,6 +639,8 @@ def test_end_of_session(started_cluster, request):
         genuine_ephemeral_event = None
 
         def genuine_ephemeral_callback(event):
+            if not keeper_utils.is_znode_watch_event(event):
+                return
             print("Genuine watch triggered")
             nonlocal genuine_ephemeral_event
             genuine_ephemeral_event = event
@@ -684,6 +704,8 @@ def test_end_of_watches_session(started_cluster, request):
         dummy_set = 0
 
         def dummy_callback(event):
+            if not keeper_utils.is_znode_watch_event(event):
+                return
             nonlocal dummy_set
             dummy_set += 1
             print(event)
@@ -743,6 +765,8 @@ def test_concurrent_watches(started_cluster, request):
 
             # new function each time
             def dumb_watch(event):
+                if not keeper_utils.is_znode_watch_event(event):
+                    return
                 nonlocal dumb_watch_triggered_counter
                 dumb_watch_triggered_counter += 1
                 nonlocal all_paths_triggered

--- a/tests/integration/test_keeper_multinode_simple/test.py
+++ b/tests/integration/test_keeper_multinode_simple/test.py
@@ -7,6 +7,8 @@ from helpers.cluster import ClickHouseCluster
 from helpers.network import PartitionManager
 from helpers.test_tools import assert_eq_with_retry
 
+import uuid
+
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance(
     "node1",
@@ -56,8 +58,9 @@ def test_read_write_multinode(started_cluster):
         node3_zk = get_fake_zk("node3")
 
         # Cleanup
-        if node1_zk.exists("/test_read_write_multinode_node1") != None:
-            node1_zk.delete("/test_read_write_multinode_node1")
+        for i in range(1, 4):
+            if node1_zk.exists(f"/test_read_write_multinode_node{i}") != None:
+                node1_zk.delete(f"/test_read_write_multinode_node{i}")
 
         node1_zk.create("/test_read_write_multinode_node1", b"somedata1")
         node2_zk.create("/test_read_write_multinode_node2", b"somedata2")
@@ -240,18 +243,19 @@ def test_follower_restart(started_cluster):
 
 def test_simple_replicated_table(started_cluster):
     wait_nodes()
+    test_name = f"test_simple_replicated_table_{uuid.uuid4().hex}"
 
     for i, node in enumerate([node1, node2, node3]):
-        node.query("DROP TABLE IF EXISTS t SYNC")
+        node.query(f"DROP TABLE IF EXISTS {test_name} SYNC")
         node.query(
-            f"CREATE TABLE t (value UInt64) ENGINE = ReplicatedMergeTree('/clickhouse/t', '{i + 1}') ORDER BY tuple()"
+            f"CREATE TABLE {test_name} (value UInt64) ENGINE = ReplicatedMergeTree('/clickhouse/{test_name}', '{i + 1}') ORDER BY tuple()"
         )
 
-    node2.query("INSERT INTO t SELECT number FROM numbers(10)")
+    node2.query(f"INSERT INTO {test_name} SELECT number FROM numbers(10)")
 
-    node1.query("SYSTEM SYNC REPLICA t", timeout=10)
-    node3.query("SYSTEM SYNC REPLICA t", timeout=10)
+    node1.query(f"SYSTEM SYNC REPLICA {test_name}", timeout=10)
+    node3.query(f"SYSTEM SYNC REPLICA {test_name}", timeout=10)
 
-    assert_eq_with_retry(node1, "SELECT COUNT() FROM t", "10")
-    assert_eq_with_retry(node2, "SELECT COUNT() FROM t", "10")
-    assert_eq_with_retry(node3, "SELECT COUNT() FROM t", "10")
+    assert_eq_with_retry(node1, f"SELECT COUNT() FROM {test_name}", "10")
+    assert_eq_with_retry(node2, f"SELECT COUNT() FROM {test_name}", "10")
+    assert_eq_with_retry(node3, f"SELECT COUNT() FROM {test_name}", "10")

--- a/tests/integration/test_keeper_multinode_simple/test.py
+++ b/tests/integration/test_keeper_multinode_simple/test.py
@@ -112,6 +112,8 @@ def test_watch_on_follower(started_cluster):
         node1_data = None
 
         def node1_callback(event):
+            if not keeper_utils.is_znode_watch_event(event):
+                return
             print("node1 data watch called")
             nonlocal node1_data
             node1_data = event
@@ -121,6 +123,8 @@ def test_watch_on_follower(started_cluster):
         node2_data = None
 
         def node2_callback(event):
+            if not keeper_utils.is_znode_watch_event(event):
+                return
             print("node2 data watch called")
             nonlocal node2_data
             node2_data = event
@@ -130,6 +134,8 @@ def test_watch_on_follower(started_cluster):
         node3_data = None
 
         def node3_callback(event):
+            if not keeper_utils.is_znode_watch_event(event):
+                return
             print("node3 data watch called")
             nonlocal node3_data
             node3_data = event


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

kazoo client can produce client-side watch events (e.g. on reconnect).
This can mess up some tests that depend on exact amount of watch triggers or on the data returned.

Example of failure https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=f7acb9b8013d09dfeaca0d34a1627e58adadfc79&name_0=MasterCI&name_1=Integration%20tests%20%28amd_tsan%2C%202%2F6%29&name_1=Integration%20tests%20%28amd_tsan%2C%202%2F6%29

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
