### PR TITLE
Fix crash in mergeTreeAnalyzeIndexes() with non existing parts and table with skipping indexes

### DIFF
--- a/src/Storages/StorageMergeTreeAnalyzeIndexes.cpp
+++ b/src/Storages/StorageMergeTreeAnalyzeIndexes.cpp
@@ -68,6 +68,9 @@ protected:
         if (std::exchange(analyzed, true))
             return {};
 
+        if (data_parts.empty())
+            return {};
+
         auto ranges = getIndexAnalysis();
         MutableColumns res_columns = header->cloneEmptyColumns();
 

--- a/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexes_regressions.reference
+++ b/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexes_regressions.reference
@@ -1,0 +1,6 @@
+-- { echoOn }
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data_add_minmax_index_for_numeric_columns, key = 8193);
+all_1_1_0	[(1,2)]
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data_add_minmax_index_for_numeric_columns, key = 8193, 'no_such_part');
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data_add_minmax_index_for_numeric_columns, key = 8193, '.*|no_such_part');
+all_1_1_0	[(1,2)]

--- a/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexes_regressions.sql
+++ b/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexes_regressions.sql
@@ -1,0 +1,9 @@
+-- https://github.com/ClickHouse/ClickHouse/issues/93817
+drop table if exists data_add_minmax_index_for_numeric_columns;
+create table data_add_minmax_index_for_numeric_columns (key Int, value Int) engine=MergeTree() order by key settings merge_selector_base = 1000, index_granularity=8192, index_granularity_bytes=10e9, min_bytes_for_wide_part=1e9, add_minmax_index_for_numeric_columns=1 as
+select *, *+1000000 from numbers(100000) settings max_insert_threads=1;
+-- { echoOn }
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data_add_minmax_index_for_numeric_columns, key = 8193);
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data_add_minmax_index_for_numeric_columns, key = 8193, 'no_such_part');
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data_add_minmax_index_for_numeric_columns, key = 8193, '.*|no_such_part');
+-- { echoOff }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix crash in mergeTreeAnalyzeIndexes() with non existing parts and table with skipping indexes

Fixes: https://github.com/ClickHouse/ClickHouse/issues/93817

_Note: marked as not for changelog since it has not been included into any release yet_