### PR TITLE
Fix s3_create_new_file_on_insert setting not respected via materialized views

### DIFF
--- a/tests/queries/0_stateless/03700_s3_create_new_file_on_insert_mv.reference
+++ b/tests/queries/0_stateless/03700_s3_create_new_file_on_insert_mv.reference
@@ -1,0 +1,36 @@
+-- { echo }
+drop table if exists test_03700_mv;
+drop table if exists test_03700_s3;
+drop table if exists test_03700_source;
+-- Create source MergeTree table
+create table test_03700_source (a UInt64) engine = MergeTree() order by tuple();
+-- Create S3 table with partitioning
+create table test_03700_s3 (a UInt64) 
+    engine = S3(s3_conn, filename='test_03700_{_partition_id}', format=Parquet) 
+    partition by a;
+-- Create materialized view from source to S3
+create materialized view test_03700_mv to test_03700_s3 as select a from test_03700_source;
+-- Set the truncate setting for initial insert
+set s3_truncate_on_insert = 1;
+-- Insert initial data through the MV
+insert into test_03700_source values (1);
+insert into test_03700_source values (2);
+-- Now enable create_new_file_on_insert and disable truncate
+set s3_truncate_on_insert = 0;
+set s3_create_new_file_on_insert = 1;
+-- Insert more data - this should create new files instead of failing
+insert into test_03700_source values (1);
+insert into test_03700_source values (2);
+-- Verify we have all 4 values (2 original + 2 new)
+select count() from s3(s3_conn, filename='test_03700_*', format=Parquet);
+4
+-- Verify the data content
+select a from s3(s3_conn, filename='test_03700_*', format=Parquet) order by a;
+1
+1
+2
+2
+-- Cleanup
+drop table test_03700_mv;
+drop table test_03700_s3;
+drop table test_03700_source;

--- a/tests/queries/0_stateless/03700_s3_create_new_file_on_insert_mv.sql
+++ b/tests/queries/0_stateless/03700_s3_create_new_file_on_insert_mv.sql
@@ -1,0 +1,47 @@
+-- Tags: no-parallel, no-fasttest
+-- Tag no-fasttest: Depends on S3
+
+-- Test that s3_create_new_file_on_insert setting works correctly when inserting via materialized view
+-- See: https://github.com/ClickHouse/ClickHouse/issues/47263
+
+-- { echo }
+drop table if exists test_03700_mv;
+drop table if exists test_03700_s3;
+drop table if exists test_03700_source;
+
+-- Create source MergeTree table
+create table test_03700_source (a UInt64) engine = MergeTree() order by tuple();
+
+-- Create S3 table with partitioning
+create table test_03700_s3 (a UInt64) 
+    engine = S3(s3_conn, filename='test_03700_{_partition_id}', format=Parquet) 
+    partition by a;
+
+-- Create materialized view from source to S3
+create materialized view test_03700_mv to test_03700_s3 as select a from test_03700_source;
+
+-- Set the truncate setting for initial insert
+set s3_truncate_on_insert = 1;
+
+-- Insert initial data through the MV
+insert into test_03700_source values (1);
+insert into test_03700_source values (2);
+
+-- Now enable create_new_file_on_insert and disable truncate
+set s3_truncate_on_insert = 0;
+set s3_create_new_file_on_insert = 1;
+
+-- Insert more data - this should create new files instead of failing
+insert into test_03700_source values (1);
+insert into test_03700_source values (2);
+
+-- Verify we have all 4 values (2 original + 2 new)
+select count() from s3(s3_conn, filename='test_03700_*', format=Parquet);
+
+-- Verify the data content
+select a from s3(s3_conn, filename='test_03700_*', format=Parquet) order by a;
+
+-- Cleanup
+drop table test_03700_mv;
+drop table test_03700_s3;
+drop table test_03700_source;


### PR DESCRIPTION
### Related issue(s)

Closes #47263
Related to #72374

### Problem description

When inserting data into an S3 table via a materialized view, the `s3_create_new_file_on_insert` and `s3_truncate_on_insert` settings are not respected. This results in errors like:

```
DB::Exception: Object in bucket already exists and s3_truncate_on_insert setting is disabled
```

even when the settings are explicitly enabled in the INSERT statement or session.

### Root cause

The `PartitionedStorageObjectStorageSink` class was caching `query_settings` in its constructor at sink creation time. When the sink is used via a materialized view chain, the settings from the actual INSERT statement's context are not reflected because the sink was already constructed with different settings.

### Solution

Remove the cached `query_settings` member from `PartitionedStorageObjectStorageSink` and instead fetch the settings dynamically in `createSinkForPartition()` using the stored `context`. This ensures the correct settings are used regardless of how the sink is invoked.

### Changelog category

- Bug Fix

### Changelog entry

Fixed an issue where `s3_create_new_file_on_insert` and `s3_truncate_on_insert` settings were not respected when inserting into S3 tables via materialized views.

### Testing

Added new test `03700_s3_create_new_file_on_insert_mv` that verifies the fix works correctly with materialized views.