### PR TITLE
Followup fix for --record in clickhouse

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -4341,6 +4341,15 @@ if __name__ == "__main__":
         print(e, file=sys.stderr)
         sys.exit(1)
 
+    # When using --record, disable engine replacement to ensure we record
+    # the original test's output, not a modified version
+    if args.record:
+        if args.replace_replicated_with_shared or args.replace_non_replicated_with_shared:
+            print("INFO: Disabling engine replacement (--replace-replicated-with-shared, --replace-non-replicated-with-shared)", file=sys.stderr)
+            print("      when using --record to ensure reference files are updated with original test output.", file=sys.stderr)
+        args.replace_replicated_with_shared = False
+        args.replace_non_replicated_with_shared = False
+
     # Collect explicit settings (if any)
     args.fixed_settings = {}
     args.fixed_merge_tree_settings = {}

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1935,6 +1935,26 @@ class TestCase:
             )
 
         if self.reference_file is None:
+            # If --record is enabled, create a new reference file
+            if self.testcase_args.record:
+                import shutil
+                # Use the same logic as get_reference_file to determine the correct path
+                name = removesuffix(self.name, ".gen")
+                # Determine the appropriate extension based on analyzer mode
+                if is_old_analyzer_used(self.testcase_args):
+                    ext = ".oldanalyzer.reference"
+                else:
+                    ext = ".reference"
+                self.reference_file = os.path.join(self.suite.suite_path, name) + ext
+                shutil.copy2(self.stdout_file, self.reference_file)
+                description += "\tReference file created\n"
+                return TestResult(
+                    self.name,
+                    TestStatus.OK,
+                    None,
+                    total_time,
+                    description,
+                )
             return TestResult(
                 self.name,
                 TestStatus.UNKNOWN,


### PR DESCRIPTION
Disable --replace-replicated-with-shared, --replace-non-replicated-with-shared
when --record is enabled, in order to replace the correct reference file.

Followup of [Support "--record" in clickhouse-test to replace reference with stdout when mismatch.](https://github.com/ClickHouse/ClickHouse/pull/93136)

--record doesn't work as expected for replicated or shared merge tree test cases, because 
--replace-replicated-with-shared is enabled by default, when running test, the original  reference will be transfered to a temp reference file.

tests/queries/0_stateless/03716_mutations_parts_postpone_reasons_smt.stdout-->
tests/queries/0_stateless/03716_mutations_parts_postpone_reasons_smt.**452736**.reference

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.13`
<!-- ch-version-info:end -->