### PR TITLE
WriteBufferFromS3: fix data race on deque

### DIFF
--- a/src/IO/WriteBufferFromS3.cpp
+++ b/src/IO/WriteBufferFromS3.cpp
@@ -529,7 +529,9 @@ void WriteBufferFromS3::writePart(WriteBufferFromS3::PartData && data)
         return;
     }
 
+    /// all iterators are invalidated after push_back, so we create part_tag reference after push_back
     multipart_tags.push_back({});
+    String & part_tag = multipart_tags.back();
     size_t part_number = multipart_tags.size();
     LOG_TEST(limited_log, "writePart {}, part size {}, part number {}", getShortLogDetails(), data.data_size, part_number);
 
@@ -601,10 +603,10 @@ void WriteBufferFromS3::writePart(WriteBufferFromS3::PartData && data)
             throw S3Exception(outcome.GetError().GetMessage(), outcome.GetError().GetErrorType());
         }
 
-        multipart_tags[part_number-1] = outcome.GetResult().GetETag();
+        part_tag = outcome.GetResult().GetETag();
 
         LOG_TEST(limited_log, "Write part succeeded {}, part size {}, part number {}, etag {}",
-                 getShortLogDetails(), data_size, part_number, multipart_tags[part_number-1]);
+                 getShortLogDetails(), data_size, part_number, part_tag);
     };
 
     task_tracker->add(std::move(upload_worker));

--- a/tests/queries/0_stateless/03708_flush_async_insert_queue_for_table.sql
+++ b/tests/queries/0_stateless/03708_flush_async_insert_queue_for_table.sql
@@ -11,6 +11,7 @@ ORDER by id;
 
 set async_insert = 1;
 set wait_for_async_insert = 0;
+set wait_for_async_insert_timeout = 10000, async_insert_max_query_number = 1000, async_insert_max_data_size = 10000000, async_insert_use_adaptive_busy_timeout = 0;
 
 insert into `test_table with spaces` values (1, 'a'), (2, 'b'), (3, 'c');
 insert into `test_table with spaces` values (2, 'b'), (3, 'c'), (4, 'd');

--- a/tests/queries/0_stateless/03708_flush_async_insert_queue_for_table.sql
+++ b/tests/queries/0_stateless/03708_flush_async_insert_queue_for_table.sql
@@ -11,7 +11,6 @@ ORDER by id;
 
 set async_insert = 1;
 set wait_for_async_insert = 0;
-set wait_for_async_insert_timeout = 10000, async_insert_max_query_number = 1000, async_insert_max_data_size = 10000000, async_insert_use_adaptive_busy_timeout = 0;
 
 insert into `test_table with spaces` values (1, 'a'), (2, 'b'), (3, 'c');
 insert into `test_table with spaces` values (2, 'b'), (3, 'c'), (4, 'd');


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
