### PR TITLE
Fix Decimal to Interval conversion: catch error at type resolution time

### DIFF
--- a/src/Functions/FunctionsConversion.h
+++ b/src/Functions/FunctionsConversion.h
@@ -2138,8 +2138,8 @@ struct ConvertImpl
                 && !(std::is_same_v<DataTypeTime64, FromDataType> || std::is_same_v<DataTypeTime64, ToDataType>)
                 && (!IsDataTypeDecimalOrNumber<FromDataType> || !IsDataTypeDecimalOrNumber<ToDataType>))
             {
-                throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Illegal column {}/{} of first argument of function {}",
-                    named_from.column->getName(), typeid(FromDataType).name(), Name::name);
+                throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Illegal column {} of first argument of function {}",
+                    named_from.column->getName(), Name::name);
             }
 
             const ColVecFrom * col_from = checkAndGetColumn<ColVecFrom>(named_from.column.get());
@@ -2840,6 +2840,12 @@ public:
 
         if constexpr (std::is_same_v<ToDataType, DataTypeInterval>)
         {
+            if (isDecimal(arguments[0].type))
+                throw Exception(
+                    ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
+                    "Illegal type {} of argument of function {}",
+                    arguments[0].type->getName(), getName());
+
             return std::make_shared<DataTypeInterval>(Name::kind);
         }
         else if constexpr (to_decimal)

--- a/tests/queries/0_stateless/03399_decimal_to_interval_error.sql
+++ b/tests/queries/0_stateless/03399_decimal_to_interval_error.sql
@@ -1,0 +1,11 @@
+-- https://github.com/ClickHouse/ClickHouse/issues/75451
+-- Decimal types should produce a clear error when converting to Interval, even on empty tables.
+
+SELECT toIntervalMillisecond(CAST(1 AS Decimal(18, 3))); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT toIntervalSecond(CAST(1 AS Decimal(18, 3))); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT toIntervalMillisecond(CAST(1 AS Nullable(Decimal(18, 3)))); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+
+DROP TABLE IF EXISTS t;
+CREATE TABLE t (d Nullable(Decimal(18, 3))) ENGINE = MergeTree ORDER BY tuple();
+SELECT toIntervalMillisecond(d) FROM t; -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+DROP TABLE t;


### PR DESCRIPTION
The `toInterval*` functions (e.g. `toIntervalMillisecond`) only checked for incompatible Decimal input types at execution time inside `ConvertImpl::execute`. When a table was empty, no blocks were processed, so the function was never called and the error was silently missed.

Move the check to `getReturnTypeImplRemovedNullable` so it is caught during query analysis regardless of whether the table has data.

Also fix the error message in `ConvertImpl::execute` which included a mangled C++ type name from `typeid(FromDataType).name()` producing unreadable output like `Decimal64/N2DB15DataTypeDecimalINS_7DecimalIlEEEE`.

Closes #75451

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Note: Maybe we can implement conversion from Decimal to Interval later.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.297`
<!-- ch-version-info:end -->