### PR TITLE
Add specialized AST nodes for Enum

### DIFF
--- a/src/DataTypes/DataTypeFactory.cpp
+++ b/src/DataTypes/DataTypeFactory.cpp
@@ -38,7 +38,7 @@ static DataTypePtr createEnumFromValues(const String & type_name, const std::vec
     String type_name_upper = Poco::toUpper(type_name);
     bool use_enum16 = (type_name_upper == "ENUM16");
 
-    if (type_name_upper == "ENUM")
+    if (!use_enum16 && type_name_upper == "ENUM")
     {
         /// Auto-detect Enum8 vs Enum16 based on values
         for (const auto & [_, value] : values)

--- a/src/DataTypes/DataTypeFactory.cpp
+++ b/src/DataTypes/DataTypeFactory.cpp
@@ -1,8 +1,10 @@
 #include <DataTypes/DataTypeFactory.h>
 #include <DataTypes/DataTypeCustom.h>
+#include <DataTypes/DataTypeEnum.h>
 #include <Parsers/parseQuery.h>
 #include <Parsers/ParserCreateQuery.h>
 #include <Parsers/ASTDataType.h>
+#include <Parsers/ASTEnumDataType.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTLiteral.h>
 #include <Common/typeid_cast.h>
@@ -28,6 +30,43 @@ namespace ErrorCodes
     extern const int UNKNOWN_TYPE;
     extern const int UNEXPECTED_AST_STRUCTURE;
     extern const int DATA_TYPE_CANNOT_HAVE_ARGUMENTS;
+}
+
+/// Helper to create Enum data type from ASTEnumDataType values
+static DataTypePtr createEnumFromValues(const String & type_name, const std::vector<std::pair<String, Int64>> & values)
+{
+    String type_name_upper = Poco::toUpper(type_name);
+    bool use_enum16 = (type_name_upper == "ENUM16");
+
+    if (type_name_upper == "ENUM")
+    {
+        /// Auto-detect Enum8 vs Enum16 based on values
+        for (const auto & [_, value] : values)
+        {
+            if (value < std::numeric_limits<Int8>::min() || value > std::numeric_limits<Int8>::max())
+            {
+                use_enum16 = true;
+                break;
+            }
+        }
+    }
+
+    if (use_enum16)
+    {
+        DataTypeEnum16::Values enum_values;
+        enum_values.reserve(values.size());
+        for (const auto & [name, value] : values)
+            enum_values.emplace_back(name, static_cast<Int16>(value));
+        return std::make_shared<DataTypeEnum16>(enum_values);
+    }
+    else
+    {
+        DataTypeEnum8::Values enum_values;
+        enum_values.reserve(values.size());
+        for (const auto & [name, value] : values)
+            enum_values.emplace_back(name, static_cast<Int8>(value));
+        return std::make_shared<DataTypeEnum8>(enum_values);
+    }
 }
 
 DataTypePtr DataTypeFactory::get(const String & full_name) const
@@ -86,6 +125,26 @@ DataTypePtr DataTypeFactory::tryGet(const ASTPtr & ast) const
 template <bool nullptr_on_error>
 DataTypePtr DataTypeFactory::getImpl(const ASTPtr & ast) const
 {
+    /// Handle specialized ASTEnumDataType directly
+    if (const auto * enum_type = ast->as<ASTEnumDataType>())
+    {
+        if constexpr (nullptr_on_error)
+        {
+            try
+            {
+                return createEnumFromValues(enum_type->name, enum_type->values);
+            }
+            catch (...)
+            {
+                return nullptr;
+            }
+        }
+        else
+        {
+            return createEnumFromValues(enum_type->name, enum_type->values);
+        }
+    }
+
     if (const auto * type = ast->as<ASTDataType>())
     {
         return getImpl<nullptr_on_error>(type->name, type->arguments);

--- a/src/DataTypes/DataTypeFactory.cpp
+++ b/src/DataTypes/DataTypeFactory.cpp
@@ -127,23 +127,7 @@ DataTypePtr DataTypeFactory::getImpl(const ASTPtr & ast) const
 {
     /// Handle specialized ASTEnumDataType directly
     if (const auto * enum_type = ast->as<ASTEnumDataType>())
-    {
-        if constexpr (nullptr_on_error)
-        {
-            try
-            {
-                return createEnumFromValues(enum_type->name, enum_type->values);
-            }
-            catch (...)
-            {
-                return nullptr;
-            }
-        }
-        else
-        {
-            return createEnumFromValues(enum_type->name, enum_type->values);
-        }
-    }
+        return createEnumFromValues(enum_type->name, enum_type->values);
 
     if (const auto * type = ast->as<ASTDataType>())
     {

--- a/src/Parsers/ASTEnumDataType.cpp
+++ b/src/Parsers/ASTEnumDataType.cpp
@@ -1,0 +1,62 @@
+#include <Parsers/ASTEnumDataType.h>
+#include <Common/SipHash.h>
+#include <IO/Operators.h>
+#include <IO/WriteHelpers.h>
+
+
+namespace DB
+{
+
+String ASTEnumDataType::getID(char delim) const
+{
+    return "EnumDataType" + (delim + name);
+}
+
+ASTPtr ASTEnumDataType::clone() const
+{
+    auto res = std::make_shared<ASTEnumDataType>(*this);
+    res->children.clear();
+    /// values vector is copied by the copy constructor
+    /// No arguments to clone since we don't use ASTLiteral children
+    return res;
+}
+
+void ASTEnumDataType::updateTreeHashImpl(SipHash & hash_state, bool /*ignore_aliases*/) const
+{
+    hash_state.update(name.size());
+    hash_state.update(name);
+
+    hash_state.update(values.size());
+    for (const auto & [elem_name, elem_value] : values)
+    {
+        hash_state.update(elem_name.size());
+        hash_state.update(elem_name);
+        hash_state.update(elem_value);
+    }
+}
+
+void ASTEnumDataType::formatImpl(WriteBuffer & ostr, const FormatSettings & /*settings*/, FormatState & /*state*/, FormatStateStacked /*frame*/) const
+{
+    ostr << name;
+
+    if (!values.empty())
+    {
+        ostr << '(';
+
+        bool first = true;
+        for (const auto & [elem_name, elem_value] : values)
+        {
+            if (!first)
+                ostr << ", ";
+            first = false;
+
+            writeQuotedString(elem_name, ostr);
+            ostr << " = ";
+            writeText(elem_value, ostr);
+        }
+
+        ostr << ')';
+    }
+}
+
+}

--- a/src/Parsers/ASTEnumDataType.h
+++ b/src/Parsers/ASTEnumDataType.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <Parsers/ASTDataType.h>
+#include <vector>
+#include <utility>
+
+
+namespace DB
+{
+
+/// Specialized AST for Enum data types (Enum8, Enum16, Enum)
+/// Stores enum values directly as vector of pairs instead of ASTLiteral children,
+/// significantly reducing memory allocations for enums with many values.
+class ASTEnumDataType : public ASTDataType
+{
+public:
+    /// Direct storage of enum values: (name, value) pairs
+    /// No ASTFunction/ASTLiteral children needed
+    std::vector<std::pair<String, Int64>> values;
+
+    String getID(char delim) const override;
+    ASTPtr clone() const override;
+    void updateTreeHashImpl(SipHash & hash_state, bool ignore_aliases) const override;
+
+protected:
+    /// Outputs: Enum8('name1' = 1, 'name2' = 2, ...)
+    void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+};
+
+}

--- a/src/Parsers/ParserDataType.cpp
+++ b/src/Parsers/ParserDataType.cpp
@@ -2,6 +2,7 @@
 
 #include <boost/algorithm/string/case_conv.hpp>
 #include <Parsers/ASTDataType.h>
+#include <Parsers/ASTEnumDataType.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier_fwd.h>
 #include <Parsers/ASTObjectTypeArgument.h>
@@ -9,6 +10,8 @@
 #include <Parsers/ExpressionElementParsers.h>
 #include <Parsers/ParserCreateQuery.h>
 #include <Common/StringUtils.h>
+#include <IO/ReadBufferFromMemory.h>
+#include <IO/ReadHelpers.h>
 
 
 namespace DB
@@ -16,6 +19,89 @@ namespace DB
 
 namespace
 {
+
+bool isEnumType(const String & type_name_upper)
+{
+    return type_name_upper == "ENUM" || type_name_upper == "ENUM8" || type_name_upper == "ENUM16";
+}
+
+/// Parse enum values directly into the vector without creating ASTLiteral nodes.
+/// Format: 'name1' = value1, 'name2' = value2, ...
+/// Only handles fully explicit enums (all values must have = number).
+/// Returns false to fall back to generic parser for auto-assigned values or special literals.
+bool parseEnumValues(
+    IParser::Pos & pos,
+    std::vector<std::pair<String, Int64>> & values,
+    Expected & expected)
+{
+    bool first_element = true;
+
+    while (true)
+    {
+        if (!first_element)
+        {
+            if (pos->type != TokenType::Comma)
+                break;
+            ++pos;
+        }
+        first_element = false;
+
+        if (pos->type != TokenType::StringLiteral)
+        {
+            expected.add(pos, "string literal for enum element name");
+            return false;
+        }
+
+        /// Check for prefixed string literals like b'...' or x'...' - fall back to generic parser
+        char first_char = *pos->begin;
+        if (first_char == 'b' || first_char == 'B' || first_char == 'x' || first_char == 'X')
+            return false;
+
+        String elem_name;
+        ReadBufferFromMemory in(pos->begin, pos->size());
+        try
+        {
+            readQuotedStringWithSQLStyle(elem_name, in);
+        }
+        catch (const Exception &)
+        {
+            return false;
+        }
+
+        if (in.count() != pos->size())
+            return false;
+        ++pos;
+
+        /// Must have explicit value - if not, fall back to generic parser for auto-assignment
+        if (pos->type != TokenType::Equals)
+            return false;
+        ++pos;
+
+        bool negative = false;
+        if (pos->type == TokenType::Minus)
+        {
+            negative = true;
+            ++pos;
+        }
+
+        if (pos->type != TokenType::Number)
+        {
+            expected.add(pos, "number for enum element value");
+            return false;
+        }
+
+        UInt64 abs_value = 0;
+        ReadBufferFromMemory num_in(pos->begin, pos->size());
+        if (!tryReadIntText(abs_value, num_in) || num_in.count() != pos->size())
+            return false;
+        ++pos;
+
+        Int64 elem_value = negative ? -static_cast<Int64>(abs_value) : static_cast<Int64>(abs_value);
+        values.emplace_back(elem_name, elem_value);
+    }
+
+    return !values.empty();
+}
 
 /// Parser of Dynamic type argument: Dynamic(max_types=N)
 class DynamicArgumentParser : public IParserBase
@@ -225,6 +311,26 @@ bool ParserDataType::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
         { // the end of the type definition was reached and there was a trailing comma
             ++pos;
         }
+    }
+
+    /// Handle Enum types specially - parse directly into ASTEnumDataType
+    /// to avoid creating hundreds of ASTLiteral nodes for large enums.
+    /// Only handles fully explicit enums; falls back to generic parser for auto-assigned values.
+    if (isEnumType(type_name_upper) && pos->type == TokenType::OpeningRoundBracket)
+    {
+        auto saved_pos = pos;
+        ++pos;
+
+        auto enum_node = std::make_shared<ASTEnumDataType>();
+        enum_node->name = type_name;
+
+        if (parseEnumValues(pos, enum_node->values, expected) && pos->type == TokenType::ClosingRoundBracket)
+        {
+            ++pos;
+            node = enum_node;
+            return true;
+        }
+        pos = saved_pos;
     }
 
     auto data_type_node = std::make_shared<ASTDataType>();

--- a/src/Parsers/ParserDataType.cpp
+++ b/src/Parsers/ParserDataType.cpp
@@ -59,16 +59,7 @@ bool parseEnumValues(
 
         String elem_name;
         ReadBufferFromMemory in(pos->begin, pos->size());
-        try
-        {
-            readQuotedStringWithSQLStyle(elem_name, in);
-        }
-        catch (const Exception &)
-        {
-            return false;
-        }
-
-        if (in.count() != pos->size())
+        if (!tryReadQuotedStringWithSQLStyle(elem_name, in) || in.count() != pos->size())
             return false;
         ++pos;
 

--- a/src/Parsers/ParserDataType.cpp
+++ b/src/Parsers/ParserDataType.cpp
@@ -318,6 +318,7 @@ bool ParserDataType::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
         if (parseEnumValues(pos, enum_node->values, expected) && pos->type == TokenType::ClosingRoundBracket)
         {
             ++pos;
+            enum_node->values.shrink_to_fit();
             node = enum_node;
             return true;
         }


### PR DESCRIPTION
### Changelog category (leave one):

- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Introduce Enum AST specialized class to store value parameters in string,integer pairs instead of ASTLiteral children to optimize memory consumption. 


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

Enum definitions with many values previously created one ASTLiteral node per value (with expensive Field variant inside). For enums with 100+ values, this adds up to significant memory overhead.

This change introduces ASTEnumDataType which stores enum values directly as std::vector<std::pair<String, Int64>>, avoiding the ASTLiteral overhead.

The specialized parser only handles enums where all values have explicit assignments ('name' = value). For auto-assigned values, it falls back to the generic parser which handles the complex assignment rules and validation.

Also falls back for binary/hex string literals (b'...', x'...) which need special literal parsing.

Part of https://github.com/ClickHouse/ClickHouse/pull/94094


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.606`
<!-- ch-version-info:end -->