### PR TITLE
Decrease check_cache_probability 10x (attempt to fix stateless flaky check)

### DIFF
--- a/src/Interpreters/Cache/FileCacheSettings.cpp
+++ b/src/Interpreters/Cache/FileCacheSettings.cpp
@@ -55,7 +55,7 @@ namespace ErrorCodes
     DECLARE(Bool, use_split_cache, false, "Use separation of files to system/data.", 0) \
     DECLARE(Double, split_cache_ratio, 0.1, "Ratio of system segment to total size of cache for split_cache.", 0) \
     DECLARE(UInt64, overcommit_eviction_evict_step, 10 * 1_MiB, "Eviction step in bytes for overcommit eviction policy. Used for keep_free_space_*_ratio settings", 0) \
-    DECLARE(Double, check_cache_probability, 0.01, "Works only for debug or sanitizer build. Checks cache correctness by going through all cache and checking state of each cache element", 0) \
+    DECLARE(Double, check_cache_probability, 0.001, "Works only for debug or sanitizer build. Checks cache correctness by going through all cache and checking state of each cache element", 0) \
 
 DECLARE_SETTINGS_TRAITS(FileCacheSettingsTraits, LIST_OF_FILE_CACHE_SETTINGS)
 IMPLEMENT_SETTINGS_TRAITS(FileCacheSettingsTraits, LIST_OF_FILE_CACHE_SETTINGS)

--- a/tests/queries/0_stateless/02344_describe_cache.reference
+++ b/tests/queries/0_stateless/02344_describe_cache.reference
@@ -1,2 +1,2 @@
 1
-02344_describe_cache_test	/var/lib/clickhouse/filesystem_caches/02344_describe_cache_test	102400	10000000	33554432	4194304	0	slru	0.6	5	5000	4194304	16	0	0	0	100	0	0	0	268435456	0	0	0	0	0.1	10485760	0.01	1	0	0
+02344_describe_cache_test	/var/lib/clickhouse/filesystem_caches/02344_describe_cache_test	102400	10000000	33554432	4194304	0	slru	0.6	5	5000	4194304	16	0	0	0	100	0	0	0	268435456	0	0	0	0	0.1	10485760	0.001	1	0	0


### PR DESCRIPTION
I've noticed that it can take significant amount of time, and this is likely the reason why flaky check (that uses ASan build) fails:

```sql
clickhouse-cloud$  :) select ProfileEvents from merge(default, 'query_log_') where event_date >= yesterday() and pull_request_number = 48376 and commit_sha = 'eb065d55c433eaa9d52e912df81259f98d92600b' and query_id = '4e90a696-6c90-4912-a87f-aa9712db5c06' and type != 'QueryStart' group by all format PrettyJSONEachRow

FilesystemCacheCheckCorrectness: 176,
FilesystemCacheCheckCorrectnessMicroseconds: 1053467360
```

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.239`
<!-- ch-version-info:end -->