### PR TITLE
extend test tests/integration/test_zookeeper_info/test.py

### DIFF
--- a/tests/integration/test_zookeeper_info/test.py
+++ b/tests/integration/test_zookeeper_info/test.py
@@ -74,7 +74,14 @@ def test_info(started_cluster):
     assert all(node_info['packets_received'] is not None for node_info in node_infos)
     assert all(node_info['packets_sent'] is not None for node_info in node_infos)
 
-    assert sum(node_info['is_leader'] is not None for node_info in node_infos) == 1
+    leader_infos = [n for n in node_infos if n['is_leader'] is not None]
+    assert len(leader_infos) == 1
+    leader = leader_infos[0]
+    assert int(leader['followers']) >= 0
+    synced = int(leader['synced_followers'])
+    pending = int(leader['pending_syncs'])
+    assert 0 <= synced <= int(leader['followers'])
+    assert 0 <= pending <= int(leader['followers'])
 
     assert all(int(node_info['zxid']) > 0 for node_info in node_infos)
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since this only tightens integration test assertions. Potential for minor CI flakiness if leader metrics are temporarily unavailable or inconsistent during startup.
> 
> **Overview**
> Strengthens `tests/integration/test_zookeeper_info/test.py` by explicitly identifying the single leader row (instead of counting non-NULL `is_leader`) and adding sanity checks for leader metrics (`followers`, `synced_followers`, `pending_syncs`) to be non-negative and within expected bounds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53c2952287f28627945d22326549128698f58ef6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.475`
<!-- ch-version-info:end -->