### PR TITLE
Fix SEGV in `execute_query_fuzzer` due to a nullptr `TemporaryDataOnDiskScope`

### DIFF
--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -408,7 +408,7 @@ void LocalServer::tryInitPath()
 
     global_context->setPath(fs::path(path) / "");
 
-    global_context->setTemporaryStoragePath(fs::path(path) / "tmp" / "", 0);
+    global_context->setTemporaryStoragePath(fs::path(path) / "tmp" / "", 1_Gi);
     global_context->setFlagsPath(fs::path(path) / "flags" / "");
 
     global_context->setUserFilesPath(""); /// user's files are everywhere

--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -408,7 +408,7 @@ void LocalServer::tryInitPath()
 
     global_context->setPath(fs::path(path) / "");
 
-    global_context->setTemporaryStoragePath(fs::path(path) / "tmp" / "", 1_Gi);
+    global_context->setTemporaryStoragePath(fs::path(path) / "tmp" / "", 1_GiB);
     global_context->setFlagsPath(fs::path(path) / "flags" / "");
 
     global_context->setUserFilesPath(""); /// user's files are everywhere

--- a/src/Interpreters/ProcessList.cpp
+++ b/src/Interpreters/ProcessList.cpp
@@ -872,8 +872,9 @@ ProcessListForUser::ProcessListForUser(ContextPtr global_context, ProcessList * 
             .metrics = {}, /// Metrics are set by child scopes
         };
 
-        user_temp_data_on_disk = std::make_shared<TemporaryDataOnDiskScope>(global_context->getSharedTempDataOnDisk(),
-            std::move(temporary_data_on_disk_settings));
+        if (auto shared_temp_data = global_context->getSharedTempDataOnDisk())
+            user_temp_data_on_disk = std::make_shared<TemporaryDataOnDiskScope>(std::move(shared_temp_data),
+                std::move(temporary_data_on_disk_settings));
     }
 }
 

--- a/src/Interpreters/ProcessList.cpp
+++ b/src/Interpreters/ProcessList.cpp
@@ -286,8 +286,9 @@ ProcessList::EntryPtr ProcessList::insert(
                 if (temporary_data_on_disk_settings.buffer_size > 1_GiB)
                     throw Exception(ErrorCodes::ARGUMENT_OUT_OF_BOUND, "Too large `temporary_files_buffer_size`, maximum 1 GiB");
 
-                query_context->setTempDataOnDisk(std::make_shared<TemporaryDataOnDiskScope>(
-                    user_process_list.user_temp_data_on_disk, std::move(temporary_data_on_disk_settings)));
+                if (user_process_list.user_temp_data_on_disk)
+                    query_context->setTempDataOnDisk(std::make_shared<TemporaryDataOnDiskScope>(
+                        user_process_list.user_temp_data_on_disk, std::move(temporary_data_on_disk_settings)));
             }
 
             /// Set query-level memory trackers

--- a/src/Interpreters/fuzzers/execute_query_fuzzer.cpp
+++ b/src/Interpreters/fuzzers/execute_query_fuzzer.cpp
@@ -18,7 +18,10 @@
 #include <Common/ThreadStatus.h>
 #include <Common/CurrentThread.h>
 
+#include <filesystem>
+
 using namespace DB;
+namespace fs = std::filesystem;
 
 
 ContextMutablePtr context;
@@ -31,6 +34,9 @@ extern "C" int LLVMFuzzerInitialize(int *, char ***)
     static SharedContextHolder shared_context = Context::createShared();
     context = Context::createGlobal(shared_context.get());
     context->makeGlobalContext();
+
+    /// Initialize temporary storage for processing queries
+    context->setTemporaryStoragePath((fs::temp_directory_path() / "clickhouse_fuzzer_tmp" / "").string(), 0);
 
     MainThreadStatus::getInstance();
 


### PR DESCRIPTION
The fuzzer crashed when `ProcessList::insert` tried to create a `TemporaryDataOnDiskScope` with a nullptr parent, because:
1. The fuzzer never initialized temporary storage via `setTemporaryStoragePath`
2. `getSharedTempDataOnDisk()` returned null
3. The child constructor dereferenced null at `parent->file_provider`

Fix by:
1. Adding nullptr check in `ProcessListForUser` before creating child scope
2. Initializing temporary storage in the fuzzer like clickhouse-local does

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

See https://s3.amazonaws.com/clickhouse-test-reports/REFs/master/ea16f9975e4c7cf0264f18017cacb26a03c25180/libfuzzer_tests/execute_query_fuzzer/out.txt

This is only relevant to libFuzzer's fuzzer. No bug exists in the server.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.232`
<!-- ch-version-info:end -->