### PR TITLE
tests: fix test_dictionaries_update_and_reload flakiness (under database disk)

### DIFF
--- a/src/Common/ShellCommand.cpp
+++ b/src/Common/ShellCommand.cpp
@@ -97,7 +97,7 @@ ShellCommand::~ShellCommand()
 
 bool ShellCommand::tryWaitProcessWithTimeout(size_t timeout_in_seconds)
 {
-    LOG_TRACE(getLogger(), "Try wait for shell command pid {} with timeout {}", pid, timeout_in_seconds);
+    LOG_TRACE(getLogger(), "Try wait for shell command pid {} with timeout {} (seconds)", pid, timeout_in_seconds);
 
     wait_called = true;
 

--- a/tests/integration/test_dictionaries_update_and_reload/test.py
+++ b/tests/integration/test_dictionaries_update_and_reload/test.py
@@ -105,10 +105,6 @@ def test_reload_while_loading(started_cluster):
             timeout=10,
         )
 
-    # The instance should receive the query
-    query("SYSTEM FLUSH LOGS")
-    assert instance.wait_for_log_line(query_id)
-
     # The dictionary is now loading.
     assert get_status(instance, "slow") == "LOADING"
     start_time, duration = get_loading_start_time(
@@ -129,9 +125,6 @@ def test_reload_while_loading(started_cluster):
     query_id = str(uuid.uuid4())
     with pytest.raises(QueryTimeoutExceedException):
         query("SYSTEM RELOAD DICTIONARY 'slow'", query_id=query_id, timeout=10)
-    # The instance should receive the query
-    query("SYSTEM FLUSH LOGS")
-    assert instance.wait_for_log_line(query_id)
     assert get_status(instance, "slow") == "LOADING"
     prev_start_time, prev_duration = start_time, duration
     start_time, duration = get_loading_start_time(


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Under database disk SYSTEM FLUSH LOGS can be very slow [1], and by the
time SYSTEM RELOAD DICTIONARY executed the dictGet() already fails.

  [1]: https://pastila.nl/?0042af27/d46c1cf01a6c9a9b8674506aeceef77a#M092ZKA7RgJSZvlhJf0H5Q==GCM

Fixes: https://github.com/ClickHouse/ClickHouse/issues/93250
