### PR TITLE
CI: Update GH data from API in finish check

### DIFF
--- a/ci/jobs/scripts/workflow_hooks/new_tests_check.py
+++ b/ci/jobs/scripts/workflow_hooks/new_tests_check.py
@@ -34,6 +34,7 @@ def has_new_unit_tests(changed_files):
 
 
 def check():
+    # read actual PR body from GH API - fallback to workflow context if failed
     title, body, labels = GH.get_pr_title_body_labels()
     if body:
         pr_body = body

--- a/ci/jobs/scripts/workflow_hooks/new_tests_check.py
+++ b/ci/jobs/scripts/workflow_hooks/new_tests_check.py
@@ -1,6 +1,7 @@
 import sys
 from pathlib import Path
 
+from ci.praktika.gh import GH
 from ci.praktika.info import Info
 
 
@@ -33,7 +34,14 @@ def has_new_unit_tests(changed_files):
 
 
 def check():
-    if not " Bug Fix" in Info().pr_body:
+    title, body, labels = GH.get_pr_title_body_labels()
+    if body:
+        pr_body = body
+    else:
+        print("WARNING: Failed to get PR body from GH API - using workflow context")
+        pr_body = Info().pr_body
+
+    if not " Bug Fix" in pr_body:
         print("Not a bug fix PR - skip")
         return True
 

--- a/ci/jobs/scripts/workflow_hooks/pr_body_check.py
+++ b/ci/jobs/scripts/workflow_hooks/pr_body_check.py
@@ -59,8 +59,8 @@ if __name__ == "__main__":
     title, body, labels = GH.get_pr_title_body_labels()
     if not title or not body:
         print("WARNING: Failed to get PR title or body, read from environment")
+        body = Info().pr_body
 
-    body = Info().pr_body
     error, category = get_category(body)
     if error or not category:
         print(f"ERROR: {error}")


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

---
Read actual data from the GH API in the workflow post hook (finish check) instead of relying on the PR body stored in the workflow context. 
Post hook checks PR category and blocks the merge if no new tests are added for "BugFix" PR. Actual PR data is required  to do the check properly.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.498`
<!-- ch-version-info:end -->