### PR TITLE
Trigger Alias's target MVs by refactoring the write logic using the full INSERT pipeline

### DIFF
--- a/src/Storages/StorageAlias.cpp
+++ b/src/Storages/StorageAlias.cpp
@@ -4,15 +4,16 @@
 #include <Interpreters/DatabaseCatalog.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/evaluateConstantExpression.h>
+#include <Interpreters/InterpreterInsertQuery.h>
 #include <Parsers/ASTCreateQuery.h>
-#include <Parsers/ASTIdentifier.h>
-#include <Parsers/ASTLiteral.h>
+#include <Parsers/ASTInsertQuery.h>
 #include <QueryPipeline/Pipe.h>
+#include <QueryPipeline/BlockIO.h>
 #include <Processors/QueryPlan/QueryPlan.h>
 #include <Processors/Sinks/SinkToStorage.h>
+#include <Processors/Executors/PushingPipelineExecutor.h>
 #include <Core/Settings.h>
 #include <Access/Common/AccessFlags.h>
-#include <Interpreters/InterpreterSelectQuery.h>
 
 
 namespace DB
@@ -64,6 +65,59 @@ StoragePtr StorageAlias::getTargetTable(std::optional<TargetAccess> access_check
     return DatabaseCatalog::instance().getTable(StorageID(target_database, target_table), getContext());
 }
 
+/// AliasSink: Writes data to the target table using full INSERT pipeline
+/// which triggers materialized views on the target table.
+class AliasSink : public SinkToStorage, WithContext
+{
+public:
+    AliasSink(
+        StorageAlias & storage_,
+        ContextPtr context_,
+        const StorageMetadataPtr & metadata_snapshot_)
+        : SinkToStorage(std::make_shared<const Block>(metadata_snapshot_->getSampleBlock()))
+        , WithContext(context_)
+        , storage(storage_)
+    {
+    }
+
+    String getName() const override { return "AliasSink"; }
+
+    void consume(Chunk & chunk) override
+    {
+        if (chunk.getNumRows() == 0)
+            return;
+
+        auto block = getHeader().cloneWithColumns(chunk.getColumns());
+
+        StoragePtr target = storage.getTargetTable();
+        StorageID target_id = target->getStorageID();
+
+        std::unique_ptr<ASTInsertQuery> insert = std::make_unique<ASTInsertQuery>();
+        insert->table_id = target_id;
+        ASTPtr query_ptr(insert.release());
+
+        auto insert_context = Context::createCopy(getContext());
+        insert_context->makeQueryContext();
+
+        InterpreterInsertQuery interpreter(
+            query_ptr,
+            insert_context,
+            /* allow_materialized */ false,
+            /* no_squash */ false,
+            /* no_destination */ false,
+            /* async_insert */ false);
+
+        BlockIO block_io = interpreter.execute();
+        PushingPipelineExecutor executor(block_io.pipeline);
+        executor.start();
+        executor.push(std::move(block));
+        executor.finish();
+    }
+
+private:
+    StorageAlias & storage;
+};
+
 void StorageAlias::read(
     QueryPlan & query_plan,
     const Names & column_names,
@@ -97,21 +151,17 @@ void StorageAlias::read(
 }
 
 SinkToStoragePtr StorageAlias::write(
-    const ASTPtr & query,
+    const ASTPtr & /*query*/,
     const StorageMetadataPtr & /*metadata_snapshot*/,
     ContextPtr local_context,
-    bool async_insert)
+    bool /*async_insert*/)
 {
     auto target_storage = getTargetTable(TargetAccess{local_context, AccessType::INSERT});
-    auto lock = target_storage->lockForShare(
-        local_context->getCurrentQueryId(),
-        local_context->getSettingsRef()[Setting::lock_acquire_timeout]);
-
     auto target_metadata = target_storage->getInMemoryMetadataPtr();
-    auto sink = target_storage->write(query, target_metadata, local_context, async_insert);
 
-    sink->addTableLock(lock);
-    return sink;
+    /// Use AliasSink which executes full INSERT pipeline on target
+    /// Therefore it will trigger the MV on the target
+    return std::make_shared<AliasSink>(*this, local_context, target_metadata);
 }
 
 void StorageAlias::alter(

--- a/tests/queries/0_stateless/03636_storage_alias_basic.reference
+++ b/tests/queries/0_stateless/03636_storage_alias_basic.reference
@@ -324,3 +324,44 @@ FROM system.tables
 WHERE database = currentDatabase() AND name = 'alias_with_missing_target';
 alias_with_missing_target	Alias	\N	\N	[]
 DROP TABLE alias_with_missing_target;
+-- Test: Materialized views on both Alias and target table
+DROP TABLE IF EXISTS mv_test_from_alias;
+DROP TABLE IF EXISTS mv_test_from_target;
+DROP TABLE IF EXISTS mv_test_alias_dest;
+DROP TABLE IF EXISTS mv_test_target_dest;
+DROP TABLE IF EXISTS mv_test_alias;
+DROP TABLE IF EXISTS mv_test_source;
+-- Create source table and alias
+CREATE TABLE mv_test_source (id UInt32, value String) ENGINE = MergeTree ORDER BY id;
+CREATE TABLE mv_test_alias ENGINE = Alias('mv_test_source');
+-- Create destination tables for MVs
+CREATE TABLE mv_test_alias_dest (id UInt32, value String) ENGINE = MergeTree ORDER BY id;
+CREATE TABLE mv_test_target_dest (id UInt32, value String) ENGINE = MergeTree ORDER BY id;
+-- Create MV on Alias table
+CREATE MATERIALIZED VIEW mv_test_from_alias TO mv_test_alias_dest AS SELECT id, value FROM mv_test_alias;
+-- Create MV on target table (mv_test_source)
+CREATE MATERIALIZED VIEW mv_test_from_target TO mv_test_target_dest AS SELECT id, value FROM mv_test_source;
+-- Test: Insert into mv_test_alias should trigger BOTH MVs
+INSERT INTO mv_test_alias VALUES (1, 'a'), (2, 'b');
+SELECT * FROM mv_test_alias_dest ORDER BY id;
+1	a
+2	b
+SELECT * FROM mv_test_target_dest ORDER BY id;
+1	a
+2	b
+-- Test: Insert into mv_test_source should trigger only target MV
+INSERT INTO mv_test_source VALUES (3, 'c'), (4, 'd');
+SELECT * FROM mv_test_alias_dest ORDER BY id;
+1	a
+2	b
+SELECT * FROM mv_test_target_dest ORDER BY id;
+1	a
+2	b
+3	c
+4	d
+DROP TABLE mv_test_from_alias;
+DROP TABLE mv_test_from_target;
+DROP TABLE mv_test_alias_dest;
+DROP TABLE mv_test_target_dest;
+DROP TABLE mv_test_alias;
+DROP TABLE mv_test_source;


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Refactor the write using full INSERT pipeline, which triggers materialized views on the target table.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.57`
<!-- ch-version-info:end -->