### PR TITLE
Preserve constant index granularity (use_const_adaptive_granularity) after Vertical merges (v2 with a fix for Nested, and in general)

### DIFF
--- a/src/Storages/MergeTree/IMergeTreeDataPartWriter.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPartWriter.cpp
@@ -1,9 +1,11 @@
 #include <Columns/ColumnSparse.h>
 #include <Compression/CompressionFactory.h>
 #include <Storages/MergeTree/IMergeTreeDataPartWriter.h>
+#include <Storages/MergeTree/IMergedBlockOutputStream.h>
 #include <Storages/MergeTree/MergeTreeIndexGranularity.h>
 #include <Storages/MergeTree/MergeTreeSettings.h>
 #include <Storages/StorageInMemoryMetadata.h>
+#include <base/defines.h>
 #include <Common/MemoryTrackerBlockerInThread.h>
 
 namespace DB
@@ -176,7 +178,8 @@ MergeTreeDataPartWriterPtr createMergeTreeDataPartWideWriter(
         const String & marks_file_extension_,
         const CompressionCodecPtr & default_codec_,
         const MergeTreeWriterSettings & writer_settings,
-        MergeTreeIndexGranularityPtr computed_index_granularity);
+        MergeTreeIndexGranularityPtr computed_index_granularity,
+        WrittenOffsetSubstreams * written_offset_substreams);
 
 MergeTreeDataPartWriterPtr createMergeTreeDataPartWriter(
         MergeTreeDataPartType part_type,
@@ -195,7 +198,8 @@ MergeTreeDataPartWriterPtr createMergeTreeDataPartWriter(
         const String & marks_file_extension_,
         const CompressionCodecPtr & default_codec_,
         const MergeTreeWriterSettings & writer_settings,
-        MergeTreeIndexGranularityPtr computed_index_granularity)
+        MergeTreeIndexGranularityPtr computed_index_granularity,
+        WrittenOffsetSubstreams * written_offset_substreams)
 {
     if (part_type == MergeTreeDataPartType::Compact)
         return createMergeTreeDataPartCompactWriter(
@@ -231,7 +235,8 @@ MergeTreeDataPartWriterPtr createMergeTreeDataPartWriter(
             marks_file_extension_,
             default_codec_,
             writer_settings,
-            std::move(computed_index_granularity));
+            std::move(computed_index_granularity),
+            written_offset_substreams);
     throw Exception(ErrorCodes::LOGICAL_ERROR, "Unknown part type: {}", part_type.toString());
 }
 

--- a/src/Storages/MergeTree/IMergeTreeDataPartWriter.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPartWriter.h
@@ -20,6 +20,8 @@ using IColumnPermutation = PaddedPODArray<size_t>;
 struct MergeTreeSettings;
 using MergeTreeSettingsPtr = std::shared_ptr<const MergeTreeSettings>;
 
+using WrittenOffsetSubstreams = std::set<std::string>;
+
 Block getIndexBlockAndPermute(const Block & block, const Names & names, const IColumnPermutation * permutation);
 
 Block permuteBlockIfNeeded(const Block & block, const IColumnPermutation * permutation);
@@ -109,6 +111,7 @@ MergeTreeDataPartWriterPtr createMergeTreeDataPartWriter(
         const String & marks_file_extension,
         const CompressionCodecPtr & default_codec_,
         const MergeTreeWriterSettings & writer_settings,
-        MergeTreeIndexGranularityPtr computed_index_granularity);
+        MergeTreeIndexGranularityPtr computed_index_granularity,
+        WrittenOffsetSubstreams * written_offset_substreams);
 
 }

--- a/src/Storages/MergeTree/IMergeTreeDataPartWriter.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPartWriter.h
@@ -45,6 +45,7 @@ public:
 
     virtual void write(const Block & block, const IColumnPermutation * permutation) = 0;
 
+    virtual void finalizeIndexGranularity() = 0;
     virtual void fillChecksums(MergeTreeDataPartChecksums & checksums, NameSet & checksums_to_remove) = 0;
 
     virtual void finish(bool sync) = 0;

--- a/src/Storages/MergeTree/IMergedBlockOutputStream.h
+++ b/src/Storages/MergeTree/IMergedBlockOutputStream.h
@@ -25,8 +25,6 @@ public:
 
     virtual ~IMergedBlockOutputStream() = default;
 
-    using WrittenOffsetColumns = std::set<std::string>;
-
     virtual void write(const Block & block) = 0;
     virtual void cancel() noexcept = 0;
 

--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -2449,8 +2449,6 @@ void MergeTask::ExecuteAndFinalizeHorizontalPart::createMergedStream() const
         }
 
         const bool is_vertical_merge = (global_ctx->chosen_merge_algorithm == MergeAlgorithm::Vertical);
-        /// If merge is vertical we cannot calculate it
-        ctx->blocks_are_granules_size = is_vertical_merge;
 
         if (global_ctx->cleanup && !(*merge_tree_settings)[MergeTreeSetting::allow_experimental_replacing_merge_with_cleanup])
             throw Exception(ErrorCodes::SUPPORT_IS_DISABLED, "Experimental merges with CLEANUP are not allowed");
@@ -2474,7 +2472,7 @@ void MergeTask::ExecuteAndFinalizeHorizontalPart::createMergedStream() const
             (*merge_tree_settings)[MergeTreeSetting::merge_max_block_size],
             (*merge_tree_settings)[MergeTreeSetting::merge_max_block_size_bytes],
             max_dynamic_subcolumns,
-            ctx->blocks_are_granules_size,
+            is_vertical_merge,
             cleanup,
             global_ctx->time_of_merge);
 

--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -1133,6 +1133,7 @@ bool MergeTask::ExecuteAndFinalizeHorizontalPart::executeImpl() const
 void MergeTask::ExecuteAndFinalizeHorizontalPart::finalize() const
 {
     finalizeProjections();
+    global_ctx->to->finalizeIndexGranularity();
     global_ctx->merging_executor.reset();
     global_ctx->merged_pipeline.reset();
 
@@ -1437,6 +1438,7 @@ void MergeTask::VerticalMergeStage::finalizeVerticalMergeForOneColumn() const
     global_ctx->checkOperationIsNotCanceled();
 
     ctx->executor.reset();
+    ctx->column_to->finalizeIndexGranularity();
     auto changed_checksums = ctx->column_to->fillChecksums(global_ctx->new_data_part, global_ctx->checksums_gathered_columns);
     global_ctx->checksums_gathered_columns.add(std::move(changed_checksums));
     const auto & columns_substreams = ctx->column_to->getColumnsSubstreams();

--- a/src/Storages/MergeTree/MergeTask.h
+++ b/src/Storages/MergeTree/MergeTask.h
@@ -250,7 +250,7 @@ private:
 
         std::promise<MergeTreeData::MutableDataPartPtr> promise{};
 
-        IMergedBlockOutputStream::WrittenOffsetColumns written_offset_columns{};
+        WrittenOffsetSubstreams written_offset_substreams{};
         PlainMarksByName cached_marks;
 
         MergeTreeTransactionPtr txn;

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -10377,6 +10377,7 @@ std::pair<MergeTreeData::MutableDataPartPtr, scope_guard> MergeTreeData::createE
 
     out.write(block);
     /// Here is no projections as no data inside
+    out.finalizeIndexGranularity();
     out.finalizePart(new_data_part, sync_on_insert);
 
     new_data_part_storage->precommitTransaction();

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -10371,7 +10371,11 @@ std::pair<MergeTreeData::MutableDataPartPtr, scope_guard> MergeTreeData::createE
         compression_codec,
         std::make_shared<MergeTreeIndexGranularityAdaptive>(),
         txn ? txn->tid : Tx::PrehistoricTID,
-        /*part_uncompressed_bytes=*/ 0);
+        /*part_uncompressed_bytes=*/ 0,
+        /*reset_columns_=*/ false,
+        /*blocks_are_granules_size=*/ false,
+        /*write_settings=*/ {},
+        /*written_offset_substreams=*/ nullptr);
 
     bool sync_on_insert = (*settings)[MergeTreeSetting::fsync_after_insert];
 

--- a/src/Storages/MergeTree/MergeTreeDataPartWide.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartWide.cpp
@@ -1,3 +1,4 @@
+#include <Storages/MergeTree/IMergedBlockOutputStream.h>
 #include <Storages/MergeTree/MergeTreeDataPartWide.h>
 #include <Storages/MergeTree/MergeTreeReaderWide.h>
 #include <Storages/MergeTree/MergeTreeDataPartWriterWide.h>
@@ -86,14 +87,16 @@ MergeTreeDataPartWriterPtr createMergeTreeDataPartWideWriter(
     const String & marks_file_extension_,
     const CompressionCodecPtr & default_codec_,
     const MergeTreeWriterSettings & writer_settings,
-    MergeTreeIndexGranularityPtr computed_index_granularity)
+    MergeTreeIndexGranularityPtr computed_index_granularity,
+    WrittenOffsetSubstreams * written_offset_substreams)
 {
     return std::make_unique<MergeTreeDataPartWriterWide>(
         data_part_name_, logger_name_, serializations_, data_part_storage_,
         index_granularity_info_, storage_settings_, columns_list,
         metadata_snapshot, virtual_columns, indices_to_recalc, stats_to_recalc_,
         marks_file_extension_,
-        default_codec_, writer_settings, std::move(computed_index_granularity));
+        default_codec_, writer_settings, std::move(computed_index_granularity),
+        written_offset_substreams);
 }
 
 

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterCompact.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterCompact.cpp
@@ -34,7 +34,8 @@ MergeTreeDataPartWriterCompact::MergeTreeDataPartWriterCompact(
         data_part_storage_, index_granularity_info_, storage_settings_,
         columns_list_, metadata_snapshot_, virtual_columns_,
         indices_to_recalc_, stats_to_recalc, marks_file_extension_,
-        default_codec_, settings_, std::move(index_granularity_))
+        default_codec_, settings_, std::move(index_granularity_),
+        static_cast<WrittenOffsetSubstreams *>(nullptr))
     , plain_file(getDataPartStorage().writeFile(
             MergeTreeDataPartCompact::DATA_FILE_NAME_WITH_EXTENSION,
             settings.max_compress_block_size,

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterCompact.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterCompact.cpp
@@ -321,7 +321,7 @@ void MergeTreeDataPartWriterCompact::writeDataBlock(const Block & block, const G
     }
 }
 
-void MergeTreeDataPartWriterCompact::fillDataChecksums(MergeTreeDataPartChecksums & checksums)
+void MergeTreeDataPartWriterCompact::finalizeIndexGranularity()
 {
     if (columns_buffer.size() != 0)
     {
@@ -367,7 +367,10 @@ void MergeTreeDataPartWriterCompact::fillDataChecksums(MergeTreeDataPartChecksum
 
         writeBinaryLittleEndian(static_cast<UInt64>(0), marks_out);
     }
+}
 
+void MergeTreeDataPartWriterCompact::fillDataChecksums(MergeTreeDataPartChecksums & checksums)
+{
     for (const auto & [_, stream] : streams_by_codec)
     {
         stream->hashing_buf.finalize();

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterCompact.h
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterCompact.h
@@ -32,7 +32,8 @@ public:
 
     void write(const Block & block, const IColumnPermutation * permutation) override;
 
-    void fillChecksums(MergeTreeDataPartChecksums & checksums, NameSet & checksums_to_remove) override;
+    void finalizeIndexGranularity() final;
+    void fillChecksums(MergeTreeDataPartChecksums & checksums, NameSet & checksums_to_remove) final;
     void finish(bool sync) override;
     void cancel() noexcept override;
 

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterOnDisk.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterOnDisk.cpp
@@ -44,7 +44,8 @@ MergeTreeDataPartWriterOnDisk::MergeTreeDataPartWriterOnDisk(
     const String & marks_file_extension_,
     const CompressionCodecPtr & default_codec_,
     const MergeTreeWriterSettings & settings_,
-    MergeTreeIndexGranularityPtr index_granularity_)
+    MergeTreeIndexGranularityPtr index_granularity_,
+    WrittenOffsetSubstreams * written_offset_substreams_)
     : IMergeTreeDataPartWriter(
         data_part_name_, serializations_, data_part_storage_, index_granularity_info_,
         storage_settings_, columns_list_, metadata_snapshot_, virtual_columns_, settings_, std::move(index_granularity_))
@@ -54,6 +55,7 @@ MergeTreeDataPartWriterOnDisk::MergeTreeDataPartWriterOnDisk(
     , default_codec(default_codec_)
     , compute_granularity(index_granularity->empty())
     , compress_primary_key(settings.compress_primary_key)
+    , written_offset_substreams(written_offset_substreams_)
     , execution_stats(skip_indices.size(), stats.size())
     , log(getLogger(logger_name_ + " (DataPartWriter)"))
 {

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterOnDisk.h
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterOnDisk.h
@@ -43,7 +43,7 @@ using Granules = std::vector<Granule>;
 class MergeTreeDataPartWriterOnDisk : public IMergeTreeDataPartWriter
 {
 public:
-    using WrittenOffsetColumns = std::set<std::string>;
+    using WrittenOffsetSubstreams = std::set<std::string>;
 
     using StreamPtr = std::unique_ptr<MergeTreeWriterStream<false>>;
     using StatisticStreamPtr = std::unique_ptr<MergeTreeWriterStream<true>>;
@@ -63,12 +63,8 @@ public:
         const String & marks_file_extension,
         const CompressionCodecPtr & default_codec,
         const MergeTreeWriterSettings & settings,
-        MergeTreeIndexGranularityPtr index_granularity_);
-
-    void setWrittenOffsetColumns(WrittenOffsetColumns * written_offset_columns_)
-    {
-        written_offset_columns = written_offset_columns_;
-    }
+        MergeTreeIndexGranularityPtr index_granularity_,
+        WrittenOffsetSubstreams * written_offset_substreams_);
 
     void cancel() noexcept override;
 
@@ -143,8 +139,9 @@ protected:
 
     bool data_written = false;
 
-    /// To correctly write Nested elements column-by-column.
-    WrittenOffsetColumns * written_offset_columns = nullptr;
+    /// Substreams that should be ignored by this writer, due to they had been written by other writer (as part of vertical merge)
+    /// This is to correctly write Nested elements column-by-column.
+    WrittenOffsetSubstreams * written_offset_substreams;
 
     /// Data is already written up to this mark.
     size_t current_mark = 0;

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterWide.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterWide.cpp
@@ -701,7 +701,7 @@ void MergeTreeDataPartWriterWide::validateColumnOfFixedSize(const NameAndTypePai
     }
 }
 
-void MergeTreeDataPartWriterWide::fillDataChecksums(MergeTreeDataPartChecksums & checksums, NameSet & checksums_to_remove)
+void MergeTreeDataPartWriterWide::finalizeIndexGranularity()
 {
     auto serialize_settings = getSerializationSettings();
     WrittenOffsetColumns offset_columns;
@@ -733,7 +733,10 @@ void MergeTreeDataPartWriterWide::fillDataChecksums(MergeTreeDataPartChecksums &
                 writeFinalMark(*it, offset_columns);
         }
     }
+}
 
+void MergeTreeDataPartWriterWide::fillDataChecksums(MergeTreeDataPartChecksums & checksums, NameSet & checksums_to_remove)
+{
     for (auto & [stream_name, stream] : column_streams)
     {
         /// Remove checksums for old stream name if file was

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterWide.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterWide.cpp
@@ -119,12 +119,12 @@ MergeTreeDataPartWriterWide::MergeTreeDataPartWriterWide(
     }
 }
 
-ISerialization::EnumerateStreamsSettings MergeTreeDataPartWriterWide::getEnumerateSettings() const
+ISerialization::EnumerateStreamsSettings MergeTreeDataPartWriterWide::getEnumerateSettings(const MergeTreeWriterSettings & settings_)
 {
     ISerialization::EnumerateStreamsSettings enumerate_settings;
-    enumerate_settings.object_serialization_version = settings.object_serialization_version;
-    enumerate_settings.object_shared_data_serialization_version = settings.object_shared_data_serialization_version;
-    enumerate_settings.object_shared_data_buckets = settings.object_shared_data_buckets;
+    enumerate_settings.object_serialization_version = settings_.object_serialization_version;
+    enumerate_settings.object_shared_data_serialization_version = settings_.object_shared_data_serialization_version;
+    enumerate_settings.object_shared_data_buckets = settings_.object_shared_data_buckets;
     enumerate_settings.data_part_type = MergeTreeDataPartType::Wide;
     return enumerate_settings;
 }
@@ -205,7 +205,7 @@ void MergeTreeDataPartWriterWide::addStreams(
     auto serialization = getSerialization(name_and_type.name);
     auto * sample_column = block_sample.findByName(name_and_type.name);
     auto data = ISerialization::SubstreamData(serialization).withType(name_and_type.type).withColumn(sample_column ? sample_column->column : nullptr);
-    auto enumerate_settings = getEnumerateSettings();
+    auto enumerate_settings = getEnumerateSettings(settings);
     serialization->enumerateStreams(enumerate_settings, callback, data);
 }
 
@@ -432,7 +432,7 @@ StreamsWithMarks MergeTreeDataPartWriterWide::getCurrentMarksForColumn(
 
     auto serialization = getSerialization(name_and_type.name);
     auto data = ISerialization::SubstreamData(serialization).withType(name_and_type.type).withColumn(block_sample.getByName(name_and_type.name).column);
-    auto enumerate_settings = getEnumerateSettings();
+    auto enumerate_settings = getEnumerateSettings(settings);
     serialization->enumerateStreams(enumerate_settings, callback, data);
     return result;
 }
@@ -466,7 +466,7 @@ void MergeTreeDataPartWriterWide::writeSingleGranule(
     };
 
     auto data = ISerialization::SubstreamData(serialization).withType(name_and_type.type).withColumn(block_sample.getByName(name_and_type.name).column);
-    auto enumerate_settings = getEnumerateSettings();
+    auto enumerate_settings = getEnumerateSettings(settings);
     serialization->enumerateStreams(enumerate_settings, callback, data);
 }
 
@@ -560,7 +560,7 @@ void MergeTreeDataPartWriterWide::writeColumn(
     };
 
     auto data = ISerialization::SubstreamData(serialization).withType(name_and_type.type).withColumn(block_sample.getByName(name_and_type.name).column);
-    auto enumerate_settings = getEnumerateSettings();
+    auto enumerate_settings = getEnumerateSettings(settings);
     serialization->enumerateStreams(enumerate_settings, callback, data);
 }
 
@@ -830,7 +830,7 @@ void MergeTreeDataPartWriterWide::writeFinalMark(
 
     auto serialization = getSerialization(name_and_type.name);
     auto data = ISerialization::SubstreamData(serialization).withType(name_and_type.type).withColumn(block_sample.getByName(name_and_type.name).column);
-    auto enumerate_settings = getEnumerateSettings();
+    auto enumerate_settings = getEnumerateSettings(settings);
     serialization->enumerateStreams(enumerate_settings, callback, data);
 }
 

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterWide.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterWide.cpp
@@ -10,6 +10,7 @@
 #include <Storages/MergeTree/MergeTreeSettings.h>
 #include <Storages/MergeTree/MergeTreeData.h>
 #include <Storages/StorageInMemoryMetadata.h>
+#include <Common/Logger.h>
 #include <Common/SipHash.h>
 #include <Common/escapeForFileName.h>
 #include <Common/logger_useful.h>
@@ -98,13 +99,15 @@ MergeTreeDataPartWriterWide::MergeTreeDataPartWriterWide(
     const String & marks_file_extension_,
     const CompressionCodecPtr & default_codec_,
     const MergeTreeWriterSettings & settings_,
-    MergeTreeIndexGranularityPtr index_granularity_)
+    MergeTreeIndexGranularityPtr index_granularity_,
+    WrittenOffsetSubstreams * written_offset_substreams_)
     : MergeTreeDataPartWriterOnDisk(
             data_part_name_, logger_name_, serializations_,
             data_part_storage_, index_granularity_info_, storage_settings_,
             columns_list_, metadata_snapshot_, virtual_columns_,
             indices_to_recalc_, stats_to_recalc_, marks_file_extension_,
-            default_codec_, settings_, std::move(index_granularity_))
+            default_codec_, settings_, std::move(index_granularity_),
+            written_offset_substreams_)
 {
     if (settings.save_marks_in_cache)
     {
@@ -148,6 +151,14 @@ void MergeTreeDataPartWriterWide::addStreams(
         /// Shared offsets for Nested type.
         if (column_streams.contains(stream_name))
             return;
+
+        /// Don't write offsets more than one time for Nested type in case elements of nested had been written separately, i.e. via Vertical merge.
+        if (written_offset_substreams)
+        {
+            bool is_offsets = !substream_path.empty() && substream_path.back().type == ISerialization::Substream::ArraySizes;
+            if (is_offsets && written_offset_substreams->contains(stream_name))
+                return;
+        }
 
         auto it = stream_name_to_full_name.find(stream_name);
         if (it != stream_name_to_full_name.end() && it->second != full_stream_name)
@@ -214,6 +225,16 @@ const String & MergeTreeDataPartWriterWide::getStreamName(
     const ISerialization::SubstreamPath & substream_path) const
 {
     auto full_stream_name = ISerialization::getFileNameForStream(column, substream_path, ISerialization::StreamFileNameSettings(*storage_settings));
+    String stream_name = replaceFileNameToHashIfNeeded(full_stream_name, *storage_settings, data_part_storage.get());
+
+    if (written_offset_substreams)
+    {
+        bool is_offsets = !substream_path.empty() && substream_path.back().type == ISerialization::Substream::ArraySizes;
+        /// If it has been written already return an empty string placeholder, to avoid writing it again.
+        if (is_offsets && written_offset_substreams->contains(stream_name))
+            return already_written_stream_holder;
+    }
+
     auto it = full_name_to_stream_name.find(full_stream_name);
     if (it == full_name_to_stream_name.end())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Stream {} not found", full_stream_name);
@@ -221,8 +242,8 @@ const String & MergeTreeDataPartWriterWide::getStreamName(
     return it->second;
 }
 
-ISerialization::OutputStreamGetter MergeTreeDataPartWriterWide::createStreamGetter(
-        const NameAndTypePair & column, WrittenOffsetColumns & offset_columns) const
+ISerialization::OutputStreamGetter MergeTreeDataPartWriterWide::createStreamGetter(const NameAndTypePair & column,
+    const WrittenOffsetSubstreams & offset_substreams) const
 {
     return [&, this] (const ISerialization::SubstreamPath & substream_path) -> WriteBuffer *
     {
@@ -230,11 +251,13 @@ ISerialization::OutputStreamGetter MergeTreeDataPartWriterWide::createStreamGett
         if (ISerialization::isEphemeralSubcolumn(substream_path, substream_path.size()))
             return nullptr;
 
-        bool is_offsets = !substream_path.empty() && substream_path.back().type == ISerialization::Substream::ArraySizes;
         auto stream_name = getStreamName(column, substream_path);
+        if (stream_name.empty())
+            return nullptr;
 
         /// Don't write offsets more than one time for Nested type.
-        if (is_offsets && offset_columns.contains(stream_name))
+        bool is_offsets = !substream_path.empty() && substream_path.back().type == ISerialization::Substream::ArraySizes;
+        if (is_offsets && offset_substreams.contains(stream_name))
             return nullptr;
 
         return &column_streams.at(stream_name)->compressed_hashing;
@@ -316,7 +339,8 @@ void MergeTreeDataPartWriterWide::write(const Block & block, const IColumnPermut
 
     auto granules_to_write = getGranulesToWrite(*index_granularity, block_to_write.rows(), getCurrentMark(), rows_written_in_last_mark);
 
-    auto offset_columns = written_offset_columns ? *written_offset_columns : WrittenOffsetColumns{};
+    WrittenOffsetSubstreams offset_substreams = written_offset_substreams ? *written_offset_substreams : WrittenOffsetSubstreams{};
+
     Block primary_key_block;
     if (settings.rewrite_primary_key)
         primary_key_block = getIndexBlockAndPermute(block, metadata_snapshot->getPrimaryKeyColumns(), permutation);
@@ -336,23 +360,23 @@ void MergeTreeDataPartWriterWide::write(const Block & block, const IColumnPermut
             if (primary_key_block.has(it->name))
             {
                 const auto & primary_column = *primary_key_block.getByName(it->name).column;
-                writeColumn(*it, primary_column, offset_columns, granules_to_write);
+                writeColumn(*it, primary_column, offset_substreams, granules_to_write);
             }
             else if (skip_indexes_block.has(it->name))
             {
                 const auto & index_column = *skip_indexes_block.getByName(it->name).column;
-                writeColumn(*it, index_column, offset_columns, granules_to_write);
+                writeColumn(*it, index_column, offset_substreams, granules_to_write);
             }
             else
             {
                 /// We rearrange the columns that are not included in the primary key here; Then the result is released - to save RAM.
                 ColumnPtr permuted_column = column.column->permute(*permutation, 0);
-                writeColumn(*it, *permuted_column, offset_columns, granules_to_write);
+                writeColumn(*it, *permuted_column, offset_substreams, granules_to_write);
             }
         }
         else
         {
-            writeColumn(*it, *column.column, offset_columns, granules_to_write);
+            writeColumn(*it, *column.column, offset_substreams, granules_to_write);
         }
     }
 
@@ -365,12 +389,11 @@ void MergeTreeDataPartWriterWide::write(const Block & block, const IColumnPermut
     shiftCurrentMark(granules_to_write);
 }
 
-void MergeTreeDataPartWriterWide::writeSingleMark(
-    const NameAndTypePair & name_and_type,
-    WrittenOffsetColumns & offset_columns,
+void MergeTreeDataPartWriterWide::writeSingleMark(const NameAndTypePair & name_and_type,
+    const WrittenOffsetSubstreams & offset_substreams,
     size_t number_of_rows)
 {
-    StreamsWithMarks marks = getCurrentMarksForColumn(name_and_type, offset_columns);
+    StreamsWithMarks marks = getCurrentMarksForColumn(name_and_type, offset_substreams);
     for (const auto & mark : marks)
         flushMarkToFile(mark, number_of_rows);
 }
@@ -390,9 +413,8 @@ void MergeTreeDataPartWriterWide::flushMarkToFile(const StreamNameAndMark & stre
         it->second->push_back(stream_with_mark.mark);
 }
 
-StreamsWithMarks MergeTreeDataPartWriterWide::getCurrentMarksForColumn(
-    const NameAndTypePair & name_and_type,
-    WrittenOffsetColumns & offset_columns)
+StreamsWithMarks MergeTreeDataPartWriterWide::getCurrentMarksForColumn(const NameAndTypePair & name_and_type,
+    const WrittenOffsetSubstreams & offset_substreams)
 {
     StreamsWithMarks result;
     const auto column_desc = metadata_snapshot->columns.tryGetColumnDescription(GetColumnsOptions(GetColumnsOptions::AllPhysical), name_and_type.getNameInStorage());
@@ -409,11 +431,13 @@ StreamsWithMarks MergeTreeDataPartWriterWide::getCurrentMarksForColumn(
         if (ISerialization::isEphemeralSubcolumn(substream_path, substream_path.size()))
            return;
 
-        bool is_offsets = !substream_path.empty() && substream_path.back().type == ISerialization::Substream::ArraySizes;
         auto stream_name = getStreamName(name_and_type, substream_path);
+        if (stream_name.empty())
+            return;
 
         /// Don't write offsets more than one time for Nested type.
-        if (is_offsets && offset_columns.contains(stream_name))
+        bool is_offsets = !substream_path.empty() && substream_path.back().type == ISerialization::Substream::ArraySizes;
+        if (is_offsets && offset_substreams.contains(stream_name))
             return;
 
         auto & stream = *column_streams[stream_name];
@@ -440,7 +464,7 @@ StreamsWithMarks MergeTreeDataPartWriterWide::getCurrentMarksForColumn(
 void MergeTreeDataPartWriterWide::writeSingleGranule(
     const NameAndTypePair & name_and_type,
     const IColumn & column,
-    WrittenOffsetColumns & offset_columns,
+    const WrittenOffsetSubstreams & offset_substreams,
     ISerialization::SerializeBinaryBulkStatePtr & serialization_state,
     ISerialization::SerializeBinaryBulkSettings & serialize_settings,
     const Granule & granule)
@@ -455,11 +479,13 @@ void MergeTreeDataPartWriterWide::writeSingleGranule(
         if (ISerialization::isEphemeralSubcolumn(substream_path, substream_path.size()))
             return;
 
-        bool is_offsets = !substream_path.empty() && substream_path.back().type == ISerialization::Substream::ArraySizes;
         auto stream_name = getStreamName(name_and_type, substream_path);
+        if (stream_name.empty())
+            return;
 
         /// Don't write offsets more than one time for Nested type.
-        if (is_offsets && offset_columns.contains(stream_name))
+        bool is_offsets = !substream_path.empty() && substream_path.back().type == ISerialization::Substream::ArraySizes;
+        if (is_offsets && offset_substreams.contains(stream_name))
             return;
 
         column_streams.at(stream_name)->compressed_hashing.nextIfAtEnd();
@@ -489,7 +515,7 @@ ISerialization::SerializeBinaryBulkSettings MergeTreeDataPartWriterWide::getSeri
 void MergeTreeDataPartWriterWide::writeColumn(
     const NameAndTypePair & name_and_type,
     const IColumn & column,
-    WrittenOffsetColumns & offset_columns,
+    WrittenOffsetSubstreams & offset_substreams,
     const Granules & granules)
 {
     if (granules.empty())
@@ -503,13 +529,13 @@ void MergeTreeDataPartWriterWide::writeColumn(
     if (inserted)
     {
         auto serialize_settings = getSerializationSettings();
-        serialize_settings.getter = createStreamGetter(name_and_type, offset_columns);
+        serialize_settings.getter = createStreamGetter(name_and_type, offset_substreams);
         serialize_settings.data_part_type = MergeTreeDataPartType::Wide;
         serialization->serializeBinaryBulkStatePrefix(column, serialize_settings, it->second);
     }
 
     auto serialize_settings = getSerializationSettings();
-    serialize_settings.getter = createStreamGetter(name_and_type, offset_columns);
+    serialize_settings.getter = createStreamGetter(name_and_type, offset_substreams);
     serialize_settings.stream_mark_getter = [&](const ISerialization::SubstreamPath & substream_path) -> MarkInCompressedFile
     {
         auto stream_name = getStreamName(name_and_type, substream_path);
@@ -528,16 +554,16 @@ void MergeTreeDataPartWriterWide::writeColumn(
                                 "We have to add new mark for column, but already have non written mark. "
                                 "Current mark {}, total marks {}, offset {}",
                                 getCurrentMark(), index_granularity->getMarksCount(), rows_written_in_last_mark);
-            last_non_written_marks[name] = getCurrentMarksForColumn(name_and_type, offset_columns);
+            last_non_written_marks[name] = getCurrentMarksForColumn(name_and_type, offset_substreams);
         }
 
         writeSingleGranule(
-           name_and_type,
-           column,
-           offset_columns,
-           it->second,
-           serialize_settings,
-           granule
+            name_and_type,
+            column,
+            offset_substreams,
+            it->second,
+            serialize_settings,
+            granule
         );
 
         if (granule.is_complete)
@@ -556,9 +582,8 @@ void MergeTreeDataPartWriterWide::writeColumn(
     {
         bool is_offsets = !substream_path.empty() && substream_path.back().type == ISerialization::Substream::ArraySizes;
         if (is_offsets)
-            offset_columns.insert(getStreamName(name_and_type, substream_path));
+            offset_substreams.insert(getStreamName(name_and_type, substream_path));
     };
-
     auto data = ISerialization::SubstreamData(serialization).withType(name_and_type.type).withColumn(block_sample.getByName(name_and_type.name).column);
     auto enumerate_settings = getEnumerateSettings(settings);
     serialization->enumerateStreams(enumerate_settings, callback, data);
@@ -704,7 +729,6 @@ void MergeTreeDataPartWriterWide::validateColumnOfFixedSize(const NameAndTypePai
 void MergeTreeDataPartWriterWide::finalizeIndexGranularity()
 {
     auto serialize_settings = getSerializationSettings();
-    WrittenOffsetColumns offset_columns;
     if (rows_written_in_last_mark > 0)
     {
         if (settings.can_use_adaptive_granularity && settings.blocks_are_granules_size)
@@ -717,20 +741,21 @@ void MergeTreeDataPartWriterWide::finalizeIndexGranularity()
         adjustLastMarkIfNeedAndFlushToDisk(rows_written_in_last_mark);
     }
 
+    WrittenOffsetSubstreams dummy_offset_substreams;
+    WrittenOffsetSubstreams & offset_substreams = written_offset_substreams ? *written_offset_substreams : dummy_offset_substreams;
     bool write_final_mark = (with_final_mark && data_written);
-
     {
         auto it = columns_list.begin();
         for (size_t i = 0; i < columns_list.size(); ++i, ++it)
         {
             if (!serialization_states.empty())
             {
-                serialize_settings.getter = createStreamGetter(*it, written_offset_columns ? *written_offset_columns : offset_columns);
+                serialize_settings.getter = createStreamGetter(*it, offset_substreams);
                 getSerialization(it->name)->serializeBinaryBulkStateSuffix(serialize_settings, serialization_states[it->name]);
             }
 
             if (write_final_mark)
-                writeFinalMark(*it, offset_columns);
+                writeFinalMark(*it, offset_substreams);
         }
     }
 }
@@ -818,19 +843,18 @@ void MergeTreeDataPartWriterWide::cancel() noexcept
     Base::cancel();
 }
 
-void MergeTreeDataPartWriterWide::writeFinalMark(
-    const NameAndTypePair & name_and_type,
-    WrittenOffsetColumns & offset_columns)
+void MergeTreeDataPartWriterWide::writeFinalMark(const NameAndTypePair & name_and_type,
+    WrittenOffsetSubstreams & offset_substreams)
 {
-    writeSingleMark(name_and_type, offset_columns, 0);
-    /// Memoize information about offsets
+    writeSingleMark(name_and_type, offset_substreams, 0);
+
+    /// Memorize information about offsets
     auto callback = [&] (const ISerialization::SubstreamPath & substream_path)
     {
         bool is_offsets = !substream_path.empty() && substream_path.back().type == ISerialization::Substream::ArraySizes;
         if (is_offsets)
-            offset_columns.insert(getStreamName(name_and_type, substream_path));
+            offset_substreams.insert(getStreamName(name_and_type, substream_path));
     };
-
     auto serialization = getSerialization(name_and_type.name);
     auto data = ISerialization::SubstreamData(serialization).withType(name_and_type.type).withColumn(block_sample.getByName(name_and_type.name).column);
     auto enumerate_settings = getEnumerateSettings(settings);

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterWide.h
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterWide.h
@@ -48,6 +48,8 @@ public:
 
     size_t getNumberOfOpenStreams() const override { return column_streams.size(); }
 
+    static ISerialization::EnumerateStreamsSettings getEnumerateSettings(const MergeTreeWriterSettings & settings);
+
 private:
     /// Finish serialization of data: write final mark if required and compute checksums
     /// Also validate written data in debug mode
@@ -121,8 +123,6 @@ private:
 
     ISerialization::OutputStreamGetter createStreamGetter(const NameAndTypePair & column, WrittenOffsetColumns & offset_columns) const;
     const String & getStreamName(const NameAndTypePair & column, const ISerialization::SubstreamPath & substream_path) const;
-
-    ISerialization::EnumerateStreamsSettings getEnumerateSettings() const;
 
     using SerializationState = ISerialization::SerializeBinaryBulkStatePtr;
     using SerializationStates = std::unordered_map<String, SerializationState>;

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterWide.h
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterWide.h
@@ -41,6 +41,7 @@ public:
 
     void write(const Block & block, const IColumnPermutation * permutation) override;
 
+    void finalizeIndexGranularity() final;
     void fillChecksums(MergeTreeDataPartChecksums & checksums, NameSet & checksums_to_remove) final;
 
     void finish(bool sync) final;

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterWide.h
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterWide.h
@@ -37,7 +37,8 @@ public:
         const String & marks_file_extension,
         const CompressionCodecPtr & default_codec,
         const MergeTreeWriterSettings & settings,
-        MergeTreeIndexGranularityPtr index_granularity_);
+        MergeTreeIndexGranularityPtr index_granularity_,
+        WrittenOffsetSubstreams * written_offset_substreams_);
 
     void write(const Block & block, const IColumnPermutation * permutation) override;
 
@@ -63,14 +64,14 @@ private:
     void writeColumn(
         const NameAndTypePair & name_and_type,
         const IColumn & column,
-        WrittenOffsetColumns & offset_columns,
+        WrittenOffsetSubstreams & offset_substreams,
         const Granules & granules);
 
     /// Write single granule of one column.
     void writeSingleGranule(
         const NameAndTypePair & name_and_type,
         const IColumn & column,
-        WrittenOffsetColumns & offset_columns,
+        const WrittenOffsetSubstreams & offset_substreams,
         ISerialization::SerializeBinaryBulkStatePtr & serialization_state,
         ISerialization::SerializeBinaryBulkSettings & serialize_settings,
         const Granule & granule);
@@ -78,22 +79,20 @@ private:
     /// Take offsets from column and return as MarkInCompressed file with stream name
     StreamsWithMarks getCurrentMarksForColumn(
         const NameAndTypePair & name_and_type,
-        WrittenOffsetColumns & offset_columns);
+        const WrittenOffsetSubstreams & offset_substreams);
 
     /// Write mark to disk using stream and rows count
-    void flushMarkToFile(
-        const StreamNameAndMark & stream_with_mark,
-        size_t rows_in_mark);
+    void flushMarkToFile(const StreamNameAndMark & stream_with_mark, size_t rows_in_mark);
 
     /// Write mark for column taking offsets from column stream
     void writeSingleMark(
         const NameAndTypePair & name_and_type,
-        WrittenOffsetColumns & offset_columns,
+        const WrittenOffsetSubstreams & offset_substreams,
         size_t number_of_rows);
 
     void writeFinalMark(
         const NameAndTypePair & name_and_type,
-        WrittenOffsetColumns & offset_columns);
+        WrittenOffsetSubstreams & offset_substreams);
 
     void addStreams(
         const NameAndTypePair & name_and_type,
@@ -122,7 +121,8 @@ private:
 
     ISerialization::SerializeBinaryBulkSettings getSerializationSettings() const;
 
-    ISerialization::OutputStreamGetter createStreamGetter(const NameAndTypePair & column, WrittenOffsetColumns & offset_columns) const;
+    ISerialization::OutputStreamGetter createStreamGetter(const NameAndTypePair & column,
+        const WrittenOffsetSubstreams & offset_substreams) const;
     const String & getStreamName(const NameAndTypePair & column, const ISerialization::SubstreamPath & substream_path) const;
 
     using SerializationState = ISerialization::SerializeBinaryBulkStatePtr;
@@ -150,6 +150,8 @@ private:
     /// How many rows we have already written in the current mark.
     /// More than zero when incoming blocks are smaller then their granularity.
     size_t rows_written_in_last_mark = 0;
+
+    String already_written_stream_holder;
 };
 
 }

--- a/src/Storages/MergeTree/MergeTreeDataWriter.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataWriter.cpp
@@ -881,7 +881,8 @@ MergeTreeTemporaryPartPtr MergeTreeDataWriter::writeTempPartImpl(
         block.bytes(),
         /*reset_columns=*/ false,
         /*blocks_are_granules_size=*/ false,
-        context->getWriteSettings());
+        context->getWriteSettings(),
+        static_cast<WrittenOffsetSubstreams *>(nullptr));
 
     out->writeWithPermutation(block, perm_ptr);
 
@@ -1051,7 +1052,8 @@ MergeTreeTemporaryPartPtr MergeTreeDataWriter::writeProjectionPartImpl(
         block.bytes(),
         /*reset_columns=*/ false,
         /*blocks_are_granules_size=*/ false,
-        data.getContext()->getWriteSettings());
+        data.getContext()->getWriteSettings(),
+        static_cast<WrittenOffsetSubstreams *>(nullptr));
 
     out->writeWithPermutation(block, perm_ptr);
     out->finalizeIndexGranularity();

--- a/src/Storages/MergeTree/MergeTreeDataWriter.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataWriter.cpp
@@ -905,6 +905,7 @@ MergeTreeTemporaryPartPtr MergeTreeDataWriter::writeTempPartImpl(
         }
     }
 
+    out->finalizeIndexGranularity();
     auto finalizer = out->finalizePartAsync(
         new_data_part,
         (*data_settings)[MergeTreeSetting::fsync_after_insert],
@@ -1053,6 +1054,7 @@ MergeTreeTemporaryPartPtr MergeTreeDataWriter::writeProjectionPartImpl(
         data.getContext()->getWriteSettings());
 
     out->writeWithPermutation(block, perm_ptr);
+    out->finalizeIndexGranularity();
     auto finalizer = out->finalizePartAsync(new_data_part, false);
     temp_part->part = new_data_part;
     temp_part->streams.emplace_back(MergeTreeTemporaryPart::Stream{.stream = std::move(out), .finalizer = std::move(finalizer)});

--- a/src/Storages/MergeTree/MergedBlockOutputStream.cpp
+++ b/src/Storages/MergeTree/MergedBlockOutputStream.cpp
@@ -184,6 +184,11 @@ void MergedBlockOutputStream::finalizePart(
     finalizePartAsync(new_part, sync, total_columns_list, additional_column_checksums, additional_columns_substreams).finish();
 }
 
+void MergedBlockOutputStream::finalizeIndexGranularity()
+{
+    writer->finalizeIndexGranularity();
+}
+
 MergedBlockOutputStream::Finalizer MergedBlockOutputStream::finalizePartAsync(
     const MergeTreeMutableDataPartPtr & new_part,
     bool sync,

--- a/src/Storages/MergeTree/MergedBlockOutputStream.cpp
+++ b/src/Storages/MergeTree/MergedBlockOutputStream.cpp
@@ -1,3 +1,4 @@
+#include <Storages/MergeTree/IMergedBlockOutputStream.h>
 #include <Storages/MergeTree/MergedBlockOutputStream.h>
 #include <Storages/MergeTree/MergeTreeSettings.h>
 #include <IO/HashingWriteBuffer.h>
@@ -32,7 +33,8 @@ MergedBlockOutputStream::MergedBlockOutputStream(
     size_t part_uncompressed_bytes,
     bool reset_columns_,
     bool blocks_are_granules_size,
-    const WriteSettings & write_settings_)
+    const WriteSettings & write_settings_,
+    WrittenOffsetSubstreams * written_offset_substreams)
     : IMergedBlockOutputStream(
           std::move(data_settings), data_part->getDataPartStoragePtr(), metadata_snapshot_, columns_list_, reset_columns_)
     , columns_list(columns_list_)
@@ -78,7 +80,8 @@ MergedBlockOutputStream::MergedBlockOutputStream(
         data_part->getMarksFileExtension(),
         default_codec,
         writer_settings,
-        std::move(index_granularity_ptr));
+        std::move(index_granularity_ptr),
+        written_offset_substreams);
 }
 
 /// If data is pre-sorted.

--- a/src/Storages/MergeTree/MergedBlockOutputStream.h
+++ b/src/Storages/MergeTree/MergedBlockOutputStream.h
@@ -74,6 +74,8 @@ public:
         MergeTreeData::DataPart::Checksums * additional_column_checksums = nullptr,
         ColumnsSubstreams * additional_columns_substreams = nullptr);
 
+    void finalizeIndexGranularity();
+
 private:
     /** If `permutation` is given, it rearranges the values in the columns when writing.
       * This is necessary to not keep the whole block in the RAM to sort it.

--- a/src/Storages/MergeTree/MergedBlockOutputStream.h
+++ b/src/Storages/MergeTree/MergedBlockOutputStream.h
@@ -25,9 +25,10 @@ public:
         MergeTreeIndexGranularityPtr index_granularity_ptr,
         TransactionID tid,
         size_t part_uncompressed_bytes,
-        bool reset_columns_ = false,
-        bool blocks_are_granules_size = false,
-        const WriteSettings & write_settings = {});
+        bool reset_columns_,
+        bool blocks_are_granules_size,
+        const WriteSettings & write_settings,
+        WrittenOffsetSubstreams * written_offset_substreams);
 
     Block getHeader() const { return metadata_snapshot->getSampleBlock(); }
 

--- a/src/Storages/MergeTree/MergedColumnOnlyOutputStream.cpp
+++ b/src/Storages/MergeTree/MergedColumnOnlyOutputStream.cpp
@@ -8,11 +8,6 @@
 namespace DB
 {
 
-namespace ErrorCodes
-{
-    extern const int NOT_IMPLEMENTED;
-}
-
 MergedColumnOnlyOutputStream::MergedColumnOnlyOutputStream(
     const MergeTreeMutableDataPartPtr & data_part,
     MergeTreeSettingsPtr data_settings,
@@ -23,7 +18,7 @@ MergedColumnOnlyOutputStream::MergedColumnOnlyOutputStream(
     CompressionCodecPtr default_codec,
     MergeTreeIndexGranularityPtr index_granularity_ptr,
     size_t part_uncompressed_bytes,
-    WrittenOffsetColumns * offset_columns)
+    WrittenOffsetSubstreams * written_offset_substreams)
     : IMergedBlockOutputStream(
           std::move(data_settings),
           data_part->getDataPartStoragePtr(),
@@ -62,13 +57,8 @@ MergedColumnOnlyOutputStream::MergedColumnOnlyOutputStream(
         data_part->getMarksFileExtension(),
         default_codec,
         writer_settings,
-        std::move(index_granularity_ptr));
-
-    auto * writer_on_disk = dynamic_cast<MergeTreeDataPartWriterOnDisk *>(writer.get());
-    if (!writer_on_disk)
-        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "MergedColumnOnlyOutputStream supports only parts stored on disk");
-
-    writer_on_disk->setWrittenOffsetColumns(offset_columns);
+        std::move(index_granularity_ptr),
+        written_offset_substreams);
 }
 
 void MergedColumnOnlyOutputStream::write(const Block & block)

--- a/src/Storages/MergeTree/MergedColumnOnlyOutputStream.cpp
+++ b/src/Storages/MergeTree/MergedColumnOnlyOutputStream.cpp
@@ -80,6 +80,11 @@ void MergedColumnOnlyOutputStream::write(const Block & block)
     new_serialization_infos.add(block);
 }
 
+void MergedColumnOnlyOutputStream::finalizeIndexGranularity()
+{
+    writer->finalizeIndexGranularity();
+}
+
 MergeTreeData::DataPart::Checksums
 MergedColumnOnlyOutputStream::fillChecksums(
     MergeTreeData::MutableDataPartPtr & new_part,

--- a/src/Storages/MergeTree/MergedColumnOnlyOutputStream.h
+++ b/src/Storages/MergeTree/MergedColumnOnlyOutputStream.h
@@ -29,6 +29,8 @@ public:
 
     void write(const Block & block) override;
 
+    void finalizeIndexGranularity();
+
     MergeTreeData::DataPart::Checksums
     fillChecksums(MergeTreeData::MutableDataPartPtr & new_part, MergeTreeData::DataPart::Checksums & all_checksums);
 

--- a/src/Storages/MergeTree/MergedColumnOnlyOutputStream.h
+++ b/src/Storages/MergeTree/MergedColumnOnlyOutputStream.h
@@ -13,7 +13,7 @@ class MergeTreeDataPartWriterWide;
 class MergedColumnOnlyOutputStream final : public IMergedBlockOutputStream
 {
 public:
-    /// Pass empty 'already_written_offset_columns' first time then and pass the same object to subsequent instances of MergedColumnOnlyOutputStream
+    /// Pass empty @written_offset_substreams first time then and pass the same object to subsequent instances of MergedColumnOnlyOutputStream
     ///  if you want to serialize elements of Nested data structure in different instances of MergedColumnOnlyOutputStream.
     MergedColumnOnlyOutputStream(
         const MergeTreeMutableDataPartPtr & data_part,
@@ -25,7 +25,7 @@ public:
         CompressionCodecPtr default_codec,
         MergeTreeIndexGranularityPtr index_granularity_ptr,
         size_t part_uncompressed_bytes,
-        WrittenOffsetColumns * offset_columns = nullptr);
+        WrittenOffsetSubstreams * written_offset_substreams);
 
     void write(const Block & block) override;
 

--- a/src/Storages/MergeTree/MutateTask.cpp
+++ b/src/Storages/MergeTree/MutateTask.cpp
@@ -1983,8 +1983,9 @@ private:
         ctx->mutating_executor.reset();
         ctx->mutating_pipeline.reset();
 
-        static_pointer_cast<MergedBlockOutputStream>(ctx->out)->finalizePart(
-            ctx->new_data_part, ctx->need_sync, nullptr, &ctx->existing_indices_stats_checksums);
+        const auto & out = static_pointer_cast<MergedBlockOutputStream>(ctx->out);
+        out->finalizeIndexGranularity();
+        out->finalizePart(ctx->new_data_part, ctx->need_sync, nullptr, &ctx->existing_indices_stats_checksums);
         ctx->out.reset();
     }
 
@@ -2238,20 +2239,20 @@ private:
             ctx->mutating_executor.reset();
             ctx->mutating_pipeline.reset();
 
-            auto changed_checksums =
-                static_pointer_cast<MergedColumnOnlyOutputStream>(ctx->out)->fillChecksums(
-                    ctx->new_data_part, ctx->new_data_part->checksums);
+            const auto & column_out = static_pointer_cast<MergedColumnOnlyOutputStream>(ctx->out);
+            column_out->finalizeIndexGranularity();
+            auto changed_checksums = column_out->fillChecksums(ctx->new_data_part, ctx->new_data_part->checksums);
             ctx->new_data_part->checksums.add(std::move(changed_checksums));
 
             auto new_columns_substreams = ctx->new_data_part->getColumnsSubstreams();
             if (!new_columns_substreams.empty())
             {
-                auto changed_columns_substreams = static_pointer_cast<MergedColumnOnlyOutputStream>(ctx->out)->getColumnsSubstreams();
+                auto changed_columns_substreams = column_out->getColumnsSubstreams();
                 new_columns_substreams = ColumnsSubstreams::merge(changed_columns_substreams, ctx->new_data_part->getColumnsSubstreams(), ctx->new_data_part->getColumns().getNames());
                 ctx->new_data_part->setColumnsSubstreams(new_columns_substreams);
             }
 
-            static_pointer_cast<MergedColumnOnlyOutputStream>(ctx->out)->finish(ctx->need_sync);
+            column_out->finish(ctx->need_sync);
 
             ctx->out.reset();
         }

--- a/src/Storages/MergeTree/MutateTask.cpp
+++ b/src/Storages/MergeTree/MutateTask.cpp
@@ -1964,7 +1964,8 @@ private:
             ctx->source_part->getBytesUncompressedOnDisk(),
             /*reset_columns=*/ true,
             /*blocks_are_granules_size=*/ false,
-            ctx->context->getWriteSettings());
+            ctx->context->getWriteSettings(),
+            static_cast<WrittenOffsetSubstreams *>(nullptr));
 
         ctx->mutating_pipeline = QueryPipelineBuilder::getPipeline(std::move(*builder));
         ctx->mutating_pipeline.setProgressCallback(ctx->progress_callback);
@@ -2217,7 +2218,8 @@ private:
                 ColumnsStatistics(ctx->stats_to_recalc.begin(), ctx->stats_to_recalc.end()),
                 ctx->compression_codec,
                 ctx->source_part->index_granularity,
-                ctx->source_part->getBytesUncompressedOnDisk());
+                ctx->source_part->getBytesUncompressedOnDisk(),
+                static_cast<WrittenOffsetSubstreams *>(nullptr));
 
             ctx->mutating_pipeline = QueryPipelineBuilder::getPipeline(std::move(*builder));
             ctx->mutating_pipeline.setProgressCallback(ctx->progress_callback);

--- a/tests/queries/0_stateless/03001_block_offset_column.sql.j2
+++ b/tests/queries/0_stateless/03001_block_offset_column.sql.j2
@@ -8,6 +8,9 @@ SETTINGS
     enable_block_number_column = 1,
     enable_block_offset_column = 1,
     index_granularity = 2,
+    min_bytes_for_wide_part = 0,
+    allow_vertical_merges_from_compact_to_wide_parts = 1,
+    vertical_merge_algorithm_min_rows_to_activate = 1,
     vertical_merge_algorithm_min_bytes_to_activate = 1,
     vertical_merge_algorithm_min_columns_to_activate = 1,
     enable_vertical_merge_algorithm = {{ enable_vertical_merge_algorithm }};

--- a/tests/queries/0_stateless/03800_use_const_adaptive_granularity_vertical_merge.reference
+++ b/tests/queries/0_stateless/03800_use_const_adaptive_granularity_vertical_merge.reference
@@ -1,0 +1,11 @@
+-- { echo }
+insert into tab select 1, if(number < 4096, 'foo', repeat('b', 1000)) from numbers(400e3) settings max_block_size=65535, max_insert_threads=1;
+select name, rows, marks, index_granularity_bytes_in_memory_allocated from system.parts where database = currentDatabase() and table = 'tab' and active;
+1_1_1_0	327675	3278	25
+1_2_2_0	72325	740	25
+optimize table tab;
+select name, rows, marks, index_granularity_bytes_in_memory_allocated from system.parts where database = currentDatabase() and table = 'tab' and active;
+1_1_2_1	400000	4001	25
+select * from tab format Null;
+check table tab;
+1_1_2_1	1	

--- a/tests/queries/0_stateless/03800_use_const_adaptive_granularity_vertical_merge.sql
+++ b/tests/queries/0_stateless/03800_use_const_adaptive_granularity_vertical_merge.sql
@@ -1,0 +1,31 @@
+DROP TABLE IF EXISTS tab;
+
+CREATE TABLE tab
+(
+    part Int32,
+    key String
+)
+ENGINE = MergeTree
+PARTITION BY part
+ORDER BY key
+SETTINGS
+    index_granularity = 1000000000,
+    index_granularity_bytes = 100000,
+    min_bytes_for_wide_part = 0,
+    use_const_adaptive_granularity = 1,
+    enable_index_granularity_compression = 1,
+    enable_block_number_column = 0,
+    enable_block_offset_column = 0,
+    auto_statistics_types = '',
+    vertical_merge_algorithm_min_rows_to_activate = 0,
+    vertical_merge_algorithm_min_columns_to_activate = 1,
+    string_serialization_version = 'single_stream',
+    merge_max_block_size = 65535;
+
+-- { echo }
+insert into tab select 1, if(number < 4096, 'foo', repeat('b', 1000)) from numbers(400e3) settings max_block_size=65535, max_insert_threads=1;
+select name, rows, marks, index_granularity_bytes_in_memory_allocated from system.parts where database = currentDatabase() and table = 'tab' and active;
+optimize table tab;
+select name, rows, marks, index_granularity_bytes_in_memory_allocated from system.parts where database = currentDatabase() and table = 'tab' and active;
+select * from tab format Null;
+check table tab;

--- a/tests/queries/0_stateless/03800_use_const_adaptive_granularity_vertical_merge_nested.reference
+++ b/tests/queries/0_stateless/03800_use_const_adaptive_granularity_vertical_merge_nested.reference
@@ -1,0 +1,96 @@
+-- { echo }
+SELECT 'compress_marks=0, replace_long_file_name_to_hash = 0';
+compress_marks=0, replace_long_file_name_to_hash = 0
+SELECT column, column_marks_bytes, subcolumns.names, subcolumns.marks_bytes FROM system.parts_columns WHERE database = currentDatabase() AND table = 'nested_no_pk' AND active ORDER BY column;
+complex.key	96	['size0']	[48]
+complex.value	48	['size0']	[48]
+OPTIMIZE TABLE nested_no_pk PARTITION tuple() FINAL;
+SELECT column, column_marks_bytes, subcolumns.names, subcolumns.marks_bytes FROM system.parts_columns WHERE database = currentDatabase() AND table = 'nested_no_pk' AND active ORDER BY column;
+complex.key	96	['size0']	[48]
+complex.value	48	['size0']	[48]
+SELECT * FROM nested_no_pk ORDER BY complex.key;
+['GoodBye']	[1]
+-- { echo }
+SELECT column, column_marks_bytes, subcolumns.names, subcolumns.marks_bytes FROM system.parts_columns WHERE database = currentDatabase() AND table = 'nested_pk' AND active ORDER BY column;
+complex.key	96	['size0']	[48]
+complex.value	48	['size0']	[48]
+key	48	[]	[]
+OPTIMIZE TABLE nested_pk FINAL;
+SELECT column, column_marks_bytes, subcolumns.names, subcolumns.marks_bytes FROM system.parts_columns WHERE database = currentDatabase() AND table = 'nested_pk' AND active ORDER BY column;
+complex.key	96	['size0']	[48]
+complex.value	48	['size0']	[48]
+key	48	[]	[]
+SELECT * FROM nested_pk ORDER BY complex.key;
+foo	['GoodBye']	[1]
+-- { echo }
+SELECT 'compress_marks=0, replace_long_file_name_to_hash = 1';
+compress_marks=0, replace_long_file_name_to_hash = 1
+SELECT column, column_marks_bytes, subcolumns.names, subcolumns.marks_bytes FROM system.parts_columns WHERE database = currentDatabase() AND table = 'nested_no_pk' AND active ORDER BY column;
+complex.key	96	['size0']	[48]
+complex.value	48	['size0']	[48]
+OPTIMIZE TABLE nested_no_pk PARTITION tuple() FINAL;
+SELECT column, column_marks_bytes, subcolumns.names, subcolumns.marks_bytes FROM system.parts_columns WHERE database = currentDatabase() AND table = 'nested_no_pk' AND active ORDER BY column;
+complex.key	96	['size0']	[48]
+complex.value	48	['size0']	[48]
+SELECT * FROM nested_no_pk ORDER BY complex.key;
+['GoodBye']	[1]
+-- { echo }
+SELECT column, column_marks_bytes, subcolumns.names, subcolumns.marks_bytes FROM system.parts_columns WHERE database = currentDatabase() AND table = 'nested_pk' AND active ORDER BY column;
+complex.key	96	['size0']	[48]
+complex.value	48	['size0']	[48]
+key	48	[]	[]
+OPTIMIZE TABLE nested_pk FINAL;
+SELECT column, column_marks_bytes, subcolumns.names, subcolumns.marks_bytes FROM system.parts_columns WHERE database = currentDatabase() AND table = 'nested_pk' AND active ORDER BY column;
+complex.key	96	['size0']	[48]
+complex.value	48	['size0']	[48]
+key	48	[]	[]
+SELECT * FROM nested_pk ORDER BY complex.key;
+foo	['GoodBye']	[1]
+-- { echo }
+SELECT 'compress_marks=1, replace_long_file_name_to_hash = 0';
+compress_marks=1, replace_long_file_name_to_hash = 0
+SELECT column, column_marks_bytes, subcolumns.names, subcolumns.marks_bytes FROM system.parts_columns WHERE database = currentDatabase() AND table = 'nested_no_pk' AND active ORDER BY column;
+complex.key	94	['size0']	[47]
+complex.value	47	['size0']	[47]
+OPTIMIZE TABLE nested_no_pk PARTITION tuple() FINAL;
+SELECT column, column_marks_bytes, subcolumns.names, subcolumns.marks_bytes FROM system.parts_columns WHERE database = currentDatabase() AND table = 'nested_no_pk' AND active ORDER BY column;
+complex.key	94	['size0']	[47]
+complex.value	47	['size0']	[47]
+SELECT * FROM nested_no_pk ORDER BY complex.key;
+['GoodBye']	[1]
+-- { echo }
+SELECT column, column_marks_bytes, subcolumns.names, subcolumns.marks_bytes FROM system.parts_columns WHERE database = currentDatabase() AND table = 'nested_pk' AND active ORDER BY column;
+complex.key	94	['size0']	[47]
+complex.value	47	['size0']	[47]
+key	47	[]	[]
+OPTIMIZE TABLE nested_pk FINAL;
+SELECT column, column_marks_bytes, subcolumns.names, subcolumns.marks_bytes FROM system.parts_columns WHERE database = currentDatabase() AND table = 'nested_pk' AND active ORDER BY column;
+complex.key	94	['size0']	[47]
+complex.value	47	['size0']	[47]
+key	47	[]	[]
+SELECT * FROM nested_pk ORDER BY complex.key;
+foo	['GoodBye']	[1]
+-- { echo }
+SELECT 'compress_marks=1, replace_long_file_name_to_hash = 1';
+compress_marks=1, replace_long_file_name_to_hash = 1
+SELECT column, column_marks_bytes, subcolumns.names, subcolumns.marks_bytes FROM system.parts_columns WHERE database = currentDatabase() AND table = 'nested_no_pk' AND active ORDER BY column;
+complex.key	94	['size0']	[47]
+complex.value	47	['size0']	[47]
+OPTIMIZE TABLE nested_no_pk PARTITION tuple() FINAL;
+SELECT column, column_marks_bytes, subcolumns.names, subcolumns.marks_bytes FROM system.parts_columns WHERE database = currentDatabase() AND table = 'nested_no_pk' AND active ORDER BY column;
+complex.key	94	['size0']	[47]
+complex.value	47	['size0']	[47]
+SELECT * FROM nested_no_pk ORDER BY complex.key;
+['GoodBye']	[1]
+-- { echo }
+SELECT column, column_marks_bytes, subcolumns.names, subcolumns.marks_bytes FROM system.parts_columns WHERE database = currentDatabase() AND table = 'nested_pk' AND active ORDER BY column;
+complex.key	94	['size0']	[47]
+complex.value	47	['size0']	[47]
+key	47	[]	[]
+OPTIMIZE TABLE nested_pk FINAL;
+SELECT column, column_marks_bytes, subcolumns.names, subcolumns.marks_bytes FROM system.parts_columns WHERE database = currentDatabase() AND table = 'nested_pk' AND active ORDER BY column;
+complex.key	94	['size0']	[47]
+complex.value	47	['size0']	[47]
+key	47	[]	[]
+SELECT * FROM nested_pk ORDER BY complex.key;
+foo	['GoodBye']	[1]

--- a/tests/queries/0_stateless/03800_use_const_adaptive_granularity_vertical_merge_nested.sql.j2
+++ b/tests/queries/0_stateless/03800_use_const_adaptive_granularity_vertical_merge_nested.sql.j2
@@ -1,0 +1,28 @@
+{% for compress_marks in [0, 1] %}
+{% for replace_long_file_name_to_hash in [0, 1] %}
+-- Merged columns: complex.key, Gathered columns: complex.value
+DROP TABLE IF EXISTS nested_no_pk;
+CREATE TABLE nested_no_pk (complex Nested (key String, value Int)) ENGINE = MergeTree ORDER BY tuple() SETTINGS vertical_merge_algorithm_min_rows_to_activate = 1, vertical_merge_algorithm_min_columns_to_activate = 1, min_bytes_for_wide_part = 0, use_const_adaptive_granularity = 1, enable_block_number_column = 0, enable_block_offset_column = 0, auto_statistics_types = '', string_serialization_version = 'single_stream', replace_long_file_name_to_hash = {{ replace_long_file_name_to_hash }}, compress_marks = {{ compress_marks }};
+INSERT INTO nested_no_pk VALUES (['GoodBye'], [1]);
+-- { echo }
+SELECT 'compress_marks={{ compress_marks }}, replace_long_file_name_to_hash = {{ replace_long_file_name_to_hash }}';
+SELECT column, column_marks_bytes, subcolumns.names, subcolumns.marks_bytes FROM system.parts_columns WHERE database = currentDatabase() AND table = 'nested_no_pk' AND active ORDER BY column;
+OPTIMIZE TABLE nested_no_pk PARTITION tuple() FINAL;
+SELECT column, column_marks_bytes, subcolumns.names, subcolumns.marks_bytes FROM system.parts_columns WHERE database = currentDatabase() AND table = 'nested_no_pk' AND active ORDER BY column;
+SELECT * FROM nested_no_pk ORDER BY complex.key;
+-- { echoOff }
+DROP TABLE nested_no_pk;
+
+-- Merged columns: key, Gathered columns: complex.key, complex.value
+DROP TABLE IF EXISTS nested_pk;
+CREATE TABLE nested_pk (key String, complex Nested (key String, value Int)) ENGINE = MergeTree ORDER BY key SETTINGS vertical_merge_algorithm_min_rows_to_activate = 1, vertical_merge_algorithm_min_columns_to_activate = 1, min_bytes_for_wide_part = 0, use_const_adaptive_granularity = 1, enable_block_number_column = 0, enable_block_offset_column = 0, auto_statistics_types = '', string_serialization_version = 'single_stream', replace_long_file_name_to_hash = {{ replace_long_file_name_to_hash }}, compress_marks = {{ compress_marks }};
+INSERT INTO nested_pk VALUES ('foo', ['GoodBye'], [1]);
+-- { echo }
+SELECT column, column_marks_bytes, subcolumns.names, subcolumns.marks_bytes FROM system.parts_columns WHERE database = currentDatabase() AND table = 'nested_pk' AND active ORDER BY column;
+OPTIMIZE TABLE nested_pk FINAL;
+SELECT column, column_marks_bytes, subcolumns.names, subcolumns.marks_bytes FROM system.parts_columns WHERE database = currentDatabase() AND table = 'nested_pk' AND active ORDER BY column;
+SELECT * FROM nested_pk ORDER BY complex.key;
+-- { echoOff }
+DROP TABLE nested_pk;
+{% endfor %}
+{% endfor %}


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Preserve constant index granularity (use_const_adaptive_granularity) after Vertical merges (v2 with a fix for Nested, and in general)

Firstly submitted here - https://github.com/ClickHouse/ClickHouse/pull/94725, but got reverted here - https://github.com/ClickHouse/ClickHouse/pull/95005 due to bugs, the problem was that Vertical merges are not capable to use anything except for existing granularity of the blocks, even though there was an attempt to support it (`WrittenOffsetColumns`), it did not work. Now, Vertical merges of subsequent columns will not overwrite any existing streams.

_Note, this one will not be backported due to complexity_


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.544`
<!-- ch-version-info:end -->