### PR TITLE
Clarify and enforce empty-state contract in `groupConcat` deserialize

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionGroupConcat.cpp
+++ b/src/AggregateFunctions/AggregateFunctionGroupConcat.cpp
@@ -162,17 +162,17 @@ void GroupConcatImpl<has_limit>::deserialize(AggregateDataPtr __restrict place, 
 {
     auto & cur_data = this->data(place);
 
-    UInt64 temp_size = 0;
-    readVarUInt(temp_size, buf);
-
-    cur_data.checkAndUpdateSize(temp_size, arena);
-
     /// IAggregateFunction::deserialize() must be called only for an empty (just created) state.
     if (cur_data.data_size != 0)
         throw Exception(
             ErrorCodes::LOGICAL_ERROR,
             "groupConcat deserialize() expects an empty state (data_size = 0), got data_size = {}",
             cur_data.data_size);
+
+    UInt64 temp_size = 0;
+    readVarUInt(temp_size, buf);
+
+    cur_data.checkAndUpdateSize(temp_size, arena);
 
     buf.readStrict(cur_data.data, temp_size);
     cur_data.data_size = temp_size;


### PR DESCRIPTION
IAggregateFunction::deserialize() must be called only for an empty (just created) state.

- Added comment and guard to enforce empty-state usage
- Added LOGICAL_ERROR if called on non-empty state

This makes the intended usage of deserialize() explicit.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.447`
<!-- ch-version-info:end -->