### PR TITLE
Add test for logs rotation

### DIFF
--- a/base/poco/Foundation/include/Poco/CombinedRotateStrategy.h
+++ b/base/poco/Foundation/include/Poco/CombinedRotateStrategy.h
@@ -110,6 +110,8 @@ private:
             interval = Timespan(30 * Timespan::DAYS);
         else if (unit == "seconds") // for testing only
             interval = Timespan(n * Timespan::SECONDS);
+        else if (unit == "milliseconds") // for testing only
+            interval = Timespan(n * Timespan::MILLISECONDS);
         else if (unit == "minutes")
             interval = Timespan(n * Timespan::MINUTES);
         else if (unit == "hours")


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add a test for logs rotation.
This PR adds a simple test for https://github.com/ClickHouse/ClickHouse/pull/87620.
