### PR TITLE
Fix libFuzzer timeouts that block nightly fuzzing

### DIFF
--- a/src/AggregateFunctions/fuzzers/aggregate_function_state_deserialization_fuzzer.cpp
+++ b/src/AggregateFunctions/fuzzers/aggregate_function_state_deserialization_fuzzer.cpp
@@ -43,9 +43,9 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * data, size_t size)
     try
     {
         total_memory_tracker.resetCounters();
-        total_memory_tracker.setHardLimit(1_GiB);
+        total_memory_tracker.setHardLimit(128_MiB);
         CurrentThread::get().memory_tracker.resetCounters();
-        CurrentThread::get().memory_tracker.setHardLimit(1_GiB);
+        CurrentThread::get().memory_tracker.setHardLimit(128_MiB);
 
         /// The input format is as follows:
         /// - the aggregate function name on the first line, possible with parameters, then data types of the arguments,

--- a/src/Parsers/fuzzers/create_parser_fuzzer.cpp
+++ b/src/Parsers/fuzzers/create_parser_fuzzer.cpp
@@ -13,7 +13,10 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * data, size_t size)
         std::string input = std::string(reinterpret_cast<const char*>(data), size);
 
         DB::ParserCreateQuery parser;
-        DB::ASTPtr ast = parseQuery(parser, input.data(), input.data() + input.size(), "", 0, 1000, DB::DBMS_DEFAULT_MAX_PARSER_BACKTRACKS);
+
+        const UInt64 max_parser_depth = 1000;
+        const UInt64 max_parser_backtracks = 10000;
+        DB::ASTPtr ast = parseQuery(parser, input.data(), input.data() + input.size(), "", 0, max_parser_depth, max_parser_backtracks);
 
         const UInt64 max_ast_depth = 1000;
         ast->checkDepth(max_ast_depth);

--- a/tests/fuzz/clickhouse_fuzzer.options
+++ b/tests/fuzz/clickhouse_fuzzer.options
@@ -1,2 +1,6 @@
 [libfuzzer]
 timeout = 20
+
+[fuzzer_arguments]
+--max_execution_time=10
+--max_parser_backtracks=10000


### PR DESCRIPTION
The same 3 fuzzers have been timing out every night (for at least 5 days), preventing them from completing their full fuzzing sessions.

`create_parser_fuzzer`: reduce `max_parser_backtracks` from 1000000 to 10000, matching `select_parser_fuzzer` which does not time out. The default 1M backtracks allows the parser to explore an enormous number of combinations on pathological inputs, easily exceeding the 20s libFuzzer timeout.

`clickhouse_fuzzer`: add `--max_execution_time=10` and `--max_parser_backtracks=10000` as fuzzer arguments passed to clickhouse-local. Without execution time limits, complex fuzz-generated queries run indefinitely.

`aggregate_function_state_deserialization_fuzzer`: reduce memory limit from 1 GiB to 128 MiB. Several aggregate function `deserialize` implementations read size fields from crafted input and can allocate huge data structures whose processing exceeds 20s. The tighter limit causes early OOM exceptions instead of timeouts.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=07d8d926e38297bb2911b499eea59646cb83a7de&name_0=NightlyFuzzers&name_1=libFuzzer%20tests

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.448`
<!-- ch-version-info:end -->