### PR TITLE
Fix logical error exception in `__getScalar` with non-constant argument

### DIFF
--- a/src/Planner/PlannerActionsVisitor.cpp
+++ b/src/Planner/PlannerActionsVisitor.cpp
@@ -216,9 +216,9 @@ public:
                     const auto & argument = arguments.front();
                     chassert(argument != nullptr);
 
-                    auto * argument_node = argument->as<ConstantNode>();
-                    chassert(argument_node != nullptr);
-                    chassert(isString(argument_node->getResultType()));
+                    const auto * argument_node = argument->as<ConstantNode>();
+                    if (!argument_node || !isString(argument_node->getResultType()))
+                        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Function __getScalar is internal and should not be used directly");
 
                     result = fmt::format("__getScalar('{}'_String)", argument_node->getValue().safeGet<String>());
                     break;

--- a/tests/queries/0_stateless/03035_internal_functions_direct_call.sql
+++ b/tests/queries/0_stateless/03035_internal_functions_direct_call.sql
@@ -2,6 +2,8 @@
 -- However, we cannot completely forbid it (becasue query can came from another server, for example)
 -- Check that usage of these functions does not lead to crash or logical error
 
+SET enable_analyzer = 1;
+
 SELECT __actionName(); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
 SELECT __actionName('aaa', 'aaa', 'aaa'); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
 SELECT __actionName('aaa', '') SETTINGS enable_analyzer = 1; -- { serverError BAD_ARGUMENTS }

--- a/tests/queries/0_stateless/03035_internal_functions_direct_call.sql
+++ b/tests/queries/0_stateless/03035_internal_functions_direct_call.sql
@@ -15,6 +15,7 @@ SELECT __getScalar('aaa'); -- { serverError BAD_ARGUMENTS }
 SELECT __getScalar(); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
 SELECT __getScalar(1); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
 SELECT __getScalar(materialize('1')); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT __getScalar(concat(toNullable(materialize(1))) - NULL); -- { serverError BAD_ARGUMENTS }
 
 SELECT __scalarSubqueryResult('1');
 SELECT 'a' || __scalarSubqueryResult(a), materialize('1') as a;


### PR DESCRIPTION
The AST fuzzer found that calling `__getScalar` with a non-constant expression (e.g. `SELECT __getScalar(concat(toNullable(materialize(1))) - NULL)`) caused a logical error: `argument_node != nullptr` in `calculateActionNodeName`.

Replace the `chassert` assertions with a proper exception throw, consistent with how `__actionName` handles direct user calls.

Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=d793d33ba69913dc5224aec9643956f264fd93f1&name_0=MasterCI&name_1=AST%20fuzzer%20%28amd_ubsan%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.319`
<!-- ch-version-info:end -->