### PR TITLE
Docs: add missing information about projection merge behavior configuration

### DIFF
--- a/docs/en/sql-reference/statements/alter/projection.md
+++ b/docs/en/sql-reference/statements/alter/projection.md
@@ -293,6 +293,6 @@ Below are the possible values for both `deduplicate_merge_projection_mode` and `
 - `rebuild`: The affected projection part is rebuilt to stay consistent with data in the original table part.
 
 ## See also {#see-also}
-- ["Control Of Projections During Merges" (Blogpost)](https://clickhouse.com/blog/clickhouse-release-24-08#control-of-projections-during-merges)
+- ["Control Of Projections During Merges" (blog post)](https://clickhouse.com/blog/clickhouse-release-24-08#control-of-projections-during-merges)
 - ["Projections" (guide)](/data-modeling/projections#using-projections-to-speed-up-UK-price-paid)
 - ["Materialized Views versus Projections"](https://clickhouse.com/docs/managing-data/materialized-views-versus-projections)

--- a/docs/en/sql-reference/statements/alter/projection.md
+++ b/docs/en/sql-reference/statements/alter/projection.md
@@ -187,7 +187,7 @@ WHERE _part_starting_offset + _part_offset IN (
 SETTINGS enable_shared_storage_snapshot_in_query = 1
 ```
 
-## Manipulating projections
+## Manipulating projections {#manipulating-projections}
 
 The following operations with [projections](/engines/table-engines/mergetree-family/mergetree.md/#projections) are available:
 

--- a/docs/en/sql-reference/statements/alter/projection.md
+++ b/docs/en/sql-reference/statements/alter/projection.md
@@ -7,21 +7,26 @@ title: 'Projections'
 doc_type: 'reference'
 ---
 
+This article discusses what projections are, how you can use them and various options for manipulating projections.
+
+## Overview of projections {#overview}
+
 Projections store data in a format that optimizes query execution, this feature is useful for:
 - Running queries on a column that is not a part of the primary key
 - Pre-aggregating columns, it will reduce both computation and IO
 
 You can define one or more projections for a table, and during the query analysis the projection with the least data to scan will be selected by ClickHouse without modifying the query provided by the user.
 
-:::note Disk usage
-
+:::note[Disk usage]
 Projections will create internally a new hidden table, this means that more IO and space on disk will be required.
 Example, If the projection has defined a different primary key, all the data from the original table will be duplicated.
 :::
 
 You can see more technical details about how projections work internally on this [page](/guides/best-practices/sparse-primary-indexes.md/#option-3-projections).
 
-## Example filtering without using primary keys {#example-filtering-without-using-primary-keys}
+## Using projections {#examples}
+
+### Example filtering without using primary keys {#example-filtering-without-using-primary-keys}
 
 Creating the table:
 ```sql
@@ -70,7 +75,7 @@ To verify that a query is using the projection, we could review the `system.quer
 SELECT query, projections FROM system.query_log WHERE query_id='<query_id>'
 ```
 
-## Example pre-aggregation query {#example-pre-aggregation-query}
+### Example pre-aggregation query {#example-pre-aggregation-query}
 
 Creating the table with the Projection:
 ```sql
@@ -138,7 +143,7 @@ As mentioned before, we could review the `system.query_log` table. On the `proje
 SELECT query, projections FROM system.query_log WHERE query_id='<query_id>'
 ```
 
-## Normal projection with `_part_offset` field {#normal-projection-with-part-offset-field}
+### Normal projection with `_part_offset` field {#normal-projection-with-part-offset-field}
 
 Creating a table with a normal projection that utilizes the `_part_offset` field:
 
@@ -166,7 +171,7 @@ Inserting some sample data:
 INSERT INTO events SELECT * FROM generateRandom() LIMIT 100000;
 ```
 
-### Using `_part_offset` as a secondary index {#normal-projection-secondary-index}
+#### Using `_part_offset` as a secondary index {#normal-projection-secondary-index}
 
 The `_part_offset` field preserves its value through merges and mutations, making it valuable for secondary indexing. We can leverage this in queries:
 
@@ -182,15 +187,15 @@ WHERE _part_starting_offset + _part_offset IN (
 SETTINGS enable_shared_storage_snapshot_in_query = 1
 ```
 
-# Manipulating Projections
+## Manipulating projections
 
 The following operations with [projections](/engines/table-engines/mergetree-family/mergetree.md/#projections) are available:
 
-## ADD PROJECTION {#add-projection}
+### ADD PROJECTION {#add-projection}
 
 `ALTER TABLE [db.]name [ON CLUSTER cluster] ADD PROJECTION [IF NOT EXISTS] name ( SELECT <COLUMN LIST EXPR> [GROUP BY] [ORDER BY] ) [WITH SETTINGS ( setting_name1 = setting_value1, setting_name2 = setting_value2, ...)]` - Adds projection description to tables metadata.
 
-### `WITH SETTINGS` Clause {#with-settings}
+#### `WITH SETTINGS` Clause {#with-settings}
 
 `WITH SETTINGS` defines **projection-level settings**, which customize how the projection stores data (for example, `index_granularity` or `index_granularity_bytes`).
 These correspond directly to **MergeTree table settings**, but apply **only to this projection**.
@@ -209,15 +214,15 @@ ADD PROJECTION p (
 
 Projection settings override the effective table settings for the projection, subject to validation rules (e.g., invalid or incompatible overrides will be rejected).
 
-## DROP PROJECTION {#drop-projection}
+### DROP PROJECTION {#drop-projection}
 
 `ALTER TABLE [db.]name [ON CLUSTER cluster] DROP PROJECTION [IF EXISTS] name` - Removes projection description from tables metadata and deletes projection files from disk. Implemented as a [mutation](/sql-reference/statements/alter/index.md#mutations).
 
-## MATERIALIZE PROJECTION {#materialize-projection}
+### MATERIALIZE PROJECTION {#materialize-projection}
 
 `ALTER TABLE [db.]table [ON CLUSTER cluster] MATERIALIZE PROJECTION [IF EXISTS] name [IN PARTITION partition_name]` - The query rebuilds the projection `name` in the partition `partition_name`. Implemented as a [mutation](/sql-reference/statements/alter/index.md#mutations).
 
-## CLEAR PROJECTION {#clear-projection}
+### CLEAR PROJECTION {#clear-projection}
 
 `ALTER TABLE [db.]table [ON CLUSTER cluster] CLEAR PROJECTION [IF EXISTS] name [IN PARTITION partition_name]` - Deletes projection files from disk without removing description. Implemented as a [mutation](/sql-reference/statements/alter/index.md#mutations).
 
@@ -228,3 +233,31 @@ Also, they are replicated, syncing projections metadata via ClickHouse Keeper or
 :::note
 Projection manipulation is supported only for tables with [`*MergeTree`](/engines/table-engines/mergetree-family/mergetree.md) engine (including [replicated](/engines/table-engines/mergetree-family/replication.md) variants).
 :::
+
+### Controlling projection merge behavior {#control-projections-merges}
+
+When you execute a query, ClickHouse chooses between reading from the original table or one of its projections.
+The decision to read from the original table or one of its projections is made individually per every table part.
+ClickHouse generally aims to read as little data as possible and employs a couple of tricks to identify the best part to read from, for example, sampling the primary key of a part.
+In some cases, source table parts have no corresponding projection parts.
+This can happen, for example, because creating a projection for a table in SQL is “lazy” by default - it only affects newly inserted data but keeps existing parts unaltered.
+
+As one of the projections already contains the pre-computed aggregate values, ClickHouse tries to read from the corresponding projection parts to avoid aggregating at query runtime again. If a specific part lacks the corresponding projection part, query execution falls back to the original part.
+
+But what happens if the rows in the original table change in a non-trivial way by non-trivial data part background merges?
+For example, assume the table is stored using the `ReplacingMergeTree` table engine.
+If the same row is detected in multiple input parts during merge, only the most recent row version (from the most recently inserted part) will be kept, while all older versions will be discarded.
+
+Similarly, if the table is stored using the `AggregatingMergeTree` table engine, the merge operation may fold the same rows in the input parts (based on the primary key values) into a single row to update partial aggregation states.
+
+Before ClickHouse v24.8, projection parts either silently got out of sync with the main data, or certain operations like updates and deletes could not be run at all as the database automatically threw an exception if the table had projections.
+
+Since v24.8, a new table-level setting [`deduplicate_merge_projection_mode`](/operations/settings/merge-tree-settings#deduplicate_merge_projection_mode) controls the behavior if the aforementioned non-trivial background merge operations occur in parts of the original table.
+
+Delete mutations are another example of part merge operations that drop rows in the parts of the original table. Since v24.7, we also have a setting to control the behavior w.r.t. delete mutations triggered by lightweight deletes: [`lightweight_mutation_projection_mode`](/operations/settings/merge-tree-settings#deduplicate_merge_projection_mode).
+
+Below are the possible values for both `deduplicate_merge_projection_mode` and `lightweight_mutation_projection_mode`:
+
+- `throw` (default): An exception is thrown, preventing projection parts from going out of sync.
+- `drop`: Affected projection table parts are dropped. Queries will fall back to the original table part for affected projection parts.
+- `rebuild`: The affected projection part is rebuilt to stay consistent with data in the original table part.


### PR DESCRIPTION
From an internal user, while trying to alter a projection in Cloud they received error `ADD PROJECTION is not supported in SharedReplacingMergeTree with deduplicate_merge_projection_mode = throw` and couldn't find much context for this error.

We have a blogpost discussing https://clickhouse.com/blog/clickhouse-release-24-08#control-of-projections-during-merges so updating the projections docs here to mention this. Plus a few formatting tweaks.


### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.315`
<!-- ch-version-info:end -->