### PR TITLE
Docs: update nats.md

### DIFF
--- a/docs/en/engines/table-engines/integrations/nats.md
+++ b/docs/en/engines/table-engines/integrations/nats.md
@@ -78,7 +78,8 @@ Optional parameters:
 SSL connection:
 
 For secure connection use `nats_secure = 1`.
-The default behaviour of the used library is not to check if the created TLS connection is sufficiently secure. Whether the certificate is expired, self-signed, missing or invalid: the connection is simply permitted. More strict checking of certificates can possibly be implemented in the future.
+Certificate verification is controlled by the `CLICKHOUSE_NATS_TLS_SECURE` environment variable;
+If the certificate is expired, self-signed, missing, or otherwise invalid, disable verification by setting `CLICKHOUSE_NATS_TLS_SECURE=0`.
 
 Writing to NATS table:
 


### PR DESCRIPTION
Updated NATS certificate validation documentation as mentioned [here](https://github.com/ClickHouse/ClickHouse/blob/master/src/Storages/NATS/NATSConnection.cpp#L33) in the code.

Validated the behaviour:

```bash
[anino@ip-10-0-6-78 ~]$ docker exec -it clickhouse_single bash
root@c981082b3bc5:/# echo $CLICKHOUSE_NATS_TLS_SECURE
0
```

```sql
c981082b3bc5 :) CREATE TABLE assets_from_nats
(
    `event_id` String,
    `timestamp` DateTime64(6),
    `actor_type` String,
    `environment_id` String,
    `organization_id` String,
    `aleph_id` String,
    `type` String,
    `execution_id` String,
    `unix_timestamp` UInt64,
    `message` String,
    `metadata` String DEFAULT '{}',
    `properties` String DEFAULT '{}',
    `integration_data` String DEFAULT '{}',
    `received_at` DateTime DEFAULT now()
)
ENGINE = NATS
SETTINGS nats_url = '10.0.6.78:4444', nats_secure = 1, nats_username = 'xxxxx', nats_password = 'xxxxx.123', nats_stream = 'eu-1-nats-events', nats_consumer_name = 'clickhouse_assets_consumer', nats_subjects = '*.*.*.*.asset.>', nats_format = 'JSONEachRow';

CREATE TABLE assets_from_nats
(
    `event_id` String,
    `timestamp` DateTime64(6),
    `actor_type` String,
    `environment_id` String,
    `organization_id` String,
    `aleph_id` String,
    `type` String,
    `execution_id` String,
    `unix_timestamp` UInt64,
    `message` String,
    `metadata` String DEFAULT '{}',
    `properties` String DEFAULT '{}',
    `integration_data` String DEFAULT '{}',
    `received_at` DateTime DEFAULT now()
)
ENGINE = NATS
SETTINGS nats_url = '10.0.6.78:4444', nats_secure = 1, nats_username = 'xxxxx', nats_password = 'xxxxx.123', nats_stream = 'eu-1-nats-events', nats_consumer_name = 'clickhouse_assets_consumer', nats_subjects = '*.*.*.*.asset.>', nats_format = 'JSONEachRow'

Query id: 684131b1-56f2-406d-884f-66598c26dda2

Ok.

0 rows in set. Elapsed: 0.103 sec.
```

Vs when the environment variable is not defined:

```sql
e5e48ed3ab3e :) CREATE TABLE assets_from_nats (`event_id` String, `timestamp` DateTime64(6), `actor_type` String, `environment_id` String, `organization_id` String, `aleph_id` String, `type` String, `execution_id` String, `unix_timestamp` UInt64, `message` String, `metadata` String DEFAULT '{}', `properties` String DEFAULT '{}', `integration_data` String DEFAULT '{}', `received_at` DateTime DEFAULT now()) ENGINE = NATS SETTINGS nats_url = '10.0.6.78:4444', nats_secure = 1, nats_username = 'xxxxx', nats_password = 'xxxxx.123', nats_stream = 'eu-1-nats-events', nats_consumer_name = 'clickhouse_assets_consumer', nats_subjects = '*.*.*.*.asset.>', nats_format = 'JSONEachRow';

CREATE TABLE assets_from_nats
(
    `event_id` String,
    `timestamp` DateTime64(6),
    `actor_type` String,
    `environment_id` String,
    `organization_id` String,
    `aleph_id` String,
    `type` String,
    `execution_id` String,
    `unix_timestamp` UInt64,
    `message` String,
    `metadata` String DEFAULT '{}',
    `properties` String DEFAULT '{}',
    `integration_data` String DEFAULT '{}',
    `received_at` DateTime DEFAULT now()
)
ENGINE = NATS
SETTINGS nats_url = '10.0.6.78:4444', nats_secure = 1, nats_username = 'xxxxx', nats_password = 'xxxxx.123', nats_stream = 'eu-1-nats-events', nats_consumer_name = 'clickhouse_assets_consumer', nats_subjects = '*.*.*.*.asset.>', nats_format = 'JSONEachRow'

Query id: 87a0e4c1-3f23-4775-b765-991e42bdace6


Elapsed: 0.110 sec.

Received exception from server (version 25.12.3):
Code: 665. DB::Exception: Received from localhost:9000. DB::Exception: Cannot connect to Nats last error: (conn.c:753): SSL handshake error: 20:unable to get local issuer certificate:depth=0:cert=/C=RU/ST=Some-State/O=Internet Widgits Pty Ltd/CN=server:issuer=/C=RU/ST=Some-State/O=Internet Widgits Pty Ltd/CN=ca. (CANNOT_CONNECT_NATS)
```

### Changelog category (leave one):
- Documentation (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.534`
<!-- ch-version-info:end -->