### PR TITLE
Fix updating row policies

### DIFF
--- a/src/Access/ContextAccess.h
+++ b/src/Access/ContextAccess.h
@@ -147,6 +147,7 @@ private:
     void initialize();
     void setUser(const UserPtr & user_) const TSA_REQUIRES(mutex);
     void setRolesInfo(const std::shared_ptr<const EnabledRolesInfo> & roles_info_) const TSA_REQUIRES(mutex);
+    void findRowPoliciesOfInitialUser() const TSA_REQUIRES(mutex);
     void calculateAccessRights() const TSA_REQUIRES(mutex);
 
     template <bool throw_if_denied, bool grant_option, bool wildcard>
@@ -200,6 +201,7 @@ private:
     mutable UserPtr user TSA_GUARDED_BY(mutex);
     mutable String user_name TSA_GUARDED_BY(mutex);
     mutable scope_guard subscription_for_user_change TSA_GUARDED_BY(mutex);
+    mutable scope_guard subscription_for_initial_user_change TSA_GUARDED_BY(mutex);
     mutable std::shared_ptr<const EnabledRoles> enabled_roles TSA_GUARDED_BY(mutex);
     mutable scope_guard subscription_for_roles_changes TSA_GUARDED_BY(mutex);
     mutable std::shared_ptr<const EnabledRolesInfo> roles_info TSA_GUARDED_BY(mutex);

--- a/src/Access/ContextAccessParams.cpp
+++ b/src/Access/ContextAccessParams.cpp
@@ -24,7 +24,8 @@ ContextAccessParams::ContextAccessParams(
     const std::shared_ptr<const std::vector<UUID>> & external_roles_,
     const Settings & settings_,
     const String & current_database_,
-    const ClientInfo & client_info_)
+    const ClientInfo & client_info_,
+    const std::optional<UUID> & initial_user_id_)
     : user_id(user_id_)
     , full_access(full_access_)
     , use_default_roles(use_default_roles_)
@@ -39,7 +40,7 @@ ContextAccessParams::ContextAccessParams(
     , address(std::make_shared<Poco::Net::IPAddress>(client_info_.current_address->host()))
     , forwarded_address(client_info_.getLastForwardedForHost())
     , quota_key(client_info_.quota_key)
-    , initial_user((client_info_.initial_user != client_info_.current_user) ? client_info_.initial_user : "")
+    , initial_user_id(initial_user_id_)
 {
 }
 
@@ -92,8 +93,8 @@ String ContextAccessParams::toString() const
         out << separator() << "forwarded_address = " << forwarded_address;
     if (!quota_key.empty())
         out << separator() << "quota_key = " << quota_key;
-    if (!initial_user.empty())
-        out << separator() << "initial_user = " << initial_user;
+    if (initial_user_id)
+        out << separator() << "initial_user_id = " << *initial_user_id;
     return out.str();
 }
 
@@ -133,7 +134,7 @@ bool operator ==(const ContextAccessParams & left, const ContextAccessParams & r
     CONTEXT_ACCESS_PARAMS_EQUALS(address)
     CONTEXT_ACCESS_PARAMS_EQUALS(forwarded_address)
     CONTEXT_ACCESS_PARAMS_EQUALS(quota_key)
-    CONTEXT_ACCESS_PARAMS_EQUALS(initial_user)
+    CONTEXT_ACCESS_PARAMS_EQUALS(initial_user_id)
 
     #undef CONTEXT_ACCESS_PARAMS_EQUALS
 
@@ -184,7 +185,7 @@ bool operator <(const ContextAccessParams & left, const ContextAccessParams & ri
     CONTEXT_ACCESS_PARAMS_LESS(address)
     CONTEXT_ACCESS_PARAMS_LESS(forwarded_address)
     CONTEXT_ACCESS_PARAMS_LESS(quota_key)
-    CONTEXT_ACCESS_PARAMS_LESS(initial_user)
+    CONTEXT_ACCESS_PARAMS_LESS(initial_user_id)
 
     #undef CONTEXT_ACCESS_PARAMS_LESS
 

--- a/src/Access/ContextAccessParams.h
+++ b/src/Access/ContextAccessParams.h
@@ -27,7 +27,8 @@ public:
         const std::shared_ptr<const std::vector<UUID>> & external_roles_,
         const Settings & settings_,
         const String & current_database_,
-        const ClientInfo & client_info_);
+        const ClientInfo & client_info_,
+        const std::optional<UUID> & initial_user_id_);
 
     const std::optional<UUID> user_id;
 
@@ -56,7 +57,7 @@ public:
     const String quota_key;
 
     /// Initial user is used to combine row policies with.
-    const String initial_user;
+    const std::optional<UUID> initial_user_id;
 
     /// Outputs `ContextAccessParams` to string for logging.
     String toString() const;

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -1978,8 +1978,12 @@ std::shared_ptr<const ContextAccessWrapper> Context::getAccess() const
         /// If setUserID() was never called then this must be the global context with the full access.
         bool full_access = !user_id;
 
+        std::optional<UUID> initial_user_id;
+        if (client_info.initial_user != client_info.current_user)
+            initial_user_id = getAccessControl().find<User>(client_info.initial_user);
+
         return ContextAccessParams{
-            user_id, full_access, /* use_default_roles= */ false, current_roles, external_roles, *settings, current_database, client_info};
+            user_id, full_access, /* use_default_roles= */ false, current_roles, external_roles, *settings, current_database, client_info, initial_user_id};
     };
 
     /// Check if the current access rights are still valid, otherwise get parameters for recalculating access rights.

--- a/tests/queries/0_stateless/03812_row_policy_after_changing_initial_user_roles.reference
+++ b/tests/queries/0_stateless/03812_row_policy_after_changing_initial_user_roles.reference
@@ -1,0 +1,12 @@
+with row policy a:
+0
+2
+4
+6
+8
+with row policy b:
+1
+3
+5
+7
+9

--- a/tests/queries/0_stateless/03812_row_policy_after_changing_initial_user_roles.sh
+++ b/tests/queries/0_stateless/03812_row_policy_after_changing_initial_user_roles.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+user_name="user_${CLICKHOUSE_DATABASE}"
+role_a="role_a_${CLICKHOUSE_DATABASE}"
+role_b="role_b_${CLICKHOUSE_DATABASE}"
+row_policy_a="policy_a_${CLICKHOUSE_DATABASE}"
+row_policy_b="policy_b_${CLICKHOUSE_DATABASE}"
+
+$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS test"
+$CLICKHOUSE_CLIENT -q "DROP USER IF EXISTS ${user_name}"
+$CLICKHOUSE_CLIENT -q "DROP ROLE IF EXISTS ${role_a}, ${role_b}"
+$CLICKHOUSE_CLIENT -q "DROP ROW POLICY IF EXISTS ${row_policy_a}, ${row_policy_b} ON test"
+
+$CLICKHOUSE_CLIENT -q "CREATE TABLE test(x Int64) ENGINE=Memory"
+$CLICKHOUSE_CLIENT -q "INSERT INTO test SELECT number FROM numbers(10)"
+
+$CLICKHOUSE_CLIENT -q "CREATE USER ${user_name}"
+
+$CLICKHOUSE_CLIENT -q "CREATE ROLE ${role_a}"
+$CLICKHOUSE_CLIENT -q "GRANT SELECT ON test, REMOTE ON *.* TO ${role_a}"
+$CLICKHOUSE_CLIENT -q "CREATE ROW POLICY ${row_policy_a} ON test FOR SELECT USING x % 2 = 0 TO ${role_a}"
+
+$CLICKHOUSE_CLIENT -q "CREATE ROLE ${role_b}"
+$CLICKHOUSE_CLIENT -q "GRANT SELECT ON test, REMOTE ON *.* TO ${role_b}"
+$CLICKHOUSE_CLIENT -q "CREATE ROW POLICY ${row_policy_b} ON test FOR SELECT USING x % 2 = 1 TO ${role_b}"
+
+echo 'with row policy a:'
+$CLICKHOUSE_CLIENT -q "GRANT ${role_a} TO ${user_name}"
+$CLICKHOUSE_CLIENT --user ${user_name} -q "SELECT * FROM cluster('test_shard_localhost', currentDatabase(), test)"
+$CLICKHOUSE_CLIENT -q "REVOKE ${role_a} FROM ${user_name}"
+
+echo 'with row policy b:'
+$CLICKHOUSE_CLIENT -q "GRANT ${role_b} TO ${user_name}"
+$CLICKHOUSE_CLIENT --user ${user_name} -q "SELECT * FROM cluster('test_shard_localhost', currentDatabase(), test)"
+$CLICKHOUSE_CLIENT -q "REVOKE ${role_b} FROM ${user_name}"
+
+$CLICKHOUSE_CLIENT -q "DROP TABLE test"
+$CLICKHOUSE_CLIENT -q "DROP USER ${user_name}"
+$CLICKHOUSE_CLIENT -q "DROP ROLE ${role_a}, ${role_b}"
+$CLICKHOUSE_CLIENT -q "DROP ROW POLICY ${row_policy_a}, ${row_policy_b} ON test"

--- a/tests/queries/0_stateless/03812_row_policy_after_replacing_initial_user.reference
+++ b/tests/queries/0_stateless/03812_row_policy_after_replacing_initial_user.reference
@@ -1,0 +1,12 @@
+with row policy a:
+0
+2
+4
+6
+8
+with row policy b:
+1
+3
+5
+7
+9

--- a/tests/queries/0_stateless/03812_row_policy_after_replacing_initial_user.sh
+++ b/tests/queries/0_stateless/03812_row_policy_after_replacing_initial_user.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+user_name="user_${CLICKHOUSE_DATABASE}"
+row_policy_a="policy_a_${CLICKHOUSE_DATABASE}"
+row_policy_b="policy_b_${CLICKHOUSE_DATABASE}"
+
+$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS test"
+$CLICKHOUSE_CLIENT -q "DROP USER IF EXISTS ${user_name}"
+$CLICKHOUSE_CLIENT -q "DROP ROW POLICY IF EXISTS ${row_policy_a}, ${row_policy_b} ON test"
+
+$CLICKHOUSE_CLIENT -q "CREATE TABLE test(x Int64) ENGINE=Memory"
+$CLICKHOUSE_CLIENT -q "INSERT INTO test SELECT number FROM numbers(10)"
+
+$CLICKHOUSE_CLIENT -q "CREATE ROW POLICY ${row_policy_a} ON test FOR SELECT USING x % 2 = 0"
+$CLICKHOUSE_CLIENT -q "CREATE ROW POLICY ${row_policy_b} ON test FOR SELECT USING x % 2 = 1"
+
+echo 'with row policy a:'
+$CLICKHOUSE_CLIENT -q "CREATE USER ${user_name}"
+$CLICKHOUSE_CLIENT -q "GRANT SELECT ON test, REMOTE ON *.* TO ${user_name}"
+$CLICKHOUSE_CLIENT -q "ALTER ROW POLICY ${row_policy_a} ON test TO ${user_name}"
+$CLICKHOUSE_CLIENT --user ${user_name} -q "SELECT * FROM cluster('test_shard_localhost', currentDatabase(), test)"
+$CLICKHOUSE_CLIENT -q "DROP USER ${user_name}"
+
+echo 'with row policy b:'
+$CLICKHOUSE_CLIENT -q "CREATE USER ${user_name}"
+$CLICKHOUSE_CLIENT -q "GRANT SELECT ON test, REMOTE ON *.* TO ${user_name}"
+$CLICKHOUSE_CLIENT -q "ALTER ROW POLICY ${row_policy_b} ON test TO ${user_name}"
+$CLICKHOUSE_CLIENT --user ${user_name} -q "SELECT * FROM cluster('test_shard_localhost', currentDatabase(), test)"
+$CLICKHOUSE_CLIENT -q "DROP USER ${user_name}"
+
+$CLICKHOUSE_CLIENT -q "DROP TABLE test"
+$CLICKHOUSE_CLIENT -q "DROP ROW POLICY ${row_policy_a}, ${row_policy_b} ON test"


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix updating row policies assigned to the initial user in distributed queries.

The issue was found while investigating a CI failure in [01802_test_postgresql_protocol_with_row_policy](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=95014&sha=fff0fc035ef4d61e62b6ab56370055f1946f4cde&name_0=PR&name_1=Stateless+tests+%28amd_binary%2C+ParallelReplicas%2C+s3+storage%2C+sequential%29
https://github.com/ClickHouse/ClickHouse/pull/95014)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.154`
<!-- ch-version-info:end -->