### PR TITLE
Make `NamesHash` reusable across the codebase

### DIFF
--- a/src/Core/Names.cpp
+++ b/src/Core/Names.cpp
@@ -1,0 +1,16 @@
+#include <Core/Names.h>
+
+#include <Common/SipHash.h>
+
+namespace DB
+{
+
+size_t NamesHash::operator()(const Names & column_names) const
+{
+    SipHash hash;
+    for (const auto & column_name : column_names)
+        hash.update(column_name);
+    return hash.get64();
+}
+
+}

--- a/src/Core/Names.h
+++ b/src/Core/Names.h
@@ -22,4 +22,8 @@ using NameToIndexMap = std::unordered_map<std::string, size_t>;
 using NameWithAlias = std::pair<std::string, std::string>;
 using NamesWithAliases = std::vector<NameWithAlias>;
 
+struct NamesHash
+{
+    size_t operator()(const Names & column_names) const;
+};
 }

--- a/src/Storages/MergeTree/MergeTreeReadersChain.cpp
+++ b/src/Storages/MergeTree/MergeTreeReadersChain.cpp
@@ -356,17 +356,6 @@ void MergeTreeReadersChain::applyPatchesAfterReader(ReadResult & result, size_t 
         result.columns_for_patches);
 }
 
-struct NamesHash
-{
-    size_t operator()(const Names & column_names) const
-    {
-        SipHash hash;
-        for (const auto & column_name : column_names)
-            hash.update(column_name);
-        return hash.get64();
-    }
-};
-
 void MergeTreeReadersChain::applyPatches(
     const Block & result_header,
     Columns & result_columns,


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.28`
<!-- ch-version-info:end -->