### PR TITLE
Disable test `03211_nested_json_merges` on debug builds

### DIFF
--- a/tests/queries/0_stateless/03211_nested_json_merges.sql.j2
+++ b/tests/queries/0_stateless/03211_nested_json_merges.sql.j2
@@ -1,4 +1,4 @@
--- Tags: no-fasttest, long, no-tsan, no-asan, no-msan, no-ubsan
+-- Tags: no-fasttest, long, no-debug, no-tsan, no-asan, no-msan, no-ubsan
 
 SET enable_json_type = 1;
 


### PR DESCRIPTION
The test times out (600 seconds) on debug builds because it inserts hundreds of thousands of rows and performs `optimize table final` operations that are slow in debug mode.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.850`
<!-- ch-version-info:end -->