### PR TITLE
Fix PostgreSQL Date32 values not being correctly read

### DIFF
--- a/src/Core/PostgreSQL/insertPostgreSQLValue.cpp
+++ b/src/Core/PostgreSQL/insertPostgreSQLValue.cpp
@@ -215,6 +215,8 @@ void preparePostgreSQLArrayInfo(
         parser = [](std::string & field) -> Field { return field; };
     else if (which.isDate())
         parser = [](std::string & field) -> Field { return UInt16{LocalDate{field}.getDayNum()}; };
+    else if (which.isDate32())
+        parser = [](std::string & field) -> Field { return Int32{LocalDate{field}.getExtenedDayNum()}; };
     else if (which.isDateTime())
         parser = [nested](std::string & field) -> Field
         {

--- a/src/Databases/PostgreSQL/fetchPostgreSQLTableStructure.cpp
+++ b/src/Databases/PostgreSQL/fetchPostgreSQLTableStructure.cpp
@@ -10,6 +10,7 @@
 #include <DataTypes/DataTypesDecimal.h>
 #include <DataTypes/DataTypeUUID.h>
 #include <DataTypes/DataTypeDate.h>
+#include <DataTypes/DataTypeDate32.h>
 #include <DataTypes/DataTypeDateTime64.h>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/trim.hpp>
@@ -101,7 +102,7 @@ static DataTypePtr convertPostgreSQLDataType(String & type, Fn<void()> auto && r
     else if (type.starts_with("timestamp"))
         res = std::make_shared<DataTypeDateTime64>(6);
     else if (type == "date")
-        res = std::make_shared<DataTypeDate>();
+        res = std::make_shared<DataTypeDate32>();
     else if (type == "uuid")
         res = std::make_shared<DataTypeUUID>();
     else if (type.starts_with("numeric"))

--- a/src/Storages/StoragePostgreSQL.cpp
+++ b/src/Storages/StoragePostgreSQL.cpp
@@ -401,6 +401,7 @@ public:
         else if (which.isFloat32())                      nested_column = ColumnFloat32::create();
         else if (which.isFloat64())                      nested_column = ColumnFloat64::create();
         else if (which.isDate())                         nested_column = ColumnUInt16::create();
+        else if (which.isDate32())                       nested_column = ColumnInt32::create();
         else if (which.isDateTime())                     nested_column = ColumnUInt32::create();
         else if (which.isUUID())                         nested_column = ColumnUUID::create();
         else if (which.isDateTime64())

--- a/tests/integration/test_postgresql_replica_database_engine/test_0.py
+++ b/tests/integration/test_postgresql_replica_database_engine/test_0.py
@@ -139,7 +139,7 @@ def test_different_data_types(started_cluster):
         """CREATE TABLE test_array_data_type
            (
                 key Integer NOT NULL PRIMARY KEY,
-                a Date[] NOT NULL,                          -- Date
+                a Date[] NOT NULL,                          -- Date32
                 b Timestamp[] NOT NULL,                     -- DateTime64(6)
                 c real[][] NOT NULL,                        -- Float32
                 d double precision[][] NOT NULL,            -- Float64

--- a/tests/integration/test_storage_postgresql/test.py
+++ b/tests/integration/test_storage_postgresql/test.py
@@ -148,7 +148,7 @@ def test_postgres_conversions(started_cluster):
     cursor.execute(
         """CREATE TABLE IF NOT EXISTS test_array_dimensions
            (
-                a Date[] NOT NULL,                          -- Date
+                a Date[] NOT NULL,                          -- Date32
                 b Timestamp[] NOT NULL,                     -- DateTime64(6)
                 c real[][] NOT NULL,                        -- Float32
                 d double precision[][] NOT NULL,            -- Float64
@@ -169,7 +169,7 @@ def test_postgres_conversions(started_cluster):
         DESCRIBE TABLE postgresql('postgres1:5432', 'postgres', 'test_array_dimensions', 'postgres', '{pg_pass}')"""
     )
     expected = (
-        "a\tArray(Date)\t\t\t\t\t\n"
+        "a\tArray(Date32)\t\t\t\t\t\n"
         "b\tArray(DateTime64(6))\t\t\t\t\t\n"
         "c\tArray(Array(Float32))\t\t\t\t\t\n"
         "d\tArray(Array(Float64))\t\t\t\t\t\n"
@@ -912,6 +912,66 @@ def test_postgres_reading_clone(started_cluster):
         "SELECT count() FROM (SELECT (SELECT tx.number) = 1 as x FROM test_clone AS tx) WHERE x SETTINGS correlated_subqueries_substitute_equivalent_expressions = 0"
     )
     assert result.strip() == "1"
+
+
+def test_postgres_date32(started_cluster):
+    """Test that PostgreSQL DATE values outside the Date (UInt16) range are correctly read.
+
+    This is a regression test for https://github.com/ClickHouse/ClickHouse/issues/73084
+    PostgreSQL DATE type supports a much wider range than ClickHouse Date (1970-2149).
+    Large dates like '2276-11-21' must be read correctly using Date32.
+    """
+    cursor = started_cluster.postgres_conn.cursor()
+    cursor.execute("DROP TABLE IF EXISTS test_date32")
+    cursor.execute("CREATE TABLE test_date32 (d DATE)")
+
+    # Insert dates that would overflow with the old Date (UInt16) type
+    # Date range is ~1970-2149, these dates are beyond that
+    cursor.execute(
+        "INSERT INTO test_date32 VALUES ('2276-11-21'), ('2269-07-01'), ('2200-01-01'), ('1950-06-15')"
+    )
+
+    # Read dates back using the postgresql table function
+    result = node1.query(
+        f"SELECT d FROM postgresql('postgres1:5432', 'postgres', 'test_date32', 'postgres', '{pg_pass}') ORDER BY d"
+    )
+    expected = "1950-06-15\n2200-01-01\n2269-07-01\n2276-11-21\n"
+    assert result == expected, f"Expected:\n{expected}\nGot:\n{result}"
+
+    # Also verify the column type is Date32
+    result = node1.query(
+        f"DESCRIBE TABLE postgresql('postgres1:5432', 'postgres', 'test_date32', 'postgres', '{pg_pass}')"
+    )
+    assert "Date32" in result, f"Expected Date32 type, got: {result}"
+
+    cursor.execute("DROP TABLE test_date32")
+
+
+def test_postgres_date32_array(started_cluster):
+    """Test that PostgreSQL DATE[] arrays with large dates are correctly read as Array(Date32)."""
+    cursor = started_cluster.postgres_conn.cursor()
+    cursor.execute("DROP TABLE IF EXISTS test_date32_array")
+    cursor.execute("CREATE TABLE test_date32_array (dates DATE[] NOT NULL)")
+
+    # Insert array with dates that would overflow with Date (UInt16)
+    cursor.execute(
+        "INSERT INTO test_date32_array VALUES (ARRAY['2276-11-21'::date, '2269-07-01'::date, '1950-06-15'::date])"
+    )
+
+    # Read dates back (array elements are in insertion order)
+    result = node1.query(
+        f"SELECT dates FROM postgresql('postgres1:5432', 'postgres', 'test_date32_array', 'postgres', '{pg_pass}')"
+    )
+    expected = "['2276-11-21','2269-07-01','1950-06-15']\n"
+    assert result == expected, f"Expected:\n{expected}\nGot:\n{result}"
+
+    # Verify the column type is Array(Date32)
+    result = node1.query(
+        f"DESCRIBE TABLE postgresql('postgres1:5432', 'postgres', 'test_date32_array', 'postgres', '{pg_pass}')"
+    )
+    assert "Array(Date32)" in result, f"Expected Array(Date32) type, got: {result}"
+
+    cursor.execute("DROP TABLE test_date32_array")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
PostgreSQL DATE values outside the ClickHouse `Date` range (1970-2149) were being incorrectly read due to UInt16 overflow. This changes the PostgreSQL `date` type mapping from `Date` to `Date32`, which uses Int32 storage and supports dates from 1900-2299.

Changes:
- Map PostgreSQL `date` type to `Date32` instead of `Date`
- Add `Date32` support for reading PostgreSQL date arrays
- Add `Date32` support for writing date arrays back to PostgreSQL

Fixes #73084

### Changelog category (leave one):
- Backward Incompatible Change


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
`DATE` columns from PostgreSQL are now inferred as `Date32` in ClickHouse (in previous versions they were inferred as `Date`, which led to overflow of the values outside of a narrow range). Allow inserting `Date32` values back to PostgreSQL. Closes #73084.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.270`
<!-- ch-version-info:end -->