### PR TITLE
PromQL: Simplify using decimals in PrometheusQueryTree

### DIFF
--- a/src/Core/DecimalFunctions.h
+++ b/src/Core/DecimalFunctions.h
@@ -118,6 +118,12 @@ inline T multiplyAdd(const T & x, const T & multiplier, const T & delta)
     return res;
 }
 
+template <typename T>
+inline bool tryMultiplyAdd(const T & x, const T & multiplier, const T & delta, T & result)
+{
+    return multiplyAdd<T, false>(x, multiplier, delta, result);
+}
+
 /** Make a decimal value from whole and fractional components with given scale multiplier.
   * where scale_multiplier = scaleMultiplier<T>(scale)
   * this is to reduce number of calls to scaleMultiplier when scale is known.

--- a/src/Parsers/Prometheus/PrometheusQueryParsingUtil-antlr.cpp
+++ b/src/Parsers/Prometheus/PrometheusQueryParsingUtil-antlr.cpp
@@ -198,7 +198,7 @@ namespace
             DurationType duration;
             if (!parseDuration(ctx, duration))
                 return false;
-            result = TimestampType{duration.getValue(), duration.getScale()};
+            result = static_cast<TimestampType>(duration);
             return true;
         }
 
@@ -220,12 +220,12 @@ namespace
 
             if (scalar_or_interval.scalar)
             {
-                result = DurationType{static_cast<Int64>(*scalar_or_interval.scalar * DecimalUtils::scaleMultiplier<Decimal64>(timestamp_scale)), timestamp_scale};
+                result = static_cast<Int64>(*scalar_or_interval.scalar * DecimalUtils::scaleMultiplier<Decimal64>(timestamp_scale));
             }
             else
             {
                 const auto & decimal_field = *scalar_or_interval.interval;
-                result = DurationType{DecimalUtils::convertTo<Decimal64>(timestamp_scale, decimal_field.getValue(), decimal_field.getScale()), timestamp_scale};
+                result = DecimalUtils::convertTo<Decimal64>(timestamp_scale, decimal_field.getValue(), decimal_field.getScale());
             }
 
             return true;
@@ -497,7 +497,7 @@ namespace
                 auto & offset_value = new_node->offset_value.emplace();
                 ok &= parseDuration(number_ctx, offset_value);
                 if (ok && offset_value_ctx->SUB())
-                    offset_value = DurationType{-offset_value.getValue(), offset_value.getScale()};
+                    offset_value = -offset_value;
             }
 
             if (!ok)

--- a/src/Parsers/Prometheus/PrometheusQueryParsingUtil-antlr.cpp
+++ b/src/Parsers/Prometheus/PrometheusQueryParsingUtil-antlr.cpp
@@ -1,6 +1,8 @@
 #include <Parsers/Prometheus/PrometheusQueryParsingUtil.h>
 
 #include <Common/typeid_cast.h>
+#include <Core/DecimalFunctions.h>
+#include <IO/WriteHelpers.h>
 
 #include "config.h"
 
@@ -35,8 +37,8 @@ namespace ErrorCodes
 namespace
 {
     using ScalarType = PrometheusQueryTree::ScalarType;
-    using IntervalType = PrometheusQueryTree::IntervalType;
-    using ScalarOrInterval = PrometheusQueryParsingUtil::ScalarOrInterval;
+    using TimestampType = PrometheusQueryTree::TimestampType;
+    using DurationType = PrometheusQueryTree::DurationType;
     using ResultType = PrometheusQueryResultType;
     using Node = PrometheusQueryTree::Node;
 
@@ -112,8 +114,8 @@ namespace
     class PrometheusQueryTreeBuilder : public antlr4_grammars::PromQLParserBaseVisitor
     {
     public:
-        explicit PrometheusQueryTreeBuilder(std::string_view promql_query_, ErrorListener & error_listener_)
-            : promql_query(promql_query_), error_listener(error_listener_) {}
+        explicit PrometheusQueryTreeBuilder(std::string_view promql_query_, UInt32 timestamp_scale_, ErrorListener & error_listener_)
+            : promql_query(promql_query_), timestamp_scale(timestamp_scale_), error_listener(error_listener_) {}
 
         Node * makeNode(antlr4::ParserRuleContext * expression)
         {
@@ -129,6 +131,7 @@ namespace
 
     private:
         std::string_view promql_query;
+        UInt32 timestamp_scale;
         ErrorListener & error_listener;
         std::vector<std::unique_ptr<Node>> nodes;
 
@@ -148,7 +151,8 @@ namespace
         static size_t getStartPos(const antlr4::ParserRuleContext * ctx) { return ctx->start->getStartIndex(); }
         static size_t getLength(const antlr4::tree::TerminalNode * ctx) { return ctx->getSymbol()->getStopIndex() - ctx->getSymbol()->getStartIndex() + 1; }
         static size_t getLength(const antlr4::ParserRuleContext * ctx) { return ctx->stop->getStopIndex() - ctx->start->getStartIndex() + 1; }
-        std::string_view getText(const antlr4::tree::TerminalNode * ctx) const { return std::string_view{promql_query}.substr(getStartPos(ctx), getLength(ctx)); }
+        std::string_view getText(const antlr4::tree::TerminalNode * ctx) const { return getText(getStartPos(ctx), getLength(ctx)); }
+        std::string_view getText(size_t start_pos, size_t length) const { return std::string_view{promql_query}.substr(start_pos, length); }
 
         bool parseStringLiteral(const antlr4::tree::TerminalNode * ctx, String & result)
         {
@@ -162,26 +166,78 @@ namespace
             return true;
         }
 
-        bool parseScalarOrLiteral(const antlr4::tree::TerminalNode * ctx, ScalarOrInterval & result)
+        bool parseScalar(const antlr4::tree::TerminalNode * ctx, ScalarType & result)
         {
             String error_message;
             size_t error_pos;
-            if (!PrometheusQueryParsingUtil::parseScalarOrInterval(getText(ctx), result, error_message, error_pos))
+            PrometheusQueryParsingUtil::ScalarOrInterval scalar_or_interval;
+            if (!PrometheusQueryParsingUtil::parseScalarOrInterval(getText(ctx), scalar_or_interval, error_message, error_pos))
             {
                 error_listener.setError(error_message, error_pos + getStartPos(ctx));
                 return false;
             }
+
+            if (scalar_or_interval.scalar)
+            {
+                result = *scalar_or_interval.scalar;
+            }
+            else
+            {
+                const auto & decimal_field = *scalar_or_interval.interval;
+                if (!DecimalUtils::tryConvertTo(decimal_field.getValue(), decimal_field.getScale(), result))
+                {
+                    error_listener.setError(fmt::format("Cannot convert {} to scalar", ::DB::toString(decimal_field.getValue(), decimal_field.getScale())), getStartPos(ctx));
+                    return false;
+                }
+            }
             return true;
         }
 
-        bool parseSelectorRange(const antlr4::tree::TerminalNode * ctx, ScalarOrInterval & res_range, size_t & res_start_pos, size_t & res_length)
+        bool parseTimestamp(const antlr4::tree::TerminalNode * ctx, TimestampType & result)
+        {
+            DurationType duration;
+            if (!parseDuration(ctx, duration))
+                return false;
+            result = TimestampType{duration.getValue(), duration.getScale()};
+            return true;
+        }
+
+        bool parseDuration(const antlr4::tree::TerminalNode * ctx, DurationType & result)
+        {
+            return parseDuration(getStartPos(ctx), getLength(ctx), result);
+        }
+
+        bool parseDuration(size_t start_pos, size_t length, DurationType & result)
+        {
+            String error_message;
+            size_t error_pos;
+            PrometheusQueryParsingUtil::ScalarOrInterval scalar_or_interval;
+            if (!PrometheusQueryParsingUtil::parseScalarOrInterval(getText(start_pos, length), scalar_or_interval, error_message, error_pos))
+            {
+                error_listener.setError(error_message, error_pos + start_pos);
+                return false;
+            }
+
+            if (scalar_or_interval.scalar)
+            {
+                result = DurationType{static_cast<Int64>(*scalar_or_interval.scalar * DecimalUtils::scaleMultiplier<Decimal64>(timestamp_scale)), timestamp_scale};
+            }
+            else
+            {
+                const auto & decimal_field = *scalar_or_interval.interval;
+                result = DurationType{DecimalUtils::convertTo<Decimal64>(timestamp_scale, decimal_field.getValue(), decimal_field.getScale()), timestamp_scale};
+            }
+
+            return true;
+        }
+
+        bool parseSelectorRange(const antlr4::tree::TerminalNode * ctx, DurationType & res_range)
         {
             std::string_view sv = getText(ctx);
 
             String error_message;
             size_t error_pos;
             std::string_view range_sv;
-            ScalarOrInterval range;
 
             if (!PrometheusQueryParsingUtil::findTimeRange(sv, range_sv, error_message, error_pos))
             {
@@ -189,22 +245,12 @@ namespace
                 return false;
             }
 
-            if (!PrometheusQueryParsingUtil::parseScalarOrInterval(range_sv, range, error_message, error_pos))
-            {
-                error_listener.setError(error_message, error_pos + getStartPos(ctx) + (range_sv.data() - sv.data()));
-                return false;
-            }
-
-            res_range = range;
-            res_start_pos = getStartPos(ctx) + (range_sv.data() - sv.data());
-            res_length = range_sv.length();
-            return true;
+            size_t range_start_pos = range_sv.data() - promql_query.data();
+            size_t range_length = range_sv.length();
+            return parseDuration(range_start_pos, range_length, res_range);
         }
 
-        bool parseSubqueryRangeAndResolution(const antlr4::tree::TerminalNode * ctx,
-                                             ScalarOrInterval & res_range, size_t & res_range_start_pos, size_t & res_range_length,
-                                             ScalarOrInterval & res_resolution, size_t & res_resolution_start_pos, size_t & res_resolution_length)
-
+        bool parseSubqueryRange(const antlr4::tree::TerminalNode * ctx, DurationType & res_range, std::optional<DurationType> & res_resolution)
         {
             std::string_view sv = getText(ctx);
 
@@ -212,8 +258,6 @@ namespace
             size_t error_pos;
             std::string_view range_sv;
             std::string_view resolution_sv;
-            ScalarOrInterval range;
-            ScalarOrInterval resolution;
 
             if (!PrometheusQueryParsingUtil::findSubqueryRangeAndResolution(sv, range_sv, resolution_sv, error_message, error_pos))
             {
@@ -221,37 +265,33 @@ namespace
                 return false;
             }
 
-            if (!PrometheusQueryParsingUtil::parseScalarOrInterval(range_sv, range, error_message, error_pos))
-            {
-                error_listener.setError(error_message, error_pos + getStartPos(ctx) + (range_sv.data() - sv.data()));
+            size_t range_start_pos = range_sv.data() - promql_query.data();
+            size_t range_length = range_sv.length();
+            if (!parseDuration(range_start_pos, range_length, res_range))
                 return false;
+
+            res_resolution.reset();
+
+            if (!resolution_sv.empty())
+            {
+                size_t resolution_start_pos = resolution_sv.data() - promql_query.data();
+                size_t resolution_length = resolution_sv.length();
+                if (!parseDuration(resolution_start_pos, resolution_length, res_resolution.emplace()))
+                    return false;
             }
 
-            if (!resolution_sv.empty() && !PrometheusQueryParsingUtil::parseScalarOrInterval(resolution_sv, resolution, error_message, error_pos))
-            {
-                error_listener.setError(error_message, error_pos + getStartPos(ctx) + (resolution_sv.data() - sv.data()));
-                return false;
-            }
-
-            res_range = range;
-            res_range_start_pos = getStartPos(ctx) + (range_sv.data() - sv.data());
-            res_range_length = range_sv.length();
-            res_resolution = resolution;
-            res_resolution_start_pos = getStartPos(ctx) + (resolution_sv.data() - sv.data());
-            res_resolution_length = resolution_sv.length();
             return true;
         }
 
         using Matcher = PrometheusQueryTree::Matcher;
         using MatcherType = PrometheusQueryTree::MatcherType;
         using MatcherList = PrometheusQueryTree::MatcherList;
+        using Scalar = PrometheusQueryTree::Scalar;
         using StringLiteral = PrometheusQueryTree::StringLiteral;
-        using ScalarLiteral = PrometheusQueryTree::ScalarLiteral;
-        using IntervalLiteral = PrometheusQueryTree::IntervalLiteral;
         using InstantSelector = PrometheusQueryTree::InstantSelector;
         using RangeSelector = PrometheusQueryTree::RangeSelector;
         using Subquery = PrometheusQueryTree::Subquery;
-        using At = PrometheusQueryTree::At;
+        using Offset = PrometheusQueryTree::Offset;
         using Function = PrometheusQueryTree::Function;
         using UnaryOperator = PrometheusQueryTree::UnaryOperator;
         using BinaryOperator = PrometheusQueryTree::BinaryOperator;
@@ -272,42 +312,19 @@ namespace
         }
 
         /// Makes a node for a scalar or an interval literal after parsing it.
-        Node * makeNodeForScalarOrInterval(antlr4::tree::TerminalNode * ctx, int sign = 1)
+        Node * makeScalar(antlr4::tree::TerminalNode * ctx)
         {
-            PrometheusQueryParsingUtil::ScalarOrInterval scalar_or_interval;
-            if (!parseScalarOrLiteral(ctx, scalar_or_interval))
+            ScalarType scalar;
+            if (!parseScalar(ctx, scalar))
             {
                 chassert(error_listener.hasError());
                 return nullptr;
             }
-            return makeNodeForScalarOrInterval(scalar_or_interval, getStartPos(ctx), getLength(ctx), sign);
-        }
-
-        Node * makeNodeForScalarOrInterval(const ScalarOrInterval & scalar_or_interval, size_t start_pos, size_t length, int sign = 1)
-        {
-            chassert(!scalar_or_interval.empty());
-            if (scalar_or_interval.scalar)
-            {
-                auto scalar = *scalar_or_interval.scalar;
-                if (sign < 0)
-                    scalar = -scalar;
-                auto new_node = std::make_unique<ScalarLiteral>();
-                new_node->start_pos = start_pos;
-                new_node->length = length;
-                new_node->scalar = scalar;
-                return addNode(std::move(new_node));
-            }
-            else
-            {
-                auto interval = *scalar_or_interval.interval;
-                if (sign < 0)
-                    interval = IntervalType{-interval.getValue(), interval.getScale()};
-                auto new_node = std::make_unique<IntervalLiteral>();
-                new_node->start_pos = start_pos;
-                new_node->length = length;
-                new_node->interval = interval;
-                return addNode(std::move(new_node));
-            }
+            auto new_node = std::make_unique<Scalar>();
+            new_node->start_pos = getStartPos(ctx);
+            new_node->length = getLength(ctx);
+            new_node->scalar = scalar;
+            return addNode(std::move(new_node));
         }
 
         /// Extracts a metric name.
@@ -414,19 +431,13 @@ namespace
 
             auto * instant_selector = makeInstantSelector(instant_selector_ctx);
 
-            ScalarOrInterval range;
-            size_t range_start_pos;
-            size_t range_length;
-            if (!instant_selector || !parseSelectorRange(selector_range_ctx, range, range_start_pos, range_length))
+            if (!instant_selector || !parseSelectorRange(selector_range_ctx, new_node->range))
             {
                 chassert(error_listener.hasError());
                 return nullptr;
             }
 
-            auto * range_node = makeNodeForScalarOrInterval(range, range_start_pos, range_length);
-
             addChild(new_node.get(), instant_selector);
-            addChild(new_node.get(), range_node);
             return addNode(std::move(new_node));
         }
 
@@ -440,60 +451,42 @@ namespace
             if (!subquery_range_ctx)
                 throwInconsistentSchema("SubqueryOp", ctx->getText());
 
-            ScalarOrInterval range;
-            ScalarOrInterval resolution;
-            size_t range_start_pos;
-            size_t range_length;
-            size_t resolution_start_pos;
-            size_t resolution_length;
-            if (!parseSubqueryRangeAndResolution(subquery_range_ctx, range, range_start_pos, range_length, resolution, resolution_start_pos, resolution_length))
+            if (!parseSubqueryRange(subquery_range_ctx, new_node->range, new_node->resolution))
             {
                 chassert(error_listener.hasError());
                 return nullptr;
             }
 
-            auto * range_node = makeNodeForScalarOrInterval(range, range_start_pos, range_length);
-
-            Node * resolution_node = nullptr;
-            if (!resolution.empty())
-                resolution_node = makeNodeForScalarOrInterval(resolution, resolution_start_pos, resolution_length);
-
             addChild(new_node.get(), expression);
-            addChild(new_node.get(), range_node);
-
-            if (resolution_node)
-                addChild(new_node.get(), resolution_node);
 
             auto * res_node = addNode(std::move(new_node));
 
             if (auto * offset_op_ctx = ctx->offsetOp())
             {
                 res_node->length -= getLength(offset_op_ctx);
-                res_node = makeAt(offset_op_ctx, res_node);
+                res_node = makeOffset(offset_op_ctx, res_node);
             }
 
             return res_node;
         }
 
         /// Makes a node for [@ timestamp][offset <offset>],
-        Node * makeAt(antlr4_grammars::PromQLParser::OffsetOpContext * ctx, Node * expression)
+        Node * makeOffset(antlr4_grammars::PromQLParser::OffsetOpContext * ctx, Node * expression)
         {
-            auto new_node = std::make_unique<At>();
+            auto new_node = std::make_unique<Offset>();
             new_node->start_pos = expression->start_pos;
             new_node->length = expression->length + getLength(ctx);
             new_node->result_type = expression->result_type;
 
             bool ok = true;
-            Node * at_node = nullptr;
-            Node * offset_node = nullptr;
 
             if (auto * timestamp_ctx = ctx->timestamp())
             {
                 auto * number_ctx = timestamp_ctx->NUMBER();
                 if (!number_ctx)
                     throwInconsistentSchema("OffsetOp", ctx->getText());
-                at_node = makeNodeForScalarOrInterval(number_ctx);
-                ok &= (at_node != nullptr);
+                auto & timestamp = new_node->at_timestamp.emplace();
+                ok &= parseTimestamp(number_ctx, timestamp);
             }
 
             if (auto * offset_value_ctx = ctx->offsetValue())
@@ -501,9 +494,10 @@ namespace
                 auto * number_ctx = offset_value_ctx->NUMBER();
                 if (!number_ctx)
                     throwInconsistentSchema("OffsetOp", ctx->getText());
-                int sign = offset_value_ctx->SUB() ? -1 : 1;
-                offset_node = makeNodeForScalarOrInterval(number_ctx, sign);
-                ok &= (offset_node != nullptr);
+                auto & offset_value = new_node->offset_value.emplace();
+                ok &= parseDuration(number_ctx, offset_value);
+                if (ok && offset_value_ctx->SUB())
+                    offset_value = DurationType{-offset_value.getValue(), offset_value.getScale()};
             }
 
             if (!ok)
@@ -513,19 +507,6 @@ namespace
             }
 
             addChild(new_node.get(), expression);
-
-            if (at_node)
-            {
-                new_node->at_index = new_node->children.size();
-                addChild(new_node.get(), at_node);
-            }
-
-            if (offset_node)
-            {
-                new_node->offset_index = new_node->children.size();
-                addChild(new_node.get(), offset_node);
-            }
-
             return addNode(std::move(new_node));
         }
 
@@ -770,7 +751,7 @@ namespace
         std::any visitLiteral(antlr4_grammars::PromQLParser::LiteralContext * ctx) override
         {
             if (auto * number_ctx = ctx->NUMBER())
-                return makeNodeForScalarOrInterval(number_ctx);
+                return makeScalar(number_ctx);
             else if (auto * string_ctx = ctx->STRING())
                 return makeStringLiteral(string_ctx);
             else
@@ -807,7 +788,7 @@ namespace
             if (!offset_op_ctx)
                 throwInconsistentSchema("Offset", ctx->getText());
 
-            res_node = makeAt(offset_op_ctx, res_node);
+            res_node = makeOffset(offset_op_ctx, res_node);
             return res_node;
         }
 
@@ -962,7 +943,7 @@ namespace
             Node * node = anyToNodePtr(aggregate);
             Node * next_node = anyToNodePtr(next_result);
             if (node && next_node)
-                throw Exception(ErrorCodes::LOGICAL_ERROR, "Can't aggregate\n{}and\n{}", node->dumpNode(1), next_node->dumpNode(1));
+                throw Exception(ErrorCodes::LOGICAL_ERROR, "Can't aggregate nodes {} and {}", node->node_type, next_node->node_type);
             if (node)
                 return node;
             else
@@ -973,7 +954,7 @@ namespace
 
 #endif
 
-bool PrometheusQueryParsingUtil::parseQuery([[maybe_unused]] std::string_view input, [[maybe_unused]] PrometheusQueryTree & result, [[maybe_unused]] String & error_message, [[maybe_unused]] size_t & error_pos)
+bool PrometheusQueryParsingUtil::parseQuery([[maybe_unused]] std::string_view input, [[maybe_unused]] UInt32 timestamp_scale, [[maybe_unused]] PrometheusQueryTree & result, [[maybe_unused]] String & error_message, [[maybe_unused]] size_t & error_pos)
 {
 #if USE_ANTLR4_GRAMMARS
     ErrorListener error_listener{input};
@@ -996,7 +977,7 @@ bool PrometheusQueryParsingUtil::parseQuery([[maybe_unused]] std::string_view in
     if (!expression)
         error_listener.setError("Couldn't get an expression after parsing promql query", 0);
 
-    PrometheusQueryTreeBuilder builder{input, error_listener};
+    PrometheusQueryTreeBuilder builder{input, timestamp_scale, error_listener};
     std::vector<std::unique_ptr<Node>> parsed_nodes;
     Node * parsed_root = nullptr;
     if (expression && !error_listener.hasError())
@@ -1015,7 +996,7 @@ bool PrometheusQueryParsingUtil::parseQuery([[maybe_unused]] std::string_view in
     if (!parsed_root)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Parsing promql query '{}' failed without setting any error message", input);
 
-    result = PrometheusQueryTree{String{input}, parsed_root, std::move(parsed_nodes)};
+    result = PrometheusQueryTree{String{input}, timestamp_scale, parsed_root, std::move(parsed_nodes)};
     return true;
 #else
     throw Exception(ErrorCodes::SUPPORT_IS_DISABLED, "ANTLR4 support is disabled");

--- a/src/Parsers/Prometheus/PrometheusQueryParsingUtil.cpp
+++ b/src/Parsers/Prometheus/PrometheusQueryParsingUtil.cpp
@@ -2,10 +2,11 @@
 
 #include <Common/UTF8Helpers.h>
 #include <Common/quoteString.h>
-#include <IO/ReadBufferFromMemory.h>
+#include <IO/ReadBufferFromString.h>
 #include <IO/ReadHelpers.h>
 #include <IO/readDecimalText.h>
 #include <IO/readIntText.h>
+#include <boost/algorithm/string/predicate.hpp>
 
 
 namespace DB
@@ -13,11 +14,24 @@ namespace DB
 
 namespace
 {
-    /// Parses escape sequences in a string literal and replaces them with the characters which they mean.
-    bool unescapeStringLiteral(std::string_view input, String & result, String & error_message, size_t & error_pos)
+    template<class... Types>
+    void setErrorMessage(String * error_message, fmt::format_string<Types...> format, Types&&... args)
     {
-        result.clear();
-        result.reserve(input.length());
+        if (error_message)
+            *error_message = fmt::format(format, std::forward<Types>(args)...);
+    }
+
+    void setErrorPos(size_t * error_pos, size_t value)
+    {
+        if (error_pos)
+            *error_pos = value;
+    }
+
+    /// Parses escape sequences in a string literal and replaces them with the characters which they mean.
+    bool tryUnescapeStringLiteral(std::string_view input, String & res_string, String * error_message, size_t * error_pos)
+    {
+        res_string.clear();
+        res_string.reserve(input.length());
 
         for (size_t pos = 0; pos < input.length();)
         {
@@ -25,7 +39,7 @@ namespace
             if (next_pos == String::npos)
                 next_pos = input.length();
 
-            result.append(input.substr(pos, next_pos - pos));
+            res_string.append(input.substr(pos, next_pos - pos));
             pos = next_pos;
 
             if (pos >= input.length())
@@ -34,9 +48,10 @@ namespace
             /// An escape sequences contains at least 2 characters.
             if (pos + 2 > input.length())
             {
-                error_message = fmt::format("Invalid escape sequence {}: Expected at least 2 characters",
-                                            quoteString(input.substr(pos)));
-                error_pos = pos;
+                setErrorMessage(error_message,
+                                "Invalid escape sequence {}: Expected at least 2 characters",
+                                quoteString(input.substr(pos)));
+                setErrorPos(error_pos, pos);
                 return false;
             }
 
@@ -45,36 +60,36 @@ namespace
 
             switch (c)
             {
-                case 'a':  result.push_back(0x07); pos += 2; break;  /// \a  U+0007 alert or bell
-                case 'b':  result.push_back(0x08); pos += 2; break;  /// \b  U+0008 backspace
-                case 'f':  result.push_back(0x0C); pos += 2; break;  /// \f  U+000C form feed
-                case 'n':  result.push_back(0x0A); pos += 2; break;  /// \n  U+000A line feed or newline
-                case 'r':  result.push_back(0x0D); pos += 2; break;  /// \r  U+000D carriage return
-                case 't':  result.push_back(0x09); pos += 2; break;  /// \t  U+0009 horizontal tab
-                case 'v':  result.push_back(0x0B); pos += 2; break;  /// \v  U+000B vertical tab
-                case '\\': result.push_back('\''); pos += 2; break;  /// \\  U+005C backslash
-                case '\'': result.push_back('\''); pos += 2; break;  /// \'  U+0027 single quote
-                case '"':  result.push_back('"');  pos += 2; break;  /// \"  U+0022 double quote
+                case 'a':  res_string.push_back(0x07); pos += 2; break;  /// \a  U+0007 alert or bell
+                case 'b':  res_string.push_back(0x08); pos += 2; break;  /// \b  U+0008 backspace
+                case 'f':  res_string.push_back(0x0C); pos += 2; break;  /// \f  U+000C form feed
+                case 'n':  res_string.push_back(0x0A); pos += 2; break;  /// \n  U+000A line feed or newline
+                case 'r':  res_string.push_back(0x0D); pos += 2; break;  /// \r  U+000D carriage return
+                case 't':  res_string.push_back(0x09); pos += 2; break;  /// \t  U+0009 horizontal tab
+                case 'v':  res_string.push_back(0x0B); pos += 2; break;  /// \v  U+000B vertical tab
+                case '\\': res_string.push_back('\''); pos += 2; break;  /// \\  U+005C backslash
+                case '\'': res_string.push_back('\''); pos += 2; break;  /// \'  U+0027 single quote
+                case '"':  res_string.push_back('"');  pos += 2; break;  /// \"  U+0022 double quote
                 case 'x':
                 {
                     /// \x followed by exactly two hexadecimal digits represents a single byte.
                     /// Example: \x51 is the 'Q' letter.
                     if (pos + 4 > input.length())
                     {
-                        error_message = fmt::format("Invalid escape sequence {}: Expected 4 characters",
-                                                    quoteString(input.substr(pos)));
-                        error_pos = pos;
+                        setErrorMessage(error_message, "Invalid escape sequence {}: Expected 4 characters", quoteString(input.substr(pos)));
+                        setErrorPos(error_pos, pos);
                         return false;
                     }
                     char byte;
                     if (!tryParseIntInBase<16>(byte, input.substr(pos + 2, 2)))
                     {
-                        error_message = fmt::format("Invalid escape sequence {}: Cannot parse a hexadecimal number representing a single byte",
-                                                    quoteString(input.substr(pos, 4)));
-                        error_pos = pos;
+                        setErrorMessage(error_message,
+                                        "Invalid escape sequence {}: Cannot parse a hexadecimal number representing a single byte",
+                                        quoteString(input.substr(pos, 4)));
+                        setErrorPos(error_pos, pos);
                         return false;
                     }
-                    result.push_back(byte);
+                    res_string.push_back(byte);
                     pos += 4;
                     break;
                 }
@@ -91,27 +106,28 @@ namespace
                     /// Example: \121 is the 'Q' letter.
                     if (pos + 4 > input.length())
                     {
-                        error_message = fmt::format("Invalid escape sequence {}: Expected 4 characters",
-                                                    quoteString(input.substr(pos)));
-                        error_pos = pos;
+                        setErrorMessage(error_message, "Invalid escape sequence {}: Expected 4 characters", quoteString(input.substr(pos)));
+                        setErrorPos(error_pos, pos);
                         return false;
                     }
                     UInt16 byte;
                     if (!tryParseIntInBase<8>(byte, input.substr(pos + 1, 3)))
                     {
-                        error_message = fmt::format("Invalid escape sequence {}: Cannot parse an octal number representing a single byte",
-                                                    quoteString(input.substr(pos, 4)));
-                        error_pos = pos;
+                        setErrorMessage(error_message,
+                                        "Invalid escape sequence {}: Cannot parse an octal number representing a single byte",
+                                        quoteString(input.substr(pos, 4)));
+                        setErrorPos(error_pos, pos);
                         return false;
                     }
                     if (byte > 0xFF)
                     {
-                        error_message = fmt::format("Invalid escape sequence {}: An octal representation \nnn must represent a single byte",
-                                                    quoteString(input.substr(pos, 4)));
-                        error_pos = pos;
+                        setErrorMessage(error_message,
+                                        "Invalid escape sequence {}: An octal representation \nnn must represent a single byte",
+                                        quoteString(input.substr(pos, 4)));
+                        setErrorPos(error_pos, pos);
                         return false;
                     }
-                    result.push_back(static_cast<char>(byte));
+                    res_string.push_back(static_cast<char>(byte));
                     pos += 4;
                     break;
                 }
@@ -121,22 +137,22 @@ namespace
                     /// Example: \u0051 is the 'Q' letter.
                     if (pos + 6 > input.length())
                     {
-                        error_message = fmt::format("Invalid escape sequence {}: Expected 6 characters",
-                                                    quoteString(input.substr(pos)));
-                        error_pos = pos;
+                        setErrorMessage(error_message, "Invalid escape sequence {}: Expected 6 characters", quoteString(input.substr(pos)));
+                        setErrorPos(error_pos, pos);
                         return false;
                     }
                     UInt16 code_point;
                     if (!tryParseIntInBase<16>(code_point, input.substr(pos + 2, 4)))
                     {
-                        error_message = fmt::format("Invalid escape sequence {}: Cannot parse a hexadecimal number representing a Unicode code point",
-                                                    quoteString(input.substr(pos, 6)));
-                        error_pos = pos;
+                        setErrorMessage(error_message,
+                                        "Invalid escape sequence {}: Cannot parse a hexadecimal number representing a Unicode code point",
+                                        quoteString(input.substr(pos, 6)));
+                        setErrorPos(error_pos, pos);
                         return false;
                     }
                     char bytes[3];  /// 3 bytes is enough to represent a Unicode code point up to 0xFFFF.
                     size_t num_bytes = UTF8::convertCodePointToUTF8(code_point, bytes, sizeof(bytes));
-                    result.append(bytes, num_bytes);
+                    res_string.append(bytes, num_bytes);
                     pos += 6;
                     break;
                 }
@@ -146,36 +162,38 @@ namespace
                     /// Example: \U00000051 is the 'Q' letter.
                     if (pos + 10 > input.length())
                     {
-                        error_message = fmt::format("Invalid escape sequence {}: Expected 10 characters",
-                                                    quoteString(input.substr(pos)));
-                        error_pos = pos;
+                        setErrorMessage(
+                            error_message, "Invalid escape sequence {}: Expected 10 characters", quoteString(input.substr(pos)));
+                        setErrorPos(error_pos, pos);
                         return false;
                     }
                     UInt32 code_point;
                     if (!tryParseIntInBase<16>(code_point, input.substr(pos + 2, 8)))
                     {
-                        error_message = fmt::format("Invalid escape sequence {}: Cannot parse a hexadecimal number representing a Unicode code point",
-                                                    quoteString(input.substr(pos, 10)));
-                        error_pos = pos;
+                        setErrorMessage(error_message,
+                                        "Invalid escape sequence {}: Cannot parse a hexadecimal number representing a Unicode code point",
+                                        quoteString(input.substr(pos, 10)));
+                        setErrorPos(error_pos, pos);
                         return false;
                     }
                     if (code_point > 0x10FFFF)  /// There should be no Unicode code point beyond 0x10FFFF.
                     {
-                        error_message = fmt::format("Invalid escape sequence {}: A Unicode code point can't be greater than 0x10FFFF",
-                                                    quoteString(input.substr(pos, 10)));
-                        error_pos = pos;
+                        setErrorMessage(error_message,
+                                        "Invalid escape sequence {}: A Unicode code point can't be greater than 0x10FFFF",
+                                        quoteString(input.substr(pos, 10)));
+                        setErrorPos(error_pos, pos);
                         return false;
                     }
                     char bytes[4];  /// 4 bytes is enough to represent a Unicode code point up to 0xFFFF.
                     size_t num_bytes = UTF8::convertCodePointToUTF8(code_point, bytes, sizeof(bytes));
-                    result.append(bytes, num_bytes);
+                    res_string.append(bytes, num_bytes);
                     pos += 10;
                     break;
                 }
                 default:
                 {
-                    error_message = fmt::format("Invalid escape sequence {}", quoteString(input.substr(pos)));
-                    error_pos = pos;
+                    setErrorMessage(error_message, "Invalid escape sequence {}", quoteString(input.substr(pos)));
+                    setErrorPos(error_pos, pos);
                     return false;
                 }
             }
@@ -185,15 +203,17 @@ namespace
 }
 
 /// Converts a quoted string literal to its unquoted version.
-bool PrometheusQueryParsingUtil::parseStringLiteral(std::string_view input, String & result,
-                                                    String & error_message, size_t & error_pos)
+bool PrometheusQueryParsingUtil::tryParseStringLiteral(
+    std::string_view input, String & res_string, String * error_message, size_t * error_pos)
 {
-    result.clear();
+    res_string.clear();
 
     if (!input.starts_with('\'') && !input.starts_with('\"') && !input.starts_with('`'))
     {
-        error_message = fmt::format("Cannot parse string literal {}: A string literal must open with a quote ', a double quote \" or a backtick `", input);
-        error_pos = 0;
+        setErrorMessage(error_message,
+                        "Cannot parse string literal {}: A string literal must open with a quote ', a double quote \" or a backtick `",
+                        input);
+        setErrorPos(error_pos, 0);
         return false;
     }
 
@@ -202,8 +222,8 @@ bool PrometheusQueryParsingUtil::parseStringLiteral(std::string_view input, Stri
     if ((input.length() < 2) || !input.ends_with(quote_char))
     {
         std::string_view quote_char_name = (quote_char == '\'') ? "quote" : ((quote_char == '\"') ? "double quote" : "backtick");
-        error_message = fmt::format("Cannot parse string literal {}: No closing {} {}", input, quote_char_name, quote_char);
-        error_pos = input.length() - 1;
+        setErrorMessage(error_message, "Cannot parse string literal {}: No closing {} {}", input, quote_char_name, quote_char);
+        setErrorPos(error_pos, input.length() - 1);
         return false;
     }
 
@@ -213,19 +233,20 @@ bool PrometheusQueryParsingUtil::parseStringLiteral(std::string_view input, Stri
         size_t closing_backtick = input.find('`', 1);
         if (closing_backtick != input.length() - 1)
         {
-            error_message = fmt::format("Cannot parse string literal {}: A string literal in backticks can't contain other backticks", input);
-            error_pos = closing_backtick;
+            setErrorMessage(error_message, "Cannot parse string literal {}: A string literal in backticks can't contain other backticks", input);
+            setErrorPos(error_pos, closing_backtick);
             return false;
         }
-        result = input.substr(1, input.length() - 2);
+        res_string = input.substr(1, input.length() - 2);
         return true;
     }
 
     /// A string literal enclosed in quotes or double quotes: escape sequences need to be parsed.
     std::string_view unquoted = input.substr(1, input.length() - 2);
-    if (!unescapeStringLiteral(unquoted, result, error_message, error_pos))
+    if (!tryUnescapeStringLiteral(unquoted, res_string, error_message, error_pos))
     {
-        ++error_pos;
+        if (error_pos)
+            ++*error_pos;
         return false;
     }
 
@@ -238,7 +259,8 @@ namespace
     /// Also we allow an underscore between prefix "0x" and hexadecimal digits, for example "0x_1_2_3" is allowed
     /// (because it's allowed in Prometheus).
     /// The function returns String::npos if not found.
-    size_t findUnderscoreBetweenDigits(std::string_view str, bool is_hex, size_t start_pos)
+    template <bool is_hex>
+    size_t findUnderscoreBetweenDigits(std::string_view str, size_t start_pos)
     {
         chassert(start_pos <= str.length());
         size_t pos = str.find('_', start_pos);
@@ -250,7 +272,7 @@ namespace
                 char after = str[pos + 1];
 
                 bool between_digits;
-                if (is_hex)
+                if constexpr (is_hex)
                     between_digits = (std::isxdigit(before) || (std::tolower(before) == 'x')) && std::isxdigit(after);
                 else
                     between_digits = std::isdigit(before) && std::isdigit(after);
@@ -265,14 +287,15 @@ namespace
 
     /// Removes all underscores between digits (or two hexadecimal digits if `is_hex` is true).
     /// For example, the function converts "1000_000_000" to "1000000000", "0x23_F_B" to "0x23FB" (with is_hex == true).
-    String removeUnderscoresBetweenDigits(std::string_view input, bool is_hex)
+    template <bool is_hex>
+    String removeUnderscoresBetweenDigits(std::string_view input)
     {
         String result;
         result.reserve(input.length());
         size_t pos = 0;
         while (pos != input.length())
         {
-            size_t underscore_pos = findUnderscoreBetweenDigits(input, is_hex, pos);
+            size_t underscore_pos = findUnderscoreBetweenDigits<is_hex>(input, pos);
             if (underscore_pos == String::npos)
             {
                 result.append(input.substr(pos));
@@ -284,19 +307,59 @@ namespace
         return result;
     }
 
+    using ScalarType = PrometheusQueryParsingUtil::ScalarType;
+    using TimestampType = PrometheusQueryParsingUtil::TimestampType;
+    using DurationType = PrometheusQueryParsingUtil::DurationType;
+
+    template <typename T>
+    std::string_view getTypeName()
+    {
+        if constexpr (std::is_same_v<T, TimestampType>)
+            return "timestamp";
+        else if constexpr (std::is_same_v<T, DurationType>)
+            return "duration";
+        else
+            return "number";
+    }
+
     /// Parses an unsigned scalar in number format, for example "1000" or "1_000" or "5.67" or "2e10" or "Inf" or "Nan".
     /// Underscores between digits are ignored.
     template <typename T>
-    bool parseNumber(std::string_view input, T & result, String & error_message, size_t & error_pos)
+    bool tryParseNumberFormat(std::string_view input, UInt32 scale, T & result, String * error_message, size_t * error_pos)
     {
         /// Remove underscores between digits if necessary.
-        String str = removeUnderscoresBetweenDigits(input, /* is_hex = */ false);
+        String str = removeUnderscoresBetweenDigits</* is_hex = */ false>(input);
 
-        if (!tryParse(result, str))
+        if constexpr (is_decimal<T>)
         {
-            error_message = fmt::format("Cannot parse number {}", quoteString(str));
-            error_pos = 0;
-            return false;
+            if (boost::iequals(input, "Inf") || boost::iequals(input, "NaN"))
+            {
+                setErrorMessage(error_message, "Cannot parse {} {}: Should be finite", getTypeName<T>(), quoteString(input));
+                setErrorPos(error_pos, 0);
+                return false;
+            }
+
+            ReadBufferFromString buf(str);
+
+            UInt32 target_scale = scale;
+            if (!tryReadDecimalText(buf, result, DecimalUtils::max_precision<T>, target_scale))
+            {
+                setErrorMessage(error_message, "Cannot parse {} {}", getTypeName<T>(), quoteString(str));
+                setErrorPos(error_pos, 0);
+                return false;
+            }
+
+            /// tryReadDecimalText() has already checked for overflow.
+            result *= DecimalUtils::scaleMultiplier<Decimal64>(target_scale);
+        }
+        else
+        {
+            if (!tryParse(result, str))
+            {
+                setErrorMessage(error_message, "Cannot parse {} {}", getTypeName<T>(), quoteString(str));
+                setErrorPos(error_pos, 0);
+                return false;
+            }
         }
 
         return true;
@@ -305,8 +368,8 @@ namespace
     /// Whether this input is a hexadecimal number with prefix '0x' or "0X".
     bool isHexFormat(std::string_view input)
     {
-        bool found_hex_prefix = (input.length() >= 2) && (input[0] == '0') && (std::tolower(input[1]) == 'x');
-        return found_hex_prefix;
+        bool has_hex_prefix = (input.length() >= 2) && (input[0] == '0') && (std::tolower(input[1]) == 'x');
+        return has_hex_prefix;
     }
 
     /// Tries to parse an unsigned scalar in hex format, for example "0x23_F_B".
@@ -314,36 +377,49 @@ namespace
     /// If it succeeds the function returns true and sets `result`.
     /// If it fails the function returns false and sets either `allow_other_formats` or `error_pos` & `error_message`.
     template <typename T>
-    bool parseNumberInHex(std::string_view input, T & result, String & error_message, size_t & error_pos)
+    bool tryParseHexFormat(std::string_view input, UInt32 scale, T & result, String * error_message, size_t * error_pos)
     {
-        bool found_hex_prefix = (input.length() >= 2) && (input[0] == '0') && (std::tolower(input[1]) == 'x');
-        if (!found_hex_prefix)
+        bool has_hex_prefix = (input.length() >= 2) && (input[0] == '0') && (std::tolower(input[1]) == 'x');
+        if (!has_hex_prefix)
         {
             /// No prefix "0x" is in the `input`, but we can still try other scalar formats.
-            error_message = fmt::format("Cannot parse hexadecimal number {}: Expected prefix '0x'", quoteString(input));
-            error_pos = 0;
+            setErrorMessage(error_message, "Cannot parse {} {} in hexadecimal format: Expected prefix '0x'", getTypeName<T>(), quoteString(input));
+            setErrorPos(error_pos, 0);
             return false;
         }
 
         /// Remove prefix "0x" and underscores between digits.
-        String str = removeUnderscoresBetweenDigits(input, /* is_hex = */ true);
+        String str = removeUnderscoresBetweenDigits</* is_hex = */ true>(input);
         std::string_view hex_without_prefix = std::string_view{str}.substr(2);
 
         /// Parse hexadecimal number.
         Int64 value;
         if (!tryParseIntInBase<16>(value, hex_without_prefix))
         {
-            error_message = fmt::format("Cannot parse hexadecimal number {}", quoteString(str));
-            error_pos = 2;
+            setErrorMessage(error_message, "Cannot parse {} {} in hexadecimal format", getTypeName<T>(), quoteString(str));
+            setErrorPos(error_pos, 2);
             return false;
         }
 
-        result = static_cast<T>(value);
+        if constexpr (is_decimal<T>)
+        {
+            if (common::mulOverflow(value, DecimalUtils::scaleMultiplier<T>(scale), result.value))
+            {
+                setErrorMessage(error_message, "Cannot parse {} {} in hexadecimal format: Overflow, the number is too big", getTypeName<T>(), quoteString(input));
+                setErrorPos(error_pos, 0);
+                return false;
+            }
+        }
+        else
+        {
+            result = static_cast<T>(value);
+        }
+
         return true;
     }
 
-    /// Whether this input represents an interval, i.e. it contains time units.
-    bool isIntervalFormat(std::string_view input)
+    /// Whether this input represents a duration, i.e. it contains time units.
+    bool isDurationFormat(std::string_view input)
     {
         bool found_time_unit = (input.find_first_of("ywdhms") != String::npos);
         return found_time_unit;
@@ -353,13 +429,11 @@ namespace
     /// If it succeeds the function returns true and sets `result`.
     /// If it fails the function returns false and sets either `allow_other_formats` or `error_pos` & `error_message`.
     template <typename T>
-    bool parseInterval(std::string_view input, T & result, String & error_message, size_t & error_pos)
+    bool tryParseDurationFormat(std::string_view input, UInt32 scale, T & result, String * error_message, size_t * error_pos)
     {
-        Decimal64 current = 0;
-        UInt32 current_scale = 0;
-
-        Decimal64 previous_unit = 0;
-        std::string_view previous_unit_name;
+        bool has_time_units = false;
+        Int64 seconds = 0;
+        Int64 milliseconds = 0;
 
         /// Iterate through all {number, time unit} pairs.
         size_t pos = 0;
@@ -371,9 +445,10 @@ namespace
 
             if (pos == number_start_pos)
             {
-                error_message = fmt::format("Cannot parse time duration {}: Expected a number combined with a time unit, got {}",
-                                            quoteString(input), quoteString(input.substr(pos)));
-                error_pos = pos;
+                setErrorMessage(error_message,
+                                "Cannot parse {} {} in duration format: Expected a number combined with a time unit, got {}",
+                                getTypeName<T>(), quoteString(input), quoteString(input.substr(pos)));
+                setErrorPos(error_pos, pos);
                 return false;
             }
 
@@ -381,8 +456,10 @@ namespace
             std::string_view number_as_str = input.substr(number_start_pos, pos - number_start_pos);
             if (!tryParse(number, number_as_str))
             {
-                error_message = fmt::format("Cannot parse time duration {}: Number {} is too big", quoteString(input), number_as_str);
-                error_pos = number_start_pos;
+                setErrorMessage(error_message,
+                                "Cannot parse {} {} in duration format: Overflow, the number {} is too big",
+                                getTypeName<T>(), quoteString(input), number_as_str);
+                setErrorPos(error_pos, number_start_pos);
                 return false;
             }
 
@@ -391,179 +468,203 @@ namespace
                 ++pos;
 
             std::string_view unit_name = input.substr(unit_start_pos, pos - unit_start_pos);
-            Decimal64 unit = 0;
-            UInt32 unit_scale = 0;
+            has_time_units = true;
+
+            Int64 seconds_per_unit = 0;
+            Int64 ms_per_unit = 0;
 
             if (unit_name == "y")
-                unit.value = 365ULL * 24 * 60 * 60;  /// 1y equals 365d (ignoring leap days)
+                seconds_per_unit = 365ULL * 24 * 60 * 60;  /// 1y equals 365d (ignoring leap days)
             else if (unit_name == "w")
-                unit.value = 7 * 24 * 60 * 60;  /// 1w equals 7d
+                seconds_per_unit = 7 * 24 * 60 * 60;  /// 1w equals 7d
             else if (unit_name == "d")
-                unit.value = 24 * 60 * 60;  /// 1d equals 24h
+                seconds_per_unit = 24 * 60 * 60;  /// 1d equals 24h
             else if (unit_name == "h")
-                unit.value = 60 * 60;  /// 1h equals 60m
+                seconds_per_unit = 60 * 60;  /// 1h equals 60m
             else if (unit_name == "m")
-                unit.value = 60;  /// 1m equals 60s
+                seconds_per_unit = 60;  /// 1m equals 60s
             else if (unit_name == "s")
-                unit.value = 1;  /// 1s equals 1000ms
+                seconds_per_unit = 1;  /// 1s equals 1000ms
             else if (unit_name == "ms")
-            {
-                /// milliseconds
-                unit.value = 1;
-                unit_scale = 3;
-            }
+                ms_per_unit = 1;
             else
             {
-                error_message = fmt::format("Cannot parse time duration {}: Expected one of the supported time units ('y', 'w', 'd', 'h', 'm', 's', 'ms'), got {}",
-                                            quoteString(input), quoteString(unit_name));
-                error_pos = unit_start_pos;
+                setErrorMessage(error_message,
+                                "Cannot parse {} {} in duration format: Expected one of the supported time units ('y', 'w', 'd', 'h', 'm', 's', 'ms'), got {}",
+                                getTypeName<T>(), quoteString(input), quoteString(unit_name));
+                setErrorPos(error_pos, unit_start_pos);
                 return false;
             }
 
-            if (unit_scale < current_scale)
+            if (seconds_per_unit)
             {
-                unit.value *= DecimalUtils::scaleMultiplier<Int64>(current_scale - unit_scale);
-            }
-            else if (unit_scale > current_scale)
-            {
-                auto scale_multiplier = DecimalUtils::scaleMultiplier<Int64>(unit_scale - current_scale);
-                if (common::mulOverflow(current.value, scale_multiplier, current.value))
+                if (!DecimalUtils::tryMultiplyAdd(number, seconds_per_unit, seconds, seconds))
                 {
-                    error_message = fmt::format("Cannot parse time duration {}: It's too big", quoteString(input));
-                    error_pos = 0;
+                    setErrorMessage(error_message,
+                                    "Cannot parse {} {} in duration format: Overflow, the duration is too big",
+                                    getTypeName<T>(), quoteString(input));
+                    setErrorPos(error_pos, 0);
                     return false;
                 }
-                previous_unit.value *= scale_multiplier;
-                current_scale = unit_scale;
             }
 
-            if (previous_unit && (unit >= previous_unit))
+            if (ms_per_unit)
             {
-                error_message = fmt::format("Cannot parse time duration {}: Time units must be ordered from the longest to the shortest: {} must appear before {}",
-                                            quoteString(input), quoteString(unit_name), quoteString(previous_unit_name));
-                error_pos = unit_start_pos;
-                return false;
+                if (!DecimalUtils::tryMultiplyAdd(number, ms_per_unit, milliseconds, milliseconds))
+                {
+                    setErrorMessage(error_message,
+                                    "Cannot parse {} {} in duration format: Overflow, the duration is too big",
+                                    getTypeName<T>(), quoteString(input));
+                    setErrorPos(error_pos, 0);
+                    return false;
+                }
             }
-
-            Decimal64 add;
-            bool overflow = common::mulOverflow(number, unit.value, add.value) || common::addOverflow(add.value, current.value, current.value);
-            if (overflow)
-            {
-                error_message = fmt::format("Cannot parse time duration {}: It's too big", quoteString(input));
-                error_pos = 0;
-                return false;
-            }
-
-            previous_unit = unit;
-            previous_unit_name = unit_name;
         }
 
         /// There should be at least one number with a time unit.
-        if (!previous_unit)
+        if (!has_time_units)
         {
-            error_message = fmt::format("Cannot parse time duration {}: Expected numbers combined with time units", quoteString(input));
-            error_pos = 0;
+            setErrorMessage(error_message,
+                            "Cannot parse {} {} in duration format: Expected numbers combined with time units",
+                            getTypeName<T>(), quoteString(input));
+            setErrorPos(error_pos, 0);
             return false;
         }
 
-        if constexpr (is_decimal_field<T>)
-            result = T{current, current_scale};
+        if constexpr (is_decimal<T>)
+        {
+            Int64 scaled_milliseconds;
+            if (scale > 3)
+            {
+                if (common::mulOverflow(milliseconds, DecimalUtils::scaleMultiplier<T>(scale - 3), scaled_milliseconds))
+                {
+                    setErrorMessage(error_message,
+                                    "Cannot parse {} {}: Overflow, the duration is too big",
+                                    getTypeName<T>(), quoteString(input));
+                    setErrorPos(error_pos, 0);
+                    return false;
+                }
+            }
+            else if (scale < 3)
+            {
+                Int64 divisor = DecimalUtils::scaleMultiplier<T>(3 - scale);
+                scaled_milliseconds = milliseconds / divisor;
+            }
+            else
+            {
+                scaled_milliseconds = milliseconds;
+            }
+
+            if (!DecimalUtils::tryMultiplyAdd(seconds, DecimalUtils::scaleMultiplier<T>(scale), scaled_milliseconds, result.value))
+            {
+                setErrorMessage(error_message,
+                                "Cannot parse {} {}: Overflow, the duration is too big",
+                                getTypeName<T>(), quoteString(input));
+                setErrorPos(error_pos, 0);
+                return false;
+            }
+        }
         else
-            result = static_cast<T>(DecimalField<Decimal64>{current, current_scale});
+        {
+            result = static_cast<ScalarType>(seconds) + static_cast<ScalarType>(milliseconds) / 1000;
+        }
+
+        return true;
+    }
+
+    template <typename T>
+    bool tryParseNumber(std::string_view input, UInt32 scale, T & result, String * error_message, size_t * error_pos)
+    {
+        size_t pos = 0;
+
+        /// Parse a sign.
+        bool negative = false;
+        if (input.starts_with('+'))
+        {
+            ++pos;
+        }
+        else if (input.starts_with('-'))
+        {
+            negative = true;
+            ++pos;
+        }
+
+        /// Spaces between a sign and number are allowed.
+        while (pos != input.length() && std::isspace(input[pos]))
+            ++pos;
+
+        size_t end_pos = input.length();
+        while (end_pos != pos && std::isspace(input[end_pos - 1]))
+            --end_pos;
+
+        std::string_view unsigned_input = input.substr(pos, end_pos - pos);
+
+        bool ok = false;
+
+        /// Parse an unsigned number in one of three formats.
+        if (isHexFormat(unsigned_input))
+        {
+            ok = tryParseHexFormat(unsigned_input, scale, result, error_message, error_pos);
+        }
+        else if (isDurationFormat(unsigned_input))
+        {
+            ok = tryParseDurationFormat(unsigned_input, scale, result, error_message, error_pos);
+        }
+        else
+        {
+            ok = tryParseNumberFormat(unsigned_input, scale, result, error_message, error_pos);
+        }
+
+        if (!ok)
+        {
+            if (error_pos)
+                *error_pos += pos;
+            return false;
+        }
+
+        if (negative)
+            result = -result;
 
         return true;
     }
 }
 
-/// Changes the sign of a scalar or an interval stored in `ScalarOrInterval`.
-void PrometheusQueryParsingUtil::ScalarOrInterval::negate()
+
+bool PrometheusQueryParsingUtil::tryParseScalar(std::string_view input, ScalarType & res_scalar, String * error_message, size_t * error_pos)
 {
-    if (scalar)
-    {
-        auto & scalar_ref = *scalar;
-        scalar_ref = -scalar_ref;
-    }
-    else if (interval)
-    {
-        auto & interval_ref = *interval;
-        interval_ref = IntervalType{-interval_ref.getValue(), interval_ref.getScale()};
-    }
+    /// Here `scale` is set to `0` because it's unused when parsing a floating-point number.
+    return tryParseNumber(input, /* scale */ 0, res_scalar, error_message, error_pos);
 }
 
-/// Parses a scalar or an interval literal.
-bool PrometheusQueryParsingUtil::parseScalarOrInterval(std::string_view input, ScalarOrInterval & result, String & error_message, size_t & error_pos)
+bool PrometheusQueryParsingUtil::tryParseTimestamp(
+    std::string_view input, UInt32 timestamp_scale, TimestampType & res_timestamp, String * error_message, size_t * error_pos)
 {
-    size_t pos = 0;
-
-    /// Parse a sign.
-    bool negative = false;
-    if (input.starts_with('+'))
-    {
-        ++pos;
-    }
-    else if (input.starts_with('-'))
-    {
-        negative = true;
-        ++pos;
-    }
-
-    /// Spaces between a sign and number are allowed.
-    while (pos != input.length() && std::isspace(input[pos]))
-        ++pos;
-
-    std::string_view unsigned_input = input.substr(pos);
-
-    ScalarType scalar;
-    IntervalType interval;
-    bool ok = false;
-
-    /// Parse an unsigned number in one of three formats.
-    if (isHexFormat(unsigned_input))
-    {
-        ok = parseNumberInHex(unsigned_input, scalar, error_message, error_pos);
-        if (ok)
-            result = ScalarOrInterval{scalar};
-    }
-    else if (isIntervalFormat(unsigned_input))
-    {
-        ok = parseInterval(unsigned_input, interval, error_message, error_pos);
-        if (ok)
-            result = ScalarOrInterval{interval};
-    }
-    else
-    {
-        ok = parseNumber(unsigned_input, scalar, error_message, error_pos);
-        if (ok)
-            result = ScalarOrInterval{scalar};
-    }
-
-    if (!ok)
-    {
-        error_pos += pos;
-        return false;
-    }
-
-    if (negative)
-        result.negate();
-
-    return true;
+    return tryParseNumber(input, timestamp_scale, res_timestamp, error_message, error_pos);
 }
+
+bool PrometheusQueryParsingUtil::tryParseDuration(
+    std::string_view input, UInt32 timestamp_scale, DurationType & res_duration, String * error_message, size_t * error_pos)
+{
+    return tryParseNumber(input, timestamp_scale, res_duration, error_message, error_pos);
+}
+
 
 /// Parses a time range which is used in range selectors.
-bool PrometheusQueryParsingUtil::findTimeRange(std::string_view input, std::string_view & res_range, String & error_message, size_t & error_pos)
+bool PrometheusQueryParsingUtil::tryParseSelectorRange(
+    std::string_view input, UInt32 timestamp_scale, DurationType & res_range, String * error_message, size_t * error_pos)
 {
     /// Check opening and closing brackets.
     if (!input.starts_with('['))
     {
-        error_message = fmt::format("Cannot parse time range {}: Expected an opening bracket [", quoteString(input));
-        error_pos = 0;
+        setErrorMessage(error_message, "Cannot parse time range {}: Expected an opening bracket [", quoteString(input));
+        setErrorPos(error_pos, 0);
         return false;
     }
 
     if (!input.ends_with(']'))
     {
-        error_message = fmt::format("Cannot parse time range {}: Expected a closing bracket ]", quoteString(input));
-        error_pos = input.length() - 1;
+        setErrorMessage(error_message, "Cannot parse time range {}: Expected a closing bracket ]", quoteString(input));
+        setErrorPos(error_pos, input.length() - 1);
         return false;
     }
 
@@ -581,32 +682,42 @@ bool PrometheusQueryParsingUtil::findTimeRange(std::string_view input, std::stri
 
     if (start_pos == end_pos)
     {
-        error_message = fmt::format("Cannot parse time range {}: Expected an interval between brackets [ ]", quoteString(input));
-        error_pos = start_pos;
+        setErrorMessage(error_message, "Cannot parse time range {}: Expected a duration between brackets [ ]", quoteString(input));
+        setErrorPos(error_pos, start_pos);
         return false;
     }
 
-    res_range = input.substr(start_pos, end_pos - start_pos);
+    if (!tryParseDuration(input.substr(start_pos, end_pos - start_pos), timestamp_scale, res_range, error_message, error_pos))
+    {
+        if (error_pos)
+            *error_pos += start_pos;
+        return false;
+    }
+
     return true;
 }
 
 /// Parses a time range with an optional resolution which are used in subqueries.
-bool PrometheusQueryParsingUtil::findSubqueryRangeAndResolution(std::string_view input,
-                                                                std::string_view & res_range, std::string_view & res_resolution,
-                                                                String & error_message, size_t & error_pos)
+bool PrometheusQueryParsingUtil::tryParseSubqueryRange(
+    std::string_view input,
+    UInt32 timestamp_scale,
+    DurationType & res_range,
+    std::optional<DurationType> & res_resolution,
+    String * error_message,
+    size_t * error_pos)
 {
     /// Check opening and closing brackets.
     if (!input.starts_with('['))
     {
-        error_message = fmt::format("Cannot parse subquery range {}: Expected an opening bracket [", quoteString(input));
-        error_pos = 0;
+        setErrorMessage(error_message, "Cannot parse subquery range {}: Expected an opening bracket [", quoteString(input));
+        setErrorPos(error_pos, 0);
         return false;
     }
 
     if (!input.ends_with(']'))
     {
-        error_message = fmt::format("Cannot parse subquery range {}: Expected a closing bracket ]", quoteString(input));
-        error_pos = input.length() - 1;
+        setErrorMessage(error_message, "Cannot parse subquery range {}: Expected a closing bracket ]", quoteString(input));
+        setErrorPos(error_pos, input.length() - 1);
         return false;
     }
 
@@ -614,8 +725,8 @@ bool PrometheusQueryParsingUtil::findSubqueryRangeAndResolution(std::string_view
     size_t colon_pos = input.find(':', 1);
     if (colon_pos == String::npos)
     {
-        error_message = fmt::format("Cannot parse subquery range {}: Expected a colon : in it", quoteString(input));
-        error_pos = 0;
+        setErrorMessage(error_message, "Cannot parse subquery range {}: Expected a colon : in it", quoteString(input));
+        setErrorPos(error_pos, 0);
         return false;
     }
 
@@ -643,13 +754,30 @@ bool PrometheusQueryParsingUtil::findSubqueryRangeAndResolution(std::string_view
 
     if (range_start_pos == range_end_pos)
     {
-        error_message = fmt::format("Cannot parse time range {}: Expected an interval between opening bracket [ and colon :", quoteString(input));
-        error_pos = range_start_pos;
+        setErrorMessage(error_message, "Cannot parse time range {}: Expected a duration between opening bracket [ and colon :", quoteString(input));
+        setErrorPos(error_pos, range_start_pos);
         return false;
     }
 
-    res_range = input.substr(range_start_pos, range_end_pos - range_start_pos);
-    res_resolution = input.substr(resolution_start_pos, resolution_end_pos - resolution_start_pos);
+    if (!tryParseDuration(input.substr(range_start_pos, range_end_pos - range_start_pos), timestamp_scale, res_range, error_message, error_pos))
+    {
+        if (error_pos)
+            *error_pos += range_start_pos;
+        return false;
+    }
+
+    res_resolution.reset();
+
+    if (resolution_start_pos != resolution_end_pos)
+    {
+        if (!tryParseDuration(input.substr(resolution_start_pos, resolution_end_pos - resolution_start_pos), timestamp_scale, res_resolution.emplace(), error_message, error_pos))
+        {
+            if (error_pos)
+                *error_pos += resolution_start_pos;
+            return false;
+        }
+    }
+
     return true;
 }
 

--- a/src/Parsers/Prometheus/PrometheusQueryParsingUtil.h
+++ b/src/Parsers/Prometheus/PrometheusQueryParsingUtil.h
@@ -1,49 +1,76 @@
 #pragma once
 
-#include <Parsers/Prometheus/PrometheusQueryTree.h>
+#include <base/Decimal.h>
+#include <optional>
 
 
 namespace DB
 {
+class PrometheusQueryTree;
+
 /// Helper utilities for parsing prometheus queries. These utilities are used by PrometheusQueryTree.
 struct PrometheusQueryParsingUtil
 {
-public:
+    using ScalarType = Float64;
+    using TimestampType = DateTime64;
+    using DurationType = Decimal64;
+
     /// Parses a prometheus query.
-    /// Scale `timestamp_scale` is used to parse decimals representing timestamps and offsets.
-    static bool parseQuery(std::string_view input, UInt32 timestamp_scale, PrometheusQueryTree & result, String & error_message, size_t & error_pos);
+    /// Scale `timestamp_scale` is used to parse decimals representing timestamps and durations.
+    static bool tryParseQuery(std::string_view input,
+                              UInt32 timestamp_scale,
+                              PrometheusQueryTree & res_query,
+                              String * error_message = nullptr,
+                              size_t * error_pos = nullptr);
 
     /// Converts a quoted string literal to its unquoted version: "abc" -> abc
     /// Accepts an input string in quotes or double quotes or backticks, and also handles escape sequences
     /// according to the PromQL rules (see https://prometheus.io/docs/prometheus/latest/querying/basics/#string-literals).
-    static bool parseStringLiteral(std::string_view input, String & result, String & error_message, size_t & error_pos);
+    static bool tryParseStringLiteral(std::string_view input,
+                                      String & res_string,
+                                      String * error_message = nullptr,
+                                      size_t * error_pos = nullptr);
 
-    using ScalarType = PrometheusQueryTree::ScalarType;
-    using IntervalType = DecimalField<Decimal64>;
-
-    /// Contains either a scalar or an interval.
-    struct ScalarOrInterval
-    {
-        ScalarOrInterval() = default;
-        explicit ScalarOrInterval(ScalarType scalar_) : scalar(scalar_) {}
-        explicit ScalarOrInterval(IntervalType interval_) : interval(interval_) {}
-        std::optional<ScalarType> scalar;
-        std::optional<IntervalType> interval;
-        bool empty() const { return !scalar && !interval; }
-        void negate();
-    };
-
-    /// Parses a scalar or literal which can be either an integer number or a floating-point number (e.g. 237e6), or Inf, or Nan,
-    /// or a hexadecimal number (e.g. 0xA7CD), or an interval with time units, for example 1m30s.
+    /// Parses a scalar which can be either an integer number or a floating-point number (e.g. 237e6), or Inf, or Nan,
+    /// or a hexadecimal number (e.g. 0xA7CD), or a duration with time units, for example 1m30s.
     /// Also underscores (_) can be used in between decimal or hexadecimal digits and they don't mean anything.
-    static bool parseScalarOrInterval(std::string_view input, ScalarOrInterval & result, String & error_message, size_t & error_pos);
+    static bool tryParseScalar(std::string_view input,
+                               ScalarType & res_scalar,
+                               String * error_message = nullptr,
+                               size_t * error_pos = nullptr);
 
-    /// Finds a time range in a range selector, for example for "[1h30m]" the function returns "1h30m".
-    static bool findTimeRange(std::string_view input, std::string_view & res_range, String & error_message, size_t & error_pos);
+    /// Parses a timestamp which can be either an integer or floating-point number of seconds since epoch (1 January 1970),
+    /// or a hexadecimal number of seconds since epoch, or a duration with time units since epoch.
+    /// Also underscores (_) can be used in between decimal or hexadecimal digits and they don't mean anything.
+    static bool tryParseTimestamp(std::string_view input,
+                                  UInt32 timestamp_scale,
+                                  TimestampType & res_timestamp,
+                                  String * error_message = nullptr,
+                                  size_t * error_pos = nullptr);
 
-    /// Finds a range and optionally a resolution in a subquery, for example for "[1h:5m]" the function returns "1h" and "5m".
-    static bool findSubqueryRangeAndResolution(std::string_view input, std::string_view & res_range, std::string_view & res_resolution,
-                                               String & error_message, size_t & error_pos);
+    /// Parses a timestamp which can be either an integer or floating-point number of seconds,
+    /// or a hexadecimal number of seconds, or a duration with time units.
+    /// Also underscores (_) can be used in between decimal or hexadecimal digits and they don't mean anything.
+    static bool tryParseDuration(std::string_view input,
+                                 UInt32 timestamp_scale,
+                                 DurationType & res_duration,
+                                 String * error_message = nullptr,
+                                 size_t * error_pos = nullptr);
+
+    /// Parses the range in a range selector, for example for "[1h30m]" the function parses "1h30m".
+    static bool tryParseSelectorRange(std::string_view input,
+                                      UInt32 timestamp_scale,
+                                      DurationType & res_range,
+                                      String * error_message = nullptr,
+                                      size_t * error_pos = nullptr);
+
+    /// Parses the range and optionally the resolution in a subquery, for example for "[1h:5m]" the function parses "1h" and "5m".
+    static bool tryParseSubqueryRange(std::string_view input,
+                                      UInt32 timestamp_scale,
+                                      DurationType & res_range,
+                                      std::optional<DurationType> & res_resolution,
+                                      String * error_message = nullptr,
+                                      size_t * error_pos = nullptr);
 };
 
 }

--- a/src/Parsers/Prometheus/PrometheusQueryParsingUtil.h
+++ b/src/Parsers/Prometheus/PrometheusQueryParsingUtil.h
@@ -11,7 +11,7 @@ struct PrometheusQueryParsingUtil
 public:
     /// Parses a prometheus query.
     /// Scale `timestamp_scale` is used to parse decimals representing timestamps and offsets.
-    static bool parseQuery(std::string_view input, PrometheusQueryTree & result, String & error_message, size_t & error_pos);
+    static bool parseQuery(std::string_view input, UInt32 timestamp_scale, PrometheusQueryTree & result, String & error_message, size_t & error_pos);
 
     /// Converts a quoted string literal to its unquoted version: "abc" -> abc
     /// Accepts an input string in quotes or double quotes or backticks, and also handles escape sequences
@@ -19,7 +19,7 @@ public:
     static bool parseStringLiteral(std::string_view input, String & result, String & error_message, size_t & error_pos);
 
     using ScalarType = PrometheusQueryTree::ScalarType;
-    using IntervalType = PrometheusQueryTree::IntervalType;
+    using IntervalType = DecimalField<Decimal64>;
 
     /// Contains either a scalar or an interval.
     struct ScalarOrInterval

--- a/src/Parsers/Prometheus/PrometheusQueryTree.cpp
+++ b/src/Parsers/Prometheus/PrometheusQueryTree.cpp
@@ -252,7 +252,7 @@ void PrometheusQueryTree::parse(std::string_view promql_query_, UInt32 timestamp
 {
     String error_message;
     size_t error_pos;
-    if (PrometheusQueryParsingUtil::parseQuery(promql_query_, timestamp_scale_, *this, error_message, error_pos))
+    if (PrometheusQueryParsingUtil::tryParseQuery(promql_query_, timestamp_scale_, *this, &error_message, &error_pos))
         return;
 
     throw Exception(ErrorCodes::CANNOT_PARSE_PROMQL_QUERY, "{} at position {} while parsing PromQL query: {}",
@@ -261,16 +261,7 @@ void PrometheusQueryTree::parse(std::string_view promql_query_, UInt32 timestamp
 
 bool PrometheusQueryTree::tryParse(std::string_view promql_query_, UInt32 timestamp_scale_, String * error_message_, size_t * error_pos_)
 {
-    String error_message;
-    size_t error_pos;
-    if (PrometheusQueryParsingUtil::parseQuery(promql_query_, timestamp_scale_, *this, error_message, error_pos))
-        return true;
-
-    if (error_message_)
-        *error_message_ = std::move(error_message);
-    if (error_pos_)
-        *error_pos_ = error_pos;
-    return false;
+    return PrometheusQueryParsingUtil::tryParseQuery(promql_query_, timestamp_scale_, *this, error_message_, error_pos_);
 }
 
 }

--- a/src/Parsers/Prometheus/PrometheusQueryTree.cpp
+++ b/src/Parsers/Prometheus/PrometheusQueryTree.cpp
@@ -37,17 +37,12 @@ namespace
     }
 }
 
+Node * PrometheusQueryTree::Scalar::clone(std::vector<std::unique_ptr<Node>> & node_list_) const
+{
+    return cloneNodeImpl(this, node_list_);
+}
+
 Node * PrometheusQueryTree::StringLiteral::clone(std::vector<std::unique_ptr<Node>> & node_list_) const
-{
-    return cloneNodeImpl(this, node_list_);
-}
-
-Node * PrometheusQueryTree::ScalarLiteral::clone(std::vector<std::unique_ptr<Node>> & node_list_) const
-{
-    return cloneNodeImpl(this, node_list_);
-}
-
-Node * PrometheusQueryTree::IntervalLiteral::clone(std::vector<std::unique_ptr<Node>> & node_list_) const
 {
     return cloneNodeImpl(this, node_list_);
 }
@@ -67,7 +62,7 @@ Node * PrometheusQueryTree::Subquery::clone(std::vector<std::unique_ptr<Node>> &
     return cloneNodeImpl(this, node_list_);
 }
 
-Node * PrometheusQueryTree::At::clone(std::vector<std::unique_ptr<Node>> & node_list_) const
+Node * PrometheusQueryTree::Offset::clone(std::vector<std::unique_ptr<Node>> & node_list_) const
 {
     return cloneNodeImpl(this, node_list_);
 }
@@ -103,13 +98,14 @@ PrometheusQueryTree & PrometheusQueryTree::operator=(const PrometheusQueryTree &
         if (src.root)
             new_root = src.root->clone(new_node_list);
 
-        *this = PrometheusQueryTree{src.promql_query, new_root, std::move(new_node_list)};
+        *this = PrometheusQueryTree{src.promql_query, src.timestamp_scale, new_root, std::move(new_node_list)};
     }
     return *this;
 }
 
-PrometheusQueryTree::PrometheusQueryTree(String promql_query_, const Node * root_, std::vector<std::unique_ptr<Node>> node_list_)
+PrometheusQueryTree::PrometheusQueryTree(String promql_query_, UInt32 timestamp_scale_, const Node * root_, std::vector<std::unique_ptr<Node>> node_list_)
     : promql_query(std::move(promql_query_))
+    , timestamp_scale(timestamp_scale_)
     , root(root_)
     , node_list(std::move(node_list_))
 {
@@ -118,6 +114,7 @@ PrometheusQueryTree::PrometheusQueryTree(String promql_query_, const Node * root
 PrometheusQueryTree & PrometheusQueryTree::operator=(PrometheusQueryTree && src) noexcept
 {
     promql_query = std::exchange(src.promql_query, {});
+    timestamp_scale = std::exchange(src.timestamp_scale, 0);
     root = std::exchange(src.root, nullptr);
     node_list = std::exchange(src.node_list, {});
     return *this;
@@ -145,14 +142,9 @@ String PrometheusQueryTree::dumpTree() const
         return "\nPrometheusQueryTree(EMPTY)\n";
 }
 
-String PrometheusQueryTree::ScalarLiteral::dumpNode(size_t indent) const
+String PrometheusQueryTree::Scalar::dumpNode(size_t indent) const
 {
-    return fmt::format("{}ScalarLiteral({})", makeIndent(indent), ::DB::toString(scalar));
-}
-
-String PrometheusQueryTree::IntervalLiteral::dumpNode(size_t indent) const
-{
-    return fmt::format("{}IntervalLiteral({})", makeIndent(indent), ::DB::toString(interval));
+    return fmt::format("{}Scalar({})", makeIndent(indent), ::DB::toString(scalar));
 }
 
 String PrometheusQueryTree::StringLiteral::dumpNode(size_t indent) const
@@ -171,7 +163,7 @@ String PrometheusQueryTree::InstantSelector::dumpNode(size_t indent) const
 String PrometheusQueryTree::RangeSelector::dumpNode(size_t indent) const
 {
     String str = fmt::format("{}RangeSelector:", makeIndent(indent));
-    str += fmt::format("\n{}range:\n{}", makeIndent(indent + 1), getRange()->dumpNode(indent + 2));
+    str += fmt::format("\n{}range: {}", makeIndent(indent + 1), ::DB::toString(range));
     str += fmt::format("\n{}", getInstantSelector()->dumpNode(indent + 1));
     return str;
 }
@@ -179,20 +171,20 @@ String PrometheusQueryTree::RangeSelector::dumpNode(size_t indent) const
 String PrometheusQueryTree::Subquery::dumpNode(size_t indent) const
 {
     String str = fmt::format("{}Subquery:", makeIndent(indent));
-    str += fmt::format("\n{}range:\n{}", makeIndent(indent + 1), getRange()->dumpNode(indent + 2));
-    if (const auto * resolution = getResolution())
-        str += fmt::format("\n{}resolution:\n{}", makeIndent(indent + 1), resolution->dumpNode(indent + 2));
+    str += fmt::format("\n{}range: {}", makeIndent(indent + 1), ::DB::toString(range));
+    if (resolution)
+        str += fmt::format("\n{}resolution: {}", makeIndent(indent + 1), ::DB::toString(*resolution));
     str += fmt::format("\n{}", getExpression()->dumpNode(indent + 1));
     return str;
 }
 
-String PrometheusQueryTree::At::dumpNode(size_t indent) const
+String PrometheusQueryTree::Offset::dumpNode(size_t indent) const
 {
-    String str = fmt::format("{}At:", makeIndent(indent));
-    if (const auto * at = getAt())
-        str += fmt::format("\n{}at:\n{}", makeIndent(indent + 1), at->dumpNode(indent + 2));
-    if (const auto * offset = getOffset())
-        str += fmt::format("\n{}offset:\n{}", makeIndent(indent + 1), offset->dumpNode(indent + 2));
+    String str = fmt::format("{}Offset:", makeIndent(indent));
+    if (at_timestamp)
+        str += fmt::format("\n{}at: {}", makeIndent(indent + 1), ::DB::toString(*at_timestamp));
+    if (offset_value)
+        str += fmt::format("\n{}offset: {}", makeIndent(indent + 1), ::DB::toString(*offset_value));
     str += fmt::format("\n{}", getExpression()->dumpNode(indent + 1));
     return str;
 }
@@ -202,7 +194,7 @@ String PrometheusQueryTree::Function::dumpNode(size_t indent) const
     const auto & arguments = getArguments();
     std::string_view maybe_colon = arguments.empty() ? "" : ":";
     String str = fmt::format("{}Function({}){}", makeIndent(indent), function_name, maybe_colon);
-    for (const auto * argument : getArguments())
+    for (const auto * argument : arguments)
         str += fmt::format("\n{}", argument->dumpNode(indent + 1));
     return str;
 }
@@ -256,22 +248,22 @@ String PrometheusQueryTree::AggregationOperator::dumpNode(size_t indent) const
     return str;
 }
 
-void PrometheusQueryTree::parse(std::string_view promql_query_)
+void PrometheusQueryTree::parse(std::string_view promql_query_, UInt32 timestamp_scale_)
 {
     String error_message;
     size_t error_pos;
-    if (PrometheusQueryParsingUtil::parseQuery(promql_query_, *this, error_message, error_pos))
+    if (PrometheusQueryParsingUtil::parseQuery(promql_query_, timestamp_scale_, *this, error_message, error_pos))
         return;
 
     throw Exception(ErrorCodes::CANNOT_PARSE_PROMQL_QUERY, "{} at position {} while parsing PromQL query: {}",
                     error_message, error_pos, promql_query_);
 }
 
-bool PrometheusQueryTree::tryParse(std::string_view promql_query_, String * error_message_, size_t * error_pos_)
+bool PrometheusQueryTree::tryParse(std::string_view promql_query_, UInt32 timestamp_scale_, String * error_message_, size_t * error_pos_)
 {
     String error_message;
     size_t error_pos;
-    if (PrometheusQueryParsingUtil::parseQuery(promql_query_, *this, error_message, error_pos))
+    if (PrometheusQueryParsingUtil::parseQuery(promql_query_, timestamp_scale_, *this, error_message, error_pos))
         return true;
 
     if (error_message_)

--- a/src/Parsers/Prometheus/PrometheusQueryTree.h
+++ b/src/Parsers/Prometheus/PrometheusQueryTree.h
@@ -17,10 +17,10 @@ public:
     using ScalarType = Float64;
 
     /// The timestamp type is used to store a value after '@'.
-    using TimestampType = DecimalField<DateTime64>;
+    using TimestampType = DateTime64;
 
     /// The duration type is used to store durations in range selectors and subqueries, and also a value after the 'offset' keyword.
-    using DurationType = DecimalField<Decimal64>;
+    using DurationType = Decimal64;
 
     enum class MatcherType { EQ /* = */, NE /* != */, RE /* =~ */, NRE /* !~ */};
 
@@ -67,7 +67,7 @@ public:
         Node(const Node &) = default;
         virtual ~Node() = default;
         virtual Node * clone(std::vector<std::unique_ptr<Node>> & node_list_) const = 0;
-        virtual String dumpNode(size_t indent) const = 0;
+        virtual String dumpNode(const PrometheusQueryTree & tree, size_t indent) const = 0;
     };
 
     /// A scalar literal, i.e. a floating-point or an integer number.
@@ -78,7 +78,7 @@ public:
         ScalarType scalar;
         Scalar() { node_type = NodeType::Scalar; result_type = ResultType::SCALAR; }
         Node * clone(std::vector<std::unique_ptr<Node>> & node_list_) const override;
-        String dumpNode(size_t indent) const override;
+        String dumpNode(const PrometheusQueryTree & tree, size_t indent) const override;
     };
 
     /// A string literal.
@@ -89,7 +89,7 @@ public:
         String string;
         StringLiteral() { node_type = NodeType::StringLiteral; result_type = ResultType::STRING; }
         Node * clone(std::vector<std::unique_ptr<Node>> & node_list_) const override;
-        String dumpNode(size_t indent) const override;
+        String dumpNode(const PrometheusQueryTree & tree, size_t indent) const override;
     };
 
     /// An instant selector.
@@ -100,7 +100,7 @@ public:
         MatcherList matchers;
         InstantSelector() { node_type = NodeType::InstantSelector; result_type = ResultType::INSTANT_VECTOR; }
         Node * clone(std::vector<std::unique_ptr<Node>> & node_list_) const override;
-        String dumpNode(size_t indent) const override;
+        String dumpNode(const PrometheusQueryTree & tree, size_t indent) const override;
     };
 
     /// A range selector.
@@ -112,7 +112,7 @@ public:
         const InstantSelector * getInstantSelector() const { return &typeid_cast<const InstantSelector &>(*children.at(0)); }
         RangeSelector() { node_type = NodeType::RangeSelector; result_type = ResultType::RANGE_VECTOR; }
         Node * clone(std::vector<std::unique_ptr<Node>> & node_list_) const override;
-        String dumpNode(size_t indent) const override;
+        String dumpNode(const PrometheusQueryTree & tree, size_t indent) const override;
     };
 
     /// Represents a subquery, i.e. <expression>[<range>:<resolution>]. Here resolution can be omitted, but the colon always presents.
@@ -126,7 +126,7 @@ public:
         const Node * getExpression() const { return children.at(0); }
         Subquery() { node_type = NodeType::Subquery; result_type = ResultType::RANGE_VECTOR; }
         Node * clone(std::vector<std::unique_ptr<Node>> & node_list_) const override;
-        String dumpNode(size_t indent) const override;
+        String dumpNode(const PrometheusQueryTree & tree, size_t indent) const override;
     };
 
     /// Represents a change of the evaluation time applied to an instant selector or a range selector or a subquery.
@@ -141,7 +141,7 @@ public:
         const Node * getExpression() const { return children.at(0); }
         Offset() { node_type = NodeType::Offset; }
         Node * clone(std::vector<std::unique_ptr<Node>> & node_list_) const override;
-        String dumpNode(size_t indent) const override;
+        String dumpNode(const PrometheusQueryTree & tree, size_t indent) const override;
     };
 
     /// A function with parameters in parentheses.
@@ -155,7 +155,7 @@ public:
         const std::vector<const Node *> & getArguments() const { return children; }
         Function() { node_type = NodeType::Function; }
         Node * clone(std::vector<std::unique_ptr<Node>> & node_list_) const override;
-        String dumpNode(size_t indent) const override;
+        String dumpNode(const PrometheusQueryTree & tree, size_t indent) const override;
     };
 
     /// An unary operator: either +<argument> or -<argument>.
@@ -166,7 +166,7 @@ public:
         const Node * getArgument() const { return children.at(0); }
         UnaryOperator() { node_type = NodeType::UnaryOperator; }
         Node * clone(std::vector<std::unique_ptr<Node>> & node_list_) const override;
-        String dumpNode(size_t indent) const override;
+        String dumpNode(const PrometheusQueryTree & tree, size_t indent) const override;
     };
 
     /// A binary operator: <left-argument> <operation-name> on(<on-labels>) group_left(<extra-labels>) <right-argument>
@@ -187,7 +187,7 @@ public:
         const Node * getRightArgument() const { return children.at(1); }
         BinaryOperator() { node_type = NodeType::BinaryOperator; }
         Node * clone(std::vector<std::unique_ptr<Node>> & node_list_) const override;
-        String dumpNode(size_t indent) const override;
+        String dumpNode(const PrometheusQueryTree & tree, size_t indent) const override;
     };
 
     /// An aggregation operator: <operator-name> [by (<by-labels>) | without (<without-labels>)] (<arguments>)
@@ -204,7 +204,7 @@ public:
         const std::vector<const Node *> & getArguments() const { return children; }
         AggregationOperator() { node_type = NodeType::AggregationOperator; }
         Node * clone(std::vector<std::unique_ptr<Node>> & node_list_) const override;
-        String dumpNode(size_t indent) const override;
+        String dumpNode(const PrometheusQueryTree & tree, size_t indent) const override;
     };
 
     PrometheusQueryTree() = default;

--- a/src/Parsers/Prometheus/tests/gtest_PrometheusQueryTree.cpp
+++ b/src/Parsers/Prometheus/tests/gtest_PrometheusQueryTree.cpp
@@ -19,43 +19,43 @@ TEST(PrometheusQueryTree, ParseComplianceQueries)
     /// Scalar literals.
     EXPECT_EQ(parseAndDumpTree("42"), R"(
 PrometheusQueryTree(SCALAR):
-    ScalarLiteral(42)
+    Scalar(42)
 )");
 
     EXPECT_EQ(parseAndDumpTree("1.234"), R"(
 PrometheusQueryTree(SCALAR):
-    ScalarLiteral(1.234)
+    Scalar(1.234)
 )");
 
     EXPECT_EQ(parseAndDumpTree(".123"), R"(
 PrometheusQueryTree(SCALAR):
-    ScalarLiteral(0.123)
+    Scalar(0.123)
 )");
 
     EXPECT_EQ(parseAndDumpTree("1.23e-3"), R"(
 PrometheusQueryTree(SCALAR):
-    ScalarLiteral(0.00123)
+    Scalar(0.00123)
 )");
 
     EXPECT_EQ(parseAndDumpTree("0x3d"), R"(
 PrometheusQueryTree(SCALAR):
-    ScalarLiteral(61)
+    Scalar(61)
 )");
 
     EXPECT_EQ(parseAndDumpTree("Inf"), R"(
 PrometheusQueryTree(SCALAR):
-    ScalarLiteral(inf)
+    Scalar(inf)
 )");
 
     EXPECT_EQ(parseAndDumpTree("-Inf"), R"(
 PrometheusQueryTree(SCALAR):
     UnaryOperator(-)
-        ScalarLiteral(inf)
+        Scalar(inf)
 )");
 
     EXPECT_EQ(parseAndDumpTree("NaN"), R"(
 PrometheusQueryTree(SCALAR):
-    ScalarLiteral(nan)
+    Scalar(nan)
 )");
 
     /// Vector selectors.
@@ -204,7 +204,7 @@ PrometheusQueryTree(INSTANT_VECTOR):
     EXPECT_EQ(parseAndDumpTree("topk (3, demo_memory_usage_bytes)"), R"(
 PrometheusQueryTree(INSTANT_VECTOR):
     AggregationOperator(topk)
-        ScalarLiteral(3)
+        Scalar(3)
         InstantSelector:
             __name__ EQ 'demo_memory_usage_bytes'
 )");
@@ -213,7 +213,7 @@ PrometheusQueryTree(INSTANT_VECTOR):
 PrometheusQueryTree(INSTANT_VECTOR):
     AggregationOperator(topk)
         by instance
-        ScalarLiteral(2)
+        Scalar(2)
         InstantSelector:
             __name__ EQ 'demo_memory_usage_bytes'
 )");
@@ -222,7 +222,7 @@ PrometheusQueryTree(INSTANT_VECTOR):
 PrometheusQueryTree(INSTANT_VECTOR):
     AggregationOperator(topk)
         without instance
-        ScalarLiteral(2)
+        Scalar(2)
         InstantSelector:
             __name__ EQ 'demo_memory_usage_bytes'
 )");
@@ -231,7 +231,7 @@ PrometheusQueryTree(INSTANT_VECTOR):
 PrometheusQueryTree(INSTANT_VECTOR):
     AggregationOperator(topk)
         without
-        ScalarLiteral(2)
+        Scalar(2)
         InstantSelector:
             __name__ EQ 'demo_memory_usage_bytes'
 )");
@@ -239,7 +239,7 @@ PrometheusQueryTree(INSTANT_VECTOR):
     EXPECT_EQ(parseAndDumpTree("quantile(0.5, demo_memory_usage_bytes)"), R"(
 PrometheusQueryTree(INSTANT_VECTOR):
     AggregationOperator(quantile)
-        ScalarLiteral(0.5)
+        Scalar(0.5)
         InstantSelector:
             __name__ EQ 'demo_memory_usage_bytes'
 )");
@@ -259,16 +259,16 @@ PrometheusQueryTree(SCALAR):
     BinaryOperator(-)
         BinaryOperator(+)
             BinaryOperator(*)
-                ScalarLiteral(1)
-                ScalarLiteral(2)
+                Scalar(1)
+                Scalar(2)
             BinaryOperator(/)
-                ScalarLiteral(4)
-                ScalarLiteral(6)
+                Scalar(4)
+                Scalar(6)
         BinaryOperator(%)
-            ScalarLiteral(10)
+            Scalar(10)
             BinaryOperator(^)
-                ScalarLiteral(2)
-                ScalarLiteral(2)
+                Scalar(2)
+                Scalar(2)
 )");
 
     EXPECT_EQ(parseAndDumpTree("demo_num_cpus + (1 == bool 2)"), R"(
@@ -278,8 +278,8 @@ PrometheusQueryTree(INSTANT_VECTOR):
             __name__ EQ 'demo_num_cpus'
         BinaryOperator(==)
             bool
-            ScalarLiteral(1)
-            ScalarLiteral(2)
+            Scalar(1)
+            Scalar(2)
 )");
 
     EXPECT_EQ(parseAndDumpTree("demo_memory_usage_bytes + 1.2345"), R"(
@@ -287,7 +287,7 @@ PrometheusQueryTree(INSTANT_VECTOR):
     BinaryOperator(+)
         InstantSelector:
             __name__ EQ 'demo_memory_usage_bytes'
-        ScalarLiteral(1.2345)
+        Scalar(1.2345)
 )");
 
     EXPECT_EQ(parseAndDumpTree("demo_memory_usage_bytes == bool 1.2345"), R"(
@@ -296,14 +296,14 @@ PrometheusQueryTree(INSTANT_VECTOR):
         bool
         InstantSelector:
             __name__ EQ 'demo_memory_usage_bytes'
-        ScalarLiteral(1.2345)
+        Scalar(1.2345)
 )");
 
     EXPECT_EQ(parseAndDumpTree("1.2345 == bool demo_memory_usage_bytes"), R"(
 PrometheusQueryTree(INSTANT_VECTOR):
     BinaryOperator(==)
         bool
-        ScalarLiteral(1.2345)
+        Scalar(1.2345)
         InstantSelector:
             __name__ EQ 'demo_memory_usage_bytes'
 )");
@@ -311,7 +311,7 @@ PrometheusQueryTree(INSTANT_VECTOR):
     EXPECT_EQ(parseAndDumpTree("0.12345 + demo_memory_usage_bytes"), R"(
 PrometheusQueryTree(INSTANT_VECTOR):
     BinaryOperator(+)
-        ScalarLiteral(0.12345)
+        Scalar(0.12345)
         InstantSelector:
             __name__ EQ 'demo_memory_usage_bytes'
 )");
@@ -322,16 +322,16 @@ PrometheusQueryTree(INSTANT_VECTOR):
         BinaryOperator(-)
             BinaryOperator(+)
                 BinaryOperator(*)
-                    ScalarLiteral(1)
-                    ScalarLiteral(2)
+                    Scalar(1)
+                    Scalar(2)
                 BinaryOperator(/)
-                    ScalarLiteral(4)
-                    ScalarLiteral(6)
+                    Scalar(4)
+                    Scalar(6)
             BinaryOperator(^)
                 BinaryOperator(%)
-                    ScalarLiteral(10)
-                    ScalarLiteral(7)
-                ScalarLiteral(2)
+                    Scalar(10)
+                    Scalar(7)
+                Scalar(2)
         InstantSelector:
             __name__ EQ 'demo_memory_usage_bytes'
 )");
@@ -344,12 +344,12 @@ PrometheusQueryTree(INSTANT_VECTOR):
         BinaryOperator(-)
             BinaryOperator(+)
                 BinaryOperator(*)
-                    ScalarLiteral(1)
-                    ScalarLiteral(2)
+                    Scalar(1)
+                    Scalar(2)
                 BinaryOperator(/)
-                    ScalarLiteral(4)
-                    ScalarLiteral(6)
-            ScalarLiteral(10)
+                    Scalar(4)
+                    Scalar(6)
+            Scalar(10)
 )");
 
     EXPECT_EQ(parseAndDumpTree("timestamp(demo_memory_usage_bytes * 1)"), R"(
@@ -358,7 +358,7 @@ PrometheusQueryTree(INSTANT_VECTOR):
         BinaryOperator(*)
             InstantSelector:
                 __name__ EQ 'demo_memory_usage_bytes'
-            ScalarLiteral(1)
+            Scalar(1)
 )");
 
     EXPECT_EQ(parseAndDumpTree("timestamp(-demo_memory_usage_bytes)"), R"(
@@ -478,7 +478,7 @@ PrometheusQueryTree(INSTANT_VECTOR):
     BinaryOperator(*)
         InstantSelector:
             __name__ EQ 'demo_num_cpus'
-        ScalarLiteral(inf)
+        Scalar(inf)
 )");
 
     EXPECT_EQ(parseAndDumpTree("demo_num_cpus * -Inf"), R"(
@@ -487,7 +487,7 @@ PrometheusQueryTree(INSTANT_VECTOR):
         InstantSelector:
             __name__ EQ 'demo_num_cpus'
         UnaryOperator(-)
-            ScalarLiteral(inf)
+            Scalar(inf)
 )");
 
     EXPECT_EQ(parseAndDumpTree("demo_num_cpus * NaN"), R"(
@@ -495,7 +495,7 @@ PrometheusQueryTree(INSTANT_VECTOR):
     BinaryOperator(*)
         InstantSelector:
             __name__ EQ 'demo_num_cpus'
-        ScalarLiteral(nan)
+        Scalar(nan)
 )");
 
     /// Unary expressions.
@@ -505,7 +505,7 @@ PrometheusQueryTree(INSTANT_VECTOR):
         InstantSelector:
             __name__ EQ 'demo_memory_usage_bytes'
         UnaryOperator(-)
-            ScalarLiteral(1)
+            Scalar(1)
 )");
 
     EXPECT_EQ(parseAndDumpTree("-demo_memory_usage_bytes"), R"(
@@ -520,15 +520,15 @@ PrometheusQueryTree(INSTANT_VECTOR):
 PrometheusQueryTree(SCALAR):
     UnaryOperator(-)
         BinaryOperator(^)
-            ScalarLiteral(1)
-            ScalarLiteral(2)
+            Scalar(1)
+            Scalar(2)
 )");
 
     /// Binops involving non-const scalars.
     EXPECT_EQ(parseAndDumpTree("1 + time()"), R"(
 PrometheusQueryTree(SCALAR):
     BinaryOperator(+)
-        ScalarLiteral(1)
+        Scalar(1)
         Function(time)
 )");
 
@@ -536,7 +536,7 @@ PrometheusQueryTree(SCALAR):
 PrometheusQueryTree(SCALAR):
     BinaryOperator(+)
         Function(time)
-        ScalarLiteral(1)
+        Scalar(1)
 )");
 
     EXPECT_EQ(parseAndDumpTree("time() == bool 1"), R"(
@@ -544,14 +544,14 @@ PrometheusQueryTree(SCALAR):
     BinaryOperator(==)
         bool
         Function(time)
-        ScalarLiteral(1)
+        Scalar(1)
 )");
 
     EXPECT_EQ(parseAndDumpTree("1 == bool time()"), R"(
 PrometheusQueryTree(SCALAR):
     BinaryOperator(==)
         bool
-        ScalarLiteral(1)
+        Scalar(1)
         Function(time)
 )");
 
@@ -576,8 +576,7 @@ PrometheusQueryTree(INSTANT_VECTOR):
 PrometheusQueryTree(INSTANT_VECTOR):
     Function(avg_over_time):
         RangeSelector:
-            range:
-                IntervalLiteral(1200)
+            range: 1200
             InstantSelector:
                 __name__ EQ 'demo_memory_usage_bytes'
 )");
@@ -585,10 +584,9 @@ PrometheusQueryTree(INSTANT_VECTOR):
     EXPECT_EQ(parseAndDumpTree("quantile_over_time(0.5, demo_memory_usage_bytes[20m])"), R"(
 PrometheusQueryTree(INSTANT_VECTOR):
     Function(quantile_over_time):
-        ScalarLiteral(0.5)
+        Scalar(0.5)
         RangeSelector:
-            range:
-                IntervalLiteral(1200)
+            range: 1200
             InstantSelector:
                 __name__ EQ 'demo_memory_usage_bytes'
 )");
@@ -627,8 +625,7 @@ PrometheusQueryTree(INSTANT_VECTOR):
 PrometheusQueryTree(INSTANT_VECTOR):
     Function(rate):
         RangeSelector:
-            range:
-                IntervalLiteral(1200)
+            range: 1200
             InstantSelector:
                 __name__ EQ 'demo_cpu_usage_seconds_total'
 )");
@@ -637,8 +634,7 @@ PrometheusQueryTree(INSTANT_VECTOR):
 PrometheusQueryTree(INSTANT_VECTOR):
     Function(deriv):
         RangeSelector:
-            range:
-                IntervalLiteral(1200)
+            range: 1200
             InstantSelector:
                 __name__ EQ 'demo_disk_usage_bytes'
 )");
@@ -647,11 +643,10 @@ PrometheusQueryTree(INSTANT_VECTOR):
 PrometheusQueryTree(INSTANT_VECTOR):
     Function(predict_linear):
         RangeSelector:
-            range:
-                IntervalLiteral(1200)
+            range: 1200
             InstantSelector:
                 __name__ EQ 'demo_disk_usage_bytes'
-        ScalarLiteral(600)
+        Scalar(600)
 )");
 
     EXPECT_EQ(parseAndDumpTree("time()"), R"(
@@ -696,8 +691,7 @@ PrometheusQueryTree(INSTANT_VECTOR):
 PrometheusQueryTree(INSTANT_VECTOR):
     Function(irate):
         RangeSelector:
-            range:
-                IntervalLiteral(1200)
+            range: 1200
             InstantSelector:
                 __name__ EQ 'demo_cpu_usage_seconds_total'
 )");
@@ -707,7 +701,7 @@ PrometheusQueryTree(INSTANT_VECTOR):
     Function(clamp_max):
         InstantSelector:
             __name__ EQ 'demo_memory_usage_bytes'
-        ScalarLiteral(2)
+        Scalar(2)
 )");
 
     EXPECT_EQ(parseAndDumpTree("clamp(demo_memory_usage_bytes, 0, 1)"), R"(
@@ -715,8 +709,8 @@ PrometheusQueryTree(INSTANT_VECTOR):
     Function(clamp):
         InstantSelector:
             __name__ EQ 'demo_memory_usage_bytes'
-        ScalarLiteral(0)
-        ScalarLiteral(1)
+        Scalar(0)
+        Scalar(1)
 )");
 
     EXPECT_EQ(parseAndDumpTree("clamp(demo_memory_usage_bytes, 0, 1000000000000)"), R"(
@@ -724,16 +718,15 @@ PrometheusQueryTree(INSTANT_VECTOR):
     Function(clamp):
         InstantSelector:
             __name__ EQ 'demo_memory_usage_bytes'
-        ScalarLiteral(0)
-        ScalarLiteral(1000000000000)
+        Scalar(0)
+        Scalar(1000000000000)
 )");
 
     EXPECT_EQ(parseAndDumpTree("resets(demo_cpu_usage_seconds_total[20m])"), R"(
 PrometheusQueryTree(INSTANT_VECTOR):
     Function(resets):
         RangeSelector:
-            range:
-                IntervalLiteral(1200)
+            range: 1200
             InstantSelector:
                 __name__ EQ 'demo_cpu_usage_seconds_total'
 )");
@@ -742,8 +735,7 @@ PrometheusQueryTree(INSTANT_VECTOR):
 PrometheusQueryTree(INSTANT_VECTOR):
     Function(changes):
         RangeSelector:
-            range:
-                IntervalLiteral(1200)
+            range: 1200
             InstantSelector:
                 __name__ EQ 'demo_batch_last_success_timestamp_seconds'
 )");
@@ -751,7 +743,7 @@ PrometheusQueryTree(INSTANT_VECTOR):
     EXPECT_EQ(parseAndDumpTree("vector(1.23)"), R"(
 PrometheusQueryTree(INSTANT_VECTOR):
     Function(vector):
-        ScalarLiteral(1.23)
+        Scalar(1.23)
 )");
 
     EXPECT_EQ(parseAndDumpTree("vector(time())"), R"(
@@ -763,11 +755,10 @@ PrometheusQueryTree(INSTANT_VECTOR):
     EXPECT_EQ(parseAndDumpTree("histogram_quantile(0.5, rate(demo_api_request_duration_seconds_bucket[1m]))"), R"(
 PrometheusQueryTree(INSTANT_VECTOR):
     Function(histogram_quantile):
-        ScalarLiteral(0.5)
+        Scalar(0.5)
         Function(rate):
             RangeSelector:
-                range:
-                    IntervalLiteral(60)
+                range: 60
                 InstantSelector:
                     __name__ EQ 'demo_api_request_duration_seconds_bucket'
 )");
@@ -775,7 +766,7 @@ PrometheusQueryTree(INSTANT_VECTOR):
     EXPECT_EQ(parseAndDumpTree("histogram_quantile(0.9, demo_memory_usage_bytes)"), R"(
 PrometheusQueryTree(INSTANT_VECTOR):
     Function(histogram_quantile):
-        ScalarLiteral(0.9)
+        Scalar(0.9)
         InstantSelector:
             __name__ EQ 'demo_memory_usage_bytes'
 )");
@@ -785,7 +776,7 @@ PrometheusQueryTree(INSTANT_VECTOR):
     )"), R"(
 PrometheusQueryTree(INSTANT_VECTOR):
     Function(histogram_quantile):
-        ScalarLiteral(0.9)
+        Scalar(0.9)
         InstantSelector:
             __name__ RE 'demo_api_request_duration_seconds_.+'
 )");
@@ -811,35 +802,29 @@ PrometheusQueryTree(INSTANT_VECTOR):
     EXPECT_EQ(parseAndDumpTree("max_over_time((time() - max(demo_batch_last_success_timestamp_seconds) < 1000)[5m:10s] offset 5m)"), R"(
 PrometheusQueryTree(INSTANT_VECTOR):
     Function(max_over_time):
-        At:
-            offset:
-                IntervalLiteral(300)
+        Offset:
+            offset: 300
             Subquery:
-                range:
-                    IntervalLiteral(300)
-                resolution:
-                    IntervalLiteral(10)
+                range: 300
+                resolution: 10
                 BinaryOperator(<)
                     BinaryOperator(-)
                         Function(time)
                         AggregationOperator(max)
                             InstantSelector:
                                 __name__ EQ 'demo_batch_last_success_timestamp_seconds'
-                    ScalarLiteral(1000)
+                    Scalar(1000)
 )");
 
     EXPECT_EQ(parseAndDumpTree("avg_over_time(rate(demo_cpu_usage_seconds_total[1m])[2m:10s])"), R"(
 PrometheusQueryTree(INSTANT_VECTOR):
     Function(avg_over_time):
         Subquery:
-            range:
-                IntervalLiteral(120)
-            resolution:
-                IntervalLiteral(10)
+            range: 120
+            resolution: 10
             Function(rate):
                 RangeSelector:
-                    range:
-                        IntervalLiteral(60)
+                    range: 60
                     InstantSelector:
                         __name__ EQ 'demo_cpu_usage_seconds_total'
 )");
@@ -851,58 +836,58 @@ TEST(PrometheusQueryTree, ParseOtherQueries)
 {
     EXPECT_EQ(parseAndDumpTree("0.74"), R"(
 PrometheusQueryTree(SCALAR):
-    ScalarLiteral(0.74)
+    Scalar(0.74)
 )");
 
     EXPECT_EQ(parseAndDumpTree("2e-5"), R"(
 PrometheusQueryTree(SCALAR):
-    ScalarLiteral(0.00002)
+    Scalar(0.00002)
 )");
 
     EXPECT_EQ(parseAndDumpTree("1.5E4"), R"(
 PrometheusQueryTree(SCALAR):
-    ScalarLiteral(15000)
+    Scalar(15000)
 )");
 
     EXPECT_EQ(parseAndDumpTree("0xABcd"), R"(
 PrometheusQueryTree(SCALAR):
-    ScalarLiteral(43981)
+    Scalar(43981)
 )");
 
     EXPECT_EQ(parseAndDumpTree("3h20m10s5ms"), R"(
 PrometheusQueryTree(SCALAR):
-    IntervalLiteral(12010.005)
+    Scalar(12010.005)
 )");
 
     EXPECT_EQ(parseAndDumpTree("-1"), R"(
 PrometheusQueryTree(SCALAR):
     UnaryOperator(-)
-        ScalarLiteral(1)
+        Scalar(1)
 )");
 
     EXPECT_EQ(parseAndDumpTree("Inf+inf+iNf"), R"(
 PrometheusQueryTree(SCALAR):
     BinaryOperator(+)
         BinaryOperator(+)
-            ScalarLiteral(inf)
-            ScalarLiteral(inf)
-        ScalarLiteral(inf)
+            Scalar(inf)
+            Scalar(inf)
+        Scalar(inf)
 )");
 
     EXPECT_EQ(parseAndDumpTree("NaN+nan+nAn"), R"(
 PrometheusQueryTree(SCALAR):
     BinaryOperator(+)
         BinaryOperator(+)
-            ScalarLiteral(nan)
-            ScalarLiteral(nan)
-        ScalarLiteral(nan)
+            Scalar(nan)
+            Scalar(nan)
+        Scalar(nan)
 )");
 
     EXPECT_EQ(parseAndDumpTree("0x_1_2_3 * 0X_A_B"), R"(
 PrometheusQueryTree(SCALAR):
     BinaryOperator(*)
-        ScalarLiteral(291)
-        ScalarLiteral(171)
+        Scalar(291)
+        Scalar(171)
 )");
 
     EXPECT_EQ(parseAndDumpTree(R"(
@@ -930,8 +915,7 @@ PrometheusQueryTree(INSTANT_VECTOR):
     )"), R"(
 PrometheusQueryTree(RANGE_VECTOR):
     RangeSelector:
-        range:
-            IntervalLiteral(300)
+        range: 300
         InstantSelector:
             __name__ EQ 'http_requests_total'
             job EQ 'prometheus'
@@ -939,25 +923,20 @@ PrometheusQueryTree(RANGE_VECTOR):
 
     EXPECT_EQ(parseAndDumpTree("http_requests_total offset 5m @ 1609746000"), R"(
 PrometheusQueryTree(INSTANT_VECTOR):
-    At:
-        at:
-            ScalarLiteral(1609746000)
-        offset:
-            IntervalLiteral(300)
+    Offset:
+        at: 1609746000
+        offset: 300
         InstantSelector:
             __name__ EQ 'http_requests_total'
 )");
 
     EXPECT_EQ(parseAndDumpTree("http_requests_total[5m:1m] offset -10s"), R"(
 PrometheusQueryTree(RANGE_VECTOR):
-    At:
-        offset:
-            IntervalLiteral(-10)
+    Offset:
+        offset: -10
         Subquery:
-            range:
-                IntervalLiteral(300)
-            resolution:
-                IntervalLiteral(60)
+            range: 300
+            resolution: 60
             InstantSelector:
                 __name__ EQ 'http_requests_total'
 )");

--- a/src/Storages/StoragePrometheusQuery.cpp
+++ b/src/Storages/StoragePrometheusQuery.cpp
@@ -59,6 +59,7 @@ void StoragePrometheusQuery::read(
     time_series_table_info.value_data_type = data_table_metadata->columns.get(TimeSeriesColumnNames::Value).type;
 
     LOG_INFO(log, "Building SQL to evaluate promql: {}", promql_query);
+
     PrometheusQueryToSQLConverter converter{promql_query, time_series_table_info, 5*60, 15};
     if (!evaluation_time.isNull())
         converter.setEvaluationTime(evaluation_time);

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL.cpp
@@ -58,92 +58,74 @@ namespace
 
     /// Casts field to the timestamp data type or to the interval data type.
     template <is_decimal T>
-    DecimalField<T> fieldToDecimal(const Field & field, const DataTypePtr & target_data_type)
+    T fieldToDecimal(const Field & field, UInt32 target_scale)
     {
-        UInt32 target_scale = 0;
-        Int64 target_scale_multiplier = 1;
-        if (WhichDataType{*target_data_type}.isDateTime64() || WhichDataType{*target_data_type}.isDecimal())
-        {
-            target_scale = getDecimalScale(*target_data_type);
-            target_scale_multiplier = DecimalUtils::scaleMultiplier<Int64>(target_scale);
-        }
-
         switch (field.getType())
         {
             case Field::Types::Int64:
-                return DecimalField<T>{field.safeGet<Int64>() * target_scale_multiplier, target_scale};
+            {
+                return field.safeGet<Int64>() * DecimalUtils::scaleMultiplier<T>(target_scale);
+            }
             case Field::Types::UInt64:
-                return DecimalField<T>{field.safeGet<UInt64>() * target_scale_multiplier, target_scale};
+            {
+                return field.safeGet<UInt64>() * DecimalUtils::scaleMultiplier<T>(target_scale);
+            }
             case Field::Types::Float64:
-                return DecimalField<T>{static_cast<Int64>(field.safeGet<Float64>() * static_cast<double>(target_scale_multiplier)), target_scale};
+            {
+                return static_cast<typename T::NativeType>(
+                    field.safeGet<Float64>() * static_cast<Float64>(DecimalUtils::scaleMultiplier<T>(target_scale)));
+            }
             case Field::Types::Decimal32:
             {
                 auto x = field.safeGet<Decimal32>();
-                return DecimalField<T>{DecimalUtils::convertTo<Decimal64>(target_scale, x.getValue(), x.getScale()), target_scale};
+                return DecimalUtils::convertTo<Decimal64>(target_scale, x.getValue(), x.getScale());
             }
             case Field::Types::Decimal64:
             {
                 auto x = field.safeGet<Decimal64>();
-                return DecimalField<T>{DecimalUtils::convertTo<Decimal64>(target_scale, x.getValue(), x.getScale()), target_scale};
+                return DecimalUtils::convertTo<Decimal64>(target_scale, x.getValue(), x.getScale());
             }
             default:
-                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Cannot cast field of type {} to data type {}", field.getType(), target_data_type);
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Cannot cast field of type {} to duration", field.getType());
         }
     }
 
     /// Converts a timestamp or an interval to AST.
     template <is_decimal T>
-    ASTPtr decimalToAST(const DecimalField<T> & decimal, const DataTypePtr & data_type)
+    ASTPtr decimalToAST(T decimal, UInt32 scale, const DataTypePtr & data_type)
     {
         auto data_type_idx = WhichDataType{*data_type}.idx;
         if (data_type_idx == TypeIndex::DateTime64)
         {
-            String str = toString(decimal);
+            String str = toString(decimal, scale);
             if (str.find_first_of(".eE") == String::npos)
                 str += "."; /// toDateTime64() doesn't accept an integer as its first argument, so we convert it to float.
-            return makeASTFunction("toDateTime64", make_intrusive<ASTLiteral>(str), make_intrusive<ASTLiteral>(getDecimalScale(*data_type)));
+            return makeASTFunction("toDateTime64", make_intrusive<ASTLiteral>(str), make_intrusive<ASTLiteral>(scale));
         }
         else if (data_type_idx == TypeIndex::Decimal64)
-            return makeASTFunction("toDecimal64", make_intrusive<ASTLiteral>(toString(decimal)), make_intrusive<ASTLiteral>(getDecimalScale(*data_type)));
+            return makeASTFunction("toDecimal64", make_intrusive<ASTLiteral>(toString(decimal, scale)), make_intrusive<ASTLiteral>(scale));
         else
-            return make_intrusive<ASTLiteral>(Field{decimal});
-    }
-
-    /// Subtracts an interval from a timestamp.
-    DecimalField<DateTime64> subtract(const DecimalField<DateTime64> & left, const DecimalField<Decimal64> & right)
-    {
-        UInt32 scale = left.getScale();
-        chassert(right.getScale() == scale);
-        return DecimalField<DateTime64>{left.getValue() - right.getValue(), scale};
-    }
-
-    /// Returns the previous interval value.
-    DecimalField<Decimal64> previous(const DecimalField<Decimal64> & interval)
-    {
-        chassert(interval.getValue() > 0);
-        return DecimalField<Decimal64>{interval.getValue() - 1, interval.getScale()};
+            return make_intrusive<ASTLiteral>(DecimalField<T>{decimal, scale});
     }
 
     /// Increases a timestamp to make it divisible by `step`.
-    DecimalField<DateTime64> alignUp(const DecimalField<DateTime64> & time, const DecimalField<Decimal64> & step)
+    DateTime64 alignUp(DateTime64 time, Decimal64 step)
     {
-        UInt32 scale = step.getScale();
-        chassert((step.getValue() > 0) && (scale == time.getScale()));
-        auto x = time.getValue() % step.getValue();
+        chassert(step > 0);
+        auto x = time % step;
         if (!x)
             return time;
-        return DecimalField<DateTime64>{time.getValue() + step.getValue() - x, scale};
+        return time + step - x;
     }
 
     /// Decreases a timestamp to make it divisible by `step`.
-    DecimalField<DateTime64> alignDown(const DecimalField<DateTime64> & time, const DecimalField<Decimal64> & step)
+    DateTime64 alignDown(DateTime64 time, Decimal64 step)
     {
-        UInt32 scale = time.getScale();
-        chassert((step.getValue() > 0) && (scale == time.getScale()));
-        auto x = time.getValue() % step.getValue();
+        chassert(step > 0);
+        auto x = time % step;
         if (!x)
             return time;
-        return DecimalField<DateTime64>{time.getValue() - x, scale};
+        return time - x;
     }
 }
 
@@ -155,12 +137,12 @@ public:
     explicit ASTBuilder(const PrometheusQueryToSQLConverter & converter_)
         : converter(converter_)
         , timestamp_data_type(getTimeSeriesTableInfo().timestamp_data_type)
+        , timestamp_scale((isDecimal(timestamp_data_type) || isDateTime64(timestamp_data_type)) ? getDecimalScale(*timestamp_data_type) : 0)
         , interval_data_type(getIntervalDataType(timestamp_data_type))
         , value_data_type(getTimeSeriesTableInfo().value_data_type)
         , lookback_delta(fieldToInterval(converter_.lookback_delta))
         , default_resolution(fieldToInterval(converter_.default_resolution))
         , result_type(converter_.result_type)
-        , interval_scale(lookback_delta.getScale())
     {
         if (!converter_.evaluation_time.isNull())
         {
@@ -186,20 +168,20 @@ public:
 private:
     const PrometheusQueryToSQLConverter & converter;
     DataTypePtr timestamp_data_type;
+    UInt32 timestamp_scale;
     DataTypePtr interval_data_type;
     DataTypePtr value_data_type;
-    DecimalField<Decimal64> lookback_delta;
-    DecimalField<Decimal64> default_resolution;
+    Decimal64 lookback_delta;
+    Decimal64 default_resolution;
     PrometheusQueryResultType result_type;
-    UInt32 interval_scale;
 
-    std::optional<DecimalField<DateTime64>> evaluation_time;
+    std::optional<DateTime64> evaluation_time;
 
     struct EvaluationRange
     {
-        DecimalField<DateTime64> start_time;
-        DecimalField<DateTime64> end_time;
-        DecimalField<Decimal64> step;
+        DateTime64 start_time;
+        DateTime64 end_time;
+        Decimal64 step;
     };
     std::optional<EvaluationRange> evaluation_range;
 
@@ -219,7 +201,7 @@ private:
         ResultType result_type;
 
         /// A window is extracted from a range selector. The window is used only by functions accepting range vectors, e.g. rate().
-        DecimalField<Decimal64> window;
+        Decimal64 window;
 
         /// Columns to select (nullptr if there is no such column).
         /// The names of these columns are always TimeSeriesColumnNames::Group, TimeSeriesColumnNames::Tags and so on.
@@ -567,15 +549,15 @@ private:
     /// Builds a piece to evaluate an instant selector.
     Piece buildPieceForInstantSelector(const PrometheusQueryTree::InstantSelector * instant_selector) const
     {
-        if (lookback_delta.getValue() <= 0)
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "The lookback delta must be positive, got {}", toString(lookback_delta));
+        if (lookback_delta <= 0)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "The lookback delta must be positive, got {}", toString(lookback_delta, timestamp_scale));
 
         /// Lookback deltas are left-open (and right-closed), so we decrease `window` a little bit to consider both boundaries close.
         auto window = lookback_delta;
 
-        DecimalField<DateTime64> start_time;
-        DecimalField<DateTime64> end_time;
-        DecimalField<Decimal64> step;
+        DateTime64 start_time;
+        DateTime64 end_time;
+        Decimal64 step;
         extractRangeAndStep(instant_selector, start_time, end_time, step);
 
         /// We can get an empty interval here because of aligning in extractRangeAndStep().
@@ -588,7 +570,7 @@ private:
             make_intrusive<ASTLiteral>(getTimeSeriesTableInfo().storage_id.getDatabaseName()),
             make_intrusive<ASTLiteral>(getTimeSeriesTableInfo().storage_id.getTableName()),
             make_intrusive<ASTLiteral>(getPromQLText(instant_selector)),
-            timestampToAST(subtract(start_time, previous(window))),
+            timestampToAST(start_time - window + 1),
             timestampToAST(end_time));
 
         res.group_column = makeASTFunction("timeSeriesIdToTagsGroup", make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::ID));
@@ -610,16 +592,16 @@ private:
     {
         const auto * instant_selector = range_selector->getInstantSelector();
 
-        auto range = DecimalField<Decimal64>{range_selector->range, getPromQLTree().getTimestampScale()};
-        if (range.getValue() <= 0)
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Range specified in a range selector must be positive, got {}", toString(range));
+        auto range = range_selector->range;
+        if (range <= 0)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Range specified in a range selector must be positive, got {}", toString(range, timestamp_scale));
 
         /// Ranges are left-open (and right-closed), so we decrease `window` a little bit to consider both boundaries close.
         auto window = range;
 
-        DecimalField<DateTime64> start_time;
-        DecimalField<DateTime64> end_time;
-        DecimalField<Decimal64> step;
+        DateTime64 start_time;
+        DateTime64 end_time;
+        Decimal64 step;
         extractRangeAndStep(range_selector, start_time, end_time, step);
 
         /// We can get an empty interval here because of aligning in extractRangeAndStep().
@@ -632,7 +614,7 @@ private:
             make_intrusive<ASTLiteral>(getTimeSeriesTableInfo().storage_id.getDatabaseName()),
             make_intrusive<ASTLiteral>(getTimeSeriesTableInfo().storage_id.getTableName()),
             make_intrusive<ASTLiteral>(getPromQLText(instant_selector)),
-            timestampToAST(subtract(start_time, previous(window))),
+            timestampToAST(start_time - window + 1),
             timestampToAST(end_time));
 
         res.group_column = makeASTFunction("timeSeriesIdToTagsGroup", make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::ID));
@@ -654,7 +636,7 @@ private:
             return getEmptyPiece(ResultType::RANGE_VECTOR);
 
         piece.result_type = ResultType::RANGE_VECTOR;
-        piece.window = DecimalField<Decimal64>{subquery->range, getPromQLTree().getTimestampScale()};
+        piece.window = subquery->range;
         return piece;
     }
 
@@ -760,9 +742,9 @@ private:
 
         auto window = argument.window;
 
-        DecimalField<DateTime64> start_time;
-        DecimalField<DateTime64> end_time;
-        DecimalField<Decimal64> step;
+        DateTime64 start_time;
+        DateTime64 end_time;
+        Decimal64 step;
         extractRangeAndStep(func, start_time, end_time, step);
 
         /// We can get an empty interval here because of aligning in extractRangeAndStep().
@@ -834,8 +816,8 @@ private:
     /// Builds an AST to call functions generating time series on a grid.
     /// Returns something like timeSeriesFromGrid(<start_time>, <step>, timeSeries*ToGrid(<start_time>, <end_time>, <step>, <window>)(<timestamp>, <value>)
     ASTPtr makeGridFunction(std::string_view grid_function_name,
-                            const DecimalField<DateTime64> & start_time, const DecimalField<DateTime64> & end_time,
-                            const DecimalField<Decimal64> & step, const DecimalField<Decimal64> & window,
+                            DateTime64 start_time, DateTime64 end_time,
+                            Decimal64 step, Decimal64 window,
                             ASTPtr timestamp_column, ASTPtr value_column) const
     {
         auto aggregate_function = makeASTFunction(grid_function_name, timestamp_column, value_column);
@@ -851,7 +833,7 @@ private:
     /// and determine the total time range and optionally the step used in the most inner subquery.
     /// The function always set `start_time` and `end_time`. If the node isn't used in any subquery the function sets `step` to 0.
     void extractRangeAndStep(const PrometheusQueryTree::Node * node,
-                             DecimalField<DateTime64> & start_time, DecimalField<DateTime64> & end_time, DecimalField<Decimal64> & step) const
+                             DateTime64 & start_time, DateTime64 & end_time, Decimal64 & step) const
     {
         parent_nodes.clear();
         for (const auto * parent = node; parent; parent = parent->parent)
@@ -861,7 +843,7 @@ private:
         {
             start_time = *evaluation_time;
             end_time = *evaluation_time;
-            step = getZeroInterval();
+            step = 0;
         }
         else
         {
@@ -878,16 +860,16 @@ private:
                 const auto * offset_node = typeid_cast<const PrometheusQueryTree::Offset *>(parent);
                 if (offset_node->at_timestamp)
                 {
-                    start_time = DecimalField<DateTime64>{*offset_node->at_timestamp, getPromQLTree().getTimestampScale()};
+                    start_time = *offset_node->at_timestamp;
                     end_time = start_time;
-                    step = getZeroInterval();
+                    step = 0;
                 }
                 if (offset_node->offset_value)
                 {
                     /// The "offset" modifier moves the evaluation time backward.
-                    auto offset = DecimalField<Decimal64>{*offset_node->offset_value, getPromQLTree().getTimestampScale()};
-                    start_time = subtract(start_time, offset);
-                    end_time = subtract(end_time, offset);
+                    auto offset = *offset_node->offset_value;
+                    start_time = start_time - offset;
+                    end_time = end_time - offset;
                 }
             }
             else if (parent->node_type == NodeType::Subquery)
@@ -895,20 +877,20 @@ private:
                 const auto * subquery_node = typeid_cast<const PrometheusQueryTree::Subquery *>(parent);
                 if (subquery_node->resolution)
                 {
-                    step = DecimalField<Decimal64>{*subquery_node->resolution, getPromQLTree().getTimestampScale()};
-                    if (step.getValue() <= 0)
-                        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Resolution must be positive, got {}", toString(step));
+                    step = *subquery_node->resolution;
+                    if (step <= 0)
+                        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Resolution must be positive, got {}", toString(step, timestamp_scale));
                 }
                 else
                 {
-                    if (default_resolution.getValue() <= 0)
-                        throw Exception(ErrorCodes::BAD_ARGUMENTS, "The default resolution must be positive, got {}", toString(default_resolution));
+                    if (default_resolution <= 0)
+                        throw Exception(ErrorCodes::BAD_ARGUMENTS, "The default resolution must be positive, got {}", toString(default_resolution, timestamp_scale));
                     step = default_resolution;
                 }
-                auto subquery_range = DecimalField<Decimal64>{subquery_node->range, getPromQLTree().getTimestampScale()};
-                if (subquery_range.getValue() <= 0)
-                    throw Exception(ErrorCodes::BAD_ARGUMENTS, "Subquery range must be positive, got {}", toString(subquery_range));
-                start_time = subtract(start_time, previous(subquery_range));
+                auto subquery_range = subquery_node->range;
+                if (subquery_range <= 0)
+                    throw Exception(ErrorCodes::BAD_ARGUMENTS, "Subquery range must be positive, got {}", toString(subquery_range, timestamp_scale));
+                start_time = start_time - subquery_range + 1;
 
                 /// We need to align `start_time` and `end_time` by `step` if there is a subquery.
                 /// (See https://www.robustperception.io/promql-subqueries-and-alignment/)
@@ -919,33 +901,27 @@ private:
     }
 
     /// Converts a scalar or an interval value to a timestamp compatible with the data types used in the TimeSeries table.
-    DecimalField<DateTime64> fieldToTimestamp(const Field & field) const
+    DateTime64 fieldToTimestamp(const Field & field) const
     {
-        return fieldToDecimal<DateTime64>(field, timestamp_data_type);
+        return fieldToDecimal<DateTime64>(field, timestamp_scale);
     }
 
     /// Converts a scalar or an interval value to an interval compatible with the data types used in the TimeSeries table.
-    DecimalField<Decimal64> fieldToInterval(const Field & field) const
+    Decimal64 fieldToInterval(const Field & field) const
     {
-        return fieldToDecimal<Decimal64>(field, interval_data_type);
-    }
-
-    /// Returns a zero interval with the correct scale.
-    DecimalField<Decimal64> getZeroInterval() const
-    {
-        return DecimalField<Decimal64>{0, interval_scale};
+        return fieldToDecimal<Decimal64>(field, timestamp_scale);
     }
 
     /// Converts a timestamp to AST.
-    ASTPtr timestampToAST(const DecimalField<DateTime64> & field) const
+    ASTPtr timestampToAST(DateTime64 timestamp) const
     {
-        return decimalToAST(field, timestamp_data_type);
+        return decimalToAST(timestamp, timestamp_scale, timestamp_data_type);
     }
 
     /// Converts a interval to AST.
-    ASTPtr intervalToAST(const DecimalField<Decimal64> & field) const
+    ASTPtr intervalToAST(Decimal64 interval) const
     {
-        return decimalToAST(field, interval_data_type);
+        return decimalToAST(interval, timestamp_scale, interval_data_type);
     }
 };
 

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL.cpp
@@ -610,7 +610,7 @@ private:
     {
         const auto * instant_selector = range_selector->getInstantSelector();
 
-        auto range = range_selector->range;
+        auto range = DecimalField<Decimal64>{range_selector->range, getPromQLTree().getTimestampScale()};
         if (range.getValue() <= 0)
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Range specified in a range selector must be positive, got {}", toString(range));
 
@@ -654,7 +654,7 @@ private:
             return getEmptyPiece(ResultType::RANGE_VECTOR);
 
         piece.result_type = ResultType::RANGE_VECTOR;
-        piece.window = subquery->range;
+        piece.window = DecimalField<Decimal64>{subquery->range, getPromQLTree().getTimestampScale()};
         return piece;
     }
 
@@ -878,14 +878,14 @@ private:
                 const auto * offset_node = typeid_cast<const PrometheusQueryTree::Offset *>(parent);
                 if (offset_node->at_timestamp)
                 {
-                    start_time = *offset_node->at_timestamp;
+                    start_time = DecimalField<DateTime64>{*offset_node->at_timestamp, getPromQLTree().getTimestampScale()};
                     end_time = start_time;
                     step = getZeroInterval();
                 }
                 if (offset_node->offset_value)
                 {
                     /// The "offset" modifier moves the evaluation time backward.
-                    auto offset = *offset_node->offset_value;
+                    auto offset = DecimalField<Decimal64>{*offset_node->offset_value, getPromQLTree().getTimestampScale()};
                     start_time = subtract(start_time, offset);
                     end_time = subtract(end_time, offset);
                 }
@@ -895,7 +895,7 @@ private:
                 const auto * subquery_node = typeid_cast<const PrometheusQueryTree::Subquery *>(parent);
                 if (subquery_node->resolution)
                 {
-                    step = *subquery_node->resolution;
+                    step = DecimalField<Decimal64>{*subquery_node->resolution, getPromQLTree().getTimestampScale()};
                     if (step.getValue() <= 0)
                         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Resolution must be positive, got {}", toString(step));
                 }
@@ -905,7 +905,7 @@ private:
                         throw Exception(ErrorCodes::BAD_ARGUMENTS, "The default resolution must be positive, got {}", toString(default_resolution));
                     step = default_resolution;
                 }
-                auto subquery_range = subquery_node->range;
+                auto subquery_range = DecimalField<Decimal64>{subquery_node->range, getPromQLTree().getTimestampScale()};
                 if (subquery_range.getValue() <= 0)
                     throw Exception(ErrorCodes::BAD_ARGUMENTS, "Subquery range must be positive, got {}", toString(subquery_range));
                 start_time = subtract(start_time, previous(subquery_range));


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

PromQL: Simplify storing ranges and offsets in `PrometheusQueryTree`,
use `DateTime64` instead of `DecimalField<DateTime64>`.

Part of https://github.com/ClickHouse/ClickHouse/pull/89356


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.117`
<!-- ch-version-info:end -->