### PR TITLE
Fix `test_missing_mv_transitive_target`

### DIFF
--- a/tests/integration/test_kafka_bad_messages/test_mv_target_missing.py
+++ b/tests/integration/test_kafka_bad_messages/test_mv_target_missing.py
@@ -182,8 +182,7 @@ missing_dependencies: [['test.mvother']]
         assert (
             instance.query_with_retry(
                 "SELECT count() FROM test.target2",
-                retry_count=500,
-                sleep_time=0.1,
+                retry_count=100,
                 check_callback=lambda x: int(x) == 2,
             ).strip()
             == "2"
@@ -191,8 +190,7 @@ missing_dependencies: [['test.mvother']]
         assert (
             instance.query_with_retry(
                 "SELECT count() FROM test.target1",
-                retry_count=500,
-                sleep_time=0.1,
+                retry_count=100,
                 check_callback=lambda x: int(x) == 2,
             ).strip()
             == "2"
@@ -315,8 +313,7 @@ missing_dependencies: []
         assert (
             instance.query_with_retry(
                 "SELECT count() FROM test.target2",
-                retry_count=500,
-                sleep_time=0.1,
+                retry_count=100,
                 check_callback=lambda x: int(x) == 2,
             ).strip()
             == "2"

--- a/tests/integration/test_kafka_bad_messages/test_mv_target_missing.py
+++ b/tests/integration/test_kafka_bad_messages/test_mv_target_missing.py
@@ -288,7 +288,7 @@ missing_dependencies: []
         )
 
         # The old table engine will wait for assignment up to MAX_TIME_TO_WAIT_FOR_ASSIGNMENT_MS after the consumer is
-        # created and that is won't be interrupted by flush interval (which make sense, we want to get assignment as
+        # created and that it won't be interrupted by flush interval (which make sense, we want to get assignment as
         # soon as possible, because getting stuck in a rebalance loop is expensive for all consumers in the consumer
         # group, not just for one). Therefore waiting the flush interval seconds will only ensure the new target is
         # picked up the engine after the assignment is done.

--- a/tests/integration/test_kafka_bad_messages/test_mv_target_missing.py
+++ b/tests/integration/test_kafka_bad_messages/test_mv_target_missing.py
@@ -289,7 +289,25 @@ missing_dependencies: []
 """
         )
 
-        # make sure the kafka table engine picked up the views, because it happens at the beginning of the streaming loop
+        # The old table engine will wait for assignment up to MAX_TIME_TO_WAIT_FOR_ASSIGNMENT_MS after the consumer is
+        # created and that is won't be interrupted by flush interval (which make sense, we want to get assignment as
+        # soon as possible, because getting stuck in a rebalance loop is expensive for all consumers in the consumer
+        # group, not just for one). Therefore waiting the flush interval seconds will only ensure the new target is
+        # picked up the engine after the assignment is done.
+
+        # Here we have to make sure the kafka consumer got assignment, because it can wait more than the flush interval,
+        # so let's use `system.kafka_consumers` to ensure that.
+        assigned_partition_count = instance.query_with_retry(
+            "SELECT count() FROM system.kafka_consumers WHERE table='tkafkamiss' AND length(assignments.partition_id) > 0",
+            retry_count=100,
+            check_callback=lambda x: int(x) > 0,
+        )
+        assert (
+            int(assigned_partition_count) > 0
+        ), "Kafka consumer did not get assignment in time"
+
+        # After making sure we have an assignment, let's wait the flush interval to make sure the kafka table engine
+        # picked up the views, because it happens at the beginning of the streaming loop.
         time.sleep(flush_interval_seconds * 1.2)
 
         k.kafka_produce(kafka_cluster, topic, ["1|foo", "2|bar"])


### PR DESCRIPTION
Waiting flush interval only ensures the target table is picked up by the kafka table once assignment is done.

Kind of reverts #95105 but fixes the test properly.
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.10`
<!-- ch-version-info:end -->