### PR TITLE
Fix flaky test `test_send_data2` in `test_hedged_requests`

### DIFF
--- a/tests/integration/test_hedged_requests/configs/users.xml
+++ b/tests/integration/test_hedged_requests/configs/users.xml
@@ -6,6 +6,7 @@
             <receive_data_timeout_ms>2000</receive_data_timeout_ms>
             <async_socket_for_remote>1</async_socket_for_remote>
             <use_hedged_requests>1</use_hedged_requests>
+            <allow_changing_replica_until_first_data_packet>1</allow_changing_replica_until_first_data_packet>
         </default>
     </profiles>
 </clickhouse>


### PR DESCRIPTION
The test was sporadically failing because a `Progress` packet from the slow replica arrived before the `change_replica_timeout` fired. With the default `allow_changing_replica_until_first_data_packet=0`, this Progress packet permanently locked the replica choice, preventing the hedged mechanism from switching to a faster replica.

Set `allow_changing_replica_until_first_data_packet=1` so that only actual Data packets (not Progress) lock in the replica. This allows the hedged mechanism to properly detect stalled data sending and switch replicas.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.375`
<!-- ch-version-info:end -->