### PR TITLE
Add retries with exponential backoff for GitHub API calls

### DIFF
--- a/ci/jobs/scripts/check_ci.py
+++ b/ci/jobs/scripts/check_ci.py
@@ -796,7 +796,6 @@ def main():
                 f"gh pr ready {pr_number} --repo ClickHouse/ClickHouse",
                 strict=True,
                 verbose=True,
-                retries=5,
             )
         else:
             sys.exit(0)
@@ -806,7 +805,7 @@ def main():
         mergeable_check_status, sha=head_sha
     )
 
-    if Shell.check(f"gh pr merge {pr_number} --auto --repo ClickHouse/ClickHouse", retries=5):
+    if Shell.check(f"gh pr merge {pr_number} --auto --repo ClickHouse/ClickHouse"):
         # Check if PR was successfully added to the merge queue
         # uncomment/fix if GH misses became regular
         # merge_status = Shell.check(

--- a/ci/jobs/scripts/check_ci.py
+++ b/ci/jobs/scripts/check_ci.py
@@ -796,6 +796,7 @@ def main():
                 f"gh pr ready {pr_number} --repo ClickHouse/ClickHouse",
                 strict=True,
                 verbose=True,
+                retries=5,
             )
         else:
             sys.exit(0)
@@ -805,7 +806,7 @@ def main():
         mergeable_check_status, sha=head_sha
     )
 
-    if Shell.check(f"gh pr merge {pr_number} --auto --repo ClickHouse/ClickHouse"):
+    if Shell.check(f"gh pr merge {pr_number} --auto --repo ClickHouse/ClickHouse", retries=5):
         # Check if PR was successfully added to the merge queue
         # uncomment/fix if GH misses became regular
         # merge_status = Shell.check(

--- a/ci/jobs/scripts/workflow_hooks/merge_sync_pr.py
+++ b/ci/jobs/scripts/workflow_hooks/merge_sync_pr.py
@@ -22,13 +22,15 @@ def check():
         return
 
     if not Shell.check(
-        f"gh pr ready {sync_pr_number} --repo {SYNC_REPO}", verbose=True
+        f"gh pr ready {sync_pr_number} --repo {SYNC_REPO}", verbose=True, retries=5
     ):
         print("WARNING: Failed to set Sync PR as ready")
         return
 
     if not Shell.check(
-        f"gh pr merge {sync_pr_number} --repo {SYNC_REPO} --merge", verbose=True
+        f"gh pr merge {sync_pr_number} --repo {SYNC_REPO} --merge",
+        verbose=True,
+        retries=5,
     ):
         print("WARNING: Failed to merge Sync PR")
         return

--- a/ci/jobs/scripts/workflow_hooks/pr_labels_and_category.py
+++ b/ci/jobs/scripts/workflow_hooks/pr_labels_and_category.py
@@ -176,7 +176,7 @@ def check_labels(category, info):
             info.dump()
 
     if pr_labels_to_remove or pr_labels_to_add:
-        Shell.check(cmd, verbose=True, strict=True)
+        Shell.check(cmd, verbose=True, strict=True, retries=5)
 
 
 if __name__ == "__main__":

--- a/ci/praktika/gh.py
+++ b/ci/praktika/gh.py
@@ -130,7 +130,8 @@ class GH:
                 break
             if not res:
                 retry_count += 1
-                time.sleep(5)
+                delay = min(2 ** (retry_count + 1), 60)
+                time.sleep(delay)
 
         if not res:
             print(

--- a/ci/praktika/utils.py
+++ b/ci/praktika/utils.py
@@ -391,12 +391,8 @@ class Shell:
                             print(
                                 f"ERROR: command failed, exit code: {proc.returncode}, retry: {retry+1}/{retries}"
                             )
-                        if retry < retries - 1:
-                            delay = min(2 ** (retry + 1), 60)
-                            print(f"Retrying in {delay}s...")
-                            time.sleep(delay)
+                        should_retry = not retry_errors
                         if retry_errors:
-                            should_retry = False
                             for err in retry_errors:
                                 if any(err in err_line for err_line in err_output):
                                     print(
@@ -409,6 +405,10 @@ class Shell:
                                     f"No retryable errors found, stopping retry attempts"
                                 )
                                 break
+                        if should_retry and retry < retries - 1:
+                            delay = min(2 ** (retry + 1), 60)
+                            print(f"Retrying in {delay}s...")
+                            time.sleep(delay)
             except Exception as e:
                 if verbose:
                     print(

--- a/ci/praktika/utils.py
+++ b/ci/praktika/utils.py
@@ -391,6 +391,10 @@ class Shell:
                             print(
                                 f"ERROR: command failed, exit code: {proc.returncode}, retry: {retry+1}/{retries}"
                             )
+                        if retry < retries - 1:
+                            delay = min(2 ** (retry + 1), 60)
+                            print(f"Retrying in {delay}s...")
+                            time.sleep(delay)
                         if retry_errors:
                             should_retry = False
                             for err in retry_errors:

--- a/src/Client/BuzzHouse/Generator/QueryOracle.cpp
+++ b/src/Client/BuzzHouse/Generator/QueryOracle.cpp
@@ -951,7 +951,7 @@ void QueryOracle::truncatePeerTables(const StatementGenerator & gen)
     for (const auto & entry : found_tables)
     {
         /// First truncate tables
-        other_steps_sucess &= gen.connections.truncatePeerTableOnRemote(gen.tables.at(entry));
+        other_steps_success &= gen.connections.truncatePeerTableOnRemote(gen.tables.at(entry));
     }
 }
 
@@ -962,10 +962,10 @@ void QueryOracle::optimizePeerTables(const StatementGenerator & gen)
         /// Lastly optimize tables
         const auto & ntable = gen.tables.at(entry);
 
-        other_steps_sucess &= gen.connections.optimizeTableForOracle(PeerTableDatabase::ClickHouse, ntable);
+        other_steps_success &= gen.connections.optimizeTableForOracle(PeerTableDatabase::ClickHouse, ntable);
         if (measure_performance)
         {
-            other_steps_sucess &= gen.connections.optimizeTableForOracle(PeerTableDatabase::None, ntable);
+            other_steps_success &= gen.connections.optimizeTableForOracle(PeerTableDatabase::None, ntable);
         }
     }
 }
@@ -1085,7 +1085,7 @@ void QueryOracle::resetOracleValues()
     compare_explain = false;
     measure_performance = false;
     first_errcode = 0;
-    other_steps_sucess = true;
+    other_steps_success = true;
     can_test_oracle_result = fc.compare_success_results;
     nrows = 0;
     res1 = PerformanceResult();
@@ -1094,7 +1094,7 @@ void QueryOracle::resetOracleValues()
 
 void QueryOracle::setIntermediateStepSuccess(const bool success)
 {
-    other_steps_sucess &= success;
+    other_steps_success &= success;
 }
 
 void QueryOracle::processFirstOracleQueryResult(const int errcode, ExternalIntegrations & ei)
@@ -1105,7 +1105,7 @@ void QueryOracle::processFirstOracleQueryResult(const int errcode, ExternalInteg
         {
             if (measure_performance)
             {
-                other_steps_sucess &= ei.getPerformanceMetricsForLastQuery(PeerTableDatabase::None, this->res1);
+                other_steps_success &= ei.getPerformanceMetricsForLastQuery(PeerTableDatabase::None, this->res1);
             }
             else
             {
@@ -1118,7 +1118,7 @@ void QueryOracle::processFirstOracleQueryResult(const int errcode, ExternalInteg
 
 void QueryOracle::processSecondOracleQueryResult(const int errcode, ExternalIntegrations & ei, const String & oracle_name)
 {
-    if (other_steps_sucess && can_test_oracle_result)
+    if (other_steps_success && can_test_oracle_result)
     {
         if (((first_errcode && !errcode) || (!first_errcode && errcode))
             && !fc.oracle_ignore_error_codes.contains(static_cast<uint32_t>(first_errcode ? first_errcode : errcode)))

--- a/src/Client/BuzzHouse/Generator/QueryOracle.h
+++ b/src/Client/BuzzHouse/Generator/QueryOracle.h
@@ -40,7 +40,7 @@ private:
     int first_errcode = 0;
     uint64_t nrows = 0;
     std::uniform_int_distribution<uint64_t> rows_dist;
-    bool other_steps_sucess = true, can_test_oracle_result, measure_performance, compare_explain;
+    bool other_steps_success = true, can_test_oracle_result, measure_performance, compare_explain;
 
     std::unordered_set<uint32_t> found_tables;
     DB::Strings nsettings;

--- a/src/Processors/PingPongProcessor.cpp
+++ b/src/Processors/PingPongProcessor.cpp
@@ -118,7 +118,7 @@ bool PingPongProcessor::sendPing()
     return false;
 }
 
-bool PingPongProcessor::recievePing()
+bool PingPongProcessor::receivePing()
 {
     if (aux_in_port.hasData())
     {
@@ -147,7 +147,7 @@ IProcessor::Status PingPongProcessor::prepare()
     {
         if (!is_received)
         {
-            bool received = recievePing();
+            bool received = receivePing();
             if (!received)
             {
                 return Status::NeedData;
@@ -172,7 +172,7 @@ IProcessor::Status PingPongProcessor::prepare()
         {
             if (!is_received)
             {
-                bool received = recievePing();
+                bool received = receivePing();
                 if (!received)
                 {
                     return Status::NeedData;

--- a/src/Processors/PingPongProcessor.h
+++ b/src/Processors/PingPongProcessor.h
@@ -56,7 +56,7 @@ protected:
     };
 
     bool sendPing();
-    bool recievePing();
+    bool receivePing();
     bool canSend() const;
 
     bool isPairsFinished() const;

--- a/src/Processors/Transforms/MergeJoinTransform.cpp
+++ b/src/Processors/Transforms/MergeJoinTransform.cpp
@@ -352,7 +352,7 @@ const Chunk & FullMergeJoinCursor::getCurrent() const
 
 void FullMergeJoinCursor::setChunk(Chunk && chunk)
 {
-    chassert(!recieved_all_blocks || !chunk);
+    chassert(!received_all_blocks || !chunk);
     chassert(!isValid() || !chunk);
 
     // should match the structure of sample_block (after materialization)
@@ -392,7 +392,7 @@ void FullMergeJoinCursor::setChunk(Chunk && chunk)
 
 bool FullMergeJoinCursor::fullyCompleted() const
 {
-    return !isValid() && recieved_all_blocks;
+    return !isValid() && received_all_blocks;
 }
 
 /// clang-tidy-21 false positive, loses track during the brace-initialization of the std::array.

--- a/src/Processors/Transforms/MergeJoinTransform.h
+++ b/src/Processors/Transforms/MergeJoinTransform.h
@@ -196,7 +196,7 @@ public:
     FullMergeJoinCursor & operator=(const FullMergeJoinCursor &) = delete;
 
     bool fullyCompleted() const;
-    void setCompleted() { recieved_all_blocks = true; }
+    void setCompleted() { received_all_blocks = true; }
     const Chunk & getCurrent() const;
     void setChunk(Chunk && chunk);
 
@@ -217,7 +217,7 @@ public:
 
 private:
     Chunk current_chunk;
-    bool recieved_all_blocks = false;
+    bool received_all_blocks = false;
 
     std::vector<size_t> key_indices;
     bool is_asof = false;


### PR DESCRIPTION
GitHub GraphQL API occasionally returns transient errors like "Something went wrong while executing your query". Add retries with exponential backoff (capped at 60 seconds) to handle these:

- `Shell.run`: add backoff sleep between retries
- `GH.do_command_with_retries`: replace fixed 5s sleep with backoff
- `pr_labels_and_category.py`: retry `gh pr edit` up to 5 times
- `merge_sync_pr.py`: retry `gh pr ready`/`gh pr merge` up to 5 times

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

@maxknv, see here: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96015&sha=c71f3c4a5279f70b0f2bed0d8a8ebde3ca00ab18&name_0=PR
https://github.com/ClickHouse/ClickHouse/pull/96015


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.333`
<!-- ch-version-info:end -->