### PR TITLE
Check `SHOW COLUMNS` permission in `merge`  table function

### DIFF
--- a/src/Storages/StorageMerge.cpp
+++ b/src/Storages/StorageMerge.cpp
@@ -228,9 +228,11 @@ ColumnsDescription StorageMerge::getColumnsDescriptionFromSourceTablesImpl(
         if (!t)
             return false;
 
-        if (auto id = t->getStorageID(); !access->isGranted(AccessType::SHOW_TABLES, id.database_name, id.table_name))
+        const auto storage_id = t->getStorageID();
+        if (!access->isGranted(AccessType::SHOW_TABLES, storage_id.database_name, storage_id.table_name))
             return false;
 
+        access->checkAccess(AccessType::SHOW_COLUMNS, storage_id.database_name, storage_id.table_name);
         auto structure = t->getInMemoryMetadataPtr()->getColumns();
         String prev_column_name;
         for (const ColumnDescription & column : structure)

--- a/tests/integration/test_table_functions_access_rights/test.py
+++ b/tests/integration/test_table_functions_access_rights/test.py
@@ -36,7 +36,8 @@ def cleanup_after_test():
 
 
 def test_merge():
-    select_query = "SELECT * FROM merge('default', 'table[0-9]+') ORDER BY x"
+    merge_spec = "merge('default', 'table[0-9]+')"
+    select_query = f"SELECT * FROM {merge_spec} ORDER BY x"
     assert instance.query(select_query) == "1\n2\n"
 
     instance.query("CREATE USER A")
@@ -61,6 +62,20 @@ def test_merge():
         "it's necessary to have the grant SELECT(x) ON default.table2"
         in instance.query_and_get_error(select_query, user="A")
     )
+
+    instance.query("REVOKE ALL ON default.* FROM A")
+    describe_query = f"DESCRIBE TABLE {merge_spec}"
+    assert (
+        "Either there is no database, which matches regular expression `default`, or there are no tables in the database matches `default`, which fit tables expression: table[0-9]+"
+        in instance.query_and_get_error(describe_query, user="A")
+    )
+    instance.query("GRANT SHOW TABLES ON default.table1 TO A")
+    assert (
+        "it's necessary to have the grant SHOW COLUMNS ON default.table1"
+        in instance.query_and_get_error(describe_query, user="A")
+    )
+    instance.query("GRANT SHOW COLUMNS ON default.table1 TO A")
+    assert instance.query(describe_query) == "x\tUInt32\t\t\t\t\t\n"
 
 
 def test_view_if_permitted():


### PR DESCRIPTION
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Prevent users to get the list of columns from a table without checking `SHOW COLUMNS` permission using the `merge` table engine.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.392`
- Backported to: `25.12.3.15`, `25.11.7.15`, `25.10.5.12`, `25.8.15.12`, `25.3.13.8`
<!-- ch-version-info:end -->