### PR TITLE
Explicitly mark unsupported cases in aggregation and support read in order for AutoPR

### DIFF
--- a/src/Processors/QueryPlan/AggregatingStep.cpp
+++ b/src/Processors/QueryPlan/AggregatingStep.cpp
@@ -345,7 +345,8 @@ void AggregatingStep::transformPipeline(QueryPipelineBuilder & pipeline, const B
                 }
                 else
                 {
-                    auto aggregation_for_set = std::make_shared<AggregatingTransform>(input_header, transform_params_for_set);
+                    auto aggregation_for_set
+                        = std::make_shared<AggregatingTransform>(input_header, transform_params_for_set, dataflow_cache_updater);
                     connect(*ports[i], aggregation_for_set->getInputs().front());
                     ports[i] = &aggregation_for_set->getOutputs().front();
                     processors.push_back(aggregation_for_set);
@@ -523,7 +524,8 @@ void AggregatingStep::transformPipeline(QueryPipelineBuilder & pipeline, const B
     }
     else
     {
-        pipeline.addSimpleTransform([&](const SharedHeader & header) { return std::make_shared<AggregatingTransform>(header, transform_params); });
+        pipeline.addSimpleTransform([&](const SharedHeader & header)
+                                    { return std::make_shared<AggregatingTransform>(header, transform_params, dataflow_cache_updater); });
 
         pipeline.resize(should_produce_results_in_order_of_bucket_number ? 1 : params.max_threads);
 

--- a/src/Processors/QueryPlan/AggregatingStep.h
+++ b/src/Processors/QueryPlan/AggregatingStep.h
@@ -106,7 +106,6 @@ public:
 
     bool supportsDataflowStatisticsCollection() const override
     {
-        // TODO(nickitat): support aggregation in order?
         return sort_description_for_merging.empty() && grouping_sets_params.empty();
     }
 

--- a/src/Processors/QueryPlan/IQueryPlanStep.h
+++ b/src/Processors/QueryPlan/IQueryPlanStep.h
@@ -122,6 +122,7 @@ public:
     virtual bool hasCorrelatedExpressions() const;
 
     virtual bool supportsDataflowStatisticsCollection() const { return false; }
+
     void setRuntimeDataflowStatisticsCacheUpdater(RuntimeDataflowStatisticsCacheUpdaterPtr updater)
     {
         dataflow_cache_updater = std::move(updater);

--- a/src/Processors/QueryPlan/Optimizations/RuntimeDataflowStatistics.cpp
+++ b/src/Processors/QueryPlan/Optimizations/RuntimeDataflowStatistics.cpp
@@ -158,7 +158,7 @@ void RuntimeDataflowStatisticsCacheUpdater::recordAggregationStateSizes(Aggregat
         && std::ranges::any_of(
             variant.aggregator->getParams().aggregates, [](auto agg_func) { return !agg_func.function->hasTrivialDestructor(); }))
     {
-        unsupported_case.store(true, std::memory_order_relaxed);
+        markUnsupportedCase();
         return;
     }
 

--- a/src/Processors/QueryPlan/Optimizations/RuntimeDataflowStatistics.h
+++ b/src/Processors/QueryPlan/Optimizations/RuntimeDataflowStatistics.h
@@ -81,6 +81,8 @@ public:
 
     void recordInputColumns(const ColumnsWithTypeAndName & columns, const ColumnSizeByName & column_sizes, size_t read_bytes = 0);
 
+    void markUnsupportedCase() { unsupported_case.store(true, std::memory_order_relaxed); }
+
 private:
     std::optional<size_t> cache_key;
 

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -671,7 +671,7 @@ Pipe ReadFromMergeTree::readInOrder(
             pool_settings,
             block_size,
             context,
-            nullptr);
+            dataflow_cache_updater);
     }
 
     /// If parallel replicas enabled, set total rows in progress here only on initiator with local plan

--- a/src/Processors/QueryPlan/ReadFromMergeTree.h
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.h
@@ -352,7 +352,7 @@ public:
     void clearParallelReadingExtension();
     std::shared_ptr<ParallelReadingExtension> getParallelReadingExtension();
 
-    bool supportsDataflowStatisticsCollection() const override { return true; }
+    bool supportsDataflowStatisticsCollection() const override { return !isQueryWithFinal(); }
 
     /// Adds virtual columns for reading from text index.
     /// Removes physical text columns that were eliminated by direct read from text index.

--- a/src/Processors/Transforms/AggregatingTransform.h
+++ b/src/Processors/Transforms/AggregatingTransform.h
@@ -146,7 +146,7 @@ using ManyAggregatedDataPtr = std::shared_ptr<ManyAggregatedData>;
 class AggregatingTransform final : public IProcessor
 {
 public:
-    AggregatingTransform(SharedHeader header, AggregatingTransformParamsPtr params_);
+    AggregatingTransform(SharedHeader header, AggregatingTransformParamsPtr params_, RuntimeDataflowStatisticsCacheUpdaterPtr updater_);
 
     /// For Parallel aggregating.
     AggregatingTransform(
@@ -193,7 +193,8 @@ private:
     size_t max_threads = 1;
     size_t temporary_data_merge_threads = 1;
     bool should_produce_results_in_order_of_bucket_number = true;
-    bool skip_merging = false; /// If we aggregate partitioned data merging is not needed.
+    /// If we aggregate partitioned data merging is not needed.
+    bool skip_merging = false;
 
     /// TODO: calculate time only for aggregation.
     Stopwatch watch;

--- a/tests/queries/0_stateless/03634_autopr_output_bytes_estimation.sql
+++ b/tests/queries/0_stateless/03634_autopr_output_bytes_estimation.sql
@@ -1,11 +1,10 @@
 -- Tags: stateful, long
 
-SET optimize_read_in_order=0, query_plan_read_in_order=0, local_filesystem_read_prefetch=0, merge_tree_read_split_ranges_into_intersecting_and_non_intersecting_injection_probability=0, local_filesystem_read_method='pread_threadpool', use_uncompressed_cache=0;
-
 SET enable_parallel_replicas=0, automatic_parallel_replicas_mode=2, parallel_replicas_local_plan=1, parallel_replicas_index_analysis_only_on_coordinator=1,
     parallel_replicas_for_non_replicated_merge_tree=1, max_parallel_replicas=3, cluster_for_parallel_replicas='parallel_replicas';
 
-SET max_threads=8, use_hedged_requests=0, max_bytes_before_external_group_by=0, max_bytes_ratio_before_external_group_by=0;
+-- External aggregation is not supported as of now
+SET max_bytes_before_external_group_by=0, max_bytes_ratio_before_external_group_by=0;
 
 SELECT COUNT(*) FROM test.hits WHERE AdvEngineID <> 0 FORMAT Null SETTINGS log_comment='query_1';
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Related: #87680
