### PR TITLE
Fix crash due to exception inside NOEXCEPT_SCOPE in Transaction::commit

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -8172,13 +8172,18 @@ MergeTreeData::DataPartsVector MergeTreeData::Transaction::commit(DataPartsLock 
             if (part->getDataPartStorage().hasActiveTransaction())
                 part->getDataPartStorage().commitTransaction();
 
-        if (txn)
-        {
-            for (const auto & part : precommitted_parts)
-            {
-                DataPartPtr covering_part;
-                DataPartsVector covered_active_parts = data.getActivePartsToReplace(part->info, part->name, covering_part, acquired_parts_lock);
+        /// Collect covered parts and call addNewPartAndRemoveCovered before NOEXCEPT_SCOPE,
+        /// because lockRemovalTID inside addNewPartAndRemoveCovered can throw SERIALIZATION_ERROR.
+        std::vector<DataPartsVector> covered_parts_for_commit;
+        covered_parts_for_commit.reserve(precommitted_parts.size());
 
+        for (const auto & part : precommitted_parts)
+        {
+            DataPartPtr covering_part;
+            DataPartsVector covered_parts = data.getActivePartsToReplace(part->info, part->name, covering_part, acquired_parts_lock);
+
+            if (txn)
+            {
                 /// outdated parts should be also collected here
                 /// the visible outdated parts should be tried to be removed
                 /// more likely the conflict happens at the removing visible outdated parts, what is right actually
@@ -8188,13 +8193,15 @@ MergeTreeData::DataPartsVector MergeTreeData::Transaction::commit(DataPartsLock 
                          covered_outdated_parts.size(), part->getNameWithState(), txn->tid, txn->getSnapshot(), fmt::join(getPartsNames(covered_outdated_parts), ", "));
                 data.filterVisibleDataParts(covered_outdated_parts, txn->getSnapshot(), txn->tid);
 
-                DataPartsVector covered_parts;
-                covered_parts.reserve(covered_active_parts.size() + covered_outdated_parts.size());
-                std::move(covered_active_parts.begin(), covered_active_parts.end(), std::back_inserter(covered_parts));
                 std::move(covered_outdated_parts.begin(), covered_outdated_parts.end(), std::back_inserter(covered_parts));
-
-                MergeTreeTransaction::addNewPartAndRemoveCovered(data.shared_from_this(), part, covered_parts, txn);
             }
+
+            /// Call addNewPartAndRemoveCovered only if there's no covering part.
+            /// If there's a covering part, the precommitted part will be marked as obsolete in NOEXCEPT_SCOPE below.
+            if (!covering_part)
+                MergeTreeTransaction::addNewPartAndRemoveCovered(data.shared_from_this(), part, covered_parts, txn);
+
+            covered_parts_for_commit.push_back(std::move(covered_parts));
         }
 
         NOEXCEPT_SCOPE({
@@ -8208,6 +8215,7 @@ MergeTreeData::DataPartsVector MergeTreeData::Transaction::commit(DataPartsLock 
             size_t reduce_rows = 0;
             size_t reduce_parts = 0;
 
+            size_t part_idx = 0;
             for (const auto & part : precommitted_parts)
             {
                 DataPartPtr covering_part;
@@ -8227,8 +8235,9 @@ MergeTreeData::DataPartsVector MergeTreeData::Transaction::commit(DataPartsLock 
                 }
                 else
                 {
-                    if (!txn)
-                        MergeTreeTransaction::addNewPartAndRemoveCovered(data.shared_from_this(), part, covered_parts, NO_TRANSACTION_RAW);
+                    /// Use the covered parts computed before NOEXCEPT_SCOPE.
+                    /// addNewPartAndRemoveCovered was already called above (before NOEXCEPT_SCOPE).
+                    covered_parts = std::move(covered_parts_for_commit[part_idx]);
 
                     total_covered_parts.insert(total_covered_parts.end(), covered_parts.begin(), covered_parts.end());
                     for (const auto & covered_part : covered_parts)
@@ -8253,6 +8262,7 @@ MergeTreeData::DataPartsVector MergeTreeData::Transaction::commit(DataPartsLock 
                     data.addPartContributionToColumnAndSecondaryIndexSizes(part);
                     data.addPartContributionToUncompressedBytesInPatches(part);
                 }
+                ++part_idx;
             }
 
             data.updateSerializationHints(precommitted_parts, total_covered_parts, acquired_parts_lock);


### PR DESCRIPTION
The server was crashing with `std::terminate()` when a `SERIALIZATION_ERROR` exception was thrown inside `NOEXCEPT_SCOPE` in `MergeTreeData::Transaction::commit()`.

The issue occurred in the non-transactional code path (`txn == nullptr`):
- `addNewPartAndRemoveCovered` with `NO_TRANSACTION_RAW` was called inside `NOEXCEPT_SCOPE`
- This function calls `lockRemovalTID(Tx::PrehistoricTID, ...)` for covered parts
- `lockRemovalTID` throws `SERIALIZATION_ERROR` when a part is already locked by another transaction
- Throwing inside `NOEXCEPT_SCOPE` triggers `std::terminate()`

The transactional code path (`txn != nullptr`) was already correct - it called `addNewPartAndRemoveCovered` before entering `NOEXCEPT_SCOPE`.

The fix unifies both code paths:
1. Before `NOEXCEPT_SCOPE`: collect covered parts and call `addNewPartAndRemoveCovered` for all precommitted parts (when there's no covering part), regardless of whether there's a transaction
2. Store the covered parts in `covered_parts_for_commit` vector
3. Inside `NOEXCEPT_SCOPE`: use the pre-computed covered parts instead of calling the potentially-throwing function

This ensures that `lockRemovalTID` (which can throw) is always called outside of `NOEXCEPT_SCOPE`, allowing the exception to propagate normally instead of causing the server to crash.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

See https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96013&sha=0e986faabb62200a130d22f5a32c17f9699d1f0e&name_0=PR&name_1=Stateless%20tests%20%28amd_binary%2C%20ParallelReplicas%2C%20s3%20storage%2C%20parallel%29
https://github.com/ClickHouse/ClickHouse/pull/96013

Need to consult with @tavplubix on whether this is reasonable.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.332`
<!-- ch-version-info:end -->