### PR TITLE
Add setting enabling throwing an exception on reading from a table if the table has row policies but no row policies are for the current user

### DIFF
--- a/docs/en/operations/server-configuration-parameters/_server_settings_outside_source.md
+++ b/docs/en/operations/server-configuration-parameters/_server_settings_outside_source.md
@@ -1828,12 +1828,14 @@ Settings for optional improvements in the access control system.
 | `select_from_system_db_requires_grant` | Sets whether `SELECT * FROM system.<table>` requires any grants and can be executed by any user. If set to true then this query requires `GRANT SELECT ON system.<table>` just as for non-system tables. Exceptions: a few system tables (`tables`, `columns`, `databases`, and some constant tables like `one`, `contributors`) are still accessible for everyone; and if there is a `SHOW` privilege (e.g. `SHOW USERS`) granted then the corresponding system table (i.e. `system.users`) will be accessible. | `true`  |
 | `settings_constraints_replace_previous` | Sets whether a constraint in a settings profile for some setting will cancel actions of the previous constraint (defined in other profiles) for that setting, including fields which are not set by the new constraint. It also enables the `changeable_in_readonly` constraint type.                                                                                                                                                                                                                            | `true`  |
 | `table_engines_require_grant` | Sets whether creating a table with a specific table engine requires a grant.                                                                                                                                                                                                                                                                                                                                                                                                                                     | `false` |
+| `throw_if_no_row_policies` | Sets whether reading from a table should throw an exception if the table has row policies, but none of them are for the current user | `false` |
 | `users_without_row_policies_can_read_rows` | Sets whether users without permissive row policies can still read rows using a `SELECT` query. For example, if there are two users A and B and a row policy is defined only for A, then if this setting is true, user B will see all rows. If this setting is false, user B will see no rows.                                                                                                                                                                                                                    | `true`  |
 
 Example:
 
 ```xml
 <access_control_improvements>
+    <throw_if_no_row_policies>true</throw_if_no_row_policies>
     <users_without_row_policies_can_read_rows>true</users_without_row_policies_can_read_rows>
     <on_cluster_queries_require_cluster_grant>true</on_cluster_queries_require_cluster_grant>
     <select_from_system_db_requires_grant>true</select_from_system_db_requires_grant>

--- a/docs/en/operations/server-configuration-parameters/_server_settings_outside_source.md
+++ b/docs/en/operations/server-configuration-parameters/_server_settings_outside_source.md
@@ -1828,14 +1828,14 @@ Settings for optional improvements in the access control system.
 | `select_from_system_db_requires_grant` | Sets whether `SELECT * FROM system.<table>` requires any grants and can be executed by any user. If set to true then this query requires `GRANT SELECT ON system.<table>` just as for non-system tables. Exceptions: a few system tables (`tables`, `columns`, `databases`, and some constant tables like `one`, `contributors`) are still accessible for everyone; and if there is a `SHOW` privilege (e.g. `SHOW USERS`) granted then the corresponding system table (i.e. `system.users`) will be accessible. | `true`  |
 | `settings_constraints_replace_previous` | Sets whether a constraint in a settings profile for some setting will cancel actions of the previous constraint (defined in other profiles) for that setting, including fields which are not set by the new constraint. It also enables the `changeable_in_readonly` constraint type.                                                                                                                                                                                                                            | `true`  |
 | `table_engines_require_grant` | Sets whether creating a table with a specific table engine requires a grant.                                                                                                                                                                                                                                                                                                                                                                                                                                     | `false` |
-| `throw_if_no_row_policies` | Sets whether reading from a table should throw an exception if the table has row policies, but none of them are for the current user | `false` |
+| `throw_on_unmatched_row_policies` | Sets whether reading from a table should throw an exception if the table has row policies, but none of them are for the current user | `false` |
 | `users_without_row_policies_can_read_rows` | Sets whether users without permissive row policies can still read rows using a `SELECT` query. For example, if there are two users A and B and a row policy is defined only for A, then if this setting is true, user B will see all rows. If this setting is false, user B will see no rows.                                                                                                                                                                                                                    | `true`  |
 
 Example:
 
 ```xml
 <access_control_improvements>
-    <throw_if_no_row_policies>true</throw_if_no_row_policies>
+    <throw_on_unmatched_row_policies>true</throw_on_unmatched_row_policies>
     <users_without_row_policies_can_read_rows>true</users_without_row_policies_can_read_rows>
     <on_cluster_queries_require_cluster_grant>true</on_cluster_queries_require_cluster_grant>
     <select_from_system_db_requires_grant>true</select_from_system_db_requires_grant>

--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -820,6 +820,11 @@
     </user_directories>
 
     <access_control_improvements>
+        <!-- Whether reading from a table should throw an exception if the table has row policies,
+             but none of them are for the current user.
+             By default this setting is false. -->
+        <throw_if_no_row_policies>false</throw_if_no_row_policies>
+
         <!-- Enables logic that users without permissive row policies can still read rows using a SELECT query.
              For example, if there two users A, B and a row policy is defined only for A, then
              if this setting is true the user B will see all rows, and if this setting is false the user B will see no rows.

--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -823,7 +823,7 @@
         <!-- Whether reading from a table should throw an exception if the table has row policies,
              but none of them are for the current user.
              By default this setting is false. -->
-        <throw_if_no_row_policies>false</throw_if_no_row_policies>
+        <throw_on_unmatched_row_policies>false</throw_on_unmatched_row_policies>
 
         <!-- Enables logic that users without permissive row policies can still read rows using a SELECT query.
              For example, if there two users A, B and a row policy is defined only for A, then

--- a/src/Access/AccessControl.cpp
+++ b/src/Access/AccessControl.cpp
@@ -301,6 +301,7 @@ void AccessControl::setupFromMainConfig(const Poco::Util::AbstractConfiguration 
 
     /// Optional improvements in access control system.
     /// The default values are false because we need to be compatible with earlier access configurations
+    setShouldThrowIfNoRowPolicies(config_.getBool("access_control_improvements.throw_if_no_row_policies", false));
     setEnabledUsersWithoutRowPoliciesCanReadRows(config_.getBool("access_control_improvements.users_without_row_policies_can_read_rows", true));
     setOnClusterQueriesRequireClusterGrant(config_.getBool("access_control_improvements.on_cluster_queries_require_cluster_grant", true));
     setSelectFromSystemDatabaseRequiresGrant(config_.getBool("access_control_improvements.select_from_system_db_requires_grant", true));

--- a/src/Access/AccessControl.cpp
+++ b/src/Access/AccessControl.cpp
@@ -301,7 +301,7 @@ void AccessControl::setupFromMainConfig(const Poco::Util::AbstractConfiguration 
 
     /// Optional improvements in access control system.
     /// The default values are false because we need to be compatible with earlier access configurations
-    setShouldThrowIfNoRowPolicies(config_.getBool("access_control_improvements.throw_if_no_row_policies", false));
+    setThrowOnUnmatchedRowPolicies(config_.getBool("access_control_improvements.throw_on_unmatched_row_policies", false));
     setEnabledUsersWithoutRowPoliciesCanReadRows(config_.getBool("access_control_improvements.users_without_row_policies_can_read_rows", true));
     setOnClusterQueriesRequireClusterGrant(config_.getBool("access_control_improvements.on_cluster_queries_require_cluster_grant", true));
     setSelectFromSystemDatabaseRequiresGrant(config_.getBool("access_control_improvements.select_from_system_db_requires_grant", true));

--- a/src/Access/AccessControl.h
+++ b/src/Access/AccessControl.h
@@ -179,6 +179,11 @@ public:
     void setEnableReadWriteGrants(bool enable_read_write_grants_);
     bool isEnabledReadWriteGrants() const;
 
+    /// Sets whether reading from a table should throw an exception if the table has row policies,
+    /// but none of them are for the current user.
+    void setShouldThrowIfNoRowPolicies(bool enable) { throw_if_no_row_policies = enable; }
+    bool shouldThrowIfNoRowPolicies() const { return throw_if_no_row_policies; }
+
     /// Enables logic that users without permissive row policies can still read rows using a SELECT query.
     /// For example, if there are two users A, B and a row policy is defined only for A, then
     /// if this setting is true the user B will see all rows, and if this setting is false the user B will see no rows.
@@ -283,6 +288,7 @@ private:
     std::atomic_bool allow_plaintext_password = true;
     std::atomic_bool allow_no_password = true;
     std::atomic_bool allow_implicit_no_password = true;
+    std::atomic_bool throw_if_no_row_policies = false;
     std::atomic_bool users_without_row_policies_can_read_rows = false;
     std::atomic_bool on_cluster_queries_require_cluster_grant = false;
     std::atomic_bool select_from_system_db_requires_grant = false;

--- a/src/Access/AccessControl.h
+++ b/src/Access/AccessControl.h
@@ -181,8 +181,8 @@ public:
 
     /// Sets whether reading from a table should throw an exception if the table has row policies,
     /// but none of them are for the current user.
-    void setShouldThrowIfNoRowPolicies(bool enable) { throw_if_no_row_policies = enable; }
-    bool shouldThrowIfNoRowPolicies() const { return throw_if_no_row_policies; }
+    void setThrowOnUnmatchedRowPolicies(bool enable) { throw_on_unmatched_row_policies = enable; }
+    bool shouldThrowOnUnmatchedRowPolicies() const { return throw_on_unmatched_row_policies; }
 
     /// Enables logic that users without permissive row policies can still read rows using a SELECT query.
     /// For example, if there are two users A, B and a row policy is defined only for A, then
@@ -288,7 +288,7 @@ private:
     std::atomic_bool allow_plaintext_password = true;
     std::atomic_bool allow_no_password = true;
     std::atomic_bool allow_implicit_no_password = true;
-    std::atomic_bool throw_if_no_row_policies = false;
+    std::atomic_bool throw_on_unmatched_row_policies = false;
     std::atomic_bool users_without_row_policies_can_read_rows = false;
     std::atomic_bool on_cluster_queries_require_cluster_grant = false;
     std::atomic_bool select_from_system_db_requires_grant = false;

--- a/src/Access/ContextAccess.cpp
+++ b/src/Access/ContextAccess.cpp
@@ -486,22 +486,45 @@ std::shared_ptr<const EnabledRolesInfo> ContextAccess::getRolesInfo() const
 
 RowPolicyFilterPtr ContextAccess::getRowPolicyFilter(const String & database, const String & table_name, RowPolicyFilterType filter_type) const
 {
-    std::lock_guard lock{mutex};
-
-    if (initialized && !user && !user_was_dropped)
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "ContextAccess is inconsistent (bug 55041)");
-
     RowPolicyFilterPtr filter;
-    if (enabled_row_policies)
-        filter = enabled_row_policies->getFilter(database, table_name, filter_type);
 
-    if (row_policies_of_initial_user)
     {
-        /// Find and set extra row policies to be used based on `client_info.initial_user`, if the initial user exists.
-        /// TODO: we need a better solution here. It seems we should pass the initial row policy
-        /// because a shard is allowed to not have the initial user or it might be another user
-        /// with the same name.
-        filter = row_policies_of_initial_user->getFilter(database, table_name, filter_type, filter);
+        std::lock_guard lock{mutex};
+
+        if (initialized && !user && !user_was_dropped)
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "ContextAccess is inconsistent (bug 55041)");
+
+        if (enabled_row_policies)
+            filter = enabled_row_policies->getFilter(database, table_name, filter_type);
+
+        if (row_policies_of_initial_user)
+        {
+            /// Find and set extra row policies to be used based on `client_info.initial_user`, if the initial user exists.
+            /// TODO: we need a better solution here. It seems we should pass the initial row policy
+            /// because a shard is allowed to not have the initial user or it might be another user
+            /// with the same name.
+            filter = row_policies_of_initial_user->getFilter(database, table_name, filter_type, filter);
+        }
+    }
+
+    if (filter && filter->policies.empty())
+    {
+        if (access_control->shouldThrowIfNoRowPolicies())
+        {
+            throw Exception(ErrorCodes::ACCESS_DENIED,
+                            "{}: Table {}.{} has row policies, but none of them are for the current user",
+                            getUserName(), backQuoteIfNeed(database), backQuoteIfNeed(table_name));
+        }
+        else
+        {
+            chassert(filter->isAlwaysTrue() || filter->isAlwaysFalse());
+            std::string_view filter_info =
+                filter->isAlwaysTrue() ? ", no filters will be used" :
+                (filter->isAlwaysFalse() ? ", no rows will be shown" : "");
+
+            LOG_TRACE(trace_log, "{}: Table {}.{} has row policies, but none of them are for the current user{}",
+                      getUserName(), backQuoteIfNeed(database), backQuoteIfNeed(table_name), filter_info);
+        }
     }
 
     return filter;

--- a/src/Access/ContextAccess.cpp
+++ b/src/Access/ContextAccess.cpp
@@ -509,7 +509,7 @@ RowPolicyFilterPtr ContextAccess::getRowPolicyFilter(const String & database, co
 
     if (filter && filter->policies.empty())
     {
-        if (access_control->shouldThrowIfNoRowPolicies())
+        if (access_control->shouldThrowOnUnmatchedRowPolicies())
         {
             throw Exception(ErrorCodes::ACCESS_DENIED,
                             "{}: Table {}.{} has row policies, but none of them are for the current user",

--- a/src/Access/EnabledRowPolicies.cpp
+++ b/src/Access/EnabledRowPolicies.cpp
@@ -7,10 +7,16 @@
 namespace DB
 {
 
-bool RowPolicyFilter::empty() const
+bool RowPolicyFilter::isAlwaysTrue() const
 {
     bool value;
     return !expression || (tryGetLiteralBool(expression.get(), value) && value);
+}
+
+bool RowPolicyFilter::isAlwaysFalse() const
+{
+    bool value;
+    return expression && (tryGetLiteralBool(expression.get(), value) && !value);
 }
 
 size_t EnabledRowPolicies::Hash::operator()(const MixedFiltersKey & key) const
@@ -53,11 +59,11 @@ RowPolicyFilterPtr EnabledRowPolicies::getFilter(const String & database, const 
     {
         auto new_filter = std::make_shared<RowPolicyFilter>(*filter);
 
-        if (filter->empty())
+        if (filter->isAlwaysTrue())
         {
             new_filter->expression = combine_with_filter->expression;
         }
-        else if (combine_with_filter->empty())
+        else if (combine_with_filter->isAlwaysTrue())
         {
             new_filter->expression = filter->expression;
         }

--- a/src/Access/EnabledRowPolicies.h
+++ b/src/Access/EnabledRowPolicies.h
@@ -22,7 +22,8 @@ struct RowPolicyFilter
     std::shared_ptr<const std::pair<String, String>> database_and_table_name;
     std::vector<RowPolicyPtr> policies;
 
-    bool empty() const;
+    bool isAlwaysTrue() const;
+    bool isAlwaysFalse() const;
 };
 
 using RowPolicyFilterPtr = std::shared_ptr<const RowPolicyFilter>;

--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -902,7 +902,7 @@ InterpreterSelectQuery::InterpreterSelectQuery(
             query_info.filter_asts.clear();
 
             /// Fix source_header for filter actions.
-            if (row_policy_filter && !row_policy_filter->empty())
+            if (row_policy_filter && !row_policy_filter->isAlwaysTrue())
             {
                 row_policy_info = generateFilterActions(
                     table_id, row_policy_filter->expression, context, storage, storage_snapshot, metadata_snapshot, required_columns,

--- a/src/Planner/PlannerJoinTree.cpp
+++ b/src/Planner/PlannerJoinTree.cpp
@@ -563,7 +563,7 @@ std::optional<FilterDAGInfo> buildRowPolicyFilterIfNeeded(const StoragePtr & sto
     const auto & query_context = planner_context->getQueryContext();
 
     auto row_policy_filter = query_context->getRowPolicyFilter(storage_id.getDatabaseName(), storage_id.getTableName(), RowPolicyFilterType::SELECT_FILTER);
-    if (!row_policy_filter || row_policy_filter->empty())
+    if (!row_policy_filter || row_policy_filter->isAlwaysTrue())
         return {};
 
     for (const auto & row_policy : row_policy_filter->policies)

--- a/src/Storages/StorageMerge.cpp
+++ b/src/Storages/StorageMerge.cpp
@@ -721,7 +721,7 @@ std::vector<ReadFromMerge::ChildPlan> ReadFromMerge::createChildrenPlans(SelectQ
                 database_name,
                 table_name,
                 RowPolicyFilterType::SELECT_FILTER);
-            if (row_policy_filter_ptr && !row_policy_filter_ptr->empty())
+            if (row_policy_filter_ptr && !row_policy_filter_ptr->isAlwaysTrue())
             {
                 row_policy_data_opt = RowPolicyData(row_policy_filter_ptr, storage, modified_context);
                 row_policy_data_opt->extendNames(real_column_names);

--- a/tests/casa_del_dolor/properties.py
+++ b/tests/casa_del_dolor/properties.py
@@ -93,6 +93,7 @@ possible_properties = {
         "select_from_system_db_requires_grant": true_false_lambda,
         "settings_constraints_replace_previous": true_false_lambda,
         "table_engines_require_grant": true_false_lambda,
+        "throw_if_no_row_policies": true_false_lambda,
         "users_without_row_policies_can_read_rows": true_false_lambda,
     },
     "aggregate_function_group_array_action_when_limit_is_reached": lambda: random.choice(

--- a/tests/casa_del_dolor/properties.py
+++ b/tests/casa_del_dolor/properties.py
@@ -93,7 +93,7 @@ possible_properties = {
         "select_from_system_db_requires_grant": true_false_lambda,
         "settings_constraints_replace_previous": true_false_lambda,
         "table_engines_require_grant": true_false_lambda,
-        "throw_if_no_row_policies": true_false_lambda,
+        "throw_on_unmatched_row_policies": true_false_lambda,
         "users_without_row_policies_can_read_rows": true_false_lambda,
     },
     "aggregate_function_group_array_action_when_limit_is_reached": lambda: random.choice(

--- a/tests/config/config.d/enable_access_control_improvements.xml
+++ b/tests/config/config.d/enable_access_control_improvements.xml
@@ -1,5 +1,6 @@
 <clickhouse>
     <access_control_improvements>
+        <throw_if_no_row_policies>true</throw_if_no_row_policies>
         <users_without_row_policies_can_read_rows>true</users_without_row_policies_can_read_rows>
         <on_cluster_queries_require_cluster_grant>true</on_cluster_queries_require_cluster_grant>
         <select_from_system_db_requires_grant>true</select_from_system_db_requires_grant>

--- a/tests/config/config.d/enable_access_control_improvements.xml
+++ b/tests/config/config.d/enable_access_control_improvements.xml
@@ -1,6 +1,6 @@
 <clickhouse>
     <access_control_improvements>
-        <throw_if_no_row_policies>true</throw_if_no_row_policies>
+        <throw_on_unmatched_row_policies>true</throw_on_unmatched_row_policies>
         <users_without_row_policies_can_read_rows>true</users_without_row_policies_can_read_rows>
         <on_cluster_queries_require_cluster_grant>true</on_cluster_queries_require_cluster_grant>
         <select_from_system_db_requires_grant>true</select_from_system_db_requires_grant>

--- a/tests/integration/helpers/0_common_instance_config.xml
+++ b/tests/integration/helpers/0_common_instance_config.xml
@@ -23,6 +23,7 @@
     </logger>
 
     <access_control_improvements>
+        <throw_if_no_row_policies>true</throw_if_no_row_policies>
         <users_without_row_policies_can_read_rows>true</users_without_row_policies_can_read_rows>
         <on_cluster_queries_require_cluster_grant>true</on_cluster_queries_require_cluster_grant>
         <select_from_system_db_requires_grant>true</select_from_system_db_requires_grant>

--- a/tests/integration/helpers/0_common_instance_config.xml
+++ b/tests/integration/helpers/0_common_instance_config.xml
@@ -23,7 +23,7 @@
     </logger>
 
     <access_control_improvements>
-        <throw_if_no_row_policies>true</throw_if_no_row_policies>
+        <throw_on_unmatched_row_policies>true</throw_on_unmatched_row_policies>
         <users_without_row_policies_can_read_rows>true</users_without_row_policies_can_read_rows>
         <on_cluster_queries_require_cluster_grant>true</on_cluster_queries_require_cluster_grant>
         <select_from_system_db_requires_grant>true</select_from_system_db_requires_grant>

--- a/tests/integration/test_disabled_access_control_improvements/configs/config.d/disable_access_control_improvements.xml
+++ b/tests/integration/test_disabled_access_control_improvements/configs/config.d/disable_access_control_improvements.xml
@@ -1,5 +1,6 @@
 <clickhouse>
     <access_control_improvements>
+        <throw_if_no_row_policies>false</throw_if_no_row_policies>
         <users_without_row_policies_can_read_rows>false</users_without_row_policies_can_read_rows>
         <select_from_system_db_requires_grant>false</select_from_system_db_requires_grant>
         <select_from_information_schema_requires_grant>false</select_from_information_schema_requires_grant>

--- a/tests/integration/test_disabled_access_control_improvements/configs/config.d/disable_access_control_improvements.xml
+++ b/tests/integration/test_disabled_access_control_improvements/configs/config.d/disable_access_control_improvements.xml
@@ -1,6 +1,6 @@
 <clickhouse>
     <access_control_improvements>
-        <throw_if_no_row_policies>false</throw_if_no_row_policies>
+        <throw_on_unmatched_row_policies>false</throw_on_unmatched_row_policies>
         <users_without_row_policies_can_read_rows>false</users_without_row_policies_can_read_rows>
         <select_from_system_db_requires_grant>false</select_from_system_db_requires_grant>
         <select_from_information_schema_requires_grant>false</select_from_information_schema_requires_grant>

--- a/tests/integration/test_disabled_access_control_improvements/configs/config.d/users_without_row_policies_can_read_rows.xml
+++ b/tests/integration/test_disabled_access_control_improvements/configs/config.d/users_without_row_policies_can_read_rows.xml
@@ -1,0 +1,6 @@
+<clickhouse>
+    <access_control_improvements>
+        <throw_if_no_row_policies>false</throw_if_no_row_policies>
+        <users_without_row_policies_can_read_rows>true</users_without_row_policies_can_read_rows>
+    </access_control_improvements>
+</clickhouse>

--- a/tests/integration/test_disabled_access_control_improvements/configs/config.d/users_without_row_policies_can_read_rows.xml
+++ b/tests/integration/test_disabled_access_control_improvements/configs/config.d/users_without_row_policies_can_read_rows.xml
@@ -1,6 +1,6 @@
 <clickhouse>
     <access_control_improvements>
-        <throw_if_no_row_policies>false</throw_if_no_row_policies>
+        <throw_on_unmatched_row_policies>false</throw_on_unmatched_row_policies>
         <users_without_row_policies_can_read_rows>true</users_without_row_policies_can_read_rows>
     </access_control_improvements>
 </clickhouse>

--- a/tests/integration/test_disabled_access_control_improvements/test_users_without_row_policies_can_read_rows.py
+++ b/tests/integration/test_disabled_access_control_improvements/test_users_without_row_policies_can_read_rows.py
@@ -1,0 +1,184 @@
+import os
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import TSV
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance(
+    "node",
+    main_configs=["configs/config.d/users_without_row_policies_can_read_rows.xml"],
+    user_configs=[
+        "configs/users.d/row_policy.xml",
+        "configs/users.d/another_user.xml",
+    ],
+)
+
+
+def copy_policy_xml(local_file_name, reload_immediately=True):
+    script_dir = os.path.dirname(os.path.realpath(__file__))
+    node.copy_file_to_container(
+        os.path.join(script_dir, local_file_name),
+        "/etc/clickhouse-server/users.d/row_policy.xml",
+    )
+    if reload_immediately:
+        node.query("SYSTEM RELOAD CONFIG")
+
+
+@pytest.fixture(scope="module", autouse=True)
+def started_cluster():
+    try:
+        cluster.start()
+
+        node.query(
+            """
+            CREATE DATABASE mydb;
+
+            CREATE TABLE mydb.filtered_table1 (a UInt8, b UInt8) ENGINE MergeTree ORDER BY a;
+            INSERT INTO mydb.filtered_table1 values (0, 0), (0, 1), (1, 0), (1, 1);
+
+            CREATE TABLE mydb.table (a UInt8, b UInt8) ENGINE MergeTree ORDER BY a;
+            INSERT INTO mydb.table values (0, 0), (0, 1), (1, 0), (1, 1);
+
+            CREATE TABLE mydb.filtered_table2 (a UInt8, b UInt8, c UInt8, d UInt8) ENGINE MergeTree ORDER BY a;
+            INSERT INTO mydb.filtered_table2 values (0, 0, 0, 0), (1, 2, 3, 4), (4, 3, 2, 1), (0, 0, 6, 0);
+
+            CREATE TABLE mydb.filtered_table3 (a UInt8, b UInt8, bb ALIAS b + 1, c UInt16 ALIAS a + bb - 1) ENGINE MergeTree ORDER BY a;
+            INSERT INTO mydb.filtered_table3 values (0, 0), (0, 1), (1, 0), (1, 1);
+
+            CREATE TABLE mydb.local (a UInt8, b UInt8) ENGINE MergeTree ORDER BY a;
+        """
+        )
+
+        node.query("INSERT INTO mydb.local values (2, 0), (2, 1), (1, 0), (1, 1)")
+
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+
+@pytest.fixture(autouse=True)
+def reset_policies():
+    try:
+        yield
+    finally:
+        copy_policy_xml("normal_filters.xml")
+        node.query("DROP POLICY IF EXISTS pA, pB ON mydb.filtered_table1")
+
+
+def test_policy_from_users_xml_affects_only_user_assigned():
+    assert node.query("SELECT * FROM mydb.filtered_table1") == TSV([[1, 0], [1, 1]])
+    assert node.query("SELECT * FROM mydb.filtered_table1", user="another") == TSV(
+        [[0, 0], [0, 1], [1, 0], [1, 1]]
+    )
+
+    assert node.query("SELECT * FROM mydb.filtered_table2") == TSV(
+        [[0, 0, 0, 0], [0, 0, 6, 0]]
+    )
+    assert node.query("SELECT * FROM mydb.filtered_table2", user="another") == TSV(
+        [[0, 0, 0, 0], [0, 0, 6, 0], [1, 2, 3, 4], [4, 3, 2, 1]]
+    )
+
+    assert node.query("SELECT * FROM mydb.local") == TSV(
+        [[1, 0], [1, 1], [2, 0], [2, 1]]
+    )
+    assert node.query("SELECT * FROM mydb.local", user="another") == TSV(
+        [[1, 0], [1, 1]]
+    )
+
+
+def test_dcl_management():
+    copy_policy_xml("no_filters.xml")
+    assert node.query("SHOW POLICIES") == ""
+
+    node.query("CREATE POLICY pA ON mydb.filtered_table1 FOR SELECT USING a<b")
+    assert node.query("SELECT * FROM mydb.filtered_table1") == TSV(
+        [[0, 0], [0, 1], [1, 0], [1, 1]]
+    )
+    assert node.query("SHOW POLICIES ON mydb.filtered_table1") == "pA\n"
+
+    node.query("ALTER POLICY pA ON mydb.filtered_table1 TO default")
+    assert node.query("SELECT * FROM mydb.filtered_table1") == TSV([[0, 1]])
+    assert node.query("SHOW POLICIES ON mydb.filtered_table1") == "pA\n"
+
+    node.query("ALTER POLICY pA ON mydb.filtered_table1 FOR SELECT USING a>b")
+    assert node.query("SELECT * FROM mydb.filtered_table1") == TSV([[1, 0]])
+
+    node.query("ALTER POLICY pA ON mydb.filtered_table1 RENAME TO pB")
+    assert node.query("SELECT * FROM mydb.filtered_table1") == TSV([[1, 0]])
+    assert node.query("SHOW POLICIES ON mydb.filtered_table1") == "pB\n"
+    assert (
+        node.query("SHOW CREATE POLICY pB ON mydb.filtered_table1")
+        == "CREATE ROW POLICY pB ON mydb.filtered_table1 FOR SELECT USING a > b TO default\n"
+    )
+
+    node.query("DROP POLICY pB ON mydb.filtered_table1")
+    assert node.query("SELECT * FROM mydb.filtered_table1") == TSV(
+        [[0, 0], [0, 1], [1, 0], [1, 1]]
+    )
+    assert node.query("SHOW POLICIES") == ""
+
+
+def test_dcl_users_with_policies_from_users_xml():
+    node.query("CREATE USER X")
+    node.query("GRANT SELECT ON mydb.filtered_table1 TO X")
+
+    assert node.query("SELECT * FROM mydb.filtered_table1") == TSV([[1, 0], [1, 1]])
+
+    assert node.query("SELECT * FROM mydb.filtered_table1", user="X") == TSV(
+        [[0, 0], [0, 1], [1, 0], [1, 1]]
+    )
+
+    node.query("DROP USER X")
+
+
+def test_some_users_without_policies():
+    copy_policy_xml("no_filters.xml")
+    assert node.query("SHOW POLICIES") == ""
+    node.query("CREATE USER X, Y")
+    node.query("GRANT SELECT ON mydb.filtered_table1 TO X, Y")
+
+    # permissive a >= b for X, none for Y
+    node.query(
+        "CREATE POLICY pA ON mydb.filtered_table1 FOR SELECT USING a >= b AS permissive TO X"
+    )
+    assert node.query("SELECT * FROM mydb.filtered_table1", user="X") == TSV(
+        [[0, 0], [1, 0], [1, 1]]
+    )
+    assert node.query("SELECT * FROM mydb.filtered_table1", user="Y") == TSV(
+        [[0, 0], [0, 1], [1, 0], [1, 1]]
+    )
+
+    # restrictive a >=b for X, none for Y
+    node.query("ALTER POLICY pA ON mydb.filtered_table1 AS restrictive")
+    assert node.query("SELECT * FROM mydb.filtered_table1", user="X") == TSV(
+        [[0, 0], [1, 0], [1, 1]]
+    )
+    assert node.query("SELECT * FROM mydb.filtered_table1", user="Y") == TSV(
+        [[0, 0], [0, 1], [1, 0], [1, 1]]
+    )
+
+    # permissive a >= b for X, restrictive a <= b for X, none for Y
+    node.query("ALTER POLICY pA ON mydb.filtered_table1 AS permissive")
+    node.query(
+        "CREATE POLICY pB ON mydb.filtered_table1 FOR SELECT USING a <= b AS restrictive TO X"
+    )
+    assert node.query("SELECT * FROM mydb.filtered_table1", user="X") == TSV(
+        [[0, 0], [1, 1]]
+    )
+    assert node.query("SELECT * FROM mydb.filtered_table1", user="Y") == TSV(
+        [[0, 0], [0, 1], [1, 0], [1, 1]]
+    )
+
+    # permissive a >= b for X, restrictive a <= b for Y
+    node.query("ALTER POLICY pB ON mydb.filtered_table1 TO Y")
+    assert node.query("SELECT * FROM mydb.filtered_table1", user="X") == TSV(
+        [[0, 0], [1, 0], [1, 1]]
+    )
+    assert node.query("SELECT * FROM mydb.filtered_table1", user="Y") == TSV(
+        [[0, 0], [0, 1], [1, 1]]
+    )
+
+    node.query("DROP POLICY pA, pB ON mydb.filtered_table1")
+    node.query("DROP USER X, Y")


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add setting enabling throwing an exception on reading from a table if the table has some row policies but no row policies are for the current user. That often means misconfiguration of the access control so it's better to throw an exception in such cases.

Example:
```
CREATE USER u1;
CREATE USER u2;
CREATE TABLE mydb.test_table(x Int64) ENGINE=MergeTree ORDER BY x;
GRANT SELECT ON mydb.test_table TO u1, u2;
CREATE ROW POLICY p1 ON mydb.test_table FOR SELECT USING x<100 TO u1;

<login as u1>
SELECT * FROM mydb.test_table; -- OK

<login as u2>
SELECT * FROM mydb.test_table; -- FAIL:
DB::Exception: ACCESS_DENIED: u2: Table mydb.test_table has row policies, but none of them are for the current user
```

Earlier `SELECT * FROM mydb.test_table` returned either no rows or all rows of `mydb.test_table` (depending on the server setting `users_without_row_policies_can_read_rows`), and both these behaviors were unexpected for some people.

See https://github.com/ClickHouse/ClickHouse/issues/93968, https://github.com/ClickHouse/ClickHouse/issues/33775.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.620`
<!-- ch-version-info:end -->