### PR TITLE
tests: fix test_max_temporary_data_size_on_disk flakiness

### DIFF
--- a/tests/integration/test_max_temporary_data_size_on_disk/test.py
+++ b/tests/integration/test_max_temporary_data_size_on_disk/test.py
@@ -28,6 +28,6 @@ def test(start_cluster):
             """
         )
         for i in range(10):
-            node.query("SELECT k1, k2, k3, sum(value) v FROM t_proj_external GROUP BY k1, k2, k3 ORDER BY k1, k2, k3 SETTINGS optimize_aggregation_in_order = 0, max_bytes_before_external_group_by = 1, max_bytes_ratio_before_external_group_by = 0, group_by_two_level_threshold = 1")
+            node.query("SELECT k1, k2, k3, sum(value) v FROM t_proj_external GROUP BY k1, k2, k3 ORDER BY k1, k2, k3 SETTINGS optimize_aggregation_in_order = 0, max_bytes_before_external_group_by = 1, max_bytes_ratio_before_external_group_by = 0, group_by_two_level_threshold = 1, max_block_size=65000")
     finally:
         node.query("DROP TABLE IF EXISTS t_proj_external SYNC")

--- a/tests/integration/test_max_temporary_data_size_on_disk/test.py
+++ b/tests/integration/test_max_temporary_data_size_on_disk/test.py
@@ -1,5 +1,5 @@
 import pytest
-
+from helpers.client import QueryRuntimeException
 from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
@@ -27,7 +27,15 @@ def test(start_cluster):
             INSERT INTO t_proj_external SELECT 1, number%2, number%4, number FROM numbers(50000);
             """
         )
-        for i in range(10):
+
+        with pytest.raises(
+            QueryRuntimeException,
+            match="Limit for temporary files size exceeded.* 10240 bytes",
+        ):
+            node.query("SELECT sumMap([number], [number]) FROM numbers(1e6) group by number%100000 format Null settings max_threads=1, max_bytes_before_external_group_by = 1, max_bytes_ratio_before_external_group_by = 0, group_by_two_level_threshold = 1, max_block_size=1000")
+
+        for _ in range(10):
             node.query("SELECT k1, k2, k3, sum(value) v FROM t_proj_external GROUP BY k1, k2, k3 ORDER BY k1, k2, k3 SETTINGS optimize_aggregation_in_order = 0, max_bytes_before_external_group_by = 1, max_bytes_ratio_before_external_group_by = 0, group_by_two_level_threshold = 1, max_block_size=65000")
+
     finally:
         node.query("DROP TABLE IF EXISTS t_proj_external SYNC")


### PR DESCRIPTION
Integration tests randomizes max_block_size, from 8k to 100k

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes: https://github.com/ClickHouse/ClickHouse/issues/93911


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.721`
<!-- ch-version-info:end -->