### PR TITLE
Filter out minio log queries from the hung check in Stress test

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -770,6 +770,7 @@ def get_processlist_size(args):
                     count()
                 FROM clusterAllReplicas('test_cluster_database_replicated', system.processes)
                 WHERE query NOT LIKE '%system.processes%'
+                AND query NOT LIKE '%system.minio_%_logs%'
                 """,
             ).strip()
         )
@@ -782,6 +783,7 @@ def get_processlist_size(args):
                     count()
                 FROM clusterAllReplicas('test_cluster_shared_catalog', system.processes)
                 WHERE query NOT LIKE '%system.processes%'
+                AND query NOT LIKE '%system.minio_%_logs%'
                 """,
             ).strip()
         )
@@ -793,6 +795,7 @@ def get_processlist_size(args):
                     count()
                 FROM system.processes
                 WHERE query NOT LIKE '%system.processes%'
+                AND query NOT LIKE '%system.minio_%_logs%'
             """,
         ).strip()
     )
@@ -815,6 +818,7 @@ def get_processlist_with_stacktraces(args):
             FROM system.processes p
             JOIN system.stack_trace s USING (query_id)
             WHERE query NOT LIKE '%system.processes%'
+            AND query NOT LIKE '%system.minio_%_logs%'
             GROUP BY p.*
         ))
         ORDER BY elapsed DESC FORMAT Vertical
@@ -840,6 +844,7 @@ def get_processlist_with_stacktraces(args):
             FROM system.processes p
             JOIN system.stack_trace s USING (query_id)
             WHERE query NOT LIKE '%system.processes%'
+            AND query NOT LIKE '%system.minio_%_logs%'
             GROUP BY p.*
         ))
         ORDER BY elapsed DESC FORMAT Vertical
@@ -861,6 +866,7 @@ def get_processlist_with_stacktraces(args):
         FROM system.processes p
         JOIN system.stack_trace s USING (query_id)
         WHERE query NOT LIKE '%system.processes%'
+        AND query NOT LIKE '%system.minio_%_logs%'
         GROUP BY p.*
         ORDER BY elapsed DESC FORMAT Vertical
         """,


### PR DESCRIPTION
The hung check was detecting `INSERT INTO system.minio_audit_logs` and `system.minio_server_logs` async insert flush queries as "hung", causing false positive CI failures. These are internal infrastructure queries from the minio webhook logging setup that may still be flushing to S3 when tests finish.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=cf0c6e566bf9a79f352424fb4849715d7e725cb1&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_binary%2C%20old%20analyzer%2C%20s3%20storage%2C%20DatabaseReplicated%2C%20parallel%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.427`
<!-- ch-version-info:end -->