### PR TITLE
Add timeout to column convergence loop in `03144_parallel_alter_add_drop_column_zookeeper_on_steroids.sh`

### DIFF
--- a/tests/queries/0_stateless/03144_parallel_alter_add_drop_column_zookeeper_on_steroids.sh
+++ b/tests/queries/0_stateless/03144_parallel_alter_add_drop_column_zookeeper_on_steroids.sh
@@ -113,7 +113,12 @@ columns1=$($CLICKHOUSE_CLIENT --query "select count() from system.columns where 
 columns2=$($CLICKHOUSE_CLIENT --query "select count() from system.columns where table='concurrent_alter_add_drop_steroids_2' and database='$CLICKHOUSE_DATABASE'" 2> /dev/null)
 columns3=$($CLICKHOUSE_CLIENT --query "select count() from system.columns where table='concurrent_alter_add_drop_steroids_3' and database='$CLICKHOUSE_DATABASE'" 2> /dev/null)
 
+CONVERGE_TIMEOUT=$((SECONDS + 300))
 while [ "$columns1" != "$columns2" ] || [ "$columns2" != "$columns3" ]; do
+    if [ $SECONDS -ge "$CONVERGE_TIMEOUT" ]; then
+        echo "Columns did not converge after 300 seconds: $columns1 $columns2 $columns3"
+        break
+    fi
     columns1=$($CLICKHOUSE_CLIENT --query "select count() from system.columns where table='concurrent_alter_add_drop_steroids_1' and database='$CLICKHOUSE_DATABASE'" 2> /dev/null)
     columns2=$($CLICKHOUSE_CLIENT --query "select count() from system.columns where table='concurrent_alter_add_drop_steroids_2' and database='$CLICKHOUSE_DATABASE'" 2> /dev/null)
     columns3=$($CLICKHOUSE_CLIENT --query "select count() from system.columns where table='concurrent_alter_add_drop_steroids_3' and database='$CLICKHOUSE_DATABASE'" 2> /dev/null)


### PR DESCRIPTION
The test has an unbounded `while` loop waiting for column counts to converge across three replicas.  When replication is slow this loop can spin indefinitely, causing the test to time out without a meaningful error message.  Add a 300-second deadline and an explicit diagnostic message so the test fails promptly with useful output.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.399`
<!-- ch-version-info:end -->