### PR TITLE
Fix typo in developer instructions

### DIFF
--- a/docs/en/development/developer-instruction.md
+++ b/docs/en/development/developer-instruction.md
@@ -9,7 +9,7 @@ doc_type: 'guide'
 
 # Prerequisites
 
-ClickHouse can be build on Linux, FreeBSD and macOS.
+ClickHouse can be built on Linux, FreeBSD and macOS.
 If you use Windows, you can still build ClickHouse in a virtual machine running Linux, e.g. [VirtualBox](https://www.virtualbox.org/) with Ubuntu.
 
 ## Create a Repository on GitHub {#create-a-repository-on-github}


### PR DESCRIPTION
This fixes what I presume is a minor typo in the developer documentation:

"ClickHouse can be build on Linux, ..." --> "ClickHouse can be built on Linux, ...".

### Changelog category (leave one):
- Documentation (changelog entry is not required)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.357`
<!-- ch-version-info:end -->