### PR TITLE
Add `mutations_sync = 2` to `00062_replicated_merge_tree_alter_zookeeper_long`

### DIFF
--- a/tests/queries/0_stateless/00062_replicated_merge_tree_alter_zookeeper_long.sql
+++ b/tests/queries/0_stateless/00062_replicated_merge_tree_alter_zookeeper_long.sql
@@ -6,6 +6,7 @@ DROP TABLE IF EXISTS replicated_alter1;
 DROP TABLE IF EXISTS replicated_alter2;
 
 SET replication_alter_partitions_sync = 2;
+SET mutations_sync = 2;
 
 set allow_deprecated_syntax_for_merge_tree=1;
 CREATE TABLE replicated_alter1 (d Date, k UInt64, i32 Int32) ENGINE=ReplicatedMergeTree('/clickhouse/tables/{database}/test_00062/alter', 'r1', d, k, 8192);


### PR DESCRIPTION
The test drops column `n.d` (line 58) and then re-adds it (line 66). The DROP generates an asynchronous mutation to remove data from parts. With only `replication_alter_partitions_sync = 2`, the ALTER metadata is synchronized across replicas but the mutation runs asynchronously. When `n.d` is re-added before the mutation completes, stale data from un-mutated parts resurfaces, causing the SELECT to return old values instead of empty arrays.

Setting `mutations_sync = 2` ensures every mutation-generating ALTER waits for the mutation to finish on all replicas before returning.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.396`
<!-- ch-version-info:end -->