### PR TITLE
Fix possible usage of outdated parts due to TOCTOU race for shared parts

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -7134,14 +7134,13 @@ MergeTreeData::getPossiblySharedVisibleDataPartsRanges(ContextPtr local_context)
     {
         if (!shared_parts_list)
         {
-            auto parts = getDataPartsVectorForInternalUsage({DataPartState::Active}, *shared_lock_holder);
-
             /// Convert read to write lock, and re-check the shared_parts_list
             shared_lock_holder.reset();
             lock_holder.emplace(data_parts_mutex, /*data_=*/ nullptr);
 
             if (!shared_parts_list)
             {
+                auto parts = getDataPartsVectorForInternalUsage({DataPartState::Active}, *lock_holder);
                 shared_ranges_in_parts = std::make_shared<const RangesInDataParts>(parts);
                 shared_parts_list = std::make_shared<const DataPartsVector>(std::move(parts));
             }


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix possible usage of outdated parts due to TOCTOU race for shared parts

Imagine the following scenario:

    T1: TRUNCATE TABLE                       T2: OPTIMIZE TABLE

          lockParts() # exclusive lock!
            shared_parts_list = nullptr
                                               getPossiblySharedVisibleDataPartsRanges()
                                                 shared_lock_holder = readLockParts() # shared lock, shared_parts_list == nullptr
                                                 auto parts = getDataPartsVectorForInternalUsage({DataPartState::Active}, *shared_lock_holder);
                                                 shared_lock_holder.reset();
          lockParts() # exclusive lock
            remove parts from list
            shared_parts_list = nullptr
                                                 lock_holder.emplace(data_parts_mutex, /*data_=*/ nullptr); # exclusive lock!
                                                 shared_ranges_in_parts = std::make_shared<const RangesInDataParts>(parts);
                                                 shared_parts_list = std::make_shared<const DataPartsVector>(std::move(parts));

It will lead to T2 will cache outdated parts in `shared_parts_list`.

And I think this is why `01443_merge_truncate_long` started to fail

Fixes: https://github.com/ClickHouse/ClickHouse/issues/92098
Fixes: https://github.com/ClickHouse/ClickHouse/pull/85535
