### PR TITLE
tests: fix flaky 02350_views_max_insert_threads

### DIFF
--- a/tests/queries/0_stateless/02350_views_max_insert_threads.sql
+++ b/tests/queries/0_stateless/02350_views_max_insert_threads.sql
@@ -7,7 +7,13 @@ drop table if exists t_mv;
 create table t (a UInt64) Engine = Null;
 create materialized view t_mv Engine = Null AS select now() as ts, max(a) from t group by ts;
 
-insert into t select * from numbers_mt(10e6) settings max_threads = 10, max_insert_threads=10, max_block_size=100000, parallel_view_processing=1;
+insert into t select * from numbers_mt(10e6)
+settings max_threads=10,
+         max_insert_threads=10,
+         max_block_size=100000,
+         parallel_view_processing=1,
+         use_concurrency_control=0;
+
 system flush logs query_log;
 
 select peak_threads_usage>=10 from system.query_log where


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Details

Closes #93249 

According to the logs, stateless tests have concurrency control enabled (server logs from couple of failed jobs):
```
2026.01.16 11:09:29.655283 [ 1126 ] {} <Information> Application: ConcurrencyControl limit is set to 16 CPU slots with 'fair_round_robin' scheduler
...
2026.01.24 12:52:11.142069 [ 1147 ] {} <Information> Application: ConcurrencyControl limit is set to 16 CPU slots with 'fair_round_robin' scheduler
...
2026.01.23 23:12:22.797548 [ 1140 ] {} <Information> Application: ConcurrencyControl limit is set to 16 CPU slots with 'fair_round_robin' scheduler
```
and even `--no-parallel` tag not always helps to acquire 10 threads for the query execution

The fix is to disable concurrency control for the insert query, to allow always plan max_threads for it.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.849`
<!-- ch-version-info:end -->