### PR TITLE
Sets with subqueries support (key IN (SELECT)) in mergeTreeAnalyzeIndexes()

### DIFF
--- a/src/Storages/StorageMergeTreeAnalyzeIndexes.cpp
+++ b/src/Storages/StorageMergeTreeAnalyzeIndexes.cpp
@@ -5,6 +5,7 @@
 #include <Core/Field.h>
 #include <Planner/CollectSets.h>
 #include <Planner/CollectTableExpressionData.h>
+#include <Planner/Planner.h>
 #include <Planner/PlannerContext.h>
 #include <Planner/Utils.h>
 #include <Processors/QueryPlan/ReadFromMergeTree.h>
@@ -145,6 +146,21 @@ protected:
                 planner_context,
                 empty_correlated_columns_set);
             correlated_subtrees.assertEmpty("in constant expression without query context");
+
+            auto subquery_options = SelectQueryOptions{}.subquery();
+            subquery_options.ignore_limits = false;
+            for (auto & subquery : planner_context->getPreparedSets().getSubqueries())
+            {
+                auto query_tree = subquery->detachQueryTree();
+                Planner subquery_planner(
+                    query_tree,
+                    subquery_options,
+                    std::make_shared<GlobalPlannerContext>(nullptr, nullptr, FiltersForTableExpressionMap{}));
+                subquery_planner.buildQueryPlanIfNeeded();
+
+                auto subquery_plan = std::move(subquery_planner).extractQueryPlan();
+                subquery->setQueryPlan(std::make_unique<QueryPlan>(std::move(subquery_plan)));
+            }
 
             filter_dag.emplace(std::move(actions));
         }

--- a/src/Storages/StorageMergeTreeAnalyzeIndexes.cpp
+++ b/src/Storages/StorageMergeTreeAnalyzeIndexes.cpp
@@ -3,7 +3,6 @@
 #include <Analyzer/Resolve/QueryAnalyzer.h>
 #include <Analyzer/TableNode.h>
 #include <Core/Field.h>
-#include <Interpreters/ExpressionAnalyzer.h>
 #include <Planner/CollectSets.h>
 #include <Planner/CollectTableExpressionData.h>
 #include <Planner/PlannerContext.h>
@@ -15,12 +14,8 @@
 #include <Storages/StorageMergeTreeAnalyzeIndexes.h>
 #include <Parsers/ASTSelectQuery.h>
 #include <Storages/ColumnsDescription.h>
-#include <Storages/MergeTree/LoadedMergeTreeDataPartInfoForReader.h>
-#include <Storages/MergeTree/MergeTreeDataPartCompact.h>
-#include <Storages/MergeTree/MergeTreeMarksLoader.h>
 #include <Storages/System/getQueriedColumnsMaskAndHeader.h>
 #include <Access/Common/AccessFlags.h>
-#include <Interpreters/ExpressionActions.h>
 #include <Processors/QueryPlan/QueryPlan.h>
 #include <Processors/QueryPlan/SourceStepWithFilter.h>
 #include <Processors/ISource.h>

--- a/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexes_sets.reference
+++ b/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexes_sets.reference
@@ -1,0 +1,9 @@
+-- { echo }
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, key in (select key from data order by key limit 10));
+all_1_1_0	[(0,1)]
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, key in (select key from data order by key desc limit 10));
+all_1_1_0	[(11,12)]
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, key in keys_1);
+all_1_1_0	[(0,1)]
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, key in keys_2);
+all_1_1_0	[(1,2)]

--- a/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexes_sets.sql
+++ b/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexes_sets.sql
@@ -1,5 +1,5 @@
 drop table if exists data;
-create table data (key Int, value Int) engine=MergeTree() order by key settings merge_selector_base = 1000, index_granularity=8192, min_bytes_for_wide_part=1e9 as select *, *+1000000 from numbers(100000);
+create table data (key Int, value Int) engine=MergeTree() order by key settings merge_selector_base = 1000, index_granularity=8192, index_granularity_bytes=10e9, min_bytes_for_wide_part=1e9 as select *, *+1000000 from numbers(100000) settings max_insert_threads=1;
 
 drop table if exists keys_1;
 create table keys_1 (key Int) engine=Log() as select * from numbers(10);

--- a/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexes_sets.sql
+++ b/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexes_sets.sql
@@ -1,0 +1,14 @@
+drop table if exists data;
+create table data (key Int, value Int) engine=MergeTree() order by key settings merge_selector_base = 1000, index_granularity=8192, min_bytes_for_wide_part=1e9 as select *, *+1000000 from numbers(100000);
+
+drop table if exists keys_1;
+create table keys_1 (key Int) engine=Log() as select * from numbers(10);
+
+drop table if exists keys_2;
+create table keys_2 (key Int) engine=Log() as select * from numbers(10000, 10);
+
+-- { echo }
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, key in (select key from data order by key limit 10));
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, key in (select key from data order by key desc limit 10));
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, key in keys_1);
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, key in keys_2);


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Sets with subqueries support (key IN (SELECT)) in mergeTreeAnalyzeIndexes()

_Note: not for changelog since original PR has never been released - https://github.com/ClickHouse/ClickHouse/pull/92954_