### PR TITLE
Fix "WriteBuffer is neither finalized nor canceled when destructor is called" while pushing to Set

### DIFF
--- a/src/Storages/StorageSet.cpp
+++ b/src/Storages/StorageSet.cpp
@@ -48,6 +48,7 @@ public:
     String getName() const override { return "SetOrJoinSink"; }
     void consume(Chunk & chunk) override;
     void onFinish() override;
+    void onException(std::exception_ptr /* exception */) override;
 
 private:
     void cancelBuffers() noexcept;
@@ -124,6 +125,11 @@ void SetOrJoinSink::onFinish()
     {
         cancelBuffers();
     }
+}
+
+void SetOrJoinSink::onException(std::exception_ptr /* exception */)
+{
+    cancelBuffers();
 }
 
 

--- a/tests/queries/0_stateless/03792_push_to_set_via_mv_with_an_error.sql
+++ b/tests/queries/0_stateless/03792_push_to_set_via_mv_with_an_error.sql
@@ -1,0 +1,24 @@
+SET materialized_views_ignore_errors=1;
+-- Catch "WriteBuffer is neither finalized nor canceled when destructor is called. No exceptions in flight are detected."
+SET send_logs_level='error';
+
+-- First case with exception during reading
+DROP TABLE IF EXISTS tab;
+DROP TABLE IF EXISTS mv;
+
+CREATE TABLE tab (`c0` Int) ENGINE = Memory;
+CREATE MATERIALIZED VIEW mv ENGINE = Set() AS (SELECT c0, throwIf(1) FROM tab);
+
+-- Previously lead to "WriteBuffer is neither finalized nor canceled when destructor is called. No exceptions in flight are detected."
+INSERT INTO FUNCTION remote('localhost', currentDatabase(), tab) SELECT * FROM numbers(1) LIMIT 1;
+
+-- Second case with exception during analysis
+DROP TABLE IF EXISTS tab;
+DROP TABLE IF EXISTS mv;
+
+CREATE TABLE tab (c0 Int, c1 Int) ENGINE = Memory;
+CREATE MATERIALIZED VIEW mv ENGINE = Set() AS (SELECT c1 FROM tab);
+ALTER TABLE tab DROP COLUMN c1;
+
+-- Previously lead to "WriteBuffer is neither finalized nor canceled when destructor is called. No exceptions in flight are detected."
+INSERT INTO FUNCTION remote('localhost', currentDatabase(), tab) SELECT * FROM numbers(1) LIMIT 1;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix "WriteBuffer is neither finalized nor canceled when destructor is called" while pushing to Set

CI: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=94376&sha=d9245a3f418551366e8a3a6a9f892afb59c351b5&name_0=PR&name_1=BuzzHouse%20%28arm_asan%29
https://github.com/ClickHouse/ClickHouse/pull/94376

Fixes: https://github.com/ClickHouse/ClickHouse/issues/92204


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.601`
<!-- ch-version-info:end -->