### PR TITLE
Increase wait timeouts in `test_storage_s3_queue`

### DIFF
--- a/tests/integration/test_storage_s3_queue/test_4.py
+++ b/tests/integration/test_storage_s3_queue/test_4.py
@@ -318,7 +318,7 @@ def test_alter_settings(started_cluster):
         )
 
     expected_rows = files_to_generate
-    for _ in range(100):
+    for _ in range(300):
         if expected_rows == get_count():
             break
         time.sleep(1)

--- a/tests/integration/test_storage_s3_queue/test_6.py
+++ b/tests/integration/test_storage_s3_queue/test_6.py
@@ -161,7 +161,7 @@ def test_ordered_mode_with_hive(started_cluster, engine_name, processing_threads
                 assert data.count(expected_line) == 1, f"Expected exacly one element '{expected_line}', got: {data}"
 
     def wait_for_data(dst_table_name, expected_count):
-        for i in range(10):
+        for i in range(60):
             count = 0
             for node in instances:
                 count += int(node.query(f"SELECT count() FROM {dst_table_name}"))
@@ -373,7 +373,7 @@ def test_ordered_mode_with_regex_partitioning(started_cluster, engine_name, proc
                 assert data.count(expected_line) == 1, f"Expected exactly one element '{expected_line}', got: {data}"
 
     def wait_for_data(dst_table_name, expected_count):
-        for i in range(10):
+        for i in range(60):
             count = 0
             for node in instances:
                 count += int(node.query(f"SELECT count() FROM {dst_table_name}"))


### PR DESCRIPTION
`test_alter_settings` (253 failures/30d): Increase wait from 100s to 300s for processing 1000 files. With 5% Keeper fault injection and ASan/TSan overhead, 100s is frequently insufficient.

`test_ordered_mode_with_hive` (9-26 failures/30d per parametrization): Increase wait_for_data from 10s to 60s. 10s is far too short under Keeper fault injection with sanitizer builds.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)
