### PR TITLE
Fix flaky test `02844_max_backup_bandwidth_s3`

### DIFF
--- a/tests/queries/0_stateless/02844_max_backup_bandwidth_s3.reference
+++ b/tests/queries/0_stateless/02844_max_backup_bandwidth_s3.reference
@@ -1,2 +1,1 @@
-native_copy	0
-no_native_copy	1
+1

--- a/tests/queries/0_stateless/02844_max_backup_bandwidth_s3.sh
+++ b/tests/queries/0_stateless/02844_max_backup_bandwidth_s3.sh
@@ -14,28 +14,29 @@ client_opts=(
 $CLICKHOUSE_CLIENT "${client_opts[@]}" -m -q "
     drop table if exists data;
     create table data (key UInt64 CODEC(NONE)) engine=MergeTree() order by tuple() settings min_bytes_for_wide_part=1e9, disk='s3_disk';
-    -- reading 1e6*8 bytes with 1M bandwith it should take (8-1)/1=7 seconds
-    insert into data select * from numbers(1e6);
+    -- 2e6*8 bytes = 16MB, with 1MB/s bandwidth it should take ~16 seconds for non-native copy
+    insert into data select * from numbers(2e6);
 "
 
-query_id=$(random_str 10)
-$CLICKHOUSE_CLIENT "${client_opts[@]}" --query_id "$query_id" -q "backup table data to S3(s3_conn, 'backups/$CLICKHOUSE_DATABASE/data/backup2') SETTINGS allow_s3_native_copy=1" --max_backup_bandwidth=1M > /dev/null
+query_id_native=$(random_str 10)
+$CLICKHOUSE_CLIENT "${client_opts[@]}" --query_id "$query_id_native" -q "backup table data to S3(s3_conn, 'backups/$CLICKHOUSE_DATABASE/data/backup2') SETTINGS allow_s3_native_copy=1" --max_backup_bandwidth=1M > /dev/null
+
+query_id_no_native=$(random_str 10)
+$CLICKHOUSE_CLIENT "${client_opts[@]}" --query_id "$query_id_no_native" -q "backup table data to S3(s3_conn, 'backups/$CLICKHOUSE_DATABASE/data/backup3') SETTINGS allow_s3_native_copy=0" --max_backup_bandwidth=1M > /dev/null
+
+# Check that non-native copy with bandwidth limiting takes significantly longer than native copy.
+# Native copy uses S3 server-side copy which bypasses client bandwidth limiting.
+# We check that non-native copy is at least 10 seconds longer than native copy,
+# which verifies that bandwidth limiting is being applied.
 $CLICKHOUSE_CLIENT "${client_opts[@]}" -m -q "
     SYSTEM FLUSH LOGS query_log;
     SELECT
-        'native_copy',
-        query_duration_ms >= 7e3
-    FROM system.query_log
-    WHERE current_database = '$CLICKHOUSE_DATABASE' AND query_id = '$query_id' AND type != 'QueryStart'
-"
-
-query_id=$(random_str 10)
-$CLICKHOUSE_CLIENT "${client_opts[@]}" --query_id "$query_id" -q "backup table data to S3(s3_conn, 'backups/$CLICKHOUSE_DATABASE/data/backup3') SETTINGS allow_s3_native_copy=0" --max_backup_bandwidth=1M > /dev/null
-$CLICKHOUSE_CLIENT "${client_opts[@]}" -m -q "
-    SYSTEM FLUSH LOGS query_log;
-    SELECT
-        'no_native_copy',
-        query_duration_ms >= 7e3
-    FROM system.query_log
-    WHERE current_database = '$CLICKHOUSE_DATABASE' AND query_id = '$query_id' AND type != 'QueryStart'
+        (no_native_duration_ms - native_duration_ms) >= 10000 AS bandwidth_limiting_works
+    FROM (
+        SELECT
+            (SELECT query_duration_ms FROM system.query_log
+             WHERE current_database = '$CLICKHOUSE_DATABASE' AND query_id = '$query_id_native' AND type != 'QueryStart') AS native_duration_ms,
+            (SELECT query_duration_ms FROM system.query_log
+             WHERE current_database = '$CLICKHOUSE_DATABASE' AND query_id = '$query_id_no_native' AND type != 'QueryStart') AS no_native_duration_ms
+    )
 "


### PR DESCRIPTION
The test was flaky because it used absolute timing thresholds (>= 7 seconds) which are unreliable due to variable S3 latency and system performance.

The fix changes to a relative timing comparison:
- Run both backup operations (with and without native copy)
- Compare their durations instead of checking absolute times
- Verify that non-native copy takes at least 10 seconds longer than native copy

This ensures the test validates that bandwidth limiting works (applied only to non-native copy) without being affected by S3 latency variations.

Also increased data size from 8MB to 16MB for more pronounced timing differences.

Closes #85084

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

See https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=95118&sha=ab1adaa5d88f38a4934fac9fc8ffb91e97ef5a6f&name_0=PR&name_1=Stateless%20tests%20%28arm_binary%2C%20parallel%29
https://github.com/ClickHouse/ClickHouse/pull/95118

Note: if it continues, we will remove the timing check from the test entirely.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.881`
<!-- ch-version-info:end -->