### PR TITLE
Docs: fix typo in codeblock comment

### DIFF
--- a/docs/en/sql-reference/data-types/datetime64.md
+++ b/docs/en/sql-reference/data-types/datetime64.md
@@ -39,7 +39,7 @@ CREATE TABLE dt64
     `timestamp` DateTime64(3, 'Asia/Istanbul'),
     `event_id` UInt8
 )
-ENGINE = MergeTree();
+ENGINE = MergeTree;
 ```
 
 ```sql

--- a/docs/en/sql-reference/data-types/datetime64.md
+++ b/docs/en/sql-reference/data-types/datetime64.md
@@ -31,7 +31,7 @@ Note: The precision of the maximum value is 8. If the maximum precision of 9 dig
 
 ## Examples {#examples}
 
-1. Creating a table with `DateTime64`-type column and inserting data into it:
+1. Creating a table with `DateTime64`-type column and insert data into it:
 
 ```sql
 CREATE TABLE dt64
@@ -39,15 +39,20 @@ CREATE TABLE dt64
     `timestamp` DateTime64(3, 'Asia/Istanbul'),
     `event_id` UInt8
 )
-ENGINE = TinyLog;
+ENGINE = MergeTree();
 ```
 
 ```sql
 -- Parse DateTime
--- - from integer interpreted as number of microseconds (because of precision 3) since 1970-01-01,
--- - from decimal interpreted as number of seconds before the decimal part, and based on the precision after the decimal point,
--- - from string.
-INSERT INTO dt64 VALUES (1546300800123, 1), (1546300800.123, 2), ('2019-01-01 00:00:00', 3);
+-- - from an integer interpreted as the number of milliseconds (because of precision 3) since 1970-01-01,
+-- - from a decimal interpreted as the number of seconds before the decimal part, and based on the precision after the decimal point,
+-- - from a string.
+
+INSERT INTO dt64
+VALUES
+(1546300800123, 1),
+(1546300800.123, 2),
+('2019-01-01 00:00:00', 3);
 
 SELECT * FROM dt64;
 ```


### PR DESCRIPTION
Closes https://github.com/ClickHouse/clickhouse-docs/issues/5459. The comment says "microseconds" but it should be "milliseconds"
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.285`
<!-- ch-version-info:end -->