### PR TITLE
Add an asynchronous metric with the longest running merge elapsed time

### DIFF
--- a/ci/jobs/scripts/check_style/aspell-ignore/en/aspell-dict.txt
+++ b/ci/jobs/scripts/check_style/aspell-ignore/en/aspell-dict.txt
@@ -666,6 +666,7 @@ LogQL
 LogQueriesType
 LogsLevel
 Logstash
+LongestRunningMerge
 LookML
 LoongArch
 LowCardinality

--- a/docs/en/operations/system-tables/asynchronous_metrics.md
+++ b/docs/en/operations/system-tables/asynchronous_metrics.md
@@ -588,6 +588,10 @@ The server uptime in seconds. It includes the time spent for server initializati
 
 The last ZXID seen by the current ZooKeeper client session. This value increases monotonically as the client observes transactions from ZooKeeper.
 
+### LongestRunningMerge {#longestrunningmerge}
+
+Elapsed time in seconds of the longest currently running background merge.
+
 ### jemalloc.active {#jemallocactive}
 
 An internal metric of the low-level memory allocator (jemalloc). See https://jemalloc.net/jemalloc.3.html

--- a/src/Interpreters/ServerAsynchronousMetrics.cpp
+++ b/src/Interpreters/ServerAsynchronousMetrics.cpp
@@ -369,6 +369,15 @@ void ServerAsynchronousMetrics::updateImpl(TimePoint update_time, TimePoint curr
 
     new_values["ZooKeeperClientLastZXIDSeen"] = { getContext()->getZooKeeperLastZXIDSeen(), "The last ZXID the ZooKeeper client has seen."};
 
+    {
+        Float64 max_merge_elapsed = 0;
+        for (const auto & merge : getContext()->getMergeList().get())
+            if (merge.elapsed > max_merge_elapsed)
+                max_merge_elapsed = merge.elapsed;
+        new_values["LongestRunningMerge"]
+            = {max_merge_elapsed, "Elapsed time in seconds of the longest currently running background merge."};
+    }
+
 #if USE_NURAFT
     {
         auto keeper_dispatcher = getContext()->tryGetKeeperDispatcher();

--- a/src/Interpreters/ServerAsynchronousMetrics.cpp
+++ b/src/Interpreters/ServerAsynchronousMetrics.cpp
@@ -372,8 +372,7 @@ void ServerAsynchronousMetrics::updateImpl(TimePoint update_time, TimePoint curr
     {
         Float64 max_merge_elapsed = 0;
         for (const auto & merge : getContext()->getMergeList().get())
-            if (merge.elapsed > max_merge_elapsed)
-                max_merge_elapsed = merge.elapsed;
+            max_merge_elapsed = std::max(merge.elapsed, max_merge_elapsed);
         new_values["LongestRunningMerge"]
             = {max_merge_elapsed, "Elapsed time in seconds of the longest currently running background merge."};
     }


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add an asynchronous metric with the longest running merge elapsed time

Keep track of the longest running merge in asynchronous metric. It might help when troubleshooting issues (such as TOO_MANY_PARTS). `system.merges` is a snapshot of a specific moment (so not persisted or accessible after the fact), and `system.part_log` only includes finished operations.

I think this is fine for non-heavy metrics, but we could "drop" it to heavy if it proves too slow

cc @pkutaj


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.775`
<!-- ch-version-info:end -->