### PR TITLE
Fix inability to remove outdated data parts

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -8224,6 +8224,8 @@ MergeTreeData::DataPartsVector MergeTreeData::Transaction::commit(DataPartsLock 
 
                     part->remove_time.store(0, std::memory_order_relaxed); /// The part will be removed without waiting for old_parts_lifetime seconds.
                     data.modifyPartState(part, DataPartState::Outdated, acquired_parts_lock);
+
+                    MergeTreeTransaction::removeOldPart(data.shared_from_this(), part, NO_TRANSACTION_RAW);
                 }
                 else
                 {


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix


### Changelog entry
Fix inability to remove outdated data parts when a newly inserted part is already covered by a merged part from another replica before becoming active, leaving the part on disk with removal_state = "Part maybe visible for transactions".


Closes https://github.com/ClickHouse/ClickHouse/issues/96037
