### PR TITLE
Fix deadlock when dictionary with HASHED layout has circular dependency

### DIFF
--- a/tests/queries/0_stateless/03823_dictionary_circular_dep_deadlock.sql
+++ b/tests/queries/0_stateless/03823_dictionary_circular_dep_deadlock.sql
@@ -1,18 +1,13 @@
--- Tags: no-parallel
 -- Test for https://github.com/ClickHouse/ClickHouse/issues/78360
 -- A HASHED dictionary that references itself through a Merge table should not deadlock.
 -- Previously this would hang forever; now it should produce an error about circular dependency.
 
-DROP DATABASE IF EXISTS test_dict_deadlock;
-CREATE DATABASE test_dict_deadlock ENGINE = Atomic;
+CREATE TABLE t0 (c0 Int) ENGINE = Merge(currentDatabase(), 'd1');
+CREATE DICTIONARY d1 (c0 Int DEFAULT 1) PRIMARY KEY (c0) SOURCE(CLICKHOUSE(DB currentDatabase() TABLE 't0')) LAYOUT(HASHED()) LIFETIME(1);
 
-CREATE TABLE test_dict_deadlock.t0 (c0 Int) ENGINE = Merge('test_dict_deadlock', 'd1');
-CREATE DICTIONARY test_dict_deadlock.d1 (c0 Int DEFAULT 1) PRIMARY KEY (c0) SOURCE(CLICKHOUSE(DB 'test_dict_deadlock' TABLE 't0')) LAYOUT(HASHED()) LIFETIME(1);
+SELECT 1 FROM d1; -- { serverError DEADLOCK_AVOIDED }
 
-SELECT 1 FROM test_dict_deadlock.d1; -- { serverError DEADLOCK_AVOIDED }
+SYSTEM RELOAD DICTIONARY d1; -- { serverError DEADLOCK_AVOIDED }
 
-SYSTEM RELOAD DICTIONARY test_dict_deadlock.d1; -- { serverError DEADLOCK_AVOIDED }
-
-DROP DICTIONARY test_dict_deadlock.d1;
-DROP TABLE test_dict_deadlock.t0;
-DROP DATABASE test_dict_deadlock;
+DROP DICTIONARY d1;
+DROP TABLE t0;

--- a/tests/queries/0_stateless/03823_dictionary_circular_dep_deadlock.sql
+++ b/tests/queries/0_stateless/03823_dictionary_circular_dep_deadlock.sql
@@ -1,0 +1,18 @@
+-- Tags: no-parallel
+-- Test for https://github.com/ClickHouse/ClickHouse/issues/78360
+-- A HASHED dictionary that references itself through a Merge table should not deadlock.
+-- Previously this would hang forever; now it should produce an error about circular dependency.
+
+DROP DATABASE IF EXISTS test_dict_deadlock;
+CREATE DATABASE test_dict_deadlock ENGINE = Atomic;
+
+CREATE TABLE test_dict_deadlock.t0 (c0 Int) ENGINE = Merge('test_dict_deadlock', 'd1');
+CREATE DICTIONARY test_dict_deadlock.d1 (c0 Int DEFAULT 1) PRIMARY KEY (c0) SOURCE(CLICKHOUSE(DB 'test_dict_deadlock' TABLE 't0')) LAYOUT(HASHED()) LIFETIME(1);
+
+SELECT 1 FROM test_dict_deadlock.d1; -- { serverError DEADLOCK_AVOIDED }
+
+SYSTEM RELOAD DICTIONARY test_dict_deadlock.d1; -- { serverError DEADLOCK_AVOIDED }
+
+DROP DICTIONARY test_dict_deadlock.d1;
+DROP TABLE test_dict_deadlock.t0;
+DROP DATABASE test_dict_deadlock;


### PR DESCRIPTION
When a dictionary with a non-DIRECT layout (e.g., HASHED) referenced itself through a Merge table, the ExternalLoader thread would deadlock: the loader thread tried to read the dictionary it was currently loading, waiting on a condition variable that only it could signal.

Add a thread_local set tracking objects being loaded by each thread. In `doLoading`, the object name is registered before `loadSingleObject` and removed after. In `loadImpl`, before waiting on the condition variable, we check for re-entrant loading and throw `DEADLOCK_AVOIDED` instead of hanging forever.

Closes #78360

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Avoid a deadlock in dictionaries loaded when one dictionary references a Merge table that references it recursively. Closes #78360.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.335`
<!-- ch-version-info:end -->