### PR TITLE
Fix assertion failure in Parquet writer when row group write is interrupted

### DIFF
--- a/src/Processors/Formats/Impl/ParquetBlockOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/ParquetBlockOutputFormat.cpp
@@ -246,7 +246,7 @@ void ParquetBlockOutputFormat::finalizeImpl()
             }
         }
 
-        if (file_state.completed_row_groups.empty())
+        if (file_state.offset == 0)
         {
             base_offset = out.count();
             writeFileHeader(file_state, out);
@@ -405,7 +405,7 @@ void ParquetBlockOutputFormat::writeRowGroupInOneThread(Chunk chunk)
             chunk.getColumns()[i], header.getByPosition(i).type, header.getByPosition(i).name,
             options, &columns_to_write);
 
-    if (file_state.completed_row_groups.empty())
+    if (file_state.offset == 0)
     {
         base_offset = out.count();
         writeFileHeader(file_state, out);
@@ -467,7 +467,7 @@ void ParquetBlockOutputFormat::reapCompletedRowGroups(std::unique_lock<std::mute
 
         lock.unlock();
 
-        if (file_state.completed_row_groups.empty())
+        if (file_state.offset == 0)
         {
             base_offset = out.count();
             writeFileHeader(file_state, out);


### PR DESCRIPTION
The Parquet writer was using `file_state.completed_row_groups.empty()` to decide whether to write the file header, but the assertion inside `writeFileHeader` checks `file.offset == 0`. These conditions can diverge when an exception occurs after the header is written but before `finalizeRowGroup` completes.

The failing scenario:
1. A row group starts being written - `writeFileHeader` is called, setting `offset = 4`
2. Column chunks are written, increasing `offset` further
3. An exception occurs before `finalizeRowGroup` is called
4. Now `offset > 0` but `completed_row_groups` is still empty
5. When `finalizeImpl` is called during cleanup, it sees `completed_row_groups.empty()` is true
6. It tries to write the header again, but `offset != 0` - assertion fails

The fix changes the condition from `file_state.completed_row_groups.empty()` to `file_state.offset == 0` in all three places where `writeFileHeader` is called. This ensures the check is consistent with the assertion - the header is only written when no data has been written to the file yet.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

See https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=95008&sha=91a0d339f2eee3b0ffc6d47dcabdbb2dd2b951ad&name_0=PR&name_1=BuzzHouse%20%28amd_msan%29
https://github.com/ClickHouse/ClickHouse/pull/95008


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.813`
<!-- ch-version-info:end -->