### PR TITLE
Try fix flaky `02246_is_secure_query_log`

### DIFF
--- a/tests/queries/0_stateless/02246_is_secure_query_log.reference
+++ b/tests/queries/0_stateless/02246_is_secure_query_log.reference
@@ -1,3 +1,7 @@
+native plain
+native secure
+http plain
+http secure
 1	0
 1	1
 2	0

--- a/tests/queries/0_stateless/02246_is_secure_query_log.sh
+++ b/tests/queries/0_stateless/02246_is_secure_query_log.sh
@@ -6,17 +6,13 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../shell_config.sh
 
 ${CLICKHOUSE_CLIENT} --log_queries=1 --query_id "2246_${CLICKHOUSE_DATABASE}_client_nonsecure" -q "select 1 Format Null"
-${CLICKHOUSE_CLIENT} -q "system flush logs query_log"
-${CLICKHOUSE_CLIENT} -q "select interface, is_secure from system.query_log where query_id = '2246_${CLICKHOUSE_DATABASE}_client_nonsecure' and type = 'QueryFinish' and current_database = currentDatabase()"
-
 ${CLICKHOUSE_CLIENT_SECURE} --log_queries=1 --query_id "2246_${CLICKHOUSE_DATABASE}_client_secure" -q "select 1 Format Null"
-${CLICKHOUSE_CLIENT} -q "system flush logs query_log"
-${CLICKHOUSE_CLIENT} -q "select interface, is_secure from system.query_log where query_id = '2246_${CLICKHOUSE_DATABASE}_client_secure' and type = 'QueryFinish' and current_database = currentDatabase()"
-
 ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&log_queries=1&query_id=2246_${CLICKHOUSE_DATABASE}_http_nonsecure" -d "select 1 Format Null"
-${CLICKHOUSE_CLIENT} -q "system flush logs query_log"
-${CLICKHOUSE_CLIENT} -q "select interface, is_secure from system.query_log where query_id = '2246_${CLICKHOUSE_DATABASE}_http_nonsecure' and type = 'QueryFinish' and current_database = currentDatabase()"
-
 ${CLICKHOUSE_CURL} -sSk "${CLICKHOUSE_URL_HTTPS}&log_queries=1&query_id=2246_${CLICKHOUSE_DATABASE}_http_secure" -d "select 1 Format Null"
+
 ${CLICKHOUSE_CLIENT} -q "system flush logs query_log"
+
+${CLICKHOUSE_CLIENT} -q "select interface, is_secure from system.query_log where query_id = '2246_${CLICKHOUSE_DATABASE}_client_nonsecure' and type = 'QueryFinish' and current_database = currentDatabase()"
+${CLICKHOUSE_CLIENT} -q "select interface, is_secure from system.query_log where query_id = '2246_${CLICKHOUSE_DATABASE}_client_secure' and type = 'QueryFinish' and current_database = currentDatabase()"
+${CLICKHOUSE_CLIENT} -q "select interface, is_secure from system.query_log where query_id = '2246_${CLICKHOUSE_DATABASE}_http_nonsecure' and type = 'QueryFinish' and current_database = currentDatabase()"
 ${CLICKHOUSE_CLIENT} -q "select interface, is_secure from system.query_log where query_id = '2246_${CLICKHOUSE_DATABASE}_http_secure' and type = 'QueryFinish' and current_database = currentDatabase()"

--- a/tests/queries/0_stateless/02246_is_secure_query_log.sh
+++ b/tests/queries/0_stateless/02246_is_secure_query_log.sh
@@ -5,10 +5,10 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
-${CLICKHOUSE_CLIENT} --log_queries=1 --query_id "2246_${CLICKHOUSE_DATABASE}_client_nonsecure" -q "select 1 Format Null"
-${CLICKHOUSE_CLIENT_SECURE} --log_queries=1 --query_id "2246_${CLICKHOUSE_DATABASE}_client_secure" -q "select 1 Format Null"
-${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&log_queries=1&query_id=2246_${CLICKHOUSE_DATABASE}_http_nonsecure" -d "select 1 Format Null"
-${CLICKHOUSE_CURL} -sSk "${CLICKHOUSE_URL_HTTPS}&log_queries=1&query_id=2246_${CLICKHOUSE_DATABASE}_http_secure" -d "select 1 Format Null"
+${CLICKHOUSE_CLIENT} --log_queries=1 --query_id "2246_${CLICKHOUSE_DATABASE}_client_nonsecure" -q "select 'native plain'"
+${CLICKHOUSE_CLIENT_SECURE} --log_queries=1 --query_id "2246_${CLICKHOUSE_DATABASE}_client_secure" -q "select 'native secure'"
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&log_queries=1&query_id=2246_${CLICKHOUSE_DATABASE}_http_nonsecure" -d "select 'http plain'"
+${CLICKHOUSE_CURL} -sSk "${CLICKHOUSE_URL_HTTPS}&log_queries=1&query_id=2246_${CLICKHOUSE_DATABASE}_http_secure" -d "select 'http secure'"
 
 ${CLICKHOUSE_CLIENT} -q "system flush logs query_log"
 

--- a/tests/queries/0_stateless/02246_is_secure_query_log.sh
+++ b/tests/queries/0_stateless/02246_is_secure_query_log.sh
@@ -7,8 +7,8 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 ${CLICKHOUSE_CLIENT} --log_queries=1 --query_id "2246_${CLICKHOUSE_DATABASE}_client_nonsecure" -q "select 'native plain'"
 ${CLICKHOUSE_CLIENT_SECURE} --log_queries=1 --query_id "2246_${CLICKHOUSE_DATABASE}_client_secure" -q "select 'native secure'"
-${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&log_queries=1&query_id=2246_${CLICKHOUSE_DATABASE}_http_nonsecure" -d "select 'http plain'"
-${CLICKHOUSE_CURL} -sSk "${CLICKHOUSE_URL_HTTPS}&log_queries=1&query_id=2246_${CLICKHOUSE_DATABASE}_http_secure" -d "select 'http secure'"
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&log_queries=1&http_wait_end_of_query=1&query_id=2246_${CLICKHOUSE_DATABASE}_http_nonsecure" -d "select 'http plain'"
+${CLICKHOUSE_CURL} -sSk "${CLICKHOUSE_URL_HTTPS}&log_queries=1&http_wait_end_of_query=1&query_id=2246_${CLICKHOUSE_DATABASE}_http_secure" -d "select 'http secure'"
 
 ${CLICKHOUSE_CLIENT} -q "system flush logs query_log"
 


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

There are just two cases of failures for this test:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=86281&sha=9fc07bb3c5dfa6ab95243d55801da8bb6ccbd0e5&name_0=PR&name_1=Stateless%20tests%20%28amd_tsan%2C%20parallel%2C%201%2F2%29&name_1=Stateless%20tests%20%28amd_tsan%2C%20parallel%2C%201%2F2%29
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=81877&sha=0e404d704a6e57292da685cd925b3753fdd9e3a0&name_0=PR&name_1=Stateless%20tests%20%28amd_msan%2C%20parallel%2C%201%2F2%29&name_1=Stateless%20tests%20%28amd_msan%2C%20parallel%2C%201%2F2%29

Looks like flush didn't reach `system.query_log`; let's try to do flush just once.

EDIT: ~~additionally, I just noticed that both of these runs share `http_wait_end_of_query=False` setting, let's try setting it to `True` explicitly~~ probably unrelated.

Closes https://github.com/ClickHouse/ClickHouse/issues/86325



