### PR TITLE
Fix logical error in `arrayWithConstant` with `FixedString` argument

### DIFF
--- a/tests/queries/0_stateless/03825_array_with_constant_fixed_string.reference
+++ b/tests/queries/0_stateless/03825_array_with_constant_fixed_string.reference
@@ -1,0 +1,1 @@
+['qwerty','qwerty']

--- a/tests/queries/0_stateless/03825_array_with_constant_fixed_string.sql
+++ b/tests/queries/0_stateless/03825_array_with_constant_fixed_string.sql
@@ -1,0 +1,3 @@
+-- Regression test: arrayWithConstant with materialized FixedString used to throw
+-- LOGICAL_ERROR due to byteSize() overhead mismatch in ColumnFixedString.
+SELECT arrayWithConstant(2, materialize(toFixedString('qwerty', 6)));


### PR DESCRIPTION
The old code had a pre-loop check comparing `byteSize()` against `byteSizeAt(0) * size()`. For `ColumnFixedString`, `byteSize()` includes a constant `sizeof(n)` overhead not reflected in `byteSizeAt`, causing a false positive `LOGICAL_ERROR` for queries like
`arrayWithConstant(2, materialize(toFixedString('qwerty', 6)))`.

Remove the broken assertion and move `element_size` computation per-row inside the loop, which also correctly handles variable-size elements.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


See https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=194eacbd328f2756b387b0899673d7eec30c26cc&name_0=MasterCI&name_1=AST%20fuzzer%20%28amd_ubsan%29&name_1=AST%20fuzzer%20%28amd_ubsan%29

Note: the code change is authored by me, only the test was generated.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.317`
<!-- ch-version-info:end -->