### PR TITLE
KILL QUERY and cancel query (Ctrl+C) don't work with mysql() table function

### DIFF
--- a/src/Common/mysqlxx/Connection.cpp
+++ b/src/Common/mysqlxx/Connection.cpp
@@ -158,7 +158,7 @@ MYSQL * Connection::getDriver()
     return driver.get();
 }
 
-unsigned long Connection::getDriverThreadID()
+uint64_t Connection::getDriverThreadID()
 {
     return mysql_thread_id(driver.get());
 }

--- a/src/Common/mysqlxx/Connection.cpp
+++ b/src/Common/mysqlxx/Connection.cpp
@@ -158,5 +158,9 @@ MYSQL * Connection::getDriver()
     return driver.get();
 }
 
+unsigned long Connection::getDriverThreadID()
+{
+    return mysql_thread_id(driver.get());
 }
 
+}

--- a/src/Common/mysqlxx/mysqlxx/Connection.h
+++ b/src/Common/mysqlxx/mysqlxx/Connection.h
@@ -161,6 +161,8 @@ public:
     /// Get MySQL C API MYSQL object.
     MYSQL * getDriver();
 
+    unsigned long getDriverThreadID();
+
 private:
     std::unique_ptr<MYSQL> driver;
     bool is_initialized = false;

--- a/src/Common/mysqlxx/mysqlxx/Connection.h
+++ b/src/Common/mysqlxx/mysqlxx/Connection.h
@@ -161,7 +161,7 @@ public:
     /// Get MySQL C API MYSQL object.
     MYSQL * getDriver();
 
-    unsigned long getDriverThreadID();
+    uint64_t getDriverThreadID();
 
 private:
     std::unique_ptr<MYSQL> driver;

--- a/src/Common/mysqlxx/mysqlxx/Pool.h
+++ b/src/Common/mysqlxx/mysqlxx/Pool.h
@@ -61,6 +61,18 @@ public:
             incrementRefCount();
         }
 
+        Entry& operator=(const Entry& src)
+        {
+            if (this != &src)
+            {
+                decrementRefCount();
+                data = src.data;
+                pool = src.pool;
+                incrementRefCount();
+            }
+            return *this;
+        }
+
         ~Entry()
         {
             decrementRefCount();

--- a/src/Processors/Sources/MySQLSource.cpp
+++ b/src/Processors/Sources/MySQLSource.cpp
@@ -161,8 +161,6 @@ void MySQLWithFailoverSource::onCancel() noexcept
 {
     try
     {
-        LOG_DEBUG(log, "Entering onCancel()");
-
         if (mysql_connection_id == 0)
         {
             LOG_DEBUG(log, "No valid MySQL connection ID to cancel");
@@ -199,8 +197,6 @@ void MySQLWithFailoverSource::onCancel() noexcept
         {
             LOG_WARNING(log, "std::exception during cancellation: {}", e.what());
         }
-
-        LOG_DEBUG(log, "Exiting onCancel()");
     }
     catch (...)
     {

--- a/src/Processors/Sources/MySQLSource.cpp
+++ b/src/Processors/Sources/MySQLSource.cpp
@@ -146,9 +146,9 @@ Chunk MySQLWithFailoverSource::generate()
 
         return MySQLSource::generate();
     }
-    catch (...)
+    catch (const mysqlxx::BadQuery & e)
     {
-        LOG_ERROR(log, "Error in MySQLWithFailoverSource::generate()");
+        LOG_ERROR(log, "Error in MySQLWithFailoverSource::generate(): {}", e.displayText());
 
         if (!isCancelled())
             throw;

--- a/src/Processors/Sources/MySQLSource.cpp
+++ b/src/Processors/Sources/MySQLSource.cpp
@@ -149,6 +149,10 @@ Chunk MySQLWithFailoverSource::generate()
     catch (...)
     {
         LOG_ERROR(log, "Error in MySQLWithFailoverSource::generate()");
+
+        if (!isCancelled())
+            throw;
+
         return {};
     }
 }

--- a/src/Processors/Sources/MySQLSource.cpp
+++ b/src/Processors/Sources/MySQLSource.cpp
@@ -106,6 +106,7 @@ void MySQLWithFailoverSource::onStart()
             mysqlxx::PoolWithFailover::Entry entry = pool->get();
             mysqlxx::Connection & mysql_conn = entry;
             mysql_connection_id = mysql_conn.getDriverThreadID();
+            LOG_TEST(log, "Get data from database");
             connection = std::make_unique<Connection>(entry, query_str);
             break;
         }
@@ -390,6 +391,7 @@ namespace
 
 Chunk MySQLSource::generate()
 {
+    LOG_TEST(log, "Generate a chuck");
     auto row = connection->result.fetch();
     if (!row)
     {

--- a/src/Processors/Sources/MySQLSource.h
+++ b/src/Processors/Sources/MySQLSource.h
@@ -82,8 +82,8 @@ private:
 
     mysqlxx::PoolWithFailoverPtr pool;
     std::string query_str;
-    bool is_initialized = false;
-    uint64_t mysql_connection_id = 0;
+    std::atomic<bool> is_initialized{false};
+    std::atomic<uint64_t> mysql_connection_id{0};
 };
 
 }

--- a/src/Processors/Sources/MySQLSource.h
+++ b/src/Processors/Sources/MySQLSource.h
@@ -83,7 +83,7 @@ private:
     mysqlxx::PoolWithFailoverPtr pool;
     std::string query_str;
     bool is_initialized = false;
-    unsigned long mysql_connection_id = 0;
+    uint64_t mysql_connection_id = 0;
 };
 
 }

--- a/src/Processors/Sources/MySQLSource.h
+++ b/src/Processors/Sources/MySQLSource.h
@@ -74,12 +74,16 @@ public:
 
     Chunk generate() override;
 
+protected:
+    void onCancel() noexcept override;
+
 private:
     void onStart();
 
     mysqlxx::PoolWithFailoverPtr pool;
     std::string query_str;
     bool is_initialized = false;
+    unsigned long mysql_connection_id = 0;
 };
 
 }

--- a/tests/integration/test_mysql_kill_query/configs/users.xml
+++ b/tests/integration/test_mysql_kill_query/configs/users.xml
@@ -1,0 +1,22 @@
+<clickhouse>
+    <profiles>
+        <default>
+        </default>
+    </profiles>
+
+    <users>
+        <default>
+            <password></password>
+            <networks incl="networks" replace="replace">
+                <ip>::/0</ip>
+            </networks>
+            <profile>default</profile>
+            <quota>default</quota>
+        </default>
+    </users>
+
+    <quotas>
+        <default>
+        </default>
+    </quotas>
+</clickhouse>

--- a/tests/integration/test_mysql_kill_query/test.py
+++ b/tests/integration/test_mysql_kill_query/test.py
@@ -127,7 +127,7 @@ def test_kill_infinite_query(setup_infinite_query):
             '{mysql_pass}')""",
             query_id=query_id,
         )
-        assert "Dmysql_conn.commit()B::Exception: Query was cancelled" in error
+        assert "DB::Exception: Query was cancelled" in error
 
     query_thread = threading.Thread(target=execute_query)
     query_thread.start()

--- a/tests/integration/test_mysql_kill_query/test.py
+++ b/tests/integration/test_mysql_kill_query/test.py
@@ -177,6 +177,7 @@ SETTINGS max_block_size = 10000""",
     query_thread = threading.Thread(target=execute_query)
     query_thread.start()
 
+    node1.wait_for_log_line("Get data from database")
     node1.wait_for_log_line("Generate a chuck")
     time.sleep(1)
 
@@ -254,6 +255,8 @@ SETTINGS max_block_size = 10000"""
 
     query_thread = threading.Thread(target=execute_query)
     query_thread.start()
+
+    node1.wait_for_log_line("Get data from database")
     node1.wait_for_log_line("Generate a chuck")
     time.sleep(2)
 

--- a/tests/integration/test_mysql_kill_query/test.py
+++ b/tests/integration/test_mysql_kill_query/test.py
@@ -1,0 +1,265 @@
+import pytest
+import uuid
+import threading
+import logging
+import warnings
+import time
+import pymysql
+from helpers.config_cluster import mysql_pass
+from helpers.cluster import ClickHouseCluster
+
+
+cluster = ClickHouseCluster(__file__)
+node1 = cluster.add_instance(
+    "node1",
+    user_configs=["configs/users.xml"],
+    with_mysql8=True,
+)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        mysql_conn = pymysql.connect(
+            user="root",
+            password=mysql_pass,
+            host=cluster.mysql8_ip,
+            port=cluster.mysql8_port,
+        )
+        with mysql_conn.cursor() as cursor:
+            cursor.execute("DROP DATABASE IF EXISTS test_db")
+            cursor.execute("CREATE DATABASE test_db")
+            cursor.execute("USE test_db")
+        mysql_conn.commit()
+        yield mysql_conn, cluster
+    finally:
+        cluster.shutdown()
+
+
+@pytest.fixture(scope="module")
+def setup_infinite_query(started_cluster):
+    mysql_conn, cluster = started_cluster
+    with mysql_conn.cursor() as cursor:
+        # Create function with infinite sleep (sleeps one year)
+        cursor.execute(
+            """CREATE FUNCTION infinite_sleep() RETURNS INT
+DETERMINISTIC
+NO SQL
+BEGIN
+DO SLEEP(31536000);
+RETURN 1;
+END"""
+        )
+        cursor.execute(
+            """CREATE VIEW infinite_counter AS
+SELECT 1 AS col
+WHERE infinite_sleep() = 1;"""
+        )
+    mysql_conn.commit()
+    yield mysql_conn, cluster
+
+
+@pytest.fixture(scope="module")
+def setup_big_data_table(started_cluster):
+    mysql_conn, cluster = started_cluster
+    with mysql_conn.cursor() as cursor:
+        # Create big table
+        cursor.execute(
+            """CREATE TABLE big_data_table (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    random_int INT,
+    random_string VARCHAR(100),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB; """
+        )
+
+        # Create procedure to insert data
+        cursor.execute(
+            """CREATE PROCEDURE insert_big_data(IN num_rows INT)
+BEGIN
+  DECLARE i INT DEFAULT 0;
+  START TRANSACTION;
+  WHILE i < num_rows DO
+    INSERT INTO big_data_table (random_int, random_string)
+    VALUES (
+      FLOOR(RAND() * 1000000),
+      SUBSTRING(UUID(), 1, 10)
+    );
+    SET i = i + 1;
+    IF i % 10000 = 0 THEN
+      COMMIT;
+      START TRANSACTION;
+    END IF;
+  END WHILE;
+  COMMIT;
+END"""
+        )
+
+        # Insert test data using the procedure
+        cursor.execute("CALL insert_big_data(1000000)")
+
+    mysql_conn.commit()
+
+    yield mysql_conn, cluster
+
+
+# Stop clickhouse-client by SIGINT signal that is the same as pressing Ctrl+C
+def stop_clickhouse_client():
+    client_pid = node1.get_process_pid("clickhouse client")
+    node1.exec_in_container(
+        ["bash", "-c", f"kill -INT {client_pid}"],
+        user="root",
+    )
+
+
+def test_kill_infinite_query(setup_infinite_query):
+    mysql_conn, cluster = setup_infinite_query
+    query_id = str(uuid.uuid4())
+
+    def execute_query():
+        _, error = node1.query_and_get_answer_with_error(
+            f"""SELECT * FROM mysql(
+            '{cluster.mysql8_ip}:{cluster.mysql8_port}',
+            'test_db',
+            'infinite_counter',
+            'root',
+            '{mysql_pass}')""",
+            query_id=query_id,
+        )
+        assert "Dmysql_conn.commit()B::Exception: Query was cancelled" in error
+
+    query_thread = threading.Thread(target=execute_query)
+    query_thread.start()
+
+    node1.wait_for_log_line("Get data from database")
+    time.sleep(1)
+
+    node1.query(f"KILL QUERY WHERE query_id='{query_id}' SYNC")
+
+    query_thread.join()
+
+    # Verify that query was successfully cancelled in ClickHouse server
+    result = node1.query(
+        "SELECT count(*) FROM system.processes WHERE query_id='{query_id}'"
+    )
+    assert int(result.strip()) == 0
+
+    # Verify that query was successfully cancelled in MySQL server
+    with mysql_conn.cursor() as cursor:
+        cursor.execute("SHOW PROCESSLIST;")
+        processes = cursor.fetchall()
+        logging.debug(f"Processes: {processes}")
+        assert len(processes) == 0 or "infinite_counter" not in str(processes)
+
+    assert node1.contains_in_log("QUERY_WAS_CANCELLED")
+
+
+def test_kill_query_during_generation(setup_big_data_table):
+    mysql_conn, cluster = setup_big_data_table
+    query_id = str(uuid.uuid4())
+
+    def execute_query():
+        _, error = node1.query_and_get_answer_with_error(
+            f"""SELECT sleepEachRow(0.0001), id, random_int, random_string
+FROM mysql(
+    '{cluster.mysql8_ip}:{cluster.mysql8_port}',
+    'test_db',
+    'big_data_table',
+    'root',
+    '{mysql_pass}'
+)
+SETTINGS max_block_size = 10000""",
+            query_id=query_id,
+        )
+        assert "DB::Exception: Query was cancelled" in error
+
+    query_thread = threading.Thread(target=execute_query)
+    query_thread.start()
+
+    node1.wait_for_log_line("Generate a chuck")
+    time.sleep(1)
+
+    node1.query(f"KILL QUERY WHERE query_id='{query_id}' SYNC")
+
+    query_thread.join()
+
+    # Verify that query was successfully cancelled in ClickHouse server
+    result = node1.query(
+        "SELECT count(*) FROM system.processes WHERE query_id='{query_id}'"
+    )
+    assert int(result.strip()) == 0
+
+    # Verify that query was successfully cancelled in MySQL server
+    with mysql_conn.cursor() as cursor:
+        cursor.execute("SHOW PROCESSLIST;")
+        processes = cursor.fetchall()
+        logging.debug(f"Processes: {processes}")
+        assert len(processes) == 0 or "big_data_table" not in str(processes)
+
+    assert node1.contains_in_log("QUERY_WAS_CANCELLED")
+
+
+def test_cancel_infinite_query(setup_infinite_query):
+    _, cluster = setup_infinite_query
+
+    def execute_query():
+        query = f"""SELECT * FROM mysql(
+        '{cluster.mysql8_ip}:{cluster.mysql8_port}',
+        'test_db',
+        'infinite_counter',
+        'root',
+        '{mysql_pass}')"""
+        node1.exec_in_container(
+            [
+                "bash",
+                "-c",
+                f"""/usr/bin/clickhouse client --query "{query}" """,
+            ]
+        )
+
+    query_thread = threading.Thread(target=execute_query)
+    query_thread.start()
+    node1.wait_for_log_line("Get data from database")
+    time.sleep(2)
+
+    stop_clickhouse_client()
+    node1.wait_for_log_line("DB::Exception: Received 'Cancel' packet from the client")
+    time.sleep(1)
+
+    query_thread.join()
+    assert node1.contains_in_log("QUERY_WAS_CANCELLED_BY_CLIENT")
+
+
+def test_cancel_query_during_generation(setup_big_data_table):
+    _, cluster = setup_big_data_table
+
+    def execute_query():
+        query = f"""SELECT sleepEachRow(0.0001), id, random_int, random_string
+FROM mysql(
+    '{cluster.mysql8_ip}:{cluster.mysql8_port}',
+    'test_db',
+    'big_data_table',
+    'root',
+    '{mysql_pass}'
+)
+SETTINGS max_block_size = 10000"""
+        node1.exec_in_container(
+            [
+                "bash",
+                "-c",
+                f"""/usr/bin/clickhouse client --query "{query}" """,
+            ]
+        )
+
+    query_thread = threading.Thread(target=execute_query)
+    query_thread.start()
+    node1.wait_for_log_line("Generate a chuck")
+    time.sleep(2)
+
+    stop_clickhouse_client()
+    node1.wait_for_log_line("DB::Exception: Received 'Cancel' packet from the client")
+    time.sleep(1)
+
+    query_thread.join()
+    assert node1.contains_in_log("QUERY_WAS_CANCELLED_BY_CLIENT")


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix  mysql() table function canceling  by KILL QUERY and cancel query (Ctrl+C) in clickhouse-client.

Closed #95515


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.565`
<!-- ch-version-info:end -->