### PR TITLE
Add `no-azure-blob-storage` tag to tests that consistently time out

### DIFF
--- a/tests/queries/0_stateless/00443_preferred_block_size_bytes.sh
+++ b/tests/queries/0_stateless/00443_preferred_block_size_bytes.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-random-merge-tree-settings
+# Tags: no-random-merge-tree-settings, no-azure-blob-storage
 
 set -e
 

--- a/tests/queries/0_stateless/01114_database_atomic.sh
+++ b/tests/queries/0_stateless/01114_database_atomic.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest
+# Tags: no-fasttest, no-azure-blob-storage
 # Tag no-fasttest: 45 seconds running
 
 # Creation of a database with Ordinary engine emits a warning.

--- a/tests/queries/0_stateless/01167_isolation_hermitage.sh
+++ b/tests/queries/0_stateless/01167_isolation_hermitage.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: long, no-fasttest, no-replicated-database, no-ordinary-database, no-encrypted-storage
+# Tags: long, no-fasttest, no-replicated-database, no-ordinary-database, no-encrypted-storage, no-azure-blob-storage
 # Looks like server does not listen https port in fasttest
 # FIXME Replicated database executes ALTERs in separate context, so transaction info is lost
 

--- a/tests/queries/0_stateless/01169_alter_partition_isolation_stress.sh
+++ b/tests/queries/0_stateless/01169_alter_partition_isolation_stress.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: long, no-replicated-database, no-ordinary-database, no-encrypted-storage
+# Tags: long, no-replicated-database, no-ordinary-database, no-encrypted-storage, no-azure-blob-storage
 
 # shellcheck disable=SC2015
 # shellcheck disable=SC2119

--- a/tests/queries/0_stateless/01171_mv_select_insert_isolation_long.sh
+++ b/tests/queries/0_stateless/01171_mv_select_insert_isolation_long.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: long, no-ordinary-database, no-encrypted-storage, no-msan
+# Tags: long, no-ordinary-database, no-encrypted-storage, no-msan, no-azure-blob-storage
 # no-msan: it is too slow
 # shellcheck disable=SC2119
 

--- a/tests/queries/0_stateless/01443_merge_truncate_long.sh
+++ b/tests/queries/0_stateless/01443_merge_truncate_long.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: long, no-async-insert
+# Tags: long, no-async-insert, no-azure-blob-storage
 # no-async-insert: Too many small inserts (each taking async_insert_busy_timeout_max_ms time)
 
 set -e

--- a/tests/queries/0_stateless/01516_drop_table_stress_long.sh
+++ b/tests/queries/0_stateless/01516_drop_table_stress_long.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: long, no-debug
+# Tags: long, no-debug, no-azure-blob-storage
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/01656_sequence_next_node_long.sql
+++ b/tests/queries/0_stateless/01656_sequence_next_node_long.sql
@@ -1,4 +1,4 @@
--- Tags: long
+-- Tags: long, no-azure-blob-storage
 
 SET allow_experimental_funnel_functions = 1;
 

--- a/tests/queries/0_stateless/01666_merge_tree_max_query_limit.sh
+++ b/tests/queries/0_stateless/01666_merge_tree_max_query_limit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Tags: no-azure-blob-storage
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/01871_merge_tree_compile_expressions.sql
+++ b/tests/queries/0_stateless/01871_merge_tree_compile_expressions.sql
@@ -1,3 +1,5 @@
+-- Tags: no-azure-blob-storage
+
 DROP TABLE IF EXISTS data_01875_1;
 DROP TABLE IF EXISTS data_01875_2;
 DROP TABLE IF EXISTS data_01875_3;

--- a/tests/queries/0_stateless/01926_order_by_desc_limit.sql
+++ b/tests/queries/0_stateless/01926_order_by_desc_limit.sql
@@ -1,4 +1,4 @@
--- Tags: no-random-settings
+-- Tags: no-random-settings, no-azure-blob-storage
 
 DROP TABLE IF EXISTS order_by_desc;
 

--- a/tests/queries/0_stateless/02286_parallel_final.sh
+++ b/tests/queries/0_stateless/02286_parallel_final.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-random-merge-tree-settings
+# Tags: no-random-merge-tree-settings, no-azure-blob-storage
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/02346_text_index_array_support.sql
+++ b/tests/queries/0_stateless/02346_text_index_array_support.sql
@@ -1,4 +1,4 @@
--- Tags: no-parallel-replicas
+-- Tags: no-parallel-replicas, no-azure-blob-storage
 
 -- Tests that text indexes can be build on and used with Array columns.
 

--- a/tests/queries/0_stateless/02473_multistep_prewhere.sh
+++ b/tests/queries/0_stateless/02473_multistep_prewhere.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: long, no-parallel, no-sanitizers, no-flaky-check
+# Tags: long, no-parallel, no-sanitizers, no-flaky-check, no-azure-blob-storage
 # ^ The test is heavy
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)

--- a/tests/queries/0_stateless/02481_async_insert_dedup.sh
+++ b/tests/queries/0_stateless/02481_async_insert_dedup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: long, zookeeper, no-fasttest, no-shared-merge-tree
+# Tags: long, zookeeper, no-fasttest, no-shared-merge-tree, no-azure-blob-storage
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/02481_async_insert_dedup_token.sh
+++ b/tests/queries/0_stateless/02481_async_insert_dedup_token.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: long, zookeeper, no-fasttest, no-shared-merge-tree
+# Tags: long, zookeeper, no-fasttest, no-shared-merge-tree, no-azure-blob-storage
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/02941_variant_type_3.sh
+++ b/tests/queries/0_stateless/02941_variant_type_3.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: long
+# Tags: long, no-azure-blob-storage
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/02941_variant_type_4.sh
+++ b/tests/queries/0_stateless/02941_variant_type_4.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: long, no-msan
+# Tags: long, no-msan, no-azure-blob-storage
 # msan: too slow
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)

--- a/tests/queries/0_stateless/02943_variant_type_with_different_local_and_global_order.sh
+++ b/tests/queries/0_stateless/02943_variant_type_with_different_local_and_global_order.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: long, no-debug
+# Tags: long, no-debug, no-azure-blob-storage
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/02950_parallel_replicas_used_count.sql
+++ b/tests/queries/0_stateless/02950_parallel_replicas_used_count.sql
@@ -1,3 +1,5 @@
+-- Tags: no-azure-blob-storage
+
 DROP TABLE IF EXISTS test;
 
 CREATE TABLE test (k UInt64, v String)

--- a/tests/queries/0_stateless/03173_set_transformed_partition_pruning.sql
+++ b/tests/queries/0_stateless/03173_set_transformed_partition_pruning.sql
@@ -1,4 +1,4 @@
--- Tags: no-msan, long
+-- Tags: no-msan, long, no-azure-blob-storage
 -- msan: too slow
 
 SELECT '-- Single partition by function';

--- a/tests/queries/0_stateless/03224_nested_json_merges_new_type_in_shared_data.sql
+++ b/tests/queries/0_stateless/03224_nested_json_merges_new_type_in_shared_data.sql
@@ -1,3 +1,5 @@
+-- Tags: no-azure-blob-storage
+
 SET enable_json_type = 1;
 
 drop table if exists test;

--- a/tests/queries/0_stateless/03237_insert_sparse_columns_mem.sh
+++ b/tests/queries/0_stateless/03237_insert_sparse_columns_mem.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, long
+# Tags: no-fasttest, long, no-azure-blob-storage
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/03403_distributed_merge_two_level_aggregation.sql
+++ b/tests/queries/0_stateless/03403_distributed_merge_two_level_aggregation.sql
@@ -1,4 +1,4 @@
--- Tags: no-fasttest, long
+-- Tags: no-fasttest, long, no-azure-blob-storage
 
 DROP TABLE IF EXISTS test_table_1;
 CREATE TABLE test_table_1(number UInt64) ENGINE = MergeTree ORDER BY number;

--- a/tests/queries/0_stateless/03553_json_shared_data_advanced_serialization.sql
+++ b/tests/queries/0_stateless/03553_json_shared_data_advanced_serialization.sql
@@ -1,4 +1,4 @@
--- Tags: long
+-- Tags: long, no-azure-blob-storage
 
 set output_format_json_quote_64bit_integers=0;
 

--- a/tests/queries/0_stateless/03638_merge_max_dynamic_subcolumns_in_wide_part.sql
+++ b/tests/queries/0_stateless/03638_merge_max_dynamic_subcolumns_in_wide_part.sql
@@ -1,3 +1,5 @@
+-- Tags: no-azure-blob-storage
+
 drop table if exists test;
 create table test (json JSON(max_dynamic_paths=4)) engine=MergeTree order by tuple() settings min_bytes_for_wide_part=1, min_rows_for_wide_part=1, merge_max_dynamic_subcolumns_in_wide_part=2;
 insert into test select '{"a" : 42, "b" : 42, "c" : 42, "d" : 42, "e" : 42, "f" : 42}';

--- a/tests/queries/0_stateless/03753_anti_join_runtime_filter_4.sql
+++ b/tests/queries/0_stateless/03753_anti_join_runtime_filter_4.sql
@@ -1,3 +1,5 @@
+-- Tags: no-azure-blob-storage
+
 CREATE TABLE nation(n_nationkey Int32, n_name String) ENGINE MergeTree ORDER BY n_nationkey;
 CREATE TABLE customer(c_custkey Int32, c_nationkey Int32, c_nationkey_copy Int32) ENGINE MergeTree ORDER BY c_custkey SETTINGS index_granularity=10;
 

--- a/tests/queries/0_stateless/03753_join_runtime_filter_dynamically_disable.sql
+++ b/tests/queries/0_stateless/03753_join_runtime_filter_dynamically_disable.sql
@@ -1,3 +1,5 @@
+-- Tags: no-azure-blob-storage
+
 CREATE TABLE nation(n_nationkey Int32, n_name String) ENGINE MergeTree ORDER BY n_nationkey;
 CREATE TABLE customer(c_custkey Int32, c_nationkey Int32, c_nationkey_copy Int32) ENGINE MergeTree ORDER BY c_custkey SETTINGS index_granularity=10;
 

--- a/tests/queries/0_stateless/03770_min_columns_to_activate_adaptive_write_buffer.sql.j2
+++ b/tests/queries/0_stateless/03770_min_columns_to_activate_adaptive_write_buffer.sql.j2
@@ -1,4 +1,4 @@
--- Tags: no-debug, long, no-distributed-cache
+-- Tags: no-debug, long, no-distributed-cache, no-azure-blob-storage
 -- - no-debug - debug build uses S3 and this in combination works very slow
 -- - no-distributed-cache - distributed cache does not support adaptive buffers
 

--- a/tests/queries/0_stateless/03781_split_join_filter_bug.sql
+++ b/tests/queries/0_stateless/03781_split_join_filter_bug.sql
@@ -1,3 +1,5 @@
+-- Tags: no-azure-blob-storage
+
 CREATE TABLE nation(n_nationkey Int32, n_name String) ENGINE MergeTree ORDER BY n_nationkey;
 CREATE TABLE customer(c_custkey Int32, c_nationkey Int32, c_nationkey_copy Int32) ENGINE MergeTree ORDER BY c_custkey SETTINGS index_granularity=10;
 


### PR DESCRIPTION
These tests take over 300 seconds on Azure blob storage and cause CI failures. Disabling them for Azure runs.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.47`
<!-- ch-version-info:end -->