### PR TITLE
Use minimal debug info in the case of OMIT_HEAVY_DEBUG_SYMBOLS

### DIFF
--- a/contrib/arrow-cmake/CMakeLists.txt
+++ b/contrib/arrow-cmake/CMakeLists.txt
@@ -583,6 +583,6 @@ endforeach ()
 
 # The library is large - avoid bloat.
 if (OMIT_HEAVY_DEBUG_SYMBOLS)
-    target_compile_options (_arrow PRIVATE -g0)
-    target_compile_options (_parquet PRIVATE -g0)
+    target_compile_options (_arrow PRIVATE -g1)
+    target_compile_options (_parquet PRIVATE -g1)
 endif()

--- a/contrib/aws-cmake/CMakeLists.txt
+++ b/contrib/aws-cmake/CMakeLists.txt
@@ -395,7 +395,7 @@ aws_set_thread_name_method(_aws)
 
 # The library is large - avoid bloat.
 if (OMIT_HEAVY_DEBUG_SYMBOLS)
-    target_compile_options (_aws PRIVATE -g0)
+    target_compile_options (_aws PRIVATE -g1)
 endif()
 
 add_library(ch_contrib::aws_s3 ALIAS _aws)

--- a/contrib/curl-cmake/CMakeLists.txt
+++ b/contrib/curl-cmake/CMakeLists.txt
@@ -206,7 +206,7 @@ target_link_libraries (_curl PRIVATE OpenSSL::SSL ch_contrib::c-ares)
 
 # The library is large - avoid bloat (XXX: is it?)
 if (OMIT_HEAVY_DEBUG_SYMBOLS)
-    target_compile_options (_curl PRIVATE -g0)
+    target_compile_options (_curl PRIVATE -g1)
 endif()
 
 add_library (ch_contrib::curl ALIAS _curl)

--- a/contrib/google-cloud-cpp-cmake/CMakeLists.txt
+++ b/contrib/google-cloud-cpp-cmake/CMakeLists.txt
@@ -129,7 +129,7 @@ target_link_libraries(_gcloud INTERFACE ${GOOGLE_CLOUD_CPP_PRIVATE_LIBS} ${GOOGL
 # The library is large - avoid bloat.
 if(OMIT_HEAVY_DEBUG_SYMBOLS)
     foreach(lib ${GOOGLE_CLOUD_CPP_PRIVATE_LIBS})
-        target_compile_options(${lib} PRIVATE -g0)
+        target_compile_options(${lib} PRIVATE -g1)
     endforeach()
 endif()
 

--- a/contrib/vectorscan-cmake/CMakeLists.txt
+++ b/contrib/vectorscan-cmake/CMakeLists.txt
@@ -275,7 +275,7 @@ add_library (_vectorscan ${SRCS})
 
 # library has too much debug information
 if (OMIT_HEAVY_DEBUG_SYMBOLS)
-    target_compile_options (_vectorscan PRIVATE -g0)
+    target_compile_options (_vectorscan PRIVATE -g1)
 endif()
 
 target_include_directories (_vectorscan SYSTEM PUBLIC "${LIBRARY_DIR}/src")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -90,7 +90,7 @@ if (OMIT_HEAVY_DEBUG_SYMBOLS)
         Functions/GatherUtils/createArraySink.cpp
         Functions/GatherUtils/resizeConstantSize.cpp
         Functions/GatherUtils/resizeDynamicSize.cpp
-        PROPERTIES COMPILE_FLAGS -g0)
+        PROPERTIES COMPILE_FLAGS -g1)
 endif()
 
 add_headers_and_sources(clickhouse_common_io Common)

--- a/src/Dictionaries/CMakeLists.txt
+++ b/src/Dictionaries/CMakeLists.txt
@@ -14,7 +14,7 @@ if (OMIT_HEAVY_DEBUG_SYMBOLS)
         CacheDictionary.cpp
         RangeHashedDictionary.cpp
         DirectDictionary.cpp
-        PROPERTIES COMPILE_FLAGS -g0)
+        PROPERTIES COMPILE_FLAGS -g1)
 endif()
 
 extract_into_parent_list(clickhouse_dictionaries_sources dbms_sources

--- a/src/Functions/CMakeLists.txt
+++ b/src/Functions/CMakeLists.txt
@@ -67,7 +67,7 @@ extract_into_parent_list(clickhouse_functions_headers dbms_headers
 
 add_library(clickhouse_functions_obj OBJECT ${clickhouse_functions_headers} ${clickhouse_functions_sources})
 if (OMIT_HEAVY_DEBUG_SYMBOLS)
-    target_compile_options(clickhouse_functions_obj PRIVATE "-g0")
+    target_compile_options(clickhouse_functions_obj PRIVATE "-g1")
 endif()
 
 list (APPEND OBJECT_LIBS $<TARGET_OBJECTS:clickhouse_functions_obj>)

--- a/src/Functions/GatherUtils/CMakeLists.txt
+++ b/src/Functions/GatherUtils/CMakeLists.txt
@@ -20,7 +20,7 @@ add_library(clickhouse_functions_gatherutils ${clickhouse_functions_gatherutils_
 target_link_libraries(clickhouse_functions_gatherutils PRIVATE dbms)
 
 if (OMIT_HEAVY_DEBUG_SYMBOLS)
-    target_compile_options(clickhouse_functions_gatherutils PRIVATE "-g0")
+    target_compile_options(clickhouse_functions_gatherutils PRIVATE "-g1")
 endif()
 
 set_target_properties(clickhouse_functions_gatherutils PROPERTIES COMPILE_FLAGS "${X86_INTRINSICS_FLAGS}")

--- a/src/Functions/JSONPath/CMakeLists.txt
+++ b/src/Functions/JSONPath/CMakeLists.txt
@@ -8,5 +8,5 @@ target_link_libraries(clickhouse_functions_jsonpath PRIVATE dbms)
 target_link_libraries(clickhouse_functions_jsonpath PRIVATE clickhouse_parsers)
 
 if (OMIT_HEAVY_DEBUG_SYMBOLS)
-    target_compile_options(clickhouse_functions_jsonpath PRIVATE "-g0")
+    target_compile_options(clickhouse_functions_jsonpath PRIVATE "-g1")
 endif()

--- a/src/Functions/Kusto/CMakeLists.txt
+++ b/src/Functions/Kusto/CMakeLists.txt
@@ -4,5 +4,5 @@ add_library(clickhouse_functions_kusto OBJECT ${clickhouse_functions_kusto_sourc
 target_link_libraries(clickhouse_functions_kusto PRIVATE dbms clickhouse_functions_gatherutils)
 
 if (OMIT_HEAVY_DEBUG_SYMBOLS)
-    target_compile_options(clickhouse_functions_kusto PRIVATE "-g0")
+    target_compile_options(clickhouse_functions_kusto PRIVATE "-g1")
 endif()

--- a/src/Functions/URL/CMakeLists.txt
+++ b/src/Functions/URL/CMakeLists.txt
@@ -5,7 +5,7 @@ target_link_libraries(clickhouse_functions_url PRIVATE dbms)
 set_source_files_properties(tldLookup.generated.cpp PROPERTIES COMPILE_FLAGS -Wno-shorten-64-to-32)
 
 if (OMIT_HEAVY_DEBUG_SYMBOLS)
-    target_compile_options(clickhouse_functions_url PRIVATE "-g0")
+    target_compile_options(clickhouse_functions_url PRIVATE "-g1")
 endif()
 
 # TODO: move Functions/Regexps.h to some lib and use here

--- a/src/Functions/array/CMakeLists.txt
+++ b/src/Functions/array/CMakeLists.txt
@@ -21,5 +21,5 @@ if (TARGET ch_contrib::vectorscan)
 endif()
 
 if (OMIT_HEAVY_DEBUG_SYMBOLS)
-    target_compile_options(clickhouse_functions_array PRIVATE "-g0")
+    target_compile_options(clickhouse_functions_array PRIVATE "-g1")
 endif()


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Use minimal debug info instead of no debug info for heavy translation units, such as functions.

I was working with the introspection of the ClickHouse binary, comparing coverage from the CI with the actual code running on production (from the system.trace_log), and there was a thought - let's try to record the source file name for every symbol.

But in the current build, there is almost zero info in certain areas:
`SELECT unit_name, length(ranges), arraySum(x -> x.2 - x.1, ranges) FROM file('ch', DWARF) WHERE tag = 'compile_unit' AND unit_name LIKE './src/Functions/%' ORDER BY 3 DESC`

Adding minimal debug info still significantly increases the total size (15..20%):

```
milovidov@milovidov-pc:~/work/ClickHouse/build/programs$ ls -l clickhouse
-rwxrwxr-x 1 milovidov milovidov 3267135704 dec 25 21:52 clickhouse
...
milovidov@milovidov-pc:~/work/ClickHouse/build/programs$ ls -l clickhouse
-rwxrwxr-x 1 milovidov milovidov 3743434680 dec 25 22:57 clickhouse
```

But it might be worth it.