### PR TITLE
Fix sporadic test failures in `test_keeper_auth` with genuine ZooKeeper

### DIFF
--- a/tests/integration/compose/docker_compose_zookeeper.yml
+++ b/tests/integration/compose/docker_compose_zookeeper.yml
@@ -5,6 +5,7 @@ services:
         restart: always
         environment:
             ZOO_TICK_TIME: 500
+            ZOO_MAX_CLIENT_CNXNS: 0
             ZOO_SERVERS: server.1=zoo1:2888:3888;2181 server.2=zoo2:2888:3888;2181 server.3=zoo3:2888:3888;2181
             ZOO_MY_ID: 1
             JVMFLAGS: -Dzookeeper.forceSync=no
@@ -22,6 +23,7 @@ services:
         restart: always
         environment:
             ZOO_TICK_TIME: 500
+            ZOO_MAX_CLIENT_CNXNS: 0
             ZOO_SERVERS: server.1=zoo1:2888:3888;2181 server.2=zoo2:2888:3888;2181 server.3=zoo3:2888:3888
             ZOO_MY_ID: 2
             JVMFLAGS: -Dzookeeper.forceSync=no
@@ -39,6 +41,7 @@ services:
         restart: always
         environment:
             ZOO_TICK_TIME: 500
+            ZOO_MAX_CLIENT_CNXNS: 0
             ZOO_SERVERS: server.1=zoo1:2888:3888;2181 server.2=zoo2:2888:3888;2181 server.3=zoo3:2888:3888;2181
             ZOO_MY_ID: 3
             JVMFLAGS: -Dzookeeper.forceSync=no

--- a/tests/integration/compose/docker_compose_zookeeper_secure.yml
+++ b/tests/integration/compose/docker_compose_zookeeper_secure.yml
@@ -5,6 +5,7 @@ services:
         restart: always
         environment:
             ZOO_TICK_TIME: 500
+            ZOO_MAX_CLIENT_CNXNS: 0
             ZOO_SERVERS: server.1=zoo1:2888:3888;2181 server.2=zoo2:2888:3888;2181 server.3=zoo3:2888:3888;2181
             ZOO_MY_ID: 1
             JVMFLAGS: -Dzookeeper.forceSync=no
@@ -31,6 +32,7 @@ services:
         restart: always
         environment:
             ZOO_TICK_TIME: 500
+            ZOO_MAX_CLIENT_CNXNS: 0
             ZOO_SERVERS: server.1=zoo1:2888:3888;2181 server.2=zoo2:2888:3888;2181 server.3=zoo3:2888:3888
             ZOO_MY_ID: 2
             JVMFLAGS: -Dzookeeper.forceSync=no
@@ -58,6 +60,7 @@ services:
         restart: always
         environment:
             ZOO_TICK_TIME: 500
+            ZOO_MAX_CLIENT_CNXNS: 0
             ZOO_SERVERS: server.1=zoo1:2888:3888;2181 server.2=zoo2:2888:3888;2181 server.3=zoo3:2888:3888;2181
             ZOO_MY_ID: 3
             JVMFLAGS: -Dzookeeper.forceSync=no


### PR DESCRIPTION
The integration tests using genuine ZooKeeper (as opposed to ClickHouse Keeper) were failing sporadically, especially in TSan builds.

Root cause: ZooKeeper's default `maxClientCnxns` setting limits connections to 60 per IP address. When ClickHouse connects to ZooKeeper for internal coordination, it can create many connections. Under TSAN, ClickHouse runs slower and connections accumulate faster than they are cleaned up, causing the limit to be exceeded.

When this happens, ZooKeeper rejects new connections with the error: "Too many connections from /172.16.3.1 - max is 60"

This caused the kazoo client in the test to fail with "Connection dropped: socket connection broken" when trying to connect to genuine ZooKeeper.

The fix sets `ZOO_MAX_CLIENT_CNXNS: 0` (unlimited) in the ZooKeeper Docker Compose configuration for all ZooKeeper nodes, both regular and secure.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

See https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=b1bbbf63db6364765650b200a0e4184b2672b8ea&name_0=MasterCI&name_1=Integration%20tests%20%28amd_tsan%2C%206%2F6%29&name_1=Integration%20tests%20%28amd_tsan%2C%206%2F6%29


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.247`
<!-- ch-version-info:end -->