### PR TITLE
CI: Fix previous failures query in targeted job

### DIFF
--- a/ci/jobs/scripts/check_ci.py
+++ b/ci/jobs/scripts/check_ci.py
@@ -152,6 +152,8 @@ Test output:
 ```
 """
         labels = [IssueLabels.CI_ISSUE, IssueLabels.FUZZ]
+        if "sanitizer" in result.name.lower():
+            labels.append(IssueLabels.SANITIZER)
 
         return cls.create_and_link_gh_issue(title, body, labels)
 

--- a/ci/praktika/issue.py
+++ b/ci/praktika/issue.py
@@ -88,6 +88,7 @@ class IssueLabels:
     FLAKY_TEST = "flaky test"
     FUZZ = "fuzz"
     INFRASTRUCTURE = "infrastructure"
+    SANITIZER = "sanitizer"
 
 
 @dataclass


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

---
- Integration test targeted job had a bug in the query for previous failures search
- check ci minor improvment: add label "sanitizer" for sanitizer gh issues
