### PR TITLE
Enable named collection for YTsaurus dictionaries and tables.

### DIFF
--- a/src/Storages/YTsaurus/StorageYTsaurus.cpp
+++ b/src/Storages/YTsaurus/StorageYTsaurus.cpp
@@ -7,6 +7,7 @@
 #include <Storages/StorageFactory.h>
 #include <Storages/YTsaurus/StorageYTsaurus.h>
 #include <Storages/checkAndGetLiteralArgument.h>
+#include <Storages/NamedCollectionsHelpers.h>
 #include <Common/ErrorCodes.h>
 #include <Core/Settings.h>
 #include <Processors/Sources/YTsaurusSource.h>
@@ -86,15 +87,51 @@ Pipe StorageYTsaurus::read(
     return Pipe(ptr);
 }
 
+YTsaurusStorageConfiguration StorageYTsaurus::processNamedCollectionResult(
+    const NamedCollection & named_collection, const YTsaurusSettings& settings, bool is_for_dictionary = false)
+{
+    ValidateKeysMultiset<ExternalDatabaseEqualKeysSet> required_arguments = {"http_proxy_urls", "cypress_path", "oauth_token"};
+    ValidateKeysMultiset<ExternalDatabaseEqualKeysSet> optional_arguments = {"ytsaurus_columns_description"};
+    if (is_for_dictionary)
+    {
+        for (const auto& name : settings.getAllRegisteredNames())
+        {
+            optional_arguments.insert(name);
+        }
+        optional_arguments.insert("name");
+    }
+    validateNamedCollection<ValidateKeysMultiset<ExternalDatabaseEqualKeysSet>>(named_collection, required_arguments, optional_arguments);
+
+
+    YTsaurusStorageConfiguration configuration{.settings = settings};
+    configuration.settings.loadFromNamedCollection(named_collection);
+
+    boost::split(configuration.http_proxy_urls, named_collection.get<String>("http_proxy_urls"), [](char c) { return c == '|'; });
+    configuration.cypress_path = named_collection.get<String>("cypress_path");
+    configuration.oauth_token = named_collection.get<String>("oauth_token");
+
+    if (is_for_dictionary)
+    {
+        auto column_description = named_collection.getOrDefault<String>("ytsaurus_columns_description", "");
+        if (!column_description.empty())
+            configuration.ytsaurus_columns_description = std::move(column_description);
+    }
+    return configuration;
+}
+
 YTsaurusStorageConfiguration StorageYTsaurus::getConfiguration(ASTs engine_args, const YTsaurusSettings & settings, ContextPtr context)
 {
-    YTsaurusStorageConfiguration configuration{.settings = settings};
-    for (auto & engine_arg : engine_args)
+    if (auto named_collection = tryGetNamedCollectionWithOverrides(engine_args, context))
     {
-        engine_arg = evaluateConstantExpressionOrIdentifierAsLiteral(engine_arg, context);
+        return StorageYTsaurus::processNamedCollectionResult(*named_collection, settings);
     }
+    YTsaurusStorageConfiguration configuration{.settings = settings};
     if (engine_args.size() == 3)
     {
+        for (auto & engine_arg : engine_args)
+        {
+            engine_arg = evaluateConstantExpressionOrIdentifierAsLiteral(engine_arg, context);
+        }
         boost::split(configuration.http_proxy_urls, checkAndGetLiteralArgument<String>(engine_args[0], "http_proxy_urls"), [](char c) { return c == '|'; });
         configuration.cypress_path = checkAndGetLiteralArgument<String>(engine_args[1], "cypress_path");
         configuration.oauth_token = checkAndGetLiteralArgument<String>(engine_args[2], "oauth_token");

--- a/src/Storages/YTsaurus/StorageYTsaurus.cpp
+++ b/src/Storages/YTsaurus/StorageYTsaurus.cpp
@@ -94,7 +94,7 @@ YTsaurusStorageConfiguration StorageYTsaurus::processNamedCollectionResult(
     ValidateKeysMultiset<ExternalDatabaseEqualKeysSet> optional_arguments = {"ytsaurus_columns_description"};
     if (is_for_dictionary)
     {
-        for (const auto& name : settings.getAllRegisteredNames())
+        for (const auto & name : settings.getAllRegisteredNames())
         {
             optional_arguments.insert(name);
         }

--- a/src/Storages/YTsaurus/StorageYTsaurus.h
+++ b/src/Storages/YTsaurus/StorageYTsaurus.h
@@ -31,6 +31,9 @@ class StorageYTsaurus final : public IStorage
 public:
     static YTsaurusStorageConfiguration getConfiguration(ASTs engine_args, const YTsaurusSettings & settings, ContextPtr context);
 
+    static YTsaurusStorageConfiguration processNamedCollectionResult(const NamedCollection & named_collection, const YTsaurusSettings & setting, bool is_for_dictionary);
+
+
     StorageYTsaurus(
         const StorageID & table_id_,
         YTsaurusStorageConfiguration configuration_,

--- a/src/TableFunctions/TableFunctionYtsaurus.cpp
+++ b/src/TableFunctions/TableFunctionYtsaurus.cpp
@@ -102,9 +102,14 @@ void TableFunctionYTsaurus::parseArguments(const ASTPtr & ast_function, ContextP
             break;
         }
     }
-
-
-    if (args.size() == 4)
+    if (args.size() == 2)
+    {
+        // With Named Collection
+        ASTs main_arguments(args.begin(), args.begin() + 1);
+        configuration = std::make_shared<YTsaurusStorageConfiguration>(StorageYTsaurus::getConfiguration(main_arguments, yt_settings, context));
+        structure = checkAndGetLiteralArgument<String>(args[1], "structure");
+    }
+    else if (args.size() == 4)
     {
         ASTs main_arguments(args.begin(), args.begin() + 3);
         configuration = std::make_shared<YTsaurusStorageConfiguration>(StorageYTsaurus::getConfiguration(main_arguments, yt_settings, context));
@@ -115,7 +120,9 @@ void TableFunctionYTsaurus::parseArguments(const ASTPtr & ast_function, ContextP
         throw Exception(
             ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH,
             "Table function 'ytsaurus' 4 parameters: "
-            "ytsaurus('http_proxy_url', cypress_path, oauth_token, structure).");
+            "ytsaurus('http_proxy_url', cypress_path, oauth_token, structure) "
+            "or with 2 parameters: ytsaurus(named_collections, structure)."
+        );
     }
 }
 

--- a/tests/integration/test_ytsaurus/test_dictionaries.py
+++ b/tests/integration/test_ytsaurus/test_dictionaries.py
@@ -374,3 +374,40 @@ def test_yt_dictionary_with_query(started_cluster):
 
     instance.query("DROP DICTIONARY yt_dict")
     yt.remove_table(path)
+
+
+def test_yt_dictionary_with_named_collection(started_cluster):
+    yt = YTsaurusCLI(started_cluster, instance, yt_uri_helper.host, yt_uri_helper.port)
+    path = "//tmp/table"
+
+    yt.create_table(
+        path,
+        '{"id":1,"value":"ffff"}{"id":2,"value":"abc"}{"id":3,"value":"aa"}',
+        schema={"id": "uint64", "value": "string"},
+        dynamic=True,
+    )
+    instance.query(
+        f"""
+        CREATE NAMED COLLECTION ytsaurus_nc AS
+            http_proxy_urls = '{yt_uri_helper.uri}',
+            cypress_path = '{path}',
+            oauth_token = '{yt_uri_helper.token}',
+            check_table_schema = 0,
+            ytsaurus_columns_description = 'id, length(value) as len'
+        """
+    )
+
+    instance.query(
+        f"""
+        CREATE DICTIONARY yt_dict(id UInt64, len Int32) PRIMARY KEY id SOURCE(YTSAURUS(NAME ytsaurus_nc)) LAYOUT(HASHED()) LIFETIME(MIN 0 MAX 1000)
+        """
+    )
+    assert (
+        instance.query("SELECT dictGet('yt_dict', 'len', number + 1) FROM numbers(3)")
+        == "4\n3\n2\n"
+    )
+
+    assert instance.query("SELECT dictGet('yt_dict', 'len', 2)") == "3\n"
+
+    instance.query("DROP DICTIONARY yt_dict")
+    yt.remove_table(path)

--- a/tests/integration/test_ytsaurus/test_dictionaries.py
+++ b/tests/integration/test_ytsaurus/test_dictionaries.py
@@ -410,4 +410,5 @@ def test_yt_dictionary_with_named_collection(started_cluster):
     assert instance.query("SELECT dictGet('yt_dict', 'len', 2)") == "3\n"
 
     instance.query("DROP DICTIONARY yt_dict")
+    instance.query("DROP NAMED COLLECTION ytsaurus_nc")
     yt.remove_table(path)

--- a/tests/integration/test_ytsaurus/test_tables.py
+++ b/tests/integration/test_ytsaurus/test_tables.py
@@ -34,11 +34,12 @@ def started_cluster():
 
 
 def test_yt_simple_table_engine(started_cluster):
+    table = "//tmp/table"
     yt = YTsaurusCLI(started_cluster, instance, yt_uri_helper.host, yt_uri_helper.port)
-    yt.create_table("//tmp/table", '{"a":"10","b":"20"}\n{"a":"20","b":"40"}')
+    yt.create_table(table, '{"a":"10","b":"20"}\n{"a":"20","b":"40"}')
     instance.rotate_logs()
     instance.query(
-        f"CREATE TABLE yt_test(a Int32, b Int32) ENGINE=YTsaurus('{yt_uri_helper.uri}', '//tmp/table', '{yt_uri_helper.token}')"
+        f"CREATE TABLE yt_test(a Int32, b Int32) ENGINE=YTsaurus('{yt_uri_helper.uri}', '{table}', '{yt_uri_helper.token}')"
     )
 
     assert instance.query("SELECT * FROM yt_test") == "10\t20\n20\t40\n"
@@ -50,7 +51,7 @@ def test_yt_simple_table_engine(started_cluster):
 
     instance.query("DROP TABLE yt_test SYNC")
 
-    yt.remove_table("//tmp/table")
+    yt.remove_table(table)
 
 
 def test_yt_simple_table_function(started_cluster):
@@ -515,3 +516,38 @@ def test_ytsaurus_replicated_table(started_cluster):
     assert instance.query("SELECT * FROM yt_test") == "10\t20\n20\t40\n"
     instance.query("DROP TABLE yt_test SYNC")
     yt.remove_replicated_table(f"{table_path}")
+
+
+def test_yt_named_collection(started_cluster):
+    table = "//tmp/table"
+    yt = YTsaurusCLI(started_cluster, instance, yt_uri_helper.host, yt_uri_helper.port)
+    yt.create_table(table, '{"a":"10","b":"20"}\n{"a":"20","b":"40"}')
+    instance.rotate_logs()
+    instance.query(
+        f"""
+            CREATE NAMED COLLECTION ytsaurus_nc AS
+            http_proxy_urls = '{yt_uri_helper.uri}',
+            cypress_path = '{table}',
+            oauth_token = '{yt_uri_helper.token}'
+            """
+    )
+
+    instance.query(
+        f"CREATE TABLE yt_test(a Int32, b Int32) ENGINE=YTsaurus(ytsaurus_nc)"
+    )
+
+    assert instance.query("SELECT * FROM yt_test") == "10\t20\n20\t40\n"
+    assert instance.query("SELECT a,b FROM yt_test") == "10\t20\n20\t40\n"
+    assert instance.query("SELECT a FROM yt_test") == "10\n20\n"
+
+    assert instance.query("SELECT * FROM yt_test WHERE a > 15") == "20\t40\n"
+    instance.wait_for_log_line("Get list of heavy proxies from path")
+
+    assert (
+        instance.query(f"SELECT * FROM ytsaurus(ytsaurus_nc, 'a Int32, b Int32')")
+        == "10\t20\n20\t40\n"
+    )
+
+    instance.query("DROP TABLE yt_test SYNC")
+
+    yt.remove_table(table)

--- a/tests/integration/test_ytsaurus/test_tables.py
+++ b/tests/integration/test_ytsaurus/test_tables.py
@@ -549,5 +549,6 @@ def test_yt_named_collection(started_cluster):
     )
 
     instance.query("DROP TABLE yt_test SYNC")
+    instance.query("DROP NAMED COLLECTION ytsaurus_nc")
 
     yt.remove_table(table)


### PR DESCRIPTION
Enable using NC with YTsaurus sources. Example:
```
  CREATE NAMED COLLECTION ytsaurus_nc AS
    http_proxy_urls = 'http://localhost:80',
    cypress_path = '//tmp/table',
    oauth_token = '1234'

CREATE TABLE yt_test(a Int32, b Int32) ENGINE=YTsaurus(ytsaurus_nc)
```

### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Enable named collection for YTsaurus dictionaries and tables.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.695`
<!-- ch-version-info:end -->