### PR TITLE
Docs: fix for failing docs check (unescaped `{` and `}`)

### DIFF
--- a/src/Core/FormatFactorySettings.h
+++ b/src/Core/FormatFactorySettings.h
@@ -547,7 +547,7 @@ Possible values:
 When enabled, during parsing JSON object into JSON type duplicated paths will be ignored and only the first one will be inserted instead of an exception
 )", 0) \
     DECLARE(Bool, type_json_allow_duplicated_key_with_literal_and_nested_object, false, R"(
-When enabled, JSONs like {"a" : 42, "a" : {"b" : 42}} where some key is duplicated but one of them is a nested object are allowed to be parsed.
+When enabled, JSONs like `{"a" : 42, "a" : {"b" : 42}}` where some key is duplicated but one of them is a nested object are allowed to be parsed.
 )", 0) \
     DECLARE(Bool, type_json_use_partial_match_to_skip_paths_by_regexp, true, R"(
 When enabled, during parsing JSON object into JSON type regular expressions specified using SKIP REGEXP will require partial match to skip a path. When disabled, full match will be required.


### PR DESCRIPTION
Fix for failing docs check:

```
[ERROR] Client bundle compiled with errors therefore further build is impossible.                                                                                                  
× Module build failed:
  ╰─▶   × Error: MDX compilation failed for file "clickhouse-docs/docs/operations/settings/settings-formats.md"
        │ Cause: Could not parse expression with acorn
        │ Details:
        │ {
        │   "cause": {
        │     "pos": 89284,
        │     "loc": {
        │       "line": 2281,
        │       "column": 29
        │     }
        │   },
        │   "column": 30,
        │   "message": "Could not parse expression with acorn",
        │   "line": 2281,
        │   "name": "2281:30",
        │   "place": {
        │     "line": 2281,
        │     "column": 30,
        │     "offset": 89284
        │   },
        │   "reason": "Could not parse expression with acorn",
        │   "ruleId": "acorn",
        │   "source": "micromark-extension-mdx-expression",
        │   "url": "https://github.com/micromark/micromark-extension-mdx-expression/tree/main/packages/micromark-extension-mdx-expression#could-not-parse-expression-with-acorn"
        │ }
```

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.459`
<!-- ch-version-info:end -->