### PR TITLE
Fix UBSan overflow in join order cardinality estimation

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/joinOrder.cpp
+++ b/src/Processors/QueryPlan/Optimizations/joinOrder.cpp
@@ -193,7 +193,10 @@ static std::optional<UInt64> estimateJoinCardinality(
     if (join_kind == JoinKind::Full)
         joined_rows = std::max(joined_rows, lhs + rhs);
 
-    if (joined_rows > static_cast<double>(std::numeric_limits<UInt64>::max()))
+    /// Use >= to avoid undefined behavior when joined_rows is very close to max UInt64
+    /// Due to floating point precision, a value slightly less than max when compared
+    /// as double could still overflow when cast to UInt64
+    if (joined_rows >= static_cast<double>(std::numeric_limits<UInt64>::max()))
         return std::numeric_limits<UInt64>::max();
     if (joined_rows < 1)
         return 1;

--- a/tests/queries/0_stateless/03812_join_order_ubsan_overflow.sql
+++ b/tests/queries/0_stateless/03812_join_order_ubsan_overflow.sql
@@ -7,17 +7,13 @@ DROP TABLE IF EXISTS data_03812;
 CREATE TABLE data_03812 (key UInt64, value UInt64) ENGINE = MergeTree ORDER BY key;
 INSERT INTO data_03812 VALUES (1, 1), (2, 2);
 
--- This query triggers the join order optimizer with extremely large estimated row counts
--- which can cause overflow when converting double to UInt64 in estimateJoinCardinality
--- Using EXPLAIN to trigger planning without actual execution
--- The GROUPING SETS clause helps trigger the code path that exercises the join optimizer
+
 EXPLAIN PLAN
-SELECT DISTINCT 1
+SELECT 1
 FROM data_03812 AS t1
 ALL INNER JOIN (
     SELECT number FROM system.numbers LIMIT 9223372036854775806
-) AS t2 ON t2.number = t2.number
-GROUP BY GROUPING SETS ((t1.value), (t1.key))
+) AS t2 ON 1
 FORMAT Null;
 
 DROP TABLE data_03812;

--- a/tests/queries/0_stateless/03812_join_order_ubsan_overflow.sql
+++ b/tests/queries/0_stateless/03812_join_order_ubsan_overflow.sql
@@ -1,0 +1,23 @@
+-- Test for UBSan issue in join order optimization when estimated row count overflows UInt64
+-- The issue occurs when converting a very large double to UInt64 in estimateJoinCardinality
+-- https://github.com/ClickHouse/ClickHouse/pull/94704
+
+DROP TABLE IF EXISTS data_03812;
+
+CREATE TABLE data_03812 (key UInt64, value UInt64) ENGINE = MergeTree ORDER BY key;
+INSERT INTO data_03812 VALUES (1, 1), (2, 2);
+
+-- This query triggers the join order optimizer with extremely large estimated row counts
+-- which can cause overflow when converting double to UInt64 in estimateJoinCardinality
+-- Using EXPLAIN to trigger planning without actual execution
+-- The GROUPING SETS clause helps trigger the code path that exercises the join optimizer
+EXPLAIN PLAN
+SELECT DISTINCT 1
+FROM data_03812 AS t1
+ALL INNER JOIN (
+    SELECT number FROM system.numbers LIMIT 9223372036854775806
+) AS t2 ON t2.number = t2.number
+GROUP BY GROUPING SETS ((t1.value), (t1.key))
+FORMAT Null;
+
+DROP TABLE data_03812;


### PR DESCRIPTION
The `estimateJoinCardinality` function could trigger undefined behavior when `joined_rows` was very close to `std::numeric_limits<UInt64>::max()`. Due to floating point precision, a value that passes the `>` comparison could still overflow when cast to `UInt64`.

Changed the comparison from `>` to `>=` to ensure values at or near the maximum are safely clamped before the cast.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


See https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=94704&sha=12111fa6b75e98627c8042cd7fdfa6ed3a4f2936&name_0=PR&name_1=AST%20fuzzer%20%28amd_ubsan%29
https://github.com/ClickHouse/ClickHouse/pull/94704

I checked that the test is good.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.144`
<!-- ch-version-info:end -->