### PR TITLE
Use interruptible waits in DDL worker retry loops for faster shutdown

### DIFF
--- a/src/Databases/DatabaseReplicatedWorker.cpp
+++ b/src/Databases/DatabaseReplicatedWorker.cpp
@@ -8,7 +8,6 @@
 #include <Interpreters/DDLTask.h>
 #include <Interpreters/DatabaseCatalog.h>
 #include <Storages/StorageMaterializedView.h>
-#include <base/sleep.h>
 #include <Common/FailPoint.h>
 #include <Common/OpenTelemetryTraceContext.h>
 #include <Common/ZooKeeper/KeeperException.h>
@@ -125,7 +124,7 @@ bool DatabaseReplicatedDDLWorker::initializeMainThread()
         catch (...)
         {
             tryLogCurrentException(log, fmt::format("Error on initialization of {}", database->getDatabaseName()));
-            sleepForSeconds(5);
+            queue_updated_event->tryWait(5000);
         }
     }
 

--- a/src/Interpreters/DDLWorker.cpp
+++ b/src/Interpreters/DDLWorker.cpp
@@ -38,7 +38,6 @@
 #include <Common/setThreadName.h>
 
 #include <base/getFQDNOrHostName.h>
-#include <base/sleep.h>
 #include <base/sort.h>
 
 #include <memory>
@@ -1178,7 +1177,9 @@ bool DDLWorker::initializeMainThread()
         }
 
         /// Avoid busy loop when ZooKeeper is not available.
-        sleepForSeconds(5);
+        /// Use an interruptible wait so that shutdown() can wake us up immediately
+        /// instead of waiting for the full sleep duration.
+        queue_updated_event->tryWait(5000);
     }
 
     return false;
@@ -1258,7 +1259,7 @@ void DDLWorker::runMainThread()
                 LOG_ERROR(log, "Unexpected ZooKeeper error, will try to restart main thread: {}", getCurrentExceptionMessage(true));
                 reset_state();
             }
-            sleepForSeconds(1);
+            queue_updated_event->tryWait(1000);
         }
         catch (...)
         {
@@ -1283,8 +1284,9 @@ void DDLWorker::runMainThread()
 
             LOG_ERROR(log, "Unexpected error ({} times in a row), will try to restart main thread: {}", subsequent_errors_count.load(), message);
 
-            /// Sleep before retrying
-            sleepForSeconds(5);
+            /// Sleep before retrying, but use an interruptible wait
+            /// so that shutdown() can wake us up promptly.
+            queue_updated_event->tryWait(5000);
             /// Reset state after sleeping, so DatabaseReplicated::canExecuteReplicatedMetadataAlter()
             /// will have a chance even when the database got stuck in infinite retries
             reset_state();


### PR DESCRIPTION
Replace `sleepForSeconds` calls in `DDLWorker` and `DatabaseReplicatedDDLWorker` with `queue_updated_event->tryWait`.

When `shutdown` is called, it signals `queue_updated_event`, so threads sleeping in retry loops wake up immediately instead of blocking for the full delay. This speeds up server shutdown when ZooKeeper is unavailable, preventing sporadic integration test timeouts under TSan (`test_startup_without_zk` in `test_replicated_database`).

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


See https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=95995&sha=7eff1ed96faf549bcbdb3a9a38a8dfea89d70a64&name_0=PR&name_1=Integration%20tests%20%28amd_tsan%2C%204%2F6%29
https://github.com/ClickHouse/ClickHouse/pull/95995

Note: this looks like a solid improvement, but it's unlikely it will help.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.334`
<!-- ch-version-info:end -->