### PR TITLE
Do not add join runtime filter when right table is already filled

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/joinRuntimeFilter.cpp
+++ b/src/Processors/QueryPlan/Optimizations/joinRuntimeFilter.cpp
@@ -74,7 +74,7 @@ bool tryAddJoinRuntimeFilter(QueryPlan::Node & node, QueryPlan::Nodes & nodes, c
     if (node.children.size() != 2)
         return false;
 
-    /// If right table is already prepared then runtime filter cannot be constructed
+    /// If right table is already filled and will be used for lookups directly (e.g. StorageJoin) then runtime filter cannot be constructed
     if (typeid_cast<JoinStepLogicalLookup *>(node.children[1]->step.get()))
         return false;
 

--- a/src/Processors/QueryPlan/Optimizations/joinRuntimeFilter.cpp
+++ b/src/Processors/QueryPlan/Optimizations/joinRuntimeFilter.cpp
@@ -74,6 +74,10 @@ bool tryAddJoinRuntimeFilter(QueryPlan::Node & node, QueryPlan::Nodes & nodes, c
     if (node.children.size() != 2)
         return false;
 
+    /// If right table is already prepared then runtime filter cannot be constructed
+    if (typeid_cast<JoinStepLogicalLookup *>(node.children[1]->step.get()))
+        return false;
+
     /// Check if join can do runtime filtering on left table
     const auto & join_operator = join_step->getJoinOperator();
     auto & join_algorithms = join_step->getJoinSettings().join_algorithms;

--- a/tests/queries/0_stateless/03777_join_runtime_filter_prepared_right_table.reference
+++ b/tests/queries/0_stateless/03777_join_runtime_filter_prepared_right_table.reference
@@ -1,0 +1,26 @@
+============ runtime filters disabled =========
+Expression (Project names)
+  Sorting (Sorting for ORDER BY)
+    Expression ((Before ORDER BY + Projection))
+      Expression (Post Join Actions)
+        FilledJoin (Filled JOIN)
+          Expression (Left Join Actions)
+            Expression (Change column names to column identifiers)
+              ReadFromMergeTree (default.t1)
+21	22	23	2000
+31	32	33	3000
+41	42	43	4000
+51	52	53	5000
+============ runtime filters enabled =========
+Expression (Project names)
+  Sorting (Sorting for ORDER BY)
+    Expression ((Before ORDER BY + Projection))
+      Expression (Post Join Actions)
+        FilledJoin (Filled JOIN)
+          Expression (Left Join Actions)
+            Expression (Change column names to column identifiers)
+              ReadFromMergeTree (default.t1)
+21	22	23	2000
+31	32	33	3000
+41	42	43	4000
+51	52	53	5000

--- a/tests/queries/0_stateless/03777_join_runtime_filter_prepared_right_table.sql
+++ b/tests/queries/0_stateless/03777_join_runtime_filter_prepared_right_table.sql
@@ -1,0 +1,24 @@
+SET enable_parallel_replicas = 0;
+SET enable_analyzer = 1;
+
+CREATE TABLE t1 (key1 UInt64, key2 UInt64, key3 UInt64) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t1 VALUES (11, 12, 13), (21, 22, 23), (31, 32, 33), (41, 42, 43), (51, 52, 53);
+
+CREATE TABLE tj (key2 UInt64, key1 UInt64, key3 UInt64, attr UInt64) ENGINE = Join(ALL, INNER, key3, key2, key1);
+INSERT INTO tj VALUES (22, 21, 23, 2000), (32, 31, 33, 3000), (42, 41, 43, 4000), (52, 51, 53, 5000), (62, 61, 63, 6000);
+
+SELECT '============ runtime filters disabled =========';
+SET enable_join_runtime_filters = 0;
+
+EXPLAIN
+SELECT * FROM t1 ALL INNER JOIN tj USING (key1, key2, key3) ORDER BY key1;
+
+SELECT * FROM t1 ALL INNER JOIN tj USING (key1, key2, key3) ORDER BY key1;
+
+SELECT '============ runtime filters enabled =========';
+SET enable_join_runtime_filters = 1;
+
+EXPLAIN
+SELECT * FROM t1 ALL INNER JOIN tj USING (key1, key2, key3) ORDER BY key1;
+
+SELECT * FROM t1 ALL INNER JOIN tj USING (key1, key2, key3) ORDER BY key1;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Do not add runtime filter when joining with already filled right table.

 
### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
