### PR TITLE
Mergeable configuration defined workloads and resources 

### DIFF
--- a/src/Common/Scheduler/Workload/WorkloadEntityConfigStorage.cpp
+++ b/src/Common/Scheduler/Workload/WorkloadEntityConfigStorage.cpp
@@ -17,14 +17,36 @@ void WorkloadEntityConfigStorage::loadEntities(const Poco::Util::AbstractConfigu
 
     std::vector<std::pair<String, ASTPtr>> new_entities;
 
-    // Load entities from the combined resources_and_workloads section
-    String sql = config.getString("resources_and_workloads", "");
-    if (!sql.empty())
+    const String config_prefix = "resources_and_workloads";
+
+    if (config.has(config_prefix))
     {
-        auto parsed_entities = parseEntitiesFromString(sql, log);
-        for (const auto & [entity_name, ast] : parsed_entities)
+        Poco::Util::AbstractConfiguration::Keys keys;
+        config.keys(config_prefix, keys);
+
+        if (!keys.empty())
         {
-            new_entities.emplace_back(entity_name, ast);
+            // iterate over all child elements
+            for (const auto & key : keys)
+            {
+                String sql = config.getString(config_prefix + "." + key, "");
+                if (!sql.empty())
+                {
+                    auto parsed_entities = parseEntitiesFromString(sql, log);
+                    for (const auto & [entity_name, ast] : parsed_entities)
+                        new_entities.emplace_back(entity_name, ast);
+                }
+            }
+        }
+        else
+        {
+            String sql = config.getString(config_prefix, "");
+            if (!sql.empty())
+            {
+                auto parsed_entities = parseEntitiesFromString(sql, log);
+                for (const auto & [entity_name, ast] : parsed_entities)
+                    new_entities.emplace_back(entity_name, ast);
+            }
         }
     }
 
@@ -33,24 +55,15 @@ void WorkloadEntityConfigStorage::loadEntities(const Poco::Util::AbstractConfigu
     LOG_DEBUG(log, "Loaded {} workload entities from configuration", new_entities.size());
 }
 
-WorkloadEntityConfigStorage::OperationResult WorkloadEntityConfigStorage::storeEntityImpl(
-    const ContextPtr &,
-    WorkloadEntityType,
-    const String &,
-    ASTPtr,
-    bool,
-    bool,
-    const Settings &)
+WorkloadEntityConfigStorage::OperationResult
+WorkloadEntityConfigStorage::storeEntityImpl(const ContextPtr &, WorkloadEntityType, const String &, ASTPtr, bool, bool, const Settings &)
 {
     // Config storage is read-only - entities come from config, not SQL. This function should not be called
     return OperationResult::Failed;
 }
 
-WorkloadEntityConfigStorage::OperationResult WorkloadEntityConfigStorage::removeEntityImpl(
-    const ContextPtr &,
-    WorkloadEntityType,
-    const String &,
-    bool)
+WorkloadEntityConfigStorage::OperationResult
+WorkloadEntityConfigStorage::removeEntityImpl(const ContextPtr &, WorkloadEntityType, const String &, bool)
 {
     // Config storage is read-only - entities come from config, not SQL. This function should not be called
     return OperationResult::Failed;

--- a/tests/integration/test_scheduler/test.py
+++ b/tests/integration/test_scheduler/test.py
@@ -89,7 +89,7 @@ def clear_workloads_and_resources(set_default_configs):
     yield
 
 
-def update_workloads_config(*nodes, **settings):
+def update_workloads_config(*nodes, config_file="workloads", **settings):
     xml = ""
     for name in settings:
         value = settings[name]
@@ -106,14 +106,14 @@ def update_workloads_config(*nodes, **settings):
             [
                 "bash",
                 "-c",
-                f"echo '<clickhouse>{xml}</clickhouse>' > /etc/clickhouse-server/config.d/workloads.xml",
+                f"echo '<clickhouse>{xml}</clickhouse>' > /etc/clickhouse-server/config.d/{config_file}.xml",
             ]
         )
         n.query("system reload config")
 
 
-def update_workloads_config_on_cluster(**settings):
-    update_workloads_config(node, node2, **settings)
+def update_workloads_config_on_cluster(config_file="workloads", **settings):
+    update_workloads_config(node, node2, config_file=config_file, **settings)
 
 def check_profile_event_for_query(workload, profile_event, amount=1):
     node.query("system flush logs")
@@ -1221,6 +1221,120 @@ def test_config_based_workloads_and_resources_with_sql_elements():
             "SELECT count() FROM system.workloads"
         )
         == "2\n"
+    )
+
+    # Make sure it's possible to clean the config without "Logical error: 'Removing workload 'all' with children"
+    node.query("DROP WORKLOAD development")
+
+def test_multiple_config_based_workloads_and_resources():
+    # Create a test configuration with resources and workloads with multiple config files
+    # It is important to update config on cluster, because otherwise node2 expectedly crashes with
+    # Logical error: 'Parent node 'all' for creating workload 'development' does not exist in resource 'sql_io_read''.
+    update_workloads_config_on_cluster(config_file="workloads_1", resources_and_workloads=[
+        "<io_read>CREATE RESOURCE config_io_read (READ DISK s3_no_resource);</io_read>",
+        "<io_write>CREATE RESOURCE config_io_write (WRITE DISK s3_no_resource);</io_write>",
+        "<inflight>CREATE WORKLOAD all SETTINGS max_bytes_inflight = 1000000, max_bytes_inflight = 2000000 FOR config_io_write;</inflight>",
+        "<prod>CREATE WORKLOAD production IN all SETTINGS priority = 1, weight = 3;</prod>",
+    ])
+    update_workloads_config_on_cluster(config_file="workloads_2", resources_and_workloads=[
+        "<stage>CREATE WORKLOAD stage IN all SETTINGS priority = 1, weight = 3;</stage>",
+    ])
+
+    # Verify config-based entities are loaded
+    assert (
+        node.query(
+            "SELECT count() FROM system.resources"
+        )
+        == "2\n"
+    )
+
+    assert (
+        node.query(
+            "SELECT count() FROM system.workloads"
+        )
+        == "3\n"
+    )
+
+    # Verify scheduler nodes exist for config entities
+    assert (
+        node.query(
+            "SELECT count() == 2 FROM system.scheduler WHERE resource IN ('config_io_read', 'config_io_write') AND path = '/all'"
+        )
+        == "1\n"
+    )
+
+    # Try to create SQL entities with same names - should fail
+    try:
+        node.query("CREATE RESOURCE config_io_read (READ DISK non_existent_disk)")
+        assert False, "Should not be able to create resource with same name as config entity"
+    except Exception as ex:
+        assert "already exists" in str(ex)
+
+    try:
+        node.query("CREATE WORKLOAD all")
+        assert False, "Should not be able to create workload with same name as config entity"
+    except Exception as ex:
+        assert "already exists" in str(ex)
+
+    # Create SQL entities with different names
+    node.query("CREATE RESOURCE sql_io_read (READ DISK non_existent_disk)")
+    node.query("CREATE WORKLOAD development IN all SETTINGS max_bytes_inflight = 500000 FOR sql_io_read")
+
+    # Verify both config and SQL entities exist
+    assert (
+        node.query(
+            "SELECT count() FROM system.resources WHERE name IN ('config_io_read', 'config_io_write', 'sql_io_read')"
+        )
+        == "3\n"
+    )
+    assert (
+        node.query(
+            "SELECT count() FROM system.workloads WHERE name IN ('all', 'production', 'development', 'stage')"
+        )
+        == "4\n"
+    )
+
+    # Test that config entities cannot be dropped
+    try:
+        node.query("DROP RESOURCE config_io_read")
+        assert False, "Should not be able to drop config-defined resource"
+    except Exception as ex:
+        assert "It is not allowed to remove workload entity 'config_io_read' that is stored in read-only configuration storage" in str(ex)
+
+    try:
+        node.query("DROP WORKLOAD production")
+        assert False, "Should not be able to drop config-defined workload"
+    except Exception as ex:
+        assert "It is not allowed to remove workload entity 'production' that is stored in read-only configuration storage" in str(ex)
+
+    try:
+        node.query("DROP WORKLOAD stage")
+        assert False, "Should not be able to drop config-defined workload"
+    except Exception as ex:
+        assert "It is not allowed to remove workload entity 'stage' that is stored in read-only configuration storage" in str(ex)
+
+    # But SQL entities can be dropped
+    node.query("CREATE OR REPLACE WORKLOAD development IN all SETTINGS max_bytes_inflight = 500000")
+    node.query("DROP RESOURCE sql_io_read")
+
+    # Update config to remove some entities (test with mixed list of <sql> elements)
+    update_workloads_config_on_cluster(resources_and_workloads=[
+        "<sql>CREATE RESOURCE config_io_read (READ DISK s3_no_resource);</sql>",
+        "<sql>CREATE WORKLOAD all SETTINGS max_bytes_inflight = 1000000 FOR config_io_read;</sql>",
+    ])
+
+    # Verify entities are updated
+    assert (
+        node.query(
+            "SELECT count() FROM system.resources"
+        )
+        == "1\n"
+    )
+    assert (
+        node.query(
+            "SELECT count() FROM system.workloads"
+        )
+        == "3\n"
     )
 
     # Make sure it's possible to clean the config without "Logical error: 'Removing workload 'all' with children"

--- a/tests/integration/test_scheduler/test.py
+++ b/tests/integration/test_scheduler/test.py
@@ -92,7 +92,12 @@ def clear_workloads_and_resources(set_default_configs):
 def update_workloads_config(*nodes, **settings):
     xml = ""
     for name in settings:
-        xml += f"<{name}>{settings[name]}</{name}>"
+        value = settings[name]
+        if isinstance(value, list):
+            content = "\n        ".join(value)
+        else:
+            content = value
+        xml += f"<{name}>{content}</{name}>"
     print(xml)
     if nodes == ():
         nodes = (node,)
@@ -1097,6 +1102,112 @@ def test_config_based_workloads_and_resources():
         CREATE WORKLOAD all SETTINGS max_bytes_inflight = 1000000 FOR config_io_read;
     """
     )
+
+    # Verify entities are updated
+    assert (
+        node.query(
+            "SELECT count() FROM system.resources"
+        )
+        == "1\n"
+    )
+    assert (
+        node.query(
+            "SELECT count() FROM system.workloads"
+        )
+        == "2\n"
+    )
+
+    # Make sure it's possible to clean the config without "Logical error: 'Removing workload 'all' with children"
+    node.query("DROP WORKLOAD development")
+
+
+def test_config_based_workloads_and_resources_with_sql_elements():
+    # Create a test configuration with resources and workloads in new configuration style (per-SQL-statement elements - list of statements with unique tags)
+    # It is important to update config on cluster, because otherwise node2 expectedly crashes with
+    # Logical error: 'Parent node 'all' for creating workload 'development' does not exist in resource 'sql_io_read''.
+    update_workloads_config_on_cluster(resources_and_workloads=[
+        "<io_read>CREATE RESOURCE config_io_read (READ DISK s3_no_resource);</io_read>",
+        "<io_write>CREATE RESOURCE config_io_write (WRITE DISK s3_no_resource);</io_write>",
+        "<inflight>CREATE WORKLOAD all SETTINGS max_bytes_inflight = 1000000, max_bytes_inflight = 2000000 FOR config_io_write;</inflight>",
+        "<prod>CREATE WORKLOAD production IN all SETTINGS priority = 1, weight = 3;</prod>",
+    ])
+
+    # Verify config-based entities are loaded
+    assert (
+        node.query(
+            "SELECT count() FROM system.resources"
+        )
+        == "2\n"
+    )
+
+    assert (
+        node.query(
+            "SELECT count() FROM system.workloads"
+        )
+        == "2\n"
+    )
+
+    # Verify scheduler nodes exist for config entities
+    assert (
+        node.query(
+            "SELECT count() == 2 FROM system.scheduler WHERE resource IN ('config_io_read', 'config_io_write') AND path = '/all'"
+        )
+        == "1\n"
+    )
+
+    # Try to create SQL entities with same names - should fail
+    try:
+        node.query("CREATE RESOURCE config_io_read (READ DISK non_existent_disk)")
+        assert False, "Should not be able to create resource with same name as config entity"
+    except Exception as ex:
+        assert "already exists" in str(ex)
+
+    try:
+        node.query("CREATE WORKLOAD all")
+        assert False, "Should not be able to create workload with same name as config entity"
+    except Exception as ex:
+        assert "already exists" in str(ex)
+
+    # Create SQL entities with different names
+    node.query("CREATE RESOURCE sql_io_read (READ DISK non_existent_disk)")
+    node.query("CREATE WORKLOAD development IN all SETTINGS max_bytes_inflight = 500000 FOR sql_io_read")
+
+    # Verify both config and SQL entities exist
+    assert (
+        node.query(
+            "SELECT count() FROM system.resources WHERE name IN ('config_io_read', 'config_io_write', 'sql_io_read')"
+        )
+        == "3\n"
+    )
+    assert (
+        node.query(
+            "SELECT count() FROM system.workloads WHERE name IN ('all', 'production', 'development')"
+        )
+        == "3\n"
+    )
+
+    # Test that config entities cannot be dropped
+    try:
+        node.query("DROP RESOURCE config_io_read")
+        assert False, "Should not be able to drop config-defined resource"
+    except Exception as ex:
+        assert "It is not allowed to remove workload entity 'config_io_read' that is stored in read-only configuration storage" in str(ex)
+
+    try:
+        node.query("DROP WORKLOAD production")
+        assert False, "Should not be able to drop config-defined workload"
+    except Exception as ex:
+        assert "It is not allowed to remove workload entity 'production' that is stored in read-only configuration storage" in str(ex)
+
+    # But SQL entities can be dropped
+    node.query("CREATE OR REPLACE WORKLOAD development IN all SETTINGS max_bytes_inflight = 500000")
+    node.query("DROP RESOURCE sql_io_read")
+
+    # Update config to remove some entities (test with mixed list of <sql> elements)
+    update_workloads_config_on_cluster(resources_and_workloads=[
+        "<sql>CREATE RESOURCE config_io_read (READ DISK s3_no_resource);</sql>",
+        "<sql>CREATE WORKLOAD all SETTINGS max_bytes_inflight = 1000000 FOR config_io_read;</sql>",
+    ])
 
     # Verify entities are updated
     assert (


### PR DESCRIPTION
In the current version of ClickHouse, if multiple `resources_and_workloads` are defined across multiple config files, only the statements in the last parsed config file will be merged into the final pre-processed config file.

This PR allows configurations spanning across multiple configuration files, by allowing XML elements under `resources_and_workloads` tag:

```xml
<!-- some_config.xml -->
<clickhouse>
    <resources_and_workloads>
        <all>CREATE WORKLOAD all;</all>
        <prod>CREATE WORKLOAD prod in all;</prod>
    </resources_and_workloads>
</clickhouse>
```

```xml
<!-- another_config.xml -->
<clickhouse>
    <resources_and_workloads>
        <stage>CREATE WORKLOAD stage;</stage>
    </resources_and_workloads>
</clickhouse>
```

```xml
<!-- result.xml -->
<clickhouse>
    <resources_and_workloads>
        <all>CREATE WORKLOAD all;</all>
        <prod>CREATE WORKLOAD prod in all;</prod>
        <stage>CREATE WORKLOAD stage;</stage>
    </resources_and_workloads>
</clickhouse>
```

For compatibility reason, the old parsing behaviour where SQL is defined right inside the `resources_and_workloads` continues to work.

References:

#79542 
[Pull Request #87430](github.com/ClickHouse/ClickHouse/pull/87430)


### Changelog category (leave one):

- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Configuration-based workloads and resources across multiple configuration files is now possible by putting SQL statements in its own XML element under the `resources_and_workloads` tag.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->