### PR TITLE
Add missing SELECT grant check in `mergeTreeProjection` table function

### DIFF
--- a/src/Storages/MergeTree/StorageFromMergeTreeProjection.cpp
+++ b/src/Storages/MergeTree/StorageFromMergeTreeProjection.cpp
@@ -1,5 +1,7 @@
 #include <Storages/MergeTree/StorageFromMergeTreeProjection.h>
 
+#include <Access/Common/AccessFlags.h>
+#include <Interpreters/Context.h>
 #include <Processors/QueryPlan/QueryPlan.h>
 #include <Processors/QueryPlan/ReadNothingStep.h>
 #include <Processors/Sources/NullSource.h>
@@ -30,6 +32,8 @@ void StorageFromMergeTreeProjection::read(
     size_t max_block_size,
     size_t num_streams)
 {
+    context->checkAccess(AccessType::SELECT, parent_storage->getStorageID());
+
     const auto & snapshot_data = assert_cast<const MergeTreeData::SnapshotData &>(*storage_snapshot->data);
     const auto & parts = snapshot_data.parts;
 

--- a/tests/queries/0_stateless/03812_mergetree_introspection_grants.reference
+++ b/tests/queries/0_stateless/03812_mergetree_introspection_grants.reference
@@ -1,0 +1,14 @@
+=== mergeTreeAnalyzeIndexes without grant ===
+ACCESS_DENIED
+=== mergeTreeIndex without grant ===
+ACCESS_DENIED
+=== mergeTreeAnalyzeIndexes with grant ===
+1
+=== mergeTreeIndex with grant ===
+1
+=== mergeTreeAnalyzeIndexesUUID without grant ===
+ACCESS_DENIED
+=== mergeTreeAnalyzeIndexesUUID with grant ===
+1
+=== mergeTreeAnalyzeIndexes with column-only grant ===
+ACCESS_DENIED

--- a/tests/queries/0_stateless/03812_mergetree_introspection_grants.sh
+++ b/tests/queries/0_stateless/03812_mergetree_introspection_grants.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest, no-parallel
+
+# Test that MergeTree introspection functions check table grants correctly.
+# These functions should require SELECT permission on the source table.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS test_grants_mt"
+$CLICKHOUSE_CLIENT -q "DROP USER IF EXISTS test_user_03812"
+
+$CLICKHOUSE_CLIENT -q "
+CREATE TABLE test_grants_mt (key Int, value Int, INDEX idx_value value TYPE minmax GRANULARITY 1)
+ENGINE = MergeTree() ORDER BY key
+"
+
+$CLICKHOUSE_CLIENT -q "INSERT INTO test_grants_mt SELECT number, number * 10 FROM numbers(1000)"
+
+# Create user without any grants
+$CLICKHOUSE_CLIENT -q "CREATE USER test_user_03812"
+
+# Test mergeTreeAnalyzeIndexes - should fail without SELECT grant
+echo "=== mergeTreeAnalyzeIndexes without grant ==="
+$CLICKHOUSE_CLIENT --user test_user_03812 -q "
+SELECT count() FROM mergeTreeAnalyzeIndexes(currentDatabase(), test_grants_mt)
+" 2>&1 | grep -o 'ACCESS_DENIED' | head -1
+
+# Test mergeTreeIndex - should fail without SELECT grant
+echo "=== mergeTreeIndex without grant ==="
+$CLICKHOUSE_CLIENT --user test_user_03812 -q "
+SELECT count() FROM mergeTreeIndex(currentDatabase(), test_grants_mt)
+" 2>&1 | grep -o 'ACCESS_DENIED' | head -1
+
+# Grant SELECT permission
+$CLICKHOUSE_CLIENT -q "GRANT SELECT ON ${CLICKHOUSE_DATABASE}.test_grants_mt TO test_user_03812"
+
+# Test mergeTreeAnalyzeIndexes - should work with SELECT grant
+echo "=== mergeTreeAnalyzeIndexes with grant ==="
+$CLICKHOUSE_CLIENT --user test_user_03812 -q "
+SELECT count() > 0 FROM mergeTreeAnalyzeIndexes(currentDatabase(), test_grants_mt)
+"
+
+# Test mergeTreeIndex - should work with SELECT grant
+echo "=== mergeTreeIndex with grant ==="
+$CLICKHOUSE_CLIENT --user test_user_03812 -q "
+SELECT count() > 0 FROM mergeTreeIndex(currentDatabase(), test_grants_mt)
+"
+
+# Test mergeTreeAnalyzeIndexesUUID
+TABLE_UUID=$($CLICKHOUSE_CLIENT -q "SELECT uuid FROM system.tables WHERE database = currentDatabase() AND name = 'test_grants_mt'")
+
+# Revoke grants for UUID test
+$CLICKHOUSE_CLIENT -q "REVOKE SELECT ON ${CLICKHOUSE_DATABASE}.test_grants_mt FROM test_user_03812"
+
+# Test mergeTreeAnalyzeIndexesUUID - should fail without SELECT grant
+echo "=== mergeTreeAnalyzeIndexesUUID without grant ==="
+$CLICKHOUSE_CLIENT --user test_user_03812 -q "
+SELECT count() FROM mergeTreeAnalyzeIndexesUUID('$TABLE_UUID')
+" 2>&1 | grep -o 'ACCESS_DENIED' | head -1
+
+# Grant SELECT permission again
+$CLICKHOUSE_CLIENT -q "GRANT SELECT ON ${CLICKHOUSE_DATABASE}.test_grants_mt TO test_user_03812"
+
+# Test mergeTreeAnalyzeIndexesUUID - should work with SELECT grant
+echo "=== mergeTreeAnalyzeIndexesUUID with grant ==="
+$CLICKHOUSE_CLIENT --user test_user_03812 -q "
+SELECT count() > 0 FROM mergeTreeAnalyzeIndexesUUID('$TABLE_UUID')
+"
+
+# Test mergeTreeAnalyzeIndexes with column-level grant only
+$CLICKHOUSE_CLIENT -q "DROP USER IF EXISTS test_user_03812_col"
+$CLICKHOUSE_CLIENT -q "CREATE USER test_user_03812_col"
+$CLICKHOUSE_CLIENT -q "GRANT SELECT(key) ON ${CLICKHOUSE_DATABASE}.test_grants_mt TO test_user_03812_col"
+
+# mergeTreeAnalyzeIndexes checks table-level SELECT, should fail with column-only grant
+echo "=== mergeTreeAnalyzeIndexes with column-only grant ==="
+$CLICKHOUSE_CLIENT --user test_user_03812_col -q "
+SELECT count() FROM mergeTreeAnalyzeIndexes(currentDatabase(), test_grants_mt)
+" 2>&1 | grep -o 'ACCESS_DENIED' | head -1
+
+# Cleanup
+$CLICKHOUSE_CLIENT -q "DROP TABLE test_grants_mt"
+$CLICKHOUSE_CLIENT -q "DROP USER test_user_03812"
+$CLICKHOUSE_CLIENT -q "DROP USER test_user_03812_col"

--- a/tests/queries/0_stateless/03813_mergetree_projection_grants.reference
+++ b/tests/queries/0_stateless/03813_mergetree_projection_grants.reference
@@ -1,0 +1,4 @@
+=== mergeTreeProjection without grant ===
+ACCESS_DENIED
+=== mergeTreeProjection with grant ===
+1

--- a/tests/queries/0_stateless/03813_mergetree_projection_grants.sh
+++ b/tests/queries/0_stateless/03813_mergetree_projection_grants.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest, no-parallel
+
+# Test that mergeTreeProjection checks table grants correctly.
+# This function should require SELECT permission on the source table.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS test_proj_grants_mt"
+$CLICKHOUSE_CLIENT -q "DROP USER IF EXISTS test_user_03813"
+
+$CLICKHOUSE_CLIENT -q "
+CREATE TABLE test_proj_grants_mt (key Int, value Int, PROJECTION proj_sum (SELECT key, sum(value) GROUP BY key))
+ENGINE = MergeTree() ORDER BY key
+"
+
+$CLICKHOUSE_CLIENT -q "INSERT INTO test_proj_grants_mt SELECT number % 10, number FROM numbers(1000)"
+$CLICKHOUSE_CLIENT -q "OPTIMIZE TABLE test_proj_grants_mt FINAL"
+
+# Create user without any grants
+$CLICKHOUSE_CLIENT -q "CREATE USER test_user_03813"
+
+# Test mergeTreeProjection - should fail without SELECT grant
+echo "=== mergeTreeProjection without grant ==="
+$CLICKHOUSE_CLIENT --user test_user_03813 -q "
+SELECT count() FROM mergeTreeProjection(currentDatabase(), test_proj_grants_mt, proj_sum)
+" 2>&1 | grep -o 'ACCESS_DENIED' | head -1
+
+# Grant SELECT permission
+$CLICKHOUSE_CLIENT -q "GRANT SELECT ON ${CLICKHOUSE_DATABASE}.test_proj_grants_mt TO test_user_03813"
+
+# Test mergeTreeProjection - should work with SELECT grant
+echo "=== mergeTreeProjection with grant ==="
+$CLICKHOUSE_CLIENT --user test_user_03813 -q "
+SELECT count() > 0 FROM mergeTreeProjection(currentDatabase(), test_proj_grants_mt, proj_sum)
+"
+
+# Cleanup
+$CLICKHOUSE_CLIENT -q "DROP TABLE test_proj_grants_mt"
+$CLICKHOUSE_CLIENT -q "DROP USER test_user_03813"


### PR DESCRIPTION
The `mergeTreeProjection` table function was missing an access check, allowing users without SELECT permission on a table to read data from its projections. This fix adds the same access check that `mergeTreeIndex` and `mergeTreeAnalyzeIndexes` already have.

Also adds tests for grant checking on all MergeTree introspection functions: `mergeTreeAnalyzeIndexes`, `mergeTreeAnalyzeIndexesUUID`, `mergeTreeIndex`, and `mergeTreeProjection`.

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
The `mergeTreeProjection` table function was missing an access check, allowing users without SELECT permission on a table (but with permissions for table functions) to read data from its projections. This fix adds the same access check that `mergeTreeIndex` and `mergeTreeAnalyzeIndexes` already have.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.94`
- Backported to: `26.1.1.908`, `25.12.7.13`, `25.11.10.7`, `25.8.17.30`
<!-- ch-version-info:end -->