### PR TITLE
Fix event_date in system.asynchronous_metric_log

### DIFF
--- a/src/Interpreters/AsynchronousMetricLog.cpp
+++ b/src/Interpreters/AsynchronousMetricLog.cpp
@@ -68,7 +68,7 @@ void AsynchronousMetricLog::addValues(const AsynchronousMetricValues & values)
     AsynchronousMetricLogElement element;
 
     element.event_time = time(nullptr);
-    element.event_date = static_cast<UInt16>(DateLUT::instance().toDayNum(static_cast<UInt16>(element.event_time)));
+    element.event_date = static_cast<UInt16>(DateLUT::instance().toDayNum(element.event_time));
 
     /// We will round the values to make them compress better in the table.
     /// Note: as an alternative we can also use fixed point Decimal data type,


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix event_date in system.asynchronous_metric_log

Closes https://github.com/ClickHouse/ClickHouse/issues/95924

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.241`
- Backported to: `26.1.3.10`
<!-- ch-version-info:end -->