### PR TITLE
Compute alias subcolumns in analyzer

### DIFF
--- a/tests/queries/0_stateless/03822_alias_subcolumns_computed.reference
+++ b/tests/queries/0_stateless/03822_alias_subcolumns_computed.reference
@@ -1,0 +1,15 @@
+1	abc
+2
+Expression ((Project names + (Projection + (Change column names to column identifiers + Compute alias columns))))
+Actions: INPUT :: 0 -> c Int32 : 0
+         COLUMN Const(UInt64) -> arr.size0 UInt64 : 1
+Positions: 1
+  ReadFromStorageLog
+2	[1,2]	['a','b']
+Expression ((Project names + (Projection + (Change column names to column identifiers + Compute alias columns))))
+Actions: INPUT :: 0 -> c Int32 : 0
+         COLUMN Const(UInt64) -> n.size0 UInt64 : 1
+         COLUMN Const(Array(Int8)) -> n.a Array(Int8) : 2
+         COLUMN Const(Array(String)) -> n.b Array(String) : 3
+Positions: 1 2 3
+  ReadFromMemoryStorage

--- a/tests/queries/0_stateless/03822_alias_subcolumns_computed.sql
+++ b/tests/queries/0_stateless/03822_alias_subcolumns_computed.sql
@@ -1,0 +1,25 @@
+SET enable_analyzer=1;
+
+CREATE TABLE tuple_subcolumn (
+  c Int,
+  t Tuple(a Int, b String) ALIAS (1, 'abc')
+) Engine=Log;
+INSERT INTO TABLE tuple_subcolumn (c) VALUES (1);
+SELECT t.a, t.b FROM tuple_subcolumn;
+
+CREATE TABLE array_subcolumn (
+    c Int,
+    arr Array(Int) ALIAS [1, 2]
+) Engine=Log;
+INSERT INTO TABLE array_subcolumn (c) VALUES (1);
+SELECT arr.size0 FROM array_subcolumn;
+EXPLAIN actions=1 SELECT arr.size0 FROM array_subcolumn;
+
+SET flatten_nested=false;
+CREATE TABLE nested_subcolumn (
+    c Int,
+    n Nested(a Int8, b String) ALIAS [(1, 'a'), (2, 'b')]
+) Engine=Memory;
+INSERT INTO TABLE nested_subcolumn (c) VALUES (1);
+SELECT n.size0, n.a, n.b FROM nested_subcolumn;
+EXPLAIN actions=1 SELECT n.size0, n.a, n.b FROM nested_subcolumn;


### PR DESCRIPTION
Closes: #76899

It broke the Log engine because the analyzer passed such subcolumns to read from storage, and it failed to find data files.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixes the computation of ALIAS column subcolumns