### PR TITLE
Fix race between distributed DDL and dropping Replicated database

### DIFF
--- a/src/Databases/DatabaseReplicated.h
+++ b/src/Databases/DatabaseReplicated.h
@@ -87,7 +87,7 @@ public:
 
     /// Try to execute DLL query on current host as initial query. If query is succeed,
     /// then it will be executed on all replicas.
-    BlockIO tryEnqueueReplicatedDDL(const ASTPtr & query, ContextPtr query_context, QueryFlags flags) override;
+    BlockIO tryEnqueueReplicatedDDL(const ASTPtr & query, ContextPtr query_context, QueryFlags flags, DDLGuardPtr && database_guard) override;
 
     bool canExecuteReplicatedMetadataAlter() const override;
 
@@ -212,7 +212,7 @@ private:
     void reinitializeDDLWorker();
 
     static BlockIO
-    getQueryStatus(const String & node_path, const String & replicas_path, ContextPtr context, const Strings & hosts_to_wait);
+    getQueryStatus(const String & node_path, const String & replicas_path, ContextPtr context, const Strings & hosts_to_wait, DDLGuardPtr && database_guard);
 
     const String zookeeper_path;
     const String shard_name;

--- a/src/Databases/IDatabase.cpp
+++ b/src/Databases/IDatabase.cpp
@@ -206,7 +206,7 @@ void IDatabase::stopReplication()
     throw Exception(ErrorCodes::LOGICAL_ERROR, "Database engine {} does not run a replication thread", getEngineName());
 }
 
-BlockIO IDatabase::tryEnqueueReplicatedDDL(const ASTPtr & /*query*/, ContextPtr /*query_context*/, [[maybe_unused]] QueryFlags flags) /// NOLINT
+BlockIO IDatabase::tryEnqueueReplicatedDDL(const ASTPtr & /*query*/, ContextPtr /*query_context*/, [[maybe_unused]] QueryFlags flags, DDLGuardPtr && /*database_guard*/) /// NOLINT
 {
     throw Exception(ErrorCodes::LOGICAL_ERROR, "Database engine {} does not have replicated DDL queue", getEngineName());
 }

--- a/src/Databases/IDatabase.h
+++ b/src/Databases/IDatabase.h
@@ -4,6 +4,7 @@
 #include <Databases/LoadingStrictnessLevel.h>
 #include <Disks/IDisk.h>
 #include <Interpreters/Context_fwd.h>
+#include <Interpreters/DDLGuard.h>
 #include <Interpreters/QueryFlags.h>
 #include <Parsers/IAST_fwd.h>
 #include <QueryPipeline/BlockIO.h>
@@ -431,7 +432,7 @@ public:
 
     virtual bool shouldReplicateQuery(const ContextPtr & /*query_context*/, const ASTPtr & /*query_ptr*/) const { return false; }
 
-    virtual BlockIO tryEnqueueReplicatedDDL(const ASTPtr & /*query*/, ContextPtr /*query_context*/, [[maybe_unused]] QueryFlags flags);
+    virtual BlockIO tryEnqueueReplicatedDDL(const ASTPtr & /*query*/, ContextPtr /*query_context*/, [[maybe_unused]] QueryFlags flags, DDLGuardPtr && /*database_guard*/);
 
     /// Returns CREATE TABLE queries and corresponding tables prepared for writing to a backup.
     virtual std::vector<std::pair<ASTPtr, StoragePtr>> getTablesForBackup(const FilterByNameFunction & filter, const ContextPtr & context) const;

--- a/src/Interpreters/DDLGuard.h
+++ b/src/Interpreters/DDLGuard.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <Common/SharedMutex.h>
+#include <mutex>
+
+
+namespace DB
+{
+
+/// Allows executing DDL query only in one thread.
+/// Puts an element into the map, locks tables's mutex, counts how much threads run parallel query on the table,
+/// when counter is 0 erases element in the destructor.
+/// If the element already exists in the map, waits when ddl query will be finished in other thread.
+class DDLGuard
+{
+public:
+    struct Entry
+    {
+      std::unique_ptr<std::mutex> mutex;
+      UInt32 counter;
+    };
+
+    /// Element name -> (mutex, counter).
+    /// NOTE: using std::map here (and not std::unordered_map) to avoid iterator invalidation on insertion.
+    using Map = std::map<String, Entry>;
+
+    DDLGuard(
+        Map & map_,
+        SharedMutex & db_mutex_,
+        std::unique_lock<std::mutex> guards_lock_,
+        const String & elem,
+        const String & database_name);
+    ~DDLGuard();
+
+    /// Unlocks table name, keeps holding read lock for database name
+    void releaseTableLock() noexcept;
+
+private:
+    Map & map;
+    SharedMutex & db_mutex;
+    Map::iterator it;
+    std::unique_lock<std::mutex> guards_lock;
+    std::unique_lock<std::mutex> table_lock;
+    bool table_lock_removed = false;
+    bool is_database_guard = false;
+};
+
+using DDLGuardPtr = std::unique_ptr<DDLGuard>;
+
+}

--- a/src/Interpreters/DatabaseCatalog.h
+++ b/src/Interpreters/DatabaseCatalog.h
@@ -3,6 +3,7 @@
 #include <Core/UUID.h>
 #include <Databases/TablesDependencyGraph.h>
 #include <Interpreters/Context_fwd.h>
+#include <Interpreters/DDLGuard.h>
 #include <Interpreters/StorageID.h>
 #include <Parsers/IAST_fwd.h>
 #include <Storages/IStorage_fwd.h>
@@ -39,45 +40,6 @@ using Databases = std::map<String, std::shared_ptr<IDatabase>, std::less<>>;
 using DiskPtr = std::shared_ptr<IDisk>;
 using TableNamesSet = std::unordered_set<QualifiedTableName>;
 
-/// Allows executing DDL query only in one thread.
-/// Puts an element into the map, locks tables's mutex, counts how much threads run parallel query on the table,
-/// when counter is 0 erases element in the destructor.
-/// If the element already exists in the map, waits when ddl query will be finished in other thread.
-class DDLGuard
-{
-public:
-    struct Entry
-    {
-        std::unique_ptr<std::mutex> mutex;
-        UInt32 counter;
-    };
-
-    /// Element name -> (mutex, counter).
-    /// NOTE: using std::map here (and not std::unordered_map) to avoid iterator invalidation on insertion.
-    using Map = std::map<String, Entry>;
-
-    DDLGuard(
-        Map & map_,
-        SharedMutex & db_mutex_,
-        std::unique_lock<std::mutex> guards_lock_,
-        const String & elem,
-        const String & database_name);
-    ~DDLGuard();
-
-    /// Unlocks table name, keeps holding read lock for database name
-    void releaseTableLock() noexcept;
-
-private:
-    Map & map;
-    SharedMutex & db_mutex;
-    Map::iterator it;
-    std::unique_lock<std::mutex> guards_lock;
-    std::unique_lock<std::mutex> table_lock;
-    bool table_lock_removed = false;
-    bool is_database_guard = false;
-};
-
-using DDLGuardPtr = std::unique_ptr<DDLGuard>;
 
 class FutureSetFromSubquery;
 using FutureSetFromSubqueryPtr = std::shared_ptr<FutureSetFromSubquery>;

--- a/src/Interpreters/InterpreterAlterQuery.cpp
+++ b/src/Interpreters/InterpreterAlterQuery.cpp
@@ -136,7 +136,7 @@ BlockIO InterpreterAlterQuery::executeToTable(const ASTAlterQuery & alter)
     {
         auto guard = DatabaseCatalog::instance().getDDLGuard(table_id.database_name, table_id.table_name, database.get());
         guard->releaseTableLock();
-        return database->tryEnqueueReplicatedDDL(query_ptr, getContext(), {});
+        return database->tryEnqueueReplicatedDDL(query_ptr, getContext(), {}, std::move(guard));
     }
 
 #if CLICKHOUSE_CLOUD

--- a/src/Interpreters/InterpreterCreateIndexQuery.cpp
+++ b/src/Interpreters/InterpreterCreateIndexQuery.cpp
@@ -78,7 +78,7 @@ BlockIO InterpreterCreateIndexQuery::execute()
     {
         auto guard = DatabaseCatalog::instance().getDDLGuard(table_id.database_name, table_id.table_name, database.get());
         guard->releaseTableLock();
-        return database->tryEnqueueReplicatedDDL(query_ptr, current_context, {});
+        return database->tryEnqueueReplicatedDDL(query_ptr, current_context, {}, std::move(guard));
     }
 
     StoragePtr table = DatabaseCatalog::instance().getTable(table_id, current_context);

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -1526,7 +1526,7 @@ BlockIO InterpreterCreateQuery::createTable(ASTCreateQuery & create)
             auto guard = DatabaseCatalog::instance().getDDLGuard(database_name, create.getTable(), database.get());
             create.setDatabase(database_name);
             guard->releaseTableLock();
-            return database->tryEnqueueReplicatedDDL(query_ptr, getContext(), QueryFlags{ .internal = internal, .distributed_backup_restore = is_restore_from_backup });
+            return database->tryEnqueueReplicatedDDL(query_ptr, getContext(), QueryFlags{ .internal = internal, .distributed_backup_restore = is_restore_from_backup }, std::move(guard));
         }
 
         if (!create.cluster.empty())
@@ -1719,7 +1719,7 @@ BlockIO InterpreterCreateQuery::createTable(ASTCreateQuery & create)
         auto guard = DatabaseCatalog::instance().getDDLGuard(create.getDatabase(), create.getTable(), database.get());
         assertOrSetUUID(create, database);
         guard->releaseTableLock();
-        return database->tryEnqueueReplicatedDDL(query_ptr, getContext(), QueryFlags{ .internal = internal, .distributed_backup_restore = is_restore_from_backup });
+        return database->tryEnqueueReplicatedDDL(query_ptr, getContext(), QueryFlags{ .internal = internal, .distributed_backup_restore = is_restore_from_backup }, std::move(guard));
     }
 
     if (!create.cluster.empty())

--- a/src/Interpreters/InterpreterDeleteQuery.cpp
+++ b/src/Interpreters/InterpreterDeleteQuery.cpp
@@ -82,7 +82,7 @@ BlockIO InterpreterDeleteQuery::execute()
     {
         auto guard = DatabaseCatalog::instance().getDDLGuard(table_id.database_name, table_id.table_name, database.get());
         guard->releaseTableLock();
-        return database->tryEnqueueReplicatedDDL(query_ptr, getContext(), {});
+        return database->tryEnqueueReplicatedDDL(query_ptr, getContext(), {}, std::move(guard));
     }
 
     auto table_lock = table->lockForShare(getContext()->getCurrentQueryId(), settings[Setting::lock_acquire_timeout]);

--- a/src/Interpreters/InterpreterDropIndexQuery.cpp
+++ b/src/Interpreters/InterpreterDropIndexQuery.cpp
@@ -47,7 +47,7 @@ BlockIO InterpreterDropIndexQuery::execute()
     {
         auto guard = DatabaseCatalog::instance().getDDLGuard(table_id.database_name, table_id.table_name, database.get());
         guard->releaseTableLock();
-        return database->tryEnqueueReplicatedDDL(query_ptr, current_context, {});
+        return database->tryEnqueueReplicatedDDL(query_ptr, current_context, {}, std::move(guard));
     }
 
     StoragePtr table = DatabaseCatalog::instance().getTable(table_id, current_context);

--- a/src/Interpreters/InterpreterDropQuery.cpp
+++ b/src/Interpreters/InterpreterDropQuery.cpp
@@ -228,7 +228,7 @@ BlockIO InterpreterDropQuery::executeToTableImpl(const ContextPtr & context_, AS
 
             query_to_send.if_empty = false;
 
-            return database->tryEnqueueReplicatedDDL(new_query_ptr, context_, {});
+            return database->tryEnqueueReplicatedDDL(new_query_ptr, context_, {}, std::move(ddl_guard));
         }
 
         if (query.kind == ASTDropQuery::Kind::Detach)

--- a/src/Interpreters/InterpreterRenameQuery.cpp
+++ b/src/Interpreters/InterpreterRenameQuery.cpp
@@ -126,7 +126,7 @@ BlockIO InterpreterRenameQuery::executeToTables(const ASTRenameQuery & rename, c
             UniqueTableName to(elem.to_database_name, elem.to_table_name);
             ddl_guards[from]->releaseTableLock();
             ddl_guards[to]->releaseTableLock();
-            return database->tryEnqueueReplicatedDDL(query_ptr, getContext(), {});
+            return database->tryEnqueueReplicatedDDL(query_ptr, getContext(), {}, std::move(ddl_guards[from]));
         }
 
         StorageID from_table_id{elem.from_database_name, elem.from_table_name};

--- a/src/Interpreters/InterpreterUpdateQuery.cpp
+++ b/src/Interpreters/InterpreterUpdateQuery.cpp
@@ -104,7 +104,7 @@ BlockIO InterpreterUpdateQuery::execute()
     {
         auto guard = DatabaseCatalog::instance().getDDLGuard(table_id.database_name, table_id.table_name, database.get());
         guard->releaseTableLock();
-        return database->tryEnqueueReplicatedDDL(query_ptr, getContext(), {});
+        return database->tryEnqueueReplicatedDDL(query_ptr, getContext(), {}, std::move(guard));
     }
 
     MutationCommands commands;

--- a/src/Interpreters/ReplicatedDatabaseQueryStatusSource.cpp
+++ b/src/Interpreters/ReplicatedDatabaseQueryStatusSource.cpp
@@ -21,9 +21,10 @@ extern const int LOGICAL_ERROR;
 }
 
 ReplicatedDatabaseQueryStatusSource::ReplicatedDatabaseQueryStatusSource(
-    const String & zk_node_path, const String & zk_replicas_path, ContextPtr context_, const Strings & hosts_to_wait)
+    const String & zk_node_path, const String & zk_replicas_path, ContextPtr context_, const Strings & hosts_to_wait, DDLGuardPtr && database_guard_)
     : DistributedQueryStatusSource(
           zk_node_path, zk_replicas_path, std::make_shared<const Block>(getSampleBlock()), context_, hosts_to_wait, "ReplicatedDatabaseQueryStatusSource")
+    , database_guard(std::move(database_guard_))
 {
 }
 

--- a/src/Interpreters/ReplicatedDatabaseQueryStatusSource.h
+++ b/src/Interpreters/ReplicatedDatabaseQueryStatusSource.h
@@ -26,6 +26,7 @@ protected:
 
 private:
     static Block getSampleBlock();
+    /// A kind of read lock for the database which prevents dropping the database (and its metadata from zk that we use for getting the query status)
     DDLGuardPtr database_guard;
 
 

--- a/src/Interpreters/ReplicatedDatabaseQueryStatusSource.h
+++ b/src/Interpreters/ReplicatedDatabaseQueryStatusSource.h
@@ -11,7 +11,7 @@ class ReplicatedDatabaseQueryStatusSource final : public DistributedQueryStatusS
 {
 public:
     ReplicatedDatabaseQueryStatusSource(
-        const String & zk_node_path, const String & zk_replicas_path, ContextPtr context_, const Strings & hosts_to_wait);
+        const String & zk_node_path, const String & zk_replicas_path, ContextPtr context_, const Strings & hosts_to_wait, DDLGuardPtr && database_guard_);
 
     String getName() const override { return "ReplicatedDatabaseQueryStatus"; }
 
@@ -26,6 +26,7 @@ protected:
 
 private:
     static Block getSampleBlock();
+    DDLGuardPtr database_guard;
 
 
 };


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `There was an error: Cannot obtain error message` logical error when waiting for a distributed DDL and dropping the Replicated database concurrently. Fixes https://github.com/ClickHouse/ClickHouse/issues/95539

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.142`
- Backported to: `26.1.2.11`, `25.12.5.42`, `25.11.9.12`, `25.10.6.36`, `25.8.16.34`
<!-- ch-version-info:end -->