### PR TITLE
Fix flaky "Kafka bad" test `test_missing_mv_transitive_target` in TSan

### DIFF
--- a/tests/integration/test_kafka_bad_messages/test_mv_target_missing.py
+++ b/tests/integration/test_kafka_bad_messages/test_mv_target_missing.py
@@ -182,6 +182,8 @@ missing_dependencies: [['test.mvother']]
         assert (
             instance.query_with_retry(
                 "SELECT count() FROM test.target2",
+                retry_count=500,
+                sleep_time=0.1,
                 check_callback=lambda x: int(x) == 2,
             ).strip()
             == "2"
@@ -189,6 +191,8 @@ missing_dependencies: [['test.mvother']]
         assert (
             instance.query_with_retry(
                 "SELECT count() FROM test.target1",
+                retry_count=500,
+                sleep_time=0.1,
                 check_callback=lambda x: int(x) == 2,
             ).strip()
             == "2"
@@ -293,6 +297,8 @@ missing_dependencies: []
         assert (
             instance.query_with_retry(
                 "SELECT count() FROM test.target2",
+                retry_count=500,
+                sleep_time=0.1,
                 check_callback=lambda x: int(x) == 2,
             ).strip()
             == "2"


### PR DESCRIPTION
The test was failing intermittently in TSAN builds because the `query_with_retry` calls used default retry parameters (20 retries with 0.5s sleep = 10 seconds total), which is insufficient under TSAN where the Kafka consumer takes longer to detect resolved dependencies and start streaming.

Increased retry parameters to `retry_count=500, sleep_time=0.1` (50 seconds total), matching other Kafka tests in the same directory.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.859`
<!-- ch-version-info:end -->