### PR TITLE
Fix incorrect monotonicity for `toWeek`, `toYearWeek`, `toStartOfWeek`, `toLastDayOfWeek`, `toDayOfWeek` causing wrong pruning

### DIFF
--- a/tests/queries/0_stateless/03789_to_year_week_monotonicity_key_condition.reference
+++ b/tests/queries/0_stateless/03789_to_year_week_monotonicity_key_condition.reference
@@ -1,0 +1,52 @@
+-- { echo }
+
+DROP TABLE IF EXISTS t;
+CREATE TABLE t (s String)
+ENGINE = MergeTree
+ORDER BY s;
+INSERT INTO t VALUES
+    ('2020-01-10 00:00:00'),
+    ('2020-01-2 00:00:00');
+SELECT * FROM t
+WHERE toYearWeek(s) = toYearWeek('2020-01-2 00:00:00');
+2020-01-2 00:00:00
+DROP TABLE IF EXISTS t;
+CREATE TABLE t (d Date32)
+ENGINE = MergeTree
+ORDER BY d;
+INSERT INTO t VALUES ('2020-12-31'), ('2021-01-01');
+SELECT * FROM t
+WHERE toWeek(d) = toWeek(toDate32('2020-12-31'));
+2020-12-31
+DROP TABLE IF EXISTS t;
+CREATE TABLE t (s String)
+ENGINE = MergeTree
+ORDER BY s;
+INSERT INTO t VALUES
+    ('2020-02-11 00:00:00'),
+    ('2020-02-3 00:00:00');
+SELECT * FROM t
+WHERE toWeek(s) = toWeek('2020-02-3 00:00:00');
+2020-02-3 00:00:00
+DROP TABLE IF EXISTS t;
+CREATE TABLE t (dt DateTime) ENGINE=MergeTree ORDER BY dt SETTINGS index_granularity=1;
+INSERT INTO t SELECT toDateTime('2020-01-01 00:00:00') + number * 3600 FROM numbers(24 * 40);
+SELECT count()
+FROM t
+WHERE toWeek(dt) = toWeek(toDateTime('2020-01-15 00:00:00')) SETTINGS force_primary_key = 1, max_rows_to_read = 169;
+168
+DROP TABLE IF EXISTS t;
+CREATE TABLE t (s LowCardinality(String)) ENGINE = MergeTree ORDER BY s;
+INSERT INTO t VALUES ('2020-01-10 00:00:00'), ('2020-01-2 00:00:00');
+SELECT * FROM t WHERE toYearWeek(s) = toYearWeek('2020-01-2 00:00:00');
+2020-01-2 00:00:00
+DROP TABLE IF EXISTS t;
+CREATE TABLE t (s Nullable(String)) ENGINE = MergeTree ORDER BY s SETTINGS allow_nullable_key = 1;
+INSERT INTO t VALUES ('2020-01-10 00:00:00'), ('2020-01-2 00:00:00');
+SELECT * FROM t WHERE toYearWeek(s) = toYearWeek('2020-01-2 00:00:00');
+2020-01-2 00:00:00
+DROP TABLE IF EXISTS t;
+CREATE TABLE t (s LowCardinality(String)) ENGINE = MergeTree ORDER BY s;
+INSERT INTO t VALUES ('2020-01-10 00:00:00'), ('2020-01-2 00:00:00');
+SELECT * FROM t WHERE toYearWeek(s) = toYearWeek('2020-01-2 00:00:00');
+2020-01-2 00:00:00

--- a/tests/queries/0_stateless/03789_to_year_week_monotonicity_key_condition.sql
+++ b/tests/queries/0_stateless/03789_to_year_week_monotonicity_key_condition.sql
@@ -1,0 +1,61 @@
+-- { echo }
+
+DROP TABLE IF EXISTS t;
+CREATE TABLE t (s String)
+ENGINE = MergeTree
+ORDER BY s;
+
+INSERT INTO t VALUES
+    ('2020-01-10 00:00:00'),
+    ('2020-01-2 00:00:00');
+
+SELECT * FROM t
+WHERE toYearWeek(s) = toYearWeek('2020-01-2 00:00:00');
+
+DROP TABLE IF EXISTS t;
+CREATE TABLE t (d Date32)
+ENGINE = MergeTree
+ORDER BY d;
+
+INSERT INTO t VALUES ('2020-12-31'), ('2021-01-01');
+
+SELECT * FROM t
+WHERE toWeek(d) = toWeek(toDate32('2020-12-31'));
+
+DROP TABLE IF EXISTS t;
+CREATE TABLE t (s String)
+ENGINE = MergeTree
+ORDER BY s;
+
+INSERT INTO t VALUES
+    ('2020-02-11 00:00:00'),
+    ('2020-02-3 00:00:00');
+
+SELECT * FROM t
+WHERE toWeek(s) = toWeek('2020-02-3 00:00:00');
+
+DROP TABLE IF EXISTS t;
+CREATE TABLE t (dt DateTime) ENGINE=MergeTree ORDER BY dt SETTINGS index_granularity=1;
+INSERT INTO t SELECT toDateTime('2020-01-01 00:00:00') + number * 3600 FROM numbers(24 * 40);
+
+SELECT count()
+FROM t
+WHERE toWeek(dt) = toWeek(toDateTime('2020-01-15 00:00:00')) SETTINGS force_primary_key = 1, max_rows_to_read = 169;
+
+DROP TABLE IF EXISTS t;
+CREATE TABLE t (s LowCardinality(String)) ENGINE = MergeTree ORDER BY s;
+INSERT INTO t VALUES ('2020-01-10 00:00:00'), ('2020-01-2 00:00:00');
+
+SELECT * FROM t WHERE toYearWeek(s) = toYearWeek('2020-01-2 00:00:00');
+
+DROP TABLE IF EXISTS t;
+CREATE TABLE t (s Nullable(String)) ENGINE = MergeTree ORDER BY s SETTINGS allow_nullable_key = 1;
+INSERT INTO t VALUES ('2020-01-10 00:00:00'), ('2020-01-2 00:00:00');
+
+SELECT * FROM t WHERE toYearWeek(s) = toYearWeek('2020-01-2 00:00:00');
+
+DROP TABLE IF EXISTS t;
+CREATE TABLE t (s LowCardinality(String)) ENGINE = MergeTree ORDER BY s;
+INSERT INTO t VALUES ('2020-01-10 00:00:00'), ('2020-01-2 00:00:00');
+
+SELECT * FROM t WHERE toYearWeek(s) = toYearWeek('2020-01-2 00:00:00');


### PR DESCRIPTION
Wrong answer:

```sql
CREATE TABLE t (s String) ENGINE = MergeTree ORDER BY s;
INSERT INTO t VALUES ('2020-01-10 00:00:00'), ('2020-01-2 00:00:00');
SELECT count() FROM t WHERE toYearWeek(s) = toYearWeek('2020-01-2 00:00:00'); -- should be 1
```

```sql
CREATE TABLE t (d Date32) ENGINE = MergeTree ORDER BY d;
INSERT INTO t VALUES ('2020-12-31'), ('2021-01-01');
SELECT count() FROM t WHERE toWeek(d) = toWeek(toDate32('2020-12-31')); -- should be 1
```

Exception on valid query:
```sql
CREATE TABLE t (s LowCardinality(String)) ENGINE = MergeTree ORDER BY s;
INSERT INTO t VALUES ('2020-01-10 00:00:00'), ('2020-01-2 00:00:00');
SELECT * FROM t WHERE toYearWeek(s) = toYearWeek('2020-01-2 00:00:00');
```

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix incorrect primary key and skip index pruning for predicates involving `toWeek`, `toYearWeek`, `toStartOfWeek`, `toLastDayOfWeek`, and `toDayOfWeek`, and fix exceptions in some of these functions for valid queries with `LowCardinality(String)`.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.132`
- Backported to: `26.1.2.10`, `25.12.5.41`, `25.11.9.10`, `25.10.6.34`, `25.8.16.31`, `25.3.14.14`
<!-- ch-version-info:end -->