### PR TITLE
fix segfault in DeltaLakeMetadata::getFieldValue

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.cpp
@@ -745,7 +745,7 @@ Field DeltaLakeMetadata::getFieldValue(const String & value, DataTypePtr data_ty
     {
         ReadBufferFromString in(value);
         DateTime64 time = 0;
-        readDateTime64Text(time, 6, in, assert_cast<const DataTypeDateTime64 *>(data_type.get())->getTimeZone());
+        readDateTime64Text(time, 6, in, assert_cast<const DataTypeDateTime64 *>(check_type.get())->getTimeZone());
         return time;
     }
 

--- a/src/Storages/tests/gtest_delta_kernel.cpp
+++ b/src/Storages/tests/gtest_delta_kernel.cpp
@@ -70,3 +70,19 @@ TEST_F(DeltaKernelTest, ExpressionVisitor)
 }
 
 #endif
+
+#if USE_PARQUET
+
+#include <Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.h>
+#include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypeDateTime64.h>
+#include <Core/Field.h>
+
+/// Regression test for segfault
+TEST(DeltaLakeMetadata, GetFieldValueNullableDateTime64)
+{
+    auto nullable_datetime64_type = std::make_shared<DB::DataTypeNullable>(std::make_shared<DB::DataTypeDateTime64>(6, "UTC"));
+    ASSERT_NO_THROW(DB::DeltaLakeMetadata::getFieldValue("2024-01-15 10:30:45.123456", nullable_datetime64_type));
+}
+
+#endif

--- a/src/Storages/tests/gtest_delta_kernel.cpp
+++ b/src/Storages/tests/gtest_delta_kernel.cpp
@@ -1,9 +1,10 @@
 #include "config.h"
 
+#include <gtest/gtest.h>
+
 #if USE_DELTA_KERNEL_RS
 
 #include <base/scope_guard.h>
-#include <gtest/gtest.h>
 #include <Common/tests/gtest_global_context.h>
 #include <Common/tests/gtest_global_register.h>
 #include <Common/logger_useful.h>


### PR DESCRIPTION
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixes https://github.com/ClickHouse/clickhouse-core-incidents/issues/1250. Likely due to a mix-up, `data_type` (which may be `DataTypeNullable*`) is `static_cast`-ed to `DataTypeDateTime64*`. Instead, we should cast `check_type` (the nested type variable).



### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.755`
- Backported to: `25.12.5.8`, `25.11.8.7`, `25.10.6.11`, `25.8.16.5`
<!-- ch-version-info:end -->