### PR TITLE
Fix flaky test 01079_parallel_alter_detach_table_zookeeper

### DIFF
--- a/tests/queries/0_stateless/01079_parallel_alter_detach_table_zookeeper.sh
+++ b/tests/queries/0_stateless/01079_parallel_alter_detach_table_zookeeper.sh
@@ -8,7 +8,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 REPLICAS=3
 
 for i in $(seq $REPLICAS); do
-    $CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS concurrent_alter_detach_$i"
+    $CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS concurrent_alter_detach_$i" 2>&1 | grep -Fa "Exception: " | grep -Fv "TIMEOUT_EXCEEDED"
 done
 
 for i in $(seq $REPLICAS); do
@@ -116,5 +116,5 @@ for i in $(seq $REPLICAS); do
     $CLICKHOUSE_CLIENT --query "SELECT COUNT() FROM system.mutations WHERE database = '$CLICKHOUSE_DATABASE' and is_done=0 and table = 'concurrent_alter_detach_$i'" # all mutations have to be done
     $CLICKHOUSE_CLIENT --query "SELECT * FROM system.mutations WHERE database = '$CLICKHOUSE_DATABASE' and is_done=0 and table = 'concurrent_alter_detach_$i'" # all mutations have to be done
     $CLICKHOUSE_CLIENT --query "SELECT * FROM system.replication_queue WHERE table = 'concurrent_alter_detach_$i' and (type = 'ALTER_METADATA' or type = 'MUTATE_PART')" # all mutations and alters have to be done
-    $CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS concurrent_alter_detach_$i"
+    $CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS concurrent_alter_detach_$i" 2>&1 | grep -Fa "Exception: " | grep -Fv "TIMEOUT_EXCEEDED"
 done

--- a/tests/queries/0_stateless/01079_parallel_alter_detach_table_zookeeper.sh
+++ b/tests/queries/0_stateless/01079_parallel_alter_detach_table_zookeeper.sh
@@ -98,12 +98,16 @@ for i in $(seq $REPLICAS); do
 done
 
 # This alter will finish all previous, but replica 1 maybe still not up-to-date
-while [[ $(timeout 120 ${CLICKHOUSE_CLIENT} --query "ALTER TABLE concurrent_alter_detach_1 MODIFY COLUMN value1 String SETTINGS replication_alter_partitions_sync=2" 2>&1) ]]; do
-    sleep 1
-    # just try to attach table if it failed for some reason in the code above
-    for i in $(seq $REPLICAS); do
-        $CLICKHOUSE_CLIENT --query "ATTACH TABLE concurrent_alter_detach_$i" 2> /dev/null
-    done
+for retry in $(seq 3); do
+    if [[ $(timeout 120 ${CLICKHOUSE_CLIENT} --query "ALTER TABLE concurrent_alter_detach_1 MODIFY COLUMN value1 String SETTINGS replication_alter_partitions_sync=2" 2>&1) ]]; then
+        sleep 1
+        # just try to attach table if it failed for some reason in the code above
+        for i in $(seq $REPLICAS); do
+            $CLICKHOUSE_CLIENT --query "ATTACH TABLE concurrent_alter_detach_$i" 2> /dev/null
+        done
+    else
+        break
+    fi
 done
 
 for i in $(seq $REPLICAS); do


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

Fixes https://github.com/ClickHouse/ClickHouse/issues/91413

All the test failures I observed fail due to TIMEOUT_EXCEEDED due to `distributed_ddl_task_timeout` during `DROP TABLE`. I've modified the lines running `DROP TABLE` to ignore `TIMEOUT_EXCEEDED` errors. In all the example the test failures, the final output matches indicating no issues with the test run itself.

Example failures:
[[1]](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=88383&sha=aceb3e0e20aea76f3a95dfb92c4213fb7eaa7adb&name_0=PR&name_1=Stateless+tests+%28amd_binary%2C+old+analyzer%2C+s3+storage%2C+DatabaseReplicated%2C+sequential%29&name_1=Stateless+tests+%28amd_binary%2C+old+analyzer%2C+s3+storage%2C+DatabaseReplicated%2C+sequential%29&name_2=Tests
https://github.com/ClickHouse/ClickHouse/pull/88383), [[2]](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=88490&sha=c627b0c7f0c609119caf233a4b89a1bfa3919364&name_0=PR&name_1=Stateless%20tests%20%28amd_binary%2C%20old%20analyzer%2C%20s3%20storage%2C%20DatabaseReplicated%2C%20sequential%29&name_1=Stateless%20tests%20%28amd_binary%2C%20old%20analyzer%2C%20s3%20storage%2C%20DatabaseReplicated%2C%20sequential%29
https://github.com/ClickHouse/ClickHouse/pull/88490), [[3]](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=88827&sha=df34d890cffbf1de8b664ba1ab66d896b7de1ab6&name_0=PR&name_1=Stateless%20tests%20%28amd_binary%2C%20old%20analyzer%2C%20s3%20storage%2C%20DatabaseReplicated%2C%20sequential%29&name_1=Stateless%20tests%20%28amd_binary%2C%20old%20analyzer%2C%20s3%20storage%2C%20DatabaseReplicated%2C%20sequential%29
https://github.com/ClickHouse/ClickHouse/pull/88827), [[4]](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=89367&sha=05881f0516f7bfb8fcdc62f0833c0fb22213ba96&name_0=PR&name_1=Stateless%20tests%20%28amd_binary%2C%20old%20analyzer%2C%20s3%20storage%2C%20DatabaseReplicated%2C%20sequential%29&name_1=Stateless%20tests%20%28amd_binary%2C%20old%20analyzer%2C%20s3%20storage%2C%20DatabaseReplicated%2C%20sequential%29
https://github.com/ClickHouse/ClickHouse/pull/89367), [[5]](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=88269&sha=0a53cf04e9436bc4c109ef4766044df5aef6c21e&name_0=PR&name_1=Stateless%20tests%20%28amd_binary%2C%20old%20analyzer%2C%20s3%20storage%2C%20DatabaseReplicated%2C%20sequential%29&name_1=Stateless%20tests%20%28amd_binary%2C%20old%20analyzer%2C%20s3%20storage%2C%20DatabaseReplicated%2C%20sequential%29
https://github.com/ClickHouse/ClickHouse/pull/88269)

Also, while running the test locally, due to a faulty setup, my test was hanging. I've made a change to the test so that it retries only 3 times and not until it passes.