### PR TITLE
tests: fix 03393_max_merge_delayed_streams_for_parallel_write flakiness

### DIFF
--- a/tests/queries/0_stateless/03393_max_merge_delayed_streams_for_parallel_write.sql
+++ b/tests/queries/0_stateless/03393_max_merge_delayed_streams_for_parallel_write.sql
@@ -22,6 +22,7 @@ settings
     max_merge_delayed_streams_for_parallel_write = 100,
     -- avoid superfluous merges
     merge_selector_base = 1000,
+    min_columns_to_activate_adaptive_write_buffer = 0,
     auto_statistics_types = '';
 
 insert into metric_log select * from generateRandom() limit 10;


### PR DESCRIPTION
CI: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=94407&sha=ef097a9ccd99e3e079eb37a89ab297bfe165f036&name_0=PR&name_1=Stateless%20tests%20%28amd_binary%2C%20ParallelReplicas%2C%20s3%20storage%2C%20sequential%29
https://github.com/ClickHouse/ClickHouse/pull/94407

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.611`
<!-- ch-version-info:end -->