### PR TITLE
Log std::logic_error before abort()

### DIFF
--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -862,6 +862,7 @@ void TCPHandler::runImpl()
 #ifdef DEBUG_OR_SANITIZER_BUILD
         catch (const std::logic_error & e)
         {
+            tryLogCurrentException(log);
             if (query_state)
                 query_state->io.onException();
             exception = std::make_unique<DB::Exception>(Exception::CreateFromSTDTag{}, e);


### PR DESCRIPTION
Will help with cases like [1], since it is quiet hard to understand what went wrong now:

    $ podman run --privileged -v ./clickhouse:/bin/clickhouse -v ./core:/core -e --rm -it ubuntu:22.04
    $ gdb clickhouse /core
    (gdb) f 5
    (gdb) p e
    $1 = <optimized out>

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=44ca60cd484bcc7a4234c7a0d70e70dffab73610&name_0=MasterCI&name_1=AST%20fuzzer%20%28amd_debug%29&name_1=AST%20fuzzer%20%28amd_debug%29

_Though here is a fix for a crash - https://github.com/ClickHouse/ClickHouse/pull/95687_

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.149`
<!-- ch-version-info:end -->