### PR TITLE
Demangle stack trace symbols on MacOS

### DIFF
--- a/src/Common/StackTrace.cpp
+++ b/src/Common/StackTrace.cpp
@@ -337,7 +337,7 @@ void StackTrace::forEachFrame(
         current_frame.virtual_addr = frame_pointers[i];
         current_frame.physical_addr = frame_pointers[i];
         current_frame.object = split[1];
-        current_frame.symbol = split[3];
+        current_frame.symbol = demangle(split[3].c_str());
         callback(current_frame);
     }
 #else


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Details
Since now `StackTrace::forEachFrame` is expected to return demangled symbols, add demangling for OS_DARWIN in this function.

Follow-up for  #93099 (therefore `not for changelog` -- this hasn't been released yet, at least not in 25.12.3.21)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.662`
<!-- ch-version-info:end -->