### PR TITLE
Add cpu_time to http summary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- `src/` contains the C++ engine; `base/` hosts shared utilities; `programs/` builds the unified `clickhouse` binary (server and client tools).
+- `contrib/` vendors third-party libraries; `cmake/` holds build modules; `rust/` contains optional Rust components.
+- Tests live in `tests/` (functional and integration); documentation in `docs/`; performance tools in `benchmark/`; helper scripts in `utils/`; container and packaging assets in `docker/` and `packages/`.
+
+## Build, Test, and Development Commands
+- Configure debug build: `cmake -S . -B build_debug -D CMAKE_BUILD_TYPE=Debug`.
+- Build server/client: `cmake --build build_debug --target clickhouse` (or `ninja -C build_debug clickhouse`).
+- Build everything (tests/tools): `cmake --build build_debug`.
+- Run the server locally: `./build_debug/programs/clickhouse server --config-file programs/server/config.xml`.
+- Run a specific functional test: `PATH=build_debug/programs:$PATH tests/clickhouse-test <pattern>`.
+
+## Coding Style & Naming Conventions
+- C++ style enforced by `.clang-format`: 4-space indents, braces on separate lines, spaces around binary operators; follow surrounding code.
+- Prefer `const` before the type, `using` aliases for templates, and logical grouping of headers/implementations.
+- Run `utils/check-style` and format only touched hunks to keep diffs focused; codespell catches typos.
+
+## Testing Guidelines
+- Functional SQL tests reside in `tests/queries/0_stateless`; use five-digit prefixes with descriptive slugs (e.g., `01428_feature.sql`) and generate matching `.reference` outputs.
+- Integration and other suites sit under `tests/`; prefer `.sql` over `.sh` unless shell behavior is required.
+- Clean up artifacts under the `test` database; tag tests (`-- Tags: no-fasttest`, etc.) when special CI handling is needed.
+
+## Commit & Pull Request Guidelines
+- Commit subjects are short and imperative (e.g., `Fix .reference`, `Add cpu time to summary`); keep scope focused.
+- Use feature branches; include brief PR descriptions, expected behavior, test coverage, and links to issues. Add documentation updates for user-facing changes.
+- Sign the Individual CLA on first contribution. Avoid formatting-only churn; keep changes minimal and intentional.
+
+## Security & Configuration Tips
+- The server looks for `config.xml` in the working directory; override with `-C`/`--config-file` when needed.
+- Explicitly set `CC`/`CXX` if multiple compilers are installed. Keep build directories separate (e.g., `build_debug`, `build_release`) to avoid cross-contamination.

--- a/docs/en/operations/monitoring.md
+++ b/docs/en/operations/monitoring.md
@@ -59,6 +59,16 @@ ClickHouse server has embedded instruments for self-state monitoring.
 
 To track server events use server logs. See the [logger](../operations/server-configuration-parameters/settings.md#logger) section of the configuration file.
 
+## HTTP progress headers {#http-progress-headers}
+
+When running queries over HTTP with `send_progress_in_http_headers=1`, ClickHouse emits `X-ClickHouse-Progress` during execution and a final `X-ClickHouse-Summary`. These JSON payloads mirror query log statistics, including `read_rows`, `read_bytes`, `result_rows`, `result_bytes`, `memory_usage`, `elapsed_ns`, and `cpu_time_us` (user + system CPU time in microseconds). Example:
+
+```
+< X-ClickHouse-Summary: {"read_rows":"10","read_bytes":"80","result_rows":"10","result_bytes":"1360","cpu_time_us":"12345","memory_usage":"0"}
+```
+
+You can consume these headers in clients to track progress without polling system tables.
+
 ClickHouse collects:
 
 - Different metrics of how the server uses computational resources.

--- a/src/Core/ProtocolDefines.h
+++ b/src/Core/ProtocolDefines.h
@@ -90,6 +90,9 @@ static constexpr auto DBMS_MIN_REVISION_WITH_SPARSE_SERIALIZATION = 54465;
 
 static constexpr auto DBMS_MIN_REVISION_WITH_SSH_AUTHENTICATION = 54466;
 
+/// The server will send query CPU time in the Progress packet.
+static constexpr auto DBMS_MIN_PROTOCOL_VERSION_WITH_CPU_TIME_IN_PROGRESS = 54484;
+
 /// Send read-only flag for Replicated tables as well
 static constexpr auto DBMS_MIN_REVISION_WITH_TABLE_READ_ONLY_CHECK = 54467;
 
@@ -132,5 +135,5 @@ static constexpr auto DBMS_MIN_REVISION_WITH_NULLABLE_SPARSE_SERIALIZATION = 544
 /// NOTE: DBMS_TCP_PROTOCOL_VERSION has nothing common with VERSION_REVISION,
 /// later is just a number for server version (one number instead of commit SHA)
 /// for simplicity (sometimes it may be more convenient in some use cases).
-static constexpr auto DBMS_TCP_PROTOCOL_VERSION = 54483;
+static constexpr auto DBMS_TCP_PROTOCOL_VERSION = 54484;
 }

--- a/src/IO/Progress.cpp
+++ b/src/IO/Progress.cpp
@@ -112,6 +112,7 @@ void ProgressValues::writeJSON(WriteBuffer & out, bool write_zero_values) const
     write("\"result_rows\"", result_rows);
     write("\"result_bytes\"", result_bytes);
     write("\"elapsed_ns\"", elapsed_ns);
+    write("\"cpu_time_us\"", cpu_time_us);
     write("\"memory_usage\"", memory_usage);
     writeCString("}", out);
 }
@@ -131,6 +132,8 @@ bool Progress::incrementPiecewiseAtomically(const Progress & rhs)
     result_bytes += rhs.result_bytes;
 
     elapsed_ns += rhs.elapsed_ns;
+
+    cpu_time_us += rhs.cpu_time_us;
 
     memory_usage += rhs.memory_usage;
 
@@ -153,6 +156,8 @@ void Progress::reset()
 
     elapsed_ns = 0;
 
+    cpu_time_us = 0;
+
     memory_usage = 0;
 }
 
@@ -173,6 +178,8 @@ ProgressValues Progress::getValues() const
     res.result_bytes = result_bytes.load(std::memory_order_relaxed);
 
     res.elapsed_ns = elapsed_ns.load(std::memory_order_relaxed);
+
+    res.cpu_time_us = cpu_time_us.load(std::memory_order_relaxed);
 
     res.memory_usage = memory_usage.load(std::memory_order_relaxed);
 
@@ -197,6 +204,8 @@ ProgressValues Progress::fetchValuesAndResetPiecewiseAtomically()
 
     res.elapsed_ns = elapsed_ns.fetch_and(0);
 
+    res.cpu_time_us = cpu_time_us.fetch_and(0);
+
     res.memory_usage = memory_usage.fetch_and(0);
 
     return res;
@@ -220,6 +229,8 @@ Progress Progress::fetchAndResetPiecewiseAtomically()
 
     res.elapsed_ns = elapsed_ns.fetch_and(0);
 
+    res.cpu_time_us = cpu_time_us.fetch_and(0);
+
     res.memory_usage = memory_usage.fetch_and(0);
 
     return res;
@@ -240,6 +251,8 @@ Progress & Progress::operator=(Progress && other) noexcept
     result_bytes = other.result_bytes.load(std::memory_order_relaxed);
 
     elapsed_ns = other.elapsed_ns.load(std::memory_order_relaxed);
+
+    cpu_time_us = other.cpu_time_us.load(std::memory_order_relaxed);
 
     memory_usage = other.memory_usage.load(std::memory_order_relaxed);
 

--- a/src/IO/Progress.cpp
+++ b/src/IO/Progress.cpp
@@ -54,6 +54,10 @@ void ProgressValues::read(ReadBuffer & in, UInt64 server_revision)
     {
         readVarUInt(elapsed_ns, in);
     }
+    if (server_revision >= DBMS_MIN_PROTOCOL_VERSION_WITH_CPU_TIME_IN_PROGRESS)
+    {
+        readVarUInt(cpu_time_us, in);
+    }
 }
 
 
@@ -80,6 +84,10 @@ void ProgressValues::write(WriteBuffer & out, UInt64 client_revision) const
     if (client_revision >= DBMS_MIN_PROTOCOL_VERSION_WITH_SERVER_QUERY_TIME_IN_PROGRESS)
     {
         writeVarUInt(elapsed_ns, out);
+    }
+    if (client_revision >= DBMS_MIN_PROTOCOL_VERSION_WITH_CPU_TIME_IN_PROGRESS)
+    {
+        writeVarUInt(cpu_time_us, out);
     }
 }
 
@@ -273,6 +281,8 @@ void Progress::read(ReadBuffer & in, UInt64 server_revision)
     written_bytes.store(values.written_bytes, std::memory_order_relaxed);
 
     elapsed_ns.store(values.elapsed_ns, std::memory_order_relaxed);
+
+    cpu_time_us.store(values.cpu_time_us, std::memory_order_relaxed);
 
     memory_usage.store(values.memory_usage, std::memory_order_relaxed);
 }

--- a/src/IO/Progress.h
+++ b/src/IO/Progress.h
@@ -29,6 +29,8 @@ struct ProgressValues
 
     UInt64 elapsed_ns = 0;
 
+    UInt64 cpu_time_us = 0;
+
     Int64 memory_usage = 0;
 
     void read(ReadBuffer & in, UInt64 server_revision);
@@ -60,10 +62,11 @@ struct ResultProgress
 {
     UInt64 result_rows = 0;
     UInt64 result_bytes = 0;
+    UInt64 cpu_time_us = 0;
     Int64 memory_usage = 0;
 
-    ResultProgress(UInt64 result_rows_, UInt64 result_bytes_, Int64 memory_usage_)
-        : result_rows(result_rows_), result_bytes(result_bytes_), memory_usage(memory_usage_) {}
+    ResultProgress(UInt64 result_rows_, UInt64 result_bytes_, Int64 memory_usage_, UInt64 cpu_time_us_ = 0)
+        : result_rows(result_rows_), result_bytes(result_bytes_), cpu_time_us(cpu_time_us_), memory_usage(memory_usage_) {}
 };
 
 struct FileProgress
@@ -99,6 +102,8 @@ struct Progress
 
     std::atomic<UInt64> elapsed_ns {0};
 
+    std::atomic<UInt64> cpu_time_us {0};
+
     std::atomic<Int64> memory_usage {0};
 
     Progress() = default;
@@ -113,7 +118,10 @@ struct Progress
         : written_rows(write_progress.written_rows), written_bytes(write_progress.written_bytes) {}
 
     explicit Progress(ResultProgress result_progress)
-        : result_rows(result_progress.result_rows), result_bytes(result_progress.result_bytes), memory_usage(result_progress.memory_usage) {}
+        : result_rows(result_progress.result_rows)
+        , result_bytes(result_progress.result_bytes)
+        , cpu_time_us(result_progress.cpu_time_us)
+        , memory_usage(result_progress.memory_usage) {}
 
     explicit Progress(FileProgress file_progress)
         : read_bytes(file_progress.read_bytes), total_bytes_to_read(file_progress.total_bytes_to_read) {}

--- a/tests/queries/0_stateless/00416_pocopatch_progress_in_http_headers.sh
+++ b/tests/queries/0_stateless/00416_pocopatch_progress_in_http_headers.sh
@@ -12,7 +12,7 @@ result=""
 lines_expected=5
 counter=0
 while [ $counter -lt $RETRIES ] && [ "$(echo "$result" | wc -l)" != "$lines_expected" ]; do
-    result=$(${CLICKHOUSE_CURL} -vsS "${CLICKHOUSE_URL}&output_format_parallel_formatting=0&max_block_size=5&send_progress_in_http_headers=1&http_headers_progress_interval_ms=0" -d 'SELECT max(number) FROM numbers(10)' 2>&1 | grep -E 'Content-Encoding|X-ClickHouse-Progress|X-ClickHouse-Summary|^[0-9]' | grep -v 'Access-Control-Expose-Headers' | sed 's/,\"elapsed_ns[^}]*//')
+    result=$(${CLICKHOUSE_CURL} -vsS "${CLICKHOUSE_URL}&output_format_parallel_formatting=0&max_block_size=5&send_progress_in_http_headers=1&http_headers_progress_interval_ms=0" -d 'SELECT max(number) FROM numbers(10)' 2>&1 | grep -E 'Content-Encoding|X-ClickHouse-Progress|X-ClickHouse-Summary|^[0-9]' | grep -v 'Access-Control-Expose-Headers' | sed -E 's/,\"elapsed_ns[^}]*//;s/,\"cpu_time_us[^}]*//')
     let counter=counter+1
 done
 echo "&output_format_parallel_formatting=0&max_block_size=5&send_progress_in_http_headers=1&http_headers_progress_interval_ms=0"
@@ -22,7 +22,7 @@ result=""
 lines_expected=5
 counter=0
 while [ $counter -lt $RETRIES ] && [ "$(echo "$result" | wc -l)" != "$lines_expected" ]; do
-    result=$(${CLICKHOUSE_CURL} -vsS "${CLICKHOUSE_URL}&output_format_parallel_formatting=1&max_block_size=5&send_progress_in_http_headers=1&http_headers_progress_interval_ms=0" -d 'SELECT max(number) FROM numbers(10)' 2>&1 | grep -E 'Content-Encoding|X-ClickHouse-Progress|X-ClickHouse-Summary|^[0-9]' | grep -v 'Access-Control-Expose-Headers' | sed 's/,\"elapsed_ns[^}]*//')
+    result=$(${CLICKHOUSE_CURL} -vsS "${CLICKHOUSE_URL}&output_format_parallel_formatting=1&max_block_size=5&send_progress_in_http_headers=1&http_headers_progress_interval_ms=0" -d 'SELECT max(number) FROM numbers(10)' 2>&1 | grep -E 'Content-Encoding|X-ClickHouse-Progress|X-ClickHouse-Summary|^[0-9]' | grep -v 'Access-Control-Expose-Headers' | sed -E 's/,\"elapsed_ns[^}]*//;s/,\"cpu_time_us[^}]*//')
     let counter=counter+1
 done
 echo "&output_format_parallel_formatting=1&max_block_size=5&send_progress_in_http_headers=1&http_headers_progress_interval_ms=0"
@@ -32,7 +32,7 @@ result=""
 lines_expected=22
 counter=0
 while [ $counter -lt $RETRIES ] && [ "$(echo "$result" | wc -l)" != "$lines_expected" ]; do
-    result=$(${CLICKHOUSE_CURL} -vsS "${CLICKHOUSE_URL}&max_block_size=1&send_progress_in_http_headers=1&http_headers_progress_interval_ms=0" -d 'SELECT number FROM numbers(10)' 2>&1 | grep -E 'Content-Encoding|X-ClickHouse-Progress|X-ClickHouse-Summary|^[0-9]' | grep -v 'Access-Control-Expose-Headers' | sed 's/,\"elapsed_ns[^}]*//')
+    result=$(${CLICKHOUSE_CURL} -vsS "${CLICKHOUSE_URL}&max_block_size=1&send_progress_in_http_headers=1&http_headers_progress_interval_ms=0" -d 'SELECT number FROM numbers(10)' 2>&1 | grep -E 'Content-Encoding|X-ClickHouse-Progress|X-ClickHouse-Summary|^[0-9]' | grep -v 'Access-Control-Expose-Headers' | sed -E 's/,\"elapsed_ns[^}]*//;s/,\"cpu_time_us[^}]*//')
     let counter=counter+1
 done
 echo "&max_block_size=1&send_progress_in_http_headers=1&http_headers_progress_interval_ms=0"
@@ -59,7 +59,7 @@ ${CLICKHOUSE_CURL} -vsS "${CLICKHOUSE_URL}" -H 'Accept-Encoding: gzip' -d 'CREAT
 result=""
 counter=0
 while [ $counter -lt $RETRIES ] && [ -z "$result" ]; do
-    result=$(${CLICKHOUSE_CURL} -vsS "${CLICKHOUSE_URL}&max_block_size=1&http_headers_progress_interval_ms=0&send_progress_in_http_headers=1" -d 'INSERT INTO insert_number_query (record) SELECT number FROM system.numbers LIMIT 10' 2>&1 | grep -E 'Content-Encoding|X-ClickHouse-Summary|^[0-9]' | grep -v 'Access-Control-Expose-Headers' | sed 's/,\"elapsed_ns[^}]*//')
+    result=$(${CLICKHOUSE_CURL} -vsS "${CLICKHOUSE_URL}&max_block_size=1&http_headers_progress_interval_ms=0&send_progress_in_http_headers=1" -d 'INSERT INTO insert_number_query (record) SELECT number FROM system.numbers LIMIT 10' 2>&1 | grep -E 'Content-Encoding|X-ClickHouse-Summary|^[0-9]' | grep -v 'Access-Control-Expose-Headers' | sed -E 's/,\"elapsed_ns[^}]*//;s/,\"cpu_time_us[^}]*//')
     let counter=counter+1
 done
 echo "$result"

--- a/tests/queries/0_stateless/02136_scalar_progress.sh
+++ b/tests/queries/0_stateless/02136_scalar_progress.sh
@@ -4,4 +4,4 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
-$CLICKHOUSE_CURL -sS "${CLICKHOUSE_URL}&http_wait_end_of_query=1&send_progress_in_http_headers=1&http_headers_progress_interval_ms=0" -d "SELECT (SELECT max(number), count(number) FROM numbers(100000) settings max_block_size=65505);" -v 2>&1 | grep -E "X-ClickHouse-Summary|X-ClickHouse-Progress" | sed 's/,\"elapsed_ns[^}]*//'
+$CLICKHOUSE_CURL -sS "${CLICKHOUSE_URL}&http_wait_end_of_query=1&send_progress_in_http_headers=1&http_headers_progress_interval_ms=0" -d "SELECT (SELECT max(number), count(number) FROM numbers(100000) settings max_block_size=65505);" -v 2>&1 | grep -E "X-ClickHouse-Summary|X-ClickHouse-Progress" | sed -E 's/,\"elapsed_ns[^}]*//;s/,\"cpu_time_us[^}]*//'

--- a/tests/queries/0_stateless/02373_progress_contain_result.sh
+++ b/tests/queries/0_stateless/02373_progress_contain_result.sh
@@ -6,4 +6,4 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 echo 'SELECT 1 FROM numbers(100)' |
   ${CLICKHOUSE_CURL_COMMAND} -vsS "${CLICKHOUSE_URL}&http_wait_end_of_query=1&send_progress_in_http_headers=0" --data-binary @- 2>&1 |
-  grep 'X-ClickHouse-Summary' | sed 's/,\"elapsed_ns[^}]*//'
+  grep 'X-ClickHouse-Summary' | sed -E 's/,\"elapsed_ns[^}]*//;s/,\"cpu_time_us[^}]*//'

--- a/tests/queries/0_stateless/02423_insert_summary_behaviour.sh
+++ b/tests/queries/0_stateless/02423_insert_summary_behaviour.sh
@@ -11,11 +11,11 @@ $CLICKHOUSE_CLIENT -q "CREATE MATERIALIZED VIEW floats_to_target TO target_1 AS 
 $CLICKHOUSE_CLIENT -q "CREATE MATERIALIZED VIEW floats_to_target_2 TO target_2 AS SELECT v FROM floats, numbers(2) n"
 
 echo "No materialized views"
-${CLICKHOUSE_CURL} "${CLICKHOUSE_URL}&http_wait_end_of_query=1&query=INSERT+INTO+target_1" -d "VALUES(1.0)" -v 2>&1 | grep 'X-ClickHouse-Summary' | sed 's/,\"elapsed_ns[^}]*//'
-$CLICKHOUSE_LOCAL -q "SELECT number::Float64 AS v FROM numbers(10)" --format Native | ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&http_wait_end_of_query=1&query=INSERT+INTO+target_1+FORMAT+Native" --data-binary @- -v 2>&1 | grep 'X-ClickHouse-Summary' | sed 's/,\"elapsed_ns[^}]*//'
-$CLICKHOUSE_LOCAL -q "SELECT number::Float64 AS v FROM numbers(10)" --format RowBinary | ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&http_wait_end_of_query=1&query=INSERT+INTO+target_1+FORMAT+RowBinary" --data-binary @- -v 2>&1 | grep 'X-ClickHouse-Summary' | sed 's/,\"elapsed_ns[^}]*//'
+${CLICKHOUSE_CURL} "${CLICKHOUSE_URL}&http_wait_end_of_query=1&query=INSERT+INTO+target_1" -d "VALUES(1.0)" -v 2>&1 | grep 'X-ClickHouse-Summary' | sed -E 's/,\"elapsed_ns[^}]*//;s/,\"cpu_time_us[^}]*//'
+$CLICKHOUSE_LOCAL -q "SELECT number::Float64 AS v FROM numbers(10)" --format Native | ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&http_wait_end_of_query=1&query=INSERT+INTO+target_1+FORMAT+Native" --data-binary @- -v 2>&1 | grep 'X-ClickHouse-Summary' | sed -E 's/,\"elapsed_ns[^}]*//;s/,\"cpu_time_us[^}]*//'
+$CLICKHOUSE_LOCAL -q "SELECT number::Float64 AS v FROM numbers(10)" --format RowBinary | ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&http_wait_end_of_query=1&query=INSERT+INTO+target_1+FORMAT+RowBinary" --data-binary @- -v 2>&1 | grep 'X-ClickHouse-Summary' | sed -E 's/,\"elapsed_ns[^}]*//;s/,\"cpu_time_us[^}]*//'
 
 echo "With materialized views"
-${CLICKHOUSE_CURL} "${CLICKHOUSE_URL}&http_wait_end_of_query=1&query=INSERT+INTO+floats" -d "VALUES(1.0)" -v 2>&1 | grep 'X-ClickHouse-Summary' | sed 's/,\"elapsed_ns[^}]*//'
-$CLICKHOUSE_LOCAL -q "SELECT number::Float64 AS v FROM numbers(10)" --format Native | ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&http_wait_end_of_query=1&query=INSERT+INTO+floats+FORMAT+Native" --data-binary @- -v 2>&1 | grep 'X-ClickHouse-Summary' | sed 's/,\"elapsed_ns[^}]*//'
-$CLICKHOUSE_LOCAL -q "SELECT number::Float64 AS v FROM numbers(10)" --format RowBinary | ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&http_wait_end_of_query=1&query=INSERT+INTO+floats+FORMAT+RowBinary" --data-binary @- -v 2>&1 | grep 'X-ClickHouse-Summary' | sed 's/,\"elapsed_ns[^}]*//'
+${CLICKHOUSE_CURL} "${CLICKHOUSE_URL}&http_wait_end_of_query=1&query=INSERT+INTO+floats" -d "VALUES(1.0)" -v 2>&1 | grep 'X-ClickHouse-Summary' | sed -E 's/,\"elapsed_ns[^}]*//;s/,\"cpu_time_us[^}]*//'
+$CLICKHOUSE_LOCAL -q "SELECT number::Float64 AS v FROM numbers(10)" --format Native | ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&http_wait_end_of_query=1&query=INSERT+INTO+floats+FORMAT+Native" --data-binary @- -v 2>&1 | grep 'X-ClickHouse-Summary' | sed -E 's/,\"elapsed_ns[^}]*//;s/,\"cpu_time_us[^}]*//'
+$CLICKHOUSE_LOCAL -q "SELECT number::Float64 AS v FROM numbers(10)" --format RowBinary | ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&http_wait_end_of_query=1&query=INSERT+INTO+floats+FORMAT+RowBinary" --data-binary @- -v 2>&1 | grep 'X-ClickHouse-Summary' | sed -E 's/,\"elapsed_ns[^}]*//;s/,\"cpu_time_us[^}]*//'

--- a/tests/queries/0_stateless/02457_insert_select_progress_http.sh
+++ b/tests/queries/0_stateless/02457_insert_select_progress_http.sh
@@ -5,5 +5,5 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../shell_config.sh
 
 ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&send_progress_in_http_headers=1&http_headers_progress_interval_ms=0" -d @- <<< "insert into function null('_ Int') select * from numbers(5) settings max_block_size=1, max_insert_threads=1" -v |& {
-    grep -F -e X-ClickHouse-Progress: -e X-ClickHouse-Summary:  | sed 's/,\"elapsed_ns[^}]*//'
+    grep -F -e X-ClickHouse-Progress: -e X-ClickHouse-Summary:  | sed -E 's/,\"elapsed_ns[^}]*//;s/,\"cpu_time_us[^}]*//'
 }

--- a/tests/queries/0_stateless/03272_json_with_progress.sh
+++ b/tests/queries/0_stateless/03272_json_with_progress.sh
@@ -4,4 +4,4 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
-$CLICKHOUSE_CURL -sS "$CLICKHOUSE_URL&http_wait_end_of_query=0&http_response_buffer_size=0" -d "SELECT number FROM system.numbers WHERE number % 1234567890 = 1 SETTINGS max_block_size = 100000, max_rows_to_read = 0, max_bytes_to_read = 0, interactive_delay = 0 FORMAT JSONEachRowWithProgress" 2>/dev/null | head -n10 | sed -r -e 's/,?"elapsed_ns":"[0-9]+"//'
+$CLICKHOUSE_CURL -sS "$CLICKHOUSE_URL&http_wait_end_of_query=0&http_response_buffer_size=0" -d "SELECT number FROM system.numbers WHERE number % 1234567890 = 1 SETTINGS max_block_size = 100000, max_rows_to_read = 0, max_bytes_to_read = 0, interactive_delay = 0 FORMAT JSONEachRowWithProgress" 2>/dev/null | head -n10 | sed -r -e 's/,?"elapsed_ns":"[0-9]+"//' -e 's/,?"cpu_time_us":"[0-9]+"//'

--- a/tests/queries/0_stateless/03784_cpu_time_in_http_summary.reference
+++ b/tests/queries/0_stateless/03784_cpu_time_in_http_summary.reference
@@ -1,0 +1,1 @@
+"cpu_time_us":"<num>"

--- a/tests/queries/0_stateless/03784_cpu_time_in_http_summary.sh
+++ b/tests/queries/0_stateless/03784_cpu_time_in_http_summary.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# Ensure HTTP summary headers include CPU time (value normalized to placeholder).
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&send_progress_in_http_headers=1&http_headers_progress_interval_ms=0&http_wait_end_of_query=1" -d "SELECT 1" -v 2>&1 |
+  grep 'X-ClickHouse-Summary' |
+  grep -o '"cpu_time_us":"[0-9]*"' |
+  sed -E 's/[0-9]+/<num>/'


### PR DESCRIPTION
## Summary

  Add CPU time (user + system time in microseconds) to HTTP progress headers (X-ClickHouse-Progress and X-ClickHouse-Summary) and the native protocol Progress packet.

## Test plan

  - New test 03784_cpu_time_in_http_summary.sh verifies cpu_time_us field appears in X-ClickHouse-Summary header
  - Existing HTTP header progress tests updated to include cpu_time_us field

  ---
## Changelog category (leave one):

  - New Feature

## Changelog entry

  Added cpu_time_us field to HTTP progress headers (X-ClickHouse-Progress and X-ClickHouse-Summary) and native protocol Progress packets, reporting total CPU time (user + system) consumed by the query in microseconds.

## Documentation entry for user-facing changes

  - Documentation is written (mandatory for new features)

  The documentation has been added to docs/en/operations/monitoring.md under a new "HTTP progress headers" section, explaining:
  - The cpu_time_us field reports user + system CPU time in microseconds
  - Example of the X-ClickHouse-Summary header format with the new field
  - How clients can consume these headers to track query progress