### PR TITLE
Fix something about Docker in CI

### DIFF
--- a/ci/praktika/info.py
+++ b/ci/praktika/info.py
@@ -271,7 +271,8 @@ class Info:
         return True
 
     def docker_tag(self, image_name):
-        runconfig = self.get_kv_data("workflow_config")
-        if runconfig:
-            return runconfig.get("digest_dockers", None).get(image_name, None)
+        if self.env.WORKFLOW_CONFIG:
+            digest_dockers = self.env.WORKFLOW_CONFIG.get("digest_dockers", None)
+            if digest_dockers:
+                return digest_dockers.get(image_name, None)
         return None

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -334,7 +334,7 @@ static void incrementProfileEventsBlock(Block & dst, const Block & src)
         }
     }
 
-    /// Copy rows from src that dst does not contains.
+    /// Copy rows from src that dst does not contain.
     for (const auto & [id, pos] : rows_by_name)
     {
         for (size_t col = 0; col < src.columns(); ++col)

--- a/tests/queries/0_stateless/03746_system_background_schedule_pool_log.sh
+++ b/tests/queries/0_stateless/03746_system_background_schedule_pool_log.sh
@@ -28,7 +28,7 @@ function wait_distributed_background_flush()
   return 1
 }
 if ! wait_distributed_background_flush; then
-  echo "test_local_03745 does not contains all data" >&2
+  echo "test_local_03745 does not contain all data" >&2
   exit 1
 fi
 $CLICKHOUSE_CLIENT -nmq "


### PR DESCRIPTION
> The docker_tag() method was looking for docker digest information in env.JOB_KV_DATA["workflow_config"], but the CI config job stores this data in env.WORKFLOW_CONFIG. This caused integration tests to fail with "No tag found for image" errors.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

I don't fully understand these changes, not enough expertise in Python.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.545`
<!-- ch-version-info:end -->