### PR TITLE
Disable flaky test `01583_parallel_parsing_exception_with_offset` in debug/sanitizer builds

### DIFF
--- a/tests/queries/0_stateless/01583_parallel_parsing_exception_with_offset.sh
+++ b/tests/queries/0_stateless/01583_parallel_parsing_exception_with_offset.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Tags: no-debug, no-asan, no-tsan, no-msan, no-ubsan
+# Test is flaky in debug/sanitizer builds because the large data transfer
+# can cause connection timeouts before the parsing error is reported.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 CLICKHOUSE_CLIENT_SERVER_LOGS_LEVEL=none


### PR DESCRIPTION
The test is flaky in debug and sanitizer builds because the large data transfer (22 million rows) can cause connection timeouts before the parsing error is properly reported to the client.

In slower builds, the server detects the parsing error at row 2000001 while the client is still sending 20 million more rows, causing TCP buffer congestion and "Connection reset by peer" errors instead of the expected error message with the row number.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

See https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=93627&sha=29bcdd1dc159a0edee907d2b1f2fad9f03e161da&name_0=PR&name_1=Stateless%20tests%20%28amd_debug%2C%20parallel%29
https://github.com/ClickHouse/ClickHouse/pull/93627


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.836`
<!-- ch-version-info:end -->