### PR TITLE
Remove 'Bad Version' handling from S3Queue

### DIFF
--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
@@ -971,81 +971,61 @@ void StorageObjectStorageQueue::commit(
         source->prepareCommitRequests(requests, insert_succeeded, successful_objects, file_map, created_nodes, exception_message, error_code);
     ObjectStorageQueueSource::prepareHiveProcessedRequests(requests, file_map);
 
-    size_t retry_count = 0;
-    constexpr size_t retry_limit = 5;
-
-    while (true)
+    if (requests.empty())
     {
-        if (requests.empty())
+        LOG_TEST(log, "Nothing to commit");
+        return;
+    }
+
+    ProfileEvents::increment(ProfileEvents::ObjectStorageQueueCommitRequests, requests.size());
+
+    if (!successful_objects.empty()
+        && files_metadata->getTableMetadata().after_processing != ObjectStorageQueueAction::KEEP)
+    {
+        postProcess(successful_objects);
+    }
+
+    auto context = getContext();
+    const auto & settings = context->getSettingsRef();
+    auto zk_retry = ObjectStorageQueueMetadata::getKeeperRetriesControl(log);
+
+    std::optional<Coordination::Error> code;
+    Coordination::Responses responses;
+    size_t try_num = 0;
+    zk_retry.retryLoop([&]
+    {
+        if (zk_retry.isRetry())
         {
-            LOG_TEST(log, "Nothing to commit");
-            return;
+            LOG_TRACE(
+                log, "Failed to commit processed files at try {}/{}, will retry",
+                try_num, toString(settings[Setting::keeper_max_retries].value));
         }
-
-        ProfileEvents::increment(ProfileEvents::ObjectStorageQueueCommitRequests, requests.size());
-
-        if (!successful_objects.empty()
-            && files_metadata->getTableMetadata().after_processing != ObjectStorageQueueAction::KEEP)
-        {
-            postProcess(successful_objects);
-        }
-
-        auto context = getContext();
-        const auto & settings = context->getSettingsRef();
-        auto zk_retry = ObjectStorageQueueMetadata::getKeeperRetriesControl(log);
-
-        std::optional<Coordination::Error> code;
-        Coordination::Responses responses;
-        size_t try_num = 0;
-        zk_retry.retryLoop([&]
-        {
-            if (zk_retry.isRetry())
-            {
-                LOG_TRACE(
-                    log, "Failed to commit processed files at try {}/{}, will retry",
-                    try_num, toString(settings[Setting::keeper_max_retries].value));
-            }
-            ++try_num;
-            fiu_do_on(FailPoints::object_storage_queue_fail_commit, {
-                throw zkutil::KeeperException::fromMessage(Coordination::Error::ZCONNECTIONLOSS, "Failed to commit processed files");
-            });
-            fiu_do_on(FailPoints::object_storage_queue_fail_commit_once, {
-                throw zkutil::KeeperException::fromMessage(Coordination::Error::ZCONNECTIONLOSS, "Failed to commit processed files");
-            });
-
-            auto zk_client = getZooKeeper();
-            code = zk_client->tryMulti(requests, responses);
+        ++try_num;
+        fiu_do_on(FailPoints::object_storage_queue_fail_commit, {
+            throw zkutil::KeeperException::fromMessage(Coordination::Error::ZCONNECTIONLOSS, "Failed to commit processed files");
+        });
+        fiu_do_on(FailPoints::object_storage_queue_fail_commit_once, {
+            throw zkutil::KeeperException::fromMessage(Coordination::Error::ZCONNECTIONLOSS, "Failed to commit processed files");
         });
 
-        if (!code.has_value())
-        {
-            throw Exception(
-                ErrorCodes::KEEPER_EXCEPTION,
-                "Failed to commit files with {} retries, last error message: {}",
-                settings[Setting::keeper_max_retries].value,
-                zk_retry.getLastKeeperErrorMessage());
-        }
+        auto zk_client = getZooKeeper();
+        code = zk_client->tryMulti(requests, responses);
+    });
 
-        if (code.value() == Coordination::Error::ZBADVERSION && retry_count < retry_limit)
-        {
-            ++retry_count;
-            LOG_INFO(log, "Keeper Bad Version error, other node wrote something, retry {}", retry_count);
-            /// Need to recreate requests list based on new keeper state
-            requests.clear();
-            for (auto & source : sources)
-                source->prepareCommitRequests(requests, insert_succeeded, successful_objects, file_map, created_nodes, exception_message, error_code);
-            ObjectStorageQueueSource::prepareHiveProcessedRequests(requests, file_map);
-            continue;
-        }
+    if (!code.has_value())
+    {
+        throw Exception(
+            ErrorCodes::KEEPER_EXCEPTION,
+            "Failed to commit files with {} retries, last error message: {}",
+            settings[Setting::keeper_max_retries].value,
+            zk_retry.getLastKeeperErrorMessage());
+    }
 
-        chassert(code.value() == Coordination::Error::ZOK || Coordination::isUserError(code.value()));
-        if (code.value() != Coordination::Error::ZOK)
-        {
-            ProfileEvents::increment(ProfileEvents::ObjectStorageQueueUnsuccessfulCommits);
-            throw zkutil::KeeperMultiException(code.value(), requests, responses);
-        }
-
-        break;
+    chassert(code.value() == Coordination::Error::ZOK || Coordination::isUserError(code.value()));
+    if (code.value() != Coordination::Error::ZOK)
+    {
+        ProfileEvents::increment(ProfileEvents::ObjectStorageQueueUnsuccessfulCommits);
+        throw zkutil::KeeperMultiException(code.value(), requests, responses);
     }
 
     ProfileEvents::increment(ProfileEvents::ObjectStorageQueueSuccessfulCommits);

--- a/tests/integration/test_storage_s3_queue/configs/s3queue_log.xml
+++ b/tests/integration/test_storage_s3_queue/configs/s3queue_log.xml
@@ -7,4 +7,7 @@
         <database>system</database>
         <table>s3queue_log</table>
     </s3queue_log>
+    <logger>
+        <count>25</count>
+    </logger>
 </clickhouse>


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Remove 'Bad version' handling.

### Documentation entry for user-facing changes
Fix for #81040. Remove 'Bad version' handling, this error must not happen in normal situation.
Happens in configuration with one bucket and one processing thread, but with several replicas. This configuration is invalid and in any way does not work properly.

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
