### PR TITLE
Do not add MemorySample events for null pointer free

### DIFF
--- a/src/Common/AllocationTrace.h
+++ b/src/Common/AllocationTrace.h
@@ -22,6 +22,8 @@ struct AllocationTrace
     {
         if (likely(sample_probability <= 0))
             return;
+        if (!size)
+            return;
 
         onFreeImpl(ptr, size);
     }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

I've looked at one case, and saw the following distribution for `MemorySample`:

    countIf(greater(size, 0)): 1126200 -- 1.13 million
    countIf(less(size, 0)):    1106997 -- 1.11 million
    countIf(equals(size, 0)):  9810747 -- 9.81 million
