### PR TITLE
Fix link to ULID spec in ULIDStringToDateTime docs

### DIFF
--- a/src/Functions/ULIDStringToDateTime.cpp
+++ b/src/Functions/ULIDStringToDateTime.cpp
@@ -172,7 +172,7 @@ REGISTER_FUNCTION(ULIDStringToDateTime)
 {
     /// ULIDStringToDateTime documentation
     FunctionDocumentation::Description description_ULIDStringToDateTime = R"(
-This function extracts the timestamp from a [ULID]((https://github.com/ulid/spec).
+This function extracts the timestamp from a [ULID](https://github.com/ulid/spec).
     )";
     FunctionDocumentation::Syntax syntax_ULIDStringToDateTime = "ULIDStringToDateTime(ulid[, timezone])";
     FunctionDocumentation::Arguments arguments_ULIDStringToDateTime = {


### PR DESCRIPTION
This PR fixes the markdown link to the ULID spec. 

https://clickhouse.com/docs/sql-reference/functions/ulid-functions#ULIDStringToDateTime

<img width="648" height="176" alt="image" src="https://github.com/user-attachments/assets/357cbeab-d5b0-4f8a-b6f3-9eef043d7c89" />


A similar link is correctly formatted in generateULID
https://github.com/ClickHouse/ClickHouse/blob/0c359bad5cd45128e684989903a6071fb120201a/src/Functions/generateULID.cpp#L79



### Changelog category (leave one):
- Documentation (changelog entry is not required)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
