### PR TITLE
Allow empty order by keys in special MergeTree again

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -10455,7 +10455,7 @@ size_t MergeTreeData::unloadPrimaryKeysAndClearCachesOfOutdatedParts()
     return parts_to_clear.size();
 }
 
-void MergeTreeData::verifySortingKey(const KeyDescription & sorting_key, const MergeTreeData::MergingParams & merging_params)
+void MergeTreeData::verifySortingKey(const KeyDescription & sorting_key)
 {
     /// Aggregate functions already forbidden, but SimpleAggregateFunction are not
     for (const auto & data_type : sorting_key.data_types)
@@ -10463,9 +10463,6 @@ void MergeTreeData::verifySortingKey(const KeyDescription & sorting_key, const M
         if (dynamic_cast<const DataTypeCustomSimpleAggregateFunction *>(data_type->getCustomName()))
             throw Exception(ErrorCodes::DATA_TYPE_CANNOT_BE_USED_IN_KEY, "Column with type {} is not allowed in key expression", data_type->getCustomName()->getName());
     }
-
-    if (sorting_key.data_types.empty() && merging_params.mode != MergingParams::Mode::Ordinary)
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Sorting key cannot be empty for MergeTree table with {} merging mode", merging_params.mode);
 }
 
 size_t MergeTreeData::NamesAndTypesListHash::operator()(const NamesAndTypesList & list) const noexcept

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -964,7 +964,7 @@ public:
         AlterLockHolder & table_lock_holder);
 
     static std::pair<String, bool> getNewImplicitStatisticsTypes(const StorageInMemoryMetadata & new_metadata, const MergeTreeSettings & old_settings);
-    static void verifySortingKey(const KeyDescription & sorting_key, const MergeTreeData::MergingParams & merging_params);
+    static void verifySortingKey(const KeyDescription & sorting_key);
 
     /// Should be called if part data is suspected to be corrupted.
     /// Has the ability to check all other parts

--- a/src/Storages/MergeTree/registerStorageMergeTree.cpp
+++ b/src/Storages/MergeTree/registerStorageMergeTree.cpp
@@ -678,7 +678,7 @@ static StoragePtr create(const StorageFactory::Arguments & args)
             args.storage_def->order_by->ptr(), metadata.columns, context, merging_param_key_arg);
 
         if (!local_settings[Setting::allow_suspicious_primary_key] && args.mode <= LoadingStrictnessLevel::CREATE)
-            MergeTreeData::verifySortingKey(metadata.sorting_key, merging_params);
+            MergeTreeData::verifySortingKey(metadata.sorting_key);
 
         /// If primary key explicitly defined, than get it from AST
         if (args.storage_def->primary_key)
@@ -806,7 +806,7 @@ static StoragePtr create(const StorageFactory::Arguments & args)
             = KeyDescription::getSortingKeyFromAST(engine_args[arg_num], metadata.columns, context, merging_param_key_arg);
 
         if (!local_settings[Setting::allow_suspicious_primary_key] && args.mode <= LoadingStrictnessLevel::CREATE)
-            MergeTreeData::verifySortingKey(metadata.sorting_key, merging_params);
+            MergeTreeData::verifySortingKey(metadata.sorting_key);
 
         /// In old syntax primary_key always equals to sorting key.
         metadata.primary_key = KeyDescription::getKeyFromAST(engine_args[arg_num], metadata.columns, context);

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -419,7 +419,7 @@ void StorageMergeTree::alter(
     addImplicitStatistics(new_metadata.columns, auto_statistics_types);
 
     if (!query_settings[Setting::allow_suspicious_primary_key])
-        MergeTreeData::verifySortingKey(new_metadata.sorting_key, merging_params);
+        MergeTreeData::verifySortingKey(new_metadata.sorting_key);
 
     /// This alter can be performed at new_metadata level only
     if (commands.isSettingsAlter())

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -6547,7 +6547,7 @@ void StorageReplicatedMergeTree::alter(
 
     if (!query_settings[Setting::allow_suspicious_primary_key])
     {
-        MergeTreeData::verifySortingKey(future_metadata.sorting_key, merging_params);
+        MergeTreeData::verifySortingKey(future_metadata.sorting_key);
     }
 
     {

--- a/tests/integration/test_parallel_replicas_protocol/test.py
+++ b/tests/integration/test_parallel_replicas_protocol/test.py
@@ -84,7 +84,6 @@ def test_final_on_parallel_replicas(start_cluster):
     nodes[0].query("DROP TABLE IF EXISTS t0")
     nodes[0].query(
         "CREATE TABLE t0 (c0 Int) ENGINE = SummingMergeTree() ORDER BY tuple()",
-        settings={"allow_suspicious_primary_key": 1},
     )
     nodes[0].query("INSERT INTO t0 VALUES (1)")
     nodes[0].query("OPTIMIZE TABLE t0 FINAL")

--- a/tests/queries/0_stateless/00578_merge_trees_without_primary_key.sql
+++ b/tests/queries/0_stateless/00578_merge_trees_without_primary_key.sql
@@ -13,7 +13,6 @@ SELECT * FROM unsorted;
 
 DROP TABLE unsorted;
 
-SET allow_suspicious_primary_key = 1;
 SELECT '*** ReplacingMergeTree ***';
 
 DROP TABLE IF EXISTS unsorted_replacing;

--- a/tests/queries/0_stateless/00752_low_cardinality_mv_1.sql
+++ b/tests/queries/0_stateless/00752_low_cardinality_mv_1.sql
@@ -5,7 +5,6 @@ create table lc_00752 (str LowCardinality(String)) engine = MergeTree order by t
 
 insert into lc_00752 values ('a'), ('bbb'), ('ab'), ('accccc'), ('baasddas'), ('bcde');
 
-SET allow_suspicious_primary_key = 1;
 CREATE MATERIALIZED VIEW lc_mv_00752 ENGINE = AggregatingMergeTree() ORDER BY tuple() populate AS SELECT substring(str, 1, 1) as letter, min(length(str)) AS min_len, max(length(str)) AS max_len FROM lc_00752 GROUP BY substring(str, 1, 1);
 
 insert into lc_00752 values ('a'), ('bbb'), ('ab'), ('accccc'), ('baasddas'), ('bcde');

--- a/tests/queries/0_stateless/02177_sum_if_not_found.sql
+++ b/tests/queries/0_stateless/02177_sum_if_not_found.sql
@@ -22,8 +22,6 @@ SELECT
 FROM data
 GROUP BY t; -- { serverError UNKNOWN_FUNCTION}
 
-SET allow_suspicious_primary_key = 1;
-
 CREATE TABLE agg
 ENGINE = AggregatingMergeTree
 ORDER BY tuple() AS

--- a/tests/queries/0_stateless/02995_preliminary_filters_duplicated_columns.sql
+++ b/tests/queries/0_stateless/02995_preliminary_filters_duplicated_columns.sql
@@ -1,5 +1,4 @@
 -- It is special because actions cannot be reused for SimpleAggregateFunction (see https://github.com/ClickHouse/ClickHouse/pull/54436)
-SET allow_suspicious_primary_key = 1;
 drop table if exists data;
 create table data (key Int) engine=AggregatingMergeTree() order by tuple();
 insert into data values (0);

--- a/tests/queries/0_stateless/02995_preliminary_filters_duplicated_columns_SimpleAggregateFunction.sql
+++ b/tests/queries/0_stateless/02995_preliminary_filters_duplicated_columns_SimpleAggregateFunction.sql
@@ -1,5 +1,4 @@
 -- It is special because actions cannot be reused for SimpleAggregateFunction (see https://github.com/ClickHouse/ClickHouse/pull/54436)
-set allow_suspicious_primary_key = 1;
 drop table if exists data;
 create table data (key SimpleAggregateFunction(max, Int)) engine=AggregatingMergeTree() order by tuple();
 insert into data values (0);

--- a/tests/queries/0_stateless/03210_optimize_rewrite_aggregate_function_with_if_return_type_bug.sql
+++ b/tests/queries/0_stateless/03210_optimize_rewrite_aggregate_function_with_if_return_type_bug.sql
@@ -1,5 +1,4 @@
 SET enable_analyzer = 1;
-SET allow_suspicious_primary_key = 1;
 
 -- For function count, rewrite countState to countStateIf changes the type from AggregateFunction(count, Nullable(UInt64)) to AggregateFunction(count, UInt64)
 -- We can cast AggregateFunction(count, UInt64) back to AggregateFunction(count, Nullable(UInt64)) with additional _CAST

--- a/tests/queries/0_stateless/03230_subcolumns_mv.sql
+++ b/tests/queries/0_stateless/03230_subcolumns_mv.sql
@@ -3,7 +3,6 @@ DROP TABLE IF EXISTS raw_to_attributes_mv;
 DROP TABLE IF EXISTS attributes;
 
 SET optimize_functions_to_subcolumns = 1;
-SET allow_suspicious_primary_key = 1;
 
 CREATE TABLE rawtable
 (

--- a/tests/queries/0_stateless/03261_sort_cursor_crash.sql
+++ b/tests/queries/0_stateless/03261_sort_cursor_crash.sql
@@ -3,8 +3,6 @@
 DROP TABLE IF EXISTS t0;
 DROP TABLE IF EXISTS t1;
 
-SET allow_suspicious_primary_key = 1;
-
 CREATE TABLE t0 (c0 Int) ENGINE = AggregatingMergeTree() ORDER BY tuple();
 INSERT INTO TABLE t0 (c0) VALUES (1);
 SELECT 42 FROM t0 FINAL PREWHERE t0.c0 = 1;

--- a/tests/queries/0_stateless/03291_collapsing_invalid_sign.sql
+++ b/tests/queries/0_stateless/03291_collapsing_invalid_sign.sql
@@ -1,5 +1,4 @@
 SET send_logs_level = 'fatal';
-SET allow_suspicious_primary_key = 1;
 
 DROP TABLE IF EXISTS t_03291_collapsing_invalid_sign;
 

--- a/tests/queries/0_stateless/03325_count_summing_merge_tree_order_by_tuple.sql
+++ b/tests/queries/0_stateless/03325_count_summing_merge_tree_order_by_tuple.sql
@@ -1,5 +1,4 @@
 SET enable_analyzer = 1;
-SET allow_suspicious_primary_key = 1;
 
 CREATE TABLE t0 (c0 Nullable(Int)) ENGINE = SummingMergeTree() ORDER BY tuple() PARTITION BY (c0) SETTINGS allow_nullable_key = 1;
 INSERT INTO TABLE t0 (c0) VALUES (NULL);

--- a/tests/queries/0_stateless/03411_summing_merge_tree_dynamic_values.sql
+++ b/tests/queries/0_stateless/03411_summing_merge_tree_dynamic_values.sql
@@ -1,5 +1,4 @@
 DROP TABLE IF EXISTS t0;
-SET allow_suspicious_primary_key = 1;
 CREATE TABLE t0 (c0 Dynamic) ENGINE = SummingMergeTree() ORDER BY tuple();
 INSERT INTO TABLE t0 (c0) VALUES ('a'::Enum('a' = 1)), (2);
 SELECT c0 FROM t0 FINAL;

--- a/tests/queries/0_stateless/03463_numeric_indexed_vector_overflow.sql
+++ b/tests/queries/0_stateless/03463_numeric_indexed_vector_overflow.sql
@@ -49,8 +49,6 @@ SELECT numericIndexedVectorToMap(numericIndexedVectorPointwiseGreaterEqual(vec_1
 
 DROP TABLE uin_value_details;
 
-SET allow_suspicious_primary_key = 1;
-
 -- https://github.com/ClickHouse/ClickHouse/issues/82239
 SELECT 'Test with NaN, INFs and Nulls' AS test;
 

--- a/tests/queries/0_stateless/03532_dynamic_flattened_serialization_bug.sql
+++ b/tests/queries/0_stateless/03532_dynamic_flattened_serialization_bug.sql
@@ -1,7 +1,6 @@
 -- Tags: no-fasttest
 
 SET type_json_skip_duplicated_paths=1;
-SET allow_suspicious_primary_key=1;
 
 DROP TABLE IF EXISTS t0;
 CREATE TABLE t0 (c0 Variant(Int,JSON(max_dynamic_paths=3, max_dynamic_types=13))) ENGINE = SummingMergeTree() ORDER BY tuple();

--- a/tests/queries/0_stateless/03551_no_alter_for_columns_to_sum.sql
+++ b/tests/queries/0_stateless/03551_no_alter_for_columns_to_sum.sql
@@ -1,5 +1,4 @@
 DROP TABLE IF EXISTS t0;
-SET allow_suspicious_primary_key = 1;
 CREATE TABLE t0 (c0 Int) ENGINE = SummingMergeTree((c0)) ORDER BY tuple();
 ALTER TABLE t0 RENAME COLUMN c0 TO c1; -- { serverError ALTER_OF_COLUMN_IS_FORBIDDEN }
 DROP TABLE t0;

--- a/tests/queries/0_stateless/03562_parallel_replicas_subquery_has_final.sql
+++ b/tests/queries/0_stateless/03562_parallel_replicas_subquery_has_final.sql
@@ -1,5 +1,3 @@
-SET allow_suspicious_primary_key = 1;
-
 CREATE OR REPLACE TABLE t0 (c0 Int) ENGINE = SummingMergeTree() ORDER BY tuple();
 INSERT INTO t0 VALUES (1);
 

--- a/tests/queries/0_stateless/03594_coalescing_merge_tree_segfault.sql
+++ b/tests/queries/0_stateless/03594_coalescing_merge_tree_segfault.sql
@@ -1,4 +1,3 @@
-SET allow_suspicious_primary_key = 1;
 CREATE TABLE t0 (c0 String) ENGINE = CoalescingMergeTree() ORDER BY tuple();
 INSERT INTO TABLE t0 (c0) VALUES ('playl哪国人[]美国认识你很高兴');
 SELECT * FROM t0;

--- a/tests/queries/0_stateless/03652_coalescing_merge_tree_fix_empty_tuple.sql
+++ b/tests/queries/0_stateless/03652_coalescing_merge_tree_fix_empty_tuple.sql
@@ -1,5 +1,3 @@
-SET allow_suspicious_primary_key = 1;
-
 DROP TABLE IF EXISTS t0;
 
 CREATE TABLE t0 (c0 Tuple(a Int32, b Nullable(Int32)), c1 Int32) ENGINE = SummingMergeTree() ORDER BY c1;

--- a/tests/queries/0_stateless/03751_summing_coalescing_merge_tree_sparse_columns_in_header.sql
+++ b/tests/queries/0_stateless/03751_summing_coalescing_merge_tree_sparse_columns_in_header.sql
@@ -1,4 +1,3 @@
-set allow_suspicious_primary_key = 1;
 drop table if exists src;
 create table src (x UInt64) engine=MergeTree order by tuple();
 insert into src select 0 from numbers(1000000);


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes #96045.
Partially reverts #91569.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.325`
- Backported to: `26.1.3.27`, `25.12.6.15`
<!-- ch-version-info:end -->