### PR TITLE
ci: fix pattern for flaky check to run only modified tests

### DIFF
--- a/ci/jobs/scripts/find_tests.py
+++ b/ci/jobs/scripts/find_tests.py
@@ -2,6 +2,7 @@ import argparse
 import ast
 import os
 import re
+import shlex
 import sys
 from pathlib import Path
 
@@ -83,7 +84,7 @@ class Targeting:
                 fname_without_ext = os.path.splitext(fname)[0]
 
                 # Add '.' suffix to precisely match this test only
-                result.add(f"{fname_without_ext}.")
+                result.add(shlex.quote(f"{fname_without_ext}\."))
 
             elif fpath.startswith("tests/queries/"):
                 # Log any other changed file under tests/queries for future debugging


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Details
An unescaped dot in the end of changed tests being run by `clickhouse-test`, make it to treat test names as a prefixes (which was not intended according to the comment), which results in running unmodified tests in flaky check job.

<details>
<summary>Example</summary>

https://s3.amazonaws.com/clickhouse-test-reports/PRs/93882/2684f3cce9d1721bf7e23f62a264f1c4e6f81bdb//stateless_tests_amd_asan_flaky_check/job.log

The test `03008_s3_plain_rewritable_fault` hasn't been changed, not in the list of tests to run, but still running
```
[2026-01-19 07:43:32] Test list: [['03008_azure_plain_rewritable.', '03008_azure_plain_rewritable_with_slash.', '03008_local_plain_rewritable.', '03008_s3_plain_rewritable.', '03787_alter_s3_plain_rewritable.', '03787_alter_s3_plain_rewritable_read_write.', '03788_alter_table_with_custom_disk.']]
...
[2026-01-19 09:54:33] 2026-01-19 18:54:33 03008_s3_plain_rewritable_fault:                                        [ OK ] 30.89 sec.
[2026-01-19 09:55:04] 2026-01-19 18:55:04 03008_s3_plain_rewritable_fault:                                        [ OK ] 31.44 sec.
[2026-01-19 09:55:33] 2026-01-19 18:55:33 03008_s3_plain_rewritable_fault:                                        [ OK ] 28.13 sec.
[2026-01-19 09:56:01] 2026-01-19 18:56:01 03008_s3_plain_rewritable_fault:                                        [ OK ] 27.95 sec.
[2026-01-19 09:56:31] 2026-01-19 18:56:31 03008_s3_plain_rewritable_fault:                                        [ OK ] 30.00 sec.
[2026-01-19 09:56:58] 2026-01-19 18:56:58 03008_s3_plain_rewritable_fault:                                        [ OK ] 26.62 sec.
[2026-01-19 09:57:26] 2026-01-19 18:57:26 03008_s3_plain_rewritable_fault:                                        [ OK ] 28.38 sec.
```
</details>