### PR TITLE
tests: disable 02473_multistep_split_prewhere under MSan/ASan (too slow)

### DIFF
--- a/tests/queries/0_stateless/02473_multistep_split_prewhere.sh
+++ b/tests/queries/0_stateless/02473_multistep_split_prewhere.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Tags: long
+# Tags: long, no-parallel, no-msan, no-asan, no-flaky-check, no-tsan
+# ^ The test is heavy
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes: https://github.com/ClickHouse/ClickHouse/issues/93608


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.541`
<!-- ch-version-info:end -->