### PR TITLE
Fix test_peak_memory_usage flakiness by making logging of peak memory more accurate

### DIFF
--- a/src/Server/TCPHandler.h
+++ b/src/Server/TCPHandler.h
@@ -301,11 +301,11 @@ private:
 
     /// Process INSERT query
     void startInsertQuery(QueryState & state);
-    void processInsertQuery(QueryState & state);
+    void processInsertQuery(QueryState & state, CurrentThread::QueryScope & query_scope);
     AsynchronousInsertQueue::PushResult processAsyncInsertQuery(QueryState & state, AsynchronousInsertQueue & insert_queue);
 
     /// Process a request that does not require the receiving of data blocks from the client
-    void processOrdinaryQuery(QueryState & state);
+    void processOrdinaryQuery(QueryState & state, CurrentThread::QueryScope & query_scope);
 
     void processTablesStatusRequest();
 


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

Fixes: https://github.com/ClickHouse/ClickHouse/issues/90840


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.570`
<!-- ch-version-info:end -->