### PR TITLE
tests: less flaky test_storage_kafka_sasl

### DIFF
--- a/tests/integration/compose/docker_compose_kafka_sasl.yml
+++ b/tests/integration/compose/docker_compose_kafka_sasl.yml
@@ -20,6 +20,7 @@ services:
 
       KAFKA_OPTS: "-Djava.security.auth.login.config=/etc/kafka/secrets/kafka_server_jaas.conf"
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_OFFSETS_TOPIC_NUM_PARTITIONS: 1
       CLUSTER_ID: "Ch3OEYBSD34fcwNTASDNDM2Qk"
     volumes:
       - ${KAFKA_DIR:-}/secrets:/etc/kafka/secrets

--- a/tests/integration/test_storage_kafka_sasl/test.py
+++ b/tests/integration/test_storage_kafka_sasl/test.py
@@ -59,6 +59,7 @@ def test_kafka_sasl(kafka_cluster):
                      kafka_sasl_mechanism = 'PLAIN',
                      kafka_sasl_username = '{kafka_sasl_user}',
                      kafka_sasl_password = '{kafka_sasl_pass}',
+                     kafka_flush_interval_ms = 1000,
                      kafka_topic_list = 'topic1',
                      kafka_group_name = 'group1',
                      kafka_format = 'JSONEachRow';
@@ -74,7 +75,13 @@ def test_kafka_sasl(kafka_cluster):
     producer.send(topic="topic1", value='{"key":1, "value":"test123"}')
     producer.flush()
 
-    assert_eq_with_retry(instance, "SELECT value FROM test.messages", "test123")
+    assert_eq_with_retry(
+        instance,
+        "SELECT value FROM test.messages",
+        "test123",
+        retry_count=120,
+        sleep_time=0.5,
+    )
 
 
 def test_kafka_sasl_settings_precedence(kafka_cluster):


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Details

[cidb](https://play.clickhouse.com/play?user=play&run=1#V0lUSAogICAgOTAgQVMgaW50ZXJ2YWxfZGF5cwpTRUxFQ1QKICAgIHRvU3RhcnRPZkRheShjaGVja19zdGFydF90aW1lKSBBUyBkYXksCiAgICBjb3VudCgpIEFTIGZhaWx1cmVzLAogICAgZ3JvdXBVbmlxQXJyYXkocHVsbF9yZXF1ZXN0X251bWJlcikgQVMgcHJzLAogICAgYW55KHJlcG9ydF91cmwpIEFTIHJlcG9ydF91cmwKRlJPTSBjaGVja3MKV0hFUkUgKG5vdygpIC0gdG9JbnRlcnZhbERheShpbnRlcnZhbF9kYXlzKSkgPD0gY2hlY2tfc3RhcnRfdGltZQogICAgQU5EIHRlc3RfbmFtZSA9ICd0ZXN0X3N0b3JhZ2Vfa2Fma2Ffc2FzbC90ZXN0LnB5Ojp0ZXN0X2thZmthX3Nhc2wnCiAgICAtLSBBTkQgY2hlY2tfbmFtZSA9ICdJbnRlZ3JhdGlvbiB0ZXN0cyAoYW1kX2JpbmFyeSwgMy81KScKICAgIEFORCB0ZXN0X3N0YXR1cyBJTiAoJ0ZBSUwnLCAnRVJST1InKQogICAgQU5EIChwdWxsX3JlcXVlc3RfbnVtYmVyID0gMCBPUiBiYXNlX3JlZiBJTiAoJ21hc3RlcicpKQogICAgQU5EIHRlc3RfY29udGV4dF9yYXcgTElLRSAnJUFzc2VydGlvbkVycm9yJScKR1JPVVAgQlkgZGF5Ck9SREVSIEJZIGRheSBERVNDCg==)

Should become
1) faster -- less time spent on `__consumer_offsets` topic initialization due to reduced number of created partitions (50 -> 1) and reduced flush interval (7.5 sec -> 1 sec)
2) more stable -- due to increased assertion period (just in case)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.671`
<!-- ch-version-info:end -->