### PR TITLE
Fix race

### DIFF
--- a/src/Interpreters/Cache/LRUFileCachePriority.cpp
+++ b/src/Interpreters/Cache/LRUFileCachePriority.cpp
@@ -605,11 +605,12 @@ void LRUFileCachePriority::LRUIterator::invalidate()
         cache_priority->state->sub(entry->size, 1);
         entry->size = 0;
     }
-    entry->setInvalidatedFlag();
 
     LOG_TEST(cache_priority->log,
-             "Invalidated entry in LRU queue {}: {}",
+             "Invalidating entry in LRU queue {}: {}",
              entry->toString(), cache_priority->getApproxStateInfoForLog());
+
+    entry->setInvalidatedFlag();
 }
 
 void LRUFileCachePriority::LRUIterator::incrementSize(size_t size, const CacheStateGuard::Lock & lock)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Not for changelog because was introduced in a PR merged this week.


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.738`
<!-- ch-version-info:end -->