### PR TITLE
Fix data file bounds parsing in Iceberg manifest file for position delete

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFile.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFile.cpp
@@ -475,7 +475,6 @@ ManifestFileContent::ManifestFileContent(
                         it != value_for_bounds.end())
                     {
                         auto & [lower, upper] = it->second;
-                        bounds_set_by_referenced_data_file = true;
                         if (!lower.isNull())
                             lower_reference_data_file_path = lower.safeGet<String>();
                         if (!upper.isNull())

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFile.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFile.cpp
@@ -482,10 +482,6 @@ ManifestFileContent::ManifestFileContent(
                             upper_reference_data_file_path = upper.safeGet<String>();
                     }
                 }
-                if (!bounds_set_by_referenced_data_file)
-                {
-                    throw Exception(ErrorCodes::ICEBERG_SPECIFICATION_VIOLATION, "Bounds are not set for position delete file entry");
-                }
                 this->position_deletes_files_without_deleted.emplace_back(
                     std::make_shared<ManifestFileEntry>(
                         file_path_key,

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFile.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFile.cpp
@@ -346,6 +346,11 @@ ManifestFileContent::ManifestFileContent(
                     Int32 number = static_cast<Int32>(column_number_and_bound[0].safeGet<Int32>());
                     const Field & bound_value = column_number_and_bound[1];
 
+                    if (!value_for_bounds.contains(number))
+                    {
+                        value_for_bounds[number] = std::make_pair(Field{}, Field{});
+                    }
+
                     if (path == c_data_file_lower_bounds)
                         value_for_bounds[number].first = bound_value;
                     else
@@ -453,6 +458,7 @@ ManifestFileContent::ManifestFileContent(
                 /// reference_file_path can be absent in schema for some reason, though it is present in specification: https://iceberg.apache.org/spec/#manifests
                 std::optional<String> lower_reference_data_file_path = std::nullopt;
                 std::optional<String> upper_reference_data_file_path = std::nullopt;
+                bool bounds_set_by_referenced_data_file = false;
                 if (manifest_file_deserializer.hasPath(c_data_file_referenced_data_file))
                 {
                     Field reference_file_path_field = manifest_file_deserializer.getValueFromRowByName(i, c_data_file_referenced_data_file);
@@ -460,14 +466,25 @@ ManifestFileContent::ManifestFileContent(
                     {
                         lower_reference_data_file_path = reference_file_path_field.safeGet<String>();
                         upper_reference_data_file_path = reference_file_path_field.safeGet<String>();
+                        bounds_set_by_referenced_data_file = true;
                     }
                 }
-                else if (auto it = value_for_bounds.find(IcebergPositionDeleteTransform::data_file_path_column_field_id);
-                         it != value_for_bounds.end())
+                if (!bounds_set_by_referenced_data_file)
                 {
-                    auto & [lower, upper] = it->second;
-                    lower_reference_data_file_path = lower.safeGet<String>();
-                    upper_reference_data_file_path = upper.safeGet<String>();
+                    if (auto it = value_for_bounds.find(IcebergPositionDeleteTransform::data_file_path_column_field_id);
+                        it != value_for_bounds.end())
+                    {
+                        auto & [lower, upper] = it->second;
+                        bounds_set_by_referenced_data_file = true;
+                        if (!lower.isNull())
+                            lower_reference_data_file_path = lower.safeGet<String>();
+                        if (!upper.isNull())
+                            upper_reference_data_file_path = upper.safeGet<String>();
+                    }
+                }
+                if (!bounds_set_by_referenced_data_file)
+                {
+                    throw Exception(ErrorCodes::ICEBERG_SPECIFICATION_VIOLATION, "Bounds are not set for position delete file entry");
                 }
                 this->position_deletes_files_without_deleted.emplace_back(
                     std::make_shared<ManifestFileEntry>(


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Earlier if reference data file inside iceberg manifest file for position delete was present in an entry but was null, we didn't get correct bounds for a corresponding data files. This PR fixes this bug.

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.311`
- Backported to: `26.1.3.18`
<!-- ch-version-info:end -->