### PR TITLE
Stabilize 02319_lightweight_delete_on_merge_tree by draining mutations with a synchronous OPTIMIZE FINAL after DROP INDEX

### DIFF
--- a/tests/queries/0_stateless/02319_lightweight_delete_on_merge_tree.sql
+++ b/tests/queries/0_stateless/02319_lightweight_delete_on_merge_tree.sql
@@ -55,6 +55,8 @@ alter table t_light MATERIALIZE INDEX i_c SETTINGS mutations_sync=2;
 alter table t_light update b=-1 where a<3 SETTINGS mutations_sync=2;
 alter table t_light drop index i_c SETTINGS mutations_sync=2;
 
+optimize table t_light final SETTINGS mutations_sync=2;
+
 DETACH TABLE t_light;
 ATTACH TABLE t_light;
 CHECK TABLE t_light;

--- a/tests/queries/0_stateless/02319_lightweight_delete_on_merge_tree.sql
+++ b/tests/queries/0_stateless/02319_lightweight_delete_on_merge_tree.sql
@@ -55,11 +55,11 @@ alter table t_light MATERIALIZE INDEX i_c SETTINGS mutations_sync=2;
 alter table t_light update b=-1 where a<3 SETTINGS mutations_sync=2;
 alter table t_light drop index i_c SETTINGS mutations_sync=2;
 
-optimize table t_light final SETTINGS mutations_sync=2;
-
 DETACH TABLE t_light;
 ATTACH TABLE t_light;
 CHECK TABLE t_light;
+
+SYSTEM STOP MERGES t_light;
 
 SELECT command, is_done FROM system.mutations WHERE database = currentDatabase() AND table = 't_light';
 
@@ -68,6 +68,8 @@ select count(*) from t_light;
 select * from t_light order by a;
 
 select table, partition, name, rows from system.parts where database = currentDatabase() AND active and table ='t_light' order by name;
+
+SYSTEM START MERGES t_light;
 
 optimize table t_light final SETTINGS mutations_sync=2;
 select count(*) from t_light;


### PR DESCRIPTION
- CI failures show two pending mutations during assertions:
  - (UPDATE b = -1 WHERE a < 3) 0, (DROP INDEX i_c) 0
  - Data still 0 0 0 (expected 0 -1 0)
  - Parts ..._0_8 (expected ..._0_10)
- Potential Root cause: timing/race with background merges under fuzzed settings

Consitent failures this week with similar logs - https://play.clickhouse.com/play?user=play&run=1#V0lUSAogICAgOTAgQVMgaW50ZXJ2YWxfZGF5cwpTRUxFQ1QKICAgIHRvU3RhcnRPZkRheShjaGVja19zdGFydF90aW1lKSBBUyBkYXksCiAgICBjb3VudCgpIEFTIGZhaWx1cmVzLAogICAgZ3JvdXBVbmlxQXJyYXkocHVsbF9yZXF1ZXN0X251bWJlcikgQVMgcHJzLAogICAgYW55KHJlcG9ydF91cmwpIEFTIHJlcG9ydF91cmwKRlJPTSBjaGVja3MKV0hFUkUgKG5vdygpIC0gdG9JbnRlcnZhbERheShpbnRlcnZhbF9kYXlzKSkgPD0gY2hlY2tfc3RhcnRfdGltZQogICAgQU5EIHRlc3RfbmFtZSA9ICcwMjMxOV9saWdodHdlaWdodF9kZWxldGVfb25fbWVyZ2VfdHJlZScKICAgIC0tIEFORCBjaGVja19uYW1lID0gJ1N0YXRlbGVzcyB0ZXN0cyAoYW1kX2RlYnVnLCBBc3luY0luc2VydCwgczMgc3RvcmFnZSwgcGFyYWxsZWwpJwogICAgQU5EIHRlc3Rfc3RhdHVzIElOICgnRkFJTCcsICdFUlJPUicpCiAgICBBTkQgKChoZWFkX3JlZiA9ICdtYXN0ZXInIEFORCBwdWxsX3JlcXVlc3RfbnVtYmVyID0gMCkgT1IgcHVsbF9yZXF1ZXN0X251bWJlciAhPSAwKQpHUk9VUCBCWSBkYXkKT1JERVIgQlkgZGF5IERFU0MK

```
2025-12-21 06:03:05 Reason: result differs with reference:  
2025-12-21 06:03:05 --- /home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/tests/queries/0_stateless/02319_lightweight_delete_on_merge_tree.reference	2025-12-21 05:59:18.650102832 +0100
2025-12-21 06:03:05 +++ /home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/tests/queries/0_stateless/02319_lightweight_delete_on_merge_tree.stdout	2025-12-21 06:03:05.659743945 +0100
2025-12-21 06:03:05 @@ -4,32 +4,32 @@
2025-12-21 06:03:05  1
2025-12-21 06:03:05  0
2025-12-21 06:03:05  1
2025-12-21 06:03:05  -----lightweight mutation type-----
2025-12-21 06:03:05  1
2025-12-21 06:03:05  1
2025-12-21 06:03:05  1
2025-12-21 06:03:05  (UPDATE _row_exists = 0 WHERE (c % 5) = 1)	1
2025-12-21 06:03:05  (UPDATE _row_exists = 0 WHERE c = 4)	1
2025-12-21 06:03:05  (MATERIALIZE INDEX i_c)	1
2025-12-21 06:03:05 -(UPDATE b = -1 WHERE a < 3)	1
2025-12-21 06:03:05 -(DROP INDEX i_c)	1
2025-12-21 06:03:05 +(UPDATE b = -1 WHERE a < 3)	0
2025-12-21 06:03:05 +(DROP INDEX i_c)	0
2025-12-21 06:03:05  -----Check that select and merge with lightweight delete.-----
2025-12-21 06:03:05  7
2025-12-21 06:03:05 -0	-1	0
2025-12-21 06:03:05 +0	0	0
2025-12-21 06:03:05  2	-1	2
2025-12-21 06:03:05  3	3	3
2025-12-21 06:03:05  5	5	5
2025-12-21 06:03:05  7	7	7
2025-12-21 06:03:05  8	8	8
2025-12-21 06:03:05  9	9	9
2025-12-21 06:03:05 -t_light	0	0_1_1_0_10	2
2025-12-21 06:03:05 +t_light	0	0_1_1_0_8	2
```

Closes https://github.com/ClickHouse/ClickHouse/issues/92633 

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
