### PR TITLE
Do not hold a storage in storage snapshot

### DIFF
--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -1351,8 +1351,9 @@ static BlockIO executeQueryImpl(
 
     /// Avoid early destruction of process_list_entry if it was not saved to `res` yet (in case of exception)
     ProcessList::EntryPtr process_list_entry;
-    QueryMetadataCachePtr query_metadata_cache;
     BlockIO res;
+    /// May use storage that is protected by pipeline (res.pipeline), so should be destroyed first
+    QueryMetadataCachePtr query_metadata_cache;
     String query_database;
     String query_table;
 

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -1805,9 +1805,6 @@ static BlockIO executeQueryImpl(
         /// Hold element of process list till end of query execution.
         res.process_list_entries.push_back(process_list_entry);
 
-        /// Hold query metadata cache till end of query execution.
-        res.query_metadata_cache = std::move(query_metadata_cache);
-
         if (query_plan)
         {
             auto plan = QueryPlan::makeSets(std::move(*query_plan), context);
@@ -1826,6 +1823,9 @@ static BlockIO executeQueryImpl(
 
             res.pipeline = QueryPipelineBuilder::getPipeline(std::move(*pipeline));
         }
+
+        /// Hold query metadata cache till end of query execution.
+        res.query_metadata_cache = std::move(query_metadata_cache);
 
         auto & pipeline = res.pipeline;
 

--- a/src/QueryPipeline/BlockIO.h
+++ b/src/QueryPipeline/BlockIO.h
@@ -88,6 +88,8 @@ struct BlockIO
     /// Release query slot early to allow client to reuse it for his next query.
     void releaseQuerySlot() const;
 
+    void resetPipeline(bool cancel);
+
 private:
     void reset();
 };

--- a/src/QueryPipeline/BlockIO.h
+++ b/src/QueryPipeline/BlockIO.h
@@ -35,6 +35,8 @@ struct BlockIO
     /// Each level calls executeQuery and adds its process list entry.
     std::vector<std::shared_ptr<ProcessListEntry>> process_list_entries;
 
+    QueryPipeline pipeline;
+
     /// Query-scoped cache for storage metadata and snapshots.
     ///
     /// The cache is created at query execution entry point and is kept alive by BlockIO for the entire lifetime of
@@ -46,8 +48,6 @@ struct BlockIO
     /// The cache is *not* owned by Context to prevent reference cycles; Context only holds a weak reference to it for
     /// access during query execution.
     QueryMetadataCachePtr query_metadata_cache;
-
-    QueryPipeline pipeline;
 
     /// The finalize_query_pipeline function is called once to flush the pipeline progress and reset it.
     /// Then all finish callbacks are called with the resulting QueryPipelineFinalizedInfo.

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -1322,8 +1322,7 @@ void TCPHandler::processInsertQuery(QueryState & state, CurrentThread::QueryScop
         if (result.status == AsynchronousInsertQueue::PushResult::OK)
         {
             /// Reset pipeline because it may hold write lock for some storages.
-            state.io.pipeline.cancel();
-            state.io.pipeline.reset();
+            state.io.resetPipeline(/*cancel=*/true);
             if (settings[Setting::wait_for_async_insert])
             {
                 size_t timeout_ms = settings[Setting::wait_for_async_insert_timeout].totalMilliseconds();

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -10158,8 +10158,6 @@ MergeTreeData::createStorageSnapshot(const StorageMetadataPtr & metadata_snapsho
         return std::make_shared<StorageSnapshot>(*this, metadata_snapshot, std::make_unique<SnapshotData>());
 
     auto snapshot_data = std::make_unique<SnapshotData>();
-    snapshot_data->storage = shared_from_this();
-
     auto [query_ranges, query_parts] = getPossiblySharedVisibleDataPartsRanges(query_context);
     snapshot_data->parts = query_ranges;
 

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -614,10 +614,6 @@ public:
     /// and mutations required to be applied at the moment of the start of query.
     struct SnapshotData : public StorageSnapshot::Data
     {
-        /// Hold a reference to the storage since the snapshot cache in query context
-        /// may outlive the storage and delay destruction of data parts.
-        ConstStoragePtr storage;
-
         // shared_ptr because lifetime is as long as some query still reading it
         // const because we are sharing across multiple queries, we cannot have things mutating this.
         RangesInDataPartsPtr parts;

--- a/src/Storages/MergeTree/StorageFromMergeTreeProjection.cpp
+++ b/src/Storages/MergeTree/StorageFromMergeTreeProjection.cpp
@@ -79,7 +79,6 @@ StorageFromMergeTreeProjection::getStorageSnapshot(const StorageMetadataPtr & me
     const auto & parent_snapshot_data = assert_cast<const MergeTreeData::SnapshotData &>(*parent_storage_snapshot->data);
 
     auto data = std::make_unique<MergeTreeData::SnapshotData>();
-    data->storage = parent_snapshot_data.storage;
     data->parts = parent_snapshot_data.parts;
     data->mutations_snapshot = parent_snapshot_data.mutations_snapshot;
 


### PR DESCRIPTION
The storage should not outlive the execution after #92118, since it is hold in QueryPipeline.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.111`
<!-- ch-version-info:end -->