### PR TITLE
Fix crash in `ActionsDAG` partial evaluation for `ANY LEFT JOIN`

### DIFF
--- a/tests/queries/0_stateless/03799_any_left_join_isnotnull_crash.reference
+++ b/tests/queries/0_stateless/03799_any_left_join_isnotnull_crash.reference
@@ -1,0 +1,1 @@
+{"site":"STORE_A","page_level":1,"count":1}

--- a/tests/queries/0_stateless/03799_any_left_join_isnotnull_crash.sql
+++ b/tests/queries/0_stateless/03799_any_left_join_isnotnull_crash.sql
@@ -1,0 +1,53 @@
+SET allow_experimental_analyzer = 1;
+
+DROP TABLE IF EXISTS AddedToCart;
+DROP TABLE IF EXISTS Session;
+
+CREATE TABLE Session
+(
+    id String,
+    site Enum8('STORE_A' = 1, 'STORE_B' = 2),
+    device Enum8('DESKTOP' = 1, 'MOBILE' = 2)
+)
+ENGINE = MergeTree
+ORDER BY id;
+
+CREATE TABLE AddedToCart
+(
+    sessionId String,
+    order Int32,
+    top Nullable(Int32),
+    screenHeight Nullable(Int32),
+    screenWidth Nullable(Int32),
+    isPromotion UInt8,
+    date DateTime64(3)
+)
+ENGINE = MergeTree
+ORDER BY (sessionId, date);
+
+INSERT INTO Session (id, site, device) VALUES
+    ('s1', 'STORE_A', 'DESKTOP'),
+    ('s2', 'STORE_B', 'MOBILE');
+
+INSERT INTO AddedToCart (sessionId, order, top, screenHeight, screenWidth, isPromotion, date) VALUES
+    ('s1', 1, 100, 400, 1024, 1, parseDateTime64BestEffort('2026-01-19T12:00:00.000Z', 3)),
+    ('s2', 2, 100, 400, 1024, 1, parseDateTime64BestEffort('2026-01-19T12:00:01.000Z', 3));
+
+SELECT
+    s.site AS site,
+    if((a.order IS NULL) OR (a.order <= 0) OR (a.order > 30), NULL, accurateCastOrNull(a.order, 'Int32')) AS page_level,
+    count() AS count
+FROM AddedToCart AS a
+ANY LEFT JOIN Session AS s ON a.sessionId = s.id
+WHERE (a.top IS NOT NULL)
+  AND (a.screenHeight IS NOT NULL)
+  AND (a.screenHeight > 0)
+  AND (a.isPromotion = _CAST(1, 'UInt8'))
+  AND (s.device = 'DESKTOP')
+  AND isNotNull(s.site)
+GROUP BY site, page_level
+ORDER BY site ASC, page_level ASC
+FORMAT JSONEachRow;
+
+DROP TABLE AddedToCart;
+DROP TABLE Session;


### PR DESCRIPTION
### Changelog category (leave one):

- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):

Fix a crash during ANY LEFT JOIN optimization when `isNotNull` is evaluated on a missing column.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

---

I fixed the crash by changing `ActionsDAG::evaluatePartialResult` to avoid `node_to_column[child]` (which default-constructs a `ColumnWithTypeAndName` with `type == nullptr`), and instead use `find()` with a typed stub `{nullptr, child->result_type, child->result_name}` for missing children, so `isNotNull()` can safely fold constants without a null dereference.

This is a minimal, localized fix, it avoids the crash without redefining the broader "unknown argument" contract in partial evaluation, closes #94597


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.720`
- Backported to: `25.12.4.35`, `25.11.8.13`, `25.10.6.21`, `25.8.16.11`, `25.3.14.8`
<!-- ch-version-info:end -->