### PR TITLE
Do not recursively split always-true ranges in PK analysis

### DIFF
--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -3458,7 +3458,7 @@ BoolMask KeyCondition::checkInHyperrectangle(
                             current_intersection = current_intersection & BoolMask(intersects, !contains);
                         }
 
-                        mask = mask | current_intersection;
+                        mask = BoolMask::combine(mask, current_intersection);
                     };
 
                     switch (curve_type(key_column))

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -1745,12 +1745,11 @@ MarkRanges MergeTreeDataSelectExecutor::markRangesFromPKRange(
 
                 ++steps;
 
-                auto result = check_in_range(
-                    range, exact_ranges && range.end == range.begin + 1 ? BoolMask() : BoolMask::consider_only_can_be_true);
+                auto result = check_in_range(range, BoolMask());
                 if (!result.can_be_true)
                     continue;
 
-                if (range.end == range.begin + 1)
+                if (!result.can_be_false || range.end == range.begin + 1)
                 {
                     /// We saw a useful gap between neighboring marks. Either add it to the last range, or start a new range.
                     if (res.empty() || range.begin - res.back().end > min_marks_for_seek)


### PR DESCRIPTION
### Motivation
For very large tables, with queries that select one or more large, consecutive ranges of the table, the generic exclusion search algorithm can take a significant fraction of the total time. This is because for each candidate range, it only considers whether the key condition can be true within that range, otherwise it discards the range. But if the range _cannot be false_, the algorithm currently splits the range into `merge_tree_coarse_index_granularity` pieces, and recursively checks them. This leads to O(N * log N) evaluations of the key condition against the inner marks.

It turns out KeyCondition already supports checking if the condition can be false within a range. This PR enables the check, and exits the algorithm early if the selected range cannot be false.

Compare performance:
```
CREATE OR REPLACE TABLE excl (a int, b int)
ENGINE = MergeTree() ORDER BY (a, b)
SETTINGS index_granularity = 1
AS SELECT 1, 1 FROM numbers(1_000_000);

-- Query
EXPLAIN indexes = 1
SELECT * FROM excl WHERE b = 1
SETTINGS max_threads = 1, send_logs_level = 'trace'

-- Base:
<Trace> default.excl (SelectExecutor): Used generic exclusion search over index for part all_1_1_0 with 1379234 steps
...
0 rows in set. Elapsed: 0.422 sec.

-- PR:
<Trace> default.excl (SelectExecutor): Used generic exclusion search over index for part all_1_1_0 with 1 steps
...
0 rows in set. Elapsed: 0.003 sec.
```

Maybe there are some cases where it is too expensive to check if a range can be false. I claim we should detect those cases with heuristics and selectively disable this optimization.

Part of https://github.com/ClickHouse/ClickHouse/issues/92780

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Improved the performance of generic exclusion search for queries that select large consecutive ranges of the table.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.269`
<!-- ch-version-info:end -->