### PR TITLE
Fix misinterpreted doc and default value of dns_max_consecutive_failures

### DIFF
--- a/src/Core/ServerSettings.cpp
+++ b/src/Core/ServerSettings.cpp
@@ -571,7 +571,7 @@ namespace DB
     DECLARE(UInt64, dns_cache_max_entries, 10000, R"(Internal DNS cache max entries.)", 0) \
     DECLARE(Int32, dns_cache_update_period, 15, "Internal DNS cache update period in seconds.", 0) \
     DECLARE(UInt32, dns_max_consecutive_failures, 5, R"(
-    Stop further attempts to resolve the DNS name after this number of failures. The information still remains in the DNS cache.
+    Stop further attempts to update a hostname's DNS cache after this number of consecutive failures. The information still remains in the DNS cache. Zero means unlimited.
 
     **See also**
 

--- a/src/Core/ServerSettings.cpp
+++ b/src/Core/ServerSettings.cpp
@@ -571,11 +571,7 @@ namespace DB
     DECLARE(UInt64, dns_cache_max_entries, 10000, R"(Internal DNS cache max entries.)", 0) \
     DECLARE(Int32, dns_cache_update_period, 15, "Internal DNS cache update period in seconds.", 0) \
     DECLARE(UInt32, dns_max_consecutive_failures, 5, R"(
-    The number of consecutive failures accepted when updating a DNS cache entry before it is dropped. Set to `0` to disable cache dropping.
-
-    :::note
-    Cache dropping means just stopping to update this cache entry after consecutive failures (the others still continue to be updated), but it won't be cleared. Cache entries will only be cleaned by `SYSTEM DROP DNS CACHE`.
-    :::
+    Stop further attempts to resolve the DNS name after this number of failures. The information still remains in the DNS cache.
 
     **See also**
 

--- a/src/Core/ServerSettings.cpp
+++ b/src/Core/ServerSettings.cpp
@@ -570,7 +570,17 @@ namespace DB
     DECLARE(Bool, disable_internal_dns_cache, false, "Disables the internal DNS cache. Recommended for operating ClickHouse in systems with frequently changing infrastructure such as Kubernetes.", 0) \
     DECLARE(UInt64, dns_cache_max_entries, 10000, R"(Internal DNS cache max entries.)", 0) \
     DECLARE(Int32, dns_cache_update_period, 15, "Internal DNS cache update period in seconds.", 0) \
-    DECLARE(UInt32, dns_max_consecutive_failures, 10, "Max DNS resolve failures of a hostname before dropping the hostname from ClickHouse DNS cache.", 0) \
+    DECLARE(UInt32, dns_max_consecutive_failures, 5, R"(
+    The number of consecutive failures accepted when updating a DNS cache entry before it is dropped. Set to `0` to disable cache dropping.
+
+    :::note
+    Cache dropping means just stopping to update this cache entry after consecutive failures (the others still continue to be updated), but it won't be cleared. Cache entries will only be cleaned by `SYSTEM DROP DNS CACHE`.
+    :::
+
+    **See also**
+
+    - [`SYSTEM DROP DNS CACHE`](../../sql-reference/statements/system#drop-dns-cache)
+    )", 0) \
     DECLARE(Bool, dns_allow_resolve_names_to_ipv4, true, "Allows resolve names to ipv4 addresses.", 0) \
     DECLARE(Bool, dns_allow_resolve_names_to_ipv6, true, "Allows resolve names to ipv6 addresses.", 0) \
     \


### PR DESCRIPTION
### Changelog category (leave one):

- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.428`
<!-- ch-version-info:end -->