### PR TITLE
tests: fix 03640_load_marks_synchronously flakiness

### DIFF
--- a/tests/queries/0_stateless/03640_load_marks_synchronously.sql
+++ b/tests/queries/0_stateless/03640_load_marks_synchronously.sql
@@ -1,11 +1,11 @@
 -- Tags: no-parallel-replicas
 
-create table data (key int) engine=MergeTree() order by key settings prewarm_mark_cache=0;
+-- Note: we need to have index_granularity==number or rows, to avoid processing
+-- parts in parallel, since in this case marks can be requested from multiple
+-- threads, which will lead to the query will have both MarksTasksFromCache and
+-- BackgroundLoadingMarksTasks
+create table data (key int) engine=MergeTree() order by key settings prewarm_mark_cache=0, index_granularity=1000;
 insert into data select * from numbers(1000);
-
--- Clear marks cache
-detach table data;
-attach table data;
 
 select * from data settings load_marks_asynchronously=1 format Null /* 1 */;
 select * from data settings load_marks_asynchronously=1 format Null /* 2 */;


### PR DESCRIPTION
Fixes https://github.com/ClickHouse/ClickHouse/issues/92537.

The problem was that in case of wide parts and lots of granulas
(low index_granularity value due to settings randomization) the same
granulas can be loaded in parallel which will lead to a situation when
query will have both MarksTasksFromCache and BackgroundLoadingMarksTasks

And also simplify the test.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


