### PR TITLE
Docs: add note on MacOS support of `DeltaLake` table engine / `deltaLake` table function

### DIFF
--- a/docs/en/engines/table-engines/integrations/deltalake.md
+++ b/docs/en/engines/table-engines/integrations/deltalake.md
@@ -30,6 +30,11 @@ Engine parameters can be specified using [Named Collections](/operations/named-c
 
 **Example**
 
+:::note[Compatibility note for MacOS]
+If you're using a recent version but still getting an error `Received exception:
+Code: 56. DB::Exception: Unknown table engine DeltaLake. (UNKNOWN_STORAGE)` this is because builds on Mac don't include DeltaLake due to the usage of Rust.
+:::
+
 ```sql
 CREATE TABLE deltalake ENGINE=DeltaLake('http://mars-doc-test.s3.amazonaws.com/clickhouse-bucket-3/test_table/', 'ABC123', 'Abc+123')
 ```

--- a/docs/en/sql-reference/table-functions/deltalake.md
+++ b/docs/en/sql-reference/table-functions/deltalake.md
@@ -37,6 +37,11 @@ A table with the specified structure for reading data in the specified Delta Lak
 
 ## Examples {#examples}
 
+:::note[Compatibility note for MacOS]
+If you're using a recent version but still getting an error `Received exception:
+Code: 46. DB::Exception: Unknown table function deltaLake. (UNKNOWN_FUNCTION)` this is because builds on Mac don't include DeltaLake due to the usage of Rust.
+:::
+
 Selecting rows from the table in S3 `https://clickhouse-public-datasets.s3.amazonaws.com/delta_lake/hits/`:
 
 ```sql


### PR DESCRIPTION
Tried testing it now and ran into the same issue that @mneedham ran into that he posted about in #data-lovers channel. Response from Alexey was that it doesn't work on MacOS due to Rust requirement.
Adding a note here to document.
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
