### PR TITLE
CI: Fix FuzzerLogParser to return files list for reproduce commands

### DIFF
--- a/ci/jobs/ast_fuzzer_job.py
+++ b/ci/jobs/ast_fuzzer_job.py
@@ -175,7 +175,7 @@ def run_fuzz_job(check_name: str):
                 workspace_path / "fuzzerout.sql" if buzzhouse else fuzzer_log
             ),
         )
-        parsed_name, parsed_info = fuzzer_log_parser.parse_failure()
+        parsed_name, parsed_info, files = fuzzer_log_parser.parse_failure()
 
         if parsed_name:
             results.append(
@@ -183,6 +183,7 @@ def run_fuzz_job(check_name: str):
                     name=parsed_name,
                     info=parsed_info,
                     status=Result.StatusExtended.FAIL,
+                    files=files,
                 )
             )
 

--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -864,12 +864,13 @@ clickhouse-client --query "SELECT count() FROM test.visits"
                         stderr_log=str(stderr_log),
                         fuzzer_log="",
                     )
-                    name, description = log_parser.parse_failure()
+                    name, description, files = log_parser.parse_failure()
                     results.append(
                         Result.create_from(
                             name=name,
                             info=description,
                             status=Result.StatusExtended.FAIL,
+                            files=files,
                         )
                     )
                 except Exception:

--- a/ci/jobs/scripts/log_parser.py
+++ b/ci/jobs/scripts/log_parser.py
@@ -53,6 +53,7 @@ class FuzzerLogParser:
         self.stack_trace_str = stack_trace_str
 
     def parse_failure(self):
+        files = []
         is_logical_error = False
         is_sanitizer_error = False
         is_killed_by_signal = False
@@ -123,7 +124,11 @@ class FuzzerLogParser:
                 break
 
         if not error_output:
-            return self.UNKNOWN_ERROR, "Lost connection to server. See the logs.\n"
+            return (
+                self.UNKNOWN_ERROR,
+                "Lost connection to server. See the logs.\n",
+                files,
+            )
 
         error_lines = error_output.splitlines()
         result_name = error_lines[0].removesuffix(".")
@@ -263,11 +268,11 @@ class FuzzerLogParser:
         if reproduce_commands:
             info += "---\n\nReproduce commands (auto-generated; may require manual adjustment):\n"
             if len(reproduce_commands) > self.MAX_INLINE_REPRODUCE_COMMANDS:
-                reproduce_file_sql = workspace_path / "reproduce_commands.sql"
+                reproduce_file_sql = "reproduce_commands.sql"
                 try:
                     with open(reproduce_file_sql, "w") as f:
                         f.write("\n".join(reproduce_commands))
-                    paths.append(reproduce_file_sql)
+                    files.append(reproduce_file_sql)
                     info += f"See file: {reproduce_file_sql}\n"
                 except IOError as write_error:
                     info += f"Failed to write reproduce commands file: {write_error}\n"
@@ -277,7 +282,7 @@ class FuzzerLogParser:
             info += "---\n\nStack trace:\n"
             info += stack_trace + "\n"
 
-        return result_name, info
+        return result_name, info, files
 
     def get_sanitizer_stack_trace(self):
         # return all lines after Sanitizer error starting with "    #DIGITS "
@@ -567,6 +572,6 @@ if __name__ == "__main__":
     server_log = "./no_stid/server.log"
     FTG = FuzzerLogParser(server_log, fuzzer_log)
     # FTG2 = FuzzerLogParser("", "", stack_trace_str="...")
-    result_name, info = FTG.parse_failure()
+    result_name, info, files = FTG.parse_failure()
     print("Result name:", result_name)
     print("Info:\n", info)

--- a/ci/jobs/stress_job.py
+++ b/ci/jobs/stress_job.py
@@ -254,10 +254,13 @@ def run_stress_test(upgrade_check: bool = False) -> None:
                 stderr_log=stderr_log if stderr_log.exists() else "",
                 fuzzer_log="",
             )
-            name, description = log_parser.parse_failure()
+            name, description, files = log_parser.parse_failure()
             test_results.append(
                 Result.create_from(
-                    name=name, info=description, status=Result.StatusExtended.FAIL
+                    name=name,
+                    info=description,
+                    status=Result.StatusExtended.FAIL,
+                    files=files,
                 )
             )
 

--- a/ci/praktika/utils.py
+++ b/ci/praktika/utils.py
@@ -979,12 +979,7 @@ class TeePopen:
         # Search backwards for "Traceback"
         for i in range(len(buffer) - 1, -1, -1):
             if "Traceback" in buffer[i]:
-                return "\n".join(buffer[i:])
+                return "".join(buffer[i:])
 
         # Fallback: return last max_lines
-        return "\n".join(buffer[-max_lines:])
-
-
-if __name__ == "__main__":
-
-    Utils.compress_gz("/tmp/test/")
+        return "".join(buffer[-max_lines:])


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

```
Traceback (most recent call last):
  File "/home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/./ci/jobs/ast_fuzzer_job.py", line 209, in <module>
    run_fuzz_job(check_name)
  File "/home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/./ci/jobs/ast_fuzzer_job.py", line 178, in run_fuzz_job
    parsed_name, parsed_info = fuzzer_log_parser.parse_failure()
  File "/home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/ci/jobs/scripts/log_parser.py", line 266, in parse_failure
    reproduce_file_sql = workspace_path / "reproduce_commands.sql"
NameError: name 'workspace_path' is not defined
```
