### PR TITLE
Add `files` column to system.parts

### DIFF
--- a/docs/en/operations/system-tables/parts.md
+++ b/docs/en/operations/system-tables/parts.md
@@ -61,6 +61,8 @@ Columns:
 
 - `marks_bytes` ([UInt64](../../sql-reference/data-types/int-uint.md)) – The size of the file with marks.
 
+- `files` ([UInt64](../../sql-reference/data-types/int-uint.md)) – The number of files in the data part.
+
 - `secondary_indices_compressed_bytes` ([UInt64](../../sql-reference/data-types/int-uint.md)) – Total size of compressed data for secondary indices in the data part. All the auxiliary files (for example, files with marks) are not included.
 
 - `secondary_indices_uncompressed_bytes` ([UInt64](../../sql-reference/data-types/int-uint.md)) – Total size of uncompressed data for secondary indices in the data part. All the auxiliary files (for example, files with marks) are not included.

--- a/src/Storages/System/StorageSystemParts.cpp
+++ b/src/Storages/System/StorageSystemParts.cpp
@@ -139,6 +139,8 @@ Name of the data part. The part naming structure can be used to determine many a
 
         {"last_removal_attempt_time",                   std::make_shared<DataTypeDateTime>(), "The last time the server tried to delete this part."},
         {"removal_state",                               std::make_shared<DataTypeString>(), "The current state of part removal process."},
+
+        {"files",                                       std::make_shared<DataTypeUInt64>(), "The number of files in the data part."},
     }
     )
 {
@@ -371,6 +373,9 @@ void StorageSystemParts::processNextStorage(
             columns[res_index++]->insert(static_cast<UInt64>(part->last_removal_attempt_time.load(std::memory_order_relaxed)));
         if (columns_mask[src_index++])
             columns[res_index++]->insert(getRemovalStateDescription(part->removal_state.load(std::memory_order_relaxed)));
+
+        if (columns_mask[src_index++])
+            columns[res_index++]->insert(part->checksums.files.size());
 
         /// _state column should be the latest.
         /// Do not use part->getState*, it can be changed from different thread

--- a/tests/queries/0_stateless/02117_show_create_table_system.reference
+++ b/tests/queries/0_stateless/02117_show_create_table_system.reference
@@ -489,6 +489,7 @@ CREATE TABLE system.parts
     `active` UInt8,
     `marks` UInt64,
     `rows` UInt64,
+    `files` UInt64,
     `bytes_on_disk` UInt64,
     `data_compressed_bytes` UInt64,
     `data_uncompressed_bytes` UInt64,
@@ -553,7 +554,6 @@ CREATE TABLE system.parts
     `has_lightweight_delete` UInt8,
     `last_removal_attempt_time` DateTime,
     `removal_state` String,
-    `files` UInt64,
     `bytes` UInt64 ALIAS bytes_on_disk,
     `marks_size` UInt64 ALIAS marks_bytes,
     `part_name` String ALIAS name

--- a/tests/queries/0_stateless/02117_show_create_table_system.reference
+++ b/tests/queries/0_stateless/02117_show_create_table_system.reference
@@ -553,6 +553,7 @@ CREATE TABLE system.parts
     `has_lightweight_delete` UInt8,
     `last_removal_attempt_time` DateTime,
     `removal_state` String,
+    `files` UInt64,
     `bytes` UInt64 ALIAS bytes_on_disk,
     `marks_size` UInt64 ALIAS marks_bytes,
     `part_name` String ALIAS name

--- a/tests/queries/0_stateless/03791_system_parts_files_column.reference
+++ b/tests/queries/0_stateless/03791_system_parts_files_column.reference
@@ -1,0 +1,4 @@
+files column exists and is positive
+1
+files column type is UInt64
+UInt64

--- a/tests/queries/0_stateless/03791_system_parts_files_column.sql
+++ b/tests/queries/0_stateless/03791_system_parts_files_column.sql
@@ -1,5 +1,3 @@
--- Tags: no-parallel
-
 DROP TABLE IF EXISTS test_parts_files;
 
 CREATE TABLE test_parts_files (x UInt64) ENGINE = MergeTree ORDER BY x;

--- a/tests/queries/0_stateless/03791_system_parts_files_column.sql
+++ b/tests/queries/0_stateless/03791_system_parts_files_column.sql
@@ -1,0 +1,15 @@
+-- Tags: no-parallel
+
+DROP TABLE IF EXISTS test_parts_files;
+
+CREATE TABLE test_parts_files (x UInt64) ENGINE = MergeTree ORDER BY x;
+
+INSERT INTO test_parts_files VALUES (1), (2), (3);
+
+SELECT 'files column exists and is positive';
+SELECT files > 0 FROM system.parts WHERE database = currentDatabase() AND table = 'test_parts_files' AND active;
+
+SELECT 'files column type is UInt64';
+SELECT toTypeName(files) FROM system.parts WHERE database = currentDatabase() AND table = 'test_parts_files' AND active LIMIT 1;
+
+DROP TABLE test_parts_files;


### PR DESCRIPTION
### Changelog category (leave one):

- New Feature

### Changelog entry (a https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md of the changes that goes into CHANGELOG.md):

- Add files column to system.parts table that shows the number of files in each data part.

### Documentation entry for user-facing changes

- Documentation is written (mandatory for new features)

A new column files has been added to the system.parts table.

- Motivation: This column helps monitor storage efficiency by showing how many files each data part contains. Users can identify parts with many small files versus fewer large files, which is useful for understanding merge behavior and storage optimization.
- Column: files (UInt64) – The number of files in the data part.
- Example use:
```
SELECT database, table, name, files, bytes_on_disk, rows
FROM system.parts
WHERE active
ORDER BY files DESC
LIMIT 10;
```

Closes #94328

---

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=132382032


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.627`
<!-- ch-version-info:end -->