### PR TITLE
Fix flaky `test_simple_alter_table` for `Replicated` databases by adding explicit replica synchronization

### DIFF
--- a/tests/integration/test_replicated_database/test.py
+++ b/tests/integration/test_replicated_database/test.py
@@ -284,6 +284,13 @@ def test_simple_alter_table(started_cluster, engine):
         "SETTINGS index_granularity = 8192".format(name, full_engine)
     )
 
+    # Ensure all replicas are synchronized before asserting schema equality
+    dummy_node.query(f"SYSTEM SYNC DATABASE REPLICA {database}")
+    competing_node.query(f"SYSTEM SYNC DATABASE REPLICA {database}")
+    if "Replicated" in engine:
+        dummy_node.query(f"SYSTEM SYNC REPLICA {name}")
+        competing_node.query(f"SYSTEM SYNC REPLICA {name}")
+
     assert_create_query([main_node, dummy_node, competing_node], name, expected)
     main_node.query(f"DROP DATABASE {database} SYNC")
     dummy_node.query(f"DROP DATABASE {database} SYNC")


### PR DESCRIPTION
The test creates a new replica that joins an existing Replicated database, then performs ALTER operations. The new replica must catch up on all DDL operations, but the default 10-second retry timeout was sometimes insufficient.

Added `SYSTEM SYNC DATABASE REPLICA` and `SYSTEM SYNC REPLICA` calls before asserting schema equality, following the pattern used in other tests in this file.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

See https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=37f13730553a28b303b22da3a29a4367e8a7aa4c&name_0=MasterCI&name_1=Integration%20tests%20%28amd_asan%2C%20db%20disk%2C%20old%20analyzer%2C%202%2F6%29&name_1=Integration%20tests%20%28amd_asan%2C%20db%20disk%2C%20old%20analyzer%2C%202%2F6%29


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.864`
<!-- ch-version-info:end -->