### PR TITLE
Fix `03783_autopr_dataflow_cache_reuse_qcc` again

### DIFF
--- a/tests/queries/0_stateless/03783_autopr_dataflow_cache_reuse_qcc.reference
+++ b/tests/queries/0_stateless/03783_autopr_dataflow_cache_reuse_qcc.reference
@@ -2,5 +2,4 @@ query	stats_collected	pr_used
 03783_autopr_dataflow_cache_reuse_query_0	1	0
 03783_autopr_dataflow_cache_reuse_query_1	0	1
 03783_autopr_dataflow_cache_reuse_query_2	1	0
-03783_autopr_dataflow_cache_reuse_query_3	1	0
-03783_autopr_dataflow_cache_reuse_query_4	0	0
+03783_autopr_dataflow_cache_reuse_query_3	0	0

--- a/tests/queries/0_stateless/03783_autopr_dataflow_cache_reuse_qcc.sql
+++ b/tests/queries/0_stateless/03783_autopr_dataflow_cache_reuse_qcc.sql
@@ -29,13 +29,23 @@ SYSTEM CLEAR QUERY CONDITION CACHE;
 SELECT SUM(value) FROM t FORMAT Null SETTINGS log_comment='03783_autopr_dataflow_cache_reuse_query_0'; -- empty cache, don't apply optimization, collect stats
 
 SELECT SUM(value) FROM t FORMAT Null SETTINGS log_comment='03783_autopr_dataflow_cache_reuse_query_1'; -- stats available, apply
+set send_logs_level='none';
 
+-- Query #2 will see a lot of bytes read, since we read all rows.
+-- At the same time, as query #2 completes, it populates the query condition cache with an entry for the condition "value = 42".
+-- Subsequent queries will read much less data and thus the automatic parallel replicas decision should change.
+-- The goal is to verify that it will actually happen.
 SELECT SUM(value) FROM t WHERE value = 42 FORMAT Null SETTINGS log_comment='03783_autopr_dataflow_cache_reuse_query_2'; -- empty cache, don't apply optimization, collect stats
 
-SELECT SUM(value) FROM t WHERE value = 42 FORMAT Null SETTINGS log_comment='03783_autopr_dataflow_cache_reuse_query_3'; -- stats available, but we have to recollect since data shrinked (due to pruning by QCC), don't apply
+-- For an unclear reason, the QCC is not always populated with the knowledge about all irrelevant granules from the first run.
+-- It make take a few invocations (we do five to be sure). Because of that, we do a bit relaxed check here and only check the end result - that parallel replicas won't be used eventually.
+SELECT SUM(value) FROM t WHERE value = 42 FORMAT Null;
+SELECT SUM(value) FROM t WHERE value = 42 FORMAT Null;
+SELECT SUM(value) FROM t WHERE value = 42 FORMAT Null;
+SELECT SUM(value) FROM t WHERE value = 42 FORMAT Null;
+SELECT SUM(value) FROM t WHERE value = 42 FORMAT Null;
 
-SELECT SUM(value) FROM t WHERE value = 42 FORMAT Null SETTINGS log_comment='03783_autopr_dataflow_cache_reuse_query_4'; -- stats available, don't apply since no benefit
-set send_logs_level='none';
+SELECT SUM(value) FROM t WHERE value = 42 FORMAT Null SETTINGS log_comment='03783_autopr_dataflow_cache_reuse_query_3'; -- stats available, don't apply since no benefit
 
 SET enable_parallel_replicas=0, automatic_parallel_replicas_mode=0;
 

--- a/tests/queries/0_stateless/03783_autopr_dataflow_cache_reuse_qcc.sql
+++ b/tests/queries/0_stateless/03783_autopr_dataflow_cache_reuse_qcc.sql
@@ -38,7 +38,7 @@ set send_logs_level='none';
 SELECT SUM(value) FROM t WHERE value = 42 FORMAT Null SETTINGS log_comment='03783_autopr_dataflow_cache_reuse_query_2'; -- empty cache, don't apply optimization, collect stats
 
 -- For an unclear reason, the QCC is not always populated with the knowledge about all irrelevant granules from the first run.
--- It make take a few invocations (we do five to be sure). Because of that, we do a bit relaxed check here and only check the end result - that parallel replicas won't be used eventually.
+-- It may take a few invocations (we do five to be sure). Because of that, we do a bit relaxed check here and only check the end result - that parallel replicas won't be used eventually.
 SELECT SUM(value) FROM t WHERE value = 42 FORMAT Null;
 SELECT SUM(value) FROM t WHERE value = 42 FORMAT Null;
 SELECT SUM(value) FROM t WHERE value = 42 FORMAT Null;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.356`
<!-- ch-version-info:end -->