### PR TITLE
Add `no-async-insert` tag to `01079_parallel_alter_modify_zookeeper_long`

### DIFF
--- a/tests/queries/0_stateless/01079_parallel_alter_modify_zookeeper_long.sh
+++ b/tests/queries/0_stateless/01079_parallel_alter_modify_zookeeper_long.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-# Tags: long, zookeeper, no-fasttest, no-parallel
+# Tags: long, zookeeper, no-fasttest, no-parallel, no-async-insert
+# no-async-insert: concurrent ALTER MODIFY COLUMN changes column types while inserts are in flight.
+# With async inserts, the buffered block type may not match the altered column type at flush time,
+# causing TYPE_MISMATCH errors in the HTTP response that pollute stdout.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
The test runs concurrent `ALTER MODIFY COLUMN` while inserting data. With async inserts, the buffered block type may not match the altered column type at flush time, causing `TYPE_MISMATCH` errors in stdout.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96373&sha=c9e0312cb8e6aa86c07ee90ae94707346422cc6c&name_0=PR&name_1=Stateless%20tests%20%28amd_debug%2C%20AsyncInsert%2C%20s3%20storage%2C%20sequential%29
https://github.com/ClickHouse/ClickHouse/pull/96373

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

This is an interesting observation. Async inserts may reject an insert if a table was ALTERed during the batch. Which is ok, but good to know.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.461`
<!-- ch-version-info:end -->