### PR TITLE
Fix a bug in BuzzHouse when table has no columns (nullptr dereference)

### DIFF
--- a/src/Client/BuzzHouse/Generator/SQLTable.cpp
+++ b/src/Client/BuzzHouse/Generator/SQLTable.cpp
@@ -622,6 +622,11 @@ void StatementGenerator::generateNextTTL(
 void StatementGenerator::pickUpNextCols(RandomGenerator & rg, const SQLTable & t, ColumnPathList * clist)
 {
     flatTableColumnPath(flat_nested | skip_nested_node, t.cols, [](const SQLColumn &) { return true; });
+    if (this->entries.empty())
+    {
+        clist->mutable_col()->mutable_col()->set_column("c0");
+        return;
+    }
     const uint32_t ocols = (rg.nextLargeNumber() % std::min<uint32_t>(static_cast<uint32_t>(this->entries.size()), UINT32_C(4))) + 1;
     std::shuffle(entries.begin(), entries.end(), rg.generator);
     for (uint32_t i = 0; i < ocols; i++)

--- a/src/Client/BuzzHouse/Generator/StatementGenerator.cpp
+++ b/src/Client/BuzzHouse/Generator/StatementGenerator.cpp
@@ -1731,17 +1731,17 @@ std::optional<String> StatementGenerator::alterSingleTable(
         const uint32_t heavy_delete = 30 * static_cast<uint32_t>(no_oracle && t.can_run_merges);
         const uint32_t heavy_update = 40 * static_cast<uint32_t>(can_update && t.can_run_merges);
         const uint32_t add_column = 2 * static_cast<uint32_t>(no_oracle && !t.hasDatabasePeer() && t.cols.size() < fc.max_columns);
-        const uint32_t materialize_column = 2 * static_cast<uint32_t>(t.can_run_merges);
+        const uint32_t materialize_column = 2 * static_cast<uint32_t>(!t.cols.empty() && t.can_run_merges);
         const uint32_t drop_column = 2 * static_cast<uint32_t>(no_oracle && !t.hasDatabasePeer() && !t.cols.empty() && t.can_run_merges);
-        const uint32_t rename_column = 2 * static_cast<uint32_t>(no_oracle && !t.hasDatabasePeer() && t.can_run_merges);
-        const uint32_t clear_column = 2 * static_cast<uint32_t>(t.can_run_merges);
-        const uint32_t modify_column = 2 * static_cast<uint32_t>(no_oracle && !t.hasDatabasePeer() && t.can_run_merges);
-        const uint32_t comment_column = 2;
-        const uint32_t add_stats = 3;
-        const uint32_t mod_stats = 3 * static_cast<uint32_t>(t.can_run_merges);
-        const uint32_t drop_stats = 3 * static_cast<uint32_t>(t.can_run_merges);
-        const uint32_t clear_stats = 3 * static_cast<uint32_t>(t.can_run_merges);
-        const uint32_t mat_stats = 3 * static_cast<uint32_t>(t.can_run_merges);
+        const uint32_t rename_column = 2 * static_cast<uint32_t>(no_oracle && !t.hasDatabasePeer() && !t.cols.empty() && t.can_run_merges);
+        const uint32_t clear_column = 2 * static_cast<uint32_t>(!t.cols.empty() && t.can_run_merges);
+        const uint32_t modify_column = 2 * static_cast<uint32_t>(no_oracle && !t.hasDatabasePeer() && !t.cols.empty() && t.can_run_merges);
+        const uint32_t comment_column = 2 * static_cast<uint32_t>(!t.cols.empty());
+        const uint32_t add_stats = 3 * static_cast<uint32_t>(!t.cols.empty());
+        const uint32_t mod_stats = 3 * static_cast<uint32_t>(!t.cols.empty() && t.can_run_merges);
+        const uint32_t drop_stats = 3 * static_cast<uint32_t>(!t.cols.empty() && t.can_run_merges);
+        const uint32_t clear_stats = 3 * static_cast<uint32_t>(!t.cols.empty() && t.can_run_merges);
+        const uint32_t mat_stats = 3 * static_cast<uint32_t>(!t.cols.empty() && t.can_run_merges);
         const uint32_t delete_mask = 8 * static_cast<uint32_t>(t.can_run_merges);
         const uint32_t add_idx = 2 * static_cast<uint32_t>(no_oracle && t.idxs.size() < 3);
         const uint32_t materialize_idx = 2 * static_cast<uint32_t>(t.can_run_merges && !t.idxs.empty());
@@ -1814,7 +1814,7 @@ std::optional<String> StatementGenerator::alterSingleTable(
             const uint64_t type_mask_backup = this->next_type_mask;
             std::vector<uint32_t> nested_ids;
 
-            if (next_option < 4)
+            if (!t.cols.empty() && next_option < 4)
             {
                 flatTableColumnPath(flat_nested, t.cols, [](const SQLColumn &) { return true; });
                 columnPathRef(rg.pickRandomly(this->entries), add_col->mutable_add_where()->mutable_col());


### PR DESCRIPTION
The crash occurred in `StatementGenerator::columnPathRef` when `pickRandomly` was called on an empty `entries` vector. This happened when operations like `comment_column`, `materialize_column`, etc. were attempted on tables with no columns.

Added `!t.cols.empty()` checks to variable definitions for operations that require existing columns, and added a defensive early return in `pickUpNextCols` for empty entries.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)
