### PR TITLE
Reset templates when parameters change

### DIFF
--- a/src/Processors/Formats/Impl/ValuesBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ValuesBlockInputFormat.cpp
@@ -697,6 +697,13 @@ void ValuesBlockInputFormat::setQueryParameters(const NameToNameMap & parameters
     auto context_copy = Context::createCopy(context);
     context_copy->setQueryParameters(parameters);
     context = std::move(context_copy);
+
+    // Reset templates when parameters change
+    for (size_t i = 0; i < num_columns; ++i)
+    {
+        templates[i].reset();
+        parser_type_for_column[i] = ParserType::Streaming;
+    }
 }
 
 ValuesSchemaReader::ValuesSchemaReader(ReadBuffer & in_, const FormatSettings & format_settings_)

--- a/tests/queries/0_stateless/03821_async_insert_same_param_names.sh
+++ b/tests/queries/0_stateless/03821_async_insert_same_param_names.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Test that concurrent async inserts with same param names but different values
+# don't cross-contaminate data
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. "$CURDIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS test_async_params"
+$CLICKHOUSE_CLIENT -q "CREATE TABLE test_async_params (x UInt64) ENGINE = MergeTree ORDER BY x"
+
+# Send concurrent inserts with same param name, different values
+for i in {1..10}; do
+$CLICKHOUSE_CLIENT --param_val=$i --async_insert=1 --wait_for_async_insert=0 \
+   -q "INSERT INTO test_async_params VALUES ({val:UInt64})" &
+done
+wait
+
+# Verify each value appears exactly once
+$CLICKHOUSE_CLIENT -q "SELECT x, count() as c FROM test_async_params GROUP BY x HAVING c != 1"
+# Should output nothing (all counts are 1)
+
+$CLICKHOUSE_CLIENT -q "DROP TABLE test_async_params"
+


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix a bug with possible data corruption when concurrent async inserts are using the same parameter names but contain different values.

### Details

Customer detected data mismatch after simultaneous async inserts with same parameter names. It was discovered that when using async inserts with parameterized VALUES ({param:Type} syntax), concurrent requests using the same parameter names but different values can experience data corruption. Values from one request leak into another.

Parameter values are getting stored in the templates. They need to be reset when parameters change.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.1000`
<!-- ch-version-info:end -->