### PR TITLE
Fix unused columns removal in presence of correlated subqueries

### DIFF
--- a/src/Analyzer/Passes/RemoveUnusedProjectionColumnsPass.cpp
+++ b/src/Analyzer/Passes/RemoveUnusedProjectionColumnsPass.cpp
@@ -17,90 +17,6 @@ namespace DB
 namespace
 {
 
-class CollectUsedColumnsVisitor : public InDepthQueryTreeVisitorWithContext<CollectUsedColumnsVisitor>
-{
-public:
-    using Base = InDepthQueryTreeVisitorWithContext<CollectUsedColumnsVisitor>;
-    using Base::Base;
-
-    bool needChildVisit(QueryTreeNodePtr &, QueryTreeNodePtr & child)
-    {
-        if (isQueryOrUnionNode(child))
-        {
-            subqueries_nodes_to_visit.insert(child);
-            return false;
-        }
-
-        return true;
-    }
-
-    void enterImpl(QueryTreeNodePtr & node)
-    {
-        auto node_type = node->getNodeType();
-
-        if (node_type == QueryTreeNodeType::QUERY)
-        {
-            auto & query_node = node->as<QueryNode &>();
-            auto table_expressions = extractTableExpressions(query_node.getJoinTree());
-            for (const auto & table_expression : table_expressions)
-                if (isQueryOrUnionNode(table_expression))
-                    query_or_union_node_to_used_columns.emplace(table_expression, std::unordered_set<std::string>());
-
-            return;
-        }
-
-        if (node_type == QueryTreeNodeType::FUNCTION)
-        {
-            auto & function_node = node->as<FunctionNode &>();
-
-            if (function_node.getFunctionName() != "exists")
-                return;
-
-            const auto & subquery_argument = function_node.getArguments().getNodes().front();
-            auto * query_node = subquery_argument->as<QueryNode>();
-            auto * union_node = subquery_argument->as<UnionNode>();
-
-            const auto & correlated_columns = query_node != nullptr ? query_node->getCorrelatedColumns() : union_node->getCorrelatedColumns();
-            for (const auto & correlated_column : correlated_columns)
-            {
-                auto * column_node = correlated_column->as<ColumnNode>();
-                auto column_source_node = column_node->getColumnSource();
-                auto column_source_node_type = column_source_node->getNodeType();
-                if (column_source_node_type == QueryTreeNodeType::QUERY || column_source_node_type == QueryTreeNodeType::UNION)
-                    query_or_union_node_to_used_columns[column_source_node].insert(column_node->getColumnName());
-            }
-            return;
-        }
-
-        if (node_type != QueryTreeNodeType::COLUMN)
-            return;
-
-        auto & column_node = node->as<ColumnNode &>();
-        if (column_node.getColumnName() == "__grouping_set")
-            return;
-
-        auto column_source_node = column_node.getColumnSource();
-
-        auto it = query_or_union_node_to_used_columns.find(column_source_node);
-        /// If the source node is not found in the map then:
-        /// 1. Tt's either not a Query or Union node.
-        /// 2. It's a correlated column and it comes from the outer scope.
-        if (it != query_or_union_node_to_used_columns.end())
-        {
-            it->second.insert(column_node.getColumnName());
-        }
-    }
-
-    void reset()
-    {
-        subqueries_nodes_to_visit.clear();
-        query_or_union_node_to_used_columns.clear();
-    }
-
-    std::unordered_set<QueryTreeNodePtr> subqueries_nodes_to_visit;
-    std::unordered_map<QueryTreeNodePtr, std::unordered_set<std::string>> query_or_union_node_to_used_columns;
-};
-
 std::unordered_set<size_t> convertUsedColumnNamesToUsedProjectionIndexes(const QueryTreeNodePtr & query_or_union_node, const std::unordered_set<std::string> & used_column_names)
 {
     std::unordered_set<size_t> result;
@@ -159,23 +75,130 @@ void updateUsedProjectionIndexes(const QueryTreeNodePtr & query_or_union_node, s
     }
 }
 
+template <typename ShouldVisitPredicate, typename Func>
+void traverseQueryTree(const QueryTreeNodePtr & node, ShouldVisitPredicate should_visit_predicate, Func func)
+{
+    QueryTreeNodes nodes_to_process = { node };
+
+    while (!nodes_to_process.empty())
+    {
+        auto current_node = nodes_to_process.back();
+        nodes_to_process.pop_back();
+
+        // LOG_DEBUG(getLogger(__func__), "Processing Node:\n{}", current_node->dumpTree());
+
+        func(current_node);
+
+        if (auto * table_function_node = current_node->as<TableFunctionNode>())
+        {
+            for (const auto & child : current_node->getChildren())
+            {
+                if (!child)
+                    continue;
+
+                if (child == table_function_node->getArgumentsNode())
+                {
+                    const auto & unresolved_indexes = table_function_node->getUnresolvedArgumentIndexes();
+                    const auto & arguments_nodes = table_function_node->getArguments().getNodes();
+
+                    for (size_t index = 0; index < arguments_nodes.size(); ++index)
+                    {
+                        const auto & argument_node = arguments_nodes[index];
+                        if (std::find(unresolved_indexes.begin(), unresolved_indexes.end(), index) == unresolved_indexes.end())
+                        {
+                            nodes_to_process.push_back(argument_node);
+                        }
+                    }
+                }
+                else
+                {
+                    if (should_visit_predicate(current_node, child))
+                        nodes_to_process.push_back(child);
+                }
+            }
+        }
+        else
+        {
+            for (const auto & child : current_node->getChildren())
+            {
+                if (!child)
+                    continue;
+
+                if (should_visit_predicate(current_node, child))
+                    nodes_to_process.push_back(child);
+            }
+        }
+    }
 }
 
-void RemoveUnusedProjectionColumnsPass::run(QueryTreeNodePtr & query_tree_node, ContextPtr context)
-{
-    std::vector<QueryTreeNodePtr> nodes_to_visit;
-    nodes_to_visit.push_back(query_tree_node);
+}
 
-    CollectUsedColumnsVisitor visitor(std::move(context));
+void RemoveUnusedProjectionColumnsPass::run(QueryTreeNodePtr & query_tree_node, ContextPtr /*context*/)
+{
+    QueryTreeNodes nodes_to_visit = { query_tree_node };
 
     while (!nodes_to_visit.empty())
     {
         auto node_to_visit = std::move(nodes_to_visit.back());
         nodes_to_visit.pop_back();
 
-        visitor.visit(node_to_visit);
+        std::unordered_set<QueryTreeNodePtr> subqueries_nodes_to_visit;
+        std::unordered_map<QueryTreeNodePtr, std::unordered_set<std::string>> node_to_used_columns;
 
-        for (auto & [query_or_union_node, used_columns] : visitor.query_or_union_node_to_used_columns)
+        /// Initialize map with query and union nodes in the FROM clause
+        if (auto * query_node = node_to_visit->as<QueryNode>())
+        {
+            for (const auto & table_expression : extractTableExpressions(query_node->getJoinTree()))
+                if (isQueryOrUnionNode(table_expression))
+                    node_to_used_columns.emplace(table_expression, std::unordered_set<std::string>());
+        }
+
+        traverseQueryTree(node_to_visit,
+            [&](const QueryTreeNodePtr & /*parent*/, const QueryTreeNodePtr & child)
+            {
+                if (isQueryOrUnionNode(child))
+                {
+                    subqueries_nodes_to_visit.insert(child);
+
+                    auto * query_node = child->as<QueryNode>();
+                    auto * union_node = child->as<UnionNode>();
+
+                    const auto & correlated_columns = query_node != nullptr ? query_node->getCorrelatedColumns() : union_node->getCorrelatedColumns();
+                    for (const auto & correlated_column : correlated_columns)
+                    {
+                        auto * column_node = correlated_column->as<ColumnNode>();
+                        auto column_source_node = column_node->getColumnSource();
+                        auto column_source_node_type = column_source_node->getNodeType();
+                        if (column_source_node_type == QueryTreeNodeType::QUERY || column_source_node_type == QueryTreeNodeType::UNION)
+                            node_to_used_columns[column_source_node].insert(column_node->getColumnName());
+                    }
+                    return false;
+                }
+                return true;
+            },
+            [&](const QueryTreeNodePtr & node)
+            {
+                const auto node_type = node->getNodeType();
+                if (node_type != QueryTreeNodeType::COLUMN)
+                    return;
+
+                auto & column_node = node->as<ColumnNode &>();
+                if (column_node.getColumnName() == "__grouping_set")
+                    return;
+
+                auto column_source_node = column_node.getColumnSource();
+
+                auto it = node_to_used_columns.find(column_source_node);
+                /// If the source node is not found in the map then:
+                /// 1. Tt's either not a Query or Union node.
+                /// 2. It's a correlated column and it comes from the outer scope.
+                if (it != node_to_used_columns.end())
+                {
+                    it->second.insert(column_node.getColumnName());
+                }
+            });
+
+        for (auto & [query_or_union_node, used_columns] : node_to_used_columns)
         {
             /// can't remove columns from distinct, see example - 03023_remove_unused_column_distinct.sql
             if (auto * query_node = query_or_union_node->as<QueryNode>())
@@ -197,10 +220,8 @@ void RemoveUnusedProjectionColumnsPass::run(QueryTreeNodePtr & query_tree_node, 
                 query_node->removeUnusedProjectionColumns(used_projection_indexes);
         }
 
-        for (const auto & subquery_node_to_visit : visitor.subqueries_nodes_to_visit)
+        for (const auto & subquery_node_to_visit : subqueries_nodes_to_visit)
             nodes_to_visit.push_back(subquery_node_to_visit);
-
-        visitor.reset();
     }
 }
 

--- a/src/Analyzer/Passes/RemoveUnusedProjectionColumnsPass.cpp
+++ b/src/Analyzer/Passes/RemoveUnusedProjectionColumnsPass.cpp
@@ -119,7 +119,10 @@ void RemoveUnusedProjectionColumnsPass::run(QueryTreeNodePtr & query_tree_node, 
                         auto column_source_node = column_node->getColumnSource();
                         auto column_source_node_type = column_source_node->getNodeType();
                         if (column_source_node_type == QueryTreeNodeType::QUERY || column_source_node_type == QueryTreeNodeType::UNION)
-                            node_to_used_columns[column_source_node].insert(column_node->getColumnName());
+                        {
+                            if (auto it = node_to_used_columns.find(column_source_node); it != node_to_used_columns.end())
+                                it->second.insert(column_node->getColumnName());
+                        }
                     }
                     return false;
                 }

--- a/src/Analyzer/traverseQueryTree.h
+++ b/src/Analyzer/traverseQueryTree.h
@@ -1,4 +1,3 @@
-
 #pragma once
 
 #include <Analyzer/IQueryTreeNode.h>

--- a/src/Analyzer/traverseQueryTree.h
+++ b/src/Analyzer/traverseQueryTree.h
@@ -1,0 +1,75 @@
+
+#pragma once
+
+#include <Analyzer/IQueryTreeNode.h>
+#include <Analyzer/TableFunctionNode.h>
+
+namespace DB
+{
+
+/// Traverse query tree in depth-first manner, applying `func` to each node.
+/// `should_visit_predicate` is called for each child node to determine whether to visit it or not.
+/// If the node is a TableFunctionNode, its arguments that are not resolved are skipped during traversal.
+///
+/// Note: This function implements non-recursive traversal to avoid stack overflow on deep trees.
+/// If you need recursive traversal or you need to use query context, consider using InDepthQueryTreeVisitorWithContext.
+/// This function is suitable for simple use cases where you just need to apply a function to each node.
+///
+/// @param node The root node of the query tree to traverse.
+/// @param should_visit_predicate A callable that takes (parent_node, child_node) and returns a bool indicating whether to visit the child node.
+/// @param func A callable that takes (current_node) to be applied to each visited node.
+template <typename ShouldVisitPredicate, typename Func>
+void traverseQueryTree(const QueryTreeNodePtr & node, ShouldVisitPredicate should_visit_predicate, Func func)
+{
+    QueryTreeNodes nodes_to_process = { node };
+
+    while (!nodes_to_process.empty())
+    {
+        auto current_node = nodes_to_process.back();
+        nodes_to_process.pop_back();
+
+        func(current_node);
+
+        if (auto * table_function_node = current_node->as<TableFunctionNode>())
+        {
+            for (const auto & child : current_node->getChildren())
+            {
+                if (!child)
+                    continue;
+
+                if (child == table_function_node->getArgumentsNode())
+                {
+                    const auto & unresolved_indexes = table_function_node->getUnresolvedArgumentIndexes();
+                    const auto & arguments_nodes = table_function_node->getArguments().getNodes();
+
+                    for (size_t index = 0; index < arguments_nodes.size(); ++index)
+                    {
+                        const auto & argument_node = arguments_nodes[index];
+                        if (std::find(unresolved_indexes.begin(), unresolved_indexes.end(), index) == unresolved_indexes.end())
+                        {
+                            nodes_to_process.push_back(argument_node);
+                        }
+                    }
+                }
+                else
+                {
+                    if (should_visit_predicate(current_node, child))
+                        nodes_to_process.push_back(child);
+                }
+            }
+        }
+        else
+        {
+            for (const auto & child : current_node->getChildren())
+            {
+                if (!child)
+                    continue;
+
+                if (should_visit_predicate(current_node, child))
+                    nodes_to_process.push_back(child);
+            }
+        }
+    }
+}
+
+}

--- a/tests/queries/0_stateless/03777_analyzer_unused_columns_removal_correlated_subquery.reference
+++ b/tests/queries/0_stateless/03777_analyzer_unused_columns_removal_correlated_subquery.reference
@@ -1,0 +1,65 @@
+QUERY id: 0
+  PROJECTION COLUMNS
+    avg_yearly Float64
+  PROJECTION
+    LIST id: 1, nodes: 1
+      FUNCTION id: 2, function_name: divide, function_type: ordinary, result_type: Float64
+        ARGUMENTS
+          LIST id: 3, nodes: 2
+            FUNCTION id: 4, function_name: sum, function_type: aggregate, result_type: Decimal(38, 2)
+              ARGUMENTS
+                LIST id: 5, nodes: 1
+                  COLUMN id: 6, column_name: l_extendedprice, result_type: Decimal(15, 2), source_id: 7
+            CONSTANT id: 8, constant_value: Float64_7, constant_value_type: Float64
+  JOIN TREE
+    QUERY id: 7, alias: __table1, is_subquery: 1
+      PROJECTION COLUMNS
+        l_quantity Decimal(15, 2)
+        l_extendedprice Decimal(15, 2)
+        p_partkey Int32
+      PROJECTION
+        LIST id: 9, nodes: 3
+          COLUMN id: 10, column_name: l_quantity, result_type: Decimal(15, 2), source_id: 11
+          COLUMN id: 12, column_name: l_extendedprice, result_type: Decimal(15, 2), source_id: 11
+          COLUMN id: 13, column_name: p_partkey, result_type: Int32, source_id: 14
+      JOIN TREE
+        JOIN id: 15, strictness: ALL, kind: INNER
+          LEFT TABLE EXPRESSION
+            TABLE id: 11, alias: __table2, table_name: default.lineitem
+          RIGHT TABLE EXPRESSION
+            TABLE id: 14, alias: __table3, table_name: default.part
+          JOIN EXPRESSION
+            FUNCTION id: 16, function_name: equals, function_type: ordinary, result_type: UInt8
+              ARGUMENTS
+                LIST id: 17, nodes: 2
+                  COLUMN id: 18, column_name: p_partkey, result_type: Int32, source_id: 14
+                  COLUMN id: 19, column_name: l_partkey, result_type: Int32, source_id: 11
+  WHERE
+    FUNCTION id: 20, function_name: less, function_type: ordinary, result_type: Nullable(UInt8)
+      ARGUMENTS
+        LIST id: 21, nodes: 2
+          COLUMN id: 22, column_name: l_quantity, result_type: Decimal(15, 2), source_id: 7
+          QUERY id: 23, alias: __table4, is_subquery: 1, is_correlated: 1
+            CORRELATED COLUMNS
+              LIST id: 24, nodes: 1
+                COLUMN id: 25, column_name: p_partkey, result_type: Int32, source_id: 7
+            PROJECTION COLUMNS
+              multiply(0.2, avg(l_quantity)) Float64
+            PROJECTION
+              LIST id: 26, nodes: 1
+                FUNCTION id: 27, function_name: multiply, function_type: ordinary, result_type: Float64
+                  ARGUMENTS
+                    LIST id: 28, nodes: 2
+                      CONSTANT id: 29, constant_value: Float64_0.2, constant_value_type: Float64
+                      FUNCTION id: 30, function_name: avg, function_type: aggregate, result_type: Float64
+                        ARGUMENTS
+                          LIST id: 31, nodes: 1
+                            COLUMN id: 32, column_name: l_quantity, result_type: Decimal(15, 2), source_id: 33
+            JOIN TREE
+              TABLE id: 33, alias: __table5, table_name: default.lineitem
+            WHERE
+              FUNCTION id: 34, function_name: equals, function_type: ordinary, result_type: UInt8
+                ARGUMENTS
+                  LIST id: 35, nodes: 2
+                    COLUMN id: 36, column_name: l_partkey, result_type: Int32, source_id: 33
+                    COLUMN id: 25, column_name: p_partkey, result_type: Int32, source_id: 7

--- a/tests/queries/0_stateless/03777_analyzer_unused_columns_removal_correlated_subquery.sql
+++ b/tests/queries/0_stateless/03777_analyzer_unused_columns_removal_correlated_subquery.sql
@@ -1,0 +1,67 @@
+SET enable_analyzer = 1;
+SET enable_parallel_replicas = 0;
+SET correlated_subqueries_substitute_equivalent_expressions = 0;
+
+CREATE TABLE lineitem (
+    l_orderkey       Int32,
+    l_partkey        Int32,
+    l_suppkey        Int32,
+    l_linenumber     Int32,
+    l_quantity       Decimal(15,2),
+    l_extendedprice  Decimal(15,2),
+    l_discount       Decimal(15,2),
+    l_tax            Decimal(15,2),
+    l_returnflag     String,
+    l_linestatus     String,
+    l_shipdate       Date,
+    l_commitdate     Date,
+    l_receiptdate    Date,
+    l_shipinstruct   String,
+    l_shipmode       String,
+    l_comment        String)
+ORDER BY (l_orderkey, l_linenumber);
+INSERT INTO lineitem SELECT * FROM generateRandom() LIMIT 1;
+
+CREATE TABLE part (
+    p_partkey     Int32,
+    p_name        String,
+    p_mfgr        String,
+    p_brand       String,
+    p_type        String,
+    p_size        Int32,
+    p_container   String,
+    p_retailprice Decimal(15,2),
+    p_comment     String)
+ORDER BY (p_partkey);
+INSERT INTO part SELECT * FROM generateRandom() LIMIT 1;
+
+
+EXPLAIN QUERY TREE
+SELECT
+    sum(l_extendedprice) / 7.0 AS avg_yearly
+FROM
+    (SELECT * FROM lineitem, part WHERE p_partkey = l_partkey) AS lp
+WHERE
+    l_quantity < (
+        SELECT
+            0.2 * avg(l_quantity)
+        FROM
+            lineitem
+        WHERE
+            l_partkey = lp.p_partkey
+    );
+
+SELECT
+    sum(l_extendedprice) / 7.0 AS avg_yearly
+FROM
+    (SELECT * FROM lineitem, part WHERE p_partkey = l_partkey) AS lp
+WHERE
+    l_quantity < (
+        SELECT
+            0.2 * avg(l_quantity)
+        FROM
+            lineitem
+        WHERE
+            l_partkey = lp.p_partkey
+    )
+FORMAT Null;


### PR DESCRIPTION
### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix unused columns removal from subqueries in the presence of a scalar correlated subquery. Before the fix column could have been removed if it was used only in the correlated subquery, and the query would fail with `NOT_FOUND_COLUMN_IN_BLOCK` error.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
