### PR TITLE
Make sure that zookeeper is finalized on shutdown

### DIFF
--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -987,6 +987,8 @@ struct ContextSharedPart : boost::noncopyable
         {
             /// Stop zookeeper connection
             std::lock_guard lock(zookeeper_mutex);
+            if (zookeeper)
+                zookeeper->finalize("shutdown");
             zookeeper.reset();
         }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Make sure that zookeeper is finalized on shutdown (fix possible hung on shutdown in very unlikely cases)

Otherwise if someone (though this should not happen) will still hold shared_ptr, then, it won't be finalized, and it will block shutdown since receive/send threads will be active.
