### PR TITLE
tests: use separate filesystem cache for tests that rely on system.filesystem_cache

### DIFF
--- a/tests/queries/0_stateless/02240_system_filesystem_cache_table.reference
+++ b/tests/queries/0_stateless/02240_system_filesystem_cache_table.reference
@@ -1,51 +1,45 @@
-Using storage policy: s3_cache
+Using disk: s3_disk
 0
 Expect cache
-DOWNLOADED	0	0	1
 DOWNLOADED	0	79	80
 DOWNLOADED	0	745	746
-3
+2
 Expect cache
-DOWNLOADED	0	0	1
 DOWNLOADED	0	79	80
 DOWNLOADED	0	745	746
-3
+2
 Expect no cache
 Expect cache
 DOWNLOADED	0	79	80
 DOWNLOADED	0	745	746
 2
 Expect no cache
-Using storage policy: local_cache
+Using disk: local_disk
 0
 Expect cache
-DOWNLOADED	0	0	1
 DOWNLOADED	0	79	80
 DOWNLOADED	0	745	746
-3
+2
 Expect cache
-DOWNLOADED	0	0	1
 DOWNLOADED	0	79	80
 DOWNLOADED	0	745	746
-3
+2
 Expect no cache
 Expect cache
 DOWNLOADED	0	79	80
 DOWNLOADED	0	745	746
 2
 Expect no cache
-Using storage policy: azure_cache
+Using disk: azure
 0
 Expect cache
-DOWNLOADED	0	0	1
 DOWNLOADED	0	79	80
 DOWNLOADED	0	745	746
-3
+2
 Expect cache
-DOWNLOADED	0	0	1
 DOWNLOADED	0	79	80
 DOWNLOADED	0	745	746
-3
+2
 Expect no cache
 Expect cache
 DOWNLOADED	0	79	80

--- a/tests/queries/0_stateless/02240_system_filesystem_cache_table.sh
+++ b/tests/queries/0_stateless/02240_system_filesystem_cache_table.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Tags: long, no-fasttest, no-parallel, no-object-storage, no-random-settings
 
-# set -x
+set -e
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -9,41 +9,50 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=./cache.lib
 . "$CUR_DIR"/cache.lib
 
-for STORAGE_POLICY in 's3_cache' 'local_cache' 'azure_cache'; do
-    echo "Using storage policy: $STORAGE_POLICY"
-    drop_filesystem_cache
-    ${CLICKHOUSE_CLIENT} --query "SYSTEM DROP MARK CACHE"
-    ${CLICKHOUSE_CLIENT} --query "SELECT count() FROM system.filesystem_cache"
+for disk in 's3_disk' 'local_disk' 'azure'; do
+    echo "Using disk: $disk"
 
+    cache_path=02240_system_filesystem_cache_table_$disk
     ${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS test_02240_storage_policy"
-    ${CLICKHOUSE_CLIENT} --query "CREATE TABLE test_02240_storage_policy (key UInt32, value String) Engine=MergeTree() ORDER BY key SETTINGS storage_policy='${STORAGE_POLICY}', min_bytes_for_wide_part = 1000000, compress_marks=false, compress_primary_key=false, serialization_info_version='basic'"
+    ${CLICKHOUSE_CLIENT} --query "
+        CREATE TABLE test_02240_storage_policy (key UInt32, value String)
+        Engine=MergeTree()
+        ORDER BY key
+        SETTINGS disk=disk(type='cache', path='$cache_path', disk='$disk', max_size=10_000_000_000, cache_on_write_operations=1), min_bytes_for_wide_part = 1000000, compress_marks=false, compress_primary_key=false, serialization_info_version='basic'
+    "
+    cache_name=$($CLICKHOUSE_CLIENT -q "SELECT name FROM system.disks WHERE cache_path LIKE '%$cache_path'")
+
+    drop_filesystem_cache $cache_name
+    ${CLICKHOUSE_CLIENT} --query "SYSTEM DROP MARK CACHE"
+    ${CLICKHOUSE_CLIENT} --query "SELECT count() FROM system.filesystem_cache WHERE cache_name = '$cache_name'"
+
     ${CLICKHOUSE_CLIENT} --query "SYSTEM STOP MERGES test_02240_storage_policy"
     ${CLICKHOUSE_CLIENT} --enable_filesystem_cache_on_write_operations=0 --query "INSERT INTO test_02240_storage_policy SELECT number, toString(number) FROM numbers(100)"
 
     echo 'Expect cache'
     ${CLICKHOUSE_CLIENT} --query "SYSTEM DROP MARK CACHE"
     ${CLICKHOUSE_CLIENT} --query "SELECT * FROM test_02240_storage_policy FORMAT Null"
-    ${CLICKHOUSE_CLIENT} --query "SELECT state, file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache ORDER BY file_segment_range_begin, file_segment_range_end, size"
-    ${CLICKHOUSE_CLIENT} --query "SELECT uniqExact(key) FROM system.filesystem_cache";
+    ${CLICKHOUSE_CLIENT} --query "SELECT state, file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache WHERE cache_name = '$cache_name' ORDER BY file_segment_range_begin, file_segment_range_end, size"
+    ${CLICKHOUSE_CLIENT} --query "SELECT uniqExact(key) FROM system.filesystem_cache WHERE cache_name = '$cache_name'";
 
     echo 'Expect cache'
     ${CLICKHOUSE_CLIENT} --query "SYSTEM DROP MARK CACHE"
     ${CLICKHOUSE_CLIENT} --query "SELECT * FROM test_02240_storage_policy FORMAT Null"
-    ${CLICKHOUSE_CLIENT} --query "SELECT state, file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache ORDER BY file_segment_range_begin, file_segment_range_end, size"
-    ${CLICKHOUSE_CLIENT} --query "SELECT uniqExact(key) FROM system.filesystem_cache";
+    ${CLICKHOUSE_CLIENT} --query "SELECT state, file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache WHERE cache_name = '$cache_name' ORDER BY file_segment_range_begin, file_segment_range_end, size"
+    ${CLICKHOUSE_CLIENT} --query "SELECT uniqExact(key) FROM system.filesystem_cache WHERE cache_name = '$cache_name'";
 
-    drop_filesystem_cache
+    drop_filesystem_cache $cache_name
     echo 'Expect no cache'
-    ${CLICKHOUSE_CLIENT} --query "SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache"
+    ${CLICKHOUSE_CLIENT} --query "SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache WHERE cache_name = '$cache_name'"
 
     echo 'Expect cache'
     ${CLICKHOUSE_CLIENT} --query "SYSTEM DROP MARK CACHE"
     ${CLICKHOUSE_CLIENT} --query "SELECT * FROM test_02240_storage_policy FORMAT Null"
-    ${CLICKHOUSE_CLIENT} --query "SELECT state, file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache ORDER BY file_segment_range_begin, file_segment_range_end, size"
-    ${CLICKHOUSE_CLIENT} --query "SELECT uniqExact(key) FROM system.filesystem_cache";
+    ${CLICKHOUSE_CLIENT} --query "SELECT state, file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache WHERE cache_name = '$cache_name' ORDER BY file_segment_range_begin, file_segment_range_end, size"
+    ${CLICKHOUSE_CLIENT} --query "SELECT uniqExact(key) FROM system.filesystem_cache WHERE cache_name = '$cache_name'";
 
-    drop_filesystem_cache
+    drop_filesystem_cache $cache_name
     echo 'Expect no cache'
-    ${CLICKHOUSE_CLIENT} --query "SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache"
+    ${CLICKHOUSE_CLIENT} --query "SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache WHERE cache_name = '$cache_name'"
 
 done

--- a/tests/queries/0_stateless/02241_filesystem_cache_on_write_operations.reference
+++ b/tests/queries/0_stateless/02241_filesystem_cache_on_write_operations.reference
@@ -1,6 +1,6 @@
-Using storage policy: s3_cache
+Using disk: s3_disk
 DROP TABLE IF EXISTS test_02241
-CREATE TABLE test_02241 (key UInt32, value String) Engine=MergeTree() ORDER BY key SETTINGS storage_policy='s3_cache', min_bytes_for_wide_part = 10485760, compress_marks=false, compress_primary_key=false, min_bytes_for_full_part_storage=0, ratio_of_defaults_for_sparse_serialization = 1, write_marks_for_substreams_in_compact_parts=1, serialization_info_version='basic'
+CREATE TABLE test_02241 (key UInt32, value String) Engine=MergeTree() ORDER BY key SETTINGS disk=disk(type='cache', path='02241_filesystem_cache_on_write_operations_s3_disk', disk='s3_disk', max_size=10_000_000_000, cache_on_write_operations=1), min_bytes_for_wide_part = 10485760, compress_marks=false, compress_primary_key=false, min_bytes_for_full_part_storage=0, ratio_of_defaults_for_sparse_serialization = 1, write_marks_for_substreams_in_compact_parts=1, serialization_info_version='basic'
 SYSTEM STOP MERGES test_02241
 SYSTEM DROP FILESYSTEM CACHE
 SELECT file_segment_range_begin, file_segment_range_end, size, state
@@ -15,12 +15,13 @@ SELECT file_segment_range_begin, file_segment_range_end, size, state
         INNER JOIN
             system.filesystem_cache AS caches
         ON data_paths.cache_path = caches.cache_path
+        WHERE caches.cache_name = '__tmp_internal'
     )
     WHERE endsWith(local_path, 'data.bin')
     FORMAT Vertical
-SELECT count() FROM (SELECT arrayJoin(cache_paths) AS cache_path, local_path, remote_path FROM system.remote_data_paths ) AS data_paths INNER JOIN system.filesystem_cache AS caches ON data_paths.cache_path = caches.cache_path
+SELECT count() FROM (SELECT arrayJoin(cache_paths) AS cache_path, local_path, remote_path FROM system.remote_data_paths ) AS data_paths INNER JOIN system.filesystem_cache AS caches ON data_paths.cache_path = caches.cache_path WHERE caches.cache_name = '__tmp_internal'
 0
-SELECT count(), sum(size) FROM system.filesystem_cache
+SELECT count(), sum(size) FROM system.filesystem_cache WHERE cache_name = '__tmp_internal'
 0	0
 INSERT INTO test_02241 SELECT number, toString(number) FROM numbers(100)
 SELECT file_segment_range_begin, file_segment_range_end, size, state
@@ -35,6 +36,7 @@ SELECT file_segment_range_begin, file_segment_range_end, size, state
         INNER JOIN
             system.filesystem_cache AS caches
         ON data_paths.cache_path = caches.cache_path
+        WHERE caches.cache_name = '__tmp_internal'
     )
     WHERE endsWith(local_path, 'data.bin')
     FORMAT Vertical
@@ -44,19 +46,17 @@ file_segment_range_begin: 0
 file_segment_range_end:   745
 size:                     746
 state:                    DOWNLOADED
-SELECT count() FROM (SELECT arrayJoin(cache_paths) AS cache_path, local_path, remote_path FROM system.remote_data_paths ) AS data_paths INNER JOIN system.filesystem_cache AS caches ON data_paths.cache_path = caches.cache_path
+SELECT count() FROM (SELECT arrayJoin(cache_paths) AS cache_path, local_path, remote_path FROM system.remote_data_paths ) AS data_paths INNER JOIN system.filesystem_cache AS caches ON data_paths.cache_path = caches.cache_path WHERE caches.cache_name = '__tmp_internal'
 9
-SELECT count(), sum(size) FROM system.filesystem_cache
+SELECT count(), sum(size) FROM system.filesystem_cache WHERE cache_name = '__tmp_internal'
 9	1217
-SELECT count() FROM system.filesystem_cache WHERE cache_hits > 0
-0
 SELECT * FROM test_02241 FORMAT Null
-SELECT count() FROM system.filesystem_cache WHERE cache_hits > 0
+SELECT count() FROM system.filesystem_cache WHERE cache_hits > 0 AND cache_name = '__tmp_internal'
 2
 SELECT * FROM test_02241 FORMAT Null
-SELECT count() FROM system.filesystem_cache WHERE cache_hits > 0
+SELECT count() FROM system.filesystem_cache WHERE cache_hits > 0 AND cache_name = '__tmp_internal'
 2
-SELECT count(), sum(size) size FROM system.filesystem_cache
+SELECT count(), sum(size) size FROM system.filesystem_cache WHERE cache_name = '__tmp_internal'
 9	1217
 SYSTEM DROP FILESYSTEM CACHE
 INSERT INTO test_02241 SELECT number, toString(number) FROM numbers(100, 200)
@@ -72,6 +72,7 @@ SELECT file_segment_range_begin, file_segment_range_end, size, state
         INNER JOIN
             system.filesystem_cache AS caches
         ON data_paths.cache_path = caches.cache_path
+        WHERE caches.cache_name = '__tmp_internal'
     )
     WHERE endsWith(local_path, 'data.bin')
     FORMAT Vertical;
@@ -81,25 +82,25 @@ file_segment_range_begin: 0
 file_segment_range_end:   1659
 size:                     1660
 state:                    DOWNLOADED
-SELECT count() FROM (SELECT arrayJoin(cache_paths) AS cache_path, local_path, remote_path FROM system.remote_data_paths ) AS data_paths INNER JOIN system.filesystem_cache AS caches ON data_paths.cache_path = caches.cache_path
+SELECT count() FROM (SELECT arrayJoin(cache_paths) AS cache_path, local_path, remote_path FROM system.remote_data_paths ) AS data_paths INNER JOIN system.filesystem_cache AS caches ON data_paths.cache_path = caches.cache_path WHERE caches.cache_name = '__tmp_internal'
 9
-SELECT count(), sum(size) FROM system.filesystem_cache
+SELECT count(), sum(size) FROM system.filesystem_cache WHERE cache_name = '__tmp_internal'
 9	2131
-SELECT count(), sum(size) FROM system.filesystem_cache
+SELECT count(), sum(size) FROM system.filesystem_cache WHERE cache_name = '__tmp_internal'
 9	2131
 INSERT INTO test_02241 SELECT number, toString(number) FROM numbers(100) SETTINGS enable_filesystem_cache_on_write_operations=0
-SELECT count(), sum(size) FROM system.filesystem_cache
+SELECT count(), sum(size) FROM system.filesystem_cache WHERE cache_name = '__tmp_internal'
 9	2131
 INSERT INTO test_02241 SELECT number, toString(number) FROM numbers(100)
 INSERT INTO test_02241 SELECT number, toString(number) FROM numbers(300, 10000)
-SELECT count(), sum(size) FROM system.filesystem_cache
+SELECT count(), sum(size) FROM system.filesystem_cache WHERE cache_name = '__tmp_internal'
 27	84396
 SYSTEM START MERGES test_02241
 OPTIMIZE TABLE test_02241 FINAL
-SELECT count(), sum(size) FROM system.filesystem_cache
+SELECT count(), sum(size) FROM system.filesystem_cache WHERE cache_name = '__tmp_internal'
 36	167711
 ALTER TABLE test_02241 UPDATE value = 'kek' WHERE key = 100
-SELECT count(), sum(size) FROM system.filesystem_cache
+SELECT count(), sum(size) FROM system.filesystem_cache WHERE cache_name = '__tmp_internal'
 46	251128
 INSERT INTO test_02241 SELECT number, toString(number) FROM numbers(5000000)
 SYSTEM FLUSH LOGS query_log
@@ -108,9 +109,9 @@ SELECT count() FROM test_02241
 5010500
 SELECT count() FROM test_02241 WHERE value LIKE '%010%'
 18816
-Using storage policy: local_cache
+Using disk: local_disk
 DROP TABLE IF EXISTS test_02241
-CREATE TABLE test_02241 (key UInt32, value String) Engine=MergeTree() ORDER BY key SETTINGS storage_policy='local_cache', min_bytes_for_wide_part = 10485760, compress_marks=false, compress_primary_key=false, min_bytes_for_full_part_storage=0, ratio_of_defaults_for_sparse_serialization = 1, write_marks_for_substreams_in_compact_parts=1, serialization_info_version='basic'
+CREATE TABLE test_02241 (key UInt32, value String) Engine=MergeTree() ORDER BY key SETTINGS disk=disk(type='cache', path='02241_filesystem_cache_on_write_operations_local_disk', disk='local_disk', max_size=10_000_000_000, cache_on_write_operations=1), min_bytes_for_wide_part = 10485760, compress_marks=false, compress_primary_key=false, min_bytes_for_full_part_storage=0, ratio_of_defaults_for_sparse_serialization = 1, write_marks_for_substreams_in_compact_parts=1, serialization_info_version='basic'
 SYSTEM STOP MERGES test_02241
 SYSTEM DROP FILESYSTEM CACHE
 SELECT file_segment_range_begin, file_segment_range_end, size, state
@@ -125,12 +126,13 @@ SELECT file_segment_range_begin, file_segment_range_end, size, state
         INNER JOIN
             system.filesystem_cache AS caches
         ON data_paths.cache_path = caches.cache_path
+        WHERE caches.cache_name = '__tmp_internal'
     )
     WHERE endsWith(local_path, 'data.bin')
     FORMAT Vertical
-SELECT count() FROM (SELECT arrayJoin(cache_paths) AS cache_path, local_path, remote_path FROM system.remote_data_paths ) AS data_paths INNER JOIN system.filesystem_cache AS caches ON data_paths.cache_path = caches.cache_path
+SELECT count() FROM (SELECT arrayJoin(cache_paths) AS cache_path, local_path, remote_path FROM system.remote_data_paths ) AS data_paths INNER JOIN system.filesystem_cache AS caches ON data_paths.cache_path = caches.cache_path WHERE caches.cache_name = '__tmp_internal'
 0
-SELECT count(), sum(size) FROM system.filesystem_cache
+SELECT count(), sum(size) FROM system.filesystem_cache WHERE cache_name = '__tmp_internal'
 0	0
 INSERT INTO test_02241 SELECT number, toString(number) FROM numbers(100)
 SELECT file_segment_range_begin, file_segment_range_end, size, state
@@ -145,6 +147,7 @@ SELECT file_segment_range_begin, file_segment_range_end, size, state
         INNER JOIN
             system.filesystem_cache AS caches
         ON data_paths.cache_path = caches.cache_path
+        WHERE caches.cache_name = '__tmp_internal'
     )
     WHERE endsWith(local_path, 'data.bin')
     FORMAT Vertical
@@ -154,19 +157,17 @@ file_segment_range_begin: 0
 file_segment_range_end:   745
 size:                     746
 state:                    DOWNLOADED
-SELECT count() FROM (SELECT arrayJoin(cache_paths) AS cache_path, local_path, remote_path FROM system.remote_data_paths ) AS data_paths INNER JOIN system.filesystem_cache AS caches ON data_paths.cache_path = caches.cache_path
+SELECT count() FROM (SELECT arrayJoin(cache_paths) AS cache_path, local_path, remote_path FROM system.remote_data_paths ) AS data_paths INNER JOIN system.filesystem_cache AS caches ON data_paths.cache_path = caches.cache_path WHERE caches.cache_name = '__tmp_internal'
 9
-SELECT count(), sum(size) FROM system.filesystem_cache
+SELECT count(), sum(size) FROM system.filesystem_cache WHERE cache_name = '__tmp_internal'
 9	1217
-SELECT count() FROM system.filesystem_cache WHERE cache_hits > 0
-0
 SELECT * FROM test_02241 FORMAT Null
-SELECT count() FROM system.filesystem_cache WHERE cache_hits > 0
+SELECT count() FROM system.filesystem_cache WHERE cache_hits > 0 AND cache_name = '__tmp_internal'
 2
 SELECT * FROM test_02241 FORMAT Null
-SELECT count() FROM system.filesystem_cache WHERE cache_hits > 0
+SELECT count() FROM system.filesystem_cache WHERE cache_hits > 0 AND cache_name = '__tmp_internal'
 2
-SELECT count(), sum(size) size FROM system.filesystem_cache
+SELECT count(), sum(size) size FROM system.filesystem_cache WHERE cache_name = '__tmp_internal'
 9	1217
 SYSTEM DROP FILESYSTEM CACHE
 INSERT INTO test_02241 SELECT number, toString(number) FROM numbers(100, 200)
@@ -182,6 +183,7 @@ SELECT file_segment_range_begin, file_segment_range_end, size, state
         INNER JOIN
             system.filesystem_cache AS caches
         ON data_paths.cache_path = caches.cache_path
+        WHERE caches.cache_name = '__tmp_internal'
     )
     WHERE endsWith(local_path, 'data.bin')
     FORMAT Vertical;
@@ -191,25 +193,25 @@ file_segment_range_begin: 0
 file_segment_range_end:   1659
 size:                     1660
 state:                    DOWNLOADED
-SELECT count() FROM (SELECT arrayJoin(cache_paths) AS cache_path, local_path, remote_path FROM system.remote_data_paths ) AS data_paths INNER JOIN system.filesystem_cache AS caches ON data_paths.cache_path = caches.cache_path
+SELECT count() FROM (SELECT arrayJoin(cache_paths) AS cache_path, local_path, remote_path FROM system.remote_data_paths ) AS data_paths INNER JOIN system.filesystem_cache AS caches ON data_paths.cache_path = caches.cache_path WHERE caches.cache_name = '__tmp_internal'
 9
-SELECT count(), sum(size) FROM system.filesystem_cache
+SELECT count(), sum(size) FROM system.filesystem_cache WHERE cache_name = '__tmp_internal'
 9	2131
-SELECT count(), sum(size) FROM system.filesystem_cache
+SELECT count(), sum(size) FROM system.filesystem_cache WHERE cache_name = '__tmp_internal'
 9	2131
 INSERT INTO test_02241 SELECT number, toString(number) FROM numbers(100) SETTINGS enable_filesystem_cache_on_write_operations=0
-SELECT count(), sum(size) FROM system.filesystem_cache
+SELECT count(), sum(size) FROM system.filesystem_cache WHERE cache_name = '__tmp_internal'
 9	2131
 INSERT INTO test_02241 SELECT number, toString(number) FROM numbers(100)
 INSERT INTO test_02241 SELECT number, toString(number) FROM numbers(300, 10000)
-SELECT count(), sum(size) FROM system.filesystem_cache
+SELECT count(), sum(size) FROM system.filesystem_cache WHERE cache_name = '__tmp_internal'
 27	84396
 SYSTEM START MERGES test_02241
 OPTIMIZE TABLE test_02241 FINAL
-SELECT count(), sum(size) FROM system.filesystem_cache
+SELECT count(), sum(size) FROM system.filesystem_cache WHERE cache_name = '__tmp_internal'
 36	167711
 ALTER TABLE test_02241 UPDATE value = 'kek' WHERE key = 100
-SELECT count(), sum(size) FROM system.filesystem_cache
+SELECT count(), sum(size) FROM system.filesystem_cache WHERE cache_name = '__tmp_internal'
 46	251128
 INSERT INTO test_02241 SELECT number, toString(number) FROM numbers(5000000)
 SYSTEM FLUSH LOGS query_log
@@ -218,9 +220,9 @@ SELECT count() FROM test_02241
 5010500
 SELECT count() FROM test_02241 WHERE value LIKE '%010%'
 18816
-Using storage policy: azure_cache
+Using disk: azure
 DROP TABLE IF EXISTS test_02241
-CREATE TABLE test_02241 (key UInt32, value String) Engine=MergeTree() ORDER BY key SETTINGS storage_policy='azure_cache', min_bytes_for_wide_part = 10485760, compress_marks=false, compress_primary_key=false, min_bytes_for_full_part_storage=0, ratio_of_defaults_for_sparse_serialization = 1, write_marks_for_substreams_in_compact_parts=1, serialization_info_version='basic'
+CREATE TABLE test_02241 (key UInt32, value String) Engine=MergeTree() ORDER BY key SETTINGS disk=disk(type='cache', path='02241_filesystem_cache_on_write_operations_azure', disk='azure', max_size=10_000_000_000, cache_on_write_operations=1), min_bytes_for_wide_part = 10485760, compress_marks=false, compress_primary_key=false, min_bytes_for_full_part_storage=0, ratio_of_defaults_for_sparse_serialization = 1, write_marks_for_substreams_in_compact_parts=1, serialization_info_version='basic'
 SYSTEM STOP MERGES test_02241
 SYSTEM DROP FILESYSTEM CACHE
 SELECT file_segment_range_begin, file_segment_range_end, size, state
@@ -235,12 +237,13 @@ SELECT file_segment_range_begin, file_segment_range_end, size, state
         INNER JOIN
             system.filesystem_cache AS caches
         ON data_paths.cache_path = caches.cache_path
+        WHERE caches.cache_name = '__tmp_internal'
     )
     WHERE endsWith(local_path, 'data.bin')
     FORMAT Vertical
-SELECT count() FROM (SELECT arrayJoin(cache_paths) AS cache_path, local_path, remote_path FROM system.remote_data_paths ) AS data_paths INNER JOIN system.filesystem_cache AS caches ON data_paths.cache_path = caches.cache_path
+SELECT count() FROM (SELECT arrayJoin(cache_paths) AS cache_path, local_path, remote_path FROM system.remote_data_paths ) AS data_paths INNER JOIN system.filesystem_cache AS caches ON data_paths.cache_path = caches.cache_path WHERE caches.cache_name = '__tmp_internal'
 0
-SELECT count(), sum(size) FROM system.filesystem_cache
+SELECT count(), sum(size) FROM system.filesystem_cache WHERE cache_name = '__tmp_internal'
 0	0
 INSERT INTO test_02241 SELECT number, toString(number) FROM numbers(100)
 SELECT file_segment_range_begin, file_segment_range_end, size, state
@@ -255,6 +258,7 @@ SELECT file_segment_range_begin, file_segment_range_end, size, state
         INNER JOIN
             system.filesystem_cache AS caches
         ON data_paths.cache_path = caches.cache_path
+        WHERE caches.cache_name = '__tmp_internal'
     )
     WHERE endsWith(local_path, 'data.bin')
     FORMAT Vertical
@@ -264,19 +268,17 @@ file_segment_range_begin: 0
 file_segment_range_end:   745
 size:                     746
 state:                    DOWNLOADED
-SELECT count() FROM (SELECT arrayJoin(cache_paths) AS cache_path, local_path, remote_path FROM system.remote_data_paths ) AS data_paths INNER JOIN system.filesystem_cache AS caches ON data_paths.cache_path = caches.cache_path
+SELECT count() FROM (SELECT arrayJoin(cache_paths) AS cache_path, local_path, remote_path FROM system.remote_data_paths ) AS data_paths INNER JOIN system.filesystem_cache AS caches ON data_paths.cache_path = caches.cache_path WHERE caches.cache_name = '__tmp_internal'
 9
-SELECT count(), sum(size) FROM system.filesystem_cache
+SELECT count(), sum(size) FROM system.filesystem_cache WHERE cache_name = '__tmp_internal'
 9	1217
-SELECT count() FROM system.filesystem_cache WHERE cache_hits > 0
-0
 SELECT * FROM test_02241 FORMAT Null
-SELECT count() FROM system.filesystem_cache WHERE cache_hits > 0
+SELECT count() FROM system.filesystem_cache WHERE cache_hits > 0 AND cache_name = '__tmp_internal'
 2
 SELECT * FROM test_02241 FORMAT Null
-SELECT count() FROM system.filesystem_cache WHERE cache_hits > 0
+SELECT count() FROM system.filesystem_cache WHERE cache_hits > 0 AND cache_name = '__tmp_internal'
 2
-SELECT count(), sum(size) size FROM system.filesystem_cache
+SELECT count(), sum(size) size FROM system.filesystem_cache WHERE cache_name = '__tmp_internal'
 9	1217
 SYSTEM DROP FILESYSTEM CACHE
 INSERT INTO test_02241 SELECT number, toString(number) FROM numbers(100, 200)
@@ -292,6 +294,7 @@ SELECT file_segment_range_begin, file_segment_range_end, size, state
         INNER JOIN
             system.filesystem_cache AS caches
         ON data_paths.cache_path = caches.cache_path
+        WHERE caches.cache_name = '__tmp_internal'
     )
     WHERE endsWith(local_path, 'data.bin')
     FORMAT Vertical;
@@ -301,25 +304,25 @@ file_segment_range_begin: 0
 file_segment_range_end:   1659
 size:                     1660
 state:                    DOWNLOADED
-SELECT count() FROM (SELECT arrayJoin(cache_paths) AS cache_path, local_path, remote_path FROM system.remote_data_paths ) AS data_paths INNER JOIN system.filesystem_cache AS caches ON data_paths.cache_path = caches.cache_path
+SELECT count() FROM (SELECT arrayJoin(cache_paths) AS cache_path, local_path, remote_path FROM system.remote_data_paths ) AS data_paths INNER JOIN system.filesystem_cache AS caches ON data_paths.cache_path = caches.cache_path WHERE caches.cache_name = '__tmp_internal'
 9
-SELECT count(), sum(size) FROM system.filesystem_cache
+SELECT count(), sum(size) FROM system.filesystem_cache WHERE cache_name = '__tmp_internal'
 9	2131
-SELECT count(), sum(size) FROM system.filesystem_cache
+SELECT count(), sum(size) FROM system.filesystem_cache WHERE cache_name = '__tmp_internal'
 9	2131
 INSERT INTO test_02241 SELECT number, toString(number) FROM numbers(100) SETTINGS enable_filesystem_cache_on_write_operations=0
-SELECT count(), sum(size) FROM system.filesystem_cache
+SELECT count(), sum(size) FROM system.filesystem_cache WHERE cache_name = '__tmp_internal'
 9	2131
 INSERT INTO test_02241 SELECT number, toString(number) FROM numbers(100)
 INSERT INTO test_02241 SELECT number, toString(number) FROM numbers(300, 10000)
-SELECT count(), sum(size) FROM system.filesystem_cache
+SELECT count(), sum(size) FROM system.filesystem_cache WHERE cache_name = '__tmp_internal'
 27	84396
 SYSTEM START MERGES test_02241
 OPTIMIZE TABLE test_02241 FINAL
-SELECT count(), sum(size) FROM system.filesystem_cache
+SELECT count(), sum(size) FROM system.filesystem_cache WHERE cache_name = '__tmp_internal'
 36	167711
 ALTER TABLE test_02241 UPDATE value = 'kek' WHERE key = 100
-SELECT count(), sum(size) FROM system.filesystem_cache
+SELECT count(), sum(size) FROM system.filesystem_cache WHERE cache_name = '__tmp_internal'
 46	251128
 INSERT INTO test_02241 SELECT number, toString(number) FROM numbers(5000000)
 SYSTEM FLUSH LOGS query_log

--- a/tests/queries/0_stateless/02241_filesystem_cache_on_write_operations.sh
+++ b/tests/queries/0_stateless/02241_filesystem_cache_on_write_operations.sh
@@ -2,7 +2,7 @@
 # Tags: long, no-fasttest, no-parallel, no-object-storage, no-random-settings, no-flaky-check
 # no-flaky-check: Too slow
 
-# set -x
+set -e
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -10,15 +10,17 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=./cache.lib
 . "$CUR_DIR"/cache.lib
 
-for STORAGE_POLICY in 's3_cache' 'local_cache' 'azure_cache'; do
-    echo "Using storage policy: $STORAGE_POLICY"
+for disk in 's3_disk' 'local_disk' 'azure'; do
+    echo "Using disk: $disk"
 
+    cache_path=02241_filesystem_cache_on_write_operations_$disk
     $CLICKHOUSE_CLIENT --echo --query "DROP TABLE IF EXISTS test_02241"
-    $CLICKHOUSE_CLIENT --echo --query "CREATE TABLE test_02241 (key UInt32, value String) Engine=MergeTree() ORDER BY key SETTINGS storage_policy='$STORAGE_POLICY', min_bytes_for_wide_part = 10485760, compress_marks=false, compress_primary_key=false, min_bytes_for_full_part_storage=0, ratio_of_defaults_for_sparse_serialization = 1, write_marks_for_substreams_in_compact_parts=1, serialization_info_version='basic'"
+    $CLICKHOUSE_CLIENT --echo --query "CREATE TABLE test_02241 (key UInt32, value String) Engine=MergeTree() ORDER BY key SETTINGS disk=disk(type='cache', path='$cache_path', disk='$disk', max_size=10_000_000_000, cache_on_write_operations=1), min_bytes_for_wide_part = 10485760, compress_marks=false, compress_primary_key=false, min_bytes_for_full_part_storage=0, ratio_of_defaults_for_sparse_serialization = 1, write_marks_for_substreams_in_compact_parts=1, serialization_info_version='basic'"
     $CLICKHOUSE_CLIENT --echo --query "SYSTEM STOP MERGES test_02241"
+    cache_name=$($CLICKHOUSE_CLIENT -q "SELECT name FROM system.disks WHERE cache_path LIKE '%$cache_path'")
 
     echo "SYSTEM DROP FILESYSTEM CACHE"
-    drop_filesystem_cache
+    drop_filesystem_cache $cache_name
 
     $CLICKHOUSE_CLIENT --echo --query "SELECT file_segment_range_begin, file_segment_range_end, size, state
     FROM
@@ -32,12 +34,13 @@ for STORAGE_POLICY in 's3_cache' 'local_cache' 'azure_cache'; do
         INNER JOIN
             system.filesystem_cache AS caches
         ON data_paths.cache_path = caches.cache_path
+        WHERE caches.cache_name = '$cache_name'
     )
     WHERE endsWith(local_path, 'data.bin')
     FORMAT Vertical"
 
-    $CLICKHOUSE_CLIENT --echo --query "SELECT count() FROM (SELECT arrayJoin(cache_paths) AS cache_path, local_path, remote_path FROM system.remote_data_paths ) AS data_paths INNER JOIN system.filesystem_cache AS caches ON data_paths.cache_path = caches.cache_path"
-    $CLICKHOUSE_CLIENT --echo --query "SELECT count(), sum(size) FROM system.filesystem_cache"
+    $CLICKHOUSE_CLIENT --echo --query "SELECT count() FROM (SELECT arrayJoin(cache_paths) AS cache_path, local_path, remote_path FROM system.remote_data_paths ) AS data_paths INNER JOIN system.filesystem_cache AS caches ON data_paths.cache_path = caches.cache_path WHERE caches.cache_name = '$cache_name'"
+    $CLICKHOUSE_CLIENT --echo --query "SELECT count(), sum(size) FROM system.filesystem_cache WHERE cache_name = '$cache_name'"
 
     $CLICKHOUSE_CLIENT --echo --enable_filesystem_cache_on_write_operations=1 --query "INSERT INTO test_02241 SELECT number, toString(number) FROM numbers(100)"
 
@@ -53,25 +56,24 @@ for STORAGE_POLICY in 's3_cache' 'local_cache' 'azure_cache'; do
         INNER JOIN
             system.filesystem_cache AS caches
         ON data_paths.cache_path = caches.cache_path
+        WHERE caches.cache_name = '$cache_name'
     )
     WHERE endsWith(local_path, 'data.bin')
     FORMAT Vertical"
 
-    $CLICKHOUSE_CLIENT --echo --query "SELECT count() FROM (SELECT arrayJoin(cache_paths) AS cache_path, local_path, remote_path FROM system.remote_data_paths ) AS data_paths INNER JOIN system.filesystem_cache AS caches ON data_paths.cache_path = caches.cache_path"
-    $CLICKHOUSE_CLIENT --echo --query "SELECT count(), sum(size) FROM system.filesystem_cache"
-
-    $CLICKHOUSE_CLIENT --echo --query "SELECT count() FROM system.filesystem_cache WHERE cache_hits > 0"
+    $CLICKHOUSE_CLIENT --echo --query "SELECT count() FROM (SELECT arrayJoin(cache_paths) AS cache_path, local_path, remote_path FROM system.remote_data_paths ) AS data_paths INNER JOIN system.filesystem_cache AS caches ON data_paths.cache_path = caches.cache_path WHERE caches.cache_name = '$cache_name'"
+    $CLICKHOUSE_CLIENT --echo --query "SELECT count(), sum(size) FROM system.filesystem_cache WHERE cache_name = '$cache_name'"
 
     $CLICKHOUSE_CLIENT --echo --query "SELECT * FROM test_02241 FORMAT Null"
-    $CLICKHOUSE_CLIENT --echo --query "SELECT count() FROM system.filesystem_cache WHERE cache_hits > 0"
+    $CLICKHOUSE_CLIENT --echo --query "SELECT count() FROM system.filesystem_cache WHERE cache_hits > 0 AND cache_name = '$cache_name'"
 
     $CLICKHOUSE_CLIENT --echo --query "SELECT * FROM test_02241 FORMAT Null"
-    $CLICKHOUSE_CLIENT --echo --query "SELECT count() FROM system.filesystem_cache WHERE cache_hits > 0"
+    $CLICKHOUSE_CLIENT --echo --query "SELECT count() FROM system.filesystem_cache WHERE cache_hits > 0 AND cache_name = '$cache_name'"
 
-    $CLICKHOUSE_CLIENT --echo --query "SELECT count(), sum(size) size FROM system.filesystem_cache"
+    $CLICKHOUSE_CLIENT --echo --query "SELECT count(), sum(size) size FROM system.filesystem_cache WHERE cache_name = '$cache_name'"
 
     echo "SYSTEM DROP FILESYSTEM CACHE"
-    drop_filesystem_cache
+    drop_filesystem_cache $cache_name
 
     $CLICKHOUSE_CLIENT --echo --enable_filesystem_cache_on_write_operations=1 --query "INSERT INTO test_02241 SELECT number, toString(number) FROM numbers(100, 200)"
 
@@ -87,29 +89,30 @@ for STORAGE_POLICY in 's3_cache' 'local_cache' 'azure_cache'; do
         INNER JOIN
             system.filesystem_cache AS caches
         ON data_paths.cache_path = caches.cache_path
+        WHERE caches.cache_name = '$cache_name'
     )
     WHERE endsWith(local_path, 'data.bin')
     FORMAT Vertical;"
 
-    $CLICKHOUSE_CLIENT --echo --query "SELECT count() FROM (SELECT arrayJoin(cache_paths) AS cache_path, local_path, remote_path FROM system.remote_data_paths ) AS data_paths INNER JOIN system.filesystem_cache AS caches ON data_paths.cache_path = caches.cache_path"
-    $CLICKHOUSE_CLIENT --echo --query "SELECT count(), sum(size) FROM system.filesystem_cache"
+    $CLICKHOUSE_CLIENT --echo --query "SELECT count() FROM (SELECT arrayJoin(cache_paths) AS cache_path, local_path, remote_path FROM system.remote_data_paths ) AS data_paths INNER JOIN system.filesystem_cache AS caches ON data_paths.cache_path = caches.cache_path WHERE caches.cache_name = '$cache_name'"
+    $CLICKHOUSE_CLIENT --echo --query "SELECT count(), sum(size) FROM system.filesystem_cache WHERE cache_name = '$cache_name'"
 
-    $CLICKHOUSE_CLIENT --echo --query "SELECT count(), sum(size) FROM system.filesystem_cache"
+    $CLICKHOUSE_CLIENT --echo --query "SELECT count(), sum(size) FROM system.filesystem_cache WHERE cache_name = '$cache_name'"
     $CLICKHOUSE_CLIENT --echo --enable_filesystem_cache_on_write_operations=1 --query "INSERT INTO test_02241 SELECT number, toString(number) FROM numbers(100) SETTINGS enable_filesystem_cache_on_write_operations=0"
-    $CLICKHOUSE_CLIENT --echo --query "SELECT count(), sum(size) FROM system.filesystem_cache"
+    $CLICKHOUSE_CLIENT --echo --query "SELECT count(), sum(size) FROM system.filesystem_cache WHERE cache_name = '$cache_name'"
 
     $CLICKHOUSE_CLIENT --echo --enable_filesystem_cache_on_write_operations=1 --query "INSERT INTO test_02241 SELECT number, toString(number) FROM numbers(100)"
     $CLICKHOUSE_CLIENT --echo --enable_filesystem_cache_on_write_operations=1 --query "INSERT INTO test_02241 SELECT number, toString(number) FROM numbers(300, 10000)"
-    $CLICKHOUSE_CLIENT --echo --query "SELECT count(), sum(size) FROM system.filesystem_cache"
+    $CLICKHOUSE_CLIENT --echo --query "SELECT count(), sum(size) FROM system.filesystem_cache WHERE cache_name = '$cache_name'"
 
     $CLICKHOUSE_CLIENT --echo --query "SYSTEM START MERGES test_02241"
 
     $CLICKHOUSE_CLIENT --echo --enable_filesystem_cache_on_write_operations=1 --query "OPTIMIZE TABLE test_02241 FINAL"
 
-    $CLICKHOUSE_CLIENT --echo --query "SELECT count(), sum(size) FROM system.filesystem_cache"
+    $CLICKHOUSE_CLIENT --echo --query "SELECT count(), sum(size) FROM system.filesystem_cache WHERE cache_name = '$cache_name'"
 
     $CLICKHOUSE_CLIENT --echo --enable_filesystem_cache_on_write_operations=1 --mutations_sync=2 --query "ALTER TABLE test_02241 UPDATE value = 'kek' WHERE key = 100"
-    $CLICKHOUSE_CLIENT --echo --query "SELECT count(), sum(size) FROM system.filesystem_cache"
+    $CLICKHOUSE_CLIENT --echo --query "SELECT count(), sum(size) FROM system.filesystem_cache WHERE cache_name = '$cache_name'"
     $CLICKHOUSE_CLIENT --echo --enable_filesystem_cache_on_write_operations=1 --query "INSERT INTO test_02241 SELECT number, toString(number) FROM numbers(5000000)"
 
     $CLICKHOUSE_CLIENT --echo --query "SYSTEM FLUSH LOGS query_log"
@@ -129,4 +132,4 @@ for STORAGE_POLICY in 's3_cache' 'local_cache' 'azure_cache'; do
 
     $CLICKHOUSE_CLIENT --echo --query "SELECT count() FROM test_02241"
     $CLICKHOUSE_CLIENT --echo --query "SELECT count() FROM test_02241 WHERE value LIKE '%010%'"
-done
+done |& sed 's/__tmp_internal_[0-9]*/__tmp_internal/'

--- a/tests/queries/0_stateless/02286_drop_filesystem_cache.reference
+++ b/tests/queries/0_stateless/02286_drop_filesystem_cache.reference
@@ -1,4 +1,4 @@
-Using storage policy: s3_cache
+Using disk: s3_disk
 0
 2
 0
@@ -7,7 +7,7 @@ Using storage policy: s3_cache
 1
 1
 0
-Using storage policy: local_cache
+Using disk: local_disk
 0
 2
 0
@@ -16,7 +16,7 @@ Using storage policy: local_cache
 1
 1
 0
-Using storage policy: azure_cache
+Using disk: azure
 0
 2
 0

--- a/tests/queries/0_stateless/02286_drop_filesystem_cache.sh
+++ b/tests/queries/0_stateless/02286_drop_filesystem_cache.sh
@@ -10,36 +10,41 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=./cache.lib
 . "$CUR_DIR"/cache.lib
 
-for STORAGE_POLICY in 's3_cache' 'local_cache' 'azure_cache'; do
-    echo "Using storage policy: $STORAGE_POLICY"
-    $CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS test_02286"
+set -e
 
+for disk in 's3_disk' 'local_disk' 'azure'; do
+    echo "Using disk: $disk"
+
+    cache_path=drop_filesystem_cache_test_$disk
+    $CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS test_02286"
     $CLICKHOUSE_CLIENT --query "CREATE TABLE test_02286 (key UInt32, value String)
-                                   Engine=MergeTree()
-                                   ORDER BY key
-                                   SETTINGS storage_policy='$STORAGE_POLICY', min_bytes_for_wide_part = 10485760"
+                                Engine=MergeTree()
+                                ORDER BY key
+                                SETTINGS disk=disk(type='cache', path='$cache_path', disk='$disk', max_size=10_000_000_000, cache_on_write_operations=1), min_bytes_for_wide_part = 10485760"
+
+    cache_name=$($CLICKHOUSE_CLIENT -q "SELECT name FROM system.disks WHERE cache_path LIKE '%$cache_path'")
 
     $CLICKHOUSE_CLIENT --query "SYSTEM STOP MERGES test_02286"
-    drop_filesystem_cache
+    drop_filesystem_cache $cache_name
 
-    $CLICKHOUSE_CLIENT --query "SELECT count() FROM system.filesystem_cache"
+    $CLICKHOUSE_CLIENT --query "SELECT count() FROM system.filesystem_cache WHERE cache_name = '$cache_name'"
     $CLICKHOUSE_CLIENT --enable_filesystem_cache_on_write_operations=0 --query "INSERT INTO test_02286 SELECT number, toString(number) FROM numbers(100)"
 
     $CLICKHOUSE_CLIENT --query "SELECT * FROM test_02286 FORMAT Null"
-    $CLICKHOUSE_CLIENT --query "SELECT count() FROM system.filesystem_cache"
+    $CLICKHOUSE_CLIENT --query "SELECT count() FROM system.filesystem_cache WHERE cache_name = '$cache_name'"
 
-    drop_filesystem_cache
-    $CLICKHOUSE_CLIENT --query "SELECT count() FROM system.filesystem_cache"
+    drop_filesystem_cache $cache_name
+    $CLICKHOUSE_CLIENT --query "SELECT count() FROM system.filesystem_cache WHERE cache_name = '$cache_name'"
 
     $CLICKHOUSE_CLIENT --query "SELECT * FROM test_02286 FORMAT Null"
-    $CLICKHOUSE_CLIENT --query "SELECT count() FROM system.filesystem_cache"
+    $CLICKHOUSE_CLIENT --query "SELECT count() FROM system.filesystem_cache WHERE cache_name = '$cache_name'"
 
     $CLICKHOUSE_CLIENT --multiline --query "SYSTEM DROP FILESYSTEM CACHE 'ff'; --{serverError 36}"
 
-    $CLICKHOUSE_CLIENT --query "SELECT count() FROM system.filesystem_cache"
+    $CLICKHOUSE_CLIENT --query "SELECT count() FROM system.filesystem_cache WHERE cache_name = '$cache_name'"
 
     $CLICKHOUSE_CLIENT --query "SELECT * FROM test_02286 FORMAT Null"
-    $CLICKHOUSE_CLIENT --query "SELECT count() FROM system.filesystem_cache"
+    $CLICKHOUSE_CLIENT --query "SELECT count() FROM system.filesystem_cache WHERE cache_name = '$cache_name'"
     $CLICKHOUSE_CLIENT --query "SELECT count()
                                    FROM (
                                        SELECT
@@ -50,17 +55,18 @@ for STORAGE_POLICY in 's3_cache' 'local_cache' 'azure_cache'; do
                                            system.remote_data_paths
                                        ) AS data_paths
                                    INNER JOIN system.filesystem_cache AS caches
-                                   ON data_paths.cache_path = caches.cache_path"
+                                   ON data_paths.cache_path = caches.cache_path
+                                   WHERE caches.cache_name = '$cache_name'"
 
     $CLICKHOUSE_CLIENT --query "DROP TABLE test_02286 SYNC"
 
-    cache_entries=$($CLICKHOUSE_CLIENT --query "SELECT count() FROM system.filesystem_cache")
+    cache_entries=$($CLICKHOUSE_CLIENT --query "SELECT count() FROM system.filesystem_cache WHERE cache_name = '$cache_name'")
     echo "$cache_entries"
     # system.remote_data_paths is very slow for web disks, so let's avoid extra
     # call to it (we need it only for debugging of this tests, and only when we
     # have cache entries, which tests does not expect)
     if [ $cache_entries -gt 0 ]; then
-        $CLICKHOUSE_CLIENT --query "SELECT cache_path FROM system.filesystem_cache"
+        $CLICKHOUSE_CLIENT --query "SELECT cache_path FROM system.filesystem_cache WHERE cache_name = '$cache_name'"
         $CLICKHOUSE_CLIENT --query "SELECT cache_path, local_path
                                        FROM (
                                            SELECT
@@ -71,7 +77,8 @@ for STORAGE_POLICY in 's3_cache' 'local_cache' 'azure_cache'; do
                                                system.remote_data_paths
                                            ) AS data_paths
                                        INNER JOIN system.filesystem_cache AS caches
-                                       ON data_paths.cache_path = caches.cache_path "
+                                       ON data_paths.cache_path = caches.cache_path
+                                       WHERE caches.cache_name = '$cache_name'"
     fi
 
     $CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS test_022862"

--- a/tests/queries/0_stateless/cache.lib
+++ b/tests/queries/0_stateless/cache.lib
@@ -2,8 +2,9 @@
 
 function drop_filesystem_cache()
 {
-    while [ $($CLICKHOUSE_CURL -sS "$CLICKHOUSE_URL" -d "SELECT count() FROM system.filesystem_cache") -gt 0 ]; do
-        $CLICKHOUSE_CURL -sS "$CLICKHOUSE_URL" -d "SYSTEM DROP FILESYSTEM CACHE"
+    local cache_name=$1 && shift
+    while [ $($CLICKHOUSE_CURL -sS "$CLICKHOUSE_URL" -d "SELECT count() FROM system.filesystem_cache WHERE cache_name = '$cache_name'") -gt 0 ]; do
+        $CLICKHOUSE_CURL -sS "$CLICKHOUSE_URL" -d "SYSTEM DROP FILESYSTEM CACHE '$cache_name'"
         sleep 1
     done
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes: https://github.com/ClickHouse/ClickHouse/issues/75876