### PR TITLE
Add semicolons to fuzzer reproduce commands

### DIFF
--- a/ci/jobs/scripts/log_parser.py
+++ b/ci/jobs/scripts/log_parser.py
@@ -507,7 +507,7 @@ class FuzzerLogParser:
 
         if not (tables or table_files or table_finctions):
             print("WARNING: No tables found in query command")
-            return [failed_query]
+            return [failed_query + ";" if not failed_query.endswith(";") else failed_query]
 
         # Get all write commands for found tables
         commands_to_reproduce = []
@@ -528,6 +528,12 @@ class FuzzerLogParser:
             # Add table drop commands
             for table in tables:
                 commands_to_reproduce.append(f"DROP TABLE IF EXISTS {table}")
+
+        # Ensure all commands end with a semicolon
+        commands_to_reproduce = [
+            cmd + ";" if not cmd.endswith(";") else cmd
+            for cmd in commands_to_reproduce
+        ]
 
         return commands_to_reproduce
 


### PR DESCRIPTION
The reproduce commands in the AST fuzzer CI report were missing trailing semicolons, making them less convenient to copy-paste and execute.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=a1ce95512f6c8d75e10929bc4835787e194eeed8&name_0=MasterCI&name_1=AST%20fuzzer%20%28amd_ubsan%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.467`
<!-- ch-version-info:end -->