### PR TITLE
do not use oauth login when username + password is in connection string

### DIFF
--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -1059,7 +1059,7 @@ void Client::readArguments(
                 // intentionally ignored. argv[1] is not a uri, but could be a query.
             }
 
-            if (isCloudEndpoint(hostname))
+            if (isCloudEndpoint(hostname) && !has_auth_in_connection_string)
             {
                 is_hostname_argument = true;
 

--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -1041,6 +1041,7 @@ void Client::readArguments(
         {
             std::string hostname(argv[1]);
             std::string port;
+            bool has_auth_in_connection_string = false;
 
             try
             {
@@ -1050,6 +1051,8 @@ void Client::readArguments(
                     hostname = host;
                     port = std::to_string(uri.getPort());
                 }
+                /// Check if connection string contains user credentials (e.g., clickhouse://user:password@host)
+                has_auth_in_connection_string = !uri.getUserInfo().empty();
             }
             catch (const Poco::URISyntaxException &) // NOLINT(bugprone-empty-catch)
             {
@@ -1074,8 +1077,8 @@ void Client::readArguments(
                     }
                 }
 
-                /// Only auto-add --login if no authentication credentials provided via command line
-                if (!has_auth_in_cmdline)
+                /// Only auto-add --login if no authentication credentials provided via command line or connection string
+                if (!has_auth_in_cmdline && !has_auth_in_connection_string)
                 {
                     common_arguments.emplace_back("--login");
                     login_was_auto_added = true;

--- a/tests/queries/0_stateless/03749_cloud_endpoint_auth_precedence.reference
+++ b/tests/queries/0_stateless/03749_cloud_endpoint_auth_precedence.reference
@@ -8,6 +8,10 @@ Test 4: --host= with --port (space) should work
 OK
 Test 5: Config file credentials should be respected
 OK
-Test 6: Multiple host/port format variations
+Test 6: Connection string with only user should not trigger OAuth
+OK
+Test 7: Connection string with user:password@ should not trigger OAuth
+OK
+Test 8: Multiple host/port format variations
 OK
 All tests completed

--- a/tests/queries/0_stateless/03749_cloud_endpoint_auth_precedence.sh
+++ b/tests/queries/0_stateless/03749_cloud_endpoint_auth_precedence.sh
@@ -64,8 +64,24 @@ fi
 
 rm -f "$CONFIG_FILE"
 
-# Test 6: Multiple --host and --port combinations should all work
-echo "Test 6: Multiple host/port format variations"
+echo "Test 6: Connection string with only user should not trigger OAuth"
+output=$($CLICKHOUSE_CLIENT_BINARY "clickhouse://default@${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT_TCP}/" --query "SELECT 1" 2>&1)
+if echo "$output" | grep -qi "login\|OAuth\|browser"; then
+    echo "FAILED: OAuth login triggered despite connection string credentials"
+else
+    echo "OK"
+fi
+
+echo "Test 7: Connection string with user:password@ should not trigger OAuth"
+output=$($CLICKHOUSE_CLIENT_BINARY "clickhouse://default:super-secret@${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT_TCP}/" --query "SELECT 1" 2>&1)
+if echo "$output" | grep -qi "login\|OAuth\|browser"; then
+    echo "FAILED: OAuth login triggered despite connection string credentials"
+else
+    echo "OK"
+fi
+
+# Test 8: Multiple --host and --port combinations should all work
+echo "Test 8: Multiple host/port format variations"
 failed=0
 for cmd in \
     "$CLICKHOUSE_CLIENT_BINARY --host=${CLICKHOUSE_HOST} --port=${CLICKHOUSE_PORT_TCP} --query 'SELECT 1'" \


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Avoids oauth login in ClickHouse Client when username/password are within the connection string


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.474`
- Backported to: `25.12.4.5`
<!-- ch-version-info:end -->