### PR TITLE
Skip nullptr check for TCP connection

### DIFF
--- a/base/poco/Net/src/TCPServerDispatcher.cpp
+++ b/base/poco/Net/src/TCPServerDispatcher.cpp
@@ -111,8 +111,8 @@ void TCPServerDispatcher::run()
                     if (!_stopped)
                     {
                         std::unique_ptr<TCPServerConnection> pConnection(_pConnectionFactory->createConnection(pCNf->socket()));
-                        poco_check_ptr(pConnection.get());
-                        pConnection->start();
+                        if (pConnection)
+                            pConnection->start();
                     }
                     /// endConnection() should be called after destroying TCPServerConnection,
                     /// otherwise currentConnections() could become zero while some connections are yet still alive.


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

After this change https://github.com/ClickHouse/ClickHouse/pull/94496/changes#diff-4132daa7d11054405c5838789e2d40d96ea6812e4cb7028dd3f75d6e22f109f9R32 `TCPServerConnectionFactory` can return `nullptr`.

cc @alexey-milovidov 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.714`
<!-- ch-version-info:end -->