### PR TITLE
Fix YTsaurus crash loop from non-idempotent admin user creation

### DIFF
--- a/tests/integration/compose/docker_compose_ytsaurus.yml
+++ b/tests/integration/compose/docker_compose_ytsaurus.yml
@@ -10,17 +10,27 @@ services:
             YT_PROXY: ytsaurus_backend1:${YTSAURUS_PROXY_PORT}
         ports:
             - ${YTSAURUS_PROXY_PORT}:${YTSAURUS_PROXY_PORT}
-        entrypoint: yt_local start --proxy-port ${YTSAURUS_PROXY_PORT}
-                    --local-cypress-dir /var/lib/yt/local-cypress
-                    --ytserver-all-path /usr/bin/ytserver-all
-                    --sync --fqdn ytsaurus_backend1
-                    --proxy-config '{coordinator={public_fqdn="ytsaurus_backend1:${YTSAURUS_PROXY_PORT}"}}'
-                    --node-count 1
-                    --queue-agent-count 1
-                    --address-resolver-config '{enable_ipv4=%true;enable_ipv6=%false;}'
-                    --listen-port-pool ${YTSAURUS_INTERNAL_PORTS_LIST}
-                    --native-client-supported
-                    --id primary -c '{name=query-tracker}'
-                    --enable-auth
-                    --create-admin-user
+        entrypoint:
+            - bash
+            - -c
+            - |
+              ADMIN_FLAG=""
+              if [ ! -f /tmp/.yt_admin_created ]; then
+                ADMIN_FLAG="--create-admin-user"
+                touch /tmp/.yt_admin_created
+              fi
+              exec yt_local start \
+                --proxy-port ${YTSAURUS_PROXY_PORT} \
+                --local-cypress-dir /var/lib/yt/local-cypress \
+                --ytserver-all-path /usr/bin/ytserver-all \
+                --sync --fqdn ytsaurus_backend1 \
+                --proxy-config '{coordinator={public_fqdn="ytsaurus_backend1:${YTSAURUS_PROXY_PORT}"}}' \
+                --node-count 1 \
+                --queue-agent-count 1 \
+                --address-resolver-config '{enable_ipv4=%true;enable_ipv6=%false;}' \
+                --listen-port-pool ${YTSAURUS_INTERNAL_PORTS_LIST} \
+                --native-client-supported \
+                --id primary -c '{name=query-tracker}' \
+                --enable-auth \
+                $$ADMIN_FLAG
         cpus: 3


### PR DESCRIPTION
When the YTsaurus scheduler times out during startup (40s default), the container exits and Docker restarts it (`restart: always`). On restart, `--create-admin-user` fails because the admin user already exists from the first attempt (data persists via `--local-cypress-dir`). This creates an infinite crash loop where the `/ping` endpoint briefly responds between restarts, giving a false "ready" signal.

Fix by wrapping the entrypoint in bash and using a marker file (`/tmp/.yt_admin_created`) to only pass `--create-admin-user` on the first startup attempt.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.405`
<!-- ch-version-info:end -->