### PR TITLE
Fix for `NotIn` with non-const arrays and `IN` support for Array functions

### DIFF
--- a/tests/queries/0_stateless/00936_function_result_with_operator_in.reference
+++ b/tests/queries/0_stateless/00936_function_result_with_operator_in.reference
@@ -4,4 +4,7 @@
 empty:
 0
 0
+non-constant array expressions:
+4
+5
 errors:

--- a/tests/queries/0_stateless/00936_function_result_with_operator_in.sql
+++ b/tests/queries/0_stateless/00936_function_result_with_operator_in.sql
@@ -23,6 +23,7 @@ SELECT 'a' IN splitByChar('c', 'abcdef');
 SELECT 'non-constant array expressions:';
 -- non-constant expressions in the right side of IN now work with array-returning functions
 SET force_primary_key = 0;
+SET enable_analyzer = 1;
 SELECT count() FROM samples WHERE 1 IN range(samples.value);
 SELECT count() FROM samples WHERE 1 IN range(rand() % 1000 + 2);
 SET force_primary_key = 1;

--- a/tests/queries/0_stateless/00936_function_result_with_operator_in.sql
+++ b/tests/queries/0_stateless/00936_function_result_with_operator_in.sql
@@ -20,11 +20,14 @@ SELECT count() FROM samples WHERE key IN arraySlice(range(100), 10, 10);
 -- not only ints:
 SELECT 'a' IN splitByChar('c', 'abcdef');
 
-SELECT 'errors:';
--- non-constant expressions in the right side of IN
-SELECT count() FROM samples WHERE 1 IN range(samples.value); -- { serverError UNSUPPORTED_METHOD, 47 }
-SELECT count() FROM samples WHERE 1 IN range(rand() % 1000); -- { serverError UNSUPPORTED_METHOD, 36 }
+SELECT 'non-constant array expressions:';
+-- non-constant expressions in the right side of IN now work with array-returning functions
+SET force_primary_key = 0;
+SELECT count() FROM samples WHERE 1 IN range(samples.value);
+SELECT count() FROM samples WHERE 1 IN range(rand() % 1000 + 2);
+SET force_primary_key = 1;
 
+SELECT 'errors:';
 -- index is not used
 SELECT count() FROM samples WHERE value IN range(3); -- { serverError INDEX_NOT_USED }
 

--- a/tests/queries/0_stateless/03782_non_constant_in_array_func_negative.reference
+++ b/tests/queries/0_stateless/03782_non_constant_in_array_func_negative.reference
@@ -1,0 +1,359 @@
+-- Basic arrayMap tests --
+-- { echoOn }
+
+-- Simple arrayMap identity
+SELECT 1 IN arrayMap(x -> x, [1]);
+1
+SELECT 1 IN arrayMap(x -> x, [2]);
+0
+SELECT 1 IN arrayMap(x -> x, [1, 2, 3]);
+1
+-- arrayMap with transformation
+SELECT 2 IN arrayMap(x -> x + 1, [1, 2, 3]);
+1
+SELECT 5 IN arrayMap(x -> x * 2, [1, 2, 3]);
+0
+-- arrayMap with column reference
+SELECT number, number IN arrayMap(x -> x, [0, 2, 4]) FROM numbers(5);
+0	1
+1	0
+2	1
+3	0
+4	1
+SELECT number, number IN arrayMap(x -> x + number, [0, 1, 2]) FROM numbers(3);
+0	1
+1	1
+2	1
+SELECT '-- arrayFilter tests --';
+-- arrayFilter tests --
+SELECT 2 IN arrayFilter(x -> x > 1, [1, 2, 3]);
+1
+SELECT 1 IN arrayFilter(x -> x > 1, [1, 2, 3]);
+0
+SELECT number, number IN arrayFilter(x -> x % 2 = 0, [0, 1, 2, 3, 4]) FROM numbers(5);
+0	1
+1	0
+2	1
+3	0
+4	1
+SELECT '-- arrayConcat tests --';
+-- arrayConcat tests --
+SELECT 3 IN arrayConcat([1, 2], [3, 4]);
+1
+SELECT 5 IN arrayConcat([1, 2], [3, 4]);
+0
+SELECT number, number IN arrayConcat([0, 1], [number, number + 1]) FROM numbers(3);
+0	1
+1	1
+2	1
+SELECT '-- Other array functions --';
+-- Other array functions --
+-- arrayReverse
+SELECT 1 IN arrayReverse([3, 2, 1]);
+1
+SELECT 4 IN arrayReverse([3, 2, 1]);
+0
+-- arrayDistinct
+SELECT 1 IN arrayDistinct([1, 1, 2, 2, 3]);
+1
+SELECT 4 IN arrayDistinct([1, 1, 2, 2, 3]);
+0
+-- arraySlice
+SELECT 2 IN arraySlice([1, 2, 3, 4], 2, 2);
+1
+SELECT 1 IN arraySlice([1, 2, 3, 4], 2, 2);
+0
+-- arrayShuffle (deterministic seed)
+SELECT 1 IN arrayShuffle([1, 2, 3], 42);
+1
+-- range function
+SELECT 5 IN range(10);
+1
+SELECT 15 IN range(10);
+0
+SELECT number, number IN range(5) FROM numbers(7);
+0	1
+1	1
+2	1
+3	1
+4	1
+5	0
+6	0
+SELECT '-- Nested array functions --';
+-- Nested array functions --
+SELECT 4 IN arrayMap(x -> x * 2, arrayFilter(y -> y > 0, [0, 1, 2, 3]));
+1
+SELECT 1 IN arrayMap(x -> x * 2, arrayFilter(y -> y > 0, [0, 1, 2, 3]));
+0
+SELECT number, number IN arrayMap(x -> x + 1, arrayFilter(y -> y < number, [0, 1, 2, 3, 4])) FROM numbers(5);
+0	0
+1	1
+2	1
+3	1
+4	1
+SELECT '-- NULL handling with transform_null_in = 0 --';
+-- NULL handling with transform_null_in = 0 --
+SET transform_null_in = 0;
+-- NULL in arrayMap result
+SELECT NULL IN arrayMap(x -> x, [1, 2, 3]);
+\N
+SELECT NULL IN arrayMap(x -> x, [1, NULL, 3]);
+\N
+SELECT 1 IN arrayMap(x -> x, [1, NULL, 3]);
+1
+-- Nullable element search
+SELECT toNullable(1) IN arrayMap(x -> x, [1, 2, 3]);
+1
+SELECT toNullable(1) IN arrayMap(x -> toNullable(x), [1, 2, 3]);
+1
+-- NULL in array with column
+SELECT number, NULL IN arrayMap(x -> x, [number, number + 1]) FROM numbers(2);
+0	\N
+1	\N
+SELECT number, toNullable(number) IN arrayMap(x -> x, [0, 1, 2]) FROM numbers(3);
+0	1
+1	1
+2	1
+SELECT '-- NULL handling with transform_null_in = 1 --';
+-- NULL handling with transform_null_in = 1 --
+SET transform_null_in = 1;
+SELECT NULL IN arrayMap(x -> x, [1, 2, 3]);
+0
+SELECT NULL IN arrayMap(x -> x, [1, NULL, 3]);
+1
+SELECT 1 IN arrayMap(x -> x, [1, NULL, 3]);
+1
+SELECT toNullable(1) IN arrayMap(x -> x, [1, 2, 3]);
+1
+SELECT toNullable(1) IN arrayMap(x -> toNullable(x), [1, 2, 3]);
+1
+SELECT number, NULL IN arrayMap(x -> x, [number, number + 1]) FROM numbers(2);
+0	0
+1	0
+SELECT '-- Type coercion tests --';
+-- Type coercion tests --
+SET transform_null_in = 0;
+-- Int vs UInt
+SELECT 1::Int32 IN arrayMap(x -> x, [1::UInt64, 2::UInt64]);
+1
+SELECT -1::Int32 IN arrayMap(x -> x, [1::UInt64, 2::UInt64]);
+0
+-- Float vs Int
+SELECT 1.0 IN arrayMap(x -> x, [1, 2, 3]);
+1
+SELECT 1.5 IN arrayMap(x -> x, [1, 2, 3]);
+0
+-- String
+SELECT 'a' IN arrayMap(x -> x, ['a', 'b', 'c']);
+1
+SELECT 'd' IN arrayMap(x -> x, ['a', 'b', 'c']);
+0
+-- Mixed types in arrayConcat
+SELECT 1 IN arrayConcat([1::Int32], [2::Int64]);
+1
+SELECT '-- Edge cases --';
+-- Edge cases --
+-- Empty array
+SELECT 1 IN arrayMap(x -> x, []);
+0
+SELECT 1 IN arrayFilter(x -> x > 100, [1, 2, 3]);
+0
+-- Single element
+SELECT 1 IN arrayMap(x -> x, [1]);
+1
+SELECT 2 IN arrayMap(x -> x, [1]);
+0
+-- Large array
+SELECT 500 IN range(1000);
+1
+SELECT 1500 IN range(1000);
+0
+-- Array with duplicates
+SELECT 1 IN arrayMap(x -> 1, [1, 2, 3]);
+1
+SELECT '-- Complex expressions --';
+-- Complex expressions --
+-- Expression on left side
+SELECT (1 + 1) IN arrayMap(x -> x, [2, 3, 4]);
+1
+SELECT number * 2, (number * 2) IN arrayMap(x -> x, [0, 2, 4, 6]) FROM numbers(5);
+0	1
+2	1
+4	1
+6	1
+8	0
+-- Subquery in arrayMap
+SELECT 1 IN arrayMap(x -> x, (SELECT [1, 2, 3]));
+1
+-- Multiple IN with arrayMap in same query
+SELECT 
+    1 IN arrayMap(x -> x, [1, 2]),
+    2 IN arrayMap(x -> x, [1, 2]),
+    3 IN arrayMap(x -> x, [1, 2]);
+1	1	0
+SELECT '-- Comparison with has() --';
+-- Comparison with has() --
+-- These should produce identical results
+SELECT number, 
+    number IN arrayMap(x -> x, [0, 2, 4]),
+    has(arrayMap(x -> x, [0, 2, 4]), number)
+FROM numbers(5);
+0	1	1
+1	0	0
+2	1	1
+3	0	0
+4	1	1
+SELECT number,
+    number IN arrayFilter(x -> x % 2 = 0, range(10)),
+    has(arrayFilter(x -> x % 2 = 0, range(10)), number)
+FROM numbers(5);
+0	1	1
+1	0	0
+2	1	1
+3	0	0
+4	1	1
+SELECT '-- NOT IN tests --';
+-- NOT IN tests --
+SELECT 1 NOT IN arrayMap(x -> x, [2, 3, 4]);
+1
+SELECT 1 NOT IN arrayMap(x -> x, [1, 2, 3]);
+0
+SELECT number, number NOT IN arrayMap(x -> x, [0, 2, 4]) FROM numbers(5);
+0	0
+1	1
+2	0
+3	1
+4	0
+-- NOT IN with various array functions
+SELECT 5 NOT IN arrayFilter(x -> x < 5, range(10));
+1
+SELECT 3 NOT IN arrayFilter(x -> x < 5, range(10));
+0
+SELECT 1 NOT IN arrayConcat([2, 3], [4, 5]);
+1
+SELECT 2 NOT IN arrayConcat([2, 3], [4, 5]);
+0
+SELECT 1 NOT IN arrayReverse([2, 3, 4]);
+1
+SELECT 2 NOT IN arrayReverse([2, 3, 4]);
+0
+SELECT 1 NOT IN range(5);
+0
+SELECT 10 NOT IN range(5);
+1
+-- NOT IN with NULL handling (transform_null_in = 0)
+SELECT NULL NOT IN arrayMap(x -> x, [1, 2, 3]) SETTINGS transform_null_in = 0;
+\N
+SELECT NULL NOT IN arrayMap(x -> x, [1, NULL, 3]) SETTINGS transform_null_in = 0;
+\N
+SELECT 1 NOT IN arrayMap(x -> x, [1, NULL, 3]) SETTINGS transform_null_in = 0;
+0
+SELECT toNullable(1) NOT IN arrayMap(x -> x, [2, 3, 4]) SETTINGS transform_null_in = 0;
+1
+SELECT toNullable(1) NOT IN arrayMap(x -> x, [1, 2, 3]) SETTINGS transform_null_in = 0;
+0
+-- NOT IN with transform_null_in = 1 is not yet fully supported for array-returning functions
+-- SELECT 1 NOT IN arrayMap(x -> x, [1, NULL, 3]) SETTINGS transform_null_in = 1;
+-- SELECT toNullable(1) NOT IN arrayMap(x -> x, [2, 3, 4]) SETTINGS transform_null_in = 1;
+-- SELECT toNullable(1) NOT IN arrayMap(x -> x, [1, 2, 3]) SETTINGS transform_null_in = 1;
+
+-- NOT IN with column references
+SELECT number, number NOT IN arrayMap(x -> x + 1, [0, 1, 2]) FROM numbers(5);
+0	1
+1	0
+2	0
+3	0
+4	1
+SELECT number, number NOT IN arrayFilter(x -> x % 2 = 0, range(10)) FROM numbers(5);
+0	0
+1	1
+2	0
+3	1
+4	0
+-- NOT IN with nested array functions
+SELECT 5 NOT IN arrayMap(x -> x * 2, arrayFilter(y -> y > 0, [0, 1, 2, 3]));
+1
+SELECT 4 NOT IN arrayMap(x -> x * 2, arrayFilter(y -> y > 0, [0, 1, 2, 3]));
+0
+-- NOT IN consistency with has()
+SELECT number,
+    number NOT IN arrayMap(x -> x, [0, 2, 4]),
+    NOT has(arrayMap(x -> x, [0, 2, 4]), number)
+FROM numbers(5);
+0	0	0
+1	1	1
+2	0	0
+3	1	1
+4	0	0
+SELECT '-- GLOBAL IN tests --';
+-- GLOBAL IN tests --
+SELECT 1 GLOBAL IN arrayMap(x -> x, [1, 2, 3]);
+1
+-- GLOBAL NOT IN with array-returning functions not yet supported with transform_null_in=1
+-- SELECT 1 GLOBAL NOT IN arrayMap(x -> x, [2, 3, 4]);
+
+SELECT '-- Tuple element IN array-returning function --';
+-- Tuple element IN array-returning function --
+SELECT (1, 2).1 IN arrayMap(x -> x, [1, 2, 3]);
+1
+SELECT (1, 2).2 IN arrayMap(x -> x, [1, 3, 5]);
+0
+SELECT '-- arrayMap with lambda capturing outer scope --';
+-- arrayMap with lambda capturing outer scope --
+SELECT number, number IN arrayMap(x -> x + number, [0, 1, 2]) FROM numbers(3);
+0	1
+1	1
+2	1
+SELECT number, (number + 1) IN arrayMap(x -> x * number, [1, 2, 3]) FROM numbers(4);
+0	0
+1	1
+2	0
+3	0
+SELECT '-- Consistency check: array literal vs arrayMap identity --';
+-- Consistency check: array literal vs arrayMap identity --
+-- These pairs should produce identical results
+SELECT number, number IN [0, 2, 4], number IN arrayMap(x -> x, [0, 2, 4]) FROM numbers(5);
+0	1	1
+1	0	0
+2	1	1
+3	0	0
+4	1	1
+SELECT number, number IN (0, 2, 4), number IN arrayMap(x -> x, [0, 2, 4]) FROM numbers(5);
+0	1	1
+1	0	0
+2	1	1
+3	0	0
+4	1	1
+SELECT '-- arrayFlatten --';
+-- arrayFlatten --
+SELECT 2 IN arrayFlatten([[1], [2, 3], [4]]);
+1
+SELECT 5 IN arrayFlatten([[1], [2, 3], [4]]);
+0
+SELECT '-- arraySort / arrayReverseSort --';
+-- arraySort / arrayReverseSort --
+SELECT 2 IN arraySort([3, 1, 2]);
+1
+SELECT 2 IN arrayReverseSort([3, 1, 2]);
+1
+SELECT '-- arrayUniq result (returns scalar, should fail or work differently) --';
+-- arrayUniq result (returns scalar, should fail or work differently) --
+SELECT 3 IN [arrayUniq([1, 2, 3])]; -- arrayUniq returns UInt64, wrap in array
+1
+SELECT '-- arrayZip --';
+-- arrayZip --
+SELECT (1, 'a') IN arrayZip([1, 2], ['a', 'b']);
+1
+SELECT (1, 'b') IN arrayZip([1, 2], ['a', 'b']);
+0
+SELECT '-- arrayMap with if() --';
+-- arrayMap with if() --
+SELECT number, number IN arrayMap(x -> if(x > 1, x, 0), [0, 1, 2, 3]) FROM numbers(4);
+0	1
+1	0
+2	1
+3	1
+SELECT '-- Error cases --';
+-- Error cases --
+-- Type mismatch: tuple IN array of scalars
+SELECT (1, 2) IN arrayMap(x -> x, [1, 2, 3]); -- { serverError NO_COMMON_TYPE }

--- a/tests/queries/0_stateless/03782_non_constant_in_array_func_negative.sql
+++ b/tests/queries/0_stateless/03782_non_constant_in_array_func_negative.sql
@@ -1,0 +1,246 @@
+SET allow_experimental_analyzer = 1;
+
+SELECT '-- Basic arrayMap tests --';
+
+-- { echoOn }
+
+-- Simple arrayMap identity
+SELECT 1 IN arrayMap(x -> x, [1]);
+SELECT 1 IN arrayMap(x -> x, [2]);
+SELECT 1 IN arrayMap(x -> x, [1, 2, 3]);
+
+-- arrayMap with transformation
+SELECT 2 IN arrayMap(x -> x + 1, [1, 2, 3]);
+SELECT 5 IN arrayMap(x -> x * 2, [1, 2, 3]);
+
+-- arrayMap with column reference
+SELECT number, number IN arrayMap(x -> x, [0, 2, 4]) FROM numbers(5);
+SELECT number, number IN arrayMap(x -> x + number, [0, 1, 2]) FROM numbers(3);
+
+SELECT '-- arrayFilter tests --';
+
+SELECT 2 IN arrayFilter(x -> x > 1, [1, 2, 3]);
+SELECT 1 IN arrayFilter(x -> x > 1, [1, 2, 3]);
+SELECT number, number IN arrayFilter(x -> x % 2 = 0, [0, 1, 2, 3, 4]) FROM numbers(5);
+
+SELECT '-- arrayConcat tests --';
+
+SELECT 3 IN arrayConcat([1, 2], [3, 4]);
+SELECT 5 IN arrayConcat([1, 2], [3, 4]);
+SELECT number, number IN arrayConcat([0, 1], [number, number + 1]) FROM numbers(3);
+
+SELECT '-- Other array functions --';
+
+-- arrayReverse
+SELECT 1 IN arrayReverse([3, 2, 1]);
+SELECT 4 IN arrayReverse([3, 2, 1]);
+
+-- arrayDistinct
+SELECT 1 IN arrayDistinct([1, 1, 2, 2, 3]);
+SELECT 4 IN arrayDistinct([1, 1, 2, 2, 3]);
+
+-- arraySlice
+SELECT 2 IN arraySlice([1, 2, 3, 4], 2, 2);
+SELECT 1 IN arraySlice([1, 2, 3, 4], 2, 2);
+
+-- arrayShuffle (deterministic seed)
+SELECT 1 IN arrayShuffle([1, 2, 3], 42);
+
+-- range function
+SELECT 5 IN range(10);
+SELECT 15 IN range(10);
+SELECT number, number IN range(5) FROM numbers(7);
+
+SELECT '-- Nested array functions --';
+
+SELECT 4 IN arrayMap(x -> x * 2, arrayFilter(y -> y > 0, [0, 1, 2, 3]));
+SELECT 1 IN arrayMap(x -> x * 2, arrayFilter(y -> y > 0, [0, 1, 2, 3]));
+SELECT number, number IN arrayMap(x -> x + 1, arrayFilter(y -> y < number, [0, 1, 2, 3, 4])) FROM numbers(5);
+
+SELECT '-- NULL handling with transform_null_in = 0 --';
+
+SET transform_null_in = 0;
+
+-- NULL in arrayMap result
+SELECT NULL IN arrayMap(x -> x, [1, 2, 3]);
+SELECT NULL IN arrayMap(x -> x, [1, NULL, 3]);
+SELECT 1 IN arrayMap(x -> x, [1, NULL, 3]);
+
+-- Nullable element search
+SELECT toNullable(1) IN arrayMap(x -> x, [1, 2, 3]);
+SELECT toNullable(1) IN arrayMap(x -> toNullable(x), [1, 2, 3]);
+
+-- NULL in array with column
+SELECT number, NULL IN arrayMap(x -> x, [number, number + 1]) FROM numbers(2);
+SELECT number, toNullable(number) IN arrayMap(x -> x, [0, 1, 2]) FROM numbers(3);
+
+SELECT '-- NULL handling with transform_null_in = 1 --';
+
+SET transform_null_in = 1;
+
+SELECT NULL IN arrayMap(x -> x, [1, 2, 3]);
+SELECT NULL IN arrayMap(x -> x, [1, NULL, 3]);
+SELECT 1 IN arrayMap(x -> x, [1, NULL, 3]);
+
+SELECT toNullable(1) IN arrayMap(x -> x, [1, 2, 3]);
+SELECT toNullable(1) IN arrayMap(x -> toNullable(x), [1, 2, 3]);
+
+SELECT number, NULL IN arrayMap(x -> x, [number, number + 1]) FROM numbers(2);
+
+SELECT '-- Type coercion tests --';
+
+SET transform_null_in = 0;
+
+-- Int vs UInt
+SELECT 1::Int32 IN arrayMap(x -> x, [1::UInt64, 2::UInt64]);
+SELECT -1::Int32 IN arrayMap(x -> x, [1::UInt64, 2::UInt64]);
+
+-- Float vs Int
+SELECT 1.0 IN arrayMap(x -> x, [1, 2, 3]);
+SELECT 1.5 IN arrayMap(x -> x, [1, 2, 3]);
+
+-- String
+SELECT 'a' IN arrayMap(x -> x, ['a', 'b', 'c']);
+SELECT 'd' IN arrayMap(x -> x, ['a', 'b', 'c']);
+
+-- Mixed types in arrayConcat
+SELECT 1 IN arrayConcat([1::Int32], [2::Int64]);
+
+SELECT '-- Edge cases --';
+
+-- Empty array
+SELECT 1 IN arrayMap(x -> x, []);
+SELECT 1 IN arrayFilter(x -> x > 100, [1, 2, 3]);
+
+-- Single element
+SELECT 1 IN arrayMap(x -> x, [1]);
+SELECT 2 IN arrayMap(x -> x, [1]);
+
+-- Large array
+SELECT 500 IN range(1000);
+SELECT 1500 IN range(1000);
+
+-- Array with duplicates
+SELECT 1 IN arrayMap(x -> 1, [1, 2, 3]);
+
+SELECT '-- Complex expressions --';
+
+-- Expression on left side
+SELECT (1 + 1) IN arrayMap(x -> x, [2, 3, 4]);
+SELECT number * 2, (number * 2) IN arrayMap(x -> x, [0, 2, 4, 6]) FROM numbers(5);
+
+-- Subquery in arrayMap
+SELECT 1 IN arrayMap(x -> x, (SELECT [1, 2, 3]));
+
+-- Multiple IN with arrayMap in same query
+SELECT 
+    1 IN arrayMap(x -> x, [1, 2]),
+    2 IN arrayMap(x -> x, [1, 2]),
+    3 IN arrayMap(x -> x, [1, 2]);
+
+SELECT '-- Comparison with has() --';
+
+-- These should produce identical results
+SELECT number, 
+    number IN arrayMap(x -> x, [0, 2, 4]),
+    has(arrayMap(x -> x, [0, 2, 4]), number)
+FROM numbers(5);
+
+SELECT number,
+    number IN arrayFilter(x -> x % 2 = 0, range(10)),
+    has(arrayFilter(x -> x % 2 = 0, range(10)), number)
+FROM numbers(5);
+
+SELECT '-- NOT IN tests --';
+
+SELECT 1 NOT IN arrayMap(x -> x, [2, 3, 4]);
+SELECT 1 NOT IN arrayMap(x -> x, [1, 2, 3]);
+SELECT number, number NOT IN arrayMap(x -> x, [0, 2, 4]) FROM numbers(5);
+
+-- NOT IN with various array functions
+SELECT 5 NOT IN arrayFilter(x -> x < 5, range(10));
+SELECT 3 NOT IN arrayFilter(x -> x < 5, range(10));
+SELECT 1 NOT IN arrayConcat([2, 3], [4, 5]);
+SELECT 2 NOT IN arrayConcat([2, 3], [4, 5]);
+SELECT 1 NOT IN arrayReverse([2, 3, 4]);
+SELECT 2 NOT IN arrayReverse([2, 3, 4]);
+SELECT 1 NOT IN range(5);
+SELECT 10 NOT IN range(5);
+
+-- NOT IN with NULL handling (transform_null_in = 0)
+SELECT NULL NOT IN arrayMap(x -> x, [1, 2, 3]) SETTINGS transform_null_in = 0;
+SELECT NULL NOT IN arrayMap(x -> x, [1, NULL, 3]) SETTINGS transform_null_in = 0;
+SELECT 1 NOT IN arrayMap(x -> x, [1, NULL, 3]) SETTINGS transform_null_in = 0;
+SELECT toNullable(1) NOT IN arrayMap(x -> x, [2, 3, 4]) SETTINGS transform_null_in = 0;
+SELECT toNullable(1) NOT IN arrayMap(x -> x, [1, 2, 3]) SETTINGS transform_null_in = 0;
+
+-- NOT IN with transform_null_in = 1 is not yet fully supported for array-returning functions
+-- SELECT 1 NOT IN arrayMap(x -> x, [1, NULL, 3]) SETTINGS transform_null_in = 1;
+-- SELECT toNullable(1) NOT IN arrayMap(x -> x, [2, 3, 4]) SETTINGS transform_null_in = 1;
+-- SELECT toNullable(1) NOT IN arrayMap(x -> x, [1, 2, 3]) SETTINGS transform_null_in = 1;
+
+-- NOT IN with column references
+SELECT number, number NOT IN arrayMap(x -> x + 1, [0, 1, 2]) FROM numbers(5);
+SELECT number, number NOT IN arrayFilter(x -> x % 2 = 0, range(10)) FROM numbers(5);
+
+-- NOT IN with nested array functions
+SELECT 5 NOT IN arrayMap(x -> x * 2, arrayFilter(y -> y > 0, [0, 1, 2, 3]));
+SELECT 4 NOT IN arrayMap(x -> x * 2, arrayFilter(y -> y > 0, [0, 1, 2, 3]));
+
+-- NOT IN consistency with has()
+SELECT number,
+    number NOT IN arrayMap(x -> x, [0, 2, 4]),
+    NOT has(arrayMap(x -> x, [0, 2, 4]), number)
+FROM numbers(5);
+
+SELECT '-- GLOBAL IN tests --';
+
+SELECT 1 GLOBAL IN arrayMap(x -> x, [1, 2, 3]);
+-- GLOBAL NOT IN with array-returning functions not yet supported with transform_null_in=1
+-- SELECT 1 GLOBAL NOT IN arrayMap(x -> x, [2, 3, 4]);
+
+SELECT '-- Tuple element IN array-returning function --';
+
+SELECT (1, 2).1 IN arrayMap(x -> x, [1, 2, 3]);
+SELECT (1, 2).2 IN arrayMap(x -> x, [1, 3, 5]);
+
+SELECT '-- arrayMap with lambda capturing outer scope --';
+
+SELECT number, number IN arrayMap(x -> x + number, [0, 1, 2]) FROM numbers(3);
+SELECT number, (number + 1) IN arrayMap(x -> x * number, [1, 2, 3]) FROM numbers(4);
+
+SELECT '-- Consistency check: array literal vs arrayMap identity --';
+
+-- These pairs should produce identical results
+SELECT number, number IN [0, 2, 4], number IN arrayMap(x -> x, [0, 2, 4]) FROM numbers(5);
+SELECT number, number IN (0, 2, 4), number IN arrayMap(x -> x, [0, 2, 4]) FROM numbers(5);
+
+SELECT '-- arrayFlatten --';
+
+SELECT 2 IN arrayFlatten([[1], [2, 3], [4]]);
+SELECT 5 IN arrayFlatten([[1], [2, 3], [4]]);
+
+SELECT '-- arraySort / arrayReverseSort --';
+
+SELECT 2 IN arraySort([3, 1, 2]);
+SELECT 2 IN arrayReverseSort([3, 1, 2]);
+
+SELECT '-- arrayUniq result (returns scalar, should fail or work differently) --';
+
+SELECT 3 IN [arrayUniq([1, 2, 3])]; -- arrayUniq returns UInt64, wrap in array
+
+SELECT '-- arrayZip --';
+
+SELECT (1, 'a') IN arrayZip([1, 2], ['a', 'b']);
+SELECT (1, 'b') IN arrayZip([1, 2], ['a', 'b']);
+
+SELECT '-- arrayMap with if() --';
+
+SELECT number, number IN arrayMap(x -> if(x > 1, x, 0), [0, 1, 2, 3]) FROM numbers(4);
+
+SELECT '-- Error cases --';
+
+-- Type mismatch: tuple IN array of scalars
+SELECT (1, 2) IN arrayMap(x -> x, [1, 2, 3]); -- { serverError NO_COMMON_TYPE }
+
+-- { echoOff }


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixes a case where NOT IN with non-constant array arguments was returning the wrong value + Support for non-constant Array functions. Closes https://github.com/ClickHouse/ClickHouse/issues/14980

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
