### PR TITLE
Fix TSan "unlock of an unlocked mutex" in CHECK TABLE in SMT

### DIFF
--- a/src/Core/BackgroundSchedulePool.cpp
+++ b/src/Core/BackgroundSchedulePool.cpp
@@ -114,11 +114,6 @@ bool BackgroundSchedulePoolTaskInfo::activateAndSchedule()
     return scheduleImpl(lock);
 }
 
-std::unique_lock<std::mutex> BackgroundSchedulePoolTaskInfo::getExecLock()
-{
-    return std::unique_lock{exec_mutex};
-}
-
 bool BackgroundSchedulePoolTaskInfo::execute(BackgroundSchedulePool & pool)
 {
     CurrentMetrics::Increment metric_increment(pool.tasks_metric);

--- a/src/Core/BackgroundSchedulePool.h
+++ b/src/Core/BackgroundSchedulePool.h
@@ -161,10 +161,6 @@ public:
     /// Return **permanent** watch callback needed for notifications from ZooKeeper watches.
     Coordination::WatchCallbackPtr getWatchCallback();
 
-    /// Returns lock that protects from concurrent task execution.
-    /// This lock should not be held for a long time.
-    std::unique_lock<std::mutex> getExecLock();
-
 private:
     friend class TaskNotification;
     friend class BackgroundSchedulePool;


### PR DESCRIPTION
Follow-up for: https://github.com/ClickHouse/ClickHouse/pull/94541 (cc @alexey-milovidov )

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.682`
<!-- ch-version-info:end -->