### PR TITLE
Fix rare hanging of ON CLUSTER backups and restores

### DIFF
--- a/src/Backups/BackupCoordinationStageSync.h
+++ b/src/Backups/BackupCoordinationStageSync.h
@@ -87,6 +87,9 @@ private:
     /// Checks that there is no concurrent backup or restore if `allow_concurrency` is false.
     void checkConcurrency(Coordination::ZooKeeperWithFaultInjection::Ptr zookeeper);
 
+    /// Reads the initiator version from ZooKeeper.
+    void readInitiatorVersion();
+
     /// Watching thread periodically reads the current state from ZooKeeper and recreates the 'alive' node.
     void startWatchingThread();
     void stopWatchingThread();
@@ -171,6 +174,7 @@ private:
     const String operation_node_name;
     const String start_node_path;
     const String finish_node_path;
+    const String initiator_start_node_path;
     const String num_hosts_node_path;
     const String error_node_path;
     const String alive_node_path;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix rare hanging of ON CLUSTER backups and restores.

Example of failure in CI:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=95025&sha=de069e3b508e9fb680390c8d584bf736af708430&name_0=PR&name_1=Stateless%20tests%20%28arm_binary%2C%20parallel%29
https://github.com/ClickHouse/ClickHouse/pull/95025


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.155`
<!-- ch-version-info:end -->