### PR TITLE
Execute current query in Ctrl+R search in client if no history match found

### DIFF
--- a/rust/workspace/skim/src/lib.rs
+++ b/rust/workspace/skim/src/lib.rs
@@ -90,10 +90,13 @@ fn skim_impl(prefix: &CxxString, words: &CxxVector<CxxString>) -> Result<String,
         return Ok("".to_string());
     }
 
-    if output.selected_items.is_empty() {
-        return Err("No items had been selected".to_string());
+    if !output.selected_items.is_empty() {
+        return Ok(output.selected_items[0].output().to_string());
     }
-    Ok(output.selected_items[0].output().to_string())
+    if !output.query.is_empty() {
+        return Ok(output.query);
+    }
+    return Err("No items had been selected".to_string());
 }
 
 fn skim(prefix: &CxxString, words: &CxxVector<CxxString>) -> Result<String, String> {


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Execute current query in Ctrl+R search in client if no history match found

Fixes: https://github.com/ClickHouse/ClickHouse/issues/81795 (cc @alexey-milovidov )