### PR TITLE
tests: fix flaky 03373_named_session_try_recreate_before_timeout

### DIFF
--- a/tests/queries/0_stateless/03373_named_session_try_recreate_before_timeout.sh
+++ b/tests/queries/0_stateless/03373_named_session_try_recreate_before_timeout.sh
@@ -21,7 +21,8 @@ $CLICKHOUSE_CURL -sS -d "select value, changed from system.settings where name =
 $CLICKHOUSE_CURL -sS -d 'begin transaction' "$CLICKHOUSE_URL&$SETTINGS"
 $CLICKHOUSE_CURL -sS -d 'commit' "$CLICKHOUSE_URL&$SETTINGS&close_session=1"
 
-$CLICKHOUSE_CURL -sS -X POST --data-binary @- \
+# Deferred HTTP 100 response from ClickHouse prevents curl from sending body using potentially closed connection
+$CLICKHOUSE_CURL -sS -X POST -H "X-ClickHouse-100-Continue: defer" --data-binary @- \
   "$CLICKHOUSE_URL&$SETTINGS&session_check=1&query=insert+into+$TABLE_NAME+format+TSV" \
   < "$DATA_FILE" 2>&1 | {
     response=$(cat)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Details
Closes #93568.

Test fails with
```
curl: (55) Send failure: Connection reset by peer
```

So, it fails to send body, when trying to execute insert with closed session and `session_check=1`.

Fixi by deferring `100 Continue` response from ClickHouse to prevent curl from writing POST body using closed connection. Session check performed before query execution / quota checks, so this header will work for this case.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.416`
<!-- ch-version-info:end -->