### PR TITLE
Fix strange code in InterpreterCreateQuery

### DIFF
--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -735,7 +735,7 @@ ConstraintsDescription InterpreterCreateQuery::getConstraintsDescription(
 
 
 InterpreterCreateQuery::TableProperties InterpreterCreateQuery::getTablePropertiesAndNormalizeCreateQuery(
-    ASTCreateQuery & create, LoadingStrictnessLevel mode) const
+    ASTCreateQuery & create, LoadingStrictnessLevel mode)
 {
     /// Set the table engine if it was not specified explicitly.
     setEngine(create);

--- a/src/Interpreters/InterpreterCreateQuery.h
+++ b/src/Interpreters/InterpreterCreateQuery.h
@@ -100,7 +100,7 @@ private:
     BlockIO createTable(ASTCreateQuery & create);
 
     /// Calculate list of columns, constraints, indices, etc... of table. Rewrite query in canonical way.
-    TableProperties getTablePropertiesAndNormalizeCreateQuery(ASTCreateQuery & create, LoadingStrictnessLevel mode) const;
+    TableProperties getTablePropertiesAndNormalizeCreateQuery(ASTCreateQuery & create, LoadingStrictnessLevel mode);
     void validateTableStructure(const ASTCreateQuery & create, const TableProperties & properties) const;
     void validateMaterializedViewColumnsAndEngine(const ASTCreateQuery & create, const TableProperties & properties, const DatabasePtr & database);
     void setEngine(ASTCreateQuery & create) const;
@@ -139,7 +139,7 @@ private:
     bool need_ddl_guard = true;
     bool is_restore_from_backup = false;
 
-    mutable String as_database_saved;
-    mutable String as_table_saved;
+    String as_database_saved;
+    String as_table_saved;
 };
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

When I see `mutable`, I think "oh, shi~". But it's not AI code, it's from 2021. CC @tavplubix 


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.469`
<!-- ch-version-info:end -->