### PR TITLE
Disable parallel queries in CI

### DIFF
--- a/ci/jobs/buzzhouse_job.py
+++ b/ci/jobs/buzzhouse_job.py
@@ -179,14 +179,16 @@ def main():
         "max_insert_rows": random.randint(min_insert_rows, max_insert_rows),
         "min_string_length": min_string_length,
         "max_string_length": random.randint(min_string_length, max_string_length),
-        "max_parallel_queries": (
-            1
-            if (
-                any(x in Info().job_name for x in ["tsan", "asan", "msan"])
-                or random.randint(1, 2) == 1
-            )
-            else random.randint(1, 5)
-        ),
+        # Disable parallel queries, there are issues in the CI currently
+        # "max_parallel_queries": (
+        #    1
+        #    if (
+        #        any(x in Info().job_name for x in ["tsan", "asan", "msan"])
+        #        or random.randint(1, 2) == 1
+        #    )
+        #    else random.randint(1, 5)
+        # ),
+        "max_parallel_queries": 1,
         "max_number_alters": (1 if random.randint(1, 2) == 1 else random.randint(1, 4)),
         "fuzz_floating_points": random.choice([True, False]),
         "enable_fault_injection_settings": random.randint(1, 4) == 1,


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

cc @maxknv this should mitigate this case https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=95162&sha=d6d4d2b85e09835c092c427c7a762af3f11afad6&name_0=PR&name_1=BuzzHouse%20%28amd_debug%29
https://github.com/ClickHouse/ClickHouse/pull/95162 I enabled parallel queries a few PRs back, but I didn't realize this issue still exists with them.

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.30`
<!-- ch-version-info:end -->