### PR TITLE
Enable `chdig` build on macOS

### DIFF
--- a/contrib/chdig-cmake/CMakeLists.txt
+++ b/contrib/chdig-cmake/CMakeLists.txt
@@ -1,9 +1,8 @@
 set(ENABLE_CHDIG_DEFAULT ${ENABLE_RUST})
 # SANITIZE            - Some issues with undefined symbols
 # NO_ARMV81_OR_HIGHER - Disabled because ring assumes that Neon is available with ARM
-# OR OS_DARWIN        - linking issues (__Z11CityHash128PKcm not found)
 # OS_FREEBSD          - linking issues (undefined reference to `getrandom' and CityHash128())
-if (ENABLE_CHDIG_DEFAULT AND (SANITIZE OR NO_ARMV81_OR_HIGHER OR OS_DARWIN OR OS_FREEBSD))
+if (ENABLE_CHDIG_DEFAULT AND (SANITIZE OR NO_ARMV81_OR_HIGHER OR OS_FREEBSD))
     message(STATUS "Environment is not compatible with chdig. Disabling.")
     set(ENABLE_CHDIG_DEFAULT OFF)
 endif()


### PR DESCRIPTION
Fix the CityHash128 linkage issue in the vendored clickhouse-rs-cityhash-sys crate by adding `extern "C"` to the declaration in city.h and fixing the signature to use `const char*`.

The issue was that CityHashCrc128 called CityHash128 using C++ linkage (looking for mangled symbol `__Z11CityHash128PKcm`), but CityHash128 was defined with C linkage (`extern "C"`).

### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
The chdig tool is available on macOS.

See https://github.com/ClickHouse/rust_vendor/pull/55