### PR TITLE
tests: fix test_distributed_insert_select_to_rmt_where flakiness (due to deduplication)

### DIFF
--- a/tests/integration/test_s3_cluster_insert_select/test.py
+++ b/tests/integration/test_s3_cluster_insert_select/test.py
@@ -208,7 +208,11 @@ def test_distributed_insert_select_to_rmt_where(started_cluster):
     INSERT INTO {table} SELECT * FROM s3Cluster(
         '{cluster_name}',
         'http://minio1:9001/root/data/generated/*.csv', 'minio', '{minio_secret_key}', 'CSV','a String, b UInt64'
-    ) WHERE b = 100 SETTINGS parallel_distributed_insert_select=2;
+    ) WHERE b = 100
+    SETTINGS
+        parallel_distributed_insert_select=2,
+        -- disable deduplication since all rows identical, and if the batch size will be the same size on different nodes it will be deduplicated
+        insert_deduplicate=0;
         """
     )
 


### PR DESCRIPTION
See https://github.com/ClickHouse/ClickHouse/pull/84611#issuecomment-3696087461

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
