### PR TITLE
unflake 02842_mutations_replace_non_deterministic

### DIFF
--- a/tests/queries/0_stateless/02842_mutations_replace_non_deterministic.sql
+++ b/tests/queries/0_stateless/02842_mutations_replace_non_deterministic.sql
@@ -107,10 +107,12 @@ UPDATE v =
 (
     SELECT sum(number) FROM numbers(1000) WHERE number > randConstant()
 ) WHERE 1
-SETTINGS mutations_execute_subqueries_on_initiator = 0, allow_nondeterministic_mutations = 1;
+SETTINGS mutations_execute_subqueries_on_initiator = 0, allow_nondeterministic_mutations = 1, mutations_sync = 0;
 
+-- Just verify the command was stored correctly. Don't require completion to avoid query context expiration issues when
+-- subqueries execute on replicas on CI leading to flakiness.
 SELECT command FROM system.mutations
-WHERE database = currentDatabase() AND table = 't_mutations_nondeterministic' AND is_done
+WHERE database = currentDatabase() AND table = 't_mutations_nondeterministic'
 ORDER BY command;
 
 DROP TABLE t_mutations_nondeterministic SYNC;


### PR DESCRIPTION
The test `02842_mutations_replace_non_deterministic` was introduced in https://github.com/ClickHouse/ClickHouse/pull/53129. It looks like most of the flakyness from [cidb](https://play.clickhouse.com/play?user=play&run=1#V0lUSAogICAgOTAgQVMgaW50ZXJ2YWxfZGF5cwpTRUxFQ1QKICAgIHRvU3RhcnRPZkRheShjaGVja19zdGFydF90aW1lKSBBUyBkYXksCiAgICBjb3VudCgpIEFTIGZhaWx1cmVzLAogICAgZ3JvdXBVbmlxQXJyYXkocHVsbF9yZXF1ZXN0X251bWJlcikgQVMgcHJzLAogICAgYW55KHJlcG9ydF91cmwpIEFTIHJlcG9ydF91cmwKRlJPTSBjaGVja3MKV0hFUkUgKG5vdygpIC0gdG9JbnRlcnZhbERheShpbnRlcnZhbF9kYXlzKSkgPD0gY2hlY2tfc3RhcnRfdGltZQogICAgQU5EIHRlc3RfbmFtZSA9ICcwMjg0Ml9tdXRhdGlvbnNfcmVwbGFjZV9ub25fZGV0ZXJtaW5pc3RpYycKICAgIC0tIEFORCBjaGVja19uYW1lID0gJ1N0YXRlbGVzcyB0ZXN0cyAoYXJtX2FzYW4sIHRhcmdldGVkKScKICAgIEFORCB0ZXN0X3N0YXR1cyBJTiAoJ0ZBSUwnLCAnRVJST1InKQogICAgQU5EIChwdWxsX3JlcXVlc3RfbnVtYmVyID0gMCBPUiBiYXNlX3JlZiBJTiAoJ21hc3RlcicpKQogICAgQU5EIHRlc3RfY29udGV4dF9yYXcgTElLRSAnJXJldHVybiBjb2RlJScKR1JPVVAgQlkgZGF5Ck9SREVSIEJZIGRheSBERVNDCg==) is from query timeout while waiting for execution (the mutation would try to execute the subquery,  but the initiator's query context would expire). Just verify the main function of the test i.e. subqueries aren't replaced when `mutations_execute_subqueries_on_initiator = 0` but skip waiting for the mutation to complete.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
