### PR TITLE
fix flaky test 03238_create_or_replace_view_atomically_with_replicated_engine

### DIFF
--- a/tests/queries/0_stateless/03238_create_or_replace_view_atomically_with_replicated_engine.sh
+++ b/tests/queries/0_stateless/03238_create_or_replace_view_atomically_with_replicated_engine.sh
@@ -33,18 +33,7 @@ select_view_thread &
 select_view_thread &
 select_view_thread &
 select_view_thread &
-select_view_thread &
-select_view_thread &
-select_view_thread &
-select_view_thread &
-select_view_thread &
-select_view_thread &
 
-create_or_replace_view_thread &
-create_or_replace_view_thread &
-create_or_replace_view_thread &
-create_or_replace_view_thread &
-create_or_replace_view_thread &
 create_or_replace_view_thread &
 create_or_replace_view_thread &
 create_or_replace_view_thread &
@@ -52,3 +41,5 @@ create_or_replace_view_thread &
 create_or_replace_view_thread &
 
 wait
+
+${CLICKHOUSE_CURL} -sSg "${CLICKHOUSE_URL}" -d "DROP DATABASE IF EXISTS ${CLICKHOUSE_DATABASE}_db SYNC" > /dev/null


### PR DESCRIPTION
Looks like the test is too heavy for ASAN builds. Only seeing flaky test for ASAN builds. Though the tests seems to have gotten stable over the last week from [cidb](https://play.clickhouse.com/play?user=play#V0lUSAogICAgOTAgQVMgaW50ZXJ2YWxfZGF5cwpTRUxFQ1QKICAgIHRvU3RhcnRPZkRheShjaGVja19zdGFydF90aW1lKSBBUyBkYXksCiAgICBjb3VudCgpIEFTIGZhaWx1cmVzLAogICAgZ3JvdXBVbmlxQXJyYXkocHVsbF9yZXF1ZXN0X251bWJlcikgQVMgcHJzLAogICAgYW55KHJlcG9ydF91cmwpIEFTIHJlcG9ydF91cmwKRlJPTSBjaGVja3MKV0hFUkUgKG5vdygpIC0gdG9JbnRlcnZhbERheShpbnRlcnZhbF9kYXlzKSkgPD0gY2hlY2tfc3RhcnRfdGltZQogICAgQU5EIHRlc3RfbmFtZSA9ICcwMzIzOF9jcmVhdGVfb3JfcmVwbGFjZV92aWV3X2F0b21pY2FsbHlfd2l0aF9yZXBsaWNhdGVkX2VuZ2luZScKICAgIC0tIEFORCBjaGVja19uYW1lID0gJ1N0YXRlbGVzcyB0ZXN0cyAoYW1kX2FzYW4sIGRpc3RyaWJ1dGVkIHBsYW4sIHBhcmFsbGVsLCAxLzIpJwogICAgQU5EIHRlc3Rfc3RhdHVzIElOICgnRkFJTCcsICdFUlJPUicpCiAgICBBTkQgKHB1bGxfcmVxdWVzdF9udW1iZXIgPSAwIE9SIGJhc2VfcmVmIElOICgnbWFzdGVyJykpCiAgICBBTkQgdGVzdF9jb250ZXh0X3JhdyBMSUtFICclaGF2aW5nIHN0ZGVycm9yJScKR1JPVVAgQlkgZGF5Ck9SREVSIEJZIGRheSBERVNDCg==). Reduce the number of concurrent threads.

Closes: https://github.com/ClickHouse/ClickHouse/issues/93696
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.620`
<!-- ch-version-info:end -->