### PR TITLE
Fix flaky `test_failure_in_the_middle` in S3Queue integration test

### DIFF
--- a/tests/integration/test_storage_s3_queue/test_5.py
+++ b/tests/integration/test_storage_s3_queue/test_5.py
@@ -498,7 +498,7 @@ def test_failure_in_the_middle(started_cluster):
                 f"StorageS3Queue (default.{table_name}): Got an error while pulling chunk: Code: 1002. DB::Exception: Failed to read file. Processed rows:"
             )
 
-        for _ in range(40):
+        for _ in range(120):
             if check_failpoint():
                 break
             time.sleep(1)


### PR DESCRIPTION
The test creates a ~2GB CSV file (1M rows × 2000 chars) and waits for a failpoint error to appear in the server logs. The original 40-second timeout is insufficient under TSAN, where operations are significantly slower due to instrumentation overhead.

Increased the timeout from 40 to 120 seconds to accommodate TSAN builds.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

See https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=e6518ca209cfdc081bb79e0ffb090c56d72397ef&name_0=MasterCI&name_1=Integration%20tests%20%28amd_tsan%2C%205%2F6%29&name_1=Integration%20tests%20%28amd_tsan%2C%205%2F6%29


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.856`
<!-- ch-version-info:end -->