### PR TITLE
Fix a logical error exception that occurs when createEmptyPartInsteadOfLost is called on a readonly replica

### DIFF
--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -10807,6 +10807,12 @@ bool StorageReplicatedMergeTree::checkIfDetachedPartitionExists(const String & p
 
 bool StorageReplicatedMergeTree::createEmptyPartInsteadOfLost(zkutil::ZooKeeperPtr zookeeper, const String & lost_part_name)
 {
+    if (is_readonly)
+    {
+        LOG_WARNING(log, "Cannot replace lost part {} with empty part because replica is readonly", lost_part_name);
+        return false;
+    }
+
     LOG_INFO(log, "Going to replace lost part {} with empty part", lost_part_name);
 
     auto new_part_info = MergeTreePartInfo::fromPartName(lost_part_name, format_version);


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

Logical error: 'Tried to pull logs to queue (reason: MERGE_PREDICATE) on readonly replica d21.t752, it's a bug'

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=95016&sha=1b36ff5b2f0cfa88955bc81ebcae4e0044addcad&name_0=PR&name_1=BuzzHouse%20%28amd_debug%29
https://github.com/ClickHouse/ClickHouse/pull/95016

  ### Root Cause Analysis

  The issue occurs through the following sequence:

  1. A table is converted to `ReplicatedMergeTree` but stays in **readonly mode** because ZooKeeper metadata is missing

  2. A `CHECK TABLE` query runs on this readonly replica. When it finds parts that are "young" (not yet in ZooKeeper), it enqueues them for a delayed recheck (typically
  285 seconds later) via `enqueuePart`

  3. During the delay, `SYSTEM RESTORE REPLICA` may be executed, which:
     - Moves existing parts to `detached/`
     - Creates ZooKeeper nodes
     - Attempts to attach parts back, but this can **timeout** leaving the replica still readonly

  4. When the delayed part check runs (~5 minutes later):
     - The part is not in ZooKeeper (commit timed out)
     - The part is not on disk (moved to detached)
     - `checkPartAndFix` → `onPartIsLostForever` → `createEmptyPartInsteadOfLost` is called

  5. `createEmptyPartInsteadOfLost` calls `queue.getMergePredicate()` which internally calls `pullLogsToQueue` with reason `MERGE_PREDICATE`

  6. `pullLogsToQueue` has a safety check that throws `LOGICAL_ERROR` when called on a readonly replica (to catch programming bugs), causing the server to abort in debug
   builds

  ### Why the part_check_thread runs on a readonly replica

  The `part_check_thread` background loop is only started by `RestartingThread` after the replica is fully activated. However, parts can be **enqueued for checking**
  through other code paths:

  - `CHECK TABLE` query calls `part_check_thread.checkPartAndFix()` directly
  - This can enqueue parts for delayed rechecking even on a readonly replica
  - When the background thread later processes these enqueued parts, the replica may still be readonly

  ### The Fix

  Add readonly checks in `createEmptyPartInsteadOfLost`:

  1. **Early check at function entry**: Avoids unnecessary work (creating temp parts, transactions) when we already know the operation will fail

  2. **Check inside the retry loop**: Catches the case where the replica becomes readonly during the operation (e.g., ZooKeeper session expires)

  When `createEmptyPartInsteadOfLost` returns `false`, the caller (`onPartIsLostForever`) logs a warning and the operation will be retried later, which is appropriate
  behavior for a temporarily readonly replica.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.841`
<!-- ch-version-info:end -->