### PR TITLE
Fix crash in clearDirectory on concurrent removal of delete_tmp_ directory

### DIFF
--- a/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
+++ b/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
@@ -727,6 +727,15 @@ void DataPartStorageOnDiskBase::remove(
                 disk->removeSharedRecursive(
                     fs::path(to) / "", !can_remove_description->can_remove_anything, can_remove_description->files_not_to_remove);
             }
+            catch (const fs::filesystem_error & e)
+            {
+                if (e.code() == std::errc::no_such_file_or_directory)
+                {
+                    /// If the directory was already removed (e.g. by clearOldTemporaryDirectories), nothing to do.
+                }
+                else
+                    throw;
+            }
             catch (...)
             {
                 LOG_ERROR(
@@ -860,7 +869,19 @@ void DataPartStorageOnDiskBase::clearDirectory(
     if (checksums.empty() || incomplete_temporary_part)
     {
         /// If the part is not completely written, we cannot use fast path by listing files.
-        disk->removeSharedRecursive(fs::path(dir) / "", !can_remove_shared_data, names_not_to_remove);
+        try
+        {
+            disk->removeSharedRecursive(fs::path(dir) / "", !can_remove_shared_data, names_not_to_remove);
+        }
+        catch (const fs::filesystem_error & e)
+        {
+            if (e.code() == std::errc::no_such_file_or_directory)
+            {
+                /// If the directory was already removed (e.g. by clearOldTemporaryDirectories), nothing to do.
+            }
+            else
+                throw;
+        }
         return;
     }
 


### PR DESCRIPTION
During `ReplicatedMergeTree` startup, `clearOldTemporaryDirectories` (called from `AttachThread` with `delete_tmp_` prefix, added in #37906) can concurrently delete a directory that `loadOutdatedDataParts` is also removing via `clearDirectory`. The fallback `fs::remove_all` throws `filesystem_error` when files disappear mid-traversal, propagating to `std::terminate`.

Applied the same `catch (const fs::filesystem_error & e)` pattern already used in `clearOldTemporaryDirectories` (`MergeTreeData.cpp:3130`).

Fixes #94891

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixes a crash during `ReplicatedMergeTree` startup caused by concurrent removal of `delete_tmp_*` directories.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.131`
- Backported to: `26.1.2.8`, `25.12.5.39`, `25.11.9.9`, `25.8.16.30`, `25.3.15.20`
<!-- ch-version-info:end -->