### PR TITLE
Fix exception in `CancellationChecker` crashing server in BackgroundSchedulePool

### DIFF
--- a/src/Interpreters/CancellationChecker.cpp
+++ b/src/Interpreters/CancellationChecker.cpp
@@ -34,10 +34,19 @@ void CancellationChecker::cancelTask(CancellationChecker::QueryToTrack task)
 {
     if (task.query)
     {
-        if (task.overflow_mode == OverflowMode::THROW)
-            task.query->cancelQuery(CancelReason::TIMEOUT);
-        else
-            task.query->checkTimeLimit();
+        try
+        {
+            if (task.overflow_mode == OverflowMode::THROW)
+                task.query->cancelQuery(CancelReason::TIMEOUT);
+            else
+                task.query->checkTimeLimit();
+        }
+        catch (...)
+        {
+            /// This function is called from BackgroundSchedulePool which does not allow exceptions.
+            /// The query might have been already cancelled by another mechanism, which is fine.
+            tryLogCurrentException("CancellationChecker");
+        }
     }
 }
 


### PR DESCRIPTION
`CancellationChecker::cancelTask` calls `QueryStatus::checkTimeLimit` which can throw via `throwProperExceptionIfNeeded` when the query is already killed. Since `workerFunction` runs as a `BackgroundSchedulePool` task, this exception propagates to the pool's `execute` method and triggers a fatal assertion: `chassert(false && "Tasks in BackgroundSchedulePool cannot throw")`.

Wrap the cancellation logic in a try-catch to prevent the exception from escaping the background task context.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=3b89165de7e5c5377f99e616fc93c74cd85310e6&name_0=MasterCI&name_1=Stress%20test%20%28amd_tsan%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.466`
<!-- ch-version-info:end -->