### PR TITLE
CI: Improve cherry-pick PR assignment and lifecycle management

### DIFF
--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -401,7 +401,16 @@ close it.
                 )
                 return
             self.cherrypick_pr.create_issue_comment(comment_body)
+            logging.info(
+                "Posted closing comment to cherry-pick PR #%s",
+                self.cherrypick_pr.number,
+            )
             self.cherrypick_pr.edit(state="closed")
+            logging.info(
+                "Closed cherry-pick PR #%s after %s of inactivity",
+                self.cherrypick_pr.number,
+                since_updated_str,
+            )
             return
 
         # Ping after 3 days
@@ -449,6 +458,11 @@ close it.
             return
 
         self.cherrypick_pr.create_issue_comment(comment_body)
+        logging.info(
+            "Posted ping comment to cherry-pick PR #%s after %s of inactivity",
+            self.cherrypick_pr.number,
+            since_updated_str,
+        )
 
     def _assign_new_pr(self, new_pr: PullRequest) -> None:
         """Assign `new_pr` to author, merger and assignees of an original PR"""
@@ -843,6 +857,12 @@ class CherryPickPRs:
 
         original_pr.remove_from_labels(Labels.PR_BACKPORTS_CREATED)
         pr.create_issue_comment(comment_body)
+        logging.info(
+            "Removed label %s from PR #%s and posted comment to cherry-pick PR #%s",
+            Labels.PR_BACKPORTS_CREATED,
+            original_pr.number,
+            pr.number,
+        )
 
 
 def parse_args():

--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -56,7 +56,6 @@ class BackportException(Exception):
 
 
 class ReleaseBranch:
-    STALE_THRESHOLD = 24 * 3600
     CHERRYPICK_DESCRIPTION = f"""## Do not merge this PR manually
 
 This pull-request is a first step of an automated backporting.
@@ -215,6 +214,16 @@ close it.
             self.cherrypick_pr.number,
             self.pr.number,
         )
+        # Assign to engineer if not already assigned (only for PRs with conflicts)
+        if not self.cherrypick_pr.assignees:
+            if dry_run:
+                logging.info(
+                    "DRY RUN: Would assign cherry-pick PR #%s to engineers",
+                    self.cherrypick_pr.number,
+                )
+            else:
+                self._assign_new_pr(self.cherrypick_pr)
+                self.cherrypick_pr.update()
         self.ping_cherry_pick_assignees(dry_run)
 
     def create_cherrypick(self):
@@ -258,7 +267,7 @@ close it.
             # There are changes to apply, so continue
             git_runner(f"{GIT_PREFIX} reset --merge")
 
-        # Push, create the cherry-pick PR, label and assign it
+        # Push, create the cherry-pick PR and label it
         for branch in [self.cherrypick_branch, self.backport_branch]:
             git_runner(f"{GIT_PREFIX} push -f {self.REMOTE} {branch}:{branch}")
 
@@ -275,7 +284,7 @@ close it.
             self.cherrypick_pr.add_to_labels(Labels.PR_CRITICAL_BUGFIX)
         elif Labels.PR_BUGFIX in [label.name for label in self.pr.labels]:
             self.cherrypick_pr.add_to_labels(Labels.PR_BUGFIX)
-        self._assign_new_pr(self.cherrypick_pr)
+        # Do not assign yet - will assign only if there are conflicts
         # update cherrypick PR to get the state for PR.mergable
         self.cherrypick_pr.update()
 
@@ -340,7 +349,7 @@ close it.
     def ping_cherry_pick_assignees(self, dry_run: bool) -> None:
         assert self.cherrypick_pr is not None
         logging.info(
-            "Checking if cherry-pick PR #%s needs to be pinged",
+            "Checking if cherry-pick PR #%s needs to be pinged or closed",
             self.cherrypick_pr.number,
         )
         # The `updated_at` is Optional[datetime]
@@ -352,23 +361,65 @@ close it.
             f"{since_updated // 86400}d{since_updated // 3600 % 24}h"
             f"{since_updated // 60 % 60}m{since_updated % 60}s"
         )
-        if since_updated < self.STALE_THRESHOLD:
+
+        PING_THRESHOLD = 3 * 24 * 3600  # 3 days
+        CLOSE_THRESHOLD = 7 * 24 * 3600  # 7 days
+
+        if since_updated < PING_THRESHOLD:
             logging.info(
-                "The cherry-pick PR was updated %s ago, "
-                "waiting for the next running",
+                "The cherry-pick PR was updated %s ago, waiting for the next run",
                 since_updated_str,
             )
             return
+
+        if since_updated >= CLOSE_THRESHOLD:
+            # Close the PR after 7 days
+            assignees = ", ".join(
+                f"@{user.login}" for user in self.cherrypick_pr.assignees
+            )
+            comment_body = (
+                f"Dear {assignees}, this cherry-pick PR has not been updated for {since_updated_str}. "
+                f"Closing automatically. If you still want to backport #{self.pr.number}, "
+                "please resolve the conflicts and reopen this PR."
+            )
+            if dry_run:
+                logging.info(
+                    "DRY RUN: would close cherry-pick PR #%s with comment:\n%s",
+                    self.cherrypick_pr.number,
+                    comment_body,
+                )
+                return
+            self.cherrypick_pr.create_issue_comment(comment_body)
+            self.cherrypick_pr.edit(state="closed")
+            return
+
+        # Ping after 3 days
+        # Check if we've already pinged to avoid spamming
+        comments = self.cherrypick_pr.get_issue_comments()
+        for comment in comments:
+            if (
+                "has not been updated for" in comment.body
+                and "resolve the conflicts" in comment.body
+            ):
+                # We've already pinged, don't ping again
+                logging.info(
+                    "Already pinged cherry-pick PR #%s, waiting for update or closure threshold",
+                    self.cherrypick_pr.number,
+                )
+                return
+
         assignees = ", ".join(f"@{user.login}" for user in self.cherrypick_pr.assignees)
         comment_body = (
-            f"Dear {assignees}, the PR is not updated for {since_updated_str}. "
-            "Please, either resolve the conflicts, or close it to finish "
-            f"the backport process of #{self.pr.number}"
+            f"Dear {assignees}, this cherry-pick PR has not been updated for {since_updated_str}. "
+            f"Please resolve the conflicts to backport #{self.pr.number}, "
+            "or close this PR if the backport is no longer needed. "
+            f"This PR will be automatically closed after {CLOSE_THRESHOLD // 86400} days of inactivity."
         )
         if dry_run:
             logging.info(
-                "DRY RUN: would comment the cherry-pick PR #%s:\n",
+                "DRY RUN: would comment on cherry-pick PR #%s:\n%s",
                 self.cherrypick_pr.number,
+                comment_body,
             )
             return
 


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


#### Description

This PR optimizes the cherry-pick automation process to reduce unnecessary engineer notifications and improve workflow efficiency.

##### New Logic:

**Before:**
- All cherry-pick PRs were immediately assigned to engineers
- Daily pings started after 24 hours of inactivity
- PRs were never automatically closed

**After:**
- Cherry-pick PRs are only assigned when there are **conflicts** that prevent automatic merging
- If a cherry-pick is mergeable, it's merged automatically without assigning anyone
- For PRs with conflicts:
  - Assignment happens immediately when conflicts are detected
  - First ping is sent after **3 days** of inactivity (with duplicate prevention)
  - PR is automatically closed after **7 days** of inactivity

##### Benefits:
- Reduces notification noise for engineers
- Streamlines the backport process for conflict-free changes
- Provides a clear timeline for conflict resolution

Requested by
@nikitamikhaylov @kssenii 


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.574`
<!-- ch-version-info:end -->