### PR TITLE
tests: fix 02881_system_detached_parts_modification_time flakiness

### DIFF
--- a/tests/queries/0_stateless/02881_system_detached_parts_modification_time.reference
+++ b/tests/queries/0_stateless/02881_system_detached_parts_modification_time.reference
@@ -1,2 +1,2 @@
-after detach	5
-after detach	5
+data_compact	1
+data_wide	1

--- a/tests/queries/0_stateless/02881_system_detached_parts_modification_time.sql.j2
+++ b/tests/queries/0_stateless/02881_system_detached_parts_modification_time.sql.j2
@@ -15,11 +15,11 @@ alter table data_{{ id }} detach partition all;
 system flush logs query_log;
 
 select
-  table,
+  parts.table,
   -- make sure that the modification_time is within (query_start_time; query_finish_time) of ALTER query
   abs(dateDiff('seconds', modification_time, query_finish_time)) <= ceil(query_duration_ms/1e3),
-from system.detached_parts
+from system.detached_parts parts
 left join (select tables[1] as table, event_time query_finish_time, query_duration_ms from system.query_log where current_database = currentDatabase() and type = 'QueryFinish' and query_kind = 'Alter') query_log
-  on (query_log.table = database || '.' || table)
+  on (query_log.table = database || '.' || parts.table)
 where database = currentDatabase()
-order by table;
+order by parts.table;

--- a/tests/queries/0_stateless/02881_system_detached_parts_modification_time.sql.j2
+++ b/tests/queries/0_stateless/02881_system_detached_parts_modification_time.sql.j2
@@ -5,14 +5,21 @@ set mutations_sync=1;
     ("compact", "min_bytes_for_wide_part=1000, min_rows_for_wide_part=100"),
 ]
 %}
-
 drop table if exists data_{{ id }};
 create table data_{{ id }} (key Int) engine=MergeTree() order by tuple() settings {{ settings }};
 insert into data_{{ id }} values (1);
 select 'before detach', modification_time from system.detached_parts where database = currentDatabase() and table = 'data_{{ id }}';
 alter table data_{{ id }} detach partition all;
-system flush logs query_log;
-with (select event_time from system.query_log where current_database = currentDatabase() and type = 'QueryFinish' and query_kind = 'Alter' and tables = [currentDatabase() || '.data_{{ id }}']) as finish_time_
-select 'after detach', max2(abs(dateDiff('seconds', modification_time, finish_time_)), 5) from system.detached_parts where database = currentDatabase() and table = 'data_{{ id }}';
-
 {% endfor %}
+
+system flush logs query_log;
+
+select
+  table,
+  -- make sure that the modification_time is within (query_start_time; query_finish_time) of ALTER query
+  abs(dateDiff('seconds', modification_time, query_finish_time)) <= ceil(query_duration_ms/1e3),
+from system.detached_parts
+left join (select tables[1] as table, event_time query_finish_time, query_duration_ms from system.query_log where current_database = currentDatabase() and type = 'QueryFinish' and query_kind = 'Alter') query_log
+  on (query_log.table = database || '.' || table)
+where database = currentDatabase()
+order by table;


### PR DESCRIPTION
DETACH of wide part can be slow, i.e. [1]:

    :) select event_time_microseconds, normalizeQuery(query), query_duration_ms from `query_log.tsv.zst` where current_database = 'test_6uu7kwww' and type != 'QueryStart' and query_kind = 'Alter' order by 1

       ┌────event_time_microseconds─┬─normalizeQuery(query)──────────────────────────┬─query_duration_ms─┐
    1. │ 2025-12-23 20:50:41.648787 │ alter table data_wide detach partition all;    │              6145 │
    2. │ 2025-12-23 20:50:44.425337 │ alter table data_compact detach partition all; │               173 │
       └────────────────────────────┴────────────────────────────────────────────────┴───────────────────┘

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=92927&sha=ca11a3a71caca3535621eefbb870cc601ed61cff&name_0=PR&name_1=Stateless%20tests%20%28amd_tsan%2C%20s3%20storage%2C%20parallel%29

So:
- Rely on query_duration_ms instead of some static const
- Use only one "SYSTEM FLUSH LOGS"

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes: https://github.com/ClickHouse/ClickHouse/issues/92974