### PR TITLE
Support `asyncTryMultiNoThrow` with span for injection keeper

### DIFF
--- a/src/Common/ZooKeeper/ZooKeeperWithFaultInjection.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperWithFaultInjection.cpp
@@ -446,6 +446,7 @@ zkutil::ZooKeeper::FutureMulti ZooKeeperWithFaultInjection::asyncTryMultiNoThrow
 }
 
 zkutil::ZooKeeper::FutureMulti ZooKeeperWithFaultInjection::asyncTryMultiNoThrow(std::span<const Coordination::RequestPtr> ops)
+{
 #ifndef NDEBUG
     /// asyncTryMultiNoThrow is not setup to handle faults with ephemeral nodes
     /// To do it we'd need to look at ops and save the indexes BEFORE the callback, as the ops are not

--- a/src/Common/ZooKeeper/ZooKeeperWithFaultInjection.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperWithFaultInjection.cpp
@@ -440,9 +440,12 @@ zkutil::ZooKeeper::FutureGet ZooKeeperWithFaultInjection::asyncTryGet(std::strin
     return future;
 }
 
-
 zkutil::ZooKeeper::FutureMulti ZooKeeperWithFaultInjection::asyncTryMultiNoThrow(const Coordination::Requests & ops)
 {
+    return asyncTryMultiNoThrow(std::span(ops));
+}
+
+zkutil::ZooKeeper::FutureMulti ZooKeeperWithFaultInjection::asyncTryMultiNoThrow(std::span<const Coordination::RequestPtr> ops)
 #ifndef NDEBUG
     /// asyncTryMultiNoThrow is not setup to handle faults with ephemeral nodes
     /// To do it we'd need to look at ops and save the indexes BEFORE the callback, as the ops are not

--- a/src/Common/ZooKeeper/ZooKeeperWithFaultInjection.h
+++ b/src/Common/ZooKeeper/ZooKeeperWithFaultInjection.h
@@ -234,6 +234,7 @@ public:
     zkutil::ZooKeeper::FutureGet asyncTryGet(std::string path);
 
     zkutil::ZooKeeper::FutureMulti asyncTryMultiNoThrow(const Coordination::Requests & ops);
+    zkutil::ZooKeeper::FutureMulti asyncTryMultiNoThrow(std::span<const Coordination::RequestPtr> ops);
 
     zkutil::ZooKeeper::FutureRemove asyncTryRemove(std::string path, int32_t version = -1);
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
I need this interface; it exists for the regular keeper client.
