### PR TITLE
Fix flaky test `03629_create_or_replace_as_select_with_progress_tcp`

### DIFF
--- a/tests/queries/0_stateless/helpers/parse_query_progress_tcp.python
+++ b/tests/queries/0_stateless/helpers/parse_query_progress_tcp.python
@@ -265,10 +265,12 @@ def main():
                 non_empty_progress_packets += 1
 
         print(summary_progress)
-        # Print only non empty progress packets, eventually we should have at least 3 of them
-        # - 2 for each INSERT block (one of them can be merged with read block, heance 3 or for)
+        # Print only non empty progress packets, we should have at least 3 of them:
+        # - 2 for each INSERT block (one of them can be merged with read block)
         # - 1 or 2 for each SELECT block
-        assert non_empty_progress_packets in (3, 4), f"{non_empty_progress_packets=:}"
+        # The upper bound is not enforced because under slow environments (e.g. TSan)
+        # the events may arrive in separate packets instead of being batched together.
+        assert non_empty_progress_packets >= 3, f"{non_empty_progress_packets=:}"
 
         s.close()
 


### PR DESCRIPTION
The assertion `non_empty_progress_packets in (3, 4)` is too strict. Under TSan, the query produces 5 non-empty progress packets because the individual progress events arrive in separate packets instead of being batched together within the same `interactive_delay` interval.

Relax the assertion to `>= 3` — the test's purpose is to verify that progress packets are received during `CREATE OR REPLACE ... AS SELECT`, not to enforce a timing-dependent upper bound.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=95865&sha=f7d5f749b1c3760bdbacfc605c636018ecc79b2c&name_0=PR&name_1=Stateless%20tests%20%28amd_tsan%2C%20s3%20storage%2C%20parallel%2C%201%2F2%29
https://github.com/ClickHouse/ClickHouse/pull/95865

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.388`
<!-- ch-version-info:end -->