### PR TITLE
Reject skip indices with empty expressions

### DIFF
--- a/src/Storages/IndicesDescription.cpp
+++ b/src/Storages/IndicesDescription.cpp
@@ -117,6 +117,9 @@ IndexDescription IndexDescription::getIndexFromAST(
         result.data_types.push_back(elem.type);
     }
 
+    if (result.column_names.empty())
+        throw Exception(ErrorCodes::INCORRECT_QUERY, "Skip index '{}' must have at least one column in its expression", result.name);
+
     if (index_type && index_type->arguments)
     {
         result.arguments = (index_type->name == TEXT_INDEX_NAME)

--- a/tests/queries/0_stateless/03910_skip_index_empty_expression.sql
+++ b/tests/queries/0_stateless/03910_skip_index_empty_expression.sql
@@ -1,0 +1,5 @@
+-- Verify that creating a skip index with an empty expression is rejected.
+-- https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=e773da12ff7fd4f1e855b298b829898e001d4d32&name_0=MasterCI&name_1=BuzzHouse%20%28arm_asan%29
+
+CREATE TABLE t_empty_index (c0 Int32, INDEX i0 () TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY c0; -- { serverError INCORRECT_QUERY }
+CREATE TABLE t_empty_index (c0 Int32, INDEX i0 () TYPE minmax GRANULARITY 1) ENGINE = MergeTree ORDER BY c0; -- { serverError INCORRECT_QUERY }


### PR DESCRIPTION
A fuzzed query like `INDEX i0 () TYPE bloom_filter` created an `IndexDescription` with an empty `column_names` vector. When `addImplicitIndicesForColumn` later called `index.column_names.front()`, it dereferenced an empty vector, causing a segfault.

Validate in `IndexDescription::getIndexFromAST` that the index has at least one column, throwing `INCORRECT_QUERY` otherwise.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=e773da12ff7fd4f1e855b298b829898e001d4d32&name_0=MasterCI&name_1=BuzzHouse%20%28arm_asan%29

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
It was possible to create a table with an empty expression `()` as an index, which led to an invalid memory access.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.436`
<!-- ch-version-info:end -->