### PR TITLE
Fix flaky test `03339_native_reader_exact_rows`

### DIFF
--- a/tests/queries/0_stateless/03339_native_reader_exact_rows.sql
+++ b/tests/queries/0_stateless/03339_native_reader_exact_rows.sql
@@ -8,7 +8,7 @@
 SELECT number FROM numbers(5e6) ORDER BY number * 1234567890123456789 LIMIT 4999980, 20
 SETTINGS
     max_threads=1,
-    max_memory_usage='200Mi',
+    max_memory_usage='220Mi',
     /* 65536 rows takes buffer of 512KB, so use slightly bigger value to increase overhead */
     max_block_size=65540,
     max_bytes_before_external_sort='2Mi',


### PR DESCRIPTION
Increase `max_memory_usage` from 200Mi to 220Mi to provide headroom for memory variations in parallel test environments.

The test failed sporadically when running in parallel, exceeding the limit by only 0.02 MiB. The 220Mi limit still validates the memory optimization (avoiding power-of-2 rounding) while being resilient to minor variations.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

There could be another reason, but for now I'll take it.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.827`
<!-- ch-version-info:end -->