### PR TITLE
Fix fuzzer crash in Backup engine with < 2 arguments

### DIFF
--- a/src/Parsers/FunctionSecretArgumentsFinder.h
+++ b/src/Parsers/FunctionSecretArgumentsFinder.h
@@ -724,6 +724,9 @@ protected:
 
     void findBackupDatabaseSecretArguments()
     {
+        if (function->arguments->size() < 2)
+            return;
+
         auto storage_arg = function->arguments->at(1);
         auto storage_function = storage_arg->getFunction();
 

--- a/tests/queries/0_stateless/03791_backup_engine_with_one_arg_must_not_crash.sql
+++ b/tests/queries/0_stateless/03791_backup_engine_with_one_arg_must_not_crash.sql
@@ -1,0 +1,2 @@
+-- Bug https://github.com/ClickHouse/ClickHouse/issues/93551
+CREATE DATABASE d1 ENGINE = Backup(-5036955478727481395::Int64); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }


### PR DESCRIPTION
Resolves #93551

### Changelog category (leave one):
-  Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Creating a Backup database engine with less than two arguments now returns a more descriptive error message (`Wrong number of arguments` instead of `std::out_of_range: InlinedVector::at(size_type) const failed bounds check.`).


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.579`
<!-- ch-version-info:end -->