### PR TITLE
Fix heap-use-after-free in LogSource/StripeLogSource during concurrent DROP TABLE

### DIFF
--- a/src/Storages/StorageLog.h
+++ b/src/Storages/StorageLog.h
@@ -184,7 +184,7 @@ public:
     ReadFromStorageLogStep(
         const Names & column_names_,
         ContextPtr local_context_,
-        StorageLog & storage_,
+        std::shared_ptr<StorageLog> storage_,
         const StorageSnapshotPtr & storage_snapshot_,
         size_t max_block_size_,
         size_t num_streams_
@@ -205,7 +205,7 @@ public:
 private:
     const Names column_names;
     ContextPtr local_context;
-    StorageLog & storage;
+    std::shared_ptr<StorageLog> storage;
     const StorageSnapshotPtr storage_snapshot;
     const size_t max_block_size;
     const size_t num_streams;

--- a/src/Storages/StorageStripeLog.cpp
+++ b/src/Storages/StorageStripeLog.cpp
@@ -99,7 +99,7 @@ public:
     }
 
     StripeLogSource(
-        std::shared_ptr<const StorageStripeLog> storage_holder_,
+        std::shared_ptr<const StorageStripeLog> storage_,
         const StorageSnapshotPtr & storage_snapshot_,
         const Names & column_names,
         ReadSettings read_settings_,
@@ -108,8 +108,7 @@ public:
         IndexForNativeFormat::Blocks::const_iterator index_end_,
         size_t file_size_)
         : ISource(std::make_shared<const Block>(getHeader(storage_snapshot_, column_names, index_begin_, index_end_)))
-        , storage_holder(std::move(storage_holder_))
-        , storage(*storage_holder)
+        , storage(std::move(storage_))
         , storage_snapshot(storage_snapshot_)
         , read_settings(std::move(read_settings_))
         , indices(indices_)
@@ -144,8 +143,7 @@ protected:
     }
 
 private:
-    const std::shared_ptr<const StorageStripeLog> storage_holder;
-    const StorageStripeLog & storage;
+    const std::shared_ptr<const StorageStripeLog> storage;
     StorageSnapshotPtr storage_snapshot;
     ReadSettings read_settings;
 
@@ -170,8 +168,8 @@ private:
         {
             started = true;
 
-            String data_file_path = storage.table_path + "data.bin";
-            data_in.emplace(storage.disk->readFile(data_file_path, read_settings.adjustBufferSize(file_size)));
+            String data_file_path = storage->table_path + "data.bin";
+            data_in.emplace(storage->disk->readFile(data_file_path, read_settings.adjustBufferSize(file_size)));
             block_in.emplace(*data_in, 0, index_begin, index_end);
         }
     }

--- a/tests/queries/0_stateless/03824_log_engine_use_after_free_race.reference
+++ b/tests/queries/0_stateless/03824_log_engine_use_after_free_race.reference
@@ -1,0 +1,6 @@
+Testing TinyLog
+Done TinyLog
+Testing StripeLog
+Done StripeLog
+Testing Log
+Done Log

--- a/tests/queries/0_stateless/03824_log_engine_use_after_free_race.sh
+++ b/tests/queries/0_stateless/03824_log_engine_use_after_free_race.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Tags: race, log-engine
+
+# Test for use-after-free race condition in StorageLog/StorageStripeLog/TinyLog
+# where LogSource holds a reference to the storage object, but the storage
+# can be destroyed by a concurrent DROP TABLE while reading is still in progress.
+
+set -e
+
+CLICKHOUSE_CLIENT_SERVER_LOGS_LEVEL=fatal
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+TIMEOUT=10
+
+function thread_create_insert {
+    local TIMELIMIT=$((SECONDS+TIMEOUT))
+    while [ $SECONDS -lt "$TIMELIMIT" ]
+    do
+        $CLICKHOUSE_CLIENT --query "CREATE TABLE IF NOT EXISTS $1 (x UInt64, s String) ENGINE = $2" 2>&1 | grep -v -e 'Received exception from server' -e '^(query: ' | grep -v -P 'Code: (57|60|741)'
+        $CLICKHOUSE_CLIENT --query "INSERT INTO $1 SELECT number, repeat(toString(number), 100) FROM numbers(10000)" 2>&1 | grep -v -e 'Received exception from server' -e '^(query: ' | grep -v -P 'Code: (57|60|741)'
+    done
+}
+
+function thread_select {
+    local TIMELIMIT=$((SECONDS+TIMEOUT))
+    while [ $SECONDS -lt "$TIMELIMIT" ]
+    do
+        $CLICKHOUSE_CLIENT --local_filesystem_read_method pread --query "SELECT * FROM $1 FORMAT Null" 2>&1 | grep -v -e 'Received exception from server' -e '^(query: ' | grep -v -P 'Code: (60|218|741)'
+    done
+}
+
+function thread_drop {
+    local TIMELIMIT=$((SECONDS+TIMEOUT))
+    while [ $SECONDS -lt "$TIMELIMIT" ]
+    do
+        $CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS $1" 2>&1 | grep -v -e 'Received exception from server' -e '^(query: ' | grep -v -P 'Code: (57|60|741)'
+    done
+}
+
+function test_with_engine {
+    echo "Testing $1"
+
+    thread_create_insert t_race_log $1 &
+    thread_select t_race_log &
+    thread_select t_race_log &
+    thread_select t_race_log &
+    thread_select t_race_log &
+    thread_drop t_race_log &
+    thread_drop t_race_log &
+
+    wait
+    echo "Done $1"
+}
+
+test_with_engine TinyLog
+test_with_engine StripeLog
+test_with_engine Log
+
+$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS t_race_log"
+$CLICKHOUSE_CLIENT -q "KILL QUERY WHERE current_database = currentDatabase() SYNC FORMAT Null"


### PR DESCRIPTION
Fix a heap-use-after-free race condition where `LogSource::readData` accesses `storage.data_files_by_names` on a freed `StorageLog` object. This was detected by ASan in the stress test (arm_asan) with the following scenario:

1. A SELECT query starts reading from a Log/TinyLog/StripeLog table, building a pipeline with `LogSource` processors that hold a raw reference to the storage.
2. A concurrent DROP TABLE detaches the table from the Atomic database and enqueues it for async cleanup via `DatabaseCatalog::dropTablesParallel`.
3. The background cleanup task checks `isSharedPtrUnique` on the storage's `shared_ptr` and, finding no other holders, destroys the `StorageLog` object.
4. The pipeline's `LogSource` thread (`QueryPullPipeEx`) continues reading from the now-freed storage, causing use-after-free.

The standard query execution paths (Planner via `extendQueryContextAndStoragesLifetime`, old `InterpreterSelectQuery`, `resolveStorages`) all properly add `StoragePtr` to `QueryPlanResourceHolder::storage_holders`, which should keep the storage alive for the pipeline's lifetime. The exact code path where the `StoragePtr` is lost remains elusive despite exhaustive investigation of TCPHandler, HTTPHandler, `PullingAsyncPipelineExecutor`, `CompletedPipelineExecutor`, `BlockIO` lifecycle, and the `getTablesToDrop`/`dropTablesParallel` TOCTOU window. The issue reproduces only under heavy stress test conditions.

The fix makes `LogSource`, `ReadFromStorageLogStep`, and `StripeLogSource` hold a `shared_ptr` to their respective storage objects instead of raw references. This provides defense in depth: even if the pipeline's resource chain somehow loses the `StoragePtr`, the processors themselves keep the storage alive for the duration of their execution.

PS. 

  What we know from the ASan trace                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                          
  - T1096 (QueryPullPipeEx): LogSource::readData → storage.data_files_by_names.find() on freed storage
  - T1151 (ThreadPool): DatabaseCatalog::dropTablesParallel → ~TableMarkedAsDropped → frees the StorageLog
  - T1034 (TCPHandler): InterpreterCreateQuery::createTable → make_shared<StorageLog> allocated it

  All standard StoragePtr-holding paths are correct

  I traced every code path exhaustively:

  1. Planner (Planner.cpp:331-347): extendQueryContextAndStoragesLifetime iterates all table expressions and calls query_plan.addStorageHolder(table_node->getStorage()) - always called at line 1633 with no early returns that could skip it.
  2. Old InterpreterSelectQuery (InterpreterSelectQuery.cpp:1152): query_plan.addStorageHolder(storage) - properly adds StoragePtr.
  3. resolveStorages (resolveStorages.cpp:263): reading_plan.addStorageHolder(std::move(storage)) - for deserialized plans.
  4. StorageMerge (StorageMerge.cpp:565): resources.storage_holders.push_back(std::get<1>(table)) - holds child table StoragePtr.
  5. Pipeline resource transfer (QueryPlan.cpp:222): last_pipeline->addResources(resources) - plan resources transferred to pipeline builder, then to pipeline.
  6. QueryPipeline member destruction order (QueryPipeline.h:153,159): resources (line 153) declared before processors (line 159), so processors destroyed first, then resources. Correct.
  7. PullingAsyncPipelineExecutor (PullingAsyncPipelineExecutor.cpp:169-170): cancel() calls data->thread.join() which guarantees the worker thread is completely finished before pipeline destruction.
  8. PipelineExecutor (PipelineExecutor.cpp:602): pool->wait() ensures all internal worker threads complete.
  9. TCPHandler flow (TCPHandler.cpp:802-803): processOrdinaryQuery() creates/destroys executor (joining thread), then io.onFinish() destroys pipeline. Sequential, safe.

  What I couldn't find

  Despite exhaustive search, I could not identify a specific code path where the StoragePtr is lost while the pipeline is still running. Every standard path properly holds StoragePtr.

  TOCTOU in getTablesToDrop

  There IS a theoretical TOCTOU race between getTablesToDrop() checking isSharedPtrUnique (under tables_marked_dropped_mutex at line 1400) and dropTablesParallel() actually dropping the table (without the mutex at line 1442). However, this requires someone to take a NEW reference to the storage
  after the check, which is difficult because the table is already detached from the database.

  Conclusion

  For isSharedPtrUnique to return true (which it must have, since the storage was destroyed), the pipeline must NOT have held a StoragePtr at the moment of the check. Given that all standard paths add StoragePtr, the trigger is likely a very specific, hard-to-reproduce timing scenario - possibly
  involving an obscure code path I couldn't identify, or a subtle edge case in the shared_ptr lifecycle.

  The fix we implemented (making LogSource, StripeLogSource, and ReadFromStorageLogStep hold shared_ptr to the storage) is the correct defense-in-depth approach. Even if the pipeline's resource chain somehow loses the StoragePtr, the processors themselves keep the storage alive. This makes the
  code robust against any such gap.


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


Note: the test is marginally useful: maybe it has a chance to reproduce a similar problem in the future.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.367`
<!-- ch-version-info:end -->