### PR TITLE
Fix crash caused by uninitialized RuntimeFilterLookup

### DIFF
--- a/src/Functions/FunctionApplyFilter.cpp
+++ b/src/Functions/FunctionApplyFilter.cpp
@@ -85,6 +85,8 @@ public:
         /// Query context contains filter lookup where per-query filters are stored
         auto query_context = CurrentThread::get().getQueryContext();
         auto filter_lookup = query_context->getRuntimeFilterLookup();
+        if (!filter_lookup)
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Runtime filter lookup was not initialized");
         auto filter = filter_lookup->find(filter_name);
 
         /// If filter is not present all rows pass

--- a/src/Functions/FunctionApplyFilter.cpp
+++ b/src/Functions/FunctionApplyFilter.cpp
@@ -19,6 +19,7 @@ namespace ErrorCodes
 {
     extern const int ILLEGAL_TYPE_OF_ARGUMENT;
     extern const int TOO_FEW_ARGUMENTS_FOR_FUNCTION;
+    extern const int LOGICAL_ERROR;
 }
 
 class FunctionApplyFilter : public IFunction

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -1177,6 +1177,7 @@ ContextData::ContextData(const ContextData &o) :
     classifier(o.classifier),
     prepared_sets_cache(o.prepared_sets_cache),
     offset_parallel_replicas_enabled(o.offset_parallel_replicas_enabled),
+    runtime_filter_lookup(o.runtime_filter_lookup),
     kitchen_sink(o.kitchen_sink),
     part_uuids(o.part_uuids),
     ignored_part_uuids(o.ignored_part_uuids),


### PR DESCRIPTION
This crash reproduced in CI on a query that has MV with a JOIN attached to a system table in test `01360_materialized_view_with_join_on_query_log` when runtime filters are enabled by default
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=89314&sha=latest&name_0=PR
https://github.com/ClickHouse/ClickHouse/pull/89314

Stacktrace:
```
./ci/tmp/build/./src/Functions/FunctionApplyFilter.cpp:88: DB::FunctionApplyFilter::executeImpl(std::vector<DB::ColumnWithTypeAndName, std::allocator<DB::ColumnWithTypeAndName>> const&, std::shared_ptr<DB::IDataType const> const&, unsigned long) const @ 0x000000000b07486d
./src/Functions/IFunction.h:465: DB::IFunction::executeImplDryRun(std::vector<DB::ColumnWithTypeAndName, std::allocator<DB::ColumnWithTypeAndName>> const&, std::shared_ptr<DB::IDataType const> const&, unsigned long) const @ 0x000000000b07024a
./ci/tmp/build/./src/Functions/IFunctionAdaptors.cpp:16: DB::FunctionToExecutableFunctionAdaptor::executeDryRunImpl(std::vector<DB::ColumnWithTypeAndName, std::allocator<DB::ColumnWithTypeAndName>> const&, std::shared_ptr<DB::IDataType const> const&, unsigned long) const @ 0x0000000017219dfa
./ci/tmp/build/./src/Functions/IFunction.cpp:363: DB::IExecutableFunction::executeWithoutLowCardinalityColumns(std::vector<DB::ColumnWithTypeAndName, std::allocator<DB::ColumnWithTypeAndName>> const&, std::shared_ptr<DB::IDataType const> const&, unsigned long, bool) const @ 0x0000000017211a32
./ci/tmp/build/./src/Functions/IFunction.cpp:438: DB::IExecutableFunction::executeWithoutSparseColumns(std::vector<DB::ColumnWithTypeAndName, std::allocator<DB::ColumnWithTypeAndName>> const&, std::shared_ptr<DB::IDataType const> const&, unsigned long, bool) const @ 0x0000000017212e65
./ci/tmp/build/./src/Functions/IFunction.cpp:577: DB::IExecutableFunction::executeWithoutReplicatedColumns(std::vector<DB::ColumnWithTypeAndName, std::allocator<DB::ColumnWithTypeAndName>> const&, std::shared_ptr<DB::IDataType const> const&, unsigned long, bool) const @ 0x0000000017214515
./ci/tmp/build/./src/Functions/IFunction.cpp:486: DB::IExecutableFunction::execute(std::vector<DB::ColumnWithTypeAndName, std::allocator<DB::ColumnWithTypeAndName>> const&, std::shared_ptr<DB::IDataType const> const&, unsigned long, bool) const @ 0x0000000017213f49
./ci/tmp/build/./src/Interpreters/ActionsDAG.cpp:895: DB::executeActionForPartialResult(DB::ActionsDAG::Node const*, std::vector<DB::ColumnWithTypeAndName, std::allocator<DB::ColumnWithTypeAndName>>, unsigned long, bool) @ 0x00000000186ec435
./ci/tmp/build/./src/Interpreters/ActionsDAG.cpp:1106: DB::ActionsDAG::evaluatePartialResult(std::unordered_map<DB::ActionsDAG::Node const*, DB::ColumnWithTypeAndName, std::hash<DB::ActionsDAG::Node const*>, std::equal_to<DB::ActionsDAG::Node const*>, std::allocator<std::pair<DB::ActionsDAG::Node const* const, DB::ColumnWithTypeAndName>>>&, std::vector<DB::ActionsDAG::Node const*, std::allocator<DB::ActionsDAG::Node const*>> const&, unsigned long, DB::PartialEvaluationParameters) @ 0x00000000186eb389
./ci/tmp/build/./src/Interpreters/ActionsDAG.cpp:995: DB::ActionsDAG::updateHeader(DB::Block const&) const @ 0x00000000186e9f94
./ci/tmp/build/./src/Processors/Transforms/FilterTransform.cpp:52: DB::FilterTransform::transformHeader(DB::Block const&, DB::ActionsDAG const*, String const&, bool) @ 0x000000001cd09d68
./ci/tmp/build/./src/Processors/QueryPlan/FilterStep.cpp:129: DB::FilterStep::FilterStep(std::shared_ptr<DB::Block const> const&, DB::ActionsDAG, String, bool) @ 0x000000001cf061e5
./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:759: std::unique_ptr<DB::FilterStep, std::default_delete<DB::FilterStep>> std::make_unique[abi:ne210105]<DB::FilterStep, std::shared_ptr<DB::Block const> const&, DB::ActionsDAG, String&, bool, 0>(std::shared_ptr<DB::Block const> const&, DB::ActionsDAG&&, String&, bool&&) @ 0x000000001bbae5d5
./ci/tmp/build/./src/Processors/QueryPlan/Optimizations/joinRuntimeFilter.cpp:248: DB::QueryPlanOptimizations::tryAddJoinRuntimeFilter(DB::QueryPlan::Node&, std::list<DB::QueryPlan::Node, std::allocator<DB::QueryPlan::Node>>&, DB::QueryPlanOptimizationSettings const&) @ 0x000000001d0a343a
inlined from ./ci/tmp/build/./src/Processors/QueryPlan/Optimizations/optimizeTree.cpp:537: operator()<DB::QueryPlan::Node>
inlined from ./ci/tmp/build/./src/Processors/QueryPlan/Optimizations/optimizeTree.cpp:194: void DB::QueryPlanOptimizations::traverseQueryPlan<DB::QueryPlanOptimizations::optimizeTreeSecondPass(DB::QueryPlanOptimizationSettings const&, DB::QueryPlan::Node&, std::list<DB::QueryPlan::Node, std::allocator<DB::QueryPlan::Node>>&, DB::QueryPlan&)::$_2, DB::QueryPlanOptimizations::optimizeTreeSecondPass(DB::QueryPlanOptimizationSettings const&, DB::QueryPlan::Node&, std::list<DB::QueryPlan::Node, std::allocator<DB::QueryPlan::Node>>&, DB::QueryPlan&)::$_3>(std::vector<DB::QueryPlanOptimizations::Frame, std::allocator<DB::QueryPlanOptimizations::Frame>>&, DB::QueryPlan::Node&, DB::QueryPlanOptimizations::optimizeTreeSecondPass(DB::QueryPlanOptimizationSettings const&, DB::QueryPlan::Node&, std::list<DB::QueryPlan::Node, std::allocator<DB::QueryPlan::Node>>&, DB::QueryPlan&)::$_2&&, DB::QueryPlanOptimizations::optimizeTreeSecondPass(DB::QueryPlanOptimizationSettings const&, DB::QueryPlan::Node&, std::list<DB::QueryPlan::Node, std::allocator<DB::QueryPlan::Node>>&, DB::QueryPlan&)::$_3&&)
./ci/tmp/build/./src/Processors/QueryPlan/Optimizations/optimizeTree.cpp:527: DB::QueryPlanOptimizations::optimizeTreeSecondPass(DB::QueryPlanOptimizationSettings const&, DB::QueryPlan::Node&, std::list<DB::QueryPlan::Node, std::allocator<DB::QueryPlan::Node>>&, DB::QueryPlan&) @ 0x000000001d05c4a9
./ci/tmp/build/./src/Processors/QueryPlan/QueryPlan.cpp:580: DB::QueryPlan::optimize(DB::QueryPlanOptimizationSettings const&) @ 0x000000001cf5c44a
./ci/tmp/build/./src/Processors/QueryPlan/QueryPlan.cpp:182: DB::QueryPlan::buildQueryPipeline(DB::QueryPlanOptimizationSettings const&, DB::BuildQueryPipelineSettings const&, bool) @ 0x000000001cf5b98d
./ci/tmp/build/./src/Interpreters/InterpreterSelectQueryAnalyzer.cpp:375: DB::InterpreterSelectQueryAnalyzer::buildQueryPipeline() @ 0x000000001936d90c
./ci/tmp/build/./src/Interpreters/InsertDependenciesBuilder.cpp:610: DB::ExecutingInnerQueryFromViewTransform<DB::PullingPipelineExecutor>::process(DB::Block, DB::CollectionOfDerivedItems<DB::ChunkInfo>&&) @ 0x00000000192af99d
./ci/tmp/build/./src/Interpreters/InsertDependenciesBuilder.cpp:544: DB::ExecutingInnerQueryFromViewTransform<DB::PullingPipelineExecutor>::onConsume(DB::Chunk) @ 0x00000000192af0c0
inlined from ./ci/tmp/build/./src/Processors/Transforms/ExceptionKeepingTransform.cpp:136: operator()
inlined from ./contrib/llvm-project/libcxx/include/__type_traits/invoke.h:87: std::__invoke_result_impl<void, DB::ExceptionKeepingTransform::work()::$_1&>::type std::__invoke[abi:ne210105]<DB::ExceptionKeepingTransform::work()::$_1&>(DB::ExceptionKeepingTransform::work()::$_1&)
inlined from ./contrib/llvm-project/libcxx/include/__type_traits/invoke.h:342: void std::__invoke_void_return_wrapper<void, true>::__call[abi:ne210105]<DB::ExceptionKeepingTransform::work()::$_1&>(DB::ExceptionKeepingTransform::work()::$_1&)
inlined from ./contrib/llvm-project/libcxx/include/__type_traits/invoke.h:348: void std::__invoke_r[abi:ne210105]<void, DB::ExceptionKeepingTransform::work()::$_1&>(DB::ExceptionKeepingTransform::work()::$_1&)
./contrib/llvm-project/libcxx/include/__functional/function.h:450: ? @ 0x000000001cd06c01
inlined from ./contrib/llvm-project/libcxx/include/__functional/function.h:508: ?
inlined from ./contrib/llvm-project/libcxx/include/__functional/function.h:772: ?
./ci/tmp/build/./src/Processors/Transforms/ExceptionKeepingTransform.cpp:105: DB::runStep(std::function<void ()>, std::shared_ptr<DB::ThreadGroup>&) @ 0x000000001cd06a00
./ci/tmp/build/./src/Processors/Transforms/ExceptionKeepingTransform.cpp:136: DB::ExceptionKeepingTransform::work() @ 0x000000001cd0629c
inlined from ./ci/tmp/build/./src/Processors/Executors/ExecutionThreadContext.cpp:53: DB::executeJob(DB::ExecutingGraph::Node*, DB::ReadProgressCallback*)
./ci/tmp/build/./src/Processors/Executors/ExecutionThreadContext.cpp:102: DB::ExecutionThreadContext::executeTask() @ 0x000000001ca78360
./ci/tmp/build/./src/Processors/Executors/PipelineExecutor.cpp:351: DB::PipelineExecutor::executeStepImpl(unsigned long, DB::IAcquiredSlot*, std::atomic<bool>*) @ 0x000000001ca6b56e
./ci/tmp/build/./src/Processors/Executors/PipelineExecutor.cpp:179: DB::PipelineExecutor::executeStep(std::atomic<bool>*) @ 0x000000001ca6b1c3
./ci/tmp/build/./src/Interpreters/SystemLog.cpp:705: DB::SystemLog<DB::QueryLogElement>::flushImpl(std::vector<DB::QueryLogElement, std::allocator<DB::QueryLogElement>> const&, unsigned long) @ 0x000000001950abfd
./ci/tmp/build/./src/Interpreters/SystemLog.cpp:616: DB::SystemLog<DB::QueryLogElement>::savingThreadFunction() @ 0x0000000019509ea2
inlined from ./ci/tmp/build/./src/Common/SystemLogBase.cpp:300: operator()
inlined from ./contrib/llvm-project/libcxx/include/__type_traits/invoke.h:87: std::__invoke_result_impl<void, DB::SystemLogBase<DB::QueryLogElement>::startup()::'lambda'()&>::type std::__invoke[abi:ne210105]<DB::SystemLogBase<DB::QueryLogElement>::startup()::'lambda'()&>(DB::SystemLogBase<DB::QueryLogElement>::startup()::'lambda'()&)
inlined from ./contrib/llvm-project/libcxx/include/tuple:1380: decltype(auto) std::__apply_tuple_impl[abi:ne210105]<DB::SystemLogBase<DB::QueryLogElement>::startup()::'lambda'()&, std::tuple<>&>(DB::SystemLogBase<DB::QueryLogElement>::startup()::'lambda'()&, std::tuple<>&, std::__tuple_indices<...>)
inlined from ./contrib/llvm-project/libcxx/include/tuple:1384: decltype(auto) std::apply[abi:ne210105]<DB::SystemLogBase<DB::QueryLogElement>::startup()::'lambda'()&, std::tuple<>&>(DB::SystemLogBase<DB::QueryLogElement>::startup()::'lambda'()&, std::tuple<>&)
./src/Common/ThreadPool.h:312: ThreadFromGlobalPoolImpl<true, true>::ThreadFromGlobalPoolImpl<DB::SystemLogBase<DB::QueryLogElement>::startup()::'lambda'()>(DB::SystemLogBase<DB::QueryLogElement>::startup()::'lambda'()&&)::'lambda'()::operator()() @ 0x00000000136b5d0c
inlined from ./contrib/llvm-project/libcxx/include/__functional/function.h:508: ?
inlined from ./contrib/llvm-project/libcxx/include/__functional/function.h:772: ?
./ci/tmp/build/./src/Common/ThreadPool.cpp:811: ThreadPoolImpl<std::thread>::ThreadFromThreadPool::worker() @ 0x000000001365e8f5
inlined from ./contrib/llvm-project/libcxx/include/__type_traits/invoke.h:0: std::__invoke_result_impl<void, void (ThreadPoolImpl<std::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::thread>::ThreadFromThreadPool*>::type std::__invoke[abi:ne210105]<void (ThreadPoolImpl<std::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::thread>::ThreadFromThreadPool*>(void (ThreadPoolImpl<std::thread>::ThreadFromThreadPool::*&&)(), ThreadPoolImpl<std::thread>::ThreadFromThreadPool*&&)
inlined from ./contrib/llvm-project/libcxx/include/__thread/thread.h:159: void std::__thread_execute[abi:ne210105]<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void (ThreadPoolImpl<std::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::thread>::ThreadFromThreadPool*, 2ul>(std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void (ThreadPoolImpl<std::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::thread>::ThreadFromThreadPool*>&, std::__tuple_indices<2ul>)
./contrib/llvm-project/libcxx/include/__thread/thread.h:168: void* std::__thread_proxy[abi:ne210105]<std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void (ThreadPoolImpl<std::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::thread>::ThreadFromThreadPool*>>(void*) @ 0x000000001366417b
? @ 0x0000000000094ac3
? @ 0x00000000001268c0
```


### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix crash under some conditions when join runtime filters are enabled by default.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.804`
- Backported to: `25.12.5.13`, `25.11.8.22`, `25.10.6.22`
<!-- ch-version-info:end -->