### PR TITLE
Fix bugfix validation not detecting server crashes

### DIFF
--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -616,11 +616,9 @@ def main():
                 stopwatch=sw_,
             )
         )
-        # fatal failures found in logs represented as normal test cases
-        test_result.extend_sub_results(results[-1].results)
-        results[-1].results = []
 
         # invert result status for bugfix validation
+        # must be done before results are moved to test_result
         if is_bugfix_validation:
             has_failure = False
             for r in results[-1].results:
@@ -635,6 +633,10 @@ def main():
                 results[-1].set_failed().set_info("Failed to reproduce the bug")
             else:
                 results[-1].set_success()
+
+        # fatal failures found in logs represented as normal test cases
+        test_result.extend_sub_results(results[-1].results)
+        results[-1].results = []
 
         if not results[-1].is_ok():
             results[-1].set_info("Found errors added into Tests results")


### PR DESCRIPTION
> The bugfix validation code was iterating over results[-1].results after it had been cleared, so has_failure was always False. This caused it to incorrectly report "Failed to reproduce the bug" even when a crash was detected.

> Move the bugfix validation block to before the results are moved to test_result and cleared.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

See https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=94511&sha=1e4efbde42c0ae19c63996d8211ddd477df6630b&name_0=PR&name_1=Bugfix%20validation%20%28functional%20tests%29
https://github.com/ClickHouse/ClickHouse/pull/94511