### PR TITLE
fix multiple flushes in TraceSender

### DIFF
--- a/src/Common/TraceSender.cpp
+++ b/src/Common/TraceSender.cpp
@@ -7,6 +7,7 @@
 #include <Common/TraceSender.h>
 #include <Common/setThreadName.h>
 #include <base/defines.h>
+#include <base/scope_guard.h>
 
 #include <string_view>
 
@@ -40,6 +41,7 @@ void TraceSender::send(TraceType trace_type, const StackTrace & stack_trace, Ext
     if (unlikely(inside_send))
         return;
     inside_send = true;
+    SCOPE_EXIT({ inside_send = false; });
     DENY_ALLOCATIONS_IN_SCOPE;
 
     constexpr size_t buf_size = sizeof(char) /// TraceCollector stop flag
@@ -117,8 +119,6 @@ void TraceSender::send(TraceType trace_type, const StackTrace & stack_trace, Ext
 
     /// Multiple threads are calling this function concurrently, so writes to pipe should be atomic (single flush).
     chassert(out.getFlushCount() == 1);
-
-    inside_send = false;
 }
 
 }

--- a/src/Common/TraceSender.cpp
+++ b/src/Common/TraceSender.cpp
@@ -48,6 +48,7 @@ void TraceSender::send(TraceType trace_type, const StackTrace & stack_trace, Ext
         + sizeof(UInt8)                      /// Number of stack frames
         + sizeof(FramePointers)              /// Collected stack trace, maximum capacity
         + sizeof(TraceType)                  /// trace type
+        + sizeof(UInt64)                     /// cpu_id
         + sizeof(UInt64)                     /// thread_id
         + sizeof(ThreadName)                 /// thread name enum
         + sizeof(Int64)                      /// size
@@ -113,6 +114,9 @@ void TraceSender::send(TraceType trace_type, const StackTrace & stack_trace, Ext
 
     out.next();
     out.finalize();
+
+    /// Multiple threads are calling this function concurrently, so writes to pipe should be atomic (single flush).
+    chassert(out.getFlushCount() == 1);
 
     inside_send = false;
 }

--- a/src/Common/TraceSender.cpp
+++ b/src/Common/TraceSender.cpp
@@ -48,8 +48,7 @@ void TraceSender::send(TraceType trace_type, const StackTrace & stack_trace, Ext
         + sizeof(UInt8)                      /// Number of stack frames
         + sizeof(FramePointers)              /// Collected stack trace, maximum capacity
         + sizeof(TraceType)                  /// trace type
-        // NOTE: temporarily comment out the fix to confirm that multiple flushes are caught by the CI (see the assert below)
-        // + sizeof(UInt64)                     /// cpu_id
+        + sizeof(UInt64)                     /// cpu_id
         + sizeof(UInt64)                     /// thread_id
         + sizeof(ThreadName)                 /// thread name enum
         + sizeof(Int64)                      /// size

--- a/src/Common/TraceSender.cpp
+++ b/src/Common/TraceSender.cpp
@@ -48,7 +48,8 @@ void TraceSender::send(TraceType trace_type, const StackTrace & stack_trace, Ext
         + sizeof(UInt8)                      /// Number of stack frames
         + sizeof(FramePointers)              /// Collected stack trace, maximum capacity
         + sizeof(TraceType)                  /// trace type
-        + sizeof(UInt64)                     /// cpu_id
+        // NOTE: temporarily comment out the fix to confirm that multiple flushes are caught by the CI (see the assert below)
+        // + sizeof(UInt64)                     /// cpu_id
         + sizeof(UInt64)                     /// thread_id
         + sizeof(ThreadName)                 /// thread name enum
         + sizeof(Int64)                      /// size

--- a/src/Common/TraceSender.cpp
+++ b/src/Common/TraceSender.cpp
@@ -20,7 +20,7 @@ namespace
     /// The performance test query ids can be surprisingly long like
     /// `aggregating_merge_tree_simple_aggregate_function_string.query100.profile100`,
     /// so make some allowance for them as well.
-    constexpr size_t QUERY_ID_MAX_LEN = 100;
+    constexpr size_t QUERY_ID_MAX_LEN = 95;
     static_assert(QUERY_ID_MAX_LEN <= std::numeric_limits<uint8_t>::max());
 }
 

--- a/src/IO/WriteBuffer.h
+++ b/src/IO/WriteBuffer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <algorithm>
+#include <atomic>
 #include <exception>
 #include <memory>
 
@@ -107,7 +108,7 @@ public:
     bool isCanceled() const { return canceled; }
 
     /// Get number of times next() has been called (number of flushes)
-    size_t getFlushCount() const { return flush_count; }
+    size_t getFlushCount() const { return flush_count.load(std::memory_order_relaxed); }
 
     /// Wait for data to be reliably written. Mainly, call fsync for fd.
     /// May be called after finalize() if needed.
@@ -152,7 +153,7 @@ private:
     int exception_level = std::uncaught_exceptions();
 
     /// Number of flushes for debugging/assertions
-    size_t flush_count = 0;
+    std::atomic<size_t> flush_count = 0;
 };
 
 

--- a/src/IO/WriteBuffer.h
+++ b/src/IO/WriteBuffer.h
@@ -51,6 +51,7 @@ public:
         try
         {
             nextImpl();
+            ++flush_count;
         }
         catch (CurrentBufferExhausted &)
         {
@@ -105,6 +106,9 @@ public:
     bool isFinalized() const { return finalized; }
     bool isCanceled() const { return canceled; }
 
+    /// Get number of times next() has been called (number of flushes)
+    size_t getFlushCount() const { return flush_count; }
+
     /// Wait for data to be reliably written. Mainly, call fsync for fd.
     /// May be called after finalize() if needed.
     virtual void sync()
@@ -146,6 +150,9 @@ private:
     }
 
     int exception_level = std::uncaught_exceptions();
+
+    /// Number of flushes for debugging/assertions
+    size_t flush_count = 0;
 };
 
 


### PR DESCRIPTION
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

In https://github.com/ClickHouse/ClickHouse/pull/89173, we added an extra field to the structure that `TraceSender` sends through an internal pipe. However, the buffer size was not updated ([here](https://github.com/ClickHouse/ClickHouse/pull/89173/changes#diff-36ecfac5cde34c92c031652d8a77f0d12782cd5d43e68d6ef159e6d46a54224fL44)), therefore we are writting more data to buffer than `buffer_size` which results in multiple flushes. And because `TraceSender::send` is called from different threads, different threads' flushes may interleave which breaks the invariant that the receiving end (`TraceCollector`) relies on.

Fixes https://github.com/ClickHouse/clickhouse-core-incidents/issues/1242. The broken invariant may have resulted in reading garbage data for `ProfileEvents::Event` which may have caused a segfault when doing `strings[event]`;

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.477`
- Backported to: `25.12.4.7`
<!-- ch-version-info:end -->