### PR TITLE
Revert "Fix test_peak_memory_usage flakiness by making logging of peak memory more accurate"

### DIFF
--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -794,12 +794,12 @@ void TCPHandler::runImpl()
             {
                 /// FIXME: check explicitly that insert query suggests to receive data via native protocol,
                 query_state->need_receive_data_for_insert = true;
-                processInsertQuery(*query_state, *query_scope);
+                processInsertQuery(*query_state);
                 query_state->io.onFinish();
             }
             else if (query_state->io.pipeline.pulling())
             {
-                processOrdinaryQuery(*query_state, *query_scope);
+                processOrdinaryQuery(*query_state);
                 query_state->io.onFinish();
             }
             else if (query_state->io.pipeline.completed())
@@ -824,12 +824,7 @@ void TCPHandler::runImpl()
                 /// NOTE: we cannot send Progress for regular INSERT (with VALUES)
                 /// without breaking protocol compatibility, but it can be done
                 /// by increasing revision.
-
                 sendProgress(*query_state);
-
-                /// Log peak memory usage just before sending it to client to make it as accurate as possible
-                /// (though note we may still have some allocations in between, that will make the difference)
-                query_scope->logPeakMemoryUsage();
                 sendSelectProfileEvents(*query_state);
             }
             else
@@ -842,13 +837,13 @@ void TCPHandler::runImpl()
                     create_query && create_query->isCreateQueryWithImmediateInsertSelect())
                 {
                     sendProgress(*query_state);
-
-                    /// Log peak memory usage just before sending it to client to make it as accurate as possible
-                    /// (though note we may still have some allocations in between, that will make the difference)
-                    query_scope->logPeakMemoryUsage();
                     sendSelectProfileEvents(*query_state);
                 }
             }
+
+            /// Do it before sending end of stream, to have a chance to show log message in client.
+            query_scope->logPeakMemoryUsage();
+
             sendLogs(*query_state);
             sendEndOfStream(*query_state);
 
@@ -1270,7 +1265,7 @@ AsynchronousInsertQueue::PushResult TCPHandler::processAsyncInsertQuery(QuerySta
 }
 
 
-void TCPHandler::processInsertQuery(QueryState & state, CurrentThread::QueryScope & query_scope)
+void TCPHandler::processInsertQuery(QueryState & state)
 {
     size_t num_threads = state.io.pipeline.getNumThreads();
 
@@ -1359,14 +1354,11 @@ void TCPHandler::processInsertQuery(QueryState & state, CurrentThread::QueryScop
         run_executor(executor, std::move(processed_block));
     }
 
-    /// Log peak memory usage just before sending it to client to make it as accurate as possible
-    /// (though note we may still have some allocations in between, that will make the difference)
-    query_scope.logPeakMemoryUsage();
     sendInsertProfileEvents(state);
 }
 
 
-void TCPHandler::processOrdinaryQuery(QueryState & state, CurrentThread::QueryScope & query_scope)
+void TCPHandler::processOrdinaryQuery(QueryState & state)
 {
     auto & pipeline = state.io.pipeline;
 
@@ -1448,10 +1440,6 @@ void TCPHandler::processOrdinaryQuery(QueryState & state, CurrentThread::QuerySc
         sendProfileInfo(state, executor.getProfileInfo());
         sendProgress(state);
         sendLogs(state);
-
-        /// Log peak memory usage just before sending it to client to make it as accurate as possible
-        /// (though note we may still have some allocations in between, that will make the difference)
-        query_scope.logPeakMemoryUsage();
         sendSelectProfileEvents(state);
 
         sendData(state, {});

--- a/src/Server/TCPHandler.h
+++ b/src/Server/TCPHandler.h
@@ -301,11 +301,11 @@ private:
 
     /// Process INSERT query
     void startInsertQuery(QueryState & state);
-    void processInsertQuery(QueryState & state, CurrentThread::QueryScope & query_scope);
+    void processInsertQuery(QueryState & state);
     AsynchronousInsertQueue::PushResult processAsyncInsertQuery(QueryState & state, AsynchronousInsertQueue & insert_queue);
 
     /// Process a request that does not require the receiving of data blocks from the client
-    void processOrdinaryQuery(QueryState & state, CurrentThread::QueryScope & query_scope);
+    void processOrdinaryQuery(QueryState & state);
 
     void processTablesStatusRequest();
 


### PR DESCRIPTION
Reverts ClickHouse/ClickHouse#93910 since it didn't help. 


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.115`
<!-- ch-version-info:end -->