### PR TITLE
Fix flaky test `test_send_table_status_sleep` in `test_hedged_requests`

### DIFF
--- a/tests/integration/test_hedged_requests/test.py
+++ b/tests/integration/test_hedged_requests/test.py
@@ -256,7 +256,13 @@ def test_send_table_status_sleep(started_cluster):
     if NODES["node"].is_built_with_thread_sanitizer():
         pytest.skip("Hedged requests don't work under Thread Sanitizer")
 
-    update_configs(node_1_sleep_in_send_tables_status=sleep_time)
+    # Add a small delay to node_3 to ensure node_2 always wins the race
+    # when both are faster than node_1. Without this, under heavy load (e.g., ASAN builds),
+    # node_3 can occasionally respond before node_2.
+    update_configs(
+        node_1_sleep_in_send_tables_status=sleep_time,
+        node_3_sleep_in_send_tables_status=1000,
+    )
     check_query(expected_replica="node_2")
     check_changing_replica_events(1)
 


### PR DESCRIPTION
The test was sporadically failing because when only node_1 is configured with a delay, both node_2 and node_3 can respond to hedged requests. The test expected node_2 to always win the race, but under heavy load (e.g., ASAN builds), node_3 could occasionally respond first.

Fixed by adding a small delay (1 second) to node_3's `send_tables_status`, ensuring node_2 always responds first. This follows the same pattern used in other tests like `test_combination3` and `test_combination4`.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

See https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=95965&sha=674b1ac56a2f1aaa52d702810eb3abf9e948521e&name_0=PR&name_1=Integration%20tests%20%28amd_asan%2C%20db%20disk%2C%20old%20analyzer%2C%202%2F6%29
https://github.com/ClickHouse/ClickHouse/pull/95965