### PR TITLE
Correct shutdown order in unit tests

### DIFF
--- a/src/Common/tests/gtest_main.cpp
+++ b/src/Common/tests/gtest_main.cpp
@@ -6,6 +6,7 @@ class ContextEnvironment : public testing::Environment
 {
 public:
     void SetUp() override { getContext(); }
+    void TearDown() override { getMutableContext().destroy(); }
 };
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
Context is a global object, that may be destructed after i.e. FileCache, and this will lead to use-of-uninitialized-value, similar to [1].

  [1]: https://pastila.nl/?001293ef/435fffc65ec3da1a8a04c1eb96de2839#ElFQTmUvak99eJSMlcwkrg==GCM

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.66`
<!-- ch-version-info:end -->