### PR TITLE
CI: Fix Fast test binary artifact

### DIFF
--- a/ci/jobs/fast_test.py
+++ b/ci/jobs/fast_test.py
@@ -273,7 +273,7 @@ def main():
 
     if attach_debug:
         attach_files += [
-            Utils.compress_file(f"{temp_dir}/build/programs/clickhouse-stripped"),
+            clickhouse_bin_path,
             f"{temp_dir}/var/log/clickhouse-server/clickhouse-server.err.log",
             f"{temp_dir}/var/log/clickhouse-server/clickhouse-server.log",
         ]


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

---


- Fix path to clickhouse binary in attached files list
- remove binary compression since binary is uploaded only on failure

