### PR TITLE
Check what would happen if I replace absl::InlinedVector back from std::vector in IAST

### DIFF
--- a/src/Common/QueryFuzzer.cpp
+++ b/src/Common/QueryFuzzer.cpp
@@ -387,7 +387,7 @@ void QueryFuzzer::fuzzOrderByList(IAST * ast, const size_t nproj)
     if (fuzz_rand() % 50 == 0)
     {
         /// Order by one of the projections, starting from position 1
-        auto * pos = list->children.empty() ? list->children.begin() : list->children.begin() + fuzz_rand() % list->children.size();
+        auto pos = list->children.empty() ? list->children.begin() : list->children.begin() + fuzz_rand() % list->children.size();
         const auto col = nproj && (fuzz_rand() % 4 == 0) ? std::make_shared<ASTLiteral>((fuzz_rand() % nproj) + 1) : getRandomColumnLike();
         if (col)
         {
@@ -439,7 +439,7 @@ void QueryFuzzer::fuzzColumnLikeExpressionList(IAST * ast)
     // Add element
     if (fuzz_rand() % 50 == 0)
     {
-        auto * pos = impl->children.empty() ? impl->children.begin() : impl->children.begin() + fuzz_rand() % impl->children.size();
+        auto pos = impl->children.empty() ? impl->children.begin() : impl->children.begin() + fuzz_rand() % impl->children.size();
         auto col = getRandomColumnLike();
         if (col)
             impl->children.insert(pos, col);

--- a/src/Dictionaries/getDictionaryConfigurationFromAST.cpp
+++ b/src/Dictionaries/getDictionaryConfigurationFromAST.cpp
@@ -382,7 +382,7 @@ void buildPrimaryKeyConfiguration(
 
         auto identifier_name = key_names.front();
 
-        const auto * it = std::find_if(
+        const auto it = std::find_if(
             children.begin(),
             children.end(),
             [&](const ASTPtr & node)

--- a/src/Interpreters/ApplyWithGlobalVisitor.cpp
+++ b/src/Interpreters/ApplyWithGlobalVisitor.cpp
@@ -88,7 +88,7 @@ void ApplyWithGlobalVisitor::visit(ASTPtr & ast)
                     if (auto * ast_with_alias = dynamic_cast<ASTWithAlias *>(child.get()))
                         exprs[ast_with_alias->alias] = child;
                 }
-                for (auto * it = node_union->list_of_selects->children.begin() + 1; it != node_union->list_of_selects->children.end(); ++it)
+                for (auto it = node_union->list_of_selects->children.begin() + 1; it != node_union->list_of_selects->children.end(); ++it)
                 {
                     if (auto * union_child = (*it)->as<ASTSelectWithUnionQuery>())
                         visit(*union_child, exprs, with_expression_list);

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -2621,7 +2621,7 @@ StoragePtr Context::executeTableFunction(const ASTPtr & table_expression, const 
             auto virtual_column_names = table_function_ptr->getVirtualsToCheckBeforeUsingStructureHint();
             bool asterisk = false;
             const auto & expression_list = select_query_hint->select()->as<ASTExpressionList>()->children;
-            const auto * expression = expression_list.begin();
+            auto expression = expression_list.begin();
 
             /// We want to go through SELECT expression list and correspond each expression to column in insert table
             /// which type will be used as a hint for the file structure inference.

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -628,7 +628,7 @@ ColumnsDescription InterpreterCreateQuery::getColumnsDescription(
 
     ColumnsDescription res;
     auto name_type_it = column_names_and_types.begin();
-    for (const auto * ast_it = columns_ast.children.begin(); ast_it != columns_ast.children.end(); ++ast_it, ++name_type_it)
+    for (auto ast_it = columns_ast.children.begin(); ast_it != columns_ast.children.end(); ++ast_it, ++name_type_it)
     {
         ColumnDescription column;
 

--- a/src/Interpreters/LogicalExpressionsOptimizer.cpp
+++ b/src/Interpreters/LogicalExpressionsOptimizer.cpp
@@ -357,7 +357,7 @@ void LogicalExpressionsOptimizer::cleanupOrExpressions()
     for (const auto & entry : garbage_map)
     {
         const auto * function = entry.first;
-        auto * first_erased = entry.second;
+        auto first_erased = entry.second;
 
         auto & operands = getFunctionOperands(function);
         operands.erase(first_erased, operands.end());

--- a/src/Interpreters/RewriteArrayExistsFunctionVisitor.cpp
+++ b/src/Interpreters/RewriteArrayExistsFunctionVisitor.cpp
@@ -25,7 +25,7 @@ void RewriteArrayExistsFunctionMatcher::visit(ASTPtr & ast, Data & data)
     {
         if (join->using_expression_list)
         {
-            auto * it = std::find(join->children.begin(), join->children.end(), join->using_expression_list);
+            auto it = std::find(join->children.begin(), join->children.end(), join->using_expression_list);
             if (it == join->children.end())
                 throw Exception(ErrorCodes::LOGICAL_ERROR, "Could not find join->using_expression_list in '{}'", join->formatForLogging());
 
@@ -35,7 +35,7 @@ void RewriteArrayExistsFunctionMatcher::visit(ASTPtr & ast, Data & data)
 
         if (join->on_expression)
         {
-            auto * it = std::find(join->children.begin(), join->children.end(), join->on_expression);
+            auto it = std::find(join->children.begin(), join->children.end(), join->on_expression);
             if (it == join->children.end())
                 throw Exception(ErrorCodes::LOGICAL_ERROR, "Could not find join->on_expression in '{}'", join->formatForLogging());
 

--- a/src/Interpreters/TreeRewriter.cpp
+++ b/src/Interpreters/TreeRewriter.cpp
@@ -506,7 +506,7 @@ void removeUnneededColumnsFromSelectClause(ASTSelectQuery * select_query, const 
         auto & children = select_query->interpolate()->children;
         if (!children.empty())
         {
-            for (auto * it = children.begin(); it != children.end();)
+            for (auto it = children.begin(); it != children.end();)
             {
                 if (remove_columns.contains((*it)->as<ASTInterpolateElement>()->column))
                     it = select_query->interpolate()->children.erase(it);

--- a/src/Interpreters/applyTableOverride.cpp
+++ b/src/Interpreters/applyTableOverride.cpp
@@ -26,7 +26,7 @@ void applyTableOverrideToCreateQuery(const ASTTableOverride & override, ASTCreat
                 if (!create_query->columns_list->columns)
                     create_query->columns_list->set(create_query->columns_list->columns, std::make_shared<ASTExpressionList>());
                 auto & dest_children = create_query->columns_list->columns->children;
-                auto * exists = std::find_if(
+                auto exists = std::find_if(
                     dest_children.begin(),
                     dest_children.end(),
                     [&](ASTPtr node) -> bool { return node->as<ASTColumnDeclaration>()->name == override_column->name; });
@@ -52,7 +52,7 @@ void applyTableOverrideToCreateQuery(const ASTTableOverride & override, ASTCreat
                 if (!create_query->columns_list->indices)
                     create_query->columns_list->set(create_query->columns_list->indices, std::make_shared<ASTExpressionList>());
                 auto & dest_children = create_query->columns_list->indices->children;
-                auto * exists = std::find_if(
+                auto exists = std::find_if(
                     dest_children.begin(),
                     dest_children.end(),
                     [&](ASTPtr node) -> bool { return node->as<ASTIndexDeclaration>()->name == override_index->name; });
@@ -72,7 +72,7 @@ void applyTableOverrideToCreateQuery(const ASTTableOverride & override, ASTCreat
                 if (!create_query->columns_list->constraints)
                     create_query->columns_list->set(create_query->columns_list->constraints, std::make_shared<ASTExpressionList>());
                 auto & dest_children = create_query->columns_list->constraints->children;
-                auto * exists = std::find_if(
+                auto exists = std::find_if(
                     dest_children.begin(),
                     dest_children.end(),
                     [&](ASTPtr node) -> bool { return node->as<ASTConstraintDeclaration>()->name == override_constraint->name; });
@@ -92,7 +92,7 @@ void applyTableOverrideToCreateQuery(const ASTTableOverride & override, ASTCreat
                 if (!create_query->columns_list->projections)
                     create_query->columns_list->set(create_query->columns_list->projections, std::make_shared<ASTExpressionList>());
                 auto & dest_children = create_query->columns_list->projections->children;
-                auto * exists = std::find_if(
+                auto exists = std::find_if(
                     dest_children.begin(),
                     dest_children.end(),
                     [&](ASTPtr node) -> bool { return node->as<ASTProjectionDeclaration>()->name == override_projection->name; });

--- a/src/Parsers/ASTColumnsMatcher.cpp
+++ b/src/Parsers/ASTColumnsMatcher.cpp
@@ -89,7 +89,7 @@ void ASTColumnsListMatcher::appendColumnName(WriteBuffer & ostr) const
         writeCString(".", ostr);
     }
     writeCString("COLUMNS(", ostr);
-    for (auto * it = column_list->children.begin(); it != column_list->children.end(); ++it)
+    for (auto it = column_list->children.begin(); it != column_list->children.end(); ++it)
     {
         if (it != column_list->children.begin())
             writeCString(", ", ostr);
@@ -198,7 +198,7 @@ void ASTQualifiedColumnsListMatcher::appendColumnName(WriteBuffer & ostr) const
     qualifier->appendColumnName(ostr);
     writeCString(".COLUMNS(", ostr);
 
-    for (auto * it = column_list->children.begin(); it != column_list->children.end(); ++it)
+    for (auto it = column_list->children.begin(); it != column_list->children.end(); ++it)
     {
         if (it != column_list->children.begin())
             writeCString(", ", ostr);

--- a/src/Parsers/ASTColumnsTransformers.cpp
+++ b/src/Parsers/ASTColumnsTransformers.cpp
@@ -230,7 +230,7 @@ void ASTColumnsExceptTransformer::transform(ASTs & nodes) const
         for (const auto & child : children)
             expected_columns.insert(child->as<const ASTIdentifier &>().name());
 
-        for (auto * it = nodes.begin(); it != nodes.end();)
+        for (auto it = nodes.begin(); it != nodes.end();)
         {
             if (const auto * id = it->get()->as<ASTIdentifier>())
             {
@@ -249,9 +249,9 @@ void ASTColumnsExceptTransformer::transform(ASTs & nodes) const
     {
         auto regexp = getMatcher();
 
-        for (auto * it = nodes.begin(); it != nodes.end();)
+        for (auto it = nodes.begin(); it != nodes.end();)
         {
-            if (const auto * id = it->get()->as<ASTIdentifier>())
+            if (auto id = it->get()->as<ASTIdentifier>())
             {
                 if (RE2::PartialMatch(id->shortName(), *regexp))
                 {

--- a/src/Parsers/ASTColumnsTransformers.cpp
+++ b/src/Parsers/ASTColumnsTransformers.cpp
@@ -251,7 +251,7 @@ void ASTColumnsExceptTransformer::transform(ASTs & nodes) const
 
         for (auto it = nodes.begin(); it != nodes.end();)
         {
-            if (auto id = it->get()->as<ASTIdentifier>())
+            if (auto * id = it->get()->as<ASTIdentifier>())
             {
                 if (RE2::PartialMatch(id->shortName(), *regexp))
                 {

--- a/src/Parsers/ASTDropQuery.cpp
+++ b/src/Parsers/ASTDropQuery.cpp
@@ -74,7 +74,7 @@ void ASTDropQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings & se
     else if (database_and_tables)
     {
         auto & list = database_and_tables->as<ASTExpressionList &>();
-        for (auto * it = list.children.begin(); it != list.children.end(); ++it)
+        for (auto it = list.children.begin(); it != list.children.end(); ++it)
         {
             if (it != list.children.begin())
                 ostr << ", ";

--- a/src/Parsers/ASTFunction.cpp
+++ b/src/Parsers/ASTFunction.cpp
@@ -55,7 +55,7 @@ void ASTFunction::appendColumnNameImpl(WriteBuffer & ostr) const
     if (parameters)
     {
         writeChar('(', ostr);
-        for (auto * it = parameters->children.begin(); it != parameters->children.end(); ++it)
+        for (auto it = parameters->children.begin(); it != parameters->children.end(); ++it)
         {
             if (it != parameters->children.begin())
                 writeCString(", ", ostr);
@@ -68,7 +68,7 @@ void ASTFunction::appendColumnNameImpl(WriteBuffer & ostr) const
     writeChar('(', ostr);
     if (arguments)
     {
-        for (auto * it = arguments->children.begin(); it != arguments->children.end(); ++it)
+        for (auto it = arguments->children.begin(); it != arguments->children.end(); ++it)
         {
             if (it != arguments->children.begin())
                 writeCString(", ", ostr);

--- a/src/Parsers/ASTQueryWithOutput.cpp
+++ b/src/Parsers/ASTQueryWithOutput.cpp
@@ -86,7 +86,7 @@ bool ASTQueryWithOutput::resetOutputASTIfExist(IAST & ast)
         {
             if (p)
             {
-                if (auto * it = std::find(ast_with_output->children.begin(), ast_with_output->children.end(), p);
+                if (auto it = std::find(ast_with_output->children.begin(), ast_with_output->children.end(), p);
                     it != ast_with_output->children.end())
                     ast_with_output->children.erase(it);
                 p.reset();

--- a/src/Parsers/ASTTTLElement.cpp
+++ b/src/Parsers/ASTTTLElement.cpp
@@ -51,7 +51,7 @@ void ASTTTLElement::formatImpl(WriteBuffer & ostr, const FormatSettings & settin
     else if (mode == TTLMode::GROUP_BY)
     {
         ostr << " GROUP BY ";
-        for (const auto * it = group_by_key.begin(); it != group_by_key.end(); ++it)
+        for (auto it = group_by_key.begin(); it != group_by_key.end(); ++it)
         {
             if (it != group_by_key.begin())
                 ostr << ", ";
@@ -61,7 +61,7 @@ void ASTTTLElement::formatImpl(WriteBuffer & ostr, const FormatSettings & settin
         if (!group_by_assignments.empty())
         {
             ostr << " SET ";
-            for (const auto * it = group_by_assignments.begin(); it != group_by_assignments.end(); ++it)
+            for (auto it = group_by_assignments.begin(); it != group_by_assignments.end(); ++it)
             {
                 if (it != group_by_assignments.begin())
                     ostr << ", ";

--- a/src/Parsers/ExpressionListParsers.cpp
+++ b/src/Parsers/ExpressionListParsers.cpp
@@ -635,7 +635,7 @@ public:
 
         asts.reserve(asts.size() + n);
 
-        auto * start = operands.begin() + operands.size() - n;
+        auto start = operands.begin() + operands.size() - n;
         asts.insert(asts.end(), std::make_move_iterator(start), std::make_move_iterator(operands.end()));
         operands.erase(start, operands.end());
 

--- a/src/Parsers/IAST.h
+++ b/src/Parsers/IAST.h
@@ -163,7 +163,7 @@ public:
         if (field == nullptr)
             return;
 
-        auto * child = children.begin();
+        auto child = children.begin();
         while (child != children.end())
         {
             if (child->get() == field)

--- a/src/Parsers/IAST_fwd.h
+++ b/src/Parsers/IAST_fwd.h
@@ -8,8 +8,6 @@ namespace DB
 
 class IAST;
 using ASTPtr = std::shared_ptr<IAST>;
-/// sizeof(absl::InlinedVector<ASTPtr, N>) == 8 + N * 16.
-/// 7 elements take 120 Bytes which is ~128
 using ASTs = std::vector<ASTPtr>;
 
 }

--- a/src/Parsers/IAST_fwd.h
+++ b/src/Parsers/IAST_fwd.h
@@ -10,6 +10,6 @@ class IAST;
 using ASTPtr = std::shared_ptr<IAST>;
 /// sizeof(absl::InlinedVector<ASTPtr, N>) == 8 + N * 16.
 /// 7 elements take 120 Bytes which is ~128
-using ASTs = absl::InlinedVector<ASTPtr, 7>;
+using ASTs = std::vector<ASTPtr>;
 
 }

--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -817,14 +817,14 @@ void AlterCommand::apply(StorageInMemoryMetadata & metadata, ContextPtr context)
                         constraint_name);
         }
 
-        auto * insert_it = constraints.end();
+        auto insert_it = constraints.end();
         constraints.emplace(insert_it, constraint_decl);
         metadata.constraints = ConstraintsDescription(constraints);
     }
     else if (type == DROP_CONSTRAINT)
     {
         auto constraints = metadata.constraints.getConstraints();
-        auto * erase_it = std::find_if(
+        auto erase_it = std::find_if(
             constraints.begin(),
             constraints.end(),
             [this](const ASTPtr & constraint_ast) { return constraint_ast->as<ASTConstraintDeclaration &>().name == constraint_name; });

--- a/src/Storages/NamedCollectionsHelpers.cpp
+++ b/src/Storages/NamedCollectionsHelpers.cpp
@@ -129,7 +129,7 @@ MutableNamedCollectionPtr tryGetNamedCollectionWithOverrides(
 
     const auto allow_override_by_default = context->getSettingsRef()[Setting::allow_named_collection_override_by_default];
 
-    for (auto * it = std::next(asts.begin()); it != asts.end(); ++it)
+    for (auto it = std::next(asts.begin()); it != asts.end(); ++it)
     {
         auto value_override = getKeyValueFromASTImpl(*it, /* fallback_to_ast_value */ complex_args != nullptr, context);
 

--- a/src/Storages/ObjectStorage/S3/Configuration.cpp
+++ b/src/Storages/ObjectStorage/S3/Configuration.cpp
@@ -342,7 +342,7 @@ void S3StorageParsedArguments::fromAST(ASTs & args, ContextPtr context, bool wit
     size_t count = StorageURL::evalArgsAndCollectHeaders(args, headers_from_ast, context);
 
     ASTs key_value_asts;
-    if (auto * first_key_value_arg_it = getFirstKeyValueArgument(args);
+    if (auto first_key_value_arg_it = getFirstKeyValueArgument(args);
         first_key_value_arg_it != args.end())
     {
         key_value_asts = ASTs(first_key_value_arg_it, args.end());
@@ -712,7 +712,7 @@ static void addStructureAndFormatToArgsIfNeededS3(
         size_t count = StorageURL::evalArgsAndCollectHeaders(args, tmp_headers, context);
 
         ASTs key_value_asts;
-        auto * first_key_value_arg_it = getFirstKeyValueArgument(args);
+        auto first_key_value_arg_it = getFirstKeyValueArgument(args);
         if (first_key_value_arg_it != args.end())
         {
             key_value_asts = ASTs(first_key_value_arg_it, args.end());
@@ -733,7 +733,7 @@ static void addStructureAndFormatToArgsIfNeededS3(
 
         bool format_in_key_value = false;
         bool structure_in_key_value = false;
-        for (auto * it = first_key_value_arg_it; it != args.end(); ++it)
+        for (auto it = first_key_value_arg_it; it != args.end(); ++it)
         {
             const auto & arg = *it;
             const auto * function_ast = arg->as<ASTFunction>();

--- a/src/Storages/ObjectStorage/StorageObjectStorageCluster.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageCluster.cpp
@@ -174,7 +174,7 @@ void StorageObjectStorageCluster::updateQueryToSendIfNeeded(
     }
 
     ASTPtr settings_temporary_storage = nullptr;
-    for (auto * it = args.begin(); it != args.end(); ++it)
+    for (auto it = args.begin(); it != args.end(); ++it)
     {
         ASTSetQuery * settings_ast = (*it)->as<ASTSetQuery>();
         if (settings_ast)

--- a/src/Storages/ObjectStorage/Utils.cpp
+++ b/src/Storages/ObjectStorage/Utils.cpp
@@ -125,7 +125,7 @@ void validateSupportedColumns(
 ASTs::iterator getFirstKeyValueArgument(ASTs & args)
 {
     ASTs::iterator first_key_value_arg_it = args.end();
-    for (auto * it = args.begin(); it != args.end(); ++it)
+    for (auto it = args.begin(); it != args.end(); ++it)
     {
         const auto * function_ast = (*it)->as<ASTFunction>();
         if (function_ast && function_ast->name == "equals")
@@ -207,7 +207,7 @@ ParseFromDiskResult parseFromDisk(ASTs args, bool with_structure, ContextPtr con
         engine_args_to_idx = {{"path", 0}};
 
     ASTs key_value_asts;
-    if (auto * first_key_value_arg_it = getFirstKeyValueArgument(args);
+    if (auto first_key_value_arg_it = getFirstKeyValueArgument(args);
         first_key_value_arg_it != args.end())
     {
         key_value_asts = ASTs(first_key_value_arg_it, args.end());

--- a/src/Storages/StorageFuzzJSON.cpp
+++ b/src/Storages/StorageFuzzJSON.cpp
@@ -684,7 +684,7 @@ StorageFuzzJSON::Configuration StorageFuzzJSON::getConfiguration(ASTs & engine_a
     if (auto named_collection = tryGetNamedCollectionWithOverrides(engine_args, local_context))
     {
         /// Perform strict validation of ASTs in addition to name collection extraction.
-        for (auto * args_it = std::next(engine_args.begin()); args_it != engine_args.end(); ++args_it)
+        for (auto args_it = std::next(engine_args.begin()); args_it != engine_args.end(); ++args_it)
             getKeyValueFromAST(*args_it, local_context);
 
         StorageFuzzJSON::processNamedCollectionResult(configuration, *named_collection);

--- a/src/Storages/StorageURL.cpp
+++ b/src/Storages/StorageURL.cpp
@@ -1583,7 +1583,7 @@ size_t StorageURL::evalArgsAndCollectHeaders(
 {
     ASTs::iterator headers_it = url_function_args.end();
 
-    for (auto * arg_it = url_function_args.begin(); arg_it != url_function_args.end(); ++arg_it)
+    for (auto arg_it = url_function_args.begin(); arg_it != url_function_args.end(); ++arg_it)
     {
         const auto * headers_ast_function = (*arg_it)->as<ASTFunction>();
         if (headers_ast_function && headers_ast_function->name == "headers")

--- a/src/Storages/TimeSeries/TimeSeriesDefinitionNormalizer.cpp
+++ b/src/Storages/TimeSeries/TimeSeriesDefinitionNormalizer.cpp
@@ -267,7 +267,7 @@ void TimeSeriesDefinitionNormalizer::addMissingDefaultForIDColumn(ASTCreateQuery
         return;
 
     auto & columns = create.columns_list->columns->children;
-    auto * it = std::find_if(columns.begin(), columns.end(), [](const ASTPtr & column)
+    auto it = std::find_if(columns.begin(), columns.end(), [](const ASTPtr & column)
     {
         return typeid_cast<const ASTColumnDeclaration &>(*column).name == TimeSeriesColumnNames::ID;
     });

--- a/src/TableFunctions/TableFunctionMySQL.cpp
+++ b/src/TableFunctions/TableFunctionMySQL.cpp
@@ -81,7 +81,7 @@ void TableFunctionMySQL::parseArguments(const ASTPtr & ast_function, ContextPtr 
     mysql_settings[MySQLSetting::connect_timeout] = settings[Setting::external_storage_connect_timeout_sec];
     mysql_settings[MySQLSetting::read_write_timeout] = settings[Setting::external_storage_rw_timeout_sec];
 
-    for (auto * it = args.begin(); it != args.end(); ++it)
+    for (auto it = args.begin(); it != args.end(); ++it)
     {
         const ASTSetQuery * settings_ast = (*it)->as<ASTSetQuery>();
         if (settings_ast)

--- a/src/TableFunctions/TableFunctionObjectStorage.cpp
+++ b/src/TableFunctions/TableFunctionObjectStorage.cpp
@@ -178,7 +178,7 @@ void TableFunctionObjectStorage<Definition, Configuration, is_data_lake>::parseA
     /// e.g. `s3(endpoint, ..., SETTINGS setting=value, ..., setting=value)`
     /// We do similarly for some other table functions
     /// whose storage implementation supports storage settings (for example, MySQL).
-    for (auto * it = args.begin(); it != args.end(); ++it)
+    for (auto it = args.begin(); it != args.end(); ++it)
     {
         ASTSetQuery * settings_ast = (*it)->as<ASTSetQuery>();
         if (settings_ast)

--- a/src/TableFunctions/TableFunctionYtsaurus.cpp
+++ b/src/TableFunctions/TableFunctionYtsaurus.cpp
@@ -92,7 +92,7 @@ void TableFunctionYTsaurus::parseArguments(const ASTPtr & ast_function, ContextP
 
     YTsaurusSettings yt_settings;
 
-    for (auto * it = args.begin(); it != args.end(); ++it)
+    for (auto it = args.begin(); it != args.end(); ++it)
     {
         const ASTSetQuery * settings_ast = (*it)->as<ASTSetQuery>();
         if (settings_ast)


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Reduce memory usage for AST

### Details

This was changed in https://github.com/ClickHouse/ClickHouse/pull/42284, but it makes `sizeof(IAST)` is `168` instead of `72`. 

Also, I don't see a perf difference locally (on `performance/explain_ast.xml`), so I want to recheck in CI.

```
Before

Queries executed: 113.

localhost:9000, queries: 113, QPS: 5.336, RPS: 195723.391, MiB/s: 16.682, result RPS: 195723.391, result MiB/s: 16.682.

0%		0.149 sec.	
10%		0.151 sec.	
20%		0.152 sec.	
30%		0.156 sec.	
40%		0.161 sec.	
50%		0.165 sec.	
60%		0.170 sec.	
70%		0.183 sec.	
80%		0.203 sec.	
90%		0.236 sec.	
95%		0.267 sec.	
99%		0.277 sec.	
99.9%		0.277 sec.	
99.99%		0.277 sec.	

After

localhost:9000, queries: 251, QPS: 5.831, RPS: 213865.428, MiB/s: 18.228, result RPS: 213865.428, result MiB/s: 18.228.

0%		0.148 sec.	
10%		0.149 sec.	
20%		0.150 sec.	
30%		0.151 sec.	
40%		0.152 sec.	
50%		0.155 sec.	
60%		0.160 sec.	
70%		0.164 sec.	
80%		0.173 sec.	
90%		0.187 sec.	
95%		0.217 sec.	
99%		0.272 sec.	
99.9%		0.280 sec.	
99.99%		0.280 sec.

```

