### PR TITLE
Dynamic update s3 access tokens in long queries

### DIFF
--- a/src/Databases/DataLake/DatabaseDataLake.cpp
+++ b/src/Databases/DataLake/DatabaseDataLake.cpp
@@ -583,7 +583,7 @@ StoragePtr DatabaseDataLake::tryGetTableImpl(const String & name, ContextPtr con
         auto storage_cluster = std::make_shared<StorageObjectStorageCluster>(
             parallel_replicas_cluster_name,
             configuration,
-            configuration->createObjectStorage(context_copy, /* is_readonly */ false),
+            configuration->createObjectStorage(context_copy, /* is_readonly */ false, catalog->getCredentialsConfigurationCallback()),
             StorageID(getDatabaseName(), name),
             columns,
             ConstraintsDescription{},
@@ -603,7 +603,7 @@ StoragePtr DatabaseDataLake::tryGetTableImpl(const String & name, ContextPtr con
 
     return std::make_shared<StorageObjectStorage>(
         configuration,
-        configuration->createObjectStorage(context_copy, /* is_readonly */ false),
+        configuration->createObjectStorage(context_copy, /* is_readonly */ false, catalog->getCredentialsConfigurationCallback()),
         context_copy,
         StorageID(getDatabaseName(), name),
         /* columns */columns,

--- a/src/Databases/DataLake/DatabaseDataLake.cpp
+++ b/src/Databases/DataLake/DatabaseDataLake.cpp
@@ -580,11 +580,12 @@ StoragePtr DatabaseDataLake::tryGetTableImpl(const String & name, ContextPtr con
 
     if (can_use_parallel_replicas && !is_secondary_query)
     {
+        auto storage_id = StorageID(getDatabaseName(), name);
         auto storage_cluster = std::make_shared<StorageObjectStorageCluster>(
             parallel_replicas_cluster_name,
             configuration,
-            configuration->createObjectStorage(context_copy, /* is_readonly */ false, catalog->getCredentialsConfigurationCallback()),
-            StorageID(getDatabaseName(), name),
+            configuration->createObjectStorage(context_copy, /* is_readonly */ false, catalog->getCredentialsConfigurationCallback(storage_id)),
+            storage_id,
             columns,
             ConstraintsDescription{},
             nullptr,
@@ -603,7 +604,7 @@ StoragePtr DatabaseDataLake::tryGetTableImpl(const String & name, ContextPtr con
 
     return std::make_shared<StorageObjectStorage>(
         configuration,
-        configuration->createObjectStorage(context_copy, /* is_readonly */ false, catalog->getCredentialsConfigurationCallback()),
+        configuration->createObjectStorage(context_copy, /* is_readonly */ false, catalog->getCredentialsConfigurationCallback(StorageID(getDatabaseName(), name))),
         context_copy,
         StorageID(getDatabaseName(), name),
         /* columns */columns,

--- a/src/Databases/DataLake/GlueCatalog.cpp
+++ b/src/Databases/DataLake/GlueCatalog.cpp
@@ -515,7 +515,7 @@ GlueCatalog::ObjectStorageWithPath GlueCatalog::createObjectStorageForEarlyTable
     auto configuration = std::make_shared<DB::StorageS3IcebergConfiguration>(storage_settings);
     DB::StorageObjectStorageConfiguration::initialize(*configuration, args, getContext(), false);
 
-    auto object_storage = configuration->createObjectStorage(getContext(), true);
+    auto object_storage = configuration->createObjectStorage(getContext(), true, {});
 
     /// Parse S3 path to extract bucket and table path
     String table_path = s3_location;

--- a/src/Databases/DataLake/ICatalog.h
+++ b/src/Databases/DataLake/ICatalog.h
@@ -130,6 +130,7 @@ class ICatalog
 {
 public:
     using Namespaces = std::vector<std::string>;
+    using CredentialsRefreshCallback = std::function<std::shared_ptr<DataLake::IStorageCredentials>()>;
 
     explicit ICatalog(const std::string & warehouse_) : warehouse(warehouse_) {}
 
@@ -180,6 +181,14 @@ public:
     /// So the REST catalog is transactional.
     /// The Glue catalog does not support such operation.
     virtual bool isTransactional() const { return false; }
+
+    virtual CredentialsRefreshCallback getCredentialsConfigurationCallback()
+    {
+        return [] () -> std::shared_ptr<DataLake::IStorageCredentials>
+        {
+            return nullptr;
+        };
+    }
 
 protected:
     /// Name of the warehouse,

--- a/src/Databases/DataLake/ICatalog.h
+++ b/src/Databases/DataLake/ICatalog.h
@@ -3,7 +3,7 @@
 #include <Core/NamesAndTypes.h>
 #include <Core/SettingsEnums.h>
 #include <Common/SettingsChanges.h>
-#include "Interpreters/StorageID.h"
+#include <Interpreters/StorageID.h>
 #include <Databases/DataLake/StorageCredentials.h>
 #include <Storages/ObjectStorage/StorageObjectStorageSettings.h>
 #include <Databases/DataLake/DatabaseDataLakeStorageType.h>

--- a/src/Databases/DataLake/ICatalog.h
+++ b/src/Databases/DataLake/ICatalog.h
@@ -3,6 +3,7 @@
 #include <Core/NamesAndTypes.h>
 #include <Core/SettingsEnums.h>
 #include <Common/SettingsChanges.h>
+#include "Interpreters/StorageID.h"
 #include <Databases/DataLake/StorageCredentials.h>
 #include <Storages/ObjectStorage/StorageObjectStorageSettings.h>
 #include <Databases/DataLake/DatabaseDataLakeStorageType.h>

--- a/src/Databases/DataLake/ICatalog.h
+++ b/src/Databases/DataLake/ICatalog.h
@@ -183,7 +183,7 @@ public:
     /// The Glue catalog does not support such operation.
     virtual bool isTransactional() const { return false; }
 
-    virtual CredentialsRefreshCallback getCredentialsConfigurationCallback()
+    virtual CredentialsRefreshCallback getCredentialsConfigurationCallback(const DB::StorageID & /*storage_id*/)
     {
         return [] () -> std::shared_ptr<DataLake::IStorageCredentials>
         {

--- a/src/Databases/DataLake/ICatalog.h
+++ b/src/Databases/DataLake/ICatalog.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <optional>
 #include <Core/Types.h>
 #include <Core/NamesAndTypes.h>
 #include <Core/SettingsEnums.h>
@@ -131,7 +132,7 @@ class ICatalog
 {
 public:
     using Namespaces = std::vector<std::string>;
-    using CredentialsRefreshCallback = std::function<std::shared_ptr<DataLake::IStorageCredentials>()>;
+    using CredentialsRefreshCallback = std::optional<std::function<std::shared_ptr<DataLake::IStorageCredentials>()>>;
 
     explicit ICatalog(const std::string & warehouse_) : warehouse(warehouse_) {}
 
@@ -185,10 +186,7 @@ public:
 
     virtual CredentialsRefreshCallback getCredentialsConfigurationCallback(const DB::StorageID & /*storage_id*/)
     {
-        return [] () -> std::shared_ptr<DataLake::IStorageCredentials>
-        {
-            return nullptr;
-        };
+        return std::nullopt;
     }
 
 protected:

--- a/src/Databases/DataLake/RestCatalog.cpp
+++ b/src/Databases/DataLake/RestCatalog.cpp
@@ -2,7 +2,7 @@
 #include <Poco/Net/HTTPRequest.h>
 #include <Common/setThreadName.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.h>
-#include "Databases/DataLake/Common.h"
+#include <Databases/DataLake/Common.h>
 #include "config.h"
 
 #if USE_AVRO

--- a/src/Databases/DataLake/RestCatalog.cpp
+++ b/src/Databases/DataLake/RestCatalog.cpp
@@ -1007,8 +1007,6 @@ ICatalog::CredentialsRefreshCallback RestCatalog::getCredentialsConfigurationCal
     };
 }
 
-
-
 }
 
 #endif

--- a/src/Databases/DataLake/RestCatalog.cpp
+++ b/src/Databases/DataLake/RestCatalog.cpp
@@ -1,5 +1,7 @@
 #include <Poco/JSON/Object.h>
 #include <Poco/Net/HTTPRequest.h>
+#include "Common/Logger.h"
+#include "Common/logger_useful.h"
 #include <Common/setThreadName.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.h>
 #include <Databases/DataLake/Common.h>
@@ -962,6 +964,8 @@ ICatalog::CredentialsRefreshCallback RestCatalog::getCredentialsConfigurationCal
 {
     return [this] () -> std::shared_ptr<IStorageCredentials>
     {
+        LOG_DEBUG(log, "Update credentials in the catalog");
+
         DB::HTTPHeaderEntries headers;
         headers.emplace_back("X-Iceberg-Access-Delegation", "vended-credentials");
 

--- a/src/Databases/DataLake/RestCatalog.cpp
+++ b/src/Databases/DataLake/RestCatalog.cpp
@@ -2,6 +2,7 @@
 #include <Poco/Net/HTTPRequest.h>
 #include <Common/setThreadName.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.h>
+#include "Databases/DataLake/Common.h"
 #include "config.h"
 
 #if USE_AVRO
@@ -956,6 +957,56 @@ void RestCatalog::dropTable(const String & namespace_name, const String & table_
         throw DB::Exception(DB::ErrorCodes::DATALAKE_DATABASE_ERROR, "Failed to drop table {}", ex.displayText());
     }
 }
+
+ICatalog::CredentialsRefreshCallback RestCatalog::getCredentialsConfigurationCallback()
+{
+    return [this] () -> std::shared_ptr<IStorageCredentials>
+    {
+        DB::HTTPHeaderEntries headers;
+        headers.emplace_back("X-Iceberg-Access-Delegation", "vended-credentials");
+
+        auto [namespace_name, table_name] = DataLake::parseTableName(getTables()[0]);
+        const std::string endpoint = std::filesystem::path(NAMESPACES_ENDPOINT) / encodeNamespaceForURI(namespace_name) / "tables" / table_name;
+        auto buf = createReadBuffer(config.prefix / endpoint, /* params */{}, headers);
+
+        if (buf->eof())
+        {
+            LOG_DEBUG(log, "Table doesn't exist (endpoint: {})", endpoint);
+            return nullptr;
+        }
+
+        String json_str;
+        readJSONObjectPossiblyInvalid(json_str, *buf);
+        LOG_DEBUG(log, "Receiving table metadata {} {}", table_name, json_str);
+
+        Poco::JSON::Parser parser;
+        Poco::Dynamic::Var json = parser.parse(json_str);
+        const Poco::JSON::Object::Ptr & object = json.extract<Poco::JSON::Object::Ptr>();
+
+        auto config_object = object->get("config").extract<Poco::JSON::Object::Ptr>();
+
+        static constexpr auto access_key_id_str = "s3.access-key-id";
+        static constexpr auto secret_access_key_str = "s3.secret-access-key";
+        static constexpr auto session_token_str = "s3.session-token";
+        static constexpr auto storage_endpoint_str = "s3.endpoint";
+
+        std::string access_key_id;
+        std::string secret_access_key;
+        std::string session_token;
+        std::string storage_endpoint;
+        if (config_object->has(access_key_id_str))
+            access_key_id = config_object->get(access_key_id_str).extract<String>();
+        if (config_object->has(secret_access_key_str))
+            secret_access_key = config_object->get(secret_access_key_str).extract<String>();
+        if (config_object->has(session_token_str))
+            session_token = config_object->get(session_token_str).extract<String>();
+        if (config_object->has(storage_endpoint_str))
+            storage_endpoint = config_object->get(storage_endpoint_str).extract<String>();
+
+        return std::make_shared<S3Credentials>(access_key_id, secret_access_key, session_token);
+    };
+}
+
 
 
 }

--- a/src/Databases/DataLake/RestCatalog.cpp
+++ b/src/Databases/DataLake/RestCatalog.cpp
@@ -1,7 +1,6 @@
 #include <Poco/JSON/Object.h>
 #include <Poco/Net/HTTPRequest.h>
-#include "Common/Logger.h"
-#include "Common/logger_useful.h"
+#include <Common/Logger.h>
 #include <Common/setThreadName.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.h>
 #include <Databases/DataLake/Common.h>

--- a/src/Databases/DataLake/RestCatalog.cpp
+++ b/src/Databases/DataLake/RestCatalog.cpp
@@ -702,64 +702,11 @@ bool RestCatalog::getTableMetadataImpl(
         auto config_object = object->get("config").extract<Poco::JSON::Object::Ptr>();
         if (!config_object)
             throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "Cannot parse config result");
-
-        auto storage_type = parseStorageTypeFromLocation(location);
-        switch (storage_type)
-        {
-            case StorageType::S3:
-            {
-                static constexpr auto access_key_id_str = "s3.access-key-id";
-                static constexpr auto secret_access_key_str = "s3.secret-access-key";
-                static constexpr auto session_token_str = "s3.session-token";
-                static constexpr auto storage_endpoint_str = "s3.endpoint";
-
-                std::string access_key_id;
-                std::string secret_access_key;
-                std::string session_token;
-                std::string storage_endpoint;
-                if (config_object->has(access_key_id_str))
-                    access_key_id = config_object->get(access_key_id_str).extract<String>();
-                if (config_object->has(secret_access_key_str))
-                    secret_access_key = config_object->get(secret_access_key_str).extract<String>();
-                if (config_object->has(session_token_str))
-                    session_token = config_object->get(session_token_str).extract<String>();
-                if (config_object->has(storage_endpoint_str))
-                    storage_endpoint = config_object->get(storage_endpoint_str).extract<String>();
-
-                result.setStorageCredentials(
-                    std::make_shared<S3Credentials>(access_key_id, secret_access_key, session_token));
-
-                result.setEndpoint(storage_endpoint);
-                break;
-            }
-            case StorageType::Azure:
-            {
-                /// Azure ADLS Gen2 vended credentials use SAS tokens.
-                /// The config keys follow the pattern: adls.sas-token.<account_name>
-                /// or adls.sas-token.<account_name>.dfs.core.windows.net
-                /// We look for any key starting with "adls.sas-token." and use the first one found.
-                String sas_token;
-                std::vector<std::string> names;
-                config_object->getNames(names);
-                for (const auto & name : names)
-                {
-                    if (name.starts_with("adls.sas-token."))
-                    {
-                        sas_token = config_object->get(name).extract<String>();
-                        LOG_DEBUG(log, "Found Azure SAS token with key: {}", name);
-                        break;
-                    }
-                }
-
-                if (!sas_token.empty())
-                {
-                    result.setStorageCredentials(std::make_shared<AzureCredentials>(sas_token));
-                }
-                break;
-            }
-            default:
-                break;
-        }
+        auto [parsed_credentials, parsed_endpoint] = getCredentialsAndEndpoint(config_object, location);
+        if (parsed_credentials)
+            result.setStorageCredentials(parsed_credentials);
+        if (!parsed_endpoint.empty())
+            result.setEndpoint(parsed_endpoint);
     }
 
     if (result.requiresDataLakeSpecificProperties())
@@ -960,16 +907,76 @@ void RestCatalog::dropTable(const String & namespace_name, const String & table_
     }
 }
 
-ICatalog::CredentialsRefreshCallback RestCatalog::getCredentialsConfigurationCallback()
+std::pair<std::shared_ptr<IStorageCredentials>, String> RestCatalog::getCredentialsAndEndpoint(Poco::JSON::Object::Ptr object, const String & location) const
 {
-    return [this] () -> std::shared_ptr<IStorageCredentials>
+    auto storage_type = parseStorageTypeFromLocation(location);
+    switch (storage_type)
+    {
+        case StorageType::S3:
+        {
+            static constexpr auto access_key_id_str = "s3.access-key-id";
+            static constexpr auto secret_access_key_str = "s3.secret-access-key";
+            static constexpr auto session_token_str = "s3.session-token";
+            static constexpr auto storage_endpoint_str = "s3.endpoint";
+
+            std::string access_key_id;
+            std::string secret_access_key;
+            std::string session_token;
+            std::string storage_endpoint;
+            if (object->has(access_key_id_str))
+                access_key_id = object->get(access_key_id_str).extract<String>();
+            if (object->has(secret_access_key_str))
+                secret_access_key = object->get(secret_access_key_str).extract<String>();
+            if (object->has(session_token_str))
+                session_token = object->get(session_token_str).extract<String>();
+            if (object->has(storage_endpoint_str))
+                storage_endpoint = object->get(storage_endpoint_str).extract<String>();
+
+            LOG_DEBUG(log, "initial tokens {} {} {}", access_key_id, secret_access_key, session_token);
+            return {std::make_shared<S3Credentials>(access_key_id, secret_access_key, session_token), storage_endpoint};
+        }
+        case StorageType::Azure:
+        {
+            /// Azure ADLS Gen2 vended credentials use SAS tokens.
+            /// The config keys follow the pattern: adls.sas-token.<account_name>
+            /// or adls.sas-token.<account_name>.dfs.core.windows.net
+            /// We look for any key starting with "adls.sas-token." and use the first one found.
+            String sas_token;
+            std::vector<std::string> names;
+            object->getNames(names);
+            for (const auto & name : names)
+            {
+                if (name.starts_with("adls.sas-token."))
+                {
+                    sas_token = object->get(name).extract<String>();
+                    LOG_DEBUG(log, "Found Azure SAS token with key: {}", name);
+                    break;
+                }
+            }
+
+            if (!sas_token.empty())
+            {
+                return {std::make_shared<AzureCredentials>(sas_token), ""};
+            }
+            break;
+        }
+        default:
+            break;
+    }
+    return {nullptr, ""};
+}
+
+ICatalog::CredentialsRefreshCallback RestCatalog::getCredentialsConfigurationCallback(const DB::StorageID & storage_id)
+{
+    return [this, storage_id] () -> std::shared_ptr<IStorageCredentials>
     {
         LOG_DEBUG(log, "Update credentials in the catalog");
 
         DB::HTTPHeaderEntries headers;
         headers.emplace_back("X-Iceberg-Access-Delegation", "vended-credentials");
 
-        auto [namespace_name, table_name] = DataLake::parseTableName(getTables()[0]);
+        const auto & table = storage_id.getTableName();
+        auto [namespace_name, table_name] = DataLake::parseTableName(table);
         const std::string endpoint = std::filesystem::path(NAMESPACES_ENDPOINT) / encodeNamespaceForURI(namespace_name) / "tables" / table_name;
         auto buf = createReadBuffer(config.prefix / endpoint, /* params */{}, headers);
 
@@ -988,26 +995,21 @@ ICatalog::CredentialsRefreshCallback RestCatalog::getCredentialsConfigurationCal
         const Poco::JSON::Object::Ptr & object = json.extract<Poco::JSON::Object::Ptr>();
 
         auto config_object = object->get("config").extract<Poco::JSON::Object::Ptr>();
+        std::string location;
+        {
+            if (object->has("metadata-location"))
+            {
+                location = object->get("metadata-location").extract<String>();
+                LOG_DEBUG(log, "Location for table {}: {}", table_name, location);
+            }
+            else
+            {
+                throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Cannot read table {}, because no 'location' in response", table_name);
+            }
+        }
 
-        static constexpr auto access_key_id_str = "s3.access-key-id";
-        static constexpr auto secret_access_key_str = "s3.secret-access-key";
-        static constexpr auto session_token_str = "s3.session-token";
-        static constexpr auto storage_endpoint_str = "s3.endpoint";
-
-        std::string access_key_id;
-        std::string secret_access_key;
-        std::string session_token;
-        std::string storage_endpoint;
-        if (config_object->has(access_key_id_str))
-            access_key_id = config_object->get(access_key_id_str).extract<String>();
-        if (config_object->has(secret_access_key_str))
-            secret_access_key = config_object->get(secret_access_key_str).extract<String>();
-        if (config_object->has(session_token_str))
-            session_token = config_object->get(session_token_str).extract<String>();
-        if (config_object->has(storage_endpoint_str))
-            storage_endpoint = config_object->get(storage_endpoint_str).extract<String>();
-
-        return std::make_shared<S3Credentials>(access_key_id, secret_access_key, session_token);
+        auto [new_credentials, _] = getCredentialsAndEndpoint(config_object, location);
+        return new_credentials;
     };
 }
 

--- a/src/Databases/DataLake/RestCatalog.h
+++ b/src/Databases/DataLake/RestCatalog.h
@@ -81,6 +81,8 @@ public:
     String getClientId() const { return client_id; }
     String getClientSecret() const { return client_secret; }
 
+    ICatalog::CredentialsRefreshCallback getCredentialsConfigurationCallback() override;
+
 private:
     void createNamespaceIfNotExists(const String & namespace_name, const String & location) const;
 

--- a/src/Databases/DataLake/RestCatalog.h
+++ b/src/Databases/DataLake/RestCatalog.h
@@ -81,7 +81,7 @@ public:
     String getClientId() const { return client_id; }
     String getClientSecret() const { return client_secret; }
 
-    ICatalog::CredentialsRefreshCallback getCredentialsConfigurationCallback() override;
+    ICatalog::CredentialsRefreshCallback getCredentialsConfigurationCallback(const DB::StorageID & storage_id) override;
 
 private:
     void createNamespaceIfNotExists(const String & namespace_name, const String & location) const;
@@ -158,6 +158,8 @@ private:
         Poco::JSON::Object::Ptr request_body,
         const String & method = Poco::Net::HTTPRequest::HTTP_POST,
         bool ignore_result = false) const;
+
+    std::pair<std::shared_ptr<IStorageCredentials>, String> getCredentialsAndEndpoint(Poco::JSON::Object::Ptr object, const String & location) const;
 };
 
 }

--- a/src/Databases/DataLake/StorageCredentials.h
+++ b/src/Databases/DataLake/StorageCredentials.h
@@ -49,7 +49,7 @@ public:
 
     const String & getSecretAccessKey() const
     {
-        return secret_access_key;   
+        return secret_access_key;
     }
 
     const String & getSessionToken() const

--- a/src/Databases/DataLake/StorageCredentials.h
+++ b/src/Databases/DataLake/StorageCredentials.h
@@ -42,6 +42,21 @@ public:
             engine_args.push_back(std::make_shared<DB::ASTLiteral>(session_token));
     }
 
+    const String & getAccessKeyId() const
+    {
+        return access_key_id;
+    }
+
+    const String & getSecretAccessKey() const
+    {
+        return secret_access_key;   
+    }
+
+    const String & getSessionToken() const
+    {
+        return session_token;
+    }
+
 private:
     std::string access_key_id;
     std::string secret_access_key;

--- a/src/Databases/DataLake/UnityCatalog.cpp
+++ b/src/Databases/DataLake/UnityCatalog.cpp
@@ -445,6 +445,8 @@ ICatalog::CredentialsRefreshCallback UnityCatalog::getCredentialsConfigurationCa
 {
     return [this] () -> std::shared_ptr<IStorageCredentials>
     {
+        LOG_DEBUG(log, "Update credentials in the catalog");
+
         auto [json, _] = postJSONRequest(TEMPORARY_CREDENTIALS_ENDPOINT, {});
         const Poco::JSON::Object::Ptr & object = json.extract<Poco::JSON::Object::Ptr>();
 

--- a/src/Databases/DataLake/UnityCatalog.cpp
+++ b/src/Databases/DataLake/UnityCatalog.cpp
@@ -1,5 +1,4 @@
 #include <Databases/DataLake/UnityCatalog.h>
-#include "Databases/DataLake/StorageCredentials.h"
 
 #if USE_PARQUET
 
@@ -12,6 +11,7 @@
 #include <IO/Operators.h>
 #include <Core/NamesAndTypes.h>
 #include <Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.h>
+#include <Databases/DataLake/StorageCredentials.h>
 #include <fmt/ranges.h>
 
 namespace DB::ErrorCodes

--- a/src/Databases/DataLake/UnityCatalog.cpp
+++ b/src/Databases/DataLake/UnityCatalog.cpp
@@ -441,7 +441,7 @@ UnityCatalog::UnityCatalog(
 {
 }
 
-ICatalog::CredentialsRefreshCallback UnityCatalog::getCredentialsConfigurationCallback()
+ICatalog::CredentialsRefreshCallback UnityCatalog::getCredentialsConfigurationCallback(const DB::StorageID &)
 {
     return [this] () -> std::shared_ptr<IStorageCredentials>
     {

--- a/src/Databases/DataLake/UnityCatalog.h
+++ b/src/Databases/DataLake/UnityCatalog.h
@@ -68,6 +68,8 @@ private:
         const std::string & namespace_name,
         const std::string & table_name,
         TableMetadata & result) const;
+
+    ICatalog::CredentialsRefreshCallback getCredentialsConfigurationCallback() override;
 };
 
 }

--- a/src/Databases/DataLake/UnityCatalog.h
+++ b/src/Databases/DataLake/UnityCatalog.h
@@ -69,7 +69,7 @@ private:
         const std::string & table_name,
         TableMetadata & result) const;
 
-    ICatalog::CredentialsRefreshCallback getCredentialsConfigurationCallback() override;
+    ICatalog::CredentialsRefreshCallback getCredentialsConfigurationCallback(const DB::StorageID & storage_id) override;
 };
 
 }

--- a/src/Disks/DiskObjectStorage/ObjectStorages/S3/S3ObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/S3/S3ObjectStorage.cpp
@@ -199,7 +199,8 @@ std::unique_ptr<ReadBufferFromFileBase> S3ObjectStorage::readObject( /// NOLINT
         /* offset */0,
         /* read_until_position */0,
         read_settings.remote_read_buffer_restrict_seek,
-        object.bytes_size ? std::optional<size_t>(object.bytes_size) : std::nullopt);
+        object.bytes_size ? std::optional<size_t>(object.bytes_size) : std::nullopt,
+        credentials_refresh_callback);
 }
 
 SmallObjectDataWithMetadata S3ObjectStorage::readSmallObjectAndGetObjectMetadata( /// NOLINT

--- a/src/Disks/DiskObjectStorage/ObjectStorages/S3/S3ObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/S3/S3ObjectStorage.cpp
@@ -465,10 +465,11 @@ ObjectMetadata S3ObjectStorage::getObjectMetadata(const std::string & path, bool
     {
         object_info = S3::getObjectInfo(*client.get(), uri.bucket, path, /*version_id=*/ {}, /*with_metadata=*/ true, /*with_tags=*/ with_tags);
     }
-    catch (DB::Exception & e)
+    catch (const DB::Exception &)
     {
-        e.addMessage("while reading " + path);
-        throw;
+        auto new_client = credentials_refresh_callback();
+        client.set(std::move(new_client));
+        object_info = S3::getObjectInfo(*client.get(), uri.bucket, path, /*version_id=*/ {}, /*with_metadata=*/ true, /*with_tags=*/ with_tags);
     }
 
     ObjectMetadata result;
@@ -522,6 +523,11 @@ void S3ObjectStorage::copyObjectToAnotherObjectStorage( // NOLINT
             /// If authentication/permissions error occurs then fallthrough to copy with buffer.
             if (exc.getS3ErrorCode() != Aws::S3::S3Errors::ACCESS_DENIED)
                 throw;
+            else
+            {
+                auto new_client = credentials_refresh_callback();
+                client.set(std::move(new_client));
+            }
             LOG_WARNING(getLogger("S3ObjectStorage"),
                 "S3-server-side copy object from the disk {} to the disk {} can not be performed: {}\n",
                 getName(), dest_s3->getName(), exc.what());

--- a/src/Disks/DiskObjectStorage/ObjectStorages/S3/S3ObjectStorage.h
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/S3/S3ObjectStorage.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "IO/S3/Client.h"
 #include "config.h"
 
 #if USE_AWS_S3
@@ -13,6 +12,7 @@
 #include <Common/ObjectStorageKeyGenerator.h>
 #include <IO/ReadBufferFromS3.h>
 #include <Parsers/IParser.h>
+#include <IO/S3/Client.h>
 
 namespace DB
 {

--- a/src/Disks/DiskObjectStorage/ObjectStorages/S3/S3ObjectStorage.h
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/S3/S3ObjectStorage.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "Parsers/IParser.h"
 #include "config.h"
 
 #if USE_AWS_S3
@@ -12,6 +11,7 @@
 #include <Common/MultiVersion.h>
 #include <Common/ObjectStorageKeyGenerator.h>
 #include <IO/ReadBufferFromS3.h>
+#include <Parsers/IParser.h>
 
 namespace DB
 {

--- a/src/Disks/DiskObjectStorage/ObjectStorages/S3/S3ObjectStorage.h
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/S3/S3ObjectStorage.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Parsers/IParser.h"
 #include "config.h"
 
 #if USE_AWS_S3
@@ -10,7 +11,7 @@
 #include <IO/S3Settings.h>
 #include <Common/MultiVersion.h>
 #include <Common/ObjectStorageKeyGenerator.h>
-
+#include <IO/ReadBufferFromS3.h>
 
 namespace DB
 {
@@ -23,6 +24,9 @@ namespace S3RequestSetting
 
 class S3ObjectStorage : public IObjectStorage
 {
+public:
+    using S3CredentialsRefreshCallback = ReadBufferFromS3::S3CredentialsRefreshCallback;
+
 private:
     friend class S3PlainObjectStorage;
 
@@ -34,7 +38,8 @@ private:
         const S3Capabilities & s3_capabilities_,
         ObjectStorageKeyGeneratorPtr key_generator_,
         const String & disk_name_,
-        bool for_disk_s3_ = true)
+        bool for_disk_s3_ = true,
+        const S3CredentialsRefreshCallback & credentials_refresh_callback_ = {})
         : uri(uri_)
         , disk_name(disk_name_)
         , client(std::move(client_))
@@ -43,6 +48,7 @@ private:
         , key_generator(std::move(key_generator_))
         , log(getLogger(logger_name))
         , for_disk_s3(for_disk_s3_)
+        , credentials_refresh_callback(credentials_refresh_callback_)
     {
     }
 
@@ -158,6 +164,7 @@ private:
     LoggerPtr log;
 
     const bool for_disk_s3;
+    S3CredentialsRefreshCallback credentials_refresh_callback;
 };
 
 }

--- a/src/Disks/DiskObjectStorage/ObjectStorages/S3/S3ObjectStorage.h
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/S3/S3ObjectStorage.h
@@ -40,7 +40,7 @@ private:
         ObjectStorageKeyGeneratorPtr key_generator_,
         const String & disk_name_,
         bool for_disk_s3_ = true,
-        const S3CredentialsRefreshCallback & credentials_refresh_callback_ = [] -> std::shared_ptr<const S3::Client>{ return nullptr; })
+        const S3CredentialsRefreshCallback & credentials_refresh_callback_ = [] -> std::unique_ptr<const S3::Client>{ return nullptr; })
         : uri(uri_)
         , disk_name(disk_name_)
         , client(std::move(client_))
@@ -156,7 +156,7 @@ private:
 
     std::string disk_name;
 
-    MultiVersion<S3::Client> client;
+    mutable MultiVersion<S3::Client> client;
     MultiVersion<S3Settings> s3_settings;
     S3Capabilities s3_capabilities;
 

--- a/src/Disks/DiskObjectStorage/ObjectStorages/S3/S3ObjectStorage.h
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/S3/S3ObjectStorage.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "IO/S3/Client.h"
 #include "config.h"
 
 #if USE_AWS_S3
@@ -39,7 +40,7 @@ private:
         ObjectStorageKeyGeneratorPtr key_generator_,
         const String & disk_name_,
         bool for_disk_s3_ = true,
-        const S3CredentialsRefreshCallback & credentials_refresh_callback_ = {})
+        const S3CredentialsRefreshCallback & credentials_refresh_callback_ = [] -> std::shared_ptr<const S3::Client>{ return nullptr; })
         : uri(uri_)
         , disk_name(disk_name_)
         , client(std::move(client_))

--- a/src/Disks/DiskObjectStorage/ObjectStorages/S3/diskSettings.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/S3/diskSettings.cpp
@@ -1,3 +1,4 @@
+#include <memory>
 #include <Disks/DiskObjectStorage/ObjectStorages/S3/diskSettings.h>
 
 #if USE_AWS_S3
@@ -89,17 +90,18 @@ std::unique_ptr<S3::Client> getClient(
     const S3Settings & settings,
     ContextPtr context,
     bool for_disk_s3,
-    std::optional<std::string> opt_disk_name)
+    std::optional<std::string> opt_disk_name,
+    std::function<std::shared_ptr<DataLake::IStorageCredentials>()> refresh_credentials_callback)
 
 {
     auto url = S3::URI(endpoint);
     if (!url.key.ends_with('/'))
         url.key.push_back('/');
-    return getClient(url, settings, context, for_disk_s3, opt_disk_name);
+    return getClient(url, settings, context, for_disk_s3, opt_disk_name, refresh_credentials_callback);
 }
 
 std::unique_ptr<S3::Client>
-getClient(const S3::URI & url, const S3Settings & settings, ContextPtr context, bool for_disk_s3, std::optional<std::string> opt_disk_name)
+getClient(const S3::URI & url, const S3Settings & settings, ContextPtr context, bool for_disk_s3, std::optional<std::string> opt_disk_name, std::function<std::shared_ptr<DataLake::IStorageCredentials>()> refresh_credentials_callback)
 {
     const auto & auth_settings = settings.auth_settings;
     const auto & server_settings = context->getGlobalContext()->getServerSettings();
@@ -198,11 +200,21 @@ getClient(const S3::URI & url, const S3Settings & settings, ContextPtr context, 
         /*sts_endpoint_override=*/""
     };
 
+    String access_key_id = auth_settings[S3AuthSetting::access_key_id];
+    String secret_access_key = auth_settings[S3AuthSetting::secret_access_key];
+
+    auto updated_credentials = refresh_credentials_callback();
+    if (updated_credentials)
+    {
+        auto s3_updated_credentials = std::static_pointer_cast<DataLake::S3Credentials>(updated_credentials);
+        access_key_id = s3_updated_credentials->getAccessKeyId();
+        secret_access_key = s3_updated_credentials->getSecretAccessKey();
+    }
     return S3::ClientFactory::instance().create(
         client_configuration,
         client_settings,
-        auth_settings[S3AuthSetting::access_key_id],
-        auth_settings[S3AuthSetting::secret_access_key],
+        access_key_id,
+        secret_access_key,
         auth_settings[S3AuthSetting::server_side_encryption_customer_key_base64],
         auth_settings.server_side_encryption_kms_config,
         auth_settings.getHeaders(),

--- a/src/Disks/DiskObjectStorage/ObjectStorages/S3/diskSettings.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/S3/diskSettings.cpp
@@ -1,6 +1,5 @@
 #include <memory>
 #include <Disks/DiskObjectStorage/ObjectStorages/S3/diskSettings.h>
-#include "Interpreters/StorageID.h"
 
 #if USE_AWS_S3
 
@@ -26,6 +25,7 @@
 #include <IO/S3Settings.h>
 #include <Disks/DiskObjectStorage/ObjectStorages/S3/S3ObjectStorage.h>
 #include <Disks/DiskLocal.h>
+#include <Interpreters/StorageID.h>
 
 namespace DB
 {

--- a/src/Disks/DiskObjectStorage/ObjectStorages/S3/diskSettings.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/S3/diskSettings.cpp
@@ -1,5 +1,6 @@
 #include <memory>
 #include <Disks/DiskObjectStorage/ObjectStorages/S3/diskSettings.h>
+#include "Interpreters/StorageID.h"
 
 #if USE_AWS_S3
 

--- a/src/Disks/DiskObjectStorage/ObjectStorages/S3/diskSettings.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/S3/diskSettings.cpp
@@ -206,14 +206,17 @@ getClient(const S3::URI & url, const S3Settings & settings, ContextPtr context, 
     String secret_access_key = auth_settings[S3AuthSetting::secret_access_key];
     String session_token = auth_settings[S3AuthSetting::session_token];
 
-    auto updated_credentials = refresh_credentials_callback();
-    if (updated_credentials)
+    if (refresh_credentials_callback)
     {
-        auto s3_updated_credentials = std::static_pointer_cast<DataLake::S3Credentials>(updated_credentials);
-        access_key_id = s3_updated_credentials->getAccessKeyId();
-        secret_access_key = s3_updated_credentials->getSecretAccessKey();
-        session_token = s3_updated_credentials->getSessionToken();
-        LOG_DEBUG(getLogger("getClient"), "Got new access tokens {} {} {}", access_key_id, secret_access_key, session_token);
+        auto updated_credentials = refresh_credentials_callback();
+        if (updated_credentials)
+        {
+            auto s3_updated_credentials = std::static_pointer_cast<DataLake::S3Credentials>(updated_credentials);
+            access_key_id = s3_updated_credentials->getAccessKeyId();
+            secret_access_key = s3_updated_credentials->getSecretAccessKey();
+            session_token = s3_updated_credentials->getSessionToken();
+            LOG_DEBUG(getLogger("getClient"), "Got new access tokens {} {} {}", access_key_id, secret_access_key, session_token);
+        }
     }
     return S3::ClientFactory::instance().create(
         client_configuration,

--- a/src/Disks/DiskObjectStorage/ObjectStorages/S3/diskSettings.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/S3/diskSettings.cpp
@@ -93,7 +93,7 @@ std::unique_ptr<S3::Client> getClient(
     ContextPtr context,
     bool for_disk_s3,
     std::optional<std::string> opt_disk_name,
-    std::function<std::shared_ptr<DataLake::IStorageCredentials>()> refresh_credentials_callback)
+    std::optional<std::function<std::shared_ptr<DataLake::IStorageCredentials>()>> refresh_credentials_callback)
 
 {
     auto url = S3::URI(endpoint);
@@ -103,7 +103,7 @@ std::unique_ptr<S3::Client> getClient(
 }
 
 std::unique_ptr<S3::Client>
-getClient(const S3::URI & url, const S3Settings & settings, ContextPtr context, bool for_disk_s3, std::optional<std::string> opt_disk_name, std::function<std::shared_ptr<DataLake::IStorageCredentials>()> refresh_credentials_callback)
+getClient(const S3::URI & url, const S3Settings & settings, ContextPtr context, bool for_disk_s3, std::optional<std::string> opt_disk_name, std::optional<std::function<std::shared_ptr<DataLake::IStorageCredentials>()>> refresh_credentials_callback)
 {
     const auto & auth_settings = settings.auth_settings;
     const auto & server_settings = context->getGlobalContext()->getServerSettings();
@@ -208,7 +208,7 @@ getClient(const S3::URI & url, const S3Settings & settings, ContextPtr context, 
 
     if (refresh_credentials_callback)
     {
-        auto updated_credentials = refresh_credentials_callback();
+        auto updated_credentials = (*refresh_credentials_callback)();
         if (updated_credentials)
         {
             auto s3_updated_credentials = std::static_pointer_cast<DataLake::S3Credentials>(updated_credentials);

--- a/src/Disks/DiskObjectStorage/ObjectStorages/S3/diskSettings.h
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/S3/diskSettings.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Interpreters/StorageID.h"
 #include "config.h"
 
 #if USE_AWS_S3

--- a/src/Disks/DiskObjectStorage/ObjectStorages/S3/diskSettings.h
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/S3/diskSettings.h
@@ -9,6 +9,7 @@
 #include <IO/S3Settings.h>
 
 #include <IO/S3/Client.h>
+#include <Databases/DataLake/StorageCredentials.h>
 
 namespace DB
 {
@@ -18,10 +19,11 @@ std::unique_ptr<S3::Client> getClient(
     const S3Settings & settings,
     ContextPtr context,
     bool for_disk_s3,
-    std::optional<std::string> opt_disk_name = {});
+    std::optional<std::string> opt_disk_name = {},
+    std::function<std::shared_ptr<DataLake::IStorageCredentials>()> refresh_credentials_callback = {});
 
 std::unique_ptr<S3::Client> getClient(
-    const S3::URI & url_, const S3Settings & settings, ContextPtr context, bool for_disk_s3, std::optional<std::string> opt_disk_name = {});
+    const S3::URI & url_, const S3Settings & settings, ContextPtr context, bool for_disk_s3, std::optional<std::string> opt_disk_name = {}, std::function<std::shared_ptr<DataLake::IStorageCredentials>()> refresh_credentials_callback = {});
 }
 
 #endif

--- a/src/Disks/DiskObjectStorage/ObjectStorages/S3/diskSettings.h
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/S3/diskSettings.h
@@ -20,10 +20,15 @@ std::unique_ptr<S3::Client> getClient(
     ContextPtr context,
     bool for_disk_s3,
     std::optional<std::string> opt_disk_name = {},
-    std::function<std::shared_ptr<DataLake::IStorageCredentials>()> refresh_credentials_callback = {});
+    std::function<std::shared_ptr<DataLake::IStorageCredentials>()> refresh_credentials_callback = [] {return nullptr;});
 
 std::unique_ptr<S3::Client> getClient(
-    const S3::URI & url_, const S3Settings & settings, ContextPtr context, bool for_disk_s3, std::optional<std::string> opt_disk_name = {}, std::function<std::shared_ptr<DataLake::IStorageCredentials>()> refresh_credentials_callback = {});
+    const S3::URI & url_,
+    const S3Settings & settings,
+    ContextPtr context,
+    bool for_disk_s3,
+    std::optional<std::string> opt_disk_name = {},
+    std::function<std::shared_ptr<DataLake::IStorageCredentials>()> refresh_credentials_callback = [] {return nullptr;});
 }
 
 #endif

--- a/src/Disks/DiskObjectStorage/ObjectStorages/S3/diskSettings.h
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/S3/diskSettings.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "Interpreters/StorageID.h"
 #include "config.h"
 
 #if USE_AWS_S3
@@ -11,6 +10,7 @@
 
 #include <IO/S3/Client.h>
 #include <Databases/DataLake/StorageCredentials.h>
+#include <Interpreters/StorageID.h>
 
 namespace DB
 {

--- a/src/Disks/DiskObjectStorage/ObjectStorages/S3/diskSettings.h
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/S3/diskSettings.h
@@ -21,7 +21,7 @@ std::unique_ptr<S3::Client> getClient(
     ContextPtr context,
     bool for_disk_s3,
     std::optional<std::string> opt_disk_name = {},
-    std::function<std::shared_ptr<DataLake::IStorageCredentials>()> refresh_credentials_callback = [] {return nullptr;});
+    std::optional<std::function<std::shared_ptr<DataLake::IStorageCredentials>()>> refresh_credentials_callback = std::nullopt);
 
 std::unique_ptr<S3::Client> getClient(
     const S3::URI & url_,
@@ -29,7 +29,7 @@ std::unique_ptr<S3::Client> getClient(
     ContextPtr context,
     bool for_disk_s3,
     std::optional<std::string> opt_disk_name = {},
-    std::function<std::shared_ptr<DataLake::IStorageCredentials>()> refresh_credentials_callback = [] {return nullptr;});
+    std::optional<std::function<std::shared_ptr<DataLake::IStorageCredentials>()>> refresh_credentials_callback = std::nullopt);
 }
 
 #endif

--- a/src/IO/ReadBufferFromS3.cpp
+++ b/src/IO/ReadBufferFromS3.cpp
@@ -296,7 +296,8 @@ bool ReadBufferFromS3::processException(size_t read_offset, size_t attempt) cons
     {
         if (s3_exception->isAccessTokenExpiredError())
         {
-            credentials_refresh_callback();
+            auto new_client = credentials_refresh_callback();
+            client_ptr = std::move(new_client);
             return true;
         }
 

--- a/src/IO/ReadBufferFromS3.cpp
+++ b/src/IO/ReadBufferFromS3.cpp
@@ -65,7 +65,8 @@ ReadBufferFromS3::ReadBufferFromS3(
     size_t offset_,
     size_t read_until_position_,
     bool restricted_seek_,
-    std::optional<size_t> file_size_)
+    std::optional<size_t> file_size_,
+    const S3CredentialsRefreshCallback & credentials_refresh_callback_)
     : ReadBufferFromFileBase()
     , client_ptr(std::move(client_ptr_))
     , bucket(bucket_)
@@ -77,6 +78,7 @@ ReadBufferFromS3::ReadBufferFromS3(
     , read_settings(settings_)
     , use_external_buffer(use_external_buffer_)
     , restricted_seek(restricted_seek_)
+    , credentials_refresh_callback(credentials_refresh_callback_)
 {
     file_size = file_size_;
 }
@@ -292,6 +294,12 @@ bool ReadBufferFromS3::processException(size_t read_offset, size_t attempt) cons
 
     if (auto * s3_exception = current_exception_cast<S3Exception *>())
     {
+        if (s3_exception->isAccessTokenExpiredError())
+        {
+            credentials_refresh_callback();
+            return true;
+        }
+
         /// It doesn't make sense to retry Access Denied or No Such Key
         if (!s3_exception->isRetryableError())
         {

--- a/src/IO/ReadBufferFromS3.cpp
+++ b/src/IO/ReadBufferFromS3.cpp
@@ -158,9 +158,6 @@ bool ReadBufferFromS3::nextImpl()
             if (!impl)
             {
                 impl = initialize(attempt);
-                for (size_t i = 0; i < next_calls; ++i)
-                    impl->next();
-                next_calls = 0;
 
                 if (use_external_buffer)
                 {
@@ -177,7 +174,6 @@ bool ReadBufferFromS3::nextImpl()
 
             /// Try to read a next portion of data.
             next_result = impl->next();
-            next_calls += 1;
             break;
         }
         catch (...)

--- a/src/IO/ReadBufferFromS3.cpp
+++ b/src/IO/ReadBufferFromS3.cpp
@@ -158,6 +158,9 @@ bool ReadBufferFromS3::nextImpl()
             if (!impl)
             {
                 impl = initialize(attempt);
+                for (size_t i = 0; i < next_calls; ++i)
+                    impl->next();
+                next_calls = 0;
 
                 if (use_external_buffer)
                 {
@@ -174,6 +177,7 @@ bool ReadBufferFromS3::nextImpl()
 
             /// Try to read a next portion of data.
             next_result = impl->next();
+            next_calls += 1;
             break;
         }
         catch (...)

--- a/src/IO/ReadBufferFromS3.h
+++ b/src/IO/ReadBufferFromS3.h
@@ -42,7 +42,7 @@ private:
     LoggerPtr log = getLogger("ReadBufferFromS3");
 
 public:
-    using S3CredentialsRefreshCallback = std::function<std::shared_ptr<const S3::Client>()>;
+    using S3CredentialsRefreshCallback = std::function<std::unique_ptr<const S3::Client>()>;
 
     ReadBufferFromS3(
         std::shared_ptr<const S3::Client> client_ptr_,

--- a/src/IO/ReadBufferFromS3.h
+++ b/src/IO/ReadBufferFromS3.h
@@ -42,6 +42,8 @@ private:
     LoggerPtr log = getLogger("ReadBufferFromS3");
 
 public:
+    using S3CredentialsRefreshCallback = std::function<std::shared_ptr<const S3::Client>()>;
+
     ReadBufferFromS3(
         std::shared_ptr<const S3::Client> client_ptr_,
         const String & bucket_,
@@ -53,7 +55,9 @@ public:
         size_t offset_ = 0,
         size_t read_until_position_ = 0,
         bool restricted_seek_ = false,
-        std::optional<size_t> file_size = std::nullopt);
+        std::optional<size_t> file_size = std::nullopt,
+        const S3CredentialsRefreshCallback & credentials_refresh_callback_ = [] {return nullptr;}
+        );
 
     ~ReadBufferFromS3() override = default;
 
@@ -109,6 +113,8 @@ private:
     bool restricted_seek;
 
     bool read_all_range_successfully = false;
+
+    const S3CredentialsRefreshCallback credentials_refresh_callback;
 };
 
 }

--- a/src/IO/ReadBufferFromS3.h
+++ b/src/IO/ReadBufferFromS3.h
@@ -23,7 +23,7 @@ namespace DB
 class ReadBufferFromS3 : public ReadBufferFromFileBase
 {
 private:
-    std::shared_ptr<const S3::Client> client_ptr;
+    mutable std::shared_ptr<const S3::Client> client_ptr;
     String bucket;
     String key;
     String version_id;

--- a/src/IO/ReadBufferFromS3.h
+++ b/src/IO/ReadBufferFromS3.h
@@ -24,7 +24,6 @@ class ReadBufferFromS3 : public ReadBufferFromFileBase
 {
 private:
     mutable std::shared_ptr<const S3::Client> client_ptr;
-    mutable size_t next_calls = 0;
     String bucket;
     String key;
     String version_id;

--- a/src/IO/ReadBufferFromS3.h
+++ b/src/IO/ReadBufferFromS3.h
@@ -24,6 +24,7 @@ class ReadBufferFromS3 : public ReadBufferFromFileBase
 {
 private:
     mutable std::shared_ptr<const S3::Client> client_ptr;
+    mutable size_t next_calls = 0;
     String bucket;
     String key;
     String version_id;

--- a/src/IO/S3Common.cpp
+++ b/src/IO/S3Common.cpp
@@ -45,6 +45,11 @@ bool S3Exception::isRetryableError() const
     return !unretryable_errors.contains(code);
 }
 
+bool S3Exception::isAccessTokenExpiredError() const
+{
+    return code == Aws::S3::S3Errors::INVALID_ACCESS_KEY_ID;
+}
+
 }
 namespace DB::ErrorCodes
 {

--- a/src/IO/S3Common.cpp
+++ b/src/IO/S3Common.cpp
@@ -47,7 +47,7 @@ bool S3Exception::isRetryableError() const
 
 bool S3Exception::isAccessTokenExpiredError() const
 {
-    return code == Aws::S3::S3Errors::INVALID_ACCESS_KEY_ID;
+    return code == Aws::S3::S3Errors::INVALID_ACCESS_KEY_ID || code == Aws::S3::S3Errors::ACCESS_DENIED || code == Aws::S3::S3Errors::INVALID_SIGNATURE;
 }
 
 }

--- a/src/IO/S3Common.cpp
+++ b/src/IO/S3Common.cpp
@@ -47,7 +47,7 @@ bool S3Exception::isRetryableError() const
 
 bool S3Exception::isAccessTokenExpiredError() const
 {
-    return code == Aws::S3::S3Errors::INVALID_ACCESS_KEY_ID || code == Aws::S3::S3Errors::ACCESS_DENIED || code == Aws::S3::S3Errors::INVALID_SIGNATURE;
+    return code == Aws::S3::S3Errors::INVALID_ACCESS_KEY_ID || code == Aws::S3::S3Errors::ACCESS_DENIED || code == Aws::S3::S3Errors::INVALID_SIGNATURE || code == Aws::S3::S3Errors::UNKNOWN;
 }
 
 }

--- a/src/IO/S3Common.h
+++ b/src/IO/S3Common.h
@@ -46,6 +46,7 @@ public:
     }
 
     bool isRetryableError() const;
+    bool isAccessTokenExpiredError() const;
 
     S3Exception * clone() const override { return new S3Exception(*this); }
     void rethrow() const override { throw *this; } /// NOLINT(cert-err60-cpp)

--- a/src/Storages/ObjectStorage/Azure/Configuration.cpp
+++ b/src/Storages/ObjectStorage/Azure/Configuration.cpp
@@ -89,7 +89,7 @@ StorageObjectStorageQuerySettings StorageAzureConfiguration::getQuerySettings(co
     };
 }
 
-ObjectStoragePtr StorageAzureConfiguration::createObjectStorage(ContextPtr context, bool is_readonly) /// NOLINT
+ObjectStoragePtr StorageAzureConfiguration::createObjectStorage(ContextPtr context, bool is_readonly, CredentialsConfigurationCallback /*refresh_credentials_callback*/) /// NOLINT
 {
     assertInitialized();
 

--- a/src/Storages/ObjectStorage/Azure/Configuration.h
+++ b/src/Storages/ObjectStorage/Azure/Configuration.h
@@ -99,7 +99,7 @@ public:
 
     void check(ContextPtr context) override;
 
-    ObjectStoragePtr createObjectStorage(ContextPtr context, bool is_readonly) override;
+    ObjectStoragePtr createObjectStorage(ContextPtr context, bool is_readonly, CredentialsConfigurationCallback refresh_credentials_callback) override;
 
     void addStructureAndFormatToArgsIfNeeded(
         ASTs & args,

--- a/src/Storages/ObjectStorage/DataLakes/DataLakeConfiguration.h
+++ b/src/Storages/ObjectStorage/DataLakes/DataLakeConfiguration.h
@@ -164,11 +164,11 @@ public:
 
     }
 
-    ObjectStoragePtr createObjectStorage(ContextPtr context, bool is_readonly) override
+    ObjectStoragePtr createObjectStorage(ContextPtr context, bool is_readonly, StorageObjectStorageConfiguration::CredentialsConfigurationCallback refresh_credentials_callback) override
     {
         if (ready_object_storage)
             return ready_object_storage;
-        return BaseStorageConfiguration::createObjectStorage(context, is_readonly);
+        return BaseStorageConfiguration::createObjectStorage(context, is_readonly, refresh_credentials_callback);
     }
 
     std::optional<ColumnsDescription> tryGetTableStructureFromMetadata(ContextPtr local_context) const override

--- a/src/Storages/ObjectStorage/HDFS/Configuration.cpp
+++ b/src/Storages/ObjectStorage/HDFS/Configuration.cpp
@@ -50,7 +50,8 @@ void StorageHDFSConfiguration::check(ContextPtr context)
 
 ObjectStoragePtr StorageHDFSConfiguration::createObjectStorage( /// NOLINT
     ContextPtr context,
-    bool /* is_readonly */)
+    bool /* is_readonly */,
+    CredentialsConfigurationCallback /*refresh_credentials_callback*/)
 {
     assertInitialized();
     const auto & settings = context->getSettingsRef();

--- a/src/Storages/ObjectStorage/HDFS/Configuration.h
+++ b/src/Storages/ObjectStorage/HDFS/Configuration.h
@@ -75,7 +75,7 @@ public:
 
     void check(ContextPtr context) override;
 
-    ObjectStoragePtr createObjectStorage(ContextPtr context, bool is_readonly) override;
+    ObjectStoragePtr createObjectStorage(ContextPtr context, bool is_readonly, CredentialsConfigurationCallback /*refresh_credentials_callback*/) override;
 
     void addStructureAndFormatToArgsIfNeeded(
         ASTs & args, const String & structure_, const String & format_, ContextPtr context, bool with_structure) override;

--- a/src/Storages/ObjectStorage/Local/Configuration.h
+++ b/src/Storages/ObjectStorage/Local/Configuration.h
@@ -74,7 +74,7 @@ public:
     String getDataSourceDescription() const override { return ""; }
     StorageObjectStorageQuerySettings getQuerySettings(const ContextPtr &) const override;
 
-    ObjectStoragePtr createObjectStorage(ContextPtr, bool readonly) override
+    ObjectStoragePtr createObjectStorage(ContextPtr, bool readonly, CredentialsConfigurationCallback /*refresh_credentials_callback*/) override
     {
         return std::make_shared<LocalObjectStorage>(LocalObjectStorageSettings(disk_name, "/", readonly));
     }

--- a/src/Storages/ObjectStorage/S3/Configuration.cpp
+++ b/src/Storages/ObjectStorage/S3/Configuration.cpp
@@ -153,7 +153,7 @@ StorageObjectStorageQuerySettings StorageS3Configuration::getQuerySettings(const
     };
 }
 
-ObjectStoragePtr StorageS3Configuration::createObjectStorage(ContextPtr context, bool /* is_readonly */) /// NOLINT
+ObjectStoragePtr StorageS3Configuration::createObjectStorage(ContextPtr context, bool /* is_readonly */, CredentialsConfigurationCallback refresh_credentials_callback) /// NOLINT
 {
     assertInitialized();
 
@@ -165,6 +165,11 @@ ObjectStoragePtr StorageS3Configuration::createObjectStorage(ContextPtr context,
     }
 
     auto client = getClient(url, *s3_settings, context, /* for_disk_s3 */false);
+    auto client_refresher = [refresh_credentials_callback, this, context] ()
+    {
+        auto new_client = getClient(url, *s3_settings, context, /* for_disk_s3 */false);
+        return new_client;
+    };
     return std::make_shared<S3ObjectStorage>(
         std::move(client),
         std::make_unique<S3Settings>(*s3_settings),
@@ -172,7 +177,8 @@ ObjectStoragePtr StorageS3Configuration::createObjectStorage(ContextPtr context,
         *s3_capabilities,
         /*key_generator=*/nullptr,
         "StorageS3",
-        false);
+        false,
+        client_refresher);
 }
 
 void S3StorageParsedArguments::fromNamedCollection(const NamedCollection & collection, ContextPtr context)

--- a/src/Storages/ObjectStorage/S3/Configuration.cpp
+++ b/src/Storages/ObjectStorage/S3/Configuration.cpp
@@ -167,7 +167,7 @@ ObjectStoragePtr StorageS3Configuration::createObjectStorage(ContextPtr context,
     auto client = getClient(url, *s3_settings, context, /* for_disk_s3 */false);
     auto client_refresher = [refresh_credentials_callback, this, context] ()
     {
-        auto new_client = getClient(url, *s3_settings, context, /* for_disk_s3 */false);
+        auto new_client = getClient(url, *s3_settings, context, /* for_disk_s3 */false, /*opt_disk_name*/ {}, refresh_credentials_callback);
         return new_client;
     };
     return std::make_shared<S3ObjectStorage>(

--- a/src/Storages/ObjectStorage/S3/Configuration.cpp
+++ b/src/Storages/ObjectStorage/S3/Configuration.cpp
@@ -166,11 +166,11 @@ ObjectStoragePtr StorageS3Configuration::createObjectStorage(ContextPtr context,
 
     auto client = getClient(url, *s3_settings, context, /* for_disk_s3 */false);
 
-    auto client_refresher = [refresh_credentials_callback, this, context] () -> std::unique_ptr<S3::Client>
+    auto client_refresher = [refresh_credentials_callback, this, context_ = Context::createCopy(context)] () -> std::unique_ptr<S3::Client>
     {
         if (!refresh_credentials_callback)
             return nullptr;
-        auto new_client = getClient(url, *s3_settings, context, /* for_disk_s3 */false, /*opt_disk_name*/ {}, refresh_credentials_callback);
+        auto new_client = getClient(url, *s3_settings, context_, /* for_disk_s3 */false, /*opt_disk_name*/ {}, refresh_credentials_callback);
         return new_client;
     };
     return std::make_shared<S3ObjectStorage>(

--- a/src/Storages/ObjectStorage/S3/Configuration.cpp
+++ b/src/Storages/ObjectStorage/S3/Configuration.cpp
@@ -172,14 +172,14 @@ ObjectStoragePtr StorageS3Configuration::createObjectStorage(ContextPtr context,
     {
         // Capture by value to avoid circular references
         auto url_copy = url;
-        auto s3_settings_copy = std::make_unique<S3Settings>(*s3_settings);
+        auto s3_settings_shared = std::make_shared<S3Settings>(*s3_settings);
         ContextWeakPtr context_weak = context;
-        client_refresher = [refresh_credentials_callback, url_copy, s3_settings_copy = std::move(s3_settings_copy), context_weak] () mutable
+        client_refresher = [refresh_credentials_callback, url_copy, s3_settings_shared, context_weak] () mutable
         {
             auto context_locked = context_weak.lock();
             if (!context_locked)
                 return std::unique_ptr<const S3::Client>();
-            auto new_client = getClient(url_copy, *s3_settings_copy, context_locked, /* for_disk_s3 */false, /*opt_disk_name*/ {}, refresh_credentials_callback);
+            auto new_client = getClient(url_copy, *s3_settings_shared, context_locked, /* for_disk_s3 */false, /*opt_disk_name*/ {}, refresh_credentials_callback);
             return std::unique_ptr<const S3::Client>(new_client.release());
         };
     }

--- a/src/Storages/ObjectStorage/S3/Configuration.cpp
+++ b/src/Storages/ObjectStorage/S3/Configuration.cpp
@@ -165,7 +165,7 @@ ObjectStoragePtr StorageS3Configuration::createObjectStorage(ContextPtr context,
     }
 
     auto client = getClient(url, *s3_settings, context, /* for_disk_s3 */false);
-    
+
     // Only create refresher callback if refresh_credentials_callback is provided and callable
     S3ObjectStorage::S3CredentialsRefreshCallback client_refresher;
     if (refresh_credentials_callback)

--- a/src/Storages/ObjectStorage/S3/Configuration.h
+++ b/src/Storages/ObjectStorage/S3/Configuration.h
@@ -124,7 +124,7 @@ public:
     void validateNamespace(const String & name) const override;
     bool isStaticConfiguration() const override { return static_configuration; }
 
-    ObjectStoragePtr createObjectStorage(ContextPtr context, bool is_readonly) override;
+    ObjectStoragePtr createObjectStorage(ContextPtr context, bool is_readonly, CredentialsConfigurationCallback refresh_credentials_callback) override;
 
     void addStructureAndFormatToArgsIfNeeded(
         ASTs & args,

--- a/src/Storages/ObjectStorage/StorageObjectStorageConfiguration.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorageConfiguration.h
@@ -16,6 +16,7 @@
 #include <Storages/StorageFactory.h>
 #include <Formats/FormatFilterInfo.h>
 #include <Storages/ObjectStorage/DataLakes/IDataLakeMetadata.h>
+#include <Databases/DataLake/StorageCredentials.h>
 
 namespace DB
 {
@@ -56,6 +57,8 @@ struct StorageObjectStorageQuerySettings
 class StorageObjectStorageConfiguration
 {
 public:
+    using CredentialsConfigurationCallback = std::function<std::shared_ptr<DataLake::IStorageCredentials>()>;
+
     StorageObjectStorageConfiguration() = default;
     virtual ~StorageObjectStorageConfiguration() = default;
 
@@ -134,7 +137,7 @@ public:
     virtual void check(ContextPtr context);
     virtual void validateNamespace(const String & /* name */) const {}
 
-    virtual ObjectStoragePtr createObjectStorage(ContextPtr context, bool is_readonly) = 0;
+    virtual ObjectStoragePtr createObjectStorage(ContextPtr context, bool is_readonly, CredentialsConfigurationCallback refresh_credentials_callback) = 0;
     virtual bool isStaticConfiguration() const { return true; }
 
     virtual bool isDataLakeConfiguration() const { return false; }

--- a/src/Storages/ObjectStorage/StorageObjectStorageConfiguration.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorageConfiguration.h
@@ -57,7 +57,7 @@ struct StorageObjectStorageQuerySettings
 class StorageObjectStorageConfiguration
 {
 public:
-    using CredentialsConfigurationCallback = std::function<std::shared_ptr<DataLake::IStorageCredentials>()>;
+    using CredentialsConfigurationCallback = std::optional<std::function<std::shared_ptr<DataLake::IStorageCredentials>()>>;
 
     StorageObjectStorageConfiguration() = default;
     virtual ~StorageObjectStorageConfiguration() = default;

--- a/src/Storages/ObjectStorage/registerStorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/registerStorageObjectStorage.cpp
@@ -81,7 +81,7 @@ createStorageObjectStorage(const StorageFactory::Arguments & args, StorageObject
         configuration,
         // We only want to perform write actions (e.g. create a container in Azure) when the table is being created,
         // and we want to avoid it when we load the table after a server restart.
-        configuration->createObjectStorage(context, /* is_readonly */ args.mode != LoadingStrictnessLevel::CREATE),
+        configuration->createObjectStorage(context, /* is_readonly */ args.mode != LoadingStrictnessLevel::CREATE, []{return nullptr;}),
         context_copy, /// Use global context.
         args.table_id,
         args.columns,

--- a/src/Storages/ObjectStorage/registerStorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/registerStorageObjectStorage.cpp
@@ -81,7 +81,7 @@ createStorageObjectStorage(const StorageFactory::Arguments & args, StorageObject
         configuration,
         // We only want to perform write actions (e.g. create a container in Azure) when the table is being created,
         // and we want to avoid it when we load the table after a server restart.
-        configuration->createObjectStorage(context, /* is_readonly */ args.mode != LoadingStrictnessLevel::CREATE, []{return nullptr;}),
+        configuration->createObjectStorage(context, /* is_readonly */ args.mode != LoadingStrictnessLevel::CREATE, std::nullopt),
         context_copy, /// Use global context.
         args.table_id,
         args.columns,

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
@@ -302,7 +302,7 @@ StorageObjectStorageQueue::StorageObjectStorageQueue(
     const bool is_attach = mode > LoadingStrictnessLevel::CREATE;
     validateSettings(*queue_settings_, is_attach);
 
-    object_storage = configuration->createObjectStorage(context_, /* is_readonly */true, {});
+    object_storage = configuration->createObjectStorage(context_, /* is_readonly */true, [] { return nullptr; });
     FormatFactory::instance().checkFormatName(configuration->format);
     configuration->check(context_);
 

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
@@ -302,7 +302,7 @@ StorageObjectStorageQueue::StorageObjectStorageQueue(
     const bool is_attach = mode > LoadingStrictnessLevel::CREATE;
     validateSettings(*queue_settings_, is_attach);
 
-    object_storage = configuration->createObjectStorage(context_, /* is_readonly */true);
+    object_storage = configuration->createObjectStorage(context_, /* is_readonly */true, {});
     FormatFactory::instance().checkFormatName(configuration->format);
     configuration->check(context_);
 

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
@@ -302,7 +302,7 @@ StorageObjectStorageQueue::StorageObjectStorageQueue(
     const bool is_attach = mode > LoadingStrictnessLevel::CREATE;
     validateSettings(*queue_settings_, is_attach);
 
-    object_storage = configuration->createObjectStorage(context_, /* is_readonly */true, [] { return nullptr; });
+    object_storage = configuration->createObjectStorage(context_, /* is_readonly */true, std::nullopt);
     FormatFactory::instance().checkFormatName(configuration->format);
     configuration->check(context_);
 

--- a/src/TableFunctions/TableFunctionObjectStorage.cpp
+++ b/src/TableFunctions/TableFunctionObjectStorage.cpp
@@ -56,7 +56,7 @@ template <typename Definition, typename Configuration, bool is_data_lake>
 ObjectStoragePtr TableFunctionObjectStorage<Definition, Configuration, is_data_lake>::getObjectStorage(const ContextPtr & context, bool create_readonly) const
 {
     if (!object_storage)
-        object_storage = configuration->createObjectStorage(context, create_readonly, {});
+        object_storage = configuration->createObjectStorage(context, create_readonly, [] { return nullptr; });
     return object_storage;
 }
 

--- a/src/TableFunctions/TableFunctionObjectStorage.cpp
+++ b/src/TableFunctions/TableFunctionObjectStorage.cpp
@@ -56,7 +56,7 @@ template <typename Definition, typename Configuration, bool is_data_lake>
 ObjectStoragePtr TableFunctionObjectStorage<Definition, Configuration, is_data_lake>::getObjectStorage(const ContextPtr & context, bool create_readonly) const
 {
     if (!object_storage)
-        object_storage = configuration->createObjectStorage(context, create_readonly);
+        object_storage = configuration->createObjectStorage(context, create_readonly, {});
     return object_storage;
 }
 

--- a/src/TableFunctions/TableFunctionObjectStorage.cpp
+++ b/src/TableFunctions/TableFunctionObjectStorage.cpp
@@ -56,7 +56,7 @@ template <typename Definition, typename Configuration, bool is_data_lake>
 ObjectStoragePtr TableFunctionObjectStorage<Definition, Configuration, is_data_lake>::getObjectStorage(const ContextPtr & context, bool create_readonly) const
 {
     if (!object_storage)
-        object_storage = configuration->createObjectStorage(context, create_readonly, [] { return nullptr; });
+        object_storage = configuration->createObjectStorage(context, create_readonly, std::nullopt);
     return object_storage;
 }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Dynamic update s3 access tokens in long queries with unity catalog. This closes https://github.com/ClickHouse/ClickHouse/issues/93981

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.487`
<!-- ch-version-info:end -->