### PR TITLE
Fix readonlyness of encrypted disks

### DIFF
--- a/src/Disks/DiskEncrypted.h
+++ b/src/Disks/DiskEncrypted.h
@@ -322,6 +322,10 @@ public:
     bool supportsChmod() const override { return delegate->supportsChmod(); }
     bool isSymlinkSupported() const override { return delegate->isSymlinkSupported(); }
 
+    bool isReadOnly() const override { return delegate->isReadOnly(); }
+    bool isWriteOnce() const override { return delegate->isWriteOnce(); }
+    bool isPlain() const override { return delegate->isPlain(); }
+
     SyncGuardPtr getDirectorySyncGuard(const String & path) const override;
 
     std::shared_ptr<DiskEncryptedTransaction> createEncryptedTransaction() const

--- a/src/Disks/DiskEncrypted.h
+++ b/src/Disks/DiskEncrypted.h
@@ -326,6 +326,8 @@ public:
     bool isWriteOnce() const override { return delegate->isWriteOnce(); }
     bool isPlain() const override { return delegate->isPlain(); }
 
+    ObjectStoragePtr getObjectStorage() override { return delegate->getObjectStorage(); }
+
     SyncGuardPtr getDirectorySyncGuard(const String & path) const override;
 
     std::shared_ptr<DiskEncryptedTransaction> createEncryptedTransaction() const

--- a/src/Disks/DiskSelector.cpp
+++ b/src/Disks/DiskSelector.cpp
@@ -51,10 +51,31 @@ void DiskSelector::recordDisk(const std::string & disk_name, DiskPtr disk)
             const auto new_prefix = disk->getObjectStorage()->getCommonKeyPrefix();
             const auto saved_prefix = saved_disk->getObjectStorage()->getCommonKeyPrefix();
             if (new_prefix.starts_with(saved_prefix) || saved_prefix.starts_with(new_prefix))
-                if (disk->getMetadataStorage().get() != saved_disk->getMetadataStorage().get())
+            {
+                bool same = disk->getMetadataStorage().get() == saved_disk->getMetadataStorage().get();
+
+                if (!same)
+                {
+                    /// In case of encrypted disk we cannot simply compare getMetadataStorage() since it is wrapped
+                    if (disk->getDataSourceDescription().is_encrypted)
+                    {
+                        auto underlying_disk = disk->getDelegateDiskIfExists();
+                        if (underlying_disk)
+                            same = underlying_disk->getMetadataStorage().get() == saved_disk->getMetadataStorage().get();
+                    }
+                    else if (saved_disk->getDataSourceDescription().is_encrypted)
+                    {
+                        auto underlying_saved_disk = saved_disk->getDelegateDiskIfExists();
+                        if (underlying_saved_disk)
+                            same = underlying_saved_disk->getMetadataStorage().get() == disk->getMetadataStorage().get();
+                    }
+                }
+
+                if (!same)
                     throw Exception(ErrorCodes::BAD_ARGUMENTS,
                         "It is not possible to register multiple plain-rewritable disks with the same object storage prefix. Disks '{}' and '{}'",
                         disk_name, saved_disk_name);
+            }
         }
     }
 

--- a/tests/queries/0_stateless/03801_merge_tree_on_readonly_disk.sh
+++ b/tests/queries/0_stateless/03801_merge_tree_on_readonly_disk.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT -nm -q "
+create table mt_ro (key Int) settings disk=disk(readonly = 1, type = 's3_plain_rewritable', endpoint = 'http://localhost:11111/test/s3_plain_rewritable_$CLICKHOUSE_DATABASE', access_key_id = clickhouse, secret_access_key = clickhouse);
+
+insert into mt_ro values (1); -- { serverError TABLE_IS_READ_ONLY }
+
+drop table mt_ro;
+"
+
+$CLICKHOUSE_CLIENT -nm -q "
+create table mt_ro (key Int) settings disk=disk(type='encrypted', readonly=1, key='1234567812345678', disk=disk(readonly = 1, type = 's3_plain_rewritable', endpoint = 'http://localhost:11111/test/s3_plain_rewritable_encrypted_$CLICKHOUSE_DATABASE', access_key_id = clickhouse, secret_access_key = clickhouse));
+
+insert into mt_ro values (1); -- { serverError TABLE_IS_READ_ONLY }
+
+drop table mt_ro;
+"


### PR DESCRIPTION
Note, this is only minimal fix for backport, later I will submit cleanup of `IDisk`

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix readonlyness of encrypted disks


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.791`
- Backported to: `25.12.5.16`, `25.11.8.17`, `25.10.6.19`, `25.8.16.23`
<!-- ch-version-info:end -->