### PR TITLE
Add cmake support for illumos.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -390,6 +390,8 @@ elseif (OS_DARWIN)
     include(cmake/darwin/default_libs.cmake)
 elseif (OS_FREEBSD)
     include(cmake/freebsd/default_libs.cmake)
+elseif (OS_SUNOS)
+    include(cmake/sunos/default_libs.cmake)
 endif ()
 link_libraries(global-group)
 target_link_libraries(global-group INTERFACE $<TARGET_PROPERTY:global-libs,INTERFACE_LINK_LIBRARIES>)
@@ -509,7 +511,7 @@ macro (clickhouse_add_executable target)
     # to inject memory tracking mechanism into them.
     # Sanitizers have their own way of intercepting the
     # allocations and deallocations, so we skip this step for them.
-    if (NOT (SANITIZE OR SANITIZE_COVERAGE OR OS_DARWIN OR OS_FREEBSD))
+    if (NOT (SANITIZE OR SANITIZE_COVERAGE OR OS_DARWIN OR OS_FREEBSD OR OS_SUNOS))
         target_link_options(${target} PRIVATE
             "LINKER:--wrap=malloc"
             "LINKER:--wrap=free"

--- a/cmake/arch.cmake
+++ b/cmake/arch.cmake
@@ -1,4 +1,4 @@
-if (CMAKE_SYSTEM_PROCESSOR MATCHES "amd64|x86_64")
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "amd64|x86_64|i386")
     if (CMAKE_LIBRARY_ARCHITECTURE MATCHES "i386")
         message (FATAL_ERROR "32bit platforms are not supported")
     endif ()

--- a/cmake/sunos/default_libs.cmake
+++ b/cmake/sunos/default_libs.cmake
@@ -1,0 +1,33 @@
+# Set standard, system and compiler libraries explicitly for illumos/SunOS.
+# This is intended for more control of what we are linking.
+
+# illumos requires these defines to expose POSIX APIs in system headers:
+# - _REENTRANT: thread-safe libc functions
+# - _POSIX_PTHREAD_SEMANTICS: POSIX-compliant function signatures
+# - __EXTENSIONS__: expose non-standard but necessary APIs
+add_compile_definitions(_REENTRANT _POSIX_PTHREAD_SEMANTICS __EXTENSIONS__)
+
+set (DEFAULT_LIBS "-nodefaultlibs")
+
+set (BUILTINS_LIBRARY "-lgcc_s")
+if (USE_SYSTEM_COMPILER_RT)
+    # Try to find the clang builtins library
+    execute_process(COMMAND
+        ${CMAKE_CXX_COMPILER} --print-libgcc-file-name --rtlib=compiler-rt
+        OUTPUT_VARIABLE BUILTINS_LIBRARY
+        COMMAND_ERROR_IS_FATAL ANY
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif ()
+
+set (DEFAULT_LIBS "${DEFAULT_LIBS} ${BUILTINS_LIBRARY} -lc -lm -lrt -lpthread -ldl -lsocket -lnsl -lsendfile -lproc -lumem")
+
+message(STATUS "Default libraries: ${DEFAULT_LIBS}")
+
+set(CMAKE_CXX_STANDARD_LIBRARIES ${DEFAULT_LIBS})
+set(CMAKE_C_STANDARD_LIBRARIES ${DEFAULT_LIBS})
+
+add_library(Threads::Threads INTERFACE IMPORTED)
+set_target_properties(Threads::Threads PROPERTIES INTERFACE_LINK_LIBRARIES pthread)
+
+include (cmake/unwind.cmake)
+include (cmake/cxx.cmake)

--- a/contrib/postgres-cmake/CMakeLists.txt
+++ b/contrib/postgres-cmake/CMakeLists.txt
@@ -78,7 +78,7 @@ target_include_directories (_libpq SYSTEM PUBLIC "${LIBPQ_CMAKE_SOURCE_DIR}") # 
 # NOTE: this is a dirty hack to avoid and instead pg_config.h should be shipped
 # for different OS'es like for jemalloc, not one generic for all OS'es like
 # now.
-if (OS_DARWIN OR OS_FREEBSD OR USE_MUSL)
+if (OS_DARWIN OR OS_FREEBSD OR OS_SUNOS OR USE_MUSL)
     target_compile_definitions(_libpq PRIVATE -DSTRERROR_R_INT=1)
 endif()
 

--- a/src/Common/AllocationInterceptors.h
+++ b/src/Common/AllocationInterceptors.h
@@ -8,7 +8,7 @@
 
 // NOLINTBEGIN
 
-#if defined(SANITIZER) || defined(SANITIZE_COVERAGE) || defined(OS_DARWIN) || defined(OS_FREEBSD)
+#if defined(SANITIZER) || defined(SANITIZE_COVERAGE) || defined(OS_DARWIN) || defined(OS_FREEBSD) || defined(OS_SUNOS)
 
 #define __real_malloc(size) ::malloc(size)
 #define __real_calloc(nmemb, size) ::calloc(nmemb, size)


### PR DESCRIPTION
- Add illumos-specific cmake config.
- Treat i386 as x86_64, since illumos reports i386 from `uname -p`.
- Use posix strerror_r for postgres on illumos.

Part of #23777.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.678`
<!-- ch-version-info:end -->