### PR TITLE
Add `lazy_load_tables` database setting for deferred table loading

### DIFF
--- a/docs/en/sql-reference/statements/create/database.md
+++ b/docs/en/sql-reference/statements/create/database.md
@@ -12,7 +12,7 @@ doc_type: 'reference'
 Creates a new database.
 
 ```sql
-CREATE DATABASE [IF NOT EXISTS] db_name [ON CLUSTER cluster] [ENGINE = engine(...)] [COMMENT 'Comment']
+CREATE DATABASE [IF NOT EXISTS] db_name [ON CLUSTER cluster] [ENGINE = engine(...)] [SETTINGS ...] [COMMENT 'Comment']
 ```
 
 ## Clauses {#clauses}
@@ -60,3 +60,19 @@ Result:
 │ db_comment │ The temporary database │
 └────────────┴────────────────────────┘
 ```
+
+### SETTINGS {#settings}
+
+#### lazy_load_tables {#lazy-load-tables}
+
+When enabled, tables are not fully loaded during database startup. Instead, a lightweight proxy is created for each table and the real table engine is materialized on first access. This reduces startup time and memory usage for databases with many tables where only a subset is actively queried.
+
+```sql
+CREATE DATABASE db_name ENGINE = Atomic SETTINGS lazy_load_tables = 1;
+```
+
+Before a table is accessed, it appears with engine `TableProxy` in `system.tables`. After first access, it shows its real engine name.
+
+Applies to database engines that store table metadata on disk (e.g. `Atomic`, `Ordinary`). Views, materialized views, dictionaries, and tables backed by table functions are always loaded eagerly regardless of this setting.
+
+Default value: `0` (disabled).

--- a/src/Databases/DatabaseMetadataDiskSettings.cpp
+++ b/src/Databases/DatabaseMetadataDiskSettings.cpp
@@ -14,6 +14,7 @@ namespace DB
 {
 #define LIST_OF_DATABASE_METADATA_DISK_SETTINGS(DECLARE, DECLARE_WITH_ALIAS) \
     DECLARE(String, disk, "", R"(Name of disk storing table metadata files in the database.)", 0) \
+    DECLARE(Bool, lazy_load_tables, false, R"(If enabled, tables are not loaded during database startup. Instead, a lightweight proxy is created and the real table is loaded on first access.)", 0) \
 
 DECLARE_SETTINGS_TRAITS(DatabaseMetadataDiskSettingsTraits, LIST_OF_DATABASE_METADATA_DISK_SETTINGS)
 IMPLEMENT_SETTINGS_TRAITS(DatabaseMetadataDiskSettingsTraits, LIST_OF_DATABASE_METADATA_DISK_SETTINGS)
@@ -41,7 +42,10 @@ void DatabaseMetadataDiskSettingsImpl::loadFromQuery(ASTStorage & storage_def, C
     auto changes = storage_def.settings->changes;
     auto * value = changes.tryGet("disk");
     if (!value)
+    {
+        applyChanges(changes);
         return;
+    }
 
     ASTPtr value_as_custom_ast = nullptr;
     CustomType custom;

--- a/src/Databases/DatabaseMetadataDiskSettings.h
+++ b/src/Databases/DatabaseMetadataDiskSettings.h
@@ -13,6 +13,7 @@ struct DatabaseMetadataDiskSettingsImpl;
 
 /// List of available types supported in MetadataDiskSettings object
 #define DATABASE_METADATA_SETTINGS_SUPPORTED_TYPES(CLASS_NAME, M) \
+    M(CLASS_NAME, Bool) \
     M(CLASS_NAME, String)
 
 DATABASE_METADATA_SETTINGS_SUPPORTED_TYPES(DatabaseMetadataDiskSettings, DECLARE_SETTING_TRAIT)

--- a/src/Databases/DatabaseOrdinary.cpp
+++ b/src/Databases/DatabaseOrdinary.cpp
@@ -29,6 +29,7 @@
 #include <Parsers/parseQuery.h>
 #include <Storages/MergeTree/MergeTreeSettings.h>
 #include <Storages/StorageReplicatedMergeTree.h>
+#include <Storages/StorageTableProxy.h>
 #include <Common/CurrentMetrics.h>
 #include <Common/PoolId.h>
 #include <Common/Stopwatch.h>
@@ -78,6 +79,7 @@ namespace ErrorCodes
 
 namespace DatabaseMetadataDiskSetting
 {
+extern const DatabaseMetadataDiskSettingsBool lazy_load_tables;
 extern const DatabaseMetadataDiskSettingsString disk;
 }
 
@@ -358,6 +360,12 @@ void DatabaseOrdinary::loadTableFromMetadata(
     assert(name.database == TSA_SUPPRESS_WARNING_FOR_READ(database_name));
     const auto & query = ast->as<const ASTCreateQuery &>();
 
+    if (shouldLazyLoad(query, mode))
+    {
+        loadTableLazy(local_context, name, ast, mode);
+        return;
+    }
+
     LOG_TRACE(log, "Loading table {}", name.getFullName());
 
     constexpr size_t max_tries = 3;
@@ -401,6 +409,57 @@ void DatabaseOrdinary::loadTableFromMetadata(
             throw;
         }
     }
+}
+
+bool DatabaseOrdinary::shouldLazyLoad(const ASTCreateQuery & query, LoadingStrictnessLevel mode) const
+{
+    if (!database_metadata_disk_settings[DatabaseMetadataDiskSetting::lazy_load_tables])
+        return false;
+
+    if (query.is_ordinary_view || query.is_materialized_view || query.is_dictionary
+        || query.isParameterizedView() || query.is_window_view)
+        return false;
+
+    /// Already handled by `StorageTableFunctionProxy`.
+    if (query.as_table_function)
+        return false;
+
+    if (mode == LoadingStrictnessLevel::FORCE_RESTORE)
+        return false;
+
+    return true;
+}
+
+void DatabaseOrdinary::loadTableLazy(
+    ContextMutablePtr local_context,
+    const QualifiedTableName & name,
+    const ASTPtr & ast,
+    LoadingStrictnessLevel mode)
+{
+    const auto & query = ast->as<const ASTCreateQuery &>();
+
+    LOG_TRACE(log, "Lazy-loading table {}", name.getFullName());
+
+    ColumnsDescription columns;
+    if (query.columns_list && query.columns_list->columns)
+        columns = InterpreterCreateQuery::getColumnsDescription(
+            *query.columns_list->columns, local_context, mode);
+
+    StorageID table_id(name.database, query.getTable(), query.uuid);
+    String table_data_path = getTableDataPath(query);
+
+    auto get_nested = [ast, db_name = name.database, table_data_path, local_context, mode]() -> StoragePtr
+    {
+        const auto & create_query = ast->as<const ASTCreateQuery &>();
+        auto [_, table] = createTableFromAST(
+            create_query, db_name, table_data_path, local_context, mode);
+        return table;
+    };
+
+    auto proxy = std::make_shared<StorageTableProxy>(
+        table_id, std::move(get_nested), std::move(columns));
+
+    attachTable(local_context, query.getTable(), proxy, table_data_path);
 }
 
 LoadTaskPtr DatabaseOrdinary::loadTableFromMetadataAsync(

--- a/src/Databases/DatabaseOrdinary.h
+++ b/src/Databases/DatabaseOrdinary.h
@@ -108,6 +108,13 @@ protected:
     DiskPtr metadata_disk_ptr;
 
 private:
+    bool shouldLazyLoad(const ASTCreateQuery & query, LoadingStrictnessLevel mode) const;
+    void loadTableLazy(
+        ContextMutablePtr local_context,
+        const QualifiedTableName & name,
+        const ASTPtr & ast,
+        LoadingStrictnessLevel mode);
+
     void convertMergeTreeToReplicatedIfNeeded(ASTPtr ast, const QualifiedTableName & qualified_name, const String & file_name);
     void restoreMetadataAfterConvertingToReplicated(StoragePtr table, const QualifiedTableName & name);
     String getConvertToReplicatedFlagPath(const String & name, bool tableStarted);

--- a/src/Storages/StorageTableProxy.h
+++ b/src/Storages/StorageTableProxy.h
@@ -1,0 +1,148 @@
+#pragma once
+
+#include <functional>
+
+#include <Storages/StorageProxy.h>
+#include <Common/Logger.h>
+#include <Common/logger_useful.h>
+
+
+namespace DB
+{
+
+/// Lazily creates underlying storage for tables in databases with `lazy_load_tables` setting.
+/// Similar to `StorageTableFunctionProxy`, but for real on-disk tables.
+class StorageTableProxy final : public StorageProxy
+{
+public:
+    StorageTableProxy(const StorageID & table_id_, std::function<StoragePtr()> get_nested_, ColumnsDescription cached_columns)
+        : StorageProxy(table_id_)
+        , get_nested(std::move(get_nested_))
+        , log(getLogger("StorageTableProxy (" + table_id_.getFullTableName() + ")"))
+    {
+        StorageInMemoryMetadata cached_metadata;
+        cached_metadata.setColumns(std::move(cached_columns));
+        setInMemoryMetadata(cached_metadata);
+    }
+
+    std::string getName() const override { return "TableProxy"; }
+
+    StoragePtr getNested() const override
+    {
+        std::lock_guard lock{nested_mutex};
+        if (nested)
+            return nested;
+
+        LOG_INFO(log, "Loading lazy table on first access");
+
+        auto nested_storage = get_nested();
+        nested_storage->startup();
+        nested_storage->renameInMemory(getStorageID());
+        nested = nested_storage;
+        get_nested = {};
+        return nested;
+    }
+
+    bool storesDataOnDisk() const override { return true; }
+    StoragePolicyPtr getStoragePolicy() const override { return nullptr; }
+    bool isView() const override { return false; }
+
+    void startup() override { }
+
+    void shutdown(bool is_drop) override
+    {
+        std::lock_guard lock{nested_mutex};
+        if (nested)
+            nested->shutdown(is_drop);
+    }
+
+    void flushAndPrepareForShutdown() override
+    {
+        std::lock_guard lock{nested_mutex};
+        if (nested)
+            nested->flushAndPrepareForShutdown();
+    }
+
+    /// Force-load to clean up data from disk.
+    void drop() override
+    {
+        getNested()->drop();
+    }
+
+    void read(
+        QueryPlan & query_plan,
+        const Names & column_names,
+        const StorageSnapshotPtr & /*storage_snapshot*/,
+        SelectQueryInfo & query_info,
+        ContextPtr context,
+        QueryProcessingStage::Enum processed_stage,
+        size_t max_block_size,
+        size_t num_streams) override
+    {
+        auto storage = getNested();
+        auto nested_snapshot = storage->getStorageSnapshot(storage->getInMemoryMetadataPtr(), context);
+        storage->read(query_plan, column_names, nested_snapshot, query_info, context,
+                      processed_stage, max_block_size, num_streams);
+    }
+
+    SinkToStoragePtr write(
+        const ASTPtr & query,
+        const StorageMetadataPtr & metadata_snapshot,
+        ContextPtr context,
+        bool async_insert) override
+    {
+        auto storage = getNested();
+        return storage->write(query, metadata_snapshot, context, async_insert);
+    }
+
+    void renameInMemory(const StorageID & new_table_id) override
+    {
+        std::lock_guard lock{nested_mutex};
+        if (nested)
+            StorageProxy::renameInMemory(new_table_id);
+        else
+            IStorage::renameInMemory(new_table_id); /// NOLINT
+    }
+
+    void checkTableCanBeDropped([[maybe_unused]] ContextPtr query_context) const override { }
+
+    std::optional<UInt64> totalRows(ContextPtr query_context) const override
+    {
+        std::lock_guard lock{nested_mutex};
+        if (nested)
+            return nested->totalRows(query_context);
+        return std::nullopt;
+    }
+
+    std::optional<UInt64> totalBytes(ContextPtr query_context) const override
+    {
+        std::lock_guard lock{nested_mutex};
+        if (nested)
+            return nested->totalBytes(query_context);
+        return std::nullopt;
+    }
+
+    std::optional<UInt64> lifetimeRows() const override
+    {
+        std::lock_guard lock{nested_mutex};
+        if (nested)
+            return nested->lifetimeRows();
+        return std::nullopt;
+    }
+
+    std::optional<UInt64> lifetimeBytes() const override
+    {
+        std::lock_guard lock{nested_mutex};
+        if (nested)
+            return nested->lifetimeBytes();
+        return std::nullopt;
+    }
+
+private:
+    mutable std::recursive_mutex nested_mutex;
+    mutable std::function<StoragePtr()> get_nested;
+    mutable StoragePtr nested;
+    LoggerPtr log;
+};
+
+}

--- a/src/Storages/StorageTableProxy.h
+++ b/src/Storages/StorageTableProxy.h
@@ -133,7 +133,7 @@ public:
     void renameInMemory(const StorageID & new_table_id) override
     {
         std::lock_guard lock{nested_mutex};
-        IStorage::renameInMemory(new_table_id);
+        IStorage::renameInMemory(new_table_id); // NOLINT(bugprone-parent-virtual-call)
         if (nested)
             nested->renameInMemory(new_table_id);
     }

--- a/tests/queries/0_stateless/03823_lazy_load_tables.reference
+++ b/tests/queries/0_stateless/03823_lazy_load_tables.reference
@@ -1,0 +1,8 @@
+t1	TableProxy
+v1	View
+1	hello
+2	world
+t1	TableProxy
+v1	View
+t2	TableProxy
+0

--- a/tests/queries/0_stateless/03823_lazy_load_tables.reference
+++ b/tests/queries/0_stateless/03823_lazy_load_tables.reference
@@ -2,7 +2,7 @@ t1	TableProxy
 v1	View
 1	hello
 2	world
-t1	TableProxy
+t1	MergeTree
 v1	View
 t2	TableProxy
 0

--- a/tests/queries/0_stateless/03823_lazy_load_tables.reference
+++ b/tests/queries/0_stateless/03823_lazy_load_tables.reference
@@ -6,3 +6,8 @@ t1	MergeTree
 v1	View
 t2	TableProxy
 0
+mv	MaterializedView
+src	TableProxy
+dict
+t3_renamed	MergeTree
+value	String

--- a/tests/queries/0_stateless/03823_lazy_load_tables.sql
+++ b/tests/queries/0_stateless/03823_lazy_load_tables.sql
@@ -1,0 +1,45 @@
+-- Tags: no-replicated-database
+
+DROP DATABASE IF EXISTS test_lazy_load;
+
+-- Create database with lazy_load_tables enabled (Atomic engine, the default)
+CREATE DATABASE test_lazy_load ENGINE = Atomic SETTINGS lazy_load_tables = 1;
+
+-- Create a MergeTree table and insert data
+CREATE TABLE test_lazy_load.t1 (id UInt64, value String) ENGINE = MergeTree ORDER BY id;
+INSERT INTO test_lazy_load.t1 VALUES (1, 'hello'), (2, 'world');
+
+-- Create a view (should NOT be lazy-loaded)
+CREATE VIEW test_lazy_load.v1 AS SELECT * FROM test_lazy_load.t1;
+
+-- Detach and re-attach database to trigger reload with lazy loading
+DETACH DATABASE test_lazy_load;
+ATTACH DATABASE test_lazy_load;
+
+-- After re-attach, the MergeTree table should show as TableProxy (lazy, not yet loaded).
+-- Views are not lazy-loaded so they keep their real engine name.
+SELECT name, engine FROM system.tables WHERE database = 'test_lazy_load' ORDER BY name;
+
+-- Accessing the table should trigger loading and return the correct data.
+SELECT * FROM test_lazy_load.t1 ORDER BY id;
+
+-- The engine name in system.tables stays as TableProxy (by design: proxy wraps the real storage).
+SELECT name, engine FROM system.tables WHERE database = 'test_lazy_load' ORDER BY name;
+
+-- Test: DROP works on an unloaded lazy table.
+-- Create t2, insert data, then detach/attach so it becomes a proxy.
+CREATE TABLE test_lazy_load.t2 (x UInt32) ENGINE = MergeTree ORDER BY x;
+INSERT INTO test_lazy_load.t2 VALUES (42);
+
+DETACH DATABASE test_lazy_load;
+ATTACH DATABASE test_lazy_load;
+
+-- t2 should be a proxy now
+SELECT name, engine FROM system.tables WHERE database = 'test_lazy_load' AND name = 't2';
+
+-- DROP should work even though the table is still a proxy (forces nested load for cleanup)
+DROP TABLE test_lazy_load.t2;
+SELECT count() FROM system.tables WHERE database = 'test_lazy_load' AND name = 't2';
+
+-- Cleanup
+DROP DATABASE test_lazy_load;

--- a/tests/queries/0_stateless/03823_lazy_load_tables.sql
+++ b/tests/queries/0_stateless/03823_lazy_load_tables.sql
@@ -15,11 +15,12 @@ DETACH DATABASE {CLICKHOUSE_DATABASE_1:Identifier};
 ATTACH DATABASE {CLICKHOUSE_DATABASE_1:Identifier};
 
 -- After re-attach, MergeTree shows as TableProxy; views load normally.
-SELECT name, engine FROM system.tables WHERE database = {CLICKHOUSE_DATABASE_1:String} ORDER BY name;
+USE {CLICKHOUSE_DATABASE_1:Identifier};
+SELECT name, engine FROM system.tables WHERE database = currentDatabase() ORDER BY name;
 
 SELECT * FROM {CLICKHOUSE_DATABASE_1:Identifier}.t1 ORDER BY id;
 
-SELECT name, engine FROM system.tables WHERE database = {CLICKHOUSE_DATABASE_1:String} ORDER BY name;
+SELECT name, engine FROM system.tables WHERE database = currentDatabase() ORDER BY name;
 
 -- DROP on an unloaded lazy proxy forces nested load for cleanup.
 CREATE TABLE {CLICKHOUSE_DATABASE_1:Identifier}.t2 (x UInt32) ENGINE = MergeTree ORDER BY x;
@@ -28,9 +29,10 @@ INSERT INTO {CLICKHOUSE_DATABASE_1:Identifier}.t2 VALUES (42);
 DETACH DATABASE {CLICKHOUSE_DATABASE_1:Identifier};
 ATTACH DATABASE {CLICKHOUSE_DATABASE_1:Identifier};
 
-SELECT name, engine FROM system.tables WHERE database = {CLICKHOUSE_DATABASE_1:String} AND name = 't2';
+USE {CLICKHOUSE_DATABASE_1:Identifier};
+SELECT name, engine FROM system.tables WHERE database = currentDatabase() AND name = 't2';
 
 DROP TABLE {CLICKHOUSE_DATABASE_1:Identifier}.t2;
-SELECT count() FROM system.tables WHERE database = {CLICKHOUSE_DATABASE_1:String} AND name = 't2';
+SELECT count() FROM system.tables WHERE database = currentDatabase() AND name = 't2';
 
 DROP DATABASE {CLICKHOUSE_DATABASE_1:Identifier};

--- a/tests/queries/0_stateless/03823_lazy_load_tables.sql
+++ b/tests/queries/0_stateless/03823_lazy_load_tables.sql
@@ -1,45 +1,36 @@
 -- Tags: no-replicated-database
 
-DROP DATABASE IF EXISTS test_lazy_load;
+DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE_1:Identifier};
 
--- Create database with lazy_load_tables enabled (Atomic engine, the default)
-CREATE DATABASE test_lazy_load ENGINE = Atomic SETTINGS lazy_load_tables = 1;
+CREATE DATABASE {CLICKHOUSE_DATABASE_1:Identifier} ENGINE = Atomic SETTINGS lazy_load_tables = 1;
 
--- Create a MergeTree table and insert data
-CREATE TABLE test_lazy_load.t1 (id UInt64, value String) ENGINE = MergeTree ORDER BY id;
-INSERT INTO test_lazy_load.t1 VALUES (1, 'hello'), (2, 'world');
+CREATE TABLE {CLICKHOUSE_DATABASE_1:Identifier}.t1 (id UInt64, value String) ENGINE = MergeTree ORDER BY id;
+INSERT INTO {CLICKHOUSE_DATABASE_1:Identifier}.t1 VALUES (1, 'hello'), (2, 'world');
 
--- Create a view (should NOT be lazy-loaded)
-CREATE VIEW test_lazy_load.v1 AS SELECT * FROM test_lazy_load.t1;
+-- Use the database so the view's AS clause resolves table names without explicit db prefix.
+USE {CLICKHOUSE_DATABASE_1:Identifier};
+CREATE VIEW v1 AS SELECT * FROM t1;
 
--- Detach and re-attach database to trigger reload with lazy loading
-DETACH DATABASE test_lazy_load;
-ATTACH DATABASE test_lazy_load;
+DETACH DATABASE {CLICKHOUSE_DATABASE_1:Identifier};
+ATTACH DATABASE {CLICKHOUSE_DATABASE_1:Identifier};
 
--- After re-attach, the MergeTree table should show as TableProxy (lazy, not yet loaded).
--- Views are not lazy-loaded so they keep their real engine name.
-SELECT name, engine FROM system.tables WHERE database = 'test_lazy_load' ORDER BY name;
+-- After re-attach, MergeTree shows as TableProxy; views load normally.
+SELECT name, engine FROM system.tables WHERE database = {CLICKHOUSE_DATABASE_1:String} ORDER BY name;
 
--- Accessing the table should trigger loading and return the correct data.
-SELECT * FROM test_lazy_load.t1 ORDER BY id;
+SELECT * FROM {CLICKHOUSE_DATABASE_1:Identifier}.t1 ORDER BY id;
 
--- The engine name in system.tables stays as TableProxy (by design: proxy wraps the real storage).
-SELECT name, engine FROM system.tables WHERE database = 'test_lazy_load' ORDER BY name;
+SELECT name, engine FROM system.tables WHERE database = {CLICKHOUSE_DATABASE_1:String} ORDER BY name;
 
--- Test: DROP works on an unloaded lazy table.
--- Create t2, insert data, then detach/attach so it becomes a proxy.
-CREATE TABLE test_lazy_load.t2 (x UInt32) ENGINE = MergeTree ORDER BY x;
-INSERT INTO test_lazy_load.t2 VALUES (42);
+-- DROP on an unloaded lazy proxy forces nested load for cleanup.
+CREATE TABLE {CLICKHOUSE_DATABASE_1:Identifier}.t2 (x UInt32) ENGINE = MergeTree ORDER BY x;
+INSERT INTO {CLICKHOUSE_DATABASE_1:Identifier}.t2 VALUES (42);
 
-DETACH DATABASE test_lazy_load;
-ATTACH DATABASE test_lazy_load;
+DETACH DATABASE {CLICKHOUSE_DATABASE_1:Identifier};
+ATTACH DATABASE {CLICKHOUSE_DATABASE_1:Identifier};
 
--- t2 should be a proxy now
-SELECT name, engine FROM system.tables WHERE database = 'test_lazy_load' AND name = 't2';
+SELECT name, engine FROM system.tables WHERE database = {CLICKHOUSE_DATABASE_1:String} AND name = 't2';
 
--- DROP should work even though the table is still a proxy (forces nested load for cleanup)
-DROP TABLE test_lazy_load.t2;
-SELECT count() FROM system.tables WHERE database = 'test_lazy_load' AND name = 't2';
+DROP TABLE {CLICKHOUSE_DATABASE_1:Identifier}.t2;
+SELECT count() FROM system.tables WHERE database = {CLICKHOUSE_DATABASE_1:String} AND name = 't2';
 
--- Cleanup
-DROP DATABASE test_lazy_load;
+DROP DATABASE {CLICKHOUSE_DATABASE_1:Identifier};


### PR DESCRIPTION
### Changelog category (leave one):
- New Feature


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add `lazy_load_tables` database setting. When enabled, tables are not loaded during database startup — a lightweight `StorageTableProxy` is created instead and the real table engine is materialized on first access.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

**Motivation:** Large databases with many tables can have slow startup times because every table is loaded eagerly. The `lazy_load_tables` setting allows deferring table loading until the table is actually accessed, reducing startup time and memory usage for databases where only a subset of tables are actively queried.

**Parameters:**
- `lazy_load_tables` (Bool, default `false`) — Database-level setting. When set to `1`/`true`, tables are replaced with a lightweight `StorageTableProxy` during database startup. The real storage engine is created and started on first read/write access.

**Scope:** Works with `Atomic`, `Ordinary`, and similar on-disk database engines. Views, dictionaries, materialized views, and table functions are excluded from lazy loading (they load normally).

**Example use:**
```sql
CREATE DATABASE my_db ENGINE = Atomic SETTINGS lazy_load_tables = 1;
CREATE TABLE my_db.t1 (id UInt64) ENGINE = MergeTree ORDER BY id;

-- After server restart or DETACH/ATTACH, t1 appears as TableProxy in system.tables
-- until it is first accessed:
SELECT name, engine FROM system.tables WHERE database = 'my_db';
-- ┌─name─┬─engine─────┐
-- │ t1   │ TableProxy │
-- └──────┴────────────┘

-- First query triggers real loading transparently:
SELECT * FROM my_db.t1;
```

Closes #94039


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.950`
<!-- ch-version-info:end -->