### PR TITLE
Fix free space calculation in self-extracting decompressor.

### DIFF
--- a/utils/self-extracting-executable/decompressor.cpp
+++ b/utils/self-extracting-executable/decompressor.cpp
@@ -1,10 +1,6 @@
 #include <zstd.h>
 #include <sys/mman.h>
-#if defined(OS_DARWIN) || defined(OS_FREEBSD)
-#   include <sys/mount.h>
-#else
-#   include <sys/statfs.h>
-#endif
+#include <sys/statvfs.h>
 #include <fcntl.h>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -216,17 +212,18 @@ int decompressFiles(int input_fd, char * path, char * name, bool & have_compress
     }
 
     /// Check free space
-    struct statfs fs_info;
-    if (0 != fstatfs(input_fd, &fs_info))
+    struct statvfs fs_info;
+    if (0 != fstatvfs(input_fd, &fs_info))
     {
-        perror("fstatfs");
+        perror("fstatvfs");
         if (0 != munmap(input, info_in.st_size))
                 perror("munmap");
         return 1;
     }
-    if (fs_info.f_blocks * info_in.st_blksize < decompressed_full_size)
+    /// Available space in bytes = free blocks * block size
+    if (fs_info.f_bavail * fs_info.f_frsize < decompressed_full_size)
     {
-        std::cerr << "Not enough space for decompression. Have " << fs_info.f_blocks * info_in.st_blksize << ", need " << decompressed_full_size << std::endl;
+        std::cerr << "Not enough space for decompression. Have " << fs_info.f_bavail * fs_info.f_frsize << ", need " << decompressed_full_size << std::endl;
         return 1;
     }
 


### PR DESCRIPTION
The previous calculation used `f_blocks * st_blksize`, which incorrectly mixed statvfs block counts with an unrelated stat field:

- f_blocks (from statvfs): total blocks on filesystem, not free space.
- st_blksize (from stat): "preferred I/O block size" - an optimization hint, not a unit for block counting.

On linux, st_blksize happens to match the actual block size, which hides the bug. But on macos, f_frsize is 1 MiB while st_blksize is 4 KB, causing a 256x undercount and spurious "Not enough space" errors.

This patch uses f_bavail (blocks available) rather than f_blocks (total blocks on fs), and f_frsize (block size) rather than st_blksize (preferred block size).

Fixes #93896.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.464`
<!-- ch-version-info:end -->