### PR TITLE
Adding last modify time info in iceberg metadata file cache key

### DIFF
--- a/src/Databases/DataLake/GlueCatalog.cpp
+++ b/src/Databases/DataLake/GlueCatalog.cpp
@@ -547,7 +547,7 @@ String GlueCatalog::resolveMetadataPathFromTableLocation(const String & table_lo
 
     try
     {
-        auto [metadata_version, metadata_path, compression_method] = DB::Iceberg::getLatestOrExplicitMetadataFileAndVersion(
+        auto [metadata_version, metadata_path, _, compression_method] = DB::Iceberg::getLatestOrExplicitMetadataFileAndVersion(
             object_storage,
             table_path,
             *storage_settings,

--- a/src/Disks/DiskObjectStorage/ObjectStorages/IObjectStorage.h
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/IObjectStorage.h
@@ -129,7 +129,7 @@ struct RelativePathWithMetadata
     ~RelativePathWithMetadata() = default;
 
     /// Implicit conversion to string
-    operator std::string() const { return relative_path; }
+    explicit operator std::string() const { return relative_path; }
 
     std::string getFileName() const { return std::filesystem::path(relative_path).filename(); }
     std::string getPath() const { return relative_path; }

--- a/src/Disks/DiskObjectStorage/ObjectStorages/IObjectStorage.h
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/IObjectStorage.h
@@ -128,9 +128,6 @@ struct RelativePathWithMetadata
 
     ~RelativePathWithMetadata() = default;
 
-    /// Implicit conversion to string
-    explicit operator std::string() const { return relative_path; }
-
     std::string getFileName() const { return std::filesystem::path(relative_path).filename(); }
     std::string getPath() const { return relative_path; }
 };

--- a/src/Disks/DiskObjectStorage/ObjectStorages/IObjectStorage.h
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/IObjectStorage.h
@@ -128,6 +128,9 @@ struct RelativePathWithMetadata
 
     ~RelativePathWithMetadata() = default;
 
+    /// Implicit conversion to string
+    operator std::string() const { return relative_path; }
+
     std::string getFileName() const { return std::filesystem::path(relative_path).filename(); }
     std::string getPath() const { return relative_path; }
 };

--- a/src/Storages/ObjectStorage/DataLakes/Common/Common.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Common/Common.cpp
@@ -36,7 +36,11 @@ std::vector<RelativePathWithMetadataPtr> listFiles(
         if (check_need(*file_with_metadata))
             res.emplace_back(file_with_metadata);
     }
-    LOG_TRACE(getLogger("DataLakeCommon"), "Listed {} files ({})", res.size(), fmt::join(res, ", "));
+    LOG_TRACE(
+        getLogger("DataLakeCommon"),
+        "Listed {} files ({})",
+        res.size(),
+        fmt::join(res | std::views::transform([](const auto & p) -> const String & { return p->relative_path; }), ", "));
     return res;
 }
 }

--- a/src/Storages/ObjectStorage/DataLakes/Common/Common.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Common/Common.cpp
@@ -8,7 +8,7 @@
 namespace DB
 {
 
-std::vector<String> listFiles(
+std::vector<RelativePathWithMetadataPtr> listFiles(
     const IObjectStorage & object_storage,
     const String & path,
     const String & prefix, const String & suffix)
@@ -21,7 +21,7 @@ std::vector<String> listFiles(
 }
 
 
-std::vector<String> listFiles(
+std::vector<RelativePathWithMetadataPtr> listFiles(
     const IObjectStorage & object_storage,
     const String & path,
     const String & prefix,
@@ -30,11 +30,11 @@ std::vector<String> listFiles(
     auto key = std::filesystem::path(path) / prefix;
     RelativePathsWithMetadata files_with_metadata;
     object_storage.listObjects(key, files_with_metadata, 0);
-    Strings res;
+    std::vector<RelativePathWithMetadataPtr> res;
     for (const auto & file_with_metadata : files_with_metadata)
     {
         if (check_need(*file_with_metadata))
-            res.push_back(file_with_metadata->relative_path);
+            res.emplace_back(file_with_metadata);
     }
     LOG_TRACE(getLogger("DataLakeCommon"), "Listed {} files ({})", res.size(), fmt::join(res, ", "));
     return res;

--- a/src/Storages/ObjectStorage/DataLakes/Common/Common.h
+++ b/src/Storages/ObjectStorage/DataLakes/Common/Common.h
@@ -7,12 +7,12 @@ namespace DB
 {
 
 class IObjectStorage;
-std::vector<String> listFiles(
+std::vector<RelativePathWithMetadataPtr> listFiles(
     const IObjectStorage & object_storage,
     const String & path,
     const String & prefix, const String & suffix);
 
-std::vector<String> listFiles(
+std::vector<RelativePathWithMetadataPtr> listFiles(
     const IObjectStorage & object_storage,
     const String & path,
     const String & prefix,

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.cpp
@@ -194,8 +194,8 @@ struct DeltaLakeMetadataImpl
         else
         {
             const auto keys = listFiles(*object_storage, table_path, deltalake_metadata_directory, metadata_file_suffix);
-            for (const String & key : keys)
-                processMetadataFile(key, current_schema, current_partition_columns, result_files);
+            for (const auto & key : keys)
+                processMetadataFile(key->relative_path, current_schema, current_partition_columns, result_files);
         }
 
         return DeltaLakeMetadata{current_schema, Strings(result_files.begin(), result_files.end()), current_partition_columns};

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.cpp
@@ -433,7 +433,7 @@ void DeltaLakeMetadataDeltaKernel::logMetadataFiles(ContextPtr context) const
         auto buf = createReadBuffer(object_info, object_storage_common, context, log);
         String json_str;
         readStringUntilEOF(json_str, *buf);
-        insertDeltaRowToLogTable(context, json_str, kernel_helper->getDataPath(), key);
+        insertDeltaRowToLogTable(context, json_str, kernel_helper->getDataPath(), object_info.relative_path);
     }
 
 }

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.cpp
@@ -430,7 +430,7 @@ void DeltaLakeMetadataDeltaKernel::logMetadataFiles(ContextPtr context) const
     auto read_settings = context->getReadSettings();
     for (const auto & object_info : files)
     {
-        auto buf = createReadBuffer(object_info->relative_path, object_storage_common, context, log);
+        auto buf = createReadBuffer(*object_info, object_storage_common, context, log);
         String json_str;
         readStringUntilEOF(json_str, *buf);
         insertDeltaRowToLogTable(context, json_str, kernel_helper->getDataPath(), object_info->relative_path);

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.cpp
@@ -430,10 +430,10 @@ void DeltaLakeMetadataDeltaKernel::logMetadataFiles(ContextPtr context) const
     auto read_settings = context->getReadSettings();
     for (const auto & object_info : files)
     {
-        auto buf = createReadBuffer(object_info, object_storage_common, context, log);
+        auto buf = createReadBuffer(object_info->relative_path, object_storage_common, context, log);
         String json_str;
         readStringUntilEOF(json_str, *buf);
-        insertDeltaRowToLogTable(context, json_str, kernel_helper->getDataPath(), object_info.relative_path);
+        insertDeltaRowToLogTable(context, json_str, kernel_helper->getDataPath(), object_info->relative_path);
     }
 
 }

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.cpp
@@ -426,11 +426,10 @@ void DeltaLakeMetadataDeltaKernel::logMetadataFiles(ContextPtr context) const
     if (!context->getSettingsRef()[Setting::delta_lake_log_metadata].value)
         return;
 
-    const auto keys = listFiles(*object_storage_common, kernel_helper->getDataPath(), deltalake_metadata_directory, metadata_file_suffix);
+    const auto files = listFiles(*object_storage_common, kernel_helper->getDataPath(), deltalake_metadata_directory, metadata_file_suffix);
     auto read_settings = context->getReadSettings();
-    for (const String & key : keys)
+    for (const auto & object_info : files)
     {
-        RelativePathWithMetadata object_info(key);
         auto buf = createReadBuffer(object_info, object_storage_common, context, log);
         String json_str;
         readStringUntilEOF(json_str, *buf);

--- a/src/Storages/ObjectStorage/DataLakes/HudiMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/HudiMetadata.cpp
@@ -56,12 +56,12 @@ Strings HudiMetadata::getDataFilesImpl() const
 
     for (const auto & key : keys)
     {
-        auto key_file = std::filesystem::path(key);
+        auto key_file = std::filesystem::path(key->relative_path);
         Strings file_parts;
         const String stem = key_file.stem();
         splitInto<'_'>(file_parts, stem);
         if (file_parts.size() != 3)
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected format for file: {}", key);
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected format for file: {}", key->relative_path);
 
         const auto partition = key_file.parent_path().stem();
         const auto & file_id = file_parts[0];
@@ -70,7 +70,7 @@ Strings HudiMetadata::getDataFilesImpl() const
         auto & file_info = files[partition][file_id];
         if (file_info.timestamp == 0 || file_info.timestamp < timestamp)
         {
-            file_info.key = key;
+            file_info.key = key->relative_path;
             file_info.timestamp = timestamp;
         }
     }

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Compaction.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Compaction.cpp
@@ -499,10 +499,14 @@ std::vector<String> getOldFiles(ObjectStoragePtr object_storage, const String & 
     auto metadata_files = listFiles(*object_storage, table_path, "metadata", "");
     auto data_files = listFiles(*object_storage, table_path, "data", "");
 
-    for (auto && data_file : data_files)
-        metadata_files.push_back(data_file);
+    std::vector<String> res;
+    res.reserve(data_files.size() + metadata_files.size());
+    for (auto & data_file : data_files)
+        res.emplace_back(data_file->relative_path);
+    for (auto & metadata_file : metadata_files)
+        res.emplace_back(metadata_file->relative_path);
 
-    return metadata_files;
+    return res;
 }
 
 void clearOldFiles(ObjectStoragePtr object_storage, const std::vector<String> & old_files)

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Compaction.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Compaction.cpp
@@ -123,7 +123,7 @@ Plan getPlan(
     plan.generator = FileNamesGenerator(
         persistent_table_components.table_path, persistent_table_components.table_path, false, compression_method, write_format);
 
-    const auto [metadata_version, metadata_file_path, _] = getLatestOrExplicitMetadataFileAndVersion(
+    const auto [metadata_version, metadata_file_path, last_modify_time, _] = getLatestOrExplicitMetadataFileAndVersion(
         object_storage,
         persistent_table_components.table_path,
         data_lake_settings,
@@ -132,8 +132,15 @@ Plan getPlan(
         log.get(),
         persistent_table_components.table_uuid);
 
-    Poco::JSON::Object::Ptr initial_metadata_object
-        = getMetadataJSONObject(metadata_file_path, object_storage, persistent_table_components.metadata_cache, context, log, compression_method, persistent_table_components.table_uuid);
+    Poco::JSON::Object::Ptr initial_metadata_object = getMetadataJSONObject(
+        metadata_file_path,
+        last_modify_time,
+        object_storage,
+        persistent_table_components.metadata_cache,
+        context,
+        log,
+        compression_method,
+        persistent_table_components.table_uuid);
 
     if (initial_metadata_object->getValue<Int32>(Iceberg::f_format_version) < 2)
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Compaction is supported only for format_version 2.");

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.h
@@ -140,7 +140,7 @@ private:
     std::pair<Iceberg::IcebergDataSnapshotPtr, Int32>
     getStateImpl(const ContextPtr & local_context, Poco::JSON::Object::Ptr metadata_object) const;
     std::pair<Iceberg::IcebergDataSnapshotPtr, Iceberg::TableStateSnapshot>
-    getState(const ContextPtr & local_context, const String & metadata_path, Int32 metadata_version) const;
+    getState(const ContextPtr & local_context, const Iceberg::MetadataFileWithInfo & file_info) const;
     Iceberg::IcebergDataSnapshotPtr
     getRelevantDataSnapshotFromTableStateSnapshot(Iceberg::TableStateSnapshot table_state_snapshot, ContextPtr local_context) const;
     std::pair<Iceberg::IcebergDataSnapshotPtr, Iceberg::TableStateSnapshot> getRelevantState(const ContextPtr & context) const;

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadataFilesCache.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadataFilesCache.h
@@ -99,6 +99,8 @@ public:
 
     static String getKey(const String& table_uuid, const String & data_path) { return table_uuid + data_path; }
 
+    static String getKey(const String & table_uuid, const String & data_path, const String & etag) { return table_uuid + data_path + etag; }
+
     template <typename LoadFunc>
     String getOrSetTableMetadata(const String & data_path, LoadFunc && load_fn)
     {

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergTableStateSnapshot.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergTableStateSnapshot.cpp
@@ -23,6 +23,7 @@ void TableStateSnapshot::serialize(WriteBuffer & out) const
     writeChar(snapshot_id.has_value() ? 1 : 0, out);
     if (snapshot_id.has_value())
         writeVarInt(snapshot_id.value(), out);
+    writeVarUInt(last_modify_time, out);
 }
 
 TableStateSnapshot TableStateSnapshot::deserialize(ReadBuffer & in, const int datalake_state_protocol_version)
@@ -51,6 +52,7 @@ TableStateSnapshot TableStateSnapshot::deserialize(ReadBuffer & in, const int da
         {
             state.snapshot_id = std::nullopt;
         }
+        readVarUInt(state.last_modify_time, in);
         return state;
     }
     UNREACHABLE();
@@ -59,6 +61,6 @@ TableStateSnapshot TableStateSnapshot::deserialize(ReadBuffer & in, const int da
 bool TableStateSnapshot::operator==(const TableStateSnapshot & other) const
 {
     return metadata_file_path == other.metadata_file_path && metadata_version == other.metadata_version && schema_id == other.schema_id
-        && snapshot_id == other.snapshot_id;
+        && snapshot_id == other.snapshot_id && last_modify_time == other.last_modify_time;
 }
 }

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergTableStateSnapshot.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergTableStateSnapshot.h
@@ -15,6 +15,8 @@ struct TableStateSnapshot
     Int32 metadata_version;
     Int32 schema_id;
     std::optional<Int64> snapshot_id;
+    // this filed is from metadata_file_path file last modified time
+    UInt64 last_modify_time;
 
     void serialize(WriteBuffer & out) const;
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
@@ -647,7 +647,7 @@ IcebergStorageSink::IcebergStorageSink(
 
     metadata = getMetadataJSONObject(
         metadata_path,
-        last_modified_time,
+        last_modify_time,
         object_storage,
         persistent_table_components.metadata_cache,
         context,

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
@@ -636,7 +636,7 @@ IcebergStorageSink::IcebergStorageSink(
     , blob_storage_type_name(configuration_->getTypeName())
     , blob_storage_namespace_name(configuration_->getNamespace())
 {
-    auto [last_version, metadata_path, compression_method] = getLatestOrExplicitMetadataFileAndVersion(
+    auto [last_version, metadata_path, last_modify_time, compression_method] = getLatestOrExplicitMetadataFileAndVersion(
         object_storage,
         persistent_table_components.table_path,
         data_lake_settings,
@@ -647,6 +647,7 @@ IcebergStorageSink::IcebergStorageSink(
 
     metadata = getMetadataJSONObject(
         metadata_path,
+        last_modified_time,
         object_storage,
         persistent_table_components.metadata_cache,
         context,
@@ -887,7 +888,7 @@ bool IcebergStorageSink::initializeMetadata()
 
         if (retry_because_of_metadata_conflict)
         {
-            auto [last_version, metadata_path, compression_method] = getLatestOrExplicitMetadataFileAndVersion(
+            auto [last_version, metadata_path, last_modified_time, compression_method] = getLatestOrExplicitMetadataFileAndVersion(
                 object_storage,
                 persistent_table_components.table_path,
                 data_lake_settings,
@@ -903,6 +904,7 @@ bool IcebergStorageSink::initializeMetadata()
 
             metadata = getMetadataJSONObject(
                 metadata_path,
+                last_modified_time,
                 object_storage,
                 persistent_table_components.metadata_cache,
                 context,

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Mutations.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Mutations.cpp
@@ -565,7 +565,7 @@ void mutate(
         filename_generator.setVersion(last_version + 1);
         filename_generator.setCompressionMethod(compression_method);
 
-        auto metadata = getMetadataJSONObject(metadata_path, last_modified_time, object_storage, persistent_table_components.metadata_cache, context, log, compression_method, persistent_table_components.table_uuid);
+        auto metadata = getMetadataJSONObject(metadata_path, last_modify_time, object_storage, persistent_table_components.metadata_cache, context, log, compression_method, persistent_table_components.table_uuid);
         if (metadata->getValue<Int32>(f_format_version) < 2)
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Mutations are supported only for the second version of iceberg format");
         auto partition_spec_id = metadata->getValue<Int64>(Iceberg::f_default_spec_id);

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Mutations.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Mutations.cpp
@@ -553,7 +553,7 @@ void mutate(
     {
         FileNamesGenerator filename_generator(common_path, common_path, false, CompressionMethod::None, write_format);
         auto log = getLogger("IcebergMutations");
-        auto [last_version, metadata_path, compression_method] = getLatestOrExplicitMetadataFileAndVersion(
+        auto [last_version, metadata_path, last_modify_time, compression_method] = getLatestOrExplicitMetadataFileAndVersion(
             object_storage,
             persistent_table_components.table_path,
             data_lake_settings,
@@ -565,7 +565,7 @@ void mutate(
         filename_generator.setVersion(last_version + 1);
         filename_generator.setCompressionMethod(compression_method);
 
-        auto metadata = getMetadataJSONObject(metadata_path, object_storage, persistent_table_components.metadata_cache, context, log, compression_method, persistent_table_components.table_uuid);
+        auto metadata = getMetadataJSONObject(metadata_path, last_modified_time, object_storage, persistent_table_components.metadata_cache, context, log, compression_method, persistent_table_components.table_uuid);
         if (metadata->getValue<Int32>(f_format_version) < 2)
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Mutations are supported only for the second version of iceberg format");
         auto partition_spec_id = metadata->getValue<Int64>(Iceberg::f_default_spec_id);
@@ -685,7 +685,7 @@ void alter(
         FileNamesGenerator filename_generator(
             persistent_table_components.table_path, persistent_table_components.table_path, false, CompressionMethod::None, write_format);
         auto log = getLogger("IcebergMutations");
-        auto [last_version, metadata_path, compression_method] = getLatestOrExplicitMetadataFileAndVersion(
+        auto [last_version, metadata_path, last_modify_time, compression_method] = getLatestOrExplicitMetadataFileAndVersion(
             object_storage,
             persistent_table_components.table_path,
             data_lake_settings,
@@ -697,7 +697,7 @@ void alter(
         filename_generator.setVersion(last_version + 1);
         filename_generator.setCompressionMethod(compression_method);
 
-        auto metadata = getMetadataJSONObject(metadata_path, object_storage, persistent_table_components.metadata_cache, context, log, compression_method, persistent_table_components.table_uuid);
+        auto metadata = getMetadataJSONObject(metadata_path, last_modified_time, object_storage, persistent_table_components.metadata_cache, context, log, compression_method, persistent_table_components.table_uuid);
 
         auto metadata_json_generator = MetadataGenerator(metadata);
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Mutations.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Mutations.cpp
@@ -697,7 +697,7 @@ void alter(
         filename_generator.setVersion(last_version + 1);
         filename_generator.setCompressionMethod(compression_method);
 
-        auto metadata = getMetadataJSONObject(metadata_path, last_modified_time, object_storage, persistent_table_components.metadata_cache, context, log, compression_method, persistent_table_components.table_uuid);
+        auto metadata = getMetadataJSONObject(metadata_path, last_modify_time, object_storage, persistent_table_components.metadata_cache, context, log, compression_method, persistent_table_components.table_uuid);
 
         auto metadata_json_generator = MetadataGenerator(metadata);
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
@@ -139,13 +139,8 @@ static Iceberg::MetadataFileWithInfo getMetadataFileAndVersion(const std::string
     UInt64 last_modify_time = 0;
     if (need_add_last_modify_time)
     {
-        RelativePathsWithMetadata files;
-        object_storage->listObjects(path, files, 1);
-
-        if (files.size() != 1 || !files[0]->metadata)
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Bad metadata file name path: '{}'. Path size is {}.", file_name, files.size());
-
-        last_modify_time = files[0]->metadata->last_modified.epochTime();
+        ObjectMetadata meta = object_storage->getObjectMetadata(path, false);
+        last_modify_time = static_cast<UInt64>(meta.last_modified.epochTime());
     }
 
     return MetadataFileWithInfo{

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
@@ -222,8 +222,8 @@ bool writeMetadataFileAndVersionHint(
                 write_if_none_match.clear();
             }
 
-            auto [old_version, _1, _2, _3] = getMetadataFileAndVersion(version_hint_value);
-            auto [new_version, _4, _5, _6] = getMetadataFileAndVersion(version_hint_content);
+            auto [old_version, _1, _2, _3] = getMetadataFileAndVersion(version_hint_value, object_storage);
+            auto [new_version, _4, _5, _6] = getMetadataFileAndVersion(version_hint_content, object_storage);
             if (old_version < new_version)
             {
                 try
@@ -913,7 +913,7 @@ static MetadataFileWithInfo getLatestMetadataFileAndVersion(
         String filename = std::filesystem::path(path).filename();
         if (isTemporaryMetadataFile(filename))
             continue;
-        auto [version, metadata_file_path, last_modify_time,compression_method] = getMetadataFileAndVersion(path);
+        auto [version, metadata_file_path, last_modify_time,compression_method] = getMetadataFileAndVersion(path, object_storage);
 
         if (need_all_metadata_files_parsing)
         {
@@ -1018,7 +1018,7 @@ MetadataFileWithInfo getLatestOrExplicitMetadataFileAndVersion(
             }
             if (!explicit_metadata_path.starts_with(table_path))
                 explicit_metadata_path = std::filesystem::path(table_path) / explicit_metadata_path;
-            return getMetadataFileAndVersion(explicit_metadata_path);
+            return getMetadataFileAndVersion(explicit_metadata_path, object_storage);
         }
         catch (const std::exception & ex)
         {
@@ -1064,7 +1064,7 @@ MetadataFileWithInfo getLatestOrExplicitMetadataFileAndVersion(
         LOG_TEST(log, "Version hint file points to {}, will read from this metadata file", metadata_file);
         ProfileEvents::increment(ProfileEvents::IcebergVersionHintUsed);
 
-        return getMetadataFileAndVersion(std::filesystem::path(table_path) / "metadata" / fs::path(metadata_file).filename());
+        return getMetadataFileAndVersion(std::filesystem::path(table_path) / "metadata" / fs::path(metadata_file).filename(), object_storage);
     }
     else
     {

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.h
@@ -60,6 +60,7 @@ std::optional<TransformAndArgument> parseTransformAndArgument(const String & tra
 
 Poco::JSON::Object::Ptr getMetadataJSONObject(
     const String & metadata_file_path,
+    UInt64 last_modify_time,
     ObjectStoragePtr object_storage,
     IcebergMetadataFilesCachePtr metadata_cache,
     const ContextPtr & local_context,
@@ -67,10 +68,21 @@ Poco::JSON::Object::Ptr getMetadataJSONObject(
     CompressionMethod compression_method,
     const std::optional<String> & table_uuid);
 
+Poco::JSON::Object::Ptr getMetadataJSONObject(
+    const String & metadata_file_path,
+    UInt64 last_modify_time,
+    ObjectStoragePtr object_storage,
+    StorageObjectStorageConfigurationPtr configuration_ptr,
+    IcebergMetadataFilesCachePtr cache_ptr,
+    const ContextPtr & local_context,
+    LoggerPtr log,
+    CompressionMethod compression_method);
+
 struct MetadataFileWithInfo
 {
     Int32 version;
     String path;
+    UInt64 last_modify_time;
     CompressionMethod compression_method;
 };
 

--- a/src/Storages/ObjectStorage/DataLakes/Paimon/PaimonClient.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Paimon/PaimonClient.cpp
@@ -132,9 +132,9 @@ std::pair<Int32, String> PaimonTableClient::getLastestTableSchemaInfo()
         }
         return current_version;
     };
-    for (const auto & path : schema_files)
+    for (const auto & file : schema_files)
     {
-        schema_files_with_versions.emplace_back(std::make_pair(parse_version(path), path));
+        schema_files_with_versions.emplace_back(std::make_pair(parse_version(file->relative_path), file->relative_path));
     }
     return *std::max_element(schema_files_with_versions.begin(), schema_files_with_versions.end());
 }
@@ -224,9 +224,9 @@ std::optional<std::pair<Int64, String>> PaimonTableClient::getLastestTableSnapsh
         return current_version;
     };
 
-    for (const auto & path : snapshot_files)
+    for (const auto & file : snapshot_files)
     {
-        snapshot_files_with_versions.emplace_back(std::make_pair(parse_version(path), path));
+        snapshot_files_with_versions.emplace_back(std::make_pair(parse_version(file->relative_path), file->relative_path));
     }
     return *std::max_element(snapshot_files_with_versions.begin(), snapshot_files_with_versions.end());
 }

--- a/src/Storages/ObjectStorage/tests/gtest_datalake_table_state_serde.cpp
+++ b/src/Storages/ObjectStorage/tests/gtest_datalake_table_state_serde.cpp
@@ -14,12 +14,14 @@ std::vector<Iceberg::TableStateSnapshot> example_iceberg_states = {
         .metadata_version = std::numeric_limits<Int32>::min(),
         .schema_id = std::numeric_limits<Int32>::max(),
         .snapshot_id = std::optional{std::numeric_limits<Int64>::max()},
+        .last_modify_time = 1234
     },
     Iceberg::TableStateSnapshot{
         .metadata_file_path = "",
         .metadata_version = 0,
         .schema_id = std::numeric_limits<Int32>::max(),
         .snapshot_id = std::nullopt,
+        .last_modify_time = 2345
     },
 };
 }

--- a/tests/integration/test_storage_iceberg_with_spark/test_simple_table_recreation.py
+++ b/tests/integration/test_storage_iceberg_with_spark/test_simple_table_recreation.py
@@ -1,0 +1,93 @@
+import pytest
+
+from helpers.iceberg_utils import (
+    default_upload_directory,
+    create_iceberg_table,
+    get_uuid_str,
+    drop_iceberg_table
+)
+
+
+@pytest.mark.parametrize("storage_type", ["s3", "azure", "local"])
+def test_simple_table_recreation(started_cluster_iceberg_with_spark, storage_type):
+    """
+    Simple test that:
+    1. Creates a table with Spark
+    2. Inserts data and queries it
+    3. Recreates the table with same approach
+    4. Verifies the query still works with metadata cache
+    """
+    instance = started_cluster_iceberg_with_spark.instances["node1"]
+    spark = started_cluster_iceberg_with_spark.spark_session
+
+    TABLE_NAME = (
+        "test_simple_table_recreation_"
+        + storage_type
+        + "_"
+        + get_uuid_str()
+    )
+
+    # Step 1: Create initial table with Spark
+    spark.sql(
+        f"CREATE TABLE {TABLE_NAME} (id bigint, name string, value double) USING iceberg TBLPROPERTIES ('format-version' = '2')"
+    )
+
+    # Step 2: Insert sample data
+    spark.sql(
+        f"INSERT INTO {TABLE_NAME} VALUES (1, 'Alice', 100.5), (2, 'Bob', 200.25), (3, 'Charlie', 300.75)"
+    )
+
+    # Upload data to storage
+    default_upload_directory(
+        started_cluster_iceberg_with_spark,
+        storage_type,
+        f"/iceberg_data/default/{TABLE_NAME}/",
+        f"/iceberg_data/default/{TABLE_NAME}/",
+    )
+
+    # Step 3: Create ClickHouse table and query initial data
+    create_iceberg_table(storage_type, instance, TABLE_NAME, started_cluster_iceberg_with_spark)
+
+    # Query the initial data
+    initial_count = int(instance.query(f"SELECT count() FROM {TABLE_NAME}"))
+    initial_sum = float(instance.query(f"SELECT sum(value) FROM {TABLE_NAME}"))
+    initial_names = instance.query(f"SELECT name FROM {TABLE_NAME} ORDER BY id").strip()
+
+    # Verify initial state
+    assert initial_count == 3
+    assert initial_sum == 601.5
+    assert initial_names == "Alice\nBob\nCharlie"
+
+    # Step 5: Recreate the table using spark (drop and create again)
+    drop_iceberg_table(instance, TABLE_NAME, if_exists=True)
+
+    spark.sql(
+        f"CREATE TABLE {TABLE_NAME} (id bigint, name string, value double) USING iceberg TBLPROPERTIES ('format-version' = '2')"
+    )
+
+    spark.sql(
+        f"INSERT INTO {TABLE_NAME} VALUES (1, 'Alice', 100.5), (2, 'Bob', 200.25), (3, 'Charlie', 300.75)"
+    )
+
+    # Upload data to storage twice
+    default_upload_directory(
+        started_cluster_iceberg_with_spark,
+        storage_type,
+        f"/iceberg_data/default/{TABLE_NAME}/",
+        f"/iceberg_data/default/{TABLE_NAME}/",
+    )
+
+    # Query the second data
+    initial_count = int(instance.query(f"SELECT count() FROM {TABLE_NAME}"))
+    initial_sum = float(instance.query(f"SELECT sum(value) FROM {TABLE_NAME}"))
+    initial_names = instance.query(f"SELECT name FROM {TABLE_NAME} ORDER BY id").strip()
+
+    # Verify initial state
+    assert initial_count == 3
+    assert initial_sum == 601.5
+    assert initial_names == "Alice\nBob\nCharlie"
+
+    print(f"✓ Successfully tested table recreation for {TABLE_NAME}")
+    print(f"  Initial count: {initial_count}, Final count: {final_count}")
+    print(f"  Initial sum: {initial_sum}, Final sum: {final_sum}")
+    print(f"  All queries work correctly after table recreation")

--- a/tests/integration/test_storage_iceberg_with_spark/test_simple_table_recreation.py
+++ b/tests/integration/test_storage_iceberg_with_spark/test_simple_table_recreation.py
@@ -83,14 +83,14 @@ def test_simple_table_recreation(started_cluster_iceberg_with_spark, storage_typ
 
     create_iceberg_table(storage_type, instance, TABLE_NAME, started_cluster_iceberg_with_spark)
     # Query the second data
-    initial_count = int(instance.query(f"SELECT count() FROM {TABLE_NAME}"))
-    initial_sum = float(instance.query(f"SELECT sum(value) FROM {TABLE_NAME}"))
-    initial_names = instance.query(f"SELECT name FROM {TABLE_NAME} ORDER BY id").strip()
+    final_count = int(instance.query(f"SELECT count() FROM {TABLE_NAME}"))
+    final_sum = float(instance.query(f"SELECT sum(value) FROM {TABLE_NAME}"))
+    final_names = instance.query(f"SELECT name FROM {TABLE_NAME} ORDER BY id").strip()
 
     # Verify initial state
-    assert initial_count == 3
-    assert initial_sum == 601.5
-    assert initial_names == "Alice\nBob\nCharlie"
+    assert final_count == 3
+    assert final_sum == 601.5
+    assert final_names == "Alice\nBob\nCharlie"
 
     print(f"✓ Successfully tested table recreation for {TABLE_NAME}")
     print(f"  Initial count: {initial_count}, Final count: {final_count}")

--- a/tests/integration/test_storage_iceberg_with_spark/test_simple_table_recreation.py
+++ b/tests/integration/test_storage_iceberg_with_spark/test_simple_table_recreation.py
@@ -62,6 +62,10 @@ def test_simple_table_recreation(started_cluster_iceberg_with_spark, storage_typ
     drop_iceberg_table(instance, TABLE_NAME, if_exists=True)
 
     spark.sql(
+        f"DROP TABLE IF EXISTS {TABLE_NAME}"
+    )
+
+    spark.sql(
         f"CREATE TABLE {TABLE_NAME} (id bigint, name string, value double) USING iceberg TBLPROPERTIES ('format-version' = '2')"
     )
 
@@ -77,6 +81,7 @@ def test_simple_table_recreation(started_cluster_iceberg_with_spark, storage_typ
         f"/iceberg_data/default/{TABLE_NAME}/",
     )
 
+    create_iceberg_table(storage_type, instance, TABLE_NAME, started_cluster_iceberg_with_spark)
     # Query the second data
     initial_count = int(instance.query(f"SELECT count() FROM {TABLE_NAME}"))
     initial_sum = float(instance.query(f"SELECT sum(value) FROM {TABLE_NAME}"))


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Adding last modify time info as iceberg metadata file cache key. close #93363

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
