### PR TITLE
ci: fix old system log tables rotation in upgrade check

### DIFF
--- a/tests/docker_scripts/stress_tests.lib
+++ b/tests/docker_scripts/stress_tests.lib
@@ -69,7 +69,7 @@ function configure()
     #
     #  DB::Exception: Incorrect file extension: V.sql.move_from.X in metadata directory store/346/346b09d6-907d-4b6b-a1e3-361ecfdab8a4/. (INCORRECT_FILE_NAME)
     #
-    /repo/tests/config/install.sh /etc/clickhouse-server /etc/clickhouse-client --no-keeper-inject-auth --no-remote-database-disk
+    /repo/tests/config/install.sh /etc/clickhouse-server /etc/clickhouse-client --no-keeper-inject-auth --no-remote-database-disk "$@"
 
     # avoid too slow startup
     sudo cat /etc/clickhouse-server/config.d/keeper_port.xml \

--- a/tests/docker_scripts/upgrade_runner.sh
+++ b/tests/docker_scripts/upgrade_runner.sh
@@ -91,14 +91,6 @@ save_mergetree_settings_clean 'old_merge_tree_settings.native'
 save_major_version 'old_version.native'
 old_major_version=$(clickhouse-local -q "select a[1] || '.' || a[2] from (select splitByChar('.', version()) as a)")
 
-# Initial run without S3 to create system.*_log on local file system to make it
-# available for dump via clickhouse-local
-configure
-
-start_server || (echo "Failed to start server" && exit 1)
-stop_server || (echo "Failed to stop server" && exit 1)
-mv /var/log/clickhouse-server/clickhouse-server.log /var/log/clickhouse-server/clickhouse-server.initial.log
-
 configure_opts=(
     # Let's enable S3 storage by default
     --s3-storage

--- a/tests/docker_scripts/upgrade_runner.sh
+++ b/tests/docker_scripts/upgrade_runner.sh
@@ -363,7 +363,6 @@ rg -Fav -e "Code: 236. DB::Exception: Cancelled merging parts" \
            -e "doesn't have metadata version on disk" \
            -e "Unknown codec family: ZSTD_QAT" \
            -e "Unknown codec family: DEFLATE_QPL" \
-           -e "Failed to flush system log" \
            -e "Bad get: has String, requested UInt64. (BAD_GET" \
            -e "Disk does not support stat. (NOT_IMPLEMENTED" \
            -e "QUALIFY clause is not supported in the old analyzer" \


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Upgrade job cannot `RENAME` old system tables because it mixes S3 and local disk policy:

```
2026.01.23 00:47:54.383367 [ 1094548 ] {} <Error> void DB::SystemLog<DB::ZooKeeperConnectionLogElement>::flushImpl(const std::vector<LogElement> &, uint64_t) [LogElement = DB::ZooKeeperConnectionLogElement]: Failed to flush system log system.zookeeper_connection_log with 1 entries up to offset 1: Code: 57. DB::Exception: Directory for table data data/system/zookeeper_connection_log/ already exists. (TABLE_ALREADY_EXISTS), Stack trace (when copying this message, always include the lines below):
```

This was needed because previously `clickhouse-local` was not able to dump tables from S3 (due to we do not pass config), but now it should work, and we can simply remove it


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.234`
<!-- ch-version-info:end -->