### PR TITLE
tests: disable 03778_window_funnel_respects_memory_limit under sanitizers and debug (slow)

### DIFF
--- a/tests/queries/0_stateless/03778_window_funnel_respects_memory_limit.sql
+++ b/tests/queries/0_stateless/03778_window_funnel_respects_memory_limit.sql
@@ -1,4 +1,4 @@
--- Tags: no-random-mergetree-settings, no-random-settings, long
+-- Tags: no-random-mergetree-settings, no-random-settings, long, no-tsan, no-asan, no-ubsan, no-msan, no-debug
 
 DROP TABLE IF EXISTS test;
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

CI: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=ceac670e024304c6fd23dd15b2d387d7d2915755&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_ubsan%2C%20parallel%29&name_1=Stateless%20tests%20%28amd_ubsan%2C%20parallel%29
Refs: https://github.com/ClickHouse/ClickHouse/pull/93035