### PR TITLE
Sccache: second attempt

### DIFF
--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -6,9 +6,10 @@ from ci.defs.defs import ArtifactNames, BuildTypes, JobNames, RunnerLabels
 LIMITED_MEM = Utils.physical_memory() - 2 * 1024**3
 
 BINARY_DOCKER_COMMAND = (
-    "clickhouse/binary-builder+--network=host+"
-    f"--memory={Utils.physical_memory() * 95 // 100}+"
-    f"--memory-reservation={Utils.physical_memory() * 9 // 10}"
+    "clickhouse/binary-builder+--network=host"
+    f"+--memory={Utils.physical_memory() * 95 // 100}"
+    f"+--memory-reservation={Utils.physical_memory() * 9 // 10}"
+    f"+--volume=.:/ClickHouse+--workdir=/ClickHouse"
 )
 
 if Utils.is_arm():
@@ -105,12 +106,6 @@ common_integration_test_job_config = Job.Config(
     run_in_docker=f"clickhouse/integration-tests-runner+root+--memory={LIMITED_MEM}+--privileged+--dns-search='.'+--security-opt seccomp=unconfined+--cap-add=SYS_PTRACE+{docker_sock_mount}+--volume=clickhouse_integration_tests_volume:/var/lib/docker+--cgroupns=host",
 )
 
-BINARY_DOCKER_COMMAND = (
-    "clickhouse/binary-builder+--network=host+"
-    f"--memory={Utils.physical_memory() * 95 // 100}+"
-    f"--memory-reservation={Utils.physical_memory() * 9 // 10}"
-)
-
 
 class JobConfigs:
     style_check = Job.Config(
@@ -133,7 +128,7 @@ class JobConfigs:
         command="python3 ./ci/jobs/fast_test.py",
         # --network=host required for ec2 metadata http endpoint to work
         # --root/--privileged/--cgroupns=host is required for clickhouse-test --memory-limit
-        run_in_docker="clickhouse/fasttest+--network=host+--privileged+--cgroupns=host+--volume=./ci/tmp/var/lib/clickhouse:/var/lib/clickhouse+--volume=./ci/tmp/etc/clickhouse-client:/etc/clickhouse-client+--volume=./ci/tmp/etc/clickhouse-server:/etc/clickhouse-server+--volume=./ci/tmp/var/log:/var/log+root",
+        run_in_docker="clickhouse/fasttest+--network=host+--privileged+--cgroupns=host+--volume=./ci/tmp/var/lib/clickhouse:/var/lib/clickhouse+--volume=./ci/tmp/etc/clickhouse-client:/etc/clickhouse-client+--volume=./ci/tmp/etc/clickhouse-server:/etc/clickhouse-server+--volume=./ci/tmp/var/log:/var/log+--volume=.:/ClickHouse+--workdir=/ClickHouse+root",
         digest_config=Job.CacheDigestConfig(
             include_paths=[
                 "./ci/jobs/fast_test.py",

--- a/ci/jobs/build_clickhouse.py
+++ b/ci/jobs/build_clickhouse.py
@@ -107,14 +107,24 @@ def main():
 
     cmake_cmd = BUILD_TYPE_TO_CMAKE[build_type]
     info = Info()
-    if not info.is_local_run:
+    # Global sccache settings for local and CI runs
+    os.environ["SCCACHE_DIR"] = f"{temp_dir}/sccache"
+    os.environ["SCCACHE_CACHE_SIZE"] = "40G"
+    os.environ["SCCACHE_IDLE_TIMEOUT"] = "7200"
+    os.environ["SCCACHE_BUCKET"] = Settings.S3_ARTIFACT_PATH
+    os.environ["SCCACHE_S3_KEY_PREFIX"] = "ccache/sccache"
+    os.environ["SCCACHE_ERROR_LOG"] = f"{build_dir}/sccache.log"
+    os.environ["SCCACHE_LOG"] = "info"
+
+    os.makedirs(build_dir, exist_ok=True)
+
+    if info.is_local_run:
+        os.environ["SCCACHE_S3_NO_CREDENTIALS"] = "true"
+    else:
         # Default timeout (10min), can be too low, we run this in docker
         # anyway, will be terminated once the build is finished
-        os.environ["SCCACHE_IDLE_TIMEOUT"] = "7200"
-        os.environ["SCCACHE_BUCKET"] = Settings.S3_ARTIFACT_PATH
-        os.environ["SCCACHE_S3_KEY_PREFIX"] = "ccache/sccache"
         os.environ["CTCACHE_LOG_LEVEL"] = "debug"
-        os.environ["CTCACHE_DIR"] = f"{build_dir}/ccache/clang-tidy-cache"
+        os.environ["CTCACHE_DIR"] = f"{temp_dir}/ccache/clang-tidy-cache"
         os.environ["CTCACHE_S3_BUCKET"] = Settings.S3_ARTIFACT_PATH
         os.environ["CTCACHE_S3_FOLDER"] = "ccache/clang-tidy-cache"
 

--- a/ci/jobs/scripts/log_parser.py
+++ b/ci/jobs/scripts/log_parser.py
@@ -339,11 +339,6 @@ class FuzzerLogParser:
             if match:
                 # Extract only the part after the pattern
                 extracted = line[match.end() :]
-                # Remove everything before and including 'ClickHouse/' if present
-                if "ClickHouse/" in extracted:
-                    extracted = extracted.split("ClickHouse/")[-1]
-                elif "/./" in extracted:
-                    extracted = extracted.split("/./")[-1]
                 # Only append if there's meaningful content after extraction
                 if extracted.strip():
                     lines.append(extracted)

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -306,6 +306,7 @@ class Runner:
 
             docker = docker or f"{docker_name}:{docker_tag}"
             current_dir = os.getcwd()
+            workdir = f"--workdir={current_dir}"
             for setting in settings:
                 if setting.startswith("--volume"):
                     volume = setting.removeprefix("--volume=").split(":")[0]
@@ -314,6 +315,11 @@ class Runner:
                             "WARNING: Create mount dir point in advance to have the same owner"
                         )
                         Shell.check(f"mkdir -p {volume}", verbose=True, strict=True)
+                elif setting.startswith("--workdir"):
+                    print(
+                        f"NOTE: Job [{job.name}] use custom workdir - praktika won't control workdir"
+                    )
+                    workdir = ""
             Shell.check(
                 "docker ps -a --format '{{.Names}}' | grep -q praktika && docker rm -f praktika",
                 verbose=True,
@@ -333,7 +339,7 @@ class Runner:
             for p_ in [path, path_1]:
                 if p_ and Path(p_).exists() and p_.startswith("/"):
                     extra_mounts += f" --volume {p_}:{p_}"
-            cmd = f"docker run {tty} --rm --name praktika {'--user $(id -u):$(id -g)' if not from_root else ''} -e PYTHONUNBUFFERED=1 -e PYTHONPATH='.:./ci' --volume ./:{current_dir} {extra_mounts} {gh_mount} --workdir={current_dir} {' '.join(settings)} {docker} {job.command}"
+            cmd = f"docker run {tty} --rm --name praktika {'--user $(id -u):$(id -g)' if not from_root else ''} -e PYTHONUNBUFFERED=1 -e PYTHONPATH='.:./ci' --volume ./:{current_dir} {extra_mounts} {gh_mount} {workdir} {' '.join(settings)} {docker} {job.command}"
         else:
             cmd = job.command
             python_path = os.getenv("PYTHONPATH", ":")

--- a/ci/workflows/pull_request.py
+++ b/ci/workflows/pull_request.py
@@ -154,6 +154,7 @@ workflow = Workflow.Config(
             0
         ].name,  # plain integration test job, no old analyzer, no dist plan
         "functional": PLAIN_FUNCTIONAL_TEST_JOB.name,
+        "build": "Build (amd_binary)",
     },
 )
 


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

---

- Makes build directory stable and absolute to the `/` regardless of the environment.
- Enables sccache for local run with `python -m ci.praktika build`


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.760`
<!-- ch-version-info:end -->