### PR TITLE
Fix flaky `test_backup_restore_system_tables_with_plain_rewritable_disk`

### DIFF
--- a/tests/integration/test_backup_restore_s3/test.py
+++ b/tests/integration/test_backup_restore_s3/test.py
@@ -1006,6 +1006,9 @@ def test_backup_restore_system_tables_with_plain_rewritable_disk(cluster):
     backup_name = new_backup_name()
     backup_destination = f"S3('http://minio1:9001/root/data/backups/{backup_name}', 'minio', '{minio_secret_key}')"
 
+    # Truncate query_log to limit data size, avoiding timeouts under sanitizers
+    instance.query("TRUNCATE TABLE IF EXISTS system.query_log")
+    instance.query("SELECT 1")
     instance.query("SYSTEM FLUSH LOGS")
 
     backup_query_id = uuid.uuid4().hex


### PR DESCRIPTION
The test was timing out under TSAN because `system.query_log` accumulated large amounts of data during CI runs. Truncate the table before the test to ensure a controlled dataset size, and run a query to ensure the backup contains actual data.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

See https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=635d211f164a9c8496bfd3dc1c31485a77fdfd99&name_0=MasterCI&name_1=Integration%20tests%20%28amd_tsan%2C%202%2F6%29&name_1=Integration%20tests%20%28amd_tsan%2C%202%2F6%29


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.863`
<!-- ch-version-info:end -->