### PR TITLE
Implement mergeTreeAnalyzeIndex() function

### DIFF
--- a/src/Planner/CollectSets.cpp
+++ b/src/Planner/CollectSets.cpp
@@ -2,6 +2,7 @@
 
 #include <Storages/StorageSet.h>
 
+#include <Analyzer/TableFunctionNode.h>
 #include <Analyzer/ConstantNode.h>
 #include <Analyzer/FunctionNode.h>
 #include <Analyzer/InDepthQueryTreeVisitor.h>
@@ -13,6 +14,9 @@
 #include <Interpreters/Set.h>
 #include <Planner/Planner.h>
 #include <Planner/PlannerContext.h>
+#include <TableFunctions/TableFunctionFactory.h>
+
+#include <unordered_set>
 
 
 namespace DB
@@ -40,6 +44,29 @@ public:
 
     void visitImpl(const QueryTreeNodePtr & node)
     {
+        if (const auto * table_node = node->as<TableFunctionNode>())
+        {
+            const auto & table_function_name = table_node->getTableFunctionName();
+            const auto & context = planner_context.getQueryContext();
+            TableFunctionPtr table_function_ptr = TableFunctionFactory::instance().tryGet(table_function_name, context);
+            auto skip_analysis_arguments_indexes = table_function_ptr->skipAnalysisForArguments(node, context);
+
+            const auto & table_function_arguments = table_node->getArguments().getNodes();
+            size_t table_function_arguments_size = table_function_arguments.size();
+
+            for (size_t table_function_argument_index = 0; table_function_argument_index < table_function_arguments_size; ++table_function_argument_index)
+            {
+                const auto & table_function_argument = table_function_arguments[table_function_argument_index];
+
+                auto skip_argument_index_it = std::find(skip_analysis_arguments_indexes.begin(), skip_analysis_arguments_indexes.end(), table_function_argument_index);
+                if (skip_argument_index_it != skip_analysis_arguments_indexes.end())
+                {
+                    skip_children.insert(table_function_argument);
+                    continue;
+                }
+            }
+        }
+
         if (const auto * constant_node = node->as<ConstantNode>())
             /// Collect sets from source expression as well.
             /// Most likely we will not build them, but those sets could be requested during analysis.
@@ -118,14 +145,21 @@ public:
         }
     }
 
-    static bool needChildVisit(const QueryTreeNodePtr &, const QueryTreeNodePtr & child_node)
+    bool needChildVisit(const QueryTreeNodePtr &, const QueryTreeNodePtr & child_node)
     {
+        if (skip_children.contains(child_node))
+        {
+            skip_children.erase(child_node);
+            return false;
+        }
+
         auto child_node_type = child_node->getNodeType();
         return !(child_node_type == QueryTreeNodeType::QUERY || child_node_type == QueryTreeNodeType::UNION);
     }
 
 private:
     PlannerContext & planner_context;
+    std::unordered_set<QueryTreeNodePtr> skip_children;
 };
 
 }

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -1820,15 +1820,15 @@ ReadFromMergeTree::AnalysisResultPtr ReadFromMergeTree::selectRangesToRead(bool 
     return analyzed_result_ptr;
 }
 
-static void buildIndexes(
+void ReadFromMergeTree::buildIndexes(
     std::optional<ReadFromMergeTree::Indexes> & indexes,
-    const ActionsDAG * filter_actions_dag,
+    const ActionsDAG * filter_actions_dag_,
     const MergeTreeData & data,
     const RangesInDataParts & parts,
     [[maybe_unused]] const std::optional<VectorSearchParameters> & vector_search_parameters,
     [[maybe_unused]] const std::optional<TopKFilterInfo> top_k_filter_info,
-    const ContextPtr & context,
-    const SelectQueryInfo & query_info,
+    const ContextPtr & query_context,
+    const SelectQueryInfo & query_info_,
     const StorageMetadataPtr & metadata_snapshot)
 {
     indexes.reset();
@@ -1837,38 +1837,38 @@ static void buildIndexes(
     const auto & primary_key = metadata_snapshot->getPrimaryKey();
     const Names & primary_key_column_names = primary_key.column_names;
 
-    const auto & settings = context->getSettingsRef();
+    const auto & settings = query_context->getSettingsRef();
 
-    ActionsDAGWithInversionPushDown filter_dag((filter_actions_dag ? filter_actions_dag->getOutputs().front() : nullptr), context);
+    ActionsDAGWithInversionPushDown filter_dag((filter_actions_dag_ ? filter_actions_dag_->getOutputs().front() : nullptr), query_context);
 
     indexes.emplace(
-        ReadFromMergeTree::Indexes{KeyCondition{filter_dag, context, primary_key_column_names, primary_key.expression}});
+        ReadFromMergeTree::Indexes{KeyCondition{filter_dag, query_context, primary_key_column_names, primary_key.expression}});
 
     NamesAndTypesList dummy_names_and_types;
-    indexes->key_condition_rpn_template = KeyCondition{filter_dag, context, {}, std::make_shared<ExpressionActions>(ActionsDAG(dummy_names_and_types))};
+    indexes->key_condition_rpn_template = KeyCondition{filter_dag, query_context, {}, std::make_shared<ExpressionActions>(ActionsDAG(dummy_names_and_types))};
 
     if (metadata_snapshot->hasPartitionKey())
     {
         const auto & partition_key = metadata_snapshot->getPartitionKey();
         auto minmax_columns_names = MergeTreeData::getMinMaxColumnsNames(partition_key);
-        auto minmax_expression_actions = MergeTreeData::getMinMaxExpr(partition_key, ExpressionActionsSettings(context));
+        auto minmax_expression_actions = MergeTreeData::getMinMaxExpr(partition_key, ExpressionActionsSettings(query_context));
 
-        indexes->minmax_idx_condition.emplace(filter_dag, context, minmax_columns_names, minmax_expression_actions);
-        indexes->partition_pruner.emplace(metadata_snapshot, filter_dag, context, false /* strict */);
+        indexes->minmax_idx_condition.emplace(filter_dag, query_context, minmax_columns_names, minmax_expression_actions);
+        indexes->partition_pruner.emplace(metadata_snapshot, filter_dag, query_context, false /* strict */);
     }
 
     indexes->part_values
-        = MergeTreeDataSelectExecutor::filterPartsByVirtualColumns(metadata_snapshot, data, parts, filter_dag.predicate, context);
+        = MergeTreeDataSelectExecutor::filterPartsByVirtualColumns(metadata_snapshot, data, parts, filter_dag.predicate, query_context);
 
     /// Perform virtual column key analysis only when no corresponding physical columns exist.
     const auto & columns = metadata_snapshot->getColumns();
     if (!columns.has("_part_offset") && !columns.has("_part"))
-        MergeTreeDataSelectExecutor::buildKeyConditionFromPartOffset(indexes->part_offset_condition, filter_dag.predicate, context);
+        MergeTreeDataSelectExecutor::buildKeyConditionFromPartOffset(indexes->part_offset_condition, filter_dag.predicate, query_context);
     if (!columns.has("_part_offset") && !columns.has("_part_starting_offset"))
-        MergeTreeDataSelectExecutor::buildKeyConditionFromTotalOffset(indexes->total_offset_condition, filter_dag.predicate, context);
+        MergeTreeDataSelectExecutor::buildKeyConditionFromTotalOffset(indexes->total_offset_condition, filter_dag.predicate, query_context);
 
     indexes->use_skip_indexes = settings[Setting::use_skip_indexes];
-    if (query_info.isFinal() && !settings[Setting::use_skip_indexes_if_final])
+    if (query_info_.isFinal() && !settings[Setting::use_skip_indexes_if_final])
         indexes->use_skip_indexes = false;
 
     if (!indexes->use_skip_indexes)
@@ -1905,7 +1905,7 @@ static void buildIndexes(
             if (inserted)
             {
                 skip_indexes.merged_indices.emplace_back();
-                skip_indexes.merged_indices.back().condition = index_helper->createIndexMergedCondition(query_info, metadata_snapshot);
+                skip_indexes.merged_indices.back().condition = index_helper->createIndexMergedCondition(query_info_, metadata_snapshot);
             }
 
             skip_indexes.merged_indices[it->second].addIndex(index_helper);
@@ -1917,7 +1917,7 @@ static void buildIndexes(
         {
 #if USE_USEARCH
             if (const auto * vector_similarity_index = typeid_cast<const MergeTreeIndexVectorSimilarity *>(index_helper.get()))
-                condition = vector_similarity_index->createIndexCondition(filter_dag.predicate, context, vector_search_parameters);
+                condition = vector_similarity_index->createIndexCondition(filter_dag.predicate, query_context, vector_search_parameters);
 #endif
             if (!condition)
                 throw Exception(ErrorCodes::LOGICAL_ERROR, "Unknown vector search index {}", index_helper->index.name);
@@ -1925,7 +1925,7 @@ static void buildIndexes(
         else
         {
             if (filter_dag.predicate)
-                condition = index_helper->createIndexCondition(filter_dag.predicate, context);
+                condition = index_helper->createIndexCondition(filter_dag.predicate, query_context);
         }
 
         if (condition && !condition->alwaysUnknownOrTrue())

--- a/src/Processors/QueryPlan/ReadFromMergeTree.h
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.h
@@ -361,6 +361,17 @@ public:
     const std::optional<Indexes> & getIndexes() const { return indexes; }
     ConditionSelectivityEstimatorPtr getConditionSelectivityEstimator() const;
 
+    static void buildIndexes(
+        std::optional<ReadFromMergeTree::Indexes> & indexes,
+        const ActionsDAG * filter_actions_dag_,
+        const MergeTreeData & data,
+        const RangesInDataParts & parts,
+        [[maybe_unused]] const std::optional<VectorSearchParameters> & vector_search_parameters,
+        [[maybe_unused]] std::optional<TopKFilterInfo> top_k_filter_info,
+        const ContextPtr & query_context,
+        const SelectQueryInfo & query_info_,
+        const StorageMetadataPtr & metadata_snapshot);
+
     void setTopKColumn(const TopKFilterInfo & top_k_filter_info_);
     bool isSkipIndexAvailableForTopK(const String & sort_column) const;
     const ProjectionIndexReadDescription & getProjectionIndexReadDescription() const { return projection_index_read_desc; }

--- a/src/Storages/StorageMergeTreeAnalyzeIndexes.cpp
+++ b/src/Storages/StorageMergeTreeAnalyzeIndexes.cpp
@@ -1,0 +1,298 @@
+#include <unordered_set>
+#include <Core/Field.h>
+#include <Interpreters/ExpressionAnalyzer.h>
+#include <Processors/QueryPlan/ReadFromMergeTree.h>
+#include <Storages/MergeTree/MergeTreeDataSelectExecutor.h>
+#include <Storages/StorageInMemoryMetadata.h>
+#include <Storages/StorageMergeTreeAnalyzeIndexes.h>
+#include <Parsers/ASTSelectQuery.h>
+#include <Storages/ColumnsDescription.h>
+#include <Storages/MergeTree/LoadedMergeTreeDataPartInfoForReader.h>
+#include <Storages/MergeTree/MergeTreeDataPartCompact.h>
+#include <Storages/MergeTree/MergeTreeMarksLoader.h>
+#include <Access/Common/AccessFlags.h>
+#include <Interpreters/ExpressionActions.h>
+#include <Processors/QueryPlan/QueryPlan.h>
+#include <Processors/QueryPlan/SourceStepWithFilter.h>
+#include <Processors/ISource.h>
+#include <QueryPipeline/QueryPipelineBuilder.h>
+#include <Interpreters/Context.h>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int BAD_ARGUMENTS;
+    extern const int LOGICAL_ERROR;
+}
+
+///
+/// MergeTreeAnalyzeIndexSource
+///
+class MergeTreeAnalyzeIndexSource : public ISource, WithContext
+{
+public:
+    MergeTreeAnalyzeIndexSource(
+        SharedHeader header_,
+        const StoragePtr & storage_,
+        const SelectQueryInfo & query_info_,
+        size_t num_streams_,
+        MergeTreeData::DataPartsVector data_parts_,
+        MergeTreeSettingsPtr table_settings_,
+        const ASTPtr & predicate_,
+        ContextPtr context_)
+        : ISource(header_)
+        , WithContext(context_)
+        , header(std::move(header_))
+        , storage(storage_)
+        , query_info(query_info_)
+        , num_streams(num_streams_)
+        , predicate(predicate_)
+        , data_parts(std::move(data_parts_))
+        , table_settings(std::move(table_settings_))
+    {
+    }
+
+    String getName() const override { return "MergeTreeAnalyzeIndexes"; }
+
+protected:
+    Chunk generate() override
+    {
+        if (std::exchange(analyzed, true))
+            return {};
+
+        auto ranges = getIndexAnalysis();
+        MutableColumns res_columns = header->cloneEmptyColumns();
+
+        std::unordered_set<std::string> processed_parts;
+
+        for (const auto & ranges_in_part : ranges)
+        {
+            size_t i = 0;
+            res_columns[i++]->insert(ranges_in_part.data_part->name);
+
+            /// ranges
+            {
+                Array field;
+                for (const auto & range : ranges_in_part.ranges)
+                    field.push_back(Tuple{range.begin, range.end});
+                res_columns[i++]->insert(std::move(field));
+            }
+
+            processed_parts.insert(ranges_in_part.data_part->name);
+        }
+
+        /// Add existing parts, but filtered out into the result.
+        for (const auto & part : data_parts)
+        {
+            if (processed_parts.contains(part->name))
+                continue;
+
+            size_t i = 0;
+            res_columns[i++]->insert(part->name);
+            res_columns[i++]->insertDefault();
+        }
+
+        size_t rows = res_columns.front()->size();
+        return Chunk(std::move(res_columns), rows);
+    }
+
+    RangesInDataParts getIndexAnalysis()
+    {
+        const auto & context = getContext();
+
+        auto reader_settings = MergeTreeReaderSettings::createForQuery(context, *table_settings, query_info);
+
+        StorageMetadataPtr metadata_snapshot = storage->getInMemoryMetadataPtr();
+        const auto * merge_tree_data = dynamic_cast<const MergeTreeData *>(storage.get());
+        if (!merge_tree_data)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Storage MergeTreeAnalyzeIndexes expected MergeTree table, got: {}", storage->getName());
+
+        std::optional<ActionsDAG> filter_dag;
+        if (predicate)
+        {
+            /// FIXME:
+            /// - use analyzer
+            /// - use primary_key->getSampleBlock().getNamesAndTypesList() over metadata_snapshot->getSampleBlock().getNamesAndTypesList()
+            TreeRewriterResultPtr syntax_analyzer_result = TreeRewriter(context).analyze(predicate, metadata_snapshot->getSampleBlock().getNamesAndTypesList());
+            ExpressionAnalyzer analyzer(predicate, syntax_analyzer_result, context);
+            /// FIXME: add_aliases is true to avoid adding source columns as outputs
+            filter_dag.emplace(analyzer.getActionsDAG(/*add_aliases=*/ true));
+            if (filter_dag->getOutputs().size() != 1)
+                throw Exception(ErrorCodes::LOGICAL_ERROR, "ActionsDAG contains more than 1 output for expression: {}", predicate->formatForLogging());
+        }
+
+        const auto & parts_ranges = RangesInDataParts{data_parts};
+
+        const StorageSnapshotPtr storage_snapshot = storage->getStorageSnapshot(metadata_snapshot, context);
+        const auto & snapshot_data = assert_cast<const MergeTreeData::SnapshotData &>(*storage_snapshot->data);
+
+        std::optional<ReadFromMergeTree::Indexes> indexes;
+        ReadFromMergeTree::buildIndexes(
+            indexes,
+            filter_dag ? &filter_dag.value() : nullptr,
+            *merge_tree_data,
+            parts_ranges,
+            /*vector_search_parameters=*/ std::nullopt,
+            /*top_k_filter_info=*/ std::nullopt,
+            context,
+            query_info,
+            metadata_snapshot);
+
+        ContextMutablePtr new_context = Context::createCopy(context);
+        new_context->setSetting("use_skip_indexes_on_data_read", false);
+
+        /// TODO: we may also want to support query condition cache here as well
+
+        ReadFromMergeTree::AnalysisResult analysis_result;
+        return MergeTreeDataSelectExecutor::filterPartsByPrimaryKeyAndSkipIndexes(
+            parts_ranges,
+            metadata_snapshot,
+            snapshot_data.mutations_snapshot,
+            query_info,
+            new_context,
+            indexes->key_condition,
+            indexes->part_offset_condition,
+            indexes->total_offset_condition,
+            indexes->key_condition_rpn_template,
+            indexes->skip_indexes,
+            /* top_k_filter_info= */ std::nullopt,
+            reader_settings,
+            getLogger("MergeTreeAnalyzeIndexSource"),
+            num_streams,
+            analysis_result.index_stats,
+            indexes->use_skip_indexes,
+            indexes->use_skip_indexes_for_disjunctions,
+            /* find_exact_ranges= */ false,
+            /* is_final_query= */ false,
+            /* is_parallel_reading_from_replicas= */ false,
+            analysis_result);
+    }
+
+private:
+    SharedHeader header;
+    const StoragePtr storage;
+    SelectQueryInfo query_info;
+    size_t num_streams;
+    ASTPtr predicate;
+    MergeTreeData::DataPartsVector data_parts;
+    MergeTreeSettingsPtr table_settings;
+
+    bool analyzed = false;
+};
+
+///
+/// ReadFromMergeTreeAnalyzeIndex
+///
+class ReadFromMergeTreeAnalyzeIndexes : public SourceStepWithFilter
+{
+public:
+    std::string getName() const override { return "ReadFromMergeTreeAnalyzeIndexes"; }
+    void initializePipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings &) override;
+
+    ReadFromMergeTreeAnalyzeIndexes(
+        const Names & column_names_,
+        const SelectQueryInfo & query_info_,
+        size_t num_streams_,
+        const StorageSnapshotPtr & storage_snapshot_,
+        const ContextPtr & context_,
+        SharedHeader sample_block,
+        std::shared_ptr<StorageMergeTreeAnalyzeIndexes> storage_)
+        : SourceStepWithFilter(
+            std::move(sample_block),
+            column_names_,
+            query_info_,
+            storage_snapshot_,
+            context_)
+        , storage(std::move(storage_))
+        , num_streams(num_streams_)
+        , log(&Poco::Logger::get("StorageMergeTreeAnalyzeIndexes"))
+    {
+    }
+
+private:
+    std::shared_ptr<StorageMergeTreeAnalyzeIndexes> storage;
+    const size_t num_streams;
+    Poco::Logger * log;
+};
+
+void ReadFromMergeTreeAnalyzeIndexes::initializePipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings &)
+{
+    LOG_DEBUG(log, "Analyzing index from {} parts of table {}",
+        storage->data_parts.size(),
+        storage->source_table->getStorageID().getNameForLogs());
+
+    pipeline.init(Pipe(std::make_shared<MergeTreeAnalyzeIndexSource>(
+        getOutputHeader(),
+        storage->source_table,
+        getQueryInfo(),
+        num_streams,
+        storage->data_parts,
+        storage->table_settings,
+        storage->predicate,
+        context)));
+}
+
+
+///
+/// StorageMergeTreeAnalyzeIndex
+///
+StorageMergeTreeAnalyzeIndexes::StorageMergeTreeAnalyzeIndexes(
+    const StorageID & table_id_,
+    const StoragePtr & source_table_,
+    const ColumnsDescription & columns,
+    const String & parts_regexp_,
+    const ASTPtr & predicate_)
+    : IStorage(table_id_)
+    , source_table(source_table_)
+    , predicate(predicate_)
+{
+    const auto * merge_tree_data = dynamic_cast<const MergeTreeData *>(source_table.get());
+    if (!merge_tree_data)
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Storage MergeTreeAnalyzeIndexes expected MergeTree table, got: {}", source_table->getName());
+
+    data_parts = merge_tree_data->getDataPartsVectorForInternalUsage();
+    std::erase_if(data_parts, [](const MergeTreeData::DataPartPtr & part) { return part->isEmpty(); });
+    if (!parts_regexp_.empty())
+    {
+        OptimizedRegularExpression regexp(parts_regexp_);
+        std::erase_if(data_parts, [&](const MergeTreeData::DataPartPtr & part) { return !regexp.match(part->name); });
+    }
+
+    table_settings = merge_tree_data->getSettings();
+
+    StorageInMemoryMetadata storage_metadata;
+    storage_metadata.setColumns(columns);
+    setInMemoryMetadata(storage_metadata);
+}
+
+void StorageMergeTreeAnalyzeIndexes::read(
+    QueryPlan & query_plan,
+    const Names & column_names,
+    const StorageSnapshotPtr & storage_snapshot,
+    SelectQueryInfo & query_info,
+    ContextPtr context,
+    QueryProcessingStage::Enum,
+    size_t /*max_block_size*/,
+    size_t num_streams)
+{
+    context->checkAccess(AccessType::SELECT, source_table->getStorageID());
+
+    auto sample_block = std::make_shared<const Block>(storage_snapshot->getSampleBlockForColumns(column_names));
+    auto this_ptr = std::static_pointer_cast<StorageMergeTreeAnalyzeIndexes>(shared_from_this());
+
+    auto reading = std::make_unique<ReadFromMergeTreeAnalyzeIndexes>(
+        column_names,
+        query_info,
+        num_streams,
+        storage_snapshot,
+        std::move(context),
+        std::move(sample_block),
+        std::move(this_ptr));
+
+    query_plan.addStep(std::move(reading));
+}
+
+
+}

--- a/src/Storages/StorageMergeTreeAnalyzeIndexes.cpp
+++ b/src/Storages/StorageMergeTreeAnalyzeIndexes.cpp
@@ -33,7 +33,6 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;
-    extern const int LOGICAL_ERROR;
 }
 
 ///

--- a/src/Storages/StorageMergeTreeAnalyzeIndexes.h
+++ b/src/Storages/StorageMergeTreeAnalyzeIndexes.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <Storages/MergeTree/MergeTreeData.h>
+
+namespace DB
+{
+
+/// Internal temporary storage for table function mergeTreeAnalyzeIndexes(...)
+class StorageMergeTreeAnalyzeIndexes final : public IStorage
+{
+public:
+    StorageMergeTreeAnalyzeIndexes(
+        const StorageID & table_id_,
+        const StoragePtr & source_table_,
+        const ColumnsDescription & columns,
+        const String & parts_regexp_,
+        const ASTPtr & primary_key_predicate_);
+
+    void read(
+        QueryPlan & query_plan,
+        const Names & column_names,
+        const StorageSnapshotPtr & storage_snapshot,
+        SelectQueryInfo & query_info,
+        ContextPtr context,
+        QueryProcessingStage::Enum processing_stage,
+        size_t max_block_size,
+        size_t num_streams) override;
+
+    String getName() const override { return "MergeTreeAnalyzeIndexes"; }
+
+private:
+    friend class ReadFromMergeTreeAnalyzeIndexes;
+
+    StoragePtr source_table;
+    MergeTreeData::DataPartsVector data_parts;
+    MergeTreeSettingsPtr table_settings;
+    ASTPtr predicate;
+};
+
+}

--- a/src/TableFunctions/TableFunctionMergeTreeAnalyzeIndexes.cpp
+++ b/src/TableFunctions/TableFunctionMergeTreeAnalyzeIndexes.cpp
@@ -1,0 +1,212 @@
+#include <DataTypes/DataTypeArray.h>
+#include <DataTypes/DataTypeTuple.h>
+#include <IO/ReadHelpers.h>
+#include <Interpreters/evaluateConstantExpression.h>
+#include <Storages/StorageMergeTreeAnalyzeIndexes.h>
+#include <TableFunctions/ITableFunction.h>
+#include <Interpreters/DatabaseCatalog.h>
+#include <Storages/checkAndGetLiteralArgument.h>
+#include <TableFunctions/TableFunctionFactory.h>
+#include <Common/quoteString.h>
+
+namespace
+{
+
+const char * mergeTreeAnalyzeIndexFunctionName(bool resolve_by_uuid)
+{
+    if (resolve_by_uuid)
+        return "mergeTreeAnalyzeIndexesUUID";
+    else
+        return "mergeTreeAnalyzeIndexes";
+}
+
+}
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
+    extern const int LOGICAL_ERROR;
+    extern const int UNKNOWN_TABLE;
+}
+
+class TableFunctionMergeTreeAnalyzeIndexes : public ITableFunction
+{
+public:
+    explicit TableFunctionMergeTreeAnalyzeIndexes(bool resolve_by_uuid_)
+        : resolve_by_uuid(resolve_by_uuid_)
+    {}
+
+    std::string getName() const override { return mergeTreeAnalyzeIndexFunctionName(resolve_by_uuid); }
+
+    void parseArguments(const ASTPtr & ast_function, ContextPtr context) override;
+    ColumnsDescription getActualTableStructure(ContextPtr context, bool is_insert_query) const override;
+    std::vector<size_t> skipAnalysisForArguments(const QueryTreeNodePtr & query_node_table_function, ContextPtr context) const override;
+
+private:
+    StoragePtr executeImpl(
+        const ASTPtr & ast_function,
+        ContextPtr context,
+        const std::string & table_name,
+        ColumnsDescription cached_columns,
+        bool is_insert_query) const override;
+
+    const char * getStorageEngineName() const override
+    {
+        /// Technically it's MergeTreeAnalyzeIndexes but it doesn't register itself
+        return "";
+    }
+
+    void parseArgumentsUUID(const ASTs & args_func, ContextPtr context);
+    void parseArgumentsDatabaseTable(const ASTs & args_func, ContextPtr context);
+
+    const bool resolve_by_uuid;
+    StorageID source_table_id{StorageID::createEmpty()};
+    String parts_regexp;
+    ASTPtr predicate;
+};
+
+std::vector<size_t> TableFunctionMergeTreeAnalyzeIndexes::skipAnalysisForArguments(const QueryTreeNodePtr & /* query_node_table_function */, ContextPtr /* context */) const
+{
+    /// Filter should not be analyzed
+    if (resolve_by_uuid)
+        return {2};
+    else
+        return {3};
+}
+
+void TableFunctionMergeTreeAnalyzeIndexes::parseArguments(const ASTPtr & ast_function, ContextPtr context)
+{
+    const ASTs & args_func = ast_function->children;
+    if (args_func.size() != 1)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Table function ({}) must have arguments.", quoteString(getName()));
+
+    if (resolve_by_uuid)
+        parseArgumentsUUID(args_func, context);
+    else
+        parseArgumentsDatabaseTable(args_func, context);
+}
+
+void TableFunctionMergeTreeAnalyzeIndexes::parseArgumentsUUID(const ASTs & args_func, ContextPtr context)
+{
+    ASTs & args = args_func.at(0)->children;
+    /// clang-tidy suggest to use args.empty() over args.size() < 1, which looks wrong here, but OK, let's use empty()
+    if (args.empty() || args.size() > 3)
+        throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH,
+            "Table function '{}' must have at from 1 to 3 arguments (UUID, parts_regexp, condition), got: {}", getName(), args.size());
+
+    args[0] = evaluateConstantExpressionAsLiteral(args[0], context);
+    auto uuid = parseFromString<UUID>(checkAndGetLiteralArgument<String>(args[0], "UUID"));
+
+    if (args.size() > 1)
+    {
+        args[1] = evaluateConstantExpressionOrIdentifierAsLiteral(args[1], context);
+        parts_regexp = checkAndGetLiteralArgument<String>(args[1], "parts_regexp");
+    }
+
+    if (args.size() > 2)
+        predicate = args[2]->clone();
+
+    source_table_id = StorageID{/*database=*/ "", /*table=*/ "", uuid};
+}
+
+void TableFunctionMergeTreeAnalyzeIndexes::parseArgumentsDatabaseTable(const ASTs & args_func, ContextPtr context)
+{
+    ASTs & args = args_func.at(0)->children;
+    if (args.size() < 2 || args.size() > 4)
+        throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH,
+            "Table function '{}' must have at from 2 to 4 arguments (database, table, parts_regexp, condition), got: {}", getName(), args.size());
+
+    args[0] = evaluateConstantExpressionForDatabaseName(args[0], context);
+    auto database = checkAndGetLiteralArgument<String>(args[0], "database");
+
+    args[1] = evaluateConstantExpressionOrIdentifierAsLiteral(args[1], context);
+    auto table = checkAndGetLiteralArgument<String>(args[1], "table");
+
+    if (args.size() > 2)
+    {
+        args[2] = evaluateConstantExpressionOrIdentifierAsLiteral(args[2], context);
+        parts_regexp = checkAndGetLiteralArgument<String>(args[2], "parts_regexp");
+    }
+
+    if (args.size() > 3)
+        predicate = args[3]->clone();
+
+    source_table_id = StorageID{database, table};
+}
+
+ColumnsDescription TableFunctionMergeTreeAnalyzeIndexes::getActualTableStructure(ContextPtr /*context*/, bool /*is_insert_query*/) const
+{
+    return ColumnsDescription(NamesAndTypesList({
+        {"part_name", std::make_shared<DataTypeString>()},
+        {"ranges", std::make_shared<DataTypeArray>(std::make_shared<DataTypeTuple>(DataTypes{
+            std::make_shared<DataTypeUInt64>(), // begin
+            std::make_shared<DataTypeUInt64>(), // end
+        }))},
+    }));
+}
+
+StoragePtr TableFunctionMergeTreeAnalyzeIndexes::executeImpl(
+    const ASTPtr & /*ast_function*/,
+    ContextPtr context,
+    const std::string & table_name,
+    ColumnsDescription /*cached_columns*/,
+    bool is_insert_query) const
+{
+    StoragePtr source_table;
+    if (source_table_id.hasUUID())
+    {
+        /// Note, there is no getByUUID() at the time of writing, hence using try*() methods.
+        auto database_and_table = DatabaseCatalog::instance().tryGetByUUID(source_table_id.uuid);
+        source_table = DatabaseCatalog::instance().tryGetByUUID(source_table_id.uuid).second;
+        if (!source_table)
+            throw Exception(ErrorCodes::UNKNOWN_TABLE, "Table with UUID {} does not exist", source_table_id.uuid);
+    }
+    else
+        source_table = DatabaseCatalog::instance().getTable(source_table_id, context);
+
+    auto columns = getActualTableStructure(context, is_insert_query);
+    StorageID storage_id(getDatabaseName(), table_name);
+
+    auto res = std::make_shared<StorageMergeTreeAnalyzeIndexes>(
+        std::move(storage_id),
+        std::move(source_table),
+        std::move(columns),
+        parts_regexp,
+        predicate);
+    res->startup();
+    return res;
+}
+
+void registerTableFunctionMergeTreeAnalyzeIndexes(TableFunctionFactory & factory)
+{
+    factory.registerFunction(mergeTreeAnalyzeIndexFunctionName(/*resolve_by_uuid=*/ false), TableFunctionFactoryData{
+        []() { return std::make_shared<TableFunctionMergeTreeAnalyzeIndexes>(/* resolve_by_uuid_= */ false); },
+        TableFunctionProperties{
+            .documentation =
+            {
+                .description = "Internal function for index analysis",
+                .examples = {{"mergeTreeAnalyzeIndexes", "SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), mt_table, 'parts_regexp', predicate)", ""}},
+                .category = FunctionDocumentation::Category::TableFunction
+            },
+            .allow_readonly = true,
+        }
+    });
+
+    factory.registerFunction(mergeTreeAnalyzeIndexFunctionName(/*resolve_by_uuid=*/ true), TableFunctionFactoryData{
+        []() { return std::make_shared<TableFunctionMergeTreeAnalyzeIndexes>(/* resolve_by_uuid_= */ true); },
+        TableFunctionProperties{
+            .documentation =
+            {
+                .description = "Internal function for index analysis",
+                .examples = {{"mergeTreeAnalyzeIndexes", "SELECT * FROM mergeTreeAnalyzeIndexesUUID('table_uuid', 'parts_regexp', predicate)", ""}},
+                .category = FunctionDocumentation::Category::TableFunction
+            },
+            .allow_readonly = true,
+        }
+    });
+}
+
+}

--- a/src/TableFunctions/registerTableFunctions.cpp
+++ b/src/TableFunctions/registerTableFunctions.cpp
@@ -32,6 +32,7 @@ void registerTableFunctions()
 #endif
 
     registerTableFunctionMergeTreeIndex(factory);
+    registerTableFunctionMergeTreeAnalyzeIndexes(factory);
     registerTableFunctionMergeTreeProjection(factory);
     registerTableFunctionFuzzQuery(factory);
 #if USE_RAPIDJSON || USE_SIMDJSON

--- a/src/TableFunctions/registerTableFunctions.h
+++ b/src/TableFunctions/registerTableFunctions.h
@@ -33,6 +33,7 @@ void registerTableFunctionArrowFlight(TableFunctionFactory & factory);
 #endif
 
 void registerTableFunctionMergeTreeIndex(TableFunctionFactory & factory);
+void registerTableFunctionMergeTreeAnalyzeIndexes(TableFunctionFactory & factory);
 void registerTableFunctionMergeTreeProjection(TableFunctionFactory & factory);
 void registerTableFunctionFuzzQuery(TableFunctionFactory & factory);
 #if USE_RAPIDJSON || USE_SIMDJSON

--- a/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexes.reference
+++ b/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexes.reference
@@ -1,0 +1,24 @@
+-- { echo }
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data);
+all_1_1_0	[(0,12)]
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, '');
+all_1_1_0	[(0,12)]
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, '', key = 8193);
+all_1_1_0	[(1,2)]
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, '', key >= 8193);
+all_1_1_0	[(1,12)]
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, '', key = 8192+1 or key = 8192*3+1);
+all_1_1_0	[(1,2),(3,4)]
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, '', key = 8192+1 or key = 8192*5+1);
+all_1_1_0	[(1,2),(5,6)]
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, 'all_1_1_0', key = 8193);
+all_1_1_0	[(1,2)]
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, 'no_such_part', key = 8193);
+-- Columns not from PK is allowed and ignored.
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, '', value = 0);
+all_1_1_0	[(0,12)]
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, '', key = 8193 and value = 0);
+all_1_1_0	[(1,2)]
+-- Set
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, '', key in (8193, 16385));
+all_1_1_0	[(1,3)]

--- a/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexes.reference
+++ b/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexes.reference
@@ -1,24 +1,24 @@
 -- { echo }
 select * from mergeTreeAnalyzeIndexes(currentDatabase(), data);
 all_1_1_0	[(0,12)]
-select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, '');
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data);
 all_1_1_0	[(0,12)]
-select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, '', key = 8193);
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, key = 8193);
 all_1_1_0	[(1,2)]
-select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, '', key >= 8193);
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, key >= 8193);
 all_1_1_0	[(1,12)]
-select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, '', key = 8192+1 or key = 8192*3+1);
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, key = 8192+1 or key = 8192*3+1);
 all_1_1_0	[(1,2),(3,4)]
-select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, '', key = 8192+1 or key = 8192*5+1);
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, key = 8192+1 or key = 8192*5+1);
 all_1_1_0	[(1,2),(5,6)]
-select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, 'all_1_1_0', key = 8193);
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, key = 8193, 'all_1_1_0');
 all_1_1_0	[(1,2)]
-select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, 'no_such_part', key = 8193);
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, key = 8193, 'no_such_part');
 -- Columns not from PK is allowed and ignored.
-select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, '', value = 0);
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, value = 0);
 all_1_1_0	[(0,12)]
-select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, '', key = 8193 and value = 0);
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, key = 8193 and value = 0);
 all_1_1_0	[(1,2)]
 -- Set
-select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, '', key in (8193, 16385));
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, key in (8193, 16385));
 all_1_1_0	[(1,3)]

--- a/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexes.sql
+++ b/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexes.sql
@@ -1,0 +1,24 @@
+-- Tags: no-random-merge-tree-settings
+-- - no-random-merge-tree-settings -- may change amount of granulas
+
+drop table if exists data;
+create table data (key Int, value Int) engine=MergeTree() order by key;
+insert into data select *, *+1000000 from numbers(100000);
+
+-- { echo }
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data);
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, '');
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, '', key = 8193);
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, '', key >= 8193);
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, '', key = 8192+1 or key = 8192*3+1);
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, '', key = 8192+1 or key = 8192*5+1);
+
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, 'all_1_1_0', key = 8193);
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, 'no_such_part', key = 8193);
+
+-- Columns not from PK is allowed and ignored.
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, '', value = 0);
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, '', key = 8193 and value = 0);
+
+-- Set
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, '', key in (8193, 16385));

--- a/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexes.sql
+++ b/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexes.sql
@@ -7,18 +7,18 @@ insert into data select *, *+1000000 from numbers(100000);
 
 -- { echo }
 select * from mergeTreeAnalyzeIndexes(currentDatabase(), data);
-select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, '');
-select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, '', key = 8193);
-select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, '', key >= 8193);
-select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, '', key = 8192+1 or key = 8192*3+1);
-select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, '', key = 8192+1 or key = 8192*5+1);
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data);
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, key = 8193);
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, key >= 8193);
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, key = 8192+1 or key = 8192*3+1);
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, key = 8192+1 or key = 8192*5+1);
 
-select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, 'all_1_1_0', key = 8193);
-select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, 'no_such_part', key = 8193);
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, key = 8193, 'all_1_1_0');
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, key = 8193, 'no_such_part');
 
 -- Columns not from PK is allowed and ignored.
-select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, '', value = 0);
-select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, '', key = 8193 and value = 0);
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, value = 0);
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, key = 8193 and value = 0);
 
 -- Set
-select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, '', key in (8193, 16385));
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, key in (8193, 16385));

--- a/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexesUUID.reference
+++ b/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexesUUID.reference
@@ -1,24 +1,24 @@
 -- { echo }
   select * from mergeTreeAnalyzeIndexesUUID('UUID');
 all_1_1_0	[(0,12)]
-select * from mergeTreeAnalyzeIndexesUUID('UUID', '');
+select * from mergeTreeAnalyzeIndexesUUID('UUID');
 all_1_1_0	[(0,12)]
-select * from mergeTreeAnalyzeIndexesUUID('UUID', '', key = 8193);
+select * from mergeTreeAnalyzeIndexesUUID('UUID', key = 8193);
 all_1_1_0	[(1,2)]
-select * from mergeTreeAnalyzeIndexesUUID('UUID', '', key >= 8193);
+select * from mergeTreeAnalyzeIndexesUUID('UUID', key >= 8193);
 all_1_1_0	[(1,12)]
-select * from mergeTreeAnalyzeIndexesUUID('UUID', '', key = 8192+1 or key = 8192*3+1);
+select * from mergeTreeAnalyzeIndexesUUID('UUID', key = 8192+1 or key = 8192*3+1);
 all_1_1_0	[(1,2),(3,4)]
-select * from mergeTreeAnalyzeIndexesUUID('UUID', '', key = 8192+1 or key = 8192*5+1);
+select * from mergeTreeAnalyzeIndexesUUID('UUID', key = 8192+1 or key = 8192*5+1);
 all_1_1_0	[(1,2),(5,6)]
-select * from mergeTreeAnalyzeIndexesUUID('UUID', 'all_1_1_0', key = 8193);
+select * from mergeTreeAnalyzeIndexesUUID('UUID', key = 8193, 'all_1_1_0');
 all_1_1_0	[(1,2)]
-select * from mergeTreeAnalyzeIndexesUUID('UUID', 'no_such_part', key = 8193);
+select * from mergeTreeAnalyzeIndexesUUID('UUID', key = 8193, 'no_such_part');
 -- Columns not from PK is allowed and ignored.
-  select * from mergeTreeAnalyzeIndexesUUID('UUID', '', value = 0);
+  select * from mergeTreeAnalyzeIndexesUUID('UUID', value = 0);
 all_1_1_0	[(0,12)]
-select * from mergeTreeAnalyzeIndexesUUID('UUID', '', key = 8193 and value = 0);
+select * from mergeTreeAnalyzeIndexesUUID('UUID', key = 8193 and value = 0);
 all_1_1_0	[(1,2)]
 -- Set
-  select * from mergeTreeAnalyzeIndexesUUID('UUID', '', key in (8193, 16385));
+  select * from mergeTreeAnalyzeIndexesUUID('UUID', key in (8193, 16385));
 all_1_1_0	[(1,3)]

--- a/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexesUUID.reference
+++ b/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexesUUID.reference
@@ -1,0 +1,24 @@
+-- { echo }
+  select * from mergeTreeAnalyzeIndexesUUID('UUID');
+all_1_1_0	[(0,12)]
+select * from mergeTreeAnalyzeIndexesUUID('UUID', '');
+all_1_1_0	[(0,12)]
+select * from mergeTreeAnalyzeIndexesUUID('UUID', '', key = 8193);
+all_1_1_0	[(1,2)]
+select * from mergeTreeAnalyzeIndexesUUID('UUID', '', key >= 8193);
+all_1_1_0	[(1,12)]
+select * from mergeTreeAnalyzeIndexesUUID('UUID', '', key = 8192+1 or key = 8192*3+1);
+all_1_1_0	[(1,2),(3,4)]
+select * from mergeTreeAnalyzeIndexesUUID('UUID', '', key = 8192+1 or key = 8192*5+1);
+all_1_1_0	[(1,2),(5,6)]
+select * from mergeTreeAnalyzeIndexesUUID('UUID', 'all_1_1_0', key = 8193);
+all_1_1_0	[(1,2)]
+select * from mergeTreeAnalyzeIndexesUUID('UUID', 'no_such_part', key = 8193);
+-- Columns not from PK is allowed and ignored.
+  select * from mergeTreeAnalyzeIndexesUUID('UUID', '', value = 0);
+all_1_1_0	[(0,12)]
+select * from mergeTreeAnalyzeIndexesUUID('UUID', '', key = 8193 and value = 0);
+all_1_1_0	[(1,2)]
+-- Set
+  select * from mergeTreeAnalyzeIndexesUUID('UUID', '', key in (8193, 16385));
+all_1_1_0	[(1,3)]

--- a/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexesUUID.sh
+++ b/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexesUUID.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Tags: no-random-merge-tree-settings
+# - no-random-merge-tree-settings -- may change amount of granulas
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT -nm -q "
+  drop table if exists data;
+  create table data (key Int, value Int) engine=MergeTree() order by key;
+  insert into data select *, *+1000000 from numbers(100000);
+"
+
+table_uuid="$($CLICKHOUSE_CLIENT -q "SELECT uuid FROM system.tables WHERE database = currentDatabase() AND table = 'data'")"
+
+$CLICKHOUSE_CLIENT -nm -q "
+  -- { echo }
+  select * from mergeTreeAnalyzeIndexesUUID('$table_uuid');
+  select * from mergeTreeAnalyzeIndexesUUID('$table_uuid', '');
+  select * from mergeTreeAnalyzeIndexesUUID('$table_uuid', '', key = 8193);
+  select * from mergeTreeAnalyzeIndexesUUID('$table_uuid', '', key >= 8193);
+  select * from mergeTreeAnalyzeIndexesUUID('$table_uuid', '', key = 8192+1 or key = 8192*3+1);
+  select * from mergeTreeAnalyzeIndexesUUID('$table_uuid', '', key = 8192+1 or key = 8192*5+1);
+
+  select * from mergeTreeAnalyzeIndexesUUID('$table_uuid', 'all_1_1_0', key = 8193);
+  select * from mergeTreeAnalyzeIndexesUUID('$table_uuid', 'no_such_part', key = 8193);
+
+  -- Columns not from PK is allowed and ignored.
+  select * from mergeTreeAnalyzeIndexesUUID('$table_uuid', '', value = 0);
+  select * from mergeTreeAnalyzeIndexesUUID('$table_uuid', '', key = 8193 and value = 0);
+
+  -- Set
+  select * from mergeTreeAnalyzeIndexesUUID('$table_uuid', '', key in (8193, 16385));
+" |& sed "s/$table_uuid/UUID/"

--- a/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexesUUID.sh
+++ b/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexesUUID.sh
@@ -17,19 +17,19 @@ table_uuid="$($CLICKHOUSE_CLIENT -q "SELECT uuid FROM system.tables WHERE databa
 $CLICKHOUSE_CLIENT -nm -q "
   -- { echo }
   select * from mergeTreeAnalyzeIndexesUUID('$table_uuid');
-  select * from mergeTreeAnalyzeIndexesUUID('$table_uuid', '');
-  select * from mergeTreeAnalyzeIndexesUUID('$table_uuid', '', key = 8193);
-  select * from mergeTreeAnalyzeIndexesUUID('$table_uuid', '', key >= 8193);
-  select * from mergeTreeAnalyzeIndexesUUID('$table_uuid', '', key = 8192+1 or key = 8192*3+1);
-  select * from mergeTreeAnalyzeIndexesUUID('$table_uuid', '', key = 8192+1 or key = 8192*5+1);
+  select * from mergeTreeAnalyzeIndexesUUID('$table_uuid');
+  select * from mergeTreeAnalyzeIndexesUUID('$table_uuid', key = 8193);
+  select * from mergeTreeAnalyzeIndexesUUID('$table_uuid', key >= 8193);
+  select * from mergeTreeAnalyzeIndexesUUID('$table_uuid', key = 8192+1 or key = 8192*3+1);
+  select * from mergeTreeAnalyzeIndexesUUID('$table_uuid', key = 8192+1 or key = 8192*5+1);
 
-  select * from mergeTreeAnalyzeIndexesUUID('$table_uuid', 'all_1_1_0', key = 8193);
-  select * from mergeTreeAnalyzeIndexesUUID('$table_uuid', 'no_such_part', key = 8193);
+  select * from mergeTreeAnalyzeIndexesUUID('$table_uuid', key = 8193, 'all_1_1_0');
+  select * from mergeTreeAnalyzeIndexesUUID('$table_uuid', key = 8193, 'no_such_part');
 
   -- Columns not from PK is allowed and ignored.
-  select * from mergeTreeAnalyzeIndexesUUID('$table_uuid', '', value = 0);
-  select * from mergeTreeAnalyzeIndexesUUID('$table_uuid', '', key = 8193 and value = 0);
+  select * from mergeTreeAnalyzeIndexesUUID('$table_uuid', value = 0);
+  select * from mergeTreeAnalyzeIndexesUUID('$table_uuid', key = 8193 and value = 0);
 
   -- Set
-  select * from mergeTreeAnalyzeIndexesUUID('$table_uuid', '', key in (8193, 16385));
+  select * from mergeTreeAnalyzeIndexesUUID('$table_uuid', key in (8193, 16385));
 " |& sed "s/$table_uuid/UUID/"

--- a/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexes_columns.reference
+++ b/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexes_columns.reference
@@ -1,12 +1,12 @@
 -- { echo }
-select part_name from mergeTreeAnalyzeIndexes(currentDatabase(), data, '', key >= 1000);
+select part_name from mergeTreeAnalyzeIndexes(currentDatabase(), data, key >= 1000);
 all_1_1_0
 all_2_2_0
-select ranges from mergeTreeAnalyzeIndexes(currentDatabase(), data, '', key >= 1000);
+select ranges from mergeTreeAnalyzeIndexes(currentDatabase(), data, key >= 1000);
 [(0,12)]
 [(0,24)]
-select arraySum(arrayMap(e -> ((e.2) - (e.1)), ranges)) as ranges_size from mergeTreeAnalyzeIndexes(currentDatabase(), data, '', key >= 1000);
+select arraySum(arrayMap(e -> ((e.2) - (e.1)), ranges)) as ranges_size from mergeTreeAnalyzeIndexes(currentDatabase(), data, key >= 1000);
 12
 24
-select sum(arraySum(arrayMap(e -> ((e.2) - (e.1)), ranges))) as ranges_size from mergeTreeAnalyzeIndexes(currentDatabase(), data, '', key >= 1000);
+select sum(arraySum(arrayMap(e -> ((e.2) - (e.1)), ranges))) as ranges_size from mergeTreeAnalyzeIndexes(currentDatabase(), data, key >= 1000);
 36

--- a/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexes_columns.reference
+++ b/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexes_columns.reference
@@ -1,0 +1,12 @@
+-- { echo }
+select part_name from mergeTreeAnalyzeIndexes(currentDatabase(), data, '', key >= 1000);
+all_1_1_0
+all_2_2_0
+select ranges from mergeTreeAnalyzeIndexes(currentDatabase(), data, '', key >= 1000);
+[(0,12)]
+[(0,24)]
+select arraySum(arrayMap(e -> ((e.2) - (e.1)), ranges)) as ranges_size from mergeTreeAnalyzeIndexes(currentDatabase(), data, '', key >= 1000);
+12
+24
+select sum(arraySum(arrayMap(e -> ((e.2) - (e.1)), ranges))) as ranges_size from mergeTreeAnalyzeIndexes(currentDatabase(), data, '', key >= 1000);
+36

--- a/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexes_columns.sql
+++ b/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexes_columns.sql
@@ -1,0 +1,14 @@
+-- Tags: no-random-merge-tree-settings
+-- - no-random-merge-tree-settings -- may change amount of granulas
+
+drop table if exists data;
+create table data (key Int, value Int) engine=MergeTree() order by key;
+system stop merges data;
+insert into data select *, *+1000000 from numbers(100000);
+insert into data select *, *+1000000 from numbers(100000, 200000);
+
+-- { echo }
+select part_name from mergeTreeAnalyzeIndexes(currentDatabase(), data, '', key >= 1000);
+select ranges from mergeTreeAnalyzeIndexes(currentDatabase(), data, '', key >= 1000);
+select arraySum(arrayMap(e -> ((e.2) - (e.1)), ranges)) as ranges_size from mergeTreeAnalyzeIndexes(currentDatabase(), data, '', key >= 1000);
+select sum(arraySum(arrayMap(e -> ((e.2) - (e.1)), ranges))) as ranges_size from mergeTreeAnalyzeIndexes(currentDatabase(), data, '', key >= 1000);

--- a/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexes_columns.sql
+++ b/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexes_columns.sql
@@ -8,7 +8,7 @@ insert into data select *, *+1000000 from numbers(100000);
 insert into data select *, *+1000000 from numbers(100000, 200000);
 
 -- { echo }
-select part_name from mergeTreeAnalyzeIndexes(currentDatabase(), data, '', key >= 1000);
-select ranges from mergeTreeAnalyzeIndexes(currentDatabase(), data, '', key >= 1000);
-select arraySum(arrayMap(e -> ((e.2) - (e.1)), ranges)) as ranges_size from mergeTreeAnalyzeIndexes(currentDatabase(), data, '', key >= 1000);
-select sum(arraySum(arrayMap(e -> ((e.2) - (e.1)), ranges))) as ranges_size from mergeTreeAnalyzeIndexes(currentDatabase(), data, '', key >= 1000);
+select part_name from mergeTreeAnalyzeIndexes(currentDatabase(), data, key >= 1000);
+select ranges from mergeTreeAnalyzeIndexes(currentDatabase(), data, key >= 1000);
+select arraySum(arrayMap(e -> ((e.2) - (e.1)), ranges)) as ranges_size from mergeTreeAnalyzeIndexes(currentDatabase(), data, key >= 1000);
+select sum(arraySum(arrayMap(e -> ((e.2) - (e.1)), ranges))) as ranges_size from mergeTreeAnalyzeIndexes(currentDatabase(), data, key >= 1000);

--- a/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexes_skip_indexes.reference
+++ b/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexes_skip_indexes.reference
@@ -1,0 +1,7 @@
+-- { echo }
+SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), 'with_skip_index', '', value > 0);
+all_1_1_0	[(0,122)]
+SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), 'with_skip_index', '', value > 5_000_000);
+all_1_1_0	[(6,122)]
+SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), 'with_skip_index', '', value > 100_000_000);
+all_1_1_0	[]

--- a/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexes_skip_indexes.reference
+++ b/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexes_skip_indexes.reference
@@ -1,7 +1,7 @@
 -- { echo }
-SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), 'with_skip_index', '', value > 0);
+SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), 'with_skip_index', value > 0);
 all_1_1_0	[(0,122)]
-SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), 'with_skip_index', '', value > 5_000_000);
+SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), 'with_skip_index', value > 5_000_000);
 all_1_1_0	[(6,122)]
-SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), 'with_skip_index', '', value > 100_000_000);
+SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), 'with_skip_index', value > 100_000_000);
 all_1_1_0	[]

--- a/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexes_skip_indexes.sql
+++ b/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexes_skip_indexes.sql
@@ -6,6 +6,6 @@ create table with_skip_index (key Int, value Int, index value_idx value type min
 insert into with_skip_index select number, number*100 from numbers(1e6);
 
 -- { echo }
-SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), 'with_skip_index', '', value > 0);
-SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), 'with_skip_index', '', value > 5_000_000);
-SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), 'with_skip_index', '', value > 100_000_000);
+SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), 'with_skip_index', value > 0);
+SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), 'with_skip_index', value > 5_000_000);
+SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), 'with_skip_index', value > 100_000_000);

--- a/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexes_skip_indexes.sql
+++ b/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexes_skip_indexes.sql
@@ -1,0 +1,11 @@
+-- Tags: no-random-merge-tree-settings
+-- - no-random-merge-tree-settings -- may change amount of granulas
+
+drop table if exists with_skip_index;
+create table with_skip_index (key Int, value Int, index value_idx value type minmax granularity 1) engine=MergeTree() order by key;
+insert into with_skip_index select number, number*100 from numbers(1e6);
+
+-- { echo }
+SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), 'with_skip_index', '', value > 0);
+SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), 'with_skip_index', '', value > 5_000_000);
+SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), 'with_skip_index', '', value > 100_000_000);


### PR DESCRIPTION
### Changelog category (leave one):
- New Feature

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Implement `mergeTreeAnalyzeIndex()` function

This is mostly a function for experienced users, for index analysis introspection (it will return particular ranges for specific query, after applying PK and data skipping indexes)

I've decoupled this changes from another PR (#86786), to make review easier and also to merge this earlier (I started this at a wrong time, MergeTree code this days is very hot, which causes constant conflicts)