### PR TITLE
Disable CrashWriter for integration tests

### DIFF
--- a/src/Daemon/CrashWriter.cpp
+++ b/src/Daemon/CrashWriter.cpp
@@ -19,12 +19,30 @@
 
 using namespace DB;
 
+namespace
+{
+constexpr std::string logger_name = "CrashWriter";
+}
 
 std::unique_ptr<CrashWriter> CrashWriter::instance;
 
 void CrashWriter::initialize(Poco::Util::LayeredConfiguration & config)
 {
-    instance.reset(new CrashWriter(config));
+    auto logger = getLogger(logger_name);
+    if (!config.getBool("send_crash_reports.enabled", false))
+    {
+        LOG_DEBUG(logger, "Sending crash reports is disabled");
+        return;
+    }
+
+    auto endpoint = config.getString("send_crash_reports.endpoint");
+    if (endpoint.empty())
+    {
+        LOG_DEBUG(logger, "Sending crash reports is disabled because send_crash_reports.endpoint is not set");
+        return;
+    }
+
+    instance.reset(new CrashWriter(std::move(endpoint), config.getString("path", "")));
 }
 
 bool CrashWriter::initialized()
@@ -32,20 +50,12 @@ bool CrashWriter::initialized()
     return instance != nullptr;
 }
 
-CrashWriter::CrashWriter(Poco::Util::LayeredConfiguration & config)
+CrashWriter::CrashWriter(std::string endpoint_, std::string server_data_path_)
+    : endpoint(std::move(endpoint_))
+    , server_data_path(std::move(server_data_path_))
+    , logger(getLogger(logger_name))
 {
-    auto logger = getLogger("CrashWriter");
-
-    if (config.getBool("send_crash_reports.enabled", false))
-    {
-        endpoint = config.getString("send_crash_reports.endpoint");
-        server_data_path = config.getString("path", "");
-        LOG_DEBUG(logger, "Sending crash reports is initialized with {} endpoint (anonymized)", endpoint);
-    }
-    else
-    {
-        LOG_DEBUG(logger, "Sending crash reports is disabled");
-    }
+    LOG_DEBUG(logger, "Sending crash reports is initialized with {} endpoint (anonymized)", endpoint);
 }
 
 void CrashWriter::onSignal(int sig, std::string_view error_message, const FramePointers & frame_pointers, size_t offset, size_t size)
@@ -62,7 +72,6 @@ void CrashWriter::onException(int code, std::string_view format_string, const Fr
 
 void CrashWriter::sendError(Type type, int sig_or_error, std::string_view error_message, const FramePointers & frame_pointers, size_t offset, size_t size)
 {
-    auto logger = getLogger("CrashWriter");
     if (!instance)
     {
         LOG_INFO(logger, "Not sending crash report");

--- a/src/Daemon/CrashWriter.h
+++ b/src/Daemon/CrashWriter.h
@@ -4,7 +4,19 @@
 #include <Common/StackTrace.h>
 
 
-namespace Poco { namespace Util { class LayeredConfiguration; }}
+namespace Poco
+{
+
+namespace Util
+{
+class LayeredConfiguration;
+};
+
+class Logger;
+
+}
+
+using LoggerPtr = std::shared_ptr<Poco::Logger>;
 
 
 /// Sends crash reports and LOGICAL_ERRORs (if "send_logical_errors" is enabled)
@@ -38,12 +50,14 @@ public:
         size_t size);
 
 private:
-    explicit CrashWriter(Poco::Util::LayeredConfiguration & config);
+    explicit CrashWriter(std::string endpoint_, std::string server_data_path_);
 
     static std::unique_ptr<CrashWriter> instance;
 
     std::string endpoint;
     std::string server_data_path;
+
+    LoggerPtr logger;
 
     enum Type
     {

--- a/tests/integration/helpers/0_common_disable_crash_writer.xml
+++ b/tests/integration/helpers/0_common_disable_crash_writer.xml
@@ -1,0 +1,5 @@
+<clickhouse>
+    <send_crash_reports>
+        <enabled>false</enabled>
+    </send_crash_reports>
+</clickhouse>

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -5552,6 +5552,7 @@ class ClickHouseInstance:
             use_distributed_plan = self.use_distributed_plan
 
         write_embedded_config("0_common_masking_rules.xml", self.config_d_dir)
+        write_embedded_config("0_common_disable_crash_writer.xml", self.config_d_dir)
 
         if use_old_analyzer:
             write_embedded_config("0_common_enable_old_analyzer.xml", users_d_dir)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Tests that rely on producing aborts or crashes can hang in some cases when trying to send report using CrashWriter.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
