### PR TITLE
Stabilise `QBit` performance tests

### DIFF
--- a/tests/performance/qbit_l2_distance_bfloat16_memory.xml
+++ b/tests/performance/qbit_l2_distance_bfloat16_memory.xml
@@ -38,25 +38,25 @@
     <create_query>INSERT INTO tab_{type} SELECT number + 1 AS id, arrayMap(i -> id + i - 1, range({vector_size})) AS vec FROM numbers({elements})</create_query>
 
     <query>
-        SELECT * FROM (SELECT 1 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 1) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        SELECT * FROM (SELECT 1 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + k) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
         UNION ALL
-        SELECT * FROM (SELECT 2 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 2) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        SELECT * FROM (SELECT 2 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + k) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
         UNION ALL
-        SELECT * FROM (SELECT 3 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 3) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        SELECT * FROM (SELECT 3 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + k) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
         UNION ALL
-        SELECT * FROM (SELECT 4 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 4) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        SELECT * FROM (SELECT 4 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + k) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
         UNION ALL
-        SELECT * FROM (SELECT 5 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 5) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        SELECT * FROM (SELECT 5 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + k) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
         UNION ALL
-        SELECT * FROM (SELECT 6 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 6) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        SELECT * FROM (SELECT 6 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + k) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
         UNION ALL
-        SELECT * FROM (SELECT 7 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 7) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        SELECT * FROM (SELECT 7 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + k) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
         UNION ALL
-        SELECT * FROM (SELECT 8 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 8) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        SELECT * FROM (SELECT 8 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + k) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
         UNION ALL
-        SELECT * FROM (SELECT 9 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 9) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        SELECT * FROM (SELECT 9 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + k) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
         UNION ALL
-        SELECT * FROM (SELECT 10 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 10) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        SELECT * FROM (SELECT 10 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + k) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
     </query>
 
     <drop_query>DROP TABLE tab_{type}</drop_query>

--- a/tests/performance/qbit_l2_distance_bfloat16_memory.xml
+++ b/tests/performance/qbit_l2_distance_bfloat16_memory.xml
@@ -26,10 +26,9 @@
         <substitution>
             <name>p</name>
             <values>
+                <!-- Test full and small precisions -->
                 <value>16</value>
                 <value>8</value>
-                <value>4</value>
-                <value>2</value>
             </values>
         </substitution>
     </substitutions>
@@ -38,7 +37,27 @@
     <create_query>CREATE TABLE tab_{type} (id UInt32, vec QBit({type}, {vector_size})) ENGINE = Memory</create_query>
     <create_query>INSERT INTO tab_{type} SELECT number + 1 AS id, arrayMap(i -> id + i - 1, range({vector_size})) AS vec FROM numbers({elements})</create_query>
 
-    <query>WITH arrayMap(i -> (i + 1) * 2, range({vector_size})) AS reference_vec SELECT id, L2DistanceTransposed(vec, reference_vec, {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 3</query>
+    <query>
+        SELECT * FROM (SELECT 1 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 1) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        UNION ALL
+        SELECT * FROM (SELECT 2 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 2) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        UNION ALL
+        SELECT * FROM (SELECT 3 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 3) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        UNION ALL
+        SELECT * FROM (SELECT 4 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 4) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        UNION ALL
+        SELECT * FROM (SELECT 5 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 5) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        UNION ALL
+        SELECT * FROM (SELECT 6 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 6) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        UNION ALL
+        SELECT * FROM (SELECT 7 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 7) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        UNION ALL
+        SELECT * FROM (SELECT 8 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 8) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        UNION ALL
+        SELECT * FROM (SELECT 9 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 9) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        UNION ALL
+        SELECT * FROM (SELECT 10 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 10) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+    </query>
 
     <drop_query>DROP TABLE tab_{type}</drop_query>
 </test>

--- a/tests/performance/qbit_l2_distance_float32_memory.xml
+++ b/tests/performance/qbit_l2_distance_float32_memory.xml
@@ -38,25 +38,25 @@
     <create_query>INSERT INTO tab_{type} SELECT number + 1 AS id, arrayMap(i -> id + i - 1, range({vector_size})) AS vec FROM numbers({elements})</create_query>
 
     <query>
-        SELECT * FROM (SELECT 1 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 1) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        SELECT * FROM (SELECT 1 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + k) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
         UNION ALL
-        SELECT * FROM (SELECT 2 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 2) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        SELECT * FROM (SELECT 2 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + k) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
         UNION ALL
-        SELECT * FROM (SELECT 3 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 3) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        SELECT * FROM (SELECT 3 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + k) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
         UNION ALL
-        SELECT * FROM (SELECT 4 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 4) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        SELECT * FROM (SELECT 4 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + k) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
         UNION ALL
-        SELECT * FROM (SELECT 5 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 5) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        SELECT * FROM (SELECT 5 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + k) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
         UNION ALL
-        SELECT * FROM (SELECT 6 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 6) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        SELECT * FROM (SELECT 6 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + k) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
         UNION ALL
-        SELECT * FROM (SELECT 7 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 7) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        SELECT * FROM (SELECT 7 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + k) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
         UNION ALL
-        SELECT * FROM (SELECT 8 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 8) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        SELECT * FROM (SELECT 8 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + k) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
         UNION ALL
-        SELECT * FROM (SELECT 9 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 9) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        SELECT * FROM (SELECT 9 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + k) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
         UNION ALL
-        SELECT * FROM (SELECT 10 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 10) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        SELECT * FROM (SELECT 10 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + k) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
     </query>
 
     <drop_query>DROP TABLE tab_{type}</drop_query>

--- a/tests/performance/qbit_l2_distance_float32_memory.xml
+++ b/tests/performance/qbit_l2_distance_float32_memory.xml
@@ -26,11 +26,9 @@
         <substitution>
             <name>p</name>
             <values>
+                <!-- Test full and small precisions -->
                 <value>32</value>
-                <value>16</value>
                 <value>8</value>
-                <value>4</value>
-                <value>2</value>
             </values>
         </substitution>
     </substitutions>
@@ -39,7 +37,27 @@
     <create_query>CREATE TABLE tab_{type} (id UInt32, vec QBit({type}, {vector_size})) ENGINE = Memory</create_query>
     <create_query>INSERT INTO tab_{type} SELECT number + 1 AS id, arrayMap(i -> id + i - 1, range({vector_size})) AS vec FROM numbers({elements})</create_query>
 
-    <query>WITH arrayMap(i -> (i + 1) * 2, range({vector_size})) AS reference_vec SELECT id, L2DistanceTransposed(vec, reference_vec, {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 3</query>
+    <query>
+        SELECT * FROM (SELECT 1 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 1) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        UNION ALL
+        SELECT * FROM (SELECT 2 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 2) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        UNION ALL
+        SELECT * FROM (SELECT 3 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 3) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        UNION ALL
+        SELECT * FROM (SELECT 4 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 4) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        UNION ALL
+        SELECT * FROM (SELECT 5 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 5) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        UNION ALL
+        SELECT * FROM (SELECT 6 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 6) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        UNION ALL
+        SELECT * FROM (SELECT 7 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 7) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        UNION ALL
+        SELECT * FROM (SELECT 8 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 8) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        UNION ALL
+        SELECT * FROM (SELECT 9 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 9) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        UNION ALL
+        SELECT * FROM (SELECT 10 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 10) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+    </query>
 
     <drop_query>DROP TABLE tab_{type}</drop_query>
 </test>

--- a/tests/performance/qbit_l2_distance_float64_memory.xml
+++ b/tests/performance/qbit_l2_distance_float64_memory.xml
@@ -38,25 +38,25 @@
     <create_query>INSERT INTO tab_{type} SELECT number + 1 AS id, arrayMap(i -> id + i - 1, range({vector_size})) AS vec FROM numbers({elements})</create_query>
 
     <query>
-        SELECT * FROM (SELECT 1 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 1) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        SELECT * FROM (SELECT 1 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + k) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
         UNION ALL
-        SELECT * FROM (SELECT 2 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 2) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        SELECT * FROM (SELECT 2 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + k) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
         UNION ALL
-        SELECT * FROM (SELECT 3 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 3) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        SELECT * FROM (SELECT 3 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + k) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
         UNION ALL
-        SELECT * FROM (SELECT 4 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 4) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        SELECT * FROM (SELECT 4 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + k) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
         UNION ALL
-        SELECT * FROM (SELECT 5 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 5) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        SELECT * FROM (SELECT 5 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + k) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
         UNION ALL
-        SELECT * FROM (SELECT 6 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 6) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        SELECT * FROM (SELECT 6 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + k) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
         UNION ALL
-        SELECT * FROM (SELECT 7 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 7) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        SELECT * FROM (SELECT 7 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + k) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
         UNION ALL
-        SELECT * FROM (SELECT 8 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 8) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        SELECT * FROM (SELECT 8 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + k) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
         UNION ALL
-        SELECT * FROM (SELECT 9 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 9) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        SELECT * FROM (SELECT 9 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + k) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
         UNION ALL
-        SELECT * FROM (SELECT 10 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 10) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        SELECT * FROM (SELECT 10 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + k) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
     </query>
 
     <drop_query>DROP TABLE tab_{type}</drop_query>

--- a/tests/performance/qbit_l2_distance_float64_memory.xml
+++ b/tests/performance/qbit_l2_distance_float64_memory.xml
@@ -26,12 +26,9 @@
         <substitution>
             <name>p</name>
             <values>
+                <!-- Test full and small precisions -->
                 <value>64</value>
-                <value>32</value>
-                <value>16</value>
                 <value>8</value>
-                <value>4</value>
-                <value>2</value>
             </values>
         </substitution>
     </substitutions>
@@ -40,7 +37,27 @@
     <create_query>CREATE TABLE tab_{type} (id UInt32, vec QBit({type}, {vector_size})) ENGINE = Memory</create_query>
     <create_query>INSERT INTO tab_{type} SELECT number + 1 AS id, arrayMap(i -> id + i - 1, range({vector_size})) AS vec FROM numbers({elements})</create_query>
 
-    <query>WITH arrayMap(i -> (i + 1) * 2, range({vector_size})) AS reference_vec SELECT id, L2DistanceTransposed(vec, reference_vec, {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 3</query>
+    <query>
+        SELECT * FROM (SELECT 1 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 1) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        UNION ALL
+        SELECT * FROM (SELECT 2 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 2) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        UNION ALL
+        SELECT * FROM (SELECT 3 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 3) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        UNION ALL
+        SELECT * FROM (SELECT 4 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 4) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        UNION ALL
+        SELECT * FROM (SELECT 5 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 5) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        UNION ALL
+        SELECT * FROM (SELECT 6 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 6) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        UNION ALL
+        SELECT * FROM (SELECT 7 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 7) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        UNION ALL
+        SELECT * FROM (SELECT 8 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 8) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        UNION ALL
+        SELECT * FROM (SELECT 9 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 9) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+        UNION ALL
+        SELECT * FROM (SELECT 10 AS k, id, L2DistanceTransposed(vec, arrayMap(i -> (i + 10) * 2, range({vector_size})), {p}) AS dist FROM tab_{type} ORDER BY dist LIMIT 10)
+    </query>
 
     <drop_query>DROP TABLE tab_{type}</drop_query>
 </test>


### PR DESCRIPTION
The old performance tests had multiple queries that executed too fast and were prone to fluctuations. This instability recently started making CI red [[1](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=92323&sha=3623952389e69422445e8fbea3cd78d3e18e81ba&name_0=PR&name_1=Performance+Comparison+%28amd_release%2C+master_head%2C+2%2F6%29), [2](https://github.com/ClickHouse/ClickHouse/pull/92541#issuecomment-3672429019)]. Now, for each `QBit` test (there are three, one for each supported type) there are two subtests:
* on full precision
* on reasonable low precision (8 bits)

This is enough to monitor degradations. Moreover, to make tests heavier, we combine 10 search queries using `UNION ALL`.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)