### PR TITLE
Improve S3 authentication error messages with credential source hints

### DIFF
--- a/src/IO/S3/getObjectInfo.h
+++ b/src/IO/S3/getObjectInfo.h
@@ -68,6 +68,7 @@ void checkObjectExists(
     std::string_view description = {});
 
 bool isNotFoundError(Aws::S3::S3Errors error);
+bool isAuthenticationError(Aws::S3::S3Errors error);
 
 }
 


### PR DESCRIPTION
## Summary

When S3 authentication fails, the error message now includes a hint to check credentials, making it easier to diagnose authentication issues.

**Before:**
```
Code: 499. DB::Exception: Failed to get object info: No response body.. 
HTTP response code: 403 (S3_ERROR)
```

**After:**
```
Code: 499. DB::Exception: Failed to get object info: No response body.. 
HTTP response code: 403. Please check your AWS credentials and permissions. (S3_ERROR)
```

Fixes #85894

### Changelog category:
- Improvement

### Changelog entry:
Improved S3 authentication error messages to include a hint to check credentials when access is denied.

### Test plan:
- Added integration test `test_error_message_includes_auth_hint` in `test_invalid_env_credentials.py`


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.430`
<!-- ch-version-info:end -->