### PR TITLE
Preserve constant index granularity (use_const_adaptive_granularity) after Vertical merges

### DIFF
--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -2446,8 +2446,6 @@ void MergeTask::ExecuteAndFinalizeHorizontalPart::createMergedStream() const
         }
 
         const bool is_vertical_merge = (global_ctx->chosen_merge_algorithm == MergeAlgorithm::Vertical);
-        /// If merge is vertical we cannot calculate it
-        ctx->blocks_are_granules_size = is_vertical_merge;
 
         if (global_ctx->cleanup && !(*merge_tree_settings)[MergeTreeSetting::allow_experimental_replacing_merge_with_cleanup])
             throw Exception(ErrorCodes::SUPPORT_IS_DISABLED, "Experimental merges with CLEANUP are not allowed");
@@ -2469,7 +2467,7 @@ void MergeTask::ExecuteAndFinalizeHorizontalPart::createMergedStream() const
             (*merge_tree_settings)[MergeTreeSetting::merge_max_block_size],
             (*merge_tree_settings)[MergeTreeSetting::merge_max_block_size_bytes],
             max_dynamic_subcolumns,
-            ctx->blocks_are_granules_size,
+            is_vertical_merge,
             cleanup,
             global_ctx->time_of_merge);
 

--- a/tests/queries/0_stateless/03800_use_const_adaptive_granularity_vertical_merge.reference
+++ b/tests/queries/0_stateless/03800_use_const_adaptive_granularity_vertical_merge.reference
@@ -1,0 +1,11 @@
+-- { echo }
+insert into tab select 1, if(number < 4096, 'foo', repeat('b', 1000)) from numbers(400e3) settings max_block_size=65535, max_insert_threads=1;
+select name, rows, marks, index_granularity_bytes_in_memory_allocated from system.parts where database = currentDatabase() and table = 'tab' and active;
+1_1_1_0	327675	3278	25
+1_2_2_0	72325	740	25
+optimize table tab;
+select name, rows, marks, index_granularity_bytes_in_memory_allocated from system.parts where database = currentDatabase() and table = 'tab' and active;
+1_1_2_1	400000	4001	25
+select * from tab format Null;
+check table tab;
+1_1_2_1	1	

--- a/tests/queries/0_stateless/03800_use_const_adaptive_granularity_vertical_merge.sql
+++ b/tests/queries/0_stateless/03800_use_const_adaptive_granularity_vertical_merge.sql
@@ -1,0 +1,31 @@
+DROP TABLE IF EXISTS tab;
+
+CREATE TABLE tab
+(
+    part Int32,
+    key String
+)
+ENGINE = MergeTree
+PARTITION BY part
+ORDER BY key
+SETTINGS
+    index_granularity = 1000000000,
+    index_granularity_bytes = 100000,
+    min_bytes_for_wide_part = 0,
+    use_const_adaptive_granularity = 1,
+    enable_index_granularity_compression = 1,
+    enable_block_number_column = 0,
+    enable_block_offset_column = 0,
+    auto_statistics_types = '',
+    vertical_merge_algorithm_min_rows_to_activate = 0,
+    vertical_merge_algorithm_min_columns_to_activate = 1,
+    string_serialization_version = 'single_stream',
+    merge_max_block_size = 65535;
+
+-- { echo }
+insert into tab select 1, if(number < 4096, 'foo', repeat('b', 1000)) from numbers(400e3) settings max_block_size=65535, max_insert_threads=1;
+select name, rows, marks, index_granularity_bytes_in_memory_allocated from system.parts where database = currentDatabase() and table = 'tab' and active;
+optimize table tab;
+select name, rows, marks, index_granularity_bytes_in_memory_allocated from system.parts where database = currentDatabase() and table = 'tab' and active;
+select * from tab format Null;
+check table tab;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Preserve constant index granularity (use_const_adaptive_granularity) after Vertical merges

The problem was that just before creating index granularity the blocks_are_granules_size has been set to true in case of vertical merges, and this forces to use adaptive granulas

But, we do not need this, since it is written before vertical merges anyway, vertical merges does not calculate index granularity


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.743`
- Backported to: `25.12.4.36`, `25.11.8.5`, `25.10.6.6`, `25.8.16.6`
<!-- ch-version-info:end -->