### PR TITLE
Try to exchange docker pause/unpause to process SIGSTOP/SIGCONT in test_postgresql_replica_database_engine/test_1.py::test_abrupt_connection_loss_while_heavy_replication

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -4032,6 +4032,12 @@ class ClickHouseCluster:
     def _unpause_container(self, instance_name):
         subprocess_check_call(self.base_cmd + ["unpause", instance_name])
 
+    def _pause_container_using_signal(self, instance_name):
+        subprocess_check_call(self.base_cmd + ["kill", "--signal=SIGSTOP", instance_name])
+
+    def _unpause_container_using_signal(self, instance_name):
+        subprocess_check_call(self.base_cmd + ["kill", "--signal=SIGCONT", instance_name])
+
     @contextmanager
     def pause_container(self, instance_name):
         """Use it as following:
@@ -4043,6 +4049,14 @@ class ClickHouseCluster:
             yield
         finally:
             self._unpause_container(instance_name)
+
+    @contextmanager
+    def pause_container_using_signal(self, instance_name):
+        self._pause_container_using_signal(instance_name)
+        try:
+            yield
+        finally:
+            self._unpause_container_using_signal(instance_name)
 
     def open_bash_shell(self, instance_name):
         os.system(" ".join(self.base_cmd + ["exec", instance_name, "/bin/bash"]))

--- a/tests/integration/test_postgresql_replica_database_engine/test_1.py
+++ b/tests/integration/test_postgresql_replica_database_engine/test_1.py
@@ -307,7 +307,7 @@ def test_abrupt_connection_loss_while_heavy_replication(started_cluster):
     time.sleep(2)
 
 
-    with started_cluster.pause_container("postgres1"):
+    with started_cluster.pause_container_using_signal("postgres1"):
         # for i in range(NUM_TABLES):
         #     result = instance.query(f"SELECT count() FROM test_database.postgresql_replica_{i}")
         #     print(result) # Just debug


### PR DESCRIPTION
Resolves https://github.com/ClickHouse/ClickHouse/issues/93427.


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Currently we have some obscure and rare error happening while running test `test_postgresql_replica_database_engine/test_1.py::test_abrupt_connection_loss_while_heavy_replication`:

```
time="2026-01-04T18:46:47.871357550Z" level=debug msg="Calling POST /v1.46/containers/71afd8f5158af39024bc34d6ed15ae4eef73a72c73a743397f735635397e18ae/pause"
time="2026-01-04T18:46:48.228050112Z" level=debug msg="FIXME: Got an API for which error does not match any expected type!!!" error="cannot pause container 71afd8f5158af39024bc34d6ed15ae4eef73a72c73a743397f735635397e18ae: OCI runtime pause failed: unable to freeze: unknown" error_type="*errors.errorString" module=api
time="2026-01-04T18:46:48.228084337Z" level=error msg="Handler for POST /v1.46/containers/71afd8f5158af39024bc34d6ed15ae4eef73a72c73a743397f735635397e18ae/pause returned error: cannot pause container 71afd8f5158af39024bc34d6ed15ae4eef73a72c73a743397f735635397e18ae: OCI runtime pause failed: unable to freeze: unknown"
```

The error is due to inability to pause docket container. The logs show that this is a docker problem. 

Since the goal of pausing docker container in the tests is to simulate abruptly broken connection, I exchanged `pause`/ `unpause` with sending `SIGSTOP`/`SIGCONT` to the container's process to simulate similar behavior.   

PR to solution of a similar problem: https://github.com/ClickHouse/ClickHouse/pull/66760

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.692`
<!-- ch-version-info:end -->