### PR TITLE
Fix `03357_join_pk_sharding` timeouts

### DIFF
--- a/tests/queries/0_stateless/03357_join_pk_sharding.sql
+++ b/tests/queries/0_stateless/03357_join_pk_sharding.sql
@@ -1,4 +1,4 @@
--- Tags: long
+-- Tags: long, no-asan, no-msan
 
 SET allow_statistics_optimize = 0;
 drop table if exists tab_l;

--- a/tests/queries/0_stateless/03357_join_pk_sharding.sql
+++ b/tests/queries/0_stateless/03357_join_pk_sharding.sql
@@ -20,6 +20,7 @@ set enable_analyzer=1;
 set query_plan_join_swap_table=0;
 set query_plan_join_shard_by_pk_ranges=1;
 set allow_experimental_parallel_reading_from_replicas=0;
+set max_threads=4;
 
 -- { echo On }
 


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


Analyzing failures for `03357_join_pk_sharding` I notice that most of them have `max_threads=1` and were ran with MSan or ASan.
Let's disable running with some sanitizers and set `max_threads` explicitly. Closes https://github.com/ClickHouse/ClickHouse/issues/85939
