### PR TITLE
Add the setting to ignore ON CLUSTER clause for replicated databases

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -7253,6 +7253,9 @@ Serialize String values during aggregation with zero byte at the end. Enable to 
 Maximum number of `_path` values that can be extracted from query filters to use for file iteration
 instead of glob listing. 0 means disabled.
 )", 0) \
+    DECLARE(Bool, ignore_on_cluster_for_replicated_database, false, R"(
+Always ignore ON CLUSTER clause for DDL queries with replicated databases.
+)", 0) \
     \
     /* ####################################################### */ \
     /* ########### START OF EXPERIMENTAL FEATURES ############ */ \

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -41,6 +41,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
         /// Note: please check if the key already exists to prevent duplicate entries.
         addSettingsChanges(settings_changes_history, "26.1",
         {
+            {"ignore_on_cluster_for_replicated_database", false, false, "Add a new setting to ignore ON CLUSTER clause for DDL queries with a replicated database."},
             {"input_format_binary_max_type_complexity", 1000, 1000, "Add a new setting to control max number of type nodes when decoding binary types. Protects against malicious inputs."},
             {"trace_profile_events_list", "", "", "New setting"},
         });

--- a/src/Interpreters/executeDDLQueryOnCluster.cpp
+++ b/src/Interpreters/executeDDLQueryOnCluster.cpp
@@ -37,6 +37,7 @@ namespace Setting
     extern const SettingsDistributedDDLOutputMode distributed_ddl_output_mode;
     extern const SettingsInt64 distributed_ddl_task_timeout;
     extern const SettingsBool throw_on_unsupported_query_inside_transaction;
+    extern const SettingsBool ignore_on_cluster_for_replicated_database;
 }
 
 namespace ServerSetting
@@ -235,17 +236,19 @@ bool maybeRemoveOnCluster(const ASTPtr & query_ptr, ContextPtr context)
         database_name = context->getCurrentDatabase();
 
     auto * query_on_cluster = dynamic_cast<ASTQueryWithOnCluster *>(query_ptr.get());
-    if (database_name != query_on_cluster->cluster)
-        return false;
-
     auto database = DatabaseCatalog::instance().tryGetDatabase(database_name);
     if (database && database->shouldReplicateQuery(context, query_ptr))
     {
+        if (!context->getSettingsRef()[Setting::ignore_on_cluster_for_replicated_database] && database_name != query_on_cluster->cluster)
+            return false;
         /// It's Replicated database and query is replicated on database level,
         /// so ON CLUSTER clause is redundant.
         query_on_cluster->cluster.clear();
         return true;
     }
+
+    if (database_name != query_on_cluster->cluster)
+        return false;
 
     return false;
 }

--- a/src/Interpreters/executeDDLQueryOnCluster.cpp
+++ b/src/Interpreters/executeDDLQueryOnCluster.cpp
@@ -247,9 +247,6 @@ bool maybeRemoveOnCluster(const ASTPtr & query_ptr, ContextPtr context)
         return true;
     }
 
-    if (database_name != query_on_cluster->cluster)
-        return false;
-
     return false;
 }
 


### PR DESCRIPTION
### Changelog category (leave one):
- New Feature

### Changelog entry (a [user-readable short description]
It is possible to execute DDL queries with `ON CLUSTER` clause for a Replicated database if the `ignore_on_cluster_for_replicated_database` setting is enabled. In this case, the cluster name will be ignored.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

Basically reopening https://github.com/ClickHouse/ClickHouse/pull/84176. Main use case is for a seamless migration of a database to replicated engine, so users can still use their old ON CLUSTER ddl queries without change.
In some cases ignoring cluster name can be unexpected behaviour, so using a setting for this feature can fix that.
