### PR TITLE
Extend cast_keep_nullable to work with Dynamic/JSON types

### DIFF
--- a/src/Functions/CastOverloadResolver.cpp
+++ b/src/Functions/CastOverloadResolver.cpp
@@ -137,7 +137,7 @@ protected:
             return type;
 
         if (keep_nullable
-            && (arguments.front().type->isNullable() || arguments.front().type->isLowCardinalityNullable())
+            && (arguments.front().type->isNullable() || arguments.front().type->isLowCardinalityNullable() || isDynamic(*arguments.front().type))
             && type->canBeInsideNullable())
             return makeNullable(type);
 

--- a/src/Functions/FunctionsConversion.cpp
+++ b/src/Functions/FunctionsConversion.cpp
@@ -58,7 +58,8 @@ ColumnPtr ConvertImplFromDynamicToColumn::execute(
     const ColumnsWithTypeAndName & arguments,
     const DataTypePtr & result_type,
     size_t input_rows_count,
-    const std::function<ColumnPtr(ColumnsWithTypeAndName &, const DataTypePtr)> & nested_convert)
+    const std::function<ColumnPtr(ColumnsWithTypeAndName &, const DataTypePtr)> & nested_convert,
+    bool throw_on_null)
 {
     /// When casting Dynamic to regular column we should cast all variants from current Dynamic column
     /// and construct the result based on discriminators.
@@ -156,6 +157,9 @@ ColumnPtr ConvertImplFromDynamicToColumn::execute(
         auto global_discr = variant_column.globalDiscriminatorByLocal(local_discriminators[i]);
         if (global_discr == ColumnVariant::NULL_DISCRIMINATOR)
         {
+            if (throw_on_null)
+                throw Exception(ErrorCodes::CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN,
+                    "Cannot convert NULL value to non-Nullable type");
             res->insertDefault();
         }
         else if (global_discr == shared_variant_discr)
@@ -1468,10 +1472,13 @@ FunctionCast::WrapperType FunctionCast::createDynamicToColumnWrapper(const DataT
         return wrapper(args, result_type, nullptr, args[0].column->size());
     };
 
-    return [nested_convert]
+    bool keep_nullable = settings.cast_keep_nullable;
+    return [nested_convert, keep_nullable]
            (ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, const ColumnNullable *, size_t input_rows_count) -> ColumnPtr
     {
-        return ConvertImplFromDynamicToColumn::execute(arguments, result_type, input_rows_count, nested_convert);
+        return ConvertImplFromDynamicToColumn::execute(
+            arguments, result_type, input_rows_count, nested_convert,
+            keep_nullable && !result_type->isNullable() && !result_type->isLowCardinalityNullable() && !result_type->canBeInsideNullable());
     };
 }
 

--- a/src/Functions/FunctionsConversion.h
+++ b/src/Functions/FunctionsConversion.h
@@ -84,6 +84,7 @@ namespace DB
 namespace Setting
 {
     extern const SettingsBool cast_ipv4_ipv6_default_on_conversion_error;
+    extern const SettingsBool cast_keep_nullable;
     extern const SettingsBool cast_string_to_dynamic_use_inference;
     extern const SettingsBool cast_string_to_variant_use_inference;
     extern const SettingsDateTimeOverflowBehavior date_time_overflow_behavior;
@@ -130,6 +131,7 @@ struct FunctionConvertSettings
     const bool input_format_ipv6_default_on_conversion_error;
     const bool check_conversion_from_numbers_to_enum;
     const bool date_time_64_output_format_cut_trailing_zeros_align_to_groups_of_thousands;
+    const bool cast_keep_nullable;
     const FormatSettings::DateTimeInputFormat cast_string_to_date_time_mode;
     const FormatSettings format_settings;
 
@@ -145,6 +147,7 @@ struct FunctionConvertSettings
         , input_format_ipv6_default_on_conversion_error(context && context->getSettingsRef()[Setting::input_format_ipv6_default_on_conversion_error])
         , check_conversion_from_numbers_to_enum(context && context->getSettingsRef()[Setting::check_conversion_from_numbers_to_enum])
         , date_time_64_output_format_cut_trailing_zeros_align_to_groups_of_thousands(context && context->getSettingsRef()[Setting::date_time_64_output_format_cut_trailing_zeros_align_to_groups_of_thousands])
+        , cast_keep_nullable(context && context->getSettingsRef()[Setting::cast_keep_nullable])
         , cast_string_to_date_time_mode(context ? context->getSettingsRef()[Setting::cast_string_to_date_time_mode] : FormatSettings::DateTimeInputFormat::Basic)
         , format_settings(context ? getFormatSettings(context) : FormatSettings{})
     {
@@ -2785,7 +2788,8 @@ struct ConvertImplFromDynamicToColumn
         const ColumnsWithTypeAndName & arguments,
         const DataTypePtr & result_type,
         size_t input_rows_count,
-        const std::function<ColumnPtr(ColumnsWithTypeAndName &, const DataTypePtr)> & nested_convert);
+        const std::function<ColumnPtr(ColumnsWithTypeAndName &, const DataTypePtr)> & nested_convert,
+        bool throw_on_null = false);
 };
 
 /// Declared early because used below.
@@ -3193,7 +3197,9 @@ private:
                 return executeInternal(args, to_type, args[0].column->size(), /*to_nullable=*/ false);
             };
 
-            return ConvertImplFromDynamicToColumn::execute(arguments, result_type, input_rows_count, nested_convert);
+            return ConvertImplFromDynamicToColumn::execute(
+                arguments, result_type, input_rows_count, nested_convert,
+                settings.cast_keep_nullable && !result_type->isNullable() && !result_type->isLowCardinalityNullable() && !result_type->canBeInsideNullable());
         }
 
         auto call = [&](const auto & types, BehaviourOnErrorFromString from_string_tag) -> bool

--- a/tests/queries/0_stateless/04035_cast_keep_nullable_dynamic.reference
+++ b/tests/queries/0_stateless/04035_cast_keep_nullable_dynamic.reference
@@ -1,0 +1,5 @@
+\N	Nullable(Int32)
+\N	Nullable(String)
+[1,2,3]
+[]
+0

--- a/tests/queries/0_stateless/04035_cast_keep_nullable_dynamic.sql
+++ b/tests/queries/0_stateless/04035_cast_keep_nullable_dynamic.sql
@@ -1,0 +1,24 @@
+-- Tags: no-fasttest, no-random-settings
+-- Tests for cast_keep_nullable with Dynamic/JSON types
+SET enable_analyzer = 1;
+SET cast_keep_nullable = 1;
+
+-- Dynamic cast NULL to Nullable-eligible types: should return NULL
+SELECT v.a::Int32 AS val, toTypeName(val) FROM (SELECT '{"a":null}'::JSON AS v);
+SELECT v.a::String AS val, toTypeName(val) FROM (SELECT '{"a":null}'::JSON AS v);
+
+-- Dynamic cast NULL to non-Nullable type (Array): should throw
+SELECT v.a::Array(String) FROM (SELECT '{"a":null}'::JSON AS v); -- { serverError CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN }
+
+-- Dynamic cast non-NULL to Array: should work fine
+SELECT v.a::Array(UInt32) FROM (SELECT '{"a":[1,2,3]}'::JSON AS v);
+
+-- Without setting: backward compatible
+SET cast_keep_nullable = 0;
+SELECT v.a::Array(String) FROM (SELECT '{"a":null}'::JSON AS v);
+SELECT v.a::Int32 FROM (SELECT '{"a":null}'::JSON AS v);
+
+-- Via-Dynamic cast consistency with direct cast
+SET cast_keep_nullable = 1;
+SELECT vv::Array(String) FROM (SELECT v.a::LowCardinality(Nullable(String)) AS vv FROM (SELECT '{"a":null}'::JSON AS v)); -- { serverError CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN }
+SELECT vv::Dynamic::Array(String) FROM (SELECT v.a::LowCardinality(Nullable(String)) AS vv FROM (SELECT '{"a":null}'::JSON AS v)); -- { serverError CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN }


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Extend `cast_keep_nullable` to work with Dynamic/JSON types. When set, casting NULL from types that can be Nullable will return NULL, otherwise NULL will throw `CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN` error.

### Details

A customer reported two inconsistencies when casting JSON null values:                                                                               

1. Query `select v.a::Array(String) from (select '{"a":null}'::JSON as v) settings cast_keep_nullable=1` returns `[]` instead of signaling an error.
The user set `cast_keep_nullable=1` explicitly requesting null preservation, but the system silently swallowed the null into a default value.

2. Direct cast Nullable(String) NULL to Array(String) throws `CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN`, but when casting Nullable(String) NULL to Dynamic to Array(String) silently returns `[]`. The same null value produces different results depending on the cast path.

Root cause: `cast_keep_nullable` only checks `isNullable()` on the source type. Dynamic (used by JSON) stores nulls via an internal discriminator, not the Nullable wrapper, so the setting has no effect. And `ConvertImplFromDynamicToColumn` unconditionally calls `insertDefault()` for null values regardless of any settings.     

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `CAST`/`::` behavior for `Dynamic`/`JSON` sources when `cast_keep_nullable=1`, potentially turning previously silent NULL-to-default conversions into `CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN` errors for non-nullable targets.
> 
> **Overview**
> Extends `cast_keep_nullable` handling to `Dynamic`/`JSON` casts so that *NULL preservation is enforced consistently*.
> 
> When `cast_keep_nullable=1`, casting `Dynamic`-backed NULLs now returns NULL only for targets that can be nullable, and throws `CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN` when converting NULL into non-Nullable targets (instead of inserting defaults like `[]`). Adds a dedicated stateless test to cover the new Dynamic/JSON null-casting behavior and backward-compatibility when the setting is off.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c49951291f45693c333945271b91e6286ee36e1e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.276`
<!-- ch-version-info:end -->