### PR TITLE
ci: add libc6-dbg into all CI images

### DIFF
--- a/ci/docker/fuzzer/Dockerfile
+++ b/ci/docker/fuzzer/Dockerfile
@@ -8,7 +8,6 @@ ENV LANG=C.UTF-8
 # Install additional packages needed for fuzzer that are not in test-base
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
-            libc6-dbg \
             ncdu \
             p7zip-full \
             parallel \

--- a/ci/docker/libfuzzer/Dockerfile
+++ b/ci/docker/libfuzzer/Dockerfile
@@ -16,7 +16,6 @@ RUN apt-get update \
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
-            libc6-dbg \
             moreutils \
             ncdu \
             p7zip-full \

--- a/ci/docker/performance-comparison/Dockerfile
+++ b/ci/docker/performance-comparison/Dockerfile
@@ -15,7 +15,6 @@ RUN apt-get update \
             git \
             gnuplot \
             imagemagick \
-            libc6-dbg \
             moreutils \
             ncdu \
             numactl \

--- a/ci/docker/test-base/Dockerfile
+++ b/ci/docker/test-base/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update \
 
 RUN apt-get update \
     && apt-get install \
+        libc6-dbg \
         sudo \
         apt-transport-https \
         apt-utils \


### PR DESCRIPTION
This should show complete stacktraces inside libc, i.e. for cases like https://github.com/ClickHouse/ClickHouse/issues/92297

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.145`
<!-- ch-version-info:end -->