### PR TITLE
Fix OpenTelemetry trace context propagation in fibers

### DIFF
--- a/src/Common/Fiber.h
+++ b/src/Common/Fiber.h
@@ -137,9 +137,14 @@ private:
             return main_instance;
 
         Fiber::DataPtr & ptr = current_fiber->getLocalData(this);
-        /// Initialize instance on first request.
+        /// Initialize instance on first request, copying from main_instance
+        /// to inherit context (e.g., OpenTelemetry trace context).
         if (!ptr)
-            ptr = std::make_unique<DataWrapperImpl>();
+        {
+            auto wrapper = std::make_unique<DataWrapperImpl>();
+            wrapper->impl = main_instance;
+            ptr = std::move(wrapper);
+        }
 
         return dynamic_cast<DataWrapperImpl *>(ptr.get())->impl;
     }

--- a/tests/queries/0_stateless/01455_opentelemetry_distributed.reference
+++ b/tests/queries/0_stateless/01455_opentelemetry_distributed.reference
@@ -6,7 +6,7 @@
 {"query":"SELECT 1 AS `1` FROM `system`.`one` AS `__table1`","query_status":"QueryFinish","tracestate":"some custom state","sorted_by_finish_time":1}
 {"query":"select 1 from remote('127.0.0.2', system, one) settings enable_analyzer = 1 format Null\n","query_status":"QueryFinish","tracestate":"some custom state","sorted_by_finish_time":1}
 {"total spans":3,"unique spans":3,"unique non-zero parent spans":3}
-{"initial query spans with proper parent":2}
+{"initial query spans with proper parent":1}
 {"unique non-empty tracestate values":1}
 ===native===
 {"query":"select * from url('http:\/\/127.0.0.2:8123\/?query=select%201%20format%20Null', CSV, 'a int')","status":"QueryFinish","tracestate":"another custom state","sorted_by_start_time":1}


### PR DESCRIPTION
> The FiberLocal<T> class was creating fresh instances for fibers instead of inheriting from the main thread's context. This caused OpenTelemetry trace context to not be properly propagated when queries were sent asynchronously via fibers (controlled by async_query_sending_for_remote).

> The fix copies from main_instance when initializing fiber-local data, ensuring trace context is properly inherited. This makes the trace hierarchy consistent regardless of whether async or sync query sending is used.

> Updated the test expectation from 2 to 1, since the previous value was based on buggy behavior where async mode caused trace context to not be propagated, resulting in remote TCPHandler spans having the external parent directly instead of going through Connection::sendQuery.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


Closes #67108.