### PR TITLE
Fix race between temporary part cleanup and `ReplicatedMergeTreeCleanupThread`

### DIFF
--- a/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
+++ b/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
@@ -746,7 +746,7 @@ void DataPartStorageOnDiskBase::remove(
 
         if (!disk->existsDirectory(from))
         {
-            LOG_ERROR(log, "Directory {} (part to remove) doesn't exist or one of nested files has gone. Most likely this is due to manual removing. This should be discouraged. Ignoring.", fullPath(disk, from));
+            LOG_WARNING(log, "Directory {} (part to remove) doesn't exist or one of nested files has gone. Most likely this is due to manual removing. This should be discouraged. Ignoring.", fullPath(disk, from));
             /// We will never touch this part again, so unlocking it from zero-copy
             if (!can_remove_description)
                 can_remove_description.emplace(can_remove_callback());
@@ -769,7 +769,7 @@ void DataPartStorageOnDiskBase::remove(
         {
             if (e.code() == ErrorCodes::FILE_DOESNT_EXIST)
             {
-                LOG_ERROR(log, "Directory {} (part to remove) doesn't exist or one of nested files has gone. Most likely this is due to manual removing. This should be discouraged. Ignoring.", fullPath(disk, from));
+                LOG_WARNING(log, "Directory {} (part to remove) doesn't exist or one of nested files has gone. Most likely this is due to manual removing. This should be discouraged. Ignoring.", fullPath(disk, from));
                 return;
             }
             throw;
@@ -778,7 +778,7 @@ void DataPartStorageOnDiskBase::remove(
         {
             if (e.code() == std::errc::no_such_file_or_directory)
             {
-                LOG_ERROR(log, "Directory {} (part to remove) doesn't exist or one of nested files has gone. "
+                LOG_WARNING(log, "Directory {} (part to remove) doesn't exist or one of nested files has gone. "
                           "Most likely this is due to manual removing. This should be discouraged. Ignoring.", fullPath(disk, from));
                 return;
             }


### PR DESCRIPTION
The race condition manifests as a spurious `LOG_ERROR` "Directory ... (part to remove) doesn't exist" during concurrent INSERT + ALTER operations on replicated tables, causing test `00446_clear_column_in_partition_concurrent_zookeeper` to fail in TSan + S3 CI runs.

Root cause: member destruction order in `MergeTreeTemporaryPart`.

When a deduplicated INSERT finishes, `delayed_parts.clear()` destroys `MergeTreeTemporaryPart`. C++ destroys members in reverse declaration order. Previously, `temporary_directory_lock` (a `scope_guard` that unregisters the directory from `temporary_parts`) was declared after `part`, so it was destroyed first:

1. Thread A (INSERT, query `95372240`): creates `tmp_insert_20000201_20000201_16_16_0`, discovers the block is a duplicate, begins destroying `MergeTreeTemporaryPart`.
2. Thread A: `temporary_directory_lock` destroyed first — unregisters the directory name from `temporary_parts`.
3. Thread B (`ReplicatedMergeTreeCleanupThread`, `BgSchPool`): iterates temporary directories, calls `temporary_parts.contains()` — returns false (just unregistered!), proceeds to remove the directory from disk.
4. Thread A: `part` destroyed — `~MergeTreeDataPartWide` calls `removeIfNeeded`, which calls `DataPartStorageOnDiskBase::remove` — directory is already gone, logs ERROR.

Fix: move `temporary_directory_lock` before `part` in the struct declaration, so `part` is destroyed first (removing the directory while the lock is still held), and only then the lock is released.

Also downgrade the "Directory ... (part to remove) doesn't exist" messages from `LOG_ERROR` to `LOG_WARNING`, since the condition is handled gracefully (the code explicitly says "Ignoring") and may occur in benign scenarios.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=0eb81bc361b325b1b5e4766e5b48cd938e6a3cf8&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_tsan%2C%20s3%20storage%2C%20parallel%2C%201%2F2%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.508`
<!-- ch-version-info:end -->