### PR TITLE
Fix path traversal vulnerability in ATTACH PART FROM (unreleased)

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -7594,6 +7594,7 @@ MergeTreeData::MutableDataPartsVector MergeTreeData::tryLoadPartsToAttach(const 
         const String part_name = command.partition->as<ASTLiteral &>().value.safeGet<String>();
         const String part_directory = command.from_path.empty() ? part_name : command.from_path;
         validateDetachedPartName(part_name);
+        validateDetachedPartName(part_directory);
 
         if (temporary_parts.contains(source_dir / part_directory))
         {


### PR DESCRIPTION
The `FROM` clause in `ALTER TABLE ... ATTACH PART ... FROM` was not validated for path traversal attempts. This allowed specifying paths like `../` to access files outside the `detached/` directory.

The fix adds validation of `part_directory` using `validateDetachedPartName` which rejects paths containing `/`, `.`, or `..`.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Alternative to https://github.com/ClickHouse/ClickHouse/pull/95566


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.118`
- Backported to: `26.1.2.2`
<!-- ch-version-info:end -->