### PR TITLE
Fix JSON column size lazy calculation

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -122,6 +122,8 @@ struct DataPartsSharedLock
     DataPartsSharedLock(DataPartsSharedLock &&) = default;
     DataPartsSharedLock & operator=(DataPartsSharedLock &&) = default;
 
+    void unlock() { lock.unlock(); }
+
 private:
     std::optional<Stopwatch> wait_watch;
     std::shared_lock<DB::SharedMutex> lock;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix JSON column size lazy calculation

PR#85535 splits parts lock into read and write, but, it also removes one optimization that is made by #83877, revert it back, since it is likely still make sense.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.20`
<!-- ch-version-info:end -->