### PR TITLE
Fix sporadic test failure in `03640_load_marks_synchronously`

### DIFF
--- a/tests/queries/0_stateless/03640_load_marks_synchronously.sql
+++ b/tests/queries/0_stateless/03640_load_marks_synchronously.sql
@@ -1,4 +1,5 @@
--- Tags: no-parallel-replicas
+-- Tags: no-parallel-replicas, no-parallel
+-- Test depends on mark cache, don't run with others in parallel
 
 -- Note: we need to have index_granularity==number or rows, to avoid processing
 -- parts in parallel, since in this case marks can be requested from multiple


### PR DESCRIPTION
The test verifies that marks loaded asynchronously in the first query are found in the mark cache during the second query. Without the `no-parallel` tag, other tests running concurrently can evict marks from the cache, causing the second query to load marks asynchronously instead of finding them in cache.

This was observed in CI where the test sporadically failed with:
- Expected: Row 2 has `async: 0, sync: 1` (marks from cache)
- Actual: Row 2 has `async: 1, sync: 0` (marks loaded again)

The fix adds the `no-parallel` tag, consistent with similar test `03759_marks_cache_events.sql` which already uses this tag with the comment "Test depends on mark cache, don't run with others in parallel".

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

See https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=95990&sha=6df3f937f6b7e7c31d27ee92fc3ad75679aa4002&name_0=PR&name_1=Stateless%20tests%20%28arm_binary%2C%20parallel%29
https://github.com/ClickHouse/ClickHouse/pull/95990


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.271`
<!-- ch-version-info:end -->