### PR TITLE
Fix for runtime filter with unsupported type in BloomFilter

### DIFF
--- a/src/Processors/QueryPlan/RuntimeFilterLookup.cpp
+++ b/src/Processors/QueryPlan/RuntimeFilterLookup.cpp
@@ -94,6 +94,27 @@ static void mergeBloomFilters(BloomFilter & destination, const BloomFilter & sou
 
 static constexpr UInt64 BLOOM_FILTER_SEED = 42;
 
+void ExactContainsRuntimeFilter::merge(const IRuntimeFilter * source)
+{
+    if (inserts_are_finished)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Trying to merge into runtime filter after it was marked as finished");
+
+    const auto * source_typed = typeid_cast<const ExactContainsRuntimeFilter *>(source);
+    if (!source_typed)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Trying to merge runtime filters with different types");
+
+    insert(source_typed->getValuesColumn());
+    --filters_to_merge;
+}
+
+void ExactContainsRuntimeFilter::finishInsert()
+{
+    Base::finishInsert();
+
+    if (isFull())
+        setFullyDisabled(); /// Some keys were dropped so we cannot filter by partial set of keys
+}
+
 void ExactNotContainsRuntimeFilter::merge(const IRuntimeFilter * source)
 {
     if (inserts_are_finished)
@@ -105,6 +126,13 @@ void ExactNotContainsRuntimeFilter::merge(const IRuntimeFilter * source)
 
     insert(source_typed->getValuesColumn());
     --filters_to_merge;
+}
+
+bool ApproximateRuntimeFilter::isDataTypeSupported(const DataTypePtr & data_type)
+{
+    /// Current BloomFilter implementation relies on IColumn::getDataAt method that returns a string_view of contiguous
+    /// memory chunk containing the value
+    return data_type->isValueUnambiguouslyRepresentedInContiguousMemoryRegion();
 }
 
 ApproximateRuntimeFilter::ApproximateRuntimeFilter(

--- a/src/Processors/QueryPlan/RuntimeFilterLookup.cpp
+++ b/src/Processors/QueryPlan/RuntimeFilterLookup.cpp
@@ -112,7 +112,11 @@ void ExactContainsRuntimeFilter::finishInsert()
     Base::finishInsert();
 
     if (isFull())
-        setFullyDisabled(); /// Some keys were dropped so we cannot filter by partial set of keys
+    {
+        /// Some keys were dropped so we cannot filter by partial set of keys
+        setFullyDisabled();
+        releaseExactValues();
+    }
 }
 
 void ExactNotContainsRuntimeFilter::merge(const IRuntimeFilter * source)

--- a/src/Processors/QueryPlan/RuntimeFilterLookup.h
+++ b/src/Processors/QueryPlan/RuntimeFilterLookup.h
@@ -187,6 +187,26 @@ private:
     std::optional<Field> single_element_in_set;
 };
 
+class ExactContainsRuntimeFilter : public RuntimeFilterBase<false>
+{
+    using Base = RuntimeFilterBase<false>;
+
+public:
+    ExactContainsRuntimeFilter(
+        size_t filters_to_merge_,
+        const DataTypePtr & filter_column_target_type_,
+        Float64 pass_ratio_threshold_for_disabling_,
+        UInt64 blocks_to_skip_before_reenabling_,
+        UInt64 bytes_limit_,
+        UInt64 exact_values_limit_
+    )
+        : RuntimeFilterBase(filters_to_merge_, filter_column_target_type_, pass_ratio_threshold_for_disabling_, blocks_to_skip_before_reenabling_, bytes_limit_, exact_values_limit_)
+    {}
+
+    void merge(const IRuntimeFilter * source) override;
+
+    void finishInsert() override;
+};
 
 class ExactNotContainsRuntimeFilter : public RuntimeFilterBase<true>
 {
@@ -211,6 +231,8 @@ class ApproximateRuntimeFilter : public RuntimeFilterBase<false>
 {
     using Base = RuntimeFilterBase<false>;
 public:
+    static bool isDataTypeSupported(const DataTypePtr & data_type);
+
     ApproximateRuntimeFilter(
         size_t filters_to_merge_,
         const DataTypePtr & filter_column_target_type_,

--- a/src/Processors/Transforms/BuildRuntimeFilterTransform.cpp
+++ b/src/Processors/Transforms/BuildRuntimeFilterTransform.cpp
@@ -35,16 +35,32 @@ BuildRuntimeFilterTransform::BuildRuntimeFilterTransform(
         cast_to_target_type = createInternalCast(filter_column, filter_column_target_type, CastType::nonAccurate, {}, nullptr);
 
     if (allow_to_use_not_exact_filter_)
-        built_filter = std::make_unique<ApproximateRuntimeFilter>(
-            filters_to_merge_,
-            filter_column_target_type,
-            pass_ratio_threshold_for_disabling_,
-            blocks_to_skip_before_reenabling_,
-            bloom_filter_bytes_,
-            exact_values_limit_,
-            bloom_filter_hash_functions_,
-            max_ratio_of_set_bits_in_bloom_filter_);
+    {
+        if (ApproximateRuntimeFilter::isDataTypeSupported(filter_column_target_type))
+        {
+            built_filter = std::make_unique<ApproximateRuntimeFilter>(
+                filters_to_merge_,
+                filter_column_target_type,
+                pass_ratio_threshold_for_disabling_,
+                blocks_to_skip_before_reenabling_,
+                bloom_filter_bytes_,
+                exact_values_limit_,
+                bloom_filter_hash_functions_,
+                max_ratio_of_set_bits_in_bloom_filter_);
+        }
+        else
+        {
+            built_filter = std::make_unique<ExactContainsRuntimeFilter>(
+                filters_to_merge_,
+                filter_column_target_type,
+                pass_ratio_threshold_for_disabling_,
+                blocks_to_skip_before_reenabling_,
+                bloom_filter_bytes_,
+                exact_values_limit_);
+        }
+    }
     else
+    {
         built_filter = std::make_unique<ExactNotContainsRuntimeFilter>(
             filters_to_merge_,
             filter_column_target_type,
@@ -52,6 +68,7 @@ BuildRuntimeFilterTransform::BuildRuntimeFilterTransform(
             blocks_to_skip_before_reenabling_,
             bloom_filter_bytes_,
             exact_values_limit_);
+    }
 }
 
 

--- a/tests/queries/0_stateless/03777_join_runtime_filter_unsupported_type.reference
+++ b/tests/queries/0_stateless/03777_join_runtime_filter_unsupported_type.reference
@@ -1,0 +1,10 @@
+============ Filter key count greater than exact values limit
+(997,998)	(997,998)
+(998,999)	(998,999)
+(999,1000)	(999,1000)
+0	3
+============ Filter key count less than exact values limit
+(997,998)	(997,998)
+(998,999)	(998,999)
+(999,1000)	(999,1000)
+3	0

--- a/tests/queries/0_stateless/03777_join_runtime_filter_unsupported_type.sql
+++ b/tests/queries/0_stateless/03777_join_runtime_filter_unsupported_type.sql
@@ -1,0 +1,37 @@
+-- Freeze some settings to produce stable query plans
+SET enable_analyzer=1;
+SET enable_parallel_replicas=0;
+SET join_algorithm = 'hash,parallel_hash';
+SET query_plan_optimize_join_order_algorithm='greedy';
+SET query_plan_optimize_join_order_limit=1;
+SET query_plan_join_swap_table=0;
+
+
+SELECT '============ Filter key count greater than exact values limit';
+SELECT *
+FROM
+    (SELECT (number, number+1) AS a FROM numbers(1000-3, 3)) AS t1,
+    (SELECT (number, number+1) aS b FROM numbers(1000)) AS t2
+WHERE t1.a = t2.b
+SETTINGS enable_join_runtime_filters=1, join_runtime_filter_exact_values_limit=100, log_comment='Q1';
+
+SYSTEM FLUSH LOGS system.query_log;
+
+SELECT ProfileEvents['RuntimeFilterRowsChecked'], ProfileEvents['RuntimeFilterRowsSkipped']
+FROM system.query_log
+WHERE current_database = currentDatabase() AND event_time > now() - INTERVAL 30 MINUTE AND type = 'QueryFinish' AND log_comment = 'Q1';
+
+
+SELECT '============ Filter key count less than exact values limit';
+SELECT *
+FROM
+    (SELECT (number, number+1) AS a FROM numbers(1000-3, 3)) AS t1,
+    (SELECT (number, number+1) aS b FROM numbers(1000)) AS t2
+WHERE t1.a = t2.b
+SETTINGS enable_join_runtime_filters=1, join_runtime_filter_exact_values_limit=10000, log_comment='Q2';
+
+SYSTEM FLUSH LOGS system.query_log;
+
+SELECT ProfileEvents['RuntimeFilterRowsChecked'], ProfileEvents['RuntimeFilterRowsSkipped']
+FROM system.query_log
+WHERE current_database = currentDatabase() AND event_time > now() - INTERVAL 30 MINUTE AND type = 'QueryFinish' AND log_comment = 'Q2';


### PR DESCRIPTION
Fixes error when runtime filter cannot be built on a column because it has type that is incompatible with the current BloomFilter implementation:
```
Received exception from server (version 25.12.3):
Code: 48. DB::Exception: Received from localhost:9000. DB::Exception: Method getDataAt is not supported for Tuple(UInt64, UInt64). (NOT_IMPLEMENTED)
(query: SELECT *
FROM
    (SELECT (number, number+1) AS a FROM numbers(1000-3, 3)) AS t1,
    (SELECT (number, number+1) aS b FROM numbers(1000)) AS t2
WHERE t1.a = t2.b
SETTINGS enable_join_runtime_filters=1, join_runtime_filter_exact_values_limit=100, log_comment='Q1';)
```
https://fiddle.clickhouse.com/f7067992-9b46-475d-806c-4d1e3a76d9c1

We will fallback to using only exact set for the runtime filter in such a case.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.580`
<!-- ch-version-info:end -->