### PR TITLE
Fix use-after-free in dictionaries

### DIFF
--- a/src/Dictionaries/CacheDictionary.cpp
+++ b/src/Dictionaries/CacheDictionary.cpp
@@ -646,11 +646,11 @@ void CacheDictionary<dictionary_key_type>::update(CacheDictionaryUpdateUnitPtr<d
 
             Columns fetched_columns_during_update = fetch_request.makeAttributesResultColumnsNonMutable();
 
-            DictionaryPipelineExecutor executor(io.pipeline, configuration.use_async_executor);
-            io.pipeline.setConcurrencyControl(false);
-
             io.executeWithCallbacks([&]()
             {
+                DictionaryPipelineExecutor executor(io.pipeline, configuration.use_async_executor);
+                io.pipeline.setConcurrencyControl(false);
+
                 Block block;
                 while (executor.pull(block))
                 {

--- a/src/Dictionaries/DictionaryHelpers.h
+++ b/src/Dictionaries/DictionaryHelpers.h
@@ -594,10 +594,10 @@ Block mergeBlockWithPipe(
 
     auto result_fetched_columns = block_to_update.cloneEmptyColumns();
 
-    PullingPipelineExecutor executor(io.pipeline);
-
     io.executeWithCallbacks([&]()
     {
+        PullingPipelineExecutor executor(io.pipeline);
+
         Block block;
         while (executor.pull(block))
         {

--- a/src/Dictionaries/DirectDictionary.cpp
+++ b/src/Dictionaries/DirectDictionary.cpp
@@ -90,15 +90,15 @@ Columns DirectDictionary<dictionary_key_type>::getColumns(
 
     BlockIO io = loadKeys(requested_keys, key_columns);
 
-    QueryPipeline pipeline(getSourcePipe(io.pipeline, use_async_executor));
-    PullingPipelineExecutor executor(pipeline);
-
     Stopwatch watch;
     size_t block_num = 0;
     size_t rows_num = 0;
 
     io.executeWithCallbacks([&]()
     {
+        QueryPipeline pipeline(getSourcePipe(io.pipeline, use_async_executor));
+        PullingPipelineExecutor executor(pipeline);
+
         Block block;
         while (executor.pull(block))
         {
@@ -262,13 +262,13 @@ ColumnUInt8::Ptr DirectDictionary<dictionary_key_type>::hasKeys(
 
     BlockIO io = loadKeys(requested_keys, key_columns);
 
-    QueryPipeline pipeline(getSourcePipe(io.pipeline, use_async_executor));
-    PullingPipelineExecutor executor(pipeline);
-
     size_t keys_found = 0;
 
     io.executeWithCallbacks([&]()
     {
+        QueryPipeline pipeline(getSourcePipe(io.pipeline, use_async_executor));
+        PullingPipelineExecutor executor(pipeline);
+
         Block block;
         while (executor.pull(block))
         {

--- a/src/Dictionaries/FlatDictionary.cpp
+++ b/src/Dictionaries/FlatDictionary.cpp
@@ -456,12 +456,13 @@ void FlatDictionary::updateData()
 
     if (!update_field_loaded_block || update_field_loaded_block->rows() == 0)
     {
-        DictionaryPipelineExecutor executor(io.pipeline, configuration.use_async_executor);
-        io.pipeline.setConcurrencyControl(false);
         update_field_loaded_block.reset();
 
         io.executeWithCallbacks([&]()
         {
+            DictionaryPipelineExecutor executor(io.pipeline, configuration.use_async_executor);
+            io.pipeline.setConcurrencyControl(false);
+
             Block block;
             while (executor.pull(block))
             {
@@ -501,11 +502,11 @@ void FlatDictionary::loadData()
     {
         BlockIO io = source_ptr->loadAll();
 
-        DictionaryPipelineExecutor executor(io.pipeline, configuration.use_async_executor);
-        io.pipeline.setConcurrencyControl(false);
-
         io.executeWithCallbacks([&]()
         {
+            DictionaryPipelineExecutor executor(io.pipeline, configuration.use_async_executor);
+            io.pipeline.setConcurrencyControl(false);
+
             Block block;
             while (executor.pull(block))
                 blockToAttributes(block);

--- a/src/Dictionaries/HashedArrayDictionary.cpp
+++ b/src/Dictionaries/HashedArrayDictionary.cpp
@@ -483,12 +483,13 @@ void HashedArrayDictionary<dictionary_key_type, sharded>::updateData()
 
     if (!update_field_loaded_block || update_field_loaded_block->rows() == 0)
     {
-        DictionaryPipelineExecutor executor(io.pipeline, configuration.use_async_executor);
-        io.pipeline.setConcurrencyControl(false);
         update_field_loaded_block.reset();
 
         io.executeWithCallbacks([&]()
         {
+            DictionaryPipelineExecutor executor(io.pipeline, configuration.use_async_executor);
+            io.pipeline.setConcurrencyControl(false);
+
             Block block;
             while (executor.pull(block))
             {
@@ -985,9 +986,6 @@ void HashedArrayDictionary<dictionary_key_type, sharded>::loadData()
 
         BlockIO io = source_ptr->loadAll();
 
-        DictionaryPipelineExecutor executor(io.pipeline, configuration.use_async_executor);
-        io.pipeline.setConcurrencyControl(false);
-
         UInt64 pull_time_microseconds = 0;
         UInt64 process_time_microseconds = 0;
 
@@ -997,6 +995,9 @@ void HashedArrayDictionary<dictionary_key_type, sharded>::loadData()
 
         io.executeWithCallbacks([&]()
         {
+            DictionaryPipelineExecutor executor(io.pipeline, configuration.use_async_executor);
+            io.pipeline.setConcurrencyControl(false);
+
             Block block;
             while (true)
             {

--- a/src/Dictionaries/HashedDictionary.h
+++ b/src/Dictionaries/HashedDictionary.h
@@ -879,12 +879,13 @@ void HashedDictionary<dictionary_key_type, sparse, sharded>::updateData()
 
     if (!update_field_loaded_block || update_field_loaded_block->rows() == 0)
     {
-        DictionaryPipelineExecutor executor(io.pipeline, configuration.use_async_executor);
-        io.pipeline.setConcurrencyControl(false);
         update_field_loaded_block.reset();
 
         io.executeWithCallbacks([&]()
         {
+            DictionaryPipelineExecutor executor(io.pipeline, configuration.use_async_executor);
+            io.pipeline.setConcurrencyControl(false);
+
             Block block;
             while (executor.pull(block))
             {
@@ -1161,11 +1162,12 @@ void HashedDictionary<dictionary_key_type, sparse, sharded>::loadData()
 
         BlockIO io = source_ptr->loadAll();
 
-        DictionaryPipelineExecutor executor(io.pipeline, configuration.use_async_executor);
-        io.pipeline.setConcurrencyControl(false);
         DictionaryKeysArenaHolder<dictionary_key_type> arena_holder;
         io.executeWithCallbacks([&]()
         {
+            DictionaryPipelineExecutor executor(io.pipeline, configuration.use_async_executor);
+            io.pipeline.setConcurrencyControl(false);
+
             Block block;
             while (executor.pull(block))
             {

--- a/src/Dictionaries/IPAddressDictionary.cpp
+++ b/src/Dictionaries/IPAddressDictionary.cpp
@@ -415,11 +415,11 @@ void IPAddressDictionary::loadData()
     {
         BlockIO io = source_ptr->loadAll();
 
-        DictionaryPipelineExecutor executor(io.pipeline, configuration.use_async_executor);
-        io.pipeline.setConcurrencyControl(false);
-
         io.executeWithCallbacks([&]()
         {
+            DictionaryPipelineExecutor executor(io.pipeline, configuration.use_async_executor);
+            io.pipeline.setConcurrencyControl(false);
+
             Block block;
             while (executor.pull(block))
             {

--- a/src/Dictionaries/PolygonDictionary.cpp
+++ b/src/Dictionaries/PolygonDictionary.cpp
@@ -291,10 +291,11 @@ void IPolygonDictionary::loadData()
 {
     BlockIO io = source_ptr->loadAll();
 
-    DictionaryPipelineExecutor executor(io.pipeline, configuration.use_async_executor);
-    io.pipeline.setConcurrencyControl(false);
     io.executeWithCallbacks([&]()
     {
+        DictionaryPipelineExecutor executor(io.pipeline, configuration.use_async_executor);
+        io.pipeline.setConcurrencyControl(false);
+
         Block block;
         while (executor.pull(block))
             blockToAttributes(block);

--- a/src/Dictionaries/RangeHashedDictionary.h
+++ b/src/Dictionaries/RangeHashedDictionary.h
@@ -547,10 +547,11 @@ void RangeHashedDictionary<dictionary_key_type>::loadData()
     {
         BlockIO io = source_ptr->loadAll();
 
-        DictionaryPipelineExecutor executor(io.pipeline, configuration.use_async_executor);
-        io.pipeline.setConcurrencyControl(false);
         io.executeWithCallbacks([&]()
         {
+            DictionaryPipelineExecutor executor(io.pipeline, configuration.use_async_executor);
+            io.pipeline.setConcurrencyControl(false);
+
             Block block;
             while (executor.pull(block))
             {
@@ -702,12 +703,13 @@ void RangeHashedDictionary<dictionary_key_type>::updateData()
 
     if (!update_field_loaded_block || update_field_loaded_block->rows() == 0)
     {
-        DictionaryPipelineExecutor executor(io.pipeline, configuration.use_async_executor);
-        io.pipeline.setConcurrencyControl(false);
         update_field_loaded_block.reset();
 
         io.executeWithCallbacks([&]()
         {
+            DictionaryPipelineExecutor executor(io.pipeline, configuration.use_async_executor);
+            io.pipeline.setConcurrencyControl(false);
+
             Block block;
             while (executor.pull(block))
             {

--- a/src/Dictionaries/RegExpTreeDictionary.cpp
+++ b/src/Dictionaries/RegExpTreeDictionary.cpp
@@ -318,11 +318,11 @@ void RegExpTreeDictionary::loadData()
     {
         BlockIO io = source_ptr->loadAll();
 
-        DictionaryPipelineExecutor executor(io.pipeline, configuration.use_async_executor);
-        io.pipeline.setConcurrencyControl(false);
-
         io.executeWithCallbacks([&]()
         {
+            DictionaryPipelineExecutor executor(io.pipeline, configuration.use_async_executor);
+            io.pipeline.setConcurrencyControl(false);
+
             Block block;
             while (executor.pull(block))
             {


### PR DESCRIPTION
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
We store storages' shared pointers in `QueryPipeline::resources::storage_holders` to make sure that the `IStorage` objects are not destroyed while `PipelineExecutor` is alive.

After https://github.com/ClickHouse/ClickHouse/pull/83277, `~QueryPipeline` is called before `~PipelineExecutor` as `BlockIO::executeWithCallbacks` `std::move`s the pipeline which destroys `QueryPipeline::resources::storage_holders` which breaks that invariant and leads to issues like: Closes https://github.com/ClickHouse/ClickHouse/issues/91656, Closes https://github.com/ClickHouse/ClickHouse/issues/92497, Closes https://github.com/ClickHouse/ClickHouse/issues/93411, Closes https://github.com/ClickHouse/ClickHouse/issues/93161.

The fix moves executors' creation (and thus, destruction) inside the lambdas passed into `executeWithCallbacks`. This way, they are destroyed before `BlockIO::onFinish`/`BlockIO::onException` is called.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
