### PR TITLE
Fix BuzzHouse exception when table has no insertable columns

### DIFF
--- a/src/Client/BuzzHouse/Generator/SQLTable.cpp
+++ b/src/Client/BuzzHouse/Generator/SQLTable.cpp
@@ -2471,7 +2471,7 @@ void StatementGenerator::generateNextCreateTable(RandomGenerator & rg, const boo
                 rg,
                 true,
                 false,
-                static_cast<uint32_t>(next.numberOfInsertableColumns(rg.nextSmallNumber() < 4)),
+                static_cast<uint32_t>(std::max<size_t>(1, next.numberOfInsertableColumns(rg.nextSmallNumber() < 4))),
                 std::numeric_limits<uint32_t>::max(),
                 std::nullopt,
                 cts->mutable_select());


### PR DESCRIPTION
`numberOfInsertableColumns` can return 0 when all columns are non-insertable (e.g., `MATERIALIZED`, `EPHEMERAL` with defaults). This caused `generateSelect` to be called with `ncols=0`, triggering the assertion `chassert(ncols)`.

Use `std::max` to ensure at least 1 column is requested.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=95047&sha=8ab3e5b7d1e008e47b3a43639fe2a4a8191698f2&name_0=PR&name_1=BuzzHouse%20%28arm_asan%29
https://github.com/ClickHouse/ClickHouse/pull/95047


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.821`
<!-- ch-version-info:end -->