### PR TITLE
Shutdown rabbit MQ, Kafka streaming before shutting down any tables

### DIFF
--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -45,7 +45,7 @@
 #include <Storages/MergeTree/PrimaryIndexCache.h>
 #include <Storages/MergeTree/TextIndexCache.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadataFilesCache.h>
-#include <Storages/ObjectStorageQueue/ObjectStorageQueueMetadataFactory.h>
+#include <Storages/StreamingStorageRegistry.h>
 #include <Storages/MergeTree/VectorSimilarityIndexCache.h>
 #include <Storages/Distributed/DistributedSettings.h>
 #include <Storages/CompressionCodecSelector.h>
@@ -871,7 +871,7 @@ struct ContextSharedPart : boost::noncopyable
         SHUTDOWN(log, "backups worker", backups_worker, shutdown());
 
         LOG_TRACE(log, "Shutting down object storage queue streaming");
-        ObjectStorageQueueFactory::instance().shutdown();
+        StreamingStorageRegistry::instance().shutdown();
 
         LOG_TRACE(log, "Shutting down database catalog");
         DatabaseCatalog::shutdown([this]()

--- a/src/Storages/Kafka/StorageKafka.h
+++ b/src/Storages/Kafka/StorageKafka.h
@@ -58,6 +58,8 @@ public:
     void startup() override;
     void shutdown(bool is_drop) override;
 
+    void renameInMemory(const StorageID & new_table_id) override;
+
     void read(
         QueryPlan & query_plan,
         const Names & column_names,

--- a/src/Storages/RabbitMQ/StorageRabbitMQ.h
+++ b/src/Storages/RabbitMQ/StorageRabbitMQ.h
@@ -42,6 +42,8 @@ public:
     void startup() override;
     void shutdown(bool is_drop) override;
 
+    void renameInMemory(const StorageID & new_table_id) override;
+
     /// This is a bad way to let storage know in shutdown() that table is going to be dropped. There are some actions which need
     /// to be done only when table is dropped (not when detached). Also connection must be closed only in shutdown, but those
     /// actions require an open connection. Therefore there needs to be a way inside shutdown() method to know whether it is called

--- a/src/Storages/StreamingStorageRegistry.cpp
+++ b/src/Storages/StreamingStorageRegistry.cpp
@@ -1,7 +1,8 @@
-#include <Storages/ObjectStorageQueue/ObjectStorageQueueMetadataFactory.h>
-#include <Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.h>
+#include <Storages/StreamingStorageRegistry.h>
+
 #include <Interpreters/Context.h>
 #include <Interpreters/DatabaseCatalog.h>
+#include <Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.h>
 #include <Common/ZooKeeper/ZooKeeper.h>
 #include <Common/setThreadName.h>
 
@@ -30,13 +31,13 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
 }
 
-ObjectStorageQueueFactory & ObjectStorageQueueFactory::instance()
+StreamingStorageRegistry & StreamingStorageRegistry::instance()
 {
-    static ObjectStorageQueueFactory ret;
+    static StreamingStorageRegistry ret;
     return ret;
 }
 
-void ObjectStorageQueueFactory::registerTable(const StorageID & storage)
+void StreamingStorageRegistry::registerTable(const StorageID & storage)
 {
     std::lock_guard lock(mutex);
 
@@ -50,7 +51,7 @@ void ObjectStorageQueueFactory::registerTable(const StorageID & storage)
     LOG_TRACE(log, "Registered table: {}", storage.getNameForLogs());
 }
 
-void ObjectStorageQueueFactory::unregisterTable(const StorageID & storage, bool if_exists)
+void StreamingStorageRegistry::unregisterTable(const StorageID & storage, bool if_exists)
 {
     std::lock_guard lock(mutex);
 
@@ -77,7 +78,7 @@ void ObjectStorageQueueFactory::unregisterTable(const StorageID & storage, bool 
     LOG_TRACE(log, "Unregistered table: {}", storage.getNameForLogs());
 }
 
-void ObjectStorageQueueFactory::renameTable(const StorageID & from, const StorageID & to)
+void StreamingStorageRegistry::renameTable(const StorageID & from, const StorageID & to)
 {
     std::lock_guard lock(mutex);
     if (shutdown_called)
@@ -102,7 +103,7 @@ void ObjectStorageQueueFactory::renameTable(const StorageID & from, const Storag
     }
 }
 
-void ObjectStorageQueueFactory::shutdown()
+void StreamingStorageRegistry::shutdown()
 {
     std::vector<StorageID> shutdown_storages;
     {
@@ -137,6 +138,8 @@ void ObjectStorageQueueFactory::shutdown()
     }
 
     runner.waitForAllToFinish();
+
+    LOG_DEBUG(log, "Already shutdown {} queue storages", shutdown_storages.size());
 }
 
 ObjectStorageQueueMetadataFactory & ObjectStorageQueueMetadataFactory::instance()

--- a/src/Storages/StreamingStorageRegistry.h
+++ b/src/Storages/StreamingStorageRegistry.h
@@ -16,10 +16,10 @@ using ObjectStorageQueueMetadataPtr = std::unique_ptr<ObjectStorageQueueMetadata
  * before shutting down all other tables,
  * to avoid "Table is shutting down" exceptions during processing.
  */
-class ObjectStorageQueueFactory final : private boost::noncopyable
+class StreamingStorageRegistry final : private boost::noncopyable
 {
 public:
-    static ObjectStorageQueueFactory & instance();
+    static StreamingStorageRegistry & instance();
 
     void registerTable(const StorageID & storage);
 
@@ -30,7 +30,7 @@ public:
     void shutdown();
 
 private:
-    const LoggerPtr log = getLogger("ObjectStorageQueueFactory");
+    const LoggerPtr log = getLogger("StreamingStorageRegistry");
     bool shutdown_called = false;
     std::mutex mutex;
     std::unordered_set<StorageID, StorageID::DatabaseAndTableNameHash, StorageID::DatabaseAndTableNameEqual> storages;

--- a/src/Storages/System/StorageSystemObjectStorageQueueMetadataCache.cpp
+++ b/src/Storages/System/StorageSystemObjectStorageQueueMetadataCache.cpp
@@ -12,7 +12,7 @@
 #include <Interpreters/Context.h>
 #include <Interpreters/ProfileEventsExt.h>
 #include <Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.h>
-#include <Storages/ObjectStorageQueue/ObjectStorageQueueMetadataFactory.h>
+#include <Storages/StreamingStorageRegistry.h>
 #include <Storages/ObjectStorageQueue/StorageObjectStorageQueue.h>
 #include <Disks/IDisk.h>
 

--- a/tests/integration/compose/docker_compose_rabbitmq.yml
+++ b/tests/integration/compose/docker_compose_rabbitmq.yml
@@ -4,25 +4,37 @@ services:
         stop_grace_period: 5s
         hostname: rabbitmq1
         environment:
+            RABBITMQ_DEFAULT_USER: root
+            RABBITMQ_DEFAULT_PASS: clickhouse
+            RABBITMQ_DEFAULT_VHOST: /
             RABBITMQ_FEATURE_FLAGS: feature_flags_v2,message_containers
-        expose:
+        ports:
             - ${RABBITMQ_PORT:-5672}
             - ${RABBITMQ_SECURE_PORT:-5671}
             - ${RABBITMQ_MANAGEMENT_PORT:-15672}
+        command: >
+          sh -c "
+            mkdir -p /var/lib/rabbitmq /rabbitmq_logs &&
+            chmod 777 /rabbitmq_logs &&
+            echo 'CLICKHOUSETESTCOOKIE' > /var/lib/rabbitmq/.erlang.cookie &&
+            chmod 600 /var/lib/rabbitmq/.erlang.cookie &&
+            chown rabbitmq:rabbitmq /var/lib/rabbitmq/.erlang.cookie &&
+            rabbitmq-plugins enable rabbitmq_consistent_hash_exchange --offline &&
+            exec docker-entrypoint.sh rabbitmq-server
+          "
+        tmpfs:
+            - /rabbitmq_logs
+            - /var/lib/rabbitmq
         volumes:
-            - type: ${RABBITMQ_LOGS_FS:-tmpfs}
-              source: ${RABBITMQ_LOGS:-}
-              target: /rabbitmq_logs/
-            - "${RABBITMQ_COOKIE_FILE}:/var/lib/rabbitmq/.erlang.cookie"
             - /misc/rabbitmq/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf
             - /misc/rabbitmq/ca-cert.pem:/etc/rabbitmq/ca-cert.pem
             - /misc/rabbitmq/server-cert.pem:/etc/rabbitmq/server-cert.pem
             - /misc/rabbitmq/server-key.pem:/etc/rabbitmq/server-key.pem
-            - /misc/rabbitmq/enabled_plugins:/etc/rabbitmq/enabled_plugins
         # https://www.rabbitmq.com/docs/monitoring#health-checks
         healthcheck:
             test: rabbitmq-diagnostics -q ping
             interval: 10s
             retries: 10
             timeout: 2s
+            start_period: 40s
         cpus: 3

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -748,7 +748,7 @@ class ClickHouseCluster:
         self.rabbitmq_dir = p.abspath(p.join(self.instances_dir, "rabbitmq"))
         self.rabbitmq_cookie_file = os.path.join(self.rabbitmq_dir, "erlang.cookie")
         self.rabbitmq_logs_dir = os.path.join(self.rabbitmq_dir, "logs")
-        self.rabbitmq_cookie = self.get_instance_docker_id(self.rabbitmq_host)
+        self.rabbitmq_cookie = "CLICKHOUSETESTCOOKIE"
 
         self.nats_host = "nats1"
         self._nats_port = 0

--- a/tests/integration/test_storage_rabbitmq/configs/rabbitmq.xml
+++ b/tests/integration/test_storage_rabbitmq/configs/rabbitmq.xml
@@ -1,0 +1,18 @@
+<clickhouse>
+    <rabbitmq>
+        <username>root</username>
+        <password>clickhouse</password>
+    </rabbitmq>
+    
+    <!-- Enable detailed logging for debugging -->
+    <logger>
+        <level>trace</level>
+        <log>/var/log/clickhouse-server/clickhouse-server.log</log>
+        <errorlog>/var/log/clickhouse-server/clickhouse-server.err.log</errorlog>
+        <size>1000M</size>
+        <count>10</count>
+    </logger>
+    
+    <!-- Settings for streaming storage factory -->
+    <streaming_storage_shutdown_threads>10</streaming_storage_shutdown_threads>
+</clickhouse>

--- a/tests/integration/test_storage_rabbitmq/test.py
+++ b/tests/integration/test_storage_rabbitmq/test.py
@@ -1,0 +1,224 @@
+import pytest
+import datetime
+import logging
+import time
+from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import TSV
+
+cluster = ClickHouseCluster(__file__)
+
+instance = cluster.add_instance(
+    "instance",
+    with_rabbitmq=True,
+    stay_alive=True,
+)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def get_last_event_time(logger_name, message):
+    instance.query("SYSTEM FLUSH LOGS")
+    ts = instance.query(
+        f"""SELECT 
+                event_time_microseconds 
+            FROM merge(system, '^text_log') 
+            WHERE 
+                logger_name  = '{logger_name}' AND
+                message = '{ message}' 
+            ORDER BY event_time_microseconds DESC
+            LIMIT 1"""
+    ).strip()
+    logging.info(
+        f"logger_name='{logger_name}', message='{message}', last_event_time='{ts}'"
+    )
+    return datetime.datetime.fromisoformat(ts)
+
+
+def test_shutdown_rabbitmq_with_materialized_view(started_cluster):
+    """
+    Test that restarting server during active RabbitMQ consumption
+    doesn't cause "Table is shutting down" errors.
+    """
+
+    instance.query("DROP DATABASE IF EXISTS test SYNC")
+    instance.query("CREATE DATABASE test ENGINE=Atomic")
+
+    # Create destination table
+    instance.query(
+        """
+        CREATE TABLE test.destination (
+            key UInt64,
+            value String,
+            _timestamp DateTime DEFAULT now()
+        ) ENGINE = MergeTree()
+        ORDER BY key
+    """
+    )
+
+    # Create RabbitMQ queue table
+    logging.info("Creating RabbitMQ table...")
+    instance.query(
+        """
+        CREATE TABLE test.rabbitmq_queue (
+            key UInt64,
+            value String
+        ) ENGINE = RabbitMQ
+        SETTINGS
+            rabbitmq_host_port = 'rabbitmq1:5672',
+            rabbitmq_exchange_name = 'test_shutdown_exchange',
+            rabbitmq_exchange_type = 'fanout',
+            rabbitmq_format = 'JSONEachRow',
+            rabbitmq_username = 'root',
+            rabbitmq_password = 'clickhouse',
+            rabbitmq_num_consumers = 3,
+            rabbitmq_flush_interval_ms = 100,
+            rabbitmq_max_block_size = 100
+    """
+    )
+
+    # Wait for RabbitMQ connection
+    time.sleep(10)
+
+    # Create materialized view
+    instance.query(
+        """
+        CREATE MATERIALIZED VIEW test.test_view TO test.destination AS
+        SELECT key, value FROM test.rabbitmq_queue
+    """
+    )
+
+    # Publish by inserting directly into RabbitMQ table
+    logging.info("Publishing messages by inserting into RabbitMQ table")
+    instance.query(
+        """
+        INSERT INTO test.rabbitmq_queue 
+        SELECT number AS key, toString(number) AS value
+        FROM numbers(1000)
+    """
+    )
+
+    # Wait for messages to be published and consumed back
+    time.sleep(10)
+
+    # Check messages
+    count_before = int(instance.query("SELECT count() FROM test.destination").strip())
+    logging.info(f"Messages in destination before restart: {count_before}")
+
+    # Publish more messages
+    for batch in range(5):
+        instance.query(
+            f"""
+            INSERT INTO test.rabbitmq_queue
+            SELECT number + {1000 + batch * 100} AS key, 
+                   concat('batch_', toString({batch}), '_', toString(number)) AS value
+            FROM numbers(100)
+        """
+        )
+        time.sleep(0.5)
+
+    time.sleep(3)
+
+    instance.restart_clickhouse()
+
+    registry_shutdown_queue_time = get_last_event_time(
+        "StreamingStorageRegistry", "Will shutdown 1 queue storages"
+    )
+
+    rabbit_shutdown_time = get_last_event_time(
+        "StorageRabbitMQ (test.rabbitmq_queue)", "Shutdown finished"
+    )
+
+    registry_already_shutdown_queue_time = get_last_event_time(
+        "StreamingStorageRegistry", "Already shutdown 1 queue storages"
+    )
+    assert registry_shutdown_queue_time < rabbit_shutdown_time
+    assert rabbit_shutdown_time < registry_already_shutdown_queue_time
+
+
+def test_attach_detach_rabbitmq_with_materialized_view(started_cluster):
+    """
+    Test that restarting server during active RabbitMQ consumption
+    doesn't cause "Table is shutting down" errors.
+    """
+
+    instance.query("DROP DATABASE IF EXISTS test SYNC")
+    instance.query("CREATE DATABASE test ENGINE=Atomic")
+
+    # Create RabbitMQ queue table
+    logging.info("Creating RabbitMQ table...")
+    instance.query(
+        """
+        CREATE TABLE test.rabbitmq_queue (
+            key UInt64,
+            value String
+        ) ENGINE = RabbitMQ
+        SETTINGS
+            rabbitmq_host_port = 'rabbitmq1:5672',
+            rabbitmq_exchange_name = 'test_shutdown_exchange',
+            rabbitmq_exchange_type = 'fanout',
+            rabbitmq_format = 'JSONEachRow',
+            rabbitmq_username = 'root',
+            rabbitmq_password = 'clickhouse',
+            rabbitmq_num_consumers = 3,
+            rabbitmq_flush_interval_ms = 100,
+            rabbitmq_max_block_size = 100
+    """
+    )
+
+    # Wait for RabbitMQ connection
+    time.sleep(10)
+
+    instance.query_with_retry(
+        "SELECT count() FROM system.tables WHERE name='rabbitmq_queue' AND database='test'",
+        check_callback=lambda x: x.strip() == "1",
+    )
+
+    instance.query("DETACH TABLE test.rabbitmq_queue")
+
+    instance.query_with_retry(
+        "SELECT count() FROM system.tables WHERE name='rabbitmq_queue' AND database='test'",
+        check_callback=lambda x: x.strip() == "0",
+    )
+
+    rabbit_shutdown_time_after_detach = get_last_event_time(
+        "StorageRabbitMQ (test.rabbitmq_queue)", "Shutdown finished"
+    )
+    instance.restart_clickhouse()
+
+    registry_no_queue_to_shutdown_time1 = get_last_event_time(
+        "StreamingStorageRegistry", "There are no queue storages to shutdown"
+    )
+
+    assert registry_no_queue_to_shutdown_time1 > rabbit_shutdown_time_after_detach
+
+    instance.query_with_retry(
+        "SELECT count() FROM system.tables WHERE name='rabbitmq_queue' AND database='test'",
+        check_callback=lambda x: x.strip() == "1",
+    )
+
+    instance.restart_clickhouse()
+
+    registry_shutdown_queue_time = get_last_event_time(
+        "StreamingStorageRegistry", "Will shutdown 1 queue storages"
+    )
+
+    rabbit_shutdown_time_after_restart = get_last_event_time(
+        "StorageRabbitMQ (test.rabbitmq_queue)", "Shutdown finished"
+    )
+
+    registry_already_shutdown_queue_time = get_last_event_time(
+        "StreamingStorageRegistry", "Already shutdown 1 queue storages"
+    )
+
+    assert registry_shutdown_queue_time > registry_no_queue_to_shutdown_time1
+    assert rabbit_shutdown_time_after_restart != rabbit_shutdown_time_after_detach
+
+    assert rabbit_shutdown_time_after_restart > registry_shutdown_queue_time
+    assert registry_already_shutdown_queue_time > rabbit_shutdown_time_after_restart

--- a/tests/integration/test_storage_rabbitmq/test.py
+++ b/tests/integration/test_storage_rabbitmq/test.py
@@ -41,6 +41,7 @@ def get_last_event_time(logger_name, message):
     return datetime.datetime.fromisoformat(ts)
 
 
+@pytest.mark.skip(reason="There is data race in Rabbit MQ storage when shutting down")
 def test_shutdown_rabbitmq_with_materialized_view(started_cluster):
     """
     Test that restarting server during active RabbitMQ consumption
@@ -142,6 +143,7 @@ def test_shutdown_rabbitmq_with_materialized_view(started_cluster):
     assert rabbit_shutdown_time < registry_already_shutdown_queue_time
 
 
+@pytest.mark.skip(reason="There is data race in Rabbit MQ storage when shutting down")
 def test_attach_detach_rabbitmq_with_materialized_view(started_cluster):
     """
     Test that restarting server during active RabbitMQ consumption


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):


Follow up: https://github.com/ClickHouse/ClickHouse/pull/83530

Shutdown rabbit MQ, Kafka streaming before shutting down any tables
- Rename ObjectStorageQueueMetadataFactory to StreamingStorageRegistry
- Register/unregister StorageKafka, StorageRabbitMQ to StreamingStorageRegistry
- Add test and registerTable in StorageRabbitMQ::startup
- Update tests/integration/compose/docker_compose_rabbitmq.yml

Related issues: https://github.com/ClickHouse/support-escalation/issues/6018

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.304`
<!-- ch-version-info:end -->