### PR TITLE
Fix inconsistent formatting when subquery or tuple in IN or NOT has alias

### DIFF
--- a/tests/queries/0_stateless/03780_AST_formatting_inconsistencies_in_debug_check.reference
+++ b/tests/queries/0_stateless/03780_AST_formatting_inconsistencies_in_debug_check.reference
@@ -6,3 +6,10 @@ Test repeated alias for statement which is not a literal:
 Test repeated alias for negated col:
 Test that large max_query_size doesnt cause overflow:
 test
+Test repeated alias in subquery after IN:
+[1,2,3]	0
+Test repeated alias in subquery after NOT:
+1	0
+Test repeated alias for tuple after IN:
+(1,'a')	1
+Test repeated alias for tuple after NOT fails cleanly:

--- a/tests/queries/0_stateless/03780_AST_formatting_inconsistencies_in_debug_check.sql
+++ b/tests/queries/0_stateless/03780_AST_formatting_inconsistencies_in_debug_check.sql
@@ -1,3 +1,5 @@
+SET enable_analyzer = 1;
+
 SELECT 'These tests just need to run, dont care about output';
 SELECT 'Test repeated alias for literal as 2nd arg to IN operator:';
 SELECT ([1] AS foo), [1] IN ([1] AS foo);
@@ -12,3 +14,15 @@ DROP TABLE tab;
 
 SELECT 'Test that large max_query_size doesnt cause overflow:';
 SELECT 'test' SETTINGS max_query_size = 9223372036854775309;
+
+SELECT 'Test repeated alias in subquery after IN:';
+SELECT ((SELECT [1,2,3]) AS a1), [5] IN ((SELECT [1,2,3]) AS a1);
+
+SELECT 'Test repeated alias in subquery after NOT:';
+SELECT ((SELECT 1) AS a1), NOT ((SELECT 1) AS a1);
+
+SELECT 'Test repeated alias for tuple after IN:';
+select tuple(1, 'a') as a1, tuple(1, 'a') IN (tuple(1, 'a') as a1);
+
+SELECT 'Test repeated alias for tuple after NOT fails cleanly:';
+select tuple(1, 'a') as a1, not (tuple(1, 'a') as a1); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }

--- a/tests/queries/0_stateless/03786_AST_formatting_inconsistencies_in_debug_check.reference
+++ b/tests/queries/0_stateless/03786_AST_formatting_inconsistencies_in_debug_check.reference
@@ -1,0 +1,23 @@
+SELECT
+    [1] AS foo,
+    [1] IN (foo)
+SELECT
+    [isNaN(1)] AS foo,
+    [1] IN (foo)
+SELECT
+    -((-c1) AS a2),
+    NOT (-a2)
+FROM tab
+SELECT
+    (
+        SELECT [1, 2, 3]
+    ) AS a1,
+    [5] IN (a1)
+SELECT
+    (
+        SELECT 1
+    ) AS a1,
+    NOT a1
+SELECT
+    tuple(1, 'a') AS a1,
+    tuple(1, 'a') IN (a1)

--- a/tests/queries/0_stateless/03786_AST_formatting_inconsistencies_in_debug_check.sh
+++ b/tests/queries/0_stateless/03786_AST_formatting_inconsistencies_in_debug_check.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# Test repeated alias for literal as 2nd arg to IN operator
+echo "SELECT ([1] AS foo), [1] IN ([1] AS foo);" | "$CLICKHOUSE_FORMAT"
+
+# Test repeated alias for statement which is not a literal
+echo "SELECT ([isNaN(1)] AS foo), [1] IN ([isNaN(1)] AS foo);" | "$CLICKHOUSE_FORMAT"
+
+# Test repeated alias for negated col
+echo "SELECT (-((-\`c1\`) AS \`a2\`)), NOT (-((-\`c1\`) AS \`a2\`)) from tab;" | "$CLICKHOUSE_FORMAT"
+
+# Test repeated alias in subquery after IN
+echo "SELECT ((SELECT [1,2,3]) AS a1), [5] IN ((SELECT [1,2,3]) AS a1);" | "$CLICKHOUSE_FORMAT"
+
+# Test repeated alias in subquery after NOT
+echo "SELECT ((SELECT 1) AS a1), NOT ((SELECT 1) AS a1);" | "$CLICKHOUSE_FORMAT"
+
+# Test repeated alias for tuple after IN
+echo "SELECT tuple(1, 'a') as a1, tuple(1, 'a') IN (tuple(1, 'a') as a1);" | "$CLICKHOUSE_FORMAT"


### PR DESCRIPTION
Fixes #93576.

Queries with subqueries or tuples with aliases in IN or NOT statements would be inconsistently wrapped in parentheses during the format-parse-format debug check.

f.e.
`SELECT ((SELECT [1,2,3]) AS a1), [5] IN ((SELECT [1,2,3]) AS a1)`
Formatted as:
`SELECT (SELECT [1, 2, 3]) AS a1, [5] IN a1`
Was parsed and formatted back as:
`SELECT (SELECT [1, 2, 3]) AS a1, [5] IN (a1)'`

Note the difference: `5 in a1` vs `5 in (a1)`.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.472`
<!-- ch-version-info:end -->