### PR TITLE
ci: reduce memory usage for tests with coverage build

### DIFF
--- a/tests/queries/0_stateless/02125_many_mutations_2.sh
+++ b/tests/queries/0_stateless/02125_many_mutations_2.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Tags: long, no-tsan, no-debug, no-asan, no-msan, no-ubsan, no-parallel, no-shared-merge-tree, no-replicated-database, no-object-storage
+# Tags: long, no-tsan, no-debug, no-asan, no-msan, no-ubsan, no-parallel, no-shared-merge-tree, no-replicated-database, no-object-storage, no-flaky-check
 # no-shared-merge-tree -- this test is too slow
+# no-flaky-check -- too slow with thread fuzzer
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/02125_many_mutations_2.sh
+++ b/tests/queries/0_stateless/02125_many_mutations_2.sh
@@ -19,10 +19,9 @@ $CLICKHOUSE_CLIENT -q "select count() from many_mutations"
 
 job()
 {
-   for i in {1..1000}
-   do
-      echo "alter table many_mutations delete where y = ${i} * 2 settings mutations_sync = 0;"
-   done | $CLICKHOUSE_CLIENT
+   for i in {1..1000}; do
+     $CLICKHOUSE_CURL -sS $CLICKHOUSE_URL -d "alter table many_mutations delete where y = ${i} * 2 settings mutations_sync = 0"
+   done
 }
 
 job &

--- a/tests/queries/0_stateless/03248_create-same-table-concurrently-with-replicated-engine.sh
+++ b/tests/queries/0_stateless/03248_create-same-table-concurrently-with-replicated-engine.sh
@@ -11,7 +11,7 @@ $CLICKHOUSE_CLIENT --query "CREATE DATABASE IF NOT EXISTS ${CLICKHOUSE_DATABASE}
 function create_or_replace_table_thread
 {
     for _ in {1..15}; do
-        $CLICKHOUSE_CLIENT --query "CREATE OR REPLACE TABLE ${CLICKHOUSE_DATABASE}_db.test_table (x Int) ENGINE=Memory" > /dev/null
+        $CLICKHOUSE_CURL -sS $CLICKHOUSE_URL -d "CREATE OR REPLACE TABLE ${CLICKHOUSE_DATABASE}_db.test_table (x Int) ENGINE=Memory" > /dev/null
     done
 }
 export -f create_or_replace_table_thread;
@@ -22,4 +22,4 @@ done
 
 wait
 
-$CLICKHOUSE_CLIENT --query "DROP DATABASE IF EXISTS ${CLICKHOUSE_DATABASE}_db SYNC";
+$CLICKHOUSE_CLIENT --query "DROP DATABASE IF EXISTS ${CLICKHOUSE_DATABASE}_db SYNC"

--- a/tests/queries/0_stateless/replication.lib
+++ b/tests/queries/0_stateless/replication.lib
@@ -38,8 +38,9 @@ function try_sync_replicas()
     local i=0
     for t in "${tables_arr[@]}"
     do
-        $CLICKHOUSE_CLIENT --receive_timeout $time_left -q "SYSTEM SYNC REPLICA $t STRICT" || ($CLICKHOUSE_CLIENT -q \
-            "select 'sync failed, queue:', * from system.replication_queue where database=currentDatabase() and table='$t' order by database, table, node_name" && exit 1) &
+        $CLICKHOUSE_CURL --max-time $time_left --fail -sS $CLICKHOUSE_URL -d "SYSTEM SYNC REPLICA $t STRICT" || {
+            $CLICKHOUSE_CURL --max-time $time_left -sS $CLICKHOUSE_URL -d "select 'sync failed, queue:', * from system.replication_queue where database=currentDatabase() and table='$t' ORDER BY database, table, node_name" && exit 1
+        } &
         pids[${i}]=$!
         i=$((i + 1))
     done


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Follow-up for: https://github.com/ClickHouse/ClickHouse/pull/82361
CI: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=a6866032b1399e57f53eaf9c15fdda89ea2bb02f&name_0=NightlyCoverage&name_1=Stateless%20tests%20%28amd_coverage%2C%201%2F8%29&name_1=Stateless%20tests%20%28amd_coverage%2C%201%2F8%29


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.513`
<!-- ch-version-info:end -->