### PR TITLE
Fix flaky `test_ordered_mode_with_hive` integration test

### DIFF
--- a/tests/integration/test_storage_s3_queue/test_6.py
+++ b/tests/integration/test_storage_s3_queue/test_6.py
@@ -160,14 +160,16 @@ def test_ordered_mode_with_hive(started_cluster, engine_name, processing_threads
             for expected_line in expected_data:
                 assert data.count(expected_line) == 1, f"Expected exacly one element '{expected_line}', got: {data}"
 
-    def wait_for_data(dst_table_name, expected_count):
+    def wait_for_data(dst_table_name, expected_data, columns="column1, column2, column3"):
         for i in range(60):
-            count = 0
+            data = ""
             for node in instances:
-                count += int(node.query(f"SELECT count() FROM {dst_table_name}"))
-            print(f"{count}/{expected_count}")
-            if count >= expected_count:
+                data += node.query(f"SELECT {columns} FROM {dst_table_name} ORDER BY {columns} FORMAT CSV")
+            data_lines = data.strip().split("\n")
+            missing = [row for row in expected_data if row not in data_lines]
+            if not missing:
                 break
+            print(f"{len(expected_data) - len(missing)}/{len(expected_data)}")
             time.sleep(1)
 
     expected_data = [
@@ -178,7 +180,7 @@ def test_ordered_mode_with_hive(started_cluster, engine_name, processing_threads
         '3,1,1,"2025-01-03","Amsterdam"',
         '3,1,3,"2025-01-03","Amsterdam"',
     ]
-    wait_for_data(dst_table_name, len(expected_data))
+    wait_for_data(dst_table_name, expected_data, "column1, column2, column3, date, city")
 
     data = ""
     for node in instances:
@@ -206,7 +208,7 @@ def test_ordered_mode_with_hive(started_cluster, engine_name, processing_threads
         "3,1,3",
         "3,1,4",
     ]
-    wait_for_data(dst_table_name, len(expected_data))
+    wait_for_data(dst_table_name, expected_data)
 
     # With buckets we can get some files from the middle, if those files are last in bucket, but not global last.
     # It depends of hashes of file paths.
@@ -231,7 +233,7 @@ def test_ordered_mode_with_hive(started_cluster, engine_name, processing_threads
         "2,1,2",
     ]
     expected_data.sort()
-    wait_for_data(dst_table_name, len(expected_data))
+    wait_for_data(dst_table_name, expected_data)
     if not is_single_thread:
         time.sleep(10)
 
@@ -260,7 +262,7 @@ def test_ordered_mode_with_hive(started_cluster, engine_name, processing_threads
         "2,1,3",
     ]
     expected_data.sort()
-    wait_for_data(dst_table_name, len(expected_data))
+    wait_for_data(dst_table_name, expected_data)
 
     if not is_single_thread:
         time.sleep(10)
@@ -372,14 +374,16 @@ def test_ordered_mode_with_regex_partitioning(started_cluster, engine_name, proc
             for expected_line in expected_data:
                 assert data.count(expected_line) == 1, f"Expected exactly one element '{expected_line}', got: {data}"
 
-    def wait_for_data(dst_table_name, expected_count):
+    def wait_for_data(dst_table_name, expected_data, columns="column1, column2, column3"):
         for i in range(60):
-            count = 0
+            data = ""
             for node in instances:
-                count += int(node.query(f"SELECT count() FROM {dst_table_name}"))
-            print(f"{count}/{expected_count}")
-            if count >= expected_count:
+                data += node.query(f"SELECT {columns} FROM {dst_table_name} ORDER BY {columns} FORMAT CSV")
+            data_lines = data.strip().split("\n")
+            missing = [row for row in expected_data if row not in data_lines]
+            if not missing:
                 break
+            print(f"{len(expected_data) - len(missing)}/{len(expected_data)}")
             time.sleep(1)
 
     # Step 1: Verify initial 6 rows
@@ -391,7 +395,7 @@ def test_ordered_mode_with_regex_partitioning(started_cluster, engine_name, proc
         "3,1,1",
         "3,1,3",
     ]
-    wait_for_data(dst_table_name, len(expected_data))
+    wait_for_data(dst_table_name, expected_data)
 
     data = ""
     for node in instances:
@@ -420,7 +424,7 @@ def test_ordered_mode_with_regex_partitioning(started_cluster, engine_name, proc
         "3,1,3",
         "3,1,4",
     ]
-    wait_for_data(dst_table_name, len(expected_data))
+    wait_for_data(dst_table_name, expected_data)
 
     if not is_single_thread:
         time.sleep(10)
@@ -441,7 +445,7 @@ def test_ordered_mode_with_regex_partitioning(started_cluster, engine_name, proc
         "2,1,2",
     ]
     expected_data.sort()
-    wait_for_data(dst_table_name, len(expected_data))
+    wait_for_data(dst_table_name, expected_data)
 
     if not is_single_thread:
         time.sleep(10)
@@ -471,7 +475,7 @@ def test_ordered_mode_with_regex_partitioning(started_cluster, engine_name, proc
         "2,1,3",
     ]
     expected_data.sort()
-    wait_for_data(dst_table_name, len(expected_data))
+    wait_for_data(dst_table_name, expected_data)
 
     if not is_single_thread:
         time.sleep(10)


### PR DESCRIPTION
The `wait_for_data` helper used a simple row count to determine when new files were processed. With bucket mode, "middle" files from a previous step could also be processed (last-in-bucket but not global last), inflating the row count. When the next step added files and waited for `count >= N`, the target was already met by extra rows — so the wait returned before the new files were actually processed.

Change `wait_for_data` to check for the presence of specific expected rows instead of just counting, so it only returns when all expected rows are actually in the table.

The same fix is applied to `test_ordered_mode_with_regex_partitioning` which had an identical pattern.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96359&sha=2663a0412e2c5796633875276ad818515e5f5e2d&name_0=PR&name_1=Integration%20tests%20%28amd_tsan%2C%206%2F6%29
https://github.com/ClickHouse/ClickHouse/pull/96359

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.446`
<!-- ch-version-info:end -->