### PR TITLE
Fix bad test `01040_dictionary_invalidate_query_switchover_long.sh`

### DIFF
--- a/src/Interpreters/ExternalLoader.cpp
+++ b/src/Interpreters/ExternalLoader.cpp
@@ -1081,7 +1081,6 @@ private:
             next_update_time = TimePoint::max();
         }
 
-
         Info * info = getInfo(name);
 
         /// We should check if this is still the same loading as we were doing.

--- a/tests/queries/0_stateless/01040_dictionary_invalidate_query_switchover_long.sh
+++ b/tests/queries/0_stateless/01040_dictionary_invalidate_query_switchover_long.sh
@@ -49,12 +49,16 @@ check_exception_detected 2> /dev/null
 $CLICKHOUSE_CLIENT --query "SELECT last_exception FROM system.dictionaries WHERE database = currentDatabase() AND name = 'invalidate'" 2>&1 | grep -Eo "dict_invalidate.*UNKNOWN_TABLE" | wc -l
 
 $CLICKHOUSE_CLIENT --query "
-CREATE TABLE dict_invalidate
+CREATE TABLE dict_invalidate_new
 ENGINE = Memory AS
 SELECT
     133 as dummy,
     toDateTime('2019-10-29 18:51:35') AS last_time
 FROM system.one"
+
+$CLICKHOUSE_CLIENT --query "
+RENAME TABLE dict_invalidate_new TO dict_invalidate
+"
 
 function check_exception_fixed()
 {


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

Closes #87587.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.629`
<!-- ch-version-info:end -->