### PR TITLE
Add userver to the list of third-party libraries

### DIFF
--- a/docs/en/interfaces/third-party/client-libraries.md
+++ b/docs/en/interfaces/third-party/client-libraries.md
@@ -72,6 +72,8 @@ ClickHouse Inc does **not** maintain the libraries listed below and hasn't done 
 - [clickhouse-scala-client](https://github.com/crobox/clickhouse-scala-client)
 ### Kotlin {#kotlin}
 - [AORM](https://github.com/TanVD/AORM)
+### C++ {#cpp}
+- [ClickHouse driver for userver framework](https://userver.tech/dd/ddb/clickhouse_driver.html)
 ### C# {#c}
 - [Octonica.ClickHouseClient](https://github.com/Octonica/ClickHouseClient)
 - [ClickHouse.Ado](https://github.com/killwort/ClickHouse-Net)


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

Add userver to the list of third-party libraries

### Motivation:
Userver was mentioned on the official clickhouse-cpp landing page: https://clickhouse.com/docs/interfaces/cpp. However, we have a dedicated section for third-party libraries: https://clickhouse.com/docs/interfaces/third-party/client-libraries. Since the clickhouse-cpp page is currently being updated (see https://github.com/ClickHouse/clickhouse-docs/pull/5109) , this is a good time to move userver to the appropriate place to avoid confusion and clutter.