### PR TITLE
Remove unused columns when rebuilding projection on merge.

### DIFF
--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -968,7 +968,11 @@ void MergeTask::ExecuteAndFinalizeHorizontalPart::calculateProjections(const Blo
     for (size_t i = 0, size = global_ctx->projections_to_rebuild.size(); i < size; ++i)
     {
         const auto & projection = *global_ctx->projections_to_rebuild[i];
-        Block block_to_squash = projection.calculate(block, global_ctx->context);
+        Block block_with_required_columns;
+        for (const auto & name : projection.getRequiredColumns())
+            if (name != "_part_offset")
+                block_with_required_columns.insert(block.getByName(name));
+        Block block_to_squash = projection.calculate(block_with_required_columns, global_ctx->context);
         /// Avoid replacing the projection squash header if nothing was generated (it used to return an empty block)
         if (block_to_squash.rows() == 0)
             return;

--- a/tests/integration/test_projection_rebuild_with_required_columns/configs/insert_limits.xml
+++ b/tests/integration/test_projection_rebuild_with_required_columns/configs/insert_limits.xml
@@ -1,0 +1,8 @@
+<clickhouse>
+  <profiles>
+    <default>
+      <min_insert_block_size_bytes>1048576</min_insert_block_size_bytes>
+      <min_insert_block_size_rows>10000</min_insert_block_size_rows>
+    </default>
+  </profiles>
+</clickhouse>

--- a/tests/integration/test_projection_rebuild_with_required_columns/test.py
+++ b/tests/integration/test_projection_rebuild_with_required_columns/test.py
@@ -1,0 +1,30 @@
+import pytest
+
+from helpers.client import QueryRuntimeException
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+node1 = cluster.add_instance("node1", user_configs=["configs/insert_limits.xml"])
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+
+def test_projection_rebuild_uses_only_required_columns(started_cluster):
+    node1.query("create table tab (x UInt64, y UInt64, data String codec(NONE), v UInt8, projection p (select _part_offset order by y)) engine = ReplacingMergeTree(v) order by x settings allow_part_offset_column_in_projections=1, deduplicate_merge_projection_mode='rebuild';")
+    node1.query("insert into tab select number, number, rightPad('', 100, 'a'), 0 from numbers(30000);")
+    node1.query("optimize table tab final settings mutations_sync=2, alter_sync=2;")
+    node1.query("system flush logs;")
+
+    uuid = node1.query("select uuid from system.tables where table = 'tab';").strip()
+    cnt = node1.query("select count() from system.text_log where query_id = '{}::all_1_1_2' and message like '%Reading%from part p_%from the beginning of the part%'".format(uuid))
+    assert (cnt == '2\n')
+


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Remove unused columns when the projection is rebuilt during the merge. It reduces memory usage and creates fewer temporary parts. 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
