### PR TITLE
feat(Functions): add KUSTO `iif` fuction

### DIFF
--- a/ci/jobs/scripts/check_style/codespell-ignore-words.list
+++ b/ci/jobs/scripts/check_style/codespell-ignore-words.list
@@ -45,3 +45,4 @@ XNPV
 tage
 goup
 childres
+iif

--- a/src/Parsers/Kusto/KustoFunctions/KQLFunctionFactory.cpp
+++ b/src/Parsers/Kusto/KustoFunctions/KQLFunctionFactory.cpp
@@ -208,6 +208,7 @@ std::unordered_map<String, KQLFunctionValue> KQLFunctionFactory::kql_functions
 
        {"bin", KQLFunctionValue::bin},
        {"bin_at", KQLFunctionValue::bin_at},
+       {"iif", KQLFunctionValue::iif},
 
        {"bool", KQLFunctionValue::datatype_bool},
        {"boolean", KQLFunctionValue::datatype_bool},
@@ -774,6 +775,9 @@ std::unique_ptr<IParserKQLFunction> KQLFunctionFactory::get(String & kql_functio
 
         case KQLFunctionValue::bin_at:
             return std::make_unique<BinAt>();
+
+        case KQLFunctionValue::iif:
+            return std::make_unique<Iif>();
 
         case KQLFunctionValue::datatype_bool:
             return std::make_unique<DatatypeBool>();

--- a/src/Parsers/Kusto/KustoFunctions/KQLFunctionFactory.h
+++ b/src/Parsers/Kusto/KustoFunctions/KQLFunctionFactory.h
@@ -195,6 +195,7 @@ enum class KQLFunctionValue : uint16_t
 
     bin,
     bin_at,
+    iif,
 
     datatype_bool,
     datatype_datetime,

--- a/src/Parsers/Kusto/KustoFunctions/KQLGeneralFunctions.cpp
+++ b/src/Parsers/Kusto/KustoFunctions/KQLGeneralFunctions.cpp
@@ -19,6 +19,11 @@
 
 #include <fmt/format.h>
 
+namespace DB::ErrorCodes
+{
+extern const int SYNTAX_ERROR;
+}
+
 namespace DB
 {
 
@@ -109,12 +114,18 @@ bool Iif::convertImpl(String & out, IParser::Pos & pos)
 
     ++pos;
     String predicate = getConvertedArgument(fn_name, pos);
+    if (predicate.empty())
+        throw Exception(ErrorCodes::SYNTAX_ERROR, "Number of arguments do not match in function: {}", fn_name);
 
     ++pos;
     String if_true = getConvertedArgument(fn_name, pos);
+    if (if_true.empty())
+        throw Exception(ErrorCodes::SYNTAX_ERROR, "Number of arguments do not match in function: {}", fn_name);
 
     ++pos;
     String if_false = getConvertedArgument(fn_name, pos);
+    if (if_false.empty())
+        throw Exception(ErrorCodes::SYNTAX_ERROR, "Number of arguments do not match in function: {}", fn_name);
 
     out = fmt::format("if({}, {}, {})", predicate, if_true, if_false);
     return true;

--- a/src/Parsers/Kusto/KustoFunctions/KQLGeneralFunctions.cpp
+++ b/src/Parsers/Kusto/KustoFunctions/KQLGeneralFunctions.cpp
@@ -101,4 +101,23 @@ bool BinAt::convertImpl(String & out, IParser::Pos & pos)
     return true;
 }
 
+bool Iif::convertImpl(String & out, IParser::Pos & pos)
+{
+    const String fn_name = getKQLFunctionName(pos);
+    if (fn_name.empty())
+        return false;
+
+    ++pos;
+    String predicate = getConvertedArgument(fn_name, pos);
+
+    ++pos;
+    String if_true = getConvertedArgument(fn_name, pos);
+
+    ++pos;
+    String if_false = getConvertedArgument(fn_name, pos);
+
+    out = fmt::format("if({}, {}, {})", predicate, if_true, if_false);
+    return true;
+}
+
 }

--- a/src/Parsers/Kusto/KustoFunctions/KQLGeneralFunctions.h
+++ b/src/Parsers/Kusto/KustoFunctions/KQLGeneralFunctions.h
@@ -18,4 +18,11 @@ protected:
     bool convertImpl(String & out, IParser::Pos & pos) override;
 };
 
+class Iif : public IParserKQLFunction
+{
+protected:
+    const char * getName() const override { return "iif()"; }
+    bool convertImpl(String & out, IParser::Pos & pos) override;
+};
+
 }

--- a/tests/queries/0_stateless/02366_kql_func_iif.reference
+++ b/tests/queries/0_stateless/02366_kql_func_iif.reference
@@ -1,0 +1,25 @@
+-- iif() basic tests
+yes
+no
+less or equal
+100
+-- iif() with numeric types
+1.5
+200
+-- iif() with null values
+is null
+has value
+-- iif() nested
+inner true
+inner true
+-- iif() with table data
+ten	low
+twenty	high
+thirty	high
+five	low
+ten	20
+twenty	20
+thirty	30
+five	10
+twenty	20
+thirty	30

--- a/tests/queries/0_stateless/02366_kql_func_iif.sql
+++ b/tests/queries/0_stateless/02366_kql_func_iif.sql
@@ -1,0 +1,37 @@
+-- Test iif() function in KQL dialect
+DROP TABLE IF EXISTS iif_test;
+CREATE TABLE iif_test
+(    
+    value Int32,
+    name String
+) ENGINE = Memory;
+INSERT INTO iif_test VALUES (10, 'ten'), (20, 'twenty'), (30, 'thirty'), (5, 'five');
+
+set allow_experimental_kusto_dialect=1;
+set dialect = 'kusto';
+
+print '-- iif() basic tests';
+print iif(true, 'yes', 'no');
+print iif(false, 'yes', 'no');
+print iif(1 > 2, 'greater', 'less or equal');
+print iif(10 < 20, 100, 200);
+
+print '-- iif() with numeric types';
+print iif(5 > 3, 1.5, 2.5);
+print iif(5 < 3, 100, 200);
+
+print '-- iif() with null values';
+print iif(isnull(null), 'is null', 'not null');
+print iif(isnotnull(5), 'has value', 'no value');
+
+print '-- iif() nested';
+print iif(true, iif(true, 'inner true', 'inner false'), 'outer false');
+print iif(false, 'outer true', iif(true, 'inner true', 'inner false'));
+
+print '-- iif() with table data';
+iif_test | project name, category = iif(value > 15, 'high', 'low');
+iif_test | project name, doubled = iif(value < 20, value * 2, value);
+iif_test | where iif(value > 10, true, false) | project name, value;
+
+set dialect = 'clickhouse';
+DROP TABLE IF EXISTS iif_test;


### PR DESCRIPTION
Relates to #94779 

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
- Add `iif` function to ClickHouse KQL.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

- Motivation: Provide the `iif` function, a commonly used function in KQL.

- Parameters:
  - `predicate` — expression evaluated as boolean.
  - `if_true` — value returned when predicate is true.
  - `if_false` — value returned when predicate is false.

- Example:
   ```
   iif(age >= 18, 'adult', 'minor')
   SELECT iif(score >= 60, 'pass', 'fail') FROM users;
   ```
<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.158`
<!-- ch-version-info:end -->