### PR TITLE
ci: fix obtaining stacktraces for unit tests

### DIFF
--- a/ci/jobs/unit_tests_job.py
+++ b/ci/jobs/unit_tests_job.py
@@ -5,7 +5,7 @@ if __name__ == "__main__":
     # Note, LSan does not compatible with debugger
     if "asan" not in Info().job_name:
         # With gdb we will capture stacktrace in case of abnormal termination and timeout (45 mins)
-        command_launcher = f"timeout -v 45m gdb -batch -ex 'handle all nostop' -ex 'set print thread-events off' -ex run -ex bt -ex 'thread apply all bt' -arg"
+        command_launcher = f"timeout -s INT -v 45m gdb -batch -ex 'handle all nostop' -ex 'set print thread-events off' -ex run -ex bt -ex 'thread apply all bt' -arg"
     else:
         command_launcher = ""
 


### PR DESCRIPTION
gdb does not handle TERM gracefuly, only INT [1].

  [1]: https://pastila.nl/?003812c5/86afb3394bf9e2bc1e464491ffbde6a9#/5AX51nHpLPBNC6lj85bOQ==

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes: https://github.com/ClickHouse/ClickHouse/issues/87123