### PR TITLE
Threshold for dirty allocator pages

### DIFF
--- a/programs/keeper/Keeper.cpp
+++ b/programs/keeper/Keeper.cpp
@@ -396,7 +396,11 @@ try
     });
 
     MemoryWorker memory_worker(
-        config().getUInt64("memory_worker_period_ms", 0), config().getBool("memory_worker_correct_memory_tracker", false), /*use_cgroup*/ true, /*page_cache*/ nullptr);
+        config().getUInt64("memory_worker_period_ms", 0),
+        /*purge_dirty_pages_threshold_ratio_=*/ 0,
+        config().getBool("memory_worker_correct_memory_tracker", false),
+        /*use_cgroup=*/ true,
+        /*page_cache_=*/ nullptr);
     memory_worker.start();
 
     static ServerErrorHandler error_handler;

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -305,6 +305,7 @@ namespace ServerSetting
     extern const ServerSettingsUInt64 max_view_num_to_warn;
     extern const ServerSettingsUInt64 max_waiting_queries;
     extern const ServerSettingsUInt64 memory_worker_period_ms;
+    extern const ServerSettingsDouble memory_worker_purge_dirty_pages_threshold_ratio;
     extern const ServerSettingsBool memory_worker_correct_memory_tracker;
     extern const ServerSettingsBool memory_worker_use_cgroup;
     extern const ServerSettingsUInt64 merges_mutations_memory_usage_soft_limit;
@@ -1369,6 +1370,7 @@ try
 
     MemoryWorker memory_worker(
         server_settings[ServerSetting::memory_worker_period_ms],
+        server_settings[ServerSetting::memory_worker_purge_dirty_pages_threshold_ratio],
         server_settings[ServerSetting::memory_worker_correct_memory_tracker],
         global_context->getServerSettings()[ServerSetting::memory_worker_use_cgroup],
         global_context->getPageCache());

--- a/src/Common/MemoryWorker.h
+++ b/src/Common/MemoryWorker.h
@@ -41,7 +41,12 @@ struct ICgroupsReader
 class MemoryWorker
 {
 public:
-    MemoryWorker(uint64_t period_ms_, bool correct_tracker_, bool use_cgroup, std::shared_ptr<PageCache> page_cache_);
+    MemoryWorker(
+        uint64_t period_ms_,
+        double purge_dirty_pages_threshold_ratio_,
+        bool correct_tracker_,
+        bool use_cgroup,
+        std::shared_ptr<PageCache> page_cache_);
 
     enum class MemoryUsageSource : uint8_t
     {
@@ -71,6 +76,9 @@ private:
     uint64_t period_ms;
     bool correct_tracker = false;
 
+    double purge_dirty_pages_threshold_ratio;
+    uint64_t page_size = 0;
+
     MemoryUsageSource source{MemoryUsageSource::None};
 
     std::shared_ptr<ICgroupsReader> cgroups_reader;
@@ -80,9 +88,11 @@ private:
 #if USE_JEMALLOC
     Jemalloc::MibCache<uint64_t> epoch_mib{"epoch"};
     Jemalloc::MibCache<size_t> resident_mib{"stats.resident"};
+    Jemalloc::MibCache<size_t> pagesize_mib{"arenas.page"};
 
 #define STRINGIFY_HELPER(x) #x
 #define STRINGIFY(x) STRINGIFY_HELPER(x)
+    Jemalloc::MibCache<size_t> pdirty_mib{"stats.arenas." STRINGIFY(MALLCTL_ARENAS_ALL) ".pdirty"};
     Jemalloc::MibCache<size_t> purge_mib{"arena." STRINGIFY(MALLCTL_ARENAS_ALL) ".purge"};
 #undef STRINGIFY
 #undef STRINGIFY_HELPER

--- a/src/Core/ServerSettings.cpp
+++ b/src/Core/ServerSettings.cpp
@@ -1067,6 +1067,9 @@ The policy on how to perform a scheduling of CPU slots specified by `concurrent_
     DECLARE(UInt64, memory_worker_period_ms, 0, R"(
     Tick period of background memory worker which corrects memory tracker memory usages and cleans up unused pages during higher memory usage. If set to 0, default value will be used depending on the memory usage source
     )", 0) \
+    DECLARE(Double, memory_worker_purge_dirty_pages_threshold_ratio, 0.2, R"(
+    The threshold ratio for jemalloc dirty pages relative to the memory available to ClickHouse server. When dirty pages size exceeds this ratio, the background memory worker forces purging of dirty pages. If set to 0, forced purging is disabled.
+    )", 0) \
     DECLARE(Bool, memory_worker_correct_memory_tracker, 0, R"(
     Whether background memory worker should correct internal memory tracker based on the information from external sources like jemalloc and cgroups
     )", 0) \

--- a/tests/integration/test_dirty_pages_force_purge/configs/overrides.yaml
+++ b/tests/integration/test_dirty_pages_force_purge/configs/overrides.yaml
@@ -1,0 +1,3 @@
+---
+max_server_memory_usage: 4Gi
+memory_worker_purge_dirty_pages_threshold_ratio: 0.2

--- a/tests/integration/test_dirty_pages_force_purge/test.py
+++ b/tests/integration/test_dirty_pages_force_purge/test.py
@@ -1,0 +1,69 @@
+import time
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+# Jemalloc configuration used in this test disables automated dirty pages purge,
+# to simplify its accumulation, and verify that they'll be cleaned up by the
+# MemoryWorker
+MALLOC_CONF = "background_thread:false,dirty_decay_ms:-1,muzzy_decay_ms:0,oversize_threshold:0"
+PEAK_MEMORY_UPPER_BOUND = 3 * 1024 * 1024 * 1024
+
+PEAK_MEMORY_COUNTER_PATHS = [
+    "/sys/fs/cgroup/memory/memory.max_usage_in_bytes",  # cgroup v1
+    "/sys/fs/cgroup/memory.peak",                       # cgroup v2
+]
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance(
+    "node",
+    main_configs=["configs/overrides.yaml"],
+    env_variables={"MALLOC_CONF": MALLOC_CONF},
+)
+
+
+@pytest.fixture(scope="module")
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_dirty_pages_force_purge(start_cluster):
+    if node.is_built_with_sanitizer():
+        pytest.skip("Jemalloc disabled in sanitizer builds")
+
+    purges = ""
+    for _ in range(100):
+        node.query("""
+            SELECT arrayMap(x -> randomPrintableASCII(40), range(4096))
+            FROM numbers(2048)
+            FORMAT Null
+        """)
+
+        purges = node.query("SELECT value from system.events where event = 'MemoryAllocatorPurge'")
+        if purges:
+            break
+
+        time.sleep(0.2)
+
+    if not purges:
+        raise TimeoutError("Timed out waiting for MemoryAllocatorPurge event")
+
+    for path in PEAK_MEMORY_COUNTER_PATHS:
+        try:
+            peak_memory = int(node.exec_in_container(["cat", path]))
+            break
+        except Exception as ex:
+            if not str(ex).lower().strip().endswith("no such file or directory"):
+                raise
+    else:
+        raise RuntimeError("Failed to find peak memory counter")
+
+    # Assert peak memory usage is lower than expected peak, which is noticeably lower
+    # than max_server_memory_usage, to guarantee that purge has been cause by dirty pages
+    # volume, not the memory tracker limit
+    assert(peak_memory < PEAK_MEMORY_UPPER_BOUND)


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Force purging of jemalloc arenas in case the ratio of dirty pages size to `max_server_memory_usage` exceeds `memory_worker_purge_dirty_pages_threshold_ratio`

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

### Details
Closes #93380.

Make memory worker to be able to preventilvely purge jemalloc arenas, if the size of dirty pages exceeds pre-configured threshold ratio (relatively to `max_server_memory_usage`), even if the process memory is below memory tracker limit.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.367`
- Backported to: `25.12.5.18`, `25.10.6.17`, `25.8.16.14`
<!-- ch-version-info:end -->