### PR TITLE
Fix `Mergeable Check` falsely failing for `no_aws` jobs like macOS smoke test

### DIFF
--- a/ci/praktika/native_jobs.py
+++ b/ci/praktika/native_jobs.py
@@ -776,6 +776,8 @@ def _finish_workflow(workflow, job_name):
                 workflow_result.dump()
                 workflow_result.ext["is_cancelled"] = True
                 update_final_report = True
+                dropped_results.append(result.name)
+                continue
             elif gh_job_result == "success":
                 print(
                     f"NOTE: not finished job [{result.name}] in the workflow but GitHub status is [{gh_job_result}] - set status to success"
@@ -783,6 +785,7 @@ def _finish_workflow(workflow, job_name):
                 result.status = Result.Status.SUCCESS
                 workflow_result.dump()
                 update_final_report = True
+                continue
             else:
                 print(
                     f"ERROR: not finished job [{result.name}] in the workflow - set status to error"


### PR DESCRIPTION
In `_finish_workflow`, when a job has `no_aws=True` (e.g. macOS smoke test), it cannot upload its Praktika result to S3, so the workflow result shows it as "pending". The code correctly looks up the GitHub Actions `needs` context and finds the job succeeded, updating the status to SUCCESS. However, it was missing a `continue` statement, causing execution to fall through to the code that unconditionally adds the job to `failed_results` — making the Mergeable Check report failure even though the job actually passed.

Add `continue` after the "success" and "cancelled" branches so that resolved jobs are not incorrectly added to `failed_results`.

https://github.com/ClickHouse/ClickHouse/pull/96318

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.401`
<!-- ch-version-info:end -->