### PR TITLE
Throw exception when Keeper snapshot or changelog are broken

### DIFF
--- a/src/Coordination/Changelog.cpp
+++ b/src/Coordination/Changelog.cpp
@@ -1865,7 +1865,6 @@ Changelog::Changelog(
 }
 
 void Changelog::readChangelogAndInitWriter(uint64_t last_commited_log_index, uint64_t logs_to_keep)
-try
 {
     std::lock_guard writer_lock(writer_mutex);
     std::optional<ChangelogReadResult> last_log_read_result;
@@ -1874,7 +1873,7 @@ try
     bool last_log_is_not_complete = false;
 
     /// We must start to read from this log index
-    uint64_t start_to_read_from = last_commited_log_index;
+    uint64_t start_to_read_from = last_commited_log_index + 1;
 
     /// If we need to have some reserved log read additional `logs_to_keep` logs
     if (start_to_read_from > logs_to_keep)
@@ -1894,25 +1893,20 @@ try
         {
             if (!last_log_read_result) /// still nothing was read
             {
+                LOG_INFO(log, "from log index: {}, to log index: {}, last committed log index: {}", changelog_description.from_log_index, changelog_description.to_log_index, last_commited_log_index);
                 /// Our first log starts from the more fresh log_id than we required to read and this changelog is not empty log.
-                /// So we are missing something in our logs, but it's not dataloss, we will receive snapshot and required
-                /// entries from leader.
+                /// So we are missing something in our logs.
                 if (changelog_description.from_log_index > last_commited_log_index
                     && (changelog_description.from_log_index - last_commited_log_index) > 1)
                 {
-                    LOG_ERROR(
-                        log,
-                        "Some records were lost, last committed log index {}, smallest available log index on disk {}. Hopefully will "
-                        "receive missing records from leader.",
+                    throw Exception(
+                        ErrorCodes::CORRUPTED_DATA,
+                        "Some records were lost, last committed log index {}, smallest available log index on disk {}. Manual intervention "
+                        "is necessary for recovery but removing changelogs can lead to data loss.",
                         last_commited_log_index,
                         changelog_description.from_log_index);
-                    /// Nothing to do with our more fresh log, leader will overwrite them, so remove everything and just start from last_commited_index
-                    removeAllLogs();
-                    max_log_id = last_commited_log_index == 0 ? 0 : last_commited_log_index - 1;
-                    current_writer->rotate(max_log_id + 1);
-                    initialized = true;
-                    return;
                 }
+
                 if (changelog_description.from_log_index > start_to_read_from)
                 {
                     /// We don't have required amount of reserved logs, but nothing was lost.
@@ -1946,13 +1940,12 @@ try
                 {
                     if (!last_log_read_result->error)
                     {
-                        LOG_ERROR(
-                            log,
-                            "Some records were lost, last found log index {}, while the next log index on disk is {}. Hopefully will receive "
-                            "missing records from leader.",
+                        throw Exception(
+                            ErrorCodes::CORRUPTED_DATA,
+                            "Some records were lost, last found log index {}, while the next log index on disk is {}. Manual intervention "
+                            "is necessary for recovery but removing changelogs can lead to data loss.",
                             last_read_index,
                             changelog_description.from_log_index);
-                        removeAllLogsAfter(last_log_read_result->log_start_index);
                     }
                     break;
                 }
@@ -2005,18 +1998,18 @@ try
     {
         /// Just to be sure they don't exist
         removeAllLogs();
-        max_log_id = last_commited_log_index == 0 ? 0 : last_commited_log_index - 1;
+        max_log_id = last_commited_log_index;
     }
-    else if (last_commited_log_index != 0 && max_log_id < last_commited_log_index - 1) /// If we have more fresh snapshot than our logs
+    else if (max_log_id < last_commited_log_index) /// If we have more fresh snapshot than our logs
     {
         LOG_WARNING(
             log,
             "Our most fresh log_id {} is smaller than stored data in snapshot {}. It can indicate data loss. Removing outdated logs.",
             max_log_id,
-            last_commited_log_index - 1);
+            last_commited_log_index);
 
         removeAllLogs();
-        max_log_id = last_commited_log_index - 1;
+        max_log_id = last_commited_log_index;
     }
     else if (last_log_is_not_complete) /// if it's complete just start new one
     {
@@ -2086,11 +2079,6 @@ try
 
     initialized = true;
 }
-catch (...)
-{
-    tryLogCurrentException(__PRETTY_FUNCTION__);
-}
-
 
 void Changelog::initWriter(ChangelogFileDescriptionPtr description)
 {
@@ -2351,7 +2339,7 @@ void Changelog::writeThread()
     catch (...)
     {
         tryLogCurrentException(log, "Write thread failed, aborting");
-        std::abort();
+        std::terminate();
     }
 }
 
@@ -2648,13 +2636,16 @@ void Changelog::shutdown()
 
 Changelog::~Changelog()
 {
-    try
+    if (initialized)
     {
-        flush();
-    }
-    catch (...)
-    {
-        tryLogCurrentException(__PRETTY_FUNCTION__);
+        try
+        {
+            flush();
+        }
+        catch (...)
+        {
+            tryLogCurrentException(__PRETTY_FUNCTION__);
+        }
     }
 
     try

--- a/src/Coordination/KeeperServer.cpp
+++ b/src/Coordination/KeeperServer.cpp
@@ -587,7 +587,7 @@ void KeeperServer::startup(const Poco::Util::AbstractConfiguration & config, boo
 
     const auto & coordination_settings = keeper_context->getCoordinationSettings();
 
-    state_manager->loadLogStore(state_machine->last_commit_index() + 1, coordination_settings[CoordinationSetting::reserved_log_items]);
+    state_manager->loadLogStore(state_machine->last_commit_index(), coordination_settings[CoordinationSetting::reserved_log_items]);
 
     auto log_store = state_manager->load_log_store();
     last_log_idx_on_disk = log_store->next_slot() - 1;

--- a/src/Coordination/tests/gtest_coordination.cpp
+++ b/src/Coordination/tests/gtest_coordination.cpp
@@ -288,7 +288,7 @@ void testLogAndStateMachine(
             .force_sync = true, .compress_logs = enable_compression, .rotate_interval = (*settings)[DB::CoordinationSetting::rotate_log_storage_interval]},
         DB::FlushSettings(),
         keeper_context);
-    changelog.init(state_machine->last_commit_index() + 1, (*settings)[DB::CoordinationSetting::reserved_log_items]);
+    changelog.init(state_machine->last_commit_index(), (*settings)[DB::CoordinationSetting::reserved_log_items]);
 
     for (size_t i = 1; i < total_logs + 1; ++i)
     {
@@ -336,7 +336,7 @@ void testLogAndStateMachine(
             .force_sync = true, .compress_logs = enable_compression, .rotate_interval = (*settings)[DB::CoordinationSetting::rotate_log_storage_interval]},
         DB::FlushSettings(),
         keeper_context);
-    restore_changelog.init(restore_machine->last_commit_index() + 1, (*settings)[DB::CoordinationSetting::reserved_log_items]);
+    restore_changelog.init(restore_machine->last_commit_index(), (*settings)[DB::CoordinationSetting::reserved_log_items]);
 
     EXPECT_EQ(restore_changelog.size(), std::min((*settings)[DB::CoordinationSetting::reserved_log_items] + total_logs % (*settings)[DB::CoordinationSetting::snapshot_distance], total_logs));
     EXPECT_EQ(restore_changelog.next_slot(), total_logs + 1);

--- a/src/Coordination/tests/gtest_coordination_changelog.cpp
+++ b/src/Coordination/tests/gtest_coordination_changelog.cpp
@@ -53,7 +53,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogTestSimple)
         DB::LogFileSettings{.force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 5},
         DB::FlushSettings(),
         this->keeper_context);
-    changelog.init(1, 0);
+    changelog.init(0, 0);
     auto entry = getLogEntry("hello world", 77);
     changelog.append(entry);
     changelog.end_of_append_batch(0, 0);
@@ -74,7 +74,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogTestFile)
         DB::LogFileSettings{.force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 5},
         DB::FlushSettings(),
         this->keeper_context);
-    changelog.init(1, 0);
+    changelog.init(0, 0);
     auto entry = getLogEntry("hello world", 77);
     changelog.append(entry);
     changelog.end_of_append_batch(0, 0);
@@ -107,7 +107,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogReadWrite)
         DB::LogFileSettings{.force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 1000},
         DB::FlushSettings(),
         this->keeper_context);
-    changelog.init(1, 0);
+    changelog.init(0, 0);
 
     for (size_t i = 0; i < 10; ++i)
     {
@@ -124,7 +124,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogReadWrite)
         DB::LogFileSettings{.force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 1000},
         DB::FlushSettings(),
         this->keeper_context);
-    changelog_reader.init(1, 0);
+    changelog_reader.init(0, 0);
     EXPECT_EQ(changelog_reader.size(), 10);
     EXPECT_EQ(changelog_reader.last_entry()->get_term(), changelog.last_entry()->get_term());
     EXPECT_EQ(changelog_reader.start_index(), changelog.start_index());
@@ -149,7 +149,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogWriteAt)
         DB::LogFileSettings{.force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 1000},
         DB::FlushSettings(),
         this->keeper_context);
-    changelog.init(1, 0);
+    changelog.init(0, 0);
     for (size_t i = 0; i < 10; ++i)
     {
         auto entry = getLogEntry("hello world", i * 10);
@@ -174,7 +174,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogWriteAt)
         DB::LogFileSettings{.force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 1000},
         DB::FlushSettings(),
         this->keeper_context);
-    changelog_reader.init(1, 0);
+    changelog_reader.init(0, 0);
 
     EXPECT_EQ(changelog_reader.size(), changelog.size());
     EXPECT_EQ(changelog_reader.last_entry()->get_term(), changelog.last_entry()->get_term());
@@ -193,7 +193,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogTestAppendAfterRead)
         DB::LogFileSettings{.force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 5},
         DB::FlushSettings(),
         this->keeper_context);
-    changelog.init(1, 0);
+    changelog.init(0, 0);
     for (size_t i = 0; i < 7; ++i)
     {
         auto entry = getLogEntry("hello world", i * 10);
@@ -212,7 +212,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogTestAppendAfterRead)
         DB::LogFileSettings{.force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 5},
         DB::FlushSettings(),
         this->keeper_context);
-    changelog_reader.init(1, 0);
+    changelog_reader.init(0, 0);
 
     EXPECT_EQ(changelog_reader.size(), 7);
     for (size_t i = 7; i < 10; ++i)
@@ -266,7 +266,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogTestCompaction)
         DB::LogFileSettings{.force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 5},
         DB::FlushSettings(),
         this->keeper_context);
-    changelog.init(1, 0);
+    changelog.init(0, 0);
 
     for (size_t i = 0; i < 3; ++i)
     {
@@ -320,7 +320,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogTestCompaction)
         DB::LogFileSettings{.force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 5},
         DB::FlushSettings(),
         this->keeper_context);
-    changelog_reader.init(7, 0);
+    changelog_reader.init(6, 0);
 
     EXPECT_EQ(changelog_reader.size(), 1);
     EXPECT_EQ(changelog_reader.start_index(), 7);
@@ -338,7 +338,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogTestBatchOperations)
         DB::LogFileSettings{.force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 100},
         DB::FlushSettings(),
         this->keeper_context);
-    changelog.init(1, 0);
+    changelog.init(0, 0);
     for (size_t i = 0; i < 10; ++i)
     {
         auto entry = getLogEntry(std::to_string(i) + "_hello_world", i * 10);
@@ -356,7 +356,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogTestBatchOperations)
         DB::LogFileSettings{.force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 100},
         DB::FlushSettings(),
         this->keeper_context);
-    apply_changelog.init(1, 0);
+    apply_changelog.init(0, 0);
 
     for (size_t i = 0; i < 10; ++i)
     {
@@ -395,7 +395,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogTestBatchOperationsEmpty)
             DB::LogFileSettings{.force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 100},
             DB::FlushSettings(),
             this->keeper_context);
-        changelog.init(1, 0);
+        changelog.init(0, 0);
         for (size_t i = 0; i < 10; ++i)
         {
             auto entry = getLogEntry(std::to_string(i) + "_hello_world", i * 10);
@@ -416,7 +416,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogTestBatchOperationsEmpty)
         DB::LogFileSettings{.force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 100},
         DB::FlushSettings(),
         this->keeper_context);
-    changelog_new.init(1, 0);
+    changelog_new.init(0, 0);
     EXPECT_EQ(changelog_new.size(), 0);
 
     changelog_new.apply_pack(5, *entries);
@@ -455,7 +455,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogTestWriteAtPreviousFile)
         DB::LogFileSettings{.force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 5},
         DB::FlushSettings(),
         this->keeper_context);
-    changelog.init(1, 0);
+    changelog.init(0, 0);
 
     for (size_t i = 0; i < 33; ++i)
     {
@@ -499,7 +499,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogTestWriteAtPreviousFile)
         DB::LogFileSettings{.force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 5},
         DB::FlushSettings(),
         this->keeper_context);
-    changelog_read.init(1, 0);
+    changelog_read.init(0, 0);
     EXPECT_EQ(changelog_read.size(), 7);
     EXPECT_EQ(changelog_read.start_index(), 1);
     EXPECT_EQ(changelog_read.next_slot(), 8);
@@ -516,7 +516,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogTestWriteAtFileBorder)
         DB::LogFileSettings{.force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 5},
         DB::FlushSettings(),
         this->keeper_context);
-    changelog.init(1, 0);
+    changelog.init(0, 0);
 
     for (size_t i = 0; i < 33; ++i)
     {
@@ -560,7 +560,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogTestWriteAtFileBorder)
         DB::LogFileSettings{.force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 5},
         DB::FlushSettings(),
         this->keeper_context);
-    changelog_read.init(1, 0);
+    changelog_read.init(0, 0);
     EXPECT_EQ(changelog_read.size(), 11);
     EXPECT_EQ(changelog_read.start_index(), 1);
     EXPECT_EQ(changelog_read.next_slot(), 12);
@@ -577,7 +577,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogTestWriteAtAllFiles)
         DB::LogFileSettings{.force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 5},
         DB::FlushSettings(),
         this->keeper_context);
-    changelog.init(1, 0);
+    changelog.init(0, 0);
     for (size_t i = 0; i < 33; ++i)
     {
         auto entry = getLogEntry(std::to_string(i) + "_hello_world", i * 10);
@@ -627,7 +627,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogTestStartNewLogAfterRead)
         DB::LogFileSettings{.force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 5},
         DB::FlushSettings(),
         this->keeper_context);
-    changelog.init(1, 0);
+    changelog.init(0, 0);
 
     for (size_t i = 0; i < 35; ++i)
     {
@@ -651,7 +651,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogTestStartNewLogAfterRead)
         DB::LogFileSettings{.force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 5},
         DB::FlushSettings(),
         this->keeper_context);
-    changelog_reader.init(1, 0);
+    changelog_reader.init(0, 0);
 
     auto entry = getLogEntry("36_hello_world", 360);
     changelog_reader.append(entry);
@@ -700,7 +700,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogTestReadAfterBrokenTruncate)
         DB::LogFileSettings{.force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 5},
         DB::FlushSettings(),
         this->keeper_context);
-    changelog.init(1, 0);
+    changelog.init(0, 0);
 
     for (size_t i = 0; i < 35; ++i)
     {
@@ -724,24 +724,30 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogTestReadAfterBrokenTruncate)
     plain_buf.truncate(0);
     plain_buf.finalize();
 
+    {
+        DB::KeeperLogStore changelog_reader(
+            DB::LogFileSettings{.force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 5},
+            DB::FlushSettings(),
+            this->keeper_context);
+        ASSERT_THROW(changelog_reader.init(0, 0), DB::Exception);
+    }
+
+    fs::remove(log_folder / ("changelog_16_20.bin" + this->extension));
+    fs::remove(log_folder / ("changelog_21_25.bin" + this->extension));
+    fs::remove(log_folder / ("changelog_26_30.bin" + this->extension));
+    fs::remove(log_folder / ("changelog_31_35.bin" + this->extension));
+
     DB::KeeperLogStore changelog_reader(
         DB::LogFileSettings{.force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 5},
         DB::FlushSettings(),
         this->keeper_context);
-    changelog_reader.init(1, 0);
-    changelog_reader.end_of_append_batch(0, 0);
-
+    changelog_reader.init(0, 0);
     EXPECT_EQ(changelog_reader.size(), 10);
     EXPECT_EQ(changelog_reader.last_entry()->get_term(), 90);
 
     EXPECT_TRUE(fs::exists("./logs/changelog_1_5.bin" + this->extension));
     EXPECT_TRUE(fs::exists("./logs/changelog_6_10.bin" + this->extension));
     EXPECT_TRUE(fs::exists("./logs/changelog_11_15.bin" + this->extension));
-
-    assertBrokenFileRemoved(log_folder, "changelog_16_20.bin" + this->extension);
-    assertBrokenFileRemoved(log_folder, "changelog_21_25.bin" + this->extension);
-    assertBrokenFileRemoved(log_folder, "changelog_26_30.bin" + this->extension);
-    assertBrokenFileRemoved(log_folder, "changelog_31_35.bin" + this->extension);
 
     auto entry = getLogEntry("h", 7777);
     changelog_reader.append(entry);
@@ -755,16 +761,11 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogTestReadAfterBrokenTruncate)
     EXPECT_TRUE(fs::exists("./logs/changelog_6_10.bin" + this->extension));
     EXPECT_TRUE(fs::exists("./logs/changelog_11_15.bin" + this->extension));
 
-    assertBrokenFileRemoved(log_folder, "changelog_16_20.bin" + this->extension);
-    assertBrokenFileRemoved(log_folder, "changelog_21_25.bin" + this->extension);
-    assertBrokenFileRemoved(log_folder, "changelog_26_30.bin" + this->extension);
-    assertBrokenFileRemoved(log_folder, "changelog_31_35.bin" + this->extension);
-
     DB::KeeperLogStore changelog_reader2(
         DB::LogFileSettings{.force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 5},
         DB::FlushSettings(),
         this->keeper_context);
-    changelog_reader2.init(1, 0);
+    changelog_reader2.init(0, 0);
     EXPECT_EQ(changelog_reader2.size(), 11);
     EXPECT_EQ(changelog_reader2.last_entry()->get_term(), 7777);
 }
@@ -780,7 +781,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogTestReadAfterBrokenTruncate2)
         DB::LogFileSettings{.force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 20},
         DB::FlushSettings(),
         this->keeper_context);
-    changelog.init(1, 0);
+    changelog.init(0, 0);
 
     for (size_t i = 0; i < 35; ++i)
     {
@@ -798,15 +799,24 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogTestReadAfterBrokenTruncate2)
     plain_buf.truncate(30);
     plain_buf.finalize();
 
+    {
+        DB::KeeperLogStore changelog_reader(
+            DB::LogFileSettings{.force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 20},
+            DB::FlushSettings(),
+            this->keeper_context);
+        ASSERT_THROW(changelog_reader.init(0, 0), DB::Exception);
+    }
+
+    fs::remove("./logs/changelog_21_40.bin" + this->extension);
+
     DB::KeeperLogStore changelog_reader(
         DB::LogFileSettings{.force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 20},
         DB::FlushSettings(),
         this->keeper_context);
-    changelog_reader.init(1, 0);
+    changelog_reader.init(0, 0);
 
     EXPECT_EQ(changelog_reader.size(), 0);
     EXPECT_TRUE(fs::exists("./logs/changelog_1_20.bin" + this->extension));
-    assertBrokenFileRemoved("./logs", "changelog_21_40.bin" + this->extension);
     auto entry = getLogEntry("hello_world", 7777);
     changelog_reader.append(entry);
     changelog_reader.end_of_append_batch(0, 0);
@@ -820,7 +830,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogTestReadAfterBrokenTruncate2)
         DB::LogFileSettings{.force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 1},
         DB::FlushSettings(),
         this->keeper_context);
-    changelog_reader2.init(1, 0);
+    changelog_reader2.init(0, 0);
     EXPECT_EQ(changelog_reader2.size(), 1);
     EXPECT_EQ(changelog_reader2.last_entry()->get_term(), 7777);
 }
@@ -837,7 +847,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogTestReadAfterBrokenTruncate3)
         DB::LogFileSettings{.force_sync = true, .compress_logs = false, .rotate_interval = 20},
         DB::FlushSettings(),
         this->keeper_context);
-    changelog.init(1, 0);
+    changelog.init(0, 0);
 
     for (size_t i = 0; i < 35; ++i)
     {
@@ -860,7 +870,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogTestReadAfterBrokenTruncate3)
         DB::LogFileSettings{.force_sync = true, .compress_logs = false, .rotate_interval = 20},
         DB::FlushSettings(),
         this->keeper_context);
-    changelog_reader.init(1, 0);
+    changelog_reader.init(0, 0);
 
     EXPECT_EQ(changelog_reader.size(), 19);
     EXPECT_TRUE(fs::exists("./logs/changelog_1_20.bin"));
@@ -912,7 +922,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogTestMixedLogTypes)
             DB::LogFileSettings{.force_sync = true, .compress_logs = false, .rotate_interval = 20},
             DB::FlushSettings(),
             this->keeper_context);
-        changelog.init(1, 0);
+        changelog.init(0, 0);
 
         for (size_t i = 0; i < 35; ++i)
             append_log(changelog, std::to_string(i) + "_hello_world", (i+ 44) * 10);
@@ -933,7 +943,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogTestMixedLogTypes)
             DB::LogFileSettings{.force_sync = true, .compress_logs = true, .rotate_interval = 20},
             DB::FlushSettings(),
             this->keeper_context);
-        changelog_compressed.init(1, 0);
+        changelog_compressed.init(0, 0);
 
         verify_changelog_files();
         verify_log_content(changelog_compressed);
@@ -955,7 +965,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogTestMixedLogTypes)
             DB::LogFileSettings{.force_sync = true, .compress_logs = false, .rotate_interval = 20},
             DB::FlushSettings(),
             this->keeper_context);
-        changelog.init(1, 0);
+        changelog.init(0, 0);
 
         verify_changelog_files();
         verify_log_content(changelog);
@@ -982,7 +992,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogTestLostFiles)
         DB::LogFileSettings{.force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 20},
         DB::FlushSettings(),
         this->keeper_context);
-    changelog.init(1, 0);
+    changelog.init(0, 0);
 
     for (size_t i = 0; i < 35; ++i)
     {
@@ -1001,9 +1011,8 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogTestLostFiles)
         DB::LogFileSettings{.force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 20},
         DB::FlushSettings(),
         this->keeper_context);
-    /// It should print error message, but still able to start
-    changelog_reader.init(5, 0);
-    assertBrokenFileRemoved("./logs", "changelog_21_40.bin" + this->extension);
+
+    ASSERT_THROW(changelog_reader.init(5, 0), DB::Exception);
 }
 
 TYPED_TEST(CoordinationChangelogTest, ChangelogTestLostFiles2)
@@ -1016,7 +1025,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogTestLostFiles2)
         DB::LogFileSettings{.force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 10},
         DB::FlushSettings(),
         this->keeper_context);
-    changelog.init(1, 0);
+    changelog.init(0, 0);
 
     for (size_t i = 0; i < 35; ++i)
     {
@@ -1039,12 +1048,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogTestLostFiles2)
         DB::LogFileSettings{.force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 10},
         DB::FlushSettings(),
         this->keeper_context);
-    /// It should print error message, but still able to start
-    changelog_reader.init(5, 0);
-    EXPECT_TRUE(fs::exists("./logs/changelog_1_10.bin" + this->extension));
-    EXPECT_TRUE(fs::exists("./logs/changelog_11_20.bin" + this->extension));
-
-    assertBrokenFileRemoved("./logs", "changelog_31_40.bin" + this->extension);
+    ASSERT_THROW(changelog_reader.init(5, 0), DB::Exception);
 }
 
 TYPED_TEST(CoordinationChangelogTest, TestRotateIntervalChanges)
@@ -1164,7 +1168,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogTestMaxLogSize)
                 .force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 20, .max_size = 50 * 1024 * 1024},
             DB::FlushSettings(),
             this->keeper_context);
-        changelog.init(1, 0);
+        changelog.init(0, 0);
 
         for (; i < 100; ++i)
         {
@@ -1184,7 +1188,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogTestMaxLogSize)
                 .force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 100'000, .max_size = 4000},
             DB::FlushSettings(),
             this->keeper_context);
-        changelog.init(1, 0);
+        changelog.init(0, 0);
 
         ASSERT_EQ(changelog.entry_at(last_entry_index)->get_term(), (i - 1 + 44) * 10);
 
@@ -1206,7 +1210,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogTestMaxLogSize)
                 .force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 100'000, .max_size = 4000},
             DB::FlushSettings(),
             this->keeper_context);
-        changelog.init(1, 0);
+        changelog.init(0, 0);
         ASSERT_EQ(changelog.entry_at(last_entry_index)->get_term(), (i - 1 + 44) * 10);
     }
 }
@@ -1275,7 +1279,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogInsertThreeTimesSmooth)
             DB::LogFileSettings{.force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 100},
             DB::FlushSettings(),
             this->keeper_context);
-        changelog.init(1, 0);
+        changelog.init(0, 0);
         auto entry = getLogEntry("hello_world", 1000);
         changelog.append(entry);
         changelog.end_of_append_batch(0, 0);
@@ -1289,7 +1293,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogInsertThreeTimesSmooth)
             DB::LogFileSettings{.force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 100},
             DB::FlushSettings(),
             this->keeper_context);
-        changelog.init(1, 0);
+        changelog.init(0, 0);
         auto entry = getLogEntry("hello_world", 1000);
         changelog.append(entry);
         changelog.end_of_append_batch(0, 0);
@@ -1303,7 +1307,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogInsertThreeTimesSmooth)
             DB::LogFileSettings{.force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 100},
             DB::FlushSettings(),
             this->keeper_context);
-        changelog.init(1, 0);
+        changelog.init(0, 0);
         auto entry = getLogEntry("hello_world", 1000);
         changelog.append(entry);
         changelog.end_of_append_batch(0, 0);
@@ -1317,7 +1321,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogInsertThreeTimesSmooth)
             DB::LogFileSettings{.force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 100},
             DB::FlushSettings(),
             this->keeper_context);
-        changelog.init(1, 0);
+        changelog.init(0, 0);
         auto entry = getLogEntry("hello_world", 1000);
         changelog.append(entry);
         changelog.end_of_append_batch(0, 0);
@@ -1339,7 +1343,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogInsertMultipleTimesSmooth)
             DB::LogFileSettings{.force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 100},
             DB::FlushSettings(),
             this->keeper_context);
-        changelog.init(1, 0);
+        changelog.init(0, 0);
         for (size_t j = 0; j < 7; ++j)
         {
             auto entry = getLogEntry("hello_world", 7);
@@ -1353,7 +1357,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogInsertMultipleTimesSmooth)
         DB::LogFileSettings{.force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 100},
         DB::FlushSettings(),
         this->keeper_context);
-    changelog.init(1, 0);
+    changelog.init(0, 0);
     EXPECT_EQ(changelog.next_slot(), 36 * 7 + 1);
 }
 
@@ -1368,7 +1372,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogInsertThreeTimesHard)
             DB::LogFileSettings{.force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 100},
             DB::FlushSettings(),
             this->keeper_context);
-        changelog1.init(1, 0);
+        changelog1.init(0, 0);
         auto entry = getLogEntry("hello_world", 1000);
         changelog1.append(entry);
         changelog1.end_of_append_batch(0, 0);
@@ -1382,7 +1386,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogInsertThreeTimesHard)
             DB::LogFileSettings{.force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 100},
             DB::FlushSettings(),
             this->keeper_context);
-        changelog2.init(1, 0);
+        changelog2.init(0, 0);
         auto entry = getLogEntry("hello_world", 1000);
         changelog2.append(entry);
         changelog2.end_of_append_batch(0, 0);
@@ -1396,7 +1400,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogInsertThreeTimesHard)
             DB::LogFileSettings{.force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 100},
             DB::FlushSettings(),
             this->keeper_context);
-        changelog3.init(1, 0);
+        changelog3.init(0, 0);
         auto entry = getLogEntry("hello_world", 1000);
         changelog3.append(entry);
         changelog3.end_of_append_batch(0, 0);
@@ -1410,7 +1414,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogInsertThreeTimesHard)
             DB::LogFileSettings{.force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 100},
             DB::FlushSettings(),
             this->keeper_context);
-        changelog4.init(1, 0);
+        changelog4.init(0, 0);
         auto entry = getLogEntry("hello_world", 1000);
         changelog4.append(entry);
         changelog4.end_of_append_batch(0, 0);
@@ -1444,7 +1448,7 @@ TYPED_TEST(CoordinationChangelogTest, TestLogGap)
         DB::LogFileSettings{.force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 100},
         DB::FlushSettings(),
         this->keeper_context);
-    changelog1.init(61, 3);
+    changelog1.init(60, 3);
 
     /// Logs discarded
     EXPECT_FALSE(fs::exists("./logs/changelog_1_100.bin" + this->extension));
@@ -1465,7 +1469,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogTestBrokenWriteAt)
             DB::LogFileSettings{.force_sync = true, .compress_logs = false, .rotate_interval = 20},
             DB::FlushSettings(),
             this->keeper_context);
-        changelog.init(1, 0);
+        changelog.init(0, 0);
 
         for (size_t i = 0; i < 20; ++i)
         {
@@ -1489,7 +1493,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogTestBrokenWriteAt)
             DB::LogFileSettings{.force_sync = true, .compress_logs = false, .rotate_interval = 20},
             DB::FlushSettings(),
             this->keeper_context);
-        changelog.init(1, 0);
+        changelog.init(0, 0);
 
         for (size_t i = 20; i < 25; ++i)
         {
@@ -1520,7 +1524,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogTestBrokenWriteAt)
             DB::LogFileSettings{.force_sync = true, .compress_logs = false, .rotate_interval = 20},
             DB::FlushSettings(),
             this->keeper_context);
-        changelog.init(1, 0);
+        changelog.init(0, 0);
 
         EXPECT_EQ(changelog.size(), 24);
     }
@@ -1540,7 +1544,7 @@ TYPED_TEST(CoordinationChangelogTest, ChangelogLoadingFromInvalidName)
                 .force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 100'000, .max_size = 500},
             DB::FlushSettings(),
             this->keeper_context);
-        changelog.init(1, 0);
+        changelog.init(0, 0);
 
         EXPECT_TRUE(fs::exists("./logs/changelog_1_100000.bin"));
         for (size_t i = 0; i < 500; ++i)


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
When Keeper detects broken snapshot or inconsistent changelogs, throw exception instead of manually aborting or cleaning up files automatically. This should lead to a safer behaviour of Keeper relying on manual intervention.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.544`
<!-- ch-version-info:end -->