### PR TITLE
tests: make 03770_min_columns_to_activate_adaptive_write_buffer less flaky for encrypted disks

### DIFF
--- a/tests/queries/0_stateless/03770_min_columns_to_activate_adaptive_write_buffer.reference
+++ b/tests/queries/0_stateless/03770_min_columns_to_activate_adaptive_write_buffer.reference
@@ -1,4 +1,4 @@
 metric_log_0	Compact	Horizontal	100000000
-metric_log_0	Wide	Horizontal	1000000000
+metric_log_0	Wide	Horizontal	1500000000
 metric_log_1	Compact	Horizontal	100000000
 metric_log_1	Wide	Horizontal	100000000

--- a/tests/queries/0_stateless/03770_min_columns_to_activate_adaptive_write_buffer.sql.j2
+++ b/tests/queries/0_stateless/03770_min_columns_to_activate_adaptive_write_buffer.sql.j2
@@ -18,7 +18,7 @@ insert into metric_log_{{ v }} select * from generateRandom() limit 1 settings m
 optimize table metric_log_{{ v }} final;
 truncate table metric_log_{{ v }};
 alter table metric_log_{{ v }} modify setting min_bytes_for_wide_part=0;
-insert into metric_log_{{ v }} select * from generateRandom() limit 1 settings max_memory_usage = '{{ 50 if v == 1 else 1000 }}Mi' /* w/o adaptive buffers uses ~3 (for regular) and ~600MiB-1GiB (for encrypted disks), w/ 100MiB for regular and ~200-400MiB for encrypted disks */;
+insert into metric_log_{{ v }} select * from generateRandom() limit 1 settings max_memory_usage = '{{ 50 if v == 1 else 1500 }}Mi' /* w/o adaptive buffers uses ~3 (for regular) and ~600MiB-1GiB (for encrypted disks), w/ 100MiB for regular and ~200-400MiB for encrypted disks */;
 optimize table metric_log_{{ v }} final;
 drop table metric_log_{{ v }};
 {% endfor %}
@@ -35,7 +35,7 @@ select
       -- see comments for max_memory_usage
       part_type = 'Compact', 100e6,
       table = 'metric_log_1', 100e6,
-      table = 'metric_log_0', 1e9,
+      table = 'metric_log_0', 1.5e9,
       0.
     )
   )


### PR DESCRIPTION
CI: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=3b4908fb60172ece51a73e0c4bb1f83378590fdd&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_binary%2C%20old%20analyzer%2C%20s3%20storage%2C%20DatabaseReplicated%2C%20parallel%29&name_1=Stateless%20tests%20%28amd_binary%2C%20old%20analyzer%2C%20s3%20storage%2C%20DatabaseReplicated%2C%20parallel%29

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)