### PR TITLE
S3Queue auxiliary zookeeper support

### DIFF
--- a/docs/en/engines/table-engines/integrations/s3queue.md
+++ b/docs/en/engines/table-engines/integrations/s3queue.md
@@ -214,7 +214,10 @@ Default value: empty string.
 
 ### `keeper_path` {#keeper_path}
 
-The path in ZooKeeper can be specified as a table engine setting or default path can be formed from the global configuration-provided path and table UUID.
+Path to the queue metadata in ZooKeeper. If not specified explicitly, ClickHouse builds the path from `s3queue_default_zookeeper_path`, the database UUID, and the table UUID. Absolute values (starting with `/`) are used as provided, while relative values are appended to the configured prefix. Macros such as `{database}` or `{uuid}` are expanded before the engine connects to ZooKeeper.
+
+To target an auxiliary ZooKeeper cluster, prefix the value with the configured name, for example `analytics_keeper:/clickhouse/queue/orders`. The name must exist in `<auxiliary_zookeepers>`; otherwise the engine reports `Unknown auxiliary ZooKeeper name ...`. The full string (including the prefix) is preserved in `SHOW CREATE TABLE` so the statement can be replicated verbatim.
+
 Possible values:
 
 - String.

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueIFileMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueIFileMetadata.cpp
@@ -124,6 +124,7 @@ ObjectStorageQueueIFileMetadata::NodeMetadata ObjectStorageQueueIFileMetadata::N
 
 ObjectStorageQueueIFileMetadata::ObjectStorageQueueIFileMetadata(
     const std::string & path_,
+    const std::string & zookeeper_name_,
     const std::string & processing_node_path_,
     const std::string & processed_node_path_,
     const std::string & failed_node_path_,
@@ -133,6 +134,7 @@ ObjectStorageQueueIFileMetadata::ObjectStorageQueueIFileMetadata(
     bool use_persistent_processing_nodes_,
     LoggerPtr log_)
     : path(path_)
+    , zookeeper_name(zookeeper_name_)
     , node_name(getNodeName(path_))
     , file_status(file_status_)
     , max_loading_retries(max_loading_retries_)
@@ -179,7 +181,7 @@ ObjectStorageQueueIFileMetadata::~ObjectStorageQueueIFileMetadata()
             auto zk_retry = ObjectStorageQueueMetadata::getKeeperRetriesControl(log);
             zk_retry.retryLoop([&]
             {
-                auto zk_client = ObjectStorageQueueMetadata::getZooKeeper(log);
+                auto zk_client = ObjectStorageQueueMetadata::getZooKeeper(log, zookeeper_name);
                 if (zk_retry.isRetry())
                 {
                     /// It is possible that we fail "after operation",
@@ -397,7 +399,7 @@ void ObjectStorageQueueIFileMetadata::resetProcessing()
     auto zk_retry = ObjectStorageQueueMetadata::getKeeperRetriesControl(log);
     zk_retry.retryLoop([&]
     {
-        auto zk_client = ObjectStorageQueueMetadata::getZooKeeper(log);
+        auto zk_client = ObjectStorageQueueMetadata::getZooKeeper(log, zookeeper_name);
         if (zk_retry.isRetry())
         {
             /// It is possible that we fail "after operation",
@@ -512,7 +514,7 @@ void ObjectStorageQueueIFileMetadata::finalizeProcessed()
 #ifdef DEBUG_OR_SANITIZER_BUILD
     ObjectStorageQueueMetadata::getKeeperRetriesControl(log).retryLoop([&]
     {
-        auto zk_client = ObjectStorageQueueMetadata::getZooKeeper(log);
+        auto zk_client = ObjectStorageQueueMetadata::getZooKeeper(log, zookeeper_name);
         chassert(
             !zk_client->exists(processing_node_path),
             fmt::format("Expected path {} not to exist while finalizing {}", processing_node_path, path));
@@ -541,7 +543,7 @@ void ObjectStorageQueueIFileMetadata::finalizeFailed(const std::string & excepti
 #ifdef DEBUG_OR_SANITIZER_BUILD
     ObjectStorageQueueMetadata::getKeeperRetriesControl(log).retryLoop([&]
     {
-        auto zk_client = ObjectStorageQueueMetadata::getZooKeeper(log);
+    auto zk_client = ObjectStorageQueueMetadata::getZooKeeper(log, zookeeper_name);
         chassert(
             !zk_client->exists(processing_node_path),
             fmt::format("Expected path {} not to exist while finalizing {}", processing_node_path, path));
@@ -587,7 +589,7 @@ void ObjectStorageQueueIFileMetadata::prepareFailedRequestsImpl(
     bool has_failed_before = false;
     ObjectStorageQueueMetadata::getKeeperRetriesControl(log).retryLoop([&]
     {
-        auto zk_client = ObjectStorageQueueMetadata::getZooKeeper(log);
+        auto zk_client = ObjectStorageQueueMetadata::getZooKeeper(log, zookeeper_name);
         has_failed_before = zk_client->tryGet(retrieable_failed_node_path, res, &retriable_failed_node_stat);
     });
     if (has_failed_before)

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueIFileMetadata.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueIFileMetadata.h
@@ -88,6 +88,7 @@ public:
 
     explicit ObjectStorageQueueIFileMetadata(
         const std::string & path_,
+        const std::string & zookeeper_name_,
         const std::string & processing_node_path_,
         const std::string & processed_node_path_,
         const std::string & failed_node_path_,
@@ -185,12 +186,12 @@ protected:
     void prepareFailedRequestsImpl(Coordination::Requests & requests, bool retriable);
 
     const std::string path;
+    const std::string zookeeper_name;
     const std::string node_name;
     const FileStatusPtr file_status;
     const size_t max_loading_retries;
     const std::atomic<size_t> & metadata_ref_count;
     const bool use_persistent_processing_nodes;
-
     const std::string processing_node_path;
     const std::string processed_node_path;
     const std::string failed_node_path;

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
@@ -132,6 +132,7 @@ private:
 ObjectStorageQueueMetadata::ObjectStorageQueueMetadata(
     ObjectStorageType storage_type_,
     const fs::path & zookeeper_path_,
+    const std::string & zookeeper_name_,
     const ObjectStorageQueueTableMetadata & table_metadata_,
     size_t cleanup_interval_min_ms_,
     size_t cleanup_interval_max_ms_,
@@ -143,13 +144,17 @@ ObjectStorageQueueMetadata::ObjectStorageQueueMetadata(
     , storage_type(storage_type_)
     , mode(table_metadata.getMode())
     , zookeeper_path(zookeeper_path_)
+    , zookeeper_name(zookeeper_name_)
     , keeper_multiread_batch_size(keeper_multiread_batch_size_)
     , cleanup_interval_min_ms(cleanup_interval_min_ms_)
     , cleanup_interval_max_ms(cleanup_interval_max_ms_)
     , use_persistent_processing_nodes(use_persistent_processing_nodes_)
     , persistent_processing_node_ttl_seconds(persistent_processing_nodes_ttl_seconds_)
     , buckets_num(table_metadata_.getBucketsNum())
-    , log(getLogger("StorageObjectStorageQueue(" + zookeeper_path_.string() + ")"))
+    , log(getLogger(fmt::format(
+        "StorageObjectStorageQueue({}{})",
+        zookeeper_name_.empty() ? "" : zookeeper_name_ + ":",
+        zookeeper_path_.string())))
     , local_file_statuses(std::make_shared<LocalFileStatuses>())
     , is_path_with_hive_partitioning(is_path_with_hive_partitioning_)
 {
@@ -164,10 +169,10 @@ ObjectStorageQueueMetadata::~ObjectStorageQueueMetadata()
     shutdown();
 }
 
-ZooKeeperWithFaultInjection::Ptr ObjectStorageQueueMetadata::getZooKeeper(LoggerPtr log)
+ZooKeeperWithFaultInjection::Ptr ObjectStorageQueueMetadata::getZooKeeper(LoggerPtr log, const String & zookeeper_name)
 {
     auto context = Context::getGlobalContextInstance();
-    auto zk_client = context->getZooKeeper();
+    auto zk_client = context->getDefaultOrAuxiliaryZooKeeper(zookeeper_name);
     if (context->getSettingsRef()[Setting::s3queue_keeper_fault_injection_probability] != 0.0)
     {
         return ZooKeeperWithFaultInjection::createInstance(
@@ -253,6 +258,7 @@ ObjectStorageQueueMetadata::FileMetadataPtr ObjectStorageQueueMetadata::getFileM
                 table_metadata.loading_retries,
                 *metadata_ref_count,
                 use_persistent_processing_nodes,
+                zookeeper_name,
                 is_path_with_hive_partitioning,
                 log);
         case ObjectStorageQueueMode::UNORDERED:
@@ -263,6 +269,7 @@ ObjectStorageQueueMetadata::FileMetadataPtr ObjectStorageQueueMetadata::getFileM
                 table_metadata.loading_retries,
                 *metadata_ref_count,
                 use_persistent_processing_nodes,
+                zookeeper_name,
                 log);
     }
 }
@@ -285,7 +292,7 @@ ObjectStorageQueueMetadata::Bucket ObjectStorageQueueMetadata::getBucketForPath(
 ObjectStorageQueueOrderedFileMetadata::BucketHolderPtr
 ObjectStorageQueueMetadata::tryAcquireBucket(const Bucket & bucket)
 {
-    return ObjectStorageQueueOrderedFileMetadata::tryAcquireBucket(zookeeper_path, bucket, use_persistent_processing_nodes, log);
+    return ObjectStorageQueueOrderedFileMetadata::tryAcquireBucket(zookeeper_path, bucket, use_persistent_processing_nodes, zookeeper_name, log);
 }
 
 void ObjectStorageQueueMetadata::alterSettings(const SettingsChanges & changes, const ContextPtr & context)
@@ -295,7 +302,7 @@ void ObjectStorageQueueMetadata::alterSettings(const SettingsChanges & changes, 
 
     const fs::path alter_settings_lock_path = zookeeper_path / "alter_settings_lock";
     zkutil::EphemeralNodeHolder::Ptr alter_settings_lock;
-    auto zookeeper = getZooKeeper(log);
+    auto zookeeper = getZooKeeper();
 
     if (is_initial_query)
     {
@@ -437,16 +444,19 @@ void ObjectStorageQueueMetadata::migrateToBucketsInKeeper(size_t value)
 {
     chassert(table_metadata.buckets == 0 || table_metadata.buckets == 1);
     chassert(buckets_num == 1, "Buckets: " + toString(buckets_num));
-
     LOG_TRACE(log, "Changing buckets value from {} to {}", table_metadata.buckets.load(), value);
-
-    ObjectStorageQueueOrderedFileMetadata::migrateToBuckets(zookeeper_path, value, /* prev_value */table_metadata.buckets);
+    ObjectStorageQueueOrderedFileMetadata::migrateToBuckets(
+        zookeeper_path,
+        value,
+        /* prev_value */table_metadata.buckets,
+        zookeeper_name);
     table_metadata.buckets = value;
     buckets_num = table_metadata.getBucketsNum();
 }
 
 ObjectStorageQueueTableMetadata ObjectStorageQueueMetadata::syncWithKeeper(
     const fs::path & zookeeper_path,
+    const String & zookeeper_name,
     const ObjectStorageQueueSettings & settings,
     const ColumnsDescription & columns,
     const std::string & format,
@@ -480,7 +490,7 @@ ObjectStorageQueueTableMetadata ObjectStorageQueueMetadata::syncWithKeeper(
     const auto table_metadata_path = zookeeper_path / "metadata";
     bool warned = false;
 
-    zk_retries.retryLoop([&] { getZooKeeper(log)->createAncestors(zookeeper_path); });
+    zk_retries.retryLoop([&] { getZooKeeper(log, zookeeper_name)->createAncestors(zookeeper_path); });
 
     for (size_t i = 0; i < 1000; ++i)
     {
@@ -490,7 +500,7 @@ ObjectStorageQueueTableMetadata ObjectStorageQueueMetadata::syncWithKeeper(
         zk_retries.resetFailures();
         zk_retries.retryLoop([&]
         {
-            auto zk_client = getZooKeeper(log);
+            auto zk_client = getZooKeeper(log, zookeeper_name);
             std::optional<ObjectStorageQueueTableMetadata> metadata_from_zk;
             if (zk_client->exists(table_metadata_path))
             {
@@ -547,6 +557,7 @@ ObjectStorageQueueTableMetadata ObjectStorageQueueMetadata::syncWithKeeper(
                     table_metadata.loading_retries,
                     noop,
                     /* use_persistent_processing_nodes */false, /// Processing nodes will not be created.
+                    zookeeper_name,
                     is_path_with_hive_partitioning,
                     log).prepareProcessedAtStartRequests(requests);
             }
@@ -646,7 +657,7 @@ void ObjectStorageQueueMetadata::registerActive(const StorageID & storage_id)
     Coordination::Error code;
     getKeeperRetriesControl(log).retryLoop([&]
     {
-        code = getZooKeeper(log)->tryCreate(
+        code = getZooKeeper()->tryCreate(
             table_path,
             self.serialize(),
             zkutil::CreateMode::Ephemeral);
@@ -680,7 +691,7 @@ void ObjectStorageQueueMetadata::registerNonActive(const StorageID & storage_id,
         zk_retries.resetFailures();
         zk_retries.retryLoop([&]
         {
-            auto zk_client = getZooKeeper(log);
+            auto zk_client = getZooKeeper();
             bool registry_exists = zk_client->tryGet(registry_path, registry_str, &stat);
             if (registry_exists)
             {
@@ -724,7 +735,7 @@ void ObjectStorageQueueMetadata::registerNonActive(const StorageID & storage_id,
                     zkutil::CreateMode::Persistent));
 
                 if (!zk_client->isFeatureEnabled(DB::KeeperFeatureFlag::REMOVE_RECURSIVE))
-                    zkutil::addCheckNotExistsRequest(requests, *getZooKeeper(log), drop_lock_path);
+                    zkutil::addCheckNotExistsRequest(requests, *getZooKeeper(), drop_lock_path);
             }
 
             code = zk_client->tryMulti(requests, responses);
@@ -756,14 +767,14 @@ Strings ObjectStorageQueueMetadata::getRegistered(bool active)
     if (active)
     {
         Coordination::Error code;
-        zk_retries.retryLoop([&] { code = getZooKeeper(log)->tryGetChildren(registry_path, registered); });
+        zk_retries.retryLoop([&] { code = getZooKeeper()->tryGetChildren(registry_path, registered); });
         if (code != Coordination::Error::ZOK && code != Coordination::Error::ZNONODE)
             throw zkutil::KeeperException(code);
     }
     else
     {
         std::string registry_str;
-        zk_retries.retryLoop([&] { getZooKeeper(log)->tryGet(registry_path, registry_str); });
+        zk_retries.retryLoop([&] { getZooKeeper()->tryGet(registry_path, registry_str); });
         if (!registry_str.empty())
             splitInto<','>(registered, registry_str);
     }
@@ -776,7 +787,7 @@ void ObjectStorageQueueMetadata::unregisterActive(const StorageID & storage_id)
     const auto table_path = registry_path / getProcessorID(storage_id);
 
     Coordination::Error code;
-    getKeeperRetriesControl(log).retryLoop([&] { code = getZooKeeper(log)->tryRemove(table_path); });
+    getKeeperRetriesControl(log).retryLoop([&] { code = getZooKeeper()->tryRemove(table_path); });
 
     if (code == Coordination::Error::ZOK)
     {
@@ -820,7 +831,7 @@ void ObjectStorageQueueMetadata::unregisterNonActive(const StorageID & storage_i
 
         try
         {
-            zk_client = getZooKeeper(log);
+            zk_client = getZooKeeper();
             supports_remove_recursive = allow_remove_recursive && zk_client->isFeatureEnabled(DB::KeeperFeatureFlag::REMOVE_RECURSIVE);
 
             Coordination::Stat stat;
@@ -1150,7 +1161,7 @@ void ObjectStorageQueueMetadata::cleanupThreadFuncImpl()
     auto timer = DB::CurrentThread::getProfileEvents().timer(ProfileEvents::ObjectStorageQueueCleanupMaxSetSizeOrTTLMicroseconds);
 
     const fs::path zookeeper_cleanup_lock_path = zookeeper_path / "cleanup_lock";
-    const auto zk_client = getZooKeeper(log);
+    const auto zk_client = getZooKeeper();
     auto zk_retries = getKeeperRetriesControl(log);
 
     /// Create a lock so that with distributed processing
@@ -1174,7 +1185,7 @@ void ObjectStorageQueueMetadata::cleanupThreadFuncImpl()
     Coordination::Error code;
     zk_retries.retryLoop([&]
     {
-        code = getZooKeeper(log)->tryGetChildren(zookeeper_processed_path, processed_nodes);
+        code = getZooKeeper()->tryGetChildren(zookeeper_processed_path, processed_nodes);
     });
     if (code != Coordination::Error::ZOK)
     {
@@ -1190,7 +1201,7 @@ void ObjectStorageQueueMetadata::cleanupThreadFuncImpl()
     zk_retries.resetFailures();
     zk_retries.retryLoop([&]
     {
-        code = getZooKeeper(log)->tryGetChildren(zookeeper_failed_path, failed_nodes);
+        code = getZooKeeper()->tryGetChildren(zookeeper_failed_path, failed_nodes);
     });
     if (code != Coordination::Error::ZOK)
     {
@@ -1246,7 +1257,7 @@ void ObjectStorageQueueMetadata::cleanupThreadFuncImpl()
             zk_retries.resetFailures();
             zk_retries.retryLoop([&]
             {
-                response = getZooKeeper(log)->tryGet(paths);
+                response = zk_client->tryGet(paths);
             });
 
             for (size_t i = 0; i < response.size(); ++i)
@@ -1303,10 +1314,7 @@ void ObjectStorageQueueMetadata::cleanupThreadFuncImpl()
 
     const auto remove_nodes = [&](bool node_limit)
     {
-        zk_retries.retryLoop([&]
-        {
-            code = getZooKeeper(log)->tryMulti(remove_requests, remove_responses);
-        });
+        code = zk_client->tryMulti(remove_requests, remove_responses);
 
         if (code == Coordination::Error::ZOK)
         {
@@ -1329,7 +1337,7 @@ void ObjectStorageQueueMetadata::cleanupThreadFuncImpl()
                     zk_retries.resetFailures();
                     zk_retries.retryLoop([&]
                     {
-                        code = getZooKeeper(log)->tryRemove(remove_requests[i]->getPath());
+                        code = getZooKeeper()->tryRemove(remove_requests[i]->getPath());
                     });
                     if (code == Coordination::Error::ZOK)
                     {
@@ -1422,7 +1430,7 @@ void ObjectStorageQueueMetadata::cleanupPersistentProcessingNodes()
     Coordination::Error code;
     zk_retries.retryLoop([&]
     {
-        code = getZooKeeper(log)->tryGetChildren(zookeeper_persistent_processing_path, persistent_processing_nodes);
+        code = getZooKeeper()->tryGetChildren(zookeeper_persistent_processing_path, persistent_processing_nodes);
     });
     if (code != Coordination::Error::ZOK)
     {
@@ -1454,7 +1462,7 @@ void ObjectStorageQueueMetadata::cleanupPersistentProcessingNodes()
         zk_retries.resetFailures();
         zk_retries.retryLoop([&]
         {
-            response = getZooKeeper(log)->tryGet(get_batch);
+            response = getZooKeeper()->tryGet(get_batch);
         });
 
         for (size_t i = 0; i < response.size(); ++i)
@@ -1504,7 +1512,7 @@ void ObjectStorageQueueMetadata::cleanupPersistentProcessingNodes()
         zk_retries.resetFailures();
         zk_retries.retryLoop([&]
         {
-            code = getZooKeeper(log)->tryRemove(node);
+            code = getZooKeeper()->tryRemove(node);
         });
         if (code != Coordination::Error::ZOK && code != Coordination::Error::ZNONODE)
             throw zkutil::KeeperException::fromPath(code, node);

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.h
@@ -57,6 +57,7 @@ public:
     ObjectStorageQueueMetadata(
         ObjectStorageType storage_type_,
         const fs::path & zookeeper_path_,
+        const std::string & zookeeper_name_,
         const ObjectStorageQueueTableMetadata & table_metadata_,
         size_t cleanup_interval_min_ms_,
         size_t cleanup_interval_max_ms_,
@@ -82,6 +83,7 @@ public:
     /// because its default depends on the CPU cores on the server);
     static ObjectStorageQueueTableMetadata syncWithKeeper(
         const fs::path & zookeeper_path,
+        const String & zookeeper_name,
         const ObjectStorageQueueSettings & settings,
         const ColumnsDescription & columns,
         const std::string & format,
@@ -150,7 +152,9 @@ public:
     /// Acquire (take unique ownership of) bucket for processing.
     ObjectStorageQueueOrderedFileMetadata::BucketHolderPtr tryAcquireBucket(const Bucket & bucket);
 
-    static std::shared_ptr<ZooKeeperWithFaultInjection> getZooKeeper(LoggerPtr log);
+    const String & getZooKeeperName() const { return zookeeper_name; }
+    std::shared_ptr<ZooKeeperWithFaultInjection> getZooKeeper() const { return getZooKeeper(log, zookeeper_name); }
+    static std::shared_ptr<ZooKeeperWithFaultInjection> getZooKeeper(LoggerPtr log, const String & zookeeper_name);
     static ZooKeeperRetriesControl getKeeperRetriesControl(LoggerPtr log);
 
     /// Set local ref count for metadata.
@@ -182,6 +186,7 @@ private:
     const ObjectStorageType storage_type;
     const ObjectStorageQueueMode mode;
     const fs::path zookeeper_path;
+    const std::string zookeeper_name;
     const size_t keeper_multiread_batch_size;
 
     std::atomic<size_t> cleanup_interval_min_ms;

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadataFactory.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadataFactory.cpp
@@ -2,6 +2,7 @@
 #include <Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/DatabaseCatalog.h>
+#include <Common/ZooKeeper/ZooKeeper.h>
 #include <Common/setThreadName.h>
 
 namespace CurrentMetrics
@@ -13,6 +14,15 @@ namespace CurrentMetrics
 
 namespace DB
 {
+namespace
+{
+std::string makeMetadataKey(const std::string & zookeeper_name, const std::string & zookeeper_path)
+{
+    if (zookeeper_name == zkutil::DEFAULT_ZOOKEEPER_NAME)
+        return zookeeper_path;
+    return zookeeper_name + ":" + zookeeper_path;
+}
+}
 
 namespace ErrorCodes
 {
@@ -136,16 +146,18 @@ ObjectStorageQueueMetadataFactory & ObjectStorageQueueMetadataFactory::instance(
 }
 
 ObjectStorageQueueMetadataFactory::FilesMetadataPtr ObjectStorageQueueMetadataFactory::getOrCreate(
+    const std::string & zookeeper_name,
     const std::string & zookeeper_path,
     ObjectStorageQueueMetadataPtr metadata,
     const StorageID & storage_id,
     bool & created_new_metadata)
 {
     std::lock_guard lock(mutex);
-    auto it = metadata_by_path.find(zookeeper_path);
+    const auto metadata_key = makeMetadataKey(zookeeper_name, zookeeper_path);
+    auto it = metadata_by_path.find(metadata_key);
     if (it == metadata_by_path.end())
     {
-        it = metadata_by_path.emplace(zookeeper_path, std::move(metadata)).first;
+        it = metadata_by_path.emplace(metadata_key, std::move(metadata)).first;
         it->second.metadata->setMetadataRefCount(*it->second.ref_count);
     }
     else
@@ -162,16 +174,18 @@ ObjectStorageQueueMetadataFactory::FilesMetadataPtr ObjectStorageQueueMetadataFa
 }
 
 void ObjectStorageQueueMetadataFactory::remove(
+    const std::string & zookeeper_name,
     const std::string & zookeeper_path,
     const StorageID & storage_id,
     bool is_drop,
     bool keep_data_in_keeper)
 {
     std::lock_guard lock(mutex);
-    auto it = metadata_by_path.find(zookeeper_path);
+    const auto metadata_key = makeMetadataKey(zookeeper_name, zookeeper_path);
+    auto it = metadata_by_path.find(metadata_key);
 
     if (it == metadata_by_path.end())
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Metadata with zookeeper path {} does not exist", zookeeper_path);
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Metadata with zookeeper path {} does not exist", metadata_key);
 
     *it->second.ref_count -= 1;
 
@@ -200,8 +214,12 @@ void ObjectStorageQueueMetadataFactory::remove(
 std::unordered_map<std::string, ObjectStorageQueueMetadataFactory::FilesMetadataPtr> ObjectStorageQueueMetadataFactory::getAll()
 {
     std::unordered_map<std::string, ObjectStorageQueueMetadataFactory::FilesMetadataPtr> result;
-    for (const auto & [zk_path, metadata] : metadata_by_path)
-        result.emplace(zk_path, metadata.metadata);
+    for (const auto & [key, metadata] : metadata_by_path)
+    {
+        const auto & name = metadata.metadata->getZooKeeperName();
+        const auto & path = metadata.metadata->getPath();
+        result.emplace(key, metadata.metadata);
+    }
     return result;
 }
 

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadataFactory.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadataFactory.h
@@ -51,6 +51,7 @@ public:
     /// Get a metadata instance if exists, otherwise create a new one.
     /// Registers table in keeper in persistent node.
     FilesMetadataPtr getOrCreate(
+        const std::string & zookeeper_name,
         const std::string & zookeeper_path,
         ObjectStorageQueueMetadataPtr metadata,
         const StorageID & storage_id,
@@ -60,6 +61,7 @@ public:
     /// Metadata will be removed when ref count becomes zero.
     /// Unregisters table in keeper from persistent node.
     void remove(
+        const std::string & zookeeper_name,
         const std::string & zookeeper_path,
         const StorageID & storage_id,
         bool is_drop,

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueOrderedFileMetadata.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueOrderedFileMetadata.h
@@ -33,6 +33,7 @@ public:
         size_t max_loading_retries_,
         std::atomic<size_t> & metadata_ref_count_,
         bool use_persistent_processing_nodes_,
+        const std::string & zookeeper_name_,
         bool is_path_with_hive_partitioning,
         LoggerPtr log_);
 
@@ -46,19 +47,25 @@ public:
         const std::filesystem::path & zk_path,
         const Bucket & bucket,
         bool use_persistent_processing_nodes_,
+        const std::string & zookeeper_name_,
         LoggerPtr log_);
 
     static ObjectStorageQueueOrderedFileMetadata::Bucket getBucketForPath(const std::string & path, size_t buckets_num);
 
     static std::vector<std::string> getMetadataPaths(size_t buckets_num);
 
-    static void migrateToBuckets(const std::string & zk_path, size_t value, size_t prev_value);
+    static void migrateToBuckets(
+        const std::string & zk_path,
+        size_t value,
+        size_t prev_value,
+        const std::string & zookeeper_name_);
 
     /// Return vector of indexes of filtered paths.
     static void filterOutProcessedAndFailed(
         std::vector<std::string> & paths,
         const std::filesystem::path & zk_path_,
         size_t buckets_num,
+        const std::string & zookeeper_name_,
         bool is_path_with_hive_partitioning,
         LoggerPtr log);
 
@@ -80,7 +87,8 @@ private:
         NodeMetadata & result,
         Coordination::Stat * stat,
         const std::string & processed_node_path_,
-        LoggerPtr log_);
+        LoggerPtr log_,
+        const std::string & zookeeper_name_);
 
     struct LastProcessedInfo
     {
@@ -99,12 +107,14 @@ private:
         const std::string & file_path,
         std::optional<std::string> processed_node_hive_partitioning_path = std::nullopt,
         std::optional<std::string> failed_node_path = std::nullopt,
-        LoggerPtr log_ = nullptr);
+        LoggerPtr log_ = nullptr,
+        const std::string & zookeeper_name_ = {});
 
     static bool getMaxProcessedFilesByHivePartition(
         std::unordered_map<std::string, std::string> & max_processed_files,
         const std::string & processed_node_path_,
-        LoggerPtr log_);
+        LoggerPtr log_,
+        const std::string & zookeeper_name_);
 
     void doPrepareProcessedRequests(
         Coordination::Requests & requests,
@@ -128,7 +138,8 @@ struct ObjectStorageQueueOrderedFileMetadata::BucketHolder : private boost::nonc
         const Bucket & bucket_,
         const std::string & bucket_lock_path_,
         const std::string & processor_info_,
-        LoggerPtr log_);
+        LoggerPtr log_,
+        const std::string & zookeeper_name_);
 
     ~BucketHolder();
 
@@ -148,6 +159,7 @@ private:
     bool released = false;
     bool finished = false;
     LoggerPtr log;
+    std::string zookeeper_name;
 };
 
 }

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.cpp
@@ -284,7 +284,7 @@ ObjectStorageQueueSource::FileIterator::next()
                 Coordination::Error code;
                 zk_retry.retryLoop([&]
                 {
-                    auto zk_client = ObjectStorageQueueMetadata::getZooKeeper(log);
+                    auto zk_client = metadata->getZooKeeper();
                     if (zk_retry.isRetry())
                     {
                         LOG_TEST(log, "Retrying set processing requests batch ({})", processing_paths.size());
@@ -293,7 +293,7 @@ ObjectStorageQueueSource::FileIterator::next()
                         bool is_multi_read_enabled = zk_client->isFeatureEnabled(DB::KeeperFeatureFlag::MULTI_READ);
                         if (is_multi_read_enabled)
                         {
-                            auto processing_paths_responses = ObjectStorageQueueMetadata::getZooKeeper(log)->tryGet(processing_paths);
+                            auto processing_paths_responses = metadata->getZooKeeper()->tryGet(processing_paths);
                             for (size_t i = 0; i < processing_paths_responses.size(); ++i)
                             {
                                 LOG_TEST(log, "Path {} has processor: {}, current processor: {}",
@@ -446,13 +446,15 @@ void ObjectStorageQueueSource::FileIterator::filterProcessableFiles(ObjectInfos 
     if (enable_hash_ring_filtering && mode == ObjectStorageQueueMode::UNORDERED)
         metadata->filterOutForProcessor(paths, storage_id);
 
+    const auto & zookeeper_name = metadata->getZooKeeperName();
     if (mode == ObjectStorageQueueMode::UNORDERED)
-        ObjectStorageQueueUnorderedFileMetadata::filterOutProcessedAndFailed(paths, metadata->getPath(), log);
+        ObjectStorageQueueUnorderedFileMetadata::filterOutProcessedAndFailed(paths, metadata->getPath(), zookeeper_name, log);
     else
         ObjectStorageQueueOrderedFileMetadata::filterOutProcessedAndFailed(
             paths,
             metadata->getPath(),
             metadata->getBucketsNum(),
+            zookeeper_name,
             metadata->isPathWithHivePartitioning(),
             log);
 
@@ -692,7 +694,7 @@ ObjectStorageQueueSource::FileIterator::getNextKeyFromAcquiredBucket(size_t proc
     {
         ObjectStorageQueueMetadata::getKeeperRetriesControl(log).retryLoop([&]
         {
-            auto zk_client = ObjectStorageQueueMetadata::getZooKeeper(log);
+            auto zk_client = metadata->getZooKeeper();
             chassert(current_bucket_holder->checkBucketOwnership(zk_client));
         });
     }
@@ -730,7 +732,7 @@ ObjectStorageQueueSource::FileIterator::getNextKeyFromAcquiredBucket(size_t proc
                     std::optional<std::string> processor_info;
                     ObjectStorageQueueMetadata::getKeeperRetriesControl(log).retryLoop([&]
                     {
-                        auto zk_client = ObjectStorageQueueMetadata::getZooKeeper(log);
+                        auto zk_client = metadata->getZooKeeper();
                         processor_info = current_bucket_holder->getProcessorInfo(zk_client);
                     });
                     throw Exception(
@@ -1502,7 +1504,7 @@ void ObjectStorageQueueSource::commit(bool insert_succeeded, const std::string &
         postProcessor.process(successful_objects);
     }
 
-    auto zk_client = ObjectStorageQueueMetadata::getZooKeeper(log);
+    auto zk_client = files_metadata->getZooKeeper();
     Coordination::Responses responses;
 
     auto zk_retry = ObjectStorageQueueMetadata::getKeeperRetriesControl(log);

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueUnorderedFileMetadata.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueUnorderedFileMetadata.h
@@ -18,6 +18,7 @@ public:
         size_t max_loading_retries_,
         std::atomic<size_t> & metadata_ref_count_,
         bool use_persistent_processing_nodes_,
+        const std::string & zookeeper_name_,
         LoggerPtr log_);
 
     static std::vector<std::string> getMetadataPaths() { return {"processed", "failed", "processing", "persistent_processing"}; }
@@ -26,6 +27,7 @@ public:
     static void filterOutProcessedAndFailed(
         std::vector<std::string> & paths,
         const std::filesystem::path & zk_path_,
+        const std::string & zookeeper_name_,
         LoggerPtr log_);
 
 private:

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.h
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.h
@@ -61,6 +61,7 @@ public:
     const auto & getFormatName() const { return configuration->format; }
 
     const fs::path & getZooKeeperPath() const { return zk_path; }
+    const String & getZooKeeperName() const { return zookeeper_name; }
 
     zkutil::ZooKeeperPtr getZooKeeper() const;
 
@@ -78,7 +79,8 @@ public:
         const StorageID & table_id,
         const Settings & settings,
         const ObjectStorageQueueSettings & queue_settings,
-        UUID database_uuid = UUIDHelpers::Nil);
+        UUID database_uuid = UUIDHelpers::Nil,
+        String * zookeeper_name_out = nullptr);
 
     static constexpr auto engine_names = {"S3Queue", "AzureQueue"};
 
@@ -96,7 +98,8 @@ private:
 
     ObjectStorageType type;
     const std::string engine_name;
-    const fs::path zk_path;
+    std::string zookeeper_name;
+    fs::path zk_path;
     const bool enable_logging_to_queue_log;
     mutable std::mutex mutex;
     UInt64 polling_min_timeout_ms TSA_GUARDED_BY(mutex);

--- a/tests/integration/test_storage_s3_queue/configs/zookeeper.xml
+++ b/tests/integration/test_storage_s3_queue/configs/zookeeper.xml
@@ -13,4 +13,16 @@
             <port>2181</port>
         </node>
     </zookeeper>
+    <auxiliary_zookeepers>
+        <zookeeper2>
+            <node index="1">
+                <host>zoo1</host>
+                <port>2181</port>
+            </node>
+            <node index="2">
+                <host>zoo2</host>
+                <port>2181</port>
+            </node>
+        </zookeeper2>
+    </auxiliary_zookeepers>
 </clickhouse>

--- a/tests/integration/test_storage_s3_queue/test_0.py
+++ b/tests/integration/test_storage_s3_queue/test_0.py
@@ -29,6 +29,7 @@ from helpers.s3_queue_common import (
 )
 
 AVAILABLE_MODES = ["unordered", "ordered"]
+AUXILIARY_ZOOKEEPER_NAME = "zookeeper2"
 
 
 @pytest.fixture(autouse=True)
@@ -400,7 +401,84 @@ def test_move_after_processing(started_cluster, engine_name, move_to):
         assert moved_count == files_num, f"moved blob count mismatch: {moved_count} != {files_num}"
 
         blob_count = count_azurite_blobs(started_cluster, src_container, files_path)
-        assert blob_count == 0, f"blobs left: {blob_count}"
+    assert blob_count == 0, f"blobs left: {blob_count}"
+
+
+@pytest.mark.parametrize("engine_name", ["S3Queue", "AzureQueue"])
+def test_auxiliary_zookeeper_keeper_path(started_cluster, engine_name):
+    node = started_cluster.instances["instance"]
+    table_name = f"aux_keeper_{engine_name.lower()}_{generate_random_string()}"
+    dst_table_name = f"{table_name}_dst"
+    files_path = f"{table_name}_data"
+    files_num = 3
+    row_num = 2
+    keeper_suffix = f"/clickhouse/test_{table_name}"
+    keeper_path_with_aux = f"{AUXILIARY_ZOOKEEPER_NAME}:{keeper_suffix}"
+
+    storage = "s3" if engine_name == "S3Queue" else "azure"
+    total_values = generate_random_files(
+        started_cluster, files_path, files_num, row_num=row_num, storage=storage
+    )
+
+    create_table(
+        started_cluster,
+        node,
+        table_name,
+        "ordered",
+        files_path,
+        additional_settings={"keeper_path": keeper_path_with_aux},
+        engine_name=engine_name,
+    )
+    create_mv(node, table_name, dst_table_name)
+
+    expected_count = files_num * row_num
+    for _ in range(60):
+        if int(node.query(f"SELECT count() FROM {dst_table_name}")) == expected_count:
+            break
+        time.sleep(1)
+    assert int(node.query(f"SELECT count() FROM {dst_table_name}")) == expected_count
+
+    show_create = node.query(f"SHOW CREATE TABLE {table_name}")
+    assert keeper_path_with_aux in show_create
+
+    settings_table = (
+        "system.s3_queue_settings"
+        if engine_name == "S3Queue"
+        else "system.azure_queue_settings"
+    )
+    keeper_setting = node.query(
+        f"SELECT value FROM {settings_table} WHERE table = '{table_name}' AND name = 'keeper_path'"
+    ).strip()
+    assert keeper_setting == keeper_path_with_aux
+
+    assert int(node.query(f"SELECT uniq(_path) FROM {dst_table_name}")) == files_num
+    assert sorted(
+        [
+            list(map(int, l.split()))
+            for l in node.query(
+                f"SELECT column1, column2, column3 FROM {dst_table_name} ORDER BY column1, column2, column3"
+            ).splitlines()
+        ]
+    ) == sorted(total_values, key=lambda x: (x[0], x[1], x[2]))
+
+
+def test_auxiliary_zookeeper_missing_configuration(started_cluster):
+    node = started_cluster.instances["instance"]
+    table_name = f"aux_keeper_missing_{generate_random_string()}"
+    files_path = f"{table_name}_data"
+    keeper_path = f"unknown_keeper:/clickhouse/test_{table_name}"
+
+    error = create_table(
+        started_cluster,
+        node,
+        table_name,
+        "unordered",
+        files_path,
+        additional_settings={"keeper_path": keeper_path},
+        expect_error=True,
+    )
+
+    assert "Unknown auxiliary ZooKeeper name" in error
 
 
 @pytest.mark.parametrize("mode", ["unordered", "ordered"])


### PR DESCRIPTION
S3Queue auxiliary Zookeeper support using keeper_path setting from s3Queue

This will allow to do workload separation for heavy zk usage modes like unordered, by creating a zk/keeper specifically for some S3Queue tables and creating an S3queue specifying keeper_path with an auxiliary zookeeper like in a ReplicatedMergeTree table:

'auxiliary_zookeeper:/clickhouse/s3queue/my_s3queue_table'

Added integration tests and doc

