### PR TITLE
Add FilesystemCacheCheckCorrectnessMicroseconds

### DIFF
--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -787,6 +787,7 @@ The server successfully detected this situation and will download merged part fr
     M(FilesystemCacheBackgroundEvictedFileSegments, "Number of file segments evicted by background thread", ValueType::Number) \
     M(FilesystemCacheBackgroundEvictedBytes, "Number of bytes evicted by background thread", ValueType::Number) \
     M(FilesystemCacheCheckCorrectness, "Number of times FileCache::assertCacheCorrectness was called", ValueType::Number) \
+    M(FilesystemCacheCheckCorrectnessMicroseconds, "How much time does FileCache::assertCacheCorrectness takes", ValueType::Microseconds) \
     M(FileSegmentWaitMicroseconds, "Wait on DOWNLOADING state", ValueType::Microseconds) \
     M(FileSegmentCompleteMicroseconds, "Duration of FileSegment::complete() in filesystem cache", ValueType::Microseconds) \
     M(FileSegmentLockMicroseconds, "Lock file segment time", ValueType::Microseconds) \

--- a/src/Interpreters/Cache/FileCache.cpp
+++ b/src/Interpreters/Cache/FileCache.cpp
@@ -45,6 +45,7 @@ namespace ProfileEvents
     extern const Event FilesystemCacheBackgroundEvictedFileSegments;
     extern const Event FilesystemCacheBackgroundEvictedBytes;
     extern const Event FilesystemCacheCheckCorrectness;
+    extern const Event FilesystemCacheCheckCorrectnessMicroseconds;
 }
 
 namespace CurrentMetrics
@@ -1970,6 +1971,7 @@ void FileCache::assertCacheCorrectness()
 {
 #ifdef DEBUG_OR_SANITIZER_BUILD
     LOG_TEST(log, "Checking cache correctness");
+    ProfileEventTimeIncrement<Microseconds> watch(ProfileEvents::FilesystemCacheCheckCorrectnessMicroseconds);
     ProfileEvents::increment(ProfileEvents::FilesystemCacheCheckCorrectness);
 
     metadata.iterate([&](LockedKey & locked_key)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

For better introspection (I saw that sometimes filesystem cache takes a lot of time)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.176`
<!-- ch-version-info:end -->