### PR TITLE
Get PK size from checksums file instead of filesystem

### DIFF
--- a/src/Storages/MergeTree/IMergeTreeDataPart.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.h
@@ -408,7 +408,7 @@ public:
     UInt64 getIndexGranularityBytes() const;
     UInt64 getIndexGranularityAllocatedBytes() const;
     UInt64 getMarksCount() const;
-    UInt64 getIndexSizeFromFile() const;
+    IndexSize getIndexSizeFromFile() const;
 
     UInt64 getBytesOnDisk() const { return bytes_on_disk; }
     UInt64 getBytesUncompressedOnDisk() const { return bytes_uncompressed_on_disk; }

--- a/src/Storages/System/StorageSystemParts.cpp
+++ b/src/Storages/System/StorageSystemParts.cpp
@@ -199,7 +199,10 @@ void StorageSystemParts::processNextStorage(
         if (columns_mask[src_index++])
             columns[res_index++]->insert(get_columns_size().data_uncompressed);
         if (columns_mask[src_index++])
-            columns[res_index++]->insert(part->getIndexSizeFromFile());
+        {
+            auto index_size = part->getIndexSizeFromFile();
+            columns[res_index++]->insert(index_size.data_compressed > 0 ? index_size.data_compressed : index_size.data_uncompressed);
+        }
         if (columns_mask[src_index++])
             columns[res_index++]->insert(get_columns_size().marks);
         if (columns_mask[src_index++])


### PR DESCRIPTION
Since later I will need uncompressed size for another patch

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)