### PR TITLE
Proper handle sparse nullable columns in inner/left joins

### DIFF
--- a/src/Interpreters/JoinUtils.cpp
+++ b/src/Interpreters/JoinUtils.cpp
@@ -234,7 +234,7 @@ void removeColumnNullability(ColumnWithTypeAndName & column)
 
         if (column.column && column.column->isNullable())
         {
-            column.column = column.column->convertToFullColumnIfConst();
+            column.column = column.column->convertToFullIfNeeded();
             const auto * nullable_col = checkAndGetColumn<ColumnNullable>(column.column.get());
             if (!nullable_col)
             {

--- a/tests/queries/0_stateless/03773_nullable_sparse_join.sql
+++ b/tests/queries/0_stateless/03773_nullable_sparse_join.sql
@@ -1,0 +1,16 @@
+DROP TABLE IF EXISTS t1;
+DROP TABLE IF EXISTS t2;
+
+SET max_partitions_per_insert_block=99999999;
+SET compatibility='23.3';
+
+CREATE TABLE t1 (`c1` String, `c3` String, `c2` DateTime) ENGINE = MergeTree PARTITION BY toYYYYMM(c2) ORDER BY c1;
+CREATE TABLE t2 (`c4` Int64) ENGINE = MergeTree ORDER BY c4;
+
+INSERT INTO t1 SELECT * FROM generateRandom() LIMIT 9;
+INSERT INTO t2 SELECT * FROM generateRandom() LIMIT 9;
+
+SELECT lo.c4 FROM t1 AS l INNER JOIN t2 AS lo ON toInt64OrNull(l.c3) = lo.c4 FORMAT NULL;
+
+DROP TABLE t1;
+DROP TABLE t2;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix join results when the right-side join key is a sparse column. This closes #92920. I can only reproduce the bug with `set compatibility='23.3'`. Not sure if it should be backported.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.177`
- Backported to: `25.12.5.10`, `25.11.8.11`, `25.10.6.12`, `25.8.16.9`
<!-- ch-version-info:end -->