### PR TITLE
Fix null pointer dereference in `DataTypeFunction::updateHashImpl`

### DIFF
--- a/src/DataTypes/DataTypeFunction.cpp
+++ b/src/DataTypes/DataTypeFunction.cpp
@@ -36,10 +36,16 @@ bool DataTypeFunction::equals(const IDataType & rhs) const
 
 void DataTypeFunction::updateHashImpl(SipHash & hash) const
 {
+    /// Argument types and return type can be nullptr when the lambda is not yet resolved.
     hash.update(argument_types.size());
     for (const auto & arg_type : argument_types)
-        arg_type->updateHash(hash);
+    {
+        hash.update(arg_type != nullptr);
+        if (arg_type)
+            arg_type->updateHash(hash);
+    }
 
+    hash.update(return_type != nullptr);
     if (return_type)
         return_type->updateHash(hash);
 }

--- a/tests/queries/0_stateless/03913_data_type_function_null_arg_hash.sql
+++ b/tests/queries/0_stateless/03913_data_type_function_null_arg_hash.sql
@@ -1,0 +1,3 @@
+-- Regression test: DataTypeFunction::updateHashImpl must handle null argument types
+-- https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=b9e68f4b9b0b33c7db43b00afb3eff4ff2050694&name_0=MasterCI&name_1=AST%20fuzzer%20%28amd_ubsan%29
+SELECT arrayFold((acc, x) -> plus(acc, toString(NULL, toLowCardinality(toUInt128(4)), materialize(4), 'aaaa', materialize(4), 4, 4, 1), x), range(number), ((acc, x) -> if(x % 2, arrayPushFront(acc, x), arrayPushBack(acc, x)))) FROM system.numbers LIMIT 0; -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }


### PR DESCRIPTION
`DataTypeFunction` can have null argument types when the lambda is not yet resolved (e.g. created via `DataTypes(lambda_arguments_size, nullptr)` in `resolveFunction`). The `doGetName` method already handled this with a null check, but `updateHashImpl` did not, causing a null pointer dereference found by AST fuzzer with UBSan.

Also hash null/non-null markers to avoid collisions between types with different null patterns.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=b9e68f4b9b0b33c7db43b00afb3eff4ff2050694&name_0=MasterCI&name_1=AST%20fuzzer%20%28amd_ubsan%29

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix null pointer dereference in certain expressions with lambda functions.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.507`
- Backported to: `26.1.5.32`, `25.12.9.36`, `25.8.19.14`
<!-- ch-version-info:end -->