### PR TITLE
Fix propagating exceptions through StdStreamFromReadBuffer

### DIFF
--- a/src/IO/StdStreamFromReadBuffer.cpp
+++ b/src/IO/StdStreamFromReadBuffer.cpp
@@ -10,14 +10,15 @@ StdIStreamFromReadBuffer::StdIStreamFromReadBuffer(std::unique_ptr<ReadBuffer> b
     : Base(&stream_buf)
     , stream_buf(std::move(buf), size)
 {
-    exceptions(std::ios::failbit | std::ios::badbit);
+    /// ios::failbit isn't specified here because otherwise stream.read() will throw an exception on EOF.
+    exceptions(std::ios::badbit);
 }
 
 StdIStreamFromReadBuffer::StdIStreamFromReadBuffer(ReadBuffer & buf, size_t size)
     : Base(&stream_buf)
     , stream_buf(buf, size)
 {
-    exceptions(std::ios::failbit | std::ios::badbit);
+    exceptions(std::ios::badbit);
 }
 
 
@@ -25,14 +26,15 @@ StdStreamFromReadBuffer::StdStreamFromReadBuffer(std::unique_ptr<ReadBuffer> buf
     : Base(&stream_buf)
     , stream_buf(std::move(buf), size)
 {
-    exceptions(std::ios::failbit | std::ios::badbit);
+    /// ios::failbit isn't specified here because otherwise stream.read() will throw an exception on EOF.
+    exceptions(std::ios::badbit);
 }
 
 StdStreamFromReadBuffer::StdStreamFromReadBuffer(ReadBuffer & buf, size_t size)
     : Base(&stream_buf)
     , stream_buf(buf, size)
 {
-    exceptions(std::ios::failbit | std::ios::badbit);
+    exceptions(std::ios::badbit);
 }
 
 }

--- a/src/IO/StdStreamFromReadBuffer.cpp
+++ b/src/IO/StdStreamFromReadBuffer.cpp
@@ -1,0 +1,38 @@
+#include <IO/StdStreamFromReadBuffer.h>
+
+#include <IO/ReadBuffer.h>
+
+
+namespace DB
+{
+
+StdIStreamFromReadBuffer::StdIStreamFromReadBuffer(std::unique_ptr<ReadBuffer> buf, size_t size)
+    : Base(&stream_buf)
+    , stream_buf(std::move(buf), size)
+{
+    exceptions(std::ios::failbit | std::ios::badbit);
+}
+
+StdIStreamFromReadBuffer::StdIStreamFromReadBuffer(ReadBuffer & buf, size_t size)
+    : Base(&stream_buf)
+    , stream_buf(buf, size)
+{
+    exceptions(std::ios::failbit | std::ios::badbit);
+}
+
+
+StdStreamFromReadBuffer::StdStreamFromReadBuffer(std::unique_ptr<ReadBuffer> buf, size_t size)
+    : Base(&stream_buf)
+    , stream_buf(std::move(buf), size)
+{
+    exceptions(std::ios::failbit | std::ios::badbit);
+}
+
+StdStreamFromReadBuffer::StdStreamFromReadBuffer(ReadBuffer & buf, size_t size)
+    : Base(&stream_buf)
+    , stream_buf(buf, size)
+{
+    exceptions(std::ios::failbit | std::ios::badbit);
+}
+
+}

--- a/src/IO/StdStreamFromReadBuffer.h
+++ b/src/IO/StdStreamFromReadBuffer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <IO/StdStreamBufFromReadBuffer.h>
+#include <iostream>
 #include <memory>
 
 
@@ -13,8 +14,8 @@ class StdIStreamFromReadBuffer : public std::istream
 {
 public:
     using Base = std::istream;
-    StdIStreamFromReadBuffer(std::unique_ptr<ReadBuffer> buf, size_t size) : Base(&stream_buf), stream_buf(std::move(buf), size) { }
-    StdIStreamFromReadBuffer(ReadBuffer & buf, size_t size) : Base(&stream_buf), stream_buf(buf, size) { }
+    StdIStreamFromReadBuffer(std::unique_ptr<ReadBuffer> buf, size_t size);
+    StdIStreamFromReadBuffer(ReadBuffer & buf, size_t size);
     StdStreamBufFromReadBuffer * rdbuf() const { return const_cast<StdStreamBufFromReadBuffer *>(&stream_buf); }
 
 private:
@@ -27,8 +28,8 @@ class StdStreamFromReadBuffer : public std::iostream
 {
 public:
     using Base = std::iostream;
-    StdStreamFromReadBuffer(std::unique_ptr<ReadBuffer> buf, size_t size) : Base(&stream_buf), stream_buf(std::move(buf), size) { }
-    StdStreamFromReadBuffer(ReadBuffer & buf, size_t size) : Base(&stream_buf), stream_buf(buf, size) { }
+    StdStreamFromReadBuffer(std::unique_ptr<ReadBuffer> buf, size_t size);
+    StdStreamFromReadBuffer(ReadBuffer & buf, size_t size);
     StdStreamBufFromReadBuffer * rdbuf() const { return const_cast<StdStreamBufFromReadBuffer *>(&stream_buf); }
 
 private:


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix propagating exceptions through `StdStreamFromReadBuffer`.
This PR fixes logical error `ReadBuffer is canceled. Can't read from it` in `StdStreamBufFromReadBuffer::xsgetn()`.

[Example of failure](https://github.com/ClickHouse/ClickHouse/issues/84186#issue-3250926003)

Stack trace:
```
BaseDaemon: (version 25.8.1.1, build id: 3B371C88B1F24858F6EF0E87AFAC9D41A02792B5, git hash: fda7c2aa9293262095a0cd3bf04d26a7da9939f2) (from thread 60493) (query_id: e18b34b3-3240-48f5-81ec-6110cde18058) (query: BACKUP TABLE data TO S3('http://localhost:11111/test/backups/test_7/use_same_s3_credentials_for_base_backup_base_base', 'test', '[HIDDEN]')) Received signal Aborted (6)
...
BaseDaemon: 10. ./ci/tmp/build/./src/Common/Exception.cpp:56: DB::abortOnFailedAssertion(String const&) @ 0x0000000012ab9257
BaseDaemon: 11. DB::ReadBuffer::next() @ 0x00000000090a1c7f
BaseDaemon: 12.0. inlined from ./src/IO/ReadBuffer.h:114: DB::ReadBuffer::eof()
BaseDaemon: 12.1. inlined from ./src/IO/ReadBuffer.h:191: DB::ReadBuffer::read(char*, unsigned long)
BaseDaemon: 12. ./ci/tmp/build/./src/IO/StdStreamBufFromReadBuffer.cpp:51: DB::StdStreamBufFromReadBuffer::xsgetn(char*, long) @ 0x0000000018f55a8f
BaseDaemon: 13.0. inlined from ./contrib/llvm-project/libcxx/include/streambuf:198: std::basic_streambuf<char, std::char_traits<char>>::sgetn[abi:ne190107](char*, long)
BaseDaemon: 13. ./contrib/llvm-project/libcxx/include/istream:897: std::basic_istream<char, std::char_traits<char>>::read(char*, long) @ 0x000000002a90629a
BaseDaemon: 14. Aws::Utils::Crypto::Sha256OpenSSLImpl::Calculate(std::basic_istream<char, std::char_traits<char>>&) @ 0x0000000029d17aa9
BaseDaemon: 15. Aws::Utils::Crypto::Sha256::Calculate(std::basic_istream<char, std::char_traits<char>>&) @ 0x0000000029d0e8e0
BaseDaemon: 16. Aws::Client::AWSAuthV4Signer::ComputePayloadHash(Aws::Http::HttpRequest&) const @ 0x0000000029c7ebac
BaseDaemon: 17. Aws::Client::AWSAuthV4Signer::SignRequest(Aws::Http::HttpRequest&, char const*, char const*, bool) const @ 0x0000000029c7c266
BaseDaemon: 18. bool std::__function::__policy_invoker<bool ()>::__call_impl[abi:ne190107]<std::__function::__default_alloc_func<Aws::Client::AWSClient::AttemptOneRequest(std::shared_ptr<Aws::Http::HttpRequest> const&, Aws::AmazonWebServiceRequest const&, char const*, char const*, char const*) const::$_1, bool ()>>(std::__function::__policy_storage const*) @ 0x0000000029ca0d01
BaseDaemon: 19. bool smithy::components::tracing::TracingUtils::MakeCallWithTiming<bool>(std::function<bool ()>, String const&, smithy::components::tracing::Meter const&, std::map<String, String, std::less<String>, std::allocator<std::pair<String const, String>>>&&, String const&) @ 0x0000000029c9810a
BaseDaemon: 20. Aws::Client::AWSClient::AttemptOneRequest(std::shared_ptr<Aws::Http::HttpRequest> const&, Aws::AmazonWebServiceRequest const&, char const*, char const*, char const*) const @ 0x0000000029c8e29b
BaseDaemon: 21. Aws::Client::AWSClient::AttemptExhaustively(Aws::Http::URI const&, Aws::AmazonWebServiceRequest const&, Aws::Http::HttpMethod, char const*, char const*, char const*) const @ 0x0000000029c8913b
...
BaseDaemon: 28.0. inlined from ./ci/tmp/build/./src/IO/S3/copyS3File.cpp:552: DB::(anonymous namespace)::CopyDataToFileHelper::processPutRequest(DB::S3::ExtendedRequest<Aws::S3::Model::PutObjectRequest>&)
BaseDaemon: 28.1. inlined from ./ci/tmp/build/./src/IO/S3/copyS3File.cpp:517: DB::(anonymous namespace)::CopyDataToFileHelper::performSinglepartUpload()
BaseDaemon: 28.2. inlined from ./ci/tmp/build/./src/IO/S3/copyS3File.cpp:500: DB::(anonymous namespace)::CopyDataToFileHelper::performCopy()
BaseDaemon: 28. ./ci/tmp/build/./src/IO/S3/copyS3File.cpp:897: DB::copyDataToS3File(std::function<std::unique_ptr<DB::SeekableReadBuffer, std::default_delete<DB::SeekableReadBuffer>> ()> const&, unsigned long, unsigned long, std::shared_ptr<DB::S3::Client const> const&, String const&, String const&, DB::S3::S3RequestSettings const&, std::shared_ptr<DB::BlobStorageLogWriter>, std::function<std::future<void> (std::function<void ()>&&, Priority)>, std::optional<std::map<String, String, std::less<String>, std::allocator<std::pair<String const, String>>>> const&) @ 0x0000000018f403c5
BaseDaemon: 29. ./ci/tmp/build/./src/Backups/BackupIO_S3.cpp:349: DB::BackupWriterS3::copyDataToFile(String const&, std::function<std::unique_ptr<DB::SeekableReadBuffer, std::default_delete<DB::SeekableReadBuffer>> ()> const&, unsigned long, unsigned long) @ 0x000000001938411f
BaseDaemon: 30. ./ci/tmp/build/./src/Backups/BackupIO_Default.cpp:91: DB::BackupWriterDefault::copyFileFromDisk(String const&, std::shared_ptr<DB::IDisk>, String const&, bool, unsigned long, unsigned long) @ 0x0000000019298c06
BaseDaemon: 31. ./ci/tmp/build/./src/Backups/BackupIO_S3.cpp:318: DB::BackupWriterS3::copyFileFromDisk(String const&, std::shared_ptr<DB::IDisk>, String const&, bool, unsigned long, unsigned long) @ 0x0000000019381c42
BaseDaemon: 32. ./ci/tmp/build/./src/Backups/BackupImpl.cpp:939: DB::BackupImpl::writeFile(DB::BackupFileInfo const&, std::shared_ptr<DB::IBackupEntry const>) @ 0x00000000192ad723
BaseDaemon: 33. ./ci/tmp/build/./src/Backups/BackupsWorker.cpp:705: DB::BackupsWorker::writeBackupEntries(std::shared_ptr<DB::IBackup>, std::vector<std::pair<String, std::shared_ptr<DB::IBackupEntry const>>, std::allocator<std::pair<String, std::shared_ptr<DB::IBackupEntry const>>>>&&, String const&, std::shared_ptr<DB::IBackupCoordination>, bool, std::shared_ptr<DB::QueryStatus>)::$_0::operator()() const @ 0x000000001927c779
...
```

Related to https://github.com/ClickHouse/ClickHouse/issues/84186


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.577`
<!-- ch-version-info:end -->