### PR TITLE
Fix assertion in `MergeTreePrefetchedReadPool::startPrefetches`

### DIFF
--- a/src/Storages/MergeTree/MergeTreePrefetchedReadPool.cpp
+++ b/src/Storages/MergeTree/MergeTreePrefetchedReadPool.cpp
@@ -181,7 +181,9 @@ void MergeTreePrefetchedReadPool::startPrefetches()
 
     [[maybe_unused]] TaskHolder prev;
     [[maybe_unused]] const Priority highest_priority{reader_settings.read_settings.priority.value + 1};
-    assert(prefetch_queue.top().task->priority == highest_priority);
+    /// Not all tasks are necessarily prefetched: some may be skipped due to memory or prefetch count limits.
+    /// So the top of the queue may have a priority higher than `highest_priority`.
+    assert(prefetch_queue.top().task->priority >= highest_priority);
 
     while (!prefetch_queue.empty())
     {

--- a/src/Storages/MergeTree/MergeTreePrefetchedReadPool.cpp
+++ b/src/Storages/MergeTree/MergeTreePrefetchedReadPool.cpp
@@ -181,7 +181,7 @@ void MergeTreePrefetchedReadPool::startPrefetches()
 
     [[maybe_unused]] TaskHolder prev;
     [[maybe_unused]] const Priority highest_priority{reader_settings.read_settings.priority.value + 1};
-    /// Not all tasks are necessarily prefetched: some may be skipped due to memory or prefetch count limits.
+    /// Due to the difference in `estimated_memory_usage_for_single_prefetch` for different parts (column sizes might be different), it might happen that for the given thread, task number N won't fit in the prefetch memory limit, but the next task will.
     /// So the top of the queue may have a priority higher than `highest_priority`.
     assert(prefetch_queue.top().task->priority >= highest_priority);
 

--- a/tests/queries/0_stateless/03823_prefetched_read_pool_priority_assertion.sql
+++ b/tests/queries/0_stateless/03823_prefetched_read_pool_priority_assertion.sql
@@ -1,0 +1,21 @@
+-- Regression test for https://github.com/ClickHouse/ClickHouse/issues/78287
+-- The assertion in `MergeTreePrefetchedReadPool::startPrefetches` could fail
+-- when `filesystem_prefetch_max_memory_usage` is low enough that the first tasks
+-- of all threads are skipped for prefetching, so the top of the prefetch queue
+-- has a priority higher than the initial (highest) priority.
+
+DROP TABLE IF EXISTS t0;
+
+CREATE TABLE t0 (c0 Tuple(Int256, String)) ENGINE = MergeTree() ORDER BY tuple() SETTINGS min_bytes_for_wide_part = 0;
+
+SET allow_prefetched_read_pool_for_local_filesystem = 1, filesystem_prefetch_max_memory_usage = 4096, max_threads = 4;
+
+INSERT INTO TABLE t0 SELECT (number, repeat('x', number % 100 + 1)) FROM numbers(1000);
+INSERT INTO TABLE t0 SELECT (number + 1000, repeat('y', number % 200 + 1)) FROM numbers(500);
+INSERT INTO TABLE t0 SELECT (number + 2000, repeat('z', number % 50 + 1)) FROM numbers(200);
+INSERT INTO TABLE t0 SELECT (number + 3000, repeat('w', number % 150 + 1)) FROM numbers(800);
+INSERT INTO TABLE t0 SELECT (number + 4000, repeat('a', number % 300 + 1)) FROM numbers(100);
+
+SELECT * FROM t0 FORMAT Null;
+
+DROP TABLE t0;

--- a/tests/queries/0_stateless/03823_prefetched_read_pool_priority_assertion.sql
+++ b/tests/queries/0_stateless/03823_prefetched_read_pool_priority_assertion.sql
@@ -1,8 +1,4 @@
 -- Regression test for https://github.com/ClickHouse/ClickHouse/issues/78287
--- The assertion in `MergeTreePrefetchedReadPool::startPrefetches` could fail
--- when `filesystem_prefetch_max_memory_usage` is low enough that the first tasks
--- of all threads are skipped for prefetching, so the top of the prefetch queue
--- has a priority higher than the initial (highest) priority.
 
 DROP TABLE IF EXISTS t0;
 


### PR DESCRIPTION
The assertion checked that the top of `prefetch_queue` had a priority equal to `highest_priority`, but not all tasks are prefetched — some are skipped due to `filesystem_prefetch_max_memory_usage` or prefetch count limits. When the first tasks of all threads are skipped, the top of the queue has a higher priority value, violating the `==` assertion.

Closes #78287

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.350`
<!-- ch-version-info:end -->