### PR TITLE
Fix stress test failure caused by empty Azure connection string

### DIFF
--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -242,10 +242,12 @@ def main():
 
     if not info.is_local_run:
         # TODO: find a way to work with Azure secret so it's ok for local tests as well, for now keep azure disabled
-        os.environ["AZURE_CONNECTION_STRING"] = Shell.get_output(
+        azure_connection_string = Shell.get_output(
             f"aws ssm get-parameter --region us-east-1 --name azure_connection_string --with-decryption --output text --query Parameter.Value",
             verbose=True,
+            strict=True,
         )
+        os.environ["AZURE_CONNECTION_STRING"] = azure_connection_string
     else:
         print("Disable azure for a local run")
         config_installs_args += " --no-azure"

--- a/ci/jobs/stress_job.py
+++ b/ci/jobs/stress_job.py
@@ -64,6 +64,7 @@ def get_additional_envs(info, check_name: str) -> List[str]:
         azure_connection_string = Shell.get_output(
             f"aws ssm get-parameter --region us-east-1 --name azure_connection_string --with-decryption --output text --query Parameter.Value",
             verbose=True,
+            strict=True,
         )
         result.append(f"AZURE_CONNECTION_STRING='{azure_connection_string}'")
     # some cloud-specific features require feature flags enabled

--- a/src/Disks/DiskObjectStorage/ObjectStorages/AzureBlobStorage/AzureBlobStorageCommon.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/AzureBlobStorage/AzureBlobStorageCommon.cpp
@@ -496,6 +496,10 @@ Endpoint processEndpoint(const Poco::Util::AbstractConfiguration & config, const
     else if (config.has(config_prefix + ".connection_string"))
     {
         storage_url = config.getString(config_prefix + ".connection_string");
+        if (storage_url.empty())
+            throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                "Azure Blob Storage connection string is empty. "
+                "If it is specified via an environment variable, please check that the variable is set");
         container_name = get_container_name();
     }
     else if (config.has(config_prefix + ".storage_account_url"))

--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -330,7 +330,7 @@ elif [[ "$USE_AZURE_STORAGE_FOR_MERGE_TREE" == "1" ]]; then
 fi
 
 if [[ "$EXPORT_S3_STORAGE_POLICIES" == "1" ]]; then
-    if [[ "$NO_AZURE" != "1" ]]; then
+    if [[ "$NO_AZURE" != "1" ]] && [[ -n "$AZURE_CONNECTION_STRING" ]]; then
         ln -sf $SRC_PATH/config.d/azure_storage_conf.xml $DEST_SERVER_PATH/config.d/
     fi
 


### PR DESCRIPTION
When the `AZURE_CONNECTION_STRING` environment variable is not available (e.g. AWS SSM credentials missing on the runner), the Azure storage config was still linked, and the empty connection string produced a cryptic `Unsupported scheme in URI '/'` error that prevented the server from starting.

Two fixes:
- Validate that the connection string is not empty in `processEndpoint`, giving a clear error message instead of the cryptic Azure SDK error.
- Skip linking `azure_storage_conf.xml` in test config installation when `AZURE_CONNECTION_STRING` is not set.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=eebc7db1bbe11dd62ce80e2fd4e34b58004d22a6&name_0=MasterCI&name_1=Stress%20test%20%28amd_tsan%29&name_1=Stress%20test%20%28amd_tsan%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

Note: this does not fix the root cause, but makes error messages way clearer, so next time you'll spend less time wondering what has happened.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.413`
<!-- ch-version-info:end -->