### PR TITLE
tests: make 01460_line_as_string_format less flaky (under slow MSan)

### DIFF
--- a/tests/queries/0_stateless/01460_line_as_string_format.reference
+++ b/tests/queries/0_stateless/01460_line_as_string_format.reference
@@ -6,5 +6,5 @@
 Finally implement this new feature.
 42	ClickHouse
 42	ClickHouse is a `fast` #open-source# (OLAP) database "management" :system:
-1000000
+100000
 1000

--- a/tests/queries/0_stateless/01460_line_as_string_format.sh
+++ b/tests/queries/0_stateless/01460_line_as_string_format.sh
@@ -35,14 +35,12 @@ echo -e 'ClickHouse is a `fast` #open-source# (OLAP) database "management" :syst
 $CLICKHOUSE_CLIENT --query="SELECT * FROM line_as_string2 order by c";
 $CLICKHOUSE_CLIENT --query="DROP TABLE line_as_string2"
 
-$CLICKHOUSE_CLIENT --query="select repeat('aaa',50) from numbers(1000000)" > "${CLICKHOUSE_TMP}"/data1
 $CLICKHOUSE_CLIENT --query="CREATE TABLE line_as_string3(field String) ENGINE = Memory";
-$CLICKHOUSE_CLIENT --query="INSERT INTO line_as_string3 FORMAT LineAsString" < "${CLICKHOUSE_TMP}"/data1
+$CLICKHOUSE_CLIENT --query="SELECT repeat('aaa',50) FROM numbers(100000)" | $CLICKHOUSE_CLIENT --query="INSERT INTO line_as_string3 FORMAT LineAsString"
 $CLICKHOUSE_CLIENT --query="SELECT count(*) FROM line_as_string3";
 $CLICKHOUSE_CLIENT --query="DROP TABLE line_as_string3"
 
-$CLICKHOUSE_CLIENT --query="select randomString(50000) FROM numbers(1000)" > "${CLICKHOUSE_TMP}"/data2
 $CLICKHOUSE_CLIENT --query="CREATE TABLE line_as_string4(field String) ENGINE = Memory";
-$CLICKHOUSE_CLIENT --query="INSERT INTO line_as_string4 FORMAT LineAsString" < "${CLICKHOUSE_TMP}"/data2
+$CLICKHOUSE_CLIENT --query="SELECT randomString(50000) FROM numbers(1000)" | $CLICKHOUSE_CLIENT --query="INSERT INTO line_as_string4 FORMAT LineAsString"
 $CLICKHOUSE_CLIENT --query="SELECT count(*) FROM line_as_string4";
 $CLICKHOUSE_CLIENT --query="DROP TABLE line_as_string4"


### PR DESCRIPTION
CI: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=86786&sha=80738ad3bc7c61f823d1b2dc835a6abc7ef800dd&name_0=PR&name_1=Stateless%20tests%20%28amd_msan%2C%20parallel%2C%201%2F2%29
https://github.com/ClickHouse/ClickHouse/pull/86786

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.478`
<!-- ch-version-info:end -->