### PR TITLE
BuzzHouse fix for Materialized views

### DIFF
--- a/src/Client/BuzzHouse/Generator/StatementGenerator.cpp
+++ b/src/Client/BuzzHouse/Generator/StatementGenerator.cpp
@@ -555,7 +555,7 @@ void StatementGenerator::generateNextCreateView(RandomGenerator & rg, CreateView
         const auto & table_to_lambda = [&view_ncols, &next](const SQLTable & t)
         { return t.isAttached() && t.cols.size() >= view_ncols && (t.is_deterministic || !next.is_deterministic); };
         next.has_with_cols = collectionHas<SQLTable>(table_to_lambda);
-        const bool has_tables = next.has_with_cols || !tables.empty();
+        const bool has_tables = collectionHas<SQLTable>(attached_tables);
         const bool has_to
             = !replace && nopt > 6 && (next.has_with_cols || has_tables) && rg.nextSmallNumber() < (next.has_with_cols ? 9 : 6);
 


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

In the last PR, I changed the logic to use existing tables only for `TO` Materialized Views, but I didn't realize it didn't check correctly if there was any available beforehand. Fixes this SEGV: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=b93a24d8f9acbcaaac1130e72ff723195d9a76d6&name_0=MasterCI&name_1=BuzzHouse+%28amd_ubsan%29

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
