### PR TITLE
CI: Add explicit `--repo` flag to `gh pr` commands in check_ci script

### DIFF
--- a/ci/jobs/scripts/check_ci.py
+++ b/ci/jobs/scripts/check_ci.py
@@ -628,7 +628,9 @@ def main():
             not issue_catalog
             or issue_catalog.updated_at < datetime.now().timestamp() - 10 * 60
         ):
-            issue_catalog = TestCaseIssueCatalog.from_gh(verbose=False)
+            issue_catalog = TestCaseIssueCatalog.from_gh(
+                verbose=False, repo="ClickHouse/ClickHouse"
+            )
             issue_catalog.dump()
         print(f"Loaded {len(issue_catalog.active_test_issues)} active issues from gh\n")
         print("Checking failures against open issues...\n")

--- a/ci/jobs/scripts/check_ci.py
+++ b/ci/jobs/scripts/check_ci.py
@@ -777,10 +777,14 @@ def main():
         sys.exit(0)
 
     if Shell.check(
-        f"gh pr view {pr_number} --json isDraft --jq '.isDraft' | grep -q true"
+        f"gh pr view {pr_number} --json isDraft --jq '.isDraft' --repo ClickHouse/ClickHouse | grep -q true"
     ):
         if UserPrompt.confirm(f"It's a draft PR. Do you want to undraft it?"):
-            Shell.check(f"gh pr ready {pr_number}", strict=True, verbose=True)
+            Shell.check(
+                f"gh pr ready {pr_number} --repo ClickHouse/ClickHouse",
+                strict=True,
+                verbose=True,
+            )
         else:
             sys.exit(0)
 
@@ -789,7 +793,7 @@ def main():
         mergeable_check_status, sha=head_sha
     )
 
-    if Shell.check(f"gh pr merge {pr_number} --auto"):
+    if Shell.check(f"gh pr merge {pr_number} --auto --repo ClickHouse/ClickHouse"):
         # Check if PR was successfully added to the merge queue
         # uncomment/fix if GH misses became regular
         # merge_status = Shell.check(

--- a/ci/praktika/issue.py
+++ b/ci/praktika/issue.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 
 
 def fetch_github_issues(
-    label: str, state: str = "open", hours_back: float = None
+    label: str, state: str = "open", hours_back: float = None, repo: str = ""
 ) -> List[dict]:
     """
     Fetch issues from GitHub using gh CLI with manual pagination.
@@ -28,6 +28,7 @@ def fetch_github_issues(
         label: GitHub label to filter by
         state: Issue state (open or closed)
         hours_back: For closed issues, only fetch those closed within this many hours (default: None for all)
+        repo: GitHub repository in format owner/repo (default: empty string uses current repo)
 
     Returns:
         List of issue dictionaries
@@ -35,6 +36,7 @@ def fetch_github_issues(
     if isinstance(label, str):
         label = [label]
     all_issues = []
+    repo_arg = f"--repo {repo}" if repo else ""
     limit_per_request = 1000  # Maximum we'll fetch per request
 
     # Build base command
@@ -44,13 +46,13 @@ def fetch_github_issues(
         )
         label_query = " ".join([f'label:"{lbl}"' for lbl in label])
         search_query = f"{label_query} is:closed closed:>{date_threshold}"
-        base_cmd = f"gh issue list --search '{search_query}' --json number,title,body,closedAt,labels --limit {limit_per_request}"
+        base_cmd = f"gh issue list {repo_arg} --search '{search_query}' --json number,title,body,closedAt,labels --limit {limit_per_request}"
         print(
             f"Fetching {state} issues with label '{label}' closed in last {hours_back} hours (since {date_threshold})..."
         )
     else:
         label_args = " ".join([f'--label "{lbl}"' for lbl in label])
-        base_cmd = f"gh issue list {label_args} --state {state} --json number,title,body,closedAt,labels --limit {limit_per_request}"
+        base_cmd = f"gh issue list {repo_arg} {label_args} --state {state} --json number,title,body,closedAt,labels --limit {limit_per_request}"
         print(f"Fetching {state} issues with label '{label}'...")
 
     try:
@@ -416,9 +418,13 @@ class TestCaseIssueCatalog(MetaClasses.Serializable):
         return res
 
     @classmethod
-    def from_gh(cls, verbose=True):
+    def from_gh(cls, verbose=True, repo=""):
         """
         Fetch and organize all CI test issues from GitHub.
+
+        Args:
+            verbose: Enable verbose output
+            repo: GitHub repository in format owner/repo (default: empty string uses current repo)
 
         Returns:
             TestCaseIssueCatalog with active issues (including recently closed)
@@ -429,7 +435,9 @@ class TestCaseIssueCatalog(MetaClasses.Serializable):
         # Fetch open issues with label "testing" (CI_ISSUE) first
         if verbose:
             print("\n--- Fetching active testing issues ---")
-        testing_issues = fetch_github_issues(label=IssueLabels.CI_ISSUE, state="open")
+        testing_issues = fetch_github_issues(
+            label=IssueLabels.CI_ISSUE, state="open", repo=repo
+        )
         catalog.active_test_issues = cls.process_issue(testing_issues, verbose=verbose)
         if verbose:
             print(f"Processed {len(catalog.active_test_issues)} testing issues")
@@ -438,7 +446,7 @@ class TestCaseIssueCatalog(MetaClasses.Serializable):
         if verbose:
             print("--- Fetching closed testing issues from last 8 hours ---")
         closed_testing_issues = fetch_github_issues(
-            label=IssueLabels.CI_ISSUE, state="closed", hours_back=8
+            label=IssueLabels.CI_ISSUE, state="closed", hours_back=8, repo=repo
         )
         closed_testing_processed = cls.process_issue(
             closed_testing_issues, verbose=verbose


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.521`
<!-- ch-version-info:end -->