### PR TITLE
Support "--record" in clickhouse-test to replace reference with stdou…

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1947,6 +1947,19 @@ class TestCase:
         )
 
         if result_is_different:
+            # If --record is enabled, copy stdout to reference file
+            if self.testcase_args.record:
+                import shutil
+                shutil.copy2(self.stdout_file, self.reference_file)
+                description += "\tReference file updated\n"
+                return TestResult(
+                    self.name,
+                    TestStatus.OK,
+                    None,
+                    total_time,
+                    description,
+                )
+
             with Popen(
                 [
                     "diff",
@@ -4015,6 +4028,12 @@ def parse_args():
     )
     parser.add_argument(
         "--no-long", action="store_true", dest="no_long", help="Do not run long tests"
+    )
+    parser.add_argument(
+        "--record",
+        action="store_true",
+        default=False,
+        help="Automatically update reference files when stdout differs from reference",
     )
     parser.add_argument(
         "--client-option", nargs="+", help="Specify additional client argument"


### PR DESCRIPTION
Support "--record" in clickhouse-test to replace reference with stdout when mismatch.

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
