### PR TITLE
Follow-up to #92489

### DIFF
--- a/src/Analyzer/Resolve/evaluateScalarSubqueryIfNeeded.cpp
+++ b/src/Analyzer/Resolve/evaluateScalarSubqueryIfNeeded.cpp
@@ -49,7 +49,7 @@ namespace Setting
     extern const SettingsString implicit_table_at_top_level;
     extern const SettingsUInt64 use_structure_from_insertion_table_in_table_functions;
     extern const SettingsBool enable_scalar_subquery_optimization;
-    extern const SettingsUInt64 allow_experimental_parallel_reading_from_replicas;
+    extern const SettingsUInt64 enable_parallel_replicas;
 }
 
 namespace
@@ -132,7 +132,7 @@ void QueryAnalyzer::evaluateScalarSubqueryIfNeeded(QueryTreeNodePtr & node, Iden
         /// When execute `INSERT INTO t WITH ... SELECT ...`, it may lead to `Unknown columns`
         /// exception with this settings enabled(https://github.com/ClickHouse/ClickHouse/issues/52494).
         subquery_settings[Setting::use_structure_from_insertion_table_in_table_functions] = false;
-        subquery_settings[Setting::allow_experimental_parallel_reading_from_replicas] = 0;
+        subquery_settings[Setting::enable_parallel_replicas] = 0;
         subquery_context->setSettings(subquery_settings);
 
         auto query_tree = node->clone();

--- a/src/Client/HedgedConnections.cpp
+++ b/src/Client/HedgedConnections.cpp
@@ -18,7 +18,7 @@ namespace DB
 namespace Setting
 {
     extern const SettingsBool allow_changing_replica_until_first_data_packet;
-    extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool enable_analyzer;
     extern const SettingsUInt64 connections_with_failover_max_tries;
     extern const SettingsDialect dialect;
     extern const SettingsBool fallback_to_stale_replicas_for_distributed_queries;
@@ -231,11 +231,11 @@ void HedgedConnections::sendQuery(
             modified_settings[Setting::parallel_replica_offset] = fd_to_replica_location[replica.packet_receiver->getFileDescriptor()].offset;
         }
 
-        /// FIXME: Remove once we will make `allow_experimental_analyzer` obsolete setting.
+        /// FIXME: Remove once we will make `enable_analyzer` obsolete setting.
         /// Make the analyzer being set, so it will be effectively applied on the remote server.
         /// In other words, the initiator always controls whether the analyzer enabled or not for
         /// all servers involved in the distributed query processing.
-        modified_settings.set("allow_experimental_analyzer", static_cast<bool>(modified_settings[Setting::allow_experimental_analyzer]));
+        modified_settings.set("enable_analyzer", static_cast<bool>(modified_settings[Setting::enable_analyzer]));
 
         replica.connection->sendQuery(
             timeouts, query, /* query_parameters */ {}, query_id, stage, &modified_settings, &client_info, with_pending_data, external_roles, {});

--- a/src/Client/MultiplexedConnections.cpp
+++ b/src/Client/MultiplexedConnections.cpp
@@ -15,7 +15,7 @@ namespace DB
 {
 namespace Setting
 {
-    extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool enable_analyzer;
     extern const SettingsDialect dialect;
     extern const SettingsUInt64 group_by_two_level_threshold;
     extern const SettingsUInt64 group_by_two_level_threshold_bytes;
@@ -177,11 +177,11 @@ void MultiplexedConnections::sendQuery(
         client_info.number_of_current_replica = replica_info->number_of_current_replica;
     }
 
-    /// FIXME: Remove once we will make `allow_experimental_analyzer` obsolete setting.
+    /// FIXME: Remove once we will make `enable_analyzer` obsolete setting.
     /// Make the analyzer being set, so it will be effectively applied on the remote server.
     /// In other words, the initiator always controls whether the analyzer enabled or not for
     /// all servers involved in the distributed query processing.
-    modified_settings.set("allow_experimental_analyzer", static_cast<bool>(modified_settings[Setting::allow_experimental_analyzer]));
+    modified_settings.set("enable_analyzer", static_cast<bool>(modified_settings[Setting::enable_analyzer]));
 
     const bool enable_offset_parallel_processing = context->canUseOffsetParallelReplicas();
 

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -5781,10 +5781,10 @@ Use query plan for lazy materialization optimization.
     DECLARE(Bool, enable_lazy_columns_replication, true, R"(
 Enables lazy columns replication in JOIN and ARRAY JOIN, it allows to avoid unnecessary copy of the same rows multiple times in memory.
 )", 0) \
-    DECLARE_WITH_ALIAS(Bool, query_plan_use_new_logical_join_step, true, R"(
+    DECLARE_WITH_ALIAS(Bool, query_plan_use_logical_join_step, true, R"(
 Use logical join step in query plan.
 Note: setting `query_plan_use_new_logical_join_step` is deprecated, use `query_plan_use_logical_join_step` instead.
-)", 0, query_plan_use_logical_join_step) \
+)", 0, query_plan_use_new_logical_join_step) \
     DECLARE(Bool, serialize_query_plan, false, R"(
 Serialize query plan for distributed processing
 )", 0) \
@@ -6820,9 +6820,9 @@ For testing purposes. Replaces all external table functions to Null to not initi
 Replace external dictionary sources to Null on restore. Useful for testing purposes
 )", 0) \
         /* Parallel replicas */ \
-    DECLARE_WITH_ALIAS(UInt64, allow_experimental_parallel_reading_from_replicas, 0, R"(
+    DECLARE_WITH_ALIAS(UInt64, enable_parallel_replicas, 0, R"(
 Use up to `max_parallel_replicas` the number of replicas from each shard for SELECT query execution. Reading is parallelized and coordinated dynamically. 0 - disabled, 1 - enabled, silently disable them in case of failure, 2 - enabled, throw an exception in case of failure
-)", 0, enable_parallel_replicas) \
+)", 0, allow_experimental_parallel_reading_from_replicas) \
     DECLARE(UInt64, automatic_parallel_replicas_mode, 0, R"(
 Enable automatic switching to execution with parallel replicas based on collected statistics. Requires enabling `parallel_replicas_local_plan` and providing `cluster_for_parallel_replicas`.
 0 - disabled, 1 - enabled, 2 - only statistics collection is enabled (switching to execution with parallel replicas is disabled).
@@ -6932,18 +6932,18 @@ Replace table function engines with their -Cluster alternatives
     DECLARE(Bool, parallel_replicas_allow_materialized_views, true, R"(
 Allow usage of materialized views with parallel replicas
 )", 0) \
-    DECLARE_WITH_ALIAS(Bool, allow_experimental_database_iceberg, false, R"(
+    DECLARE_WITH_ALIAS(Bool, allow_database_iceberg, false, R"(
 Allow experimental database engine DataLakeCatalog with catalog_type = 'iceberg'
-)", BETA, allow_database_iceberg) \
-    DECLARE_WITH_ALIAS(Bool, allow_experimental_database_unity_catalog, false, R"(
+)", BETA, allow_experimental_database_iceberg) \
+    DECLARE_WITH_ALIAS(Bool, allow_database_unity_catalog, false, R"(
 Allow experimental database engine DataLakeCatalog with catalog_type = 'unity'
-)", BETA, allow_database_unity_catalog) \
-    DECLARE_WITH_ALIAS(Bool, allow_experimental_database_glue_catalog, false, R"(
+)", BETA, allow_experimental_database_unity_catalog) \
+    DECLARE_WITH_ALIAS(Bool, allow_database_glue_catalog, false, R"(
 Allow experimental database engine DataLakeCatalog with catalog_type = 'glue'
-)", BETA, allow_database_glue_catalog) \
-    DECLARE_WITH_ALIAS(Bool, allow_experimental_analyzer, true, R"(
+)", BETA, allow_experimental_database_glue_catalog) \
+    DECLARE_WITH_ALIAS(Bool, enable_analyzer, true, R"(
 Allow new query analyzer.
-)", IMPORTANT, enable_analyzer) \
+)", IMPORTANT, allow_experimental_analyzer) \
     DECLARE(Bool, analyzer_compatibility_join_using_top_level_identifier, false, R"(
 Force to resolve identifier in JOIN USING from projection (for example, in `SELECT a + 1 AS b FROM t1 JOIN t2 USING (b)` join will be performed by `t1.a + 1 = t2.b`, rather then `t1.b = t2.b`).
 )", 0) \

--- a/src/Databases/DataLake/DatabaseDataLake.cpp
+++ b/src/Databases/DataLake/DatabaseDataLake.cpp
@@ -60,9 +60,9 @@ namespace DatabaseDataLakeSetting
 
 namespace Setting
 {
-    extern const SettingsBool allow_experimental_database_iceberg;
-    extern const SettingsBool allow_experimental_database_unity_catalog;
-    extern const SettingsBool allow_experimental_database_glue_catalog;
+    extern const SettingsBool allow_database_iceberg;
+    extern const SettingsBool allow_database_unity_catalog;
+    extern const SettingsBool allow_database_glue_catalog;
     extern const SettingsBool allow_experimental_database_hms_catalog;
     extern const SettingsBool use_hive_partitioning;
     extern const SettingsBool parallel_replicas_for_cluster_engines;
@@ -846,7 +846,7 @@ void registerDatabaseDataLake(DatabaseFactory & factory)
             case DatabaseDataLakeCatalogType::ICEBERG_REST:
             {
                 if (!args.create_query.attach
-                    && !args.context->getSettingsRef()[Setting::allow_experimental_database_iceberg])
+                    && !args.context->getSettingsRef()[Setting::allow_database_iceberg])
                 {
                     throw Exception(ErrorCodes::SUPPORT_IS_DISABLED,
                                     "DatabaseDataLake with Iceberg Rest catalog is beta. "
@@ -859,7 +859,7 @@ void registerDatabaseDataLake(DatabaseFactory & factory)
             case DatabaseDataLakeCatalogType::GLUE:
             {
                 if (!args.create_query.attach
-                    && !args.context->getSettingsRef()[Setting::allow_experimental_database_glue_catalog])
+                    && !args.context->getSettingsRef()[Setting::allow_database_glue_catalog])
                 {
                     throw Exception(ErrorCodes::SUPPORT_IS_DISABLED,
                                     "DatabaseDataLake with Glue catalog is beta. "
@@ -872,7 +872,7 @@ void registerDatabaseDataLake(DatabaseFactory & factory)
             case DatabaseDataLakeCatalogType::UNITY:
             {
                 if (!args.create_query.attach
-                    && !args.context->getSettingsRef()[Setting::allow_experimental_database_unity_catalog])
+                    && !args.context->getSettingsRef()[Setting::allow_database_unity_catalog])
                 {
                     throw Exception(ErrorCodes::SUPPORT_IS_DISABLED,
                                     "DataLake database with Unity catalog catalog is beta. "

--- a/src/Functions/isNotNull.cpp
+++ b/src/Functions/isNotNull.cpp
@@ -16,7 +16,7 @@ namespace DB
 {
 namespace Setting
 {
-    extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool enable_analyzer;
 }
 
 namespace
@@ -31,7 +31,7 @@ public:
 
     static FunctionPtr create(ContextPtr context)
     {
-        return std::make_shared<FunctionIsNotNull>(context->getSettingsRef()[Setting::allow_experimental_analyzer]);
+        return std::make_shared<FunctionIsNotNull>(context->getSettingsRef()[Setting::enable_analyzer]);
     }
 
     explicit FunctionIsNotNull(bool use_analyzer_) : use_analyzer(use_analyzer_) {}

--- a/src/Functions/isNull.cpp
+++ b/src/Functions/isNull.cpp
@@ -15,12 +15,12 @@ namespace DB
 {
 namespace Setting
 {
-    extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool enable_analyzer;
 }
 
 FunctionPtr FunctionIsNull::create(ContextPtr context)
 {
-    return std::make_shared<FunctionIsNull>(context->getSettingsRef()[Setting::allow_experimental_analyzer]);
+    return std::make_shared<FunctionIsNull>(context->getSettingsRef()[Setting::enable_analyzer]);
 }
 
 ColumnPtr FunctionIsNull::getConstantResultForNonConstArguments(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type) const

--- a/src/Functions/isNull.h
+++ b/src/Functions/isNull.h
@@ -8,7 +8,7 @@ namespace DB
 {
 namespace Setting
 {
-    extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool enable_analyzer;
 }
 
 /// Implements the function isNull which returns true if a value

--- a/src/Functions/isNullable.cpp
+++ b/src/Functions/isNullable.cpp
@@ -10,7 +10,7 @@ namespace DB
 {
 namespace Setting
 {
-    extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool enable_analyzer;
 }
 
 namespace
@@ -23,7 +23,7 @@ public:
     static constexpr auto name = "isNullable";
     static FunctionPtr create(ContextPtr context)
     {
-        return std::make_shared<FunctionIsNullable>(context->getSettingsRef()[Setting::allow_experimental_analyzer]);
+        return std::make_shared<FunctionIsNullable>(context->getSettingsRef()[Setting::enable_analyzer]);
     }
 
     explicit FunctionIsNullable(bool use_analyzer_) : use_analyzer(use_analyzer_) {}

--- a/src/Interpreters/ActionsVisitor.cpp
+++ b/src/Interpreters/ActionsVisitor.cpp
@@ -61,7 +61,7 @@ namespace DB
 {
 namespace Setting
 {
-    extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool enable_analyzer;
     extern const SettingsBool force_grouping_standard_compatibility;
     extern const SettingsUInt64 max_ast_elements;
     extern const SettingsBool transform_null_in;
@@ -1451,7 +1451,7 @@ FutureSetPtr ActionsMatcher::makeSet(const ASTFunction & node, Data & data, bool
             return {};
 
         PreparedSets::Hash set_key;
-        if (data.getContext()->getSettingsRef()[Setting::allow_experimental_analyzer] && !identifier)
+        if (data.getContext()->getSettingsRef()[Setting::enable_analyzer] && !identifier)
         {
             /// Here we can be only from mutation interpreter. Normal selects with analyzed use other interpreter.
             /// This is a hacky way to allow reusing cache for prepared sets.

--- a/src/Interpreters/ApplyWithSubqueryVisitor.cpp
+++ b/src/Interpreters/ApplyWithSubqueryVisitor.cpp
@@ -20,7 +20,7 @@ namespace DB
 
 namespace Setting
 {
-extern const SettingsBool allow_experimental_analyzer;
+extern const SettingsBool enable_analyzer;
 }
 
 namespace ErrorCodes
@@ -29,7 +29,7 @@ extern const int UNSUPPORTED_METHOD;
 }
 
 ApplyWithSubqueryVisitor::ApplyWithSubqueryVisitor(ContextPtr context_)
-    : use_analyzer(context_->getSettingsRef()[Setting::allow_experimental_analyzer])
+    : use_analyzer(context_->getSettingsRef()[Setting::enable_analyzer])
 {
 }
 

--- a/src/Interpreters/AsynchronousInsertQueue.cpp
+++ b/src/Interpreters/AsynchronousInsertQueue.cpp
@@ -64,7 +64,6 @@ namespace DB
 {
 namespace Setting
 {
-    extern const SettingsUInt64 allow_experimental_parallel_reading_from_replicas;
     extern const SettingsBool allow_experimental_query_deduplication;
     extern const SettingsDouble async_insert_busy_timeout_decrease_rate;
     extern const SettingsDouble async_insert_busy_timeout_increase_rate;

--- a/src/Interpreters/ClusterProxy/SelectStreamFactory.cpp
+++ b/src/Interpreters/ClusterProxy/SelectStreamFactory.cpp
@@ -38,7 +38,7 @@ namespace DB
 {
 namespace Setting
 {
-    extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool enable_analyzer;
     extern const SettingsBool fallback_to_stale_replicas_for_distributed_queries;
     extern const SettingsUInt64 max_replica_delay_for_distributed_queries;
     extern const SettingsBool prefer_localhost_replica;
@@ -77,7 +77,7 @@ ASTPtr rewriteSelectQuery(
     // are written into the query context and will be sent by the query pipeline.
     select_query.setExpression(ASTSelectQuery::Expression::SETTINGS, {});
 
-    if (!context->getSettingsRef()[Setting::allow_experimental_analyzer])
+    if (!context->getSettingsRef()[Setting::enable_analyzer])
     {
         if (table_function_ptr)
             select_query.addTableFunction(table_function_ptr);
@@ -175,7 +175,7 @@ void SelectStreamFactory::createForShardImpl(
 
         /// Disable for distributed_group_by_no_merge now, because distributed-over-distributed only works up to FetchColumns,
         /// But distributed_group_by_no_merge requires Complete.
-        if (settings[Setting::allow_experimental_analyzer] && settings[Setting::serialize_query_plan] && !settings[Setting::distributed_group_by_no_merge])
+        if (settings[Setting::enable_analyzer] && settings[Setting::serialize_query_plan] && !settings[Setting::distributed_group_by_no_merge])
         {
             query_plan = createLocalPlan(
                 query_ast, *header, context, processed_stage, shard_info.shard_num, shard_count, true, shard_info.default_database);
@@ -184,7 +184,7 @@ void SelectStreamFactory::createForShardImpl(
         }
         else
         {
-            if (settings[Setting::allow_experimental_analyzer])
+            if (settings[Setting::enable_analyzer])
                 std::tie(shard_header, planner_context) = InterpreterSelectQueryAnalyzer::getSampleBlockAndPlannerContext(query_tree, context, SelectQueryOptions(processed_stage).analyze());
             else
                 shard_header = header;

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -259,7 +259,7 @@ namespace DB
 {
 namespace Setting
 {
-    extern const SettingsUInt64 allow_experimental_parallel_reading_from_replicas;
+    extern const SettingsUInt64 enable_parallel_replicas;
     extern const SettingsMilliseconds async_insert_poll_timeout_ms;
     extern const SettingsBool azure_allow_parallel_part_upload;
     extern const SettingsString cluster_for_parallel_replicas;
@@ -322,7 +322,7 @@ namespace Setting
     extern const SettingsUInt64 use_structure_from_insertion_table_in_table_functions;
     extern const SettingsString workload;
     extern const SettingsString compatibility;
-    extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool enable_analyzer;
     extern const SettingsBool parallel_replicas_only_with_analyzer;
     extern const SettingsBool enable_hdfs_pread;
     extern const SettingsUInt64 max_reverse_dictionary_lookup_cache_size_bytes;
@@ -7086,10 +7086,10 @@ bool Context::canUseTaskBasedParallelReplicas() const
 {
     const auto & settings_ref = getSettingsRef();
 
-    if (!settings_ref[Setting::allow_experimental_analyzer] && settings_ref[Setting::parallel_replicas_only_with_analyzer])
+    if (!settings_ref[Setting::enable_analyzer] && settings_ref[Setting::parallel_replicas_only_with_analyzer])
         return false;
 
-    return settings_ref[Setting::allow_experimental_parallel_reading_from_replicas] > 0
+    return settings_ref[Setting::enable_parallel_replicas] > 0
         && settings_ref[Setting::parallel_replicas_mode] == ParallelReplicasMode::READ_TASKS
         && settings_ref[Setting::max_parallel_replicas] > 1;
 }
@@ -7109,7 +7109,7 @@ bool Context::canUseParallelReplicasCustomKey() const
     const auto & settings_ref = getSettingsRef();
 
     const bool has_enough_servers = settings_ref[Setting::max_parallel_replicas] > 1;
-    const bool parallel_replicas_enabled = settings_ref[Setting::allow_experimental_parallel_reading_from_replicas] > 0;
+    const bool parallel_replicas_enabled = settings_ref[Setting::enable_parallel_replicas] > 0;
     const bool is_parallel_replicas_with_custom_key =
         settings_ref[Setting::parallel_replicas_mode] == ParallelReplicasMode::CUSTOM_KEY_SAMPLING ||
         settings_ref[Setting::parallel_replicas_mode] == ParallelReplicasMode::CUSTOM_KEY_RANGE;
@@ -7132,7 +7132,7 @@ bool Context::canUseOffsetParallelReplicas() const
      * We combine them together into one group for convenience.
      */
     const bool has_enough_servers = settings_ref[Setting::max_parallel_replicas] > 1;
-    const bool parallel_replicas_enabled = settings_ref[Setting::allow_experimental_parallel_reading_from_replicas] > 0;
+    const bool parallel_replicas_enabled = settings_ref[Setting::enable_parallel_replicas] > 0;
     const bool is_parallel_replicas_with_custom_key_or_native_sampling_key =
         settings_ref[Setting::parallel_replicas_mode] == ParallelReplicasMode::SAMPLING_KEY ||
         settings_ref[Setting::parallel_replicas_mode] == ParallelReplicasMode::CUSTOM_KEY_SAMPLING ||

--- a/src/Interpreters/GlobalSubqueriesVisitor.cpp
+++ b/src/Interpreters/GlobalSubqueriesVisitor.cpp
@@ -31,7 +31,7 @@ namespace DB
 {
 namespace Setting
 {
-    extern const SettingsUInt64 allow_experimental_parallel_reading_from_replicas;
+    extern const SettingsUInt64 enable_parallel_replicas;
     extern const SettingsBool parallel_replicas_allow_in_with_subquery;
     extern const SettingsBool prefer_global_in_and_join;
 }
@@ -176,13 +176,13 @@ void GlobalSubqueriesMatcher::visit(ASTFunction & func, ASTPtr &, Data & data)
             /// We don't enable parallel replicas for IN (subquery)
             if (!settings[Setting::parallel_replicas_allow_in_with_subquery] && ast->as<ASTSubquery>())
             {
-                if (settings[Setting::allow_experimental_parallel_reading_from_replicas] == 1)
+                if (settings[Setting::enable_parallel_replicas] == 1)
                 {
                     LOG_DEBUG(getLogger("GlobalSubqueriesMatcher"), "IN with subquery is not supported with parallel replicas");
-                    data.getContext()->getQueryContext()->setSetting("allow_experimental_parallel_reading_from_replicas", Field(0));
+                    data.getContext()->getQueryContext()->setSetting("enable_parallel_replicas", Field(0));
                     return;
                 }
-                if (settings[Setting::allow_experimental_parallel_reading_from_replicas] >= 2)
+                if (settings[Setting::enable_parallel_replicas] >= 2)
                     throw Exception(ErrorCodes::SUPPORT_IS_DISABLED, "IN with subquery is not supported with parallel replicas");
             }
         }
@@ -233,13 +233,13 @@ void GlobalSubqueriesMatcher::visit(ASTTablesInSelectQueryElement & table_elem, 
 
             if (!is_subquery)
             {
-                if (settings[Setting::allow_experimental_parallel_reading_from_replicas] == 1)
+                if (settings[Setting::enable_parallel_replicas] == 1)
                 {
                     LOG_DEBUG(getLogger("GlobalSubqueriesMatcher"), "JOIN with parallel replicas is only supported with subqueries");
-                    data.getContext()->getQueryContext()->setSetting("allow_experimental_parallel_reading_from_replicas", Field(0));
+                    data.getContext()->getQueryContext()->setSetting("enable_parallel_replicas", Field(0));
                     return;
                 }
-                if (settings[Setting::allow_experimental_parallel_reading_from_replicas] >= 2)
+                if (settings[Setting::enable_parallel_replicas] >= 2)
                     throw Exception(ErrorCodes::SUPPORT_IS_DISABLED, "JOIN with parallel replicas is only supported with subqueries");
             }
         }

--- a/src/Interpreters/IInterpreterUnionOrSelectQuery.cpp
+++ b/src/Interpreters/IInterpreterUnionOrSelectQuery.cpp
@@ -22,7 +22,7 @@ namespace DB
 {
 namespace Setting
 {
-    extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool enable_analyzer;
     extern const SettingsString additional_result_filter;
     extern const SettingsUInt64 max_bytes_to_read;
     extern const SettingsUInt64 max_bytes_to_read_leaf;
@@ -57,12 +57,12 @@ IInterpreterUnionOrSelectQuery::IInterpreterUnionOrSelectQuery(
     /// it's possible that new analyzer will be enabled in ::getQueryProcessingStage method
     /// of the underlying storage when all other parts of infrastructure are not ready for it
     /// (built with old analyzer).
-    if (context->getSettingsRef()[Setting::allow_experimental_analyzer])
+    if (context->getSettingsRef()[Setting::enable_analyzer])
     {
         LOG_TRACE(getLogger("IInterpreterUnionOrSelectQuery"),
-            "The new analyzer is enabled, but the old interpreter is used. It can be a bug, please report it. Will disable 'allow_experimental_analyzer' setting (for query: {})",
+            "The new analyzer is enabled, but the old interpreter is used. It can be a bug, please report it. Will disable 'enable_analyzer' setting (for query: {})",
             query_ptr->formatForLogging());
-        context->setSetting("allow_experimental_analyzer", false);
+        context->setSetting("enable_analyzer", false);
     }
 
     if (options.shard_num)

--- a/src/Interpreters/InsertDependenciesBuilder.cpp
+++ b/src/Interpreters/InsertDependenciesBuilder.cpp
@@ -111,7 +111,7 @@ namespace DB
 {
 namespace Setting
 {
-    extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool enable_analyzer;
     extern const SettingsUInt64 min_insert_block_size_rows;
     extern const SettingsUInt64 min_insert_block_size_bytes;
     extern const SettingsBool async_insert_deduplicate;
@@ -622,7 +622,7 @@ private:
 
         QueryPipelineBuilder pipeline;
 
-        if (local_context->getSettingsRef()[Setting::allow_experimental_analyzer])
+        if (local_context->getSettingsRef()[Setting::enable_analyzer])
         {
             InterpreterSelectQueryAnalyzer interpreter(select_query, local_context,local_context->getViewSource(), SelectQueryOptions().ignoreAccessCheck());
             pipeline = interpreter.buildQueryPipeline();

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -107,7 +107,7 @@ namespace DB
 {
 namespace Setting
 {
-    extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool enable_analyzer;
     extern const SettingsBool allow_experimental_codecs;
     extern const SettingsBool allow_experimental_database_materialized_postgresql;
     extern const SettingsBool enable_full_text_index;
@@ -930,7 +930,7 @@ InterpreterCreateQuery::TableProperties InterpreterCreateQuery::getTableProperti
 
         SharedHeader as_select_sample;
 
-        if (getContext()->getSettingsRef()[Setting::allow_experimental_analyzer])
+        if (getContext()->getSettingsRef()[Setting::enable_analyzer])
         {
             as_select_sample = InterpreterSelectQueryAnalyzer::getSampleBlock(create.select->clone(), getContext());
         }
@@ -1082,7 +1082,7 @@ void InterpreterCreateQuery::validateMaterializedViewColumnsAndEngine(const ASTC
     {
         try
         {
-            if (getContext()->getSettingsRef()[Setting::allow_experimental_analyzer])
+            if (getContext()->getSettingsRef()[Setting::enable_analyzer])
             {
                 /// We should treat SELECT as an initial query in order to properly analyze it.
                 auto context = Context::createCopy(getContext());

--- a/src/Interpreters/InterpreterDescribeQuery.cpp
+++ b/src/Interpreters/InterpreterDescribeQuery.cpp
@@ -26,7 +26,7 @@ namespace DB
 {
 namespace Setting
 {
-    extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool enable_analyzer;
     extern const SettingsBool describe_compact_output;
     extern const SettingsBool describe_include_subcolumns;
     extern const SettingsBool describe_include_virtual_columns;
@@ -137,7 +137,7 @@ void InterpreterDescribeQuery::fillColumnsFromSubquery(const ASTTableExpression 
     auto select_query = table_expression.subquery->children.at(0);
     auto current_context = getContext();
 
-    if (settings[Setting::allow_experimental_analyzer])
+    if (settings[Setting::enable_analyzer])
     {
         SelectQueryOptions select_query_options;
         sample_block = InterpreterSelectQueryAnalyzer(select_query, current_context, select_query_options).getSampleBlock();

--- a/src/Interpreters/InterpreterExplainQuery.cpp
+++ b/src/Interpreters/InterpreterExplainQuery.cpp
@@ -43,7 +43,7 @@ namespace DB
 {
 namespace Setting
 {
-    extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool enable_analyzer;
     extern const SettingsBool allow_statistics_optimize;
     extern const SettingsBool format_display_secrets_in_show_and_select;
     extern const SettingsUInt64 query_plan_max_step_description_length;
@@ -518,7 +518,7 @@ QueryPipeline InterpreterExplainQuery::executeImpl()
         {
             auto settings = checkAndGetSettings<QuerySyntaxSettings>(ast.getSettings());
 
-            if (query_context->getSettingsRef()[Setting::allow_experimental_analyzer])
+            if (query_context->getSettingsRef()[Setting::enable_analyzer])
             {
                 bool explain_ok = explainQueryTree(ast.getExplainedQuery(), query_context, QueryTreeSettings{
                     .run_passes = settings.run_query_tree_passes,
@@ -532,7 +532,7 @@ QueryPipeline InterpreterExplainQuery::executeImpl()
                 if (explain_ok)
                     break;
                 auto query_context_mutable = Context::createCopy(query_context);
-                query_context_mutable->setSetting("allow_experimental_analyzer", false);
+                query_context_mutable->setSetting("enable_analyzer", false);
                 query_context = std::move(query_context_mutable);
             }
 
@@ -544,7 +544,7 @@ QueryPipeline InterpreterExplainQuery::executeImpl()
         }
         case ASTExplainQuery::QueryTree:
         {
-            if (!query_context->getSettingsRef()[Setting::allow_experimental_analyzer])
+            if (!query_context->getSettingsRef()[Setting::enable_analyzer])
                 throw Exception(ErrorCodes::NOT_IMPLEMENTED,
                     "EXPLAIN QUERY TREE is only supported with a new analyzer. SET enable_analyzer = 1.");
 
@@ -567,7 +567,7 @@ QueryPipeline InterpreterExplainQuery::executeImpl()
 
             ContextPtr context;
 
-            if (query_context->getSettingsRef()[Setting::allow_experimental_analyzer])
+            if (query_context->getSettingsRef()[Setting::enable_analyzer])
             {
                 InterpreterSelectQueryAnalyzer interpreter(ast.getExplainedQuery(), query_context, options);
                 context = interpreter.getContext();
@@ -622,7 +622,7 @@ QueryPipeline InterpreterExplainQuery::executeImpl()
                 QueryPlan plan;
                 ContextPtr context;
 
-                if (query_context->getSettingsRef()[Setting::allow_experimental_analyzer])
+                if (query_context->getSettingsRef()[Setting::enable_analyzer])
                 {
                     InterpreterSelectQueryAnalyzer interpreter(ast.getExplainedQuery(), query_context, options);
                     context = interpreter.getContext();
@@ -685,7 +685,7 @@ QueryPipeline InterpreterExplainQuery::executeImpl()
             QueryPlan plan;
             ContextPtr context = query_context;
 
-            if (context->getSettingsRef()[Setting::allow_experimental_analyzer])
+            if (context->getSettingsRef()[Setting::enable_analyzer])
             {
                 InterpreterSelectQueryAnalyzer interpreter(ast.getExplainedQuery(), query_context, SelectQueryOptions());
                 context = interpreter.getContext();

--- a/src/Interpreters/InterpreterFactory.cpp
+++ b/src/Interpreters/InterpreterFactory.cpp
@@ -87,7 +87,7 @@ namespace DB
 {
 namespace Setting
 {
-    extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool enable_analyzer;
     extern const SettingsBool insert_allow_materialized_columns;
 }
 
@@ -138,7 +138,7 @@ InterpreterFactory::InterpreterPtr InterpreterFactory::get(ASTPtr & query, Conte
 
     if (query->as<ASTSelectQuery>())
     {
-        if (context->getSettingsRef()[Setting::allow_experimental_analyzer])
+        if (context->getSettingsRef()[Setting::enable_analyzer])
             interpreter_name = "InterpreterSelectQueryAnalyzer";
         /// This is internal part of ASTSelectWithUnionQuery.
         /// Even if there is SELECT without union, it is represented by ASTSelectWithUnionQuery with single ASTSelectQuery as a child.
@@ -149,7 +149,7 @@ InterpreterFactory::InterpreterPtr InterpreterFactory::get(ASTPtr & query, Conte
     {
         ProfileEvents::increment(ProfileEvents::SelectQuery);
 
-        if (context->getSettingsRef()[Setting::allow_experimental_analyzer])
+        if (context->getSettingsRef()[Setting::enable_analyzer])
             interpreter_name = "InterpreterSelectQueryAnalyzer";
         else
             interpreter_name = "InterpreterSelectWithUnionQuery";
@@ -242,7 +242,7 @@ InterpreterFactory::InterpreterPtr InterpreterFactory::get(ASTPtr & query, Conte
     {
         const auto kind = query->as<ASTExplainQuery>()->getKind();
         if (kind == ASTExplainQuery::ParsedAST)
-            context->setSetting("allow_experimental_analyzer", false);
+            context->setSetting("enable_analyzer", false);
 
         interpreter_name = "InterpreterExplainQuery";
     }

--- a/src/Interpreters/InterpreterInsertQuery.cpp
+++ b/src/Interpreters/InterpreterInsertQuery.cpp
@@ -64,7 +64,7 @@ namespace DB
 {
 namespace Setting
 {
-    extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool enable_analyzer;
     extern const SettingsBool distributed_foreground_insert;
     extern const SettingsBool insert_null_as_default;
     extern const SettingsBool optimize_trivial_insert_select;
@@ -82,7 +82,6 @@ namespace Setting
     extern const SettingsSeconds lock_acquire_timeout;
     extern const SettingsUInt64 parallel_distributed_insert_select;
     extern const SettingsBool enable_parsing_to_custom_serialization;
-    extern const SettingsUInt64 allow_experimental_parallel_reading_from_replicas;
     extern const SettingsBool parallel_replicas_local_plan;
     extern const SettingsBool parallel_replicas_insert_select_local_pipeline;
     extern const SettingsBool async_query_sending_for_remote;
@@ -150,7 +149,7 @@ StoragePtr InterpreterInsertQuery::getTable(ASTInsertQuery & query)
             SharedHeader header_block;
             auto select_query_options = SelectQueryOptions(QueryProcessingStage::Complete, 1);
 
-            if (current_context->getSettingsRef()[Setting::allow_experimental_analyzer])
+            if (current_context->getSettingsRef()[Setting::enable_analyzer])
             {
                 header_block = InterpreterSelectQueryAnalyzer::getSampleBlock(query.select, current_context, select_query_options);
             }
@@ -159,7 +158,7 @@ StoragePtr InterpreterInsertQuery::getTable(ASTInsertQuery & query)
                 ASTPtr input_function;
                 query.tryFindInputFunction(input_function);
                 if (input_function)
-                    throw Exception(ErrorCodes::QUERY_IS_PROHIBITED, "Schema inference is not supported with allow_experimental_analyzer=0 for INSERT INTO FUNCTION ... SELECT FROM input()");
+                    throw Exception(ErrorCodes::QUERY_IS_PROHIBITED, "Schema inference is not supported with enable_analyzer=0 for INSERT INTO FUNCTION ... SELECT FROM input()");
 
                 InterpreterSelectWithUnionQuery interpreter_select{
                     query.select, current_context, select_query_options};
@@ -613,7 +612,7 @@ QueryPipeline InterpreterInsertQuery::buildInsertSelectPipeline(ASTInsertQuery &
         auto select_query_options = SelectQueryOptions(QueryProcessingStage::Complete, 1);
 
         const Settings & settings = select_context->getSettingsRef();
-        if (settings[Setting::allow_experimental_analyzer])
+        if (settings[Setting::enable_analyzer])
         {
             InterpreterSelectQueryAnalyzer interpreter_select_analyzer(query.select, select_context, select_query_options);
             return interpreter_select_analyzer.buildQueryPipeline();
@@ -694,7 +693,7 @@ std::optional<QueryPipeline> InterpreterInsertQuery::buildInsertSelectPipelinePa
 {
     auto context_ptr = getContext();
     const Settings & settings = context_ptr->getSettingsRef();
-    if (!settings[Setting::allow_experimental_analyzer])
+    if (!settings[Setting::enable_analyzer])
         return {};
 
     if (!context_ptr->canUseParallelReplicasOnInitiator())

--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -129,7 +129,7 @@ namespace Setting
     extern const SettingsMap additional_table_filters;
     extern const SettingsUInt64 aggregation_in_order_max_block_bytes;
     extern const SettingsUInt64 aggregation_memory_efficient_merge_threads;
-    extern const SettingsUInt64 allow_experimental_parallel_reading_from_replicas;
+    extern const SettingsUInt64 enable_parallel_replicas;
     extern const SettingsBool allow_experimental_query_deduplication;
     extern const SettingsBool async_socket_for_remote;
     extern const SettingsBool collect_hash_table_stats_during_aggregation;
@@ -629,12 +629,12 @@ InterpreterSelectQuery::InterpreterSelectQuery(
     bool is_query_with_final = isQueryWithFinal(query_info);
     if (is_query_with_final && context->canUseTaskBasedParallelReplicas())
     {
-        if (settings[Setting::allow_experimental_parallel_reading_from_replicas] == 1)
+        if (settings[Setting::enable_parallel_replicas] == 1)
         {
             LOG_DEBUG(log, "FINAL modifier is not supported with parallel replicas. Query will be executed without using them.");
-            context->setSetting("allow_experimental_parallel_reading_from_replicas", Field(0));
+            context->setSetting("enable_parallel_replicas", Field(0));
         }
-        else if (settings[Setting::allow_experimental_parallel_reading_from_replicas] >= 2)
+        else if (settings[Setting::enable_parallel_replicas] >= 2)
         {
             throw Exception(ErrorCodes::SUPPORT_IS_DISABLED, "FINAL modifier is not supported with parallel replicas");
         }
@@ -642,15 +642,15 @@ InterpreterSelectQuery::InterpreterSelectQuery(
 
     /// Check support for parallel replicas for non-replicated storage (plain MergeTree)
     bool is_plain_merge_tree = storage && storage->isMergeTree() && !storage->supportsReplication();
-    if (is_plain_merge_tree && settings[Setting::allow_experimental_parallel_reading_from_replicas] > 0
+    if (is_plain_merge_tree && settings[Setting::enable_parallel_replicas] > 0
         && !settings[Setting::parallel_replicas_for_non_replicated_merge_tree])
     {
-        if (settings[Setting::allow_experimental_parallel_reading_from_replicas] == 1)
+        if (settings[Setting::enable_parallel_replicas] == 1)
         {
             LOG_DEBUG(log, "To use parallel replicas with plain MergeTree tables please enable setting `parallel_replicas_for_non_replicated_merge_tree`. For now query will be executed without using them.");
-            context->setSetting("allow_experimental_parallel_reading_from_replicas", Field(0));
+            context->setSetting("enable_parallel_replicas", Field(0));
         }
-        else if (settings[Setting::allow_experimental_parallel_reading_from_replicas] >= 2)
+        else if (settings[Setting::enable_parallel_replicas] >= 2)
         {
             throw Exception(ErrorCodes::SUPPORT_IS_DISABLED, "To use parallel replicas with plain MergeTree tables please enable setting `parallel_replicas_for_non_replicated_merge_tree`");
         }
@@ -940,10 +940,10 @@ InterpreterSelectQuery::InterpreterSelectQuery(
     };
 
 
-    /// This is a hack to make sure we reanalyze if GlobalSubqueriesVisitor changed allow_experimental_parallel_reading_from_replicas
+    /// This is a hack to make sure we reanalyze if GlobalSubqueriesVisitor changed enable_parallel_replicas
     /// inside the query context (because it doesn't have write access to the main context)
     UInt64 parallel_replicas_before_analysis
-        = context->hasQueryContext() ? context->getQueryContext()->getSettingsRef()[Setting::allow_experimental_parallel_reading_from_replicas] : 0;
+        = context->hasQueryContext() ? context->getQueryContext()->getSettingsRef()[Setting::enable_parallel_replicas] : 0;
 
     /// Conditionally support AST-based PREWHERE optimization.
     analyze(shouldMoveToPrewhere() && (!settings[Setting::query_plan_optimize_prewhere] || !settings[Setting::query_plan_enable_optimizations]));
@@ -955,10 +955,10 @@ InterpreterSelectQuery::InterpreterSelectQuery(
     if (context->hasQueryContext())
     {
         /// As this query can't be executed with parallel replicas, we must reanalyze it
-        if (context->getQueryContext()->getSettingsRef()[Setting::allow_experimental_parallel_reading_from_replicas]
+        if (context->getQueryContext()->getSettingsRef()[Setting::enable_parallel_replicas]
             != parallel_replicas_before_analysis)
         {
-            context->setSetting("allow_experimental_parallel_reading_from_replicas", Field(0));
+            context->setSetting("enable_parallel_replicas", Field(0));
             context->setSetting("max_parallel_replicas", UInt64{1});
             need_analyze_again = true;
         }
@@ -1052,7 +1052,7 @@ bool InterpreterSelectQuery::adjustParallelReplicasAfterAnalysis()
     if (getTrivialCount(0).has_value())
     {
         /// The query could use trivial count if it didn't use parallel replicas, so let's disable it and reanalyze
-        context->setSetting("allow_experimental_parallel_reading_from_replicas", Field(0));
+        context->setSetting("enable_parallel_replicas", Field(0));
         context->setSetting("max_parallel_replicas", UInt64{1});
         LOG_DEBUG(log, "Disabling parallel replicas to be able to use a trivial count optimization");
         return true;
@@ -1106,7 +1106,7 @@ bool InterpreterSelectQuery::adjustParallelReplicasAfterAnalysis()
 
     if (number_of_replicas_to_use <= 1)
     {
-        context->setSetting("allow_experimental_parallel_reading_from_replicas", Field(0));
+        context->setSetting("enable_parallel_replicas", Field(0));
         context->setSetting("max_parallel_replicas", UInt64{1});
         LOG_DEBUG(log, "Disabling parallel replicas because there aren't enough rows to read");
         return true;
@@ -2490,7 +2490,7 @@ void InterpreterSelectQuery::addPrewhereAliasActions()
 }
 
 /// Based on the query analysis, check if using a trivial count (storage or partition metadata) is possible
-std::optional<UInt64> InterpreterSelectQuery::getTrivialCount(UInt64 allow_experimental_parallel_reading_from_replicas)
+std::optional<UInt64> InterpreterSelectQuery::getTrivialCount(UInt64 enable_parallel_replicas)
 {
     const Settings & settings = context->getSettingsRef();
 
@@ -2500,7 +2500,7 @@ std::optional<UInt64> InterpreterSelectQuery::getTrivialCount(UInt64 allow_exper
 
     bool optimize_trivial_count =
         syntax_analyzer_result->optimize_trivial_count
-        && (allow_experimental_parallel_reading_from_replicas == 0)
+        && (enable_parallel_replicas == 0)
         && !settings[Setting::allow_experimental_query_deduplication]
         && !empty_result_for_aggregation_by_empty_set
         && storage
@@ -2587,7 +2587,7 @@ void InterpreterSelectQuery::executeFetchColumns(QueryProcessingStage::Enum proc
     std::optional<UInt64> num_rows;
 
     /// Optimization for trivial query like SELECT count() FROM table.
-    if (processing_stage == QueryProcessingStage::FetchColumns && (num_rows = getTrivialCount(settings[Setting::allow_experimental_parallel_reading_from_replicas])))
+    if (processing_stage == QueryProcessingStage::FetchColumns && (num_rows = getTrivialCount(settings[Setting::enable_parallel_replicas])))
     {
         const auto & desc = query_analyzer->aggregates()[0];
         const auto & func = desc.function;

--- a/src/Interpreters/InterpreterSelectQuery.h
+++ b/src/Interpreters/InterpreterSelectQuery.h
@@ -200,7 +200,7 @@ private:
     void executeExtremes(QueryPlan & query_plan);
     void executeSubqueriesInSetsAndJoins(QueryPlan & query_plan);
     bool autoFinalOnQuery(ASTSelectQuery & select_query);
-    std::optional<UInt64> getTrivialCount(UInt64 allow_experimental_parallel_reading_from_replicas);
+    std::optional<UInt64> getTrivialCount(UInt64 enable_parallel_replicas);
     /// Check if we can limit block size to read based on LIMIT clause
     UInt64 maxBlockSizeByLimit() const;
 

--- a/src/Interpreters/MutationsInterpreter.cpp
+++ b/src/Interpreters/MutationsInterpreter.cpp
@@ -60,7 +60,7 @@ namespace DB
 {
 namespace Setting
 {
-    extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool enable_analyzer;
     extern const SettingsBool allow_nondeterministic_mutations;
     extern const SettingsNonZeroUInt64 max_block_size;
     extern const SettingsBool use_concurrency_control;
@@ -225,7 +225,7 @@ IsStorageTouched isStorageTouchedByMutations(
     std::optional<InterpreterSelectQuery> interpreter_select_query;
     BlockIO io;
 
-    if (context->getSettingsRef()[Setting::allow_experimental_analyzer])
+    if (context->getSettingsRef()[Setting::enable_analyzer])
     {
         auto select_query_tree = prepareQueryAffectedQueryTree(commands, storage_from_part, context);
         InterpreterSelectQueryAnalyzer interpreter(select_query_tree, context, SelectQueryOptions().ignoreLimits());
@@ -468,9 +468,9 @@ MutationsInterpreter::MutationsInterpreter(
     , logger(getLogger("MutationsInterpreter(" + source.getStorage()->getStorageID().getFullTableName() + ")"))
 {
     auto new_context = Context::createCopy(context_);
-    if (new_context->getSettingsRef()[Setting::allow_experimental_analyzer])
+    if (new_context->getSettingsRef()[Setting::enable_analyzer])
     {
-        new_context->setSetting("allow_experimental_analyzer", false);
+        new_context->setSetting("enable_analyzer", false);
         LOG_TEST(logger, "Will use old analyzer to prepare mutation");
     }
     context = std::move(new_context);
@@ -1625,7 +1625,7 @@ void MutationsInterpreter::validate()
     // Make sure the mutation query is valid
     if (context->getSettingsRef()[Setting::validate_mutation_query])
     {
-        if (context->getSettingsRef()[Setting::allow_experimental_analyzer])
+        if (context->getSettingsRef()[Setting::enable_analyzer])
             prepareQueryAffectedQueryTree(commands, source.getStorage(), context);
         else
         {

--- a/src/Interpreters/TableJoin.cpp
+++ b/src/Interpreters/TableJoin.cpp
@@ -43,7 +43,7 @@ namespace DB
 namespace Setting
 {
     extern const SettingsBool allow_experimental_join_right_table_sorting;
-    extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool enable_analyzer;
     extern const SettingsUInt64 cross_join_min_bytes_to_compress;
     extern const SettingsUInt64 cross_join_min_rows_to_compress;
     extern const SettingsUInt64 default_max_bytes_in_join;
@@ -162,7 +162,7 @@ TableJoin::TableJoin(const Settings & settings, VolumePtr tmp_volume_, Temporary
     , max_memory_usage(settings[Setting::max_memory_usage])
     , tmp_volume(tmp_volume_)
     , tmp_data(tmp_data_)
-    , enable_analyzer(settings[Setting::allow_experimental_analyzer])
+    , enable_analyzer(settings[Setting::enable_analyzer])
 {
 }
 

--- a/src/Interpreters/evaluateConstantExpression.cpp
+++ b/src/Interpreters/evaluateConstantExpression.cpp
@@ -54,7 +54,7 @@ namespace DB
 namespace Setting
 {
     extern const SettingsBool normalize_function_names;
-    extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool enable_analyzer;
 }
 
 namespace ErrorCodes
@@ -101,7 +101,7 @@ std::optional<EvaluateConstantExpressionResult> evaluateConstantExpressionImpl(c
 
     ColumnPtr result_column;
     DataTypePtr result_type;
-    if (context->getSettingsRef()[Setting::allow_experimental_analyzer])
+    if (context->getSettingsRef()[Setting::enable_analyzer])
     {
         result_name = ast->getColumnName();
 

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -114,7 +114,7 @@ namespace DB
 {
 namespace Setting
 {
-    extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool enable_analyzer;
     extern const SettingsBool allow_experimental_kusto_dialect;
     extern const SettingsBool allow_experimental_prql_dialect;
     extern const SettingsBool allow_settings_after_format_in_insert;
@@ -1037,10 +1037,10 @@ void validateAnalyzerSettings(ASTPtr ast, bool context_value)
 
         if (auto * set_query = node->as<ASTSetQuery>())
         {
-            if (auto * value = set_query->changes.tryGet("allow_experimental_analyzer"))
+            if (auto * value = set_query->changes.tryGet("enable_analyzer"))
             {
                 if (top_level != field_to_bool(*value))
-                    throw Exception(ErrorCodes::INCORRECT_QUERY, "Setting 'allow_experimental_analyzer' is changed in the subquery. Top level value: {}", top_level);
+                    throw Exception(ErrorCodes::INCORRECT_QUERY, "Setting 'enable_analyzer' is changed in the subquery. Top level value: {}", top_level);
             }
 
             if (auto * value = set_query->changes.tryGet("enable_analyzer"))
@@ -1403,7 +1403,7 @@ static BlockIO executeQueryImpl(
             /// Interpret SETTINGS clauses as early as possible (before invoking the corresponding interpreter),
             /// to allow settings to take effect.
             InterpreterSetQuery::applySettingsFromQuery(out_ast, context);
-            validateAnalyzerSettings(out_ast, settings[Setting::allow_experimental_analyzer]);
+            validateAnalyzerSettings(out_ast, settings[Setting::enable_analyzer]);
 
             if (settings[Setting::enforce_strict_identifier_format])
             {

--- a/src/Interpreters/getHeaderForProcessingStage.cpp
+++ b/src/Interpreters/getHeaderForProcessingStage.cpp
@@ -19,7 +19,7 @@ namespace DB
 {
 namespace Setting
 {
-    extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool enable_analyzer;
 }
 
 namespace ErrorCodes
@@ -146,7 +146,7 @@ SharedHeader getHeaderForProcessingStage(
 
             SharedHeader result;
 
-            if (context->getSettingsRef()[Setting::allow_experimental_analyzer])
+            if (context->getSettingsRef()[Setting::enable_analyzer])
             {
                 auto storage = std::make_shared<StorageDummy>(storage_snapshot->storage.getStorageID(),
                                                                                         storage_snapshot->getAllColumnsDescription(),

--- a/src/Interpreters/inplaceBlockConversions.cpp
+++ b/src/Interpreters/inplaceBlockConversions.cpp
@@ -38,7 +38,7 @@ namespace DB
 
 namespace Setting
 {
-    extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool enable_analyzer;
 }
 
 namespace ErrorCodes
@@ -274,7 +274,7 @@ void performRequiredConversions(Block & block, const NamesAndTypesList & require
         return;
 
     std::optional<ActionsDAG> dag;
-    if (context->getSettingsRef()[Setting::allow_experimental_analyzer])
+    if (context->getSettingsRef()[Setting::enable_analyzer])
         dag = createExpressionsAnalyzer(block, conversion_expr_list, true, context);
     else
         dag = createExpressions(block, conversion_expr_list, true, context);
@@ -308,7 +308,7 @@ std::optional<ActionsDAG> evaluateMissingDefaults(
         return {};
 
     ASTPtr expr_list = defaultRequiredExpressions(header, required_columns, columns, null_as_default);
-    if (context->getSettingsRef()[Setting::allow_experimental_analyzer])
+    if (context->getSettingsRef()[Setting::enable_analyzer])
         return createExpressionsAnalyzer(header, expr_list, save_unneeded_columns, context);
     return createExpressions(header, expr_list, save_unneeded_columns, context);
 }

--- a/src/Planner/Planner.cpp
+++ b/src/Planner/Planner.cpp
@@ -117,7 +117,7 @@ namespace Setting
 {
     extern const SettingsUInt64 aggregation_in_order_max_block_bytes;
     extern const SettingsUInt64 aggregation_memory_efficient_merge_threads;
-    extern const SettingsUInt64 allow_experimental_parallel_reading_from_replicas;
+    extern const SettingsUInt64 enable_parallel_replicas;
     extern const SettingsBool collect_hash_table_stats_during_aggregation;
     extern const SettingsOverflowMode distinct_overflow_mode;
     extern const SettingsBool distributed_aggregation_memory_efficient;
@@ -1814,11 +1814,11 @@ void Planner::buildPlanForQueryNode()
     {
         if (!settings[Setting::parallel_replicas_allow_in_with_subquery] && planner_context->getPreparedSets().hasSubqueries())
         {
-            if (settings[Setting::allow_experimental_parallel_reading_from_replicas] >= 2)
+            if (settings[Setting::enable_parallel_replicas] >= 2)
                 throw Exception(ErrorCodes::SUPPORT_IS_DISABLED, "IN with subquery is not supported with parallel replicas");
 
             auto & mutable_context = planner_context->getMutableQueryContext();
-            mutable_context->setSetting("allow_experimental_parallel_reading_from_replicas", Field(0));
+            mutable_context->setSetting("enable_parallel_replicas", Field(0));
             LOG_DEBUG(log, "Disabling parallel replicas to execute a query with IN with subquery");
         }
     }
@@ -1854,12 +1854,12 @@ void Planner::buildPlanForQueryNode()
             const auto & modifiers = table_node->getTableExpressionModifiers();
             if (modifiers.has_value() && modifiers->hasFinal())
             {
-                if (settings[Setting::allow_experimental_parallel_reading_from_replicas] >= 2)
+                if (settings[Setting::enable_parallel_replicas] >= 2)
                     throw Exception(ErrorCodes::SUPPORT_IS_DISABLED, "FINAL modifier is not supported with parallel replicas");
 
                 LOG_DEBUG(log, "FINAL modifier is not supported with parallel replicas. Query will be executed without using them.");
                 auto & mutable_context = planner_context->getMutableQueryContext();
-                mutable_context->setSetting("allow_experimental_parallel_reading_from_replicas", Field(0));
+                mutable_context->setSetting("enable_parallel_replicas", Field(0));
                 break;
             }
         }
@@ -1870,13 +1870,13 @@ void Planner::buildPlanForQueryNode()
         /// Check support for JOIN for parallel replicas with custom key
         if (planner_context->getTableExpressionNodeToData().size() > 1)
         {
-            if (settings[Setting::allow_experimental_parallel_reading_from_replicas] >= 2)
+            if (settings[Setting::enable_parallel_replicas] >= 2)
                 throw Exception(ErrorCodes::SUPPORT_IS_DISABLED, "JOINs are not supported with parallel replicas");
 
             LOG_DEBUG(log, "JOINs are not supported with parallel replicas. Query will be executed without using them.");
 
             auto & mutable_context = planner_context->getMutableQueryContext();
-            mutable_context->setSetting("allow_experimental_parallel_reading_from_replicas", Field(0));
+            mutable_context->setSetting("enable_parallel_replicas", Field(0));
             mutable_context->setSetting("parallel_replicas_custom_key", String{""});
         }
     }

--- a/src/Planner/findParallelReplicasQuery.cpp
+++ b/src/Planner/findParallelReplicasQuery.cpp
@@ -348,7 +348,7 @@ const QueryNode * findQueryForParallelReplicas(const QueryTreeNodePtr & query_tr
 
     /// This is needed to avoid infinite recursion.
     auto mutable_context = Context::createCopy(context);
-    mutable_context->setSetting("allow_experimental_parallel_reading_from_replicas", Field(0));
+    mutable_context->setSetting("enable_parallel_replicas", Field(0));
 
     /// Here we replace tables to dummy, in order to build a temporary query plan for parallel replicas analysis.
     ResultReplacementMap replacement_map;

--- a/src/Processors/QueryPlan/DistributedCreateLocalPlan.cpp
+++ b/src/Processors/QueryPlan/DistributedCreateLocalPlan.cpp
@@ -11,7 +11,7 @@ namespace DB
 {
 namespace Setting
 {
-    extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool enable_analyzer;
 }
 
 std::unique_ptr<QueryPlan> createLocalPlan(
@@ -46,7 +46,7 @@ std::unique_ptr<QueryPlan> createLocalPlan(
 
     select_query_options.build_logical_plan = build_logical_plan;
 
-    if (context->getSettingsRef()[Setting::allow_experimental_analyzer])
+    if (context->getSettingsRef()[Setting::enable_analyzer])
     {
         /// For Analyzer, identifier in GROUP BY/ORDER BY/LIMIT BY lists has been resolved to
         /// ConstantNode in QueryTree if it is an alias of a constant, so we should not replace

--- a/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.cpp
+++ b/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.cpp
@@ -8,7 +8,7 @@ namespace DB
 namespace Setting
 {
     extern const SettingsBool allow_aggregate_partitions_independently;
-    extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool enable_analyzer;
     extern const SettingsBool force_optimize_projection;
     extern const SettingsBool optimize_aggregation_in_order;
     extern const SettingsBool optimize_distinct_in_order;
@@ -76,7 +76,7 @@ namespace Setting
     extern const SettingsBool use_skip_indexes;
     extern const SettingsBool use_skip_indexes_on_data_read;
     extern const SettingsBool enable_full_text_index;
-    extern const SettingsUInt64 allow_experimental_parallel_reading_from_replicas;
+    extern const SettingsUInt64 enable_parallel_replicas;
     extern const SettingsNonZeroUInt64 max_parallel_replicas;
     extern const SettingsBool use_skip_indexes_for_top_k;
     extern const SettingsBool use_top_k_dynamic_filtering;
@@ -129,7 +129,7 @@ QueryPlanOptimizationSettings::QueryPlanOptimizationSettings(
     convert_any_join_to_semi_or_anti_join = from[Setting::query_plan_enable_optimizations] && from[Setting::query_plan_convert_any_join_to_semi_or_anti_join];
     try_use_top_k_optimization = from[Setting::use_skip_indexes_for_top_k] || from[Setting::use_top_k_dynamic_filtering];
 
-    bool use_parallel_replicas = from[Setting::allow_experimental_parallel_reading_from_replicas] && from[Setting::max_parallel_replicas] > 1;
+    bool use_parallel_replicas = from[Setting::enable_parallel_replicas] && from[Setting::max_parallel_replicas] > 1;
     query_plan_optimize_join_order_limit = use_parallel_replicas ? 0 : from[Setting::query_plan_optimize_join_order_limit];
     if (query_plan_optimize_join_order_limit > 64)
         throw Exception(ErrorCodes::INVALID_SETTING_VALUE,
@@ -148,7 +148,7 @@ QueryPlanOptimizationSettings::QueryPlanOptimizationSettings(
     optimize_sorting_by_input_stream_properties = from[Setting::query_plan_enable_optimizations] && from[Setting::optimize_sorting_by_input_stream_properties];
     aggregation_in_order = from[Setting::query_plan_enable_optimizations] && from[Setting::optimize_aggregation_in_order] && from[Setting::query_plan_aggregation_in_order];
     optimize_projection = from[Setting::optimize_use_projections];
-    use_query_condition_cache = from[Setting::use_query_condition_cache] && from[Setting::allow_experimental_analyzer];
+    use_query_condition_cache = from[Setting::use_query_condition_cache] && from[Setting::enable_analyzer];
     query_condition_cache_store_conditions_as_plaintext = from[Setting::query_condition_cache_store_conditions_as_plaintext];
     direct_read_from_text_index = from[Setting::query_plan_direct_read_from_text_index] && from[Setting::use_skip_indexes] && from[Setting::use_skip_indexes_on_data_read];
     enable_full_text_index = from[Setting::enable_full_text_index];
@@ -174,7 +174,7 @@ QueryPlanOptimizationSettings::QueryPlanOptimizationSettings(
     distributed_plan_force_shuffle_aggregation = from[Setting::distributed_plan_force_shuffle_aggregation];
     distributed_aggregation_memory_efficient = from[Setting::distributed_aggregation_memory_efficient];
 
-    optimize_lazy_materialization = from[Setting::query_plan_optimize_lazy_materialization] && from[Setting::allow_experimental_analyzer];
+    optimize_lazy_materialization = from[Setting::query_plan_optimize_lazy_materialization] && from[Setting::enable_analyzer];
     max_limit_for_lazy_materialization = from[Setting::query_plan_max_limit_for_lazy_materialization];
 
     max_limit_for_vector_search_queries = from[Setting::max_limit_for_vector_search_queries].value;
@@ -213,7 +213,7 @@ QueryPlanOptimizationSettings::QueryPlanOptimizationSettings(
 
     max_threads = from[Setting::max_threads];
 
-    parallel_replicas_enabled = from[Setting::allow_experimental_parallel_reading_from_replicas];
+    parallel_replicas_enabled = from[Setting::enable_parallel_replicas];
     max_parallel_replicas = from[Setting::max_parallel_replicas];
     automatic_parallel_replicas_mode = from[Setting::automatic_parallel_replicas_mode];
     automatic_parallel_replicas_min_bytes_per_replica = from[Setting::automatic_parallel_replicas_min_bytes_per_replica];

--- a/src/Processors/QueryPlan/Optimizations/optimizeReadInOrder.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeReadInOrder.cpp
@@ -39,7 +39,7 @@ namespace DB
 {
 namespace Setting
 {
-    extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool enable_analyzer;
     extern const SettingsBool query_plan_read_in_order;
     extern const SettingsBool optimize_read_in_order;
     extern const SettingsBool optimize_read_in_window_order;
@@ -1510,7 +1510,7 @@ size_t tryReuseStorageOrderingForWindowFunctions(QueryPlan::Node * parent_node, 
     auto context = read_from_merge_tree->getContext();
     const auto & settings = context->getSettingsRef();
     if (!settings[Setting::optimize_read_in_window_order] || (settings[Setting::optimize_read_in_order] && settings[Setting::query_plan_read_in_order])
-        || context->getSettingsRef()[Setting::allow_experimental_analyzer])
+        || context->getSettingsRef()[Setting::enable_analyzer])
     {
         return 0;
     }

--- a/src/Processors/QueryPlan/Optimizations/projectionsCommon.cpp
+++ b/src/Processors/QueryPlan/Optimizations/projectionsCommon.cpp
@@ -25,7 +25,7 @@ namespace Setting
     extern const SettingsUInt64 select_sequential_consistency;
     extern const SettingsBool parallel_replicas_local_plan;
     extern const SettingsBool parallel_replicas_support_projection;
-    extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool enable_analyzer;
     extern const SettingsBool optimize_aggregation_in_order;
     extern const SettingsBool force_aggregation_in_order;
     extern const SettingsUInt64 max_projection_rows_to_use_projection_index;
@@ -58,7 +58,7 @@ bool canUseProjectionForReadingStep(ReadFromMergeTree * reading)
 
     if (reading->isParallelReadingEnabled())
     {
-        bool support_projection = query_settings[Setting::allow_experimental_analyzer]
+        bool support_projection = query_settings[Setting::enable_analyzer]
             && query_settings[Setting::parallel_replicas_local_plan]
             && query_settings[Setting::parallel_replicas_support_projection];
 

--- a/src/Processors/QueryPlan/ParallelReplicasLocalPlan.cpp
+++ b/src/Processors/QueryPlan/ParallelReplicasLocalPlan.cpp
@@ -50,7 +50,7 @@ std::pair<QueryPlanPtr, bool> createLocalPlanForParallelReplicas(
     /// ConstantNode in QueryTree if it is an alias of a constant, so we should not replace
     /// ConstantNode with ProjectionNode again(https://github.com/ClickHouse/ClickHouse/issues/62289).
     new_context->setSetting("enable_positional_arguments", Field(false));
-    new_context->setSetting("allow_experimental_parallel_reading_from_replicas", Field(0));
+    new_context->setSetting("enable_parallel_replicas", Field(0));
     auto interpreter = InterpreterSelectQueryAnalyzer(query_ast, new_context, select_query_options);
     query_plan = std::make_unique<QueryPlan>(std::move(interpreter).extractQueryPlan());
 

--- a/src/Processors/QueryPlan/ReadFromLoopStep.cpp
+++ b/src/Processors/QueryPlan/ReadFromLoopStep.cpp
@@ -129,7 +129,7 @@ namespace DB
     static ContextPtr disableParallelReplicas(ContextPtr context)
     {
         auto modified_context = Context::createCopy(context);
-        modified_context->setSetting("allow_experimental_parallel_reading_from_replicas", Field(0));
+        modified_context->setSetting("enable_parallel_replicas", Field(0));
         return modified_context;
     }
 

--- a/src/Processors/QueryPlan/ReadFromRemote.cpp
+++ b/src/Processors/QueryPlan/ReadFromRemote.cpp
@@ -53,7 +53,7 @@ namespace DB
 namespace Setting
 {
     extern const SettingsUInt64 query_plan_max_step_description_length;
-    extern const SettingsUInt64 allow_experimental_parallel_reading_from_replicas;
+    extern const SettingsUInt64 enable_parallel_replicas;
     extern const SettingsBool async_query_sending_for_remote;
     extern const SettingsBool async_socket_for_remote;
     extern const SettingsString cluster_for_parallel_replicas;
@@ -624,7 +624,7 @@ void ReadFromRemote::addPipe(
     bool add_extremes = false;
     bool async_read = context->getSettingsRef()[Setting::async_socket_for_remote];
     bool async_query_sending = context->getSettingsRef()[Setting::async_query_sending_for_remote];
-    bool parallel_replicas_disabled = context->getSettingsRef()[Setting::allow_experimental_parallel_reading_from_replicas] == 0;
+    bool parallel_replicas_disabled = context->getSettingsRef()[Setting::enable_parallel_replicas] == 0;
     if (stage == QueryProcessingStage::Complete)
     {
         if (const auto * ast_select = shard.query->as<ASTSelectQuery>())

--- a/src/Server/MySQLHandler.cpp
+++ b/src/Server/MySQLHandler.cpp
@@ -39,7 +39,7 @@ namespace DB
 {
 namespace Setting
 {
-    extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool enable_analyzer;
     extern const SettingsBool prefer_column_name_to_alias;
     extern const SettingsSeconds receive_timeout;
     extern const SettingsSeconds send_timeout;
@@ -522,7 +522,7 @@ void MySQLHandler::comQuery(ReadBuffer & payload, bool binary_protocol)
 
         /// --- Workaround for Bug 56173.
         auto settings = query_context->getSettingsCopy();
-        if (!settings[Setting::allow_experimental_analyzer])
+        if (!settings[Setting::enable_analyzer])
         {
             settings[Setting::prefer_column_name_to_alias] = true;
             query_context->setSettings(settings);

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -96,7 +96,7 @@ namespace DB
 {
 namespace Setting
 {
-    extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool enable_analyzer;
     extern const SettingsBool allow_experimental_codecs;
     extern const SettingsBool allow_experimental_query_deduplication;
     extern const SettingsBool allow_suspicious_codecs;
@@ -104,6 +104,7 @@ namespace Setting
     extern const SettingsUInt64 async_insert_max_data_size;
     extern const SettingsBool calculate_text_stack_trace;
     extern const SettingsBool deduplicate_blocks_in_dependent_materialized_views;
+    extern const SettingsBool enable_zstd_qat_codec;
     extern const SettingsUInt64 idle_connection_timeout;
     extern const SettingsBool input_format_defaults_for_omitted_fields;
     extern const SettingsUInt64 interactive_delay;
@@ -2309,15 +2310,15 @@ void TCPHandler::processQuery(std::shared_ptr<QueryState> & state)
     /// Settings
     ///
 
-    /// FIXME: Remove when allow_experimental_analyzer will become obsolete.
+    /// FIXME: Remove when enable_analyzer will become obsolete.
     /// Analyzer became Beta in 24.3 and started to be enabled by default.
     /// We have to disable it for ourselves to make sure we don't have different settings on
     /// different servers.
     if (query_kind == ClientInfo::QueryKind::SECONDARY_QUERY
         && VersionNumber(client_info.client_version_major, client_info.client_version_minor, client_info.client_version_patch)
             < VersionNumber(23, 3, 0)
-        && !passed_settings[Setting::allow_experimental_analyzer].changed)
-        passed_settings.set("allow_experimental_analyzer", false);
+        && !passed_settings[Setting::enable_analyzer].changed)
+        passed_settings.set("enable_analyzer", false);
 
     if (state->stage == QueryProcessingStage::WithMergeableState
         && VersionNumber(client_info.connection_client_version_major, client_info.connection_client_version_minor, client_info.connection_client_version_patch)

--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -48,7 +48,7 @@ namespace DB
 {
 namespace Setting
 {
-    extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool enable_analyzer;
     extern const SettingsBool allow_experimental_codecs;
     extern const SettingsBool allow_suspicious_codecs;
     extern const SettingsBool allow_suspicious_ttl_expressions;
@@ -863,7 +863,7 @@ void AlterCommand::apply(StorageInMemoryMetadata & metadata, ContextPtr context)
         metadata.select = SelectQueryDescription::getSelectQueryFromASTForMatView(select, metadata.refresh != nullptr, context);
         SharedHeader as_select_sample;
 
-        if (context->getSettingsRef()[Setting::allow_experimental_analyzer])
+        if (context->getSettingsRef()[Setting::enable_analyzer])
         {
             as_select_sample = InterpreterSelectQueryAnalyzer::getSampleBlock(select->clone(), context);
         }

--- a/src/Storages/ColumnsDescription.cpp
+++ b/src/Storages/ColumnsDescription.cpp
@@ -61,7 +61,7 @@ namespace DB
 
 namespace Setting
 {
-    extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool enable_analyzer;
 }
 
 namespace ErrorCodes
@@ -1264,7 +1264,7 @@ std::optional<Block> validateColumnsDefaultsAndGetSampleBlockImpl(ASTPtr default
 
     try
     {
-        if (context->getSettingsRef()[Setting::allow_experimental_analyzer])
+        if (context->getSettingsRef()[Setting::enable_analyzer])
             return validateDefaultsWithAnalyzer(default_expr_list, all_columns, context, get_sample_block);
         else
         {

--- a/src/Storages/IStorageCluster.cpp
+++ b/src/Storages/IStorageCluster.cpp
@@ -33,7 +33,7 @@ namespace DB
 {
 namespace Setting
 {
-    extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool enable_analyzer;
     extern const SettingsBool async_query_sending_for_remote;
     extern const SettingsBool async_socket_for_remote;
     extern const SettingsBool skip_unavailable_shards;
@@ -147,7 +147,7 @@ void IStorageCluster::read(
     SharedHeader sample_block;
     ASTPtr query_to_send = query_info.query;
 
-    if (context->getSettingsRef()[Setting::allow_experimental_analyzer])
+    if (context->getSettingsRef()[Setting::enable_analyzer])
     {
         sample_block = InterpreterSelectQueryAnalyzer::getSampleBlock(query_info.query, context, SelectQueryOptions(processed_stage));
     }

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -185,7 +185,7 @@ namespace DB
 namespace Setting
 {
     extern const SettingsBool allow_drop_detached;
-    extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool enable_analyzer;
     extern const SettingsBool enable_full_text_index;
     extern const SettingsBool allow_non_metadata_alters;
     extern const SettingsBool allow_statistics_optimize;
@@ -8478,7 +8478,7 @@ QueryProcessingStage::Enum MergeTreeData::getQueryProcessingStage(
     SelectQueryInfo &) const
 {
     /// with new analyzer, Planner make decision regarding parallel replicas usage, and so about processing stage on reading
-    if (!query_context->getSettingsRef()[Setting::allow_experimental_analyzer])
+    if (!query_context->getSettingsRef()[Setting::enable_analyzer])
     {
         const auto & settings = query_context->getSettingsRef();
         if (query_context->canUseParallelReplicasCustomKey())

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -74,7 +74,7 @@ namespace Setting
 {
     extern const SettingsBool per_part_index_stats;
     extern const SettingsBool allow_experimental_query_deduplication;
-    extern const SettingsUInt64 allow_experimental_parallel_reading_from_replicas;
+    extern const SettingsUInt64 enable_parallel_replicas;
     extern const SettingsString force_data_skipping_indices;
     extern const SettingsBool force_index_by_date;
     extern const SettingsSeconds lock_acquire_timeout;
@@ -92,7 +92,7 @@ namespace Setting
     extern const SettingsBool use_skip_indexes_on_data_read;
     extern const SettingsBool use_skip_indexes_for_disjunctions;
     extern const SettingsBool use_query_condition_cache;
-    extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool enable_analyzer;
     extern const SettingsBool parallel_replicas_local_plan;
     extern const SettingsBool parallel_replicas_index_analysis_only_on_coordinator;
     extern const SettingsBool secondary_indices_enable_bulk_filtering;
@@ -311,7 +311,7 @@ MergeTreeDataSelectSamplingData MergeTreeDataSelectExecutor::getSampling(
         */
 
     const bool can_use_sampling_key_parallel_replicas =
-        settings[Setting::allow_experimental_parallel_reading_from_replicas] > 0
+        settings[Setting::enable_parallel_replicas] > 0
         && settings[Setting::max_parallel_replicas] > 1
         && settings[Setting::parallel_replicas_mode] == ParallelReplicasMode::SAMPLING_KEY;
 
@@ -1273,7 +1273,7 @@ void MergeTreeDataSelectExecutor::filterPartsByQueryConditionCache(
 {
     const auto & settings = context->getSettingsRef();
     if (!settings[Setting::use_query_condition_cache]
-            || !settings[Setting::allow_experimental_analyzer]
+            || !settings[Setting::enable_analyzer]
             || (!select_query_info.prewhere_info && !select_query_info.filter_actions_dag)
             || (vector_search_parameters.has_value()) /// vector search has filter in the ORDER BY
             || select_query_info.isFinal()

--- a/src/Storages/MergeTree/MergeTreeIOSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeIOSettings.cpp
@@ -25,7 +25,7 @@ namespace Setting
     extern const SettingsFloat max_streams_to_max_threads_ratio;
     extern const SettingsUInt64 max_streams_for_merge_tree_reading;
     extern const SettingsBool use_query_condition_cache;
-    extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool enable_analyzer;
     extern const SettingsBool load_marks_asynchronously;
     extern const SettingsBool query_condition_cache_store_conditions_as_plaintext;
     extern const SettingsBool merge_tree_use_deserialization_prefixes_cache;
@@ -106,7 +106,7 @@ MergeTreeReaderSettings MergeTreeReaderSettings::createFromContext(const Context
         && (settings[Setting::max_streams_to_max_threads_ratio] > 1 || settings[Setting::max_streams_for_merge_tree_reading] > 1);
     result.enable_multiple_prewhere_read_steps = settings[Setting::enable_multiple_prewhere_read_steps];
     result.force_short_circuit_execution = settings[Setting::query_plan_merge_filters];
-    result.use_query_condition_cache = settings[Setting::use_query_condition_cache] && settings[Setting::allow_experimental_analyzer];
+    result.use_query_condition_cache = settings[Setting::use_query_condition_cache] && settings[Setting::enable_analyzer];
     result.query_condition_cache_store_conditions_as_plaintext = settings[Setting::query_condition_cache_store_conditions_as_plaintext];
     result.use_deserialization_prefixes_cache = settings[Setting::merge_tree_use_deserialization_prefixes_cache];
     result.use_prefixes_deserialization_thread_pool = settings[Setting::merge_tree_use_prefixes_deserialization_thread_pool];
@@ -114,7 +114,7 @@ MergeTreeReaderSettings MergeTreeReaderSettings::createFromContext(const Context
     result.merge_tree_min_bytes_for_seek = settings[Setting::merge_tree_min_bytes_for_seek];
     result.merge_tree_min_rows_for_seek = settings[Setting::merge_tree_min_rows_for_seek];
     result.filesystem_prefetches_limit = settings[Setting::filesystem_prefetches_limit];
-    result.enable_analyzer = settings[Setting::allow_experimental_analyzer];
+    result.enable_analyzer = settings[Setting::enable_analyzer];
     result.load_marks_asynchronously = settings[Setting::load_marks_asynchronously];
     return result;
 }

--- a/src/Storages/MergeTree/RPNBuilder.cpp
+++ b/src/Storages/MergeTree/RPNBuilder.cpp
@@ -36,7 +36,7 @@ namespace DB
 {
 namespace Setting
 {
-    extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool enable_analyzer;
 }
 
 namespace ErrorCodes
@@ -189,7 +189,7 @@ std::string RPNBuilderTreeNode::getColumnName() const
     if (ast_node)
         return ast_node->getColumnNameWithoutAlias();
 
-    return getColumnNameWithoutAlias(*dag_node, getTreeContext().getQueryContext(), getTreeContext().getSettings()[Setting::allow_experimental_analyzer]);
+    return getColumnNameWithoutAlias(*dag_node, getTreeContext().getQueryContext(), getTreeContext().getSettings()[Setting::enable_analyzer]);
 }
 
 std::string RPNBuilderTreeNode::getColumnNameWithModuloLegacy() const
@@ -201,7 +201,7 @@ std::string RPNBuilderTreeNode::getColumnNameWithModuloLegacy() const
         return adjusted_ast->getColumnNameWithoutAlias();
     }
 
-    return getColumnNameWithoutAlias(*dag_node, getTreeContext().getQueryContext(), getTreeContext().getSettings()[Setting::allow_experimental_analyzer], true /*legacy*/);
+    return getColumnNameWithoutAlias(*dag_node, getTreeContext().getQueryContext(), getTreeContext().getSettings()[Setting::enable_analyzer], true /*legacy*/);
 }
 
 bool RPNBuilderTreeNode::isFunction() const

--- a/src/Storages/StorageBuffer.cpp
+++ b/src/Storages/StorageBuffer.cpp
@@ -79,7 +79,7 @@ namespace DB
 {
 namespace Setting
 {
-    extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool enable_analyzer;
     extern const SettingsBool insert_allow_materialized_columns;
     extern const SettingsSeconds lock_acquire_timeout;
     extern const SettingsUInt64 readonly;
@@ -270,7 +270,7 @@ void StorageBuffer::read(
     size_t max_block_size,
     size_t num_streams)
 {
-    bool enable_analyzer = local_context->getSettingsRef()[Setting::allow_experimental_analyzer];
+    bool enable_analyzer = local_context->getSettingsRef()[Setting::enable_analyzer];
 
     if (enable_analyzer && processed_stage > QueryProcessingStage::FetchColumns)
     {

--- a/src/Storages/StorageExecutable.cpp
+++ b/src/Storages/StorageExecutable.cpp
@@ -34,7 +34,7 @@ namespace DB
 {
 namespace Setting
 {
-    extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool enable_analyzer;
     extern const SettingsSeconds max_execution_time;
 }
 
@@ -179,7 +179,7 @@ void StorageExecutable::read(
     for (auto & input_query : input_queries)
     {
         QueryPipelineBuilder builder;
-        if (context->getSettingsRef()[Setting::allow_experimental_analyzer])
+        if (context->getSettingsRef()[Setting::enable_analyzer])
             builder = InterpreterSelectQueryAnalyzer(input_query, context, {}).buildQueryPipeline();
         else
             builder = InterpreterSelectWithUnionQuery(input_query, context, {}).buildQueryPipeline();

--- a/src/Storages/StorageMaterializedView.cpp
+++ b/src/Storages/StorageMaterializedView.cpp
@@ -48,7 +48,7 @@ namespace DB
 {
 namespace Setting
 {
-    extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool enable_analyzer;
     extern const SettingsSeconds lock_acquire_timeout;
     extern const SettingsUInt64 log_queries_cut_to_length;
 }
@@ -588,7 +588,7 @@ StorageMaterializedView::prepareRefresh(bool append, ContextMutablePtr refresh_c
     insert_query->table_id = target_table;
 
     SharedHeader header;
-    if (refresh_context->getSettingsRef()[Setting::allow_experimental_analyzer])
+    if (refresh_context->getSettingsRef()[Setting::enable_analyzer])
         header = InterpreterSelectQueryAnalyzer::getSampleBlock(insert_query->select, refresh_context);
     else
         header = InterpreterSelectWithUnionQuery(insert_query->select, refresh_context, SelectQueryOptions()).getSampleBlock();

--- a/src/Storages/StorageMerge.cpp
+++ b/src/Storages/StorageMerge.cpp
@@ -67,7 +67,7 @@ namespace DB
 {
 namespace Setting
 {
-    extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool enable_analyzer;
     extern const SettingsBool distributed_aggregation_memory_efficient;
     extern const SettingsSeconds lock_acquire_timeout;
     extern const SettingsFloat max_streams_multiplier_for_merge_tables;
@@ -459,7 +459,7 @@ void StorageMerge::read(
     /// What will be result structure depending on query processed stage in source tables?
     auto common_header = getHeaderForProcessingStage(column_names, storage_snapshot, query_info, local_context, processed_stage);
 
-    if (local_context->getSettingsRef()[Setting::allow_experimental_analyzer] && processed_stage == QueryProcessingStage::Complete)
+    if (local_context->getSettingsRef()[Setting::enable_analyzer] && processed_stage == QueryProcessingStage::Complete)
     {
         auto block = *common_header;
         /// Remove constants.
@@ -676,7 +676,7 @@ std::vector<ReadFromMerge::ChildPlan> ReadFromMerge::createChildrenPlans(SelectQ
 
             Names column_names_as_aliases;
             Names real_column_names = column_names;
-            bool use_analyzer = context->getSettingsRef()[Setting::allow_experimental_analyzer];
+            bool use_analyzer = context->getSettingsRef()[Setting::enable_analyzer];
             if (use_analyzer && has_table_virtual_column
                 && (common_processed_stage != QueryProcessingStage::FetchColumns
                     || std::dynamic_pointer_cast<StorageMerge>(storage)
@@ -702,7 +702,7 @@ std::vector<ReadFromMerge::ChildPlan> ReadFromMerge::createChildrenPlans(SelectQ
             auto modified_query_info
                 = getModifiedQueryInfo(modified_context, table, nested_storage_snapshot, real_column_names, column_names_as_aliases, is_smallest_column_requested, aliases);
 
-            if (!context->getSettingsRef()[Setting::allow_experimental_analyzer])
+            if (!context->getSettingsRef()[Setting::enable_analyzer])
             {
                 auto storage_columns = storage_metadata_snapshot->getColumns();
                 auto syntax_result = TreeRewriter(context).analyzeSelect(
@@ -1083,7 +1083,7 @@ void ReadFromMerge::addVirtualColumns(
 
     auto plan_header = child.plan.getCurrentHeader();
 
-    if (context->getSettingsRef()[Setting::allow_experimental_analyzer])
+    if (context->getSettingsRef()[Setting::enable_analyzer])
     {
         String table_alias = modified_query_info.query_tree->as<QueryNode>()->getJoinTree()->as<TableNode>()->getAlias();
 
@@ -1164,7 +1164,7 @@ QueryPipelineBuilderPtr ReadFromMerge::buildPipeline(
         return builder;
 
     if (processed_stage > child.stage
-        || (context->getSettingsRef()[Setting::allow_experimental_analyzer] && processed_stage != QueryProcessingStage::FetchColumns))
+        || (context->getSettingsRef()[Setting::enable_analyzer] && processed_stage != QueryProcessingStage::FetchColumns))
     {
         /** Materialization is needed, since from distributed storage the constants come materialized.
           * If you do not do this, different types (Const and non-Const) columns will be produced in different threads,
@@ -1199,7 +1199,7 @@ ReadFromMerge::ChildPlan ReadFromMerge::createPlanForTable(
         modified_select.setFinal();
     }
 
-    bool use_analyzer = modified_context->getSettingsRef()[Setting::allow_experimental_analyzer];
+    bool use_analyzer = modified_context->getSettingsRef()[Setting::enable_analyzer];
 
     auto storage_stage = storage->getQueryProcessingStage(modified_context,
         processed_stage,
@@ -1506,7 +1506,7 @@ void ReadFromMerge::convertAndFilterSourceStream(
 
     auto pipe_columns = before_block_header->getNamesAndTypesList();
 
-    if (local_context->getSettingsRef()[Setting::allow_experimental_analyzer])
+    if (local_context->getSettingsRef()[Setting::enable_analyzer])
     {
         for (const auto & alias : aliases)
         {

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -70,7 +70,7 @@ namespace FailPoints
 
 namespace Setting
 {
-    extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool enable_analyzer;
     extern const SettingsBool allow_suspicious_primary_key;
     extern const SettingsUInt64 alter_sync;
     extern const SettingsSeconds lock_acquire_timeout;
@@ -291,7 +291,7 @@ void StorageMergeTree::read(
     const auto & settings = local_context->getSettingsRef();
     /// reading step for parallel replicas with new analyzer is built in Planner, so don't do it here
     if (local_context->canUseParallelReplicasOnInitiator() && settings[Setting::parallel_replicas_for_non_replicated_merge_tree]
-        && !settings[Setting::allow_experimental_analyzer])
+        && !settings[Setting::enable_analyzer])
     {
         ClusterProxy::executeQueryWithParallelReplicas(
             query_plan, getStorageID(), processed_stage, query_info.query, local_context, query_info.storage_limits);
@@ -299,7 +299,7 @@ void StorageMergeTree::read(
     }
 
     if (local_context->canUseParallelReplicasCustomKey() && settings[Setting::parallel_replicas_for_non_replicated_merge_tree]
-        && !settings[Setting::allow_experimental_analyzer] && local_context->getClientInfo().distributed_depth == 0)
+        && !settings[Setting::enable_analyzer] && local_context->getClientInfo().distributed_depth == 0)
     {
         auto cluster = local_context->getClusterForParallelReplicas();
         if (local_context->canUseParallelReplicasCustomKeyForCluster(*cluster))

--- a/src/Storages/StorageMongoDB.cpp
+++ b/src/Storages/StorageMongoDB.cpp
@@ -55,7 +55,7 @@ namespace ErrorCodes
 
 namespace Setting
 {
-    extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool enable_analyzer;
     extern const SettingsBool mongodb_throw_on_unsupported_query;
 }
 
@@ -470,7 +470,7 @@ bsoncxx::document::value StorageMongoDB::buildMongoDBQuery(const ContextPtr & co
 
     bool throw_on_error = context->getSettingsRef()[Setting::mongodb_throw_on_unsupported_query];
 
-    if (!context->getSettingsRef()[Setting::allow_experimental_analyzer])
+    if (!context->getSettingsRef()[Setting::enable_analyzer])
     {
         if (throw_on_error)
             throw Exception(ErrorCodes::NOT_IMPLEMENTED, "MongoDB storage does not support 'enable_analyzer = 0' setting");

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -159,7 +159,7 @@ namespace DB
 namespace Setting
 {
     extern const SettingsBool async_insert_deduplicate;
-    extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool enable_analyzer;
     extern const SettingsBool allow_suspicious_primary_key;
     extern const SettingsUInt64 alter_sync;
     extern const SettingsBool async_query_sending_for_remote;
@@ -5893,13 +5893,13 @@ void StorageReplicatedMergeTree::read(
         return;
     }
     /// reading step for parallel replicas with new analyzer is built in Planner, so don't do it here
-    if (local_context->canUseParallelReplicasOnInitiator() && !settings[Setting::allow_experimental_analyzer])
+    if (local_context->canUseParallelReplicasOnInitiator() && !settings[Setting::enable_analyzer])
     {
         readParallelReplicasImpl(query_plan, column_names, query_info, local_context, processed_stage);
         return;
     }
 
-    if (local_context->canUseParallelReplicasCustomKey() && !settings[Setting::allow_experimental_analyzer]
+    if (local_context->canUseParallelReplicasCustomKey() && !settings[Setting::enable_analyzer]
         && local_context->getClientInfo().distributed_depth == 0)
     {
         auto cluster = local_context->getClusterForParallelReplicas();

--- a/src/Storages/StorageView.cpp
+++ b/src/Storages/StorageView.cpp
@@ -37,7 +37,7 @@ namespace DB
 {
 namespace Setting
 {
-    extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool enable_analyzer;
     extern const SettingsBool extremes;
     extern const SettingsUInt64 max_result_rows;
     extern const SettingsUInt64 max_result_bytes;
@@ -176,7 +176,7 @@ void StorageView::read(
 
     auto options = SelectQueryOptions(QueryProcessingStage::Complete, 0, false, query_info.settings_limit_offset_done);
 
-    if (context->getSettingsRef()[Setting::allow_experimental_analyzer])
+    if (context->getSettingsRef()[Setting::enable_analyzer])
     {
         auto view_context = getViewContext(context, storage_snapshot);
         InterpreterSelectQueryAnalyzer interpreter(current_inner_query, view_context, options, column_names);

--- a/src/Storages/TimeSeries/PrometheusRemoteReadProtocol.cpp
+++ b/src/Storages/TimeSeries/PrometheusRemoteReadProtocol.cpp
@@ -48,7 +48,7 @@ namespace ErrorCodes
 
 namespace Setting
 {
-    extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool enable_analyzer;
 }
 
 namespace
@@ -482,7 +482,7 @@ void PrometheusRemoteReadProtocol::readTimeSeries(google::protobuf::RepeatedPtrF
     auto context = getContext();
     BlockIO io;
     std::optional<InterpreterSelectQuery> interpreter_holder;
-    if (context->getSettingsRef()[Setting::allow_experimental_analyzer])
+    if (context->getSettingsRef()[Setting::enable_analyzer])
     {
         InterpreterSelectQueryAnalyzer interpreter(select_query, context, SelectQueryOptions{});
         io = interpreter.execute();

--- a/src/Storages/WindowView/StorageWindowView.cpp
+++ b/src/Storages/WindowView/StorageWindowView.cpp
@@ -70,7 +70,7 @@ namespace DB
 {
 namespace Setting
 {
-    extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool enable_analyzer;
     extern const SettingsBool allow_experimental_window_view;
     extern const SettingsBool insert_null_as_default;
     extern const SettingsSeconds lock_acquire_timeout;
@@ -1236,7 +1236,7 @@ StorageWindowView::StorageWindowView(
     , fire_signal_timeout_s(context_->getSettingsRef()[Setting::wait_for_window_view_fire_signal_timeout].totalSeconds())
     , clean_interval_usec(context_->getSettingsRef()[Setting::window_view_clean_interval].totalMicroseconds())
 {
-    if (context_->getSettingsRef()[Setting::allow_experimental_analyzer])
+    if (context_->getSettingsRef()[Setting::enable_analyzer])
         disabled_due_to_analyzer = true;
 
     if (mode <= LoadingStrictnessLevel::CREATE)
@@ -1804,9 +1804,9 @@ StoragePtr StorageWindowView::getTargetTable() const
 
 void StorageWindowView::throwIfWindowViewIsDisabled(ContextPtr local_context) const
 {
-    if (disabled_due_to_analyzer || (local_context && local_context->getSettingsRef()[Setting::allow_experimental_analyzer]))
+    if (disabled_due_to_analyzer || (local_context && local_context->getSettingsRef()[Setting::enable_analyzer]))
         throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "Experimental WINDOW VIEW feature is not supported "
-                        "in the current infrastructure for query analysis (the setting 'allow_experimental_analyzer')");
+                        "in the current infrastructure for query analysis (the setting 'enable_analyzer')");
 }
 
 void registerStorageWindowView(StorageFactory & factory)

--- a/src/TableFunctions/TableFunctionObjectStorage.cpp
+++ b/src/TableFunctions/TableFunctionObjectStorage.cpp
@@ -35,7 +35,6 @@ namespace DB
 
 namespace Setting
 {
-    extern const SettingsUInt64 allow_experimental_parallel_reading_from_replicas;
     extern const SettingsBool parallel_replicas_for_cluster_engines;
     extern const SettingsString cluster_for_parallel_replicas;
     extern const SettingsParallelReplicasMode parallel_replicas_mode;

--- a/src/TableFunctions/TableFunctionURL.cpp
+++ b/src/TableFunctions/TableFunctionURL.cpp
@@ -27,7 +27,6 @@ namespace DB
 
 namespace Setting
 {
-    extern const SettingsUInt64 allow_experimental_parallel_reading_from_replicas;
     extern const SettingsBool parallel_replicas_for_cluster_engines;
     extern const SettingsString cluster_for_parallel_replicas;
     extern const SettingsParallelReplicasMode parallel_replicas_mode;

--- a/src/TableFunctions/TableFunctionView.cpp
+++ b/src/TableFunctions/TableFunctionView.cpp
@@ -15,7 +15,7 @@ namespace DB
 {
 namespace Setting
 {
-    extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool enable_analyzer;
 }
 
 namespace ErrorCodes
@@ -56,7 +56,7 @@ ColumnsDescription TableFunctionView::getActualTableStructure(ContextPtr context
 
     SharedHeader sample_block;
 
-    if (context->getSettingsRef()[Setting::allow_experimental_analyzer])
+    if (context->getSettingsRef()[Setting::enable_analyzer])
         sample_block = InterpreterSelectQueryAnalyzer::getSampleBlock(create.children[0], context);
     else
         sample_block = InterpreterSelectWithUnionQuery::getSampleBlock(create.children[0], context);

--- a/src/TableFunctions/TableFunctionViewIfPermitted.cpp
+++ b/src/TableFunctions/TableFunctionViewIfPermitted.cpp
@@ -21,7 +21,7 @@ namespace DB
 {
 namespace Setting
 {
-    extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool enable_analyzer;
 }
 
 namespace ErrorCodes
@@ -119,7 +119,7 @@ bool TableFunctionViewIfPermitted::isPermitted(const ContextPtr & context, const
 
     try
     {
-        if (context->getSettingsRef()[Setting::allow_experimental_analyzer])
+        if (context->getSettingsRef()[Setting::enable_analyzer])
         {
             sample_block = InterpreterSelectQueryAnalyzer::getSampleBlock(create.children[0], context);
         }

--- a/tests/queries/0_stateless/03763_no_new.sql
+++ b/tests/queries/0_stateless/03763_no_new.sql
@@ -1,3 +1,24 @@
-SELECT throwIf(name != '', 'No settings can be named "new"') FROM system.settings WHERE name LIKE '%new\_%' AND name NOT LIKE '%new\_file%' AND name NOT IN (select alias_for from system.settings where name not like '%new\_%');
-SELECT throwIf(name != '', 'No settings can be named "new"') FROM system.merge_tree_settings WHERE name LIKE '%new\_%' AND name NOT LIKE '%new\_file%';
-SELECT throwIf(name != '', 'No settings can be named "new"') FROM system.server_settings WHERE name LIKE '%new\_%' AND name NOT LIKE '%new\_file%';
+-- Checks that setting names don't contain "new"
+
+SELECT throwIf(name != '', 'Settings must not contain "new"')
+FROM system.settings
+WHERE
+    name LIKE '%new\_%'
+    AND name NOT LIKE '%_create_new\_file%'
+    AND alias_for == '';
+-- Intentionally ignore setting aliases (column "alias_for").
+-- We need aliases as a backdoor to fix setting names with "new":
+-- - 1) Introduce a new setting without "new".
+-- - 2) Make the existing setting with "new" an alias of the new setting.
+
+SELECT throwIf(name != '', 'Settings must not contain "new"')
+FROM system.merge_tree_settings
+WHERE
+    name LIKE '%new\_%'
+    AND name NOT LIKE '%new\_file%';
+
+SELECT throwIf(name != '', 'Settings must not contain "new"')
+FROM system.server_settings
+WHERE
+    name LIKE '%new\_%'
+    AND name NOT LIKE '%new\_file%';


### PR DESCRIPTION
I wanted to understand the handling for setting aliases in "tests/queries/0_stateless/03763_no_new.sql".

Aliases are usually introduced when
- an experimental feature is made non-experimental, e.g. `allow_experimental_analyzer` --> `enable_analyzer`
- a typo or ambiguity in the setting name is fixed, e.g. `extract_kvp_max_pairs_per_row` --> `extract_key_value_pairs_max_pairs_per_row`
- settings containing "new" are renamed, e.g. `query_plan_use_new_logical_join_step` --> `query_plan_use_new_logical_join_step`

I then noticed that aliases were in some cases added inconsistently.

- Correct approach 1: A new setting is introduced. The existing setting is made an alias of the new setting.
- Wrong approach 2: A new setting is introduced as alias of an existing setting.

This PR converts all aliases added with approach 2 to approach 1.

Start reviewing in "src/Core/Settings.cpp".

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)