### PR TITLE
Improve posix portability for illumos.

### DIFF
--- a/base/base/getFQDNOrHostName.cpp
+++ b/base/base/getFQDNOrHostName.cpp
@@ -6,7 +6,7 @@ namespace
 {
     std::string getFQDNOrHostNameImpl()
     {
-#if defined(OS_DARWIN)
+#if defined(OS_DARWIN) || defined(OS_SUNOS)
         return Poco::Net::DNS::hostName();
 #else
         try

--- a/base/poco/Foundation/src/FPEnvironment_SUN.cpp
+++ b/base/poco/Foundation/src/FPEnvironment_SUN.cpp
@@ -64,7 +64,7 @@ bool FPEnvironmentImpl::isInfiniteImpl(double value)
 
 bool FPEnvironmentImpl::isInfiniteImpl(long double value)
 {
-	int cls = fpclass(value);
+	int cls = fpclass(static_cast<double>(value));
 	return cls == FP_PINF || cls == FP_NINF;
 }
 

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -1743,6 +1743,7 @@ try
         }
     }
 
+#if defined(RLIMIT_NPROC)
     /// Try to increase limit on number of threads.
     {
         rlimit rlim;
@@ -1777,6 +1778,7 @@ try
                     "Maximum number of threads is lower than 30000. There could be problems with handling a lot of simultaneous queries."));
         }
     }
+#endif
 
     static ServerErrorHandler error_handler;
     Poco::ErrorHandler::set(&error_handler);

--- a/src/Client/TerminalKeystrokeInterceptor.cpp
+++ b/src/Client/TerminalKeystrokeInterceptor.cpp
@@ -10,6 +10,9 @@
 #include <unistd.h>
 #include <base/defines.h>
 #include <sys/ioctl.h>
+#ifdef __sun
+#include <sys/filio.h>  // illumos defines FIONREAD in sys/filio.h, not sys/ioctl.h
+#endif
 
 namespace DB::ErrorCodes
 {

--- a/utils/self-extracting-executable/decompressor.cpp
+++ b/utils/self-extracting-executable/decompressor.cpp
@@ -1,10 +1,6 @@
 #include <zstd.h>
 #include <sys/mman.h>
-#if defined(OS_DARWIN) || defined(OS_FREEBSD)
-#   include <sys/mount.h>
-#else
-#   include <sys/statfs.h>
-#endif
+#include <sys/statvfs.h>
 #include <fcntl.h>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -216,10 +212,10 @@ int decompressFiles(int input_fd, char * path, char * name, bool & have_compress
     }
 
     /// Check free space
-    struct statfs fs_info;
-    if (0 != fstatfs(input_fd, &fs_info))
+    struct statvfs fs_info;
+    if (0 != fstatvfs(input_fd, &fs_info))
     {
-        perror("fstatfs");
+        perror("fstatvfs");
         if (0 != munmap(input, info_in.st_size))
                 perror("munmap");
         return 1;


### PR DESCRIPTION
- Guard RLIMIT_NPROC usage; not defined on illumos.
- Include sys/filio.h for FIONREAD on illumos (not in sys/ioctl.h).
- Use posix statvfs in decompressor.
- Use DNS::hostName() instead of DNS::thisHost() on illumos.
- Fix fpclass() call for long double.

See also:
- https://github.com/oxidecomputer/garbage-compactor/blob/master/clickhouse/patches/0017-Use-statvfs-on-illumos.patch
- https://github.com/oxidecomputer/garbage-compactor/blob/master/clickhouse/patches/0018-Do-not-try-to-increase-the-thread-limit-via-proc.patch

Part of #23777.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.415`
<!-- ch-version-info:end -->