### PR TITLE
Increase disconnection timeout in short disconnection backup/restore tests

### DIFF
--- a/tests/integration/test_backup_restore_on_cluster/test_cancel_backup.py
+++ b/tests/integration/test_backup_restore_on_cluster/test_cancel_backup.py
@@ -672,7 +672,7 @@ def test_short_disconnection_doesnt_stop_backup():
         backup_id = random_id()
         initiator.query(
             f"BACKUP TABLE tbl ON CLUSTER 'cluster' TO {get_backup_name(backup_id)} SETTINGS id='{backup_id}' ASYNC",
-            settings={"backup_restore_failure_after_host_disconnected_for_seconds": 10},
+            settings={"backup_restore_failure_after_host_disconnected_for_seconds": 30},
         )
 
         assert get_status(initiator, backup_id=backup_id) == "CREATING_BACKUP"
@@ -726,7 +726,7 @@ def test_short_disconnection_doesnt_stop_restore():
         restore_id = random_id()
         initiator.query(
             f"RESTORE TABLE tbl ON CLUSTER 'cluster' FROM {get_backup_name(backup_id)} SETTINGS id='{restore_id}' ASYNC",
-            settings={"backup_restore_failure_after_host_disconnected_for_seconds": 10},
+            settings={"backup_restore_failure_after_host_disconnected_for_seconds": 30},
         )
 
         assert get_status(initiator, restore_id=restore_id) == "RESTORING"


### PR DESCRIPTION
The `test_short_disconnection_doesnt_stop_backup` and `test_short_disconnection_doesnt_stop_restore` tests were flaky under TSan because the `backup_restore_failure_after_host_disconnected_for_seconds` timeout of 10s left too little margin — the actual disconnection can last up to ~8s (two `random_sleep` calls), and TSan overhead pushed it over the threshold. Increase to 30s.

See https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=95865&sha=f7d5f749b1c3760bdbacfc605c636018ecc79b2c&name_0=PR&name_1=Integration%20tests%20%28amd_tsan%2C%205%2F6%29
https://github.com/ClickHouse/ClickHouse/pull/95865

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.403`
<!-- ch-version-info:end -->