### PR TITLE
Limit `temporary_files_buffer_size`

### DIFF
--- a/src/Interpreters/JoinOperator.cpp
+++ b/src/Interpreters/JoinOperator.cpp
@@ -20,6 +20,7 @@ namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
     extern const int INCORRECT_DATA;
+    extern const int ARGUMENT_OUT_OF_BOUND;
 }
 
 namespace Setting
@@ -152,6 +153,9 @@ JoinSettings::JoinSettings(const Settings & query_settings)
     allow_dynamic_type_in_join_keys = query_settings[Setting::allow_dynamic_type_in_join_keys];
     use_join_disjunctions_push_down = query_settings[Setting::use_join_disjunctions_push_down];
     enable_lazy_columns_replication = query_settings[Setting::enable_lazy_columns_replication];
+
+    if (temporary_files_buffer_size > 1_GiB)
+        throw Exception(ErrorCodes::ARGUMENT_OUT_OF_BOUND, "Too large `temporary_files_buffer_size`, maximum 1 GiB");
 }
 
 JoinSettings::JoinSettings(const QueryPlanSerializationSettings & settings)

--- a/src/Interpreters/ProcessList.cpp
+++ b/src/Interpreters/ProcessList.cpp
@@ -64,6 +64,7 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
     extern const int QUERY_WAS_CANCELLED;
     extern const int TIMEOUT_EXCEEDED;
+    extern const int ARGUMENT_OUT_OF_BOUND;
 }
 
 
@@ -279,6 +280,10 @@ ProcessList::EntryPtr ProcessList::insert(
                     .compression_codec = settings[Setting::temporary_files_codec],
                     .buffer_size = settings[Setting::temporary_files_buffer_size],
                 };
+
+                if (temporary_data_on_disk_settings.buffer_size > 1_GiB)
+                    throw Exception(ErrorCodes::ARGUMENT_OUT_OF_BOUND, "Too large `temporary_files_buffer_size`, maximum 1 GiB");
+
                 query_context->setTempDataOnDisk(std::make_shared<TemporaryDataOnDiskScope>(
                     user_process_list.user_temp_data_on_disk, std::move(temporary_data_on_disk_settings)));
             }

--- a/tests/queries/0_stateless/03775_too_large_temporary_files_buffer_size.sql
+++ b/tests/queries/0_stateless/03775_too_large_temporary_files_buffer_size.sql
@@ -1,0 +1,1 @@
+SELECT number FROM system.numbers GROUP BY number SETTINGS max_bytes_before_external_group_by = 1, temporary_files_buffer_size = 9223372036854775806, group_by_two_level_threshold = 1; -- { serverError ARGUMENT_OUT_OF_BOUND }


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Closes #93065.