### PR TITLE
Fix misleading error in CI when S3 credentials are missing

### DIFF
--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -1045,7 +1045,7 @@ class _ResultS3:
         local_dir = Path(local_path).parent
         s3_path = f"{Settings.HTML_S3_PATH}/{env.get_s3_prefix()}"
         latest_result_file = Shell.get_output(
-            f"aws s3 ls {s3_path}/{file_name}_ | awk '{{print $4}}' | sort -r | head -n 1",
+            f"set -o pipefail && aws s3 ls {s3_path}/{file_name}_ | awk '{{print $4}}' | sort -r | head -n 1",
             strict=True,
             verbose=True,
         )


### PR DESCRIPTION
The pipeline `aws s3 ls ... | awk | sort | head` in `copy_result_from_s3_with_version` returned exit code 0 even when `aws s3 ls` failed, because bash uses the last command's exit code. This caused a confusing `ValueError: invalid literal for int()` instead of a clear credentials error.

Add `set -o pipefail` so the pipeline properly propagates the `aws s3 ls` failure to the `strict=True` check.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96373&sha=latest&name_0=PR
https://github.com/ClickHouse/ClickHouse/pull/96373

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.465`
<!-- ch-version-info:end -->