### PR TITLE
Fix overflow in parsing/formatting debug check

### DIFF
--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -1201,7 +1201,14 @@ static BlockIO executeQueryImpl(
                 String formatted1 = format_ast(out_ast);
 
                 /// The query can become more verbose after formatting, so:
-                size_t new_max_query_size = max_query_size > 0 ? (1000 + 2 * max_query_size) : 0;
+                size_t size_t_max = -1;
+                size_t new_max_query_size = 0;
+                if (max_query_size == 0)
+                    new_max_query_size = 0;
+                else if (max_query_size > (size_t_max - 1000) / 2)
+                    new_max_query_size = size_t_max;
+                else
+                    new_max_query_size = 1000 + 2 * max_query_size;
 
                 ASTPtr ast2;
                 try

--- a/tests/queries/0_stateless/03780_AST_formatting_inconsistencies_in_debug_check.reference
+++ b/tests/queries/0_stateless/03780_AST_formatting_inconsistencies_in_debug_check.reference
@@ -4,3 +4,5 @@ Test repeated alias for literal as 2nd arg to IN operator:
 Test repeated alias for statement which is not a literal:
 [0]	0
 Test repeated alias for negated col:
+Test that large max_query_size doesnt cause overflow:
+test

--- a/tests/queries/0_stateless/03780_AST_formatting_inconsistencies_in_debug_check.sql
+++ b/tests/queries/0_stateless/03780_AST_formatting_inconsistencies_in_debug_check.sql
@@ -9,3 +9,6 @@ SELECT 'Test repeated alias for negated col:';
 CREATE TABLE tab(c1 int);
 SELECT (-((-`c1`) AS `a2`)), NOT (-((-`c1`) AS `a2`)) from tab;
 DROP TABLE tab;
+
+SELECT 'Test that large max_query_size doesnt cause overflow:';
+SELECT 'test' SETTINGS max_query_size = 9223372036854775309;


### PR DESCRIPTION
Fixes #91974.
Caused by an overflow in max_query_size when it is adjusted during the debug check.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

