### PR TITLE
Fix docs for `dictGetKeys`

### DIFF
--- a/src/Functions/FunctionDictGetKeys.cpp
+++ b/src/Functions/FunctionDictGetKeys.cpp
@@ -553,7 +553,7 @@ This is most effective with large dictionaries when the input has low cardinalit
 SELECT dictGetKeys('task_id_to_priority_dictionary', 'priority_level', 'high') AS ids;
     )",
             R"(
-┌─-ids──┐
+┌─ids───┐
 │ [4,2] │
 └───────┘
     )"}};


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)
