### PR TITLE
Fix some kafka tests

### DIFF
--- a/tests/integration/test_storage_kafka/test_batch_fast.py
+++ b/tests/integration/test_storage_kafka/test_batch_fast.py
@@ -1103,7 +1103,9 @@ def test_librdkafka_compression(kafka_cluster, create_query_generator, log_line)
             k.kafka_produce(kafka_cluster, topic_name, messages)
 
             instance.wait_for_log_line(current_log_line.format(offset=number_of_messages, topic=topic_name))
-            result = instance.query(f"SELECT * FROM test.{kafka_table}_view")
+            result = instance.query(
+                f"SELECT * FROM test.{kafka_table}_view ORDER BY key"
+            )
             assert TSV(result) == TSV(expected)
 
             instance.query(f"DROP TABLE test.{kafka_table} SYNC")
@@ -3097,7 +3099,11 @@ def test_system_kafka_consumers(kafka_cluster, create_query_generator, consumer_
             CREATE MATERIALIZED VIEW test.{kafka_table}_view ENGINE=MergeTree ORDER BY tuple() AS SELECT * FROM test.{kafka_table};
             """
         )
-        instance.query_with_retry(f"SELECT count() FROM test.{kafka_table}_view", check_callback=lambda res: int(res) == 4)
+        count = instance.query_with_retry(
+            f"SELECT count() FROM test.{kafka_table}_view",
+            check_callback=lambda res: int(res) == 6,
+        )
+        assert int(count) == 6
 
         instance.query_with_retry(f"DROP TABLE test.{kafka_table}_view SYNC")
 
@@ -3664,7 +3670,6 @@ def test_kafka_consumer_reschedule_validation(kafka_cluster, create_query_genera
         },
     )
     instance.query(create_query)
-
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`test_librdkafka_compression` were missing an `ORDER BY` clause, causing the query result deviate in ordering sometimes.

`test_system_kafka_consumers` was waiting for the wrong number of rows: we produce 4 message, but in total they contain 6 messages.

Real fixes intead of https://github.com/ClickHouse/ClickHouse/pull/95062, cc @alexey-milovidov 

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.26`
<!-- ch-version-info:end -->