### PR TITLE
Require SELECT privelege for executing joinGet function

### DIFF
--- a/src/Functions/FunctionJoinGet.cpp
+++ b/src/Functions/FunctionJoinGet.cpp
@@ -9,7 +9,8 @@
 #include <Interpreters/HashJoin/HashJoin.h>
 #include <Storages/StorageJoin.h>
 #include <Storages/TableLockHolder.h>
-
+#include <Access/Common/AccessType.h>
+#include <Access/Common/AccessFlags.h>
 
 namespace DB
 {
@@ -138,6 +139,11 @@ template <bool or_null>
 ExecutableFunctionPtr FunctionJoinGet<or_null>::prepare(const ColumnsWithTypeAndName &) const
 {
     Block result_columns {{return_type->createColumn(), return_type, attr_name}};
+
+    Names column_names = storage_join->getKeyNames();
+    column_names.push_back(attr_name);
+    context->checkAccess(AccessType::SELECT, storage_join->getStorageID(), column_names);
+
     return std::make_unique<ExecutableFunctionJoinGet<or_null>>(context, table_lock, storage_join, result_columns);
 }
 

--- a/tests/queries/0_stateless/03788_storage_join_access.reference
+++ b/tests/queries/0_stateless/03788_storage_join_access.reference
@@ -1,0 +1,4 @@
+1	SENSITIVE_DATA	payload1
+SENSITIVE_DATA
+payload1
+payload1

--- a/tests/queries/0_stateless/03788_storage_join_access.sh
+++ b/tests/queries/0_stateless/03788_storage_join_access.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+user="user03788_$CLICKHOUSE_DATABASE"
+db=${CLICKHOUSE_DATABASE}
+
+$CLICKHOUSE_CLIENT -m -q "
+DROP TABLE IF EXISTS join_table;
+CREATE TABLE join_table (id UInt8, secret String, payload String) ENGINE=Join(ANY, LEFT, id);
+INSERT INTO join_table VALUES (1, 'SENSITIVE_DATA', 'payload1');
+
+DROP USER IF EXISTS $user;
+CREATE USER $user IDENTIFIED WITH no_password;
+"
+
+$CLICKHOUSE_CLIENT --user $user -m -q "SELECT * FROM join_table; -- { serverError ACCESS_DENIED }"
+$CLICKHOUSE_CLIENT --user $user -m -q "SELECT joinGet('$db.join_table', 'secret', 1); -- { serverError ACCESS_DENIED }"
+
+$CLICKHOUSE_CLIENT -m -q "GRANT SELECT ON $db.join_table TO $user"
+
+$CLICKHOUSE_CLIENT --user $user -m -q "SELECT * FROM join_table"
+$CLICKHOUSE_CLIENT --user $user -m -q "SELECT joinGet('$db.join_table', 'secret', 1)"
+
+$CLICKHOUSE_CLIENT -m -q "REVOKE SELECT(secret) ON $db.join_table FROM $user;"
+
+$CLICKHOUSE_CLIENT --user $user -m -q "SELECT joinGet('$db.join_table', 'secret', 1); -- { serverError ACCESS_DENIED }"
+$CLICKHOUSE_CLIENT --user $user -m -q "SELECT secret FROM join_table; -- { serverError ACCESS_DENIED }"
+$CLICKHOUSE_CLIENT --user $user -m -q "SELECT joinGet('$db.join_table', 'payload', 1)"
+$CLICKHOUSE_CLIENT --user $user -m -q "SELECT payload FROM join_table;"
+
+$CLICKHOUSE_CLIENT -m -q "REVOKE SELECT(id) ON $db.join_table FROM $user;"
+$CLICKHOUSE_CLIENT --user $user -m -q "SELECT id FROM join_table; -- { serverError ACCESS_DENIED }"
+$CLICKHOUSE_CLIENT --user $user -m -q "SELECT joinGet('$db.join_table', 'payload', 1); -- { serverError ACCESS_DENIED }"
+
+
+$CLICKHOUSE_CLIENT -m -q "DROP USER $user"


### PR DESCRIPTION


### Changelog category (leave one):

- Backward Incompatible Change



### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
* The `joinGet/joinGetOrNull` functions now enforce `SELECT` privileges on the underlying Join table. After this change, executing `joinGet('db.table', 'column', key)` requires the user to have `SELECT` privilege on both the key columns defined in the Join table and the attribute column being retrieved. Queries lacking these privileges will fail with `ACCESS_DENIED`. To migrate, grant the necessary permissions using `GRANT SELECT ON db.join_table TO user` for full table access, or `GRANT SELECT(key_col, attr_col) ON db.join_table TO user` for column-level access. This change affects all users and applications relying on `joinGet`/`joinGetOrNull` where explicit `SELECT` grants were not previously configured.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.667`
<!-- ch-version-info:end -->