### PR TITLE
Fix flaky test `test_rmv_append_backup`

### DIFF
--- a/tests/integration/test_backup_restore_new/test.py
+++ b/tests/integration/test_backup_restore_new/test.py
@@ -1163,6 +1163,8 @@ def test_rmv_append_backup():
     instance.query(
         "CREATE MATERIALIZED VIEW test.view REFRESH EVERY 6 HOURS APPEND TO test.target AS SELECT x FROM test.table"
     )
+    instance.query("SYSTEM REFRESH VIEW test.view")
+    instance.query("SYSTEM WAIT VIEW test.view")
 
     backup_name = new_backup_name()
     backup_settings = {"backup_data_from_refreshable_materialized_view_targets": False}


### PR DESCRIPTION
The test was flaky because it relied on the automatic refresh of a refreshable materialized view happening before the backup, but this was not guaranteed to occur in time.

The test creates a refreshable MV with `APPEND TO test.target` and then immediately runs a backup expecting `data/test/target/` directory to exist. However, the MV is configured with `REFRESH EVERY 6 HOURS`, and the first automatic refresh might not have executed yet by the time the backup runs, leaving `test.target` empty with no data parts to back up.

The fix adds explicit `SYSTEM REFRESH VIEW` and `SYSTEM WAIT VIEW` calls before the backup to ensure the target table has data. This matches the pattern used in the similar `test_rmv_append` test which also uses these commands (albeit after restore).

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

See https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=95009&sha=b5802b23a9895b8327e50eed7e9df38c96867386&name_0=PR&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%203%2F4%29
https://github.com/ClickHouse/ClickHouse/pull/95009


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.858`
<!-- ch-version-info:end -->