### PR TITLE
Fix ALTER UPDATE crash on object storage engines

### DIFF
--- a/src/Storages/ObjectStorage/StorageObjectStorageConfiguration.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorageConfiguration.h
@@ -228,8 +228,14 @@ public:
         const StorageID & /*storage_id*/,
         StorageMetadataPtr /*metadata_snapshot*/,
         std::shared_ptr<DataLake::ICatalog> /*catalog*/,
-        const std::optional<FormatSettings> & /*format_settings*/) {}
-    virtual void checkMutationIsPossible(const MutationCommands & /*commands*/) {}
+        const std::optional<FormatSettings> & /*format_settings*/)
+    {
+        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Table engine {} doesn't support mutations", getTypeName());
+    }
+    virtual void checkMutationIsPossible(const MutationCommands & /*commands*/)
+    {
+        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Table engine {} doesn't support mutations", getTypeName());
+    }
 
     virtual void checkAlterIsPossible(const AlterCommands & commands)
     {

--- a/tests/queries/0_stateless/03903_alter_update_object_storage_crash.sql
+++ b/tests/queries/0_stateless/03903_alter_update_object_storage_crash.sql
@@ -1,0 +1,16 @@
+-- Tags: no-fasttest
+
+-- Reproducer for https://github.com/ClickHouse/ClickHouse/issues/92994
+-- ALTER UPDATE on non-MergeTree engines that support prewhere (like S3 with Parquet)
+-- used to crash with a null pointer dereference in the PREWHERE optimization code.
+
+DROP TABLE IF EXISTS t_object_storage_update;
+
+CREATE TABLE t_object_storage_update (c0 Int32)
+ENGINE = S3(s3_conn, filename = 'test_03903_alter_update.parquet', format = Parquet);
+
+INSERT INTO t_object_storage_update VALUES (0);
+
+ALTER TABLE t_object_storage_update UPDATE c0 = 1 WHERE TRUE; -- { serverError NOT_IMPLEMENTED }
+
+DROP TABLE IF EXISTS t_object_storage_update;

--- a/tests/queries/0_stateless/03903_alter_update_object_storage_crash.sql
+++ b/tests/queries/0_stateless/03903_alter_update_object_storage_crash.sql
@@ -7,7 +7,7 @@
 DROP TABLE IF EXISTS t_object_storage_update;
 
 CREATE TABLE t_object_storage_update (c0 Int32)
-ENGINE = S3(s3_conn, filename = 'test_03903_alter_update.parquet', format = Parquet);
+ENGINE = S3(s3_conn, filename = currentDatabase() || '_test_03903_alter_update.parquet', format = Parquet);
 
 INSERT INTO t_object_storage_update VALUES (0);
 


### PR DESCRIPTION
`ALTER TABLE ... UPDATE` on `AzureBlobStorage`, `S3`, and other `StorageObjectStorage`-based engines caused a null pointer dereference in the PREWHERE optimization code. The `InterpreterSelectQuery` did `assert_cast<MergeTreeData::SnapshotData&>(*storage_snapshot->data)` but `storage_snapshot->data` is `nullptr` for non-MergeTree engines that support prewhere (e.g., object storage with Parquet format).

Two fixes:
- Check `storage_snapshot->data` for null before casting in the PREWHERE optimizer, preventing the crash for any non-MergeTree engine with prewhere support.
- Make base `StorageObjectStorageConfiguration::checkMutationIsPossible` and `mutate` throw `NOT_IMPLEMENTED` instead of being silent no-ops. DataLake configurations (Iceberg, Delta Lake) properly override these methods and continue to work.

Closes #92994

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Running an invalid ALTER UPDATE mutation on object storage file-like tables, such as S3 and Azure, could lead to a nullptr dereference. Closes #92994.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.324`
<!-- ch-version-info:end -->