### PR TITLE
Add connection_address and connection_port to query_log

### DIFF
--- a/docs/en/operations/system-tables/query_log.md
+++ b/docs/en/operations/system-tables/query_log.md
@@ -76,12 +76,12 @@ You can use the [log_formatted_queries](/operations/settings/settings#log_format
 - `is_initial_query` ([UInt8](../../sql-reference/data-types/int-uint.md)) — Query type. Possible values:
   - 1 — Query was initiated by the client.
   - 0 — Query was initiated by another query as part of distributed query execution.
-- `connection_address` ([IPv6](../../sql-reference/data-types/ipv6.md)) — The client IP address from which connection was made.
-- `connection_port` ([UInt16](../../sql-reference/data-types/int-uint.md)) — The client port from which connection was made.
+- `connection_address` ([IPv6](../../sql-reference/data-types/ipv6.md)) — The client IP address from which the connection was made. When connected through a proxy this will be the address of the proxy.
+- `connection_port` ([UInt16](../../sql-reference/data-types/int-uint.md)) — The client port from which the connection was made. When connected through a proxy this will be the port of the proxy.
 - `user` ([String](../../sql-reference/data-types/string.md)) — Name of the user who initiated the current query.
 - `query_id` ([String](../../sql-reference/data-types/string.md)) — ID of the query.
-- `address` ([IPv6](../../sql-reference/data-types/ipv6.md)) — IP address that was used to make the query.
-- `port` ([UInt16](../../sql-reference/data-types/int-uint.md)) — The client port that was used to make the query.
+- `address` ([IPv6](../../sql-reference/data-types/ipv6.md)) — The IP address that was used to make the query. When connected through a proxy and [auth_use_forwarded_address](/operations/server-configuration-parameters/settings#auth_use_forwarded_address) is set this will be the address of the client instead of the proxy.
+- `port` ([UInt16](/sql-reference/data-types/int-uint#integer-ranges)) — The client port that was used to make the query. When connected through a proxy and [auth_use_forwarded_address](/operations/server-configuration-parameters/settings#auth_use_forwarded_address) is set this will be the port of the client instead of the proxy.
 - `initial_user` ([String](../../sql-reference/data-types/string.md)) — Name of the user who ran the initial query (for distributed query execution).
 - `initial_query_id` ([String](../../sql-reference/data-types/string.md)) — ID of the initial query (for distributed query execution).
 - `initial_address` ([IPv6](../../sql-reference/data-types/ipv6.md)) — IP address that the parent query was launched from.

--- a/docs/en/operations/system-tables/query_log.md
+++ b/docs/en/operations/system-tables/query_log.md
@@ -76,6 +76,8 @@ You can use the [log_formatted_queries](/operations/settings/settings#log_format
 - `is_initial_query` ([UInt8](../../sql-reference/data-types/int-uint.md)) — Query type. Possible values:
   - 1 — Query was initiated by the client.
   - 0 — Query was initiated by another query as part of distributed query execution.
+- `connection_address` ([IPv6](../../sql-reference/data-types/ipv6.md)) — The client IP address from which connection was made.
+- `connection_port` ([UInt16](../../sql-reference/data-types/int-uint.md)) — The client port from which connection was made.
 - `user` ([String](../../sql-reference/data-types/string.md)) — Name of the user who initiated the current query.
 - `query_id` ([String](../../sql-reference/data-types/string.md)) — ID of the query.
 - `address` ([IPv6](../../sql-reference/data-types/ipv6.md)) — IP address that was used to make the query.

--- a/docs/en/operations/system-tables/query_thread_log.md
+++ b/docs/en/operations/system-tables/query_thread_log.md
@@ -48,6 +48,8 @@ Columns:
 - `is_initial_query` ([UInt8](/sql-reference/data-types/int-uint#integer-ranges)) — Query type. Possible values:
   - 1 — Query was initiated by the client.
   - 0 — Query was initiated by another query for distributed query execution.
+- `connection_address` ([IPv6](../../sql-reference/data-types/ipv6.md)) — The client IP address from which connection was made.
+- `connection_port` ([UInt16](../../sql-reference/data-types/int-uint.md)) — The client port from which connection was made.
 - `user` ([String](../../sql-reference/data-types/string.md)) — Name of the user who initiated the current query.
 - `query_id` ([String](../../sql-reference/data-types/string.md)) — ID of the query.
 - `address` ([IPv6](../../sql-reference/data-types/ipv6.md)) — IP address that was used to make the query.

--- a/docs/en/operations/system-tables/query_thread_log.md
+++ b/docs/en/operations/system-tables/query_thread_log.md
@@ -48,12 +48,12 @@ Columns:
 - `is_initial_query` ([UInt8](/sql-reference/data-types/int-uint#integer-ranges)) — Query type. Possible values:
   - 1 — Query was initiated by the client.
   - 0 — Query was initiated by another query for distributed query execution.
-- `connection_address` ([IPv6](../../sql-reference/data-types/ipv6.md)) — The client IP address from which connection was made.
-- `connection_port` ([UInt16](../../sql-reference/data-types/int-uint.md)) — The client port from which connection was made.
+- `connection_address` ([IPv6](../../sql-reference/data-types/ipv6.md)) — The client IP address from which the connection was made. When connected through a proxy this will be the address of the proxy.
+- `connection_port` ([UInt16](../../sql-reference/data-types/int-uint.md)) — The client port from which the connection was made. When connected through a proxy this will be the port of the proxy.
 - `user` ([String](../../sql-reference/data-types/string.md)) — Name of the user who initiated the current query.
 - `query_id` ([String](../../sql-reference/data-types/string.md)) — ID of the query.
-- `address` ([IPv6](../../sql-reference/data-types/ipv6.md)) — IP address that was used to make the query.
-- `port` ([UInt16](/sql-reference/data-types/int-uint#integer-ranges)) — The client port that was used to make the query.
+- `address` ([IPv6](../../sql-reference/data-types/ipv6.md)) — The IP address that was used to make the query. When connected through a proxy and [auth_use_forwarded_address](/operations/server-configuration-parameters/settings#auth_use_forwarded_address) is set this will be the address of the client instead of the proxy.
+- `port` ([UInt16](/sql-reference/data-types/int-uint#integer-ranges)) — The client port that was used to make the query. When connected through a proxy and [auth_use_forwarded_address](/operations/server-configuration-parameters/settings#auth_use_forwarded_address) is set this will be the port of the client instead of the proxy.
 - `initial_user` ([String](../../sql-reference/data-types/string.md)) — Name of the user who ran the initial query (for distributed query execution).
 - `initial_query_id` ([String](../../sql-reference/data-types/string.md)) — ID of the initial query (for distributed query execution).
 - `initial_address` ([IPv6](../../sql-reference/data-types/ipv6.md)) — IP address that the parent query was launched from.

--- a/src/Interpreters/ClientInfo.cpp
+++ b/src/Interpreters/ClientInfo.cpp
@@ -24,6 +24,7 @@ namespace ErrorCodes
 
 ClientInfo::ClientInfo()
 {
+    connection_address = std::make_shared<Poco::Net::SocketAddress>();
     current_address = std::make_shared<Poco::Net::SocketAddress>();
     initial_address = std::make_shared<Poco::Net::SocketAddress>();
 }

--- a/src/Interpreters/ClientInfo.h
+++ b/src/Interpreters/ClientInfo.h
@@ -60,6 +60,8 @@ public:
 
     QueryKind query_kind = QueryKind::NO_QUERY;
 
+    std::shared_ptr<Poco::Net::SocketAddress> connection_address;
+
     /// Current values are not serialized, because it is passed separately.
     String current_user;
     String current_query_id;

--- a/src/Interpreters/QueryLog.cpp
+++ b/src/Interpreters/QueryLog.cpp
@@ -96,6 +96,8 @@ ColumnsDescription QueryLogElement::getColumnsDescription()
         {"stack_trace", std::make_shared<DataTypeString>(), "Stack trace. An empty string, if the query was completed successfully."},
 
         {"is_initial_query", std::make_shared<DataTypeUInt8>(), "Query type. Possible values: 1 — query was initiated by the client, 0 — query was initiated by another query as part of distributed query execution."},
+        {"connection_address", DataTypeFactory::instance().get("IPv6"), "The client IP address from which connection was made."},
+        {"connection_port", std::make_shared<DataTypeUInt16>(), "The client port from which connection was made."},
         {"user", low_cardinality_string, "Name of the user who initiated the current query."},
         {"query_id", std::make_shared<DataTypeString>(), "ID of the query."},
         {"address", DataTypeFactory::instance().get("IPv6"), "IP address that was used to make the query."},
@@ -345,6 +347,9 @@ void QueryLogElement::appendToBlock(MutableColumns & columns) const
 void QueryLogElement::appendClientInfo(const ClientInfo & client_info, MutableColumns & columns, size_t & i)
 {
     typeid_cast<ColumnUInt8 &>(*columns[i++]).getData().push_back(client_info.query_kind == ClientInfo::QueryKind::INITIAL_QUERY);
+
+    typeid_cast<ColumnIPv6 &>(*columns[i++]).insertData(IPv6ToBinary(client_info.connection_address->host()).data(), 16);
+    typeid_cast<ColumnUInt16 &>(*columns[i++]).getData().push_back(client_info.connection_address->port());
 
     typeid_cast<ColumnLowCardinality &>(*columns[i++]).insertData(client_info.current_user.data(), client_info.current_user.size());
     typeid_cast<ColumnString &>(*columns[i++]).insertData(client_info.current_query_id.data(), client_info.current_query_id.size());

--- a/src/Interpreters/QueryThreadLog.cpp
+++ b/src/Interpreters/QueryThreadLog.cpp
@@ -47,6 +47,8 @@ ColumnsDescription QueryThreadLogElement::getColumnsDescription()
         {"normalized_query_hash", std::make_shared<DataTypeUInt64>(), "The hash of normalized query - with wiped constanstans, etc."},
 
         {"is_initial_query", std::make_shared<DataTypeUInt8>(), "Query type. Possible values: 1 — Query was initiated by the client, 0 — Query was initiated by another query for distributed query execution."},
+        {"connection_address", DataTypeFactory::instance().get("IPv6"), "The client IP address from which connection was made."},
+        {"connection_port", std::make_shared<DataTypeUInt16>(), "The client port from which connection was made."},
         {"user", low_cardinality_string, "Name of the user who initiated the current query."},
         {"query_id", std::make_shared<DataTypeString>(), "ID of the query."},
         {"address", DataTypeFactory::instance().get("IPv6"), "IP address that was used to make the query."},

--- a/src/Interpreters/Session.cpp
+++ b/src/Interpreters/Session.cpp
@@ -358,12 +358,12 @@ std::unordered_set<AuthenticationType> Session::getAuthenticationTypesOrLogInFai
     }
 }
 
-void Session::authenticate(const String & user_name, const String & password, const Poco::Net::SocketAddress & address, const Poco::Net::SocketAddress & orig_address, const Strings & external_roles_)
+void Session::authenticate(const String & user_name, const String & password, const Poco::Net::SocketAddress & address, const std::optional<Poco::Net::SocketAddress> & connection_address, const Strings & external_roles_)
 {
-    authenticate(BasicCredentials{user_name, password}, address, orig_address, external_roles_);
+    authenticate(BasicCredentials{user_name, password}, address, connection_address, external_roles_);
 }
 
-void Session::authenticate(const Credentials & credentials_, const Poco::Net::SocketAddress & address_, const Poco::Net::SocketAddress & orig_address, const Strings & external_roles_)
+void Session::authenticate(const Credentials & credentials_, const Poco::Net::SocketAddress & address_, const std::optional<Poco::Net::SocketAddress> & connection_address, const Strings & external_roles_)
 {
     if (session_context)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "If there is a session context it must be created after authentication");
@@ -404,10 +404,8 @@ void Session::authenticate(const Credentials & credentials_, const Poco::Net::So
 
     prepared_client_info->current_user = credentials_.getUserName();
     prepared_client_info->authenticated_user = credentials_.getUserName();
-    if (orig_address == Poco::Net::SocketAddress())
-        prepared_client_info->current_address = std::make_shared<Poco::Net::SocketAddress>(address);
-    else
-        prepared_client_info->current_address = std::make_shared<Poco::Net::SocketAddress>(orig_address);
+    prepared_client_info->current_address = std::make_shared<Poco::Net::SocketAddress>(address);
+    prepared_client_info->connection_address = std::make_shared<Poco::Net::SocketAddress>(connection_address ? *connection_address : address);
 }
 
 void Session::checkIfUserIsStillValid()

--- a/src/Interpreters/Session.cpp
+++ b/src/Interpreters/Session.cpp
@@ -358,12 +358,12 @@ std::unordered_set<AuthenticationType> Session::getAuthenticationTypesOrLogInFai
     }
 }
 
-void Session::authenticate(const String & user_name, const String & password, const Poco::Net::SocketAddress & address, const Strings & external_roles_)
+void Session::authenticate(const String & user_name, const String & password, const Poco::Net::SocketAddress & address, const Poco::Net::SocketAddress & orig_address, const Strings & external_roles_)
 {
-    authenticate(BasicCredentials{user_name, password}, address, external_roles_);
+    authenticate(BasicCredentials{user_name, password}, address, orig_address, external_roles_);
 }
 
-void Session::authenticate(const Credentials & credentials_, const Poco::Net::SocketAddress & address_, const Strings & external_roles_)
+void Session::authenticate(const Credentials & credentials_, const Poco::Net::SocketAddress & address_, const Poco::Net::SocketAddress & orig_address, const Strings & external_roles_)
 {
     if (session_context)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "If there is a session context it must be created after authentication");
@@ -404,7 +404,10 @@ void Session::authenticate(const Credentials & credentials_, const Poco::Net::So
 
     prepared_client_info->current_user = credentials_.getUserName();
     prepared_client_info->authenticated_user = credentials_.getUserName();
-    prepared_client_info->current_address = std::make_shared<Poco::Net::SocketAddress>(address);
+    if (orig_address == Poco::Net::SocketAddress())
+        prepared_client_info->current_address = std::make_shared<Poco::Net::SocketAddress>(address);
+    else
+        prepared_client_info->current_address = std::make_shared<Poco::Net::SocketAddress>(orig_address);
 }
 
 void Session::checkIfUserIsStillValid()

--- a/src/Interpreters/Session.h
+++ b/src/Interpreters/Session.h
@@ -5,6 +5,7 @@
 #include <Interpreters/ClientInfo.h>
 #include <Interpreters/Context_fwd.h>
 #include <Interpreters/SessionTracker.h>
+#include <Poco/Net/SocketAddress.h>
 
 #include <chrono>
 #include <memory>
@@ -51,11 +52,11 @@ public:
 
     /// Sets the current user, checks the credentials and that the specified address is allowed to connect from.
     /// The function throws an exception if there is no such user or password is wrong.
-    void authenticate(const String & user_name, const String & password, const Poco::Net::SocketAddress & address, const Strings & external_roles_ = {});
+    void authenticate(const String & user_name, const String & password, const Poco::Net::SocketAddress & address, const Poco::Net::SocketAddress & orig_address = {}, const Strings & external_roles_ = {});
 
     /// `external_roles_` names of the additional roles (over what is granted via local access control mechanisms) that would be granted to user during this session.
     /// Role is not granted if it can't be found by name via AccessControl (i.e. doesn't exist on this instance).
-    void authenticate(const Credentials & credentials_, const Poco::Net::SocketAddress & address_, const Strings & external_roles_ = {});
+    void authenticate(const Credentials & credentials_, const Poco::Net::SocketAddress & address_, const Poco::Net::SocketAddress & orig_address = {}, const Strings & external_roles_ = {});
 
     // Verifies whether the user's validity extends beyond the current time.
     // Throws an exception if the user's validity has expired.

--- a/src/Interpreters/Session.h
+++ b/src/Interpreters/Session.h
@@ -52,11 +52,11 @@ public:
 
     /// Sets the current user, checks the credentials and that the specified address is allowed to connect from.
     /// The function throws an exception if there is no such user or password is wrong.
-    void authenticate(const String & user_name, const String & password, const Poco::Net::SocketAddress & address, const Poco::Net::SocketAddress & orig_address = {}, const Strings & external_roles_ = {});
+    void authenticate(const String & user_name, const String & password, const Poco::Net::SocketAddress & address, const std::optional<Poco::Net::SocketAddress> & connection_address = {}, const Strings & external_roles_ = {});
 
     /// `external_roles_` names of the additional roles (over what is granted via local access control mechanisms) that would be granted to user during this session.
     /// Role is not granted if it can't be found by name via AccessControl (i.e. doesn't exist on this instance).
-    void authenticate(const Credentials & credentials_, const Poco::Net::SocketAddress & address_, const Poco::Net::SocketAddress & orig_address = {}, const Strings & external_roles_ = {});
+    void authenticate(const Credentials & credentials_, const Poco::Net::SocketAddress & address_, const std::optional<Poco::Net::SocketAddress> & connection_address = {}, const Strings & external_roles_ = {});
 
     // Verifies whether the user's validity extends beyond the current time.
     // Throws an exception if the user's validity has expired.

--- a/src/Server/HTTP/authenticateUserByHTTP.cpp
+++ b/src/Server/HTTP/authenticateUserByHTTP.cpp
@@ -250,7 +250,7 @@ bool authenticateUserByHTTP(
     try
     {
         if (forwarded_address && global_context->getConfigRef().getBool("auth_use_forwarded_address", false))
-            session.authenticate(*current_credentials, *forwarded_address);
+            session.authenticate(*current_credentials, *forwarded_address, request.clientAddress());
         else
             session.authenticate(*current_credentials, request.clientAddress());
     }

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -1883,7 +1883,7 @@ void TCPHandler::receiveHello()
             {
                 session->authenticate(
                     SSLCertificateCredentials{user, X509Certificate(secure_socket.peerCertificate()).extractAllSubjects()},
-                    getClientAddress(client_info));
+                    getClientAddress(client_info), socket().peerAddress());
                 return;
             }
             catch (const Exception & e)
@@ -1951,12 +1951,12 @@ void TCPHandler::receiveHello()
         };
 
         auto cred = SshCredentials(user, signature, prepare_string_for_ssh_validation(user, challenge));
-        session->authenticate(cred, getClientAddress(client_info));
+        session->authenticate(cred, getClientAddress(client_info), socket().peerAddress());
         return;
     }
 #endif
 
-    session->authenticate(user, password, getClientAddress(client_info));
+    session->authenticate(user, password, getClientAddress(client_info), socket().peerAddress());
 }
 
 
@@ -2278,7 +2278,7 @@ void TCPHandler::processQuery(std::shared_ptr<QueryState> & state)
             /// the query was come, since the real address is the address of
             /// the initiator server, while we are interested in client's
             /// address.
-            session->authenticate(AlwaysAllowCredentials{client_info.initial_user}, *client_info.initial_address, external_roles);
+            session->authenticate(AlwaysAllowCredentials{client_info.initial_user}, *client_info.initial_address, *client_info.current_address, external_roles);
         }
 
         is_interserver_authenticated = true;

--- a/tests/integration/helpers/proxy1.py
+++ b/tests/integration/helpers/proxy1.py
@@ -9,11 +9,13 @@ class Proxy1:
         self._proxy_string = proxy_string
 
     def _run(self):
+        self._source_addr_lock = threading.Lock()
         self._server, addr = self._sock.accept()
         self._sock.close()
         self._client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self._client.bind(("", 0))
         self._client.connect(self._address)
+        self._source_addr = self._client.getsockname()
         self._client.send("PROXY ".encode("utf-8"))
         if self._proxy_string == "":
             self._client.send(
@@ -58,6 +60,10 @@ class Proxy1:
 
         self._client.close()
         self._server.close()
+
+    def get_source_addr(self):
+        with self._source_addr_lock:
+            return self._source_addr
 
     def start(self, address):
         self._address = address

--- a/tests/integration/test_composable_protocols/test.py
+++ b/tests/integration/test_composable_protocols/test.py
@@ -165,9 +165,9 @@ def test_proxy_1():
     source_addr = proxy.get_source_addr()
     assert (
         client.query(
-            f"SELECT forwarded_for, address, port, initial_address, initial_port FROM system.query_log WHERE query_id = '{query_id}' AND type = 'QueryStart'"
+            f"SELECT forwarded_for, address, port, initial_address, initial_port, connection_address, connection_port FROM system.query_log WHERE query_id = '{query_id}' AND type = 'QueryStart'"
         )
-        == f"123.231.132.213:12345\t::ffff:{source_addr[0]}\t{source_addr[1]}\t::ffff:{source_addr[0]}\t{source_addr[1]}\n"
+        == f"123.231.132.213:12345\t::ffff:123.231.132.213\t12345\t::ffff:123.231.132.213\t12345\t::ffff:{source_addr[0]}\t{source_addr[1]}\n"
     )
 
     # user123 only allowed from 123.123.123.123
@@ -183,9 +183,9 @@ def test_proxy_1():
     source_addr = proxy.get_source_addr()
     assert (
         client.query(
-            f"SELECT forwarded_for, address, port, initial_address, initial_port FROM system.query_log WHERE query_id = '{query_id}' AND type = 'QueryStart'"
+            f"SELECT forwarded_for, address, port, initial_address, initial_port, connection_address, connection_port FROM system.query_log WHERE query_id = '{query_id}' AND type = 'QueryStart'"
         )
-        == f"123.123.123.123:12345\t::ffff:{source_addr[0]}\t{source_addr[1]}\t::ffff:{source_addr[0]}\t{source_addr[1]}\n"
+        == f"123.123.123.123:12345\t::ffff:123.123.123.123\t12345\t::ffff:123.123.123.123\t12345\t::ffff:{source_addr[0]}\t{source_addr[1]}\n"
     )
 
     # user123 is not allowed from other than 123.123.123.123

--- a/tests/integration/test_composable_protocols/test.py
+++ b/tests/integration/test_composable_protocols/test.py
@@ -162,11 +162,12 @@ def test_proxy_1():
     query_id = proxy_client.query("SELECT currentQueryID()")[:-1]
     cluster.instances["server"].query("SYSTEM FLUSH LOGS")
     client = Client(server.ip_address, 9000, command=cluster.client_bin_path)
+    source_addr = proxy.get_source_addr()
     assert (
         client.query(
             f"SELECT forwarded_for, address, port, initial_address, initial_port FROM system.query_log WHERE query_id = '{query_id}' AND type = 'QueryStart'"
         )
-        == "123.231.132.213:12345\t::ffff:123.231.132.213\t12345\t::ffff:123.231.132.213\t12345\n"
+        == f"123.231.132.213:12345\t::ffff:{source_addr[0]}\t{source_addr[1]}\t::ffff:{source_addr[0]}\t{source_addr[1]}\n"
     )
 
     # user123 only allowed from 123.123.123.123
@@ -179,11 +180,12 @@ def test_proxy_1():
     query_id = proxy_client.query("SELECT currentQueryID()", user="user123")[:-1]
     cluster.instances["server"].query("SYSTEM FLUSH LOGS")
     client = Client(server.ip_address, 9000, command=cluster.client_bin_path)
+    source_addr = proxy.get_source_addr()
     assert (
         client.query(
             f"SELECT forwarded_for, address, port, initial_address, initial_port FROM system.query_log WHERE query_id = '{query_id}' AND type = 'QueryStart'"
         )
-        == "123.123.123.123:12345\t::ffff:123.123.123.123\t12345\t::ffff:123.123.123.123\t12345\n"
+        == f"123.123.123.123:12345\t::ffff:{source_addr[0]}\t{source_addr[1]}\t::ffff:{source_addr[0]}\t{source_addr[1]}\n"
     )
 
     # user123 is not allowed from other than 123.123.123.123


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add `connection_address` and `connection_port` to query_log to reflect physical connection (`address` and `port` are replaced when connected through proxy and auth_use_forwarded_address=1)


closes #95443


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.274`
<!-- ch-version-info:end -->