### PR TITLE
Added dedicated user for background operations

### DIFF
--- a/docs/en/operations/settings/overview.md
+++ b/docs/en/operations/settings/overview.md
@@ -16,14 +16,14 @@ supported for ClickHouse Cloud. To specify settings for your ClickHouse Cloud
 service, you must use [SQL-driven Settings Profiles](/operations/access-rights#settings-profiles-management).
 :::
 
-There are two main groups of ClickHouse settings:
+There are following main groups of ClickHouse settings:
 
 - Global server settings
 - Session settings
+- Query settings
+- Background operations settings
 
-The main distinction between both is that global server settings apply globally 
-for the ClickHouse server, while session settings apply to user sessions or even
-individual queries.
+Global settings apply by default unless overridden at further levels. Session settings can be specified via profiles, user configuration and SET commands. Query settings can be provided via SETTINGS clause and are applied to individual queries. Background operations settings are applied to Mutations, Merges and potentially other operations, executed asynchronously in the background.
 
 ## Viewing non-default settings {#see-non-default-settings}
 
@@ -60,3 +60,4 @@ Which will return something like this:
   ClickHouse server at the global server level.
 - See [session settings](/operations/settings/settings-query-level.md) to learn more about configuring your ClickHouse 
   server at the session level.
+- See [context hierarchy](/development/architecture.md#context) to learn more about configuration processing by Clickhouse.

--- a/docs/en/operations/settings/settings-profiles.md
+++ b/docs/en/operations/settings/settings-profiles.md
@@ -42,6 +42,12 @@ Example:
         <max_threads>8</max_threads>
     </default>
 
+    <!-- Background operations settings -->
+    <background>
+        <!-- Re-defining maximum number of threads for background operations -->
+        <max_threads>12</max_threads>
+    </background>
+
     <!-- Settings for queries from the user interface -->
     <web>
         <max_rows_to_read>1000000000</max_rows_to_read>
@@ -79,6 +85,8 @@ Example:
 
 The example specifies two profiles: `default` and `web`.
 
-The `default` profile has a special purpose: it must always be present and is applied when starting the server. In other words, the `default` profile contains default settings.
+The `default` profile has a special purpose: it must always be present and is applied when starting the server. In other words, the `default` profile contains default settings. The name of the default profile can be changed via `default_profile` server setting.
+
+The `background` profile has a special purpose: it might be present to override settings for background operations. The parameter is optional and its name can be changed via `background_profile` server setting.
 
 The `web` profile is a regular profile that can be set using the `SET` query or using a URL parameter in an HTTP query.

--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -871,6 +871,11 @@
     <!-- System profile of settings. This settings are used by internal processes (Distributed DDL worker and so on). -->
     <!-- <system_profile>default</system_profile> -->
 
+    <!-- Background profile of settings. This profile is used by background operations (e.g. Merge, Mutate). 
+         Default profile name is 'background', which can be changed via the following setting. If such profile is not configured, system_profile is used.
+    -->
+    <!-- <background_profile>background</background_profile> -->
+
     <!-- Buffer profile of settings.
          This settings are used by Buffer storage to flush data to the underlying table.
          Default: used from system_profile directive.

--- a/programs/server/config.yaml.example
+++ b/programs/server/config.yaml.example
@@ -469,6 +469,10 @@ default_profile: default
 # System profile of settings. This settings are used by internal processes (Distributed DDL worker and so on).
 # system_profile: default
 
+# Background profile of settings. This profile is used by background operations (e.g. Merge, Mutate).
+# Default profile name is 'background', which can be changed via the following setting. If such profile is not configured, system_profile is used.
+# background_profile: background
+
 # Buffer profile of settings.
 # This settings are used by Buffer storage to flush data to the underlying table.
 # Default: used from system_profile directive.

--- a/programs/server/users.xml
+++ b/programs/server/users.xml
@@ -8,6 +8,10 @@
             <!-- <async_insert>1</async_insert> -->
         </default>
 
+        <!-- Settings for background operations (e.g. Merge, Mutate) -->
+        <!-- <background> -->
+        <!-- </background> -->
+
         <!-- Profile that allows only read queries. -->
         <readonly>
             <readonly>1</readonly>

--- a/programs/server/users.yaml.example
+++ b/programs/server/users.yaml.example
@@ -14,7 +14,10 @@ profiles:
         # first_or_random - if first replica one has higher number of errors, pick a random one from replicas with minimum number of errors.
         load_balancing: random
 
-        # Profile that allows only read queries.
+    # Settings for background operations (e.g. Merge, Mutate)
+    #background:
+
+    # Profile that allows only read queries.
     readonly:
         readonly: 1
 

--- a/src/Disks/DiskObjectStorage/ObjectStorages/S3/S3ObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/S3/S3ObjectStorage.cpp
@@ -235,7 +235,7 @@ std::unique_ptr<WriteBufferFromFileBase> S3ObjectStorage::writeObject( /// NOLIN
     /// default user's .xml config. It's obscure and unclear behavior. For them it's always better
     /// to rely on settings from disk.
     if (auto query_context = CurrentThread::getQueryContext();
-        query_context && !query_context->isBackgroundOperationContext())
+        query_context && !query_context->isBackgroundContext())
     {
         const auto & settings = query_context->getSettingsRef();
         request_settings.updateFromSettings(settings, /* if_changed */ true, settings[Setting::s3_validate_request_settings]);

--- a/src/Interpreters/ClientInfo.h
+++ b/src/Interpreters/ClientInfo.h
@@ -138,16 +138,6 @@ public:
     UInt64 obsolete_count_participating_replicas{0};
     UInt64 number_of_current_replica{0};
 
-    enum class BackgroundOperationType : uint8_t
-    {
-        NOT_A_BACKGROUND_OPERATION = 0,
-        MERGE = 1,
-        MUTATION = 2,
-    };
-
-    /// It's ClientInfo and context created for background operation (not real query)
-    BackgroundOperationType background_operation_type{BackgroundOperationType::NOT_A_BACKGROUND_OPERATION};
-
     bool empty() const { return query_kind == QueryKind::NO_QUERY; }
 
     /** Serialization and deserialization.

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -1175,7 +1175,6 @@ ContextData::ContextData(const ContextData &o) :
     session_context(o.session_context),
     global_context(o.global_context),
     background_context(o.background_context),
-    // parent_context(o.parent_context),
     buffer_context(o.buffer_context),
     is_internal_query(o.is_internal_query),
     is_background_operation(o.is_background_operation),

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -6266,9 +6266,6 @@ void Context::setDefaultProfiles(const Poco::Util::AbstractConfiguration & confi
     applySettingsQuirks(*settings, getLogger("SettingsQuirks"));
     doSettingsSanityCheckClamp(*settings, getLogger("SettingsSanity"));
 
-    static constexpr std::string background_profile_name_setting = "background_profile";
-    static constexpr std::string background_profile_default_name = "background";
-
     makeBackgroundContext(config);
 
     shared->buffer_profile_name = config.getString("buffer_profile", shared->system_profile_name);

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -3160,18 +3160,6 @@ void Context::setCurrentQueryId(const String & query_id)
         client_info.initial_query_id = client_info.current_query_id;
 }
 
-// TODO: CHECK HERE
-void Context::setBackgroundOperationTypeForContext(ClientInfo::BackgroundOperationType background_operation)
-{
-    chassert(background_operation != ClientInfo::BackgroundOperationType::NOT_A_BACKGROUND_OPERATION);
-    client_info.background_operation_type = background_operation;
-}
-
-bool Context::isBackgroundOperationContext() const
-{
-    return client_info.background_operation_type != ClientInfo::BackgroundOperationType::NOT_A_BACKGROUND_OPERATION;
-}
-
 void Context::killCurrentQuery() const
 {
     if (auto elem = getProcessListElement())

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -3,6 +3,7 @@
 #include <optional>
 #include <memory>
 #include <Poco/UUID.h>
+#include <Poco/Util/AbstractConfiguration.h>
 #include <Poco/Util/Application.h>
 #include <Common/quoteString.h>
 #include <Common/setThreadName.h>
@@ -32,6 +33,7 @@
 #include <Formats/FormatFactory.h>
 #include <Databases/DatabaseReplicatedSettings.h>
 #include <Databases/IDatabase.h>
+#include <Interpreters/Context_fwd.h>
 #include <Server/ServerType.h>
 #include <Storages/MarkCache.h>
 #include <Storages/MergeTree/MergeList.h>
@@ -497,6 +499,7 @@ struct ContextSharedPart : boost::noncopyable
     /// No lock required for default_profile_name, system_profile_name, buffer_profile_name modified only during initialization
     String default_profile_name;                                /// Default profile name used for default values.
     String system_profile_name;                                 /// Profile used by system processes
+    String background_profile_name;                             /// Profile used by background operations
     String buffer_profile_name;                                 /// Profile used by Buffer engine for flushing to the underlying
     String merge_workload TSA_GUARDED_BY(mutex);                /// Workload setting value that is used by all merges
     String mutation_workload TSA_GUARDED_BY(mutex);             /// Workload setting value that is used by all mutations
@@ -1171,8 +1174,11 @@ ContextData::ContextData(const ContextData &o) :
     query_context(o.query_context),
     session_context(o.session_context),
     global_context(o.global_context),
+    background_context(o.background_context),
+    // parent_context(o.parent_context),
     buffer_context(o.buffer_context),
     is_internal_query(o.is_internal_query),
+    is_background_operation(o.is_background_operation),
     temp_data_on_disk(o.temp_data_on_disk),
     classifier(o.classifier),
     prepared_sets_cache(o.prepared_sets_cache),
@@ -3154,6 +3160,7 @@ void Context::setCurrentQueryId(const String & query_id)
         client_info.initial_query_id = client_info.current_query_id;
 }
 
+// TODO: CHECK HERE
 void Context::setBackgroundOperationTypeForContext(ClientInfo::BackgroundOperationType background_operation)
 {
     chassert(background_operation != ClientInfo::BackgroundOperationType::NOT_A_BACKGROUND_OPERATION);
@@ -3227,8 +3234,7 @@ void Context::setMacros(std::unique_ptr<Macros> && macros)
 ContextMutablePtr Context::getQueryContext() const
 {
     auto ptr = query_context.lock();
-    if (!ptr)
-        throw Exception(ErrorCodes::THERE_IS_NO_QUERY, "There is no query or query context has expired");
+    if (!ptr) throw Exception(ErrorCodes::THERE_IS_NO_QUERY, "There is no query or query context has expired");
     return ptr;
 }
 
@@ -3249,6 +3255,14 @@ ContextMutablePtr Context::getGlobalContext() const
 {
     auto ptr = global_context.lock();
     if (!ptr) throw Exception(ErrorCodes::LOGICAL_ERROR, "There is no global context or global context has expired");
+    return ptr;
+}
+
+ContextMutablePtr Context::getBackgroundContext() const
+{
+    auto ptr = background_context.lock();
+    if (!ptr)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "There is no background context or background context has not been initialized");
     return ptr;
 }
 
@@ -3311,6 +3325,30 @@ void Context::makeGlobalContext()
     EventNotifier::init();
 
     global_context = shared_from_this();
+}
+
+void Context::makeBackgroundContext(const Poco::Util::AbstractConfiguration & config)
+{
+    assert(!background_context_instance);
+    static constexpr std::string background_profile_name_setting = "background_profile";
+    static constexpr std::string background_profile_default_name = "background";
+
+    if (config.has(background_profile_name_setting))
+        /// 1. if background profile name setting is set explicitly - it'll be used, and will throw on lacking profile configuration
+        shared->background_profile_name = config.getString(background_profile_name_setting);
+    else if (getAccessControl().find<SettingsProfile>(background_profile_default_name).has_value())
+        /// 2. or if background profile is configured under its default name - it'll be used
+        shared->background_profile_name = background_profile_default_name;
+    else
+        /// 3. otherwise the system profile will be used for background operations
+        shared->background_profile_name = shared->system_profile_name;
+
+    ContextMutablePtr background_context_ptr = Context::createCopy(shared_from_this());
+    background_context_ptr->setCurrentProfile(shared->background_profile_name);
+    background_context_ptr->is_background_operation = true;
+
+    background_context_instance = background_context_ptr;
+    background_context = background_context_ptr;
 }
 
 const EmbeddedDictionaries & Context::getEmbeddedDictionaries() const
@@ -6239,6 +6277,11 @@ void Context::setDefaultProfiles(const Poco::Util::AbstractConfiguration & confi
 
     applySettingsQuirks(*settings, getLogger("SettingsQuirks"));
     doSettingsSanityCheckClamp(*settings, getLogger("SettingsSanity"));
+
+    static constexpr std::string background_profile_name_setting = "background_profile";
+    static constexpr std::string background_profile_default_name = "background";
+
+    makeBackgroundContext(config);
 
     shared->buffer_profile_name = config.getString("buffer_profile", shared->system_profile_name);
     buffer_context = Context::createCopy(shared_from_this());

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -547,7 +547,7 @@ protected:
     bool is_background_operation = false;
 
     inline static ContextPtr global_context_instance;
-    inline static ContextPtr background_context_instance;   /// Background context is a global concept (kinda singletone for now), and this is a actual place to own it.
+    inline static ContextPtr background_context_instance;   /// Global holder to maintain ownership of background_context
 
     /// Temporary data for query execution accounting.
     TemporaryDataOnDiskScopePtr temp_data_on_disk;

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -999,12 +999,6 @@ public:
     void setCurrentDatabaseNameInGlobalContext(const String & name);
     void setCurrentQueryId(const String & query_id);
 
-    /// FIXME: for background operations (like Merge and Mutation) we also use the same Context object and even setup
-    /// query_id for it (table_uuid::result_part_name). We can distinguish queries from background operation in some way like
-    /// bool is_background = query_id.contains("::"), but it's much worse than just enum check with more clear purpose
-    void setBackgroundOperationTypeForContext(ClientInfo::BackgroundOperationType setBackgroundOperationTypeForContextbackground_operation);
-    bool isBackgroundOperationContext() const;
-
     void killCurrentQuery() const;
     bool isCurrentQueryKilled() const;
 
@@ -1179,7 +1173,6 @@ public:
         return ptr && ptr.get() == this;
     }
 
-    /// TODO: has* and is* are not actually needed - remove
     bool hasBackgroundContext() const { return !background_context.expired(); }
     bool isBackgroundContext() const
     {

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -27,6 +27,7 @@
 #include <Backups/BackupsInMemoryHolder.h>
 
 #include <Poco/AutoPtr.h>
+#include <Poco/Util/AbstractConfiguration.h>
 
 #include "config.h"
 
@@ -533,16 +534,20 @@ protected:
     mutable std::mutex table_function_results_mutex;
 
     ContextWeakMutablePtr query_context;
-    ContextWeakMutablePtr session_context;  /// Session context or nullptr. Could be equal to this.
-    ContextWeakMutablePtr global_context;   /// Global context. Could be equal to this.
+    ContextWeakMutablePtr session_context;      /// Session context or nullptr. Could be equal to this.
+    ContextWeakMutablePtr global_context;       /// Global context. Could be equal to this.
+    ContextWeakMutablePtr background_context;   /// Context of background operations or a copy of global context. Could be equal to this.
 
     /// XXX: move this stuff to shared part instead.
     ContextMutablePtr buffer_context;  /// Buffer context. Could be equal to this.
 
     /// A flag, used to distinguish between user query and internal query to a database engine (MaterializedPostgreSQL).
     bool is_internal_query = false;
+    /// A flag, used to detect sub-operations of background operations - in this case we won't need to build another background contexts
+    bool is_background_operation = false;
 
     inline static ContextPtr global_context_instance;
+    inline static ContextPtr background_context_instance;   /// Background context is a global concept (kinda singletone for now), and this is a actual place to own it.
 
     /// Temporary data for query execution accounting.
     TemporaryDataOnDiskScopePtr temp_data_on_disk;
@@ -1174,6 +1179,14 @@ public:
         return ptr && ptr.get() == this;
     }
 
+    /// TODO: has* and is* are not actually needed - remove
+    bool hasBackgroundContext() const { return !background_context.expired(); }
+    bool isBackgroundContext() const
+    {
+        return is_background_operation;
+    }
+    ContextMutablePtr getBackgroundContext() const;
+
     ContextMutablePtr getBufferContext() const;
 
     void setQueryContext(ContextMutablePtr context_) { query_context = context_; }
@@ -1184,6 +1197,7 @@ public:
     void makeQueryContextForMutate(const MergeTreeSettings & merge_tree_settings);
     void makeSessionContext();
     void makeGlobalContext();
+    void makeBackgroundContext(const Poco::Util::AbstractConfiguration & config);
 
     void setProgressCallback(ProgressCallback callback);
     /// Used in executeQuery() to pass it to the QueryPipeline.

--- a/src/Storages/MergeTree/MergeFromLogEntryTask.cpp
+++ b/src/Storages/MergeTree/MergeFromLogEntryTask.cpp
@@ -344,10 +344,9 @@ ReplicatedMergeMutateTaskBase::PrepareResult MergeFromLogEntryTask::prepare()
 
     auto table_id = storage.getStorageID();
 
-    task_context = Context::createCopy(storage.getContext());
+    task_context = Context::createCopy(storage.getContext()->getBackgroundContext());
     task_context->makeQueryContextForMerge(*storage.getSettings());
     task_context->setCurrentQueryId(getQueryId());
-    task_context->setBackgroundOperationTypeForContext(ClientInfo::BackgroundOperationType::MERGE);
 
     /// Add merge to list
     merge_mutate_entry = storage.getContext()->getMergeList().insert(

--- a/src/Storages/MergeTree/MergePlainMergeTreeTask.cpp
+++ b/src/Storages/MergeTree/MergePlainMergeTreeTask.cpp
@@ -204,11 +204,10 @@ void MergePlainMergeTreeTask::cancel() noexcept
 
 ContextMutablePtr MergePlainMergeTreeTask::createTaskContext() const
 {
-    auto context = Context::createCopy(storage.getContext());
+    auto context = Context::createCopy(storage.getContext()->getBackgroundContext());
     context->makeQueryContextForMerge(*storage.getSettings());
     auto query_id = getQueryId();
     context->setCurrentQueryId(query_id);
-    context->setBackgroundOperationTypeForContext(ClientInfo::BackgroundOperationType::MERGE);
     return context;
 }
 

--- a/src/Storages/MergeTree/MutateFromLogEntryTask.cpp
+++ b/src/Storages/MergeTree/MutateFromLogEntryTask.cpp
@@ -211,10 +211,9 @@ ReplicatedMergeMutateTaskBase::PrepareResult MutateFromLogEntryTask::prepare()
         }
     }
 
-    task_context = Context::createCopy(storage.getContext());
+    task_context = Context::createCopy(storage.getContext()->getBackgroundContext());
     task_context->makeQueryContextForMutate(*storage.getSettings());
     task_context->setCurrentQueryId(getQueryId());
-    task_context->setBackgroundOperationTypeForContext(ClientInfo::BackgroundOperationType::MUTATION);
 
     merge_mutate_entry = storage.getContext()->getMergeList().insert(
         storage.getStorageID(),

--- a/src/Storages/MergeTree/MutatePlainMergeTreeTask.cpp
+++ b/src/Storages/MergeTree/MutatePlainMergeTreeTask.cpp
@@ -176,11 +176,10 @@ void MutatePlainMergeTreeTask::cancel() noexcept
 
 ContextMutablePtr MutatePlainMergeTreeTask::createTaskContext() const
 {
-    auto context = Context::createCopy(storage.getContext());
+    auto context = Context::createCopy(storage.getContext()->getBackgroundContext());
     context->makeQueryContextForMutate(*storage.getSettings());
     auto queryId = getQueryId();
     context->setCurrentQueryId(queryId);
-    context->setBackgroundOperationTypeForContext(ClientInfo::BackgroundOperationType::MUTATION);
     return context;
 }
 

--- a/tests/integration/test_background_operations_config/configs/background_profile.xml
+++ b/tests/integration/test_background_operations_config/configs/background_profile.xml
@@ -1,0 +1,7 @@
+<clickhouse>
+  <profiles>
+    <background>
+      <function_sleep_max_microseconds_per_block>5000000</function_sleep_max_microseconds_per_block>
+    </background>
+  </profiles>
+</clickhouse>

--- a/tests/integration/test_background_operations_config/configs/custom_server_config.xml
+++ b/tests/integration/test_background_operations_config/configs/custom_server_config.xml
@@ -1,0 +1,3 @@
+<clickhouse>
+  <background_profile>custom</background_profile>
+</clickhouse>

--- a/tests/integration/test_background_operations_config/configs/tightened_background_profile.xml
+++ b/tests/integration/test_background_operations_config/configs/tightened_background_profile.xml
@@ -1,0 +1,10 @@
+<clickhouse>
+  <profiles>
+    <default>
+      <function_sleep_max_microseconds_per_block>300000</function_sleep_max_microseconds_per_block>
+    </default>
+    <background>
+      <function_sleep_max_microseconds_per_block>500000</function_sleep_max_microseconds_per_block>
+    </background>
+  </profiles>
+</clickhouse>

--- a/tests/integration/test_background_operations_config/configs/tightened_custom_profile.xml
+++ b/tests/integration/test_background_operations_config/configs/tightened_custom_profile.xml
@@ -1,0 +1,10 @@
+<clickhouse>
+  <profiles>
+    <default>
+      <function_sleep_max_microseconds_per_block>300000</function_sleep_max_microseconds_per_block>
+    </default>
+    <custom>
+      <function_sleep_max_microseconds_per_block>500000</function_sleep_max_microseconds_per_block>
+    </custom>
+  </profiles>
+</clickhouse>

--- a/tests/integration/test_background_operations_config/configs/tightened_default_profile.xml
+++ b/tests/integration/test_background_operations_config/configs/tightened_default_profile.xml
@@ -1,0 +1,7 @@
+<clickhouse>
+  <profiles>
+    <default>
+      <function_sleep_max_microseconds_per_block>300000</function_sleep_max_microseconds_per_block>
+    </default>
+  </profiles>
+</clickhouse>

--- a/tests/integration/test_background_operations_config/test.py
+++ b/tests/integration/test_background_operations_config/test.py
@@ -1,0 +1,97 @@
+import pytest
+from helpers.client import QueryRuntimeException
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+
+# This test validates that background operations can use a dedicated 'background' user profile when it's configured.
+# The feature and behavior is described at #93905
+# We leverage 'sleepEachRow' for mutate queries to trigger operation timeout:
+# - in cases where 'default' is used - mutations are expected to fail
+# - in cases where the new 'background' profile is used - mutations will succeed, as the timeout will be increased
+
+# We spin up a node with unique configuration for each scnenario to be checked
+# 1. [EXPECTED FAILURE] Default configuration only, operation timeout is 3s and implicitly applied via 'default' profile
+node1 = cluster.add_instance("node1")
+# 2. [EXPECTED SUCCESS] 'background' profile sets timeout to 5s and mutations are using it
+node2 = cluster.add_instance("node2", user_configs=['configs/background_profile.xml'])
+# 3. [EXPECTED FAILURE] Default configuration only, operation timeout is set to 0.3s and we check that mutation are using it via 'default' profile
+node3 = cluster.add_instance("node3", user_configs=['configs/tightened_default_profile.xml'])
+# 4. [EXPECTED SUCCESS] 'background' profile sets timeout to 0.5s and mutations are using it
+node4 = cluster.add_instance("node4", user_configs=["configs/tightened_background_profile.xml"])
+# 5. [EXPECTED SUCCESS] 'custom' profile is set to be used by background operations, it sets timeout to 0.5s and mutations are using it
+node5 = cluster.add_instance(
+    "node5",
+    main_configs=["configs/custom_server_config.xml"],
+    user_configs=["configs/tightened_custom_profile.xml"]
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def started_cluster():
+  try:
+      cluster.start()
+      yield cluster
+  finally:
+      cluster.shutdown()
+
+def get_table_name(instance):
+    table_name = "test_table"
+    return f"{table_name}_{instance.name}"
+
+
+def prepare_data(instance):
+  table_name = get_table_name(instance)
+
+  instance.query(f"DROP TABLE IF EXISTS {table_name} SYNC")
+
+  instance.query(f"""
+    CREATE TABLE IF NOT EXISTS {table_name} (
+      v1 UInt16
+    ) ENGINE = MergeTree()
+  """)
+
+  instance.query(f"INSERT INTO {table_name} VALUES (1), (2), (3), (4)")
+
+def mutate_blocking(instance, sleep_sec_per_row):
+  query = f"""
+    ALTER TABLE {get_table_name(instance)} UPDATE v1 = (v1 + 1)
+    WHERE sleepEachRow({sleep_sec_per_row})==0
+    SETTINGS mutations_sync=1
+  """
+  instance.query(query)
+
+def validate_failure(query):
+  with pytest.raises(QueryRuntimeException):
+    query()
+
+def validate_success(query):
+  query()
+
+
+def test_excpected_failure_with_default_profile(started_cluster):
+  # this case is kinda redundant, it's destined to fire if the default for <function_sleep_max_microseconds_per_block> ever changes
+  # and we'll have to adjust timeout expectations for this test
+  prepare_data(instance=node1)
+  validate_failure(lambda: mutate_blocking(instance=node1, sleep_sec_per_row=1))
+  print(f"Check 1: background operation failed as expected with all defaults")
+
+def test_background_profile_configured_with_all_defaults(started_cluster):
+  prepare_data(instance=node2)
+  validate_success(lambda: mutate_blocking(instance=node2, sleep_sec_per_row=1))
+  print(f"Check 2: background operation succeeds with 'background' profile minimally configured")
+
+def test_excpected_failure_with_tightened_default_profile(started_cluster):
+  prepare_data(instance=node3)
+  validate_failure(lambda: mutate_blocking(instance=node3, sleep_sec_per_row=0.1))
+  print(f"Check 3: background operation failed as expected with a tighter query timeout")
+
+def test_background_profile_configured(started_cluster):
+  prepare_data(instance=node4)
+  validate_success(lambda: mutate_blocking(instance=node4, sleep_sec_per_row=0.1))
+  print(f"Check 4: background operation succeeds with 'background' profile configured")
+
+def test_custom_background_profile_configured(started_cluster):
+  prepare_data(instance=node5)
+  validate_success(lambda: mutate_blocking(instance=node5, sleep_sec_per_row=0.1))
+  print(f"Check 5: background operation succeeds with a custom background profile configured")


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Background operations (Mutate, Merge) can now be configured independently via 'background' profile. Previously such operations shared settings with regular queries via 'default' profile. 

Closes #91845
Reverts #64456 as no longer needed.

### Documentation entry for user-facing changes
- [x] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.67`
<!-- ch-version-info:end -->