### PR TITLE
Avoid crash in Connection::receivePacket

### DIFF
--- a/src/Client/Connection.cpp
+++ b/src/Client/Connection.cpp
@@ -1326,6 +1326,11 @@ Packet Connection::receivePacket()
 {
     try
     {
+        if (!in)
+        {
+            throw Exception(ErrorCodes::NETWORK_ERROR, "Connection to {} is terminated", getDescription());
+        }
+
         Packet res;
 
         /// Have we already read packet type?


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Avoid crash in Connection::receivePacket for distributed queries.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

```
2026-01-12 19:45:05	########## Short fault info ############
	2026-01-12 19:45:05	(version 25.8.1.8925 (official build), build id: A124FDEAC743B13E691520F468069EC91E3390AC, git hash: 06de24ca67e532316575219be78d5555b821812e, architecture: x86_64) (from thread 4260) Received signal 11
	2026-01-12 19:45:05	Signal description: Segmentation fault
	2026-01-12 19:45:05	Address: 0x8. Access: read. Address not mapped to object.
	2026-01-12 19:45:05	Stack trace: 0x000000001a3074ed 0x000000001a35121f 0x000000001a350f3e 0x00000000172a48a5 0x000000001a9f89f1 0x000000001a605036 0x000000001a624249 0x000000001a615d90 0x000000001a619c43 0x000000001388776b 0x000000001388eae6 0x0000000013884752 0x000000001388c21a 0x00007f01398d9ac3 0x00007f013996b8c0
	2026-01-12 19:45:05	########################################
	2026-01-12 19:45:05	(version 25.8.1.8925 (official build), build id: A124FDEAC743B13E691520F468069EC91E3390AC, git hash: 06de24ca67e532316575219be78d5555b821812e) (from thread 4260) (query_id: 9b792dfb-62a8-4cda-bc20-f24fc3391f8b) (query: WITH sampledKeys AS (SELECT LogAttributes.keys AS keysArr FROM otel.otel_cploghouse_logs_1_distributed LIMIT _CAST(3000000, \'Int32\')) SELECT DISTINCT lowCardinalityKeys(arrayJoin(keysArr)) AS key FROM sampledKeys LIMIT _CAST(1000, \'Int32\') FORMAT JSON) Received signal Segmentation fault (11)
	2026-01-12 19:45:05	Address: 0x8. Access: read. Address not mapped to object.
	2026-01-12 19:45:05	Stack trace: 0x000000001a3074ed 0x000000001a35121f 0x000000001a350f3e 0x00000000172a48a5 0x000000001a9f89f1 0x000000001a605036 0x000000001a624249 0x000000001a615d90 0x000000001a619c43 0x000000001388776b 0x000000001388eae6 0x0000000013884752 0x000000001388c21a 0x00007f01398d9ac3 0x00007f013996b8c0
	2026-01-12 19:45:05	2.0. inlined from ./src/IO/VarInt.h:98: DB::readVarUInt(unsigned long&, DB::ReadBuffer&)
	2026-01-12 19:45:05	2. ./ci/tmp/build/./src/Client/Connection.cpp:1310: DB::Connection::receivePacket() @ 0x000000001a3074ed
	2026-01-12 19:45:05	3. ./ci/tmp/build/./src/Client/MultiplexedConnections.cpp:398: DB::MultiplexedConnections::receivePacketUnlocked(std::function<void (int, Poco::Timespan, DB::AsyncEventTimeoutType, String const&, unsigned int)>) @ 0x000000001a35121f
	2026-01-12 19:45:05	4. ./ci/tmp/build/./src/Client/MultiplexedConnections.cpp:253: DB::MultiplexedConnections::receivePacket() @ 0x000000001a350f3e
	2026-01-12 19:45:05	5. ./ci/tmp/build/./src/QueryPipeline/RemoteQueryExecutor.cpp:808: DB::RemoteQueryExecutor::finish() @ 0x00000000172a48a5
	2026-01-12 19:45:05	6. ./ci/tmp/build/./src/Processors/Sources/RemoteSource.cpp:216: DB::RemoteSource::tryGenerate() @ 0x000000001a9f89f1
	2026-01-12 19:45:05	7. ./ci/tmp/build/./src/Processors/ISource.cpp:110: DB::ISource::work() @ 0x000000001a605036
	2026-01-12 19:45:05	8.0. inlined from ./ci/tmp/build/./src/Processors/Executors/ExecutionThreadContext.cpp:53: DB::executeJob(DB::ExecutingGraph::Node*, DB::ReadProgressCallback*)
	2026-01-12 19:45:05	8. ./ci/tmp/build/./src/Processors/Executors/ExecutionThreadContext.cpp:102: DB::ExecutionThreadContext::executeTask() @ 0x000000001a624249
	2026-01-12 19:45:05	9. ./ci/tmp/build/./src/Processors/Executors/PipelineExecutor.cpp:351: DB::PipelineExecutor::executeStepImpl(unsigned long, DB::IAcquiredSlot*, std::atomic<bool>*) @ 0x000000001a615d90
	2026-01-12 19:45:05	10.0. inlined from ./ci/tmp/build/./src/Processors/Executors/PipelineExecutor.cpp:279: DB::PipelineExecutor::executeSingleThread(unsigned long, DB::IAcquiredSlot*)
	2026-01-12 19:45:05	10.1. inlined from ./ci/tmp/build/./src/Processors/Executors/PipelineExecutor.cpp:565: operator()
	2026-01-12 19:45:05	10.2. inlined from ./contrib/llvm-project/libcxx/include/__type_traits/invoke.h:149: decltype(std::declval<DB::PipelineExecutor::spawnThreads(std::shared_ptr<DB::IAcquiredSlot>)::$_0&>()()) std::__invoke[abi:ne190107]<DB::PipelineExecutor::spawnThreads(std::shared_ptr<DB::IAcquiredSlot>)::$_0&>(DB::PipelineExecutor::spawnThreads(std::shared_ptr<DB::IAcquiredSlot>)::$_0&)
	2026-01-12 19:45:05	10.3. inlined from ./contrib/llvm-project/libcxx/include/__type_traits/invoke.h:224: void std::__invoke_void_return_wrapper<void, true>::__call[abi:ne190107]<DB::PipelineExecutor::spawnThreads(std::shared_ptr<DB::IAcquiredSlot>)::$_0&>(DB::PipelineExecutor::spawnThreads(std::shared_ptr<DB::IAcquiredSlot>)::$_0&)
	2026-01-12 19:45:05	10.4. inlined from ./contrib/llvm-project/libcxx/include/__functional/function.h:210: ?
	2026-01-12 19:45:05	10. ./contrib/llvm-project/libcxx/include/__functional/function.h:610: ? @ 0x000000001a619c43
	2026-01-12 19:45:05	11.0. inlined from ./contrib/llvm-project/libcxx/include/__functional/function.h:716: ?
	2026-01-12 19:45:05	11.1. inlined from ./contrib/llvm-project/libcxx/include/__functional/function.h:989: ?
	2026-01-12 19:45:05	11. ./ci/tmp/build/./src/Common/ThreadPool.cpp:802: ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::worker() @ 0x000000001388776b
	2026-01-12 19:45:05	12.0. inlined from ./contrib/llvm-project/libcxx/include/__type_traits/invoke.h:117: decltype(*std::declval<ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&>().*std::declval<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)()>()()) std::__invoke[abi:ne190107]<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&, void>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&)
	2026-01-12 19:45:05	12.1. inlined from ./contrib/llvm-project/libcxx/include/tuple:1354: decltype(auto) std::__apply_tuple_impl[abi:ne190107]<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)(), std::tuple<ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>&, 0ul>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)(), std::tuple<ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>&, std::__tuple_indices<0ul>)
	2026-01-12 19:45:05	12.2. inlined from ./contrib/llvm-project/libcxx/include/tuple:1358: decltype(auto) std::apply[abi:ne190107]<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)(), std::tuple<ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>&>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&)(), std::tuple<ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>&)
	2026-01-12 19:45:05	12.3. inlined from ./src/Common/ThreadPool.h:312: operator()
	2026-01-12 19:45:05	12.4. inlined from ./contrib/llvm-project/libcxx/include/__type_traits/invoke.h:149: decltype(std::declval<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)()>()(std::declval<ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>())) std::__invoke[abi:ne190107]<ThreadFromGlobalPoolImpl<false, true>::ThreadFromGlobalPoolImpl<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&)::\'lambda\'()&>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&)
	2026-01-12 19:45:05	12.5. inlined from ./contrib/llvm-project/libcxx/include/__type_traits/invoke.h:224: void std::__invoke_void_return_wrapper<void, true>::__call[abi:ne190107]<ThreadFromGlobalPoolImpl<false, true>::ThreadFromGlobalPoolImpl<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&)::\'lambda\'()&>(ThreadFromGlobalPoolImpl<false, true>::ThreadFromGlobalPoolImpl<void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*>(void (ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool*&&)::\'lambda\'()&)
	2026-01-12 19:45:05	12.6. inlined from ./contrib/llvm-project/libcxx/include/__functional/function.h:210: ?
	2026-01-12 19:45:05	12. ./contrib/llvm-project/libcxx/include/__functional/function.h:610: ? @ 0x000000001388eae6
	2026-01-12 19:45:05	13.0. inlined from ./contrib/llvm-project/libcxx/include/__functional/function.h:716: ?
	2026-01-12 19:45:05	13.1. inlined from ./contrib/llvm-project/libcxx/include/__functional/function.h:989: ?
	2026-01-12 19:45:05	13. ./ci/tmp/build/./src/Common/ThreadPool.cpp:812: ThreadPoolImpl<std::thread>::ThreadFromThreadPool::worker() @ 0x0000000013884752
	2026-01-12 19:45:05	14.0. inlined from ./contrib/llvm-project/libcxx/include/__type_traits/invoke.h:117: decltype(*std::declval<ThreadPoolImpl<std::thread>::ThreadFromThreadPool*>().*std::declval<void (ThreadPoolImpl<std::thread>::ThreadFromThreadPool::*)()>()()) std::__invoke[abi:ne190107]<void (ThreadPoolImpl<std::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::thread>::ThreadFromThreadPool*, void>(void (ThreadPoolImpl<std::thread>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<std::thread>::ThreadFromThreadPool*&&)
	2026-01-12 19:45:05	14.1. inlined from ./contrib/llvm-project/libcxx/include/__thread/thread.h:192: void std::__thread_execute[abi:ne190107]<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void (ThreadPoolImpl<std::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::thread>::ThreadFromThreadPool*, 2ul>(std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void (ThreadPoolImpl<std::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::thread>::ThreadFromThreadPool*>&, std::__tuple_indices<2ul>)
	2026-01-12 19:45:05	14. ./contrib/llvm-project/libcxx/include/__thread/thread.h:201: void* std::__thread_proxy[abi:ne190107]<std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void (ThreadPoolImpl<std::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::thread>::ThreadFromThreadPool*>>(void*) @ 0x000000001388c21a
	2026-01-12 19:45:05	15. ? @ 0x0000000000094ac3
	2026-01-12 19:45:05	16. ? @ 0x00000000001268c0
	2026-01-12 19:45:05	Integrity check of the executable successfully passed (checksum: EA1AF986D1EAC23F8E311F678B1F2EC7)

```
