### PR TITLE
Add missing const qualifier for Context::buildParameterizedViewStorage()

### DIFF
--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -2786,7 +2786,7 @@ StoragePtr Context::executeTableFunction(const ASTPtr & table_expression, const 
 }
 
 
-StoragePtr Context::buildParameterizedViewStorage(const String & database_name, const String & table_name, const NameToNameMap & param_values)
+StoragePtr Context::buildParameterizedViewStorage(const String & database_name, const String & table_name, const NameToNameMap & param_values) const
 {
     if (table_name.empty())
         return nullptr;

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -977,7 +977,7 @@ public:
     /// Overload for the new analyzer. Structure inference is performed in QueryAnalysisPass.
     StoragePtr executeTableFunction(const ASTPtr & table_expression, const TableFunctionPtr & table_function_ptr);
 
-    StoragePtr buildParameterizedViewStorage(const String & database_name, const String & table_name, const NameToNameMap & param_values);
+    StoragePtr buildParameterizedViewStorage(const String & database_name, const String & table_name, const NameToNameMap & param_values) const;
 
     void addViewSource(const StoragePtr & storage);
     StoragePtr getViewSource() const;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

While doing https://github.com/ClickHouse/ClickHouse/pull/94287, I found missing const qualifier


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.572`
<!-- ch-version-info:end -->