### PR TITLE
Fix bug where SELECT in parens was confused for column list in INSERT query

### DIFF
--- a/src/Parsers/ParserInsertQuery.cpp
+++ b/src/Parsers/ParserInsertQuery.cpp
@@ -112,6 +112,8 @@ bool ParserInsertQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
         }
     }
 
+    Pos before_lparen = pos;
+
     /// Is there a list of columns
     if (s_lparen.ignore(pos, expected))
     {
@@ -121,8 +123,12 @@ bool ParserInsertQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
         /// Optional trailing comma
         ParserToken(TokenType::Comma).ignore(pos);
 
+        /// If this fails, we want to rewind to before the lparen so we can later check for (SELECT ...)
         if (!s_rparen.ignore(pos, expected))
-            return false;
+        {
+            columns.reset();
+            pos = before_lparen;
+        }
     }
 
     /// Check if file is a source of data.

--- a/tests/queries/0_stateless/03780_AST_formatting_inconsistencies_in_debug_check.reference
+++ b/tests/queries/0_stateless/03780_AST_formatting_inconsistencies_in_debug_check.reference
@@ -1,4 +1,3 @@
-These tests just need to run, dont care about output
 Test repeated alias for literal as 2nd arg to IN operator:
 [1]	1
 Test repeated alias for statement which is not a literal:
@@ -14,3 +13,5 @@ Test repeated alias for tuple after IN:
 (1,'a')	1
 Alias in ON clause of JOIN:
 Test repeated alias for tuple after NOT fails cleanly:
+Test that INSERT INTO with EXCEPT does not crash debug build:
+Test weird SELECT/EXCEPT/SELECT statement:

--- a/tests/queries/0_stateless/03780_AST_formatting_inconsistencies_in_debug_check.sql
+++ b/tests/queries/0_stateless/03780_AST_formatting_inconsistencies_in_debug_check.sql
@@ -1,6 +1,6 @@
 SET enable_analyzer = 1;
 
-SELECT 'These tests just need to run, dont care about output';
+--These tests just need to run, dont care about output
 SELECT 'Test repeated alias for literal as 2nd arg to IN operator:';
 SELECT ([1] AS foo), [1] IN ([1] AS foo);
 
@@ -22,7 +22,7 @@ SELECT 'Test repeated alias in subquery after NOT:';
 SELECT ((SELECT 1) AS a1), NOT ((SELECT 1) AS a1);
 
 SELECT 'Test repeated alias for tuple after IN:';
-select tuple(1, 'a') as a1, tuple(1, 'a') IN (tuple(1, 'a') as a1);
+SELECT tuple(1, 'a') AS a1, tuple(1, 'a') IN (tuple(1, 'a') AS a1);
 
 SELECT 'Alias in ON clause of JOIN:';
 CREATE TABLE t1 (x int);
@@ -31,4 +31,14 @@ SELECT * FROM t1 JOIN t2 ON ((t1.x = t2.x) AND (t1.x IS NULL) AS e2);
 DROP TABLE t1, t2;
 
 SELECT 'Test repeated alias for tuple after NOT fails cleanly:';
-select tuple(1, 'a') as a1, not (tuple(1, 'a') as a1); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT tuple(1, 'a') AS a1, NOT (tuple(1, 'a') AS a1); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+
+SELECT 'Test that INSERT INTO with EXCEPT does not crash debug build:';
+CREATE TABLE tab (c1 int, c2 int, c3 int);
+CREATE TABLE tab2 (c1 int, c2 int, c3 int);
+INSERT INTO tab2 SELECT * FROM tab EXCEPT SELECT * FROM tab;
+DROP TABLE tab;
+DROP TABLE tab2;
+
+SELECT 'Test weird SELECT/EXCEPT/SELECT statement:';
+SELECT 1,2,3 EXCEPT SELECT 1,2,3;

--- a/tests/queries/0_stateless/03786_AST_formatting_inconsistencies_in_debug_check.reference
+++ b/tests/queries/0_stateless/03786_AST_formatting_inconsistencies_in_debug_check.reference
@@ -1,39 +1,60 @@
-Original:  SELECT ([1] AS foo), [1] IN ([1] AS foo)
-Formatted: SELECT [1] AS foo, [1] IN ([1] AS foo)
+Original:          SELECT ([1] AS foo), [1] IN ([1] AS foo)
+format(original):  SELECT [1] AS foo, [1] IN ([1] AS foo)
+format(formatted): SELECT [1] AS foo, [1] IN ([1] AS foo)
 
-Original:  SELECT ([isNaN(1)] AS foo), [1] IN ([isNaN(1)] AS foo)
-Formatted: SELECT [isNaN(1)] AS foo, [1] IN ([isNaN(1)] AS foo)
+Original:          SELECT ([isNaN(1)] AS foo), [1] IN ([isNaN(1)] AS foo)
+format(original):  SELECT [isNaN(1)] AS foo, [1] IN ([isNaN(1)] AS foo)
+format(formatted): SELECT [isNaN(1)] AS foo, [1] IN ([isNaN(1)] AS foo)
 
-Original:  SELECT (-((-`c1`) AS `a2`)), NOT (-((-`c1`) AS `a2`)) from tab
-Formatted: SELECT -((-c1) AS a2), NOT (-((-c1) AS a2)) FROM tab
+Original:          SELECT (-((-`c1`) AS `a2`)), NOT (-((-`c1`) AS `a2`)) from tab
+format(original):  SELECT -((-c1) AS a2), NOT (-((-c1) AS a2)) FROM tab
+format(formatted): SELECT -((-c1) AS a2), NOT (-((-c1) AS a2)) FROM tab
 
-Original:  SELECT ((SELECT [1,2,3]) AS a1), [5] IN ((SELECT [1,2,3]) AS a1)
-Formatted: SELECT (SELECT [1, 2, 3]) AS a1, [5] IN ((SELECT [1, 2, 3]) AS a1)
+Original:          SELECT ((SELECT [1,2,3]) AS a1), [5] IN ((SELECT [1,2,3]) AS a1)
+format(original):  SELECT (SELECT [1, 2, 3]) AS a1, [5] IN ((SELECT [1, 2, 3]) AS a1)
+format(formatted): SELECT (SELECT [1, 2, 3]) AS a1, [5] IN ((SELECT [1, 2, 3]) AS a1)
 
-Original:  SELECT ((SELECT 1) AS a1), NOT ((SELECT 1) AS a1)
-Formatted: SELECT (SELECT 1) AS a1, NOT ((SELECT 1) AS a1)
+Original:          SELECT ((SELECT 1) AS a1), NOT ((SELECT 1) AS a1)
+format(original):  SELECT (SELECT 1) AS a1, NOT ((SELECT 1) AS a1)
+format(formatted): SELECT (SELECT 1) AS a1, NOT ((SELECT 1) AS a1)
 
-Original:  SELECT tuple(1, 'a') as a1, tuple(1, 'a') IN (tuple(1, 'a') as a1)
-Formatted: SELECT tuple(1, 'a') AS a1, tuple(1, 'a') IN (tuple(1, 'a') AS a1)
+Original:          SELECT tuple(1, 'a') as a1, tuple(1, 'a') IN (tuple(1, 'a') as a1)
+format(original):  SELECT tuple(1, 'a') AS a1, tuple(1, 'a') IN (tuple(1, 'a') AS a1)
+format(formatted): SELECT tuple(1, 'a') AS a1, tuple(1, 'a') IN (tuple(1, 'a') AS a1)
 
-Original:  SELECT * FROM t1 JOIN t2 ON ((t1.x = t2.x) AND (t1.x IS NULL) AS e2)
-Formatted: SELECT * FROM t1 INNER JOIN t2 ON ((t1.x = t2.x) AND (t1.x IS NULL) AS e2)
+Original:          SELECT * FROM t1 JOIN t2 ON ((t1.x = t2.x) AND (t1.x IS NULL) AS e2)
+format(original):  SELECT * FROM t1 INNER JOIN t2 ON ((t1.x = t2.x) AND (t1.x IS NULL) AS e2)
+format(formatted): SELECT * FROM t1 INNER JOIN t2 ON ((t1.x = t2.x) AND (t1.x IS NULL) AS e2)
 
-Original:  SELECT (1,1) c0, (1,(1)) c0
-Formatted: SELECT (1, 1) AS c0, (1, 1) AS c0
+Original:          SELECT (1,1) c0, (1,(1)) c0
+format(original):  SELECT (1, 1) AS c0, (1, 1) AS c0
+format(formatted): SELECT (1, 1) AS c0, (1, 1) AS c0
 
-Original:  SELECT (1, (1 AS c0, 1 AS c0) IS NULL AS c0), (1, (1, 1 AS c0) IS NULL AS c0) IS NULL AS c0
-Formatted: SELECT (1, (1 AS c0, 1 AS c0) IS NULL AS c0), (1, (1, 1 AS c0) IS NULL AS c0) IS NULL AS c0
+Original:          SELECT (1, (1 AS c0, 1 AS c0) IS NULL AS c0), (1, (1, 1 AS c0) IS NULL AS c0) IS NULL AS c0
+format(original):  SELECT (1, (1 AS c0, 1 AS c0) IS NULL AS c0), (1, (1, 1 AS c0) IS NULL AS c0) IS NULL AS c0
+format(formatted): SELECT (1, (1 AS c0, 1 AS c0) IS NULL AS c0), (1, (1, 1 AS c0) IS NULL AS c0) IS NULL AS c0
 
-Original:  SELECT NOT ((1, 1, 1))
-Formatted: SELECT NOT ((1, 1, 1))
+Original:          SELECT NOT ((1, 1, 1))
+format(original):  SELECT NOT ((1, 1, 1))
+format(formatted): SELECT NOT ((1, 1, 1))
 
-Original:  select (((1), (2)))
-Formatted: SELECT (1, 2)
+Original:          select (((1), (2)))
+format(original):  SELECT (1, 2)
+format(formatted): SELECT (1, 2)
 
-Original:  select * from tuple('42', '3141592')
-Formatted: SELECT * FROM tuple('42', '3141592')
+Original:          select * from tuple('42', '3141592')
+format(original):  SELECT * FROM tuple('42', '3141592')
+format(formatted): SELECT * FROM tuple('42', '3141592')
 
-Original:  SELECT 1 FROM VALUES (1, (NOT 1 IS NULL)) tx
-Formatted: SELECT 1 FROM VALUES(1, NOT (1 IS NULL)) AS tx
+Original:          SELECT 1 FROM VALUES (1, (NOT 1 IS NULL)) tx
+format(original):  SELECT 1 FROM VALUES(1, NOT (1 IS NULL)) AS tx
+format(formatted): SELECT 1 FROM VALUES(1, NOT (1 IS NULL)) AS tx
+
+Original:          INSERT INTO tab2 SELECT * FROM tab EXCEPT SELECT * FROM tab;
+format(original):  INSERT INTO tab2 (SELECT * FROM tab) EXCEPT (SELECT * FROM tab)
+format(formatted): INSERT INTO tab2 (SELECT * FROM tab) EXCEPT (SELECT * FROM tab)
+
+Original:          SELECT 1,2,3 EXCEPT SELECT 1,2,3;
+format(original):  (SELECT 1, 2, 3) EXCEPT (SELECT 1, 2, 3)
+format(formatted): (SELECT 1, 2, 3) EXCEPT (SELECT 1, 2, 3)
 

--- a/tests/queries/0_stateless/03786_AST_formatting_inconsistencies_in_debug_check.sh
+++ b/tests/queries/0_stateless/03786_AST_formatting_inconsistencies_in_debug_check.sh
@@ -10,8 +10,10 @@ ch_format() {
 
 format_query() {
   local query="$1"
-  echo "Original:  $query"
-  echo 'Formatted:' "$(echo "$query" | ch_format)"
+  echo "Original:          $query"
+  local formatted="$(echo "$query" | ch_format)"
+  echo "format(original):  $formatted"
+  echo 'format(formatted):' "$(echo "$formatted" | ch_format)"
   echo
 }
 
@@ -43,3 +45,9 @@ format_query "SELECT NOT ((1, 1, 1))"
 format_query "select (((1), (2)))"
 format_query "select * from tuple('42', '3141592')"
 format_query "SELECT 1 FROM VALUES (1, (NOT 1 IS NULL)) tx"
+
+# Test that INSERT INTO with EXCEPT does not crash debug build
+format_query "INSERT INTO tab2 SELECT * FROM tab EXCEPT SELECT * FROM tab;"
+
+# Test weird SELECT/EXCEPT/SELECT statement
+format_query "SELECT 1,2,3 EXCEPT SELECT 1,2,3;"


### PR DESCRIPTION
Fix issue with allowing parentheses around SELECT inside a INSERT INTO query. This resolves https://github.com/ClickHouse/ClickHouse/issues/90925.

The original PR that allowed the parentheses around the SELECT inside INSERT is [here](https://github.com/ClickHouse/ClickHouse/pull/95057).

The issue was that a query like this:

```insert into tab2 (select * from tab) except (select * from tab)```

could not be parsed, since the first `SELECT` was parsed as a column name and then the parser failed on the `*`. This was due to the left paren being assumed to be the start of a column list, and if that failed then the whole query failed. The fix was to not fail immediately here and allow the parser a chance to parse the same expression as a SELECT.


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.279`
<!-- ch-version-info:end -->