### PR TITLE
Add a check for Keeper misconfiguration

### DIFF
--- a/src/Coordination/KeeperServer.cpp
+++ b/src/Coordination/KeeperServer.cpp
@@ -875,25 +875,6 @@ nuraft::cb_func::ReturnCode KeeperServer::callbackFunc(nuraft::cb_func::Type typ
                     preprocess_logs();
                 break;
             }
-            case nuraft::cb_func::ReceivedMisbehavingMessage:
-            {
-                auto & req = *static_cast<nuraft::req_msg *>(param->ctx);
-
-                if (req.get_src() == server_id)
-                {
-                    LOG_FATAL
-                    (
-                        log,
-                        "Raft received its own message intended for another peer, this indicates misconfiguration; server_id: {}, src: {}, dst: {}",
-                        server_id,
-                        req.get_src(),
-                        req.get_dst()
-                    );
-                    std::terminate();
-                }
-
-                break;
-            }
             default:
                 break;
         }
@@ -1066,6 +1047,25 @@ nuraft::cb_func::ReturnCode KeeperServer::callbackFunc(nuraft::cb_func::Type typ
         {
             const auto & entry = *static_cast<LogEntryPtr *>(param->ctx);
             return follower_preappend(entry);
+        }
+        case nuraft::cb_func::ReceivedMisbehavingMessage:
+        {
+            auto & req = *static_cast<nuraft::req_msg *>(param->ctx);
+
+            if (req.get_src() == server_id)
+            {
+                LOG_FATAL
+                (
+                    log,
+                    "Raft received its own message intended for another peer, this indicates misconfiguration; server_id: {}, src: {}, dst: {}",
+                    server_id,
+                    req.get_src(),
+                    req.get_dst()
+                );
+                std::terminate();
+            }
+
+            return nuraft::cb_func::ReturnCode::Ok;
         }
         default: /// ignore other events
             return nuraft::cb_func::ReturnCode::Ok;

--- a/src/Coordination/KeeperServer.cpp
+++ b/src/Coordination/KeeperServer.cpp
@@ -880,7 +880,17 @@ nuraft::cb_func::ReturnCode KeeperServer::callbackFunc(nuraft::cb_func::Type typ
                 auto & req = *static_cast<nuraft::req_msg *>(param->ctx);
 
                 if (req.get_src() == server_id)
-                    throw Exception(ErrorCodes::LOGICAL_ERROR, "Raft received its own message intended for another peer, this indicates misconfiguration; server_id: {}, src: {}, dst: {}", server_id, req.get_src(), req.get_dst());
+                {
+                    LOG_FATAL
+                    (
+                        log,
+                        "Raft received its own message intended for another peer, this indicates misconfiguration; server_id: {}, src: {}, dst: {}",
+                        server_id,
+                        req.get_src(),
+                        req.get_dst()
+                    );
+                    std::terminate();
+                }
 
                 break;
             }

--- a/src/Coordination/KeeperServer.cpp
+++ b/src/Coordination/KeeperServer.cpp
@@ -875,6 +875,15 @@ nuraft::cb_func::ReturnCode KeeperServer::callbackFunc(nuraft::cb_func::Type typ
                     preprocess_logs();
                 break;
             }
+            case nuraft::cb_func::ReceivedMisbehavingMessage:
+            {
+                auto & req = *static_cast<nuraft::req_msg *>(param->ctx);
+
+                if (req.get_src() == server_id)
+                    throw Exception(ErrorCodes::LOGICAL_ERROR, "Raft received its own message intended for another peer, this indicates misconfiguration; server_id: {}, src: {}, dst: {}", server_id, req.get_src(), req.get_dst());
+
+                break;
+            }
             default:
                 break;
         }


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add a check for Keeper misconfiguration leading to cluster assembly failures. Closes https://github.com/ClickHouse/ClickHouse/issues/60932

With the following configuration, Keeper instance with ID `1` will try to reach peer `3` and receive its own message. This should never happen.
```
<clickhouse>
    <interserver_listen_host>127.0.0.4</interserver_listen_host>

    <keeper_server>
        <tcp_port>9181</tcp_port>
        <server_id>1</server_id>
        <log_storage_path>./keeper_log</log_storage_path>
        <snapshot_storage_path>./keeper_snapshot</snapshot_storage_path>

        <raft_configuration>
            <server>
                <id>1</id>
                <hostname>127.0.0.2</hostname>
                <port>9234</port>
            </server>
            <server>
                <id>2</id>
                <hostname>127.0.0.3</hostname>
                <port>9234</port>
            </server>
            <server>
                <id>3</id>
                <hostname>127.0.0.4</hostname>
                <port>9234</port>
            </server>
        </raft_configuration>
    </keeper_server>
</clickhouse>
```


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.38`
<!-- ch-version-info:end -->