### PR TITLE
Speed up isValidASCII

### DIFF
--- a/src/Functions/isValidASCII.cpp
+++ b/src/Functions/isValidASCII.cpp
@@ -23,16 +23,11 @@ namespace
 
 UInt8 isValidASCII(const UInt8 * data, UInt64 len)
 {
-    if (len == 0)
-        return 1;
-
+    /// https://lemire.me/blog/2025/12/20/performance-trick-optimistic-vs-pessimistic-checks/
+    UInt8 res = 0;
     for (UInt64 i = 0; i < len; ++i)
-    {
-        if (data[i] > 0x7F)
-            return 0;
-    }
-
-    return 1;
+        res |= data[i];
+    return res <= 0x7F;
 }
 
 }
@@ -135,7 +130,7 @@ private:
 REGISTER_FUNCTION(IsValidASCII)
 {
     factory.registerFunction<DB::FunctionIsValidASCII>(DB::FunctionDocumentation{
-        .description = R"(Returns 1 if the input String or FixedString contains only ASCII bytes (0x00–0x7F), otherwise 0.)",
+        .description = R"(Returns 1 if the input String or FixedString contains only ASCII bytes (0x00–0x7F), otherwise 0. Optimized for the positive case (the input _is_ valid ASCII).)",
         .examples = {{"isValidASCII", "SELECT isValidASCII('hello') AS is_ascii, isValidASCII('你好') AS is_not_ascii", ""}},
         .introduced_in = {25, 9},
         .category = DB::FunctionDocumentation::Category::String,

--- a/tests/performance/isValidASCII.xml
+++ b/tests/performance/isValidASCII.xml
@@ -1,27 +1,38 @@
 <?xml version="1.0"?>
 <clickhouse>
-    <create_query>CREATE TABLE IF NOT EXISTS test_ascii_data (
-        id UInt32,
-        ascii_string String,
-        mixed_string String,
-        long_string String,
-        empty_string String
-    ) ENGINE = Memory</create_query>
-    
-    <fill_query>INSERT INTO test_ascii_data SELECT 
-        number as id,
-        repeat('A', 100) as ascii_string,
-        repeat('Hello World!', 50) as mixed_string,
-        repeat('Pure ASCII 123 !@#', 30) as long_string,
-        '' as empty_string
-    FROM numbers(1000000)</fill_query>
-    
-    <query>SELECT isValidASCII(ascii_string) FROM test_ascii_data FORMAT Null</query>
-    <query>SELECT isValidASCII(mixed_string) FROM test_ascii_data FORMAT Null</query>
-    <query>SELECT isValidASCII(long_string) FROM test_ascii_data FORMAT Null</query>
-    <query>SELECT isValidASCII(empty_string) FROM test_ascii_data FORMAT Null</query>
-    
-    <query>SELECT isValidASCII('Mixed\x80Content') FROM test_ascii_data LIMIT 1000000 FORMAT Null</query>
-    
-    <query>DROP TABLE IF EXISTS test_ascii_data</query>
+    <create_query>
+        CREATE TABLE IF NOT EXISTS tab (
+            id UInt32,
+            empty String,
+            short_ascii String,
+            medium_ascii String,
+            long_ascii String,
+            short_utf8 String,
+            medium_utf8 String,
+            long_utf8 String,
+        ) ENGINE = Memory
+    </create_query>
+
+    <fill_query>
+        INSERT INTO tab SELECT
+            number as id,
+            '',
+            repeat('aaaaaaaaaaaaaaaa', 1),
+            repeat('aaaaaaaaaaaaaaaa', 16),
+            repeat('aaaaaaaaaaaaaaaa', 16 * 16),
+            repeat('ääääääääääääääää', 1),
+            repeat('ääääääääääääääää', 16),
+            repeat('ääääääääääääääää', 16 * 16),
+        FROM numbers(1.000.000)
+    </fill_query>
+
+    <query>SELECT isValidASCII(empty) FROM tab FORMAT Null</query>
+    <query>SELECT isValidASCII(short_ascii) FROM tab FORMAT Null</query>
+    <query>SELECT isValidASCII(medium_ascii) FROM tab FORMAT Null</query>
+    <query>SELECT isValidASCII(long_ascii) FROM tab FORMAT Null</query>
+    <query>SELECT isValidASCII(short_utf8) FROM tab FORMAT Null</query>
+    <query>SELECT isValidASCII(medium_utf8) FROM tab FORMAT Null</query>
+    <query>SELECT isValidASCII(long_utf8) FROM tab FORMAT Null</query>
+
+    <query>DROP TABLE tab</query>
 </clickhouse>

--- a/tests/performance/isValidASCII.xml
+++ b/tests/performance/isValidASCII.xml
@@ -23,7 +23,7 @@
             repeat('ääääääääääääääää', 1),
             repeat('ääääääääääääääää', 16),
             repeat('ääääääääääääääää', 16 * 16),
-        FROM numbers(1.000.000)
+        FROM numbers(1000000)
     </fill_query>
 
     <query>SELECT isValidASCII(empty) FROM tab FORMAT Null</query>


### PR DESCRIPTION
Applies the optimistic checking from https://lemire.me/blog/2025/12/20/performance-trick-optimistic-vs-pessimistic-checks. The assumption here is that most practical usage of `isValidASCII` has positive outcome (i.e. the majority of inputs is ASCII).

```sql
CREATE TABLE IF NOT EXISTS tab (
    id UInt32,
    empty String,
    short_ascii String,
    medium_ascii String,
    long_ascii String,
    short_utf8 String,
    medium_utf8 String,
    long_utf8 String,
) ENGINE = Memory

INSERT INTO tab SELECT
    number as id,
    '',
    repeat('aaaaaaaaaaaaaaaa', 1),
    repeat('aaaaaaaaaaaaaaaa', 16),
    repeat('aaaaaaaaaaaaaaaa', 16 * 16),
    repeat('ääääääääääääääää', 1),
    repeat('ääääääääääääääää', 16),
    repeat('ääääääääääääääää', 16 * 16),
FROM numbers(5000000)
```

(1) `SELECT isValidASCII(empty) FROM tab FORMAT Null` 0.003 s --> 0.003 s, no change

Common case usage:
(2) `SELECT isValidASCII(short_ascii) FROM tab FORMAT Null` 0.005 s --> 0.003 s, 1.7x faster
(3) `SELECT isValidASCII(medium_ascii) FROM tab FORMAT Null` 0.041 s --> 0.012 s 3.4x faster
(4) `SELECT isValidASCII(long_ascii) FROM tab FORMAT Null` 0.620 s --> 0.14 s 4.4x faster

Exceptional case usage:
(5)`SELECT isValidASCII(short_utf8) FROM tab FORMAT Null` 0.004 s --> 0.004 s, no change
(6) `SELECT isValidASCII(medium_utf8) FROM tab FORMAT Null` 0.006 s --> 0.020 s 3.3x slower
(7) `SELECT isValidASCII(long_utf8) FROM tab FORMAT Null` 0.008 s --> 0.0027 s 3.4x slower

Side note: Because optimistic checking loses the early exit, I thought we should limit the deterioration for UTF-8 inputs. I tried a hybrid version (first 256 characters: optimistic checking, tail: pessimistic checking) but the factors were not much different. I think this was because of extra conditionals to evaluate. So let's keep it simple and dumb.

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Function `isValidASCII` was optimized for positive outcomes, i.e. all-ASCII input values.