### PR TITLE
Fix flaky test `01414_freeze_does_not_prevent_alters`

### DIFF
--- a/tests/queries/0_stateless/01414_freeze_does_not_prevent_alters.sql
+++ b/tests/queries/0_stateless/01414_freeze_does_not_prevent_alters.sql
@@ -2,7 +2,7 @@
 -- It's not longer the case. Let's prove it.
 
 DROP TABLE IF EXISTS t;
-CREATE TABLE t (k UInt64, s String) ENGINE = MergeTree ORDER BY k;
+CREATE TABLE t (k UInt64, s String) ENGINE = MergeTree ORDER BY k SETTINGS old_parts_lifetime = 600;
 INSERT INTO t VALUES (1, 'hello'), (2, 'world');
 
 SELECT * FROM t;


### PR DESCRIPTION
The test expects outdated frozen parts to remain visible in `system.parts`, but randomized MergeTree settings can set `old_parts_lifetime` to as low as 10 seconds. In debug builds the test takes >12s, so the cleanup thread removes the outdated part before the test checks for it.

Fix by setting `old_parts_lifetime = 600` on the table, which takes priority over randomized settings.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96306&sha=544ea1ce06770763efcaa4fba03d4127f57c8b7b&name_0=PR&name_1=Stateless%20tests%20%28amd_debug%2C%20distributed%20plan%2C%20s3%20storage%2C%20parallel%29
https://github.com/ClickHouse/ClickHouse/pull/96306

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.429`
<!-- ch-version-info:end -->