### PR TITLE
Fix inconsistent formatting of CREATE DICTIONARY

### DIFF
--- a/src/Parsers/ParserCreateQuery.cpp
+++ b/src/Parsers/ParserCreateQuery.cpp
@@ -5,7 +5,6 @@
 #include <Parsers/ASTExpressionList.h>
 #include <Parsers/ASTForeignKeyDeclaration.h>
 #include <Parsers/ASTFunction.h>
-#include <Parsers/ASTDataType.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTIndexDeclaration.h>
 #include <Parsers/ASTStatisticsDeclaration.h>

--- a/src/Parsers/ParserDictionaryAttributeDeclaration.cpp
+++ b/src/Parsers/ParserDictionaryAttributeDeclaration.cpp
@@ -21,7 +21,7 @@ bool ParserDictionaryAttributeDeclaration::parseImpl(Pos & pos, ASTPtr & node, E
     ParserKeyword s_is_object_id{Keyword::IS_OBJECT_ID};
     ParserLiteral default_parser;
     ParserArrayOfLiterals array_literals_parser;
-    ParserExpression expression_parser;
+    ParserExpressionWithOptionalAlias expression_parser(false);
 
     /// mandatory attribute name
     ASTPtr name;

--- a/tests/queries/0_stateless/03579_inconsistent_formatting_substitutions.sh
+++ b/tests/queries/0_stateless/03579_inconsistent_formatting_substitutions.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# Tags: no-random-settings, no-random-merge-tree-settings
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh

--- a/tests/queries/0_stateless/03806_inconsistent_formatting_create_dictionary.reference
+++ b/tests/queries/0_stateless/03806_inconsistent_formatting_create_dictionary.reference
@@ -1,0 +1,16 @@
+CREATE DICTIONARY d0.d213
+(
+    `c0` Int128 DEFAULT '{"c0.c1":[],"😉😉":17453198.019}' HIERARCHICAL,
+    `c1` IPv6 DEFAULT inf,
+    `c2` Int32 DEFAULT '\'漂亮\'' INJECTIVE,
+    `c3` Int128 DEFAULT inf EXPRESSION c1 AS a0 HIERARCHICAL
+)
+PRIMARY KEY c3, c0, c1
+SOURCE(CLICKHOUSE(DB 'd0' TABLE 'd109'))
+LIFETIME(MIN 2 MAX 30)
+LAYOUT(RANGE_HASHED())
+RANGE(MIN c2 MAX c1)
+SETTINGS(allow_prefetched_read_pool_for_local_filesystem = 1, max_compress_block_size = 524288, join_on_disk_max_files_to_merge = 10, materialized_views_ignore_errors = 0, alter_partition_verbose_result = 0, query_plan_optimize_prewhere = 0, input_format_arrow_case_insensitive_column_matching = 0, input_format_parallel_parsing = 1, output_format_protobuf_nullables_with_google_wrappers = 1, input_format_allow_errors_num = 64, use_page_cache_with_distributed_cache = 1, optimize_trivial_insert_select = 1, parallel_replicas_custom_key_range_lower = 524288, filesystem_cache_enable_background_download_during_fetch = 1, max_parts_to_move = 2837, optimize_throw_if_noop = 0, validate_experimental_and_suspicious_types_inside_nested_types = 0, force_optimize_projection = 1, max_insert_threads = 4)
+COMMENT '日本'
+PARALLEL WITH
+SYSTEM DISABLE FAILPOINT zero_copy_lock_zk_fail_before_op

--- a/tests/queries/0_stateless/03806_inconsistent_formatting_create_dictionary.sh
+++ b/tests/queries/0_stateless/03806_inconsistent_formatting_create_dictionary.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+$CLICKHOUSE_FORMAT --query "
+CREATE DICTIONARY d0.\`d213\` (\`c0\` Int128 DEFAULT '{\"c0.c1\":[],\"😉😉\":17453198.019}' HIERARCHICAL, \`c1\` IPv6 DEFAULT +inf, \`c2\` Int32 DEFAULT '\\'\\xE6\\xBC\\x82\\xE4\\xBA\\xAE\\'' INJECTIVE, \`c3\` Int128 DEFAULT +inf EXPRESSION (\`c1\` AS \`a0\`) HIERARCHICAL) PRIMARY KEY (\`c3\`, \`c0\`, \`c1\`) SOURCE(CLICKHOUSE(DB 'd0' TABLE 'd109')) LAYOUT(RANGE_HASHED()) RANGE(MIN \`c2\`MAX \`c1\`) LIFETIME(MIN 2 MAX 30) SETTINGS(allow_prefetched_read_pool_for_local_filesystem = 1, max_compress_block_size = 524288, join_on_disk_max_files_to_merge = 10, materialized_views_ignore_errors = 0, alter_partition_verbose_result = 0, query_plan_optimize_prewhere = 0, input_format_arrow_case_insensitive_column_matching = 0, input_format_parallel_parsing = 1, output_format_protobuf_nullables_with_google_wrappers = 1, input_format_allow_errors_num = 64, use_page_cache_with_distributed_cache = 1, optimize_trivial_insert_select = 1, parallel_replicas_custom_key_range_lower = 524288, filesystem_cache_enable_background_download_during_fetch = 1, max_parts_to_move = 2837, optimize_throw_if_noop = 0, validate_experimental_and_suspicious_types_inside_nested_types = 0, force_optimize_projection = 1, max_insert_threads = 4) COMMENT '日本' PARALLEL WITH SYSTEM DISABLE FAILPOINT zero_copy_lock_zk_fail_before_op;
+" | $CLICKHOUSE_FORMAT


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

See https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=95054&sha=f6f79261c5d9f40939e89f978fce4426ef3bb99a&name_0=PR&name_1=BuzzHouse%20%28amd_debug%29
https://github.com/ClickHouse/ClickHouse/pull/95054


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.828`
<!-- ch-version-info:end -->