### PR TITLE
Fix qualified column resolution for multiple JOINs with USING

### DIFF
--- a/src/Analyzer/Resolve/IdentifierResolver.cpp
+++ b/src/Analyzer/Resolve/IdentifierResolver.cpp
@@ -912,12 +912,6 @@ QueryTreeNodePtr createProjectionForUsing(const ColumnNode & using_column_node, 
             arguments[i] = converted_argument;
     }
 
-    if (join_kind == JoinKind::Right)
-        return arguments.back();
-
-    if (join_kind != JoinKind::Full)
-        arguments.pop_back();
-
     if (arguments.size() == 1)
         return arguments.front();
 

--- a/tests/queries/0_stateless/02374_analyzer_join_using.reference
+++ b/tests/queries/0_stateless/02374_analyzer_join_using.reference
@@ -102,12 +102,12 @@ SELECT t1.value AS t1_value, toTypeName(t1_value), t2.value AS t2_value, toTypeN
 FROM test_table_join_1 AS t1 FULL JOIN test_table_join_2 AS t2 USING (test_value); -- { serverError UNKNOWN_IDENTIFIER }
 SELECT 'First JOIN INNER second JOIN INNER';
 First JOIN INNER second JOIN INNER
-SELECT id AS using_id, toTypeName(using_id), t1.id AS t1_id, toTypeName(t1_id), t1.value AS t1_value, toTypeName(t1_value),
-t2.id AS t2_id, toTypeName(t2_id), t2.value AS t2_value, toTypeName(t2_value), t3.id AS t3_id, toTypeName(t3_id), t3.value AS t3_value, toTypeName(t3_value)
+SELECT id AS using_id, toTypeName(using_id), t1.id + 1 AS t1_id, toTypeName(t1_id), t1.value AS t1_value, toTypeName(t1_value),
+t2.id + 1 AS t2_id, toTypeName(t2_id), t2.value AS t2_value, toTypeName(t2_value), t3.id + 1 AS t3_id, toTypeName(t3_id), t3.value AS t3_value, toTypeName(t3_value)
 FROM test_table_join_1 AS t1 INNER JOIN test_table_join_2 AS t2 USING (id) INNER JOIN test_table_join_3 AS t3 USING(id)
 ORDER BY ALL;
-0	UInt64	0	UInt64	Join_1_Value_0	String	0	UInt64	Join_2_Value_0	String	0	UInt64	Join_3_Value_0	String
-1	UInt64	1	UInt64	Join_1_Value_1	String	1	UInt64	Join_2_Value_1	String	1	UInt64	Join_3_Value_1	String
+0	UInt64	1	UInt64	Join_1_Value_0	String	1	UInt32	Join_2_Value_0	String	1	UInt64	Join_3_Value_0	String
+1	UInt64	2	UInt64	Join_1_Value_1	String	2	UInt32	Join_2_Value_1	String	2	UInt64	Join_3_Value_1	String
 SELECT '--';
 --
 SELECT t1.value AS t1_value, toTypeName(t1_value), t2.value AS t2_value, toTypeName(t2_value), t3.value AS t3_value, toTypeName(t3_value)
@@ -123,12 +123,12 @@ SELECT 1 FROM test_table_join_1 AS t1 INNER JOIN test_table_join_2 AS t2 USING (
 SELECT id FROM test_table_join_1 AS t1 INNER JOIN test_table_join_2 AS t2 ON t1.id = t2.id INNER JOIN test_table_join_3 AS t3 USING (id); -- { serverError AMBIGUOUS_IDENTIFIER }
 SELECT 'First JOIN INNER second JOIN LEFT';
 First JOIN INNER second JOIN LEFT
-SELECT id AS using_id, toTypeName(using_id), t1.id AS t1_id, toTypeName(t1_id), t1.value AS t1_value, toTypeName(t1_value),
-t2.id AS t2_id, toTypeName(t2_id), t2.value AS t2_value, toTypeName(t2_value), t3.id AS t3_id, toTypeName(t3_id), t3.value AS t3_value, toTypeName(t3_value)
+SELECT id AS using_id, toTypeName(using_id), t1.id + 1 AS t1_id, toTypeName(t1_id), t1.value AS t1_value, toTypeName(t1_value),
+t2.id + 1 AS t2_id, toTypeName(t2_id), t2.value AS t2_value, toTypeName(t2_value), t3.id + 1 AS t3_id, toTypeName(t3_id), t3.value AS t3_value, toTypeName(t3_value)
 FROM test_table_join_1 AS t1 INNER JOIN test_table_join_2 AS t2 USING (id) LEFT JOIN test_table_join_3 AS t3 USING(id)
 ORDER BY ALL;
-0	UInt64	0	UInt64	Join_1_Value_0	String	0	UInt64	Join_2_Value_0	String	0	UInt64	Join_3_Value_0	String
-1	UInt64	1	UInt64	Join_1_Value_1	String	1	UInt64	Join_2_Value_1	String	1	UInt64	Join_3_Value_1	String
+0	UInt64	1	UInt64	Join_1_Value_0	String	1	UInt32	Join_2_Value_0	String	1	UInt64	Join_3_Value_0	String
+1	UInt64	2	UInt64	Join_1_Value_1	String	2	UInt32	Join_2_Value_1	String	2	UInt64	Join_3_Value_1	String
 SELECT '--';
 --
 SELECT t1.value AS t1_value, toTypeName(t1_value), t2.value AS t2_value, toTypeName(t2_value), t3.value AS t3_value, toTypeName(t3_value)
@@ -144,13 +144,13 @@ SELECT 1 FROM test_table_join_1 AS t1 INNER JOIN test_table_join_2 AS t2 USING (
 SELECT id FROM test_table_join_1 AS t1 INNER JOIN test_table_join_2 AS t2 ON t1.id = t2.id LEFT JOIN test_table_join_3 AS t3 USING (id); -- { serverError AMBIGUOUS_IDENTIFIER }
 SELECT 'First JOIN INNER second JOIN RIGHT';
 First JOIN INNER second JOIN RIGHT
-SELECT id AS using_id, toTypeName(using_id), t1.id AS t1_id, toTypeName(t1_id), t1.value AS t1_value, toTypeName(t1_value),
-t2.id AS t2_id, toTypeName(t2_id), t2.value AS t2_value, toTypeName(t2_value), t3.id AS t3_id, toTypeName(t3_id), t3.value AS t3_value, toTypeName(t3_value)
+SELECT id AS using_id, toTypeName(using_id), t1.id + 1 AS t1_id, toTypeName(t1_id), t1.value AS t1_value, toTypeName(t1_value),
+t2.id + 1 AS t2_id, toTypeName(t2_id), t2.value AS t2_value, toTypeName(t2_value), t3.id + 1 AS t3_id, toTypeName(t3_id), t3.value AS t3_value, toTypeName(t3_value)
 FROM test_table_join_1 AS t1 INNER JOIN test_table_join_2 AS t2 USING (id) RIGHT JOIN test_table_join_3 AS t3 USING(id)
 ORDER BY ALL;
-0	UInt64	0	UInt64	Join_1_Value_0	String	0	UInt64	Join_2_Value_0	String	0	UInt64	Join_3_Value_0	String
-1	UInt64	1	UInt64	Join_1_Value_1	String	1	UInt64	Join_2_Value_1	String	1	UInt64	Join_3_Value_1	String
-4	UInt64	0	UInt64		String	0	UInt64		String	4	UInt64	Join_3_Value_4	String
+0	UInt64	1	UInt64	Join_1_Value_0	String	1	UInt32	Join_2_Value_0	String	1	UInt64	Join_3_Value_0	String
+1	UInt64	2	UInt64	Join_1_Value_1	String	2	UInt32	Join_2_Value_1	String	2	UInt64	Join_3_Value_1	String
+4	UInt64	1	UInt64		String	1	UInt32		String	5	UInt64	Join_3_Value_4	String
 SELECT '--';
 --
 SELECT t1.value AS t1_value, toTypeName(t1_value), t2.value AS t2_value, toTypeName(t2_value), t3.value AS t3_value, toTypeName(t3_value)
@@ -168,13 +168,13 @@ SELECT 1 FROM test_table_join_1 AS t1 INNER JOIN test_table_join_2 AS t2 USING (
 SELECT id FROM test_table_join_1 AS t1 INNER JOIN test_table_join_2 AS t2 ON t1.id = t2.id RIGHT JOIN test_table_join_3 AS t3 USING (id); -- { serverError AMBIGUOUS_IDENTIFIER }
 SELECT 'First JOIN INNER second JOIN FULL';
 First JOIN INNER second JOIN FULL
-SELECT id AS using_id, toTypeName(using_id), t1.id AS t1_id, toTypeName(t1_id), t1.value AS t1_value, toTypeName(t1_value),
-t2.id AS t2_id, toTypeName(t2_id), t2.value AS t2_value, toTypeName(t2_value), t3.id AS t3_id, toTypeName(t3_id), t3.value AS t3_value, toTypeName(t3_value)
+SELECT id AS using_id, toTypeName(using_id), t1.id + 1 AS t1_id, toTypeName(t1_id), t1.value AS t1_value, toTypeName(t1_value),
+t2.id + 1 AS t2_id, toTypeName(t2_id), t2.value AS t2_value, toTypeName(t2_value), t3.id + 1 AS t3_id, toTypeName(t3_id), t3.value AS t3_value, toTypeName(t3_value)
 FROM test_table_join_1 AS t1 INNER JOIN test_table_join_2 AS t2 USING (id) FULL JOIN test_table_join_3 AS t3 USING(id)
 ORDER BY ALL;
-0	UInt64	0	UInt64	Join_1_Value_0	String	0	UInt64	Join_2_Value_0	String	0	UInt64	Join_3_Value_0	String
-1	UInt64	1	UInt64	Join_1_Value_1	String	1	UInt64	Join_2_Value_1	String	1	UInt64	Join_3_Value_1	String
-4	UInt64	0	UInt64		String	0	UInt64		String	4	UInt64	Join_3_Value_4	String
+0	UInt64	1	UInt64	Join_1_Value_0	String	1	UInt32	Join_2_Value_0	String	1	UInt64	Join_3_Value_0	String
+1	UInt64	2	UInt64	Join_1_Value_1	String	2	UInt32	Join_2_Value_1	String	2	UInt64	Join_3_Value_1	String
+4	UInt64	1	UInt64		String	1	UInt32		String	5	UInt64	Join_3_Value_4	String
 SELECT '--';
 --
 SELECT t1.value AS t1_value, toTypeName(t1_value), t2.value AS t2_value, toTypeName(t2_value), t3.value AS t3_value, toTypeName(t3_value)
@@ -192,12 +192,12 @@ SELECT 1 FROM test_table_join_1 AS t1 INNER JOIN test_table_join_2 AS t2 USING (
 SELECT id FROM test_table_join_1 AS t1 INNER JOIN test_table_join_2 AS t2 ON t1.id = t2.id FULL JOIN test_table_join_3 AS t3 USING (id); -- { serverError AMBIGUOUS_IDENTIFIER }
 SELECT 'First JOIN LEFT second JOIN INNER';
 First JOIN LEFT second JOIN INNER
-SELECT id AS using_id, toTypeName(using_id), t1.id AS t1_id, toTypeName(t1_id), t1.value AS t1_value, toTypeName(t1_value),
-t2.id AS t2_id, toTypeName(t2_id), t2.value AS t2_value, toTypeName(t2_value), t3.id AS t3_id, toTypeName(t3_id), t3.value AS t3_value, toTypeName(t3_value)
+SELECT id AS using_id, toTypeName(using_id), t1.id + 1 AS t1_id, toTypeName(t1_id), t1.value AS t1_value, toTypeName(t1_value),
+t2.id + 1 AS t2_id, toTypeName(t2_id), t2.value AS t2_value, toTypeName(t2_value), t3.id + 1 AS t3_id, toTypeName(t3_id), t3.value AS t3_value, toTypeName(t3_value)
 FROM test_table_join_1 AS t1 LEFT JOIN test_table_join_2 AS t2 USING (id) INNER JOIN test_table_join_3 AS t3 USING(id)
 ORDER BY ALL;
-0	UInt64	0	UInt64	Join_1_Value_0	String	0	UInt64	Join_2_Value_0	String	0	UInt64	Join_3_Value_0	String
-1	UInt64	1	UInt64	Join_1_Value_1	String	1	UInt64	Join_2_Value_1	String	1	UInt64	Join_3_Value_1	String
+0	UInt64	1	UInt64	Join_1_Value_0	String	1	UInt32	Join_2_Value_0	String	1	UInt64	Join_3_Value_0	String
+1	UInt64	2	UInt64	Join_1_Value_1	String	2	UInt32	Join_2_Value_1	String	2	UInt64	Join_3_Value_1	String
 SELECT '--';
 --
 SELECT t1.value AS t1_value, toTypeName(t1_value), t2.value AS t2_value, toTypeName(t2_value), t3.value AS t3_value, toTypeName(t3_value)
@@ -213,13 +213,13 @@ SELECT 1 FROM test_table_join_1 AS t1 LEFT JOIN test_table_join_2 AS t2 USING (i
 SELECT id FROM test_table_join_1 AS t1 LEFT JOIN test_table_join_2 AS t2 ON t1.id = t2.id INNER JOIN test_table_join_3 AS t3 USING (id); -- { serverError AMBIGUOUS_IDENTIFIER }
 SELECT 'First JOIN LEFT second JOIN LEFT';
 First JOIN LEFT second JOIN LEFT
-SELECT id AS using_id, toTypeName(using_id), t1.id AS t1_id, toTypeName(t1_id), t1.value AS t1_value, toTypeName(t1_value),
-t2.id AS t2_id, toTypeName(t2_id), t2.value AS t2_value, toTypeName(t2_value), t3.id AS t3_id, toTypeName(t3_id), t3.value AS t3_value, toTypeName(t3_value)
+SELECT id AS using_id, toTypeName(using_id), t1.id + 1 AS t1_id, toTypeName(t1_id), t1.value AS t1_value, toTypeName(t1_value),
+t2.id + 1 AS t2_id, toTypeName(t2_id), t2.value AS t2_value, toTypeName(t2_value), t3.id + 1 AS t3_id, toTypeName(t3_id), t3.value AS t3_value, toTypeName(t3_value)
 FROM test_table_join_1 AS t1 LEFT JOIN test_table_join_2 AS t2 USING (id) LEFT JOIN test_table_join_3 AS t3 USING(id)
 ORDER BY ALL;
-0	UInt64	0	UInt64	Join_1_Value_0	String	0	UInt64	Join_2_Value_0	String	0	UInt64	Join_3_Value_0	String
-1	UInt64	1	UInt64	Join_1_Value_1	String	1	UInt64	Join_2_Value_1	String	1	UInt64	Join_3_Value_1	String
-2	UInt64	2	UInt64	Join_1_Value_2	String	0	UInt64		String	0	UInt64		String
+0	UInt64	1	UInt64	Join_1_Value_0	String	1	UInt32	Join_2_Value_0	String	1	UInt64	Join_3_Value_0	String
+1	UInt64	2	UInt64	Join_1_Value_1	String	2	UInt32	Join_2_Value_1	String	2	UInt64	Join_3_Value_1	String
+2	UInt64	3	UInt64	Join_1_Value_2	String	1	UInt32		String	1	UInt64		String
 SELECT '--';
 --
 SELECT t1.value AS t1_value, toTypeName(t1_value), t2.value AS t2_value, toTypeName(t2_value), t3.value AS t3_value, toTypeName(t3_value)
@@ -237,13 +237,13 @@ SELECT 1 FROM test_table_join_1 AS t1 LEFT JOIN test_table_join_2 AS t2 USING (i
 SELECT id FROM test_table_join_1 AS t1 LEFT JOIN test_table_join_2 AS t2 ON t1.id = t2.id LEFT JOIN test_table_join_3 AS t3 USING (id); -- { serverError AMBIGUOUS_IDENTIFIER }
 SELECT 'First JOIN LEFT second JOIN RIGHT';
 First JOIN LEFT second JOIN RIGHT
-SELECT id AS using_id, toTypeName(using_id), t1.id AS t1_id, toTypeName(t1_id), t1.value AS t1_value, toTypeName(t1_value),
-t2.id AS t2_id, toTypeName(t2_id), t2.value AS t2_value, toTypeName(t2_value), t3.id AS t3_id, toTypeName(t3_id), t3.value AS t3_value, toTypeName(t3_value)
+SELECT id AS using_id, toTypeName(using_id), t1.id + 1 AS t1_id, toTypeName(t1_id), t1.value AS t1_value, toTypeName(t1_value),
+t2.id + 1 AS t2_id, toTypeName(t2_id), t2.value AS t2_value, toTypeName(t2_value), t3.id + 1 AS t3_id, toTypeName(t3_id), t3.value AS t3_value, toTypeName(t3_value)
 FROM test_table_join_1 AS t1 LEFT JOIN test_table_join_2 AS t2 USING (id) RIGHT JOIN test_table_join_3 AS t3 USING(id)
 ORDER BY ALL;
-0	UInt64	0	UInt64	Join_1_Value_0	String	0	UInt64	Join_2_Value_0	String	0	UInt64	Join_3_Value_0	String
-1	UInt64	1	UInt64	Join_1_Value_1	String	1	UInt64	Join_2_Value_1	String	1	UInt64	Join_3_Value_1	String
-4	UInt64	0	UInt64		String	0	UInt64		String	4	UInt64	Join_3_Value_4	String
+0	UInt64	1	UInt64	Join_1_Value_0	String	1	UInt32	Join_2_Value_0	String	1	UInt64	Join_3_Value_0	String
+1	UInt64	2	UInt64	Join_1_Value_1	String	2	UInt32	Join_2_Value_1	String	2	UInt64	Join_3_Value_1	String
+4	UInt64	1	UInt64		String	1	UInt32		String	5	UInt64	Join_3_Value_4	String
 SELECT '--';
 --
 SELECT t1.value AS t1_value, toTypeName(t1_value), t2.value AS t2_value, toTypeName(t2_value), t3.value AS t3_value, toTypeName(t3_value)
@@ -261,14 +261,14 @@ SELECT 1 FROM test_table_join_1 AS t1 LEFT JOIN test_table_join_2 AS t2 USING (i
 SELECT id FROM test_table_join_1 AS t1 LEFT JOIN test_table_join_2 AS t2 ON t1.id = t2.id RIGHT JOIN test_table_join_3 AS t3 USING (id); -- { serverError AMBIGUOUS_IDENTIFIER }
 SELECT 'First JOIN LEFT second JOIN FULL';
 First JOIN LEFT second JOIN FULL
-SELECT id AS using_id, toTypeName(using_id), t1.id AS t1_id, toTypeName(t1_id), t1.value AS t1_value, toTypeName(t1_value),
-t2.id AS t2_id, toTypeName(t2_id), t2.value AS t2_value, toTypeName(t2_value), t3.id AS t3_id, toTypeName(t3_id), t3.value AS t3_value, toTypeName(t3_value)
+SELECT id AS using_id, toTypeName(using_id), t1.id + 1 AS t1_id, toTypeName(t1_id), t1.value AS t1_value, toTypeName(t1_value),
+t2.id + 1 AS t2_id, toTypeName(t2_id), t2.value AS t2_value, toTypeName(t2_value), t3.id + 1 AS t3_id, toTypeName(t3_id), t3.value AS t3_value, toTypeName(t3_value)
 FROM test_table_join_1 AS t1 LEFT JOIN test_table_join_2 AS t2 USING (id) FULL JOIN test_table_join_3 AS t3 USING(id)
 ORDER BY ALL;
-0	UInt64	0	UInt64	Join_1_Value_0	String	0	UInt64	Join_2_Value_0	String	0	UInt64	Join_3_Value_0	String
-1	UInt64	1	UInt64	Join_1_Value_1	String	1	UInt64	Join_2_Value_1	String	1	UInt64	Join_3_Value_1	String
-2	UInt64	2	UInt64	Join_1_Value_2	String	0	UInt64		String	0	UInt64		String
-4	UInt64	0	UInt64		String	0	UInt64		String	4	UInt64	Join_3_Value_4	String
+0	UInt64	1	UInt64	Join_1_Value_0	String	1	UInt32	Join_2_Value_0	String	1	UInt64	Join_3_Value_0	String
+1	UInt64	2	UInt64	Join_1_Value_1	String	2	UInt32	Join_2_Value_1	String	2	UInt64	Join_3_Value_1	String
+2	UInt64	3	UInt64	Join_1_Value_2	String	1	UInt32		String	1	UInt64		String
+4	UInt64	1	UInt64		String	1	UInt32		String	5	UInt64	Join_3_Value_4	String
 SELECT '--';
 --
 SELECT t1.value AS t1_value, toTypeName(t1_value), t2.value AS t2_value, toTypeName(t2_value), t3.value AS t3_value, toTypeName(t3_value)
@@ -288,12 +288,12 @@ SELECT 1 FROM test_table_join_1 AS t1 LEFT JOIN test_table_join_2 AS t2 USING (i
 SELECT id FROM test_table_join_1 AS t1 LEFT JOIN test_table_join_2 AS t2 ON t1.id = t2.id FULL JOIN test_table_join_3 AS t3 USING (id); -- { serverError AMBIGUOUS_IDENTIFIER }
 SELECT 'First JOIN RIGHT second JOIN INNER';
 First JOIN RIGHT second JOIN INNER
-SELECT id AS using_id, toTypeName(using_id), t1.id AS t1_id, toTypeName(t1_id), t1.value AS t1_value, toTypeName(t1_value),
-t2.id AS t2_id, toTypeName(t2_id), t2.value AS t2_value, toTypeName(t2_value), t3.id AS t3_id, toTypeName(t3_id), t3.value AS t3_value, toTypeName(t3_value)
+SELECT id AS using_id, toTypeName(using_id), t1.id + 1 AS t1_id, toTypeName(t1_id), t1.value AS t1_value, toTypeName(t1_value),
+t2.id + 1 AS t2_id, toTypeName(t2_id), t2.value AS t2_value, toTypeName(t2_value), t3.id + 1 AS t3_id, toTypeName(t3_id), t3.value AS t3_value, toTypeName(t3_value)
 FROM test_table_join_1 AS t1 RIGHT JOIN test_table_join_2 AS t2 USING (id) INNER JOIN test_table_join_3 AS t3 USING(id)
 ORDER BY ALL;
-0	UInt64	0	UInt64	Join_1_Value_0	String	0	UInt64	Join_2_Value_0	String	0	UInt64	Join_3_Value_0	String
-1	UInt64	1	UInt64	Join_1_Value_1	String	1	UInt64	Join_2_Value_1	String	1	UInt64	Join_3_Value_1	String
+0	UInt64	1	UInt32	Join_1_Value_0	String	1	UInt64	Join_2_Value_0	String	1	UInt64	Join_3_Value_0	String
+1	UInt64	2	UInt32	Join_1_Value_1	String	2	UInt64	Join_2_Value_1	String	2	UInt64	Join_3_Value_1	String
 SELECT '--';
 --
 SELECT t1.value AS t1_value, toTypeName(t1_value), t2.value AS t2_value, toTypeName(t2_value), t3.value AS t3_value, toTypeName(t3_value)
@@ -309,13 +309,13 @@ SELECT 1 FROM test_table_join_1 AS t1 RIGHT JOIN test_table_join_2 AS t2 USING (
 SELECT id FROM test_table_join_1 AS t1 RIGHT JOIN test_table_join_2 AS t2 ON t1.id = t2.id INNER JOIN test_table_join_3 AS t3 USING (id); -- { serverError AMBIGUOUS_IDENTIFIER }
 SELECT 'First JOIN RIGHT second JOIN LEFT';
 First JOIN RIGHT second JOIN LEFT
-SELECT id AS using_id, toTypeName(using_id), t1.id AS t1_id, toTypeName(t1_id), t1.value AS t1_value, toTypeName(t1_value),
-t2.id AS t2_id, toTypeName(t2_id), t2.value AS t2_value, toTypeName(t2_value), t3.id AS t3_id, toTypeName(t3_id), t3.value AS t3_value, toTypeName(t3_value)
+SELECT id AS using_id, toTypeName(using_id), t1.id + 1 AS t1_id, toTypeName(t1_id), t1.value AS t1_value, toTypeName(t1_value),
+t2.id + 1 AS t2_id, toTypeName(t2_id), t2.value AS t2_value, toTypeName(t2_value), t3.id + 1 AS t3_id, toTypeName(t3_id), t3.value AS t3_value, toTypeName(t3_value)
 FROM test_table_join_1 AS t1 RIGHT JOIN test_table_join_2 AS t2 USING (id) LEFT JOIN test_table_join_3 AS t3 USING(id)
 ORDER BY ALL;
-0	UInt64	0	UInt64	Join_1_Value_0	String	0	UInt64	Join_2_Value_0	String	0	UInt64	Join_3_Value_0	String
-1	UInt64	1	UInt64	Join_1_Value_1	String	1	UInt64	Join_2_Value_1	String	1	UInt64	Join_3_Value_1	String
-3	UInt64	0	UInt64		String	3	UInt64	Join_2_Value_3	String	0	UInt64		String
+0	UInt64	1	UInt32	Join_1_Value_0	String	1	UInt64	Join_2_Value_0	String	1	UInt64	Join_3_Value_0	String
+1	UInt64	2	UInt32	Join_1_Value_1	String	2	UInt64	Join_2_Value_1	String	2	UInt64	Join_3_Value_1	String
+3	UInt64	1	UInt32		String	4	UInt64	Join_2_Value_3	String	1	UInt64		String
 SELECT '--';
 --
 SELECT t1.value AS t1_value, toTypeName(t1_value), t2.value AS t2_value, toTypeName(t2_value), t3.value AS t3_value, toTypeName(t3_value)
@@ -333,13 +333,13 @@ SELECT 1 FROM test_table_join_1 AS t1 RIGHT JOIN test_table_join_2 AS t2 USING (
 SELECT id FROM test_table_join_1 AS t1 RIGHT JOIN test_table_join_2 AS t2 ON t1.id = t2.id LEFT JOIN test_table_join_3 AS t3 USING (id); -- { serverError AMBIGUOUS_IDENTIFIER }
 SELECT 'First JOIN RIGHT second JOIN RIGHT';
 First JOIN RIGHT second JOIN RIGHT
-SELECT id AS using_id, toTypeName(using_id), t1.id AS t1_id, toTypeName(t1_id), t1.value AS t1_value, toTypeName(t1_value),
-t2.id AS t2_id, toTypeName(t2_id), t2.value AS t2_value, toTypeName(t2_value), t3.id AS t3_id, toTypeName(t3_id), t3.value AS t3_value, toTypeName(t3_value)
+SELECT id AS using_id, toTypeName(using_id), t1.id + 1 AS t1_id, toTypeName(t1_id), t1.value AS t1_value, toTypeName(t1_value),
+t2.id + 1 AS t2_id, toTypeName(t2_id), t2.value AS t2_value, toTypeName(t2_value), t3.id + 1 AS t3_id, toTypeName(t3_id), t3.value AS t3_value, toTypeName(t3_value)
 FROM test_table_join_1 AS t1 RIGHT JOIN test_table_join_2 AS t2 USING (id) RIGHT JOIN test_table_join_3 AS t3 USING(id)
 ORDER BY ALL;
-0	UInt64	0	UInt64	Join_1_Value_0	String	0	UInt64	Join_2_Value_0	String	0	UInt64	Join_3_Value_0	String
-1	UInt64	1	UInt64	Join_1_Value_1	String	1	UInt64	Join_2_Value_1	String	1	UInt64	Join_3_Value_1	String
-4	UInt64	0	UInt64		String	0	UInt64		String	4	UInt64	Join_3_Value_4	String
+0	UInt64	1	UInt32	Join_1_Value_0	String	1	UInt64	Join_2_Value_0	String	1	UInt64	Join_3_Value_0	String
+1	UInt64	2	UInt32	Join_1_Value_1	String	2	UInt64	Join_2_Value_1	String	2	UInt64	Join_3_Value_1	String
+4	UInt64	1	UInt32		String	1	UInt64		String	5	UInt64	Join_3_Value_4	String
 SELECT '--';
 --
 SELECT t1.value AS t1_value, toTypeName(t1_value), t2.value AS t2_value, toTypeName(t2_value), t3.value AS t3_value, toTypeName(t3_value)
@@ -357,14 +357,14 @@ SELECT 1 FROM test_table_join_1 AS t1 RIGHT JOIN test_table_join_2 AS t2 USING (
 SELECT id FROM test_table_join_1 AS t1 RIGHT JOIN test_table_join_2 AS t2 ON t1.id = t2.id RIGHT JOIN test_table_join_3 AS t3 USING (id); -- { serverError AMBIGUOUS_IDENTIFIER }
 SELECT 'First JOIN RIGHT second JOIN FULL';
 First JOIN RIGHT second JOIN FULL
-SELECT id AS using_id, toTypeName(using_id), t1.id AS t1_id, toTypeName(t1_id), t1.value AS t1_value, toTypeName(t1_value),
-t2.id AS t2_id, toTypeName(t2_id), t2.value AS t2_value, toTypeName(t2_value), t3.id AS t3_id, toTypeName(t3_id), t3.value AS t3_value, toTypeName(t3_value)
+SELECT id AS using_id, toTypeName(using_id), t1.id + 1 AS t1_id, toTypeName(t1_id), t1.value AS t1_value, toTypeName(t1_value),
+t2.id + 1 AS t2_id, toTypeName(t2_id), t2.value AS t2_value, toTypeName(t2_value), t3.id + 1 AS t3_id, toTypeName(t3_id), t3.value AS t3_value, toTypeName(t3_value)
 FROM test_table_join_1 AS t1 RIGHT JOIN test_table_join_2 AS t2 USING (id) FULL JOIN test_table_join_3 AS t3 USING(id)
 ORDER BY ALL;
-0	UInt64	0	UInt64	Join_1_Value_0	String	0	UInt64	Join_2_Value_0	String	0	UInt64	Join_3_Value_0	String
-1	UInt64	1	UInt64	Join_1_Value_1	String	1	UInt64	Join_2_Value_1	String	1	UInt64	Join_3_Value_1	String
-3	UInt64	0	UInt64		String	3	UInt64	Join_2_Value_3	String	0	UInt64		String
-4	UInt64	0	UInt64		String	0	UInt64		String	4	UInt64	Join_3_Value_4	String
+0	UInt64	1	UInt32	Join_1_Value_0	String	1	UInt64	Join_2_Value_0	String	1	UInt64	Join_3_Value_0	String
+1	UInt64	2	UInt32	Join_1_Value_1	String	2	UInt64	Join_2_Value_1	String	2	UInt64	Join_3_Value_1	String
+3	UInt64	1	UInt32		String	4	UInt64	Join_2_Value_3	String	1	UInt64		String
+4	UInt64	1	UInt32		String	1	UInt64		String	5	UInt64	Join_3_Value_4	String
 SELECT '--';
 --
 SELECT t1.value AS t1_value, toTypeName(t1_value), t2.value AS t2_value, toTypeName(t2_value), t3.value AS t3_value, toTypeName(t3_value)
@@ -384,12 +384,12 @@ SELECT 1 FROM test_table_join_1 AS t1 RIGHT JOIN test_table_join_2 AS t2 USING (
 SELECT id FROM test_table_join_1 AS t1 RIGHT JOIN test_table_join_2 AS t2 ON t1.id = t2.id FULL JOIN test_table_join_3 AS t3 USING (id); -- { serverError AMBIGUOUS_IDENTIFIER }
 SELECT 'First JOIN FULL second JOIN INNER';
 First JOIN FULL second JOIN INNER
-SELECT id AS using_id, toTypeName(using_id), t1.id AS t1_id, toTypeName(t1_id), t1.value AS t1_value, toTypeName(t1_value),
-t2.id AS t2_id, toTypeName(t2_id), t2.value AS t2_value, toTypeName(t2_value), t3.id AS t3_id, toTypeName(t3_id), t3.value AS t3_value, toTypeName(t3_value)
+SELECT id AS using_id, toTypeName(using_id), t1.id + 1 AS t1_id, toTypeName(t1_id), t1.value AS t1_value, toTypeName(t1_value),
+t2.id + 1 AS t2_id, toTypeName(t2_id), t2.value AS t2_value, toTypeName(t2_value), t3.id + 1 AS t3_id, toTypeName(t3_id), t3.value AS t3_value, toTypeName(t3_value)
 FROM test_table_join_1 AS t1 FULL JOIN test_table_join_2 AS t2 USING (id) INNER JOIN test_table_join_3 AS t3 USING(id)
 ORDER BY ALL;
-0	UInt64	0	UInt64	Join_1_Value_0	String	0	UInt64	Join_2_Value_0	String	0	UInt64	Join_3_Value_0	String
-1	UInt64	1	UInt64	Join_1_Value_1	String	1	UInt64	Join_2_Value_1	String	1	UInt64	Join_3_Value_1	String
+0	UInt64	1	UInt64	Join_1_Value_0	String	1	UInt64	Join_2_Value_0	String	1	UInt64	Join_3_Value_0	String
+1	UInt64	2	UInt64	Join_1_Value_1	String	2	UInt64	Join_2_Value_1	String	2	UInt64	Join_3_Value_1	String
 SELECT '--';
 --
 SELECT t1.value AS t1_value, toTypeName(t1_value), t2.value AS t2_value, toTypeName(t2_value), t3.value AS t3_value, toTypeName(t3_value)
@@ -405,14 +405,14 @@ SELECT 1 FROM test_table_join_1 AS t1 FULL JOIN test_table_join_2 AS t2 USING (i
 SELECT id FROM test_table_join_1 AS t1 FULL JOIN test_table_join_2 AS t2 ON t1.id = t2.id INNER JOIN test_table_join_3 AS t3 USING (id); -- { serverError AMBIGUOUS_IDENTIFIER }
 SELECT 'First JOIN FULL second JOIN LEFT';
 First JOIN FULL second JOIN LEFT
-SELECT id AS using_id, toTypeName(using_id), t1.id AS t1_id, toTypeName(t1_id), t1.value AS t1_value, toTypeName(t1_value),
-t2.id AS t2_id, toTypeName(t2_id), t2.value AS t2_value, toTypeName(t2_value), t3.id AS t3_id, toTypeName(t3_id), t3.value AS t3_value, toTypeName(t3_value)
+SELECT id AS using_id, toTypeName(using_id), t1.id + 1 AS t1_id, toTypeName(t1_id), t1.value AS t1_value, toTypeName(t1_value),
+t2.id + 1 AS t2_id, toTypeName(t2_id), t2.value AS t2_value, toTypeName(t2_value), t3.id + 1 AS t3_id, toTypeName(t3_id), t3.value AS t3_value, toTypeName(t3_value)
 FROM test_table_join_1 AS t1 FULL JOIN test_table_join_2 AS t2 USING (id) LEFT JOIN test_table_join_3 AS t3 USING(id)
 ORDER BY ALL;
-0	UInt64	0	UInt64	Join_1_Value_0	String	0	UInt64	Join_2_Value_0	String	0	UInt64	Join_3_Value_0	String
-1	UInt64	1	UInt64	Join_1_Value_1	String	1	UInt64	Join_2_Value_1	String	1	UInt64	Join_3_Value_1	String
-2	UInt64	2	UInt64	Join_1_Value_2	String	0	UInt64		String	0	UInt64		String
-3	UInt64	0	UInt64		String	3	UInt64	Join_2_Value_3	String	0	UInt64		String
+0	UInt64	1	UInt64	Join_1_Value_0	String	1	UInt64	Join_2_Value_0	String	1	UInt64	Join_3_Value_0	String
+1	UInt64	2	UInt64	Join_1_Value_1	String	2	UInt64	Join_2_Value_1	String	2	UInt64	Join_3_Value_1	String
+2	UInt64	3	UInt64	Join_1_Value_2	String	1	UInt64		String	1	UInt64		String
+3	UInt64	1	UInt64		String	4	UInt64	Join_2_Value_3	String	1	UInt64		String
 SELECT '--';
 --
 SELECT t1.value AS t1_value, toTypeName(t1_value), t2.value AS t2_value, toTypeName(t2_value), t3.value AS t3_value, toTypeName(t3_value)
@@ -432,13 +432,13 @@ SELECT 1 FROM test_table_join_1 AS t1 FULL JOIN test_table_join_2 AS t2 USING (i
 SELECT id FROM test_table_join_1 AS t1 FULL JOIN test_table_join_2 AS t2 ON t1.id = t2.id LEFT JOIN test_table_join_3 AS t3 USING (id); -- { serverError AMBIGUOUS_IDENTIFIER }
 SELECT 'First JOIN FULL second JOIN RIGHT';
 First JOIN FULL second JOIN RIGHT
-SELECT id AS using_id, toTypeName(using_id), t1.id AS t1_id, toTypeName(t1_id), t1.value AS t1_value, toTypeName(t1_value),
-t2.id AS t2_id, toTypeName(t2_id), t2.value AS t2_value, toTypeName(t2_value), t3.id AS t3_id, toTypeName(t3_id), t3.value AS t3_value, toTypeName(t3_value)
+SELECT id AS using_id, toTypeName(using_id), t1.id + 1 AS t1_id, toTypeName(t1_id), t1.value AS t1_value, toTypeName(t1_value),
+t2.id + 1 AS t2_id, toTypeName(t2_id), t2.value AS t2_value, toTypeName(t2_value), t3.id + 1 AS t3_id, toTypeName(t3_id), t3.value AS t3_value, toTypeName(t3_value)
 FROM test_table_join_1 AS t1 FULL JOIN test_table_join_2 AS t2 USING (id) RIGHT JOIN test_table_join_3 AS t3 USING(id)
 ORDER BY ALL;
-0	UInt64	0	UInt64	Join_1_Value_0	String	0	UInt64	Join_2_Value_0	String	0	UInt64	Join_3_Value_0	String
-1	UInt64	1	UInt64	Join_1_Value_1	String	1	UInt64	Join_2_Value_1	String	1	UInt64	Join_3_Value_1	String
-4	UInt64	0	UInt64		String	0	UInt64		String	4	UInt64	Join_3_Value_4	String
+0	UInt64	1	UInt64	Join_1_Value_0	String	1	UInt64	Join_2_Value_0	String	1	UInt64	Join_3_Value_0	String
+1	UInt64	2	UInt64	Join_1_Value_1	String	2	UInt64	Join_2_Value_1	String	2	UInt64	Join_3_Value_1	String
+4	UInt64	1	UInt64		String	1	UInt64		String	5	UInt64	Join_3_Value_4	String
 SELECT '--';
 --
 SELECT t1.value AS t1_value, toTypeName(t1_value), t2.value AS t2_value, toTypeName(t2_value), t3.value AS t3_value, toTypeName(t3_value)
@@ -456,15 +456,15 @@ SELECT 1 FROM test_table_join_1 AS t1 FULL JOIN test_table_join_2 AS t2 USING (i
 SELECT id FROM test_table_join_1 AS t1 FULL JOIN test_table_join_2 AS t2 ON t1.id = t2.id RIGHT JOIN test_table_join_3 AS t3 USING (id); -- { serverError AMBIGUOUS_IDENTIFIER }
 SELECT 'First JOIN FULL second JOIN FULL';
 First JOIN FULL second JOIN FULL
-SELECT id AS using_id, toTypeName(using_id), t1.id AS t1_id, toTypeName(t1_id), t1.value AS t1_value, toTypeName(t1_value),
-t2.id AS t2_id, toTypeName(t2_id), t2.value AS t2_value, toTypeName(t2_value), t3.id AS t3_id, toTypeName(t3_id), t3.value AS t3_value, toTypeName(t3_value)
+SELECT id AS using_id, toTypeName(using_id), t1.id + 1 AS t1_id, toTypeName(t1_id), t1.value AS t1_value, toTypeName(t1_value),
+t2.id + 1 AS t2_id, toTypeName(t2_id), t2.value AS t2_value, toTypeName(t2_value), t3.id + 1 AS t3_id, toTypeName(t3_id), t3.value AS t3_value, toTypeName(t3_value)
 FROM test_table_join_1 AS t1 FULL JOIN test_table_join_2 AS t2 USING (id) FULL JOIN test_table_join_3 AS t3 USING(id)
 ORDER BY ALL;
-0	UInt64	0	UInt64	Join_1_Value_0	String	0	UInt64	Join_2_Value_0	String	0	UInt64	Join_3_Value_0	String
-1	UInt64	1	UInt64	Join_1_Value_1	String	1	UInt64	Join_2_Value_1	String	1	UInt64	Join_3_Value_1	String
-2	UInt64	2	UInt64	Join_1_Value_2	String	0	UInt64		String	0	UInt64		String
-3	UInt64	0	UInt64		String	3	UInt64	Join_2_Value_3	String	0	UInt64		String
-4	UInt64	0	UInt64		String	0	UInt64		String	4	UInt64	Join_3_Value_4	String
+0	UInt64	1	UInt64	Join_1_Value_0	String	1	UInt64	Join_2_Value_0	String	1	UInt64	Join_3_Value_0	String
+1	UInt64	2	UInt64	Join_1_Value_1	String	2	UInt64	Join_2_Value_1	String	2	UInt64	Join_3_Value_1	String
+2	UInt64	3	UInt64	Join_1_Value_2	String	1	UInt64		String	1	UInt64		String
+3	UInt64	1	UInt64		String	4	UInt64	Join_2_Value_3	String	1	UInt64		String
+4	UInt64	1	UInt64		String	1	UInt64		String	5	UInt64	Join_3_Value_4	String
 SELECT '--';
 --
 SELECT t1.value AS t1_value, toTypeName(t1_value), t2.value AS t2_value, toTypeName(t2_value), t3.value AS t3_value, toTypeName(t3_value)

--- a/tests/queries/0_stateless/02374_analyzer_join_using.sql.j2
+++ b/tests/queries/0_stateless/02374_analyzer_join_using.sql.j2
@@ -64,8 +64,8 @@ FROM test_table_join_1 AS t1 {{ join_type }} JOIN test_table_join_2 AS t2 USING 
 
 SELECT 'First JOIN {{ first_join_type }} second JOIN {{ second_join_type }}';
 
-SELECT id AS using_id, toTypeName(using_id), t1.id AS t1_id, toTypeName(t1_id), t1.value AS t1_value, toTypeName(t1_value),
-t2.id AS t2_id, toTypeName(t2_id), t2.value AS t2_value, toTypeName(t2_value), t3.id AS t3_id, toTypeName(t3_id), t3.value AS t3_value, toTypeName(t3_value)
+SELECT id AS using_id, toTypeName(using_id), t1.id + 1 AS t1_id, toTypeName(t1_id), t1.value AS t1_value, toTypeName(t1_value),
+t2.id + 1 AS t2_id, toTypeName(t2_id), t2.value AS t2_value, toTypeName(t2_value), t3.id + 1 AS t3_id, toTypeName(t3_id), t3.value AS t3_value, toTypeName(t3_value)
 FROM test_table_join_1 AS t1 {{ first_join_type }} JOIN test_table_join_2 AS t2 USING (id) {{ second_join_type }} JOIN test_table_join_3 AS t3 USING(id)
 ORDER BY ALL;
 


### PR DESCRIPTION
### Changelog category (leave one):

- Bug Fix

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

* Fixed type inference for qualified columns from source tables when multiple joins are used with `USING` clause. Previously, subsequent joins incorrectly updated types of underlying source columns to a common supertype even when the column was not involved in that join (e.g., in `SELECT t2.a FROM t1 LEFT JOIN t2 USING (a) LEFT JOIN t3 USING (a)`, the `t2.a` column is only used by the first join, so its type should be the supertype of `t1.a` and `t2.a`, excluding `t3.a`). This could lead to logical errors or crashes when functions expected different column types than what actually appeared in the execution plan.

Ref https://github.com/ClickHouse/ClickHouse/pull/91738


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.97`
- Backported to: `26.1.3.2`, `25.12.6.4`, `25.11.9.14`, `25.8.17.5`, `25.3.15.4`
<!-- ch-version-info:end -->