### PR TITLE
Ignore `KEEPER_EXCEPTION` in stress test smoke check

### DIFF
--- a/ci/jobs/scripts/stress/stress.py
+++ b/ci/jobs/scripts/stress/stress.py
@@ -265,11 +265,12 @@ def run_func_test(
         except subprocess.CalledProcessError as e:
             logging.info(e.stdout)
 
-            # Ignore fault injects, but most of the time tests should complete successfully
+            # Ignore fault injects and transient errors, but most of the time tests should complete successfully
             ignored_errors = [
                 "CANNOT_SCHEDULE_TASK",
                 "Fault injection",
                 "Query memory tracker: fault injected",
+                "KEEPER_EXCEPTION",
             ]
             if any(err in e.stdout or err in e.stderr for err in ignored_errors):
                 logging.warning(


### PR DESCRIPTION
The smoke check phase runs simple tests across all randomization configurations before the actual stress run. Under TSan + ThreadFuzzer, Keeper heartbeats can take ~10s, causing transient connection loss errors that kill the entire stress test before it even starts.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.389`
<!-- ch-version-info:end -->