### PR TITLE
Enable statistics cache

### DIFF
--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -44,7 +44,6 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"deduplicate_insert", "backward_compatible_choice", "backward_compatible_choice", "New setting to control deduplication for INSERT queries."},
             {"default_dictionary_database", "", "", "New setting"},
             {"parallel_replicas_filter_pushdown", false, false, "New setting"},
-            {"refresh_statistics_interval", 0, 300, "Enable statistics cache"},
         });
         addSettingsChanges(settings_changes_history, "26.1",
         {
@@ -1042,6 +1041,7 @@ const VersionToSettingsChangesMap & getMergeTreeSettingsChangesHistory()
             {"add_minmax_index_for_temporal_columns", false, false, "New setting"},
             {"distributed_index_analysis_min_parts_to_activate", 10, 10, "New setting"},
             {"distributed_index_analysis_min_indexes_size_to_activate", 1_GiB, 1_GiB, "New setting"},
+            {"refresh_statistics_interval", 0, 300, "Enable statistics cache"},
         });
         addSettingsChanges(merge_tree_settings_changes_history, "26.1",
         {

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -44,7 +44,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"deduplicate_insert", "backward_compatible_choice", "backward_compatible_choice", "New setting to control deduplication for INSERT queries."},
             {"default_dictionary_database", "", "", "New setting"},
             {"parallel_replicas_filter_pushdown", false, false, "New setting"},
-            {"use_statistics_cache", 0, 120, "Enable statistics cache"},
+            {"use_statistics_cache", 0, 300, "Enable statistics cache"},
         });
         addSettingsChanges(settings_changes_history, "26.1",
         {
@@ -97,6 +97,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"use_paimon_partition_pruning", false, false, "New setting."},
             {"use_skip_indexes_for_disjunctions", false, true, "New setting"},
             {"allow_statistics_optimize", false, true, "Enable this optimization by default."},
+            {"allow_statistic_optimize", false, true, "Enable this optimization by default."},
             {"query_plan_text_index_add_hint", true, true, "New setting"},
             {"query_plan_read_in_order_through_join", false, true, "New setting"},
             {"query_plan_max_limit_for_lazy_materialization", 10, 10000, "Increase the limit after performance improvement"},

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -44,6 +44,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"deduplicate_insert", "backward_compatible_choice", "backward_compatible_choice", "New setting to control deduplication for INSERT queries."},
             {"default_dictionary_database", "", "", "New setting"},
             {"parallel_replicas_filter_pushdown", false, false, "New setting"},
+            {"use_statistics_cache", 0, 120, "Enable statistics cache"},
         });
         addSettingsChanges(settings_changes_history, "26.1",
         {
@@ -96,7 +97,6 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"use_paimon_partition_pruning", false, false, "New setting."},
             {"use_skip_indexes_for_disjunctions", false, true, "New setting"},
             {"allow_statistics_optimize", false, true, "Enable this optimization by default."},
-            {"allow_statistic_optimize", false, true, "Enable this optimization by default."},
             {"query_plan_text_index_add_hint", true, true, "New setting"},
             {"query_plan_read_in_order_through_join", false, true, "New setting"},
             {"query_plan_max_limit_for_lazy_materialization", 10, 10000, "Increase the limit after performance improvement"},

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -44,7 +44,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"deduplicate_insert", "backward_compatible_choice", "backward_compatible_choice", "New setting to control deduplication for INSERT queries."},
             {"default_dictionary_database", "", "", "New setting"},
             {"parallel_replicas_filter_pushdown", false, false, "New setting"},
-            {"use_statistics_cache", 0, 300, "Enable statistics cache"},
+            {"refresh_statistics_interval", 0, 300, "Enable statistics cache"},
         });
         addSettingsChanges(settings_changes_history, "26.1",
         {

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -2470,12 +2470,12 @@ void MergeTreeData::loadDataParts(bool skip_sanity_checks, std::optional<std::un
 
         refresh_parts_task->scheduleAfter(refresh_parts_interval);
     }
-
-    startStatisticsCache((*settings)[MergeTreeSetting::refresh_statistics_interval].totalSeconds());
 }
 
-void MergeTreeData::startStatisticsCache(UInt64 refresh_statistics_seconds)
+void MergeTreeData::startStatisticsCache()
 {
+    const auto settings = getSettings();
+    UInt64 refresh_statistics_seconds = (*settings)[MergeTreeSetting::refresh_statistics_interval].totalSeconds();
     if (refresh_statistics_seconds && !refresh_stats_task)
     {
         LOG_INFO(log, "Start to refresh statistics");

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -1833,7 +1833,7 @@ protected:
     mutable std::mutex stats_mutex;
     ConditionSelectivityEstimatorPtr cached_estimator;
 
-    void startStatisticsCache(UInt64 refresh_statistics_seconds);
+    void startStatisticsCache();
     void refreshStatistics(UInt64 interval_seconds);
 
     static void incrementInsertedPartsProfileEvent(MergeTreeDataPartType type);

--- a/src/Storages/MergeTree/MergeTreeSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeSettings.cpp
@@ -2064,7 +2064,7 @@ namespace ErrorCodes
     - local - scope is limited by local disks .
     - none - empty scope, do not search
     )", 0) \
-    DECLARE(Seconds, refresh_statistics_interval, 0, R"(
+    DECLARE(Seconds, refresh_statistics_interval, 300, R"(
     The interval of refreshing statistics cache in seconds. If it is set to zero, the refreshing will be disabled.
     )", 0) \
     DECLARE(UInt64, distributed_index_analysis_min_parts_to_activate, 10, R"(

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -228,6 +228,7 @@ void StorageMergeTree::startup()
         background_operations_assignee.start();
         startBackgroundMovesIfNeeded();
         startOutdatedAndUnexpectedDataPartsLoadingTask();
+        startStatisticsCache();
     }
     catch (...)
     {

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -5581,6 +5581,7 @@ void StorageReplicatedMergeTree::startup()
 {
     LOG_TRACE(log, "Starting up table");
     startOutdatedAndUnexpectedDataPartsLoadingTask();
+    startStatisticsCache();
     if (attach_thread)
     {
         attach_thread->start();

--- a/tests/queries/0_stateless/03745_system_background_schedule_pool.reference
+++ b/tests/queries/0_stateless/03745_system_background_schedule_pool.reference
@@ -1,4 +1,5 @@
 1
 buffer_flush	default	test_buffer_03745	1	StorageBuffer (default.test_buffer_03745)/Bg
 schedule	default	test_merge_tree_03745	1	BackgroundJobsAssignee:DataProcessing
+schedule	default	test_merge_tree_03745	1	MergeTreeData::refreshStatistics
 distributed	default	test_distributed_03745	1	default.test_distributed_03745.DistributedInsertQueue.default/Bg

--- a/tests/queries/0_stateless/03745_system_background_schedule_pool.reference
+++ b/tests/queries/0_stateless/03745_system_background_schedule_pool.reference
@@ -1,5 +1,4 @@
 1
 buffer_flush	default	test_buffer_03745	1	StorageBuffer (default.test_buffer_03745)/Bg
 schedule	default	test_merge_tree_03745	1	BackgroundJobsAssignee:DataProcessing
-schedule	default	test_merge_tree_03745	1	MergeTreeData::refreshStatistics
 distributed	default	test_distributed_03745	1	default.test_distributed_03745.DistributedInsertQueue.default/Bg

--- a/tests/queries/0_stateless/03745_system_background_schedule_pool.sql
+++ b/tests/queries/0_stateless/03745_system_background_schedule_pool.sql
@@ -13,7 +13,7 @@ DROP TABLE test_table_03745;
 
 -- Test 2: MergeTree table (schedule pool)
 DROP TABLE IF EXISTS test_merge_tree_03745;
-CREATE TABLE test_merge_tree_03745 (x UInt64, y String) ENGINE = MergeTree() ORDER BY x;
+CREATE TABLE test_merge_tree_03745 (x UInt64, y String) ENGINE = MergeTree() ORDER BY x SETTINGS refresh_statistics_interval = '0';
 INSERT INTO test_merge_tree_03745 VALUES (1, 'a'), (2, 'b');
 SELECT pool, database, table, table_uuid != toUUIDOrDefault(0) AS has_uuid, log_name FROM system.background_schedule_pool WHERE database = currentDatabase();
 DROP TABLE test_merge_tree_03745;


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement



### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Enable statistics cache and set the update period of cache to 300s

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.221`
<!-- ch-version-info:end -->