### PR TITLE
Wait for Keeper to start after restart in `test_keeper_session_refuse_stale_server`

### DIFF
--- a/tests/integration/test_keeper_session_refuse_stale_server/test.py
+++ b/tests/integration/test_keeper_session_refuse_stale_server/test.py
@@ -70,6 +70,7 @@ def test_session_refused_on_stale_keeper(started_cluster):
         )
     started_cluster.stop_zookeeper_nodes(ZOOKEEPER_CONTAINERS)
     started_cluster.start_zookeeper_nodes(ZOOKEEPER_CONTAINERS)
+    started_cluster.wait_zookeeper_to_start()
 
     # all the connection attempts should fail because keeper client's last_zxid_seen is larger than the server's
     error = node.query_and_get_error(f"CREATE DATABASE {t2} ENGINE = Replicated('/clickhouse/databases/{t2}', 's1', 'r1')")


### PR DESCRIPTION
`start_zookeeper_nodes` only starts Docker containers but does not wait for Keeper to be ready. Without `wait_zookeeper_to_start`, the test may get "Connection refused" at line 89 because the Keeper cluster hasn't finished starting, rather than the intended `SESSION_REFUSED` from the stale zxid check.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)
