### PR TITLE
Add ability to log only slow requests to zookeeper_log

### DIFF
--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -1486,6 +1486,16 @@
         <ttl>event_date + INTERVAL 30 DAY</ttl>
     </aggregated_zookeeper_log>
 
+    <!--
+    <zookeeper_log>
+        <database>system</database>
+        <table>zookeeper_log</table>
+        <partition_by>toYYYYMM(event_date)</partition_by>
+        <ttl>event_date + INTERVAL 30 DAY</ttl>
+        <duration_threshold_microseconds>0</duration_threshold_microseconds>
+    </zookeeper_log>
+    -->
+
     <!-- ZooKeeper connection log.
     -->
     <zookeeper_connection_log>

--- a/src/Common/ZooKeeper/ZooKeeperImpl.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperImpl.cpp
@@ -1892,6 +1892,9 @@ void ZooKeeper::logOperationIfNeeded(const ZooKeeperRequestPtr & request, const 
     if (!maybe_zk_log)
         return;
 
+    if (elapsed_microseconds < maybe_zk_log->getDurationMicrosecondsThreshold())
+        return;
+
     ZooKeeperLogElement::Type log_type = ZooKeeperLogElement::UNKNOWN;
     Decimal64 event_time = std::chrono::duration_cast<std::chrono::microseconds>(
                                std::chrono::system_clock::now().time_since_epoch()

--- a/src/Interpreters/SystemLog.cpp
+++ b/src/Interpreters/SystemLog.cpp
@@ -415,6 +415,12 @@ SystemLogs::SystemLogs(ContextPtr global_context, const Poco::Util::AbstractConf
         size_t duration_threshold_milliseconds = config.getUInt64("background_schedule_pool_log.duration_threshold_milliseconds", 30);
         background_schedule_pool_log->setDurationMillisecondsThreshold(duration_threshold_milliseconds);
     }
+
+    if (zookeeper_log)
+    {
+        size_t duration_threshold_microseconds = config.getUInt64("zookeeper_log.duration_threshold_microseconds", 0);
+        zookeeper_log->setDurationMicrosecondsThreshold(duration_threshold_microseconds);
+    }
 }
 
 std::vector<ISystemLog *> SystemLogs::getAllLogs() const

--- a/src/Interpreters/ZooKeeperLog.h
+++ b/src/Interpreters/ZooKeeperLog.h
@@ -78,6 +78,11 @@ struct ZooKeeperLogElement
 class ZooKeeperLog : public SystemLog<ZooKeeperLogElement>
 {
     using SystemLog<ZooKeeperLogElement>::SystemLog;
+    size_t duration_microseconds_threshold = 0;
+
+public:
+    void setDurationMicrosecondsThreshold(size_t duration_microseconds_threshold_) { duration_microseconds_threshold = duration_microseconds_threshold_; }
+    size_t getDurationMicrosecondsThreshold() const { return duration_microseconds_threshold; }
 };
 
 DataTypePtr getCoordinationErrorCodesEnumType();


### PR DESCRIPTION
zookeeper_log can be heavy, but having this information can help a lot for debugging tricky cases that involves keeper, and usually slow requests can help.

And here is some statistics about ops durations (from ci-logs) - https://pastila.nl/?03edf015/4a657d0fa4ec7717a205603f9bf6bc52#/WkHllBtBz1QDMTX4p4l6A==GCM

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add ability to log only slow requests to zookeeper_log


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.489`
<!-- ch-version-info:end -->