### PR TITLE
Fix flaky test `02806_system_parts_columns_modification_time` under TSan

### DIFF
--- a/tests/queries/0_stateless/02806_system_parts_columns_modification_time.sql.j2
+++ b/tests/queries/0_stateless/02806_system_parts_columns_modification_time.sql.j2
@@ -16,10 +16,10 @@ drop table if exists data_{{ id }};
 create table data_{{ id }} (key Int) engine=MergeTree() order by tuple() settings {{ settings }};
 insert into data_{{ id }} values (1);
 select sleep(3) format Null;
-select part_type, column, now()-modification_time < 10, modification_time - column_modification_time < {{ mtime_diff_in_seconds }} from system.parts_columns where database = currentDatabase() and table = 'data_{{ id }}';
+select part_type, column, now()-modification_time < 60, modification_time - column_modification_time < {{ mtime_diff_in_seconds }} from system.parts_columns where database = currentDatabase() and table = 'data_{{ id }}';
 alter table data_{{ id }} add column value Int default 0;
 alter table data_{{ id }} materialize column value;
-select part_type, column, now()-modification_time < 10,
+select part_type, column, now()-modification_time < 60,
 {% if file_per_column %}
 modification_time - column_modification_time >= 3
 {% else %}


### PR DESCRIPTION
The test was failing intermittently on TSAN builds because it checked `now()-modification_time < 10` to verify that parts were modified recently. Under TSAN, even `sleep(3)` can take much longer than expected.

Evidence from the failing CI run (stateless_tests_amd_tsan_parallel_2_2):

For `data_compact` table:
- Insert completed at: 10:56:45.520673
- `sleep(3)` started at: 10:56:45.520673
- SELECT ran at: 10:56:59.726169

The `sleep(3)` took ~14 seconds instead of 3 seconds due to TSAN overhead. By the time the SELECT executed, `modification_time` was ~14 seconds old, so `now()-modification_time < 10` returned false (0) instead of true (1).

Compare with `data_wide` which ran earlier and passed:
- Insert at: 10:56:42.147755
- SELECT at: 10:56:45.301943 (~3 seconds later, as expected)

The fix increases the threshold from 10 to 60 seconds to accommodate TSAN's variable execution speed while still validating that `modification_time` is reasonably recent.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
See https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=67522222c8705bd81cb222f38006e1dc61deea20&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_tsan%2C%20parallel%2C%202%2F2%29&name_1=Stateless%20tests%20%28amd_tsan%2C%20parallel%2C%202%2F2%29


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.91`
<!-- ch-version-info:end -->