### PR TITLE
CI: Add hook to validate backport content

### DIFF
--- a/ci/jobs/scripts/workflow_hooks/check_backport_branch.py
+++ b/ci/jobs/scripts/workflow_hooks/check_backport_branch.py
@@ -1,0 +1,29 @@
+import sys
+from ci.praktika.info import Info
+from ci.praktika.utils import Shell
+
+
+if __name__ == "__main__":
+    info = Info()
+    if info.workflow_name == "BackportPR":
+        num_commits = int(
+            Shell.get_output_or_raise(
+                f"git rev-list --count {info.base_branch}..{info.sha}"
+            )
+        )
+        if num_commits == 0:
+            print(f"ERROR: No commits found between {info.base_branch} and {info.sha}")
+            sys.exit(-1)
+
+        if num_commits > 50:
+            print(
+                f"ERROR: Number of commits between {info.sha} and {info.base_branch} is {num_commits}. "
+                f"Backport PR should have between 1 and 50 commits."
+            )
+            sys.exit(-1)
+
+        if Shell.check(f"git diff --quiet {info.base_branch}...{info.sha}"):
+            print(f"ERROR: Diff is empty between {info.base_branch} and {info.sha}")
+            sys.exit(-1)
+    else:
+        assert False, f"Unsupported workflow name [{info.workflow_name}]"

--- a/ci/jobs/scripts/workflow_hooks/check_backport_branch.py
+++ b/ci/jobs/scripts/workflow_hooks/check_backport_branch.py
@@ -10,12 +10,12 @@ if __name__ == "__main__":
         # Ensure base branch is fetched.
         # We use treeless fetch (--filter=tree:0) and no-tags to minimize data transfer.
         Shell.run(
-            f"git fetch --no-tags --prune --no-recurse-submodules --filter=tree:0 origin {info.base_branch}",
+            f"git fetch --no-tags --prune --no-recurse-submodules --filter=tree:0 origin +{info.base_branch}:{info.base_branch}",
             verbose=True,
         )
         num_commits = int(
             Shell.get_output_or_raise(
-                f"git rev-list --count origin/{info.base_branch}..{info.sha}"
+                f"git rev-list --count {info.base_branch}..{info.sha}"
             )
         )
         if num_commits == 0:
@@ -29,8 +29,8 @@ if __name__ == "__main__":
             )
             sys.exit(-1)
 
-        if Shell.check(f"git diff --quiet origin/{info.base_branch}...{info.sha}"):
-            print(f"ERROR: Diff is empty between {info.base_branch} and {info.sha}")
+        if not info.get_changed_files():
+            print(f"ERROR: No Files changed in the Backport PR.")
             sys.exit(-1)
     else:
         assert False, f"Unsupported workflow name [{info.workflow_name}]"

--- a/ci/jobs/scripts/workflow_hooks/check_backport_branch.py
+++ b/ci/jobs/scripts/workflow_hooks/check_backport_branch.py
@@ -6,9 +6,16 @@ from ci.praktika.utils import Shell
 if __name__ == "__main__":
     info = Info()
     if info.workflow_name == "BackportPR":
+        assert info.base_branch
+        # Ensure base branch is fetched.
+        # We use treeless fetch (--filter=tree:0) and no-tags to minimize data transfer.
+        Shell.run(
+            f"git fetch --no-tags --prune --no-recurse-submodules --filter=tree:0 origin {info.base_branch}",
+            verbose=True,
+        )
         num_commits = int(
             Shell.get_output_or_raise(
-                f"git rev-list --count {info.base_branch}..{info.sha}"
+                f"git rev-list --count origin/{info.base_branch}..{info.sha}"
             )
         )
         if num_commits == 0:
@@ -22,7 +29,7 @@ if __name__ == "__main__":
             )
             sys.exit(-1)
 
-        if Shell.check(f"git diff --quiet {info.base_branch}...{info.sha}"):
+        if Shell.check(f"git diff --quiet origin/{info.base_branch}...{info.sha}"):
             print(f"ERROR: Diff is empty between {info.base_branch} and {info.sha}")
             sys.exit(-1)
     else:

--- a/ci/workflows/backport_branches.py
+++ b/ci/workflows/backport_branches.py
@@ -56,6 +56,7 @@ workflow = Workflow.Config(
     pre_hooks=[
         "python3 ./ci/jobs/scripts/workflow_hooks/store_data.py",
         "python3 ./ci/jobs/scripts/workflow_hooks/version_log.py",
+        "python3 ./ci/jobs/scripts/workflow_hooks/check_backport_branch.py",
     ],
     workflow_filter_hooks=[should_skip_job],
     post_hooks=[],


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

---
For backport CI check:
1. too many commits (>50) - fail immediately
2. 0 changes - fail immediately