### PR TITLE
Fix 00634_performance_introspection_and_logging

### DIFF
--- a/tests/queries/0_stateless/00634_performance_introspection_and_logging.sh
+++ b/tests/queries/0_stateless/00634_performance_introspection_and_logging.sh
@@ -26,7 +26,7 @@ $CLICKHOUSE_CLIENT $settings -q "
 DROP TABLE IF EXISTS null_00634;
 CREATE TABLE null_00634 (i UInt8) ENGINE = MergeTree PARTITION BY tuple() ORDER BY tuple();"
 
-head -c 1000 /dev/zero | $CLICKHOUSE_CLIENT $settings --max_insert_block_size=10 --min_insert_block_size_rows=1 --min_insert_block_size_bytes=1 -q "INSERT INTO null_00634 FORMAT RowBinary"
+head -c 1000 /dev/zero | $CLICKHOUSE_CLIENT $settings --max_insert_block_size=10 --min_insert_block_size_rows=10 --min_insert_block_size_bytes=1 -q "INSERT INTO null_00634 FORMAT RowBinary"
 
 $CLICKHOUSE_CLIENT $settings -q "
 SELECT count() FROM null_00634;

--- a/tests/queries/0_stateless/00634_performance_introspection_and_logging.sh
+++ b/tests/queries/0_stateless/00634_performance_introspection_and_logging.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Tags: no-async-insert
+# Tags: no-async-insert, long
 # no-async-insert: Test expects new part for each insert
+# long: Flaky check in private times out sometimes :(
 
 set -e
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Closes: #93378

---

As far as I see, it always times out on `INSERT INTO null_00634 FORMAT RowBinary` that may perform up to 1k individual inserts (row-by-row). Let's just increase `min_insert_block_size_rows`.