### PR TITLE
tests: optimize 02126_dist_desc by removing redudant SYSTEM FLUSH LOGS

### DIFF
--- a/tests/queries/0_stateless/02126_dist_desc.reference
+++ b/tests/queries/0_stateless/02126_dist_desc.reference
@@ -1,81 +1,8 @@
--- { echo }
-select * from remote('127.1', 'system.one') settings log_queries=1, log_comment='127.1 db.name literal' format Null;
-system flush logs query_log;
-select count() from system.query_log where
-    type = 'QueryFinish' and
-    not is_initial_query and
-    startsWith(query, 'DESC') and
-    initial_query_id = (
-        select distinct query_id from system.query_log where log_comment = '127.1 db.name literal' and current_database = currentDatabase()
-    );
-0
-select * from remote('127.1', 'system', 'one') settings log_queries=1, log_comment='127.1 db,name literal' format Null;
-system flush logs query_log;
-select count() from system.query_log where
-    type = 'QueryFinish' and
-    not is_initial_query and
-    startsWith(query, 'DESC') and
-    initial_query_id = (
-        select distinct query_id from system.query_log where log_comment = '127.1 db,name literal' and current_database = currentDatabase()
-    );
-0
-select * from remote('127.1', system.one) settings log_queries=1, log_comment='127.1 db.name identifier' format Null;
-system flush logs query_log;
-select count() from system.query_log where
-    type = 'QueryFinish' and
-    not is_initial_query and
-    startsWith(query, 'DESC') and
-    initial_query_id = (
-        select distinct query_id from system.query_log where log_comment = '127.1 db.name identifier' and current_database = currentDatabase()
-    );
-0
-select * from remote('127.1', system, one) settings log_queries=1, log_comment='127.1 db,name identifier' format Null;
-system flush logs query_log;
-select count() from system.query_log where
-    type = 'QueryFinish' and
-    not is_initial_query and
-    startsWith(query, 'DESC') and
-    initial_query_id = (
-        select distinct query_id from system.query_log where log_comment = '127.1 db,name identifier' and current_database = currentDatabase()
-    );
-0
-select * from remote('127.2', 'system.one') settings log_queries=1, log_comment='127.2 db.name literal' format Null;
-system flush logs query_log;
-select count() from system.query_log where
-    type = 'QueryFinish' and
-    not is_initial_query and
-    startsWith(query, 'DESC') and
-    initial_query_id = (
-        select distinct query_id from system.query_log where log_comment = '127.2 db.name literal' and current_database = currentDatabase()
-    );
-1
-select * from remote('127.2', 'system', 'one') settings log_queries=1, log_comment='127.2 db,name literal' format Null;
-system flush logs query_log;
-select count() from system.query_log where
-    type = 'QueryFinish' and
-    not is_initial_query and
-    startsWith(query, 'DESC') and
-    initial_query_id = (
-        select distinct query_id from system.query_log where log_comment = '127.2 db,name literal' and current_database = currentDatabase()
-    );
-1
-select * from remote('127.2', system.one) settings log_queries=1, log_comment='127.2 db.name identifier' format Null;
-system flush logs query_log;
-select count() from system.query_log where
-    type = 'QueryFinish' and
-    not is_initial_query and
-    startsWith(query, 'DESC') and
-    initial_query_id = (
-        select distinct query_id from system.query_log where log_comment = '127.2 db.name identifier' and current_database = currentDatabase()
-    );
-1
-select * from remote('127.2', system, one) settings log_queries=1, log_comment='127.2 db,name identifier' format Null;
-system flush logs query_log;
-select count() from system.query_log where
-    type = 'QueryFinish' and
-    not is_initial_query and
-    startsWith(query, 'DESC') and
-    initial_query_id = (
-        select distinct query_id from system.query_log where log_comment = '127.2 db,name identifier' and current_database = currentDatabase()
-    );
-1
+select * from remote(\'127.1\', \'system.one\') format Null;	[]
+select * from remote(\'127.1\', \'system\', \'one\') format Null;	[]
+select * from remote(\'127.1\', system.one) format Null;	[]
+select * from remote(\'127.1\', system, one) format Null;	[]
+select * from remote(\'127.2\', \'system.one\') format Null;	['DESC TABLE system.one']
+select * from remote(\'127.2\', \'system\', \'one\') format Null;	['DESC TABLE system.one']
+select * from remote(\'127.2\', system.one) format Null;	['DESC TABLE system.one']
+select * from remote(\'127.2\', system, one) format Null;	['DESC TABLE system.one']

--- a/tests/queries/0_stateless/02126_dist_desc.sql.j2
+++ b/tests/queries/0_stateless/02126_dist_desc.sql.j2
@@ -1,19 +1,20 @@
--- { echo }
 {% for host in ['127.1', '127.2'] -%}
-{% for args, comment in [
-    ("'system.one'",    host + ' db.name literal'),
-    ("'system', 'one'", host + ' db,name literal'),
-    ("system.one",      host + ' db.name identifier'),
-    ("system, one",     host + ' db,name identifier'),
+{% for args in [
+    "'system.one'",
+    "'system', 'one'",
+    "system.one",
+    "system, one",
 ] -%}
-select * from remote('{{host}}', {{args}}) settings log_queries=1, log_comment='{{comment}}' format Null;
+select * from remote('{{host}}', {{args}}) format Null;
+{% endfor -%}
+{% endfor -%}
+
 system flush logs query_log;
-select count() from system.query_log where
+select anyIf(query, is_initial_query), groupArrayIf(query, query_kind = 'Describe' and not is_initial_query) from system.query_log
+where
     type = 'QueryFinish' and
-    not is_initial_query and
-    startsWith(query, 'DESC') and
-    initial_query_id = (
-        select distinct query_id from system.query_log where log_comment = '{{comment}}' and current_database = currentDatabase()
-    );
-{% endfor -%}
-{% endfor -%}
+    -- current_database is not set for queries on shards
+    -- (so 'current_database = currentDatabase()' will not show DESC queries)
+    log_comment like '%' || currentDatabase() || '%'
+group by initial_query_id
+order by max(event_time_microseconds);


### PR DESCRIPTION
CI: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=92500&sha=f37414270395e4176a9e0fbe040649fe7ee3f6df&name_0=PR&name_1=Stateless%20tests%20%28amd_msan%2C%20parallel%29

`SYSTEM FLUSH LOGS` is too slow under MSan - https://pastila.nl/?000bc898/1bca3c1552fa619500a7636feeef75d8#Oxy0V578VPKmvgVVwoE9dQ==

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
