### PR TITLE
optimize WindowTransform for libcxx hardening

### DIFF
--- a/src/AggregateFunctions/WindowFunction.h
+++ b/src/AggregateFunctions/WindowFunction.h
@@ -3,6 +3,7 @@
 #include <Interpreters/WindowDescription.h>
 #include <Common/AlignedBuffer.h>
 #include <Common/ContainersWithMemoryTracking.h>
+#include <Common/PODArray.h>
 
 
 namespace DB
@@ -12,6 +13,7 @@ namespace ErrorCodes
 extern const int BAD_ARGUMENTS;
 }
 class WindowTransform;
+struct WindowTransformBlock;
 
 
 // Interface for true window functions. It's not much of an interface, they just
@@ -29,7 +31,7 @@ public:
 
     virtual std::optional<WindowFrame> getDefaultFrame() const { return {}; }
 
-    virtual ColumnPtr castColumn(const Columns &, const std::vector<size_t> &) { return nullptr; }
+    virtual ColumnPtr castColumn(const Columns &, const PODArray<size_t> &) { return nullptr; }
 
     /// Is the frame type supported by this function.
     virtual bool checkWindowFrameType(const WindowTransform * /*transform*/) const { return true; }
@@ -48,7 +50,7 @@ struct WindowFunctionWorkspace
     // instead.
     IWindowFunction * window_function_impl = nullptr;
 
-    std::vector<size_t> argument_column_indices;
+    PODArray<size_t> argument_column_indices;
 
     // Will not be initialized for a pure window function.
     mutable AlignedBuffer aggregate_function_state;

--- a/src/Processors/Transforms/WindowTransform.h
+++ b/src/Processors/Transforms/WindowTransform.h
@@ -5,6 +5,7 @@
 #include <Interpreters/WindowDescription.h>
 #include <Processors/IProcessor.h>
 #include <Processors/Port.h>
+#include <Common/PODArray.h>
 
 #include <deque>
 
@@ -89,6 +90,9 @@ public:
     void advancePartitionEnd();
 
     bool arePeers(const RowNumber & x, const RowNumber & y) const;
+    bool arePeersImpl(
+        const RowNumber & x, const RowNumber & y,
+        const ColumnPtr * columns_x, const ColumnPtr * columns_y) const;
 
     void advanceFrameStartRowsOffset();
     void advanceFrameStartRangeOffset();
@@ -247,9 +251,9 @@ public:
     WindowDescription window_description;
 
     // Indices of the PARTITION BY columns in block.
-    std::vector<size_t> partition_by_indices;
+    PODArray<size_t> partition_by_indices;
     // Indices of the ORDER BY columns in block;
-    std::vector<size_t> order_by_indices;
+    PODArray<size_t> order_by_indices;
 
     // Per-window-function scratch spaces.
     std::vector<WindowFunctionWorkspace> workspaces;


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Enabling fast libc++ hardening makes `WindowTransform` around 10% slower, according to ClickBench. This is because in many places it performs `std::vector` (or `std::deque`) random access for each processed row which, with libc++ hardening, also involves bounds checking.

To optimise `WindowTransform`, we need to get rid of superfluous `std::vector` (or `std::deque`) random accesses:
1. Avoid calling `WindowTransform::inputAt` and `WindowTransform::blockAt` for every processed row. Reuse the result for each block.
3. For `WindowTransform::partition_by_indices`, `WindowTransform::order_by_indices`, `WindowFunctionWorkspace::argument_column_indices`, use `PODArray` instead of `std::vector`.
4. Do `std::vector<...>::data()` where necessary.

Even with libc++ hardening enabled, profiling shows >10% less CPU consumed in `WindowTransform` as a result of these changes.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
