### PR TITLE
Fix `pointInPolygon` performance test

### DIFF
--- a/tests/performance/point_in_polygon_3d_huge_multipolygon.xml
+++ b/tests/performance/point_in_polygon_3d_huge_multipolygon.xml
@@ -72,16 +72,15 @@
                 toInt32(rand64(number*41) % 2001 - 1000),
                 toInt32(rand64(number*43) % 2001 - 1000)
             ) AS pt
-        FROM numbers(200_000);
+        FROM numbers(500_000);
     </create_query>
 
     <query>
         WITH
-            (SELECT poly FROM multipoly_holder LIMIT 1) AS mp,
-            arrayShuffle(mp) AS mp_shuffled
+            (SELECT poly FROM multipoly_holder LIMIT 1) AS mp
         SELECT count()
         FROM random_pts
-        WHERE NOT ignore(pointInPolygon(pt, mp_shuffled));
+        WHERE NOT ignore(pointInPolygon(pt, mp));
     </query>
     <drop_query>DROP TABLE IF EXISTS random_polys;</drop_query>
     <drop_query>DROP TABLE IF EXISTS multipoly_holder;</drop_query>


### PR DESCRIPTION
Previously, the performance test used `arrayShuffle` which created constant column. But after https://github.com/ClickHouse/ClickHouse/pull/94134, `arrayShuffle` no longer creates constant column in this scenario, leading to materialization over `200_000` rows causing memory limit exceeded.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Closes https://github.com/ClickHouse/ClickHouse/issues/95291

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.42`
<!-- ch-version-info:end -->