### PR TITLE
Fix using Sparse column for TTL update

### DIFF
--- a/src/Storages/MergeTree/MergeTreeDataWriter.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataWriter.cpp
@@ -316,6 +316,8 @@ void updateTTL(
         subquery->buildSetInplace(context);
 
     auto ttl_column = ITTLAlgorithm::executeExpressionAndGetColumn(expr_and_set.expression, block, ttl_entry.result_column);
+    /// In some cases block can contain Sparse columns (for example, during direct deserialization into Sparse in input formats).
+    ttl_column = ttl_column->convertToFullColumnIfSparse();
     ColumnPtr where_column;
 
     if (ttl_entry.where_expression_ast)

--- a/tests/queries/0_stateless/03780_insert_sparse_into_ttl_column.sh
+++ b/tests/queries/0_stateless/03780_insert_sparse_into_ttl_column.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT --query="
+drop table if exists test;
+create table test (c0 Int, c1 DateTime) engine=MergeTree order by tuple() ttl c1 SETTINGS ratio_of_defaults_for_sparse_serialization = 0.001;
+insert into test (c0) select * from numbers(10);
+insert into function file(${CLICKHOUSE_TEST_UNIQUE_NAME}.csv) select * from test;
+insert into test select * from file(${CLICKHOUSE_TEST_UNIQUE_NAME}.csv);
+drop table test;
+"


### PR DESCRIPTION
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix using Sparse column for TTL update during direct deserialization into Sparse columns in some input formats. It fixes possible logical error `Unexpected type of result TTL column`.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.437`
- Backported to: `25.12.3.18`, `25.11.7.16`, `25.10.5.14`, `25.8.15.24`, `25.3.13.11`
<!-- ch-version-info:end -->