### PR TITLE
Fix "Failed to set file processing within 100 retries" error in s3queue

### DIFF
--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueIFileMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueIFileMetadata.cpp
@@ -366,7 +366,7 @@ void ObjectStorageQueueIFileMetadata::afterSetProcessing(bool success, std::opti
         chassert(!created_processing_node);
         ProfileEvents::increment(ProfileEvents::ObjectStorageQueueTrySetProcessingFailed);
 
-        if (file_state.has_value())
+        if (file_state.has_value() && file_state.value() != FileStatus::State::None)
         {
             LOG_TEST(log, "Updating state of {} from {} to {}", path, file_status->state.load(), file_state.value());
             file_status->updateState(file_state.value());

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueOrderedFileMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueOrderedFileMetadata.cpp
@@ -290,6 +290,7 @@ std::pair<bool, ObjectStorageQueueIFileMetadata::FileStatus::State> ObjectStorag
 
     const size_t max_num_tries = 100;
     Coordination::Error code;
+    std::string failed_path;
     for (size_t i = 0; i < max_num_tries; ++i)
     {
         std::optional<NodeMetadata> processed_node;
@@ -418,7 +419,8 @@ std::pair<bool, ObjectStorageQueueIFileMetadata::FileStatus::State> ObjectStorag
         auto has_request_failed = [&](size_t request_index) { return responses[request_index]->error != Coordination::Error::ZOK; };
 
         auto failed_idx = zkutil::getFailedOpIndex(code, responses);
-        LOG_DEBUG(log, "Code: {}, failed idx: {}, failed path: {}", code, failed_idx, requests[failed_idx]->getPath());
+        failed_path = requests[failed_idx]->getPath();
+        LOG_DEBUG(log, "Code: {}, failed idx: {}, failed path: {}", code, failed_idx, failed_path);
 
         if (has_request_failed(failed_path_doesnt_exist_idx))
             return {false, FileStatus::State::Failed};
@@ -436,10 +438,9 @@ std::pair<bool, ObjectStorageQueueIFileMetadata::FileStatus::State> ObjectStorag
         LOG_DEBUG(log, "Retrying setProcessing because processing node id path is unexpectedly missing or was created (error code: {})", code);
     }
 
-    throw Exception(
-        ErrorCodes::LOGICAL_ERROR,
-        "Failed to set file processing within {} retries, last error: {}",
-        max_num_tries, code);
+    LOG_WARNING(log, "Failed to set file processing within {} retries, last error {} for path {}", max_num_tries, code, failed_path);
+    chassert(false); /// Catch in CI.
+    return {false, FileStatus::State::None};
 }
 
 void ObjectStorageQueueOrderedFileMetadata::prepareProcessedAtStartRequests(Coordination::Requests & requests)


### PR DESCRIPTION
<!-- Fixes issue link part, do not remove -->
## Linked issues
- fixes https://github.com/ClickHouse/clickhouse-core-incidents/issues/938
<!-- End of fixes issue link part, do not remove -->

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix logical error ` Failed to set file processing within 100 retries` in storgae `S3Queue` in `Ordered` mode. It is now replaced with a warning. This error could happen before 25.10 version if keeper session expired, however it will still be a warning in 25.10+ versions, as it is still theoretically possible to get this error in case of high processing concurrency in `Ordered` mode. 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.101`
- Backported to: `25.12.2.24`, `25.11.5.2`, `25.10.4.98`, `25.8.15.32`
<!-- ch-version-info:end -->