### PR TITLE
Improve the UX of SYSTEM INSTRUMENT ADD/REMOVE

### DIFF
--- a/docs/en/sql-reference/statements/system.md
+++ b/docs/en/sql-reference/statements/system.md
@@ -252,8 +252,8 @@ where `FUNCTION` is any function or substring of a function such as `QueryMetric
 Prints the text provided as an argument and the stack trace either on `ENTRY` or `EXIT` of the function.
 
 ```sql
-SYSTEM INSTRUMENT ADD `QueryMetricLog::startQuery` LOG ENTRY 'this is a log printed at entry'
-SYSTEM INSTRUMENT ADD `QueryMetricLog::startQuery` LOG EXIT 'this is a log printed at exit'
+SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' LOG ENTRY 'this is a log printed at entry'
+SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' LOG EXIT 'this is a log printed at exit'
 ```
 
 #### SLEEP {#instrument-add-sleep}
@@ -261,13 +261,13 @@ SYSTEM INSTRUMENT ADD `QueryMetricLog::startQuery` LOG EXIT 'this is a log print
 Sleeps for a number of fix amount of seconds either on `ENTRY` or `EXIT`:
 
 ```sql
-SYSTEM INSTRUMENT ADD `QueryMetricLog::startQuery` SLEEP ENTRY 0.5
+SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' SLEEP ENTRY 0.5
 ```
 
 or for a uniformly distributed random amount of seconds providing min and max separated by a whitespace:
 
 ```sql
-SYSTEM INSTRUMENT ADD `QueryMetricLog::startQuery` SLEEP ENTRY 0 1
+SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' SLEEP ENTRY 0 1
 ```
 
 #### PROFILE {#instrument-add-profile}
@@ -277,7 +277,7 @@ The result of the profiling is stored in [`system.trace_log`](../../operations/s
 to [Chrome Event Trace Format](../../operations/system-tables/trace_log.md#chrome-event-trace-format).
 
 ```sql
-SYSTEM INSTRUMENT ADD `QueryMetricLog::startQuery` PROFILE
+SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' PROFILE
 ```
 
 ### SYSTEM INSTRUMENT REMOVE {#instrument-remove}
@@ -294,13 +294,19 @@ all of them using the `ALL` parameter:
 SYSTEM INSTRUMENT REMOVE ALL
 ```
 
-or a set of IDs from a subquery:
+a set of IDs from a subquery:
 
 ```sql
 SYSTEM INSTRUMENT REMOVE (SELECT id FROM system.instrumentation WHERE handler = 'log')
 ```
 
-The instrumentation point ID can be collected from [`system.instrumentation`](../../operations/system-tables/instrumentation.md) system table.
+or all instrumentation points that match a given function_name:
+
+```sql
+SYSTEM INSTRUMENT REMOVE 'QueryMetricLog::startQuery'
+```
+
+The instrumentation point information can be collected from [`system.instrumentation`](../../operations/system-tables/instrumentation.md) system table.
 
 ## Managing Distributed Tables {#managing-distributed-tables}
 

--- a/src/Interpreters/InstrumentationManager.cpp
+++ b/src/Interpreters/InstrumentationManager.cpp
@@ -153,7 +153,8 @@ void InstrumentationManager::patchFunction(ContextPtr context, const String & fu
     /// Lazy load the XRay instrumentation map only once we need to set up a handler
     ensureInitialization();
 
-    struct Function {
+    struct Function
+    {
         Int32 function_id;
         String symbol;
     };

--- a/src/Interpreters/InstrumentationManager.cpp
+++ b/src/Interpreters/InstrumentationManager.cpp
@@ -184,7 +184,7 @@ void InstrumentationManager::patchFunction(ContextPtr context, const String & fu
 
     std::lock_guard lock(shared_mutex);
 
-    for (auto [function_id, symbol] : functions_to_patch)
+    for (const auto & [function_id, symbol] : functions_to_patch)
     {
         patchFunctionIfNeeded(function_id);
 

--- a/src/Interpreters/InstrumentationManager.cpp
+++ b/src/Interpreters/InstrumentationManager.cpp
@@ -153,15 +153,18 @@ void InstrumentationManager::patchFunction(ContextPtr context, const String & fu
     /// Lazy load the XRay instrumentation map only once we need to set up a handler
     ensureInitialization();
 
-    Int32 function_id = -1;
-    String symbol;
+    struct Function {
+        Int32 function_id;
+        String symbol;
+    };
+
+    std::vector<Function> functions_to_patch;
     auto fn_it = functions_container.get<FunctionName>().find(function_name);
 
     /// First, assume the name provided is the full qualified name.
     if (fn_it != functions_container.get<FunctionName>().end())
     {
-        function_id = fn_it->function_id;
-        symbol = fn_it->function_name;
+        functions_to_patch.emplace_back(fn_it->function_id, fn_it->function_name);
     }
     else
     {
@@ -170,25 +173,27 @@ void InstrumentationManager::patchFunction(ContextPtr context, const String & fu
         {
             if (function.find(function_name) != std::string::npos)
             {
-                function_id = id;
-                symbol = function;
-                break;
+                functions_to_patch.emplace_back(id, function);
             }
         }
     }
 
-    if (function_id < 0 || symbol.empty())
+    if (functions_to_patch.empty())
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unknown function to instrument: '{}'. XRay instruments by default only functions of at least 200 instructions. "
             "You can change that threshold with '-fxray-instruction-threshold=1'. You can also force the instrumentation of specific functions decorating them with '[[clang::xray_always_instrument]]' "
             "and making sure they are not decorated with '[[clang::xray_never_instrument]]'", function_name);
 
     std::lock_guard lock(shared_mutex);
-    patchFunctionIfNeeded(function_id);
 
-    InstrumentedPointInfo info{context, instrumented_point_ids, function_id, function_name, handler_name_lower, entry_type, symbol, parameters};
-    LOG_INFO(logger, "Adding instrumentation point for {}", info.toString());
-    instrumented_points.emplace(std::move(info));
-    instrumented_point_ids++;
+    for (auto [function_id, symbol] : functions_to_patch)
+    {
+        patchFunctionIfNeeded(function_id);
+
+        InstrumentedPointInfo info{context, instrumented_point_ids, function_id, function_name, handler_name_lower, entry_type, symbol, parameters};
+        LOG_INFO(logger, "Adding instrumentation point for {}", info.toString());
+        instrumented_points.emplace(std::move(info));
+        instrumented_point_ids++;
+    }
 }
 
 void InstrumentationManager::unpatchFunction(std::variant<UInt64, bool> id)

--- a/src/Interpreters/InstrumentationManager.h
+++ b/src/Interpreters/InstrumentationManager.h
@@ -40,6 +40,8 @@ namespace Instrumentation
 EntryType fromXRayEntryType(XRayEntryType entry_type);
 String entryTypeToString(EntryType entry_type);
 
+struct All {};
+
 }
 
 struct TraceLogElement;
@@ -100,7 +102,7 @@ public:
     static InstrumentationManager & instance();
 
     [[clang::xray_never_instrument]] void patchFunction(ContextPtr context, const String & function_name, const String & handler_name, Instrumentation::EntryType entry_type, const std::vector<InstrumentedParameter> & parameters);
-    [[clang::xray_never_instrument]] void unpatchFunction(std::variant<UInt64, bool> id);
+    [[clang::xray_never_instrument]] void unpatchFunction(std::variant<UInt64, Instrumentation::All, String> id);
 
     using InstrumentedPoints = std::vector<InstrumentedPointInfo>;
     InstrumentedPoints getInstrumentedPoints() const;

--- a/src/Interpreters/InterpreterSystemQuery.cpp
+++ b/src/Interpreters/InterpreterSystemQuery.cpp
@@ -1838,19 +1838,21 @@ void InterpreterSystemQuery::instrumentWithXRay(bool add, ASTSystemQuery & query
             }
             else
             {
-                InstrumentationManager::instance().unpatchFunction(query.instrumentation_point_id.value());
+                InstrumentationManager::instance().unpatchFunction(query.instrumentation_point.value());
             }
         }
     }
     catch (const DB::Exception & e)
     {
         String id;
-        if (query.instrumentation_point_id.has_value())
+        if (query.instrumentation_point.has_value())
         {
-            if (std::holds_alternative<bool>(query.instrumentation_point_id.value()))
+            if (std::holds_alternative<Instrumentation::All>(query.instrumentation_point.value()))
                 id = " and ALL ids";
+            else if (std::holds_alternative<String>(query.instrumentation_point.value()))
+                id = fmt::format(" and ids with function_name containing '{}'", std::get<String>(query.instrumentation_point.value()));
             else
-                id = fmt::format(" and id '{}'", std::get<UInt64>(query.instrumentation_point_id.value()));
+                id = fmt::format(" and id '{}'", std::get<UInt64>(query.instrumentation_point.value()));
         }
 
         throw Exception(

--- a/src/Parsers/ASTSystemQuery.cpp
+++ b/src/Parsers/ASTSystemQuery.cpp
@@ -500,9 +500,7 @@ void ASTSystemQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & setti
         case Type::INSTRUMENT_ADD:
         {
             if (!instrumentation_function_name.empty())
-            {
                 ostr << ' ' << quoteString(instrumentation_function_name);
-            }
 
             if (!instrumentation_handler_name.empty())
             {
@@ -542,12 +540,14 @@ void ASTSystemQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & setti
         {
             if (!instrumentation_subquery.empty())
                 ostr << " (" << instrumentation_subquery << ')';
-            else if (instrumentation_point_id)
+            else if (instrumentation_point)
             {
-                if (std::holds_alternative<bool>(instrumentation_point_id.value()))
+                if (std::holds_alternative<Instrumentation::All>(instrumentation_point.value()))
                     ostr << " ALL";
+                else if (std::holds_alternative<String>(instrumentation_point.value()))
+                    ostr << ' ' << quoteString(std::get<String>(instrumentation_point.value()));
                 else
-                    ostr << ' ' << std::get<UInt64>(instrumentation_point_id.value());
+                    ostr << ' ' << std::get<UInt64>(instrumentation_point.value());
             }
             break;
         }

--- a/src/Parsers/ASTSystemQuery.cpp
+++ b/src/Parsers/ASTSystemQuery.cpp
@@ -501,8 +501,7 @@ void ASTSystemQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & setti
         {
             if (!instrumentation_function_name.empty())
             {
-                ostr << ' ';
-                print_identifier(instrumentation_function_name);
+                ostr << ' ' << quoteString(instrumentation_function_name);
             }
 
             if (!instrumentation_handler_name.empty())

--- a/src/Parsers/ASTSystemQuery.h
+++ b/src/Parsers/ASTSystemQuery.h
@@ -204,7 +204,7 @@ public:
     String instrumentation_function_name;
     String instrumentation_handler_name;
     Instrumentation::EntryType instrumentation_entry_type;
-    std::optional<std::variant<UInt64, bool>> instrumentation_point_id;
+    std::optional<std::variant<UInt64, Instrumentation::All, String>> instrumentation_point;
     std::vector<InstrumentParameter> instrumentation_parameters;
     String instrumentation_subquery;
 #endif

--- a/src/Parsers/ParserSystemQuery.cpp
+++ b/src/Parsers/ParserSystemQuery.cpp
@@ -797,14 +797,14 @@ bool ParserSystemQuery::parseImpl(IParser::Pos & pos, ASTPtr & node, Expected & 
                 break;
             }
 
-            res->instrumentation_point_id = temporary_identifier->as<ASTLiteral>()->value.safeGet<UInt64>();
+            res->instrumentation_point_id = temporary_identifier->as<ASTLiteral &>().value.safeGet<UInt64>();
             break;
         }
         case Type::INSTRUMENT_ADD:
         {
             ASTPtr temporary_identifier;
-            if (ParserIdentifier{}.parse(pos, temporary_identifier, expected))
-                res->instrumentation_function_name = temporary_identifier->as<ASTIdentifier &>().name();
+            if (ParserLiteral{}.parse(pos, temporary_identifier, expected))
+                res->instrumentation_function_name = temporary_identifier->as<ASTLiteral &>().value.safeGet<String>();
             else
                 return false;
 

--- a/src/Parsers/ParserSystemQuery.cpp
+++ b/src/Parsers/ParserSystemQuery.cpp
@@ -802,9 +802,9 @@ bool ParserSystemQuery::parseImpl(IParser::Pos & pos, ASTPtr & node, Expected & 
             }
             else if (ParserIdentifier{}.parse(pos, temporary_identifier, expected))
             {
-                    String identifier = temporary_identifier->as<ASTIdentifier &>().name();
-                    if (Poco::toLower(identifier) == "all")
-                        res->instrumentation_point = Instrumentation::All{};
+                String identifier = temporary_identifier->as<ASTIdentifier &>().name();
+                if (Poco::toLower(identifier) == "all")
+                    res->instrumentation_point = Instrumentation::All{};
                 else
                     return false;
             }

--- a/src/Parsers/ParserSystemQuery.cpp
+++ b/src/Parsers/ParserSystemQuery.cpp
@@ -785,19 +785,30 @@ bool ParserSystemQuery::parseImpl(IParser::Pos & pos, ASTPtr & node, Expected & 
                 break;
             }
 
-            if (!ParserLiteral{}.parse(pos, temporary_identifier, expected))
+            if (ParserLiteral{}.parse(pos, temporary_identifier, expected))
             {
-                if (!ParserIdentifier{}.parse(pos, temporary_identifier, expected))
+                const auto field = temporary_identifier->as<ASTLiteral &>().value;
+                switch (field.getType())
+                {
+                    case Field::Types::Which::String:
+                        res->instrumentation_point = field.safeGet<String>();
+                        break;
+                    case Field::Types::Which::UInt64:
+                        res->instrumentation_point = field.safeGet<UInt64>();
+                        break;
+                    default:
+                        return false;
+                }
+            }
+            else if (ParserIdentifier{}.parse(pos, temporary_identifier, expected))
+            {
+                    String identifier = temporary_identifier->as<ASTIdentifier &>().name();
+                    if (Poco::toLower(identifier) == "all")
+                        res->instrumentation_point = Instrumentation::All{};
+                else
                     return false;
-
-                if (Poco::toLower(temporary_identifier->as<ASTIdentifier &>().name()) != "all")
-                    return false;
-
-                res->instrumentation_point_id = true;
-                break;
             }
 
-            res->instrumentation_point_id = temporary_identifier->as<ASTLiteral &>().value.safeGet<UInt64>();
             break;
         }
         case Type::INSTRUMENT_ADD:

--- a/tests/queries/0_stateless/03642_system_instrument_add_remove.reference
+++ b/tests/queries/0_stateless/03642_system_instrument_add_remove.reference
@@ -26,6 +26,6 @@ QueryMetricLog::finishQuery	log	Entry	DB::QueryMetricLog::finishQuery(std::__1::
 -- Add several functions that match
 1	executeQuery	log	Entry
 -- Remove functions that match
-0
+QueryMetricLog::startQuery	log	Entry	DB::QueryMetricLog::startQuery(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::chrono::time_point<std::__1::chrono::system_clock, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000l>>>, unsigned long)	['my log in startQuery']
 -- Remove everything
 0

--- a/tests/queries/0_stateless/03642_system_instrument_add_remove.reference
+++ b/tests/queries/0_stateless/03642_system_instrument_add_remove.reference
@@ -25,5 +25,7 @@ QueryMetricLog::finishQuery	log	Entry	DB::QueryMetricLog::finishQuery(std::__1::
 0
 -- Add several functions that match
 1	executeQuery	log	Entry
+-- Remove functions that match
+0
 -- Remove everything
 0

--- a/tests/queries/0_stateless/03642_system_instrument_add_remove.reference
+++ b/tests/queries/0_stateless/03642_system_instrument_add_remove.reference
@@ -23,3 +23,7 @@ QueryMetricLog::finishQuery	log	Entry	DB::QueryMetricLog::finishQuery(std::__1::
 -- Remove with wrong arguments fails
 -- Remove everything
 0
+-- Add several functions that match
+1	executeQuery	log	Entry
+-- Remove everything
+0

--- a/tests/queries/0_stateless/03642_system_instrument_add_remove.sh
+++ b/tests/queries/0_stateless/03642_system_instrument_add_remove.sh
@@ -21,15 +21,15 @@ $CLICKHOUSE_CLIENT -q "
     SELECT count() FROM system.instrumentation;
 
     SELECT '-- Add one';
-    SYSTEM INSTRUMENT ADD \`QueryMetricLog::finishQuery\` LOG ENTRY 'my log in finishQuery';
+    SYSTEM INSTRUMENT ADD 'QueryMetricLog::finishQuery' LOG ENTRY 'my log in finishQuery';
     SELECT function_name, handler, entry_type, symbol, parameters FROM system.instrumentation ORDER BY id ASC;
 
     SELECT '-- Adding the same one again';
-    SYSTEM INSTRUMENT ADD \`QueryMetricLog::finishQuery\` LOG ENTRY 'another log in finishQuery';
+    SYSTEM INSTRUMENT ADD 'QueryMetricLog::finishQuery' LOG ENTRY 'another log in finishQuery';
     SELECT function_name, handler, entry_type, symbol, parameters FROM system.instrumentation ORDER BY id ASC;
 
     SELECT '-- Add another one';
-    SYSTEM INSTRUMENT ADD \`QueryMetricLog::startQuery\` LOG ENTRY 'my log in startQuery';
+    SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' LOG ENTRY 'my log in startQuery';
     SELECT function_name, handler, entry_type, symbol, parameters FROM system.instrumentation ORDER BY id ASC;
 "
 
@@ -41,8 +41,8 @@ $CLICKHOUSE_CLIENT -q "
     SELECT function_name, handler, entry_type, symbol, parameters FROM system.instrumentation ORDER BY id ASC;
 
     SELECT '-- Add 2 more';
-    SYSTEM INSTRUMENT ADD \`QueryMetricLog::startQuery\` LOG EXIT 'my other in startQuery';
-    SYSTEM INSTRUMENT ADD \`QueryMetricLog::finishQuery\` LOG EXIT 'my other in finishQuery';
+    SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' LOG EXIT 'my other in startQuery';
+    SYSTEM INSTRUMENT ADD 'QueryMetricLog::finishQuery' LOG EXIT 'my other in finishQuery';
     SELECT function_name, handler, entry_type, symbol, parameters FROM system.instrumentation ORDER BY id ASC;
 
     SELECT '-- Remove the entries with entry_type = Exit';

--- a/tests/queries/0_stateless/03642_system_instrument_add_remove.sh
+++ b/tests/queries/0_stateless/03642_system_instrument_add_remove.sh
@@ -52,6 +52,7 @@ $CLICKHOUSE_CLIENT -q "
     SELECT '-- Remove with wrong arguments fails';
     SYSTEM INSTRUMENT REMOVE (SELECT id, function_id FROM system.instrumentation); -- { serverError BAD_ARGUMENTS }
     SYSTEM INSTRUMENT REMOVE (SELECT handler FROM system.instrumentation); -- { serverError BAD_ARGUMENTS }
+    SYSTEM INSTRUMENT REMOVE 3.2; -- { clientError SYNTAX_ERROR }
 
     SELECT '-- Remove everything';
     SYSTEM INSTRUMENT REMOVE ALL;
@@ -62,6 +63,11 @@ $CLICKHOUSE_CLIENT -q "
     SELECT '-- Add several functions that match';
     SYSTEM INSTRUMENT ADD 'executeQuery' LOG ENTRY 'my log in executeQuery';
     SELECT count() > 10, function_name, handler, entry_type FROM system.instrumentation WHERE symbol ILIKE '%executeQuery%' GROUP BY function_name, handler, entry_type;
+
+    SELECT '-- Remove functions that match';
+    SYSTEM INSTRUMENT REMOVE 'unknown'; -- { serverError BAD_ARGUMENTS }
+    SYSTEM INSTRUMENT REMOVE 'executeQuery';
+    SELECT count() FROM system.instrumentation;
 
     SELECT '-- Remove everything';
     SYSTEM INSTRUMENT REMOVE ALL;

--- a/tests/queries/0_stateless/03642_system_instrument_add_remove.sh
+++ b/tests/queries/0_stateless/03642_system_instrument_add_remove.sh
@@ -65,9 +65,10 @@ $CLICKHOUSE_CLIENT -q "
     SELECT count() > 10, function_name, handler, entry_type FROM system.instrumentation WHERE symbol ILIKE '%executeQuery%' GROUP BY function_name, handler, entry_type;
 
     SELECT '-- Remove functions that match';
+    SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' LOG ENTRY 'my log in startQuery';
     SYSTEM INSTRUMENT REMOVE 'unknown'; -- { serverError BAD_ARGUMENTS }
     SYSTEM INSTRUMENT REMOVE 'executeQuery';
-    SELECT count() FROM system.instrumentation;
+    SELECT function_name, handler, entry_type, symbol, parameters FROM system.instrumentation ORDER BY id ASC;
 
     SELECT '-- Remove everything';
     SYSTEM INSTRUMENT REMOVE ALL;

--- a/tests/queries/0_stateless/03642_system_instrument_add_remove.sh
+++ b/tests/queries/0_stateless/03642_system_instrument_add_remove.sh
@@ -57,3 +57,13 @@ $CLICKHOUSE_CLIENT -q "
     SYSTEM INSTRUMENT REMOVE ALL;
     SELECT count() FROM system.instrumentation;
 "
+
+$CLICKHOUSE_CLIENT -q "
+    SELECT '-- Add several functions that match';
+    SYSTEM INSTRUMENT ADD 'executeQuery' LOG ENTRY 'my log in executeQuery';
+    SELECT count() > 10, function_name, handler, entry_type FROM system.instrumentation WHERE symbol ILIKE '%executeQuery%' GROUP BY function_name, handler, entry_type;
+
+    SELECT '-- Remove everything';
+    SYSTEM INSTRUMENT REMOVE ALL;
+    SELECT count() FROM system.instrumentation;
+"

--- a/tests/queries/0_stateless/03642_system_instrument_entry_exit.sh
+++ b/tests/queries/0_stateless/03642_system_instrument_entry_exit.sh
@@ -18,10 +18,10 @@ trap cleanup EXIT
 # Execute them in random order (not handler-ordered alphabetically) to make sure they're executed in this same order.
 $CLICKHOUSE_CLIENT -q "
     SYSTEM INSTRUMENT REMOVE ALL;
-    SYSTEM INSTRUMENT ADD \`QueryMetricLog::startQuery\` PROFILE;
-    SYSTEM INSTRUMENT ADD \`QueryMetricLog::startQuery\` LOG ENTRY 'this is an entry log';
-    SYSTEM INSTRUMENT ADD \`QueryMetricLog::startQuery\` SLEEP ENTRY 3;
-    SYSTEM INSTRUMENT ADD \`QueryMetricLog::startQuery\` LOG EXIT 'this is an exit log';
+    SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' PROFILE;
+    SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' LOG ENTRY 'this is an entry log';
+    SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' SLEEP ENTRY 3;
+    SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' LOG EXIT 'this is an exit log';
 "
 
 $CLICKHOUSE_CLIENT --query-id=$query_id -q "SELECT 1 FORMAT Null;"

--- a/tests/queries/0_stateless/03642_system_instrument_log.sh
+++ b/tests/queries/0_stateless/03642_system_instrument_log.sh
@@ -15,7 +15,7 @@ trap cleanup EXIT
 
 $CLICKHOUSE_CLIENT -q "
     SYSTEM INSTRUMENT REMOVE ALL;
-    SYSTEM INSTRUMENT ADD \`QueryMetricLog::startQuery\` LOG EXIT 'this is an instrumentation log';
+    SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' LOG EXIT 'this is an instrumentation log';
 "
 
 query_id="${CLICKHOUSE_DATABASE}_log"

--- a/tests/queries/0_stateless/03642_system_instrument_multiple_handlers.sh
+++ b/tests/queries/0_stateless/03642_system_instrument_multiple_handlers.sh
@@ -15,12 +15,12 @@ trap cleanup EXIT
 
 $CLICKHOUSE_CLIENT -q "
     SYSTEM INSTRUMENT REMOVE ALL;
-    SYSTEM INSTRUMENT ADD \`QueryMetricLog::startQuery\` LOG ENTRY 'entry_one';
-    SYSTEM INSTRUMENT ADD \`QueryMetricLog::startQuery\` LOG ENTRY 'entry_two';
-    SYSTEM INSTRUMENT ADD \`QueryMetricLog::startQuery\` LOG ENTRY 'entry_three';
-    SYSTEM INSTRUMENT ADD \`QueryMetricLog::startQuery\` LOG EXIT 'exit_one';
-    SYSTEM INSTRUMENT ADD \`QueryMetricLog::startQuery\` LOG EXIT 'exit_two';
-    SYSTEM INSTRUMENT ADD \`QueryMetricLog::startQuery\` LOG EXIT 'exit_three';
+    SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' LOG ENTRY 'entry_one';
+    SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' LOG ENTRY 'entry_two';
+    SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' LOG ENTRY 'entry_three';
+    SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' LOG EXIT 'exit_one';
+    SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' LOG EXIT 'exit_two';
+    SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' LOG EXIT 'exit_three';
 "
 
 query_id="${CLICKHOUSE_DATABASE}_log"

--- a/tests/queries/0_stateless/03642_system_instrument_profile.sh
+++ b/tests/queries/0_stateless/03642_system_instrument_profile.sh
@@ -15,7 +15,7 @@ trap cleanup EXIT
 
 $CLICKHOUSE_CLIENT -q """
     SYSTEM INSTRUMENT REMOVE ALL;
-    SYSTEM INSTRUMENT ADD \`QueryMetricLog::startQuery\` PROFILE;
+    SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' PROFILE;
 """
 
 query_id="${CLICKHOUSE_DATABASE}_profile"
@@ -34,7 +34,7 @@ $CLICKHOUSE_CLIENT -q "
 "
 
 query_id="${CLICKHOUSE_DATABASE}_profile_recursive"
-$CLICKHOUSE_CLIENT -q "SYSTEM INSTRUMENT ADD \`DB::recursiveRemoveLowCardinality(std::__1::shared_ptr<DB::IDataType const> const&)\` PROFILE;"
+$CLICKHOUSE_CLIENT -q "SYSTEM INSTRUMENT ADD 'DB::recursiveRemoveLowCardinality(std::__1::shared_ptr<DB::IDataType const> const&)' PROFILE;"
 $CLICKHOUSE_CLIENT --query-id="$query_id" -q "SELECT arrayFold(acc, x -> acc + x, [1, 2, 3], 0::Int64) FORMAT Null;"
 
 $CLICKHOUSE_CLIENT -q "

--- a/tests/queries/0_stateless/03642_system_instrument_sleep.sh
+++ b/tests/queries/0_stateless/03642_system_instrument_sleep.sh
@@ -15,7 +15,7 @@ trap cleanup EXIT
 
 $CLICKHOUSE_CLIENT -q """
     SYSTEM INSTRUMENT REMOVE ALL;
-    SYSTEM INSTRUMENT ADD \`QueryMetricLog::startQuery\` SLEEP ENTRY 3.2;
+    SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' SLEEP ENTRY 3.2;
 """
 
 query_id="${CLICKHOUSE_DATABASE}_sleep"
@@ -28,7 +28,7 @@ $CLICKHOUSE_CLIENT -q "
 "
 
 $CLICKHOUSE_CLIENT -q "
-    SYSTEM INSTRUMENT ADD \`QueryMetricLog::startQuery\` SLEEP ENTRY 0 1;
+    SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' SLEEP ENTRY 0 1;
 "
 
 query_id="${CLICKHOUSE_DATABASE}_sleep_random"

--- a/tests/queries/0_stateless/03642_system_instrument_stress.sh
+++ b/tests/queries/0_stateless/03642_system_instrument_stress.sh
@@ -24,14 +24,14 @@ statements=(
     "SELECT * FROM system.trace_log WHERE event_date >= yesterday() AND event_time > now() - INTERVAL 1 MINUTE AND trace_type = 'Instrumentation' FORMAT NULL"
     "SYSTEM INSTRUMENT REMOVE ALL"
     "SYSTEM INSTRUMENT REMOVE (SELECT id FROM system.instrumentation LIMIT 2)"
-    "SYSTEM INSTRUMENT ADD \`QueryMetricLog::startQuery\` LOG ENTRY 'entry log'"
-    "SYSTEM INSTRUMENT ADD \`QueryMetricLog::startQuery\` LOG EXIT 'exit log'"
-    "SYSTEM INSTRUMENT ADD \`QueryMetricLog::finishQuery\` SLEEP ENTRY 0"
-    "SYSTEM INSTRUMENT ADD \`QueryMetricLog::finishQuery\` SLEEP EXIT 0"
-    "SYSTEM INSTRUMENT ADD \`QueryMetricLog::finishQuery\` SLEEP ENTRY 0 0.01"
-    "SYSTEM INSTRUMENT ADD \`QueryMetricLog::finishQuery\` SLEEP EXIT 0 0.01"
-    "SYSTEM INSTRUMENT ADD \`QueryMetricLog::startQuery\` PROFILE"
-    "SYSTEM INSTRUMENT ADD \`QueryMetricLog::finishQuery\` PROFILE"
+    "SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' LOG ENTRY 'entry log'"
+    "SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' LOG EXIT 'exit log'"
+    "SYSTEM INSTRUMENT ADD 'QueryMetricLog::finishQuery' SLEEP ENTRY 0"
+    "SYSTEM INSTRUMENT ADD 'QueryMetricLog::finishQuery' SLEEP EXIT 0"
+    "SYSTEM INSTRUMENT ADD 'QueryMetricLog::finishQuery' SLEEP ENTRY 0 0.01"
+    "SYSTEM INSTRUMENT ADD 'QueryMetricLog::finishQuery' SLEEP EXIT 0 0.01"
+    "SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' PROFILE"
+    "SYSTEM INSTRUMENT ADD 'QueryMetricLog::finishQuery' PROFILE"
 )
 
 statements_nr=${#statements[@]}


### PR DESCRIPTION
Follow-up on https://github.com/ClickHouse/ClickHouse/pull/89173 based on [this](https://github.com/ClickHouse/ClickHouse/pull/89173#discussion_r2648648493) and [this](https://github.com/ClickHouse/ClickHouse/pull/89173#discussion_r2648646611) comments:

Improve the UX of SYSTEM INSTRUMENT ADD/REMOVE:
- Use String literals for function names. I'm not considering it a backwards incompatible change since it was released in 25.12 and I doubt anyone's using it yet
- Patch all functions that match. This is the same behavior as debuggers
- Allow using function_name in `REMOVE`. This is a nice to have thing, but previously could be done with a subquery
```sql
SYSTEM INSTRUMENT REMOVE (SELECT id FROM system.instrumentation WHERE function_name = 'executeQuery') 
```

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Improve the UX of SYSTEM INSTRUMENT ADD/REMOVE: use String literals for function names, patch all functions that match and allow using function_name in `REMOVE`

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
