### PR TITLE
query profiler: use feature detection rather than os detection.

### DIFF
--- a/src/Common/QueryProfiler.h
+++ b/src/Common/QueryProfiler.h
@@ -30,7 +30,7 @@ namespace DB
   * Note that signal handler implementation is defined by template parameter. See QueryProfilerReal and QueryProfilerCPU.
   */
 
-#ifndef __APPLE__
+#if defined(SIGEV_THREAD_ID)
 class Timer
 {
 public:
@@ -48,7 +48,7 @@ private:
     LoggerPtr log;
     std::optional<timer_t> timer_id;
 };
-#endif
+#endif // defined(SIGEV_THREAD_ID)
 
 template <typename ProfilerImpl>
 class QueryProfilerBase
@@ -66,7 +66,7 @@ private:
 
     LoggerPtr log;
 
-#ifndef __APPLE__
+#if defined(SIGEV_THREAD_ID)
     inline static thread_local Timer timer = Timer();
 #endif
 

--- a/src/Interpreters/ThreadStatusExt.cpp
+++ b/src/Interpreters/ThreadStatusExt.cpp
@@ -596,7 +596,7 @@ void ThreadStatus::resetPerformanceCountersLastUsage()
 
 void ThreadStatus::initGlobalProfiler([[maybe_unused]] UInt64 global_profiler_real_time_period, [[maybe_unused]] UInt64 global_profiler_cpu_time_period)
 {
-#if !defined(SANITIZER) && !defined(__APPLE__)
+#if !defined(SANITIZER) && defined(SIGEV_THREAD_ID)
     /// profilers are useless without trace collector
     auto context = Context::getGlobalContextInstance();
     if (!context->hasTraceCollector())


### PR DESCRIPTION
SIGEV_THREAD_ID is supported on linux but not macos or illumos. Rather than guarding on os, this patch guards on the feature instead. This allows us to compile on illumos without adding an illumos-specific check.

Part of #23777.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.688`
<!-- ch-version-info:end -->