### PR TITLE
Don't run 03735_excessive_buffer_flush in fast tests

### DIFF
--- a/tests/queries/0_stateless/03735_excessive_buffer_flush.sql
+++ b/tests/queries/0_stateless/03735_excessive_buffer_flush.sql
@@ -1,3 +1,4 @@
+-- Tags: no-fasttest
 -- Note, this test uses sleep, but, it should not affect it's flakiness
 
 set function_sleep_max_microseconds_per_block=5e9;


### PR DESCRIPTION
Sleeps too much

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
