### PR TITLE
Fix truncating fails because parts are temporarily locked.

### DIFF
--- a/tests/queries/0_stateless/03812_truncate_optimize_in_transaction.sql
+++ b/tests/queries/0_stateless/03812_truncate_optimize_in_transaction.sql
@@ -1,0 +1,14 @@
+DROP TABLE IF EXISTS test_table;
+DROP TABLE IF EXISTS t2;
+
+CREATE TABLE test_table (key UInt64, value String) ENGINE = MergeTree ORDER BY key SETTINGS merge_tree_clear_old_parts_interval_seconds=30;
+CREATE TABLE t2 (key UInt64, value String) ENGINE = Memory;
+
+INSERT INTO TABLE test_table VALUES (1, 'a'), (2, 'b'), (1, 'a');
+
+SET throw_on_unsupported_query_inside_transaction=0;
+SET implicit_transaction=1;
+OPTIMIZE TABLE test_table FINAL DEDUPLICATE BY key, value PARALLEL WITH  OPTIMIZE TABLE t2 SETTINGS max_threads=10; -- { serverError INVALID_TRANSACTION, NOT_IMPLEMENTED }
+
+SET implicit_transaction=0;
+TRUNCATE TABLE test_table;

--- a/tests/queries/0_stateless/03812_truncate_optimize_in_transaction.sql
+++ b/tests/queries/0_stateless/03812_truncate_optimize_in_transaction.sql
@@ -1,3 +1,6 @@
+-- Tags: no-encrypted-storage
+-- Tag: no-encrypted-storage: not support transactions
+
 DROP TABLE IF EXISTS test_table;
 DROP TABLE IF EXISTS t2;
 


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

When renaming and committing empty parts, retry if any part is temporarily locked

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.165`
<!-- ch-version-info:end -->