### PR TITLE
Support auxiliary keeper for DatabaseReplicated (Resubmit of #91683).

### DIFF
--- a/docs/en/engines/database-engines/replicated.md
+++ b/docs/en/engines/database-engines/replicated.md
@@ -32,6 +32,12 @@ If `zoo_path` contains macro `{uuid}`, it is required to specify explicit UUID o
 
 For [ReplicatedMergeTree](/engines/table-engines/mergetree-family/replication) tables if no arguments provided, then default arguments are used: `/clickhouse/tables/{uuid}/{shard}` and `{replica}`. These can be changed in the server settings [default_replica_path](../../operations/server-configuration-parameters/settings.md#default_replica_path) and [default_replica_name](../../operations/server-configuration-parameters/settings.md#default_replica_name). Macro `{uuid}` is unfolded to table's uuid, `{shard}` and `{replica}` are unfolded to values from server config, not from database engine arguments. But in the future, it will be possible to use `shard_name` and `replica_name` of Replicated database.
 
+Auxiliary ZooKeeper cluster is also supported for storing metadata of a replicated database instead of using the default ZooKeeper cluster. We can use SQL to create the replicated database with auxiliary ZooKeeper cluster as follows:
+
+```sql
+CREATE DATABASE database_name ENGINE = Replicated('zookeeper_name_configured_in_auxiliary_zookeepers:path', 'shard_name', 'replica_name')
+```
+
 ## Specifics and recommendations {#specifics-and-recommendations}
 
 DDL queries with `Replicated` database work in a similar way to [ON CLUSTER](../../sql-reference/distributed-ddl.md) queries, but with minor differences.

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -2955,6 +2955,7 @@ try
                     global_context,
                     &config(),
                     "distributed_ddl",
+                    "default",
                     "DDLWorker",
                     &CurrentMetrics::MaxDDLEntryID,
                     &CurrentMetrics::MaxPushedDDLEntryID),

--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -2091,7 +2091,7 @@ void DatabaseReplicated::restoreDatabaseInKeeper(ContextPtr)
     initDatabaseReplica(zookeeper, LoadingStrictnessLevel::CREATE);
 
     /// Force the database to recover to update the restored metadata
-    auto current_zookeeper = getContext()->getZooKeeper();
+    auto current_zookeeper = getZooKeeper();
     current_zookeeper->set(replica_path + "/digest", DatabaseReplicatedDDLWorker::FORCE_AUTO_RECOVERY_DIGEST);
     reinitializeDDLWorker();
 }

--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -130,7 +130,7 @@ static constexpr const char * FIRST_REPLICA_DATABASE_NAME = "first_replica_datab
 
 ZooKeeperPtr DatabaseReplicated::getZooKeeper() const
 {
-    return getContext()->getZooKeeper();
+    return getContext()->getDefaultOrAuxiliaryZooKeeper(zookeeper_name);
 }
 
 static inline String getHostID(ContextPtr global_context, const UUID & db_uuid, bool secure)
@@ -191,12 +191,14 @@ DatabaseReplicated::DatabaseReplicated(
     const String & name_,
     const String & metadata_path_,
     UUID uuid,
+    const String & zookeeper_name_,
     const String & zookeeper_path_,
     const String & shard_name_,
     const String & replica_name_,
     DatabaseReplicatedSettings db_settings_,
     ContextPtr context_)
     : DatabaseAtomic(name_, metadata_path_, uuid, "DatabaseReplicated (" + name_ + ")", context_)
+    , zookeeper_name(zookeeper_name_)
     , zookeeper_path(normalizeZooKeeperPath(zookeeper_path_))
     , shard_name(shard_name_)
     , replica_name(replica_name_)
@@ -369,7 +371,7 @@ ClusterPtr DatabaseReplicated::getClusterImpl(bool all_groups) const
     Strings hosts;
     Strings host_ids;
 
-    auto zookeeper = getContext()->getZooKeeper();
+    auto zookeeper = getZooKeeper();
     constexpr int max_retries = 10;
     int iteration = 0;
     bool success = false;
@@ -1420,7 +1422,13 @@ BlockIO DatabaseReplicated::tryEnqueueReplicatedDDL(const ASTPtr & query, Contex
     }
 
 
-    return getQueryStatus(node_path, fs::path(zookeeper_path) / "replicas", query_context, hosts_to_wait, std::move(database_guard));
+    return getQueryStatus(
+        zookeeper_name,
+        node_path,
+        fs::path(zookeeper_path) / "replicas",
+        query_context,
+        hosts_to_wait,
+        std::move(database_guard));
 }
 
 static UUID getTableUUIDIfReplicated(const String & metadata, ContextPtr context)
@@ -2009,7 +2017,12 @@ ASTPtr DatabaseReplicated::parseQueryFromMetadataOnDisk(const String & table_nam
 }
 
 void DatabaseReplicated::dropReplica(
-    DatabaseReplicated * database, const String & database_zookeeper_path, const String & shard, const String & replica, bool throw_if_noop)
+    DatabaseReplicated * database,
+    const String & zookeeper_name,
+    const String & database_zookeeper_path,
+    const String & shard,
+    const String & replica,
+    bool throw_if_noop)
 {
     auto component_guard = Coordination::setCurrentComponent("DatabaseReplicated::dropReplica");
     chassert(!database || database_zookeeper_path == database->zookeeper_path);
@@ -2019,7 +2032,7 @@ void DatabaseReplicated::dropReplica(
     if (full_replica_name.contains('/'))
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Invalid replica name, '/' is not allowed: {}", full_replica_name);
 
-    auto zookeeper = Context::getGlobalContextInstance()->getZooKeeper();
+    auto zookeeper = Context::getGlobalContextInstance()->getDefaultOrAuxiliaryZooKeeper(zookeeper_name);
 
     String database_mark;
     bool db_path_exists = zookeeper->tryGet(database_zookeeper_path, database_mark);
@@ -2409,7 +2422,7 @@ DatabaseReplicated::getTablesForBackup(const FilterByNameFunction & filter, cons
 
     /// Here we read metadata from ZooKeeper. We could do that by simple call of DatabaseAtomic::getTablesForBackup() however
     /// reading from ZooKeeper is better because thus we won't be dependent on how fast the replication queue of this database is.
-    auto zookeeper = getContext()->getZooKeeper();
+    auto zookeeper = getZooKeeper();
     UInt32 snapshot_version = parse<UInt32>(zookeeper->get(zookeeper_path + "/max_log_ptr"));
     auto snapshot = getConsistentMetadataSnapshotImpl(zookeeper, filter, /* max_retries= */ 20, snapshot_version);
 
@@ -2611,6 +2624,8 @@ void registerDatabaseReplicated(DatabaseFactory & factory)
         if (allow_uuid_macro)
             info.table_id.uuid = args.uuid;
         zookeeper_path = args.context->getMacros()->expand(zookeeper_path, info);
+        auto zookeeper_name = zkutil::extractZooKeeperName(zookeeper_path);
+        zookeeper_path = zkutil::extractZooKeeperPath(zookeeper_path, /*check_starts_with_slash*/false);
 
         info.level = 0;
         info.table_id.uuid = UUIDHelpers::Nil;
@@ -2628,6 +2643,7 @@ void registerDatabaseReplicated(DatabaseFactory & factory)
             args.database_name,
             args.metadata_path,
             args.uuid,
+            zookeeper_name,
             zookeeper_path,
             shard_name,
             replica_name,
@@ -2637,13 +2653,18 @@ void registerDatabaseReplicated(DatabaseFactory & factory)
 }
 
 BlockIO DatabaseReplicated::getQueryStatus(
-    const String & node_path, const String & replicas_path, ContextPtr context_, const Strings & hosts_to_wait, DDLGuardPtr && database_guard)
+    const String & zookeeper_name,
+    const String & node_path,
+    const String & replicas_path,
+    ContextPtr context_,
+    const Strings & hosts_to_wait,
+    DDLGuardPtr && database_guard)
 {
     BlockIO io;
     if (context_->getSettingsRef()[Setting::distributed_ddl_task_timeout] == 0)
         return io;
 
-    auto source = std::make_shared<ReplicatedDatabaseQueryStatusSource>(node_path, replicas_path, context_, hosts_to_wait, std::move(database_guard));
+    auto source = std::make_shared<ReplicatedDatabaseQueryStatusSource>(zookeeper_name, node_path, replicas_path, context_, hosts_to_wait, std::move(database_guard));
     io.pipeline = QueryPipeline(std::move(source));
 
     if (context_->getSettingsRef()[Setting::distributed_ddl_output_mode] == DistributedDDLOutputMode::NONE

--- a/src/Databases/DatabaseReplicated.h
+++ b/src/Databases/DatabaseReplicated.h
@@ -69,7 +69,8 @@ public:
     };
 
     DatabaseReplicated(const String & name_, const String & metadata_path_, UUID uuid,
-                       const String & zookeeper_path_, const String & shard_name_, const String & replica_name_,
+                       const String & zookeeper_name_, const String & zookeeper_path_,
+                       const String & shard_name_, const String & replica_name_,
                        DatabaseReplicatedSettings db_settings_,
                        ContextPtr context);
 
@@ -116,6 +117,7 @@ public:
     static String getFullReplicaName(const String & shard, const String & replica);
     static std::pair<String, String> parseFullReplicaName(const String & name);
 
+    const String & getZooKeeperName() const { return zookeeper_name; }
     const String & getZooKeeperPath() const { return zookeeper_path; }
 
     void getStatus(ReplicatedStatus& response, bool with_zk_fields) const;
@@ -137,7 +139,13 @@ public:
 
     bool shouldReplicateQuery(const ContextPtr & query_context, const ASTPtr & query_ptr) const override;
 
-    static void dropReplica(DatabaseReplicated * database, const String & database_zookeeper_path, const String & shard, const String & replica, bool throw_if_noop);
+    static void dropReplica(
+        DatabaseReplicated * database,
+        const String & zookeeper_name,
+        const String & database_zookeeper_path,
+        const String & shard,
+        const String & replica,
+        bool throw_if_noop);
 
     void restoreDatabaseInKeeper(ContextPtr ctx);
 
@@ -226,9 +234,15 @@ private:
     void restoreDatabaseNodesInKeeper(const ZooKeeperPtr & zookeeper);
     void reinitializeDDLWorker();
 
-    static BlockIO
-    getQueryStatus(const String & node_path, const String & replicas_path, ContextPtr context, const Strings & hosts_to_wait, DDLGuardPtr && database_guard);
+    static BlockIO getQueryStatus(
+        const String & zookeeper_name,
+        const String & node_path,
+        const String & replicas_path,
+        ContextPtr context,
+        const Strings & hosts_to_wait,
+        DDLGuardPtr && database_guard);
 
+    const String zookeeper_name;
     const String zookeeper_path;
     const String shard_name;
     const String replica_name;

--- a/src/Databases/DatabaseReplicatedWorker.cpp
+++ b/src/Databases/DatabaseReplicatedWorker.cpp
@@ -60,6 +60,7 @@ DatabaseReplicatedDDLWorker::DatabaseReplicatedDDLWorker(DatabaseReplicated * db
           context_,
           nullptr,
           {},
+          db->zookeeper_name,
           fmt::format("DDLWorker({})", db->getDatabaseName()))
     , database(db)
 {
@@ -308,14 +309,14 @@ void DatabaseReplicatedDDLWorker::markReplicasActive(bool reinitialized)
 
 String DatabaseReplicatedDDLWorker::enqueueQuery(DDLLogEntry & entry, const ZooKeeperRetriesInfo &)
 {
-    auto zookeeper = context->getZooKeeper();
+    auto zookeeper = getZooKeeperFromContext();
     return enqueueQueryImpl(zookeeper, entry, database);
 }
 
 bool DatabaseReplicatedDDLWorker::waitForReplicaToProcessAllEntries(UInt64 timeout_ms)
 {
     auto component_guard = Coordination::setCurrentComponent("DatabaseReplicatedDDLWorker::waitForReplicaToProcessAllEntries");
-    auto zookeeper = context->getZooKeeper();
+    auto zookeeper = getZooKeeperFromContext();
     const auto our_log_ptr_path = database->replica_path + "/log_ptr";
     const auto max_log_ptr_path = database->zookeeper_path + "/max_log_ptr";
     UInt32 our_log_ptr = parse<UInt32>(zookeeper->get(our_log_ptr_path));
@@ -424,7 +425,7 @@ String DatabaseReplicatedDDLWorker::tryEnqueueAndExecuteEntry(DDLLogEntry & entr
     span.addAttribute("clickhouse.cluster", database->getDatabaseName());
     entry.tracing_context = OpenTelemetry::CurrentContext();
 
-    auto zookeeper = context->getZooKeeper();
+    auto zookeeper = getZooKeeperFromContext();
     UInt32 our_log_ptr = getLogPointer();
 
     UInt32 max_log_ptr = parse<UInt32>(zookeeper->get(database->zookeeper_path + "/max_log_ptr"));

--- a/src/Interpreters/DDLOnClusterQueryStatusSource.cpp
+++ b/src/Interpreters/DDLOnClusterQueryStatusSource.cpp
@@ -25,6 +25,7 @@ extern const int TIMEOUT_EXCEEDED;
 DDLOnClusterQueryStatusSource::DDLOnClusterQueryStatusSource(
     const String & zk_node_path, const String & zk_replicas_path, ContextPtr context_, const Strings & hosts_to_wait)
     : DistributedQueryStatusSource(
+          "default",
           zk_node_path,
           zk_replicas_path,
           std::make_shared<const Block>(getSampleBlock(context_->getSettingsRef()[Setting::distributed_ddl_output_mode])),

--- a/src/Interpreters/DDLWorker.h
+++ b/src/Interpreters/DDLWorker.h
@@ -63,6 +63,7 @@ public:
         ContextPtr context_,
         const Poco::Util::AbstractConfiguration * config,
         const String & prefix,
+        const String & zookeeper_name_ = "default",
         const String & logger_name = "DDLWorker",
         const CurrentMetrics::Metric * max_entry_metric_ = nullptr,
         const CurrentMetrics::Metric * max_pushed_entry_metric_ = nullptr);
@@ -90,6 +91,8 @@ public:
 
     bool isCurrentlyActive() const { return initialized && !stop_flag; }
 
+    /// Return the latest ZooKeeper session.
+    ZooKeeperPtr getZooKeeperFromContext() const;
     /// Returns cached ZooKeeper session (possibly expired).
     ZooKeeperPtr getZooKeeper() const;
     /// If necessary, creates a new session and caches it.
@@ -192,6 +195,7 @@ protected:
     std::string replicas_dir;
 
     mutable std::mutex zookeeper_mutex;
+    const std::string zookeeper_name;
     ZooKeeperPtr current_zookeeper TSA_GUARDED_BY(zookeeper_mutex);
 
     /// Save state of executed task to avoid duplicate execution on ZK error

--- a/src/Interpreters/DDLWorker.h
+++ b/src/Interpreters/DDLWorker.h
@@ -63,7 +63,7 @@ public:
         ContextPtr context_,
         const Poco::Util::AbstractConfiguration * config,
         const String & prefix,
-        const String & zookeeper_name_ = "default",
+        const String & zookeeper_name_,
         const String & logger_name = "DDLWorker",
         const CurrentMetrics::Metric * max_entry_metric_ = nullptr,
         const CurrentMetrics::Metric * max_pushed_entry_metric_ = nullptr);

--- a/src/Interpreters/DistributedQueryStatusSource.cpp
+++ b/src/Interpreters/DistributedQueryStatusSource.cpp
@@ -22,6 +22,7 @@ extern const int UNFINISHED;
 }
 
 DistributedQueryStatusSource::DistributedQueryStatusSource(
+    const String & zookeeper_name_,
     const String & zk_node_path,
     const String & zk_replicas_path,
     SharedHeader block,
@@ -29,6 +30,7 @@ DistributedQueryStatusSource::DistributedQueryStatusSource(
     const Strings & hosts_to_wait,
     const char * logger_name)
     : ISource(block)
+    , zookeeper_name(zookeeper_name_)
     , node_path(zk_node_path)
     , replicas_path(zk_replicas_path)
     , context(context_)
@@ -49,7 +51,6 @@ DistributedQueryStatusSource::DistributedQueryStatusSource(
     addTotalRowsApprox(waiting_hosts.size());
     timeout_seconds = context->getSettingsRef()[Setting::distributed_ddl_task_timeout];
 }
-
 
 IProcessor::Status DistributedQueryStatusSource::prepare()
 {
@@ -142,7 +143,7 @@ ExecutionStatus DistributedQueryStatusSource::getExecutionStatus(const fs::path 
     bool finished_exists = false;
 
     auto retries_ctl = ZooKeeperRetriesControl("executeDDLQueryOnCluster", getLogger("DDLQueryStatusSource"), getRetriesInfo());
-    retries_ctl.retryLoop([&]() { finished_exists = context->getZooKeeper()->tryGet(status_path, status_data); });
+    retries_ctl.retryLoop([&]() { finished_exists = context->getDefaultOrAuxiliaryZooKeeper(zookeeper_name)->tryGet(status_path, status_data); });
     if (finished_exists)
         status.tryDeserializeText(status_data);
 
@@ -217,7 +218,7 @@ Chunk DistributedQueryStatusSource::generate()
             retries_ctl.retryLoop(
                 [&]()
                 {
-                    auto zookeeper = context->getZooKeeper();
+                    auto zookeeper = context->getDefaultOrAuxiliaryZooKeeper(zookeeper_name);
                     Strings paths = getNodesToWait();
                     auto res = zookeeper->tryGetChildren(paths);
                     for (size_t i = 0; i < res.size(); ++i)

--- a/src/Interpreters/DistributedQueryStatusSource.h
+++ b/src/Interpreters/DistributedQueryStatusSource.h
@@ -15,6 +15,7 @@ class DistributedQueryStatusSource : public ISource
 {
 public:
     DistributedQueryStatusSource(
+        const String & zookeeper_name_,
         const String & zk_node_path,
         const String & zk_replicas_path,
         SharedHeader block,
@@ -55,6 +56,7 @@ protected:
         UNFINISHED = 3,
     };
 
+    String zookeeper_name;
     String node_path;
     String replicas_path;
     ContextPtr context;

--- a/src/Interpreters/InterpreterSystemQuery.cpp
+++ b/src/Interpreters/InterpreterSystemQuery.cpp
@@ -1479,10 +1479,10 @@ void InterpreterSystemQuery::dropStorageReplicasFromDatabase(const String & quer
 }
 
 DatabasePtr InterpreterSystemQuery::restoreDatabaseFromKeeperPath(
-    const String & zookeeper_path, const String & full_replica_name, const String & restoring_database_name)
+    const String & zookeeper_name, const String & zookeeper_path, const String & full_replica_name, const String & restoring_database_name)
 {
     auto component_guard = Coordination::setCurrentComponent("InterpreterSystemQuery::restoreDatabaseFromKeeperPath");
-    auto zookeeper = getContext()->getZooKeeper();
+    auto zookeeper = getContext()->getDefaultOrAuxiliaryZooKeeper(zookeeper_name);
 
     String metadata_path = zookeeper_path + "/metadata";
     if (!zookeeper->exists(metadata_path))
@@ -1730,7 +1730,8 @@ void InterpreterSystemQuery::dropDatabaseReplica(ASTSystemQuery & query)
             check_not_local_replica(replicated, full_replica_name, query_replica_zk_path);
             if (query.with_tables)
                 dropStorageReplicasFromDatabase(query.replica, database);
-            DatabaseReplicated::dropReplica(replicated, replicated->getZooKeeperPath(), query.shard, query.replica, /*throw_if_noop*/ true);
+            DatabaseReplicated::dropReplica(
+                replicated, replicated->getZooKeeperName(), replicated->getZooKeeperPath(), query.shard, query.replica, /*throw_if_noop*/ true);
         }
         else
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Database {} is not Replicated, cannot drop replica", query.getDatabase());
@@ -1757,7 +1758,8 @@ void InterpreterSystemQuery::dropDatabaseReplica(ASTSystemQuery & query)
             check_not_local_replica(replicated, full_replica_name, query_replica_zk_path);
             if (query.with_tables)
                 dropStorageReplicasFromDatabase(query.replica, database);
-            DatabaseReplicated::dropReplica(replicated, replicated->getZooKeeperPath(), query.shard, query.replica, /*throw_if_noop*/ false);
+            DatabaseReplicated::dropReplica(
+                replicated, replicated->getZooKeeperName(), replicated->getZooKeeperPath(), query.shard, query.replica, /*throw_if_noop*/ false);
             LOG_TRACE(log, "Dropped replica {} of Replicated database {}", query.replica, backQuoteIfNeed(database->getDatabaseName()));
         }
     }
@@ -1794,6 +1796,7 @@ void InterpreterSystemQuery::dropDatabaseReplica(ASTSystemQuery & query)
                 executeQuery(drop_query, drop_ctx);
             });
             auto database = restoreDatabaseFromKeeperPath(
+                /*zookeeper_name=*/query.zk_name,
                 /*zookeeper_path=*/query.replica_zk_path,
                 /*full_replica_name=*/full_replica_name,
                 /*restoring_database_name=*/restoring_database_name);
@@ -1804,8 +1807,8 @@ void InterpreterSystemQuery::dropDatabaseReplica(ASTSystemQuery & query)
             }
         }
 
-        DatabaseReplicated::dropReplica(nullptr, query.replica_zk_path, query.shard, query.replica, /*throw_if_noop*/ true);
-        LOG_INFO(log, "Dropped replica {} of Replicated database with path {}", query.replica, query.replica_zk_path);
+        DatabaseReplicated::dropReplica(nullptr, query.zk_name, query.replica_zk_path, query.shard, query.replica, /*throw_if_noop*/ true);
+        LOG_INFO(log, "Dropped replica {} of Replicated database with path {}", query.replica, query.full_replica_zk_path);
     }
 }
 

--- a/src/Interpreters/InterpreterSystemQuery.h
+++ b/src/Interpreters/InterpreterSystemQuery.h
@@ -89,7 +89,7 @@ private:
     void dropDatabaseReplica(ASTSystemQuery & query);
     void flushDistributed(ASTSystemQuery & query);
     DatabasePtr
-    restoreDatabaseFromKeeperPath(const String & zookeeper_path, const String & full_replica_name, const String & restoring_database_name);
+    restoreDatabaseFromKeeperPath(const String & zookeeper_name, const String & zookeeper_path, const String & full_replica_name, const String & restoring_database_name);
     std::optional<String> getDetachedDatabaseFromKeeperPath(const ASTSystemQuery & query_);
     [[noreturn]] void restartDisk(String & name);
 

--- a/src/Interpreters/ReplicatedDatabaseQueryStatusSource.cpp
+++ b/src/Interpreters/ReplicatedDatabaseQueryStatusSource.cpp
@@ -21,9 +21,20 @@ extern const int LOGICAL_ERROR;
 }
 
 ReplicatedDatabaseQueryStatusSource::ReplicatedDatabaseQueryStatusSource(
-    const String & zk_node_path, const String & zk_replicas_path, ContextPtr context_, const Strings & hosts_to_wait, DDLGuardPtr && database_guard_)
+    const String & zookeeper_name_,
+    const String & zk_node_path,
+    const String & zk_replicas_path,
+    ContextPtr context_,
+    const Strings & hosts_to_wait,
+    DDLGuardPtr && database_guard_)
     : DistributedQueryStatusSource(
-          zk_node_path, zk_replicas_path, std::make_shared<const Block>(getSampleBlock()), context_, hosts_to_wait, "ReplicatedDatabaseQueryStatusSource")
+        zookeeper_name_,
+        zk_node_path,
+        zk_replicas_path,
+        std::make_shared<const Block>(getSampleBlock()),
+        context_,
+        hosts_to_wait,
+        "ReplicatedDatabaseQueryStatusSource")
     , database_guard(std::move(database_guard_))
 {
 }

--- a/src/Interpreters/ReplicatedDatabaseQueryStatusSource.h
+++ b/src/Interpreters/ReplicatedDatabaseQueryStatusSource.h
@@ -11,7 +11,12 @@ class ReplicatedDatabaseQueryStatusSource final : public DistributedQueryStatusS
 {
 public:
     ReplicatedDatabaseQueryStatusSource(
-        const String & zk_node_path, const String & zk_replicas_path, ContextPtr context_, const Strings & hosts_to_wait, DDLGuardPtr && database_guard_);
+        const String & zookeeper_name_,
+        const String & zk_node_path,
+        const String & zk_replicas_path,
+        ContextPtr context_,
+        const Strings & hosts_to_wait,
+        DDLGuardPtr && database_guard_);
 
     String getName() const override { return "ReplicatedDatabaseQueryStatus"; }
 

--- a/src/Parsers/ASTSystemQuery.cpp
+++ b/src/Parsers/ASTSystemQuery.cpp
@@ -144,9 +144,9 @@ void ASTSystemQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & setti
             print_keyword(" FROM TABLE ");
             print_database_table();
         }
-        else if (!replica_zk_path.empty())
+        else if (!full_replica_zk_path.empty())
         {
-            print_keyword(" FROM ZKPATH ") << quoteString(replica_zk_path);
+            print_keyword(" FROM ZKPATH ") << quoteString(full_replica_zk_path);
         }
         else if (database)
         {

--- a/src/Parsers/ASTSystemQuery.h
+++ b/src/Parsers/ASTSystemQuery.h
@@ -159,6 +159,8 @@ public:
     String target_function;
     String replica;
     String shard;
+    String zk_name;
+    String full_replica_zk_path;
     String replica_zk_path;
     bool is_drop_whole_replica{};
     bool with_tables{false};

--- a/src/Parsers/ParserSystemQuery.cpp
+++ b/src/Parsers/ParserSystemQuery.cpp
@@ -12,6 +12,7 @@
 #include <IO/ReadHelpers.h>
 #include <IO/WriteBufferFromString.h>
 #include <Interpreters/InstrumentationManager.h>
+#include <Common/ZooKeeper/ZooKeeper.h>
 
 #include <base/EnumReflection.h>
 
@@ -192,7 +193,9 @@ enum class SystemQueryTargetType : uint8_t
             String zk_path = path_ast->as<ASTLiteral &>().value.safeGet<String>();
             if (!zk_path.empty() && zk_path[zk_path.size() - 1] == '/')
                 zk_path.pop_back();
-            res->replica_zk_path = zk_path;
+            res->full_replica_zk_path = std::move(zk_path);
+            res->zk_name = zkutil::extractZooKeeperName(res->full_replica_zk_path);
+            res->replica_zk_path = zkutil::extractZooKeeperPath(res->full_replica_zk_path, /*check_starts_with_slash*/false);
         }
         else
             return false;

--- a/src/Parsers/ParserSystemQuery.cpp
+++ b/src/Parsers/ParserSystemQuery.cpp
@@ -193,9 +193,12 @@ enum class SystemQueryTargetType : uint8_t
             String zk_path = path_ast->as<ASTLiteral &>().value.safeGet<String>();
             if (!zk_path.empty() && zk_path[zk_path.size() - 1] == '/')
                 zk_path.pop_back();
-            res->full_replica_zk_path = std::move(zk_path);
-            res->zk_name = zkutil::extractZooKeeperName(res->full_replica_zk_path);
-            res->replica_zk_path = zkutil::extractZooKeeperPath(res->full_replica_zk_path, /*check_starts_with_slash*/false);
+            if (!zk_path.empty())
+            {
+                res->full_replica_zk_path = std::move(zk_path);
+                res->zk_name = zkutil::extractZooKeeperName(res->full_replica_zk_path);
+                res->replica_zk_path = zkutil::extractZooKeeperPath(res->full_replica_zk_path, /*check_starts_with_slash*/false);
+            }
         }
         else
             return false;

--- a/src/Storages/System/StorageSystemDDLWorkerQueue.cpp
+++ b/src/Storages/System/StorageSystemDDLWorkerQueue.cpp
@@ -237,9 +237,9 @@ static void fillStatusColumns(MutableColumns & res_columns, size_t & col,
 void StorageSystemDDLWorkerQueue::fillData(MutableColumns & res_columns, ContextPtr context, const ActionsDAG::Node *, std::vector<UInt8>) const
 {
     auto component_guard = Coordination::setCurrentComponent("StorageSystemDDLWorkerQueue::fillData");
-    auto& ddl_worker = context->getDDLWorker();
+    auto & ddl_worker = context->getDDLWorker();
     fs::path ddl_zookeeper_path = ddl_worker.getQueueDir();
-    zkutil::ZooKeeperPtr zookeeper = context->getZooKeeper();
+    zkutil::ZooKeeperPtr zookeeper = ddl_worker.getZooKeeperFromContext();
     Strings ddl_task_paths = zookeeper->getChildren(ddl_zookeeper_path);
 
 

--- a/tests/integration/test_replicated_database_with_auxiliary_zookeepers/configs/auxiliary_zookeepers.xml
+++ b/tests/integration/test_replicated_database_with_auxiliary_zookeepers/configs/auxiliary_zookeepers.xml
@@ -1,0 +1,14 @@
+<clickhouse>
+    <auxiliary_zookeepers>
+        <zookeeper2>
+            <node index="1">
+                <host>zoo1</host>
+                <port>2181</port>
+            </node>
+            <node index="2">
+                <host>zoo2</host>
+                <port>2181</port>
+            </node>
+        </zookeeper2>
+    </auxiliary_zookeepers>
+</clickhouse>

--- a/tests/integration/test_replicated_database_with_auxiliary_zookeepers/test.py
+++ b/tests/integration/test_replicated_database_with_auxiliary_zookeepers/test.py
@@ -1,0 +1,75 @@
+import pytest
+
+from helpers.client import QueryRuntimeException
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+node1 = cluster.add_instance(
+    "node1",
+    main_configs=["configs/auxiliary_zookeepers.xml"],
+    with_zookeeper=True,
+    use_keeper=False,
+    macros={"shard": 1, "replica": 1},
+)
+node2 = cluster.add_instance(
+    "node2",
+    main_configs=["configs/auxiliary_zookeepers.xml"],
+    with_zookeeper=True,
+    use_keeper=False,
+    macros={"shard": 1, "replica": 2},
+)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+
+        yield cluster
+
+    except Exception as ex:
+        print(ex)
+
+    finally:
+        cluster.shutdown()
+
+
+def drop_database(nodes, database_name):
+    for node in nodes:
+        node.query("DROP DATABASE IF EXISTS {} SYNC".format(database_name))
+
+def check_table_exists(node, database_name, table_name):
+    assert node.query(f"EXISTS TABLE {database_name}.{table_name}") == "1\n"
+
+
+def check_table_not_exists(node, database_name, table_name):
+    assert node.query(f"EXISTS TABLE {database_name}.{table_name}") == "0\n"
+
+# Create table with auxiliary zookeeper.
+def test_create_replicated_database_with_auxiliary_zookeeper(started_cluster):
+    drop_database([node1, node2], "test_auxiliary_zookeeper")
+    for node in [node1, node2]:
+        node.query(
+            """
+                CREATE DATABASE test_auxiliary_zookeeper
+                ENGINE = Replicated('zookeeper2:/clickhouse/databases/test_auxiliary_zookeeper', '{shard}', '{replica}')
+            """)
+    node1.query("CREATE TABLE test_auxiliary_zookeeper.test_table(a Int32) ENGINE = MergeTree() ORDER BY a")
+    for node in [node1, node2]:
+        check_table_exists(node, "test_auxiliary_zookeeper", "test_table")
+    node2.query("DROP TABLE test_auxiliary_zookeeper.test_table SYNC")
+    for node in [node1, node2]:
+        check_table_not_exists(node, "test_auxiliary_zookeeper", "test_table")
+
+# Create table with auxiliary zookeeper that does not exist.
+def test_create_replicated_database_with_nonexistent_zookeeper(
+    started_cluster,
+):
+    drop_database([node1], "test_not_exist_zookeeper")
+    with pytest.raises(QueryRuntimeException):
+        node1.query(
+            """
+                CREATE DATABASE test_not_exist_zookeeper
+                ENGINE = Replicated('zookeeper_not_exists:/clickhouse/databases/test_not_exist_zookeeper', '{shard}', '{replica}')
+            """)
+

--- a/tests/queries/0_stateless/02447_drop_database_replica_auxiliary_zookeeper.reference
+++ b/tests/queries/0_stateless/02447_drop_database_replica_auxiliary_zookeeper.reference
@@ -1,0 +1,42 @@
+t
+1
+2
+2
+2
+2
+2
+2
+2
+2
+2
+2
+rdb_default	1	1	s1	r1	1
+2
+skip inactive
+s1	r1	OK	2	0
+s1	r2	QUEUED	2	0
+s2	r1	QUEUED	2	0
+s1	r1	OK	2	0
+s1	r2	QUEUED	2	0
+s2	r1	QUEUED	2	0
+timeout on active
+2
+2
+s1	r1	OK	3	0
+s1	r2	QUEUED	3	0
+s2	r1	QUEUED	3	0
+s9	r9	QUEUED	3	0
+drop replica
+2
+rdb_default	1	1	s1	r1	1
+rdb_default	1	2	s1	r2	0
+2
+2
+t
+t2
+t22
+t3
+t33
+t4
+t44
+rdb_default_4	1	1	s1	r1	1

--- a/tests/queries/0_stateless/02447_drop_database_replica_auxiliary_zookeeper.sh
+++ b/tests/queries/0_stateless/02447_drop_database_replica_auxiliary_zookeeper.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+
+# Tags: no-parallel, no-fasttest
+# no-parallel: This test is not parallel because when we execute system-wide SYSTEM DROP REPLICA,
+#  other tests might shut down the storage in parallel and the test will fail.
+# no-fasttest: It has several tests with timeouts for inactive replicas
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+db="rdb_$CLICKHOUSE_DATABASE"
+
+$CLICKHOUSE_CLIENT -q "system flush logs query_log"
+$CLICKHOUSE_CLIENT -q "create database $db engine=Replicated('zookeeper2:/test/$CLICKHOUSE_DATABASE/rdb', 's1', 'r1')"
+$CLICKHOUSE_CLIENT --distributed_ddl_output_mode=none -q "create table $db.t as system.query_log"   # Suppress style check: current_database=$CLICKHOUSE_DATABASE
+$CLICKHOUSE_CLIENT -q "show tables from $db"
+
+$CLICKHOUSE_CLIENT -q "system drop database replica 's1|r1' from table t" 2>&1| grep -Fac "SYNTAX_ERROR"
+$CLICKHOUSE_CLIENT -q "system drop database replica 's1|r1' from database $db" 2>&1| grep -Fac "There is a local database"
+$CLICKHOUSE_CLIENT -q "system drop database replica 'r1' from shard 's1' from database $db" 2>&1| grep -Fac "There is a local database"
+$CLICKHOUSE_CLIENT -q "system drop database replica 's1|r1' from zkpath 'zookeeper2:/test/$CLICKHOUSE_DATABASE/rdb'" 2>&1| grep -Fac "There is a local database"
+$CLICKHOUSE_CLIENT -q "system drop database replica 's1|r1' from zkpath 'zookeeper2:/test/$CLICKHOUSE_DATABASE/rdb/'" 2>&1| grep -Fac "There is a local database"
+$CLICKHOUSE_CLIENT -q "system drop database replica 'r1' from shard 's1' from zkpath 'zookeeper2:/test/$CLICKHOUSE_DATABASE/rdb/'" 2>&1| grep -Fac "There is a local database"
+
+$CLICKHOUSE_CLIENT -q "system drop database replica 's1|r1' from zkpath 'zookeeper2:/test/$CLICKHOUSE_DATABASE/'" 2>&1| grep -Fac "does not look like a path of Replicated database"
+$CLICKHOUSE_CLIENT -q "system drop database replica 's2|r1' from zkpath 'zookeeper2:/test/$CLICKHOUSE_DATABASE/rdb'" 2>&1| grep -Fac "does not exist"
+$CLICKHOUSE_CLIENT -q "system drop database replica 's1' from shard 'r1' from zkpath 'zookeeper2:/test/$CLICKHOUSE_DATABASE/rdb'" 2>&1| grep -Fac "does not exist"
+$CLICKHOUSE_CLIENT -q "system drop database replica 's1|r1' from shard 's1' from zkpath 'zookeeper2:/test/$CLICKHOUSE_DATABASE/rdb'" 2>&1| grep -Fac "does not exist"
+$CLICKHOUSE_CLIENT -q "system drop database replica 's2/r1' from zkpath 'zookeeper2:/test/$CLICKHOUSE_DATABASE/rdb'" 2>&1| grep -Fac "Invalid replica name"
+
+db2="${db}_2"
+db3="${db}_3"
+$CLICKHOUSE_CLIENT -q "create database $db2 engine=Replicated('zookeeper2:/test/$CLICKHOUSE_DATABASE/rdb', 's1', 'r2')"
+$CLICKHOUSE_CLIENT -q "create database $db3 engine=Replicated('zookeeper2:/test/$CLICKHOUSE_DATABASE/rdb', 's2', 'r1')"
+$CLICKHOUSE_CLIENT -q "system sync database replica $db"
+$CLICKHOUSE_CLIENT -q "select cluster, shard_num, replica_num, database_shard_name, database_replica_name, is_active from system.clusters where cluster='$db' and shard_num=1 and replica_num=1"
+$CLICKHOUSE_CLIENT -q "system drop database replica 's1|r1' from database $db2" 2>&1| grep -Fac "is active, cannot drop it"
+
+# Also check that it doesn't exceed distributed_ddl_task_timeout waiting for inactive replicas
+echo 'skip inactive'
+timeout 60s $CLICKHOUSE_CLIENT --distributed_ddl_task_timeout=1000 --distributed_ddl_output_mode=none_only_active -q "create table $db.t2 (n int) engine=Log"
+timeout 60s $CLICKHOUSE_CLIENT --distributed_ddl_task_timeout=1000 --distributed_ddl_output_mode=throw_only_active -q "create table $db.t3 (n int) engine=Log" | sort
+timeout 60s $CLICKHOUSE_CLIENT --distributed_ddl_task_timeout=1000 --distributed_ddl_output_mode=null_status_on_timeout_only_active -q "create table $db.t4 (n int) engine=Log" | sort
+
+# And that it still throws TIMEOUT_EXCEEDED for active replicas
+echo 'timeout on active'
+db9="${db}_9"
+REPLICA_UUID=$($CLICKHOUSE_CLIENT -q "select serverUUID()")
+if ! [[ $REPLICA_UUID =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then
+    echo "Weird UUID ${REPLICA_UUID}"
+    exit 1
+fi
+$CLICKHOUSE_CLIENT -q "create database $db9 engine=Replicated('zookeeper2:/test/${CLICKHOUSE_DATABASE}/rdb', 's9', 'r9')"
+$CLICKHOUSE_CLIENT -q "detach database $db9"
+$CLICKHOUSE_CLIENT -q "insert into system.zookeeper(name, path, value, zookeeperName) values ('active', '/test/${CLICKHOUSE_DATABASE}/rdb/replicas/s9|r9', '${REPLICA_UUID}', 'zookeeper2')"
+
+$CLICKHOUSE_CLIENT --distributed_ddl_task_timeout=5 --distributed_ddl_output_mode=none_only_active -q "create table $db.t22 (n int) engine=Log" 2>&1| grep -Fac "TIMEOUT_EXCEEDED"
+$CLICKHOUSE_CLIENT --distributed_ddl_task_timeout=5 --distributed_ddl_output_mode=throw_only_active -q "create table $db.t33 (n int) engine=Log" 2>&1| grep -Fac "TIMEOUT_EXCEEDED"
+$CLICKHOUSE_CLIENT --distributed_ddl_task_timeout=5 --distributed_ddl_output_mode=null_status_on_timeout_only_active -q "create table $db.t44 (n int) engine=Log" | sort
+
+$CLICKHOUSE_CLIENT -q "attach database $db9"
+$CLICKHOUSE_CLIENT -q "drop database $db9"
+
+echo 'drop replica'
+
+$CLICKHOUSE_CLIENT -q "detach database $db3"
+$CLICKHOUSE_CLIENT -q "system drop database replica 'r1' from shard 's2' from database $db"
+$CLICKHOUSE_CLIENT -q "attach database $db3" 2>/dev/null
+$CLICKHOUSE_CLIENT --distributed_ddl_output_mode=none -q "create table $db3.t2 as system.query_log" 2>&1| grep -Fac "Database is in readonly mode"   # Suppress style check: current_database=$CLICKHOUSE_DATABASE
+
+$CLICKHOUSE_CLIENT -q "detach database $db2"
+$CLICKHOUSE_CLIENT -q "system sync database replica $db"
+$CLICKHOUSE_CLIENT -q "select cluster, shard_num, replica_num, database_shard_name, database_replica_name, is_active from system.clusters where cluster='$db' order by shard_num, replica_num"
+$CLICKHOUSE_CLIENT -q "system drop database replica 's1|r2' from database $db"
+$CLICKHOUSE_CLIENT -q "attach database $db2" 2>/dev/null
+$CLICKHOUSE_CLIENT --distributed_ddl_output_mode=none -q "create table $db2.t2 as system.query_log" 2>&1| grep -Fac "Database is in readonly mode"   # Suppress style check: current_database=$CLICKHOUSE_DATABASE
+
+$CLICKHOUSE_CLIENT -q "detach database $db"
+$CLICKHOUSE_CLIENT -q "system drop database replica 'r1' from shard 's1' from zkpath 'zookeeper2:/test/$CLICKHOUSE_DATABASE/rdb/'"
+$CLICKHOUSE_CLIENT -q "attach database $db" 2>/dev/null
+$CLICKHOUSE_CLIENT --distributed_ddl_output_mode=none -q "create table $db.t2 as system.query_log" 2>&1| grep -Fac "Database is in readonly mode"   # Suppress style check: current_database=$CLICKHOUSE_DATABASE
+$CLICKHOUSE_CLIENT -q "show tables from $db"
+
+db4="${db}_4"
+$CLICKHOUSE_CLIENT -q "create database $db4 engine=Replicated('zookeeper2:/test/$CLICKHOUSE_DATABASE/rdb', 's1', 'r1')"
+$CLICKHOUSE_CLIENT -q "system sync database replica $db4"
+$CLICKHOUSE_CLIENT -q "select cluster, shard_num, replica_num, database_shard_name, database_replica_name, is_active from system.clusters where cluster='$db4'"
+
+# Don't throw "replica doesn't exist" when removing all replicas [from a database]
+$CLICKHOUSE_CLIENT -q "system drop database replica 'zookeeper2:doesntexist$CLICKHOUSE_DATABASE' from shard 'doesntexist'"
+
+$CLICKHOUSE_CLIENT -q "drop database $db"
+$CLICKHOUSE_CLIENT -q "drop database $db2"
+$CLICKHOUSE_CLIENT -q "drop database $db3"
+
+$CLICKHOUSE_CLIENT --distributed_ddl_output_mode=none -q "create table $db4.rmt (n int) engine=ReplicatedMergeTree order by n"
+$CLICKHOUSE_CLIENT -q "system drop replica 'zookeeper2:doesntexist$CLICKHOUSE_DATABASE' from database $db4"
+$CLICKHOUSE_CLIENT -q "system drop replica 'zookeeper2:doesntexist$CLICKHOUSE_DATABASE'"
+
+$CLICKHOUSE_CLIENT -q "drop database $db4"


### PR DESCRIPTION
We already support auxiliary zookeeper for storing metadata of `ReplicatedMergeTree` long time ago. This PR supports auxiliary zookeeper for `DatabaseReplicated`.

Resubmit of #91683.

### Changelog category (leave one):
- New Feature


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Support auxiliary zookeeper for `DatabaseReplicated`.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.98`
<!-- ch-version-info:end -->