### PR TITLE
Fix sporadic test failure in `test_validate_only_initial_alter_query` with Replicated database

### DIFF
--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -576,22 +576,13 @@ void DatabaseReplicated::tryConnectToZooKeeperAndInitDatabase(LoadingStrictnessL
 
         auto current_zookeeper = getContext()->getZooKeeper();
 
-        bool is_create_query = mode == LoadingStrictnessLevel::CREATE;
-
         if (!current_zookeeper->exists(zookeeper_path))
         {
             /// Create new database, multiple nodes can execute it concurrently
             createDatabaseNodesInZooKeeper(current_zookeeper);
         }
-        else if (is_create_query && !current_zookeeper->exists(zookeeper_path + "/max_log_ptr"))
-        {
-            /// Database metadata is incomplete, likely from a previous DROP that partially removed ZK nodes
-            /// (e.g. tryRemoveRecursive removed children but failed to remove the root).
-            /// Clean up and recreate.
-            LOG_WARNING(log, "Found incomplete Replicated database metadata in ZooKeeper at {}, cleaning up and recreating", zookeeper_path);
-            current_zookeeper->tryRemoveRecursive(zookeeper_path);
-            createDatabaseNodesInZooKeeper(current_zookeeper);
-        }
+
+        bool is_create_query = mode == LoadingStrictnessLevel::CREATE;
 
         String replica_host_id;
         bool replica_exists_in_zk = current_zookeeper->tryGet(replica_path, replica_host_id);

--- a/tests/integration/test_validate_only_initial_alter_query/common.py
+++ b/tests/integration/test_validate_only_initial_alter_query/common.py
@@ -2,7 +2,7 @@ from helpers.cluster import ClickHouseInstance
 
 # Used also in private, so when changing this please verify that it still works in private
 def run_test(node1: ClickHouseInstance, node2: ClickHouseInstance, database_engine_spec: str, table_engine: str):
-    database_name = "test_validate_only_initial_query"
+    database_name = f"test_validate_only_initial_query_{table_engine.lower()}"
     nodes = [node1, node2]
     create_table_query = f"""
         SET cast_ipv4_ipv6_default_on_conversion_error=1;


### PR DESCRIPTION
The test is parametrized with `[MergeTree, ReplicatedMergeTree]` table engines, but both parametrizations used the same database name and therefore the same ZooKeeper path. After the first parametrization finishes, the second one drops and recreates the database. However, `tryRemoveRecursive` during DROP can leave the ZooKeeper root path intact while removing children (like `max_log_ptr`). The subsequent `CREATE DATABASE` sees the root path exists, skips creating database nodes, and then `createReplicaNodesInZooKeeper` fails trying to read the missing `max_log_ptr`.

Two fixes:

1. Test: include `table_engine` in the database name so each parametrization uses a unique ZooKeeper path, avoiding interference between test cases.

~~2. Server: in `tryConnectToZooKeeperAndInitDatabase`, detect incomplete ZooKeeper metadata (root exists but `max_log_ptr` is missing) during `CREATE DATABASE`, clean up the stale path, and recreate. This makes the server resilient to partially-cleaned ZooKeeper state from prior failed drops.~~

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96310&sha=3f042c3998883caebc6331331fe441e8f572c5a4&name_0=PR&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%204%2F4%29
https://github.com/ClickHouse/ClickHouse/pull/96310

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.456`
<!-- ch-version-info:end -->