### PR TITLE
Some optimizations to reduce IAST size in memory

### DIFF
--- a/src/Common/QueryFuzzer.cpp
+++ b/src/Common/QueryFuzzer.cpp
@@ -620,13 +620,13 @@ void QueryFuzzer::fuzzCreateQuery(ASTCreateQuery & create)
 
 void QueryFuzzer::fuzzColumnDeclaration(ASTColumnDeclaration & column)
 {
-    if (column.type)
+    if (auto type = column.getType())
     {
-        auto data_type = fuzzDataType(DataTypeFactory::instance().get(column.type));
+        auto data_type = fuzzDataType(DataTypeFactory::instance().get(type));
 
         ParserDataType parser;
-        column.type = parseQuery(
-            parser, data_type->getName(), DBMS_DEFAULT_MAX_QUERY_SIZE, DBMS_DEFAULT_MAX_PARSER_DEPTH, DBMS_DEFAULT_MAX_PARSER_BACKTRACKS);
+        column.setType(parseQuery(
+            parser, data_type->getName(), DBMS_DEFAULT_MAX_QUERY_SIZE, DBMS_DEFAULT_MAX_PARSER_DEPTH, DBMS_DEFAULT_MAX_PARSER_BACKTRACKS));
     }
 }
 

--- a/src/DataTypes/DataTypeFactory.cpp
+++ b/src/DataTypes/DataTypeFactory.cpp
@@ -131,7 +131,7 @@ DataTypePtr DataTypeFactory::getImpl(const ASTPtr & ast) const
 
     if (const auto * type = ast->as<ASTDataType>())
     {
-        return getImpl<nullptr_on_error>(type->name, type->arguments);
+        return getImpl<nullptr_on_error>(type->name, type->getArguments());
     }
 
     if (const auto * ident = ast->as<ASTIdentifier>())

--- a/src/Databases/DataLake/DatabaseDataLake.cpp
+++ b/src/Databases/DataLake/DatabaseDataLake.cpp
@@ -36,6 +36,7 @@
 
 #include <Formats/FormatFactory.h>
 
+#include <Parsers/ASTColumnDeclaration.h>
 #include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTFunction.h>
@@ -845,7 +846,7 @@ ASTPtr DatabaseDataLake::getCreateTableQueryImpl(
         LOG_DEBUG(log, "Processing column {}", column_type_and_name.name);
         const auto column_declaration = make_intrusive<ASTColumnDeclaration>();
         column_declaration->name = column_type_and_name.name;
-        column_declaration->type = makeASTDataType(column_type_and_name.type->getName());
+        column_declaration->setType(makeASTDataType(column_type_and_name.type->getName()));
         columns_expression_list->children.emplace_back(column_declaration);
     }
 

--- a/src/Databases/DatabasesCommon.cpp
+++ b/src/Databases/DatabasesCommon.cpp
@@ -88,7 +88,7 @@ void validateCreateQuery(const ASTCreateQuery & query, ContextPtr context)
         const auto & col_decl = ast->as<ASTColumnDeclaration &>();
         /// There might be some special columns for which `columns_desc.get` would throw, e.g. Nested column when flatten_nested is enabled.
         /// At the time of writing I am not aware of anything else, but my knowledge is limited and new types might be added, so let's be safe.
-        if (!col_decl.default_expression)
+        if (!col_decl.getDefaultExpression())
             continue;
 
         /// If no column description for the name, let's skip the validation of default expressions, but let's log the fact that something went wrong
@@ -278,12 +278,12 @@ ASTPtr getCreateQueryFromStorage(const StoragePtr & storage, const ASTPtr & ast_
                                         backQuote(table_id.database_name), backQuote(table_id.table_name));
                     return nullptr;
                 }
-                ast_column_declaration->type = ast_type;
+                ast_column_declaration->setType(std::move(ast_type));
 
                 if (auto column_default = metadata_ptr->columns.getDefault(column_name_and_type.name))
                 {
                     ast_column_declaration->default_specifier = toString(column_default->kind);
-                    ast_column_declaration->default_expression = column_default->expression;
+                    ast_column_declaration->setDefaultExpression(column_default->expression->clone());
                 }
             }
             ast_expression_list->children.emplace_back(ast_column_declaration);

--- a/src/Databases/DatabasesCommon.cpp
+++ b/src/Databases/DatabasesCommon.cpp
@@ -8,6 +8,7 @@
 #include <Interpreters/InterpreterCreateQuery.h>
 #include <Interpreters/TreeRewriter.h>
 #include <Parsers/ASTCreateQuery.h>
+#include <Parsers/ASTColumnDeclaration.h>
 #include <Parsers/ASTExpressionList.h>
 #include <Parsers/ASTSelectWithUnionQuery.h>
 #include <Parsers/ParserCreateQuery.h>
@@ -282,7 +283,7 @@ ASTPtr getCreateQueryFromStorage(const StoragePtr & storage, const ASTPtr & ast_
 
                 if (auto column_default = metadata_ptr->columns.getDefault(column_name_and_type.name))
                 {
-                    ast_column_declaration->default_specifier = toString(column_default->kind);
+                    ast_column_declaration->default_specifier = toColumnDefaultSpecifier(column_default->kind);
                     ast_column_declaration->setDefaultExpression(column_default->expression->clone());
                 }
             }

--- a/src/Databases/PostgreSQL/DatabasePostgreSQL.cpp
+++ b/src/Databases/PostgreSQL/DatabasePostgreSQL.cpp
@@ -12,6 +12,7 @@
 #include <Interpreters/Context.h>
 #include <Interpreters/DatabaseCatalog.h>
 #include <Interpreters/evaluateConstantExpression.h>
+#include <Parsers/ASTColumnDeclaration.h>
 #include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTDataType.h>
@@ -470,7 +471,7 @@ ASTPtr DatabasePostgreSQL::getCreateTableQueryImpl(const String & table_name, Co
     {
         const auto column_declaration = make_intrusive<ASTColumnDeclaration>();
         column_declaration->name = column_type_and_name.name;
-        column_declaration->type = getColumnDeclaration(column_type_and_name.type);
+        column_declaration->setType(getColumnDeclaration(column_type_and_name.type));
         columns_expression_list->children.emplace_back(column_declaration);
     }
 

--- a/src/Interpreters/FunctionNameNormalizer.cpp
+++ b/src/Interpreters/FunctionNameNormalizer.cpp
@@ -32,8 +32,8 @@ void FunctionNameNormalizer::visit(IAST * ast)
     // have the same name as function, e.g. Date.
     if (auto * node_decl = ast->as<ASTColumnDeclaration>())
     {
-        visit(node_decl->default_expression.get());
-        visit(node_decl->ttl.get());
+        visit(node_decl->getDefaultExpression().get());
+        visit(node_decl->getTTL().get());
         return;
     }
 

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -409,7 +409,7 @@ ASTPtr InterpreterCreateQuery::formatColumns(const NamesAndTypesList & columns)
         String type_name = column.type->getName();
         const char * pos = type_name.data();
         const char * end = pos + type_name.size();
-        column_declaration->type = parseQuery(type_parser, pos, end, "data type", 0, DBMS_DEFAULT_MAX_PARSER_DEPTH, DBMS_DEFAULT_MAX_PARSER_BACKTRACKS);
+        column_declaration->setType(parseQuery(type_parser, pos, end, "data type", 0, DBMS_DEFAULT_MAX_PARSER_DEPTH, DBMS_DEFAULT_MAX_PARSER_BACKTRACKS));
         columns_list->children.emplace_back(column_declaration);
     }
 
@@ -429,7 +429,7 @@ ASTPtr InterpreterCreateQuery::formatColumns(const NamesAndTypesList & columns, 
         String type_name = alias_column.type->getName();
         const char * type_pos = type_name.data();
         const char * type_end = type_pos + type_name.size();
-        column_declaration->type = parseQuery(type_parser, type_pos, type_end, "data type", 0, DBMS_DEFAULT_MAX_PARSER_DEPTH, DBMS_DEFAULT_MAX_PARSER_BACKTRACKS);
+        column_declaration->setType(parseQuery(type_parser, type_pos, type_end, "data type", 0, DBMS_DEFAULT_MAX_PARSER_DEPTH, DBMS_DEFAULT_MAX_PARSER_BACKTRACKS));
 
         column_declaration->default_specifier = "ALIAS";
 
@@ -437,8 +437,7 @@ ASTPtr InterpreterCreateQuery::formatColumns(const NamesAndTypesList & columns, 
         const char * alias_pos = alias.data();
         const char * alias_end = alias_pos + alias.size();
         ParserExpression expression_parser;
-        column_declaration->default_expression = parseQuery(expression_parser, alias_pos, alias_end, "expression", 0, DBMS_DEFAULT_MAX_PARSER_DEPTH, DBMS_DEFAULT_MAX_PARSER_BACKTRACKS);
-        column_declaration->children.push_back(column_declaration->default_expression);
+        column_declaration->setDefaultExpression(parseQuery(expression_parser, alias_pos, alias_end, "expression", 0, DBMS_DEFAULT_MAX_PARSER_DEPTH, DBMS_DEFAULT_MAX_PARSER_BACKTRACKS));
 
         columns_list->children.emplace_back(column_declaration);
     }
@@ -461,39 +460,34 @@ ASTPtr InterpreterCreateQuery::formatColumns(const ColumnsDescription & columns)
         String type_name = column.type->getName();
         const char * type_name_pos = type_name.data();
         const char * type_name_end = type_name_pos + type_name.size();
-        column_declaration->type = parseQuery(type_parser, type_name_pos, type_name_end, "data type", 0, DBMS_DEFAULT_MAX_PARSER_DEPTH, DBMS_DEFAULT_MAX_PARSER_BACKTRACKS);
+        column_declaration->setType(parseQuery(type_parser, type_name_pos, type_name_end, "data type", 0, DBMS_DEFAULT_MAX_PARSER_DEPTH, DBMS_DEFAULT_MAX_PARSER_BACKTRACKS));
 
         if (column.default_desc.expression)
         {
             column_declaration->default_specifier = toString(column.default_desc.kind);
-            column_declaration->default_expression = column.default_desc.expression->clone();
-            column_declaration->children.push_back(column_declaration->default_expression);
+            column_declaration->setDefaultExpression(column.default_desc.expression->clone());
         }
 
         column_declaration->ephemeral_default = column.default_desc.ephemeral_default;
 
         if (!column.comment.empty())
         {
-            column_declaration->comment = make_intrusive<ASTLiteral>(Field(column.comment));
-            column_declaration->children.push_back(column_declaration->comment);
+            column_declaration->setComment(make_intrusive<ASTLiteral>(Field(column.comment)));
         }
 
         if (column.codec)
         {
-            column_declaration->codec = column.codec;
-            column_declaration->children.push_back(column_declaration->codec);
+            column_declaration->setCodec(column.codec->clone());
         }
 
         if (column.statistics.hasExplicitStatistics())
         {
-            column_declaration->statistics_desc = column.statistics.getAST();
-            column_declaration->children.push_back(column_declaration->statistics_desc);
+            column_declaration->setStatisticsDesc(column.statistics.getAST());
         }
 
         if (column.ttl)
         {
-            column_declaration->ttl = column.ttl;
-            column_declaration->children.push_back(column_declaration->ttl);
+            column_declaration->setTTL(column.ttl->clone());
         }
 
         if (!column.settings.empty())
@@ -501,7 +495,7 @@ ASTPtr InterpreterCreateQuery::formatColumns(const ColumnsDescription & columns)
             auto settings = make_intrusive<ASTSetQuery>();
             settings->is_standalone = false;
             settings->changes = column.settings;
-            column_declaration->settings = std::move(settings);
+            column_declaration->setSettings(std::move(settings));
         }
 
         columns_list->children.push_back(column_declaration_ptr);
@@ -544,13 +538,14 @@ ASTPtr InterpreterCreateQuery::formatProjections(const ProjectionsDescription & 
 DataTypePtr InterpreterCreateQuery::getColumnType(
     const ASTColumnDeclaration & col_decl, const LoadingStrictnessLevel mode, const bool make_columns_nullable)
 {
-    if (!col_decl.type)
+    auto col_type = col_decl.getType();
+    if (!col_type)
     {
         /// we're creating dummy DataTypeUInt8 in order to prevent the NullPointerException in ExpressionActions
         return std::make_shared<DataTypeUInt8>();
     }
 
-    DataTypePtr column_type = DataTypeFactory::instance().get(col_decl.type);
+    DataTypePtr column_type = DataTypeFactory::instance().get(col_type);
 
     if (LoadingStrictnessLevel::ATTACH <= mode)
         setVersionToAggregateFunctions(column_type, true);
@@ -566,9 +561,9 @@ DataTypePtr InterpreterCreateQuery::getColumnType(
     {
         column_type = makeNullable(column_type);
     }
-    else if (
-        !hasNullable(column_type) && col_decl.default_specifier == "DEFAULT" && col_decl.default_expression
-        && col_decl.default_expression->as<ASTLiteral>() && col_decl.default_expression->as<ASTLiteral>()->value.isNull())
+    else if (auto default_expr = col_decl.getDefaultExpression();
+        !hasNullable(column_type) && col_decl.default_specifier == "DEFAULT" && default_expr
+        && default_expr->as<ASTLiteral>() && default_expr->as<ASTLiteral>()->value.isNull())
     {
         if (column_type->lowCardinality())
         {
@@ -599,7 +594,7 @@ ColumnsDescription InterpreterCreateQuery::getColumnsDescription(
     {
         const auto & col_decl = ast->as<ASTColumnDeclaration &>();
 
-        if (col_decl.collation && !context_->getSettingsRef()[Setting::compatibility_ignore_collation_in_create_table])
+        if (col_decl.getCollation() && !context_->getSettingsRef()[Setting::compatibility_ignore_collation_in_create_table])
         {
             throw Exception(
                 ErrorCodes::NOT_IMPLEMENTED, "Cannot support collation, please set compatibility_ignore_collation_in_create_table=true");
@@ -646,7 +641,7 @@ ColumnsDescription InterpreterCreateQuery::getColumnsDescription(
                             "in column declaration, set `compatibility_ignore_auto_increment_in_create_table` to true");
         }
 
-        if (col_decl.default_expression)
+        if (auto default_expression = col_decl.getDefaultExpression())
         {
             if (context_->hasQueryContext() && context_->getQueryContext().get() == context_.get())
             {
@@ -654,12 +649,12 @@ ColumnsDescription InterpreterCreateQuery::getColumnsDescription(
                 /// And for CREATE query we can pass local context, because result will not change after restart.
                 NormalizeAndEvaluateConstantsVisitor::Data visitor_data{context_};
                 NormalizeAndEvaluateConstantsVisitor visitor(visitor_data);
-                visitor.visit(col_decl.default_expression);
+                visitor.visit(default_expression);
             }
 
-            ASTPtr default_expr = col_decl.default_expression->clone();
+            ASTPtr default_expr = default_expression->clone();
 
-            if (col_decl.type)
+            if (col_decl.getType())
                 column.type = name_type_it->type;
             else
             {
@@ -673,37 +668,37 @@ ColumnsDescription InterpreterCreateQuery::getColumnsDescription(
             column.default_desc.expression = default_expr;
             column.default_desc.ephemeral_default = col_decl.ephemeral_default;
         }
-        else if (col_decl.type)
+        else if (col_decl.getType())
             column.type = name_type_it->type;
         else
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Neither default value expression nor type is provided for a column");
 
-        if (col_decl.comment)
-            column.comment = col_decl.comment->as<ASTLiteral &>().value.safeGet<String>();
+        if (auto comment = col_decl.getComment())
+            column.comment = comment->as<ASTLiteral &>().value.safeGet<String>();
 
-        if (col_decl.codec)
+        if (auto codec = col_decl.getCodec())
         {
             if (col_decl.default_specifier == "ALIAS")
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "Cannot specify codec for column type ALIAS");
             column.codec = CompressionCodecFactory::instance().validateCodecAndGetPreprocessedAST(
-                col_decl.codec, column.type, sanity_check_compression_codecs, allow_experimental_codecs);
+                codec, column.type, sanity_check_compression_codecs, allow_experimental_codecs);
         }
 
-        if (col_decl.statistics_desc)
+        if (auto statistics_desc = col_decl.getStatisticsDesc())
         {
             if (!skip_checks && !context_->getSettingsRef()[Setting::allow_experimental_statistics])
                 throw Exception(
                     ErrorCodes::INCORRECT_QUERY, "Create table with statistics is now disabled. Turn on allow_experimental_statistics");
 
-            column.statistics = ColumnStatisticsDescription::fromStatisticsDescriptionAST(col_decl.statistics_desc, column.name, column.type);
+            column.statistics = ColumnStatisticsDescription::fromStatisticsDescriptionAST(statistics_desc, column.name, column.type);
         }
 
-        if (col_decl.ttl)
-            column.ttl = col_decl.ttl;
+        if (auto ttl = col_decl.getTTL())
+            column.ttl = ttl;
 
-        if (col_decl.settings)
+        if (auto settings = col_decl.getSettings())
         {
-            column.settings = col_decl.settings->as<ASTSetQuery &>().changes;
+            column.settings = settings->as<ASTSetQuery &>().changes;
             MergeTreeColumnSettings::validate(column.settings);
         }
 

--- a/src/Interpreters/TableOverrideUtils.cpp
+++ b/src/Interpreters/TableOverrideUtils.cpp
@@ -98,8 +98,8 @@ void TableOverrideAnalyzer::analyze(const StorageInMemoryMetadata & metadata, Re
             auto override_type = DataTypeFactory::instance().get(override_column->getType());
             auto found = metadata.columns.tryGetColumnOrSubcolumn(GetColumnsOptions::All, override_column->name);
             std::optional<ColumnDefaultKind> override_default_kind;
-            if (!override_column->default_specifier.empty())
-                override_default_kind = columnDefaultKindFromString(override_column->default_specifier);
+            if (override_column->default_specifier != ColumnDefaultSpecifier::Empty)
+                override_default_kind = toColumnDefaultKind(override_column->default_specifier);
             if (found)
             {
                 std::optional<ColumnDefaultKind> existing_default_kind;

--- a/src/Interpreters/TableOverrideUtils.cpp
+++ b/src/Interpreters/TableOverrideUtils.cpp
@@ -95,7 +95,7 @@ void TableOverrideAnalyzer::analyze(const StorageInMemoryMetadata & metadata, Re
         for (const auto & column_ast : override->columns->columns->children)
         {
             auto * override_column = column_ast->as<ASTColumnDeclaration>();
-            auto override_type = DataTypeFactory::instance().get(override_column->type);
+            auto override_type = DataTypeFactory::instance().get(override_column->getType());
             auto found = metadata.columns.tryGetColumnOrSubcolumn(GetColumnsOptions::All, override_column->name);
             std::optional<ColumnDefaultKind> override_default_kind;
             if (!override_column->default_specifier.empty())

--- a/src/Interpreters/applyTableOverride.cpp
+++ b/src/Interpreters/applyTableOverride.cpp
@@ -35,7 +35,7 @@ void applyTableOverrideToCreateQuery(const ASTTableOverride & override, ASTCreat
                 ///       executed from InterpreterCreateQuery / InterpreterAlterQuery.
                 if (exists == dest_children.end())
                 {
-                    if (override_column->default_specifier == "ALIAS")
+                    if (override_column->default_specifier == ColumnDefaultSpecifier::Alias)
                         dest_children.emplace_back(override_column_ast);
                 }
                 else

--- a/src/Parsers/ASTColumnDeclaration.cpp
+++ b/src/Parsers/ASTColumnDeclaration.cpp
@@ -6,6 +6,55 @@
 namespace DB
 {
 
+const char * toString(ColumnDefaultSpecifier kind)
+{
+    switch (kind)
+    {
+        case ColumnDefaultSpecifier::Empty: return "";
+        case ColumnDefaultSpecifier::Default: return "DEFAULT";
+        case ColumnDefaultSpecifier::Materialized: return "MATERIALIZED";
+        case ColumnDefaultSpecifier::Alias: return "ALIAS";
+        case ColumnDefaultSpecifier::Ephemeral: return "EPHEMERAL";
+        case ColumnDefaultSpecifier::AutoIncrement: return "AUTO_INCREMENT";
+    }
+}
+
+ColumnDefaultSpecifier columnDefaultSpecifierFromString(std::string_view str)
+{
+    if (str.empty()) return ColumnDefaultSpecifier::Empty;
+    if (str == "DEFAULT") return ColumnDefaultSpecifier::Default;
+    if (str == "MATERIALIZED") return ColumnDefaultSpecifier::Materialized;
+    if (str == "ALIAS") return ColumnDefaultSpecifier::Alias;
+    if (str == "EPHEMERAL") return ColumnDefaultSpecifier::Ephemeral;
+    if (str == "AUTO_INCREMENT") return ColumnDefaultSpecifier::AutoIncrement;
+    return ColumnDefaultSpecifier::Empty;
+}
+
+ColumnDefaultSpecifier toColumnDefaultSpecifier(ColumnDefaultKind kind)
+{
+    switch (kind)
+    {
+        case ColumnDefaultKind::Default: return ColumnDefaultSpecifier::Default;
+        case ColumnDefaultKind::Materialized: return ColumnDefaultSpecifier::Materialized;
+        case ColumnDefaultKind::Alias: return ColumnDefaultSpecifier::Alias;
+        case ColumnDefaultKind::Ephemeral: return ColumnDefaultSpecifier::Ephemeral;
+    }
+}
+
+ColumnDefaultKind toColumnDefaultKind(ColumnDefaultSpecifier specifier)
+{
+    switch (specifier)
+    {
+        case ColumnDefaultSpecifier::Empty:
+        case ColumnDefaultSpecifier::Default:
+        case ColumnDefaultSpecifier::AutoIncrement:
+            return ColumnDefaultKind::Default;
+        case ColumnDefaultSpecifier::Materialized: return ColumnDefaultKind::Materialized;
+        case ColumnDefaultSpecifier::Alias: return ColumnDefaultKind::Alias;
+        case ColumnDefaultSpecifier::Ephemeral: return ColumnDefaultKind::Ephemeral;
+    }
+}
+
 ASTPtr ASTColumnDeclaration::clone() const
 {
     const auto res = make_intrusive<ASTColumnDeclaration>(*this);
@@ -52,7 +101,7 @@ void ASTColumnDeclaration::formatImpl(WriteBuffer & ostr, const FormatSettings &
 
     if (auto default_expression = getDefaultExpression())
     {
-        ostr << ' '  << default_specifier ;
+        ostr << ' ' << toString(default_specifier);
         if (!ephemeral_default)
         {
             ostr << ' ';

--- a/src/Parsers/ASTColumnDeclaration.cpp
+++ b/src/Parsers/ASTColumnDeclaration.cpp
@@ -10,14 +10,7 @@ ASTPtr ASTColumnDeclaration::clone() const
 {
     const auto res = make_intrusive<ASTColumnDeclaration>(*this);
     res->children.clear();
-    res->type_idx = kNotSet;
-    res->default_expression_idx = kNotSet;
-    res->comment_idx = kNotSet;
-    res->codec_idx = kNotSet;
-    res->statistics_desc_idx = kNotSet;
-    res->ttl_idx = kNotSet;
-    res->collation_idx = kNotSet;
-    res->settings_idx = kNotSet;
+    res->packed_indices = kAllNotSet;
 
     if (auto node = getType())
         res->setType(node->clone());
@@ -110,21 +103,19 @@ void ASTColumnDeclaration::formatImpl(WriteBuffer & ostr, const FormatSettings &
 
 void ASTColumnDeclaration::forEachPointerToChild(std::function<void(IAST **, boost::intrusive_ptr<IAST> *)> f)
 {
-    if (type_idx != kNotSet)
-        f(nullptr, &children[type_idx]);
-    if (default_expression_idx != kNotSet)
-        f(nullptr, &children[default_expression_idx]);
-    if (comment_idx != kNotSet)
-        f(nullptr, &children[comment_idx]);
-    if (codec_idx != kNotSet)
-        f(nullptr, &children[codec_idx]);
-    if (statistics_desc_idx != kNotSet)
-        f(nullptr, &children[statistics_desc_idx]);
-    if (ttl_idx != kNotSet)
-        f(nullptr, &children[ttl_idx]);
-    if (collation_idx != kNotSet)
-        f(nullptr, &children[collation_idx]);
-    if (settings_idx != kNotSet)
-        f(nullptr, &children[settings_idx]);
+    auto callIfSet = [&](IndexSlot slot)
+    {
+        UInt8 idx = getIndex(slot);
+        if (idx != kNotSet)
+            f(nullptr, &children[idx]);
+    };
+    callIfSet(TYPE);
+    callIfSet(DEFAULT_EXPR);
+    callIfSet(COMMENT);
+    callIfSet(CODEC);
+    callIfSet(STATS);
+    callIfSet(TTL);
+    callIfSet(COLLATION);
+    callIfSet(SETTINGS);
 }
 }

--- a/src/Parsers/ASTColumnDeclaration.cpp
+++ b/src/Parsers/ASTColumnDeclaration.cpp
@@ -1,6 +1,5 @@
 #include <Parsers/ASTColumnDeclaration.h>
 #include <Parsers/ASTWithAlias.h>
-#include <Common/quoteString.h>
 #include <IO/Operators.h>
 
 
@@ -11,54 +10,31 @@ ASTPtr ASTColumnDeclaration::clone() const
 {
     const auto res = make_intrusive<ASTColumnDeclaration>(*this);
     res->children.clear();
+    res->type_idx = kNotSet;
+    res->default_expression_idx = kNotSet;
+    res->comment_idx = kNotSet;
+    res->codec_idx = kNotSet;
+    res->statistics_desc_idx = kNotSet;
+    res->ttl_idx = kNotSet;
+    res->collation_idx = kNotSet;
+    res->settings_idx = kNotSet;
 
-    if (type)
-    {
-        res->type = type->clone();
-        res->children.push_back(res->type);
-    }
-
-    if (default_expression)
-    {
-        res->default_expression = default_expression->clone();
-        res->children.push_back(res->default_expression);
-    }
-
-    if (comment)
-    {
-        res->comment = comment->clone();
-        res->children.push_back(res->comment);
-    }
-
-    if (codec)
-    {
-        res->codec = codec->clone();
-        res->children.push_back(res->codec);
-    }
-
-    if (statistics_desc)
-    {
-        res->statistics_desc = statistics_desc->clone();
-        res->children.push_back(res->statistics_desc);
-    }
-
-    if (ttl)
-    {
-        res->ttl = ttl->clone();
-        res->children.push_back(res->ttl);
-    }
-
-    if (collation)
-    {
-        res->collation = collation->clone();
-        res->children.push_back(res->collation);
-    }
-
-    if (settings)
-    {
-        res->settings = settings->clone();
-        res->children.push_back(res->settings);
-    }
+    if (auto node = getType())
+        res->setType(node->clone());
+    if (auto node = getDefaultExpression())
+        res->setDefaultExpression(node->clone());
+    if (auto node = getComment())
+        res->setComment(node->clone());
+    if (auto node = getCodec())
+        res->setCodec(node->clone());
+    if (auto node = getStatisticsDesc())
+        res->setStatisticsDesc(node->clone());
+    if (auto node = getTTL())
+        res->setTTL(node->clone());
+    if (auto node = getCollation())
+        res->setCollation(node->clone());
+    if (auto node = getSettings())
+        res->setSettings(node->clone());
 
     return res;
 }
@@ -69,7 +45,7 @@ void ASTColumnDeclaration::formatImpl(WriteBuffer & ostr, const FormatSettings &
 
     format_settings.writeIdentifier(ostr, name, /*ambiguous=*/true);
 
-    if (type)
+    if (auto type = getType())
     {
         ostr << ' ';
         type->format(ostr, format_settings, state, frame);
@@ -81,7 +57,7 @@ void ASTColumnDeclaration::formatImpl(WriteBuffer & ostr, const FormatSettings &
                       << (*null_modifier ? "" : "NOT ") << "NULL" ;
     }
 
-    if (default_expression)
+    if (auto default_expression = getDefaultExpression())
     {
         ostr << ' '  << default_specifier ;
         if (!ephemeral_default)
@@ -91,25 +67,25 @@ void ASTColumnDeclaration::formatImpl(WriteBuffer & ostr, const FormatSettings &
         }
     }
 
-    if (comment)
+    if (auto comment = getComment())
     {
         ostr << ' '  << "COMMENT"  << ' ';
         comment->format(ostr, format_settings, state, frame);
     }
 
-    if (codec)
+    if (auto codec = getCodec())
     {
         ostr << ' ';
         codec->format(ostr, format_settings, state, frame);
     }
 
-    if (statistics_desc)
+    if (auto statistics_desc = getStatisticsDesc())
     {
         ostr << ' ';
         statistics_desc->format(ostr, format_settings, state, frame);
     }
 
-    if (ttl)
+    if (auto ttl = getTTL())
     {
         ostr << ' '  << "TTL"  << ' ';
         auto nested_frame = frame;
@@ -118,13 +94,13 @@ void ASTColumnDeclaration::formatImpl(WriteBuffer & ostr, const FormatSettings &
         ttl->format(ostr, format_settings, state, nested_frame);
     }
 
-    if (collation)
+    if (auto collation = getCollation())
     {
         ostr << ' '  << "COLLATE"  << ' ';
         collation->format(ostr, format_settings, state, frame);
     }
 
-    if (settings)
+    if (auto settings = getSettings())
     {
         ostr << ' '  << "SETTINGS"  << ' ' << '(';
         settings->format(ostr, format_settings, state, frame);
@@ -134,12 +110,21 @@ void ASTColumnDeclaration::formatImpl(WriteBuffer & ostr, const FormatSettings &
 
 void ASTColumnDeclaration::forEachPointerToChild(std::function<void(IAST **, boost::intrusive_ptr<IAST> *)> f)
 {
-    f(nullptr, &default_expression);
-    f(nullptr, &comment);
-    f(nullptr, &codec);
-    f(nullptr, &statistics_desc);
-    f(nullptr, &ttl);
-    f(nullptr, &collation);
-    f(nullptr, &settings);
+    if (type_idx != kNotSet)
+        f(nullptr, &children[type_idx]);
+    if (default_expression_idx != kNotSet)
+        f(nullptr, &children[default_expression_idx]);
+    if (comment_idx != kNotSet)
+        f(nullptr, &children[comment_idx]);
+    if (codec_idx != kNotSet)
+        f(nullptr, &children[codec_idx]);
+    if (statistics_desc_idx != kNotSet)
+        f(nullptr, &children[statistics_desc_idx]);
+    if (ttl_idx != kNotSet)
+        f(nullptr, &children[ttl_idx]);
+    if (collation_idx != kNotSet)
+        f(nullptr, &children[collation_idx]);
+    if (settings_idx != kNotSet)
+        f(nullptr, &children[settings_idx]);
 }
 }

--- a/src/Parsers/ASTColumnDeclaration.h
+++ b/src/Parsers/ASTColumnDeclaration.h
@@ -47,7 +47,7 @@ private:
     }
 
 public:
-    bool hasChildren() const { return children.size() != 0; }
+    bool hasChildren() const { return !children.empty(); }
     ASTPtr getType() const { return getChildOrNull(type_idx); }
     ASTPtr getDefaultExpression() const { return getChildOrNull(default_expression_idx); }
     ASTPtr getComment() const { return getChildOrNull(comment_idx); }

--- a/src/Parsers/ASTColumnDeclaration.h
+++ b/src/Parsers/ASTColumnDeclaration.h
@@ -12,26 +12,71 @@ class ASTColumnDeclaration : public IAST
 {
 public:
     String name;
-    ASTPtr type;
-    std::optional<bool> null_modifier;
     String default_specifier;
-    ASTPtr default_expression;
+
+    std::optional<bool> null_modifier;
     bool ephemeral_default = false;
-    ASTPtr comment;
-    ASTPtr codec;
-    ASTPtr statistics_desc;
-    ASTPtr ttl;
-    ASTPtr collation;
-    ASTPtr settings;
     bool primary_key_specifier = false;
+
+private:
+    static constexpr UInt8 kNotSet = 0xFF;
+
+    UInt8 type_idx = kNotSet;
+    UInt8 default_expression_idx = kNotSet;
+    UInt8 comment_idx = kNotSet;
+    UInt8 codec_idx = kNotSet;
+    UInt8 statistics_desc_idx = kNotSet;
+    UInt8 ttl_idx = kNotSet;
+    UInt8 collation_idx = kNotSet;
+    UInt8 settings_idx = kNotSet;
+
+    ASTPtr getChildOrNull(UInt8 idx) const { return idx == kNotSet ? nullptr : children[idx]; }
+
+    void setChild(UInt8 & idx, ASTPtr && node)
+    {
+        if (!node)
+            return;
+
+        if (idx != kNotSet)
+            children[idx] = std::move(node);
+        else
+        {
+            idx = static_cast<UInt8>(children.size());
+            children.push_back(std::move(node));
+        }
+    }
+
+public:
+    bool hasChildren() const { return children.size() != 0; }
+    ASTPtr getType() const { return getChildOrNull(type_idx); }
+    ASTPtr getDefaultExpression() const { return getChildOrNull(default_expression_idx); }
+    ASTPtr getComment() const { return getChildOrNull(comment_idx); }
+    ASTPtr getCodec() const { return getChildOrNull(codec_idx); }
+    ASTPtr getStatisticsDesc() const { return getChildOrNull(statistics_desc_idx); }
+    ASTPtr getTTL() const { return getChildOrNull(ttl_idx); }
+    ASTPtr getCollation() const { return getChildOrNull(collation_idx); }
+    ASTPtr getSettings() const { return getChildOrNull(settings_idx); }
+
+    void setType(ASTPtr && node) { setChild(type_idx, std::move(node)); }
+    void setDefaultExpression(ASTPtr && node) { setChild(default_expression_idx, std::move(node)); }
+    void setComment(ASTPtr && node) { setChild(comment_idx, std::move(node)); }
+    void setCodec(ASTPtr && node) { setChild(codec_idx, std::move(node)); }
+    void setStatisticsDesc(ASTPtr && node) { setChild(statistics_desc_idx, std::move(node)); }
+    void setTTL(ASTPtr && node) { setChild(ttl_idx, std::move(node)); }
+    void setCollation(ASTPtr && node) { setChild(collation_idx, std::move(node)); }
+    void setSettings(ASTPtr && node) { setChild(settings_idx, std::move(node)); }
 
     String getID(char delim) const override { return "ColumnDeclaration" + (delim + name); }
 
     ASTPtr clone() const override;
 
+
 protected:
     void formatImpl(WriteBuffer & ostr, const FormatSettings & format_settings, FormatState & state, FormatStateStacked frame) const override;
     void forEachPointerToChild(std::function<void(IAST **, boost::intrusive_ptr<IAST> *)> f) override;
+
+private:
+    using IAST::children; /// Don't let other manipulate children directly
 };
 
 }

--- a/src/Parsers/ASTColumnDeclaration.h
+++ b/src/Parsers/ASTColumnDeclaration.h
@@ -1,9 +1,26 @@
 #pragma once
 
 #include <Parsers/IAST.h>
+#include <Storages/ColumnDefault.h>
 
 namespace DB
 {
+
+/// Default specifier for column declarations - compatible with ColumnDefaultKind plus Empty and AutoIncrement
+enum class ColumnDefaultSpecifier : UInt8
+{
+    Empty = 0,
+    Default,
+    Materialized,
+    Alias,
+    Ephemeral,
+    AutoIncrement
+};
+
+const char * toString(ColumnDefaultSpecifier kind);
+ColumnDefaultSpecifier columnDefaultSpecifierFromString(std::string_view str);
+ColumnDefaultSpecifier toColumnDefaultSpecifier(ColumnDefaultKind kind);
+ColumnDefaultKind toColumnDefaultKind(ColumnDefaultSpecifier specifier);
 
 /** Name, type, default-specifier, default-expression, comment-expression.
  *  The type is optional if default-expression is specified.
@@ -12,11 +29,11 @@ class ASTColumnDeclaration : public IAST
 {
 public:
     String name;
-    String default_specifier;
+    ColumnDefaultSpecifier default_specifier = ColumnDefaultSpecifier::Empty;
 
     std::optional<bool> null_modifier;
-    bool ephemeral_default = false;
-    bool primary_key_specifier = false;
+    bool ephemeral_default : 1 = false;
+    bool primary_key_specifier : 1 = false;
 
 private:
     /// Pack 8 indices (4 bits each) into a single UInt32. 0xF means "not set".

--- a/src/Parsers/ASTDataType.cpp
+++ b/src/Parsers/ASTDataType.cpp
@@ -25,7 +25,7 @@ ASTPtr ASTDataType::clone() const
 
 ASTPtr ASTDataType::getArguments() const
 {
-    if (children.size())
+    if (!children.empty())
         return children[0];
     return nullptr;
 }

--- a/src/Parsers/ASTDataType.cpp
+++ b/src/Parsers/ASTDataType.cpp
@@ -14,15 +14,25 @@ String ASTDataType::getID(char delim) const
 ASTPtr ASTDataType::clone() const
 {
     auto res = make_intrusive<ASTDataType>(*this);
+    const auto & arguments = getArguments();
     res->children.clear();
 
     if (arguments)
-    {
-        res->arguments = arguments->clone();
-        res->children.push_back(res->arguments);
-    }
+        res->children.push_back(arguments->clone());
 
     return res;
+}
+
+ASTPtr ASTDataType::getArguments() const
+{
+    if (children.size())
+        return children[0];
+    return nullptr;
+}
+
+void ASTDataType::resetArguments()
+{
+    children.clear();
 }
 
 void ASTDataType::updateTreeHashImpl(SipHash & hash_state, bool) const
@@ -36,6 +46,7 @@ void ASTDataType::formatImpl(WriteBuffer & ostr, const FormatSettings & settings
 {
     ostr << name;
 
+    const auto & arguments = getArguments();
     if (arguments && !arguments->children.empty())
     {
         ostr << '(';

--- a/src/Parsers/ASTDataType.h
+++ b/src/Parsers/ASTDataType.h
@@ -11,11 +11,13 @@ class ASTDataType : public IAST
 {
 public:
     String name;
-    ASTPtr arguments;
 
     String getID(char delim) const override;
     ASTPtr clone() const override;
     void updateTreeHashImpl(SipHash & hash_state, bool ignore_aliases) const override;
+
+    ASTPtr getArguments() const;
+    void resetArguments();
 
 protected:
     void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
@@ -29,9 +31,9 @@ boost::intrusive_ptr<ASTDataType> makeASTDataType(const String & name, Args &&..
 
     if constexpr (sizeof...(args))
     {
-        data_type->arguments = make_intrusive<ASTExpressionList>();
-        data_type->children.push_back(data_type->arguments);
-        data_type->arguments->children = { std::forward<Args>(args)... };
+        auto arguments = make_intrusive<ASTExpressionList>();
+        data_type->children.push_back(arguments);
+        arguments->children = {std::forward<Args>(args)...};
     }
 
     return data_type;

--- a/src/Parsers/ExpressionElementParsers.cpp
+++ b/src/Parsers/ExpressionElementParsers.cpp
@@ -475,10 +475,11 @@ bool ParserFilterClause::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
     {
         /// Remove child from function.arguments if it's '*' because countIf(*) is not supported.
         /// See https://github.com/ClickHouse/ClickHouse/issues/61004
-        std::erase_if(function.arguments->children, [] (const ASTPtr & child)
+        function.arguments->children.erase(
+            std::remove_if(function.arguments->children.begin(), function.arguments->children.end(), [] (const ASTPtr & child)
         {
             return typeid_cast<const ASTAsterisk *>(child.get()) || typeid_cast<const ASTQualifiedAsterisk *>(child.get());
-        });
+        }));
     }
 
     function.name += "If";

--- a/src/Parsers/ExpressionElementParsers.cpp
+++ b/src/Parsers/ExpressionElementParsers.cpp
@@ -44,6 +44,8 @@
 
 #include <Interpreters/StorageID.h>
 
+#include <boost/range/algorithm.hpp>
+#include <boost/range/algorithm_ext.hpp>
 
 namespace DB
 {
@@ -475,12 +477,10 @@ bool ParserFilterClause::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
     {
         /// Remove child from function.arguments if it's '*' because countIf(*) is not supported.
         /// See https://github.com/ClickHouse/ClickHouse/issues/61004
-        function.arguments->children.erase(
-            std::remove_if(
-                function.arguments->children.begin(),
-                function.arguments->children.end(),
-                [](const ASTPtr & child)
-                { return typeid_cast<const ASTAsterisk *>(child.get()) || typeid_cast<const ASTQualifiedAsterisk *>(child.get()); }));
+        boost::range::remove_erase_if(function.arguments->children, [] (const ASTPtr & child)
+        {
+            return typeid_cast<const ASTAsterisk *>(child.get()) || typeid_cast<const ASTQualifiedAsterisk *>(child.get());
+        });
     }
 
     function.name += "If";

--- a/src/Parsers/ExpressionElementParsers.cpp
+++ b/src/Parsers/ExpressionElementParsers.cpp
@@ -476,10 +476,11 @@ bool ParserFilterClause::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
         /// Remove child from function.arguments if it's '*' because countIf(*) is not supported.
         /// See https://github.com/ClickHouse/ClickHouse/issues/61004
         function.arguments->children.erase(
-            std::remove_if(function.arguments->children.begin(), function.arguments->children.end(), [] (const ASTPtr & child)
-        {
-            return typeid_cast<const ASTAsterisk *>(child.get()) || typeid_cast<const ASTQualifiedAsterisk *>(child.get());
-        }));
+            std::remove_if(
+                function.arguments->children.begin(),
+                function.arguments->children.end(),
+                [](const ASTPtr & child)
+                { return typeid_cast<const ASTAsterisk *>(child.get()) || typeid_cast<const ASTQualifiedAsterisk *>(child.get()); }));
     }
 
     function.name += "If";

--- a/src/Parsers/IAST.cpp
+++ b/src/Parsers/IAST.cpp
@@ -82,6 +82,9 @@ namespace boost::sp_adl_block
 namespace DB
 {
 
+/// Verify that we did not increase the size of IAST by accident.
+static_assert(sizeof(IAST) <= 32);
+
 void intrusive_ptr_add_ref(const IAST* p)
 {
     boost::sp_adl_block::intrusive_ptr_add_ref<IAST, boost::thread_safe_counter>(p);

--- a/src/Parsers/IAST.h
+++ b/src/Parsers/IAST.h
@@ -12,6 +12,7 @@
 
 class SipHash;
 
+#include <boost/container/vector.hpp>
 
 namespace DB
 {

--- a/src/Parsers/IAST_fwd.h
+++ b/src/Parsers/IAST_fwd.h
@@ -13,12 +13,15 @@ namespace DB
 
 #include <boost/smart_ptr/intrusive_ref_counter.hpp>
 #include <boost/smart_ptr/intrusive_ptr.hpp>
+#include <boost/container/vector.hpp>
 
 namespace DB
 {
 
 using ASTPtr = boost::intrusive_ptr<IAST>;
-using ASTs = std::vector<ASTPtr>;
+/// Boost vector with smaller stored size to save memory for AST children vectors.
+using ASTs = boost::container::vector<ASTPtr, boost::container::new_allocator<ASTPtr>,
+         boost::container::vector_options<boost::container::stored_size<uint32_t>>::type>;
 
 template <typename T, typename ... Args>
 constexpr boost::intrusive_ptr<T> make_intrusive(Args && ... args)

--- a/src/Parsers/IAST_fwd.h
+++ b/src/Parsers/IAST_fwd.h
@@ -11,17 +11,19 @@ namespace DB
 }
 
 
-#include <boost/smart_ptr/intrusive_ref_counter.hpp>
-#include <boost/smart_ptr/intrusive_ptr.hpp>
 #include <boost/container/vector.hpp>
+#include <boost/smart_ptr/intrusive_ptr.hpp>
+#include <boost/smart_ptr/intrusive_ref_counter.hpp>
 
 namespace DB
 {
 
 using ASTPtr = boost::intrusive_ptr<IAST>;
 /// Boost vector with smaller stored size to save memory for AST children vectors.
-using ASTs = boost::container::vector<ASTPtr, boost::container::new_allocator<ASTPtr>,
-         boost::container::vector_options<boost::container::stored_size<uint32_t>>::type>;
+using ASTs = boost::container::vector<
+    ASTPtr,
+    boost::container::new_allocator<ASTPtr>,
+    boost::container::vector_options<boost::container::stored_size<uint32_t>>::type>;
 
 template <typename T, typename ... Args>
 constexpr boost::intrusive_ptr<T> make_intrusive(Args && ... args)

--- a/src/Parsers/MySQL/tests/gtest_column_parser.cpp
+++ b/src/Parsers/MySQL/tests/gtest_column_parser.cpp
@@ -21,7 +21,7 @@ TEST(ParserColumn, AllNonGeneratedColumnOption)
     ASTPtr ast = parseQuery(p_column, input.data(), input.data() + input.size(), "", 0, 0, 0);
     EXPECT_EQ(ast->as<ASTDeclareColumn>()->name, "col_01");
     EXPECT_EQ(ast->as<ASTDeclareColumn>()->data_type->as<ASTDataType>()->name, "VARCHAR");
-    EXPECT_EQ(ast->as<ASTDeclareColumn>()->data_type->as<ASTDataType>()->arguments->children[0]->as<ASTLiteral>()->value.safeGet<UInt64>(), 100);
+    EXPECT_EQ(ast->as<ASTDeclareColumn>()->data_type->as<ASTDataType>()->getArguments()->children[0]->as<ASTLiteral>()->value.safeGet<UInt64>(), 100);
 
     ASTDeclareOptions * declare_options = ast->as<ASTDeclareColumn>()->column_options->as<ASTDeclareOptions>();
     EXPECT_EQ(declare_options->changes["is_null"]->as<ASTLiteral>()->value.safeGet<UInt64>(), 0);
@@ -46,7 +46,7 @@ TEST(ParserColumn, AllGeneratedColumnOption)
     ASTPtr ast = parseQuery(p_column, input.data(), input.data() + input.size(), "", 0, 0, 0);
     EXPECT_EQ(ast->as<ASTDeclareColumn>()->name, "col_01");
     EXPECT_EQ(ast->as<ASTDeclareColumn>()->data_type->as<ASTDataType>()->name, "VARCHAR");
-    EXPECT_EQ(ast->as<ASTDeclareColumn>()->data_type->as<ASTDataType>()->arguments->children[0]->as<ASTLiteral>()->value.safeGet<UInt64>(), 100);
+    EXPECT_EQ(ast->as<ASTDeclareColumn>()->data_type->as<ASTDataType>()->getArguments()->children[0]->as<ASTLiteral>()->value.safeGet<UInt64>(), 100);
 
     ASTDeclareOptions * declare_options = ast->as<ASTDeclareColumn>()->column_options->as<ASTDeclareOptions>();
     EXPECT_EQ(declare_options->changes["is_null"]->as<ASTLiteral>()->value.safeGet<UInt64>(), 1);

--- a/src/Parsers/ParserAlterQuery.cpp
+++ b/src/Parsers/ParserAlterQuery.cpp
@@ -776,7 +776,7 @@ bool ParserAlterCommand::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
                 {
                     const auto & column_decl = command_col_decl->as<const ASTColumnDeclaration &>();
 
-                    if (column_decl.hasChildren() || column_decl.null_modifier.has_value() || !column_decl.default_specifier.empty()
+                    if (column_decl.hasChildren() || column_decl.null_modifier.has_value() || column_decl.default_specifier != ColumnDefaultSpecifier::Empty
                         || column_decl.ephemeral_default || column_decl.primary_key_specifier)
                     {
                         throw Exception(ErrorCodes::SYNTAX_ERROR, "Cannot specify column properties before '{}'", keyword);

--- a/src/Parsers/ParserAlterQuery.cpp
+++ b/src/Parsers/ParserAlterQuery.cpp
@@ -776,7 +776,7 @@ bool ParserAlterCommand::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
                 {
                     const auto & column_decl = command_col_decl->as<const ASTColumnDeclaration &>();
 
-                    if (!column_decl.children.empty() || column_decl.null_modifier.has_value() || !column_decl.default_specifier.empty()
+                    if (column_decl.hasChildren() || column_decl.null_modifier.has_value() || !column_decl.default_specifier.empty()
                         || column_decl.ephemeral_default || column_decl.primary_key_specifier)
                     {
                         throw Exception(ErrorCodes::SYNTAX_ERROR, "Cannot specify column properties before '{}'", keyword);
@@ -832,7 +832,7 @@ bool ParserAlterCommand::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
 
                 /// Make sure that type is not populated when REMOVE/MODIFY SETTING/RESET SETTING is used, because we wouldn't modify the type, which can be confusing
                 chassert(
-                    nullptr == command_col_decl->as<const ASTColumnDeclaration &>().type
+                    nullptr == command_col_decl->as<const ASTColumnDeclaration &>().getType()
                     || (command->remove_property.empty() && nullptr == command_settings_changes && nullptr == command_settings_resets));
             }
             else if (s_modify_order_by.ignore(pos, expected))

--- a/src/Parsers/ParserCreateQuery.h
+++ b/src/Parsers/ParserCreateQuery.h
@@ -373,10 +373,7 @@ bool IParserColumnDeclaration<NameParser>::parseImpl(Pos & pos, ASTPtr & node, E
     node = column_declaration;
 
     if (type)
-    {
-        column_declaration->type = type;
-        column_declaration->children.push_back(std::move(type));
-    }
+        column_declaration->setType(std::move(type));
 
     column_declaration->null_modifier = null_modifier;
 
@@ -384,45 +381,26 @@ bool IParserColumnDeclaration<NameParser>::parseImpl(Pos & pos, ASTPtr & node, E
     if (default_expression)
     {
         column_declaration->ephemeral_default = ephemeral_default;
-        column_declaration->default_expression = default_expression;
-        column_declaration->children.push_back(std::move(default_expression));
+        column_declaration->setDefaultExpression(std::move(default_expression));
     }
 
     if (comment_expression)
-    {
-        column_declaration->comment = comment_expression;
-        column_declaration->children.push_back(std::move(comment_expression));
-    }
+        column_declaration->setComment(std::move(comment_expression));
 
     if (codec_expression)
-    {
-        column_declaration->codec = codec_expression;
-        column_declaration->children.push_back(std::move(codec_expression));
-    }
+        column_declaration->setCodec(std::move(codec_expression));
 
     if (settings)
-    {
-        column_declaration->settings = settings;
-        column_declaration->children.push_back(std::move(settings));
-    }
+        column_declaration->setSettings(std::move(settings));
 
     if (statistics_desc_expression)
-    {
-        column_declaration->statistics_desc = statistics_desc_expression;
-        column_declaration->children.push_back(std::move(statistics_desc_expression));
-    }
+        column_declaration->setStatisticsDesc(std::move(statistics_desc_expression));
 
     if (ttl_expression)
-    {
-        column_declaration->ttl = ttl_expression;
-        column_declaration->children.push_back(std::move(ttl_expression));
-    }
+        column_declaration->setTTL(std::move(ttl_expression));
 
     if (collation_expression)
-    {
-        column_declaration->collation = collation_expression;
-        column_declaration->children.push_back(std::move(collation_expression));
-    }
+        column_declaration->setCollation(std::move(collation_expression));
 
     column_declaration->primary_key_specifier = primary_key_specifier;
 

--- a/src/Parsers/ParserDataType.cpp
+++ b/src/Parsers/ParserDataType.cpp
@@ -438,8 +438,7 @@ bool ParserDataType::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
         return false;
     ++pos;
 
-    data_type_node->arguments = expr_list_args;
-    data_type_node->children.push_back(data_type_node->arguments);
+    data_type_node->children.push_back(expr_list_args);
 
     node = data_type_node;
     return true;

--- a/src/Processors/Formats/Impl/MySQLDumpRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/MySQLDumpRowInputFormat.cpp
@@ -215,7 +215,7 @@ static NamesAndTypesList getColumnsList(const ASTExpressionList * columns_defini
             }
 
             if (type_name_upper == "SET")
-                data_type_node->arguments.reset();
+                data_type_node->resetArguments();
 
             /// Transforms MySQL ENUM's list of strings to ClickHouse string-integer pairs
             /// For example ENUM('a', 'b', 'c') -> ENUM('a'=1, 'b'=2, 'c'=3)
@@ -224,7 +224,7 @@ static NamesAndTypesList getColumnsList(const ASTExpressionList * columns_defini
             if (type_name_upper.contains("ENUM"))
             {
                 UInt16 i = 0;
-                for (ASTPtr & child : data_type_node->arguments->children)
+                for (ASTPtr & child : data_type_node->getArguments()->children)
                 {
                     auto new_child = make_intrusive<ASTFunction>();
                     new_child->name = "equals";

--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -105,33 +105,33 @@ std::optional<AlterCommand> AlterCommand::parse(const ASTAlterCommand * command_
         const auto & ast_col_decl = command_ast->col_decl->as<ASTColumnDeclaration &>();
 
         command.column_name = ast_col_decl.name;
-        if (ast_col_decl.type)
+        if (ast_col_decl.getType())
         {
-            command.data_type = data_type_factory.get(ast_col_decl.type);
+            command.data_type = data_type_factory.get(ast_col_decl.getType());
         }
-        if (ast_col_decl.default_expression)
+        if (ast_col_decl.getDefaultExpression())
         {
             command.default_kind = columnDefaultKindFromString(ast_col_decl.default_specifier);
-            command.default_expression = ast_col_decl.default_expression;
+            command.default_expression = ast_col_decl.getDefaultExpression();
         }
 
-        if (ast_col_decl.comment)
+        if (ast_col_decl.getComment())
         {
-            const auto & ast_comment = typeid_cast<ASTLiteral &>(*ast_col_decl.comment);
+            const auto & ast_comment = typeid_cast<ASTLiteral &>(*ast_col_decl.getComment());
             command.comment = ast_comment.value.safeGet<String>();
         }
 
-        if (ast_col_decl.codec)
+        if (ast_col_decl.getCodec())
         {
             if (ast_col_decl.default_specifier == "ALIAS")
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "Cannot specify codec for column type ALIAS");
-            command.codec = ast_col_decl.codec;
+            command.codec = ast_col_decl.getCodec();
         }
         if (command_ast->column)
             command.after_column = getIdentifierName(command_ast->column);
 
-        if (ast_col_decl.ttl)
-            command.ttl = ast_col_decl.ttl;
+        if (ast_col_decl.getTTL())
+            command.ttl = ast_col_decl.getTTL();
 
         command.first = command_ast->first;
         command.if_not_exists = command_ast->if_not_exists;
@@ -162,31 +162,31 @@ std::optional<AlterCommand> AlterCommand::parse(const ASTAlterCommand * command_
         command.column_name = ast_col_decl.name;
         command.to_remove = removePropertyFromString(command_ast->remove_property);
 
-        if (ast_col_decl.type)
+        if (ast_col_decl.getType())
         {
-            command.data_type = data_type_factory.get(ast_col_decl.type);
+            command.data_type = data_type_factory.get(ast_col_decl.getType());
         }
 
-        if (ast_col_decl.default_expression)
+        if (ast_col_decl.getDefaultExpression())
         {
             command.default_kind = columnDefaultKindFromString(ast_col_decl.default_specifier);
-            command.default_expression = ast_col_decl.default_expression;
+            command.default_expression = ast_col_decl.getDefaultExpression();
         }
 
-        if (ast_col_decl.comment)
+        if (ast_col_decl.getComment())
         {
-            const auto & ast_comment = ast_col_decl.comment->as<ASTLiteral &>();
+            const auto & ast_comment = ast_col_decl.getComment()->as<ASTLiteral &>();
             command.comment.emplace(ast_comment.value.safeGet<String>());
         }
 
-        if (ast_col_decl.ttl)
-            command.ttl = ast_col_decl.ttl;
+        if (ast_col_decl.getTTL())
+            command.ttl = ast_col_decl.getTTL();
 
-        if (ast_col_decl.codec)
-            command.codec = ast_col_decl.codec;
+        if (ast_col_decl.getCodec())
+            command.codec = ast_col_decl.getCodec();
 
-        if (ast_col_decl.settings)
-            command.settings_changes = ast_col_decl.settings->as<ASTSetQuery &>().changes;
+        if (ast_col_decl.getSettings())
+            command.settings_changes = ast_col_decl.getSettings()->as<ASTSetQuery &>().changes;
 
         /// At most only one of ast_col_decl.settings or command_ast->settings_changes is non-null
         if (command_ast->settings_changes)

--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -111,7 +111,7 @@ std::optional<AlterCommand> AlterCommand::parse(const ASTAlterCommand * command_
         }
         if (ast_col_decl.getDefaultExpression())
         {
-            command.default_kind = columnDefaultKindFromString(ast_col_decl.default_specifier);
+            command.default_kind = toColumnDefaultKind(ast_col_decl.default_specifier);
             command.default_expression = ast_col_decl.getDefaultExpression();
         }
 
@@ -123,7 +123,7 @@ std::optional<AlterCommand> AlterCommand::parse(const ASTAlterCommand * command_
 
         if (ast_col_decl.getCodec())
         {
-            if (ast_col_decl.default_specifier == "ALIAS")
+            if (ast_col_decl.default_specifier == ColumnDefaultSpecifier::Alias)
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "Cannot specify codec for column type ALIAS");
             command.codec = ast_col_decl.getCodec();
         }
@@ -169,7 +169,7 @@ std::optional<AlterCommand> AlterCommand::parse(const ASTAlterCommand * command_
 
         if (ast_col_decl.getDefaultExpression())
         {
-            command.default_kind = columnDefaultKindFromString(ast_col_decl.default_specifier);
+            command.default_kind = toColumnDefaultKind(ast_col_decl.default_specifier);
             command.default_expression = ast_col_decl.getDefaultExpression();
         }
 

--- a/src/Storages/ColumnsDescription.cpp
+++ b/src/Storages/ColumnsDescription.cpp
@@ -228,27 +228,27 @@ void ColumnDescription::readText(ReadBuffer & buf)
 
         if (auto * col_ast = ast->as<ASTColumnDeclaration>())
         {
-            if (col_ast->default_expression)
+            if (auto col_default_expression = col_ast->getDefaultExpression())
             {
                 default_desc.kind = columnDefaultKindFromString(col_ast->default_specifier);
-                default_desc.expression = std::move(col_ast->default_expression);
+                default_desc.expression = std::move(col_default_expression);
                 default_desc.ephemeral_default = col_ast->ephemeral_default;
             }
 
-            if (col_ast->comment)
-                comment = col_ast->comment->as<ASTLiteral &>().value.safeGet<String>();
+            if (auto col_comment = col_ast->getComment())
+                comment = col_comment->as<ASTLiteral &>().value.safeGet<String>();
 
-            if (col_ast->codec)
-                codec = CompressionCodecFactory::instance().validateCodecAndGetPreprocessedAST(col_ast->codec, type, false, true);
+            if (auto col_codec = col_ast->getCodec())
+                codec = CompressionCodecFactory::instance().validateCodecAndGetPreprocessedAST(col_codec, type, false, true);
 
-            if (col_ast->ttl)
-                ttl = col_ast->ttl;
+            if (auto col_ttl = col_ast->getTTL())
+                ttl = col_ttl;
 
-            if (col_ast->settings)
-                settings = col_ast->settings->as<ASTSetQuery &>().changes;
+            if (auto col_settings = col_ast->getSettings())
+                settings = col_settings->as<ASTSetQuery &>().changes;
 
-            if (col_ast->statistics_desc)
-                statistics = ColumnStatisticsDescription::fromStatisticsDescriptionAST(col_ast->statistics_desc, name, type);
+            if (auto col_statistics_desc = col_ast->getStatisticsDesc())
+                statistics = ColumnStatisticsDescription::fromStatisticsDescriptionAST(col_statistics_desc, name, type);
         }
         else
             throw Exception(ErrorCodes::CANNOT_PARSE_TEXT, "Cannot parse column description");
@@ -981,14 +981,15 @@ std::optional<NameAndTypePair> ColumnsDescription::tryGetDynamicSubcolumn(const 
 
 void getDefaultExpressionInfoInto(const ASTColumnDeclaration & col_decl, const DataTypePtr & data_type, DefaultExpressionsInfo & info)
 {
-    if (!col_decl.default_expression)
+    auto col_default_expression = col_decl.getDefaultExpression();
+    if (!col_default_expression)
         return;
 
     /** For columns with explicitly-specified type create two expressions:
     * 1. default_expression aliased as column name with _tmp suffix
     * 2. conversion of expression (1) to explicitly-specified type alias as column name
     */
-    if (col_decl.type)
+    if (col_decl.getType())
     {
         const auto & final_column_name = col_decl.name;
         const auto tmp_column_name = final_column_name + "_tmp_alter" + toString(randomSeed());
@@ -997,12 +998,12 @@ void getDefaultExpressionInfoInto(const ASTColumnDeclaration & col_decl, const D
         info.expr_list->children.emplace_back(setAlias(
             addTypeConversionToAST(make_intrusive<ASTIdentifier>(tmp_column_name), data_type_ptr->getName()), final_column_name));
 
-        info.expr_list->children.emplace_back(setAlias(col_decl.default_expression->clone(), tmp_column_name));
+        info.expr_list->children.emplace_back(setAlias(col_default_expression->clone(), tmp_column_name));
     }
     else
     {
         info.has_columns_with_default_without_type = true;
-        info.expr_list->children.emplace_back(setAlias(col_decl.default_expression->clone(), col_decl.name));
+        info.expr_list->children.emplace_back(setAlias(col_default_expression->clone(), col_decl.name));
     }
 }
 

--- a/src/Storages/ColumnsDescription.cpp
+++ b/src/Storages/ColumnsDescription.cpp
@@ -230,7 +230,7 @@ void ColumnDescription::readText(ReadBuffer & buf)
         {
             if (auto col_default_expression = col_ast->getDefaultExpression())
             {
-                default_desc.kind = columnDefaultKindFromString(col_ast->default_specifier);
+                default_desc.kind = toColumnDefaultKind(col_ast->default_specifier);
                 default_desc.expression = std::move(col_default_expression);
                 default_desc.ephemeral_default = col_ast->ephemeral_default;
             }

--- a/src/Storages/ColumnsDescription.h
+++ b/src/Storages/ColumnsDescription.h
@@ -11,6 +11,8 @@
 #include <Common/NamePrompter.h>
 #include <Common/SettingsChanges.h>
 
+#include <Parsers/IAST.h>
+
 #include <boost/multi_index/member.hpp>
 #include <boost/multi_index/mem_fun.hpp>
 #include <boost/multi_index/hashed_index.hpp>

--- a/src/Storages/MutationCommands.cpp
+++ b/src/Storages/MutationCommands.cpp
@@ -151,10 +151,10 @@ std::optional<MutationCommand> MutationCommand::parse(const ASTAlterCommand & co
     {
         res.type = MutationCommand::Type::READ_COLUMN;
         const auto & ast_col_decl = command.col_decl->as<ASTColumnDeclaration &>();
-        if (nullptr == ast_col_decl.type)
+        if (nullptr == ast_col_decl.getType())
             throw Exception(ErrorCodes::LOGICAL_ERROR, "MODIFY COLUMN mutation command doesn't specify type: {}", command.formatForErrorMessage());
         res.column_name = ast_col_decl.name;
-        res.data_type = DataTypeFactory::instance().get(ast_col_decl.type);
+        res.data_type = DataTypeFactory::instance().get(ast_col_decl.getType());
         return res;
     }
     if (parse_alter_commands && command.type == ASTAlterCommand::DROP_COLUMN)

--- a/src/Storages/PostgreSQL/StorageMaterializedPostgreSQL.cpp
+++ b/src/Storages/PostgreSQL/StorageMaterializedPostgreSQL.cpp
@@ -309,13 +309,10 @@ boost::intrusive_ptr<ASTColumnDeclaration> StorageMaterializedPostgreSQL::getMat
     auto column_declaration = make_intrusive<ASTColumnDeclaration>();
 
     column_declaration->name = std::move(name);
-    column_declaration->type = makeASTDataType(type);
+    column_declaration->setType(makeASTDataType(type));
 
     column_declaration->default_specifier = "MATERIALIZED";
-    column_declaration->default_expression = make_intrusive<ASTLiteral>(default_value);
-
-    column_declaration->children.emplace_back(column_declaration->type);
-    column_declaration->children.emplace_back(column_declaration->default_expression);
+    column_declaration->setDefaultExpression(make_intrusive<ASTLiteral>(default_value));
 
     return column_declaration;
 }
@@ -350,11 +347,11 @@ StorageMaterializedPostgreSQL::getColumnsExpressionList(const NamesAndTypesList 
         const auto & column_declaration = make_intrusive<ASTColumnDeclaration>();
 
         column_declaration->name = name;
-        column_declaration->type = getColumnDeclaration(type);
+        column_declaration->setType(getColumnDeclaration(type));
 
         if (auto it = defaults.find(name); it != defaults.end())
         {
-            column_declaration->default_expression = it->second;
+            column_declaration->setDefaultExpression(std::move(it->second));
             column_declaration->default_specifier = "DEFAULT";
         }
 
@@ -430,7 +427,7 @@ ASTPtr StorageMaterializedPostgreSQL::getCreateNestedTableQuery(
                     for (const auto & child : columns->children)
                     {
                         const auto * column_declaration = child->as<ASTColumnDeclaration>();
-                        auto type = DataTypeFactory::instance().get(column_declaration->type);
+                        auto type = DataTypeFactory::instance().get(column_declaration->getType());
                         ordinary_columns_and_types.emplace_back(NameAndTypePair(column_declaration->name, type));
                     }
                 }

--- a/src/Storages/PostgreSQL/StorageMaterializedPostgreSQL.cpp
+++ b/src/Storages/PostgreSQL/StorageMaterializedPostgreSQL.cpp
@@ -311,7 +311,7 @@ boost::intrusive_ptr<ASTColumnDeclaration> StorageMaterializedPostgreSQL::getMat
     column_declaration->name = std::move(name);
     column_declaration->setType(makeASTDataType(type));
 
-    column_declaration->default_specifier = "MATERIALIZED";
+    column_declaration->default_specifier = ColumnDefaultSpecifier::Materialized;
     column_declaration->setDefaultExpression(make_intrusive<ASTLiteral>(default_value));
 
     return column_declaration;
@@ -352,7 +352,7 @@ StorageMaterializedPostgreSQL::getColumnsExpressionList(const NamesAndTypesList 
         if (auto it = defaults.find(name); it != defaults.end())
         {
             column_declaration->setDefaultExpression(std::move(it->second));
-            column_declaration->default_specifier = "DEFAULT";
+            column_declaration->default_specifier = ColumnDefaultSpecifier::Default;
         }
 
         columns_expression_list->children.emplace_back(column_declaration);

--- a/src/Storages/StatisticsDescription.h
+++ b/src/Storages/StatisticsDescription.h
@@ -2,7 +2,6 @@
 
 #include <DataTypes/IDataType.h>
 #include <Parsers/IAST_fwd.h>
-#include <Parsers/ASTColumnDeclaration.h>
 
 #include <base/types.h>
 

--- a/src/Storages/TimeSeries/TimeSeriesDefinitionNormalizer.cpp
+++ b/src/Storages/TimeSeries/TimeSeriesDefinitionNormalizer.cpp
@@ -278,9 +278,9 @@ void TimeSeriesDefinitionNormalizer::addMissingDefaultForIDColumn(ASTCreateQuery
     auto & column_declaration = typeid_cast<ASTColumnDeclaration &>(**it);
 
     /// We add a DEFAULT for the 'id' column only if it's not specified yet.
-    if (column_declaration.default_specifier.empty() && !column_declaration.getDefaultExpression())
+    if (column_declaration.default_specifier == ColumnDefaultSpecifier::Empty && !column_declaration.getDefaultExpression())
     {
-        column_declaration.default_specifier = "DEFAULT";
+        column_declaration.default_specifier = ColumnDefaultSpecifier::Default;
         column_declaration.setDefaultExpression(chooseIDAlgorithm(column_declaration));
     }
 }

--- a/src/Storages/TimeSeries/TimeSeriesDefinitionNormalizer.cpp
+++ b/src/Storages/TimeSeries/TimeSeriesDefinitionNormalizer.cpp
@@ -162,11 +162,11 @@ void TimeSeriesDefinitionNormalizer::addMissingColumns(ASTCreateQuery & create) 
         return false;
     };
 
-    auto make_new_column = [&](const String & column_name, ASTPtr type)
+    auto make_new_column = [&](const String & column_name, ASTPtr && type)
     {
         auto new_column = make_intrusive<ASTColumnDeclaration>();
         new_column->name = column_name;
-        new_column->type = type;
+        new_column->setType(std::move(type));
         columns.insert(columns.begin() + position, new_column);
         ++position;
     };
@@ -194,7 +194,7 @@ void TimeSeriesDefinitionNormalizer::addMissingColumns(ASTCreateQuery & create) 
         make_new_column(TimeSeriesColumnNames::Timestamp, get_datetime_type());
 
     auto timestamp_column = boost::static_pointer_cast<ASTColumnDeclaration>(columns[position - 1]);
-    auto timestamp_type = boost::static_pointer_cast<ASTDataType>(timestamp_column->type);
+    auto timestamp_type = boost::static_pointer_cast<ASTDataType>(timestamp_column->getType());
 
     if (!is_next_column_named(TimeSeriesColumnNames::Value))
         make_new_column(TimeSeriesColumnNames::Value, get_float_type());
@@ -278,10 +278,10 @@ void TimeSeriesDefinitionNormalizer::addMissingDefaultForIDColumn(ASTCreateQuery
     auto & column_declaration = typeid_cast<ASTColumnDeclaration &>(**it);
 
     /// We add a DEFAULT for the 'id' column only if it's not specified yet.
-    if (column_declaration.default_specifier.empty() && !column_declaration.default_expression)
+    if (column_declaration.default_specifier.empty() && !column_declaration.getDefaultExpression())
     {
         column_declaration.default_specifier = "DEFAULT";
-        column_declaration.default_expression = chooseIDAlgorithm(column_declaration);
+        column_declaration.setDefaultExpression(chooseIDAlgorithm(column_declaration));
     }
 }
 
@@ -320,7 +320,7 @@ ASTPtr TimeSeriesDefinitionNormalizer::chooseIDAlgorithm(const ASTColumnDeclarat
     };
 
     /// The type of a hash function depends on the type of the 'id' column.
-    auto id_type = DataTypeFactory::instance().get(id_column.type);
+    auto id_type = DataTypeFactory::instance().get(id_column.getType());
     WhichDataType id_type_which(*id_type);
 
     if (id_type_which.isUInt64())

--- a/src/Storages/WindowView/StorageWindowView.cpp
+++ b/src/Storages/WindowView/StorageWindowView.cpp
@@ -828,7 +828,7 @@ ASTPtr StorageWindowView::getInnerTableCreateQuery(const ASTPtr & inner_query, c
     {
         auto column_window = make_intrusive<ASTColumnDeclaration>();
         column_window->name = window_id_name;
-        column_window->type = makeASTDataType("UInt32");
+        column_window->setType(makeASTDataType("UInt32"));
         columns_list->children.push_back(column_window);
     }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Some optimizations to reduce IAST size in memory


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.875`
<!-- ch-version-info:end -->