### PR TITLE
Fix order of destruction in MergeTreeReadPoolBase

### DIFF
--- a/src/Storages/MergeTree/MergeTreeReadPoolBase.cpp
+++ b/src/Storages/MergeTree/MergeTreeReadPoolBase.cpp
@@ -41,11 +41,11 @@ MergeTreeReadPoolBase::MergeTreeReadPoolBase(
     const MergeTreeReadTask::BlockSizeParams & block_size_params_,
     const ContextPtr & context_)
     : WithContext(context_)
+    , storage_snapshot(storage_snapshot_)
     , parts_ranges(std::move(parts_))
     , mutations_snapshot(std::move(mutations_snapshot_))
     , shared_virtual_fields(std::move(shared_virtual_fields_))
     , index_read_tasks(index_read_tasks_)
-    , storage_snapshot(storage_snapshot_)
     , row_level_filter(row_level_filter_)
     , prewhere_info(prewhere_info_)
     , actions_settings(actions_settings_)
@@ -74,8 +74,8 @@ MergeTreeReadPoolBase::MergeTreeReadPoolBase(
     const MergeTreeReadTask::BlockSizeParams & block_size_params_,
     const ContextPtr & context_)
     : WithContext(context_)
-    , mutations_snapshot(std::move(mutations_snapshot_))
     , storage_snapshot(storage_snapshot_)
+    , mutations_snapshot(std::move(mutations_snapshot_))
     , prewhere_info(prewhere_info_)
     , actions_settings(actions_settings_)
     , reader_settings(reader_settings_)

--- a/src/Storages/MergeTree/MergeTreeReadPoolBase.h
+++ b/src/Storages/MergeTree/MergeTreeReadPoolBase.h
@@ -62,11 +62,11 @@ public:
 
 protected:
     /// Initialized in constructor
+    const StorageSnapshotPtr storage_snapshot;
     const RangesInDataParts parts_ranges;
     const MutationsSnapshotPtr mutations_snapshot;
     const VirtualFields shared_virtual_fields;
     const IndexReadTasks index_read_tasks;
-    const StorageSnapshotPtr storage_snapshot;
     const FilterDAGInfoPtr row_level_filter;
     const PrewhereInfoPtr prewhere_info;
     const ExpressionActionsSettings actions_settings;


### PR DESCRIPTION
StorageSnapshotPtr holds ConstStoragePtr, RangesInDataParts holds IMergeTreeDataPart, and even though holding ConstStoragePtr is questionable in StorageSnapshotPtr, let's fix the order.

(This patch has been picked from https://github.com/ClickHouse/ClickHouse/pull/95391)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.90`
- Backported to: `26.1.3.47`, `25.12.6.36`
<!-- ch-version-info:end -->