### PR TITLE
Wait for Keeper to start

### DIFF
--- a/tests/integration/test_keeper_log_gap_before_committed/test.py
+++ b/tests/integration/test_keeper_log_gap_before_committed/test.py
@@ -30,6 +30,7 @@ def get_fake_zk(timeout=30.0):
 
 def start_clickhouse():
     node1.start_clickhouse()
+    keeper_utils.wait_until_connected(cluster, node1)
 
 
 def test_keeper_log_gap_before_committed(started_cluster):


### PR DESCRIPTION
After restarting clickhouse, Keeper can ignore requests until the Keeper is initialized properly. Let's wait until it is started and don't try to connect until that, because those tries end up in broken connection and connection failure.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.35`
<!-- ch-version-info:end -->