### PR TITLE
Better fatal message for SIGABRT

### DIFF
--- a/src/Common/SignalHandlers.cpp
+++ b/src/Common/SignalHandlers.cpp
@@ -17,6 +17,7 @@
 #include <Poco/Environment.h>
 
 #include <thread>
+#include <unistd.h>
 
 #pragma clang diagnostic ignored "-Wreserved-identifier"
 
@@ -381,9 +382,10 @@ try
     /// in case of double fault.
 
     LOG_FATAL(log, "########## Short fault info ############");
-    LOG_FATAL(log, "(version {}{}, build id: {}, git hash: {}, architecture: {}) (from thread {}) Received signal {}",
+    LOG_FATAL(log, "(version {}{}, build id: {}, git hash: {}, architecture: {}) (from thread {}) Received signal {} ({})",
               VERSION_STRING, VERSION_OFFICIAL, build_id(), GIT_HASH, Poco::Environment::osArchitecture(),
-              thread_num, sig);
+              thread_num, sig,
+              info.si_pid == getpid() ? "internal" : fmt::format("signal send by {} from user {}", info.si_pid, info.si_uid));
 
     std::string signal_description = "Unknown signal";
 
@@ -395,8 +397,7 @@ try
 
     LOG_FATAL(log, "Signal description: {}", signal_description);
 
-    String error_message;
-    error_message = signalToErrorMessage(sig, info, *context);
+    String error_message = signalToErrorMessage(sig, info, *context);
     LOG_FATAL(log, fmt::runtime(error_message));
 
     String bare_stacktrace_str;

--- a/src/Common/StackTrace.cpp
+++ b/src/Common/StackTrace.cpp
@@ -180,7 +180,7 @@ static constexpr std::string_view SigillErrorString(int si_code)
     }
 }
 
-std::string signalToErrorMessage(int sig, const siginfo_t & info, [[maybe_unused]] const ucontext_t & context)
+std::string signalToErrorMessage(int sig, const siginfo_t & info, const ucontext_t & context)
 {
     switch (sig)
     {


### PR DESCRIPTION
This signal is special, since abort() will also issue this signal, but our CI also does this, so we need a way to distinguish internal errors from external signals.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.188`
<!-- ch-version-info:end -->