### PR TITLE
Fix flaky test_throttling

### DIFF
--- a/tests/integration/test_throttling/test.py
+++ b/tests/integration/test_throttling/test.py
@@ -399,7 +399,7 @@ def test_remote_read_throttling_reload():
     node.query("SYSTEM RELOAD CONFIG")
 
     _, took = elapsed(node.query, f"select * from data")
-    assert took < 1
+    assert took < 3
 
 def test_local_read_throttling_reload():
     node.query(
@@ -430,7 +430,7 @@ def test_local_read_throttling_reload():
     node.query("SYSTEM RELOAD CONFIG")
 
     _, took = elapsed(node.query, f"select * from data")
-    assert took < 1
+    assert took < 3
 
 @pytest.mark.parametrize(
     "policy,mode,setting,value,should_take",
@@ -522,7 +522,7 @@ def test_remote_write_throttling_reload():
     node.query("SYSTEM RELOAD CONFIG")
 
     _, took = elapsed(node.query, f"insert into data select * from numbers(1e6)")
-    assert took < 1
+    assert took < 3
 
 def test_local_write_throttling_reload():
     node.query(
@@ -553,7 +553,7 @@ def test_local_write_throttling_reload():
     node.query("SYSTEM RELOAD CONFIG")
 
     _, took = elapsed(node.query, f"insert into data select * from numbers(1e6)")
-    assert took < 1
+    assert took < 3
 
 def test_max_mutations_bandwidth_for_server():
     node.query(


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes rare flakiness of tests that check config changes on the fly w/o a server restart. Unfortunately, there is no reliable way to check for an unlimited case, so we only increase the arbitrary check from "<1" to "<3". This is because in the limited case, it should be ">3", and we need to distinguish between these cases. 

Fixes: https://github.com/ClickHouse/ClickHouse/issues/93251
Fixes: https://github.com/ClickHouse/ClickHouse/issues/86098
Fixes: https://github.com/ClickHouse/ClickHouse/issues/86963
Fixes: https://github.com/ClickHouse/ClickHouse/issues/85563