### PR TITLE
Fix demangling of `char8_t` literal template parameters

### DIFF
--- a/tests/queries/0_stateless/03775_demangle_char8_t_literal_template_parameter.reference
+++ b/tests/queries/0_stateless/03775_demangle_char8_t_literal_template_parameter.reference
@@ -1,0 +1,4 @@
+int f<(char8_t)99>()
+int f<(char16_t)99>()
+int f<(char32_t)99>()
+DB::IAggregateFunctionHelper<DB::AggregateFunctionUniqCombined<DB::IPv4, (char8_t)12, unsigned int>>::createAndDeserializeBatch(DB::PODArray<char*, 4096ul, Allocator<false, false>, 63ul, 64ul>&, char*, unsigned long, unsigned long, DB::ReadBuffer&, std::__1::optional<unsigned long>, DB::Arena*) const

--- a/tests/queries/0_stateless/03775_demangle_char8_t_literal_template_parameter.sql
+++ b/tests/queries/0_stateless/03775_demangle_char8_t_literal_template_parameter.sql
@@ -1,0 +1,4 @@
+SELECT demangle('_Z1fILDu99EEiv');
+SELECT demangle('_Z1fILDs99EEiv');
+SELECT demangle('_Z1fILDi99EEiv');
+SELECT demangle('_ZNK2DB24IAggregateFunctionHelperINS_29AggregateFunctionUniqCombinedINS_4IPv4ELDu12EjEEE25createAndDeserializeBatchERNS_8PODArrayIPcLm4096E9AllocatorILb0ELb0EELm63ELm64EEES6_mmRNS_10ReadBufferENSt3__18optionalImEEPNS_5ArenaE');


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
In previous versions, some of C++ function names were displayed incorrectly ("mangled") in the `system.trace_log` and `system.symbols`, and the `demangle` function didn't process them well. Closes #93074.