### PR TITLE
CI: Promote test failures to ERROR on server death

### DIFF
--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -566,11 +566,15 @@ def main():
 
     if JobStages.RETRIES in stages and test_result and test_result.is_failure():
         # retry all failed tests and mark original failed either as success on retry or failed on retry
-        failed_tests = [
-            t.name
-            for t in test_result.results
-            if t.is_failure() and t.name and t.name[0].isdigit()
-        ]
+        failed_tests = []
+        for t in test_result.results:
+            if t.is_failure() and t.name and t.name[0].isdigit():
+                failed_tests.append(t.name)
+            elif t.is_error():
+                failed_tests = []
+                print("NOTE: Skipping retry stage because the main test run ended with errors")
+                break
+
         if len(failed_tests) > 10:
             results.append(
                 Result(

--- a/ci/jobs/scripts/functional_tests_results.py
+++ b/ci/jobs/scripts/functional_tests_results.py
@@ -185,6 +185,11 @@ class FTResultsProcessor:
             )
         elif s.server_died:
             state = Result.Status.FAILED
+            for result in test_results:
+                if result.is_failure():
+                    # Promote all individual test failures to ERROR when the server dies,
+                    # so that they can be distinguished from normal test failures in CIDB.
+                    result.status = Result.StatusExtended.ERROR
             test_results.append(Result("Server died", "FAIL", info="Server died"))
         elif not s.success_finish:
             state = Result.Status.ERROR


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


---

- If server dies in Functional test - reset failed tests statuses to error, so that they can be distinguished from normal test failures in CIDB
- Skip retry stage in the job if any test has status error - setup not working (dead server)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.177`
<!-- ch-version-info:end -->