### PR TITLE
Fix use-of-uninitialized-value in `formatDateTime`

### DIFF
--- a/tests/queries/0_stateless/03902_format_datetime_fractional_msan.reference
+++ b/tests/queries/0_stateless/03902_format_datetime_fractional_msan.reference
@@ -1,0 +1,9 @@
+January 12345678
+January 1234
+January 000000
+January 1234
+January 0
+005
+050
+005000
+00

--- a/tests/queries/0_stateless/03902_format_datetime_fractional_msan.sql
+++ b/tests/queries/0_stateless/03902_format_datetime_fractional_msan.sql
@@ -1,0 +1,18 @@
+-- Test for use-of-uninitialized-value in formatDateTime fractional second formatters.
+-- %M is a variable-width formatter, so the output buffer is not pre-filled with the template.
+-- The fractional second formatters must fully initialize their output bytes.
+
+-- mysqlFractionalSecondScaleNumDigits (formatdatetime_f_prints_scale_number_of_digits = 1)
+SELECT formatDateTime(toDateTime64('2024-01-01 12:00:00.12345678', 8, 'UTC'), '%M %f') SETTINGS formatdatetime_f_prints_scale_number_of_digits = 1;
+SELECT formatDateTime(toDateTime64('2024-01-01 12:00:00.1234', 4, 'UTC'), '%M %f') SETTINGS formatdatetime_f_prints_scale_number_of_digits = 1;
+SELECT formatDateTime(toDateTime64('2024-01-01 12:00:00', 0, 'UTC'), '%M %f') SETTINGS formatdatetime_f_prints_scale_number_of_digits = 1;
+
+-- mysqlFractionalSecondSingleZero (formatdatetime_f_prints_single_zero = 1)
+SELECT formatDateTime(toDateTime64('2024-01-01 12:00:00.1234', 4, 'UTC'), '%M %f') SETTINGS formatdatetime_f_prints_single_zero = 1;
+SELECT formatDateTime(toDateTime64('2024-01-01 12:00:00', 0, 'UTC'), '%M %f') SETTINGS formatdatetime_f_prints_single_zero = 1;
+
+-- jodaFractionOfSecond: leading zeros must be preserved (e.g. fractional_second=5, scale=3 -> "005")
+SELECT formatDateTimeInJodaSyntax(toDateTime64('2024-01-01 12:00:00.005', 3, 'UTC'), 'SSS');
+SELECT formatDateTimeInJodaSyntax(toDateTime64('2024-01-01 12:00:00.050', 3, 'UTC'), 'SSS');
+SELECT formatDateTimeInJodaSyntax(toDateTime64('2024-01-01 12:00:00.005', 3, 'UTC'), 'SSSSSS');
+SELECT formatDateTimeInJodaSyntax(toDateTime64('2024-01-01 12:00:00.005', 3, 'UTC'), 'SS');


### PR DESCRIPTION
`mysqlFractionalSecondScaleNumDigits` and `mysqlFractionalSecondSingleZero` used `dest[i-1] += fractional_second % 10` which reads the destination byte before writing. When the output buffer is not pre-filled with the template (variable-width formatters path, e.g. format string contains `%M`), this reads uninitialized memory.

Also fix `jodaFractionOfSecond` where `toString(fractional_second)` does not preserve leading zeros (e.g. fractional_second=5, scale=3 gives "5" instead of "005"), leaving the buffer partially uninitialized.

Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=172a57f2ad219399818d551a89e2d32d62f88ccf&name_0=MasterCI&name_1=Stress%20test%20%28azure%2C%20amd_msan%29

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix use-of-uninitialized-value in `formatDateTime` with non-fixed-width formatters, such as MySQL and JODA-style.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.303`
- Backported to: `26.1.3.14`, `25.12.6.11`, `25.11.9.21`, `25.8.19.15`, `25.3.15.19`
<!-- ch-version-info:end -->