### PR TITLE
Tell AI agents how to run stateless tests

### DIFF
--- a/.claude/instructions.md
+++ b/.claude/instructions.md
@@ -1,0 +1,50 @@
+# ClickHouse Development Instructions
+
+## Running Stateless Tests
+
+Stateless tests are located in `tests/queries/0_stateless/`.
+
+### Prerequisites
+1. Build ClickHouse: `cd build && ninja clickhouse-server`
+2. Start the server: `./build/programs/clickhouse server --config-file ./programs/server/config.xml`
+3. Wait for server to be ready: `./build/programs/clickhouse client -q "SELECT 1"`
+
+### Running Tests
+Run tests with the correct port environment variables (default config uses TCP=9000, HTTP=8123):
+
+```bash
+CLICKHOUSE_PORT_TCP=9000 CLICKHOUSE_PORT_HTTP=8123 ./tests/clickhouse-test <test_name>
+```
+
+### Useful Flags
+- `--no-random-settings` - Disable settings randomization (useful for deterministic debugging)
+- `--no-random-merge-tree-settings` - Disable MergeTree settings randomization
+- `--record` - Automatically update `.reference` files when stdout differs
+
+### Test File Extensions
+- `.sql` - SQL test (most common)
+- `.sql.j2` - Jinja2-templated SQL test
+- `.sh` - Shell script test
+- `.py` - Python test
+- `.expect` - Expect script test
+- `.reference` - Expected output (compared against stdout)
+- `.gen.reference` - Generated reference for `.j2` tests
+
+### Database Name Normalization
+The test runner creates a temporary database with a random name (e.g., `test_abc123`) for each test.
+After test execution, the random database name is replaced with `default` in stdout/stderr files before comparison with `.reference`.
+This means `.reference` files should use `default` for database names, NOT `${CLICKHOUSE_DATABASE}` or the actual random name.
+
+### Test Tags
+Tests can have tags in the first line as a comment: `-- Tags: no-fasttest, no-parallel`
+Common tags: `disabled`, `no-fasttest`, `no-parallel`, `no-random-settings`, `no-random-merge-tree-settings`, `long`
+
+### Random Settings Limits
+Tests can specify limits for randomized settings: `-- Random settings limits: max_threads=(1, 4); ...`
+
+### Stopping the Server
+Find and kill the server process:
+```bash
+pgrep -f "clickhouse server"  # Get PIDs
+kill <pid1> <pid2>            # Stop processes
+```

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -211,3 +211,49 @@ STYLE & CONDUCT
 - Avoid changing scope: review what’s in the PR; suggest follow-ups separately.
 - If you are not reasonably confident a finding is a real issue or meaningful risk, **do not mention it**.
 - When performing a code review, **ignore `/.github/workflows/*` files**.
+
+RUNNING STATELESS TESTS
+
+Stateless tests are located in `tests/queries/0_stateless/`.
+
+**Prerequisites:**
+1. Build ClickHouse: `cd build && ninja clickhouse-server`
+2. Start the server: `./build/programs/clickhouse server --config-file ./programs/server/config.xml`
+3. Wait for server to be ready: `./build/programs/clickhouse client -q "SELECT 1"`
+
+**Running tests** (default config uses TCP=9000, HTTP=8123):
+```bash
+CLICKHOUSE_PORT_TCP=9000 CLICKHOUSE_PORT_HTTP=8123 ./tests/clickhouse-test <test_name>
+```
+
+**Useful flags:**
+- `--no-random-settings` - Disable settings randomization (useful for deterministic debugging)
+- `--no-random-merge-tree-settings` - Disable MergeTree settings randomization
+- `--record` - Automatically update `.reference` files when stdout differs
+
+**Test file extensions:**
+- `.sql` - SQL test (most common)
+- `.sql.j2` - Jinja2-templated SQL test
+- `.sh` - Shell script test
+- `.py` - Python test
+- `.expect` - Expect script test
+- `.reference` - Expected output (compared against stdout)
+- `.gen.reference` - Generated reference for `.j2` tests
+
+**Database name normalization:**
+The test runner creates a temporary database with a random name (e.g., `test_abc123`) for each test.
+After test execution, the random database name is replaced with `default` in stdout/stderr files before comparison with `.reference`.
+This means `.reference` files should use `default` for database names, NOT `${CLICKHOUSE_DATABASE}` or the actual random name.
+
+**Test tags:**
+Tests can have tags in the first line as a comment: `-- Tags: no-fasttest, no-parallel`
+Common tags: `disabled`, `no-fasttest`, `no-parallel`, `no-random-settings`, `no-random-merge-tree-settings`, `long`
+
+**Random settings limits:**
+Tests can specify limits for randomized settings: `-- Random settings limits: max_threads=(1, 4); ...`
+
+**Stopping the server:**
+```bash
+pgrep -f "clickhouse server"  # Get PIDs
+kill <pid1> <pid2>            # Stop processes
+```


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Tell AI agents how to run stateless tests

I asked copilot+claude to teach itself how to run tests after having to correct it several times.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.734`
<!-- ch-version-info:end -->