### PR TITLE
Fix leaving connection in a broken state after preliminary cancellation distributed queries

### DIFF
--- a/src/QueryPipeline/RemoteQueryExecutor.cpp
+++ b/src/QueryPipeline/RemoteQueryExecutor.cpp
@@ -778,9 +778,6 @@ void RemoteQueryExecutor::finish()
 {
     LockAndBlocker guard(was_cancelled_mutex);
 
-    /// To make sure finish is only called once
-    SCOPE_EXIT({ finished = true; });
-
     /** If one of:
       * - nothing started to do;
       * - received all packets before EndOfStream;
@@ -790,6 +787,9 @@ void RemoteQueryExecutor::finish()
       */
     if (!isQueryPending() || hasThrownException())
         return;
+
+    /// To make sure finish is only called once
+    SCOPE_EXIT({ finished = true; });
 
     /** If you have not read all the data yet, but they are no longer needed.
       * This may be due to the fact that the data is sufficient (for example, when using LIMIT).


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix leaving connection in a broken state after preliminary cancellation distributed queries

The problem is that some places in the code (i.e.
RemoteSource::onUpdatePorts()), can call finish() even before sendQueryAsync() finishes sending the query, and so if after it will try to call finish() again (after sendQueryAsync() finishes) it will be no-op.

The problem pops up after #92807, since `RemoteSource` has these (anti-)pattern.

Fixes: https://github.com/ClickHouse/ClickHouse/pull/92807
Fixes: https://github.com/ClickHouse/ClickHouse/issues/93018