### PR TITLE
Don't try to authenticate twice when using ssh

### DIFF
--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -386,6 +386,7 @@ try
         if ((e.code() != ErrorCodes::AUTHENTICATION_FAILED && e.code() != ErrorCodes::REQUIRED_PASSWORD) ||
             config().has("password") ||
             config().getBool("ask-password", false) ||
+            config().has("ssh-key-file") ||
             !is_interactive)
             throw;
 

--- a/tests/queries/0_stateless/03780_failed_ssh.expect
+++ b/tests/queries/0_stateless/03780_failed_ssh.expect
@@ -1,0 +1,33 @@
+#!/usr/bin/expect -f
+
+set basedir [file dirname $argv0]
+set basename [file tail $argv0]
+if {[info exists env(CLICKHOUSE_TMP)]} {
+    set CLICKHOUSE_TMP $env(CLICKHOUSE_TMP)
+} else {
+    set CLICKHOUSE_TMP "."
+}
+exp_internal 1
+#exp_internal -f $CLICKHOUSE_TMP/$basename.debuglog 0
+
+log_user 0
+set timeout 5
+match_max 100000
+
+expect_after {
+    # Do not ignore eof from expect
+    -i $any_spawn_id eof { exp_continue }
+    # A default timeout action is to do nothing, change it to fail
+    -i $any_spawn_id timeout { exit 1 }
+}
+
+file delete -force id_rsa_03780_failed_ssh
+spawn ssh-keygen -t rsa -b 4096 -f id_rsa_03780_failed_ssh -N "" -q
+expect eof
+
+spawn bash -c "source $basedir/../shell_config.sh ; ../../../build/programs/clickhouse-client \$CLICKHOUSE_CLIENT_EXPECT_OPT --ssh-key-file id_rsa_03780_failed_ssh --user admin"
+expect "Enter your SSH private key passphrase (leave empty for no passphrase): "
+send "\r"
+expect "Connecting to * as user admin."
+expect "Code: 516. *"
+expect eof

--- a/tests/queries/0_stateless/03780_failed_ssh.expect
+++ b/tests/queries/0_stateless/03780_failed_ssh.expect
@@ -7,8 +7,8 @@ if {[info exists env(CLICKHOUSE_TMP)]} {
 } else {
     set CLICKHOUSE_TMP "."
 }
-exp_internal 1
-#exp_internal -f $CLICKHOUSE_TMP/$basename.debuglog 0
+
+exp_internal -f $CLICKHOUSE_TMP/$basename.debuglog 0
 
 log_user 0
 set timeout 5

--- a/tests/queries/0_stateless/03780_failed_ssh.expect
+++ b/tests/queries/0_stateless/03780_failed_ssh.expect
@@ -1,4 +1,5 @@
 #!/usr/bin/expect -f
+# Tags: no-fasttest
 
 set basedir [file dirname $argv0]
 set basename [file tail $argv0]

--- a/tests/queries/0_stateless/03780_failed_ssh.expect
+++ b/tests/queries/0_stateless/03780_failed_ssh.expect
@@ -12,7 +12,7 @@ if {[info exists env(CLICKHOUSE_TMP)]} {
 exp_internal -f $CLICKHOUSE_TMP/$basename.debuglog 0
 
 log_user 0
-set timeout 5
+set timeout 60
 match_max 100000
 
 expect_after {
@@ -21,7 +21,6 @@ expect_after {
     # A default timeout action is to do nothing, change it to fail
     -i $any_spawn_id timeout { exit 1 }
 }
-
 
 spawn bash -c "echo '-----BEGIN OPENSSH PRIVATE KEY-----
 b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAlwAAAAdzc2gtcn
@@ -38,9 +37,9 @@ l+CHod8qOHF+eWWnw+TvPw3sTM/5rcJ+0N3anhpo9Ph3AAAAQQDl0EKJvfyRgnKHcjtLUM
 IPac9E4ZR36UA2lWK/gr0x8PvxzlonzWqBcYFmCAQv9lPvk1GJK8/EnCkkD5pTvKbHAAAA
 QQDbVchcKjXrhsYklDvJQ4xyGkUH6+xMRVINwzjP3JQ1akUF/MJAYg5vr8j4gibWysVwWV
 0lgWuG96Yy/MxT62bvAAAAE2lzYWtlbEBwYzY0MTAxLTI1MzYBAgMEBQYH
------END OPENSSH PRIVATE KEY-----' > ssh_key"
+-----END OPENSSH PRIVATE KEY-----' > id_rsa_03780_failed_ssh"
 
-spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CLIENT_BINARY \$CLICKHOUSE_CLIENT_EXPECT_OPT --ssh-key-file ssh_key --user admin"
+spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CLIENT_BINARY \$CLICKHOUSE_CLIENT_EXPECT_OPT --ssh-key-file id_rsa_03780_failed_ssh --user admin"
 expect "Enter your SSH private key passphrase (leave empty for no passphrase): "
 send "\r"
 expect "Connecting to * as user admin."

--- a/tests/queries/0_stateless/03780_failed_ssh.expect
+++ b/tests/queries/0_stateless/03780_failed_ssh.expect
@@ -45,7 +45,7 @@ spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CLIENT_BINARY \
 
 expect "Enter your SSH private key passphrase (leave empty for no passphrase): "
 send "\r"
-expect "Connecting to * as user admin."
+expect "Connecting to * as user user_03780_failed_ssh."
 expect "Code: 516. *"
 expect eof
 

--- a/tests/queries/0_stateless/03780_failed_ssh.expect
+++ b/tests/queries/0_stateless/03780_failed_ssh.expect
@@ -37,12 +37,12 @@ l+CHod8qOHF+eWWnw+TvPw3sTM/5rcJ+0N3anhpo9Ph3AAAAQQDl0EKJvfyRgnKHcjtLUM
 IPac9E4ZR36UA2lWK/gr0x8PvxzlonzWqBcYFmCAQv9lPvk1GJK8/EnCkkD5pTvKbHAAAA
 QQDbVchcKjXrhsYklDvJQ4xyGkUH6+xMRVINwzjP3JQ1akUF/MJAYg5vr8j4gibWysVwWV
 0lgWuG96Yy/MxT62bvAAAAE2lzYWtlbEBwYzY0MTAxLTI1MzYBAgMEBQYH
------END OPENSSH PRIVATE KEY-----' > id_rsa_03780_failed_ssh"
+-----END OPENSSH PRIVATE KEY-----' > id_rsa_03780_\$CLICKHOUSE_DATABASE"
 
-spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CURL -sS \$CLICKHOUSE_URL -d 'CREATE USER IF NOT EXISTS user_03780_\$CLICKHOUSE_TEST_UNIQUE_NAME'"
+spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CURL -sS \$CLICKHOUSE_URL -d \"CREATE USER IF NOT EXISTS user_03780_\$CLICKHOUSE_DATABASE\""
 expect eof
 
-spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CLIENT_BINARY \$CLICKHOUSE_CLIENT_EXPECT_OPT --ssh-key-file id_rsa_03780_failed_ssh --user user_03780_\$CLICKHOUSE_TEST_UNIQUE_NAME"
+spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CLIENT_BINARY \$CLICKHOUSE_CLIENT_EXPECT_OPT --ssh-key-file id_rsa_03780_\$CLICKHOUSE_DATABASE --user user_03780_\$CLICKHOUSE_DATABASE"
 
 expect "Enter your SSH private key passphrase (leave empty for no passphrase): "
 send "\r"
@@ -50,5 +50,8 @@ expect "Connecting to * as user user_03780_*."
 expect "Code: 516. *"
 expect eof
 
-spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CURL -sS \$CLICKHOUSE_URL -d 'DROP USER IF EXISTS user_03780_\$CLICKHOUSE_TEST_UNIQUE_NAME'"
+spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CURL -sS \$CLICKHOUSE_URL -d \"DROP USER IF EXISTS user_03780_\$CLICKHOUSE_DATABASE\""
+expect eof
+
+spawn bash -c "rm -f id_rsa_03780_\$CLICKHOUSE_DATABASE"
 expect eof

--- a/tests/queries/0_stateless/03780_failed_ssh.expect
+++ b/tests/queries/0_stateless/03780_failed_ssh.expect
@@ -39,16 +39,16 @@ QQDbVchcKjXrhsYklDvJQ4xyGkUH6+xMRVINwzjP3JQ1akUF/MJAYg5vr8j4gibWysVwWV
 0lgWuG96Yy/MxT62bvAAAAE2lzYWtlbEBwYzY0MTAxLTI1MzYBAgMEBQYH
 -----END OPENSSH PRIVATE KEY-----' > id_rsa_03780_failed_ssh"
 
-spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CURL -sS \$CLICKHOUSE_URL -d 'CREATE USER IF NOT EXISTS user_03780_failed_ssh'"
+spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CURL -sS \$CLICKHOUSE_URL -d 'CREATE USER IF NOT EXISTS user_03780_\$CLICKHOUSE_TEST_UNIQUE_NAME'"
 
-spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CLIENT_BINARY \$CLICKHOUSE_CLIENT_EXPECT_OPT --ssh-key-file id_rsa_03780_failed_ssh --user user_03780_failed_ssh"
+spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CLIENT_BINARY \$CLICKHOUSE_CLIENT_EXPECT_OPT --ssh-key-file id_rsa_03780_failed_ssh --user user_03780_\$CLICKHOUSE_TEST_UNIQUE_NAME"
 
 expect "Enter your SSH private key passphrase (leave empty for no passphrase): "
 send "\r"
-expect "Connecting to * as user user_03780_failed_ssh."
+expect "Connecting to * as user user_03780_*."
 expect "Code: 516. *"
 expect eof
 
-spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CURL -sS \$CLICKHOUSE_URL -d 'DROP USER IF EXISTS user_03780_failed_ssh'"
+spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CURL -sS \$CLICKHOUSE_URL -d 'DROP USER IF EXISTS user_03780_\$CLICKHOUSE_TEST_UNIQUE_NAME'"
 
 expect eof

--- a/tests/queries/0_stateless/03780_failed_ssh.expect
+++ b/tests/queries/0_stateless/03780_failed_ssh.expect
@@ -39,9 +39,16 @@ QQDbVchcKjXrhsYklDvJQ4xyGkUH6+xMRVINwzjP3JQ1akUF/MJAYg5vr8j4gibWysVwWV
 0lgWuG96Yy/MxT62bvAAAAE2lzYWtlbEBwYzY0MTAxLTI1MzYBAgMEBQYH
 -----END OPENSSH PRIVATE KEY-----' > id_rsa_03780_failed_ssh"
 
-spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CLIENT_BINARY \$CLICKHOUSE_CLIENT_EXPECT_OPT --ssh-key-file id_rsa_03780_failed_ssh --user admin"
+spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CURL -sS \$CLICKHOUSE_URL -d 'CREATE USER IF NOT EXISTS user_03780_failed_ssh'"
+
+spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CLIENT_BINARY \$CLICKHOUSE_CLIENT_EXPECT_OPT --ssh-key-file id_rsa_03780_failed_ssh --user user_03780_failed_ssh"
+
 expect "Enter your SSH private key passphrase (leave empty for no passphrase): "
 send "\r"
 expect "Connecting to * as user admin."
 expect "Code: 516. *"
+expect eof
+
+spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CURL -sS \$CLICKHOUSE_URL -d 'DROP USER IF EXISTS user_03780_failed_ssh'"
+
 expect eof

--- a/tests/queries/0_stateless/03780_failed_ssh.expect
+++ b/tests/queries/0_stateless/03780_failed_ssh.expect
@@ -21,11 +21,25 @@ expect_after {
     -i $any_spawn_id timeout { exit 1 }
 }
 
-file delete -force id_rsa_03780_failed_ssh
-spawn ssh-keygen -t rsa -b 4096 -f id_rsa_03780_failed_ssh -N "" -q
-expect eof
 
-spawn bash -c "source $basedir/../shell_config.sh ; ../../../build/programs/clickhouse-client \$CLICKHOUSE_CLIENT_EXPECT_OPT --ssh-key-file id_rsa_03780_failed_ssh --user admin"
+spawn bash -c "echo '-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAlwAAAAdzc2gtcn
+NhAAAAAwEAAQAAAIEAxOYq7137PbwKYw6IahB/pHvYNvFTrMg6bAT182PLg+Fidb+wbMNw
+qkeL4C8wIxwulaScbjpidEEVbB3egOXf92cVmO7FxnwJkbuOkQdTZ68+vh9oy7jRwLsTq0
+K5Ez0nnauHyoR2Qdd+7AnTSSyEi1Efdni5Ble/LhHhRPU//ckAAAIQRkn3H0ZJ9x8AAAAH
+c3NoLXJzYQAAAIEAxOYq7137PbwKYw6IahB/pHvYNvFTrMg6bAT182PLg+Fidb+wbMNwqk
+eL4C8wIxwulaScbjpidEEVbB3egOXf92cVmO7FxnwJkbuOkQdTZ68+vh9oy7jRwLsTq0K5
+Ez0nnauHyoR2Qdd+7AnTSSyEi1Efdni5Ble/LhHhRPU//ckAAAADAQABAAAAgDW3MSliM0
+NxREgn09FTtO7TlnXOumwdp8qGQ+7lX8UXvLuw0tmpK9hYcnFzjidV7eOHJ+HubaOXideY
+AnaZv9KNNWBDTOeuHpMtaIzjq3yb/BuOSC1Xthjb7UZoQGlgAUOdCTFap3jxV8PeLbFazg
+oMqjTVCwiWxlIumBoZgwTNAAAAQQCxyh6w3GOFtqts66TVNs8pSe8r/cSOUnTU1cws5s0t
+l+CHod8qOHF+eWWnw+TvPw3sTM/5rcJ+0N3anhpo9Ph3AAAAQQDl0EKJvfyRgnKHcjtLUM
+IPac9E4ZR36UA2lWK/gr0x8PvxzlonzWqBcYFmCAQv9lPvk1GJK8/EnCkkD5pTvKbHAAAA
+QQDbVchcKjXrhsYklDvJQ4xyGkUH6+xMRVINwzjP3JQ1akUF/MJAYg5vr8j4gibWysVwWV
+0lgWuG96Yy/MxT62bvAAAAE2lzYWtlbEBwYzY0MTAxLTI1MzYBAgMEBQYH
+-----END OPENSSH PRIVATE KEY-----' > ssh_key"
+
+spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CLIENT_BINARY \$CLICKHOUSE_CLIENT_EXPECT_OPT --ssh-key-file ssh_key --user admin"
 expect "Enter your SSH private key passphrase (leave empty for no passphrase): "
 send "\r"
 expect "Connecting to * as user admin."

--- a/tests/queries/0_stateless/03780_failed_ssh.expect
+++ b/tests/queries/0_stateless/03780_failed_ssh.expect
@@ -40,6 +40,7 @@ QQDbVchcKjXrhsYklDvJQ4xyGkUH6+xMRVINwzjP3JQ1akUF/MJAYg5vr8j4gibWysVwWV
 -----END OPENSSH PRIVATE KEY-----' > id_rsa_03780_failed_ssh"
 
 spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CURL -sS \$CLICKHOUSE_URL -d 'CREATE USER IF NOT EXISTS user_03780_\$CLICKHOUSE_TEST_UNIQUE_NAME'"
+expect eof
 
 spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CLIENT_BINARY \$CLICKHOUSE_CLIENT_EXPECT_OPT --ssh-key-file id_rsa_03780_failed_ssh --user user_03780_\$CLICKHOUSE_TEST_UNIQUE_NAME"
 
@@ -50,5 +51,4 @@ expect "Code: 516. *"
 expect eof
 
 spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CURL -sS \$CLICKHOUSE_URL -d 'DROP USER IF EXISTS user_03780_\$CLICKHOUSE_TEST_UNIQUE_NAME'"
-
 expect eof


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a bug where clickhouse-client would ask for password twice when connecting using ssh.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.684`
<!-- ch-version-info:end -->