### PR TITLE
Increase S3 file cache size to fix flaky test

### DIFF
--- a/tests/config/config.d/s3_storage_policy_by_default.xml
+++ b/tests/config/config.d/s3_storage_policy_by_default.xml
@@ -9,7 +9,7 @@
             </s3>
             <cached_s3>
                 <type>cache</type>
-                <max_size>1Gi</max_size>
+                <max_size>5Gi</max_size>
                 <path>cached_s3/</path>
                 <disk>s3</disk>
             </cached_s3>

--- a/tests/config/config.d/s3_storage_policy_with_template_object_key.xml
+++ b/tests/config/config.d/s3_storage_policy_with_template_object_key.xml
@@ -11,7 +11,7 @@
             </s3>
             <cached_s3>
                 <type>cache</type>
-                <max_size>1Gi</max_size>
+                <max_size>5Gi</max_size>
                 <path>cached_s3/</path>
                 <disk>s3</disk>
             </cached_s3>


### PR DESCRIPTION
The test `03514_grace_hash_join_logical_error` was failing sporadically with `NOT_ENOUGH_SPACE` error when running with S3 storage configuration. The grace hash join creates temporary files in the file cache, and with 1Gi limit the cache was filling up when running in parallel with other tests.

Increase the cache size from 1Gi to 5Gi.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

See https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=a1b25f3f4beb3ba49aa3b73671cc244185331b86&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_binary%2C%20ParallelReplicas%2C%20s3%20storage%2C%20parallel%29&name_1=Stateless%20tests%20%28amd_binary%2C%20ParallelReplicas%2C%20s3%20storage%2C%20parallel%29


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.855`
<!-- ch-version-info:end -->