### PR TITLE
Fix incorrect granules pruning in `KeyCondition` for `NOT materialize(...)` and `NOT CAST(...)`

### DIFF
--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -651,11 +651,19 @@ static const ActionsDAG::Node & cloneDAGWithInversionPushDown(
             {
                 /// Remove "materialize" from index analysis.
                 res = &cloneDAGWithInversionPushDown(*node.children.front(), inverted_dag, inputs_mapping, context, need_inversion);
+
+                /// `need_inversion` was already pushed into the child; avoid adding an extra `not()` wrapper
+                /// Without this, we could add an extra `not()` here (double inversion), e.g. `NOT materialize(x = 0)` -> `not(notEquals(x, 0))`.
+                handled_inversion = true;
             }
             else if (isTrivialCast(node))
             {
                 /// Remove trivial cast and keep its first argument.
                 res = &cloneDAGWithInversionPushDown(*node.children.front(), inverted_dag, inputs_mapping, context, need_inversion);
+
+                /// `need_inversion` was already pushed into the child; avoid adding an extra `not()` wrapper
+                /// Without this, we could add an extra `not()` here (double inversion), e.g. `NOT CAST(x = 0, 'UInt8')` -> `not(notEquals(x, 0))`.
+                handled_inversion = true;
             }
             else if (need_inversion && (name == "and" || name == "or"))
             {

--- a/tests/queries/0_stateless/03773_key_condition_not_materialize_not_cast.reference
+++ b/tests/queries/0_stateless/03773_key_condition_not_materialize_not_cast.reference
@@ -1,0 +1,32 @@
+1
+2
+Expression (Project names)
+  Sorting (Sorting for ORDER BY)
+    Expression ((Before ORDER BY + Projection))
+      Filter ((WHERE + Change column names to column identifiers))
+        ReadFromMergeTree (default.t_cast_bug)
+        Indexes:
+          PrimaryKey
+            Keys:
+              val
+            Condition: (val not in [0, 0])
+            Parts: 2/3
+            Granules: 2/3
+            Search Algorithm: generic exclusion search
+          Ranges: 2
+1
+2
+Expression (Project names)
+  Sorting (Sorting for ORDER BY)
+    Expression ((Before ORDER BY + (Projection + (WHERE + (Change column names to column identifiers + (Convert VIEW subquery result to VIEW table structure + (Materialize constants after VIEW subquery + (Project names + (Projection + (Change column names to column identifiers + (Project names + (Projection + Change column names to column identifiers))))))))))))
+      Filter (((WHERE + (Change column names to column identifiers + (Convert VIEW subquery result to VIEW table structure + (Materialize constants after VIEW subquery + (Project names + (Projection + (Change column names to column identifiers + (Project names + (Projection + Change column names to column identifiers))))))))))[split])
+        ReadFromMergeTree (default.t_materialize_bug)
+        Indexes:
+          PrimaryKey
+            Keys:
+              val
+            Condition: (val not in [0, 0])
+            Parts: 2/3
+            Granules: 2/3
+            Search Algorithm: generic exclusion search
+          Ranges: 2

--- a/tests/queries/0_stateless/03773_key_condition_not_materialize_not_cast.sql
+++ b/tests/queries/0_stateless/03773_key_condition_not_materialize_not_cast.sql
@@ -1,0 +1,33 @@
+-- Tags: no-replicated-database, no-parallel-replicas, no-parallel, no-random-merge-tree-settings
+-- EXPLAIN output may differ
+
+DROP TABLE IF EXISTS t_cast_bug;
+
+CREATE TABLE t_cast_bug (val UInt8) ENGINE = MergeTree ORDER BY val;
+SYSTEM STOP MERGES t_cast_bug;
+
+INSERT INTO t_cast_bug VALUES (1);
+INSERT INTO t_cast_bug VALUES (0);
+INSERT INTO t_cast_bug VALUES (0), (2);
+
+SELECT val FROM t_cast_bug WHERE NOT CAST(val = 0, 'UInt8') ORDER BY val;
+
+EXPLAIN indexes=1
+SELECT val FROM t_cast_bug WHERE NOT CAST(val = 0, 'UInt8') ORDER BY val;
+
+
+DROP TABLE IF EXISTS t_materialize_bug;
+
+CREATE TABLE t_materialize_bug (val UInt8) ORDER BY (val);
+CREATE VIEW v AS SELECT val, val = 0 AS is_zero FROM t_materialize_bug;
+SYSTEM STOP MERGES t_materialize_bug;
+
+INSERT INTO t_materialize_bug VALUES (1);
+INSERT INTO t_materialize_bug VALUES (0);
+INSERT INTO t_materialize_bug VALUES (0), (2);
+
+SELECT val FROM v WHERE NOT is_zero ORDER BY val;
+
+EXPLAIN indexes=1
+SELECT val FROM v WHERE NOT is_zero ORDER BY val;
+


### PR DESCRIPTION
Both queries currently return 2, but should return `1 2`.

```sql
CREATE TABLE t_cast_bug (val UInt8) ENGINE = MergeTree ORDER BY val;
SYSTEM STOP MERGES t_cast_bug;

INSERT INTO t_cast_bug VALUES (1);
INSERT INTO t_cast_bug VALUES (0);
INSERT INTO t_cast_bug VALUES (0), (2);

SELECT val FROM t_cast_bug WHERE NOT CAST(val = 0, 'UInt8') ORDER BY val;
```

```sql
CREATE TABLE t_materialize_bug (val UInt8) ORDER BY (val);
CREATE VIEW v AS SELECT val, val = 0 AS is_zero FROM t_materialize_bug;
SYSTEM STOP MERGES t_materialize_bug;

INSERT INTO t_materialize_bug VALUES (1);
INSERT INTO t_materialize_bug VALUES (0);
INSERT INTO t_materialize_bug VALUES (0), (2);

SELECT val FROM v WHERE NOT is_zero ORDER BY val;
```


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix bug in data skipping logic when `not materialize(...)` or `not CAST(...)` is used in WHERE causing incorrect results. Closes https://github.com/ClickHouse/ClickHouse/issues/88536.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
