### PR TITLE
Fix 03702_alter_column_update_and_delete_with_secondary_index_rebuild flakiness

### DIFF
--- a/tests/queries/0_stateless/03702_alter_column_update_and_delete_with_secondary_index_rebuild.reference
+++ b/tests/queries/0_stateless/03702_alter_column_update_and_delete_with_secondary_index_rebuild.reference
@@ -8,7 +8,7 @@ CREATE TABLE test_table
     ENGINE = MergeTree()
     ORDER BY id
     PARTITION BY intDiv(id, 100)
-    SETTINGS alter_column_secondary_index_mode = 'rebuild', min_bytes_for_wide_part = 0, min_bytes_for_full_part_storage=0;
+    SETTINGS alter_column_secondary_index_mode = 'rebuild', index_granularity=8192, index_granularity_bytes='10M', min_bytes_for_wide_part = 0, min_bytes_for_full_part_storage=0;
 INSERT INTO test_table SELECT number, number FROM numbers(10);
 SYSTEM STOP MERGES test_table;
 SET alter_sync = 0, mutations_sync = 0;
@@ -339,7 +339,7 @@ CREATE TABLE test_table
     ENGINE = MergeTree()
     ORDER BY id
     PARTITION BY intDiv(id, 100)
-    SETTINGS alter_column_secondary_index_mode = 'rebuild', min_bytes_for_full_part_storage ='1G';
+    SETTINGS alter_column_secondary_index_mode = 'rebuild', index_granularity=8192, index_granularity_bytes='10M', min_bytes_for_full_part_storage ='1G';
 INSERT INTO test_table SELECT number, number FROM numbers(10);
 SYSTEM STOP MERGES test_table;
 SET alter_sync = 0, mutations_sync = 0;

--- a/tests/queries/0_stateless/03702_alter_column_update_and_delete_with_secondary_index_rebuild.sh
+++ b/tests/queries/0_stateless/03702_alter_column_update_and_delete_with_secondary_index_rebuild.sh
@@ -41,7 +41,7 @@ do
     ENGINE = MergeTree()
     ORDER BY id
     PARTITION BY intDiv(id, 100)
-    SETTINGS alter_column_secondary_index_mode = 'rebuild', ${part_type_setting};
+    SETTINGS alter_column_secondary_index_mode = 'rebuild', index_granularity=8192, index_granularity_bytes='10M', ${part_type_setting};
 
     INSERT INTO test_table SELECT number, number FROM numbers(10);
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix 03702_alter_column_update_and_delete_with_secondary_index_rebuild flakiness

Closes https://github.com/ClickHouse/ClickHouse/issues/94595
The changes in index granularity made plan changes around granules

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.685`
<!-- ch-version-info:end -->