### PR TITLE
doc(bin): add `QBit` datatype in `bin` function doc

### DIFF
--- a/src/Functions/FunctionsBinaryRepresentation.cpp
+++ b/src/Functions/FunctionsBinaryRepresentation.cpp
@@ -820,9 +820,10 @@ to the following logic for different types:
 | `String` and `FixedString` | All bytes are simply encoded as eight binary numbers. Zero bytes are not omitted.                                                                                                                                                                                     |
 | `Float*` and `Decimal`     | Encoded as their representation in memory. As we support little-endian architecture, they are encoded in little-endian. Zero leading/trailing bytes are not omitted.                                                                                                  |
 | `UUID`                     | Encoded as big-endian order string.                                                                                                                                                                                                                                   |
+| `QBit`                     | Individual bit planes are accessed via subcolumns (e.g., bin(`vec.1`), bin(`vec.2`)). Each subcolumn is a FixedString and is encoded as eight binary numbers per byte. Zero bytes are not omitted.                                                                             |
     )";
     FunctionDocumentation::Syntax bin_syntax = "bin(arg)";
-    FunctionDocumentation::Arguments bin_arguments = {{"arg", "A value to convert to binary.", {"String", "FixedString", "(U)Int*", "Float*", "Decimal", "Date", "DateTime"}}};
+    FunctionDocumentation::Arguments bin_arguments = {{"arg", "A value to convert to binary.", {"String", "FixedString", "(U)Int*", "Float*", "Decimal", "Date", "DateTime", "QBit"}}};
     FunctionDocumentation::ReturnedValue bin_returned_value = {"Returns a string with the binary representation of the argument.", {"String"}};
     FunctionDocumentation::Examples bin_examples =
     {


### PR DESCRIPTION
With experimental support to QBit type, we can use `bin` helper to access the QBit's subcolumns

This is even explained in QBit doc.
https://clickhouse.com/docs/sql-reference/data-types/qbit#qbit-subcolumns

but it is missed in `bin` function doc. This PR addresses it

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
