### PR TITLE
Insert to Iceberg preserves chunk infos 

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
@@ -718,8 +718,6 @@ void IcebergStorageSink::consume(Chunk & chunk)
         return;
     total_rows += chunk.getNumRows();
 
-    LOG_DEBUG(&Poco::Logger::get("IcebergStorageSink"), "Consuming chunk with chunk infos begin: {} ", chunk.getChunkInfos().debug());
-
     size_t start_columns_size = chunk.getNumColumns();
     if (!sort_description.column_names.empty())
     {
@@ -812,7 +810,6 @@ void IcebergStorageSink::consume(Chunk & chunk)
     auto new_chunk = Chunk(columns, chunk.getNumRows());
     new_chunk.setChunkInfos(chunk.getChunkInfos());
     chunk = std::move(new_chunk);
-    LOG_DEBUG(&Poco::Logger::get("IcebergStorageSink"), "Consuming chunk with chunk infos end: {} ", chunk.getChunkInfos().debug());
 }
 
 void IcebergStorageSink::onFinish()

--- a/tests/queries/0_stateless/03800_mv_from_iceberg.sh
+++ b/tests/queries/0_stateless/03800_mv_from_iceberg.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest, no-parallel-replicas
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS t0, t1, v0"
+$CLICKHOUSE_CLIENT -q "CREATE TABLE t0 (c0 Int) ENGINE = MergeTree() ORDER BY tuple()"
+$CLICKHOUSE_CLIENT -q "CREATE TABLE IF NOT EXISTS t1 (c0 Int) ENGINE = IcebergS3(s3_conn, filename = '03800_mv_from_iceberg/t1_${CLICKHOUSE_TEST_UNIQUE_NAME}')"
+$CLICKHOUSE_CLIENT -q "CREATE MATERIALIZED VIEW v0 TO t0 AS (SELECT c0 FROM t1)"
+$CLICKHOUSE_CLIENT -q "INSERT INTO TABLE t1 (c0) SETTINGS allow_experimental_insert_into_iceberg = 1 VALUES (1)"

--- a/tests/queries/0_stateless/03800_mv_from_iceberg.sql
+++ b/tests/queries/0_stateless/03800_mv_from_iceberg.sql
@@ -1,7 +1,0 @@
--- Tags: no-fasttest, no-parallel-replicas
-
-DROP TABLE IF EXISTS t0, t1, v0;
-CREATE TABLE t0 (c0 Int) ENGINE = MergeTree() ORDER BY tuple();
-CREATE TABLE IF NOT EXISTS t1 (c0 Int) ENGINE = IcebergS3(s3_conn, filename = '03800_mv_from_iceberg/t1');
-CREATE MATERIALIZED VIEW v0 TO t0 AS (SELECT c0 FROM t1);
-INSERT INTO TABLE t1 (c0) SETTINGS allow_experimental_insert_into_iceberg = 1 VALUES (1);

--- a/tests/queries/0_stateless/03800_mv_from_iceberg.sql
+++ b/tests/queries/0_stateless/03800_mv_from_iceberg.sql
@@ -1,5 +1,7 @@
+-- Tags: no-fasttest, no-parallel-replicas
+
 DROP TABLE IF EXISTS t0, t1, v0;
 CREATE TABLE t0 (c0 Int) ENGINE = MergeTree() ORDER BY tuple();
-CREATE TABLE t1 (c0 Int) ENGINE = IcebergLocal('./user_files/lakehouse/t1/');
+CREATE TABLE t1 (c0 Int) ENGINE = IcebergS3(s3_conn, filename = '03800_mv_from_iceberg/t1');
 CREATE MATERIALIZED VIEW v0 TO t0 AS (SELECT c0 FROM t1);
 INSERT INTO TABLE t1 (c0) SETTINGS allow_experimental_insert_into_iceberg = 1 VALUES (1);

--- a/tests/queries/0_stateless/03800_mv_from_iceberg.sql
+++ b/tests/queries/0_stateless/03800_mv_from_iceberg.sql
@@ -1,0 +1,5 @@
+DROP TABLE IF EXISTS t0, t1, v0;
+CREATE TABLE t0 (c0 Int) ENGINE = MergeTree() ORDER BY tuple();
+CREATE TABLE t1 (c0 Int) ENGINE = IcebergLocal('./user_files/lakehouse/t1/');
+CREATE MATERIALIZED VIEW v0 TO t0 AS (SELECT c0 FROM t1);
+INSERT INTO TABLE t1 (c0) SETTINGS allow_experimental_insert_into_iceberg = 1 VALUES (1);

--- a/tests/queries/0_stateless/03800_mv_from_iceberg.sql
+++ b/tests/queries/0_stateless/03800_mv_from_iceberg.sql
@@ -2,6 +2,6 @@
 
 DROP TABLE IF EXISTS t0, t1, v0;
 CREATE TABLE t0 (c0 Int) ENGINE = MergeTree() ORDER BY tuple();
-CREATE TABLE t1 (c0 Int) ENGINE = IcebergS3(s3_conn, filename = '03800_mv_from_iceberg/t1');
+CREATE TABLE IF NOT EXISTS t1 (c0 Int) ENGINE = IcebergS3(s3_conn, filename = '03800_mv_from_iceberg/t1');
 CREATE MATERIALIZED VIEW v0 TO t0 AS (SELECT c0 FROM t1);
 INSERT INTO TABLE t1 (c0) SETTINGS allow_experimental_insert_into_iceberg = 1 VALUES (1);


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Preserve chunk infos of a chunk after interaction with Iceberg sink

Closes https://github.com/ClickHouse/ClickHouse/issues/90966


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.27`
<!-- ch-version-info:end -->