### PR TITLE
EXPLAIN indices = 1 now works as alias for indexes #92483

### DIFF
--- a/src/Interpreters/InterpreterExplainQuery.cpp
+++ b/src/Interpreters/InterpreterExplainQuery.cpp
@@ -261,6 +261,7 @@ struct QueryPlanSettings
             {"description", query_plan_options.description},
             {"actions", query_plan_options.actions},
             {"indexes", query_plan_options.indexes},
+            {"indices", query_plan_options.indexes},
             {"projections", query_plan_options.projections},
             {"optimize", optimize},
             {"json", json},

--- a/tests/queries/0_stateless/03644_explain_indices.reference
+++ b/tests/queries/0_stateless/03644_explain_indices.reference
@@ -1,0 +1,12 @@
+Expression ((Project names + Projection))
+  Expression ((WHERE + Change column names to column identifiers))
+    ReadFromMergeTree (default.test_indexed)
+    Indexes:
+      PrimaryKey
+        Keys:
+          id
+        Condition: (id in [5, 5])
+        Parts: 1/1
+        Granules: 1/1
+        Search Algorithm: binary search
+      Ranges: 1

--- a/tests/queries/0_stateless/03644_explain_indices.sql
+++ b/tests/queries/0_stateless/03644_explain_indices.sql
@@ -1,0 +1,16 @@
+-- Tags: no-fasttest
+
+CREATE TABLE IF NOT EXISTS test_indexed
+(
+    id UInt32,
+    value String
+) ENGINE = MergeTree()
+    ORDER BY id;
+
+INSERT INTO test_indexed VALUES
+                             (1,'a'),(5,'b'),(10,'c'),(15,'d'),(20,'e');
+
+EXPLAIN indices = 1
+SELECT *
+FROM test_indexed
+WHERE id = 5

--- a/tests/queries/0_stateless/03644_explain_indices.sql
+++ b/tests/queries/0_stateless/03644_explain_indices.sql
@@ -7,8 +7,8 @@ CREATE TABLE IF NOT EXISTS test_indexed
 ) ENGINE = MergeTree()
     ORDER BY id;
 
-INSERT INTO test_indexed VALUES
-                             (1,'a'),(5,'b'),(10,'c'),(15,'d'),(20,'e');
+INSERT INTO test_indexed
+VALUES (1,'a'),(5,'b'),(10,'c'),(15,'d'),(20,'e');
 
 EXPLAIN indices = 1
 SELECT *

--- a/tests/queries/0_stateless/03644_explain_indices.sql
+++ b/tests/queries/0_stateless/03644_explain_indices.sql
@@ -1,11 +1,14 @@
--- Tags: no-fasttest
+-- Tags: no-fasttest skip_msan skip_s3 skip_parallel skip_tsan no-parallel-replicas
 
-CREATE TABLE IF NOT EXISTS test_indexed
+
+DROP TABLE IF EXISTS test_indexed;
+
+CREATE TABLE test_indexed
 (
     id UInt32,
     value String
 ) ENGINE = MergeTree()
-    ORDER BY id;
+ORDER BY id;
 
 INSERT INTO test_indexed
 VALUES (1,'a'),(5,'b'),(10,'c'),(15,'d'),(20,'e');
@@ -14,3 +17,7 @@ EXPLAIN indices = 1
 SELECT *
 FROM test_indexed
 WHERE id = 5
+FORMAT TSVRaw;
+
+DROP TABLE test_indexed;
+

--- a/tests/queries/0_stateless/03644_explain_indices.sql
+++ b/tests/queries/0_stateless/03644_explain_indices.sql
@@ -1,5 +1,6 @@
--- Tags: no-fasttest skip_msan skip_s3 skip_parallel skip_tsan no-parallel-replicas
-
+-- Tags: no-replicated-database, no-parallel-replicas
+-- no-replicated-database: EXPLAIN output differs for replicated database.
+-- no-parallel-replicas: EXPLAIN output differs for parallel replicas.
 
 DROP TABLE IF EXISTS test_indexed;
 
@@ -10,14 +11,11 @@ CREATE TABLE test_indexed
 ) ENGINE = MergeTree()
 ORDER BY id;
 
-INSERT INTO test_indexed
-VALUES (1,'a'),(5,'b'),(10,'c'),(15,'d'),(20,'e');
+INSERT INTO test_indexed VALUES (1,'a'),(5,'b'),(10,'c'),(15,'d'),(20,'e');
 
 EXPLAIN indices = 1
 SELECT *
 FROM test_indexed
-WHERE id = 5
-FORMAT TSVRaw;
+WHERE id = 5;
 
 DROP TABLE test_indexed;
-


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Support `EXPLAIN indices = 1` as an alias for `EXPLAIN indexes = 1`. Closes https://github.com/ClickHouse/ClickHouse/issues/92483.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
