### PR TITLE
Add missed `--external` argument in client help message

### DIFF
--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -767,6 +767,7 @@ void Client::addExtraOptions(OptionsDescription & options_description)
 
     options_description.external_description.emplace(createOptionsDescription("External tables options", terminal_width));
     options_description.external_description->add_options()
+        ("external", "marks the beginning of a clause. You may have multiple sections like this, for the number of tables being transmitted")
         ("file", po::value<std::string>(), "data file or - for stdin")
         ("name", po::value<std::string>()->default_value("_data"), "name of the table")
         ("format", po::value<std::string>()->default_value("TabSeparated"), "data format")


### PR DESCRIPTION
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


```
External tables options:
  --external                   marks the beginning of a clause. You may have
                               multiple sections like this, for the number
                               of tables being transmitted
  --file arg                   data file or - for stdin
  --name arg (=_data)          name of the table
  --format arg (=TabSeparated) data format
  --structure arg              structure
  --types arg                  types
```


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.380`
<!-- ch-version-info:end -->