### PR TITLE
Fix relative config paths resolving against wrong directory after chdir

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -525,11 +525,13 @@ enum StartupScriptsExecutionState : CurrentMetrics::Value
 };
 
 
-static std::string getCanonicalPath(std::string && path)
+static std::string getCanonicalPath(std::string && path, const std::string & base = {})
 {
     Poco::trimInPlace(path);
     if (path.empty())
         throw Exception(ErrorCodes::INVALID_CONFIG_PARAMETER, "path configuration parameter is empty");
+    if (!base.empty() && fs::path(path).is_relative())
+        path = fs::weakly_canonical(fs::path(base) / path);
     if (path.back() != '/')
         path += '/';
     return std::move(path);
@@ -719,7 +721,7 @@ void Server::initialize(Poco::Util::Application & self)
 
 std::string Server::getDefaultCorePath() const
 {
-    return getCanonicalPath(config().getString("path", DBMS_DEFAULT_PATH)) + "cores";
+    return getCanonicalPath(config().getString("path", DBMS_DEFAULT_PATH), original_working_directory) + "cores";
 }
 
 void Server::defineOptions(Poco::Util::OptionSet & options)
@@ -784,7 +786,7 @@ int readNumber(const String & path)
 
 void sanityChecks(Server & server, const ServerSettings & server_settings)
 {
-    std::string data_path = getCanonicalPath(String(server_settings[ServerSetting::path]));
+    std::string data_path = getCanonicalPath(String(server_settings[ServerSetting::path]), server.getOriginalWorkingDirectory());
     std::string logs_path = server_settings[ServerSetting::logger_log];
 
     if (server.logger().is(Poco::Message::PRIO_TEST))
@@ -1618,7 +1620,7 @@ try
         server_settings[ServerSetting::max_format_parsing_thread_pool_free_size],
         server_settings[ServerSetting::format_parsing_thread_pool_queue_size]);
 
-    std::string path_str = getCanonicalPath(String(server_settings[ServerSetting::path]));
+    std::string path_str = getCanonicalPath(String(server_settings[ServerSetting::path]), original_working_directory);
     fs::path path = path_str;
 
     /// Check that the process user id matches the owner of the data.
@@ -1849,27 +1851,31 @@ try
       */
     {
         const auto & user_files_path_setting = server_settings[ServerSetting::user_files_path];
-        std::string user_files_path = user_files_path_setting.changed ? user_files_path_setting.value : String(path / "user_files/");
+        std::string user_files_path = user_files_path_setting.changed
+            ? getCanonicalPath(String(user_files_path_setting.value), path_str) : String(path / "user_files/");
         global_context->setUserFilesPath(user_files_path);
         fs::create_directories(user_files_path);
     }
 
     {
         const auto & dictionaries_lib_path_setting = server_settings[ServerSetting::dictionaries_lib_path];
-        std::string dictionaries_lib_path = dictionaries_lib_path_setting.changed ? dictionaries_lib_path_setting.value : String(path / "dictionaries_lib/");
+        std::string dictionaries_lib_path = dictionaries_lib_path_setting.changed
+            ? getCanonicalPath(String(dictionaries_lib_path_setting.value), path_str) : String(path / "dictionaries_lib/");
         global_context->setDictionariesLibPath(dictionaries_lib_path);
     }
 
     {
         const auto & user_scripts_path_setting = server_settings[ServerSetting::user_scripts_path];
-        std::string user_scripts_path = user_scripts_path_setting.changed ? user_scripts_path_setting.value : String(path / "user_scripts/");
+        std::string user_scripts_path = user_scripts_path_setting.changed
+            ? getCanonicalPath(String(user_scripts_path_setting.value), path_str) : String(path / "user_scripts/");
         global_context->setUserScriptsPath(user_scripts_path);
     }
 
     /// top_level_domains_lists
     {
         const auto & top_level_domains_path_setting = server_settings[ServerSetting::top_level_domains_path];
-        const std::string & top_level_domains_path = top_level_domains_path_setting.changed ? top_level_domains_path_setting.value : String(path / "top_level_domains/");
+        std::string top_level_domains_path = top_level_domains_path_setting.changed
+            ? getCanonicalPath(String(top_level_domains_path_setting.value), path_str) : String(path / "top_level_domains/");
         TLDListsHolder::getInstance().parseConfig(fs::path(top_level_domains_path) / "", config());
     }
 
@@ -2645,7 +2651,8 @@ try
     else
     {
         const auto & tmp_path_setting = server_settings[ServerSetting::tmp_path];
-        std::string temporary_path = tmp_path_setting.changed ? tmp_path_setting.value : String(path / "tmp/");
+        std::string temporary_path = tmp_path_setting.changed
+            ? getCanonicalPath(String(tmp_path_setting.value), path_str) : String(path / "tmp/");
         global_context->setTemporaryStoragePath(temporary_path, server_settings[ServerSetting::max_temporary_data_on_disk_size]);
     }
 
@@ -2715,7 +2722,8 @@ try
 
     /// Set path for format schema files
     const auto & format_schema_path_setting = server_settings[ServerSetting::format_schema_path];
-    fs::path format_schema_path(format_schema_path_setting.changed ? fs::path(format_schema_path_setting.value) : path / "format_schemas/");
+    fs::path format_schema_path(format_schema_path_setting.changed
+        ? fs::path(getCanonicalPath(String(format_schema_path_setting.value), path_str)) : path / "format_schemas/");
     global_context->setFormatSchemaPath(format_schema_path);
     fs::create_directories(format_schema_path);
 
@@ -2724,9 +2732,11 @@ try
         global_context->setGoogleProtosPath(fs::weakly_canonical(server_settings[ServerSetting::google_protos_path].value));
 
     /// Set path for filesystem caches
-    fs::path filesystem_caches_path = server_settings[ServerSetting::filesystem_caches_path].value;
-    if (!filesystem_caches_path.empty())
-        global_context->setFilesystemCachesPath(filesystem_caches_path);
+    {
+        String filesystem_caches_path = server_settings[ServerSetting::filesystem_caches_path].value;
+        if (!filesystem_caches_path.empty())
+            global_context->setFilesystemCachesPath(getCanonicalPath(std::move(filesystem_caches_path), path_str));
+    }
 
     /// NOTE: Do sanity checks after we loaded all possible substitutions (for the configuration) from ZK
     /// Additionally, making the check after the default profile is initialized.

--- a/src/Daemon/BaseDaemon.cpp
+++ b/src/Daemon/BaseDaemon.cpp
@@ -233,6 +233,11 @@ void BaseDaemon::closeFDs()
 void BaseDaemon::initialize(Application & self)
 {
     closeFDs();
+
+    /// Remember the original working directory before any chdir calls below.
+    /// This is needed to correctly resolve relative config paths later.
+    original_working_directory = fs::current_path();
+
     ServerApplication::initialize(self);
 
     /// now highest priority (lowest value) is PRIO_APPLICATION = -100, we want higher!

--- a/src/Daemon/BaseDaemon.h
+++ b/src/Daemon/BaseDaemon.h
@@ -121,6 +121,9 @@ public:
     /// Hash of the binary for integrity checks.
     String getStoredBinaryHash() const;
 
+    /// The working directory at the time the daemon was started, before any chdir calls.
+    const std::string & getOriginalWorkingDirectory() const { return original_working_directory; }
+
 protected:
     virtual void logRevision() const;
 
@@ -161,6 +164,10 @@ protected:
     std::string config_path;
     DB::ConfigProcessor::LoadedConfig loaded_config;
     Poco::Util::AbstractConfiguration * last_configuration = nullptr;
+
+    /// The working directory at the time the daemon was started, before any chdir calls.
+    /// Used to resolve relative config paths correctly.
+    std::string original_working_directory;
 
     String build_id;
     String stored_binary_hash;

--- a/tests/integration/test_relative_filepath/test.py
+++ b/tests/integration/test_relative_filepath/test.py
@@ -4,7 +4,7 @@ from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance("node", main_configs=["configs/config.xml"])
-path_to_userfiles_from_defaut_config = "user_files"
+path_to_userfiles_from_defaut_config = "/var/lib/clickhouse/user_files"
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_relative_filepath/test.py
+++ b/tests/integration/test_relative_filepath/test.py
@@ -4,7 +4,11 @@ from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance("node", main_configs=["configs/config.xml"])
-path_to_userfiles_from_defaut_config = "/var/lib/clickhouse/user_files"
+
+# The config sets user_files_path to the relative value "user_files".
+# The server resolves it against the main path setting to /var/lib/clickhouse/user_files/.
+user_files_absolute = "/var/lib/clickhouse/user_files"
+user_files_dirname = "user_files"
 
 
 @pytest.fixture(scope="module")
@@ -21,7 +25,7 @@ def test_filepath(start_cluster):
     some_data = "Test\t111.222\nData\t333.444"
 
     node.exec_in_container(
-        ["bash", "-c", "mkdir -p {}".format(path_to_userfiles_from_defaut_config)],
+        ["bash", "-c", "mkdir -p {}".format(user_files_absolute)],
         privileged=True,
         user="root",
     )
@@ -32,7 +36,7 @@ def test_filepath(start_cluster):
             "-c",
             'echo "{}" > {}'.format(
                 some_data,
-                path_to_userfiles_from_defaut_config + "/relative_user_file_test",
+                user_files_absolute + "/relative_user_file_test",
             ),
         ],
         privileged=True,
@@ -42,7 +46,7 @@ def test_filepath(start_cluster):
     test_requests = [
         ("relative_user_file_test", "2"),
         (
-            "../" + path_to_userfiles_from_defaut_config + "/relative_user_file_test",
+            "../" + user_files_dirname + "/relative_user_file_test",
             "2",
         ),
     ]


### PR DESCRIPTION
`BaseDaemon::initialize` performs up to 3 `chdir` calls during daemon startup (to application path, log path, and cores directory). After `initialize` returns, `Server::main` reads path settings from config. If those paths are relative, they resolve against the cores directory instead of the original startup directory.

Fix by capturing the original working directory at the start of `BaseDaemon::initialize` and using it to resolve the main `path` setting to absolute. All secondary path settings (like `user_files_path`, `tmp_path`, `format_schema_path`, etc.) are resolved relative to the now-absolute main `path`.

### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Under certain circumstances, manual server startup without a configuration file, could place the data directory inside an unusual location, e.g., `/tmp/cores/`. This is fixed by resolving the `path` configuration parameter relative to the working directory at the moment of server startup and resolving all other paths relative to the `path`.

See https://github.com/ClickHouse/homebrew-clickhouse/issues/78


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.434`
<!-- ch-version-info:end -->