### PR TITLE
fix(old-analyzer): don't add pre-limit step if there is fractional limit/offset

### DIFF
--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -1794,7 +1794,15 @@ void InterpreterSelectQuery::executeImpl(QueryPlan & query_plan, std::optional<P
 
                 /// WITH TIES simply not supported properly for preliminary steps, so let's disable it.
                 if (query.limitLength() && !query.limitBy() && !query.limit_with_ties)
-                    executePreLimit(query_plan, true);
+                {
+                    /// Preliminary Limits mustn't be added if there is a fractional limit/offset
+                    /// because in order to correctly calculate the number of rows to be produced
+                    /// based on the given fraction the final limit/offset processor must count the entire dataset.
+                    /// For example, LIMIT 0.1 and 30 rows in the sources - we must read all 30 rows to calculate that rows_cnt * 0.1 = 3.
+                    LimitInfo lim_info = getLimitLengthAndOffset(query, context);
+                    if (lim_info.fractional_offset == 0 && lim_info.fractional_limit == 0)
+                        executePreLimit(query_plan, true);
+                }
             }
         };
 

--- a/tests/queries/0_stateless/03681_distributed_fractional_limit_offset.reference
+++ b/tests/queries/0_stateless/03681_distributed_fractional_limit_offset.reference
@@ -24,3 +24,11 @@ New Analyzer
 99
 99
 99
+Old Analyzer - Distributed Table
+
+0	18	1
+0	18	3
+New Analyzer - Distributed Table
+
+0	18	1
+0	18	3

--- a/tests/queries/0_stateless/03681_distributed_fractional_limit_offset.sql
+++ b/tests/queries/0_stateless/03681_distributed_fractional_limit_offset.sql
@@ -22,9 +22,10 @@ SELECT number from remote('127.0.0.{1,2,3}', numbers_mt(100)) ORDER BY number LI
 
 SELECT number from remote('127.0.0.{1,2,3}', numbers_mt(100)) ORDER BY number LIMIT 0.01 OFFSET 297;
 
-SELECT 'Old Analyzer - Distributed Table';
+-- Distributed Table
 
-SET enable_analyzer=0;
+SET extremes = 1;
+SET prefer_localhost_replica = 0;
 
 DROP TABLE IF EXISTS test__fuzz_2_local;
 DROP TABLE IF EXISTS test__fuzz_2_dist;
@@ -42,9 +43,9 @@ INSERT INTO test__fuzz_2_local VALUES (1),(2),(3);
 CREATE TABLE test__fuzz_2_dist AS test__fuzz_2_local
 ENGINE = Distributed(test_cluster_two_shards, currentDatabase(), test__fuzz_2_local, rand());
 
+SELECT 'Old Analyzer - Distributed Table';
+
 SET enable_analyzer = 0;
-SET extremes = 1;
-SET prefer_localhost_replica = 0;
 
 SELECT 0 AS `0`, 18 AS `18`, __table1.k AS k
 FROM test__fuzz_2_dist AS __table1
@@ -52,11 +53,9 @@ PREWHERE _CAST(11, 'Nullable(UInt8)')
 ORDER BY __table1.k DESC NULLS LAST
 LIMIT 0.9999, _CAST(100, 'UInt64');
 
-SET extremes = 0;
 SELECT 'New Analyzer - Distributed Table';
 
 SET enable_analyzer = 1;
-SET extremes = 1;
 
 SELECT 0 AS `0`, 18 AS `18`, __table1.k AS k
 FROM test__fuzz_2_dist AS __table1

--- a/tests/queries/0_stateless/03681_distributed_fractional_limit_offset.sql
+++ b/tests/queries/0_stateless/03681_distributed_fractional_limit_offset.sql
@@ -24,7 +24,6 @@ SELECT number from remote('127.0.0.{1,2,3}', numbers_mt(100)) ORDER BY number LI
 
 -- Distributed Table
 
-SET extremes = 1;
 SET prefer_localhost_replica = 0;
 
 DROP TABLE IF EXISTS test__fuzz_2_local;
@@ -46,6 +45,7 @@ ENGINE = Distributed(test_cluster_two_shards, currentDatabase(), test__fuzz_2_lo
 SELECT 'Old Analyzer - Distributed Table';
 
 SET enable_analyzer = 0;
+SET extremes = 1;
 
 SELECT 0 AS `0`, 18 AS `18`, __table1.k AS k
 FROM test__fuzz_2_dist AS __table1
@@ -53,9 +53,11 @@ PREWHERE _CAST(11, 'Nullable(UInt8)')
 ORDER BY __table1.k DESC NULLS LAST
 LIMIT 0.9999, _CAST(100, 'UInt64');
 
+SET extremes = 0;
 SELECT 'New Analyzer - Distributed Table';
 
 SET enable_analyzer = 1;
+SET extremes = 1;
 
 SELECT 0 AS `0`, 18 AS `18`, __table1.k AS k
 FROM test__fuzz_2_dist AS __table1

--- a/tests/queries/0_stateless/03681_distributed_fractional_limit_offset.sql
+++ b/tests/queries/0_stateless/03681_distributed_fractional_limit_offset.sql
@@ -21,3 +21,45 @@ SELECT number from remote('127.0.0.{1,2,3}', numbers_mt(100)) ORDER BY number LI
 SELECT number from remote('127.0.0.{1,2,3}', numbers_mt(100)) ORDER BY number LIMIT 3 OFFSET 0.9;
 
 SELECT number from remote('127.0.0.{1,2,3}', numbers_mt(100)) ORDER BY number LIMIT 0.01 OFFSET 297;
+
+SELECT 'Old Analyzer - Distributed Table';
+
+SET enable_analyzer=0;
+
+DROP TABLE IF EXISTS test__fuzz_2_local;
+DROP TABLE IF EXISTS test__fuzz_2_dist;
+
+CREATE TABLE test__fuzz_2_local
+(
+    k UInt64
+)
+ENGINE = MergeTree
+ORDER BY k
+SETTINGS index_granularity = 1;
+
+INSERT INTO test__fuzz_2_local VALUES (1),(2),(3);
+
+CREATE TABLE test__fuzz_2_dist AS test__fuzz_2_local
+ENGINE = Distributed(test_cluster_two_shards, currentDatabase(), test__fuzz_2_local, rand());
+
+SET enable_analyzer = 0;
+SET extremes = 1;
+SET prefer_localhost_replica = 0;
+
+SELECT 0 AS `0`, 18 AS `18`, __table1.k AS k
+FROM test__fuzz_2_dist AS __table1
+PREWHERE _CAST(11, 'Nullable(UInt8)')
+ORDER BY __table1.k DESC NULLS LAST
+LIMIT 0.9999, _CAST(100, 'UInt64');
+
+SET extremes = 0;
+SELECT 'New Analyzer - Distributed Table';
+
+SET enable_analyzer = 1;
+SET extremes = 1;
+
+SELECT 0 AS `0`, 18 AS `18`, __table1.k AS k
+FROM test__fuzz_2_dist AS __table1
+PREWHERE _CAST(11, 'Nullable(UInt8)')
+ORDER BY __table1.k DESC NULLS LAST
+LIMIT 0.9999, _CAST(100, 'UInt64');


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix logical error in fractional `LIMIT/OFFSET` when using the old analyzer with Distributed tables. Closes https://github.com/ClickHouse/ClickHouse/issues/94712.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

Closes #94712 


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.807`
- Backported to: `25.12.5.15`, `25.11.8.15`
<!-- ch-version-info:end -->