### PR TITLE
Fix aligned alloc in ASan

### DIFF
--- a/src/Common/memory.h
+++ b/src/Common/memory.h
@@ -72,7 +72,7 @@ inline ALWAYS_INLINE void * newNoExcept(std::size_t size) noexcept
 
 inline ALWAYS_INLINE void * newNoExcept(std::size_t size, std::align_val_t align) noexcept
 {
-    return __real_aligned_alloc(static_cast<size_t>(align), size);
+    return __real_aligned_alloc(static_cast<size_t>(align), alignUp(size, static_cast<size_t>(align)));
 }
 
 inline ALWAYS_INLINE void deleteImpl(void * ptr) noexcept


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
I wonder why it isn't shown in CI, but on my machine, it was as follows:

```
milovidov@milovidov-pc:~/work/ClickHouse/build_asan$ programs/clickhouse
=================================================================
==3302453==ERROR: AddressSanitizer: invalid alignment requested in aligned_alloc: 8, alignment must be a power of two and the requested size 0x1e must be a multiple of alignment (thread T0)
    #0 0x5583ee288f82 in aligned_alloc /home/milovidov/work/llvm-project/compiler-rt/lib/asan/asan_malloc_linux.cpp:107:3
    #1 0x558405022702 in Memory::newNoExcept(unsigned long, std::align_val_t) build_asan/./src/Common/memory.h:75:12
    #2 0x558405022702 in operator new(unsigned long, std::align_val_t, std::nothrow_t const&) build_asan/./src/Common/AllocationInterceptors.cpp:110:18
    #3 0x5584284f100f in llvm::allocate_buffer(unsigned long, unsigned long) (/home/milovidov/work/ClickHouse/build_asan/programs/clickhouse+0x4772b00f) (BuildId: 4880004eea861f2b20f8b48ffa34e4429708cfef)
    #4 0x5584284994e6 in std::__1::pair<llvm::StringMapIterator<llvm::cl::Option*>, bool> llvm::StringMap<llvm::cl::Option*, llvm::MallocAllocator>::try_emplace_with_hash<llvm::cl::Option*>(llvm::StringRef, unsigned int, llvm::cl::Option*&&) CommandLine.cpp
    #5 0x5584284998f0 in (anonymous namespace)::CommandLineParser::addOption(llvm::cl::Option*, llvm::cl::SubCommand*) CommandLine.cpp
    #6 0x55842848b7d4 in llvm::cl::Option::addArgument() (/home/milovidov/work/ClickHouse/build_asan/programs/clickhouse+0x476c57d4) (BuildId: 4880004eea861f2b20f8b48ffa34e4429708cfef)
    #7 0x5584284a27d7 in llvm::cl::list<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, llvm::DebugCounter, llvm::cl::parser<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>::list<char [14], llvm::cl::OptionHidden, llvm::cl::desc, llvm::cl::MiscFlags, llvm::cl::LocationClass<llvm::DebugCounter>>(char const (&) [14], llvm::cl::OptionHidden const&, llvm::cl::desc const&, llvm::cl::MiscFlags const&, llvm::cl::LocationClass<llvm::DebugCounter> const&) DebugCounter.cpp
    #8 0x55842849fc25 in (anonymous namespace)::DebugCounterOwner::DebugCounterOwner() DebugCounter.cpp
    #9 0x55842849fa73 in llvm::DebugCounter::instance() (/home/milovidov/work/ClickHouse/build_asan/programs/clickhouse+0x476d9a73) (BuildId: 4880004eea861f2b20f8b48ffa34e4429708cfef)
    #10 0x5584234d42fc in llvm::DebugCounter::registerCounter(llvm::StringRef, llvm::StringRef) PassBuilder.cpp
    #11 0x558423586268 in _GLOBAL__sub_I_PassBuilder.cpp PassBuilder.cpp
    #12 0x5584308c181c in __libc_csu_init (/home/milovidov/work/ClickHouse/build_asan/programs/clickhouse+0x4fafb81c) (BuildId: 4880004eea861f2b20f8b48ffa34e4429708cfef)

==3302453==HINT: if you don't care about these errors you may set allocator_may_return_null=1
SUMMARY: AddressSanitizer: invalid-aligned-alloc-alignment build_asan/./src/Common/memory.h:75:12 in Memory::newNoExcept(unsigned long, std::align_val_t)
==3302453==ABORTING
Aborted
milovidov@milovidov-pc:~/work/ClickHouse/build_asan$ ninja clickhouse
[0/2] Re-checking globbed directories...
[9/9] Linking CXX executable programs/clickhouse
milovidov@milovidov-pc:~/work/ClickHouse/build_asan$ programs/clickhouse
ClickHouse local version 26.1.1.1.

:) SELECT 1

SELECT 1

Query id: d83ed542-d260-400a-91a9-aa89b9532e72

   ┌─1─┐
1. │ 1 │
   └───┘

1 row in set. Elapsed: 0.004 sec. 

:) Bye.
```