### PR TITLE
Fix stress test log parser failing with "Parse failure error"

### DIFF
--- a/ci/jobs/scripts/log_parser.py
+++ b/ci/jobs/scripts/log_parser.py
@@ -538,7 +538,8 @@ class FuzzerLogParser:
         return commands_to_reproduce
 
     def _get_all_fuzzer_commands(self):
-        assert self.fuzzer_log, "Fuzzer log is not provided"
+        if not self.fuzzer_log:
+            return None
         error_logs = [
             "Fuzzing step",
             "Query succeeded",

--- a/ci/jobs/scripts/log_parser.py
+++ b/ci/jobs/scripts/log_parser.py
@@ -158,7 +158,7 @@ class FuzzerLogParser:
 
         if is_logical_error:
             failed_query = self.get_failed_query()
-            if failed_query:
+            if failed_query and self.fuzzer_log:
                 reproduce_commands = self.get_reproduce_commands(failed_query)
             if format_message and "Inconsistent AST formatting" not in result_name:
                 # Replace {} placeholders with A, B, C, etc. to create a generic error pattern.
@@ -538,8 +538,7 @@ class FuzzerLogParser:
         return commands_to_reproduce
 
     def _get_all_fuzzer_commands(self):
-        if not self.fuzzer_log:
-            return None
+        assert self.fuzzer_log, "Fuzzer log is not provided"
         error_logs = [
             "Fuzzing step",
             "Query succeeded",


### PR DESCRIPTION
When a stress test detects a server crash (logical error), the log parser tries to generate reproduce commands by reading the fuzzer log. But stress tests don't have a fuzzer log, so `_get_all_fuzzer_commands` hits an assert and raises an exception. This causes the actual failure details (error message, stack trace) to be lost, replaced by the misleading "Parse failure error: Fuzzer log is not provided" message.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96416&sha=4fe43025ab04c2076b002214a8a1e53b1f823c45&name_0=PR&name_1=Stress%20test%20%28arm_asan%2C%20s3%29
https://github.com/ClickHouse/ClickHouse/pull/96416

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.477`
<!-- ch-version-info:end -->