### PR TITLE
Fix logical error "ReadBuffer is canceled. Can't read from it" in TCPHandler::skipData()

### DIFF
--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -1166,6 +1166,9 @@ void TCPHandler::readTemporaryTables(QueryState & state)
 
 void TCPHandler::skipData(QueryState & state)
 {
+    if (in->isCanceled())
+        return;
+
     state.skipping_data = true;
     SCOPE_EXIT({ state.skipping_data = false; });
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix logical error `ReadBuffer is canceled. Can't read from it` in `TCPHandler::skipData()`.

[Example of failure](https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=7a343d8260c25f47a552a9624b65a10584a38b6e&name_0=MasterCI&name_1=BuzzHouse%20%28amd_debug%29&name_1=BuzzHouse%20%28amd_debug%29)

Stack trace:
```
src/Common/Exception.cpp:57: DB::abortOnFailedAssertion(String const&, std::basic_string_view<char, std::char_traits<char>>, void* const*, unsigned long, unsigned long) @ 0x00000000162cd1bc
src/Common/Exception.cpp:63: ? @ 0x00000000162cdf07
src/IO/ReadBuffer.cpp:90: DB::ReadBuffer::next() @ 0x00000000163b6e54
src/IO/ReadBuffer.h:81: DB::ReadBuffer::eof()
src/IO/VarInt.h:82: void DB::varint_impl::readVarUInt<true>(unsigned long&, DB::ReadBuffer&)
src/IO/VarInt.h:101: DB::readVarUInt(unsigned long&, DB::ReadBuffer&)
src/Server/TCPHandler.cpp:1100: DB::TCPHandler::receivePacketsExpectData(DB::QueryState&) @ 0x00000000202cbc82
src/Server/TCPHandler.cpp:1173: DB::TCPHandler::skipData(DB::QueryState&) @ 0x00000000202c54c0
src/Server/TCPHandler.cpp:970: DB::TCPHandler::runImpl() @ 0x00000000202b8680
src/Server/TCPHandler.cpp:2867: DB::TCPHandler::run() @ 0x00000000202d30e4
```

Related to https://github.com/ClickHouse/ClickHouse/issues/84186


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.609`
<!-- ch-version-info:end -->