### PR TITLE
Docs: fix last broken links in source code docs

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionCramersVBiasCorrected.cpp
+++ b/src/AggregateFunctions/AggregateFunctionCramersVBiasCorrected.cpp
@@ -44,7 +44,7 @@ void registerAggregateFunctionCramersVBiasCorrected(AggregateFunctionFactory & f
 {
     FunctionDocumentation::Description description = R"(
 Cramer's V is a measure of association between two columns in a table.
-The result of the [`cramersV` function](./cramersv.md) ranges from 0 (corresponding to no association between the variables) to 1 and can reach 1 only when each value is completely determined by the other.
+The result of the [`cramersV` function](/sql-reference/aggregate-functions/reference/cramersV) ranges from 0 (corresponding to no association between the variables) to 1 and can reach 1 only when each value is completely determined by the other.
 The function can be heavily biased, so this version of Cramer's V uses the [bias correction](https://en.wikipedia.org/wiki/Cram%C3%A9r%27s_V#Bias_correction).
     )";
     FunctionDocumentation::Syntax syntax = "cramersVBiasCorrected(column1, column2)";

--- a/src/AggregateFunctions/AggregateFunctionSecondMoment.cpp
+++ b/src/AggregateFunctions/AggregateFunctionSecondMoment.cpp
@@ -126,7 +126,7 @@ FROM test_data;
     factory.registerFunction("varPop", {createAggregateFunctionStatisticsUnary<AggregateFunctionSecondMoment, StatisticsFunctionKind::varPop>, {}, documentation_varPop});
     FunctionDocumentation::Description description_stddevSamp = R"(
 Returns the sample standard deviation of a numeric data sequence.
-The result is equal to the square root of [`varSamp`](/sql-reference/aggregate-functions/reference/varsamp).
+The result is equal to the square root of [`varSamp`](/sql-reference/aggregate-functions/reference/varSamp).
 
 :::note
 This function uses a numerically unstable algorithm.
@@ -171,7 +171,7 @@ FROM test_data;
     factory.registerFunction("stddevSamp", {createAggregateFunctionStatisticsUnary<AggregateFunctionSecondMoment, StatisticsFunctionKind::stddevSamp>, {}, documentation_stddevSamp});
     FunctionDocumentation::Description description_stddevPop = R"(
 Returns the population standard deviation of a numeric data sequence.
-The result is equal to the square root of [`varPop`](/sql-reference/aggregate-functions/reference/varpop).
+The result is equal to the square root of [`varPop`](/sql-reference/aggregate-functions/reference/varPop).
 
 :::note
 This function uses a numerically unstable algorithm. If you need [numerical stability](https://en.wikipedia.org/wiki/Numerical_stability) in calculations, use the [`stddevPopStable`](/sql-reference/aggregate-functions/reference/stddevpopstable) function. It works slower but provides a lower computational error.


### PR DESCRIPTION
Fixes 3 broken links which crept in while link checker was turned off. Fixing and turning it back on again with https://github.com/ClickHouse/clickhouse-docs/pull/5453
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.259`
<!-- ch-version-info:end -->