### PR TITLE
Respect `allow_experimental_nullable_tuple_type` in schema inference

### DIFF
--- a/src/Formats/FormatFactory.cpp
+++ b/src/Formats/FormatFactory.cpp
@@ -48,6 +48,7 @@ FORMAT_FACTORY_SETTINGS(DECLARE_FORMAT_EXTERN, INITIALIZE_SETTING_EXTERN)
     extern const SettingsUInt64 interactive_delay;
     extern const SettingsAggregateFunctionInputFormat aggregate_function_input_format;
     extern const SettingsBool allow_special_serialization_kinds_in_output_formats;
+    extern const SettingsBool allow_experimental_nullable_tuple_type;
 
     extern SettingsBool input_format_parallel_parsing;
     extern SettingsBool output_format_parallel_formatting;
@@ -336,6 +337,7 @@ FormatSettings getFormatSettings(const ContextPtr & context, const Settings & se
     format_settings.schema_inference_hints = settings[Setting::schema_inference_hints];
     format_settings.schema_inference_make_columns_nullable = settings[Setting::schema_inference_make_columns_nullable].valueOr(2);
     format_settings.schema_inference_make_json_columns_nullable = settings[Setting::schema_inference_make_json_columns_nullable];
+    format_settings.schema_inference_allow_nullable_tuple_type = settings[Setting::allow_experimental_nullable_tuple_type];
     format_settings.mysql_dump.table_name = settings[Setting::input_format_mysql_dump_table_name];
     format_settings.mysql_dump.map_column_names = settings[Setting::input_format_mysql_dump_map_column_names];
     format_settings.sql_insert.max_batch_size = settings[Setting::output_format_sql_insert_max_batch_size];

--- a/src/Formats/FormatSettings.h
+++ b/src/Formats/FormatSettings.h
@@ -91,6 +91,7 @@ struct FormatSettings
 
     UInt64 schema_inference_make_columns_nullable = 1;
     bool schema_inference_make_json_columns_nullable = false;
+    bool schema_inference_allow_nullable_tuple_type = false;
 
     DateTimeOutputFormat date_time_output_format = DateTimeOutputFormat::Simple;
 

--- a/src/Formats/SchemaInferenceUtils.cpp
+++ b/src/Formats/SchemaInferenceUtils.cpp
@@ -1667,10 +1667,13 @@ static DataTypePtr adjustNullableRecursively(DataTypePtr type, bool make_nullabl
             nested_types.push_back(nested_type);
         }
 
+        DataTypePtr tuple_res;
         if (tuple_type->hasExplicitNames())
-            return std::make_shared<DataTypeTuple>(std::move(nested_types), tuple_type->getElementNames());
+            tuple_res = std::make_shared<DataTypeTuple>(std::move(nested_types), tuple_type->getElementNames());
+        else
+            tuple_res = std::make_shared<DataTypeTuple>(std::move(nested_types));
 
-        return std::make_shared<DataTypeTuple>(std::move(nested_types));
+        return (make_nullable && settings.schema_inference_allow_nullable_tuple_type) ? makeNullableSafe(tuple_res) : tuple_res;
     }
 
     if (which.isMap())

--- a/src/Formats/SchemaInferenceUtils.h
+++ b/src/Formats/SchemaInferenceUtils.h
@@ -104,6 +104,8 @@ void transformInferredJSONTypesFromDifferentFilesIfNeeded(DataTypePtr & first, D
 ///  - Type -> Nullable(type)
 ///  - Array(Type) -> Array(Nullable(Type))
 ///  - Tuple(Type1, ..., TypeN) -> Tuple(Nullable(Type1), ..., Nullable(TypeN))
+///    If settings.schema_inference_allow_nullable_tuple_type is enabled, also wraps the whole tuple:
+///      Tuple(...) -> Nullable(Tuple(...))
 ///  - Map(KeyType, ValueType) -> Map(KeyType, Nullable(ValueType))
 ///  - LowCardinality(Type) -> LowCardinality(Nullable(Type))
 /// Does not recurse into types with custom name.

--- a/tests/queries/0_stateless/03814_tuple_inside_nullable_schema_inference.reference
+++ b/tests/queries/0_stateless/03814_tuple_inside_nullable_schema_inference.reference
@@ -1,0 +1,16 @@
+-- { echo }
+
+SET allow_experimental_nullable_tuple_type=0;
+SELECT * FROM format(JSON, '{"x":{"y":1,"z":2}}, {}');
+(1,2)
+(NULL,NULL)
+SELECT * FROM format(JSONEachRow, '{"x":{"y":1,"z":2}}, {}');
+(1,2)
+(NULL,NULL)
+SET allow_experimental_nullable_tuple_type=1;
+SELECT * FROM format(JSON, '{"x":{"y":1,"z":2}}, {}');
+(1,2)
+\N
+SELECT * FROM format(JSONEachRow, '{"x":{"y":1,"z":2}}, {}');
+(1,2)
+\N

--- a/tests/queries/0_stateless/03814_tuple_inside_nullable_schema_inference.sql
+++ b/tests/queries/0_stateless/03814_tuple_inside_nullable_schema_inference.sql
@@ -1,0 +1,13 @@
+-- { echo }
+
+SET allow_experimental_nullable_tuple_type=0;
+
+SELECT * FROM format(JSON, '{"x":{"y":1,"z":2}}, {}');
+
+SELECT * FROM format(JSONEachRow, '{"x":{"y":1,"z":2}}, {}');
+
+SET allow_experimental_nullable_tuple_type=1;
+
+SELECT * FROM format(JSON, '{"x":{"y":1,"z":2}}, {}');
+
+SELECT * FROM format(JSONEachRow, '{"x":{"y":1,"z":2}}, {}');


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Schema inference now respects `allow_experimental_nullable_tuple_type`. When enabled, it allows inferred tuple types to be `Nullable(Tuple(...))`, so missing nested objects can become `NULL` instead of a tuple of `NULL` elements.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.212`
- Backported to: `26.1.3.50`
<!-- ch-version-info:end -->