### PR TITLE
Fix `tokens` with non-const parameters

### DIFF
--- a/src/Functions/tokens.cpp
+++ b/src/Functions/tokens.cpp
@@ -258,18 +258,18 @@ For example, with separators = `['%21', '%']` string `%21abc` would be tokenized
     FunctionDocumentation::Syntax syntax = R"(
 tokens(value)
 tokens(value, tokenizer)
-tokens(value, 'ngrams'[, ngrams])
+tokens(value, 'ngrams'[, n])
 tokens(value, 'splitByString'[, separators])
-tokens(value, 'sparse_grams'[, min_length, max_length[, min_cutoff_length]])
+tokens(value, 'sparseGrams'[, min_length, max_length[, min_cutoff_length]])
 )";
     FunctionDocumentation::Arguments arguments = {
         {"value", "The input string.", {"String", "FixedString"}},
         {"tokenizer", "The tokenizer to use. Valid arguments are `splitByNonAlpha`, `ngrams`, `splitByString`, `array`, and `sparseGrams`. Optional, if not set explicitly, defaults to `splitByNonAlpha`.", {"const String"}},
-        {"ngrams", "Only relevant if argument `tokenizer` is `ngrams`: An optional parameter which defines the length of the ngrams. If not set explicitly, defaults to `3`.", {"const UInt8"}},
+        {"n", "Only relevant if argument `tokenizer` is `ngrams`: An optional parameter which defines the length of the ngrams. If not set explicitly, defaults to `3`.", {"const UInt8"}},
         {"separators", "Only relevant if argument `tokenizer` is `split`: An optional parameter which defines the separator strings. If not set explicitly, defaults to `[' ']`.", {"const Array(String)"}},
-        {"min_length", "Only relevant if argument `tokenizer` is `sparse_grams`: An optional parameter which defines the minimum gram length, defaults to 3.", {"const UInt8"}},
-        {"max_length", "Only relevant if argument `tokenizer` is `sparse_grams`: An optional parameter which defines the maximum gram length, defaults to 100.", {"const UInt8"}},
-        {"min_cutoff_length", "Only relevant if argument `tokenizer` is `sparse_grams`: An optional parameter which defines the minimum cutoff length.", {"const UInt8"}}
+        {"min_length", "Only relevant if argument `tokenizer` is `sparseGrams`: An optional parameter which defines the minimum gram length, defaults to 3.", {"const UInt8"}},
+        {"max_length", "Only relevant if argument `tokenizer` is `sparseGrams`: An optional parameter which defines the maximum gram length, defaults to 100.", {"const UInt8"}},
+        {"min_cutoff_length", "Only relevant if argument `tokenizer` is `sparseGrams`: An optional parameter which defines the minimum cutoff length.", {"const UInt8"}}
     };
     FunctionDocumentation::ReturnedValue returned_value = {"Returns the resulting array of tokens from input string.", {"Array"}};
     FunctionDocumentation::Examples examples = {

--- a/src/Functions/tokens.cpp
+++ b/src/Functions/tokens.cpp
@@ -8,6 +8,7 @@
 #include <Functions/IFunction.h>
 #include <Interpreters/Context_fwd.h>
 #include <Interpreters/ITokenExtractor.h>
+#include <Common/Exception.h>
 
 namespace DB
 {
@@ -32,6 +33,9 @@ std::unique_ptr<ITokenExtractor> createTokenizer(const ColumnsWithTypeAndName & 
     for (size_t i = 2; i < arguments.size(); ++i)
     {
         const auto & col = arguments[i].column;
+        if (!col)
+            throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Invalid argument of function {}", function_name);
+
         WhichDataType which_type(arguments[i].type);
         if (which_type.isUInt())
         {
@@ -185,7 +189,7 @@ public:
     String getName() const override { return name; }
     size_t getNumberOfArguments() const override { return 0; }
     bool isVariadic() const override { return true; }
-    ColumnNumbers getArgumentsThatAreAlwaysConstant() const override { return {1, 2}; }
+    ColumnNumbers getArgumentsThatAreAlwaysConstant() const override { return {1, 2, 3, 4}; }
 
     static FunctionOverloadResolverPtr create(ContextPtr)
     {
@@ -219,10 +223,10 @@ public:
 
                 if (tokenizer == SparseGramsTokenExtractor::getExternalName())
                 {
-                    optional_args.emplace_back("min_length", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isUInt8), isColumnConst, "UInt8");
-                    optional_args.emplace_back("max_length", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isUInt8), isColumnConst, "UInt8");
+                    optional_args.emplace_back("min_length", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isUInt8), isColumnConst, "const UInt8");
+                    optional_args.emplace_back("max_length", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isUInt8), isColumnConst, "const UInt8");
                     if (arguments.size() == 5)
-                        optional_args.emplace_back("min_cutoff_length", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isUInt8), isColumnConst, "UInt8");
+                        optional_args.emplace_back("min_cutoff_length", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isUInt8), isColumnConst, "const UInt8");
                 }
             }
         }
@@ -247,16 +251,25 @@ REGISTER_FUNCTION(Tokens)
 Splits a string into tokens using the given tokenizer.
 The default tokenizer uses non-alphanumeric ASCII characters as separators.
 
-In case of the `split` tokenizer, if the tokens do not form a [prefix code](https://en.wikipedia.org/wiki/Prefix_code), you likely want that the matching prefers longer separators first.
+In case of the `splitByString` tokenizer, if the tokens do not form a [prefix code](https://en.wikipedia.org/wiki/Prefix_code), you likely want that the matching prefers longer separators first.
 To do so, pass the separators in order of descending length.
 For example, with separators = `['%21', '%']` string `%21abc` would be tokenized as `['abc']`, whereas separators = `['%', '%21']` would tokenize to `['21ac']` (which is likely not what you wanted).
 )";
-    FunctionDocumentation::Syntax syntax = "tokens(value[, tokenizer[, ngrams[, separators]]])";
+    FunctionDocumentation::Syntax syntax = R"(
+tokens(value)
+tokens(value, tokenizer)
+tokens(value, 'ngrams'[, ngrams])
+tokens(value, 'splitByString'[, separators])
+tokens(value, 'sparse_grams'[, min_length, max_length[, min_cutoff_length]])
+)";
     FunctionDocumentation::Arguments arguments = {
         {"value", "The input string.", {"String", "FixedString"}},
         {"tokenizer", "The tokenizer to use. Valid arguments are `splitByNonAlpha`, `ngrams`, `splitByString`, `array`, and `sparseGrams`. Optional, if not set explicitly, defaults to `splitByNonAlpha`.", {"const String"}},
         {"ngrams", "Only relevant if argument `tokenizer` is `ngrams`: An optional parameter which defines the length of the ngrams. If not set explicitly, defaults to `3`.", {"const UInt8"}},
-        {"separators", "Only relevant if argument `tokenizer` is `split`: An optional parameter which defines the separator strings. If not set explicitly, defaults to `[' ']`.", {"const Array(String)"}}
+        {"separators", "Only relevant if argument `tokenizer` is `split`: An optional parameter which defines the separator strings. If not set explicitly, defaults to `[' ']`.", {"const Array(String)"}},
+        {"min_length", "Only relevant if argument `tokenizer` is `sparse_grams`: An optional parameter which defines the minimum gram length, defaults to 3.", {"const UInt8"}},
+        {"max_length", "Only relevant if argument `tokenizer` is `sparse_grams`: An optional parameter which defines the maximum gram length, defaults to 100.", {"const UInt8"}},
+        {"min_cutoff_length", "Only relevant if argument `tokenizer` is `sparse_grams`: An optional parameter which defines the minimum cutoff length.", {"const UInt8"}}
     };
     FunctionDocumentation::ReturnedValue returned_value = {"Returns the resulting array of tokens from input string.", {"Array"}};
     FunctionDocumentation::Examples examples = {

--- a/tests/queries/0_stateless/03403_function_tokens.reference
+++ b/tests/queries/0_stateless/03403_function_tokens.reference
@@ -4,7 +4,7 @@ Default tokenizer
 []	Array(String)	1
 ['abc','def','foo','bar','baz','code','hello','world','xäöüx']	Array(String)	1
 ['abc','def','foo','bar','baz','code','hello','world','xäöüx']	Array(String)	1
-Ngram tokenizer
+Ngrams tokenizer
 []	Array(String)	1
 ['abc','bc ','c d',' de','def']	Array(String)	1
 ['abc','bc ','c d',' de','def']	Array(String)	1
@@ -15,7 +15,7 @@ Split tokenizer
 ['a','bc','d']	Array(String)	1
 ['a','bc','d']	Array(String)	1
 ['a','bc','d']	Array(String)	1
-No-op tokenizer
+Array tokenizer
 []	Array(String)	1
 ['abc def']	Array(String)	1
 Special cases (not systematically tested)
@@ -28,17 +28,17 @@ Default tokenizer
 ['abc','def']	Array(String)	0
 ['hello','world']	Array(String)	0
 ['xäöüx','code']	Array(String)	0
-Ngram tokenizer
+Ngrams tokenizer
 ['abc','bc ','c d',' de','def']	Array(String)	0
 ['Cli','lic','ick','ckH','kHo','Hou','ous','use']	Array(String)	0
 Split tokenizer
 ['a','bc','d']	Array(String)	0
 ['a','bc','d']	Array(String)	0
-No-op tokenizer
+Array tokenizer
 []	Array(String)	0
 ['abc def']	Array(String)	0
 ['abc','def','foo','bar','baz','code','hello','world']
-Sparse tokenizer
+Sparse grams tokenizer
 []
 ['abc','bc ','c d',' de','c de','bc de','def','bc def','ef ','f c',' cb','f cb','ef cb','cba']
 ['abc ','bc d','c de',' def','c def','def ','c def ','bc def ','ef c','f cb','ef cb',' cba']

--- a/tests/queries/0_stateless/03403_function_tokens.sql
+++ b/tests/queries/0_stateless/03403_function_tokens.sql
@@ -36,7 +36,7 @@ SELECT tokens('') AS tokenized, toTypeName(tokenized), isConstant(tokenized);
 SELECT tokens('abc+ def- foo! bar? baz= code; hello: world/ xäöüx') AS tokenized, toTypeName(tokenized), isConstant(tokenized);
 SELECT tokens('abc+ def- foo! bar? baz= code; hello: world/ xäöüx', 'splitByNonAlpha') AS tokenized, toTypeName(tokenized), isConstant(tokenized);
 
-SELECT 'Ngram tokenizer';
+SELECT 'Ngrams tokenizer';
 
 SELECT tokens('', 'ngrams') AS tokenized, toTypeName(tokenized), isConstant(tokenized);
 SELECT tokens('abc def', 'ngrams') AS tokenized, toTypeName(tokenized), isConstant(tokenized);
@@ -51,7 +51,7 @@ SELECT tokens('()()a()bc()d', 'splitByString', ['()']) AS tokenized, toTypeName(
 SELECT tokens(',()a(),bc,(),d,', 'splitByString', ['()', ',']) AS tokenized, toTypeName(tokenized), isConstant(tokenized);
 SELECT tokens('\\a\n\\bc\\d\n', 'splitByString', ['\n', '\\']) AS tokenized, toTypeName(tokenized), isConstant(tokenized);
 
-SELECT 'No-op tokenizer';
+SELECT 'Array tokenizer';
 
 SELECT tokens('', 'array') AS tokenized, toTypeName(tokenized), isConstant(tokenized);
 SELECT tokens('abc def', 'array') AS tokenized, toTypeName(tokenized), isConstant(tokenized);
@@ -76,7 +76,7 @@ SELECT tokens(str, 'splitByNonAlpha') AS tokenized, toTypeName(tokenized), isCon
 
 DROP TABLE tab;
 
-SELECT 'Ngram tokenizer';
+SELECT 'Ngrams tokenizer';
 
 CREATE TABLE tab (
     id Int64,
@@ -102,7 +102,7 @@ SELECT tokens(str, 'splitByString', ['()', ',']) AS tokenized, toTypeName(tokeni
 
 DROP TABLE tab;
 
-SELECT 'No-op tokenizer';
+SELECT 'Array tokenizer';
 
 CREATE TABLE tab (
     id Int64,
@@ -116,7 +116,7 @@ SELECT tokens(str, 'array') AS tokenized, toTypeName(tokenized), isConstant(toke
 DROP TABLE tab;
 SELECT tokens(materialize('abc+ def- foo! bar? baz= code; hello: world/'));
 
-SELECT 'Sparse tokenizer';
+SELECT 'Sparse grams tokenizer';
 
 SELECT tokens('', 'sparseGrams') AS tokenized;
 SELECT tokens('abc def cba', 'sparseGrams') AS tokenized;

--- a/tests/queries/0_stateless/03404_tokens_bug93207.sql
+++ b/tests/queries/0_stateless/03404_tokens_bug93207.sql
@@ -1,0 +1,1 @@
+SELECT tokens(NULL, 1, materialize(1)) -- { serverError ILLEGAL_COLUMN }


### PR DESCRIPTION
Resolves #93207

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
The server no longer crashes if function `tokens` is called with non-const tokenizer parameters (the 2th, 3rd, 4th parameter), e.g., `SELECT tokens(NULL, 1, materialize(1))`.