### PR TITLE
Fix flaky `test_scheduler_cpu_preemptive::test_independent_pools`

### DIFF
--- a/src/Common/Scheduler/CPULeaseAllocation.h
+++ b/src/Common/Scheduler/CPULeaseAllocation.h
@@ -181,7 +181,9 @@ private:
     size_t upscale();
 
     /// Unregisters specified thread from leased set
-    void downscale(size_t thread_num);
+    /// If shutdown is true, ConcurrencyControlDownscales profile event is not incremented
+    /// (shutdown-induced termination is normal, not resource contention)
+    void downscale(size_t thread_num, bool shutdown = false);
 
     /// Preempted thread set management
     void setPreempted(size_t thread_num);


### PR DESCRIPTION
The test expects zero `ConcurrencyControlDownscales` when using a 60-second preemption timeout, but a race condition during query shutdown could cause a downscale to be counted even when it wasn't due to resource contention.

The race condition occurs when:
1. A thread gets preempted and waits in `waitForGrant`
2. The query finishes, `free` is called, which sets `shutdown = true` and calls `resetPreempted` to wake preempted threads
3. The thread wakes up, `waitForGrant` returns true (successfully resumed)
4. But the check `if (!waitForGrant(...) || shutdown)` still triggers because `shutdown` is true
5. `downscale` is called, incrementing `ConcurrencyControlDownscales`

This is incorrect because:
- A "downscale" should represent resource contention (thread timed out waiting for a CPU slot)
- Shutdown-induced termination is normal query completion, not resource contention

The fix adds a `shutdown` parameter to the `downscale` function:
- `shutdown = false` (default): increment `ConcurrencyControlDownscales` (actual resource contention / timeout)
- `shutdown = true`: don't increment the profile event (normal termination)

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

See https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=871e8d512459101998cd5620d65562e033ac147d&name_0=MasterCI&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%204%2F4%29&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%204%2F4%29


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.866`
<!-- ch-version-info:end -->