### PR TITLE
Fix direct read from text index with duplicate search queries

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
@@ -206,6 +206,9 @@ TextSearchQueryPtr MergeTreeIndexConditionText::createTextSearchQuery(const Acti
 
 std::optional<String> MergeTreeIndexConditionText::replaceToVirtualColumn(const TextSearchQuery & query, const String & index_name)
 {
+    if (query.tokens.empty() && query.direct_read_mode == TextIndexDirectReadMode::Hint)
+        return std::nullopt;
+
     auto query_hash = query.getHash();
     auto it = all_search_queries.find(query_hash.get128());
 

--- a/tests/queries/0_stateless/02346_text_index_hint.reference
+++ b/tests/queries/0_stateless/02346_text_index_hint.reference
@@ -2,7 +2,7 @@
 1
 Prewhere filter column: and(__text_index_idx_equals_60401dc80cdf16a5b834b7108446de9e, equals(__table1.s, \'5555\'_String)) (removed)
 19
-Prewhere filter column: and(__text_index_idx_like_979062e3f4cc09e575bebe02aafffe20, like(__table1.s, \'%5555%\'_String)) (removed)
+Filter column: like(__table1.s, \'%5555%\'_String) (removed)
 -- array
 1
 Filter column: __text_index_idx_equals_4cc4896344a261de82ee42d2854f5d47 (removed)

--- a/tests/queries/0_stateless/02346_text_index_hint_map.reference
+++ b/tests/queries/0_stateless/02346_text_index_hint_map.reference
@@ -1,31 +1,23 @@
 SELECT count() FROM tab WHERE has(mapKeys(m), 'k18')
 36663
+Filter column: __text_index_idx_mk_has_0c0040b6161ceb1d92b4b734c3e49d61 (removed)
 Name: idx_mk
-Prewhere filter column: and(__text_index_idx_mk_has_475affbe41c477a7e0a3c1ea73e4c6f8, has(mapKeys(__table1.m), \'k18\'_String)) (removed)
 SELECT count() FROM tab WHERE has(m, 'k18')
 36663
+Filter column: __text_index_idx_mk_has_0c0040b6161ceb1d92b4b734c3e49d61 (removed)
 Name: idx_mk
-Prewhere filter column: and(__text_index_idx_mk_has_475affbe41c477a7e0a3c1ea73e4c6f8, has(__table1.m, \'k18\'_String)) (removed)
 SELECT count() FROM tab WHERE mapContains(m, 'k18')
 36663
+Filter column: __text_index_idx_mk_mapContainsKey_93e0ae3393c50112dba76c2f8e7b0085 (removed)
 Name: idx_mk
-Prewhere filter column: and(__text_index_idx_mk_mapContainsKey_06c8259c51f53148f99a166759c9a9d6, mapContainsKey(__table1.m, \'k18\'_String)) (removed)
 SELECT count() FROM tab WHERE mapContainsKey(m, 'k18')
 36663
+Filter column: __text_index_idx_mk_mapContainsKey_93e0ae3393c50112dba76c2f8e7b0085 (removed)
 Name: idx_mk
-Prewhere filter column: and(__text_index_idx_mk_mapContainsKey_06c8259c51f53148f99a166759c9a9d6, mapContainsKey(__table1.m, \'k18\'_String)) (removed)
-SELECT count() FROM tab WHERE mapContainsKeyLike(m, '%k18%')
-36663
-Name: idx_mk
-Prewhere filter column: and(__text_index_idx_mk_mapContainsKeyLike_69bf036226cc6dd333b21afde82cfe3a, mapContainsKeyLike(__table1.m, \'%k18%\'_String)) (removed)
 SELECT count() FROM tab WHERE mapContainsValue(m, 'v18')
 36663
+Filter column: __text_index_idx_mv_mapContainsValue_7a21ae1c0c7797455d0b2d4018cdafab (removed)
 Name: idx_mv
-Prewhere filter column: and(__text_index_idx_mv_mapContainsValue_47086a7da4284f286a4b2484758c8b47, mapContainsValue(__table1.m, \'v18\'_String)) (removed)
-SELECT count() FROM tab WHERE mapContainsValueLike(m, '%v18%')
-36663
-Name: idx_mv
-Prewhere filter column: and(__text_index_idx_mv_mapContainsValueLike_293b78beb2facc4aee5c9b885646242f, mapContainsValueLike(__table1.m, \'%v18%\'_String)) (removed)
 SELECT count() FROM tab WHERE m['k18'] = 'v18'
 36663
 Name: idx_mk
@@ -34,8 +26,7 @@ Prewhere filter column: and(__text_index_idx_mk_mapContainsKey_06c8259c51f53148f
 SELECT count() FROM tab WHERE m['k18'] LIKE '%v18%'
 36663
 Name: idx_mk
-Name: idx_mv
-Prewhere filter column: and(__text_index_idx_mk_mapContainsKey_06c8259c51f53148f99a166759c9a9d6, __text_index_idx_mv_like_979062e3f4cc09e575bebe02aafffe20, like(arrayElement(__table1.m, \'k18\'_String), \'%v18%\'_String)) (removed)
+Prewhere filter column: and(__text_index_idx_mk_mapContainsKey_06c8259c51f53148f99a166759c9a9d6, like(arrayElement(__table1.m, \'k18\'_String), \'%v18%\'_String)) (removed)
 SELECT count() FROM tab WHERE notEmpty(m['k18'])
 36663
 Name: idx_mk
@@ -50,3 +41,11 @@ Prewhere filter column: and(__text_index_idx_mk_mapContainsKey_06c8259c51f53148f
 SELECT count() FROM tab WHERE toUInt64OrZero(extract(m['k18'], '[0-9]+')) = 0
 63337
 Filter column: equals(toUInt64OrZero(extract(arrayElement(__table1.m, \'k18\'_String), \'[0-9]+\'_String)), 0_UInt8) (removed)
+SELECT count() FROM tab WHERE mapContainsKeyLike(m, '%k18%')
+36663
+Name: idx_mk
+Prewhere filter column: and(__text_index_idx_mk_mapContainsKeyLike_76118c49566944c6be6e9c88a233f2fa, mapContainsKeyLike(__table1.m, \'%k18%\'_String)) (removed)
+SELECT count() FROM tab WHERE mapContainsValueLike(m, '%v18%')
+36663
+Name: idx_mv
+Prewhere filter column: and(__text_index_idx_mv_mapContainsValueLike_7fbeb66c74170858ae6115f905f135b5, mapContainsValueLike(__table1.m, \'%v18%\'_String)) (removed)

--- a/tests/queries/0_stateless/02346_text_index_hint_map.sh
+++ b/tests/queries/0_stateless/02346_text_index_hint_map.sh
@@ -15,8 +15,8 @@ $MY_CLICKHOUSE_CLIENT --query "
     CREATE TABLE tab
     (
         m Map(String, String),
-        INDEX idx_mk (mapKeys(m)) TYPE text(tokenizer = splitByNonAlpha) GRANULARITY 4,
-        INDEX idx_mv (mapValues(m)) TYPE text(tokenizer = splitByNonAlpha) GRANULARITY 4
+        INDEX idx_mk (mapKeys(m)) TYPE text(tokenizer = array),
+        INDEX idx_mv (mapValues(m)) TYPE text(tokenizer = array)
     ) ENGINE = MergeTree ORDER BY tuple();
 
     INSERT INTO tab SELECT (arrayMap(x -> 'k' || x, range(number % 30)), arrayMap(x -> 'v' || x, range(number % 30))) FROM numbers(100000);
@@ -42,14 +42,28 @@ run "SELECT count() FROM tab WHERE has(mapKeys(m), 'k18')"
 run "SELECT count() FROM tab WHERE has(m, 'k18')"
 run "SELECT count() FROM tab WHERE mapContains(m, 'k18')"
 run "SELECT count() FROM tab WHERE mapContainsKey(m, 'k18')"
-run "SELECT count() FROM tab WHERE mapContainsKeyLike(m, '%k18%')"
 run "SELECT count() FROM tab WHERE mapContainsValue(m, 'v18')"
-run "SELECT count() FROM tab WHERE mapContainsValueLike(m, '%v18%')"
 run "SELECT count() FROM tab WHERE m['k18'] = 'v18'"
 run "SELECT count() FROM tab WHERE m['k18'] LIKE '%v18%'"
 run "SELECT count() FROM tab WHERE notEmpty(m['k18'])"
 run "SELECT count() FROM tab WHERE empty(m['k18'])"
 run "SELECT count() FROM tab WHERE toUInt64OrZero(extract(m['k18'], '[0-9]+')) = 18"
 run "SELECT count() FROM tab WHERE toUInt64OrZero(extract(m['k18'], '[0-9]+')) = 0"
+
+$MY_CLICKHOUSE_CLIENT --query "
+    DROP TABLE tab;
+
+    CREATE TABLE tab
+    (
+        m Map(String, String),
+        INDEX idx_mk (mapKeys(m)) TYPE text(tokenizer = ngrams(3)),
+        INDEX idx_mv (mapValues(m)) TYPE text(tokenizer = ngrams(3))
+    ) ENGINE = MergeTree ORDER BY tuple();
+
+    INSERT INTO tab SELECT (arrayMap(x -> 'k' || x, range(number % 30)), arrayMap(x -> 'v' || x, range(number % 30))) FROM numbers(100000);
+"
+
+run "SELECT count() FROM tab WHERE mapContainsKeyLike(m, '%k18%')"
+run "SELECT count() FROM tab WHERE mapContainsValueLike(m, '%v18%')"
 
 $MY_CLICKHOUSE_CLIENT --query "DROP TABLE tab;"

--- a/tests/queries/0_stateless/03780_text_index_duplicate_tokens.reference
+++ b/tests/queries/0_stateless/03780_text_index_duplicate_tokens.reference
@@ -1,0 +1,6 @@
+1
+Filter column: or(and(__text_index_idx_s_like_c305058f11a5516ef44493a7cfb61e2e, like(__table1.s, \'%Hello%\'_String)), and(__text_index_idx_s_like_c305058f11a5516ef44493a7cfb61e2e, like(__table1.s, \'%hello%\'_String))) (removed)
+1
+Filter column: or(like(__table1.s, \'%Hello%\'_String), like(__table1.s, \'%hello%\'_String)) (removed)
+1
+Filter column: or(and(__text_index_idx_s_startsWith_b7277e8eb6394ebe778469bf968cb40f, startsWith(__table1.s, \'Hello,\'_String)), and(__text_index_idx_s_startsWith_b7277e8eb6394ebe778469bf968cb40f, startsWith(__table1.s, \'hello,\'_String))) (removed)

--- a/tests/queries/0_stateless/03780_text_index_duplicate_tokens.sql
+++ b/tests/queries/0_stateless/03780_text_index_duplicate_tokens.sql
@@ -1,0 +1,58 @@
+-- Tags: no-parallel-replicas
+
+DROP TABLE IF EXISTS t_text_index;
+
+SET enable_analyzer = 1;
+SET enable_full_text_index = 1;
+SET use_skip_indexes_on_data_read = 1;
+SET query_plan_text_index_add_hint = 1;
+SET optimize_rewrite_like_perfect_affix = 1;
+SET optimize_or_like_chain = 0;
+
+CREATE TABLE t_text_index
+(
+    s String,
+    INDEX idx_s (s) TYPE text(tokenizer = ngrams(3), preprocessor = lower(s))
+)
+ENGINE = MergeTree ORDER BY tuple();
+
+INSERT INTO t_text_index (s) VALUES ('Hello, world!');
+
+SELECT count() FROM t_text_index WHERE s LIKE '%Hello%' OR s LIKE '%hello%';
+
+SELECT trim(explain) FROM
+(
+    EXPLAIN actions = 1 SELECT count() FROM t_text_index WHERE s LIKE '%Hello%' OR s LIKE '%hello%' SETTINGS use_skip_indexes_on_data_read = 1
+)
+WHERE explain LIKE '%Filter column%';
+
+DROP TABLE t_text_index;
+
+CREATE TABLE t_text_index
+(
+    s String,
+    INDEX idx_s (s) TYPE text(tokenizer = splitByNonAlpha, preprocessor = lower(s))
+)
+ENGINE = MergeTree ORDER BY tuple();
+
+INSERT INTO t_text_index (s) VALUES ('Hello, world!');
+
+-- Direct read from index is not used because splitByNonAlpha
+-- tokenizer produces no tokens for the following query.
+SELECT count() FROM t_text_index WHERE s LIKE '%Hello%' OR s LIKE '%hello%';
+
+SELECT trim(explain) FROM
+(
+    EXPLAIN actions = 1 SELECT count() FROM t_text_index WHERE s LIKE '%Hello%' OR s LIKE '%hello%' SETTINGS use_skip_indexes_on_data_read = 1
+)
+WHERE explain LIKE '%Filter column%';
+
+SELECT count() FROM t_text_index WHERE s LIKE 'Hello,%' OR s LIKE 'hello,%';
+
+SELECT trim(explain) FROM
+(
+    EXPLAIN actions = 1, indexes = 1 SELECT count() FROM t_text_index WHERE s LIKE 'Hello,%' OR s LIKE 'hello,%' SETTINGS use_skip_indexes_on_data_read = 1
+)
+WHERE explain LIKE '%Filter column%';
+
+DROP TABLE t_text_index;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed direct reading from text index with duplicate search queries


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.353`
- Backported to: `25.12.9.10`
<!-- ch-version-info:end -->