### PR TITLE
Increase startup timeout for Keeper HTTP control tests

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -3315,7 +3315,7 @@ class ClickHouseCluster:
     def wait_arrowflight_to_start(self):
         time.sleep(5) # TODO
 
-    def start(self):
+    def start(self, connection_timeout=None):
         pytest_xdist_logging_to_separate_files.setup()
         logging.info("Running tests in {}".format(self.base_path))
         if not os.path.exists(self.instances_dir):
@@ -3891,7 +3891,7 @@ class ClickHouseCluster:
                 logging.debug(
                     f"Waiting for ClickHouse start in {instance.name}, ip: {instance.ip_address}..."
                 )
-                instance.wait_for_start(start_timeout)
+                instance.wait_for_start(start_timeout, connection_timeout=connection_timeout)
                 logging.debug(f"ClickHouse {instance.name} started")
 
                 instance.client = Client(

--- a/tests/integration/test_keeper_http_control_cli/test.py
+++ b/tests/integration/test_keeper_http_control_cli/test.py
@@ -35,7 +35,7 @@ node3 = cluster.add_instance(
 @pytest.fixture(scope="module")
 def started_cluster():
     try:
-        cluster.start(connection_timeout=600.0)
+        cluster.start(connection_timeout=420.0)
         yield cluster
     finally:
         cluster.shutdown()

--- a/tests/integration/test_keeper_http_control_cli/test.py
+++ b/tests/integration/test_keeper_http_control_cli/test.py
@@ -35,7 +35,7 @@ node3 = cluster.add_instance(
 @pytest.fixture(scope="module")
 def started_cluster():
     try:
-        cluster.start()
+        cluster.start(connection_timeout=600.0)
         yield cluster
     finally:
         cluster.shutdown()

--- a/tests/integration/test_keeper_http_control_cli/test.py
+++ b/tests/integration/test_keeper_http_control_cli/test.py
@@ -35,7 +35,7 @@ node3 = cluster.add_instance(
 @pytest.fixture(scope="module")
 def started_cluster():
     try:
-        cluster.start(connection_timeout=420.0)
+        cluster.start(connection_timeout=450.0)
         yield cluster
     finally:
         cluster.shutdown()

--- a/tests/integration/test_keeper_http_control_readiness/test.py
+++ b/tests/integration/test_keeper_http_control_readiness/test.py
@@ -36,7 +36,7 @@ node3 = cluster.add_instance(
 @pytest.fixture(scope="module")
 def started_cluster():
     try:
-        cluster.start(connection_timeout=600.0)
+        cluster.start(connection_timeout=420.0)
         yield cluster
     finally:
         cluster.shutdown()

--- a/tests/integration/test_keeper_http_control_readiness/test.py
+++ b/tests/integration/test_keeper_http_control_readiness/test.py
@@ -36,7 +36,7 @@ node3 = cluster.add_instance(
 @pytest.fixture(scope="module")
 def started_cluster():
     try:
-        cluster.start()
+        cluster.start(connection_timeout=600.0)
         yield cluster
     finally:
         cluster.shutdown()

--- a/tests/integration/test_keeper_http_control_readiness/test.py
+++ b/tests/integration/test_keeper_http_control_readiness/test.py
@@ -36,7 +36,7 @@ node3 = cluster.add_instance(
 @pytest.fixture(scope="module")
 def started_cluster():
     try:
-        cluster.start(connection_timeout=420.0)
+        cluster.start(connection_timeout=450.0)
         yield cluster
     finally:
         cluster.shutdown()


### PR DESCRIPTION
3-node Keeper clusters can take more than 300 seconds to start under ASan/CI load. Pass `connection_timeout=600.0` to allow extended startup when the server is still making progress (producing log output).

Add `connection_timeout` parameter to `ClickHouseCluster.start` and forward it to `wait_for_start`.

Note: in the example, it took 303s.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.424`
<!-- ch-version-info:end -->