### PR TITLE
tests: disable 03820_plain_rewritable_over_another_disk_with_same_path for replicated database

### DIFF
--- a/tests/queries/0_stateless/03820_plain_rewritable_over_another_disk_with_same_path.sh
+++ b/tests/queries/0_stateless/03820_plain_rewritable_over_another_disk_with_same_path.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest
+# Tags: no-fasttest, no-replicated-database
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
**This should help to make database replicated job feels better**

DROP will fail on replicas, since it got already removed by another one:

    2026.01.29 22:19:10.111119 [ 3338 ] {} <Trace> test_z0avgn3s.mt1 (dc95d797-edeb-4b9e-9bc9-116be1f79e2b): dropAllData: waiting for locks.
    2026.01.29 22:19:10.111149 [ 3338 ] {} <Trace> test_z0avgn3s.mt1 (dc95d797-edeb-4b9e-9bc9-116be1f79e2b): dropAllData: removing data parts (count 0) from filesystem.
    2026.01.29 22:19:10.111165 [ 3338 ] {} <Trace> test_z0avgn3s.mt1 (dc95d797-edeb-4b9e-9bc9-116be1f79e2b): dropAllData: removing all data parts from memory.
    2026.01.29 22:19:10.111168 [ 3338 ] {} <Information> test_z0avgn3s.mt1 (dc95d797-edeb-4b9e-9bc9-116be1f79e2b): dropAllData: clearing temporary directories
    2026.01.29 22:19:10.111263 [ 3338 ] {} <Information> test_z0avgn3s.mt1 (dc95d797-edeb-4b9e-9bc9-116be1f79e2b): dropAllData: remove format_version.txt, detached, moving and write ahead logs
    2026.01.29 22:19:10.113365 [ 3338 ] {} <Trace> deleteFileFromS3: Writing Delete operation for blob s3_plain_rewritable_test_z0avgn3s_cache_on_write_operations_0/__root/npbpeljcyluzehcd
    2026.01.29 22:19:10.113398 [ 3338 ] {} <Debug> deleteFileFromS3: Object with path s3_plain_rewritable_test_z0avgn3s_cache_on_write_operations_0/__root/npbpeljcyluzehcd was removed from S3
    2026.01.29 22:19:10.113550 [ 3338 ] {} <Error> DatabaseCatalog: Cannot drop table test_z0avgn3s.mt1 (dc95d797-edeb-4b9e-9bc9-116be1f79e2b). Will retry later.: Code: 499. DB::Exception: Failed to get object info: No response body.. HTTP response code: 404: While committing metadata operation #0. (S3_ERROR), Stack trace (when copying this message, always include the lines below):


But note, that for this to happen failed replica should be slow, that slow that the `__root` metadata in `plain_rewriteable` already removed by another replica

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.140`
<!-- ch-version-info:end -->