### PR TITLE
Disable slow tests on Azure blob storage

### DIFF
--- a/tests/queries/0_stateless/00276_sample.sql
+++ b/tests/queries/0_stateless/00276_sample.sql
@@ -1,3 +1,6 @@
+-- Tags: no-azure-blob-storage
+-- no-azure-blob-storage: too slow
+
 DROP TABLE IF EXISTS sample_00276;
 
 set allow_deprecated_syntax_for_merge_tree=1;

--- a/tests/queries/0_stateless/00314_sample_factor_virtual_column.sql
+++ b/tests/queries/0_stateless/00314_sample_factor_virtual_column.sql
@@ -1,4 +1,5 @@
--- Tags: no-msan
+-- Tags: no-msan, no-azure-blob-storage
+-- no-azure-blob-storage: too slow
 --          ^
 --          makes SELECTs extremely slow sometimes for some reason: "Aggregated. 1000000 to 1 rows (from 7.63 MiB) in 242.829221645 sec."
 

--- a/tests/queries/0_stateless/03207_json_read_subcolumns_1_wide_merge_tree.sql.j2
+++ b/tests/queries/0_stateless/03207_json_read_subcolumns_1_wide_merge_tree.sql.j2
@@ -1,4 +1,4 @@
--- Tags: no-fasttest
+-- Tags: no-fasttest, no-azure-blob-storage
 -- Tag: no-azure-blob-storage - too slow
 
 SET enable_json_type = 1;

--- a/tests/queries/0_stateless/03208_array_of_json_read_subcolumns_1.sql.j2
+++ b/tests/queries/0_stateless/03208_array_of_json_read_subcolumns_1.sql.j2
@@ -1,4 +1,5 @@
--- Tags: no-fasttest, long
+-- Tags: no-fasttest, long, no-azure-blob-storage
+-- no-azure-blob-storage: too slow
 
 SET enable_json_type = 1;
 set allow_experimental_variant_type = 1;

--- a/tests/queries/0_stateless/03251_insert_sparse_all_formats.sh
+++ b/tests/queries/0_stateless/03251_insert_sparse_all_formats.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, long, no-msan
+# Tags: no-fasttest, long, no-msan, no-azure-blob-storage
+# no-azure-blob-storage: too slow
 # no-msan: it is too slow
 
 set -e

--- a/tests/queries/0_stateless/03759_distinct_json_paths_optimization.sql.j2
+++ b/tests/queries/0_stateless/03759_distinct_json_paths_optimization.sql.j2
@@ -1,4 +1,5 @@
--- Tags: long
+-- Tags: long, no-azure-blob-storage
+-- no-azure-blob-storage: too slow
 -- Random settings limits: index_granularity=(1000, None); index_granularity_bytes=(1000000, None)
 
 SET enable_analyzer=1;


### PR DESCRIPTION
These tests consistently time out (600s) in the Azure blob storage CI:
- 00276_sample
- 00314_sample_factor_virtual_column
- 03207_json_read_subcolumns_1_wide_merge_tree
- 03208_array_of_json_read_subcolumns_1
- 03251_insert_sparse_all_formats
- 03759_distinct_json_paths_optimization

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

See https://play.clickhouse.com/play?user=play&run=1#U0VMRUNUIGNoZWNrX3N0YXJ0X3RpbWUsIHRlc3RfbmFtZSwgdGVzdF9kdXJhdGlvbl9tcywgcmVwb3J0X3VybApGUk9NIGNoZWNrcwpXSEVSRSAxCiAgICBBTkQgY2hlY2tfc3RhcnRfdGltZSA+PSBub3coKSAtIElOVEVSVkFMIDEgV0VFSwogICAgQU5EIChoZWFkX3JlZiA9ICdtYXN0ZXInIEFORCBzdGFydHNXaXRoKGhlYWRfcmVwbywgJ0NsaWNrSG91c2UvJykpCiAgICBBTkQgdGVzdF9zdGF0dXMgIT0gJ1NLSVBQRUQnCiAgICBBTkQgKHRlc3Rfc3RhdHVzIExJS0UgJ0YlJyBPUiB0ZXN0X3N0YXR1cyBMSUtFICdFJScpIAogICAgQU5EIGNoZWNrX3N0YXR1cyAhPSAnc3VjY2VzcycKICAgIEFORCBjaGVja19uYW1lID0gJ1N0YXRlbGVzcyB0ZXN0cyAoYXJtX2FzYW4sIGF6dXJlLCBwYXJhbGxlbCknCk9SREVSIEJZIHRlc3RfZHVyYXRpb25fbXMgREVTQw==


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.895`
<!-- ch-version-info:end -->