### PR TITLE
Fix crashing at `IColumn::shrinkToFit()` and `IColumn::filter()` due to concurrent in-place mutations

### DIFF
--- a/src/Columns/ColumnNullable.cpp
+++ b/src/Columns/ColumnNullable.cpp
@@ -770,7 +770,7 @@ void ColumnNullable::prepareForSquashing(const Columns & source_columns, size_t 
 void ColumnNullable::shrinkToFit()
 {
     getNestedColumn().shrinkToFit();
-    getNullMapData().shrink_to_fit();
+    getNullMapColumn().shrinkToFit();
 }
 
 void ColumnNullable::ensureOwnership()

--- a/src/Storages/MergeTree/MergeTreeRangeReader.cpp
+++ b/src/Storages/MergeTree/MergeTreeRangeReader.cpp
@@ -87,9 +87,15 @@ static void filterColumns(Columns & columns, const FilterWithCachedCount & filte
                     column->size(), filter.size());
 
             if (canInplaceFilter(column, filter.getColumn()))
-                column->assumeMutable()->filter(filter_data);
+            {
+                auto mutable_column = IColumn::mutate(std::move(column));
+                mutable_column->filter(filter_data);
+                column = std::move(mutable_column);
+            }
             else
+            {
                 column = column->filter(filter_data, filter.countBytesInFilter());
+            }
 
             if (column->empty())
             {

--- a/src/Storages/MergeTree/MergeTreeRangeReader.cpp
+++ b/src/Storages/MergeTree/MergeTreeRangeReader.cpp
@@ -88,6 +88,8 @@ static void filterColumns(Columns & columns, const FilterWithCachedCount & filte
 
             if (canInplaceFilter(column, filter.getColumn()))
             {
+                /// The contract is - not to filter in-place if the column is shared. But if there're some shared subcolumns,
+                /// we'll clone them via IColumn::mutate() and then safely filter in-place.
                 auto mutable_column = IColumn::mutate(std::move(column));
                 mutable_column->filter(filter_data);
                 column = std::move(mutable_column);

--- a/src/Storages/MergeTree/MergeTreeReadTask.cpp
+++ b/src/Storages/MergeTree/MergeTreeReadTask.cpp
@@ -381,12 +381,17 @@ MergeTreeReadTask::BlockAndProgress MergeTreeReadTask::read()
     Block block;
     if (read_result.num_rows != 0)
     {
-        for (const auto & column : read_result.columns)
+        for (auto & column : read_result.columns)
         {
-            /// We may have columns that has other references, usually it is a constant column that has been created during analysis
-            /// (that will not be const here anymore, i.e. after materialize()), and we do not need to shrink it anyway.
+            /// We may have columns that have other references, usually it is a constant column that has been created during analysis
+            /// (that will not be const here anymore, i.e. after materialize()). The contract is - not to shrink if column is shared.
+            /// But if some subcolumns are shared, we'll clone them at IColumn::mutate() and then safely shrink
             if (column->use_count() == 1)
-                column->assumeMutableRef().shrinkToFit();
+            {
+                auto mutable_column = IColumn::mutate(std::move(column));
+                mutable_column->shrinkToFit();
+                column = std::move(mutable_column);
+            }
         }
         block = sample_block.cloneWithColumns(read_result.columns);
     }

--- a/src/Storages/MergeTree/MergeTreeReadTask.cpp
+++ b/src/Storages/MergeTree/MergeTreeReadTask.cpp
@@ -385,7 +385,7 @@ MergeTreeReadTask::BlockAndProgress MergeTreeReadTask::read()
         {
             /// We may have columns that have other references, usually it is a constant column that has been created during analysis
             /// (that will not be const here anymore, i.e. after materialize()). The contract is - not to shrink if column is shared.
-            /// But if some subcolumns are shared, we'll clone them at IColumn::mutate() and then safely shrink
+            /// But if some subcolumns are shared, we'll clone them via IColumn::mutate() and then safely shrink
             if (column->use_count() == 1)
             {
                 auto mutable_column = IColumn::mutate(std::move(column));

--- a/tests/queries/0_stateless/03680_mergetree_shrink_const_from_prewhere_repetitive.sh
+++ b/tests/queries/0_stateless/03680_mergetree_shrink_const_from_prewhere_repetitive.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+RUNS=${RUNS:-25}
+# This test covers #88605 and #90695 - different occurences of the same issue - calling shrinkToFit on a shared column.
+# Due to flaky nature of the problem, the test repeats same queries multiple times in order the trigger a simultanuous
+# attempt to shrink at several exec threads.
+# This test complements 03680_mergetree_shrink_const_from_prewhere.sql
+#
+# #88605 (const_node_1): Here we have condition with a constant "materialize(255)", for which convertToFullColumnIfConst() will return underlying column w/o copying,
+# and later shrinkToFit() will be called from multiple threads on this column, and leads to UB
+# #90695 (const_node_2): The combination of "materialize()" with "and()" and "toNullable()" creates nested column and a chain, where double-free happened at shrinkToFit()
+
+setup() {
+    $CLICKHOUSE_CLIENT -q "
+        DROP TABLE IF EXISTS const_node_1;
+        DROP TABLE IF EXISTS const_node_2;
+        CREATE TABLE const_node_1 (v Nullable(UInt8)) ENGINE = MergeTree ORDER BY tuple();
+        SYSTEM STOP MERGES const_node_1;
+        INSERT INTO const_node_1 VALUES (1);
+        INSERT INTO const_node_1 VALUES (2);
+        INSERT INTO const_node_1 VALUES (3);
+        DROP TABLE IF EXISTS const_node_2;
+        CREATE TABLE const_node_2 (x Int16) ENGINE = MergeTree PARTITION BY (x) ORDER BY x;
+        INSERT INTO const_node_2 VALUES (1), (2), (1), (3);
+    "
+}
+
+run_queries() {
+    for i in $(seq 1 "$RUNS"); do
+        $CLICKHOUSE_CLIENT -q "
+            SELECT v FROM const_node_1 PREWHERE and(materialize(255), *) ORDER BY v FORMAT NULL;
+            SELECT median(3) IGNORE NULLS FROM const_node_2 PREWHERE and(materialize(toNullable(materialize(1))), not(materialize(100) = *)) FORMAT NULL;
+        "
+    done
+}
+
+cleanup() {
+    $CLICKHOUSE_CLIENT -q "
+        DROP TABLE IF EXISTS const_node_1;
+        DROP TABLE IF EXISTS const_node_2;
+    "
+}
+
+setup
+run_queries
+cleanup


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix potential crash caused by in place mutation of underlying const PREWHERE columns. This could've happened at column shrinking (`IColumn::shrinkToFit`) or filtering (`IColumn::filter`), which could've triggered concurrently from several threads.

In addition to #88605, the issue could've been caused by leveraging chained or nested columns, e.g. via PREWHERE conditions `and()`, `toNullable()`. The fix is to mutate the column recursively before calling `shrinkToFit()`. If the column (or its nested part) is not shared, then no copying will take place.
Similar logic has been applied to #90630, preventing concurrent mutation at in-place filtering.

Closes #90695

