### PR TITLE
Fallback to read & write for native copy fails

### DIFF
--- a/src/IO/AzureBlobStorage/copyAzureBlobStorageFile.cpp
+++ b/src/IO/AzureBlobStorage/copyAzureBlobStorageFile.cpp
@@ -430,7 +430,7 @@ void copyAzureBlobStorageFile(
                           e.StatusCode, src_container_for_logging, src_blob, dest_container_for_logging, dest_blob);
         }
     }
-    if (!g)
+    if (!is_native_copy_done)
     {
         /// Copy through read and write
         LOG_TRACE(log, "Reading and writing Blob: {} from Container: {}", src_blob, src_container_for_logging);

--- a/src/IO/AzureBlobStorage/copyAzureBlobStorageFile.cpp
+++ b/src/IO/AzureBlobStorage/copyAzureBlobStorageFile.cpp
@@ -425,17 +425,12 @@ void copyAzureBlobStorageFile(
         }
         catch (const Azure::Storage::StorageException & e)
         {
-            if (e.StatusCode == Azure::Core::Http::HttpStatusCode::Unauthorized)
-            {
-                LOG_TRACE(log, "Copy operation has thrown unauthorized access error, which indicates that the storage account of the source & destination are not the same. "
-                               "Will attempt to copy using read & write. source container = {} blob = {} and destination container = {} blob = {}",
-                          src_container_for_logging, src_blob, dest_container_for_logging, dest_blob);
-            }
-            else
-                throw;
+            LOG_TRACE(log, "Copy operation has thrown error access error {}. "
+                            "Will attempt to copy using read & write. source container = {} blob = {} and destination container = {} blob = {}",
+                          e.StatusCode, src_container_for_logging, src_blob, dest_container_for_logging, dest_blob);
         }
     }
-    if (!is_native_copy_done)
+    if (!g)
     {
         /// Copy through read and write
         LOG_TRACE(log, "Reading and writing Blob: {} from Container: {}", src_blob, src_container_for_logging);

--- a/src/IO/AzureBlobStorage/copyAzureBlobStorageFile.cpp
+++ b/src/IO/AzureBlobStorage/copyAzureBlobStorageFile.cpp
@@ -433,7 +433,7 @@ void copyAzureBlobStorageFile(
             }
             else if (e.StatusCode == Azure::Core::Http::HttpStatusCode::BadRequest)
             {
-                LOG_TRACE(log, "Copy operation has thrown bad argument error. e.what = {}"
+                LOG_TRACE(log, "Copy operation has thrown bad argument error. e.what = {}. "
                                "Will attempt to copy using read & write. source container = {} blob = {} and destination container = {} blob = {}",
                           e.what(), src_container_for_logging, src_blob, dest_container_for_logging, dest_blob);
             }


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fallback to read-write copy for Azure Blob Storage when native copy fails with BadRequest (e.g. invalid block list). Previously this was only done for Unauthorized error which was seen while copying blob to different storage accounts. But we also sometimes see "The specified block list is invalid" error. So now updated the condition to fallback to read & write for all native copy fails.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
