### PR TITLE
Fix `std::length_error` when `max_query_size` is `UINT64_MAX`

### DIFF
--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -1368,7 +1368,7 @@ static BlockIO executeQueryImpl(
     {
         /// Anyway log the query.
         if (query.empty())
-            query.assign(begin, std::min(end - begin, static_cast<ptrdiff_t>(max_query_size)));
+            query.assign(begin, std::min(static_cast<size_t>(end - begin), max_query_size));
 
         query_for_logging = wipeSensitiveDataAndCutToLength(query, log_queries_cut_to_length, true);
         logQuery(query_for_logging, context, internal, stage);

--- a/tests/queries/0_stateless/03813_max_query_size_overflow.sql
+++ b/tests/queries/0_stateless/03813_max_query_size_overflow.sql
@@ -1,0 +1,18 @@
+-- Test that max_query_size = UINT64_MAX doesn't cause std::length_error
+-- when an exception is thrown during query processing.
+--
+-- Bug description: In executeQuery.cpp, when an exception is thrown
+-- and query.empty() is true, the code does:
+--   query.assign(begin, std::min(end - begin, static_cast<ptrdiff_t>(max_query_size)))
+-- When max_query_size is 18446744073709551615 (UINT64_MAX), casting it to ptrdiff_t
+-- results in -1. Then std::min(positive, -1) returns -1, and query.assign(begin, -1)
+-- converts -1 to SIZE_MAX, causing std::length_error.
+
+-- The setting must be applied BEFORE the query is parsed (via SET, not inline SETTINGS)
+-- to trigger the bug. This query uses an undefined query parameter, which triggers
+-- an exception after parsing but before the query string is assigned.
+-- Before the fix: std::length_error is thrown
+-- After the fix: UNKNOWN_QUERY_PARAMETER error is returned properly
+
+SET max_query_size = 18446744073709551615;
+SELECT {undefined_param:UInt64}; -- {serverError UNKNOWN_QUERY_PARAMETER}


### PR DESCRIPTION
When `max_query_size` is set to 18446744073709551615 (UINT64_MAX) and an exception is thrown during query processing before the query string is assigned, the exception handler would trigger `std::length_error`.

The bug was in `executeQuery.cpp` where the code did:
```
query.assign(begin, std::min(end - begin, static_cast<ptrdiff_t>(max_query_size)));
```

When `max_query_size` is UINT64_MAX, casting it to `ptrdiff_t` results in -1 (signed overflow). Then `std::min(positive_value, -1)` returns -1, and `query.assign(begin, -1)` converts -1 to SIZE_MAX, causing `std::length_error`.

The fix changes the cast to keep values as `size_t`:
```
query.assign(begin, std::min(static_cast<size_t>(end - begin), max_query_size));
```

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

See https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=95496&sha=aa649503487871f8fa335314b943aa1dba7670b4&name_0=PR&name_1=AST%20fuzzer%20%28amd_debug%29
https://github.com/ClickHouse/ClickHouse/pull/95496


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.143`
<!-- ch-version-info:end -->