### PR TITLE
Fix upgrade check to respect no-{sanitizer} tags

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -2034,8 +2034,9 @@ class TestCase:
         if tags and ("no-encrypted-storage" in tags) and args.encrypted_storage:
             return FailureReason.ENCRYPTED_STORAGE
 
-        # Ingore no-{build} tags in stress-tests job
-        if tags and not args.stress_tests:
+        # Ignore no-{build} tags in stress-tests job, but still apply them in upgrade-check
+        # because upgrade check may start with an old version and upgrade to a new version with different build flags
+        if tags and (not args.stress_tests or args.upgrade_check):
             for build_flag in args.build_flags:
                 # We ignore no-buildflag for flaky check (args.flaky_check and args.test_runs > 1)
                 # and do not ignore for targeted check (args.flaky_check and args.test_runs == 1)
@@ -4187,6 +4188,12 @@ def main(args):
             raise TestException(f"Sticky host '{host}' not responding")
 
     args.build_flags = collect_build_flags(args)
+    # Add extra build flags if specified (used in upgrade checks to pass sanitizer flags from new binary)
+    if args.extra_build_flags:
+        for flag in args.extra_build_flags.split(","):
+            flag = flag.strip()
+            if flag and flag not in args.build_flags:
+                args.build_flags.append(flag)
     args.changed_merge_tree_settings = collect_changed_merge_tree_settings(args)
 
     if args.s3_storage and (BuildFlags.RELEASE not in args.build_flags):
@@ -4967,6 +4974,12 @@ def parse_args():
         "--capture-client-stacktrace",
         action="store_true",
         help="Capture stacktraces from clickhouse-client/local on errors",
+    )
+    parser.add_argument(
+        "--extra-build-flags",
+        default="",
+        help="Comma-separated list of extra build flags to use for test filtering (e.g., msan,tsan). "
+        "Used in upgrade checks to pass sanitizer flags from the new binary.",
     )
     parser.add_argument(
         "--trace", action="store_true", help="Capture various tracing info"

--- a/tests/queries/0_stateless/03784_bad_base_backup.sh
+++ b/tests/queries/0_stateless/03784_bad_base_backup.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Tags: no-msan
+# `DeltaLakeLocal` is not supported in MSAN builds.
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
Upgrade check failure example: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=95611&sha=254a0211695d3925b5c924650b098045831546e9&name_0=PR&name_1=Upgrade%20check%20%28amd_msan%29&name_1=Upgrade%20check%20%28amd_msan%29
https://github.com/ClickHouse/ClickHouse/pull/95611

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Respect the skip tags (`no-msan`, `no-asan`) for the Upgrade check with a respective sanitizer. Otherwise, it leads to a false positive failure when the previous version (release build) creates a table that is simply not supported.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
