### PR TITLE
Fix upgrade check failure due to missing auxiliary ZooKeeper config

### DIFF
--- a/tests/config/config.d/zookeeper_fault_injection.xml
+++ b/tests/config/config.d/zookeeper_fault_injection.xml
@@ -1,23 +1,18 @@
 <clickhouse>
+    <!-- This config is used as an override on top of zookeeper.xml.
+         It only contains fault injection specific settings.
+
+         Approximate probability of request success:
+           (1 - send_fault_probability) * (1 - recv_fault_probability) = 0.99998 * 0.99998 = 0.99996
+         Actually it will be less, because if some request fails due to fault injection,
+         then all requests which are in the queue now also fail.
+         In other words, session will expire 4 times per 99996 successful requests
+         or approximately each 25000 requests (on average).
+    -->
     <zookeeper>
-        <use_compression>1</use_compression>
-        <use_xid_64>1</use_xid_64>
-        <node index="1">
-            <host>localhost</host>
-            <port>9181</port>
-        </node>
-        <!-- Settings for fault injection.
-          Approximate probability of request success:
-            (1 - send_fault_probability) * (1 - recv_fault_probability) = 0.99998 * 0.99998 = 0.99996
-          Actually it will be less, because if some request fails due to fault injection,
-          then all requests which are in the queue now also fail.
-          In other words, session will expire 4 times per 99996 successful requests
-          or approximately each 25000 requests (on average).
-        -->
         <enable_fault_injections_during_startup>0</enable_fault_injections_during_startup>
         <send_fault_probability>0.00002</send_fault_probability>
         <recv_fault_probability>0.00002</recv_fault_probability>
-
         <send_sleep_probability>0.00001</send_sleep_probability>
         <send_sleep_ms>10000</send_sleep_ms>
     </zookeeper>

--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -241,12 +241,14 @@ ln -sf $SRC_PATH/dhparam.pem $DEST_SERVER_PATH/
 ln -sf --backup=simple --suffix=_original.xml \
    $SRC_PATH/config.d/query_masking_rules.xml $DEST_SERVER_PATH/config.d/
 
+# Always install zookeeper.xml as the base config
+ln -sf $SRC_PATH/config.d/zookeeper.xml $DEST_SERVER_PATH/config.d/
+
+# Additionally install fault injection settings as an override when enabled
 if [[ -n "$ZOOKEEPER_FAULT_INJECTION" ]] && [[ "$ZOOKEEPER_FAULT_INJECTION" -eq 1 ]]; then
-    rm -f $DEST_SERVER_PATH/config.d/zookeeper.xml ||:
     ln -sf $SRC_PATH/config.d/zookeeper_fault_injection.xml $DEST_SERVER_PATH/config.d/
 else
     rm -f $DEST_SERVER_PATH/config.d/zookeeper_fault_injection.xml ||:
-    ln -sf $SRC_PATH/config.d/zookeeper.xml $DEST_SERVER_PATH/config.d/
 fi
 
 if [[ -n "$THREAD_POOL_FAULT_INJECTION" ]] && [[ "$THREAD_POOL_FAULT_INJECTION" -eq 1 ]]; then

--- a/tests/docker_scripts/stress_tests.lib
+++ b/tests/docker_scripts/stress_tests.lib
@@ -98,13 +98,9 @@ function configure()
     sudo chown clickhouse /etc/clickhouse-server/config.d/keeper_port.xml
     sudo chgrp clickhouse /etc/clickhouse-server/config.d/keeper_port.xml
 
-    if [[ -n "$ZOOKEEPER_FAULT_INJECTION" ]] && [[ "$ZOOKEEPER_FAULT_INJECTION" -eq 1 ]]; then
-        randomize_config_boolean_value use_compression zookeeper_fault_injection
-        randomize_config_boolean_value use_xid_64 zookeeper_fault_injection
-    else
-        randomize_config_boolean_value use_compression zookeeper
-        randomize_config_boolean_value use_xid_64 zookeeper
-    fi
+    # Always randomize in zookeeper.xml (the base config)
+    randomize_config_boolean_value use_compression zookeeper
+    randomize_config_boolean_value use_xid_64 zookeeper
 
     # for clickhouse-server (via service)
     echo "ASAN_OPTIONS='malloc_context_size=10 verbosity=1 allocator_release_to_os_interval_ms=10000'" >> /etc/environment


### PR DESCRIPTION
The upgrade check was failing because `zookeeper_fault_injection.xml` was used as a replacement for `zookeeper.xml`, but it didn't contain the `auxiliary_zookeepers` section with `zookeeper2`.

When a table created during stress tests used `zookeeper2`, the upgraded server couldn't find it and failed with:
"Unknown auxiliary ZooKeeper name 'zookeeper2'"

Now `zookeeper.xml` is always installed as the base config, and `zookeeper_fault_injection.xml` is used as an override containing only the fault injection specific settings.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.181`
<!-- ch-version-info:end -->