### PR TITLE
Fix "Cannot add action to empty ExpressionActionsChain" for ALTER TABLE REWRITE PARTS (v2)

### DIFF
--- a/src/Interpreters/MutationsInterpreter.cpp
+++ b/src/Interpreters/MutationsInterpreter.cpp
@@ -715,16 +715,7 @@ void MutationsInterpreter::prepare(bool dry_run)
     bool need_rebuild_projections = false;
     std::vector<String> read_columns;
 
-    if (has_lightweight_delete_materialization)
-    {
-        auto & stage = stages.emplace_back(context);
-        stage.affects_all_columns = true;
-
-        need_rebuild_indexes = true;
-        need_rebuild_projections = true;
-    }
-
-    if (has_rewrite_parts)
+    if (has_lightweight_delete_materialization || has_rewrite_parts)
     {
         auto & stage = stages.emplace_back(context);
         stage.affects_all_columns = true;

--- a/tests/queries/0_stateless/03640_multiple_mutations_with_rewrite_parts.reference
+++ b/tests/queries/0_stateless/03640_multiple_mutations_with_rewrite_parts.reference
@@ -16,3 +16,4 @@ select partition_id, rows, index_granularity_bytes_in_memory_allocated>25 from s
 0	2500	1
 1	2500	1
 select * from system.mutations where database = currentDatabase() and not is_done format Vertical;
+alter table test_materialize (APPLY DELETED MASK), (REWRITE PARTS);

--- a/tests/queries/0_stateless/03640_multiple_mutations_with_rewrite_parts.sql
+++ b/tests/queries/0_stateless/03640_multiple_mutations_with_rewrite_parts.sql
@@ -16,3 +16,5 @@ alter table test_materialize delete where (key % 2) == 0 settings mutations_sync
 select partition_id, rows, index_granularity_bytes_in_memory_allocated>25 from system.parts where database = currentDatabase() and table = 'test_materialize' and active order by 1;
 
 select * from system.mutations where database = currentDatabase() and not is_done format Vertical;
+
+alter table test_materialize (APPLY DELETED MASK), (REWRITE PARTS);


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix "Cannot add action to empty ExpressionActionsChain" for ALTER TABLE REWRITE PARTS (v2)

Fixes: https://github.com/ClickHouse/ClickHouse/issues/88150
Follow-up for: https://github.com/ClickHouse/ClickHouse/pull/88608