### PR TITLE
Fix stress test script crash on `subprocess.TimeoutExpired`

### DIFF
--- a/ci/jobs/scripts/stress/stress.py
+++ b/ci/jobs/scripts/stress/stress.py
@@ -319,7 +319,12 @@ def call_with_retry(
 ) -> None:
     logging.info("Running command: %s", str(query))
     for i in range(retry_count):
-        code = call(query, shell=True, stderr=STDOUT, timeout=timeout)
+        try:
+            code = call(query, shell=True, stderr=STDOUT, timeout=timeout)
+        except subprocess.TimeoutExpired:
+            logging.info("Command timed out after %s seconds, retrying", str(timeout))
+            time.sleep(i)
+            continue
         if code != 0:
             logging.info("Command returned %s, retrying", str(code))
             time.sleep(i)


### PR DESCRIPTION
`call_with_retry` calls `subprocess.call` with a timeout but never catches `subprocess.TimeoutExpired`. When `clickhouse client` takes longer than 0.5s (common under MSan), the unhandled exception kills the entire stress test before it even starts.

Catch the exception and retry, which is the intended behavior of `call_with_retry`.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=28637dd7907ab97b954ddadd712f746200f716f1&name_0=MasterCI&name_1=Stress%20test%20%28amd_msan%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.402`
<!-- ch-version-info:end -->