### PR TITLE
Fix logical error "ReadBuffer is canceled. Can't read from it" in TCPHandler::runImpl() after preserving canceled connection

### DIFF
--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -977,7 +977,7 @@ void TCPHandler::runImpl()
             }
 
             if (exception->code() == ErrorCodes::UNEXPECTED_PACKET_FROM_CLIENT || exception->code() == ErrorCodes::USER_EXPIRED
-                || exception->code() == ErrorCodes::TCP_CONNECTION_LIMIT_REACHED)
+                || exception->code() == ErrorCodes::TCP_CONNECTION_LIMIT_REACHED || in->isCanceled())
             {
                 LOG_DEBUG(log, "Going to close connection due to exception: {}", exception->message());
                 query_state->finalizeOut(out);

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -976,17 +976,24 @@ void TCPHandler::runImpl()
                 return;
             }
 
+            /// We close the connection after an exception if there is something wrong with the connection,
+            /// otherwise we try to preserve it and reuse for other queries.
             if (exception->code() == ErrorCodes::UNEXPECTED_PACKET_FROM_CLIENT || exception->code() == ErrorCodes::USER_EXPIRED
-                || exception->code() == ErrorCodes::TCP_CONNECTION_LIMIT_REACHED || in->isCanceled())
+                || exception->code() == ErrorCodes::TCP_CONNECTION_LIMIT_REACHED)
             {
                 LOG_DEBUG(log, "Going to close connection due to exception: {}", exception->message());
                 query_state->finalizeOut(out);
                 return;
             }
-            else
+
+            if (in->isCanceled())
             {
-                LOG_TRACE(log, "Logs and exception has been sent. The connection is preserved.");
+                LOG_DEBUG(log, "Going to close connection because the input stream was canceled");
+                query_state->finalizeOut(out);
+                return;
             }
+
+            LOG_TRACE(log, "Logs and exception has been sent. The connection is preserved.");
         }
 
         query_state->finalizeOut(out);


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix logical error `ReadBuffer is canceled. Can't read from it` in `TCPHandler::runImpl()` after preserving canceled connection.

[Example of failure](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=93174&sha=edb4346c535968cb8c0a79e03f55c834b836345a&name_0=PR&name_1=AST%20fuzzer%20%28amd_ubsan%29&name_1=AST%20fuzzer%20%28amd_ubsan%29
https://github.com/ClickHouse/ClickHouse/pull/93174).

Stack trace:
```
src/Common/Exception.cpp:57: DB::abortOnFailedAssertion(String const&, std::basic_string_view<char, std::char_traits<char>>, void* const*, unsigned long, unsigned long) @ 0x00000000202cc79d
src/Common/Exception.cpp:63: ? @ 0x00000000202cccc9
src/IO/ReadBuffer.cpp:90: DB::ReadBuffer::next() @ 0x00000000203d5d9b
inlined from ./src/IO/ReadBuffer.h:81: DB::ReadBuffer::eof()
src/Server/TCPHandler.cpp:504: DB::TCPHandler::runImpl() @ 0x000000002f186e3b
src/Server/TCPHandler.cpp:2867: DB::TCPHandler::run() @ 0x000000002f1ab2dc
base/poco/Net/src/TCPServerConnection.cpp:40: Poco::Net::TCPServerConnection::start() @ 0x0000000034dd5ccc
base/poco/Net/src/TCPServerDispatcher.cpp:115: Poco::Net::TCPServerDispatcher::run() @ 0x0000000034dd65dc
base/poco/Foundation/src/ThreadPool.cpp:205: Poco::PooledThread::run() @ 0x0000000034d5f3f4
./base/poco/Foundation/src/Thread_POSIX.cpp:341: Poco::ThreadImpl::runnableEntry(void*) @ 0x0000000034d5bad3
```

Related to https://github.com/ClickHouse/ClickHouse/issues/84186


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.589`
<!-- ch-version-info:end -->