### PR TITLE
update SystemLog.cpp

### DIFF
--- a/src/Interpreters/SystemLog.cpp
+++ b/src/Interpreters/SystemLog.cpp
@@ -88,63 +88,11 @@ namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;
     extern const int LOGICAL_ERROR;
-    extern const int NOT_IMPLEMENTED;
 }
 
 namespace ActionLocks
 {
     extern const StorageActionBlockType PartsMerge;
-}
-
-namespace
-{
-    class StorageWithComment : public IAST
-    {
-    public:
-        ASTPtr storage;
-        ASTPtr comment;
-
-        String getID(char) const override { return "Storage with comment definition"; }
-
-        ASTPtr clone() const override
-        {
-            throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method clone is not supported");
-        }
-
-    protected:
-        void formatImpl(WriteBuffer &, const FormatSettings &, FormatState &, FormatStateStacked) const override
-        {
-            throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method formatImpl is not supported");
-        }
-    };
-
-    class ParserStorageWithComment : public IParserBase
-    {
-    protected:
-        const char * getName() const override { return "storage definition with comment"; }
-        bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override
-        {
-            ParserStorage storage_p{ParserStorage::TABLE_ENGINE};
-            ASTPtr storage;
-
-            if (!storage_p.parse(pos, storage, expected))
-                return false;
-
-            ParserKeyword s_comment(Keyword::COMMENT);
-            ParserStringLiteral string_literal_parser;
-            ASTPtr comment;
-
-            if (s_comment.ignore(pos, expected))
-                string_literal_parser.parse(pos, comment, expected);
-
-            auto storage_with_comment = make_intrusive<StorageWithComment>();
-            storage_with_comment->storage = std::move(storage);
-            storage_with_comment->comment = std::move(comment);
-
-            node = storage_with_comment;
-            return true;
-        }
-    };
 }
 
 namespace


### PR DESCRIPTION
Move `StorageWithComment` and `ParserStorageWithComment` from anonymous namespace in `SystemLog.cpp` to `DB` namespace in `SystemLog.h`. These are currently only used in `SystemLog.cpp` but I'll soon need them to be used in other places and I want to avoid copying code.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.537`
<!-- ch-version-info:end -->