### PR TITLE
Fix possible deadlock in case of exception during disks initialization

### DIFF
--- a/src/Disks/DiskBackup.cpp
+++ b/src/Disks/DiskBackup.cpp
@@ -264,10 +264,6 @@ DataSourceDescription DiskBackup::getDataSourceDescription() const
     return description;
 }
 
-void DiskBackup::shutdown()
-{
-}
-
 String DiskBackup::replacePathPrefix(const String & path) const
 {
     if (path.starts_with(path_prefix_replacement.from))

--- a/src/Disks/DiskBackup.h
+++ b/src/Disks/DiskBackup.h
@@ -122,8 +122,6 @@ public:
 
     bool isReadOnly() const override { return true; }
 
-    void shutdown() override;
-
 private:
     const std::shared_ptr<IBackup> backup;
     const PathPrefixReplacement path_prefix_replacement;

--- a/src/Disks/DiskSelector.cpp
+++ b/src/Disks/DiskSelector.cpp
@@ -65,6 +65,7 @@ void DiskSelector::recordDisk(const std::string & disk_name, DiskPtr disk)
 
 void DiskSelector::initialize(
     const Poco::Util::AbstractConfiguration & config, const String & config_prefix, ContextPtr context, DiskValidator disk_validator)
+try
 {
     Poco::Util::AbstractConfiguration::Keys keys;
     config.keys(config_prefix, keys);
@@ -106,6 +107,12 @@ void DiskSelector::initialize(
         recordDisk(LOCAL_DISK_NAME, std::make_shared<DiskLocal>(LOCAL_DISK_NAME, "/", 0, context, config, config_prefix));
     }
     is_initialized = true;
+}
+catch (...)
+{
+    for (const auto & [name, disk] : disks)
+        disk->shutdown();
+    throw;
 }
 
 DiskSelectorPtr DiskSelector::updateFromConfig(


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix possible deadlock in case of exception during disks initialization

In case of `DiskSelector::initalize()` will throw, the `shutdown()` will
not be called on each disk, and this will lead to possible deadlock [1]
in case of `local_disk_check_period_ms > 0`.

  [1]: https://pastila.nl/?00620377/1d01d6bd2c9ab94267be3e03542b8496#EjAmYc7LfcQDTePv7Knncg==GCM

This is possible in case of i.e. you create a cached disk over a regular
one, regular is created, while cached is failed, with i.e.:

    Cannot wrap disk `s3_plain_rewritable` with cache layer `s3_plain_rewritable_cache`: there is no such disk (it should be initialized before cache disk).

_Note: marked as `Not for changelog` since the problem is possible only due to misconfiguration_


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.800`
<!-- ch-version-info:end -->