### PR TITLE
Fix flaky tests failing due to slippery tmp FS failures

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -67,6 +67,9 @@ MESSAGES_TO_RETRY = [
     "is already started to be removing by another replica right now",
     # This is from LSan, and it indicates its own internal problem:
     "Unable to get registers from thread",
+    # Next two can be caused by a flaky tmp FS; normally fine upon retry; details at #93451
+    "No such file or directory",
+    "Permission denied",
 ]
 
 IGNORED_SANITIZER_ERRORS = [


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
TL;DR of explanation at [#93451](https://github.com/ClickHouse/ClickHouse/issues/93451#issuecomment-3749454613):
There's a flaky tmp fs outage happening rarely, which makes tmp path unavailable. Retrying should fix flakiness of certain tests, the main issue should be investigated further.

Closes #93451


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.540`
<!-- ch-version-info:end -->