### PR TITLE
Fix test `fix-test-00091_prewhere_two_conditions`

### DIFF
--- a/tests/queries/0_stateless/00091_prewhere_two_conditions.sql
+++ b/tests/queries/0_stateless/00091_prewhere_two_conditions.sql
@@ -1,4 +1,4 @@
--- Tags: stateful, no-parallel-replicas
+-- Tags: stateful, no-parallel-replicas, long
 -- Requires investigation (max_bytes_to_read is not respected)
 
 SET max_bytes_to_read = 600000000;

--- a/tests/queries/0_stateless/00091_prewhere_two_conditions.sql
+++ b/tests/queries/0_stateless/00091_prewhere_two_conditions.sql
@@ -13,6 +13,7 @@ WITH toTimeZone(EventTime, 'Asia/Dubai') AS xyz SELECT uniq(*) FROM test.hits WH
 
 SET optimize_move_to_prewhere = 0;
 SET enable_multiple_prewhere_read_steps = 0;
+SET use_query_condition_cache = 0;
 
 SELECT uniq(URL) FROM test.hits WHERE toTimeZone(EventTime, 'Asia/Dubai') >= '2014-03-20 00:00:00' AND toTimeZone(EventTime, 'Asia/Dubai') < '2014-03-21 00:00:00'; -- { serverError TOO_MANY_BYTES }
 SELECT uniq(URL) FROM test.hits WHERE toTimeZone(EventTime, 'Asia/Dubai') >= '2014-03-20 00:00:00' AND URL != '' AND toTimeZone(EventTime, 'Asia/Dubai') < '2014-03-21 00:00:00'; -- { serverError TOO_MANY_BYTES }


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

Closes #94110.

It was "targeted" check with repeated runs, which gave a clue: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=93715&sha=dae957b68de0037eee899f4ea950fb6176396278&name_0=PR&name_1=Stateless%20tests%20%28arm_asan%2C%20targeted%29
https://github.com/ClickHouse/ClickHouse/pull/93715


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.552`
<!-- ch-version-info:end -->