### PR TITLE
Fix flaky `test_interactive_totp_authentication`

### DIFF
--- a/tests/integration/helpers/uclient.py
+++ b/tests/integration/helpers/uclient.py
@@ -21,7 +21,7 @@ class client(object):
         self.client.eol("\r")
         self.client.logger(log, prefix=name)
         self.client.timeout(20)
-        self.client.expect("[#\\$] ", timeout=2)
+        self.client.expect("[#\\$] ", timeout=10)
         self.client.send(command)
 
     def __enter__(self):


### PR DESCRIPTION
Increase bash prompt timeout in `uclient.py` from 2s to 10s. On loaded ARM runners, spawning bash and getting the prompt can exceed 2 seconds, especially after multiple sequential `client()` invocations. This only affects the timeout ceiling — in the happy path the prompt appears instantly so test speed is unaffected.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=94853&sha=10a06df362cfd95623a238cf7aed602c2e216e18&name_0=PR&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%203%2F4%29
https://github.com/ClickHouse/ClickHouse/pull/94853

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.548`
<!-- ch-version-info:end -->