### PR TITLE
Fix dynamic subcolumns resolution in column aliases in analyzer

### DIFF
--- a/src/Analyzer/Resolve/IdentifierResolveScope.h
+++ b/src/Analyzer/Resolve/IdentifierResolveScope.h
@@ -148,7 +148,7 @@ struct IdentifierResolveScope
     ScopeAliases global_with_aliases;
 
     /// Table column name to column node. Valid only during table ALIAS columns resolve.
-    ColumnNameToColumnNodeMap column_name_to_column_node;
+    AnalysisTableExpressionData * table_expression_data_for_alias_resolution = nullptr;
 
     std::list<std::unordered_map<std::string, ColumnNodePtr> *> join_using_columns;
 

--- a/src/Analyzer/Resolve/IdentifierResolveScope.h
+++ b/src/Analyzer/Resolve/IdentifierResolveScope.h
@@ -147,7 +147,7 @@ struct IdentifierResolveScope
     /// Store current scope aliases defined in WITH clause if `enable_scopes_for_with_statement` setting is disabled.
     ScopeAliases global_with_aliases;
 
-    /// Table column name to column node. Valid only during table ALIAS columns resolve.
+    /// Valid only during table ALIAS columns resolve.
     AnalysisTableExpressionData * table_expression_data_for_alias_resolution = nullptr;
 
     std::list<std::unordered_map<std::string, ColumnNodePtr> *> join_using_columns;

--- a/src/Analyzer/Resolve/IdentifierResolver.cpp
+++ b/src/Analyzer/Resolve/IdentifierResolver.cpp
@@ -354,26 +354,25 @@ bool IdentifierResolver::tryBindIdentifierToJoinUsingColumn(const IdentifierLook
   */
 QueryTreeNodePtr IdentifierResolver::tryResolveIdentifierFromTableColumns(const IdentifierLookup & identifier_lookup, IdentifierResolveScope & scope)
 {
-    if (scope.column_name_to_column_node.empty() || !identifier_lookup.isExpressionLookup())
+    if (!scope.table_expression_data_for_alias_resolution || !identifier_lookup.isExpressionLookup())
         return {};
 
     const auto & identifier = identifier_lookup.identifier;
-    auto it = scope.column_name_to_column_node.find(identifier.getFullName());
-    bool full_column_name_match = it != scope.column_name_to_column_node.end();
+    auto identifier_full_name = identifier.getFullName();
+    auto it = scope.table_expression_data_for_alias_resolution->column_name_to_column_node.find(identifier_full_name);
+    if (it != scope.table_expression_data_for_alias_resolution->column_name_to_column_node.end())
+        return it->second;
 
-    if (!full_column_name_match)
+    /// Check if it's a subcolumn
+    if (auto subcolumn_info = scope.table_expression_data_for_alias_resolution->tryGetSubcolumnInfo(identifier_full_name))
     {
-        it = scope.column_name_to_column_node.find(identifier_lookup.identifier[0]);
-        if (it == scope.column_name_to_column_node.end())
-            return {};
+        if (scope.table_expression_data_for_alias_resolution->supports_subcolumns)
+            return std::make_shared<ColumnNode>(NameAndTypePair{identifier_full_name, subcolumn_info->subcolumn_type}, subcolumn_info->column_node->getColumnSource());
+
+        return wrapExpressionNodeInSubcolumn(subcolumn_info->column_node, String(subcolumn_info->subcolumn_name), scope.context);
     }
 
-    QueryTreeNodePtr result = it->second;
-
-    if (!full_column_name_match && identifier.isCompound())
-        return tryResolveIdentifierFromCompoundExpression(identifier_lookup.identifier, 1 /*identifier_bind_size*/, it->second, {}, scope);
-
-    return result;
+    return {};
 }
 
 bool IdentifierResolver::tryBindIdentifierToTableExpression(const IdentifierLookup & identifier_lookup,

--- a/src/Analyzer/Resolve/QueryAnalyzer.cpp
+++ b/src/Analyzer/Resolve/QueryAnalyzer.cpp
@@ -3651,6 +3651,7 @@ void QueryAnalyzer::initializeTableExpressionData(const QueryTreeNodePtr & table
             }
         }
 
+        table_expression_data.column_name_to_column_node = std::move(column_name_to_column_node);
         for (auto & [alias_column_to_resolve_name, alias_column_to_resolve] : alias_columns_to_resolve)
         {
             /** Alias column could be potentially resolved during resolve of other ALIAS column.
@@ -3658,10 +3659,9 @@ void QueryAnalyzer::initializeTableExpressionData(const QueryTreeNodePtr & table
               *
               * During resolve of alias_value_1, alias_value_2 column will be resolved.
               */
-            alias_column_to_resolve = column_name_to_column_node[alias_column_to_resolve_name];
+            alias_column_to_resolve = table_expression_data.column_name_to_column_node[alias_column_to_resolve_name];
 
             IdentifierResolveScope & alias_column_resolve_scope = createIdentifierResolveScope(alias_column_to_resolve, &scope /*parent_scope*/);
-            table_expression_data.column_name_to_column_node = std::move(column_name_to_column_node);
             alias_column_resolve_scope.table_expression_data_for_alias_resolution = &table_expression_data;
             alias_column_resolve_scope.context = scope.context;
 
@@ -3676,11 +3676,8 @@ void QueryAnalyzer::initializeTableExpressionData(const QueryTreeNodePtr & table
             auto & resolved_expression = alias_column_to_resolve->getExpression();
             if (!resolved_expression->getResultType()->equals(*alias_column_to_resolve->getResultType()))
                 resolved_expression = buildCastFunction(resolved_expression, alias_column_to_resolve->getResultType(), scope.context, true);
-            column_name_to_column_node = std::move(table_expression_data.column_name_to_column_node);
-            column_name_to_column_node[alias_column_to_resolve_name] = alias_column_to_resolve;
+            table_expression_data.column_name_to_column_node[alias_column_to_resolve_name] = alias_column_to_resolve;
         }
-
-        table_expression_data.column_name_to_column_node = std::move(column_name_to_column_node);
     }
     else if (query_node || union_node)
     {

--- a/src/Analyzer/Resolve/QueryAnalyzer.cpp
+++ b/src/Analyzer/Resolve/QueryAnalyzer.cpp
@@ -3661,7 +3661,8 @@ void QueryAnalyzer::initializeTableExpressionData(const QueryTreeNodePtr & table
             alias_column_to_resolve = column_name_to_column_node[alias_column_to_resolve_name];
 
             IdentifierResolveScope & alias_column_resolve_scope = createIdentifierResolveScope(alias_column_to_resolve, &scope /*parent_scope*/);
-            alias_column_resolve_scope.column_name_to_column_node = std::move(column_name_to_column_node);
+            table_expression_data.column_name_to_column_node = std::move(column_name_to_column_node);
+            alias_column_resolve_scope.table_expression_data_for_alias_resolution = &table_expression_data;
             alias_column_resolve_scope.context = scope.context;
 
             /// Initialize aliases in alias column scope
@@ -3675,7 +3676,7 @@ void QueryAnalyzer::initializeTableExpressionData(const QueryTreeNodePtr & table
             auto & resolved_expression = alias_column_to_resolve->getExpression();
             if (!resolved_expression->getResultType()->equals(*alias_column_to_resolve->getResultType()))
                 resolved_expression = buildCastFunction(resolved_expression, alias_column_to_resolve->getResultType(), scope.context, true);
-            column_name_to_column_node = std::move(alias_column_resolve_scope.column_name_to_column_node);
+            column_name_to_column_node = std::move(table_expression_data.column_name_to_column_node);
             column_name_to_column_node[alias_column_to_resolve_name] = alias_column_to_resolve;
         }
 

--- a/tests/queries/0_stateless/03766_subcolumns_resolution_in_aliases.reference
+++ b/tests/queries/0_stateless/03766_subcolumns_resolution_in_aliases.reference
@@ -1,0 +1,23 @@
+0	43
+QUERY id: 0
+  PROJECTION COLUMNS
+    ab UInt64
+    bcd UInt64
+  PROJECTION
+    LIST id: 1, nodes: 2
+      COLUMN id: 2, column_name: ab, result_type: UInt64, source_id: 3
+        EXPRESSION
+          FUNCTION id: 4, function_name: _CAST, function_type: ordinary, result_type: UInt64
+            ARGUMENTS
+              LIST id: 5, nodes: 2
+                COLUMN id: 6, column_name: a.b, result_type: Dynamic, source_id: 3
+                CONSTANT id: 7, constant_value: \'UInt64\', constant_value_type: String
+      COLUMN id: 8, column_name: bcd, result_type: UInt64, source_id: 3
+        EXPRESSION
+          FUNCTION id: 9, function_name: _CAST, function_type: ordinary, result_type: UInt64
+            ARGUMENTS
+              LIST id: 10, nodes: 2
+                COLUMN id: 11, column_name: b.c.d, result_type: Dynamic, source_id: 3
+                CONSTANT id: 12, constant_value: \'UInt64\', constant_value_type: String
+  JOIN TREE
+    TABLE id: 3, alias: __table1, table_name: default.test

--- a/tests/queries/0_stateless/03766_subcolumns_resolution_in_aliases.sql
+++ b/tests/queries/0_stateless/03766_subcolumns_resolution_in_aliases.sql
@@ -1,0 +1,9 @@
+set enable_analyzer=1;
+
+drop table if exists test;
+create table test (a JSON, `b.c` JSON, ab UInt64 alias a.b, bcd UInt64 alias b.c.d) engine=MergeTree order by tuple();
+insert into test select '{"a" : 42}', '{"d" : 43}';
+select ab, bcd from test;
+explain query tree select ab, bcd from test;
+drop table test;
+


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix dynamic subcolumns resolution in column aliases in analyzer. Previously dynamic subcolumn in column alias was wrapped in `getSubcolumn` and in some cases could be not resolved at all. Closes https://github.com/ClickHouse/ClickHouse/issues/91434

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.379`
- Backported to: `25.12.3.11`, `25.11.7.28`, `25.10.5.30`, `25.8.15.25`, `25.3.14.5`
<!-- ch-version-info:end -->