### PR TITLE
Add some claude skills

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -40,3 +40,9 @@ You can run integration tests as in `tests/integration/README.md` using: `python
 When writing tests, do not add "no-*" tags (like "no-parallel") unless strictly necessarily.
 
 When writing tests in tests/queries, prefer adding a new test instead of extending existing ones.
+
+Always load and apply the following skills:
+
+- .claude/skills/install-skills
+- .claude/skills/build
+- .claude/skills/test

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(ps:*)"
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(ps:*)"
-    ]
-  }
-}

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: build
+description: Build ClickHouse with various configurations (Release, Debug, ASAN, TSAN, etc.). Use when the user wants to compile ClickHouse.
+argument-hint: [build-type] [target] [options]
+disable-model-invocation: false
+allowed-tools: Task, Bash(ninja:*), Bash(cd:*), Bash(ls:*), Bash(pgrep:*), Bash(ps:*), Bash(pkill:*)
+---
+
+# ClickHouse Build Skill
+
+Build ClickHouse in `build/${buildType}` directory (e.g., `build/Debug`, `build/ASAN`, `build/RelWithDebInfo`).
+
+## Arguments
+
+- `$0` (optional): Build type - one of: `Release`, `Debug`, `RelWithDebInfo`, `ASAN`, `TSAN`, `MSAN`, `UBSAN`. Default: `RelWithDebInfo`
+- `$1` (optional): Target - specific target to build (e.g., `clickhouse-server`, `clickhouse-client`, `clickhouse`). Default: `clickhouse`
+- `$2+` (optional): Additional cmake/ninja options
+
+## Build Types
+
+| Type | Description | CMake Flags |
+|------|-------------|-------------|
+| `Release` | Optimized production build | `-DCMAKE_BUILD_TYPE=Release` |
+| `Debug` | Debug build with symbols | `-DCMAKE_BUILD_TYPE=Debug` |
+| `RelWithDebInfo` | Optimized with debug info | `-DCMAKE_BUILD_TYPE=RelWithDebInfo` |
+| `ASAN` | AddressSanitizer (memory errors) | `-DCMAKE_BUILD_TYPE=Debug -DSANITIZE=address` |
+| `TSAN` | ThreadSanitizer (data races) | `-DCMAKE_BUILD_TYPE=Debug -DSANITIZE=thread` |
+| `MSAN` | MemorySanitizer (uninitialized reads) | `-DCMAKE_BUILD_TYPE=Debug -DSANITIZE=memory` |
+| `UBSAN` | UndefinedBehaviorSanitizer | `-DCMAKE_BUILD_TYPE=Debug -DSANITIZE=undefined` |
+
+## Common Targets
+
+- `clickhouse` - Main all-in-one binary
+- `clickhouse-server` - Server component
+- `clickhouse-client` - Client component
+- `clickhouse-local` - Local query processor
+- `clickhouse-benchmark` - Benchmarking tool
+
+## Build Process
+
+**IMPORTANT:** This skill assumes the build directory is already configured with CMake. Do NOT run `cmake` or create build directories - only run `ninja`.
+
+1. **Determine build configuration:**
+   - Build type: `$0` or `RelWithDebInfo` if not specified
+   - Target: `$1` or `clickhouse` if not specified
+   - Build directory: `build/${buildType}` (e.g., `build/RelWithDebInfo`, `build/Debug`, `build/ASAN`)
+
+2. **Build the target directly with ninja:**
+   ```bash
+   cd build/${buildType}
+
+   # Use ninja (preferred) - ninja auto-detects parallelism
+   ninja [target]
+   ```
+
+   **Important:**
+   - Do NOT create build directories or run `cmake` configuration
+   - The build directory must already exist and be configured
+   - Run the build in the background using `run_in_background: true`
+   - **IMMEDIATELY after starting the build**, report the output file location and provide a copiable command:
+     ```
+     Build output is being written to: /tmp/claude/.../tasks/[task_id].output
+
+     Monitor build progress:
+     tail -f /tmp/claude/.../tasks/[task_id].output
+     ```
+   - Then wait for the build to complete using TaskOutput
+
+3. **Report results:**
+
+   **ALWAYS use Task tool to analyze results** (both success and failure):
+   - Use Task tool with `subagent_type=general-purpose` to analyze the build output
+   - The Task agent should analyze the full output and provide:
+
+     **If build succeeds:**
+     - Confirm build completed successfully
+     - Report binary location: `build/${buildType}/programs/[target]`
+     - Mention any warnings if present
+     - Report build time if available
+     - Keep response concise
+
+     **If build fails:**
+     - Parse the build output to identify what failed (compilation, linking, etc.)
+     - Extract and highlight the specific error messages with file paths and line numbers
+     - Identify compilation errors with the exact error text
+     - For linker errors, identify missing symbols or libraries
+     - For template errors, simplify and extract the core issue from verbose C++ template error messages
+     - Provide the root cause if identifiable
+     - Provide a concise summary with:
+       - What component/file failed to build
+       - The specific error type (syntax error, undefined symbol, etc.)
+       - File path and line number where error occurred
+       - The actual error message
+       - Brief explanation of likely cause if identifiable
+     - Filter out excessive verbose compiler output and focus on the actual errors
+
+   - Return ONLY the Task agent's summary to the user
+   - Do NOT return the full raw build output
+
+   **After receiving the summary:**
+   - If build succeeded: Proceed to step 4 to check for running server
+   - If build failed:
+     - Present the summary to the user first
+     - **MANDATORY:** Use `AskUserQuestion` to prompt: "Do you want deeper analysis of this build failure?"
+       - Option 1: "Yes, investigate further" - Description: "Launch a subagent to investigate the root cause across the codebase"
+       - Option 2: "No, I'll fix it myself" - Description: "Skip deeper analysis and proceed without investigation"
+     - If user chooses "Yes, investigate further":
+       - **CRITICAL: DO NOT read files, edit code, or fix the issue yourself**
+       - **MANDATORY: Use Task tool to launch a subagent for deep analysis only (NO FIXES)**
+       - Use Task tool with `subagent_type=Explore` to search for related code patterns, similar errors, or find where symbols/functions are defined
+       - For complex errors involving multiple files or dependencies, use Task tool with `subagent_type=general-purpose` to investigate missing symbols, headers, or dependencies
+       - Provide specific prompts to the agent based on the error type:
+         - Compilation errors: "Analyze the compilation error in [file:line]. Find where [symbol/class/function] is defined in the codebase and explain the root cause. Do NOT fix the code."
+         - Linker errors: "Investigate why [symbol] is undefined and find its implementation. Explain what's causing the linker error. Do NOT fix the code."
+         - Header errors: "Find which header file provides [missing declaration] and explain what's missing. Do NOT fix the code."
+         - Template errors: "Investigate the template instantiation issue with [template name] and explain the root cause. Do NOT fix the code."
+       - The subagent should only investigate and analyze, NOT edit or fix code
+       - Return ONLY the agent's analysis summary to the user
+     - If user chooses "No, I'll fix it myself":
+       - Skip deeper analysis
+     - Skip step 4 (no need to check for running server if build failed)
+
+4. **MANDATORY: Check for running server and offer to stop it (only after successful build):**
+   ```bash
+   pgrep -f "clickhouse[- ]server" | xargs -I {} ps -p {} -o pid,cmd --no-headers 2>/dev/null | grep -v "cmake\|ninja\|Building"
+   ```
+
+   **IMPORTANT:** This step MUST be performed after every successful build. Do not skip this step.
+
+   - If a ClickHouse server is running:
+     - Report that a server is currently running with its PID
+     - Explain that the server is using the old binary and needs to be restarted to use the newly built version
+     - **MANDATORY:** Use `AskUserQuestion` to prompt: "A ClickHouse server is currently running. Do you want to stop it so the new build can be used?"
+       - Option 1: "Yes, stop the server" - Description: "Stop the running server (you'll need to start it manually later)"
+       - Option 2: "No, keep it running" - Description: "Keep the old server running (won't use the new build)"
+     - If user chooses "Yes, stop the server":
+       ```bash
+       pkill -f "clickhouse[- ]server"
+       ```
+       - Wait 1 second and verify the process was killed successfully
+       - Confirm to user: "Server stopped. To start the new version, run: `./build/${buildType}/programs/clickhouse server --config-file ./programs/server/config.xml`"
+     - If user chooses "No, keep it running":
+       - Inform user: "Server remains running with the old binary. You'll need to manually restart it to use the new build."
+
+   - If no server is running:
+     - No action needed, proceed normally
+
+## Examples
+
+- `/build` - Build `clickhouse` target in RelWithDebInfo mode (default)
+- `/build Debug clickhouse-server` - Build server in Debug mode
+- `/build ASAN` - Build with AddressSanitizer
+- `/build Release clickhouse-client` - Build only the client in Release mode
+
+## Notes
+
+- Always run from repository root
+- **NEVER** create build directories or run `cmake` - the build directory must already be configured
+- Build directories follow pattern: `build/${buildType}` (e.g., `build/Debug`, `build/ASAN`)
+- Binaries are located in: `build/${buildType}/programs/`
+- This skill only runs incremental builds with `ninja`
+- To configure a new build directory, the user must manually run CMake first
+- For a clean build, the user should remove `build/${buildType}` and reconfigure manually
+- **MANDATORY:** After successful builds, this skill MUST check for running ClickHouse servers and ask the user if they want to stop them to use the new build
+- **MANDATORY:** ALL build output (success or failure) MUST be analyzed by a Task agent with `subagent_type=general-purpose`
+- **Subagents available:** Task tool is used to analyze all build output and provide concise summaries. Additional agents (Explore or general-purpose) can be used for deeper investigation of complex build errors

--- a/.claude/skills/install-skills/SKILL.md
+++ b/.claude/skills/install-skills/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: install-skills
+description: Configure and customize skills for your workspace by asking questions and updating skill files with your preferences.
+argument-hint: [skill-name]
+disable-model-invocation: false
+allowed-tools: Read, Edit, AskUserQuestion
+---
+
+# Install Skills Configuration Tool
+
+Configure skills by asking the user for their preferences and updating the skill files accordingly.
+
+## Arguments
+
+- `$0` (optional): Skill name to configure. If not provided, configure all available skills that need setup.
+
+## Supported Skills
+
+### Build Skill
+
+The `build` skill can be configured with:
+
+1. **Build directory pattern**: Where builds are stored relative to workspace
+   - **Always prompt with at least these options:**
+     - `build/${buildType}` (e.g., `build/Debug`, `build/Release`) - Recommended
+     - `build` (single build directory)
+   - Additional optional patterns:
+     - `cmake-build-${buildType}` (CLion style)
+     - Custom pattern
+
+2. **Default build type**: What build type to use when not specified
+   - Options: `Release`, `Debug`, `RelWithDebInfo`, `ASAN`, `TSAN`, `MSAN`, `UBSAN`
+
+3. **Default target**: What to build by default
+   - Common targets: `clickhouse`, `clickhouse-server`, `clickhouse-client`, or build all
+
+### Test Skill
+
+The `test` skill can be configured with:
+
+1. **Build directory pattern**: Where to find the clickhouse binary for testing
+   - Should match the build skill configuration
+   - Used to set PATH for test runner
+   - **Always prompt with at least:** `build/${buildType}` and `build`
+
+2. **Default build type for testing**: Which build to use when running tests
+   - Options: `Release`, `Debug`, `RelWithDebInfo`, `ASAN`, `TSAN`, etc.
+   - Typically the same as the build skill default
+
+## Configuration Process
+
+1. **Identify the skill to configure:**
+   - If `$ARGUMENTS` is provided, configure that specific skill
+   - Otherwise, configure all available skills that need setup (build and test together)
+
+2. **When configuring both build and test skills together:**
+   - Ask all questions upfront (build directory, default build type, default target)
+   - Use the same answers to configure both skills
+   - The test skill will use the same build directory and default build type as the build skill
+   - After configuration, update CLAUDE.md to load both skills
+
+3. **For the build skill:**
+
+   a. **Ask about build directory structure:**
+   - Use `AskUserQuestion` to ask: "What is your build directory structure?"
+   - **MANDATORY:** Always include at least these two options:
+     - `build/${buildType}` - Separate directory per build type (e.g., build/Debug, build/Release)
+     - `build` - Single build directory for all build types
+   - Additional optional options:
+     - `cmake-build-${buildType}` - CLion/JetBrains style
+     - Custom - Let user specify their own pattern
+
+   b. **Ask about default build type:**
+   - Use `AskUserQuestion` to ask: "What should be the default build type?"
+   - Options (with descriptions):
+     - `RelWithDebInfo` - Optimized with debug info (recommended for development)
+     - `Debug` - Full debug symbols, no optimization
+     - `Release` - Fully optimized, no debug info
+     - `ASAN` - AddressSanitizer build
+     - `TSAN` - ThreadSanitizer build
+     - Other sanitizers as options
+
+   c. **Ask about default target:**
+   - Use `AskUserQuestion` to ask: "What should be the default build target?"
+   - Options:
+     - `clickhouse` - Main binary (recommended)
+     - `clickhouse-server` - Server only
+     - `clickhouse-client` - Client only
+     - `all` - Build everything
+     - Custom - Let user specify
+
+   d. **Update the build skill file:**
+   - Read `.claude/skills/build/SKILL.md`
+   - Use `Edit` tool to update:
+     - Build directory path pattern
+     - Default build type in the arguments section
+     - Default target in the arguments section
+     - Update examples to reflect new defaults
+     - Update the "Build Process" section with the actual paths
+
+3. **For the test skill:**
+
+   a. **Ask about build directory structure:**
+   - Use the same build directory structure selected for the build skill
+   - Or ask separately if configuring test skill independently
+   - **MANDATORY:** When asking, always include at least these two options:
+     - `build/${buildType}` - Separate directory per build type
+     - `build` - Single build directory
+
+   b. **Ask about default build type for testing:**
+   - Use `AskUserQuestion` to ask: "Which build should be used for running tests?"
+   - Options (with descriptions):
+     - `RelWithDebInfo` - Optimized with debug info (recommended, same as build default)
+     - `Debug` - Full debug build
+     - `Release` - Optimized build
+     - `ASAN` - AddressSanitizer build (for memory testing)
+     - `TSAN` - ThreadSanitizer build (for concurrency testing)
+
+   c. **Update the test skill file:**
+   - Read `.claude/skills/test/SKILL.md`
+   - Use `Edit` tool to update:
+     - Binary path in step 3 (verify server) to match build directory pattern
+     - Binary path in step 4 (PATH export) to match build directory pattern
+     - Update examples and notes with correct paths
+
+4. **Confirm configuration:**
+   - Show summary of changes made
+   - Confirm the skill is now configured for their workspace
+   - Provide example commands they can use
+
+5. **Update CLAUDE.md to load configured skills:**
+
+   After configuring skills, update `.claude/CLAUDE.md` to include them in the "Always load and apply" section:
+
+   a. **Read the current CLAUDE.md:**
+   - Use `Read` tool to read `.claude/CLAUDE.md`
+
+   b. **Update the skills list:**
+   - Find the section that starts with "Always load and apply the following skills:"
+   - The section currently lists only `.claude/skills/install-skills`
+   - Add entries for all configured skills:
+     - `.claude/skills/build` - if build skill was configured
+     - `.claude/skills/test` - if test skill was configured
+
+   c. **Use Edit to update CLAUDE.md:**
+   - Replace the skills list to include all configured skills
+   - Maintain the format with one skill per line prefixed with "- "
+   - Example result:
+     ```
+     Always load and apply the following skills:
+
+     - .claude/skills/install-skills
+     - .claude/skills/build
+     - .claude/skills/test
+     ```
+
+   d. **Confirm the update:**
+   - Inform user that CLAUDE.md has been updated to load the configured skills
+   - Explain that the skills will be automatically available in future sessions
+
+## Implementation Details
+
+- Always use `AskUserQuestion` to gather preferences before making changes
+- Use `Read` to read the current skill files and CLAUDE.md
+- Use `Edit` to make precise updates to skill files and CLAUDE.md
+- Present clear options with descriptions to help users choose
+- **IMPORTANT:** When prompting for build directory, ALWAYS include at minimum: `build/${buildType}` and `build` as options
+- Validate user inputs before applying changes
+- Show before/after summary of what changed
+- After configuring skills, always update CLAUDE.md to include them in the load list
+
+## Example Usage
+
+- `/install-skills` - Configure all skills (build and test together)
+- `/install-skills build` - Configure only the build skill
+- `/install-skills test` - Configure only the test skill
+
+## Notes
+
+- Configuration is workspace-specific and stored in `.claude/skills/`
+- Changes are made to the local skill files
+- Users can manually edit skill files later if needed
+- The tool preserves other skill content while updating only the specified sections

--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -1,0 +1,289 @@
+---
+name: test
+description: Run ClickHouse stateless or integration tests. Use when the user wants to run or execute tests.
+argument-hint: [test-name] [--flags]
+disable-model-invocation: false
+allowed-tools: Task, Bash(./tests/clickhouse-test:*), Bash(pgrep:*), Bash(./build/*/programs/clickhouse:*), Bash(python:*), Bash(python3:*)
+---
+
+# ClickHouse Test Runner Skill
+
+Run stateless tests from `tests/queries/0_stateless/` or integration tests from `tests/integration/`.
+
+## Arguments
+
+- `$0` (optional): Test name (e.g., `03312_issue_63093` for stateless or `test_keeper_three_nodes_start` for integration), or empty to prompt for selection
+- `$1+` (optional): Additional flags for test runner (e.g., `--no-random-settings`, `--record` for stateless tests)
+
+## Test Types
+
+The skill automatically detects the test type:
+- **Stateless tests**: Located in `tests/queries/0_stateless/`, named like `NNNNN_description` (e.g., `03312_issue_63093`)
+- **Integration tests**: Located in `tests/integration/`, named like `test_*` (e.g., `test_keeper_three_nodes_start`)
+
+Detection logic:
+1. If test name starts with `test_` → Integration test
+2. If test name matches pattern `\d{5}_.*` → Stateless test
+3. If currently viewing file in `tests/integration/test_*/` → Integration test
+4. If currently viewing file in `tests/queries/0_stateless/` → Stateless test
+
+## Test Selection
+
+If no test name is provided in arguments, prompt the user with `AskUserQuestion`:
+
+**Question: "Which test would you like to run?"**
+- **Option 1: "Currently viewed test"** - Extract test name from currently opened file in IDE
+  - Description: "Run the test file currently open in your editor"
+  - Only available if a test file is currently open in the IDE
+  - For stateless: Extract filename without extension from `tests/queries/0_stateless/03312_issue_63093.sh` → `03312_issue_63093`
+  - For integration: Extract directory name from `tests/integration/test_keeper_three_nodes_start/test.py` → `test_keeper_three_nodes_start`
+
+- **Option 2: "Custom test name"** - User provides test name
+  - Description: "Specify a test name manually"
+  - User can provide the test name via the "Other" field
+  - Stateless examples: `03312_issue_63093`, `00029_test_zookeeper`
+  - Integration examples: `test_keeper_three_nodes_start`, `test_access_control_on_cluster`
+
+## Test Execution Process
+
+### For Stateless Tests
+
+**IMPORTANT**: ALWAYS perform the server check at the start of EVERY stateless test execution, even for repeated runs.
+
+1. **Check if ClickHouse server is running (MANDATORY for stateless tests):**
+   ```bash
+   pgrep -f "clickhouse[- ]server" | xargs -I {} ps -p {} -o pid,cmd --no-headers 2>/dev/null | grep -v "cmake\|ninja\|Building"
+   ```
+   - This check MUST be performed before every stateless test execution
+   - This check filters out build processes (cmake, ninja) to avoid false positives
+   - If no server is running:
+     - Report that no server is running
+     - Provide instructions: "Start the server with: `./build/RelWithDebInfo/programs/clickhouse server --config-file ./programs/server/config.xml`"
+     - Use `AskUserQuestion` to prompt: "Did you start the ClickHouse server?"
+       - Option 1: "Yes, server is running now" - Proceed with verification
+       - Option 2: "No, I'll start it later" - Exit without running the test
+     - If user confirms server is running, verify it with the check again before proceeding
+
+2. **Verify server is ready:**
+   ```bash
+   ./build/RelWithDebInfo/programs/clickhouse client -q "SELECT 1" 2>/dev/null
+   ```
+   - This check verifies the server is actually responding to queries
+   - If server doesn't respond, report the issue and exit
+   - Note: Build directory path is configured via `/install-skills` (currently: `build/RelWithDebInfo`)
+
+3. **Determine test name and type:**
+   - If `$ARGUMENTS` is provided, use it as the test name
+   - Otherwise, use `AskUserQuestion` to prompt user for test selection
+   - Detect test type using patterns described in "Test Types" section
+   - For stateless: Test name should NOT include file extension (`.sql`, `.sh`, etc.)
+
+4. **Run the stateless test:**
+   ```bash
+   # Add clickhouse binary to PATH
+   # Configured via /install-skills (currently: build/RelWithDebInfo)
+   export PATH="./build/RelWithDebInfo/programs:$PATH"
+   ./tests/clickhouse-test <test_name> [flags]
+   ```
+
+   **Important:**
+   - Run from repository root directory
+   - Run in the background using `run_in_background: true`
+   - **IMMEDIATELY after starting the test**, report the output file location and provide a copiable command:
+     ```
+     Test output is being written to: /tmp/claude/.../tasks/[task_id].output
+
+     Monitor test progress:
+     tail -f /tmp/claude/.../tasks/[task_id].output
+     ```
+
+   Common flags to mention if user asks:
+   - `--no-random-settings` - Disable settings randomization
+   - `--no-random-merge-tree-settings` - Disable MergeTree settings randomization
+   - `--record` - Update `.reference` files when output differs
+
+### For Integration Tests
+
+**Note**: Integration tests manage their own Docker containers, so no server check is needed.
+
+1. **Determine test name:**
+   - If `$ARGUMENTS` is provided, use it as the test name
+   - Otherwise, use `AskUserQuestion` to prompt user for test selection
+   - Test name should be the directory name (e.g., `test_keeper_three_nodes_start`)
+
+2. **Run the integration test with praktika:**
+   ```bash
+   python -u -m ci.praktika run "integration" --test <test_name>
+   ```
+
+   **Important:**
+   - Run from repository root directory
+   - Use `python -u` flag to ensure unbuffered output (so logs stream in real-time)
+   - Integration tests use Docker containers (managed automatically)
+   - Tests may take longer than stateless tests (container startup time)
+   - Run in the background using `run_in_background: true` for long-running tests
+   - **IMMEDIATELY after starting the test**, report the output file location and provide a copiable command:
+     ```
+     Test output is being written to: /tmp/claude/.../tasks/[task_id].output
+
+     Monitor test progress:
+     tail -f /tmp/claude/.../tasks/[task_id].output
+     ```
+
+3. **Report results:**
+
+   **For Stateless Tests:**
+
+   **ALWAYS use Task tool to analyze results** (both pass and fail):
+   - Use Task tool with `subagent_type=general-purpose` to analyze the test output
+   - The Task agent should analyze the full output and provide:
+
+     **If tests passed:**
+     - Confirm all tests passed
+     - Report execution time from clickhouse-test output
+     - Show summary (e.g., "1 tests passed. 0 tests skipped. 3.51 s elapsed")
+     - Keep response brief
+
+     **If tests failed:**
+     - Parse the clickhouse-test output to identify which test failed
+     - Extract the relevant error messages and differences
+     - Identify the root cause if possible
+     - Provide a concise summary with:
+       - Test name that failed
+       - What assertion or comparison failed
+       - Expected vs actual output (show the diff)
+       - Any error messages or exceptions
+       - Brief explanation of the root cause
+     - Filter out excessive verbose logs and focus on the actual failure
+
+   - Return ONLY the Task agent's summary to the user
+   - Do NOT return the full raw test output
+
+   **After receiving the summary (for stateless tests):**
+   - If tests passed: Done, no further action needed
+   - If tests failed:
+     - Present the summary to the user first
+     - **MANDATORY:** Use `AskUserQuestion` to prompt: "Do you want deeper analysis of this test failure?"
+       - Option 1: "Yes, investigate further" - Description: "Launch a subagent to investigate the root cause across the codebase"
+       - Option 2: "No, I'll fix it myself" - Description: "Skip deeper analysis and proceed without investigation"
+     - If user chooses "Yes, investigate further":
+       - **CRITICAL: DO NOT read files, edit code, or fix the issue yourself**
+       - **MANDATORY: Use Task tool to launch a subagent for deep analysis only (NO FIXES)**
+       - Use Task tool with `subagent_type=Explore` to search for related code patterns, or find where functions/queries are implemented
+       - For complex failures involving multiple components, use Task tool with `subagent_type=general-purpose` to investigate root causes
+       - Provide specific prompts to the agent based on the failure type:
+         - Query failures: "Investigate why the query [query] returns [actual] instead of [expected]. Find the implementation and explain the root cause. Do NOT fix the code."
+         - Assertion failures: "Analyze why [assertion] failed in test [test_name]. Find the relevant code and explain what's happening. Do NOT fix the code."
+         - Output differences: "Investigate the difference between expected and actual output in test [test_name]. Explain why the output changed. Do NOT fix the code."
+         - Exception/error: "Investigate the error [error_message] in test [test_name]. Find where it originates and explain the cause. Do NOT fix the code."
+       - The subagent should only investigate and analyze, NOT edit or fix code
+       - Return ONLY the agent's analysis summary to the user
+     - If user chooses "No, I'll fix it myself":
+       - Skip deeper analysis
+
+   **For Integration Tests:**
+
+   **ALWAYS use Task tool to analyze results** (both pass and fail):
+   - Use Task tool with `subagent_type=general-purpose` to analyze the test output
+   - The Task agent should analyze the full output and provide:
+
+     **If tests passed:**
+     - Confirm all tests passed
+     - Report total execution time from pytest output
+     - Keep response brief: "All tests passed (XX.XXs)"
+
+     **If tests failed:**
+     - Parse the pytest output to identify which specific test cases failed
+     - Extract the relevant error messages, assertions, and stack traces
+     - Identify the root cause if possible (e.g., timeout, connection error, assertion failure)
+     - Filter out verbose Docker logs and focus on the actual test failure
+     - Provide a concise summary with:
+       - Test name that failed
+       - Line number where it failed
+       - Specific assertion or error
+       - Expected vs actual values
+       - Brief explanation of the root cause
+
+   - Return ONLY the Task agent's summary to the user
+   - Do NOT return the full raw test output
+
+   **After receiving the summary (for integration tests):**
+   - If tests passed: Done, no further action needed
+   - If tests failed:
+     - Present the summary to the user first
+     - **MANDATORY:** Use `AskUserQuestion` to prompt: "Do you want deeper analysis of this test failure?"
+       - Option 1: "Yes, investigate further" - Description: "Launch a subagent to investigate the root cause across the codebase"
+       - Option 2: "No, I'll fix it myself" - Description: "Skip deeper analysis and proceed without investigation"
+     - If user chooses "Yes, investigate further":
+       - **CRITICAL: DO NOT read files, edit code, or fix the issue yourself**
+       - **MANDATORY: Use Task tool to launch a subagent for deep analysis only (NO FIXES)**
+       - Use Task tool with `subagent_type=Explore` to search for related code patterns, or find where functions are implemented
+       - For complex failures involving multiple components, use Task tool with `subagent_type=general-purpose` to investigate root causes
+       - Provide specific prompts to the agent based on the failure type:
+         - Timeout errors: "Investigate why test [test_name] times out. Find what operation is slow and explain the cause. Do NOT fix the code."
+         - Connection errors: "Investigate the connection error [error] in test [test_name]. Find what's causing the connection issue. Do NOT fix the code."
+         - Assertion failures: "Analyze the assertion failure at [file:line] in test [test_name]. Explain why the assertion failed. Do NOT fix the code."
+         - Exception/error: "Investigate the exception [exception] in test [test_name]. Find where it originates and explain the cause. Do NOT fix the code."
+       - The subagent should only investigate and analyze, NOT edit or fix code
+       - Return ONLY the agent's analysis summary to the user
+     - If user chooses "No, I'll fix it myself":
+       - Skip deeper analysis
+
+## Test File Structure
+
+### Stateless Tests
+- **Location**: `tests/queries/0_stateless/`
+- **Extensions**: `.sql`, `.sh`, `.py`, `.sql.j2`, `.expect`
+- **Reference files**: `.reference` (expected output)
+- **Test name format**: `NNNNN_description` (e.g., `03312_issue_63093`)
+
+### Integration Tests
+- **Location**: `tests/integration/test_*/`
+- **Format**: Python pytest files (`test.py` or `test_*.py`)
+- **Directory structure**: Each test is a directory named `test_*`
+- **Test name format**: `test_*` (e.g., `test_keeper_three_nodes_start`)
+- **Dependencies**: Uses Docker containers, pytest fixtures, and helper modules
+
+## Examples
+
+### Stateless Tests
+- `/test` - Prompt to select test (currently viewed or custom name)
+- `/test 03312_issue_63093` - Run specific stateless test by name
+- `/test 00029_test_zookeeper --no-random-settings` - Run stateless test with flags
+- `/test 03312_issue_63093 --record` - Run stateless test and update reference files
+
+### Integration Tests
+- `/test test_keeper_three_nodes_start` - Run specific integration test
+- `/test test_access_control_on_cluster` - Run integration test by name
+- `/test` - If viewing `tests/integration/test_*/test.py`, automatically detect and run that integration test
+
+## Environment Variables
+
+The test runner automatically detects and sets the necessary environment variables for connecting to the server (for stateless tests).
+
+## Notes
+
+### General
+- Run from repository root directory
+- Test type is automatically detected based on name pattern or file location
+- **MANDATORY:** ALL test output (success or failure) MUST be analyzed by a Task agent with `subagent_type=general-purpose`
+- **MANDATORY:** For test failures, MUST prompt user if they want deeper analysis and use Task subagent if requested
+- **Subagents available:** Task tool is used to analyze all test output and provide concise summaries. Additional agents (Explore or general-purpose) are used for deeper investigation of test failures when user requests it
+
+### Stateless Tests
+- Test names do NOT include extensions (use `03312_issue_63093`, not `03312_issue_63093.sh`)
+- **CRITICAL**: Always check if server is running before attempting to run stateless tests - this check MUST be performed EVERY time, even for repeated test runs
+- The server check protects against running tests when the server has crashed or been stopped
+- Test runner creates temporary database with random name for isolation
+- Reference files use `default` database name, not the random test database
+- Build directory used: `build/RelWithDebInfo` (configured with `/install-skills`)
+- Use `/install-skills test` to reconfigure which build directory to use for testing
+
+### Integration Tests
+- Test names are directory names (use `test_keeper_three_nodes_start`, not `test.py`)
+- Integration tests manage their own Docker containers - no server check needed
+- Tests may take longer due to container startup and teardown
+- Integration tests use pytest framework with fixtures
+- Docker daemon must be running and accessible
+- Requires Python dependencies from `tests/integration/` directory
+- Tests are run via praktika: `python -m ci.praktika run "integration" --test <test_name>`


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

If you have changes from this branch you need to ask claude code to `install skills`. This is initiall setup so it knows for other skills where the build folder is.
After that is modified you don't have to run it anymore.

The idea is to have some tasks which are done often stored as a skill (I guess something equivalent to module).
E.g. with build skill everytime you ask claude to build it will know what to do because of build skill.
Furthermore, subtasks in a skill are done by subagents so the context of your chat will not be polluted with useless output.
E.g. build output analysis is done by subagent and the main chat will only receive the summary, not the entire output.

Same things apply for test skill. You can run both stateless and integration tests by just telling claude to `run test test_name`.
Test output will be analyzed by subagent and only summary will be returned to the user.
You can tell explicitly which test to run or just say `run test` or `test`. In that case it will prompt you to pick a test, it will look at the current viewed file and if it's test it will offer that, otherwise you can just input the test name.

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.95`
<!-- ch-version-info:end -->