### PR TITLE
Add a check for autogenerated docker/server/README.md

### DIFF
--- a/ci/jobs/docker_server.py
+++ b/ci/jobs/docker_server.py
@@ -299,6 +299,22 @@ def test_docker_library(test_results) -> None:
         )
 
 
+def check_server_readme(image_path: str) -> Result:
+    name = "Check README"
+    script = Path(f"{image_path}/README.sh")
+    if not script.is_file():
+        return Result(
+            name=name,
+            status=Result.Status.SKIPPED,
+            info="README.sh file is missing in the docker context",
+        )
+    # Regenerate README
+    Shell.check(script.as_posix())
+    return Result.from_commands_run(
+        name=name, command=f"git diff --exit-code {image_path}/README.md"
+    )
+
+
 def main():
     logging.basicConfig(level=logging.INFO)
     sw = Utils.Stopwatch()
@@ -406,6 +422,8 @@ def main():
         # The image is built locally only when we don't push it
         # See `--output=type=docker`
         test_docker_library(test_results)
+
+    test_results.append(check_server_readme(image.path))
 
     Result.create_from(results=test_results, stopwatch=sw).complete_job()
 

--- a/docker/server/README.src/content.md
+++ b/docker/server/README.src/content.md
@@ -72,7 +72,7 @@ docker rm some-clickhouse-server
 You can expose your ClickHouse running in docker by [mapping a particular port](https://docs.docker.com/config/containers/container-networking/) from inside the container using host ports:
 
 ```bash
-docker run -d -p 18123:8123 -p19000:9000 -e CLICKHOUSE_PASSWORD=changeme --name some-clickhouse-server --ulimit nofile=262144:262144 %%IMAGE%%
+docker run -d -p 18123:8123 -p 19000:9000 -e CLICKHOUSE_PASSWORD=changeme --name some-clickhouse-server --ulimit nofile=262144:262144 %%IMAGE%%
 echo 'SELECT version()' | curl 'http://localhost:18123/?password=changeme' --data-binary @-
 ```
 


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
The README.md shouldn't be edited manually, only by tweaking `README.src` + `README.sh` to have the same description as https://hub.docker.com/_/clickhouse

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.82`
<!-- ch-version-info:end -->