### PR TITLE
Rollback memory limiter for Fast tests

### DIFF
--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -134,8 +134,7 @@ class JobConfigs:
         runs_on=RunnerLabels.AMD_LARGE,
         command="python3 ./ci/jobs/fast_test.py",
         # --network=host required for ec2 metadata http endpoint to work
-        # --root/--privileged/--cgroupns=host is required for clickhouse-test --memory-limit
-        run_in_docker="clickhouse/fasttest+--network=host+--privileged+--cgroupns=host+--volume=./ci/tmp/var/lib/clickhouse:/var/lib/clickhouse+--volume=./ci/tmp/etc/clickhouse-client:/etc/clickhouse-client+--volume=./ci/tmp/etc/clickhouse-server:/etc/clickhouse-server+--volume=./ci/tmp/var/log:/var/log+root",
+        run_in_docker="clickhouse/fasttest+--network=host+--volume=./ci/tmp/var/lib/clickhouse:/var/lib/clickhouse+--volume=./ci/tmp/etc/clickhouse-client:/etc/clickhouse-client+--volume=./ci/tmp/etc/clickhouse-server:/etc/clickhouse-server+--volume=./ci/tmp/var/log:/var/log",
         digest_config=Job.CacheDigestConfig(
             include_paths=[
                 "./ci/jobs/fast_test.py",

--- a/ci/jobs/fast_test.py
+++ b/ci/jobs/fast_test.py
@@ -146,13 +146,16 @@ def main():
                 f"NOTE: It's a local run and clickhouse binary is not found [{clickhouse_bin_path}] - will be built"
             )
             time.sleep(5)
+        resolved_clickhouse_bin_path = clickhouse_bin_path.resolve()
         Shell.check(
-            f"ln -sf {clickhouse_bin_path} {os.path.dirname(clickhouse_bin_path)}/clickhouse-server", strict=True
+            f"ln -sf {resolved_clickhouse_bin_path} {resolved_clickhouse_bin_path.parent}/clickhouse-server",
+            strict=True,
         )
         Shell.check(
-            f"ln -sf {clickhouse_bin_path} {os.path.dirname(clickhouse_bin_path)}/clickhouse-client", strict=True
+            f"ln -sf {resolved_clickhouse_bin_path} {resolved_clickhouse_bin_path.parent}/clickhouse-client",
+            strict=True,
         )
-        Shell.check(f"chmod +x {clickhouse_bin_path}", strict=True)
+        Shell.check(f"chmod +x {resolved_clickhouse_bin_path}", strict=True)
     else:
         os.environ["CH_HOSTNAME"] = (
             "https://build-cache.eu-west-1.aws.clickhouse-staging.com"

--- a/ci/jobs/fast_test.py
+++ b/ci/jobs/fast_test.py
@@ -162,11 +162,6 @@ def main():
     attach_files = []
     job_info = ""
 
-    if os.getuid() == 0:
-        res = res and Shell.check(
-            f"git config --global --add safe.directory {current_directory}"
-        )
-
     if res and JobStages.CHECKOUT_SUBMODULES in stages:
         results.append(
             Result.from_commands_run(

--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -93,7 +93,7 @@ class ClickHouseProc:
         self.proc_2 = None
         self.pid = 0
         nproc = int(Utils.cpu_count() / 2)
-        self.fast_test_command = f"cd {temp_dir} && clickhouse-test --hung-check --memory-limit {5*2**30} --trace --capture-client-stacktrace --no-random-settings --no-random-merge-tree-settings --no-long --testname --shard --check-zookeeper-session --order random --report-logs-stats --fast-tests-only --no-stateful --jobs {nproc} -- '{{TEST}}' | ts '%Y-%m-%d %H:%M:%S' | tee -a \"{self.test_output_file}\""
+        self.fast_test_command = f"cd {temp_dir} && clickhouse-test --hung-check --trace --capture-client-stacktrace --no-random-settings --no-random-merge-tree-settings --no-long --testname --shard --check-zookeeper-session --order random --report-logs-stats --fast-tests-only --no-stateful --jobs {nproc} -- '{{TEST}}' | ts '%Y-%m-%d %H:%M:%S' | tee -a \"{self.test_output_file}\""
         self.minio_proc = None
         self.azurite_proc = None
         self.debug_artifacts = []


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

---
Partly reverts https://github.com/ClickHouse/ClickHouse/pull/82361
To simplify Fast test setup and drop root privileges. Test process memory limit preserved in normal Functional tests.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.901`
<!-- ch-version-info:end -->