### PR TITLE
query view log duration

### DIFF
--- a/src/Common/ThreadStatus.h
+++ b/src/Common/ThreadStatus.h
@@ -130,7 +130,7 @@ public:
     UInt64 getGroupElapsedMs() const;
 
     void linkThread(UInt64 thread_id);
-    void unlinkThread(UInt64 elapsed_thread_counter_ms);
+    void unlinkThread();
 
 private:
     mutable std::mutex mutex;

--- a/src/Common/ThreadStatus.h
+++ b/src/Common/ThreadStatus.h
@@ -127,7 +127,7 @@ public:
 
     std::vector<UInt64> getInvolvedThreadIds() const;
     size_t getPeakThreadsUsage() const;
-    UInt64 getThreadsTotalElapsedMs() const;
+    UInt64 getGroupElapsedMs() const;
 
     void linkThread(UInt64 thread_id);
     void unlinkThread(UInt64 elapsed_thread_counter_ms);
@@ -147,7 +147,8 @@ private:
     /// Peak threads count in the group
     size_t peak_threads_usage TSA_GUARDED_BY(mutex) = 0;
 
-    UInt64 elapsed_total_threads_counter_ms TSA_GUARDED_BY(mutex) = 0;
+    Stopwatch effective_group_stopwatch TSA_GUARDED_BY(mutex);
+    UInt64 elapsed_group_ms TSA_GUARDED_BY(mutex) = 0;
 
     static ThreadGroupPtr create(ContextPtr context, Int32 os_threads_nice_value);
 };

--- a/src/Common/ThreadStatus.h
+++ b/src/Common/ThreadStatus.h
@@ -147,7 +147,7 @@ private:
     /// Peak threads count in the group
     size_t peak_threads_usage TSA_GUARDED_BY(mutex) = 0;
 
-    Stopwatch effective_group_stopwatch TSA_GUARDED_BY(mutex);
+    Stopwatch effective_group_stopwatch TSA_GUARDED_BY(mutex) = Stopwatch(STOPWATCH_DEFAULT_CLOCK, 0, /* is running */ false);
     UInt64 elapsed_group_ms TSA_GUARDED_BY(mutex) = 0;
 
     static ThreadGroupPtr create(ContextPtr context, Int32 os_threads_nice_value);

--- a/src/Interpreters/InsertDependenciesBuilder.cpp
+++ b/src/Interpreters/InsertDependenciesBuilder.cpp
@@ -1499,7 +1499,7 @@ void InsertDependenciesBuilder::logQueryView(StorageID view_id, std::exception_p
     const auto & view_type = view_types.at(view_id);
     const auto & inner_table_id = inner_tables.at(view_id);
 
-    UInt64 elapsed_ms = thread_group->getThreadsTotalElapsedMs();
+    UInt64 elapsed_ms = thread_group->getGroupElapsedMs();
 
     UInt64 min_query_duration = settings[Setting::log_queries_min_query_duration_ms].totalMilliseconds();
     if (min_query_duration && elapsed_ms <= min_query_duration)

--- a/src/Interpreters/ThreadStatusExt.cpp
+++ b/src/Interpreters/ThreadStatusExt.cpp
@@ -124,10 +124,10 @@ size_t ThreadGroup::getPeakThreadsUsage() const
     return peak_threads_usage;
 }
 
-UInt64 ThreadGroup::getThreadsTotalElapsedMs() const
+UInt64 ThreadGroup::getGroupElapsedMs() const
 {
     std::lock_guard lock(mutex);
-    return elapsed_total_threads_counter_ms;
+    return elapsed_group_ms;
 }
 
 void ThreadGroup::linkThread(UInt64 thread_id)
@@ -135,16 +135,21 @@ void ThreadGroup::linkThread(UInt64 thread_id)
     std::lock_guard lock(mutex);
     thread_ids.insert(thread_id);
 
+    if (active_thread_count == 0)
+        effective_group_stopwatch.restart();
+
     ++active_thread_count;
     peak_threads_usage = std::max(peak_threads_usage, active_thread_count);
 }
 
-void ThreadGroup::unlinkThread(UInt64 elapsed_thread_counter_ms)
+void ThreadGroup::unlinkThread(UInt64 /*elapsed_thread_counter_ms*/)
 {
     std::lock_guard lock(mutex);
     chassert(active_thread_count > 0);
     --active_thread_count;
-    elapsed_total_threads_counter_ms += elapsed_thread_counter_ms;
+
+    if (active_thread_count == 0)
+        elapsed_group_ms += effective_group_stopwatch.elapsedMilliseconds();
 }
 
 ThreadGroupPtr ThreadGroup::createForQuery(ContextPtr query_context_, std::function<void()> fatal_error_callback_)

--- a/src/Interpreters/ThreadStatusExt.cpp
+++ b/src/Interpreters/ThreadStatusExt.cpp
@@ -142,7 +142,7 @@ void ThreadGroup::linkThread(UInt64 thread_id)
     peak_threads_usage = std::max(peak_threads_usage, active_thread_count);
 }
 
-void ThreadGroup::unlinkThread(UInt64 /*elapsed_thread_counter_ms*/)
+void ThreadGroup::unlinkThread()
 {
     std::lock_guard lock(mutex);
     chassert(active_thread_count > 0);
@@ -408,7 +408,7 @@ void ThreadStatus::detachFromGroup()
     /// Extract MemoryTracker out from query and user context
     memory_tracker.setParent(&total_memory_tracker);
 
-    thread_group->unlinkThread(thread_attach_time.elapsedMilliseconds());
+    thread_group->unlinkThread();
 
     if (thread_group->os_threads_nice_value != 0)
     {


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
now `view_duration_ms` shows the time when group was active, not the sum of the threads duration in it.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.877`
- Backported to: `25.12.5.31`, `25.11.9.4`, `25.10.6.29`, `25.8.16.24`
<!-- ch-version-info:end -->