### PR TITLE
Fix possible "Cannot finalize buffer after cancellation" in estimateCompressionRatio()

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionEstimateCompressionRatio.cpp
+++ b/src/AggregateFunctions/AggregateFunctionEstimateCompressionRatio.cpp
@@ -59,11 +59,12 @@ struct AggregationFunctionEstimateCompressionRatioData
 
     [[maybe_unused]] ~AggregationFunctionEstimateCompressionRatioData()
     {
-        /// WriteBuffer can be cancelled on exception
-        if (compressed_buf && !compressed_buf->isCanceled())
-            compressed_buf->finalize();
-        if (null_buf && !null_buf->isCanceled())
-            null_buf->finalize();
+        /// Real cancellation can happen only in case of exception
+        /// In other cases the data will be read via finalizeAndGetSizes()
+        if (compressed_buf)
+            compressed_buf->cancel();
+        if (null_buf)
+            null_buf->cancel();
     }
 };
 

--- a/src/AggregateFunctions/AggregateFunctionEstimateCompressionRatio.cpp
+++ b/src/AggregateFunctions/AggregateFunctionEstimateCompressionRatio.cpp
@@ -59,9 +59,10 @@ struct AggregationFunctionEstimateCompressionRatioData
 
     [[maybe_unused]] ~AggregationFunctionEstimateCompressionRatioData()
     {
-        if (compressed_buf)
+        /// WriteBuffer can be cancelled on exception
+        if (compressed_buf && !compressed_buf->isCanceled())
             compressed_buf->finalize();
-        if (null_buf)
+        if (null_buf && !null_buf->isCanceled())
             null_buf->finalize();
     }
 };


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix possible `Cannot finalize buffer after cancellation` in `estimateCompressionRatio()`. Fixes: https://github.com/ClickHouse/ClickHouse/issues/87380

Fixes https://github.com/ClickHouse/clickhouse-core-incidents/issues/1265.