### PR TITLE
Docs: update `DeltaLake` table engine docs to show possibility to use with Azure and GCS

### DIFF
--- a/ci/jobs/scripts/check_style/aspell-ignore/en/aspell-dict.txt
+++ b/ci/jobs/scripts/check_style/aspell-ignore/en/aspell-dict.txt
@@ -2150,6 +2150,7 @@ groupnumericindexedvector
 groupuniqarray
 grpc
 grpcio
+gsutil
 gtest
 gtid
 gunzip

--- a/docs/en/engines/table-engines/integrations/deltalake.md
+++ b/docs/en/engines/table-engines/integrations/deltalake.md
@@ -131,6 +131,11 @@ INSERT INTO deltalake(id, firstname, lastname, gender, age)
 VALUES (1, 'John', 'Smith', 'M', 32);
 ```
 
+:::note
+Writing using the table engine is supported only through delta kernel.
+Writes to Azure are not yet supported.
+:::
+
 ### Data cache {#data-cache}
 
 The `DeltaLake` table engine and table function support data caching, the same as `S3`, `AzureBlobStorage`, `HDFS` storages. See ["S3 table engine"](../../../engines/table-engines/integrations/s3.md#data-cache) for more details.

--- a/docs/en/engines/table-engines/integrations/deltalake.md
+++ b/docs/en/engines/table-engines/integrations/deltalake.md
@@ -8,16 +8,24 @@ title: 'DeltaLake table engine'
 doc_type: 'reference'
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # DeltaLake table engine
 
-This engine provides an integration with existing [Delta Lake](https://github.com/delta-io/delta) tables in Amazon S3, and supports both reads and writes (from v25.10).
+This engine provides an integration with existing [Delta Lake](https://github.com/delta-io/delta) tables in S3, GCP and Azure storage and supports both reads and writes (from v25.10).
 
-## Create a table {#create-table}
+## Create a DeltaLake table {#create-table}
 
-Note that the Delta Lake table must already exist in S3, this command does not take DDL parameters to create a new table.
+To create a DeltaLake table it must already exist in S3, GCP or Azure storage. The commands below do not take DDL parameters to create a new table.
+
+<Tabs>
+<TabItem value="S3" label="S3" default>
+
+**Syntax**
 
 ```sql
-CREATE TABLE deltalake
+CREATE TABLE table_name
 ENGINE = DeltaLake(url, [aws_access_key_id, aws_secret_access_key,])
 ```
 
@@ -53,12 +61,66 @@ Using named collections:
 CREATE TABLE deltalake
 ENGINE = DeltaLake(deltalake_conf, filename = 'test_table')
 ```
+</TabItem>
 
-### Data cache {#data-cache}
+<TabItem value="GCP" label="GCP" default>
 
-The `DeltaLake` table engine and table function support data caching same as `S3`, `AzureBlobStorage`, `HDFS` storages. See [here](../../../engines/table-engines/integrations/s3.md#data-cache).
+GCS is accessed through the S3-compatible API using HMAC credentials.
 
-## Insert data {#insert-data}
+**Syntax**
+
+```sql
+-- Using HTTPS URL (recommended)
+CREATE TABLE table_name
+ENGINE = DeltaLake('https://storage.googleapis.com/<bucket>/<path>/', '<hmac_key>', '<hmac_secret>')
+
+-- Using gs:// scheme (auto-converted to HTTPS)
+CREATE TABLE table_name
+ENGINE = DeltaLake('gs://<bucket>/<path>/', '<hmac_key>', '<hmac_secret>')
+```
+
+**Arguments**
+
+- `url` — GCS bucket URL to the Delta Lake table. Must use `https://storage.googleapis.com/<bucket>/<path>/`
+   format (the GCS XML API endpoint), or `gs://<bucket>/<path>/` which is auto-converted.
+- `hmac_key` — GCS HMAC access key ID. Create via Google Cloud Console → Cloud Storage → Settings → Interoperability.
+- `hmac_secret` — GCS HMAC secret key.
+   
+</TabItem>
+
+<TabItem value="Azure" label="Azure" default>
+
+**Syntax**
+
+```sql
+-- With connection string
+CREATE TABLE table_name
+ENGINE = DeltaLake(connection_string, container_name, blobpath [, format] [, compression])
+
+-- With storage account URL and credentials
+CREATE TABLE table_name
+ENGINE = DeltaLake(storage_account_url, container_name, blobpath, account_name, account_key [,
+format] [, compression])
+
+-- With named collection (from tests)
+CREATE TABLE table_name
+ENGINE = DeltaLake(named_collection, container = 'container_name', storage_account_url = 'url',
+blob_path = '/path/')
+```
+
+**Arguments**
+
+- `connection_string` — Azure connection string
+- `storage_account_url` — Azure storage account URL (e.g., https://account.blob.core.windows.net)
+- `container_name` — Azure container name
+- `blobpath` — Path to the Delta Lake table within the container
+- `account_name` — Azure storage account name
+- `account_key` — Azure storage account key
+
+</TabItem>
+</Tabs>
+
+## Write data using a DeltaLake table {#insert-data}
 
 Once you have created a table using the DeltaLake table engine, you can insert data into it with:
 
@@ -68,6 +130,10 @@ SET allow_experimental_delta_lake_writes = 1;
 INSERT INTO deltalake(id, firstname, lastname, gender, age)
 VALUES (1, 'John', 'Smith', 'M', 32);
 ```
+
+### Data cache {#data-cache}
+
+The `DeltaLake` table engine and table function support data caching, the same as `S3`, `AzureBlobStorage`, `HDFS` storages. See ["S3 table engine"](../../../engines/table-engines/integrations/s3.md#data-cache) for more details.
 
 ## See also {#see-also}
 

--- a/docs/en/engines/table-engines/integrations/deltalake.md
+++ b/docs/en/engines/table-engines/integrations/deltalake.md
@@ -65,26 +65,38 @@ ENGINE = DeltaLake(deltalake_conf, filename = 'test_table')
 
 <TabItem value="GCP" label="GCP" default>
 
-GCS is accessed through the S3-compatible API using HMAC credentials.
-
 **Syntax**
 
 ```sql
 -- Using HTTPS URL (recommended)
 CREATE TABLE table_name
-ENGINE = DeltaLake('https://storage.googleapis.com/<bucket>/<path>/', '<hmac_key>', '<hmac_secret>')
-
--- Using gs:// scheme (auto-converted to HTTPS)
-CREATE TABLE table_name
-ENGINE = DeltaLake('gs://<bucket>/<path>/', '<hmac_key>', '<hmac_secret>')
+ENGINE = DeltaLake('https://storage.googleapis.com/<bucket>/<path>/', '<access_key_id>', '<secret_access_key>')
 ```
+
+:::note[Unsupported gsutil URI]
+gsutil URI such as `gs://clickhouse-docs-example-bucket` is not supported, please use a URL starting `https://storage.googleapis.com`
+:::
 
 **Arguments**
 
 - `url` — GCS bucket URL to the Delta Lake table. Must use `https://storage.googleapis.com/<bucket>/<path>/`
    format (the GCS XML API endpoint), or `gs://<bucket>/<path>/` which is auto-converted.
-- `hmac_key` — GCS HMAC access key ID. Create via Google Cloud Console → Cloud Storage → Settings → Interoperability.
-- `hmac_secret` — GCS HMAC secret key.
+- `access_key_id` — GCS Access Key. Create via Google Cloud Console → Cloud Storage → Settings → Interoperability.
+- `secret_access_key` — GCS Secrety.
+
+**Named collections**
+
+You can also use named collections.
+For example:
+
+```sql
+CREATE NAMED COLLECTION gcs_creds AS
+access_key_id = '<access_key>',
+secret_access_key = '<secret>';
+
+CREATE TABLE gcpDeltaLake
+ENGINE = DeltaLake(gcs_creds, url = 'https://storage.googleapis.com/<bucket>/<path>')
+```
    
 </TabItem>
 
@@ -133,7 +145,7 @@ VALUES (1, 'John', 'Smith', 'M', 32);
 
 :::note
 Writing using the table engine is supported only through delta kernel.
-Writes to Azure are not yet supported.
+Writes to Azure are not yet supported but work for S3 and GCS.
 :::
 
 ### Data cache {#data-cache}

--- a/docs/en/engines/table-engines/integrations/deltalake.md
+++ b/docs/en/engines/table-engines/integrations/deltalake.md
@@ -105,19 +105,8 @@ ENGINE = DeltaLake(gcs_creds, url = 'https://storage.googleapis.com/<bucket>/<pa
 **Syntax**
 
 ```sql
--- With connection string
 CREATE TABLE table_name
-ENGINE = DeltaLake(connection_string, container_name, blobpath [, format] [, compression])
-
--- With storage account URL and credentials
-CREATE TABLE table_name
-ENGINE = DeltaLake(storage_account_url, container_name, blobpath, account_name, account_key [,
-format] [, compression])
-
--- With named collection (from tests)
-CREATE TABLE table_name
-ENGINE = DeltaLake(named_collection, container = 'container_name', storage_account_url = 'url',
-blob_path = '/path/')
+ENGINE = DeltaLake(connection_string|storage_account_url, container_name, blobpath, [account_name, account_key, format, compression])
 ```
 
 **Arguments**

--- a/docs/en/engines/table-engines/integrations/deltalake.md
+++ b/docs/en/engines/table-engines/integrations/deltalake.md
@@ -82,7 +82,7 @@ gsutil URI such as `gs://clickhouse-docs-example-bucket` is not supported, pleas
 - `url` — GCS bucket URL to the Delta Lake table. Must use `https://storage.googleapis.com/<bucket>/<path>/`
    format (the GCS XML API endpoint), or `gs://<bucket>/<path>/` which is auto-converted.
 - `access_key_id` — GCS Access Key. Create via Google Cloud Console → Cloud Storage → Settings → Interoperability.
-- `secret_access_key` — GCS Secrety.
+- `secret_access_key` — GCS secret.
 
 **Named collections**
 


### PR DESCRIPTION
The `DeltaLake` table engine doc currently states that it only works for S3, however the table function works with Azure and GCS so I feel like this should work.

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.200`
<!-- ch-version-info:end -->