### PR TITLE
Fix `test_git_import` timeout by adding per-attempt clone timeout and early return

### DIFF
--- a/tests/integration/test_git_import/test.py
+++ b/tests/integration/test_git_import/test.py
@@ -21,15 +21,14 @@ def start_cluster():
 
 
 def clone_git_repository(repo, dir, commit=None):
-    command = (
-        f"rm -rf {dir} && mkdir {dir} && cd {dir} && git clone --quiet {repo} {dir}"
-    )
+    command = f"rm -rf {dir} && mkdir {dir} && cd {dir} && GIT_TERMINAL_PROMPT=0 timeout 60 git clone --quiet {repo} {dir}"
     if commit:
         command += f" && git checkout --quiet {commit}"
     num_attempts = 10
     for attempt_no in range(1, num_attempts + 1):
         try:
             node.exec_in_container(["bash", "-c", command])
+            return
         except Exception as err:
             try_again = attempt_no < num_attempts
             what_next = "will try again" if try_again else "will stop"


### PR DESCRIPTION
The test was timing out (>900s) because `git clone` could hang indefinitely after a transient GitHub error (502). Two bugs fixed:

- Added `return` after successful clone: the retry loop had no early exit, causing redundant clones on every iteration even after success.
- Added `timeout 60` to the `git clone` command so a hung clone fails fast and the retry logic can re-attempt instead of blocking the full test.
- Added `GIT_TERMINAL_PROMPT=0` to prevent git from waiting for interactive input in CI.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=1b84634db8c299eb02c7f6e5c1e426c5225e750e&name_0=MasterCI&name_1=Integration%20tests%20%28amd_asan%2C%20db%20disk%2C%20old%20analyzer%2C%205%2F6%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

This was a GitHub downtime, but nevertheless, the test will be more robust.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.506`
<!-- ch-version-info:end -->