### PR TITLE
Fix overflow in `groupConcat` deserialisation

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionGroupConcat.cpp
+++ b/src/AggregateFunctions/AggregateFunctionGroupConcat.cpp
@@ -172,6 +172,10 @@ void GroupConcatImpl<has_limit>::deserialize(AggregateDataPtr __restrict place, 
     if constexpr (has_limit)
     {
         readVarUInt(cur_data.num_rows, buf);
+
+        if (cur_data.num_rows > std::numeric_limits<UInt64>::max() / 2)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Invalid groupConcat state: num_rows ({}) is too large and would overflow the offsets array.", cur_data.num_rows);
+
         cur_data.offsets.resize_exact(cur_data.num_rows * 2, arena);
         for (auto & offset : cur_data.offsets)
             readVarUInt(offset, buf);

--- a/tests/queries/0_stateless/03773_group_concat_overflow.sql
+++ b/tests/queries/0_stateless/03773_group_concat_overflow.sql
@@ -1,0 +1,8 @@
+-- Check if we catch overflow on num_rows
+
+-- data_size = 4, data = AAAA, num_rows = 2^63
+SELECT hex(groupConcatMerge(',', 10)(state))
+FROM
+(
+    SELECT CAST(unhex('044141414180808080808080808001'), 'AggregateFunction(groupConcat(\',\', 10), String)') AS state
+) -- { serverError BAD_ARGUMENTS }


### PR DESCRIPTION
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed integer overflow vulnerability in `groupConcat` state deserialisation that could cause memory safety issues with crafted aggregate states.

