### PR TITLE
Disable long test `03593_backup_with_broken_projection` under MSan

### DIFF
--- a/tests/queries/0_stateless/03593_backup_with_broken_projection.sql
+++ b/tests/queries/0_stateless/03593_backup_with_broken_projection.sql
@@ -1,3 +1,5 @@
+-- Tags: no-msan
+
 CREATE TABLE 03593_backup_with_broken_projection
 (
     `id` UInt64,


### PR DESCRIPTION
The test times out under MSan builds with randomized settings (small `index_granularity`, small block sizes) because mutations on 5 million rows become too slow.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

See https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=95056&sha=7fcd6d1a96826d1c66442ada4bf32a2f064afea7&name_0=PR&name_1=Stateless%20tests%20%28amd_msan%2C%20parallel%2C%201%2F2%29
https://github.com/ClickHouse/ClickHouse/pull/95056


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.847`
<!-- ch-version-info:end -->