### PR TITLE
CI: BackportCI to check PR content is valid

### DIFF
--- a/ci/jobs/scripts/workflow_hooks/check_backport_branch.py
+++ b/ci/jobs/scripts/workflow_hooks/check_backport_branch.py
@@ -1,0 +1,36 @@
+import sys
+from ci.praktika.info import Info
+from ci.praktika.utils import Shell
+
+
+if __name__ == "__main__":
+    info = Info()
+    if info.workflow_name == "BackportPR":
+        assert info.base_branch
+        # Ensure base branch is fetched.
+        # We use treeless fetch (--filter=tree:0) and no-tags to minimize data transfer.
+        Shell.run(
+            f"git fetch --no-tags --prune --no-recurse-submodules --filter=tree:0 origin +{info.base_branch}:{info.base_branch}",
+            verbose=True,
+        )
+        num_commits = int(
+            Shell.get_output_or_raise(
+                f"git rev-list --count {info.base_branch}..{info.sha}"
+            )
+        )
+        if num_commits == 0:
+            print(f"ERROR: No commits found between {info.base_branch} and {info.sha}")
+            sys.exit(-1)
+
+        if num_commits > 50:
+            print(
+                f"ERROR: Number of commits between {info.sha} and {info.base_branch} is {num_commits}. "
+                f"Backport PR should have between 1 and 50 commits."
+            )
+            sys.exit(-1)
+
+        if not info.get_changed_files():
+            print(f"ERROR: No Files changed in the Backport PR.")
+            sys.exit(-1)
+    else:
+        assert False, f"Unsupported workflow name [{info.workflow_name}]"

--- a/ci/workflows/backport_branches.py
+++ b/ci/workflows/backport_branches.py
@@ -56,6 +56,7 @@ workflow = Workflow.Config(
     pre_hooks=[
         "python3 ./ci/jobs/scripts/workflow_hooks/store_data.py",
         "python3 ./ci/jobs/scripts/workflow_hooks/version_log.py",
+        "python3 ./ci/jobs/scripts/workflow_hooks/check_backport_branch.py",
     ],
     workflow_filter_hooks=[should_skip_job],
     post_hooks=[],


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

----
Before automatic merge BackportCI should check:
1. PR does not have too many commits. It's a sign of not squashed auxiliary empty merge-commits.
2. PR has non zero content


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.15`
- Backported to: `26.1.1.898`, `25.11.8.23`, `25.10.6.23`, `25.8.16.17`
<!-- ch-version-info:end -->