### PR TITLE
Feature/generate random json support

### DIFF
--- a/src/Storages/StorageGenerateRandom.cpp
+++ b/src/Storages/StorageGenerateRandom.cpp
@@ -734,9 +734,14 @@ protected:
     {
         Columns columns;
         columns.reserve(block_to_fill.columns());
+        
+        /// Default values for fillColumnWithRandomData and estimateValueSize function testing.  
+        constexpr UInt64 default_max_json_keys = 10;
+        constexpr UInt64 default_max_json_depth = 3;
+        constexpr double default_null_ratio = 0.1;
 
         for (const auto & elem : block_to_fill)
-            columns.emplace_back(fillColumnWithRandomData(elem.type, block_size, max_array_length, max_string_length, rng, context));
+            columns.emplace_back(fillColumnWithRandomData(elem.type, block_size, max_array_length, max_string_length,default_max_json_keys,default_max_json_depth , default_null_ratio,rng, context));
 
         columns = Nested::flattenNested(block_to_fill.cloneWithColumns(columns)).getColumns();
 
@@ -865,7 +870,13 @@ Pipe StorageGenerateRandom::read(
     size_t preferred_block_size_bytes = context->getSettingsRef()[Setting::preferred_block_size_bytes];
     if (preferred_block_size_bytes)
     {
-        size_t estimated_row_size_bytes = estimateValueSize(std::make_shared<DataTypeTuple>(block_header.getDataTypes()), max_array_length, max_string_length);
+
+        /// Default values for fillColumnWithRandomData and estimateValueSize function testing.  
+        constexpr UInt64 default_max_json_keys = 10;
+        constexpr UInt64 default_max_json_depth = 3;
+        constexpr double default_null_ratio = 0.1;
+
+        size_t estimated_row_size_bytes = estimateValueSize(std::make_shared<DataTypeTuple>(block_header.getDataTypes()), max_array_length, max_string_length, default_max_json_keys,default_max_json_depth,default_null_ratio);
 
         size_t estimated_block_size_bytes = 0;
         if (common::mulOverflow(max_block_size, estimated_row_size_bytes, estimated_block_size_bytes))

--- a/src/Storages/StorageGenerateRandom.h
+++ b/src/Storages/StorageGenerateRandom.h
@@ -2,14 +2,17 @@
 
 #include <optional>
 #include <Storages/IStorage.h>
+#include <base/types.h>
 #include <pcg_random.hpp>
 
 
 namespace DB
 {
-
+    
+/// max_json_keys, max_json_depth and null_ratio are internal defaults for JSON/Object
+/// generation. User-facing configuration will be added in a follow-up change.
 ColumnPtr fillColumnWithRandomData(
-    DataTypePtr type, UInt64 limit, UInt64 max_array_length, UInt64 max_string_length, pcg64 & rng, ContextPtr context);
+    DataTypePtr type, UInt64 limit, UInt64 max_array_length, UInt64 max_string_length, UInt64 max_json_keys, UInt64 max_json_depth, double null_ratio, pcg64 & rng, ContextPtr context);
 
 /* Generates random data for given schema.
  */


### PR DESCRIPTION
Related to #92360

### Changelog category :
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
GenerateRandom now supports generation of structured Object (JSON-like) values for benchmarking and testing.


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

### Description

- This change adds internal support for generating structured Object (JSON-like) values in the GenerateRandom table engine.

- It enables generation of nested objects, arrays, and scalar values for benchmarking and testing, and removes the previous “not implemented for Object” error.
- User-facing configuration of JSON generation parameters (such as nesting depth, key count, and null ratio) will be added in a follow-up PR.

### Motivation: 
- GenerateRandom is commonly used to populate tables with synthetic data for testing and benchmarking. 
- Adding support for structured Object values allows generating JSON-like data directly within ClickHouse, without relying on external data sources.

### Parameters: 
- No new user-facing parameters are introduced in this change. 
- Existing parameters max_string_length and max_array_length are reused internally for Object value generation. Additional JSON-specific parameters will be exposed in a follow-up PR.

### Example use: 
```
CREATE TABLE t
(
    payload Object
)
ENGINE = GenerateRandom();
```