### PR TITLE
Fix flaky `test_server_overload` integration test

### DIFF
--- a/tests/integration/test_server_overload/configs/early_drop.xml
+++ b/tests/integration/test_server_overload/configs/early_drop.xml
@@ -1,5 +1,5 @@
 <clickhouse>
     <os_cpu_busy_time_threshold>300000</os_cpu_busy_time_threshold>
-    <min_os_cpu_wait_time_ratio_to_drop_connection>2.0</min_os_cpu_wait_time_ratio_to_drop_connection>
+    <min_os_cpu_wait_time_ratio_to_drop_connection>1.0</min_os_cpu_wait_time_ratio_to_drop_connection>
     <max_os_cpu_wait_time_ratio_to_drop_connection>6.0</max_os_cpu_wait_time_ratio_to_drop_connection>
 </clickhouse>

--- a/tests/integration/test_server_overload/test.py
+++ b/tests/integration/test_server_overload/test.py
@@ -33,15 +33,15 @@ def started_cluster():
 def test_overload(started_cluster):
     queries = []
     for i in range(4):
-        queries.append(node1.get_query_request("select * from numbers(1e18) format null", ignore_error=True, timeout=15))
+        queries.append(node1.get_query_request("select * from numbers(1e18) format null", ignore_error=True, timeout=30))
 
     def wait_for_queries():
         for query in queries:
             query.get_answer()
 
-    for i in range(30):
+    for i in range(60):
         try:
-            node1.query("select 1 settings min_os_cpu_wait_time_ratio_to_throw=2, max_os_cpu_wait_time_ratio_to_throw=6")
+            node1.query("select 1 settings min_os_cpu_wait_time_ratio_to_throw=1, max_os_cpu_wait_time_ratio_to_throw=6")
         except QueryRuntimeException as ex:
             assert "(SERVER_OVERLOADED)" in str(ex), "Only server overloaded error is expected"
             wait_for_queries() # Needed for flaky check to make sure CPU is not loaded with queries from previous runs
@@ -55,13 +55,13 @@ def test_overload(started_cluster):
 def test_drop_connections(started_cluster):
     queries = []
     for i in range(4):
-        queries.append(node2.get_query_request("select * from numbers(1e18) format null", ignore_error=True, timeout=15))
+        queries.append(node2.get_query_request("select * from numbers(1e18) format null", ignore_error=True, timeout=30))
 
     def wait_for_queries():
         for query in queries:
             query.get_answer()
 
-    for i in range(30):
+    for i in range(60):
         try:
             node2.query("select 1")
         except QueryRuntimeException as ex:


### PR DESCRIPTION
`getCPUOverload` computes the CPU wait/busy ratio cumulatively since server startup (never resets). Startup and idle CPU time dilutes the overload signal, so it takes many seconds for the ratio to reach the `min_os_cpu_wait_time_ratio_to_drop_connection` threshold. With the previous threshold of 2.0 and only 30 retry iterations (9 seconds), the ratio often didn't reach the threshold in time, or too few qualifying attempts remained for the probabilistic check to trigger.

Lower `min_os_cpu_wait_time_ratio_to_drop_connection` from 2.0 to 1.0 so the probability curve starts earlier. Increase retry iterations from 30 to 60 and heavy query timeout from 15 to 30 seconds for both tests.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


See https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96012&sha=afe59262176650cd4a78ad8c5d2334344874c23e&name_0=PR&name_1=Integration%20tests%20%28amd_binary%2C%204%2F5%29
https://github.com/ClickHouse/ClickHouse/pull/96012

This only increases the probability. If it won't help, we will just remove the test.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.288`
<!-- ch-version-info:end -->