### PR TITLE
depricate throw_if_deduplication_in_dependent_materialized_views_enabled_with_async_insert

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -11,6 +11,7 @@
 #include <Core/SettingsChangesHistory.h>
 #include <Core/SettingsEnums.h>
 #include <Core/SettingsFields.h>
+#include <Core/SettingsObsoleteMacros.h>
 #include <IO/ReadBufferFromString.h>
 #include <IO/S3Defines.h>
 #include <Storages/System/MutableColumnsAndConstraints.h>
@@ -4453,9 +4454,6 @@ This setting is useful for ensuring that materialized views do not contain dupli
 
 - [NULL Processing in IN Operators](/guides/developer/deduplicating-inserts-on-retries#insert-deduplication-with-materialized-views)
 )", 0) \
-    DECLARE(Bool, throw_if_deduplication_in_dependent_materialized_views_enabled_with_async_insert, true, R"(
-Throw exception on INSERT query when the setting `deduplicate_blocks_in_dependent_materialized_views` is enabled along with `async_insert`. It guarantees correctness, because these features can't work together.
-)", 0) \
     DECLARE(Bool, materialized_views_ignore_errors, false, R"(
 Allows to ignore errors for MATERIALIZED VIEW, and deliver original block to the table regardless of MVs
 )", 0) \
@@ -7594,6 +7592,7 @@ Allow experimental database engine DataLakeCatalog with catalog_type = 'paimon_r
     MAKE_OBSOLETE(M, Bool, allow_not_comparable_types_in_comparison_functions, false) \
     MAKE_OBSOLETE(M, Bool, enable_zstd_qat_codec, false) \
     MAKE_OBSOLETE(M, Bool, enable_deflate_qpl_codec, false) \
+    MAKE_OBSOLETE(M, Bool, throw_if_deduplication_in_dependent_materialized_views_enabled_with_async_insert, false) \
 \
     /* moved to config.xml: see also src/Core/ServerSettings.h */ \
     MAKE_DEPRECATED_BY_SERVER_CONFIG(M, UInt64, background_buffer_flush_schedule_pool_size, 16) \

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -57,6 +57,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"join_runtime_bloom_filter_max_ratio_of_set_bits", 0.7, 0.7, "New setting"},
             {"use_primary_key", true, true, "New setting controlling whether MergeTree uses the primary key for granule-level pruning."},
             {"use_variant_default_implementation_for_comparisons", false, true, "Enable default implementation for Variant type in comparison functions"},
+            {"throw_if_deduplication_in_dependent_materialized_views_enabled_with_async_insert", true, false, "It becomes obsolete."},
         });
         addSettingsChanges(settings_changes_history, "25.12",
         {

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -166,7 +166,6 @@ namespace Setting
     extern const SettingsOverflowMode result_overflow_mode;
     extern const SettingsOverflowMode set_overflow_mode;
     extern const SettingsOverflowMode sort_overflow_mode;
-    extern const SettingsBool throw_if_deduplication_in_dependent_materialized_views_enabled_with_async_insert;
     extern const SettingsBool throw_on_unsupported_query_inside_transaction;
     extern const SettingsOverflowMode timeout_overflow_mode;
     extern const SettingsOverflowMode transfer_overflow_mode;
@@ -1517,21 +1516,6 @@ static BlockIO executeQueryImpl(
                 throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Async inserts inside transactions are not supported");
             if (settings[Setting::implicit_transaction] && settings[Setting::throw_on_unsupported_query_inside_transaction])
                 throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Async inserts with 'implicit_transaction' are not supported");
-
-            /// Let's agree on terminology and say that a mini-INSERT is an asynchronous INSERT
-            /// which typically contains not a lot of data inside and a big-INSERT in an INSERT
-            /// which was formed by concatenating several mini-INSERTs together.
-            /// In case when the client had to retry some mini-INSERTs then they will be properly deduplicated
-            /// by the source tables. This functionality is controlled by a setting `async_insert_deduplicate`.
-            /// But then they will be glued together into a block and pushed through a chain of Materialized Views if any.
-            /// The process of forming such blocks is not deterministic so each time we retry mini-INSERTs the resulting
-            /// block may be concatenated differently.
-            /// That's why deduplication in dependent Materialized Views doesn't make sense in presence of async INSERTs.
-            if (settings[Setting::throw_if_deduplication_in_dependent_materialized_views_enabled_with_async_insert]
-                && settings[Setting::deduplicate_blocks_in_dependent_materialized_views])
-                throw Exception(ErrorCodes::SUPPORT_IS_DISABLED,
-                        "Deduplication in dependent materialized view cannot work together with async inserts. "\
-                        "Please disable either `deduplicate_blocks_in_dependent_materialized_views` or `async_insert` setting.");
 
             if (settings[Setting::insert_quorum].valueOr(0) > 0)
                 throw Exception(ErrorCodes::SUPPORT_IS_DISABLED,

--- a/tests/queries/0_stateless/03006_mv_deduplication_throw_if_async_insert.sql
+++ b/tests/queries/0_stateless/03006_mv_deduplication_throw_if_async_insert.sql
@@ -10,10 +10,9 @@ CREATE TABLE 03006_test
 )
 ENGINE = MergeTree ORDER BY tuple();
 
-INSERT INTO 03006_test VALUES ('2024-03-05', 1), ('2024-03-05', 2), ('2024-03-05', 1);  -- { serverError SUPPORT_IS_DISABLED  }
 INSERT INTO 03006_test SETTINGS compatibility='24.1' VALUES ('2024-03-05', 1), ('2024-03-05', 2), ('2024-03-05', 1);
 INSERT INTO 03006_test SETTINGS async_insert=0 VALUES ('2024-03-05', 1), ('2024-03-05', 2), ('2024-03-05', 1);
 INSERT INTO 03006_test SETTINGS deduplicate_blocks_in_dependent_materialized_views=0 VALUES ('2024-03-05', 1), ('2024-03-05', 2), ('2024-03-05', 1);
-INSERT INTO 03006_test SETTINGS throw_if_deduplication_in_dependent_materialized_views_enabled_with_async_insert=0 VALUES ('2024-03-05', 1), ('2024-03-05', 2), ('2024-03-05', 1);
+INSERT INTO 03006_test VALUES ('2024-03-05', 1), ('2024-03-05', 2), ('2024-03-05', 1);
 
 DROP TABLE IF EXISTS 02985_test;

--- a/tests/queries/0_stateless/03717_async_deduplication_with_mv.sql
+++ b/tests/queries/0_stateless/03717_async_deduplication_with_mv.sql
@@ -63,8 +63,7 @@ TO 03717_mv_table_all AS
 SELECT count() as value FROM 03717_table;
 
 
-SET async_insert = 1, insert_deduplicate = 1, async_insert_deduplicate = 1, wait_for_async_insert = 0,
-    throw_if_deduplication_in_dependent_materialized_views_enabled_with_async_insert=0, deduplicate_blocks_in_dependent_materialized_views=1;
+SET async_insert = 1, insert_deduplicate = 1, async_insert_deduplicate = 1, wait_for_async_insert = 0, deduplicate_blocks_in_dependent_materialized_views=1;
 set async_insert_use_adaptive_busy_timeout=0, async_insert_busy_timeout_min_ms=1000, async_insert_busy_timeout_max_ms=5000;
 
 SET max_block_size=1;

--- a/tests/queries/0_stateless/03732_async_insert_cases.sql
+++ b/tests/queries/0_stateless/03732_async_insert_cases.sql
@@ -3,7 +3,6 @@ set async_insert = 1;
 set wait_for_async_insert = 0;
 set async_insert_deduplicate = 1;
 set deduplicate_blocks_in_dependent_materialized_views = 1;
-set throw_if_deduplication_in_dependent_materialized_views_enabled_with_async_insert = 0;
 
 -- turn off adaptive busy timeout to make test stable
 set async_insert_use_adaptive_busy_timeout=0, async_insert_busy_timeout_min_ms=1000, async_insert_busy_timeout_max_ms=5000;

--- a/tests/queries/0_stateless/03733_async_insert_not_supported.sql
+++ b/tests/queries/0_stateless/03733_async_insert_not_supported.sql
@@ -2,7 +2,6 @@ set async_insert = 1;
 set wait_for_async_insert = 0;
 set async_insert_deduplicate = 1;
 set deduplicate_blocks_in_dependent_materialized_views = 1;
-set throw_if_deduplication_in_dependent_materialized_views_enabled_with_async_insert = 0;
 
 set async_insert_use_adaptive_busy_timeout=0, async_insert_busy_timeout_min_ms=1000, async_insert_busy_timeout_max_ms=5000;
 

--- a/tests/queries/0_stateless/03735_async_insert_mergetree.sql
+++ b/tests/queries/0_stateless/03735_async_insert_mergetree.sql
@@ -2,7 +2,6 @@ set async_insert = 1;
 set wait_for_async_insert = 0;
 set async_insert_deduplicate = 1;
 set deduplicate_blocks_in_dependent_materialized_views = 1;
-set throw_if_deduplication_in_dependent_materialized_views_enabled_with_async_insert = 0;
 
 set async_insert_use_adaptive_busy_timeout=0, async_insert_busy_timeout_min_ms=1000, async_insert_busy_timeout_max_ms=5000;
 

--- a/tests/queries/0_stateless/03735_async_insert_mergetree_count.sql
+++ b/tests/queries/0_stateless/03735_async_insert_mergetree_count.sql
@@ -2,7 +2,6 @@ set async_insert = 1;
 set wait_for_async_insert = 0;
 set async_insert_deduplicate = 1;
 set deduplicate_blocks_in_dependent_materialized_views = 1;
-set throw_if_deduplication_in_dependent_materialized_views_enabled_with_async_insert = 0;
 
 set async_insert_use_adaptive_busy_timeout=0, async_insert_busy_timeout_min_ms=1000, async_insert_busy_timeout_max_ms=5000;
 


### PR DESCRIPTION
…led_with_async_insert

### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
It is allowed to use deduplication with async inserts when materialized views are involved 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.564`
<!-- ch-version-info:end -->