### PR TITLE
Avoid possible crash for distributed queries in case of cancellation

### DIFF
--- a/src/Client/Connection.cpp
+++ b/src/Client/Connection.cpp
@@ -84,6 +84,7 @@ namespace ErrorCodes
     extern const int SUPPORT_IS_DISABLED;
     extern const int BAD_ARGUMENTS;
     extern const int EMPTY_DATA_PASSED;
+    extern const int LOGICAL_ERROR;
 }
 
 Connection::~Connection()
@@ -1329,7 +1330,7 @@ Packet Connection::receivePacket()
         /// If we already disconnected.
         if (!in)
         {
-            throw Exception(ErrorCodes::NETWORK_ERROR, "Connection to {} is terminated", getDescription());
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Connection to {} is terminated", getDescription());
         }
 
         Packet res;

--- a/src/Client/Connection.cpp
+++ b/src/Client/Connection.cpp
@@ -1327,11 +1327,10 @@ Packet Connection::receivePacket()
 {
     try
     {
-        /// If we already disconnected.
+        /// We are trying to send something to already disconnected connection,
+        /// this means that we continue using Connection after exception.
         if (!in)
-        {
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Connection to {} is terminated", getDescription());
-        }
 
         Packet res;
 

--- a/src/Client/Connection.cpp
+++ b/src/Client/Connection.cpp
@@ -1326,6 +1326,11 @@ Packet Connection::receivePacket()
 {
     try
     {
+        if (!in)
+        {
+            throw Exception(ErrorCodes::NETWORK_ERROR, "Connection to {} is terminated", getDescription());
+        }
+
         Packet res;
 
         /// Have we already read packet type?

--- a/src/Client/Connection.cpp
+++ b/src/Client/Connection.cpp
@@ -1326,6 +1326,7 @@ Packet Connection::receivePacket()
 {
     try
     {
+        /// If we already disconnected.
         if (!in)
         {
             throw Exception(ErrorCodes::NETWORK_ERROR, "Connection to {} is terminated", getDescription());

--- a/src/Processors/Sources/RemoteSource.cpp
+++ b/src/Processors/Sources/RemoteSource.cpp
@@ -249,6 +249,8 @@ void RemoteSource::onCancel() noexcept
 
 void RemoteSource::onUpdatePorts()
 {
+    if (isCancelled())
+        return;
     if (getPort().isFinished())
         query_executor->finish();
 }

--- a/src/QueryPipeline/RemoteQueryExecutor.cpp
+++ b/src/QueryPipeline/RemoteQueryExecutor.cpp
@@ -785,7 +785,7 @@ void RemoteQueryExecutor::finish()
       * - received an unknown packet from one replica;
       * then you do not need to read anything.
       */
-    if (!isQueryPending() || hasThrownException())
+    if (!isQueryPending() || hasThrownException() || was_cancelled)
         return;
 
     /// To make sure finish is only called once


### PR DESCRIPTION
<!-- Fixes issue link part, do not remove -->
## Linked issues
- fixes https://github.com/ClickHouse/clickhouse-core-incidents/issues/1114
<!-- End of fixes issue link part, do not remove -->

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Avoid possible crash for distributed queries in case of cancellation

### Details

```
(gdb) bt
#0  DB::readVarUInt (x=<optimized out>, istr=...) at ./src/IO/VarInt.h:98
#1  DB::Connection::receivePacket (this=0x7fb32ee2f418) at ./ci/tmp/build/./src/Client/Connection.cpp:1315
#2  0x000000001a4b71e8 in DB::MultiplexedConnections::receivePacketUnlocked(std::__1::function<void (int, Poco::Timespan, DB::AsyncEventTimeoutType, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, unsigned int)>) (this=0x7fb268e99c40, async_callback=...)
    at ./ci/tmp/build/./src/Client/MultiplexedConnections.cpp:398
#3  0x000000001a4b6efe in DB::MultiplexedConnections::receivePacket (this=0x7fb268e99c40) at ./ci/tmp/build/./src/Client/MultiplexedConnections.cpp:253
#4  0x00000000178df465 in DB::RemoteQueryExecutor::finish (this=0x7fb17401af98) at ./ci/tmp/build/./src/QueryPipeline/RemoteQueryExecutor.cpp:811
#5  0x000000001a6b747a in DB::ExecutingGraph::updateNode (this=0x7fb4889a9f80, pid=<optimized out>, queue=..., async_queue=...) at ./ci/tmp/build/./src/Processors/Executors/ExecutingGraph.cpp:253
#6  0x000000001a6b1be6 in DB::PipelineExecutor::executeStepImpl (this=0x7fa7149f3c10, thread_num=<optimized out>, cpu_slot=<optimized out>, yield_flag=0x0) at ./ci/tmp/build/./src/Processors/Executors/PipelineExecutor.cpp:371
#7  0x000000001a6b5c03 in DB::PipelineExecutor::executeSingleThread (this=0x7fa7149f3c10, thread_num=814337472, cpu_slot=0x0) at ./ci/tmp/build/./src/Processors/Executors/PipelineExecutor.cpp:279
#8  DB::PipelineExecutor::spawnThreads(std::__1::shared_ptr<DB::IAcquiredSlot>)::$_0::operator()() const (this=0x7fb22db706b0) at ./ci/tmp/build/./src/Processors/Executors/PipelineExecutor.cpp:565
```

The `in` buffer:

```
(gdb) frame 1
(gdb) print this->in
$19 = {__ptr_ = 0x0, __cntrl_ = 0x0}
(gdb) print this->connected
$18 = false
```

But the same time:

```
(gdb) frame 2
  async_callback=...) at ./ci/tmp/build/./src/Client/MultiplexedConnections.cpp:398
(gdb) print this->sent_query
$15 = true
(gdb) print this->cancelled
$16 = false
(gdb) print this->active_connection_count
$17 = 1
```

Ref: https://github.com/ClickHouse/ClickHouse/pull/89740
Ref: https://github.com/ClickHouse/ClickHouse/pull/92807
Ref: https://github.com/ClickHouse/ClickHouse/pull/93029

CC @kssenii @azat 

<!-- fixes https://github.com/ClickHouse/clickhouse-core-incidents/issues/1114 -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.126`
- Backported to: `26.1.2.4`, `25.12.5.37`, `25.11.9.11`, `25.10.6.35`, `25.8.16.33`
<!-- ch-version-info:end -->