### PR TITLE
Fix 03652_memory_usage_headers flaky

### DIFF
--- a/tests/queries/0_stateless/03652_memory_usage_headers.sh
+++ b/tests/queries/0_stateless/03652_memory_usage_headers.sh
@@ -30,7 +30,7 @@ echo "$CURL_OUTPUT" | grep -m1 'X-ClickHouse-Summary:' | grep -q '"memory_usage"
 CURL_OUTPUT="$(
     ${CLICKHOUSE_CURL} -s -S -v -N -G "${CLICKHOUSE_URL}" \
     --data-urlencode "query=SELECT number, avg(number) FROM numbers(1e12) GROUP BY number FORMAT Null SETTINGS max_rows_to_read = 0" \
-    --data-urlencode "max_memory_usage=100000000" 2>&1
+    --data-urlencode "max_memory_usage=20000000" 2>&1
 )"
 
 echo "$CURL_OUTPUT" | grep 'X-ClickHouse-Summary:' | grep -q '"memory_usage":"[1-9][0-9]*"' && echo "Ok"


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

In 03652_memory_usage_headers, reduce max_memory_usage of the OOM query from 100MB to 20MB to avoid timeout.

In [this job](https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=67758a093c59949c15d12b0e44854d1cf9c9973d&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_tsan%2C%20s3%20storage%2C%20parallel%29&name_1=Stateless%20tests%20%28amd_tsan%2C%20s3%20storage%2C%20parallel%29):

Error: https://pastila.clickhouse.com/?0034c872/df2df16a0ee1135e49207fd9f817446c#7v2JAmkDRuG8ODdpEiqcZw==GCM

The last query takes more than 3 minutes:
https://pastila.clickhouse.com/?00056be4/edef18fabb2b77799def415a7c0d4e7e#mUASnJvrvMpb9KBDjGXOfw==GCM
However, the curl max-time config is set to 120 seconds.

Closes https://github.com/ClickHouse/ClickHouse/issues/90148

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
