### PR TITLE
Use equivalent sets to push down filter for SEMI JOIN

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/filterPushDown.cpp
+++ b/src/Processors/QueryPlan/Optimizations/filterPushDown.cpp
@@ -387,9 +387,9 @@ static size_t tryPushDownOverJoinStep(QueryPlan::Node * parent_node, QueryPlan::
         left_stream_filter_push_down_input_columns_available = false;
 
     if (logical_join && logical_join->getJoinOperator().kind == JoinKind::Left)
-        right_stream_filter_push_down_input_columns_available = false;
+        right_stream_filter_push_down_input_columns_available = logical_join->getJoinOperator().strictness == JoinStrictness::Semi;
     else if (logical_join && logical_join->getJoinOperator().kind == JoinKind::Right)
-        left_stream_filter_push_down_input_columns_available = false;
+        left_stream_filter_push_down_input_columns_available = logical_join->getJoinOperator().strictness == JoinStrictness::Semi;
 
     /** We disable push down to right table in cases:
       * 1. Right side is already filled. Example: JOIN with Dictionary.

--- a/tests/queries/0_stateless/03773_semi_join_equivalent_sets.reference
+++ b/tests/queries/0_stateless/03773_semi_join_equivalent_sets.reference
@@ -1,13 +1,7 @@
-Expression ((Project names + Projection))
-  Filter (WHERE)
-    Expression (Post Join Actions)
-      Join (JOIN FillRightFirst)
-        Expression (Left Pre Join Actions)
-          Expression (Change column names to column identifiers)
-            ReadFromMergeTree (default.users)
-        Expression (Right Pre Join Actions)
-          Expression ((Change column names to column identifiers + (Project names + (Projection + Change column names to column identifiers))))
-            ReadFromSystemNumbers
+  Filter column: equals(__table2.number, 0_UInt8) (removed)
+      Type: LEFT
+      Strictness: ANY
+            ReadType: Default
 Expression ((Project names + (Projection + )))
 Actions: INPUT : 0 -> __table1.uid UInt64 : 0
          INPUT : 1 -> __table1.name String : 1
@@ -67,3 +61,26 @@ Positions: 4 0 1 2
                  ALIAS number :: 1 -> __table2.number UInt64 : 2
         Positions: 3 2
           ReadFromSystemNumbers
+    Type: LEFT
+    Strictness: SEMI
+          ReadType: Default
+            Prewhere filter column: equals(__table1.uid, 1_UInt8) (removed)
+        Filter column: equals(__table2.number, 1_UInt8) (removed)
+--
+    Type: LEFT
+    Strictness: SEMI
+          ReadType: Default
+            Prewhere filter column: equals(__table1.uid, 1_UInt8) (removed)
+        Filter column: equals(__table2.number, 1_UInt8) (removed)
+--
+    Type: RIGHT
+    Strictness: SEMI
+          ReadType: Default
+            Prewhere filter column: equals(__table1.uid, 1_UInt8) (removed)
+        Filter column: equals(__table2.number, 1_UInt8) (removed)
+--
+    Type: RIGHT
+    Strictness: SEMI
+          ReadType: Default
+            Prewhere filter column: equals(__table1.uid, 1_UInt8) (removed)
+        Filter column: equals(__table2.number, 1_UInt8) (removed)

--- a/tests/queries/0_stateless/03773_semi_join_equivalent_sets.reference
+++ b/tests/queries/0_stateless/03773_semi_join_equivalent_sets.reference
@@ -1,0 +1,61 @@
+Expression ((Project names + Projection))
+  Filter (WHERE)
+    Expression (Post Join Actions)
+      Join (JOIN FillRightFirst)
+        Expression (Left Pre Join Actions)
+          Expression (Change column names to column identifiers)
+            ReadFromMergeTree (default.users)
+        Expression (Right Pre Join Actions)
+          Expression ((Change column names to column identifiers + (Project names + (Projection + Change column names to column identifiers))))
+            ReadFromSystemNumbers
+Expression ((Project names + (Projection + )))
+Actions: INPUT : 0 -> __table1.uid UInt64 : 0
+         INPUT : 1 -> __table1.name String : 1
+         INPUT : 2 -> __table1.age Int16 : 2
+         INPUT : 3 -> __table2.number UInt64 : 3
+         ALIAS __table1.uid :: 0 -> uid UInt64 : 4
+         ALIAS __table1.name :: 1 -> name String : 0
+         ALIAS __table1.age :: 2 -> age Int16 : 1
+         ALIAS __table2.number :: 3 -> number UInt64 : 2
+Positions: 4 0 1 2
+  JoinLogical
+  Join: users ⋉ t2
+  ResultRows: unknown
+  Type: LEFT
+  Strictness: SEMI
+  Locality: UNSPECIFIED
+  Expression: equals(__table1.uid, __table2.number)
+  Expression:
+  Actions: INPUT : 0 -> __table1.uid UInt64 : 0
+           INPUT :: 1 -> __table1.name String : 1
+           INPUT :: 2 -> __table1.age Int16 : 2
+           INPUT : 3 -> __table2.number UInt64 : 3
+           FUNCTION equals(__table1.uid : 0, __table2.number : 3) -> equals(__table1.uid, __table2.number) UInt8 : 4
+  Positions: 0 1 2 3
+  Expression Sources:
+  __table1.uid: {0}
+  __table1.name: {0}
+  __table1.age: {0}
+  __table2.number: {1}
+    Expression (Change column names to column identifiers)
+    Actions: INPUT : 0 -> uid UInt64 : 0
+             INPUT : 1 -> name String : 1
+             INPUT : 2 -> age Int16 : 2
+             ALIAS uid :: 0 -> __table1.uid UInt64 : 3
+             ALIAS name :: 1 -> __table1.name String : 0
+             ALIAS age :: 2 -> __table1.age Int16 : 1
+    Positions: 3 0 1
+      ReadFromMergeTree (default.users)
+      ReadType: Default
+      Parts: 3
+      Granules: 3
+    Filter ((WHERE + (Change column names to column identifiers + (Project names + (Projection + Change column names to column identifiers)))))
+    Filter column: equals(__table2.number, 1_UInt8) (removed)
+    Actions: INPUT : 0 -> number UInt64 : 0
+             COLUMN Const(UInt8) -> 1_UInt8 UInt8 : 1
+             ALIAS number : 0 -> __table3.number UInt64 : 2
+             FUNCTION equals(number :: 0, 1_UInt8 :: 1) -> equals(__table2.number, 1_UInt8) UInt8 : 3
+             ALIAS __table3.number :: 2 -> number UInt64 : 1
+             ALIAS number :: 1 -> __table2.number UInt64 : 2
+    Positions: 3 2
+      ReadFromSystemNumbers

--- a/tests/queries/0_stateless/03773_semi_join_equivalent_sets.reference
+++ b/tests/queries/0_stateless/03773_semi_join_equivalent_sets.reference
@@ -18,44 +18,52 @@ Actions: INPUT : 0 -> __table1.uid UInt64 : 0
          ALIAS __table1.age :: 2 -> age Int16 : 1
          ALIAS __table2.number :: 3 -> number UInt64 : 2
 Positions: 4 0 1 2
-  JoinLogical
-  Join: users ⋉ t2
-  ResultRows: unknown
-  Type: LEFT
-  Strictness: SEMI
-  Locality: UNSPECIFIED
-  Expression: equals(__table1.uid, __table2.number)
-  Expression:
-  Actions: INPUT : 0 -> __table1.uid UInt64 : 0
+  Expression (Post Join Actions)
+  Actions: INPUT :: 0 -> __table1.uid UInt64 : 0
            INPUT :: 1 -> __table1.name String : 1
            INPUT :: 2 -> __table1.age Int16 : 2
-           INPUT : 3 -> __table2.number UInt64 : 3
-           FUNCTION equals(__table1.uid : 0, __table2.number : 3) -> equals(__table1.uid, __table2.number) UInt8 : 4
+           INPUT :: 3 -> __table2.number UInt64 : 3
   Positions: 0 1 2 3
-  Expression Sources:
-  __table1.uid: {0}
-  __table1.name: {0}
-  __table1.age: {0}
-  __table2.number: {1}
-    Expression (Change column names to column identifiers)
-    Actions: INPUT : 0 -> uid UInt64 : 0
-             INPUT : 1 -> name String : 1
-             INPUT : 2 -> age Int16 : 2
-             ALIAS uid :: 0 -> __table1.uid UInt64 : 3
-             ALIAS name :: 1 -> __table1.name String : 0
-             ALIAS age :: 2 -> __table1.age Int16 : 1
-    Positions: 3 0 1
-      ReadFromMergeTree (default.users)
-      ReadType: Default
-      Parts: 3
-      Granules: 3
-    Filter ((WHERE + (Change column names to column identifiers + (Project names + (Projection + Change column names to column identifiers)))))
-    Filter column: equals(__table2.number, 1_UInt8) (removed)
-    Actions: INPUT : 0 -> number UInt64 : 0
-             COLUMN Const(UInt8) -> 1_UInt8 UInt8 : 1
-             ALIAS number : 0 -> __table3.number UInt64 : 2
-             FUNCTION equals(number :: 0, 1_UInt8 :: 1) -> equals(__table2.number, 1_UInt8) UInt8 : 3
-             ALIAS __table3.number :: 2 -> number UInt64 : 1
-             ALIAS number :: 1 -> __table2.number UInt64 : 2
-    Positions: 3 2
-      ReadFromSystemNumbers
+    Join (JOIN FillRightFirst)
+    Type: LEFT
+    Strictness: SEMI
+    Algorithm: ConcurrentHashJoin
+    Clauses: [(__table1.uid) = (__table2.number)]
+      Expression (Left Pre Join Actions)
+      Actions: INPUT :: 0 -> __table1.uid UInt64 : 0
+               INPUT :: 1 -> __table1.name String : 1
+               INPUT :: 2 -> __table1.age Int16 : 2
+      Positions: 0 1 2
+        Expression ((WHERE + Change column names to column identifiers))
+        Actions: INPUT : 1 -> name String : 0
+                 INPUT : 2 -> age Int16 : 1
+                 INPUT : 0 -> uid UInt64 : 2
+                 ALIAS name :: 0 -> __table1.name String : 3
+                 ALIAS age :: 1 -> __table1.age Int16 : 0
+                 ALIAS uid :: 2 -> __table1.uid UInt64 : 1
+        Positions: 1 3 0
+          ReadFromMergeTree (default.users)
+          ReadType: Default
+          Parts: 0
+          Granules: 0
+          Prewhere info
+          Need filter: 1
+            Prewhere filter
+            Prewhere filter column: equals(__table1.uid, 1_UInt8) (removed)
+            Actions: INPUT : 0 -> uid UInt64 : 0
+                     COLUMN Const(UInt8) -> 1_UInt8 UInt8 : 1
+                     FUNCTION equals(uid : 0, 1_UInt8 :: 1) -> equals(__table1.uid, 1_UInt8) UInt8 : 2
+            Positions: 0 2
+      Expression (Right Pre Join Actions)
+      Actions: INPUT :: 0 -> __table2.number UInt64 : 0
+      Positions: 0
+        Filter ((WHERE + (Change column names to column identifiers + (Project names + (Projection + Change column names to column identifiers)))))
+        Filter column: equals(__table2.number, 1_UInt8) (removed)
+        Actions: INPUT : 0 -> number UInt64 : 0
+                 COLUMN Const(UInt8) -> 1_UInt8 UInt8 : 1
+                 ALIAS number : 0 -> __table3.number UInt64 : 2
+                 FUNCTION equals(number :: 0, 1_UInt8 :: 1) -> equals(__table2.number, 1_UInt8) UInt8 : 3
+                 ALIAS __table3.number :: 2 -> number UInt64 : 1
+                 ALIAS number :: 1 -> __table2.number UInt64 : 2
+        Positions: 3 2
+          ReadFromSystemNumbers

--- a/tests/queries/0_stateless/03773_semi_join_equivalent_sets.sql
+++ b/tests/queries/0_stateless/03773_semi_join_equivalent_sets.sql
@@ -4,8 +4,32 @@ INSERT INTO users VALUES (1231, 'John', 33);
 INSERT INTO users VALUES (6666, 'Ksenia', 48);
 INSERT INTO users VALUES (8888, 'Alice', 50);
 
-EXPLAIN
-SELECT * FROM users LEFT ANY JOIN (SELECT number FROM numbers(10)) as t2 ON users.uid = t2.number WHERE t2.number = 0;
+SELECT explain FROM (
+    EXPLAIN actions = 1
+    SELECT * FROM users LEFT ANY JOIN (SELECT number FROM numbers(10)) as t2 ON users.uid = t2.number WHERE t2.number = 0
+) WHERE explain ilike '%Type:%' OR explain ilike '%Strictness%' OR explain ilike '%filter column%';
 
 EXPLAIN actions = 1
 SELECT * FROM users LEFT SEMI JOIN (SELECT number FROM numbers(10)) as t2 ON users.uid = t2.number WHERE t2.number = 1;
+
+SELECT explain FROM (
+  EXPLAIN actions = 1 SELECT * FROM users LEFT ANY JOIN (SELECT number FROM numbers(10)) as t2 ON users.uid = t2.number WHERE t2.number = 1
+) WHERE explain ilike '%Type:%' OR explain ilike '%Strictness%' OR explain ilike '%filter column%';
+
+SELECT '--';
+
+SELECT explain FROM (
+  EXPLAIN actions = 1 SELECT * FROM users LEFT SEMI JOIN (SELECT number FROM numbers(10)) as t2 ON users.uid = t2.number WHERE users.uid = 1
+) WHERE explain ilike '%Type:%' OR explain ilike '%Strictness%' OR explain ilike '%filter column%';
+
+SELECT '--';
+
+SELECT explain FROM (
+  EXPLAIN actions = 1 SELECT * FROM users RIGHT ANY JOIN (SELECT number FROM numbers(10)) as t2 ON users.uid = t2.number WHERE users.uid = 1
+) WHERE explain ilike '%Type:%' OR explain ilike '%Strictness%' OR explain ilike '%filter column%';
+
+SELECT '--';
+
+SELECT explain FROM (
+  EXPLAIN actions = 1 SELECT * FROM users RIGHT SEMI JOIN (SELECT number FROM numbers(10)) as t2 ON users.uid = t2.number WHERE t2.number = 1
+) WHERE explain ilike '%Type:%' OR explain ilike '%Strictness%' OR explain ilike '%filter column%';

--- a/tests/queries/0_stateless/03773_semi_join_equivalent_sets.sql
+++ b/tests/queries/0_stateless/03773_semi_join_equivalent_sets.sql
@@ -1,3 +1,7 @@
+SET enable_analyzer = 1;
+SET enable_parallel_replicas = 0;
+SET query_plan_join_swap_table = 0;
+
 CREATE TABLE users (uid UInt64, name String, age Int16) ENGINE=MergeTree ORDER BY uid;
 
 INSERT INTO users VALUES (1231, 'John', 33);

--- a/tests/queries/0_stateless/03773_semi_join_equivalent_sets.sql
+++ b/tests/queries/0_stateless/03773_semi_join_equivalent_sets.sql
@@ -1,0 +1,11 @@
+CREATE TABLE users (uid UInt64, name String, age Int16) ENGINE=MergeTree ORDER BY uid;
+
+INSERT INTO users VALUES (1231, 'John', 33);
+INSERT INTO users VALUES (6666, 'Ksenia', 48);
+INSERT INTO users VALUES (8888, 'Alice', 50);
+
+EXPLAIN
+SELECT * FROM users LEFT ANY JOIN (SELECT number FROM numbers(10)) as t2 ON users.uid = t2.number WHERE t2.number = 1;
+
+EXPLAIN actions = 1, keep_logical_steps = 1
+SELECT * FROM users LEFT SEMI JOIN (SELECT number FROM numbers(10)) as t2 ON users.uid = t2.number WHERE t2.number = 1;

--- a/tests/queries/0_stateless/03773_semi_join_equivalent_sets.sql
+++ b/tests/queries/0_stateless/03773_semi_join_equivalent_sets.sql
@@ -5,7 +5,7 @@ INSERT INTO users VALUES (6666, 'Ksenia', 48);
 INSERT INTO users VALUES (8888, 'Alice', 50);
 
 EXPLAIN
-SELECT * FROM users LEFT ANY JOIN (SELECT number FROM numbers(10)) as t2 ON users.uid = t2.number WHERE t2.number = 1;
+SELECT * FROM users LEFT ANY JOIN (SELECT number FROM numbers(10)) as t2 ON users.uid = t2.number WHERE t2.number = 0;
 
-EXPLAIN actions = 1, keep_logical_steps = 1
+EXPLAIN actions = 1
 SELECT * FROM users LEFT SEMI JOIN (SELECT number FROM numbers(10)) as t2 ON users.uid = t2.number WHERE t2.number = 1;


### PR DESCRIPTION
### Changelog category (leave one):

- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Allow using equivalent sets to push down filters for `SEMI JOIN`. Closes https://github.com/ClickHouse/ClickHouse/issues/85239.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
