### PR TITLE
tests: fix shell syntax in 02935_http_content_type_with_http_headers_progress

### DIFF
--- a/tests/queries/0_stateless/02935_http_content_type_with_http_headers_progress.sh
+++ b/tests/queries/0_stateless/02935_http_content_type_with_http_headers_progress.sh
@@ -11,7 +11,7 @@ do
   echo $format
   url="${CLICKHOUSE_URL}&http_headers_progress_interval_ms=1&send_progress_in_http_headers=true&query=select+sleepEachRow(0.01)from+numbers(10)+FORMAT+${format}"
   (
-    for _ in seq 1 ${THREADS}; do
+    for _ in $(seq ${THREADS}); do
       curl -Ss -v -o /dev/null ${url} 2>&1 | grep -P -o " Content-Type:.*$" &
     done
     wait


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Found by: @nightpool
Fixes: #92117