### PR TITLE
Fix flaky test `test_refreshable_mv_in_system_db`

### DIFF
--- a/tests/integration/test_refreshable_mv/test.py
+++ b/tests/integration/test_refreshable_mv/test.py
@@ -240,6 +240,7 @@ def test_refreshable_mv_in_system_db(started_cluster, cleanup):
 
     node1.restart_clickhouse()
     node1.query("system refresh view system.a")
+    node1.query("system wait view system.a")
     assert node1.query("select count(), sum(x) from system.a") == "2\t3\n"
 
 


### PR DESCRIPTION
The test was flaky because it queried the table immediately after `SYSTEM REFRESH VIEW` without waiting for the refresh to complete. Added `SYSTEM WAIT VIEW` to ensure the refresh finishes before asserting.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

See https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=f342285fa8c9072b5cec996b3c7ab0c3a92e6ac1&name_0=MasterCI&name_1=Integration%20tests%20%28amd_asan%2C%20db%20disk%2C%20old%20analyzer%2C%206%2F6%29&name_1=Integration%20tests%20%28amd_asan%2C%20db%20disk%2C%20old%20analyzer%2C%206%2F6%29


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.857`
<!-- ch-version-info:end -->