### PR TITLE
Modernize time limit, and set it for CI runs

### DIFF
--- a/ci/jobs/buzzhouse_job.py
+++ b/ci/jobs/buzzhouse_job.py
@@ -221,6 +221,8 @@ def main():
         "allow_transactions": allow_transactions,
         # Run query oracles sometimes
         "allow_query_oracles": random.randint(1, 4) == 1,
+        # Run for 30 minutes max
+        "time_to_run": 30,
         "remote_servers": ["localhost:9000"],
         "remote_secure_servers": ["localhost:9440"],
         "http_servers": ["localhost:8123"],

--- a/programs/client/FuzzLoop.cpp
+++ b/programs/client/FuzzLoop.cpp
@@ -498,19 +498,6 @@ bool Client::processBuzzHouseQuery(const String & full_query)
     return server_up;
 }
 
-using sighandler_t = void (*)(int);
-sighandler_t volatile prev_signal = nullptr;
-std::sig_atomic_t volatile buzz_done = 0;
-
-static void finishBuzzHouse(int num)
-{
-    if (prev_signal)
-    {
-        prev_signal(num);
-    }
-    buzz_done = 1;
-}
-
 bool Client::fuzzLoopReconnect()
 {
     connection->disconnect();
@@ -548,18 +535,16 @@ bool Client::buzzHouse()
         R"((?i)^--External\s+command\s+(?:(async)\s+)?with\s+seed\s+(\d+)\s+to\s([^\s.]+)\stable\s+([^\s.]+)\.([^\s.]+)\s*$)");
 
     /// Set time to run, but what if a query runs for too long?
-    buzz_done = 0;
-    if (fuzz_config->time_to_run > 0)
-    {
-        prev_signal = std::signal(SIGALRM, finishBuzzHouse);
-    }
-    alarm(fuzz_config->time_to_run);
+    using clock = std::chrono::steady_clock;
+    const auto deadline = fuzz_config->time_to_run > 0
+        ? std::optional<clock::time_point>(clock::now() + std::chrono::minutes(fuzz_config->time_to_run))
+        : std::nullopt;
     full_query.reserve(8192);
     if (fuzz_config->read_log)
     {
         std::ifstream infile(fuzz_config->log_path);
 
-        while (server_up && !buzz_done && std::getline(infile, full_query))
+        while (server_up && (!deadline || clock::now() < *deadline) && std::getline(infile, full_query))
         {
             String async_flag;
             String seed_str;
@@ -643,7 +628,7 @@ bool Client::buzzHouse()
         full_query2.reserve(8192);
         BuzzHouse::StatementGenerator gen(rg, *fuzz_config, *external_integrations, has_cloud_features);
         BuzzHouse::QueryOracle qo(*fuzz_config);
-        while (server_up && !buzz_done)
+        while (server_up && (!deadline || clock::now() < *deadline))
         {
             sq1.Clear();
             full_query.resize(0);


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- What the title says. BuzzHouse is going to run for 30 minutes max at each CI run. cc @maxknv
- Also added a few log messages about how the fuzzing session ended.

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.819`
<!-- ch-version-info:end -->