### PR TITLE
Inserts to Alias trigger MVs on alias target

### DIFF
--- a/tests/queries/0_stateless/03777_insert_to_alias_triggers_mv_on_alias_target.reference
+++ b/tests/queries/0_stateless/03777_insert_to_alias_triggers_mv_on_alias_target.reference
@@ -1,0 +1,6 @@
+Direct insert to source_table
+source_table count:	1
+mv_target count:	1
+Insert through alias_table
+source_table count:	2
+mv_target count:	2

--- a/tests/queries/0_stateless/03777_insert_to_alias_triggers_mv_on_alias_target.sql
+++ b/tests/queries/0_stateless/03777_insert_to_alias_triggers_mv_on_alias_target.sql
@@ -1,0 +1,33 @@
+-- Test that Materialized Views are triggered when inserting through Alias tables
+
+DROP TABLE IF EXISTS source_table;
+DROP TABLE IF EXISTS alias_table;
+DROP TABLE IF EXISTS mv_target;
+DROP TABLE IF EXISTS mv;
+
+-- Create source table
+CREATE TABLE source_table (id UInt32, value String) ENGINE = MergeTree ORDER BY id;
+
+-- Create MV target table and MV that triggers on source_table inserts
+CREATE TABLE mv_target (id UInt32, value String) ENGINE = MergeTree ORDER BY id;
+CREATE MATERIALIZED VIEW mv TO mv_target AS SELECT id, value FROM source_table;
+
+-- Create alias to source_table
+CREATE TABLE alias_table ENGINE = Alias('source_table') settings allow_experimental_alias_table_engine=1;
+
+-- Test 1: Direct insert to source_table triggers MV
+SELECT 'Direct insert to source_table';
+INSERT INTO source_table VALUES (1, 'direct');
+SELECT 'source_table count:', count() FROM source_table;
+SELECT 'mv_target count:', count() FROM mv_target;
+
+-- Test 2: Insert through alias also triggers MV
+SELECT 'Insert through alias_table';
+INSERT INTO alias_table VALUES (2, 'via_alias');
+SELECT 'source_table count:', count() FROM source_table;
+SELECT 'mv_target count:', count() FROM mv_target;
+
+DROP TABLE mv;
+DROP TABLE mv_target;
+DROP TABLE alias_table;
+DROP TABLE source_table;


### PR DESCRIPTION
With a table with `engine = Alias(src_table)` and a MV `select * from src_table`, inserts to the alias table now trigger the MV.  

Before this change, inserting data to an Alias table, would only trigger MVs that select from that table. As in:

**This is the behaviour in master**
```
create table src_table (id Int32) engine = MergeTree() order by tuple();
create table alias engine = Alias('src_table') settings allow_experimental_alias_table_engine;
create table mv_target (id Int32) engine = MergeTree() order by tuple();

-- Create MV reading from src_table
create materialized view mv_from_src to mv_target as select id from src_table;

-- Insert into Alias and check target
insert into alias values (1);
select count() from mv_target; -- This returns 0. The MV was not triggered

-- Drop MV and create MV from Alias
drop view mv_from_src;
create materialized view mv_from_alias to mv_target as select id from alias;

-- Insert into Alias and check target
insert into alias values (1);
select count() from mv_target; -- This returns 1. The MV is triggered, which I don't think it's deliberate.
```

There's a test that illustrates the behaviour after my change. TL;DR: first count returns 1, second count returns 0.


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

I am not 100% that this was undesired behaviour, but it's my best guess :)

### Changelog entry (leave one):

Inserts to an Alias table now trigger MVs with the Alias target as the source table, and don't trigger MVs with the alias itself as the source table.

