### PR TITLE
CI: Allow broader matching for flaky integration test cases

### DIFF
--- a/ci/jobs/scripts/check_ci.py
+++ b/ci/jobs/scripts/check_ci.py
@@ -159,8 +159,10 @@ Test output:
     def can_process(cls, job_result, test_result):
         if any(key in job_result.name for key in ("Unit",)):
             return True
-        if job_result.is_error() or test_result.is_error():
-            print(f"Cannot handle error status in job [{job_result.name}] - skip")
+        if job_result.is_error() or test_result.is_error() or job_result.is_dropped():
+            print(
+                f"Cannot handle dropped or error status in job [{job_result.name}] - skip"
+            )
             return False
         if len(job_result.results) > 4:
             print("Cannot handle more than 4 test failures in one job - skip")
@@ -197,7 +199,7 @@ Test output:
         # so we truncate from the bottom to preserve the initial context.
         res += result.get_info_truncated(
             truncate_from_top=result.status == Result.Status.ERROR,
-            max_info_lines_cnt=20,
+            max_info_lines_cnt=50,
             max_line_length=200,
         )
         res += f"\n - flags: {', '.join(result.get_labels()) or 'not flaged'}"

--- a/ci/praktika/issue.py
+++ b/ci/praktika/issue.py
@@ -248,13 +248,17 @@ class Issue:
         test_name = self.test_name
 
         # Normalize pytest parameterized names
-        if ".py" in name_in_report:
+        if ".py" in name_in_report and ".py" in test_name:
             if "[" in test_name:
                 # Issue mentions a specific parametrization: keep full name for exact match
                 pass
             elif "[" in name_in_report:
                 # Issue mentions only the base test: compare against the base part
                 name_in_report = name_in_report.split("[")[0]
+
+            if "::" not in test_name:
+                # Issue mentions only the module path without function: extract module path from report test name
+                name_in_report = name_in_report.split("::")[0]
 
         # Check if test name matches
         if not name_in_report.endswith(test_name):

--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -197,6 +197,9 @@ class Result(MetaClasses.Serializable):
     def is_error(self):
         return self.status in (Result.Status.ERROR, Result.StatusExtended.ERROR)
 
+    def is_dropped(self):
+        return self.status in (Result.Status.DROPPED,)
+
     def set_status(self, status) -> "Result":
         self.status = status
         self.dump()


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


When searching open flaky test issues, allow failure matching by a test module only (without test function) for integration tests if the open issue does not specify a test function: for example [issue](https://github.com/ClickHouse/ClickHouse/issues/68012)
(some modules can be entirely flaky)