### PR TITLE
Fix FixedString escaping for SQLite and similar storage engines

### DIFF
--- a/src/DataTypes/Serializations/SerializationFixedString.cpp
+++ b/src/DataTypes/Serializations/SerializationFixedString.cpp
@@ -205,10 +205,17 @@ bool SerializationFixedString::tryDeserializeTextEscaped(IColumn & column, ReadB
 }
 
 
-void SerializationFixedString::serializeTextQuoted(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings &) const
+void SerializationFixedString::serializeTextQuoted(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings & settings) const
 {
     const char * pos = reinterpret_cast<const char *>(&assert_cast<const ColumnFixedString &>(column).getChars()[n * row_num]);
-    writeAnyQuotedString<'\''>(pos, pos + n, ostr);
+    if (settings.values.escape_quote_with_quote)
+    {
+        writeChar('\'', ostr);
+        writeAnyEscapedString<'\'', true, false>(pos, pos + n, ostr);
+        writeChar('\'', ostr);
+    }
+    else
+        writeAnyQuotedString<'\''>(pos, pos + n, ostr);
 }
 
 

--- a/tests/queries/0_stateless/03751_fixed_string_escape_quote_with_quote.reference
+++ b/tests/queries/0_stateless/03751_fixed_string_escape_quote_with_quote.reference
@@ -1,0 +1,3 @@
+('\'\0\0\0')('foo\'bar\0')
+output_format_values_escape_quote_with_quote=1
+('''\0\0\0')('foo''bar\0')

--- a/tests/queries/0_stateless/03751_fixed_string_escape_quote_with_quote.sql
+++ b/tests/queries/0_stateless/03751_fixed_string_escape_quote_with_quote.sql
@@ -1,0 +1,16 @@
+-- Test that FixedString respects the output_format_values_escape_quote_with_quote setting
+-- This was broken: https://github.com/ClickHouse/ClickHouse/issues/73519
+
+-- Default behavior (backslash escaping)
+select toFixedString('\'', 4) format Values;
+select toFixedString('foo\'bar', 8) format Values;
+
+select '\noutput_format_values_escape_quote_with_quote=1' format LineAsString;
+set output_format_values_escape_quote_with_quote=1;
+
+-- PostgreSQL/SQLite style (quote doubling)
+select toFixedString('\'', 4) format Values;
+select toFixedString('foo\'bar', 8) format Values;
+
+-- Ensure no newline issues at end of file
+select '' format LineAsString;

--- a/tests/queries/0_stateless/03752_sqlite_fixed_string_quote_escape.reference
+++ b/tests/queries/0_stateless/03752_sqlite_fixed_string_quote_escape.reference
@@ -1,0 +1,6 @@
+Data in SQLite (first char hex):
+27
+74
+Data in SQLite (raw, first 7 chars):
+'\0\0\0
+test's\

--- a/tests/queries/0_stateless/03752_sqlite_fixed_string_quote_escape.sh
+++ b/tests/queries/0_stateless/03752_sqlite_fixed_string_quote_escape.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+
+# Test for https://github.com/ClickHouse/ClickHouse/issues/73519
+# FixedString was not properly escaping single quotes for SQLite,
+# using backslash escaping (\') instead of quote doubling ('')
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+DB_PATH="${CLICKHOUSE_TMP}/${CLICKHOUSE_DATABASE}_sqlite_fixed_string.db"
+
+rm -f "${DB_PATH}"
+
+# Create SQLite table
+sqlite3 "${DB_PATH}" 'CREATE TABLE t(c0 TEXT);'
+
+# Create ClickHouse table with FixedString type backed by SQLite
+# Insert single quote - this was failing before the fix with:
+# "Failed to execute sqlite INSERT query. Status: 1. Message: unrecognized token"
+${CLICKHOUSE_LOCAL} -q "
+    CREATE TABLE t(c0 FixedString(8)) ENGINE = SQLite('${DB_PATH}', 't');
+    INSERT INTO t VALUES ('''');
+    INSERT INTO t VALUES ('test''s');
+"
+
+# Verify data was inserted by reading directly from SQLite
+# (Reading via ClickHouse has a separate bug with FixedString/SQLite)
+echo "Data in SQLite (first char hex):"
+sqlite3 "${DB_PATH}" "SELECT hex(substr(c0, 1, 1)) FROM t ORDER BY c0;"
+
+echo "Data in SQLite (raw, first 7 chars):"
+sqlite3 "${DB_PATH}" "SELECT substr(c0, 1, 7) FROM t ORDER BY c0;"
+
+rm -f "${DB_PATH}"


### PR DESCRIPTION
`SerializationFixedString::serializeTextQuoted` was ignoring the `output_format_values_escape_quote_with_quote` setting, always using backslash escaping (`\'`). SQLite requires quote-doubling (`''`) for escaping single quotes.

This fix makes `FixedString` respect the setting, matching the behavior already implemented in `SerializationString`.

Closes #73519
Closes #73850

This is a simplified version of the fix from @jh0x

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
`FixedString` values were escaped incorrectly in queries to external databases, SQLite and PostgreSQL. Closes #73519. Co-authored with @jh0x.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.295`
<!-- ch-version-info:end -->