### PR TITLE
Respect max_parts_to_merge_at_once in TTLPartDropMergeSelector

### DIFF
--- a/src/Interpreters/PartLog.cpp
+++ b/src/Interpreters/PartLog.cpp
@@ -118,7 +118,7 @@ ColumnsDescription PartLogElement::getColumnsDescription()
             "The reason for the event with type MERGE_PARTS. Can have one of the following values: "
             "NotAMerge — The current event has the type other than MERGE_PARTS, "
             "RegularMerge — Some regular merge, "
-            "TTLDeleteMerge — Cleaning up expired data. "
+            "TTLDeleteMerge, TTLDropMerge — Cleaning up expired data. "
             "TTLRecompressMerge — Recompressing data part with the. "},
         {"merge_algorithm", std::move(merge_algorithm_datatype), "Merge algorithm for the event with type MERGE_PARTS. Can have one of the following values: Undecided, Horizontal, Vertical"},
         {"event_date", std::make_shared<DataTypeDate>(), "Event date."},

--- a/src/Storages/MergeTree/Compaction/MergeSelectorApplier.cpp
+++ b/src/Storages/MergeTree/Compaction/MergeSelectorApplier.cpp
@@ -75,7 +75,7 @@ MergeSelectorChoices tryChooseTTLMerge(const ChooseContext & ctx)
     {
         /// The size of the completely expired part of TTL drop is not affected by the merge pressure and the size of the storage space.
         std::vector<MergeConstraint> ttl_constraints(ctx.merge_constraints.size(), {std::numeric_limits<size_t>::max(), std::numeric_limits<size_t>::max()});
-        TTLPartDropMergeSelector drop_ttl_selector(ctx.current_time);
+        TTLPartDropMergeSelector drop_ttl_selector(ctx.current_time, ctx.merge_tree_settings[MergeTreeSetting::max_parts_to_merge_at_once]);
 
         if (auto merge_ranges = drop_ttl_selector.select(ctx.ranges, ttl_constraints, ctx.range_filter); !merge_ranges.empty())
             return pack(ctx, std::move(merge_ranges), MergeType::TTLDrop);

--- a/src/Storages/MergeTree/Compaction/MergeSelectors/TTLMergeSelector.h
+++ b/src/Storages/MergeTree/Compaction/MergeSelectors/TTLMergeSelector.h
@@ -20,7 +20,7 @@ class ITTLMergeSelector : public IMergeSelector
     friend class MergeRangesConstructor;
 
 public:
-    ITTLMergeSelector(const PartitionIdToTTLs * merge_due_times_, time_t current_time_);
+    ITTLMergeSelector(const PartitionIdToTTLs * merge_due_times_, time_t current_time_, size_t max_parts_to_merge_at_once_ = 0);
 
     PartsRanges select(
         const PartsRanges & parts_ranges,
@@ -45,18 +45,31 @@ private:
     bool needToPostponePartition(const std::string & partition_id) const;
 
     std::vector<CenterPosition> findCenters(const PartsRanges & parts_ranges) const;
-    PartsIterator findLeftRangeBorder(const CenterPosition & center_position, size_t & usable_memory, size_t & usable_rows, DisjointPartsRangesSet & disjoint_set) const;
-    PartsIterator findRightRangeBorder(const CenterPosition & center_position, size_t & usable_memory, size_t & usable_rows, DisjointPartsRangesSet & disjoint_set) const;
+
+    PartsIterator findLeftRangeBorder(
+        const CenterPosition & center_position,
+        size_t & usable_memory,
+        size_t & usable_rows,
+        size_t & usable_parts,
+        DisjointPartsRangesSet & disjoint_set) const;
+
+    PartsIterator findRightRangeBorder(
+        const CenterPosition & center_position,
+        size_t & usable_memory,
+        size_t & usable_rows,
+        size_t & usable_parts,
+        DisjointPartsRangesSet & disjoint_set) const;
 
     const time_t current_time;
     const PartitionIdToTTLs * merge_due_times;
+    const size_t max_parts_to_merge_at_once;
 };
 
 /// Select parts that must be fully deleted because of ttl for part.
 class TTLPartDropMergeSelector : public ITTLMergeSelector
 {
 public:
-    explicit TTLPartDropMergeSelector(time_t current_time_);
+    explicit TTLPartDropMergeSelector(time_t current_time_, size_t max_parts_to_drop_at_once_);
 
 private:
     time_t getTTLForPart(const PartProperties & part) const override;

--- a/tests/integration/test_ttl_replicated/test.py
+++ b/tests/integration/test_ttl_replicated/test.py
@@ -689,7 +689,7 @@ def test_ttl_compatibility(started_cluster, node_left, node_right, num_run):
         node.query(f"DROP TABLE {table}_where SYNC")
 
 
-def test_merges_mutations_limit(started_cluster):
+def test_ttl_drop_parts_limit(started_cluster):
     table = f"test_merges_mutations_limit_{uuid.uuid4().hex}"
 
     max_parts_to_merge_at_once = 123
@@ -752,6 +752,8 @@ def test_merges_mutations_limit(started_cluster):
         f"SELECT count() FROM system.parts WHERE table = '{table}' AND active AND rows > 0"
     ).strip())
     assert final_parts == 0, f"Expected zero parts after merge, got {final_parts} (was {initial_parts})"
+
+    node1.query("SYSTEM FLUSH LOGS")
 
     # Check that no merge created with more than max_parts_to_merge_at_once parts
     max_parts_in_merge = int(node1.query(

--- a/tests/integration/test_ttl_replicated/test.py
+++ b/tests/integration/test_ttl_replicated/test.py
@@ -1,4 +1,5 @@
 import time
+import uuid
 
 import pytest
 
@@ -686,3 +687,81 @@ def test_ttl_compatibility(started_cluster, node_left, node_right, num_run):
         node.query(f"DROP TABLE {table}_delete SYNC")
         node.query(f"DROP TABLE {table}_group_by SYNC")
         node.query(f"DROP TABLE {table}_where SYNC")
+
+
+def test_merges_mutations_limit(started_cluster):
+    table = f"test_merges_mutations_limit_{uuid.uuid4().hex}"
+
+    max_parts_to_merge_at_once = 123
+    node1.query(
+        f"""
+        CREATE TABLE {table} (
+            date DateTime,
+            id UInt32,
+            value String
+        )
+        ENGINE = MergeTree()
+        ORDER BY id
+        TTL date + INTERVAL 1 DAY
+        SETTINGS merge_with_ttl_timeout=0, max_merge_selecting_sleep_ms=6000,
+        -- Disables ordinary merges, but not TTL merges
+        min_parts_to_merge_at_once=2000,
+        -- Sets limit for TTL merges
+        max_parts_to_merge_at_once = {max_parts_to_merge_at_once}
+        """
+    )
+
+    # Stop merges, to be able to accumulate a big number of parts
+    node1.query(f"SYSTEM STOP MERGES {table}")
+
+    # Insert many parts (over 1000) with old dates that should expire
+    parts_count = 1100
+    old_date = "toDateTime('2000-01-01 00:00:00')"
+
+    for i in range(parts_count):
+        node1.query(
+            f"INSERT INTO {table} VALUES ({old_date}, {i}, 'value_{i}')"
+        )
+
+    # Verify we have many parts
+    initial_parts = int(node1.query(
+        f"SELECT count() FROM system.parts WHERE table = '{table}' AND active"
+    ).strip())
+    assert initial_parts >= parts_count, f"Expected at least {parts_count} parts, got {initial_parts}"
+
+    # Verify data exists before TTL merge
+    initial_rows = int(node1.query(f"SELECT count() FROM {table}").strip())
+    assert initial_rows == parts_count, f"Expected {parts_count} rows, got {initial_rows}"
+
+    node1.query(f"SYSTEM START MERGES {table}")
+
+    # Wait for TTL merges to process the parts and remove data
+    max_wait_iterations = 100
+    final_rows = initial_rows
+    for _ in range(max_wait_iterations):
+        final_rows = int(node1.query(f"SELECT count() FROM {table}").strip())
+        if final_rows == 0:
+            break
+        time.sleep(0.5)
+
+    # Verify that TTL has removed the data
+    assert final_rows == 0, f"Expected 0 rows after TTL expiration, got {final_rows}"
+
+    # Verify parts were removed
+    final_parts = int(node1.query(
+        f"SELECT count() FROM system.parts WHERE table = '{table}' AND active AND rows > 0"
+    ).strip())
+    assert final_parts == 0, f"Expected zero parts after merge, got {final_parts} (was {initial_parts})"
+
+    # Check that no merge created with more than max_parts_to_merge_at_once parts
+    max_parts_in_merge = int(node1.query(
+        f"""
+        SELECT max(length(merged_from))
+        FROM system.part_log
+        WHERE table = '{table}' AND merge_reason = 'TTLDropMerge'
+        """
+    ))
+
+    assert max_parts_in_merge == max_parts_to_merge_at_once, f"Found merge with {max_parts_in_merge} parts, which exceeds max_parts_to_merge_at_once limit of {max_parts_to_merge_at_once}"
+
+    node1.query(f"DROP TABLE {table} SYNC")


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Respect `max_parts_to_merge_at_once` in TTL drop part merges.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.59`
- Backported to: `26.1.1.902`, `25.12.5.28`
<!-- ch-version-info:end -->