### PR TITLE
Add belonging file check before apply position delete using IcebergBi…

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/PositionDeleteTransform.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/PositionDeleteTransform.cpp
@@ -157,8 +157,16 @@ void IcebergBitmapPositionDeleteTransform::initialize()
 
             for (size_t i = 0; i < delete_chunk.getNumRows(); ++i)
             {
-                auto position_to_delete = position_column->get64(i);
-                bitmap.add(position_to_delete);
+                // Add filename matching check
+                auto filename_in_delete_record = filename_column->getDataAt(i);
+                auto current_data_file_path = iceberg_object_info->info.data_object_file_path_key;
+
+                // Only add to delete bitmap when the filename in delete record matches current data file path
+                if (filename_in_delete_record == current_data_file_path)
+                {
+                    auto position_to_delete = position_column->get64(i);
+                    bitmap.add(position_to_delete);
+                }
             }
         }
     }

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/PositionDeleteTransform.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/PositionDeleteTransform.cpp
@@ -162,7 +162,7 @@ void IcebergBitmapPositionDeleteTransform::initialize()
                 auto current_data_file_path = iceberg_object_info->info.data_object_file_path_key;
 
                 // Only add to delete bitmap when the filename in delete record matches current data file path
-                if (filename_in_delete_record == current_data_file_path)
+                if (filename_in_delete_record == current_data_file_path || filename_in_delete_record == "/" + current_data_file_path)
                 {
                     auto position_to_delete = position_column->get64(i);
                     bitmap.add(position_to_delete);


### PR DESCRIPTION
…tmapPositionDeleteTransform

one delete file may contains multi different data file's delete info(most time is one by one).
here, need add check if the delete record is belong to this data file.

```
nucolumnarservice-lvs-lakequery-6d47bc588-mbhbb :) select * from hdfs ('hdfs://hubble-lvs/workspaces/P_yangzhong_T/position_delete_base_table/data/00000-126281481-d9f9f3d4-9797-43f1-8683-1f375995908a-00001-deletes.parquet') ;
:-]
:-]

SELECT *
FROM hdfs('hdfs://xxxx/workspaces/xxx/position_delete_base_table/data/00000-126281481-d9f9f3d4-9797-43f1-8683-1f375995908a-00001-deletes.parquet')

Query id: 810a10fa-dbb3-43c7-ba15-751cd14b1de4

   ┌─file_path───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┬─pos─┐
1. │ hdfs://xxxx/workspaces/xxx/position_delete_base_table/data/00017-126235887-6d9c55c6-75ec-49bb-bdbf-0cbc7e93268a-0-00001.parquet │   0 │
2. │ hdfs://xxxx/workspaces/xxx/position_delete_base_table/data/00019-126235889-6d9c55c6-75ec-49bb-bdbf-0cbc7e93268a-0-00001.parquet │   0 │
3. │ hdfs://xxxx/workspaces/xxx/position_delete_base_table/data/00022-126235892-6d9c55c6-75ec-49bb-bdbf-0cbc7e93268a-0-00001.parquet │   0 │
4. │ hdfs://xxxx/workspaces/xxx/position_delete_base_table/data/00025-126235895-6d9c55c6-75ec-49bb-bdbf-0cbc7e93268a-0-00001.parquet │   0 │
5. │ hdfs://xxxx/workspaces/xxx/position_delete_base_table/data/00028-126235898-6d9c55c6-75ec-49bb-bdbf-0cbc7e93268a-0-00001.parquet │   0 │
   └─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┴─────┘

5 rows in set. Elapsed: 0.314 sec.
```

### Changelog category (leave one):
- Improvement 

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add belonging file check before apply position delete using IcebergBitmapPositionDeleteTransform

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.817`
<!-- ch-version-info:end -->