### PR TITLE
Ignore `NO_SUCH_INTERSERVER_IO_ENDPOINT` in upgrade check

### DIFF
--- a/tests/docker_scripts/upgrade_runner.sh
+++ b/tests/docker_scripts/upgrade_runner.sh
@@ -310,6 +310,8 @@ cp /var/log/clickhouse-server/clickhouse-server.upgrade.log /test_output/clickho
 #       Let's just ignore all errors from queries ("} <Error> TCPHandler: Code:", "} <Error> executeQuery: Code:")
 # FIXME https://github.com/ClickHouse/ClickHouse/issues/39197 ("Missing columns: 'v3' while processing query: 'v3, k, v1, v2, p'")
 # FIXME https://github.com/ClickHouse/ClickHouse/issues/39174 - bad mutation does not indicate backward incompatibility
+# `NO_SUCH_INTERSERVER_IO_ENDPOINT` is expected during upgrades because replicated tables try to fetch parts
+# from replicas that are being restarted and whose interserver endpoints are temporarily unavailable.
 echo "Check for Error messages in server log:"
 rg -Fav -e "Code: 236. DB::Exception: Cancelled merging parts" \
            -e "Code: 236. DB::Exception: Cancelled mutating parts" \
@@ -361,6 +363,7 @@ rg -Fav -e "Code: 236. DB::Exception: Cancelled merging parts" \
            -e "QUALIFY clause is not supported in the old analyzer" \
            -e "Cannot attach table \`test_7\`" \
            -e "Cannot open file /var/lib/clickhouse/access/" \
+           -e "NO_SUCH_INTERSERVER_IO_ENDPOINT" \
     /test_output/clickhouse-server.upgrade.log \
     | grep -av -e "_repl_01111_.*Mapping for table with UUID" \
     | grep -Fa "<Error>" > /test_output/upgrade_error_messages.txt || true


### PR DESCRIPTION
This error is expected during upgrades because replicated tables try to fetch parts from replicas that are being restarted and whose interserver endpoints are temporarily unavailable.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96336&sha=245a6b22ab97960368f399c05660bc0b10f4277a&name_0=PR&name_1=Upgrade%20check%20%28amd_release%29
https://github.com/ClickHouse/ClickHouse/pull/96336

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.438`
<!-- ch-version-info:end -->