### PR TITLE
Fix flaky test_ttl_move 

### DIFF
--- a/tests/integration/test_ttl_move/configs/config.d/storage_configuration.xml
+++ b/tests/integration/test_ttl_move/configs/config.d/storage_configuration.xml
@@ -16,18 +16,6 @@
     </disks>
 
     <policies>
-        <external_with_jbods>
-            <volumes>
-                <external>
-                    <disk>external</disk>
-                </external>
-                <main>
-                    <disk>jbod1</disk>
-                    <disk>jbod2</disk>
-                </main>
-            </volumes>
-        </external_with_jbods>
-
         <jbods_with_external>
             <volumes>
                 <main>
@@ -39,6 +27,21 @@
                 </external>
             </volumes>
         </jbods_with_external>
+
+        <jbod1_then_jbod2_then_external>
+            <volumes>
+                <banana>
+                    <disk>jbod1</disk>
+                </banana>
+                <apple>
+                    <disk>jbod2</disk>
+                </apple>
+                <orange>
+                    <disk>external</disk>
+                </orange>
+            </volumes>
+        </jbod1_then_jbod2_then_external>
+
 
         <default_with_small_jbod_with_external>
             <volumes>
@@ -76,13 +79,13 @@
             </volumes>
         </jbod1_with_jbod2>
 
-        <only_jbod_1>
+        <only_jbod1>
             <volumes>
                 <main>
                     <disk>jbod1</disk>
                 </main>
             </volumes>
-        </only_jbod_1>
+        </only_jbod1>
 
         <only_jbod2>
             <volumes>

--- a/tests/integration/test_ttl_move/test.py
+++ b/tests/integration/test_ttl_move/test.py
@@ -1,6 +1,8 @@
+from collections import defaultdict
+import datetime
 import inspect
+import json
 import random
-import threading
 import time
 from multiprocessing.dummy import Pool
 
@@ -10,10 +12,6 @@ from helpers.client import QueryRuntimeException
 from helpers.cluster import ClickHouseCluster
 from helpers.network import PartitionManager
 from helpers.test_tools import assert_eq_with_retry, assert_logs_contain_with_retry
-
-# FIXME: each sleep(1) is a time bomb, and not only this cause false positive
-# it also makes the test not reliable (i.e. assertions may be wrong, due timing issues)
-# Seems that some SYSTEM query should be added to wait those things insteadof sleep.
 
 cluster = ClickHouseCluster(__file__)
 
@@ -26,7 +24,7 @@ node1 = cluster.add_instance(
         "configs/config.d/cluster.xml",
     ],
     with_zookeeper=True,
-    tmpfs=["/test_ttl_move_jbod1:size=40M", "/test_ttl_move_jbod2:size=40M", "/test_ttl_move_external:size=200M"],
+    tmpfs=["/test_ttl_move_jbod1:size=40M", "/test_ttl_move_jbod2:size=40M", "/test_ttl_move_external:size=40M"],
     macros={"shard": 0, "replica": 1},
     stay_alive=True,
 )
@@ -40,11 +38,11 @@ node2 = cluster.add_instance(
         "configs/config.d/cluster.xml",
     ],
     with_zookeeper=True,
-    tmpfs=["/test_ttl_move_jbod1:size=40M", "/test_ttl_move_jbod2:size=40M", "/test_ttl_move_external:size=200M"],
+    tmpfs=["/test_ttl_move_jbod1:size=40M", "/test_ttl_move_jbod2:size=40M", "/test_ttl_move_external:size=40M"],
     macros={"shard": 0, "replica": 2},
 )
 
-
+# ---------------------------------
 @pytest.fixture(scope="module")
 def started_cluster():
     try:
@@ -55,1364 +53,1374 @@ def started_cluster():
         cluster.shutdown()
 
 
-def get_used_disks_for_table(node, table_name, partition=None):
-    if partition is None:
-        suffix = ""
-    else:
-        suffix = "and partition='{}'".format(partition)
-    return (
-        node.query(
-            """
-        SELECT disk_name
+def check_if_should_skip_this_then_skip(node):
+    if node.is_built_with_sanitizer() or node.is_debug_build():
+        pytest.skip("Disabled for debug and sanitizer builds")
+
+# --------- Helpers to track MOVE operations ---------
+def get_disks_state(node, table_name, partition=None):
+    and_with_partition = '' if partition is None else "AND partition='{}'".format(partition)
+
+    query_result = node.query(
+        f"""
+        SELECT part_name,rows,disk_name,modification_time,now()
         FROM system.parts
-        WHERE table == '{name}' AND active=1 {suffix}
-        ORDER BY modification_time
-    """.format(
-                name=table_name, suffix=suffix
-            )
-        )
-        .strip()
-        .split("\n")
-    )
+        WHERE table == '{table_name}' AND active=1 {and_with_partition}
+        FORMAT JSONEachRow
+        """)
 
+    result = defaultdict(lambda: {
+            'rows': 0,
+    })
 
-def check_used_disks_with_retry(node, table_name, expected_disks, retries=1):
+    for line in query_result.strip().split('\n'):
+        if line:
+            line = json.loads(line)
+            disk_stats  = result[line['disk_name']]
+            disk_stats['rows'] += line['rows']
+    return result
+
+def get_disk_names(node, table_name, partition=None):
+    return set(get_disks_state(node, table_name, partition).keys())
+
+def wait_if_moving_then_assert_disks(node, table_name, partition=None, retries=10, sleep_sec=1, target_state=None):
+
     for _ in range(retries):
-        used_disks = get_used_disks_for_table(node, table_name)
-        if set(used_disks).issubset(expected_disks):
-            return True
-        time.sleep(0.5)
-    return False
+        moves = int(node.query(f"SELECT count() FROM system.moves WHERE table = '{table_name}'").strip())
+
+        if moves > 0:
+            # just waiting until the moves are actually finished
+            continue
+
+        elif get_disks_state(node, table_name, partition) == target_state:
+            # if there's no active move happenning, and we're in the target state - this is success
+            return
+
+        time.sleep(sleep_sec)
+
+    # timeout is reached, we gonna fail if we're not in target state yet
+    assert get_disks_state(node, table_name, partition) == target_state, "Move hasn't finished in at least {} seconds".format(retries * sleep_sec)
 
 
-# Use unique table name for flaky checker, that run tests multiple times
-def unique_table_name(base_name):
-    return f"{base_name.replace('[', '_').replace(']', '_').replace('-', '_')}_{int(time.time())}"
+# --------- Helpers to populate/manipulate data ---------
+F_SMALL_STRING = lambda: 'randomPrintableASCII(1024)'
+F_LARGE_STRING = lambda: 'randomPrintableASCII(1024*1024)'
+
+SOON_SECONDS = 3
+NEVER_SECONDS = 24*3600
+F_ALREADY_EXPIRED_DATETIME = lambda now_ts: f'toDateTime({now_ts - 1})'
+F_SOON_TO_EXPIRE_DATETIME = lambda now_ts: f'toDateTime({now_ts + SOON_SECONDS})'
+F_NEVER_EXPIRE_DATETIME = lambda now_ts: f'toDateTime({now_ts + NEVER_SECONDS})'
+
+def gen_uni_records(num, f_gen_string_field):
+    v_string_field = f_gen_string_field()
+
+    for _ in range(num):
+        yield f'({v_string_field})'
+
+def gen_pair_records(num, f_gen_string_field, f_gen_datetime_field, now_ts=None):
+    v_string_field = f_gen_string_field()
+    v_datetime_field = f_gen_datetime_field(now_ts is not None or time.time())
+
+    for _ in range(num):
+        yield f'({v_string_field},{v_datetime_field})'
+
+def gen_triplet_records(num, v_partition, f_gen_string_field, f_gen_datetime_field, now_ts=None):
+    v_string_field = f_gen_string_field()
+    v_datetime_field = f_gen_datetime_field(now_ts is not None or time.time())
+
+    for _ in range(num):
+        yield f'({v_partition},{v_string_field},{v_datetime_field})'
 
 
-def wait_parts_mover(node, table, *args, **kwargs):
-    # wait for MergeTreePartsMover
-    assert_logs_contain_with_retry(
-        node, f"default.{table}.*Removed part from old location", *args, **kwargs
-    )
+def populate_with_records(node, table_name, generators):
+    print(f'INSTER1 t={datetime.datetime.now()}, {time.time()}')
+    for g in generators:
+        insert_query = "INSERT INTO {} VALUES {}".format(
+            table_name,
+            ','.join(g)
+        )
+        print(insert_query)
+        node.query(insert_query)
 
+def drop_if_exists(node, table_name):
+    try:
+        node.query(f"DROP TABLE IF EXISTS {table_name} SYNC")
+    except:
+        pass
 
+def unique_table_name(pytest_request_fixture):
+    if hasattr(pytest_request_fixture.node, 'callspec'):
+        name = pytest_request_fixture.node.originalname + '_' + pytest_request_fixture.node.callspec.id
+    else:
+        name = pytest_request_fixture.node.originalname
+    return f"{name.replace('[', '_').replace(']', '_').replace('-', '_')}_{int(time.time())}"
+
+# ---------------------------------
 @pytest.mark.parametrize(
-    "name,engine,alter",
+    "engine",
     [
         pytest.param(
-            "mt_test_rule_with_invalid_destination", "MergeTree()", 0, id="case0"
+            "MergeTree()",
+            id="mt"
         ),
         pytest.param(
-            "replicated_mt_test_rule_with_invalid_destination",
-            "ReplicatedMergeTree('/clickhouse/replicated_test_rule_with_invalid_destination', '1')",
-            0,
-            id="case1",
-        ),
-        pytest.param(
-            "mt_test_rule_with_invalid_destination", "MergeTree()", 1, id="case2"
-        ),
-        pytest.param(
-            "replicated_mt_test_rule_with_invalid_destination",
-            "ReplicatedMergeTree('/clickhouse/replicated_test_rule_with_invalid_destination', '1')",
-            1,
-            id="case3",
-        ),
-    ],
+            "ReplicatedMergeTree('/clickhouse/test_create_with_invalid_destination_rmt', '1')",
+            id="rmt"
+        )
+    ]
 )
-def test_rule_with_invalid_destination(started_cluster, name, engine, alter):
-    name = unique_table_name(name)
+def test_create_with_invalid_destination(started_cluster, engine, request):
+    table_name = unique_table_name(request)
 
     try:
+        def get_create_command(rule, policy):
+            return f"""
+                CREATE TABLE {table_name} (
+                    s1 String,
+                    d1 DateTime
+                ) ENGINE = {engine}
+                ORDER BY tuple()
+                {rule}
+                SETTINGS storage_policy='{policy}'
+            """
 
-        def get_command(x, policy):
-            x = x or ""
-            if alter and x:
-                return """
-                    ALTER TABLE {name} MODIFY TTL {expression}
-                """.format(
-                    expression=x, name=name
-                )
-            else:
-                return """
-                    CREATE TABLE {name} (
-                        s1 String,
-                        d1 DateTime
-                    ) ENGINE = {engine}
-                    ORDER BY tuple()
-                    {expression}
-                    SETTINGS storage_policy='{policy}'
-                """.format(
-                    expression=x, name=name, engine=engine, policy=policy
-                )
-
-        if alter:
-            node1.query(get_command(None, "small_jbod_with_external"))
-
-        with pytest.raises(QueryRuntimeException):
-            node1.query(
-                get_command("TTL d1 TO DISK 'unknown'", "small_jbod_with_external")
+        # unknown disk
+        node1.query_and_get_error(
+            get_create_command(
+                rule="TTL d1 TO DISK 'unknown'",
+                policy="small_jbod_with_external"
             )
-
-        node1.query("DROP TABLE IF EXISTS {} SYNC".format(name))
-
-        if alter:
-            node1.query(get_command(None, "small_jbod_with_external"))
-
-        with pytest.raises(QueryRuntimeException):
-            node1.query(
-                get_command("TTL d1 TO VOLUME 'unknown'", "small_jbod_with_external")
+        )
+        # unknown volume
+        node1.query_and_get_error(
+            get_create_command(
+                rule="TTL d1 TO VOLUME 'unknown'",
+                policy="small_jbod_with_external"
             )
-
-        node1.query("DROP TABLE IF EXISTS {} SYNC".format(name))
-
-        if alter:
-            node1.query(get_command(None, "only_jbod2"))
-
-        with pytest.raises(QueryRuntimeException):
-            node1.query(get_command("TTL d1 TO DISK 'jbod1'", "only_jbod2"))
-
-        node1.query("DROP TABLE IF EXISTS {} SYNC".format(name))
-
-        if alter:
-            node1.query(get_command(None, "only_jbod2"))
-
-        with pytest.raises(QueryRuntimeException):
-            node1.query(get_command("TTL d1 TO VOLUME 'external'", "only_jbod2"))
+        )
+        # unsupported disk
+        node1.query_and_get_error(
+            get_create_command(
+                rule="TTL d1 TO DISK 'jbod1'",
+                policy="only_jbod2"
+            )
+        )
+        # unsupported volume
+        node1.query_and_get_error(
+            get_create_command(
+                rule="TTL d1 TO VOLUME 'external'",
+                policy="only_jbod2"
+            )
+        )
+        # unknown field
+        node1.query_and_get_error(
+            get_create_command(
+                rule="TTL unknownField TO DISK 'jbod2'",
+                policy="only_jbod2"
+            )
+        )
 
     finally:
-        node1.query("DROP TABLE IF EXISTS {} SYNC".format(name))
+        drop_if_exists(node1, table_name)
 
 
 @pytest.mark.parametrize(
-    "name,engine,positive",
+    "engine",
     [
         pytest.param(
-            "mt_test_inserts_to_disk_do_not_work",
             "MergeTree()",
-            0,
-            id="mt_test_inserts_to_disk_do_not_work",
+            id="mt"
         ),
         pytest.param(
-            "replicated_mt_test_inserts_to_disk_do_not_work",
-            "ReplicatedMergeTree('/clickhouse/replicated_test_inserts_to_disk_do_not_work', '1')",
-            0,
-            id="replicated_mt_test_inserts_to_disk_do_not_work",
-        ),
+            "ReplicatedMergeTree('/clickhouse/test_alter_with_invalid_destination', '1')",
+            id="rmt"
+        )
+    ]
+)
+def test_alter_with_invalid_destination(started_cluster, engine, request):
+    table_name = unique_table_name(request)
+
+    try:
+        def get_create_command(policy):
+            return f"""
+                CREATE TABLE {table_name} (
+                    s1 String,
+                    d1 DateTime
+                ) ENGINE = {engine}
+                ORDER BY tuple()
+                SETTINGS storage_policy='{policy}'
+            """
+        def get_alter_command(rule):
+            return f"""
+                ALTER TABLE {table_name} MODIFY TTL {rule}
+            """
+
+        node1.query(get_create_command('small_jbod_with_external'))
+        # unknown disk
+        node1.query_and_get_error(
+            get_alter_command(
+                rule="TTL d1 TO DISK 'unknown'"
+            )
+        )
+        # unknown volume
+        node1.query_and_get_error(
+            get_alter_command(
+                rule="TTL d1 TO VOLUME 'unknown'",
+            )
+        )
+
+        # recreate table with different policy
+        drop_if_exists(node1, table_name)
+        node1.query(get_create_command('only_jbod2'))
+        # unsupported disk
+        node1.query_and_get_error(
+            get_alter_command(
+                rule="TTL d1 TO DISK 'jbod1'",
+            )
+        )
+        # unsupported volume
+        node1.query_and_get_error(
+            get_alter_command(
+                rule="TTL d1 TO VOLUME 'external'",
+            )
+        )
+        # unknown field
+        node1.query_and_get_error(
+            get_alter_command(
+                rule="TTL unknownField TO DISK 'jbod2'",
+            )
+        )
+
+    finally:
+        drop_if_exists(node1, table_name)
+
+
+@pytest.mark.parametrize(
+    "engine,ttl_rule",
+    [
         pytest.param(
-            "mt_test_inserts_to_disk_work",
             "MergeTree()",
-            1,
-            id="mt_test_inserts_to_disk_work_1",
+            "TTL d1 TO DISK 'external'",
+            id="mt_disk",
         ),
         pytest.param(
-            "replicated_mt_test_inserts_to_disk_work",
-            "ReplicatedMergeTree('/clickhouse/replicated_test_inserts_to_disk_work', '1')",
-            1,
-            id="replicated_mt_test_inserts_to_disk_work_1",
+            "ReplicatedMergeTree('/clickhouse/test_inserts_and_moves_rmt_disk', '1')",
+            "TTL d1 TO DISK 'external'",
+            id="rmt_disk",
+        ),
+        pytest.param(
+            "MergeTree()",
+            "TTL d1 TO VOLUME 'external'",
+            id="mt_volume",
+        ),
+        pytest.param(
+            "ReplicatedMergeTree('/clickhouse/test_inserts_and_moves_rmt_volume', '1')",
+            "TTL d1 TO VOLUME 'external'",
+            id="rmt_volume",
         ),
     ],
 )
-def test_inserts_to_disk_work(started_cluster, name, engine, positive):
-    name = unique_table_name(name)
+def test_inserts_and_moves(started_cluster, engine, ttl_rule, request):
+    table_name = unique_table_name(request)
 
     try:
-        node1.query(
-            """
-            CREATE TABLE {name} (
+        # --------------------- CASE I ---------------------
+        # INSERT into a simple table with all defaults, using records:
+        #   - are already expired and should be written to 'external' directly
+        #   - gonna expire soon and should be moved to 'external' by the end of the test
+        # We check that both types of data eventually make it to the target destination
+        # NOTE: we are not checking resuls of direct INSERT here to prevent flakinness; it's covered later at CASE II in a controlled fashion
+        node1.query(f"""
+            CREATE TABLE {table_name} (
                 s1 String,
                 d1 DateTime
             ) ENGINE = {engine}
             ORDER BY tuple()
-            TTL d1 TO DISK 'external'
+            {ttl_rule}
             SETTINGS storage_policy='small_jbod_with_external'
-        """.format(
-                name=name, engine=engine
-            )
+        """)
+
+        populate_with_records(
+            node=node1,
+            table_name=table_name,
+            generators=[
+                gen_pair_records(10, F_SMALL_STRING, F_ALREADY_EXPIRED_DATETIME),
+                gen_pair_records(10, F_SMALL_STRING, F_ALREADY_EXPIRED_DATETIME),
+                gen_pair_records(10, F_SMALL_STRING, F_SOON_TO_EXPIRE_DATETIME),
+                gen_pair_records(10, F_SMALL_STRING, F_SOON_TO_EXPIRE_DATETIME),
+            ]
         )
 
-        data = []  # 10MB in total
-        for i in range(10):
-            data.append(
-                (
-                    "randomPrintableASCII(1024*1024)",
-                    "toDateTime({})".format(
-                        time.time() - 1 if i > 0 or positive else time.time() + 300
-                    ),
-                )
-            )
+        time.sleep(SOON_SECONDS)    # waiting to let the records expire
+        wait_if_moving_then_assert_disks(node1, table_name, target_state={
+            'external': {'rows': 40},
+        })
+        assert node1.query(f"SELECT count() FROM {table_name}").strip() == "40"
 
-        node1.query(
-            "INSERT INTO {} (s1, d1) VALUES {}".format(
-                name, ",".join(["(" + ",".join(x) + ")" for x in data])
-            )
-        )
-        used_disks = get_used_disks_for_table(node1, name)
-        assert set(used_disks) == {"external" if positive else "jbod1"}
-
-        assert (
-            node1.query("SELECT count() FROM {name}".format(name=name)).strip() == "10"
-        )
-
-    finally:
-        try:
-            node1.query("DROP TABLE IF EXISTS {} SYNC".format(name))
-        except:
-            pass
-
-
-@pytest.mark.parametrize(
-    "name,engine",
-    [
-        pytest.param(
-            "mt_test_moves_work_after_storage_policy_change",
-            "MergeTree()",
-            id="mt_test_moves_work_after_storage_policy_change",
-        ),
-        pytest.param(
-            "replicated_mt_test_moves_work_after_storage_policy_change",
-            "ReplicatedMergeTree('/clickhouse/test_moves_work_after_storage_policy_change', '1')",
-            id="replicated_mt_test_moves_work_after_storage_policy_change",
-        ),
-    ],
-)
-def test_moves_work_after_storage_policy_change(started_cluster, name, engine):
-    name = unique_table_name(name)
-
-    try:
-        node1.query(
-            """
-            CREATE TABLE {name} (
+        drop_if_exists(node1, table_name)
+        # --------------------- CASE I~ (NEGATIVE CHECK) ---------------------
+        # INSERT into a simple table with all defaults, using records:
+        #   - are already expired and should be written to 'external' directly
+        #   - never gonna expire and won't move by the end of the test
+        # NOTE: Case I and Case I~ could be united together, but mixing all three types of records won't play nicely for RMT
+        #       We'll check it more thouroughly later, when manually controlling MOVES and MERGES, but here it's kept simple
+        node1.query(f"""
+            CREATE TABLE {table_name} (
                 s1 String,
                 d1 DateTime
             ) ENGINE = {engine}
             ORDER BY tuple()
-        """.format(
-                name=name, engine=engine
-            )
-        )
-
-        node1.query(
-            """ALTER TABLE {name} MODIFY SETTING storage_policy='default_with_small_jbod_with_external'""".format(
-                name=name
-            )
-        )
-
-        # Second expression is preferred because d1 > now()-3600.
-        node1.query(
-            """ALTER TABLE {name} MODIFY TTL now()-3600 TO DISK 'jbod1', d1 TO DISK 'external'""".format(
-                name=name
-            ),
-            settings={"allow_suspicious_ttl_expressions": 1},
-        )
-
-        wait_expire_1 = 12
-        wait_expire_2 = 4
-        time_1 = time.time() + wait_expire_1
-
-        data = []  # 10MB in total
-        for i in range(10):
-            data.append(
-                ("randomPrintableASCII(1024*1024)", "toDateTime({})".format(time_1))
-            )
-
-        node1.query(
-            "INSERT INTO {} (s1, d1) VALUES {}".format(
-                name, ",".join(["(" + ",".join(x) + ")" for x in data])
-            )
-        )
-        used_disks = get_used_disks_for_table(node1, name)
-        assert set(used_disks) == {"jbod1"}
-
-        wait_parts_mover(node1, name, retry_count=40)
-
-        used_disks = get_used_disks_for_table(node1, name)
-        assert set(used_disks) == {"external"}
-
-        assert (
-            node1.query("SELECT count() FROM {name}".format(name=name)).strip() == "10"
-        )
-
-    finally:
-        node1.query("DROP TABLE IF EXISTS {} SYNC".format(name))
-
-
-@pytest.mark.parametrize(
-    "name,engine,positive",
-    [
-        pytest.param(
-            "mt_test_moves_to_disk_do_not_work",
-            "MergeTree()",
-            0,
-            id="mt_test_moves_to_disk_do_not_work",
-        ),
-        pytest.param(
-            "replicated_mt_test_moves_to_disk_do_not_work",
-            "ReplicatedMergeTree('/clickhouse/replicated_test_moves_to_disk_do_not_work', '1')",
-            0,
-            id="replicated_mt_test_moves_to_disk_do_not_work",
-        ),
-        pytest.param(
-            "mt_test_moves_to_disk_work",
-            "MergeTree()",
-            1,
-            id="mt_test_moves_to_disk_work",
-        ),
-        pytest.param(
-            "replicated_mt_test_moves_to_disk_work",
-            "ReplicatedMergeTree('/clickhouse/replicated_test_moves_to_disk_work', '1')",
-            1,
-            id="replicated_mt_test_moves_to_disk_work",
-        ),
-    ],
-)
-def test_moves_to_disk_work(started_cluster, name, engine, positive):
-    name = unique_table_name(name)
-
-    try:
-        node1.query(
-            """
-            CREATE TABLE {name} (
-                s1 String,
-                d1 DateTime
-            ) ENGINE = {engine}
-            ORDER BY tuple()
-            TTL d1 TO DISK 'external'
+            {ttl_rule}
             SETTINGS storage_policy='small_jbod_with_external'
-        """.format(
-                name=name, engine=engine
-            )
+        """)
+
+        populate_with_records(
+            node=node1,
+            table_name=table_name,
+            generators=[
+                gen_pair_records(10, F_SMALL_STRING, F_ALREADY_EXPIRED_DATETIME),
+                gen_pair_records(10, F_SMALL_STRING, F_ALREADY_EXPIRED_DATETIME),
+                gen_pair_records(10, F_SMALL_STRING, F_NEVER_EXPIRE_DATETIME),
+                gen_pair_records(10, F_SMALL_STRING, F_NEVER_EXPIRE_DATETIME),
+            ]
         )
+        # Check 1. Immediately after INSERT
+        wait_if_moving_then_assert_disks(node1, table_name, target_state={
+            'jbod1': {'rows': 20},
+            'external': {'rows': 20},
+        })
+        assert node1.query(f"SELECT count() FROM {table_name}").strip() == "40"
 
-        wait_expire_1 = 12
-        wait_expire_2 = 20
-        time_1 = time.time() + wait_expire_1
-        time_2 = time.time() + wait_expire_1 + wait_expire_2
+        # Check 2. Upon expiration
+        time.sleep(SOON_SECONDS)    # wait for expiration
+        wait_if_moving_then_assert_disks(node1, table_name, target_state={
+            'jbod1': {'rows': 20},
+            'external': {'rows': 20},
+        })
+        assert node1.query(f"SELECT count() FROM {table_name}").strip() == "40"
 
-        wait_expire_1_thread = threading.Thread(
-            target=time.sleep, args=(wait_expire_1,)
+
+        drop_if_exists(node1, table_name)
+        # --------------------- CASE II ---------------------
+        # INSERT into a simple table with MERGES and MOVES disabled, using records which:
+        #   - are already expired and should be written to 'external' directly
+        #   - gonna expire soon
+        # and then checking that MOVE doesn't occur until re-enabled
+        node1.query(f"""
+            CREATE TABLE {table_name} (
+                s1 String,
+                d1 DateTime
+            ) ENGINE = {engine}
+            ORDER BY tuple()
+            {ttl_rule}
+            SETTINGS storage_policy='small_jbod_with_external'
+        """)
+        node1.query(f"SYSTEM STOP MERGES {table_name}")
+        node1.query(f"SYSTEM STOP MOVES {table_name}")
+
+        populate_with_records(
+            node=node1,
+            table_name=table_name,
+            generators=[
+                gen_pair_records(10, F_SMALL_STRING, F_ALREADY_EXPIRED_DATETIME),
+                gen_pair_records(10, F_SMALL_STRING, F_ALREADY_EXPIRED_DATETIME),
+                gen_pair_records(10, F_SMALL_STRING, F_SOON_TO_EXPIRE_DATETIME),
+                gen_pair_records(10, F_SMALL_STRING, F_SOON_TO_EXPIRE_DATETIME),
+            ]
         )
-        wait_expire_1_thread.start()
-
-        data = []  # 10MB in total
-        for i in range(10):
-            data.append(
-                (
-                    "randomPrintableASCII(1024*1024)",
-                    "toDateTime({})".format(time_1 if i > 0 or positive else time_2),
-                )
-            )
-
-        node1.query(
-            "INSERT INTO {} (s1, d1) VALUES {}".format(
-                name, ",".join(["(" + ",".join(x) + ")" for x in data])
-            )
-        )
-        used_disks = get_used_disks_for_table(node1, name)
-        assert set(used_disks) == {"jbod1"}
-
-        wait_expire_1_thread.join()
-        time.sleep(wait_expire_2 / 2)
-
-        used_disks = get_used_disks_for_table(node1, name)
-        assert set(used_disks) == {"external" if positive else "jbod1"}
-
-        assert (
-            node1.query("SELECT count() FROM {name}".format(name=name)).strip() == "10"
-        )
-
-    finally:
-        node1.query("DROP TABLE IF EXISTS {} SYNC".format(name))
+        # Check 1. Immediately after INSERT
+        wait_if_moving_then_assert_disks(node1, table_name, target_state={
+            'jbod1': {'rows': 20},
+            'external': {'rows': 20},
+        })
+        assert node1.query(f"SELECT count() FROM {table_name}").strip() == "40"
 
 
-@pytest.mark.parametrize(
-    "name,engine",
-    [
-        pytest.param(
-            "mt_test_moves_to_volume_work",
-            "MergeTree()",
-            id="mt_test_moves_to_volume_work",
-        ),
-        pytest.param(
-            "replicated_mt_test_moves_to_volume_work",
-            "ReplicatedMergeTree('/clickhouse/replicated_test_moves_to_volume_work', '1')",
-            id="replicated_mt_test_moves_to_volume_work",
-        ),
-    ],
-)
-def test_moves_to_volume_work(started_cluster, name, engine):
-    name = unique_table_name(name)
+        # Check 2. Upon expiration
+        time.sleep(SOON_SECONDS)    # wait for expiration
+        wait_if_moving_then_assert_disks(node1, table_name, target_state={
+            'jbod1': {'rows': 20},
+            'external': {'rows': 20},
+        })
+        assert node1.query(f"SELECT count() FROM {table_name}").strip() == "40"
 
-    try:
-        node1.query(
-            """
-            CREATE TABLE {name} (
+        # Check 3. Upon re-enabling of MOVES
+        node1.query(f"SYSTEM START MOVES {table_name}")
+        wait_if_moving_then_assert_disks(node1, table_name, target_state={
+            'external': {'rows': 40},
+        })
+        assert node1.query(f"SELECT count() FROM {table_name}").strip() == "40"
+
+
+        drop_if_exists(node1, table_name)
+        # --------------------- CASE III ---------------------
+        # INSERT into a PARTITIONed table with MERGES and MOVES disabled, using records which:
+        #   - are already expired and should be written to 'external' directly
+        #   - gonna expire soon
+        # and then checking that MOVE doesn't occur until re-enabled
+        node1.query(f"""
+            CREATE TABLE {table_name} (
                 p1 Int64,
                 s1 String,
                 d1 DateTime
             ) ENGINE = {engine}
             ORDER BY tuple()
-            PARTITION BY p1
-            TTL d1 TO VOLUME 'external'
-            SETTINGS storage_policy='jbods_with_external'
-        """.format(
-                name=name, engine=engine
-            )
+            {ttl_rule}
+            SETTINGS storage_policy='small_jbod_with_external'
+        """)
+        # Disabling MOVES and MERGES to get full control over the course of the scenario
+        node1.query(f"SYSTEM STOP MERGES {table_name}")
+        node1.query(f"SYSTEM STOP MOVES {table_name}")
+        # 1. Let's write some parts:
+        populate_with_records(
+            node=node1,
+            table_name=table_name,
+            generators=[
+                gen_triplet_records(10, 0, F_SMALL_STRING, F_ALREADY_EXPIRED_DATETIME),
+                gen_triplet_records(10, 1, F_SMALL_STRING, F_ALREADY_EXPIRED_DATETIME),
+                gen_triplet_records(10, 0, F_SMALL_STRING, F_SOON_TO_EXPIRE_DATETIME),
+                gen_triplet_records(10, 1, F_SMALL_STRING, F_SOON_TO_EXPIRE_DATETIME),
+                gen_triplet_records(10, 0, F_SMALL_STRING, F_NEVER_EXPIRE_DATETIME),
+                gen_triplet_records(10, 1, F_SMALL_STRING, F_NEVER_EXPIRE_DATETIME),
+            ]
         )
+        # Check 1. Immediately after INSERT
+        wait_if_moving_then_assert_disks(node1, table_name, target_state={
+            'jbod1': {'rows': 40},
+            'external': {'rows': 20},
+        })
+        assert node1.query(f"SELECT count() FROM {table_name}").strip() == "60"
 
-        wait_expire_1 = 10
-        time_1 = time.time() + wait_expire_1
+        # Check 2. Upon expiration
+        time.sleep(SOON_SECONDS)    # wait for expiration
+        wait_if_moving_then_assert_disks(node1, table_name, target_state={
+            'jbod1': {'rows': 40},
+            'external': {'rows': 20},
+        })
+        assert node1.query(f"SELECT count() FROM {table_name}").strip() == "60"
 
-        for p in range(2):
-            data = []  # 10MB in total
-            for i in range(5):
-                data.append(
-                    (
-                        str(p),
-                        "randomPrintableASCII(1024*1024)",
-                        "toDateTime({})".format(time_1),
-                    )
-                )
+        # Check 3. Upon re-enabling of MOVES
+        node1.query(f"SYSTEM START MOVES {table_name}")
+        wait_if_moving_then_assert_disks(node1, table_name, target_state={
+            'jbod1': {'rows': 20},
+            'external': {'rows': 40},
+        })
+        assert node1.query(f"SELECT count() FROM {table_name}").strip() == "60"
 
-            node1.query(
-                "INSERT INTO {} (p1, s1, d1) VALUES {}".format(
-                    name, ",".join(["(" + ",".join(x) + ")" for x in data])
-                )
-            )
 
-        used_disks = get_used_disks_for_table(node1, name)
-        assert set(used_disks) == {"jbod1", "jbod2"}
+        drop_if_exists(node1, table_name)
+        # --------------------- CASE IV ---------------------
+        # Very special case with direct INSERTs disabled (see 'jbod_without_instant_ttl_move') - the data is moved only via MOVE operation
+        node1.query(f"""
+            CREATE TABLE {table_name} (
+                s1 String,
+                d1 DateTime
+            ) ENGINE = {engine}
+            ORDER BY tuple()
+            {ttl_rule}
+            SETTINGS storage_policy='jbod_without_instant_ttl_move'
+        """)
+        node1.query(f"SYSTEM STOP MOVES {table_name}")
 
-        wait_parts_mover(node1, name, retry_count=40)
-
-        used_disks = get_used_disks_for_table(node1, name)
-        assert set(used_disks) == {"external"}
-
-        assert (
-            node1.query("SELECT count() FROM {name}".format(name=name)).strip() == "10"
+        populate_with_records(
+            node=node1,
+            table_name=table_name,
+            generators=[
+                gen_pair_records(10, F_SMALL_STRING, F_ALREADY_EXPIRED_DATETIME),
+                gen_pair_records(10, F_SMALL_STRING, F_ALREADY_EXPIRED_DATETIME),
+            ]
         )
+        # Check 1. Immediately after INSERT
+        wait_if_moving_then_assert_disks(node1, table_name, target_state={
+            'jbod1': {'rows': 20},
+        })
+        assert node1.query(f"SELECT count() FROM {table_name}").strip() == "20"
+
+
+        # Check 2. Upon re-enabling of MOVES
+        node1.query(f"SYSTEM START MOVES {table_name}")
+        wait_if_moving_then_assert_disks(node1, table_name, target_state={
+            'external': {'rows': 20},
+        })
+        assert node1.query(f"SELECT count() FROM {table_name}").strip() == "20"
+
 
     finally:
-        node1.query("DROP TABLE IF EXISTS {} SYNC".format(name))
+        drop_if_exists(node1, table_name)
 
 
 @pytest.mark.parametrize(
-    "name,engine,positive",
+    "engine,ttl_rule",
     [
         pytest.param(
-            "mt_test_inserts_to_volume_do_not_work",
             "MergeTree()",
-            0,
-            id="mt_test_inserts_to_volume_do_not_work",
+            f"TTL d1 + INTERVAL {SOON_SECONDS} SECOND DELETE",
+            id="mt_interval_delete",
         ),
         pytest.param(
-            "replicated_mt_test_inserts_to_volume_do_not_work",
-            "ReplicatedMergeTree('/clickhouse/replicated_test_inserts_to_volume_do_not_work', '1')",
-            0,
-            id="replicated_mt_test_inserts_to_volume_do_not_work",
+            "ReplicatedMergeTree('/clickhouse/test_delete_rmt_interval_delete', '1')",
+            f"TTL d1 + INTERVAL {SOON_SECONDS} SECOND DELETE",
+            id="rmt_interval_delete",
         ),
         pytest.param(
-            "mt_test_inserts_to_volume_work",
             "MergeTree()",
-            1,
-            id="mt_test_inserts_to_volume_work",
+            "TTL d1 DELETE",
+            id="mt_delete",
         ),
         pytest.param(
-            "replicated_mt_test_inserts_to_volume_work",
-            "ReplicatedMergeTree('/clickhouse/replicated_test_inserts_to_volume_work', '1')",
-            1,
-            id="replicated_mt_test_inserts_to_volume_work",
+            "ReplicatedMergeTree('/clickhouse/test_delete_rmt_delete', '1')",
+            "TTL d1 DELETE",
+            id="rmt_delete",
         ),
     ],
 )
-def test_inserts_to_volume_work(started_cluster, name, engine, positive):
-    name = unique_table_name(name)
+def test_delete(started_cluster, engine, ttl_rule, request):
+    table_name = unique_table_name(request)
 
     try:
-        node1.query(
-            """
-            CREATE TABLE {name} (
+        # This test is to prove 'TTL .. DELETE' works. Also we validate that DELETE is actually performed by MERGE operation,
+        # by disabling/enabling at checkpoints
+        node1.query(f"""
+            CREATE TABLE {table_name} (
+                s1 String,
+                d1 DateTime
+            ) ENGINE = {engine}
+            ORDER BY tuple()
+            {ttl_rule}
+            SETTINGS storage_policy='only_jbod1'
+        """)
+        node1.query(f"SYSTEM STOP MERGES {table_name}")
+        node1.query(f"SYSTEM STOP MOVES {table_name}")
+
+        populate_with_records(
+            node=node1,
+            table_name=table_name,
+            generators=[
+                gen_pair_records(10, F_SMALL_STRING, F_ALREADY_EXPIRED_DATETIME),
+                gen_pair_records(10, F_SMALL_STRING, F_ALREADY_EXPIRED_DATETIME),
+                gen_pair_records(10, F_SMALL_STRING, F_SOON_TO_EXPIRE_DATETIME),
+                gen_pair_records(10, F_SMALL_STRING, F_SOON_TO_EXPIRE_DATETIME),
+                gen_pair_records(10, F_SMALL_STRING, F_NEVER_EXPIRE_DATETIME),
+                gen_pair_records(10, F_SMALL_STRING, F_NEVER_EXPIRE_DATETIME),
+            ]
+        )
+        # Check 1. All records are in place
+        assert node1.query(f"SELECT count() FROM {table_name}").strip() == "60"
+        # Check 2. MOVES do nothing
+        node1.query(f"SYSTEM START MOVES {table_name}")
+        time.sleep(SOON_SECONDS*2)    # wait for expiration and a bit more for MOVE to kick in (it won't)
+        assert node1.query(f"SELECT count() FROM {table_name}").strip() == "60"
+        # Check 3. MERGES actually deletes data
+        node1.query(f"SYSTEM START MERGES {table_name}")
+        node1.query(f"OPTIMIZE TABLE {table_name} FINAL",
+                    settings={'mutations_sync': 1})
+        assert get_disks_state(node1, table_name) == {
+            'jbod1' : {'rows':20}
+        }
+        assert node1.query(f"SELECT count() FROM {table_name}").strip() == "20"
+
+    finally:
+        drop_if_exists(node1, table_name)
+
+
+@pytest.mark.parametrize(
+    "engine,ttl_create_rule,ttl_alter_rule",
+    [
+        pytest.param(
+            "MergeTree()",
+            "TTL d1 TO DISK 'external'",
+            "MODIFY TTL d1 + INTERVAL 60 MINUTE DELETE",
+            id="mt_disk_interval_delete",
+        ),
+        pytest.param(
+            "ReplicatedMergeTree('/clickhouse/test_alter_rmt_1', '1')",
+            "TTL d1 TO DISK 'external'",
+            "MODIFY TTL d1 + INTERVAL 60 MINUTE DELETE",
+            id="rmt_disk_internal_delete",
+        ),
+        pytest.param(
+            "MergeTree()",
+            "TTL d1 TO VOLUME 'external'",
+            "MODIFY TTL d1 + INTERVAL 60 MINUTE TO DISK 'external'",
+            id="mt_volume_interval_delete",
+        ),
+        pytest.param(
+            "ReplicatedMergeTree('/clickhouse/test_alter_rmt_2', '1')",
+            "TTL d1 TO VOLUME 'external'",
+            "MODIFY TTL d1 + INTERVAL 60 MINUTE TO DISK 'external'",
+            id="rmt_volume_interval_delete",
+        ),
+        pytest.param(
+            "MergeTree()",
+            "TTL d1 TO DISK 'external'",
+            "REMOVE TTL",
+            id="mt_disk_remove_ttl",
+        ),
+        pytest.param(
+            "ReplicatedMergeTree('/clickhouse/test_alter_rmt_3', '1')",
+            "TTL d1 TO DISK 'external'",
+            "REMOVE TTL",
+            id="rmt_disk_remove_ttl",
+        ),
+        pytest.param(
+            "MergeTree()",
+            "TTL d1 TO VOLUME 'external'",
+            "REMOVE TTL",
+            id="mt_disk_remove_ttl",
+        ),
+        pytest.param(
+            "ReplicatedMergeTree('/clickhouse/test_alter_rmt_3', '1')",
+            "TTL d1 TO VOLUME 'external'",
+            "REMOVE TTL",
+            id="rmt_disk_remove_ttl",
+        ),
+    ],
+)
+def test_alter(started_cluster, engine, ttl_create_rule, ttl_alter_rule, request):
+    table_name = unique_table_name(request)
+
+    try:
+        # This test is to prove that ALTERing TTL rules is possible. We first create a table with immdiate TTL move policy,
+        # and then modifying it to disable it.
+        node1.query(f"""
+            CREATE TABLE {table_name} (
+                s1 String,
+                d1 DateTime
+            ) ENGINE = {engine}
+            ORDER BY tuple()
+            {ttl_create_rule}
+            SETTINGS storage_policy='small_jbod_with_external'
+        """)
+        node1.query(f"""
+            ALTER TABLE {table_name} {ttl_alter_rule}
+        """)
+
+        # 1. Let's write some parts:
+        #   - some are already expired - to validate that direct INSERT doesn't work anymore
+        #   - some are not yet expired (but will expire later during the test) - to validate that MOVE won't work either
+        populate_with_records(
+            node=node1,
+            table_name=table_name,
+            generators=[
+                gen_pair_records(10, F_SMALL_STRING, F_ALREADY_EXPIRED_DATETIME),
+                gen_pair_records(10, F_SMALL_STRING, F_ALREADY_EXPIRED_DATETIME),
+                gen_pair_records(10, F_SMALL_STRING, F_SOON_TO_EXPIRE_DATETIME),
+                gen_pair_records(10, F_SMALL_STRING, F_SOON_TO_EXPIRE_DATETIME),
+            ]
+        )
+
+        # Check 1. Immediately after INSERT
+        wait_if_moving_then_assert_disks(node1, table_name, target_state={
+            'jbod1': {'rows': 40},
+        })
+        assert node1.query(f"SELECT count() FROM {table_name}").strip() == "40"
+
+
+        # Check 2. Upon expiration
+        time.sleep(SOON_SECONDS*2)    # wait for expiration and a bit more for MOVE to kick in (it won't in happy scenario)
+        wait_if_moving_then_assert_disks(node1, table_name, target_state={
+            'jbod1': {'rows': 40},
+        })
+        assert node1.query(f"SELECT count() FROM {table_name}").strip() == "40"
+
+    finally:
+        drop_if_exists(node1, table_name)
+
+
+@pytest.mark.parametrize(
+    "engine",
+    [
+        pytest.param(
+            "MergeTree()",
+            id="mt",
+        ),
+        pytest.param(
+            "ReplicatedMergeTree('/clickhouse/test_ttl_can_be_changed_with_alter_ReplicatedMergeTree', '1')",
+            id="rmt",
+        ),
+    ],
+)
+def test_layered_tired_storage(started_cluster, engine, request):
+    table_name = unique_table_name(request)
+
+    try:
+        # Multi-layered tired storage is validated in this test. The entire policy applies via ALTER.
+        # From other tests we're confident that it doesn't matter if TTL is configured at CREATE or via ALTER.
+        # But using step-by-step altering appoach prevents flakinness on this test:
+        #   at each phase the target state is either achieved, either failed - variety of states is eliminated
+        #
+        # Natural and straight forward approach would be to have multiple layers configured at once, and then to sleep to let MOVEs to happen.
+        # This approach is prone to flakinness due to unexpected delays happenning randomly at test and node sides.
+        node1.query(f"""
+            CREATE TABLE {table_name} (
                 p1 Int64,
                 s1 String,
                 d1 DateTime
             ) ENGINE = {engine}
             ORDER BY tuple()
-            PARTITION BY p1
-            TTL d1 TO VOLUME 'external'
-            SETTINGS storage_policy='small_jbod_with_external'
-        """.format(
-                name=name, engine=engine
-            )
+            PARTITION by p1
+            SETTINGS storage_policy='jbod1_then_jbod2_then_external'
+        """)
+
+        # 1.
+        node1.query(f"""
+            ALTER TABLE {table_name} MODIFY
+            TTL d1 + INTERVAL 0 SECOND TO DISK 'jbod2'
+        """)
+
+        populate_with_records(
+            node=node1,
+            table_name=table_name,
+            generators=[
+                gen_triplet_records(10, 0, F_SMALL_STRING, F_ALREADY_EXPIRED_DATETIME),
+                gen_triplet_records(10, 1, F_SMALL_STRING, F_ALREADY_EXPIRED_DATETIME),
+                gen_triplet_records(10, 0, F_SMALL_STRING, F_NEVER_EXPIRE_DATETIME),
+                gen_triplet_records(10, 1, F_SMALL_STRING, F_NEVER_EXPIRE_DATETIME),
+            ]
         )
 
-        node1.query("SYSTEM STOP MOVES {name}".format(name=name))
+        wait_if_moving_then_assert_disks(node1, table_name, target_state={
+            'jbod1': {'rows': 20},
+            'jbod2': {'rows': 20},
+        })
+        assert node1.query(f"SELECT count() FROM {table_name}").strip() == "40"
 
-        for p in range(2):
-            data = []  # 20MB in total
-            for i in range(10):
-                data.append(
-                    (
-                        str(p),
-                        "randomPrintableASCII(1024*1024)",
-                        "toDateTime({})".format(
-                            time.time() - 1 if i > 0 or positive else time.time() + 300
-                        ),
-                    )
-                )
-
-            node1.query(
-                "INSERT INTO {} (p1, s1, d1) VALUES {}".format(
-                    name, ",".join(["(" + ",".join(x) + ")" for x in data])
-                )
-            )
-
-        used_disks = get_used_disks_for_table(node1, name)
-        assert set(used_disks) == {"external" if positive else "jbod1"}
-
-        assert (
-            node1.query("SELECT count() FROM {name}".format(name=name)).strip() == "20"
-        )
+        # 2.
+        node1.query(f"""
+            ALTER TABLE {table_name} MODIFY
+            TTL d1 + INTERVAL 0 SECOND TO DISK 'jbod2',
+                d1 + INTERVAL {SOON_SECONDS} SECOND TO DISK 'external'
+        """)
+        time.sleep(SOON_SECONDS)
+        wait_if_moving_then_assert_disks(node1, table_name, target_state={
+            'jbod1': {'rows': 20},
+            'external': {'rows': 20},
+        })
+        assert node1.query(f"SELECT count() FROM {table_name}").strip() == "40"
 
     finally:
-        node1.query("DROP TABLE IF EXISTS {} SYNC".format(name))
+        drop_if_exists(node1, table_name)
 
 
 @pytest.mark.parametrize(
-    "name,engine",
+    "engine",
     [
         pytest.param(
-            "mt_test_moves_to_disk_eventually_work",
             "MergeTree()",
-            id="mt_test_moves_to_disk_eventually_work",
+            id="mt"
         ),
         pytest.param(
-            "replicated_mt_test_moves_to_disk_eventually_work",
-            "ReplicatedMergeTree('/clickhouse/replicated_test_moves_to_disk_eventually_work', '1')",
-            id="replicated_mt_test_moves_to_disk_eventually_work",
+            "ReplicatedMergeTree('/clickhouse/test_materialize_ttl_per_partition_with_rmt', '1')",
+            id="rmt"
         ),
-    ],
+    ]
 )
-def test_moves_to_disk_eventually_work(started_cluster, name, engine):
-    name = unique_table_name(name)
+def test_materialize_ttl_per_partition(started_cluster, engine, request):
+    table_name = unique_table_name(request)
 
     try:
-        name_temp = name + "_temp"
-
-        node1.query(
-            """
-            CREATE TABLE {name} (
-                s1 String
-            ) ENGINE = MergeTree()
-            ORDER BY tuple()
-            SETTINGS storage_policy='only_jbod2'
-        """.format(
-                name=name_temp
-            )
+        # This test checks that TTL can be materialized per partition
+        node1.query(f"""
+            CREATE TABLE {table_name} (
+                p1 Int8,
+                s1 String,
+                d1 DateTime
+            ) ENGINE {engine}
+            ORDER BY p1
+            PARTITION BY p1
+            SETTINGS storage_policy='small_jbod_with_external'
+        """)
+        populate_with_records(
+            node=node1,
+            table_name=table_name,
+            generators=[
+                gen_triplet_records(10, 0, F_SMALL_STRING, F_ALREADY_EXPIRED_DATETIME),
+                gen_triplet_records(10, 1, F_SMALL_STRING, F_ALREADY_EXPIRED_DATETIME),
+                gen_triplet_records(10, 2, F_SMALL_STRING, F_ALREADY_EXPIRED_DATETIME),
+                gen_triplet_records(10, 3, F_SMALL_STRING, F_ALREADY_EXPIRED_DATETIME),
+                gen_triplet_records(10, 4, F_SMALL_STRING, F_ALREADY_EXPIRED_DATETIME),
+            ]
         )
+        wait_if_moving_then_assert_disks(node1, table_name, target_state={
+            'jbod1': {'rows': 50},
+        })
 
-        data = []  # 35MB in total
-        for i in range(35):
-            data.append("randomPrintableASCII(1024*1024)")
+        # Now let's apply TTL policy
+        node1.query(f"""
+            ALTER TABLE {table_name}
+                MODIFY TTL
+                d1 TO DISK 'external' SETTINGS materialize_ttl_after_modify=0, mutations_sync=1
+        """)
+        # Nothing has changes becuase of 'materialize_ttl_after_modify=0'
+        wait_if_moving_then_assert_disks(node1, table_name, target_state={
+            'jbod1': {'rows': 50},
+        })
+        # Now we manually trigger materialization
+        node1.query(f"""
+            ALTER TABLE {table_name} MATERIALIZE TTL IN PARTITION 2
+            SETTINGS mutations_sync=1
+        """)
+        node1.query(f"""
+            ALTER TABLE {table_name} MATERIALIZE TTL IN PARTITION 4
+            SETTINGS mutations_sync=1
+        """)
 
-        node1.query(
-            "INSERT INTO {} VALUES {}".format(
-                name_temp, ",".join(["(" + x + ")" for x in data])
-            )
-        )
-        used_disks = get_used_disks_for_table(node1, name_temp)
-        assert set(used_disks) == {"jbod2"}
+        # And checking that the correct partitions were moved
+        wait_if_moving_then_assert_disks(node1, table_name, partition=0, target_state={
+            'jbod1': {'rows': 10}})
+        wait_if_moving_then_assert_disks(node1, table_name, partition=1, target_state={
+            'jbod1': {'rows': 10}})
+        wait_if_moving_then_assert_disks(node1, table_name, partition=2, target_state={
+            'external': {'rows': 10}})
+        wait_if_moving_then_assert_disks(node1, table_name, partition=3, target_state={
+            'jbod1': {'rows': 10}})
+        wait_if_moving_then_assert_disks(node1, table_name, partition=4, target_state={
+            'external': {'rows': 10}})
+        assert node1.query(f"SELECT count() FROM {table_name}").strip() == "50"
 
-        node1.query(
-            """
-            CREATE TABLE {name} (
+    finally:
+        drop_if_exists(node1, table_name)
+
+
+@pytest.mark.parametrize(
+    "engine",
+    [
+        pytest.param(
+            "MergeTree()",
+            id="mt",
+        ),
+        pytest.param(
+            "ReplicatedMergeTree('/clickhouse/test_move_works_after_policy_change_rmt', '1')",
+            id="rmt",
+        ),
+    ]
+)
+def test_move_after_policy_change(started_cluster, engine, request):
+    table_name = unique_table_name(request)
+
+    try:
+        node1.query(f"""
+            CREATE TABLE {table_name} (
                 s1 String,
                 d1 DateTime
             ) ENGINE = {engine}
             ORDER BY tuple()
-            TTL d1 TO DISK 'jbod2'
-            SETTINGS storage_policy='jbod1_with_jbod2'
-        """.format(
-                name=name, engine=engine
-            )
+        """)
+
+        node1.query(f"""
+            ALTER TABLE {table_name} MODIFY SETTING storage_policy='default_with_small_jbod_with_external'
+        """)
+
+        # 1st rule won't work, 2nd will
+        node1.query(f"""
+            ALTER TABLE {table_name} MODIFY TTL now()-3600 TO DISK 'jbod1', d1 TO DISK 'external'
+            """,
+            settings={"allow_suspicious_ttl_expressions": 1}
+        )
+        # We control MOVES to prevent flakinness
+        node1.query(f"SYSTEM STOP MOVES {table_name}")
+
+        populate_with_records(
+            node=node1,
+            table_name=table_name,
+            generators=[
+                gen_pair_records(10, F_SMALL_STRING, F_SOON_TO_EXPIRE_DATETIME),
+                gen_pair_records(10, F_SMALL_STRING, F_SOON_TO_EXPIRE_DATETIME),
+            ]
         )
 
-        data = []  # 10MB in total
-        for i in range(10):
-            data.append(
-                (
-                    "randomPrintableASCII(1024*1024)",
-                    "toDateTime({})".format(time.time() - 1),
-                )
-            )
+        # 1. Records are not yet expired, so we expect them to be at the default disk - jbod1
+        wait_if_moving_then_assert_disks(node1, table_name, target_state={
+            'jbod1': {'rows': 20},
+        })
+        assert node1.query(f"SELECT count() FROM {table_name}").strip() == "20"
 
-        node1.query(
-            "INSERT INTO {} (s1, d1) VALUES {}".format(
-                name, ",".join(["(" + ",".join(x) + ")" for x in data])
-            )
-        )
-        used_disks = get_used_disks_for_table(node1, name)
-        assert set(used_disks) == {"jbod1"}
-
-        node1.query("DROP TABLE {} SYNC".format(name_temp))
-
-        wait_parts_mover(node1, name)
-
-        used_disks = get_used_disks_for_table(node1, name)
-        assert set(used_disks) == {"jbod2"}
-
-        assert (
-            node1.query("SELECT count() FROM {name}".format(name=name)).strip() == "10"
-        )
+        # Now it's safe to re-enable MOVES
+        node1.query(f"SYSTEM START MOVES {table_name}")
+        time.sleep(SOON_SECONDS)
+        # 2. Now should be expired and moved to the 'external' disk
+        wait_if_moving_then_assert_disks(node1, table_name, target_state={
+            'external': {'rows': 20}
+        })
+        assert node1.query(f"SELECT count() FROM {table_name}").strip() == "20"
 
     finally:
-        node1.query("DROP TABLE IF EXISTS {} SYNC".format(name_temp))
-        node1.query("DROP TABLE IF EXISTS {} SYNC".format(name))
+        drop_if_exists(node1, table_name)
 
 
-def test_replicated_download_ttl_info(started_cluster):
-    name = unique_table_name("test_replicated_ttl_info")
+def test_replicated_download_ttl_info(started_cluster, request):
+    table_name = unique_table_name(request)
     engine = "ReplicatedMergeTree('/clickhouse/test_replicated_download_ttl_info', '{replica}')"
+
     try:
-        for i, node in enumerate((node1, node2), start=1):
-            node.query(
-                """
-                CREATE TABLE {name} (
+        for node in (node1, node2):
+            node.query(f"""
+                CREATE TABLE {table_name} (
                     s1 String,
                     d1 DateTime
                 ) ENGINE = {engine}
                 ORDER BY tuple()
                 TTL d1 TO DISK 'external'
                 SETTINGS storage_policy='small_jbod_with_external'
-            """.format(
-                    name=name, engine=engine
-                )
-            )
+            """)
 
-        node1.query("SYSTEM STOP MOVES {}".format(name))
+        # 1. We'll check direct inserts, which should work with MOVES disabled:
+        # - expired records will be written directly to 'external'
+        # - soon-to-expire records will remain on 'jbod1'
+        node1.query(f"SYSTEM STOP MOVES {table_name}")
+        node2.query(f"SYSTEM STOP MOVES {table_name}")
 
-        node2.query(
-            "INSERT INTO {} (s1, d1) VALUES (randomPrintableASCII(1024*1024), toDateTime({}))".format(
-                name, time.time() - 100
-            )
+        populate_with_records(
+            node=node2,
+            table_name=table_name,
+            generators=[
+                gen_pair_records(10, F_SMALL_STRING, F_ALREADY_EXPIRED_DATETIME),
+                gen_pair_records(10, F_SMALL_STRING, F_SOON_TO_EXPIRE_DATETIME),
+            ]
         )
 
-        assert set(get_used_disks_for_table(node2, name)) == {"external"}
+        wait_if_moving_then_assert_disks(node1, table_name, target_state={
+            'jbod1': {'rows': 10},
+            'external': {'rows': 10},
+        })
+        assert node1.query(f"SELECT count() FROM {table_name}").strip() == "20"
 
-        time.sleep(1)
+        wait_if_moving_then_assert_disks(node2, table_name, target_state={
+            'jbod1': {'rows': 10},
+            'external': {'rows': 10},
+        })
+        assert node2.query(f"SELECT count() FROM {table_name}").strip() == "20"
 
-        assert node1.query("SELECT count() FROM {}".format(name)).splitlines() == ["1"]
-        assert set(get_used_disks_for_table(node1, name)) == {"external"}
+        # 2. Now let's resume MOVES, and check that soon-to-expire records move
+        node1.query(f"SYSTEM START MOVES {table_name}")
+        node2.query(f"SYSTEM START MOVES {table_name}")
+        time.sleep(SOON_SECONDS)
+
+        wait_if_moving_then_assert_disks(node1, table_name, target_state={
+            'external': {'rows': 20}
+        })
+        assert node1.query(f"SELECT count() FROM {table_name}").strip() == "20"
+
+        wait_if_moving_then_assert_disks(node2, table_name, target_state={
+            'external': {'rows': 20}
+        })
+        assert node2.query(f"SELECT count() FROM {table_name}").strip() == "20"
 
     finally:
-        for node in (node1, node2):
-            try:
-                node.query("DROP TABLE IF EXISTS {} SYNC".format(name))
-            except:
-                continue
+        for n in (node1, node2):
+            drop_if_exists(n, table_name)
 
 
 @pytest.mark.parametrize(
-    "name,engine,positive",
+    "dest_type",
     [
-        pytest.param(
-            "mt_test_merges_to_disk_do_not_work",
-            "MergeTree()",
-            0,
-            id="mt_test_merges_to_disk_do_not_work",
-        ),
-        pytest.param(
-            "replicated_mt_test_merges_to_disk_do_not_work",
-            "ReplicatedMergeTree('/clickhouse/replicated_test_merges_to_disk_do_not_work', '1')",
-            0,
-            id="mt_test_merges_to_disk_do_not_work",
-        ),
-        pytest.param(
-            "mt_test_merges_to_disk_work",
-            "MergeTree()",
-            1,
-            id="mt_test_merges_to_disk_work",
-        ),
-        pytest.param(
-            "replicated_mt_test_merges_to_disk_work",
-            "ReplicatedMergeTree('/clickhouse/replicated_test_merges_to_disk_work', '1')",
-            1,
-            id="replicated_mt_test_merges_to_disk_work",
-        ),
-    ],
+        pytest.param("DISK", id="rmt_disk"),
+        pytest.param("VOLUME", id="rmt_volume"),
+    ]
 )
-def test_merges_to_disk_work(started_cluster, name, engine, positive):
-    name = unique_table_name(name)
+def test_ttl_move_if_exists(started_cluster, dest_type, request):
+    table_name = unique_table_name(request)
 
     try:
-        node1.query(
-            """
-            CREATE TABLE {name} (
+        # This test validates that IF EXISTS works correctly with TTL rules. Two replicas are created with different
+        # storage policies, and the data is eventually moved if the specified destination exists.
+        # The data is placed to the available disk if the specified destination doesn't exist.
+        create_query_template = """
+            CREATE TABLE {table_name} (
+                s1 String,
+                d1 DateTime
+            ) ENGINE = ReplicatedMergeTree('/clickhouse/test_ttl_move_if_exists', '{node_name}')
+            ORDER BY tuple()
+            TTL d1 TO {dest_type} {if_exists} 'external'
+            SETTINGS storage_policy='{policy}'
+        """
+
+        node1.query_and_get_error(
+            create_query_template.format(
+                table_name=table_name,
+                node_name=node1.name,
+                dest_type=dest_type,
+                if_exists="",           # this why this call gonna fail - 'external' is attempted to be used
+                policy="only_jbod1",    # with the 'jbod1' only policy
+            )
+        )
+
+        for node,policy in zip(
+            (node1, node2), ("only_jbod1", "small_jbod_with_external")
+        ):
+            node.query(
+                create_query_template.format(
+                    table_name=table_name,
+                    node_name=node.name,
+                    dest_type=dest_type,
+                    if_exists="IF EXISTS",  # now this should work despite whether 'external' is configured
+                    policy=policy,
+                )
+            )
+
+        # 1. MOVE'ing expired data, it ends up directly at the target disk
+        populate_with_records(
+            node=node1,
+            table_name=table_name,
+            generators=[
+                gen_pair_records(10, F_SMALL_STRING, F_ALREADY_EXPIRED_DATETIME),
+                gen_pair_records(10, F_SMALL_STRING, F_ALREADY_EXPIRED_DATETIME),
+            ]
+        )
+        node2.query(f"SYSTEM SYNC REPLICA {table_name}") # this sync is blocking, no sleep needed
+
+        wait_if_moving_then_assert_disks(node1, table_name, target_state={
+            'jbod1': {'rows': 20},
+        })
+        wait_if_moving_then_assert_disks(node2, table_name, target_state={
+            'external': {'rows': 20},
+        })
+        assert node1.query(f"SELECT count() FROM {table_name}").strip() == "20"
+        assert node2.query(f"SELECT count() FROM {table_name}").strip() == "20"
+
+        # 2. MOVE'ing never-expiring data, it will be placed to the original 'jbod1'
+        populate_with_records(
+            node=node1,
+            table_name=table_name,
+            generators=[
+                gen_pair_records(10, F_SMALL_STRING, F_NEVER_EXPIRE_DATETIME),
+                gen_pair_records(10, F_SMALL_STRING, F_NEVER_EXPIRE_DATETIME),
+            ]
+        )
+        node2.query(f"SYSTEM SYNC REPLICA {table_name}")
+
+        wait_if_moving_then_assert_disks(node1, table_name, target_state={
+            'jbod1': {'rows': 40},
+        })
+        wait_if_moving_then_assert_disks(node2, table_name, target_state={
+            'jbod1': {'rows': 20},
+            'external': {'rows': 20},
+        })
+        assert node1.query(f"SELECT count() FROM {table_name}").strip() == "40"
+        assert node2.query(f"SELECT count() FROM {table_name}").strip() == "40"
+
+    finally:
+        drop_if_exists(node1, table_name)
+        drop_if_exists(node2, table_name)
+
+
+@pytest.mark.parametrize(
+    "engine",
+    [
+        pytest.param(
+            "MergeTree()",
+            id="mt"
+        ),
+        pytest.param(
+            "ReplicatedMergeTree('/clickhouse/replicated_test_merges_to_disk_rmt', '1')",
+            id="rmt"
+        ),
+    ]
+)
+def test_merges_to_disk(started_cluster, engine, request):
+    table_name = unique_table_name(request)
+
+    try:
+        node1.query(f"""
+            CREATE TABLE {table_name} (
                 s1 String,
                 d1 DateTime
             ) ENGINE = {engine}
             ORDER BY tuple()
             TTL d1 TO DISK 'external'
             SETTINGS storage_policy='small_jbod_with_external'
-        """.format(
-                name=name, engine=engine
-            )
+        """)
+
+        node1.query(f"SYSTEM STOP MERGES {table_name}")
+        node1.query(f"SYSTEM STOP MOVES {table_name}")
+
+        populate_with_records(
+            node=node1,
+            table_name=table_name,
+            generators=[
+                gen_pair_records(10, F_SMALL_STRING, F_ALREADY_EXPIRED_DATETIME),
+                gen_pair_records(10, F_SMALL_STRING, F_ALREADY_EXPIRED_DATETIME),
+                gen_pair_records(10, F_SMALL_STRING, F_SOON_TO_EXPIRE_DATETIME),
+                gen_pair_records(10, F_SMALL_STRING, F_SOON_TO_EXPIRE_DATETIME),
+                gen_pair_records(10, F_SMALL_STRING, F_NEVER_EXPIRE_DATETIME),
+                gen_pair_records(10, F_SMALL_STRING, F_NEVER_EXPIRE_DATETIME),
+            ]
         )
 
-        node1.query("SYSTEM STOP MERGES {}".format(name))
-        node1.query("SYSTEM STOP MOVES {}".format(name))
+        # 1.
+        assert get_disks_state(node1, table_name) == {
+            'jbod1': {'rows': 40},
+            'external': {'rows': 20}
+        }
+        assert node1.query(f"SELECT count() FROM {table_name}").strip() == "60"
 
-        wait_expire_1 = 16
-        wait_expire_2 = 20
-        time_1 = time.time() + wait_expire_1
-        time_2 = time.time() + wait_expire_1 + wait_expire_2
+        # 2. Wait for expiration and re-enable & trigger MERGES to see that it applied TTL policy and the data has moved
+        # NOTE: Merge operation will merge all outstanding parts to the disk with the highest id, which is 'external' in this case
+        time.sleep(SOON_SECONDS)
+        node1.query(f"SYSTEM START MERGES {table_name}")
+        node1.query(f"OPTIMIZE TABLE {table_name}",
+                    settings={'mutations_sync': 1})
 
-        wait_expire_1_thread = threading.Thread(
-            target=time.sleep, args=(wait_expire_1,)
-        )
-        wait_expire_1_thread.start()
-
-        for _ in range(2):
-            data = []  # 16MB in total
-            for i in range(8):
-                data.append(
-                    (
-                        "randomPrintableASCII(1024*1024)",
-                        "toDateTime({})".format(
-                            time_1 if i > 0 or positive else time_2
-                        ),
-                    )
-                )
-
-            node1.query(
-                "INSERT INTO {} (s1, d1) VALUES {}".format(
-                    name, ",".join(["(" + ",".join(x) + ")" for x in data])
-                )
-            )
-
-        used_disks = get_used_disks_for_table(node1, name)
-        assert set(used_disks) == {"jbod1"}
-        assert (
-            "2"
-            == node1.query(
-                "SELECT count() FROM system.parts WHERE table = '{}' AND active = 1".format(
-                    name
-                )
-            ).strip()
-        )
-
-        wait_expire_1_thread.join()
-        time.sleep(wait_expire_2 / 2)
-
-        node1.query("SYSTEM START MERGES {}".format(name))
-        node1.query("OPTIMIZE TABLE {}".format(name))
-
-        used_disks = get_used_disks_for_table(node1, name)
-        assert set(used_disks) == {"external" if positive else "jbod1"}
-        assert (
-            "1"
-            == node1.query(
-                "SELECT count() FROM system.parts WHERE table = '{}' AND active = 1".format(
-                    name
-                )
-            ).strip()
-        )
-
-        assert (
-            node1.query("SELECT count() FROM {name}".format(name=name)).strip() == "16"
-        )
+        assert get_disks_state(node1, table_name) == {
+            'external': {'rows': 60}
+        }
+        assert node1.query(f"SELECT count() FROM {table_name}").strip() == "60"
 
     finally:
-        node1.query("DROP TABLE IF EXISTS {} SYNC".format(name))
+        drop_if_exists(node1, table_name)
 
 
 @pytest.mark.parametrize(
-    "name,engine",
+    "engine",
     [
         pytest.param(
-            "mt_test_merges_with_full_disk_work",
             "MergeTree()",
-            id="mt_test_merges_with_full_disk_work",
+            id="mt",
         ),
         pytest.param(
-            "replicated_mt_test_merges_with_full_disk_work",
-            "ReplicatedMergeTree('/clickhouse/replicated_test_merges_with_full_disk_work', '1')",
-            id="replicated_mt_test_merges_with_full_disk_work",
+            "ReplicatedMergeTree('/clickhouse/test_moves_with_full_disk_work_rmt', '1')",
+            id="rmt",
         ),
     ],
 )
-def test_merges_with_full_disk_work(started_cluster, name, engine):
-    name = unique_table_name(name)
+def test_moves_with_full_disk(started_cluster, engine, request):
+    check_if_should_skip_this_then_skip(node1)
+
+    table_name = unique_table_name(request)
+    temp_table_name = table_name + '_temp'
 
     try:
-        name_temp = name + "_temp"
-
-        node1.query(
-            """
-            CREATE TABLE {name} (
+        # This test checks that if the target disk is full, the data will be placed onto the available disk,
+        # and later moved to the correct destination once possible.
+        # TEMP table to fill up the disk
+        node1.query(f"""
+            CREATE TABLE {temp_table_name} (
                 s1 String
             ) ENGINE = MergeTree()
             ORDER BY tuple()
             SETTINGS storage_policy='only_jbod2'
-        """.format(
-                name=name_temp
-            )
+        """)
+
+        # Disk is 40Mb, we write 35Mb
+        populate_with_records(
+            node=node1,
+            table_name=temp_table_name,
+            generators=[
+                gen_uni_records(35, F_LARGE_STRING),
+            ]
         )
+        assert get_disk_names(node1, temp_table_name) == {'jbod2'}
 
-        data = []  # 35MB in total
-        for i in range(35):
-            data.append("randomPrintableASCII(1024*1024)")
-
-        node1.query(
-            "INSERT INTO {} VALUES {}".format(
-                name_temp, ",".join(["(" + x + ")" for x in data])
-            )
+        # Now we create the target table and populate it
+        node1.query(f"""
+        CREATE TABLE {table_name} (
+            s1 String,
+            d1 DateTime
+        ) ENGINE = {engine}
+        ORDER BY tuple()
+        TTL d1 TO DISK 'jbod2'
+        SETTINGS storage_policy='jbod1_with_jbod2'
+        """)
+        # 10Mb of expired records to be placed to 'jbod2' as a single part, but it's full up to 35Mb out of 40Mb
+        populate_with_records(
+            node=node1,
+            table_name=table_name,
+            generators=[
+                gen_pair_records(10, F_LARGE_STRING, F_ALREADY_EXPIRED_DATETIME),
+            ]
         )
-        used_disks = get_used_disks_for_table(node1, name_temp)
-        assert set(used_disks) == {"jbod2"}
+        # so this part ends up at 'jbod1'
+        assert get_disk_names(node1, table_name) == {'jbod1'}
 
-        node1.query(
-            """
-            CREATE TABLE {name} (
+        # Now we drop the TEMP table, free up the space, and eventually the move happens
+        node1.query(f"DROP TABLE {temp_table_name} SYNC")
+        wait_if_moving_then_assert_disks(node1, table_name, target_state={
+            'jbod2': {'rows': 10}
+        })
+        assert node1.query(f"SELECT count() FROM {table_name}").strip() == "10"
+
+    finally:
+        drop_if_exists(node1, temp_table_name)
+        drop_if_exists(node1, table_name)
+
+
+@pytest.mark.parametrize(
+    "engine",
+    [
+        pytest.param(
+            "MergeTree()",
+            id="mt",
+        ),
+        pytest.param(
+            "ReplicatedMergeTree('/clickhouse/test_merges_with_full_disk_rmt', '1')",
+            id="rmt",
+        ),
+    ],
+)
+def test_merges_with_full_disk(started_cluster, engine, request):
+    check_if_should_skip_this_then_skip(node1)
+
+    table_name = unique_table_name(request)
+    temp_table_name = table_name + '_temp'
+
+    try:
+        # This test checks that MERGE falls back to the available disk, if the target disk is full
+        # NOTE: MERGE operation is sensitive to not-having enough free space at 'jbod1' - it data sizes are imbalanced (or 'jbod1' is more full than expected), this test might flap by haning in OPTIMIZE
+
+        # TEMP table to fill up the disk
+        node1.query(f"""
+            CREATE TABLE {temp_table_name} (
+                s1 String
+            ) ENGINE = MergeTree()
+            ORDER BY tuple()
+            SETTINGS storage_policy='only_jbod2'
+        """)
+
+        # Disk is 40Mb, we write 35Mb
+        populate_with_records(
+            node=node1,
+            table_name=temp_table_name,
+            generators=[
+                gen_uni_records(35, F_LARGE_STRING),
+            ]
+        )
+        assert get_disk_names(node1, temp_table_name) == {'jbod2'}
+
+        # Now we create the target table and populate it
+        node1.query(f"""
+            CREATE TABLE {table_name} (
                 s1 String,
                 d1 DateTime
             ) ENGINE = {engine}
             ORDER BY tuple()
             TTL d1 TO DISK 'jbod2'
             SETTINGS storage_policy='jbod1_with_jbod2'
-        """.format(
-                name=name, engine=engine
-            )
+        """)
+        # 2 parts of 10Mb of expired records to be move to 'jbod2', but it's full up to 35Mb out of 40Mb
+        populate_with_records(
+            node=node1,
+            table_name=table_name,
+            generators=[
+                gen_pair_records(6, F_LARGE_STRING, F_ALREADY_EXPIRED_DATETIME),
+                gen_pair_records(6, F_LARGE_STRING, F_ALREADY_EXPIRED_DATETIME),
+            ]
         )
 
-        wait_expire_1 = 10
-        time_1 = time.time() + wait_expire_1
+        # 1. Check that records are placed at 'jbod1'
+        assert get_disk_names(node1, table_name) == {'jbod1'}
+        assert node1.query(f"SELECT count() FROM system.parts WHERE table='{table_name}' AND active=1").strip() == "2"
 
-        wait_expire_1_thread = threading.Thread(
-            target=time.sleep, args=(wait_expire_1,)
-        )
-        wait_expire_1_thread.start()
-
-        for _ in range(2):
-            data = []  # 12MB in total
-            for i in range(6):
-                data.append(
-                    ("randomPrintableASCII(1024*1024)", "toDateTime({})".format(time_1))
-                )  # 1MB row
-            node1.query(
-                "INSERT INTO {} (s1, d1) VALUES {}".format(
-                    name, ",".join(["(" + ",".join(x) + ")" for x in data])
-                )
-            )
-
-        used_disks = get_used_disks_for_table(node1, name)
-        assert set(used_disks) == {"jbod1"}
-        assert (
-            "2"
-            == node1.query(
-                "SELECT count() FROM system.parts WHERE table = '{}' AND active = 1".format(
-                    name
-                )
-            ).strip()
-        )
-
-        wait_expire_1_thread.join()
-
-        node1.query("OPTIMIZE TABLE {}".format(name))
+        # 2. Disk is still full, but we force MERGE, data is expected to still be at 'jbod1'
+        node1.query(f"OPTIMIZE TABLE {table_name} SETTINGS mutations_sync=1")
         time.sleep(1)
-
-        used_disks = get_used_disks_for_table(node1, name)
-        assert set(used_disks) == {"jbod1"}  # Merged to the same disk against the rule.
-        assert (
-            "1"
-            == node1.query(
-                "SELECT count() FROM system.parts WHERE table = '{}' AND active = 1".format(
-                    name
-                )
-            ).strip()
-        )
-
-        assert (
-            node1.query("SELECT count() FROM {name}".format(name=name)).strip() == "12"
-        )
+        assert get_disk_names(node1, table_name) == {'jbod1'}
+        assert node1.query(f"SELECT count() FROM system.parts WHERE table='{table_name}' AND active=1").strip() == "1"
+        assert node1.query(f"SELECT count() FROM {table_name}").strip() == "12"
 
     finally:
-        node1.query("DROP TABLE IF EXISTS {} SYNC".format(name_temp))
-        node1.query("DROP TABLE IF EXISTS {} SYNC".format(name))
+        drop_if_exists(node1, temp_table_name)
+        drop_if_exists(node1, table_name)
 
 
 @pytest.mark.parametrize(
-    "name,engine,positive",
+    "engine",
     [
         pytest.param(
-            "mt_test_moves_after_merges_do_not_work",
             "MergeTree()",
-            0,
-            id="mt_test_moves_after_merges_do_not_work",
+            id="mt"
         ),
         pytest.param(
-            "replicated_mt_test_moves_after_merges_do_not_work",
-            "ReplicatedMergeTree('/clickhouse/replicated_test_moves_after_merges_do_not_work', '1')",
-            0,
-            id="replicated_mt_test_moves_after_merges_do_not_work",
+            "ReplicatedMergeTree('/clickhouse/test_moves_after_merges_rmt', '1')",
+            id="rmt"
         ),
-        pytest.param(
-            "mt_test_moves_after_merges_work",
-            "MergeTree()",
-            1,
-            id="mt_test_moves_after_merges_work",
-        ),
-        pytest.param(
-            "replicated_mt_test_moves_after_merges_work",
-            "ReplicatedMergeTree('/clickhouse/replicated_test_moves_after_merges_work', '1')",
-            1,
-            id="replicated_mt_test_moves_after_merges_work",
-        ),
-    ],
+    ]
 )
-def test_moves_after_merges_work(started_cluster, name, engine, positive):
-    name = unique_table_name(name)
+def test_moves_after_merges(started_cluster, engine, request):
+    table_name = unique_table_name(request)
 
     try:
-        node1.query(
-            """
-            CREATE TABLE {name} (
+        node1.query(f"""
+            CREATE TABLE {table_name} (
                 s1 String,
                 d1 DateTime
             ) ENGINE = {engine}
             ORDER BY tuple()
             TTL d1 TO DISK 'external'
             SETTINGS storage_policy='small_jbod_with_external'
-        """.format(
-                name=name, engine=engine
-            )
+        """)
+        # we want to control over when to MOVE to eliminate flakinness
+        node1.query(f"SYSTEM STOP MOVES {table_name}")
+        populate_with_records(
+            node=node1,
+            table_name=table_name,
+            generators=[
+                gen_pair_records(10, F_SMALL_STRING, F_SOON_TO_EXPIRE_DATETIME),
+                gen_pair_records(10, F_SMALL_STRING, F_SOON_TO_EXPIRE_DATETIME),
+            ]
         )
 
-        wait_expire_1 = 16
-        wait_expire_2 = 20
-        time_1 = time.time() + wait_expire_1
-        time_2 = time.time() + wait_expire_1 + wait_expire_2
+        node1.query(f"OPTIMIZE TABLE {table_name}")
 
-        wait_expire_1_thread = threading.Thread(
-            target=time.sleep, args=(wait_expire_1,)
-        )
-        wait_expire_1_thread.start()
+        # 1. Check after MERGE
+        wait_if_moving_then_assert_disks(node1, table_name, target_state={
+            'jbod1' : {'rows': 20}
+        })
+        assert node1.query(f"SELECT count() FROM system.parts WHERE table='{table_name}' AND active=1").strip() == "1"
 
-        for _ in range(2):
-            data = []  # 14MB in total
-            for i in range(7):
-                data.append(
-                    (
-                        "randomPrintableASCII(1024*1024)",
-                        "toDateTime({})".format(
-                            time_1 if i > 0 or positive else time_2
-                        ),
-                    )
-                )  # 1MB row
-
-            node1.query(
-                "INSERT INTO {} (s1, d1) VALUES {}".format(
-                    name, ",".join(["(" + ",".join(x) + ")" for x in data])
-                )
-            )
-
-        node1.query("OPTIMIZE TABLE {}".format(name))
-
-        used_disks = get_used_disks_for_table(node1, name)
-        assert set(used_disks) == {"jbod1"}
-        assert (
-            "1"
-            == node1.query(
-                "SELECT count() FROM system.parts WHERE table = '{}' AND active = 1".format(
-                    name
-                )
-            ).strip()
-        )
-
-        wait_expire_1_thread.join()
-        time.sleep(wait_expire_2 / 2)
-
-        used_disks = get_used_disks_for_table(node1, name)
-        assert set(used_disks) == {"external" if positive else "jbod1"}
-
-        assert (
-            node1.query("SELECT count() FROM {name}".format(name=name)).strip() == "14"
-        )
+        # 2. Waiting for the data to expire and then expecting it at the target location
+        node1.query(f"SYSTEM START MOVES {table_name}")
+        time.sleep(SOON_SECONDS)
+        wait_if_moving_then_assert_disks(node1, table_name, target_state={
+            'external' : {'rows': 20}
+        })
+        assert node1.query(f"SELECT count() FROM system.parts WHERE table='{table_name}' AND active=1").strip() == "1"
+        assert node1.query(f"SELECT count() FROM {table_name}").strip() == "20"
 
     finally:
-        node1.query("DROP TABLE IF EXISTS {} SYNC".format(name))
+        drop_if_exists(node1, table_name)
 
 
 @pytest.mark.parametrize(
-    "name,engine,positive,bar",
+    "engine",
     [
         pytest.param(
-            "mt_test_moves_after_alter_do_not_work",
             "MergeTree()",
-            0,
-            "DELETE",
-            id="mt_negative",
+            id="mt",
         ),
         pytest.param(
-            "replicated_mt_test_moves_after_alter_do_not_work",
-            "ReplicatedMergeTree('/clickhouse/replicated_test_moves_after_alter_do_not_work', '1')",
-            0,
-            "DELETE",
-            id="repicated_negative",
+            "ReplicatedMergeTree('/clickhouse/test_concurrent_alter_with_ttl_move', '1')",
+            id="rmt"
         ),
-        pytest.param(
-            "mt_test_moves_after_alter_work",
-            "MergeTree()",
-            1,
-            "DELETE",
-            id="mt_positive",
-        ),
-        pytest.param(
-            "replicated_mt_test_moves_after_alter_work",
-            "ReplicatedMergeTree('/clickhouse/replicated_test_moves_after_alter_work', '1')",
-            1,
-            "DELETE",
-            id="repicated_positive",
-        ),
-        pytest.param(
-            "mt_test_moves_after_alter_do_not_work",
-            "MergeTree()",
-            0,
-            "TO DISK 'external'",
-            id="mt_external_negative",
-        ),
-        pytest.param(
-            "replicated_mt_test_moves_after_alter_do_not_work",
-            "ReplicatedMergeTree('/clickhouse/replicated_test_moves_after_alter_do_not_work', '1')",
-            0,
-            "TO DISK 'external'",
-            id="replicated_external_negative",
-        ),
-        pytest.param(
-            "mt_test_moves_after_alter_work",
-            "MergeTree()",
-            1,
-            "TO DISK 'external'",
-            id="mt_external_positive",
-        ),
-        pytest.param(
-            "replicated_mt_test_moves_after_alter_work",
-            "ReplicatedMergeTree('/clickhouse/replicated_test_moves_after_alter_work', '1')",
-            1,
-            "TO DISK 'external'",
-            id="replicated_external_positive",
-        ),
-    ],
+    ]
 )
-def test_ttls_do_not_work_after_alter(started_cluster, name, engine, positive, bar):
-    name = unique_table_name(name)
+def test_concurrent_alter_with_ttl_move(started_cluster, engine, request):
+    check_if_should_skip_this_then_skip(node1)
+
+    table_name = unique_table_name(request)
 
     try:
-        node1.query(
-            """
-            CREATE TABLE {name} (
-                s1 String,
-                d1 DateTime
-            ) ENGINE = {engine}
-            ORDER BY tuple()
-            TTL d1 TO DISK 'external'
-            SETTINGS storage_policy='small_jbod_with_external'
-        """.format(
-                name=name, engine=engine
-            )
-        )
+        # This is an opportunistic stress test, which runs multiple concurrent threads to trigger:
+        # - INSERTs         (insert)
+        # - direct MOVEs    (alter_move)
+        # - MUTATEs         (alter_update)
+        # - MOVEs by TTL    (alter_modify_ttl)
+        # - MERGES          (optimize_table)
+        # It is quite robust because we don't validate mid-states interactively, the only logical check is to assert for the correct number of rows
+        # TODO: in the worst case, the case can stuck for 25*120 sec (num operations X timeout per operation).
+        #       This is unlikely, but if that occurs, we should try making individual operations longer (increase data size + lower bandwidth) and lowering their total number.
+        # TODO: There's no clear failure criteria for this test - we stress it to check whether something fails unexpectedly.
+        #       Perhaps we could add post-validation (assert) for each operation, OR to build a serialized trace of execution and to validate it mid-points
 
-        if positive:
-            node1.query(
-                """
-                ALTER TABLE {name}
-                    MODIFY TTL
-                    d1 + INTERVAL 15 MINUTE {bar}
-            """.format(
-                    name=name, bar=bar
-                )
-            )  # That shall disable TTL.
-
-        data = []  # 10MB in total
-        for i in range(10):
-            data.append(
-                (
-                    "randomPrintableASCII(1024*1024)",
-                    "toDateTime({})".format(time.time() - 1),
-                )
-            )  # 1MB row
-        node1.query(
-            "INSERT INTO {} (s1, d1) VALUES {}".format(
-                name, ",".join(["(" + ",".join(x) + ")" for x in data])
-            )
-        )
-
-        used_disks = get_used_disks_for_table(node1, name)
-        assert set(used_disks) == {"jbod1" if positive else "external"}
-
-        assert (
-            node1.query("SELECT count() FROM {name}".format(name=name)).strip() == "10"
-        )
-
-    finally:
-        node1.query("DROP TABLE IF EXISTS {} SYNC".format(name))
-
-
-@pytest.mark.parametrize(
-    "name,engine",
-    [
-        pytest.param("mt_test_materialize_ttl_in_partition", "MergeTree()", id="mt"),
-        pytest.param(
-            "replicated_mt_test_materialize_ttl_in_partition",
-            "ReplicatedMergeTree('/clickhouse/test_materialize_ttl_in_partition', '1')",
-            id="replicated",
-        ),
-    ],
-)
-def test_materialize_ttl_in_partition(started_cluster, name, engine):
-    name = unique_table_name(name)
-
-    try:
-        node1.query(
-            """
-            CREATE TABLE {name} (
-                p1 Int8,
-                s1 String,
-                d1 DateTime
-            ) ENGINE = {engine}
-            ORDER BY p1
-            PARTITION BY p1
-            SETTINGS storage_policy='small_jbod_with_external'
-        """.format(
-                name=name, engine=engine
-            )
-        )
-
-        data = []  # 5MB in total
-        for i in range(5):
-            data.append(
-                (
-                    str(i),
-                    "randomPrintableASCII(1024*1024)",
-                    "toDateTime({})".format(time.time() - 1),
-                )
-            )  # 1MB row
-        node1.query(
-            "INSERT INTO {} (p1, s1, d1) VALUES {}".format(
-                name, ",".join(["(" + ",".join(x) + ")" for x in data])
-            )
-        )
-
-        used_disks = get_used_disks_for_table(node1, name)
-        assert set(used_disks) == {"jbod1"}
-
-        node1.query(
-            """
-                ALTER TABLE {name}
-                    MODIFY TTL
-                    d1 TO DISK 'external' SETTINGS materialize_ttl_after_modify = 0
-            """.format(
-                name=name
-            )
-        )
-
-        time.sleep(3)
-
-        used_disks = get_used_disks_for_table(node1, name)
-        assert set(used_disks) == {"jbod1"}
-
-        node1.query(
-            """
-                ALTER TABLE {name}
-                    MATERIALIZE TTL IN PARTITION 2
-        """.format(
-                name=name
-            )
-        )
-
-        node1.query(
-            """
-                ALTER TABLE {name}
-                    MATERIALIZE TTL IN PARTITION 4
-        """.format(
-                name=name
-            )
-        )
-
-        time.sleep(3)
-
-        used_disks_sets = []
-        for i in range(len(data)):
-            used_disks_sets.append(
-                set(get_used_disks_for_table(node1, name, partition=i))
-            )
-
-        assert used_disks_sets == [
-            {"jbod1"},
-            {"jbod1"},
-            {"external"},
-            {"jbod1"},
-            {"external"},
-        ]
-
-        assert node1.query(
-            "SELECT count() FROM {name}".format(name=name)
-        ).strip() == str(len(data))
-
-    finally:
-        node1.query("DROP TABLE IF EXISTS {} SYNC".format(name))
-
-
-@pytest.mark.parametrize(
-    "name,engine,positive",
-    [
-        pytest.param(
-            "mt_test_alter_multiple_ttls_positive", "MergeTree()", True, id="positive"
-        ),
-        pytest.param(
-            "mt_replicated_test_alter_multiple_ttls_positive",
-            "ReplicatedMergeTree('/clickhouse/replicated_test_alter_multiple_ttls_positive', '1')",
-            True,
-            id="replicated_positive",
-        ),
-        pytest.param(
-            "mt_test_alter_multiple_ttls_negative", "MergeTree()", False, id="negative"
-        ),
-        pytest.param(
-            "mt_replicated_test_alter_multiple_ttls_negative",
-            "ReplicatedMergeTree('/clickhouse/replicated_test_alter_multiple_ttls_negative', '1')",
-            False,
-            id="replicated_negative",
-        ),
-    ],
-)
-def test_alter_multiple_ttls(started_cluster, name, engine, positive):
-    name = unique_table_name(name)
-
-    """Check that when multiple TTL expressions are set
-    and before any parts are inserted the TTL expressions
-    are changed with ALTER command then all old
-    TTL expressions are removed and the
-    the parts are moved to the specified disk or volume or
-    deleted if the new TTL expression is triggered
-    and are not moved or deleted when it is not.
-    """
-    now = time.time()
-    try:
-        node1.query(
-            """
-            CREATE TABLE {name} (
-                p1 Int64,
-                s1 String,
-                d1 DateTime
-            ) ENGINE = {engine}
-            ORDER BY tuple()
-            PARTITION BY p1
-            TTL d1 + INTERVAL 34 SECOND TO DISK 'jbod2',
-                d1 + INTERVAL 64 SECOND TO VOLUME 'external'
-            SETTINGS storage_policy='jbods_with_external', merge_with_ttl_timeout=0
-        """.format(
-                name=name, engine=engine
-            )
-        )
-
-        node1.query(
-            """
-            ALTER TABLE {name} MODIFY
-            TTL d1 + INTERVAL 0 SECOND TO DISK 'jbod2',
-                d1 + INTERVAL 14 SECOND TO VOLUME 'external',
-                d1 + INTERVAL 19 SECOND DELETE
-        """.format(
-                name=name
-            )
-        )
-
-        for p in range(3):
-            data = []  # 6MB in total
-            now = time.time()
-            for i in range(2):
-                p1 = p
-                d1 = now - 1 if i > 0 or positive else now + 300
-                data.append(
-                    "({}, randomPrintableASCII(1024*1024), toDateTime({}))".format(
-                        p1, d1
-                    )
-                )
-            node1.query(
-                "INSERT INTO {name} (p1, s1, d1) VALUES {values}".format(
-                    name=name, values=",".join(data)
-                )
-            )
-
-        used_disks = get_used_disks_for_table(node1, name)
-        assert set(used_disks) == {"jbod2"} if positive else {"jbod1", "jbod2"}
-
-        assert node1.query(
-            "SELECT count() FROM {name}".format(name=name)
-        ).splitlines() == ["6"]
-
-        if positive:
-            expected_disks = {"external"}
-        else:
-            expected_disks = {"jbod1", "jbod2"}
-
-        check_used_disks_with_retry(node1, name, expected_disks, 50)
-
-        assert node1.query(
-            "SELECT count() FROM {name}".format(name=name)
-        ).splitlines() == ["6"]
-
-        time.sleep(5)
-
-        for i in range(50):
-            rows_count = int(
-                node1.query("SELECT count() FROM {name}".format(name=name)).strip()
-            )
-            if positive:
-                if rows_count == 0:
-                    break
-            else:
-                if rows_count == 3:
-                    break
-            node1.query("OPTIMIZE TABLE {name} FINAL".format(name=name))
-            time.sleep(0.5)
-
-        if positive:
-            assert rows_count == 0
-        else:
-            assert rows_count == 3
-
-    finally:
-        node1.query("DROP TABLE IF EXISTS {name} SYNC".format(name=name))
-
-
-@pytest.mark.parametrize(
-    "name,engine",
-    [
-        pytest.param("concurrently_altering_ttl_mt", "MergeTree()", id="mt"),
-        pytest.param(
-            "concurrently_altering_ttl_replicated_mt",
-            "ReplicatedMergeTree('/clickhouse/concurrently_altering_ttl_replicated_mt', '1')",
-            id="replicated_mt",
-        ),
-    ],
-)
-def test_concurrent_alter_with_ttl_move(started_cluster, name, engine):
-    name = unique_table_name(name)
-
-    try:
-        node1.query(
-            """
-            CREATE TABLE {name} (
+        node1.query(f"""
+            CREATE TABLE {table_name} (
                 EventDate Date,
                 number UInt64
             ) ENGINE = {engine}
             ORDER BY tuple()
             PARTITION BY toYYYYMM(EventDate)
             SETTINGS storage_policy='jbods_with_external'
-        """.format(
-                name=name, engine=engine
-            )
-        )
+        """)
 
         values = list({random.randint(1, 1000000) for _ in range(0, 1000)})
 
@@ -1423,7 +1431,7 @@ def test_concurrent_alter_with_ttl_move(started_cluster, name, engine):
                 month = "0" + str(random.choice([3, 4]))
                 node1.query(
                     "INSERT INTO {} VALUES(toDate('2019-{m}-{d}'), {v})".format(
-                        name, m=month, d=day, v=value
+                        table_name, m=month, d=day, v=value
                     )
                 )
 
@@ -1471,13 +1479,13 @@ def test_concurrent_alter_with_ttl_move(started_cluster, name, engine):
                     pass
 
             for i in range(num):
-                produce_alter_move(node1, name)
+                produce_alter_move(node1, table_name)
 
         def alter_update(num):
             for i in range(num):
                 try:
                     node1.query(
-                        "ALTER TABLE {} UPDATE number = number + 1 WHERE 1".format(name)
+                        "ALTER TABLE {} UPDATE number = number + 1 WHERE 1".format(table_name)
                     )
                 except:
                     pass
@@ -1499,16 +1507,24 @@ def test_concurrent_alter_with_ttl_move(started_cluster, name, engine):
                     ttls.append("{} {}".format(when, what))
                 try:
                     node1.query(
-                        "ALTER TABLE {} MODIFY TTL {}".format(name, ", ".join(ttls))
+                        "ALTER TABLE {} MODIFY TTL {}".format(table_name, ", ".join(ttls))
                     )
                 except QueryRuntimeException:
                     pass
+
+        def stop_and_resume_moves(num):
+            for i in range(num):
+                node1.query(f"SYSTEM STOP MOVES {table_name}")
+                time.sleep(1)
+                node1.query(f"SYSTEM START MOVES {table_name}")
+                time.sleep(1)
+
 
         def optimize_table(num):
             for i in range(num):
                 try:  # optimize may throw after concurrent alter
                     node1.query(
-                        "OPTIMIZE TABLE {} FINAL".format(name),
+                        "OPTIMIZE TABLE {} FINAL".format(table_name),
                         settings={"optimize_throw_if_noop": "1"},
                     )
                     break
@@ -1523,419 +1539,18 @@ def test_concurrent_alter_with_ttl_move(started_cluster, name, engine):
             tasks.append(p.apply_async(alter_update, (30,)))
             tasks.append(p.apply_async(alter_modify_ttl, (30,)))
             tasks.append(p.apply_async(optimize_table, (30,)))
+            tasks.append(p.apply_async(stop_and_resume_moves, (10, )))
 
         for task in tasks:
             task.get(timeout=120)
 
         assert node1.query("SELECT 1") == "1\n"
-        assert node1.query("SELECT COUNT() FROM {}".format(name)) == "150\n"
+        assert node1.query("SELECT COUNT() FROM {}".format(table_name)) == "150\n"
     finally:
-        node1.query("DROP TABLE IF EXISTS {name} SYNC".format(name=name))
+        node1.query("DROP TABLE IF EXISTS {name} SYNC".format(name=table_name))
 
 
-@pytest.mark.parametrize(
-    "name,engine,positive",
-    [
-        pytest.param("mt_test_alter_with_merge_do_not_work", "MergeTree()", 0, id="mt"),
-        pytest.param(
-            "replicated_mt_test_alter_with_merge_do_not_work",
-            "ReplicatedMergeTree('/clickhouse/replicated_test_alter_with_merge_do_not_work', '1')",
-            0,
-            id="replicated",
-        ),
-        pytest.param("mt_test_alter_with_merge_work", "MergeTree()", 1, id="mt_work"),
-        pytest.param(
-            "replicated_mt_test_alter_with_merge_work",
-            "ReplicatedMergeTree('/clickhouse/replicated_test_alter_with_merge_work', '1')",
-            1,
-            id="replicated_work",
-        ),
-    ],
-)
-def test_alter_with_merge_work(started_cluster, name, engine, positive):
-    name = unique_table_name(name)
-
-    """Check that TTL expressions are re-evaluated for
-    existing parts after ALTER command changes TTL expressions
-    and parts are merged.
-    """
-    try:
-        node1.query(
-            """
-            CREATE TABLE {name} (
-                s1 String,
-                d1 DateTime
-            ) ENGINE = {engine}
-            ORDER BY tuple()
-            TTL d1 + INTERVAL 3000 SECOND TO DISK 'jbod2',
-                d1 + INTERVAL 6000 SECOND TO VOLUME 'external'
-            SETTINGS storage_policy='jbods_with_external', merge_with_ttl_timeout=0
-        """.format(
-                name=name, engine=engine
-            )
-        )
-
-        def optimize_table(num):
-            for i in range(num):
-                try:  # optimize may throw after concurrent alter
-                    node1.query(
-                        "OPTIMIZE TABLE {} FINAL".format(name),
-                        settings={"optimize_throw_if_noop": "1"},
-                    )
-                    break
-                except:
-                    pass
-
-        for p in range(3):
-            data = []  # 6MB in total
-            now = time.time()
-            for i in range(2):
-                d1 = now - 1 if positive else now + 300
-                data.append(
-                    "(randomPrintableASCII(1024*1024), toDateTime({}))".format(d1)
-                )
-            values = ",".join(data)
-            node1.query(
-                "INSERT INTO {name} (s1, d1) VALUES {values}".format(
-                    name=name, values=values
-                )
-            )
-
-        used_disks = get_used_disks_for_table(node1, name)
-        assert set(used_disks) == {"jbod1", "jbod2"}
-
-        node1.query("SELECT count() FROM {name}".format(name=name)).splitlines() == [
-            "6"
-        ]
-
-        node1.query(
-            """
-            ALTER TABLE {name} MODIFY
-            TTL d1 + INTERVAL 0 SECOND TO DISK 'jbod2',
-                d1 + INTERVAL 5 SECOND TO VOLUME 'external',
-                d1 + INTERVAL 30 SECOND DELETE
-        """.format(
-                name=name
-            )
-        )
-
-        optimize_table(20)
-
-        assert (
-            node1.query(
-                "SELECT count() FROM system.parts WHERE table = '{name}' AND active = 1".format(
-                    name=name
-                )
-            )
-            == "1\n"
-        )
-
-        time.sleep(5)
-
-        optimize_table(20)
-
-        if positive:
-            assert check_used_disks_with_retry(
-                node1, name, set(["external"])
-            ), "Parts: " + node1.query(
-                f"SELECT disk_name, name FROM system.parts WHERE table = '{name}' AND active = 1"
-            )
-        else:
-            assert check_used_disks_with_retry(
-                node1, name, set(["jbod1", "jbod2"])
-            ), "Parts: " + node1.query(
-                f"SELECT disk_name, name FROM system.parts WHERE table = '{name}' AND active = 1"
-            )
-
-        time.sleep(25)
-
-        optimize_table(20)
-
-        if positive:
-            assert node1.query("SELECT count() FROM {name}".format(name=name)) == "0\n"
-        else:
-            assert node1.query("SELECT count() FROM {name}".format(name=name)) == "6\n"
-
-    finally:
-        node1.query("DROP TABLE IF EXISTS {name} SYNC".format(name=name))
-
-
-@pytest.mark.parametrize(
-    "name,dest_type,engine",
-    [
-        pytest.param(
-            "mt_test_disabled_ttl_move_on_insert_work", "DISK", "MergeTree()", id="disk"
-        ),
-        pytest.param(
-            "mt_test_disabled_ttl_move_on_insert_work",
-            "VOLUME",
-            "MergeTree()",
-            id="volume",
-        ),
-        pytest.param(
-            "replicated_mt_test_disabled_ttl_move_on_insert_work",
-            "DISK",
-            "ReplicatedMergeTree('/clickhouse/replicated_test_disabled_ttl_move_on_insert_work', '1')",
-            id="replicated_disk",
-        ),
-        pytest.param(
-            "replicated_mt_test_disabled_ttl_move_on_insert_work",
-            "VOLUME",
-            "ReplicatedMergeTree('/clickhouse/replicated_test_disabled_ttl_move_on_insert_work', '1')",
-            id="replicated_volume",
-        ),
-    ],
-)
-def test_disabled_ttl_move_on_insert(started_cluster, name, dest_type, engine):
-    name = unique_table_name(name)
-
-    try:
-        node1.query(
-            """
-            CREATE TABLE {name} (
-                s1 String,
-                d1 DateTime
-            ) ENGINE = {engine}
-            ORDER BY tuple()
-            TTL d1 TO {dest_type} 'external'
-            SETTINGS storage_policy='jbod_without_instant_ttl_move'
-        """.format(
-                name=name, dest_type=dest_type, engine=engine
-            )
-        )
-
-        node1.query("SYSTEM STOP MOVES {}".format(name))
-
-        data = []  # 10MB in total
-        for i in range(10):
-            data.append(
-                (
-                    "randomPrintableASCII(1024*1024)",
-                    "toDateTime({})".format(time.time() - 1),
-                )
-            )
-
-        node1.query(
-            "INSERT INTO {} (s1, d1) VALUES {}".format(
-                name, ",".join(["(" + ",".join(x) + ")" for x in data])
-            )
-        )
-
-        used_disks = get_used_disks_for_table(node1, name)
-        assert set(used_disks) == {"jbod1"}
-        assert (
-            node1.query("SELECT count() FROM {name}".format(name=name)).strip() == "10"
-        )
-
-        node1.query("SYSTEM START MOVES {}".format(name))
-        time.sleep(3)
-
-        used_disks = get_used_disks_for_table(node1, name)
-        assert set(used_disks) == {"external"}
-        assert (
-            node1.query("SELECT count() FROM {name}".format(name=name)).strip() == "10"
-        )
-
-    finally:
-        try:
-            node1.query("DROP TABLE IF EXISTS {} SYNC".format(name))
-        except:
-            pass
-
-
-@pytest.mark.parametrize(
-    "name,dest_type",
-    [
-        pytest.param("replicated_mt_move_if_exists", "DISK", id="replicated_disk"),
-        pytest.param("replicated_mt_move_if_exists", "VOLUME", id="replicated_volume"),
-    ],
-)
-def test_ttl_move_if_exists(started_cluster, name, dest_type):
-    name = unique_table_name(name)
-
-    try:
-        query_template = """
-            CREATE TABLE {name} (
-                s1 String,
-                d1 DateTime
-            ) ENGINE = ReplicatedMergeTree('/clickhouse/replicated_mt_move_if_exists', '{node_name}')
-            ORDER BY tuple()
-            TTL d1 TO {dest_type} {if_exists} 'external'
-            SETTINGS storage_policy='{policy}'
-        """
-
-        with pytest.raises(QueryRuntimeException):
-            node1.query(
-                query_template.format(
-                    name=name,
-                    node_name=node1.name,
-                    dest_type=dest_type,
-                    if_exists="",
-                    policy="only_jbod_1",
-                )
-            )
-
-        for node, policy in zip(
-            [node1, node2], ["only_jbod_1", "small_jbod_with_external"]
-        ):
-            node.query(
-                query_template.format(
-                    name=name,
-                    node_name=node.name,
-                    dest_type=dest_type,
-                    if_exists="IF EXISTS",
-                    policy=policy,
-                )
-            )
-
-        data = []  # 10MB in total
-        for i in range(10):
-            data.append(
-                (
-                    "randomPrintableASCII(1024*1024)",
-                    "toDateTime({})".format(time.time() - 1),
-                )
-            )
-
-        node1.query(
-            "INSERT INTO {} (s1, d1) VALUES {}".format(
-                name, ",".join(["(" + ",".join(x) + ")" for x in data])
-            )
-        )
-        node2.query("SYSTEM SYNC REPLICA {}".format(name))
-
-        time.sleep(5)
-
-        used_disks1 = get_used_disks_for_table(node1, name)
-        assert set(used_disks1) == {"jbod1"}
-
-        used_disks2 = get_used_disks_for_table(node2, name)
-        assert set(used_disks2) == {"external"}
-
-        assert (
-            node1.query("SELECT count() FROM {name}".format(name=name)).strip() == "10"
-        )
-        assert (
-            node2.query("SELECT count() FROM {name}".format(name=name)).strip() == "10"
-        )
-
-    finally:
-        try:
-            node1.query("DROP TABLE IF EXISTS {} SYNC".format(name))
-            node2.query("DROP TABLE IF EXISTS {} SYNC".format(name))
-        except:
-            pass
-
-
-class TestCancelBackgroundMoving:
-    @pytest.fixture()
-    def prepare_table(self, request, started_cluster):
-        name = unique_table_name(request.node.name)
-        engine = f"ReplicatedMergeTree('/clickhouse/{name}', '1')"
-
-        node1.query(
-            f"""
-            CREATE TABLE {name} (
-                s1 String,
-                d1 DateTime
-            ) ENGINE = {engine}
-            ORDER BY tuple()
-            TTL d1 + interval 5 second TO DISK 'external'
-            SETTINGS storage_policy='small_jbod_with_external'
-            """
-        )
-
-        node1.query("SYSTEM STOP MOVES")
-
-        # Insert part which is about to move
-        node1.query(
-            "INSERT INTO {} (s1, d1) VALUES (randomPrintableASCII({}), toDateTime({}))".format(
-                name, 10 * 1024 * 1024, time.time()
-            )
-        )
-
-        # Set low bandwidth to have enough time to cancel part moving
-        config = inspect.cleandoc(
-            f"""
-            <clickhouse>
-                <max_local_write_bandwidth_for_server>{256 * 1024}</max_local_write_bandwidth_for_server>
-            </clickhouse>
-            """
-        )
-        node1.replace_config(
-            "/etc/clickhouse-server/config.d/disk_throttling.xml", config
-        )
-        node1.restart_clickhouse()
-
-        try:
-            yield name
-        finally:
-            node1.query(f"DROP TABLE IF EXISTS {name} SYNC")
-
-    def test_cancel_background_moving_on_stop_moves_query(self, prepare_table):
-        name = prepare_table
-
-        # Wait for background moving task to be started
-        node1.query("SYSTEM START MOVES")
-        assert_eq_with_retry(
-            node1,
-            f"SELECT count() FROM system.moves WHERE table = '{name}'".strip(),
-            "1",
-        )
-
-        # Wait for background moving task to be cancelled
-        node1.query("SYSTEM STOP MOVES")
-        assert_logs_contain_with_retry(
-            node1, "MergeTreeBackgroundExecutor.*Cancelled moving parts"
-        )
-        assert_eq_with_retry(
-            node1,
-            f"SELECT count() FROM system.moves WHERE table = '{name}'".strip(),
-            "0",
-        )
-
-        # Ensure that part was not moved
-        assert set(get_used_disks_for_table(node1, name)) == {"jbod1"}
-
-    def test_cancel_background_moving_on_table_detach(self, prepare_table):
-        name = prepare_table
-
-        # Wait for background moving task to be started
-        node1.query("SYSTEM START MOVES")
-        assert_eq_with_retry(
-            node1,
-            f"SELECT count() FROM system.moves WHERE table = '{name}'".strip(),
-            "1",
-        )
-
-        # Wait for background moving task to be cancelled
-        node1.query(f"DETACH Table {name}")
-        assert_logs_contain_with_retry(
-            node1, "MergeTreeBackgroundExecutor.*Cancelled moving parts"
-        )
-        assert_eq_with_retry(
-            node1,
-            f"SELECT count() FROM system.moves WHERE table = '{name}'".strip(),
-            "0",
-        )
-
-    def test_cancel_background_moving_on_zookeeper_disconnect(self, prepare_table):
-        name = prepare_table
-
-        # Wait for background moving task to be started
-        node1.query("SYSTEM START MOVES")
-        assert_eq_with_retry(
-            node1,
-            f"SELECT count() FROM system.moves WHERE table = '{name}'".strip(),
-            "1",
-        )
-
-        with PartitionManager() as pm:
-            pm.drop_instance_zk_connections(node1)
-            # Wait for background moving task to be cancelled
-            assert_logs_contain_with_retry(
-                node1,
-                "MergeTreeBackgroundExecutor.*Cancelled moving parts",
-                retry_count=30,
-                sleep_time=1,
-            )
+# TODO: there was a test here, called TestCancelBackgroundMoving, which used to test whether STOP MOVES actually cancels the background operation.
+#       It was the flakiest amongst them all - the method of slowing down moves via throughput trottling coulnd't guarantee that we'd catch the move when trying to cancel it
+#       Removed the test as not having a more stable alternative (should explore using FailPoints for that)
+#       To minimally compensate coverage of pausing - added STOP/START to 'test_concurrent_alter_with_ttl_move' (concurrent randomized churner test)

--- a/tests/integration/test_ttl_move/test.py
+++ b/tests/integration/test_ttl_move/test.py
@@ -1266,7 +1266,7 @@ def test_merges_with_full_disk(started_cluster, engine, request):
 
     try:
         # This test checks that MERGE falls back to the available disk, if the target disk is full
-        # NOTE: MERGE operation is sensitive to not-having enough free space at 'jbod1' - it data sizes are imbalanced (or 'jbod1' is more full than expected), this test might flap by haning in OPTIMIZE
+        # NOTE: MERGE operation is sensitive to not-having enough free space at 'jbod1' - its data sizes are imbalanced (or 'jbod1' is more full than expected), this test might flap by hanging in OPTIMIZE
 
         # TEMP table to fill up the disk
         node1.query(f"""


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog

Closes #85011
Closes #93340

Motivation:
It was flaky due to several reasons:
1. timing issues on trivial logic check, e.g.: we do something to trigger a move, then we sleep for move to kick in, then we wait for it to finish and attempting to assert the result. The problem here was that the move could've finished before we entered waiting, or it could've started after we entered waiting - both cases would lead to false negative.
2. timing issues on complex multi state checks, e.g.: we set a tired policy, and the data is supposed to move to diskX after START+X1 seconds, and then to DISKY after START+X1+Y1 seconds. The reality (especially under pressure as a part of 'targeted', or 'parallel' jobs), the test or the server could've remained paused in between [START, START+X1], and then the test diverges with the server, what leads to a false negative.
3. TestCancelBackgroundMoving was prone to timing issues - move happens too fast (even with the throttling) before we get to the checking, and the test flaps. 

Modifications:
- [fixes (1)] Modified checking to not only wait for the move to finish, but also to assert whether the expected target state has been achieved. This covers for the variety of timing issues after the move has been triggered and before we entered the check.
- [fixes (2)] Eliminated multi-state situations in the tests - now an action is performed, leading to either an expected successful state, or either unexpected failed one. When a sequence of actions/states is to be checked, then the execution is controled manually via STOP/START MOVES to eliminate possibility of skipping stages.
- [addresses (3)] removed the case TestCancelBackgroundMoving entirely, as couldn't find a deterministic way to perform such check under pressure and timing issues. Left a TODO that we might want to re-implement it using FailPoints
- prettified test parametrization to compact and dedup things
- merged logical scenarios together (there were several different cases checking for similar scenarios)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.533`
<!-- ch-version-info:end -->