### PR TITLE
Fix timeout of `03096_text_log_format_string_args_not_empty` under TSan

### DIFF
--- a/tests/queries/0_stateless/03096_text_log_format_string_args_not_empty.sh
+++ b/tests/queries/0_stateless/03096_text_log_format_string_args_not_empty.sh
@@ -12,6 +12,7 @@ $CLICKHOUSE_CLIENT -m -q "
 system flush logs text_log;
 
 SET max_rows_to_read = 0; -- system.text_log can be really big
+SET max_threads = 0; -- override random settings, scanning text_log with 1 thread under TSan is too slow
 
 select count() > 0 from system.text_log where event_date >= yesterday() and level = 'Error' and message_format_string = 'Unknown {}{} identifier {} in scope {}{}' and value1 = 'expression' and value3 = '\`count\`' and value4 = 'SELECT count' and query_id = '${query_id}_1';
 


### PR DESCRIPTION
The test timed out after 600 seconds in `Stateless tests (amd_tsan, s3 storage, parallel, 1/2)` because the test runner injected `max_threads=1` as a random setting, making the full scan of `system.text_log` extremely slow under TSan with S3 storage.

Override with `SET max_threads = 0` (use all available threads) to avoid this bottleneck.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=ebafae80c1d357b53b18c88fd9c41795140c9aef&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_tsan%2C%20s3%20storage%2C%20parallel%2C%201%2F2%29&name_1=Stateless%20tests%20%28amd_tsan%2C%20s3%20storage%2C%20parallel%2C%201%2F2%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.454`
<!-- ch-version-info:end -->