### PR TITLE
Better ignore for global revokes on database level

### DIFF
--- a/src/Access/AccessRights.cpp
+++ b/src/Access/AccessRights.cpp
@@ -919,7 +919,13 @@ private:
         const AccessFlags & parent_flags_go,
         String path)
     {
-        auto grantable_flags = ::DB::getAllGrantableFlags(static_cast<Level>(full_name.size()));
+        Node * target_node = node;
+        if (!target_node)
+            target_node = node_go;
+
+        auto grantable_flags = target_node
+            ? ::DB::getAllGrantableFlags(target_node->level)
+            : ::DB::getAllGrantableFlags(static_cast<Level>(full_name.size()));
         auto parent_fl = parent_flags & grantable_flags;
         auto parent_fl_go = parent_flags_go & grantable_flags;
         auto flags = node ? node->flags : parent_fl;
@@ -928,10 +934,6 @@ private:
         auto revokes_go = parent_fl_go - flags_go - revokes;
         auto grants_go = flags_go - parent_fl_go;
         auto grants = flags - parent_fl - grants_go;
-
-        Node * target_node = node;
-        if (!target_node)
-            target_node = node_go;
 
         /// Inserts into result only meaningful nodes (e.g. wildcards or leafs).
         if (target_node && (target_node->isLeaf() || target_node->wildcard_grant))

--- a/src/Access/tests/gtest_access_rights_ops.cpp
+++ b/src/Access/tests/gtest_access_rights_ops.cpp
@@ -562,6 +562,27 @@ TEST(AccessRights, RevokeWithParameters)
     ASSERT_EQ(root.toString(), "GRANT SELECT ON *.* WITH GRANT OPTION, GRANT CREATE USER ON * WITH GRANT OPTION, REVOKE SELECT(bar*) ON default.foo");
 }
 
+TEST(AccessRights, RevokeWithParametersWithGrantOption)
+{
+    AccessRights root;
+    root.grantWithGrantOption(AccessType::ALL);
+    root.revokeWildcard(AccessType::INTROSPECTION, "system");  // global grant, do nothing for database revoke
+    ASSERT_EQ(root.toString(), "GRANT ALL ON *.* WITH GRANT OPTION");
+
+    root = {};
+    root.grant(AccessType::SELECT);
+    root.grant(AccessType::INTROSPECTION);
+    root.grant(AccessType::CREATE_USER);
+    root.revokeWildcard(AccessType::CREATE_USER, "system");
+    ASSERT_EQ(root.toString(), "GRANT SELECT, INTROSPECTION ON *.*, GRANT CREATE USER ON *, REVOKE CREATE USER ON system*");
+
+    root.grantWithGrantOption(AccessType::SELECT);
+    root.grantWithGrantOption(AccessType::INTROSPECTION);
+    root.grantWithGrantOption(AccessType::CREATE_USER);
+    root.revokeWildcard(AccessType::CREATE_USER, "system");
+    ASSERT_EQ(root.toString(), "GRANT SELECT, INTROSPECTION ON *.* WITH GRANT OPTION, GRANT CREATE USER ON * WITH GRANT OPTION, REVOKE CREATE USER ON system*");
+}
+
 TEST(AccessRights, ParialRevokeWithGrantOption)
 {
     AccessRights root;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Ignores impossible revokes of global grants on the database level for grants with grant option.

In our RBAC, it's impossible to revoke global grants on the database level - such queries will be ignored. 
Example:
```
GRANT ALL ON *.*; REVOKE INTROSPECTION ON foo.*
```
will result in the second revoke being ignored. Unfortunately, if the broken revoke were already in place in the .sql user/role declaration, it could live there indefinitely in some cases. This fix will forcefully delete such broken revokes.


<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.600`
- Backported to: `25.12.4.27`, `25.11.7.34`, `25.10.5.34`, `25.8.15.28`
<!-- ch-version-info:end -->