### PR TITLE
Reduce SCALE in test `01396_inactive_replica_cleanup_nodes_zookeeper`

### DIFF
--- a/tests/queries/0_stateless/01396_inactive_replica_cleanup_nodes_zookeeper.sh
+++ b/tests/queries/0_stateless/01396_inactive_replica_cleanup_nodes_zookeeper.sh
@@ -12,7 +12,7 @@ REPLICA=$($CLICKHOUSE_CLIENT --query "Select getMacro('replica')")
 # Check that if we have one inactive replica and a huge number of INSERTs to active replicas,
 # the number of nodes in ZooKeeper does not grow unbounded.
 
-SCALE=500
+SCALE=200
 
 $CLICKHOUSE_CLIENT --query "
     DROP TABLE IF EXISTS r1;


### PR DESCRIPTION
The test was timing out after 600 seconds because the INSERT with max_block_size=1 creates 500 individual block inserts, each requiring ZooKeeper coordination. In a 3-node DatabaseReplicated cluster under load, this took about 9 minutes, leaving insufficient time for the cleanup loop to complete.

Reducing SCALE from 500 to 200 should reduce INSERT time by ~60% while still adequately testing the cleanup functionality.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

Closes #80032


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.622`
<!-- ch-version-info:end -->