### PR TITLE
Fix CLEAR column with dependent indices

### DIFF
--- a/src/Interpreters/MutationsInterpreter.cpp
+++ b/src/Interpreters/MutationsInterpreter.cpp
@@ -1086,7 +1086,7 @@ void MutationsInterpreter::prepare(bool dry_run)
                     for (const auto & index : metadata_snapshot->getSecondaryIndices())
                     {
                         const auto & index_cols = index.expression->getRequiredColumns();
-                        if (std::ranges::find(index_cols, command.column_name) != index_cols.end())
+                        if (std::find(index_cols.begin(), index_cols.end(), command.column_name) != index_cols.end())
                         {
                             switch (index_mode)
                             {
@@ -1117,7 +1117,7 @@ void MutationsInterpreter::prepare(bool dry_run)
             for (const auto & index : metadata_snapshot->getSecondaryIndices())
             {
                 const auto & index_cols = index.expression->getRequiredColumns();
-                if (std::ranges::find(index_cols, command.column_name) != index_cols.end())
+                if (std::find(index_cols.begin(), index_cols.end(), command.column_name) != index_cols.end())
                     dropped_indices.insert(index.name);
             }
         }

--- a/src/Interpreters/MutationsInterpreter.cpp
+++ b/src/Interpreters/MutationsInterpreter.cpp
@@ -772,7 +772,7 @@ void MutationsInterpreter::prepare(bool dry_run)
                 stages.back().filters.push_back(predicate);
             }
 
-            /// ALTER DELETE can changes number of rows in the part, so we need to rebuild indexes and projection
+            /// ALTER DELETE can change the number of rows in the part, so we need to rebuild indexes and projection
             need_rebuild_projections = true;
             need_rebuild_indexes_for_update_delete = true;
         }

--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -1279,10 +1279,9 @@ void AlterCommands::apply(StorageInMemoryMetadata & metadata, ContextPtr context
         {
             index = IndexDescription::getIndexFromAST(index.definition_ast, metadata_copy.columns, index.isImplicitlyCreated(), context);
         }
-        catch (Exception & exception)
+        catch (const Exception & exception)
         {
-            exception.addMessage("Cannot apply mutation because it breaks skip index " + index.name);
-            throw;
+            throw Exception(ErrorCodes::ALTER_OF_COLUMN_IS_FORBIDDEN, "Cannot apply ALTER because it breaks skip index {}: {}", index.name, exception.message());
         }
     }
 
@@ -1302,10 +1301,9 @@ void AlterCommands::apply(StorageInMemoryMetadata & metadata, ContextPtr context
             performRequiredConversions(old_projection_block, new_projection.sample_block.getNamesAndTypesList(), context, metadata_copy.getColumns().getDefaults());
             new_projections.add(std::move(new_projection));
         }
-        catch (Exception & exception)
+        catch (const Exception & exception)
         {
-            exception.addMessage("Cannot apply mutation because it breaks projection " + projection.name);
-            throw;
+            throw Exception(ErrorCodes::ALTER_OF_COLUMN_IS_FORBIDDEN, "Cannot apply ALTER because it breaks projection {}: {}", projection.name, exception.message());
         }
     }
     metadata_copy.projections = std::move(new_projections);

--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -1281,7 +1281,7 @@ void AlterCommands::apply(StorageInMemoryMetadata & metadata, ContextPtr context
         }
         catch (const Exception & exception)
         {
-            throw Exception(ErrorCodes::ALTER_OF_COLUMN_IS_FORBIDDEN, "Cannot apply ALTER because it breaks skip index {}: {}", index.name, exception.message());
+            throw Exception(exception.code(), "Cannot apply ALTER because it breaks skip index {}: {}", index.name, exception.message());
         }
     }
 
@@ -1303,7 +1303,7 @@ void AlterCommands::apply(StorageInMemoryMetadata & metadata, ContextPtr context
         }
         catch (const Exception & exception)
         {
-            throw Exception(ErrorCodes::ALTER_OF_COLUMN_IS_FORBIDDEN, "Cannot apply ALTER because it breaks projection {}: {}", projection.name, exception.message());
+            throw Exception(exception.code(), "Cannot apply ALTER because it breaks projection {}: {}", projection.name, exception.message());
         }
     }
     metadata_copy.projections = std::move(new_projections);

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -4376,8 +4376,9 @@ void MergeTreeData::checkAlterIsPossible(const AlterCommands & commands, Context
             else
             {
                 /// In the case of CLEAR we want to respect `alter_column_secondary_index_mode` and we will throw if the setting is
-                /// set to `THROW` and we will clear the index files (as we do with the column files) in any other case
-                if (index_mode == AlterColumnSecondaryIndexMode::THROW)
+                /// set to `THROW` or `COMPATIBILITY` (since before this would have failed in the mutation) and
+                /// we will clear the index files (as we do with the column files) in any other case
+                if (index_mode == AlterColumnSecondaryIndexMode::THROW || index_mode == AlterColumnSecondaryIndexMode::COMPATIBILITY)
                 {
                     if (auto it = columns_in_indices.find(command.column_name); it != columns_in_indices.end())
                     {

--- a/src/Storages/MergeTree/MutateTask.cpp
+++ b/src/Storages/MergeTree/MutateTask.cpp
@@ -323,7 +323,13 @@ static void splitAndModifyMutationCommands(
                         mutated_columns.emplace(command.column_name);
 
                     if (command.type == MutationCommand::Type::DROP_COLUMN)
-                        dropped_columns.emplace(command.column_name);
+                    {
+                        /// We need to keep the clear command to also know to clear dependent indices
+                        if (command.clear)
+                            for_interpreter.push_back(command);
+                        else
+                            dropped_columns.emplace(command.column_name);
+                    }
                 }
             }
         }

--- a/src/Storages/MergeTree/MutateTask.cpp
+++ b/src/Storages/MergeTree/MutateTask.cpp
@@ -326,7 +326,10 @@ static void splitAndModifyMutationCommands(
                     {
                         /// We need to keep the clear command so we also clear dependent indices
                         if (command.clear)
+                        {
                             for_interpreter.push_back(command);
+                            for_file_renames.push_back(command); /// For packed parts
+                        }
                         else
                             dropped_columns.emplace(command.column_name);
                     }
@@ -1691,8 +1694,11 @@ private:
         NameSet entries_to_hardlink;
         NameSet removed_indices;
         NameSet removed_stats;
+        NameSet removed_projections;
         /// A stat file need to be renamed iff the column is renamed.
         NameToNameMap renamed_stats;
+
+        bool is_full_part_storage = isFullPartStorage(ctx->new_data_part->getDataPartStorage());
 
         for (const auto & command : ctx->for_file_renames)
         {
@@ -1705,7 +1711,11 @@ private:
                 auto current_removed_stats = MutationHelpers::getRemovedStatistics(ctx->metadata_snapshot, command);
                 std::move(current_removed_stats.begin(), current_removed_stats.end(), std::inserter(removed_stats, removed_stats.end()));
             }
-            else if (command.type == MutationCommand::RENAME_COLUMN)
+            else if (command.type == MutationCommand::DROP_COLUMN)
+            {
+                removed_stats.insert(command.column_name);
+            }
+            else if (command.type == MutationCommand::RENAME_COLUMN && is_full_part_storage)
             {
                 if (auto filename = MutationHelpers::getStatisticFilename(STATS_FILE_PREFIX + command.column_name, *ctx->source_part))
                 {
@@ -1713,9 +1723,12 @@ private:
                     renamed_stats[*filename] = std::move(new_filename);
                 }
             }
+            else if (command.type == MutationCommand::DROP_PROJECTION)
+            {
+                removed_projections.insert(command.column_name);
+            }
         }
 
-        bool is_full_part_storage = isFullPartStorage(ctx->source_part->getDataPartStorage());
         bool is_full_wide_part = is_full_part_storage && isWidePart(ctx->new_data_part);
         const auto & indices = ctx->metadata_snapshot->getSecondaryIndices();
 
@@ -1778,13 +1791,6 @@ private:
                     ctx->existing_indices_stats_checksums.addFile(*stat_filename, checksum);
                 }
             }
-        }
-
-        NameSet removed_projections;
-        for (const auto & command : ctx->for_file_renames)
-        {
-            if (command.type == MutationCommand::DROP_PROJECTION)
-                removed_projections.insert(command.column_name);
         }
 
         bool lightweight_delete_mode = ctx->updated_header.has(RowExistsColumn::name);

--- a/src/Storages/MergeTree/MutateTask.cpp
+++ b/src/Storages/MergeTree/MutateTask.cpp
@@ -324,7 +324,7 @@ static void splitAndModifyMutationCommands(
 
                     if (command.type == MutationCommand::Type::DROP_COLUMN)
                     {
-                        /// We need to keep the clear command to also know to clear dependent indices
+                        /// We need to keep the clear command so we also clear dependent indices
                         if (command.clear)
                             for_interpreter.push_back(command);
                         else

--- a/tests/queries/0_stateless/03786_clear_column_with_alias_and_index.reference
+++ b/tests/queries/0_stateless/03786_clear_column_with_alias_and_index.reference
@@ -1,0 +1,2 @@
+alias_before_clear	0	255
+alias_after_clear	0	0

--- a/tests/queries/0_stateless/03786_clear_column_with_alias_and_index.sql
+++ b/tests/queries/0_stateless/03786_clear_column_with_alias_and_index.sql
@@ -1,0 +1,18 @@
+DROP TABLE IF EXISTS test;
+CREATE TABLE test
+    (
+        x UInt8,
+        INDEX x_idx x TYPE minmax GRANULARITY 1,
+        z String DEFAULT 'Hello'
+    )
+    ENGINE = MergeTree ORDER BY tuple()
+    SETTINGS add_minmax_index_for_numeric_columns=0, alter_column_secondary_index_mode='throw';
+ALTER TABLE test CLEAR COLUMN x; -- { serverError ALTER_OF_COLUMN_IS_FORBIDDEN }
+ALTER TABLE test MODIFY SETTING alter_column_secondary_index_mode='rebuild', min_bytes_for_wide_part=1000;
+INSERT INTO test (x) SELECT number FROM numbers(1); -- Compact / packed
+INSERT INTO test (x) SELECT number FROM numbers(10000); -- Wide
+SELECT 'alias_before_clear', min(x), max(x) FROM test;
+ALTER TABLE test DROP COLUMN x; -- { serverError ALTER_OF_COLUMN_IS_FORBIDDEN }
+ALTER TABLE test CLEAR COLUMN x;
+SELECT 'alias_after_clear', min(x), max(x) FROM test;
+DROP TABLE test;

--- a/tests/queries/0_stateless/03786_clear_column_with_alias_and_index.sql
+++ b/tests/queries/0_stateless/03786_clear_column_with_alias_and_index.sql
@@ -6,9 +6,11 @@ CREATE TABLE test
         z String DEFAULT 'Hello'
     )
     ENGINE = MergeTree ORDER BY tuple()
-    SETTINGS add_minmax_index_for_numeric_columns=0, alter_column_secondary_index_mode='throw';
+    SETTINGS add_minmax_index_for_numeric_columns=0, min_bytes_for_wide_part=1000, alter_column_secondary_index_mode='throw';
 ALTER TABLE test CLEAR COLUMN x; -- { serverError ALTER_OF_COLUMN_IS_FORBIDDEN }
-ALTER TABLE test MODIFY SETTING alter_column_secondary_index_mode='rebuild', min_bytes_for_wide_part=1000;
+ALTER TABLE test MODIFY SETTING alter_column_secondary_index_mode='compatibility';
+ALTER TABLE test CLEAR COLUMN x; -- { serverError ALTER_OF_COLUMN_IS_FORBIDDEN }
+ALTER TABLE test MODIFY SETTING alter_column_secondary_index_mode='rebuild';
 INSERT INTO test (x) SELECT number FROM numbers(1); -- Compact / packed
 INSERT INTO test (x) SELECT number FROM numbers(10000); -- Wide
 SELECT 'alias_before_clear', min(x), max(x) FROM test;

--- a/tests/queries/0_stateless/03786_clear_column_with_alias_and_index.sql
+++ b/tests/queries/0_stateless/03786_clear_column_with_alias_and_index.sql
@@ -14,7 +14,7 @@ ALTER TABLE test MODIFY SETTING alter_column_secondary_index_mode='rebuild';
 INSERT INTO test (x) SELECT number FROM numbers(1); -- Compact / packed
 INSERT INTO test (x) SELECT number FROM numbers(10000); -- Wide
 SELECT 'alias_before_clear', min(x), max(x) FROM test;
-ALTER TABLE test DROP COLUMN x; -- { serverError ALTER_OF_COLUMN_IS_FORBIDDEN }
+ALTER TABLE test DROP COLUMN x; -- { serverError UNKNOWN_IDENTIFIER }
 ALTER TABLE test CLEAR COLUMN x;
 SELECT 'alias_after_clear', min(x), max(x) FROM test;
 DROP TABLE test;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix CLEAR column with dependent indices

* Now it respects `alter_column_secondary_index_mode`. For `throw` or `compatibility` it will throw during the analysis (instead of the mutation) if the referenced column has dependent indices. For `rebuild` or `drop` it will drop the indices files (as we drop the column files).
* Improves the error messages for `DROP column` since they were really confusing as the explanation was appended after a long error which wasn't clear. Now it's the other way around.

References https://github.com/ClickHouse/ClickHouse/pull/76867
Closes https://github.com/ClickHouse/ClickHouse/issues/93901

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.581`
<!-- ch-version-info:end -->