### PR TITLE
Fix bad assert in ColumnSparse::popBack

### DIFF
--- a/src/Columns/ColumnSparse.cpp
+++ b/src/Columns/ColumnSparse.cpp
@@ -300,7 +300,7 @@ void ColumnSparse::insertManyDefaults(size_t length)
 
 void ColumnSparse::popBack(size_t n)
 {
-    assert(n < _size);
+    assert(n <= _size);
 
     auto & offsets_data = getOffsetsData();
     size_t new_size = _size - n;

--- a/tests/queries/0_stateless/03783_sparse_pop_back.sh
+++ b/tests/queries/0_stateless/03783_sparse_pop_back.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT --query="insert into function file('${CLICKHOUSE_TEST_UNIQUE_NAME}.csv') select tuple(0, 'Hello') settings engine_file_truncate_on_insert=1"
+
+$CLICKHOUSE_CLIENT --query="drop table if exists test;"
+$CLICKHOUSE_CLIENT --query="create table test (a Tuple(Int32, Int32)) engine = MergeTree order by tuple() settings min_bytes_for_wide_part=1, ratio_of_defaults_for_sparse_serialization=0.01;"
+$CLICKHOUSE_CLIENT --query="insert into test select tuple(0, 0) from numbers(100)"
+$CLICKHOUSE_CLIENT --query="insert into test select * FROM file('${CLICKHOUSE_TEST_UNIQUE_NAME}.csv') settings input_format_allow_errors_num=1"
+$CLICKHOUSE_CLIENT --query="drop table test;"


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Closes https://github.com/ClickHouse/ClickHouse/issues/94179

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.556`
<!-- ch-version-info:end -->