### PR TITLE
Support for scalars + beautify the Non-const `IN` code

### DIFF
--- a/src/Analyzer/Resolve/QueryAnalyzer.h
+++ b/src/Analyzer/Resolve/QueryAnalyzer.h
@@ -181,6 +181,16 @@ private:
 
     std::pair<QueryTreeNodePtr, ProjectionNames> makeNullSafeHas(QueryTreeNodePtr array_arg, QueryTreeNodePtr element_arg, const ProjectionNames & args_proj, IdentifierResolveScope & scope);
 
+    ProjectionNames buildHasExpression(
+        QueryTreeNodePtr & node,
+        QueryTreeNodePtr array_arg,
+        QueryTreeNodePtr element_arg,
+        bool is_not_in,
+        bool transform_null_in,
+        const ProjectionNames & arguments_projection_names,
+        const ProjectionNames & parameters_projection_names,
+        IdentifierResolveScope & scope);
+
     ProjectionNames handleNullInTuple(const QueryTreeNodes & tuple_args, const std::string & function_name, const ProjectionNames & parameters_projection_names,
                                         const ProjectionNames & arguments_projection_names, IdentifierResolveScope & scope, QueryTreeNodePtr & node);
 

--- a/src/Analyzer/Resolve/resolveFunction.cpp
+++ b/src/Analyzer/Resolve/resolveFunction.cpp
@@ -94,6 +94,14 @@ bool isNullConstant(const QueryTreeNodePtr & node)
     return false;
 }
 
+/// Creates a NOT function node wrapping the given node (caller must resolve it)
+QueryTreeNodePtr createNotWrapper(QueryTreeNodePtr node)
+{
+    auto not_fn = std::make_shared<FunctionNode>("not");
+    not_fn->getArguments().getNodes().push_back(node);
+    return not_fn;
+}
+
 /// Builds and resolves `IF(isNull(element), NULL, has(array, element))`
 std::pair<QueryTreeNodePtr, ProjectionNames> QueryAnalyzer::makeNullSafeHas(
     QueryTreeNodePtr array_arg,    // [1,2,number]
@@ -798,110 +806,109 @@ ProjectionNames QueryAnalyzer::resolveFunction(QueryTreeNodePtr & node, Identifi
             /// If it's a function node like array(..) or tuple(..), consider rewriting them to 'has':
             if (auto * non_const_set_candidate = in_second_argument->as<FunctionNode>())
             {
-                bool left_is_null = isNullConstant(in_first_argument);
                 const auto & candidate_name = non_const_set_candidate->getFunctionName();
-                bool is_not_in = (function_name == "notIn" || function_name == "globalNotIn" ||
-                                  function_name == "notNullIn" || function_name == "globalNotNullIn");
+                const bool is_not_in = (function_name == "notIn" || function_name == "globalNotIn" ||
+                                        function_name == "notNullIn" || function_name == "globalNotNullIn");
+                const bool transform_null_in = scope.context->getSettingsRef()[Setting::transform_null_in];
+                auto & fn_args = function_node.getArguments().getNodes();
 
-                /// Case 1: array(..) node or any function returning Array type
-                if (candidate_name == "array" || isArray(non_const_set_candidate->getResultType()))
+                /// the type of the second argument
+                bool is_array_type = (candidate_name == "array") ||
+                    (non_const_set_candidate->isResolved() && isArray(non_const_set_candidate->getResultType()));
+                bool is_tuple_type = (candidate_name == "tuple");
+                bool is_scalar_type = non_const_set_candidate->isResolved() &&
+                    !isArray(non_const_set_candidate->getResultType()) &&
+                    !isTuple(non_const_set_candidate->getResultType());
+
+                /// Case 1: array(..) or any function returning Array type -> rewrite to has()
+                if (is_array_type)
                 {
-                    /// convert to has() by swapping arguments
-                    function_name = "has";
-                    is_special_function_in = false;
-                    auto & fn_args = function_node.getArguments().getNodes();
-                    std::swap(fn_args[0], fn_args[1]);
+                    auto proj = calculateFunctionProjectionName(node, parameters_projection_names, arguments_projection_names);
 
-                    if (!scope.context->getSettingsRef()[Setting::transform_null_in])
+                    if (!transform_null_in)
                     {
-                        auto [wrapped_node, proj_names] = makeNullSafeHas(
-                            fn_args[0], fn_args[1], arguments_projection_names, scope);
+                        auto [result_node, proj_names] = makeNullSafeHas(fn_args[1], fn_args[0], arguments_projection_names, scope);
                         if (is_not_in)
                         {
-                            auto not_fn = std::make_shared<FunctionNode>("not");
-                            not_fn->getArguments().getNodes().push_back(wrapped_node);
-                            resolveFunction(wrapped_node = not_fn, scope);
+                            result_node = createNotWrapper(result_node);
+                            resolveFunction(result_node, scope);
                         }
-                        node = wrapped_node;
+                        node = result_node;
+                        return proj_names;
+                    }
+
+                    auto has_fn = std::make_shared<FunctionNode>("has");
+                    has_fn->getArguments().getNodes() = {fn_args[1], fn_args[0]};
+                    QueryTreeNodePtr result_node = has_fn;
+                    resolveFunction(result_node, scope);
+
+                    if (is_not_in)
+                    {
+                        result_node = createNotWrapper(result_node);
+                        resolveFunction(result_node, scope);
+                    }
+                    node = result_node;
+                    return ProjectionNames{proj};
+                }
+
+                /// Case 2: tuple(..) -> convert to array, then rewrite to has()
+                /// If the left-hand side is a lambda, do not rewrite
+                /// Lambdas are rejected later by getLambdaArgumentTypes() with a proper error
+                if (is_tuple_type && in_first_argument->getNodeType() != QueryTreeNodeType::LAMBDA)
+                {
+                    auto & tuple_args = non_const_set_candidate->getArguments().getNodes();
+                    const bool left_is_null = isNullConstant(in_first_argument);
+
+                    /// handling for NULL IN (tuple)
+                    if (left_is_null)
+                    {
+                        if (transform_null_in)
+                            return handleNullInTuple(tuple_args, function_name,
+                                parameters_projection_names, arguments_projection_names, scope, node);
+
+                        auto proj = calculateFunctionProjectionName(node, parameters_projection_names, arguments_projection_names);
+                        node = std::make_shared<ConstantNode>(Field{},
+                            std::make_shared<DataTypeNullable>(std::make_shared<DataTypeUInt8>()));
+                        return ProjectionNames{proj};
+                    }
+
+                    /// convert tuple to array and rewrite to has()
+                    in_second_argument = convertTupleToArray(tuple_args, in_first_argument, scope);
+                    function_name = "has";
+                    is_special_function_in = false;
+                    std::swap(fn_args[0], fn_args[1]);
+
+                    if (!transform_null_in)
+                    {
+                        auto [result_node, proj_names] = makeNullSafeHas(fn_args[0], fn_args[1], arguments_projection_names, scope);
+                        if (is_not_in)
+                        {
+                            result_node = createNotWrapper(result_node);
+                            resolveFunction(result_node, scope);
+                        }
+                        node = result_node;
                         return proj_names;
                     }
 
                     if (is_not_in)
                     {
-                        /// Wrap has() result with NOT for notIn/globalNotIn
                         auto proj = calculateFunctionProjectionName(node, parameters_projection_names, arguments_projection_names);
                         resolveFunction(node, scope);
-                        auto not_fn = std::make_shared<FunctionNode>("not");
-                        not_fn->getArguments().getNodes().push_back(node);
-                        node = not_fn;
+                        node = createNotWrapper(node);
                         resolveFunction(node, scope);
                         return ProjectionNames{proj};
                     }
                 }
-                /// Case 2: tuple(..) node - rewrite into an array
-                else if (candidate_name == "tuple")
+
+                /// Case 3: scalar-returning function -> rewrite to equals/notEquals
+                if (is_scalar_type)
                 {
-                    auto & tuple_args = non_const_set_candidate->getArguments().getNodes();
-
-                    /// If the left-hand side is a lambda, do not rewrite
-                    /// Lambdas are rejected later by getLambdaArgumentTypes() with a proper error
-                    if (in_first_argument->getNodeType() == QueryTreeNodeType::LAMBDA)
-                    {
-                        /// Do nothing; leave IN as-is
-                    }
-                    else
-                    {
-                        /// special handling for NULL IN (tuple) with transform_null_in enabled
-                        if (left_is_null && scope.context->getSettingsRef()[Setting::transform_null_in])
-                        {
-                            return handleNullInTuple(tuple_args, function_name,
-                                                parameters_projection_names,
-                                                arguments_projection_names, scope, node);
-                        }
-
-                        if (left_is_null && !scope.context->getSettingsRef()[Setting::transform_null_in])
-                        {
-                            auto proj = calculateFunctionProjectionName(node, parameters_projection_names, arguments_projection_names);
-                            auto null_type = std::make_shared<DataTypeNullable>(std::make_shared<DataTypeUInt8>());
-                            node = std::make_shared<ConstantNode>(Field{}, null_type);
-                            return ProjectionNames{proj};
-                        }
-
-                        /// convert tuple to array with proper type handling
-                        in_second_argument = convertTupleToArray(tuple_args, in_first_argument, scope);
-
-                        /// convert to has() and handle null-safety
-                        function_name = "has";
-                        is_special_function_in = false;
-                        auto & fn_args = function_node.getArguments().getNodes();
-                        std::swap(fn_args[0], fn_args[1]);
-
-                        if (!scope.context->getSettingsRef()[Setting::transform_null_in])
-                        {
-                            auto [wrapped_node, proj_names] = makeNullSafeHas(
-                                fn_args[0], fn_args[1], arguments_projection_names, scope);
-                            if (is_not_in)
-                            {
-                                auto not_fn = std::make_shared<FunctionNode>("not");
-                                not_fn->getArguments().getNodes().push_back(wrapped_node);
-                                resolveFunction(wrapped_node = not_fn, scope);
-                            }
-                            node = wrapped_node;
-                            return proj_names;
-                        }
-
-                        if (is_not_in)
-                        {
-                            /// Wrap has() result with NOT for notIn/globalNotIn
-                            auto proj = calculateFunctionProjectionName(node, parameters_projection_names, arguments_projection_names);
-                            resolveFunction(node, scope);
-                            auto not_fn = std::make_shared<FunctionNode>("not");
-                            not_fn->getArguments().getNodes().push_back(node);
-                            node = not_fn;
-                            resolveFunction(node, scope);
-                            return ProjectionNames{proj};
-                        }
-                    }
+                    auto proj = calculateFunctionProjectionName(node, parameters_projection_names, arguments_projection_names);
+                    auto eq_fn = std::make_shared<FunctionNode>(is_not_in ? "notEquals" : "equals");
+                    eq_fn->getArguments().getNodes() = {fn_args[0], fn_args[1]};
+                    node = eq_fn;
+                    resolveFunction(node, scope);
+                    return ProjectionNames{proj};
                 }
             }
         }

--- a/tests/queries/0_stateless/03393_non_constant_second_argument_for_in.reference
+++ b/tests/queries/0_stateless/03393_non_constant_second_argument_for_in.reference
@@ -267,3 +267,17 @@ SELECT 1 GLOBAL NOT IN if(1 > 0, 1, 2);
 SELECT * FROM (SELECT * FROM VALUES('cab_type String, dropoff UInt16', ('yellow', 138), ('green', 132))) AS t WHERE dropoff IN if(cab_type = 'yellow', 138, 132);
 yellow	138
 green	132
+SELECT '-- Scalar NULL handling (preserves IN non-nullable behavior) --';
+-- Scalar NULL handling (preserves IN non-nullable behavior) --
+SELECT 1 IN nullIf(1, 1) AS r, toTypeName(1 IN nullIf(1, 1)) AS t;
+0	UInt8
+SELECT 1 NOT IN nullIf(1, 1) AS r, toTypeName(1 NOT IN nullIf(1, 1)) AS t;
+1	UInt8
+SELECT number, number IN nullIf(number, 1) FROM numbers(3);
+0	1
+1	0
+2	1
+SELECT number, number NOT IN nullIf(number, 1) FROM numbers(3);
+0	0
+1	1
+2	0

--- a/tests/queries/0_stateless/03393_non_constant_second_argument_for_in.reference
+++ b/tests/queries/0_stateless/03393_non_constant_second_argument_for_in.reference
@@ -190,3 +190,80 @@ SETTINGS transform_null_in = 0;
 \N	[0]	(0)	\N	\N
 \N	[1]	(1)	\N	\N
 \N	[NULL]	(NULL)	\N	\N
+SELECT '-- Scalar-returning functions (rewritten to equals/notEquals) --';
+-- Scalar-returning functions (rewritten to equals/notEquals) --
+SELECT 1 IN if(1 > 0, 1, 2);
+1
+SELECT 1 IN if(1 > 0, 2, 1);
+0
+SELECT 2 IN if(0 > 1, 1, 2);
+1
+SELECT number, number IN if(number > 2, 5, 1) FROM numbers(6);
+0	0
+1	1
+2	0
+3	0
+4	0
+5	1
+SELECT number, number IN if(number % 2 = 0, number, number + 10) FROM numbers(5);
+0	1
+1	0
+2	1
+3	0
+4	1
+SELECT 1 NOT IN if(1 > 0, 1, 2);
+0
+SELECT 1 NOT IN if(1 > 0, 2, 1);
+1
+SELECT number, number NOT IN if(number > 2, 5, 1) FROM numbers(6);
+0	1
+1	0
+2	1
+3	1
+4	1
+5	0
+SELECT 1 IN if(1 > 0, if(2 > 1, 1, 3), 2);
+1
+SELECT 2 IN if(1 > 0, if(2 > 1, 1, 3), 2);
+0
+SELECT 1 IN multiIf(1 > 2, 10, 2 > 3, 20, 1);
+1
+SELECT 10 IN multiIf(1 > 0, 10, 2 > 3, 20, 1);
+1
+SELECT 1 IN coalesce(NULL, 1);
+1
+SELECT 1 IN coalesce(NULL, 2);
+0
+SELECT 1 IN coalesce(1, 2);
+1
+SELECT 1 IN nullIf(1, 2);
+1
+SELECT 1 IN nullIf(2, 2);
+0
+SELECT 5 IN (2 + 3);
+1
+SELECT 5 IN (2 * 3);
+0
+SELECT 'hello' IN if(1 > 0, 'hello', 'world');
+1
+SELECT 'world' IN if(1 > 0, 'hello', 'world');
+0
+SELECT * FROM (SELECT number, number IN if(number > 2, 5, number) as result FROM numbers(6)) WHERE result = 1;
+0	1
+1	1
+2	1
+5	1
+SELECT number, number IN if(number > 2, 5, 1), number IN if(number < 2, 0, 10) FROM numbers(6);
+0	0	1
+1	1	0
+2	0	0
+3	0	0
+4	0	0
+5	1	0
+SELECT 1 GLOBAL IN if(1 > 0, 1, 2);
+1
+SELECT 1 GLOBAL NOT IN if(1 > 0, 1, 2);
+0
+SELECT * FROM (SELECT * FROM VALUES('cab_type String, dropoff UInt16', ('yellow', 138), ('green', 132))) AS t WHERE dropoff IN if(cab_type = 'yellow', 138, 132);
+yellow	138
+green	132

--- a/tests/queries/0_stateless/03393_non_constant_second_argument_for_in.sql
+++ b/tests/queries/0_stateless/03393_non_constant_second_argument_for_in.sql
@@ -197,3 +197,9 @@ SELECT 1 GLOBAL IN if(1 > 0, 1, 2);
 SELECT 1 GLOBAL NOT IN if(1 > 0, 1, 2);
 
 SELECT * FROM (SELECT * FROM VALUES('cab_type String, dropoff UInt16', ('yellow', 138), ('green', 132))) AS t WHERE dropoff IN if(cab_type = 'yellow', 138, 132);
+
+SELECT '-- Scalar NULL handling (preserves IN non-nullable behavior) --';
+SELECT 1 IN nullIf(1, 1) AS r, toTypeName(1 IN nullIf(1, 1)) AS t;
+SELECT 1 NOT IN nullIf(1, 1) AS r, toTypeName(1 NOT IN nullIf(1, 1)) AS t;
+SELECT number, number IN nullIf(number, 1) FROM numbers(3);
+SELECT number, number NOT IN nullIf(number, 1) FROM numbers(3);

--- a/tests/queries/0_stateless/03393_non_constant_second_argument_for_in.sql
+++ b/tests/queries/0_stateless/03393_non_constant_second_argument_for_in.sql
@@ -156,3 +156,44 @@ SELECT
     x IN (arr)
 FROM numbers(3)
 SETTINGS transform_null_in = 0;
+
+SELECT '-- Scalar-returning functions (rewritten to equals/notEquals) --';
+
+SELECT 1 IN if(1 > 0, 1, 2);
+SELECT 1 IN if(1 > 0, 2, 1);
+SELECT 2 IN if(0 > 1, 1, 2);
+
+SELECT number, number IN if(number > 2, 5, 1) FROM numbers(6);
+SELECT number, number IN if(number % 2 = 0, number, number + 10) FROM numbers(5);
+
+SELECT 1 NOT IN if(1 > 0, 1, 2);
+SELECT 1 NOT IN if(1 > 0, 2, 1);
+SELECT number, number NOT IN if(number > 2, 5, 1) FROM numbers(6);
+
+SELECT 1 IN if(1 > 0, if(2 > 1, 1, 3), 2);
+SELECT 2 IN if(1 > 0, if(2 > 1, 1, 3), 2);
+
+SELECT 1 IN multiIf(1 > 2, 10, 2 > 3, 20, 1);
+SELECT 10 IN multiIf(1 > 0, 10, 2 > 3, 20, 1);
+
+SELECT 1 IN coalesce(NULL, 1);
+SELECT 1 IN coalesce(NULL, 2);
+SELECT 1 IN coalesce(1, 2);
+
+SELECT 1 IN nullIf(1, 2);
+SELECT 1 IN nullIf(2, 2);
+
+SELECT 5 IN (2 + 3);
+SELECT 5 IN (2 * 3);
+
+SELECT 'hello' IN if(1 > 0, 'hello', 'world');
+SELECT 'world' IN if(1 > 0, 'hello', 'world');
+
+SELECT * FROM (SELECT number, number IN if(number > 2, 5, number) as result FROM numbers(6)) WHERE result = 1;
+
+SELECT number, number IN if(number > 2, 5, 1), number IN if(number < 2, 0, 10) FROM numbers(6);
+
+SELECT 1 GLOBAL IN if(1 > 0, 1, 2);
+SELECT 1 GLOBAL NOT IN if(1 > 0, 1, 2);
+
+SELECT * FROM (SELECT * FROM VALUES('cab_type String, dropoff UInt16', ('yellow', 138), ('green', 132))) AS t WHERE dropoff IN if(cab_type = 'yellow', 138, 132);


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
It is now possible to use non-constant IN for scalars (queries like `val1 NOT IN if(cond, val2, val3)`).

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.583`
<!-- ch-version-info:end -->