### PR TITLE
Fix crash order by in iceberg

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
@@ -17,6 +17,7 @@
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTLiteral.h>
+#include <Parsers/ASTOrderByElement.h>
 #include <Storages/ColumnsDescription.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/IcebergTableStateSnapshot.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.h>
@@ -696,9 +697,6 @@ std::pair<Poco::JSON::Object::Ptr, Int32> getPartitionSpec(
 
 std::pair<String, String> parseTransformAndColumn(ASTPtr object, size_t i)
 {
-    if (auto * identifier = object->as<ASTIdentifier>(); identifier)
-        return {"identity", identifier->name()};
-
     static const std::unordered_map<String, String> clickhouse_name_to_iceberg = {
         {"identity", "identity"},
         {"icebergBucket", "bucket"},
@@ -709,48 +707,127 @@ std::pair<String, String> parseTransformAndColumn(ASTPtr object, size_t i)
         {"toRelativeHourNum", "hour"}
     };
 
-    auto parse_function = [] (ASTPtr func_object) -> std::pair<String, String> {
-        auto * func = func_object->as<ASTFunction>();
-        String clickhouse_name = func->name;
-        auto args = func->children[0]->children;
+    if (!object)
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Invalid iceberg sort order expression");
+
+    auto parse_function = [] (const ASTPtr & func_object) -> std::pair<String, String>
+    {
+        const auto * func = func_object ? func_object->as<ASTFunction>() : nullptr;
+        if (!func)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Invalid iceberg sort order expression, expected a function");
+
+        const String & clickhouse_name = func->name;
+        const auto it = clickhouse_name_to_iceberg.find(clickhouse_name);
+        if (it == clickhouse_name_to_iceberg.end())
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unsupported function {} for iceberg", clickhouse_name);
+
+        const auto * args_list = func->arguments ? func->arguments->as<ASTExpressionList>() : nullptr;
+        if (!args_list)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Invalid iceberg sort order function {}: arguments are missing", clickhouse_name);
+        const auto & args = args_list->children;
+
         std::optional<size_t> arg;
         String column_name;
-        if (args.size() == 2)
+
+        if (args.size() == 1)
         {
-            arg = args[0]->as<ASTLiteral>()->value.safeGet<UInt64>();
-            column_name = args[1]->as<ASTIdentifier>()->name();
+            const auto * identifier = args[0] ? args[0]->as<ASTIdentifier>() : nullptr;
+            if (!identifier)
+                throw Exception(
+                    ErrorCodes::BAD_ARGUMENTS,
+                    "Invalid iceberg sort order function {}: expected a column identifier as an argument",
+                    clickhouse_name);
+            column_name = identifier->name();
+        }
+        else if (args.size() == 2)
+        {
+            const auto * literal = args[0] ? args[0]->as<ASTLiteral>() : nullptr;
+            const auto * identifier = args[1] ? args[1]->as<ASTIdentifier>() : nullptr;
+            if (!literal || !identifier)
+                throw Exception(
+                    ErrorCodes::BAD_ARGUMENTS,
+                    "Invalid iceberg sort order function {}: expected (integer_literal, column_identifier)",
+                    clickhouse_name);
+
+            UInt64 u_param = 0;
+            Int64 i_param = 0;
+            if (literal->value.tryGet(u_param))
+                arg = static_cast<size_t>(u_param);
+            else if (literal->value.tryGet(i_param) && i_param >= 0)
+                arg = static_cast<size_t>(i_param);
+            else
+                throw Exception(
+                    ErrorCodes::BAD_ARGUMENTS,
+                    "Invalid iceberg sort order function {}: expected a non-negative integer literal as first argument",
+                    clickhouse_name);
+
+            column_name = identifier->name();
         }
         else
-            column_name = args[0]->as<ASTIdentifier>()->name();
+        {
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "Invalid iceberg sort order function {}: expected 1 or 2 arguments",
+                clickhouse_name);
+        }
 
-        if (!clickhouse_name_to_iceberg.contains(clickhouse_name))
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unsupported function {} for iceberg", clickhouse_name);
-        const auto & transform_base = clickhouse_name_to_iceberg.at(clickhouse_name);
-
-        String transform = transform_base;
+        String transform = it->second;
         if (arg.has_value())
             transform += "[" + std::to_string(arg.value()) + "]";
 
         return {transform, column_name};
     };
 
-    if (auto * func = object->as<ASTFunction>(); func->name != "tuple")
+    auto unwrap_order_by_element = [] (ASTPtr ast) -> ASTPtr
     {
-        return parse_function(object);
+        if (!ast)
+            return ast;
+        if (const auto * elem = ast->as<ASTStorageOrderByElement>())
+        {
+            if (elem->children.empty() || !elem->children.front())
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Invalid iceberg sort order expression");
+            return elem->children.front();
+        }
+        return ast;
+    };
+
+    if (const auto * identifier = object->as<ASTIdentifier>())
+    {
+        if (i != 0)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Invalid iceberg sort order: position {} is out of range", i + 1);
+        return {"identity", identifier->name()};
     }
 
-    chassert(!object->children.empty());
-    chassert(object->children[0]->as<ASTExpressionList>());
-    auto function_desc = object->children[0]->children[i];
-    if (auto * identifier = function_desc->as<ASTIdentifier>(); identifier)
+    ASTPtr element = object;
+    if (const auto * func = object->as<ASTFunction>(); func && func->name == "tuple")
+    {
+        const auto * args_list = func->arguments ? func->arguments->as<ASTExpressionList>() : nullptr;
+        if (!args_list)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Invalid iceberg sort order tuple expression");
+        if (i >= args_list->children.size())
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Invalid iceberg sort order: position {} is out of range", i + 1);
+        element = args_list->children[i];
+    }
+    else if (i != 0)
+    {
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Invalid iceberg sort order: position {} is out of range", i + 1);
+    }
+
+    element = unwrap_order_by_element(element);
+
+    if (!element)
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Invalid iceberg sort order expression");
+
+    if (const auto * identifier = element->as<ASTIdentifier>())
         return {"identity", identifier->name()};
 
-    chassert(!function_desc->children.empty());
-    function_desc = function_desc->children[0];
-    if (auto * identifier = function_desc->as<ASTIdentifier>(); identifier)
-        return {"identity", identifier->name()};
+    if (const auto * func = element->as<ASTFunction>(); func && func->name != "tuple")
+        return parse_function(element);
 
-    return parse_function(function_desc);
+    throw Exception(
+        ErrorCodes::BAD_ARGUMENTS,
+        "Invalid iceberg sort order expression '{}', expected a column identifier or a supported function",
+        element->getColumnName());
 }
 
 std::pair<Poco::JSON::Object::Ptr, String> createEmptyMetadataFile(

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
@@ -784,7 +784,7 @@ static ASTPtr unwrapOrderByElement(ASTPtr ast)
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Invalid iceberg sort order expression");
     if (const auto * elem = ast->as<ASTStorageOrderByElement>())
     {
-        if (elem->children.empty() || !elem->children.front())
+        if (elem->children.size() != 1 || !elem->children.front())
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Invalid iceberg sort order expression");
         return elem->children.front();
     }

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
@@ -838,7 +838,7 @@ static std::vector<std::pair<String, String>> parseTransformAndColumnPairs(ASTPt
         const auto * args_list = func->arguments ? func->arguments->as<ASTExpressionList>() : nullptr;
         if (!args_list)
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Invalid iceberg sort order tuple expression");
-        
+
         result.reserve(args_list->children.size());
         for (const auto & child : args_list->children)
         {

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
@@ -796,8 +796,8 @@ static ASTPtr unwrapOrderByElement(ASTPtr ast)
 /// "x" -> {"identity", "x"}
 /// "identity(x)" -> {"identity", "x"}
 /// "bucket(16, x)" -> {"bucket[16]", "x"}
-static std::pair<String, String> parseTransformAndColumnElement(ASTPtr element) {
-
+static std::pair<String, String> parseTransformAndColumnElement(ASTPtr element)
+{
     element = unwrapOrderByElement(element);
 
     if (const auto * identifier = element->as<ASTIdentifier>())

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.h
@@ -99,11 +99,6 @@ std::pair<Poco::JSON::Object::Ptr, Int32> parseTableSchemaV1Method(const Poco::J
 std::pair<Poco::JSON::Object::Ptr, Int32> parseTableSchemaV2Method(const Poco::JSON::Object::Ptr & metadata_object);
 std::string normalizeUuid(const std::string & uuid);
 
-/// Parse transform and argument from input parameter
-/// "x" -> {"identity", "x"}
-/// "identity(x)" -> {"identity", "x"}
-/// "bucket(16, x)" -> {"bucket[16]", "x"}
-std::pair<String, String> parseTransformAndColumn(ASTPtr object, size_t i);
 DataTypePtr getFunctionResultType(const String & iceberg_transform_name, DataTypePtr source_type);
 
 KeyDescription getSortingKeyDescriptionFromMetadata(

--- a/tests/integration/test_storage_iceberg_with_spark/test_writes_create_table.py
+++ b/tests/integration/test_storage_iceberg_with_spark/test_writes_create_table.py
@@ -157,7 +157,6 @@ def test_writes_create_table_bug_tuple(started_cluster_iceberg_with_spark, forma
         ("(c0 Int)", "icebergBucket(c0, 1)"),
         ("(c0 Int)", "icebergBucket(-1, c0)"),
         ("(c0 Int)", "icebergTruncate(1.5, c0)"),
-        ("(c0 Int)", "tuple()"),
     ]
 )
 def test_order_by_bad_arguments(

--- a/tests/integration/test_storage_iceberg_with_spark/test_writes_create_table.py
+++ b/tests/integration/test_storage_iceberg_with_spark/test_writes_create_table.py
@@ -3,7 +3,8 @@ import pytest
 from helpers.iceberg_utils import (
     create_iceberg_table,
     get_uuid_str,
-    default_download_directory
+    default_download_directory,
+    get_creation_expression
 )
 
 
@@ -150,28 +151,102 @@ def test_writes_create_table_bug_tuple(started_cluster_iceberg_with_spark, forma
         ("(c0 Int)", "(now())"),
         ("(c0 Int)", "identity(1)"),
         ("(c0 Int)", "identity(1+1)"),
-        ("(c0 Int)", "identity()"),
-        ("(c0 Int, c1 Int)", "identity(c0, c1, c0)"),
         ("(c0 Int, c1 Int)", "icebergBucket(c0, c1)"),
         ("(c0 Int, c1 Int)", "icebergBucket(1, 2)"),
         ("(c0 Int)", "icebergBucket(c0, 1)"),
         ("(c0 Int)", "icebergBucket(-1, c0)"),
-        ("(c0 Int)", "icebergTruncate(1.5, c0)"),
     ]
 )
-def test_order_by_bad_arguments(
+def test_order_by_bad_arguments_ast_parsing(
     started_cluster_iceberg_with_spark, format_version, storage_type, schema, order_by
 ):
     instance = started_cluster_iceberg_with_spark.instances["node1"]
-    table_name = "test_order_by_bad_" + storage_type + "_" + get_uuid_str()
+    table_name = "test_order_by_bad_ast_" + storage_type + "_" + get_uuid_str()
 
-    with pytest.raises(Exception):
-        create_iceberg_table(
-            storage_type,
-            instance,
-            table_name,
-            started_cluster_iceberg_with_spark,
-            schema,
-            format_version=format_version,
-            order_by=order_by,
-        )
+    query = get_creation_expression(
+        storage_type,
+        table_name,
+        started_cluster_iceberg_with_spark,
+        schema,
+        format_version=format_version,
+        order_by=order_by,
+    )
+    
+    error = instance.query_and_get_error(query)
+    assert (
+        "Code: 36" in error or "BAD_ARGUMENTS" in error
+    ), f"Expected BAD_ARGUMENTS error (Code: 36), got: {error}"
+    assert (
+        "Invalid iceberg sort order" in error 
+        or "Unsupported function" in error 
+        or "expected a column identifier" in error.lower()
+        or "expected (integer_literal, column_identifier)" in error.lower()
+        or "expected 1 or 2 arguments" in error.lower()
+        or "expected a non-negative integer literal" in error.lower()
+        or "arguments are missing" in error.lower()
+    ), f"Expected error message about invalid sort order, got: {error}"
+
+
+@pytest.mark.parametrize("format_version", [2])
+@pytest.mark.parametrize("storage_type", ["s3"])
+@pytest.mark.parametrize(
+    "schema,order_by",
+    [
+        ("(c0 Int)", "identity()"),
+        ("(c0 Int, c1 Int)", "identity(c0, c1, c0)"),
+    ]
+)
+def test_order_by_bad_arguments_wrong_count(
+    started_cluster_iceberg_with_spark, format_version, storage_type, schema, order_by
+):
+    instance = started_cluster_iceberg_with_spark.instances["node1"]
+    table_name = "test_order_by_bad_count_" + storage_type + "_" + get_uuid_str()
+
+    query = get_creation_expression(
+        storage_type,
+        table_name,
+        started_cluster_iceberg_with_spark,
+        schema,
+        format_version=format_version,
+        order_by=order_by,
+    )
+    
+    error = instance.query_and_get_error(query)
+    assert (
+        "Code: 42" in error or "NUMBER_OF_ARGUMENTS_DOESNT_MATCH" in error
+    ), f"Expected NUMBER_OF_ARGUMENTS_DOESNT_MATCH error (Code: 42), got: {error}"
+    assert (
+        "doesn't match" in error.lower()
+    ), f"Expected error message about argument count mismatch, got: {error}"
+
+
+@pytest.mark.parametrize("format_version", [2])
+@pytest.mark.parametrize("storage_type", ["s3"])
+@pytest.mark.parametrize(
+    "schema,order_by",
+    [
+        ("(c0 Int)", "icebergTruncate(1.5, c0)"),
+    ]
+)
+def test_order_by_bad_arguments_wrong_type(
+    started_cluster_iceberg_with_spark, format_version, storage_type, schema, order_by
+):
+    instance = started_cluster_iceberg_with_spark.instances["node1"]
+    table_name = "test_order_by_bad_type_" + storage_type + "_" + get_uuid_str()
+
+    query = get_creation_expression(
+        storage_type,
+        table_name,
+        started_cluster_iceberg_with_spark,
+        schema,
+        format_version=format_version,
+        order_by=order_by,
+    )
+    
+    error = instance.query_and_get_error(query)
+    assert (
+        "Code: 43" in error or "ILLEGAL_TYPE_OF_ARGUMENT" in error
+    ), f"Expected ILLEGAL_TYPE_OF_ARGUMENT error (Code: 43), got: {error}"
+    assert (
+        "should be" in error.lower()
+    ), f"Expected error message about invalid argument type, got: {error}"


### PR DESCRIPTION
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix crash order by in iceberg. Continue https://github.com/ClickHouse/ClickHouse/pull/93296. Closes https://github.com/ClickHouse/ClickHouse/issues/93280

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.632`
- Backported to: `26.1.3.35`, `25.12.7.2`
<!-- ch-version-info:end -->