### PR TITLE
Remove wrong `noexcept` specifier at HashTable copy assignment

### DIFF
--- a/src/Common/HashTable/HashTable.h
+++ b/src/Common/HashTable/HashTable.h
@@ -848,7 +848,7 @@ public:
         return *this;
     }
 
-    HashTable & operator=(const HashTable & rhs) noexcept
+    HashTable & operator=(const HashTable & rhs)
     {
         if (this == &rhs)
             return *this;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Remove the wrong `noexcept` specifier at HashTable copy assignment that may lead to crash (`std::terminate`) on memory exceptions.

---

Introduced in #89727


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.548`
- Backported to: `25.12.4.17`, `25.11.7.26`
<!-- ch-version-info:end -->