### PR TITLE
Don't prevent ALTER of columns using implicit indexes

### DIFF
--- a/src/Interpreters/MutationsInterpreter.cpp
+++ b/src/Interpreters/MutationsInterpreter.cpp
@@ -1092,10 +1092,15 @@ void MutationsInterpreter::prepare(bool dry_run)
                             {
                                 case AlterColumnSecondaryIndexMode::THROW:
                                 case AlterColumnSecondaryIndexMode::COMPATIBILITY:
-                                    /// The only way to reach this would be if the ALTER was created and then the table setting changed
-                                    throw Exception(
-                                        ErrorCodes::BAD_ARGUMENTS,
-                                        "Cannot ALTER column `{}` because index `{}` depends on it", command.column_name, index.name);
+                                    if (!index.isImplicitlyCreated())
+                                    {
+                                        /// The only way to reach this would be if the ALTER was created and then the table setting changed
+                                        throw Exception(
+                                            ErrorCodes::BAD_ARGUMENTS,
+                                            "Cannot ALTER column `{}` because index `{}` depends on it", command.column_name, index.name);
+                                    }
+                                    /// For implicit indices we don't throw, we will rebuild them
+                                    [[fallthrough]];
                                 case AlterColumnSecondaryIndexMode::REBUILD:
                                 {
                                     for (const auto & col : index_cols)

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -4192,11 +4192,16 @@ void MergeTreeData::checkAlterIsPossible(const AlterCommands & commands, Context
     columns_in_keys.insert(columns_alter_type_metadata_only.begin(), columns_alter_type_metadata_only.end());
     columns_in_keys.insert(columns_alter_type_check_safe_for_partition.begin(), columns_alter_type_check_safe_for_partition.end());
 
-    std::unordered_map<String, String> columns_in_indices;
+    /// We use columns_in_indices to prevent alters that change column data type in a way that requires
+    /// reindexing secondary indices (respecting alter_column_secondary_index_mode). But only care about explicit indices
+    std::unordered_map<String, String> columns_in_explicit_indices;
     for (const auto & index : old_metadata.getSecondaryIndices())
     {
-        for (const String & col : index.expression->getRequiredColumns())
-            columns_in_indices.emplace(col, index.name);
+        if (!index.isImplicitlyCreated())
+        {
+            for (const String & col : index.expression->getRequiredColumns())
+                columns_in_explicit_indices.emplace(col, index.name);
+        }
     }
 
     std::unordered_map<String, String> columns_in_projections;
@@ -4320,7 +4325,7 @@ void MergeTreeData::checkAlterIsPossible(const AlterCommands & commands, Context
 
             if (index_mode == AlterColumnSecondaryIndexMode::THROW)
             {
-                if (auto it = columns_in_indices.find(command.column_name); it != columns_in_indices.end())
+                if (auto it = columns_in_explicit_indices.find(command.column_name); it != columns_in_explicit_indices.end())
                 {
                     throw Exception(
                         ErrorCodes::ALTER_OF_COLUMN_IS_FORBIDDEN,
@@ -4380,7 +4385,7 @@ void MergeTreeData::checkAlterIsPossible(const AlterCommands & commands, Context
                 /// we will clear the index files (as we do with the column files) in any other case
                 if (index_mode == AlterColumnSecondaryIndexMode::THROW || index_mode == AlterColumnSecondaryIndexMode::COMPATIBILITY)
                 {
-                    if (auto it = columns_in_indices.find(command.column_name); it != columns_in_indices.end())
+                    if (auto it = columns_in_explicit_indices.find(command.column_name); it != columns_in_explicit_indices.end())
                     {
                         throw Exception(
                             ErrorCodes::ALTER_OF_COLUMN_IS_FORBIDDEN,
@@ -4433,7 +4438,7 @@ void MergeTreeData::checkAlterIsPossible(const AlterCommands & commands, Context
 
             if (index_mode == AlterColumnSecondaryIndexMode::THROW || index_mode == AlterColumnSecondaryIndexMode::COMPATIBILITY)
             {
-                if (auto it = columns_in_indices.find(command.column_name); it != columns_in_indices.end())
+                if (auto it = columns_in_explicit_indices.find(command.column_name); it != columns_in_explicit_indices.end())
                 {
                     throw Exception(
                         ErrorCodes::ALTER_OF_COLUMN_IS_FORBIDDEN,

--- a/src/Storages/MergeTree/MergeTreeSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeSettings.cpp
@@ -2019,7 +2019,7 @@ namespace ErrorCodes
 
     Possible values:
     - `rebuild` (default): Rebuilds any secondary indices affected by the column in the `ALTER` command.
-    - `throw`: Prevents any `ALTER` of columns covered by secondary indices by throwing an exception.
+    - `throw`: Prevents any `ALTER` of columns covered by **explicit** secondary indices by throwing an exception. Implicit indices are excluded from this restriction and will be rebuilt.
     - `drop`: Drop the dependent secondary indices. The new parts won't have the indices, requiring `MATERIALIZE INDEX` to recreate them.
     - `compatibility`: Matches the original behaviour: `throw` on `ALTER ... MODIFY COLUMN` and `rebuild` on `ALTER ... UPDATE/DELETE`.
     - `ignore`: Intended for expert usage. It will leave the indices in an inconsistent state, allowing incorrect query results.

--- a/tests/queries/0_stateless/00933_test_fix_extra_seek_on_compressed_cache.sh
+++ b/tests/queries/0_stateless/00933_test_fix_extra_seek_on_compressed_cache.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Tags: no-parallel, no-random-merge-tree-settings
+# add_minmax_index_for_numeric_columns=0: Changes teh number of files and bytes read
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -8,7 +9,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 $CLICKHOUSE_CLIENT --query="DROP TABLE IF EXISTS small_table"
 
-$CLICKHOUSE_CLIENT --query="CREATE TABLE small_table (a UInt64 default 0, n UInt64) ENGINE = MergeTree() PARTITION BY tuple() ORDER BY (a) SETTINGS min_bytes_for_wide_part = 0"
+$CLICKHOUSE_CLIENT --query="CREATE TABLE small_table (a UInt64 default 0, n UInt64) ENGINE = MergeTree() PARTITION BY tuple() ORDER BY (a) SETTINGS min_bytes_for_wide_part = 0, add_minmax_index_for_numeric_columns=0"
 
 $CLICKHOUSE_CLIENT --query="INSERT INTO small_table (n) SELECT * from system.numbers limit 100000;"
 $CLICKHOUSE_CLIENT --query="OPTIMIZE TABLE small_table FINAL;"

--- a/tests/queries/0_stateless/01739_index_hint.reference
+++ b/tests/queries/0_stateless/01739_index_hint.reference
@@ -1,7 +1,8 @@
+-- add_minmax_index_for_numeric_columns=0: Disable minmax index to not interfere with the indexHint tests. With it it would filter out more rows (correctly)
 -- { echo }
 
 drop table if exists tbl;
-create table tbl (p Int64, t Int64, f Float64) Engine=MergeTree partition by p order by t settings index_granularity=1;
+create table tbl (p Int64, t Int64, f Float64) Engine=MergeTree partition by p order by t settings index_granularity=1, add_minmax_index_for_numeric_columns=0;
 insert into tbl select number / 4, number, 0 from numbers(16);
 select * from tbl WHERE indexHint(t = 1) order by t;
 0	0	0

--- a/tests/queries/0_stateless/01739_index_hint.sql
+++ b/tests/queries/0_stateless/01739_index_hint.sql
@@ -1,8 +1,9 @@
+-- add_minmax_index_for_numeric_columns=0: Disable minmax index to not interfere with the indexHint tests. With it it would filter out more rows (correctly)
 -- { echo }
 
 drop table if exists tbl;
 
-create table tbl (p Int64, t Int64, f Float64) Engine=MergeTree partition by p order by t settings index_granularity=1;
+create table tbl (p Int64, t Int64, f Float64) Engine=MergeTree partition by p order by t settings index_granularity=1, add_minmax_index_for_numeric_columns=0;
 
 insert into tbl select number / 4, number, 0 from numbers(16);
 

--- a/tests/queries/0_stateless/01834_alias_columns_laziness_filimonov.sh
+++ b/tests/queries/0_stateless/01834_alias_columns_laziness_filimonov.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# add_minmax_index_for_numeric_columns=0: Otherwise the insert needs to evaluate the function in the alias and requires
+# sleeping for 100 rows * 0.1 seconds/row = 10 seconds.
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -6,7 +8,7 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 ${CLICKHOUSE_CLIENT} --query "
 drop table if exists aliases_lazyness;
-create table aliases_lazyness (x UInt32, y ALIAS sleepEachRow(0.1)) Engine=MergeTree ORDER BY x;
+create table aliases_lazyness (x UInt32, y ALIAS sleepEachRow(0.1)) Engine=MergeTree ORDER BY x SETTINGS add_minmax_index_for_numeric_columns=0;
 insert into aliases_lazyness(x) select * from numbers(100);
 "
 

--- a/tests/queries/0_stateless/03033_set_index_in.reference
+++ b/tests/queries/0_stateless/03033_set_index_in.reference
@@ -1,3 +1,9 @@
+-- { echoOn }
+select sum(1+ignore(*)) from a where indexHint(v in (20, 40));
 32768
+select sum(1+ignore(*)) from a where indexHint(v in (select 20 union all select 40 union all select 60));
 49152
+SELECT 1 FROM a PREWHERE v IN (SELECT 1) WHERE v IN (SELECT 2);
+select 1 from a where indexHint(indexHint(materialize(0)));
+select sum(1+ignore(*)) from a where indexHint(indexHint(v in (20, 40)));
 32768

--- a/tests/queries/0_stateless/03033_set_index_in.sql
+++ b/tests/queries/0_stateless/03033_set_index_in.sql
@@ -1,7 +1,9 @@
+-- add_minmax_index_for_numeric_columns=0: Disable minmax index for numeric columns to avoid interference with SET index, otherwise indexHint can filter further rows.
 SET optimize_trivial_insert_select = 1;
 
-create table a (k UInt64, v UInt64, index i (v) type set(100) granularity 2) engine MergeTree order by k settings index_granularity=8192, index_granularity_bytes=1000000000, min_index_granularity_bytes=0;
+create table a (k UInt64, v UInt64, index i (v) type set(100) granularity 2) engine MergeTree order by k settings index_granularity=8192, index_granularity_bytes=1000000000, min_index_granularity_bytes=0, add_minmax_index_for_numeric_columns=0;
 insert into a select number, intDiv(number, 4096) from numbers(1000000);
+-- { echoOn }
 select sum(1+ignore(*)) from a where indexHint(v in (20, 40));
 select sum(1+ignore(*)) from a where indexHint(v in (select 20 union all select 40 union all select 60));
 

--- a/tests/queries/0_stateless/03792_implicit_index_modify_column.reference
+++ b/tests/queries/0_stateless/03792_implicit_index_modify_column.reference
@@ -1,0 +1,19 @@
+auto_minmax_index_a	minmax()	a	Implicit	1
+auto_minmax_index_b	minmax()	b	Implicit	1
+auto_minmax_index_a	minmax()	a	Implicit	1
+auto_minmax_index_b	minmax()	b	Implicit	1
+Expression ((Project names + Projection))
+  Expression ((WHERE + Change column names to column identifiers))
+    ReadFromMergeTree (default.test_alter)
+    Indexes:
+      PrimaryKey
+        Condition: true
+        Parts: 2/2
+        Granules: 2/2
+      Skip
+        Name: auto_minmax_index_b
+        Description: minmax GRANULARITY 1
+        Condition: (b in [\'2\', \'2\'])
+        Parts: 1/2
+        Granules: 1/2
+      Ranges: 1

--- a/tests/queries/0_stateless/03792_implicit_index_modify_column.sql
+++ b/tests/queries/0_stateless/03792_implicit_index_modify_column.sql
@@ -1,0 +1,17 @@
+-- Implicit indices should not prevent any ALTERs, even if `alter_column_secondary_index_mode` is set to 'throw'
+
+DROP TABLE IF EXISTS test_alter;
+CREATE TABLE test_alter (
+      a Int32,
+      b Int32,
+)
+ENGINE = MergeTree ORDER BY a
+SETTINGS add_minmax_index_for_numeric_columns=1, add_minmax_index_for_string_columns=1, alter_column_secondary_index_mode='throw';
+
+INSERT INTO test_alter VALUES (1, 1);
+INSERT INTO test_alter VALUES (2, 2);
+
+SELECT name, type_full, expr, creation, data_compressed_bytes > 0 FROM system.data_skipping_indices where database = current_database() and table = 'test_alter' ORDER BY name;
+ALTER TABLE test_alter MODIFY COLUMN b String;
+SELECT name, type_full, expr, creation, data_compressed_bytes > 0 FROM system.data_skipping_indices where database = current_database() and table = 'test_alter' ORDER BY name;
+EXPLAIN indexes=1 SELECT * FROM test_alter WHERE b = '2';

--- a/tests/queries/0_stateless/03792_implicit_index_modify_column.sql
+++ b/tests/queries/0_stateless/03792_implicit_index_modify_column.sql
@@ -1,4 +1,8 @@
+-- Tags: no-parallel-replicas
+-- no-parallel-replicas: Different plan
 -- Implicit indices should not prevent any ALTERs, even if `alter_column_secondary_index_mode` is set to 'throw'
+
+SET enable_analyzer=1; -- Different plan
 
 DROP TABLE IF EXISTS test_alter;
 CREATE TABLE test_alter (


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Don't prevent ALTER of columns using implicit indexes, even if `alter_column_secondary_index_mode`'s `throw` mode is used.

It also includes some fixes for tests when enabling `add_minmax_index_for_numeric_columns`

References https://github.com/ClickHouse/ClickHouse/pull/76867

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.729`
<!-- ch-version-info:end -->