### PR TITLE
Fix flaky `03100_lwu_42_bytes_limits` test

### DIFF
--- a/tests/queries/0_stateless/03100_lwu_42_bytes_limits.sh
+++ b/tests/queries/0_stateless/03100_lwu_42_bytes_limits.sh
@@ -15,6 +15,8 @@ $CLICKHOUSE_CLIENT -q "
         enable_block_number_column = 1,
         enable_block_offset_column = 1,
         max_uncompressed_bytes_in_patches = '100Ki',
+        index_granularity = 8192,
+        index_granularity_bytes = '10Mi',
         cleanup_delay_period = 1,
         max_cleanup_delay_period = 1,
         cleanup_delay_period_random_add = 0;


### PR DESCRIPTION
Pin `index_granularity` and `index_granularity_bytes` in the table settings to prevent the randomizer from injecting extreme values (e.g. `index_granularity = 1`), which inflate mark file sizes and push `data_uncompressed_bytes` over the 100Ki threshold.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96406&sha=f258c3e0d9175f59e227ce3263b177df86933ff8&name_0=PR&name_1=Stateless%20tests%20%28amd_ubsan%2C%20parallel%29
https://github.com/ClickHouse/ClickHouse/pull/96406

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.474`
<!-- ch-version-info:end -->