### PR TITLE
ci: fix bugfix check

### DIFF
--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -428,12 +428,13 @@ class JobConfigs:
             requires=[ArtifactNames.CH_ARM_ASAN],
         ),
     )
+    # --root/--privileged/--cgroupns=host is required for clickhouse-test --memory-limit
     bugfix_validation_ft_pr_job = Job.Config(
         name=JobNames.BUGFIX_VALIDATE_FT,
         runs_on=RunnerLabels.FUNC_TESTER_ARM,
         command="python3 ./ci/jobs/functional_tests.py --options BugfixValidation",
         # some tests can be flaky due to very slow disks - use tmpfs for temporary ClickHouse files
-        run_in_docker="clickhouse/stateless-test+--network=host+--security-opt seccomp=unconfined+--tmpfs /tmp/clickhouse:mode=1777",
+        run_in_docker="clickhouse/stateless-test+--network=host+--privileged+--cgroupns=host+root+--security-opt seccomp=unconfined+--tmpfs /tmp/clickhouse:mode=1777",
         digest_config=Job.CacheDigestConfig(
             include_paths=[
                 "./ci/jobs/functional_tests.py",


### PR DESCRIPTION
Now it always fails with

    [2026-01-13 20:29:23] 2026-01-13 15:29:23 Running about 1 stateless tests (Process-3).
    [2026-01-13 20:29:23] Failed to configure cgroup clickhouse-test-5281: [Errno 30] Read-only file system: '/sys/fs/cgroup/memory/clickhouse-test-5281'
    [2026-01-13 20:29:23] 2026-01-13 15:29:23 03790_uniqTheta_error:                                                  [ UNKNOWN ] 0.14 sec.
    [2026-01-13 20:29:23] 2026-01-13 15:29:23 Reason: Test internal error:
    [2026-01-13 20:29:23] 2026-01-13 15:29:23 FileNotFoundError
    [2026-01-13 20:29:23] 2026-01-13 15:29:23 [Errno 2] No such file or directory: '/home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/tests/queries/0_stateless/03790_uniqTheta_error.stdout'

Introduced in: https://github.com/ClickHouse/ClickHouse/pull/82361

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.533`
<!-- ch-version-info:end -->