### PR TITLE
Add specialized AST nodes for Enum, Decimal, DateTime64, FixedString data types

### DIFF
--- a/src/Parsers/ASTDateTime64DataType.cpp
+++ b/src/Parsers/ASTDateTime64DataType.cpp
@@ -1,0 +1,45 @@
+#include <Parsers/ASTDateTime64DataType.h>
+#include <Common/SipHash.h>
+#include <IO/Operators.h>
+#include <IO/WriteHelpers.h>
+
+
+namespace DB
+{
+
+String ASTDateTime64DataType::getID(char delim) const
+{
+    return "DateTime64DataType" + (delim + name);
+}
+
+ASTPtr ASTDateTime64DataType::clone() const
+{
+    auto res = std::make_shared<ASTDateTime64DataType>(*this);
+    res->children.clear();
+    return res;
+}
+
+void ASTDateTime64DataType::updateTreeHashImpl(SipHash & hash_state, bool /*ignore_aliases*/) const
+{
+    hash_state.update(name.size());
+    hash_state.update(name);
+    hash_state.update(precision);
+    hash_state.update(timezone.size());
+    hash_state.update(timezone);
+}
+
+void ASTDateTime64DataType::formatImpl(WriteBuffer & ostr, const FormatSettings & /*settings*/, FormatState & /*state*/, FormatStateStacked /*frame*/) const
+{
+    ostr << name << '(';
+    writeText(precision, ostr);
+
+    if (!timezone.empty())
+    {
+        ostr << ", ";
+        writeQuotedString(timezone, ostr);
+    }
+
+    ostr << ')';
+}
+
+}

--- a/src/Parsers/ASTDateTime64DataType.h
+++ b/src/Parsers/ASTDateTime64DataType.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <Parsers/ASTDataType.h>
+
+
+namespace DB
+{
+
+/// Specialized AST for DateTime64 data type
+/// Stores precision and timezone directly as fields instead of ASTLiteral children.
+class ASTDateTime64DataType : public ASTDataType
+{
+public:
+    UInt32 precision = 3;  /// Default precision is 3 (milliseconds)
+    String timezone;       /// Optional timezone
+
+    String getID(char delim) const override;
+    ASTPtr clone() const override;
+    void updateTreeHashImpl(SipHash & hash_state, bool ignore_aliases) const override;
+
+protected:
+    /// Outputs: DateTime64(precision) or DateTime64(precision, 'timezone')
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+};
+
+}

--- a/src/Parsers/ASTDecimalDataType.cpp
+++ b/src/Parsers/ASTDecimalDataType.cpp
@@ -2,6 +2,7 @@
 #include <Common/SipHash.h>
 #include <IO/Operators.h>
 #include <IO/WriteHelpers.h>
+#include <Poco/String.h>
 
 
 namespace DB
@@ -32,8 +33,9 @@ void ASTDecimalDataType::formatImpl(WriteBuffer & ostr, const FormatSettings & /
     ostr << name << '(';
 
     /// Decimal32, Decimal64, Decimal128, Decimal256 only have scale parameter
-    /// Decimal has both precision and scale
-    if (name == "Decimal")
+    /// Decimal has both precision and scale (case-insensitive comparison)
+    String name_upper = Poco::toUpper(name);
+    if (name_upper == "DECIMAL")
     {
         writeText(precision, ostr);
         ostr << ", ";

--- a/src/Parsers/ASTDecimalDataType.cpp
+++ b/src/Parsers/ASTDecimalDataType.cpp
@@ -1,0 +1,46 @@
+#include <Parsers/ASTDecimalDataType.h>
+#include <Common/SipHash.h>
+#include <IO/Operators.h>
+#include <IO/WriteHelpers.h>
+
+
+namespace DB
+{
+
+String ASTDecimalDataType::getID(char delim) const
+{
+    return "DecimalDataType" + (delim + name);
+}
+
+ASTPtr ASTDecimalDataType::clone() const
+{
+    auto res = std::make_shared<ASTDecimalDataType>(*this);
+    res->children.clear();
+    return res;
+}
+
+void ASTDecimalDataType::updateTreeHashImpl(SipHash & hash_state, bool /*ignore_aliases*/) const
+{
+    hash_state.update(name.size());
+    hash_state.update(name);
+    hash_state.update(precision);
+    hash_state.update(scale);
+}
+
+void ASTDecimalDataType::formatImpl(WriteBuffer & ostr, const FormatSettings & /*settings*/, FormatState & /*state*/, FormatStateStacked /*frame*/) const
+{
+    ostr << name << '(';
+
+    /// Decimal32, Decimal64, Decimal128, Decimal256 only have scale parameter
+    /// Decimal has both precision and scale
+    if (name == "Decimal")
+    {
+        writeText(precision, ostr);
+        ostr << ", ";
+    }
+
+    writeText(scale, ostr);
+    ostr << ')';
+}
+
+}

--- a/src/Parsers/ASTDecimalDataType.h
+++ b/src/Parsers/ASTDecimalDataType.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <Parsers/ASTDataType.h>
+
+
+namespace DB
+{
+
+/// Specialized AST for Decimal data types (Decimal, Decimal32, Decimal64, Decimal128, Decimal256)
+/// Stores precision and scale directly as fields instead of ASTLiteral children.
+class ASTDecimalDataType : public ASTDataType
+{
+public:
+    UInt32 precision = 0;
+    UInt32 scale = 0;
+
+    String getID(char delim) const override;
+    ASTPtr clone() const override;
+    void updateTreeHashImpl(SipHash & hash_state, bool ignore_aliases) const override;
+
+protected:
+    /// Outputs: Decimal(precision, scale) or Decimal32(scale) etc.
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+};
+
+}

--- a/src/Parsers/ASTEnumDataType.cpp
+++ b/src/Parsers/ASTEnumDataType.cpp
@@ -1,0 +1,62 @@
+#include <Parsers/ASTEnumDataType.h>
+#include <Common/SipHash.h>
+#include <IO/Operators.h>
+#include <IO/WriteHelpers.h>
+
+
+namespace DB
+{
+
+String ASTEnumDataType::getID(char delim) const
+{
+    return "EnumDataType" + (delim + name);
+}
+
+ASTPtr ASTEnumDataType::clone() const
+{
+    auto res = std::make_shared<ASTEnumDataType>(*this);
+    res->children.clear();
+    /// values vector is copied by the copy constructor
+    /// No arguments to clone since we don't use ASTLiteral children
+    return res;
+}
+
+void ASTEnumDataType::updateTreeHashImpl(SipHash & hash_state, bool /*ignore_aliases*/) const
+{
+    hash_state.update(name.size());
+    hash_state.update(name);
+
+    hash_state.update(values.size());
+    for (const auto & [elem_name, elem_value] : values)
+    {
+        hash_state.update(elem_name.size());
+        hash_state.update(elem_name);
+        hash_state.update(elem_value);
+    }
+}
+
+void ASTEnumDataType::formatImpl(WriteBuffer & ostr, const FormatSettings & /*settings*/, FormatState & /*state*/, FormatStateStacked /*frame*/) const
+{
+    ostr << name;
+
+    if (!values.empty())
+    {
+        ostr << '(';
+
+        bool first = true;
+        for (const auto & [elem_name, elem_value] : values)
+        {
+            if (!first)
+                ostr << ", ";
+            first = false;
+
+            writeQuotedString(elem_name, ostr);
+            ostr << " = ";
+            writeText(elem_value, ostr);
+        }
+
+        ostr << ')';
+    }
+}
+
+}

--- a/src/Parsers/ASTEnumDataType.h
+++ b/src/Parsers/ASTEnumDataType.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <Parsers/ASTDataType.h>
+#include <vector>
+#include <utility>
+
+
+namespace DB
+{
+
+/// Specialized AST for Enum data types (Enum8, Enum16, Enum)
+/// Stores enum values directly as vector of pairs instead of ASTLiteral children,
+/// significantly reducing memory allocations for enums with many values.
+class ASTEnumDataType : public ASTDataType
+{
+public:
+    /// Direct storage of enum values: (name, value) pairs
+    /// No ASTFunction/ASTLiteral children needed
+    std::vector<std::pair<String, Int64>> values;
+
+    String getID(char delim) const override;
+    ASTPtr clone() const override;
+    void updateTreeHashImpl(SipHash & hash_state, bool ignore_aliases) const override;
+
+protected:
+    /// Outputs: Enum8('name1' = 1, 'name2' = 2, ...)
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+};
+
+}

--- a/src/Parsers/ASTFixedStringDataType.cpp
+++ b/src/Parsers/ASTFixedStringDataType.cpp
@@ -1,0 +1,36 @@
+#include <Parsers/ASTFixedStringDataType.h>
+#include <Common/SipHash.h>
+#include <IO/Operators.h>
+#include <IO/WriteHelpers.h>
+
+
+namespace DB
+{
+
+String ASTFixedStringDataType::getID(char delim) const
+{
+    return "FixedStringDataType" + (delim + name);
+}
+
+ASTPtr ASTFixedStringDataType::clone() const
+{
+    auto res = std::make_shared<ASTFixedStringDataType>(*this);
+    res->children.clear();
+    return res;
+}
+
+void ASTFixedStringDataType::updateTreeHashImpl(SipHash & hash_state, bool /*ignore_aliases*/) const
+{
+    hash_state.update(name.size());
+    hash_state.update(name);
+    hash_state.update(n);
+}
+
+void ASTFixedStringDataType::formatImpl(WriteBuffer & ostr, const FormatSettings & /*settings*/, FormatState & /*state*/, FormatStateStacked /*frame*/) const
+{
+    ostr << name << '(';
+    writeText(n, ostr);
+    ostr << ')';
+}
+
+}

--- a/src/Parsers/ASTFixedStringDataType.h
+++ b/src/Parsers/ASTFixedStringDataType.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <Parsers/ASTDataType.h>
+
+
+namespace DB
+{
+
+/// Specialized AST for FixedString data type
+/// Stores the length directly as a field instead of an ASTLiteral child.
+class ASTFixedStringDataType : public ASTDataType
+{
+public:
+    UInt64 n = 0;  /// Length of the fixed string
+
+    String getID(char delim) const override;
+    ASTPtr clone() const override;
+    void updateTreeHashImpl(SipHash & hash_state, bool ignore_aliases) const override;
+
+protected:
+    /// Outputs: FixedString(n)
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+};
+
+}

--- a/src/Parsers/ParserDataType.cpp
+++ b/src/Parsers/ParserDataType.cpp
@@ -78,7 +78,6 @@ bool parseEnumValues(
 {
     bool first_element = true;
     Int64 auto_value = 1;
-    bool has_explicit_values = false;
     bool has_auto_values = false;
 
     while (true)
@@ -129,7 +128,6 @@ bool parseEnumValues(
         if (pos->type == TokenType::Equals)
         {
             ++pos;
-            has_explicit_values = true;
 
             /// Parse the numeric value (can be negative)
             bool negative = false;
@@ -170,12 +168,11 @@ bool parseEnumValues(
         ++auto_value;
     }
 
-    /// Check that we don't mix explicit and auto values (except for the first element which sets the base)
-    if (has_explicit_values && has_auto_values && values.size() > 1)
-    {
-        /// This is actually allowed - first element can have explicit value, rest can be auto
-        /// The rule is: either all explicit OR first explicit then all auto OR all auto
-    }
+    /// If there are ANY auto-assigned values, fall back to the generic parser
+    /// which handles the complex auto-assignment validation (mixing rules etc.)
+    /// Our specialized parser only handles the case where ALL values are explicitly assigned
+    if (has_auto_values)
+        return false;
 
     return !values.empty();
 }

--- a/src/Parsers/ParserDataType.cpp
+++ b/src/Parsers/ParserDataType.cpp
@@ -475,14 +475,10 @@ bool ParserDataType::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
         return true;
     }
 
-    /// Handle DateTime64 specially
-    if (isDateTime64Type(type_name_upper))
+    /// Handle DateTime64 specially - only if it has parameters
+    /// DateTime64 without parameters is valid and defaults to precision 3
+    if (isDateTime64Type(type_name_upper) && pos->type == TokenType::OpeningRoundBracket)
     {
-        if (pos->type != TokenType::OpeningRoundBracket)
-        {
-            expected.add(pos, "opening bracket for DateTime64 parameters");
-            return false;
-        }
         ++pos;
 
         auto dt64_node = std::make_shared<ASTDateTime64DataType>();


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Introduce specialized AST objects for parametrized data types. Parser does not allow to use valiables or aliases in parameters of data types so change is backward compatible. 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

Introduce polymorphic AST classes that inherit from ASTDataType and store type-specific parameters directly as fields instead of ASTLiteral children.

New AST classes:
- ASTEnumDataType: stores enum values as vector<pair<String, Int64>>
- ASTDecimalDataType: stores precision and scale as UInt32
- ASTDateTime64DataType: stores precision (UInt32) and timezone (String)
- ASTFixedStringDataType: stores length as UInt64

Benefits:
- Significantly reduced memory allocations for large enums (100-element enum: ~400 AST nodes -> 1 AST node)
- Direct parameter storage eliminates ASTLiteral/ASTFunction overhead
- Maintains full backward compatibility (SQL round-trip safe)
- No virtual method overhead - uses explicit as<>() type checks in factory

Parser changes (ParserDataType.cpp):
- Detect specialized types early and parse directly into specialized AST
- Skip creation of intermediate ASTLiteral nodes for type parameters

Factory changes (DataTypeFactory.cpp):
- Handle specialized AST types with explicit type checks before generic path
- Create DataType objects directly from AST fields

<img width="1728" height="999" alt="Screenshot 2026-01-13 at 20 35 21" src="https://github.com/user-attachments/assets/d8784edf-fad3-4a63-b23b-cac808d2c371" />

<img width="1695" height="932" alt="Screenshot 2026-01-13 at 20 39 50" src="https://github.com/user-attachments/assets/c1dc42a5-075f-45dd-8a8f-95730b6b4c5f" />
