### PR TITLE
Fix logging via fmt::runtime()

### DIFF
--- a/src/Common/LoggingFormatStringHelpers.h
+++ b/src/Common/LoggingFormatStringHelpers.h
@@ -166,8 +166,8 @@ template <typename... Args> inline std::string tryGetArgsAndFormat(std::vector<s
 template <typename... Ts> constexpr size_t numArgs(Ts &&...) { return sizeof...(Ts); }
 template <typename T, typename... Ts> constexpr auto firstArg(T && x, Ts &&...) { return std::forward<T>(x); }
 /// For implicit conversion of fmt::basic_runtime<> to char* for std::string ctor
-template <typename T, typename... Ts> constexpr auto firstArg(fmt::runtime_format_string<T> && data, Ts &&...) { return data.str.data(); }
-template <typename T, typename... Ts> constexpr auto firstArg(const fmt::runtime_format_string<T> & data, Ts &&...) { return data.str.data(); }
+template <typename T, typename... Ts> constexpr auto firstArg(fmt::runtime_format_string<T> && data, Ts &&...) { return std::string(data.str.data(), data.str.size()); }
+template <typename T, typename... Ts> constexpr auto firstArg(const fmt::runtime_format_string<T> & data, Ts &&...) { return std::string(data.str.data(), data.str.size()); }
 
 consteval ssize_t formatStringCountArgsNum(const char * const str, size_t len)
 {


### PR DESCRIPTION
To obtain message for fmt::runtime(), firstArg() helper is used, which incorrectly creates std::string(std::string_view().data()), which ignores the view boundaries.

Noticed this in a uncaught exception handler - https://pastila.nl/?00084733/1008852afce2395f1dbfccad88816c00#VHNQrUXiNqMObn9USJkV0A==GCM

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)