### PR TITLE
Fix flaky test `test_distributed_respect_user_timeouts`

### DIFF
--- a/tests/integration/test_distributed_respect_user_timeouts/test.py
+++ b/tests/integration/test_distributed_respect_user_timeouts/test.py
@@ -57,8 +57,8 @@ TIMEOUT_DIFF_UPPER_BOUND = {
         "remote": 2.5,
     },
     "ready_to_wait": {
-        "distributed": 3,
-        "remote": 2.0,
+        "distributed": 5.5,
+        "remote": 3.0,
     },
 }
 


### PR DESCRIPTION
Increase `TIMEOUT_DIFF_UPPER_BOUND` for the `ready_to_wait` user to match the margin already given to the `default` user. The old bound of 3s extra for `distributed` queries allowed only 0.6s overhead per retry (5 retries), which is too tight under CI load with SSL handshakes.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96341&sha=2f17738f7a9b70c79c99f1b1b0bf1bea3ae71428&name_0=PR&name_1=Integration%20tests%20%28amd_binary%2C%203%2F5%29
https://github.com/ClickHouse/ClickHouse/pull/96341

Root cause: The test is timing-sensitive. For the ready_to_wait user with distributed query:
  - connect_timeout_with_failover_secure_ms = 3000ms
  - connections_with_failover_max_tries = 5
  - Expected total timeout = 3s * 5 = 15s
  - The upper bound on extra time is TIMEOUT_DIFF_UPPER_BOUND["ready_to_wait"]["distributed"] = 3s
  - So the test allows up to 18s total, but the actual measured time was 18.21s — just 0.21s over the limit

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.428`
<!-- ch-version-info:end -->