### PR TITLE
Fix logical error when reading subcolumns of EPHEMERAL columns from `StorageLog`

### DIFF
--- a/src/Storages/ColumnsDescription.cpp
+++ b/src/Storages/ColumnsDescription.cpp
@@ -549,6 +549,12 @@ void ColumnsDescription::addSubcolumnsToList(NamesAndTypesList & source_list) co
     NamesAndTypesList subcolumns_list;
     for (const auto & col : source_list)
     {
+        /// Skip subcolumns of EPHEMERAL columns: they have no physical data
+        /// and no expression to compute them during SELECT.
+        auto it = columns.get<1>().find(col.name);
+        if (it != columns.get<1>().end() && it->default_desc.kind == ColumnDefaultKind::Ephemeral)
+            continue;
+
         auto range = subcolumns.get<1>().equal_range(col.name);
         if (range.first != range.second)
             subcolumns_list.insert(subcolumns_list.end(), range.first, range.second);

--- a/src/Storages/StorageLog.cpp
+++ b/src/Storages/StorageLog.cpp
@@ -970,7 +970,7 @@ Pipe StorageLog::createReadingPipe(
 
     /// Converting to subcolumns of Nested is needed for
     /// correct reading of parts of Nested with shared offsets.
-    auto options = GetColumnsOptions(GetColumnsOptions::All).withSubcolumns();
+    auto options = GetColumnsOptions(GetColumnsOptions::AllPhysical).withSubcolumns();
     auto all_columns = storage_snapshot->getColumnsByNames(options, column_names);
     all_columns = Nested::convertToSubcolumns(all_columns);
 
@@ -1282,7 +1282,7 @@ SharedHeader getHeader(
     const StorageSnapshotPtr & storage_snapshot
 )
 {
-    auto options = GetColumnsOptions(GetColumnsOptions::All).withSubcolumns();
+    auto options = GetColumnsOptions(GetColumnsOptions::AllPhysical).withSubcolumns();
     auto all_columns = storage_snapshot->getColumnsByNames(options, column_names);
     all_columns = Nested::convertToSubcolumns(all_columns);
 

--- a/tests/queries/0_stateless/03829_log_engine_ephemeral_subcolumn.sql
+++ b/tests/queries/0_stateless/03829_log_engine_ephemeral_subcolumn.sql
@@ -1,0 +1,5 @@
+DROP TABLE IF EXISTS test;
+CREATE TABLE test (c0 Tuple(c1 Nullable(DateTime64(6))) EPHEMERAL, c2 Nullable(Bool)) ENGINE = TinyLog;
+INSERT INTO test (c2) VALUES (true);
+SELECT c0.c1.null FROM test; -- { serverError NO_SUCH_COLUMN_IN_TABLE }
+DROP TABLE test;

--- a/tests/queries/0_stateless/03829_log_engine_ephemeral_subcolumn.sql
+++ b/tests/queries/0_stateless/03829_log_engine_ephemeral_subcolumn.sql
@@ -1,5 +1,5 @@
 DROP TABLE IF EXISTS test;
 CREATE TABLE test (c0 Tuple(c1 Nullable(DateTime64(6))) EPHEMERAL, c2 Nullable(Bool)) ENGINE = TinyLog;
 INSERT INTO test (c2) VALUES (true);
-SELECT c0.c1.null FROM test; -- { serverError NO_SUCH_COLUMN_IN_TABLE }
+SELECT c0.c1.null FROM test; -- { serverError NO_SUCH_COLUMN_IN_TABLE, NOT_FOUND_COLUMN_IN_BLOCK }
 DROP TABLE test;


### PR DESCRIPTION
`hasColumnOrSubcolumn` and `tryGetColumn` in `ColumnsDescription` did not filter subcolumns by the parent column's kind. When `hasColumnOrSubcolumn(AllPhysical, "c0.c1.null")` was called for an EPHEMERAL column `c0`, it found the subcolumn and returned true, even though the parent has no physical data. This caused `StorageLog` to try reading non-existent data files, resulting in a `LOGICAL_ERROR` exception.

Fix by checking the parent column's kind when resolving subcolumns, and by using `AllPhysical` instead of `All` in `StorageLog` column resolution.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=8c9ef966cad58dfff0b777db071df2de10dd2c33&name_0=MasterCI&name_1=BuzzHouse%20%28amd_tsan%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.590`
<!-- ch-version-info:end -->