### PR TITLE
fix crash due to exception in `SCOPE_EXIT`

### DIFF
--- a/src/IO/ReadBufferFromPocoSocket.cpp
+++ b/src/IO/ReadBufferFromPocoSocket.cpp
@@ -1,6 +1,7 @@
 #include <Poco/Net/NetException.h>
 
 #include <base/scope_guard.h>
+#include <Common/scope_guard_safe.h>
 
 #include <IO/ReadBufferFromPocoSocket.h>
 #include <Common/Exception.h>
@@ -56,7 +57,7 @@ ssize_t ReadBufferFromPocoSocketBase::socketReceiveBytesImpl(char * ptr, size_t 
         if (async_callback)
         {
             socket.setBlocking(false);
-            SCOPE_EXIT(socket.setBlocking(true));
+            SCOPE_EXIT_SAFE(socket.setBlocking(true));
             bool secure = socket.secure();
             bytes_read = socket.impl()->receiveBytes(ptr, static_cast<int>(size));
 

--- a/src/IO/WriteBufferFromPocoSocket.cpp
+++ b/src/IO/WriteBufferFromPocoSocket.cpp
@@ -1,6 +1,7 @@
 #include <Poco/Net/NetException.h>
 
 #include <base/scope_guard.h>
+#include <Common/scope_guard_safe.h>
 
 #include <IO/WriteBufferFromPocoSocket.h>
 
@@ -47,7 +48,7 @@ ssize_t WriteBufferFromPocoSocket::socketSendBytesImpl(const char * ptr, size_t 
     {
         socket.setBlocking(false);
         /// Set socket to blocking mode at the end.
-        SCOPE_EXIT(socket.setBlocking(true));
+        SCOPE_EXIT_SAFE(socket.setBlocking(true));
         bool secure = socket.secure();
         res = socket.impl()->sendBytes(ptr, static_cast<int>(size));
 


### PR DESCRIPTION
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixes https://github.com/ClickHouse/clickhouse-core-incidents/issues/1217. Exception was thrown from a `socket.setBlocking(true)` call inside `SCOPE_EXIT`: [logs](https://grafana.clickhouse-prd.com/a/loghouseapp/sysex?thanos_datasource=LightHouse+Thanos+%28production%29&environment=production&sortOrder=Asc&namespace=ns-olive-ae-66&region=us-central1&limit=500&whereExtra=and+level+%3D+%27Fatal%27&tableName=text_log&groupBy=level&extraCols=level&timeFrom=2025-12-29T01%3A13%3A46Z&timeFromCHFormat=2025-12-29+01%3A13%3A46&timeFromUnix=1766970826&timeTo=2025-12-29T02%3A13%3A51Z&timeToCHFormat=2025-12-29+02%3A13%3A51&timeToUnix=1766974431&dateTo=2025-12-29&dateFrom=2025-12-29). Because `SCOPE_EXIT` creates a scope guard object and runs the provided code in the scope guard's destructor, we can't use `SCOPE_EXIT` with functions that throw exceptions and should use `SCOPE_EXIT_SAFE` instead.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.508`
- Backported to: `25.12.4.10`, `25.11.7.29`, `25.10.5.31`, `25.8.15.26`, `25.3.13.14`
<!-- ch-version-info:end -->