### PR TITLE
Fix a typo in integration tests

### DIFF
--- a/tests/integration/integration-tests-entrypoint.sh
+++ b/tests/integration/integration-tests-entrypoint.sh
@@ -19,7 +19,7 @@ function handle_term()
 }
 trap handle_term TERM
 
-echo "Runnig: $*"
+echo "Running: $*"
 "$@" &
 PID=$!
 # This will be interrupted by SIGTERM that is received by this script


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

See https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=ccb603e29d0fcb30b170b480a09d699af6e5af14&name_0=MasterCI&name_1=Integration%20tests%20%28amd_asan%2C%20db%20disk%2C%20old%20analyzer%2C%202%2F6%29&name_1=Integration%20tests%20%28amd_asan%2C%20db%20disk%2C%20old%20analyzer%2C%202%2F6%29


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.612`
<!-- ch-version-info:end -->