### PR TITLE
Store correct database in DDL dependency for Alias target

### DIFF
--- a/docs/en/engines/table-engines/special/alias.md
+++ b/docs/en/engines/table-engines/special/alias.md
@@ -45,6 +45,10 @@ The `Alias` table does not support explicit column definitions. Columns are auto
 - **`target_db (optional)`** — Name of the database containing the target table.
 - **`target_table`** — Name of the target table.
 
+:::note
+When `target_db` is omitted and `target_table` is not fully qualified (e.g., `Alias('my_table')`), the target is resolved to the same database as the alias itself, not the session's current database.
+:::
+
 ## Supported Operations {#supported-operations}
 
 The `Alias` table engine supports all major operations. 

--- a/src/Databases/DDLDependencyVisitor.cpp
+++ b/src/Databases/DDLDependencyVisitor.cpp
@@ -260,10 +260,12 @@ namespace
                 visitDistributedTableEngine(table_engine);
 
             /// Alias(table_name) or Alias(db_name, table_name)
+            /// Note: Alias resolves non-qualified target names to its own database (not current_database),
+            /// so we use addQualifiedNameFromArgumentUsingTableDatabase for the single-argument case.
             if (table_engine.name == "Alias" && table_engine.arguments)
             {
                 if (table_engine.arguments->children.size() == 1)
-                    addQualifiedNameFromArgument(table_engine, 0);
+                    addQualifiedNameFromArgumentUsingTableDatabase(table_engine, 0);
                 else
                     addDatabaseAndTableNameFromArguments(table_engine, 0, 1);
             }
@@ -480,6 +482,19 @@ namespace
         {
             if (auto qualified_name = tryGetQualifiedNameFromArgument(function, arg_idx, evaluate))
                 dependencies.emplace(std::move(qualified_name).value());
+        }
+
+        /// Like addQualifiedNameFromArgument, but uses the database of the table being created
+        /// as the default database (instead of current_database). This matches the behavior of
+        /// engines like Alias that resolve non-qualified target names to their own database.
+        void addQualifiedNameFromArgumentUsingTableDatabase(const ASTFunction & function, size_t arg_idx, bool evaluate = true)
+        {
+            if (auto qualified_name = tryGetQualifiedNameFromArgument(function, arg_idx, evaluate, /* apply_current_database= */ false))
+            {
+                if (qualified_name->database.empty())
+                    qualified_name->database = table_name.database;
+                dependencies.emplace(std::move(qualified_name).value());
+            }
         }
 
         /// Returns a database name and a table name extracted from two separate arguments.

--- a/tests/queries/0_stateless/03802_storage_alias_referential_check.reference
+++ b/tests/queries/0_stateless/03802_storage_alias_referential_check.reference
@@ -1,0 +1,35 @@
+-- { echo }
+-- Tests for check_referential_table_dependencies with Alias table engine
+
+SET allow_experimental_alias_table_engine = 1;
+-- Test: check_referential_table_dependencies prevents dropping target
+SELECT 'Test check_referential_table_dependencies';
+Test check_referential_table_dependencies
+DROP TABLE IF EXISTS ref_dep_alias;
+DROP TABLE IF EXISTS ref_dep_target;
+CREATE TABLE ref_dep_target (id UInt32, value String) ENGINE = MergeTree ORDER BY id;
+CREATE TABLE ref_dep_alias ENGINE = Alias('ref_dep_target');
+-- This should fail with check_referential_table_dependencies = 1
+SET check_referential_table_dependencies = 1;
+DROP TABLE ref_dep_target; -- { serverError HAVE_DEPENDENT_OBJECTS }
+-- Dropping the alias first, then the target should work
+DROP TABLE ref_dep_alias;
+DROP TABLE ref_dep_target;
+SET check_referential_table_dependencies = 0;
+-- Test: check_referential_table_dependencies with non-qualified target name
+-- when alias is created from a different current database
+SELECT 'Test check_referential_table_dependencies cross-database';
+Test check_referential_table_dependencies cross-database
+DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE_1:Identifier};
+CREATE DATABASE {CLICKHOUSE_DATABASE_1:Identifier};
+CREATE TABLE {CLICKHOUSE_DATABASE_1:Identifier}.cross_db_target (id UInt32) ENGINE = MergeTree ORDER BY id;
+-- Create alias in CLICKHOUSE_DATABASE_1 while current database is CLICKHOUSE_DATABASE
+-- The non-qualified 'cross_db_target' should resolve to CLICKHOUSE_DATABASE_1, not current db
+CREATE TABLE {CLICKHOUSE_DATABASE_1:Identifier}.cross_db_alias ENGINE = Alias('cross_db_target');
+SET check_referential_table_dependencies = 1;
+DROP TABLE {CLICKHOUSE_DATABASE_1:Identifier}.cross_db_target; -- { serverError HAVE_DEPENDENT_OBJECTS }
+-- Clean up
+DROP TABLE {CLICKHOUSE_DATABASE_1:Identifier}.cross_db_alias;
+DROP TABLE {CLICKHOUSE_DATABASE_1:Identifier}.cross_db_target;
+DROP DATABASE {CLICKHOUSE_DATABASE_1:Identifier};
+SET check_referential_table_dependencies = 0;

--- a/tests/queries/0_stateless/03802_storage_alias_referential_check.sql
+++ b/tests/queries/0_stateless/03802_storage_alias_referential_check.sql
@@ -1,0 +1,43 @@
+-- { echo }
+-- Tests for check_referential_table_dependencies with Alias table engine
+
+SET allow_experimental_alias_table_engine = 1;
+
+-- Test: check_referential_table_dependencies prevents dropping target
+SELECT 'Test check_referential_table_dependencies';
+DROP TABLE IF EXISTS ref_dep_alias;
+DROP TABLE IF EXISTS ref_dep_target;
+
+CREATE TABLE ref_dep_target (id UInt32, value String) ENGINE = MergeTree ORDER BY id;
+CREATE TABLE ref_dep_alias ENGINE = Alias('ref_dep_target');
+
+-- This should fail with check_referential_table_dependencies = 1
+SET check_referential_table_dependencies = 1;
+DROP TABLE ref_dep_target; -- { serverError HAVE_DEPENDENT_OBJECTS }
+
+-- Dropping the alias first, then the target should work
+DROP TABLE ref_dep_alias;
+DROP TABLE ref_dep_target;
+
+SET check_referential_table_dependencies = 0;
+
+-- Test: check_referential_table_dependencies with non-qualified target name
+-- when alias is created from a different current database
+SELECT 'Test check_referential_table_dependencies cross-database';
+DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE_1:Identifier};
+CREATE DATABASE {CLICKHOUSE_DATABASE_1:Identifier};
+
+CREATE TABLE {CLICKHOUSE_DATABASE_1:Identifier}.cross_db_target (id UInt32) ENGINE = MergeTree ORDER BY id;
+-- Create alias in CLICKHOUSE_DATABASE_1 while current database is CLICKHOUSE_DATABASE
+-- The non-qualified 'cross_db_target' should resolve to CLICKHOUSE_DATABASE_1, not current db
+CREATE TABLE {CLICKHOUSE_DATABASE_1:Identifier}.cross_db_alias ENGINE = Alias('cross_db_target');
+
+SET check_referential_table_dependencies = 1;
+DROP TABLE {CLICKHOUSE_DATABASE_1:Identifier}.cross_db_target; -- { serverError HAVE_DEPENDENT_OBJECTS }
+
+-- Clean up
+DROP TABLE {CLICKHOUSE_DATABASE_1:Identifier}.cross_db_alias;
+DROP TABLE {CLICKHOUSE_DATABASE_1:Identifier}.cross_db_target;
+DROP DATABASE {CLICKHOUSE_DATABASE_1:Identifier};
+
+SET check_referential_table_dependencies = 0;


### PR DESCRIPTION
Different engines that take tables as a parameter have different behaviours when the table argument is not fully qualified:
* Buffer and Distributed use the session database
* Alias uses the alias table database

This means we need dedicated logic when we save the alias target as a dependency. Before this change it was saved with the incorrect database in some cases.

Another option would be to change how non-fully-qualified tables are handled. I'd be happy to implement that if you think that's a better option.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixes how an Alias table target is saved as a DDL dependency when not fully qualified: it's now saved with the Alias table database instead of the session database.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.394`
<!-- ch-version-info:end -->