### PR TITLE
Fix TSan "unlock of an unlocked mutex" in CHECK TABLE for ReplicatedMergeTree

### DIFF
--- a/src/Core/BackgroundSchedulePoolTaskHolder.cpp
+++ b/src/Core/BackgroundSchedulePoolTaskHolder.cpp
@@ -34,4 +34,9 @@ const BackgroundSchedulePoolTaskInfo * BackgroundSchedulePoolTaskHolder::operato
     return task_info.get();
 }
 
+BackgroundSchedulePoolTaskInfoPtr BackgroundSchedulePoolTaskHolder::getTaskInfoPtr() const
+{
+    return task_info;
+}
+
 }

--- a/src/Core/BackgroundSchedulePoolTaskHolder.h
+++ b/src/Core/BackgroundSchedulePoolTaskHolder.h
@@ -26,6 +26,10 @@ public:
     BackgroundSchedulePoolTaskInfo * operator->();
     const BackgroundSchedulePoolTaskInfo * operator->() const;
 
+    /// Get the shared pointer to the task info.
+    /// Useful when you need to extend the lifetime of the task.
+    BackgroundSchedulePoolTaskInfoPtr getTaskInfoPtr() const;
+
 private:
     BackgroundSchedulePoolTaskInfoPtr task_info;
 };

--- a/src/Storages/MergeTree/ReplicatedMergeTreePartCheckThread.h
+++ b/src/Storages/MergeTree/ReplicatedMergeTreePartCheckThread.h
@@ -69,9 +69,28 @@ public:
 
     ReplicatedCheckResult checkPartImpl(const String & part_name, bool throw_on_broken_projection);
 
-    std::unique_lock<std::mutex> pausePartsCheck();
+    /// RAII guard that pauses parts check and reactivates it on destruction.
+    /// Safe to destroy from any thread.
+    class TemporaryPause
+    {
+    public:
+        explicit TemporaryPause(BackgroundSchedulePoolTaskInfoPtr task_);
+        ~TemporaryPause();
 
-    /// Can be called only while holding a lock returned from pausePartsCheck()
+        TemporaryPause(const TemporaryPause &) = delete;
+        TemporaryPause & operator=(const TemporaryPause &) = delete;
+        TemporaryPause(TemporaryPause &&) = default;
+        TemporaryPause & operator=(TemporaryPause &&) = default;
+
+    private:
+        BackgroundSchedulePoolTaskInfoPtr task;
+    };
+
+    /// Pause parts check in a thread-safe way.
+    /// The returned guard can be safely destroyed from any thread.
+    TemporaryPause temporaryPause();
+
+    /// Can be called only while holding a TemporaryPause guard.
     void cancelRemovedPartsCheck(const MergeTreePartInfo & drop_range_info);
 
 private:

--- a/src/Storages/StorageReplicatedMergeTree.h
+++ b/src/Storages/StorageReplicatedMergeTree.h
@@ -1011,8 +1011,8 @@ private:
 
     struct DataValidationTasks : public IStorage::DataValidationTasksBase
     {
-        explicit DataValidationTasks(DataPartsVector && parts_, std::unique_lock<std::mutex> && parts_check_lock_)
-            : parts_check_lock(std::move(parts_check_lock_)), parts(std::move(parts_)), it(parts.begin())
+        explicit DataValidationTasks(DataPartsVector && parts_, ReplicatedMergeTreePartCheckThread::TemporaryPause && pause_)
+            : pause(std::move(pause_)), parts(std::move(parts_)), it(parts.begin())
         {}
 
         DataPartPtr next()
@@ -1029,7 +1029,9 @@ private:
             return std::distance(it, parts.end());
         }
 
-        std::unique_lock<std::mutex> parts_check_lock;
+        /// Pauses the part check thread while this object exists.
+        /// Safe to destroy from any thread (unlike unique_lock which has thread affinity).
+        ReplicatedMergeTreePartCheckThread::TemporaryPause pause;
 
         mutable std::mutex mutex;
         DataPartsVector parts;


### PR DESCRIPTION
> The `DataValidationTasks` struct stored a `std::unique_lock<std::mutex>` holding a lock on `BackgroundSchedulePoolTaskInfo::exec_mutex`. This caused a ThreadSanitizer warning because:

> 1. Thread A acquires the lock via `pausePartsCheck()` -> `getExecLock()`
> 2. `DataValidationTasks` is stored in a `shared_ptr` and copied to worker threads during parallel CHECK TABLE execution (via `TableCheckTask`)
> 3. When the last reference is destroyed (potentially on Thread B), the `unique_lock` destructor tries to unlock the mutex
> 4. pthread mutexes must be unlocked by the same thread that locked them, causing the TSan error "unlock of an unlocked mutex (or by a wrong thread)"

> The fix replaces `pausePartsCheck()` (which returned a `unique_lock`) with `temporaryPause()` which returns a new `TemporaryPause` RAII guard. This guard uses `deactivate()` to pause the background task and `activateAndSchedule()` in its destructor to resume it. Both operations are thread-safe and can be called from any thread, eliminating the thread-affinity issue.

> Changes:
> - Add `getTaskInfoPtr()` to `BackgroundSchedulePoolTaskHolder`
> - Add `TemporaryPause` class to `ReplicatedMergeTreePartCheckThread`
> - Remove `pausePartsCheck()` and replace all usages with `temporaryPause()`
> - Update `DataValidationTasks` to use `TemporaryPause` instead of `unique_lock`

Fixes #87916

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.663`
<!-- ch-version-info:end -->