### PR TITLE
Mark task as done without parent ProcessList task

### DIFF
--- a/src/Interpreters/CancellationChecker.cpp
+++ b/src/Interpreters/CancellationChecker.cpp
@@ -92,7 +92,7 @@ void CancellationChecker::appendTask(const QueryStatusPtr & query, const Int64 t
 
 void CancellationChecker::appendDoneTasks(const QueryStatusPtr & query)
 {
-    std::unique_lock<std::mutex> lock(m);
+    std::unique_lock lock(m);
     removeQueryFromSet(query);
     cond_var.notify_all();
 }

--- a/src/Interpreters/ProcessList.cpp
+++ b/src/Interpreters/ProcessList.cpp
@@ -396,6 +396,7 @@ ProcessList::EntryPtr ProcessList::insert(
 
 ProcessListEntry::~ProcessListEntry()
 {
+    CancellationChecker::getInstance().appendDoneTasks(*it);
     LockAndOverCommitTrackerBlocker<std::unique_lock, ProcessList::Mutex> lock(parent.getMutex());
 
     const String user = (*it)->getClientInfo().current_user;
@@ -434,8 +435,6 @@ ProcessListEntry::~ProcessListEntry()
 
     if (auto query_user = parent.queries_to_user.find(query_id); query_user != parent.queries_to_user.end())
         parent.queries_to_user.erase(query_user);
-
-    CancellationChecker::getInstance().appendDoneTasks(*it);
 
     /// This removes the memory_tracker of one request.
     parent.processes.erase(it);


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Should reduce lock contention.
cc @yariks5s any reason not to do it like this?

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.134`
- Backported to: `26.1.3.3`, `25.12.6.2`, `25.11.9.13`, `25.8.17.3`
<!-- ch-version-info:end -->