### PR TITLE
Fix `03514_grace_hash_join_logical_error` timeout on TSan + S3

### DIFF
--- a/tests/queries/0_stateless/03514_grace_hash_join_logical_error.sql
+++ b/tests/queries/0_stateless/03514_grace_hash_join_logical_error.sql
@@ -3,7 +3,7 @@ DROP TABLE IF EXISTS A;
 create table A (A Int64, B Int64, S String) Engine=MergeTree order by A
 as select number,number, toString(arrayMap(i->cityHash64(i*number), range(10))) from numbers(1e6);
 
-SET join_algorithm = 'grace_hash', grace_hash_join_initial_buckets=128, grace_hash_join_max_buckets=256;
+SET max_threads = 0, join_algorithm = 'grace_hash', grace_hash_join_initial_buckets=128, grace_hash_join_max_buckets=256;
 
 select * from A a join A as b on a.A = b.A limit 1 FORMAT Null;
 


### PR DESCRIPTION
Set `max_threads = 0` explicitly to prevent randomized `--max_threads 1` from making the 1M-row self-join too slow under TSan with S3 storage.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=2dce8d9554a92c63c662565f1fe280ab7480964e&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_tsan%2C%20s3%20storage%2C%20parallel%2C%201%2F2%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.437`
<!-- ch-version-info:end -->