### PR TITLE
tests: enable 02968_file_log_multiple_read under parallel replicas

### DIFF
--- a/tests/queries/0_stateless/02968_file_log_multiple_read.sh
+++ b/tests/queries/0_stateless/02968_file_log_multiple_read.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# Tags: no-parallel-replicas
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -41,7 +40,7 @@ CREATE MATERIALIZED VIEW file_log_mv TO table_to_store_data AS
             FROM file_log
         )
     );
-"
+" || exit 1
 
 function count()
 {


### PR DESCRIPTION
I've fixed a few problems that analyzer may lost context of subqueries (#89527), and it looks like now it works

Fixes: https://github.com/ClickHouse/ClickHouse/issues/79788

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
