### PR TITLE
Safely refuse connection after fatal error

### DIFF
--- a/src/Server/TCPProtocolStackHandler.h
+++ b/src/Server/TCPProtocolStackHandler.h
@@ -35,6 +35,10 @@ public:
         for (auto & factory : stack)
         {
             std::unique_ptr<TCPServerConnection> connection(factory->createConnection(socket(), tcp_server, stack_data));
+
+            if (!connection)
+                return;
+
             connection->run();
             if (stack_data.socket != socket())
                 socket() = stack_data.socket;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fix after https://github.com/ClickHouse/ClickHouse/pull/94496 . A crash can lead to a second crash without this nullptr check.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.362`
<!-- ch-version-info:end -->