### PR TITLE
Make core dump size limit configuration setting hot-reloadable

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -2447,6 +2447,17 @@ try
             if (global_context->isServerCompletelyStarted())
                 CannotAllocateThreadFaultInjector::setFaultProbability(new_server_settings[ServerSetting::cannot_allocate_thread_fault_injection_probability]);
 
+            /// Update core dump size limit.
+            {
+                rlimit rlim;
+                if (getrlimit(RLIMIT_CORE, &rlim) == 0)
+                {
+                    rlim.rlim_cur = config->getUInt64("core_dump.size_limit", 1024 * 1024 * 1024);
+                    if (setrlimit(RLIMIT_CORE, &rlim))
+                        LOG_WARNING(log, "Cannot set max size of core file to {}", rlim.rlim_cur);
+                }
+            }
+
             ProfileEvents::increment(ProfileEvents::MainConfigLoads);
 
             /// Must be the last.

--- a/src/Daemon/BaseDaemon.cpp
+++ b/src/Daemon/BaseDaemon.cpp
@@ -272,20 +272,6 @@ void BaseDaemon::initialize(Application & self)
 #endif
     );
 
-    /// Write core dump on crash.
-    {
-        struct rlimit rlim;
-        if (getrlimit(RLIMIT_CORE, &rlim))
-            throw Poco::Exception("Cannot getrlimit");
-        /// 1 GiB by default. If more - it writes to disk too long.
-        rlim.rlim_cur = config().getUInt64("core_dump.size_limit", 1024 * 1024 * 1024);
-
-        if (rlim.rlim_cur && setrlimit(RLIMIT_CORE, &rlim))
-        {
-            /// It doesn't work under address/thread sanitizer. http://lists.llvm.org/pipermail/llvm-bugs/2013-April/027880.html
-            std::cerr << "Cannot set max size of core file to " + std::to_string(rlim.rlim_cur) << std::endl;
-        }
-    }
 
 #if defined(OS_LINUX)
     /// Configure RLIMIT_SIGPENDING

--- a/tests/integration/test_core_dump_size_limit/configs/core_dump.xml
+++ b/tests/integration/test_core_dump_size_limit/configs/core_dump.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<clickhouse>
+    <core_dump>
+        <size_limit>1073741824</size_limit>
+    </core_dump>
+</clickhouse>

--- a/tests/integration/test_core_dump_size_limit/configs/core_dump.xml
+++ b/tests/integration/test_core_dump_size_limit/configs/core_dump.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <clickhouse>
     <core_dump>
         <size_limit>1073741824</size_limit>

--- a/tests/integration/test_core_dump_size_limit/test.py
+++ b/tests/integration/test_core_dump_size_limit/test.py
@@ -39,3 +39,11 @@ def test_core_dump_size_limit_hot_reload(start_cluster):
     node.query("SYSTEM RELOAD CONFIG")
 
     assert get_core_dump_limit() == 536870912
+
+    # Restore original config so the test is repeatable
+    node.replace_in_config(
+        "/etc/clickhouse-server/config.d/core_dump.xml",
+        "<size_limit>536870912</size_limit>",
+        "<size_limit>1073741824</size_limit>",
+    )
+    node.query("SYSTEM RELOAD CONFIG")

--- a/tests/integration/test_core_dump_size_limit/test.py
+++ b/tests/integration/test_core_dump_size_limit/test.py
@@ -1,0 +1,41 @@
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+
+node = cluster.add_instance(
+    "node",
+    main_configs=["configs/core_dump.xml"],
+    stay_alive=True,
+)
+
+
+@pytest.fixture(scope="module")
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_core_dump_size_limit_hot_reload(start_cluster):
+    def get_core_dump_limit():
+        pid = node.get_process_pid("clickhouse")
+        result = node.exec_in_container(
+            ["bash", "-c", f"prlimit --pid {pid} --core --output=SOFT --noheadings"],
+            user="root",
+        )
+        return int(result.strip())
+
+    assert get_core_dump_limit() == 1073741824
+
+    node.replace_in_config(
+        "/etc/clickhouse-server/config.d/core_dump.xml",
+        "<size_limit>1073741824</size_limit>",
+        "<size_limit>536870912</size_limit>",
+    )
+    node.query("SYSTEM RELOAD CONFIG")
+
+    assert get_core_dump_limit() == 536870912


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Make `core_dump.size_limit` configuration setting hot-reloadable, to avoid having to restart servers for configuration changes to take place.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.538`
<!-- ch-version-info:end -->