### PR TITLE
Allow parse `SELECT` without parentheses around `DESCRIBE SELECT`

### DIFF
--- a/docs/en/sql-reference/statements/describe-table.md
+++ b/docs/en/sql-reference/statements/describe-table.md
@@ -66,6 +66,26 @@ The second query additionally shows subcolumns:
 └───────────┴───────────────────────────────┴──────────────┴────────────────────┴─────────┴──────────────────┴────────────────┴──────────────┘
 ```
 
+The DESCRIBE statement can also be used with subqueries or scalar expressions:
+
+``` SQL
+DESCRIBE SELECT 1 FORMAT TSV;
+```
+
+or
+
+``` SQL
+DESCRIBE (SELECT 1) FORMAT TSV;
+```
+
+Result:
+
+``` text
+1       UInt8
+```
+
+This usage returns metadata about the result columns of the specified query or subquery. It is useful for understanding the structure of complex queries before execution.
+
 **See Also**
 
 - [describe_include_subcolumns](../../operations/settings/settings.md#describe_include_subcolumns) setting.

--- a/src/Parsers/ParserDescribeTableQuery.cpp
+++ b/src/Parsers/ParserDescribeTableQuery.cpp
@@ -1,4 +1,6 @@
+#include <Parsers/ParserSelectWithUnionQuery.h>
 #include <Parsers/TablePropertiesQueriesASTs.h>
+#include <Parsers/ASTTablesInSelectQuery.h>
 
 #include <Parsers/CommonParsers.h>
 #include <Parsers/ParserDescribeTableQuery.h>
@@ -19,8 +21,7 @@ bool ParserDescribeTableQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & ex
     ParserKeyword s_settings(Keyword::SETTINGS);
     ParserSetQuery parser_settings(true);
 
-    ASTPtr database;
-    ASTPtr table;
+    ASTPtr select;
 
     if (!s_describe.ignore(pos, expected) && !s_desc.ignore(pos, expected))
         return false;
@@ -29,7 +30,17 @@ bool ParserDescribeTableQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & ex
 
     s_table.ignore(pos, expected);
 
-    if (!ParserTableExpression().parse(pos, query->table_expression, expected))
+    /// Try to parse SELECT query without parentheses (e.g., DESCRIBE SELECT 1)
+    if (ParserSelectWithUnionQuery().parse(pos, select, expected))
+    {
+        auto table_expr = std::make_shared<ASTTableExpression>();
+        /// Wrap SELECT in ASTSubquery, as expected by the rest of the codebase
+        auto subquery = std::make_shared<ASTSubquery>(std::move(select));
+        table_expr->subquery = subquery;
+        table_expr->children.push_back(table_expr->subquery);
+        query->table_expression = table_expr;
+    }
+    else if (!ParserTableExpression().parse(pos, query->table_expression, expected))
         return false;
 
     /// For compatibility with SELECTs, where SETTINGS can be in front of FORMAT

--- a/src/Parsers/ParserDescribeTableQuery.cpp
+++ b/src/Parsers/ParserDescribeTableQuery.cpp
@@ -5,6 +5,7 @@
 #include <Parsers/CommonParsers.h>
 #include <Parsers/ParserDescribeTableQuery.h>
 #include <Parsers/ParserTablesInSelectQuery.h>
+#include <Parsers/ParserSelectWithUnionQuery.h>
 #include <Parsers/ParserSetQuery.h>
 
 #include <Common/typeid_cast.h>

--- a/src/Parsers/ParserDescribeTableQuery.cpp
+++ b/src/Parsers/ParserDescribeTableQuery.cpp
@@ -1,5 +1,5 @@
-#include <Parsers/ParserSelectWithUnionQuery.h>
 #include <Parsers/TablePropertiesQueriesASTs.h>
+#include <Parsers/ASTSubquery.h>
 #include <Parsers/ASTTablesInSelectQuery.h>
 
 #include <Parsers/CommonParsers.h>

--- a/tests/queries/0_stateless/03782_parse_describe_select_without_parentheses_around_select.reference
+++ b/tests/queries/0_stateless/03782_parse_describe_select_without_parentheses_around_select.reference
@@ -1,0 +1,4 @@
+1	UInt8					
+1	UInt8					
+number	UInt64					
+example	String					

--- a/tests/queries/0_stateless/03782_parse_describe_select_without_parentheses_around_select.sql
+++ b/tests/queries/0_stateless/03782_parse_describe_select_without_parentheses_around_select.sql
@@ -1,0 +1,6 @@
+DESCRIBE SELECT 1 FORMAT TSV;
+DESCRIBE (SELECT 1) FORMAT TSV;
+
+CREATE TABLE test_table (number UInt64, example String) ENGINE = Memory;
+DESCRIBE test_table FORMAT TSV;
+DROP TABLE test_table;


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
ClickHouse can now parse `SELECT` without parentheses around `DESCRIBE SELECT` queries. Closes https://github.com/ClickHouse/ClickHouse/issues/58382.


### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
