### PR TITLE
Disable distributed_index_analysis for non-shared engines

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -6976,8 +6976,13 @@ Replace table function engines with their -Cluster alternatives
 Allow usage of materialized views with parallel replicas
 )", 0) \
     DECLARE(Bool, distributed_index_analysis, false, R"(
-Index analysis will be distributed across replicas. Requires cluster_for_parallel_replicas.
+Index analysis will be distributed across replicas.
+Beneficial for shared storage and huge amount of data in cluster.
+Uses replicas from cluster_for_parallel_replicas.
 )", EXPERIMENTAL) \
+    DECLARE(Bool, distributed_index_analysis_for_non_shared_merge_tree, false, R"(
+Enable distributed index analysis even for non SharedMergeTree (cloud only engine).
+)", 0) \
     DECLARE_WITH_ALIAS(Bool, allow_experimental_database_iceberg, false, R"(
 Allow experimental database engine DataLakeCatalog with catalog_type = 'iceberg'
 )", BETA, allow_database_iceberg) \

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -45,6 +45,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"ignore_on_cluster_for_replicated_database", false, false, "Add a new setting to ignore ON CLUSTER clause for DDL queries with a replicated database."},
             {"input_format_binary_max_type_complexity", 1000, 1000, "Add a new setting to control max number of type nodes when decoding binary types. Protects against malicious inputs."},
             {"distributed_index_analysis", false, false, "New experimental setting"},
+            {"distributed_index_analysis_for_non_shared_merge_tree", false, false, "New setting"},
             {"distributed_cache_file_cache_name", "", "", "New setting."},
             {"trace_profile_events_list", "", "", "New setting"},
             {"correlated_subqueries_use_in_memory_buffer", false, true, "Use in-memory buffer for input of correlated subqueries by default."},

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -175,6 +175,7 @@ namespace Setting
     extern const SettingsBool parallel_replicas_index_analysis_only_on_coordinator;
     extern const SettingsBool parallel_replicas_support_projection;
     extern const SettingsBool distributed_index_analysis;
+    extern const SettingsBool distributed_index_analysis_for_non_shared_merge_tree;
     extern const SettingsUInt64 preferred_block_size_bytes;
     extern const SettingsUInt64 preferred_max_column_in_block_size_bytes;
     extern const SettingsUInt64 read_in_order_two_level_merge_threshold;
@@ -2228,7 +2229,9 @@ ReadFromMergeTree::AnalysisResultPtr ReadFromMergeTree::selectRangesToRead(
 
         bool final_second_pass = indexes->use_skip_indexes && !indexes->skip_indexes.empty() && query_info_.isFinal() && settings[Setting::use_skip_indexes_if_final_exact_mode];
         /// Note, use_skip_indexes_if_final_exact_mode requires complete PK, so we cannot apply distributed_index_analysis with it
-        bool distributed_index_analysis_enabled = settings[Setting::distributed_index_analysis] && !final_second_pass;
+        bool distributed_index_analysis_enabled = settings[Setting::distributed_index_analysis]
+            && (settings[Setting::distributed_index_analysis_for_non_shared_merge_tree] || data.isSharedStorage())
+            && !final_second_pass;
 
         if (!distributed_index_analysis_enabled)
         {

--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -192,6 +192,9 @@ ln -sf $SRC_PATH/users.d/nonconst_timezone.xml $DEST_SERVER_PATH/users.d/
 ln -sf $SRC_PATH/users.d/allow_introspection_functions.yaml $DEST_SERVER_PATH/users.d/
 ln -sf $SRC_PATH/users.d/replicated_ddl_entry.xml $DEST_SERVER_PATH/users.d/
 ln -sf $SRC_PATH/users.d/limits.yaml $DEST_SERVER_PATH/users.d/
+if check_clickhouse_version 26.1; then
+    ln -sf $SRC_PATH/users.d/distributed_index_analysis.yaml $DEST_SERVER_PATH/users.d/
+fi
 if [[ $(is_fast_build) == 1 ]]; then
     ln -sf $SRC_PATH/users.d/limits_fast.yaml $DEST_SERVER_PATH/users.d/
 fi

--- a/tests/config/users.d/distributed_index_analysis.yaml
+++ b/tests/config/users.d/distributed_index_analysis.yaml
@@ -1,0 +1,3 @@
+profiles:
+  default:
+    distributed_index_analysis_for_non_shared_merge_tree: true

--- a/tests/integration/test_distributed_index_analysis/test.py
+++ b/tests/integration/test_distributed_index_analysis/test.py
@@ -88,6 +88,7 @@ def test_primary_key():
     # Note, correctness (and ProfileEvents) checked in stateless tests
     master.query("select * from test.pk_test where k2 = repeat('a', 100)", settings={
         "distributed_index_analysis": 1,
+        "distributed_index_analysis_for_non_shared_merge_tree": 1,
         "use_query_condition_cache": 0,
         "cluster_for_parallel_replicas": "default",
     })

--- a/tests/queries/0_stateless/03623_distributed_index_analysis_for_non_shared_merge_tree.reference
+++ b/tests/queries/0_stateless/03623_distributed_index_analysis_for_non_shared_merge_tree.reference
@@ -1,0 +1,2 @@
+distributed_index_analysis_for_non_shared_merge_tree=0, DistributedIndexAnalysisMicroseconds>0=0
+distributed_index_analysis_for_non_shared_merge_tree=1, DistributedIndexAnalysisMicroseconds>0=1

--- a/tests/queries/0_stateless/03623_distributed_index_analysis_for_non_shared_merge_tree.sql
+++ b/tests/queries/0_stateless/03623_distributed_index_analysis_for_non_shared_merge_tree.sql
@@ -1,0 +1,29 @@
+drop table if exists test_10m;
+create table test_10m (key Int, value Int) engine=MergeTree() order by key;
+insert into test_10m select number, number*100 from numbers(1e6);
+
+set allow_experimental_parallel_reading_from_replicas=0;
+set cluster_for_parallel_replicas='parallel_replicas';
+
+--- Ignore warnings when replica does not respond, and analysis is done on initiator
+set send_logs_level='error';
+
+select sum(key) from test_10m settings distributed_index_analysis=1, distributed_index_analysis_for_non_shared_merge_tree=0 format Null;
+select sum(key) from test_10m settings distributed_index_analysis=1, distributed_index_analysis_for_non_shared_merge_tree=1 format Null;
+
+system flush logs query_log;
+select format(
+  'distributed_index_analysis_for_non_shared_merge_tree={}, DistributedIndexAnalysisMicroseconds>0={}',
+  Settings['distributed_index_analysis_for_non_shared_merge_tree'],
+  ProfileEvents['DistributedIndexAnalysisMicroseconds'] > 0
+)
+from system.query_log
+where
+  current_database = currentDatabase()
+  and event_date >= yesterday()
+  and type = 'QueryFinish'
+  and query_kind = 'Select'
+  and is_initial_query
+  and has(Settings, 'distributed_index_analysis')
+  and endsWith(log_comment, '-' || currentDatabase())
+order by event_time_microseconds;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Disable distributed_index_analysis for non-shared engines

Follow-up for: https://github.com/ClickHouse/ClickHouse/pull/86786


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.676`
<!-- ch-version-info:end -->