### PR TITLE
Fix flaky `03364_estimate_compression_ratio`

### DIFF
--- a/tests/queries/0_stateless/03364_estimate_compression_ratio.reference
+++ b/tests/queries/0_stateless/03364_estimate_compression_ratio.reference
@@ -1,8 +1,8 @@
-OK - For codec=ZSTD(1) block_size=65536 num_rows=1_000: Estimated compression ratios are within 40.00% of actual ratios
-OK - For codec=ZSTD(1) block_size=1048576 num_rows=1_000: Estimated compression ratios are within 40.00% of actual ratios
-OK - For codec=LZ4 block_size=65536 num_rows=1_000: Estimated compression ratios are within 40.00% of actual ratios
-OK - For codec=LZ4 block_size=1048576 num_rows=1_000: Estimated compression ratios are within 40.00% of actual ratios
-OK - For codec=ZSTD(1) block_size=65536 num_rows=50_000: Estimated compression ratios are within 40.00% of actual ratios
-OK - For codec=ZSTD(1) block_size=1048576 num_rows=50_000: Estimated compression ratios are within 40.00% of actual ratios
-OK - For codec=LZ4 block_size=65536 num_rows=50_000: Estimated compression ratios are within 40.00% of actual ratios
-OK - For codec=LZ4 block_size=1048576 num_rows=50_000: Estimated compression ratios are within 40.00% of actual ratios
+OK - For codec=ZSTD(1) block_size=65536 num_rows=1_000: Estimated compression ratios are within 45.00% of actual ratios
+OK - For codec=ZSTD(1) block_size=1048576 num_rows=1_000: Estimated compression ratios are within 45.00% of actual ratios
+OK - For codec=LZ4 block_size=65536 num_rows=1_000: Estimated compression ratios are within 45.00% of actual ratios
+OK - For codec=LZ4 block_size=1048576 num_rows=1_000: Estimated compression ratios are within 45.00% of actual ratios
+OK - For codec=ZSTD(1) block_size=65536 num_rows=50_000: Estimated compression ratios are within 45.00% of actual ratios
+OK - For codec=ZSTD(1) block_size=1048576 num_rows=50_000: Estimated compression ratios are within 45.00% of actual ratios
+OK - For codec=LZ4 block_size=65536 num_rows=50_000: Estimated compression ratios are within 45.00% of actual ratios
+OK - For codec=LZ4 block_size=1048576 num_rows=50_000: Estimated compression ratios are within 45.00% of actual ratios

--- a/tests/queries/0_stateless/03364_estimate_compression_ratio.sh
+++ b/tests/queries/0_stateless/03364_estimate_compression_ratio.sh
@@ -5,7 +5,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 column_names=("number_col" "str_col" "array_col" "nullable_col" "sparse_col" "tuple_col")
 table_name="table_for_estimate_compression_ratio"
-tolerance=0.40
+tolerance=0.45
 formatted_tolerance=$(awk "BEGIN {printf \"%.2f\", $tolerance * 100}")%
 
 # all combinations of the following should be tested


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Because the data being compressed is randomly generated, the compression ratio sometimes falls just below the target. [CIDB link](https://play.clickhouse.com/play?user=play#V0lUSAogICAgMzY1IEFTIGludGVydmFsX2RheXMKU0VMRUNUCiAgICB0b1N0YXJ0T2ZEYXkoY2hlY2tfc3RhcnRfdGltZSkgQVMgZGF5LAogICAgY291bnQoKSBBUyBmYWlsdXJlcywKICAgIGdyb3VwVW5pcUFycmF5KHB1bGxfcmVxdWVzdF9udW1iZXIpIEFTIHBycywKICAgIGFueShyZXBvcnRfdXJsKSBBUyByZXBvcnRfdXJsCkZST00gY2hlY2tzCldIRVJFIChub3coKSAtIHRvSW50ZXJ2YWxEYXkoaW50ZXJ2YWxfZGF5cykpIDw9IGNoZWNrX3N0YXJ0X3RpbWUKICAgIEFORCB0ZXN0X25hbWUgPSAnMDMzNjRfZXN0aW1hdGVfY29tcHJlc3Npb25fcmF0aW8nCiAgICAtLSBBTkQgY2hlY2tfbmFtZSA9ICdTdGF0ZWxlc3MgdGVzdHMgKGFtZF9kZWJ1ZywgQXN5bmNJbnNlcnQsIHMzIHN0b3JhZ2UsIHBhcmFsbGVsKScKICAgIEFORCB0ZXN0X3N0YXR1cyBJTiAoJ0ZBSUwnLCAnRVJST1InKQogICAgQU5EIChwdWxsX3JlcXVlc3RfbnVtYmVyID0gMCBPUiBiYXNlX3JlZiBJTiAoJ21hc3RlcicpKQogICAgQU5EIHRlc3RfY29udGV4dF9yYXcgTElLRSAnJXJldHVybiBjb2RlJScKR1JPVVAgQlkgZGF5Ck9SREVSIEJZIGRheSBERVNDCg==).

By increasing the allowed variance to 45%, the probability of missing the target is a lot lower, which fixes the flaky test.

Fixes https://github.com/ClickHouse/ClickHouse/issues/95309.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.52`
<!-- ch-version-info:end -->