### PR TITLE
Fix flaky test `02310_clickhouse_client_INSERT_progress_profile_events.expect`

### DIFF
--- a/tests/queries/0_stateless/02310_clickhouse_client_INSERT_progress_profile_events.expect
+++ b/tests/queries/0_stateless/02310_clickhouse_client_INSERT_progress_profile_events.expect
@@ -33,6 +33,8 @@ send "yes | head -n10000000 | \$CLICKHOUSE_CLIENT --progress --query \"insert in
 expect "Progress: "
 send "\3"
 expect "bash) "
+send "\r"
+expect "bash) "
 
 send "exit\r"
 expect eof


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

Closes https://github.com/ClickHouse/ClickHouse/issues/68531

See https://s3.amazonaws.com/clickhouse-test-reports/REFs/master/2a0e1ee7cfdc9e83f20b5ca89526b23f5d945cd2//stateless_tests_amd_binary_old_analyzer_s3_storage_databasereplicated_parallel/job.log

Note: I didn't find the explanation plausible, but the fix should help:

> After sending Ctrl+C to interrupt a command, the terminal may still be in a transitional state when the next command is sent. This can cause the first character to be lost (e.g., "exit" becomes "xit").

> Add a sync line after Ctrl+C to ensure the terminal is fully settled before sending the exit command.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.483`
<!-- ch-version-info:end -->