### PR TITLE
Fix support for Prometheus Remote Read protocol

### DIFF
--- a/src/IO/Protobuf/ProtobufZeroCopyOutputStreamFromWriteBuffer.cpp
+++ b/src/IO/Protobuf/ProtobufZeroCopyOutputStreamFromWriteBuffer.cpp
@@ -27,6 +27,7 @@ ProtobufZeroCopyOutputStreamFromWriteBuffer::ProtobufZeroCopyOutputStreamFromWri
 
 bool ProtobufZeroCopyOutputStreamFromWriteBuffer::Next(void ** data, int * size)
 {
+    out->nextIfAtEnd();
     *data = out->position();
     *size = static_cast<int>(out->available());
     out->position() += *size;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix support for Prometheus Remote Read protocol


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.442`
- Backported to: `25.12.3.20`, `25.11.7.17`, `25.10.5.15`, `25.8.15.14`
<!-- ch-version-info:end -->