### PR TITLE
Add valid_until to system.users

### DIFF
--- a/tests/integration/test_user_valid_until/test.py
+++ b/tests/integration/test_user_valid_until/test.py
@@ -30,6 +30,7 @@ def test_basic(started_cluster):
         == "CREATE USER user_basic IDENTIFIED WITH no_password\n"
     )
     assert node.query("SELECT 1", user="user_basic") == "1\n"
+    assert node.query("SELECT valid_until FROM system.users WHERE name = 'user_basic'") == "['1970-01-01 00:00:00']\n"
 
     # 2. With valid VALID UNTIL
     node.query("ALTER USER user_basic VALID UNTIL '06/11/2040 08:03:20 Z+3'")
@@ -39,7 +40,7 @@ def test_basic(started_cluster):
         == "CREATE USER user_basic IDENTIFIED WITH no_password VALID UNTIL \\'2040-11-06 05:03:20\\'\n"
     )
     assert node.query("SELECT 1", user="user_basic") == "1\n"
-
+    assert node.query("SELECT valid_until FROM system.users WHERE name = 'user_basic'") == "['2040-11-06 05:03:20']\n"
     # 3. With expired VALID UNTIL
     node.query("ALTER USER user_basic VALID UNTIL '06/11/2010 08:03:20 Z+3'")
 

--- a/tests/queries/0_stateless/02117_show_create_table_system.reference
+++ b/tests/queries/0_stateless/02117_show_create_table_system.reference
@@ -1199,6 +1199,7 @@ CREATE TABLE system.users
     `storage` String,
     `auth_type` Array(Enum8('no_password' = 0, 'plaintext_password' = 1, 'sha256_password' = 2, 'double_sha1_password' = 3, 'ldap' = 4, 'kerberos' = 5, 'ssl_certificate' = 6, 'bcrypt_password' = 7, 'ssh_key' = 8, 'http' = 9, 'jwt' = 10, 'scram_sha256_password' = 11, 'no_authentication' = 12)),
     `auth_params` Array(String),
+    `valid_until` Array(DateTime),
     `host_ip` Array(String),
     `host_names` Array(String),
     `host_names_regexp` Array(String),


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add valid_until to `system.users` table.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.328`
<!-- ch-version-info:end -->