### PR TITLE
Add s3 schema validation

### DIFF
--- a/src/Storages/ObjectStorage/StorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorage.cpp
@@ -3,7 +3,6 @@
 #include <Common/Exception.h>
 #include <Common/Logger.h>
 #include <Common/logger_useful.h>
-#include "Core/NamesAndTypes.h"
 #include <Core/Settings.h>
 #include <Formats/FormatFactory.h>
 #include <Formats/ReadSchemaUtils.h>
@@ -34,7 +33,6 @@
 #include <Storages/ColumnsDescription.h>
 #include <Storages/HivePartitioningUtils.h>
 #include <Storages/ObjectStorage/StorageObjectStorageSettings.h>
-#include <Processors/Formats/ISchemaReader.h>
 
 namespace DB
 {

--- a/src/Storages/ObjectStorage/StorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorage.cpp
@@ -3,7 +3,7 @@
 #include <Common/Exception.h>
 #include <Common/Logger.h>
 #include <Common/logger_useful.h>
-#include "Core/LogsLevel.h"
+#include <Core/LogsLevel.h>
 #include <Core/Settings.h>
 #include <Formats/FormatFactory.h>
 #include <Formats/ReadSchemaUtils.h>
@@ -637,13 +637,9 @@ std::unique_ptr<ReadBufferIterator> StorageObjectStorage::createReadBufferIterat
     ObjectInfos & read_keys,
     const ContextPtr & context)
 {
-    auto query_settings = configuration->getQuerySettings(context);
-    /// We don't want to throw an exception if there are no files with specified path during schema inference.
-    query_settings.ignore_non_existent_file = true;
-    
     auto file_iterator = StorageObjectStorageSource::createFileIterator(
         configuration,
-        query_settings,
+        configuration->getQuerySettings(context),
         object_storage,
         nullptr, /* storage_metadata */
         false, /* distributed_processing */

--- a/src/Storages/ObjectStorage/StorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorage.cpp
@@ -275,7 +275,8 @@ StorageObjectStorage::StorageObjectStorage(
     if (!configuration->isDataLakeConfiguration() &&
         !columns_in_table_or_function_definition.empty() &&
         !is_table_function && configuration_->format == "Parquet" &&
-        mode == LoadingStrictnessLevel::CREATE)
+        mode == LoadingStrictnessLevel::CREATE &&
+        !do_lazy_init)
     {
         String sample_path_schema;
         std::optional<ColumnsDescription> schema_file;

--- a/src/Storages/ObjectStorage/StorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorage.cpp
@@ -274,7 +274,7 @@ StorageObjectStorage::StorageObjectStorage(
     }
     if (!configuration->isDataLakeConfiguration() && !columns_in_table_or_function_definition.empty())
     {
-        String sample_path_schema;   
+        String sample_path_schema;
         std::optional<ColumnsDescription> schema_file;
         try
         {
@@ -286,10 +286,8 @@ StorageObjectStorage::StorageObjectStorage(
         }
         if (schema_file)
         {
-            if (schema_file->size() != columns_in_table_or_function_definition.size())
-                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Number of columns mismatch in schema and file {} {}", schema_file->size(), columns_in_table_or_function_definition.size());
-            for (const auto & column : *schema_file)
-                if (!columns_in_table_or_function_definition.tryGet(column.name))
+            for (const auto & column : columns_in_table_or_function_definition)
+                if (!schema_file->tryGet(column.name))
                     throw Exception(ErrorCodes::BAD_ARGUMENTS, "Cannot find column in schema {}", column.name);
         }
     }

--- a/src/Storages/ObjectStorage/StorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorage.cpp
@@ -272,7 +272,10 @@ StorageObjectStorage::StorageObjectStorage(
         auto metadata_snapshot = configuration->getStorageSnapshotMetadata(context);
         setInMemoryMetadata(metadata_snapshot);
     }
-    if (!configuration->isDataLakeConfiguration() && !columns_in_table_or_function_definition.empty() && !is_table_function && configuration_->format == "Parquet")
+    if (!configuration->isDataLakeConfiguration() &&
+        !columns_in_table_or_function_definition.empty() &&
+        !is_table_function && configuration_->format == "Parquet" &&
+        mode == LoadingStrictnessLevel::CREATE)
     {
         String sample_path_schema;
         std::optional<ColumnsDescription> schema_file;

--- a/src/Storages/ObjectStorage/StorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorage.cpp
@@ -209,31 +209,20 @@ StorageObjectStorage::StorageObjectStorage(
         format_settings,
         context);
 
-    std::optional<ValidateColumnsSchemaParams> schema_validation_params;
-    if (!need_resolve_columns_or_format &&
-        !configuration->isDataLakeConfiguration() &&
-        !columns_in_table_or_function_definition.empty() &&
-        !is_table_function &&
-        configuration_->format != "CSV" &&
-        configuration_->format != "TSV" &&
-        mode == LoadingStrictnessLevel::CREATE &&
-        !do_lazy_init)
-    {
-        schema_validation_params = ValidateColumnsSchemaParams{
-            object_storage_,
-            configuration_,
-            format_settings,
-            sample_path,
-            context,
-            hive_partition_columns_to_read_from_file_path,
-            columns_in_table_or_function_definition,
-            is_table_function,
-            mode,
-            do_lazy_init,
-            log,
-        };
-    }
-    validateColumns(columns, *configuration, schema_validation_params);
+    validateColumns(columns, *configuration, std::optional<ValidateColumnsSchemaParams>({
+        need_resolve_columns_or_format,
+        object_storage_,
+        configuration_,
+        format_settings,
+        sample_path,
+        context,
+        hive_partition_columns_to_read_from_file_path,
+        columns_in_table_or_function_definition,
+        is_table_function,
+        mode,
+        do_lazy_init,
+        log,
+    }));
 
     // Assert file contains at least one column. The assertion only takes place if we were able to deduce the schema. The storage might be empty.
     if (!columns.empty() && file_columns.empty())

--- a/src/Storages/ObjectStorage/StorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorage.cpp
@@ -209,10 +209,17 @@ StorageObjectStorage::StorageObjectStorage(
         format_settings,
         context);
 
+    bool validate_schema_with_remote = !need_resolve_columns_or_format
+        && !configuration->isDataLakeConfiguration()
+        && !columns_in_table_or_function_definition.empty()
+        && !is_table_function
+        && mode == LoadingStrictnessLevel::CREATE
+        && !do_lazy_init;
+
     validateColumns(
         columns,
         *configuration,
-        need_resolve_columns_or_format,
+        validate_schema_with_remote,
         object_storage_,
         configuration_,
         &format_settings,
@@ -220,9 +227,6 @@ StorageObjectStorage::StorageObjectStorage(
         context,
         &hive_partition_columns_to_read_from_file_path,
         &columns_in_table_or_function_definition,
-        is_table_function,
-        mode,
-        do_lazy_init,
         log);
 
     // Assert file contains at least one column. The assertion only takes place if we were able to deduce the schema. The storage might be empty.

--- a/src/Storages/ObjectStorage/StorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorage.cpp
@@ -209,20 +209,21 @@ StorageObjectStorage::StorageObjectStorage(
         format_settings,
         context);
 
-    validateColumns(columns, *configuration, std::optional<ValidateColumnsSchemaParams>({
+    validateColumns(
+        columns,
+        *configuration,
         need_resolve_columns_or_format,
         object_storage_,
         configuration_,
-        format_settings,
-        sample_path,
+        &format_settings,
+        &sample_path,
         context,
-        hive_partition_columns_to_read_from_file_path,
-        columns_in_table_or_function_definition,
+        &hive_partition_columns_to_read_from_file_path,
+        &columns_in_table_or_function_definition,
         is_table_function,
         mode,
         do_lazy_init,
-        log,
-    }));
+        log);
 
     // Assert file contains at least one column. The assertion only takes place if we were able to deduce the schema. The storage might be empty.
     if (!columns.empty() && file_columns.empty())

--- a/src/Storages/ObjectStorage/StorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorage.cpp
@@ -218,10 +218,9 @@ StorageObjectStorage::StorageObjectStorage(
 
     validateColumns(
         columns,
-        *configuration,
+        configuration_,
         validate_schema_with_remote,
         object_storage_,
-        configuration_,
         &format_settings,
         &sample_path,
         context,

--- a/src/Storages/ObjectStorage/Utils.cpp
+++ b/src/Storages/ObjectStorage/Utils.cpp
@@ -128,6 +128,18 @@ void validateColumns(
     if (!schema_params)
         return;
 
+    /// We don't need to process data lakes because tables may have "schema evolution" feature.
+    /// We don't check csv and tsv formats because they change column names.
+    if (schema_params->need_resolve_columns_or_format
+        || configuration.isDataLakeConfiguration()
+        || schema_params->columns_in_table_or_function_definition.empty()
+        || schema_params->is_table_function
+        || configuration.format == "CSV"
+        || configuration.format == "TSV"
+        || schema_params->mode != LoadingStrictnessLevel::CREATE
+        || schema_params->do_lazy_init)
+        return;
+
     /// Verify that explicitly specified columns exist in the schema inferred from data.
     String sample_path_schema = schema_params->sample_path;
     std::optional<ColumnsDescription> schema_file;

--- a/src/Storages/ObjectStorage/Utils.h
+++ b/src/Storages/ObjectStorage/Utils.h
@@ -2,7 +2,6 @@
 #include <Storages/ObjectStorage/StorageObjectStorage.h>
 #include <Parsers/IAST_fwd.h>
 #include <Core/NamesAndTypes.h>
-#include <Databases/LoadingStrictnessLevel.h>
 #include <Common/Logger.h>
 
 namespace DB
@@ -29,7 +28,7 @@ void resolveSchemaAndFormat(
 void validateColumns(
     const ColumnsDescription & columns,
     const StorageObjectStorageConfiguration & configuration,
-    bool need_resolve_columns_or_format = true,
+    bool validate_schema_with_remote = false,
     ObjectStoragePtr object_storage = nullptr,
     StorageObjectStorageConfigurationPtr config_ptr = nullptr,
     const std::optional<FormatSettings> * format_settings = nullptr,
@@ -37,9 +36,6 @@ void validateColumns(
     ContextPtr context = nullptr,
     const NamesAndTypesList * hive_partition_columns_to_read_from_file_path = nullptr,
     const ColumnsDescription * columns_in_table_or_function_definition = nullptr,
-    bool is_table_function = false,
-    LoadingStrictnessLevel mode = LoadingStrictnessLevel::CREATE,
-    bool do_lazy_init = false,
     LoggerPtr log = nullptr);
 
 std::unique_ptr<ReadBufferFromFileBase> createReadBuffer(

--- a/src/Storages/ObjectStorage/Utils.h
+++ b/src/Storages/ObjectStorage/Utils.h
@@ -1,9 +1,9 @@
 #pragma once
 #include <Storages/ObjectStorage/StorageObjectStorage.h>
 #include <Parsers/IAST_fwd.h>
-#include <Core/NamesAndTypesList.h>
+#include <Core/NamesAndTypes.h>
 #include <Databases/LoadingStrictnessLevel.h>
-#include <Common/Logger_fwd.h>
+#include <Common/Logger.h>
 
 namespace DB
 {

--- a/src/Storages/ObjectStorage/Utils.h
+++ b/src/Storages/ObjectStorage/Utils.h
@@ -10,23 +10,6 @@ namespace DB
 
 class IObjectStorage;
 
-/// Optional parameters for schema consistency validation when columns were explicitly specified.
-struct ValidateColumnsSchemaParams
-{
-    bool need_resolve_columns_or_format;
-    ObjectStoragePtr object_storage;
-    StorageObjectStorageConfigurationPtr configuration;
-    std::optional<FormatSettings> format_settings;
-    std::string sample_path;
-    ContextPtr context;
-    NamesAndTypesList hive_partition_columns_to_read_from_file_path;
-    ColumnsDescription columns_in_table_or_function_definition;
-    bool is_table_function;
-    LoadingStrictnessLevel mode;
-    bool do_lazy_init;
-    LoggerPtr log;
-};
-
 std::optional<std::string> checkAndGetNewFileOnInsertIfNeeded(
     const IObjectStorage & object_storage,
     const StorageObjectStorageConfiguration & configuration,
@@ -46,7 +29,18 @@ void resolveSchemaAndFormat(
 void validateColumns(
     const ColumnsDescription & columns,
     const StorageObjectStorageConfiguration & configuration,
-    const std::optional<ValidateColumnsSchemaParams> & schema_params = std::nullopt);
+    bool need_resolve_columns_or_format = true,
+    ObjectStoragePtr object_storage = nullptr,
+    StorageObjectStorageConfigurationPtr config_ptr = nullptr,
+    const std::optional<FormatSettings> * format_settings = nullptr,
+    const std::string * sample_path = nullptr,
+    ContextPtr context = nullptr,
+    const NamesAndTypesList * hive_partition_columns_to_read_from_file_path = nullptr,
+    const ColumnsDescription * columns_in_table_or_function_definition = nullptr,
+    bool is_table_function = false,
+    LoadingStrictnessLevel mode = LoadingStrictnessLevel::CREATE,
+    bool do_lazy_init = false,
+    LoggerPtr log = nullptr);
 
 std::unique_ptr<ReadBufferFromFileBase> createReadBuffer(
     RelativePathWithMetadata & object_info,

--- a/src/Storages/ObjectStorage/Utils.h
+++ b/src/Storages/ObjectStorage/Utils.h
@@ -1,11 +1,30 @@
 #pragma once
 #include <Storages/ObjectStorage/StorageObjectStorage.h>
 #include <Parsers/IAST_fwd.h>
+#include <Core/NamesAndTypesList.h>
+#include <Databases/LoadingStrictnessLevel.h>
+#include <Common/Logger_fwd.h>
 
 namespace DB
 {
 
 class IObjectStorage;
+
+/// Optional parameters for schema consistency validation when columns were explicitly specified.
+struct ValidateColumnsSchemaParams
+{
+    ObjectStoragePtr object_storage;
+    StorageObjectStorageConfigurationPtr configuration;
+    std::optional<FormatSettings> format_settings;
+    std::string sample_path;
+    ContextPtr context;
+    NamesAndTypesList hive_partition_columns_to_read_from_file_path;
+    ColumnsDescription columns_in_table_or_function_definition;
+    bool is_table_function;
+    LoadingStrictnessLevel mode;
+    bool do_lazy_init;
+    LoggerPtr log;
+};
 
 std::optional<std::string> checkAndGetNewFileOnInsertIfNeeded(
     const IObjectStorage & object_storage,
@@ -23,9 +42,10 @@ void resolveSchemaAndFormat(
     std::string & sample_path,
     const ContextPtr & context);
 
-void validateSupportedColumns(
-    ColumnsDescription & columns,
-    const StorageObjectStorageConfiguration & configuration);
+void validateColumns(
+    const ColumnsDescription & columns,
+    const StorageObjectStorageConfiguration & configuration,
+    const std::optional<ValidateColumnsSchemaParams> & schema_params = std::nullopt);
 
 std::unique_ptr<ReadBufferFromFileBase> createReadBuffer(
     RelativePathWithMetadata & object_info,

--- a/src/Storages/ObjectStorage/Utils.h
+++ b/src/Storages/ObjectStorage/Utils.h
@@ -27,10 +27,9 @@ void resolveSchemaAndFormat(
 
 void validateColumns(
     const ColumnsDescription & columns,
-    const StorageObjectStorageConfiguration & configuration,
+    StorageObjectStorageConfigurationPtr configuration = nullptr,
     bool validate_schema_with_remote = false,
     ObjectStoragePtr object_storage = nullptr,
-    StorageObjectStorageConfigurationPtr config_ptr = nullptr,
     const std::optional<FormatSettings> * format_settings = nullptr,
     const std::string * sample_path = nullptr,
     ContextPtr context = nullptr,

--- a/src/Storages/ObjectStorage/Utils.h
+++ b/src/Storages/ObjectStorage/Utils.h
@@ -13,6 +13,7 @@ class IObjectStorage;
 /// Optional parameters for schema consistency validation when columns were explicitly specified.
 struct ValidateColumnsSchemaParams
 {
+    bool need_resolve_columns_or_format;
     ObjectStoragePtr object_storage;
     StorageObjectStorageConfigurationPtr configuration;
     std::optional<FormatSettings> format_settings;

--- a/tests/integration/test_storage_s3/test.py
+++ b/tests/integration/test_storage_s3/test.py
@@ -1312,6 +1312,7 @@ def test_check_parquet_schema(started_cluster):
     instance.query("DROP TABLE IF EXISTS test_check_parquet_schema")
     instance.query_and_get_error(f"CREATE TABLE test_check_parquet_schema (a Int32, b String, c Int32) ENGINE = S3('{file_path}')")
     instance.query_and_get_error(f"CREATE TABLE test_check_parquet_schema (d Int32, b String) ENGINE = S3('{file_path}')")
+    instance.query(f"CREATE TABLE test_check_parquet_schema (a Int32) ENGINE = S3('{file_path}')")
 
 
 # At the time of writing the actual read bytes are respectively 148 and 169, so -10% to not be flaky

--- a/tests/integration/test_storage_s3/test.py
+++ b/tests/integration/test_storage_s3/test.py
@@ -1286,6 +1286,33 @@ def test_url_reconnect_in_the_middle(started_cluster):
         assert result == "1000000\t3914219105369203805\n"
 
 
+def test_check_parquet_schema(started_cluster):
+    instance = started_cluster.instances["dummy"]  # type: ClickHouseInstance
+    format_name = 'Parquet'
+    file_path = 'http://minio1:9001/root/test_parquet/test_check_parquet_schema.parquet'
+    table_function = f"s3('{file_path}', structure='a Int32, b String', format='{format_name}')"
+    expected_lines = 15000
+    instance.query(f"""
+        CREATE TABLE t_s3_schema_test
+        (
+            a Int32,
+            b String
+        )
+        ENGINE = S3('{file_path}', '{format_name}')
+        SETTINGS s3_truncate_on_insert = 1
+    """)
+
+    exec_query_with_retry(
+        instance,
+        f"INSERT INTO t_s3_schema_test SELECT number, randomString(100) FROM numbers({expected_lines})",
+        timeout=300,
+    )
+
+    instance.query("DROP TABLE IF EXISTS test_check_parquet_schema")
+    instance.query_and_get_error(f"CREATE TABLE test_check_parquet_schema (a Int32, b String, c Int32) ENGINE = S3('{file_path}')")
+    instance.query_and_get_error(f"CREATE TABLE test_check_parquet_schema (d Int32, b String) ENGINE = S3('{file_path}')")
+
+
 # At the time of writing the actual read bytes are respectively 148 and 169, so -10% to not be flaky
 @pytest.mark.parametrize(
     "format_name,expected_bytes_read", [("Parquet", 133), ("ORC", 150)]

--- a/tests/integration/test_storage_s3/test.py
+++ b/tests/integration/test_storage_s3/test.py
@@ -1292,6 +1292,7 @@ def test_check_parquet_schema(started_cluster):
     file_path = 'http://minio1:9001/root/test_parquet/test_check_parquet_schema.parquet'
     table_function = f"s3('{file_path}', structure='a Int32, b String', format='{format_name}')"
     expected_lines = 15000
+    instance.query("DROP TABLE IF EXISTS t_s3_schema_test")
     instance.query(f"""
         CREATE TABLE t_s3_schema_test
         (

--- a/tests/integration/test_storage_s3/test.py
+++ b/tests/integration/test_storage_s3/test.py
@@ -1289,7 +1289,8 @@ def test_url_reconnect_in_the_middle(started_cluster):
 def test_check_parquet_schema(started_cluster):
     instance = started_cluster.instances["dummy"]  # type: ClickHouseInstance
     format_name = 'Parquet'
-    file_path = 'http://minio1:9001/root/test_parquet/test_check_parquet_schema.parquet'
+    idx = random.randint(0, 1000000)
+    file_path = f'http://minio1:9001/root/test_parquet/test_check_parquet_schema_{idx}.parquet'
     table_function = f"s3('{file_path}', structure='a Int32, b String', format='{format_name}')"
     expected_lines = 15000
     instance.query("DROP TABLE IF EXISTS t_s3_schema_test")

--- a/tests/queries/0_stateless/03363_hive_style_partition.reference
+++ b/tests/queries/0_stateless/03363_hive_style_partition.reference
@@ -34,5 +34,4 @@ test/t_03363_function/year=2025/country=/<snowflakeid>.parquet	11
 1
 3
 USA	2022	1
-0
 1

--- a/tests/queries/0_stateless/03363_hive_style_partition.sql
+++ b/tests/queries/0_stateless/03363_hive_style_partition.sql
@@ -79,8 +79,8 @@ INSERT INTO FUNCTION s3(s3_conn, filename='half_baked', format=Parquet, partitio
 -- Should fail because contains only partition columns in schema and `use_hive_partitioning=1`
 CREATE TABLE s3_table_half_schema_with_format (year UInt64) engine=S3(s3_conn, filename='half_baked/**.parquet', format=Parquet) SETTINGS use_hive_partitioning=1; -- {serverError INCORRECT_DATA}
 
--- Should succeed because hive is off
-CREATE TABLE s3_table_half_schema_with_format (year UInt64) engine=S3(s3_conn, filename='half_baked/**.parquet', format=Parquet) SETTINGS use_hive_partitioning=0;
+-- Shouldn't succeed because hive is off and schema contains non existing parquet columns
+CREATE TABLE s3_table_half_schema_with_format (year UInt64) engine=S3(s3_conn, filename='half_baked/**.parquet', format=Parquet) SETTINGS use_hive_partitioning=0;  -- {serverError BAD_ARGUMENTS}
 
 -- Should succeed and not return hive columns (as nothing else is in schema - then no columns at all). Distinct because maybe MinIO isn't cleaned up
 SELECT DISTINCT * FROM s3_table_half_schema_with_format;

--- a/tests/queries/0_stateless/03363_hive_style_partition.sql
+++ b/tests/queries/0_stateless/03363_hive_style_partition.sql
@@ -82,15 +82,9 @@ CREATE TABLE s3_table_half_schema_with_format (year UInt64) engine=S3(s3_conn, f
 -- Shouldn't succeed because hive is off and schema contains non existing parquet columns
 CREATE TABLE s3_table_half_schema_with_format (year UInt64) engine=S3(s3_conn, filename='half_baked/**.parquet', format=Parquet) SETTINGS use_hive_partitioning=0;  -- {serverError BAD_ARGUMENTS}
 
--- Should succeed and not return hive columns (as nothing else is in schema - then no columns at all). Distinct because maybe MinIO isn't cleaned up
-SELECT DISTINCT * FROM s3_table_half_schema_with_format;
-
 CREATE TABLE s3_table_half_schema_with_format_2 (key UInt64) engine=S3(s3_conn, filename='half_baked/**.parquet', format=Parquet) SETTINGS use_hive_partitioning=0;
 
 SELECT DISTINCT * FROM s3_table_half_schema_with_format_2;
-
--- Should fail because the column year does not exist
-SELECT key, * FROM s3_table_half_schema_with_format; -- {serverError UNKNOWN_IDENTIFIER}
 
 -- hive with partition id placeholder
 CREATE TABLE t_03363_s3_sink (year UInt16, country String, counter UInt8)


### PR DESCRIPTION
### Changelog category (leave one):
- Backward Incompatible Change


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add s3 schema validation. This closes https://github.com/ClickHouse/ClickHouse/issues/96089

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.668`
<!-- ch-version-info:end -->