### PR TITLE
Fix flaky test `02435_rollback_cancelled_queries`

### DIFF
--- a/tests/queries/0_stateless/02435_rollback_cancelled_queries.sh
+++ b/tests/queries/0_stateless/02435_rollback_cancelled_queries.sh
@@ -46,11 +46,12 @@ function insert_data
         $CLICKHOUSE_CLIENT --stacktrace --query_id="$ID" --throw_on_unsupported_query_inside_transaction=0 --implicit_transaction="$IMPLICIT" \
             --max_block_size=1000 --max_insert_block_size=1000 -q \
             "${BEGIN}insert into dedup_test settings max_insert_block_size=110000, min_insert_block_size_rows=110000 format TSV$COMMIT" < $DATA_FILE \
-            | grep -Fv "Transaction is not in RUNNING state"
+            | grep -Fv "Transaction is not in RUNNING state" | grep -Fv "There is no current transaction"
     fi
 
     if [[ "$IMPLICIT" -eq 0 ]]; then
-        $CLICKHOUSE_CURL -sS -d 'commit' "$CLICKHOUSE_URL&$TXN_SETTINGS&close_session=1" 2>&1| grep -Fav "Transaction is not in RUNNING state"
+        $CLICKHOUSE_CURL -sS -d 'commit' "$CLICKHOUSE_URL&$TXN_SETTINGS&close_session=1" 2>&1 \
+            | grep -Fav "Transaction is not in RUNNING state" | grep -Fav "There is no current transaction"
     fi
 }
 


### PR DESCRIPTION
The test intentionally cancels INSERT queries mid-flight using signals (INT/KILL) to verify that cancelled transactions are properly rolled back and data remains consistent.

When a transaction is cancelled, two different error messages can occur:
1. "Transaction is not in RUNNING state" - when the transaction exists but was already rolled back
2. "There is no current transaction" - when the session/transaction was fully cleaned up before the commit attempt

The test already filtered the first error message, but not the second, causing intermittent failures in CI when the timing resulted in the transaction being cleaned up before the explicit `commit` command.

This fix adds filtering for "There is no current transaction" errors alongside the existing filter for "Transaction is not in RUNNING state", as both are expected outcomes when cancelling transactions.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

See https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=942f98bf19cc81693428e6409c2fcf3bafdebf6c&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_tsan%2C%20s3%20storage%2C%20parallel%29&name_1=Stateless%20tests%20%28amd_tsan%2C%20s3%20storage%2C%20parallel%29

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=95052&sha=758cae5afb57282d447c2cd6f60a6b4bfc419be0&name_0=PR&name_1=Stateless%20tests%20%28amd_binary%2C%20old%20analyzer%2C%20s3%20storage%2C%20DatabaseReplicated%2C%20parallel%29
https://github.com/ClickHouse/ClickHouse/pull/95052


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.839`
<!-- ch-version-info:end -->