### PR TITLE
Fix obscure bug in ZooKeeper client on connect which leads to hungs and crashes

### DIFF
--- a/src/Common/ZooKeeper/ZooKeeperImpl.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperImpl.cpp
@@ -351,7 +351,7 @@ void ZooKeeper::flushWriteBuffer()
 void ZooKeeper::cancelWriteBuffer() noexcept
 {
     if (compressed_out)
-         compressed_out->cancel();
+        compressed_out->cancel();
     if (out)
         out->cancel();
 }
@@ -590,7 +590,6 @@ void ZooKeeper::connect(
                     throw;
                 }
 
-                connected = true;
                 if (use_compression)
                 {
                     compressed_in.emplace(*in);
@@ -598,6 +597,8 @@ void ZooKeeper::connect(
                 }
 
                 original_index.store(node.original_index);
+
+                connected = true;
                 break;
             }
             catch (...)


### PR DESCRIPTION
The problem is that we may use ZooKeeper that is not properly initialized, since we can exit from connect() early, before we properly connected.

Imagine when the is exception (i.e. my favorite MEMORY_LIMIT_EXCEEDED) during initializing compressed buffer, in this case we will set `connected = true` and break later, but the exception will not be throw because `connected = true`

Likely this is the reason in one of setups, even though there is `out` and `compressed_out` is not set (`__engaged_ = false`), but it is possible that on the first iteration we set `in` and `out`, then fail on installing `compressed_out`, and trying the next address, but there we failed on installing `out`.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix obscure bug in ZooKeeper client on connect which leads to hungs and crashes


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.566`
- Backported to: `25.12.4.22`, `25.11.7.30`, `25.10.5.32`, `25.8.15.27`, `25.3.13.15`
<!-- ch-version-info:end -->