### PR TITLE
Fix flaky test_s3_cluster_restart by relaxing DistributedConnectionFailTry assertions

### DIFF
--- a/tests/integration/test_s3_cluster_restart/test.py
+++ b/tests/integration/test_s3_cluster_restart/test.py
@@ -194,11 +194,14 @@ def test_reconnect_after_nodes_restart_no_wait(started_cluster):
 
     node1.query("system flush logs query_log")
 
-    assert (
-        node1.query(
-            f"""SELECT ProfileEvents['DistributedConnectionReconnectCount'], ProfileEvents['DistributedConnectionFailTry'] > 0 FROM system.query_log WHERE query_id = '{uuid}' and type = 'QueryFinish';"""
-        ) == "1\t1\n"
-    )
+    result = node1.query(
+            f"""SELECT ProfileEvents['DistributedConnectionReconnectCount'], ProfileEvents['DistributedConnectionFailTry'] FROM system.query_log WHERE query_id = '{uuid}' and type = 'QueryFinish';"""
+        ).strip().split('\t')
+    reconnect_count = int(result[0])
+    fail_try = int(result[1])
+    assert reconnect_count == 1
+    # DistributedConnectionFailTry can be 0 if node2 restarted fast enough before the reconnection attempt
+    assert fail_try <= 1
 
     # avoid leaving the test w/o started node, so next test will start with fully runnning cluster
     node2.wait_for_start(30)
@@ -280,7 +283,8 @@ def test_insert_select(started_cluster, wait_restart, missing_table):
 
     if (not wait_restart):
         node1.query("SYSTEM FLUSH LOGS query_log");
-        assert ( node1.query(f"select ProfileEvents['DistributedConnectionFailTry'] from system.query_log where query_id = '{uuid}' and type = 'QueryFinish'") == "1\n")
+        # DistributedConnectionFailTry can be 0 if node2 restarted fast enough before the query tried to connect
+        assert int(node1.query(f"select ProfileEvents['DistributedConnectionFailTry'] from system.query_log where query_id = '{uuid}' and type = 'QueryFinish'").strip()) <= 1
 
 
     if (missing_table):


### PR DESCRIPTION
We can't rely on counting the number of retries, because there could be more retries for any reason.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

See https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96097&sha=17e412f895cbecafffb4a2a5ffebe2c6e12d242f&name_0=PR&name_1=Integration%20tests%20%28amd_binary%2C%201%2F5%29
https://github.com/ClickHouse/ClickHouse/pull/96097


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.400`
<!-- ch-version-info:end -->