### PR TITLE
S3Queue ordered mode support bucketing based on partition key

### DIFF
--- a/src/Core/SettingsEnums.cpp
+++ b/src/Core/SettingsEnums.cpp
@@ -279,6 +279,12 @@ IMPLEMENT_SETTING_ENUM(ObjectStorageQueuePartitioningMode, ErrorCodes::BAD_ARGUM
      {"regex", ObjectStorageQueuePartitioningMode::REGEX},
      {"REGEX", ObjectStorageQueuePartitioningMode::REGEX}})
 
+IMPLEMENT_SETTING_ENUM(ObjectStorageQueueBucketingMode, ErrorCodes::BAD_ARGUMENTS,
+    {{"path", ObjectStorageQueueBucketingMode::PATH},
+     {"PATH", ObjectStorageQueueBucketingMode::PATH},
+     {"partition", ObjectStorageQueueBucketingMode::PARTITION},
+     {"PARTITION", ObjectStorageQueueBucketingMode::PARTITION}})
+
 IMPLEMENT_SETTING_ENUM(ExternalCommandStderrReaction, ErrorCodes::BAD_ARGUMENTS,
     {{"none", ExternalCommandStderrReaction::NONE},
      {"log", ExternalCommandStderrReaction::LOG},

--- a/src/Core/SettingsEnums.h
+++ b/src/Core/SettingsEnums.h
@@ -391,6 +391,14 @@ enum class ObjectStorageQueuePartitioningMode : uint8_t
 
 DECLARE_SETTING_ENUM(ObjectStorageQueuePartitioningMode)
 
+enum class ObjectStorageQueueBucketingMode : uint8_t
+{
+    PATH,       /// Hash full file path for bucketing (default, existing behavior)
+    PARTITION,  /// Hash partition key for bucketing (requires partitioning_mode != NONE)
+};
+
+DECLARE_SETTING_ENUM(ObjectStorageQueueBucketingMode)
+
 DECLARE_SETTING_ENUM(ExternalCommandStderrReaction)
 
 DECLARE_SETTING_ENUM(SchemaInferenceMode)

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
@@ -142,6 +142,7 @@ ObjectStorageQueueMetadata::ObjectStorageQueueMetadata(
     : table_metadata(table_metadata_)
     , storage_type(storage_type_)
     , mode(table_metadata.getMode())
+    , bucketing_mode(table_metadata.getBucketingMode())
     , partitioning_mode(table_metadata.getPartitioningMode())
     , zookeeper_path(zookeeper_path_)
     , keeper_multiread_batch_size(keeper_multiread_batch_size_)
@@ -273,6 +274,7 @@ ObjectStorageQueueMetadata::FileMetadataPtr ObjectStorageQueueMetadata::getFileM
                 table_metadata.loading_retries,
                 *metadata_ref_count,
                 use_persistent_processing_nodes,
+                bucketing_mode,
                 partitioning_mode,
                 filename_parser.get(),
                 log);
@@ -295,12 +297,17 @@ bool ObjectStorageQueueMetadata::useBucketsForProcessing() const
 
 ObjectStorageQueueMetadata::Bucket ObjectStorageQueueMetadata::getBucketForPath(const std::string & path) const
 {
-    return getBucketForPath(path, buckets_num);
+    return getBucketForPath(path, buckets_num, bucketing_mode, partitioning_mode, filename_parser.get());
 }
 
-ObjectStorageQueueMetadata::Bucket ObjectStorageQueueMetadata::getBucketForPath(const std::string & path, size_t buckets_num)
+ObjectStorageQueueMetadata::Bucket ObjectStorageQueueMetadata::getBucketForPath(
+    const std::string & path,
+    size_t buckets_num,
+    ObjectStorageQueueBucketingMode bucketing_mode,
+    ObjectStorageQueuePartitioningMode partitioning_mode,
+    const ObjectStorageQueueFilenameParser * parser)
 {
-    return ObjectStorageQueueOrderedFileMetadata::getBucketForPath(path, buckets_num);
+    return ObjectStorageQueueOrderedFileMetadata::getBucketForPath(path, buckets_num, bucketing_mode, partitioning_mode, parser);
 }
 
 ObjectStorageQueueOrderedFileMetadata::BucketHolderPtr
@@ -567,6 +574,7 @@ ObjectStorageQueueTableMetadata ObjectStorageQueueMetadata::syncWithKeeper(
                     table_metadata.loading_retries,
                     noop,
                     /* use_persistent_processing_nodes */false, /// Processing nodes will not be created.
+                    table_metadata.getBucketingMode(),
                     table_metadata.getPartitioningMode(),
                     /* parser */nullptr,  /// Parser not needed for ZK metadata initialization
                     log).prepareProcessedAtStartRequests(requests);

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.h
@@ -145,7 +145,12 @@ public:
     size_t getBucketsNum() const { return buckets_num; }
     /// Get bucket by file path in case of bucket-based processing.
     Bucket getBucketForPath(const std::string & path) const;
-    static Bucket getBucketForPath(const std::string & path, size_t buckets_num);
+    static Bucket getBucketForPath(
+        const std::string & path,
+        size_t buckets_num,
+        ObjectStorageQueueBucketingMode bucketing_mode,
+        ObjectStorageQueuePartitioningMode partitioning_mode,
+        const ObjectStorageQueueFilenameParser * parser);
     /// Acquire (take unique ownership of) bucket for processing.
     ObjectStorageQueueOrderedFileMetadata::BucketHolderPtr tryAcquireBucket(const Bucket & bucket);
 
@@ -155,6 +160,7 @@ public:
     /// Set local ref count for metadata.
     void setMetadataRefCount(std::atomic<size_t> & ref_count_) { chassert(!metadata_ref_count); metadata_ref_count = &ref_count_; }
 
+    ObjectStorageQueueBucketingMode getBucketingMode() const { return bucketing_mode; }
     ObjectStorageQueuePartitioningMode getPartitioningMode() const { return partitioning_mode; }
     const ObjectStorageQueueFilenameParser * getFilenameParser() const { return filename_parser.get(); }
 
@@ -181,6 +187,7 @@ private:
     ObjectStorageQueueTableMetadata table_metadata;
     const ObjectStorageType storage_type;
     const ObjectStorageQueueMode mode;
+    const ObjectStorageQueueBucketingMode bucketing_mode;
     const ObjectStorageQueuePartitioningMode partitioning_mode;
     const fs::path zookeeper_path;
     const size_t keeper_multiread_batch_size;

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueOrderedFileMetadata.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueOrderedFileMetadata.h
@@ -35,6 +35,7 @@ public:
         size_t max_loading_retries_,
         std::atomic<size_t> & metadata_ref_count_,
         bool use_persistent_processing_nodes_,
+        ObjectStorageQueueBucketingMode bucketing_mode_,
         ObjectStorageQueuePartitioningMode partitioning_mode_,
         const ObjectStorageQueueFilenameParser * parser_,
         LoggerPtr log_);
@@ -51,7 +52,12 @@ public:
         bool use_persistent_processing_nodes_,
         LoggerPtr log_);
 
-    static ObjectStorageQueueOrderedFileMetadata::Bucket getBucketForPath(const std::string & path, size_t buckets_num);
+    static ObjectStorageQueueOrderedFileMetadata::Bucket getBucketForPath(
+        const std::string & path,
+        size_t buckets_num,
+        ObjectStorageQueueBucketingMode bucketing_mode,
+        ObjectStorageQueuePartitioningMode partitioning_mode,
+        const ObjectStorageQueueFilenameParser * parser);
 
     static std::vector<std::string> getMetadataPaths(size_t buckets_num);
 
@@ -62,6 +68,7 @@ public:
         std::vector<std::string> & paths,
         const std::filesystem::path & zk_path_,
         size_t buckets_num,
+        ObjectStorageQueueBucketingMode bucketing_mode,
         ObjectStorageQueuePartitioningMode partitioning_mode,
         const ObjectStorageQueueFilenameParser * parser,
         LoggerPtr log);

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueSettings.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueSettings.cpp
@@ -53,6 +53,7 @@ namespace ErrorCodes
     DECLARE(ObjectStorageQueuePartitioningMode, partitioning_mode, ObjectStorageQueuePartitioningMode::NONE, "Partitioning strategy: NONE (no partitioning, default), HIVE (path-based like date=2025-01-01/city=NY), or REGEX (extract from filename using partition_regex)", 0) \
     DECLARE(String, partition_regex, "", "Regex to extract named capture groups from filename. All named groups are captured. Use partition_component to specify which group is the partition key. Example: '(?P<hostname>[^_]+)_(?P<timestamp>[^_]+)_(?P<sequence>\\d+)'", 0) \
     DECLARE(String, partition_component, "", "Name of the capture group from partition_regex to use as partition key. Required when using partitioning_mode='regex'. Example: 'hostname'", 0) \
+    DECLARE(ObjectStorageQueueBucketingMode, bucketing_mode, ObjectStorageQueueBucketingMode::PATH, "Bucketing strategy for Ordered mode parallel processing: PATH (hash full file path, default), PARTITION (hash partition key, requires partitioning_mode != NONE)", 0) \
     DECLARE(UInt32, after_processing_retries, 10, "Number of retries for the after_processing action before giving up", 0) \
     DECLARE(String, after_processing_move_uri, "", "S3 bucket URL to move processed files to", 0) \
     DECLARE(String, after_processing_move_prefix, "", "Path prefix to move processed files to", 0) \

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueSettings.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueSettings.h
@@ -32,6 +32,7 @@ struct StorageID;
     M(CLASS_NAME, IntervalOutputFormat) \
     M(CLASS_NAME, MsgPackUUIDRepresentation) \
     M(CLASS_NAME, ObjectStorageQueueAction) \
+    M(CLASS_NAME, ObjectStorageQueueBucketingMode) \
     M(CLASS_NAME, ObjectStorageQueueMode) \
     M(CLASS_NAME, ObjectStorageQueuePartitioningMode) \
     M(CLASS_NAME, ORCCompression) \

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.cpp
@@ -453,6 +453,7 @@ void ObjectStorageQueueSource::FileIterator::filterProcessableFiles(ObjectInfos 
             paths,
             metadata->getPath(),
             metadata->getBucketsNum(),
+            metadata->getBucketingMode(),
             metadata->getPartitioningMode(),
             metadata->getFilenameParser(),
             log);
@@ -568,7 +569,12 @@ void ObjectStorageQueueSource::FileIterator::returnForRetry(ObjectInfoPtr object
 
     if (use_buckets_for_processing)
     {
-        const auto bucket = ObjectStorageQueueMetadata::getBucketForPath(object_info->getPath(), buckets_num);
+        const auto bucket = ObjectStorageQueueMetadata::getBucketForPath(
+            object_info->getPath(),
+            buckets_num,
+            metadata->getBucketingMode(),
+            metadata->getPartitioningMode(),
+            metadata->getFilenameParser());
         std::lock_guard lock(mutex);
         keys_cache_per_bucket.at(bucket)->keys.emplace_front(object_info, file_metadata);
     }
@@ -829,7 +835,12 @@ ObjectStorageQueueSource::FileIterator::getNextKeyFromAcquiredBucket(size_t proc
 
             chassert(!file_metadata);
 
-            const auto bucket = ObjectStorageQueueMetadata::getBucketForPath(object_info->getPath(), buckets_num);
+            const auto bucket = ObjectStorageQueueMetadata::getBucketForPath(
+                object_info->getPath(),
+                buckets_num,
+                metadata->getBucketingMode(),
+                metadata->getPartitioningMode(),
+                metadata->getFilenameParser());
             auto bucket_it = keys_cache_per_bucket.find(bucket);
             if (bucket_it == keys_cache_per_bucket.end())
             {

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueTableMetadata.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueTableMetadata.h
@@ -24,6 +24,7 @@ struct ObjectStorageQueueTableMetadata
     const String columns;
     const String mode;
     const String last_processed_path;
+    const String bucketing_mode;
     const String partitioning_mode;
     const String partition_regex;
     const String partition_component;
@@ -48,6 +49,7 @@ struct ObjectStorageQueueTableMetadata
         , columns(other.columns)
         , mode(other.mode)
         , last_processed_path(other.last_processed_path)
+        , bucketing_mode(other.bucketing_mode)
         , partitioning_mode(other.partitioning_mode)
         , partition_regex(other.partition_regex)
         , partition_component(other.partition_component)
@@ -80,6 +82,7 @@ struct ObjectStorageQueueTableMetadata
     String toString() const;
 
     ObjectStorageQueueMode getMode() const;
+    ObjectStorageQueueBucketingMode getBucketingMode() const;
     ObjectStorageQueuePartitioningMode getPartitioningMode() const;
 
     void adjustFromKeeper(const ObjectStorageQueueTableMetadata & from_zk);
@@ -95,6 +98,7 @@ struct ObjectStorageQueueTableMetadata
             "mode",
             "buckets",
             "last_processed_path",
+            "bucketing_mode",
             "partitioning_mode",
             "partition_regex",
             "partition_component",


### PR DESCRIPTION
Following PR https://github.com/ClickHouse/ClickHouse/pull/94321 which added more generic partitioning support to S3Queue in ordered mode, add support for specifying bucketing strategy:
- `path` - Hash full file path for bucketing (default, existing behavior)
- `partition` - Hash the partition key for bucketing (requires valid `partition_regex` and `partition_component`)

For example, if the the partition component is a specific hostname in the partition regex, then only the hostname is used to bucket the file, which would ensure that files from one host always goes to a fixed bucket. 

**Note:** There might be a scenario where the number of `buckets < number of hosts` (though rare, it's possible). In this case, each bucket might contain files from more than one host.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Support bucketing based on partition key for S3Queue in ordered mode.
 
### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.741`
<!-- ch-version-info:end -->