### PR TITLE
Forward aws to 1.11.712

### DIFF
--- a/contrib/aws-cmake/CMakeLists.txt
+++ b/contrib/aws-cmake/CMakeLists.txt
@@ -117,6 +117,8 @@ file(GLOB AWS_SDK_CORE_SRC
     "${AWS_SDK_CORE_DIR}/source/utils/xml/*.cpp"
 )
 
+list(REMOVE_ITEM AWS_SDK_CORE_SRC "${AWS_SDK_CORE_DIR}/source/auth/LoginCredentialsProvider.cpp")
+
 if(OS_LINUX OR OS_DARWIN)
     file(GLOB AWS_SDK_CORE_NET_SRC "${AWS_SDK_CORE_DIR}/source/net/linux-shared/*.cpp")
     file(GLOB AWS_SDK_CORE_PLATFORM_SRC "${AWS_SDK_CORE_DIR}/source/platform/linux-shared/*.cpp")

--- a/src/IO/S3/Client.cpp
+++ b/src/IO/S3/Client.cpp
@@ -696,7 +696,7 @@ Client::doRequest(RequestType & request, RequestFn request_fn) const
         if (checkIfCredentialsChanged(error))
         {
             LOG_INFO(log, "Credentials changed, attempting again");
-            credentials_provider->SetNeedRefresh();
+            credentials_provider->GetAWSCredentials();
             continue;
         }
 

--- a/src/IO/S3/Credentials.cpp
+++ b/src/IO/S3/Credentials.cpp
@@ -691,11 +691,11 @@ AwsAuthSTSAssumeRoleWebIdentityCredentialsProvider::AwsAuthSTSAssumeRoleWebIdent
 Aws::Auth::AWSCredentials AwsAuthSTSAssumeRoleWebIdentityCredentialsProvider::GetAWSCredentials()
 {
     Aws::Utils::Threading::ReaderLockGuard guard(m_reloadLock);
-    if (!IsSetNeedRefresh() && !areCredentialsEmptyOrExpired(credentials, expiration_window_seconds))
+    if (!areCredentialsEmptyOrExpired(credentials, expiration_window_seconds))
         return credentials;
 
     guard.UpgradeToWriterLock();
-    if (!IsSetNeedRefresh() && !areCredentialsEmptyOrExpired(credentials, expiration_window_seconds)) // double-checked lock to avoid refreshing twice
+    if (!areCredentialsEmptyOrExpired(credentials, expiration_window_seconds)) // double-checked lock to avoid refreshing twice
         return credentials;
 
     Reload();
@@ -809,12 +809,12 @@ void SSOCredentialsProvider::Reload()
 void SSOCredentialsProvider::refreshIfExpired()
 {
     Aws::Utils::Threading::ReaderLockGuard guard(m_reloadLock);
-    if (!IsSetNeedRefresh() && !areCredentialsEmptyOrExpired(credentials, expiration_window_seconds))
+    if (!areCredentialsEmptyOrExpired(credentials, expiration_window_seconds))
         return;
 
     guard.UpgradeToWriterLock();
 
-    if (!IsSetNeedRefresh() && !areCredentialsEmptyOrExpired(credentials, expiration_window_seconds)) // double-checked lock to avoid refreshing twice
+    if (!areCredentialsEmptyOrExpired(credentials, expiration_window_seconds)) // double-checked lock to avoid refreshing twice
         return;
 
     Reload();


### PR DESCRIPTION
This PR aims to fix CVE-2025-14760 by forwarding aws library to 1.11.712. It needs to be backported to 25.8 and 25.3
### Changelog category (leave one):
- Build/Testing/Packaging Improvement



### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Bump aws from 1.11.712. This addresses aws' CVE-2025-14760