### PR TITLE
Disable runtime filters to allow PK sharding to kick in

### DIFF
--- a/tests/queries/0_stateless/03357_join_pk_sharding.sql
+++ b/tests/queries/0_stateless/03357_join_pk_sharding.sql
@@ -20,6 +20,7 @@ set enable_analyzer=1;
 set query_plan_join_swap_table=0;
 set query_plan_join_shard_by_pk_ranges=1;
 set allow_experimental_parallel_reading_from_replicas=0;
+set enable_join_runtime_filters=0;
 set max_threads=4;
 
 -- { echo On }


### PR DESCRIPTION
Currently  PK sharding optimization is applied at late stages of optimization after runtime filters were possibly added. And if they we added then PK sharding cannot be applied.  

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.785`
<!-- ch-version-info:end -->