### PR TITLE
Pin third-party Docker images to specific versions

### DIFF
--- a/ci/jobs/scripts/check_style/various_checks.sh
+++ b/ci/jobs/scripts/check_style/various_checks.sh
@@ -83,6 +83,11 @@ done
 # See https://stackoverflow.com/questions/53918088/import-file-mismatch-in-pytest
 for i in "${ROOT_PATH}"/tests/integration/test_*; do FILE="${i}/__init__.py"; [ ! -f "${FILE}" ] && echo "${FILE} should exist for every integration test"; done
 
+# Docker compose files in integration tests should not use :latest for third-party images,
+# because it leads to non-reproducible builds and unexpected breakage when upstream images change.
+# ClickHouse-owned images with ${VAR:-latest} pattern are excluded since the variable is set in CI.
+find "${ROOT_PATH}/tests/integration/compose" -name '*.yml' -print0 | xargs -0 grep -P 'image:\s*\S+:latest\s*$' | grep -v '\${\|clickhouse/' && echo "Docker compose files should use pinned versions instead of :latest for third-party images"
+
 # Check for executable bit on non-executable files
 git ls-files -s $ROOT_PATH/{src,base,programs,utils,tests,docs,cmake} | \
     awk '$1 != "120000" && $1 != "100644" { print $4 }' | grep -E '\.(cpp|h|sql|j2|xml|reference|txt|md)$' && echo "These files should not be executable."

--- a/tests/integration/compose/docker_compose_iceberg_nessie_catalog.yml
+++ b/tests/integration/compose/docker_compose_iceberg_nessie_catalog.yml
@@ -1,6 +1,6 @@
 services:
   nessie:
-    image: ghcr.io/projectnessie/nessie:latest
+    image: ghcr.io/projectnessie/nessie:0.107.2
     depends_on:
       minio:
         condition: service_started

--- a/tests/integration/compose/docker_compose_letsencrypt_pebble.yml
+++ b/tests/integration/compose/docker_compose_letsencrypt_pebble.yml
@@ -1,6 +1,6 @@
 services:
   pebble:
-    image: ghcr.io/letsencrypt/pebble:v2.9.0
+    image: ghcr.io/letsencrypt/pebble:2.9.0
     command: -config test/config/pebble-config.json -strict -dnsserver 10.5.11.3:8053
     environment:
       - PEBBLE_WFE_NONCEREJECT=0
@@ -13,7 +13,7 @@ services:
         ipv4_address: 10.5.11.2
     cpus: 3
   challtestsrv:
-    image: ghcr.io/letsencrypt/pebble-challtestsrv:v2.9.0
+    image: ghcr.io/letsencrypt/pebble-challtestsrv:2.9.0
     command: -defaultIPv6 "" -defaultIPv4 10.5.11.3
     ports:
       - ${LE_PEBBLE_CHALSRV_EXTERNAL_API_PORT:-8055}:${LE_PEBBLE_CHALSRV_INTERNAL_API_PORT:-8055}

--- a/tests/integration/compose/docker_compose_letsencrypt_pebble.yml
+++ b/tests/integration/compose/docker_compose_letsencrypt_pebble.yml
@@ -1,6 +1,6 @@
 services:
   pebble:
-    image: ghcr.io/letsencrypt/pebble:latest
+    image: ghcr.io/letsencrypt/pebble:v2.9.0
     command: -config test/config/pebble-config.json -strict -dnsserver 10.5.11.3:8053
     environment:
       - PEBBLE_WFE_NONCEREJECT=0
@@ -13,7 +13,7 @@ services:
         ipv4_address: 10.5.11.2
     cpus: 3
   challtestsrv:
-    image: ghcr.io/letsencrypt/pebble-challtestsrv:latest
+    image: ghcr.io/letsencrypt/pebble-challtestsrv:v2.9.0
     command: -defaultIPv6 "" -defaultIPv4 10.5.11.3
     ports:
       - ${LE_PEBBLE_CHALSRV_EXTERNAL_API_PORT:-8055}:${LE_PEBBLE_CHALSRV_INTERNAL_API_PORT:-8055}

--- a/tests/integration/compose/docker_compose_postgres.yml
+++ b/tests/integration/compose/docker_compose_postgres.yml
@@ -27,7 +27,7 @@ services:
             - "autoheal=true"
         cpus: 3
     autoheal:
-      image: willfarrell/autoheal:latest
+      image: willfarrell/autoheal:1.2.0
       stop_grace_period: 5s
       tty: true
       restart: always


### PR DESCRIPTION
I'm in shock that it was not done before. Using non-pinned versions is a crime.
See https://github.com/ClickHouse/ClickHouse/issues/51682#issuecomment-1619219699


### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Pin third-party Docker images to specific versions.

## Summary
- Pin all third-party Docker images in integration test compose files to specific versions instead of `:latest`, preventing non-reproducible builds and unexpected breakage from upstream image updates
- Add a style check in `various_checks.sh` to prevent future introduction of `:latest` tags
- ClickHouse-owned images with `${VAR:-latest}` pattern are excluded from the check since the variable is set by CI

### Images pinned:
| Image | Version |
|-------|---------|
| `ghcr.io/projectnessie/nessie` | `0.107.2` |
| `ghcr.io/letsencrypt/pebble` | `v2.9.0` |
| `ghcr.io/letsencrypt/pebble-challtestsrv` | `v2.9.0` |
| `willfarrell/autoheal` | `1.2.0` |

Note: `coredns/coredns` was already pinned to `1.9.3` with a comment "`:latest` broke this test".

## Test plan
- [ ] Style check passes (no `:latest` in compose files)
- [ ] Integration tests using affected images still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.504`
- Backported to: `26.1.3.34`, `25.12.6.25`, `25.11.9.32`
<!-- ch-version-info:end -->