### PR TITLE
Do optimizePrewhere only after possible runtime filters were added

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/optimizeTree.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeTree.cpp
@@ -544,10 +544,10 @@ void optimizeTreeSecondPass(
             continue;
         }
 
-        /// Prewhere optimization relies on PK optimization (getConditionSelectivityEstimatorByPredicate)
-        if (optimization_settings.optimize_prewhere)
-            optimizePrewhere(*frame.node);
-
+//        /// Prewhere optimization relies on PK optimization (getConditionSelectivityEstimatorByPredicate)
+//        if (optimization_settings.optimize_prewhere)
+//            optimizePrewhere(*frame.node);
+//
         stack.pop_back();
     }
 
@@ -600,12 +600,21 @@ void optimizeTreeSecondPass(
                         break;
                 }
             },
-            [&](auto & frame_node)
+            [](auto &)
             {
-                if (optimization_settings.optimize_prewhere)
-                    optimizePrewhere(frame_node);
             });
     }
+
+    /// Do optimizePrewhere after possible RuntimeFilter pushdown
+    traverseQueryPlan(stack, root,
+        [](auto &)
+        {
+        },
+        [&](auto & frame_node)
+        {
+            if (optimization_settings.optimize_prewhere)
+                optimizePrewhere(frame_node);
+        });
 
     traverseQueryPlan(stack, root,
         [&](auto & frame_node)

--- a/src/Processors/QueryPlan/Optimizations/optimizeTree.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeTree.cpp
@@ -544,10 +544,6 @@ void optimizeTreeSecondPass(
             continue;
         }
 
-//        /// Prewhere optimization relies on PK optimization (getConditionSelectivityEstimatorByPredicate)
-//        if (optimization_settings.optimize_prewhere)
-//            optimizePrewhere(*frame.node);
-//
         stack.pop_back();
     }
 
@@ -581,7 +577,7 @@ void optimizeTreeSecondPass(
             convertLogicalJoinToPhysical(frame_node, nodes, optimization_settings);
         });
 
-    /// If join runtime filters were added re-run optimizePrewhere and filter push down optimizations
+    /// If join runtime filters were added re-run push down optimizations
     /// to move newly added runtime filter as deep in the tree as possible
     if (join_runtime_filters_were_added)
     {
@@ -599,22 +595,18 @@ void optimizeTreeSecondPass(
                     if (!changed_nodes)
                         break;
                 }
-            },
-            [](auto &)
-            {
             });
     }
 
-    /// Do optimizePrewhere after possible RuntimeFilter pushdown
-    traverseQueryPlan(stack, root,
-        [](auto &)
-        {
-        },
-        [&](auto & frame_node)
-        {
-            if (optimization_settings.optimize_prewhere)
+    /// Do PREWHERE optimization after all possible filters including JOIN runtime filters were pushed down
+    if (optimization_settings.optimize_prewhere)
+    {
+        traverseQueryPlan(stack, root,
+            [&](auto & frame_node)
+            {
                 optimizePrewhere(frame_node);
-        });
+            });
+    }
 
     traverseQueryPlan(stack, root,
         [&](auto & frame_node)

--- a/tests/queries/0_stateless/03580_join_runtime_filter_prewhere.reference
+++ b/tests/queries/0_stateless/03580_join_runtime_filter_prewhere.reference
@@ -10,3 +10,9 @@ Prewhere filter column: __applyFilter(_runtime_filter_UNIQ_ID_0, __table2.c_nati
 BuildRuntimeFilter (Build runtime join filter on __table1.n_nationkey)
 ReadFromMergeTree (default.nation)
 Prewhere filter column: equals(__table1.n_name, \'FRANCE\'_String) (removed)
+-- Addintional filter in PREWHERE
+ReadFromMergeTree (default.customer)
+Prewhere filter column: and(equals(modulo(__table2.c_custkey, 4_UInt8), 0_UInt8), __applyFilter(_runtime_filter_UNIQ_ID_0, __table2.c_nationkey)) (removed)
+BuildRuntimeFilter (Build runtime join filter on __table1.n_nationkey)
+ReadFromMergeTree (default.nation)
+Prewhere filter column: equals(__table1.n_name, \'FRANCE\'_String) (removed)

--- a/tests/queries/0_stateless/03580_join_runtime_filter_prewhere.sql
+++ b/tests/queries/0_stateless/03580_join_runtime_filter_prewhere.sql
@@ -41,3 +41,15 @@ FROM
     ))
 )
 WHERE (explain LIKE '%ReadFromMergeTree%') OR (explain LIKE '%Prewhere filter column:%') OR (explain LIKE '%Build%');
+
+
+SELECT '-- Addintional filter in PREWHERE';
+SELECT REGEXP_REPLACE(trimLeft(explain), '_runtime_filter_\\d+', '_runtime_filter_UNIQ_ID')
+FROM
+(
+    EXPLAIN actions=1
+    SELECT count() FROM nation, customer
+    WHERE (c_nationkey = n_nationkey) AND (n_name = 'FRANCE') AND (c_custkey%4 = 0)
+    SETTINGS enable_join_runtime_filters = 1, optimize_move_to_prewhere = 1, query_plan_join_swap_table = 1
+)
+WHERE (explain LIKE '%ReadFromMergeTree%') OR (explain LIKE '%Prewhere filter column:%') OR (explain LIKE '%Build%');

--- a/tests/queries/0_stateless/03580_join_runtime_filter_prewhere.sql
+++ b/tests/queries/0_stateless/03580_join_runtime_filter_prewhere.sql
@@ -1,5 +1,5 @@
-CREATE TABLE nation(n_nationkey Int32, n_name String) ENGINE MergeTree ORDER BY n_nationkey;
-CREATE TABLE customer(c_custkey Int32, c_nationkey Int32) ENGINE MergeTree ORDER BY c_custkey;
+CREATE TABLE nation(n_nationkey Int32, n_name String) ENGINE MergeTree ORDER BY n_nationkey SETTINGS auto_statistics_types='uniq,tdigest';
+CREATE TABLE customer(c_custkey Int32, c_nationkey Int32) ENGINE MergeTree ORDER BY c_custkey SETTINGS auto_statistics_types='uniq,tdigest';
 
 INSERT INTO nation VALUES (5,'ETHIOPIA'),(6,'FRANCE'),(7,'GERMANY');
 
@@ -8,6 +8,7 @@ INSERT INTO customer SELECT number, 5 FROM numbers(500);
 SET enable_analyzer=1;
 SET enable_parallel_replicas=0;
 SET join_algorithm = 'hash,parallel_hash';
+SET use_statistics = 1;
 
 SELECT '-- Check that filter on c_nationkey is moved to PREWHERE';
 SELECT REGEXP_REPLACE(trimLeft(explain), '_runtime_filter_\\d+', '_runtime_filter_UNIQ_ID')
@@ -50,6 +51,6 @@ FROM
     EXPLAIN actions=1
     SELECT count() FROM nation, customer
     WHERE (c_nationkey = n_nationkey) AND (n_name = 'FRANCE') AND (c_custkey%4 = 0)
-    SETTINGS enable_join_runtime_filters = 1, optimize_move_to_prewhere = 1, query_plan_join_swap_table = 1
+    SETTINGS enable_join_runtime_filters = 1, optimize_move_to_prewhere = 1, query_plan_join_swap_table = 1, enable_multiple_prewhere_read_steps = 1
 )
 WHERE (explain LIKE '%ReadFromMergeTree%') OR (explain LIKE '%Prewhere filter column:%') OR (explain LIKE '%Build%');

--- a/tests/queries/0_stateless/03753_join_runtime_filter_dynamically_disable.sql
+++ b/tests/queries/0_stateless/03753_join_runtime_filter_dynamically_disable.sql
@@ -19,6 +19,7 @@ SET join_algorithm = 'hash,parallel_hash';
 SET query_plan_optimize_join_order_algorithm='greedy';
 SET query_plan_optimize_join_order_limit=1;
 SET query_plan_join_swap_table=0;
+SET enable_multiple_prewhere_read_steps=1;
 
 -- 1 row in filter
 SELECT count()


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
When read step already has PREWHERE filters a new filter cannot be added. This change postpones PREWHERE optimization until after JOIN runtime filter optimization so that runtime filters can be also pushed to PREWHERE.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.200`
<!-- ch-version-info:end -->