### PR TITLE
Add caching to AWSInstanceProfileCredentialsProvider to prevent EC2 metadata endpoint throttling

### DIFF
--- a/src/IO/S3/Credentials.h
+++ b/src/IO/S3/Credentials.h
@@ -105,9 +105,23 @@ class AWSInstanceProfileCredentialsProvider : public Aws::Auth::AWSCredentialsPr
 public:
     /// See InstanceProfileCredentialsProvider.
 
+    static std::shared_ptr<Aws::Auth::AWSCredentialsProvider>
+    create(const Aws::Client::ClientConfiguration & client_configuration, bool use_secure_pull);
+
     explicit AWSInstanceProfileCredentialsProvider(const std::shared_ptr<AWSEC2InstanceProfileConfigLoader> & config_loader);
 
     Aws::Auth::AWSCredentials GetAWSCredentials() override;
+
+    struct CacheKey
+    {
+        String endpoint;
+        bool use_secure_pull;
+
+        bool operator==(const CacheKey & rhs) const = default;
+
+        void updateHash(SipHash & hash) const;
+    };
+
 protected:
     void Reload() override;
 

--- a/src/IO/S3/tests/gtest_aws_s3_client.cpp
+++ b/src/IO/S3/tests/gtest_aws_s3_client.cpp
@@ -364,6 +364,30 @@ void validateAssumeRoleQueryParams(const Poco::URI::QueryParameters query_params
 
 }
 
+TEST(IOTestAwsS3Client, InstanceProfileCredentialsProviderCaching)
+{
+    DB::S3::ClientFactory::instance();
+
+    Aws::Client::ClientConfiguration client_config;
+    client_config.connectTimeoutMs = 50;
+    client_config.requestTimeoutMs = 1000;
+
+    auto provider1 = DB::S3::AWSInstanceProfileCredentialsProvider::create(client_config, /*use_secure_pull=*/true);
+    ASSERT_TRUE(provider1);
+
+    auto provider2 = DB::S3::AWSInstanceProfileCredentialsProvider::create(client_config, /*use_secure_pull=*/true);
+    ASSERT_TRUE(provider2);
+    EXPECT_EQ(provider1.get(), provider2.get());
+
+    auto provider3 = DB::S3::AWSInstanceProfileCredentialsProvider::create(client_config, /*use_secure_pull=*/false);
+    ASSERT_TRUE(provider3);
+    EXPECT_NE(provider1.get(), provider3.get());
+
+    auto provider4 = DB::S3::AWSInstanceProfileCredentialsProvider::create(client_config, /*use_secure_pull=*/false);
+    ASSERT_TRUE(provider4);
+    EXPECT_EQ(provider3.get(), provider4.get());
+}
+
 TEST(IOTestAwsS3Client, AssumeRole)
 {
     const auto get_credential_string =  [&](const Poco::Net::MessageHeader & headers) -> std::string

--- a/tests/integration/test_s3_imds/test_simple.py
+++ b/tests/integration/test_s3_imds/test_simple.py
@@ -47,7 +47,7 @@ def start_cluster():
 
 def test_credentials_from_metadata():
     node.query(
-        f"INSERT INTO FUNCTION s3('http://{cluster.minio_host}:{cluster.minio_port}/{cluster.minio_bucket}/test1.jsonl') SELECT * FROM numbers(100)"
+        f"INSERT INTO FUNCTION s3('http://{cluster.minio_host}:{cluster.minio_port}/{cluster.minio_bucket}/test1.jsonl') SELECT * FROM numbers(100) SETTINGS s3_truncate_on_insert = 1"
     )
 
     assert (
@@ -74,7 +74,7 @@ def test_credentials_from_metadata():
 
 def test_credentials_provider_caching():
     node.query(
-        f"INSERT INTO FUNCTION s3('http://{cluster.minio_host}:{cluster.minio_port}/{cluster.minio_bucket}/test_caching.jsonl') SELECT * FROM numbers(10)"
+        f"INSERT INTO FUNCTION s3('http://{cluster.minio_host}:{cluster.minio_port}/{cluster.minio_bucket}/test_caching.jsonl') SELECT * FROM numbers(10) SETTINGS s3_truncate_on_insert = 1"
     )
 
     for _ in range(10):

--- a/tests/integration/test_s3_imds/test_simple.py
+++ b/tests/integration/test_s3_imds/test_simple.py
@@ -70,3 +70,37 @@ def test_credentials_from_metadata():
         assert node.contains_in_log(
             "AWSEC2InstanceProfileConfigLoader: " + expected_msg
         )
+
+
+def test_credentials_provider_caching():
+    node.query(
+        f"INSERT INTO FUNCTION s3('http://{cluster.minio_host}:{cluster.minio_port}/{cluster.minio_bucket}/test_caching.jsonl') SELECT * FROM numbers(10)"
+    )
+
+    for _ in range(10):
+        result = node.query(
+            f"SELECT count() FROM s3('http://{cluster.minio_host}:{cluster.minio_port}/{cluster.minio_bucket}/test_caching.jsonl')"
+        ).strip()
+        assert result == "10"
+
+    added = int(
+        node.query(
+            "SELECT value FROM system.events WHERE event = 'S3CachedCredentialsProvidersAdded'"
+        ).strip() or "0"
+    )
+    reused = int(
+        node.query(
+            "SELECT value FROM system.events WHERE event = 'S3CachedCredentialsProvidersReused'"
+        ).strip() or "0"
+    )
+
+    assert added > 0
+    assert reused > 0
+    assert reused >= added
+
+    current_cached = int(
+        node.query(
+            "SELECT value FROM system.metrics WHERE name = 'S3CachedCredentialsProviders'"
+        ).strip() or "0"
+    )
+    assert current_cached > 0


### PR DESCRIPTION
Fixes [issues](https://github.com/ClickHouse/ClickHouse/issues/72588) when running multiple requests to S3 concurrently, causing the metadata endpoint to start returning errors. This change uses the existing caching mechanism used by `AwsAuthSTSAssumeRoleWebIdentityCredentialsProvider` and `AwsAuthSTSAssumeRoleCredentialsProvider`.

### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix EC2 metadata endpoint throttling when running many concurrent S3 queries with EC2 instance profile credentials. Previously, each query created its own `AWSInstanceProfileCredentialsProvider`, causing concurrent requests to the EC2 metadata service which could result in timeouts and `HTTP response code: 403` errors. Now the credentials provider is cached and shared across all queries.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)