### PR TITLE
Fix sporadic timeout in `03634_autopr_*_bytes_estimation` tests

### DIFF
--- a/tests/queries/0_stateless/03634_autopr_input_bytes_estimation.sql
+++ b/tests/queries/0_stateless/03634_autopr_input_bytes_estimation.sql
@@ -8,6 +8,9 @@ SET enable_parallel_replicas=0, automatic_parallel_replicas_mode=2, parallel_rep
 -- Reading of aggregation states from disk will affect `ReadCompressedBytes`
 SET max_bytes_before_external_group_by=0, max_bytes_ratio_before_external_group_by=0;
 
+-- Override randomized max_threads to avoid timeout on slow builds (ASan)
+SET max_threads=0;
+
 SELECT COUNT(*) FROM test.hits WHERE AdvEngineID <> 0 FORMAT Null SETTINGS log_comment='query_1';
 
 -- Unsupported at the moment, refer to comments in `RuntimeDataflowStatisticsCacheUpdater::recordAggregationStateSizes`

--- a/tests/queries/0_stateless/03634_autopr_output_bytes_estimation.sql
+++ b/tests/queries/0_stateless/03634_autopr_output_bytes_estimation.sql
@@ -6,6 +6,9 @@ SET enable_parallel_replicas=0, automatic_parallel_replicas_mode=2, parallel_rep
 -- External aggregation is not supported as of now
 SET max_bytes_before_external_group_by=0, max_bytes_ratio_before_external_group_by=0;
 
+-- Override randomized max_threads to avoid timeout on slow builds (ASan)
+SET max_threads=0;
+
 SELECT COUNT(*) FROM test.hits WHERE AdvEngineID <> 0 FORMAT Null SETTINGS log_comment='query_1';
 
 -- Unsupported at the moment, refer to comments in `RuntimeDataflowStatisticsCacheUpdater::recordAggregationStateSizes`


### PR DESCRIPTION
The test `03634_autopr_output_bytes_estimation` timed out (600s) on arm ASan because the randomized `max_threads=1` setting forced heavy analytical queries on `test.hits` to run single-threaded. With ASan overhead this far exceeds the timeout. The input bytes test was also close to the limit (404s).

Override `max_threads` to auto-detect (0) in both tests, since thread count is irrelevant to what they verify (dataflow statistics accuracy).

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.409`
<!-- ch-version-info:end -->