### PR TITLE
Save updated access entity after name collision check

### DIFF
--- a/src/Access/MemoryAccessStorage.cpp
+++ b/src/Access/MemoryAccessStorage.cpp
@@ -215,15 +215,19 @@ bool MemoryAccessStorage::updateNoLock(const UUID & id, const UpdateFunc & updat
     if (*new_entity == *old_entity)
         return true;
 
+    auto & entries_by_name = entries_by_name_and_type[static_cast<size_t>(old_entity->getType())];
+
+    bool name_changed = (new_entity->getName() != old_entity->getName());
+    if (name_changed)
+    {
+        if (entries_by_name.contains(new_entity->getName()))
+            throwNameCollisionCannotRename(old_entity->getType(), old_entity->getName(), new_entity->getName(), getStorageName());
+    }
+
     entry.entity = new_entity;
 
-    if (new_entity->getName() != old_entity->getName())
+    if (name_changed)
     {
-        auto & entries_by_name = entries_by_name_and_type[static_cast<size_t>(old_entity->getType())];
-        auto it2 = entries_by_name.find(new_entity->getName());
-        if (it2 != entries_by_name.end())
-            throwNameCollisionCannotRename(old_entity->getType(), old_entity->getName(), new_entity->getName(), getStorageName());
-
         entries_by_name.erase(old_entity->getName());
         entries_by_name[new_entity->getName()] = &entry;
     }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

Fixes https://github.com/ClickHouse/ClickHouse/issues/90320


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.787`
<!-- ch-version-info:end -->