### PR TITLE
Fix GLOBAL IN support with analyzer (previously set was created on the remote node again)

### DIFF
--- a/src/Interpreters/PreparedSets.h
+++ b/src/Interpreters/PreparedSets.h
@@ -37,6 +37,7 @@ struct SetAndKey
 {
     String key;
     SetPtr set;
+    StoragePtr external_table;
 };
 
 using SetAndKeyPtr = std::shared_ptr<SetAndKey>;
@@ -131,7 +132,7 @@ public:
         Hash hash_,
         ASTPtr ast_,
         std::unique_ptr<QueryPlan> source_,
-        StoragePtr external_table_,
+        StoragePtr external_table,
         std::shared_ptr<FutureSetFromSubquery> external_table_set_,
         bool transform_null_in,
         SizeLimits size_limits,
@@ -170,7 +171,6 @@ private:
     Hash hash;
     ASTPtr ast;
     SetAndKeyPtr set_and_key;
-    StoragePtr external_table;
     std::shared_ptr<FutureSetFromSubquery> external_table_set;
 
     std::unique_ptr<QueryPlan> source;

--- a/src/Interpreters/PreparedSets.h
+++ b/src/Interpreters/PreparedSets.h
@@ -162,6 +162,8 @@ public:
 
     QueryTreeNodePtr detachQueryTree() { return std::move(query_tree); }
     void setQueryPlan(std::unique_ptr<QueryPlan> source_);
+
+    void buildExternalTableFromInplaceSet(StoragePtr external_table_);
     void setExternalTable(StoragePtr external_table_);
 
     const QueryPlan * getQueryPlan() const { return source.get(); }

--- a/src/Processors/QueryPlan/CreatingSetsStep.cpp
+++ b/src/Processors/QueryPlan/CreatingSetsStep.cpp
@@ -42,12 +42,10 @@ static ITransformingStep::Traits getTraits()
 CreatingSetStep::CreatingSetStep(
     const SharedHeader & input_header_,
     SetAndKeyPtr set_and_key_,
-    StoragePtr external_table_,
     SizeLimits network_transfer_limits_,
     PreparedSetsCachePtr prepared_sets_cache_)
     : ITransformingStep(input_header_, std::make_shared<const Block>(Block{}), getTraits())
     , set_and_key(std::move(set_and_key_))
-    , external_table(std::move(external_table_))
     , network_transfer_limits(std::move(network_transfer_limits_))
     , prepared_sets_cache(std::move(prepared_sets_cache_))
 {
@@ -58,7 +56,6 @@ void CreatingSetStep::transformPipeline(QueryPipelineBuilder & pipeline, const B
     pipeline.addCreatingSetsTransform(
         getOutputHeader(),
         std::move(set_and_key),
-        std::move(external_table),
         network_transfer_limits,
         std::move(prepared_sets_cache));
 }

--- a/src/Processors/QueryPlan/CreatingSetsStep.h
+++ b/src/Processors/QueryPlan/CreatingSetsStep.h
@@ -19,7 +19,6 @@ public:
     CreatingSetStep(
         const SharedHeader & input_header_,
         SetAndKeyPtr set_and_key_,
-        StoragePtr external_table_,
         SizeLimits network_transfer_limits_,
         PreparedSetsCachePtr prepared_sets_cache_);
 
@@ -34,7 +33,6 @@ private:
     void updateOutputHeader() override;
 
     SetAndKeyPtr set_and_key;
-    StoragePtr external_table;
     SizeLimits network_transfer_limits;
     PreparedSetsCachePtr prepared_sets_cache;
 };

--- a/src/Processors/QueryPlan/ReadFromRemote.cpp
+++ b/src/Processors/QueryPlan/ReadFromRemote.cpp
@@ -236,7 +236,7 @@ static ASTPtr tryBuildAdditionalFilterAST(
     const std::unordered_set<std::string> & projection_names,
     const std::unordered_map<std::string, QueryTreeNodePtr> & execution_name_to_projection_query_tree,
     Tables * external_tables,
-    const ContextPtr & context)
+    ContextMutablePtr & context)
 {
     std::unordered_map<const ActionsDAG::Node *, ASTPtr> node_to_ast;
 
@@ -405,6 +405,8 @@ static ASTPtr tryBuildAdditionalFilterAST(
 
                         external_table = external_storage_holder.getTable();
                         set_from_subquery->setExternalTable(external_table);
+
+                        context->addExternalTable(temporary_table_name, std::move(external_storage_holder));
                     }
 
                     node_to_ast[second_arg] = std::make_shared<ASTIdentifier>(temporary_table_name);
@@ -422,7 +424,7 @@ static ASTPtr tryBuildAdditionalFilterAST(
 
 static void addFilters(
     Tables * external_tables,
-    const ContextMutablePtr & context,
+    ContextMutablePtr & context,
     const ASTPtr & query_ast,
     const QueryTreeNodePtr & query_tree,
     const PlannerContextPtr & planner_context,

--- a/src/Processors/QueryPlan/ReadFromRemote.cpp
+++ b/src/Processors/QueryPlan/ReadFromRemote.cpp
@@ -408,6 +408,7 @@ static ASTPtr tryBuildAdditionalFilterAST(
                     }
 
                     node_to_ast[second_arg] = std::make_shared<ASTIdentifier>(temporary_table_name);
+                    arguments[1] = node_to_ast[second_arg];
                 }
             }
         }

--- a/src/Processors/Transforms/CreatingSetsTransform.cpp
+++ b/src/Processors/Transforms/CreatingSetsTransform.cpp
@@ -56,12 +56,10 @@ CreatingSetsTransform::CreatingSetsTransform(
     SharedHeader in_header_,
     SharedHeader out_header_,
     SetAndKeyPtr set_and_key_,
-    StoragePtr external_table_,
     SizeLimits network_transfer_limits_,
     PreparedSetsCachePtr prepared_sets_cache_)
     : IAccumulatingTransform(std::move(in_header_), std::move(out_header_))
     , set_and_key(std::move(set_and_key_))
-    , external_table(std::move(external_table_))
     , network_transfer_limits(std::move(network_transfer_limits_))
     , prepared_sets_cache(std::move(prepared_sets_cache_))
 {
@@ -104,7 +102,7 @@ void CreatingSetsTransform::work()
 void CreatingSetsTransform::startSubquery()
 {
     /// Lookup the set in the cache if we don't need to build table.
-    if (prepared_sets_cache && !external_table)
+    if (prepared_sets_cache && !set_and_key->external_table)
     {
         /// Try to find the set in the cache and wait for it to be built.
         /// Retry if the set from cache fails to be built.
@@ -152,15 +150,15 @@ void CreatingSetsTransform::startSubquery()
 
     if (set_and_key->set && !set_from_cache)
         LOG_TRACE(log, "Creating set, key: {}", set_and_key->key);
-    if (external_table)
+    if (set_and_key->external_table)
         LOG_TRACE(log, "Filling temporary table.");
 
-    if (external_table)
+    if (set_and_key->external_table)
         /// TODO: make via port
-        table_out = QueryPipeline(external_table->write({}, external_table->getInMemoryMetadataPtr(), nullptr, /*async_insert=*/false));
+        table_out = QueryPipeline(set_and_key->external_table->write({}, set_and_key->external_table->getInMemoryMetadataPtr(), nullptr, /*async_insert=*/false));
 
     done_with_set = !set_and_key->set || set_from_cache;
-    done_with_table = !external_table;
+    done_with_table = !set_and_key->external_table;
 
     if ((done_with_set && !set_from_cache) && done_with_table)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Nothing to do with subquery");
@@ -184,7 +182,7 @@ void CreatingSetsTransform::finishSubquery()
     {
         if (set_and_key->set)
             LOG_DEBUG(log, "Created Set with {} entries from {} rows in {} sec.", set_and_key->set->getTotalRowCount(), read_rows, seconds);
-        if (external_table)
+        if (set_and_key->external_table)
             LOG_DEBUG(log, "Created Table with {} rows in {} sec.", read_rows, seconds);
     }
     else

--- a/src/Processors/Transforms/CreatingSetsTransform.h
+++ b/src/Processors/Transforms/CreatingSetsTransform.h
@@ -31,7 +31,6 @@ public:
         SharedHeader in_header_,
         SharedHeader out_header_,
         SetAndKeyPtr set_and_key_,
-        StoragePtr external_table_,
         SizeLimits network_transfer_limits_,
         PreparedSetsCachePtr prepared_sets_cache_);
 
@@ -45,7 +44,6 @@ public:
 
 private:
     SetAndKeyPtr set_and_key;
-    StoragePtr external_table;
     std::optional<std::promise<SetPtr>> promise_to_build;
 
     QueryPipeline table_out;

--- a/src/QueryPipeline/QueryPipelineBuilder.cpp
+++ b/src/QueryPipeline/QueryPipelineBuilder.cpp
@@ -724,7 +724,6 @@ std::unique_ptr<QueryPipelineBuilder> QueryPipelineBuilder::joinPipelinesByShard
 void QueryPipelineBuilder::addCreatingSetsTransform(
     SharedHeader res_header,
     SetAndKeyPtr set_and_key,
-    StoragePtr external_table,
     const SizeLimits & limits,
     PreparedSetsCachePtr prepared_sets_cache)
 {
@@ -735,7 +734,6 @@ void QueryPipelineBuilder::addCreatingSetsTransform(
             getSharedHeader(),
             res_header,
             std::move(set_and_key),
-            std::move(external_table),
             limits,
             std::move(prepared_sets_cache));
 

--- a/src/QueryPipeline/QueryPipelineBuilder.h
+++ b/src/QueryPipeline/QueryPipelineBuilder.h
@@ -164,7 +164,6 @@ public:
     void addCreatingSetsTransform(
         SharedHeader res_header,
         SetAndKeyPtr set_and_key,
-        StoragePtr external_table,
         const SizeLimits & limits,
         PreparedSetsCachePtr prepared_sets_cache);
 

--- a/tests/queries/0_stateless/03302_analyzer_distributed_filter_push_down.reference
+++ b/tests/queries/0_stateless/03302_analyzer_distributed_filter_push_down.reference
@@ -319,11 +319,11 @@ CreatingSets (Create sets before main query execution)
                     PrimaryKey
                       Keys:
                         x
-                      Condition: (x in 1-element set)
-                      Parts: 1/1
-                      Granules: 1/123
-                      Search Algorithm: binary search
-                    Ranges: 1
+                      Condition: (x in 0-element set)
+                      Parts: 0/1
+                      Granules: 0/123
+                      Search Algorithm: generic exclusion search
+                    Ranges: 0
   CreatingSet (Create set for subquery)
     Expression ((Project names + (Projection + Change column names to column identifiers)))
       ReadFromSystemNumbers
@@ -358,11 +358,11 @@ CreatingSets (Create sets before main query execution)
                     PrimaryKey
                       Keys:
                         x
-                      Condition: (x in 1-element set)
-                      Parts: 1/1
-                      Granules: 1/123
-                      Search Algorithm: binary search
-                    Ranges: 1
+                      Condition: (x in 0-element set)
+                      Parts: 0/1
+                      Granules: 0/123
+                      Search Algorithm: generic exclusion search
+                    Ranges: 0
             CreatingSets (Create sets before main query execution)
               Expression ((Project names + Projection))
                 Expression ((WHERE + Change column names to column identifiers))
@@ -371,15 +371,15 @@ CreatingSets (Create sets before main query execution)
                     PrimaryKey
                       Keys:
                         x
-                      Condition: (x in 1-element set)
-                      Parts: 1/1
-                      Granules: 1/123
-                      Search Algorithm: binary search
-                    Ranges: 1
+                      Condition: (x in 0-element set)
+                      Parts: 0/1
+                      Granules: 0/123
+                      Search Algorithm: generic exclusion search
+                    Ranges: 0
   CreatingSet (Create set for subquery)
     Expression ((Project names + (Projection + Change column names to column identifiers)))
       ReadFromSystemNumbers
-84
+42
 CreatingSets (Create sets before main query execution)
   Expression ((Project names + Projection))
     Aggregating
@@ -407,12 +407,12 @@ CreatingSets (Create sets before main query execution)
                       PrimaryKey
                         Keys:
                           x
-                        Condition: (x in 1-element set)
-                        Parts: 1/1
-                        Granules: 1/123
-                        Search Algorithm: binary search
-                      Ranges: 1
-126
+                        Condition: (x in 0-element set)
+                        Parts: 0/1
+                        Granules: 0/123
+                        Search Algorithm: generic exclusion search
+                      Ranges: 0
+42
 CreatingSets (Create sets before main query execution)
   Expression ((Project names + Projection))
     Aggregating
@@ -440,11 +440,11 @@ CreatingSets (Create sets before main query execution)
                       PrimaryKey
                         Keys:
                           x
-                        Condition: (x in 1-element set)
-                        Parts: 1/1
-                        Granules: 1/123
-                        Search Algorithm: binary search
-                      Ranges: 1
+                        Condition: (x in 0-element set)
+                        Parts: 0/1
+                        Granules: 0/123
+                        Search Algorithm: generic exclusion search
+                      Ranges: 0
               CreatingSets (Create sets before main query execution)
                 Expression ((Project names + Projection))
                   Expression ((WHERE + Change column names to column identifiers))
@@ -453,11 +453,11 @@ CreatingSets (Create sets before main query execution)
                       PrimaryKey
                         Keys:
                           x
-                        Condition: (x in 1-element set)
-                        Parts: 1/1
-                        Granules: 1/123
-                        Search Algorithm: binary search
-                      Ranges: 1
+                        Condition: (x in 0-element set)
+                        Parts: 0/1
+                        Granules: 0/123
+                        Search Algorithm: generic exclusion search
+                      Ranges: 0
 126
 CreatingSets (Create sets before main query execution)
   Expression ((Project names + Projection))
@@ -487,7 +487,7 @@ CreatingSets (Create sets before main query execution)
                       Ranges: 1
                 CreatingSet (Create set for subquery)
                   Expression ((Project names + (Projection + Change column names to column identifiers)))
-                    ReadFromSystemNumbers
+                    ReadFromMemoryStorage
               CreatingSets (Create sets before main query execution)
                 Expression ((Project names + Projection))
                   Expression ((WHERE + Change column names to column identifiers))
@@ -500,7 +500,7 @@ CreatingSets (Create sets before main query execution)
                       Ranges: 1
                 CreatingSet (Create set for subquery)
                   Expression ((Project names + (Projection + Change column names to column identifiers)))
-                    ReadFromSystemNumbers
+                    ReadFromMemoryStorage
   CreatingSet (Create set for subquery)
     Expression ((Project names + (Projection + Change column names to column identifiers)))
       ReadFromSystemNumbers

--- a/tests/queries/0_stateless/03302_analyzer_distributed_filter_push_down.reference
+++ b/tests/queries/0_stateless/03302_analyzer_distributed_filter_push_down.reference
@@ -379,7 +379,7 @@ CreatingSets (Create sets before main query execution)
   CreatingSet (Create set for subquery)
     Expression ((Project names + (Projection + Change column names to column identifiers)))
       ReadFromSystemNumbers
-42
+84
 CreatingSets (Create sets before main query execution)
   Expression ((Project names + Projection))
     Aggregating
@@ -407,12 +407,12 @@ CreatingSets (Create sets before main query execution)
                       PrimaryKey
                         Keys:
                           x
-                        Condition: (x in 0-element set)
-                        Parts: 0/1
-                        Granules: 0/123
-                        Search Algorithm: generic exclusion search
-                      Ranges: 0
-42
+                        Condition: (x in 1-element set)
+                        Parts: 1/1
+                        Granules: 1/123
+                        Search Algorithm: binary search
+                      Ranges: 1
+126
 CreatingSets (Create sets before main query execution)
   Expression ((Project names + Projection))
     Aggregating
@@ -440,11 +440,11 @@ CreatingSets (Create sets before main query execution)
                       PrimaryKey
                         Keys:
                           x
-                        Condition: (x in 0-element set)
-                        Parts: 0/1
-                        Granules: 0/123
-                        Search Algorithm: generic exclusion search
-                      Ranges: 0
+                        Condition: (x in 1-element set)
+                        Parts: 1/1
+                        Granules: 1/123
+                        Search Algorithm: binary search
+                      Ranges: 1
               CreatingSets (Create sets before main query execution)
                 Expression ((Project names + Projection))
                   Expression ((WHERE + Change column names to column identifiers))
@@ -453,11 +453,11 @@ CreatingSets (Create sets before main query execution)
                       PrimaryKey
                         Keys:
                           x
-                        Condition: (x in 0-element set)
-                        Parts: 0/1
-                        Granules: 0/123
-                        Search Algorithm: generic exclusion search
-                      Ranges: 0
+                        Condition: (x in 1-element set)
+                        Parts: 1/1
+                        Granules: 1/123
+                        Search Algorithm: binary search
+                      Ranges: 1
 126
 CreatingSets (Create sets before main query execution)
   Expression ((Project names + Projection))

--- a/tests/queries/0_stateless/03620_analyzer_distributed_global_in.reference
+++ b/tests/queries/0_stateless/03620_analyzer_distributed_global_in.reference
@@ -7,6 +7,14 @@ select sum(y) from (select * from remote('127.0.0.2', currentDatabase(), tab0)) 
 42
 select sum(y) from (select * from remote('127.0.0.2', currentDatabase(), tab0)) where x global in (select number + 42 from numbers(1));
 42
+select sum(y) from (select * from remote('127.0.0.{1,2}', currentDatabase(), tab0)) where x in (select number + 42 from numbers(1));
+84
+select sum(y) from (select * from remote('127.0.0.{1,2}', currentDatabase(), tab0)) where x global in (select number + 42 from numbers(1));
+84
+select sum(y) from (select * from remote('127.0.0.{2,3}', currentDatabase(), tab0)) where x in (select number + 42 from numbers(1));
+84
+select sum(y) from (select * from remote('127.0.0.{2,3}', currentDatabase(), tab0)) where x global in (select number + 42 from numbers(1));
+84
 select * from (explain indexes=1
     select sum(y) from (select * from remote('127.0.0.1', currentDatabase(), tab0)) where x global in (select number + 42 from numbers(1))
 );
@@ -54,4 +62,10 @@ system flush logs query_log;
 -- SKIP: current_database = currentDatabase()
 select normalizeQuery(replace(query, currentDatabase(), 'default')) from system.query_log where event_date >= yesterday() and log_comment like '%' || currentDatabase() || '%' and not is_initial_query and type != 'QueryStart' and query_kind = 'Select' order by event_time_microseconds;
 SELECT `__table1`.`x` AS `x`, `__table1`.`y` AS `y` FROM `default`.`tab0` AS `__table1` HAVING in(`x`, (SELECT `__table1`.`number` + ? AS `?` FROM numbers(?) AS `__table1`))
+SELECT `__table1`.`x` AS `x`, `__table1`.`y` AS `y` FROM `default`.`tab0` AS `__table1` HAVING globalIn(`x`, `?`)
+SELECT `__table1`.`x` AS `x`, `__table1`.`y` AS `y` FROM `default`.`tab0` AS `__table1` HAVING in(`x`, (SELECT `__table1`.`number` + ? AS `?` FROM numbers(?) AS `__table1`))
+SELECT `__table1`.`x` AS `x`, `__table1`.`y` AS `y` FROM `default`.`tab0` AS `__table1` HAVING globalIn(`x`, `?`)
+SELECT `__table1`.`x` AS `x`, `__table1`.`y` AS `y` FROM `default`.`tab0` AS `__table1` HAVING in(`x`, (SELECT `__table1`.`number` + ? AS `?` FROM numbers(?) AS `__table1`))
+SELECT `__table1`.`x` AS `x`, `__table1`.`y` AS `y` FROM `default`.`tab0` AS `__table1` HAVING in(`x`, (SELECT `__table1`.`number` + ? AS `?` FROM numbers(?) AS `__table1`))
+SELECT `__table1`.`x` AS `x`, `__table1`.`y` AS `y` FROM `default`.`tab0` AS `__table1` HAVING globalIn(`x`, `?`)
 SELECT `__table1`.`x` AS `x`, `__table1`.`y` AS `y` FROM `default`.`tab0` AS `__table1` HAVING globalIn(`x`, `?`)

--- a/tests/queries/0_stateless/03620_analyzer_distributed_global_in.reference
+++ b/tests/queries/0_stateless/03620_analyzer_distributed_global_in.reference
@@ -1,0 +1,57 @@
+-- { echo }
+select sum(y) from (select * from remote('127.0.0.1', currentDatabase(), tab0)) where x in (select number + 42 from numbers(1));
+42
+select sum(y) from (select * from remote('127.0.0.1', currentDatabase(), tab0)) where x global in (select number + 42 from numbers(1));
+42
+select sum(y) from (select * from remote('127.0.0.2', currentDatabase(), tab0)) where x in (select number + 42 from numbers(1));
+42
+select sum(y) from (select * from remote('127.0.0.2', currentDatabase(), tab0)) where x global in (select number + 42 from numbers(1));
+42
+select * from (explain indexes=1
+    select sum(y) from (select * from remote('127.0.0.1', currentDatabase(), tab0)) where x global in (select number + 42 from numbers(1))
+);
+CreatingSets (Create sets before main query execution)
+  Expression ((Project names + Projection))
+    Aggregating
+      Expression (Before GROUP BY)
+        Expression ((WHERE + (Change column names to column identifiers + (Project names + (Projection + Change column names to column identifiers)))))
+          ReadFromMergeTree (default.tab0)
+          Indexes:
+            PrimaryKey
+              Keys:
+                x
+              Condition: (x in 1-element set)
+              Parts: 1/1
+              Granules: 1/123
+              Search Algorithm: binary search
+            Ranges: 1
+select * from (explain indexes=1, distributed=1
+    select sum(y) from (select * from remote('127.0.0.2', currentDatabase(), tab0)) where x global in (select number + 42 from numbers(1))
+);
+CreatingSets (Create sets before main query execution)
+  Expression ((Project names + Projection))
+    Aggregating
+      Expression (Before GROUP BY)
+        Filter ((WHERE + Change column names to column identifiers))
+          ReadFromRemote (Read from remote replica)
+            CreatingSets (Create sets before main query execution)
+              Expression ((Project names + Projection))
+                Expression ((WHERE + Change column names to column identifiers))
+                  ReadFromMergeTree (default.tab0)
+                  Indexes:
+                    PrimaryKey
+                      Keys:
+                        x
+                      Condition: (x in 0-element set)
+                      Parts: 0/1
+                      Granules: 0/123
+                      Search Algorithm: generic exclusion search
+                    Ranges: 0
+  CreatingSet (Create set for subquery)
+    Expression ((Project names + (Projection + Change column names to column identifiers)))
+      ReadFromSystemNumbers
+system flush logs query_log;
+-- SKIP: current_database = currentDatabase()
+select normalizeQuery(replace(query, currentDatabase(), 'default')) from system.query_log where event_date >= yesterday() and log_comment like '%' || currentDatabase() || '%' and not is_initial_query and type != 'QueryStart' and query_kind = 'Select' order by event_time_microseconds;
+SELECT `__table1`.`x` AS `x`, `__table1`.`y` AS `y` FROM `default`.`tab0` AS `__table1` HAVING in(`x`, (SELECT `__table1`.`number` + ? AS `?` FROM numbers(?) AS `__table1`))
+SELECT `__table1`.`x` AS `x`, `__table1`.`y` AS `y` FROM `default`.`tab0` AS `__table1` HAVING globalIn(`x`, `?`)

--- a/tests/queries/0_stateless/03620_analyzer_distributed_global_in.sql
+++ b/tests/queries/0_stateless/03620_analyzer_distributed_global_in.sql
@@ -10,6 +10,10 @@ select sum(y) from (select * from remote('127.0.0.1', currentDatabase(), tab0)) 
 select sum(y) from (select * from remote('127.0.0.1', currentDatabase(), tab0)) where x global in (select number + 42 from numbers(1));
 select sum(y) from (select * from remote('127.0.0.2', currentDatabase(), tab0)) where x in (select number + 42 from numbers(1));
 select sum(y) from (select * from remote('127.0.0.2', currentDatabase(), tab0)) where x global in (select number + 42 from numbers(1));
+select sum(y) from (select * from remote('127.0.0.{1,2}', currentDatabase(), tab0)) where x in (select number + 42 from numbers(1));
+select sum(y) from (select * from remote('127.0.0.{1,2}', currentDatabase(), tab0)) where x global in (select number + 42 from numbers(1));
+select sum(y) from (select * from remote('127.0.0.{2,3}', currentDatabase(), tab0)) where x in (select number + 42 from numbers(1));
+select sum(y) from (select * from remote('127.0.0.{2,3}', currentDatabase(), tab0)) where x global in (select number + 42 from numbers(1));
 select * from (explain indexes=1
     select sum(y) from (select * from remote('127.0.0.1', currentDatabase(), tab0)) where x global in (select number + 42 from numbers(1))
 );

--- a/tests/queries/0_stateless/03620_analyzer_distributed_global_in.sql
+++ b/tests/queries/0_stateless/03620_analyzer_distributed_global_in.sql
@@ -3,7 +3,7 @@ set enable_analyzer=1;
 set enable_parallel_replicas=0;
 set prefer_localhost_replica=1;
 
-create table tab0 (x UInt32, y UInt32) engine = MergeTree order by x settings index_granularity=8192, min_bytes_for_wide_part=1e9;
+create table tab0 (x UInt32, y UInt32) engine = MergeTree order by x settings index_granularity=8192, min_bytes_for_wide_part=1e9, index_granularity_bytes=10e6;
 insert into tab0 select number, number from numbers(8192 * 123);
 
 -- { echo }

--- a/tests/queries/0_stateless/03620_analyzer_distributed_global_in.sql
+++ b/tests/queries/0_stateless/03620_analyzer_distributed_global_in.sql
@@ -1,3 +1,4 @@
+set serialize_query_plan = 0;
 set enable_analyzer=1;
 set enable_parallel_replicas=0;
 set prefer_localhost_replica=1;

--- a/tests/queries/0_stateless/03620_analyzer_distributed_global_in.sql
+++ b/tests/queries/0_stateless/03620_analyzer_distributed_global_in.sql
@@ -1,0 +1,21 @@
+set enable_analyzer=1;
+set enable_parallel_replicas=0;
+set prefer_localhost_replica=1;
+
+create table tab0 (x UInt32, y UInt32) engine = MergeTree order by x settings index_granularity=8192, min_bytes_for_wide_part=1e9;
+insert into tab0 select number, number from numbers(8192 * 123);
+
+-- { echo }
+select sum(y) from (select * from remote('127.0.0.1', currentDatabase(), tab0)) where x in (select number + 42 from numbers(1));
+select sum(y) from (select * from remote('127.0.0.1', currentDatabase(), tab0)) where x global in (select number + 42 from numbers(1));
+select sum(y) from (select * from remote('127.0.0.2', currentDatabase(), tab0)) where x in (select number + 42 from numbers(1));
+select sum(y) from (select * from remote('127.0.0.2', currentDatabase(), tab0)) where x global in (select number + 42 from numbers(1));
+select * from (explain indexes=1
+    select sum(y) from (select * from remote('127.0.0.1', currentDatabase(), tab0)) where x global in (select number + 42 from numbers(1))
+);
+select * from (explain indexes=1, distributed=1
+    select sum(y) from (select * from remote('127.0.0.2', currentDatabase(), tab0)) where x global in (select number + 42 from numbers(1))
+);
+system flush logs query_log;
+-- SKIP: current_database = currentDatabase()
+select normalizeQuery(replace(query, currentDatabase(), 'default')) from system.query_log where event_date >= yesterday() and log_comment like '%' || currentDatabase() || '%' and not is_initial_query and type != 'QueryStart' and query_kind = 'Select' order by event_time_microseconds;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix GLOBAL IN support with analyzer (previously set was created on the remote node again)

Fixes: https://github.com/ClickHouse/ClickHouse/pull/74085/