### PR TITLE
Update head build

### DIFF
--- a/ci/jobs/docker_server.py
+++ b/ci/jobs/docker_server.py
@@ -166,6 +166,8 @@ def buildx_args(
     action_url: str,
 ) -> List[str]:
     args = [
+        "--provenance=true",
+        "--sbom=true",
         f"--platform=linux/{arch}",
         f"--label=build-url={action_url}",
         f"--label=com.clickhouse.build.githash={sha}",


### PR DESCRIPTION
Small tweaks to make better docker images. Similar to this PR - https://github.com/ClickHouse/ClickHouse/pull/94630 , 

Add --provenance=true  --sbom=true to server and keeper image build command. This improves overall Docker Scout score and generate Software Bill of Materials (SBOM) and SLSA Provenance attestations as metadata for the image.

### Changelog category (leave one):

- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.83`
<!-- ch-version-info:end -->