### PR TITLE
tests: fix 02943_rmt_alter_metadata_merge_checksum_mismatch exit path

### DIFF
--- a/tests/queries/0_stateless/02943_rmt_alter_metadata_merge_checksum_mismatch.sh
+++ b/tests/queries/0_stateless/02943_rmt_alter_metadata_merge_checksum_mismatch.sh
@@ -26,12 +26,14 @@ function wait_part()
 
 function restore_failpoints()
 {
+    if [ -z "$failed_replica" ]; then
+        return
+    fi
+
     # restore entry error with failpoints (to avoid endless errors in logs)
-    $CLICKHOUSE_CLIENT -m -q "
-        system enable failpoint replicated_queue_unfail_entries;
-        system sync replica $failed_replica;
-        system disable failpoint replicated_queue_unfail_entries;
-    "
+    $CLICKHOUSE_CLIENT -q "system enable failpoint replicated_queue_unfail_entries" ||:
+    $CLICKHOUSE_CLIENT -q "system sync replica $failed_replica" ||:
+    $CLICKHOUSE_CLIENT -q "system disable failpoint replicated_queue_unfail_entries" ||:
 }
 trap restore_failpoints EXIT
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Minor cleanup while investigating test failure in https://github.com/ClickHouse/ClickHouse/issues/92670

Fixes issues like this:

```
2025-10-03 04:58:31 Reason: return code:  62
2025-10-03 04:58:31 ALTER_METADATA does not succeed on any replica
2025-10-03 04:58:31 Code: 62. DB::Exception: Syntax error: failed at position 21 (end of query) (line 1, col 21): ;
2025-10-03 04:58:31         system disable failpoint replicated_queue_unfail_entries;
2025-10-03 04:58:31     . Expected one of: ON, identifier. (SYNTAX_ERROR)
```

CI: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=4ee8d057fa73c995f21f6931058ebf496f42d822&name_0=MasterCI&name_1=Stateless%20tests%20%28arm_asan%2C%20azure%2C%20sequential%29&name_1=Stateless%20tests%20%28arm_asan%2C%20azure%2C%20sequential%29