### PR TITLE
Fix flaky test `00177_memory_bound_merging`

### DIFF
--- a/tests/queries/0_stateless/00177_memory_bound_merging.sh
+++ b/tests/queries/0_stateless/00177_memory_bound_merging.sh
@@ -31,7 +31,7 @@ test1() {
         GROUP BY CounterID, URL, EventDate
         ORDER BY URL, EventDate
         LIMIT 5 OFFSET 10
-        SETTINGS optimize_aggregation_in_order = 1, enable_memory_bound_merging_of_aggregation_results = 1, enable_parallel_replicas = 1, parallel_replicas_for_non_replicated_merge_tree = 1, max_parallel_replicas = 3"
+        SETTINGS optimize_aggregation_in_order = 1, enable_memory_bound_merging_of_aggregation_results = 1, enable_parallel_replicas = 1, parallel_replicas_for_non_replicated_merge_tree = 1, max_parallel_replicas = 3, optimize_read_in_order = 1, max_rows_to_read = 0"
     check_replicas_read_in_order $query_id
 }
 
@@ -46,7 +46,7 @@ test2() {
         GROUP BY URL, EventDate
         ORDER BY URL, EventDate
         LIMIT 5 OFFSET 10
-        SETTINGS optimize_aggregation_in_order = 1, enable_memory_bound_merging_of_aggregation_results = 1, enable_parallel_replicas = 1, parallel_replicas_for_non_replicated_merge_tree = 1, max_parallel_replicas = 3, query_plan_aggregation_in_order = 1"
+        SETTINGS optimize_aggregation_in_order = 1, enable_memory_bound_merging_of_aggregation_results = 1, enable_parallel_replicas = 1, parallel_replicas_for_non_replicated_merge_tree = 1, max_parallel_replicas = 3, query_plan_aggregation_in_order = 1, optimize_read_in_order = 1, max_rows_to_read = 0"
     check_replicas_read_in_order $query_id
 }
 
@@ -62,7 +62,7 @@ test3() {
             FROM test.hits
             WHERE CounterID = 1704509 AND UserID = 4322253409885123546
             GROUP BY URL, EventDate
-            SETTINGS optimize_aggregation_in_order = 1, enable_memory_bound_merging_of_aggregation_results = 1, enable_parallel_replicas = 1, parallel_replicas_for_non_replicated_merge_tree = 1, max_parallel_replicas = 3, parallel_replicas_local_plan=1
+            SETTINGS optimize_aggregation_in_order = 1, enable_memory_bound_merging_of_aggregation_results = 1, enable_parallel_replicas = 1, parallel_replicas_for_non_replicated_merge_tree = 1, max_parallel_replicas = 3, parallel_replicas_local_plan=1, optimize_read_in_order = 1
         )
         WHERE explain LIKE '%Aggr%Transform%' OR explain LIKE '%InOrder%'"
 }


### PR DESCRIPTION
Two failure modes:

1. `TOO_MANY_ROWS`: With 3 parallel replicas each reading ~8.87M rows from `test.hits`, total rows exceed the CI profile limit of 20M. Fix: add `max_rows_to_read=0` to test1 and test2 queries to disable the limit.

2. Reference diff in `EXPLAIN PIPELINE` output: The CI test runner randomizes `optimize_read_in_order` which, when set to 0, prevents the aggregation-in-order optimization path, producing different pipeline transforms. Fix: explicitly set `optimize_read_in_order=1` in all test queries since the test specifically verifies in-order aggregation behavior.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.378`
<!-- ch-version-info:end -->