### PR TITLE
Fix `03047_on_fly_mutations_prewhere` timeout under TSan

### DIFF
--- a/tests/queries/0_stateless/03047_on_fly_mutations_prewhere.sql
+++ b/tests/queries/0_stateless/03047_on_fly_mutations_prewhere.sql
@@ -4,7 +4,7 @@ SET mutations_sync = 2;
 SET apply_mutations_on_fly = 0;
 
 CREATE TABLE t_update_prewhere (id UInt64, c1 UInt64, c2 UInt64, c3 UInt64)
-ENGINE = MergeTree ORDER BY id;
+ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 8192;
 
 INSERT INTO t_update_prewhere SELECT number, number, number, number FROM numbers(100000);
 
@@ -28,7 +28,7 @@ SET mutations_sync = 0;
 SET apply_mutations_on_fly = 1;
 
 CREATE TABLE t_update_prewhere (id UInt64, c1 UInt64, c2 UInt64, c3 UInt64)
-ENGINE = MergeTree ORDER BY id;
+ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 8192;
 
 SYSTEM STOP MERGES t_update_prewhere;
 


### PR DESCRIPTION
The test inserts 100,000 rows without specifying `index_granularity`. When the CI randomizer sets `--index_granularity 2`, it creates ~50,000 granules instead of ~13, making mutations extremely slow under TSan and causing a timeout.

Fix by explicitly setting `index_granularity = 8192` in both CREATE TABLE statements.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=6a8e0420cef9c6f53f4a4b5a834d63f50a8402cd&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_tsan%2C%20s3%20storage%2C%20parallel%2C%202%2F2%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.462`
<!-- ch-version-info:end -->