### PR TITLE
Set explicit `merge_max_block_size` in `03785_rebuild_projection_with_part_offset`

### DIFF
--- a/tests/queries/0_stateless/03785_rebuild_projection_with_part_offset.sql
+++ b/tests/queries/0_stateless/03785_rebuild_projection_with_part_offset.sql
@@ -15,7 +15,7 @@ CREATE TABLE test
 )
 ENGINE = ReplacingMergeTree
 ORDER BY a
-SETTINGS index_granularity_bytes = 10485760, index_granularity = 8192, deduplicate_merge_projection_mode = 'rebuild';
+SETTINGS index_granularity_bytes = 10485760, index_granularity = 8192, merge_max_block_size = 8192, deduplicate_merge_projection_mode = 'rebuild';
 
 INSERT INTO test SELECT number * 3, rand() FROM numbers(100000);
 INSERT INTO test SELECT number * 3 + 1, rand() FROM numbers(100000);


### PR DESCRIPTION
The test inserts 200,000 rows and runs `OPTIMIZE TABLE FINAL` with projection rebuild.  Randomized CI settings can set `merge_max_block_size` as low as 3, making the merge process rows in batches of 3 — resulting in a 600-second timeout under MSan.

Pin `merge_max_block_size = 8192` in the table settings so the merge completes in reasonable time regardless of randomized settings.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.377`
<!-- ch-version-info:end -->