### PR TITLE
Docs: fix typo

### DIFF
--- a/docs/en/engines/table-engines/integrations/nats.md
+++ b/docs/en/engines/table-engines/integrations/nats.md
@@ -118,7 +118,7 @@ Example:
 ```
 
 The NATS server configuration can be added using the ClickHouse config file.
-More specifically you can add Redis password for NATS engine:
+More specifically you can add your password for the NATS engine:
 
 ```xml
 <nats>


### PR DESCRIPTION
"redis password" is mentioned for NATS engine. Closes https://github.com/ClickHouse/clickhouse-docs/issues/1901
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.592`
<!-- ch-version-info:end -->