### PR TITLE
Fix crash in `getTopKMarks` when limit is zero

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexMinMax.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexMinMax.cpp
@@ -271,6 +271,9 @@ void MergeTreeIndexBulkGranulesMinMax::deserializeBinary(size_t granule_num, Rea
 
 void MergeTreeIndexBulkGranulesMinMax::getTopKMarks(size_t n, std::vector<MinMaxGranule> & result)
 {
+    if (n == 0)
+        return;
+
     if (n >= granules.size())
     {
         result.insert(result.end(), granules.begin(), granules.end());
@@ -305,6 +308,9 @@ void MergeTreeIndexBulkGranulesMinMax::getTopKMarks(int direction,
                                                     const std::vector<std::vector<MinMaxGranule>> & parts,
                                                     std::vector<MarkRanges> & result)
 {
+    if (n == 0)
+        return;
+
     std::priority_queue<MinMaxGranuleItem> queue;
 
     for (size_t part_index = 0; part_index < parts.size(); ++part_index)

--- a/tests/queries/0_stateless/03807_top_k_limit_zero.sql
+++ b/tests/queries/0_stateless/03807_top_k_limit_zero.sql
@@ -1,0 +1,18 @@
+-- Test for crash when LIMIT 0 is used with use_skip_indexes_for_top_k
+-- Regression test for https://github.com/ClickHouse/ClickHouse/issues/95065
+
+DROP TABLE IF EXISTS tab;
+
+CREATE TABLE tab
+(
+    id UInt32,
+    v1 UInt32,
+    INDEX v1idx v1 TYPE minmax GRANULARITY 1
+) Engine = MergeTree ORDER BY id SETTINGS index_granularity = 64;
+
+INSERT INTO tab SELECT number, number FROM numbers(1000);
+
+SELECT id, v1 FROM tab ORDER BY v1 DESC NULLS LAST LIMIT 0 SETTINGS use_skip_indexes_for_top_k = 1;
+SELECT id, v1 FROM tab ORDER BY v1 ASC LIMIT 0 SETTINGS use_skip_indexes_for_top_k = 1;
+
+DROP TABLE tab;


### PR DESCRIPTION
When `LIMIT -0.` (or any expression that evaluates to 0) is used with `use_skip_indexes_for_top_k = 1`, the `getTopKMarks` functions would call `queue.top()` on an empty priority queue, causing undefined behavior and a segmentation fault.

The fix adds an early return when `n == 0` in both `getTopKMarks` overloads, since requesting the top 0 elements should return nothing.

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix crash in the top K optimization when `LIMIT` is zero. Closes #93893.

See https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=95065&sha=e047a3f739277d9272ec5108eb879df601c7aaf7&name_0=PR&name_1=AST%20fuzzer%20%28arm_asan%29
https://github.com/ClickHouse/ClickHouse/pull/95065

Checked manually that the new test reproduces the issue on the debug build.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.843`
- Backported to: `25.12.5.17`
<!-- ch-version-info:end -->