### PR TITLE
Fix integration test failures in flaky check

### DIFF
--- a/tests/integration/test_async_connect_to_multiple_ips/test.py
+++ b/tests/integration/test_async_connect_to_multiple_ips/test.py
@@ -70,3 +70,7 @@ def test(cluster_without_dns_cache_update):
         )
         == "1\n"
     )
+
+    node1.query(
+        "DROP TABLE test"
+    )

--- a/tests/integration/test_format_schema_on_server/test.py
+++ b/tests/integration/test_format_schema_on_server/test.py
@@ -70,6 +70,9 @@ message MessageTmp {
         os.path.join(database_path, "format_schemas", protobuf_schema_path_name), "w"
     ) as file:
         file.write(schema)
+
+    instance.query("SYSTEM CLEAR FORMAT SCHEMA CACHE FOR Protobuf")
+
     assert (
         instance.http_query(
             "SELECT * FROM test.simple FORMAT Protobuf SETTINGS format_schema='message_tmp:MessageTmp'"
@@ -99,9 +102,9 @@ message MessageTmp {
     )
     instance.query("INSERT INTO test.new_simple VALUES (1, 'abc'), (2, 'def')")
 
-    instance.query("SYSTEM DROP FORMAT SCHEMA CACHE FOR Protobuf")
+    instance.query("SYSTEM CLEAR FORMAT SCHEMA CACHE FOR Protobuf")
 
-    # Tets works with new scheme
+    # Test works with new scheme
     assert (
         instance.http_query(
             "SELECT * FROM test.new_simple FORMAT Protobuf SETTINGS format_schema='message_tmp:MessageTmp'"
@@ -160,7 +163,7 @@ struct MessageTmp {
     )
     instance.query("INSERT INTO test.new_simple VALUES (1, 'abc'), (2, 'def')")
 
-    # instance.query("SYSTEM DROP FORMAT SCHEMA CACHE FOR CapnProto")
+    # instance.query("SYSTEM CLEAR FORMAT SCHEMA CACHE FOR CapnProto")
 
     # Tets works with new scheme
     assert instance.http_query(


### PR DESCRIPTION
Fixes integration test failures in flaky checks (happened in https://github.com/ClickHouse/ClickHouse/pull/96430/changes#diff-9b330552f776c53add7b6ba643e1aaff958a9e89281e45c14dea20c4f6976a0b)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.488`
<!-- ch-version-info:end -->