### PR TITLE
Move config setting 'allow_impersonate_user' to section 'access_control_improvements'

### DIFF
--- a/docs/en/sql-reference/statements/execute_as.md
+++ b/docs/en/sql-reference/statements/execute_as.md
@@ -22,7 +22,7 @@ The first form (without `subquery`) sets that all the following queries in the c
 
 The second form (with `subquery`) executes only the specified `subquery` on behalf of the specified `target_user`.
 
-In order to work both forms require server setting [allow_impersonate_user](/operations/server-configuration-parameters/settings#allow_impersonate_user)
+In order to work both forms require config setting `access_control_improvements.allow_impersonate_user`
 to be set to `1` and the `IMPERSONATE` privilege to be granted. For example, the following commands
 ```sql
 GRANT IMPERSONATE ON user1 TO user2;

--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -854,6 +854,9 @@
              however you can change this behaviour by setting this to true -->
         <table_engines_require_grant>false</table_engines_require_grant>
 
+        <!-- Enable/disable the IMPERSONATE feature (EXECUTE AS target_user). -->
+        <allow_impersonate_user>false</allow_impersonate_user>
+
         <!-- Number of seconds since last access a role is stored in the Role Cache -->
         <role_cache_expiration_time_seconds>600</role_cache_expiration_time_seconds>
     </access_control_improvements>

--- a/src/Access/AccessControl.cpp
+++ b/src/Access/AccessControl.cpp
@@ -308,6 +308,7 @@ void AccessControl::setupFromMainConfig(const Poco::Util::AbstractConfiguration 
     setSettingsConstraintsReplacePrevious(config_.getBool("access_control_improvements.settings_constraints_replace_previous", true));
     setTableEnginesRequireGrant(config_.getBool("access_control_improvements.table_engines_require_grant", false));
     setEnableReadWriteGrants(config_.getBool("access_control_improvements.enable_read_write_grants", false));
+    setImpersonateUserAllowed(config_.getBool("access_control_improvements.allow_impersonate_user", config_.getBool("allow_impersonate_user", false)));
 
     /// Set `true` by default because the feature is backward incompatible only when older version replicas are in the same cluster.
     setEnableUserNameAccessType(config_.getBool("access_control_improvements.enable_user_name_access_type", true));

--- a/src/Access/AccessControl.h
+++ b/src/Access/AccessControl.h
@@ -201,6 +201,10 @@ public:
     void setTableEnginesRequireGrant(bool enable) { table_engines_require_grant = enable; }
     bool doesTableEnginesRequireGrant() const { return table_engines_require_grant; }
 
+    /// Enable/disable the IMPERSONATE feature (EXECUTE AS target_user).
+    void setImpersonateUserAllowed(bool allow) { allow_impersonate_user = allow; }
+    bool isImpersonateUserAllowed() const { return allow_impersonate_user; }
+
     void setThrowOnInvalidReplicatedAccessEntities(bool enable) { throw_on_invalid_replicated_access_entities = enable; }
     bool shouldThrowOnInvalidReplicatedAccessEntities() const { return throw_on_invalid_replicated_access_entities; }
 
@@ -296,6 +300,7 @@ private:
     std::atomic_bool allow_beta_tier_settings = true;
     std::atomic_bool enable_user_name_access_type = true;
     std::atomic_bool enable_read_write_grants = false;
+    std::atomic_bool allow_impersonate_user = false;
 };
 
 }

--- a/src/Core/ServerSettings.cpp
+++ b/src/Core/ServerSettings.cpp
@@ -1248,7 +1248,7 @@ The policy on how to perform a scheduling of CPU slots specified by `concurrent_
     Possible values: -20 to 19.
     )", 0) \
     DECLARE(String, keeper_hosts, "", R"(Dynamic setting. Contains a set of [Zoo]Keeper hosts ClickHouse can potentially connect to. Doesn't expose information from `<auxiliary_zookeepers>`)", 0) \
-    DECLARE(Bool, allow_impersonate_user, false, R"(Enable/disable the IMPERSONATE feature (EXECUTE AS target_user).)", 0) \
+    DECLARE(Bool, allow_impersonate_user, false, R"(Enable/disable the IMPERSONATE feature (EXECUTE AS target_user). The setting is deprecated.)", SettingsTierType::OBSOLETE) \
     DECLARE(UInt64, s3_credentials_provider_max_cache_size, 100, R"(The maximum number of S3 credentials providers that can be cached)", 0) \
     DECLARE(UInt64, max_open_files, 0, R"(
     The maximum number of open files.

--- a/tests/config/config.d/allow_impersonate_user.xml
+++ b/tests/config/config.d/allow_impersonate_user.xml
@@ -1,3 +1,0 @@
-<clickhouse>
-    <allow_impersonate_user>1</allow_impersonate_user>
-</clickhouse>

--- a/tests/config/config.d/enable_access_control_improvements.xml
+++ b/tests/config/config.d/enable_access_control_improvements.xml
@@ -6,5 +6,6 @@
         <select_from_information_schema_requires_grant>true</select_from_information_schema_requires_grant>
         <settings_constraints_replace_previous>true</settings_constraints_replace_previous>
         <table_engines_require_grant>true</table_engines_require_grant>
+        <allow_impersonate_user>true</allow_impersonate_user>
     </access_control_improvements>
 </clickhouse>

--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -162,7 +162,6 @@ ln -sf $SRC_PATH/config.d/process_query_plan_packet.xml $DEST_SERVER_PATH/config
 ln -sf $SRC_PATH/config.d/storage_conf_03008.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/memory_access.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/jemalloc_flush_profile.yaml $DEST_SERVER_PATH/config.d/
-ln -sf $SRC_PATH/config.d/allow_impersonate_user.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/wait_remaining_connections.xml $DEST_SERVER_PATH/config.d/
 
 if [ "$FAST_TEST" != "1" ]; then

--- a/tests/integration/helpers/0_common_instance_config.xml
+++ b/tests/integration/helpers/0_common_instance_config.xml
@@ -28,6 +28,7 @@
         <select_from_system_db_requires_grant>true</select_from_system_db_requires_grant>
         <select_from_information_schema_requires_grant>true</select_from_information_schema_requires_grant>
         <settings_constraints_replace_previous>true</settings_constraints_replace_previous>
+        <allow_impersonate_user>true</allow_impersonate_user>
         <role_cache_expiration_time_seconds>2</role_cache_expiration_time_seconds>
     </access_control_improvements>
 

--- a/tests/integration/test_disabled_access_control_improvements/configs/config.d/disable_access_control_improvements.xml
+++ b/tests/integration/test_disabled_access_control_improvements/configs/config.d/disable_access_control_improvements.xml
@@ -4,5 +4,6 @@
         <select_from_system_db_requires_grant>false</select_from_system_db_requires_grant>
         <select_from_information_schema_requires_grant>false</select_from_information_schema_requires_grant>
         <settings_constraints_replace_previous>false</settings_constraints_replace_previous>
+        <allow_impersonate_user>false</allow_impersonate_user>
     </access_control_improvements>
 </clickhouse>

--- a/tests/integration/test_disabled_access_control_improvements/test_impersonate_user.py
+++ b/tests/integration/test_disabled_access_control_improvements/test_impersonate_user.py
@@ -1,12 +1,13 @@
 import pytest
 
-from helpers.cluster import ClickHouseCluster, ClickHouseInstance
+from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
-
 node = cluster.add_instance(
-    "node"
+    "node",
+    main_configs=["configs/config.d/disable_access_control_improvements.xml"],
 )
+
 
 @pytest.fixture(scope="module", autouse=True)
 def started_cluster():
@@ -18,8 +19,7 @@ def started_cluster():
         cluster.shutdown()
 
 
-def test_sql_impersonate():
-
+def test_impersonate_user_disabled():
     node.query(
         "CREATE USER user1 IDENTIFIED WITH plaintext_password BY 'password1';"
         "CREATE USER user2 IDENTIFIED WITH plaintext_password BY 'password2';"

--- a/tests/queries/0_stateless/02888_obsolete_settings.reference
+++ b/tests/queries/0_stateless/02888_obsolete_settings.reference
@@ -1,4 +1,5 @@
 -- Obsolete server settings
+allow_impersonate_user
 storage_metadata_write_full_object_key
 -- Obsolete general settings
 1


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Move config setting `allow_impersonate_user` to the section with other access-control improvements.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.522`
<!-- ch-version-info:end -->