### PR TITLE
Fix flaky test_restore_db_replica

### DIFF
--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -13,6 +13,7 @@
 #include <Databases/DatabaseFactory.h>
 #include <Databases/DatabaseReplicated.h>
 #include <Databases/DatabaseReplicatedWorker.h>
+#include <Databases/LoadingStrictnessLevel.h>
 #include <Databases/TablesDependencyGraph.h>
 #include <Databases/enableAllExperimentalSettings.h>
 #include <IO/ReadBufferFromFile.h>
@@ -35,9 +36,9 @@
 #include <Interpreters/executeQuery.h>
 #include <Parsers/ASTAlterQuery.h>
 #include <Parsers/ASTDeleteQuery.h>
-#include <Parsers/ASTUpdateQuery.h>
 #include <Parsers/ASTDropQuery.h>
 #include <Parsers/ASTFunction.h>
+#include <Parsers/ASTUpdateQuery.h>
 #include <Parsers/ParserCreateQuery.h>
 #include <Parsers/parseQuery.h>
 #include <Processors/Sinks/EmptySink.h>
@@ -46,6 +47,8 @@
 #include <base/chrono_io.h>
 #include <base/defines.h>
 #include <base/getFQDNOrHostName.h>
+#include <base/scope_guard.h>
+#include <Common/AsyncLoader.h>
 #include <Common/Exception.h>
 #include <Common/FailPoint.h>
 #include <Common/Macros.h>
@@ -58,7 +61,6 @@
 #include <Common/ZooKeeper/ZooKeeper.h>
 #include <Common/threadPoolCallbackRunner.h>
 #include <Common/thread_local_rng.h>
-#include <Common/AsyncLoader.h>
 
 
 namespace DB
@@ -574,124 +576,14 @@ void DatabaseReplicated::tryConnectToZooKeeperAndInitDatabase(LoadingStrictnessL
             throw Exception(ErrorCodes::NO_ZOOKEEPER, "Can't create replicated database without ZooKeeper");
         }
 
-        auto current_zookeeper = getContext()->getZooKeeper();
-
-        if (!current_zookeeper->exists(zookeeper_path))
+        auto current_zookeeper = getZooKeeper();
+        if (mode < LoadingStrictnessLevel::ATTACH && !current_zookeeper->exists(zookeeper_path))
         {
             /// Create new database, multiple nodes can execute it concurrently
             createDatabaseNodesInZooKeeper(current_zookeeper);
         }
 
-        bool is_create_query = mode == LoadingStrictnessLevel::CREATE;
-
-        String replica_host_id;
-        bool replica_exists_in_zk = current_zookeeper->tryGet(replica_path, replica_host_id);
-
-        LOG_TEST(log, "Replica {} exists in Keeper {}", replica_path, replica_exists_in_zk);
-
-        if (replica_exists_in_zk)
-        {
-            if (replica_host_id == DROPPED_MARK && !is_create_query)
-            {
-                LOG_WARNING(log, "Database {} exists locally, but marked dropped in ZooKeeper ({}). "
-                                 "Will not try to start it up", getDatabaseName(), replica_path);
-                is_probably_dropped = true;
-                return;
-            }
-
-            String host_id = getHostID(getContext(), db_uuid, cluster_auth_info.cluster_secure_connection);
-            String host_id_default = getHostID(getContext(), db_uuid, false);
-
-            if (replica_host_id != host_id && replica_host_id != host_id_default)
-            {
-                UUID uuid_in_keeper = UUIDHelpers::Nil;
-                try
-                {
-                    uuid_in_keeper = std::get<2>(parseHostID(replica_host_id));
-                }
-                catch (const Exception & e)
-                {
-                    LOG_WARNING(log, "Failed to parse host_id {} in zookeeper, error {}", replica_host_id, e.what());
-                }
-
-                if (uuid_in_keeper != db_uuid)
-                    throw Exception(
-                        ErrorCodes::REPLICA_ALREADY_EXISTS,
-                        "Replica {} of shard {} of replicated database at {} already exists. Replica host ID: '{}', current host ID: '{}'",
-                        replica_name,
-                        shard_name,
-                        zookeeper_path,
-                        replica_host_id,
-                        host_id);
-
-                // After restarting, InterserverIOAddress might change (e.g: config updated, `getFQDNOrHostName` returns a different one)
-                // If the UUID in the keeper is the same as the current server UUID, we will update the host_id in keeper
-                LOG_INFO(
-                    log,
-                    "Replicated database replica: {}, shard {}, zk_path: {} already exists with the same UUID, replica host ID: '{}', "
-                    "current host ID: '{}', will set the host_id to the current host ID",
-                    replica_name,
-                    shard_name,
-                    zookeeper_path,
-                    replica_host_id,
-                    host_id);
-                current_zookeeper->set(replica_path, host_id, -1);
-                createEmptyLogEntry(current_zookeeper);
-            }
-
-            /// Before 24.6 we always created host_id with insecure port, even if cluster_auth_info.cluster_secure_connection was true.
-            /// So not to break compatibility, we need to update host_id to secure one if cluster_auth_info.cluster_secure_connection is true.
-            if (host_id != host_id_default && replica_host_id == host_id_default)
-            {
-                current_zookeeper->set(replica_path, host_id, -1);
-                createEmptyLogEntry(current_zookeeper);
-            }
-
-            /// Check that replica_group_name in ZooKeeper matches the local one and change it if necessary.
-            String zk_replica_group_name;
-            if (!current_zookeeper->tryGet(replica_path + "/replica_group", zk_replica_group_name))
-            {
-                /// Replica groups were introduced in 23.10, so the node might not exist
-                current_zookeeper->create(replica_path + "/replica_group", replica_group_name, zkutil::CreateMode::Persistent);
-                if (!replica_group_name.empty())
-                    createEmptyLogEntry(current_zookeeper);
-            }
-            else if (zk_replica_group_name != replica_group_name)
-            {
-                current_zookeeper->set(replica_path + "/replica_group", replica_group_name, -1);
-                createEmptyLogEntry(current_zookeeper);
-            }
-
-            /// Needed to mark all the queries
-            /// in the range (max log ptr at replica ZooKeeper nodes creation, max log ptr after replica recovery] as successful.
-            String max_log_ptr_at_creation_str;
-            if (current_zookeeper->tryGet(replica_path + "/max_log_ptr_at_creation", max_log_ptr_at_creation_str))
-                max_log_ptr_at_creation = parse<UInt32>(max_log_ptr_at_creation_str);
-        }
-
-        if (is_create_query)
-        {
-            /// Create replica nodes in ZooKeeper. If newly initialized nodes already exist, reuse them.
-            createReplicaNodesInZooKeeper(current_zookeeper);
-        }
-        else if (!replica_exists_in_zk)
-        {
-            /// It's not CREATE query, but replica does not exist. Probably it was dropped.
-            /// Do not create anything, continue as readonly.
-            LOG_WARNING(log, "Database {} exists locally, but its replica does not exist in ZooKeeper ({}). "
-                             "Assuming it was dropped, will not try to start it up", getDatabaseName(), replica_path);
-            is_probably_dropped = true;
-            return;
-        }
-
-        /// If not exist, create a node with the database name for introspection.
-        /// Technically, the database may have different names on different replicas, but this is not a usual case and we only save the first one
-        auto db_name_path = fs::path(zookeeper_path) / FIRST_REPLICA_DATABASE_NAME;
-        auto error_code = current_zookeeper->trySet(db_name_path, getDatabaseName());
-        if (error_code == Coordination::Error::ZNONODE)
-            current_zookeeper->tryCreate(db_name_path, getDatabaseName(), zkutil::CreateMode::Persistent);
-
-        is_readonly = false;
+        initDatabaseReplica(current_zookeeper, mode);
     }
     catch (...)
     {
@@ -704,10 +596,122 @@ void DatabaseReplicated::tryConnectToZooKeeperAndInitDatabase(LoadingStrictnessL
     }
 }
 
-bool DatabaseReplicated::createDatabaseNodesInZooKeeper(const zkutil::ZooKeeperPtr & current_zookeeper)
+void DatabaseReplicated::initDatabaseReplica(const ZooKeeperPtr & current_zookeeper, LoadingStrictnessLevel mode)
 {
-    current_zookeeper->createAncestors(zookeeper_path);
+    bool is_create_query = mode == LoadingStrictnessLevel::CREATE;
 
+    String replica_host_id;
+    bool replica_exists_in_zk = current_zookeeper->tryGet(replica_path, replica_host_id);
+
+    LOG_TEST(log, "Replica {} exists in Keeper {}", replica_path, replica_exists_in_zk);
+
+    if (replica_exists_in_zk)
+    {
+        if (replica_host_id == DROPPED_MARK && !is_create_query)
+        {
+                LOG_WARNING(log, "Database {} exists locally, but marked dropped in ZooKeeper ({}). "
+                                 "Will not try to start it up", getDatabaseName(), replica_path);
+            is_probably_dropped = true;
+            return;
+        }
+
+        String host_id = getHostID(getContext(), db_uuid, cluster_auth_info.cluster_secure_connection);
+        String host_id_default = getHostID(getContext(), db_uuid, false);
+
+        if (replica_host_id != host_id && replica_host_id != host_id_default)
+        {
+            UUID uuid_in_keeper = UUIDHelpers::Nil;
+            try
+            {
+                uuid_in_keeper = std::get<2>(parseHostID(replica_host_id));
+            }
+            catch (const Exception & e)
+            {
+                LOG_WARNING(log, "Failed to parse host_id {} in zookeeper, error {}", replica_host_id, e.what());
+            }
+
+            if (uuid_in_keeper != db_uuid)
+                throw Exception(
+                    ErrorCodes::REPLICA_ALREADY_EXISTS,
+                    "Replica {} of shard {} of replicated database at {} already exists. Replica host ID: '{}', current host ID: '{}'",
+                    replica_name,
+                    shard_name,
+                    zookeeper_path,
+                    replica_host_id,
+                    host_id);
+
+            // After restarting, InterserverIOAddress might change (e.g: config updated, `getFQDNOrHostName` returns a different one)
+            // If the UUID in the keeper is the same as the current server UUID, we will update the host_id in keeper
+            LOG_INFO(
+                log,
+                "Replicated database replica: {}, shard {}, zk_path: {} already exists with the same UUID, replica host ID: '{}', "
+                "current host ID: '{}', will set the host_id to the current host ID",
+                replica_name,
+                shard_name,
+                zookeeper_path,
+                replica_host_id,
+                host_id);
+            current_zookeeper->set(replica_path, host_id, -1);
+            createEmptyLogEntry(current_zookeeper);
+        }
+
+        /// Before 24.6 we always created host_id with insecure port, even if cluster_auth_info.cluster_secure_connection was true.
+        /// So not to break compatibility, we need to update host_id to secure one if cluster_auth_info.cluster_secure_connection is true.
+        if (host_id != host_id_default && replica_host_id == host_id_default)
+        {
+            current_zookeeper->set(replica_path, host_id, -1);
+            createEmptyLogEntry(current_zookeeper);
+        }
+
+        /// Check that replica_group_name in ZooKeeper matches the local one and change it if necessary.
+        String zk_replica_group_name;
+        if (!current_zookeeper->tryGet(replica_path + "/replica_group", zk_replica_group_name))
+        {
+            /// Replica groups were introduced in 23.10, so the node might not exist
+            current_zookeeper->create(replica_path + "/replica_group", replica_group_name, zkutil::CreateMode::Persistent);
+            if (!replica_group_name.empty())
+                createEmptyLogEntry(current_zookeeper);
+        }
+        else if (zk_replica_group_name != replica_group_name)
+        {
+            current_zookeeper->set(replica_path + "/replica_group", replica_group_name, -1);
+            createEmptyLogEntry(current_zookeeper);
+        }
+
+        /// Needed to mark all the queries
+        /// in the range (max log ptr at replica ZooKeeper nodes creation, max log ptr after replica recovery] as successful.
+        String max_log_ptr_at_creation_str;
+        if (current_zookeeper->tryGet(replica_path + "/max_log_ptr_at_creation", max_log_ptr_at_creation_str))
+            max_log_ptr_at_creation = parse<UInt32>(max_log_ptr_at_creation_str);
+    }
+
+    if (is_create_query)
+    {
+        /// Create replica nodes in ZooKeeper. If newly initialized nodes already exist, reuse them.
+        createReplicaNodesInZooKeeper(current_zookeeper);
+    }
+    else if (!replica_exists_in_zk)
+    {
+        /// It's not CREATE query, but replica does not exist. Probably it was dropped.
+        /// Do not create anything, continue as readonly.
+            LOG_WARNING(log, "Database {} exists locally, but its replica does not exist in ZooKeeper ({}). "
+                             "Assuming it was dropped, will not try to start it up", getDatabaseName(), replica_path);
+        is_probably_dropped = true;
+        return;
+    }
+
+    /// If not exist, create a node with the database name for introspection.
+    /// Technically, the database may have different names on different replicas, but this is not a usual case and we only save the first one
+    auto db_name_path = fs::path(zookeeper_path) / FIRST_REPLICA_DATABASE_NAME;
+    auto error_code = current_zookeeper->trySet(db_name_path, getDatabaseName());
+    if (error_code == Coordination::Error::ZNONODE)
+        current_zookeeper->tryCreate(db_name_path, getDatabaseName(), zkutil::CreateMode::Persistent);
+
+    is_readonly = false;
+}
+
+Coordination::Requests DatabaseReplicated::buildDatabaseNodesInZooKeeper()
+{
     Coordination::Requests ops;
     ops.emplace_back(zkutil::makeCreateRequest(zookeeper_path, REPLICATED_DATABASE_MARK, zkutil::CreateMode::Persistent));
     ops.emplace_back(zkutil::makeCreateRequest(zookeeper_path + "/log", "", zkutil::CreateMode::Persistent));
@@ -721,7 +725,17 @@ bool DatabaseReplicated::createDatabaseNodesInZooKeeper(const zkutil::ZooKeeperP
     ops.emplace_back(zkutil::makeCreateRequest(zookeeper_path + "/metadata", "", zkutil::CreateMode::Persistent));
     ops.emplace_back(zkutil::makeCreateRequest(zookeeper_path + "/max_log_ptr", "1", zkutil::CreateMode::Persistent));
     auto logs_to_keep = db_settings[DatabaseReplicatedSetting::logs_to_keep];
-    ops.emplace_back(zkutil::makeCreateRequest(zookeeper_path + "/logs_to_keep", std::to_string(logs_to_keep), zkutil::CreateMode::Persistent));
+    ops.emplace_back(
+        zkutil::makeCreateRequest(zookeeper_path + "/logs_to_keep", std::to_string(logs_to_keep), zkutil::CreateMode::Persistent));
+
+    return ops;
+}
+
+bool DatabaseReplicated::createDatabaseNodesInZooKeeper(const zkutil::ZooKeeperPtr & current_zookeeper)
+{
+    current_zookeeper->createAncestors(zookeeper_path);
+
+    Coordination::Requests ops = buildDatabaseNodesInZooKeeper();
 
     Coordination::Responses responses;
     auto res = current_zookeeper->tryMulti(ops, responses);
@@ -782,8 +796,8 @@ bool DatabaseReplicated::waitForReplicaToProcessAllEntries(UInt64 timeout_ms, Sy
         if (!ddl_worker || is_probably_dropped)
             return false;
     }
-    if (mode == SyncReplicaMode::DEFAULT)
-        return ddl_worker->waitForReplicaToProcessAllEntries(timeout_ms);
+        if (mode == SyncReplicaMode::DEFAULT)
+            return ddl_worker->waitForReplicaToProcessAllEntries(timeout_ms);
 
     Stopwatch elapsed;
     while (true)
@@ -976,29 +990,19 @@ void DatabaseReplicated::initDDLWorkerUnlocked()
     ddl_worker_initialized = true;
 }
 
-void DatabaseReplicated::restoreTablesMetadataInKeeper()
+void DatabaseReplicated::restoreDatabaseNodesInKeeper(const ZooKeeperPtr & zookeeper)
 {
-    auto zookeeper = getZooKeeper();
     auto local_context = getContext();
 
-    std::vector<std::string> tables_metadata_in_zk;
-    Coordination::Stat entity_name_stat;
+    zookeeper->createAncestors(zookeeper_path);
 
-    const String metadata_node_path = zookeeper_path + "/metadata";
+    Coordination::Requests ops;
+    auto add_ops = [&ops](Coordination::Requests && others)
+    { ops.insert(ops.end(), std::make_move_iterator(others.begin()), std::make_move_iterator(others.end())); };
 
-    const auto error_code = zookeeper->tryGetChildren(metadata_node_path, tables_metadata_in_zk, &entity_name_stat);
+    add_ops(buildDatabaseNodesInZooKeeper());
 
-    if (error_code != Coordination::Error::ZOK)
-        throw Coordination::Exception::fromPath(error_code, metadata_node_path);
-
-    if (!tables_metadata_in_zk.empty())
-    {
-        LOG_INFO(log, "Table metadata in '{}' was restored by another replica", metadata_node_path);
-        return;
-    }
-
-    auto txn = std::make_shared<ZooKeeperMetadataTransaction>(zookeeper, zookeeper_path, true, "");
-    UInt64 tables_digest{};
+    UInt64 tables_digest = 0;
 
     for (auto existing_tables_it = getTablesIterator(local_context, {}, /*skip_not_loaded=*/false); existing_tables_it->isValid();
          existing_tables_it->next())
@@ -1006,24 +1010,27 @@ void DatabaseReplicated::restoreTablesMetadataInKeeper()
         const String table_name = existing_tables_it->name();
         LOG_TEST(log, "Restoring metadata in Keeper of table {}", table_name);
 
-        assert(!ddl_worker || !ddl_worker->isCurrentlyActive());
-
         const String statement = getObjectDefinitionFromCreateQuery(getCreateTableQuery(table_name, local_context));
         const String table_metadata_zk_path = zookeeper_path + "/metadata/" + escapeForFileName(table_name);
-        txn->addOp(zkutil::makeCreateRequest(table_metadata_zk_path, statement, zkutil::CreateMode::Persistent));
+        add_ops({zkutil::makeCreateRequest(table_metadata_zk_path, statement, zkutil::CreateMode::Persistent)});
 
         tables_digest += DB::getMetadataHash(table_name, statement);
     }
 
-    txn->addOp(zkutil::makeSetRequest(metadata_node_path, "", entity_name_stat.version));
-    txn->addOp(zkutil::makeSetRequest(replica_path + "/digest", toString(tables_digest), -1));
     {
         std::lock_guard lock{metadata_mutex};
         tables_metadata_digest = tables_digest;
         if (!checkDigestValid(local_context))
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Digest does not match");
     }
-    txn->commit();
+    Coordination::Responses responses;
+    auto code = zookeeper->tryMulti(ops, responses);
+
+    if (code == Coordination::Error::ZOK)
+        return;
+
+    zkutil::KeeperMultiException::check(code, ops, responses);
+    UNREACHABLE();
 }
 
 void DatabaseReplicated::reinitializeDDLWorker()
@@ -1835,13 +1842,18 @@ std::map<String, String> DatabaseReplicated::getConsistentMetadataSnapshotImpl(
 {
     std::map<String, String> table_name_to_metadata;
     size_t iteration = 0;
+    auto metadata_path = zookeeper_path + "/metadata";
     while (++iteration <= max_retries)
     {
         table_name_to_metadata.clear();
+
+        Coordination::Stat prev_metadata_path_stat;
+        zookeeper->get(metadata_path, &prev_metadata_path_stat);
+
         LOG_DEBUG(log, "Trying to get consistent metadata snapshot for log pointer {}", max_log_ptr);
 
         Strings escaped_table_names;
-        escaped_table_names = zookeeper->getChildren(zookeeper_path + "/metadata");
+        escaped_table_names = zookeeper->getChildren(metadata_path);
         if (filter_by_table_name)
             std::erase_if(escaped_table_names, [&](const String & table) { return !filter_by_table_name(unescapeForFileName(table)); });
 
@@ -1849,11 +1861,24 @@ std::map<String, String> DatabaseReplicated::getConsistentMetadataSnapshotImpl(
         paths_to_fetch.reserve(escaped_table_names.size() + 1);
 
         for (const auto & table : escaped_table_names)
-            paths_to_fetch.push_back(zookeeper_path + "/metadata/" + table);
+            paths_to_fetch.push_back(metadata_path + "/" + table);
 
         paths_to_fetch.push_back(zookeeper_path + "/max_log_ptr");
 
         auto table_metadata_and_version = zookeeper->tryGet(paths_to_fetch);
+
+        Coordination::Stat current_metadata_path_stat;
+        zookeeper->get(metadata_path, &current_metadata_path_stat);
+
+        if (current_metadata_path_stat.ctime != prev_metadata_path_stat.ctime)
+        {
+            LOG_DEBUG(
+                log,
+                "Database zookeeper path was recreated. Created time before {}, current {}",
+                prev_metadata_path_stat.ctime,
+                current_metadata_path_stat.ctime);
+            continue;
+        }
 
         for (size_t i = 0; i < escaped_table_names.size(); ++i)
         {
@@ -1986,52 +2011,33 @@ void DatabaseReplicated::dropReplica(
     }
 }
 
-void DatabaseReplicated::restoreDatabaseMetadataInKeeper(ContextPtr)
+void DatabaseReplicated::restoreDatabaseInKeeper(ContextPtr)
 {
     waitDatabaseStarted();
 
-    /// Stop the DDL worker before restoring metadata to prevent a race condition:
-    /// the old DDL worker may reconnect to ZooKeeper, read the intermediate state
-    /// (where table metadata has not been written yet), and mistakenly move local
-    /// tables to `_broken_replicated_tables`.
-    {
-        std::lock_guard lock{ddl_worker_mutex};
-        if (ddl_worker)
-        {
-            LOG_TRACE(log, "Stopping DDL worker before restoring database metadata in Keeper.");
-            ddl_worker->shutdown();
-            ddl_worker_initialized = false;
-            ddl_worker = nullptr;
-        }
-    }
-
-    /// If the restore fails, reinitialize the DDL worker so the database remains functional.
-    bool need_reinitialize_ddl_worker = true;
-    SCOPE_EXIT({
-        if (need_reinitialize_ddl_worker)
-            reinitializeDDLWorker();
-    });
-
-    tryConnectToZooKeeperAndInitDatabase(LoadingStrictnessLevel::CREATE);
+    auto zookeeper = getZooKeeper();
+    if (!zookeeper)
+        throw Exception(ErrorCodes::NO_ZOOKEEPER, "No ZooKeeper");
 
     try
     {
-        restoreTablesMetadataInKeeper();
+        restoreDatabaseNodesInKeeper(zookeeper);
     }
     catch (const zkutil::KeeperMultiException & e)
     {
         if (Coordination::Error::ZNODEEXISTS != e.code)
-        {
             throw;
-        }
-        LOG_DEBUG(log, "It seems that the metadata was restored previously: {}.", e.what());
+
+        LOG_INFO(log, "Metadata was restored previously: {}.", e.what());
     }
+
+    initDatabaseReplica(zookeeper, LoadingStrictnessLevel::CREATE);
 
     /// Force the database to recover to update the restored metadata
     auto current_zookeeper = getContext()->getZooKeeper();
     current_zookeeper->set(replica_path + "/digest", DatabaseReplicatedDDLWorker::FORCE_AUTO_RECOVERY_DIGEST);
 
-    need_reinitialize_ddl_worker = false;
+    zookeeper->set(replica_path + "/digest", DatabaseReplicatedDDLWorker::FORCE_AUTO_RECOVERY_DIGEST);
     reinitializeDDLWorker();
 }
 

--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -1871,13 +1871,13 @@ std::map<String, String> DatabaseReplicated::getConsistentMetadataSnapshotImpl(
         Coordination::Stat current_metadata_path_stat;
         zookeeper->get(metadata_path, &current_metadata_path_stat);
 
-        if (current_metadata_path_stat.ctime != prev_metadata_path_stat.ctime)
+        if (current_metadata_path_stat.czxid != prev_metadata_path_stat.czxid)
         {
             LOG_DEBUG(
                 log,
                 "Database zookeeper path was recreated. Created time before {}, current {}",
-                prev_metadata_path_stat.ctime,
-                current_metadata_path_stat.ctime);
+                prev_metadata_path_stat.czxid,
+                current_metadata_path_stat.czxid);
             continue;
         }
 

--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -796,8 +796,9 @@ bool DatabaseReplicated::waitForReplicaToProcessAllEntries(UInt64 timeout_ms, Sy
         if (!ddl_worker || is_probably_dropped)
             return false;
     }
-        if (mode == SyncReplicaMode::DEFAULT)
-            return ddl_worker->waitForReplicaToProcessAllEntries(timeout_ms);
+
+    if (mode == SyncReplicaMode::DEFAULT)
+        return ddl_worker->waitForReplicaToProcessAllEntries(timeout_ms);
 
     Stopwatch elapsed;
     while (true)
@@ -2036,8 +2037,6 @@ void DatabaseReplicated::restoreDatabaseInKeeper(ContextPtr)
     /// Force the database to recover to update the restored metadata
     auto current_zookeeper = getContext()->getZooKeeper();
     current_zookeeper->set(replica_path + "/digest", DatabaseReplicatedDDLWorker::FORCE_AUTO_RECOVERY_DIGEST);
-
-    zookeeper->set(replica_path + "/digest", DatabaseReplicatedDDLWorker::FORCE_AUTO_RECOVERY_DIGEST);
     reinitializeDDLWorker();
 }
 

--- a/src/Databases/DatabaseReplicated.h
+++ b/src/Databases/DatabaseReplicated.h
@@ -5,11 +5,12 @@
 
 #include <Databases/DatabaseAtomic.h>
 #include <Databases/DatabaseReplicatedSettings.h>
-#include <QueryPipeline/BlockIO.h>
 #include <Interpreters/Context_fwd.h>
-#include <base/defines.h>
 #include <Interpreters/QueryFlags.h>
 #include <Parsers/SyncReplicaMode.h>
+#include <QueryPipeline/BlockIO.h>
+#include <base/defines.h>
+#include <Common/ZooKeeper/IKeeper.h>
 
 
 namespace zkutil
@@ -125,7 +126,7 @@ public:
 
     static void dropReplica(DatabaseReplicated * database, const String & database_zookeeper_path, const String & shard, const String & replica, bool throw_if_noop);
 
-    void restoreDatabaseMetadataInKeeper(ContextPtr ctx);
+    void restoreDatabaseInKeeper(ContextPtr ctx);
 
     ReplicasInfo tryGetReplicasInfo(const ClusterPtr & cluster_) const;
 
@@ -147,6 +148,8 @@ protected:
 
 private:
     void tryConnectToZooKeeperAndInitDatabase(LoadingStrictnessLevel mode);
+    void initDatabaseReplica(const ZooKeeperPtr & current_zookeeper, LoadingStrictnessLevel mode);
+    Coordination::Requests buildDatabaseNodesInZooKeeper();
     bool createDatabaseNodesInZooKeeper(const ZooKeeperPtr & current_zookeeper);
     static bool looksLikeReplicatedDatabasePath(const ZooKeeperPtr & current_zookeeper, const String & path);
     void createReplicaNodesInZooKeeper(const ZooKeeperPtr & current_zookeeper);
@@ -207,8 +210,7 @@ private:
 
     void initDDLWorkerUnlocked() TSA_REQUIRES(ddl_worker_mutex);
 
-    void restoreTablesMetadataInKeeper();
-
+    void restoreDatabaseNodesInKeeper(const ZooKeeperPtr & zookeeper);
     void reinitializeDDLWorker();
 
     static BlockIO

--- a/src/Interpreters/InterpreterSystemQuery.cpp
+++ b/src/Interpreters/InterpreterSystemQuery.cpp
@@ -1056,7 +1056,7 @@ void InterpreterSystemQuery::restoreDatabaseReplica(ASTSystemQuery & query)
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Database {} is not Replicated", database_name);
     }
 
-    replicated_db->restoreDatabaseMetadataInKeeper(getContext());
+    replicated_db->restoreDatabaseInKeeper(getContext());
 
     LOG_TRACE(log, "Replicated database {} was restored.", database_name);
 }

--- a/tests/integration/test_replicated_database/test.py
+++ b/tests/integration/test_replicated_database/test.py
@@ -1864,14 +1864,18 @@ def test_block_system_database_replicas(started_cluster):
             f"ATTACH DATABASE {prefix}_db_{i}"
         )
 
-    expected = TSV([
-        [f"{prefix}_db_1", 1, 1],
-        [f"{prefix}_db_2", 1, 1],
-        [f"{prefix}_db_3", 1, 1],
-        [f"{prefix}_db_4", 0, 1],
-        [f"{prefix}_db_5", 0, 1],
-        [f"{prefix}_db_6", 0, 1],
-    ])
+    # When attaching database, if the db keeper path is remove, it does not recreate DB nodes on Keeper
+    # So max_log_ptr is zero because it is never updated.
+    expected = TSV(
+        [
+            [f"{prefix}_db_1", 1, 0],
+            [f"{prefix}_db_2", 1, 0],
+            [f"{prefix}_db_3", 1, 0],
+            [f"{prefix}_db_4", 0, 1],
+            [f"{prefix}_db_5", 0, 1],
+            [f"{prefix}_db_6", 0, 1],
+        ]
+    )
 
     assert (
         main_node.query(

--- a/tests/integration/test_replicated_database/test.py
+++ b/tests/integration/test_replicated_database/test.py
@@ -101,7 +101,6 @@ def zk_rmr_with_retries(zk, path):
     assert False
 
 
-
 def generate_random_string(length=6):
     return "".join(random.choice(string.ascii_lowercase) for i in range(length))
 
@@ -1770,9 +1769,13 @@ def test_system_database_replicas_with_ro(started_cluster):
     main_node.query(f"DETACH DATABASE {database_1}")
     main_node.query(f"ATTACH DATABASE {database_1}", ignore_error=True)
 
-    expected = TSV([
-        [database_1, 1, 1],
-    ])
+    # When attaching database, if the db keeper path is remove, it does not recreate DB nodes on Keeper
+    # So max_log_ptr is zero because it is never updated.
+    expected = TSV(
+        [
+            [database_1, 1, 0],
+        ]
+    )
     assert (
         main_node.query(
             f"SELECT database, is_readonly, max_log_ptr FROM system.database_replicas WHERE database LIKE '{prefix}_%'") == expected
@@ -1783,10 +1786,12 @@ def test_system_database_replicas_with_ro(started_cluster):
         f"CREATE DATABASE {database_2} ENGINE = Replicated('/test/{database_2}', 'shard1', 'replica1');"
     )
 
-    expected = TSV([
-        [database_1, 1, 1],
-        [database_2, 0, 1],
-    ])
+    expected = TSV(
+        [
+            [database_1, 1, 0],
+            [database_2, 0, 1],
+        ]
+    )
     assert (
         main_node.query(
             f"SELECT database, is_readonly, max_log_ptr FROM system.database_replicas WHERE database LIKE '{prefix}_%' ORDER BY database"

--- a/tests/integration/test_restore_db_replica/configs/logger.xml
+++ b/tests/integration/test_restore_db_replica/configs/logger.xml
@@ -1,0 +1,5 @@
+<clickhouse>
+    <logger>
+        <count>100</count>
+    </logger>
+</clickhouse>

--- a/tests/integration/test_restore_db_replica/test.py
+++ b/tests/integration/test_restore_db_replica/test.py
@@ -8,7 +8,7 @@ from helpers.cluster import ClickHouseCluster, ClickHouseKiller
 from helpers.test_tools import TSV
 
 cluster = ClickHouseCluster(__file__)
-configs = ["configs/remote_servers.xml"]
+configs = ["configs/remote_servers.xml", "configs/logger.xml"]
 
 node_1 = cluster.add_instance(
     name="node1",
@@ -140,6 +140,36 @@ def zk_rmr_with_retries(zk, path):
     assert False
 
 
+def count_log_message(node, db_name, msg):
+    node.query("SYSTEM FLUSH LOGS")
+    return int(
+        node.query(
+            f"SELECT count() FROM system.text_log WHERE logger_name='DatabaseReplicated ({db_name})' AND message ='{msg}'"
+        ).strip()
+    )
+
+
+def restore_database_and_wait(node, db_name: str, on_cluster):
+    print(f"Restore database node {node.name}, db {db_name}")
+    log_msg = "All tables are created successfully"
+    prev_count = count_log_message(node, db_name, log_msg)
+
+    if on_cluster is not None:
+        node.query(
+            f"SYSTEM RESTORE DATABASE REPLICA ON CLUSTER `{on_cluster}` `{db_name}`"
+        )
+    else:
+        node.query(f"SYSTEM RESTORE DATABASE REPLICA `{db_name}`")
+
+    for i in range(30):
+        current_count = count_log_message(node, db_name, log_msg)
+        if current_count > prev_count:
+            return
+        time.sleep(0.5)
+
+    raise Exception(f"Creating all table timed out when restoring database {db_name}")
+
+
 @pytest.fixture(scope="module")
 def start_cluster():
     try:
@@ -257,8 +287,7 @@ def test_query_after_restore_db_replica(
         is None
     )
 
-    node_1.query(f"SYSTEM RESTORE DATABASE REPLICA {exclusive_database_name}")
-    assert node_1.wait_for_log_line(f"{exclusive_database_name}): All tables are created successfully")
+    restore_database_and_wait(node_1, exclusive_database_name, None)
 
     if need_restart:
         node_1.restart_clickhouse()
@@ -274,8 +303,7 @@ def test_query_after_restore_db_replica(
         is None
     )
 
-    node_2.query(f"SYSTEM RESTORE DATABASE REPLICA {exclusive_database_name}")
-    assert node_2.wait_for_log_line(f"{exclusive_database_name}): All tables are created successfully")
+    restore_database_and_wait(node_2, exclusive_database_name, None)
     assert zk.exists(f"/clickhouse/{exclusive_database_name}/replicas/shard1|replica2")
 
     if exists_table:
@@ -346,10 +374,8 @@ def test_query_after_restore_db_replica(
         is None
     )
 
-    node_1.query(f"SYSTEM RESTORE DATABASE REPLICA {exclusive_database_name}")
-    assert node_1.wait_for_log_line(f"{exclusive_database_name}): All tables are created successfully")
-    node_2.query(f"SYSTEM RESTORE DATABASE REPLICA {exclusive_database_name}")
-    assert node_2.wait_for_log_line(f"{exclusive_database_name}): All tables are created successfully")
+    restore_database_and_wait(node_1, exclusive_database_name, None)
+    restore_database_and_wait(node_2, exclusive_database_name, None)
 
     if need_restart:
         node_1.restart_clickhouse()
@@ -482,8 +508,7 @@ def test_restore_db_replica_with_diffrent_table_metadata(
         nodes.reverse()
 
     for node in nodes:
-        node.query(f"SYSTEM RESTORE DATABASE REPLICA {exclusive_database_name}")
-        assert node.wait_for_log_line(f"{exclusive_database_name}): All tables are created successfully")
+        restore_database_and_wait(node, exclusive_database_name, None)
 
     assert node_1.query_with_retry(
         f"SELECT count(*) FROM {exclusive_database_name}.{test_table_1}",
@@ -625,8 +650,7 @@ def test_restore_db_replica_on_cluster(
     zk_rmr_with_retries(zk, f"/clickhouse/{exclusive_database_name}")
     assert zk.exists(f"/clickhouse/{exclusive_database_name}") is None
 
-    node_1.query(f"SYSTEM RESTORE DATABASE REPLICA ON CLUSTER `test_cluster` {exclusive_database_name}")
-    assert node_1.wait_for_log_line(f"{exclusive_database_name}): All tables are created successfully")
+    restore_database_and_wait(node_1, exclusive_database_name, "test_cluster")
 
     assert node_1.query(
         f"SELECT count(*) FROM system.databases WHERE name='{exclusive_database_name}'"


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

CIDB [link](https://play.clickhouse.com/play?user=play&run=1#U0VMRUNUIGNoZWNrX3N0YXJ0X3RpbWUsIGNoZWNrX25hbWUsIHRlc3RfbmFtZSwgcmVwb3J0X3VybApGUk9NIGNoZWNrcwpXSEVSRSBjaGVja19zdGFydF90aW1lID49IG5vdygpIC0gSU5URVJWQUwgMSBNT05USAogICAgQU5EIChoZWFkX3JlZiA9ICdtYXN0ZXInIEFORCBzdGFydHNXaXRoKGhlYWRfcmVwbywgJ0NsaWNrSG91c2UvJykpCiAgICBBTkQgdGVzdF9zdGF0dXMgIT0gJ1NLSVBQRUQnCiAgICBBTkQgKHRlc3Rfc3RhdHVzIExJS0UgJ0YlJyBPUiB0ZXN0X3N0YXR1cyBMSUtFICdFJScpIAogICAgQU5EIGNoZWNrX3N0YXR1cyAhPSAnc3VjY2VzcycKICAgIEFORCBwb3NpdGlvbih0ZXN0X25hbWUsICdyZXN0b3JlX2RiX3JlcGxpY2EnKSA+IDAKT1JERVIgQlkgY2hlY2tfc3RhcnRfdGltZSBERVND)

Wait for the database to be restored completely in test_restore_db_replica

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.646`
<!-- ch-version-info:end -->