### PR TITLE
Revert 64 byte alignment for ProfileEvents::Counter

### DIFF
--- a/src/Common/ProfileEvents.h
+++ b/src/Common/ProfileEvents.h
@@ -23,8 +23,7 @@ namespace ProfileEvents
     using Count = size_t;
     using Increment = Int64;
 
-    /// Avoid false sharing when multiple threads increment different counters close to each other.
-    struct alignas(64) Counter : public std::atomic<Count>
+    struct Counter : public std::atomic<Count>
     {
         using std::atomic<Count>::atomic;
         /// When we should send it to system.trace_log


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Revert 64 byte alignment for ProfileEvents::Counter

With 64 byte alignment and 1144 counters (as of now) the Counters object took ~73KiB, and I saw that CachedOnDiskReadBufferFromFile eats ~90GiB of RAM because of this.

This should decrease memory usage 4x, but we need to make it even better (i.e. move should_trace somewhere else).

Note, that even though the category is `Performance Improvement` it is an opposite thing, but, we do not have `Memory Improvement`

Refs: https://github.com/ClickHouse/ClickHouse/pull/82697 (cc @alexey-milovidov @jiebinn)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.308`
<!-- ch-version-info:end -->