### PR TITLE
Remove redunant logging in DDLDependencyVisitor about "visitTableExpression for"

### DIFF
--- a/src/Databases/DDLDependencyVisitor.cpp
+++ b/src/Databases/DDLDependencyVisitor.cpp
@@ -207,7 +207,6 @@ namespace
         /// (for example, CREATE VIEW).
         void visitTableExpression(const ASTTableExpression & expr)
         {
-            LOG_TRACE(&Poco::Logger::get("DDLDependencyVisitor"), "visitTableExpression for {}", expr.formatForLogging());
             if (!expr.database_and_table_name)
                 return;
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Follow-up for: #72123 


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.608`
<!-- ch-version-info:end -->