### PR TITLE
Fix invalid assert in SessionLogElement::appendToBlock

### DIFF
--- a/src/Interpreters/SessionLog.cpp
+++ b/src/Interpreters/SessionLog.cpp
@@ -165,8 +165,10 @@ ColumnsDescription SessionLogElement::getColumnsDescription()
 
 void SessionLogElement::appendToBlock(MutableColumns & columns) const
 {
-    assert(type >= SESSION_LOGIN_FAILURE && type <= SESSION_LOGOUT);
-    assert(user_identified_with >= AuthenticationType::NO_PASSWORD && user_identified_with <= AuthenticationType::MAX);
+    chassert(type >= SESSION_LOGIN_FAILURE && type <= SESSION_LOGOUT);
+    chassert(
+        !user_identified_with
+        || (*user_identified_with >= AuthenticationType::NO_PASSWORD && *user_identified_with < AuthenticationType::MAX));
 
     size_t i = 0;
 
@@ -178,7 +180,7 @@ void SessionLogElement::appendToBlock(MutableColumns & columns) const
     columns[i++]->insert(event_time);
     columns[i++]->insert(event_time_microseconds);
 
-    assert((user && user_identified_with) || client_info.interface == ClientInfo::Interface::TCP_INTERSERVER);
+    chassert((user && user_identified_with) || client_info.interface == ClientInfo::Interface::TCP_INTERSERVER);
     columns[i++]->insert(user ? Field(*user) : Field());
     columns[i++]->insert(user_identified_with ? Field(*user_identified_with) : Field());
 


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

The 2 asserts are contradictory:
  1. user_identified_with is declared as std::optional<AuthenticationType>, which can be empty (std::nullopt)
  2. The assertion compared the optional directly with enum values without checking if it contains a value
  3. When user_identified_with is std::nullopt (which is valid for TCP_INTERSERVER connections), the comparison fails, triggering the assertion

Closes https://github.com/ClickHouse/ClickHouse/issues/96472

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.505`
<!-- ch-version-info:end -->