### PR TITLE
Remove useless optional in ASTWithAlias

### DIFF
--- a/src/Interpreters/ReplaceQueryParameterVisitor.cpp
+++ b/src/Interpreters/ReplaceQueryParameterVisitor.cpp
@@ -215,6 +215,6 @@ void ReplaceQueryParameterVisitor::resolveParameterizedAlias(ASTPtr & ast)
         return;
 
     if (ast_with_alias->parametrised_alias)
-        setAlias(ast, getParamValue((*ast_with_alias->parametrised_alias)->name));
+        setAlias(ast, getParamValue(ast_with_alias->parametrised_alias->name));
 }
 }

--- a/src/Parsers/ASTWithAlias.h
+++ b/src/Parsers/ASTWithAlias.h
@@ -20,7 +20,7 @@ public:
     bool prefer_alias_to_column_name = false;
     // An alias can be defined as a query parameter,
     // in which case we can only resolve it during query execution.
-    std::optional<std::shared_ptr<ASTQueryParameter>> parametrised_alias;
+    std::shared_ptr<ASTQueryParameter> parametrised_alias;
 
     using IAST::IAST;
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Let's not waste those 8 bytes.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
