### PR TITLE
Add `no-msan` tag to tests that consistently time out on MSan

### DIFF
--- a/tests/queries/0_stateless/00024_random_counters.sql
+++ b/tests/queries/0_stateless/00024_random_counters.sql
@@ -1,4 +1,4 @@
--- Tags: stateful, no-parallel
+-- Tags: stateful, no-parallel, no-msan
 -- no-parallel: Heavy
 SELECT uniq(UserID), sum(Sign) FROM test.visits WHERE CounterID = 32152608;
 SELECT uniq(UserID), sum(Sign) FROM test.visits WHERE CounterID = 9627212;

--- a/tests/queries/0_stateless/00090_union_race_conditions_1.sh
+++ b/tests/queries/0_stateless/00090_union_race_conditions_1.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: race
+# Tags: race, no-msan
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/00091_union_race_conditions_2.sh
+++ b/tests/queries/0_stateless/00091_union_race_conditions_2.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: race
+# Tags: race, no-msan
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/00092_union_race_conditions_3.sh
+++ b/tests/queries/0_stateless/00092_union_race_conditions_3.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: race
+# Tags: race, no-msan
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/00094_union_race_conditions_5.sh
+++ b/tests/queries/0_stateless/00094_union_race_conditions_5.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: race
+# Tags: race, no-msan
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/00386_long_in_pk.sh
+++ b/tests/queries/0_stateless/00386_long_in_pk.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: long
+# Tags: long, no-msan
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/00534_functions_bad_arguments1.sh
+++ b/tests/queries/0_stateless/00534_functions_bad_arguments1.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-tsan, no-debug
+# Tags: no-tsan, no-debug, no-msan
 # Tag no-tsan: Too long for TSan
 
 # shellcheck disable=SC2016

--- a/tests/queries/0_stateless/00534_functions_bad_arguments11.sh
+++ b/tests/queries/0_stateless/00534_functions_bad_arguments11.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-tsan, no-debug
+# Tags: no-tsan, no-debug, no-msan
 # Tag no-tsan: Too long for TSan
 
 # shellcheck disable=SC2016

--- a/tests/queries/0_stateless/00534_functions_bad_arguments12.sh
+++ b/tests/queries/0_stateless/00534_functions_bad_arguments12.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-tsan, no-debug
+# Tags: no-tsan, no-debug, no-msan
 # Tag no-tsan: Too long for TSan
 
 # shellcheck disable=SC2016

--- a/tests/queries/0_stateless/00534_functions_bad_arguments13.sh
+++ b/tests/queries/0_stateless/00534_functions_bad_arguments13.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-tsan, no-debug
+# Tags: no-tsan, no-debug, no-msan
 # Tag no-tsan: Too long for TSan
 
 # shellcheck disable=SC2016

--- a/tests/queries/0_stateless/00534_functions_bad_arguments2.sh
+++ b/tests/queries/0_stateless/00534_functions_bad_arguments2.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-tsan, no-debug
+# Tags: no-tsan, no-debug, no-msan
 # Tag no-tsan: Too long for TSan
 
 # shellcheck disable=SC2016

--- a/tests/queries/0_stateless/00534_functions_bad_arguments3.sh
+++ b/tests/queries/0_stateless/00534_functions_bad_arguments3.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-tsan, no-debug
+# Tags: no-tsan, no-debug, no-msan
 # Tag no-tsan: Too long for TSan
 
 # shellcheck disable=SC2016

--- a/tests/queries/0_stateless/00534_functions_bad_arguments4_long.sh
+++ b/tests/queries/0_stateless/00534_functions_bad_arguments4_long.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: long, no-tsan, no-debug
+# Tags: long, no-tsan, no-debug, no-msan
 # Tag no-tsan: Too long for TSan
 
 # shellcheck disable=SC2016

--- a/tests/queries/0_stateless/00534_functions_bad_arguments7.sh
+++ b/tests/queries/0_stateless/00534_functions_bad_arguments7.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-tsan, no-debug, no-fasttest
+# Tags: no-tsan, no-debug, no-fasttest, no-msan
 # Tag no-tsan: Too long for TSan
 
 # shellcheck disable=SC2016

--- a/tests/queries/0_stateless/00534_functions_bad_arguments8.sh
+++ b/tests/queries/0_stateless/00534_functions_bad_arguments8.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-tsan, no-debug
+# Tags: no-tsan, no-debug, no-msan
 # Tag no-tsan: Too long for TSan
 
 # shellcheck disable=SC2016

--- a/tests/queries/0_stateless/00921_datetime64_compatibility_long.sh
+++ b/tests/queries/0_stateless/00921_datetime64_compatibility_long.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: long
+# Tags: long, no-msan
 
 CLICKHOUSE_CLIENT_SERVER_LOGS_LEVEL="none"
 # We should have correct env vars from shell_config.sh to run this test

--- a/tests/queries/0_stateless/01049_join_low_card_bug_long.sql.j2
+++ b/tests/queries/0_stateless/01049_join_low_card_bug_long.sql.j2
@@ -1,4 +1,4 @@
--- Tags: long
+-- Tags: long, no-msan
 
 DROP TABLE IF EXISTS l;
 DROP TABLE IF EXISTS r;

--- a/tests/queries/0_stateless/01111_create_drop_replicated_db_stress.sh
+++ b/tests/queries/0_stateless/01111_create_drop_replicated_db_stress.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: race, zookeeper, no-parallel, long
+# Tags: race, zookeeper, no-parallel, long, no-msan
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/01154_move_partition_long.sh
+++ b/tests/queries/0_stateless/01154_move_partition_long.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: long, no-parallel, no-shared-merge-tree
+# Tags: long, no-parallel, no-shared-merge-tree, no-msan
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/01395_limit_more_cases_random.sh
+++ b/tests/queries/0_stateless/01395_limit_more_cases_random.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest
+# Tags: no-fasttest, no-msan
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/02273_full_sort_join.sql.j2
+++ b/tests/queries/0_stateless/02273_full_sort_join.sql.j2
@@ -1,4 +1,4 @@
--- Tags: long, no-random-settings
+-- Tags: long, no-random-settings, no-msan
 
 DROP TABLE IF EXISTS t1;
 DROP TABLE IF EXISTS t2;

--- a/tests/queries/0_stateless/02521_aggregation_by_partitions.sql
+++ b/tests/queries/0_stateless/02521_aggregation_by_partitions.sql
@@ -1,4 +1,4 @@
--- Tags: long, no-object-storage
+-- Tags: long, no-object-storage, no-msan
 
 SET merge_tree_read_split_ranges_into_intersecting_and_non_intersecting_injection_probability = 0.0;
 

--- a/tests/queries/0_stateless/03008_deduplication_mv_generates_several_blocks_replicated.sh
+++ b/tests/queries/0_stateless/03008_deduplication_mv_generates_several_blocks_replicated.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: long, no-fasttest, no-parallel, no-object-storage, no-flaky-check
+# Tags: long, no-fasttest, no-parallel, no-object-storage, no-flaky-check, no-msan
 # Tag no-flaky-check -- not compatible with ThreadFuzzer
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)

--- a/tests/queries/0_stateless/03008_deduplication_several_mv_into_one_table_replicated.sh
+++ b/tests/queries/0_stateless/03008_deduplication_several_mv_into_one_table_replicated.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: long, no-fasttest, no-parallel, no-object-storage, no-flaky-check
+# Tags: long, no-fasttest, no-parallel, no-object-storage, no-flaky-check, no-msan
 # Tag no-flaky-check -- not compatible with ThreadFuzzer
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)

--- a/tests/queries/0_stateless/03212_thousand_exceptions.sh
+++ b/tests/queries/0_stateless/03212_thousand_exceptions.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: long
+# Tags: long, no-msan
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/03554_json_shared_data_advanced_serialization_compact_part_big.sql
+++ b/tests/queries/0_stateless/03554_json_shared_data_advanced_serialization_compact_part_big.sql
@@ -1,4 +1,4 @@
--- Tags: long
+-- Tags: long, no-msan
 -- Random settings limits: index_granularity=(100, None); index_granularity_bytes=(100000, None)
 
 drop table if exists test_compact_without_substreams_advanced;

--- a/tests/queries/0_stateless/03634_autopr_output_bytes_estimation.sql
+++ b/tests/queries/0_stateless/03634_autopr_output_bytes_estimation.sql
@@ -1,4 +1,4 @@
--- Tags: stateful, long
+-- Tags: stateful, long, no-msan
 
 SET enable_parallel_replicas=0, automatic_parallel_replicas_mode=2, parallel_replicas_local_plan=1, parallel_replicas_index_analysis_only_on_coordinator=1,
     parallel_replicas_for_non_replicated_merge_tree=1, max_parallel_replicas=3, cluster_for_parallel_replicas='parallel_replicas';

--- a/tests/queries/0_stateless/03710_parallel_alter_comment_rename_selects.sh
+++ b/tests/queries/0_stateless/03710_parallel_alter_comment_rename_selects.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-flaky-check, no-parallel, deadlock, long, replica
+# Tags: no-fasttest, no-flaky-check, no-parallel, deadlock, long, replica, no-msan
 #  no-fasttest, no-flaky-check: test can run up to 10 minutes with sanitizers
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)

--- a/tests/queries/0_stateless/03759_distinct_json_paths_optimization.sql.j2
+++ b/tests/queries/0_stateless/03759_distinct_json_paths_optimization.sql.j2
@@ -1,4 +1,4 @@
--- Tags: long, no-azure-blob-storage
+-- Tags: long, no-azure-blob-storage, no-msan
 -- no-azure-blob-storage: too slow
 -- Random settings limits: index_granularity=(1000, None); index_granularity_bytes=(1000000, None)
 


### PR DESCRIPTION
These tests consistently exceed the 300 second timeout limit when running with MSan instrumentation, causing CI failures.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.46`
<!-- ch-version-info:end -->