### PR TITLE
Fix segfault in `groupConcat` merge with malformed serialized state

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionGroupConcat.cpp
+++ b/src/AggregateFunctions/AggregateFunctionGroupConcat.cpp
@@ -173,11 +173,15 @@ void GroupConcatImpl<has_limit>::deserialize(AggregateDataPtr __restrict place, 
     {
         readVarUInt(cur_data.num_rows, buf);
         cur_data.offsets.resize_exact(cur_data.num_rows * 2, arena);
-        for (auto & offset : cur_data.offsets)
+        for (size_t i = 0; i < cur_data.offsets.size(); ++i)
         {
-            readVarUInt(offset, buf);
-            if (offset > cur_data.data_size)
-                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Invalid offset {} in groupConcat state: exceeds data size {}", offset, cur_data.data_size);
+            readVarUInt(cur_data.offsets[i], buf);
+
+            if (cur_data.offsets[i] > cur_data.data_size)
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Invalid offset {} in groupConcat state: exceeds data size {}", cur_data.offsets[i], cur_data.data_size);
+
+            if (cur_data.offsets[i] < cur_data.offsets[i - 1])
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Invalid offsets in groupConcat state: end offset {} is less than start offset {}", cur_data.offsets[i], cur_data.offsets[i - 1]);
         }
     }
 }

--- a/src/AggregateFunctions/AggregateFunctionGroupConcat.cpp
+++ b/src/AggregateFunctions/AggregateFunctionGroupConcat.cpp
@@ -173,6 +173,7 @@ void GroupConcatImpl<has_limit>::deserialize(AggregateDataPtr __restrict place, 
     {
         readVarUInt(cur_data.num_rows, buf);
         cur_data.offsets.resize_exact(cur_data.num_rows * 2, arena);
+
         for (size_t i = 0; i < cur_data.offsets.size(); ++i)
         {
             readVarUInt(cur_data.offsets[i], buf);
@@ -183,6 +184,9 @@ void GroupConcatImpl<has_limit>::deserialize(AggregateDataPtr __restrict place, 
             if (i != 0 && cur_data.offsets[i] < cur_data.offsets[i - 1])
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "Invalid offsets in groupConcat state: end offset {} is less than start offset {}", cur_data.offsets[i], cur_data.offsets[i - 1]);
         }
+
+        if (cur_data.num_rows != 0 && cur_data.offsets.back() != cur_data.data_size)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Invalid offsets in groupConcat state: last offset {} is not equal to data size {}", cur_data.offsets.back(), cur_data.data_size);
     }
 }
 

--- a/src/AggregateFunctions/AggregateFunctionGroupConcat.cpp
+++ b/src/AggregateFunctions/AggregateFunctionGroupConcat.cpp
@@ -180,7 +180,7 @@ void GroupConcatImpl<has_limit>::deserialize(AggregateDataPtr __restrict place, 
             if (cur_data.offsets[i] > cur_data.data_size)
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "Invalid offset {} in groupConcat state: exceeds data size {}", cur_data.offsets[i], cur_data.data_size);
 
-            if (cur_data.offsets[i] < cur_data.offsets[i - 1])
+            if (i != 0 && cur_data.offsets[i] < cur_data.offsets[i - 1])
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "Invalid offsets in groupConcat state: end offset {} is less than start offset {}", cur_data.offsets[i], cur_data.offsets[i - 1]);
         }
     }

--- a/src/AggregateFunctions/AggregateFunctionGroupConcat.cpp
+++ b/src/AggregateFunctions/AggregateFunctionGroupConcat.cpp
@@ -174,7 +174,11 @@ void GroupConcatImpl<has_limit>::deserialize(AggregateDataPtr __restrict place, 
         readVarUInt(cur_data.num_rows, buf);
         cur_data.offsets.resize_exact(cur_data.num_rows * 2, arena);
         for (auto & offset : cur_data.offsets)
+        {
             readVarUInt(offset, buf);
+            if (offset > cur_data.data_size)
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Invalid offset {} in groupConcat state: exceeds data size {}", offset, cur_data.data_size);
+        }
     }
 }
 

--- a/tests/queries/0_stateless/03773_deserialise_malformed_aggregate_state.sql
+++ b/tests/queries/0_stateless/03773_deserialise_malformed_aggregate_state.sql
@@ -3,4 +3,11 @@ SELECT hex(groupConcatMerge(',', 10)(state))
 FROM
 (
     SELECT CAST(unhex('01580180808080108A80808010'), 'AggregateFunction(groupConcat(\',\', 10), String)') AS state
-) -- { serverError BAD_ARGUMENTS }
+); -- { serverError BAD_ARGUMENTS }
+
+-- Check for non-monotonic offsets
+SELECT hex(groupConcatMerge(',', 10)(state))
+FROM
+(
+    SELECT CAST(unhex('0141010100'), 'AggregateFunction(groupConcat(\',\', 10), String)') AS state
+); -- { serverError BAD_ARGUMENTS }

--- a/tests/queries/0_stateless/03773_deserialise_malformed_aggregate_state.sql
+++ b/tests/queries/0_stateless/03773_deserialise_malformed_aggregate_state.sql
@@ -1,0 +1,6 @@
+-- https://github.com/ClickHouse/ClickHouse/issues/93026
+SELECT hex(groupConcatMerge(',', 10)(state))
+FROM
+(
+    SELECT CAST(unhex('01580180808080108A80808010'), 'AggregateFunction(groupConcat(\',\', 10), String)') AS state
+) -- { serverError BAD_ARGUMENTS }


### PR DESCRIPTION
<!-- Fixes issue link part, do not remove -->
## Linked issues
- fixes https://github.com/ClickHouse/clickhouse-core-incidents/issues/1154
<!-- End of fixes issue link part, do not remove -->

Closes #93026 

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix crash when deserialising malformed `groupConcat` aggregate state with out-of-bounds offsets.
