### PR TITLE
Introduce `TryRemove` keeper extension

### DIFF
--- a/src/Common/ZooKeeper/IKeeper.h
+++ b/src/Common/ZooKeeper/IKeeper.h
@@ -425,6 +425,7 @@ struct RemoveRequest : virtual Request
 {
     String path;
     int32_t version = -1;
+    bool try_remove = false;
 
     void addRootPath(const String & root_path) override;
     String getPath() const override { return path; }

--- a/src/Common/ZooKeeper/KeeperFeatureFlags.h
+++ b/src/Common/ZooKeeper/KeeperFeatureFlags.h
@@ -27,6 +27,7 @@ enum class KeeperFeatureFlag : size_t
     CHECK_STAT,
     PERSISTENT_WATCHES,
     CREATE_WITH_STATS,
+    TRY_REMOVE,
 };
 
 class KeeperFeatureFlags

--- a/src/Common/ZooKeeper/SystemTablesDataTypes.cpp
+++ b/src/Common/ZooKeeper/SystemTablesDataTypes.cpp
@@ -50,6 +50,7 @@ DB::DataTypePtr SystemTablesDataTypes::operationEnum()
             {"Error",               static_cast<Int16>(OpNum::Error)},
             {"Create",              static_cast<Int16>(OpNum::Create)},
             {"Remove",              static_cast<Int16>(OpNum::Remove)},
+            {"TryRemove",           static_cast<Int16>(OpNum::TryRemove)},
             {"Exists",              static_cast<Int16>(OpNum::Exists)},
             {"Reconfig",            static_cast<Int16>(OpNum::Reconfig)},
             {"Get",                 static_cast<Int16>(OpNum::Get)},

--- a/src/Common/ZooKeeper/TestKeeper.cpp
+++ b/src/Common/ZooKeeper/TestKeeper.cpp
@@ -363,15 +363,18 @@ std::pair<ResponsePtr, Undo> TestKeeperRemoveRequest::process(TestKeeper::Contai
     auto it = container.find(path);
     if (it == container.end())
     {
-        response.error = Error::ZNONODE;
+        if (!try_remove)
+            response.error = Error::ZNONODE;
     }
     else if (version != -1 && version != it->second.stat.version)
     {
-        response.error = Error::ZBADVERSION;
+        if (!try_remove)
+            response.error = Error::ZBADVERSION;
     }
     else if (it->second.stat.numChildren)
     {
-        response.error = Error::ZNOTEMPTY;
+        if (!try_remove)
+            response.error = Error::ZNOTEMPTY;
     }
     else
     {
@@ -766,6 +769,7 @@ TestKeeper::TestKeeper(const zkutil::ZooKeeperArgs & args_)
     keeper_feature_flags.enableFeatureFlag(KeeperFeatureFlag::CREATE_IF_NOT_EXISTS);
     keeper_feature_flags.enableFeatureFlag(KeeperFeatureFlag::REMOVE_RECURSIVE);
     keeper_feature_flags.enableFeatureFlag(KeeperFeatureFlag::CHECK_STAT);
+    keeper_feature_flags.enableFeatureFlag(KeeperFeatureFlag::TRY_REMOVE);
 
     processing_thread = ThreadFromGlobalPool([this] { processingThread(); });
 }

--- a/src/Common/ZooKeeper/Types.h
+++ b/src/Common/ZooKeeper/Types.h
@@ -26,7 +26,7 @@ template <typename R>
 using AsyncResponses = std::vector<std::pair<std::string, std::future<R>>>;
 
 Coordination::RequestPtr makeCreateRequest(const std::string & path, const std::string & data, int create_mode, bool ignore_if_exists = false);
-Coordination::RequestPtr makeRemoveRequest(const std::string & path, int version);
+Coordination::RequestPtr makeRemoveRequest(const std::string & path, int version, bool try_remove = false);
 Coordination::RequestPtr makeSetRequest(const std::string & path, const std::string & data, int version);
 Coordination::RequestPtr makeCheckRequest(const std::string & path, int version, bool not_exists = false, std::optional<Coordination::Stat> stat_to_check = std::nullopt);
 Coordination::RequestPtr makeGetRequest(const std::string & path, Coordination::WatchCallbackPtrOrEventPtr watch = {});

--- a/src/Common/ZooKeeper/ZooKeeper.cpp
+++ b/src/Common/ZooKeeper/ZooKeeper.cpp
@@ -1665,11 +1665,12 @@ Coordination::RequestPtr makeCreateRequest(const std::string & path, const std::
     return request;
 }
 
-Coordination::RequestPtr makeRemoveRequest(const std::string & path, int version)
+Coordination::RequestPtr makeRemoveRequest(const std::string & path, int version, bool try_remove)
 {
     auto request = std::make_shared<Coordination::ZooKeeperRemoveRequest>();
     request->path = path;
     request->version = version;
+    request->try_remove = try_remove;
     return request;
 }
 

--- a/src/Common/ZooKeeper/ZooKeeperCommon.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperCommon.cpp
@@ -1525,6 +1525,8 @@ void registerZooKeeperRequest(ZooKeeperRequestFactory & factory)
             res->include_stats = true;
         else if constexpr (num == OpNum::CheckStat)
             res->stat_to_check.emplace();
+        else if constexpr (num == OpNum::TryRemove)
+            res->try_remove = true;
 
         return res;
     });
@@ -1539,6 +1541,7 @@ ZooKeeperRequestFactory::ZooKeeperRequestFactory()
     registerZooKeeperRequest<OpNum::Create, ZooKeeperCreateRequest>(*this);
     registerZooKeeperRequest<OpNum::Create2, ZooKeeperCreateRequest>(*this);
     registerZooKeeperRequest<OpNum::Remove, ZooKeeperRemoveRequest>(*this);
+    registerZooKeeperRequest<OpNum::TryRemove, ZooKeeperRemoveRequest>(*this);
     registerZooKeeperRequest<OpNum::Exists, ZooKeeperExistsRequest>(*this);
     registerZooKeeperRequest<OpNum::Get, ZooKeeperGetRequest>(*this);
     registerZooKeeperRequest<OpNum::Set, ZooKeeperSetRequest>(*this);

--- a/src/Common/ZooKeeper/ZooKeeperCommon.h
+++ b/src/Common/ZooKeeper/ZooKeeperCommon.h
@@ -296,7 +296,7 @@ struct ZooKeeperRemoveRequest final : RemoveRequest, ZooKeeperRequest
     ZooKeeperRemoveRequest() = default;
     explicit ZooKeeperRemoveRequest(const RemoveRequest & base) : RemoveRequest(base) {}
 
-    OpNum getOpNum() const override { return OpNum::Remove; }
+    OpNum getOpNum() const override { return try_remove ? OpNum::TryRemove : OpNum::Remove; }
     void writeImpl(WriteBuffer & out) const override;
     size_t sizeImpl() const override;
     void readImpl(ReadBuffer & in) override;
@@ -310,7 +310,7 @@ struct ZooKeeperRemoveRequest final : RemoveRequest, ZooKeeperRequest
     void createLogElements(LogElements & elems) const override;
 };
 
-struct ZooKeeperRemoveResponse final : RemoveResponse, ZooKeeperResponse
+struct ZooKeeperRemoveResponse : RemoveResponse, ZooKeeperResponse
 {
     void readImpl(ReadBuffer &) override {}
     void writeImpl(WriteBuffer &) const override {}
@@ -318,6 +318,12 @@ struct ZooKeeperRemoveResponse final : RemoveResponse, ZooKeeperResponse
     OpNum getOpNum() const override { return OpNum::Remove; }
 
     size_t bytesSize() const override { return RemoveResponse::bytesSize() + sizeof(xid) + sizeof(zxid); }
+};
+
+struct ZooKeeperTryRemoveResponse final : ZooKeeperRemoveResponse
+{
+    OpNum getOpNum() const override { return OpNum::TryRemove; }
+    using ZooKeeperRemoveResponse::ZooKeeperRemoveResponse;
 };
 
 struct ZooKeeperRemoveRecursiveRequest final : RemoveRecursiveRequest, ZooKeeperRequest

--- a/src/Common/ZooKeeper/ZooKeeperConstants.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperConstants.cpp
@@ -12,6 +12,7 @@ static const std::unordered_set<int32_t> VALID_OPERATIONS =
     static_cast<int32_t>(OpNum::Create),
     static_cast<int32_t>(OpNum::Create2),
     static_cast<int32_t>(OpNum::Remove),
+    static_cast<int32_t>(OpNum::TryRemove),
     static_cast<int32_t>(OpNum::Exists),
     static_cast<int32_t>(OpNum::Get),
     static_cast<int32_t>(OpNum::Set),
@@ -71,6 +72,7 @@ const char * toOperationTypeMetricLabel(OpNum op_num)
         case OpNum::Create:
         case OpNum::Create2:
         case OpNum::Remove:
+        case OpNum::TryRemove:
         case OpNum::RemoveWatch:
         case OpNum::SetWatch:
         case OpNum::SetWatch2:

--- a/src/Common/ZooKeeper/ZooKeeperConstants.h
+++ b/src/Common/ZooKeeper/ZooKeeperConstants.h
@@ -48,6 +48,7 @@ enum class OpNum : int32_t
     CreateIfNotExists = 502,
     RemoveRecursive = 503,
     CheckStat = 504,
+    TryRemove = 505,
 
     SessionID = 997, /// Special internal request
 };

--- a/src/Coordination/KeeperContext.cpp
+++ b/src/Coordination/KeeperContext.cpp
@@ -639,6 +639,8 @@ bool KeeperContext::isOperationSupported(Coordination::OpNum operation) const
             return feature_flags.isEnabled(KeeperFeatureFlag::CHECK_STAT);
         case Coordination::OpNum::Create2:
             return feature_flags.isEnabled(KeeperFeatureFlag::CREATE_WITH_STATS);
+        case Coordination::OpNum::TryRemove:
+            return feature_flags.isEnabled(KeeperFeatureFlag::TRY_REMOVE);
         case Coordination::OpNum::SetWatch:
         case Coordination::OpNum::SetWatch2:
         case Coordination::OpNum::AddWatch:

--- a/src/Coordination/KeeperDispatcher.cpp
+++ b/src/Coordination/KeeperDispatcher.cpp
@@ -8,6 +8,7 @@
 #include <Common/HistogramMetrics.h>
 #include <Common/ZooKeeper/IKeeper.h>
 #include <Common/ZooKeeper/ZooKeeperCommon.h>
+#include <Common/ZooKeeper/ZooKeeperConstants.h>
 #include <Common/setThreadName.h>
 #include <Common/ZooKeeper/KeeperException.h>
 #include <Common/checkStackSize.h>
@@ -113,7 +114,8 @@ bool checkIfRequestIncreaseMem(const Coordination::ZooKeeperRequestPtr & request
                     memory_delta += set_req.bytesSize();
                     break;
                 }
-                case Coordination::OpNum::Remove: {
+                case Coordination::OpNum::Remove:
+                case Coordination::OpNum::TryRemove: {
                     Coordination::ZooKeeperRemoveRequest & remove_req
                         = dynamic_cast<Coordination::ZooKeeperRemoveRequest &>(*sub_zk_request);
                     memory_delta -= remove_req.bytesSize();

--- a/src/Coordination/tests/gtest_coordination.cpp
+++ b/src/Coordination/tests/gtest_coordination.cpp
@@ -946,6 +946,7 @@ TYPED_TEST(CoordinationTest, TestFeatureFlags)
     ASSERT_TRUE(feature_flags.isEnabled(KeeperFeatureFlag::REMOVE_RECURSIVE));
     ASSERT_TRUE(feature_flags.isEnabled(KeeperFeatureFlag::MULTI_WATCHES));
     ASSERT_FALSE(feature_flags.isEnabled(KeeperFeatureFlag::CHECK_STAT));
+    ASSERT_FALSE(feature_flags.isEnabled(KeeperFeatureFlag::TRY_REMOVE));
 }
 
 #endif


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
This patch adds the possibility to execute a non-failing remove request. In the event of an error, nothing will be changed in the Keeper data.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.759`
<!-- ch-version-info:end -->