### PR TITLE
Proper DateTime saturation to the start of Unix, considering local timezones

### DIFF
--- a/src/Core/FormatFactorySettings.h
+++ b/src/Core/FormatFactorySettings.h
@@ -706,6 +706,13 @@ See also:
 - [DateTime data type.](../../sql-reference/data-types/datetime.md)
 - [Functions for working with dates and times.](../../sql-reference/functions/date-time-functions.md)
 )", 0) \
+    DECLARE(Bool, date_time_overflow_behavior_use_local_timezone, false, R"(
+When parsing dates/times that overflow the supported range (e.g., dates before 1970 for DateTime),
+saturate to the minimum representable time in the local timezone instead of UTC epoch.
+
+- For timezones west of UTC (e.g., America/New_York at UTC-5): pre-1970 dates saturate to '1970-01-01 00:00:00' local time (Unix timestamp = timezone offset in seconds).
+- For timezones east of UTC: pre-1970 dates saturate to Unix timestamp 0, which displays as '1970-01-01' plus the timezone offset (since DateTime cannot store negative timestamps).
+)", 0) \
     DECLARE(DateTimeOutputFormat, date_time_output_format, FormatSettings::DateTimeOutputFormat::Simple, R"(
 Allows choosing different output formats of the text representation of date and time.
 

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -43,6 +43,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
         {
             {"deduplicate_insert", "backward_compatible_choice", "backward_compatible_choice", "New setting to control deduplication for INSERT queries."},
             {"parallel_replicas_filter_pushdown", false, false, "New setting"},
+            {"date_time_overflow_behavior_use_local_timezone", false, false, "New setting to control timezone-aware saturation for DateTime overflow during format parsing."},
             {"use_statistics_cache", false, true, "Enable statistics cache"},
 
         });

--- a/src/DataTypes/Serializations/SerializationDateTime.cpp
+++ b/src/DataTypes/Serializations/SerializationDateTime.cpp
@@ -64,7 +64,14 @@ inline bool tryReadText(
             break;
     }
 
-    x = std::max<time_t>(0, x);
+    /// DateTime cannot store negative timestamps, so we need to clamp to valid range
+    /// we also need to consider that timezone can affect the final value, so we set it explicitly to 0 for a current tz
+    /// - west of UTC: min_value = local epoch (positive), saturates to '1970-01-01 00:00:00' local
+    /// - east of UTC: min_value = 0 (local epoch is negative), saturates to Unix timestamp 0
+    time_t min_value = settings.date_time_overflow_behavior_use_local_timezone
+        ? std::max<time_t>(0, time_zone.makeDateTime(1970, 1, 1, 0, 0, 0))
+        : 0;
+    x = std::max(min_value, x);
     return res;
 }
 

--- a/src/Formats/FormatFactory.cpp
+++ b/src/Formats/FormatFactory.cpp
@@ -146,6 +146,7 @@ FormatSettings getFormatSettings(const ContextPtr & context, const Settings & se
     format_settings.custom.allow_variable_number_of_columns = settings[Setting::input_format_custom_allow_variable_number_of_columns];
     format_settings.date_time_input_format = settings[Setting::date_time_input_format];
     format_settings.date_time_output_format = settings[Setting::date_time_output_format];
+    format_settings.date_time_overflow_behavior_use_local_timezone = settings[Setting::date_time_overflow_behavior_use_local_timezone];
     format_settings.date_time_64_output_format_cut_trailing_zeros_align_to_groups_of_thousands = settings[Setting::date_time_64_output_format_cut_trailing_zeros_align_to_groups_of_thousands];
     format_settings.interval_output_format = settings[Setting::interval_output_format];
     format_settings.input_format_ipv4_default_on_conversion_error = settings[Setting::input_format_ipv4_default_on_conversion_error];

--- a/src/Formats/FormatSettings.h
+++ b/src/Formats/FormatSettings.h
@@ -95,6 +95,8 @@ struct FormatSettings
 
     DateTimeOutputFormat date_time_output_format = DateTimeOutputFormat::Simple;
 
+    bool date_time_overflow_behavior_use_local_timezone = false;
+
     enum class IntervalOutputFormat : uint8_t
     {
         Kusto,

--- a/tests/queries/0_stateless/03724_to_date_time_or_null_negative_arg_bug.reference
+++ b/tests/queries/0_stateless/03724_to_date_time_or_null_negative_arg_bug.reference
@@ -36,3 +36,27 @@ accurateCastOrNull to DateTime64 (best_effort_us):
 1960-01-01	1960-01-01 00:00:00.000
 1800-01-01	1900-01-01 00:00:00.000
 3000-01-01	2299-12-31 00:00:00.000
+CSV input with America/New_York (default behavior):
+1969-12-31 19:00:00
+CSV input with America/New_York (timezone-aware saturation):
+1970-01-01 00:00:00
+CSV input with Europe/Kyiv (default behavior):
+1970-01-01 03:00:00
+CSV input with Europe/Kyiv (timezone-aware saturation):
+1970-01-01 03:00:00
+CSV input with BestEffort mode - America/New_York (default behavior):
+1969-12-31 19:00:00
+CSV input with BestEffort mode - America/New_York (timezone-aware saturation):
+1970-01-01 00:00:00
+CSV input with BestEffort mode - Europe/Kyiv (default behavior):
+1970-01-01 03:00:00
+CSV input with BestEffort mode - Europe/Kyiv (timezone-aware saturation):
+1970-01-01 03:00:00
+CSV input with BestEffortUS mode - America/New_York (default behavior):
+1969-12-31 19:00:00
+CSV input with BestEffortUS mode - America/New_York (timezone-aware saturation):
+1970-01-01 00:00:00
+CSV input with BestEffortUS mode - Europe/Kyiv (default behavior):
+1970-01-01 03:00:00
+CSV input with BestEffortUS mode - Europe/Kyiv (timezone-aware saturation):
+1970-01-01 03:00:00

--- a/tests/queries/0_stateless/03724_to_date_time_or_null_negative_arg_bug.sql
+++ b/tests/queries/0_stateless/03724_to_date_time_or_null_negative_arg_bug.sql
@@ -56,3 +56,43 @@ select 'accurateCastOrNull to DateTime64 (best_effort_us):';
 select '1960-01-01' as input, accurateCastOrNull('1960-01-01', 'DateTime64') as result settings cast_string_to_date_time_mode='best_effort_us';
 select '1800-01-01' as input, accurateCastOrNull('1800-01-01', 'DateTime64') as result settings cast_string_to_date_time_mode='best_effort_us';
 select '3000-01-01' as input, accurateCastOrNull('3000-01-01', 'DateTime64') as result settings cast_string_to_date_time_mode='best_effort_us';
+
+-- Test with CSV format input - West-of-UTC timezone (America/New_York, UTC-5)
+select 'CSV input with America/New_York (default behavior):';
+select * from format(CSV, 'dt DateTime', '1960-01-01 00:00:00') settings session_timezone='America/New_York';
+
+select 'CSV input with America/New_York (timezone-aware saturation):';
+select * from format(CSV, 'dt DateTime', '1960-01-01 00:00:00') settings session_timezone='America/New_York', date_time_overflow_behavior_use_local_timezone=1;
+
+-- Test with CSV format input - East-of-UTC timezone (Europe/Kyiv, UTC+2/+3)
+select 'CSV input with Europe/Kyiv (default behavior):';
+select * from format(CSV, 'dt DateTime', '1960-01-01 00:00:00') settings session_timezone='Europe/Kyiv';
+
+select 'CSV input with Europe/Kyiv (timezone-aware saturation):';
+select * from format(CSV, 'dt DateTime', '1960-01-01 00:00:00') settings session_timezone='Europe/Kyiv', date_time_overflow_behavior_use_local_timezone=1;
+
+-- Test with BestEffort mode
+select 'CSV input with BestEffort mode - America/New_York (default behavior):';
+select * from format(CSV, 'dt DateTime', '1960-01-01 00:00:00') settings session_timezone='America/New_York', date_time_input_format='best_effort';
+
+select 'CSV input with BestEffort mode - America/New_York (timezone-aware saturation):';
+select * from format(CSV, 'dt DateTime', '1960-01-01 00:00:00') settings session_timezone='America/New_York', date_time_input_format='best_effort', date_time_overflow_behavior_use_local_timezone=1;
+
+select 'CSV input with BestEffort mode - Europe/Kyiv (default behavior):';
+select * from format(CSV, 'dt DateTime', '1960-01-01 00:00:00') settings session_timezone='Europe/Kyiv', date_time_input_format='best_effort';
+
+select 'CSV input with BestEffort mode - Europe/Kyiv (timezone-aware saturation):';
+select * from format(CSV, 'dt DateTime', '1960-01-01 00:00:00') settings session_timezone='Europe/Kyiv', date_time_input_format='best_effort', date_time_overflow_behavior_use_local_timezone=1;
+
+-- Test with BestEffortUS mode
+select 'CSV input with BestEffortUS mode - America/New_York (default behavior):';
+select * from format(CSV, 'dt DateTime', '01/01/1960 00:00:00') settings session_timezone='America/New_York', date_time_input_format='best_effort_us';
+
+select 'CSV input with BestEffortUS mode - America/New_York (timezone-aware saturation):';
+select * from format(CSV, 'dt DateTime', '01/01/1960 00:00:00') settings session_timezone='America/New_York', date_time_input_format='best_effort_us', date_time_overflow_behavior_use_local_timezone=1;
+
+select 'CSV input with BestEffortUS mode - Europe/Kyiv (default behavior):';
+select * from format(CSV, 'dt DateTime', '01/01/1960 00:00:00') settings session_timezone='Europe/Kyiv', date_time_input_format='best_effort_us';
+
+select 'CSV input with BestEffortUS mode - Europe/Kyiv (timezone-aware saturation):';
+select * from format(CSV, 'dt DateTime', '01/01/1960 00:00:00') settings session_timezone='Europe/Kyiv', date_time_input_format='best_effort_us', date_time_overflow_behavior_use_local_timezone=1;


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Previously, it was possible to have a DateTime, saturated to a point before 1970-01-01 (using timezones). A new setting `date_time_overflow_behavior_use_local_timezone` provides a proper saturation. Disabled by default.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
