### PR TITLE
Fix system instrument stateless tests

### DIFF
--- a/src/Interpreters/InstrumentationManager.h
+++ b/src/Interpreters/InstrumentationManager.h
@@ -101,8 +101,9 @@ public:
 
     static InstrumentationManager & instance();
 
-    [[clang::xray_never_instrument]] void patchFunction(ContextPtr context, const String & function_name, const String & handler_name, Instrumentation::EntryType entry_type, const std::vector<InstrumentedParameter> & parameters);
     [[clang::xray_never_instrument]] void unpatchFunction(std::variant<UInt64, Instrumentation::All, String> id);
+    [[clang::xray_never_instrument]] static bool shouldPatchFunction(String function_to_patch, String function);
+    [[clang::xray_never_instrument]] void patchFunction(ContextPtr context, const String & function_name, const String & handler_name, Instrumentation::EntryType entry_type, const std::vector<InstrumentedParameter> & parameters);
 
     using InstrumentedPoints = std::vector<InstrumentedPointInfo>;
     InstrumentedPoints getInstrumentedPoints() const;

--- a/src/Interpreters/InstrumentationManager.h
+++ b/src/Interpreters/InstrumentationManager.h
@@ -102,7 +102,7 @@ public:
     static InstrumentationManager & instance();
 
     [[clang::xray_never_instrument]] void unpatchFunction(std::variant<UInt64, Instrumentation::All, String> id);
-    [[clang::xray_never_instrument]] static bool shouldPatchFunction(String function_to_patch, String function);
+    [[clang::xray_never_instrument]] static bool shouldPatchFunction(String function_to_patch, String full_qualified_function);
     [[clang::xray_never_instrument]] void patchFunction(ContextPtr context, const String & function_name, const String & handler_name, Instrumentation::EntryType entry_type, const std::vector<InstrumentedParameter> & parameters);
 
     using InstrumentedPoints = std::vector<InstrumentedPointInfo>;

--- a/src/Interpreters/tests/gtest_instrumentation.cpp
+++ b/src/Interpreters/tests/gtest_instrumentation.cpp
@@ -1,0 +1,22 @@
+#include "config.h"
+
+#if USE_XRAY
+
+#include <Interpreters/InstrumentationManager.h>
+#include <gtest/gtest.h>
+
+using namespace DB;
+
+TEST(InstrumentationManager, shouldPatchFunction)
+{
+    ASSERT_TRUE(InstrumentationManager::shouldPatchFunction("QueryMetricLog::startQuery",
+        "DB::QueryMetricLog::startQuery(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::chrono::time_point<std::__1::chrono::system_clock, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000l>>>, unsigned long)"));
+
+    ASSERT_FALSE(InstrumentationManager::shouldPatchFunction("QueryMetricLog::startQuery",
+        "std::__1::__function::__policy_func<void ()>::__call_func[abi:ne210105]<DB::QueryMetricLog::startQuery(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::chrono::time_point<std::__1::chrono::system_clock, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000l>>>, unsigned long)::$_0>(std::__1::__function::__policy_storage const*)"));
+
+    ASSERT_TRUE(InstrumentationManager::shouldPatchFunction("QueryMetricLog::startQuery",
+        "DB::something<bool>::otherClass<MyClass>::QueryMetricLog::startQuery"));
+}
+
+#endif


### PR DESCRIPTION
Follow-up on https://github.com/ClickHouse/ClickHouse/pull/93345

Fix system instrument tests that use `QueryMetricLog::startQuery`.

Patching all functions that match broke the [tests in private](http://cidb.clickhouse-staging.com:8123/play?user=play#V0lUSAogICAgMzAgQVMgbGFzdF9kYXlzX3RvX2NoZWNrLAogICAgMTAwIEFTIG1heF90ZXN0c190b19zaG93LAogICAgNSBhcyBtYXhfcHJzX3RvX3Nob3csCiAgICA3MCBBUyB0ZXN0X25hbWVfbWF4X2xlbmd0aApTRUxFQ1QKICAgIGNoZWNrX3N0YXJ0X3RpbWUsCiAgICBwdWxsX3JlcXVlc3RfbnVtYmVyLAogICAgdGVzdF9zdGF0dXMsCiAgICByZXBvcnRfdXJsLAogICAgcHVsbF9yZXF1ZXN0X3VybApGUk9NIGNoZWNrcwpXSEVSRQogICAgY2hlY2tfc3RhcnRfdGltZSA+PSBub3coKSAtIGludGVydmFsIGxhc3RfZGF5c190b19jaGVjayBkYXkKICAgIEFORCAodGVzdF9zdGF0dXMgPSAnRkFJTCcpCiAgICBBTkQgdGVzdF9uYW1lIElMSUtFICclMDM2NDJfc3lzdGVtX2luc3RydW1lbnQlJwpPUkRFUiBCWSBjaGVja19zdGFydF90aW1lIERFU0MKTElNSVQgbWF4X3Rlc3RzX3RvX3Nob3c=). The CI didn't catch it because the `CH Inc sync` job only runs the `amd_asan` version, which is built without XRay support because symbols clash and thus [the tests are skipped](https://d1k2gkhrlfqv31.cloudfront.net/clickhouse-test-reports-private/PRs/45461/eeedd36fef880cad72a59344907c21100cf7db8d//stateless_tests_amd_asan_db_disk_distributed_cache_meta_storage_in_keeper_s3_storage_sequential_1_2/job.log). Also, the failures only happen in the private fork because of how a lambda symbol within `QueryMetricLog::startQuery` is named:

```sql
SELECT *
FROM system.symbols
WHERE symbol_demangled ILIKE '%QueryMetricLog::startQuery%'
SETTINGS allow_introspection_functions = 1

Query id: 68611f22-150a-4c34-8895-fe6f485162c2

Row 1:
──────
symbol:           _ZN2DB14QueryMetricLog10startQueryERKNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEENS1_6chrono10time_pointINSA_12system_clockENSA_8durationIxNS1_5ratioILl1ELl1000000EEEEEEEm
symbol_demangled: DB::QueryMetricLog::startQuery(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::chrono::time_point<std::__1::chrono::system_clock, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000l>>>, unsigned long)
function_id:      205671
address_begin:    467638464 -- 467.64 million
address_end:      467642420 -- 467.64 million

Row 2:
──────
symbol:           _ZNSt3__110__function13__policy_funcIFvvEE11__call_funcB8ne210105IZN2DB14QueryMetricLog10startQueryERKNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEENS_6chrono10time_pointINSF_12system_clockENSF_8durationIxNS_5ratioILl1ELl1000000EEEEEEEmE3$_0EEvPKNS0_16__policy_storageE
symbol_demangled: void std::__1::__function::__policy_func<void ()>::__call_func[abi:ne210105]<DB::QueryMetricLog::startQuery(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::chrono::time_point<std::__1::chrono::system_clock, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000l>>>, unsigned long)::$_0>(std::__1::__function::__policy_storage const*)
function_id:      205689
address_begin:    467676864 -- 467.68 million
address_end:      467683108 -- 467.68 million

2 rows in set. Elapsed: 1.626 sec. Processed 814.18 thousand rows, 263.08 MB (500.62 thousand rows/s., 161.76 MB/s.)
Peak memory usage: 206.48 MiB.
```

While this function should be patched for `QueryMetricLog::startQuery`:
```
DB::QueryMetricLog::startQuery(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::chrono::time_point<std::__1::chrono::system_clock, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000l>>>, unsigned long)
```

This one that comes from a lambda on a release build shouldn't:
```
std::__1::__function::__policy_func<void ()>::__call_func[abi:ne210105]<DB::QueryMetricLog::startQuery(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::chrono::time_point<std::__1::chrono::system_clock, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000l>>>, unsigned long)::$_0>(std::__1::__function::__policy_storage const*)
```

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
