### PR TITLE
Reduce row count in `02943_variant_read_subcolumns` to fix MSan timeout

### DIFF
--- a/tests/queries/0_stateless/02943_variant_read_subcolumns.sh
+++ b/tests/queries/0_stateless/02943_variant_read_subcolumns.sh
@@ -10,7 +10,7 @@ CH_CLIENT="$CLICKHOUSE_CLIENT --allow_experimental_variant_type=1 --use_variant_
 function test()
 {
     echo "test"
-    $CH_CLIENT -q "insert into test select number, multiIf(number % 3 == 2, NULL, number % 3 == 1, number, arrayMap(x -> multiIf(number % 9 == 0, NULL, number % 9 == 3, 'str_' || toString(number), number), range(number % 10))) from numbers(1000000) settings min_insert_block_size_rows=100000"
+    $CH_CLIENT -q "insert into test select number, multiIf(number % 3 == 2, NULL, number % 3 == 1, number, arrayMap(x -> multiIf(number % 9 == 0, NULL, number % 9 == 3, 'str_' || toString(number), number), range(number % 10))) from numbers(100000) settings min_insert_block_size_rows=10000"
     $CH_CLIENT -q "select v, v.UInt64, v.\`Array(Variant(String, UInt64))\`,  v.\`Array(Variant(String, UInt64))\`.size0, v.\`Array(Variant(String, UInt64))\`.UInt64 from test order by id format Null"
     $CH_CLIENT -q "select v.UInt64, v.\`Array(Variant(String, UInt64))\`,  v.\`Array(Variant(String, UInt64))\`.size0, v.\`Array(Variant(String, UInt64))\`.UInt64 from test order by id format Null"
     $CH_CLIENT -q "select v.\`Array(Variant(String, UInt64))\`,  v.\`Array(Variant(String, UInt64))\`.size0, v.\`Array(Variant(String, UInt64))\`.UInt64, v.\`Array(Variant(String, UInt64))\`.String from test order by id format Null"


### PR DESCRIPTION
The test timed out in MSan CI with randomized `index_granularity=9`, which creates excessive granules for 1M rows of complex Variant data. Reduce from 1M to 100K rows — sufficient to test Variant subcolumn read paths across Memory, compact, and wide MergeTree engines.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=7b241737b445273aa39bd13ff57a13d7a8c7669d&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_msan%2C%20parallel%2C%202%2F2%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.476`
<!-- ch-version-info:end -->