### PR TITLE
Fix race between INSERT and DROP_RANGE causing LOGICAL_ERROR in paranoid check of covered parts.

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -8132,6 +8132,8 @@ void MergeTreeData::Transaction::rollback(DataPartsLock & lock)
     }
 
     clear();
+
+    data.preactive_parts_cv.notify_all();
 }
 
 void MergeTreeData::Transaction::clear()
@@ -8265,6 +8267,8 @@ MergeTreeData::DataPartsVector MergeTreeData::Transaction::commit(DataPartsLock 
     }
 
     clear();
+
+    data.preactive_parts_cv.notify_all();
 
     return total_covered_parts;
 }

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -1480,6 +1480,10 @@ protected:
     /// On updates shared_parts_list/shared_ranges_in_parts should be reset (will be updated in getPossiblySharedVisibleDataPartsRanges())
     mutable DB::SharedMutex data_parts_mutex;
 
+    /// Notified when parts transition out of PreActive state (via Transaction::commit or rollback).
+    /// Used by waitForPreActivePartsInRange to avoid a race between INSERT and DROP_RANGE.
+    mutable std::condition_variable_any preactive_parts_cv;
+
     DataPartsIndexes data_parts_indexes;
     DataPartsIndexes::index<TagByInfo>::type & data_parts_by_info;
     DataPartsIndexes::index<TagByStateAndInfo>::type & data_parts_by_state_and_info;

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -2708,19 +2708,60 @@ static void paranoidCheckForCoveredPartsInZooKeeper(
     if (!paranoid_check_for_covered_parts)
         return;
 
-    auto drop_range_info = MergeTreePartInfo::fromPartName(covering_part_name, format_version);
+    auto dominated_info = MergeTreePartInfo::fromPartName(covering_part_name, format_version);
+
     Strings parts_remain = zookeeper->getChildren(replica_path + "/parts");
+    Strings orphaned_parts;
     for (const auto & part_name : parts_remain)
     {
-        auto part_info = MergeTreePartInfo::fromPartName(part_name, format_version);
-        if (drop_range_info.contains(part_info))
-            throw Exception(
-                ErrorCodes::LOGICAL_ERROR,
-                "Part {} from table {} remains in ZooKeeper after DROP_RANGE {}",
-                part_name,
-                storage.getStorageID().getNameForLogs(),
-                covering_part_name);
+        auto part_info = MergeTreePartInfo::tryParsePartName(part_name, format_version);
+        if (part_info && dominated_info.contains(*part_info))
+            orphaned_parts.push_back(part_name);
     }
+
+    if (orphaned_parts.empty())
+        return;
+
+    throw Exception(ErrorCodes::LOGICAL_ERROR,
+        "Part(s) [{}] in ZooKeeper of table {} are covered by DROP_RANGE {}",
+        fmt::join(orphaned_parts, ", "),
+        storage.getStorageID().getNameForLogs(),
+        covering_part_name);
+}
+
+void StorageReplicatedMergeTree::waitForPreActivePartsInRange(const MergeTreePartInfo & drop_range) const
+{
+    /// An INSERT on the originating replica commits a part to ZooKeeper (via the ZK multi-op
+    /// in `commitPart`) before making it Active locally (via `transaction.commit`). Between these
+    /// two points the part is in PreActive state locally but already has a ZooKeeper node.
+    /// `removePartsInRangeFromWorkingSetAndGetPartsToRemoveFromZooKeeper` only queries
+    /// Active/Outdated/Deleting parts, so it would miss the PreActive part and leave its
+    /// ZooKeeper node behind.
+    ///
+    /// We wait here for any such parts to finish committing. Since `clearLockedBlockNumbersInPartition`
+    /// was called before the DROP_RANGE log entry was created, no new INSERTs can commit parts
+    /// in this range, so the wait is guaranteed to terminate.
+
+    auto has_preactive_in_range = [&]()
+    {
+        DataPartStateAndPartitionID state_with_partition{MergeTreeDataPartState::PreActive, drop_range.getPartitionId()};
+        auto begin = data_parts_by_state_and_info.lower_bound(state_with_partition);
+        auto end = data_parts_by_state_and_info.upper_bound(state_with_partition);
+
+        for (auto it = begin; it != end; ++it)
+        {
+            if (drop_range.contains((*it)->info))
+            {
+                LOG_TRACE(log, "Waiting for PreActive part {} to finish committing before DROP_RANGE",
+                          (*it)->name);
+                return true;
+            }
+        }
+        return false;
+    };
+
+    std::unique_lock lock(data_parts_mutex);
+    preactive_parts_cv.wait(lock, [&] { return !has_preactive_in_range(); });
 }
 
 void StorageReplicatedMergeTree::executeDropRange(const LogEntry & entry)
@@ -2741,6 +2782,8 @@ void StorageReplicatedMergeTree::executeDropRange(const LogEntry & entry)
         queue.removePartProducingOpsInRange(getZooKeeper(), drop_range_info, entry);
         part_check_thread.cancelRemovedPartsCheck(drop_range_info);
     }
+
+    waitForPreActivePartsInRange(drop_range_info);
 
     /// Delete the parts contained in the range to be deleted.
     /// It's important that no old parts remain (after the merge), because otherwise,
@@ -2880,6 +2923,9 @@ bool StorageReplicatedMergeTree::executeReplaceRange(LogEntry & entry)
             entry_replace.part_names_checksums.at(i),
             format_version));
     }
+
+    if (replace)
+        waitForPreActivePartsInRange(drop_range);
 
     /// What parts we should add? Or we have already added all required parts (we an replica-initializer)
     {
@@ -3199,6 +3245,9 @@ bool StorageReplicatedMergeTree::executeReplaceRange(LogEntry & entry)
 
         if (!ops.empty())
             zookeeper->multi(ops);
+
+        if (replace)
+            waitForPreActivePartsInRange(drop_range);
 
         {
             auto data_parts_lock = lockParts();

--- a/src/Storages/StorageReplicatedMergeTree.h
+++ b/src/Storages/StorageReplicatedMergeTree.h
@@ -683,6 +683,10 @@ private:
 
     void executeDropRange(const LogEntry & entry);
 
+    /// Wait for parts in PreActive state within the drop range to finish committing.
+    /// This prevents a race between a concurrent INSERT and DROP_RANGE processing.
+    void waitForPreActivePartsInRange(const MergeTreePartInfo & drop_range) const;
+
     /// Execute alter of table metadata. Set replica/metadata and replica/columns
     /// nodes in zookeeper and also changes in memory metadata.
     /// New metadata and columns values stored in entry.


### PR DESCRIPTION
This is very interesting and not easy to understand, but the explanation looks correct.
---

The `paranoidCheckForCoveredPartsInZooKeeper` assertion was failing sporadically in test `01154_move_partition_long` because a part's ZooKeeper node remained after `executeDropRange` removed all known parts from ZK.

Root cause: a race between a concurrent INSERT on the originating replica and `executeDropRange` processing on the same replica.

The sequence of events:

1. INSERT thread calls `renameTempPartAndAdd` — the part enters `data_parts` in PreActive state, then the data_parts lock is released.

2. INSERT thread executes the ZK multi-op (`commitPart`) — the part node is created in ZooKeeper under `/replicas/{replica}/parts/{part_name}`. The ephemeral block number lock is removed atomically by this multi-op.

3. `executeDropRange` runs on the same replica:
   - `removePartProducingOpsInRange` waits for currently executing queue entries, but INSERT on the originating replica bypasses the queue.
   - `removePartsInRangeFromWorkingSetAndGetPartsToRemoveFromZooKeeper` enumerates local parts filtered to Active/Outdated/Deleting states — PreActive parts are skipped.
   - `removePartsFromZooKeeperWithRetries` removes ZK nodes only for the parts it found — the INSERT's ZK node is not in the list.
   - `paranoidCheckForCoveredPartsInZooKeeper` finds the INSERT's ZK node still present — throws `LOGICAL_ERROR`.

4. INSERT thread calls `transaction.commit()` — the part transitions from PreActive to Active, but the DROP_RANGE has already completed.

`clearLockedBlockNumbersInPartition` (called before the DROP_RANGE log entry is created) cannot prevent this race: by the time it runs, the INSERT has already completed its ZK multi-op, which atomically removed the block number lock and created the part node.

Fix: add `waitForPreActivePartsInRange` that waits on a condition variable (`preactive_parts_cv`) for all PreActive parts in the drop range to finish committing or rolling back. The condition variable is notified by `Transaction::commit` and `Transaction::rollback`. Since `clearLockedBlockNumbersInPartition` prevents new INSERTs from committing in the range, the wait is guaranteed to terminate.

The wait is added before `removePartsInRangeFromWorkingSetAndGetPartsToRemoveFromZooKeeper` in `executeDropRange` and both removal sites in `executeReplaceRange`.

Also,

```
❯ How parts in Keeper can be PreActive? 

● You're right to challenge this — let me be precise. Parts in ZooKeeper don't have a "PreActive" state. A ZK node under /replicas/{replica}/parts/ either exists or it doesn't.

  The issue is on the local side: removePartsInRangeFromWorkingSetAndGetPartsToRemoveFromZooKeeper builds the list of ZK nodes to remove by enumerating local parts filtered to Active/Outdated/Deleting states. A part that's locally PreActive is skipped, so its ZK node is never added to the removal list.

  But let me re-examine whether this window actually exists during INSERT. Let me trace the exact ordering more carefully.

  The issue is that removePartsInRangeFromWorkingSetAndGetPartsToRemoveFromZooKeeper builds the list of ZK nodes to remove by enumerating local parts:
  - Line 5292: grabActivePartsToRemoveForDropRange → only Active
  - Line 5298-5299: getDataPartsVectorInPartitionForInternalUsage({Outdated, Deleting}, ...) → only Outdated/Deleting

  A part that's locally PreActive is skipped by both queries. So its corresponding ZK node is never added to the removal list.

  The INSERT flow in ReplicatedMergeTreeSink::commitPart creates this situation:

  Line 914:  renameTempPartAndAdd → part is PreActive in data_parts (under lockParts)
             lockParts released
  Line 930:  transaction.renameParts() → renamed on disk
  Line 939:  ZK multi-op → creates /replicas/{replica}/parts/{part_name} in ZK
  Line 944:  transaction.commit() → PreActive → Active

  Between lines 914 and 944, the data_parts lock is NOT held. executeDropRange can interleave:

  T1 (INSERT): lockParts → add PreActive to data_parts → unlock     [line 914]
  T2 (DROP):   lockParts → query Active parts (misses PreActive) → unlock
  T1 (INSERT): ZK multi-op succeeds → ZK node now exists           [line 939]
  T2 (DROP):   removePartsFromZooKeeperWithRetries (doesn't include INSERT's node)
  T2 (DROP):   paranoidCheck → finds INSERT's ZK node → LOGICAL_ERROR
  T1 (INSERT): transaction.commit() → Active                        [line 944]

  Or even simpler — the INSERT's ZK multi-op may happen before DROP takes the lock, but since it only queries Active/Outdated/Deleting, the PreActive part is invisible regardless.
```

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.339`
<!-- ch-version-info:end -->