### PR TITLE
Fix `03783_autopr_dataflow_cache_reuse*` tests

### DIFF
--- a/tests/queries/0_stateless/03783_autopr_dataflow_cache_reuse.sql
+++ b/tests/queries/0_stateless/03783_autopr_dataflow_cache_reuse.sql
@@ -12,6 +12,9 @@ SET enable_analyzer=1;
 -- May disable the usage of parallel replicas
 SET automatic_parallel_replicas_min_bytes_per_replica=0;
 
+-- External aggregation is not supported at the moment, i.e., no statistics will be reported
+SET max_bytes_before_external_group_by=0, max_bytes_ratio_before_external_group_by=0;
+
 SET max_threads=2;
 
 INSERT INTO t SELECT toString(number), number FROM numbers(1e3);

--- a/tests/queries/0_stateless/03783_autopr_dataflow_cache_reuse_qcc.sql
+++ b/tests/queries/0_stateless/03783_autopr_dataflow_cache_reuse_qcc.sql
@@ -14,7 +14,13 @@ SET enable_analyzer=1;
 SET use_query_condition_cache=1;
 SET automatic_parallel_replicas_min_bytes_per_replica='1Mi';
 
+-- External aggregation is not supported at the moment, i.e., no statistics will be reported
+SET max_bytes_before_external_group_by=0, max_bytes_ratio_before_external_group_by=0;
+
 INSERT INTO t SELECT 'ololokekkekkek' || toString(number % 10), number FROM numbers(1e6);
+
+-- Try to avoid eviction of relevant cache entries
+SYSTEM CLEAR QUERY CONDITION CACHE;
 
 --set send_logs_level='trace', send_logs_source_regexp = 'optimize|SelectExecutor';
 SELECT SUM(value) FROM t FORMAT Null SETTINGS log_comment='03783_autopr_dataflow_cache_reuse_query_0'; -- empty cache, don't apply optimization, collect stats

--- a/tests/queries/0_stateless/03783_autopr_dataflow_cache_reuse_qcc.sql
+++ b/tests/queries/0_stateless/03783_autopr_dataflow_cache_reuse_qcc.sql
@@ -1,3 +1,6 @@
+-- Tags: no-parallel
+-- Tag no-parallel: Depends on the query condition cache content (queries executed in parallel may overflow the cache size or straight away call "clear cache")
+
 DROP TABLE IF EXISTS t;
 
 -- TODO(nickitat): Enforcing wide parts is a temporary workaround, not sure why collection doesn't work otherwise


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.137`
<!-- ch-version-info:end -->