### PR TITLE
Fix `optimize_syntax_fuse_functions` to not rewrite `sum/count/avg` into `sumCount()` when the aggregate argument is `LowCardinality(Nullable)`

### DIFF
--- a/src/Analyzer/Passes/FuseFunctionsPass.cpp
+++ b/src/Analyzer/Passes/FuseFunctionsPass.cpp
@@ -266,8 +266,8 @@ void tryFuseSumCountAvg(QueryTreeNodePtr query_tree_node, ContextPtr context)
         if (nodes.size() < 2)
             continue;
 
-        if (argument.first.node->getResultType()->isNullable())
-            /// Do not apply to functions with Nullable arguments, because `sumCount` handles it different from `sum` and `avg`.
+        if (isNullableOrLowCardinalityNullable(argument.first.node->getResultType()))
+            /// Do not apply to functions with Nullable/LowCardinality(Nullable) arguments, because `sumCount` handles it different from `sum` and `avg`.
             continue;
 
         auto sum_count_node = createResolvedAggregateFunction("sumCount", argument.first.node);

--- a/tests/queries/0_stateless/03904_fuse_function_pass_lowcardinality_nullable_argument.reference
+++ b/tests/queries/0_stateless/03904_fuse_function_pass_lowcardinality_nullable_argument.reference
@@ -1,0 +1,72 @@
+-- { echo }
+
+SET optimize_syntax_fuse_functions = 1;
+SET allow_suspicious_low_cardinality_types=1;
+DROP TABLE IF EXISTS test;
+CREATE TABLE test (`a` Float64, `b` LowCardinality(Nullable(Int8))) ENGINE = Log;
+SELECT count(b) * count(b) IGNORE NULLS FROM (SELECT b FROM test);
+0
+SELECT avg(b) * 3, (sum(b) + 1) + count(b), count(b) * count(b), count() IGNORE NULLS FROM (SELECT b FROM test);
+\N	\N	0	0
+INSERT INTO test (a, b) VALUES
+    (0.0, NULL),
+    (1.0, 0),
+    (-1.0, 1),
+    (3.141592653589793, -1),
+    (-2.718281828459045, 127),
+    (1e-12, -128),
+    (1e12, 42),
+    (NaN, NULL),
+    (Inf, 7),
+    (-Inf, -7);
+SELECT avg(b) * 3, (sum(b) + 1) + count(b), count(b) * count(b), count() IGNORE NULLS FROM (SELECT b FROM test);
+15.375	50	64	10
+SELECT sum(b), count(b), sum(a), count(a) FROM (SELECT a, b FROM test);
+41	8	nan	10
+SELECT sum(a), count(a) FROM ( SELECT CAST(materialize(1), 'LowCardinality(Nullable(Int32))') AS a) t;
+1	1
+SET enable_analyzer = 1;
+EXPLAIN SYNTAX run_query_tree_passes=1
+SELECT count(b) * count(b) IGNORE NULLS FROM (SELECT b FROM test);
+SELECT count(__table1.b) * count(__table1.b) AS `multiply(count(b), count(b))`
+FROM
+(
+    SELECT __table2.b AS b
+    FROM default.test AS __table2
+) AS __table1
+EXPLAIN SYNTAX run_query_tree_passes=1
+SELECT avg(b) * 3, (sum(b) + 1) + count(b), count(b) * count(b), count() IGNORE NULLS FROM (SELECT b FROM test);
+SELECT
+    avg(__table1.b) * 3 AS `multiply(avg(b), 3)`,
+    (sum(__table1.b) + 1) + count(__table1.b) AS `plus(plus(sum(b), 1), count(b))`,
+    count(__table1.b) * count(__table1.b) AS `multiply(count(b), count(b))`,
+    count() AS `count()`
+FROM
+(
+    SELECT __table2.b AS b
+    FROM default.test AS __table2
+) AS __table1
+EXPLAIN SYNTAX run_query_tree_passes=1
+SELECT sum(b), count(b), sum(a), count(a) FROM (SELECT a, b FROM test);
+SELECT
+    sum(__table1.b) AS `sum(b)`,
+    count(__table1.b) AS `count(b)`,
+    tupleElement(sumCount(__table1.a), 1) AS `sum(a)`,
+    tupleElement(sumCount(__table1.a), 2) AS `count(a)`
+FROM
+(
+    SELECT
+        __table2.a AS a,
+        __table2.b AS b
+    FROM default.test AS __table2
+) AS __table1
+EXPLAIN SYNTAX run_query_tree_passes=1
+SELECT sum(a), count(a) FROM ( SELECT CAST(materialize(1), 'LowCardinality(Nullable(Int32))') AS a) t;
+SELECT
+    sum(__table1.a) AS `sum(a)`,
+    count(__table1.a) AS `count(a)`
+FROM
+(
+    SELECT CAST(materialize(1), \'LowCardinality(Nullable(Int32))\') AS a
+    FROM system.one AS __table2
+) AS __table1

--- a/tests/queries/0_stateless/03904_fuse_function_pass_lowcardinality_nullable_argument.sql
+++ b/tests/queries/0_stateless/03904_fuse_function_pass_lowcardinality_nullable_argument.sql
@@ -1,0 +1,43 @@
+-- { echo }
+
+SET optimize_syntax_fuse_functions = 1;
+SET allow_suspicious_low_cardinality_types=1;
+
+DROP TABLE IF EXISTS test;
+CREATE TABLE test (`a` Float64, `b` LowCardinality(Nullable(Int8))) ENGINE = Log;
+
+SELECT count(b) * count(b) IGNORE NULLS FROM (SELECT b FROM test);
+
+SELECT avg(b) * 3, (sum(b) + 1) + count(b), count(b) * count(b), count() IGNORE NULLS FROM (SELECT b FROM test);
+
+INSERT INTO test (a, b) VALUES
+    (0.0, NULL),
+    (1.0, 0),
+    (-1.0, 1),
+    (3.141592653589793, -1),
+    (-2.718281828459045, 127),
+    (1e-12, -128),
+    (1e12, 42),
+    (NaN, NULL),
+    (Inf, 7),
+    (-Inf, -7);
+
+SELECT avg(b) * 3, (sum(b) + 1) + count(b), count(b) * count(b), count() IGNORE NULLS FROM (SELECT b FROM test);
+
+SELECT sum(b), count(b), sum(a), count(a) FROM (SELECT a, b FROM test);
+
+SELECT sum(a), count(a) FROM ( SELECT CAST(materialize(1), 'LowCardinality(Nullable(Int32))') AS a) t;
+
+SET enable_analyzer = 1;
+
+EXPLAIN SYNTAX run_query_tree_passes=1
+SELECT count(b) * count(b) IGNORE NULLS FROM (SELECT b FROM test);
+
+EXPLAIN SYNTAX run_query_tree_passes=1
+SELECT avg(b) * 3, (sum(b) + 1) + count(b), count(b) * count(b), count() IGNORE NULLS FROM (SELECT b FROM test);
+
+EXPLAIN SYNTAX run_query_tree_passes=1
+SELECT sum(b), count(b), sum(a), count(a) FROM (SELECT a, b FROM test);
+
+EXPLAIN SYNTAX run_query_tree_passes=1
+SELECT sum(a), count(a) FROM ( SELECT CAST(materialize(1), 'LowCardinality(Nullable(Int32))') AS a) t;


### PR DESCRIPTION
Currently, we incorrectly fuse `count(b) * count(b)` even though we should not.

```sql
SET optimize_syntax_fuse_functions = 1;
SET allow_suspicious_low_cardinality_types=1;

CREATE TABLE test (`a` Float64, `b` LowCardinality(Nullable(Int8))) ENGINE = Log;

EXPLAIN SYNTAX run_query_tree_passes=1
SELECT count(b) * count(b) IGNORE NULLS FROM (SELECT b FROM test);
```

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `optimize_syntax_fuse_functions` to not rewrite `sum/count/avg` into `sumCount()` when the aggregate argument is `LowCardinality(Nullable)`. Closes https://github.com/ClickHouse/ClickHouse/issues/95390

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.360`
- Backported to: `26.1.3.21`
<!-- ch-version-info:end -->