### PR TITLE
Fix data loss when DROP PARTITION removes parts created by later log entries in ReplicatedMergeTree

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -133,7 +133,9 @@ static struct InitFiu
     ONCE(shared_set_full_update_fails_when_initializing) \
     PAUSEABLE(after_kill_part_pause) \
     ONCE(parallel_replicas_reading_response_timeout) \
-    ONCE(database_iceberg_gcs)
+    ONCE(database_iceberg_gcs) \
+    REGULAR(rmt_delay_execute_drop_range) \
+    REGULAR(rmt_delay_commit_part)
 
 namespace FailPoints
 {

--- a/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
@@ -60,6 +60,7 @@ namespace FailPoints
     extern const char replicated_merge_tree_insert_quorum_fail_0[];
     extern const char replicated_merge_tree_commit_zk_fail_when_recovering_from_hw_fault[];
     extern const char replicated_merge_tree_insert_retry_pause[];
+    extern const char rmt_delay_commit_part[];
 }
 
 namespace ErrorCodes
@@ -939,9 +940,10 @@ std::map<std::string, std::string> ReplicatedMergeTreeSink::commitPart(
 
         fiu_do_on(FailPoints::replicated_merge_tree_commit_zk_fail_after_op, { zookeeper->forceFailureAfterOperation(); });
 
+        fiu_do_on(FailPoints::rmt_delay_commit_part, { sleepForSeconds(5); });
+
         Coordination::Responses responses;
         Coordination::Error multi_code = zookeeper->tryMultiNoThrow(ops, responses, /* check_session_valid */ true); /// 1 RTT
-
         if (multi_code == Coordination::Error::ZOK)
         {
             part->new_part_was_committed_to_zookeeper_after_rename_on_disk = true;

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -32,6 +32,7 @@
 #include <Disks/DiskObjectStorage/MetadataStorages/IMetadataStorage.h>
 #include <Disks/SingleDiskVolume.h>
 
+#include <base/sleep.h>
 #include <base/sort.h>
 
 #include <Storages/buildQueryTreeForShard.h>
@@ -118,9 +119,10 @@
 #include <Common/scope_guard_safe.h>
 #include <IO/SharedThreadPools.h>
 
+#include <base/types.h>
+#include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/join.hpp>
 #include <boost/algorithm/string/replace.hpp>
-#include <boost/algorithm/string.hpp>
 
 #include <algorithm>
 #include <ctime>
@@ -241,6 +243,7 @@ namespace FailPoints
     extern const char zero_copy_unlock_zk_fail_after_op[];
     extern const char rmt_lightweight_update_sleep_after_block_allocation[];
     extern const char rmt_merge_selecting_task_pause_when_scheduled[];
+    extern const char rmt_delay_execute_drop_range[];
 }
 
 namespace ErrorCodes
@@ -2718,6 +2721,8 @@ static void paranoidCheckForCoveredPartsInZooKeeper(
 void StorageReplicatedMergeTree::executeDropRange(const LogEntry & entry)
 {
     LOG_TRACE(log, "Executing DROP_RANGE {}", entry.new_part_name);
+
+    fiu_do_on(FailPoints::rmt_delay_execute_drop_range, { sleepForSeconds(10); });
 
     auto drop_range_info = MergeTreePartInfo::fromPartName(entry.new_part_name, format_version);
 
@@ -8493,12 +8498,13 @@ void StorageReplicatedMergeTree::clearLockedBlockNumbersInPartition(
                 LOG_WARNING(log, new_version_warning, paths_to_get[i], result.data);
 
             Stopwatch time_waiting;
-            const auto & stop_waiting = [this, &time_waiting]()
-            {
-                auto timeout = getContext()->getSettingsRef()[Setting::lock_acquire_timeout].value.seconds();
-                return partial_shutdown_called || (timeout < time_waiting.elapsedSeconds());
-            };
-            zookeeper.waitForDisappear(paths_to_get[i], stop_waiting);
+            const Int64 timeout = getContext()->getSettingsRef()[Setting::lock_acquire_timeout].value.totalSeconds();
+            const auto & stop_waiting
+                = [this, &time_waiting, &timeout]() { return partial_shutdown_called || (timeout < Int64(time_waiting.elapsedSeconds())); };
+
+            if (!zookeeper.waitForDisappear(paths_to_get[i], stop_waiting))
+                throw Exception(
+                    ErrorCodes::TIMEOUT_EXCEEDED, "Path {} does not disappear, timed out after {} seconds", paths_to_get[i], timeout);
         }
     }
 }

--- a/tests/integration/test_race_condition_for_replicated_merge_tree/configs/users.xml
+++ b/tests/integration/test_race_condition_for_replicated_merge_tree/configs/users.xml
@@ -1,0 +1,17 @@
+<clickhouse>
+    <profiles>
+        <default>
+            <allow_drop_detached>1</allow_drop_detached>
+            <allow_experimental_alter_materialized_view_structure>1</allow_experimental_alter_materialized_view_structure>
+            <allow_experimental_object_type>0</allow_experimental_object_type>
+            <allow_suspicious_codecs>0</allow_suspicious_codecs>
+            <database_replicated_allow_replicated_engine_arguments>2</database_replicated_allow_replicated_engine_arguments>
+            <database_replicated_allow_explicit_uuid>3</database_replicated_allow_explicit_uuid>
+        </default>
+    </profiles>
+    <users>
+        <default>
+            <profile>default</profile>
+        </default>
+    </users>
+</clickhouse>

--- a/tests/integration/test_race_condition_for_replicated_merge_tree/test.py
+++ b/tests/integration/test_race_condition_for_replicated_merge_tree/test.py
@@ -1,0 +1,173 @@
+import pytest
+import threading
+import time
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+
+node1 = cluster.add_instance(
+    "node1",
+    with_zookeeper=True,
+    user_configs=["configs/users.xml"],
+    stay_alive=True,
+    macros={"shard": "s1", "replica": "r1"},
+)
+node2 = cluster.add_instance(
+    "node2",
+    with_zookeeper=True,
+    user_configs=["configs/users.xml"],
+    stay_alive=True,
+    macros={"shard": "s1", "replica": "r2"},
+)
+node3 = cluster.add_instance(
+    "node3",
+    with_zookeeper=True,
+    user_configs=["configs/users.xml"],
+    stay_alive=True,
+    macros={"shard": "s1", "replica": "r3"},
+)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def get_last_block_number_for_partition(node, table_uuid, partition):
+    query = f"""
+    SELECT 
+        toInt64(replaceRegexpOne(name, 'block-', '')) as block_number
+    FROM system.zookeeper
+    WHERE path = '/clickhouse/tables/{table_uuid}/s1/block_numbers/{partition}'
+        AND name LIKE 'block-%'
+    ORDER BY block_number DESC
+    LIMIT 1
+    """
+    result = node.query(query).strip()
+    if result == "":
+        return None
+    return int(result)
+
+
+def wait_for_queue_to_process(node, database, table, timeout=60):
+    """Poll until replication queue is empty."""
+    start = time.time()
+    while time.time() - start < timeout:
+        result = node.query(
+            f"""
+            SELECT queue_size, absolute_delay 
+            FROM system.replicas 
+            WHERE database = '{database}' AND table = '{table}'
+        """
+        )
+
+        if result:
+            queue_size, delay = map(int, result.strip().split("\t"))
+            if queue_size == 0 and delay == 0:
+                print(f"Queue processed on {node.name}")
+                return True
+
+        time.sleep(0.5)
+
+    raise TimeoutError(f"Queue not processed within {timeout}s")
+
+
+def test_partition_move_drop_race(started_cluster):
+    for node in [node1, node2, node3]:
+        node.query(f"DROP DATABASE IF EXISTS test_db SYNC")
+
+    node1.query("SYSTEM ENABLE FAILPOINT rmt_delay_execute_drop_range")
+    node1.query("SYSTEM ENABLE FAILPOINT rmt_delay_commit_part")
+
+    for node in [node1, node2, node3]:
+        node.query(
+            """
+            CREATE DATABASE test_db 
+            ENGINE = Replicated('/test/db', '{shard}', '{replica}')
+        """
+        )
+
+    node1.query(
+        f"""
+        CREATE TABLE test_db.tbl (id UInt32, val String)
+        ENGINE = ReplicatedMergeTree
+        PARTITION BY id % 10 ORDER BY id
+        SETTINGS old_parts_lifetime = 1
+    """
+    )
+
+    for node in [node1, node2, node3]:
+        assert node.query_with_retry(
+            "SELECT count() FROM system.tables WHERE database='test_db' AND name='tbl'",
+            check_callback=lambda x: x.strip() == "1",
+        )
+
+    table_uuid = node1.query(
+        "SELECT uuid FROM system.tables WHERE database='test_db' AND name='tbl'"
+    ).strip()
+
+    node2.query(f"SYSTEM STOP FETCHES test_db.tbl")
+    node3.query(f"SYSTEM STOP FETCHES test_db.tbl")
+
+    prev_block_number = get_last_block_number_for_partition(node1, table_uuid, 0)
+
+    exception_holder = [None]
+    def drop_op():
+        try:
+            # Wait until INSERT query allocates the block number
+            timeout = 60  # seconds
+            start_time = time.time()
+
+            while True:
+                current_block_number = get_last_block_number_for_partition(
+                    node1, table_uuid, 0
+                )
+                if current_block_number != prev_block_number:
+                    break
+
+                if time.time() - start_time > timeout:
+                    raise TimeoutError(
+                        f"Timeout waiting for block number to change after {timeout}s. "
+                        f"Previous: {prev_block_number}, Current: {current_block_number}"
+                    )
+                time.sleep(0.5)
+
+            node1.query(f"ALTER TABLE test_db.tbl DROP PARTITION 0")
+        except Exception as e:
+            exception_holder[0] = e
+
+    t = threading.Thread(target=drop_op)
+    t.start()
+
+    node1.query(f"INSERT INTO test_db.tbl VALUES (0, 'a'), (10, 'b'), (20, 'c')")
+    t.join()
+
+    if exception_holder[0]:
+        raise exception_holder[0]
+
+    wait_for_queue_to_process(node1, "test_db", "tbl")
+    node3.query(f"SYSTEM START FETCHES test_db.tbl")
+    wait_for_queue_to_process(node3, "test_db", "tbl")
+
+    errors = []
+    for node in [node1, node2, node3]:
+        lost = int(
+            node.query(
+                "SELECT lost_part_count FROM system.replicas WHERE database = 'test_db' AND table = 'tbl'"
+            ).strip()
+        )
+
+        print(f"{node.name} lost_parts: {lost}")
+
+        if lost > 0:
+            errors.append(f"{node.name} has {lost} lost parts")
+
+    if errors:
+        pytest.fail(f"Race: {'; '.join(errors)}")
+
+    for node in [node1, node2, node3]:
+        node.query(f"DROP DATABASE IF EXISTS test_db SYNC")


### PR DESCRIPTION
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Related issue: https://github.com/ClickHouse/ClickHouse/issues/80315
CIDB: [link](https://play.clickhouse.com/play?user=play#U0VMRUNUIGJhc2VfcmVwbywgcHVsbF9yZXF1ZXN0X251bWJlciBhcyBwciwgY2hlY2tfc3RhcnRfdGltZSwgY2hlY2tfbmFtZSwgdGVzdF9uYW1lLCB0ZXN0X3N0YXR1cywgcmVwb3J0X3VybApGUk9NIGNoZWNrcwpXSEVSRSAxCiAgICBBTkQgdGVzdF9zdGF0dXMgSU4gKCdGQUlMJywgJ0VSUk9SJywgJ0JST0tFTicpCiAgICBBTkQgdG9EYXRlKGNoZWNrX3N0YXJ0X3RpbWUpID4gJzIwMjUtMDYtMDEnCiAgICBBTkQgdGVzdF9uYW1lIGxpa2UgJyUwMTE1NF9tb3ZlX3BhcnRpdGlvbl9sb25nJScKICAgIEFORCB0ZXN0X2NvbnRleHRfcmF3IGxpa2UgJyVyZXN1bHQgZGlmZmVycyB3aXRoIHJlZmVyZW5jZSUnCk9SREVSIEJZIGNoZWNrX3N0YXJ0X3RpbWUgREVTQwpTRVRUSU5HUyByZWFkX3Rocm91Z2hfZGlzdHJpYnV0ZWRfY2FjaGU9MA==)

This PR fixes a part of the issue. The CI job of `01154_move_partition_long` failed due to `result differs with reference`.

Problem: 
When creating a part, allocating a block number and committing the part are not done atomically.

- node1: adding a part with block number 0 (not committed yet)
- node2: 
    - During the gap of the adding operation, this node drops the partition, which allocates a greater block number: e.g, block 1. 
    - This operation is committed earlier, and gets a smaller log number (e.g: `log-0000000000`) with drop range `0_0_0_999999999_999999999`
- node1: 
    - The adding part is now committed with name `0_0_0_0` and with a greater log number (e.g: `log-0000000001`). 
    - Then, it executes `DROP_RANGE 0_0_0_999999999_999999999` and removes part `0_0_0_0` (just created)
- node3: 
    - Execute  `log-0000000000` (DROP_RANGE 0_0_0_999999999_999999999), 
    - Execute  `log-0000000001` (new part 0_0_0_0) -> cannot find the part on `node1`, marks it as a lost part
    
Fix:
- In `clearLockedBlockNumbersInPartition`, when waiting for block number paths to disappear, get the waiting duration by `totalSeconds` instead of `seconds`
- If any path does not disappear, throw an exception

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.654`
- Backported to: `25.12.4.33`, `25.11.7.41`, `25.10.5.40`, `25.8.15.35`, `25.3.13.19`
<!-- ch-version-info:end -->