### PR TITLE
Fix crash in Kusto functions when empty arguments are provided

### DIFF
--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -415,7 +415,7 @@ ASTPtr ClientBase::parseQuery(const char *& pos, const char * end, const Setting
         try
         {
             if (dialect == Dialect::kusto)
-                res = tryParseKQLQuery(*parser, pos, end, message, true, "", allow_multi_statements, max_length, settings[Setting::max_parser_depth], settings[Setting::max_parser_backtracks], true);
+                res = tryParseKQLQuery(*parser, pos, end, message, nullptr, true, "", allow_multi_statements, max_length, settings[Setting::max_parser_depth], settings[Setting::max_parser_backtracks], true);
             else
                 res = tryParseQuery(*parser, pos, end, message, true, "", allow_multi_statements, max_length, settings[Setting::max_parser_depth], settings[Setting::max_parser_backtracks], true);
         }

--- a/src/Parsers/Kusto/KustoFunctions/IParserKQLFunction.cpp
+++ b/src/Parsers/Kusto/KustoFunctions/IParserKQLFunction.cpp
@@ -146,8 +146,6 @@ String IParserKQLFunction::getConvertedArgument(const String & fn_name, IParser:
 {
     int32_t round_bracket_count = 0;
     int32_t square_bracket_count = 0;
-    if (pos->type == TokenType::ClosingRoundBracket || pos->type == TokenType::ClosingSquareBracket)
-        return {};
 
     if (!isValidKQLPos(pos) || pos->type == TokenType::PipeMark || pos->type == TokenType::Semicolon)
         throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Need more argument(s) in function: {}", fn_name);
@@ -232,7 +230,9 @@ IParserKQLFunction::getOptionalArgument(const String & function_name, DB::IParse
         return {};
 
     ++pos;
-    if (const auto type = pos->type; type == DB::TokenType::ClosingRoundBracket || type == DB::TokenType::ClosingSquareBracket)
+    if (const auto type = pos->type;
+        type == DB::TokenType::ClosingRoundBracket || type == DB::TokenType::ClosingSquareBracket
+            || type == DB::TokenType::Comma)
         return {};
 
     if (argument_state == ArgumentState::Parsed)

--- a/src/Parsers/Kusto/KustoFunctions/KQLGeneralFunctions.cpp
+++ b/src/Parsers/Kusto/KustoFunctions/KQLGeneralFunctions.cpp
@@ -115,8 +115,9 @@ bool BinAt::convertImpl(String & out, IParser::Pos & pos)
     String original_expr(pos->begin, pos->end);
 
     String expression_str = getConvertedArgument(fn_name, pos);
-    expression_str.erase(std::remove_if(expression_str.begin(), expression_str.end(), [](unsigned char c) { return std::isspace(c); }), expression_str.end());
-    if (expression_str.empty())
+    String expression_no_spaces = expression_str;
+    expression_no_spaces.erase(std::remove_if(expression_no_spaces.begin(), expression_no_spaces.end(), [](unsigned char c) { return std::isspace(c); }), expression_no_spaces.end());
+    if (expression_no_spaces.empty())
         return false;
 
     ++pos;
@@ -127,8 +128,9 @@ bool BinAt::convertImpl(String & out, IParser::Pos & pos)
 
     ++pos;
     String fixed_point_str = getConvertedArgument(fn_name, pos);
-    fixed_point_str.erase(std::remove_if(fixed_point_str.begin(), fixed_point_str.end(), [](unsigned char c) { return std::isspace(c); }), fixed_point_str.end());
-    if (fixed_point_str.empty())
+    String fixed_point_no_spaces = fixed_point_str;
+    fixed_point_no_spaces.erase(std::remove_if(fixed_point_no_spaces.begin(), fixed_point_no_spaces.end(), [](unsigned char c) { return std::isspace(c); }), fixed_point_no_spaces.end());
+    if (fixed_point_no_spaces.empty())
         return false;
 
     auto t1 = fmt::format("toFloat64({})", fixed_point_str);

--- a/src/Parsers/Kusto/KustoFunctions/KQLGeneralFunctions.cpp
+++ b/src/Parsers/Kusto/KustoFunctions/KQLGeneralFunctions.cpp
@@ -24,11 +24,6 @@
 #include <fmt/format.h>
 #include <stdexcept>
 
-namespace DB::ErrorCodes
-{
-extern const int SYNTAX_ERROR;
-}
-
 namespace DB
 {
 

--- a/src/Parsers/Kusto/KustoFunctions/KQLGeneralFunctions.cpp
+++ b/src/Parsers/Kusto/KustoFunctions/KQLGeneralFunctions.cpp
@@ -45,10 +45,9 @@ bool Bin::convertImpl(String & out, IParser::Pos & pos)
 
     ++pos;
     String round_to = getConvertedArgument(fn_name, pos);
+    round_to.erase(std::remove_if(round_to.begin(), round_to.end(), [](unsigned char c) { return std::isspace(c); }), round_to.end());
     if (round_to.empty())
         return false;
-
-    round_to.erase(std::remove_if(round_to.begin(), round_to.end(), [](unsigned char c) { return std::isspace(c); }), round_to.end());
 
     String value_no_spaces = value;
     value_no_spaces.erase(std::remove_if(value_no_spaces.begin(), value_no_spaces.end(), [](unsigned char c) { return std::isspace(c); }), value_no_spaces.end());
@@ -116,21 +115,21 @@ bool BinAt::convertImpl(String & out, IParser::Pos & pos)
     String original_expr(pos->begin, pos->end);
 
     String expression_str = getConvertedArgument(fn_name, pos);
+    expression_str.erase(std::remove_if(expression_str.begin(), expression_str.end(), [](unsigned char c) { return std::isspace(c); }), expression_str.end());
     if (expression_str.empty())
         return false;
-    expression_str.erase(std::remove_if(expression_str.begin(), expression_str.end(), [](unsigned char c) { return std::isspace(c); }), expression_str.end());
 
     ++pos;
     String bin_size_str = getConvertedArgument(fn_name, pos);
+    bin_size_str.erase(std::remove_if(bin_size_str.begin(), bin_size_str.end(), [](unsigned char c) { return std::isspace(c); }), bin_size_str.end());
     if (bin_size_str.empty())
         return false;
-    bin_size_str.erase(std::remove_if(bin_size_str.begin(), bin_size_str.end(), [](unsigned char c) { return std::isspace(c); }), bin_size_str.end());
 
     ++pos;
     String fixed_point_str = getConvertedArgument(fn_name, pos);
+    fixed_point_str.erase(std::remove_if(fixed_point_str.begin(), fixed_point_str.end(), [](unsigned char c) { return std::isspace(c); }), fixed_point_str.end());
     if (fixed_point_str.empty())
         return false;
-    fixed_point_str.erase(std::remove_if(fixed_point_str.begin(), fixed_point_str.end(), [](unsigned char c) { return std::isspace(c); }), fixed_point_str.end());
 
     auto t1 = fmt::format("toFloat64({})", fixed_point_str);
     auto t2 = fmt::format("toFloat64({})", expression_str);
@@ -142,7 +141,10 @@ bool BinAt::convertImpl(String & out, IParser::Pos & pos)
     }
     catch (const std::exception &)
     {
-        return false;
+        ParserKQLDateTypeTimespan time_span_parser;
+        if (!time_span_parser.parseConstKQLTimespan(bin_size_str))
+            return false;
+        bin_size = time_span_parser.toSeconds();
     }
 
     // validate if bin_size is a positive number

--- a/src/Parsers/Kusto/KustoFunctions/KQLGeneralFunctions.cpp
+++ b/src/Parsers/Kusto/KustoFunctions/KQLGeneralFunctions.cpp
@@ -14,10 +14,15 @@
 #include <Parsers/Kusto/ParserKQLDateTypeTimespan.h>
 #include <Parsers/Kusto/ParserKQLQuery.h>
 #include <Parsers/Kusto/ParserKQLStatement.h>
+#include <Parsers/Kusto/Utilities.h>
 #include <Parsers/ParserSetQuery.h>
+#include <Common/Exception.h>
 #include <boost/lexical_cast.hpp>
 
+#include <algorithm>
+#include <cctype>
 #include <fmt/format.h>
+#include <stdexcept>
 
 namespace DB::ErrorCodes
 {
@@ -34,25 +39,63 @@ bool Bin::convertImpl(String & out, IParser::Pos & pos)
     if (fn_name.empty())
         return false;
 
+
     ++pos;
-    String origal_expr(pos->begin, pos->end);
+
+    String original_expr(pos->begin, pos->end);
+
     String value = getConvertedArgument(fn_name, pos);
+    if (value.empty())
+        return false;
 
     ++pos;
     String round_to = getConvertedArgument(fn_name, pos);
+    if (round_to.empty())
+        return false;
 
-    //remove sapce between minus and number
-    round_to.erase(std::remove_if(round_to.begin(), round_to.end(), isspace), round_to.end());
+    round_to.erase(std::remove_if(round_to.begin(), round_to.end(), [](unsigned char c) { return std::isspace(c); }), round_to.end());
+
+    String value_no_spaces = value;
+    value_no_spaces.erase(std::remove_if(value_no_spaces.begin(), value_no_spaces.end(), [](unsigned char c) { return std::isspace(c); }), value_no_spaces.end());
+    if (value_no_spaces.empty())
+        return false;
+    try
+    {
+        size_t pos_end = 0;
+        std::stod(value_no_spaces, &pos_end);
+        if (pos_end != value_no_spaces.size())
+            throw std::invalid_argument("not a number");
+    }
+    catch (const std::exception &)
+    {
+        ParserKQLDateTypeTimespan value_tsp;
+        if (value_tsp.parseConstKQLTimespan(value_no_spaces))
+            value = std::to_string(value_tsp.toSeconds());
+    }
 
     auto t = fmt::format("toFloat64({})", value);
 
-    bin_size = std::stod(round_to);
+    try
+    {
+        bin_size = std::stod(round_to);
+    }
+    catch (const std::exception &)
+    {
+        ParserKQLDateTypeTimespan time_span_parser;
+        if (!time_span_parser.parseConstKQLTimespan(round_to))
+            return false;
+        bin_size = time_span_parser.toSeconds();
+    }
 
-    if (origal_expr == "datetime" || origal_expr == "date")
+    if (bin_size <= 0)
+        return false;
+
+    // Use datetime output whenever first argument is datetime/date (whether bin size is numeric or timespan)
+    if (original_expr == "datetime" || original_expr == "date")
     {
         out = fmt::format("toDateTime64(toInt64({0}/{1}) * {1}, 9, 'UTC')", t, bin_size);
     }
-    else if (origal_expr == "timespan" || origal_expr == "time" || ParserKQLDateTypeTimespan().parseConstKQLTimespan(origal_expr))
+    else if (original_expr == "timespan" || original_expr == "time" || ParserKQLDateTypeTimespan().parseConstKQLTimespan(original_expr))
     {
         String bin_value = fmt::format("toInt64({0}/{1}) * {1}", t, bin_size);
         out = fmt::format(
@@ -63,6 +106,7 @@ bool Bin::convertImpl(String & out, IParser::Pos & pos)
     {
         out = fmt::format("toInt64({0} / {1}) * {1}", t, bin_size);
     }
+
     return true;
 }
 
@@ -74,25 +118,47 @@ bool BinAt::convertImpl(String & out, IParser::Pos & pos)
         return false;
 
     ++pos;
-    String origal_expr(pos->begin, pos->end);
+    String original_expr(pos->begin, pos->end);
+
     String expression_str = getConvertedArgument(fn_name, pos);
+    if (expression_str.empty())
+        return false;
+    expression_str.erase(std::remove_if(expression_str.begin(), expression_str.end(), [](unsigned char c) { return std::isspace(c); }), expression_str.end());
 
     ++pos;
     String bin_size_str = getConvertedArgument(fn_name, pos);
+    if (bin_size_str.empty())
+        return false;
+    bin_size_str.erase(std::remove_if(bin_size_str.begin(), bin_size_str.end(), [](unsigned char c) { return std::isspace(c); }), bin_size_str.end());
 
     ++pos;
     String fixed_point_str = getConvertedArgument(fn_name, pos);
+    if (fixed_point_str.empty())
+        return false;
+    fixed_point_str.erase(std::remove_if(fixed_point_str.begin(), fixed_point_str.end(), [](unsigned char c) { return std::isspace(c); }), fixed_point_str.end());
 
     auto t1 = fmt::format("toFloat64({})", fixed_point_str);
     auto t2 = fmt::format("toFloat64({})", expression_str);
     int dir = t2 >= t1 ? 0 : -1;
-    bin_size = std::stod(bin_size_str);
 
-    if (origal_expr == "datetime" || origal_expr == "date")
+    try
+    {
+        bin_size = std::stod(bin_size_str);
+    }
+    catch (const std::exception &)
+    {
+        return false;
+    }
+
+    // validate if bin_size is a positive number
+    if (bin_size <= 0)
+        return false;
+
+    if (original_expr == "datetime" || original_expr == "date")
     {
         out = fmt::format("toDateTime64({} + toInt64(({} - {}) / {} + {}) * {}, 9, 'UTC')", t1, t2, t1, bin_size, dir, bin_size);
     }
-    else if (origal_expr == "timespan" || origal_expr == "time" || ParserKQLDateTypeTimespan().parseConstKQLTimespan(origal_expr))
+    else if (original_expr == "timespan" || original_expr == "time" || ParserKQLDateTypeTimespan().parseConstKQLTimespan(original_expr))
     {
         String bin_value = fmt::format("{} + toInt64(({} - {}) / {} + {}) * {}", t1, t2, t1, bin_size, dir, bin_size);
         out = fmt::format(
@@ -115,17 +181,17 @@ bool Iif::convertImpl(String & out, IParser::Pos & pos)
     ++pos;
     String predicate = getConvertedArgument(fn_name, pos);
     if (predicate.empty())
-        throw Exception(ErrorCodes::SYNTAX_ERROR, "Number of arguments do not match in function: {}", fn_name);
+        return false;
 
     ++pos;
     String if_true = getConvertedArgument(fn_name, pos);
     if (if_true.empty())
-        throw Exception(ErrorCodes::SYNTAX_ERROR, "Number of arguments do not match in function: {}", fn_name);
+        return false;
 
     ++pos;
     String if_false = getConvertedArgument(fn_name, pos);
     if (if_false.empty())
-        throw Exception(ErrorCodes::SYNTAX_ERROR, "Number of arguments do not match in function: {}", fn_name);
+        return false;
 
     out = fmt::format("if({}, {}, {})", predicate, if_true, if_false);
     return true;

--- a/src/Parsers/Kusto/KustoFunctions/KQLStringFunctions.cpp
+++ b/src/Parsers/Kusto/KustoFunctions/KQLStringFunctions.cpp
@@ -126,7 +126,10 @@ bool Extract::convertImpl(String & out, IParser::Pos & pos)
     String regex = getConvertedArgument(fn_name, pos);
 
     ++pos;
-    size_t capture_group = stoi(getConvertedArgument(fn_name, pos));
+    String capture_group_str = getConvertedArgument(fn_name, pos);
+    if (capture_group_str.empty())
+        return false;
+    size_t capture_group = stoi(capture_group_str);
 
     ++pos;
     String source = getConvertedArgument(fn_name, pos);
@@ -343,17 +346,26 @@ bool IndexOf::convertImpl(String & out, IParser::Pos & pos)
     if (pos->type == TokenType::Comma)
     {
         ++pos;
-        start_index = stoi(getConvertedArgument(fn_name, pos));
+        String start_index_str = getConvertedArgument(fn_name, pos);
+        if (start_index_str.empty())
+            return false;
+        start_index = stoi(start_index_str);
 
         if (pos->type == TokenType::Comma)
         {
             ++pos;
-            length = stoi(getConvertedArgument(fn_name, pos));
+            String length_str = getConvertedArgument(fn_name, pos);
+            if (length_str.empty())
+                return false;
+            length = stoi(length_str);
 
             if (pos->type == TokenType::Comma)
             {
                 ++pos;
-                occurrence = stoi(getConvertedArgument(fn_name, pos));
+                String occurrence_str = getConvertedArgument(fn_name, pos);
+                if (occurrence_str.empty())
+                    return false;
+                occurrence = stoi(occurrence_str);
             }
         }
     }

--- a/src/Parsers/Kusto/parseKQLQuery.h
+++ b/src/Parsers/Kusto/parseKQLQuery.h
@@ -19,6 +19,7 @@ ASTPtr tryParseKQLQuery(
     const char * & _out_query_end, // query start as input parameter, query end as output
     const char * end,
     std::string & out_error_message,
+    int * out_error_code,
     bool hilite,
     const std::string & description,
     bool allow_multi_statements,

--- a/src/Parsers/Kusto/parseKQLQuery.h
+++ b/src/Parsers/Kusto/parseKQLQuery.h
@@ -20,7 +20,7 @@ ASTPtr tryParseKQLQuery(
     const char * end,
     std::string & out_error_message,
     int * out_error_code,
-    bool hilite,asdfasdfasdf
+    bool hilite,
     const std::string & description,
     bool allow_multi_statements,
     size_t max_query_size,

--- a/src/Parsers/Kusto/parseKQLQuery.h
+++ b/src/Parsers/Kusto/parseKQLQuery.h
@@ -20,7 +20,7 @@ ASTPtr tryParseKQLQuery(
     const char * end,
     std::string & out_error_message,
     int * out_error_code,
-    bool hilite,
+    bool hilite,asdfasdfasdf
     const std::string & description,
     bool allow_multi_statements,
     size_t max_query_size,

--- a/tests/queries/0_stateless/03820_kusto_functions_empty_argument_validation.sql
+++ b/tests/queries/0_stateless/03820_kusto_functions_empty_argument_validation.sql
@@ -1,0 +1,9 @@
+
+SET allow_experimental_kusto_dialect = 1;
+SET dialect = 'kusto';
+
+print bin(, 1.5); -- { clientError SYNTAX_ERROR }
+print bin_at(, 2.5, 7); -- { clientError SYNTAX_ERROR }
+print iif(, 1, 2); -- { clientError SYNTAX_ERROR }
+print indexof('abc', , 0); -- { clientError SYNTAX_ERROR }
+print extract("User: ([^,]+)", , "User: James, Email: James@example.com, Age: 29"); -- { clientError SYNTAX_ERROR }


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (Fixes : https://github.com/ClickHouse/ClickHouse/issues/95509)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixes a crash in Kusto dialect functions `bin()`, `bin_at()`, `extract()`, and `indexof()` when empty arguments are provided.


### Details

This PR fixes issue #95509 where Kusto functions would crash when given empty arguments instead of throwing proper exceptions.

**Changes:**
- Added validation for empty `bin_size` argument in `bin()` and `bin_at()` functions
- Added validation for empty `capture_group` argument in `extract()` function  
- Added validation for empty `start_index`, `length`, and `occurrence` arguments in `indexof()` function
- All affected functions now throw `BAD_ARGUMENTS` exception with clear error messages when empty arguments are detected

**Files Changed:**
- `src/Parsers/Kusto/KustoFunctions/KQLGeneralFunctions.cpp` - Added validation for `bin()` and `bin_at()`
- `src/Parsers/Kusto/KustoFunctions/KQLStringFunctions.cpp` - Added validation for `extract()` and `indexof()`
- `tests/queries/0_stateless/03820_kusto_functions_empty_argument_validation.sql` - Comprehensive test cases
- `tests/queries/0_stateless/03820_kusto_functions_empty_argument_validation.reference` - Expected test output

**Testing:**
- All tests pass and follow ClickHouse testing conventions


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.124`
<!-- ch-version-info:end -->