### PR TITLE
Improve GLOBAL IN/JOIN performance and respect max_execution_time

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -107,6 +107,7 @@ static struct InitFiu
     REGULAR(zero_copy_unlock_zk_fail_before_op) \
     REGULAR(zero_copy_unlock_zk_fail_after_op) \
     REGULAR(plain_rewritable_object_storage_azure_not_found_on_init) \
+    REGULAR(sleep_on_receive_external_table_data) \
     PAUSEABLE(storage_merge_tree_background_clear_old_parts_pause) \
     PAUSEABLE_ONCE(storage_shared_merge_tree_mutate_pause_before_wait) \
     PAUSEABLE(database_replicated_startup_pause) \

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -353,6 +353,9 @@
     M(ExternalJoinCompressedBytes, "Number of compressed bytes written for JOIN in external memory.", ValueType::Bytes) \
     M(ExternalJoinUncompressedBytes, "Amount of data (uncompressed, before compression) written for JOIN in external memory.", ValueType::Bytes) \
     \
+    M(InitializeExternalTablesMicroseconds, "Time spent initializing (receiving) external tables.", ValueType::Microseconds) \
+    M(SendExternalTablesMicroseconds, "Time spent sending external tables.", ValueType::Microseconds) \
+    \
     M(IcebergPartitionPrunedFiles, "Number of skipped files during Iceberg partition pruning", ValueType::Number) \
     M(IcebergTrivialCountOptimizationApplied, "Trivial count optimization applied while reading from Iceberg", ValueType::Number) \
     M(IcebergVersionHintUsed, "Number of times version-hint.text has been used.", ValueType::Number) \

--- a/src/QueryPipeline/RemoteQueryExecutor.cpp
+++ b/src/QueryPipeline/RemoteQueryExecutor.cpp
@@ -38,6 +38,7 @@ namespace ProfileEvents
     extern const Event ReadTaskRequestsReceived;
     extern const Event MergeTreeReadTaskRequestsReceived;
     extern const Event ParallelReplicasAvailableCount;
+    extern const Event SendExternalTablesMicroseconds;
 }
 
 namespace DB
@@ -882,6 +883,11 @@ void RemoteQueryExecutor::sendScalars()
 
 void RemoteQueryExecutor::sendExternalTables()
 {
+    Stopwatch watch;
+    SCOPE_EXIT({
+        ProfileEvents::increment(ProfileEvents::SendExternalTablesMicroseconds, watch.elapsedMicroseconds());
+    });
+
     size_t count = connections->size();
 
     {

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -104,6 +104,7 @@ namespace Setting
     extern const SettingsBool partial_result_on_first_cancel;
     extern const SettingsUInt64 poll_interval;
     extern const SettingsSeconds receive_timeout;
+    extern const SettingsSeconds max_execution_time;
     extern const SettingsLogsLevel send_logs_level;
     extern const SettingsBool send_profile_events;
     extern const SettingsString send_logs_source_regexp;
@@ -130,6 +131,7 @@ namespace ServerSetting
 namespace FailPoints
 {
 extern const char parallel_replicas_reading_response_timeout[];
+extern const char sleep_on_receive_external_table_data[];
 }
 }
 
@@ -148,6 +150,7 @@ namespace ProfileEvents
     extern const Event MergeTreeAllRangesAnnouncementsSent;
     extern const Event ReadTaskRequestsSentElapsedMicroseconds;
     extern const Event MergeTreeReadTaskRequestsSentElapsedMicroseconds;
+    extern const Event InitializeExternalTablesMicroseconds;
     extern const Event MergeTreeAllRangesAnnouncementsSentElapsedMicroseconds;
 }
 
@@ -1040,9 +1043,11 @@ void TCPHandler::extractConnectionSettingsFromContext(const ContextPtr & context
 {
     const auto & settings = context->getSettingsRef();
     send_exception_with_stack_trace = settings[Setting::calculate_text_stack_trace];
-    send_timeout = settings[Setting::send_timeout];
-    receive_timeout = settings[Setting::receive_timeout];
-    poll_interval = settings[Setting::poll_interval];
+    max_execution_time = settings[Setting::max_execution_time];
+    auto saturate_timeout = [&](const Poco::Timespan & t) { return max_execution_time.totalSeconds() > 0 && t > max_execution_time ? max_execution_time : t; };
+    send_timeout = saturate_timeout(settings[Setting::send_timeout]);
+    receive_timeout = saturate_timeout(settings[Setting::receive_timeout]);
+    poll_interval = max_execution_time.totalSeconds() > 0 ? std::min<UInt64>(settings[Setting::poll_interval], max_execution_time.totalSeconds()) : settings[Setting::poll_interval];
     idle_connection_timeout = settings[Setting::idle_connection_timeout];
     interactive_delay = settings[Setting::interactive_delay];
     sleep_in_send_tables_status = settings[Setting::sleep_in_send_tables_status_ms];
@@ -1182,11 +1187,19 @@ void TCPHandler::readTemporaryTables(QueryState & state)
 {
     sendLogs(state);
 
+    Stopwatch watch(CLOCK_MONOTONIC_COARSE);
+    SCOPE_EXIT({
+        ProfileEvents::increment(ProfileEvents::InitializeExternalTablesMicroseconds, watch.elapsedMicroseconds());
+    });
+
     /// no sense in partial_result_on_first_cancel setting when temporary data is read.
     auto off_setting_guard = TurnOffBoolSettingTemporary(state.allow_partial_result_on_first_cancel);
 
     while (receivePacketsExpectData(state))
     {
+        if (max_execution_time.totalSeconds() > 0 && watch.elapsedSeconds() > max_execution_time.totalSeconds())
+            throw Exception(ErrorCodes::TIMEOUT_EXCEEDED, "Timeout exceeded while reading external table data. Spent {} seconds, timeout is {} seconds.", watch.elapsedSeconds(), max_execution_time.totalSeconds());
+
         sendLogs(state);
         sendInsertProfileEvents(state);
     }
@@ -2462,7 +2475,10 @@ bool TCPHandler::processData(QueryState & state, bool scalar)
     Block block = state.block_in->read();
 
     if (block.empty())
+    {
+        state.resetExternalTablePipelines(/*cancel=*/false);
         return false;
+    }
 
     if (scalar)
     {
@@ -2472,28 +2488,41 @@ bool TCPHandler::processData(QueryState & state, bool scalar)
     else if (!state.need_receive_data_for_insert && !state.need_receive_data_for_input)
     {
         /// Data for external tables
+        /// Check if we already have an executor for this external table
+        auto it = state.external_table_pipelines.find(temporary_id.table_name);
+        if (it == state.external_table_pipelines.end())
+        {
+            /// First block for this table - create storage if needed and set up executor
+            auto resolved = state.query_context->tryResolveStorageID(temporary_id, Context::ResolveExternal);
+            StoragePtr storage;
+            if (resolved)
+            {
+                storage = DatabaseCatalog::instance().getTable(resolved, state.query_context);
+            }
+            else
+            {
+                NamesAndTypesList columns = block.getNamesAndTypesList();
+                auto temporary_table = TemporaryTableHolder(state.query_context, ColumnsDescription(columns), {});
+                storage = temporary_table.getTable();
+                state.query_context->addExternalTable(temporary_id.table_name, std::move(temporary_table));
+            }
+            auto metadata_snapshot = storage->getInMemoryMetadataPtr();
 
-        auto resolved = state.query_context->tryResolveStorageID(temporary_id, Context::ResolveExternal);
-        StoragePtr storage;
-        /// If such a table does not exist, create it.
-        if (resolved)
-        {
-            storage = DatabaseCatalog::instance().getTable(resolved, state.query_context);
+            /// Create and cache the pipeline and executor
+            auto & pipeline_holder = state.external_table_pipelines[temporary_id.table_name];
+            pipeline_holder.pipeline = QueryPipeline(storage->write(ASTPtr(), metadata_snapshot, state.query_context, /*async_insert=*/false));
+            pipeline_holder.executor = std::make_unique<PushingPipelineExecutor>(pipeline_holder.pipeline);
+            pipeline_holder.executor->start();
+
+            it = state.external_table_pipelines.find(temporary_id.table_name);
         }
-        else
-        {
-            NamesAndTypesList columns = block.getNamesAndTypesList();
-            auto temporary_table = TemporaryTableHolder(state.query_context, ColumnsDescription(columns), {});
-            storage = temporary_table.getTable();
-            state.query_context->addExternalTable(temporary_id.table_name, std::move(temporary_table));
-        }
-        auto metadata_snapshot = storage->getInMemoryMetadataPtr();
-        /// The data will be written directly to the table.
-        QueryPipeline temporary_table_out(storage->write(ASTPtr(), metadata_snapshot, state.query_context, /*async_insert=*/false));
-        PushingPipelineExecutor executor(temporary_table_out);
-        executor.start();
-        executor.push(block);
-        executor.finish();
+
+        /// Push block to the cached executor
+        it->second.executor->push(block);
+
+        fiu_do_on(FailPoints::sleep_on_receive_external_table_data, {
+            sleepForSeconds(1);
+        });
     }
     else if (state.need_receive_data_for_input)
     {

--- a/src/Server/TCPHandler.h
+++ b/src/Server/TCPHandler.h
@@ -9,6 +9,8 @@
 #include <Formats/NativeReader.h>
 #include <Formats/NativeWriter.h>
 #include <IO/Progress.h>
+#include <Processors/Executors/PushingPipelineExecutor.h>
+#include <QueryPipeline/QueryPipeline.h>
 #include <IO/ReadBufferFromPocoSocketChunked.h>
 #include <IO/TimeoutSetter.h>
 #include <IO/WriteBufferFromPocoSocketChunked.h>
@@ -116,6 +118,37 @@ struct QueryState
     bool skipping_data = false;
     bool query_duration_already_logged = false;
 
+    /// Cached pipelines and executors for external tables to avoid O(n^2) complexity
+    /// when inserting many blocks into temporary Memory tables.
+    struct ExternalTablePipeline
+    {
+        QueryPipeline pipeline;
+        std::unique_ptr<PushingPipelineExecutor> executor;
+    };
+    std::unordered_map<String, ExternalTablePipeline> external_table_pipelines;
+
+    void resetExternalTablePipelines(bool cancel)
+    {
+        for (auto & [name, pipeline_holder] : external_table_pipelines)
+        {
+            if (pipeline_holder.executor)
+            {
+                if (cancel)
+                    pipeline_holder.executor->cancel();
+                else
+                    pipeline_holder.executor->finish();
+            }
+        }
+        external_table_pipelines.clear();
+    }
+
+    ~QueryState()
+    {
+        /// Cancel any pending external table executors before destruction
+        /// PushingPipelineExecutor destructor asserts that it is finished
+        resetExternalTablePipelines(/*cancel=*/true);
+    }
+
     ProfileEvents::ThreadIdToCountersSnapshot last_sent_snapshots;
 
     /// To output progress, the difference after the previous sending of progress.
@@ -208,6 +241,7 @@ private:
 
     /// Connection settings, which are extracted from a context.
     bool send_exception_with_stack_trace = true;
+    Poco::Timespan max_execution_time;
     Poco::Timespan send_timeout = Poco::Timespan(DBMS_DEFAULT_SEND_TIMEOUT_SEC, 0);
     Poco::Timespan receive_timeout = Poco::Timespan(DBMS_DEFAULT_RECEIVE_TIMEOUT_SEC, 0);
     UInt64 poll_interval = DBMS_DEFAULT_POLL_INTERVAL;

--- a/tests/integration/test_global_in/configs/remote_servers.xml
+++ b/tests/integration/test_global_in/configs/remote_servers.xml
@@ -1,0 +1,16 @@
+<clickhouse>
+    <remote_servers>
+        <test_cluster>
+            <shard>
+                <replica>
+                    <host>node1</host>
+                    <port>9000</port>
+                </replica>
+                <replica>
+                    <host>node2</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </test_cluster>
+    </remote_servers>
+</clickhouse>

--- a/tests/integration/test_global_in/configs/users.xml
+++ b/tests/integration/test_global_in/configs/users.xml
@@ -1,0 +1,7 @@
+<clickhouse>
+    <profiles>
+        <default>
+            <max_memory_usage>20000000000</max_memory_usage>
+        </default>
+    </profiles>
+</clickhouse>

--- a/tests/integration/test_global_in/test.py
+++ b/tests/integration/test_global_in/test.py
@@ -1,0 +1,114 @@
+import pytest
+import time
+import uuid
+
+from threading import Thread
+
+from helpers.cluster import ClickHouseCluster, QueryRuntimeException
+from helpers.network import PartitionManager
+
+
+cluster = ClickHouseCluster(__file__)
+
+node1 = cluster.add_instance(
+    "node1",
+    main_configs=["configs/remote_servers.xml"],
+)
+node2 = cluster.add_instance(
+    "node2",
+    main_configs=["configs/remote_servers.xml"],
+)
+
+query = """
+SELECT count()
+FROM clusterAllReplicas('test_cluster', numbers(10))
+WHERE number GLOBAL IN (
+    SELECT number % 5 FROM numbers_mt(1000000000)
+) OR number GLOBAL IN (
+    SELECT number % 7 FROM numbers_mt(1000000000)
+)
+"""
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+@pytest.mark.parametrize("enable_analyzer", [0, 1])
+def test_success(started_cluster, enable_analyzer):
+    assert (
+        int(
+            node1.query(
+                query, settings={"enable_analyzer": enable_analyzer}, timeout=30
+            ).strip()
+        )
+        == 14
+    )
+
+
+@pytest.mark.parametrize("enable_analyzer", [0, 1])
+def test_max_execution_time_timeout(started_cluster, enable_analyzer):
+    query_id = str(uuid.uuid4())
+    node2.query("SYSTEM ENABLE FAILPOINT sleep_on_receive_external_table_data")
+    try:
+        with pytest.raises(QueryRuntimeException) as e:
+            node1.query(
+                query,
+                settings={"max_execution_time": 15, "enable_analyzer": enable_analyzer},
+                timeout=30,
+                query_id=query_id,
+            )
+        assert "TIMEOUT_EXCEEDED" in str(e.value)
+        node2.query("SYSTEM FLUSH LOGS")
+        remote_exception = node2.query(
+            f"SELECT exception FROM system.query_log WHERE initial_query_id = '{query_id}' AND type = 'ExceptionBeforeStart'"
+        )
+        assert (
+            "Code: 159. DB::Exception: Timeout exceeded while reading external table data."
+            in remote_exception
+        )
+        assert "timeout is 15 seconds. (TIMEOUT_EXCEEDED)" in remote_exception
+    finally:
+        node2.query("SYSTEM DISABLE FAILPOINT sleep_on_receive_external_table_data")
+
+
+@pytest.mark.parametrize("enable_analyzer", [0, 1])
+def test_max_execution_time_socket_timeout(started_cluster, enable_analyzer):
+    query_id = str(uuid.uuid4())
+
+    def run_query():
+        try:
+            node1.query(
+                query,
+                settings={"max_execution_time": 9, "enable_analyzer": enable_analyzer},
+                timeout=30,
+                query_id=query_id,
+            )
+        except QueryRuntimeException as e:
+            assert "TIMEOUT_EXCEEDED" in str(e)
+
+    query_thread = Thread(target=run_query)
+    with PartitionManager() as pm:
+        # make sending external table data slow by adding a delay to all outgoing packets on node1
+        # this gives us a chance to pause the container while it's sending external table data
+        pm.add_network_delay(node1, 700)
+        query_thread.start()
+        try:
+            # wait for the remote query to arrive on node2
+            node2.wait_for_log_line(f"initial_query_id: {query_id}")
+            with cluster.pause_container("node1"):
+                time.sleep(15)
+                node2.query("SYSTEM FLUSH LOGS")
+                remote_exception = node2.query(
+                    f"SELECT exception FROM system.query_log WHERE initial_query_id = '{query_id}' AND type = 'ExceptionBeforeStart'"
+                )
+                assert "SOCKET_TIMEOUT" in remote_exception
+                # max_execution_time should be used as the receive timeout
+                assert "9000 ms" in remote_exception
+        finally:
+            query_thread.join()

--- a/tests/integration/test_global_in/test.py
+++ b/tests/integration/test_global_in/test.py
@@ -1,22 +1,22 @@
 import pytest
-import time
 import uuid
 
 from threading import Thread
 
 from helpers.cluster import ClickHouseCluster, QueryRuntimeException
 from helpers.network import PartitionManager
+from helpers.test_tools import assert_eq_with_retry
 
 
 cluster = ClickHouseCluster(__file__)
 
 node1 = cluster.add_instance(
     "node1",
-    main_configs=["configs/remote_servers.xml"],
+    main_configs=["configs/remote_servers.xml", "configs/users.xml"],
 )
 node2 = cluster.add_instance(
     "node2",
-    main_configs=["configs/remote_servers.xml"],
+    main_configs=["configs/remote_servers.xml", "configs/users.xml"],
 )
 
 query = """
@@ -44,7 +44,7 @@ def test_success(started_cluster, enable_analyzer):
     assert (
         int(
             node1.query(
-                query, settings={"enable_analyzer": enable_analyzer}, timeout=30
+                query, settings={"enable_analyzer": enable_analyzer}, timeout=120
             ).strip()
         )
         == 14
@@ -59,12 +59,18 @@ def test_max_execution_time_timeout(started_cluster, enable_analyzer):
         with pytest.raises(QueryRuntimeException) as e:
             node1.query(
                 query,
-                settings={"max_execution_time": 15, "enable_analyzer": enable_analyzer},
-                timeout=30,
+                settings={"max_execution_time": 30, "enable_analyzer": enable_analyzer},
+                timeout=120,
                 query_id=query_id,
             )
         assert "TIMEOUT_EXCEEDED" in str(e.value)
-        node2.query("SYSTEM FLUSH LOGS")
+        assert_eq_with_retry(
+            node2,
+            f"SELECT count() FROM system.query_log WHERE initial_query_id = '{query_id}' AND type = 'ExceptionBeforeStart'",
+            "1",
+            retry_count=60,
+            sleep_time=1,
+        )
         remote_exception = node2.query(
             f"SELECT exception FROM system.query_log WHERE initial_query_id = '{query_id}' AND type = 'ExceptionBeforeStart'"
         )
@@ -72,7 +78,7 @@ def test_max_execution_time_timeout(started_cluster, enable_analyzer):
             "Code: 159. DB::Exception: Timeout exceeded while reading external table data."
             in remote_exception
         )
-        assert "timeout is 15 seconds. (TIMEOUT_EXCEEDED)" in remote_exception
+        assert "timeout is 30 seconds. (TIMEOUT_EXCEEDED)" in remote_exception
     finally:
         node2.query("SYSTEM DISABLE FAILPOINT sleep_on_receive_external_table_data")
 
@@ -85,8 +91,12 @@ def test_max_execution_time_socket_timeout(started_cluster, enable_analyzer):
         try:
             node1.query(
                 query,
-                settings={"max_execution_time": 9, "enable_analyzer": enable_analyzer},
-                timeout=30,
+                settings={
+                    "max_execution_time": 25,
+                    "enable_analyzer": enable_analyzer,
+                    "connect_timeout_with_failover_ms": 5000,
+                },
+                timeout=120,
                 query_id=query_id,
             )
         except QueryRuntimeException as e:
@@ -96,19 +106,24 @@ def test_max_execution_time_socket_timeout(started_cluster, enable_analyzer):
     with PartitionManager() as pm:
         # make sending external table data slow by adding a delay to all outgoing packets on node1
         # this gives us a chance to pause the container while it's sending external table data
-        pm.add_network_delay(node1, 700)
+        pm.add_network_delay(node1, 1000)
         query_thread.start()
         try:
             # wait for the remote query to arrive on node2
-            node2.wait_for_log_line(f"initial_query_id: {query_id}")
+            node2.wait_for_log_line(f"initial_query_id: {query_id}", timeout=60)
             with cluster.pause_container("node1"):
-                time.sleep(15)
-                node2.query("SYSTEM FLUSH LOGS")
+                assert_eq_with_retry(
+                    node2,
+                    f"SELECT count() FROM system.query_log WHERE initial_query_id = '{query_id}' AND type = 'ExceptionBeforeStart'",
+                    "1",
+                    retry_count=60,
+                    sleep_time=1,
+                )
                 remote_exception = node2.query(
                     f"SELECT exception FROM system.query_log WHERE initial_query_id = '{query_id}' AND type = 'ExceptionBeforeStart'"
                 )
                 assert "SOCKET_TIMEOUT" in remote_exception
                 # max_execution_time should be used as the receive timeout
-                assert "9000 ms" in remote_exception
+                assert "25000 ms" in remote_exception
         finally:
             query_thread.join()


### PR DESCRIPTION
This PR tries to address some issues with queries using GLOBAL IN/JOIN.

The first issue is about performance. Processing the data from the GLOBAL subquery can take a significant amount of time on the remote replicas receiving this data. The data is sent by `RemoteQueryExecutor` in blocks. The default block size is 65409. `TCPHandler::receiveData` creates a new `QueryPipeline` and `PushingPipelineExecutor` for each block. `MemorySink::onFinish` copies all existing blocks of the memory table before appending the new block. I think it does that for snapshot isolation. But this makes the external table initialization O(n^2) (with n being the number of blocks). We've seen GLOBAL IN subqueries in production that produced billions of rows, leading to thousands of blocks. For those cases, the quadratic complexity becomes an issue (queries were running for hours).

I'm addressing this performance problem by using a single pipeline and executor per external table instead of per block. This allows us to flush the data from `MemorySink` to `StorageMemory` only once. This should be fine because nothing will query the memory table until all data is available.

It's worth noting that with the analyzer enabled, this is less of an issue because externabl table blocks are squashed (see `min_external_table_block_size_rows` and `min_external_table_block_size_bytes` settings). So there are less blocks, but the fundamental issue still exists.

The second issue is that no timeouts are checked during external table initialization. If table initialization takes longer than `max_execution_time` (because of the performance issue described above or any other reason), the query should be aborted. This is fixed by checking the elapsed time in the read loop of `TCPHandler::readData`.

In addition to that, I think that timeouts like `receive_timeout` and `send_timeout` should be capped by `max_execution_time`, if present. This avoids waiting for a dead/frozen initiator replica longer than necessary. This is done in `TCPHandler::extractConnectionSettingsFromContext`.

### Changelog category (leave one):

- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Improve performance for GLOBAL IN/JOIN subqueries that return a large number of rows and respect `max_execution_time` on remote servers.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core TCP protocol handling for external table reception and connection timeouts; bugs here could cause stuck queries, premature timeouts, or unfinished pipeline executors under error paths.
> 
> **Overview**
> Improves performance of `GLOBAL IN/JOIN` external table initialization by **reusing a single `QueryPipeline`/`PushingPipelineExecutor` per external table** instead of recreating one per received block, and ensures these executors are finished/cancelled via `QueryState` lifecycle management.
> 
> Makes remote replicas **respect `max_execution_time` during external table reception** (throws `TIMEOUT_EXCEEDED`) and caps `send_timeout`/`receive_timeout`/`poll_interval` by `max_execution_time` when set. Adds profile events (`InitializeExternalTablesMicroseconds`, `SendExternalTablesMicroseconds`) plus a new failpoint (`sleep_on_receive_external_table_data`) and an integration test covering both execution-time and socket-timeout scenarios.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13bb0b14c1caa6079940f2d5fcbc139ae17384f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->