### PR TITLE
Fix style in `TokenExtractor`

### DIFF
--- a/src/Functions/ngrams.cpp
+++ b/src/Functions/ngrams.cpp
@@ -105,7 +105,7 @@ private:
             size_t token_start = 0;
             size_t token_length = 0;
 
-            while (cur < data.size() && extractor.nextInString(data.data(), data.size(), &cur, &token_start, &token_length))
+            while (cur < data.size() && extractor.nextInString(data.data(), data.size(), cur, token_start, token_length))
             {
                 result_data_column.insertData(data.data() + token_start, token_length);
                 ++current_tokens_size;

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -2689,7 +2689,7 @@ try
 }
 catch (...)
 {
-    LOG_ERROR(log, "Loading of unexpected parts failed. "
+    LOG_FATAL(log, "Loading of unexpected parts failed. "
         "Will terminate to avoid undefined behaviour due to inconsistent set of parts. "
         "Exception: {}", getCurrentExceptionMessage(true));
     std::terminate();
@@ -2789,7 +2789,7 @@ try
 }
 catch (...)
 {
-    LOG_ERROR(log, "Loading of outdated parts failed. "
+    LOG_FATAL(log, "Loading of outdated parts failed. "
         "Will terminate to avoid undefined behaviour due to inconsistent set of parts. "
         "Exception: {}", getCurrentExceptionMessage(true));
     std::terminate();

--- a/src/Storages/tests/gtest_SplitByNonAlphaTokenExtractor.cpp
+++ b/src/Storages/tests/gtest_SplitByNonAlphaTokenExtractor.cpp
@@ -62,12 +62,12 @@ TEST_P(SplitByNonAlphaTokenExtractorTest, next)
     for (const auto & expected_token : param.tokens)
     {
         SCOPED_TRACE(++i);
-        ASSERT_TRUE(token_extractor.nextInStringPadded(data->data(), data->size(), &pos, &token_start, &token_len));
+        ASSERT_TRUE(token_extractor.nextInStringPadded(data->data(), data->size(), pos, token_start, token_len));
 
         EXPECT_EQ(expected_token, std::string_view(data->data() + token_start, token_len))
                 << " token_start:" << token_start << " token_len: " << token_len;
     }
-    ASSERT_FALSE(token_extractor.nextInStringPadded(data->data(), data->size(), &pos, &token_start, &token_len))
+    ASSERT_FALSE(token_extractor.nextInStringPadded(data->data(), data->size(), pos, token_start, token_len))
             << "\n\t=> \"" << param.source.substr(token_start, token_len) << "\""
             << "\n\t" << token_start << ", " << token_len << ", " << pos << ", " << data->size();
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


It used pointers for no reason, and the code was hard to read. Replaced with references according to the ClickHouse C++ Style Guide.