### PR TITLE
`SHOW COLUMNS` instead of `SHOW TABLES` for `CREATE AS` queries

### DIFF
--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -794,7 +794,7 @@ InterpreterCreateQuery::TableProperties InterpreterCreateQuery::getTableProperti
     else if (!create.as_table.empty())
     {
         String as_database_name = getContext()->resolveDatabase(create.as_database);
-        getContext()->checkAccess(AccessType::SHOW_TABLES, as_database_name, create.as_table);
+        getContext()->checkAccess(AccessType::SHOW_COLUMNS, as_database_name, create.as_table);
         StoragePtr as_storage = DatabaseCatalog::instance().getTable({as_database_name, create.as_table}, getContext());
 
         /// as_storage->getColumns() and setEngine(...) must be called under structure lock of other_table for CREATE ... AS other_table.

--- a/tests/queries/0_stateless/02184_table_engine_access.sh
+++ b/tests/queries/0_stateless/02184_table_engine_access.sh
@@ -11,6 +11,7 @@ $CLICKHOUSE_CLIENT --query "CREATE USER user_test_02184 IDENTIFIED WITH plaintex
 ${CLICKHOUSE_CLIENT} -q "REVOKE ALL ON *.* FROM user_test_02184"
 
 $CLICKHOUSE_CLIENT --query "GRANT CREATE ON *.* TO user_test_02184;"
+$CLICKHOUSE_CLIENT --query "GRANT SHOW COLUMNS ON *.* TO user_test_02184;"
 
 $CLICKHOUSE_CLIENT --query "CREATE TABLE url ENGINE=URL('https://clickhouse.com', LineAsString)"
 

--- a/tests/queries/0_stateless/03702_check_show_grant_in_create_as_query.sh
+++ b/tests/queries/0_stateless/03702_check_show_grant_in_create_as_query.sh
@@ -13,6 +13,7 @@ DROP USER IF EXISTS $user;
 CREATE USER $user;
 CREATE TABLE $db.test_table (x int) ORDER BY x;
 GRANT CREATE TABLE ON *.* TO $user;
+GRANT TABLE ENGINE ON * TO $user;
 EOF
 
 ${CLICKHOUSE_CLIENT} --user $user --query "CREATE TABLE $db.test_copy AS $db.test_table; -- { serverError ACCESS_DENIED }";

--- a/tests/queries/0_stateless/03702_check_show_grant_in_create_as_query.sh
+++ b/tests/queries/0_stateless/03702_check_show_grant_in_create_as_query.sh
@@ -17,6 +17,9 @@ EOF
 
 ${CLICKHOUSE_CLIENT} --user $user --query "CREATE TABLE $db.test_copy AS $db.test_table; -- { serverError ACCESS_DENIED }";
 
+${CLICKHOUSE_CLIENT} --query "GRANT SHOW COLUMNS ON $db.test_table TO $user"
+${CLICKHOUSE_CLIENT} --user $user --query "CREATE TABLE $db.test_copy AS $db.test_table"
+
 ${CLICKHOUSE_CLIENT} <<EOF
 DROP USER IF EXISTS $user;
 EOF

--- a/tests/queries/0_stateless/03702_check_show_grant_in_create_as_query.sh
+++ b/tests/queries/0_stateless/03702_check_show_grant_in_create_as_query.sh
@@ -14,6 +14,7 @@ CREATE USER $user;
 CREATE TABLE $db.test_table (x int) ORDER BY x;
 GRANT CREATE TABLE ON *.* TO $user;
 GRANT TABLE ENGINE ON * TO $user;
+DROP TABLE IF EXISTS test_copy;
 EOF
 
 ${CLICKHOUSE_CLIENT} --user $user --query "CREATE TABLE $db.test_copy AS $db.test_table; -- { serverError ACCESS_DENIED }";


### PR DESCRIPTION
### Changelog category (leave one):
- Backward Incompatible Change

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Check `SHOW COLUMNS` for `CREATE TABLE ... AS ...` queries. Previously, it checked `SHOW TABLES`, which is an incorrect grant for this type of permission check.

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.763`
<!-- ch-version-info:end -->