### PR TITLE
Disable flaky test 02434_cancel_insert_when_client_dies for DatabaseReplicated

### DIFF
--- a/tests/queries/0_stateless/02434_cancel_insert_when_client_dies.sh
+++ b/tests/queries/0_stateless/02434_cancel_insert_when_client_dies.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-random-settings, no-asan, no-msan, no-tsan, no-async-insert, no-debug, no-fasttest
+# Tags: no-random-settings, no-asan, no-msan, no-tsan, no-async-insert, no-debug, no-fasttest, no-replicated-database
 # no-fasttest: The test runs for 40 seconds
 # shellcheck disable=SC2009
 


### PR DESCRIPTION
The test uses distributed tables with `test_cluster_one_shard_two_replicas` cluster. In `DatabaseReplicated` environments, the `system flush distributed` command can take significantly longer than the 300-second timeout, causing sporadic test failures.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.208`
<!-- ch-version-info:end -->