### PR TITLE
Fix crash on CREATE WORKLOAD in an active workload

### DIFF
--- a/src/Common/Scheduler/Nodes/FifoQueue.h
+++ b/src/Common/Scheduler/Nodes/FifoQueue.h
@@ -9,6 +9,7 @@
 #include <boost/intrusive/list.hpp>
 
 #include <mutex>
+#include <vector>
 
 
 namespace DB
@@ -119,16 +120,25 @@ public:
 
     void purgeQueue() override
     {
-        std::lock_guard lock(mutex);
-        is_not_usable = true;
-        while (!requests.empty())
+        // Collect requests to fail while holding the lock, but call failed() outside the lock
+        // to avoid potential deadlock with CPULeaseAllocation::mutex (lock order inversion)
+        std::vector<ResourceRequest *> requests_to_fail;
         {
-            ResourceRequest * request = &requests.front();
-            requests.pop_front();
-            request->failed(std::make_exception_ptr(
-                Exception(ErrorCodes::INVALID_SCHEDULER_NODE, "Scheduler queue with resource request is about to be destructed")));
+            std::lock_guard lock(mutex);
+            is_not_usable = true;
+            while (!requests.empty())
+            {
+                ResourceRequest * request = &requests.front();
+                requests.pop_front();
+                requests_to_fail.push_back(request);
+            }
+            event_queue->cancelActivation(this);
         }
-        event_queue->cancelActivation(this);
+        // Now notify all collected requests about the failure without holding the mutex
+        auto exception = std::make_exception_ptr(
+            Exception(ErrorCodes::INVALID_SCHEDULER_NODE, "Scheduler queue with resource request is about to be destructed"));
+        for (ResourceRequest * request : requests_to_fail)
+            request->failed(exception);
     }
 
     bool isActive() override

--- a/tests/integration/test_scheduler_cpu_preemptive/test.py
+++ b/tests/integration/test_scheduler_cpu_preemptive/test.py
@@ -201,10 +201,12 @@ def test_independent_pools(with_custom_config):
 
 # For debugging purposes
 LOG = []
+LOG_LOCK = threading.Lock()
 def mylog(message: str, *args) -> None:
     # Format a human-readable timestamp and append a tuple to LOG
     timestamp = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
-    LOG.append((timestamp, message, args))
+    with LOG_LOCK:
+        LOG.append((timestamp, message, args))
 
 
 class QueryPool:
@@ -214,9 +216,12 @@ class QueryPool:
         self.stop_event: threading.Event = threading.Event()
         self.threads: list[threading.Thread] = []
         self.stopped: bool = True
+        self.errors: int = 0
+        self._errors_lock: threading.Lock = threading.Lock()
 
     def start_random(self, max_billions: int, max_threads: int) -> None:
         assert self.stopped, "Pool is already running"
+        self.stopped = False
 
         def query_thread() -> None:
             while not self.stop_event.is_set():
@@ -233,6 +238,7 @@ class QueryPool:
 
     def start_fixed(self, billions: int, max_threads: int) -> None:
         assert self.stopped, "Pool is already running"
+        self.stopped = False
 
         def query_thread() -> None:
             while not self.stop_event.is_set():
@@ -246,6 +252,41 @@ class QueryPool:
             self.threads.append(threading.Thread(target=query_thread, args=()))
         for thread in self.threads:
             thread.start()
+
+    def start_fixed_stop_on_error(self, billions: int, max_threads: int) -> None:
+        assert self.stopped, "Pool is already running"
+        self.stopped = False
+
+        def query_thread() -> None:
+            while not self.stop_event.is_set():
+                mylog(f"Running query in workload {self.workload}")
+                try:
+                    node.query(
+                        f"with (select {billions * 1000000000})::UInt64 as n select count(*) from numbers_mt(n) settings "
+                        f"workload='{self.workload}', max_threads={max_threads}"
+                    )
+                except QueryRuntimeException as e:
+                    mylog(f"Query in workload {self.workload} failed with exception: {e}")
+                    with self._errors_lock:
+                        self.errors += 1
+
+        for _ in range(self.num_queries):
+            self.threads.append(threading.Thread(target=query_thread, args=()))
+        for thread in self.threads:
+            thread.start()
+
+    def get_errors(self) -> int:
+        with self._errors_lock:
+            return self.errors
+
+    def wait_for_all_errors(self) -> None:
+        """Wait until all threads have failed with errors, then stop the pool."""
+        while True:
+            with self._errors_lock:
+                if self.errors >= self.num_queries:
+                    break
+            time.sleep(0.01)
+        self.stop()
 
     def stop(self) -> None:
         mylog(f"Stopping workload {self.workload}")
@@ -429,3 +470,63 @@ def test_downscaling(with_custom_config):
     finally:
         for tid in active_ids:
             development.stop(tid)
+
+
+def test_create_workload_under_load():
+    """Test that creating a WORKLOAD while queries are running does not cause crashes or deadlocks."""
+    node.query(
+        f"""
+        create resource cpu (master thread, worker thread);
+        create workload all settings max_concurrent_threads=3;
+        create workload production in all settings weight=1;
+        create workload development in all settings weight=1, max_cpus=1;
+    """
+    )
+
+    production = QueryPool(2, "production")
+    production.start_fixed_stop_on_error(1, 2)
+    development = QueryPool(2, "development")
+    development.start_fixed_stop_on_error(1, 2)
+    time.sleep(1)
+
+    assert production.get_errors() == 0, "Errors occurred in production workload"
+    assert development.get_errors() == 0, "Errors occurred in development workload"
+
+    # Try to create a new workload while the queries are running
+    # This is sibling workload, so it should not affect existing queries
+    node.query(
+        f"create workload staging in all settings weight=2, max_cpus=1;"
+    )
+    time.sleep(1)
+    assert production.get_errors() == 0, "Errors occurred in production workload"
+    assert development.get_errors() == 0, "Errors occurred in development workload"
+
+    # This make production non-usable, as it will be not a leaf workload anymore
+    node.query(
+        f"create workload production2 in production;"
+    )
+    time.sleep(1)
+    production.wait_for_all_errors()
+    assert development.get_errors() == 0, "Errors occurred in development workload"
+
+    # Restart load inside new workload
+    production2 = QueryPool(2, "production2")
+    production2.start_fixed_stop_on_error(1, 2)
+
+    # This make development non-usable, as it will be not a leaf workload anymore
+    node.query(
+        f"create workload development2 in development;"
+    )
+    time.sleep(1)
+    development.wait_for_all_errors()
+    assert production2.get_errors() == 0, "Errors occurred in production2 workload"
+
+    # Restart load inside new workload
+    development2 = QueryPool(2, "development2")
+    development2.start_fixed_stop_on_error(1, 2)
+
+    # Cleanup
+    production2.stop()
+    development2.stop()
+    assert development2.get_errors() == 0, "Errors occurred in development2 workload"
+    assert production2.get_errors() == 0, "Errors occurred in production2 workload"

--- a/tests/integration/test_scheduler_cpu_preemptive/test.py
+++ b/tests/integration/test_scheduler_cpu_preemptive/test.py
@@ -36,6 +36,9 @@ def start_cluster():
 def clear_workloads_and_resources():
     node.query(
         f"""
+        drop workload if exists production2;
+        drop workload if exists development2;
+        drop workload if exists staging;
         drop workload if exists production;
         drop workload if exists development;
         drop workload if exists admin;


### PR DESCRIPTION
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Creating a workload in another workload that is currently in use no longer causes a crash.

Fixes https://github.com/ClickHouse/ClickHouse/issues/92207

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.788`
- Backported to: `25.11.9.26`, `25.8.22.8`
<!-- ch-version-info:end -->