### PR TITLE
Don't copy old data on HashTable::resize if it's empty

### DIFF
--- a/src/Common/HashTable/HashTable.h
+++ b/src/Common/HashTable/HashTable.h
@@ -532,32 +532,42 @@ protected:
             new_grower.increaseSize();
 
         /// Expand the space.
+        if (empty())
+        {
+            size_t old_buffer_size = getBufferSizeInBytes();
+            auto old_buf = buf;
+            buf = reinterpret_cast<Cell *>(Allocator::alloc(allocCheckOverflow(new_grower.bufSize())));
+            Allocator::free(old_buf, old_buffer_size);
+            grower = new_grower;
+        }
+        else
+        {
+            size_t old_buffer_size = getBufferSizeInBytes();
+            buf = reinterpret_cast<Cell *>(Allocator::realloc(buf, old_buffer_size, allocCheckOverflow(new_grower.bufSize())));
 
-        size_t old_buffer_size = getBufferSizeInBytes();
-        buf = reinterpret_cast<Cell *>(Allocator::realloc(buf, old_buffer_size, allocCheckOverflow(new_grower.bufSize())));
+            grower = new_grower;
 
-        grower = new_grower;
+            /** Now some items may need to be moved to a new location.
+              * The element can stay in place, or move to a new location "on the right",
+              *  or move to the left of the collision resolution chain, because the elements to the left of it have been moved to the new "right" location.
+              */
+            size_t i = 0;
+            for (; i < old_size; ++i)
+                if (!buf[i].isZero(*this))
+                    reinsert(buf[i], buf[i].getHash(*this));
 
-        /** Now some items may need to be moved to a new location.
-          * The element can stay in place, or move to a new location "on the right",
-          *  or move to the left of the collision resolution chain, because the elements to the left of it have been moved to the new "right" location.
-          */
-        size_t i = 0;
-        for (; i < old_size; ++i)
-            if (!buf[i].isZero(*this))
+            /** There is also a special case:
+              *    if the element was to be at the end of the old buffer,                  [        x]
+              *    but is at the beginning because of the collision resolution chain,      [o       x]
+              *    then after resizing, it will first be out of place again,               [        xo        ]
+              *    and in order to transfer it where necessary,
+              *    after transferring all the elements from the old halves you need to     [         o   x    ]
+              *    process tail from the collision resolution chain immediately after it   [        o    x    ]
+              */
+            size_t new_size = grower.bufSize();
+            for (; i < new_size && !buf[i].isZero(*this); ++i)
                 reinsert(buf[i], buf[i].getHash(*this));
-
-        /** There is also a special case:
-          *    if the element was to be at the end of the old buffer,                  [        x]
-          *    but is at the beginning because of the collision resolution chain,      [o       x]
-          *    then after resizing, it will first be out of place again,               [        xo        ]
-          *    and in order to transfer it where necessary,
-          *    after transferring all the elements from the old halves you need to     [         o   x    ]
-          *    process tail from the collision resolution chain immediately after it   [        o    x    ]
-          */
-        size_t new_size = grower.bufSize();
-        for (; i < new_size && !buf[i].isZero(*this); ++i)
-            reinsert(buf[i], buf[i].getHash(*this));
+        }
 
 #ifdef DBMS_HASH_MAP_DEBUG_RESIZES
         watch.stop();

--- a/src/Common/HashTable/HashTable.h
+++ b/src/Common/HashTable/HashTable.h
@@ -532,21 +532,12 @@ protected:
             new_grower.increaseSize();
 
         /// Expand the space.
-        if (empty())
-        {
-            size_t old_buffer_size = getBufferSizeInBytes();
-            auto old_buf = buf;
-            buf = reinterpret_cast<Cell *>(Allocator::alloc(allocCheckOverflow(new_grower.bufSize())));
-            Allocator::free(old_buf, old_buffer_size);
-            grower = new_grower;
-        }
-        else
-        {
-            size_t old_buffer_size = getBufferSizeInBytes();
-            buf = reinterpret_cast<Cell *>(Allocator::realloc(buf, old_buffer_size, allocCheckOverflow(new_grower.bufSize())));
+        size_t old_buffer_size = getBufferSizeInBytes();
+        buf = reinterpret_cast<Cell *>(Allocator::realloc(buf, old_buffer_size, allocCheckOverflow(new_grower.bufSize())));
+        grower = new_grower;
 
-            grower = new_grower;
-
+        if (!empty())
+        {
             /** Now some items may need to be moved to a new location.
               * The element can stay in place, or move to a new location "on the right",
               *  or move to the left of the collision resolution chain, because the elements to the left of it have been moved to the new "right" location.


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Don't copy old data on HashTable::resize if it's empty

Apparently (set_index perf test, Q3) we often call resize() on empty HashTable. We can save the memcpy and iterating over keys

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.479`
<!-- ch-version-info:end -->