### PR TITLE
Fully clear removed blobs queue on shutdown

### DIFF
--- a/src/Disks/DiskObjectStorage/MetadataStorages/Cache/MetadataStorageFromCacheObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/MetadataStorages/Cache/MetadataStorageFromCacheObjectStorage.cpp
@@ -1,5 +1,6 @@
 #include <Disks/DiskObjectStorage/MetadataStorages/Cache/MetadataStorageFromCacheObjectStorage.h>
 
+#include <limits>
 #include <ranges>
 
 namespace DB
@@ -193,6 +194,9 @@ bool MetadataStorageFromCacheObjectStorage::supportWritingWithAppend() const
 IMetadataStorage::BlobsToRemove MetadataStorageFromCacheObjectStorage::getBlobsToRemove(const ClusterConfigurationPtr & cluster, int64_t max_count)
 {
     std::lock_guard guard(removed_objects_mutex);
+
+    if (max_count == 0)
+        max_count = std::numeric_limits<int64_t>::max();
 
     BlobsToRemove blobs_to_remove;
     for (const auto & blob : objects_to_remove | std::views::take(max_count))

--- a/src/Disks/DiskObjectStorage/MetadataStorages/Local/MetadataStorageFromDisk.cpp
+++ b/src/Disks/DiskObjectStorage/MetadataStorages/Local/MetadataStorageFromDisk.cpp
@@ -9,6 +9,7 @@
 
 #include <Common/logger_useful.h>
 
+#include <limits>
 #include <ranges>
 #include <memory>
 #include <shared_mutex>
@@ -152,6 +153,9 @@ uint32_t MetadataStorageFromDisk::getHardlinkCount(const std::string & path) con
 IMetadataStorage::BlobsToRemove MetadataStorageFromDisk::getBlobsToRemove(const ClusterConfigurationPtr & cluster, int64_t max_count)
 {
     std::lock_guard guard(removed_objects_mutex);
+
+    if (max_count == 0)
+        max_count = std::numeric_limits<int64_t>::max();
 
     BlobsToRemove blobs_to_remove;
     for (const auto & blob : objects_to_remove | std::views::take(max_count))

--- a/src/Disks/DiskObjectStorage/Replication/BlobKillerThread.cpp
+++ b/src/Disks/DiskObjectStorage/Replication/BlobKillerThread.cpp
@@ -250,7 +250,7 @@ void BlobKillerThread::shutdown()
     task->deactivate();
 
     /// We need to execute it here explicitly because some blobs may be in the metadata storage queue.
-    executeBlobsCleanup(metadata_request_batch.load(), remove_tasks_runner, cluster, metadata_storage, object_storages, log);
+    executeBlobsCleanup(/*max_to_remove=*/0, remove_tasks_runner, cluster, metadata_storage, object_storages, log);
 }
 
 void BlobKillerThread::applyNewSettings(const Poco::Util::AbstractConfiguration & config, const std::string & config_prefix)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.497`
<!-- ch-version-info:end -->