### PR TITLE
Make 03753_segfault_with_empty_callback no-parallel

### DIFF
--- a/tests/queries/0_stateless/03753_segfault_with_empty_callback.sql
+++ b/tests/queries/0_stateless/03753_segfault_with_empty_callback.sql
@@ -1,2 +1,4 @@
+-- Tags: no-parallel
+-- no-parallel: Uses failpoints, which break concurrent queries
 SYSTEM ENABLE FAILPOINT execute_query_calling_empty_set_result_func_on_exception;
 SELECT 1 FROM url('http://localhost:8123/?query=SELECT+1+FROM+t0+FORMAT+JSON', 'JSON', 'c0 Int') tx; -- { serverError RECEIVED_ERROR_FROM_REMOTE_IO_SERVER }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Make 03753_segfault_with_empty_callback no-parallel

Otherwise it breaks random tests, like https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=94197&sha=9e1d55517f402a915c155fcacf9bd6ee28856d6f&name_0=PR&name_1=Stateless%20tests%20%28amd_tsan%2C%20parallel%29
https://github.com/ClickHouse/ClickHouse/pull/94197

```
2026.01.14 17:31:16.466580 [ 50634 ] {} <Trace> HTTP-Session-13652d2e-a7da-4486-b3cf-c3234883b2d0: 13652d2e-a7da-4486-b3cf-c3234883b2d0 Creating query context from session context, user_id: 94309d50-4f52-5250-31bd-74fecac179db, parent context user: default
2026.01.14 17:31:16.466708 [ 13021 ] {8244bb6b-1e9b-4a66-8d74-b8faf0621f16} <Error> DynamicQueryHandler: std::exception. Code: 1001, type: std::__1::bad_function_call, e.what() = std::bad_function_call, Stack trace (when copying this message, always include the lines below):

0. ./contrib/llvm-project/libcxx/include/__exception/exception.h:113: std::bad_function_call::bad_function_call[abi:ne210105]() @ 0x0000000009eef9d6
1. ./ci/tmp/build/./src/Interpreters/executeQuery.cpp:2097: DB::executeQuery(std::unique_ptr<DB::ReadBuffer, std::default_delete<DB::ReadBuffer>>, DB::WriteBuffer&, std::shared_ptr<DB::Context>, std::function<void (DB::QueryResultDetails const&)>, DB::QueryFlags, std::optional<DB::FormatSettings> const&, std::function<void (DB::IOutputFormat&, String const&, std::shared_ptr<DB::Context const> const&, std::optional<DB::FormatSettings> const&)>, std::function<void ()>, std::function<void ()>)::$_2::operator()() const @ 0x0000000020c66354
2. ./ci/tmp/build/./src/Interpreters/executeQuery.cpp:2128: DB::executeQuery(std::unique_ptr<DB::ReadBuffer, std::default_delete<DB::ReadBuffer>>, DB::WriteBuffer&, std::shared_ptr<DB::Context>, std::function<void (DB::QueryResultDetails const&)>, DB::QueryFlags, std::optional<DB::FormatSettings> const&, std::function<void (DB::IOutputFormat&, String const&, std::shared_ptr<DB::Context const> const&, std::optional<DB::FormatSettings> const&)>, std::function<void ()>, std::function<void ()>) @ 0x0000000020c626bd
3. ./ci/tmp/build/./src/Server/HTTPHandler.cpp:607: DB::HTTPHandler::processQuery(DB::HTTPServerRequest&, DB::HTMLForm&, DB::HTTPServerResponse&, DB::HTTPHandler::Output&, std::optional<DB::CurrentThread::QueryScope>&, StrongTypedef<unsigned long, ProfileEvents::EventTag> const&) @ 0x0000000026a202d7
4. ./ci/tmp/build/./src/Server/HTTPHandler.cpp:757: DB::HTTPHandler::handleRequest(DB::HTTPServerRequest&, DB::HTTPServerResponse&, StrongTypedef<unsigned long, ProfileEvents::EventTag> const&) @ 0x0000000026a25ebd
5. ./ci/tmp/build/./src/Server/HTTP/HTTPServerConnection.cpp:105: DB::HTTPServerConnection::run() @ 0x0000000026b7f142
6. ./ci/tmp/build/./base/poco/Net/src/TCPServerConnection.cpp:40: Poco::Net::TCPServerConnection::start() @ 0x000000002f503123
7. ./ci/tmp/build/./base/poco/Net/src/TCPServerDispatcher.cpp:115: Poco::Net::TCPServerDispatcher::run() @ 0x000000002f503a42
8. ./ci/tmp/build/./base/poco/Foundation/src/ThreadPool.cpp:205: Poco::PooledThread::run() @ 0x000000002f465b91
9. ./ci/tmp/build/./base/poco/Foundation/src/Thread.cpp:45: Poco::(anonymous namespace)::RunnableHolder::run() @ 0x000000002f463c70
10. ./base/poco/Foundation/src/Thread_POSIX.cpp:341: Poco::ThreadImpl::runnableEntry(void*) @ 0x000000002f461f0a
11. __tsan_thread_start_func @ 0x0000000009ce13e8
12. ? @ 0x0000000000094ac3
13. ? @ 0x00000000001268c0
 (version 26.1.1.515)
2026.01.14 17:31:16.467080 [ 13021 ] {8244bb6b-1e9b-4a66-8d74-b8faf0621f16} <Debug> sendExceptionToHTTPClient: Draining connection (HTTP/1.1, Transfer-Encoding: identity, Content-Length: 38, Keep-Alive: true)
```

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.539`
<!-- ch-version-info:end -->