### PR TITLE
Disable long test `01007_r1r2_w_r2r1_deadlock` under MSan

### DIFF
--- a/tests/queries/0_stateless/01007_r1r2_w_r2r1_deadlock.sh
+++ b/tests/queries/0_stateless/01007_r1r2_w_r2r1_deadlock.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: deadlock, no-parallel
+# Tags: deadlock, no-parallel, no-msan
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

See https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=9f45f1066d70a146f59929136097988f8affb841&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_msan%2C%20sequential%2C%201%2F2%29&name_1=Stateless%20tests%20%28amd_msan%2C%20sequential%2C%201%2F2%29


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.92`
<!-- ch-version-info:end -->