### PR TITLE
Fix lazy-seek bounds in `CompressedReadBufferFromFile::readBig`

### DIFF
--- a/src/Compression/CompressedReadBufferFromFile.cpp
+++ b/src/Compression/CompressedReadBufferFromFile.cpp
@@ -153,6 +153,13 @@ size_t CompressedReadBufferFromFile::readBig(char * to, size_t n)
                 /// Synchronous mode must be set since we need read partial data immediately from working buffer to target buffer.
                 decompress(working_buffer, size_decompressed, size_compressed_without_checksum);
 
+                if (nextimpl_working_buffer_offset > working_buffer.size())
+                    throw Exception(
+                        ErrorCodes::SEEK_POSITION_OUT_OF_BOUND,
+                        "Required to move position beyond the decompressed block (pos: {}, block size: {})",
+                        nextimpl_working_buffer_offset,
+                        toString(working_buffer.size()));
+
                 /// Read partial data from first block. Won't run here at second block.
                 /// Avoid to call nextImpl and unnecessary memcpy in read when the second block fits entirely to output buffer.
                 size_t size_partial = std::min((size_decompressed - nextimpl_working_buffer_offset),(n - bytes_read));

--- a/src/Compression/tests/gtest_compressed_read_buffer_from_file.cpp
+++ b/src/Compression/tests/gtest_compressed_read_buffer_from_file.cpp
@@ -1,0 +1,48 @@
+#include <Common/Exception.h>
+#include <Common/filesystemHelpers.h>
+#include <Compression/CompressedReadBufferFromFile.h>
+#include <Compression/CompressedWriteBuffer.h>
+#include <IO/ReadBufferFromFile.h>
+#include <IO/WriteBufferFromFile.h>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+
+namespace DB::ErrorCodes
+{
+    extern const int SEEK_POSITION_OUT_OF_BOUND;
+}
+
+namespace
+{
+using namespace DB;
+
+TEST(CompressedReadBufferFromFile, readBigChecksSeekOffsetBounds)
+{
+    auto tmp_file = createTemporaryFile("/tmp/");
+    {
+        WriteBufferFromFile out(tmp_file->path());
+        CompressedWriteBuffer compressed_out(out);
+        compressed_out.write("abc", 3);
+        compressed_out.finalize();
+        out.finalize();
+    }
+
+    CompressedReadBufferFromFile in(std::make_unique<ReadBufferFromFile>(tmp_file->path()));
+    in.seek(0, 4);
+
+    char byte = 0;
+    try
+    {
+        [[maybe_unused]] const auto bytes_read = in.readBig(&byte, 1);
+        FAIL() << "Expected exception, but read " << bytes_read << " bytes";
+    }
+    catch (const Exception & e)
+    {
+        EXPECT_EQ(e.code(), ErrorCodes::SEEK_POSITION_OUT_OF_BOUND);
+    }
+}
+
+}


### PR DESCRIPTION
Add bounds check for nextimpl_working_buffer_offset in readBig before pointer arithmetic.

Add regression test for seek past decompressed block.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96374&sha=2e97255e245f930e6dbcebd3613957d7ba344b05&name_0=PR&name_1=Stress%20test%20%28amd_ubsan%29
https://github.com/ClickHouse/ClickHouse/pull/96374

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

This shouldn't fix anything, but it will provide us with better diagnostics.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.459`
<!-- ch-version-info:end -->