### PR TITLE
Docs: add missing `APPLY PATCHES` syntax docs

### DIFF
--- a/docs/en/sql-reference/statements/alter/apply-patches.md
+++ b/docs/en/sql-reference/statements/alter/apply-patches.md
@@ -11,20 +11,22 @@ import BetaBadge from '@theme/badges/BetaBadge';
 
 <BetaBadge/>
 
-# Apply patches from lightweight updates
-
 ```sql
 ALTER TABLE [db.]table [ON CLUSTER cluster] APPLY PATCHES [IN PARTITION partition_id]
 ```
 
-The command manually triggers the materialization of patch parts created by [lightweight `UPDATE`](/sql-reference/statements/update) statements. It forcefully applies pending patches to the data parts by rewriting only the affected columns, similar to a mutation but more efficient.
+The command manually triggers the physical materialization of patch parts created by [lightweight `UPDATE`](/sql-reference/statements/update) statements. It forcefully applies pending patches to the data parts by rewriting only the affected columns.
 
 :::note
 - It only works for tables in the [`MergeTree`](../../../engines/table-engines/mergetree-family/mergetree.md) family (including [replicated](../../../engines/table-engines/mergetree-family/replication.md) tables).
 - This is a mutation operation and executes asynchronously in the background.
 :::
 
-## When to use APPLY PATCHES
+## When to use APPLY PATCHES {#when-to-use}
+
+:::tip
+Generally, you should not need to use `APPLY PATCHES`
+:::
 
 Patch parts are normally applied automatically during merges when the [`apply_patches_on_merge`](/operations/settings/merge-tree-settings#apply_patches_on_merge) setting is enabled (default). However, you may want to manually trigger patch application in these scenarios:
 
@@ -33,15 +35,7 @@ Patch parts are normally applied automatically during merges when the [`apply_pa
 - To prepare data for backup or export with patches already materialized
 - When `apply_patches_on_merge` is disabled and you want to control when patches are applied
 
-## Performance characteristics
-
-Unlike heavyweight `ALTER TABLE ... UPDATE` mutations that rewrite entire data parts, `APPLY PATCHES`:
-- Only rewrites the columns that were updated
-- Is more efficient when only a small subset of columns have been modified
-- Can be executed in parallel with other operations
-- Does not block lightweight `UPDATE` statements
-
-## Examples
+## Examples {#examples}
 
 Apply all pending patches for a table:
 ```sql
@@ -58,7 +52,7 @@ Combine with other operations:
 ALTER TABLE my_table APPLY PATCHES, UPDATE column = value WHERE condition;
 ```
 
-## Monitoring patch application
+## Monitoring patch application {#monitor}
 
 You can monitor the progress of patch application using the [`system.mutations`](/operations/system-tables/mutations) table:
 
@@ -67,8 +61,7 @@ SELECT * FROM system.mutations
 WHERE table = 'my_table' AND command LIKE '%APPLY PATCHES%';
 ```
 
-## See also
+## See also {see-also}
 
 - [Lightweight `UPDATE`](/sql-reference/statements/update) - Create patch parts with lightweight updates
-- [Heavyweight `UPDATE`](/sql-reference/statements/alter/update) - Traditional UPDATE mutations
 - [`apply_patches_on_merge` setting](/operations/settings/merge-tree-settings#apply_patches_on_merge) - Control automatic patch application during merges

--- a/docs/en/sql-reference/statements/alter/apply-patches.md
+++ b/docs/en/sql-reference/statements/alter/apply-patches.md
@@ -61,7 +61,7 @@ SELECT * FROM system.mutations
 WHERE table = 'my_table' AND command LIKE '%APPLY PATCHES%';
 ```
 
-## See also {see-also}
+## See also {#see-also}
 
 - [Lightweight `UPDATE`](/sql-reference/statements/update) - Create patch parts with lightweight updates
 - [`apply_patches_on_merge` setting](/operations/settings/merge-tree-settings#apply_patches_on_merge) - Control automatic patch application during merges

--- a/docs/en/sql-reference/statements/alter/apply-patches.md
+++ b/docs/en/sql-reference/statements/alter/apply-patches.md
@@ -1,0 +1,74 @@
+---
+description: 'Documentation for Apply patches from lightweight updates'
+sidebar_label: 'APPLY PATCHES'
+sidebar_position: 47
+slug: /sql-reference/statements/alter/apply-patches
+title: 'Apply patches from lightweight updates'
+doc_type: 'reference'
+---
+
+import BetaBadge from '@theme/badges/BetaBadge';
+
+<BetaBadge/>
+
+# Apply patches from lightweight updates
+
+```sql
+ALTER TABLE [db.]table [ON CLUSTER cluster] APPLY PATCHES [IN PARTITION partition_id]
+```
+
+The command manually triggers the materialization of patch parts created by [lightweight `UPDATE`](/sql-reference/statements/update) statements. It forcefully applies pending patches to the data parts by rewriting only the affected columns, similar to a mutation but more efficient.
+
+:::note
+- It only works for tables in the [`MergeTree`](../../../engines/table-engines/mergetree-family/mergetree.md) family (including [replicated](../../../engines/table-engines/mergetree-family/replication.md) tables).
+- This is a mutation operation and executes asynchronously in the background.
+:::
+
+## When to use APPLY PATCHES
+
+Patch parts are normally applied automatically during merges when the [`apply_patches_on_merge`](/operations/settings/merge-tree-settings#apply_patches_on_merge) setting is enabled (default). However, you may want to manually trigger patch application in these scenarios:
+
+- To reduce the overhead of applying patches during `SELECT` queries
+- To consolidate multiple patch parts before they accumulate
+- To prepare data for backup or export with patches already materialized
+- When `apply_patches_on_merge` is disabled and you want to control when patches are applied
+
+## Performance characteristics
+
+Unlike heavyweight `ALTER TABLE ... UPDATE` mutations that rewrite entire data parts, `APPLY PATCHES`:
+- Only rewrites the columns that were updated
+- Is more efficient when only a small subset of columns have been modified
+- Can be executed in parallel with other operations
+- Does not block lightweight `UPDATE` statements
+
+## Examples
+
+Apply all pending patches for a table:
+```sql
+ALTER TABLE my_table APPLY PATCHES;
+```
+
+Apply patches only for a specific partition:
+```sql
+ALTER TABLE my_table APPLY PATCHES IN PARTITION '2024-01';
+```
+
+Combine with other operations:
+```sql
+ALTER TABLE my_table APPLY PATCHES, UPDATE column = value WHERE condition;
+```
+
+## Monitoring patch application
+
+You can monitor the progress of patch application using the [`system.mutations`](/operations/system-tables/mutations) table:
+
+```sql
+SELECT * FROM system.mutations
+WHERE table = 'my_table' AND command LIKE '%APPLY PATCHES%';
+```
+
+## See also
+
+- [Lightweight `UPDATE`](/sql-reference/statements/update) - Create patch parts with lightweight updates
+- [Heavyweight `UPDATE`](/sql-reference/statements/alter/update) - Traditional UPDATE mutations
+- [`apply_patches_on_merge` setting](/operations/settings/merge-tree-settings#apply_patches_on_merge) - Control automatic patch application during merges

--- a/docs/en/sql-reference/statements/alter/index.md
+++ b/docs/en/sql-reference/statements/alter/index.md
@@ -23,6 +23,7 @@ Most `ALTER TABLE` queries modify table settings or data:
 | [TTL](/sql-reference/statements/alter/ttl.md)                               |
 | [STATISTICS](/sql-reference/statements/alter/statistics.md)                 |
 | [APPLY DELETED MASK](/sql-reference/statements/alter/apply-deleted-mask.md) |
+| [APPLY PATCHES](/sql-reference/statements/alter/apply-patches.md)           |
 
 :::note
 Most `ALTER TABLE` queries are supported only for [\*MergeTree](/engines/table-engines/mergetree-family/index.md), [Merge](/engines/table-engines/special/merge.md) and [Distributed](/engines/table-engines/special/distributed.md) tables.
@@ -66,7 +67,7 @@ Entries for finished mutations are not deleted right away (the number of preserv
 
 For non-replicated tables, all `ALTER` queries are performed synchronously. For replicated tables, the query just adds instructions for the appropriate actions to `ZooKeeper`, and the actions themselves are performed as soon as possible. However, the query can wait for these actions to be completed on all the replicas.
 
-For `ALTER` queries that creates mutations (e.g.: including, but not limited to `UPDATE`, `DELETE`, `MATERIALIZE INDEX`, `MATERIALIZE PROJECTION`, `MATERIALIZE COLUMN`, `APPLY DELETED MASK`, `CLEAR STATISTIC`, `MATERIALIZE STATISTIC`) the synchronicity is defined by the [mutations_sync](/operations/settings/settings.md/#mutations_sync) setting.
+For `ALTER` queries that creates mutations (e.g.: including, but not limited to `UPDATE`, `DELETE`, `MATERIALIZE INDEX`, `MATERIALIZE PROJECTION`, `MATERIALIZE COLUMN`, `APPLY DELETED MASK`, `APPLY PATCHES`, `CLEAR STATISTIC`, `MATERIALIZE STATISTIC`) the synchronicity is defined by the [mutations_sync](/operations/settings/settings.md/#mutations_sync) setting.
 
 For other `ALTER` queries which only modify the metadata, you can use the [alter_sync](/operations/settings/settings#alter_sync) setting to set up waiting.
 

--- a/docs/en/sql-reference/statements/alter/update.md
+++ b/docs/en/sql-reference/statements/alter/update.md
@@ -30,6 +30,8 @@ The synchronicity of the query processing is defined by the [mutations_sync](/op
 - [Mutations](/sql-reference/statements/alter/index.md#mutations)
 - [Synchronicity of ALTER Queries](/sql-reference/statements/alter/index.md#synchronicity-of-alter-queries)
 - [mutations_sync](/operations/settings/settings.md/#mutations_sync) setting
+- [Lightweight `UPDATE`](/sql-reference/statements/update) - Alternative lightweight update using patch parts
+- [`APPLY PATCHES`](/sql-reference/statements/alter/apply-patches) - Manually apply patches from lightweight updates
 
 ## Related content {#related-content}
 

--- a/docs/en/sql-reference/statements/update.md
+++ b/docs/en/sql-reference/statements/update.md
@@ -47,20 +47,6 @@ The updated values are:
 - **Physically materialized** only during subsequent merges and mutations
 - **Automatically cleaned up** once all active parts have the patches materialized
 
-### Manually applying patches {#manually-applying-patches}
-
-While patch parts are automatically applied during merges, you can manually trigger their materialization using the [`ALTER TABLE ... APPLY PATCHES`](/sql-reference/statements/alter/apply-patches) command:
-
-```sql
-ALTER TABLE [db.]table APPLY PATCHES;
-```
-
-This is useful when you want to:
-- Reduce the overhead of applying patches during `SELECT` queries
-- Consolidate multiple patch parts before they accumulate
-- Control when patches are materialized instead of waiting for automatic merges
-
-The command only rewrites the columns that were updated, making it more efficient than heavyweight mutations that rewrite entire data parts.
 ## Lightweight updates requirements {#lightweight-update-requirements}
 
 Lightweight updates are supported for [`MergeTree`](/engines/table-engines/mergetree-family/mergetree), [`ReplacingMergeTree`](/engines/table-engines/mergetree-family/replacingmergetree), [`CollapsingMergeTree`](/engines/table-engines/mergetree-family/collapsingmergetree) engines and their [`Replicated`](/engines/table-engines/mergetree-family/replication.md) and [`Shared`](/cloud/reference/shared-merge-tree) versions.
@@ -137,3 +123,4 @@ The join mode is slower and requires more memory than the merge mode, but it is 
 
 - [`ALTER UPDATE`](/sql-reference/statements/alter/update) - Heavy `UPDATE` operations
 - [Lightweight `DELETE`](/sql-reference/statements/delete) - Lightweight `DELETE` operations
+- [`APPLY PATCHES`](/sql-reference/statements/alter/apply-patches) - Force physical materialization of patches to data parts (mutation operation)

--- a/docs/en/sql-reference/statements/update.md
+++ b/docs/en/sql-reference/statements/update.md
@@ -46,6 +46,21 @@ The updated values are:
 - **Immediately visible** in `SELECT` queries through patches application
 - **Physically materialized** only during subsequent merges and mutations
 - **Automatically cleaned up** once all active parts have the patches materialized
+
+### Manually applying patches {#manually-applying-patches}
+
+While patch parts are automatically applied during merges, you can manually trigger their materialization using the [`ALTER TABLE ... APPLY PATCHES`](/sql-reference/statements/alter/apply-patches) command:
+
+```sql
+ALTER TABLE [db.]table APPLY PATCHES;
+```
+
+This is useful when you want to:
+- Reduce the overhead of applying patches during `SELECT` queries
+- Consolidate multiple patch parts before they accumulate
+- Control when patches are materialized instead of waiting for automatic merges
+
+The command only rewrites the columns that were updated, making it more efficient than heavyweight mutations that rewrite entire data parts.
 ## Lightweight updates requirements {#lightweight-update-requirements}
 
 Lightweight updates are supported for [`MergeTree`](/engines/table-engines/mergetree-family/mergetree), [`ReplacingMergeTree`](/engines/table-engines/mergetree-family/replacingmergetree), [`CollapsingMergeTree`](/engines/table-engines/mergetree-family/collapsingmergetree) engines and their [`Replicated`](/engines/table-engines/mergetree-family/replication.md) and [`Shared`](/cloud/reference/shared-merge-tree) versions.


### PR DESCRIPTION
Adds docs for missing `APPLY PATCHES` syntax.
Closes https://github.com/ClickHouse/clickhouse-docs/issues/5305

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.133`
<!-- ch-version-info:end -->