### PR TITLE
Handle illumos macro conflicts.

### DIFF
--- a/base/base/FnTraits.h
+++ b/base/base/FnTraits.h
@@ -1,5 +1,11 @@
 #pragma once
 
+// On illumos, <sys/regset.h> defines FS as a macro (x86 segment register).
+// Undef it to allow use of FS as a template parameter below.
+#ifdef FS
+#  undef FS
+#endif
+
 #include "TypeList.h"
 
 namespace detail

--- a/src/Client/ClientBase.h
+++ b/src/Client/ClientBase.h
@@ -58,6 +58,12 @@ enum MultiQueryProcessingStage
     PARSING_FAILED,
 };
 
+// On illumos, <curses.h> defines ERR as a macro (error return value).
+// Undef it to allow use of ERR as an enum value below.
+#ifdef ERR
+#  undef ERR
+#endif
+
 enum ProgressOption
 {
     DEFAULT,

--- a/src/Common/filesystemHelpers.h
+++ b/src/Common/filesystemHelpers.h
@@ -76,6 +76,12 @@ Int64 getINodeNumberFromPath(const String & path);
 
 }
 
+// On illumos, <sys/regset.h> defines FS as a macro (x86 segment register).
+// Undef it to avoid conflict with FS namespace below.
+#ifdef FS
+#  undef FS
+#endif
+
 namespace FS
 {
 bool createFile(const std::string & path);

--- a/src/Disks/DiskLocal.cpp
+++ b/src/Disks/DiskLocal.cpp
@@ -30,6 +30,11 @@
 #include <Disks/DiskObjectStorage/DiskObjectStorage.h>
 #include <Disks/DiskObjectStorage/ObjectStorages/Local/LocalObjectStorage.h>
 
+// On illumos, <sys/regset.h> defines FS as a macro (x86 segment register).
+// Undef it to allow use of the FS:: namespace from filesystemHelpers.h.
+#ifdef FS
+#  undef FS
+#endif
 
 namespace CurrentMetrics
 {

--- a/src/Functions/UserDefined/UserDefinedExecutableFunctionFactory.cpp
+++ b/src/Functions/UserDefined/UserDefinedExecutableFunctionFactory.cpp
@@ -23,6 +23,12 @@
 
 #include <boost/algorithm/string/join.hpp>
 
+// On illumos, <sys/regset.h> defines FS as a macro (x86 segment register).
+// Undef it to allow use of the FS:: namespace from filesystemHelpers.h.
+#ifdef FS
+#  undef FS
+#endif
+
 namespace DB
 {
 

--- a/src/Parsers/CommonParsers.h
+++ b/src/Parsers/CommonParsers.h
@@ -6,6 +6,12 @@
 #include <string_view>
 #include <unordered_set>
 
+// On illumos, <sys/regset.h> defines SS as a macro (x86 segment register).
+// Undef it to allow use of SS as a parser keyword name below.
+#ifdef SS
+#  undef SS
+#endif
+
 namespace DB
 {
 


### PR DESCRIPTION
Illumos defines a few macros that conflict with ClickHouse symbols, like FS and SS from sys/regset.h and ERR from curses.h. These macros are pulled in transitively and aren't needed to build ClickHouse. This patch undefs these macros where necessary to fix conflicts.

Part of #23777.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)