### PR TITLE
Start check thread only in restarting thread

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreePartCheckThread.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreePartCheckThread.cpp
@@ -39,7 +39,7 @@ ReplicatedMergeTreePartCheckThread::ReplicatedMergeTreePartCheckThread(StorageRe
     , log(getLogger(log_name))
     , pausable_task(storage.getContext()->getSchedulePool().createTask(storage.getStorageID(), log_name, [this] { run(); }))
 {
-    getTask()->schedule();
+    getTask()->deactivate();
 }
 
 ReplicatedMergeTreePartCheckThread::~ReplicatedMergeTreePartCheckThread()


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
If the table was not started due to a broken zk metadata check, the check thread should not be run. I was debugging this https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=94977&sha=latest&name_0=PR,
https://github.com/ClickHouse/ClickHouse/pull/94977 and exactly in this case, the problem is that during the restore metadata query, `CONNECTION_LOSS` error was thrown, which triggered background parts check from the sink, and because the check thread was enabled in this configuration, eventually got into this logical error.

Fixes: https://github.com/ClickHouse/ClickHouse/issues/59327


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.810`
<!-- ch-version-info:end -->