### PR TITLE
Fix check for encrypted disks over plain_rewritable

### DIFF
--- a/src/Disks/DiskSelector.cpp
+++ b/src/Disks/DiskSelector.cpp
@@ -57,18 +57,10 @@ void DiskSelector::recordDisk(const std::string & disk_name, DiskPtr disk)
                 if (!same)
                 {
                     /// In case of encrypted disk we cannot simply compare getMetadataStorage() since it is wrapped
-                    if (disk->getDataSourceDescription().is_encrypted)
-                    {
-                        auto underlying_disk = disk->getDelegateDiskIfExists();
-                        if (underlying_disk)
-                            same = underlying_disk->getMetadataStorage().get() == saved_disk->getMetadataStorage().get();
-                    }
-                    else if (saved_disk->getDataSourceDescription().is_encrypted)
-                    {
-                        auto underlying_saved_disk = saved_disk->getDelegateDiskIfExists();
-                        if (underlying_saved_disk)
-                            same = underlying_saved_disk->getMetadataStorage().get() == disk->getMetadataStorage().get();
-                    }
+                    auto delegated_disk_or_original = disk->getDataSourceDescription().is_encrypted && disk->getDelegateDiskIfExists() ? disk->getDelegateDiskIfExists() : disk;
+                    auto delegated_saved_disk_or_original = saved_disk->getDataSourceDescription().is_encrypted && saved_disk->getDelegateDiskIfExists() ? saved_disk->getDelegateDiskIfExists() : saved_disk;
+
+                    same = delegated_disk_or_original->getMetadataStorage().get() == delegated_saved_disk_or_original->getMetadataStorage().get();
                 }
 
                 if (!same)

--- a/tests/queries/0_stateless/03820_plain_rewritable_over_another_disk_with_same_path.reference
+++ b/tests/queries/0_stateless/03820_plain_rewritable_over_another_disk_with_same_path.reference
@@ -1,0 +1,2 @@
+cache_on_write_operations=0
+cache_on_write_operations=1

--- a/tests/queries/0_stateless/03820_plain_rewritable_over_another_disk_with_same_path.sh
+++ b/tests/queries/0_stateless/03820_plain_rewritable_over_another_disk_with_same_path.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT -nm -q "
+drop table if exists mt1;
+drop table if exists mt1;
+drop table if exists mt3;
+drop table if exists mt4;
+
+create table mt1 (key Int) engine=MergeTree order by () settings disk=disk(type='s3_plain_rewritable', endpoint='http://localhost:11111/test/s3_plain_rewritable_$CLICKHOUSE_DATABASE', access_key_id=clickhouse, secret_access_key=clickhouse);
+-- cache disk on top of s3_plain_rewritable is allowed
+create table mt2 (key Int) engine=MergeTree order by () settings disk=disk(type='cache', path='disk1_$CLICKHOUSE_DATABASE', max_size=100000, disk=disk(type='s3_plain_rewritable', endpoint='http://localhost:11111/test/s3_plain_rewritable_$CLICKHOUSE_DATABASE', access_key_id=clickhouse, secret_access_key=clickhouse));
+-- encrypted disk with the same path as original s3_plain_rewritable disk is allowed
+create table mt3 (key Int) engine=MergeTree order by () settings disk=disk(type='encrypted', key='1234567812345678', disk=disk(type='s3_plain_rewritable', endpoint='http://localhost:11111/test/s3_plain_rewritable_$CLICKHOUSE_DATABASE', access_key_id=clickhouse, secret_access_key=clickhouse));
+-- encrypted disk over cache is allowed
+create table mt4 (key Int) engine=MergeTree order by () settings disk=disk(type='encrypted', key='1234567812345678', disk=disk(type='cache', path='disk1_$CLICKHOUSE_DATABASE', max_size=100000, disk=disk(type='s3_plain_rewritable', endpoint='http://localhost:11111/test/s3_plain_rewritable_$CLICKHOUSE_DATABASE', access_key_id=clickhouse, secret_access_key=clickhouse)));
+
+drop table mt1;
+drop table mt2;
+drop table mt3;
+drop table mt4;
+"

--- a/tests/queries/0_stateless/03820_plain_rewritable_over_another_disk_with_same_path.sh
+++ b/tests/queries/0_stateless/03820_plain_rewritable_over_another_disk_with_same_path.sh
@@ -5,19 +5,45 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
+echo "cache_on_write_operations=0"
+endpoint="http://localhost:11111/test/s3_plain_rewritable_${CLICKHOUSE_DATABASE}_cache_on_write_operations_0"
+cache_path="${CLICKHOUSE_DATABASE}_cache_disk_cache_on_write_operations_0"
 $CLICKHOUSE_CLIENT -nm -q "
 drop table if exists mt1;
 drop table if exists mt1;
 drop table if exists mt3;
 drop table if exists mt4;
 
-create table mt1 (key Int) engine=MergeTree order by () settings disk=disk(type='s3_plain_rewritable', endpoint='http://localhost:11111/test/s3_plain_rewritable_$CLICKHOUSE_DATABASE', access_key_id=clickhouse, secret_access_key=clickhouse);
+create table mt1 (key Int) engine=MergeTree order by () settings disk=disk(cache_on_write_operations=0, type='s3_plain_rewritable', endpoint='$endpoint', access_key_id=clickhouse, secret_access_key=clickhouse);
 -- cache disk on top of s3_plain_rewritable is allowed
-create table mt2 (key Int) engine=MergeTree order by () settings disk=disk(type='cache', path='disk1_$CLICKHOUSE_DATABASE', max_size=100000, disk=disk(type='s3_plain_rewritable', endpoint='http://localhost:11111/test/s3_plain_rewritable_$CLICKHOUSE_DATABASE', access_key_id=clickhouse, secret_access_key=clickhouse));
+create table mt2 (key Int) engine=MergeTree order by () settings disk=disk(cache_on_write_operations=0, type='cache', path='$cache_path', max_size=100000, disk=disk(cache_on_write_operations=0, type='s3_plain_rewritable', endpoint='$endpoint', access_key_id=clickhouse, secret_access_key=clickhouse));
 -- encrypted disk with the same path as original s3_plain_rewritable disk is allowed
-create table mt3 (key Int) engine=MergeTree order by () settings disk=disk(type='encrypted', key='1234567812345678', disk=disk(type='s3_plain_rewritable', endpoint='http://localhost:11111/test/s3_plain_rewritable_$CLICKHOUSE_DATABASE', access_key_id=clickhouse, secret_access_key=clickhouse));
+create table mt3 (key Int) engine=MergeTree order by () settings disk=disk(cache_on_write_operations=0, type='encrypted', key='1234567812345678', disk=disk(cache_on_write_operations=0, type='s3_plain_rewritable', endpoint='$endpoint', access_key_id=clickhouse, secret_access_key=clickhouse));
 -- encrypted disk over cache is allowed
-create table mt4 (key Int) engine=MergeTree order by () settings disk=disk(type='encrypted', key='1234567812345678', disk=disk(type='cache', path='disk1_$CLICKHOUSE_DATABASE', max_size=100000, disk=disk(type='s3_plain_rewritable', endpoint='http://localhost:11111/test/s3_plain_rewritable_$CLICKHOUSE_DATABASE', access_key_id=clickhouse, secret_access_key=clickhouse)));
+create table mt4 (key Int) engine=MergeTree order by () settings disk=disk(cache_on_write_operations=0, type='encrypted', key='1234567812345678', disk=disk(cache_on_write_operations=0, type='cache', path='$cache_path', max_size=100000, disk=disk(cache_on_write_operations=0, type='s3_plain_rewritable', endpoint='$endpoint', access_key_id=clickhouse, secret_access_key=clickhouse)));
+
+drop table mt1;
+drop table mt2;
+drop table mt3;
+drop table mt4;
+"
+
+echo "cache_on_write_operations=1"
+endpoint="http://localhost:11111/test/s3_plain_rewritable_${CLICKHOUSE_DATABASE}_cache_on_write_operations_1"
+cache_path="${CLICKHOUSE_DATABASE}_cache_disk_cache_on_write_operations_1"
+$CLICKHOUSE_CLIENT -nm -q "
+drop table if exists mt1;
+drop table if exists mt1;
+drop table if exists mt3;
+drop table if exists mt4;
+
+create table mt1 (key Int) engine=MergeTree order by () settings disk=disk(cache_on_write_operations=1, type='s3_plain_rewritable', endpoint='$endpoint', access_key_id=clickhouse, secret_access_key=clickhouse);
+-- cache disk on top of s3_plain_rewritable is allowed
+create table mt2 (key Int) engine=MergeTree order by () settings disk=disk(cache_on_write_operations=1, type='cache', path='$cache_path', max_size=100000, disk=disk(cache_on_write_operations=1, type='s3_plain_rewritable', endpoint='$endpoint', access_key_id=clickhouse, secret_access_key=clickhouse));
+-- encrypted disk with the same path as original s3_plain_rewritable disk is allowed
+create table mt3 (key Int) engine=MergeTree order by () settings disk=disk(cache_on_write_operations=1, type='encrypted', key='1234567812345678', disk=disk(cache_on_write_operations=1, type='s3_plain_rewritable', endpoint='$endpoint', access_key_id=clickhouse, secret_access_key=clickhouse));
+-- encrypted disk over cache is allowed
+create table mt4 (key Int) engine=MergeTree order by () settings disk=disk(cache_on_write_operations=1, type='encrypted', key='1234567812345678', disk=disk(cache_on_write_operations=1, type='cache', path='$cache_path', max_size=100000, disk=disk(cache_on_write_operations=1, type='s3_plain_rewritable', endpoint='$endpoint', access_key_id=clickhouse, secret_access_key=clickhouse)));
 
 drop table mt1;
 drop table mt2;

--- a/tests/queries/0_stateless/03820_plain_rewritable_over_another_disk_with_same_path.sh
+++ b/tests/queries/0_stateless/03820_plain_rewritable_over_another_disk_with_same_path.sh
@@ -5,10 +5,16 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
+settings=(
+    # Not compatible with DC
+    --write_through_distributed_cache=0
+    --read_through_distributed_cache=0
+)
+
 echo "cache_on_write_operations=0"
 endpoint="http://localhost:11111/test/s3_plain_rewritable_${CLICKHOUSE_DATABASE}_cache_on_write_operations_0"
 cache_path="${CLICKHOUSE_DATABASE}_cache_disk_cache_on_write_operations_0"
-$CLICKHOUSE_CLIENT -nm -q "
+$CLICKHOUSE_CLIENT "${settings[@]}" -nm -q "
 drop table if exists mt1;
 drop table if exists mt1;
 drop table if exists mt3;
@@ -31,7 +37,7 @@ drop table mt4;
 echo "cache_on_write_operations=1"
 endpoint="http://localhost:11111/test/s3_plain_rewritable_${CLICKHOUSE_DATABASE}_cache_on_write_operations_1"
 cache_path="${CLICKHOUSE_DATABASE}_cache_disk_cache_on_write_operations_1"
-$CLICKHOUSE_CLIENT -nm -q "
+$CLICKHOUSE_CLIENT "${settings[@]}" -nm -q "
 drop table if exists mt1;
 drop table if exists mt1;
 drop table if exists mt3;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix check for encrypted disks over plain_rewritable (Fixes possible `It is not possible to register multiple plain-rewritable disks with the same object storage prefix`)

Previously if you have two encrypted disks points to the same plain_rewritable, i.e. one over cache and one not, you will get "It is not possible to register multiple plain-rewritable disks with the same object storage prefix".

Fixes: https://github.com/ClickHouse/ClickHouse/pull/94852 (cc @yariks5s )


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.108`
- Backported to: `26.1.1.910`, `25.12.5.32`, `25.11.9.6`, `25.10.6.30`, `25.8.16.28`
<!-- ch-version-info:end -->