### PR TITLE
Do not tie remote throttler's max sleep time to socket sleep timeouts

### DIFF
--- a/base/poco/Net/include/Poco/Net/SocketImpl.h
+++ b/base/poco/Net/include/Poco/Net/SocketImpl.h
@@ -487,6 +487,7 @@ namespace Net
         bool _isBrokenTimeout;
 
         static constexpr size_t THROTTLER_QUANTUM = 32 * 1024;
+        static constexpr size_t THROTTLER_MAX_BLOCK_NS = 20 * 1000 * 1000 * 1000U;
         size_t _recvThrottlerBudget;
         size_t _sndThrottlerBudget;
         ThrottlerPtr _recvThrottler;

--- a/base/poco/Net/src/SocketImpl.cpp
+++ b/base/poco/Net/src/SocketImpl.cpp
@@ -1073,12 +1073,7 @@ void SocketImpl::throttleSend(size_t length, bool blocking)
 	{
 		size_t amount = length < THROTTLER_QUANTUM ? THROTTLER_QUANTUM : length;
 		if (blocking)
-		{
-			if (_sndTimeout.totalMicroseconds() != 0) // Avoid throttling over socket send timeout
-				_sndThrottler->throttle(amount, _sndTimeout.totalMicroseconds() * 1000 / 2);
-			else
-				_sndThrottler->throttle(amount);
-		}
+			_sndThrottler->throttle(amount, THROTTLER_MAX_BLOCK_NS);
 		else
 			_sndThrottler->throttle(amount, 0);
 		_sndThrottlerBudget += amount;
@@ -1092,12 +1087,7 @@ void SocketImpl::throttleRecv(size_t length, bool blocking)
 	{
 		size_t amount = length < THROTTLER_QUANTUM ? THROTTLER_QUANTUM : length;
 		if (blocking)
-		{
-			if (_recvTimeout.totalMicroseconds() != 0) // Avoid throttling over socket receive timeout
-				_recvThrottler->throttle(amount, _recvTimeout.totalMicroseconds() * 1000 / 2);
-			else
-				_recvThrottler->throttle(amount);
-		}
+			_recvThrottler->throttle(amount, THROTTLER_MAX_BLOCK_NS);
 		else
 			_recvThrottler->throttle(amount, 0);
 		_recvThrottlerBudget += amount;


### PR DESCRIPTION
Addresses https://github.com/ClickHouse/ClickHouse/issues/93408. See the issue for detailed notes.

Situation: Currently, network throttler's max sleep time is tied to the socket timeouts in such a way that it can be at most half the socket timeout time. This was done to prevent sockets from timing out as throttling is happening. This motivation was flawed: for local sockets, throttler's sleep and recv/send calls are sequential and therefore not affected by one another; for remote sockets, timeouts are unknown to us.

Problem: The throttler's sleep time is effectively capped at 250 milliseconds per send/recv, which in practice means that the throttler isn't effective at preventing excess throughput.

Solution: It is better to throttle correctly than try to appease remote sockets whose timeouts we don't know. We will assume that socket timeouts are generally around 30 seconds and set the max sleep time to be 20 seconds (a drastic increase from 250 ms). This way, the throttler will be effective in most scenarios. If the remote sockets ever do timeout as a result of ClickHouse-side throttling, it is desired that such failures are retried in higher-level application logic as opposed to the lower-level throttler silently failing to do its job.

Note: The old logic disabled throttling when no timeouts were set on a blocking socket. The new logic always enables throttling on blocking sockets (if throttling is configured). As explained above, this is because throttling behaviour should not be tied to local socket's settings.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description])
Remote throttler sleep time no longer dependent on local socket timeouts and capped at 20 seconds by default.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.318`
- Backported to: `25.12.4.21`, `25.11.7.10`, `25.10.5.13`, `25.8.15.9`
<!-- ch-version-info:end -->