### PR TITLE
Fix race condition in `PeriodicLog` between background thread and `SYSTEM FLUSH LOGS`

### DIFF
--- a/src/Interpreters/PeriodicLog.cpp
+++ b/src/Interpreters/PeriodicLog.cpp
@@ -48,7 +48,10 @@ void PeriodicLog<LogElement>::threadFunction()
         {
             const auto current_time = std::chrono::system_clock::now();
 
-            stepFunction(current_time);
+            {
+                std::lock_guard lock(step_mutex);
+                stepFunction(current_time);
+            }
 
             /// We will record current time into table but align it to regular time intervals to avoid time drift.
             /// We may drop some time points if the server is overloaded and recording took too much time.
@@ -67,6 +70,7 @@ void PeriodicLog<LogElement>::threadFunction()
 template <typename LogElement>
 void PeriodicLog<LogElement>::flushBufferToLog(TimePoint current_time)
 {
+    std::lock_guard lock(step_mutex);
     stepFunction(current_time);
 }
 


### PR DESCRIPTION
The background periodic thread and `flushBufferToLog` (called by `SYSTEM FLUSH LOGS`) both call `stepFunction` without synchronization. When the background thread's `stepFunction` swaps the in-memory stats but hasn't finished adding all elements to the queue, a concurrent `flushBufferToLog` call finds empty stats and returns. Then `getLastLogIndex` returns a stale index that doesn't include the elements still being added by the background thread, so `flush` doesn't wait for them.

This caused flaky failures in `01158_zookeeper_log_long` where `SYSTEM FLUSH LOGS aggregated_zookeeper_log` didn't capture all data, making the `aggregated_zookeeper_log` query return `0 0` instead of `1 1`.

Fix by adding a `step_mutex` that serializes `stepFunction` calls, ensuring `flushBufferToLog` waits for any in-progress background `stepFunction` to complete before proceeding.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96357&sha=76567a89617ff50443418c3f4297fab8183d22d5&name_0=PR&name_1=Stateless%20tests%20%28amd_ubsan%2C%20parallel%29
https://github.com/ClickHouse/ClickHouse/pull/96357

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.447`
<!-- ch-version-info:end -->