### PR TITLE
Improve posix compatibility for illumos.

### DIFF
--- a/base/base/getFQDNOrHostName.cpp
+++ b/base/base/getFQDNOrHostName.cpp
@@ -6,7 +6,7 @@ namespace
 {
     std::string getFQDNOrHostNameImpl()
     {
-#if defined(OS_DARWIN)
+#if defined(OS_DARWIN) || defined(OS_SUNOS)
         return Poco::Net::DNS::hostName();
 #else
         try

--- a/base/poco/Foundation/src/FPEnvironment_SUN.cpp
+++ b/base/poco/Foundation/src/FPEnvironment_SUN.cpp
@@ -64,7 +64,7 @@ bool FPEnvironmentImpl::isInfiniteImpl(double value)
 
 bool FPEnvironmentImpl::isInfiniteImpl(long double value)
 {
-	int cls = fpclass(value);
+	int cls = fpclass(static_cast<double>(value));
 	return cls == FP_PINF || cls == FP_NINF;
 }
 

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -1743,6 +1743,7 @@ try
         }
     }
 
+#if defined(RLIMIT_NPROC)
     /// Try to increase limit on number of threads.
     {
         rlimit rlim;
@@ -1777,6 +1778,7 @@ try
                     "Maximum number of threads is lower than 30000. There could be problems with handling a lot of simultaneous queries."));
         }
     }
+#endif
 
     static ServerErrorHandler error_handler;
     Poco::ErrorHandler::set(&error_handler);

--- a/src/Client/TerminalKeystrokeInterceptor.cpp
+++ b/src/Client/TerminalKeystrokeInterceptor.cpp
@@ -10,6 +10,9 @@
 #include <unistd.h>
 #include <base/defines.h>
 #include <sys/ioctl.h>
+#ifdef __sun
+#include <sys/filio.h>  // illumos defines FIONREAD in sys/filio.h, not sys/ioctl.h
+#endif
 
 namespace DB::ErrorCodes
 {


### PR DESCRIPTION
- Guard RLIMIT_NPROC usage; not defined on illumos.
- Include sys/filio.h for FIONREAD on illumos (not in sys/ioctl.h).
- Use DNS::hostName() instead of DNS::thisHost() on illumos.
- Fix fpclass() call for long double.

See also:
- https://github.com/oxidecomputer/garbage-compactor/blob/master/clickhouse/patches/0018-Do-not-try-to-increase-the-thread-limit-via-proc.patch

Part of #23777.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Second attempt at #93874, excluding statvfs changes, which are submitted separately with a fix in #93967.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.470`
<!-- ch-version-info:end -->