### PR TITLE
CI: Do not extract additional git info in workflow pre hook for PRs

### DIFF
--- a/ci/jobs/scripts/workflow_hooks/store_data.py
+++ b/ci/jobs/scripts/workflow_hooks/store_data.py
@@ -57,23 +57,23 @@ if __name__ == "__main__":
                 )
         info.store_kv_data("file_diff", file_diff)
 
-    # store commit sha of release branch base to find binary for performance comparison in the job script later
-    # if info.git_branch == "master" and info.repo_name == "ClickHouse/ClickHouse":
-    release_branch_base_sha = CHVersion.get_release_version_as_dict().get("githash")
-    print(f"Release branch base sha: {release_branch_base_sha}")
-    assert release_branch_base_sha
-    release_branch_base_sha_with_predecessors = [
-        s.strip()
-        for s in Shell.get_output(
-            f"git rev-list --max-count=20 {release_branch_base_sha}", verbose=True
-        ).splitlines()
-    ]
-    assert all(len(s) == 40 for s in release_branch_base_sha_with_predecessors)
-    assert release_branch_base_sha_with_predecessors[0] == release_branch_base_sha
-    info.store_kv_data(
-        "release_branch_base_sha_with_predecessors",
-        release_branch_base_sha_with_predecessors,
-    )
-    print(
-        f"Found base commit sha for latest release branch with its predecessors: [{release_branch_base_sha_with_predecessors}]"
-    )
+    elif info.git_branch == "master" and info.repo_name == "ClickHouse/ClickHouse":
+        # store commit sha of release branch base to find binary for performance comparison in the job script later
+        release_branch_base_sha = CHVersion.get_release_version_as_dict().get("githash")
+        print(f"Release branch base sha: {release_branch_base_sha}")
+        assert release_branch_base_sha
+        release_branch_base_sha_with_predecessors = [
+            s.strip()
+            for s in Shell.get_output(
+                f"git rev-list --max-count=20 {release_branch_base_sha}", verbose=True
+            ).splitlines()
+        ]
+        assert all(len(s) == 40 for s in release_branch_base_sha_with_predecessors)
+        assert release_branch_base_sha_with_predecessors[0] == release_branch_base_sha
+        info.store_kv_data(
+            "release_branch_base_sha_with_predecessors",
+            release_branch_base_sha_with_predecessors,
+        )
+        print(
+            f"Found base commit sha for latest release branch with its predecessors: [{release_branch_base_sha_with_predecessors}]"
+        )


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

----
Sometimes git/gh operations in workflow pre-hooks fail in the CI with the failure:
```
[2026-01-07 17:57:23] Run command: [git rev-parse --is-shallow-repository | grep -q true && git fetch --unshallow --prune --no-recurse-submodules --filter=tree:0 origin HEAD ||:]
[2026-01-07 17:57:23] fatal: could not read Username for 'https://github.com': No such device or address
```
it's to be investigated.

For now remove unnecessary git commands in the pre-hook in PRs to decrease the impact.


