### PR TITLE
Fix squashing partitioned delta lake data

### DIFF
--- a/tests/integration/test_storage_delta/test.py
+++ b/tests/integration/test_storage_delta/test.py
@@ -3069,7 +3069,9 @@ def test_writes(started_cluster):
         f"CREATE TABLE {table_name} (id Int32, name String) ENGINE = DeltaLake('http://{started_cluster.minio_ip}:{started_cluster.minio_port}/{bucket}/{result_file}/', 'minio', '{minio_secret_key}')"
     )
 
-    instance.query(f"INSERT INTO TABLE FUNCTION deltaLake('http://{started_cluster.minio_ip}:{started_cluster.minio_port}/{bucket}/{result_file}/', 'minio', '{minio_secret_key}', settings allow_experimental_delta_kernel_rs=1) SELECT number as name, toString(number) as id from numbers(10)")
+    instance.query(
+        f"INSERT INTO TABLE FUNCTION deltaLake('http://{started_cluster.minio_ip}:{started_cluster.minio_port}/{bucket}/{result_file}/', 'minio', '{minio_secret_key}', settings allow_experimental_delta_kernel_rs=1) SELECT number as name, toString(number) as id from numbers(10)"
+    )
 
     s3_objects = list(minio_client.list_objects(bucket, result_file, recursive=True))
     file_name = None
@@ -3936,12 +3938,103 @@ deltaLake{suffix}({cluster}
 
     upload_directory(minio_client, bucket, path, "")
 
-    assert 5 == int(node.query(f"SELECT count() FROM {delta_function} ORDER BY all").strip())
+    assert 5 == int(
+        node.query(f"SELECT count() FROM {delta_function} ORDER BY all").strip()
+    )
 
     spark.sql(f"DELETE FROM {table_name} WHERE b = 'b'")
     upload_directory(minio_client, bucket, path, "")
 
-    assert 2 == int(node.query(f"SELECT count() FROM {delta_function} ORDER BY all").strip())
+    assert 2 == int(
+        node.query(f"SELECT count() FROM {delta_function} ORDER BY all").strip()
+    )
     # check rows indexes size is 2
     # (not 3 because third deleted row is inside a different partition and represents a single row inside it)
     assert node.contains_in_log("Row indexes size: 2")
+
+
+@pytest.mark.parametrize("cluster", [False, True])
+def test_partition_columns_3(started_cluster, cluster):
+    """Test for bug https://github.com/ClickHouse/ClickHouse/issues/95526
+
+    Reproduces issue where partition column values become incorrect when inserting
+    from DeltaLake into ClickHouse with many columns and type conversions.
+    """
+    node = started_cluster.instances["node1"]
+    table_name = randomize_table_name("test_partition_columns_jumbled")
+
+    schema = pa.schema(
+        [
+            ("id", pa.int32()),
+            ("region", pa.string()),
+            ("state", pa.string()),
+        ]
+    )
+
+    data = [
+        pa.array([1, 2], type=pa.int32()),
+        pa.array(["west", "east"], type=pa.string()),
+        pa.array(["CA", "NY"], type=pa.string()),
+    ]
+
+    storage_options = {
+        "AWS_ENDPOINT_URL": f"http://{started_cluster.minio_ip}:{started_cluster.minio_port}",
+        "AWS_ACCESS_KEY_ID": minio_access_key,
+        "AWS_SECRET_ACCESS_KEY": minio_secret_key,
+        "AWS_ALLOW_HTTP": "true",
+        "AWS_S3_ALLOW_UNSAFE_RENAME": "true",
+    }
+    path = f"s3://root/{table_name}"
+    table = pa.Table.from_arrays(data, schema=schema)
+
+    write_deltalake(
+        path, table, storage_options=storage_options, partition_by=["region", "state"]
+    )
+
+    if cluster:
+        delta_function = f"""
+    deltaLakeCluster(
+             cluster,
+            'http://{started_cluster.minio_ip}:{started_cluster.minio_port}/root/{table_name}' ,
+            '{minio_access_key}',
+            '{minio_secret_key}')
+        """
+    else:
+        delta_function = f"""
+    deltaLake(
+            'http://{started_cluster.minio_ip}:{started_cluster.minio_port}/root/{table_name}' ,
+            '{minio_access_key}',
+            '{minio_secret_key}',
+        SETTINGS allow_experimental_delta_kernel_rs=0)
+        """
+
+    dst_table = f"{table_name}_dst"
+    node.query(f"""
+        CREATE TABLE {dst_table} (
+            id Int32,
+            region String,
+            state String
+        ) ENGINE = MergeTree()
+        ORDER BY id
+    """)
+
+    node.query(f"""
+        INSERT INTO {dst_table}
+        SELECT * FROM {delta_function}
+    """)
+
+    result_from_delta = node.query(
+        f"SELECT * FROM {delta_function} ORDER BY id",
+        settings={"allow_experimental_delta_kernel_rs": 1, "use_hive_partitioning": 0},
+    ).strip()
+
+    result_from_table = node.query(
+        f"SELECT * FROM {dst_table} ORDER BY id"
+    ).strip()
+
+    assert result_from_delta == result_from_table, \
+        f"Partition columns jumbled!\nFrom DeltaLake:\n{result_from_delta}\n\nFrom table:\n{result_from_table}"
+
+    expected = "1\twest\tCA\n2\teast\tNY"
+    assert result_from_table == expected, \
+        f"Data doesn't match!\nExpected:\n{expected}\n\nGot:\n{result_from_table}"


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix squashing partitioned delta lake data.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.172`
- Backported to: `26.1.3.4`, `25.12.6.9`, `25.11.9.20`, `25.8.17.8`
<!-- ch-version-info:end -->