### PR TITLE
Update 03032_dynamically_resize_filesystem_cache_2.sh

### DIFF
--- a/tests/queries/0_stateless/03032_dynamically_resize_filesystem_cache_2.reference
+++ b/tests/queries/0_stateless/03032_dynamically_resize_filesystem_cache_2.reference
@@ -1,7 +1,10 @@
-1	current size is non-zero
-1	max size is changed
-1	current size is still non-zero
-1	current size is less than max size
-1	max size is reloaded
-1	current size is still non-zero
-1	current size is less than max size
+written cache is bigger than 2000
+current size after insert is bigger than 2000
+written cache is bigger than 708
+current size is bigger than 708
+max size is changed
+current size is still non-zero
+current size is less than max size
+max size is reloaded
+current size is still non-zero
+current size is less than max size

--- a/tests/queries/0_stateless/03032_dynamically_resize_filesystem_cache_2.sh
+++ b/tests/queries/0_stateless/03032_dynamically_resize_filesystem_cache_2.sh
@@ -19,7 +19,7 @@ $CLICKHOUSE_CLIENT --query_id "$query_id" --query "INSERT INTO test SELECT rando
 
 min_expected_size=2000
 
-$CLICKHOUSE_CLIENT --query "SYSTEM FLUSH LOGS"
+$CLICKHOUSE_CLIENT --query "SYSTEM FLUSH LOGS query_log;"
 
 written_cache=$($CLICKHOUSE_CLIENT --query "SELECT ProfileEvents['CachedWriteBufferCacheWriteBytes'] FROM system.query_log WHERE current_database = currentDatabase() AND query_id = '$query_id' AND type = 'QueryFinish'")
 

--- a/tests/queries/0_stateless/03032_dynamically_resize_filesystem_cache_2.sh
+++ b/tests/queries/0_stateless/03032_dynamically_resize_filesystem_cache_2.sh
@@ -20,7 +20,7 @@ prev_max_size=$($CLICKHOUSE_CLIENT --query "SELECT max_size FROM system.filesyst
 
 config_path=${CLICKHOUSE_CONFIG_DIR}/config.d/storage_conf.xml
 
-new_max_size=$($CLICKHOUSE_CLIENT --query "SELECT divide(max_size, 2) FROM system.filesystem_cache_settings WHERE cache_name = '$disk_name'")
+new_max_size=$($CLICKHOUSE_CLIENT --query "SELECT divide(max_size, 3) FROM system.filesystem_cache_settings WHERE cache_name = '$disk_name'")
 sed -i "s|<max_size>$prev_max_size<\/max_size>|<max_size>$new_max_size<\/max_size>|" $config_path
 
 $CLICKHOUSE_CLIENT --query "SELECT current_size > $new_max_size, 'current size is non-zero' FROM system.filesystem_cache_settings WHERE cache_name = '$disk_name' FORMAT TabSeparated"

--- a/tests/queries/0_stateless/03032_dynamically_resize_filesystem_cache_2.sh
+++ b/tests/queries/0_stateless/03032_dynamically_resize_filesystem_cache_2.sh
@@ -11,19 +11,33 @@ $CLICKHOUSE_CLIENT -m --query "
 DROP TABLE IF EXISTS test;
 CREATE TABLE test (a String) engine=MergeTree() ORDER BY tuple()
 SETTINGS disk = 'dynamically_resize_filesystem_cache';
-INSERT INTO test SELECT randomString(10000);
 "
 
-$CLICKHOUSE_CLIENT --query "SELECT * FROM test FORMAT Null"
+query_id="$CLICKHOUSE_TEST_UNIQUE_NAME-query"
+# Write-through cache is enabled.
+$CLICKHOUSE_CLIENT --query_id "$query_id" --query "INSERT INTO test SELECT randomString(10000) SETTINGS enable_filesystem_cache_on_write_operations=1;"
+
+min_expected_size=2000
+
+$CLICKHOUSE_CLIENT --query "SYSTEM FLUSH LOGS"
+
+written_cache=$($CLICKHOUSE_CLIENT --query "SELECT ProfileEvents['CachedWriteBufferCacheWriteBytes'] FROM system.query_log WHERE current_database = currentDatabase() AND query_id = '$query_id' AND type = 'QueryFinish'")
+
+$CLICKHOUSE_CLIENT --query "SELECT if($written_cache > $min_expected_size, 'written cache is bigger than $min_expected_size', 'written_cache: $written_cache') FORMAT TabSeparated"
+$CLICKHOUSE_CLIENT --query "SELECT if(current_size > $min_expected_size, 'current size after insert is bigger than $min_expected_size', concat('current_size: ', current_size)) FROM system.filesystem_cache_settings WHERE cache_name = '$disk_name' FORMAT TabSeparated"
 
 prev_max_size=$($CLICKHOUSE_CLIENT --query "SELECT max_size FROM system.filesystem_cache_settings WHERE cache_name = '$disk_name'")
 
 config_path=${CLICKHOUSE_CONFIG_DIR}/config.d/storage_conf.xml
 
+# Choose a size of cache to which it will be resized.
+# In config for 'dynamically_resize_filesystem_cache' cache: max_size=~2k, max_file_segment_size=100, cache_policy=LRU.
+# We need to guarantee that the cache will contain at least this amount of bytes.
 new_max_size=$($CLICKHOUSE_CLIENT --query "SELECT divide(max_size, 3) FROM system.filesystem_cache_settings WHERE cache_name = '$disk_name'")
 sed -i "s|<max_size>$prev_max_size<\/max_size>|<max_size>$new_max_size<\/max_size>|" $config_path
 
-$CLICKHOUSE_CLIENT --query "SELECT current_size > $new_max_size, 'current size is non-zero' FROM system.filesystem_cache_settings WHERE cache_name = '$disk_name' FORMAT TabSeparated"
+$CLICKHOUSE_CLIENT --query "SELECT if($written_cache > $new_max_size, 'written cache is bigger than $new_max_size', 'written_cache: $written_cache') FORMAT TabSeparated"
+$CLICKHOUSE_CLIENT --query "SELECT if(current_size > $new_max_size, 'current size is bigger than $new_max_size', concat('current_size: ', current_size)) FROM system.filesystem_cache_settings WHERE cache_name = '$disk_name' FORMAT TabSeparated"
 
 # echo $prev_max_size
 # echo $new_max_size
@@ -32,9 +46,9 @@ $CLICKHOUSE_CLIENT -m --query "
 set send_logs_level='fatal';
 SYSTEM RELOAD CONFIG"
 
-$CLICKHOUSE_CLIENT --query "SELECT max_size == $new_max_size, 'max size is changed' FROM system.filesystem_cache_settings WHERE cache_name = '$disk_name' FORMAT TabSeparated"
-$CLICKHOUSE_CLIENT --query "SELECT current_size > 0, 'current size is still non-zero' FROM system.filesystem_cache_settings WHERE cache_name = '$disk_name' FORMAT TabSeparated"
-$CLICKHOUSE_CLIENT --query "SELECT current_size <= max_size, 'current size is less than max size' FROM system.filesystem_cache_settings WHERE cache_name = '$disk_name' FORMAT TabSeparated"
+$CLICKHOUSE_CLIENT --query "SELECT if(max_size == $new_max_size, 'max size is changed', concat('Expected: $new_max_size, Actual: ', max_size)) FROM system.filesystem_cache_settings WHERE cache_name = '$disk_name' FORMAT TabSeparated"
+$CLICKHOUSE_CLIENT --query "SELECT if(current_size > 0, 'current size is still non-zero', concat('current_size: ', current_size)) FROM system.filesystem_cache_settings WHERE cache_name = '$disk_name' FORMAT TabSeparated"
+$CLICKHOUSE_CLIENT --query "SELECT if(current_size <= max_size, 'current size is less than max size', concat('current_size: ', current_size, ', max_size: ', max_size)) FROM system.filesystem_cache_settings WHERE cache_name = '$disk_name' FORMAT TabSeparated"
 
 sed -i "s|<max_size>$new_max_size<\/max_size>|<max_size>$prev_max_size<\/max_size>|" $config_path
 
@@ -42,6 +56,6 @@ $CLICKHOUSE_CLIENT -m --query "
 set send_logs_level='fatal';
 SYSTEM RELOAD CONFIG"
 
-$CLICKHOUSE_CLIENT --query "SELECT max_size == $prev_max_size, 'max size is reloaded' FROM system.filesystem_cache_settings WHERE cache_name = '$disk_name' FORMAT TabSeparated"
-$CLICKHOUSE_CLIENT --query "SELECT current_size > 0, 'current size is still non-zero' FROM system.filesystem_cache_settings WHERE cache_name = '$disk_name' FORMAT TabSeparated"
-$CLICKHOUSE_CLIENT --query "SELECT current_size <= max_size, 'current size is less than max size' FROM system.filesystem_cache_settings WHERE cache_name = '$disk_name' FORMAT TabSeparated"
+$CLICKHOUSE_CLIENT --query "SELECT if(max_size == $prev_max_size, 'max size is reloaded', concat('Expected: $prev_max_size, Actual: ', max_size)) FROM system.filesystem_cache_settings WHERE cache_name = '$disk_name' FORMAT TabSeparated"
+$CLICKHOUSE_CLIENT --query "SELECT if(current_size > 0, 'current size is still non-zero', concat('current_size: ', current_size)) FROM system.filesystem_cache_settings WHERE cache_name = '$disk_name' FORMAT TabSeparated"
+$CLICKHOUSE_CLIENT --query "SELECT if(current_size <= max_size, 'current size is less than max size', concat('current_size: ', current_size, ', max_size: ', max_size)) FROM system.filesystem_cache_settings WHERE cache_name = '$disk_name' FORMAT TabSeparated"


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.245`
<!-- ch-version-info:end -->