### PR TITLE
CI: Fix stress test log parser crash on unexpected log format

### DIFF
--- a/ci/jobs/scripts/log_parser.py
+++ b/ci/jobs/scripts/log_parser.py
@@ -444,13 +444,7 @@ class FuzzerLogParser:
         assert failure_output, "No failure found in server log"
         failure_first_line = failure_output.splitlines()[0]
         assert failure_first_line, "No failure first line found in server log"
-        try:
-            query_id = failure_first_line.split(" ] {")[1].split("}")[0]
-        except IndexError:
-            print(
-                f"ERROR: Could not extract query_id from failure line: {failure_first_line[:200]}"
-            )
-            return None
+        query_id = failure_first_line.split(" ] {")[1].split("}")[0]
         if not query_id:
             print("ERROR: Query id not found")
             return None

--- a/ci/jobs/scripts/log_parser.py
+++ b/ci/jobs/scripts/log_parser.py
@@ -433,13 +433,24 @@ class FuzzerLogParser:
         if not failure_output:
             return None
         if "Inconsistent AST formatting: the query:" in failure_output:
-            query_command = failure_output.splitlines()[1]
-            return query_command
+            lines = failure_output.splitlines()
+            if len(lines) > 1:
+                query_command = lines[1]
+                return query_command
+            else:
+                print("ERROR: Expected query on second line but not found")
+                return None
 
         assert failure_output, "No failure found in server log"
         failure_first_line = failure_output.splitlines()[0]
         assert failure_first_line, "No failure first line found in server log"
-        query_id = failure_first_line.split(" ] {")[1].split("}")[0]
+        try:
+            query_id = failure_first_line.split(" ] {")[1].split("}")[0]
+        except IndexError:
+            print(
+                f"ERROR: Could not extract query_id from failure line: {failure_first_line[:200]}"
+            )
+            return None
         if not query_id:
             print("ERROR: Query id not found")
             return None

--- a/ci/jobs/stress_job.py
+++ b/ci/jobs/stress_job.py
@@ -235,15 +235,27 @@ def run_stress_test(upgrade_check: bool = False) -> None:
                 stderr_log=stderr_log if stderr_log.exists() else "",
                 fuzzer_log="",
             )
-            name, description, files = log_parser.parse_failure()
-            failed_results.append(
-                Result.create_from(
-                    name=name,
-                    info=description,
-                    status=Result.StatusExtended.FAIL,
-                    files=files,
+            try:
+                name, description, files = log_parser.parse_failure()
+                failed_results.append(
+                    Result.create_from(
+                        name=name,
+                        info=description,
+                        status=Result.StatusExtended.FAIL,
+                        files=files,
+                    )
                 )
-            )
+            except Exception as e:
+                print(
+                    f"ERROR: Failed to parse failure logs: {e}\nServer logs should still be collected."
+                )
+                failed_results.append(
+                    Result.create_from(
+                        name="Parse failure error",
+                        info=f"Error parsing failure logs: {e}",
+                        status=Result.Status.FAILED,
+                    )
+                )
 
     if exit_code != 0:
         failed_results.append(


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


## Summary

Added error handling to stress test log parser to prevent ungraceful termination when encountering unexpected log formats.

## Problem

The stress test log parser crashed with `IndexError` when parsing failure logs that don't match the expected format. This prevented collection of server logs, making it impossible to debug the original failure.

Example from PR #95945:
```
File "ci/jobs/scripts/log_parser.py", line 442, in get_failed_query
  query_id = failure_first_line.split(" ] {")[1].split("}")[0]
IndexError: list index out of range
```

## Changes

1. `ci/jobs/scripts/log_parser.py`: Added try-catch around query_id extraction and bounds checking
2. `ci/jobs/stress_job.py`: Wrapped `parse_failure()` call in exception handler

Now when unexpected log formats are encountered:
- Parser logs clear error message showing the problematic line
- Test continues and collects all server logs
- Test is marked as failed with meaningful error description



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.293`
<!-- ch-version-info:end -->