### PR TITLE
Fix flaky tests `992`, `993` with OPTIMIZE TABLE FINAL timeout

### DIFF
--- a/tests/queries/0_stateless/00993_system_parts_race_condition_drop_zookeeper.sh
+++ b/tests/queries/0_stateless/00993_system_parts_race_condition_drop_zookeeper.sh
@@ -48,7 +48,8 @@ function thread4()
         # NOTE: max_execution_time is needed to ensure the server-side query times out,
         # not just the client connection. OPTIMIZE TABLE FINAL can hang for a long time
         # waiting for merge entries that cannot be processed due to concurrent mutations.
-        $CLICKHOUSE_CLIENT -q "OPTIMIZE TABLE alter_table_$REPLICA FINAL SETTINGS receive_timeout=1, max_execution_time=3" |& grep -Fv "TIMEOUT_EXCEEDED"
+        # Filter both TIMEOUT_EXCEEDED and UNKNOWN_TABLE (tables can be dropped by another thread).
+        $CLICKHOUSE_CLIENT -q "OPTIMIZE TABLE alter_table_$REPLICA FINAL SETTINGS receive_timeout=1, max_execution_time=3" |& grep -Fv -e "TIMEOUT_EXCEEDED" -e "UNKNOWN_TABLE"
         sleep 0.$RANDOM;
     done
 }


### PR DESCRIPTION
Add `max_execution_time` to OPTIMIZE TABLE FINAL queries in race condition tests. The `receive_timeout` setting only affects the client-side timeout, but the server-side query can run indefinitely when the merge cannot proceed due to concurrent mutations. This caused the tests to timeout after 600 seconds.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


This is doubtful, but as it is a small change, it is good to have.