### PR TITLE
fix: merge(): hostName() constness mismatch causes ILLEGAL_COLUMN with remote()/Distributed child tables

### DIFF
--- a/src/Storages/StorageMerge.cpp
+++ b/src/Storages/StorageMerge.cpp
@@ -1515,7 +1515,6 @@ void ReadFromMerge::convertAndFilterSourceStream(
 
             QueryTreeNodePtr query_tree = buildQueryTree(alias.expression, local_context);
             query_tree->setAlias(alias.name);
-            query_tree->setResultType(alias.type);
 
             QueryAnalysisPass query_analysis_pass(modified_query_info.table_expression);
             query_analysis_pass.run(query_tree, local_context);

--- a/tests/queries/0_stateless/03781_merge_hostname_remote.reference
+++ b/tests/queries/0_stateless/03781_merge_hostname_remote.reference
@@ -1,0 +1,2 @@
+before
+after

--- a/tests/queries/0_stateless/03781_merge_hostname_remote.sql
+++ b/tests/queries/0_stateless/03781_merge_hostname_remote.sql
@@ -1,0 +1,16 @@
+DROP TABLE IF EXISTS merge_host_remote_tab_a;
+DROP TABLE IF EXISTS merge_host_remote_tab_b;
+
+CREATE TABLE merge_host_remote_tab_a (number UInt32) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO merge_host_remote_tab_a VALUES (1);
+
+CREATE TABLE merge_host_remote_tab_b AS remote('127.0.0.1', numbers(2));
+
+SET allow_experimental_analyzer = 1;
+
+SELECT 'before';
+SELECT hostName(), * FROM merge(currentDatabase(), '^merge_host_remote_tab_') ORDER BY number FORMAT Null;
+SELECT 'after';
+
+DROP TABLE merge_host_remote_tab_a;
+DROP TABLE merge_host_remote_tab_b;

--- a/tests/queries/0_stateless/03781_merge_hostname_remote.sql
+++ b/tests/queries/0_stateless/03781_merge_hostname_remote.sql
@@ -6,7 +6,7 @@ INSERT INTO merge_host_remote_tab_a VALUES (1);
 
 CREATE TABLE merge_host_remote_tab_b AS remote('127.0.0.1', numbers(2));
 
-SET allow_experimental_analyzer = 1;
+SET enable_analyzer = 1;
 
 SELECT 'before';
 SELECT hostName(), * FROM merge(currentDatabase(), '^merge_host_remote_tab_') ORDER BY number FORMAT Null;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release))


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix the `Merge` table engine query planning with the analyzer that could throw ILLEGAL_COLUMN for `hostName()` when merging local and remote/Distributed tables. Closes #92059.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.605`
<!-- ch-version-info:end -->