### PR TITLE
Fix flaky test `03644_explain_indices`

### DIFF
--- a/tests/queries/0_stateless/03644_explain_indices.sql
+++ b/tests/queries/0_stateless/03644_explain_indices.sql
@@ -10,7 +10,7 @@ CREATE TABLE test_indexed
     id UInt32,
     value String
 ) ENGINE = MergeTree()
-ORDER BY id SETTINGS add_minmax_index_for_numeric_columns=0;
+ORDER BY id SETTINGS add_minmax_index_for_numeric_columns=0, index_granularity=8192;
 
 INSERT INTO test_indexed VALUES (1,'a'),(5,'b'),(10,'c'),(15,'d'),(20,'e');
 


### PR DESCRIPTION
The test was flaky because CI runs with randomized MergeTree settings including `index_granularity=1`, which caused 5 rows to be stored in 5 granules instead of 1. Explicitly set `index_granularity=8192` to ensure consistent behavior.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

See https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=f19e93bd41cac3b4c1b62c486a23ed2690f14438&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_tsan%2C%20parallel%2C%201%2F2%29&name_1=Stateless%20tests%20%28amd_tsan%2C%20parallel%2C%201%2F2%29


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.869`
<!-- ch-version-info:end -->