### PR TITLE
Fix data race in Context::executeTableFunction while pushing to MVs v2

### DIFF
--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -2587,11 +2587,7 @@ StoragePtr Context::executeTableFunction(const ASTPtr & table_expression, const 
     auto hash = table_expression->getTreeHash(/*ignore_aliases=*/ true);
     auto key = toString(hash);
 
-    StoragePtr res;
-    {
-        std::lock_guard lock(table_function_results_mutex);
-        res = table_function_results[key];
-    }
+    StoragePtr res = table_function_results[key];
 
     if (!res)
     {
@@ -2751,7 +2747,6 @@ StoragePtr Context::executeTableFunction(const ASTPtr & table_expression, const 
         ///
         auto new_hash = table_expression->getTreeHash(/*ignore_aliases=*/ true);
 
-        std::lock_guard lock(table_function_results_mutex);
         table_function_results[key] = res;
         if (hash != new_hash)
         {
@@ -2767,18 +2762,11 @@ StoragePtr Context::executeTableFunction(const ASTPtr & table_expression, const 
     const auto hash = table_expression->getTreeHash(/*ignore_aliases=*/ true);
     const auto key = toString(hash);
 
-    StoragePtr res;
-    {
-        std::lock_guard lock(table_function_results_mutex);
-        res = table_function_results[key];
-    }
+    StoragePtr res = table_function_results[key];
 
     if (!res)
     {
         res = table_function_ptr->execute(table_expression, shared_from_this(), table_function_ptr->getName());
-        std::lock_guard lock(table_function_results_mutex);
-        /// In case of race, another thread might have inserted a result already.
-        /// We just overwrite it since both should be equivalent.
         table_function_results[key] = res;
     }
 

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -530,7 +530,6 @@ protected:
     /// TODO: maybe replace with temporary tables?
     StoragePtr view_source;                 /// Temporary StorageValues used to generate alias columns for materialized views
     Tables table_function_results;          /// Temporary tables obtained by execution of table functions. Keyed by AST tree id.
-    mutable std::mutex table_function_results_mutex;
 
     ContextWeakMutablePtr query_context;
     ContextWeakMutablePtr session_context;  /// Session context or nullptr. Could be equal to this.

--- a/src/Interpreters/InsertDependenciesBuilder.cpp
+++ b/src/Interpreters/InsertDependenciesBuilder.cpp
@@ -596,6 +596,8 @@ private:
         ///  but it will contain single block (that is INSERT-ed into main table).
         /// InterpreterSelectQuery will do processing of alias columns.
         auto local_context = Context::createCopy(context);
+        /// Avoid sharing query_context, since it can be accessed from multiple threads
+        local_context->setQueryContext(std::const_pointer_cast<Context>(context));
 
         local_context->addViewSource(std::make_shared<StorageValues>(
             source_id,


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix data race in Context::executeTableFunction while pushing to MVs v2

Refs: https://github.com/ClickHouse/ClickHouse/pull/94171