### PR TITLE
Fix incorrect granules pruning in`KeyCondition` for `match` function

### DIFF
--- a/tests/queries/0_stateless/03772_key_condition_match_function_relaxed.reference
+++ b/tests/queries/0_stateless/03772_key_condition_match_function_relaxed.reference
@@ -1,0 +1,86 @@
+-- { echo }
+SELECT count(*)
+FROM 03772_table_match
+WHERE NOT match(url, '^https?://clickhouse[.]com/');
+1
+EXPLAIN indexes = 1
+SELECT count(*)
+FROM 03772_table_match
+WHERE NOT match(url, '^https?://clickhouse[.]com/');
+Expression ((Project names + Projection))
+  Aggregating
+    Expression (Before GROUP BY)
+      Filter ((WHERE + Change column names to column identifiers))
+        ReadFromMergeTree (default.03772_table_match)
+        Indexes:
+          PrimaryKey
+            Keys:
+              url
+            Condition: not((url in [\'http\', \'httq\')))
+            Parts: 1/1
+            Granules: 1/1
+            Search Algorithm: generic exclusion search
+          Ranges: 1
+SELECT count(*)
+FROM 03772_table_match
+WHERE NOT match(url, '^abcd');
+1
+EXPLAIN indexes = 1
+SELECT count(*)
+FROM 03772_table_match
+WHERE NOT match(url, '^abcd');
+Expression ((Project names + Projection))
+  Aggregating
+    Expression (Before GROUP BY)
+      Filter ((WHERE + Change column names to column identifiers))
+        ReadFromMergeTree (default.03772_table_match)
+        Indexes:
+          PrimaryKey
+            Keys:
+              url
+            Condition: not((url in [\'abcd\', \'abce\')))
+            Parts: 1/1
+            Granules: 1/1
+            Search Algorithm: generic exclusion search
+          Ranges: 1
+SELECT count(*)
+FROM 03772_table_match
+WHERE match(url, '^abcd');
+0
+EXPLAIN indexes = 1
+SELECT count(*)
+FROM 03772_table_match
+WHERE match(url, '^abcd');
+Expression ((Project names + Projection))
+  Aggregating
+    Expression (Before GROUP BY)
+      Filter ((WHERE + Change column names to column identifiers))
+        ReadFromMergeTree (default.03772_table_match)
+        Indexes:
+          PrimaryKey
+            Keys:
+              url
+            Condition: (url in [\'abcd\', \'abce\'))
+            Parts: 0/1
+            Granules: 0/1
+            Search Algorithm: binary search
+          Ranges: 0
+SELECT count(*)
+FROM 03772_table_match
+WHERE match(url, '^https?://clickhouse[.]com/') = false;
+1
+EXPLAIN indexes = 1
+SELECT count(*)
+FROM 03772_table_match
+WHERE match(url, '^https?://clickhouse[.]com/') = false;
+Expression ((Project names + Projection))
+  Aggregating
+    Expression (Before GROUP BY)
+      Filter ((WHERE + Change column names to column identifiers))
+        ReadFromMergeTree (default.03772_table_match)
+        Indexes:
+          PrimaryKey
+            Condition: true
+            Parts: 1/1
+            Granules: 1/1
+          Ranges: 1

--- a/tests/queries/0_stateless/03772_key_condition_match_function_relaxed.sql
+++ b/tests/queries/0_stateless/03772_key_condition_match_function_relaxed.sql
@@ -1,0 +1,48 @@
+-- Tags: no-replicated-database, no-parallel-replicas
+-- no-replicated-database: EXPLAIN output differs for replicated database.
+-- no-parallel-replicas: EXPLAIN output differs for parallel replicas.
+
+
+DROP TABLE IF EXISTS 03772_table_match;
+
+CREATE TABLE 03772_table_match
+ENGINE = MergeTree()
+ORDER BY url AS
+SELECT 'http://example1.com/' AS url;
+
+-- { echo }
+SELECT count(*)
+FROM 03772_table_match
+WHERE NOT match(url, '^https?://clickhouse[.]com/');
+
+EXPLAIN indexes = 1
+SELECT count(*)
+FROM 03772_table_match
+WHERE NOT match(url, '^https?://clickhouse[.]com/');
+
+SELECT count(*)
+FROM 03772_table_match
+WHERE NOT match(url, '^abcd');
+
+EXPLAIN indexes = 1
+SELECT count(*)
+FROM 03772_table_match
+WHERE NOT match(url, '^abcd');
+
+SELECT count(*)
+FROM 03772_table_match
+WHERE match(url, '^abcd');
+
+EXPLAIN indexes = 1
+SELECT count(*)
+FROM 03772_table_match
+WHERE match(url, '^abcd');
+
+SELECT count(*)
+FROM 03772_table_match
+WHERE match(url, '^https?://clickhouse[.]com/') = false;
+
+EXPLAIN indexes = 1
+SELECT count(*)
+FROM 03772_table_match
+WHERE match(url, '^https?://clickhouse[.]com/') = false;


### PR DESCRIPTION
Currently the following query returns 0, but should be 1.

```sql
CREATE TABLE table_match
ENGINE = MergeTree()
ORDER BY url AS
SELECT 'http://example1.com/' AS url;

SELECT count(*)
FROM table_match
WHERE NOT match(url, '^https?://clickhouse[.]com/');
```

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix bug in data skipping logic when `not match(...)` is used in `WHERE` causing incorrect results. Closes https://github.com/ClickHouse/ClickHouse/issues/92492.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
