### PR TITLE
Fix system.zookeeper_info

### DIFF
--- a/programs/keeper-utils/KeeperUtils.cpp
+++ b/programs/keeper-utils/KeeperUtils.cpp
@@ -58,7 +58,7 @@ uint64_t getSnapshotPathUpToLogIdx(const String & snapshot_path)
 {
     std::filesystem::path path(snapshot_path);
     std::string filename = path.stem();
-    Strings name_parts;
+    std::vector<std::string_view> name_parts;
     splitInto<'_', '.'>(name_parts, filename);
     return parse<uint64_t>(name_parts[1]);
 }

--- a/src/Common/NamedCollections/NamedCollections.cpp
+++ b/src/Common/NamedCollections/NamedCollections.cpp
@@ -142,10 +142,10 @@ public:
         ///     key3:
         ///        key4: value3"
         WriteBufferFromOwnString wb;
-        Strings prev_key_parts;
+        std::vector<std::string_view> prev_key_parts;
         for (const auto & key : keys)
         {
-            Strings key_parts;
+            std::vector<std::string_view> key_parts;
             splitInto<'.'>(key_parts, key);
             size_t tab_cnt = 0;
 

--- a/src/Coordination/FourLetterCommand.cpp
+++ b/src/Coordination/FourLetterCommand.cpp
@@ -80,7 +80,8 @@ String IFourLetterCommand::toName(int32_t code)
 
 int32_t IFourLetterCommand::toCode(std::string_view name)
 {
-    int32_t res = *reinterpret_cast<const int32_t *>(name.data());
+    int32_t res = 0;
+    std::memcpy(&res, name.data(), sizeof(int32_t));
     /// keep consistent with Coordination::read method by changing big endian to little endian.
     return std::byteswap(res);
 }

--- a/src/Coordination/FourLetterCommand.cpp
+++ b/src/Coordination/FourLetterCommand.cpp
@@ -78,7 +78,7 @@ String IFourLetterCommand::toName(int32_t code)
     return String(reinterpret_cast<char *>(&reverted_code), 4);
 }
 
-int32_t IFourLetterCommand::toCode(const String & name)
+int32_t IFourLetterCommand::toCode(std::string_view name)
 {
     int32_t res = *reinterpret_cast<const int32_t *>(name.data());
     /// keep consistent with Coordination::read method by changing big endian to little endian.
@@ -245,12 +245,12 @@ bool FourLetterCommandFactory::supportArguments(int32_t code) const
 void FourLetterCommandFactory::initializeAllowList(KeeperDispatcher & keeper_dispatcher)
 {
     const auto & keeper_settings = keeper_dispatcher.getKeeperConfigurationAndSettings();
-
+    auto log = getLogger("FourLetterCommandFactory");
     String list_str = keeper_settings->four_letter_word_allow_list;
-    Strings tokens;
+    std::vector<std::string_view> tokens;
     splitInto<','>(tokens, list_str);
 
-    for (String token: tokens)
+    for (auto token : tokens)
     {
         trim(token);
 
@@ -261,15 +261,10 @@ void FourLetterCommandFactory::initializeAllowList(KeeperDispatcher & keeper_dis
             return;
         }
 
-        if (commands.contains(IFourLetterCommand::toCode(token)))
-        {
-            allow_list.push_back(IFourLetterCommand::toCode(token));
-        }
+        if (auto code = IFourLetterCommand::toCode(token); commands.contains(code))
+            allow_list.push_back(code);
         else
-        {
-            auto log = getLogger("FourLetterCommandFactory");
             LOG_WARNING(log, "Find invalid keeper 4lw command {} when initializing, ignore it.", token);
-        }
     }
 }
 

--- a/src/Coordination/FourLetterCommand.h
+++ b/src/Coordination/FourLetterCommand.h
@@ -34,7 +34,7 @@ public:
     int32_t code();
 
     static String toName(int32_t code);
-    static int32_t toCode(const String & name);
+    static int32_t toCode(std::string_view name);
 
 protected:
     KeeperDispatcher & keeper_dispatcher;

--- a/src/Coordination/KeeperSnapshotManager.cpp
+++ b/src/Coordination/KeeperSnapshotManager.cpp
@@ -62,7 +62,7 @@ namespace
     {
         std::filesystem::path path(snapshot_path);
         std::string filename = path.stem();
-        Strings name_parts;
+        std::vector<std::string_view> name_parts;
         splitInto<'_', '.'>(name_parts, filename);
         return parse<uint64_t>(name_parts[1]);
     }

--- a/src/Databases/DataLake/RestCatalog.cpp
+++ b/src/Databases/DataLake/RestCatalog.cpp
@@ -444,7 +444,7 @@ void RestCatalog::getNamespacesRecursive(
 
 Poco::URI::QueryParameters RestCatalog::createParentNamespaceParams(const std::string & base_namespace) const
 {
-    std::vector<std::string> parts;
+    std::vector<std::string_view> parts;
     splitInto<'.'>(parts, base_namespace);
     std::string parent_param;
     for (const auto & part : parts)

--- a/src/IO/ReadHelpers.cpp
+++ b/src/IO/ReadHelpers.cpp
@@ -91,7 +91,7 @@ void NO_INLINE throwAtAssertionFailed(const char * s, ReadBuffer & buf)
     if (buf.eof())
         out << " at end of stream.";
     else
-        out << " before: " << quote << String(buf.position(), std::min(SHOW_CHARS_ON_SYNTAX_ERROR, buf.buffer().end() - buf.position()));
+        out << " before: " << quote << std::string_view(buf.position(), std::min(SHOW_CHARS_ON_SYNTAX_ERROR, buf.buffer().end() - buf.position()));
 
     throw Exception(ErrorCodes::CANNOT_PARSE_INPUT_ASSERTION_FAILED, "Cannot parse input: expected {}", out.str());
 }

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -2557,8 +2557,8 @@ StoragePtr Context::executeTableFunction(const ASTPtr & table_expression, const 
 
         if (parts.size() == 2)
         {
-            database_name = parts[0];
-            table_name = parts[1];
+            database_name = std::move(parts[0]);
+            table_name = std::move(parts[1]);
         }
     }
 

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
@@ -623,7 +623,7 @@ namespace
             return buf.str();
         }
 
-        static Info deserialize(const std::string & str)
+        static Info deserialize(std::string_view str)
         {
             ReadBufferFromString buf(str);
             Info info;
@@ -684,7 +684,7 @@ void ObjectStorageQueueMetadata::registerNonActive(const StorageID & storage_id,
             bool registry_exists = zk_client->tryGet(registry_path, registry_str, &stat);
             if (registry_exists)
             {
-                Strings registered;
+                std::vector<std::string_view> registered;
                 splitInto<','>(registered, registry_str);
 
                 if (zk_retries.isRetry() && registered.size() == 1 && (Info::deserialize(registered[0]) == self))
@@ -697,7 +697,7 @@ void ObjectStorageQueueMetadata::registerNonActive(const StorageID & storage_id,
 
                 created_new_metadata = false;
 
-                for (const auto & elem : registered)
+                for (auto elem : registered)
                 {
                     if (elem.empty())
                         continue;
@@ -840,7 +840,7 @@ void ObjectStorageQueueMetadata::unregisterNonActive(const StorageID & storage_i
                 return;
             }
 
-            Strings registered;
+            std::vector<std::string_view> registered;
             splitInto<','>(registered, registry_str);
 
             bool found = false;

--- a/src/Storages/System/StorageSystemZooKeeperInfo.cpp
+++ b/src/Storages/System/StorageSystemZooKeeperInfo.cpp
@@ -111,19 +111,19 @@ ColumnsDescription StorageSystemZooKeeperInfo::getColumnsDescription()
     };
 }
 
-static std::map<String,String> getTokens(String response, char separator)
+static std::map<std::string_view, std::string_view> getTokens(std::string_view response, std::string_view separator)
 {
-    std::vector<String> result_split;
+    std::vector<std::string_view> result_split;
     splitInto<'\n'>(result_split, response);
 
-    std::map<String,String> responses_map;
-    for (auto & line : result_split)
+    std::map<std::string_view, std::string_view> responses_map;
+    for (auto line : result_split)
     {
         auto pos = line.rfind(separator);
-        if (pos != std::string::npos)
+        if (pos != std::string_view::npos)
         {
-            String key = line.substr(0, pos - 1);
-            String value = line.substr(pos + 1);
+            std::string_view key = line.substr(0, pos);
+            std::string_view value = line.substr(pos + separator.size());
             responses_map[key] = value;
         }
     }
@@ -146,290 +146,280 @@ void StorageSystemZooKeeperInfo::fillData(MutableColumns & res_columns, ContextP
         for (unsigned int index = 0;index < zk_args.hosts.size();++index)
         {
             const auto & host_port = zk_args.hosts[index];
-            if (!host_port.empty())
+            if (host_port.empty())
+                continue;
+
+            size_t offset = host_port.find_last_of(':');
+            String host = host_port.substr(0, offset);
+            String port_string = host_port.substr(offset + 1);
+            UInt16 port = static_cast<UInt16>(Poco::NumberParser::parseUnsigned(port_string));
+
+            res_columns[0]->insert(elem.first);
+            res_columns[1]->insert(host);
+            res_columns[2]->insert(port);
+            res_columns[3]->insert(index);
+
+            /// ruok command
+            auto ruok_output = sendFourLetterCommand(host, port, "ruok");
+            if (ruok_output.has_value())
             {
-                size_t offset = host_port.find_last_of(':');
-                String host = host_port.substr(0, offset);
-                String port_string = host_port.substr(offset + 1);
-                UInt16 port = static_cast<UInt16>(Poco::NumberParser::parseUnsigned(port_string));
+                if (ruok_output.value() == "imok")
+                    res_columns[4]->insert(true);
+                else
+                    res_columns[4]->insert(false);
+            }
+            else
+                res_columns[4]->insertDefault();
 
-                res_columns[0]->insert(elem.first);
-                res_columns[1]->insert(host);
-                res_columns[2]->insert(port);
-                res_columns[3]->insert(index);
 
-                /// ruok command
-                auto ruok_output = sendFourLetterCommand(host, port_string, "ruok");
-                if (ruok_output.has_value())
+            /// isro command
+            /// The server will respond with "ro" if in read-only mode or "rw" if not in read-only mode.
+            auto isro_output = sendFourLetterCommand(host, port, "isro");
+            if (isro_output.has_value())
+                res_columns[5]->insert(isro_output.value() == "ro");
+            else
+                res_columns[5]->insertDefault();
+
+
+            /// mntr command
+            auto mntr_output_expected = sendFourLetterCommand(host, port, "mntr");
+            if (mntr_output_expected.has_value())
+            {
+                const String & mntr_output = mntr_output_expected.value();
+                auto mntr_responses_map = getTokens(mntr_output, "\t");
+
+                /// /* 6 */{"version", std::make_shared<DataTypeString>(), "The ZooKeeper version."},
+                if (const auto it = mntr_responses_map.find("zk_version"); it != mntr_responses_map.end())
+                    res_columns[6]->insert(it->second);
+                else
+                    res_columns[6]->insertDefault();
+
+                // /* 7 */ {"avg_latency", std::make_shared<DataTypeUInt64>(), "The average latency."},
+                if (const auto it = mntr_responses_map.find("zk_avg_latency"); it != mntr_responses_map.end())
+                    res_columns[7]->insert(parse<int>(it->second));
+                else
+                    res_columns[7]->insertDefault();
+
+                // /* 8 */ {"max_latency", std::make_shared<DataTypeUInt64>(), "The max latency."},
+                if (const auto it = mntr_responses_map.find("zk_max_latency"); it != mntr_responses_map.end())
+                    res_columns[8]->insert(parse<int>(it->second));
+                else
+                    res_columns[8]->insertDefault();
+
+                //  /* 9 */ {"min_latency", std::make_shared<DataTypeUInt64>(), "The min latency."},
+                if (const auto it = mntr_responses_map.find("zk_min_latency"); it != mntr_responses_map.end())
+                    res_columns[9]->insert(parse<int>(it->second));
+                else
+                    res_columns[9]->insertDefault();
+
+                // /* 10 */ {"packets_received", std::make_shared<DataTypeUInt64>(), "The number of packets received."},
+                if (const auto it = mntr_responses_map.find("zk_packets_received"); it != mntr_responses_map.end())
+                    res_columns[10]->insert(parse<int>(it->second));
+                else
+                    res_columns[10]->insertDefault();
+
+                // /* 11 */ {"packets_sent", std::make_shared<DataTypeUInt64>(), "The number of packets sent."},
+                if (const auto it = mntr_responses_map.find("zk_packets_sent"); it != mntr_responses_map.end())
+                    res_columns[11]->insert(parse<int>(it->second));
+                else
+                    res_columns[11]->insertDefault();
+
+                // /* 12 */ {"outstanding_requests", std::make_shared<DataTypeUInt64>(), "The number of outstanding requests."},
+                if (const auto it = mntr_responses_map.find("zk_outstanding_requests"); it != mntr_responses_map.end())
+                    res_columns[12]->insert(parse<int>(it->second));
+                else
+                    res_columns[12]->insertDefault();
+
+                // /* 13 */ {"server_state", std::make_shared<DataTypeString>(), "Server state."},
+                if (const auto it = mntr_responses_map.find("zk_server_state"); it != mntr_responses_map.end())
+                    res_columns[13]->insert(it->second);
+                else
+                    res_columns[13]->insertDefault();
+
+                ///* 15 */ {"znode_count", std::make_shared<DataTypeUInt64>(), "The znode count."},
+                int followers = 0;
+                if (const auto it = mntr_responses_map.find("zk_followers"); it != mntr_responses_map.end())
                 {
-                    if (ruok_output.value() == "imok")
-                        res_columns[4]->insert(true);
-                    else
-                        res_columns[4]->insert(false);
+                    auto followers_in_string = mntr_responses_map["zk_followers"];
+                    if (!followers_in_string.empty())
+                        followers = parse<int>(followers_in_string);
+
+                    ///* 14 */ {"is_leader", std::make_shared<DataTypeUInt8>(), "Is this zookeeper leader."},
+                    res_columns[14]->insert(followers > 0);
                 }
                 else
-                    res_columns[4]->insertDefault();
+                    res_columns[14]->insertDefault();
 
+                if (const auto it = mntr_responses_map.find("zk_znode_count"); it != mntr_responses_map.end())
+                    res_columns[15]->insert(parse<int>(it->second));
+                else
+                    res_columns[15]->insertDefault();
 
-                /// isro command
-                /// The server will respond with "ro" if in read-only mode or "rw" if not in read-only mode.
-                auto isro_output = sendFourLetterCommand(host, port_string, "isro");
-                if (isro_output.has_value())
+                // /* 16 */ {"watch_count", std::make_shared<DataTypeUInt64>(), "The watch count."},
+                if (const auto it = mntr_responses_map.find("zk_watch_count"); it != mntr_responses_map.end())
+                    res_columns[16]->insert(parse<int>(it->second));
+                else
+                    res_columns[16]->insertDefault();
+
+                // /* 17 */ {"ephemerals_count", std::make_shared<DataTypeUInt64>(), "The ephemerals count."},
+                if (const auto it = mntr_responses_map.find("zk_ephemerals_count"); it != mntr_responses_map.end())
+                    res_columns[17]->insert(parse<int>(it->second));
+                else
+                    res_columns[17]->insertDefault();
+
+                // /* 18 */ {"approximate_data_size", std::make_shared<DataTypeUInt64>(), "The approximate data size."},
+                if (const auto it = mntr_responses_map.find("zk_approximate_data_size"); it != mntr_responses_map.end())
+                    res_columns[18]->insert(parse<int>(it->second));
+                else
+                    res_columns[18]->insertDefault();
+
+                // /* 19 */ {"followers", std::make_shared<DataTypeUInt64>(), "The followers of the leader. This field is only exposed by the leader."},
+                if (const auto it = mntr_responses_map.find("zk_followers"); it != mntr_responses_map.end())
+                    res_columns[19]->insert(parse<int>(it->second));
+                else
+                    res_columns[19]->insertDefault();
+
+                // /* 20 */ {"synced_followers", std::make_shared<DataTypeUInt64>(), "The synced followers of the leader. This field is only exposed by the leader."},
+                // /* 21 */ {"pending_syncs", std::make_shared<DataTypeUInt64>(), "The pending syncs of the leader. This field is only exposed by the leader."},
+                if (const auto it = mntr_responses_map.find("zk_synced_followers"); it != mntr_responses_map.end())
                 {
-                    if (isro_output.value() == "ro")
-                        res_columns[5]->insert(true);
-                    else
-                        res_columns[5]->insert(false);
+                    int synced_followers = parse<int>(it->second);
+                    res_columns[20]->insert(synced_followers);
+                    res_columns[21]->insert(followers - synced_followers);
                 }
                 else
-                    res_columns[5]->insertDefault();
-
-
-                /// mntr command
-                auto mntr_output_expected = sendFourLetterCommand(host, port_string, "mntr");
-                if (mntr_output_expected.has_value())
                 {
-                    const String & mntr_output = mntr_output_expected.value();
-                    std::map <String, String> mntr_responses_map = getTokens(mntr_output, '\t');
-
-                    /// /* 6 */{"version", std::make_shared<DataTypeString>(), "The ZooKeeper version."},
-                    if (const auto & it = mntr_responses_map.find("zk_version"); it != mntr_responses_map.end())
-                        res_columns[6]->insert(parse<int>(it->second));
-                    else
-                        res_columns[6]->insertDefault();
-
-                    // /* 7 */ {"avg_latency", std::make_shared<DataTypeUInt64>(), "The average latency."},
-                    if (const auto & it = mntr_responses_map.find("zk_avg_latency"); it != mntr_responses_map.end())
-                        res_columns[7]->insert(parse<int>(it->second));
-                    else
-                        res_columns[7]->insertDefault();
-
-                    // /* 8 */ {"max_latency", std::make_shared<DataTypeUInt64>(), "The max latency."},
-                    if (const auto & it = mntr_responses_map.find("zk_max_latency"); it != mntr_responses_map.end())
-                        res_columns[8]->insert(parse<int>(it->second));
-                    else
-                        res_columns[8]->insertDefault();
-
-                    //  /* 9 */ {"min_latency", std::make_shared<DataTypeUInt64>(), "The min latency."},
-                    if (const auto & it = mntr_responses_map.find("zk_min_latency"); it != mntr_responses_map.end())
-                        res_columns[9]->insert(parse<int>(it->second));
-                    else
-                        res_columns[9]->insertDefault();
-
-                    // /* 10 */ {"packets_received", std::make_shared<DataTypeUInt64>(), "The number of packets received."},
-                    if (const auto & it = mntr_responses_map.find("zk_packets_received"); it != mntr_responses_map.end())
-                        res_columns[10]->insert(parse<int>(it->second));
-                    else
-                        res_columns[10]->insertDefault();
-
-                    // /* 11 */ {"packets_sent", std::make_shared<DataTypeUInt64>(), "The number of packets sent."},
-                    if (const auto & it = mntr_responses_map.find("zk_packets_sent"); it != mntr_responses_map.end())
-                        res_columns[11]->insert(parse<int>(it->second));
-                    else
-                        res_columns[11]->insertDefault();
-
-                    // /* 12 */ {"outstanding_requests", std::make_shared<DataTypeUInt64>(), "The number of outstanding requests."},
-                    if (const auto & it = mntr_responses_map.find("zk_outstanding_requests"); it != mntr_responses_map.end())
-                        res_columns[12]->insert(parse<int>(it->second));
-                    else
-                        res_columns[12]->insertDefault();
-
-                    // /* 13 */ {"server_state", std::make_shared<DataTypeString>(), "Server state."},
-                    if (const auto & it = mntr_responses_map.find("zk_server_state"); it != mntr_responses_map.end())
-                        res_columns[13]->insert(it->second);
-                    else
-                        res_columns[13]->insertDefault();
-
-                    ///* 15 */ {"znode_count", std::make_shared<DataTypeUInt64>(), "The znode count."},
-                    int followers = 0;
-                    if (const auto & it = mntr_responses_map.find("zk_followers"); it != mntr_responses_map.end())
-                    {
-                        auto followers_in_string = mntr_responses_map["zk_followers"];
-                        if (!followers_in_string.empty())
-                        {
-                            followers = parse<int>(followers_in_string);
-                        }
-
-                        ///* 14 */ {"is_leader", std::make_shared<DataTypeUInt8>(), "Is this zookeeper leader."},
-                        if (followers)
-                            res_columns[14]->insert(true);
-                        else
-                            res_columns[14]->insert(false);
-                    }
-                    else
-                        res_columns[14]->insertDefault();
-
-                    if (const auto & it = mntr_responses_map.find("zk_znode_count"); it != mntr_responses_map.end())
-                        res_columns[15]->insert(parse<int>(it->second));
-                    else
-                        res_columns[15]->insertDefault();
-
-                    // /* 16 */ {"watch_count", std::make_shared<DataTypeUInt64>(), "The watch count."},
-                    if (const auto & it = mntr_responses_map.find("zk_watch_count"); it != mntr_responses_map.end())
-                        res_columns[16]->insert(parse<int>(it->second));
-                    else
-                        res_columns[16]->insertDefault();
-
-                    // /* 17 */ {"ephemerals_count", std::make_shared<DataTypeUInt64>(), "The ephemerals count."},
-                    if (const auto & it = mntr_responses_map.find("zk_ephemerals_count"); it != mntr_responses_map.end())
-                        res_columns[17]->insert(parse<int>(it->second));
-                    else
-                        res_columns[17]->insertDefault();
-
-                    // /* 18 */ {"approximate_data_size", std::make_shared<DataTypeUInt64>(), "The approximate data size."},
-                    if (const auto & it = mntr_responses_map.find("zk_approximate_data_size"); it != mntr_responses_map.end())
-                        res_columns[18]->insert(parse<int>(it->second));
-                    else
-                        res_columns[18]->insertDefault();
-
-                    // /* 19 */ {"followers", std::make_shared<DataTypeUInt64>(), "The followers of the leader. This field is only exposed by the leader."},
-                    if (const auto & it = mntr_responses_map.find("zk_followers"); it != mntr_responses_map.end())
-                        res_columns[19]->insert(parse<int>(it->second));
-                    else
-                        res_columns[19]->insertDefault();
-
-                    // /* 20 */ {"synced_followers", std::make_shared<DataTypeUInt64>(), "The synced followers of the leader. This field is only exposed by the leader."},
-                    // /* 21 */ {"pending_syncs", std::make_shared<DataTypeUInt64>(), "The pending syncs of the leader. This field is only exposed by the leader."},
-                    if (const auto & it = mntr_responses_map.find("zk_synced_followers"); it != mntr_responses_map.end())
-                    {
-                        int synced_followers = parse<int>(it->second);
-                        res_columns[20]->insert(synced_followers);
-                        res_columns[21]->insert(followers - synced_followers);
-                    }
-                    else
-                    {
-                        res_columns[20]->insertDefault();
-                        res_columns[21]->insertDefault();
-                    }
-
-                    // /* 22 */ {"open_file_descriptor_count", std::make_shared<DataTypeUInt64>(), "The open file descriptor count. Only available on Unix platforms."},
-                    if (const auto & it = mntr_responses_map.find("zk_open_file_descriptor_count"); it != mntr_responses_map.end())
-                        res_columns[22]->insert(parse<int>(it->second));
-                    else
-                        res_columns[22]->insertDefault();
-
-                    // /* 23 */ {"max_file_descriptor_count", std::make_shared<DataTypeUInt64>(), "The max file descriptor count. Only available on Unix platforms."},
-                    if (const auto & it = mntr_responses_map.find("zk_max_file_descriptor_count"); it != mntr_responses_map.end())
-                        res_columns[23]->insert(parse<int>(it->second));
-                    else
-                        res_columns[23]->insertDefault();
+                    res_columns[20]->insertDefault();
+                    res_columns[21]->insertDefault();
                 }
 
-                /// srvr command
-                auto srvr_output_expected = sendFourLetterCommand(host, port_string, "srvr");
-                if (srvr_output_expected.has_value())
-                {
-                    const String & srvr_output = srvr_output_expected.value();
-                    std::map <String, String> srvr_responses_map = getTokens(srvr_output, ':');
+                // /* 22 */ {"open_file_descriptor_count", std::make_shared<DataTypeUInt64>(), "The open file descriptor count. Only available on Unix platforms."},
+                if (const auto it = mntr_responses_map.find("zk_open_file_descriptor_count"); it != mntr_responses_map.end())
+                    res_columns[22]->insert(parse<int>(it->second));
+                else
+                    res_columns[22]->insertDefault();
 
-                    ///* 24 */ {"connections", std::make_shared<DataTypeUInt64>(), "The ZooKeeper connections."},
-                    if (const auto & it = srvr_responses_map.find("Connections"); it != srvr_responses_map.end())
-                        res_columns[24]->insert(parse<int>(it->second));
-                    else
-                        res_columns[24]->insertDefault();
+                // /* 23 */ {"max_file_descriptor_count", std::make_shared<DataTypeUInt64>(), "The max file descriptor count. Only available on Unix platforms."},
+                if (const auto it = mntr_responses_map.find("zk_max_file_descriptor_count"); it != mntr_responses_map.end())
+                    res_columns[23]->insert(parse<int>(it->second));
+                else
+                    res_columns[23]->insertDefault();
+            }
 
-                    ///* 25 */ {"outstanding", std::make_shared<DataTypeUInt64>(), "The ZooKeeper outstanding."},
-                    if (const auto & it = srvr_responses_map.find("Outstanding"); it != srvr_responses_map.end())
-                        res_columns[25]->insert(parse<int>(it->second));
-                    else
-                        res_columns[25]->insertDefault();
+            /// srvr command
+            auto srvr_output_expected = sendFourLetterCommand(host, port, "srvr");
+            if (srvr_output_expected.has_value())
+            {
+                const String & srvr_output = srvr_output_expected.value();
+                auto srvr_responses_map = getTokens(srvr_output, ": ");
 
-                    //* 26 */ {"zxid", std::make_shared<DataTypeInt64>(), "The ZooKeeper zxid."},
-                    if (const auto & it = srvr_responses_map.find("Zxid"); it != srvr_responses_map.end())
-                        res_columns[26]->insert(parse<int>(it->second));
-                    else
-                        res_columns[26]->insertDefault();
+                ///* 24 */ {"connections", std::make_shared<DataTypeUInt64>(), "The ZooKeeper connections."},
+                if (const auto it = srvr_responses_map.find("Connections"); it != srvr_responses_map.end())
+                    res_columns[24]->insert(parse<int>(it->second));
+                else
+                    res_columns[24]->insertDefault();
 
-                    //* 27 */ {"node_count", std::make_shared<DataTypeUInt64>(), "The ZooKeeper node count."},
-                    if (const auto & it = srvr_responses_map.find("Node count"); it != srvr_responses_map.end())
-                        res_columns[27]->insert(parse<int>(it->second));
-                    else
-                        res_columns[27]->insertDefault();
-                }
+                ///* 25 */ {"outstanding", std::make_shared<DataTypeUInt64>(), "The ZooKeeper outstanding."},
+                if (const auto it = srvr_responses_map.find("Outstanding"); it != srvr_responses_map.end())
+                    res_columns[25]->insert(parse<int>(it->second));
+                else
+                    res_columns[25]->insertDefault();
+
+                //* 26 */ {"zxid", std::make_shared<DataTypeInt64>(), "The ZooKeeper zxid."},
+                if (const auto it = srvr_responses_map.find("Zxid"); it != srvr_responses_map.end())
+                    res_columns[26]->insert(parseIntInBase<16, int>(it->second.substr(2))); /// we skip the 0x prefix
+                else
+                    res_columns[26]->insertDefault();
+
+                //* 27 */ {"node_count", std::make_shared<DataTypeUInt64>(), "The ZooKeeper node count."},
+                if (const auto it = srvr_responses_map.find("Node count"); it != srvr_responses_map.end())
+                    res_columns[27]->insert(parse<int>(it->second));
+                else
+                    res_columns[27]->insertDefault();
+            }
 
 
-                /// dirs command
-                auto dirs_output_expected = sendFourLetterCommand(host, port_string, "dirs");
-                if (dirs_output_expected.has_value())
-                {
-                    const String & dirs_output = dirs_output_expected.value();
-                    std::map <String, String> dirs_responses_map = getTokens(dirs_output, ':');
+            /// dirs command
+            auto dirs_output_expected = sendFourLetterCommand(host, port, "dirs");
+            if (dirs_output_expected.has_value())
+            {
+                const String & dirs_output = dirs_output_expected.value();
+                auto dirs_responses_map = getTokens(dirs_output, ": ");
 
-                    //* 28 */ {"snapshot_dir_size", std::make_shared<DataTypeUInt64>(), "The ZooKeeper snapshot directory size."},
-                    if (const auto & it = dirs_responses_map.find("snapshot_dir_size"); it != dirs_responses_map.end())
-                        res_columns[28]->insert(parse<int>(it->second));
-                    else
-                        res_columns[28]->insertDefault();
+                //* 28 */ {"snapshot_dir_size", std::make_shared<DataTypeUInt64>(), "The ZooKeeper snapshot directory size."},
+                if (const auto it = dirs_responses_map.find("snapshot_dir_size"); it != dirs_responses_map.end())
+                    res_columns[28]->insert(parse<int>(it->second));
+                else
+                    res_columns[28]->insertDefault();
 
-                    //* 29 */ {"log_dir_size", std::make_shared<DataTypeUInt64>(), "The ZooKeeper log directory size."},
-                    if (const auto & it = dirs_responses_map.find("log_dir_size"); it != dirs_responses_map.end())
-                        res_columns[29]->insert(parse<int>(it->second));
-                    else
-                        res_columns[29]->insertDefault();
-                }
+                //* 29 */ {"log_dir_size", std::make_shared<DataTypeUInt64>(), "The ZooKeeper log directory size."},
+                if (const auto it = dirs_responses_map.find("log_dir_size"); it != dirs_responses_map.end())
+                    res_columns[29]->insert(parse<int>(it->second));
+                else
+                    res_columns[29]->insertDefault();
+            }
 
-                /// lgif command
-                auto lgif_output_expected = sendFourLetterCommand(host, port_string, "lgif");
-                if (lgif_output_expected.has_value())
-                {
-                    const String & lgif_output = lgif_output_expected.value();
-                    std::map <String, String> lgif_responses_map = getTokens(lgif_output, '\t');
+            /// lgif command
+            auto lgif_output_expected = sendFourLetterCommand(host, port, "lgif");
+            if (lgif_output_expected.has_value())
+            {
+                const String & lgif_output = lgif_output_expected.value();
+                auto lgif_responses_map = getTokens(lgif_output, "\t");
 
-                    // /* 30 */ {"first_log_idx", std::make_shared<DataTypeUInt64>(), "The ZooKeeper first log index."},
-                    if (const auto & it = lgif_responses_map.find("snapshot_dir_size"); it != lgif_responses_map.end())
-                        res_columns[30]->insert(parse<int>(it->second));
-                    else
-                        res_columns[30]->insertDefault();
+                // /* 30 */ {"first_log_idx", std::make_shared<DataTypeUInt64>(), "The ZooKeeper first log index."},
+                if (const auto it = lgif_responses_map.find("first_log_idx"); it != lgif_responses_map.end())
+                    res_columns[30]->insert(parse<int>(it->second));
+                else
+                    res_columns[30]->insertDefault();
 
-                    // /* 31 */ {"first_log_term", std::make_shared<DataTypeUInt64>(), "The ZooKeeper first log term."},
-                    if (const auto & it = lgif_responses_map.find("first_log_term"); it != lgif_responses_map.end())
-                        res_columns[31]->insert(parse<int>(it->second));
-                    else
-                        res_columns[31]->insertDefault();
+                // /* 31 */ {"first_log_term", std::make_shared<DataTypeUInt64>(), "The ZooKeeper first log term."},
+                if (const auto it = lgif_responses_map.find("first_log_term"); it != lgif_responses_map.end())
+                    res_columns[31]->insert(parse<int>(it->second));
+                else
+                    res_columns[31]->insertDefault();
 
-                    // /* 32 */ {"last_log_idx", std::make_shared<DataTypeUInt64>(), "The ZooKeeper last log index."},
-                    if (const auto & it = lgif_responses_map.find("last_log_idx"); it != lgif_responses_map.end())
-                        res_columns[32]->insert(parse<int>(it->second));
-                    else
-                        res_columns[32]->insertDefault();
+                // /* 32 */ {"last_log_idx", std::make_shared<DataTypeUInt64>(), "The ZooKeeper last log index."},
+                if (const auto it = lgif_responses_map.find("last_log_idx"); it != lgif_responses_map.end())
+                    res_columns[32]->insert(parse<int>(it->second));
+                else
+                    res_columns[32]->insertDefault();
 
-                    // /* 33 */ {"last_log_term", std::make_shared<DataTypeUInt64>(), "The ZooKeeper last log term."},
-                    if (const auto & it = lgif_responses_map.find("last_log_term"); it != lgif_responses_map.end())
-                        res_columns[33]->insert(parse<int>(it->second));
-                    else
-                        res_columns[33]->insertDefault();
+                // /* 33 */ {"last_log_term", std::make_shared<DataTypeUInt64>(), "The ZooKeeper last log term."},
+                if (const auto it = lgif_responses_map.find("last_log_term"); it != lgif_responses_map.end())
+                    res_columns[33]->insert(parse<int>(it->second));
+                else
+                    res_columns[33]->insertDefault();
 
-                    // /* 34 */ {"last_committed_idx", std::make_shared<DataTypeUInt64>(), "The ZooKeeper last committed index."},
-                    if (const auto & it = lgif_responses_map.find("last_committed_log_idx"); it != lgif_responses_map.end())
-                        res_columns[34]->insert(parse<int>(it->second));
-                    else
-                        res_columns[34]->insertDefault();
+                // /* 34 */ {"last_committed_idx", std::make_shared<DataTypeUInt64>(), "The ZooKeeper last committed index."},
+                if (const auto it = lgif_responses_map.find("last_committed_log_idx"); it != lgif_responses_map.end())
+                    res_columns[34]->insert(parse<int>(it->second));
+                else
+                    res_columns[34]->insertDefault();
 
-                    // /* 35 */ {"leader_committed_log_idx", std::make_shared<DataTypeUInt64>(), "The ZooKeeper leader committed log index."},
-                    if (const auto & it = lgif_responses_map.find("leader_committed_log_idx"); it != lgif_responses_map.end())
-                        res_columns[35]->insert(parse<int>(it->second));
-                    else
-                        res_columns[35]->insertDefault();
+                // /* 35 */ {"leader_committed_log_idx", std::make_shared<DataTypeUInt64>(), "The ZooKeeper leader committed log index."},
+                if (const auto it = lgif_responses_map.find("leader_committed_log_idx"); it != lgif_responses_map.end())
+                    res_columns[35]->insert(parse<int>(it->second));
+                else
+                    res_columns[35]->insertDefault();
 
-                    // /* 36 */ {"target_committed_log_idx", std::make_shared<DataTypeUInt64>(), "The ZooKeeper target committed log index."},
-                    if (const auto & it = lgif_responses_map.find("target_committed_log_idx"); it != lgif_responses_map.end())
-                        res_columns[36]->insert(parse<int>(it->second));
-                    else
-                        res_columns[36]->insertDefault();
+                // /* 36 */ {"target_committed_log_idx", std::make_shared<DataTypeUInt64>(), "The ZooKeeper target committed log index."},
+                if (const auto it = lgif_responses_map.find("target_committed_log_idx"); it != lgif_responses_map.end())
+                    res_columns[36]->insert(parse<int>(it->second));
+                else
+                    res_columns[36]->insertDefault();
 
-                    // /* 37 */ {"last_snapshot_idx", std::make_shared<DataTypeUInt64>(), "The ZooKeeper last snapshot index."},
-                    if (const auto & it = lgif_responses_map.find("last_snapshot_idx"); it != lgif_responses_map.end())
-                        res_columns[37]->insert(parse<int>(it->second));
-                    else
-                        res_columns[37]->insertDefault();
-                }
+                // /* 37 */ {"last_snapshot_idx", std::make_shared<DataTypeUInt64>(), "The ZooKeeper last snapshot index."},
+                if (const auto it = lgif_responses_map.find("last_snapshot_idx"); it != lgif_responses_map.end())
+                    res_columns[37]->insert(parse<int>(it->second));
+                else
+                    res_columns[37]->insertDefault();
             }
         }
     }
 }
 
 
-std::expected<String,String> StorageSystemZooKeeperInfo::sendFourLetterCommand(String host, String port, String command) const
+std::expected<String,String> StorageSystemZooKeeperInfo::sendFourLetterCommand(const String & host, UInt16 port, std::string_view command) const
 {
     Poco::Net::SocketAddress address(host, port);
     Poco::Net::StreamSocket socket;
@@ -451,7 +441,7 @@ std::expected<String,String> StorageSystemZooKeeperInfo::sendFourLetterCommand(S
         Coordination::write(cmd_int,*out);
         out->next();
 
-        readString(response,*in);
+        readStringUntilEOF(response,*in);
     }
     catch (...)
     {

--- a/src/Storages/System/StorageSystemZooKeeperInfo.cpp
+++ b/src/Storages/System/StorageSystemZooKeeperInfo.cpp
@@ -434,7 +434,8 @@ std::expected<String,String> StorageSystemZooKeeperInfo::sendFourLetterCommand(c
         auto in = std::make_shared<ReadBufferFromPocoSocket>(socket);
         auto out = std::make_shared<AutoCanceledWriteBuffer<WriteBufferFromPocoSocket>>(socket);
 
-        int32_t res = *reinterpret_cast<const int32_t *>(command.data());
+        int32_t res = 0;
+        std::memcpy(&res, command.data(), sizeof(int32_t));
         /// keep consistent with Coordination::read method by changing big endian to little endian.
         int32_t cmd_int = std::byteswap(res);
 

--- a/src/Storages/System/StorageSystemZooKeeperInfo.h
+++ b/src/Storages/System/StorageSystemZooKeeperInfo.h
@@ -23,7 +23,7 @@ using IStorageSystemOneBlock::IStorageSystemOneBlock;
 
 void fillData(MutableColumns & res_columns, ContextPtr context, const ActionsDAG::Node *, std::vector<UInt8>) const override;
 
-std::expected<String,String> sendFourLetterCommand(String host, String port, String command) const;
+std::expected<String,String> sendFourLetterCommand(const String & host, UInt16 port, std::string_view command) const;
 
 };
 

--- a/tests/integration/test_zookeeper_info/test.py
+++ b/tests/integration/test_zookeeper_info/test.py
@@ -2,6 +2,9 @@
 
 import pytest
 
+import logging
+import re
+
 from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
@@ -38,8 +41,42 @@ def test_select(started_cluster):
     count = node1.query("SELECT count() FROM system.zookeeper_info")
     assert (count == "3\n")
     response = node1.query("SELECT * FROM system.zookeeper_info")
-    print(response)
+    logging.info(response)
     name = node1.query("SELECT zookeeper_cluster_name FROM system.zookeeper_info limit 1")
     assert (name == "zookeeper\n")
     indices = node1.query("SELECT index FROM system.zookeeper_info")
     assert (indices == "0\n1\n2\n")
+
+def test_info(started_cluster):
+    response = node1.query("SELECT * FROM system.zookeeper_info FORMAT Vertical")
+    response = re.sub(r'Row \d+:\n─+\n', '', response)
+    rows = response.split("\n\n")
+
+    node_infos = []
+    for row in rows:
+        row = row.strip()
+        columns = row.split("\n")
+        node_info = {}
+        for column in columns:
+            key, value = column.split(": ")
+            value = value.strip()
+            node_info[key] = None if value == 'ᴺᵁᴸᴸ' else value
+        node_infos.append(node_info)
+
+    logging.info(node_infos)
+
+    assert all(node_info['port'] == '9181' for node_info in node_infos)
+
+    assert all(node_info['is_readonly'] == '0' for node_info in node_infos)
+
+    assert all(node_info['is_connected'] == '1' for node_info in node_infos)
+
+    assert all(node_info['packets_received'] is not None for node_info in node_infos)
+    assert all(node_info['packets_sent'] is not None for node_info in node_infos)
+
+    assert sum(node_info['is_leader'] is not None for node_info in node_infos) == 1
+
+    assert all(int(node_info['zxid']) > 0 for node_info in node_infos)
+
+    assert all(int(node_info['log_dir_size']) > 0 for node_info in node_infos)
+    assert all(int(node_info['last_log_idx']) > 0 for node_info in node_infos)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

system.zookeeper_info didn't properly read and parse 4LW command responses.
I added a test for those columns.

I also did some minor changes throughout the code not related to the fix itself.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.473`
<!-- ch-version-info:end -->