### PR TITLE
tests: disable fsync/fdatasync for rabbitmq (if any)

### DIFF
--- a/tests/integration/compose/docker_compose_rabbitmq.yml
+++ b/tests/integration/compose/docker_compose_rabbitmq.yml
@@ -20,6 +20,8 @@ services:
             - /misc/rabbitmq/server-key.pem:/etc/rabbitmq/server-key.pem
             - /misc/rabbitmq/enabled_plugins:/etc/rabbitmq/enabled_plugins
         # https://www.rabbitmq.com/docs/monitoring#health-checks
+        # Run with strace to disable fsync/fdatasync for faster test execution
+        command: sh -c "apk add --no-cache strace && exec strace -qq -f -e inject=fsync,fdatasync:retval=0 -e exit_group -e signal=9 docker-entrypoint.sh rabbitmq-server"
         healthcheck:
             test: rabbitmq-diagnostics -q ping
             interval: 10s


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Note sure that it has a lot, but want to try

Note, I've tried the same for MinIO to make it faster, but it uses `openat(O_DSYNC)` and `strace` is not smart enough for this