### PR TITLE
Fix logical error with create as url cluster and database replicated

### DIFF
--- a/src/TableFunctions/TableFunctionURL.cpp
+++ b/src/TableFunctions/TableFunctionURL.cpp
@@ -93,29 +93,34 @@ void TableFunctionURL::parseArgumentsImpl(ASTs & args, const ContextPtr & contex
 }
 
 StoragePtr TableFunctionURL::getStorage(
-    const String & source, const String & format_, const ColumnsDescription & columns, ContextPtr global_context,
+    const String & source, const String & format_, const ColumnsDescription & columns, ContextPtr context,
     const std::string & table_name, const String & compression_method_, bool is_insert_query) const
 {
-    const auto & settings = global_context->getSettingsRef();
-    const auto is_secondary_query = global_context->getClientInfo().query_kind == ClientInfo::QueryKind::SECONDARY_QUERY;
+    const auto & settings = context->getSettingsRef();
+    const auto is_secondary_query = context->getClientInfo().query_kind == ClientInfo::QueryKind::SECONDARY_QUERY;
     const auto parallel_replicas_cluster_name = settings[Setting::cluster_for_parallel_replicas].toString();
-    const auto can_use_parallel_replicas = !parallel_replicas_cluster_name.empty()
+    const bool can_use_parallel_replicas = !parallel_replicas_cluster_name.empty()
         && settings[Setting::parallel_replicas_for_cluster_engines]
-        && global_context->canUseTaskBasedParallelReplicas()
-        && !global_context->isDistributed()
+        && context->canUseTaskBasedParallelReplicas()
+        && !context->isDistributed()
         && !is_secondary_query
         && !is_insert_query;
+
+    const auto & client_info = context->getClientInfo();
+    bool can_use_distributed_iterator =
+        client_info.collaborate_with_initiator &&
+        context->hasClusterFunctionReadTaskCallback();
 
     if (can_use_parallel_replicas)
     {
         return std::make_shared<StorageURLCluster>(
-            global_context,
+            context,
             parallel_replicas_cluster_name,
             source,
             format_,
             compression_method_,
             StorageID(getDatabaseName(), table_name),
-            getActualTableStructure(global_context, true),
+            getActualTableStructure(context, true),
             ConstraintsDescription{},
             configuration);
     }
@@ -128,12 +133,12 @@ StoragePtr TableFunctionURL::getStorage(
         columns,
         ConstraintsDescription{},
         String{},
-        global_context,
+        context,
         compression_method_,
         configuration.headers,
         configuration.http_method,
         nullptr,
-        /*distributed_processing=*/ is_secondary_query);
+        /*distributed_processing=*/can_use_distributed_iterator);
 }
 
 ColumnsDescription TableFunctionURL::getActualTableStructure(ContextPtr context, bool /*is_insert_query*/) const

--- a/tests/queries/0_stateless/03762_create_as_url_cluster.reference
+++ b/tests/queries/0_stateless/03762_create_as_url_cluster.reference
@@ -1,0 +1,1 @@
+shard1	replica1	OK	0	0

--- a/tests/queries/0_stateless/03762_create_as_url_cluster.sql
+++ b/tests/queries/0_stateless/03762_create_as_url_cluster.sql
@@ -1,3 +1,6 @@
+-- Tags: no-replicated-database
+-- no-replicated-database: It messes up the output and this test explicitly checks the replicated database
+
 DROP DATABASE {CLICKHOUSE_DATABASE:Identifier};
 CREATE DATABASE {CLICKHOUSE_DATABASE:Identifier} ENGINE = Replicated('/clickhouse/03762_create_as_url_cluster/{database}_replicated', 'shard1', 'replica1') FORMAT Null;
 CREATE TABLE {CLICKHOUSE_DATABASE:Identifier}.test (c0 Int) ENGINE = Memory AS (SELECT 1 FROM url('http://localhost:8123/?query=SELECT+1+FORMAT+Values', 'Values', 'c0 Int') tx)

--- a/tests/queries/0_stateless/03762_create_as_url_cluster.sql
+++ b/tests/queries/0_stateless/03762_create_as_url_cluster.sql
@@ -1,0 +1,3 @@
+DROP DATABASE {CLICKHOUSE_DATABASE:Identifier};
+CREATE DATABASE {CLICKHOUSE_DATABASE:Identifier} ENGINE = Replicated('/clickhouse/03762_create_as_url_cluster/{database}_replicated', 'shard1', 'replica1') FORMAT Null;
+CREATE TABLE {CLICKHOUSE_DATABASE:Identifier}.test (c0 Int) ENGINE = Memory AS (SELECT 1 FROM url('http://localhost:8123/?query=SELECT+1+FORMAT+Values', 'Values', 'c0 Int') tx)


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix logical error with `CREATE TABLE ... AS urlCluster()` and database engine `Replicated`. Closes https://github.com/ClickHouse/ClickHouse/issues/92216.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
