### PR TITLE
More precisely calculate rows to skip when the runtime filter is used concurrently

### DIFF
--- a/src/Processors/QueryPlan/RuntimeFilterLookup.cpp
+++ b/src/Processors/QueryPlan/RuntimeFilterLookup.cpp
@@ -38,7 +38,7 @@ void IRuntimeFilter::updateStats(UInt64 rows_checked, UInt64 rows_passed) const
 
     /// Skip next 30 blocks if too few rows got filtered out
     if (static_cast<double>(rows_passed) > pass_ratio_threshold_for_disabling * static_cast<double>(rows_checked))
-        rows_to_skip = rows_checked * blocks_to_skip_before_reenabling;
+        rows_to_skip += rows_checked * blocks_to_skip_before_reenabling;
 }
 
 bool IRuntimeFilter::shouldSkip(size_t next_block_rows) const


### PR DESCRIPTION
If multiple threads concurrently decide to dynamically disable the runtime filter then each of those threads should add its portion to the rows_to_skip.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.153`
<!-- ch-version-info:end -->