### PR TITLE
Fix flaky test `02916_glogal_in_cancel` under TSan

### DIFF
--- a/tests/queries/0_stateless/02916_glogal_in_cancel.sql
+++ b/tests/queries/0_stateless/02916_glogal_in_cancel.sql
@@ -1,2 +1,2 @@
 set max_execution_time = 0.5, timeout_overflow_mode = 'break', max_rows_to_read = 0;
-SELECT number FROM remote('127.0.0.{1|2}', numbers(1)) WHERE number GLOBAL IN (SELECT number FROM numbers(10000000000.)) format Null;
+SELECT number FROM remote('127.0.0.{1|2|3}', numbers(1)) WHERE number GLOBAL IN (SELECT number FROM numbers(10000000000.)) format Null;

--- a/tests/queries/0_stateless/02916_glogal_in_cancel.sql
+++ b/tests/queries/0_stateless/02916_glogal_in_cancel.sql
@@ -1,2 +1,2 @@
 set max_execution_time = 0.5, timeout_overflow_mode = 'break', max_rows_to_read = 0;
-SELECT number FROM remote('127.0.0.{3|2}', numbers(1)) WHERE number GLOBAL IN (SELECT number FROM numbers(10000000000.)) format Null;
+SELECT number FROM remote('127.0.0.{1|2}', numbers(1)) WHERE number GLOBAL IN (SELECT number FROM numbers(10000000000.)) format Null;


### PR DESCRIPTION
The test uses `remote('127.0.0.{3|2}', ...)` with `max_execution_time = 0.5`. Under TSan, the 0.5s timeout fires during table structure resolution (which requires network connections to remote shards), causing `NO_REMOTE_SHARD_AVAILABLE` instead of a graceful timeout.

Added a local shard in `getStructureOfRemoteTable`, allowing instant structure resolution without network calls. The test still exercises GLOBAL IN cancellation with a distributed query.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=f9e36b04ffb08eee40c70de6b8be57d77bb88338&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_tsan%2C%20parallel%2C%202%2F2%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.549`
<!-- ch-version-info:end -->