### PR TITLE
Part with unknown projections should not be marked as lost forever

### DIFF
--- a/src/Storages/MergeTree/checkDataPart.cpp
+++ b/src/Storages/MergeTree/checkDataPart.cpp
@@ -377,6 +377,8 @@ static IMergeTreeDataPart::Checksums checkDataPart(
         /// MergeTree will never use.
         if (require_checksums && !projections_on_disk.empty())
         {
+            is_broken_projection = true;
+
             throw Exception(ErrorCodes::UNEXPECTED_FILE_IN_DATA_PART,
                 "Found unexpected projection directories: {}",
                 fmt::join(projections_on_disk, ","));

--- a/tests/queries/0_stateless/03822_attach_with_unknown_projection.reference
+++ b/tests/queries/0_stateless/03822_attach_with_unknown_projection.reference
@@ -1,0 +1,3 @@
+7
+Found unexpected projection directories: pp.proj
+7

--- a/tests/queries/0_stateless/03822_attach_with_unknown_projection.sh
+++ b/tests/queries/0_stateless/03822_attach_with_unknown_projection.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT -m -q "
+drop table if exists attach_with_unknown_projection sync;
+
+create table attach_with_unknown_projection (x Int32, y Int32, projection p (select x, y order by x))
+engine = ReplicatedMergeTree('/clickhouse/tables/{database}/attach_with_unknown_projection', '1')
+order by y
+partition by intDiv(y, 100) settings max_parts_to_merge_at_once=1;
+
+insert into attach_with_unknown_projection select number, number from numbers(3);
+
+set mutations_sync = 2;
+alter table attach_with_unknown_projection add projection pp (select x, count() group by x);
+insert into attach_with_unknown_projection select number, number from numbers(4);
+select count() from attach_with_unknown_projection;
+
+alter table attach_with_unknown_projection detach partition '0';
+alter table attach_with_unknown_projection clear projection pp;
+alter table attach_with_unknown_projection drop projection pp;
+alter table attach_with_unknown_projection attach partition '0';
+"
+
+$CLICKHOUSE_CLIENT -m -q "
+set send_logs_level='fatal';
+set check_query_single_value_result = 1;
+check table attach_with_unknown_projection settings check_query_single_value_result = 0;" | grep -o "Found unexpected projection directories: pp.proj
+"
+
+$CLICKHOUSE_CLIENT -m -q "
+select count() from attach_with_unknown_projection;
+"


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Part with unknown projections should not be marked as lost forever


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.237`
<!-- ch-version-info:end -->