### PR TITLE
Docs: add DeltaLake writes examples

### DIFF
--- a/docs/en/engines/table-engines/integrations/deltalake.md
+++ b/docs/en/engines/table-engines/integrations/deltalake.md
@@ -10,15 +10,15 @@ doc_type: 'reference'
 
 # DeltaLake table engine
 
-This engine provides a read-only integration with existing [Delta Lake](https://github.com/delta-io/delta) tables in Amazon S3.
+This engine provides an integration with existing [Delta Lake](https://github.com/delta-io/delta) tables in Amazon S3, and supports both reads and writes (from v25.10).
 
-## Create table {#create-table}
+## Create a table {#create-table}
 
 Note that the Delta Lake table must already exist in S3, this command does not take DDL parameters to create a new table.
 
 ```sql
 CREATE TABLE deltalake
-    ENGINE = DeltaLake(url, [aws_access_key_id, aws_secret_access_key,])
+ENGINE = DeltaLake(url, [aws_access_key_id, aws_secret_access_key,])
 ```
 
 **Engine parameters**
@@ -31,7 +31,8 @@ Engine parameters can be specified using [Named Collections](/operations/named-c
 **Example**
 
 ```sql
-CREATE TABLE deltalake ENGINE=DeltaLake('http://mars-doc-test.s3.amazonaws.com/clickhouse-bucket-3/test_table/', 'ABC123', 'Abc+123')
+CREATE TABLE deltalake
+ENGINE = DeltaLake('http://mars-doc-test.s3.amazonaws.com/clickhouse-bucket-3/test_table/', 'ABC123', 'Abc+123')
 ```
 
 Using named collections:
@@ -49,12 +50,24 @@ Using named collections:
 ```
 
 ```sql
-CREATE TABLE deltalake ENGINE=DeltaLake(deltalake_conf, filename = 'test_table')
+CREATE TABLE deltalake
+ENGINE = DeltaLake(deltalake_conf, filename = 'test_table')
 ```
 
 ### Data cache {#data-cache}
 
-`DeltaLake` table engine and table function support data caching same as `S3`, `AzureBlobStorage`, `HDFS` storages. See [here](../../../engines/table-engines/integrations/s3.md#data-cache).
+The `DeltaLake` table engine and table function support data caching same as `S3`, `AzureBlobStorage`, `HDFS` storages. See [here](../../../engines/table-engines/integrations/s3.md#data-cache).
+
+## Insert data {#insert-data}
+
+Once you have created a table using the DeltaLake table engine, you can insert data into it with:
+
+```sql
+SET allow_experimental_delta_lake_writes = 1;
+
+INSERT INTO deltalake(id, firstname, lastname, gender, age)
+VALUES (1, 'John', 'Smith', 'M', 32);
+```
 
 ## See also {#see-also}
 


### PR DESCRIPTION
Updates docs for DeltaLake table engine and table function with information on performing writes.

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.253`
<!-- ch-version-info:end -->