### PR TITLE
Add regression test for dictionary + CASE predicate pushdown on distributed tables

### DIFF
--- a/tests/queries/0_stateless/03906_dict_case_distributed_predicate_pushdown.reference
+++ b/tests/queries/0_stateless/03906_dict_case_distributed_predicate_pushdown.reference
@@ -1,0 +1,2 @@
+1	same	alpha	SHOULD ALWAYS HAPPEN
+2	same	beta	SHOULD ALWAYS HAPPEN

--- a/tests/queries/0_stateless/03906_dict_case_distributed_predicate_pushdown.sql
+++ b/tests/queries/0_stateless/03906_dict_case_distributed_predicate_pushdown.sql
@@ -1,6 +1,8 @@
 -- Regression test for https://github.com/ClickHouse/ClickHouse/issues/87403
 -- Dictionary + CASE + distributed table: predicate pushdown should not filter out rows incorrectly.
 
+SET enable_analyzer = 1;
+
 DROP TABLE IF EXISTS t_dict_dist_local;
 DROP DICTIONARY IF EXISTS d_dict_dist;
 DROP TABLE IF EXISTS t_dict_dist;

--- a/tests/queries/0_stateless/03906_dict_case_distributed_predicate_pushdown.sql
+++ b/tests/queries/0_stateless/03906_dict_case_distributed_predicate_pushdown.sql
@@ -1,0 +1,50 @@
+-- Regression test for https://github.com/ClickHouse/ClickHouse/issues/87403
+-- Dictionary + CASE + distributed table: predicate pushdown should not filter out rows incorrectly.
+
+DROP TABLE IF EXISTS t_dict_dist_local;
+DROP DICTIONARY IF EXISTS d_dict_dist;
+DROP TABLE IF EXISTS t_dict_dist;
+
+CREATE TABLE t_dict_dist_local
+(
+    id Int64,
+    c String
+) ENGINE = MergeTree() ORDER BY id;
+
+INSERT INTO t_dict_dist_local VALUES (1, 'same'), (2, 'same');
+
+CREATE DICTIONARY d_dict_dist
+(
+    id Int64,
+    d String
+) PRIMARY KEY id
+SOURCE(CLICKHOUSE(QUERY '
+    SELECT * FROM (
+        SELECT toInt64(1) AS id, ''alpha'' AS d
+        UNION ALL
+        SELECT toInt64(2) AS id, ''beta'' AS d
+    )
+'))
+LAYOUT(FLAT())
+LIFETIME(0);
+
+CREATE TABLE t_dict_dist AS t_dict_dist_local
+ENGINE = Distributed(test_shard_localhost, currentDatabase(), t_dict_dist_local);
+
+SELECT
+    id,
+    c,
+    dictGet(concat(currentDatabase(), '.d_dict_dist'), 'd', id) AS d,
+    CASE
+        WHEN c = 'same' AND d = 'gamma' THEN 'SHOULD NOT HAPPEN'
+        WHEN c = 'same' THEN 'SHOULD ALWAYS HAPPEN'
+    END AS filter_value
+FROM (
+    SELECT * FROM t_dict_dist
+)
+WHERE filter_value = 'SHOULD ALWAYS HAPPEN'
+ORDER BY id;
+
+DROP TABLE t_dict_dist;
+DROP DICTIONARY d_dict_dist;
+DROP TABLE t_dict_dist_local;


### PR DESCRIPTION
Closes #87403 - predicate pushdown for distributed subqueries was incorrectly filtering out rows when using `dictGet` combined with CASE expressions in the WHERE clause.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.432`
<!-- ch-version-info:end -->