### PR TITLE
Add system.delta_lake_history table for Delta Lake version history

### DIFF
--- a/docs/en/operations/system-tables/delta_lake_history.md
+++ b/docs/en/operations/system-tables/delta_lake_history.md
@@ -1,0 +1,45 @@
+---
+description: 'System Delta Lake version history'
+keywords: ['system delta_lake_history']
+slug: /operations/system-tables/delta_lake_history
+title: 'system.delta_lake_history'
+doc_type: 'reference'
+---
+
+# system.delta_lake_history
+
+This system table contains the version history of Delta Lake tables existing in ClickHouse. It will be empty if you don't have any Delta Lake tables in ClickHouse.
+
+This table is useful for:
+- Inspecting the commit history of Delta Lake tables
+- Understanding what operations were performed on each version
+- Working with the Change Data Feed (CDF) feature to query specific versions
+
+Columns:
+
+- `database` ([String](../../sql-reference/data-types/string.md)) — Database name.
+- `table` ([String](../../sql-reference/data-types/string.md)) — Table name.
+- `version` ([UInt64](../../sql-reference/data-types/int-uint.md)) — Version number of the Delta Lake table.
+- `timestamp` ([Nullable](../../sql-reference/data-types/nullable.md)([DateTime64](../../sql-reference/data-types/datetime64.md))) — Timestamp when this version was committed.
+- `operation` ([String](../../sql-reference/data-types/string.md)) — Operation type (e.g., WRITE, DELETE, MERGE, UPDATE).
+- `operation_parameters` ([Map(String, String)](../../sql-reference/data-types/map.md)) — Parameters of the operation.
+- `is_latest_version` ([UInt8](../../sql-reference/data-types/int-uint.md)) — Flag indicating if this is the current (latest) version.
+
+**Example**
+
+```sql
+SELECT * FROM system.delta_lake_history;
+```
+
+```response
+┌─database─┬─table──────┬─version─┬───────────────timestamp─┬─operation─┬─operation_parameters─────────────────┬─is_latest_version─┐
+│ default  │ my_delta   │       0 │ 2024-01-15 10:30:00.000 │ WRITE     │ {'mode':'Overwrite'}                 │                 0 │
+│ default  │ my_delta   │       1 │ 2024-01-15 11:45:00.000 │ WRITE     │ {'mode':'Append'}                    │                 0 │
+│ default  │ my_delta   │       2 │ 2024-01-15 14:20:00.000 │ DELETE    │ {'predicate':'["(id > 100)"]'}       │                 1 │
+└──────────┴────────────┴─────────┴─────────────────────────┴───────────┴──────────────────────────────────────┴───────────────────┘
+```
+
+**See Also**
+
+- [Delta Lake Table Engine](/docs/en/engines/table-engines/integrations/deltalake.md)
+- [system.iceberg_history](iceberg_history.md) — Similar table for Iceberg tables

--- a/docs/en/operations/system-tables/delta_lake_history.md
+++ b/docs/en/operations/system-tables/delta_lake_history.md
@@ -1,12 +1,14 @@
 ---
 description: 'System Delta Lake version history'
 keywords: ['system delta_lake_history']
+sidebar_label: 'system.delta_lake_history'
+sidebar_position: 53
 slug: /operations/system-tables/delta_lake_history
 title: 'system.delta_lake_history'
 doc_type: 'reference'
 ---
 
-# system.delta_lake_history
+# system.delta_lake_history {#system-delta-lake-history}
 
 This system table contains the version history of Delta Lake tables existing in ClickHouse. It will be empty if you don't have any Delta Lake tables in ClickHouse.
 
@@ -15,7 +17,7 @@ This table is useful for:
 - Understanding what operations were performed on each version
 - Working with the Change Data Feed (CDF) feature to query specific versions
 
-Columns:
+## Columns {#system-delta-lake-history-columns}
 
 - `database` ([String](../../sql-reference/data-types/string.md)) — Database name.
 - `table` ([String](../../sql-reference/data-types/string.md)) — Table name.
@@ -25,7 +27,7 @@ Columns:
 - `operation_parameters` ([Map(String, String)](../../sql-reference/data-types/map.md)) — Parameters of the operation.
 - `is_latest_version` ([UInt8](../../sql-reference/data-types/int-uint.md)) — Flag indicating if this is the current (latest) version.
 
-**Example**
+## Example {#system-delta-lake-history-example}
 
 ```sql
 SELECT * FROM system.delta_lake_history;
@@ -39,7 +41,7 @@ SELECT * FROM system.delta_lake_history;
 └──────────┴────────────┴─────────┴─────────────────────────┴───────────┴──────────────────────────────────────┴───────────────────┘
 ```
 
-**See Also**
+## See Also {#system-delta-lake-history-see-also}
 
 - [Delta Lake Table Engine](/docs/en/engines/table-engines/integrations/deltalake.md)
 - [system.iceberg_history](iceberg_history.md) — Similar table for Iceberg tables

--- a/docs/en/operations/system-tables/delta_lake_history.md
+++ b/docs/en/operations/system-tables/delta_lake_history.md
@@ -43,5 +43,5 @@ SELECT * FROM system.delta_lake_history;
 
 ## See Also {#system-delta-lake-history-see-also}
 
-- [Delta Lake Table Engine](/docs/en/engines/table-engines/integrations/deltalake.md)
+- [Delta Lake Table Engine](/docs/engines/table-engines/integrations/deltalake)
 - [system.iceberg_history](iceberg_history.md) — Similar table for Iceberg tables

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -7035,6 +7035,11 @@ Defines a rows limit for a single inserted data file in delta lake.
     DECLARE(NonZeroUInt64, delta_lake_insert_max_bytes_in_data_file, 1_GiB, R"(
 Defines a bytes limit for a single inserted data file in delta lake.
 )", 0) \
+    DECLARE(UInt64, delta_lake_history_max_records, 1'000'000, R"(
+Maximum number of history records to materialize when querying Delta Lake table history.
+Tables whose version count exceeds this limit will raise an exception instead of
+consuming an unbounded amount of memory. Set to 0 to disable the limit.
+)", 0) \
     DECLARE(Bool, allow_experimental_delta_lake_writes, false, R"(
 Enables delta-kernel writes feature.
 )", EXPERIMENTAL) \

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -83,6 +83,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"functions_h3_default_if_invalid", true, false, "A new setting for legacy behaviour to allow invalid inputs to h3 functions"},
             {"max_skip_unavailable_shards_num", 0, 0, "New setting to limit the number of shards that can be silently skipped when skip_unavailable_shards is enabled."},
             {"max_skip_unavailable_shards_ratio", 0, 0, "New setting to limit the ratio of shards that can be silently skipped when skip_unavailable_shards is enabled."},
+            {"delta_lake_history_max_records", 0, 1'000'000, "New setting to cap the number of Delta Lake history records materialized in memory."},
         });
         addSettingsChanges(settings_changes_history, "26.2",
         {

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -44,6 +44,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"optimize_truncate_order_by_after_group_by_keys", false, true, "Remove trailing ORDER BY elements once all GROUP BY keys are covered in the ORDER BY prefix."},
             {"use_statistics_for_part_pruning", false, true, "New setting to use statistics for part pruning during query execution."},
             {"distributed_index_analysis_only_on_coordinator", false, false, "New setting."},
+            {"delta_lake_history_max_records", 0, 1'000'000, "New setting to cap the number of Delta Lake history records materialized in memory."},
             {"query_plan_optimize_join_order_randomize", 0, 0, "New setting to randomize join order statistics for testing."},
             {"enable_materialized_cte", false, false, "New setting"},
             {"use_strict_insert_block_limits", false, false, "New setting to use strict min and max insert bounds on inserts. When min < max, max limits take precedence."},
@@ -83,7 +84,6 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"functions_h3_default_if_invalid", true, false, "A new setting for legacy behaviour to allow invalid inputs to h3 functions"},
             {"max_skip_unavailable_shards_num", 0, 0, "New setting to limit the number of shards that can be silently skipped when skip_unavailable_shards is enabled."},
             {"max_skip_unavailable_shards_ratio", 0, 0, "New setting to limit the ratio of shards that can be silently skipped when skip_unavailable_shards is enabled."},
-            {"delta_lake_history_max_records", 0, 1'000'000, "New setting to cap the number of Delta Lake history records materialized in memory."},
         });
         addSettingsChanges(settings_changes_history, "26.2",
         {

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.cpp
@@ -6,6 +6,10 @@
 
 #if USE_PARQUET
 
+#if USE_DELTA_KERNEL_RS
+#include <Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.h>
+#endif
+
 #include <Common/logger_useful.h>
 #include <Columns/ColumnMap.h>
 #include <Columns/ColumnNullable.h>

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.cpp
@@ -619,6 +619,115 @@ DeltaLakeMetadata::DeltaLakeMetadata(ObjectStoragePtr object_storage_, StorageOb
              data_files.size(), partition_columns.size(), schema.toString());
 }
 
+/// Helper: extract version number from a .json metadata filename.
+/// Returns std::nullopt if the filename is not a valid version file.
+static std::optional<UInt64> extractVersionFromFilename(const String & path)
+{
+    auto filename = std::filesystem::path(path).filename().string();
+    if (filename.size() <= 5 || !filename.ends_with(".json"))
+        return std::nullopt;
+    filename = filename.substr(0, filename.size() - 5);
+    try
+    {
+        return std::stoull(filename);
+    }
+    catch (const std::invalid_argument &) { return std::nullopt; }
+    catch (const std::out_of_range &) { return std::nullopt; }
+}
+
+/// Helper: read _last_checkpoint file and return the checkpoint version (0 if none).
+static UInt64 readLastCheckpointVersion(
+    ObjectStoragePtr object_storage,
+    const String & table_path,
+    ContextPtr local_context,
+    LoggerPtr log)
+{
+    static constexpr auto deltalake_metadata_directory = "_delta_log";
+    const auto last_checkpoint_file = std::filesystem::path(table_path) / deltalake_metadata_directory / "_last_checkpoint";
+
+    if (!object_storage->exists(StoredObject(last_checkpoint_file)))
+        return 0;
+
+    try
+    {
+        RelativePathWithMetadata object_info(last_checkpoint_file);
+        auto buf = createReadBuffer(object_info, object_storage, local_context, log);
+        String json_str;
+        readJSONObjectPossiblyInvalid(json_str, *buf);
+        const JSON json(json_str);
+        return json["version"].getUInt();
+    }
+    catch (...)
+    {
+        tryLogCurrentException(log, "Failed to read _last_checkpoint");
+        return 0;
+    }
+}
+
+/// Parse a single .json metadata file and populate a DeltaLakeHistoryRecord.
+static void parseCommitInfo(
+    ReadBuffer & buf,
+    DeltaLakeHistoryRecord & record)
+{
+    char c;
+    while (!buf.eof())
+    {
+        /// Skip invalid characters before JSON
+        while (buf.peek(c) && c != '{')
+            buf.ignore();
+
+        if (buf.eof())
+            break;
+
+        String json_str;
+        readJSONObjectPossiblyInvalid(json_str, buf);
+
+        if (json_str.empty())
+            continue;
+
+        Poco::JSON::Parser parser;
+        Poco::Dynamic::Var json = parser.parse(json_str);
+        const Poco::JSON::Object::Ptr & json_object = json.extract<Poco::JSON::Object::Ptr>();
+
+        if (!json_object)
+            continue;
+
+        /// Extract commitInfo
+        if (json_object->has("commitInfo"))
+        {
+            const auto commit_info = json_object->get("commitInfo").extract<Poco::JSON::Object::Ptr>();
+            if (commit_info)
+            {
+                /// Prefer inCommitTimestamp over timestamp per Delta Lake protocol
+                if (commit_info->has("inCommitTimestamp"))
+                {
+                    auto ts = commit_info->getValue<Int64>("inCommitTimestamp");
+                    record.timestamp = static_cast<DateTime64>(ts);
+                }
+                else if (commit_info->has("timestamp"))
+                {
+                    auto ts = commit_info->getValue<Int64>("timestamp");
+                    record.timestamp = static_cast<DateTime64>(ts);
+                }
+
+                if (commit_info->has("operation"))
+                    record.operation = commit_info->getValue<String>("operation");
+
+                if (commit_info->has("operationParameters"))
+                {
+                    const auto params = commit_info->get("operationParameters").extract<Poco::JSON::Object::Ptr>();
+                    if (params)
+                    {
+                        for (const auto & param : *params)
+                            record.operation_parameters[param.first] = param.second.toString();
+                    }
+                }
+            }
+            break;
+        }
+    }
+}
+
 DeltaLakeHistory parseDeltaLakeHistory(
     ObjectStoragePtr object_storage,
     const String & table_path,
@@ -629,136 +738,56 @@ DeltaLakeHistory parseDeltaLakeHistory(
 
     static constexpr auto deltalake_metadata_directory = "_delta_log";
     static constexpr auto metadata_file_suffix = ".json";
-    /// Limit the number of history records to avoid excessive I/O
-    static constexpr size_t max_history_records = 100;
 
     try
     {
+        /// Read _last_checkpoint to find checkpoint version.
+        /// When a checkpoint exists, .json files for versions <= checkpoint_version
+        /// may have been removed. We still need to report those versions in the history.
+        const UInt64 checkpoint_version = readLastCheckpointVersion(object_storage, table_path, local_context, log);
+
         Strings metadata_files = listFiles(*object_storage, table_path, deltalake_metadata_directory, metadata_file_suffix);
 
-        if (metadata_files.empty())
-            return history;
-
-        /// Sort files to get versions in order (descending to get most recent first)
-        std::sort(metadata_files.begin(), metadata_files.end(), std::greater<>());
-
-        /// Limit to most recent N files
-        if (metadata_files.size() > max_history_records)
-            metadata_files.resize(max_history_records);
-
-        /// Find the current (latest) version - first file since we sorted descending
-        UInt64 current_version = 0;
+        /// Build a set of versions that have .json files available
+        std::map<UInt64, String> version_to_file;
+        UInt64 max_version = checkpoint_version;
+        for (const auto & file : metadata_files)
         {
-            const auto & first_file = metadata_files.front();
-            auto filename = std::filesystem::path(first_file).filename().string();
-            if (filename.size() > 5 && filename.ends_with(".json"))
+            if (auto version = extractVersionFromFilename(file))
             {
-                filename = filename.substr(0, filename.size() - 5);
-                try
-                {
-                    current_version = std::stoull(filename);
-                }
-                catch (const std::invalid_argument &)
-                {
-                    current_version = 0;
-                }
-                catch (const std::out_of_range &)
-                {
-                    current_version = 0;
-                }
+                version_to_file[*version] = file;
+                max_version = std::max(max_version, *version);
             }
         }
 
-        /// Process each metadata file to extract history
-        for (const auto & metadata_file : metadata_files)
+        if (max_version == 0 && version_to_file.empty())
+            return history;
+
+        /// Iterate all versions from 0 to max_version.
+        /// For versions with .json files, parse commitInfo.
+        /// For versions without .json files (removed after checkpoint), emit a record with just the version.
+        for (UInt64 version = 0; version <= max_version; ++version)
         {
             try
             {
-                /// Extract version from filename
-                auto filename = std::filesystem::path(metadata_file).filename().string();
-                if (filename.size() <= 5 || !filename.ends_with(".json"))
-                    continue;
-
-                filename = filename.substr(0, filename.size() - 5);
-                UInt64 version = 0;
-                try
-                {
-                    version = std::stoull(filename);
-                }
-                catch (const std::invalid_argument &)
-                {
-                    continue;
-                }
-                catch (const std::out_of_range &)
-                {
-                    continue;
-                }
-
-                /// Read the metadata file
-                RelativePathWithMetadata object_info(metadata_file);
-                auto buf = createReadBuffer(object_info, object_storage, local_context, log);
-
                 DeltaLakeHistoryRecord record;
                 record.version = version;
-                record.is_latest_version = (version == current_version);
+                record.is_latest_version = (version == max_version);
 
-                char c;
-                while (!buf->eof())
+                auto it = version_to_file.find(version);
+                if (it != version_to_file.end())
                 {
-                    /// Skip invalid characters before JSON
-                    while (buf->peek(c) && c != '{')
-                        buf->ignore();
-
-                    if (buf->eof())
-                        break;
-
-                    String json_str;
-                    readJSONObjectPossiblyInvalid(json_str, *buf);
-
-                    if (json_str.empty())
-                        continue;
-
-                    Poco::JSON::Parser parser;
-                    Poco::Dynamic::Var json = parser.parse(json_str);
-                    const Poco::JSON::Object::Ptr & json_object = json.extract<Poco::JSON::Object::Ptr>();
-
-                    if (!json_object)
-                        continue;
-
-                    /// Extract commitInfo
-                    if (json_object->has("commitInfo"))
-                    {
-                        const auto commit_info = json_object->get("commitInfo").extract<Poco::JSON::Object::Ptr>();
-                        if (commit_info)
-                        {
-                            if (commit_info->has("timestamp"))
-                            {
-                                auto ts = commit_info->getValue<Int64>("timestamp");
-                                record.timestamp = static_cast<DateTime64>(ts);
-                            }
-
-                            if (commit_info->has("operation"))
-                                record.operation = commit_info->getValue<String>("operation");
-
-                            if (commit_info->has("operationParameters"))
-                            {
-                                const auto params = commit_info->get("operationParameters").extract<Poco::JSON::Object::Ptr>();
-                                if (params)
-                                {
-                                    for (const auto & param : *params)
-                                        record.operation_parameters[param.first] = param.second.toString();
-                                }
-                            }
-                        }
-                        break;
-                    }
+                    /// .json file exists — parse commitInfo
+                    RelativePathWithMetadata object_info(it->second);
+                    auto buf = createReadBuffer(object_info, object_storage, local_context, log);
+                    parseCommitInfo(*buf, record);
                 }
 
                 history.push_back(std::move(record));
             }
             catch (...)
             {
-                tryLogCurrentException(log, fmt::format("Failed to process metadata file {}", metadata_file));
+                tryLogCurrentException(log, fmt::format("Failed to process version {}", version));
             }
         }
     }

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.cpp
@@ -613,9 +613,166 @@ DeltaLakeMetadata::DeltaLakeMetadata(ObjectStoragePtr object_storage_, StorageOb
     schema = result.schema;
     partition_columns = result.partition_columns;
     object_storage = object_storage_;
+    table_path = impl.table_path;
 
     LOG_TRACE(impl.log, "Found {} data files, {} partition files, schema: {}",
              data_files.size(), partition_columns.size(), schema.toString());
+}
+
+DeltaLakeHistory parseDeltaLakeHistory(
+    ObjectStoragePtr object_storage,
+    const String & table_path,
+    ContextPtr local_context,
+    LoggerPtr log)
+{
+    DeltaLakeHistory history;
+
+    static constexpr auto deltalake_metadata_directory = "_delta_log";
+    static constexpr auto metadata_file_suffix = ".json";
+    /// Limit the number of history records to avoid excessive I/O
+    static constexpr size_t max_history_records = 100;
+
+    try
+    {
+        Strings metadata_files = listFiles(*object_storage, table_path, deltalake_metadata_directory, metadata_file_suffix);
+
+        if (metadata_files.empty())
+            return history;
+
+        /// Sort files to get versions in order (descending to get most recent first)
+        std::sort(metadata_files.begin(), metadata_files.end(), std::greater<>());
+
+        /// Limit to most recent N files
+        if (metadata_files.size() > max_history_records)
+            metadata_files.resize(max_history_records);
+
+        /// Find the current (latest) version - first file since we sorted descending
+        UInt64 current_version = 0;
+        {
+            const auto & first_file = metadata_files.front();
+            auto filename = std::filesystem::path(first_file).filename().string();
+            if (filename.size() > 5 && filename.ends_with(".json"))
+            {
+                filename = filename.substr(0, filename.size() - 5);
+                try
+                {
+                    current_version = std::stoull(filename);
+                }
+                catch (const std::invalid_argument &)
+                {
+                    current_version = 0;
+                }
+                catch (const std::out_of_range &)
+                {
+                    current_version = 0;
+                }
+            }
+        }
+
+        /// Process each metadata file to extract history
+        for (const auto & metadata_file : metadata_files)
+        {
+            try
+            {
+                /// Extract version from filename
+                auto filename = std::filesystem::path(metadata_file).filename().string();
+                if (filename.size() <= 5 || !filename.ends_with(".json"))
+                    continue;
+
+                filename = filename.substr(0, filename.size() - 5);
+                UInt64 version = 0;
+                try
+                {
+                    version = std::stoull(filename);
+                }
+                catch (const std::invalid_argument &)
+                {
+                    continue;
+                }
+                catch (const std::out_of_range &)
+                {
+                    continue;
+                }
+
+                /// Read the metadata file
+                RelativePathWithMetadata object_info(metadata_file);
+                auto buf = createReadBuffer(object_info, object_storage, local_context, log);
+
+                DeltaLakeHistoryRecord record;
+                record.version = version;
+                record.is_latest_version = (version == current_version);
+
+                char c;
+                while (!buf->eof())
+                {
+                    /// Skip invalid characters before JSON
+                    while (buf->peek(c) && c != '{')
+                        buf->ignore();
+
+                    if (buf->eof())
+                        break;
+
+                    String json_str;
+                    readJSONObjectPossiblyInvalid(json_str, *buf);
+
+                    if (json_str.empty())
+                        continue;
+
+                    Poco::JSON::Parser parser;
+                    Poco::Dynamic::Var json = parser.parse(json_str);
+                    const Poco::JSON::Object::Ptr & json_object = json.extract<Poco::JSON::Object::Ptr>();
+
+                    if (!json_object)
+                        continue;
+
+                    /// Extract commitInfo
+                    if (json_object->has("commitInfo"))
+                    {
+                        const auto commit_info = json_object->get("commitInfo").extract<Poco::JSON::Object::Ptr>();
+                        if (commit_info)
+                        {
+                            if (commit_info->has("timestamp"))
+                            {
+                                auto ts = commit_info->getValue<Int64>("timestamp");
+                                record.timestamp = static_cast<DateTime64>(ts);
+                            }
+
+                            if (commit_info->has("operation"))
+                                record.operation = commit_info->getValue<String>("operation");
+
+                            if (commit_info->has("operationParameters"))
+                            {
+                                const auto params = commit_info->get("operationParameters").extract<Poco::JSON::Object::Ptr>();
+                                if (params)
+                                {
+                                    for (const auto & param : *params)
+                                        record.operation_parameters[param.first] = param.second.toString();
+                                }
+                            }
+                        }
+                        break;
+                    }
+                }
+
+                history.push_back(std::move(record));
+            }
+            catch (...)
+            {
+                tryLogCurrentException(log, fmt::format("Failed to process metadata file {}", metadata_file));
+            }
+        }
+    }
+    catch (...)
+    {
+        tryLogCurrentException(log, "Failed to get Delta Lake history");
+    }
+
+    return history;
+}
+
+DeltaLakeHistory DeltaLakeMetadata::getHistory(ContextPtr local_context) const
+{
+    return parseDeltaLakeHistory(object_storage, table_path, local_context, getLogger("DeltaLakeMetadata"));
 }
 
 static bool isDeltaKernelEnabled(ContextPtr context, ObjectStorageType storage_type)

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.cpp
@@ -62,6 +62,7 @@ namespace ErrorCodes
 {
     extern const int INCORRECT_DATA;
     extern const int BAD_ARGUMENTS;
+    extern const int LIMIT_EXCEEDED;
     extern const int LOGICAL_ERROR;
     extern const int NOT_IMPLEMENTED;
 }
@@ -69,6 +70,7 @@ namespace ErrorCodes
 namespace Setting
 {
     extern const SettingsBool allow_experimental_delta_kernel_rs;
+    extern const SettingsUInt64 delta_lake_history_max_records;
 }
 
 
@@ -743,7 +745,7 @@ DeltaLakeHistory parseDeltaLakeHistory(
 
     static constexpr auto deltalake_metadata_directory = "_delta_log";
     static constexpr auto metadata_file_suffix = ".json";
-    static constexpr UInt64 max_history_records = 1'000'000;
+    const UInt64 max_history_records = local_context->getSettingsRef()[Setting::delta_lake_history_max_records];
 
     try
     {
@@ -770,11 +772,12 @@ DeltaLakeHistory parseDeltaLakeHistory(
         UInt64 expected_history_size = 0;
         if (checkpoint_version.has_value())
         {
-            if (*checkpoint_version >= max_history_records)
+            if (max_history_records > 0 && *checkpoint_version >= max_history_records)
             {
                 throw Exception(
-                    ErrorCodes::INCORRECT_DATA,
-                    "Refusing to materialize Delta Lake history for {}: checkpoint version {} exceeds hard cap {} records",
+                    ErrorCodes::LIMIT_EXCEEDED,
+                    "Refusing to materialize Delta Lake history for {}: checkpoint version {} exceeds limit {} "
+                    "(controlled by `delta_lake_history_max_records` setting, 0 to disable)",
                     table_path,
                     *checkpoint_version,
                     max_history_records);
@@ -784,11 +787,12 @@ DeltaLakeHistory parseDeltaLakeHistory(
             for (auto it = version_to_file.upper_bound(*checkpoint_version); it != version_to_file.end(); ++it)
             {
                 ++expected_history_size;
-                if (expected_history_size > max_history_records)
+                if (max_history_records > 0 && expected_history_size > max_history_records)
                 {
                     throw Exception(
-                        ErrorCodes::INCORRECT_DATA,
-                        "Refusing to materialize Delta Lake history for {}: expected {} records exceeds hard cap {}",
+                        ErrorCodes::LIMIT_EXCEEDED,
+                        "Refusing to materialize Delta Lake history for {}: expected {} records exceeds limit {} "
+                        "(controlled by `delta_lake_history_max_records` setting, 0 to disable)",
                         table_path,
                         expected_history_size,
                         max_history_records);
@@ -798,11 +802,12 @@ DeltaLakeHistory parseDeltaLakeHistory(
         else
         {
             expected_history_size = version_to_file.size();
-            if (expected_history_size > max_history_records)
+            if (max_history_records > 0 && expected_history_size > max_history_records)
             {
                 throw Exception(
-                    ErrorCodes::INCORRECT_DATA,
-                    "Refusing to materialize Delta Lake history for {}: discovered {} metadata versions exceeds hard cap {}",
+                    ErrorCodes::LIMIT_EXCEEDED,
+                    "Refusing to materialize Delta Lake history for {}: discovered {} metadata versions exceeds limit {} "
+                    "(controlled by `delta_lake_history_max_records` setting, 0 to disable)",
                     table_path,
                     expected_history_size,
                     max_history_records);
@@ -864,7 +869,7 @@ DeltaLakeHistory parseDeltaLakeHistory(
     }
     catch (const Exception & e)
     {
-        if (e.code() == ErrorCodes::INCORRECT_DATA)
+        if (e.code() == ErrorCodes::INCORRECT_DATA || e.code() == ErrorCodes::LIMIT_EXCEEDED)
             throw;
         tryLogCurrentException(log, "Failed to get Delta Lake history");
     }

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.cpp
@@ -639,8 +639,9 @@ static std::optional<UInt64> extractVersionFromFilename(const String & path)
     catch (const std::out_of_range &) { return std::nullopt; }
 }
 
-/// Helper: read _last_checkpoint file and return the checkpoint version (0 if none).
-static UInt64 readLastCheckpointVersion(
+/// Helper: read _last_checkpoint file and return the checkpoint version.
+/// Returns std::nullopt when no checkpoint exists or it cannot be parsed.
+static std::optional<UInt64> readLastCheckpointVersion(
     ObjectStoragePtr object_storage,
     const String & table_path,
     ContextPtr local_context,
@@ -650,7 +651,7 @@ static UInt64 readLastCheckpointVersion(
     const auto last_checkpoint_file = std::filesystem::path(table_path) / deltalake_metadata_directory / "_last_checkpoint";
 
     if (!object_storage->exists(StoredObject(last_checkpoint_file)))
-        return 0;
+        return std::nullopt;
 
     try
     {
@@ -664,7 +665,7 @@ static UInt64 readLastCheckpointVersion(
     catch (...)
     {
         tryLogCurrentException(log, "Failed to read _last_checkpoint");
-        return 0;
+        return std::nullopt;
     }
 }
 
@@ -742,47 +743,92 @@ DeltaLakeHistory parseDeltaLakeHistory(
 
     static constexpr auto deltalake_metadata_directory = "_delta_log";
     static constexpr auto metadata_file_suffix = ".json";
+    static constexpr UInt64 max_history_records = 1'000'000;
 
     try
     {
         /// Read _last_checkpoint to find checkpoint version.
         /// When a checkpoint exists, .json files for versions <= checkpoint_version
         /// may have been removed. We still need to report those versions in the history.
-        const UInt64 checkpoint_version = readLastCheckpointVersion(object_storage, table_path, local_context, log);
+        const auto checkpoint_version = readLastCheckpointVersion(object_storage, table_path, local_context, log);
 
         Strings metadata_files = listFiles(*object_storage, table_path, deltalake_metadata_directory, metadata_file_suffix);
 
         /// Build a set of versions that have .json files available
         std::map<UInt64, String> version_to_file;
-        UInt64 max_version = checkpoint_version;
         for (const auto & file : metadata_files)
         {
             if (auto version = extractVersionFromFilename(file))
-            {
                 version_to_file[*version] = file;
-                max_version = std::max(max_version, *version);
+        }
+
+        if (!checkpoint_version.has_value() && version_to_file.empty())
+            return history;
+
+        /// Delta history can have sparse, very large version numbers.
+        /// Avoid dense expansion and guard against unbounded materialization.
+        UInt64 expected_history_size = 0;
+        if (checkpoint_version.has_value())
+        {
+            if (*checkpoint_version >= max_history_records)
+            {
+                throw Exception(
+                    ErrorCodes::INCORRECT_DATA,
+                    "Refusing to materialize Delta Lake history for {}: checkpoint version {} exceeds hard cap {} records",
+                    table_path,
+                    *checkpoint_version,
+                    max_history_records);
+            }
+
+            expected_history_size = *checkpoint_version + 1;
+            for (auto it = version_to_file.upper_bound(*checkpoint_version); it != version_to_file.end(); ++it)
+            {
+                ++expected_history_size;
+                if (expected_history_size > max_history_records)
+                {
+                    throw Exception(
+                        ErrorCodes::INCORRECT_DATA,
+                        "Refusing to materialize Delta Lake history for {}: expected {} records exceeds hard cap {}",
+                        table_path,
+                        expected_history_size,
+                        max_history_records);
+                }
+            }
+        }
+        else
+        {
+            expected_history_size = version_to_file.size();
+            if (expected_history_size > max_history_records)
+            {
+                throw Exception(
+                    ErrorCodes::INCORRECT_DATA,
+                    "Refusing to materialize Delta Lake history for {}: discovered {} metadata versions exceeds hard cap {}",
+                    table_path,
+                    expected_history_size,
+                    max_history_records);
             }
         }
 
-        if (max_version == 0 && version_to_file.empty())
-            return history;
+        UInt64 latest_version = 0;
+        if (checkpoint_version.has_value())
+            latest_version = *checkpoint_version;
+        if (!version_to_file.empty())
+            latest_version = std::max(latest_version, version_to_file.rbegin()->first);
 
-        /// Iterate all versions from 0 to max_version.
-        /// For versions with .json files, parse commitInfo.
-        /// For versions without .json files (removed after checkpoint), emit a record with just the version.
-        for (UInt64 version = 0; version <= max_version; ++version)
+        history.reserve(expected_history_size);
+
+        auto append_record = [&](UInt64 version, const String * metadata_file_path)
         {
             try
             {
                 DeltaLakeHistoryRecord record;
                 record.version = version;
-                record.is_latest_version = (version == max_version);
+                record.is_latest_version = (version == latest_version);
 
-                auto it = version_to_file.find(version);
-                if (it != version_to_file.end())
+                if (metadata_file_path)
                 {
                     /// .json file exists — parse commitInfo
-                    RelativePathWithMetadata object_info(it->second);
+                    RelativePathWithMetadata object_info(*metadata_file_path);
                     auto buf = createReadBuffer(object_info, object_storage, local_context, log);
                     parseCommitInfo(*buf, record);
                 }
@@ -793,7 +839,34 @@ DeltaLakeHistory parseDeltaLakeHistory(
             {
                 tryLogCurrentException(log, fmt::format("Failed to process version {}", version));
             }
+        };
+
+        auto version_it = version_to_file.begin();
+        if (checkpoint_version.has_value())
+        {
+            /// For versions in [0, checkpoint], emit synthetic entries if .json files were compacted away.
+            for (UInt64 version = 0; version <= *checkpoint_version; ++version)
+            {
+                const String * metadata_file_path = nullptr;
+                if (version_it != version_to_file.end() && version_it->first == version)
+                {
+                    metadata_file_path = &version_it->second;
+                    ++version_it;
+                }
+                append_record(version, metadata_file_path);
+            }
         }
+
+        /// For versions above checkpoint (or all versions when there is no checkpoint),
+        /// emit only discovered metadata versions (sparse iteration).
+        for (; version_it != version_to_file.end(); ++version_it)
+            append_record(version_it->first, &version_it->second);
+    }
+    catch (const Exception & e)
+    {
+        if (e.code() == ErrorCodes::INCORRECT_DATA)
+            throw;
+        tryLogCurrentException(log, "Failed to get Delta Lake history");
     }
     catch (...)
     {

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.cpp
@@ -1,3 +1,4 @@
+#include <limits>
 #include <set>
 #include <Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.h>
 #include <Storages/ObjectStorage/Utils.h>
@@ -772,6 +773,15 @@ DeltaLakeHistory parseDeltaLakeHistory(
         UInt64 expected_history_size = 0;
         if (checkpoint_version.has_value())
         {
+            if (*checkpoint_version == std::numeric_limits<UInt64>::max())
+            {
+                throw Exception(
+                    ErrorCodes::INCORRECT_DATA,
+                    "Malformed `_last_checkpoint` for {}: version {} is not supported",
+                    table_path,
+                    *checkpoint_version);
+            }
+
             if (max_history_records > 0 && *checkpoint_version >= max_history_records)
             {
                 throw Exception(

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.cpp
@@ -852,8 +852,37 @@ DeltaLakeHistory parseDeltaLakeHistory(
 
                 history.push_back(std::move(record));
             }
+            catch (const Exception & e)
+            {
+                if (e.code() == ErrorCodes::INCORRECT_DATA || e.code() == ErrorCodes::LIMIT_EXCEEDED)
+                    throw;
+
+                if (metadata_file_path)
+                {
+                    throw Exception(
+                        ErrorCodes::INCORRECT_DATA,
+                        "Failed to parse Delta Lake metadata file {} for version {} in {}: {}",
+                        *metadata_file_path,
+                        version,
+                        table_path,
+                        getCurrentExceptionMessage(false));
+                }
+
+                tryLogCurrentException(log, fmt::format("Failed to process version {}", version));
+            }
             catch (...)
             {
+                if (metadata_file_path)
+                {
+                    throw Exception(
+                        ErrorCodes::INCORRECT_DATA,
+                        "Failed to parse Delta Lake metadata file {} for version {} in {}: {}",
+                        *metadata_file_path,
+                        version,
+                        table_path,
+                        getCurrentExceptionMessage(false));
+                }
+
                 tryLogCurrentException(log, fmt::format("Failed to process version {}", version));
             }
         };

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.cpp
@@ -643,7 +643,7 @@ static std::optional<UInt64> extractVersionFromFilename(const String & path)
 }
 
 /// Helper: read _last_checkpoint file and return the checkpoint version.
-/// Returns std::nullopt when no checkpoint exists or it cannot be parsed.
+/// Returns std::nullopt when no checkpoint exists.
 static std::optional<UInt64> readLastCheckpointVersion(
     ObjectStoragePtr object_storage,
     const String & table_path,
@@ -667,8 +667,10 @@ static std::optional<UInt64> readLastCheckpointVersion(
     }
     catch (...)
     {
-        tryLogCurrentException(log, "Failed to read _last_checkpoint");
-        return std::nullopt;
+        throw Exception(
+            ErrorCodes::INCORRECT_DATA,
+            "Failed to parse `_last_checkpoint` for {}",
+            table_path);
     }
 }
 

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.h
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.h
@@ -4,17 +4,38 @@
 
 #if USE_PARQUET
 
+#include <map>
+#include <optional>
 #include <Interpreters/Context_fwd.h>
 #include <Core/Types.h>
 #include <Storages/ColumnsDescription.h>
 #include <Storages/ObjectStorage/StorageObjectStorage.h>
 #include <Storages/ObjectStorage/DataLakes/IDataLakeMetadata.h>
-#include <Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.h>
 #include <Disks/DiskObjectStorage/ObjectStorages/IObjectStorage.h>
 #include <Poco/JSON/Object.h>
 
 namespace DB
 {
+
+/// History record for Delta Lake version tracking
+struct DeltaLakeHistoryRecord
+{
+    UInt64 version;
+    std::optional<DateTime64> timestamp;
+    String operation;
+    std::map<String, String> operation_parameters;
+    bool is_latest_version;
+};
+
+using DeltaLakeHistory = std::vector<DeltaLakeHistoryRecord>;
+
+/// Shared helper to parse Delta Lake history from metadata JSON files.
+/// Used by both DeltaLakeMetadata and DeltaLakeMetadataDeltaKernel.
+DeltaLakeHistory parseDeltaLakeHistory(
+    ObjectStoragePtr object_storage,
+    const String & table_path,
+    ContextPtr local_context,
+    LoggerPtr log);
 
 struct DeltaLakePartitionColumn
 {
@@ -39,6 +60,9 @@ public:
     NamesAndTypesList getTableSchema(ContextPtr /*local_context*/) const override { return schema; }
 
     DeltaLakePartitionColumns getPartitionColumns() const { return partition_columns; }
+
+    /// Get history of Delta Lake table versions
+    DeltaLakeHistory getHistory(ContextPtr local_context) const;
 
     bool operator==(const IDataLakeMetadata & other) const override
     {
@@ -88,6 +112,7 @@ private:
     NamesAndTypesList schema;
     DeltaLakePartitionColumns partition_columns;
     ObjectStoragePtr object_storage;
+    String table_path;
 
     Strings getDataFiles(const ActionsDAG *) const { return data_files; }
 };

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.cpp
@@ -23,7 +23,6 @@
 #include <Common/FailPoint.h>
 #include <Storages/ObjectStorage/Utils.h>
 #include <Interpreters/DeltaMetadataLog.h>
-#include <IO/ReadHelpers.h>
 
 namespace CurrentMetrics
 {

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.cpp
@@ -23,6 +23,7 @@
 #include <Common/FailPoint.h>
 #include <Storages/ObjectStorage/Utils.h>
 #include <Interpreters/DeltaMetadataLog.h>
+#include <IO/ReadHelpers.h>
 
 namespace CurrentMetrics
 {
@@ -678,6 +679,11 @@ void DeltaLakeMetadataDeltaKernel::logMetadataFiles(ContextPtr context) const
 std::string DeltaLakeMetadataDeltaKernel::latestSnapshotVersionToStr() const
 {
     return latest_snapshot_version.has_value() ? toString(latest_snapshot_version.value()) : "Unknown";
+}
+
+DeltaLakeHistory DeltaLakeMetadataDeltaKernel::getHistory(ContextPtr local_context) const
+{
+    return parseDeltaLakeHistory(object_storage_common, kernel_helper->getDataPath(), local_context, log);
 }
 
 }

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.cpp
@@ -683,7 +683,7 @@ std::string DeltaLakeMetadataDeltaKernel::latestSnapshotVersionToStr() const
 
 DeltaLakeHistory DeltaLakeMetadataDeltaKernel::getHistory(ContextPtr local_context) const
 {
-    return parseDeltaLakeHistory(object_storage_common, kernel_helper->getDataPath(), local_context, log);
+    return parseDeltaLakeHistory(object_storage, kernel_helper->getDataPath(), local_context, log);
 }
 
 }

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.h
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.h
@@ -23,6 +23,8 @@ using TableChangesPtr = std::shared_ptr<TableChanges>;
 using TableChangesVersionRange = std::pair<size_t, std::optional<size_t>>;
 }
 
+#include <Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.h>
+
 namespace DB
 {
 
@@ -80,6 +82,8 @@ public:
         StorageMetadataPtr storage_metadata_snapshot,
 
         ContextPtr context) const override;
+
+    DeltaLakeHistory getHistory(ContextPtr local_context) const;
 
     DeltaLake::KernelHelperPtr getKernelHelper() const { return kernel_helper; }
 

--- a/src/Storages/System/StorageSystemDeltaLakeHistory.cpp
+++ b/src/Storages/System/StorageSystemDeltaLakeHistory.cpp
@@ -176,12 +176,13 @@ private:
                 }
                 catch (...)
                 {
-                    tryLogCurrentException(
+                    /// Broken external Delta tables are expected during broad system-table scans.
+                    /// Keep this at debug level to avoid polluting stderr in stateless tests.
+                    LOG_DEBUG(
                         getLogger("SystemDeltaLakeHistory"),
-                        fmt::format(
-                            "Ignoring broken table {}: {}",
-                            object_storage_table->getStorageID().getFullTableName(),
-                            getCurrentExceptionMessage(false)));
+                        "Ignoring broken table {}: {}",
+                        object_storage_table->getStorageID().getFullTableName(),
+                        getCurrentExceptionMessage(false));
                 }
             }
 

--- a/src/Storages/System/StorageSystemDeltaLakeHistory.cpp
+++ b/src/Storages/System/StorageSystemDeltaLakeHistory.cpp
@@ -53,10 +53,8 @@ public:
         context_copy = Context::createCopy(context_);
         access = context_copy->getAccess();
         if (access->isGranted(AccessType::SHOW_TABLES))
-        {
             databases = DatabaseCatalog::instance().getDatabases(GetDatabasesOptions{.with_datalake_catalogs = true});
-            db_it = databases.begin();
-        }
+        db_it = databases.begin();
 #endif
     }
 

--- a/src/Storages/System/StorageSystemDeltaLakeHistory.cpp
+++ b/src/Storages/System/StorageSystemDeltaLakeHistory.cpp
@@ -197,7 +197,7 @@ private:
 
 #if USE_PARQUET
     ContextMutablePtr context_copy;
-    std::shared_ptr<const ContextAccess> access;
+    std::shared_ptr<const ContextAccessWrapper> access;
     DatabaseCatalog::Databases databases;
     DatabaseCatalog::Databases::iterator db_it;
     DatabaseTablesIteratorPtr table_it;

--- a/src/Storages/System/StorageSystemDeltaLakeHistory.cpp
+++ b/src/Storages/System/StorageSystemDeltaLakeHistory.cpp
@@ -236,7 +236,7 @@ public:
     {
         auto source = std::make_shared<SystemDeltaLakeHistorySource>(getOutputHeader(), max_block_size, context);
         source->setStorageLimits(storage_limits);
-        processors.emplace_back(source);
+        processors.push_back(source);
         pipeline.init(Pipe(std::move(source)));
     }
 

--- a/src/Storages/System/StorageSystemDeltaLakeHistory.cpp
+++ b/src/Storages/System/StorageSystemDeltaLakeHistory.cpp
@@ -198,8 +198,8 @@ private:
 #if USE_PARQUET
     ContextMutablePtr context_copy;
     std::shared_ptr<const ContextAccessWrapper> access;
-    DatabaseCatalog::Databases databases;
-    DatabaseCatalog::Databases::iterator db_it;
+    Databases databases;
+    Databases::iterator db_it;
     DatabaseTablesIteratorPtr table_it;
 
     String current_database;

--- a/src/Storages/System/StorageSystemDeltaLakeHistory.cpp
+++ b/src/Storages/System/StorageSystemDeltaLakeHistory.cpp
@@ -193,7 +193,7 @@ private:
     }
 #endif
 
-    const UInt64 max_block_size;
+    [[maybe_unused]] const UInt64 max_block_size;
 
 #if USE_PARQUET
     ContextMutablePtr context_copy;

--- a/src/Storages/System/StorageSystemDeltaLakeHistory.cpp
+++ b/src/Storages/System/StorageSystemDeltaLakeHistory.cpp
@@ -1,8 +1,5 @@
-#include <mutex>
 #include <Access/ContextAccess.h>
 #include <Core/Settings.h>
-#include <DataTypes/DataTypeDate.h>
-#include <DataTypes/DataTypeDateTime.h>
 #include <DataTypes/DataTypeDateTime64.h>
 #include <DataTypes/DataTypeMap.h>
 #include <DataTypes/DataTypeNullable.h>
@@ -10,8 +7,10 @@
 #include <DataTypes/DataTypesNumber.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/DatabaseCatalog.h>
-#include <Interpreters/InterpreterSelectQuery.h>
-#include <Storages/ObjectStorage/DataLakes/DataLakeConfiguration.h>
+#include <Processors/ISource.h>
+#include <Processors/QueryPlan/QueryPlan.h>
+#include <Processors/QueryPlan/SourceStepWithFilter.h>
+#include <QueryPipeline/QueryPipelineBuilder.h>
 #include <Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.h>
 #include <Storages/ObjectStorage/StorageObjectStorage.h>
 #include <Storages/SelectQueryInfo.h>
@@ -35,9 +34,226 @@ namespace Setting
 extern const SettingsSeconds lock_acquire_timeout;
 }
 
-ColumnsDescription StorageSystemDeltaLakeHistory::getColumnsDescription()
+namespace
 {
-    return ColumnsDescription{
+
+/// Streaming source that iterates Delta Lake tables and produces history records in chunks.
+class SystemDeltaLakeHistorySource : public ISource, private WithContext
+{
+public:
+    SystemDeltaLakeHistorySource(
+        SharedHeader header_,
+        UInt64 max_block_size_,
+        ContextPtr context_)
+        : ISource(header_)
+        , WithContext(context_)
+        , max_block_size(max_block_size_)
+    {
+#if USE_PARQUET
+        context_copy = Context::createCopy(context_);
+        access = context_copy->getAccess();
+        if (access->isGranted(AccessType::SHOW_TABLES))
+        {
+            databases = DatabaseCatalog::instance().getDatabases(GetDatabasesOptions{.with_datalake_catalogs = true});
+            db_it = databases.begin();
+        }
+#endif
+    }
+
+    String getName() const override { return "SystemDeltaLakeHistorySource"; }
+
+protected:
+    Chunk generate() override
+    {
+#if USE_PARQUET
+        auto header = getPort().getHeader();
+        MutableColumns res_columns = header.cloneEmptyColumns();
+
+        size_t num_rows = 0;
+
+        while (true)
+        {
+            /// If we have buffered history records from the current table, emit them
+            while (current_history_idx < current_history.size())
+            {
+                if (num_rows && max_block_size && num_rows >= max_block_size)
+                    goto done;
+
+                auto & record = current_history[current_history_idx++];
+
+                size_t col = 0;
+                res_columns[col++]->insert(current_database);
+                res_columns[col++]->insert(current_table);
+                res_columns[col++]->insert(record.version);
+
+                if (record.timestamp.has_value())
+                    res_columns[col++]->insert(record.timestamp.value());
+                else
+                    res_columns[col++]->insertDefault();
+
+                res_columns[col++]->insert(record.operation);
+
+                Map params_map;
+                for (const auto & [key, value] : record.operation_parameters)
+                {
+                    Tuple tuple;
+                    tuple.push_back(key);
+                    tuple.push_back(value);
+                    params_map.push_back(std::move(tuple));
+                }
+                res_columns[col++]->insert(params_map);
+
+                res_columns[col++]->insert(record.is_latest_version ? 1 : 0);
+                ++num_rows;
+            }
+
+            /// Need to fetch history for the next table
+            if (!advanceToNextTable())
+                break;
+        }
+
+done:
+        if (!num_rows)
+            return {};
+
+        return Chunk(std::move(res_columns), num_rows);
+#else
+        return {};
+#endif
+    }
+
+private:
+#if USE_PARQUET
+    /// Advance the database/table iterator to the next Delta Lake table and load its history.
+    /// Returns true if a table with history was found, false if iteration is exhausted.
+    bool advanceToNextTable()
+    {
+        while (db_it != databases.end())
+        {
+            if (!table_it)
+                table_it = db_it->second->getLightweightTablesIterator(context_copy, {}, true);
+
+            while (table_it->isValid())
+            {
+                StoragePtr storage = table_it->table();
+                String db_name = table_it->databaseName();
+                String tbl_name = table_it->name();
+                table_it->next();
+
+                if (!access->isGranted(AccessType::SHOW_TABLES, db_name, tbl_name))
+                    continue;
+
+                TableLockHolder lock = storage->tryLockForShare(
+                    context_copy->getCurrentQueryId(), context_copy->getSettingsRef()[Setting::lock_acquire_timeout]);
+                if (!lock)
+                    continue;
+
+                auto * object_storage_table = dynamic_cast<StorageObjectStorage *>(storage.get());
+                if (!object_storage_table)
+                    continue;
+
+                try
+                {
+                    IDataLakeMetadata * data_lake_metadata = object_storage_table->getExternalMetadata(context_copy);
+                    DeltaLakeHistory history;
+
+#if USE_DELTA_KERNEL_RS
+                    if (auto * delta_kernel_metadata = dynamic_cast<DeltaLakeMetadataDeltaKernel *>(data_lake_metadata))
+                        history = delta_kernel_metadata->getHistory(context_copy);
+                    else if (auto * delta_metadata = dynamic_cast<DeltaLakeMetadata *>(data_lake_metadata))
+                        history = delta_metadata->getHistory(context_copy);
+#else
+                    if (auto * delta_metadata = dynamic_cast<DeltaLakeMetadata *>(data_lake_metadata))
+                        history = delta_metadata->getHistory(context_copy);
+#endif
+
+                    if (history.empty())
+                        continue;
+
+                    current_database = std::move(db_name);
+                    current_table = std::move(tbl_name);
+                    current_history = std::move(history);
+                    current_history_idx = 0;
+                    return true;
+                }
+                catch (...)
+                {
+                    tryLogCurrentException(
+                        getLogger("SystemDeltaLakeHistory"),
+                        fmt::format(
+                            "Ignoring broken table {}: {}",
+                            object_storage_table->getStorageID().getFullTableName(),
+                            getCurrentExceptionMessage(false)));
+                }
+            }
+
+            table_it = nullptr;
+            ++db_it;
+        }
+
+        return false;
+    }
+#endif
+
+    const UInt64 max_block_size;
+
+#if USE_PARQUET
+    ContextMutablePtr context_copy;
+    std::shared_ptr<const ContextAccess> access;
+    DatabaseCatalog::Databases databases;
+    DatabaseCatalog::Databases::iterator db_it;
+    DatabaseTablesIteratorPtr table_it;
+
+    String current_database;
+    String current_table;
+    DeltaLakeHistory current_history;
+    size_t current_history_idx = 0;
+#endif
+};
+
+class ReadFromSystemDeltaLakeHistory final : public SourceStepWithFilter
+{
+public:
+    ReadFromSystemDeltaLakeHistory(
+        const Names & column_names_,
+        const SelectQueryInfo & query_info_,
+        const StorageSnapshotPtr & storage_snapshot_,
+        const ContextPtr & context_,
+        const Block & header,
+        UInt64 max_block_size_)
+        : SourceStepWithFilter(
+            std::make_shared<const Block>(header),
+            column_names_,
+            query_info_,
+            storage_snapshot_,
+            context_)
+        , storage_limits(query_info.storage_limits)
+        , max_block_size(max_block_size_)
+    {
+    }
+
+    String getName() const override { return "ReadFromSystemDeltaLakeHistory"; }
+
+    void initializePipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings &) override
+    {
+        auto source = std::make_shared<SystemDeltaLakeHistorySource>(getOutputHeader(), max_block_size, context);
+        source->setStorageLimits(storage_limits);
+        processors.emplace_back(source);
+        pipeline.init(Pipe(std::move(source)));
+    }
+
+private:
+    std::shared_ptr<const StorageLimitsList> storage_limits;
+    const UInt64 max_block_size;
+};
+
+}
+
+StorageSystemDeltaLakeHistory::StorageSystemDeltaLakeHistory(const StorageID & table_id_)
+    : IStorage(table_id_)
+{
+    StorageInMemoryMetadata storage_metadata;
+    storage_metadata.setColumns(ColumnsDescription{
         {"database", std::make_shared<DataTypeString>(), "Database name."},
         {"table", std::make_shared<DataTypeString>(), "Table name."},
         {"version", std::make_shared<DataTypeUInt64>(), "Version number of the Delta Lake table."},
@@ -48,106 +264,30 @@ ColumnsDescription StorageSystemDeltaLakeHistory::getColumnsDescription()
         {"operation_parameters",
          std::make_shared<DataTypeMap>(std::make_shared<DataTypeString>(), std::make_shared<DataTypeString>()),
          "Parameters of the operation."},
-        {"is_latest_version", std::make_shared<DataTypeUInt8>(), "Flag indicating if this is the latest version."}};
+        {"is_latest_version", std::make_shared<DataTypeUInt8>(), "Flag indicating if this is the latest version."}});
+    setInMemoryMetadata(storage_metadata);
 }
 
-void StorageSystemDeltaLakeHistory::fillData(
-    [[maybe_unused]] MutableColumns & res_columns, [[maybe_unused]] ContextPtr context, const ActionsDAG::Node *, std::vector<UInt8>) const
+void StorageSystemDeltaLakeHistory::read(
+    QueryPlan & query_plan,
+    const Names & column_names,
+    const StorageSnapshotPtr & storage_snapshot,
+    SelectQueryInfo & query_info,
+    ContextPtr context,
+    QueryProcessingStage::Enum /*processed_stage*/,
+    const size_t max_block_size,
+    const size_t /*num_streams*/)
 {
-#if USE_PARQUET
-    ContextMutablePtr context_copy = Context::createCopy(context);
-
-    const auto access = context_copy->getAccess();
-
-    auto add_history_record = [&](const DatabaseTablesIteratorPtr & it, StorageObjectStorage * object_storage)
-    {
-        if (!access->isGranted(AccessType::SHOW_TABLES, it->databaseName(), it->name()))
-            return;
-
-        /// Unfortunately this try/catch is unavoidable. Delta Lake tables can be broken in various ways:
-        /// missing/corrupt _delta_log files, invalid JSON in commit files, inaccessible object storage, etc.
-        /// It's impossible to handle properly all possible errors when reading metadata
-        try
-        {
-            IDataLakeMetadata * data_lake_metadata = object_storage->getExternalMetadata(context_copy);
-            DeltaLakeHistory delta_history_items;
-
-#if USE_DELTA_KERNEL_RS
-            if (auto * delta_kernel_metadata = dynamic_cast<DeltaLakeMetadataDeltaKernel *>(data_lake_metadata))
-                delta_history_items = delta_kernel_metadata->getHistory(context_copy);
-            else if (auto * delta_metadata = dynamic_cast<DeltaLakeMetadata *>(data_lake_metadata))
-                delta_history_items = delta_metadata->getHistory(context_copy);
-#else
-            if (auto * delta_metadata = dynamic_cast<DeltaLakeMetadata *>(data_lake_metadata))
-                delta_history_items = delta_metadata->getHistory(context_copy);
-#endif
-
-            if (delta_history_items.empty())
-                return;
-
-            for (auto & delta_history_item : delta_history_items)
-            {
-                size_t column_index = 0;
-                res_columns[column_index++]->insert(it->databaseName());
-                res_columns[column_index++]->insert(it->name());
-                res_columns[column_index++]->insert(delta_history_item.version);
-
-                if (delta_history_item.timestamp.has_value())
-                    res_columns[column_index++]->insert(delta_history_item.timestamp.value());
-                else
-                    res_columns[column_index++]->insertDefault();
-
-                res_columns[column_index++]->insert(delta_history_item.operation);
-
-                /// Insert operation_parameters as Map
-                Map params_map;
-                for (const auto & [key, value] : delta_history_item.operation_parameters)
-                {
-                    Tuple tuple;
-                    tuple.push_back(key);
-                    tuple.push_back(value);
-                    params_map.push_back(std::move(tuple));
-                }
-                res_columns[column_index++]->insert(params_map);
-
-                res_columns[column_index++]->insert(delta_history_item.is_latest_version ? 1 : 0);
-            }
-        }
-        catch (...)
-        {
-            tryLogCurrentException(
-                getLogger("SystemDeltaLakeHistory"),
-                fmt::format(
-                    "Ignoring broken table {}: {}", object_storage->getStorageID().getFullTableName(), getCurrentExceptionMessage(false)));
-        }
-    };
-
-    const bool show_tables_granted = access->isGranted(AccessType::SHOW_TABLES);
-
-    if (show_tables_granted)
-    {
-        auto databases = DatabaseCatalog::instance().getDatabases(GetDatabasesOptions{.with_datalake_catalogs = true});
-        for (const auto & db : databases)
-        {
-            /// with last flag we are filtering out all non delta lake tables
-            for (auto iterator = db.second->getLightweightTablesIterator(context_copy, {}, true); iterator->isValid(); iterator->next())
-            {
-                StoragePtr storage = iterator->table();
-
-                TableLockHolder lock = storage->tryLockForShare(
-                    context_copy->getCurrentQueryId(), context_copy->getSettingsRef()[Setting::lock_acquire_timeout]);
-                if (!lock)
-                    /// Table was dropped while acquiring the lock, skipping table
-                    continue;
-
-                if (auto * object_storage_table = dynamic_cast<StorageObjectStorage *>(storage.get()))
-                {
-                    add_history_record(iterator, object_storage_table);
-                }
-            }
-        }
-    }
-#endif
+    storage_snapshot->check(column_names);
+    auto header = storage_snapshot->metadata->getSampleBlockWithVirtuals(getVirtualsList());
+    auto read_step = std::make_unique<ReadFromSystemDeltaLakeHistory>(
+        column_names,
+        query_info,
+        storage_snapshot,
+        context,
+        header,
+        max_block_size);
+    query_plan.addStep(std::move(read_step));
 }
 
 }

--- a/src/Storages/System/StorageSystemDeltaLakeHistory.cpp
+++ b/src/Storages/System/StorageSystemDeltaLakeHistory.cpp
@@ -129,7 +129,7 @@ private:
         while (db_it != databases.end())
         {
             if (!table_it)
-                table_it = db_it->second->getLightweightTablesIterator(context_copy, {}, true);
+                table_it = db_it->second->getTablesIterator(context_copy, {}, true);
 
             while (table_it->isValid())
             {

--- a/src/Storages/System/StorageSystemDeltaLakeHistory.cpp
+++ b/src/Storages/System/StorageSystemDeltaLakeHistory.cpp
@@ -1,0 +1,153 @@
+#include <mutex>
+#include <Access/ContextAccess.h>
+#include <Core/Settings.h>
+#include <DataTypes/DataTypeDate.h>
+#include <DataTypes/DataTypeDateTime.h>
+#include <DataTypes/DataTypeDateTime64.h>
+#include <DataTypes/DataTypeMap.h>
+#include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypeString.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <Interpreters/Context.h>
+#include <Interpreters/DatabaseCatalog.h>
+#include <Interpreters/InterpreterSelectQuery.h>
+#include <Storages/ObjectStorage/DataLakes/DataLakeConfiguration.h>
+#include <Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.h>
+#include <Storages/ObjectStorage/StorageObjectStorage.h>
+#include <Storages/SelectQueryInfo.h>
+#include <Storages/System/StorageSystemDeltaLakeHistory.h>
+#include <Common/logger_useful.h>
+
+#include "config.h"
+
+#if USE_DELTA_KERNEL_RS
+#include <Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.h>
+#endif
+
+/// Delta Lake timestamps are stored in milliseconds
+static constexpr auto TIME_SCALE = 3;
+
+namespace DB
+{
+
+namespace Setting
+{
+extern const SettingsSeconds lock_acquire_timeout;
+}
+
+ColumnsDescription StorageSystemDeltaLakeHistory::getColumnsDescription()
+{
+    return ColumnsDescription{
+        {"database", std::make_shared<DataTypeString>(), "Database name."},
+        {"table", std::make_shared<DataTypeString>(), "Table name."},
+        {"version", std::make_shared<DataTypeUInt64>(), "Version number of the Delta Lake table."},
+        {"timestamp",
+         std::make_shared<DataTypeNullable>(std::make_shared<DataTypeDateTime64>(TIME_SCALE)),
+         "Timestamp when this version was committed."},
+        {"operation", std::make_shared<DataTypeString>(), "Operation type (e.g., WRITE, DELETE, MERGE)."},
+        {"operation_parameters",
+         std::make_shared<DataTypeMap>(std::make_shared<DataTypeString>(), std::make_shared<DataTypeString>()),
+         "Parameters of the operation."},
+        {"is_latest_version", std::make_shared<DataTypeUInt8>(), "Flag indicating if this is the latest version."}};
+}
+
+void StorageSystemDeltaLakeHistory::fillData(
+    [[maybe_unused]] MutableColumns & res_columns, [[maybe_unused]] ContextPtr context, const ActionsDAG::Node *, std::vector<UInt8>) const
+{
+#if USE_PARQUET
+    ContextMutablePtr context_copy = Context::createCopy(context);
+
+    const auto access = context_copy->getAccess();
+
+    auto add_history_record = [&](const DatabaseTablesIteratorPtr & it, StorageObjectStorage * object_storage)
+    {
+        if (!access->isGranted(AccessType::SHOW_TABLES, it->databaseName(), it->name()))
+            return;
+
+        /// Unfortunately this try/catch is unavoidable. Delta Lake tables can be broken in various ways:
+        /// missing/corrupt _delta_log files, invalid JSON in commit files, inaccessible object storage, etc.
+        /// It's impossible to handle properly all possible errors when reading metadata
+        try
+        {
+            IDataLakeMetadata * data_lake_metadata = object_storage->getExternalMetadata(context_copy);
+            DeltaLakeHistory delta_history_items;
+
+#if USE_DELTA_KERNEL_RS
+            if (auto * delta_kernel_metadata = dynamic_cast<DeltaLakeMetadataDeltaKernel *>(data_lake_metadata))
+                delta_history_items = delta_kernel_metadata->getHistory(context_copy);
+            else if (auto * delta_metadata = dynamic_cast<DeltaLakeMetadata *>(data_lake_metadata))
+                delta_history_items = delta_metadata->getHistory(context_copy);
+#else
+            if (auto * delta_metadata = dynamic_cast<DeltaLakeMetadata *>(data_lake_metadata))
+                delta_history_items = delta_metadata->getHistory(context_copy);
+#endif
+
+            if (delta_history_items.empty())
+                return;
+
+            for (auto & delta_history_item : delta_history_items)
+            {
+                size_t column_index = 0;
+                res_columns[column_index++]->insert(it->databaseName());
+                res_columns[column_index++]->insert(it->name());
+                res_columns[column_index++]->insert(delta_history_item.version);
+
+                if (delta_history_item.timestamp.has_value())
+                    res_columns[column_index++]->insert(delta_history_item.timestamp.value());
+                else
+                    res_columns[column_index++]->insertDefault();
+
+                res_columns[column_index++]->insert(delta_history_item.operation);
+
+                /// Insert operation_parameters as Map
+                Map params_map;
+                for (const auto & [key, value] : delta_history_item.operation_parameters)
+                {
+                    Tuple tuple;
+                    tuple.push_back(key);
+                    tuple.push_back(value);
+                    params_map.push_back(std::move(tuple));
+                }
+                res_columns[column_index++]->insert(params_map);
+
+                res_columns[column_index++]->insert(delta_history_item.is_latest_version ? 1 : 0);
+            }
+        }
+        catch (...)
+        {
+            tryLogCurrentException(
+                getLogger("SystemDeltaLakeHistory"),
+                fmt::format(
+                    "Ignoring broken table {}: {}", object_storage->getStorageID().getFullTableName(), getCurrentExceptionMessage(false)));
+        }
+    };
+
+    const bool show_tables_granted = access->isGranted(AccessType::SHOW_TABLES);
+
+    if (show_tables_granted)
+    {
+        auto databases = DatabaseCatalog::instance().getDatabases(GetDatabasesOptions{.with_datalake_catalogs = true});
+        for (const auto & db : databases)
+        {
+            /// with last flag we are filtering out all non delta lake tables
+            for (auto iterator = db.second->getLightweightTablesIterator(context_copy, {}, true); iterator->isValid(); iterator->next())
+            {
+                StoragePtr storage = iterator->table();
+
+                TableLockHolder lock = storage->tryLockForShare(
+                    context_copy->getCurrentQueryId(), context_copy->getSettingsRef()[Setting::lock_acquire_timeout]);
+                if (!lock)
+                    /// Table was dropped while acquiring the lock, skipping table
+                    continue;
+
+                if (auto * object_storage_table = dynamic_cast<StorageObjectStorage *>(storage.get()))
+                {
+                    add_history_record(iterator, object_storage_table);
+                }
+            }
+        }
+    }
+#endif
+}
+
+}

--- a/src/Storages/System/StorageSystemDeltaLakeHistory.cpp
+++ b/src/Storages/System/StorageSystemDeltaLakeHistory.cpp
@@ -35,11 +35,6 @@ namespace Setting
 extern const SettingsSeconds lock_acquire_timeout;
 }
 
-namespace ErrorCodes
-{
-extern const int LIMIT_EXCEEDED;
-}
-
 namespace
 {
 
@@ -182,16 +177,14 @@ private:
                 }
                 catch (...)
                 {
-                    /// Propagate history materialization guard errors instead of silently skipping:
-                    /// this is a deliberate safety limit, not a malformed-table parsing issue.
-                    if (getCurrentExceptionCode() == ErrorCodes::LIMIT_EXCEEDED)
-                        throw;
-
-                    /// Broken external Delta tables are expected during broad system-table scans.
-                    /// Keep this at debug level to avoid polluting stderr in stateless tests.
-                    LOG_DEBUG(
+                    /// System-table filters (WHERE database/table = ...) are applied
+                    /// *after* row generation, so rethrowing here would let one
+                    /// oversized unrelated table break queries targeting healthy tables.
+                    /// Log and skip instead; users can raise
+                    /// `delta_lake_history_max_records` for specific tables.
+                    LOG_WARNING(
                         getLogger("SystemDeltaLakeHistory"),
-                        "Ignoring broken table {}: {}",
+                        "Skipping table {}: {}",
                         object_storage_table->getStorageID().getFullTableName(),
                         getCurrentExceptionMessage(false));
                 }

--- a/src/Storages/System/StorageSystemDeltaLakeHistory.cpp
+++ b/src/Storages/System/StorageSystemDeltaLakeHistory.cpp
@@ -15,6 +15,7 @@
 #include <Storages/ObjectStorage/StorageObjectStorage.h>
 #include <Storages/SelectQueryInfo.h>
 #include <Storages/System/StorageSystemDeltaLakeHistory.h>
+#include <Common/Exception.h>
 #include <Common/logger_useful.h>
 
 #include "config.h"
@@ -32,6 +33,11 @@ namespace DB
 namespace Setting
 {
 extern const SettingsSeconds lock_acquire_timeout;
+}
+
+namespace ErrorCodes
+{
+extern const int INCORRECT_DATA;
 }
 
 namespace
@@ -176,13 +182,22 @@ private:
                 }
                 catch (...)
                 {
+                    const auto exception_code = getCurrentExceptionCode();
+                    const auto exception_message = getCurrentExceptionMessage(false);
+
+                    /// Propagate history materialization guard errors instead of silently skipping:
+                    /// this is a deliberate safety limit, not a malformed-table parsing issue.
+                    if (exception_code == ErrorCodes::INCORRECT_DATA
+                        && exception_message.find("Refusing to materialize Delta Lake history") != String::npos)
+                        throw;
+
                     /// Broken external Delta tables are expected during broad system-table scans.
                     /// Keep this at debug level to avoid polluting stderr in stateless tests.
                     LOG_DEBUG(
                         getLogger("SystemDeltaLakeHistory"),
                         "Ignoring broken table {}: {}",
                         object_storage_table->getStorageID().getFullTableName(),
-                        getCurrentExceptionMessage(false));
+                        exception_message);
                 }
             }
 

--- a/src/Storages/System/StorageSystemDeltaLakeHistory.cpp
+++ b/src/Storages/System/StorageSystemDeltaLakeHistory.cpp
@@ -43,6 +43,7 @@ extern const SettingsSeconds lock_acquire_timeout;
 namespace ErrorCodes
 {
 extern const int LIMIT_EXCEEDED;
+extern const int INCORRECT_DATA;
 }
 
 namespace
@@ -193,8 +194,10 @@ private:
                     /// *after* row generation, so rethrowing here would let one
                     /// oversized unrelated table break queries targeting healthy tables.
                     /// If the query explicitly requested this table, rethrow
-                    /// `LIMIT_EXCEEDED`; otherwise log and skip.
-                    if (getCurrentExceptionCode() == ErrorCodes::LIMIT_EXCEEDED
+                    /// exceptions that indicate malformed/too-large metadata;
+                    /// otherwise log and skip.
+                    const int code = getCurrentExceptionCode();
+                    if ((code == ErrorCodes::LIMIT_EXCEEDED || code == ErrorCodes::INCORRECT_DATA)
                         && isExplicitlyRequestedTable(db_name, tbl_name))
                         throw;
 

--- a/src/Storages/System/StorageSystemDeltaLakeHistory.cpp
+++ b/src/Storages/System/StorageSystemDeltaLakeHistory.cpp
@@ -37,7 +37,7 @@ extern const SettingsSeconds lock_acquire_timeout;
 
 namespace ErrorCodes
 {
-extern const int INCORRECT_DATA;
+extern const int LIMIT_EXCEEDED;
 }
 
 namespace
@@ -182,13 +182,9 @@ private:
                 }
                 catch (...)
                 {
-                    const auto exception_code = getCurrentExceptionCode();
-                    const auto exception_message = getCurrentExceptionMessage(false);
-
                     /// Propagate history materialization guard errors instead of silently skipping:
                     /// this is a deliberate safety limit, not a malformed-table parsing issue.
-                    if (exception_code == ErrorCodes::INCORRECT_DATA
-                        && exception_message.find("Refusing to materialize Delta Lake history") != String::npos)
+                    if (getCurrentExceptionCode() == ErrorCodes::LIMIT_EXCEEDED)
                         throw;
 
                     /// Broken external Delta tables are expected during broad system-table scans.
@@ -197,7 +193,7 @@ private:
                         getLogger("SystemDeltaLakeHistory"),
                         "Ignoring broken table {}: {}",
                         object_storage_table->getStorageID().getFullTableName(),
-                        exception_message);
+                        getCurrentExceptionMessage(false));
                 }
             }
 

--- a/src/Storages/System/StorageSystemDeltaLakeHistory.cpp
+++ b/src/Storages/System/StorageSystemDeltaLakeHistory.cpp
@@ -1,4 +1,6 @@
 #include <Access/ContextAccess.h>
+#include <Columns/ColumnString.h>
+#include <Core/Block.h>
 #include <Core/Settings.h>
 #include <DataTypes/DataTypeDateTime64.h>
 #include <DataTypes/DataTypeMap.h>
@@ -15,10 +17,13 @@
 #include <Storages/ObjectStorage/StorageObjectStorage.h>
 #include <Storages/SelectQueryInfo.h>
 #include <Storages/System/StorageSystemDeltaLakeHistory.h>
+#include <Storages/VirtualColumnUtils.h>
 #include <Common/Exception.h>
 #include <Common/logger_useful.h>
 
 #include "config.h"
+
+#include <optional>
 
 #if USE_DELTA_KERNEL_RS
 #include <Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.h>
@@ -35,6 +40,11 @@ namespace Setting
 extern const SettingsSeconds lock_acquire_timeout;
 }
 
+namespace ErrorCodes
+{
+extern const int LIMIT_EXCEEDED;
+}
+
 namespace
 {
 
@@ -45,10 +55,12 @@ public:
     SystemDeltaLakeHistorySource(
         SharedHeader header_,
         UInt64 max_block_size_,
-        ContextPtr context_)
+        ContextPtr context_,
+        std::optional<ActionsDAG> explicit_database_table_filter_)
         : ISource(header_)
         , WithContext(context_)
         , max_block_size(max_block_size_)
+        , explicit_database_table_filter(std::move(explicit_database_table_filter_))
     {
 #if USE_PARQUET
         context_copy = Context::createCopy(context_);
@@ -180,8 +192,12 @@ private:
                     /// System-table filters (WHERE database/table = ...) are applied
                     /// *after* row generation, so rethrowing here would let one
                     /// oversized unrelated table break queries targeting healthy tables.
-                    /// Log and skip instead; users can raise
-                    /// `delta_lake_history_max_records` for specific tables.
+                    /// If the query explicitly requested this table, rethrow
+                    /// `LIMIT_EXCEEDED`; otherwise log and skip.
+                    if (getCurrentExceptionCode() == ErrorCodes::LIMIT_EXCEEDED
+                        && isExplicitlyRequestedTable(db_name, tbl_name))
+                        throw;
+
                     LOG_WARNING(
                         getLogger("SystemDeltaLakeHistory"),
                         "Skipping table {}: {}",
@@ -195,6 +211,24 @@ private:
         }
 
         return false;
+    }
+
+    bool isExplicitlyRequestedTable(const String & database_name, const String & table_name) const
+    {
+        if (!explicit_database_table_filter)
+            return false;
+
+        Block block;
+        auto database_column = ColumnString::create();
+        auto table_column = ColumnString::create();
+        database_column->insert(database_name);
+        table_column->insert(table_name);
+
+        block.insert(ColumnWithTypeAndName(std::move(database_column), std::make_shared<DataTypeString>(), "database"));
+        block.insert(ColumnWithTypeAndName(std::move(table_column), std::make_shared<DataTypeString>(), "table"));
+
+        VirtualColumnUtils::filterBlockWithPredicate(explicit_database_table_filter->getOutputs().at(0), block, context_copy);
+        return block.rows() > 0;
     }
 #endif
 
@@ -212,6 +246,8 @@ private:
     DeltaLakeHistory current_history;
     size_t current_history_idx = 0;
 #endif
+
+    std::optional<ActionsDAG> explicit_database_table_filter;
 };
 
 class ReadFromSystemDeltaLakeHistory final : public SourceStepWithFilter
@@ -237,9 +273,49 @@ public:
 
     String getName() const override { return "ReadFromSystemDeltaLakeHistory"; }
 
+    void applyFilters(ActionDAGNodes added_filter_nodes) override
+    {
+        SourceStepWithFilter::applyFilters(std::move(added_filter_nodes));
+
+        if (!filter_actions_dag)
+            return;
+
+        Block block_to_filter;
+        block_to_filter.insert(ColumnWithTypeAndName(ColumnString::create(), std::make_shared<DataTypeString>(), "database"));
+        block_to_filter.insert(ColumnWithTypeAndName(ColumnString::create(), std::make_shared<DataTypeString>(), "table"));
+
+        auto filter = VirtualColumnUtils::splitFilterDagForAllowedInputs(
+            filter_actions_dag->getOutputs().at(0),
+            &block_to_filter,
+            context);
+
+        if (!filter)
+            return;
+
+        bool has_database_or_table_filter = false;
+        for (const auto * input : filter->getInputs())
+        {
+            if (input->result_name == "database" || input->result_name == "table")
+            {
+                has_database_or_table_filter = true;
+                break;
+            }
+        }
+
+        if (!has_database_or_table_filter)
+            return;
+
+        VirtualColumnUtils::buildSetsForDAG(*filter, context);
+        explicit_database_table_filter = std::move(filter);
+    }
+
     void initializePipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings &) override
     {
-        auto source = std::make_shared<SystemDeltaLakeHistorySource>(getOutputHeader(), max_block_size, context);
+        auto source = std::make_shared<SystemDeltaLakeHistorySource>(
+            getOutputHeader(),
+            max_block_size,
+            context,
+            std::move(explicit_database_table_filter));
         source->setStorageLimits(storage_limits);
         processors.push_back(source);
         pipeline.init(Pipe(std::move(source)));
@@ -248,6 +324,7 @@ public:
 private:
     std::shared_ptr<const StorageLimitsList> storage_limits;
     const UInt64 max_block_size;
+    std::optional<ActionsDAG> explicit_database_table_filter;
 };
 
 }

--- a/src/Storages/System/StorageSystemDeltaLakeHistory.cpp
+++ b/src/Storages/System/StorageSystemDeltaLakeHistory.cpp
@@ -201,7 +201,7 @@ private:
                         && isExplicitlyRequestedTable(db_name, tbl_name))
                         throw;
 
-                    LOG_WARNING(
+                    LOG_DEBUG(
                         getLogger("SystemDeltaLakeHistory"),
                         "Skipping table {}: {}",
                         object_storage_table->getStorageID().getFullTableName(),

--- a/src/Storages/System/StorageSystemDeltaLakeHistory.h
+++ b/src/Storages/System/StorageSystemDeltaLakeHistory.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <optional>
-#include <Parsers/ASTIdentifier.h>
-#include <Storages/System/IStorageSystemOneBlock.h>
+#include <Storages/IStorage.h>
 
 
 namespace DB
@@ -11,7 +9,8 @@ namespace DB
 class Context;
 
 /** Implements a system table for Delta Lake tables history.
- * It provides information about the various versions of Delta Lake tables created in ClickHouse.
+ * Uses streaming mode to produce results in chunks, allowing LIMIT to work
+ * and avoiding the need for an arbitrary cap on the number of records.
  *
  * database String
  * table String
@@ -23,21 +22,23 @@ class Context;
  *
  */
 
-class StorageSystemDeltaLakeHistory final : public IStorageSystemOneBlock
+class StorageSystemDeltaLakeHistory final : public IStorage
 {
 public:
+    explicit StorageSystemDeltaLakeHistory(const StorageID & table_id_);
+
     std::string getName() const override { return "SystemDeltaLakeHistory"; }
+    bool isSystemStorage() const override { return true; }
 
-    static ColumnsDescription getColumnsDescription();
-
-protected:
-    using IStorageSystemOneBlock::IStorageSystemOneBlock;
-
-    void fillData(
-        [[maybe_unused]] MutableColumns & res_columns,
-        [[maybe_unused]] ContextPtr context,
-        const ActionsDAG::Node *,
-        std::vector<UInt8>) const override;
+    void read(
+        QueryPlan & query_plan,
+        const Names & column_names,
+        const StorageSnapshotPtr & storage_snapshot,
+        SelectQueryInfo & query_info,
+        ContextPtr context,
+        QueryProcessingStage::Enum processed_stage,
+        size_t max_block_size,
+        size_t num_streams) override;
 };
 
 }

--- a/src/Storages/System/StorageSystemDeltaLakeHistory.h
+++ b/src/Storages/System/StorageSystemDeltaLakeHistory.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <optional>
+#include <Parsers/ASTIdentifier.h>
+#include <Storages/System/IStorageSystemOneBlock.h>
+
+
+namespace DB
+{
+
+class Context;
+
+/** Implements a system table for Delta Lake tables history.
+ * It provides information about the various versions of Delta Lake tables created in ClickHouse.
+ *
+ * database String
+ * table String
+ * version UInt64
+ * timestamp Nullable(DateTime64(3))
+ * operation String
+ * operation_parameters Map(String, String)
+ * is_latest_version UInt8
+ *
+ */
+
+class StorageSystemDeltaLakeHistory final : public IStorageSystemOneBlock
+{
+public:
+    std::string getName() const override { return "SystemDeltaLakeHistory"; }
+
+    static ColumnsDescription getColumnsDescription();
+
+protected:
+    using IStorageSystemOneBlock::IStorageSystemOneBlock;
+
+    void fillData(
+        [[maybe_unused]] MutableColumns & res_columns,
+        [[maybe_unused]] ContextPtr context,
+        const ActionsDAG::Node *,
+        std::vector<UInt8>) const override;
+};
+
+}

--- a/src/Storages/System/StorageSystemDeltaLakeHistory.h
+++ b/src/Storages/System/StorageSystemDeltaLakeHistory.h
@@ -10,7 +10,8 @@ class Context;
 
 /** Implements a system table for Delta Lake tables history.
  * Uses streaming mode to produce results in chunks, allowing LIMIT to work
- * and avoiding the need for an arbitrary cap on the number of records.
+ * while applying a configurable safety cap (`delta_lake_history_max_records`)
+ * when reading records from the Delta Lake metadata log.
  *
  * database String
  * table String

--- a/src/Storages/System/attachSystemTables.cpp
+++ b/src/Storages/System/attachSystemTables.cpp
@@ -268,7 +268,7 @@ void attachSystemTablesServer(ContextPtr context, IDatabase & system_database, b
     attach<StorageSystemWorkloads>(context, system_database, "workloads", "Contains a list of all currently existing workloads.");
     attach<StorageSystemResources>(context, system_database, "resources", "Contains a list of all currently existing resources.");
     attach<StorageSystemIcebergHistory>(context, system_database, "iceberg_history", "Displays the history of an iceberg table similar to the Spark history table");
-    attach<StorageSystemDeltaLakeHistory>(context, system_database, "delta_lake_history", "Displays the history of a Delta Lake table showing all versions and their commit information");
+    attachNoDescription<StorageSystemDeltaLakeHistory>(context, system_database, "delta_lake_history", "Displays the history of a Delta Lake table showing all versions and their commit information");
 #if USE_ICU
     attach<StorageSystemUnicode>(context, system_database, "unicode", "Contains all unicode codepoints.");
 #endif

--- a/src/Storages/System/attachSystemTables.cpp
+++ b/src/Storages/System/attachSystemTables.cpp
@@ -114,6 +114,7 @@
 #include <Storages/System/StorageSystemViewRefreshes.h>
 #include <Storages/System/StorageSystemDNSCache.h>
 #include <Storages/System/StorageSystemIcebergHistory.h>
+#include <Storages/System/StorageSystemDeltaLakeHistory.h>
 #if USE_ICU
 #   include <Storages/System/StorageSystemUnicode.h>
 #endif
@@ -267,6 +268,7 @@ void attachSystemTablesServer(ContextPtr context, IDatabase & system_database, b
     attach<StorageSystemWorkloads>(context, system_database, "workloads", "Contains a list of all currently existing workloads.");
     attach<StorageSystemResources>(context, system_database, "resources", "Contains a list of all currently existing resources.");
     attach<StorageSystemIcebergHistory>(context, system_database, "iceberg_history", "Displays the history of an iceberg table similar to the Spark history table");
+    attach<StorageSystemDeltaLakeHistory>(context, system_database, "delta_lake_history", "Displays the history of a Delta Lake table showing all versions and their commit information");
 #if USE_ICU
     attach<StorageSystemUnicode>(context, system_database, "unicode", "Contains all unicode codepoints.");
 #endif

--- a/tests/integration/test_storage_delta/test.py
+++ b/tests/integration/test_storage_delta/test.py
@@ -4142,6 +4142,79 @@ def test_system_delta_lake_history_with_checkpoint(started_cluster, use_delta_ke
     node.query(f"DROP TABLE IF EXISTS {TABLE_NAME}")
 
 
+def test_system_delta_lake_history_sparse_versions_without_checkpoint(started_cluster):
+    """Without checkpoint, history should include only discovered metadata versions."""
+    node = get_node(started_cluster, "0")
+    spark = started_cluster.spark_session
+    TABLE_NAME = randomize_table_name("test_history_sparse_versions")
+    HIGH_VERSION = 50000
+
+    write_delta_from_df(
+        spark,
+        generate_data(spark, 0, 1),
+        f"/{TABLE_NAME}",
+        mode="overwrite",
+    )
+
+    high_version_filename = f"{HIGH_VERSION:020d}.json"
+    high_version_path = f"/{TABLE_NAME}/_delta_log/{high_version_filename}"
+    with open(high_version_path, "w", encoding="utf-8") as f:
+        f.write(
+            '{"commitInfo":{"timestamp":1,"operation":"WRITE","operationParameters":{"source":"sparse_test"}}}\n'
+        )
+
+    default_upload_directory(started_cluster, "s3", f"/{TABLE_NAME}", "")
+    create_delta_table(node, "s3", TABLE_NAME, started_cluster)
+
+    history_count = int(
+        node.query(
+            f"SELECT count() FROM system.delta_lake_history WHERE table = '{TABLE_NAME}'"
+        )
+    )
+    assert history_count == 2, f"Expected sparse history with 2 versions, got {history_count}"
+
+    versions = node.query(
+        f"""
+        SELECT version
+        FROM system.delta_lake_history
+        WHERE table = '{TABLE_NAME}'
+        ORDER BY version
+        """
+    ).strip()
+    assert versions == f"0\n{HIGH_VERSION}", f"Expected versions 0 and {HIGH_VERSION}, got: {versions}"
+
+    node.query(f"DROP TABLE IF EXISTS {TABLE_NAME}")
+
+
+def test_system_delta_lake_history_guard_for_large_checkpoint(started_cluster):
+    """A too-large checkpoint should trigger the history materialization guard."""
+    node = get_node(started_cluster, "0")
+    spark = started_cluster.spark_session
+    TABLE_NAME = randomize_table_name("test_history_guard_checkpoint")
+    TOO_LARGE_CHECKPOINT = 1_000_000
+
+    write_delta_from_df(
+        spark,
+        generate_data(spark, 0, 1),
+        f"/{TABLE_NAME}",
+        mode="overwrite",
+    )
+
+    last_checkpoint_path = f"/{TABLE_NAME}/_delta_log/_last_checkpoint"
+    with open(last_checkpoint_path, "w", encoding="utf-8") as f:
+        f.write(f'{{"version":{TOO_LARGE_CHECKPOINT},"size":1,"parts":1}}\n')
+
+    default_upload_directory(started_cluster, "s3", f"/{TABLE_NAME}", "")
+    create_delta_table(node, "s3", TABLE_NAME, started_cluster)
+
+    error = node.query_and_get_error(
+        f"SELECT count() FROM system.delta_lake_history WHERE table = '{TABLE_NAME}'"
+    )
+    assert "Refusing to materialize Delta Lake history" in error
+
+    node.query(f"DROP TABLE IF EXISTS {TABLE_NAME}")
+
+
 @pytest.mark.parametrize("cluster", [False, True])
 def test_partition_columns_3(started_cluster, cluster):
     """Test for bug https://github.com/ClickHouse/ClickHouse/issues/95526
@@ -4693,8 +4766,6 @@ def test_early_return_limit(started_cluster, use_delta_kernel):
     # we get +1 scanned file.
     assert scanned_files == 3, \
         f"Early return should scan 3 files with LIMIT 1, but scanned {scanned_files}"
-
-
 def test_struct_dotted_field_names(started_cluster):
     """Regression test for struct fields whose logical (and physical) names contain dots.
 

--- a/tests/integration/test_storage_delta/test.py
+++ b/tests/integration/test_storage_delta/test.py
@@ -3989,6 +3989,73 @@ deltaLake{suffix}({cluster}
     assert node.contains_in_log("Row indexes size 2 for file")
 
 
+@pytest.mark.parametrize("use_delta_kernel", ["1", "0"])
+def test_system_delta_lake_history(started_cluster, use_delta_kernel):
+    """Test that system.delta_lake_history table works correctly with Delta Lake tables."""
+    node = get_node(started_cluster, use_delta_kernel)
+    minio_client = started_cluster.minio_client
+    bucket = started_cluster.minio_bucket
+    TABLE_NAME = randomize_table_name("test_system_delta_lake_history")
+
+    # Verify system.delta_lake_history table exists and has correct schema
+    result = node.query(
+        "SELECT name FROM system.columns WHERE database = 'system' AND table = 'delta_lake_history' ORDER BY position"
+    )
+    assert len(result.strip()) > 0, "system.delta_lake_history table should have columns"
+
+    # Create a Delta Lake table with multiple versions
+    path = f"s3a://{bucket}/{TABLE_NAME}"
+    storage_options = get_storage_options(started_cluster)
+
+    # Write initial data (version 0)
+    data = pa.table({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    write_deltalake(path, data, mode="overwrite", storage_options=storage_options)
+
+    # Write more data (version 1)
+    data2 = pa.table({"a": [4, 5, 6], "b": ["p", "q", "r"]})
+    write_deltalake(path, data2, mode="append", storage_options=storage_options)
+
+    upload_directory(minio_client, bucket, f"/{TABLE_NAME}", "")
+
+    # Create the Delta Lake table in ClickHouse
+    node.query(
+        f"""
+        DROP TABLE IF EXISTS {TABLE_NAME};
+        CREATE TABLE {TABLE_NAME}
+        ENGINE=DeltaLake(s3, filename = '{TABLE_NAME}/', url = 'http://minio1:9001/{bucket}/')
+        """
+    )
+
+    # Query system.delta_lake_history for this table - check all columns except timestamp
+    history = node.query(
+        f"""
+        SELECT database, table, version, operation, operation_parameters, is_latest_version
+        FROM system.delta_lake_history
+        WHERE table = '{TABLE_NAME}'
+        ORDER BY version
+        """
+    ).strip()
+
+    # Should have at least 2 versions (initial write + append)
+    lines = history.split("\n")
+    assert len(lines) >= 2, f"Expected at least 2 history entries, got {len(lines)}"
+
+    # Verify version 0 entry
+    assert f"default\t{TABLE_NAME}\t0" in history, "Version 0 should exist with correct database and table"
+
+    # Verify version 1 entry
+    assert f"default\t{TABLE_NAME}\t1" in history, "Version 1 should exist with correct database and table"
+
+    # Verify is_latest_version flag - version 1 should be latest (1), version 0 should not be (0)
+    version_0_line = [line for line in lines if f"\t0\t" in line][0]
+    version_1_line = [line for line in lines if f"\t1\t" in line][0]
+    assert version_0_line.endswith("\t0"), "Version 0 should have is_latest_version=0"
+    assert version_1_line.endswith("\t1"), "Version 1 should have is_latest_version=1"
+
+    # Clean up
+    node.query(f"DROP TABLE IF EXISTS {TABLE_NAME}")
+
+
 @pytest.mark.parametrize("cluster", [False, True])
 def test_partition_columns_3(started_cluster, cluster):
     """Test for bug https://github.com/ClickHouse/ClickHouse/issues/95526

--- a/tests/integration/test_storage_delta/test.py
+++ b/tests/integration/test_storage_delta/test.py
@@ -4052,7 +4052,93 @@ def test_system_delta_lake_history(started_cluster, use_delta_kernel):
     assert version_0_line.endswith("\t0"), "Version 0 should have is_latest_version=0"
     assert version_1_line.endswith("\t1"), "Version 1 should have is_latest_version=1"
 
+    # Verify operation column is not empty for versions that have .json files
+    operations = node.query(
+        f"""
+        SELECT version, operation
+        FROM system.delta_lake_history
+        WHERE table = '{TABLE_NAME}'
+        ORDER BY version
+        """
+    ).strip()
+    for op_line in operations.split("\n"):
+        parts = op_line.split("\t")
+        assert len(parts) == 2 and parts[1] != "", f"Operation should not be empty: {op_line}"
+
     # Clean up
+    node.query(f"DROP TABLE IF EXISTS {TABLE_NAME}")
+
+
+@pytest.mark.parametrize("use_delta_kernel", ["1", "0"])
+def test_system_delta_lake_history_with_checkpoint(started_cluster, use_delta_kernel):
+    """Test that system.delta_lake_history works correctly when checkpoints exist.
+    When a checkpoint is created, older .json files may be removed.
+    History should still show all versions from 0 to the latest."""
+    node = get_node(started_cluster, use_delta_kernel)
+    spark = started_cluster.spark_session
+    minio_client = started_cluster.minio_client
+    bucket = started_cluster.minio_bucket
+    TABLE_NAME = randomize_table_name("test_history_checkpoint")
+
+    write_delta_from_df(
+        spark,
+        generate_data(spark, 0, 1),
+        f"/{TABLE_NAME}",
+        mode="overwrite",
+    )
+    # Write 24 more versions to trigger checkpoints (created every 10 commits)
+    for i in range(1, 25):
+        write_delta_from_df(
+            spark,
+            generate_data(spark, i, i + 1),
+            f"/{TABLE_NAME}",
+            mode="append",
+        )
+
+    files = default_upload_directory(started_cluster, "s3", f"/{TABLE_NAME}", "")
+
+    # Verify checkpoint file exists
+    has_checkpoint = any(f.endswith("last_checkpoint") for f in files)
+    assert has_checkpoint, "Expected _last_checkpoint file after 25 writes"
+
+    create_delta_table(node, "s3", TABLE_NAME, started_cluster)
+
+    # Query history - should have all 25 versions (0..24)
+    history_count = int(
+        node.query(
+            f"SELECT count() FROM system.delta_lake_history WHERE table = '{TABLE_NAME}'"
+        )
+    )
+    assert history_count == 25, f"Expected 25 history entries (versions 0-24), got {history_count}"
+
+    # Verify version range: min should be 0, max should be 24
+    version_range = node.query(
+        f"""
+        SELECT min(version), max(version)
+        FROM system.delta_lake_history
+        WHERE table = '{TABLE_NAME}'
+        """
+    ).strip()
+    assert version_range == "0\t24", f"Expected versions 0..24, got: {version_range}"
+
+    # Verify is_latest_version: only version 24 should be latest
+    latest = node.query(
+        f"""
+        SELECT version FROM system.delta_lake_history
+        WHERE table = '{TABLE_NAME}' AND is_latest_version = 1
+        """
+    ).strip()
+    assert latest == "24", f"Expected version 24 as latest, got: {latest}"
+
+    # Versions with .json files should have non-empty operation
+    ops_with_json = node.query(
+        f"""
+        SELECT count() FROM system.delta_lake_history
+        WHERE table = '{TABLE_NAME}' AND operation != ''
+        """
+    ).strip()
+    assert int(ops_with_json) > 0, "Expected some versions with non-empty operation"
+
     node.query(f"DROP TABLE IF EXISTS {TABLE_NAME}")
 
 

--- a/tests/integration/test_storage_delta/test.py
+++ b/tests/integration/test_storage_delta/test.py
@@ -4192,7 +4192,7 @@ def test_system_delta_lake_history_guard_for_large_checkpoint(started_cluster, u
     node = get_node(started_cluster, use_delta_kernel)
     spark = started_cluster.spark_session
     TABLE_NAME = randomize_table_name("test_history_guard_checkpoint")
-    TOO_LARGE_CHECKPOINT = 1_000_000
+    MAX_HISTORY_RECORDS = 10
 
     write_delta_from_df(
         spark,
@@ -4201,15 +4201,20 @@ def test_system_delta_lake_history_guard_for_large_checkpoint(started_cluster, u
         mode="overwrite",
     )
 
-    last_checkpoint_path = f"/{TABLE_NAME}/_delta_log/_last_checkpoint"
-    with open(last_checkpoint_path, "w", encoding="utf-8") as f:
-        f.write(f'{{"version":{TOO_LARGE_CHECKPOINT},"size":1,"parts":1}}\n')
+    # Create enough versions so Delta emits a real checkpoint.
+    for i in range(1, 25):
+        write_delta_from_df(
+            spark,
+            generate_data(spark, i, i + 1),
+            f"/{TABLE_NAME}",
+            mode="append",
+        )
 
     default_upload_directory(started_cluster, "s3", f"/{TABLE_NAME}", "")
     create_delta_table(node, "s3", TABLE_NAME, started_cluster)
 
     error = node.query_and_get_error(
-        f"SELECT count() FROM system.delta_lake_history WHERE table = '{TABLE_NAME}'"
+        f"SELECT count() FROM system.delta_lake_history WHERE table = '{TABLE_NAME}' SETTINGS delta_lake_history_max_records = {MAX_HISTORY_RECORDS}"
     )
     assert "Refusing to materialize Delta Lake history" in error
 

--- a/tests/integration/test_storage_delta/test.py
+++ b/tests/integration/test_storage_delta/test.py
@@ -4221,9 +4221,10 @@ def test_system_delta_lake_history_guard_for_large_checkpoint(started_cluster, u
     node.query(f"DROP TABLE IF EXISTS {TABLE_NAME}")
 
 
-def test_system_delta_lake_history_large_last_checkpoint_version(started_cluster):
+@pytest.mark.parametrize("use_delta_kernel", ["1", "0"])
+def test_system_delta_lake_history_large_last_checkpoint_version(started_cluster, use_delta_kernel):
     """Large _last_checkpoint versions should not be truncated to 32-bit values."""
-    node = get_node(started_cluster, "0")
+    node = get_node(started_cluster, use_delta_kernel)
     spark = started_cluster.spark_session
     TABLE_NAME = randomize_table_name("test_history_large_last_checkpoint")
     LARGE_CHECKPOINT_VERSION = 4_294_967_296
@@ -4249,6 +4250,7 @@ def test_system_delta_lake_history_large_last_checkpoint_version(started_cluster
     assert (
         "Refusing to materialize Delta Lake history" in error
         or "Failed to parse `_last_checkpoint`" in error
+        or "Invalid Checkpoint" in error
     ), f"Expected a history guard or checkpoint parse error, got: {error}"
 
     node.query(f"DROP TABLE IF EXISTS {TABLE_NAME}")

--- a/tests/integration/test_storage_delta/test.py
+++ b/tests/integration/test_storage_delta/test.py
@@ -4221,6 +4221,39 @@ def test_system_delta_lake_history_guard_for_large_checkpoint(started_cluster, u
     node.query(f"DROP TABLE IF EXISTS {TABLE_NAME}")
 
 
+def test_system_delta_lake_history_large_last_checkpoint_version(started_cluster):
+    """Large _last_checkpoint versions should not be truncated to 32-bit values."""
+    node = get_node(started_cluster, "0")
+    spark = started_cluster.spark_session
+    TABLE_NAME = randomize_table_name("test_history_large_last_checkpoint")
+    LARGE_CHECKPOINT_VERSION = 4_294_967_296
+    MAX_HISTORY_RECORDS = 1000
+
+    write_delta_from_df(
+        spark,
+        generate_data(spark, 0, 1),
+        f"/{TABLE_NAME}",
+        mode="overwrite",
+    )
+
+    last_checkpoint_path = f"/{TABLE_NAME}/_delta_log/_last_checkpoint"
+    with open(last_checkpoint_path, "w", encoding="utf-8") as f:
+        f.write(f'{{"version":{LARGE_CHECKPOINT_VERSION},"size":1,"parts":1}}\n')
+
+    default_upload_directory(started_cluster, "s3", f"/{TABLE_NAME}", "")
+    create_delta_table(node, "s3", TABLE_NAME, started_cluster)
+
+    error = node.query_and_get_error(
+        f"SELECT count() FROM system.delta_lake_history WHERE table = '{TABLE_NAME}' SETTINGS delta_lake_history_max_records = {MAX_HISTORY_RECORDS}"
+    )
+    assert (
+        "Refusing to materialize Delta Lake history" in error
+        or "Failed to parse `_last_checkpoint`" in error
+    ), f"Expected a history guard or checkpoint parse error, got: {error}"
+
+    node.query(f"DROP TABLE IF EXISTS {TABLE_NAME}")
+
+
 @pytest.mark.parametrize("cluster", [False, True])
 def test_partition_columns_3(started_cluster, cluster):
     """Test for bug https://github.com/ClickHouse/ClickHouse/issues/95526

--- a/tests/integration/test_storage_delta/test.py
+++ b/tests/integration/test_storage_delta/test.py
@@ -4186,9 +4186,10 @@ def test_system_delta_lake_history_sparse_versions_without_checkpoint(started_cl
     node.query(f"DROP TABLE IF EXISTS {TABLE_NAME}")
 
 
-def test_system_delta_lake_history_guard_for_large_checkpoint(started_cluster):
+@pytest.mark.parametrize("use_delta_kernel", ["1", "0"])
+def test_system_delta_lake_history_guard_for_large_checkpoint(started_cluster, use_delta_kernel):
     """A too-large checkpoint should trigger the history materialization guard."""
-    node = get_node(started_cluster, "0")
+    node = get_node(started_cluster, use_delta_kernel)
     spark = started_cluster.spark_session
     TABLE_NAME = randomize_table_name("test_history_guard_checkpoint")
     TOO_LARGE_CHECKPOINT = 1_000_000

--- a/tests/integration/test_storage_delta/test.py
+++ b/tests/integration/test_storage_delta/test.py
@@ -4242,16 +4242,33 @@ def test_system_delta_lake_history_large_last_checkpoint_version(started_cluster
         f.write(f'{{"version":{LARGE_CHECKPOINT_VERSION},"size":1,"parts":1}}\n')
 
     default_upload_directory(started_cluster, "s3", f"/{TABLE_NAME}", "")
-    create_delta_table(node, "s3", TABLE_NAME, started_cluster)
+
+    expected_errors = (
+        "Refusing to materialize Delta Lake history",
+        "Failed to parse `_last_checkpoint`",
+        "Invalid Checkpoint",
+        "S3_ERROR",
+    )
+
+    create_error = node.query_and_get_error(
+        f"""
+        DROP TABLE IF EXISTS {TABLE_NAME};
+        CREATE TABLE {TABLE_NAME}
+        ENGINE=DeltaLake(s3, filename = '{TABLE_NAME}/', format=Parquet, url = 'http://minio1:9001/{started_cluster.minio_bucket}/')
+        """
+    )
+    if create_error:
+        assert any(expected_error in create_error for expected_error in expected_errors), (
+            f"Expected explicit large-checkpoint failure during CREATE, got: {create_error}"
+        )
+        return
 
     error = node.query_and_get_error(
         f"SELECT count() FROM system.delta_lake_history WHERE table = '{TABLE_NAME}' SETTINGS delta_lake_history_max_records = {MAX_HISTORY_RECORDS}"
     )
-    assert (
-        "Refusing to materialize Delta Lake history" in error
-        or "Failed to parse `_last_checkpoint`" in error
-        or "Invalid Checkpoint" in error
-    ), f"Expected a history guard or checkpoint parse error, got: {error}"
+    assert any(expected_error in error for expected_error in expected_errors), (
+        f"Expected a history guard or checkpoint parse error, got: {error}"
+    )
 
     node.query(f"DROP TABLE IF EXISTS {TABLE_NAME}")
 

--- a/tests/integration/test_storage_delta/test.py
+++ b/tests/integration/test_storage_delta/test.py
@@ -4273,6 +4273,59 @@ def test_system_delta_lake_history_large_last_checkpoint_version(started_cluster
     node.query(f"DROP TABLE IF EXISTS {TABLE_NAME}")
 
 
+def test_system_delta_lake_history_malformed_metadata_version(started_cluster):
+    """Malformed per-version metadata should not be silently skipped in history."""
+    node = get_node(started_cluster, "0")
+    spark = started_cluster.spark_session
+    TABLE_NAME = randomize_table_name("test_history_malformed_metadata")
+
+    write_delta_from_df(
+        spark,
+        generate_data(spark, 0, 1),
+        f"/{TABLE_NAME}",
+        mode="overwrite",
+    )
+    write_delta_from_df(
+        spark,
+        generate_data(spark, 1, 2),
+        f"/{TABLE_NAME}",
+        mode="append",
+    )
+
+    malformed_metadata_path = f"/{TABLE_NAME}/_delta_log/00000000000000000001.json"
+    with open(malformed_metadata_path, "w", encoding="utf-8") as f:
+        f.write('{"commitInfo":\n')
+
+    default_upload_directory(started_cluster, "s3", f"/{TABLE_NAME}", "")
+
+    expected_errors = (
+        "Failed to parse Delta Lake metadata file",
+        "INCORRECT_DATA",
+    )
+
+    create_error = node.query_and_get_error(
+        f"""
+        DROP TABLE IF EXISTS {TABLE_NAME};
+        CREATE TABLE {TABLE_NAME}
+        ENGINE=DeltaLake(s3, filename = '{TABLE_NAME}/', format=Parquet, url = 'http://minio1:9001/{started_cluster.minio_bucket}/')
+        """
+    )
+    if create_error:
+        assert any(expected_error in create_error for expected_error in expected_errors), (
+            f"Expected malformed-metadata error during CREATE, got: {create_error}"
+        )
+        return
+
+    error = node.query_and_get_error(
+        f"SELECT count() FROM system.delta_lake_history WHERE table = '{TABLE_NAME}'"
+    )
+    assert any(expected_error in error for expected_error in expected_errors), (
+        f"Expected malformed-metadata error, got: {error}"
+    )
+
+    node.query(f"DROP TABLE IF EXISTS {TABLE_NAME}")
+
+
 @pytest.mark.parametrize("cluster", [False, True])
 def test_partition_columns_3(started_cluster, cluster):
     """Test for bug https://github.com/ClickHouse/ClickHouse/issues/95526

--- a/tests/queries/0_stateless/03402_system_delta_lake_history.reference
+++ b/tests/queries/0_stateless/03402_system_delta_lake_history.reference
@@ -1,0 +1,9 @@
+database	String
+table	String
+version	UInt64
+timestamp	Nullable(DateTime64(3))
+operation	String
+operation_parameters	Map(String, String)
+is_latest_version	UInt8
+0
+delta_lake_history

--- a/tests/queries/0_stateless/03402_system_delta_lake_history.sql
+++ b/tests/queries/0_stateless/03402_system_delta_lake_history.sql
@@ -1,0 +1,11 @@
+-- Tags: no-fasttest
+-- Tag no-fasttest: Depends on Delta Lake support (USE_PARQUET)
+
+-- Test that system.delta_lake_history table exists and has correct schema
+SELECT name, type FROM system.columns WHERE database = 'system' AND table = 'delta_lake_history' ORDER BY position;
+
+-- Test that the table is queryable (should return empty result if no Delta Lake tables exist)
+SELECT count() FROM system.delta_lake_history;
+
+-- Test that the table appears in system.tables
+SELECT name FROM system.tables WHERE database = 'system' AND name = 'delta_lake_history';


### PR DESCRIPTION
### Changelog category (leave one):
- New Feature

### Changelog entry:
Added `system.delta_lake_history` table to display version history of Delta Lake tables, similar to `system.iceberg_history`. This works well with the recently added CDF read feature (#90431).

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

Added `system.delta_lake_history` system table that displays the version history of Delta Lake tables.

**Motivation:** Users need a way to inspect the version history of their Delta Lake tables, similar to how `system.iceberg_history` works for Iceberg tables.

**Columns:**
- `database`, `table` - Table identification
- `version` - Version number (key for CDF queries)
- `timestamp` - When this version was committed
- `operation` - Operation type (WRITE, DELETE, MERGE, etc.)
- `operation_parameters` - Map of operation parameters
- `is_current` - Flag for current version

**Example use:**
```sql
SELECT version, timestamp, operation FROM system.delta_lake_history 
WHERE database = 'default' AND table = 'my_delta_table';
```

Fixes #94664
