### PR TITLE
Fix 'Bad Version' error in S3 Ordered Queue

### DIFF
--- a/tests/integration/test_storage_s3_queue/configs/s3queue_log.xml
+++ b/tests/integration/test_storage_s3_queue/configs/s3queue_log.xml
@@ -7,4 +7,7 @@
         <database>system</database>
         <table>s3queue_log</table>
     </s3queue_log>
+    <logger>
+        <count>20</count>
+    </logger>
 </clickhouse>


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Retry on 'Bad Version' error in S3 Queue processing.
Possible fix #93396

### Documentation entry for user-facing changes
Make retry on 'Bad Version' error. Possible in multi-node processing, when several nodes try to commit changes in Keeper simultaneously.

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
