### PR TITLE
Fix flaky test_scheduler_cpu_preemptive::test_independent_pools

### DIFF
--- a/tests/integration/test_scheduler_cpu_preemptive/test.py
+++ b/tests/integration/test_scheduler_cpu_preemptive/test.py
@@ -146,7 +146,7 @@ def test_create_workload():
     ],
     indirect=True,
 )
-def test_independent_pools():
+def test_independent_pools(with_custom_config):
     node.query(
         f"""
         create resource cpu (master thread, worker thread);

--- a/tests/integration/test_scheduler_cpu_preemptive/test.py
+++ b/tests/integration/test_scheduler_cpu_preemptive/test.py
@@ -136,6 +136,16 @@ def test_create_workload():
     do_checks()
 
 
+@pytest.mark.parametrize(
+    "with_custom_config",
+    [
+        pytest.param(
+            {'node': {"cpu_slot_preemption_timeout_ms": "60000"}},
+            id="cpu-slot-preemption-timeout-60s",
+        )
+    ],
+    indirect=True,
+)
 def test_independent_pools():
     node.query(
         f"""
@@ -175,7 +185,7 @@ def test_independent_pools():
             "ConcurrencyControlSlotsAcquired",
             lambda x: x <= slots,
         )
-        # Short preemptions may happen due to lags in the scheduler thread, but dowscales should not
+        # Short preemptions may happen due to lags in the scheduler thread, but dowscales should not. To enforce that we set high preemption timeout.
         assert_profile_event(
             node,
             query_id,


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes https://github.com/ClickHouse/ClickHouse/issues/87655 and https://github.com/ClickHouse/ClickHouse/issues/92760. It avoids downscaling by raising the preemption timeout.

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
