### PR TITLE
Fix nullptr dereference in `PostgreSQL` database engines

### DIFF
--- a/src/Databases/PostgreSQL/DatabaseMaterializedPostgreSQL.cpp
+++ b/src/Databases/PostgreSQL/DatabaseMaterializedPostgreSQL.cpp
@@ -509,11 +509,12 @@ void registerDatabaseMaterializedPostgreSQL(DatabaseFactory & factory)
     {
         auto * engine_define = args.create_query.storage;
         const ASTFunction * engine = engine_define->engine;
-        ASTs & engine_args = engine->arguments->children;
-        const String & engine_name = engine_define->engine->name;
 
         if (!engine->arguments)
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Engine `{}` must have arguments", engine_name);
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Engine `MaterializedPostgreSQL` must have arguments");
+
+        ASTs & engine_args = engine->arguments->children;
+        const String & engine_name = engine_define->engine->name;
 
         StoragePostgreSQL::Configuration configuration;
 

--- a/src/Databases/PostgreSQL/DatabasePostgreSQL.cpp
+++ b/src/Databases/PostgreSQL/DatabasePostgreSQL.cpp
@@ -529,11 +529,12 @@ void registerDatabasePostgreSQL(DatabaseFactory & factory)
     {
         auto * engine_define = args.create_query.storage;
         const ASTFunction * engine = engine_define->engine;
-        ASTs & engine_args = engine->arguments->children;
-        const String & engine_name = engine_define->engine->name;
 
         if (!engine->arguments)
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Engine `{}` must have arguments", engine_name);
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Engine `PostgreSQL` must have arguments");
+
+        ASTs & engine_args = engine->arguments->children;
+        const String & engine_name = engine_define->engine->name;
 
         auto use_table_cache = false;
         StoragePostgreSQL::Configuration configuration;

--- a/tests/queries/0_stateless/03790_materialized_postgresql_nullptr_dereference.sql
+++ b/tests/queries/0_stateless/03790_materialized_postgresql_nullptr_dereference.sql
@@ -2,5 +2,5 @@
 -- depends on libpq
 
 SET allow_experimental_database_materialized_postgresql = 1;
-CREATE DATABASE test ENGINE = MaterializedPostgreSQL; -- { serverError BAD_ARGUMENTS }
-CREATE DATABASE test ENGINE = PostgreSQL; -- { serverError BAD_ARGUMENTS }
+CREATE DATABASE d03790_materialized_postgresql_nullptr_dereference ENGINE = MaterializedPostgreSQL; -- { serverError BAD_ARGUMENTS }
+CREATE DATABASE d03790_materialized_postgresql_nullptr_dereference ENGINE = PostgreSQL; -- { serverError BAD_ARGUMENTS }

--- a/tests/queries/0_stateless/03790_materialized_postgresql_nullptr_dereference.sql
+++ b/tests/queries/0_stateless/03790_materialized_postgresql_nullptr_dereference.sql
@@ -1,0 +1,6 @@
+-- Tags: no-fasttest
+-- depends on libpq
+
+SET allow_experimental_database_materialized_postgresql = 1;
+CREATE DATABASE test ENGINE = MaterializedPostgreSQL; -- { serverError BAD_ARGUMENTS }
+CREATE DATABASE test ENGINE = PostgreSQL; -- { serverError BAD_ARGUMENTS }


### PR DESCRIPTION
The code was accessing engine->arguments->children before checking if engine->arguments was null, causing a nullptr dereference when creating a database without arguments.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix nullptr dereference in `PostgreSQL` database engines (when the query is incorrect). Closes #92887.

See https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=6f9b4b2b62a14a1a9f47c94cf2bbd8100a701171&name_0=MasterCI&name_1=BuzzHouse%20%28amd_ubsan%29&name_1=BuzzHouse%20%28amd_ubsan%29


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.534`
- Backported to: `25.12.4.14`, `25.11.7.25`, `25.10.5.26`, `25.8.15.19`, `25.3.13.16`
<!-- ch-version-info:end -->