### PR TITLE
Enable immediate purging of jemalloc dirty pages on non-Linux

### DIFF
--- a/contrib/jemalloc-cmake/CMakeLists.txt
+++ b/contrib/jemalloc-cmake/CMakeLists.txt
@@ -46,7 +46,17 @@ if (OS_LINUX)
     # https://github.com/jemalloc/jemalloc/pull/2842
     set (JEMALLOC_CONFIG_MALLOC_CONF "percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:0,dirty_decay_ms:5000,prof:true,prof_active:true,prof_thread_active_init:false,background_thread:true,lg_extent_max_active_fit:8")
 else()
-    set (JEMALLOC_CONFIG_MALLOC_CONF "oversize_threshold:0,muzzy_decay_ms:0,dirty_decay_ms:5000,lg_extent_max_active_fit:8")
+    # For non-Linux systems, percpu_arena and background_thread are assumed to be not supported by jemalloc.
+    # These two settings directly affect arena purging frequency and predictability:
+    # - percpu_arena:percpu restricts the number of created arenas to the number of CPUs
+    # - background_thread:true allows jemalloc to create its own background threads to trigger purging,
+    #   instead of relying on purging triggered by the allocations made by the application
+    #
+    # Without these settings, arena purging becomes less predictable and may not be triggered frequently
+    # enough, allowing the process to accumulate large RSS and causing MEMORY_LIMIT errors.
+    #
+    # To compensate it, dirty_decay_ms is set to zero, enabling immediate purging instead of the lazy one.
+    set (JEMALLOC_CONFIG_MALLOC_CONF "oversize_threshold:0,muzzy_decay_ms:0,dirty_decay_ms:0,lg_extent_max_active_fit:8")
 endif()
 # CACHE variable is empty to allow changing defaults without the necessity
 # to purge cache


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Reduce memory usage on non-Linux systems (enable immediate purging of jemalloc dirty pages)

### Details
Related to #87146 (its part about memory limit errors)

(Initially found on ClickHouse build for macOS)

Current jemalloc configuration for non-Linux systems may retain dirty pages on macOS for a significant time, which leads to bloated RSS and MEMORY_LIMIT_EXCEEDED errors, since memory limit is calculated based on process RSS.

The suggestion is to make jemalloc behavior close to the one on Linux when the purging is more agressive due to percpu_arenas (smaller number of arenas) and background_thread (not waiting for the application to trigger purge).
