### PR TITLE
Batch Zookeeper queue entry create requests when cloning replica

### DIFF
--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -1037,6 +1037,7 @@ const VersionToSettingsChangesMap & getMergeTreeSettingsChangesHistory()
     {
         addSettingsChanges(merge_tree_settings_changes_history, "26.2",
         {
+            {"clone_replica_zookeeper_create_get_part_batch_size", 1, 100, "New setting"},
             {"add_minmax_index_for_temporal_columns", false, false, "New setting"},
             {"distributed_index_analysis_min_parts_to_activate", 10, 10, "New setting"},
             {"distributed_index_analysis_min_indexes_size_to_activate", 1_GiB, 1_GiB, "New setting"},

--- a/src/Storages/MergeTree/MergeTreeSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeSettings.cpp
@@ -17,6 +17,7 @@
 #include <Common/Exception.h>
 #include <Common/NamePrompter.h>
 #include <Common/logger_useful.h>
+#include <Common/ZooKeeper/ZooKeeper.h>
 #include <Interpreters/Context.h>
 #include <Disks/DiskObjectStorage/DiskObjectStorage.h>
 
@@ -2072,6 +2073,9 @@ namespace ErrorCodes
     )", 0) \
     DECLARE(UInt64, distributed_index_analysis_min_indexes_size_to_activate, 1_GiB, R"(
     Minimal index sizes (data skipping and primary key) on disk (but uncompressed) to activated distributed index analysis
+    )", 0) \
+    DECLARE(NonZeroUInt64, clone_replica_zookeeper_create_get_part_batch_size, zkutil::MULTI_BATCH_SIZE, R"(
+    Batch size for ZooKeeper multi-create get-part requests when cloning replica.
     )", 0) \
 
 #define MAKE_OBSOLETE_MERGE_TREE_SETTING(M, TYPE, NAME, DEFAULT) \

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -231,6 +231,7 @@ namespace MergeTreeSetting
     extern const MergeTreeSettingsBool use_minimalistic_part_header_in_zookeeper;
     extern const MergeTreeSettingsMilliseconds wait_for_unique_parts_send_before_shutdown_ms;
     extern const MergeTreeSettingsString auto_statistics_types;
+    extern const MergeTreeSettingsNonZeroUInt64 clone_replica_zookeeper_create_get_part_batch_size;
 }
 
 namespace FailPoints
@@ -3566,6 +3567,29 @@ void StorageReplicatedMergeTree::cloneReplica(const String & source_replica, Coo
         return false;
     };
 
+    /// Batch ZooKeeper create requests for better performance with many parts.
+    const auto batch_size = (*getSettings())[MergeTreeSetting::clone_replica_zookeeper_create_get_part_batch_size];
+    Coordination::Requests create_requests;
+    std::vector<String> create_request_part_names;
+    const String queue_path = fs::path(replica_path) / "queue/queue-";
+    AtomicStopwatch queue_creation_watch;
+    constexpr size_t print_message_each_n_seconds = 10;
+
+    auto flush_create_requests = [&]()
+    {
+        if (create_requests.empty())
+            return;
+
+        zookeeper->multi(create_requests);
+        for (const auto & part_name : create_request_part_names)
+            created_get_parts.insert(part_name);
+        create_requests.clear();
+        create_request_part_names.clear();
+
+        if (queue_creation_watch.compareAndRestart(print_message_each_n_seconds))
+            LOG_INFO(log, "Queued {}/{} parts", created_get_parts.size(), active_parts.size());
+    };
+
     for (const String & name : active_parts)
     {
         if (should_ignore_log_entry(created_get_parts, name, "Not fetching"))
@@ -3607,9 +3631,12 @@ void StorageReplicatedMergeTree::cloneReplica(const String & source_replica, Coo
         log_entry.create_time = tryGetPartCreateTime(zookeeper, source_path, name);
 
         LOG_TEST(log, "Enqueueing {} for fetch", name);
-        zookeeper->create(fs::path(replica_path) / "queue/queue-", log_entry.toString(), zkutil::CreateMode::PersistentSequential);
-        created_get_parts.insert(name);
+        create_requests.push_back(zkutil::makeCreateRequest(queue_path, log_entry.toString(), zkutil::CreateMode::PersistentSequential));
+        create_request_part_names.push_back(name);
+        if (create_requests.size() >= batch_size)
+            flush_create_requests();
     }
+    flush_create_requests();
 
     size_t total_parts_to_fetch = created_get_parts.size();
     LOG_DEBUG(log, "Queued {} parts to be fetched, {} parts ignored", total_parts_to_fetch, active_parts.size() - total_parts_to_fetch);


### PR DESCRIPTION
We noticed that "clone replica" can take a significant amount of time for tables with many parts, especially when ZooKeeper latency isn't ideal. We found that batching the create requests for the `GET_PART` queue entries speeds things up a lot. The default multi batch size of 100 is very conservative for this function because the entries are tiny, so I'm also adding a setting that can be used to speed this up even more.

This logic should be covered by existing tests like `test_consistent_parts_after_clone_replica`, so I'm not adding any new tests here.

### Changelog category (leave one):

- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Improve clone replica performance for ReplicatedMergeTree tables with many parts by batching ZooKeeper requests.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.226`
<!-- ch-version-info:end -->