### PR TITLE
E2K: fixed syscalls, added new / reworked use of glibc

### DIFF
--- a/src/Common/ThreadFuzzer.cpp
+++ b/src/Common/ThreadFuzzer.cpp
@@ -366,7 +366,7 @@ void ThreadFuzzer::setup() const
 
 /// Starting from glibc 2.34 there are no internal symbols without version,
 /// so not __pthread_mutex_lock but __pthread_mutex_lock@2.2.5
-#if defined(OS_LINUX) and !defined(USE_MUSL) and !defined(__loongarch64) and !defined(__e2k__)
+#if defined(OS_LINUX) and !defined(USE_MUSL) and !defined(__loongarch64)
     /// You can get version from glibc/sysdeps/unix/sysv/linux/$ARCH/$BITS_OR_BYTE_ORDER/libc.abilist
     #if defined(__amd64__)
     #    define GLIBC_SYMVER "GLIBC_2.2.5"
@@ -378,6 +378,8 @@ void ThreadFuzzer::setup() const
     #    define GLIBC_SYMVER "GLIBC_2.17"
     #elif (defined(__S390X__) || defined(__s390x__))
     #    define GLIBC_SYMVER "GLIBC_2.2"
+    #elif defined(__e2k__)
+    #    define GLIBC_SYMVER "GLIBC_2.0"
     #else
     #    error Your platform is not supported.
     #endif
@@ -389,7 +391,7 @@ void ThreadFuzzer::setup() const
 #endif
 
 /// The loongarch64's glibc_version is 2.36
-#if defined(ADDRESS_SANITIZER) || defined(__loongarch64) || defined(__e2k__)
+#if defined(ADDRESS_SANITIZER) || defined(__loongarch64)
 #if USE_JEMALLOC
 #error "ASan cannot be used with jemalloc"
 #endif

--- a/src/Common/atomicRename.cpp
+++ b/src/Common/atomicRename.cpp
@@ -48,6 +48,8 @@ namespace ErrorCodes
         #define __NR_renameat2 276
     #elif defined(__loongarch64)
         #define __NR_renameat2 276
+    #elif defined(__e2k__)
+        #define __NR_renameat2 384
     #else
         #error "Unsupported architecture"
     #endif

--- a/src/Common/waitForPid.cpp
+++ b/src/Common/waitForPid.cpp
@@ -50,7 +50,7 @@ enum PollPidResult
     #elif defined(__loongarch64)
         #define SYS_pidfd_open 434
     #elif defined(__e2k__)
-        #define SYS_pidfd_open 434
+        #define SYS_pidfd_open 206
     #else
         #error "Unsupported architecture"
     #endif

--- a/src/Disks/IO/ThreadPoolReader.cpp
+++ b/src/Disks/IO/ThreadPoolReader.cpp
@@ -39,7 +39,7 @@
     #elif defined(__loongarch64)
         #define SYS_preadv2 286
     #elif defined(__e2k__)
-        #define SYS_preadv2 286
+        #define SYS_preadv2 395
     #else
         #error "Unsupported architecture"
     #endif


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

small fixes and improvements for e2k arch, continue of https://github.com/ClickHouse/ClickHouse/pull/90159