### PR TITLE
Fix leaving possible leftovers in case of CREATE TABLE fails

### DIFF
--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -2050,19 +2050,7 @@ bool InterpreterCreateQuery::doCreateTable(ASTCreateQuery & create,
     /// we can safely destroy the object without a call to "shutdown", because there is guarantee
     /// that no background threads/similar resources remain after exception from "startup".
 
-    try
-    {
-        res->startup();
-    }
-    catch (...)
-    {
-        if (create.attach)
-            database->detachTable(getContext(), create.getTable());
-        else
-            database->dropTable(getContext(), create.getTable());
-
-        throw;
-    }
+    res->startup();
     return true;
 }
 

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -2050,7 +2050,19 @@ bool InterpreterCreateQuery::doCreateTable(ASTCreateQuery & create,
     /// we can safely destroy the object without a call to "shutdown", because there is guarantee
     /// that no background threads/similar resources remain after exception from "startup".
 
-    res->startup();
+    try
+    {
+        res->startup();
+    }
+    catch (...)
+    {
+        if (create.attach)
+            database->detachTable(getContext(), create.getTable());
+        else
+            database->dropTable(getContext(), create.getTable());
+
+        throw;
+    }
     return true;
 }
 

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -1772,13 +1772,16 @@ try
 }
 catch (...)
 {
-    try
+    if (mode <= LoadingStrictnessLevel::CREATE)
     {
-        storage.drop();
-    }
-    catch (...)
-    {
-        tryLogCurrentException("validateStorage");
+        try
+        {
+            storage.drop();
+        }
+        catch (...)
+        {
+            tryLogCurrentException("validateStorage");
+        }
     }
     throw;
 }

--- a/src/Storages/StorageLog.cpp
+++ b/src/Storages/StorageLog.cpp
@@ -889,6 +889,11 @@ static std::chrono::seconds getLockTimeout(ContextPtr context)
     return std::chrono::seconds{lock_timeout};
 }
 
+void StorageLog::drop()
+{
+    disk->removeRecursive(table_path);
+}
+
 void StorageLog::truncate(const ASTPtr &, const StorageMetadataPtr &, ContextPtr local_context, TableExclusiveLockHolder &)
 {
     WriteLock lock{rwlock, getLockTimeout(local_context)};

--- a/src/Storages/StorageLog.h
+++ b/src/Storages/StorageLog.h
@@ -74,6 +74,8 @@ public:
 
     void truncate(const ASTPtr &, const StorageMetadataPtr &, ContextPtr, TableExclusiveLockHolder &) override;
 
+    void drop() override;
+
     bool storesDataOnDisk() const override { return true; }
     Strings getDataPaths() const override { return {DB::fullPath(disk, table_path)}; }
     bool supportsSubcolumns() const override { return true; }

--- a/src/Storages/StorageTimeSeries.cpp
+++ b/src/Storages/StorageTimeSeries.cpp
@@ -185,15 +185,6 @@ const TimeSeriesSettings & StorageTimeSeries::getStorageSettings() const
     return *storage_settings;
 }
 
-void StorageTimeSeries::startup()
-{
-}
-
-void StorageTimeSeries::shutdown(bool)
-{
-}
-
-
 void StorageTimeSeries::drop()
 {
     /// Sync flag and the setting make sense for Atomic databases only.

--- a/src/Storages/StorageTimeSeries.h
+++ b/src/Storages/StorageTimeSeries.h
@@ -47,9 +47,6 @@ public:
     StoragePtr getTargetTable(ViewTarget::Kind target_kind, const ContextPtr & local_context) const;
     StoragePtr tryGetTargetTable(ViewTarget::Kind target_kind, const ContextPtr & local_context) const;
 
-    void startup() override;
-    void shutdown(bool is_drop) override;
-
     void read(
         QueryPlan & query_plan,
         const Names & column_names,


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix leaving possible leftovers in case of `CREATE TABLE` fails

Refs: https://github.com/ClickHouse/ClickHouse/issues/93959


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.772`
<!-- ch-version-info:end -->