### PR TITLE
Remove begin/end token iterators from ASTLiteral as it used only for highlighting and VALUES parsing

### DIFF
--- a/src/Parsers/ASTLiteral.h
+++ b/src/Parsers/ASTLiteral.h
@@ -1,12 +1,9 @@
 #pragma once
 
 #include <Core/Field.h>
-#include <Parsers/ASTWithAlias.h>
-#include <Parsers/TokenIterator.h>
-#include <Common/FieldVisitorDump.h>
 #include <DataTypes/IDataType.h>
-
-#include <optional>
+#include <Parsers/ASTWithAlias.h>
+#include <Common/FieldVisitorDump.h>
 
 
 namespace DB
@@ -16,20 +13,20 @@ namespace DB
 class ASTLiteral : public ASTWithAlias
 {
 public:
-    explicit ASTLiteral(Field value_) : value(std::move(value_)) {}
+    explicit ASTLiteral(Field value_)
+        : value(std::move(value_))
+    {
+    }
 
     // This methond and the custom_type are only used for Apache Gluten,
-    explicit ASTLiteral(Field value_, DataTypePtr & type_) : value(std::move(value_))
+    explicit ASTLiteral(Field value_, DataTypePtr & type_)
+        : value(std::move(value_))
     {
         custom_type = type_;
     }
 
     Field value;
     DataTypePtr custom_type;
-
-    /// For ConstantExpressionTemplate
-    std::optional<TokenIterator> begin;
-    std::optional<TokenIterator> end;
 
     /*
      * The name of the column corresponding to this literal. Only used to

--- a/src/Parsers/ExpressionElementParsers.cpp
+++ b/src/Parsers/ExpressionElementParsers.cpp
@@ -1,7 +1,7 @@
 #include <cerrno>
+#include <cmath>
 #include <cstdlib>
 #include <Poco/String.h>
-#include <cmath>
 
 #include <IO/ReadBufferFromMemory.h>
 #include <IO/ReadHelpers.h>
@@ -12,37 +12,37 @@
 #include <Common/quoteString.h>
 #include <Common/typeid_cast.h>
 
-#include <Parsers/CommonParsers.h>
-#include <Parsers/DumpASTNode.h>
+#include <Parsers/ASTAssignment.h>
 #include <Parsers/ASTAsterisk.h>
 #include <Parsers/ASTCollation.h>
+#include <Parsers/ASTColumnsMatcher.h>
 #include <Parsers/ASTColumnsTransformers.h>
+#include <Parsers/ASTExplainQuery.h>
 #include <Parsers/ASTExpressionList.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTFunctionWithKeyValueArguments.h>
 #include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTInterpolateElement.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTOrderByElement.h>
-#include <Parsers/ASTInterpolateElement.h>
 #include <Parsers/ASTQualifiedAsterisk.h>
 #include <Parsers/ASTQueryParameter.h>
+#include <Parsers/ASTSelectQuery.h>
 #include <Parsers/ASTSelectWithUnionQuery.h>
+#include <Parsers/ASTSetQuery.h>
 #include <Parsers/ASTSubquery.h>
 #include <Parsers/ASTTTLElement.h>
-#include <Parsers/ASTWindowDefinition.h>
-#include <Parsers/ASTAssignment.h>
-#include <Parsers/ASTColumnsMatcher.h>
-#include <Parsers/ASTExplainQuery.h>
-#include <Parsers/ASTSetQuery.h>
-#include <Parsers/ASTSelectQuery.h>
 #include <Parsers/ASTTablesInSelectQuery.h>
+#include <Parsers/ASTWindowDefinition.h>
+#include <Parsers/CommonParsers.h>
+#include <Parsers/DumpASTNode.h>
+#include <Parsers/ExpressionElementParsers.h>
 #include <Parsers/ExpressionListParsers.h>
 #include <Parsers/IAST_erase.h>
 #include <Parsers/IAST_fwd.h>
-#include <Parsers/ParserSelectWithUnionQuery.h>
-#include <Parsers/ExpressionElementParsers.h>
 #include <Parsers/ParserCreateQuery.h>
 #include <Parsers/ParserExplainQuery.h>
+#include <Parsers/ParserSelectWithUnionQuery.h>
 
 #include <Interpreters/StorageID.h>
 
@@ -52,9 +52,40 @@ namespace DB
 
 namespace ErrorCodes
 {
-    extern const int BAD_ARGUMENTS;
-    extern const int SYNTAX_ERROR;
-    extern const int LOGICAL_ERROR;
+extern const int BAD_ARGUMENTS;
+extern const int SYNTAX_ERROR;
+extern const int LOGICAL_ERROR;
+}
+
+namespace
+{
+/// Thread-local storage for literal token positions.
+/// Used by ValuesBlockInputFormat to capture token positions for ConstantExpressionTemplate.
+thread_local LiteralTokenMap * g_literal_token_map = nullptr;
+
+/// Helper to record literal token position if the thread-local map is set.
+/// Extracts raw char* positions from TokenIterator - these point into the query buffer.
+inline void recordLiteralTokens(const ASTLiteral * literal, IParser::Pos begin, IParser::Pos end)
+{
+    if (g_literal_token_map)
+    {
+        /// Store the character positions, not the iterators.
+        /// begin points to first token of literal, end points to one-past-last token.
+        /// We need the char* range: [first_token.begin, last_token.end)
+        --end; /// end was pointing past the literal, go back to last token of literal
+        g_literal_token_map->emplace(literal, LiteralTokenInfo{begin->begin, end->end});
+    }
+}
+}
+
+void setLiteralTokenMap(LiteralTokenMap * map)
+{
+    g_literal_token_map = map;
+}
+
+LiteralTokenMap * getLiteralTokenMap()
+{
+    return g_literal_token_map;
 }
 
 /*
@@ -129,7 +160,8 @@ bool ParserSubquery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
         if (ASTPtr explained_query = explain_query.getExplainedQuery())
             if (const auto * explained_query_with_output = dynamic_cast<const ASTQueryWithOutput *>(explained_query.get()))
                 if (explained_query_with_output->hasOutputOptions())
-                    throw Exception(ErrorCodes::BAD_ARGUMENTS, "EXPLAIN in a subquery cannot have output options, such as FORMAT or INTO OUTFILE");
+                    throw Exception(
+                        ErrorCodes::BAD_ARGUMENTS, "EXPLAIN in a subquery cannot have output options, such as FORMAT or INTO OUTFILE");
 
         /// Replace subquery `(EXPLAIN <kind> <explain_settings> SELECT ...)`
         /// with `(SELECT * FROM viewExplain('<kind>', '<explain_settings>', (SELECT ...)))`
@@ -150,7 +182,8 @@ bool ParserSubquery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
             if (!explained_ast->as<ASTSelectWithUnionQuery>())
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "EXPLAIN inside subquery supports only SELECT queries");
 
-            auto view_explain = makeASTFunction("viewExplain",
+            auto view_explain = makeASTFunction(
+                "viewExplain",
                 std::make_shared<ASTLiteral>(kind_str),
                 std::make_shared<ASTLiteral>(settings_str),
                 std::make_shared<ASTSubquery>(explained_ast));
@@ -158,9 +191,8 @@ bool ParserSubquery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
         }
         else
         {
-            auto view_explain = makeASTFunction("viewExplain",
-                std::make_shared<ASTLiteral>(kind_str),
-                std::make_shared<ASTLiteral>(settings_str));
+            auto view_explain
+                = makeASTFunction("viewExplain", std::make_shared<ASTLiteral>(kind_str), std::make_shared<ASTLiteral>(settings_str));
             result_node = buildSelectFromTableFunction(view_explain);
         }
     }
@@ -199,7 +231,7 @@ bool ParserIdentifier::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
         else
             readDoubleQuotedStringWithSQLStyle(s, buf);
 
-        if (s.empty())    /// Identifiers "empty string" are not allowed.
+        if (s.empty()) /// Identifiers "empty string" are not allowed.
             return false;
 
         node = std::make_shared<ASTIdentifier>(s);
@@ -336,8 +368,12 @@ bool ParserCompoundIdentifier::parseImpl(Pos & pos, ASTPtr & node, Expected & ex
 {
     auto element_parser = std::make_unique<ParserIdentifier>(allow_query_parameter, highlight_type);
     std::vector<std::pair<ParserPtr, SpecialDelimiter>> delimiter_parsers;
-    delimiter_parsers.emplace_back(std::make_unique<ParserTokenSequence>(std::vector<TokenType>{TokenType::Dot, TokenType::Colon}), SpecialDelimiter::JSON_PATH_DYNAMIC_TYPE);
-    delimiter_parsers.emplace_back(std::make_unique<ParserTokenSequence>(std::vector<TokenType>{TokenType::Dot, TokenType::Caret}), SpecialDelimiter::JSON_PATH_PREFIX);
+    delimiter_parsers.emplace_back(
+        std::make_unique<ParserTokenSequence>(std::vector<TokenType>{TokenType::Dot, TokenType::Colon}),
+        SpecialDelimiter::JSON_PATH_DYNAMIC_TYPE);
+    delimiter_parsers.emplace_back(
+        std::make_unique<ParserTokenSequence>(std::vector<TokenType>{TokenType::Dot, TokenType::Caret}),
+        SpecialDelimiter::JSON_PATH_PREFIX);
     delimiter_parsers.emplace_back(std::make_unique<ParserToken>(TokenType::Dot), SpecialDelimiter::NONE);
     ParserArrayOfJSONIdentifierAddition array_of_json_identifier_addition;
 
@@ -411,8 +447,10 @@ bool ParserCompoundIdentifier::parseImpl(Pos & pos, ASTPtr & node, Expected & ex
             uuid = parseFromString<UUID>(ast_uuid->as<ASTLiteral>()->value.safeGet<String>());
         }
 
-        if (parts.size() == 1) node = std::make_shared<ASTTableIdentifier>(parts[0], std::move(params));
-        else node = std::make_shared<ASTTableIdentifier>(parts[0], parts[1], std::move(params));
+        if (parts.size() == 1)
+            node = std::make_shared<ASTTableIdentifier>(parts[0], std::move(params));
+        else
+            node = std::make_shared<ASTTableIdentifier>(parts[0], parts[1], std::move(params));
         node->as<ASTTableIdentifier>()->uuid = uuid;
     }
     else
@@ -477,10 +515,10 @@ bool ParserFilterClause::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
     {
         /// Remove child from function.arguments if it's '*' because countIf(*) is not supported.
         /// See https://github.com/ClickHouse/ClickHouse/issues/61004
-        std::erase_if(function.arguments->children, [] (const ASTPtr & child)
-        {
-            return typeid_cast<const ASTAsterisk *>(child.get()) || typeid_cast<const ASTQualifiedAsterisk *>(child.get());
-        });
+        std::erase_if(
+            function.arguments->children,
+            [](const ASTPtr & child)
+            { return typeid_cast<const ASTAsterisk *>(child.get()) || typeid_cast<const ASTQualifiedAsterisk *>(child.get()); });
     }
 
     function.name += "If";
@@ -517,8 +555,7 @@ bool ParserWindowReference::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
     return res;
 }
 
-static bool tryParseFrameDefinition(ASTWindowDefinition * node, IParser::Pos & pos,
-    Expected & expected)
+static bool tryParseFrameDefinition(ASTWindowDefinition * node, IParser::Pos & pos, Expected & expected)
 {
     ParserKeyword keyword_rows(Keyword::ROWS);
     ParserKeyword keyword_groups(Keyword::GROUPS);
@@ -588,8 +625,7 @@ static bool tryParseFrameDefinition(ASTWindowDefinition * node, IParser::Pos & p
             node->frame_begin_preceding = false;
             if (node->frame_begin_type == WindowFrame::BoundaryType::Unbounded)
             {
-                throw Exception(ErrorCodes::BAD_ARGUMENTS,
-                    "Frame start cannot be UNBOUNDED FOLLOWING");
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Frame start cannot be UNBOUNDED FOLLOWING");
             }
         }
         else
@@ -632,8 +668,7 @@ static bool tryParseFrameDefinition(ASTWindowDefinition * node, IParser::Pos & p
                 node->frame_end_preceding = true;
                 if (node->frame_end_type == WindowFrame::BoundaryType::Unbounded)
                 {
-                    throw Exception(ErrorCodes::BAD_ARGUMENTS,
-                        "Frame end cannot be UNBOUNDED PRECEDING");
+                    throw Exception(ErrorCodes::BAD_ARGUMENTS, "Frame end cannot be UNBOUNDED PRECEDING");
                 }
             }
             else if (keyword_following.ignore(pos, expected))
@@ -652,12 +687,10 @@ static bool tryParseFrameDefinition(ASTWindowDefinition * node, IParser::Pos & p
 }
 
 // All except parent window name.
-static bool parseWindowDefinitionParts(IParser::Pos & pos,
-    ASTWindowDefinition & node, Expected & expected)
+static bool parseWindowDefinitionParts(IParser::Pos & pos, ASTWindowDefinition & node, Expected & expected)
 {
     ParserKeyword keyword_partition_by(Keyword::PARTITION_BY);
-    ParserNotEmptyExpressionList columns_partition_by(
-        false /* we don't allow declaring aliases here*/);
+    ParserNotEmptyExpressionList columns_partition_by(false /* we don't allow declaring aliases here*/);
     ParserKeyword keyword_order_by(Keyword::ORDER_BY);
     ParserOrderByExpressionList columns_order_by;
 
@@ -785,8 +818,8 @@ bool ParserWindowList::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 
 bool ParserCodecDeclarationList::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 {
-    return ParserList(std::make_unique<ParserIdentifierWithOptionalParameters>(),
-        std::make_unique<ParserToken>(TokenType::Comma), false).parse(pos, node, expected);
+    return ParserList(std::make_unique<ParserIdentifierWithOptionalParameters>(), std::make_unique<ParserToken>(TokenType::Comma), false)
+        .parse(pos, node, expected);
 }
 
 bool ParserCodec::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
@@ -817,8 +850,8 @@ bool ParserCodec::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 
 bool ParserStatisticsType::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 {
-    ParserList stat_type_parser(std::make_unique<ParserIdentifierWithOptionalParameters>(),
-        std::make_unique<ParserToken>(TokenType::Comma), false);
+    ParserList stat_type_parser(
+        std::make_unique<ParserIdentifierWithOptionalParameters>(), std::make_unique<ParserToken>(TokenType::Comma), false);
 
     if (pos->type != TokenType::OpeningRoundBracket)
         return false;
@@ -852,11 +885,8 @@ bool ParserCollation::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     // check the collation name is valid
     const String name = getIdentifierName(collation);
 
-    bool valid_collation = name == "binary" ||
-                           endsWith(name, "_bin") ||
-                           endsWith(name, "_ci") ||
-                           endsWith(name, "_cs") ||
-                           endsWith(name, "_ks");
+    bool valid_collation
+        = name == "binary" || endsWith(name, "_bin") || endsWith(name, "_ci") || endsWith(name, "_cs") || endsWith(name, "_ks");
 
     if (!valid_collation)
         return false;
@@ -868,7 +898,7 @@ bool ParserCollation::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 }
 
 
-template <TokenType ...tokens>
+template <TokenType... tokens>
 static bool isOneOf(TokenType token)
 {
     return ((token == tokens) || ...);
@@ -967,8 +997,7 @@ bool ParserCastOperator::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
         return false;
 
     ASTPtr type_ast;
-    if (ParserToken(DoubleColon).ignore(pos, expected)
-        && ParserDataType().parse(pos, type_ast, expected))
+    if (ParserToken(DoubleColon).ignore(pos, expected) && ParserDataType().parse(pos, type_ast, expected))
     {
         size_t data_size = data_end - data_begin;
         if (string_literal)
@@ -1015,7 +1044,7 @@ bool ParserBool::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 
 static bool parseNumber(char * buffer, size_t size, bool negative, int base, Field & res)
 {
-    errno = 0;    /// Functions strto* don't clear errno.
+    errno = 0; /// Functions strto* don't clear errno.
 
     char * pos_integer = buffer;
     UInt64 uint_value = std::strtoull(buffer, &pos_integer, base);
@@ -1047,7 +1076,7 @@ bool ParserNumber::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
         ++pos;
         negative = true;
     }
-    else if (pos->type == TokenType::Plus)  /// Leading plus is simply ignored.
+    else if (pos->type == TokenType::Plus) /// Leading plus is simply ignored.
         ++pos;
 
     Field res;
@@ -1059,16 +1088,17 @@ bool ParserNumber::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     {
         std::string buf(it, end); /// Copying is needed to ensure the string is 0-terminated.
         char * str_end;
-        errno = 0;    /// Functions strto* don't clear errno.
+        errno = 0; /// Functions strto* don't clear errno.
         /// The usage of strtod is needed, because we parse hex floating point literals as well.
         Float64 float_value = std::strtod(buf.c_str(), &str_end);
         bool overflow = (errno == ERANGE && !std::isfinite(float_value));
         if (str_end == buf.c_str() + buf.size() && !overflow)
         {
             if (float_value < 0)
-                throw Exception(ErrorCodes::LOGICAL_ERROR,
-                                "Token number cannot begin with minus, "
-                                "but parsed float number is less than zero.");
+                throw Exception(
+                    ErrorCodes::LOGICAL_ERROR,
+                    "Token number cannot begin with minus, "
+                    "but parsed float number is less than zero.");
 
             if (negative)
                 float_value = -float_value;
@@ -1076,8 +1106,8 @@ bool ParserNumber::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
             res = float_value;
 
             auto literal = std::make_shared<ASTLiteral>(res);
-            literal->begin = literal_begin;
-            literal->end = ++pos;
+            ++pos;
+            recordLiteralTokens(literal.get(), literal_begin, pos);
             node = literal;
 
             return true;
@@ -1138,8 +1168,8 @@ bool ParserNumber::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
             if (parseNumber(start_pos, size, negative, 2, res))
             {
                 auto literal = std::make_shared<ASTLiteral>(res);
-                literal->begin = literal_begin;
-                literal->end = ++pos;
+                ++pos;
+                recordLiteralTokens(literal.get(), literal_begin, pos);
                 node = literal;
 
                 return true;
@@ -1155,8 +1185,8 @@ bool ParserNumber::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
             if (parseNumber(start_pos, size, negative, 16, res))
             {
                 auto literal = std::make_shared<ASTLiteral>(res);
-                literal->begin = literal_begin;
-                literal->end = ++pos;
+                ++pos;
+                recordLiteralTokens(literal.get(), literal_begin, pos);
                 node = literal;
 
                 return true;
@@ -1173,8 +1203,8 @@ bool ParserNumber::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
             if (parseNumber(start_pos, size, negative, 10, res))
             {
                 auto literal = std::make_shared<ASTLiteral>(res);
-                literal->begin = literal_begin;
-                literal->end = ++pos;
+                ++pos;
+                recordLiteralTokens(literal.get(), literal_begin, pos);
                 node = literal;
 
                 return true;
@@ -1184,8 +1214,8 @@ bool ParserNumber::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     else if (parseNumber(start_pos, size, negative, 10, res))
     {
         auto literal = std::make_shared<ASTLiteral>(res);
-        literal->begin = literal_begin;
-        literal->end = ++pos;
+        ++pos;
+        recordLiteralTokens(literal.get(), literal_begin, pos);
         node = literal;
 
         return true;
@@ -1212,8 +1242,9 @@ bool ParserUnsignedInteger::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
 
     res = x;
     auto literal = std::make_shared<ASTLiteral>(res);
-    literal->begin = pos;
-    literal->end = ++pos;
+    IParser::Pos literal_begin = pos;
+    ++pos;
+    recordLiteralTokens(literal.get(), literal_begin, pos);
     node = literal;
     return true;
 }
@@ -1221,8 +1252,9 @@ bool ParserUnsignedInteger::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
 inline static bool makeStringLiteral(IParser::Pos & pos, ASTPtr & node, String str)
 {
     auto literal = std::make_shared<ASTLiteral>(str);
-    literal->begin = pos;
-    literal->end = ++pos;
+    IParser::Pos literal_begin = pos;
+    ++pos;
+    recordLiteralTokens(literal.get(), literal_begin, pos);
     node = literal;
     return true;
 }
@@ -1312,7 +1344,8 @@ bool ParserStringLiteral::parseImpl(Pos & pos, ASTPtr & node, Expected & expecte
 template <typename Collection>
 struct CollectionOfLiteralsLayer
 {
-    explicit CollectionOfLiteralsLayer(IParser::Pos & pos) : literal_begin(pos)
+    explicit CollectionOfLiteralsLayer(IParser::Pos & pos)
+        : literal_begin(pos)
     {
         ++pos;
     }
@@ -1344,8 +1377,9 @@ bool ParserCollectionOfLiterals<Collection>::parseImpl(Pos & pos, ASTPtr & node,
                     return false;
 
                 std::shared_ptr<ASTLiteral> literal = std::make_shared<ASTLiteral>(std::move(layers.back().arr));
-                literal->begin = layers.back().literal_begin;
-                literal->end = ++pos;
+                IParser::Pos literal_begin = layers.back().literal_begin;
+                ++pos;
+                recordLiteralTokens(literal.get(), literal_begin, pos);
 
                 layers.pop_back();
                 pos.decreaseDepth();
@@ -1413,7 +1447,10 @@ template <class Container, TokenType end_token>
 class CommonCollection : public ICollection
 {
 public:
-    explicit CommonCollection(const IParser::Pos & pos) : begin(pos) {}
+    explicit CommonCollection(const IParser::Pos & pos)
+        : begin(pos)
+    {
+    }
 
     bool parse(IParser::Pos & pos, Collections & collections, ASTPtr & node, Expected & expected, bool allow_map) override;
 
@@ -1425,7 +1462,10 @@ private:
 class MapCollection : public ICollection
 {
 public:
-    explicit MapCollection(const IParser::Pos & pos) : begin(pos) {}
+    explicit MapCollection(const IParser::Pos & pos)
+        : begin(pos)
+    {
+    }
 
     bool parse(IParser::Pos & pos, Collections & collections, ASTPtr & node, Expected & expected, bool allow_map) override;
 
@@ -1450,7 +1490,8 @@ bool parseAllCollectionsStart(IParser::Pos & pos, Collections & collections, Exp
 }
 
 template <class Container, TokenType end_token>
-bool CommonCollection<Container, end_token>::parse(IParser::Pos & pos, Collections & collections, ASTPtr & node, Expected & expected, bool allow_map)
+bool CommonCollection<Container, end_token>::parse(
+    IParser::Pos & pos, Collections & collections, ASTPtr & node, Expected & expected, bool allow_map)
 {
     if (node)
     {
@@ -1468,8 +1509,7 @@ bool CommonCollection<Container, end_token>::parse(IParser::Pos & pos, Collectio
         if (end_p.ignore(pos, expected))
         {
             auto result = std::make_shared<ASTLiteral>(std::move(container));
-            result->begin = begin;
-            result->end = pos;
+            recordLiteralTokens(result.get(), begin, pos);
 
             node = std::move(result);
             break;
@@ -1506,8 +1546,7 @@ bool MapCollection::parse(IParser::Pos & pos, Collections & collections, ASTPtr 
         if (end_p.ignore(pos, expected))
         {
             auto result = std::make_shared<ASTLiteral>(std::move(container));
-            result->begin = begin;
-            result->end = pos;
+            recordLiteralTokens(result.get(), begin, pos);
 
             node = std::move(result);
             break;
@@ -1579,52 +1618,13 @@ bool ParserLiteral::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 }
 
 
-const char * ParserAlias::restricted_keywords[] =
-{
-    "ALL",
-    "ANTI",
-    "ANY",
-    "ARRAY",
-    "ASOF",
-    "BETWEEN",
-    "CROSS",
-    "PASTE",
-    "FINAL",
-    "FORMAT",
-    "FROM",
-    "FULL",
-    "GLOBAL",
-    "GROUP",
-    "HAVING",
-    "ILIKE",
-    "INNER",
-    "INTO",
-    "JOIN",
-    "LEFT",
-    "LIKE",
-    "LIMIT",
-    "NOT",
-    "OFFSET",
-    "ON",
-    "ONLY", /// YQL's synonym for ANTI. Note: YQL is the name of one of proprietary languages, completely unrelated to ClickHouse.
-    "ORDER",
-    "PARALLEL",
-    "PREWHERE",
-    "RIGHT",
-    "SAMPLE",
-    "SEMI",
-    "SETTINGS",
-    "UNION",
-    "USING",
-    "WHERE",
-    "WINDOW",
-    "QUALIFY",
-    "WITH",
-    "INTERSECT",
-    "EXCEPT",
-    "ELSE",
-    nullptr
-};
+const char * ParserAlias::restricted_keywords[]
+    = {"ALL",    "ANTI",     "ANY",      "ARRAY",  "ASOF",      "BETWEEN", "CROSS",    "PASTE", "FINAL",
+       "FORMAT", "FROM",     "FULL",     "GLOBAL", "GROUP",     "HAVING",  "ILIKE",    "INNER", "INTO",
+       "JOIN",   "LEFT",     "LIKE",     "LIMIT",  "NOT",       "OFFSET",  "ON",
+       "ONLY", /// YQL's synonym for ANTI. Note: YQL is the name of one of proprietary languages, completely unrelated to ClickHouse.
+       "ORDER",  "PARALLEL", "PREWHERE", "RIGHT",  "SAMPLE",    "SEMI",    "SETTINGS", "UNION", "USING",
+       "WHERE",  "WINDOW",   "QUALIFY",  "WITH",   "INTERSECT", "EXCEPT",  "ELSE",     nullptr};
 
 bool ParserAlias::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 {
@@ -1685,7 +1685,9 @@ bool ParserColumnsTransformers::parseImpl(Pos & pos, ASTPtr & node, Expected & e
             if (auto * func = lambda->as<ASTFunction>(); func && func->name == "lambda")
             {
                 if (!isASTLambdaFunction(*func))
-                    throw Exception(ErrorCodes::SYNTAX_ERROR, "Lambda function definition expects two arguments, first argument must be a tuple of arguments");
+                    throw Exception(
+                        ErrorCodes::SYNTAX_ERROR,
+                        "Lambda function definition expects two arguments, first argument must be a tuple of arguments");
 
                 const auto * lambda_args_tuple = func->arguments->children.at(0)->as<ASTFunction>();
                 if (!lambda_args_tuple || lambda_args_tuple->name != "tuple")
@@ -1926,7 +1928,8 @@ bool ParserQualifiedAsterisk::parseImpl(Pos & pos, ASTPtr & node, Expected & exp
 }
 
 /// Parse (columns_list) or ('REGEXP').
-static bool parseColumnsMatcherBody(IParser::Pos & pos, ASTPtr & node, Expected & expected, ParserColumnsTransformers::ColumnTransformers allowed_transformers)
+static bool parseColumnsMatcherBody(
+    IParser::Pos & pos, ASTPtr & node, Expected & expected, ParserColumnsTransformers::ColumnTransformers allowed_transformers)
 {
     if (pos->type != TokenType::OpeningRoundBracket)
         return false;
@@ -2374,7 +2377,7 @@ bool ParserFunctionWithKeyValueArguments::parseImpl(Pos & pos, ASTPtr & node, Ex
     if (pos.get().type != TokenType::OpeningRoundBracket)
     {
         if (!brackets_can_be_omitted)
-             return false;
+            return false;
     }
     else
     {
@@ -2428,8 +2431,7 @@ bool ParserTTLElement::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     /// 2: MODIFY TTL timestamp + 123, MATERIALIZE TTL
     /// In the first case, materialize belongs to the list of TTL expressions, so it is the part of TTLElement.
     /// In the second case, MATERIALIZE TTL is a separate element of the alter, so it can't be parsed as a TTLElement.
-    if (s_materialize_ttl.checkWithoutMoving(pos, expected)
-        || s_remove_ttl.checkWithoutMoving(pos, expected)
+    if (s_materialize_ttl.checkWithoutMoving(pos, expected) || s_remove_ttl.checkWithoutMoving(pos, expected)
         || s_modify_ttl.checkWithoutMoving(pos, expected))
         return false;
 
@@ -2490,8 +2492,7 @@ bool ParserTTLElement::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 
         if (s_set.ignore(pos, expected))
         {
-            ParserList parser_assignment_list(
-                std::make_unique<ParserAssignment>(), std::make_unique<ParserToken>(TokenType::Comma));
+            ParserList parser_assignment_list(std::make_unique<ParserAssignment>(), std::make_unique<ParserToken>(TokenType::Comma));
 
             if (!parser_assignment_list.parse(pos, group_by_assignments, expected))
                 return false;

--- a/src/Parsers/ExpressionElementParsers.cpp
+++ b/src/Parsers/ExpressionElementParsers.cpp
@@ -73,7 +73,10 @@ inline void recordLiteralTokens(const ASTLiteral * literal, IParser::Pos begin, 
         /// begin points to first token of literal, end points to one-past-last token.
         /// We need the char* range: [first_token.begin, last_token.end)
         --end; /// end was pointing past the literal, go back to last token of literal
-        g_literal_token_map->emplace(literal, LiteralTokenInfo{begin->begin, end->end});
+        /// Use insert_or_assign to handle memory reuse - the parser may reuse the same
+        /// memory address for different ASTLiteral objects. The final AST will have
+        /// the last literal created at each address, so we want the last token info.
+        g_literal_token_map->insert_or_assign(literal, LiteralTokenInfo{begin->begin, end->end});
     }
 }
 }

--- a/src/Parsers/ExpressionElementParsers.cpp
+++ b/src/Parsers/ExpressionElementParsers.cpp
@@ -1017,6 +1017,8 @@ bool ParserCastOperator::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
 
 bool ParserNull::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 {
+    /// Note: NULL literals are intentionally NOT recorded in the token map.
+    /// They are treated as tokens (not templated) because Nullable(Nothing) templates are useless.
     ParserKeyword nested_parser(Keyword::NULL_KEYWORD);
     if (nested_parser.parse(pos, node, expected))
     {
@@ -1029,6 +1031,8 @@ bool ParserNull::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 
 bool ParserBool::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 {
+    /// Note: Bool literals are intentionally NOT recorded in the token map.
+    /// The ConstantExpressionTemplate system does not support Bool type for templating.
     if (ParserKeyword(Keyword::TRUE_KEYWORD).parse(pos, node, expected))
     {
         node = std::make_shared<ASTLiteral>(true);

--- a/src/Parsers/ExpressionElementParsers.h
+++ b/src/Parsers/ExpressionElementParsers.h
@@ -21,7 +21,7 @@ class ASTLiteral;
 struct LiteralTokenInfo
 {
     const char * begin; /// Start of literal in query string
-    const char * end; /// End of literal in query string
+    const char * end;   /// End of literal in query string
 
     LiteralTokenInfo(const char * begin_, const char * end_)
         : begin(begin_)

--- a/src/Parsers/ExpressionElementParsers.h
+++ b/src/Parsers/ExpressionElementParsers.h
@@ -3,10 +3,69 @@
 #include <Core/Field.h>
 #include <Core/MultiEnum.h>
 #include <Parsers/IParserBase.h>
+#include <Parsers/TokenIterator.h>
 
+#include <unordered_map>
 
 namespace DB
 {
+
+class ASTLiteral;
+
+/// Token position info for literals - stores raw character pointers into the query string.
+/// Used for ConstantExpressionTemplate construction and LIKE/REGEXP syntax highlighting.
+/// Stored externally to reduce ASTLiteral size by ~48 bytes per literal.
+///
+/// IMPORTANT: These are raw pointers into the original query string. They are only valid
+/// during parsing while the query buffer exists. Do not store or access after parsing.
+struct LiteralTokenInfo
+{
+    const char * begin; /// Start of literal in query string
+    const char * end; /// End of literal in query string
+
+    LiteralTokenInfo(const char * begin_, const char * end_)
+        : begin(begin_)
+        , end(end_)
+    {
+    }
+};
+using LiteralTokenMap = std::unordered_map<const ASTLiteral *, LiteralTokenInfo>;
+
+/// Thread-local map for capturing literal token positions during parsing.
+/// Used by ValuesBlockInputFormat for ConstantExpressionTemplate and by
+/// ParserExpression for LIKE/REGEXP syntax highlighting.
+///
+/// IMPORTANT: The map stores raw pointers to ASTLiteral nodes. It must only be
+/// used during parsing while the AST nodes are still valid. Do not store or
+/// access the map after parsing completes.
+void setLiteralTokenMap(LiteralTokenMap * map);
+LiteralTokenMap * getLiteralTokenMap();
+
+/// RAII guard for managing the thread-local LiteralTokenMap.
+/// Creates a local map and sets it as the thread-local; restores previous state on destruction.
+/// Use this instead of manual setLiteralTokenMap/SCOPE_EXIT pairs.
+class LiteralTokenMapScope
+{
+public:
+    LiteralTokenMapScope()
+        : prev_map(getLiteralTokenMap())
+    {
+        setLiteralTokenMap(&map);
+    }
+
+    ~LiteralTokenMapScope() { setLiteralTokenMap(prev_map); }
+
+    LiteralTokenMap & get() { return map; }
+    const LiteralTokenMap & get() const { return map; }
+
+    /// Non-copyable, non-movable
+    LiteralTokenMapScope(const LiteralTokenMapScope &) = delete;
+    LiteralTokenMapScope & operator=(const LiteralTokenMapScope &) = delete;
+
+private:
+    LiteralTokenMap map;
+    LiteralTokenMap * prev_map;
+};
 
 
 /** The SELECT subquery, in parentheses.
@@ -26,7 +85,10 @@ class ParserIdentifier : public IParserBase
 {
 public:
     explicit ParserIdentifier(bool allow_query_parameter_ = false, Highlight highlight_type_ = Highlight::identifier)
-        : allow_query_parameter(allow_query_parameter_), highlight_type(highlight_type_) {}
+        : allow_query_parameter(allow_query_parameter_)
+        , highlight_type(highlight_type_)
+    {
+    }
     Highlight highlight() const override { return highlight_type; }
 
 protected:
@@ -61,8 +123,11 @@ protected:
 class ParserCompoundIdentifier : public IParserBase
 {
 public:
-    explicit ParserCompoundIdentifier(bool table_name_with_optional_uuid_ = false, bool allow_query_parameter_ = false, Highlight highlight_type_ = Highlight::identifier)
-        : table_name_with_optional_uuid(table_name_with_optional_uuid_), allow_query_parameter(allow_query_parameter_), highlight_type(highlight_type_)
+    explicit ParserCompoundIdentifier(
+        bool table_name_with_optional_uuid_ = false, bool allow_query_parameter_ = false, Highlight highlight_type_ = Highlight::identifier)
+        : table_name_with_optional_uuid(table_name_with_optional_uuid_)
+        , allow_query_parameter(allow_query_parameter_)
+        , highlight_type(highlight_type_)
     {
     }
 
@@ -97,12 +162,14 @@ public:
         REPLACE,
     };
     using ColumnTransformers = MultiEnum<ColumnTransformer, UInt8>;
-    static constexpr auto AllTransformers = ColumnTransformers{ColumnTransformer::APPLY, ColumnTransformer::EXCEPT, ColumnTransformer::REPLACE};
+    static constexpr auto AllTransformers
+        = ColumnTransformers{ColumnTransformer::APPLY, ColumnTransformer::EXCEPT, ColumnTransformer::REPLACE};
 
     explicit ParserColumnsTransformers(ColumnTransformers allowed_transformers_ = AllTransformers, bool is_strict_ = false)
         : allowed_transformers(allowed_transformers_)
         , is_strict(is_strict_)
-    {}
+    {
+    }
 
 protected:
     const char * getName() const override { return "COLUMNS transformers"; }
@@ -119,7 +186,8 @@ public:
     using ColumnTransformers = ParserColumnsTransformers::ColumnTransformers;
     explicit ParserAsterisk(ColumnTransformers allowed_transformers_ = ParserColumnsTransformers::AllTransformers)
         : allowed_transformers(allowed_transformers_)
-    {}
+    {
+    }
 
 protected:
     const char * getName() const override { return "asterisk"; }
@@ -145,7 +213,8 @@ public:
     using ColumnTransformers = ParserColumnsTransformers::ColumnTransformers;
     explicit ParserColumnsMatcher(ColumnTransformers allowed_transformers_ = ParserColumnsTransformers::AllTransformers)
         : allowed_transformers(allowed_transformers_)
-    {}
+    {
+    }
 
 protected:
     const char * getName() const override { return "COLUMNS matcher"; }
@@ -162,7 +231,8 @@ public:
     using ColumnTransformers = ParserColumnsTransformers::ColumnTransformers;
     explicit ParserQualifiedColumnsMatcher(ColumnTransformers allowed_transformers_ = ParserColumnsTransformers::AllTransformers)
         : allowed_transformers(allowed_transformers_)
-    {}
+    {
+    }
 
 protected:
     const char * getName() const override { return "qualified COLUMNS matcher"; }
@@ -233,6 +303,7 @@ class ParserCollation : public IParserBase
 protected:
     const char * getName() const override { return "collation"; }
     bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+
 private:
     static const char * valid_collations[];
 };
@@ -292,7 +363,11 @@ protected:
 class ParserStringLiteral : public IParserBase
 {
 public:
-    explicit ParserStringLiteral(Highlight color_ = Highlight::string) : color(color_) {}
+    explicit ParserStringLiteral(Highlight color_ = Highlight::string)
+        : color(color_)
+    {
+    }
+
 protected:
     const char * getName() const override { return "string literal"; }
     bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
@@ -313,10 +388,15 @@ class ParserCollectionOfLiterals : public IParserBase
 {
 public:
     ParserCollectionOfLiterals(TokenType opening_bracket_, TokenType closing_bracket_)
-        : opening_bracket(opening_bracket_), closing_bracket(closing_bracket_) {}
+        : opening_bracket(opening_bracket_)
+        , closing_bracket(closing_bracket_)
+    {
+    }
+
 protected:
     const char * getName() const override { return "collection of literals"; }
     bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+
 private:
     TokenType opening_bracket;
     TokenType closing_bracket;
@@ -327,24 +407,20 @@ class ParserTupleOfLiterals : public IParserBase
 {
 public:
     ParserCollectionOfLiterals<Tuple> tuple_parser{TokenType::OpeningRoundBracket, TokenType::ClosingRoundBracket};
+
 protected:
     const char * getName() const override { return "tuple"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override
-    {
-        return tuple_parser.parse(pos, node, expected);
-    }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override { return tuple_parser.parse(pos, node, expected); }
 };
 
 class ParserArrayOfLiterals : public IParserBase
 {
 public:
     ParserCollectionOfLiterals<Array> array_parser{TokenType::OpeningSquareBracket, TokenType::ClosingSquareBracket};
+
 protected:
     const char * getName() const override { return "array"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override
-    {
-        return array_parser.parse(pos, node, expected);
-    }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override { return array_parser.parse(pos, node, expected); }
 };
 
 /** Parses all collections of literals and their various combinations
@@ -353,7 +429,10 @@ protected:
 class ParserAllCollectionsOfLiterals : public IParserBase
 {
 public:
-    explicit ParserAllCollectionsOfLiterals(bool allow_map_ = true) : allow_map(allow_map_) {}
+    explicit ParserAllCollectionsOfLiterals(bool allow_map_ = true)
+        : allow_map(allow_map_)
+    {
+    }
 
 protected:
     const char * getName() const override { return "combination of maps, arrays, tuples"; }
@@ -379,7 +458,10 @@ protected:
 class ParserAlias : public IParserBase
 {
 public:
-    explicit ParserAlias(bool allow_alias_without_as_keyword_) : allow_alias_without_as_keyword(allow_alias_without_as_keyword_) { }
+    explicit ParserAlias(bool allow_alias_without_as_keyword_)
+        : allow_alias_without_as_keyword(allow_alias_without_as_keyword_)
+    {
+    }
 
 private:
     static const char * restricted_keywords[];
@@ -430,7 +512,11 @@ class ParserWithOptionalAlias : public IParserBase
 {
 public:
     ParserWithOptionalAlias(ParserPtr && elem_parser_, bool allow_alias_without_as_keyword_)
-    : elem_parser(std::move(elem_parser_)), allow_alias_without_as_keyword(allow_alias_without_as_keyword_) {}
+        : elem_parser(std::move(elem_parser_))
+        , allow_alias_without_as_keyword(allow_alias_without_as_keyword_)
+    {
+    }
+
 protected:
     ParserPtr elem_parser;
     bool allow_alias_without_as_keyword;
@@ -444,7 +530,10 @@ protected:
 class ParserStorageOrderByElement : public IParserBase
 {
 public:
-    explicit ParserStorageOrderByElement(bool allow_order_) : allow_order(allow_order_) {}
+    explicit ParserStorageOrderByElement(bool allow_order_)
+        : allow_order(allow_order_)
+    {
+    }
 
 protected:
     bool allow_order;
@@ -480,12 +569,12 @@ protected:
 class ParserFunctionWithKeyValueArguments : public IParserBase
 {
 public:
-    explicit ParserFunctionWithKeyValueArguments(bool brackets_can_be_omitted_ = false) : brackets_can_be_omitted(brackets_can_be_omitted_)
+    explicit ParserFunctionWithKeyValueArguments(bool brackets_can_be_omitted_ = false)
+        : brackets_can_be_omitted(brackets_can_be_omitted_)
     {
     }
 
 protected:
-
     const char * getName() const override { return "function with key-value arguments"; }
     bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 
@@ -499,7 +588,7 @@ protected:
 class ParserIdentifierWithOptionalParameters : public IParserBase
 {
 protected:
-    const char * getName() const  override{ return "identifier with optional parameters"; }
+    const char * getName() const override { return "identifier with optional parameters"; }
     bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
@@ -517,7 +606,7 @@ protected:
 class ParserAssignment : public IParserBase
 {
 protected:
-    const char * getName() const  override{ return "column assignment"; }
+    const char * getName() const override { return "column assignment"; }
     bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 

--- a/src/Parsers/ExpressionListParsers.cpp
+++ b/src/Parsers/ExpressionListParsers.cpp
@@ -12,21 +12,22 @@
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTSelectQuery.h>
-#include <Parsers/ASTSetQuery.h>
 #include <Parsers/ASTSelectWithUnionQuery.h>
+#include <Parsers/ASTSetQuery.h>
 #include <Parsers/ASTSubquery.h>
 #include <Parsers/ASTTablesInSelectQuery.h>
 #include <Parsers/ParserCreateQuery.h>
 #include <Parsers/ParserUnionQueryElement.h>
 #include <Parsers/parseIntervalKind.h>
-#include <Common/assert_cast.h>
 #include <Common/StringUtils.h>
+#include <Common/assert_cast.h>
 
 #include <Parsers/ParserSelectWithUnionQuery.h>
 
-#include <Common/logger_useful.h>
 #include <Parsers/CommonParsers.h>
+#include <Parsers/ExpressionElementParsers.h>
 #include <Parsers/Kusto/ParserKQLStatement.h>
+#include <Common/logger_useful.h>
 
 #include <AggregateFunctions/AggregateFunctionFactory.h>
 #include <fmt/core.h>
@@ -39,7 +40,7 @@ namespace DB
 
 namespace ErrorCodes
 {
-    extern const int SYNTAX_ERROR;
+extern const int SYNTAX_ERROR;
 }
 
 
@@ -176,8 +177,7 @@ static bool modifyAST(ASTPtr ast, SubqueryFunctionType type)
         else
             function->name = "in";
 
-        if ((type == SubqueryFunctionType::ANY && function_equals)
-            || (type == SubqueryFunctionType::ALL && function_not_equals))
+        if ((type == SubqueryFunctionType::ANY && function_equals) || (type == SubqueryFunctionType::ALL && function_not_equals))
         {
             return true;
         }
@@ -304,10 +304,13 @@ ASTPtr makeBetweenOperator(bool negative, ASTs arguments)
     return makeASTOperator("and", f_left_expr, f_right_expr);
 }
 
-ParserExpressionWithOptionalAlias::ParserExpressionWithOptionalAlias(bool allow_alias_without_as_keyword, bool is_table_function, bool allow_trailing_commas)
-    : impl(std::make_unique<ParserWithOptionalAlias>(
-        is_table_function ? ParserPtr(std::make_unique<ParserTableFunctionExpression>()) : ParserPtr(std::make_unique<ParserExpression>(allow_trailing_commas)),
-        allow_alias_without_as_keyword))
+ParserExpressionWithOptionalAlias::ParserExpressionWithOptionalAlias(
+    bool allow_alias_without_as_keyword, bool is_table_function, bool allow_trailing_commas)
+    : impl(
+          std::make_unique<ParserWithOptionalAlias>(
+              is_table_function ? ParserPtr(std::make_unique<ParserTableFunctionExpression>())
+                                : ParserPtr(std::make_unique<ParserExpression>(allow_trailing_commas)),
+              allow_alias_without_as_keyword))
 {
 }
 
@@ -315,8 +318,9 @@ ParserExpressionWithOptionalAlias::ParserExpressionWithOptionalAlias(bool allow_
 bool ParserExpressionList::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 {
     return ParserList(
-        std::make_unique<ParserExpressionWithOptionalAlias>(allow_alias_without_as_keyword, is_table_function, allow_trailing_commas),
-        std::make_unique<ParserToken>(TokenType::Comma))
+               std::make_unique<ParserExpressionWithOptionalAlias>(
+                   allow_alias_without_as_keyword, is_table_function, allow_trailing_commas),
+               std::make_unique<ParserToken>(TokenType::Comma))
         .parse(pos, node, expected);
 }
 
@@ -352,8 +356,7 @@ bool ParserGroupingSetsExpressionListElements::parseImpl(Pos & pos, ASTPtr & nod
     ParserToken s_open(TokenType::OpeningRoundBracket);
     ParserToken s_close(TokenType::ClosingRoundBracket);
     ParserExpressionWithOptionalAlias p_expression(false);
-    ParserList p_command(std::make_unique<ParserExpressionWithOptionalAlias>(false),
-                          std::make_unique<ParserToken>(TokenType::Comma), true);
+    ParserList p_command(std::make_unique<ParserExpressionWithOptionalAlias>(false), std::make_unique<ParserToken>(TokenType::Comma), true);
 
     do
     {
@@ -380,8 +383,7 @@ bool ParserGroupingSetsExpressionListElements::parseImpl(Pos & pos, ASTPtr & nod
         }
 
         command_list->children.push_back(command);
-    }
-    while (s_comma.ignore(pos, expected));
+    } while (s_comma.ignore(pos, expected));
 
     return true;
 }
@@ -390,7 +392,6 @@ bool ParserGroupingSetsExpressionList::parseImpl(Pos & pos, ASTPtr & node, Expec
 {
     ParserGroupingSetsExpressionListElements grouping_sets_elements;
     return grouping_sets_elements.parse(pos, node, expected);
-
 }
 
 bool ParserInterpolateExpressionList::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
@@ -453,17 +454,17 @@ bool ParserKeyValuePairsList::parseImpl(Pos & pos, ASTPtr & node, Expected & exp
 
 namespace
 {
-    /// This wrapper is needed to highlight function names differently.
-    class ParserFunctionName : public IParserBase
+/// This wrapper is needed to highlight function names differently.
+class ParserFunctionName : public IParserBase
+{
+protected:
+    const char * getName() const override { return "function name"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override
     {
-    protected:
-        const char * getName() const override { return "function name"; }
-        bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override
-        {
-            ParserCompoundIdentifier parser(false, true, Highlight::function);
-            return parser.parse(pos, node, expected);
-        }
-    };
+        ParserCompoundIdentifier parser(false, true, Highlight::function);
+        return parser.parse(pos, node, expected);
+    }
+};
 }
 
 
@@ -506,11 +507,13 @@ struct Operator
 {
     Operator() = default;
 
-    Operator(const std::string & function_name_,
-             int priority_,
-             int arity_,
-             OperatorType type_ = OperatorType::None)
-        : type(type_), priority(priority_), arity(arity_), function_name(function_name_) {}
+    Operator(const std::string & function_name_, int priority_, int arity_, OperatorType type_ = OperatorType::None)
+        : type(type_)
+        , priority(priority_)
+        , arity(arity_)
+        , function_name(function_name_)
+    {
+    }
 
     OperatorType type;
     int priority;
@@ -550,8 +553,11 @@ enum class Checkpoint : uint8_t
 class Layer
 {
 public:
-    explicit Layer(bool allow_alias_ = true, bool allow_alias_without_as_keyword_ = false) :
-        allow_alias(allow_alias_), allow_alias_without_as_keyword(allow_alias_without_as_keyword_) {}
+    explicit Layer(bool allow_alias_ = true, bool allow_alias_without_as_keyword_ = false)
+        : allow_alias(allow_alias_)
+        , allow_alias_without_as_keyword(allow_alias_without_as_keyword_)
+    {
+    }
 
     virtual ~Layer() = default;
 
@@ -566,10 +572,7 @@ public:
         return true;
     }
 
-    void pushOperator(Operator op)
-    {
-        operators.push_back(std::move(op));
-    }
+    void pushOperator(Operator op) { operators.push_back(std::move(op)); }
 
     bool popOperand(ASTPtr & op)
     {
@@ -582,15 +585,9 @@ public:
         return true;
     }
 
-    void pushOperand(ASTPtr op)
-    {
-        operands.push_back(std::move(op));
-    }
+    void pushOperand(ASTPtr op) { operands.push_back(std::move(op)); }
 
-    void pushResult(ASTPtr op)
-    {
-        elements.push_back(std::move(op));
-    }
+    void pushResult(ASTPtr op) { elements.push_back(std::move(op)); }
 
     virtual bool getResult(ASTPtr & node)
     {
@@ -602,10 +599,7 @@ public:
 
     virtual bool parse(IParser::Pos & /*pos*/, Expected & /*expected*/, Action & /*action*/) = 0;
 
-    bool isFinished() const
-    {
-        return finished;
-    }
+    bool isFinished() const { return finished; }
 
     int previousPriority() const
     {
@@ -623,10 +617,7 @@ public:
         return operators.back().type;
     }
 
-    int isCurrentElementEmpty() const
-    {
-        return operators.empty() && operands.empty();
-    }
+    int isCurrentElementEmpty() const { return operators.empty() && operands.empty(); }
 
     bool popLastNOperands(ASTs & asts, size_t n)
     {
@@ -659,9 +650,8 @@ public:
             ASTPtr function;
 
             // We should not meet the starting part of the operator while finishing an element
-            if (cur_op.type == OperatorType::StartIf ||
-                cur_op.type == OperatorType::StartBetween ||
-                cur_op.type == OperatorType::StartNotBetween)
+            if (cur_op.type == OperatorType::StartIf || cur_op.type == OperatorType::StartBetween
+                || cur_op.type == OperatorType::StartNotBetween)
                 return false;
 
             if (cur_op.type == OperatorType::FinishIf)
@@ -693,7 +683,7 @@ public:
                 /// enable using subscript operator for kql_array_sort
                 if (cur_op.function_name == "arrayElement" && !operands.empty())
                 {
-                    auto* first_arg_as_node = operands.front()->as<ASTFunction>();
+                    auto * first_arg_as_node = operands.front()->as<ASTFunction>();
                     if (first_arg_as_node)
                     {
                         if (first_arg_as_node->name == "kql_array_sort_asc" || first_arg_as_node->name == "kql_array_sort_desc")
@@ -703,7 +693,7 @@ public:
                         }
                         else if (first_arg_as_node->name == "arrayElement" && !first_arg_as_node->arguments->children.empty())
                         {
-                            auto *arg_inside = first_arg_as_node->arguments->children[0]->as<ASTFunction>();
+                            auto * arg_inside = first_arg_as_node->arguments->children[0]->as<ASTFunction>();
                             if (arg_inside && (arg_inside->name == "kql_array_sort_asc" || arg_inside->name == "kql_array_sort_desc"))
                                 first_arg_as_node->name = "tupleElement";
                         }
@@ -850,19 +840,17 @@ static void highlightRegexps(const ASTPtr & node, Expected & expected, size_t de
 
     bool is_like = false;
     bool is_regexp = false;
-    if (func->name == "like" || func->name == "notLike"
-        || func->name == "ilike" || func->name == "notILike")
+    if (func->name == "like" || func->name == "notLike" || func->name == "ilike" || func->name == "notILike")
     {
         is_like = true;
     }
-    else if (func->name == "match"
-             || func->name == "extract" || func->name == "extractAll"
-             || func->name == "extractGroups" || func->name == "extractAllGroups"
-             || func->name == "replaceRegexpOne" || func->name == "replaceRegexpAll"
-             || func->name == "countMatches" || func->name == "splitByRegexp"
-             || func->name == "regexp_replace" || func->name == "REGEXP_REPLACE")
+    else if (
+        func->name == "match" || func->name == "extract" || func->name == "extractAll" || func->name == "extractGroups"
+        || func->name == "extractAllGroups" || func->name == "replaceRegexpOne" || func->name == "replaceRegexpAll"
+        || func->name == "countMatches" || func->name == "splitByRegexp" || func->name == "regexp_replace"
+        || func->name == "REGEXP_REPLACE")
     {
-        is_regexp = true;  /// NOLINT(clang-analyzer-deadcode.DeadStores)
+        is_regexp = true; /// NOLINT(clang-analyzer-deadcode.DeadStores)
     }
     else
     {
@@ -875,15 +863,22 @@ static void highlightRegexps(const ASTPtr & node, Expected & expected, size_t de
         return;
 
     auto * literal = args->children[1]->as<ASTLiteral>();
-
     if (!literal || literal->value.getType() != Field::Types::String)
         return;
 
+    /// Look up token position from thread-local map (set during parsing when highlighting is enabled)
+    LiteralTokenMap * token_map = getLiteralTokenMap();
+    if (!token_map)
+        return;
+
+    auto it = token_map->find(literal);
+    if (it == token_map->end())
+        return;
+
+    /// Use the stored char* positions directly for highlighting
     chassert(is_like || is_regexp);
-    expected.highlight({
-       .begin = literal->begin.value()->begin,
-       .end = literal->begin.value()->end,
-       .highlight = is_like ? Highlight::string_like : Highlight::string_regexp});
+    expected.highlight(
+        {.begin = it->second.begin, .end = it->second.end, .highlight = is_like ? Highlight::string_like : Highlight::string_regexp});
 }
 
 struct ParserExpressionImpl
@@ -923,7 +918,6 @@ struct ParserExpressionImpl
 class ExpressionLayer : public Layer
 {
 public:
-
     explicit ExpressionLayer(bool is_table_function_, bool allow_trailing_commas_ = false)
         : Layer(false, false)
     {
@@ -1016,8 +1010,10 @@ template <TokenType separator, TokenType end>
 class LayerWithSeparator : public Layer
 {
 public:
-    explicit LayerWithSeparator(bool allow_alias_ = true, bool allow_alias_without_as_keyword_ = false) :
-        Layer(allow_alias_, allow_alias_without_as_keyword_) {}
+    explicit LayerWithSeparator(bool allow_alias_ = true, bool allow_alias_without_as_keyword_ = false)
+        : Layer(allow_alias_, allow_alias_without_as_keyword_)
+    {
+    }
 
     bool parse(IParser::Pos & pos, Expected & expected, Action & action) override
     {
@@ -1046,8 +1042,14 @@ public:
 class FunctionLayer : public Layer
 {
 public:
-    explicit FunctionLayer(String function_name_, bool allow_function_parameters_ = true, bool is_compound_name_ = false, bool is_operator_ = false)
-        : function_name(function_name_), allow_function_parameters(allow_function_parameters_), is_compound_name(is_compound_name_), is_operator(is_operator_) {}
+    explicit FunctionLayer(
+        String function_name_, bool allow_function_parameters_ = true, bool is_compound_name_ = false, bool is_operator_ = false)
+        : function_name(function_name_)
+        , allow_function_parameters(allow_function_parameters_)
+        , is_compound_name(is_compound_name_)
+        , is_operator(is_operator_)
+    {
+    }
 
     bool parse(IParser::Pos & pos, Expected & expected, Action & action) override
     {
@@ -1118,22 +1120,20 @@ public:
                  * If you do not report that the first option is an error, then the argument will be interpreted as 2014 - 01 - 01 - some number,
                  *  and the query silently returns an unexpected elements.
                  */
-                if (function_name == "toDate"
-                    && contents_end - contents_begin == strlen("2014-01-01")
-                    && contents_begin[0] >= '2' && contents_begin[0] <= '3'
-                    && contents_begin[1] >= '0' && contents_begin[1] <= '9'
-                    && contents_begin[2] >= '0' && contents_begin[2] <= '9'
-                    && contents_begin[3] >= '0' && contents_begin[3] <= '9'
-                    && contents_begin[4] == '-'
-                    && contents_begin[5] >= '0' && contents_begin[5] <= '9'
-                    && contents_begin[6] >= '0' && contents_begin[6] <= '9'
-                    && contents_begin[7] == '-'
-                    && contents_begin[8] >= '0' && contents_begin[8] <= '9'
-                    && contents_begin[9] >= '0' && contents_begin[9] <= '9')
+                if (function_name == "toDate" && contents_end - contents_begin == strlen("2014-01-01") && contents_begin[0] >= '2'
+                    && contents_begin[0] <= '3' && contents_begin[1] >= '0' && contents_begin[1] <= '9' && contents_begin[2] >= '0'
+                    && contents_begin[2] <= '9' && contents_begin[3] >= '0' && contents_begin[3] <= '9' && contents_begin[4] == '-'
+                    && contents_begin[5] >= '0' && contents_begin[5] <= '9' && contents_begin[6] >= '0' && contents_begin[6] <= '9'
+                    && contents_begin[7] == '-' && contents_begin[8] >= '0' && contents_begin[8] <= '9' && contents_begin[9] >= '0'
+                    && contents_begin[9] <= '9')
                 {
                     std::string contents_str(contents_begin, contents_end - contents_begin);
-                    throw Exception(ErrorCodes::SYNTAX_ERROR, "Argument of function toDate is unquoted: "
-                        "toDate({}), must be: toDate('{}')" , contents_str, contents_str);
+                    throw Exception(
+                        ErrorCodes::SYNTAX_ERROR,
+                        "Argument of function toDate is unquoted: "
+                        "toDate({}), must be: toDate('{}')",
+                        contents_str,
+                        contents_str);
                 }
 
                 if (allow_function_parameters && !parameters && ParserToken(TokenType::OpeningRoundBracket).ignore(pos, expected))
@@ -1344,7 +1344,10 @@ public:
 class CastLayer : public Layer
 {
 public:
-    CastLayer() : Layer(/*allow_alias*/ true, /*allow_alias_without_as_keyword*/ true) {}
+    CastLayer()
+        : Layer(/*allow_alias*/ true, /*allow_alias_without_as_keyword*/ true)
+    {
+    }
 
     bool parse(IParser::Pos & pos, Expected & expected, Action & action) override
     {
@@ -1365,10 +1368,9 @@ public:
             {
                 auto old_pos = pos;
 
-                if (ParserIdentifier().parse(pos, alias, expected) &&
-                    as_keyword_parser.ignore(pos, expected) &&
-                    ParserDataType().parse(pos, type_node, expected) &&
-                    ParserToken(TokenType::ClosingRoundBracket).ignore(pos, expected))
+                if (ParserIdentifier().parse(pos, alias, expected) && as_keyword_parser.ignore(pos, expected)
+                    && ParserDataType().parse(pos, type_node, expected)
+                    && ParserToken(TokenType::ClosingRoundBracket).ignore(pos, expected))
                 {
                     if (!insertAlias(alias))
                         return false;
@@ -1383,8 +1385,7 @@ public:
 
                 pos = old_pos;
 
-                if (ParserIdentifier().parse(pos, alias, expected) &&
-                    ParserToken(TokenType::Comma).ignore(pos, expected))
+                if (ParserIdentifier().parse(pos, alias, expected) && ParserToken(TokenType::Comma).ignore(pos, expected))
                 {
                     action = Action::OPERAND;
                     if (!insertAlias(alias))
@@ -1399,8 +1400,7 @@ public:
 
                 pos = old_pos;
 
-                if (ParserDataType().parse(pos, type_node, expected) &&
-                    ParserToken(TokenType::ClosingRoundBracket).ignore(pos, expected))
+                if (ParserDataType().parse(pos, type_node, expected) && ParserToken(TokenType::ClosingRoundBracket).ignore(pos, expected))
                 {
                     if (!mergeElement())
                         return false;
@@ -1447,7 +1447,10 @@ public:
 class ExtractLayer : public LayerWithSeparator<TokenType::Comma, TokenType::ClosingRoundBracket>
 {
 public:
-    ExtractLayer() : LayerWithSeparator(/*allow_alias*/ true, /*allow_alias_without_as_keyword*/ true) {}
+    ExtractLayer()
+        : LayerWithSeparator(/*allow_alias*/ true, /*allow_alias_without_as_keyword*/ true)
+    {
+    }
 
     bool parse(IParser::Pos & pos, Expected & expected, Action & action) override
     {
@@ -1518,7 +1521,10 @@ private:
 class SubstringLayer : public Layer
 {
 public:
-    SubstringLayer() : Layer(/*allow_alias*/ true, /*allow_alias_without_as_keyword*/ true) {}
+    SubstringLayer()
+        : Layer(/*allow_alias*/ true, /*allow_alias_without_as_keyword*/ true)
+    {
+    }
 
     bool parse(IParser::Pos & pos, Expected & expected, Action & action) override
     {
@@ -1530,8 +1536,7 @@ public:
 
         if (state == 0)
         {
-            if (ParserToken(TokenType::Comma).ignore(pos, expected) ||
-                ParserKeyword(Keyword::FROM).ignore(pos, expected))
+            if (ParserToken(TokenType::Comma).ignore(pos, expected) || ParserKeyword(Keyword::FROM).ignore(pos, expected))
             {
                 action = Action::OPERAND;
 
@@ -1544,8 +1549,7 @@ public:
 
         if (state == 1)
         {
-            if (ParserToken(TokenType::Comma).ignore(pos, expected) ||
-                ParserKeyword(Keyword::FOR).ignore(pos, expected))
+            if (ParserToken(TokenType::Comma).ignore(pos, expected) || ParserKeyword(Keyword::FOR).ignore(pos, expected))
             {
                 action = Action::OPERAND;
 
@@ -1581,7 +1585,10 @@ protected:
 class PositionLayer : public Layer
 {
 public:
-    PositionLayer() : Layer(/*allow_alias*/ true, /*allow_alias_without_as_keyword*/ true) {}
+    PositionLayer()
+        : Layer(/*allow_alias*/ true, /*allow_alias_without_as_keyword*/ true)
+    {
+    }
 
     bool parse(IParser::Pos & pos, Expected & expected, Action & action) override
     {
@@ -1652,7 +1659,10 @@ protected:
 class ExistsLayer : public Layer
 {
 public:
-    ExistsLayer() : Layer(/*allow_alias*/ true, /*allow_alias_without_as_keyword*/ true) {}
+    ExistsLayer()
+        : Layer(/*allow_alias*/ true, /*allow_alias_without_as_keyword*/ true)
+    {
+    }
 
     bool parse(IParser::Pos & pos, Expected & expected, Action & /*action*/) override
     {
@@ -1681,7 +1691,8 @@ public:
         : Layer(/*allow_alias*/ true, /*allow_alias_without_as_keyword*/ true)
         , trim_left(trim_left_)
         , trim_right(trim_right_)
-    {}
+    {
+    }
 
     bool parse(IParser::Pos & pos, Expected & expected, Action & action) override
     {
@@ -1814,7 +1825,10 @@ class DateAddLayer : public LayerWithSeparator<TokenType::Comma, TokenType::Clos
 {
 public:
     explicit DateAddLayer(const char * function_name_)
-        : LayerWithSeparator(/*allow_alias*/ true, /*allow_alias_without_as_keyword*/ true), function_name(function_name_) {}
+        : LayerWithSeparator(/*allow_alias*/ true, /*allow_alias_without_as_keyword*/ true)
+        , function_name(function_name_)
+    {
+    }
 
     bool parse(IParser::Pos & pos, Expected & expected, Action & action) override
     {
@@ -1871,7 +1885,10 @@ private:
 class DateDiffLayer : public LayerWithSeparator<TokenType::Comma, TokenType::ClosingRoundBracket>
 {
 public:
-    DateDiffLayer() : LayerWithSeparator(/*allow_alias*/ true, /*allow_alias_without_as_keyword*/ true) {}
+    DateDiffLayer()
+        : LayerWithSeparator(/*allow_alias*/ true, /*allow_alias_without_as_keyword*/ true)
+    {
+    }
 
     bool parse(IParser::Pos & pos, Expected & expected, Action & action) override
     {
@@ -1907,7 +1924,8 @@ protected:
             if (elements.size() == 2)
                 node = makeASTFunction("dateDiff", std::make_shared<ASTLiteral>(interval_kind.toDateDiffUnit()), elements[0], elements[1]);
             else if (elements.size() == 3)
-                node = makeASTFunction("dateDiff", std::make_shared<ASTLiteral>(interval_kind.toDateDiffUnit()), elements[0], elements[1], elements[2]);
+                node = makeASTFunction(
+                    "dateDiff", std::make_shared<ASTLiteral>(interval_kind.toDateDiffUnit()), elements[0], elements[1], elements[2]);
             else
                 return false;
         }
@@ -1949,7 +1967,10 @@ protected:
 class IntervalLayer : public Layer
 {
 public:
-    IntervalLayer() : Layer(/*allow_alias*/ true, /*allow_alias_without_as_keyword*/ true) {}
+    IntervalLayer()
+        : Layer(/*allow_alias*/ true, /*allow_alias_without_as_keyword*/ true)
+    {
+    }
 
     bool parse(IParser::Pos & pos, Expected & expected, Action & action) override
     {
@@ -1970,8 +1991,7 @@ public:
             //// A String literal followed INTERVAL keyword,
             /// the literal can be a part of an expression or
             /// include Number and INTERVAL TYPE at the same time
-            if (ParserStringLiteral{}.parse(pos, string_literal, expected)
-                && string_literal->as<ASTLiteral &>().value.tryGet(literal))
+            if (ParserStringLiteral{}.parse(pos, string_literal, expected) && string_literal->as<ASTLiteral &>().value.tryGet(literal))
             {
                 Tokens tokens(literal.data(), literal.data() + literal.size());
                 IParser::Pos token_pos(tokens, pos.max_depth, pos.max_backtracks);
@@ -1999,8 +2019,8 @@ public:
                 /// case: INTERVAL '1 HOUR 1 SECOND ...'
                 while (token_pos.isValid())
                 {
-                    if (!ParserNumber{}.parse(token_pos, expr, token_expected) ||
-                        !parseIntervalKind(token_pos, token_expected, interval_kind))
+                    if (!ParserNumber{}.parse(token_pos, expr, token_expected)
+                        || !parseIntervalKind(token_pos, token_expected, interval_kind))
                         return false;
 
                     pushResult(makeASTFunction(interval_kind.toNameOfFunctionToIntervalDataType(), expr));
@@ -2044,7 +2064,10 @@ private:
 class CaseLayer : public Layer
 {
 public:
-    CaseLayer() : Layer(/*allow_alias*/ true, /*allow_alias_without_as_keyword*/ true) {}
+    CaseLayer()
+        : Layer(/*allow_alias*/ true, /*allow_alias_without_as_keyword*/ true)
+    {
+    }
 
     bool parse(IParser::Pos & pos, Expected & expected, Action & action) override
     {
@@ -2138,7 +2161,10 @@ private:
 class ViewLayer : public Layer
 {
 public:
-    explicit ViewLayer(bool if_permitted_) : if_permitted(if_permitted_) {}
+    explicit ViewLayer(bool if_permitted_)
+        : if_permitted(if_permitted_)
+    {
+    }
 
     bool parse(IParser::Pos & pos, Expected & expected, Action & /*action*/) override
     {
@@ -2215,7 +2241,10 @@ private:
 class KustoLayer : public Layer
 {
 public:
-    KustoLayer() : Layer(/*allow_alias*/ true, /*allow_alias_without_as_keyword*/ true) {}
+    KustoLayer()
+        : Layer(/*allow_alias*/ true, /*allow_alias_without_as_keyword*/ true)
+    {
+    }
 
     bool parse(IParser::Pos & pos, Expected & expected, Action & /*action*/) override
     {
@@ -2270,7 +2299,8 @@ bool isFirstIdentifier(ParserExpressionImpl::Layers & layers)
     return layers.size() == 1 && dynamic_cast<ExpressionLayer *>(layers.front().get()) != nullptr;
 }
 
-std::unique_ptr<Layer> getFunctionLayer(ASTPtr identifier, bool is_table_function, bool is_first_identifier, bool allow_function_parameters_ = true)
+std::unique_ptr<Layer>
+getFunctionLayer(ASTPtr identifier, bool is_table_function, bool is_first_identifier, bool allow_function_parameters_ = true)
 {
     /// Special cases for expressions that look like functions but contain some syntax sugar:
 
@@ -2411,6 +2441,12 @@ bool ParseTimestampOperatorExpression(IParser::Pos & pos, ASTPtr & node, Expecte
 
 bool ParserExpression::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 {
+    /// Set up thread-local map to capture literal token positions for regex highlighting.
+    /// Only needed when highlighting is enabled and no map is already set (e.g., by ValuesBlockInputFormat).
+    std::optional<LiteralTokenMapScope> token_scope;
+    if (expected.enable_highlighting && !getLiteralTokenMap())
+        token_scope.emplace();
+
     auto start = std::make_unique<ExpressionLayer>(false, allow_trailing_commas);
     if (ParserExpressionImpl().parse(std::move(start), pos, node, expected))
     {
@@ -2437,8 +2473,7 @@ bool ParserFunction::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 {
     ASTPtr identifier;
 
-    if (ParserFunctionName().parse(pos, identifier, expected)
-        && ParserToken(TokenType::OpeningRoundBracket).ignore(pos, expected))
+    if (ParserFunctionName().parse(pos, identifier, expected) && ParserToken(TokenType::OpeningRoundBracket).ignore(pos, expected))
     {
         auto start = getFunctionLayer(identifier, is_table_function, /*is_first_identifier=*/true, allow_function_parameters);
         start->is_table_function = is_table_function;
@@ -2467,53 +2502,51 @@ bool ParserExpressionWithOptionalArguments::parseImpl(Pos & pos, ASTPtr & node, 
     return false;
 }
 
-const std::vector<std::pair<std::string_view, Operator>> ParserExpressionImpl::operators_table
-{
-    {"->",            Operator("lambda",          1,  2, OperatorType::Lambda)},
-    {"?",             Operator("",                2,  0, OperatorType::StartIf)},
-    {":",             Operator("if",              3,  3, OperatorType::FinishIf)},
-    {toStringView(Keyword::OR),            Operator("or",              3,  2, OperatorType::Mergeable)},
-    {toStringView(Keyword::AND),           Operator("and",             4,  2, OperatorType::Mergeable)},
+const std::vector<std::pair<std::string_view, Operator>> ParserExpressionImpl::operators_table{
+    {"->", Operator("lambda", 1, 2, OperatorType::Lambda)},
+    {"?", Operator("", 2, 0, OperatorType::StartIf)},
+    {":", Operator("if", 3, 3, OperatorType::FinishIf)},
+    {toStringView(Keyword::OR), Operator("or", 3, 2, OperatorType::Mergeable)},
+    {toStringView(Keyword::AND), Operator("and", 4, 2, OperatorType::Mergeable)},
     {toStringView(Keyword::IS_NOT_DISTINCT_FROM), Operator("isNotDistinctFrom", 6, 2)},
     {toStringView(Keyword::IS_DISTINCT_FROM), Operator("isDistinctFrom", 6, 2)},
-    {toStringView(Keyword::IS_NULL),       Operator("isNull",          6,  1, OperatorType::IsNull)},
-    {toStringView(Keyword::IS_NOT_NULL),   Operator("isNotNull",       6,  1, OperatorType::IsNull)},
-    {toStringView(Keyword::BETWEEN),       Operator("",                7,  0, OperatorType::StartBetween)},
-    {toStringView(Keyword::NOT_BETWEEN),   Operator("",                7,  0, OperatorType::StartNotBetween)},
-    {"==",            Operator("equals",          9,  2, OperatorType::Comparison)},
-    {"!=",            Operator("notEquals",       9,  2, OperatorType::Comparison)},
-    {"<=>",           Operator("isNotDistinctFrom", 9, 2, OperatorType::Comparison)},
-    {"<>",            Operator("notEquals",       9,  2, OperatorType::Comparison)},
-    {"<=",            Operator("lessOrEquals",    9,  2, OperatorType::Comparison)},
-    {">=",            Operator("greaterOrEquals", 9,  2, OperatorType::Comparison)},
-    {"<",             Operator("less",            9,  2, OperatorType::Comparison)},
-    {">",             Operator("greater",         9,  2, OperatorType::Comparison)},
-    {"=",             Operator("equals",          9,  2, OperatorType::Comparison)},
-    {toStringView(Keyword::LIKE),          Operator("like",            9,  2)},
-    {toStringView(Keyword::ILIKE),         Operator("ilike",           9,  2)},
-    {toStringView(Keyword::NOT_LIKE),      Operator("notLike",         9,  2)},
-    {toStringView(Keyword::NOT_ILIKE),     Operator("notILike",        9,  2)},
-    {toStringView(Keyword::REGEXP),        Operator("match",           9,  2)},
-    {toStringView(Keyword::IN),            Operator("in",              9,  2)},
-    {toStringView(Keyword::NOT_IN),        Operator("notIn",           9,  2)},
-    {toStringView(Keyword::GLOBAL_IN),     Operator("globalIn",        9,  2)},
-    {toStringView(Keyword::GLOBAL_NOT_IN), Operator("globalNotIn",     9,  2)},
-    {"||",            Operator("concat",          10, 2, OperatorType::Mergeable)},
-    {"+",             Operator("plus",            11, 2)},
-    {"-",             Operator("minus",           11, 2)},
-    {"−",             Operator("minus",           11, 2)},
-    {"*",             Operator("multiply",        12, 2)},
-    {"/",             Operator("divide",          12, 2)},
-    {"%",             Operator("modulo",          12, 2)},
-    {toStringView(Keyword::MOD),           Operator("modulo",          12, 2)},
-    {toStringView(Keyword::DIV),           Operator("intDiv",          12, 2)},
-    {".",             Operator("tupleElement",    14, 2, OperatorType::TupleElement)},
-    {"[",             Operator("arrayElement",    14, 2, OperatorType::ArrayElement)},
-    {"::",            Operator(toString(toStringView(Keyword::CAST)),            14, 2, OperatorType::Cast)},
+    {toStringView(Keyword::IS_NULL), Operator("isNull", 6, 1, OperatorType::IsNull)},
+    {toStringView(Keyword::IS_NOT_NULL), Operator("isNotNull", 6, 1, OperatorType::IsNull)},
+    {toStringView(Keyword::BETWEEN), Operator("", 7, 0, OperatorType::StartBetween)},
+    {toStringView(Keyword::NOT_BETWEEN), Operator("", 7, 0, OperatorType::StartNotBetween)},
+    {"==", Operator("equals", 9, 2, OperatorType::Comparison)},
+    {"!=", Operator("notEquals", 9, 2, OperatorType::Comparison)},
+    {"<=>", Operator("isNotDistinctFrom", 9, 2, OperatorType::Comparison)},
+    {"<>", Operator("notEquals", 9, 2, OperatorType::Comparison)},
+    {"<=", Operator("lessOrEquals", 9, 2, OperatorType::Comparison)},
+    {">=", Operator("greaterOrEquals", 9, 2, OperatorType::Comparison)},
+    {"<", Operator("less", 9, 2, OperatorType::Comparison)},
+    {">", Operator("greater", 9, 2, OperatorType::Comparison)},
+    {"=", Operator("equals", 9, 2, OperatorType::Comparison)},
+    {toStringView(Keyword::LIKE), Operator("like", 9, 2)},
+    {toStringView(Keyword::ILIKE), Operator("ilike", 9, 2)},
+    {toStringView(Keyword::NOT_LIKE), Operator("notLike", 9, 2)},
+    {toStringView(Keyword::NOT_ILIKE), Operator("notILike", 9, 2)},
+    {toStringView(Keyword::REGEXP), Operator("match", 9, 2)},
+    {toStringView(Keyword::IN), Operator("in", 9, 2)},
+    {toStringView(Keyword::NOT_IN), Operator("notIn", 9, 2)},
+    {toStringView(Keyword::GLOBAL_IN), Operator("globalIn", 9, 2)},
+    {toStringView(Keyword::GLOBAL_NOT_IN), Operator("globalNotIn", 9, 2)},
+    {"||", Operator("concat", 10, 2, OperatorType::Mergeable)},
+    {"+", Operator("plus", 11, 2)},
+    {"-", Operator("minus", 11, 2)},
+    {"−", Operator("minus", 11, 2)},
+    {"*", Operator("multiply", 12, 2)},
+    {"/", Operator("divide", 12, 2)},
+    {"%", Operator("modulo", 12, 2)},
+    {toStringView(Keyword::MOD), Operator("modulo", 12, 2)},
+    {toStringView(Keyword::DIV), Operator("intDiv", 12, 2)},
+    {".", Operator("tupleElement", 14, 2, OperatorType::TupleElement)},
+    {"[", Operator("arrayElement", 14, 2, OperatorType::ArrayElement)},
+    {"::", Operator(toString(toStringView(Keyword::CAST)), 14, 2, OperatorType::Cast)},
 };
 
-const std::vector<std::pair<std::string_view, Operator>> ParserExpressionImpl::unary_operators_table
-{
+const std::vector<std::pair<std::string_view, Operator>> ParserExpressionImpl::unary_operators_table{
     {toStringView(Keyword::NOT), Operator("not", 5, 1, OperatorType::Not)},
     {"-", Operator("negate", 13, 1)},
     {"−", Operator("negate", 13, 1)},
@@ -2593,8 +2626,7 @@ Action ParserExpressionImpl::tryParseOperand(Layers & layers, IParser::Pos & pos
     {
         if (typeid_cast<ViewLayer *>(layers.back().get()) || typeid_cast<KustoLayer *>(layers.back().get()))
         {
-            if (function_name_parser.parse(pos, tmp, expected)
-                && ParserToken(TokenType::OpeningRoundBracket).ignore(pos, expected))
+            if (function_name_parser.parse(pos, tmp, expected) && ParserToken(TokenType::OpeningRoundBracket).ignore(pos, expected))
             {
                 layers.push_back(getFunctionLayer(tmp, layers.front()->is_table_function, isFirstIdentifier(layers)));
                 return Action::OPERAND;
@@ -2623,8 +2655,7 @@ Action ParserExpressionImpl::tryParseOperand(Layers & layers, IParser::Pos & pos
     }
 
     /// Special case for cast expression
-    if (layers.back()->previousType() != OperatorType::TupleElement &&
-        ParseCastExpression(pos, tmp, expected))
+    if (layers.back()->previousType() != OperatorType::TupleElement && ParseCastExpression(pos, tmp, expected))
     {
         layers.back()->pushOperand(std::move(tmp));
         return Action::OPERATOR;
@@ -2709,16 +2740,11 @@ Action ParserExpressionImpl::tryParseOperand(Layers & layers, IParser::Pos & pos
         return Action::OPERAND;
     }
 
-    if (ParseDateOperatorExpression(pos, tmp, expected) ||
-        ParseTimestampOperatorExpression(pos, tmp, expected) ||
-        tuple_literal_parser.parse(pos, tmp, expected) ||
-        array_literal_parser.parse(pos, tmp, expected) ||
-        number_parser.parse(pos, tmp, expected) ||
-        literal_parser.parse(pos, tmp, expected) ||
-        asterisk_parser.parse(pos, tmp, expected) ||
-        qualified_asterisk_parser.parse(pos, tmp, expected) ||
-        columns_matcher_parser.parse(pos, tmp, expected) ||
-        qualified_columns_matcher_parser.parse(pos, tmp, expected))
+    if (ParseDateOperatorExpression(pos, tmp, expected) || ParseTimestampOperatorExpression(pos, tmp, expected)
+        || tuple_literal_parser.parse(pos, tmp, expected) || array_literal_parser.parse(pos, tmp, expected)
+        || number_parser.parse(pos, tmp, expected) || literal_parser.parse(pos, tmp, expected) || asterisk_parser.parse(pos, tmp, expected)
+        || qualified_asterisk_parser.parse(pos, tmp, expected) || columns_matcher_parser.parse(pos, tmp, expected)
+        || qualified_columns_matcher_parser.parse(pos, tmp, expected))
     {
         layers.back()->pushOperand(std::move(tmp));
     }
@@ -2743,7 +2769,6 @@ Action ParserExpressionImpl::tryParseOperand(Layers & layers, IParser::Pos & pos
         }
         else if (pos->type == TokenType::OpeningRoundBracket)
         {
-
             if (subquery_parser.parse(pos, tmp, expected))
             {
                 layers.back()->pushOperand(std::move(tmp));
@@ -2870,8 +2895,7 @@ Action ParserExpressionImpl::tryParseOperator(Layers & layers, IParser::Pos & po
     if (op.type == OperatorType::TupleElement)
     {
         ASTPtr tmp;
-        if (asterisk_parser.parse(pos, tmp, expected)
-            || columns_matcher_parser.parse(pos, tmp, expected))
+        if (asterisk_parser.parse(pos, tmp, expected) || columns_matcher_parser.parse(pos, tmp, expected))
         {
             if (auto * asterisk = tmp->as<ASTAsterisk>())
             {

--- a/src/Processors/Formats/Impl/ConstantExpressionTemplate.cpp
+++ b/src/Processors/Formats/Impl/ConstantExpressionTemplate.cpp
@@ -145,6 +145,12 @@ static void fillLiteralInfo(DataTypes & nested_types, LiteralInfo & info)
         {
             field_type = Field::Types::Map;
         }
+        else if (isBool(nested_type))
+        {
+            /// Bool is stored as UInt8 internally
+            nested_type = std::make_shared<DataTypeUInt8>();
+            field_type = Field::Types::UInt64;
+        }
         else
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected literal type inside Array: {}. It's a bug", nested_type->getName());
 
@@ -373,6 +379,12 @@ private:
             auto nested_types = assert_cast<const DataTypeMap &>(*info.type).getKeyValueTypes();
             fillLiteralInfo(nested_types, info);
             info.type = std::make_shared<DataTypeMap>(nested_types);
+        }
+        else if (field_type == Field::Types::Bool)
+        {
+            /// Bool is stored as UInt8 internally, treat as UInt64 for templating
+            info.type = std::make_shared<DataTypeUInt8>();
+            info.special_parser = SpecialParserType(Field::Types::UInt64);
         }
         else
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected literal type {}", info.literal->value.getTypeName());

--- a/src/Processors/Formats/Impl/ConstantExpressionTemplate.cpp
+++ b/src/Processors/Formats/Impl/ConstantExpressionTemplate.cpp
@@ -1,59 +1,62 @@
 #include <Columns/ColumnConst.h>
-#include <Columns/ColumnTuple.h>
 #include <Columns/ColumnMap.h>
+#include <Columns/ColumnTuple.h>
 #include <Columns/ColumnsNumber.h>
-#include <Common/SipHash.h>
-#include <Formats/FormatSettings.h>
 #include <Core/Settings.h>
-#include <DataTypes/DataTypesNumber.h>
+#include <DataTypes/DataTypeArray.h>
+#include <DataTypes/DataTypeMap.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypeString.h>
-#include <DataTypes/DataTypeArray.h>
 #include <DataTypes/DataTypeTuple.h>
-#include <DataTypes/DataTypeMap.h>
+#include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/FieldToDataType.h>
-#include <Processors/Formats/IRowInputFormat.h>
+#include <Formats/FormatSettings.h>
 #include <Functions/FunctionFactory.h>
-#include <Interpreters/ExpressionAnalyzer.h>
-#include <Interpreters/ExpressionActions.h>
-#include <Interpreters/ReplaceQueryParameterVisitor.h>
-#include <Interpreters/TreeRewriter.h>
-#include <Interpreters/Context.h>
-#include <Interpreters/convertFieldToType.h>
-#include <Interpreters/castColumn.h>
 #include <IO/Operators.h>
 #include <IO/ReadHelpers.h>
+#include <Interpreters/Context.h>
+#include <Interpreters/ExpressionActions.h>
+#include <Interpreters/ExpressionAnalyzer.h>
+#include <Interpreters/ReplaceQueryParameterVisitor.h>
+#include <Interpreters/TreeRewriter.h>
+#include <Interpreters/castColumn.h>
+#include <Interpreters/convertFieldToType.h>
 #include <Parsers/ASTExpressionList.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTQueryParameter.h>
 #include <Parsers/CommonParsers.h>
-#include <Processors/Formats/Impl/ConstantExpressionTemplate.h>
 #include <Parsers/ExpressionElementParsers.h>
+#include <Processors/Formats/IRowInputFormat.h>
+#include <Processors/Formats/Impl/ConstantExpressionTemplate.h>
 #include <boost/functional/hash.hpp>
+#include <Common/SipHash.h>
 
 
 namespace DB
 {
 namespace Setting
 {
-    extern const SettingsUInt64 max_parser_backtracks;
-    extern const SettingsUInt64 max_parser_depth;
+extern const SettingsUInt64 max_parser_backtracks;
+extern const SettingsUInt64 max_parser_depth;
 }
 
 namespace ErrorCodes
 {
-    extern const int LOGICAL_ERROR;
-    extern const int SYNTAX_ERROR;
-    extern const int BAD_ARGUMENTS;
+extern const int LOGICAL_ERROR;
+extern const int SYNTAX_ERROR;
+extern const int BAD_ARGUMENTS;
 }
 
 
 struct SpecialParserType
 {
     SpecialParserType() = default;
-    explicit SpecialParserType(Field::Types::Which main_type_) : main_type(main_type_) {}
+    explicit SpecialParserType(Field::Types::Which main_type_)
+        : main_type(main_type_)
+    {
+    }
 
     Field::Types::Which main_type = Field::Types::String;
     bool is_nullable = false;
@@ -65,20 +68,25 @@ struct SpecialParserType
 
     bool useDefaultParser() const
     {
-        return main_type == Field::Types::String || (!nested_types.empty()
-            && std::all_of(
-                nested_types.begin(),
-                nested_types.end(),
-                [](const auto & type) { return type.first == Field::Types::String; }));
+        return main_type == Field::Types::String
+            || (!nested_types.empty()
+                && std::all_of(
+                    nested_types.begin(), nested_types.end(), [](const auto & type) { return type.first == Field::Types::String; }));
     }
 };
 
 struct LiteralInfo
 {
     using ASTLiteralPtr = std::shared_ptr<ASTLiteral>;
-    LiteralInfo(const ASTLiteralPtr & literal_, const String & column_name_, bool force_nullable_)
-            : literal(literal_), dummy_column_name(column_name_), force_nullable(force_nullable_) { }
+    LiteralInfo(const ASTLiteralPtr & literal_, const LiteralTokenInfo & token_info_, const String & column_name_, bool force_nullable_)
+        : literal(literal_)
+        , token_info(token_info_)
+        , dummy_column_name(column_name_)
+        , force_nullable(force_nullable_)
+    {
+    }
     ASTLiteralPtr literal;
+    LiteralTokenInfo token_info; /// Token positions from parsing (for template construction)
     String dummy_column_name;
     /// Make column nullable even if expression type is not.
     /// (for literals in functions like ifNull and assumeNotNul, which never return NULL even for NULL arguments)
@@ -138,8 +146,7 @@ static void fillLiteralInfo(DataTypes & nested_types, LiteralInfo & info)
             field_type = Field::Types::Map;
         }
         else
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected literal type inside Array: {}. It's a bug",
-                            nested_type->getName());
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected literal type inside Array: {}. It's a bug", nested_type->getName());
 
         if (is_nullable)
             nested_type = std::make_shared<DataTypeNullable>(nested_type);
@@ -148,15 +155,78 @@ static void fillLiteralInfo(DataTypes & nested_types, LiteralInfo & info)
     }
 }
 
+/// Extracts token info for all literals in the AST in DFS order.
+/// This must be called on the ORIGINAL AST before cloning, because the token map
+/// contains pointers to original AST nodes.
+/// The resulting vector is indexed by DFS order and used during replacement on the cloned AST.
+static void extractLiteralTokens(
+    const ASTPtr & ast, const LiteralTokenMap & token_map, std::vector<std::optional<LiteralTokenInfo>> & result, ContextPtr context);
+
+static void extractLiteralTokensImpl(
+    const ASTPtr & ast, const LiteralTokenMap & token_map, std::vector<std::optional<LiteralTokenInfo>> & result, ContextPtr context)
+{
+    if (auto * literal = ast->as<ASTLiteral>())
+    {
+        auto it = token_map.find(literal);
+        if (it != token_map.end())
+            result.push_back(it->second);
+        else
+            result.push_back(std::nullopt);
+        return;
+    }
+
+    if (auto * function = ast->as<ASTFunction>())
+    {
+        if (function->name == "lambda")
+            return;
+        if (function->name.starts_with("toInterval"))
+            return;
+
+        if (!function->arguments)
+            return;
+
+        FunctionOverloadResolverPtr builder = FunctionFactory::instance().get(function->name, context);
+        ColumnNumbers dont_visit_children = builder->getArgumentsThatAreAlwaysConstant();
+
+        for (size_t i = 0; i < function->arguments->children.size(); ++i)
+        {
+            if (std::find(dont_visit_children.begin(), dont_visit_children.end(), i) == dont_visit_children.end())
+                extractLiteralTokensImpl(function->arguments->children[i], token_map, result, context);
+        }
+        return;
+    }
+
+    if (ast->as<ASTQueryParameter>())
+        return;
+    if (ast->as<ASTIdentifier>())
+        return;
+}
+
+static void extractLiteralTokens(
+    const ASTPtr & ast, const LiteralTokenMap & token_map, std::vector<std::optional<LiteralTokenInfo>> & result, ContextPtr context)
+{
+    result.clear();
+    extractLiteralTokensImpl(ast, token_map, result, context);
+}
+
 /// Extracts ASTLiterals from expression, replaces them with ASTIdentifiers where needed
-/// and deduces data types for dummy columns by field type of literal
+/// and deduces data types for dummy columns by field type of literal.
+///
+/// Note: Token positions are extracted from the original AST before cloning via extractLiteralTokens(),
+/// then matched by DFS traversal order during replacement on the cloned AST.
 class ReplaceLiteralsVisitor
 {
 public:
     LiteralsInfo replaced_literals;
     ContextPtr context;
+    const std::vector<std::optional<LiteralTokenInfo>> & literal_tokens;
+    size_t literal_index = 0;
 
-    explicit ReplaceLiteralsVisitor(ContextPtr context_) : context(context_) { }
+    ReplaceLiteralsVisitor(ContextPtr context_, const std::vector<std::optional<LiteralTokenInfo>> & literal_tokens_)
+        : context(context_)
+        , literal_tokens(literal_tokens_)
+    {
+    }
 
     void visit(ASTPtr & ast, bool force_nullable)
     {
@@ -212,7 +282,13 @@ private:
         auto literal = std::dynamic_pointer_cast<ASTLiteral>(ast);
         if (!literal)
             return false;
-        if (literal->begin && literal->end)
+
+        /// Get pre-extracted token info by DFS index (extracted from original AST before cloning)
+        if (literal_index >= literal_tokens.size())
+            return true;
+
+        const auto & token_info_opt = literal_tokens[literal_index++];
+        if (token_info_opt.has_value())
         {
             /// Do not replace empty array and array of NULLs
             if (literal->value.getType() == Field::Types::Array)
@@ -243,7 +319,7 @@ private:
             /// inserting named tuples with different names into another named
             /// tuple will result in only default values being inserted.
             String column_name = "-dummy-" + std::to_string(replaced_literals.size());
-            replaced_literals.emplace_back(literal, column_name, force_nullable);
+            replaced_literals.emplace_back(literal, token_info_opt.value(), column_name, force_nullable);
             setDataType(replaced_literals.back());
             ast = std::make_shared<ASTIdentifier>(column_name);
         }
@@ -277,7 +353,7 @@ private:
         {
             info.special_parser.is_array = true;
             info.type = applyVisitor(FieldToDataType(), info.literal->value);
-            DataTypes nested_types = { assert_cast<const DataTypeArray &>(*info.type).getNestedType() };
+            DataTypes nested_types = {assert_cast<const DataTypeArray &>(*info.type).getNestedType()};
             fillLiteralInfo(nested_types, info);
             info.type = std::make_shared<DataTypeArray>(nested_types[0]);
         }
@@ -299,9 +375,7 @@ private:
             info.type = std::make_shared<DataTypeMap>(nested_types);
         }
         else
-            throw Exception(ErrorCodes::LOGICAL_ERROR,
-                "Unexpected literal type {}",
-                info.literal->value.getTypeName());
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected literal type {}", info.literal->value.getTypeName());
 
         /// Allow literal to be NULL, if result column has nullable type or if function never returns NULL
         if (info.force_nullable && info.type->canBeInsideNullable())
@@ -316,29 +390,41 @@ private:
 /// Expression template is a sequence of tokens and data types of literals.
 /// E.g. template of "position('some string', 'other string') != 0" is
 /// ["position", "(", DataTypeString, ",", DataTypeString, ")", "!=", DataTypeUInt64]
-ConstantExpressionTemplate::TemplateStructure::TemplateStructure(LiteralsInfo & replaced_literals, TokenIterator expression_begin, TokenIterator expression_end,
-                                                                 ASTPtr & expression, const IDataType & result_type, bool null_as_default_, ContextPtr context)
+///
+/// NOTE: This function uses char* positions from LiteralTokenInfo to locate literals in the token stream.
+/// These positions point into the original query buffer which must remain valid during this call.
+ConstantExpressionTemplate::TemplateStructure::TemplateStructure(
+    LiteralsInfo & replaced_literals,
+    TokenIterator expression_begin,
+    TokenIterator expression_end,
+    ASTPtr & expression,
+    const IDataType & result_type,
+    bool null_as_default_,
+    ContextPtr context)
 {
     null_as_default = null_as_default_;
 
-    ::sort(replaced_literals.begin(), replaced_literals.end(), [](const LiteralInfo & a, const LiteralInfo & b)
-    {
-        return a.literal->begin.value() < b.literal->begin.value();
-    });
+    /// Sort literals by their position in the query string (char* comparison)
+    ::sort(
+        replaced_literals.begin(),
+        replaced_literals.end(),
+        [](const LiteralInfo & a, const LiteralInfo & b) { return a.token_info.begin < b.token_info.begin; });
 
     /// Make sequence of tokens and determine IDataType by Field::Types:Which for each literal.
     token_after_literal_idx.reserve(replaced_literals.size());
     special_parser.resize(replaced_literals.size());
     serializations.resize(replaced_literals.size());
 
-    TokenIterator prev_end = expression_begin;
+    TokenIterator cur = expression_begin;
     for (size_t i = 0; i < replaced_literals.size(); ++i)
     {
         const LiteralInfo & info = replaced_literals[i];
-        while (prev_end < info.literal->begin.value())
+
+        /// Collect tokens before this literal (compare char* positions)
+        while (cur < expression_end && cur->begin < info.token_info.begin)
         {
-            tokens.emplace_back(prev_end->begin, prev_end->size());
-            ++prev_end;
+            tokens.emplace_back(cur->begin, cur->size());
+            ++cur;
         }
         token_after_literal_idx.push_back(tokens.size());
 
@@ -346,15 +432,18 @@ ConstantExpressionTemplate::TemplateStructure::TemplateStructure(LiteralsInfo & 
 
         literals.insert({nullptr, info.type, info.dummy_column_name});
 
-        prev_end = info.literal->end.value();
+        /// Skip tokens that belong to this literal (until we're past the literal's end)
+        while (cur < expression_end && cur->begin < info.token_info.end)
+            ++cur;
 
         serializations[i] = info.type->getDefaultSerialization();
     }
 
-    while (prev_end < expression_end)
+    /// Collect remaining tokens after the last literal
+    while (cur < expression_end)
     {
-        tokens.emplace_back(prev_end->begin, prev_end->size());
-        ++prev_end;
+        tokens.emplace_back(cur->begin, cur->size());
+        ++cur;
     }
 
     addNodesToCastResult(result_type, expression, null_as_default);
@@ -363,9 +452,8 @@ ConstantExpressionTemplate::TemplateStructure::TemplateStructure(LiteralsInfo & 
     result_column_name = expression->getColumnName();
     actions_on_literals = ExpressionAnalyzer(expression, syntax_result, context).getActions(false);
     if (actions_on_literals->hasArrayJoin())
-        throw Exception(ErrorCodes::BAD_ARGUMENTS,
-                        "Array joins are not allowed in constant expressions for IN, VALUES, LIMIT and similar sections.");
-
+        throw Exception(
+            ErrorCodes::BAD_ARGUMENTS, "Array joins are not allowed in constant expressions for IN, VALUES, LIMIT and similar sections.");
 }
 
 String ConstantExpressionTemplate::TemplateStructure::dumpTemplate() const
@@ -393,17 +481,18 @@ String ConstantExpressionTemplate::TemplateStructure::dumpTemplate() const
     return res.str();
 }
 
-size_t ConstantExpressionTemplate::TemplateStructure::getTemplateHash(const ASTPtr & expression,
-                                                                      const LiteralsInfo & replaced_literals,
-                                                                      const DataTypePtr & result_column_type,
-                                                                      bool null_as_default,
-                                                                      const String & salt)
+size_t ConstantExpressionTemplate::TemplateStructure::getTemplateHash(
+    const ASTPtr & expression,
+    const LiteralsInfo & replaced_literals,
+    const DataTypePtr & result_column_type,
+    bool null_as_default,
+    const String & salt)
 {
     /// TODO distinguish expressions with the same AST and different tokens (e.g. "CAST(expr, 'Type')" and "CAST(expr AS Type)")
     SipHash hash_state;
     hash_state.update(result_column_type->getName());
 
-    expression->updateTreeHash(hash_state, /*ignore_aliases=*/ true);
+    expression->updateTreeHash(hash_state, /*ignore_aliases=*/true);
 
     for (const auto & info : replaced_literals)
         hash_state.update(info.type->getName());
@@ -420,31 +509,42 @@ size_t ConstantExpressionTemplate::TemplateStructure::getTemplateHash(const ASTP
 }
 
 
-ConstantExpressionTemplate::TemplateStructurePtr
-ConstantExpressionTemplate::Cache::getFromCacheOrConstruct(const DataTypePtr & result_column_type,
-                                                           bool null_as_default,
-                                                           TokenIterator expression_begin,
-                                                           TokenIterator expression_end,
-                                                           const ASTPtr & expression_,
-                                                           ContextPtr context,
-                                                           bool * found_in_cache,
-                                                           const String & salt)
+ConstantExpressionTemplate::TemplateStructurePtr ConstantExpressionTemplate::Cache::getFromCacheOrConstruct(
+    const DataTypePtr & result_column_type,
+    bool null_as_default,
+    TokenIterator expression_begin,
+    TokenIterator expression_end,
+    const ASTPtr & expression_,
+    ContextPtr context,
+    const LiteralTokenMap & token_map,
+    bool * found_in_cache,
+    const String & salt)
 {
     TemplateStructurePtr res;
+
+    /// Step 1: Extract token info from ORIGINAL AST before cloning
+    /// (the token_map contains pointers to original AST nodes)
+    std::vector<std::optional<LiteralTokenInfo>> literal_tokens;
+    extractLiteralTokens(expression_, token_map, literal_tokens, context);
+
+    /// Step 2: Clone the AST for modification
     ASTPtr expression = expression_->clone();
-    ReplaceLiteralsVisitor visitor(context);
+
+    /// Step 3: Replace literals using pre-extracted token info (matched by DFS order)
+    ReplaceLiteralsVisitor visitor(context, literal_tokens);
     visitor.visit(expression, result_column_type->isNullable() || null_as_default);
     ReplaceQueryParameterVisitor param_visitor(context->getQueryParameters());
     param_visitor.visit(expression);
 
-    size_t template_hash = TemplateStructure::getTemplateHash(expression, visitor.replaced_literals, result_column_type, null_as_default, salt);
+    size_t template_hash
+        = TemplateStructure::getTemplateHash(expression, visitor.replaced_literals, result_column_type, null_as_default, salt);
     auto iter = cache.find(template_hash);
     if (iter == cache.end())
     {
         if (max_size <= cache.size())
             cache.clear();
-        res = std::make_shared<TemplateStructure>(visitor.replaced_literals, expression_begin, expression_end,
-                                                  expression, *result_column_type, null_as_default, context);
+        res = std::make_shared<TemplateStructure>(
+            visitor.replaced_literals, expression_begin, expression_end, expression, *result_column_type, null_as_default, context);
         cache.insert({template_hash, res});
         if (found_in_cache)
             *found_in_cache = false;
@@ -550,7 +650,9 @@ bool ConstantExpressionTemplate::parseLiteralAndAssertType(
         ParserTupleOfLiterals parser_tuple;
 
         IParser::Pos iterator(
-            token_iterator, static_cast<unsigned>(settings[Setting::max_parser_depth]), static_cast<unsigned>(settings[Setting::max_parser_backtracks]));
+            token_iterator,
+            static_cast<unsigned>(settings[Setting::max_parser_depth]),
+            static_cast<unsigned>(settings[Setting::max_parser_backtracks]));
         while (iterator->begin < istr.position())
             ++iterator;
         Expected expected;
@@ -594,10 +696,9 @@ bool ConstantExpressionTemplate::parseLiteralAndAssertType(
                     nested_types[i] = nullable->getNestedType();
 
             WhichDataType nested_type_info(nested_types[i]);
-            bool are_types_compatible =
-                (nested_type_info.isNativeUInt() && nested_field_type == Type::UInt64) ||
-                (nested_type_info.isNativeInt()  && nested_field_type == Type::Int64)  ||
-                (nested_type_info.isFloat64()    && nested_field_type == Type::Float64);
+            bool are_types_compatible = (nested_type_info.isNativeUInt() && nested_field_type == Type::UInt64)
+                || (nested_type_info.isNativeInt() && nested_field_type == Type::Int64)
+                || (nested_type_info.isFloat64() && nested_field_type == Type::Float64);
 
             if (!are_types_compatible)
                 return false;
@@ -665,7 +766,8 @@ bool ConstantExpressionTemplate::parseLiteralAndAssertType(
     return true;
 }
 
-ColumnPtr ConstantExpressionTemplate::evaluateAll(BlockMissingValues & nulls, size_t column_idx, const DataTypePtr & expected_type, size_t offset)
+ColumnPtr
+ConstantExpressionTemplate::evaluateAll(BlockMissingValues & nulls, size_t column_idx, const DataTypePtr & expected_type, size_t offset)
 {
     Block evaluated = structure->literals.cloneWithColumns(std::move(columns));
     columns = structure->literals.cloneEmptyColumns();
@@ -674,12 +776,19 @@ ColumnPtr ConstantExpressionTemplate::evaluateAll(BlockMissingValues & nulls, si
     structure->actions_on_literals->execute(evaluated);
 
     if (evaluated.empty() || evaluated.rows() != rows_count)
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Number of rows mismatch after evaluation of batch of constant expressions: "
-                        "got {} rows for {} expressions", evaluated.rows(), rows_count);
+        throw Exception(
+            ErrorCodes::LOGICAL_ERROR,
+            "Number of rows mismatch after evaluation of batch of constant expressions: "
+            "got {} rows for {} expressions",
+            evaluated.rows(),
+            rows_count);
 
     if (!evaluated.has(structure->result_column_name))
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot evaluate template {}, block structure:\n{}",
-                        structure->result_column_name, evaluated.dumpStructure());
+        throw Exception(
+            ErrorCodes::LOGICAL_ERROR,
+            "Cannot evaluate template {}, block structure:\n{}",
+            structure->result_column_name,
+            evaluated.dumpStructure());
 
     rows_count = 0;
     auto res = evaluated.getByName(structure->result_column_name);
@@ -702,7 +811,8 @@ ColumnPtr ConstantExpressionTemplate::evaluateAll(BlockMissingValues & nulls, si
     return castColumn(res, expected_type);
 }
 
-void ConstantExpressionTemplate::TemplateStructure::addNodesToCastResult(const IDataType & result_column_type, ASTPtr & expr, bool null_as_default)
+void ConstantExpressionTemplate::TemplateStructure::addNodesToCastResult(
+    const IDataType & result_column_type, ASTPtr & expr, bool null_as_default)
 {
     /// Replace "expr" with "CAST(expr, 'TypeName')"
     /// or with "(if(isNull(_dummy_0 AS _expression), defaultValueOfTypeName('TypeName'), _CAST(_expression, 'TypeName')), isNull(_expression))" if null_as_default is true

--- a/src/Processors/Formats/Impl/ConstantExpressionTemplate.h
+++ b/src/Processors/Formats/Impl/ConstantExpressionTemplate.h
@@ -1,9 +1,10 @@
 #pragma once
 
 #include <Core/Block.h>
-#include <Parsers/TokenIterator.h>
-#include <Parsers/IAST_fwd.h>
 #include <Interpreters/Context_fwd.h>
+#include <Parsers/ExpressionElementParsers.h>
+#include <Parsers/IAST_fwd.h>
+#include <Parsers/TokenIterator.h>
 
 namespace DB
 {
@@ -26,12 +27,22 @@ class ConstantExpressionTemplate : boost::noncopyable
 {
     struct TemplateStructure : boost::noncopyable
     {
-        TemplateStructure(LiteralsInfo & replaced_literals, TokenIterator expression_begin, TokenIterator expression_end,
-                          ASTPtr & expr, const IDataType & result_type, bool null_as_default_, ContextPtr context);
+        TemplateStructure(
+            LiteralsInfo & replaced_literals,
+            TokenIterator expression_begin,
+            TokenIterator expression_end,
+            ASTPtr & expr,
+            const IDataType & result_type,
+            bool null_as_default_,
+            ContextPtr context);
 
         static void addNodesToCastResult(const IDataType & result_column_type, ASTPtr & expr, bool null_as_default);
-        static size_t getTemplateHash(const ASTPtr & expression, const LiteralsInfo & replaced_literals,
-                                      const DataTypePtr & result_column_type, bool null_as_default, const String & salt);
+        static size_t getTemplateHash(
+            const ASTPtr & expression,
+            const LiteralsInfo & replaced_literals,
+            const DataTypePtr & result_column_type,
+            bool null_as_default,
+            const String & salt);
 
         String dumpTemplate() const;
 
@@ -57,21 +68,29 @@ public:
         const size_t max_size;
 
     public:
-        explicit Cache(size_t max_size_ = 4096) : max_size(max_size_) {}
+        explicit Cache(size_t max_size_ = 4096)
+            : max_size(max_size_)
+        {
+        }
 
         /// Deduce template of expression of type result_column_type and add it to cache (or use template from cache)
-        TemplateStructurePtr getFromCacheOrConstruct(const DataTypePtr & result_column_type,
-                                                     bool null_as_default,
-                                                     TokenIterator expression_begin,
-                                                     TokenIterator expression_end,
-                                                     const ASTPtr & expression_,
-                                                     ContextPtr context,
-                                                     bool * found_in_cache = nullptr,
-                                                     const String & salt = {});
+        TemplateStructurePtr getFromCacheOrConstruct(
+            const DataTypePtr & result_column_type,
+            bool null_as_default,
+            TokenIterator expression_begin,
+            TokenIterator expression_end,
+            const ASTPtr & expression_,
+            ContextPtr context,
+            const LiteralTokenMap & token_map,
+            bool * found_in_cache = nullptr,
+            const String & salt = {});
     };
 
     explicit ConstantExpressionTemplate(const TemplateStructurePtr & structure_)
-            : structure(structure_), columns(structure->literals.cloneEmptyColumns()) {}
+        : structure(structure_)
+        , columns(structure->literals.cloneEmptyColumns())
+    {
+    }
 
     /// Read expression from istr, assert it has the same structure and the same types of literals (template matches)
     /// and parse literals into temporary columns
@@ -99,7 +118,6 @@ private:
 
     /// For expressions without literals (e.g. "now()")
     size_t rows_count = 0;
-
 };
 
 }

--- a/src/Processors/Formats/Impl/ConstantExpressionTemplate.h
+++ b/src/Processors/Formats/Impl/ConstantExpressionTemplate.h
@@ -27,22 +27,13 @@ class ConstantExpressionTemplate : boost::noncopyable
 {
     struct TemplateStructure : boost::noncopyable
     {
-        TemplateStructure(
-            LiteralsInfo & replaced_literals,
-            TokenIterator expression_begin,
-            TokenIterator expression_end,
-            ASTPtr & expr,
-            const IDataType & result_type,
-            bool null_as_default_,
-            ContextPtr context);
+        TemplateStructure(LiteralsInfo & replaced_literals,
+                          TokenIterator expression_begin, TokenIterator expression_end,
+                          ASTPtr & expr, const IDataType & result_type, bool null_as_default_, ContextPtr context);
 
         static void addNodesToCastResult(const IDataType & result_column_type, ASTPtr & expr, bool null_as_default);
-        static size_t getTemplateHash(
-            const ASTPtr & expression,
-            const LiteralsInfo & replaced_literals,
-            const DataTypePtr & result_column_type,
-            bool null_as_default,
-            const String & salt);
+        static size_t getTemplateHash(const ASTPtr & expression, const LiteralsInfo & replaced_literals,
+                                      const DataTypePtr & result_column_type, bool null_as_default, const String & salt);
 
         String dumpTemplate() const;
 
@@ -68,29 +59,22 @@ public:
         const size_t max_size;
 
     public:
-        explicit Cache(size_t max_size_ = 4096)
-            : max_size(max_size_)
-        {
-        }
+        explicit Cache(size_t max_size_ = 4096) : max_size(max_size_) {}
 
         /// Deduce template of expression of type result_column_type and add it to cache (or use template from cache)
-        TemplateStructurePtr getFromCacheOrConstruct(
-            const DataTypePtr & result_column_type,
-            bool null_as_default,
-            TokenIterator expression_begin,
-            TokenIterator expression_end,
-            const ASTPtr & expression_,
-            ContextPtr context,
-            const LiteralTokenMap & token_map,
-            bool * found_in_cache = nullptr,
-            const String & salt = {});
+        TemplateStructurePtr getFromCacheOrConstruct(const DataTypePtr & result_column_type,
+                                                     bool null_as_default,
+                                                     TokenIterator expression_begin,
+                                                     TokenIterator expression_end,
+                                                     const ASTPtr & expression_,
+                                                     ContextPtr context,
+                                                     const LiteralTokenMap & token_map,
+                                                     bool * found_in_cache = nullptr,
+                                                     const String & salt = {});
     };
 
     explicit ConstantExpressionTemplate(const TemplateStructurePtr & structure_)
-        : structure(structure_)
-        , columns(structure->literals.cloneEmptyColumns())
-    {
-    }
+            : structure(structure_), columns(structure->literals.cloneEmptyColumns()) {}
 
     /// Read expression from istr, assert it has the same structure and the same types of literals (template matches)
     /// and parse literals into temporary columns
@@ -118,6 +102,7 @@ private:
 
     /// For expressions without literals (e.g. "now()")
     size_t rows_count = 0;
+
 };
 
 }

--- a/src/Processors/Formats/Impl/ValuesBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ValuesBlockInputFormat.cpp
@@ -1,48 +1,47 @@
-#include <IO/ReadHelpers.h>
-#include <Interpreters/evaluateConstantExpression.h>
-#include <Interpreters/convertFieldToType.h>
-#include <Interpreters/castColumn.h>
-#include <Interpreters/Context.h>
-#include <Parsers/TokenIterator.h>
-#include <Processors/Formats/Impl/ValuesBlockInputFormat.h>
-#include <Formats/FormatFactory.h>
-#include <Formats/EscapingRuleUtils.h>
 #include <Core/Block.h>
-#include <base/find_symbols.h>
-#include <Common/typeid_cast.h>
-#include <Common/checkStackSize.h>
-#include <Common/logger_useful.h>
 #include <Core/Settings.h>
-#include <Parsers/ASTLiteral.h>
-#include <DataTypes/Serializations/SerializationNullable.h>
-#include <DataTypes/DataTypeTuple.h>
 #include <DataTypes/DataTypeArray.h>
 #include <DataTypes/DataTypeMap.h>
+#include <DataTypes/DataTypeTuple.h>
+#include <DataTypes/Serializations/SerializationNullable.h>
+#include <Formats/EscapingRuleUtils.h>
+#include <Formats/FormatFactory.h>
+#include <IO/ReadHelpers.h>
+#include <Interpreters/Context.h>
+#include <Interpreters/castColumn.h>
+#include <Interpreters/convertFieldToType.h>
+#include <Interpreters/evaluateConstantExpression.h>
+#include <Parsers/ASTLiteral.h>
+#include <Parsers/ExpressionElementParsers.h>
+#include <Parsers/TokenIterator.h>
+#include <Processors/Formats/Impl/ConstantExpressionTemplate.h>
+#include <Processors/Formats/Impl/ValuesBlockInputFormat.h>
+#include <base/find_symbols.h>
+#include <Common/checkStackSize.h>
+#include <Common/logger_useful.h>
+#include <Common/typeid_cast.h>
 
 namespace DB
 {
 namespace Setting
 {
-    extern const SettingsUInt64 max_parser_backtracks;
-    extern const SettingsUInt64 max_parser_depth;
+extern const SettingsUInt64 max_parser_backtracks;
+extern const SettingsUInt64 max_parser_depth;
 }
 
 namespace ErrorCodes
 {
-    extern const int LOGICAL_ERROR;
-    extern const int SYNTAX_ERROR;
-    extern const int TYPE_MISMATCH;
-    extern const int SUPPORT_IS_DISABLED;
-    extern const int ARGUMENT_OUT_OF_BOUND;
-    extern const int CANNOT_READ_ALL_DATA;
+extern const int LOGICAL_ERROR;
+extern const int SYNTAX_ERROR;
+extern const int TYPE_MISMATCH;
+extern const int SUPPORT_IS_DISABLED;
+extern const int ARGUMENT_OUT_OF_BOUND;
+extern const int CANNOT_READ_ALL_DATA;
 }
 
 
 ValuesBlockInputFormat::ValuesBlockInputFormat(
-    ReadBuffer & in_,
-    SharedHeader header_,
-    const RowInputFormatParams & params_,
-    const FormatSettings & format_settings_)
+    ReadBuffer & in_, SharedHeader header_, const RowInputFormatParams & params_, const FormatSettings & format_settings_)
     : ValuesBlockInputFormat(std::make_unique<PeekableReadBuffer>(in_), header_, params_, format_settings_)
 {
 }
@@ -52,11 +51,18 @@ ValuesBlockInputFormat::ValuesBlockInputFormat(
     SharedHeader header_,
     const RowInputFormatParams & params_,
     const FormatSettings & format_settings_)
-    : IInputFormat(header_, buf_.get()), buf(std::move(buf_)),
-        params(params_), format_settings(format_settings_), num_columns(header_->columns()),
-        parser_type_for_column(num_columns, ParserType::Streaming),
-        attempts_to_deduce_template(num_columns), attempts_to_deduce_template_cached(num_columns),
-        rows_parsed_using_template(num_columns), templates(num_columns), types(header_->getDataTypes()), serializations(header_->getSerializations())
+    : IInputFormat(header_, buf_.get())
+    , buf(std::move(buf_))
+    , params(params_)
+    , format_settings(format_settings_)
+    , num_columns(header_->columns())
+    , parser_type_for_column(num_columns, ParserType::Streaming)
+    , attempts_to_deduce_template(num_columns)
+    , attempts_to_deduce_template_cached(num_columns)
+    , rows_parsed_using_template(num_columns)
+    , templates(num_columns)
+    , types(header_->getDataTypes())
+    , serializations(header_->getSerializations())
     , block_missing_values(getPort().getHeader().columns())
 {
 }
@@ -332,83 +338,83 @@ bool ValuesBlockInputFormat::tryReadValue(IColumn & column, size_t column_idx)
 
 namespace
 {
-    void tryToReplaceNullFieldsInComplexTypesWithDefaultValues(Field & value, const IDataType & data_type)
+void tryToReplaceNullFieldsInComplexTypesWithDefaultValues(Field & value, const IDataType & data_type)
+{
+    checkStackSize();
+
+    WhichDataType type(data_type);
+
+    if (type.isTuple() && value.getType() == Field::Types::Tuple)
     {
-        checkStackSize();
+        const DataTypeTuple & type_tuple = static_cast<const DataTypeTuple &>(data_type);
 
-        WhichDataType type(data_type);
+        Tuple & tuple_value = value.safeGet<Tuple>();
 
-        if (type.isTuple() && value.getType() == Field::Types::Tuple)
+        size_t src_tuple_size = tuple_value.size();
+        size_t dst_tuple_size = type_tuple.getElements().size();
+
+        if (src_tuple_size != dst_tuple_size)
+            throw Exception(
+                ErrorCodes::TYPE_MISMATCH, "Bad size of tuple. Expected size: {}, actual size: {}.", src_tuple_size, dst_tuple_size);
+
+        for (size_t i = 0; i < src_tuple_size; ++i)
         {
-            const DataTypeTuple & type_tuple = static_cast<const DataTypeTuple &>(data_type);
+            const auto & element_type = *(type_tuple.getElements()[i]);
 
-            Tuple & tuple_value = value.safeGet<Tuple>();
+            if (tuple_value[i].isNull() && !element_type.isNullable())
+                tuple_value[i] = element_type.getDefault();
 
-            size_t src_tuple_size = tuple_value.size();
-            size_t dst_tuple_size = type_tuple.getElements().size();
-
-            if (src_tuple_size != dst_tuple_size)
-                throw Exception(ErrorCodes::TYPE_MISMATCH, "Bad size of tuple. Expected size: {}, actual size: {}.",
-                    src_tuple_size, dst_tuple_size);
-
-            for (size_t i = 0; i < src_tuple_size; ++i)
-            {
-                const auto & element_type = *(type_tuple.getElements()[i]);
-
-                if (tuple_value[i].isNull() && !element_type.isNullable())
-                    tuple_value[i] = element_type.getDefault();
-
-                tryToReplaceNullFieldsInComplexTypesWithDefaultValues(tuple_value[i], element_type);
-            }
-        }
-        else if (type.isArray() && value.getType() == Field::Types::Array)
-        {
-            const DataTypeArray & type_aray = static_cast<const DataTypeArray &>(data_type);
-            const auto & element_type = *(type_aray.getNestedType());
-
-            if (element_type.isNullable())
-                return;
-
-            Array & array_value = value.safeGet<Array>();
-            size_t array_value_size = array_value.size();
-
-            for (size_t i = 0; i < array_value_size; ++i)
-            {
-                if (array_value[i].isNull())
-                    array_value[i] = element_type.getDefault();
-
-                tryToReplaceNullFieldsInComplexTypesWithDefaultValues(array_value[i], element_type);
-            }
-        }
-        else if (type.isMap() && value.getType() == Field::Types::Map)
-        {
-            const DataTypeMap & type_map = static_cast<const DataTypeMap &>(data_type);
-
-            const auto & key_type = *type_map.getKeyType();
-            const auto & value_type = *type_map.getValueType();
-
-            auto & map = value.safeGet<Map>();
-            size_t map_size = map.size();
-
-            for (size_t i = 0; i < map_size; ++i)
-            {
-                auto & map_entry = map[i].safeGet<Tuple>();
-
-                auto & entry_key = map_entry[0];
-                auto & entry_value = map_entry[1];
-
-                if (entry_key.isNull() && !key_type.isNullable())
-                    entry_key = key_type.getDefault();
-
-                tryToReplaceNullFieldsInComplexTypesWithDefaultValues(entry_key, key_type);
-
-                if (entry_value.isNull() && !value_type.isNullable())
-                    entry_value = value_type.getDefault();
-
-                tryToReplaceNullFieldsInComplexTypesWithDefaultValues(entry_value, value_type);
-            }
+            tryToReplaceNullFieldsInComplexTypesWithDefaultValues(tuple_value[i], element_type);
         }
     }
+    else if (type.isArray() && value.getType() == Field::Types::Array)
+    {
+        const DataTypeArray & type_aray = static_cast<const DataTypeArray &>(data_type);
+        const auto & element_type = *(type_aray.getNestedType());
+
+        if (element_type.isNullable())
+            return;
+
+        Array & array_value = value.safeGet<Array>();
+        size_t array_value_size = array_value.size();
+
+        for (size_t i = 0; i < array_value_size; ++i)
+        {
+            if (array_value[i].isNull())
+                array_value[i] = element_type.getDefault();
+
+            tryToReplaceNullFieldsInComplexTypesWithDefaultValues(array_value[i], element_type);
+        }
+    }
+    else if (type.isMap() && value.getType() == Field::Types::Map)
+    {
+        const DataTypeMap & type_map = static_cast<const DataTypeMap &>(data_type);
+
+        const auto & key_type = *type_map.getKeyType();
+        const auto & value_type = *type_map.getValueType();
+
+        auto & map = value.safeGet<Map>();
+        size_t map_size = map.size();
+
+        for (size_t i = 0; i < map_size; ++i)
+        {
+            auto & map_entry = map[i].safeGet<Tuple>();
+
+            auto & entry_key = map_entry[0];
+            auto & entry_value = map_entry[1];
+
+            if (entry_key.isNull() && !key_type.isNullable())
+                entry_key = key_type.getDefault();
+
+            tryToReplaceNullFieldsInComplexTypesWithDefaultValues(entry_key, key_type);
+
+            if (entry_value.isNull() && !value_type.isNullable())
+                entry_value = value_type.getDefault();
+
+            tryToReplaceNullFieldsInComplexTypesWithDefaultValues(entry_value, value_type);
+        }
+    }
+}
 }
 
 bool ValuesBlockInputFormat::parseExpression(IColumn & column, size_t column_idx)
@@ -424,12 +430,19 @@ bool ValuesBlockInputFormat::parseExpression(IColumn & column, size_t column_idx
     ASTPtr ast;
     std::optional<IParser::Pos> ti_start;
 
+    /// RAII guard to capture literal token positions during parsing.
+    /// This is used by ConstantExpressionTemplate to track token positions.
+    /// The scope must extend past the ConstantExpressionTemplate usage below.
+    LiteralTokenMapScope literal_token_scope;
+
     if (!(*token_iterator)->isError() && !(*token_iterator)->isEnd())
     {
         Expected expected;
         /// Keep a copy to the start of the column tokens to use if later if necessary
         ti_start = IParser::Pos(
-            *token_iterator, static_cast<unsigned>(settings[Setting::max_parser_depth]), static_cast<unsigned>(settings[Setting::max_parser_backtracks]));
+            *token_iterator,
+            static_cast<unsigned>(settings[Setting::max_parser_depth]),
+            static_cast<unsigned>(settings[Setting::max_parser_backtracks]));
 
         parsed = parser.parse(*token_iterator, ast, expected);
 
@@ -485,8 +498,10 @@ bool ValuesBlockInputFormat::parseExpression(IColumn & column, size_t column_idx
     if (shouldDeduceNewTemplate(column_idx))
     {
         if (templates[column_idx])
-            throw DB::Exception(ErrorCodes::LOGICAL_ERROR, "Template for column {} already exists and it was not evaluated yet",
-                                std::to_string(column_idx));
+            throw DB::Exception(
+                ErrorCodes::LOGICAL_ERROR,
+                "Template for column {} already exists and it was not evaluated yet",
+                std::to_string(column_idx));
         std::exception_ptr exception;
         try
         {
@@ -500,11 +515,15 @@ bool ValuesBlockInputFormat::parseExpression(IColumn & column, size_t column_idx
                 *token_iterator,
                 ast,
                 context,
+                literal_token_scope.get(),
                 &found_in_cache,
                 delimiter);
 
-            LOG_TEST(getLogger("ValuesBlockInputFormat"), "Will use an expression template to parse column {}: {}",
-                     column_idx, structure->dumpTemplate());
+            LOG_TEST(
+                getLogger("ValuesBlockInputFormat"),
+                "Will use an expression template to parse column {}: {}",
+                column_idx,
+                structure->dumpTemplate());
 
             templates[column_idx].emplace(structure);
             if (found_in_cache)
@@ -563,9 +582,11 @@ bool ValuesBlockInputFormat::parseExpression(IColumn & column, size_t column_idx
             return false;
         }
         buf->rollbackToCheckpoint();
-        throw Exception(ErrorCodes::TYPE_MISMATCH, "Cannot insert NULL value into a column of type '{}' at: {}",
-                        type.getName(), String(buf->position(),
-                        std::min(SHOW_CHARS_ON_SYNTAX_ERROR, buf->buffer().end() - buf->position())));
+        throw Exception(
+            ErrorCodes::TYPE_MISMATCH,
+            "Cannot insert NULL value into a column of type '{}' at: {}",
+            type.getName(),
+            String(buf->position(), std::min(SHOW_CHARS_ON_SYNTAX_ERROR, buf->buffer().end() - buf->position())));
     }
 
     /// Insert value into the column.
@@ -614,7 +635,7 @@ bool ValuesBlockInputFormat::shouldDeduceNewTemplate(size_t column_idx)
 
     /// Using template from cache is approx 2x faster, than evaluating single expression
     /// Construction of new template is approx 1.5x slower, than evaluating single expression
-    double attempts_weighted = 1.5 * attempts_to_deduce_template[column_idx] +  0.5 * attempts_to_deduce_template_cached[column_idx];
+    double attempts_weighted = 1.5 * attempts_to_deduce_template[column_idx] + 0.5 * attempts_to_deduce_template_cached[column_idx];
 
     constexpr size_t max_attempts = 100;
     if (attempts_weighted < max_attempts)
@@ -699,7 +720,8 @@ void ValuesBlockInputFormat::setQueryParameters(const NameToNameMap & parameters
 }
 
 ValuesSchemaReader::ValuesSchemaReader(ReadBuffer & in_, const FormatSettings & format_settings_)
-    : IRowSchemaReader(buf, format_settings_), buf(in_)
+    : IRowSchemaReader(buf, format_settings_)
+    , buf(in_)
 {
 }
 
@@ -755,26 +777,20 @@ void ValuesSchemaReader::transformTypesIfNeeded(DB::DataTypePtr & type, DB::Data
 
 void registerInputFormatValues(FormatFactory & factory)
 {
-    factory.registerInputFormat("Values", [](
-        ReadBuffer & buf,
-        const Block & header,
-        const RowInputFormatParams & params,
-        const FormatSettings & settings)
-    {
-        return std::make_shared<ValuesBlockInputFormat>(buf, std::make_unique<const Block>(header), params, settings);
-    });
+    factory.registerInputFormat(
+        "Values",
+        [](ReadBuffer & buf, const Block & header, const RowInputFormatParams & params, const FormatSettings & settings)
+        { return std::make_shared<ValuesBlockInputFormat>(buf, std::make_unique<const Block>(header), params, settings); });
 }
 
 void registerValuesSchemaReader(FormatFactory & factory)
 {
-    factory.registerSchemaReader("Values", [](ReadBuffer & buf, const FormatSettings & settings)
-    {
-        return std::make_shared<ValuesSchemaReader>(buf, settings);
-    });
-    factory.registerAdditionalInfoForSchemaCacheGetter("Values", [](const FormatSettings & settings)
-    {
-        return getAdditionalFormatInfoByEscapingRule(settings, FormatSettings::EscapingRule::Quoted);
-    });
+    factory.registerSchemaReader(
+        "Values", [](ReadBuffer & buf, const FormatSettings & settings) { return std::make_shared<ValuesSchemaReader>(buf, settings); });
+    factory.registerAdditionalInfoForSchemaCacheGetter(
+        "Values",
+        [](const FormatSettings & settings)
+        { return getAdditionalFormatInfoByEscapingRule(settings, FormatSettings::EscapingRule::Quoted); });
 }
 
 }


### PR DESCRIPTION

### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Improve memory footprint of ASTLiteral by removing `std::optional<TokenIterator> begin/end` from object. Optimization makes sense as fields are not used when highlighting is not used and there is no VALUES parsing. 


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

I applied clang-format to files and formatting diff became larger.

<img width="1724" height="990" alt="Screenshot 2026-01-09 at 09 49 55" src="https://github.com/user-attachments/assets/2570cd4a-e3fd-41a8-a7a4-f9c4218d3c3f" />
