### PR TITLE
Fix possible UB in case of too big max_query_size (fixes AST fuzzer on CI)

### DIFF
--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -1368,7 +1368,12 @@ static BlockIO executeQueryImpl(
     {
         /// Anyway log the query.
         if (query.empty())
-            query.assign(begin, std::min(end - begin, static_cast<ptrdiff_t>(max_query_size)));
+        {
+            size_t query_size = end - begin;
+            if (max_query_size != 0 && query_size > max_query_size)
+                query_size = max_query_size;
+            query.assign(begin, query_size);
+        }
 
         query_for_logging = wipeSensitiveDataAndCutToLength(query, log_queries_cut_to_length, true);
         logQuery(query_for_logging, context, internal, stage);

--- a/tests/queries/0_stateless/03830_max_query_size_ub.reference
+++ b/tests/queries/0_stateless/03830_max_query_size_ub.reference
@@ -1,0 +1,1 @@
+exception: Empty query. (SYNTAX_ERROR) (version 26.2.1.1)

--- a/tests/queries/0_stateless/03830_max_query_size_ub.sh
+++ b/tests/queries/0_stateless/03830_max_query_size_ub.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&max_query_size=18446744073709551615" -d "EXPLAIN TABLE OVERRIDE  SELECT 1,    1" |& grep -o "Exception.*" | sed 's/Exception/exception/g'


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix possible UB in case of too big `max_query_size`

I've extracted everything from the core file from [1] and the query was:

    EXPLAIN TABLE OVERRIDE  SELECT 1,    1 SETTINGS max_query_size = 18446744073709551615

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=44ca60cd484bcc7a4234c7a0d70e70dffab73610&name_0=MasterCI&name_1=AST%20fuzzer%20%28amd_debug%29&name_1=AST%20fuzzer%20%28amd_debug%29
