### PR TITLE
Fix server crash on startup (in the Upgrade Check) related to transactions (experimental) when loading mutations with outdated TID

### DIFF
--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -1170,7 +1170,9 @@ void StorageMergeTree::loadMutations()
                     }
                     else
                     {
-                        TransactionLog::assertTIDIsNotOutdated(entry.tid);
+                        /// Transaction is not committed. The TID may be outdated if the transaction log entry
+                        /// was garbage-collected (e.g. after upgrade from a version that advanced tail_ptr).
+                        /// In either case the mutation was not committed and should be removed.
                         LOG_DEBUG(log, "Mutation entry {} was created by transaction {}, but it was not committed. Removing mutation entry",
                                   it->name(), entry.tid);
                         disk->removeFile(it->path());


### PR DESCRIPTION
During upgrade checks, the server could crash in `StorageMergeTree::loadMutations` with a `LOGICAL_ERROR` exception: "Trying to get CSN for too old TID".

This happened because `TransactionLog::assertTIDIsNotOutdated` was called for mutation entries whose TID had been garbage-collected from the transaction log (i.e., `tail_ptr` had advanced past `TID.start_csn`). In upgrade scenarios, the old binary could advance `tail_ptr` during stress testing, and when the new binary started and loaded mutations, uncommitted mutation entries with outdated TIDs would trigger the assertion.

The assertion was unnecessary here: if a mutation has no CSN (`entry.csn == 0`) and `TransactionLog::getCSN` returns nothing, the mutation was not committed regardless of whether the TID is outdated. The correct action in both cases is to remove the uncommitted mutation file, which the code already does on the next line.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

See https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96109&sha=2646faac0046ba91a49626371ca4a24ff30ea4f7&name_0=PR&name_1=Upgrade%20check%20%28amd_release%29
https://github.com/ClickHouse/ClickHouse/pull/96109


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.348`
<!-- ch-version-info:end -->