### PR TITLE
Fix flaky test `02896_leading_zeroes_no_octal`

### DIFF
--- a/tests/queries/0_stateless/02896_leading_zeroes_no_octal.sql
+++ b/tests/queries/0_stateless/02896_leading_zeroes_no_octal.sql
@@ -1,3 +1,5 @@
+-- Tags: no-async-insert
+
 DROP TABLE IF EXISTS t_leading_zeroes;
 DROP TABLE IF EXISTS t_leading_zeroes_f;
 


### PR DESCRIPTION
This test times out in async insert mode because it has 160+ sequential INSERT statements, each waiting for the async insert flush timeout (~5 seconds with test config).

The test configuration sets `async_insert_busy_timeout_ms=5000` (via tests/config/users.d/timeouts.xml) and with `wait_for_async_insert=1`, each INSERT blocks until flushed. With sequential single-row inserts that don't batch together, the total time exceeds the 600-second timeout.

Add `no-async-insert` tag since this test verifies number parsing behavior, not async insert functionality.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

See https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=37007ebd5784705476cee1b5b552906611a08fc8&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_debug%2C%20AsyncInsert%2C%20s3%20storage%2C%20parallel%29&name_1=Stateless%20tests%20%28amd_debug%2C%20AsyncInsert%2C%20s3%20storage%2C%20parallel%29


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.1.1.892`
<!-- ch-version-info:end -->