### PR TITLE
FTS preprocessor map

### DIFF
--- a/docs/en/engines/table-engines/mergetree-family/textindexes.md
+++ b/docs/en/engines/table-engines/mergetree-family/textindexes.md
@@ -113,8 +113,12 @@ Examples:
 - `INDEX idx(col) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(col))`
 - `INDEX idx(col) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = substringIndex(col, '\n', 1))`
 - `INDEX idx(col) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(extractTextFromHTML(col))`
+- `INDEX idx(extractTextFromHTML(col)) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(col)`
 
-Also, the preprocessor expression must only reference the column on top of which the text index is defined.
+The preprocessor expression must only reference the column on top of which the text index is defined.
+For indices defined as a functional expression the preprocessor must reference only the exact same expression.
+This is intentional to enable constructing indices in columns with different datatypes like [Maps](/sql-reference/data-types/map.md) without commutativity undefined behaviors.
+
 Using non-deterministic functions is not allowed.
 
 The preprocessor can also be used with [Array(String)](/sql-reference/data-types/array.md) and [Array(FixedString)](/sql-reference/data-types/array.md) columns.
@@ -163,9 +167,26 @@ CREATE TABLE tab
 )
 ENGINE = MergeTree
 ORDER BY tuple();
+...
 
 SELECT count() FROM tab WHERE hasToken(str, lower('Foo'));
 ```
+
+[Maps](/sql-reference/data-types/map.md) with string values or keys are also supported using index defined as expressions.
+In that case the same expressions need to be in the preprocessor and the function in the select and the index is defined as a function.
+
+Example:
+```sql
+CREATE TABLE tab
+(
+    val Map(String, String),
+    INDEX idx(mapKeys(val)) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(mapKeys(val)))
+)
+...
+
+SELECT count() FROM tab WHERE hasAllTokens(mapKeys(val), 'foo');
+```
+
 **Other arguments (optional)**. Text indexes in ClickHouse are implemented as [secondary indexes](/engines/table-engines/mergetree-family/mergetree.md/#skip-index-types).
 However, unlike other skipping indexes, text indexes have an infinite granularity, i.e. the text index is created for the entire part and explicitly specified index granularity is ignored.
 This value has been chosen empirically and it provides a good trade-off between speed and index size for most use cases.

--- a/src/Storages/MergeTree/MergeTreeIndexText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexText.cpp
@@ -8,6 +8,8 @@
 #include <Common/formatReadable.h>
 #include <Common/logger_useful.h>
 #include <Common/typeid_cast.h>
+#include "DataTypes/DataTypeMap.h"
+#include "DataTypes/IDataType.h"
 #include <Core/ColumnWithTypeAndName.h>
 #include <DataTypes/Serializations/SerializationNumber.h>
 #include <DataTypes/Serializations/SerializationString.h>
@@ -48,6 +50,7 @@ namespace ErrorCodes
     extern const int BAD_ARGUMENTS;
     extern const int LOGICAL_ERROR;
     extern const int INCORRECT_NUMBER_OF_COLUMNS;
+    extern const int INCOMPATIBLE_COLUMNS;
     extern const int CORRUPTED_DATA;
     extern const int SUPPORT_IS_DISABLED;
 }
@@ -1151,11 +1154,12 @@ void MergeTreeIndexAggregatorText::update(const Block & block, size_t * pos, siz
         return;
 
     const ColumnWithTypeAndName & index_column = block.getByName(index_column_name);
+    const TypeIndex input_column_type_id = index_column.type->getTypeId();
 
-    if (isArray(index_column.type->getTypeId()))
+    auto [preprocessed_column, offset] = preprocessor->processColumn(index_column, *pos, rows_read);
+
+    if (isArray(input_column_type_id))
     {
-        auto [preprocessed_column, offset] = preprocessor->processColumn(index_column, *pos, rows_read);
-
         const auto & column_array = assert_cast<const ColumnArray &>(*preprocessed_column);
         const auto & column_data = column_array.getData();
         const auto & column_offsets = column_array.getOffsets();
@@ -1170,9 +1174,8 @@ void MergeTreeIndexAggregatorText::update(const Block & block, size_t * pos, siz
             granule_builder.incrementCurrentRow();
         }
     }
-    else
+    else if (isStringOrFixedString(input_column_type_id) || (index_column.type->lowCardinality()))
     {
-        auto [preprocessed_column, offset] = preprocessor->processColumn(index_column, *pos, rows_read);
         for (size_t i = 0; i < rows_read; ++i)
         {
             std::string_view ref = preprocessed_column->getDataAt(offset + i);
@@ -1180,6 +1183,11 @@ void MergeTreeIndexAggregatorText::update(const Block & block, size_t * pos, siz
             granule_builder.incrementCurrentRow();
         }
     }
+    else
+        throw Exception(
+            ErrorCodes::INCOMPATIBLE_COLUMNS,
+            "Column: '{}' has incompatible or unsupported type for preprocessor: {}.",
+            index_column_name, index_column.type->getName());
 
     *pos += rows_read;
 }
@@ -1438,7 +1446,7 @@ void textIndexValidator(const IndexDescription & index, bool /*attach*/)
         data_type = WhichDataType(low_cardinality.getDictionaryType());
     }
 
-    if (!data_type.isString() && !data_type.isFixedString())
+    if (!data_type.isString() && !data_type.isFixedString() && !data_type.isMap())
     {
         throw Exception(
             ErrorCodes::BAD_ARGUMENTS,
@@ -1456,12 +1464,13 @@ void textIndexValidator(const IndexDescription & index, bool /*attach*/)
         /// validation. That way we skip the ActionsDAG and ExpressionActions constructions.
         ExpressionActions expression = MergeTreeIndexTextPreprocessor::parseExpression(index, preprocessor.value());
 
-        const Names required_columns = expression.getRequiredColumns();
+        const NamesAndTypesList &required_columns = expression.getRequiredColumnsWithTypes();
+        chassert(required_columns.size() == 1);
 
         /// This is expected that never happen because the `validatePreprocessorASTExpression` already checks that we have a single identifier.
         /// But once again, with user inputs: Don't trust, validate!
-        if (required_columns.size() != 1 || required_columns.front() != index.column_names.front())
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "Text index preprocessor expression must depend only of column: {}", index.column_names.front());
+        if (required_columns.front().name != index.column_names.front())
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Text index preprocessor expression must depend of column: {}", index.column_names.front());
     }
 }
 

--- a/src/Storages/MergeTree/MergeTreeIndexText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexText.cpp
@@ -8,8 +8,6 @@
 #include <Common/formatReadable.h>
 #include <Common/logger_useful.h>
 #include <Common/typeid_cast.h>
-#include "DataTypes/DataTypeMap.h"
-#include "DataTypes/IDataType.h"
 #include <Core/ColumnWithTypeAndName.h>
 #include <DataTypes/Serializations/SerializationNumber.h>
 #include <DataTypes/Serializations/SerializationString.h>
@@ -1186,7 +1184,7 @@ void MergeTreeIndexAggregatorText::update(const Block & block, size_t * pos, siz
     else
         throw Exception(
             ErrorCodes::INCOMPATIBLE_COLUMNS,
-            "Column: '{}' has incompatible or unsupported type for preprocessor: {}.",
+            "Column: '{}' has incompatible or unsupported type: {} for preprocessor.",
             index_column_name, index_column.type->getName());
 
     *pos += rows_read;
@@ -1446,7 +1444,7 @@ void textIndexValidator(const IndexDescription & index, bool /*attach*/)
         data_type = WhichDataType(low_cardinality.getDictionaryType());
     }
 
-    if (!data_type.isString() && !data_type.isFixedString() && !data_type.isMap())
+    if (!data_type.isString() && !data_type.isFixedString())
     {
         throw Exception(
             ErrorCodes::BAD_ARGUMENTS,

--- a/src/Storages/MergeTree/MergeTreeIndexTextPreprocessor.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPreprocessor.cpp
@@ -20,7 +20,7 @@
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/ExpressionListParsers.h>
 #include <Storages/IndicesDescription.h>
-#include "base/defines.h"
+#include <base/defines.h>
 
 
 namespace DB
@@ -37,53 +37,16 @@ namespace ErrorCodes
 namespace
 {
 
-/// On map columns the preprocessor expression should be on index definition.
-size_t validatePreprocessorASTExpressionForMaps(const ASTFunction * preprocessor_function, const IndexDescription & index_description)
+void validatePreprocessorASTRecurse(
+    const ASTFunction * subfunction,
+    const std::string &index_identifier_name,
+    const ASTFunction *index_expression_function,
+    const ASTIdentifier *index_expression_identifier)
 {
+    if (index_expression_function != nullptr && subfunction->getColumnNameWithoutAlias() == index_expression_function->getColumnNameWithoutAlias())
+        return;
 
-    const ASTIndexDeclaration &index_definition_ast = index_description.definition_ast->as<ASTIndexDeclaration &>();
-    ASTPtr index_expresion_ast = index_definition_ast.getExpression();
-    const ASTFunction *index_expression_function = index_expresion_ast->as<ASTFunction>();
-    if (index_expression_function == nullptr)
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Index definition on map columns must be an expression, but got: {}", index_expresion_ast->getColumnName());
-
-    size_t counter = 0;
-
-    if (index_expression_function->getColumnNameWithoutAlias() == preprocessor_function->getColumnNameWithoutAlias())
-        return 1;
-
-    for (const auto & argument : preprocessor_function->arguments->children)
-    {
-        /// In principle all literals are valid
-        if (argument->as<ASTLiteral>())
-            continue;
-
-        /// We must have only the index definition as argument, no Identifiers at this point.
-        if (const ASTIdentifier * argument_identifier = argument->as<ASTIdentifier>())
-            throw Exception(
-                ErrorCodes::BAD_ARGUMENTS,
-                "Preprocessor function on map column indices must only reference index definition expression: {}, but also got also: {}",
-                index_description.column_names.front(), argument_identifier->name());
-
-        /// Check the arguments recursively (won't happen more than 2 or 3 times on average so it's fine).
-        if (const ASTFunction * subfunction = argument->as<ASTFunction>())
-        {
-            counter += validatePreprocessorASTExpressionForMaps(subfunction, index_description);
-            continue;
-        }
-
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Preprocessor function on map columns expects a literal or function as argument");
-    }
-
-    return counter;
-}
-
-void validatePreprocessorASTExpressionGeneric(const ASTFunction * preprocessor_function, const IndexDescription & index_description)
-{
-    const std::string &index_identifier_name = index_description.column_names.front();
-    chassert(!index_identifier_name.empty());
-
-    for (const auto & argument : preprocessor_function->arguments->children)
+    for (const auto & argument : subfunction->arguments->children)
     {
         /// In principle all literals are valid
         if (argument->as<ASTLiteral>())
@@ -92,17 +55,21 @@ void validatePreprocessorASTExpressionGeneric(const ASTFunction * preprocessor_f
         /// We must have only the valid identifier_name as argument
         if (const ASTIdentifier * argument_identifier = argument->as<ASTIdentifier>())
         {
+            if (index_expression_identifier == nullptr)
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Preprocessor expression must only reference expression: {}",
+                    index_identifier_name);
+
             if (index_identifier_name != argument_identifier->name())
-                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Preprocessor function must only reference column: {}, also got: {}",
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Preprocessor function must only reference column: {}, but got: {}",
                     index_identifier_name, argument_identifier->name());
 
             continue;
         }
 
         /// Check the arguments recursively (won't happen more than 2 or 3 times on average so it's fine).
-        if (const ASTFunction * subfunction = argument->as<ASTFunction>())
+        if (const ASTFunction * subsubfunction = argument->as<ASTFunction>())
         {
-            validatePreprocessorASTExpressionGeneric(subfunction, index_description);
+            validatePreprocessorASTRecurse(subsubfunction, index_identifier_name, index_expression_function, index_expression_identifier);
             continue;
         }
 
@@ -113,7 +80,7 @@ void validatePreprocessorASTExpressionGeneric(const ASTFunction * preprocessor_f
 /// Early preprocessor argument validation.
 /// Maybe we could omit this validation and use only the validate function. But here we do it early and simpler to ensure that what we parse
 /// later is correct.
-void validatePreprocessorASTExpression(const ASTFunction * preprocessor_function, const IndexDescription & index_description)
+void validatePreprocessorAST(const ASTFunction * preprocessor_function, const IndexDescription & index_description)
 {
     chassert(preprocessor_function != nullptr);
     if (preprocessor_function->arguments == nullptr)
@@ -128,19 +95,10 @@ void validatePreprocessorASTExpression(const ASTFunction * preprocessor_function
     const ASTIndexDeclaration &index_definition_ast = index_description.definition_ast->as<ASTIndexDeclaration &>();
     ASTPtr index_expresion_ast = index_definition_ast.getExpression();
 
-    if (isMap(index_description.data_types.front()))
-    {
-        const size_t expression_counter = validatePreprocessorASTExpressionForMaps(preprocessor_function, index_description);
-        if (expression_counter == 0)
-            throw Exception(
-                ErrorCodes::BAD_ARGUMENTS,
-                "Preprocessor function for index {} must contain the expression: {}",
-                index_description.name,
-                index_definition_ast.getExpression()->as<ASTFunction>()->getColumnNameWithoutAlias()
-            );
-    }
-    else
-        validatePreprocessorASTExpressionGeneric(preprocessor_function, index_description);
+    const ASTFunction *index_expression_function = index_expresion_ast->as<ASTFunction>();
+    const ASTIdentifier *index_expression_identifier = index_expresion_ast->as<ASTIdentifier>();
+
+    validatePreprocessorASTRecurse(preprocessor_function, index_identifier_name, index_expression_function, index_expression_identifier);
 }
 
 DataTypePtr getInnerType(DataTypePtr type)
@@ -262,7 +220,7 @@ ExpressionActions MergeTreeIndexTextPreprocessor::parseExpression(const IndexDes
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Preprocessor argument must be an expression");
 
         /// Now we know that the only valid identifier_name must be the text indexed column.
-        validatePreprocessorASTExpression(preprocessor_function, index_description);
+        validatePreprocessorAST(preprocessor_function, index_description);
     }
 
     /// Convert ASTPtr -> ActionsDAG

--- a/src/Storages/MergeTree/MergeTreeIndexTextPreprocessor.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPreprocessor.cpp
@@ -20,6 +20,7 @@
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/ExpressionListParsers.h>
 #include <Storages/IndicesDescription.h>
+#include "base/defines.h"
 
 
 namespace DB
@@ -35,29 +36,65 @@ namespace ErrorCodes
 
 namespace
 {
-/// Early preprocessor argument validation.
-/// Maybe we could omit this validation and use only the validate function. But here we do it early and simpler to ensure that what we parse
-/// later is correct.
-void validatePreprocessorASTExpression(const ASTFunction * function, const String & identifier_name)
+
+/// On map columns the preprocessor expression should be on index definition.
+size_t validatePreprocessorASTExpressionForMaps(const ASTFunction * preprocessor_function, const IndexDescription & index_description)
 {
-    chassert(!identifier_name.empty());
-    chassert(function != nullptr);
 
-    if (function->arguments == nullptr)
-        throw Exception(ErrorCodes::INCORRECT_QUERY, "Preprocessor function has no arguments");
+    const ASTIndexDeclaration &index_definition_ast = index_description.definition_ast->as<ASTIndexDeclaration &>();
+    ASTPtr index_expresion_ast = index_definition_ast.getExpression();
+    const ASTFunction *index_expression_function = index_expresion_ast->as<ASTFunction>();
+    if (index_expression_function == nullptr)
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Index definition on map columns must be an expression, but got: {}", index_expresion_ast->getColumnName());
 
-    for (const auto & argument : function->arguments->children)
+    size_t counter = 0;
+
+    if (index_expression_function->getColumnNameWithoutAlias() == preprocessor_function->getColumnNameWithoutAlias())
+        return 1;
+
+    for (const auto & argument : preprocessor_function->arguments->children)
+    {
+        /// In principle all literals are valid
+        if (argument->as<ASTLiteral>())
+            continue;
+
+        /// We must have only the index definition as argument, no Identifiers at this point.
+        if (const ASTIdentifier * argument_identifier = argument->as<ASTIdentifier>())
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "Preprocessor function on map column indices must only reference index definition expression: {}, but also got also: {}",
+                index_description.column_names.front(), argument_identifier->name());
+
+        /// Check the arguments recursively (won't happen more than 2 or 3 times on average so it's fine).
+        if (const ASTFunction * subfunction = argument->as<ASTFunction>())
+        {
+            counter += validatePreprocessorASTExpressionForMaps(subfunction, index_description);
+            continue;
+        }
+
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Preprocessor function on map columns expects a literal or function as argument");
+    }
+
+    return counter;
+}
+
+void validatePreprocessorASTExpressionGeneric(const ASTFunction * preprocessor_function, const IndexDescription & index_description)
+{
+    const std::string &index_identifier_name = index_description.column_names.front();
+    chassert(!index_identifier_name.empty());
+
+    for (const auto & argument : preprocessor_function->arguments->children)
     {
         /// In principle all literals are valid
         if (argument->as<ASTLiteral>())
             continue;
 
         /// We must have only the valid identifier_name as argument
-        if (const ASTIdentifier * identifier = argument->as<ASTIdentifier>())
+        if (const ASTIdentifier * argument_identifier = argument->as<ASTIdentifier>())
         {
-            if (identifier_name != identifier->name())
+            if (index_identifier_name != argument_identifier->name())
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "Preprocessor function must only reference column: {}, also got: {}",
-                    identifier_name, identifier->name());
+                    index_identifier_name, argument_identifier->name());
 
             continue;
         }
@@ -65,12 +102,45 @@ void validatePreprocessorASTExpression(const ASTFunction * function, const Strin
         /// Check the arguments recursively (won't happen more than 2 or 3 times on average so it's fine).
         if (const ASTFunction * subfunction = argument->as<ASTFunction>())
         {
-            validatePreprocessorASTExpression(subfunction, identifier_name);
+            validatePreprocessorASTExpressionGeneric(subfunction, index_description);
             continue;
         }
 
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Preprocessor function expects a literal or identifier as argument");
     }
+}
+
+/// Early preprocessor argument validation.
+/// Maybe we could omit this validation and use only the validate function. But here we do it early and simpler to ensure that what we parse
+/// later is correct.
+void validatePreprocessorASTExpression(const ASTFunction * preprocessor_function, const IndexDescription & index_description)
+{
+    chassert(preprocessor_function != nullptr);
+    if (preprocessor_function->arguments == nullptr)
+        throw Exception(ErrorCodes::INCORRECT_QUERY, "Preprocessor function has no arguments");
+
+    chassert(index_description.column_names.size() == 1);
+    chassert(index_description.data_types.size() == 1);
+
+    const std::string &index_identifier_name = index_description.column_names.front();
+    chassert(!index_identifier_name.empty());
+
+    const ASTIndexDeclaration &index_definition_ast = index_description.definition_ast->as<ASTIndexDeclaration &>();
+    ASTPtr index_expresion_ast = index_definition_ast.getExpression();
+
+    if (isMap(index_description.data_types.front()))
+    {
+        const size_t expression_counter = validatePreprocessorASTExpressionForMaps(preprocessor_function, index_description);
+        if (expression_counter == 0)
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "Preprocessor function for index {} must contain the expression: {}",
+                index_description.name,
+                index_definition_ast.getExpression()->as<ASTFunction>()->getColumnNameWithoutAlias()
+            );
+    }
+    else
+        validatePreprocessorASTExpressionGeneric(preprocessor_function, index_description);
 }
 
 DataTypePtr getInnerType(DataTypePtr type)
@@ -160,9 +230,6 @@ String MergeTreeIndexTextPreprocessor::process(const String & input) const
 
 ExpressionActions MergeTreeIndexTextPreprocessor::parseExpression(const IndexDescription & index_description, const String & expression)
 {
-    chassert(index_description.column_names.size() == 1);
-    chassert(index_description.data_types.size() == 1);
-
     /// Empty expression still creates a preprocessor without actions.
     if (expression.empty())
         return ExpressionActions(ActionsDAG());
@@ -195,8 +262,7 @@ ExpressionActions MergeTreeIndexTextPreprocessor::parseExpression(const IndexDes
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Preprocessor argument must be an expression");
 
         /// Now we know that the only valid identifier_name must be the text indexed column.
-        String identifier_name = index_description.column_names.front();
-        validatePreprocessorASTExpression(preprocessor_function, identifier_name);
+        validatePreprocessorASTExpression(preprocessor_function, index_description);
     }
 
     /// Convert ASTPtr -> ActionsDAG
@@ -205,8 +271,6 @@ ExpressionActions MergeTreeIndexTextPreprocessor::parseExpression(const IndexDes
     const String alias = expression_ast->getAliasOrColumnName();
 
     DataTypePtr column_data_type = getInnerType(index_description.data_types.front());
-
-
     NamesAndTypesList source_columns({{index_description.column_names.front(), column_data_type}});
 
     NamesAndTypesList aggregation_keys;
@@ -250,6 +314,14 @@ ExpressionActions MergeTreeIndexTextPreprocessor::parseExpression(const IndexDes
 
     if (actions.hasNonDeterministic())
         throw Exception(ErrorCodes::INCORRECT_QUERY, "The preprocessor expression must not contain non-deterministic functions");
+
+    const auto &actions_inputs = actions.getInputs();
+
+    if (actions_inputs.size() != 1)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "The preprocessor expression must receive one input column");
+
+    if (!isStringOrFixedString(actions_inputs.front()->result_type))
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "The preprocessor expression must receive a String or FixedString input column");
 
     /// FINALLY! Lets build the ExpressionActions.
     return ExpressionActions(std::move(actions));

--- a/tests/queries/0_stateless/02346_text_index_preprocessor.reference
+++ b/tests/queries/0_stateless/02346_text_index_preprocessor.reference
@@ -40,24 +40,6 @@ Positive tests on preprocessor construction and use.
 1
 1
 1
-- Test simple preprocessor expression with Array(String).
-1
-1
-1
-1
-1
-1
-1
-1
-- Test simple preprocessor expression with Array(FixedString).
-1
-1
-1
-1
-1
-1
-1
-1
 - Test preprocessor declaration using column more than once.
 1
 0
@@ -90,12 +72,76 @@ Positive tests on preprocessor construction and use.
 0
 1
 1
+- Index definition must be the an expression used in the preprocessor
+-- Single arguments
+1
+0
+1
+1
+0
+0
+0
+1
+0
+1
+1
+1
+0
+1
+1
+-- Multiple arguments
+1
+0
+1
+1
+0
+0
+0
+1
+0
+1
+1
+1
+0
+1
+1
 Negative tests on preprocessor construction validations.
 - The preprocessor argument must not reference non-indexed columns
-- Index definition may not be and expression when there is preprocessor
--- Not even the same expression
+- Index definition may not be a different expression than used in the preprocessor
 - The preprocessor must be an expression
 - The preprocessor must be an expression, with existing functions
 - The preprocessor must have input and output values of the same type (here: String)
 - The preprocessor expression must use the column identifier
 - The preprocessor expression must use only deterministic functions
+- Test simple preprocessor expression with Array(String).
+1
+1
+1
+1
+1
+1
+1
+1
+- Test simple preprocessor expression with Array(FixedString).
+1
+1
+1
+1
+1
+1
+1
+1
+Maps support
+- Map positive tests
+-- Index definition must be an expression
+1
+1
+1
+1
+1
+1
+1
+1
+- Map negative tests
+-- Index on whole map must fail
+-- Index definition must appear literally in the preprocessor expression

--- a/tests/queries/0_stateless/02346_text_index_preprocessor.sql
+++ b/tests/queries/0_stateless/02346_text_index_preprocessor.sql
@@ -8,332 +8,361 @@ SET use_skip_indexes_on_data_read = 1;
 
 DROP TABLE IF EXISTS tab;
 
-SELECT 'Positive tests on preprocessor construction and use.';
+-- SELECT 'Positive tests on preprocessor construction and use.';
 
-SELECT '- Test simple preprocessor expression.';
+-- SELECT '- Test simple preprocessor expression.';
+
+-- CREATE TABLE tab
+-- (
+--     key UInt64,
+--     val String,
+--     INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(val))
+-- )
+-- ENGINE = MergeTree
+-- ORDER BY key;
+
+-- INSERT INTO tab VALUES (1, 'foo'), (2, 'BAR'), (3, 'Baz');
+
+-- SELECT count() FROM tab WHERE hasToken(val, 'foo');
+-- SELECT count() FROM tab WHERE hasToken(val, 'FOO');
+-- SELECT count() FROM tab WHERE hasToken(val, 'BAR');
+-- SELECT count() FROM tab WHERE hasToken(val, 'Baz');
+-- SELECT count() FROM tab WHERE hasToken(val, 'bar');
+-- SELECT count() FROM tab WHERE hasToken(val, 'baz');
+-- SELECT count() FROM tab WHERE hasToken(val, 'def');
+
+-- SELECT count() FROM tab WHERE hasAllTokens(val, 'foo');
+-- SELECT count() FROM tab WHERE hasAllTokens(val, 'FOO');
+-- SELECT count() FROM tab WHERE hasAllTokens(val, 'BAR');
+-- SELECT count() FROM tab WHERE hasAllTokens(val, 'Baz');
+
+-- SELECT count() FROM tab WHERE hasAnyTokens(val, 'foo');
+-- SELECT count() FROM tab WHERE hasAnyTokens(val, 'FOO');
+-- SELECT count() FROM tab WHERE hasAnyTokens(val, 'BAR');
+-- SELECT count() FROM tab WHERE hasAnyTokens(val, 'Baz');
+
+-- DROP TABLE tab;
+
+-- SELECT '- Test simple preprocessor expression with LowCardinality.';
+
+-- CREATE TABLE tab
+-- (
+--     key UInt64,
+--     val LowCardinality(String),
+--     INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(val))
+-- )
+-- ENGINE = MergeTree
+-- ORDER BY key;
+
+-- INSERT INTO tab VALUES (1, 'foo'), (2, 'BAR'), (3, 'Baz');
+
+-- SELECT count() FROM tab WHERE hasToken(val, 'foo');
+-- SELECT count() FROM tab WHERE hasToken(val, 'FOO');
+-- SELECT count() FROM tab WHERE hasToken(val, 'BAR');
+-- SELECT count() FROM tab WHERE hasToken(val, 'Baz');
+-- SELECT count() FROM tab WHERE hasToken(val, 'bar');
+-- SELECT count() FROM tab WHERE hasToken(val, 'baz');
+-- SELECT count() FROM tab WHERE hasToken(val, 'def');
+
+-- SELECT count() FROM tab WHERE hasAllTokens(val, 'foo');
+-- SELECT count() FROM tab WHERE hasAllTokens(val, 'FOO');
+-- SELECT count() FROM tab WHERE hasAllTokens(val, 'BAR');
+-- SELECT count() FROM tab WHERE hasAllTokens(val, 'Baz');
+
+-- SELECT count() FROM tab WHERE hasAnyTokens(val, 'foo');
+-- SELECT count() FROM tab WHERE hasAnyTokens(val, 'FOO');
+-- SELECT count() FROM tab WHERE hasAnyTokens(val, 'BAR');
+-- SELECT count() FROM tab WHERE hasAnyTokens(val, 'Baz');
+
+-- DROP TABLE tab;
+
+
+-- SELECT '- Test simple preprocessor expression with FixedString.';
+
+-- CREATE TABLE tab
+-- (
+--     key UInt64,
+--     val FixedString(3),
+--     INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(val))
+-- )
+-- ENGINE = MergeTree
+-- ORDER BY key;
+
+-- INSERT INTO tab VALUES (1, 'foo'), (2, 'BAR'), (3, 'Baz');
+
+-- -- hasToken doesn't support FixedString columns
+-- SELECT count() FROM tab WHERE hasToken(val, 'foo'); -- { serverError ILLEGAL_COLUMN }
+-- SELECT count() FROM tab WHERE hasToken(val, 'FOO'); -- { serverError ILLEGAL_COLUMN }
+-- SELECT count() FROM tab WHERE hasToken(val, 'BAR'); -- { serverError ILLEGAL_COLUMN }
+-- SELECT count() FROM tab WHERE hasToken(val, 'Baz'); -- { serverError ILLEGAL_COLUMN }
+-- SELECT count() FROM tab WHERE hasToken(val, 'bar'); -- { serverError ILLEGAL_COLUMN }
+-- SELECT count() FROM tab WHERE hasToken(val, 'baz'); -- { serverError ILLEGAL_COLUMN }
+-- SELECT count() FROM tab WHERE hasToken(val, 'def'); -- { serverError ILLEGAL_COLUMN }
+
+-- SELECT count() FROM tab WHERE hasAllTokens(val, 'foo');
+-- SELECT count() FROM tab WHERE hasAllTokens(val, 'FOO');
+-- SELECT count() FROM tab WHERE hasAllTokens(val, 'BAR');
+-- SELECT count() FROM tab WHERE hasAllTokens(val, 'Baz');
+
+-- SELECT count() FROM tab WHERE hasAnyTokens(val, 'foo');
+-- SELECT count() FROM tab WHERE hasAnyTokens(val, 'FOO');
+-- SELECT count() FROM tab WHERE hasAnyTokens(val, 'BAR');
+-- SELECT count() FROM tab WHERE hasAnyTokens(val, 'Baz');
+
+-- DROP TABLE tab;
+
+-- SELECT '- Test simple preprocessor expression with Array(String).';
+-- CREATE TABLE tab
+-- (
+--     key UInt64,
+--     val Array(String),
+--     INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(val))
+-- )
+-- ENGINE = MergeTree ORDER BY tuple();
+
+-- INSERT INTO tab VALUES (1, ['foo']), (2, ['BAR']), (3, ['Baz']);
+
+-- -- hasToken doesn't support Array(String) columns
+-- SELECT count() FROM tab WHERE hasToken(val, 'foo'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+-- SELECT count() FROM tab WHERE hasToken(val, 'FOO'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+-- SELECT count() FROM tab WHERE hasToken(val, 'BAR'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+-- SELECT count() FROM tab WHERE hasToken(val, 'Baz'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+-- SELECT count() FROM tab WHERE hasToken(val, 'bar'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+-- SELECT count() FROM tab WHERE hasToken(val, 'baz'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+-- SELECT count() FROM tab WHERE hasToken(val, 'def'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+
+-- SELECT count() FROM tab WHERE hasAllTokens(val, 'foo');
+-- SELECT count() FROM tab WHERE hasAllTokens(val, 'FOO');
+-- SELECT count() FROM tab WHERE hasAllTokens(val, 'BAR');
+-- SELECT count() FROM tab WHERE hasAllTokens(val, 'Baz');
+
+-- SELECT count() FROM tab WHERE hasAnyTokens(val, 'foo');
+-- SELECT count() FROM tab WHERE hasAnyTokens(val, 'FOO');
+-- SELECT count() FROM tab WHERE hasAnyTokens(val, 'BAR');
+-- SELECT count() FROM tab WHERE hasAnyTokens(val, 'Baz');
+
+-- DROP TABLE tab;
+
+-- SELECT '- Test simple preprocessor expression with Array(FixedString).';
+-- CREATE TABLE tab
+-- (
+--     key UInt64,
+--     val Array(FixedString(3)),
+--     INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(val))
+-- )
+-- ENGINE = MergeTree ORDER BY tuple();
+
+-- INSERT INTO tab VALUES (1, ['foo']), (2, ['BAR']), (3, ['Baz']);
+
+-- -- hasToken doesn't support Array(String) columns
+-- SELECT count() FROM tab WHERE hasToken(val, 'foo'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+-- SELECT count() FROM tab WHERE hasToken(val, 'FOO'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+-- SELECT count() FROM tab WHERE hasToken(val, 'BAR'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+-- SELECT count() FROM tab WHERE hasToken(val, 'Baz'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+-- SELECT count() FROM tab WHERE hasToken(val, 'bar'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+-- SELECT count() FROM tab WHERE hasToken(val, 'baz'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+-- SELECT count() FROM tab WHERE hasToken(val, 'def'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+
+-- SELECT count() FROM tab WHERE hasAllTokens(val, 'foo');
+-- SELECT count() FROM tab WHERE hasAllTokens(val, 'FOO');
+-- SELECT count() FROM tab WHERE hasAllTokens(val, 'BAR');
+-- SELECT count() FROM tab WHERE hasAllTokens(val, 'Baz');
+
+-- SELECT count() FROM tab WHERE hasAnyTokens(val, 'foo');
+-- SELECT count() FROM tab WHERE hasAnyTokens(val, 'FOO');
+-- SELECT count() FROM tab WHERE hasAnyTokens(val, 'BAR');
+-- SELECT count() FROM tab WHERE hasAnyTokens(val, 'Baz');
+
+-- DROP TABLE tab;
+
+-- SELECT '- Test preprocessor declaration using column more than once.';
+-- CREATE TABLE tab
+-- (
+--     key UInt64,
+--     val String,
+--     INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = concat(val, val))
+-- )
+-- ENGINE = MergeTree
+-- ORDER BY tuple();
+
+-- INSERT INTO tab VALUES (1, 'foo'), (2, 'BAR'), (3, 'Baz');
+
+-- SELECT count() FROM tab WHERE hasToken(val, 'foo');
+-- SELECT count() FROM tab WHERE hasToken(val, 'FOO');
+-- SELECT count() FROM tab WHERE hasToken(val, 'BAR');
+-- SELECT count() FROM tab WHERE hasToken(val, 'Baz');
+-- SELECT count() FROM tab WHERE hasToken(val, 'bar');
+-- SELECT count() FROM tab WHERE hasToken(val, 'baz');
+-- SELECT count() FROM tab WHERE hasToken(val, 'def');
+
+-- SELECT count() FROM tab WHERE hasAllTokens(val, 'foo');
+-- SELECT count() FROM tab WHERE hasAllTokens(val, 'FOO');
+-- SELECT count() FROM tab WHERE hasAllTokens(val, 'BAR');
+-- SELECT count() FROM tab WHERE hasAllTokens(val, 'Baz');
+-- SELECT count() FROM tab WHERE hasAnyTokens(val, 'foo');
+-- SELECT count() FROM tab WHERE hasAnyTokens(val, 'FOO');
+-- SELECT count() FROM tab WHERE hasAnyTokens(val, 'BAR');
+-- SELECT count() FROM tab WHERE hasAnyTokens(val, 'Baz');
+
+-- DROP TABLE tab;
+
+-- SELECT '- Test preprocessor declaration using udf.';
+-- DROP FUNCTION IF EXISTS udf_preprocessor;
+-- CREATE FUNCTION udf_preprocessor AS (s) -> concat(val, lower(val));
+
+-- CREATE TABLE tab
+-- (
+--     key UInt64,
+--     val String,
+--     INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = udf_preprocessor(val))
+-- )
+-- ENGINE = MergeTree
+-- ORDER BY tuple();
+
+
+-- INSERT INTO tab VALUES (1, 'foo'), (2, 'BAR'), (3, 'Baz');
+
+-- SELECT count() FROM tab WHERE hasToken(val, 'foo');
+-- SELECT count() FROM tab WHERE hasToken(val, 'FOO');
+-- SELECT count() FROM tab WHERE hasToken(val, 'BAR');
+-- SELECT count() FROM tab WHERE hasToken(val, 'Baz');
+-- SELECT count() FROM tab WHERE hasToken(val, 'bar');
+-- SELECT count() FROM tab WHERE hasToken(val, 'baz');
+-- SELECT count() FROM tab WHERE hasToken(val, 'def');
+
+-- SELECT count() FROM tab WHERE hasAllTokens(val, 'foo');
+-- SELECT count() FROM tab WHERE hasAllTokens(val, 'FOO');
+-- SELECT count() FROM tab WHERE hasAllTokens(val, 'BAR');
+-- SELECT count() FROM tab WHERE hasAllTokens(val, 'Baz');
+-- SELECT count() FROM tab WHERE hasAnyTokens(val, 'foo');
+-- SELECT count() FROM tab WHERE hasAnyTokens(val, 'FOO');
+-- SELECT count() FROM tab WHERE hasAnyTokens(val, 'BAR');
+-- SELECT count() FROM tab WHERE hasAnyTokens(val, 'Baz');
+
+-- DROP TABLE tab;
+-- DROP FUNCTION udf_preprocessor;
+
+-- SELECT 'Negative tests on preprocessor construction validations.';
+
+-- -- The preprocessor argument must reference the index column
+-- CREATE TABLE tab
+-- (
+--     key UInt64,
+--     val String,
+--     other_str String,
+--     INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(other_str))
+-- )
+-- ENGINE = MergeTree ORDER BY tuple();  -- { serverError BAD_ARGUMENTS }
+
+-- SELECT '- The preprocessor argument must not reference non-indexed columns';
+-- CREATE TABLE tab
+-- (
+--     key UInt64,
+--     val String,
+--     other_str String,
+--     INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = concat(val, other_str))
+-- )
+-- ENGINE = MergeTree ORDER BY tuple();   -- { serverError BAD_ARGUMENTS }
+
+-- SELECT '- Index definition may not be and expression when there is preprocessor';
+-- CREATE TABLE tab
+-- (
+--     key UInt64,
+--     val String,
+--     INDEX idx(upper(val)) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(val))
+-- )
+-- ENGINE = MergeTree ORDER BY tuple();   -- { serverError BAD_ARGUMENTS }
+
+-- SELECT '-- Not even the same expression';
+-- CREATE TABLE tab
+-- (
+--     key UInt64,
+--     val String,
+--     INDEX idx(lower(val)) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(val))
+-- )
+-- ENGINE = MergeTree ORDER BY tuple();   -- { serverError BAD_ARGUMENTS }
+
+-- CREATE TABLE tab
+-- (
+--     key UInt64,
+--     val String,
+--     INDEX idx(upper(val)) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(upper(val)))
+-- )
+-- ENGINE = MergeTree ORDER BY tuple();   -- { serverError BAD_ARGUMENTS }
+
+-- SELECT '- The preprocessor must be an expression';
+-- CREATE TABLE tab
+-- (
+--     key UInt64,
+--     val String,
+--     INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = BAD)
+-- )
+-- ENGINE = MergeTree ORDER BY key;   -- { serverError BAD_ARGUMENTS }
+
+-- SELECT '- The preprocessor must be an expression, with existing functions';
+-- CREATE TABLE tab
+-- (
+--     key UInt64,
+--     val String,
+--     INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = nonExistingFunction(val))
+-- )
+-- ENGINE = MergeTree ORDER BY tuple();   -- { serverError UNKNOWN_FUNCTION }
+
+-- SELECT '- The preprocessor must have input and output values of the same type (here: String)';
+-- CREATE TABLE tab
+-- (
+--     key UInt64,
+--     val String,
+--     INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = length(val))
+-- )
+-- ENGINE = MergeTree ORDER BY tuple();   -- { serverError INCORRECT_QUERY }
+
+-- SELECT '- The preprocessor expression must use the column identifier';
+-- CREATE TABLE tab
+-- (
+--     key UInt64,
+--     val String,
+--     INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = hostname())
+-- )
+-- ENGINE = MergeTree ORDER BY tuple();   -- { serverError INCORRECT_QUERY }
+
+-- SELECT '- The preprocessor expression must use only deterministic functions';
+-- CREATE TABLE tab
+-- (
+--     key UInt64,
+--     val String,
+--     INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = concat(val, toString(rand())))
+-- )
+-- ENGINE = MergeTree ORDER BY tuple();   -- { serverError INCORRECT_QUERY }
+
+SELECT '- The preprocessor expression should support maps';
+SELECT '-- Index definition must be an expression';
 
 CREATE TABLE tab
 (
     key UInt64,
-    val String,
-    INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(val))
-)
-ENGINE = MergeTree
-ORDER BY key;
-
-INSERT INTO tab VALUES (1, 'foo'), (2, 'BAR'), (3, 'Baz');
-
-SELECT count() FROM tab WHERE hasToken(val, 'foo');
-SELECT count() FROM tab WHERE hasToken(val, 'FOO');
-SELECT count() FROM tab WHERE hasToken(val, 'BAR');
-SELECT count() FROM tab WHERE hasToken(val, 'Baz');
-SELECT count() FROM tab WHERE hasToken(val, 'bar');
-SELECT count() FROM tab WHERE hasToken(val, 'baz');
-SELECT count() FROM tab WHERE hasToken(val, 'def');
-
-SELECT count() FROM tab WHERE hasAllTokens(val, 'foo');
-SELECT count() FROM tab WHERE hasAllTokens(val, 'FOO');
-SELECT count() FROM tab WHERE hasAllTokens(val, 'BAR');
-SELECT count() FROM tab WHERE hasAllTokens(val, 'Baz');
-
-SELECT count() FROM tab WHERE hasAnyTokens(val, 'foo');
-SELECT count() FROM tab WHERE hasAnyTokens(val, 'FOO');
-SELECT count() FROM tab WHERE hasAnyTokens(val, 'BAR');
-SELECT count() FROM tab WHERE hasAnyTokens(val, 'Baz');
-
-DROP TABLE tab;
-
-SELECT '- Test simple preprocessor expression with LowCardinality.';
-
-CREATE TABLE tab
-(
-    key UInt64,
-    val LowCardinality(String),
-    INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(val))
-)
-ENGINE = MergeTree
-ORDER BY key;
-
-INSERT INTO tab VALUES (1, 'foo'), (2, 'BAR'), (3, 'Baz');
-
-SELECT count() FROM tab WHERE hasToken(val, 'foo');
-SELECT count() FROM tab WHERE hasToken(val, 'FOO');
-SELECT count() FROM tab WHERE hasToken(val, 'BAR');
-SELECT count() FROM tab WHERE hasToken(val, 'Baz');
-SELECT count() FROM tab WHERE hasToken(val, 'bar');
-SELECT count() FROM tab WHERE hasToken(val, 'baz');
-SELECT count() FROM tab WHERE hasToken(val, 'def');
-
-SELECT count() FROM tab WHERE hasAllTokens(val, 'foo');
-SELECT count() FROM tab WHERE hasAllTokens(val, 'FOO');
-SELECT count() FROM tab WHERE hasAllTokens(val, 'BAR');
-SELECT count() FROM tab WHERE hasAllTokens(val, 'Baz');
-
-SELECT count() FROM tab WHERE hasAnyTokens(val, 'foo');
-SELECT count() FROM tab WHERE hasAnyTokens(val, 'FOO');
-SELECT count() FROM tab WHERE hasAnyTokens(val, 'BAR');
-SELECT count() FROM tab WHERE hasAnyTokens(val, 'Baz');
-
-DROP TABLE tab;
-
-
-SELECT '- Test simple preprocessor expression with FixedString.';
-
-CREATE TABLE tab
-(
-    key UInt64,
-    val FixedString(3),
-    INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(val))
-)
-ENGINE = MergeTree
-ORDER BY key;
-
-INSERT INTO tab VALUES (1, 'foo'), (2, 'BAR'), (3, 'Baz');
-
--- hasToken doesn't support FixedString columns
-SELECT count() FROM tab WHERE hasToken(val, 'foo'); -- { serverError ILLEGAL_COLUMN }
-SELECT count() FROM tab WHERE hasToken(val, 'FOO'); -- { serverError ILLEGAL_COLUMN }
-SELECT count() FROM tab WHERE hasToken(val, 'BAR'); -- { serverError ILLEGAL_COLUMN }
-SELECT count() FROM tab WHERE hasToken(val, 'Baz'); -- { serverError ILLEGAL_COLUMN }
-SELECT count() FROM tab WHERE hasToken(val, 'bar'); -- { serverError ILLEGAL_COLUMN }
-SELECT count() FROM tab WHERE hasToken(val, 'baz'); -- { serverError ILLEGAL_COLUMN }
-SELECT count() FROM tab WHERE hasToken(val, 'def'); -- { serverError ILLEGAL_COLUMN }
-
-SELECT count() FROM tab WHERE hasAllTokens(val, 'foo');
-SELECT count() FROM tab WHERE hasAllTokens(val, 'FOO');
-SELECT count() FROM tab WHERE hasAllTokens(val, 'BAR');
-SELECT count() FROM tab WHERE hasAllTokens(val, 'Baz');
-
-SELECT count() FROM tab WHERE hasAnyTokens(val, 'foo');
-SELECT count() FROM tab WHERE hasAnyTokens(val, 'FOO');
-SELECT count() FROM tab WHERE hasAnyTokens(val, 'BAR');
-SELECT count() FROM tab WHERE hasAnyTokens(val, 'Baz');
-
-DROP TABLE tab;
-
-SELECT '- Test simple preprocessor expression with Array(String).';
-CREATE TABLE tab
-(
-    key UInt64,
-    val Array(String),
-    INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(val))
-)
-ENGINE = MergeTree ORDER BY tuple();
-
-INSERT INTO tab VALUES (1, ['foo']), (2, ['BAR']), (3, ['Baz']);
-
--- hasToken doesn't support Array(String) columns
-SELECT count() FROM tab WHERE hasToken(val, 'foo'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
-SELECT count() FROM tab WHERE hasToken(val, 'FOO'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
-SELECT count() FROM tab WHERE hasToken(val, 'BAR'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
-SELECT count() FROM tab WHERE hasToken(val, 'Baz'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
-SELECT count() FROM tab WHERE hasToken(val, 'bar'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
-SELECT count() FROM tab WHERE hasToken(val, 'baz'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
-SELECT count() FROM tab WHERE hasToken(val, 'def'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
-
-SELECT count() FROM tab WHERE hasAllTokens(val, 'foo');
-SELECT count() FROM tab WHERE hasAllTokens(val, 'FOO');
-SELECT count() FROM tab WHERE hasAllTokens(val, 'BAR');
-SELECT count() FROM tab WHERE hasAllTokens(val, 'Baz');
-
-SELECT count() FROM tab WHERE hasAnyTokens(val, 'foo');
-SELECT count() FROM tab WHERE hasAnyTokens(val, 'FOO');
-SELECT count() FROM tab WHERE hasAnyTokens(val, 'BAR');
-SELECT count() FROM tab WHERE hasAnyTokens(val, 'Baz');
-
-DROP TABLE tab;
-
-SELECT '- Test simple preprocessor expression with Array(FixedString).';
-CREATE TABLE tab
-(
-    key UInt64,
-    val Array(FixedString(3)),
-    INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(val))
-)
-ENGINE = MergeTree ORDER BY tuple();
-
-INSERT INTO tab VALUES (1, ['foo']), (2, ['BAR']), (3, ['Baz']);
-
--- hasToken doesn't support Array(String) columns
-SELECT count() FROM tab WHERE hasToken(val, 'foo'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
-SELECT count() FROM tab WHERE hasToken(val, 'FOO'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
-SELECT count() FROM tab WHERE hasToken(val, 'BAR'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
-SELECT count() FROM tab WHERE hasToken(val, 'Baz'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
-SELECT count() FROM tab WHERE hasToken(val, 'bar'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
-SELECT count() FROM tab WHERE hasToken(val, 'baz'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
-SELECT count() FROM tab WHERE hasToken(val, 'def'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
-
-SELECT count() FROM tab WHERE hasAllTokens(val, 'foo');
-SELECT count() FROM tab WHERE hasAllTokens(val, 'FOO');
-SELECT count() FROM tab WHERE hasAllTokens(val, 'BAR');
-SELECT count() FROM tab WHERE hasAllTokens(val, 'Baz');
-
-SELECT count() FROM tab WHERE hasAnyTokens(val, 'foo');
-SELECT count() FROM tab WHERE hasAnyTokens(val, 'FOO');
-SELECT count() FROM tab WHERE hasAnyTokens(val, 'BAR');
-SELECT count() FROM tab WHERE hasAnyTokens(val, 'Baz');
-
-DROP TABLE tab;
-
-SELECT '- Test preprocessor declaration using column more than once.';
-CREATE TABLE tab
-(
-    key UInt64,
-    val String,
-    INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = concat(val, val))
-)
-ENGINE = MergeTree
-ORDER BY tuple();
-
-INSERT INTO tab VALUES (1, 'foo'), (2, 'BAR'), (3, 'Baz');
-
-SELECT count() FROM tab WHERE hasToken(val, 'foo');
-SELECT count() FROM tab WHERE hasToken(val, 'FOO');
-SELECT count() FROM tab WHERE hasToken(val, 'BAR');
-SELECT count() FROM tab WHERE hasToken(val, 'Baz');
-SELECT count() FROM tab WHERE hasToken(val, 'bar');
-SELECT count() FROM tab WHERE hasToken(val, 'baz');
-SELECT count() FROM tab WHERE hasToken(val, 'def');
-
-SELECT count() FROM tab WHERE hasAllTokens(val, 'foo');
-SELECT count() FROM tab WHERE hasAllTokens(val, 'FOO');
-SELECT count() FROM tab WHERE hasAllTokens(val, 'BAR');
-SELECT count() FROM tab WHERE hasAllTokens(val, 'Baz');
-SELECT count() FROM tab WHERE hasAnyTokens(val, 'foo');
-SELECT count() FROM tab WHERE hasAnyTokens(val, 'FOO');
-SELECT count() FROM tab WHERE hasAnyTokens(val, 'BAR');
-SELECT count() FROM tab WHERE hasAnyTokens(val, 'Baz');
-
-DROP TABLE tab;
-
-SELECT '- Test preprocessor declaration using udf.';
-DROP FUNCTION IF EXISTS udf_preprocessor;
-CREATE FUNCTION udf_preprocessor AS (s) -> concat(val, lower(val));
-
-CREATE TABLE tab
-(
-    key UInt64,
-    val String,
-    INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = udf_preprocessor(val))
-)
-ENGINE = MergeTree
-ORDER BY tuple();
-
-
-INSERT INTO tab VALUES (1, 'foo'), (2, 'BAR'), (3, 'Baz');
-
-SELECT count() FROM tab WHERE hasToken(val, 'foo');
-SELECT count() FROM tab WHERE hasToken(val, 'FOO');
-SELECT count() FROM tab WHERE hasToken(val, 'BAR');
-SELECT count() FROM tab WHERE hasToken(val, 'Baz');
-SELECT count() FROM tab WHERE hasToken(val, 'bar');
-SELECT count() FROM tab WHERE hasToken(val, 'baz');
-SELECT count() FROM tab WHERE hasToken(val, 'def');
-
-SELECT count() FROM tab WHERE hasAllTokens(val, 'foo');
-SELECT count() FROM tab WHERE hasAllTokens(val, 'FOO');
-SELECT count() FROM tab WHERE hasAllTokens(val, 'BAR');
-SELECT count() FROM tab WHERE hasAllTokens(val, 'Baz');
-SELECT count() FROM tab WHERE hasAnyTokens(val, 'foo');
-SELECT count() FROM tab WHERE hasAnyTokens(val, 'FOO');
-SELECT count() FROM tab WHERE hasAnyTokens(val, 'BAR');
-SELECT count() FROM tab WHERE hasAnyTokens(val, 'Baz');
-
-DROP TABLE tab;
-DROP FUNCTION udf_preprocessor;
-
-SELECT 'Negative tests on preprocessor construction validations.';
-
--- The preprocessor argument must reference the index column
-CREATE TABLE tab
-(
-    key UInt64,
-    val String,
-    other_str String,
-    INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(other_str))
-)
-ENGINE = MergeTree ORDER BY tuple();  -- { serverError BAD_ARGUMENTS }
-
-SELECT '- The preprocessor argument must not reference non-indexed columns';
-CREATE TABLE tab
-(
-    key UInt64,
-    val String,
-    other_str String,
-    INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = concat(val, other_str))
-)
-ENGINE = MergeTree ORDER BY tuple();   -- { serverError BAD_ARGUMENTS }
-
-SELECT '- Index definition may not be and expression when there is preprocessor';
-CREATE TABLE tab
-(
-    key UInt64,
-    val String,
-    INDEX idx(upper(val)) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(val))
-)
-ENGINE = MergeTree ORDER BY tuple();   -- { serverError BAD_ARGUMENTS }
-
-SELECT '-- Not even the same expression';
-CREATE TABLE tab
-(
-    key UInt64,
-    val String,
-    INDEX idx(lower(val)) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(val))
-)
-ENGINE = MergeTree ORDER BY tuple();   -- { serverError BAD_ARGUMENTS }
-
-CREATE TABLE tab
-(
-    key UInt64,
-    val String,
-    INDEX idx(upper(val)) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(upper(val)))
-)
-ENGINE = MergeTree ORDER BY tuple();   -- { serverError BAD_ARGUMENTS }
-
-SELECT '- The preprocessor must be an expression';
-CREATE TABLE tab
-(
-    key UInt64,
-    val String,
-    INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = BAD)
+    val Map(String, String),
+    INDEX idx1(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(mapKeys(val)))
 )
 ENGINE = MergeTree ORDER BY key;   -- { serverError BAD_ARGUMENTS }
 
-SELECT '- The preprocessor must be an expression, with existing functions';
+SELECT '-- Index definition must appear literally in the preprocessor expression';
 CREATE TABLE tab
 (
     key UInt64,
-    val String,
-    INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = nonExistingFunction(val))
+    val Map(String, String),
+    INDEX idx2(mapKeys(val)) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(val))
 )
-ENGINE = MergeTree ORDER BY tuple();   -- { serverError UNKNOWN_FUNCTION }
+ENGINE = MergeTree ORDER BY key;   -- { serverError BAD_ARGUMENTS }
 
-SELECT '- The preprocessor must have input and output values of the same type (here: String)';
+SELECT '-- this must work';
 CREATE TABLE tab
 (
     key UInt64,
-    val String,
-    INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = length(val))
+    val Map(String, String),
+    INDEX idx3(mapKeys(val)) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(mapKeys(val)))
 )
-ENGINE = MergeTree ORDER BY tuple();   -- { serverError INCORRECT_QUERY }
-
-SELECT '- The preprocessor expression must use the column identifier';
-CREATE TABLE tab
-(
-    key UInt64,
-    val String,
-    INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = hostname())
-)
-ENGINE = MergeTree ORDER BY tuple();   -- { serverError INCORRECT_QUERY }
-
-SELECT '- The preprocessor expression must use only deterministic functions';
-CREATE TABLE tab
-(
-    key UInt64,
-    val String,
-    INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = concat(val, toString(rand())))
-)
-ENGINE = MergeTree ORDER BY tuple();   -- { serverError INCORRECT_QUERY }
+ENGINE = MergeTree ORDER BY key;
 
 
 DROP TABLE IF EXISTS tab;

--- a/tests/queries/0_stateless/02346_text_index_preprocessor.sql
+++ b/tests/queries/0_stateless/02346_text_index_preprocessor.sql
@@ -8,341 +8,409 @@ SET use_skip_indexes_on_data_read = 1;
 
 DROP TABLE IF EXISTS tab;
 
--- SELECT 'Positive tests on preprocessor construction and use.';
-
--- SELECT '- Test simple preprocessor expression.';
-
--- CREATE TABLE tab
--- (
---     key UInt64,
---     val String,
---     INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(val))
--- )
--- ENGINE = MergeTree
--- ORDER BY key;
-
--- INSERT INTO tab VALUES (1, 'foo'), (2, 'BAR'), (3, 'Baz');
-
--- SELECT count() FROM tab WHERE hasToken(val, 'foo');
--- SELECT count() FROM tab WHERE hasToken(val, 'FOO');
--- SELECT count() FROM tab WHERE hasToken(val, 'BAR');
--- SELECT count() FROM tab WHERE hasToken(val, 'Baz');
--- SELECT count() FROM tab WHERE hasToken(val, 'bar');
--- SELECT count() FROM tab WHERE hasToken(val, 'baz');
--- SELECT count() FROM tab WHERE hasToken(val, 'def');
-
--- SELECT count() FROM tab WHERE hasAllTokens(val, 'foo');
--- SELECT count() FROM tab WHERE hasAllTokens(val, 'FOO');
--- SELECT count() FROM tab WHERE hasAllTokens(val, 'BAR');
--- SELECT count() FROM tab WHERE hasAllTokens(val, 'Baz');
-
--- SELECT count() FROM tab WHERE hasAnyTokens(val, 'foo');
--- SELECT count() FROM tab WHERE hasAnyTokens(val, 'FOO');
--- SELECT count() FROM tab WHERE hasAnyTokens(val, 'BAR');
--- SELECT count() FROM tab WHERE hasAnyTokens(val, 'Baz');
-
--- DROP TABLE tab;
-
--- SELECT '- Test simple preprocessor expression with LowCardinality.';
-
--- CREATE TABLE tab
--- (
---     key UInt64,
---     val LowCardinality(String),
---     INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(val))
--- )
--- ENGINE = MergeTree
--- ORDER BY key;
-
--- INSERT INTO tab VALUES (1, 'foo'), (2, 'BAR'), (3, 'Baz');
-
--- SELECT count() FROM tab WHERE hasToken(val, 'foo');
--- SELECT count() FROM tab WHERE hasToken(val, 'FOO');
--- SELECT count() FROM tab WHERE hasToken(val, 'BAR');
--- SELECT count() FROM tab WHERE hasToken(val, 'Baz');
--- SELECT count() FROM tab WHERE hasToken(val, 'bar');
--- SELECT count() FROM tab WHERE hasToken(val, 'baz');
--- SELECT count() FROM tab WHERE hasToken(val, 'def');
-
--- SELECT count() FROM tab WHERE hasAllTokens(val, 'foo');
--- SELECT count() FROM tab WHERE hasAllTokens(val, 'FOO');
--- SELECT count() FROM tab WHERE hasAllTokens(val, 'BAR');
--- SELECT count() FROM tab WHERE hasAllTokens(val, 'Baz');
-
--- SELECT count() FROM tab WHERE hasAnyTokens(val, 'foo');
--- SELECT count() FROM tab WHERE hasAnyTokens(val, 'FOO');
--- SELECT count() FROM tab WHERE hasAnyTokens(val, 'BAR');
--- SELECT count() FROM tab WHERE hasAnyTokens(val, 'Baz');
-
--- DROP TABLE tab;
-
-
--- SELECT '- Test simple preprocessor expression with FixedString.';
-
--- CREATE TABLE tab
--- (
---     key UInt64,
---     val FixedString(3),
---     INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(val))
--- )
--- ENGINE = MergeTree
--- ORDER BY key;
-
--- INSERT INTO tab VALUES (1, 'foo'), (2, 'BAR'), (3, 'Baz');
-
--- -- hasToken doesn't support FixedString columns
--- SELECT count() FROM tab WHERE hasToken(val, 'foo'); -- { serverError ILLEGAL_COLUMN }
--- SELECT count() FROM tab WHERE hasToken(val, 'FOO'); -- { serverError ILLEGAL_COLUMN }
--- SELECT count() FROM tab WHERE hasToken(val, 'BAR'); -- { serverError ILLEGAL_COLUMN }
--- SELECT count() FROM tab WHERE hasToken(val, 'Baz'); -- { serverError ILLEGAL_COLUMN }
--- SELECT count() FROM tab WHERE hasToken(val, 'bar'); -- { serverError ILLEGAL_COLUMN }
--- SELECT count() FROM tab WHERE hasToken(val, 'baz'); -- { serverError ILLEGAL_COLUMN }
--- SELECT count() FROM tab WHERE hasToken(val, 'def'); -- { serverError ILLEGAL_COLUMN }
-
--- SELECT count() FROM tab WHERE hasAllTokens(val, 'foo');
--- SELECT count() FROM tab WHERE hasAllTokens(val, 'FOO');
--- SELECT count() FROM tab WHERE hasAllTokens(val, 'BAR');
--- SELECT count() FROM tab WHERE hasAllTokens(val, 'Baz');
-
--- SELECT count() FROM tab WHERE hasAnyTokens(val, 'foo');
--- SELECT count() FROM tab WHERE hasAnyTokens(val, 'FOO');
--- SELECT count() FROM tab WHERE hasAnyTokens(val, 'BAR');
--- SELECT count() FROM tab WHERE hasAnyTokens(val, 'Baz');
-
--- DROP TABLE tab;
-
--- SELECT '- Test simple preprocessor expression with Array(String).';
--- CREATE TABLE tab
--- (
---     key UInt64,
---     val Array(String),
---     INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(val))
--- )
--- ENGINE = MergeTree ORDER BY tuple();
-
--- INSERT INTO tab VALUES (1, ['foo']), (2, ['BAR']), (3, ['Baz']);
-
--- -- hasToken doesn't support Array(String) columns
--- SELECT count() FROM tab WHERE hasToken(val, 'foo'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
--- SELECT count() FROM tab WHERE hasToken(val, 'FOO'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
--- SELECT count() FROM tab WHERE hasToken(val, 'BAR'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
--- SELECT count() FROM tab WHERE hasToken(val, 'Baz'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
--- SELECT count() FROM tab WHERE hasToken(val, 'bar'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
--- SELECT count() FROM tab WHERE hasToken(val, 'baz'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
--- SELECT count() FROM tab WHERE hasToken(val, 'def'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
-
--- SELECT count() FROM tab WHERE hasAllTokens(val, 'foo');
--- SELECT count() FROM tab WHERE hasAllTokens(val, 'FOO');
--- SELECT count() FROM tab WHERE hasAllTokens(val, 'BAR');
--- SELECT count() FROM tab WHERE hasAllTokens(val, 'Baz');
-
--- SELECT count() FROM tab WHERE hasAnyTokens(val, 'foo');
--- SELECT count() FROM tab WHERE hasAnyTokens(val, 'FOO');
--- SELECT count() FROM tab WHERE hasAnyTokens(val, 'BAR');
--- SELECT count() FROM tab WHERE hasAnyTokens(val, 'Baz');
-
--- DROP TABLE tab;
-
--- SELECT '- Test simple preprocessor expression with Array(FixedString).';
--- CREATE TABLE tab
--- (
---     key UInt64,
---     val Array(FixedString(3)),
---     INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(val))
--- )
--- ENGINE = MergeTree ORDER BY tuple();
-
--- INSERT INTO tab VALUES (1, ['foo']), (2, ['BAR']), (3, ['Baz']);
-
--- -- hasToken doesn't support Array(String) columns
--- SELECT count() FROM tab WHERE hasToken(val, 'foo'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
--- SELECT count() FROM tab WHERE hasToken(val, 'FOO'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
--- SELECT count() FROM tab WHERE hasToken(val, 'BAR'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
--- SELECT count() FROM tab WHERE hasToken(val, 'Baz'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
--- SELECT count() FROM tab WHERE hasToken(val, 'bar'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
--- SELECT count() FROM tab WHERE hasToken(val, 'baz'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
--- SELECT count() FROM tab WHERE hasToken(val, 'def'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
-
--- SELECT count() FROM tab WHERE hasAllTokens(val, 'foo');
--- SELECT count() FROM tab WHERE hasAllTokens(val, 'FOO');
--- SELECT count() FROM tab WHERE hasAllTokens(val, 'BAR');
--- SELECT count() FROM tab WHERE hasAllTokens(val, 'Baz');
-
--- SELECT count() FROM tab WHERE hasAnyTokens(val, 'foo');
--- SELECT count() FROM tab WHERE hasAnyTokens(val, 'FOO');
--- SELECT count() FROM tab WHERE hasAnyTokens(val, 'BAR');
--- SELECT count() FROM tab WHERE hasAnyTokens(val, 'Baz');
-
--- DROP TABLE tab;
-
--- SELECT '- Test preprocessor declaration using column more than once.';
--- CREATE TABLE tab
--- (
---     key UInt64,
---     val String,
---     INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = concat(val, val))
--- )
--- ENGINE = MergeTree
--- ORDER BY tuple();
-
--- INSERT INTO tab VALUES (1, 'foo'), (2, 'BAR'), (3, 'Baz');
-
--- SELECT count() FROM tab WHERE hasToken(val, 'foo');
--- SELECT count() FROM tab WHERE hasToken(val, 'FOO');
--- SELECT count() FROM tab WHERE hasToken(val, 'BAR');
--- SELECT count() FROM tab WHERE hasToken(val, 'Baz');
--- SELECT count() FROM tab WHERE hasToken(val, 'bar');
--- SELECT count() FROM tab WHERE hasToken(val, 'baz');
--- SELECT count() FROM tab WHERE hasToken(val, 'def');
-
--- SELECT count() FROM tab WHERE hasAllTokens(val, 'foo');
--- SELECT count() FROM tab WHERE hasAllTokens(val, 'FOO');
--- SELECT count() FROM tab WHERE hasAllTokens(val, 'BAR');
--- SELECT count() FROM tab WHERE hasAllTokens(val, 'Baz');
--- SELECT count() FROM tab WHERE hasAnyTokens(val, 'foo');
--- SELECT count() FROM tab WHERE hasAnyTokens(val, 'FOO');
--- SELECT count() FROM tab WHERE hasAnyTokens(val, 'BAR');
--- SELECT count() FROM tab WHERE hasAnyTokens(val, 'Baz');
-
--- DROP TABLE tab;
-
--- SELECT '- Test preprocessor declaration using udf.';
--- DROP FUNCTION IF EXISTS udf_preprocessor;
--- CREATE FUNCTION udf_preprocessor AS (s) -> concat(val, lower(val));
-
--- CREATE TABLE tab
--- (
---     key UInt64,
---     val String,
---     INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = udf_preprocessor(val))
--- )
--- ENGINE = MergeTree
--- ORDER BY tuple();
-
-
--- INSERT INTO tab VALUES (1, 'foo'), (2, 'BAR'), (3, 'Baz');
-
--- SELECT count() FROM tab WHERE hasToken(val, 'foo');
--- SELECT count() FROM tab WHERE hasToken(val, 'FOO');
--- SELECT count() FROM tab WHERE hasToken(val, 'BAR');
--- SELECT count() FROM tab WHERE hasToken(val, 'Baz');
--- SELECT count() FROM tab WHERE hasToken(val, 'bar');
--- SELECT count() FROM tab WHERE hasToken(val, 'baz');
--- SELECT count() FROM tab WHERE hasToken(val, 'def');
-
--- SELECT count() FROM tab WHERE hasAllTokens(val, 'foo');
--- SELECT count() FROM tab WHERE hasAllTokens(val, 'FOO');
--- SELECT count() FROM tab WHERE hasAllTokens(val, 'BAR');
--- SELECT count() FROM tab WHERE hasAllTokens(val, 'Baz');
--- SELECT count() FROM tab WHERE hasAnyTokens(val, 'foo');
--- SELECT count() FROM tab WHERE hasAnyTokens(val, 'FOO');
--- SELECT count() FROM tab WHERE hasAnyTokens(val, 'BAR');
--- SELECT count() FROM tab WHERE hasAnyTokens(val, 'Baz');
-
--- DROP TABLE tab;
--- DROP FUNCTION udf_preprocessor;
-
--- SELECT 'Negative tests on preprocessor construction validations.';
-
--- -- The preprocessor argument must reference the index column
--- CREATE TABLE tab
--- (
---     key UInt64,
---     val String,
---     other_str String,
---     INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(other_str))
--- )
--- ENGINE = MergeTree ORDER BY tuple();  -- { serverError BAD_ARGUMENTS }
-
--- SELECT '- The preprocessor argument must not reference non-indexed columns';
--- CREATE TABLE tab
--- (
---     key UInt64,
---     val String,
---     other_str String,
---     INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = concat(val, other_str))
--- )
--- ENGINE = MergeTree ORDER BY tuple();   -- { serverError BAD_ARGUMENTS }
-
--- SELECT '- Index definition may not be and expression when there is preprocessor';
--- CREATE TABLE tab
--- (
---     key UInt64,
---     val String,
---     INDEX idx(upper(val)) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(val))
--- )
--- ENGINE = MergeTree ORDER BY tuple();   -- { serverError BAD_ARGUMENTS }
-
--- SELECT '-- Not even the same expression';
--- CREATE TABLE tab
--- (
---     key UInt64,
---     val String,
---     INDEX idx(lower(val)) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(val))
--- )
--- ENGINE = MergeTree ORDER BY tuple();   -- { serverError BAD_ARGUMENTS }
-
--- CREATE TABLE tab
--- (
---     key UInt64,
---     val String,
---     INDEX idx(upper(val)) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(upper(val)))
--- )
--- ENGINE = MergeTree ORDER BY tuple();   -- { serverError BAD_ARGUMENTS }
-
--- SELECT '- The preprocessor must be an expression';
--- CREATE TABLE tab
--- (
---     key UInt64,
---     val String,
---     INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = BAD)
--- )
--- ENGINE = MergeTree ORDER BY key;   -- { serverError BAD_ARGUMENTS }
-
--- SELECT '- The preprocessor must be an expression, with existing functions';
--- CREATE TABLE tab
--- (
---     key UInt64,
---     val String,
---     INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = nonExistingFunction(val))
--- )
--- ENGINE = MergeTree ORDER BY tuple();   -- { serverError UNKNOWN_FUNCTION }
-
--- SELECT '- The preprocessor must have input and output values of the same type (here: String)';
--- CREATE TABLE tab
--- (
---     key UInt64,
---     val String,
---     INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = length(val))
--- )
--- ENGINE = MergeTree ORDER BY tuple();   -- { serverError INCORRECT_QUERY }
-
--- SELECT '- The preprocessor expression must use the column identifier';
--- CREATE TABLE tab
--- (
---     key UInt64,
---     val String,
---     INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = hostname())
--- )
--- ENGINE = MergeTree ORDER BY tuple();   -- { serverError INCORRECT_QUERY }
-
--- SELECT '- The preprocessor expression must use only deterministic functions';
--- CREATE TABLE tab
--- (
---     key UInt64,
---     val String,
---     INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = concat(val, toString(rand())))
--- )
--- ENGINE = MergeTree ORDER BY tuple();   -- { serverError INCORRECT_QUERY }
-
-SELECT '- The preprocessor expression should support maps';
-SELECT '-- Index definition must be an expression';
+SELECT 'Positive tests on preprocessor construction and use.';
+SELECT '- Test simple preprocessor expression.';
 
 CREATE TABLE tab
 (
     key UInt64,
+    val String,
+    INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(val))
+)
+ENGINE = MergeTree
+ORDER BY key;
+
+INSERT INTO tab VALUES (1, 'foo'), (2, 'BAR'), (3, 'Baz');
+
+SELECT count() FROM tab WHERE hasToken(val, 'foo');
+SELECT count() FROM tab WHERE hasToken(val, 'FOO');
+SELECT count() FROM tab WHERE hasToken(val, 'BAR');
+SELECT count() FROM tab WHERE hasToken(val, 'Baz');
+SELECT count() FROM tab WHERE hasToken(val, 'bar');
+SELECT count() FROM tab WHERE hasToken(val, 'baz');
+SELECT count() FROM tab WHERE hasToken(val, 'def');
+
+SELECT count() FROM tab WHERE hasAllTokens(val, 'foo');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'FOO');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'BAR');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'Baz');
+
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'foo');
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'FOO');
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'BAR');
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'Baz');
+
+DROP TABLE tab;
+
+
+SELECT '- Test simple preprocessor expression with LowCardinality.';
+
+CREATE TABLE tab
+(
+    key UInt64,
+    val LowCardinality(String),
+    INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(val))
+)
+ENGINE = MergeTree
+ORDER BY key;
+
+INSERT INTO tab VALUES (1, 'foo'), (2, 'BAR'), (3, 'Baz');
+
+SELECT count() FROM tab WHERE hasToken(val, 'foo');
+SELECT count() FROM tab WHERE hasToken(val, 'FOO');
+SELECT count() FROM tab WHERE hasToken(val, 'BAR');
+SELECT count() FROM tab WHERE hasToken(val, 'Baz');
+SELECT count() FROM tab WHERE hasToken(val, 'bar');
+SELECT count() FROM tab WHERE hasToken(val, 'baz');
+SELECT count() FROM tab WHERE hasToken(val, 'def');
+
+SELECT count() FROM tab WHERE hasAllTokens(val, 'foo');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'FOO');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'BAR');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'Baz');
+
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'foo');
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'FOO');
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'BAR');
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'Baz');
+
+DROP TABLE tab;
+
+
+SELECT '- Test simple preprocessor expression with FixedString.';
+
+CREATE TABLE tab
+(
+    key UInt64,
+    val FixedString(3),
+    INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(val))
+)
+ENGINE = MergeTree
+ORDER BY key;
+
+INSERT INTO tab VALUES (1, 'foo'), (2, 'BAR'), (3, 'Baz');
+
+-- hasToken doesn't support FixedString columns
+SELECT count() FROM tab WHERE hasToken(val, 'foo'); -- { serverError ILLEGAL_COLUMN }
+SELECT count() FROM tab WHERE hasToken(val, 'FOO'); -- { serverError ILLEGAL_COLUMN }
+SELECT count() FROM tab WHERE hasToken(val, 'BAR'); -- { serverError ILLEGAL_COLUMN }
+SELECT count() FROM tab WHERE hasToken(val, 'Baz'); -- { serverError ILLEGAL_COLUMN }
+SELECT count() FROM tab WHERE hasToken(val, 'bar'); -- { serverError ILLEGAL_COLUMN }
+SELECT count() FROM tab WHERE hasToken(val, 'baz'); -- { serverError ILLEGAL_COLUMN }
+SELECT count() FROM tab WHERE hasToken(val, 'def'); -- { serverError ILLEGAL_COLUMN }
+
+SELECT count() FROM tab WHERE hasAllTokens(val, 'foo');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'FOO');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'BAR');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'Baz');
+
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'foo');
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'FOO');
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'BAR');
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'Baz');
+
+DROP TABLE tab;
+
+SELECT '- Test preprocessor declaration using column more than once.';
+CREATE TABLE tab
+(
+    key UInt64,
+    val String,
+    INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = concat(val, val))
+)
+ENGINE = MergeTree
+ORDER BY tuple();
+
+INSERT INTO tab VALUES (1, 'foo'), (2, 'BAR'), (3, 'Baz');
+
+SELECT count() FROM tab WHERE hasToken(val, 'foo');
+SELECT count() FROM tab WHERE hasToken(val, 'FOO');
+SELECT count() FROM tab WHERE hasToken(val, 'BAR');
+SELECT count() FROM tab WHERE hasToken(val, 'Baz');
+SELECT count() FROM tab WHERE hasToken(val, 'bar');
+SELECT count() FROM tab WHERE hasToken(val, 'baz');
+SELECT count() FROM tab WHERE hasToken(val, 'def');
+
+SELECT count() FROM tab WHERE hasAllTokens(val, 'foo');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'FOO');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'BAR');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'Baz');
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'foo');
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'FOO');
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'BAR');
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'Baz');
+
+DROP TABLE tab;
+
+SELECT '- Test preprocessor declaration using udf.';
+DROP FUNCTION IF EXISTS udf_preprocessor;
+CREATE FUNCTION udf_preprocessor AS (s) -> concat(val, lower(val));
+
+CREATE TABLE tab
+(
+    key UInt64,
+    val String,
+    INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = udf_preprocessor(val))
+)
+ENGINE = MergeTree
+ORDER BY tuple();
+
+
+INSERT INTO tab VALUES (1, 'foo'), (2, 'BAR'), (3, 'Baz');
+
+SELECT count() FROM tab WHERE hasToken(val, 'foo');
+SELECT count() FROM tab WHERE hasToken(val, 'FOO');
+SELECT count() FROM tab WHERE hasToken(val, 'BAR');
+SELECT count() FROM tab WHERE hasToken(val, 'Baz');
+SELECT count() FROM tab WHERE hasToken(val, 'bar');
+SELECT count() FROM tab WHERE hasToken(val, 'baz');
+SELECT count() FROM tab WHERE hasToken(val, 'def');
+
+SELECT count() FROM tab WHERE hasAllTokens(val, 'foo');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'FOO');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'BAR');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'Baz');
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'foo');
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'FOO');
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'BAR');
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'Baz');
+
+DROP TABLE tab;
+DROP FUNCTION udf_preprocessor;
+
+SELECT '- Index definition must be the an expression used in the preprocessor';
+SELECT '-- Single arguments';
+CREATE TABLE tab
+(
+    key UInt64,
+    val String,
+    INDEX idx(upper(val)) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(upper(val)))
+)
+ENGINE = MergeTree ORDER BY tuple();
+
+INSERT INTO tab VALUES (1, 'foo'), (2, 'BAR'), (3, 'Baz');
+
+SELECT count() FROM tab WHERE hasToken(val, 'foo');
+SELECT count() FROM tab WHERE hasToken(val, 'FOO');
+SELECT count() FROM tab WHERE hasToken(val, 'BAR');
+SELECT count() FROM tab WHERE hasToken(val, 'Baz');
+SELECT count() FROM tab WHERE hasToken(val, 'bar');
+SELECT count() FROM tab WHERE hasToken(val, 'baz');
+SELECT count() FROM tab WHERE hasToken(val, 'def');
+
+SELECT count() FROM tab WHERE hasAllTokens(val, 'foo');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'FOO');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'BAR');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'Baz');
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'foo');
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'FOO');
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'BAR');
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'Baz');
+
+DROP TABLE tab;
+
+SELECT '-- Multiple arguments';
+CREATE TABLE tab
+(
+    key UInt64,
+    val String,
+    INDEX idx(lower(val)) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = concat(lower(val), lower(val)))
+)
+ENGINE = MergeTree ORDER BY tuple();
+
+INSERT INTO tab VALUES (1, 'foo'), (2, 'BAR'), (3, 'Baz');
+
+SELECT count() FROM tab WHERE hasToken(val, 'foo');
+SELECT count() FROM tab WHERE hasToken(val, 'FOO');
+SELECT count() FROM tab WHERE hasToken(val, 'BAR');
+SELECT count() FROM tab WHERE hasToken(val, 'Baz');
+SELECT count() FROM tab WHERE hasToken(val, 'bar');
+SELECT count() FROM tab WHERE hasToken(val, 'baz');
+SELECT count() FROM tab WHERE hasToken(val, 'def');
+
+SELECT count() FROM tab WHERE hasAllTokens(val, 'foo');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'FOO');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'BAR');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'Baz');
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'foo');
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'FOO');
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'BAR');
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'Baz');
+
+DROP TABLE tab;
+
+SELECT 'Negative tests on preprocessor construction validations.';
+
+-- The preprocessor argument must reference the index column
+CREATE TABLE tab
+(
+    key UInt64,
+    val String,
+    other_str String,
+    INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(other_str))
+)
+ENGINE = MergeTree ORDER BY tuple();  -- { serverError BAD_ARGUMENTS }
+
+SELECT '- The preprocessor argument must not reference non-indexed columns';
+CREATE TABLE tab
+(
+    key UInt64,
+    val String,
+    other_str String,
+    INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = concat(val, other_str))
+)
+ENGINE = MergeTree ORDER BY tuple();   -- { serverError BAD_ARGUMENTS }
+
+SELECT '- Index definition may not be a different expression than used in the preprocessor';
+CREATE TABLE tab
+(
+    key UInt64,
+    val String,
+    INDEX idx(upper(val)) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(val))
+)
+ENGINE = MergeTree ORDER BY tuple();   -- { serverError BAD_ARGUMENTS }
+
+SELECT '- The preprocessor must be an expression';
+CREATE TABLE tab
+(
+    key UInt64,
+    val String,
+    INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = BAD)
+)
+ENGINE = MergeTree ORDER BY key;   -- { serverError BAD_ARGUMENTS }
+
+SELECT '- The preprocessor must be an expression, with existing functions';
+CREATE TABLE tab
+(
+    key UInt64,
+    val String,
+    INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = nonExistingFunction(val))
+)
+ENGINE = MergeTree ORDER BY tuple();   -- { serverError UNKNOWN_FUNCTION }
+
+SELECT '- The preprocessor must have input and output values of the same type (here: String)';
+CREATE TABLE tab
+(
+    key UInt64,
+    val String,
+    INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = length(val))
+)
+ENGINE = MergeTree ORDER BY tuple();   -- { serverError INCORRECT_QUERY }
+
+SELECT '- The preprocessor expression must use the column identifier';
+CREATE TABLE tab
+(
+    key UInt64,
+    val String,
+    INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = hostname())
+)
+ENGINE = MergeTree ORDER BY tuple();   -- { serverError INCORRECT_QUERY }
+
+SELECT '- The preprocessor expression must use only deterministic functions';
+CREATE TABLE tab
+(
+    key UInt64,
+    val String,
+    INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = concat(val, toString(rand())))
+)
+ENGINE = MergeTree ORDER BY tuple();   -- { serverError INCORRECT_QUERY }
+
+-- Array support ------------------------------------------------------------------------------------
+
+SELECT '- Test simple preprocessor expression with Array(String).';
+CREATE TABLE tab
+(
+    key UInt64,
+    val Array(String),
+    INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(val))
+)
+ENGINE = MergeTree ORDER BY tuple();
+
+INSERT INTO tab VALUES (1, ['foo']), (2, ['BAR']), (3, ['Baz']);
+
+-- hasToken doesn't support Array(String) columns
+SELECT count() FROM tab WHERE hasToken(val, 'foo'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+
+-- has{All,Any}Token support Array(String) columns
+SELECT count() FROM tab WHERE hasAllTokens(val, 'foo');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'FOO');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'BAR');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'Baz');
+
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'foo');
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'FOO');
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'BAR');
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'Baz');
+
+DROP TABLE tab;
+
+SELECT '- Test simple preprocessor expression with Array(FixedString).';
+CREATE TABLE tab
+(
+    key UInt64,
+    val Array(FixedString(3)),
+    INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(val))
+)
+ENGINE = MergeTree ORDER BY tuple();
+
+INSERT INTO tab VALUES (1, ['foo']), (2, ['BAR']), (3, ['Baz']);
+
+-- hasToken doesn't support Array(String) columns
+SELECT count() FROM tab WHERE hasToken(val, 'foo'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+
+-- has{All,Any}Token support Array(String) columns
+SELECT count() FROM tab WHERE hasAllTokens(val, 'foo');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'FOO');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'BAR');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'Baz');
+
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'foo');
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'FOO');
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'BAR');
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'Baz');
+
+DROP TABLE tab;
+
+
+-- Map support --------------------------------------------------------------------------------------
+
+SELECT 'Maps support';
+
+SELECT '- Map positive tests';
+SELECT '-- Index definition must be an expression';
+CREATE TABLE tab
+(
+    key UInt64,
     val Map(String, String),
-    INDEX idx1(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(mapKeys(val)))
+    INDEX idx(mapKeys(val)) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(mapKeys(val)))
+)
+ENGINE = MergeTree ORDER BY key;
+
+INSERT INTO tab VALUES (1, {'foo': 'dummy'}), (2, {'BAR': 'dummy'}), (3, {'Baz': 'dummy'});
+
+-- Map itself should not be passed as argument
+SELECT count() FROM tab WHERE hasAllTokens(val, 'foo');  -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+
+-- has{All,Any}Token support Array(String) columns
+SELECT count() FROM tab WHERE hasAllTokens(mapKeys(val), 'foo');
+SELECT count() FROM tab WHERE hasAllTokens(mapKeys(val), 'FOO');
+SELECT count() FROM tab WHERE hasAllTokens(mapKeys(val), 'BAR');
+SELECT count() FROM tab WHERE hasAllTokens(mapKeys(val), 'Baz');
+
+SELECT count() FROM tab WHERE hasAnyTokens(mapKeys(val), 'foo');
+SELECT count() FROM tab WHERE hasAnyTokens(mapKeys(val), 'FOO');
+SELECT count() FROM tab WHERE hasAnyTokens(mapKeys(val), 'BAR');
+SELECT count() FROM tab WHERE hasAnyTokens(mapKeys(val), 'Baz');
+
+DROP TABLE tab;
+
+SELECT '- Map negative tests';
+SELECT '-- Index on whole map must fail';
+CREATE TABLE tab
+(
+    key UInt64,
+    val Map(String, String),
+    INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(mapKeys(val)))
 )
 ENGINE = MergeTree ORDER BY key;   -- { serverError BAD_ARGUMENTS }
 
@@ -351,18 +419,8 @@ CREATE TABLE tab
 (
     key UInt64,
     val Map(String, String),
-    INDEX idx2(mapKeys(val)) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(val))
+    INDEX idx(mapKeys(val)) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(val))
 )
 ENGINE = MergeTree ORDER BY key;   -- { serverError BAD_ARGUMENTS }
-
-SELECT '-- this must work';
-CREATE TABLE tab
-(
-    key UInt64,
-    val Map(String, String),
-    INDEX idx3(mapKeys(val)) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(mapKeys(val)))
-)
-ENGINE = MergeTree ORDER BY key;
-
 
 DROP TABLE IF EXISTS tab;


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

This includes 2 changes that come all together.
1. Allow to use text index preprocessor with expression defined indices:
   ```sql
   INDEX idx(lower(val)) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = concat(lower(val), lower(val)))
   ```
2. Add map support for text index with similar expression based indices (as a side effect of the previous one:
   ```
   INDEX idx(mapKeys(val)) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(mapKeys(val)))
   ```
   
TODO: This implementation is functional only with direct read enabled.
