### PR TITLE
Fix timeout in test `03144_parallel_alter_add_drop_column_zookeeper_on_steroids`

### DIFF
--- a/tests/queries/0_stateless/03144_parallel_alter_add_drop_column_zookeeper_on_steroids.sh
+++ b/tests/queries/0_stateless/03144_parallel_alter_add_drop_column_zookeeper_on_steroids.sh
@@ -43,9 +43,9 @@ function alter_thread_1()
     local TIMELIMIT=$((SECONDS+TIMEOUT))
     while [ $SECONDS -lt "$TIMELIMIT" ]; do
         REPLICA=$(($RANDOM % 3 + 1))
-        ${CLICKHOUSE_CLIENT} --query "ALTER TABLE concurrent_alter_add_drop_steroids_1 MODIFY COLUMN value0 String SETTINGS mutations_sync = 0"
+        ${CLICKHOUSE_CLIENT} --query "ALTER TABLE concurrent_alter_add_drop_steroids_1 MODIFY COLUMN value0 String SETTINGS mutations_sync = 0, replication_alter_partitions_sync = 0"
         sleep 1.$RANDOM
-        ${CLICKHOUSE_CLIENT} --query "ALTER TABLE concurrent_alter_add_drop_steroids_1 MODIFY COLUMN value0 UInt8 SETTINGS mutations_sync = 0"
+        ${CLICKHOUSE_CLIENT} --query "ALTER TABLE concurrent_alter_add_drop_steroids_1 MODIFY COLUMN value0 UInt8 SETTINGS mutations_sync = 0, replication_alter_partitions_sync = 0"
         sleep 1.$RANDOM
     done
 


### PR DESCRIPTION
The `alter_thread_1` function used `mutations_sync = 0` but did not set `replication_alter_partitions_sync`, which defaults to 1 (wait for own replica). With many concurrent ALTERs overwhelming the replica metadata queue, the ALTER MODIFY COLUMN could hang indefinitely waiting for the local replica to apply the metadata change, causing the test to exceed the 10-minute timeout.

Add `replication_alter_partitions_sync = 0` to the MODIFY COLUMN queries, consistent with the ADD/DROP COLUMN queries in `alter_thread` which already use this setting.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96358&sha=49014a133d2cea6dbdee117da44d4d3026279d1c&name_0=PR&name_1=Stateless%20tests%20%28amd_debug%2C%20distributed%20plan%2C%20s3%20storage%2C%20sequential%29
https://github.com/ClickHouse/ClickHouse/pull/96358

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.440`
<!-- ch-version-info:end -->