### PR TITLE
CI: Scrape system tables regardless of rows count

### DIFF
--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -42,7 +42,7 @@ class ClickHouseProc:
 """
     MINIO_LOG = f"{temp_dir}/minio.log"
     AZURITE_LOG = f"{temp_dir}/azurite.log"
-    LOGS_SAVER_CLIENT_OPTIONS = "--max_memory_usage 10G --max_threads 1 --max_result_rows 0 --max_result_bytes 0 --max_bytes_to_read 0 --max_execution_time 0 --max_execution_time_leaf 0 --max_estimated_execution_time 0"
+    LOGS_SAVER_CLIENT_OPTIONS = "--max_memory_usage 10G --max_threads 1 --max_rows_to_read=0 --max_result_rows 0 --max_result_bytes 0 --max_bytes_to_read 0 --max_execution_time 0 --max_execution_time_leaf 0 --max_estimated_execution_time 0"
     DMESG_LOG = f"{temp_dir}/dmesg.log"
     GDB_LOG = f"{temp_dir}/gdb.log"
     # TODO: run servers in  dedicated wds to keep trash localised
@@ -1044,6 +1044,7 @@ quit
             "minio_audit_logs",
             "minio_server_logs",
         ]
+        ROWS_COUNT_IN_SYSTEM_TABLE_LIMIT = 10_000_000
 
         command_args = self.LOGS_SAVER_CLIENT_OPTIONS
         # command_args += f" --config-file={self.ch_config_dir}/config.xml"
@@ -1097,6 +1098,11 @@ quit
                 scraping_system_table.set_info(
                     f"Failed to dump system table: {table}\nError: {stderr}"
                 )
+            else:
+                lines_count = int(Shell.get_output_or_raise(f"cd {self.run_path0} && wc -l < {temp_dir}/system_tables/{table}.tsv", verbose=True).strip())
+                if lines_count > ROWS_COUNT_IN_SYSTEM_TABLE_LIMIT:
+                    scraping_system_table.set_info(f"System table {table} has too many rows {lines_count} > {ROWS_COUNT_IN_SYSTEM_TABLE_LIMIT}")
+
             if "minio" in table:
                 # minio tables are not replicated
                 continue
@@ -1114,6 +1120,11 @@ quit
                         f"Failed to dump system table from replica 1: {table}\nError: {stderr}"
                     )
                     res = False
+                else:
+                    lines_count = int(Shell.get_output_or_raise(f"cd {self.run_path1} && wc -l < {temp_dir}/system_tables/{table}.1.tsv", verbose=True).strip())
+                    if lines_count > ROWS_COUNT_IN_SYSTEM_TABLE_LIMIT:
+                        scraping_system_table.set_info(f"System table {table} on replica 1 has too many rows {lines_count} > {ROWS_COUNT_IN_SYSTEM_TABLE_LIMIT}")
+
             if self.is_db_replicated:
                 path_arg = f" --path {self.run_path2}"
                 res, stdout, stderr = Shell.get_res_stdout_stderr(
@@ -1128,6 +1139,11 @@ quit
                         f"Failed to dump system table from replica 2: {table}\nError: {stderr}"
                     )
                     res = False
+                else:
+                    lines_count = int(Shell.get_output_or_raise(f"cd {self.run_path2} && wc -l < {temp_dir}/system_tables/{table}.2.tsv", verbose=True).strip())
+                    if lines_count > ROWS_COUNT_IN_SYSTEM_TABLE_LIMIT:
+                        scraping_system_table.set_info(f"System table {table} on replica 2 has too many rows {lines_count} > {ROWS_COUNT_IN_SYSTEM_TABLE_LIMIT}")
+
         if scraping_system_table.info:
             scraping_system_table.set_status(Result.StatusExtended.FAIL)
             self.extra_tests_results.append(scraping_system_table)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
After this patch, system tables will be saved in the CI record regardless of the number of rows. 


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.820`
<!-- ch-version-info:end -->