### PR TITLE
Fix timeout hangs in `clickhouse-test` runner

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -514,7 +514,8 @@ def clickhouse_execute_http(
             if i == max_http_retries - 1:
                 raise ex
             client.close()
-            sleep(i + 1)
+            # Cap sleep time to prevent unbounded delays (max 3 seconds per retry)
+            sleep(min(i + 1, 3))
 
     if res.status != 200:
         raise HTTPError(data.decode(), res.status)
@@ -3850,8 +3851,8 @@ def do_run_tests(
 
             if server_died.is_set():
                 print("Server died, terminating all processes...")
-                # Wait for test results
-                sleep(args.timeout)
+                # Wait briefly for test results to be written
+                sleep(5)
                 for p in processes:
                     if p.is_alive():
                         p.terminate()


### PR DESCRIPTION
Prevents the test runner from hanging for hours when server dies or during HTTP retries.

1. Changed server death handling to sleep for 5 seconds instead of `args.timeout` (typically 600+ seconds) before terminating child processes. This prevents accumulating delays of 10+ minutes per server death event.

2. Capped HTTP retry backoff sleep to maximum 3 seconds instead of unbounded `i + 1` growth. With `max_http_retries=20`, this reduces worst-case retry delays from 190 seconds to 60 seconds.

These changes address test runner timeouts exceeding 9000 seconds when servers become unresponsive.

[problem example](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=93974&sha=ac13f9c1c757cec2bf61bd808d6968f6c0289120&name_0=PR&name_1=Stateless%20tests%20%28amd_debug%2C%20distributed%20plan%2C%20s3%20storage%2C%20parallel%29
https://github.com/ClickHouse/ClickHouse/pull/93974)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.128`
<!-- ch-version-info:end -->