### PR TITLE
illumos: miscellaneous compatibility fixes.

### DIFF
--- a/cmake/tools.cmake
+++ b/cmake/tools.cmake
@@ -75,7 +75,7 @@ endif ()
 
 if (LINKER_NAME)
     message(STATUS "Using linker: ${LINKER_NAME}")
-elseif (NOT ARCH_S390X AND NOT OS_FREEBSD)
+elseif (NOT ARCH_S390X AND NOT OS_FREEBSD AND NOT OS_SUNOS)
     message (FATAL_ERROR "The only supported linker is LLVM's LLD, but we cannot find it.")
 else ()
     message(STATUS "Using linker: <default>")

--- a/src/Coordination/FourLetterCommand.cpp
+++ b/src/Coordination/FourLetterCommand.cpp
@@ -511,7 +511,7 @@ String EnviCommand::run()
 
     String os_user;
     os_user.resize(256, '\0');
-    if (0 == getlogin_r(os_user.data(), os_user.size() - 1))
+    if (0 == getlogin_r(os_user.data(), static_cast<int>(os_user.size() - 1)))
         os_user.resize(strlen(os_user.c_str()));
     else
         os_user.clear();    /// Don't mind if we cannot determine user login.


### PR DESCRIPTION
* cmake: use system linker for illumos, as for freebsd. We forgot to include this change in an earlier patch.
* fix illumos compatibility for getlogin_r. Required due to stricter checks in #93610.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)