### PR TITLE
 keeper-bench: report errors in metrics and generate JSON metrics file for --input-request-log mode

### DIFF
--- a/programs/keeper-bench/Runner.cpp
+++ b/programs/keeper-bench/Runner.cpp
@@ -979,11 +979,11 @@ void requestFromLogExecutor(
     Stats * bench_info)
 {
     RequestFromLog request_from_log;
-    std::optional<std::future<void>> last_request;
+    std::vector<std::future<void>> pending_requests;
     while (queue->pop(request_from_log))
     {
         auto request_promise = std::make_shared<std::promise<void>>();
-        last_request = request_promise->get_future();
+        pending_requests.push_back(request_promise->get_future());
         auto start_time = std::chrono::steady_clock::now();
         Coordination::ResponseCallback callback = [&,
                                                   request_promise,
@@ -1048,8 +1048,8 @@ void requestFromLogExecutor(
         request_from_log.connection->executeGenericRequest(request_from_log.request, callback, watch);
     }
 
-    if (last_request)
-        last_request->wait();
+    for (auto & future : pending_requests)
+        future.wait();
 }
 
 }

--- a/programs/keeper-bench/Runner.cpp
+++ b/programs/keeper-bench/Runner.cpp
@@ -1097,8 +1097,7 @@ void Runner::runBenchmarkFromLog()
             info->report(concurrency);
             DB::WriteBufferFromOwnString out;
             info->writeJSON(out, concurrency, 0);
-            auto output_string = std::move(out.str());
-            writeOutputString(output_string, 0);
+            writeOutputString(out.str(), 0);
         }
     });
 

--- a/programs/keeper-bench/Runner.cpp
+++ b/programs/keeper-bench/Runner.cpp
@@ -317,6 +317,7 @@ void Runner::thread(std::vector<std::shared_ptr<Coordination::ZooKeeper>> zookee
                 shutdown = true;
                 throw;
             }
+            info->errors.fetch_add(1, std::memory_order_relaxed);
 
             bool got_expired = false;
             for (const auto & connection : zookeepers)
@@ -390,10 +391,13 @@ bool Runner::tryPushRequestInteractively(ZooKeeperRequestWithCallbacks && reques
 
 void Runner::runBenchmark()
 {
-    if (generator)
+    // When --input-request-log is set, always replay (ignore generator/setup in config).
+    if (!input_request_log.empty())
+        runBenchmarkFromLog();
+    else if (generator)
         runBenchmarkWithGenerator();
     else
-        runBenchmarkFromLog();
+        throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Need either --input-request-log or config with generator");
 }
 
 
@@ -971,7 +975,10 @@ void dumpStats(std::string_view type, const RequestFromLogStats::Stats & stats_f
               << std::endl;
 };
 
-void requestFromLogExecutor(std::shared_ptr<ConcurrentBoundedQueue<RequestFromLog>> queue, RequestFromLogStats & request_stats)
+void requestFromLogExecutor(
+    std::shared_ptr<ConcurrentBoundedQueue<RequestFromLog>> queue,
+    RequestFromLogStats & request_stats,
+    Stats * bench_info)
 {
     RequestFromLog request_from_log;
     std::optional<std::future<void>> last_request;
@@ -980,11 +987,12 @@ void requestFromLogExecutor(std::shared_ptr<ConcurrentBoundedQueue<RequestFromLo
         auto request_promise = std::make_shared<std::promise<void>>();
         last_request = request_promise->get_future();
         Coordination::ResponseCallback callback = [&,
-                                                   request_promise,
-                                                   request = request_from_log.request,
-                                                   expected_result = request_from_log.expected_result,
-                                                   subrequest_expected_results = std::move(request_from_log.subrequest_expected_results)](
-                                                      const Coordination::Response & response) mutable
+                                                  request_promise,
+                                                  request = request_from_log.request,
+                                                  expected_result = request_from_log.expected_result,
+                                                  subrequest_expected_results = std::move(request_from_log.subrequest_expected_results),
+                                                  bench_info](
+                                                     const Coordination::Response & response) mutable
         {
             auto & stats = request->isReadRequest() ? request_stats.read_requests : request_stats.write_requests;
 
@@ -994,6 +1002,9 @@ void requestFromLogExecutor(std::shared_ptr<ConcurrentBoundedQueue<RequestFromLo
             {
                 if (*expected_result != response.error)
                     stats.unexpected_results.fetch_add(1, std::memory_order_relaxed);
+
+                if (bench_info && *expected_result != response.error)
+                    bench_info->errors.fetch_add(1, std::memory_order_relaxed);
 
 #if 0
                 if (*expected_result != response.error)
@@ -1082,6 +1093,12 @@ void Runner::runBenchmarkFromLog()
         {
             dumpStats("Write", stats.write_requests);
             dumpStats("Read", stats.read_requests);
+            std::lock_guard lock(mutex);
+            info->report(concurrency);
+            DB::WriteBufferFromOwnString out;
+            info->writeJSON(out, concurrency, 0);
+            auto output_string = std::move(out.str());
+            writeOutputString(output_string, 0);
         }
     });
 
@@ -1099,7 +1116,7 @@ void Runner::runBenchmarkFromLog()
         executor_id_to_queue.emplace(request.executor_id, executor_queue);
         auto scheduled = pool->trySchedule([&, executor_queue]() mutable
         {
-            requestFromLogExecutor(std::move(executor_queue), stats);
+            requestFromLogExecutor(std::move(executor_queue), stats, info.get());
         });
 
         if (!scheduled)
@@ -1199,7 +1216,12 @@ void Runner::runBenchmarkWithGenerator()
     DB::WriteBufferFromOwnString out;
     info->writeJSON(out, concurrency, start_timestamp_ms);
     auto output_string = std::move(out.str());
+    writeOutputString(output_string, start_timestamp_ms);
+}
 
+
+void Runner::writeOutputString(const std::string & output_string, int64_t start_timestamp_ms)
+{
     if (print_to_stdout)
         std::cout << output_string << std::endl;
 

--- a/programs/keeper-bench/Runner.cpp
+++ b/programs/keeper-bench/Runner.cpp
@@ -1,5 +1,6 @@
 #include <Runner.h>
 #include <atomic>
+#include <chrono>
 #include <Poco/Util/AbstractConfiguration.h>
 
 #include <Columns/IColumn.h>
@@ -983,8 +984,10 @@ void requestFromLogExecutor(
     {
         auto request_promise = std::make_shared<std::promise<void>>();
         last_request = request_promise->get_future();
+        auto start_time = std::chrono::steady_clock::now();
         Coordination::ResponseCallback callback = [&,
                                                   request_promise,
+                                                  start_time,
                                                   request = request_from_log.request,
                                                   expected_result = request_from_log.expected_result,
                                                   subrequest_expected_results = std::move(request_from_log.subrequest_expected_results),
@@ -994,6 +997,17 @@ void requestFromLogExecutor(
             auto & stats = request->isReadRequest() ? request_stats.read_requests : request_stats.write_requests;
 
             stats.total.fetch_add(1, std::memory_order_relaxed);
+
+            if (bench_info)
+            {
+                auto end_time = std::chrono::steady_clock::now();
+                auto microseconds = static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::microseconds>(end_time - start_time).count());
+                size_t response_bytes = 0;
+                if (request->isReadRequest())
+                    bench_info->addRead(microseconds, 1, request->bytesSize() + response_bytes);
+                else
+                    bench_info->addWrite(microseconds, 1, request->bytesSize() + response_bytes);
+            }
 
             if (expected_result)
             {

--- a/programs/keeper-bench/Runner.cpp
+++ b/programs/keeper-bench/Runner.cpp
@@ -979,11 +979,11 @@ void requestFromLogExecutor(
     Stats * bench_info)
 {
     RequestFromLog request_from_log;
-    std::vector<std::future<void>> pending_requests;
+    std::optional<std::future<void>> last_request;
     while (queue->pop(request_from_log))
     {
         auto request_promise = std::make_shared<std::promise<void>>();
-        pending_requests.push_back(request_promise->get_future());
+        last_request = request_promise->get_future();
         auto start_time = std::chrono::steady_clock::now();
         Coordination::ResponseCallback callback = [&,
                                                   request_promise,
@@ -1048,8 +1048,8 @@ void requestFromLogExecutor(
         request_from_log.connection->executeGenericRequest(request_from_log.request, callback, watch);
     }
 
-    for (auto & future : pending_requests)
-        future.wait();
+    if (last_request)
+        last_request->wait();
 }
 
 }

--- a/programs/keeper-bench/Runner.cpp
+++ b/programs/keeper-bench/Runner.cpp
@@ -391,13 +391,10 @@ bool Runner::tryPushRequestInteractively(ZooKeeperRequestWithCallbacks && reques
 
 void Runner::runBenchmark()
 {
-    // When --input-request-log is set, always replay (ignore generator/setup in config).
-    if (!input_request_log.empty())
-        runBenchmarkFromLog();
-    else if (generator)
+    if (generator)
         runBenchmarkWithGenerator();
     else
-        throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Need either --input-request-log or config with generator");
+        runBenchmarkFromLog();
 }
 
 

--- a/programs/keeper-bench/Runner.cpp
+++ b/programs/keeper-bench/Runner.cpp
@@ -1002,7 +1002,7 @@ void requestFromLogExecutor(
             {
                 auto end_time = std::chrono::steady_clock::now();
                 auto microseconds = static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::microseconds>(end_time - start_time).count());
-                size_t response_bytes = 0;
+                size_t response_bytes = response.bytesSize();
                 if (request->isReadRequest())
                     bench_info->addRead(microseconds, 1, request->bytesSize() + response_bytes);
                 else

--- a/programs/keeper-bench/Runner.h
+++ b/programs/keeper-bench/Runner.h
@@ -115,9 +115,9 @@ private:
     std::atomic<bool> shutdown = false;
 
     std::shared_ptr<Stats> info;
-    bool print_to_stdout;
+    bool print_to_stdout = false;
     std::optional<std::filesystem::path> file_output;
-    bool output_file_with_timestamp;
+    bool output_file_with_timestamp = false;
 
     Stopwatch total_watch;
     Stopwatch delay_watch;

--- a/programs/keeper-bench/Runner.h
+++ b/programs/keeper-bench/Runner.h
@@ -91,6 +91,8 @@ private:
     void runBenchmarkWithGenerator();
     void runBenchmarkFromLog();
 
+    void writeOutputString(const std::string & output_string, int64_t start_timestamp_ms);
+
     void createConnections();
     std::vector<std::shared_ptr<Coordination::ZooKeeper>> refreshConnections();
     std::shared_ptr<Coordination::ZooKeeper> getConnection(const ConnectionInfo & connection_info, size_t connection_info_idx) const;

--- a/programs/keeper-bench/Stats.cpp
+++ b/programs/keeper-bench/Stats.cpp
@@ -16,11 +16,13 @@ void Stats::StatsCollector::add(uint64_t microseconds, size_t requests_inc, size
 
 void Stats::addRead(uint64_t microseconds, size_t requests_inc, size_t bytes_inc)
 {
+    std::lock_guard lock(mutex);
     read_collector.add(microseconds, requests_inc, bytes_inc);
 }
 
 void Stats::addWrite(uint64_t microseconds, size_t requests_inc, size_t bytes_inc)
 {
+    std::lock_guard lock(mutex);
     write_collector.add(microseconds, requests_inc, bytes_inc);
 }
 

--- a/programs/keeper-bench/Stats.cpp
+++ b/programs/keeper-bench/Stats.cpp
@@ -36,6 +36,7 @@ void Stats::clear()
 {
     read_collector.clear();
     write_collector.clear();
+    errors = 0;
 }
 
 std::pair<double, double> Stats::StatsCollector::getThroughput(size_t concurrency)
@@ -127,6 +128,8 @@ void Stats::writeJSON(DB::WriteBuffer & out, size_t concurrency, int64_t start_t
     results.SetObject();
 
     results.AddMember("timestamp", Value(start_timestamp), allocator);
+    results.AddMember("errors", Value(static_cast<uint64_t>(errors.load())), allocator);
+    results.AddMember("ops", Value(static_cast<uint64_t>(read_collector.requests + write_collector.requests)), allocator);
 
     const auto get_results = [&](auto & collector)
     {

--- a/programs/keeper-bench/Stats.cpp
+++ b/programs/keeper-bench/Stats.cpp
@@ -65,8 +65,14 @@ void Stats::report(size_t concurrency)
     if (0 == read_requests && 0 == write_requests)
         return;
 
-    auto [read_rps, read_bps] = read_collector.getThroughput(concurrency);
-    auto [write_rps, write_bps] = write_collector.getThroughput(concurrency);
+    double read_rps = 0;
+    double read_bps = 0;
+    double write_rps = 0;
+    double write_bps = 0;
+    if (read_requests != 0)
+        std::tie(read_rps, read_bps) = read_collector.getThroughput(concurrency);
+    if (write_requests != 0)
+        std::tie(write_rps, write_bps) = write_collector.getThroughput(concurrency);
 
     std::cerr << "read requests " << read_requests << ", write requests " << write_requests << ", ";
     if (errors)

--- a/programs/keeper-bench/Stats.h
+++ b/programs/keeper-bench/Stats.h
@@ -2,6 +2,7 @@
 
 #include <vector>
 #include <atomic>
+#include <mutex>
 
 #include <AggregateFunctions/ReservoirSampler.h>
 
@@ -34,6 +35,8 @@ struct Stats
     void addWrite(uint64_t microseconds, size_t requests_inc, size_t bytes_inc);
 
     void clear();
+
+    std::mutex mutex;
 
     void report(size_t concurrency);
     void writeJSON(DB::WriteBuffer & out, size_t concurrency, int64_t start_timestamp);

--- a/programs/keeper-bench/Stats.h
+++ b/programs/keeper-bench/Stats.h
@@ -9,7 +9,7 @@
 
 struct Stats
 {
-    size_t errors = 0;
+    std::atomic<size_t> errors{0};
 
     using Sampler = ReservoirSampler<double>;
     struct StatsCollector
@@ -38,5 +38,3 @@ struct Stats
     void report(size_t concurrency);
     void writeJSON(DB::WriteBuffer & out, size_t concurrency, int64_t start_timestamp);
 };
-
-


### PR DESCRIPTION
- Report errors in the JSON file for both generator and replay (log) mode.
- Generate the JSON metrics file for replay (--input-request-log).
- Add total ops reporting in metrics.

### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
keeper-bench: report errors in metrics and generate JSON metrics file for --input-request-log mode

  - Errors are now reported in the JSON metrics output for both generator and replay (--input-request-log) modes.
  - The JSON metrics file is now generated when running in replay mode (--input-request-log), previously it was only produced in generator mode.
  - Added total operation count to the metrics output.

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to `keeper-bench` metrics/reporting and add some locking/atomic updates; main risk is minor performance impact or altered benchmark output format/contents.
> 
> **Overview**
> `keeper-bench` now **tracks and reports errors and total ops in JSON metrics** (new `errors` and `ops` fields), and makes stats updates thread-safe via atomics and a mutex.
> 
> In `--input-request-log` replay mode, the benchmark now **collects per-request timing/bytes into the same `Stats` structure** and **writes the JSON metrics output** (via a new `writeOutputString()` helper) instead of only printing per-type counters.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff0317563d890c96aa597fe963f83fd2d7c90161. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.483`
<!-- ch-version-info:end -->