### PR TITLE
Fix bad test `01459_manual_write_to_replicas_quorum_detach_attach`

### DIFF
--- a/src/Coordination/KeeperStorage.cpp
+++ b/src/Coordination/KeeperStorage.cpp
@@ -3855,7 +3855,7 @@ void KeeperStorage<Container>::rollbackRequest(int64_t rollback_zxid, bool allow
     }
 
     // if an exception occurs during rollback, the best option is to terminate because we can end up in an inconsistent state
-    // we block memory tracking so we can avoid terminating if we're rollbacking because of memory limit
+    // we block memory tracking so we can avoid terminating if we're rolling back because of memory limit
     LockMemoryExceptionInThread blocker{VariableContext::Global};
     try
     {

--- a/src/Interpreters/InsertDeduplication.cpp
+++ b/src/Interpreters/InsertDeduplication.cpp
@@ -374,7 +374,7 @@ std::string DeduplicationInfo::debug() const
         block_str = fmt::format("rows/cols {}/{}", original_block->rows(), original_block->getColumns().size());
 
     return fmt::format(
-        "inst: {}, {}, {}, level {}, rows/tokens {}/{}, in block: {}, tokens: {}:[{}], visited views: {}:[{}], retried view id: {}, original block id: {}",
+        "instance_id: {}, {}, {}, level {}, rows/tokens {}/{}, in block: {}, tokens: {}:[{}], visited views: {}:[{}], retried view id: {}, original block id: {}",
         instance_id,
         is_async_insert ? "async" : "sync",
         disabled ? "disabled" : "enabled",

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -8065,7 +8065,7 @@ void MergeTreeData::Transaction::rollback(DataPartsLock & lock)
         buf << ".";
         if (!detached_precommitted_parts.empty())
         {
-            buf << " Rollbacking parts state to temporary and removing from working set:";
+            buf << " Rolling back parts state to temporary and removing from working set:";
             for (const auto & part : detached_precommitted_parts)
                 buf << " " << part->getDataPartStorage().getPartDirectory();
             buf << ".";

--- a/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
@@ -8,7 +8,6 @@
 #include <Interpreters/InsertDeduplication.h>
 #include <Interpreters/PartLog.h>
 #include <Interpreters/Context.h>
-#include <Processors/Transforms/DeduplicationTokenTransforms.h>
 #include <Common/ElapsedTimeProfileEventIncrement.h>
 #include <Common/ProfileEvents.h>
 #include <Common/ZooKeeper/IKeeper.h>
@@ -16,18 +15,14 @@
 #include <Common/Exception.h>
 #include <Common/FailPoint.h>
 #include <Common/ProfileEventsScope.h>
-#include <Common/SipHash.h>
 #include <Common/ZooKeeper/KeeperException.h>
 #include <Common/ThreadFuzzer.h>
 #include <Core/BackgroundSchedulePool.h>
 #include <Core/Settings.h>
-#include <Storages/MergeTree/MergeAlgorithm.h>
 #include <Storages/MergeTree/MergeTreeDataWriter.h>
 #include <Storages/MergeTree/MergeTreeSettings.h>
-#include <Storages/MergeTree/AsyncBlockIDsCache.h>
 #include <Core/Block.h>
 #include <IO/Operators.h>
-#include <fmt/core.h>
 #include <fmt/format.h>
 
 

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -1952,9 +1952,9 @@ bool StorageReplicatedMergeTree::checkPartsImpl(bool skip_sanity_checks)
     bool insane = uncovered_unexpected_parts_rows > total_rows_on_filesystem * (*storage_settings_ptr)[MergeTreeSetting::replicated_max_ratio_of_wrong_parts];
 
     constexpr auto sanity_report_fmt = "The local set of parts of table {} doesn't look like the set of parts in ZooKeeper: "
-                                               "{} rows of {} total rows in filesystem are suspicious. "
-                                               "There are {} uncovered unexpected parts with {} rows ({} of them is not just-written with {} rows), "
-                                               "{} missing parts (with {} blocks), {} covered unexpected parts (with {} rows).";
+        "{} rows of {} total rows in filesystem are suspicious. "
+        "There are {} uncovered unexpected parts with {} rows ({} of them is not just-written with {} rows), "
+        "{} missing parts (with {} blocks), {} covered unexpected parts (with {} rows).";
 
     constexpr auto sanity_report_debug_fmt = "Uncovered unexpected parts: {}. Restorable unexpected parts: {}. Missing parts: {}. Covered unexpected parts: {}. Expected parts: {}.";
 

--- a/tests/queries/0_stateless/01459_manual_write_to_replicas_quorum_detach_attach.sh
+++ b/tests/queries/0_stateless/01459_manual_write_to_replicas_quorum_detach_attach.sh
@@ -13,8 +13,15 @@ NUM_REPLICAS=6
 for i in $(seq 1 $NUM_REPLICAS); do
     $CLICKHOUSE_CLIENT -q "
         DROP TABLE IF EXISTS r$i SYNC;
-        CREATE TABLE r$i (x UInt64) ENGINE = ReplicatedMergeTree('/clickhouse/tables/$CLICKHOUSE_TEST_ZOOKEEPER_PREFIX/r', 'r$i') ORDER BY x;
+        CREATE TABLE r$i (x UInt64) ENGINE = ReplicatedMergeTree('/clickhouse/tables/$CLICKHOUSE_TEST_ZOOKEEPER_PREFIX/r', 'r$i') ORDER BY x
+            SETTINGS replicated_max_ratio_of_wrong_parts = 1;
     "
+    # Note about `replicated_max_ratio_of_wrong_parts`:
+    # when there is "quorum for ... is already started" error, which happens in repeated concurrent inserts of the same data,
+    # the transaction is rolled back, but the data part from filesystem is deleted lazily (in the background thread),
+    # and if the table is restarted, it will see an unexpected part at startup, which is in the filesystem,
+    # but isn't present in Keeper. While this is a potential usability flaw and a source of questions,
+    # for the purpose of this test, we consider it normal.
 done
 
 valid_exceptions_to_retry='Quorum for previous write has not been satisfied yet|Another quorum insert has been already started|Unexpected logical error while adding block'


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


See https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=93867&sha=cc9e6188fdeab3d7d1cd4a27b7507711feb83a6b&name_0=PR&name_1=Stateless%20tests%20%28arm_asan%2C%20targeted%29&name_1=Stateless%20tests%20%28arm_asan%2C%20targeted%29
https://github.com/ClickHouse/ClickHouse/pull/93867

Closes #93010

Explanation: https://pastila.nl/?0000dbbc/b247254d00517285f1ce38b98fc581bb#a2vtSDRjF4DiP/Th2RYWDw==GCM


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.426`
<!-- ch-version-info:end -->