### PR TITLE
CI: Stateless tests job  fixes

### DIFF
--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -68,6 +68,7 @@ common_ft_job_config = Job.Config(
         ],
     ),
     result_name_for_cidb="Tests",
+    timeout=int(3600 * 2.5),
 )
 
 common_stress_job_config = Job.Config(

--- a/ci/jobs/build_clickhouse.py
+++ b/ci/jobs/build_clickhouse.py
@@ -8,7 +8,6 @@ from ci.praktika.result import Result
 from ci.praktika.settings import Settings
 from ci.praktika.utils import MetaClasses, Shell, Utils
 
-
 current_directory = Utils.cwd()
 build_dir = f"{current_directory}/ci/tmp/build"
 temp_dir = f"{current_directory}/ci/tmp"

--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -601,6 +601,7 @@ def main():
 
     CH.terminate()
 
+    reset_success = False
     if (
         test_result
         and not test_result.is_error()
@@ -618,6 +619,8 @@ def main():
                 ).do(),
             )
         )
+        if results[-1].is_ok():
+            reset_success = True
 
     if test_result and JobStages.CHECK_ERRORS in stages:
         # must not be performed for a test validation - test must fail and log errors are not respected
@@ -670,12 +673,18 @@ def main():
     if test_result:
         test_result.sort()
 
-    Result.create_from(
+    R = Result.create_from(
         results=results,
         stopwatch=stop_watch,
         files=CH.logs + debug_files,
         info=job_info,
-    ).complete_job(do_not_block_pipeline_on_failure=force_ok_exit)
+    )
+
+    if reset_success:
+        # coverage job ignores test failures
+        R.set_success()
+
+    R.complete_job(do_not_block_pipeline_on_failure=force_ok_exit)
 
 
 if __name__ == "__main__":

--- a/ci/jobs/performance_tests.py
+++ b/ci/jobs/performance_tests.py
@@ -600,9 +600,7 @@ def main():
 
         def run_tests():
             # Run 10 random queries per test by default, but all queries for benchmarks
-            benchmarks = {
-                "tpch.xml"
-            }
+            benchmarks = {"tpch.xml"}
             for test in test_files:
                 max_queries = 0 if test in benchmarks else 10
                 CHServer.run_test(

--- a/ci/jobs/scripts/stress/stress.py
+++ b/ci/jobs/scripts/stress/stress.py
@@ -107,7 +107,7 @@ def get_options(i: int, upgrade_check: bool, encrypted_storage: bool) -> str:
         )
     # dpsize' - implements DPsize algorithm currently only for Inner joins. So it may not work in some tests.
     # That is why we use it with fallback to 'greedy'.
-    join_order_algorithm_combinations = ['greedy', 'dpsize,greedy', 'greedy,dpsize']
+    join_order_algorithm_combinations = ["greedy", "dpsize,greedy", "greedy,dpsize"]
     client_options.append(
         f"query_plan_optimize_join_order_algorithm={random.choice(join_order_algorithm_combinations)}"
     )


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

---
1. add 2.5h job timeout
2. do not fail coverage job on test failures


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.613`
<!-- ch-version-info:end -->