### PR TITLE
CI: Enable local run for Fuzzer and Stress test jobs

### DIFF
--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -865,6 +865,7 @@ class JobConfigs:
             include_paths=[
                 "./ci/docker/fuzzer",
                 "./ci/jobs/buzzhouse_job.py",
+                "./ci/jobs/ast_fuzzer_job.py",
                 "./ci/jobs/scripts/log_parser.py",
                 "./ci/jobs/scripts/functional_tests/setup_log_cluster.sh",
                 "./ci/jobs/scripts/fuzzer/",

--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -1228,14 +1228,29 @@ if __name__ == "__main__":
     res = False
     try:
         if command == "logs_export_config":
-            res = ch.create_log_export_config()
+            if not Info().is_local_run:
+                # Disable log export for local runs - ideally this command wouldn't be triggered,
+                # but conditional disabling is complex in legacy bash scripts (run_fuzzer.sh, stress_runner.sh)
+                res = ch.create_log_export_config()
+            else:
+                res = True
         elif command == "logs_export_start":
             # FIXME: the start_time must be preserved globally in ENV or something like that
             # to get the same values in different DBs
             # As a wild idea, it could be stored in a Info.check_start_timestamp
-            res = ch.start_log_exports(check_start_time=Utils.timestamp())
+            if not Info().is_local_run:
+                # Disable log export for local runs - ideally this command wouldn't be triggered,
+                # but conditional disabling is complex in legacy bash scripts (run_fuzzer.sh, stress_runner.sh)
+                res = ch.start_log_exports(check_start_time=Utils.timestamp())
+            else:
+                res = True
         elif command == "logs_export_stop":
-            res = ch.stop_log_exports()
+            if not Info().is_local_run:
+                # Disable log export for local runs - ideally this command wouldn't be triggered,
+                # but conditional disabling is complex in legacy bash scripts (run_fuzzer.sh, stress_runner.sh)
+                res = ch.stop_log_exports()
+            else:
+                res = True
         elif command == "start_minio":
             param = sys.argv[2]
             assert param in ["stateless"]


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

For local runs, conditionally disable the **_log export_** functionality for AST/Buzz Fuzzer and Stress jobs that cannot work locally without aws auth
