### PR TITLE
Fix `LOGICAL_ERROR` exception when `SYSTEM DROP REPLICA` receives empty ZKPATH

### DIFF
--- a/src/Interpreters/InterpreterSystemQuery.cpp
+++ b/src/Interpreters/InterpreterSystemQuery.cpp
@@ -1256,7 +1256,11 @@ void InterpreterSystemQuery::dropReplica(ASTSystemQuery & query)
             LOG_TRACE(log, "Dropped replica {} from database {}", query.replica, backQuoteIfNeed(database->getDatabaseName()));
         }
     }
-    else if (!query.replica_zk_path.empty())
+    else if (query.replica_zk_path.empty())
+    {
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "ZooKeeper path is empty");
+    }
+    else
     {
         getContext()->checkAccess(AccessType::SYSTEM_DROP_REPLICA);
         String remote_replica_path = fs::path(query.replica_zk_path)  / "replicas" / query.replica;
@@ -1298,8 +1302,6 @@ void InterpreterSystemQuery::dropReplica(ASTSystemQuery & query)
         StorageReplicatedMergeTree::dropReplica(zookeeper, info, log);
         LOG_INFO(log, "Dropped replica {}", remote_replica_path);
     }
-    else
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Invalid query");
 }
 
 bool InterpreterSystemQuery::dropStorageReplica(const String & query_replica, const StoragePtr & storage)
@@ -1611,7 +1613,11 @@ void InterpreterSystemQuery::dropDatabaseReplica(ASTSystemQuery & query)
             LOG_TRACE(log, "Dropped replica {} of Replicated database {}", query.replica, backQuoteIfNeed(database->getDatabaseName()));
         }
     }
-    else if (!query.replica_zk_path.empty())
+    else if (query.replica_zk_path.empty())
+    {
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "ZooKeeper path is empty");
+    }
+    else
     {
         getContext()->checkAccess(AccessType::SYSTEM_DROP_REPLICA);
 
@@ -1653,8 +1659,6 @@ void InterpreterSystemQuery::dropDatabaseReplica(ASTSystemQuery & query)
         DatabaseReplicated::dropReplica(nullptr, query.replica_zk_path, query.shard, query.replica, /*throw_if_noop*/ true);
         LOG_INFO(log, "Dropped replica {} of Replicated database with path {}", query.replica, query.replica_zk_path);
     }
-    else
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Invalid query");
 }
 
 bool InterpreterSystemQuery::trySyncReplica(StoragePtr table, SyncReplicaMode sync_replica_mode, const std::unordered_set<String> & src_replicas, ContextPtr context_)

--- a/tests/queries/0_stateless/03444_drop_replica_empty_zkpath.sql
+++ b/tests/queries/0_stateless/03444_drop_replica_empty_zkpath.sql
@@ -1,0 +1,1 @@
+SYSTEM DROP REPLICA 'r1' FROM ZKPATH ''; -- { serverError BAD_ARGUMENTS }


### PR DESCRIPTION
`SYSTEM DROP REPLICA 'r1' FROM ZKPATH ''` with an empty ZooKeeper path fell through all if/else branches in `dropReplica` and `dropDatabaseReplica`, reaching a `LOGICAL_ERROR` throw that is fatal in debug/sanitizer builds.

This can happen during stress tests when the ZK path is obtained from `system.replicas` but the table has already been dropped concurrently.

Change the error from `LOGICAL_ERROR` to `BAD_ARGUMENTS` since empty ZKPATH is a user input issue, not a code logic bug.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

See https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96168&sha=cf8627909172a0b3915e9f517689796954e15960&name_0=PR&name_1=Stress%20test%20%28amd_tsan%29
https://github.com/ClickHouse/ClickHouse/pull/96168


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.398`
<!-- ch-version-info:end -->