### PR TITLE
Fix crash when receiving from disconnected `Connection`

### DIFF
--- a/src/Client/Connection.cpp
+++ b/src/Client/Connection.cpp
@@ -1311,6 +1311,10 @@ UInt64 Connection::receivePacketType()
     if (last_input_packet_type)
         return *last_input_packet_type;
 
+    /// If we already disconnected
+    if (!in)
+        throw Exception(ErrorCodes::NETWORK_ERROR, "Connection to {} terminated", getDescription());
+
     UInt64 type;
     readVarUInt(type, *in);
     return last_input_packet_type.emplace(type);
@@ -1321,6 +1325,10 @@ Packet Connection::receivePacket()
 {
     try
     {
+        /// If we already disconnected
+        if (!in)
+            throw Exception(ErrorCodes::NETWORK_ERROR, "Connection to {} terminated", getDescription());
+
         Packet res;
 
         /// Have we already read packet type?

--- a/src/Client/Connection.cpp
+++ b/src/Client/Connection.cpp
@@ -1311,10 +1311,6 @@ UInt64 Connection::receivePacketType()
     if (last_input_packet_type)
         return *last_input_packet_type;
 
-    /// If we already disconnected
-    if (!in)
-        throw Exception(ErrorCodes::NETWORK_ERROR, "Connection to {} terminated", getDescription());
-
     UInt64 type;
     readVarUInt(type, *in);
     return last_input_packet_type.emplace(type);
@@ -1325,10 +1321,6 @@ Packet Connection::receivePacket()
 {
     try
     {
-        /// If we already disconnected
-        if (!in)
-            throw Exception(ErrorCodes::NETWORK_ERROR, "Connection to {} terminated", getDescription());
-
         Packet res;
 
         /// Have we already read packet type?

--- a/src/Processors/Sources/RemoteSource.cpp
+++ b/src/Processors/Sources/RemoteSource.cpp
@@ -93,7 +93,7 @@ ISource::Status RemoteSource::prepare()
     if (is_async_state)
         return Status::Async;
 
-    if (query_executor->isFinishCalled())
+    if (query_executor->isFinished())
     {
         getPort().finish();
         return Status::Finished;

--- a/src/Processors/Sources/RemoteSource.cpp
+++ b/src/Processors/Sources/RemoteSource.cpp
@@ -94,7 +94,10 @@ ISource::Status RemoteSource::prepare()
         return Status::Async;
 
     if (executor_finished)
+    {
+        getPort().finish();
         return Status::Finished;
+    }
 
     Status status = ISource::prepare();
     /// To avoid resetting the connection (because of "unfinished" query) in the

--- a/src/Processors/Sources/RemoteSource.h
+++ b/src/Processors/Sources/RemoteSource.h
@@ -48,7 +48,6 @@ protected:
 private:
     std::atomic_bool was_query_sent = false;
     bool need_drain = false;
-    bool executor_finished = false;
     bool add_aggregation_info = false;
     RemoteQueryExecutorPtr query_executor;
     RowsBeforeStepCounterPtr rows_before_limit;
@@ -64,8 +63,6 @@ private:
 #if defined(OS_LINUX)
     EventFD startup_event_fd;
 #endif
-
-    void finishExecutor();
 };
 
 /// Totals source from RemoteQueryExecutor.

--- a/src/Processors/Sources/RemoteSource.h
+++ b/src/Processors/Sources/RemoteSource.h
@@ -64,6 +64,8 @@ private:
 #if defined(OS_LINUX)
     EventFD startup_event_fd;
 #endif
+
+    void finishExecutor();
 };
 
 /// Totals source from RemoteQueryExecutor.

--- a/src/QueryPipeline/RemoteQueryExecutor.cpp
+++ b/src/QueryPipeline/RemoteQueryExecutor.cpp
@@ -778,6 +778,11 @@ void RemoteQueryExecutor::finish()
 {
     LockAndBlocker guard(was_cancelled_mutex);
 
+    /// We only allow one finish call to avoid double-cancellation
+    if (isFinishCalled())
+        return;
+    finish_called = true;
+
     /** If one of:
       * - nothing started to do;
       * - received all packets before EndOfStream;

--- a/src/QueryPipeline/RemoteQueryExecutor.cpp
+++ b/src/QueryPipeline/RemoteQueryExecutor.cpp
@@ -778,10 +778,8 @@ void RemoteQueryExecutor::finish()
 {
     LockAndBlocker guard(was_cancelled_mutex);
 
-    /// We only allow one finish call to avoid double-cancellation
-    if (isFinishCalled())
-        return;
-    finish_called = true;
+    /// To make sure finish is only called once
+    SCOPE_EXIT({ finished = true; });
 
     /** If one of:
       * - nothing started to do;

--- a/src/QueryPipeline/RemoteQueryExecutor.h
+++ b/src/QueryPipeline/RemoteQueryExecutor.h
@@ -221,8 +221,7 @@ public:
     /// return true if parallel replica packet was processed
     bool processParallelReplicaPacketIfAny();
 
-    /// Check if finish() has been called
-    bool isFinishCalled() const { return finish_called; }
+    bool isFinished() const { return finished; }
 
 private:
     RemoteQueryExecutor(
@@ -279,9 +278,6 @@ private:
       * read all packets before EndOfStream
       */
     bool finished = false;
-
-    /// Keep track of whether finish() has been called to avoid double-calling
-    bool finish_called = false;
 
     /** Cancel query request was sent to all replicas because data is not needed anymore
       * This behaviour may occur when:

--- a/src/QueryPipeline/RemoteQueryExecutor.h
+++ b/src/QueryPipeline/RemoteQueryExecutor.h
@@ -221,6 +221,9 @@ public:
     /// return true if parallel replica packet was processed
     bool processParallelReplicaPacketIfAny();
 
+    /// Check if finish() has been called
+    bool isFinishCalled() const { return finish_called; }
+
 private:
     RemoteQueryExecutor(
         const String & query_,
@@ -276,6 +279,9 @@ private:
       * read all packets before EndOfStream
       */
     bool finished = false;
+
+    /// Keep track of whether finish() has been called to avoid double-calling
+    bool finish_called = false;
 
     /** Cancel query request was sent to all replicas because data is not needed anymore
       * This behaviour may occur when:


### PR DESCRIPTION
Idealogical successor of https://github.com/ClickHouse/ClickHouse/pull/89740. Avoid doing `finish()` twice.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Avoid crash due to reading from a disconnected `Connection`