### PR TITLE
Disable heavy 02473_multistep_prewhere with sanitizers

### DIFF
--- a/tests/queries/0_stateless/02473_multistep_prewhere.python
+++ b/tests/queries/0_stateless/02473_multistep_prewhere.python
@@ -1,6 +1,4 @@
 #!/usr/bin/env python3
-# Tags: long, no-parallel, no-msan, no-asan, no-flaky-check, no-tsan
-# ^ The test is heavy
 
 import os
 import sys

--- a/tests/queries/0_stateless/02473_multistep_prewhere.sh
+++ b/tests/queries/0_stateless/02473_multistep_prewhere.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Tags: long
+# Tags: long, no-parallel, no-msan, no-asan, no-flaky-check, no-tsan
+# ^ The test is heavy
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/02473_multistep_prewhere.sh
+++ b/tests/queries/0_stateless/02473_multistep_prewhere.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: long, no-parallel, no-msan, no-asan, no-flaky-check, no-tsan
+# Tags: long, no-parallel, no-sanitizers, no-flaky-check
 # ^ The test is heavy
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)


### PR DESCRIPTION
Tags should be in .sh not in .python

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.795`
<!-- ch-version-info:end -->