### PR TITLE
Make s3 session token test not flaky

### DIFF
--- a/tests/integration/test_s3_imds/test_session_token.py
+++ b/tests/integration/test_s3_imds/test_session_token.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+import random
 
 from helpers.cluster import ClickHouseCluster
 from helpers.mock_servers import start_mock_servers
@@ -46,14 +47,15 @@ def start_cluster():
 
 
 def test_credentials_from_metadata():
+    file_index = random.randint(0, 1000000000)
     node.query(
-        f"INSERT INTO FUNCTION s3('http://{cluster.minio_host}:{cluster.minio_port}/{cluster.minio_bucket}/test1.jsonl') SELECT * FROM numbers(100)"
+        f"INSERT INTO FUNCTION s3('http://{cluster.minio_host}:{cluster.minio_port}/{cluster.minio_bucket}/test{file_index}.jsonl') SELECT * FROM numbers(100)"
     )
 
     assert (
         "100"
         == node.query(
-            f"SELECT count() FROM s3('http://{cluster.minio_host}:{cluster.minio_port}/{cluster.minio_bucket}/test1.jsonl')"
+            f"SELECT count() FROM s3('http://{cluster.minio_host}:{cluster.minio_port}/{cluster.minio_bucket}/test{file_index}.jsonl')"
         ).strip()
     )
 


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Make s3 session token test not flaky

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.342`
<!-- ch-version-info:end -->