### PR TITLE
Disable dictionary layout settings while fuzzing

### DIFF
--- a/src/Client/BuzzHouse/Generator/SQLTable.cpp
+++ b/src/Client/BuzzHouse/Generator/SQLTable.cpp
@@ -2685,19 +2685,21 @@ void StatementGenerator::generateNextCreateDictionary(RandomGenerator & rg, Crea
         cd->mutable_cluster()->set_cluster(next.cluster.value());
     }
 
-    /// Layout properties
-    const auto & layoutSettings = allDictionaryLayoutSettings.at(dl);
     layout->set_layout(dl);
+    /*
+    /// Layout properties
+    /// Don't set random dictionary properties that can overhelm the server
+    const auto & layoutSettings = allDictionaryLayoutSettings.at(dl);
     if (!layoutSettings.empty() && rg.nextSmallNumber() < 5)
     {
         svs = svs ? svs : layout->mutable_setting_values();
         generateSettingValues(rg, layoutSettings, svs);
-    }
+    }*/
     if (dl == COMPLEX_KEY_SSD_CACHE || dl == SSD_CACHE)
     {
         /// needs path
-        svs = svs ? svs : layout->mutable_setting_values();
-        SetValue * sv = svs->has_set_value() ? svs->add_other_values() : svs->mutable_set_value();
+        svs = layout->mutable_setting_values();
+        SetValue * sv = svs->mutable_set_value();
         const String ncache = "cache" + std::to_string(this->cache_counter++);
         const std::filesystem::path & nfile = fc.server_file_path / ncache;
 
@@ -2711,8 +2713,7 @@ void StatementGenerator::generateNextCreateDictionary(RandomGenerator & rg, Crea
         SetValue * sv = svs->has_set_value() ? svs->add_other_values() : svs->mutable_set_value();
 
         sv->set_property("SIZE_IN_CELLS");
-        sv->set_value(
-            std::to_string(rg.thresholdGenerator<uint64_t>(0.2, 0.2, 0, UINT32_C(10) * UINT32_C(1024) * UINT32_C(1024) * UINT32_C(1024))));
+        sv->set_value(std::to_string(rg.randomInt<uint64_t>(0, UINT32_C(10) * UINT32_C(1024) * UINT32_C(1024))));
     }
 
     /// Add Primary Key

--- a/src/Client/BuzzHouse/Generator/SessionSettings.cpp
+++ b/src/Client/BuzzHouse/Generator/SessionSettings.cpp
@@ -1259,6 +1259,7 @@ void loadFuzzerServerSettings(const FuzzConfig & fc)
            "filesystem_prefetch_min_bytes_for_single_read_task",
            "filesystem_prefetch_step_bytes",
            "group_by_two_level_threshold_bytes",
+           "iceberg_insert_max_bytes_in_data_file",
            "input_format_max_block_size_bytes",
            "input_format_parquet_local_file_min_bytes_for_seek",
            "input_format_parquet_prefer_block_bytes",
@@ -1269,8 +1270,9 @@ void loadFuzzerServerSettings(const FuzzConfig & fc)
            "max_bytes_before_external_sort",
            "max_bytes_before_remerge_sort",
            "max_download_buffer_size",
-           "iceberg_insert_max_bytes_in_data_file",
            "max_joined_block_size_bytes",
+           "max_partition_size_to_drop",
+           "max_partitions_per_insert_block",
            "max_read_buffer_size",
            "max_read_buffer_size_local_fs",
            "max_read_buffer_size_remote_fs",
@@ -1368,6 +1370,29 @@ void loadFuzzerServerSettings(const FuzzConfig & fc)
              {"remote_filesystem_read_method",
               CHSetting([](RandomGenerator & rg, FuzzConfig &) { return rg.nextBool() ? "'read'" : "'threadpool'"; }, {}, false)},
              {"wait_for_async_insert", trueOrFalseSettingNoOracle}}); /// breaks table dump oracle
+        max_block_sizes.insert(
+            max_block_sizes.end(),
+            {"max_analyze_depth",
+             "max_ast_depth",
+             "max_ast_elements",
+             "max_autoincrement_series",
+             "max_backup_bandwidth",
+             "max_distributed_connections",
+             "max_distributed_depth",
+             "max_download_threads",
+             "max_expanded_ast_elements",
+             "max_fetch_partition_retries_count",
+             "max_http_get_redirects",
+             "max_network_bandwidth",
+             "max_network_bandwidth_for_all_users",
+             "max_network_bandwidth_for_user",
+             "max_parser_backtracks",
+             "max_parser_depth",
+             "max_partitions_to_read",
+             "max_sessions_for_user",
+             "max_streams_for_merge_tree_reading",
+             "max_streams_multiplier_for_merge_tables",
+             "max_subquery_depth"});
         max_bytes_values.insert(
             max_bytes_values.end(),
             {"max_bytes_in_distinct",
@@ -1377,18 +1402,31 @@ void loadFuzzerServerSettings(const FuzzConfig & fc)
              "max_bytes_to_read_leaf",
              "max_bytes_to_sort",
              "max_bytes_to_transfer",
-             "max_result_bytes"});
+             "max_execution_speed_bytes",
+             "max_hyperscan_regexp_length",
+             "max_hyperscan_regexp_total_length",
+             "max_network_bytes",
+             "max_query_size",
+             "max_result_bytes",
+             "max_size_to_preallocate_for_aggregation",
+             "max_size_to_preallocate_for_joins",
+             "min_execution_speed_bytes"});
         max_rows_values.insert(
             max_rows_values.end(),
             {"limit",
+             "max_concurrent_queries_for_all_users",
+             "max_concurrent_queries_for_user",
+             "max_execution_speed",
              "max_result_rows",
              "max_rows_in_distinct",
              "max_rows_in_join",
              "max_rows_in_set",
+             "max_rows_in_set_to_optimize_join",
              "max_rows_to_group_by",
              "max_rows_to_read",
              "max_rows_to_read_leaf",
-             "max_rows_to_sort"});
+             "max_rows_to_sort",
+             "min_execution_speed"});
         /*max_columns_values.insert( too many errors on queries
             max_columns_values.end(), {"max_columns_to_read", "max_temporary_columns", "max_temporary_non_const_columns"});*/
     }
@@ -1397,17 +1435,17 @@ void loadFuzzerServerSettings(const FuzzConfig & fc)
     for (const auto & entry : max_bytes_values)
     {
         performanceSettings.insert({{entry, CHSetting(bytesRange, {"32768", "65536", "1048576", "4194304", "33554432", "'10M'"}, false)}});
-        serverSettings.insert({{entry, CHSetting(bytesRange, {"0", "4", "8", "32", "1024", "4096", "16384", "'10M'"}, false)}});
+        serverSettings.insert({{entry, CHSetting(bytesRange, {"0", "4", "8", "16", "32", "1024", "4096", "16384"}, false)}});
     }
     for (const auto & entry : max_rows_values)
     {
         performanceSettings.insert({{entry, CHSetting(rowsRange, {"0", "512", "1024", "2048", "4096", "16384", "'10M'"}, false)}});
-        serverSettings.insert({{entry, CHSetting(rowsRange, {"0", "4", "8", "32", "1024", "4096", "16384", "'10M'"}, false)}});
+        serverSettings.insert({{entry, CHSetting(rowsRange, {"0", "4", "8", "16", "32", "1024", "4096", "16384"}, false)}});
     }
     for (const auto & entry : max_block_sizes)
     {
         performanceSettings.insert({{entry, CHSetting(highRange, {"1024", "2048", "4096", "8192", "16384", "'10M'"}, false)}});
-        serverSettings.insert({{entry, CHSetting(highRange, {"4", "8", "32", "64", "1024", "4096", "16384", "'10M'"}, false)}});
+        serverSettings.insert({{entry, CHSetting(highRange, {"4", "8", "16", "32", "64", "1024", "4096", "16384"}, false)}});
     }
     for (const auto & entry : max_columns_values)
     {


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

It makes some sanitizer CI runs slow because of possible large values. Also added some missing settings when oracles are not running.

Closes https://github.com/ClickHouse/ClickHouse/issues/92285

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
