### PR TITLE
Add support for with_data Keeper extension to improve tables fetching in Database Replicated

### DIFF
--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -1826,6 +1826,31 @@ std::map<String, String> DatabaseReplicated::getConsistentMetadataSnapshotImpl(
     UInt32 & max_log_ptr) const
 {
     std::map<String, String> table_name_to_metadata;
+
+    if (zookeeper->isFeatureEnabled(KeeperFeatureFlag::FILTERED_LIST) &&
+        zookeeper->isFeatureEnabled(KeeperFeatureFlag::MULTI_READ) &&
+        zookeeper->isFeatureEnabled(KeeperFeatureFlag::LIST_WITH_STAT_AND_DATA) &&
+        !filter_by_table_name)
+    {
+        auto paths = {
+            zookeeper_path + "/metadata",
+            zookeeper_path
+        };
+
+        auto responses = zookeeper->getChildren(paths, Coordination::ListRequestType::ALL, /* with_stat = */ false, /* with_data = */ true);
+
+        for (size_t i = 0; i < responses[0].names.size(); ++i)
+            table_name_to_metadata.emplace(unescapeForFileName(responses[0].names[i]), std::move(responses[0].data[i]));
+
+        auto it = std::find(responses[1].names.begin(), responses[1].names.end(), "max_log_ptr");
+        if (it == responses[1].names.end())
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "max_log_ptr node not found in ZooKeeper path {}", zookeeper_path);
+
+        max_log_ptr = parse<UInt32>(responses[1].data[it - responses[1].names.begin()]);
+        LOG_DEBUG(log, "Got consistent metadata snapshot for log pointer {}", max_log_ptr);
+        return table_name_to_metadata;
+    }
+
     size_t iteration = 0;
     while (++iteration <= max_retries)
     {


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add support for the with_data Keeper extension to improve table fetching in Database Replicated.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.808`
<!-- ch-version-info:end -->