### PR TITLE
Fix runtime filter and merge table

### DIFF
--- a/tests/queries/0_stateless/03777_runtime_filter_and_merge_table.reference
+++ b/tests/queries/0_stateless/03777_runtime_filter_and_merge_table.reference
@@ -1,0 +1,18 @@
+Expression ((Project names + Projection))
+  Aggregating
+    Expression
+      Join (JOIN FillRightFirst)
+        Expression (Left Pre Join Actions)
+          ReadFromMerge
+            Filter
+              ReadFromMergeTree (default.foo)
+            Filter
+              ReadFromMergeTree (default.foo1)
+        Expression (Right Pre Join Actions)
+          BuildRuntimeFilter (Build runtime join filter on __table2.Val (_runtime_filter_UNIQ_ID_0))
+            Expression (Change column names to column identifiers)
+              ReadFromMemoryStorage
+=================================================
+20000
+=================================================
+20000

--- a/tests/queries/0_stateless/03777_runtime_filter_and_merge_table.sql
+++ b/tests/queries/0_stateless/03777_runtime_filter_and_merge_table.sql
@@ -1,0 +1,35 @@
+SET enable_analyzer=1;
+
+DROP TABLE IF EXISTS foo;
+DROP TABLE IF EXISTS foo1;
+DROP TABLE IF EXISTS foo_merge;
+DROP TABLE IF EXISTS t2;
+
+CREATE TABLE foo(Id Int32, Val Int32) Engine=MergeTree PARTITION BY Val ORDER BY Id;
+CREATE TABLE foo1(Id Int32, Val Decimal32(9)) Engine=MergeTree PARTITION BY Val ORDER BY Id;
+INSERT INTO foo SELECT number, number%5 FROM numbers(100000);
+INSERT INTO foo1 SELECT number, 1 FROM numbers(100000);
+
+CREATE TABLE foo_merge as foo ENGINE=Merge(currentDatabase(), '^foo');
+
+CREATE TABLE t2 (Id Int32, Val Int64, X UInt256) Engine=Memory;
+INSERT INTO t2 values (4, 3, 4);
+
+SELECT REGEXP_REPLACE(explain, '_runtime_filter_\\d+', '_runtime_filter_UNIQ_ID') FROM (
+EXPLAIN --header=1, actions=1
+SELECT count()
+FROM foo_merge JOIN t2 USING Val
+SETTINGS enable_join_runtime_filters=1, enable_parallel_replicas=1
+);
+
+SELECT '=================================================';
+
+SELECT count()
+FROM foo_merge JOIN t2 USING Val
+SETTINGS enable_join_runtime_filters=0;
+
+SELECT '=================================================';
+
+SELECT count()
+FROM foo_merge JOIN t2 USING Val
+SETTINGS enable_join_runtime_filters=1;

--- a/tests/queries/0_stateless/03777_runtime_filter_and_merge_table.sql
+++ b/tests/queries/0_stateless/03777_runtime_filter_and_merge_table.sql
@@ -16,7 +16,7 @@ CREATE TABLE t2 (Id Int32, Val Int64, X UInt256) Engine=Memory;
 INSERT INTO t2 values (4, 3, 4);
 
 SELECT REGEXP_REPLACE(explain, '_runtime_filter_\\d+', '_runtime_filter_UNIQ_ID') FROM (
-EXPLAIN --header=1, actions=1
+EXPLAIN
 SELECT count()
 FROM foo_merge JOIN t2 USING Val
 SETTINGS enable_join_runtime_filters=1, parallel_replicas_local_plan=1

--- a/tests/queries/0_stateless/03777_runtime_filter_and_merge_table.sql
+++ b/tests/queries/0_stateless/03777_runtime_filter_and_merge_table.sql
@@ -19,7 +19,7 @@ SELECT REGEXP_REPLACE(explain, '_runtime_filter_\\d+', '_runtime_filter_UNIQ_ID'
 EXPLAIN --header=1, actions=1
 SELECT count()
 FROM foo_merge JOIN t2 USING Val
-SETTINGS enable_join_runtime_filters=1, enable_parallel_replicas=1
+SETTINGS enable_join_runtime_filters=1, parallel_replicas_local_plan=1
 );
 
 SELECT '=================================================';


### PR DESCRIPTION
Previously if filter was added after child plans were built in Merge table, this new FilterStep was silently lost resulting in an error like this:
```
<Error> executeQuery: Code: 10. DB::Exception: Not found column __table1.Val: in block Val Int32 Int32(size = 0). (NOT_FOUND_COLUMN_IN_BLOCK) (version 26.1.1.1) (from 127.0.0.1:47674) (comment: 03777_runtime_filter_and_merge_table.sql-test_kgaxkuez) (query 17, line 33) (in query: SELECT count() FROM foo_merge JOIN t2 USING Val SETTINGS enable_join_runtime_filters=1;), Stack trace (when copying this message, always include the lines below):
```

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix for FilterStep not properly added when join runtime filter is applied over Merge table.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.497`
<!-- ch-version-info:end -->