### PR TITLE
BOM option to s3 insertion

### DIFF
--- a/src/Core/FormatFactorySettings.h
+++ b/src/Core/FormatFactorySettings.h
@@ -32,6 +32,9 @@ If it set to true, then separate columns written in CSV format can be deserializ
     DECLARE(Bool, output_format_csv_crlf_end_of_line, false, R"(
 If it is set true, end of line in CSV format will be \\r\\n instead of \\n.
 )", 0) \
+    DECLARE(Bool, output_format_csv_write_bom, false, R"(
+If enabled, write UTF-8 BOM (Byte Order Mark) at the beginning of CSV output. This helps Excel correctly identify the file encoding.
+)", 0) \
     DECLARE(Bool, input_format_csv_allow_cr_end_of_line, false, R"(
 If it is set true, \\r will be allowed at end of line not followed by \\n
 )", 0) \
@@ -1174,6 +1177,9 @@ Max rows in a file (if permitted by storage)
 )", 0) \
     DECLARE(Bool, output_format_tsv_crlf_end_of_line, false, R"(
 If it is set true, end of line in TSV format will be \\r\\n instead of \\n.
+)", 0) \
+    DECLARE(Bool, output_format_tsv_write_bom, false, R"(
+If enabled, write UTF-8 BOM (Byte Order Mark) at the beginning of TSV output. This helps Excel correctly identify the file encoding.
 )", 0) \
     DECLARE(String, format_csv_null_representation, "\\N", R"(
 Custom NULL representation in CSV format

--- a/src/Formats/FormatFactory.cpp
+++ b/src/Formats/FormatFactory.cpp
@@ -110,6 +110,7 @@ FormatSettings getFormatSettings(const ContextPtr & context, const Settings & se
     format_settings.csv.serialize_tuple_into_separate_columns = settings[Setting::output_format_csv_serialize_tuple_into_separate_columns];
     format_settings.csv.deserialize_separate_columns_into_tuple = settings[Setting::input_format_csv_deserialize_separate_columns_into_tuple];
     format_settings.csv.crlf_end_of_line = settings[Setting::output_format_csv_crlf_end_of_line];
+    format_settings.csv.write_bom = settings[Setting::output_format_csv_write_bom];
     format_settings.csv.allow_cr_end_of_line = settings[Setting::input_format_csv_allow_cr_end_of_line];
     format_settings.csv.delimiter = settings[Setting::format_csv_delimiter];
     format_settings.csv.tuple_delimiter = settings[Setting::format_csv_delimiter];
@@ -278,6 +279,7 @@ FormatSettings getFormatSettings(const ContextPtr & context, const Settings & se
     format_settings.template_settings.row_format_template = settings[Setting::format_template_row_format];
     format_settings.template_settings.resultset_format_template = settings[Setting::format_template_resultset_format];
     format_settings.tsv.crlf_end_of_line = settings[Setting::output_format_tsv_crlf_end_of_line];
+    format_settings.tsv.write_bom = settings[Setting::output_format_tsv_write_bom];
     format_settings.tsv.empty_as_default = settings[Setting::input_format_tsv_empty_as_default];
     format_settings.tsv.enum_as_number = settings[Setting::input_format_tsv_enum_as_number];
     format_settings.tsv.null_representation = settings[Setting::format_tsv_null_representation];

--- a/src/Formats/FormatSettings.h
+++ b/src/Formats/FormatSettings.h
@@ -202,6 +202,7 @@ struct FormatSettings
         bool use_default_on_bad_values = false;
         bool try_infer_numbers_from_strings = true;
         bool try_infer_strings_from_quoted_tuples = true;
+        bool write_bom = false;
     } csv{};
 
     struct HiveText
@@ -454,6 +455,7 @@ struct FormatSettings
         bool skip_trailing_empty_lines = false;
         bool allow_variable_number_of_columns = false;
         bool crlf_end_of_line_input = false;
+        bool write_bom = false;
     } tsv{};
 
     struct

--- a/src/Processors/Formats/Impl/CSVRowOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/CSVRowOutputFormat.cpp
@@ -33,6 +33,9 @@ void CSVRowOutputFormat::writeLine(const std::vector<String> & values)
 
 void CSVRowOutputFormat::writePrefix()
 {
+    if (format_settings.csv.write_bom)
+        out.write("\xEF\xBB\xBF", 3);
+
     const auto & sample = getPort(PortKind::Main).getHeader();
 
     if (with_names)

--- a/src/Processors/Formats/Impl/TabSeparatedRowOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/TabSeparatedRowOutputFormat.cpp
@@ -36,6 +36,9 @@ void TabSeparatedRowOutputFormat::writeLine(const std::vector<String> & values)
 
 void TabSeparatedRowOutputFormat::writePrefix()
 {
+    if (format_settings.tsv.write_bom)
+        out.write("\xEF\xBB\xBF", 3);
+
     const auto & header = getPort(PortKind::Main).getHeader();
 
     if (with_names)

--- a/tests/queries/0_stateless/03788_csv_tsv_write_bom.reference
+++ b/tests/queries/0_stateless/03788_csv_tsv_write_bom.reference
@@ -1,0 +1,14 @@
+﻿1,"hello"
+2,"world"
+1,"hello"
+2,"world"
+﻿"id","name"
+1,"hello"
+2,"world"
+﻿1	hello
+2	world
+1	hello
+2	world
+﻿id	name
+1	hello
+2	world

--- a/tests/queries/0_stateless/03788_csv_tsv_write_bom.sql
+++ b/tests/queries/0_stateless/03788_csv_tsv_write_bom.sql
@@ -1,0 +1,25 @@
+-- Tags: no-parallel
+
+DROP TABLE IF EXISTS test_03788_bom;
+CREATE TABLE test_03788_bom (id UInt8, name String) ENGINE = MergeTree() ORDER BY id;
+INSERT INTO test_03788_bom VALUES (1, 'hello'), (2, 'world');
+
+-- Test CSV with BOM
+SELECT * FROM test_03788_bom FORMAT CSV SETTINGS output_format_csv_write_bom = 1;
+
+-- Test CSV without BOM (default)
+SELECT * FROM test_03788_bom FORMAT CSV;
+
+-- Test CSVWithNames with BOM
+SELECT * FROM test_03788_bom FORMAT CSVWithNames SETTINGS output_format_csv_write_bom = 1;
+
+-- Test TSV with BOM
+SELECT * FROM test_03788_bom FORMAT TabSeparated SETTINGS output_format_tsv_write_bom = 1;
+
+-- Test TSV without BOM (default)
+SELECT * FROM test_03788_bom FORMAT TabSeparated;
+
+-- Test TSVWithNames with BOM
+SELECT * FROM test_03788_bom FORMAT TabSeparatedWithNames SETTINGS output_format_tsv_write_bom = 1;
+
+DROP TABLE test_03788_bom;


### PR DESCRIPTION
### Changelog category (leave one):
- New Feature (Fixes #91825 )

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
- Introduce BOM encoding option for s3 CSV/TAB insertion

### Documentation entry for user-facing changes

If enabled, write UTF-8 BOM (Byte Order Mark) at the beginning of CSV output. This helps Excel correctly identify the file encoding.

Usage:
```sql
CREATE TABLE test (id UInt8, name String) ENGINE = MergeTree() ORDER BY id;
INSERT INTO test VALUES (1, 'hello'), (2, 'world');
SELECT * FROM test FORMAT TabSeparated SETTINGS output_format_tsv_write_bom = 1;
```