### PR TITLE
Add hourly workflow to retry PR CI runs failed due to infrastructure errors

### DIFF
--- a/.github/workflows/retry_infra_failures.yml
+++ b/.github/workflows/retry_infra_failures.yml
@@ -1,0 +1,84 @@
+name: Retry Infrastructure Failures
+
+on:
+  schedule:
+    - cron: '43 * * * *'
+  workflow_dispatch:
+
+permissions:
+  actions: write
+
+jobs:
+  retry-failed:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Retry PR runs failed due to infrastructure errors
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          MAX_RERUNS=10
+          rerun_count=0
+          cutoff=$(date -u -d '6 hours ago' +%Y-%m-%dT%H:%M:%SZ)
+
+          echo "Looking for failed PR workflow runs since $cutoff..."
+          echo ""
+
+          # Get recent failed runs for the PR workflow that have not been retried yet
+          run_ids=$(gh run list \
+            --repo "$GH_REPO" \
+            --workflow pull_request.yml \
+            --status failure \
+            --limit 50 \
+            --json databaseId,attempt,createdAt \
+            --jq ".[] | select(.attempt == 1 and .createdAt >= \"$cutoff\") | .databaseId")
+
+          if [ -z "$run_ids" ]; then
+            echo "No recent failed runs found."
+            exit 0
+          fi
+
+          for run_id in $run_ids; do
+            if [ "$rerun_count" -ge "$MAX_RERUNS" ]; then
+              echo "Reached maximum of $MAX_RERUNS reruns, stopping."
+              break
+            fi
+
+            echo "Checking run $run_id..."
+
+            # A run is an infrastructure failure if every failed job never reached
+            # its main "Run" step (the step was skipped or absent), meaning the
+            # failure happened during setup (checkout, environment preparation, etc.)
+            is_infra=$(gh api "repos/$GH_REPO/actions/runs/$run_id/jobs?per_page=100" \
+              --jq '
+                [.jobs[] | select(.conclusion == "failure")] as $failed |
+                if ($failed | length) == 0 then
+                  false
+                else
+                  [$failed[] |
+                    [.steps[] | select(.name == "Run")] |
+                    if length == 0 then true
+                    else .[0].conclusion == "skipped"
+                    end
+                  ] | all
+                end
+              ')
+
+            if [ "$is_infra" = "true" ]; then
+              echo "  Infrastructure failure detected, rerunning..."
+              if gh run rerun "$run_id" --repo "$GH_REPO"; then
+                echo "  Triggered rerun for run $run_id"
+                rerun_count=$((rerun_count + 1))
+              else
+                echo "  Failed to trigger rerun for run $run_id (may already be rerunning)"
+              fi
+            else
+              echo "  Not an infrastructure failure, skipping."
+            fi
+
+            echo ""
+          done
+
+          echo "Done. Triggered $rerun_count rerun(s)."


### PR DESCRIPTION
Example: https://github.com/ClickHouse/ClickHouse/actions/runs/21833467989/job/62997868324?pr=96457

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

Often GitHub is down, either intermittently or for longer periods. But restarting checks manually is too cumbersome. Let's do it automatically.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.493`
<!-- ch-version-info:end -->