### PR TITLE
Optimize locking for top-k with skip indexes

### DIFF
--- a/src/Storages/MergeTree/MergeTreeReaderIndex.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderIndex.cpp
@@ -144,7 +144,7 @@ bool MergeTreeReaderIndex::canSkipMark(size_t mark, size_t /*current_task_last_m
 {
     if (index_read_result && index_read_result->skip_index_read_result)
     {
-        auto skip_index_read_result = index_read_result->skip_index_read_result;
+        auto & skip_index_read_result = index_read_result->skip_index_read_result;
         chassert(mark < skip_index_read_result->granules_selected.size());
 
         if (!skip_index_read_result->granules_selected.at(mark))


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Improved performance of dynamic top K filtering by skip indexes with many concurrent reader threads.

This PR contains two changes, both intended to reduce cache line contention around the usage of shared atomics:
* Use double-buffering instead of a shared (RW) mutex within `TopKThresholdTracker`. The tracker's threshold is read in `MergeTreeReaderIndex::canSkipGranule` by all readers concurrently, and grabbing the shared lock requires writing to an incrementing atomic counter (the number of readers), which adds contention for the shared lock between readers.
* Take only a reference to `skip_index_read_result` in `MergeTreeReaderIndex::canSkipGranule`, which was previously making a copy of the read result's shared ptr.

I discovered both of these bottlenecks with a somewhat contrived example table:
```
CREATE TABLE traces
(
    `trace_id` UInt32,
    `start_time` DateTime64(3),
    INDEX i start_time TYPE minmax GRANULARITY 1
)
ENGINE = MergeTree
ORDER BY (trace_id, start_time)
SETTINGS index_granularity = 1
```
and this query:
```
SELECT
    trace_id,
    start_time
FROM traces
WHERE identity(1 = 1) -- To disable the TopK granule shortlisting feature
ORDER BY start_time DESC
LIMIT 10
SETTINGS
  enable_filesystem_cache = 0,
  use_query_condition_cache = 0,
  use_skip_indexes_on_data_read = true,
  use_skip_indexes_for_top_k = 1
```

In `perf`, over 90% of the time was spent waiting on atomic instructions related to the tracker threshold or the read result. After this PR, the profile is much flatter.