### PR TITLE
Fix flaky test `03759_join_filterpushdown_granules_read`

### DIFF
--- a/tests/queries/0_stateless/03759_join_filterpushdown_granules_read.sql
+++ b/tests/queries/0_stateless/03759_join_filterpushdown_granules_read.sql
@@ -2,7 +2,7 @@ DROP TABLE IF EXISTS t_mem;
 DROP TABLE IF EXISTS t_mt;
 
 CREATE TABLE t_mem (a Int32, b Int32) ENGINE = Memory;
-CREATE TABLE t_mt (a Int32, b Int32) ENGINE = MergeTree ORDER BY a SETTINGS index_granularity = 1024;
+CREATE TABLE t_mt (a Int32, b Int32) ENGINE = MergeTree ORDER BY a SETTINGS index_granularity = 1024, index_granularity_bytes = '10Mi';
 
 INSERT INTO t_mem SELECT number, sipHash64(number, 1) FROM numbers(5_000);
 INSERT INTO t_mt SELECT number, sipHash64(number, 2) FROM numbers(5_000);


### PR DESCRIPTION
The test expected specific mark counts based on index_granularity = 1024, but the fuzzer's random index_granularity_bytes setting could override this with adaptive granularity, causing more granules to be created.

Setting index_granularity_bytes = '10Mi' ensures the row-based granularity is used for this small test table.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

Closes #94218.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.549`
<!-- ch-version-info:end -->