### PR TITLE
Fix `IN` function returning incorrect results with `NULL` values when `transform_null_in` is enabled

### DIFF
--- a/src/Interpreters/convertFieldToType.cpp
+++ b/src/Interpreters/convertFieldToType.cpp
@@ -857,7 +857,6 @@ std::optional<Field> convertFieldToTypeStrict(const Field & from_value, const ID
 
     /// For Float64 -> Decimal conversions, the "strictness" check is done by converting the Decimal back to Float64
     /// and comparing with the original Float64. This prevents surprising membership results like:
-    ///
     /// Example:
     ///   SELECT CAST('33.3', 'Decimal64(1)') IN (33.33); -- 0 (RHS would round to 33.3 without strict check)
     ///   SELECT CAST('33.3', 'Decimal64(1)') IN (33.3);  -- 1

--- a/src/Interpreters/convertFieldToType.cpp
+++ b/src/Interpreters/convertFieldToType.cpp
@@ -817,28 +817,54 @@ static bool decimalEqualsFloat(Field field, Float64 float_value)
     return decimal_to_float == float_value;
 }
 
+static bool decimalEqualsFloatByType(const Field & decimal_field, Float64 float_value)
+{
+    switch (decimal_field.getType())
+    {
+        case Field::Types::Decimal32:
+            return decimalEqualsFloat<Decimal32>(decimal_field, float_value);
+        case Field::Types::Decimal64:
+            return decimalEqualsFloat<Decimal64>(decimal_field, float_value);
+        case Field::Types::Decimal128:
+            return decimalEqualsFloat<Decimal128>(decimal_field, float_value);
+        case Field::Types::Decimal256:
+            return decimalEqualsFloat<Decimal256>(decimal_field, float_value);
+        default:
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Unknown decimal type {}", decimal_field.getTypeName());
+    }
+}
+
 std::optional<Field> convertFieldToTypeStrict(const Field & from_value, const IDataType & from_type, const IDataType & to_type, const FormatSettings & format_settings)
 {
     Field result_value = convertFieldToType(from_value, to_type, &from_type, format_settings);
 
-    if (Field::isDecimal(from_value.getType()) && Field::isDecimal(result_value.getType()))
+    /// `convertFieldToType` returns NULL on failed conversion (out-of-range, loss of precision, etc).
+    /// For strict conversions we treat it as "not representable" and return empty optional,
+    /// but keep NULL -> NULL conversion valid.
+    if (!from_value.isNull() && result_value.isNull())
+        return std::nullopt;
+
+    /// For Decimal -> Decimal conversions, `convertFieldToType` may round/truncate (e.g. due to different scales).
+    /// Strict mode rejects any lossy conversion by requiring exact equality after conversion.
+    /// This is used by IN to avoid inserting values that cannot exist in the LHS type.
+    /// Example:
+    ///   SELECT CAST('33.3', 'Decimal64(1)') IN (CAST('33.33', 'Decimal64(2)')); -- 0 (would be 1 without following check)
+    ///   SELECT CAST('33.3', 'Decimal64(1)') IN (CAST('33.30', 'Decimal64(2)')); -- 1
+    if (Field::isDecimal(from_value.getType()) && Field::isDecimal(result_value.getType()) && !accurateEquals(from_value, result_value))
     {
-        bool is_equal = accurateEquals(from_value, result_value);
-        return is_equal ? result_value : std::optional<Field>{};
+        return std::nullopt;
     }
 
+    /// For Float64 -> Decimal conversions, the "strictness" check is done by converting the Decimal back to Float64
+    /// and comparing with the original Float64. This prevents surprising membership results like:
+    ///
+    /// Example:
+    ///   SELECT CAST('33.3', 'Decimal64(1)') IN (33.33); -- 0 (RHS would round to 33.3 without strict check)
+    ///   SELECT CAST('33.3', 'Decimal64(1)') IN (33.3);  -- 1
     if (from_value.getType() == Field::Types::Float64 && Field::isDecimal(result_value.getType()))
     {
-        /// Convert back to Float64 and compare
-        if (result_value.getType() == Field::Types::Decimal32)
-            return decimalEqualsFloat<Decimal32>(result_value, from_value.safeGet<Float64>()) ? result_value : std::optional<Field>{};
-        if (result_value.getType() == Field::Types::Decimal64)
-            return decimalEqualsFloat<Decimal64>(result_value, from_value.safeGet<Float64>()) ? result_value : std::optional<Field>{};
-        if (result_value.getType() == Field::Types::Decimal128)
-            return decimalEqualsFloat<Decimal128>(result_value, from_value.safeGet<Float64>()) ? result_value : std::optional<Field>{};
-        if (result_value.getType() == Field::Types::Decimal256)
-            return decimalEqualsFloat<Decimal256>(result_value, from_value.safeGet<Float64>()) ? result_value : std::optional<Field>{};
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Unknown decimal type {}", result_value.getTypeName());
+        if (!decimalEqualsFloatByType(result_value, from_value.safeGet<Float64>()))
+            return std::nullopt;
     }
 
     return result_value;

--- a/tests/queries/0_stateless/03393_non_constant_second_argument_for_in.reference
+++ b/tests/queries/0_stateless/03393_non_constant_second_argument_for_in.reference
@@ -72,7 +72,7 @@ SELECT
     NULL IN (1, NULL)  
 FROM numbers(1)  
 SETTINGS transform_null_in = 1;
-0	1	1	1
+0	1	0	1
 SELECT  
     NULL IN (1, number),  
     NULL IN (1, number, NULL),  

--- a/tests/queries/0_stateless/03814_in_function_strict_conversion.reference
+++ b/tests/queries/0_stateless/03814_in_function_strict_conversion.reference
@@ -1,0 +1,63 @@
+-- { echo }
+
+SELECT
+    CAST('33.3', 'Decimal64(1)') IN (CAST('33.33', 'Decimal64(2)')),
+    CAST('33.3', 'Decimal64(1)') IN (CAST('33.30', 'Decimal64(2)'));
+0	1
+SELECT
+    CAST('33.3','Decimal32(1)') IN (33.33),
+    CAST('33.3','Decimal32(1)') IN (33.3);
+0	1
+SELECT
+    CAST('33.3','Decimal64(1)') IN (33.33),
+    CAST('33.3','Decimal64(1)') IN (33.3);
+0	1
+SELECT
+    CAST('33.3','Decimal128(1)') IN (33.33),
+    CAST('33.3','Decimal128(1)') IN (33.3);
+0	1
+SELECT
+    CAST('33.3','Decimal256(1)') IN (33.33),
+    CAST('33.3','Decimal256(1)') IN (33.3);
+0	1
+SELECT NULL IN 1;
+\N
+SELECT CAST(NULL, 'Nullable(Int64)') IN (1.1);
+\N
+SELECT CAST(NULL, 'Nullable(Int64)') IN (NULL, 1.1);
+\N
+SELECT NULL IN (NULL);
+\N
+SELECT NULL IN (NULL, 1);
+\N
+SELECT (1, NULL) IN (1, 1);
+0
+SELECT (1, NULL) IN (1, NULL);
+0
+SELECT (1, NULL) IN ((1, 1), (NULL, 1));
+0
+SELECT NULL IN (1, 2, 3);
+\N
+SELECT (1, NULL) IN [(1, 1)];
+0
+SET transform_null_in = 1;
+SELECT NULL IN 1;
+0
+SELECT CAST(NULL, 'Nullable(Int64)') IN (1.1);
+0
+SELECT CAST(NULL, 'Nullable(Int64)') IN (NULL, 1.1);
+1
+SELECT NULL IN (NULL);
+1
+SELECT NULL IN (NULL, 1);
+1
+SELECT (1, NULL) IN (1, 1);
+0
+SELECT (1, NULL) IN (1, NULL);
+1
+SELECT (1, NULL) IN ((1, 1), (NULL, 1));
+0
+SELECT NULL IN (1, 2, 3);
+0
+SELECT (1, NULL) IN [(1, 1)];
+0

--- a/tests/queries/0_stateless/03814_in_function_strict_conversion.sql
+++ b/tests/queries/0_stateless/03814_in_function_strict_conversion.sql
@@ -1,0 +1,65 @@
+-- { echo }
+
+SELECT
+    CAST('33.3', 'Decimal64(1)') IN (CAST('33.33', 'Decimal64(2)')),
+    CAST('33.3', 'Decimal64(1)') IN (CAST('33.30', 'Decimal64(2)'));
+
+SELECT
+    CAST('33.3','Decimal32(1)') IN (33.33),
+    CAST('33.3','Decimal32(1)') IN (33.3);
+
+SELECT
+    CAST('33.3','Decimal64(1)') IN (33.33),
+    CAST('33.3','Decimal64(1)') IN (33.3);
+
+SELECT
+    CAST('33.3','Decimal128(1)') IN (33.33),
+    CAST('33.3','Decimal128(1)') IN (33.3);
+
+SELECT
+    CAST('33.3','Decimal256(1)') IN (33.33),
+    CAST('33.3','Decimal256(1)') IN (33.3);
+
+
+SELECT NULL IN 1;
+
+SELECT CAST(NULL, 'Nullable(Int64)') IN (1.1);
+
+SELECT CAST(NULL, 'Nullable(Int64)') IN (NULL, 1.1);
+
+SELECT NULL IN (NULL);
+
+SELECT NULL IN (NULL, 1);
+
+SELECT (1, NULL) IN (1, 1);
+
+SELECT (1, NULL) IN (1, NULL);
+
+SELECT (1, NULL) IN ((1, 1), (NULL, 1));
+
+SELECT NULL IN (1, 2, 3);
+
+SELECT (1, NULL) IN [(1, 1)];
+
+
+SET transform_null_in = 1;
+
+SELECT NULL IN 1;
+
+SELECT CAST(NULL, 'Nullable(Int64)') IN (1.1);
+
+SELECT CAST(NULL, 'Nullable(Int64)') IN (NULL, 1.1);
+
+SELECT NULL IN (NULL);
+
+SELECT NULL IN (NULL, 1);
+
+SELECT (1, NULL) IN (1, 1);
+
+SELECT (1, NULL) IN (1, NULL);
+
+SELECT (1, NULL) IN ((1, 1), (NULL, 1));
+
+SELECT NULL IN (1, 2, 3);
+
+SELECT (1, NULL) IN [(1, 1)];


### PR DESCRIPTION
This returns 1 but should be 0.

```sql
SELECT NULL IN 1 SETTINGS transform_null_in = 1;
```

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `IN` function returning incorrect results with `NULL` values when `transform_null_in` is enabled. Closes https://github.com/ClickHouse/ClickHouse/issues/65776.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.503`
<!-- ch-version-info:end -->