### PR TITLE
Fix flaky `test_database_delta` by fixing Derby metastore lock cleanup

### DIFF
--- a/tests/integration/test_database_delta/test.py
+++ b/tests/integration/test_database_delta/test.py
@@ -59,12 +59,16 @@ def started_cluster():
 
 
 def execute_spark_query(node, query_text):
+    # Kill any lingering Spark processes and remove stale Derby metastore lock
+    # before starting a new Spark session. The metastore_db is created inside
+    # /spark-3.5.4-bin-hadoop3/ because spark-sql is run with cd to that directory.
     node.exec_in_container(
         [
             "bash",
             "-c",
-            f"""rm -f metastore_db/dbex.lck""",
+            """pkill -9 -f 'org.apache.spark' 2>/dev/null; rm -rf /spark-3.5.4-bin-hadoop3/metastore_db/dbex.lck""",
         ],
+        nothrow=True,
     )
 
     try:


### PR DESCRIPTION
The `execute_spark_query` function was removing `metastore_db/dbex.lck` using a relative path from the container's default working directory, but the actual lock file is at `/spark-3.5.4-bin-hadoop3/metastore_db/dbex.lck` (created by Spark after `cd /spark-3.5.4-bin-hadoop3`). The lock was never actually removed.

When a Spark command timed out, the Java process kept running and held the Derby lock, causing all subsequent tests to fail with `ERROR XSDB6: Another instance of Derby may have already booted the database`.

Fix: kill stale Spark/Java processes and use the correct absolute path for lock file removal before each Spark invocation.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96506&sha=bcdfbc0d6cfeb51e9fd44afdfcfc8602d15adb4f&name_0=PR&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%204%2F4%29
https://github.com/ClickHouse/ClickHouse/pull/96506

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.550`
<!-- ch-version-info:end -->