### PR TITLE
Fix keeper persistent watches cleanup after dead session

### DIFF
--- a/src/Coordination/KeeperStorage.cpp
+++ b/src/Coordination/KeeperStorage.cpp
@@ -4018,11 +4018,13 @@ void KeeperStorageBase::clearDeadWatches(int64_t session_id)
                 erase_session_from_map(watches, watch_path);
                 break;
             case WatchType::PERSISTENT_WATCH:
-                [[fallthrough]];
+                erase_session_from_map(persistent_watches, watch_path);
+                break;
             case WatchType::PERSISTENT_LIST_WATCH:
-                [[fallthrough]];
+                erase_session_from_map(persistent_list_watches, watch_path);
+                break;
             case WatchType::PERSISTENT_RECURSIVE_WATCH:
-                ++watch_it;
+                erase_session_from_map(persistent_recursive_watches, watch_path);
                 break;
         }
     }

--- a/tests/integration/test_keeper_persistent_watches/test.py
+++ b/tests/integration/test_keeper_persistent_watches/test.py
@@ -328,3 +328,19 @@ def test_persistent_watches_cleanup_on_close(started_cluster):
             break
         time.sleep(0.1)
     assert "zk_watch_count\t0" in data
+
+def test_clear_watches(started_cluster):
+    node1.restart_clickhouse()
+    keeper_utils.wait_until_connected(cluster, node1)
+
+    client = get_fake_zk(node1)
+    NODE_PATH = "/testPersistentCleanup"
+
+    def cb(_):
+        pass
+
+    client.add_watch(NODE_PATH, cb, AddWatchMode.PERSISTENT)
+    client.add_watch(NODE_PATH, cb, AddWatchMode.PERSISTENT_RECURSIVE)
+    destroy_zk_client(client)
+    data = keeper_utils.send_4lw_cmd(cluster, node1, cmd="mntr")
+    assert "zk_watch_count\t0" in data  # Fails: returns 3

--- a/tests/integration/test_keeper_persistent_watches/test.py
+++ b/tests/integration/test_keeper_persistent_watches/test.py
@@ -343,4 +343,4 @@ def test_clear_watches(started_cluster):
     client.add_watch(NODE_PATH, cb, AddWatchMode.PERSISTENT_RECURSIVE)
     destroy_zk_client(client)
     data = keeper_utils.send_4lw_cmd(cluster, node1, cmd="mntr")
-    assert "zk_watch_count\t0" in data  # Fails: returns 3
+    assert "zk_watch_count\t0" in data


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix keeper persistent watches cleanup after dead session. This closes https://github.com/ClickHouse/ClickHouse/issues/92480

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

