### PR TITLE
support geometry type for flipCoordinates

### DIFF
--- a/src/Functions/flipCoordinates.cpp
+++ b/src/Functions/flipCoordinates.cpp
@@ -1,10 +1,12 @@
 #include <Columns/ColumnArray.h>
 #include <Columns/ColumnConst.h>
 #include <Columns/ColumnTuple.h>
+#include <Columns/ColumnVariant.h>
 #include <Columns/IColumn.h>
 #include <Columns/ColumnsNumber.h>
 #include <DataTypes/DataTypeArray.h>
 #include <DataTypes/DataTypeTuple.h>
+#include <DataTypes/DataTypeVariant.h>
 #include <Functions/FunctionFactory.h>
 #include <Functions/FunctionHelpers.h>
 #include <Functions/IFunction.h>
@@ -43,7 +45,7 @@ public:
         return arguments[0];
     }
 
-    ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t) const override
+    ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const override
     {
         const ColumnWithTypeAndName & arg = arguments[0];
 
@@ -60,7 +62,12 @@ public:
 
         ColumnPtr result;
 
-        if (checkAndGetDataType<DataTypeTuple>(arg.type.get()))
+        /// Handle Geometry (Variant) type
+        if (const auto * column_variant = checkAndGetColumn<ColumnVariant>(column.get()))
+        {
+            result = executeForVariant(column_variant, result_type, input_rows_count);
+        }
+        else if (checkAndGetDataType<DataTypeTuple>(arg.type.get()))
         {
             result = executeForPoint(column);
         }
@@ -84,6 +91,72 @@ public:
     }
 
 private:
+    ColumnPtr executeForVariant(const ColumnVariant * column_variant, const DataTypePtr & result_type, size_t input_rows_count) const
+    {
+        const auto * variant_type = typeid_cast<const DataTypeVariant *>(result_type.get());
+        if (!variant_type)
+            throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Expected Variant result type for Geometry");
+
+        /// Create a result Variant column with the same structure
+        auto result_column = result_type->createColumn();
+        auto & result_variant = assert_cast<ColumnVariant &>(*result_column);
+
+        const auto & local_discriminators = column_variant->getLocalDiscriminators();
+        const auto & offsets = column_variant->getOffsets();
+        const auto & variant_types = variant_type->getVariants();
+
+        /// Process each variant type and flip its coordinates
+        const auto & variants = column_variant->getVariants();
+        MutableColumns result_variants;
+        result_variants.reserve(variants.size());
+
+        for (size_t i = 0; i < variants.size(); ++i)
+        {
+            const auto & variant_column = variants[i];
+            auto global_discr = column_variant->globalDiscriminatorByLocal(i);
+            const auto & variant_data_type = variant_types[global_discr];
+
+            ColumnPtr flipped_variant;
+            if (checkAndGetDataType<DataTypeTuple>(variant_data_type.get()))
+            {
+                flipped_variant = executeForPoint(variant_column);
+            }
+            else if (const auto * array_type = checkAndGetDataType<DataTypeArray>(variant_data_type.get()))
+            {
+                flipped_variant = executeForArray(variant_column, array_type);
+            }
+            else
+            {
+                throw Exception(
+                    ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
+                    "Unexpected variant type {} in Geometry",
+                    variant_data_type->getName());
+            }
+            result_variants.push_back(flipped_variant->assumeMutable());
+        }
+
+        /// Build result discriminators and offsets
+        auto & result_discriminators = result_variant.getLocalDiscriminators();
+        auto & result_offsets = result_variant.getOffsets();
+        result_discriminators.reserve(input_rows_count);
+        result_offsets.reserve(input_rows_count);
+
+        for (size_t i = 0; i < input_rows_count; ++i)
+        {
+            result_discriminators.push_back(local_discriminators[i]);
+            result_offsets.push_back(offsets[i]);
+        }
+
+        /// Set the variant columns in the result
+        auto & result_variant_columns = result_variant.getVariants();
+        for (size_t i = 0; i < result_variants.size(); ++i)
+        {
+            result_variant_columns[i] = std::move(result_variants[i]);
+        }
+
+        return result_column;
+    }
+
     ColumnPtr executeForPoint(const ColumnPtr & column) const
     {
         const auto * column_tuple = checkAndGetColumn<ColumnTuple>(column.get());
@@ -153,12 +226,18 @@ private:
 
 REGISTER_FUNCTION(FlipCoordinates)
 {
-    FunctionDocumentation::Description description = "Flips the coordinates of a Point, Ring, Polygon, or MultiPolygon. For a Point, it swaps the coordinates. For arrays, it recursively applies the same transformation for each coordinate pair.";
+    FunctionDocumentation::Description description = R"(
+Flips the x and y coordinates of geometric objects. This operation swaps latitude and longitude, which is useful for converting between different coordinate systems or correcting coordinate order.
+
+For a Point, it swaps the x and y coordinates. For complex geometries (LineString, Polygon, MultiPolygon, Ring, MultiLineString), it recursively applies the transformation to each coordinate pair.
+
+The function supports both individual geometry types (Point, Ring, Polygon, MultiPolygon, LineString, MultiLineString) and the Geometry variant type.
+)";
     FunctionDocumentation::Syntax syntax = "flipCoordinates(geometry)";
     FunctionDocumentation::Arguments arguments = {
-        {"geometry", "The geometry to transform. Supported types: Point (Tuple(Float64, Float64)), Ring (Array(Point)), Polygon (Array(Ring)), MultiPolygon (Array(Polygon))."}
+        {"geometry", "The geometry to transform. Supported types: Point (Tuple(Float64, Float64)), Ring (Array(Point)), Polygon (Array(Ring)), MultiPolygon (Array(Polygon)), LineString (Array(Point)), MultiLineString (Array(LineString)), or Geometry (a variant containing any of these types)."}
     };
-    FunctionDocumentation::ReturnedValue returned_value = {"The geometry with flipped coordinates. The type is the same as the input.", {"Point", "Ring", "Polygon", "MultiPolygon"}};
+    FunctionDocumentation::ReturnedValue returned_value = {"The geometry with flipped coordinates. The return type matches the input type.", {"Point", "Ring", "Polygon", "MultiPolygon", "LineString", "MultiLineString", "Geometry"}};
     FunctionDocumentation::Examples examples = {
         {"basic_point",
          "SELECT flipCoordinates((1.0, 2.0));",
@@ -168,7 +247,13 @@ REGISTER_FUNCTION(FlipCoordinates)
          "[(2.0, 1.0), (4.0, 3.0)]"},
         {"polygon",
          "SELECT flipCoordinates([[(1.0, 2.0), (3.0, 4.0)], [(5.0, 6.0), (7.0, 8.0)]]);",
-         "[[(2.0, 1.0), (4.0, 3.0)], [(6.0, 5.0), (8.0, 7.0)]]"}
+         "[[(2.0, 1.0), (4.0, 3.0)], [(6.0, 5.0), (8.0, 7.0)]]"},
+        {"geometry_wkt",
+         "SELECT flipCoordinates(readWkt('POINT(10 20)'));",
+         "(20, 10)"},
+        {"geometry_polygon_wkt",
+         "SELECT flipCoordinates(readWkt('POLYGON((0 0, 5 0, 5 5, 0 5, 0 0))'));",
+         "[[(0, 0), (0, 5), (5, 5), (5, 0), (0, 0)]]"}
     };
     FunctionDocumentation::IntroducedIn introduced_in = {25, 10};
     FunctionDocumentation::Category category = FunctionDocumentation::Category::Other;

--- a/tests/queries/0_stateless/03444_flip_coordinates.reference
+++ b/tests/queries/0_stateless/03444_flip_coordinates.reference
@@ -1,4 +1,5 @@
 -- {echo}
+SET allow_suspicious_variant_types = 1;
 SELECT flipCoordinates(CAST((10.0, 20.0) AS Point));
 (20,10)
 SELECT flipCoordinates(CAST([(10, 20), (30, 40), (50, 60)] AS LineString));
@@ -22,3 +23,42 @@ SELECT flipCoordinates(([[[(0, 0), (10, 0), (10, 10), (0, 10)]], [[(20, 20), (50
 [[[(0,0),(0,10),(10,10),(10,0)]],[[(20,20),(20,50),(50,50),(50,20)],[(30,30),(50,50),(30,50)]]]
 SELECT flipCoordinates((1.23, 4.56)::Point), (([(1.23, 4.56)::Point, (2.34, 5.67)::Point])::Ring);
 (4.5600000000000005,1.23)	[(1.23,4.5600000000000005),(2.34,5.67)]
+SELECT flipCoordinates(readWkt('POINT(10 20)'));
+(20,10)
+SELECT flipCoordinates(readWkt('LINESTRING(10 20, 30 40, 50 60)'));
+[(20,10),(40,30),(60,50)]
+SELECT flipCoordinates(readWkt('POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))'));
+[[(0,0),(0,10),(10,10),(10,0),(0,0)]]
+SELECT flipCoordinates(readWkt('POLYGON((-111.0544 45.0016, -104.0527 45.0016, -104.0527 40.9982, -111.0544 40.9982, -111.0544 45.0016))'));
+[[(45.0016,-111.0544),(45.0016,-104.0527),(40.9982,-104.0527),(40.9982,-111.0544),(45.0016,-111.0544)]]
+SELECT flipCoordinates(readWkt('POLYGON((0 0, 100 0, 100 100, 0 100, 0 0), (25 25, 75 25, 75 75, 25 75, 25 25))'));
+[[(0,0),(0,100),(100,100),(100,0),(0,0)],[(25,25),(25,75),(75,75),(75,25),(25,25)]]
+SELECT flipCoordinates(readWkt('MULTILINESTRING((10 20, 30 40), (50 60, 70 80))'));
+[[(20,10),(40,30)],[(60,50),(80,70)]]
+SELECT flipCoordinates(readWkt('MULTIPOLYGON(((0 0, 10 0, 10 10, 0 10, 0 0)))'));
+[[[(0,0),(0,10),(10,10),(10,0),(0,0)]]]
+SELECT flipCoordinates(readWkt('MULTIPOLYGON(((0 0, 10 0, 10 10, 0 10)), ((20 20, 50 20, 50 50, 20 50), (30 30, 50 50, 50 30)))'));
+[[[(0,0),(0,10),(10,10),(10,0)]],[[(20,20),(20,50),(50,50),(50,20)],[(30,30),(50,50),(30,50)]]]
+SELECT flipCoordinates(readWkt('POINT(-73.935242 40.730610)'));
+(40.73061,-73.935242)
+SELECT flipCoordinates(readWkt('POLYGON((-180 -90, 180 -90, 180 90, -180 90, -180 -90))'));
+[[(-90,-180),(-90,180),(90,180),(90,-180),(-90,-180)]]
+SELECT flipCoordinates(materialize(readWkt('POINT(5 10)'))) FROM numbers(3);
+(10,5)
+(10,5)
+(10,5)
+DROP TABLE IF EXISTS test_geom;
+CREATE TABLE test_geom (id UInt32, geom Geometry) ENGINE = Memory;
+INSERT INTO test_geom VALUES
+    (1, readWkt('POINT(10 20)')),
+    (2, readWkt('LINESTRING(1 2, 3 4)')),
+    (3, readWkt('POLYGON((0 0, 5 0, 5 5, 0 5, 0 0))')),
+    (4, readWkt('POINT(30 40)')),
+    (5, readWkt('MULTIPOLYGON(((0 0, 2 0, 2 2, 0 2, 0 0)))'));
+SELECT id, flipCoordinates(geom) FROM test_geom ORDER BY id;
+1	(20,10)
+2	[(2,1),(4,3)]
+3	[[(0,0),(0,5),(5,5),(5,0),(0,0)]]
+4	(40,30)
+5	[[[(0,0),(0,2),(2,2),(2,0),(0,0)]]]
+DROP TABLE test_geom;

--- a/tests/queries/0_stateless/03444_flip_coordinates.sql
+++ b/tests/queries/0_stateless/03444_flip_coordinates.sql
@@ -1,4 +1,6 @@
 -- {echo}
+SET allow_suspicious_variant_types = 1;
+
 SELECT flipCoordinates(CAST((10.0, 20.0) AS Point));
 
 SELECT flipCoordinates(CAST([(10, 20), (30, 40), (50, 60)] AS LineString));
@@ -21,3 +23,38 @@ SELECT flipCoordinates(multiline);
 SELECT flipCoordinates(([[[(0, 0), (10, 0), (10, 10), (0, 10)]], [[(20, 20), (50, 20), (50, 50), (20, 50)],[(30, 30), (50, 50), (50, 30)]]]::MultiPolygon));
 
 SELECT flipCoordinates((1.23, 4.56)::Point), (([(1.23, 4.56)::Point, (2.34, 5.67)::Point])::Ring);
+
+SELECT flipCoordinates(readWkt('POINT(10 20)'));
+
+SELECT flipCoordinates(readWkt('LINESTRING(10 20, 30 40, 50 60)'));
+
+SELECT flipCoordinates(readWkt('POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))'));
+
+SELECT flipCoordinates(readWkt('POLYGON((-111.0544 45.0016, -104.0527 45.0016, -104.0527 40.9982, -111.0544 40.9982, -111.0544 45.0016))'));
+
+SELECT flipCoordinates(readWkt('POLYGON((0 0, 100 0, 100 100, 0 100, 0 0), (25 25, 75 25, 75 75, 25 75, 25 25))'));
+
+SELECT flipCoordinates(readWkt('MULTILINESTRING((10 20, 30 40), (50 60, 70 80))'));
+
+SELECT flipCoordinates(readWkt('MULTIPOLYGON(((0 0, 10 0, 10 10, 0 10, 0 0)))'));
+
+SELECT flipCoordinates(readWkt('MULTIPOLYGON(((0 0, 10 0, 10 10, 0 10)), ((20 20, 50 20, 50 50, 20 50), (30 30, 50 50, 50 30)))'));
+
+SELECT flipCoordinates(readWkt('POINT(-73.935242 40.730610)'));
+
+SELECT flipCoordinates(readWkt('POLYGON((-180 -90, 180 -90, 180 90, -180 90, -180 -90))'));
+
+SELECT flipCoordinates(materialize(readWkt('POINT(5 10)'))) FROM numbers(3);
+
+DROP TABLE IF EXISTS test_geom;
+CREATE TABLE test_geom (id UInt32, geom Geometry) ENGINE = Memory;
+INSERT INTO test_geom VALUES
+    (1, readWkt('POINT(10 20)')),
+    (2, readWkt('LINESTRING(1 2, 3 4)')),
+    (3, readWkt('POLYGON((0 0, 5 0, 5 5, 0 5, 0 0))')),
+    (4, readWkt('POINT(30 40)')),
+    (5, readWkt('MULTIPOLYGON(((0 0, 2 0, 2 2, 0 2, 0 0)))'));
+
+SELECT id, flipCoordinates(geom) FROM test_geom ORDER BY id;
+
+DROP TABLE test_geom;


### PR DESCRIPTION
This is a quick fix so that `flipCoordinates` could work with `Geometry` variant type. This special handling can be removed when https://github.com/ClickHouse/ClickHouse/pull/90900 is merged which adds default implementation for Variant type.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Support geometry type for `flipCoordinates`.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
