### PR TITLE
Docs: fix inaccuracy in CoalescingMergeTree docs

### DIFF
--- a/docs/en/engines/table-engines/mergetree-family/coalescingmergetree.md
+++ b/docs/en/engines/table-engines/mergetree-family/coalescingmergetree.md
@@ -43,10 +43,7 @@ For a description of request parameters, see [request description](../../../sql-
 
 #### Columns {#columns}
 
-`columns` - a tuple with the names of columns where values will be united. Optional parameter.
-    The columns must be of a numeric type and must not be in the partition or sorting key.
-
- If `columns` is not specified, ClickHouse unites the values in all columns that are not in the sorting key.
+`columns` - Optional. A tuple with the names of columns where values will be united. The provided columns must not be in the partition or sorting key. If `columns` is not specified, ClickHouse unites the values in all columns that are not in the sorting key.
 
 ### Query clauses {#query-clauses}
 


### PR DESCRIPTION
Closes https://github.com/ClickHouse/clickhouse-docs/issues/5074. The user points out that the docs say you need to use a numeric column value as parameter to CoalescingMergeTree, however this does not seem to be true: https://fiddle.clickhouse.com/6e61722f-b04b-49f6-b7ed-5afc6b747d65

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.371`
<!-- ch-version-info:end -->