### PR TITLE
Fix attaching Replicated DBs when the interserver host changed after restarting

### DIFF
--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -612,7 +612,7 @@ void DatabaseReplicated::tryConnectToZooKeeperAndInitDatabase(LoadingStrictnessL
                         replica_host_id,
                         host_id);
 
-                // After restarting, InterserverIOAddress might change.
+                // After restarting, InterserverIOAddress might change (e.g: config updated, `getFQDNOrHostName` returns a different one)
                 // If the UUID in the keeper is the same as the current server UUID, we will update the host_id in keeper
                 LOG_INFO(
                     log,

--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -141,9 +141,6 @@ static inline String getHostID(ContextPtr global_context, const UUID & db_uuid, 
 // Return <address, port, uuid>
 static inline std::tuple<String, UInt16, UUID> parseHostID(const String & content)
 {
-    if (content.empty())
-        throw Exception(ErrorCodes::SYNTAX_ERROR, "Invalid host ID '{}'", content);
-
     auto pos = content.find_last_of(':');
     if (pos == std::string::npos || pos + 1 >= content.size())
         throw Exception(ErrorCodes::SYNTAX_ERROR, "Invalid host ID '{}'", content);

--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -1,6 +1,8 @@
+#include <Core/UUID.h>
 #include <DataTypes/DataTypeString.h>
 
 #include <atomic>
+#include <tuple>
 #include <utility>
 
 #include <Backups/IRestoreCoordination.h>
@@ -111,6 +113,7 @@ namespace ErrorCodes
     extern const int SUPPORT_IS_DISABLED;
     extern const int ASYNC_LOAD_CANCELED;
     extern const int KEEPER_EXCEPTION;
+    extern const int SYNTAX_ERROR;
     }
 namespace FailPoints
 {
@@ -133,6 +136,24 @@ static inline String getHostID(ContextPtr global_context, const UUID & db_uuid, 
     auto host_port = global_context->getInterserverIOAddress();
     UInt16 port = secure ? global_context->getTCPPortSecure().value_or(DBMS_DEFAULT_SECURE_PORT) : global_context->getTCPPort();
     return Cluster::Address::toString(host_port.first, port) + ':' + toString(db_uuid);
+}
+
+// Return <address, port, uuid>
+static inline std::tuple<String, UInt16, UUID> parseHostID(const String & content)
+{
+    if (content.empty())
+        throw Exception(ErrorCodes::SYNTAX_ERROR, "Invalid host ID '{}'", content);
+
+    auto pos = content.find_last_of(':');
+    if (pos == std::string::npos || pos + 1 >= content.size())
+        throw Exception(ErrorCodes::SYNTAX_ERROR, "Invalid host ID '{}'", content);
+
+    auto [address, port] = Cluster::Address::fromString(content.substr(0, pos));
+    UUID db_uuid;
+    if (!tryParse(db_uuid, content.substr(pos + 1)))
+        throw Exception(ErrorCodes::SYNTAX_ERROR, "Invalid host ID '{}'", content);
+
+    return {address, port, db_uuid};
 }
 
 static inline UInt64 getMetadataHash(const String & table_name, const String & metadata)
@@ -571,10 +592,39 @@ void DatabaseReplicated::tryConnectToZooKeeperAndInitDatabase(LoadingStrictnessL
 
             if (replica_host_id != host_id && replica_host_id != host_id_default)
             {
-                throw Exception(
-                    ErrorCodes::REPLICA_ALREADY_EXISTS,
-                    "Replica {} of shard {} of replicated database at {} already exists. Replica host ID: '{}', current host ID: '{}'",
-                    replica_name, shard_name, zookeeper_path, replica_host_id, host_id);
+                UUID uuid_in_keeper = UUIDHelpers::Nil;
+                try
+                {
+                    uuid_in_keeper = std::get<2>(parseHostID(replica_host_id));
+                }
+                catch (const Exception & e)
+                {
+                    LOG_WARNING(log, "Failed to parse host_id {} in zookeeper, error {}", host_id, e.what());
+                }
+
+                if (uuid_in_keeper != db_uuid)
+                    throw Exception(
+                        ErrorCodes::REPLICA_ALREADY_EXISTS,
+                        "Replica {} of shard {} of replicated database at {} already exists. Replica host ID: '{}', current host ID: '{}'",
+                        replica_name,
+                        shard_name,
+                        zookeeper_path,
+                        replica_host_id,
+                        host_id);
+
+                // After restarting, InterserverIOAddress might change.
+                // If the UUID in the keeper is the same as the current server UUID, we will update the host_id in keeper
+                LOG_INFO(
+                    log,
+                    "Replicated database replica: {}, shard {}, zk_path: {} already exists with the same UUID, replica host ID: '{}', "
+                    "current host ID: '{}', will set the host_id to the current host ID",
+                    replica_name,
+                    shard_name,
+                    zookeeper_path,
+                    replica_host_id,
+                    host_id);
+                current_zookeeper->set(replica_path, host_id, -1);
+                createEmptyLogEntry(current_zookeeper);
             }
 
             /// Before 24.6 we always created host_id with insecure port, even if cluster_auth_info.cluster_secure_connection was true.

--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -599,7 +599,7 @@ void DatabaseReplicated::tryConnectToZooKeeperAndInitDatabase(LoadingStrictnessL
                 }
                 catch (const Exception & e)
                 {
-                    LOG_WARNING(log, "Failed to parse host_id {} in zookeeper, error {}", host_id, e.what());
+                    LOG_WARNING(log, "Failed to parse host_id {} in zookeeper, error {}", replica_host_id, e.what());
                 }
 
                 if (uuid_in_keeper != db_uuid)

--- a/tests/integration/test_replicated_database_interserver_host/test.py
+++ b/tests/integration/test_replicated_database_interserver_host/test.py
@@ -1,6 +1,7 @@
 import pytest
 import urllib.parse
 from helpers.cluster import ClickHouseCluster
+import os
 
 cluster = ClickHouseCluster(__file__)
 
@@ -21,44 +22,55 @@ node2 = cluster.add_instance(
 )
 
 
+def update_interserver_http_address(node, new_address):
+    config_path = os.path.join(os.path.dirname(__file__), "configs/config.xml")
+
+    config_content = open(config_path).read()
+    config_content = config_content.replace("NODE_NAME", new_address)
+
+    # Debug: print the config and IP address
+    print(f"Configuring {node.name} with address {new_address}")
+    print(f"New config:\n{config_content}")
+
+    node.exec_in_container(
+        [
+            "bash",
+            "-c",
+            'echo "${NEW_CONFIG}" > /etc/clickhouse-server/config.d/interserver_host.xml',
+        ],
+        environment={"NEW_CONFIG": config_content},
+    )
+
+    # Verify the file was written
+    result = node.exec_in_container(
+        ["cat", "/etc/clickhouse-server/config.d/interserver_host.xml"]
+    )
+    print(f"Verification - Config file on {node.name}:\n{result}")
+
+    # IMPORTANT: interserver_http_host is only loaded at startup, not by SYSTEM RELOAD CONFIG
+    # So we need to restart ClickHouse
+    print(
+        f"Restarting ClickHouse on {node.name} to apply interserver_http_host config..."
+    )
+    node.restart_clickhouse()
+
+    # Verify the setting was applied
+    interserver_host = node.query(
+        "SELECT value FROM system.server_settings WHERE name = 'interserver_http_host'"
+    )
+    print(
+        f"Verification - interserver_http_host setting on {node.name}: {interserver_host}"
+    )
+
+
 @pytest.fixture(scope="module")
 def started_cluster():
     try:
         cluster.start()
 
         # Replace NODE_NAME placeholder with actual IP addresses in config
-        import os
-        config_path = os.path.join(
-            os.path.dirname(__file__), "configs/config.xml"
-        )
-
         for node in [node1, node2]:
-            config_content = open(config_path).read()
-            config_content = config_content.replace("NODE_NAME", node.ip_address)
-
-            # Debug: print the config and IP address
-            print(f"Configuring {node.name} with IP {node.ip_address}")
-            print(f"Config content:\n{config_content}")
-
-            node.exec_in_container(
-                ["bash", "-c", 'echo "${NEW_CONFIG}" > /etc/clickhouse-server/config.d/interserver_host.xml'],
-                environment={"NEW_CONFIG": config_content},
-            )
-
-            # Verify the file was written
-            result = node.exec_in_container(
-                ["cat", "/etc/clickhouse-server/config.d/interserver_host.xml"]
-            )
-            print(f"Verification - Config file on {node.name}:\n{result}")
-
-            # IMPORTANT: interserver_http_host is only loaded at startup, not by SYSTEM RELOAD CONFIG
-            # So we need to restart ClickHouse
-            print(f"Restarting ClickHouse on {node.name} to apply interserver_http_host config...")
-            node.restart_clickhouse()
-
-            # Verify the setting was applied
-            interserver_host = node.query("SELECT value FROM system.server_settings WHERE name = 'interserver_http_host'")
-            print(f"Verification - interserver_http_host setting on {node.name}: {interserver_host}")
+            update_interserver_http_address(node, node.ip_address)
 
         yield cluster
     finally:
@@ -103,6 +115,33 @@ def test_replicated_database_uses_interserver_host(started_cluster):
 
     count_on_node2 = node2.query("SELECT count() FROM test_db.test_table")
     assert count_on_node2.strip() == "3"
+
+    node1.query("DROP DATABASE test_db SYNC")
+    node2.query("DROP DATABASE test_db SYNC")
+
+
+def test_replicated_database_uses_interserver_host_changed(started_cluster):
+    """Test that interserver_http_host changed, and Replicated database is still able to be attached after restarting"""
+
+    node1.query(
+        "CREATE DATABASE test_db ENGINE = Replicated('/clickhouse/databases/test_db', 'shard1', 'node1')"
+    )
+    node2.query(
+        "CREATE DATABASE test_db ENGINE = Replicated('/clickhouse/databases/test_db', 'shard1', 'node2')"
+    )
+
+    node1.query("CREATE TABLE test_db.t (x INT, y INT) ENGINE=MergeTree ORDER BY x")
+
+    for node in [node1, node2]:
+        update_interserver_http_address(node, node.name)
+
+        node.query("SYSTEM FLUSH LOGS")
+        assert (
+            node.query(
+                "SELECT count() FROM system.text_log WHERE (level='Error') AND (logger_name='DatabaseReplicated (test_db)') AND (message LIKE '%replicated database at /clickhouse/databases/test_db already exists%')"
+            ).strip()
+            == "0"
+        )
 
     node1.query("DROP DATABASE test_db SYNC")
     node2.query("DROP DATABASE test_db SYNC")

--- a/tests/integration/test_replicated_database_interserver_host/test.py
+++ b/tests/integration/test_replicated_database_interserver_host/test.py
@@ -137,7 +137,13 @@ def test_replicated_database_uses_interserver_host_changed(started_cluster):
         node.query("SYSTEM FLUSH LOGS")
         assert (
             node.query(
-                "SELECT count() FROM system.text_log WHERE (level='Error') AND (logger_name='DatabaseReplicated (test_db)') AND (message LIKE '%replicated database at /clickhouse/databases/test_db already exists%')"
+                """
+                SELECT count()
+                FROM system.text_log
+                WHERE (level='Error')
+                  AND (logger_name='DatabaseReplicated (test_db)')
+                  AND (message LIKE '%replicated database at /clickhouse/databases/test_db already exists%')
+                """
             ).strip()
             == "0"
         )

--- a/tests/integration/test_replicated_database_interserver_host/test.py
+++ b/tests/integration/test_replicated_database_interserver_host/test.py
@@ -67,18 +67,17 @@ def update_interserver_http_address(node, new_address):
 def started_cluster():
     try:
         cluster.start()
-
-        # Replace NODE_NAME placeholder with actual IP addresses in config
-        for node in [node1, node2]:
-            update_interserver_http_address(node, node.ip_address)
-
         yield cluster
+
     finally:
         cluster.shutdown()
 
 
 def test_replicated_database_uses_interserver_host(started_cluster):
     """Test that DatabaseReplicated uses interserver_http_host for replica registration."""
+
+    for node in [node1, node2]:
+        update_interserver_http_address(node, node.ip_address)
 
     node1.query(
         "CREATE DATABASE test_db ENGINE = Replicated('/clickhouse/databases/test_db', 'shard1', 'node1')"


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix attaching Replicated DBs when the interserver host changed after restarting.

After ClickHouse restarted, the interserver host might change. However, for Replicated DBs, we store host_id, which includes the host, in the replica_path. When attaching after restarting, the host_id mismatched and throw an error.

In this PR, if the host_id mismatch, but the UUID is the same, we set replica_path data to the new host_id.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.495`
- Backported to: `25.12.5.7`, `25.11.8.8`, `25.10.6.9`, `25.8.16.21`, `25.3.14.11`
<!-- ch-version-info:end -->