### PR TITLE
Allow to enter PR number in the very first check_ci.py prompt

### DIFF
--- a/ci/jobs/scripts/check_ci.py
+++ b/ci/jobs/scripts/check_ci.py
@@ -533,7 +533,7 @@ def main():
         def is_pr_number(s):
             try:
                 num = int(s.lstrip("#"))
-                return 10000 < num < 99999
+                return 10000 < num < 150_000
             except ValueError:
                 return False
 
@@ -542,7 +542,7 @@ def main():
 
         selected_pr = UserPrompt.select_from_menu(
             pr_menu,
-            "Select a from list, or enter commit sha or PR number",
+            "Select a PR from the list, or manually enter a commit sha or PR number",
             validator=lambda x: is_pr_number(x) or is_commit_sha(x),
         )
         if isinstance(selected_pr, str):

--- a/ci/jobs/scripts/check_ci.py
+++ b/ci/jobs/scripts/check_ci.py
@@ -525,22 +525,35 @@ def main():
         )
         my_prs_number_and_title = json.loads(my_prs_number_and_title)
         pr_menu = []
-        pr_menu.append((f"Process commit sha on master", 0))
-        pr_menu.append((f"Enter PR number manually", 1))
         for pr_dict in my_prs_number_and_title:
             pr_number = pr_dict["number"]
             pr_title = pr_dict["title"]
             pr_menu.append((f"#{pr_number}: {pr_title}", pr_number))
 
-        selected_pr = UserPrompt.select_from_menu(pr_menu, "Select a PR to merge")
-        if selected_pr[1] == 1:
-            pr_number = UserPrompt.get_number("Enter PR number", lambda x: x > 70000)
-        elif selected_pr[1] == 0:
-            is_master_commit = True
-            commit_sha = UserPrompt.get_string(
-                "Enter commit sha", validator=lambda x: len(x) == 40
-            )
-            pr_number = None
+        def is_pr_number(s):
+            try:
+                num = int(s.lstrip("#"))
+                return 10000 < num < 99999
+            except ValueError:
+                return False
+
+        def is_commit_sha(s):
+            return len(s) == 40 and all(c in "0123456789abcdef" for c in s.lower())
+
+        selected_pr = UserPrompt.select_from_menu(
+            pr_menu,
+            "Select a from list, or enter commit sha or PR number",
+            validator=lambda x: is_pr_number(x) or is_commit_sha(x),
+        )
+        if isinstance(selected_pr, str):
+            if is_commit_sha(selected_pr):
+                is_master_commit = True
+                commit_sha = selected_pr
+                pr_number = None
+            elif is_pr_number(selected_pr):
+                pr_number = int(selected_pr.lstrip("#"))
+            else:
+                raise Exception(f"Unrecognized input: {selected_pr}")
         else:
             pr_number = selected_pr[1]
 

--- a/ci/praktika/interactive.py
+++ b/ci/praktika/interactive.py
@@ -17,13 +17,14 @@ class UserPrompt:
             sys.exit(0)
 
     @staticmethod
-    def select_from_menu(menuitems, question="Enter your choice"):
+    def select_from_menu(menuitems, question="Enter your choice", validator=None):
         """
         Display a numbered menu and get user's selection.
 
         Args:
             menuitems: List of items to display. Can be plain values or tuples (display_value, return_value).
             question: The prompt question to display.
+            validator: If specified allow return arbitrary input satisfying the validator function.`
 
         Returns:
             The selected item (or tuple if items are tuples), or None if cancelled.
@@ -37,6 +38,8 @@ class UserPrompt:
         while True:
             try:
                 choice = UserPrompt._safe_input(f"\n{question} (1-{len(menuitems)}): ")
+                if validator is not None and validator(choice):
+                    return choice
                 choice_num = int(choice)
 
                 if 1 <= choice_num <= len(menuitems):


### PR DESCRIPTION
### Changelog category (leave one):

- CI Fix or Improvement (changelog entry is not required)



### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.219`
<!-- ch-version-info:end -->