### PR TITLE
ci: reduce number of tests in parallel for MSan (from 19 to 12)

### DIFF
--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -191,6 +191,9 @@ def main():
             nproc = int(Utils.cpu_count() * 1.2)
         elif is_database_replicated:
             nproc = int(Utils.cpu_count() * 0.4)
+        elif "msan" in args.options:
+            # MSan is slow
+            nproc = int(Utils.cpu_count() * 0.4)
         elif is_coverage:
             cidb_cluster = CIDBCluster()
             assert cidb_cluster.is_ready()


### PR DESCRIPTION
_I will merge it once I will get one review_

Binary compiled with MSan is very slow and lots of things pops up there, examples:
- https://github.com/ClickHouse/ClickHouse/issues/92955
- https://github.com/ClickHouse/ClickHouse/issues/91410

Let's try to reduce amount of threads to make things more stable.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
ci: reduce number of tests in parallel for MSan (from 19 to 12)