### PR TITLE
Fix too many watches in ReplicatedMergeTree while waiting for log entry

### DIFF
--- a/src/Storages/MergeTree/PartMovesBetweenShardsOrchestrator.cpp
+++ b/src/Storages/MergeTree/PartMovesBetweenShardsOrchestrator.cpp
@@ -193,6 +193,7 @@ bool PartMovesBetweenShardsOrchestrator::step()
 
 PartMovesBetweenShardsOrchestrator::Entry PartMovesBetweenShardsOrchestrator::stepEntry(Entry entry, zkutil::ZooKeeperPtr zk)
 {
+    StorageReplicatedMergeTree::WatchEventByPath watch_events;
     switch (entry.state.value)
     {
         case EntryState::DONE: [[fallthrough]];
@@ -257,7 +258,7 @@ PartMovesBetweenShardsOrchestrator::Entry PartMovesBetweenShardsOrchestrator::st
                 LOG_DEBUG(log, "Pushed log entry: {}", log_znode_path);
             }
 
-            Strings unwaited = storage.tryWaitForAllReplicasToProcessLogEntry(zookeeper_path, sync_source_log_entry, 1);
+            Strings unwaited = storage.tryWaitForAllReplicasToProcessLogEntry(zookeeper_path, sync_source_log_entry, 1, watch_events);
             if (!unwaited.empty())
                 throw Exception(
                     ErrorCodes::TIMEOUT_EXCEEDED, "Some replicas haven't processed event: {}, will retry later.", toString(unwaited));
@@ -315,7 +316,7 @@ PartMovesBetweenShardsOrchestrator::Entry PartMovesBetweenShardsOrchestrator::st
                 LOG_DEBUG(log, "Pushed log entry: {}", log_znode_path);
             }
 
-            Strings unwaited = storage.tryWaitForAllReplicasToProcessLogEntry(entry.to_shard, sync_destination_log_entry, 1);
+            Strings unwaited = storage.tryWaitForAllReplicasToProcessLogEntry(entry.to_shard, sync_destination_log_entry, 1, watch_events);
             if (!unwaited.empty())
                 throw Exception(
                     ErrorCodes::TIMEOUT_EXCEEDED, "Some replicas haven't processed event: {}, will retry later.", toString(unwaited));
@@ -376,7 +377,7 @@ PartMovesBetweenShardsOrchestrator::Entry PartMovesBetweenShardsOrchestrator::st
                 LOG_DEBUG(log, "Pushed log entry: {}", log_znode_path);
             }
 
-            Strings unwaited = storage.tryWaitForAllReplicasToProcessLogEntry(entry.to_shard, fetch_log_entry, 1);
+            Strings unwaited = storage.tryWaitForAllReplicasToProcessLogEntry(entry.to_shard, fetch_log_entry, 1, watch_events);
             if (!unwaited.empty())
                 throw Exception(
                     ErrorCodes::TIMEOUT_EXCEEDED, "Some replicas haven't processed event: {}, will retry later.", toString(unwaited));
@@ -456,7 +457,7 @@ PartMovesBetweenShardsOrchestrator::Entry PartMovesBetweenShardsOrchestrator::st
                     LOG_DEBUG(log, "Pushed log entry: {}", log_znode_path);
                 }
 
-                Strings unwaited = storage.tryWaitForAllReplicasToProcessLogEntry(entry.to_shard, attach_rollback_log_entry, 1);
+                Strings unwaited = storage.tryWaitForAllReplicasToProcessLogEntry(entry.to_shard, attach_rollback_log_entry, 1, watch_events);
                 if (!unwaited.empty())
                     throw Exception(
                         ErrorCodes::TIMEOUT_EXCEEDED, "Some replicas haven't processed event: {}, will retry later.", toString(unwaited));
@@ -523,7 +524,7 @@ PartMovesBetweenShardsOrchestrator::Entry PartMovesBetweenShardsOrchestrator::st
                 log_entry = *ReplicatedMergeTreeLogEntry::parse(log_entry_str, stat, storage.format_version);
             }
 
-            Strings unwaited = storage.tryWaitForAllReplicasToProcessLogEntry(entry.to_shard, log_entry, 1);
+            Strings unwaited = storage.tryWaitForAllReplicasToProcessLogEntry(entry.to_shard, log_entry, 1, watch_events);
             if (!unwaited.empty())
                 throw Exception(
                     ErrorCodes::TIMEOUT_EXCEEDED, "Some replicas haven't processed event: {}, will retry later.", toString(unwaited));
@@ -598,7 +599,7 @@ PartMovesBetweenShardsOrchestrator::Entry PartMovesBetweenShardsOrchestrator::st
                 LOG_DEBUG(log, "Pushed log entry: {}", log_znode_path);
             }
 
-            Strings unwaited = storage.tryWaitForAllReplicasToProcessLogEntry(zookeeper_path, source_drop_log_entry, 1);
+            Strings unwaited = storage.tryWaitForAllReplicasToProcessLogEntry(zookeeper_path, source_drop_log_entry, 1, watch_events);
             if (!unwaited.empty())
                 throw Exception(
                     ErrorCodes::TIMEOUT_EXCEEDED, "Some replicas haven't processed event: {}, will retry later.", toString(unwaited));

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -6325,8 +6325,9 @@ bool StorageReplicatedMergeTree::optimize(
 
     table_lock.reset();
 
+    WatchEventByPath watch_events;
     for (auto & merge_entry : merge_entries)
-        waitForLogEntryToBeProcessedIfNecessary(merge_entry, query_context);
+        waitForLogEntryToBeProcessedIfNecessary(merge_entry, query_context, watch_events);
 
     return assigned;
 }
@@ -6753,7 +6754,9 @@ void StorageReplicatedMergeTree::alter(
     table_lock_holder.unlock();
 
     LOG_DEBUG(log, "Updated shared metadata nodes in ZooKeeper. Waiting for replicas to apply changes.");
-    waitForLogEntryToBeProcessedIfNecessary(*alter_entry, query_context, "Some replicas doesn't finish metadata alter: ");
+
+    WatchEventByPath watch_events;
+    waitForLogEntryToBeProcessedIfNecessary(*alter_entry, query_context, watch_events, "Some replicas doesn't finish metadata alter: ");
 
     if (mutation_znode)
     {
@@ -6924,7 +6927,8 @@ void StorageReplicatedMergeTree::dropPart(const String & part_name, bool detach,
 
     dropPartImpl(zookeeper, part_name, entry, detach, /*throw_if_noop=*/ true);
 
-    waitForLogEntryToBeProcessedIfNecessary(entry, query_context);
+    WatchEventByPath watch_events;
+    waitForLogEntryToBeProcessedIfNecessary(entry, query_context, watch_events);
 }
 
 void StorageReplicatedMergeTree::dropPartition(const ASTPtr & partition, bool detach, ContextPtr query_context)
@@ -6963,9 +6967,10 @@ void StorageReplicatedMergeTree::dropPartitions(const zkutil::ZooKeeperPtr & zoo
     std::vector<LogEntryPtr> entries;
     dropAllPartsInPartitions(*zookeeper, partition_ids, entries, query_context, detach);
 
+    WatchEventByPath watch_events;
     for (const auto & entry : entries)
     {
-        waitForLogEntryToBeProcessedIfNecessary(*entry, query_context);
+        waitForLogEntryToBeProcessedIfNecessary(*entry, query_context, watch_events);
         auto drop_range_info = MergeTreePartInfo::fromPartName(entry->new_part_name, format_version);
         cleanLastPartNode(drop_range_info.getPartitionId());
     }
@@ -7180,7 +7185,8 @@ EphemeralLockInZooKeeper StorageReplicatedMergeTree::allocateBlockNumber(
 }
 
 Strings StorageReplicatedMergeTree::tryWaitForAllReplicasToProcessLogEntry(
-    const String & table_zookeeper_path, const ReplicatedMergeTreeLogEntryData & entry, Int64 wait_for_inactive_timeout)
+    const String & table_zookeeper_path, const ReplicatedMergeTreeLogEntryData & entry,
+    Int64 wait_for_inactive_timeout, WatchEventByPath & watch_events)
 {
     LOG_DEBUG(log, "Waiting for all replicas to process {}", entry.znode_name);
 
@@ -7192,7 +7198,8 @@ Strings StorageReplicatedMergeTree::tryWaitForAllReplicasToProcessLogEntry(
     {
         if (wait_for_inactive || zookeeper->exists(fs::path(table_zookeeper_path) / "replicas" / replica / "is_active"))
         {
-            if (!tryWaitForReplicaToProcessLogEntry(table_zookeeper_path, replica, entry, wait_for_inactive_timeout))
+            auto & watch_event = watch_events.emplace(replica, std::make_shared<Poco::Event>()).first->second;
+            if (!tryWaitForReplicaToProcessLogEntry(table_zookeeper_path, replica, entry, wait_for_inactive_timeout, watch_event))
                 unwaited.push_back(replica);
         }
         else
@@ -7206,9 +7213,11 @@ Strings StorageReplicatedMergeTree::tryWaitForAllReplicasToProcessLogEntry(
 }
 
 void StorageReplicatedMergeTree::waitForAllReplicasToProcessLogEntry(
-    const String & table_zookeeper_path, const ReplicatedMergeTreeLogEntryData & entry, Int64 wait_for_inactive_timeout, const String & error_context)
+    const String & table_zookeeper_path, const ReplicatedMergeTreeLogEntryData & entry,
+    Int64 wait_for_inactive_timeout, WatchEventByPath & watch_events,
+    const String & error_context)
 {
-    Strings unfinished_replicas = tryWaitForAllReplicasToProcessLogEntry(table_zookeeper_path, entry, wait_for_inactive_timeout);
+    Strings unfinished_replicas = tryWaitForAllReplicasToProcessLogEntry(table_zookeeper_path, entry, wait_for_inactive_timeout, watch_events);
     if (unfinished_replicas.empty())
         return;
 
@@ -7216,13 +7225,14 @@ void StorageReplicatedMergeTree::waitForAllReplicasToProcessLogEntry(
                     "Probably some replicas are inactive", error_context, fmt::join(unfinished_replicas, ", "), entry.znode_name);
 }
 
-void StorageReplicatedMergeTree::waitForLogEntryToBeProcessedIfNecessary(const ReplicatedMergeTreeLogEntryData & entry, ContextPtr query_context, const String & error_context)
+void StorageReplicatedMergeTree::waitForLogEntryToBeProcessedIfNecessary(const ReplicatedMergeTreeLogEntryData & entry, ContextPtr query_context, WatchEventByPath & watch_events, const String & error_context)
 {
     /// If necessary, wait until the operation is performed on itself or on all replicas.
     Int64 wait_for_inactive_timeout = query_context->getSettingsRef()[Setting::replication_wait_for_inactive_replica_timeout];
     if (query_context->getSettingsRef()[Setting::alter_sync] == 1)
     {
-        bool finished = tryWaitForReplicaToProcessLogEntry(zookeeper_path, replica_name, entry, wait_for_inactive_timeout);
+        auto & watch_event = watch_events.emplace(replica_name, std::make_shared<Poco::Event>()).first->second;
+        bool finished = tryWaitForReplicaToProcessLogEntry(zookeeper_path, replica_name, entry, wait_for_inactive_timeout, watch_event);
         if (!finished)
         {
             throw Exception(ErrorCodes::UNFINISHED, "{}Log entry {} is not precessed on local replica, "
@@ -7231,12 +7241,14 @@ void StorageReplicatedMergeTree::waitForLogEntryToBeProcessedIfNecessary(const R
     }
     else if (query_context->getSettingsRef()[Setting::alter_sync] == 2)
     {
-        waitForAllReplicasToProcessLogEntry(zookeeper_path, entry, wait_for_inactive_timeout, error_context);
+        waitForAllReplicasToProcessLogEntry(zookeeper_path, entry, wait_for_inactive_timeout, watch_events, error_context);
     }
 }
 
 bool StorageReplicatedMergeTree::tryWaitForReplicaToProcessLogEntry(
-    const String & table_zookeeper_path, const String & replica, const ReplicatedMergeTreeLogEntryData & entry, Int64 wait_for_inactive_timeout)
+    const String & table_zookeeper_path, const String & replica,
+    const ReplicatedMergeTreeLogEntryData & entry, Int64 wait_for_inactive_timeout,
+    Coordination::EventPtr & watch_event)
 {
     String entry_str = entry.toString();
     String log_node_name;
@@ -7286,22 +7298,24 @@ bool StorageReplicatedMergeTree::tryWaitForReplicaToProcessLogEntry(
         bool pulled_to_queue = false;
         do
         {
-            Coordination::EventPtr event = std::make_shared<Poco::Event>();
-
-            String log_pointer = getZooKeeper()->get(fs::path(table_zookeeper_path) / "replicas" / replica / "log_pointer", nullptr, event);
+            String log_pointer = getZooKeeper()->get(fs::path(table_zookeeper_path) / "replicas" / replica / "log_pointer", nullptr, watch_event);
             if (!log_pointer.empty() && parse<UInt64>(log_pointer) > log_index)
             {
                 pulled_to_queue = true;
                 break;
             }
 
+            if (stop_waiting())
+                break;
+
             /// Wait with timeout because we can be already shut down, but not dropped.
             /// So log_pointer node will exist, but we will never update it because all background threads already stopped.
             /// It can lead to query hung because table drop query can wait for some query (alter, optimize, etc) which called this method,
             /// but the query will never finish because the drop already shut down the table.
-            if (!stop_waiting())
-                event->tryWait(event_wait_timeout_ms);
-        } while (!stop_waiting());
+            watch_event->tryWait(event_wait_timeout_ms);
+            /// Reset the event state
+            (*watch_event).reset();
+        } while (true);
 
         if (!pulled_to_queue)
             return false;
@@ -8623,8 +8637,9 @@ void StorageReplicatedMergeTree::replacePartitionFrom(
     /// Force execution of inserted log entries, because it could be delayed at BackgroundPool.
     background_operations_assignee.trigger();
 
+    WatchEventByPath watch_events;
     for (const auto & entry : entries)
-        waitForLogEntryToBeProcessedIfNecessary(*entry, query_context);
+        waitForLogEntryToBeProcessedIfNecessary(*entry, query_context, watch_events);
 }
 
 std::unique_ptr<ReplicatedMergeTreeLogEntryData> StorageReplicatedMergeTree::replacePartitionFromImpl(
@@ -9160,7 +9175,8 @@ void StorageReplicatedMergeTree::movePartitionToTable(const StoragePtr & dest_ta
 
         lock2.reset();
 
-        dest_table_storage->waitForLogEntryToBeProcessedIfNecessary(entry, query_context);
+        WatchEventByPath dest_watch_events;
+        dest_table_storage->waitForLogEntryToBeProcessedIfNecessary(entry, query_context, dest_watch_events);
 
         /// Create DROP_RANGE for the source table
         Coordination::Requests ops_src;
@@ -9188,7 +9204,8 @@ void StorageReplicatedMergeTree::movePartitionToTable(const StoragePtr & dest_ta
         /// Force execution of inserted log entries, because it could be delayed at BackgroundPool.
         background_operations_assignee.trigger();
 
-        waitForLogEntryToBeProcessedIfNecessary(entry_delete, query_context);
+        WatchEventByPath watch_events;
+        waitForLogEntryToBeProcessedIfNecessary(entry_delete, query_context, watch_events);
 
         /// Cleaning possibly stored information about parts from /quorum/last_part node in ZooKeeper.
         cleanLastPartNode(partition_id);

--- a/src/Storages/StorageReplicatedMergeTree.h
+++ b/src/Storages/StorageReplicatedMergeTree.h
@@ -840,6 +840,7 @@ private:
         const String & zookeeper_path_prefix = "",
         const std::optional<String> & znode_data = std::nullopt) const;
 
+    using WatchEventByPath = std::unordered_map<std::string, Coordination::EventPtr>;
     /** Wait until all replicas, including this, execute the specified action from the log.
       * If replicas are added at the same time, it can not wait the added replica.
       *
@@ -850,18 +851,20 @@ private:
       * Because it effectively waits for other thread that usually has to also acquire a lock to proceed and this yields deadlock.
       */
     void waitForAllReplicasToProcessLogEntry(const String & table_zookeeper_path, const ReplicatedMergeTreeLogEntryData & entry,
-                                             Int64 wait_for_inactive_timeout, const String & error_context = {});
+                                             Int64 wait_for_inactive_timeout, WatchEventByPath & watch_events,
+                                             const String & error_context = {});
     Strings tryWaitForAllReplicasToProcessLogEntry(const String & table_zookeeper_path, const ReplicatedMergeTreeLogEntryData & entry,
-                                                   Int64 wait_for_inactive_timeout);
+                                                   Int64 wait_for_inactive_timeout, WatchEventByPath & watch_events);
 
     /** Wait until the specified replica executes the specified action from the log.
       * NOTE: See comment about locks above.
       */
     bool tryWaitForReplicaToProcessLogEntry(const String & table_zookeeper_path, const String & replica_name,
-                                            const ReplicatedMergeTreeLogEntryData & entry, Int64 wait_for_inactive_timeout = 0);
+                                            const ReplicatedMergeTreeLogEntryData & entry, Int64 wait_for_inactive_timeout,
+                                            Coordination::EventPtr & watch_event);
 
     /// Depending on settings, do nothing or wait for this replica or all replicas process log entry.
-    void waitForLogEntryToBeProcessedIfNecessary(const ReplicatedMergeTreeLogEntryData & entry, ContextPtr query_context, const String & error_context = {});
+    void waitForLogEntryToBeProcessedIfNecessary(const ReplicatedMergeTreeLogEntryData & entry, ContextPtr query_context, WatchEventByPath & watch_events, const String & error_context = {});
 
     /// Throw an exception if the table is readonly.
     void assertNotReadonly() const;

--- a/tests/queries/0_stateless/03791_rmt_watches.sh
+++ b/tests/queries/0_stateless/03791_rmt_watches.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# Tags: long, no-parallel
+
+# Regression test for too many watches registered for the same path in ZK during waiting for log entries (on TRUNCATE in this test)
+
+$CLICKHOUSE_CLIENT -nm -q "
+  SET throw_on_max_partitions_per_insert_block = 0;
+  CREATE TABLE t0 (c0 String) ENGINE = ReplicatedSummingMergeTree('/tables/{database}/t0', 'r1') ORDER BY (c0) PARTITION BY (c0) PRIMARY KEY (c0);
+  -- Override send_logs_level to suppress 'MergeTreeDataWriter: INSERT query from initial_user default ({}) inserted a block that created parts in 1000 partitions. This is being logged rather than throwing an exception as throw_on_max_partitions_per_insert_block=false.'
+  INSERT INTO TABLE t0 (c0) SELECT number FROM numbers(1000) SETTINGS send_logs_level='error';
+  TRUNCATE t0;
+"
+
+# Make sure there are no "Too many watches for path /tables/X/t0/replicas/r1/log_pointer: Y (This is likely an error)" messages
+# (Logs from receive/send ZooKeeper client threads are not propagated to query, so it will be checked with system.text_log for the time TRUNCATE was running)
+#
+# NOTE: in release the limit for the warning in ZooKeeper::receiveEvent() is 10K, and creating 10KK parts is very slow, so we will create only 1K, and rely on lower limit for sanitizers/debug builds, which is 100 right now
+read -r event_time_timestamp query_duration_ms < <($CLICKHOUSE_CLIENT -nm -q "
+  system flush logs query_log;
+  select toUnixTimestamp(event_time), query_duration_ms from system.query_log where current_database = '$CLICKHOUSE_DATABASE' and query_kind = 'Drop' and type = 'QueryFinish';
+")
+$CLICKHOUSE_CLIENT -nm -q "
+  system flush logs text_log;
+  with fromUnixTimestamp($event_time_timestamp) as end_, $query_duration_ms/1000 as duration_
+  select * from system.text_log where logger_name = 'ZooKeeperClient' and level = 'Warning' and event_time between end_-duration_ and end_ limit 5;
+"

--- a/tests/queries/0_stateless/03791_rmt_watches.sh
+++ b/tests/queries/0_stateless/03791_rmt_watches.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
+# Tags: long, no-parallel, no-shared-merge-tree
+# - SMT/MinIO cannot handle this amount of parts in reasonable time
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
-
-# Tags: long, no-parallel
 
 # Regression test for too many watches registered for the same path in ZK during waiting for log entries (on TRUNCATE in this test)
 


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix too many watches in ReplicatedMergeTree while waiting for log entry

Fixes: https://github.com/ClickHouse/ClickHouse/issues/94132


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.744`
<!-- ch-version-info:end -->