### PR TITLE
Less flaky test_keeper_reconfig_remove_many

### DIFF
--- a/tests/integration/test_keeper_reconfig_remove_many/configs/keeper1.xml
+++ b/tests/integration/test_keeper_reconfig_remove_many/configs/keeper1.xml
@@ -1,5 +1,6 @@
 <clickhouse>
     <keeper_server>
+        <use_cluster>false</use_cluster>
         <tcp_port>9181</tcp_port>
         <server_id>1</server_id>
         <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>

--- a/tests/integration/test_keeper_reconfig_remove_many/configs/keeper1.xml
+++ b/tests/integration/test_keeper_reconfig_remove_many/configs/keeper1.xml
@@ -18,30 +18,35 @@
                 <id>1</id>
                 <hostname>node1</hostname>
                 <port>9234</port>
+                <priority>2</priority>
             </server>
             <server>
                 <id>2</id>
                 <hostname>node2</hostname>
                 <port>9234</port>
                 <start_as_follower>true</start_as_follower>
+                <priority>1</priority>
             </server>
             <server>
                 <id>3</id>
                 <hostname>node3</hostname>
                 <port>9234</port>
                 <start_as_follower>true</start_as_follower>
+                <priority>1</priority>
             </server>
             <server>
                 <id>4</id>
                 <hostname>node4</hostname>
                 <port>9234</port>
                 <start_as_follower>true</start_as_follower>
+                <priority>1</priority>
             </server>
             <server>
                 <id>5</id>
                 <hostname>node5</hostname>
                 <port>9234</port>
                 <start_as_follower>true</start_as_follower>
+                <priority>1</priority>
             </server>
         </raft_configuration>
     </keeper_server>

--- a/tests/integration/test_keeper_reconfig_remove_many/configs/keeper2.xml
+++ b/tests/integration/test_keeper_reconfig_remove_many/configs/keeper2.xml
@@ -18,30 +18,35 @@
                 <id>1</id>
                 <hostname>node1</hostname>
                 <port>9234</port>
+                <priority>2</priority>
             </server>
             <server>
                 <id>2</id>
                 <hostname>node2</hostname>
                 <port>9234</port>
                 <start_as_follower>true</start_as_follower>
+                <priority>1</priority>
             </server>
             <server>
                 <id>3</id>
                 <hostname>node3</hostname>
                 <port>9234</port>
                 <start_as_follower>true</start_as_follower>
+                <priority>1</priority>
             </server>
             <server>
                 <id>4</id>
                 <hostname>node4</hostname>
                 <port>9234</port>
                 <start_as_follower>true</start_as_follower>
+                <priority>1</priority>
             </server>
             <server>
                 <id>5</id>
                 <hostname>node5</hostname>
                 <port>9234</port>
                 <start_as_follower>true</start_as_follower>
+                <priority>1</priority>
             </server>
         </raft_configuration>
     </keeper_server>

--- a/tests/integration/test_keeper_reconfig_remove_many/configs/keeper2.xml
+++ b/tests/integration/test_keeper_reconfig_remove_many/configs/keeper2.xml
@@ -1,5 +1,6 @@
 <clickhouse>
     <keeper_server>
+        <use_cluster>false</use_cluster>
         <tcp_port>9181</tcp_port>
         <server_id>2</server_id>
         <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>

--- a/tests/integration/test_keeper_reconfig_remove_many/configs/keeper3.xml
+++ b/tests/integration/test_keeper_reconfig_remove_many/configs/keeper3.xml
@@ -1,5 +1,6 @@
 <clickhouse>
     <keeper_server>
+        <use_cluster>false</use_cluster>
         <tcp_port>9181</tcp_port>
         <server_id>3</server_id>
         <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>

--- a/tests/integration/test_keeper_reconfig_remove_many/configs/keeper3.xml
+++ b/tests/integration/test_keeper_reconfig_remove_many/configs/keeper3.xml
@@ -18,30 +18,35 @@
                 <id>1</id>
                 <hostname>node1</hostname>
                 <port>9234</port>
+                <priority>2</priority>
             </server>
             <server>
                 <id>2</id>
                 <hostname>node2</hostname>
                 <port>9234</port>
                 <start_as_follower>true</start_as_follower>
+                <priority>1</priority>
             </server>
             <server>
                 <id>3</id>
                 <hostname>node3</hostname>
                 <port>9234</port>
                 <start_as_follower>true</start_as_follower>
+                <priority>1</priority>
             </server>
             <server>
                 <id>4</id>
                 <hostname>node4</hostname>
                 <port>9234</port>
                 <start_as_follower>true</start_as_follower>
+                <priority>1</priority>
             </server>
             <server>
                 <id>5</id>
                 <hostname>node5</hostname>
                 <port>9234</port>
                 <start_as_follower>true</start_as_follower>
+                <priority>1</priority>
             </server>
         </raft_configuration>
     </keeper_server>

--- a/tests/integration/test_keeper_reconfig_remove_many/configs/keeper4.xml
+++ b/tests/integration/test_keeper_reconfig_remove_many/configs/keeper4.xml
@@ -18,30 +18,35 @@
                 <id>1</id>
                 <hostname>node1</hostname>
                 <port>9234</port>
+                <priority>2</priority>
             </server>
             <server>
                 <id>2</id>
                 <hostname>node2</hostname>
                 <port>9234</port>
                 <start_as_follower>true</start_as_follower>
+                <priority>1</priority>
             </server>
             <server>
                 <id>3</id>
                 <hostname>node3</hostname>
                 <port>9234</port>
                 <start_as_follower>true</start_as_follower>
+                <priority>1</priority>
             </server>
             <server>
                 <id>4</id>
                 <hostname>node4</hostname>
                 <port>9234</port>
                 <start_as_follower>true</start_as_follower>
+                <priority>1</priority>
             </server>
             <server>
                 <id>5</id>
                 <hostname>node5</hostname>
                 <port>9234</port>
                 <start_as_follower>true</start_as_follower>
+                <priority>1</priority>
             </server>
         </raft_configuration>
     </keeper_server>

--- a/tests/integration/test_keeper_reconfig_remove_many/configs/keeper4.xml
+++ b/tests/integration/test_keeper_reconfig_remove_many/configs/keeper4.xml
@@ -1,5 +1,6 @@
 <clickhouse>
     <keeper_server>
+        <use_cluster>false</use_cluster>
         <tcp_port>9181</tcp_port>
         <server_id>4</server_id>
         <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>

--- a/tests/integration/test_keeper_reconfig_remove_many/configs/keeper5.xml
+++ b/tests/integration/test_keeper_reconfig_remove_many/configs/keeper5.xml
@@ -1,5 +1,6 @@
 <clickhouse>
     <keeper_server>
+        <use_cluster>false</use_cluster>
         <tcp_port>9181</tcp_port>
         <server_id>5</server_id>
         <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>

--- a/tests/integration/test_keeper_reconfig_remove_many/configs/keeper5.xml
+++ b/tests/integration/test_keeper_reconfig_remove_many/configs/keeper5.xml
@@ -18,30 +18,35 @@
                 <id>1</id>
                 <hostname>node1</hostname>
                 <port>9234</port>
+                <priority>2</priority>
             </server>
             <server>
                 <id>2</id>
                 <hostname>node2</hostname>
                 <port>9234</port>
                 <start_as_follower>true</start_as_follower>
+                <priority>1</priority>
             </server>
             <server>
                 <id>3</id>
                 <hostname>node3</hostname>
                 <port>9234</port>
                 <start_as_follower>true</start_as_follower>
+                <priority>1</priority>
             </server>
             <server>
                 <id>4</id>
                 <hostname>node4</hostname>
                 <port>9234</port>
                 <start_as_follower>true</start_as_follower>
+                <priority>1</priority>
             </server>
             <server>
                 <id>5</id>
                 <hostname>node5</hostname>
                 <port>9234</port>
                 <start_as_follower>true</start_as_follower>
+                <priority>1</priority>
             </server>
         </raft_configuration>
     </keeper_server>

--- a/tests/integration/test_keeper_reconfig_remove_many/test.py
+++ b/tests/integration/test_keeper_reconfig_remove_many/test.py
@@ -147,6 +147,8 @@ def test_reconfig_remove_2_and_leader(started_cluster):
 
     zk2.stop()
 
+    # we just removed leader so we need to make sure new leader is elected
+    # before continuing with the checks
     for i in range(100):
         if any(
             "leader" in ku.send_4lw_cmd(cluster, node, f"mntr")


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=dd963d46ace78dc3015161fd497bef2ac104ee4e&name_0=MasterCI&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%201%2F4%29&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%201%2F4%29

It can fail if we connect before new leader was elected after the old one was removed from cluster.

Close https://github.com/ClickHouse/ClickHouse/issues/93446

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.582`
<!-- ch-version-info:end -->