### PR TITLE
Log background tasks that are slower then average (`background_schedule_pool_log.duration_threshold_milliseconds=30`)  to avoid excessive tasks logging

### DIFF
--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -1260,7 +1260,8 @@
         <buffer_size_rows_flush_threshold>524288</buffer_size_rows_flush_threshold>
         <flush_on_crash>false</flush_on_crash>
         <!-- Only tasks longer then duration_threshold_milliseconds will be logged. Zero means log everything -->
-        <duration_threshold_milliseconds>0</duration_threshold_milliseconds>
+        <!-- Default value is 30ms (averge tasks execution time) -->
+        <duration_threshold_milliseconds>30</duration_threshold_milliseconds>
     </background_schedule_pool_log>
 
     <!-- Text log contains all information from usual server log but stores it in structured and efficient way.

--- a/src/Interpreters/SystemLog.cpp
+++ b/src/Interpreters/SystemLog.cpp
@@ -426,7 +426,7 @@ SystemLogs::SystemLogs(ContextPtr global_context, const Poco::Util::AbstractConf
 
     if (background_schedule_pool_log)
     {
-        size_t duration_threshold_milliseconds = config.getUInt64("background_schedule_pool_log.duration_threshold_milliseconds", 0);
+        size_t duration_threshold_milliseconds = config.getUInt64("background_schedule_pool_log.duration_threshold_milliseconds", 30);
         background_schedule_pool_log->setDurationMillisecondsThreshold(duration_threshold_milliseconds);
     }
 }

--- a/tests/config/config.d/background_schedule_pool_log.yaml
+++ b/tests/config/config.d/background_schedule_pool_log.yaml
@@ -1,0 +1,3 @@
+background_schedule_pool_log:
+    # duration > 0 will still filter enough for CI
+    duration_threshold_milliseconds: 1

--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -138,6 +138,7 @@ ln -sf $SRC_PATH/config.d/ssl_certs.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/filesystem_cache_log.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/filesystem_read_prefetches_log.yaml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/session_log.xml $DEST_SERVER_PATH/config.d/
+ln -sf $SRC_PATH/config.d/background_schedule_pool_log.yaml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/system_unfreeze.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/nlp.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/nb_models.xml $DEST_SERVER_PATH/config.d/

--- a/tests/queries/0_stateless/03746_system_background_schedule_pool_log.reference
+++ b/tests/queries/0_stateless/03746_system_background_schedule_pool_log.reference
@@ -1,2 +1,1 @@
-default	test_merge_tree_03745	1	BackgroundJobsAssignee:DataProcessing	1
 default	test_distributed_03745	1	default.test_distributed_03745.DistributedInsertQueue.default/Bg	1	1

--- a/tests/queries/0_stateless/03746_system_background_schedule_pool_log.sh
+++ b/tests/queries/0_stateless/03746_system_background_schedule_pool_log.sh
@@ -4,16 +4,6 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
-# Test for MergeTree table (schedule pool)
-$CLICKHOUSE_CLIENT -nmq "
-  DROP TABLE IF EXISTS test_merge_tree_03745;
-  CREATE TABLE test_merge_tree_03745 (x UInt64, y String) ENGINE = MergeTree() ORDER BY x;
-  INSERT INTO test_merge_tree_03745 VALUES (1, 'a'), (2, 'b');
-  SYSTEM FLUSH LOGS background_schedule_pool_log;
-  SELECT DISTINCT database, table, table_uuid != toUUIDOrDefault(0) AS has_uuid, log_name, query_id != '' FROM system.background_schedule_pool_log WHERE database = currentDatabase() AND table = 'test_merge_tree_03745';
-  DROP TABLE test_merge_tree_03745;
-"
-
 # Test for Distributed table (distributed pool)
 $CLICKHOUSE_CLIENT -nmq "
   DROP TABLE IF EXISTS test_local_03745;


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Log background tasks that are slower than average (`background_schedule_pool_log.duration_threshold_milliseconds=30`)  to avoid excessive tasks logging

Otherwise it is too much, one job in CI:
- `text_log`: 4'500'000
- `zookeeper_log`: 6'400'000
- `background_schedule_pool_log`: **54'000'000**
- `background_schedule_pool_log` where `duration_ms > 0`: **19'400**

But this is CI real values are different [1], so let's use average task
executiong time for threshold.

  [1]: https://pastila.nl/?0043db0f/96b45f5ddb995fb78c11d301d7a49f27#foCK+BCRTTH/kLTqvZ7G8g==

It should resolve flakiness due to `TOO_MANY_ROWS` [2].

  [2]: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=f7b1a4850b1597b443b472adbf0e2cd4f5a3b0bd&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_binary%2C%20old%20analyzer%2C%20s3%20storage%2C%20DatabaseReplicated%2C%20parallel%29&name_1=Stateless%20tests%20%28amd_binary%2C%20old%20analyzer%2C%20s3%20storage%2C%20DatabaseReplicated%2C%20parallel%29

