### PR TITLE
Add perf test for non-selective join runtime filter

### DIFF
--- a/tests/performance/join_runtime_filter.xml
+++ b/tests/performance/join_runtime_filter.xml
@@ -104,6 +104,23 @@
         SETTINGS enable_join_runtime_filters=1
     </query>
 
+    <!-- 91 million elements in filter  -->
+    <query>
+        SELECT avg(o_totalprice)
+        FROM orders
+        JOIN customer
+        ON c_custkey = o_custkey
+        SETTINGS enable_join_runtime_filters=0
+    </query>
+
+    <query>
+        SELECT avg(o_totalprice)
+        FROM orders
+        JOIN customer
+        ON c_custkey = o_custkey
+        SETTINGS enable_join_runtime_filters=1
+    </query>
+
     <drop_query>DROP TABLE orders</drop_query>
     <drop_query>DROP TABLE customer</drop_query>
     <drop_query>DROP TABLE nation</drop_query>


### PR DESCRIPTION
without runtime filters:
```
query   11      join_runtime_filter.query11.run0        0       0.028739452362060547
query   11      join_runtime_filter.query11.run1        0       0.026578426361083984
...
median  11      0.027719736099243164
```

with runtime filters before https://github.com/ClickHouse/ClickHouse/pull/95671:
```
query   12      join_runtime_filter.query12.run0        0       0.048084259033203125
query   12      join_runtime_filter.query12.run1        0       0.04732179641723633
...
median  12      0.04710853099822998
```

with runtime filters after https://github.com/ClickHouse/ClickHouse/pull/95671:
```
query   12      join_runtime_filter.query12.run0        0       0.031131744384765625
query   12      join_runtime_filter.query12.run1        0       0.030243396759033203
...
median  12      0.029787898063659668
```

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Increase skipped rows ratio in case of ineffective join runtime filter.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.195`
<!-- ch-version-info:end -->