### PR TITLE
Fix current metric FilesystemCacheSizeLimit

### DIFF
--- a/src/Interpreters/Cache/FileCache.cpp
+++ b/src/Interpreters/Cache/FileCache.cpp
@@ -52,7 +52,9 @@ namespace CurrentMetrics
 {
     extern const Metric FilesystemCacheDownloadQueueElements;
     extern const Metric FilesystemCacheReserveThreads;
+    extern const Metric FilesystemCacheSizeLimit;
 }
+
 
 namespace DB
 {
@@ -215,6 +217,8 @@ FileCache::FileCache(const std::string & cache_name, const FileCacheSettings & s
 
     if (settings[FileCacheSetting::enable_filesystem_query_cache_limit])
         query_limit = std::make_unique<FileCacheQueryLimit>();
+
+    CurrentMetrics::add(CurrentMetrics::FilesystemCacheSizeLimit, settings[FileCacheSetting::max_size]);
 }
 
 const FileCache::UserInfo & FileCache::getCommonUser()

--- a/src/Interpreters/Cache/IFileCachePriority.cpp
+++ b/src/Interpreters/Cache/IFileCachePriority.cpp
@@ -2,10 +2,6 @@
 #include <Common/CurrentMetrics.h>
 #include <Common/Exception.h>
 
-namespace CurrentMetrics
-{
-    extern const Metric FilesystemCacheSizeLimit;
-}
 
 namespace DB
 {
@@ -19,7 +15,6 @@ namespace ErrorCodes
 IFileCachePriority::IFileCachePriority(size_t max_size_, size_t max_elements_)
     : max_size(max_size_), max_elements(max_elements_)
 {
-    CurrentMetrics::add(CurrentMetrics::FilesystemCacheSizeLimit, max_size_);
 }
 
 IFileCachePriority::Entry::Entry(

--- a/tests/integration/test_filesystem_cache/config.d/filesystem_caches.xml
+++ b/tests/integration/test_filesystem_cache/config.d/filesystem_caches.xml
@@ -1,0 +1,20 @@
+<clickhouse>
+    <filesystem_caches>
+        <cache1>
+            <type>cache</type>
+            <disk>hdd_blob</disk>
+            <path>/cache1/</path>
+            <max_size>1234</max_size>
+            <cache_policy>SLRU</cache_policy>
+            <cache_on_write_operations>1</cache_on_write_operations>
+        </cache1>
+        <cache2>
+            <type>cache</type>
+            <disk>hdd_blob</disk>
+            <path>/cache1/</path>
+            <max_size>1234</max_size>
+            <cache_policy>SLRU</cache_policy>
+            <cache_on_write_operations>1</cache_on_write_operations>
+        </cache2>
+    </filesystem_caches>
+</clickhouse>

--- a/tests/integration/test_filesystem_cache/test_size_limit_metric.py
+++ b/tests/integration/test_filesystem_cache/test_size_limit_metric.py
@@ -1,0 +1,47 @@
+import logging
+import os
+import random
+import time
+import uuid
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+from helpers.mock_servers import start_mock_servers, start_s3_mock
+from helpers.utility import SafeThread, generate_values, replace_config
+
+SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
+
+
+@pytest.fixture(scope="module")
+def cluster():
+    try:
+        cluster = ClickHouseCluster(__file__)
+        cluster.add_instance(
+            "node_test_size_limit_metric",
+            main_configs=[
+                "config.d/filesystem_caches_path.xml",
+                "config.d/filesystem_caches.xml",
+            ],
+            user_configs=[
+                "users.d/cache_on_write_operations.xml",
+            ],
+            stay_alive=True,
+        )
+
+        logging.info("Starting cluster...")
+        cluster.start()
+        logging.info("Cluster started")
+
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_cache_size_limit_metric(cluster):
+    node = cluster.instances["node_test_size_limit_metric"]
+    assert 1234 == int(
+        node.query(
+            "SELECT value FROM system.metrics WHERE name = 'FilesystemCacheSizeLimit'"
+        )
+    )


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix incorrect value of current metric `FilesystemCacheSizeLimit` in case `SLRU` cache policy was used.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.575`
- Backported to: `25.12.4.24`, `25.11.7.39`, `25.10.5.38`, `25.8.15.31`, `25.3.13.17`
<!-- ch-version-info:end -->