### PR TITLE
Improve build time of setting classes

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -2068,7 +2068,7 @@ try
     std::optional<CgroupsMemoryUsageObserver> cgroups_memory_usage_observer;
     try
     {
-        auto wait_time = server_settings[ServerSetting::cgroups_memory_usage_observer_wait_time];
+        const auto & wait_time = server_settings[ServerSetting::cgroups_memory_usage_observer_wait_time];
         if (wait_time != 0)
             cgroups_memory_usage_observer.emplace(std::chrono::seconds(wait_time));
     }
@@ -2272,27 +2272,27 @@ try
             /// This is done for backward compatibility.
             if (global_context->areBackgroundExecutorsInitialized())
             {
-                auto new_pool_size = new_server_settings[ServerSetting::background_pool_size];
-                auto new_ratio = new_server_settings[ServerSetting::background_merges_mutations_concurrency_ratio];
+                const auto & new_pool_size = new_server_settings[ServerSetting::background_pool_size];
+                const auto & new_ratio = new_server_settings[ServerSetting::background_merges_mutations_concurrency_ratio];
                 global_context->getMergeMutateExecutor()->increaseThreadsAndMaxTasksCount(new_pool_size, static_cast<size_t>(new_pool_size * new_ratio));
                 global_context->getMergeMutateExecutor()->updateSchedulingPolicy(new_server_settings[ServerSetting::background_merges_mutations_scheduling_policy].toString());
             }
 
             if (global_context->areBackgroundExecutorsInitialized())
             {
-                auto new_pool_size = new_server_settings[ServerSetting::background_move_pool_size];
+                const auto & new_pool_size = new_server_settings[ServerSetting::background_move_pool_size];
                 global_context->getMovesExecutor()->increaseThreadsAndMaxTasksCount(new_pool_size, new_pool_size);
             }
 
             if (global_context->areBackgroundExecutorsInitialized())
             {
-                auto new_pool_size = new_server_settings[ServerSetting::background_fetches_pool_size];
+                const auto & new_pool_size = new_server_settings[ServerSetting::background_fetches_pool_size];
                 global_context->getFetchesExecutor()->increaseThreadsAndMaxTasksCount(new_pool_size, new_pool_size);
             }
 
             if (global_context->areBackgroundExecutorsInitialized())
             {
-                auto new_pool_size = new_server_settings[ServerSetting::background_common_pool_size];
+                const auto & new_pool_size = new_server_settings[ServerSetting::background_common_pool_size];
                 global_context->getCommonExecutor()->increaseThreadsAndMaxTasksCount(new_pool_size, new_pool_size);
             }
 

--- a/src/Core/BaseSettings.h
+++ b/src/Core/BaseSettings.h
@@ -23,40 +23,69 @@ namespace DB
 class ReadBuffer;
 class WriteBuffer;
 
+/// Utility functions and types used by the BaseSettings template class.
+/// These are implementation details that handle serialization, error reporting,
+/// and metadata management for settings.
 struct BaseSettingsHelpers
 {
+    /// Error handling
     [[noreturn]] static void throwSettingNotFound(std::string_view name);
     static void warningSettingNotFound(std::string_view name);
     static void flushWarnings();
 
+    /// Serialization helpers
     static void writeString(std::string_view str, WriteBuffer & out);
     static String readString(ReadBuffer & in);
 
+    /// Setting metadata flags
     enum Flags : UInt64
     {
-        IMPORTANT = 0x01,
-        CUSTOM = 0x02,
-        TIER = 0x0c, /// 0b1100 == 2 bits
+        IMPORTANT = 0x01,  /// Setting affects query results, cannot be ignored by older versions
+        CUSTOM = 0x02,     /// User-defined custom setting
+        TIER = 0x0c,       /// 0b1100 == 2 bits for tier level (PRODUCTION/BETA/EXPERIMENTAL)
         /// If adding new flags, consider first if Tier might need more bits
     };
 
     static SettingsTierType getTier(UInt64 flags);
     static void writeFlags(Flags flags, WriteBuffer & out);
     static UInt64 readFlags(ReadBuffer & in);
+
 private:
     /// For logging the summary of unknown settings instead of logging each one separately.
     inline static thread_local Strings unknown_settings;
     inline static thread_local bool unknown_settings_warning_logged = false;
-
 };
 
-/** Template class to define collections of settings.
-  * If you create a new setting, please also add it to ./utils/check-style/check-settings-style
-  * for validation
+/** Template class to define collections of settings with compile-time metadata.
   *
-  * Example of usage:
+  * OVERVIEW:
+  * This template provides a type-safe, compile-time-checked settings system.
+  * Settings are defined via macros that generate metadata and accessor functions.
+  *
+  * DESIGN RATIONALE:
+  * - Type safety: Each setting has a specific type (UInt64, Bool, String, etc.)
+  * - Performance: No runtime lookups for direct member access
+  * - Metadata: Descriptions, default values, and flags are compile-time constants
+  * - Serialization: Built-in support for reading/writing settings
+  *
+  * USAGE EXAMPLE:
+  * See the detailed example in the comments below.
+  *
+  * WORKFLOW:
+  * 1. Define your settings list with DECLARE() macros in a .cpp file
+  * 2. Use DECLARE_SETTINGS_TRAITS() to generate the trait struct
+  * 3. Use IMPLEMENT_SETTINGS_TRAITS() to implement the accessor
+  * 4. Derive your SettingsImpl from BaseSettings<YourTraits>
+  * 5. Use IMPLEMENT_SETTING_SUBSCRIPT_OPERATOR to enable settings.member syntax
+  *
+  * VALIDATION:
+  * If you create a new setting, please also add it to:
+  * ./utils/check-style/check-settings-style for validation
+  *
+  * DETAILED EXAMPLE:
   *
   * mysettings.h:
+  * -------------
   * #include <Core/BaseSettingsFwdMacros.h>
   * #include <Core/SettingsFields.h>
   *
@@ -78,14 +107,15 @@ private:
   * };
   *
   * mysettings.cpp:
+  * ---------------
   * #include <Core/BaseSettings.h>
   * #include <Core/BaseSettingsFwdMacrosImpl.h>
   *
   * #define APPLY_FOR_MYSETTINGS(DECLARE, DECLARE_WITH_ALIAS) \
   *     DECLARE(UInt64, a, 100, "Description of a", 0) \
-  *     DECLARE(Float, f, 3.11, "Description of f", IMPORTANT) // IMPORTANT - means the setting can't be ignored by older versions) \
-  *     DECLARE(String, s, "default", "Description of s", 0)
-  *     DECLARE_WITH_ALIAS(String, experimental, "default", "Description of s", 0, stable)
+  *     DECLARE(Float, f, 3.11, "Description of f", IMPORTANT) \
+  *     DECLARE(String, s, "default", "Description of s", 0) \
+  *     DECLARE_WITH_ALIAS(String, experimental, "default", "Description", 0, stable)
   *
   * DECLARE_SETTINGS_TRAITS(MySettingsTraits, APPLY_FOR_MYSETTINGS)
   * IMPLEMENT_SETTINGS_TRAITS(MySettingsTraits, APPLY_FOR_MYSETTINGS)
@@ -94,11 +124,12 @@ private:
   * {
   * };
   *
-  * #define INITIALIZE_SETTING_EXTERN(TYPE, NAME, DEFAULT, DESCRIPTION, FLAGS) MySettings##TYPE NAME = &MySettings##Impl ::NAME;
+  * #define INITIALIZE_SETTING_EXTERN(TYPE, NAME, DEFAULT, DESCRIPTION, FLAGS) \
+  *     MySettings##TYPE NAME = &MySettingsImpl::NAME;
   *
   * namespace MySetting
   * {
-  * APPLY_FOR_MYSETTINGS(INITIALIZE_SETTING_EXTERN, SETTING_SKIP_TRAIT)
+  *     APPLY_FOR_MYSETTINGS(INITIALIZE_SETTING_EXTERN, SETTING_SKIP_TRAIT)
   * }
   * #undef INITIALIZE_SETTING_EXTERN
   *
@@ -107,6 +138,7 @@ private:
 template <class TTraits>
 class BaseSettings : public TTraits::Data
 {
+    /// Hash function for efficient string lookups in custom settings map
     struct StringHash
     {
         using is_transparent = void;
@@ -124,28 +156,54 @@ public:
 
     using Traits = TTraits;
 
+    /// Set a setting by name
     virtual void set(std::string_view name, const Field & value);
+
+    /// Get the value of a setting
     Field get(std::string_view name) const;
 
+    /// Try to get a setting value; returns false if setting doesn't exist
     bool tryGet(std::string_view name, Field & value) const;
 
+    /// Check if a setting has been changed from its default value
     bool isChanged(std::string_view name) const;
+
+    /// Get all changed settings as a SettingsChanges struct
     SettingsChanges changes() const;
+
+    /// Apply a single setting change
     void applyChange(const SettingChange & change);
+
+    /// Apply multiple setting changes
     void applyChanges(const SettingsChanges & changes);
 
-    /// Resets all the settings to their default values.
+    /// Resets all the settings to their default values
     void resetToDefault();
-    /// Resets specified setting to its default value.
+
+    /// Resets specified setting to its default value
     void resetToDefault(std::string_view name);
 
+    /// Check if a setting exists (either built-in or custom)
     bool has(std::string_view name) const { return hasBuiltin(name) || hasCustom(name); }
+
+    /// Check if a built-in setting exists (excludes custom settings)
     static bool hasBuiltin(std::string_view name);
+
+    /// Check if a custom setting exists
     bool hasCustom(std::string_view name) const;
 
+    /// Get the type name of a setting (e.g., "UInt64", "String")
     const char * getTypeName(std::string_view name) const;
+
+    /// Get the description of a setting
     const char * getDescription(std::string_view name) const;
+
+    /// Get the tier (PRODUCTION/BETA/EXPERIMENTAL) of a setting
     SettingsTierType getTier(std::string_view name) const;
+
+    // ========================================================================
+    // VALIDATION & CONVERSION (static utilities)
+    // ========================================================================
 
     /// Checks if it's possible to assign a field to a specified value and throws an exception if not.
     /// This function doesn't change the fields, it performs check only.
@@ -156,13 +214,19 @@ public:
     static String valueToStringUtil(std::string_view name, const Field & value);
     static Field stringToValueUtil(std::string_view name, const String & str);
 
+    /// Write all settings (or only changed ones depending on format)
     void write(WriteBuffer & out, SettingsWriteFormat format = SettingsWriteFormat::DEFAULT) const;
+
+    /// Read settings from a buffer
     void read(ReadBuffer & in, SettingsWriteFormat format = SettingsWriteFormat::DEFAULT);
 
+    /// Write only changed settings in binary format
     void writeChangedBinary(WriteBuffer & out) const;
+
+    /// Read settings in binary format
     void readBinary(ReadBuffer & in);
 
-    // A debugging aid.
+    /// Convert all settings to a human-readable string (for debugging)
     std::string toString() const;
 
     /// Represents a reference to a setting field.
@@ -898,47 +962,111 @@ SettingsTierType BaseSettings<TTraits>::SettingFieldRef::getTier() const
     return accessor->getTier(index);
 }
 
+// ============================================================================
+// MACRO SYSTEM FOR DEFINING SETTINGS TRAITS
+// ============================================================================
+
+/** MACRO OVERVIEW:
+  *
+  * The macros below generate the "Traits" struct that describes a collection of settings.
+  * The Traits struct contains:
+  * - Data: A struct with actual SettingField members for each setting
+  * - Accessor: A singleton class providing runtime reflection/metadata
+  *
+  * MACRO HIERARCHY:
+  * - DECLARE_SETTINGS_TRAITS*: Public entry points, forward to DECLARE_SETTINGS_TRAITS_COMMON
+  * - DECLARE_SETTINGS_TRAITS_COMMON: Generates the Traits struct declaration
+  * - IMPLEMENT_SETTINGS_TRAITS*: Public entry points, forward to IMPLEMENT_SETTINGS_TRAITS_COMMON
+  * - IMPLEMENT_SETTINGS_TRAITS_COMMON: Implements the Accessor singleton
+  * - Helper macros: DECLARE_SETTINGS_TRAITS_, IMPLEMENT_SETTINGS_TRAITS_, etc.
+  *
+  * The complexity here is necessary to support:
+  * - Compile-time type safety
+  * - Runtime reflection (name -> value lookups)
+  * - Efficient direct member access (no hash lookups for known settings)
+  * - Custom user-defined settings (optional)
+  * - Setting aliases
+  */
+
 using AliasMap = std::unordered_map<std::string_view, std::string_view>;
 
+/// Generate traits for a basic settings collection (no custom settings, no paths)
 /// NOLINTNEXTLINE
 #define DECLARE_SETTINGS_TRAITS(SETTINGS_TRAITS_NAME, LIST_OF_SETTINGS_MACRO) \
     DECLARE_SETTINGS_TRAITS_COMMON(SETTINGS_TRAITS_NAME, LIST_OF_SETTINGS_MACRO, SETTING_SKIP_TRAIT, 0)
 
+/// Generate traits with support for custom (user-defined) settings
 /// NOLINTNEXTLINE
 #define DECLARE_SETTINGS_TRAITS_ALLOW_CUSTOM_SETTINGS(SETTINGS_TRAITS_NAME, LIST_OF_SETTINGS_MACRO) \
     DECLARE_SETTINGS_TRAITS_COMMON(SETTINGS_TRAITS_NAME, LIST_OF_SETTINGS_MACRO, SETTING_SKIP_TRAIT, 1)
 
+/// Generate traits with support for settings that have config file paths
 /// NOLINTNEXTLINE
 #define DECLARE_SETTINGS_TRAITS_WITH_PATH(SETTINGS_TRAITS_NAME, LIST_OF_SETTINGS_WITHOUT_PATH_MACRO, LIST_OF_SETTINGS_WITH_PATH_MACRO) \
     DECLARE_SETTINGS_TRAITS_COMMON(SETTINGS_TRAITS_NAME, LIST_OF_SETTINGS_WITHOUT_PATH_MACRO, LIST_OF_SETTINGS_WITH_PATH_MACRO, 0)
 
+/// Generate traits with both custom settings and path support
 /// NOLINTNEXTLINE
 #define DECLARE_SETTINGS_TRAITS_WITH_PATH_ALLOW_CUSTOM_SETTINGS(SETTINGS_TRAITS_NAME, LIST_OF_SETTINGS_WITHOUT_PATH_MACRO, LIST_OF_SETTINGS_WITH_PATH_MACRO) \
     DECLARE_SETTINGS_TRAITS_COMMON(SETTINGS_TRAITS_NAME, LIST_OF_SETTINGS_WITHOUT_PATH_MACRO, LIST_OF_SETTINGS_WITH_PATH_MACRO, 1)
 
+
+// ----------------------------------------------------------------------------
+// DECLARE_SETTINGS_TRAITS_COMMON - The actual implementation
+// ----------------------------------------------------------------------------
+
+/** This macro generates a complete Traits struct with two main components:
+  *
+  * 1. Data struct: Contains actual SettingFieldXXX members for each setting
+  *    - Generated from LIST_OF_SETTINGS macros
+  *    - Provides compile-time type-safe member access
+  *
+  * 2. Accessor class: Provides runtime reflection capabilities
+  *    - Maps setting names to indices
+  *    - Provides generic get/set via Field interface
+  *    - Stores metadata (description, type, default value, flags)
+  *    - Singleton pattern for efficiency
+  *
+  * PARAMETERS:
+  * - SETTINGS_TRAITS_NAME: Name of the generated traits struct
+  * - LIST_OF_SETTINGS_WITHOUT_PATH_MACRO: Macro that expands to DECLARE() calls
+  * - LIST_OF_SETTINGS_WITH_PATH_MACRO: Macro for settings with config paths
+  * - ALLOW_CUSTOM_SETTINGS: 0 or 1, enables user-defined settings
+  */
 /// NOLINTNEXTLINE
 #define DECLARE_SETTINGS_TRAITS_COMMON( \
     SETTINGS_TRAITS_NAME, LIST_OF_SETTINGS_WITHOUT_PATH_MACRO, LIST_OF_SETTINGS_WITH_PATH_MACRO, ALLOW_CUSTOM_SETTINGS) \
     struct SETTINGS_TRAITS_NAME \
     { \
+        /** Data struct: Contains one SettingFieldXXX member per setting */ \
         struct Data \
         { \
             LIST_OF_SETTINGS_WITHOUT_PATH_MACRO(DECLARE_SETTINGS_TRAITS_, DECLARE_SETTINGS_TRAITS_) \
             LIST_OF_SETTINGS_WITH_PATH_MACRO(DECLARE_SETTINGS_TRAITS_, DECLARE_SETTINGS_TRAITS_) \
         }; \
         \
+        /** Accessor: Provides runtime reflection and metadata access */ \
         class Accessor \
         { \
         public: \
+            /** Get the singleton instance (initialized once at first access) */ \
             static const Accessor & instance(); \
+            \
+            /** Get total number of settings */ \
             size_t size() const { return field_infos.size(); } \
+            \
+            /** Find setting index by name. Returns -1 if not found. */ \
             size_t find(std::string_view name) const; \
+            \
+            /* Metadata accessors (by index) */ \
             const String & getName(size_t index) const { return field_infos[index].name; } \
             const char * getPath(size_t index) const { return field_infos[index].path; } \
             const char * getTypeName(size_t index) const { return field_infos[index].type; } \
             const char * getDescription(size_t index) const { return field_infos[index].description; } \
             bool isImportant(size_t index) const { return field_infos[index].flags & BaseSettingsHelpers::Flags::IMPORTANT; } \
             SettingsTierType getTier(size_t index) const { return BaseSettingsHelpers::getTier(field_infos[index].flags); } \
+            \
+            /* Value conversion utilities */ \
             Field castValueUtil(size_t index, const Field & value) const \
             { \
                 auto p = field_infos[index].create_default_function(); \
@@ -957,6 +1085,8 @@ using AliasMap = std::unordered_map<std::string_view, std::string_view>;
                 p->parseFromString(str); \
                 return static_cast<Field>(*p); \
             } \
+            \
+            /* Direct data access (by index) */ \
             void setValue(Data & data, size_t index, const Field & value) const \
             { \
                 field_infos[index].get_data_function(data)->operator=(value); \
@@ -983,6 +1113,8 @@ using AliasMap = std::unordered_map<std::string_view, std::string_view>;
                 field_infos[index].get_data_function(*const_cast<Data *>(&data))->operator=(static_cast<Field>(*p)); \
                 field_infos[index].get_data_function(*const_cast<Data *>(&data))->setChanged(false); \
             } \
+            \
+            /* Binary serialization (by index) */ \
             void writeBinary(const Data & data, size_t index, WriteBuffer & out) const \
             { \
                 field_infos[index].get_data_function(*const_cast<Data *>(&data))->writeBinary(out); \
@@ -991,10 +1123,14 @@ using AliasMap = std::unordered_map<std::string_view, std::string_view>;
             { \
                 field_infos[index].get_data_function(data)->readBinary(in); \
             } \
+            \
+            /* Default value as string */ \
             String getDefaultValueString(size_t index) const { return field_infos[index].create_default_function()->toString(); } \
         \
         private: \
             Accessor(); \
+            \
+            /** Metadata for one setting */ \
             struct FieldInfo \
             { \
                 String name; \
@@ -1002,16 +1138,23 @@ using AliasMap = std::unordered_map<std::string_view, std::string_view>;
                 const char * const type; \
                 const char * const description; \
                 const UInt64 flags; \
-                SettingFieldBase * (*get_data_function)(Data &); \
-                std::unique_ptr<SettingFieldBase> (*create_default_function)(); \
+                SettingFieldBase * (*get_data_function)(Data &);                    /* Get pointer to setting in Data struct */ \
+                std::unique_ptr<SettingFieldBase> (*create_default_function)();     /* Create setting with default value */ \
             }; \
-            std::vector<FieldInfo> field_infos; \
-            std::unordered_map<std::string_view, size_t> name_to_index_map; \
+            \
+            std::vector<FieldInfo> field_infos;                                     /* Metadata for all settings */ \
+            std::unordered_map<std::string_view, size_t> name_to_index_map;         /* Fast name -> index lookup */ \
         }; \
+        \
+        /** Whether this traits allows custom settings */ \
         static constexpr bool allow_custom_settings = ALLOW_CUSTOM_SETTINGS; \
+        \
+        /** Map of aliases to actual setting names */ \
         static inline const AliasMap aliases_to_settings \
             = {LIST_OF_SETTINGS_WITHOUT_PATH_MACRO(SETTING_SKIP_TRAIT, DECLARE_SETTINGS_WITH_ALIAS_TRAITS_) \
                    LIST_OF_SETTINGS_WITH_PATH_MACRO(SETTING_SKIP_TRAIT, DECLARE_SETTINGS_WITH_ALIAS_TRAITS_)}; \
+        \
+        /** Reverse map: setting name -> list of aliases */ \
         using SettingsToAliasesMap = std::unordered_map<std::string_view, std::vector<std::string_view>>; \
         static inline const SettingsToAliasesMap & settingsToAliases() \
         { \
@@ -1024,6 +1167,8 @@ using AliasMap = std::unordered_map<std::string_view, std::string_view>;
             }(); \
             return setting_to_aliases_mapping; \
         } \
+        \
+        /** Resolve alias to actual setting name */ \
         static std::string_view resolveName(std::string_view name) \
         { \
             if (auto it = aliases_to_settings.find(name); it != aliases_to_settings.end()) \
@@ -1032,35 +1177,54 @@ using AliasMap = std::unordered_map<std::string_view, std::string_view>;
         } \
     };
 
+
+/// Skip this setting in the macro expansion (used for selective application)
 /// NOLINTNEXTLINE
 #define SETTING_SKIP_TRAIT(...)
 
+/// Generates a Data member
 /// NOLINTNEXTLINE
 #define DECLARE_SETTINGS_TRAITS_(TYPE, NAME, DEFAULT, DESCRIPTION, FLAGS, ...) \
     SettingField##TYPE NAME {DEFAULT};
+
+/// Generates an alias mapping entry
 /// NOLINTNEXTLINE
 #define DECLARE_SETTINGS_WITH_ALIAS_TRAITS_(TYPE, NAME, DEFAULT, DESCRIPTION, FLAGS, ALIAS) \
     { #ALIAS, #NAME },
-/// NOLINTNEXTLINE
 
+/// Implement the Accessor singleton for basic settings
 /// NOLINTNEXTLINE
 #define IMPLEMENT_SETTINGS_TRAITS(SETTINGS_TRAITS_NAME, LIST_OF_SETTINGS_MACRO) \
     IMPLEMENT_SETTINGS_TRAITS_COMMON(SETTINGS_TRAITS_NAME, LIST_OF_SETTINGS_MACRO, SETTING_SKIP_TRAIT)
 
+/// Implement the Accessor singleton for settings with paths
 /// NOLINTNEXTLINE
 #define IMPLEMENT_SETTINGS_TRAITS_WITH_PATH(SETTINGS_TRAITS_NAME, LIST_OF_SETTINGS_WITHOUT_PATH_MACRO, LIST_OF_SETTINGS_WITH_PATH_MACRO) \
     IMPLEMENT_SETTINGS_TRAITS_COMMON(SETTINGS_TRAITS_NAME, LIST_OF_SETTINGS_WITHOUT_PATH_MACRO, LIST_OF_SETTINGS_WITH_PATH_MACRO)
 
+
+/** This macro implements:
+  * 1. Accessor::instance() - Singleton accessor, initialized lazily on first access
+  * 2. Accessor::Accessor() - Private constructor
+  * 3. Accessor::find() - Name lookup function
+  * 4. Explicit template instantiation of BaseSettings<SETTINGS_TRAITS_NAME>
+  *
+  * The instance() method builds the field_infos vector with metadata for each setting.
+  * This is the "expensive" part that creates all the lambda functions at compile time.
+  */
     /// NOLINTNEXTLINE
 #define IMPLEMENT_SETTINGS_TRAITS_COMMON(SETTINGS_TRAITS_NAME, LIST_OF_SETTINGS_WITHOUT_PATH_MACRO, LIST_OF_SETTINGS_WITH_PATH_MACRO) \
     const SETTINGS_TRAITS_NAME::Accessor & SETTINGS_TRAITS_NAME::Accessor::instance() \
     { \
+        /* Singleton pattern: initialize once, return same instance */ \
         static const Accessor the_instance = [] \
         { \
             [[maybe_unused]] constexpr int IMPORTANT = 0x01; \
             Accessor res; \
+            /* Populate field_infos with one entry per setting */ \
             LIST_OF_SETTINGS_WITHOUT_PATH_MACRO(IMPLEMENT_SETTINGS_TRAITS_, IMPLEMENT_SETTINGS_TRAITS_) \
             LIST_OF_SETTINGS_WITH_PATH_MACRO(IMPLEMENT_SETTINGS_TRAITS_WITH_PATH_, IMPLEMENT_SETTINGS_TRAITS_WITH_PATH_) \
+            /* Build name -> index map for fast lookups */ \
             for (size_t i = 0, size = res.field_infos.size(); i < size; ++i) \
             { \
                 const auto & info = res.field_infos[i]; \
@@ -1080,22 +1244,36 @@ using AliasMap = std::unordered_map<std::string_view, std::string_view>;
             return it->second; \
         return static_cast<size_t>(-1); \
     } \
-    \
-    template class BaseSettings<SETTINGS_TRAITS_NAME>;
 
+
+/// Generate a FieldInfo entry for a setting without a config path.
+/// Creates two lambdas:
+/// 1. get_data_function: Returns pointer to the setting field in a Data struct
+/// 2. create_default_function: Creates a new setting field with default value
 /// NOLINTNEXTLINE
 #define IMPLEMENT_SETTINGS_TRAITS_(TYPE, NAME, DEFAULT, DESCRIPTION, FLAGS, ...) \
     res.field_infos.emplace_back( \
-        FieldInfo{#NAME, "", #TYPE, DESCRIPTION, \
+        FieldInfo\
+        { \
+            #NAME, \
+            "", \
+            #TYPE, \
+            DESCRIPTION, \
             static_cast<UInt64>(FLAGS), \
             [](Data & data) -> SettingFieldBase * { return &data.NAME; }, \
             []() -> std::unique_ptr<SettingFieldBase> { return std::make_unique<SettingField##TYPE>(DEFAULT); }, \
         });
 
+/// Generate a FieldInfo entry for a setting with a config file path
 /// NOLINTNEXTLINE
 #define IMPLEMENT_SETTINGS_TRAITS_WITH_PATH_(TYPE, NAME, DEFAULT, DESCRIPTION, FLAGS, PATH, ...) \
     res.field_infos.emplace_back( \
-        FieldInfo{#NAME, PATH, #TYPE, DESCRIPTION, \
+        FieldInfo\
+        { \
+            #NAME, \
+            PATH, \
+            #TYPE, \
+            DESCRIPTION, \
             static_cast<UInt64>(FLAGS), \
             [](Data & data) -> SettingFieldBase * { return &data.NAME; }, \
             []() -> std::unique_ptr<SettingFieldBase> { return std::make_unique<SettingField##TYPE>(DEFAULT); }, \

--- a/src/Core/BaseSettingsProgramOptions.h
+++ b/src/Core/BaseSettingsProgramOptions.h
@@ -21,7 +21,7 @@ void addProgramOptionAsMultitoken(T &cmd_settings, boost::program_options::optio
                     ->composing()
                     ->implicit_value(std::vector<std::string>{"1"}, "1")
                     ->notifier(on_program_option),
-                field.getDescription().data())));
+                field.getDescription().data()))); /// NOLINT(bugprone-suspicious-stringview-data-usage)
     }
     else
     {
@@ -29,7 +29,7 @@ void addProgramOptionAsMultitoken(T &cmd_settings, boost::program_options::optio
             boost::shared_ptr<boost::program_options::option_description>(new boost::program_options::option_description(
                 name.data(), /// NOLINT(bugprone-suspicious-stringview-data-usage)
                 boost::program_options::value<Strings>()->multitoken()->composing()->notifier(on_program_option),
-                field.getDescription().data())));
+                field.getDescription().data()))); /// NOLINT(bugprone-suspicious-stringview-data-usage)
     }
 }
 

--- a/src/Core/BaseSettingsProgramOptions.h
+++ b/src/Core/BaseSettingsProgramOptions.h
@@ -21,7 +21,7 @@ void addProgramOptionAsMultitoken(T &cmd_settings, boost::program_options::optio
                     ->composing()
                     ->implicit_value(std::vector<std::string>{"1"}, "1")
                     ->notifier(on_program_option),
-                field.getDescription())));
+                field.getDescription().data())));
     }
     else
     {
@@ -29,7 +29,7 @@ void addProgramOptionAsMultitoken(T &cmd_settings, boost::program_options::optio
             boost::shared_ptr<boost::program_options::option_description>(new boost::program_options::option_description(
                 name.data(), /// NOLINT(bugprone-suspicious-stringview-data-usage)
                 boost::program_options::value<Strings>()->multitoken()->composing()->notifier(on_program_option),
-                field.getDescription())));
+                field.getDescription().data())));
     }
 }
 
@@ -57,12 +57,12 @@ void addProgramOption(T & cmd_settings, boost::program_options::options_descript
     if (field.getTypeName() == "Bool")
     {
         options.add(boost::shared_ptr<boost::program_options::option_description>(new boost::program_options::option_description(
-                name.data(), boost::program_options::value<std::string>()->composing()->implicit_value("1")->notifier(on_program_option), field.getDescription()))); // NOLINT
+                name.data(), boost::program_options::value<std::string>()->composing()->implicit_value("1")->notifier(on_program_option), field.getDescription().data()))); // NOLINT
     }
     else
     {
         options.add(boost::shared_ptr<boost::program_options::option_description>(new boost::program_options::option_description(
-                name.data(), boost::program_options::value<std::string>()->composing()->notifier(on_program_option), field.getDescription()))); // NOLINT
+                name.data(), boost::program_options::value<std::string>()->composing()->notifier(on_program_option), field.getDescription().data()))); // NOLINT
     }
 }
 

--- a/src/Core/ServerSettings.cpp
+++ b/src/Core/ServerSettings.cpp
@@ -1768,12 +1768,12 @@ void ServerSettings::dumpToSystemServerSettingsColumns(ServerSettingColumnsParam
     for (const auto & setting : impl->all())
     {
         const auto & setting_name = setting.getName();
-        const auto & setting_path = setting.getPath();
+        String setting_path = setting.getPath();
 
         const auto & changeable_settings_it = changeable_settings.find(setting_name);
         const bool is_changeable = (changeable_settings_it != changeable_settings.end());
 
-        res_columns[0]->insert(setting_path);
+        res_columns[0]->insert(setting_path.empty() ? setting_name : setting_path);
         res_columns[1]->insert(is_changeable ? changeable_settings_it->second.first : setting.getValueString());
         res_columns[2]->insert(setting.getDefaultValueString());
         res_columns[3]->insert(setting.isValueChanged());

--- a/src/Core/ServerSettings.cpp
+++ b/src/Core/ServerSettings.cpp
@@ -1580,7 +1580,7 @@ void ServerSettingsImpl::loadSettingsFromConfig(const Poco::Util::AbstractConfig
     for (const auto & setting : all())
     {
         const auto & name = setting.getName();
-        String path = setting.getPath();
+        String path {setting.getPath()};
         const String * path_or_name = path.empty() ? &name : &path;
         try
         {
@@ -1768,7 +1768,7 @@ void ServerSettings::dumpToSystemServerSettingsColumns(ServerSettingColumnsParam
     for (const auto & setting : impl->all())
     {
         const auto & setting_name = setting.getName();
-        String setting_path = setting.getPath();
+        String setting_path {setting.getPath()};
 
         const auto & changeable_settings_it = changeable_settings.find(setting_name);
         const bool is_changeable = (changeable_settings_it != changeable_settings.end());

--- a/src/Core/ServerSettings.cpp
+++ b/src/Core/ServerSettings.cpp
@@ -1580,13 +1580,14 @@ void ServerSettingsImpl::loadSettingsFromConfig(const Poco::Util::AbstractConfig
     for (const auto & setting : all())
     {
         const auto & name = setting.getName();
-        const auto & path = setting.getPath();
+        String path = setting.getPath();
+        const String * path_or_name = path.empty() ? &name : &path;
         try
         {
-            if (config.has(path))
-                set(name, config.getString(path));
-            else if (settings_from_profile_allowlist.contains(name) && config.has("profiles.default." + path))
-                set(name, config.getString("profiles.default." + path));
+            if (config.has(*path_or_name))
+                set(name, config.getString(*path_or_name));
+            else if (settings_from_profile_allowlist.contains(name) && config.has("profiles.default." + *path_or_name))
+                set(name, config.getString("profiles.default." + *path_or_name));
         }
         catch (Exception & e)
         {

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -8113,7 +8113,7 @@ void Settings::addToProgramOptions(std::string_view setting_name, boost::program
                 this->set(setting_name, value);
             });
     options.add(boost::shared_ptr<boost::program_options::option_description>(new boost::program_options::option_description(
-            setting_name.data(), boost::program_options::value<std::string>()->composing()->notifier(on_program_option), accessor.getDescription(index)))); // NOLINT
+            setting_name.data(), boost::program_options::value<std::string>()->composing()->notifier(on_program_option), accessor.getDescription(index).data()))); // NOLINT
 }
 
 void Settings::addToProgramOptionsAsMultitokens(boost::program_options::options_description & options) const

--- a/src/Core/SettingsFields.h
+++ b/src/Core/SettingsFields.h
@@ -28,6 +28,7 @@ struct SettingFieldBase
     virtual SettingFieldBase & operator=(const Field & f) = 0;
 
     virtual bool isChanged() const = 0;
+    virtual void setChanged(bool changed_) = 0;
 
     virtual operator Field() const = 0;
 
@@ -54,6 +55,7 @@ struct SettingFieldNumber : SettingFieldBase
     {}
 
     bool isChanged() const override { return changed; }
+    void setChanged(bool changed_) override { changed = changed_; }
 
     virtual SettingFieldNumber & operator=(Type x);
     virtual SettingFieldNumber & operator=(const Field & f) override;
@@ -138,6 +140,7 @@ struct SettingAutoWrapper final : SettingFieldBase
     }
 
     bool isChanged() const override { return changed; }
+    void setChanged(bool changed_) override { changed = changed_; }
 
     explicit operator Field() const override { return is_auto ? Field(keyword) : Field(base); }
 
@@ -210,6 +213,7 @@ struct SettingFieldMaxThreads final : SettingFieldBase
     }
 
     bool isChanged() const override { return changed; }
+    void setChanged(bool changed_) override { changed = changed_; }
 
     operator UInt64() const { return value; } /// NOLINT
     explicit operator Field() const override { return value; }
@@ -273,6 +277,7 @@ struct SettingFieldTimespan final : SettingFieldBase
     }
 
     bool isChanged() const override { return changed; }
+    void setChanged(bool changed_) override { changed = changed_; }
 
     operator Poco::Timespan() const { return value; } /// NOLINT
 
@@ -328,6 +333,7 @@ struct SettingFieldString final : SettingFieldBase
     }
 
     bool isChanged() const override { return changed; }
+    void setChanged(bool changed_) override { changed = changed_; }
 
     operator const String &() const { return value; } /// NOLINT
     explicit operator Field() const override { return value; }
@@ -365,6 +371,7 @@ public:
     }
 
     bool isChanged() const override { return changed; }
+    void setChanged(bool changed_) override { changed = changed_; }
 
     operator const Map &() const { return value; } /// NOLINT
     explicit operator Field() const override { return value; }
@@ -401,6 +408,7 @@ public:
     }
 
     bool isChanged() const override { return changed; }
+    void setChanged(bool changed_) override { changed = changed_; }
 
     operator char() const { return value; } /// NOLINT
     explicit operator Field() const override { return toString(); }
@@ -441,6 +449,7 @@ struct SettingFieldURI final : SettingFieldBase
     }
 
     bool isChanged() const override { return changed; }
+    void setChanged(bool changed_) override { changed = changed_; }
 
     operator const Poco::URI &() const { return value; } /// NOLINT
     explicit operator String() const { return toString(); }
@@ -493,6 +502,7 @@ struct SettingFieldEnum final : SettingFieldBase
     }
 
     bool isChanged() const override { return changed; }
+    void setChanged(bool changed_) override { changed = changed_; }
 
     operator EnumType() const { return value; } /// NOLINT
     explicit operator Field() const override { return toString(); }
@@ -552,6 +562,7 @@ struct SettingFieldMultiEnum final : SettingFieldBase
     }
 
     bool isChanged() const override { return changed; }
+    void setChanged(bool changed_) override { changed = changed_; }
 
     operator ValueType() const { return value; } /// NOLINT
     explicit operator Field() const override { return toString(); }
@@ -657,6 +668,7 @@ struct SettingFieldTimezone final : SettingFieldBase
     }
 
     bool isChanged() const override { return changed; }
+    void setChanged(bool changed_) override { changed = changed_; }
 
     operator const String &() const { return value; } /// NOLINT
     explicit operator Field() const override { return value; }
@@ -694,6 +706,7 @@ struct SettingFieldCustom final : SettingFieldBase
     }
 
     bool isChanged() const override { return changed; }
+    void setChanged(bool changed_) override { changed = changed_; }
 
     explicit operator Field() const override { return value; }
 

--- a/src/Core/SettingsFields.h
+++ b/src/Core/SettingsFields.h
@@ -22,8 +22,24 @@ class WriteBuffer;
   *  and the remote server will use its default value.
   */
 
+struct SettingFieldBase
+{
+    virtual ~SettingFieldBase() {}
+    virtual SettingFieldBase & operator=(const Field & f) = 0;
+
+    virtual bool isChanged() const = 0;
+
+    virtual operator Field() const = 0;
+
+    virtual String toString() const = 0;
+    virtual void parseFromString(const String & str) = 0;
+
+    virtual void writeBinary(WriteBuffer & out) const = 0;
+    virtual void readBinary(ReadBuffer & in) = 0;
+};
+
 template <typename T>
-struct SettingFieldNumber
+struct SettingFieldNumber : SettingFieldBase
 {
     using Type = T;
     using ValueType = T;
@@ -33,18 +49,32 @@ struct SettingFieldNumber
 
     explicit SettingFieldNumber(Type x = 0);
     explicit SettingFieldNumber(const Field & f);
+    SettingFieldNumber(const SettingFieldNumber & o)
+        : value(o.value), changed(o.changed)
+    {}
 
-    SettingFieldNumber & operator=(Type x);
-    SettingFieldNumber & operator=(const Field & f);
+    bool isChanged() const override { return changed; }
+
+    virtual SettingFieldNumber & operator=(Type x);
+    virtual SettingFieldNumber & operator=(const Field & f) override;
+    SettingFieldNumber & operator=(const SettingFieldNumber & o)
+    {
+        if (this != &o)
+        {
+            value = o.value;
+            changed = o.changed;
+        }
+        return *this;
+    }
 
     operator Type() const { return value; } /// NOLINT
-    explicit operator Field() const { return value; }
+    explicit operator Field() const override { return value; }
 
-    String toString() const;
-    void parseFromString(const String & str);
+    String toString() const override;
+    void parseFromString(const String & str) override;
 
-    void writeBinary(WriteBuffer & out) const;
-    void readBinary(ReadBuffer & in);
+    void writeBinary(WriteBuffer & out) const override;
+    void readBinary(ReadBuffer & in) override;
 };
 
 using SettingFieldUInt64 = SettingFieldNumber<UInt64>;
@@ -63,13 +93,13 @@ using SettingFieldBool = SettingFieldNumber<bool>;
   * but when serializing 'auto' old version will see binary representation of the default value.
   */
 template <typename Base>
-struct SettingAutoWrapper
+struct SettingAutoWrapper final : SettingFieldBase
 {
     constexpr static auto keyword = "auto";
     static bool isAuto(const Field & f) { return f.getType() == Field::Types::String && f.safeGet<String>() == keyword; }
     static bool isAuto(const String & str) { return str == keyword; }
 
-    using Type = typename Base::Type;
+    using Type = Base::Type;
 
     Base base;
     bool is_auto = false;
@@ -77,6 +107,9 @@ struct SettingAutoWrapper
 
     explicit SettingAutoWrapper() : is_auto(true) {}
     explicit SettingAutoWrapper(Type val) : is_auto(false) { base = Base(val); }
+    SettingAutoWrapper(const SettingAutoWrapper & o)
+        : base(o.base), is_auto(o.is_auto), changed(o.changed)
+    {}
 
     explicit SettingAutoWrapper(const Field & f)
         : is_auto(isAuto(f))
@@ -85,7 +118,7 @@ struct SettingAutoWrapper
             base = Base(f);
     }
 
-    SettingAutoWrapper & operator=(const Field & f)
+    SettingAutoWrapper & operator=(const Field & f) override
     {
         changed = true;
         if (is_auto = isAuto(f); !is_auto)
@@ -93,18 +126,31 @@ struct SettingAutoWrapper
         return *this;
     }
 
-    explicit operator Field() const { return is_auto ? Field(keyword) : Field(base); }
+    SettingAutoWrapper & operator=(const SettingAutoWrapper & o)
+    {
+        if (this != &o)
+        {
+            base = o.base;
+            is_auto = o.is_auto;
+            changed = o.changed;
+        }
+        return *this;
+    }
 
-    String toString() const { return is_auto ? keyword : base.toString(); }
+    bool isChanged() const override { return changed; }
 
-    void parseFromString(const String & str)
+    explicit operator Field() const override { return is_auto ? Field(keyword) : Field(base); }
+
+    String toString() const override { return is_auto ? keyword : base.toString(); }
+
+    void parseFromString(const String & str) override
     {
         changed = true;
         if (is_auto = isAuto(str); !is_auto)
             base.parseFromString(str);
     }
 
-    void writeBinary(WriteBuffer & out) const
+    void writeBinary(WriteBuffer & out) const override
     {
         if (is_auto)
             Base().writeBinary(out); /// serialize default value
@@ -118,7 +164,7 @@ struct SettingAutoWrapper
      * If they were changed they were requested to use explicit value instead of `auto`.
      * And so interactions between client-server, and server-server (distributed queries), should be OK.
      */
-    void readBinary(ReadBuffer & in) { changed = true; is_auto = false; base.readBinary(in); }
+    void readBinary(ReadBuffer & in) override { changed = true; is_auto = false; base.readBinary(in); }
 
     Type valueOr(Type default_value) const { return is_auto ? default_value : base.value; }
     std::optional<Type> valueOrNullopt() const { return is_auto ? std::optional<Type>(std::nullopt) : base.value; }
@@ -136,7 +182,7 @@ using SettingFieldDoubleAuto = SettingAutoWrapper<SettingFieldDouble>;
  * When setting to 'auto' it becomes equal to  the number of processor cores without taking into account SMT.
  * A value of 0 is also treated as 'auto', so 'auto' is parsed and serialized in the same way as 0.
  */
-struct SettingFieldMaxThreads
+struct SettingFieldMaxThreads final : SettingFieldBase
 {
     bool is_auto;
     UInt64 value;
@@ -146,19 +192,34 @@ struct SettingFieldMaxThreads
 
     explicit SettingFieldMaxThreads(UInt64 x = 0) : is_auto(!x), value(is_auto ? getAuto() : x)  {}
     explicit SettingFieldMaxThreads(const Field & f);
+    SettingFieldMaxThreads(const SettingFieldMaxThreads & o)
+        : is_auto(o.is_auto), value(o.value), changed(o.changed)
+    {}
 
     SettingFieldMaxThreads & operator=(UInt64 x) { is_auto = !x; value = is_auto ? getAuto() : x; changed = true; return *this; }
-    SettingFieldMaxThreads & operator=(const Field & f);
+    SettingFieldMaxThreads & operator=(const Field & f) override;
+    SettingFieldMaxThreads & operator=(const SettingFieldMaxThreads & o)
+    {
+        if (this != &o)
+        {
+            is_auto = o.is_auto;
+            value = o.value;
+            changed = o.changed;
+        }
+        return *this;
+    }
+
+    bool isChanged() const override { return changed; }
 
     operator UInt64() const { return value; } /// NOLINT
-    explicit operator Field() const { return value; }
+    explicit operator Field() const override { return value; }
 
     /// Writes "auto(<number>)" instead of simple "<number>" if `is_auto == true`.
-    String toString() const;
-    void parseFromString(const String & str);
+    String toString() const override;
+    void parseFromString(const String & str) override;
 
-    void writeBinary(WriteBuffer & out) const;
-    void readBinary(ReadBuffer & in);
+    void writeBinary(WriteBuffer & out) const override;
+    void readBinary(ReadBuffer & in) override;
 
 private:
     static UInt64 getAuto();
@@ -172,7 +233,7 @@ enum class SettingFieldTimespanUnit : uint8_t
 };
 
 template <SettingFieldTimespanUnit unit_>
-struct SettingFieldTimespan
+struct SettingFieldTimespan final : SettingFieldBase
 {
     using Unit = SettingFieldTimespanUnit;
     static constexpr Unit unit = unit_;
@@ -180,7 +241,11 @@ struct SettingFieldTimespan
     Poco::Timespan value;
     bool changed = false;
 
-    explicit SettingFieldTimespan(Poco::Timespan x = {}) : value(x) {}
+    explicit SettingFieldTimespan() : value({}) {}
+    explicit SettingFieldTimespan(const Poco::Timespan & x) : value(x) {}
+    SettingFieldTimespan(const SettingFieldTimespan & o)
+        : value(o.value), changed(o.changed)
+    {}
 
     template <class Rep, class Period = std::ratio<1>>
     explicit SettingFieldTimespan(const std::chrono::duration<Rep, Period> & x)
@@ -189,13 +254,25 @@ struct SettingFieldTimespan
     explicit SettingFieldTimespan(UInt64 x) : SettingFieldTimespan(Poco::Timespan{static_cast<Poco::Timespan::TimeDiff>(x * microseconds_per_unit)}) {}
     explicit SettingFieldTimespan(const Field & f);
 
-    SettingFieldTimespan & operator =(Poco::Timespan x) { value = x; changed = true; return *this; }
+    SettingFieldTimespan & operator =(const Poco::Timespan & x) { value = x; changed = true; return *this; }
 
     template <class Rep, class Period = std::ratio<1>>
     SettingFieldTimespan & operator =(const std::chrono::duration<Rep, Period> & x) { *this = Poco::Timespan{static_cast<Poco::Timespan::TimeDiff>(std::chrono::duration_cast<std::chrono::microseconds>(x).count())}; return *this; }
 
     SettingFieldTimespan & operator =(UInt64 x) { *this = Poco::Timespan{static_cast<Poco::Timespan::TimeDiff>(x * microseconds_per_unit)}; return *this; }
-    SettingFieldTimespan & operator =(const Field & f);
+    SettingFieldTimespan & operator =(const Field & f) override;
+
+    SettingFieldTimespan & operator =(const SettingFieldTimespan & o)
+    {
+        if (this != &o)
+        {
+            value = o.value;
+            changed = o.changed;
+        }
+        return *this;
+    }
+
+    bool isChanged() const override { return changed; }
 
     operator Poco::Timespan() const { return value; } /// NOLINT
 
@@ -203,24 +280,24 @@ struct SettingFieldTimespan
     operator std::chrono::duration<Rep, Period>() const { return std::chrono::duration_cast<std::chrono::duration<Rep, Period>>(std::chrono::microseconds(value.totalMicroseconds())); } /// NOLINT
 
     explicit operator UInt64() const { return value.totalMicroseconds() / microseconds_per_unit; }
-    explicit operator Field() const;
+    explicit operator Field() const override;
 
     Poco::Timespan::TimeDiff totalMicroseconds() const { return value.totalMicroseconds(); }
     Poco::Timespan::TimeDiff totalMilliseconds() const { return value.totalMilliseconds(); }
     Poco::Timespan::TimeDiff totalSeconds() const { return value.totalSeconds(); }
 
-    String toString() const;
-    void parseFromString(const String & str);
+    String toString() const override;
+    void parseFromString(const String & str) override;
 
-    void writeBinary(WriteBuffer & out) const;
-    void readBinary(ReadBuffer & in);
+    void writeBinary(WriteBuffer & out) const override;
+    void readBinary(ReadBuffer & in) override;
 };
 
 using SettingFieldSeconds = SettingFieldTimespan<SettingFieldTimespanUnit::Second>;
 using SettingFieldMilliseconds = SettingFieldTimespan<SettingFieldTimespanUnit::Millisecond>;
 
 
-struct SettingFieldString
+struct SettingFieldString final : SettingFieldBase
 {
     String value;
     bool changed = false;
@@ -231,24 +308,38 @@ struct SettingFieldString
     explicit SettingFieldString(String && str) : value(std::move(str)) {}
     explicit SettingFieldString(const char * str) : SettingFieldString(std::string_view{str}) {}
     explicit SettingFieldString(const Field & f) : SettingFieldString(f.safeGet<String>()) {}
+    SettingFieldString(const SettingFieldString & o)
+        : value(o.value), changed(o.changed)
+    {}
 
     SettingFieldString & operator =(std::string_view str) { value = str; changed = true; return *this; }
     SettingFieldString & operator =(const String & str) { *this = std::string_view{str}; return *this; }
     SettingFieldString & operator =(String && str) { value = std::move(str); changed = true; return *this; }
     SettingFieldString & operator =(const char * str) { *this = std::string_view{str}; return *this; }
-    SettingFieldString & operator =(const Field & f) { *this = f.safeGet<String>(); return *this; }
+    SettingFieldString & operator =(const Field & f) override { *this = f.safeGet<String>(); return *this; }
+    SettingFieldString & operator =(const SettingFieldString & o)
+    {
+        if (this != &o)
+        {
+            value = o.value;
+            changed = o.changed;
+        }
+        return *this;
+    }
+
+    bool isChanged() const override { return changed; }
 
     operator const String &() const { return value; } /// NOLINT
-    explicit operator Field() const { return value; }
+    explicit operator Field() const override { return value; }
 
-    const String & toString() const { return value; }
-    void parseFromString(const String & str) { *this = str; }
+    String toString() const override { return value; }
+    void parseFromString(const String & str) override { *this = str; }
 
-    void writeBinary(WriteBuffer & out) const;
-    void readBinary(ReadBuffer & in);
+    void writeBinary(WriteBuffer & out) const override;
+    void readBinary(ReadBuffer & in) override;
 };
 
-struct SettingFieldMap
+struct SettingFieldMap final : SettingFieldBase
 {
 public:
     Map value;
@@ -257,21 +348,35 @@ public:
     explicit SettingFieldMap(const Map & map = {}) : value(map) {}
     explicit SettingFieldMap(Map && map) : value(std::move(map)) {}
     explicit SettingFieldMap(const Field & f);
+    SettingFieldMap(const SettingFieldMap & o)
+        : value(o.value), changed(o.changed)
+    {}
 
     SettingFieldMap & operator =(const Map & map) { value = map; changed = true; return *this; }
-    SettingFieldMap & operator =(const Field & f);
+    SettingFieldMap & operator =(const Field & f) override;
+    SettingFieldMap & operator =(const SettingFieldMap & o)
+    {
+        if (this != &o)
+        {
+            value = o.value;
+            changed = o.changed;
+        }
+        return *this;
+    }
+
+    bool isChanged() const override { return changed; }
 
     operator const Map &() const { return value; } /// NOLINT
-    explicit operator Field() const { return value; }
+    explicit operator Field() const override { return value; }
 
-    String toString() const;
-    void parseFromString(const String & str);
+    String toString() const override;
+    void parseFromString(const String & str) override;
 
-    void writeBinary(WriteBuffer & out) const;
-    void readBinary(ReadBuffer & in);
+    void writeBinary(WriteBuffer & out) const override;
+    void readBinary(ReadBuffer & in) override;
 };
 
-struct SettingFieldChar
+struct SettingFieldChar final : SettingFieldBase
 {
 public:
     char value;
@@ -279,22 +384,36 @@ public:
 
     explicit SettingFieldChar(char c = '\0') : value(c) {}
     explicit SettingFieldChar(const Field & f);
+    SettingFieldChar(const SettingFieldChar & o)
+        : value(o.value), changed(o.changed)
+    {}
 
     SettingFieldChar & operator =(char c) { value = c; changed = true; return *this; }
-    SettingFieldChar & operator =(const Field & f);
+    SettingFieldChar & operator =(const Field & f) override;
+    SettingFieldChar & operator =(const SettingFieldChar & o)
+    {
+        if (this != &o)
+        {
+            value = o.value;
+            changed = o.changed;
+        }
+        return *this;
+    }
+
+    bool isChanged() const override { return changed; }
 
     operator char() const { return value; } /// NOLINT
-    explicit operator Field() const { return toString(); }
+    explicit operator Field() const override { return toString(); }
 
-    String toString() const { return String(&value, 1); }
-    void parseFromString(const String & str);
+    String toString() const override { return String(&value, 1); }
+    void parseFromString(const String & str) override;
 
-    void writeBinary(WriteBuffer & out) const;
-    void readBinary(ReadBuffer & in);
+    void writeBinary(WriteBuffer & out) const override;
+    void readBinary(ReadBuffer & in) override;
 };
 
 
-struct SettingFieldURI
+struct SettingFieldURI final : SettingFieldBase
 {
     Poco::URI value;
     bool changed = false;
@@ -303,21 +422,35 @@ struct SettingFieldURI
     explicit SettingFieldURI(const String & str) : SettingFieldURI(Poco::URI{str}) {}
     explicit SettingFieldURI(const char * str) : SettingFieldURI(Poco::URI{str}) {}
     explicit SettingFieldURI(const Field & f) : SettingFieldURI(f.safeGet<String>()) {}
+    SettingFieldURI(const SettingFieldURI & o)
+        : value(o.value), changed(o.changed)
+    {}
 
     SettingFieldURI & operator =(const Poco::URI & x) { value = x; changed = true; return *this; }
     SettingFieldURI & operator =(const String & str) { *this = Poco::URI{str}; return *this; }
     SettingFieldURI & operator =(const char * str) { *this = Poco::URI{str}; return *this; }
-    SettingFieldURI & operator =(const Field & f) { *this = f.safeGet<String>(); return *this; }
+    SettingFieldURI & operator =(const Field & f) override { *this = f.safeGet<String>(); return *this; }
+    SettingFieldURI & operator =(const SettingFieldURI & o)
+    {
+        if (this != &o)
+        {
+            value = o.value;
+            changed = o.changed;
+        }
+        return *this;
+    }
+
+    bool isChanged() const override { return changed; }
 
     operator const Poco::URI &() const { return value; } /// NOLINT
     explicit operator String() const { return toString(); }
-    explicit operator Field() const { return toString(); }
+    explicit operator Field() const override { return toString(); }
 
-    String toString() const { return value.toString(); }
-    void parseFromString(const String & str) { *this = str; }
+    String toString() const override { return value.toString(); }
+    void parseFromString(const String & str) override { *this = str; }
 
-    void writeBinary(WriteBuffer & out) const;
-    void readBinary(ReadBuffer & in);
+    void writeBinary(WriteBuffer & out) const override;
+    void readBinary(ReadBuffer & in) override;
 };
 
 
@@ -333,7 +466,7 @@ struct SettingFieldURI
   *                        {{"Male", Gender::Male}, {"Female", Gender::Female}})
   */
 template <typename EnumT, typename Traits>
-struct SettingFieldEnum
+struct SettingFieldEnum final : SettingFieldBase
 {
     using EnumType = EnumT;
     using ValueType = EnumT;
@@ -343,18 +476,32 @@ struct SettingFieldEnum
 
     explicit SettingFieldEnum(EnumType x = EnumType{}) : value(x) {}
     explicit SettingFieldEnum(const Field & f) : SettingFieldEnum(Traits::fromString(f.safeGet<String>())) {}
+    SettingFieldEnum(const SettingFieldEnum & o)
+        : value(o.value), changed(o.changed)
+    {}
 
     SettingFieldEnum & operator =(EnumType x) { value = x; changed = true; return *this; }
-    SettingFieldEnum & operator =(const Field & f) { *this = Traits::fromString(f.safeGet<String>()); return *this; }
+    SettingFieldEnum & operator =(const Field & f) override { *this = Traits::fromString(f.safeGet<String>()); return *this; }
+    SettingFieldEnum & operator =(const SettingFieldEnum & o)
+    {
+        if (this != &o)
+        {
+            value = o.value;
+            changed = o.changed;
+        }
+        return *this;
+    }
+
+    bool isChanged() const override { return changed; }
 
     operator EnumType() const { return value; } /// NOLINT
-    explicit operator Field() const { return toString(); }
+    explicit operator Field() const override { return toString(); }
 
-    String toString() const { return Traits::toString(value); }
-    void parseFromString(const String & str) { *this = Traits::fromString(str); }
+    String toString() const override { return Traits::toString(value); }
+    void parseFromString(const String & str) override { *this = Traits::fromString(str); }
 
-    void writeBinary(WriteBuffer & out) const;
-    void readBinary(ReadBuffer & in);
+    void writeBinary(WriteBuffer & out) const override;
+    void readBinary(ReadBuffer & in) override;
 };
 
 struct SettingFieldEnumHelpers
@@ -377,7 +524,7 @@ void SettingFieldEnum<EnumT, Traits>::readBinary(ReadBuffer & in)
 
 // Mostly like SettingFieldEnum, but can have multiple enum values (or none) set at once.
 template <typename Enum, typename Traits>
-struct SettingFieldMultiEnum
+struct SettingFieldMultiEnum final : SettingFieldBase
 {
     using EnumType = Enum;
     using ValueType = std::vector<Enum>;
@@ -388,9 +535,26 @@ struct SettingFieldMultiEnum
     explicit SettingFieldMultiEnum(ValueType v = ValueType{}) : value{v} {}
     explicit SettingFieldMultiEnum(EnumType e) : value{e} {}
     explicit SettingFieldMultiEnum(const Field & f) : value(parseValueFromString(f.safeGet<String>())) {}
+    SettingFieldMultiEnum(const SettingFieldMultiEnum & o)
+        : value(o.value), changed(o.changed)
+    {}
+
+    SettingFieldMultiEnum & operator= (ValueType x) { changed = true; value = x; return *this; }
+    SettingFieldMultiEnum & operator= (const Field & x) override { parseFromString(x.safeGet<String>()); return *this; }
+    SettingFieldMultiEnum & operator= (const SettingFieldMultiEnum & o)
+    {
+        if (this != &o)
+        {
+            value = o.value;
+            changed = o.changed;
+        }
+        return *this;
+    }
+
+    bool isChanged() const override { return changed; }
 
     operator ValueType() const { return value; } /// NOLINT
-    explicit operator Field() const { return toString(); }
+    explicit operator Field() const override { return toString(); }
     operator MultiEnum<EnumType>() const /// NOLINT
     {
         MultiEnum<EnumType> res;
@@ -399,12 +563,9 @@ struct SettingFieldMultiEnum
         return res;
     }
 
-    SettingFieldMultiEnum & operator= (ValueType x) { changed = true; value = x; return *this; }
-    SettingFieldMultiEnum & operator= (const Field & x) { parseFromString(x.safeGet<String>()); return *this; }
-
-    String toString() const
+    String toString() const override
     {
-        static const String separator = ",";
+        constexpr String separator = ",";
         String result;
         for (const auto & v : value)
         {
@@ -417,15 +578,15 @@ struct SettingFieldMultiEnum
 
         return result;
     }
-    void parseFromString(const String & str) { *this = parseValueFromString(str); }
+    void parseFromString(const String & str) override { *this = parseValueFromString(str); }
 
-    void writeBinary(WriteBuffer & out) const;
-    void readBinary(ReadBuffer & in);
+    void writeBinary(WriteBuffer & out) const override;
+    void readBinary(ReadBuffer & in) override;
 
 private:
     static ValueType parseValueFromString(const std::string_view str)
     {
-        static const String separators=", ";
+        constexpr String separators=", ";
 
         ValueType result;
         std::unordered_set<EnumType> values_set;
@@ -466,7 +627,7 @@ void SettingFieldMultiEnum<EnumT, Traits>::readBinary(ReadBuffer & in)
 }
 
 /// Setting field for specifying user-defined timezone. It is basically a string, but it needs validation.
-struct SettingFieldTimezone
+struct SettingFieldTimezone final : SettingFieldBase
 {
     String value;
     bool changed = false;
@@ -476,41 +637,71 @@ struct SettingFieldTimezone
     explicit SettingFieldTimezone(String && str) { validateTimezone(str); value = std::move(str); }
     explicit SettingFieldTimezone(const char * str) { validateTimezone(str); value = str; }
     explicit SettingFieldTimezone(const Field & f) { const String & str = f.safeGet<String>(); validateTimezone(str); value = str; }
+    SettingFieldTimezone(const SettingFieldTimezone & o)
+        : value(o.value), changed(o.changed)
+    {}
 
     SettingFieldTimezone & operator =(std::string_view str) { validateTimezone(std::string(str)); value = str; changed = true; return *this; }
     SettingFieldTimezone & operator =(const String & str) { *this = std::string_view{str}; return *this; }
     SettingFieldTimezone & operator =(String && str) { validateTimezone(str); value = std::move(str); changed = true; return *this; }
     SettingFieldTimezone & operator =(const char * str) { *this = std::string_view{str}; return *this; }
-    SettingFieldTimezone & operator =(const Field & f) { *this = f.safeGet<String>(); return *this; }
+    SettingFieldTimezone & operator =(const Field & f) override { *this = f.safeGet<String>(); return *this; }
+    SettingFieldTimezone & operator =(const SettingFieldTimezone & o)
+    {
+        if (this != &o)
+        {
+            value = o.value;
+            changed = o.changed;
+        }
+        return *this;
+    }
+
+    bool isChanged() const override { return changed; }
 
     operator const String &() const { return value; } /// NOLINT
-    explicit operator Field() const { return value; }
+    explicit operator Field() const override { return value; }
 
-    const String & toString() const { return value; }
-    void parseFromString(const String & str) { *this = str; }
+    String toString() const override { return value; }
+    void parseFromString(const String & str) override { *this = str; }
 
-    void writeBinary(WriteBuffer & out) const;
-    void readBinary(ReadBuffer & in);
+    void writeBinary(WriteBuffer & out) const override;
+    void readBinary(ReadBuffer & in) override;
 
 private:
     void validateTimezone(const std::string & tz_str);
 };
 
 /// Can keep a value of any type. Used for user-defined settings.
-struct SettingFieldCustom
+struct SettingFieldCustom final : SettingFieldBase
 {
     Field value;
     bool changed = false;
 
     explicit SettingFieldCustom(const Field & f = {}) : value(f) {}
-    SettingFieldCustom & operator =(const Field & f) { value = f; changed = true; return *this; }
-    explicit operator Field() const { return value; }
+    SettingFieldCustom(const SettingFieldCustom & o)
+        : value(o.value), changed(o.changed)
+    {}
 
-    String toString() const;
-    void parseFromString(const String & str);
+    SettingFieldCustom & operator =(const Field & f) override { value = f; changed = true; return *this; }
+    SettingFieldCustom & operator =(const SettingFieldCustom & o)
+    {
+        if (this != &o)
+        {
+            value = o.value;
+            changed = o.changed;
+        }
+        return *this;
+    }
 
-    void writeBinary(WriteBuffer & out) const;
-    void readBinary(ReadBuffer & in);
+    bool isChanged() const override { return changed; }
+
+    explicit operator Field() const override { return value; }
+
+    String toString() const override;
+    void parseFromString(const String & str) override;
+
+    void writeBinary(WriteBuffer & out) const override;
+    void readBinary(ReadBuffer & in) override;
 };
 
 struct SettingFieldNonZeroUInt64 : public SettingFieldUInt64
@@ -519,10 +710,10 @@ public:
     explicit SettingFieldNonZeroUInt64(UInt64 x = 1);
     explicit SettingFieldNonZeroUInt64(const Field & f);
 
-    SettingFieldNonZeroUInt64 & operator=(UInt64 x);
-    SettingFieldNonZeroUInt64 & operator=(const Field & f);
+    SettingFieldNonZeroUInt64 & operator=(UInt64 x) override;
+    SettingFieldNonZeroUInt64 & operator=(const Field & f) override;
 
-    void parseFromString(const String & str);
+    void parseFromString(const String & str) override;
 
 private:
     void checkValueNonZero() const;

--- a/src/Core/SettingsFields.h
+++ b/src/Core/SettingsFields.h
@@ -24,13 +24,13 @@ class WriteBuffer;
 
 struct SettingFieldBase
 {
-    virtual ~SettingFieldBase() {}
+    virtual ~SettingFieldBase() = default;
     virtual SettingFieldBase & operator=(const Field & f) = 0;
 
     virtual bool isChanged() const = 0;
     virtual void setChanged(bool changed_) = 0;
 
-    virtual operator Field() const = 0;
+    virtual explicit operator Field() const = 0;
 
     virtual String toString() const = 0;
     virtual void parseFromString(const String & str) = 0;
@@ -58,7 +58,7 @@ struct SettingFieldNumber : SettingFieldBase
     void setChanged(bool changed_) override { changed = changed_; }
 
     virtual SettingFieldNumber & operator=(Type x);
-    virtual SettingFieldNumber & operator=(const Field & f) override;
+    SettingFieldNumber & operator=(const Field & f) override;
     SettingFieldNumber & operator=(const SettingFieldNumber & o)
     {
         if (this != &o)

--- a/src/Interpreters/Cache/FileCacheSettings.cpp
+++ b/src/Interpreters/Cache/FileCacheSettings.cpp
@@ -117,7 +117,7 @@ ColumnsDescription FileCacheSettings::getColumnsDescription()
         desc.name = setting.getName();
         desc.type = [&]() -> DataTypePtr
         {
-            const std::string type_name = setting.getTypeName();
+            const auto type_name = setting.getTypeName();
             if (type_name == "UInt64")
                 return std::make_shared<DataTypeUInt64>();
             else if (type_name == "String")

--- a/src/Storages/MergeTree/MergeTreeReadPoolBase.cpp
+++ b/src/Storages/MergeTree/MergeTreeReadPoolBase.cpp
@@ -153,7 +153,7 @@ calculateMinMarksPerTask(
             const size_t part_compressed_bytes = getSizeOfColumns(*part.data_part, columns);
 
             avg_mark_bytes = std::max<size_t>(part_compressed_bytes / part_marks_count, 1);
-            const auto min_bytes_per_task = settings[Setting::merge_tree_min_bytes_per_task_for_remote_reading];
+            const auto & min_bytes_per_task = settings[Setting::merge_tree_min_bytes_per_task_for_remote_reading];
             /// We're taking min here because number of tasks shouldn't be too low - it will make task stealing impossible.
             /// We also create at least two tasks per thread to have something to steal from a slow thread.
             const auto heuristic_min_marks = std::min<size_t>(


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Improve build time of setting classes

Introduce a base class `SettingFieldBase` for all SettingField##Type classes in order to remove most of the lambda functions in `FieldInfo`. This makes the classes larger (because of the virtual tables) but speeds up compilation, which is a pain.

I also tried to move from using one member per setting inside of ::Data to use a std::vector of SettingFieldBase but this made the code way more complex and slower to build (15->25 seconds).

Comparing Settings.cpp (the largest one) in my local dev machine:
* Before:
```
real    0m43.484s
user    0m42.696s
sys     0m0.548s
```

* After:
```
real    0m15.649s
user    0m15.095s
sys     0m0.307s
```

References https://github.com/ClickHouse/ClickHouse/issues/58797

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
