### PR TITLE
Deintroduce `getObjectsKeyPrefix`

### DIFF
--- a/src/Disks/DiskObjectStorage/DiskObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/DiskObjectStorage.cpp
@@ -68,14 +68,12 @@ DiskTransactionPtr DiskObjectStorage::createObjectStorageTransactionToAnotherDis
 
 DiskObjectStorage::DiskObjectStorage(
     const String & name_,
-    const String & object_key_prefix_,
     MetadataStoragePtr metadata_storage_,
     ObjectStoragePtr object_storage_,
     const Poco::Util::AbstractConfiguration & config,
     const String & config_prefix,
     bool use_fake_transaction_)
     : IDisk(name_, config, config_prefix)
-    , object_key_prefix(object_key_prefix_)
     , log(getLogger("DiskObjectStorage(" + name + ")"))
     , metadata_storage(std::move(metadata_storage_))
     , object_storage(std::move(object_storage_))
@@ -645,7 +643,6 @@ DiskObjectStoragePtr DiskObjectStorage::createDiskObjectStorage()
     const auto config_prefix = "storage_configuration.disks." + name;
     return std::make_shared<DiskObjectStorage>(
         getName(),
-        object_key_prefix,
         metadata_storage,
         object_storage,
         Context::getGlobalContextInstance()->getConfigRef(),

--- a/src/Disks/DiskObjectStorage/DiskObjectStorage.h
+++ b/src/Disks/DiskObjectStorage/DiskObjectStorage.h
@@ -31,7 +31,6 @@ friend class DiskObjectStorageReservation;
 public:
     DiskObjectStorage(
         const String & name_,
-        const String & object_key_prefix_,
         MetadataStoragePtr metadata_storage_,
         ObjectStoragePtr object_storage_,
         const Poco::Util::AbstractConfiguration & config,
@@ -208,11 +207,6 @@ public:
     /// DiskObjectStorage(CachedObjectStorage(CachedObjectStorage(S3ObjectStorage)))
     String getStructure() const { return fmt::format("DiskObjectStorage-{}({})", getName(), object_storage->getName()); }
 
-    std::string getObjectsKeyPrefix() const
-    {
-        return object_key_prefix;
-    }
-
     /// Add a cache layer.
     /// Example: DiskObjectStorage(S3ObjectStorage) -> DiskObjectStorage(CachedObjectStorage(S3ObjectStorage))
     /// There can be any number of cache layers:
@@ -245,7 +239,6 @@ private:
     String getReadResourceNameNoLock() const;
     String getWriteResourceNameNoLock() const;
 
-    const String object_key_prefix;
     LoggerPtr log;
 
     MetadataStoragePtr metadata_storage;

--- a/src/Disks/DiskObjectStorage/RegisterDiskObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/RegisterDiskObjectStorage.cpp
@@ -51,7 +51,6 @@ void registerDiskObjectStorage(DiskFactory & factory, bool global_skip_access_ch
 
         DiskPtr disk = std::make_shared<DiskObjectStorage>(
             name,
-            object_storage->getCommonKeyPrefix(),
             std::move(metadata_storage),
             std::move(object_storage),
             config,

--- a/src/Disks/tests/gtest_disk_encrypted.cpp
+++ b/src/Disks/tests/gtest_disk_encrypted.cpp
@@ -452,7 +452,7 @@ TEST_F(DiskEncryptedTest, LocalBlobs)
     auto metadata_storage = std::make_shared<MetadataStorageFromDisk>(metadata_disk, "/", object_storage->createKeyGenerator());
     Poco::AutoPtr<Poco::Util::XMLConfiguration> config(new Poco::Util::XMLConfiguration());
 
-    auto local_blobs = std::make_shared<DiskObjectStorage>("local_blobs", "/", metadata_storage, object_storage, *config, "");
+    auto local_blobs = std::make_shared<DiskObjectStorage>("local_blobs", metadata_storage, object_storage, *config, "");
 
     makeEncryptedDisk(FileEncryption::Algorithm::AES_128_CTR, "1234567890123456", local_blobs);
 

--- a/src/Storages/ObjectStorage/S3/Configuration.cpp
+++ b/src/Storages/ObjectStorage/S3/Configuration.cpp
@@ -984,7 +984,7 @@ void StorageS3Configuration::fromDisk(const String & disk_name, ASTs & args, Con
     initializeFromParsedArguments(std::move(parsed_arguments));
     if (auto object_storage_disk = std::static_pointer_cast<DiskObjectStorage>(disk); object_storage_disk)
     {
-        String path = object_storage_disk->getObjectsKeyPrefix();
+        String path = object_storage_disk->getObjectStorage()->getCommonKeyPrefix();
         fs::path root = path;
         setPathForRead(String(root / suffix));
         keys = {String(root / suffix)};


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Unnecessary complication of the interface and constructor


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.445`
<!-- ch-version-info:end -->