### PR TITLE
Use natural order for table and database names in the web UI

### DIFF
--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -1067,6 +1067,22 @@ async function loadDatabases(server_address, user, password) {
     let databases_elem = document.getElementById('databases');
     while (databases_elem.firstChild) databases_elem.removeChild(databases_elem.firstChild);
 
+    // Use natural order for database names
+    json.data.sort((a, b) => {
+        // Maintain original order for default, system, information_schema
+        const getPriority = (name) => {
+            switch (name) {
+                case 'default': return 0;
+                case 'system': return 2;
+                case 'information_schema': return 3
+                default: return 1;
+            }
+        }
+
+        return getPriority(a.database) - getPriority(b.database)
+            || a.database.localeCompare(b.database, undefined, { numeric: true });
+    });
+
     for (let elem of json.data) {
         let database = document.createElement('div');
         database.className = 'database';

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -1118,6 +1118,9 @@ async function loadTables(server_address, user, password, database, container) {
 
     let max_total_bytes = Math.max(...json.data.map(elem => +elem.total_bytes));
 
+    // Use natural order for table names
+    json.data.sort((a, b) => a.table.localeCompare(b.table, undefined, { numeric: true }));
+
     for (let elem of json.data) {
         let table = document.createElement('div');
         table.className = 'table';


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Uses natural order in the web ui for table and database names. Closes #93291.

A few things to note:
- whitespace: "test 1" would come before "test1"
- leading zero(s): "test01" would come before "test1"

I'm not sure if there's a test suite for `play.html` to change for this, didn't find anything other than a simple ping test