### PR TITLE
Fix S3Queue server restart failure with regex partitioning, leading to batch failures of integration tests

### DIFF
--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
@@ -11,6 +11,7 @@
 #include <Storages/ObjectStorageQueue/ObjectStorageQueueOrderedFileMetadata.h>
 #include <Storages/ObjectStorageQueue/ObjectStorageQueueUnorderedFileMetadata.h>
 #include <Storages/ObjectStorageQueue/ObjectStorageQueueTableMetadata.h>
+#include <Storages/ObjectStorageQueue/ObjectStorageQueueFilenameParser.h>
 #include <Storages/StorageSnapshot.h>
 #include <base/sleep.h>
 #include <Common/CurrentThread.h>
@@ -570,6 +571,17 @@ ObjectStorageQueueTableMetadata ObjectStorageQueueMetadata::syncWithKeeper(
             if (!table_metadata.last_processed_path.empty())
             {
                 std::atomic<size_t> noop = 0;
+
+                /// Create parser for regex partitioning mode.
+                /// Parser is needed to correctly compute partition keys and bucket assignments.
+                std::unique_ptr<ObjectStorageQueueFilenameParser> parser;
+                if (table_metadata.getPartitioningMode() == ObjectStorageQueuePartitioningMode::REGEX)
+                {
+                    parser = std::make_unique<ObjectStorageQueueFilenameParser>(
+                        table_metadata.partition_regex,
+                        table_metadata.partition_component);
+                }
+
                 ObjectStorageQueueOrderedFileMetadata(
                     zookeeper_path,
                     table_metadata.last_processed_path,
@@ -581,7 +593,7 @@ ObjectStorageQueueTableMetadata ObjectStorageQueueMetadata::syncWithKeeper(
                     /* use_persistent_processing_nodes */false, /// Processing nodes will not be created.
                     table_metadata.getBucketingMode(),
                     table_metadata.getPartitioningMode(),
-                    /* parser */nullptr,  /// Parser not needed for ZK metadata initialization
+                    parser.get(),
                     log).prepareProcessedAtStartRequests(requests);
             }
 


### PR DESCRIPTION
In `ObjectStorageQueueMetadata::syncWithKeeper`, when creating `ObjectStorageQueueOrderedFileMetadata` for ZK metadata initialization, `nullptr` was passed for the `parser` parameter. However, when `partitioning_mode == REGEX`, the parser is needed to:

1. Compute the correct partition key via `getPartitionKey`
2. Determine the correct bucket assignment when `bucketing_mode == PARTITION`

Without the parser, `getPartitionKey` returns an empty string for REGEX mode, causing:
- All files to hash to the same bucket (since `sipHash64("")` is constant)
- Incorrect ZooKeeper paths for partition-based processing nodes
- Server startup failure when metadata reconstruction goes wrong

The fix creates a temporary `ObjectStorageQueueFilenameParser` when `partitioning_mode == REGEX` using the `partition_regex` and `partition_component` from `table_metadata`.

Why the test failure was sporadic:

1. `last_processed_path` must be non-empty - the buggy code path only executes after files have been processed. If the server restarts before any files are processed, the bug doesn't trigger.

2. Random test settings - `use_persistent_processing_nodes` is randomly set to true/false, affecting metadata management and code paths.

3. The partition key is used in ZooKeeper path construction. When `parser == nullptr` returns empty string, it creates paths like `/processed/` instead of `/processed/server-1`. Whether this causes a failure depends on what already exists in ZooKeeper.

4. TSAN-specific timing - Thread Sanitizer significantly slows execution, making timeouts during server startup more likely and exposing race conditions that might not manifest in normal builds.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

See https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=95067&sha=68fca962cb94ef9df1e4cda63ad4d6bdfdb2ec55&name_0=PR&name_1=Integration%20tests%20%28amd_tsan%2C%205%2F6%29
https://github.com/ClickHouse/ClickHouse/pull/95067


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.870`
<!-- ch-version-info:end -->