### PR TITLE
Optimize ReplicatedMergeTree queue locks for readonly operations on tables with mutations

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeAltersSequence.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeAltersSequence.cpp
@@ -4,7 +4,7 @@
 namespace DB
 {
 
-int ReplicatedMergeTreeAltersSequence::getHeadAlterVersion(std::unique_lock<std::mutex> & /*state_lock*/) const
+int ReplicatedMergeTreeAltersSequence::getHeadAlterVersion(std::unique_lock<SharedMutex> & /*state_lock*/) const
 {
     /// If queue empty, than we don't have version
     if (!queue_state.empty())
@@ -12,7 +12,7 @@ int ReplicatedMergeTreeAltersSequence::getHeadAlterVersion(std::unique_lock<std:
     return -1;
 }
 
-void ReplicatedMergeTreeAltersSequence::addMutationForAlter(int alter_version, std::lock_guard<std::mutex> & /*state_lock*/)
+void ReplicatedMergeTreeAltersSequence::addMutationForAlter(int alter_version, std::lock_guard<SharedMutex> & /*state_lock*/)
 {
     /// Metadata alter can be added before, or
     /// maybe already finished if we startup after metadata alter was finished.
@@ -23,7 +23,7 @@ void ReplicatedMergeTreeAltersSequence::addMutationForAlter(int alter_version, s
 }
 
 void ReplicatedMergeTreeAltersSequence::addMetadataAlter(
-    int alter_version, std::lock_guard<std::mutex> & /*state_lock*/)
+    int alter_version, std::lock_guard<SharedMutex> & /*state_lock*/)
 {
     /// Data alter (mutation) always added before. See ReplicatedMergeTreeQueue::pullLogsToQueue.
     /// So mutation already added to this sequence or doesn't exist.
@@ -33,7 +33,7 @@ void ReplicatedMergeTreeAltersSequence::addMetadataAlter(
         queue_state[alter_version].metadata_finished = false;
 }
 
-void ReplicatedMergeTreeAltersSequence::finishMetadataAlter(int alter_version, std::unique_lock<std::mutex> & /*state_lock*/)
+void ReplicatedMergeTreeAltersSequence::finishMetadataAlter(int alter_version, std::unique_lock<SharedMutex> & /*state_lock*/)
 {
     /// Sequence must not be empty
     assert(!queue_state.empty());
@@ -47,7 +47,7 @@ void ReplicatedMergeTreeAltersSequence::finishMetadataAlter(int alter_version, s
         queue_state[alter_version].metadata_finished = true;
 }
 
-void ReplicatedMergeTreeAltersSequence::finishDataAlter(int alter_version, std::lock_guard<std::mutex> & /*state_lock*/)
+void ReplicatedMergeTreeAltersSequence::finishDataAlter(int alter_version, std::lock_guard<SharedMutex> & /*state_lock*/)
 {
     /// Queue can be empty after load of finished mutation without move of mutation pointer
     if (queue_state.empty())
@@ -66,7 +66,7 @@ void ReplicatedMergeTreeAltersSequence::finishDataAlter(int alter_version, std::
     }
 }
 
-bool ReplicatedMergeTreeAltersSequence::canExecuteDataAlter(int alter_version, std::unique_lock<std::mutex> & /*state_lock*/) const
+bool ReplicatedMergeTreeAltersSequence::canExecuteDataAlter(int alter_version, std::unique_lock<SharedMutex> & /*state_lock*/) const
 {
     /// Queue maybe empty when we start after server shutdown
     /// and have some MUTATE_PART records in queue
@@ -80,7 +80,7 @@ bool ReplicatedMergeTreeAltersSequence::canExecuteDataAlter(int alter_version, s
     return queue_state.at(alter_version).metadata_finished;
 }
 
-bool ReplicatedMergeTreeAltersSequence::canExecuteMetaAlter(int alter_version, std::unique_lock<std::mutex> & /*state_lock*/) const
+bool ReplicatedMergeTreeAltersSequence::canExecuteMetaAlter(int alter_version, std::unique_lock<SharedMutex> & /*state_lock*/) const
 {
     assert(!queue_state.empty());
 

--- a/src/Storages/MergeTree/ReplicatedMergeTreeAltersSequence.h
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeAltersSequence.h
@@ -4,6 +4,8 @@
 #include <mutex>
 #include <map>
 
+#include <Common/SharedMutex.h>
+
 namespace DB
 {
 /// ALTERs in StorageReplicatedMergeTree have to be executed sequentially (one
@@ -35,27 +37,27 @@ private:
 public:
 
     /// Add mutation for alter (alter data stage).
-    void addMutationForAlter(int alter_version, std::lock_guard<std::mutex> & /*state_lock*/);
+    void addMutationForAlter(int alter_version, std::lock_guard<SharedMutex> & /*state_lock*/);
 
     /// Add metadata for alter (alter metadata stage).
-    void addMetadataAlter(int alter_version, std::lock_guard<std::mutex> & /*state_lock*/);
+    void addMetadataAlter(int alter_version, std::lock_guard<SharedMutex> & /*state_lock*/);
 
     /// Finish metadata alter. If corresponding data alter finished, than we can remove
     /// alter from sequence.
-    void finishMetadataAlter(int alter_version, std::unique_lock <std::mutex> & /*state_lock*/);
+    void finishMetadataAlter(int alter_version, std::unique_lock <SharedMutex> & /*state_lock*/);
 
     /// Finish data alter. If corresponding metadata alter finished, than we can remove
     /// alter from sequence.
-    void finishDataAlter(int alter_version, std::lock_guard<std::mutex> & /*state_lock*/);
+    void finishDataAlter(int alter_version, std::lock_guard<SharedMutex> & /*state_lock*/);
 
     /// Check that we can execute this data alter. If it's metadata stage finished.
-    bool canExecuteDataAlter(int alter_version, std::unique_lock<std::mutex> & /*state_lock*/) const;
+    bool canExecuteDataAlter(int alter_version, std::unique_lock<SharedMutex> & /*state_lock*/) const;
 
     /// Check that we can execute metadata alter with version.
-    bool canExecuteMetaAlter(int alter_version, std::unique_lock<std::mutex> & /*state_lock*/) const;
+    bool canExecuteMetaAlter(int alter_version, std::unique_lock<SharedMutex> & /*state_lock*/) const;
 
     /// Just returns smallest alter version in sequence (first entry)
-    int getHeadAlterVersion(std::unique_lock<std::mutex> & /*state_lock*/) const;
+    int getHeadAlterVersion(std::unique_lock<SharedMutex> & /*state_lock*/) const;
 };
 
 }

--- a/src/Storages/MergeTree/ReplicatedMergeTreeLogEntry.h
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeLogEntry.h
@@ -169,7 +169,7 @@ struct ReplicatedMergeTreeLogEntry : public ReplicatedMergeTreeLogEntryData, std
 {
     using Ptr = std::shared_ptr<ReplicatedMergeTreeLogEntry>;
 
-    std::condition_variable execution_complete; /// Awake when currently_executing becomes false.
+    std::condition_variable_any execution_complete; /// Awake when currently_executing becomes false.
 
     static Ptr parse(const String & s, const Coordination::Stat & stat, MergeTreeDataFormatVersion format_version);
 };

--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
@@ -20,6 +20,7 @@
 #include <base/sort.h>
 #include <cassert>
 #include <ranges>
+#include <shared_mutex>
 #include <Poco/Timestamp.h>
 
 namespace DB
@@ -256,7 +257,7 @@ void ReplicatedMergeTreeQueue::removeDropReplaceIntent(const MergeTreePartInfo &
 }
 
 bool ReplicatedMergeTreeQueue::isIntersectingWithDropReplaceIntent(
-    const LogEntry & entry, const String & part_name, String & out_reason, std::unique_lock<std::mutex> & /*state_mutex lock*/) const
+    const LogEntry & entry, const String & part_name, String & out_reason, std::unique_lock<SharedMutex> & /*state_mutex lock*/) const
 {
     const auto part_info = MergeTreePartInfo::fromPartName(part_name, format_version);
     for (const auto & intent : drop_replace_range_intents)
@@ -279,7 +280,7 @@ bool ReplicatedMergeTreeQueue::isIntersectingWithDropReplaceIntent(
     return false;
 }
 
-bool ReplicatedMergeTreeQueue::isMergeOfPatchPartsBlocked(const LogEntry & entry, String & out_reason, std::unique_lock<std::mutex> & /*state_mutex_lock*/) const
+bool ReplicatedMergeTreeQueue::isMergeOfPatchPartsBlocked(const LogEntry & entry, String & out_reason, std::unique_lock<SharedMutex> & /*state_mutex_lock*/) const
 {
     if (entry.type != LogEntry::MERGE_PARTS || !storage.supportsLightweightUpdate())
         return false;
@@ -310,7 +311,7 @@ bool ReplicatedMergeTreeQueue::isMergeOfPatchPartsBlocked(const LogEntry & entry
     return false;
 }
 
-bool ReplicatedMergeTreeQueue::isDropOfPatchPartBlocked(const LogEntry & entry, String & out_reason, std::unique_lock<std::mutex> & /*state_mutex_lock*/) const
+bool ReplicatedMergeTreeQueue::isDropOfPatchPartBlocked(const LogEntry & entry, String & out_reason, std::unique_lock<SharedMutex> & /*state_mutex_lock*/) const
 {
     if (entry.type != LogEntry::DROP_PART || !storage.supportsLightweightUpdate())
         return false;
@@ -344,7 +345,7 @@ bool ReplicatedMergeTreeQueue::havePendingPatchPartsForMutation(
     const LogEntry & entry,
     String & out_reason,
     const CommittingBlocks & committing_blocks,
-    std::unique_lock<std::mutex> & /*state_mutex_lock*/) const
+    std::unique_lock<SharedMutex> & /*state_mutex_lock*/) const
 {
     if (entry.type != LogEntry::MUTATE_PART || !storage.supportsLightweightUpdate())
         return false;
@@ -389,7 +390,7 @@ bool ReplicatedMergeTreeQueue::havePendingPatchPartsForMutation(
 
 void ReplicatedMergeTreeQueue::insertUnlocked(
     const LogEntryPtr & entry, std::optional<time_t> & min_unprocessed_insert_time_changed,
-    std::lock_guard<std::mutex> & state_lock)
+    std::lock_guard<SharedMutex> & state_lock)
 {
     auto entry_virtual_parts = entry->getVirtualPartNames(format_version);
 
@@ -471,7 +472,7 @@ void ReplicatedMergeTreeQueue::updateStateOnQueueEntryRemoval(
     bool is_successful,
     std::optional<time_t> & min_unprocessed_insert_time_changed,
     std::optional<time_t> & max_processed_insert_time_changed,
-    std::unique_lock<std::mutex> & state_lock)
+    std::unique_lock<SharedMutex> & state_lock)
 {
 
     auto entry_virtual_parts = entry->getVirtualPartNames(format_version);
@@ -1474,7 +1475,7 @@ void ReplicatedMergeTreeQueue::waitForCurrentlyExecutingOpsInRange(const MergeTr
 }
 
 bool ReplicatedMergeTreeQueue::isCoveredByFuturePartsImpl(const LogEntry & entry, const String & new_part_name,
-                                                          String & out_reason, std::unique_lock<std::mutex> & /* queue_lock */,
+                                                          String & out_reason, std::unique_lock<SharedMutex> & /* queue_lock */,
                                                           std::vector<LogEntryPtr> * covered_entries_to_wait) const
 {
     /// Let's check if the same part is now being created by another action.
@@ -1621,7 +1622,7 @@ bool ReplicatedMergeTreeQueue::shouldExecuteLogEntry(
     MergeTreeDataMergerMutator & merger_mutator,
     MergeTreeData & data,
     const CommittingBlocks & committing_blocks,
-    std::unique_lock<std::mutex> & state_lock) const
+    std::unique_lock<SharedMutex> & state_lock) const
 {
     if (auto postpone_time = getPostponeTimeMsForEntry(entry, data))
     {
@@ -1938,7 +1939,7 @@ Int64 ReplicatedMergeTreeQueue::getNextMutationVersion(
 }
 
 ReplicatedMergeTreeQueue::CurrentlyExecuting::CurrentlyExecuting(
-    const ReplicatedMergeTreeQueue::LogEntryPtr & entry_, ReplicatedMergeTreeQueue & queue_, std::unique_lock<std::mutex> & /* state_lock */)
+    const ReplicatedMergeTreeQueue::LogEntryPtr & entry_, ReplicatedMergeTreeQueue & queue_, std::unique_lock<SharedMutex> & /* state_lock */)
     : entry(entry_), queue(queue_)
 {
     if (auto drop_range = entry->getDropRange(queue.format_version))
@@ -1965,7 +1966,7 @@ void ReplicatedMergeTreeQueue::CurrentlyExecuting::setActualPartName(
     ReplicatedMergeTreeQueue::LogEntry & entry,
     const String & actual_part_name,
     ReplicatedMergeTreeQueue & queue,
-    std::unique_lock<std::mutex> & state_lock,
+    std::unique_lock<SharedMutex> & state_lock,
     std::vector<LogEntryPtr> & covered_entries_to_wait)
 {
     if (actual_part_name.empty())
@@ -2262,7 +2263,7 @@ MergeTreeData::MutationsSnapshotPtr ReplicatedMergeTreeQueue::getMutationsSnapsh
     if (params.need_patch_parts)
         patch_parts = storage.getPatchPartsVectorForInternalUsage();
 
-    std::lock_guard lock(state_mutex);
+    std::shared_lock lock(state_mutex);
     if (!params.need_data_mutations && !params.need_alter_mutations && params.min_part_metadata_version >= params.metadata_version)
         return std::make_shared<MutationsSnapshot>(params, std::move(mutations_snapshot_counters), std::move(mutations_snapshot), std::move(patch_parts));
 
@@ -2679,7 +2680,7 @@ ReplicatedMergeTreeQueue::addSubscriber(ReplicatedMergeTreeQueue::SubscriberCall
                                         std::unordered_set<String> & out_entry_names, SyncReplicaMode sync_mode,
                                         std::unordered_set<String> src_replicas)
 {
-    std::lock_guard<std::mutex> lock(state_mutex);
+    std::lock_guard<SharedMutex> lock(state_mutex);
     std::lock_guard lock_subscribers(subscribers_mutex);
 
     if (sync_mode != SyncReplicaMode::PULL)
@@ -2775,7 +2776,7 @@ void ReplicatedMergeTreeQueue::notifySubscribersOnPartialShutdown()
 {
     size_t queue_size;
     {
-        std::lock_guard<std::mutex> lock(state_mutex);
+        std::lock_guard<SharedMutex> lock(state_mutex);
         queue_size = queue.size();
     }
     std::lock_guard lock_subscribers(subscribers_mutex);

--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
@@ -2334,7 +2334,7 @@ MergeTreeData::MutationsSnapshotPtr ReplicatedMergeTreeQueue::getMutationsSnapsh
 
 MutationCounters ReplicatedMergeTreeQueue::getMutationCounters() const
 {
-    std::lock_guard lock(state_mutex);
+    std::shared_lock lock(state_mutex);
     return mutation_counters;
 }
 
@@ -2491,7 +2491,7 @@ bool ReplicatedMergeTreeQueue::tryFinalizeMutations(zkutil::ZooKeeperPtr zookeep
 
 ReplicatedMergeTreeQueue::Status ReplicatedMergeTreeQueue::getStatus() const
 {
-    std::lock_guard lock(state_mutex);
+    std::shared_lock lock(state_mutex);
 
     Status res;
 
@@ -2559,7 +2559,7 @@ ReplicatedMergeTreeQueue::Status ReplicatedMergeTreeQueue::getStatus() const
 void ReplicatedMergeTreeQueue::getEntries(LogEntriesData & res) const
 {
     res.clear();
-    std::lock_guard lock(state_mutex);
+    std::shared_lock lock(state_mutex);
 
     res.reserve(queue.size());
     for (const auto & entry : queue)
@@ -2577,7 +2577,7 @@ void ReplicatedMergeTreeQueue::getInsertTimes(time_t & out_min_unprocessed_inser
 std::optional<MergeTreeMutationStatus> ReplicatedMergeTreeQueue::getIncompleteMutationsStatus(const String & znode_name, std::set<String> * mutation_ids) const
 {
 
-    std::lock_guard lock(state_mutex);
+    std::shared_lock lock(state_mutex);
     auto current_mutation_it = mutations_by_znode.find(znode_name);
     /// killed
     if (current_mutation_it == mutations_by_znode.end())
@@ -2614,7 +2614,7 @@ std::optional<MergeTreeMutationStatus> ReplicatedMergeTreeQueue::getIncompleteMu
 
 std::vector<MergeTreeMutationStatus> ReplicatedMergeTreeQueue::getMutationsStatus() const
 {
-    std::lock_guard lock(state_mutex);
+    std::shared_lock lock(state_mutex);
 
     std::vector<MergeTreeMutationStatus> result;
     for (const auto & pair : mutations_by_znode)

--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.h
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.h
@@ -5,6 +5,7 @@
 #include <expected>
 
 #include <Common/ActionBlocker.h>
+#include <Common/SharedMutex.h>
 #include <Parsers/SyncReplicaMode.h>
 #include <Storages/MergeTree/ReplicatedMergeTreeLogEntry.h>
 #include <Storages/MergeTree/ReplicatedMergeTreeMutationEntry.h>
@@ -83,7 +84,7 @@ private:
     LoggerPtr log = nullptr;
 
     /// Protects the queue, future_parts and other queue state variables.
-    mutable std::mutex state_mutex;
+    mutable SharedMutex state_mutex;
 
     /// A set of parts that should be on this replica according to the queue entries that have been done
     /// up to this point. The invariant holds: `virtual_parts` = `current_parts` + `queue`.
@@ -220,7 +221,7 @@ private:
     /// Insert new entry from log into queue
     void insertUnlocked(
         const LogEntryPtr & entry, std::optional<time_t> & min_unprocessed_insert_time_changed,
-        std::lock_guard<std::mutex> & state_lock);
+        std::lock_guard<SharedMutex> & state_lock);
 
     void removeProcessedEntry(zkutil::ZooKeeperPtr zookeeper, LogEntryPtr & entry);
 
@@ -233,7 +234,7 @@ private:
         MergeTreeDataMergerMutator & merger_mutator,
         MergeTreeData & data,
         const CommittingBlocks & committing_blocks,
-        std::unique_lock<std::mutex> & state_lock) const;
+        std::unique_lock<SharedMutex> & state_lock) const;
 
     /// Return the version (block number) of the last mutation that we don't need to apply to the part
     /// with getDataVersion() == data_version. (Either this mutation was already applied or the part
@@ -248,7 +249,7 @@ private:
     bool isCoveredByFuturePartsImpl(
         const LogEntry & entry,
         const String & new_part_name, String & out_reason,
-        std::unique_lock<std::mutex> & state_lock,
+        std::unique_lock<SharedMutex> & state_lock,
         std::vector<LogEntryPtr> * covered_entries_to_wait) const;
 
     /// After removing the queue element, update the insertion times in the RAM. Running under state_mutex.
@@ -257,7 +258,7 @@ private:
         bool is_successful,
         std::optional<time_t> & min_unprocessed_insert_time_changed,
         std::optional<time_t> & max_processed_insert_time_changed,
-        std::unique_lock<std::mutex> & state_lock);
+        std::unique_lock<SharedMutex> & state_lock);
 
     /// Add part for mutations with block_number > part.getDataVersion()
     void addPartToMutations(const String & part_name, const MergeTreePartInfo & part_info);
@@ -296,11 +297,11 @@ private:
 
     bool isIntersectingWithDropReplaceIntent(
         const LogEntry & entry,
-        const String & part_name, String & out_reason, std::unique_lock<std::mutex> & /*state_mutex lock*/) const;
+        const String & part_name, String & out_reason, std::unique_lock<SharedMutex> & /*state_mutex lock*/) const;
 
-    bool isMergeOfPatchPartsBlocked(const LogEntry & entry, String & out_reason, std::unique_lock<std::mutex> & /*state_mutex_lock*/) const;
-    bool isDropOfPatchPartBlocked(const LogEntry & entry, String & out_reason, std::unique_lock<std::mutex> & /*state_mutex_lock*/) const;
-    bool havePendingPatchPartsForMutation(const LogEntry & entry, String & out_reason, const CommittingBlocks & committing_blocks, std::unique_lock<std::mutex> & /*state_mutex_lock*/) const;
+    bool isMergeOfPatchPartsBlocked(const LogEntry & entry, String & out_reason, std::unique_lock<SharedMutex> & /*state_mutex_lock*/) const;
+    bool isDropOfPatchPartBlocked(const LogEntry & entry, String & out_reason, std::unique_lock<SharedMutex> & /*state_mutex_lock*/) const;
+    bool havePendingPatchPartsForMutation(const LogEntry & entry, String & out_reason, const CommittingBlocks & committing_blocks, std::unique_lock<SharedMutex> & /*state_mutex_lock*/) const;
 
     /// Marks the element of the queue as running.
     class CurrentlyExecuting
@@ -315,14 +316,14 @@ private:
         CurrentlyExecuting(
             const ReplicatedMergeTreeQueue::LogEntryPtr & entry_,
             ReplicatedMergeTreeQueue & queue_,
-            std::unique_lock<std::mutex> & state_lock);
+            std::unique_lock<SharedMutex> & state_lock);
 
         /// In case of fetch, we determine actual part during the execution, so we need to update entry. It is called under state_mutex.
         static void setActualPartName(
             ReplicatedMergeTreeQueue::LogEntry & entry,
             const String & actual_part_name,
             ReplicatedMergeTreeQueue & queue,
-            std::unique_lock<std::mutex> & state_lock,
+            std::unique_lock<SharedMutex> & state_lock,
             std::vector<LogEntryPtr> & covered_entries_to_wait);
 
     public:
@@ -547,7 +548,7 @@ public:
 
     void removeCurrentPartsFromMutations();
 
-    using QueueLocks = std::scoped_lock<std::mutex, std::mutex, std::mutex>;
+    using QueueLocks = std::scoped_lock<SharedMutex, std::mutex, std::mutex>;
 
     /// This method locks all important queue mutexes: state_mutex,
     /// pull_logs_to_queue and update_mutations_mutex. It should be used only


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Reduce lock contention during readonly operations on ReplicatedMergeTree tables with finished mutations.

### Details

`ReplicatedMergeTree::getMutationsSnapshot` function is called on every select query from replicated table, and due to `apply_patch_parts` it iterates through all known partitions mutations on every call.

In cases when mutations data is large (e.g. table has many partitions and couple of mutations, where each mutation contains stale partition ids, produced by the values from `/block_numbers` ZooKeeper node), and the number of concurrent queries is high enough, the lock contention in `getMutationsSnapshot` may become a bottleneck and cause queries to stuck during planning phase.

The suggestion is to allow shared locks on ReplicatedMergeTree queue state during readonly operations.

<details>
<summary>Benchmarks</summary>

The results are obtained on debug build (non-Linux, so `absl::Mutex` was used as a `SharedMutex` implementation), with the table containing 10 parts + 10k "stale" parts in mutations:

```sql
SELECT count()
FROM system.parts
WHERE `table` = 'bloat'

Query id: 0ebbb16b-62a6-47fe-ac98-fd22bb77cdba

   ┌─count()─┐
1. │      10 │
   └─────────┘

1 row in set. Elapsed: 0.002 sec.

SELECT
    count(),
    sum(length(block_numbers.partition_id))
FROM system.mutations
WHERE `table` = 'bloat'

Query id: 9caddd12-ba8f-48ba-ac6b-2a2eea7f658b

   ┌─count()─┬─sum(length(b⋯tition_id))─┐
1. │      12 │                    74750 │
   └─────────┴──────────────────────────┘

1 row in set. Elapsed: 0.030 sec.
```

Running 2-4-8 parallel SELECT queries for a single non-existing key selection:
```sh
# master -- lock_guard on std::mutex
eduard ClickHouse $ ./build/debug/programs/clickhouse-benchmark -q "select * from bloat where key = 7123 and prt_num = 11015 and prt_str = '11015' settings apply_patch_parts = 1, max_threads = 1" -t 30 -d 0 -c 2
Loaded 1 queries.
Stopping launch of queries. Requested time limit 30 seconds is exhausted.

Queries executed: 10104.

localhost:9000, queries: 10104, QPS: 336.659, RPS: 0.000, MiB/s: 0.000, result RPS: 0.000, result MiB/s: 0.000.


eduard ClickHouse $ ./build/debug/programs/clickhouse-benchmark -q "select * from bloat where key = 7123 and prt_num = 11015 and prt_str = '11015' settings apply_patch_parts = 1, max_threads = 1" -t 30 -d 0 -c 4
Loaded 1 queries.
Stopping launch of queries. Requested time limit 30 seconds is exhausted.

Queries executed: 10217.

localhost:9000, queries: 10217, QPS: 340.434, RPS: 0.000, MiB/s: 0.000, result RPS: 0.000, result MiB/s: 0.000.


eduard ClickHouse $ ./build/debug/programs/clickhouse-benchmark -q "select * from bloat where key = 7123 and prt_num = 11015 and prt_str = '11015' settings apply_patch_parts = 1, max_threads = 1" -t 30 -d 0 -c 8
Loaded 1 queries.
Stopping launch of queries. Requested time limit 30 seconds is exhausted.

Queries executed: 10218.

localhost:9000, queries: 10218, QPS: 340.325, RPS: 0.000, MiB/s: 0.000, result RPS: 0.000, result MiB/s: 0.000.

# branch -- shared_lock on SharedMutex
eduard ClickHouse $ ./build/debug/programs/clickhouse-benchmark -q "select * from bloat where key = 7123 and prt_num = 11015 and prt_str = '11015' settings apply_patch_parts = 1, max_threads = 1" -t 30 -d 0 -c 2
Loaded 1 queries.
Stopping launch of queries. Requested time limit 30 seconds is exhausted.

Queries executed: 11939.

localhost:9000, queries: 11939, QPS: 397.878, RPS: 0.000, MiB/s: 0.000, result RPS: 0.000, result MiB/s: 0.000.


eduard ClickHouse $ ./build/debug/programs/clickhouse-benchmark -q "select * from bloat where key = 7123 and prt_num = 11015 and prt_str = '11015' settings apply_patch_parts = 1, max_threads = 1" -t 30 -d 0 -c 4
Loaded 1 queries.
Stopping launch of queries. Requested time limit 30 seconds is exhausted.

Queries executed: 22542.

localhost:9000, queries: 22542, QPS: 751.229, RPS: 0.000, MiB/s: 0.000, result RPS: 0.000, result MiB/s: 0.000.


eduard ClickHouse $ ./build/debug/programs/clickhouse-benchmark -q "select * from bloat where key = 7123 and prt_num = 11015 and prt_str = '11015' settings apply_patch_parts = 1, max_threads = 1" -t 30 -d 0 -c 8
Loaded 1 queries.
Stopping launch of queries. Requested time limit 30 seconds is exhausted.

Queries executed: 32999.

localhost:9000, queries: 32999, QPS: 1095.972, RPS: 0.000, MiB/s: 0.000, result RPS: 0.000, result MiB/s: 0.000.
```
</details>

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.754`
<!-- ch-version-info:end -->