### PR TITLE
Fix: allow using offset in projections as a function argument.

### DIFF
--- a/src/Storages/ProjectionsDescription.h
+++ b/src/Storages/ProjectionsDescription.h
@@ -69,6 +69,7 @@ struct ProjectionDescription
     std::vector<size_t> partition_value_indices;
 
     bool with_parent_part_offset = false;
+    bool select_expr_required_part_offset = false;
 
     std::optional<UInt64> index_granularity;
     std::optional<UInt64> index_granularity_bytes;


### PR DESCRIPTION
### Changelog category (leave one):

- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Allow using offset in projections as a function argument. 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

In the current projection definition, _part_offset cannot be used as a function argument, which limits the applicability of projection indexes.