### PR TITLE
Add a test test_string_serialization_version_alter.py

### DIFF
--- a/tests/integration/test_backward_compatibility/test_string_serialization_version_alter.py
+++ b/tests/integration/test_backward_compatibility/test_string_serialization_version_alter.py
@@ -1,0 +1,47 @@
+import pytest
+
+from helpers.cluster import CLICKHOUSE_CI_MIN_TESTED_VERSION, ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+node1 = cluster.add_instance(
+    "node1",
+    with_zookeeper=False,
+    image="clickhouse/clickhouse-server",
+    tag=CLICKHOUSE_CI_MIN_TESTED_VERSION,
+    with_installed_binary=True,
+    stay_alive=True,
+)
+
+
+@pytest.fixture(scope="module")
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+
+def test_strings_update_add_column(start_cluster):
+    node1.query("create table tab (s String) engine = MergeTree order by tuple() settings min_bytes_for_wide_part=1")
+    node1.query("insert into tab select 'abc'")
+    assert('abc\n' == node1.query("select s from tab"))
+
+    node1.restart_with_latest_version();
+
+    node1.query("alter table tab add column s3 String default 'def' settings alter_sync=2")
+    node1.query("alter table tab MATERIALIZE column s3 settings alter_sync=2, allow_experimental_statistics=1")
+    assert('abc\tdef\n' == node1.query("select s, s3 from tab"))
+
+
+def test_strings_and_update(start_cluster):
+    node1.query("create table tab (s String, x UInt32) engine = MergeTree order by tuple() settings min_bytes_for_wide_part=1")
+    node1.query("insert into tab select 'abc', 1")
+    assert('abc\n' == node1.query("select s from tab"))
+
+    node1.restart_with_latest_version();
+
+    node1.query("alter table tab add statistics x type Uniq settings alter_sync=2, allow_experimental_statistics=1")
+    node1.query("alter table tab MATERIALIZE STATISTICS ALL settings alter_sync=2, allow_experimental_statistics=1")
+    assert('abc\n' == node1.query("select s from tab"))

--- a/tests/integration/test_backward_compatibility/test_string_serialization_version_alter.py
+++ b/tests/integration/test_backward_compatibility/test_string_serialization_version_alter.py
@@ -7,7 +7,7 @@ node1 = cluster.add_instance(
     "node1",
     with_zookeeper=False,
     image="clickhouse/clickhouse-server",
-    tag=CLICKHOUSE_CI_MIN_TESTED_VERSION,
+    tag="25.10",
     with_installed_binary=True,
     stay_alive=True,
 )
@@ -25,14 +25,17 @@ def start_cluster():
 
 def test_strings_update_add_column(start_cluster):
     node1.query("create table tab (s String) engine = MergeTree order by tuple() settings min_bytes_for_wide_part=1")
-    node1.query("insert into tab select 'abc'")
-    assert('abc\n' == node1.query("select s from tab"))
+    node1.query("insert into tab select 'abc' || toString(number) from numbers(100)")
+    assert('100\n' == node1.query("select count() from tab where not ignore(*)"))
 
-    node1.restart_with_latest_version();
+    node1.restart_with_latest_version()
 
     node1.query("alter table tab add column s3 String default 'def' settings alter_sync=2")
-    node1.query("alter table tab MATERIALIZE column s3 settings alter_sync=2, allow_experimental_statistics=1")
-    assert('abc\tdef\n' == node1.query("select s, s3 from tab"))
+    node1.query("alter table tab MATERIALIZE column s3 settings alter_sync=2, mutations_sync=2, allow_experimental_statistics=1")
+    node1.query("detach table tab")
+    node1.query("attach table tab")
+    assert('abc99\tdef\n' == node1.query("select max(s), max(s3) from tab"))
+    # assert('1' == node1.query('check table tab'))
 
 
 def test_strings_and_update(start_cluster):
@@ -40,8 +43,10 @@ def test_strings_and_update(start_cluster):
     node1.query("insert into tab select 'abc', 1")
     assert('abc\n' == node1.query("select s from tab"))
 
-    node1.restart_with_latest_version();
+    node1.restart_with_latest_version()
 
     node1.query("alter table tab add statistics x type Uniq settings alter_sync=2, allow_experimental_statistics=1")
     node1.query("alter table tab MATERIALIZE STATISTICS ALL settings alter_sync=2, allow_experimental_statistics=1")
+    node1.query("detach table tab")
+    node1.query("attach table tab")
     assert('abc\n' == node1.query("select s from tab"))


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description]
Add a test `test_string_serialization_version_alter.py`

```
$ ls test_backward_compatibility/_instances-string_serialization_version_alter/node1/database/store/b5a/b5a78b27-787a-4a63-b611-3eccea53639a/all_1_1_0_2
checksums.txt  columns.txt  count.txt  default_compression_codec.txt  metadata_version.txt  s.bin  s.mrk2  s3.bin  s3.mrk2  s3.size.bin  s3.size.mrk2  serialization.json

$ cat test_backward_compatibility/_instances-string_serialization_version_alter/node1/database/store/b5a/b5a78b27-787a-4a63-b611-3eccea53639a/all_1_1_0_2/serialization.json 
{"columns":[{"kind":"Default","name":"s3","num_defaults":0,"num_rows":1}],"types_serialization_versions":{"string":1},"version":1}

```