### PR TITLE
Fix zero‑copy unlock check before part dir move

### DIFF
--- a/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
+++ b/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
@@ -746,6 +746,11 @@ void DataPartStorageOnDiskBase::remove(
 
         try
         {
+            /// Evaluate can_remove_callback before moving the directory so zero-copy reference checks
+            /// use the current (existing) path. We intentionally don't update part_dir to avoid races.
+            if (!can_remove_description)
+                can_remove_description.emplace(can_remove_callback());
+
             disk->moveDirectory(from, to);
             /// NOTE: we intentionally don't update part_dir here because it would cause a data race
             /// with concurrent readers (e.g. system.parts table queries calling getFullPath()).


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description]
Fix regression in (experimental) zero‑copy replication introduced by #94262 where shared parts could be deleted before other replicas finished fetching them.

### Documentation entry for user-facing changes

#94262 fixes a data race between part removal and `system.parts` by stopping `DataPartStorageOnDiskBase::remove()` from updating `part_dir` after `moveDirectory()`. Previously the code did `part_dir = delete_tmp_*`, but that write could race with `getFullPath()` reads. The fix removed the write, so `part_dir` stays unchanged during removal, eliminating the race.

But that change accidentally broke zero‑copy cleanup: the “can we delete shared blobs?” check (`unlockSharedData`) reads a refcount file via `part_dir`. After the move, `part_dir` now points to the old location, so the check fails and the code assumes the part is temporary and deletes blobs without ZooKeeper checks. The fix is to evaluate the “can remove” decision before the directory is moved, while the refcount file is still visible, and then reuse that decision after the move. 
This matches existing nearby branches that already call `can_remove_callback()` before disk operations.

No new tests added; zero‑copy replication test coverage has been [removed](https://github.com/ClickHouse/ClickHouse/pull/82250) in newer branches. Change was validated internally.

P.S. This should be backported to the branches where #94262 was backported, since it introduced the regression.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.331`
<!-- ch-version-info:end -->