### PR TITLE
Fix timeout in test_scheduler_cpu_preemptive::test_downscaling with TSan

### DIFF
--- a/tests/integration/test_scheduler_cpu_preemptive/test.py
+++ b/tests/integration/test_scheduler_cpu_preemptive/test.py
@@ -390,7 +390,7 @@ class DynamicQueryPool:
     indirect=True,
 )
 def test_downscaling(with_custom_config):
-    if node.is_built_with_address_sanitizer():
+    if node.is_built_with_address_sanitizer() or node.is_built_with_thread_sanitizer():
         pytest.skip("doesn't fit in timeouts due to heavy workload")
 
     node.query(


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Seems like tsan also makes this test too slow as msan. 
Report: https://d1k2gkhrlfqv31.cloudfront.net/clickhouse-test-reports-private/json.html?REF=master&sha=a136406d2a64d1ecd0db4fff07a934f7f9ab1530&name_0=MasterCI&name_1=Integration%20tests%20%28amd_tsan%2C%202%2F6%29&name_1=Integration%20tests%20%28amd_tsan%2C%202%2F6%29

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
