### PR TITLE
Fix `02992_all_columns_should_have_comment`: Move dictionary source tables from `system` to `default` database in the CI

### DIFF
--- a/tests/config/decimals_dictionary.xml
+++ b/tests/config/decimals_dictionary.xml
@@ -7,7 +7,7 @@
             <port>9000</port>
             <user>default</user>
             <password></password>
-            <db>system</db>
+            <db>default</db>
             <table>decimals</table>
         </clickhouse>
     </source>
@@ -45,7 +45,7 @@
             <port>9000</port>
             <user>default</user>
             <password></password>
-            <db>system</db>
+            <db>default</db>
             <table>decimals</table>
         </clickhouse>
     </source>
@@ -83,7 +83,7 @@
             <port>9000</port>
             <user>default</user>
             <password></password>
-            <db>system</db>
+            <db>default</db>
             <table>decimals</table>
         </clickhouse>
     </source>
@@ -121,7 +121,7 @@
             <port>9000</port>
             <user>default</user>
             <password></password>
-            <db>system</db>
+            <db>default</db>
             <table>decimals</table>
         </clickhouse>
     </source>
@@ -162,7 +162,7 @@
             <port>9000</port>
             <user>default</user>
             <password></password>
-            <db>system</db>
+            <db>default</db>
             <table>decimals</table>
         </clickhouse>
     </source>

--- a/tests/config/ints_dictionary.xml
+++ b/tests/config/ints_dictionary.xml
@@ -7,7 +7,7 @@
             <port>9000</port>
             <user>default</user>
             <password></password>
-            <db>system</db>
+            <db>default</db>
             <table>ints</table>
         </clickhouse>
     </source>
@@ -70,7 +70,7 @@
             <port>9000</port>
             <user>default</user>
             <password></password>
-            <db>system</db>
+            <db>default</db>
             <table>ints</table>
         </clickhouse>
     </source>
@@ -133,7 +133,7 @@
             <port>9000</port>
             <user>default</user>
             <password></password>
-            <db>system</db>
+            <db>default</db>
             <table>ints</table>
         </clickhouse>
     </source>
@@ -196,7 +196,7 @@
             <port>9000</port>
             <user>default</user>
             <password></password>
-            <db>system</db>
+            <db>default</db>
             <table>ints</table>
         </clickhouse>
     </source>
@@ -259,7 +259,7 @@
             <port>9000</port>
             <user>default</user>
             <password></password>
-            <db>system</db>
+            <db>default</db>
             <table>ints</table>
         </clickhouse>
     </source>
@@ -325,7 +325,7 @@
             <port>9000</port>
             <user>default</user>
             <password></password>
-            <db>system</db>
+            <db>default</db>
             <table>ints</table>
         </clickhouse>
     </source>

--- a/tests/config/strings_dictionary.xml
+++ b/tests/config/strings_dictionary.xml
@@ -7,7 +7,7 @@
             <port>9000</port>
             <user>default</user>
             <password></password>
-            <db>system</db>
+            <db>default</db>
             <table>strings</table>
         </clickhouse>
     </source>
@@ -35,7 +35,7 @@
             <port>9000</port>
             <user>default</user>
             <password></password>
-            <db>system</db>
+            <db>default</db>
             <table>strings</table>
         </clickhouse>
     </source>
@@ -63,7 +63,7 @@
             <port>9000</port>
             <user>default</user>
             <password></password>
-            <db>system</db>
+            <db>default</db>
             <table>strings</table>
         </clickhouse>
     </source>
@@ -91,7 +91,7 @@
             <port>9000</port>
             <user>default</user>
             <password></password>
-            <db>system</db>
+            <db>default</db>
             <table>strings</table>
         </clickhouse>
     </source>
@@ -122,7 +122,7 @@
             <port>9000</port>
             <user>default</user>
             <password></password>
-            <db>system</db>
+            <db>default</db>
             <table>strings</table>
         </clickhouse>
     </source>
@@ -153,7 +153,7 @@
             <port>9000</port>
             <user>default</user>
             <password></password>
-            <db>system</db>
+            <db>default</db>
             <table>strings</table>
         </clickhouse>
     </source>
@@ -184,7 +184,7 @@
             <port>9000</port>
             <user>default</user>
             <password></password>
-            <db>system</db>
+            <db>default</db>
             <table>strings</table>
         </clickhouse>
     </source>

--- a/tests/queries/0_stateless/00950_dict_get.sql
+++ b/tests/queries/0_stateless/00950_dict_get.sql
@@ -1,7 +1,7 @@
 -- Tags: no-parallel
 
--- Must use `system` database and these tables - they're configured in tests/*_dictionary.xml
-use system;
+-- Must use `default` database and these tables - they're configured in tests/*_dictionary.xml
+use default;
 drop table if exists ints;
 drop table if exists strings;
 drop table if exists decimals;


### PR DESCRIPTION
Test `00950_dict_get` was creating tables `ints`, `decimals`, `strings` in the `system` database as source tables for XML-configured dictionaries. These tables polluted the `system` database and caused test `02992_all_columns_should_have_comment` to fail, since it checks that all columns in `system` tables have comments.

Move the dictionary source tables to the `default` database instead, which always exists and is the appropriate place for user-created tables.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.369`
<!-- ch-version-info:end -->