### PR TITLE
Skip `test_jemalloc_percpu_arena` when CPU online override is ineffective

### DIFF
--- a/tests/integration/test_jemalloc_percpu_arena/test.py
+++ b/tests/integration/test_jemalloc_percpu_arena/test.py
@@ -72,7 +72,11 @@ def test_jemalloc_percpu_arena():
     assert multiprocessing.cpu_count() > CPU_ID
 
     online_cpus = int(run_with_cpu_limit("getconf _NPROCESSORS_ONLN"))
-    assert online_cpus == 1, online_cpus
+    if online_cpus != 1:
+        pytest.skip(
+            f"sysconf(_SC_NPROCESSORS_ONLN) returned {online_cpus} instead of 1: "
+            "/sys/devices/system/cpu/online override not effective on this system"
+        )
 
     all_cpus = int(run_with_cpu_limit("getconf _NPROCESSORS_CONF"))
     assert all_cpus == multiprocessing.cpu_count(), all_cpus


### PR DESCRIPTION
The test bind-mounts a fake /sys/devices/system/cpu/online to simulate having fewer online CPUs than configured. However, `sysconf(_SC_NPROCESSORS_ONLN)` does not always read from that file - glibc can use `sched_getaffinity` instead, especially on newer kernels or ARM. When the override doesn't take effect, the test fails with `assert online_cpus == 1` getting the real CPU count.

Skip instead of failing, since the test's precondition cannot be guaranteed on all systems.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.404`
<!-- ch-version-info:end -->