### PR TITLE
Speedup T64 coded compression by using dynamic dispatch on x86

### DIFF
--- a/src/Compression/CompressionCodecT64.cpp
+++ b/src/Compression/CompressionCodecT64.cpp
@@ -367,7 +367,7 @@ void clear(T * buf)
 }
 
 
-MULTITARGET_FUNCTION_AVX512BW_AVX2(
+MULTITARGET_FUNCTION_AVX512BW_AVX512F_AVX2_SSE42(
 MULTITARGET_FUNCTION_HEADER(
 template <typename T, bool full>
 void), transposeImpl, MULTITARGET_FUNCTION_BODY((const T * src, char * dst, UInt32 num_bits, UInt32 tail) /// NOLINT
@@ -410,6 +410,11 @@ ALWAYS_INLINE void transpose(const T * src, char * dst, UInt32 num_bits, UInt32 
         transposeImplAVX512BW<T, full>(src, dst, num_bits, tail);
         return;
     }
+    if (isArchSupported(TargetArch::AVX512F))
+    {
+        transposeImplAVX512F<T, full>(src, dst, num_bits, tail);
+        return;
+    }
     if (isArchSupported(TargetArch::AVX2))
     {
         transposeImplAVX2<T, full>(src, dst, num_bits, tail);
@@ -421,7 +426,7 @@ ALWAYS_INLINE void transpose(const T * src, char * dst, UInt32 num_bits, UInt32 
     }
 }
 
-MULTITARGET_FUNCTION_AVX512BW_AVX2(
+MULTITARGET_FUNCTION_AVX512BW_AVX512F_AVX2_SSE42(
 MULTITARGET_FUNCTION_HEADER(
 template <typename T, bool full>
 void), reverseTransposeImpl, MULTITARGET_FUNCTION_BODY((const char * src, T * buf, UInt32 num_bits, UInt32 tail) /// NOLINT
@@ -459,6 +464,11 @@ ALWAYS_INLINE void reverseTranspose(const char * src, T * buf, UInt32 num_bits, 
     if (isArchSupported(TargetArch::AVX512BW))
     {
         reverseTransposeImplAVX512BW<T, full>(src, buf, num_bits, tail);
+        return;
+    }
+    if (isArchSupported(TargetArch::AVX512F))
+    {
+        reverseTransposeImplAVX512F<T, full>(src, buf, num_bits, tail);
         return;
     }
     if (isArchSupported(TargetArch::AVX2))


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Speedup T64 codec compression by using dynamic dispatch on x86

Comes from https://github.com/ClickHouse/ClickHouse/pull/90043
Observed speed-up: ~ -1.431x. Covered by `codecs_int_insert` performance test

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.238`
<!-- ch-version-info:end -->