### PR TITLE
Fix possible hung on terminating background schedule pool

### DIFF
--- a/src/Core/BackgroundSchedulePool.cpp
+++ b/src/Core/BackgroundSchedulePool.cpp
@@ -328,8 +328,14 @@ void BackgroundSchedulePool::join()
         shutdown = true;
 
         /// Unlock threads
-        tasks_cond_var.notify_all();
-        delayed_tasks_cond_var.notify_all();
+        {
+            std::lock_guard tasks_lock(tasks_mutex);
+            tasks_cond_var.notify_all();
+        }
+        {
+            std::lock_guard tasks_lock(delayed_tasks_mutex);
+            delayed_tasks_cond_var.notify_all();
+        }
 
         /// Join all worker threads to avoid any recursive calls to schedule()/scheduleAfter() from the task callbacks
         {

--- a/src/Core/tests/gtest_BackgroundSchedulePool.cpp
+++ b/src/Core/tests/gtest_BackgroundSchedulePool.cpp
@@ -54,8 +54,10 @@ TEST(BackgroundSchedulePool, ScheduleAfter)
     });
     ASSERT_EQ(task->activateAndSchedule(), true);
 
-    std::unique_lock lock(mutex);
-    condvar.wait(lock, [&] { return counter == ITERATIONS; });
+    {
+        std::unique_lock lock(mutex);
+        condvar.wait(lock, [&] { return counter == ITERATIONS; });
+    }
 
     ASSERT_EQ(counter, ITERATIONS);
 


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix possible hung on terminating background schedule pool (may lead to server hungs on shutdown)

Fixes: https://github.com/ClickHouse/ClickHouse/issues/92996
Introduced in: #81473 (25.6+)