### PR TITLE
Remove garbage from distributed DDL

### DIFF
--- a/cmake/warnings.cmake
+++ b/cmake/warnings.cmake
@@ -44,6 +44,8 @@ no_warning(unsafe-buffer-usage) # too aggressive
 no_warning(switch-default) # conflicts with "defaults in a switch covering all enum values"
 no_warning(nrvo) # not eliding copy on return - too aggressive
 no_warning(missing-noreturn) # too aggressive with no clear benefit, see https://github.com/ClickHouse/ClickHouse/pull/86416
+no_warning(lifetime-safety-intra-tu-suggestions) # New in clang-23
+no_warning(lifetime-safety-cross-tu-suggestions) # New in clang-23
 if (ARCH_E2K)
     # disable "use of GNU statement expression extension from macro expansion" warning
     no_warning(gnu-statement-expression-from-macro-expansion)

--- a/src/AggregateFunctions/AggregateFunctionSparkbar.cpp
+++ b/src/AggregateFunctions/AggregateFunctionSparkbar.cpp
@@ -238,6 +238,7 @@ private:
         }
 
         /// Scale the histogram to the range [0, BAR_LEVELS]
+#pragma clang loop vectorize(disable) /// Workaround for a bug in clang-23
         for (auto & y : histogram)
         {
             if (isNaN(y) || y <= 0)

--- a/src/Interpreters/DDLTask.h
+++ b/src/Interpreters/DDLTask.h
@@ -118,7 +118,7 @@ struct DDLTaskBase
 
     bool is_initial_query = false;
     bool is_circular_replicated = false;
-    bool execute_on_leader = false;
+    bool execute_on_single_replica = false;
 
     Coordination::Requests ops;
     ExecutionStatus execution_status;

--- a/src/Interpreters/DDLWorker.h
+++ b/src/Interpreters/DDLWorker.h
@@ -152,12 +152,12 @@ protected:
     /// Most of these queries can be executed on non-leader replica, but actually they still send
     /// query via RemoteQueryExecutor to leader, so to avoid such "2-phase" query execution we
     /// execute query directly on leader.
-    bool tryExecuteQueryOnLeaderReplica(
+    bool tryExecuteQueryOnSingleReplica(
         DDLTaskBase & task,
         StoragePtr storage,
         const String & node_path,
         const ZooKeeperPtr & zookeeper,
-        std::unique_ptr<zkutil::ZooKeeperLock> & execute_on_leader_lock);
+        std::unique_ptr<zkutil::ZooKeeperLock> & execute_on_single_replica_lock);
 
     bool tryExecuteQuery(DDLTaskBase & task, const ZooKeeperPtr & zookeeper, bool internal);
 

--- a/src/Storages/StorageAlias.h
+++ b/src/Storages/StorageAlias.h
@@ -136,10 +136,7 @@ public:
     bool areAsynchronousInsertsEnabled() const override { return getTargetTable()->areAsynchronousInsertsEnabled(); }
     bool isRemote() const override { return getTargetTable()->isRemote(); }
     bool isSharedStorage() const override { return getTargetTable()->isSharedStorage(); }
-
-    /// This is important for DatabaseReplicated, avoid not supported by distributed DDL
-    bool supportsReplication() const override { return false; }
-
+    bool supportsReplication() const override { return getTargetTable()->supportsReplication(); }
     bool hasLightweightDeletedMask() const override { return getTargetTable()->hasLightweightDeletedMask(); }
     bool supportsLightweightDelete() const override { return getTargetTable()->supportsLightweightDelete(); }
     std::expected<void, PreformattedMessage> supportsLightweightUpdate() const override { return getTargetTable()->supportsLightweightUpdate(); }


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


The stress test has failed: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=95741&sha=25cf93f3d31586ec8aea9b30ac01d2907e28be63&name_0=PR&name_1=Stress%20test%20%28arm_asan%2C%20s3%29
https://github.com/ClickHouse/ClickHouse/pull/95741

Because Iceberg tables are marked as supporting replication, and that's why DDLWorker decided to use the "execute on leader replica" mode.

Then the assertion was checking that it is ReplicatedMergeTree (or SharedMergeTree) and failed.

First observation is that there is no such thing as "leader replica". I removed the leader election, maybe 7 years ago. So I renamed all the methods to reflect this fact and removed pointless checks for "is leader".

Then I found an incorrect fix in StorageAlias - someone was clearly fixing the same bug, but in the wrong way.

Then I removed the dependency of DDLWorker on ReplicatedMergeTree, just because it's bad code.

You might think that there is still some sense in skipping inactive or restarting replicas. But if we don't do it, the code will be simpler, and it will not prevent the operation from succeeding in the end.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.244`
<!-- ch-version-info:end -->