### PR TITLE
Fix logical error with multiple joins on constant condition and join_…

### DIFF
--- a/src/Processors/QueryPlan/JoinStepLogical.cpp
+++ b/src/Processors/QueryPlan/JoinStepLogical.cpp
@@ -137,7 +137,7 @@ static void addToNullableIfNeeded(
     if (outputs.empty())
     {
         auto column_type = std::make_shared<DataTypeUInt8>();
-        ColumnWithTypeAndName column(column_type->createColumnConst(1, 0), column_type, String(join_dummy_result_name));
+        ColumnWithTypeAndName column(column_type->createColumnConst(0, 0), column_type, String(join_dummy_result_name));
         const auto * node = &actions_dag->addColumn(std::move(column));
         actions_after_join.push_back(node);
         outputs.push_back(node);
@@ -361,7 +361,7 @@ IQueryPlanStep::RemovedUnusedColumns JoinStepLogical::removeUnusedColumns(NameMu
     if (required_nodes.empty())
     {
         auto column_type = std::make_shared<DataTypeUInt8>();
-        ColumnWithTypeAndName column(column_type->createColumnConst(1, 0), column_type, String(join_dummy_result_name));
+        ColumnWithTypeAndName column(column_type->createColumnConst(0, 0), column_type, String(join_dummy_result_name));
         const auto * node = &actions_dag.addColumn(std::move(column));
         new_actions_after_join.push_back(node);
         required_nodes.push_back(node);

--- a/tests/queries/0_stateless/03755_concurrent_hash_join_dispatch_bug.sql
+++ b/tests/queries/0_stateless/03755_concurrent_hash_join_dispatch_bug.sql
@@ -1,10 +1,15 @@
--- Test for concurrent hash join with ON FALSE or missing key columns see https://github.com/ClickHouse/ClickHouse/issues/91173
-
 DROP TABLE IF EXISTS t0;
 
 CREATE TABLE t0 (c0 Int) ENGINE = Memory;
-SELECT 1 FROM remote('localhost', currentDatabase(), t0) AS t0	
-JOIN t0 t1 ON FALSE	
-RIGHT JOIN t0 t2 ON FALSE;	
+
+SELECT 1 FROM remote('localhost', currentDatabase(), t0) AS t0
+JOIN t0 t1 ON FALSE
+RIGHT JOIN t0 t2 ON FALSE;
+
+SET join_use_nulls = 1;
+
+SELECT 1 FROM remote('localhost', currentDatabase(), t0) AS t0
+JOIN t0 t1 ON FALSE
+RIGHT JOIN t0 t2 ON FALSE;
 
 DROP TABLE t0;


### PR DESCRIPTION


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

- Fix logical error with multiple joins on constant condition and `join_use_nulls`, close https://github.com/ClickHouse/ClickHouse/issues/92640
