### PR TITLE
Fix assert !read_until_position

### DIFF
--- a/src/Disks/IO/CachedOnDiskReadBufferFromFile.h
+++ b/src/Disks/IO/CachedOnDiskReadBufferFromFile.h
@@ -70,6 +70,8 @@ public:
 
     bool isContentCached(size_t offset, size_t size) override;
 
+    std::optional<size_t> tryGetFileSize() override;
+
 private:
     using ImplementationBufferPtr = std::shared_ptr<ReadBufferFromFileBase>;
 


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

https://d1k2gkhrlfqv31.cloudfront.net/clickhouse-test-reports-private/json.html?PR=45607&sha=401668088ae0e9d73730bf97b2ee93f4dd9f134a&name_0=PR&name_1=Stateless%20tests%20%28amd_msan%2C%20distributed%20cache%2C%20meta%20storage%20in%20keeper%2C%20s3%20storage%2C%20sequential%2C%202%2F2%29

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix assert `!read_until_position` in `ReadBufferFromS3` which happened when cache is enabled.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.427`
<!-- ch-version-info:end -->