### PR TITLE
CI: Support job on error hook

### DIFF
--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -103,6 +103,7 @@ common_integration_test_job_config = Job.Config(
         ],
     ),
     run_in_docker=f"clickhouse/integration-tests-runner+root+--memory={LIMITED_MEM}+--privileged+--dns-search='.'+--security-opt seccomp=unconfined+--cap-add=SYS_PTRACE+{docker_sock_mount}+--volume=clickhouse_integration_tests_volume:/var/lib/docker+--cgroupns=host",
+    timeout=180, #REMOVEME
 )
 
 BINARY_DOCKER_COMMAND = (

--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -109,7 +109,7 @@ ls -l ./tests/integration/test_backup_restore_azure_blob_storage/_instances-gw2/
 tar --dereference -czf ./ci/tmp/logs.tar.gz \
   ./tests/integration/test_*/_instances*/ \
   ./ci/tmp/*.log \
-  ./ci/tmp/*.jsonl 2>/dev/null || true
+  ./ci/tmp/*.jsonl 2>./ci/tmp/tar.log || true
 docker rm -f praktika
 """,
     timeout=600, #REMOVEME

--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -105,8 +105,8 @@ common_integration_test_job_config = Job.Config(
     run_in_docker=f"clickhouse/integration-tests-runner+root+--memory={LIMITED_MEM}+--privileged+--dns-search='.'+--security-opt seccomp=unconfined+--cap-add=SYS_PTRACE+{docker_sock_mount}+--volume=clickhouse_integration_tests_volume:/var/lib/docker+--cgroupns=host",
     timeout_shell_cleanup=
         """
-find ./tests/integration -ls > ./ci/tmp/filelist.txt
-tar -czf ./ci/tmp/logs.tar.gz \
+ls -l ./tests/integration/test_backup_restore_azure_blob_storage/_instances-gw2/node/logs/clickhouse-server.log > ./ci/tmp/filelist.txt
+tar --dereference -czf ./ci/tmp/logs.tar.gz \
   ./tests/integration/test_*/_instances*/ \
   ./ci/tmp/*.log \
   ./ci/tmp/*.jsonl 2>/dev/null || true

--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -105,7 +105,7 @@ common_integration_test_job_config = Job.Config(
     run_in_docker=f"clickhouse/integration-tests-runner+root+--memory={LIMITED_MEM}+--privileged+--dns-search='.'+--security-opt seccomp=unconfined+--cap-add=SYS_PTRACE+{docker_sock_mount}+--volume=clickhouse_integration_tests_volume:/var/lib/docker+--cgroupns=host",
     timeout_shell_cleanup=
         """
-find ./tests/integration > ./ci/tmp/filelist.txt
+find ./tests/integration -ls > ./ci/tmp/filelist.txt
 tar -czf ./ci/tmp/logs.tar.gz \
   ./tests/integration/test_*/_instances*/ \
   ./ci/tmp/*.log \

--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -103,16 +103,6 @@ common_integration_test_job_config = Job.Config(
         ],
     ),
     run_in_docker=f"clickhouse/integration-tests-runner+root+--memory={LIMITED_MEM}+--privileged+--dns-search='.'+--security-opt seccomp=unconfined+--cap-add=SYS_PTRACE+{docker_sock_mount}+--volume=clickhouse_integration_tests_volume:/var/lib/docker+--cgroupns=host",
-    timeout_shell_cleanup=
-        """
-id > ./ci/tmp/filelist.txt
-sudo echo 1 2>&1 >>./ci/tmp/filelist.txt
-tar --dereference -czf ./ci/tmp/logs.tar.gz \
-  ./tests/integration/test_*/_instances*/ \
-  ./ci/tmp/*.log \
-  ./ci/tmp/*.jsonl 2>./ci/tmp/tar.log || true
-docker rm -f praktika
-""",
     timeout=600, #REMOVEME
 )
 

--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -103,6 +103,12 @@ common_integration_test_job_config = Job.Config(
         ],
     ),
     run_in_docker=f"clickhouse/integration-tests-runner+root+--memory={LIMITED_MEM}+--privileged+--dns-search='.'+--security-opt seccomp=unconfined+--cap-add=SYS_PTRACE+{docker_sock_mount}+--volume=clickhouse_integration_tests_volume:/var/lib/docker+--cgroupns=host",
+    timeout_shell_cleanup="""
+tar -czf ./ci/tmp/logs.tar.gz \
+  ./tests/integration/test_*/_instances*/ \
+  ./ci/tmp/*.log \
+  ./ci/tmp/*.jsonl 2>/dev/null || true
+docker rm -f praktika"""
     timeout=180, #REMOVEME
 )
 

--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -110,7 +110,7 @@ tar -czf ./ci/tmp/logs.tar.gz \
   ./ci/tmp/*.log \
   ./ci/tmp/*.jsonl 2>/dev/null || true
 docker rm -f praktika
-"""
+""",
     timeout=180, #REMOVEME
 )
 

--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -105,7 +105,8 @@ common_integration_test_job_config = Job.Config(
     run_in_docker=f"clickhouse/integration-tests-runner+root+--memory={LIMITED_MEM}+--privileged+--dns-search='.'+--security-opt seccomp=unconfined+--cap-add=SYS_PTRACE+{docker_sock_mount}+--volume=clickhouse_integration_tests_volume:/var/lib/docker+--cgroupns=host",
     timeout_shell_cleanup=
         """
-ls -l ./tests/integration/test_backup_restore_azure_blob_storage/_instances-gw2/node/logs/clickhouse-server.log > ./ci/tmp/filelist.txt
+id > ./ci/tmp/filelist.txt
+sudo echo 1 2>&1 >>./ci/tmp/filelist.txt
 tar --dereference -czf ./ci/tmp/logs.tar.gz \
   ./tests/integration/test_*/_instances*/ \
   ./ci/tmp/*.log \

--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -105,6 +105,7 @@ common_integration_test_job_config = Job.Config(
     run_in_docker=f"clickhouse/integration-tests-runner+root+--memory={LIMITED_MEM}+--privileged+--dns-search='.'+--security-opt seccomp=unconfined+--cap-add=SYS_PTRACE+{docker_sock_mount}+--volume=clickhouse_integration_tests_volume:/var/lib/docker+--cgroupns=host",
     timeout_shell_cleanup=
         """
+find ./ci/tmp > ./ci/tmp/filelist.txt
 tar -czf ./ci/tmp/logs.tar.gz \
   ./tests/integration/test_*/_instances*/ \
   ./ci/tmp/*.log \

--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -103,7 +103,6 @@ common_integration_test_job_config = Job.Config(
         ],
     ),
     run_in_docker=f"clickhouse/integration-tests-runner+root+--memory={LIMITED_MEM}+--privileged+--dns-search='.'+--security-opt seccomp=unconfined+--cap-add=SYS_PTRACE+{docker_sock_mount}+--volume=clickhouse_integration_tests_volume:/var/lib/docker+--cgroupns=host",
-    timeout=600, #REMOVEME
 )
 
 BINARY_DOCKER_COMMAND = (

--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -105,7 +105,7 @@ common_integration_test_job_config = Job.Config(
     run_in_docker=f"clickhouse/integration-tests-runner+root+--memory={LIMITED_MEM}+--privileged+--dns-search='.'+--security-opt seccomp=unconfined+--cap-add=SYS_PTRACE+{docker_sock_mount}+--volume=clickhouse_integration_tests_volume:/var/lib/docker+--cgroupns=host",
     timeout_shell_cleanup=
         """
-find ./ci/tmp > ./ci/tmp/filelist.txt
+find ./tests/integration > ./ci/tmp/filelist.txt
 tar -czf ./ci/tmp/logs.tar.gz \
   ./tests/integration/test_*/_instances*/ \
   ./ci/tmp/*.log \

--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -103,12 +103,14 @@ common_integration_test_job_config = Job.Config(
         ],
     ),
     run_in_docker=f"clickhouse/integration-tests-runner+root+--memory={LIMITED_MEM}+--privileged+--dns-search='.'+--security-opt seccomp=unconfined+--cap-add=SYS_PTRACE+{docker_sock_mount}+--volume=clickhouse_integration_tests_volume:/var/lib/docker+--cgroupns=host",
-    timeout_shell_cleanup="""
+    timeout_shell_cleanup=
+        """
 tar -czf ./ci/tmp/logs.tar.gz \
   ./tests/integration/test_*/_instances*/ \
   ./ci/tmp/*.log \
   ./ci/tmp/*.jsonl 2>/dev/null || true
-docker rm -f praktika"""
+docker rm -f praktika
+"""
     timeout=180, #REMOVEME
 )
 

--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -111,7 +111,7 @@ tar -czf ./ci/tmp/logs.tar.gz \
   ./ci/tmp/*.jsonl 2>/dev/null || true
 docker rm -f praktika
 """,
-    timeout=180, #REMOVEME
+    timeout=600, #REMOVEME
 )
 
 BINARY_DOCKER_COMMAND = (

--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -169,6 +169,7 @@ def main():
     # Set on_error_hook to collect logs on hard timeout
     Result.from_fs(info.job_name).set_on_error_hook(
         """
+find ./tests/integration >./ci/tmp/filelist.txt
 tar -czf ./ci/tmp/logs.tar.gz \
   ./tests/integration/test_*/_instances*/ \
   ./ci/tmp/*.log \
@@ -180,6 +181,7 @@ dmesg -T > ./ci/tmp/dmesg.log
             "./ci/tmp/logs.tar.gz",
             "./ci/tmp/dmesg.log",
             "./ci/tmp/docker-in-docker.log",
+            "./ci/tmp/filelist.txt",
         ],
         strict=False,
     )

--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -177,6 +177,7 @@ dmesg -T > ./ci/tmp/dmesg.log
             "./ci/tmp/dmesg.log",
             "./ci/tmp/docker-in-docker.log",
             "./ci/tmp/filelist.txt",
+            "./ci/tmp/tar.log",
         ],
         strict=False,
     )

--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -176,6 +176,7 @@ dmesg -T > ./ci/tmp/dmesg.log
             "./ci/tmp/logs.tar.gz",
             "./ci/tmp/dmesg.log",
             "./ci/tmp/docker-in-docker.log",
+            "./ci/tmp/filelist.txt",
         ],
         strict=False,
     )

--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -175,13 +175,13 @@ tar -czf ./ci/tmp/logs.tar.gz \
   ./ci/tmp/*.jsonl 2>/dev/null || true
 dmesg -T > ./ci/tmp/dmesg.log
 """
-    ).set_files(
+    ).add_files(
         [
             "./ci/tmp/logs.tar.gz",
             "./ci/tmp/dmesg.log",
             "./ci/tmp/docker-in-docker.log",
         ]
-    ).dump()
+    )
 
     if args.param:
         for item in args.param.split(","):

--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -169,15 +169,18 @@ def main():
     # Set on_error_hook to collect logs on hard timeout
     Result.from_fs(info.job_name).set_on_error_hook(
         """
-dmesg -T > ./ci/tmp/dmesg.log
+dmesg -T >./ci/tmp/dmesg.log
+sudo chown -R $(id -u):$(id -g) ./tests/integration
+tar -czf ./ci/tmp/logs.tar.gz \
+  ./tests/integration/test_*/_instances*/ \
+  ./ci/tmp/*.log \
+  ./ci/tmp/*.jsonl || :
 """
     ).set_files(
         [
             "./ci/tmp/logs.tar.gz",
             "./ci/tmp/dmesg.log",
             "./ci/tmp/docker-in-docker.log",
-            "./ci/tmp/filelist.txt",
-            "./ci/tmp/tar.log",
         ],
         strict=False,
     )

--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -414,9 +414,6 @@ dmesg -T > ./ci/tmp/dmesg.log
             has_error = True
             error_info.append(test_result_parallel.info)
 
-    # test
-    assert False
-
     fail_num = len([r for r in test_results if not r.is_ok()])
     if sequential_test_modules and fail_num < MAX_FAILS_BEFORE_DROP and not has_error:
         for attempt in range(module_repeat_cnt):

--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -169,11 +169,6 @@ def main():
     # Set on_error_hook to collect logs on hard timeout
     Result.from_fs(info.job_name).set_on_error_hook(
         """
-find ./tests/integration >./ci/tmp/filelist.txt
-tar -czf ./ci/tmp/logs.tar.gz \
-  ./tests/integration/test_*/_instances*/ \
-  ./ci/tmp/*.log \
-  ./ci/tmp/*.jsonl 2>/dev/null || true
 dmesg -T > ./ci/tmp/dmesg.log
 """
     ).set_files(
@@ -181,7 +176,6 @@ dmesg -T > ./ci/tmp/dmesg.log
             "./ci/tmp/logs.tar.gz",
             "./ci/tmp/dmesg.log",
             "./ci/tmp/docker-in-docker.log",
-            "./ci/tmp/filelist.txt",
         ],
         strict=False,
     )

--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -175,12 +175,13 @@ tar -czf ./ci/tmp/logs.tar.gz \
   ./ci/tmp/*.jsonl 2>/dev/null || true
 dmesg -T > ./ci/tmp/dmesg.log
 """
-    ).add_files(
+    ).set_files(
         [
             "./ci/tmp/logs.tar.gz",
             "./ci/tmp/dmesg.log",
             "./ci/tmp/docker-in-docker.log",
-        ]
+        ],
+        strict=False,
     )
 
     if args.param:

--- a/ci/jobs/scripts/workflow_hooks/filter_job.py
+++ b/ci/jobs/scripts/workflow_hooks/filter_job.py
@@ -180,11 +180,21 @@ def should_skip_job(job_name):
 
     # If only the functional tests script changed, run only the first batch of stateless tests
     if changed_files and all(
-        f.startswith("ci/jobs/") and f.endswith(".py") for f in changed_files
+        f.startswith("ci/") and f.endswith(".py") for f in changed_files
     ):
         if JobNames.STATELESS in job_name:
             match = re.search(r"(\d)/\d", job_name)
             if match and match.group(1) != "1" or "sequential" in job_name:
+                return True, "Skipped, only job script changed - run first batch only"
+
+        if JobNames.INTEGRATION in job_name:
+            match = re.search(r"(\d)/\d", job_name)
+            if (
+                match
+                and match.group(1) != "1"
+                or "sequential" in job_name
+                or "_asan" not in job_name
+            ):
                 return True, "Skipped, only job script changed - run first batch only"
 
     return False, ""

--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -222,6 +222,11 @@ class Result(MetaClasses.Serializable):
         self.dump()
         return self
 
+    def add_files(self, files) -> "Result":
+        self.files = list(set(self.files) | set(files))
+        self.dump()
+        return self
+
     def set_files(self, files) -> "Result":
         if isinstance(files, (str, Path)):
             files = [files]

--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -222,18 +222,14 @@ class Result(MetaClasses.Serializable):
         self.dump()
         return self
 
-    def add_files(self, files) -> "Result":
-        self.files = list(set(self.files) | set(files))
-        self.dump()
-        return self
-
-    def set_files(self, files) -> "Result":
+    def set_files(self, files, strict=True) -> "Result":
         if isinstance(files, (str, Path)):
             files = [files]
-        for file in files:
-            assert Path(
-                file
-            ).is_file(), f"Not valid file [{file}] from file list [{files}]"
+        if strict:
+            for file in files:
+                assert Path(
+                    file
+                ).is_file(), f"Not valid file [{file}] from file list [{files}]"
         if not self.files:
             self.files = []
         for file in self.files:

--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -241,6 +241,30 @@ class Result(MetaClasses.Serializable):
         self.dump()
         return self
 
+    def set_on_error_hook(self, hook: str) -> "Result":
+        """
+        Sets a bash script to execute when the job encounters a critical error.
+
+        This hook runs on job-level failures such as:
+        - Hard timeout exceeded
+        - Job killed or terminated by the system
+        - Infrastructure failures
+
+        The hook script should handle cleanup, log collection, or any other
+        recovery actions needed before the job terminates.
+
+        Args:
+            hook: Bash script/commands to execute on error
+
+        Returns:
+            Self for method chaining
+        """
+        self.ext["on_error_hook"] = hook
+        return self
+
+    def get_on_error_hook(self) -> str:
+        return self.ext.get("on_error_hook", "")
+
     def set_info(self, info: str) -> "Result":
         if self.info:
             self.info += "\n"

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -474,18 +474,15 @@ class Runner:
                 info=f"Failed to read Result json, ex: [{e}]",
             ).dump()
 
-        print(f"####REMOVEME {result.is_completed()}")
-        from dataclasses import asdict
-        print("\n".join(f"{k}={v!r}" for k, v in asdict(result).items()))
-
         if not result.is_completed():
             info = f"ERROR: {ResultInfo.KILLED}"
             print(info)
             result.set_info(info).set_status(Result.Status.ERROR).dump()
-            if result.get_on_error_hook():
-                print(f"--- Run on_error_hook [{result.get_on_error_hook()}]")
-                # Add hook timeout once it's needed
-                Shell.check(result.get_on_error_hook(), verbose=True)
+
+        if result.is_error():
+            print(f"--- Run on_error_hook [{result.get_on_error_hook()}]")
+            # Add hook timeout once it's needed
+            Shell.check(result.get_on_error_hook(), verbose=True)
 
         result.update_duration()
         result.set_files([Settings.RUN_LOG])

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -22,6 +22,7 @@ from .s3 import S3
 from .settings import Settings
 from .usage import ComputeUsage, StorageUsage
 from .utils import Shell, TeePopen, Utils
+from ci.praktika import result
 
 _GH_authenticated = False
 
@@ -474,6 +475,8 @@ class Runner:
             ).dump()
 
         print(f"####REMOVEME {result.is_completed()}")
+        print("\n".join(f"{k}={v!r}" for k, v in result.items()))
+
         if not result.is_completed():
             info = f"ERROR: {ResultInfo.KILLED}"
             print(info)

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -473,6 +473,7 @@ class Runner:
                 info=f"Failed to read Result json, ex: [{e}]",
             ).dump()
 
+        print(f"####REMOVEME {result.is_completed()}")
         if not result.is_completed():
             info = f"ERROR: {ResultInfo.KILLED}"
             print(info)

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -475,7 +475,7 @@ class Runner:
             ).dump()
 
         print(f"####REMOVEME {result.is_completed()}")
-        import asdict
+        from dataclasses import asdict
         print("\n".join(f"{k}={v!r}" for k, v in asdict(result).items()))
 
         if not result.is_completed():

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -478,7 +478,7 @@ class Runner:
             print(info)
             result.set_info(info).set_status(Result.Status.ERROR).dump()
 
-        if result.is_error():
+        if result.is_error() and result.get_on_error_hook():
             print(f"--- Run on_error_hook [{result.get_on_error_hook()}]")
             # Add hook timeout once it's needed
             Shell.check(result.get_on_error_hook(), verbose=True)

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -477,6 +477,10 @@ class Runner:
             info = f"ERROR: {ResultInfo.KILLED}"
             print(info)
             result.set_info(info).set_status(Result.Status.ERROR).dump()
+            if result.get_on_error_hook():
+                print(f"--- Run on_error_hook [{result.get_on_error_hook()}]")
+                # Add hook timeout once it's needed
+                Shell.check(result.get_on_error_hook(), verbose=True)
 
         result.update_duration()
         result.set_files([Settings.RUN_LOG])

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -22,7 +22,6 @@ from .s3 import S3
 from .settings import Settings
 from .usage import ComputeUsage, StorageUsage
 from .utils import Shell, TeePopen, Utils
-from ci.praktika import result
 
 _GH_authenticated = False
 

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -475,7 +475,8 @@ class Runner:
             ).dump()
 
         print(f"####REMOVEME {result.is_completed()}")
-        print("\n".join(f"{k}={v!r}" for k, v in result.items()))
+        import asdict
+        print("\n".join(f"{k}={v!r}" for k, v in asdict(result).items()))
 
         if not result.is_completed():
             info = f"ERROR: {ResultInfo.KILLED}"


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

---

- Support on_error hook that can be set in job script
- Add on_error hook into integration test to collect logs on fatal error or timeout


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.561`
<!-- ch-version-info:end -->