### PR TITLE
Fix float value truncation in compression codec test generators

### DIFF
--- a/src/Compression/tests/gtest_compressionCodec.cpp
+++ b/src/Compression/tests/gtest_compressionCodec.cpp
@@ -386,7 +386,8 @@ CodecTestSequence generateSeq(Generator gen, const char* gen_name, B Begin = 0, 
 
     for (auto i = Begin; i < End; i += direction)
     {
-        const T v = static_cast<T>(gen(i));
+        /// Pass index as T so generators using decltype(i) produce values of the target type.
+        const T v = static_cast<T>(gen(static_cast<T>(i)));
 
         unalignedStoreLittleEndian<T>(write_pos, v);
         write_pos += sizeof(v);

--- a/src/Compression/tests/gtest_compressionCodec.cpp
+++ b/src/Compression/tests/gtest_compressionCodec.cpp
@@ -749,7 +749,7 @@ MonotonicGenerator() -> MonotonicGenerator<Int32>;
 auto RandomishGenerator = [](auto i)
 {
     using T = decltype(i);
-    double sin_value = sin(static_cast<double>(i * i)) * i;
+    double sin_value = sin(static_cast<double>(i * i)) * static_cast<double>(i);
     if (sin_value < std::numeric_limits<T>::lowest() || sin_value > static_cast<double>(std::numeric_limits<T>::max()))
         return T{};
     return T(sin_value);


### PR DESCRIPTION
Test generators using `decltype(i)` were casting values to `int` (the loop index type) instead of the target type `T`. Float tests like `SameValueGenerator(M_E)` were testing with value `2` instead of `2.718...`.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed compression codec tests where float generators were producing truncated integer values instead of actual floats


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.261`
<!-- ch-version-info:end -->