### PR TITLE
Fix for duplicated const columns produced by JoinStepLogical::preCalculateKeys

### DIFF
--- a/src/Processors/QueryPlan/JoinStepLogical.cpp
+++ b/src/Processors/QueryPlan/JoinStepLogical.cpp
@@ -1409,7 +1409,7 @@ void remapNodes(ActionsDAG::NodeRawConstPtrs & keys, const ActionsDAG::NodeMappi
 
 ActionsDAG cloneSubdagWithInputs(const SharedHeader & stream_header, ActionsDAG::NodeRawConstPtrs & keys)
 {
-    ActionsDAG dag(stream_header->getColumnsWithTypeAndName());
+    ActionsDAG dag(stream_header->getColumnsWithTypeAndName(), /* duplicate_const_columns */ false);
 
     ActionsDAG::NodeMapping node_map;
     auto second_dag = ActionsDAG::cloneSubDAG(keys, node_map, false);

--- a/src/Processors/QueryPlan/JoinStepLogical.cpp
+++ b/src/Processors/QueryPlan/JoinStepLogical.cpp
@@ -1244,9 +1244,9 @@ static QueryPlanNode buildPhysicalJoinImpl(
         {
             auto input_it = name_to_nodes.find(column.name);
 
-            if (input_it == name_to_nodes.end())
+            if (input_it == name_to_nodes.end() || input_it->second.empty())
                 throw Exception(ErrorCodes::LOGICAL_ERROR,
-                    "Cannot find input column {} on its position in inputs of expression actions DAG, expected inputs {} in {}",
+                    "Cannot find input column {} on its position in inputs of expression actions DAG, expected inputs {} in\n{}",
                     column.name,
                     fmt::join(children | std::views::transform([](const auto & c) { return fmt::format("[{}]", c->step->getOutputHeader()->dumpNames()); }), ", "),
                     expression_actions.getActionsDAG()->dumpDAG());

--- a/tests/queries/0_stateless/03777_join_precalculate_keys.reference
+++ b/tests/queries/0_stateless/03777_join_precalculate_keys.reference
@@ -1,0 +1,37 @@
+Expression ((Project names + Projection))
+Header: 1 UInt8
+  JoinLogical
+  Header: __join_result_dummy UInt8
+    Filter
+    Header: __table1.c0 Int32
+      ReadFromMemoryStorage
+      Header: c0 Int32
+    BuildRuntimeFilter (Build runtime join filter on __table2.a (_runtime_filter_UNIQ_ID_0))
+    Header: __table2.a UInt8
+      Expression ((Change column names to column identifiers + (Project names + (Projection + Change column names to column identifiers))))
+      Header: __table2.a UInt8
+        ReadFromStorage (SystemOne)
+        Header: dummy UInt8
+1
+Expression ((Project names + Projection))
+Header: 1 UInt8
+  JoinLogical
+  Header: __join_result_dummy UInt8
+    Filter
+    Header: __table1.c0 Int32
+            __table1.c1 Int32
+      ReadFromMemoryStorage
+      Header: c0 Int32
+              c1 Int32
+    BuildRuntimeFilter (Build runtime join filter on __table2.b (_runtime_filter_UNIQ_ID_1))
+    Header: __table2.a UInt8
+            __table2.b UInt8
+      BuildRuntimeFilter (Build runtime join filter on __table2.a (_runtime_filter_UNIQ_ID_0))
+      Header: __table2.a UInt8
+              __table2.b UInt8
+        Expression ((Change column names to column identifiers + (Project names + (Projection + Change column names to column identifiers))))
+        Header: __table2.a UInt8
+                __table2.b UInt8
+          ReadFromStorage (SystemOne)
+          Header: dummy UInt8
+1

--- a/tests/queries/0_stateless/03777_join_precalculate_keys.sql
+++ b/tests/queries/0_stateless/03777_join_precalculate_keys.sql
@@ -1,0 +1,25 @@
+CREATE TABLE t0 (c0 Int, c1 Int) ENGINE = Memory;
+
+INSERT INTO t0 VALUES (1, 2);
+INSERT INTO t0 VALUES (2, 3);
+
+SET enable_analyzer=1;
+SET enable_parallel_replicas=0;
+SET enable_join_runtime_filters=1;
+
+SELECT REGEXP_REPLACE(explain, '_runtime_filter_\\d+', '_runtime_filter_UNIQ_ID')
+FROM (
+   EXPLAIN header=1, keep_logical_steps=1
+   SELECT 1 FROM t0 JOIN (SELECT 1 a) tx ON t0.c0 = tx.a
+);
+
+SELECT 1 FROM t0 JOIN (SELECT 1 a) tx ON t0.c0 = tx.a;
+
+
+SELECT REGEXP_REPLACE(explain, '_runtime_filter_\\d+', '_runtime_filter_UNIQ_ID')
+FROM (
+   EXPLAIN header=1, keep_logical_steps=1
+   SELECT 1 FROM t0 JOIN (SELECT 1 AS a, 2 AS b) tx ON t0.c0 = tx.a AND t0.c1 = tx.b
+);
+
+SELECT 1 FROM t0 JOIN (SELECT 1 AS a, 2 AS b) tx ON t0.c0 = tx.a AND t0.c1 = tx.b;


### PR DESCRIPTION
Fixes #92498

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix logical error in some cases triggered when join runtime filters are added to query plan. It was caused by incorrectly returning duplicated const columns from one of join sides.  

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
