### PR TITLE
ci: fix checking for server errors in upgrade check

### DIFF
--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -1931,8 +1931,11 @@ bool InterpreterCreateQuery::doCreateTable(ASTCreateQuery & create,
         }
         else
         {
+            std::vector<std::string> directory_contents;
+            for (const auto& entry : fs::recursive_directory_iterator(full_data_path))
+                directory_contents.push_back(entry.path().string());
             throw Exception(storage_already_exists_error_code,
-                "Directory for {} data {} already exists", Poco::toLower(storage_name), String(data_path));
+                "Directory for {} data {} already exists. Content:\n{}", Poco::toLower(storage_name), String(data_path), fmt::join(directory_contents, "\n"));
         }
     }
 

--- a/tests/docker_scripts/upgrade_runner.sh
+++ b/tests/docker_scripts/upgrade_runner.sh
@@ -343,7 +343,7 @@ rg -Fav -e "Code: 236. DB::Exception: Cancelled merging parts" \
            -e "Cannot flush" \
            -e "Container already exists" \
            -e "doesn't have metadata version on disk" \
-    clickhouse-server.upgrade.log \
+    /var/log/clickhouse-server/clickhouse-server.upgrade.log \
     | grep -av -e "_repl_01111_.*Mapping for table with UUID" \
     | zgrep -Fa "<Error>" > /test_output/upgrade_error_messages.txt \
     && echo -e "Error message in clickhouse-server.log (see upgrade_error_messages.txt)$FAIL$(head_escaped /test_output/upgrade_error_messages.txt)" \


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Now it fails with `ENOENT`

```
[2025-11-10 22:09:30] + mv /var/log/clickhouse-server/clickhouse-server.log /var/log/clickhouse-server/clickhouse-server.upgrade.log
[2025-11-10 22:09:30] Check for Error messages in server log:
[2025-11-10 22:09:30] + echo 'Check for Error messages in server log:'
[2025-11-10 22:09:30] + rg -Fav -e 'Code: 236. DB::Exception: Cancelled merging parts' -e 'Code: 236. DB::Exception: Cancelled mutating parts' -e REPLICA_IS_ALREADY_ACTIVE -e REPLICA_ALREADY_EXISTS -e ALL_REPLICAS_LOST -e 'DDLWorker: Cannot parse DDL task query' -e 'RaftInstance: failed to accept a rpc connection due to error 125' -e UNKNOWN_DATABASE -e NETWORK_ERROR -e UNKNOWN_TABLE -e ZooKeeperClient -e KEEPER_EXCEPTION -e DirectoryMonitor -e DistributedInsertQueue -e TABLE_IS_READ_ONLY -e 'Code: 1000, e.code() = 111, Connection refused' -e UNFINISHED -e NETLINK_ERROR -e 'Renaming unexpected part' -e PART_IS_TEMPORARILY_LOCKED -e 'and a merge is impossible: we didn'\''t find' -e 'found in queue and some source parts for it was lost' -e 'is lost forever.' -e 'Unknown index: idx.' -e 'Cannot parse string '\''Hello'\'' as UInt64' -e '} <Error> TCPHandler: Code:' -e '} <Error> executeQuery: Code:' -e 'Missing columns: '\''v3'\'' while processing query: '\''v3, k, v1, v2, p'\''' -e 'The set of parts restored in place of' -e '(ReplicatedMergeTreeAttachThread): Initialization failed. Error' -e 'Code: 269. DB::Exception: Destination table is myself' -e 'Coordination::Exception: Connection loss' -e MutateFromLogEntryTask -e 'No connection to ZooKeeper, cannot get shared table ID' -e 'Session expired' -e TOO_MANY_PARTS -e 'Authentication failed' -e 'Cannot flush' -e 'Container already exists' -e 'doesn'\''t have metadata version on disk' clickhouse-server.upgrade.log
[2025-11-10 22:09:30] + grep -av -e '_repl_01111_.*Mapping for table with UUID'
[2025-11-10 22:09:30] + zgrep -Fa '<Error>'
[2025-11-10 22:09:30] clickhouse-server.upgrade.log: No such file or directory (os error 2)
```