### PR TITLE
Fix sporadic failure in mutations `parts_postpone_reasons` tests

### DIFF
--- a/tests/queries/0_stateless/03716_mutations_parts_postpone_reasons_mt.reference
+++ b/tests/queries/0_stateless/03716_mutations_parts_postpone_reasons_mt.reference
@@ -1,8 +1,8 @@
-mutation_4.txt	(UPDATE num = num + 1 WHERE 1)	['all_1_1_0','all_2_2_0','all_3_3_0']	[]	{'all_parts':'No free threads in pool'}	0
-mutation_4.txt	(UPDATE num = num + 1 WHERE 1)	[]	[]	{}	1
-mutation_5.txt	(UPDATE num = num + 2 WHERE 1)	['all_1_1_0_4','all_2_2_0_4','all_3_3_0_4']	[]	{'all_parts':'No free threads in pool'}	0
-mutation_6.txt	(UPDATE num = num + 3 WHERE 1)	['all_1_1_0_4','all_2_2_0_4','all_3_3_0_4']	[]	{'all_parts':'No free threads in pool'}	0
-mutation_4.txt	(UPDATE num = num + 1 WHERE 1)	['all_1_1_0','all_2_2_0','all_3_3_0']	[]	{'all_1_1_0':'Exceed max source part size','all_2_2_0':'Exceed max source part size','all_3_3_0':'Exceed max source part size'}	0
-mutation_4.txt	(UPDATE num = num + 1 WHERE 1)	[]	[]	{}	1
-mutation_5.txt	(UPDATE num = num + 2 WHERE 1)	['all_1_1_0_4','all_2_2_0_4','all_3_3_0_4']	[]	{'all_1_1_0_4':'Exceed max source part size','all_2_2_0_4':'Exceed max source part size','all_3_3_0_4':'Exceed max source part size'}	0
-mutation_6.txt	(UPDATE num = num + 3 WHERE 1)	['all_1_1_0_4','all_2_2_0_4','all_3_3_0_4']	[]	{'all_1_1_0_4':'Exceed max source part size','all_2_2_0_4':'Exceed max source part size','all_3_3_0_4':'Exceed max source part size'}	0
+mutation_2.txt	(UPDATE num = num + 1 WHERE 1)	['all_1_1_0']	[]	{'all_parts':'No free threads in pool'}	0
+mutation_2.txt	(UPDATE num = num + 1 WHERE 1)	[]	[]	{}	1
+mutation_3.txt	(UPDATE num = num + 2 WHERE 1)	['all_1_1_0_2']	[]	{'all_parts':'No free threads in pool'}	0
+mutation_4.txt	(UPDATE num = num + 3 WHERE 1)	['all_1_1_0_2']	[]	{'all_parts':'No free threads in pool'}	0
+mutation_2.txt	(UPDATE num = num + 1 WHERE 1)	['all_1_1_0']	[]	{'all_1_1_0':'Exceed max source part size'}	0
+mutation_2.txt	(UPDATE num = num + 1 WHERE 1)	[]	[]	{}	1
+mutation_3.txt	(UPDATE num = num + 2 WHERE 1)	['all_1_1_0_2']	[]	{'all_1_1_0_2':'Exceed max source part size'}	0
+mutation_4.txt	(UPDATE num = num + 3 WHERE 1)	['all_1_1_0_2']	[]	{'all_1_1_0_2':'Exceed max source part size'}	0

--- a/tests/queries/0_stateless/03716_mutations_parts_postpone_reasons_mt.sh
+++ b/tests/queries/0_stateless/03716_mutations_parts_postpone_reasons_mt.sh
@@ -16,9 +16,7 @@ $CLICKHOUSE_CLIENT --query "
     ENGINE = MergeTree()
     ORDER BY id;
 
-    INSERT INTO mt VALUES (1, 1);
-    INSERT INTO mt VALUES (2, 2);
-    INSERT INTO mt VALUES (3, 3);
+    INSERT INTO mt VALUES (1, 1), (2, 2), (3, 3);
 "
 
 #test1 'all_parts'->no thread in pool for one mutation
@@ -42,7 +40,7 @@ $CLICKHOUSE_CLIENT --query "
     SYSTEM DISABLE FAILPOINT mt_select_parts_to_mutate_no_free_threads;
 "
 
-wait_for_mutation "mt" "mutation_4.txt"
+wait_for_mutation "mt" "mutation_2.txt"
 
 #test2 'all_parts'->no thread in pool for multiple mutations
 $CLICKHOUSE_CLIENT --query "
@@ -72,9 +70,7 @@ $CLICKHOUSE_CLIENT --query "
     ENGINE = MergeTree()
     ORDER BY id;
 
-    INSERT INTO mt VALUES (1, 1);
-    INSERT INTO mt VALUES (2, 2);
-    INSERT INTO mt VALUES (3, 3);
+    INSERT INTO mt VALUES (1, 1), (2, 2), (3, 3);
 "
 
 #test3 part->postpone reasons in pool for one mutation
@@ -98,7 +94,7 @@ $CLICKHOUSE_CLIENT --query "
     SYSTEM DISABLE FAILPOINT mt_select_parts_to_mutate_max_part_size;
 "
 
-wait_for_mutation "mt" "mutation_4.txt"
+wait_for_mutation "mt" "mutation_2.txt"
 
 #test4 part->postpone reasons for multiple mutations
 $CLICKHOUSE_CLIENT --query "

--- a/tests/queries/0_stateless/03716_mutations_parts_postpone_reasons_rmt.reference
+++ b/tests/queries/0_stateless/03716_mutations_parts_postpone_reasons_rmt.reference
@@ -1,8 +1,8 @@
-0000000000	(UPDATE num = num + 1 WHERE 1)	['all_0_0_0','all_1_1_0','all_2_2_0']	[]	{'all_parts':'No free threads in pool'}	0
+0000000000	(UPDATE num = num + 1 WHERE 1)	['all_0_0_0']	[]	{'all_parts':'No free threads in pool'}	0
 0000000000	(UPDATE num = num + 1 WHERE 1)	[]	[]	{}	1
-0000000001	(UPDATE num = num + 2 WHERE 1)	['all_0_0_0_3','all_1_1_0_3','all_2_2_0_3']	[]	{'all_parts':'No free threads in pool'}	0
-0000000002	(UPDATE num = num + 3 WHERE 1)	['all_0_0_0_3','all_1_1_0_3','all_2_2_0_3']	[]	{'all_parts':'No free threads in pool'}	0
-0000000000	(UPDATE num = num + 1 WHERE 1)	['all_0_0_0','all_1_1_0','all_2_2_0']	[]	{'all_0_0_0':'Exceed max source part size','all_1_1_0':'Exceed max source part size','all_2_2_0':'Exceed max source part size'}	0
+0000000001	(UPDATE num = num + 2 WHERE 1)	['all_0_0_0_1']	[]	{'all_parts':'No free threads in pool'}	0
+0000000002	(UPDATE num = num + 3 WHERE 1)	['all_0_0_0_1']	[]	{'all_parts':'No free threads in pool'}	0
+0000000000	(UPDATE num = num + 1 WHERE 1)	['all_0_0_0']	[]	{'all_0_0_0':'Exceed max source part size'}	0
 0000000000	(UPDATE num = num + 1 WHERE 1)	[]	[]	{}	1
-0000000001	(UPDATE num = num + 2 WHERE 1)	['all_0_0_0_3','all_1_1_0_3','all_2_2_0_3']	[]	{'all_0_0_0_3':'Exceed max source part size','all_1_1_0_3':'Exceed max source part size','all_2_2_0_3':'Exceed max source part size'}	0
-0000000002	(UPDATE num = num + 3 WHERE 1)	['all_0_0_0_3','all_1_1_0_3','all_2_2_0_3']	[]	{'all_0_0_0_3':'Exceed max source part size','all_1_1_0_3':'Exceed max source part size','all_2_2_0_3':'Exceed max source part size'}	0
+0000000001	(UPDATE num = num + 2 WHERE 1)	['all_0_0_0_1']	[]	{'all_0_0_0_1':'Exceed max source part size'}	0
+0000000002	(UPDATE num = num + 3 WHERE 1)	['all_0_0_0_1']	[]	{'all_0_0_0_1':'Exceed max source part size'}	0

--- a/tests/queries/0_stateless/03716_mutations_parts_postpone_reasons_rmt.sh
+++ b/tests/queries/0_stateless/03716_mutations_parts_postpone_reasons_rmt.sh
@@ -23,9 +23,7 @@ $CLICKHOUSE_CLIENT --query "
         merge_selecting_sleep_ms = 100,
         max_merge_selecting_sleep_ms = 200;
 
-    INSERT INTO rmt VALUES (1, 1);
-    INSERT INTO rmt VALUES (2, 2);
-    INSERT INTO rmt VALUES (3, 3);
+    INSERT INTO rmt VALUES (1, 1), (2, 2), (3, 3);
 "
 
 #test1 'all_parts'->no thread in pool for one mutation
@@ -84,9 +82,7 @@ $CLICKHOUSE_CLIENT --query "
         merge_selecting_sleep_ms = 100,
         max_merge_selecting_sleep_ms = 200;
 
-    INSERT INTO rmt VALUES (1, 1);
-    INSERT INTO rmt VALUES (2, 2);
-    INSERT INTO rmt VALUES (3, 3);
+    INSERT INTO rmt VALUES (1, 1), (2, 2), (3, 3);
 "
 
 #test3 part->postpone reasons for one mutation


### PR DESCRIPTION
The merge selecting task first tries to select a merge, then falls through to the mutation path where `parts_postpone_reasons` is populated. With 3 separate inserts creating 3 small parts, the merge selector could successfully create a merge entry, returning before ever reaching the mutation path — leaving `parts_postpone_reasons` empty.

Use a single `INSERT` to create one part instead of three. With only one part the merge selector cannot select a merge (needs >= 2 parts), so the task always reaches the mutation path.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

Note: this might not be the actual reason.
See https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96249&sha=66db7414b234ea19c4b0472f968d5435511a5e7d&name_0=PR&name_1=Stateless%20tests%20%28amd_asan%2C%20db%20disk%2C%20distributed%20plan%2C%20sequential%29
https://github.com/ClickHouse/ClickHouse/pull/96249


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.366`
<!-- ch-version-info:end -->