### PR TITLE
CI: Improve cidb link with failure filtering

### DIFF
--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -328,7 +328,7 @@ def main():
             args.test or targeted_tests or changed_test_modules,
             workers,
             args.options,
-            info
+            info,
         )
     )
 

--- a/ci/jobs/scripts/check_ci.py
+++ b/ci/jobs/scripts/check_ci.py
@@ -137,7 +137,7 @@ Test name: {test_name}
 Failure reason: {failure_reason}
 CI report: [{job_name}]({cls.get_job_report_url(pr_number, head_sha, job_name)})
 
-Failing test history: [cidb]({CIDB(url=CI_DB_READ_URL, user=CI_DB_READ_USER, passwd="").get_link_to_test_case_statistics(test_name, job_name, [failure_reason], test_output=result.info)})
+Failing test history: [cidb]({CIDB(url=CI_DB_READ_URL, user=CI_DB_READ_USER, passwd="").get_link_to_test_case_statistics(test_name, job_name, [failure_reason], test_output=result.info, pr_base_branches=['master'])})
 
 Test output:
 ```

--- a/ci/jobs/scripts/check_ci.py
+++ b/ci/jobs/scripts/check_ci.py
@@ -137,7 +137,7 @@ Test name: {test_name}
 Failure reason: {failure_reason}
 CI report: [{job_name}]({cls.get_job_report_url(pr_number, head_sha, job_name)})
 
-Failing test history: [cidb]({CIDB(url=CI_DB_READ_URL, user=CI_DB_READ_USER, passwd="").get_link_to_test_case_statistics(test_name, job_name, [failure_reason], test_output=result.info, pr_base_branches=['master'])})
+Failing test history: [cidb]({CIDB(url=CI_DB_READ_URL, user=CI_DB_READ_USER, passwd="").get_link_to_test_case_statistics(result.name, job_name, [failure_reason], test_output=result.info, pr_base_branches=['master'])})
 
 Test output:
 ```
@@ -712,22 +712,23 @@ def main():
             else:
                 unknown_failures.append((job_name, failure_result))
 
-    print("\nCI failures:")
-    if known_failures:
-        print("\n--- Known problems ---")
-        for job_name, failure in known_failures:
-            print(f"[{failure.status}] {failure.name} in {job_name}")
+    if known_failures or unknown_failures or not_finished_jobs:
+        print("\nCI failures:")
+        if known_failures:
+            print("\n--- Known problems ---")
+            for job_name, failure in known_failures:
+                print(f"[{failure.status}] {failure.name} in {job_name}")
 
-    if unknown_failures:
-        print("\n--- Unknown problems ---")
-        for job_name, failure in unknown_failures:
-            print(f"[{failure.status}] {failure.name} in {job_name}")
-            failure.set_comment("IGNORED")
+        if unknown_failures:
+            print("\n--- Unknown problems ---")
+            for job_name, failure in unknown_failures:
+                print(f"[{failure.status}] {failure.name} in {job_name}")
+                failure.set_comment("IGNORED")
 
-    if not_finished_jobs:
-        print("\n--- Not finished jobs ---")
-        for _, failure in not_finished_jobs:
-            print(f"[{failure.status}] {failure.name}")
+        if not_finished_jobs:
+            print("\n--- Not finished jobs ---")
+            for _, failure in not_finished_jobs:
+                print(f"[{failure.status}] {failure.name}")
 
     if is_master_commit:
         sys.exit(0)

--- a/ci/jobs/scripts/check_ci.py
+++ b/ci/jobs/scripts/check_ci.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+import os
 import re
 import sys
 import time
@@ -8,13 +9,15 @@ from datetime import datetime
 from typing import List, Optional
 from urllib.parse import quote
 
-sys.path.append("./")
+sys.path.append(".")
 
+from ci.praktika.cidb import CIDB
 from ci.praktika.gh import GH
 from ci.praktika.interactive import UserPrompt
 from ci.praktika.issue import Issue, IssueLabels, TestCaseIssueCatalog
 from ci.praktika.result import Result
 from ci.praktika.utils import Shell
+from ci.settings.settings import CI_DB_READ_URL, CI_DB_READ_USER, TEST_FAILURE_PATTERNS
 
 
 class CheckStatuses:
@@ -108,11 +111,18 @@ class CreateIssue:
             # Despite parameter might be valuable for failure reproduction, drop it for simplicity
             test_name = test_name.split("[")[0]
 
+        failure_reason_default = None
+        for pattern in TEST_FAILURE_PATTERNS:
+            if pattern in result.info:
+                failure_reason_default = pattern
+                break
+
         failure_reason = UserPrompt.get_string(
             "\nEnter the exact error text from the test output above that identifies the failure.\n"
             "This must be a substring from the output (e.g., 'result differs with reference', 'Client failed! Return code: 210').\n"
             "It will be used to match and group similar failures",
             validator=lambda x: x in result.info,
+            default=failure_reason_default,
         )
         if result.name.startswith("test_"):
             # pytest case
@@ -127,7 +137,7 @@ Test name: {test_name}
 Failure reason: {failure_reason}
 CI report: [{job_name}]({cls.get_job_report_url(pr_number, head_sha, job_name)})
 
-CIDB statistics: [cidb]({result.get_hlabel_link('cidb')})
+Failing test history: [cidb]({CIDB(url=CI_DB_READ_URL, user=CI_DB_READ_USER, passwd="").get_link_to_test_case_statistics(test_name, job_name, [failure_reason], test_output=result.info)})
 
 Test output:
 ```
@@ -144,7 +154,7 @@ Test output:
         body = f"""\
 Test name: {result.name}
 CI report: [{job_name}]({cls.get_job_report_url(pr_number, head_sha, job_name)})
-CIDB statistics: [cidb]({result.get_hlabel_link("cidb")})
+Failing test history: [cidb]({result.get_hlabel_link("cidb")})
 
 Test output:
 ```
@@ -759,7 +769,7 @@ def main():
             traceback.print_exc()
 
     if not UserPrompt.confirm(
-        f"Do you want to merge PR #{pr_number} (y - continue, n - exit)?"
+        f"Add PR #{pr_number} to the merge queue (y - continue, n - exit)?"
     ):
         sys.exit(0)
 
@@ -777,7 +787,19 @@ def main():
     )
 
     if Shell.check(f"gh pr merge {pr_number} --auto"):
-        print(f"PR {pr_number} auto merge has been enabled")
+        # Check if PR was successfully added to the merge queue
+        # uncomment/fix if GH misses became regular
+        # merge_status = Shell.check(
+        #     f"gh pr view {pr_number} --json mergeStateStatus -q '.mergeStateStatus'",
+        #     capture_output=True,
+        # )
+        # if merge_status != "QUEUED":
+        #     print(
+        #         f"⚠ PR #{pr_number} auto-merge enabled but merge queue status unclear [{merge_status}]. "
+        #         f"If PR is not in queue, try redoing 'Merge when ready' button on GitHub."
+        #     )
+        # else:
+        print(f"✓ PR #{pr_number} added to the merge queue")
 
 
 if __name__ == "__main__":

--- a/ci/jobs/scripts/integration_tests_configs.py
+++ b/ci/jobs/scripts/integration_tests_configs.py
@@ -925,7 +925,7 @@ def get_tests_execution_time(info: Info, job_options: str) -> dict[str, int]:
     assert info.updated_at
     start_time_filter = f"parseDateTimeBestEffort('{info.updated_at}')"
 
-    build = job_options.split(',', 1)[0]
+    build = job_options.split(",", 1)[0]
 
     query = f"""
         SELECT
@@ -966,11 +966,13 @@ def get_tests_execution_time(info: Info, job_options: str) -> dict[str, int]:
         return {}
     try:
         import json
+
         data = json.loads(res)
         return {row["file"]: int(row["file_duration_ms"]) for row in data["data"]}
     except Exception as e:
         print(f"ERROR: Failed to parse CIDB response: {e}")
         return {}
+
 
 def get_optimal_test_batch(
     tests: list[str],

--- a/ci/praktika/cidb.py
+++ b/ci/praktika/cidb.py
@@ -108,7 +108,6 @@ class CIDB:
             # Add commented placeholder for manual editing
             failure_filter = "    -- AND test_context_raw LIKE '%pattern%'  -- uncomment and edit to filter by failure pattern"
 
-        git_branch = Info().git_branch or "master"
         base_git_branch = Info().base_branch or "master"
         query = f"""\
 WITH
@@ -123,7 +122,7 @@ WHERE (now() - toIntervalDay(interval_days)) <= check_start_time
     AND test_name = '{tn}'
     -- AND check_name = '{jn}'
     AND test_status IN ('FAIL', 'ERROR')
-    AND ((pull_request_number = 0 AND head_ref = '{git_branch}') OR (pull_request_number != 0 AND base_ref = '{base_git_branch}'))
+    AND (pull_request_number = 0 OR base_ref = '{base_git_branch}')
 {failure_filter}
 GROUP BY day
 ORDER BY day DESC

--- a/ci/praktika/issue.py
+++ b/ci/praktika/issue.py
@@ -138,11 +138,11 @@ class Issue:
             return fields
 
         patterns = {
-            "test_name": r"Test name:\s*(.+?)(?:\n|$)",
-            "failure_reason": r"Failure reason:\s*(.+?)(?:\n|$)",
-            "ci_action": r"CI action:\s*(.+?)(?:\n|$)",
-            "test_pattern": r"Test pattern:\s*(.+?)(?:\n|$)",
-            "job_pattern": r"Job pattern:\s*(.+?)(?:\n|$)",
+            "test_name": r"Test name:\s*([^\n]*)",
+            "failure_reason": r"Failure reason:\s*([^\n]*)",
+            "ci_action": r"CI action:\s*([^\n]*)",
+            "test_pattern": r"Test pattern:\s*([^\n]*)",
+            "job_pattern": r"Job pattern:\s*([^\n]*)",
         }
 
         for field, pattern in patterns.items():

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -590,6 +590,10 @@ class Runner:
                                     url=Settings.CI_DB_READ_URL,
                                     user=Settings.CI_DB_READ_USER,
                                     job_name=job.name,
+                                    pr_base_branches=[
+                                        env.BASE_BRANCH,
+                                        Settings.MAIN_BRANCH,
+                                    ],
                                 ),
                             )
                     result.dump()

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -585,6 +585,8 @@ class Runner:
                                 "cidb",
                                 ci_db.get_link_to_test_case_statistics(
                                     test_case_result.name,
+                                    failure_patterns=Settings.TEST_FAILURE_PATTERNS,
+                                    test_output=test_case_result.info,
                                     url=Settings.CI_DB_READ_URL,
                                     user=Settings.CI_DB_READ_USER,
                                     job_name=job.name,

--- a/ci/praktika/settings.py
+++ b/ci/praktika/settings.py
@@ -107,6 +107,11 @@ class _Settings:
     CI_DB_READ_USER: str = ""
     CI_DB_READ_URL: str = ""
 
+    # Substrings to classify test failures. Used to generate helper queries for checking failure history.
+    # Not required to cover all failures, but recommended to maximize coverage.
+    # Choose values wisely to effectively differentiate between different failure types.
+    TEST_FAILURE_PATTERNS: Optional[List[str]] = None
+
 
 _USER_DEFINED_SETTINGS = [
     "S3_ARTIFACT_PATH",
@@ -152,6 +157,7 @@ _USER_DEFINED_SETTINGS = [
     "COMPRESS_THRESHOLD_MB",
     "CI_DB_READ_USER",
     "CI_DB_READ_URL",
+    "TEST_FAILURE_PATTERNS",
 ]
 
 

--- a/ci/settings/settings.py
+++ b/ci/settings/settings.py
@@ -62,3 +62,64 @@ READY_FOR_MERGE_CUSTOM_STATUS_NAME = "Mergeable Check"
 
 CI_DB_READ_USER = "play"
 CI_DB_READ_URL = "https://play.clickhouse.com"
+
+# Substrings used to classify and categorize test failures based on error output.
+# Use the following query to find test failures NOT covered by current patterns:
+# WITH ['Timeout', 'AssertionError', 'E   assert', 'E   Exception', 'E   NameError', 'Connection refused', 'UnboundLocalError', 'AttributeError', 'Too many retry attempts', 'E   FileNotFoundError', 'E   RuntimeError', 'Connection has been closed', 'E   Failed', 'E   ValueError', 'E   KeyError', 'InternalError', 'syntax error', 'E   TypeError', 'E   OSError', 'Code:', 'ClientError', 'QueryRuntimeException', 'Max retries exceeded with url', 'UnicodeDecodeError', 'Py4JError', 'ConnectionLoss', 'Connection reset by peer', 'Exception:', 'Failure:', 'ExistsError', 'ConnectionError', 'Client Error', 'Errno']
+# AS reasons
+# SELECT test_context_raw
+# FROM checks
+# WHERE match(test_name, '^test_')
+#   AND test_context_raw != ''
+#   AND test_status = 'FAIL'
+#   AND check_name LIKE 'Integration%'
+#   AND check_start_time > now() - INTERVAL 3 MONTH
+#   AND NOT arrayExists(
+#         r -> positionCaseInsensitive(ifNull(test_context_raw, ''), r) > 0,
+#         reasons
+#       )
+# LIMIT 100;
+TEST_FAILURE_PATTERNS = [
+    # Common Functional tests failures
+    "Timeout",
+    "having stderror",
+    "result differs with reference",
+    "return code",
+    "Test runs too long",
+    "having exception in stdout",
+    "server died",
+    "Test internal error:",
+    # Common Integration tests failures
+    "AssertionError",
+    "E   assert",
+    "E   Exception",
+    "E   NameError",
+    "Connection refused",
+    "UnboundLocalError",
+    "AttributeError",
+    "Too many retry attempts",
+    "E   FileNotFoundError",
+    "E   RuntimeError",
+    "Connection has been closed",
+    "E   Failed",
+    "E   ValueError",
+    "E   KeyError",
+    "InternalError",
+    "syntax error",
+    "E   TypeError",
+    "E   OSError",
+    "Code:",
+    "ClientError",
+    "QueryRuntimeException",
+    "Max retries exceeded with url",
+    "UnicodeDecodeError",
+    "Py4JError",
+    "ConnectionLoss",
+    "Connection reset by peer",
+    "Exception:",
+    "Failure:",
+    "ExistsError",
+    "ConnectionError",
+    "Client Error",
+    "Errno",
+]


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

---
- cidb link in PR comment and CI Report will include filter to account only failures with the substring that also included in the original failure
- list of substrings (failure patterns) is configured in ci settings
