### PR TITLE
Fix cast_keep_nullable for LowCardinality(Nullable(T)) types

### DIFF
--- a/src/Functions/CastOverloadResolver.cpp
+++ b/src/Functions/CastOverloadResolver.cpp
@@ -136,7 +136,9 @@ protected:
         if (internal)
             return type;
 
-        if (keep_nullable && arguments.front().type->isNullable() && type->canBeInsideNullable())
+        if (keep_nullable
+            && (arguments.front().type->isNullable() || arguments.front().type->isLowCardinalityNullable())
+            && type->canBeInsideNullable())
             return makeNullable(type);
 
         return type;

--- a/tests/queries/0_stateless/03804_cast_keep_nullable_low_cardinality.reference
+++ b/tests/queries/0_stateless/03804_cast_keep_nullable_low_cardinality.reference
@@ -1,0 +1,6 @@
+\N
+Nullable(String)
+hello
+Nullable(String)
+\N
+Nullable(String)

--- a/tests/queries/0_stateless/03804_cast_keep_nullable_low_cardinality.sql
+++ b/tests/queries/0_stateless/03804_cast_keep_nullable_low_cardinality.sql
@@ -1,0 +1,18 @@
+-- Test for https://github.com/ClickHouse/ClickHouse/issues/95670
+-- cast_keep_nullable should work with LowCardinality(Nullable(T)) types
+
+SET cast_keep_nullable = 1;
+
+-- This should return NULL, not throw an exception
+SELECT NULL::LowCardinality(Nullable(String))::text;
+
+-- Verify the type is Nullable(String)
+SELECT toTypeName(NULL::LowCardinality(Nullable(String))::text);
+
+-- Test with non-NULL value
+SELECT 'hello'::LowCardinality(Nullable(String))::text;
+SELECT toTypeName('hello'::LowCardinality(Nullable(String))::text);
+
+-- Comparison with regular Nullable (should behave the same)
+SELECT NULL::Nullable(String)::text;
+SELECT toTypeName(NULL::Nullable(String)::text);


### PR DESCRIPTION
When casting from `LowCardinality(Nullable(T))` to a non-nullable type with `cast_keep_nullable = 1`, the result should preserve nullability and return `Nullable(TargetType)`. Previously this threw an exception "Cannot convert NULL value to non-Nullable type" because the `cast_keep_nullable` check only looked at `isNullable()`, which returns false for `LowCardinality` types even when they contain a nullable dictionary.

The fix extends the check to also use `isLowCardinalityNullable()`, which correctly identifies when a `LowCardinality` type contains a `Nullable` dictionary type.

Closes #95670

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Correctly handle LowCardinality Nullable types in `CAST` when the setting `cast_keep_nullable` is enabled. Closes #95670.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.167`
<!-- ch-version-info:end -->