### PR TITLE
Fix `test_restore_db_replica`: Wait for async recovery after `SYSTEM RESTORE DATABASE REPLICA`

### DIFF
--- a/tests/integration/test_restore_db_replica/test.py
+++ b/tests/integration/test_restore_db_replica/test.py
@@ -258,6 +258,7 @@ def test_query_after_restore_db_replica(
     )
 
     node_1.query(f"SYSTEM RESTORE DATABASE REPLICA {exclusive_database_name}")
+    assert node_1.wait_for_log_line(f"{exclusive_database_name}): All tables are created successfully")
 
     if need_restart:
         node_1.restart_clickhouse()
@@ -274,6 +275,7 @@ def test_query_after_restore_db_replica(
     )
 
     node_2.query(f"SYSTEM RESTORE DATABASE REPLICA {exclusive_database_name}")
+    assert node_2.wait_for_log_line(f"{exclusive_database_name}): All tables are created successfully")
     assert zk.exists(f"/clickhouse/{exclusive_database_name}/replicas/shard1|replica2")
 
     if exists_table:
@@ -345,7 +347,9 @@ def test_query_after_restore_db_replica(
     )
 
     node_1.query(f"SYSTEM RESTORE DATABASE REPLICA {exclusive_database_name}")
+    assert node_1.wait_for_log_line(f"{exclusive_database_name}): All tables are created successfully")
     node_2.query(f"SYSTEM RESTORE DATABASE REPLICA {exclusive_database_name}")
+    assert node_2.wait_for_log_line(f"{exclusive_database_name}): All tables are created successfully")
 
     if need_restart:
         node_1.restart_clickhouse()


### PR DESCRIPTION
`SYSTEM RESTORE DATABASE REPLICA` returns before the DDL worker finishes the actual recovery (table recreation from ZK metadata). Without waiting, subsequent operations on restored tables can fail with "Table does not exist" or miss tables in system.tables queries.

Add `wait_for_log_line("All tables are created successfully")` after each restore call, matching the pattern already used in other tests in the same file.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.407`
<!-- ch-version-info:end -->