### PR TITLE
Deprecate `tryGetBlobsFromTransactionIfExists`

### DIFF
--- a/src/Disks/DiskObjectStorage/DiskObjectStorageTransaction.cpp
+++ b/src/Disks/DiskObjectStorage/DiskObjectStorageTransaction.cpp
@@ -176,20 +176,7 @@ struct RemoveObjectStorageOperation final : public IDiskObjectStorageOperation
     {
         if (!metadata_storage.existsFile(path))
         {
-            auto maybe_blobs = tx->tryGetBlobsFromTransactionIfExists(path);
-            if (maybe_blobs.has_value())
-            {
-                auto unlink_outcome = tx->unlinkMetadata(path);
-                if (unlink_outcome)
-                    objects_to_remove = ObjectsToRemove{std::move(*maybe_blobs), std::move(unlink_outcome)};
-
-                return;
-            }
-
-            if (if_exists)
-                return;
-
-            throw Exception(ErrorCodes::FILE_DOESNT_EXIST, "Metadata path '{}' doesn't exist or isn't a regular file", path);
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Metadata path '{}' doesn't exist or isn't a regular file", path);
         }
 
         try
@@ -267,23 +254,7 @@ struct RemoveManyObjectStorageOperation final : public IDiskObjectStorageOperati
         {
             if (!metadata_storage.existsFile(path))
             {
-                auto maybe_blobs = tx->tryGetBlobsFromTransactionIfExists(path);
-                if (maybe_blobs.has_value())
-                {
-                    auto unlink_outcome = tx->unlinkMetadata(path);
-                    if (unlink_outcome && !keep_all_batch_data && !file_names_remove_metadata_only.contains(fs::path(path).filename()))
-                    {
-                        objects_to_remove.emplace_back(ObjectsToRemove{std::move(*maybe_blobs), std::move(unlink_outcome)});
-                        paths_removed_with_objects.push_back(path);
-                    }
-
-                    continue;
-                }
-
-                if (if_exists)
-                    continue;
-
-                throw Exception(ErrorCodes::FILE_DOESNT_EXIST, "Metadata path '{}' doesn't exist or isn't a regular file", path);
+                throw Exception(ErrorCodes::LOGICAL_ERROR, "Metadata path '{}' doesn't exist or isn't a regular file", path);
             }
 
             try

--- a/src/Disks/DiskObjectStorage/DiskObjectStorageTransaction.cpp
+++ b/src/Disks/DiskObjectStorage/DiskObjectStorageTransaction.cpp
@@ -176,6 +176,9 @@ struct RemoveObjectStorageOperation final : public IDiskObjectStorageOperation
     {
         if (!metadata_storage.existsFile(path))
         {
+            if (if_exists)
+                return;
+
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Metadata path '{}' doesn't exist or isn't a regular file", path);
         }
 
@@ -254,6 +257,9 @@ struct RemoveManyObjectStorageOperation final : public IDiskObjectStorageOperati
         {
             if (!metadata_storage.existsFile(path))
             {
+                if (if_exists)
+                    continue;
+
                 throw Exception(ErrorCodes::LOGICAL_ERROR, "Metadata path '{}' doesn't exist or isn't a regular file", path);
             }
 

--- a/src/Disks/DiskObjectStorage/DiskObjectStorageTransaction.cpp
+++ b/src/Disks/DiskObjectStorage/DiskObjectStorageTransaction.cpp
@@ -42,7 +42,7 @@ namespace ErrorCodes
     extern const int ATTEMPT_TO_READ_AFTER_EOF;
     extern const int CANNOT_READ_ALL_DATA;
     extern const int CANNOT_OPEN_FILE;
-    extern const int FILE_DOESNT_EXIST;
+    extern const int LOGICAL_ERROR;
     extern const int CANNOT_PARSE_INPUT_ASSERTION_FAILED;
     extern const int NOT_IMPLEMENTED;
     extern const int FAULT_INJECTED;

--- a/src/Disks/DiskObjectStorage/MetadataStorages/IMetadataStorage.h
+++ b/src/Disks/DiskObjectStorage/MetadataStorages/IMetadataStorage.h
@@ -172,9 +172,6 @@ public:
         throwNotImplemented();
     }
 
-    /// Get objects that are going to be created inside transaction if they exists
-    virtual std::optional<StoredObjects> tryGetBlobsFromTransactionIfExists(const std::string &) const = 0;
-
     virtual ~IMetadataTransaction() = default;
 
 protected:

--- a/src/Disks/DiskObjectStorage/MetadataStorages/Local/MetadataStorageFromDisk.cpp
+++ b/src/Disks/DiskObjectStorage/MetadataStorages/Local/MetadataStorageFromDisk.cpp
@@ -262,14 +262,6 @@ TruncateFileOperationOutcomePtr MetadataStorageFromDiskTransaction::truncateFile
     return outcome;
 }
 
-std::optional<StoredObjects> MetadataStorageFromDiskTransaction::tryGetBlobsFromTransactionIfExists(const std::string & path) const
-{
-    if (metadata_storage.existsFileOrDirectory(path))
-        return metadata_storage.getStorageObjects(path);
-
-    return std::nullopt;
-}
-
 ObjectStorageKey MetadataStorageFromDiskTransaction::generateObjectKeyForPath(const std::string & /*path*/)
 {
     return metadata_storage.key_generator->generate();

--- a/src/Disks/DiskObjectStorage/MetadataStorages/Local/MetadataStorageFromDisk.h
+++ b/src/Disks/DiskObjectStorage/MetadataStorages/Local/MetadataStorageFromDisk.h
@@ -138,8 +138,6 @@ public:
 
     TruncateFileOperationOutcomePtr truncateFile(const std::string & src_path, size_t target_size) override;
 
-    std::optional<StoredObjects> tryGetBlobsFromTransactionIfExists(const std::string & path) const override;
-
     ObjectStorageKey generateObjectKeyForPath(const std::string & path) override;
 };
 

--- a/src/Disks/DiskObjectStorage/MetadataStorages/Plain/MetadataStorageFromPlainObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/MetadataStorages/Plain/MetadataStorageFromPlainObjectStorage.cpp
@@ -198,11 +198,6 @@ const IMetadataStorage & MetadataStorageFromPlainObjectStorageTransaction::getSt
     return metadata_storage;
 }
 
-std::optional<StoredObjects> MetadataStorageFromPlainObjectStorageTransaction::tryGetBlobsFromTransactionIfExists(const std::string & path) const
-{
-    return metadata_storage.getStorageObjectsIfExist(path);
-}
-
 void MetadataStorageFromPlainObjectStorageTransaction::unlinkFile(const std::string & path)
 {
     if (metadata_storage.object_metadata_cache)

--- a/src/Disks/DiskObjectStorage/MetadataStorages/Plain/MetadataStorageFromPlainObjectStorage.h
+++ b/src/Disks/DiskObjectStorage/MetadataStorages/Plain/MetadataStorageFromPlainObjectStorage.h
@@ -84,7 +84,6 @@ public:
     explicit MetadataStorageFromPlainObjectStorageTransaction(MetadataStorageFromPlainObjectStorage & metadata_storage_, ObjectStoragePtr object_storage_);
 
     const IMetadataStorage & getStorageForNonTransactionalReads() const override;
-    std::optional<StoredObjects> tryGetBlobsFromTransactionIfExists(const std::string & path) const override;
 
     void createMetadataFile(const std::string & /*path*/, const StoredObjects & /* objects */) override {}
     void createDirectory(const std::string & /*path*/) override {}

--- a/src/Disks/DiskObjectStorage/MetadataStorages/PlainRewritable/MetadataStorageFromPlainRewritableObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/MetadataStorages/PlainRewritable/MetadataStorageFromPlainRewritableObjectStorage.cpp
@@ -536,11 +536,6 @@ const IMetadataStorage & MetadataStorageFromPlainRewritableObjectStorageTransact
     return metadata_storage;
 }
 
-std::optional<StoredObjects> MetadataStorageFromPlainRewritableObjectStorageTransaction::tryGetBlobsFromTransactionIfExists(const std::string & path) const
-{
-    return metadata_storage.getStorageObjectsIfExist(path);
-}
-
 ObjectStorageKey MetadataStorageFromPlainRewritableObjectStorageTransaction::generateObjectKeyForPath(const std::string & path)
 {
     const auto normalized_path = normalizePath(path);

--- a/src/Disks/DiskObjectStorage/MetadataStorages/PlainRewritable/MetadataStorageFromPlainRewritableObjectStorage.h
+++ b/src/Disks/DiskObjectStorage/MetadataStorages/PlainRewritable/MetadataStorageFromPlainRewritableObjectStorage.h
@@ -123,7 +123,6 @@ public:
     void replaceFile(const std::string & path_from, const std::string & path_to) override;
 
     const IMetadataStorage & getStorageForNonTransactionalReads() const override;
-    std::optional<StoredObjects> tryGetBlobsFromTransactionIfExists(const std::string & path) const override;
 
     ObjectStorageKey generateObjectKeyForPath(const std::string & path) override;
 };

--- a/src/Disks/MetadataStorageWithPathWrapper.h
+++ b/src/Disks/MetadataStorageWithPathWrapper.h
@@ -137,11 +137,6 @@ public:
         return delegate->truncateFile(wrappedPath(src_path), size);
     }
 
-    std::optional<StoredObjects> tryGetBlobsFromTransactionIfExists(const std::string & path) const override
-    {
-        return delegate->tryGetBlobsFromTransactionIfExists(path);
-    }
-
     ObjectStorageKey generateObjectKeyForPath(const std::string & path) override { return delegate->generateObjectKeyForPath(path); }
 };
 

--- a/src/Disks/tests/gtest_metadata_plain_rewritable_disk.cpp
+++ b/src/Disks/tests/gtest_metadata_plain_rewritable_disk.cpp
@@ -1064,30 +1064,6 @@ TEST_F(MetadataPlainRewritableDiskTest, LookupBlobs)
         tx->createDirectoryRecursive("A/B/C");
         tx->commit();
     }
-
-    {
-        auto tx = metadata->createTransaction();
-        EXPECT_EQ(tx->tryGetBlobsFromTransactionIfExists("non-existing"), std::nullopt);
-        tx->commit();
-    }
-
-    {
-        auto tx = metadata->createTransaction();
-        EXPECT_EQ(tx->tryGetBlobsFromTransactionIfExists("non-existing/A"), std::nullopt);
-        tx->commit();
-    }
-
-    {
-        auto tx = metadata->createTransaction();
-        EXPECT_EQ(tx->tryGetBlobsFromTransactionIfExists("A/B"), std::nullopt);
-        tx->commit();
-    }
-
-    {
-        auto tx = metadata->createTransaction();
-        EXPECT_EQ(tx->tryGetBlobsFromTransactionIfExists("A/X"), std::nullopt);
-        tx->commit();
-    }
 }
 
 TEST_F(MetadataPlainRewritableDiskTest, OperationsNonExisting)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
