### PR TITLE
Fix system instrument dispatch bug

### DIFF
--- a/src/Interpreters/InstrumentationManager.cpp
+++ b/src/Interpreters/InstrumentationManager.cpp
@@ -263,7 +263,7 @@ void InstrumentationManager::unpatchFunction(std::variant<UInt64, Instrumentatio
         {
             const auto it = instrumented_points.get<Id>().find(info.id);
             if (it == instrumented_points.get<Id>().end())
-                throw Exception(ErrorCodes::LOGICAL_ERROR, "Instrumentation point {} does not exist", it->toString());
+                throw Exception(ErrorCodes::LOGICAL_ERROR, "Instrumentation point {} does not exist", info.toString());
             LOG_INFO(logger, "Removing instrumented function {}", it->toString());
             unpatchFunctionIfNeeded(it->function_id);
             instrumented_points.erase(it);

--- a/src/Interpreters/InstrumentationManager.cpp
+++ b/src/Interpreters/InstrumentationManager.cpp
@@ -314,8 +314,11 @@ void InstrumentationManager::dispatchHandlerImpl(Int32 func_id, XRayEntryType en
 
     std::vector<InstrumentedPointInfo> func_ips;
     SharedLockGuard lock(shared_mutex);
-    for (auto it = instrumented_points.get<FunctionId>().find(func_id); it != instrumented_points.get<FunctionId>().end(); ++it)
+    auto range = instrumented_points.get<FunctionId>().equal_range(func_id);
+    for (auto it = range.first; it != range.second; ++it)
+    {
         func_ips.emplace_back(*it);
+    }
     lock.unlock();
 
     for (const auto & info : func_ips)

--- a/src/Interpreters/InstrumentationManager.h
+++ b/src/Interpreters/InstrumentationManager.h
@@ -28,8 +28,11 @@ enum class EntryType : UInt8
 #include <boost/multi_index/ordered_index.hpp>
 #include <xray/xray_interface.h>
 
-#include <vector>
+#include <chrono>
+#include <functional>
+#include <unordered_map>
 #include <variant>
+#include <vector>
 
 namespace DB
 {

--- a/tests/queries/0_stateless/03642_system_instrument_dispatch_bug.reference
+++ b/tests/queries/0_stateless/03642_system_instrument_dispatch_bug.reference
@@ -1,0 +1,3 @@
+-- Each function handler should be called exactly once:
+startQuery count:	1
+finishQuery count:	1

--- a/tests/queries/0_stateless/03642_system_instrument_dispatch_bug.sh
+++ b/tests/queries/0_stateless/03642_system_instrument_dispatch_bug.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Tags: use-xray, no-parallel
+# no-parallel: avoid other tests trying to add the same instrumentation to the same symbol
+#
+# How the bug manifests:
+# - The ordered_non_unique index sorts elements by (function_id, id)
+# - find(func_id) returns an iterator to the first matching element
+# - The loop continues until end(), processing ALL subsequent elements
+# - This means calling a function with a lowerfunction_id incorrectly triggers
+#   handlers for functions with higher function_ids
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+function cleanup()
+{
+    $CLICKHOUSE_CLIENT -q "SYSTEM INSTRUMENT REMOVE ALL;"
+}
+
+trap cleanup EXIT
+
+$CLICKHOUSE_CLIENT -q "SYSTEM INSTRUMENT REMOVE ALL;"
+
+$CLICKHOUSE_CLIENT -q "
+    SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' LOG ENTRY 'marker_start';
+    SYSTEM INSTRUMENT ADD 'QueryMetricLog::finishQuery' LOG ENTRY 'marker_finish';
+"
+
+query_id="${CLICKHOUSE_DATABASE}_dispatch_bug"
+$CLICKHOUSE_CLIENT --query-id="$query_id" -q "SELECT 1 FORMAT Null;"
+
+$CLICKHOUSE_CLIENT -q "SYSTEM INSTRUMENT REMOVE ALL;"
+$CLICKHOUSE_CLIENT -q "SYSTEM FLUSH LOGS system.trace_log;"
+
+# The key assertion: each function should have its handler called EXACTLY ONCE.
+# With the bug, if one function has a lower function_id than another,
+# calling the lower one also triggers the higher one's handler.
+$CLICKHOUSE_CLIENT -q "
+    SELECT '-- Each function handler should be called exactly once:';
+    SELECT 'startQuery count:', count()
+    FROM system.trace_log
+    WHERE event_date >= yesterday()
+      AND query_id = '$query_id'
+      AND trace_type = 'Instrumentation'
+      AND handler = 'log'
+      AND function_name LIKE '%QueryMetricLog::startQuery%';
+
+    SELECT 'finishQuery count:', count()
+    FROM system.trace_log
+    WHERE event_date >= yesterday()
+      AND query_id = '$query_id'
+      AND trace_type = 'Instrumentation'
+      AND handler = 'log'
+      AND function_name LIKE '%QueryMetricLog::finishQuery%';
+"

--- a/tests/queries/0_stateless/03642_system_instrument_dispatch_bug.sh
+++ b/tests/queries/0_stateless/03642_system_instrument_dispatch_bug.sh
@@ -6,7 +6,7 @@
 # - The ordered_non_unique index sorts elements by (function_id, id)
 # - find(func_id) returns an iterator to the first matching element
 # - The loop continues until end(), processing ALL subsequent elements
-# - This means calling a function with a lowerfunction_id incorrectly triggers
+# - This means calling a function with a lower function_id incorrectly triggers
 #   handlers for functions with higher function_ids
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)


### PR DESCRIPTION
Fix two different bugs pointed out by an analysis tool:
- [Invalid dereference when reporting missing instrumentation point in unpatchFunction](https://app.everdone.ai/services/codereview/manual-file-reviews/3e828da0-93d8-487c-a18d-adf5d856d42f/Cointab-Software-Pvt-Ltd/ClickHouse/master/issues/1d4678e9-5fd7-4eed-aaf5-388eeeea6063)
- [Iteration over instrumented_points by FunctionId may scan past matching keys (wrong function matches)](https://app.everdone.ai/services/codereview/manual-file-reviews/3e828da0-93d8-487c-a18d-adf5d856d42f/Cointab-Software-Pvt-Ltd/ClickHouse/master/issues/f79763d2-6111-481d-a0d2-dfa8fbb3e6f8)
- [Missing standard includes (<functional>, <unordered_map>, <chrono>) in header](https://app.everdone.ai/services/codereview/manual-file-reviews/3e828da0-93d8-487c-a18d-adf5d856d42f/Cointab-Software-Pvt-Ltd/ClickHouse/master/issues/b003c454-6a32-4d40-89d1-ea25316e4640)

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix system instrument dispatch bug

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.463`
- Backported to: `25.12.4.2`
<!-- ch-version-info:end -->