### PR TITLE
Fix flaky `01396_inactive_replica_cleanup_nodes_zookeeper`

### DIFF
--- a/tests/queries/0_stateless/01396_inactive_replica_cleanup_nodes_zookeeper.sh
+++ b/tests/queries/0_stateless/01396_inactive_replica_cleanup_nodes_zookeeper.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: replica, no-debug, no-shared-merge-tree, long, no-msan, no-asan, no-tsan
+# Tags: replica, no-debug, no-shared-merge-tree, long, no-msan, no-asan, no-tsan, no-replicated-database
 # no-shared-merge-tree: depends on zookeeper, specific logs of rmt and so on
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
@@ -28,10 +28,10 @@ $CLICKHOUSE_CLIENT --query "
 $CLICKHOUSE_CLIENT --max_execution_time 600 --insert_keeper_fault_injection_probability=0 --max_block_size 1 --min_insert_block_size_rows 1 --min_insert_block_size_bytes 1 --max_insert_threads 16 --query "INSERT INTO r1 SELECT * FROM numbers_mt(${SCALE})"
 
 
-# Now wait for cleanup thread
-for _ in {1..60}; do
-    $CLICKHOUSE_CLIENT --query "SYSTEM FLUSH LOGS text_log"
-    [[ $($CLICKHOUSE_CLIENT --query "SELECT sum(toUInt32(extract(message, 'Removed (\d+) old log entries'))) FROM system.text_log WHERE event_date >= yesterday() AND logger_name LIKE '%' || '$CLICKHOUSE_DATABASE' || '%r1%(ReplicatedMergeTreeCleanupThread)%' AND message LIKE '%Removed % old log entries%' SETTINGS max_rows_to_read = 0") -gt $((SCALE - 10)) ]] && break;
+# Now wait for cleanup thread to reduce ZK log entries
+for _ in {1..120}; do
+    count=$($CLICKHOUSE_CLIENT --query "SELECT numChildren FROM system.zookeeper WHERE path = '/clickhouse/tables/$CLICKHOUSE_TEST_ZOOKEEPER_PREFIX/$SHARD' AND name = 'log'" 2>/dev/null)
+    [[ $count -lt $((SCALE / 4)) ]] && break
     sleep 1
 done
 


### PR DESCRIPTION
Two failure modes:

1. In DatabaseReplicated mode, the `text_log` query hangs indefinitely causing a 600-second timeout.  Add `no-replicated-database` tag since the test creates its own `ReplicatedMergeTree` replicas with specific ZooKeeper paths and settings.

2. The `text_log`-based wait loop is fragile: it parses cleanup thread log messages via regex, depends on `SYSTEM FLUSH LOGS` capturing all messages in time, and depends on the logger name matching a specific pattern.  Replace it with a direct ZooKeeper node count check, which is both simpler and tests the actual invariant the test cares about.  Also increase the wait from 60 to 120 seconds.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.376`
<!-- ch-version-info:end -->