### PR TITLE
Polish MergeTree settings for distributed index analysis

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -7013,7 +7013,7 @@ Uses replicas from cluster_for_parallel_replicas.
 
 - [distributed_index_analysis_for_non_shared_merge_tree](#distributed_index_analysis_for_non_shared_merge_tree)
 - [distributed_index_analysis_min_parts_to_activate](merge-tree-settings.md/#distributed_index_analysis_min_parts_to_activate)
-- [distributed_index_analysis_min_indexes_size_to_activate](merge-tree-settings.md/#distributed_index_analysis_min_indexes_size_to_activate)
+- [distributed_index_analysis_min_indexes_bytes_to_activate](merge-tree-settings.md/#distributed_index_analysis_min_indexes_bytes_to_activate)
 )", EXPERIMENTAL) \
     DECLARE(Bool, distributed_index_analysis_for_non_shared_merge_tree, false, R"(
 Enable distributed index analysis even for non SharedMergeTree (cloud only engine).

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -1047,7 +1047,7 @@ const VersionToSettingsChangesMap & getMergeTreeSettingsChangesHistory()
             {"clone_replica_zookeeper_create_get_part_batch_size", 1, 100, "New setting"},
             {"add_minmax_index_for_temporal_columns", false, false, "New setting"},
             {"distributed_index_analysis_min_parts_to_activate", 10, 10, "New setting"},
-            {"distributed_index_analysis_min_indexes_size_to_activate", 1_GiB, 1_GiB, "New setting"},
+            {"distributed_index_analysis_min_indexes_bytes_to_activate", 1_GiB, 1_GiB, "New setting"},
             {"refresh_statistics_interval", 0, 300, "Enable statistics cache"},
         });
         addSettingsChanges(merge_tree_settings_changes_history, "26.1",

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -209,7 +209,7 @@ namespace MergeTreeSetting
     extern const MergeTreeSettingsInt64 max_partitions_to_read;
     extern const MergeTreeSettingsUInt64 min_marks_to_honor_max_concurrent_queries;
     extern const MergeTreeSettingsUInt64 distributed_index_analysis_min_parts_to_activate;
-    extern const MergeTreeSettingsUInt64 distributed_index_analysis_min_indexes_size_to_activate;
+    extern const MergeTreeSettingsUInt64 distributed_index_analysis_min_indexes_bytes_to_activate;
 }
 
 namespace ErrorCodes
@@ -2255,12 +2255,12 @@ ReadFromMergeTree::AnalysisResultPtr ReadFromMergeTree::selectRangesToRead(
         /// Note, use_skip_indexes_if_final_exact_mode requires complete PK, so we cannot apply distributed_index_analysis with it
         bool final_second_pass = indexes->use_skip_indexes_if_final_exact_mode;
         UInt64 distributed_index_analysis_min_parts_to_activate = (*data_settings_)[MergeTreeSetting::distributed_index_analysis_min_parts_to_activate];
-        UInt64 distributed_index_analysis_min_indexes_size_to_activate = (*data_settings_)[MergeTreeSetting::distributed_index_analysis_min_indexes_size_to_activate];
+        UInt64 distributed_index_analysis_min_indexes_bytes_to_activate = (*data_settings_)[MergeTreeSetting::distributed_index_analysis_min_indexes_bytes_to_activate];
         bool distributed_index_analysis_enabled = !final_second_pass
             && settings[Setting::distributed_index_analysis]
             && (settings[Setting::distributed_index_analysis_for_non_shared_merge_tree] || data.isSharedStorage())
             && (total_parts >= distributed_index_analysis_min_parts_to_activate)
-            && (!distributed_index_analysis_min_indexes_size_to_activate || get_indexes_size(data) >= distributed_index_analysis_min_indexes_size_to_activate);
+            && (!distributed_index_analysis_min_indexes_bytes_to_activate || get_indexes_size(data) >= distributed_index_analysis_min_indexes_bytes_to_activate);
 
         if (!distributed_index_analysis_enabled)
         {

--- a/src/Storages/MergeTree/MergeTreeSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeSettings.cpp
@@ -2071,7 +2071,7 @@ namespace ErrorCodes
     DECLARE(UInt64, distributed_index_analysis_min_parts_to_activate, 10, R"(
     Minimal number of parts to activated distributed index analysis
     )", 0) \
-    DECLARE(UInt64, distributed_index_analysis_min_indexes_size_to_activate, 1_GiB, R"(
+    DECLARE(UInt64, distributed_index_analysis_min_indexes_bytes_to_activate, 1_GiB, R"(
     Minimal index sizes (data skipping and primary key) on disk (but uncompressed) to activated distributed index analysis
     )", 0) \
     DECLARE(NonZeroUInt64, clone_replica_zookeeper_create_get_part_batch_size, zkutil::MULTI_BATCH_SIZE, R"(

--- a/src/Storages/MergeTree/MergeTreeSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeSettings.cpp
@@ -2070,10 +2070,10 @@ namespace ErrorCodes
     )", 0) \
     DECLARE(UInt64, distributed_index_analysis_min_parts_to_activate, 10, R"(
     Minimal number of parts to activated distributed index analysis
-    )", 0) \
+    )", EXPERIMENTAL) \
     DECLARE(UInt64, distributed_index_analysis_min_indexes_bytes_to_activate, 1_GiB, R"(
     Minimal index sizes (data skipping and primary key) on disk (but uncompressed) to activated distributed index analysis
-    )", 0) \
+    )", EXPERIMENTAL) \
     DECLARE(NonZeroUInt64, clone_replica_zookeeper_create_get_part_batch_size, zkutil::MULTI_BATCH_SIZE, R"(
     Batch size for ZooKeeper multi-create get-part requests when cloning replica.
     )", 0) \

--- a/tests/integration/test_distributed_index_analysis/test.py
+++ b/tests/integration/test_distributed_index_analysis/test.py
@@ -31,7 +31,7 @@ def bootstrap():
         engine=ReplicatedMergeTree()
         order by (k1, k2, k3, k4)
         partition by (p)
-        settings index_granularity=1, primary_key_lazy_load=0, distributed_index_analysis_min_parts_to_activate=0, distributed_index_analysis_min_indexes_size_to_activate=0
+        settings index_granularity=1, primary_key_lazy_load=0, distributed_index_analysis_min_parts_to_activate=0, distributed_index_analysis_min_indexes_bytes_to_activate=0
         """)
 
     for node in cluster.instances.values():

--- a/tests/queries/0_stateless/03620_distributed_index_analysis.sql
+++ b/tests/queries/0_stateless/03620_distributed_index_analysis.sql
@@ -2,7 +2,7 @@
 -- - no-random-merge-tree-settings -- may change number of parts
 
 drop table if exists test_10m;
-create table test_10m (key Int, value Int) engine=MergeTree() order by key settings distributed_index_analysis_min_parts_to_activate=0, distributed_index_analysis_min_indexes_size_to_activate=0;
+create table test_10m (key Int, value Int) engine=MergeTree() order by key settings distributed_index_analysis_min_parts_to_activate=0, distributed_index_analysis_min_indexes_bytes_to_activate=0;
 system stop merges test_10m;
 insert into test_10m select number, number*100 from numbers(10e6);
 

--- a/tests/queries/0_stateless/03620_distributed_index_analysis_vector_search.sql
+++ b/tests/queries/0_stateless/03620_distributed_index_analysis_vector_search.sql
@@ -13,7 +13,7 @@ CREATE TABLE dist_vec
 )
 Engine=MergeTree
 ORDER BY id
-SETTINGS index_granularity = 8, distributed_index_analysis_min_parts_to_activate = 0, distributed_index_analysis_min_indexes_size_to_activate = 10;
+SETTINGS index_granularity = 8, distributed_index_analysis_min_parts_to_activate = 0, distributed_index_analysis_min_indexes_bytes_to_activate = 10;
 
 SYSTEM STOP MERGES dist_vec;
 

--- a/tests/queries/0_stateless/03621_pr_distributed_index_analysis.sql
+++ b/tests/queries/0_stateless/03621_pr_distributed_index_analysis.sql
@@ -4,7 +4,7 @@
 -- Make sure that distributed index analysis works with parallel replicas
 
 drop table if exists test_10m;
-create table test_10m (key Int, value Int) engine=MergeTree() order by key settings distributed_index_analysis_min_parts_to_activate=0, distributed_index_analysis_min_indexes_size_to_activate=0;
+create table test_10m (key Int, value Int) engine=MergeTree() order by key settings distributed_index_analysis_min_parts_to_activate=0, distributed_index_analysis_min_indexes_bytes_to_activate=0;
 system stop merges test_10m;
 insert into test_10m select number, number*100 from numbers(10e6);
 

--- a/tests/queries/0_stateless/03622_distributed_index_analysis_additional_table_filters.sql
+++ b/tests/queries/0_stateless/03622_distributed_index_analysis_additional_table_filters.sql
@@ -4,7 +4,7 @@ drop table if exists test_1m;
 -- -min_bytes_for_wide_part -- wide parts are different (they respect index_granularity completely, unlike compact parts) -- FIXME
 -- -merge_selector_base = 1000 -- disable merges
 -- -index_granularity* -- test relies on number of granulas
-create table test_1m (key Int, value Int) engine=MergeTree() order by key settings merge_selector_base = 1000, index_granularity=8192, min_bytes_for_wide_part=1e9, index_granularity_bytes=10e6, distributed_index_analysis_min_parts_to_activate=0, distributed_index_analysis_min_indexes_size_to_activate=0;
+create table test_1m (key Int, value Int) engine=MergeTree() order by key settings merge_selector_base = 1000, index_granularity=8192, min_bytes_for_wide_part=1e9, index_granularity_bytes=10e6, distributed_index_analysis_min_parts_to_activate=0, distributed_index_analysis_min_indexes_bytes_to_activate=0;
 system stop merges test_1m;
 insert into test_1m select number, number*100 from numbers(1e6) settings max_block_size=10000, min_insert_block_size_rows=10000, max_insert_threads=1;
 select count(), sum(marks) from system.parts where database = currentDatabase() and table = 'test_1m' and active;

--- a/tests/queries/0_stateless/03622_distributed_index_analysis_all_replicas.sql
+++ b/tests/queries/0_stateless/03622_distributed_index_analysis_all_replicas.sql
@@ -4,7 +4,7 @@
 -- even failed replica (that is included into parallel_replicas cluster), and ensure that the SELECT wont fail (parts should be analyzed locally).
 
 drop table if exists test_10m;
-create table test_10m (key Int, value Int) engine=MergeTree() order by key partition by key % 200 settings distributed_index_analysis_min_parts_to_activate=0, distributed_index_analysis_min_indexes_size_to_activate=0;
+create table test_10m (key Int, value Int) engine=MergeTree() order by key partition by key % 200 settings distributed_index_analysis_min_parts_to_activate=0, distributed_index_analysis_min_indexes_bytes_to_activate=0;
 system stop merges test_10m;
 
 insert into test_10m select number, number*100 from numbers(1e6) settings max_partitions_per_insert_block=200, max_block_size=1e6;

--- a/tests/queries/0_stateless/03622_distributed_index_analysis_fallback_to_localhost.sql
+++ b/tests/queries/0_stateless/03622_distributed_index_analysis_fallback_to_localhost.sql
@@ -2,7 +2,7 @@ drop table if exists test_1m;
 -- -min_bytes_for_wide_part -- wide parts are different (they respect index_granularity completely, unlike compact parts) -- FIXME
 -- -merge_selector_base = 1000 -- disable merges
 -- -index_granularity* -- test relies on number of granulas
-create table test_1m (key Int, value Int) engine=MergeTree() order by key settings merge_selector_base = 1000, index_granularity=8192, min_bytes_for_wide_part=1e9, index_granularity_bytes=10e6, distributed_index_analysis_min_parts_to_activate=0, distributed_index_analysis_min_indexes_size_to_activate=0;
+create table test_1m (key Int, value Int) engine=MergeTree() order by key settings merge_selector_base = 1000, index_granularity=8192, min_bytes_for_wide_part=1e9, index_granularity_bytes=10e6, distributed_index_analysis_min_parts_to_activate=0, distributed_index_analysis_min_indexes_bytes_to_activate=0;
 system stop merges test_1m;
 insert into test_1m select number, number*100 from numbers(1e6) settings max_block_size=100_000, min_insert_block_size_rows=100_000, max_insert_threads=1;
 select count(), sum(marks) from system.parts where database = currentDatabase() and table = 'test_1m' and active;

--- a/tests/queries/0_stateless/03622_explain_indexes_distributed_index_analysis.sh
+++ b/tests/queries/0_stateless/03622_explain_indexes_distributed_index_analysis.sh
@@ -14,7 +14,7 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 $CLICKHOUSE_CLIENT -nm -q "
   drop table if exists test_10m;
-  create table test_10m (key Int, value Int) engine=MergeTree() order by key settings distributed_index_analysis_min_parts_to_activate=0, distributed_index_analysis_min_indexes_size_to_activate=0;
+  create table test_10m (key Int, value Int) engine=MergeTree() order by key settings distributed_index_analysis_min_parts_to_activate=0, distributed_index_analysis_min_indexes_bytes_to_activate=0;
   system stop merges test_10m;
   insert into test_10m select number, number*100 from numbers(1e6) settings max_partitions_per_insert_block=100, max_block_size=10000, min_insert_block_size_rows=10000;
   select count() from system.parts where database = currentDatabase() and table = 'test_10m';

--- a/tests/queries/0_stateless/03622_explain_indexes_distributed_index_analysis_in.sh
+++ b/tests/queries/0_stateless/03622_explain_indexes_distributed_index_analysis_in.sh
@@ -21,7 +21,7 @@ $CLICKHOUSE_CLIENT -nm -q "
   drop table if exists test_1m;
   -- -min_bytes_for_wide_part -- wide parts are different (they respect index_granularity completely, unlike compact parts) -- FIXME
   -- -merge_selector_base = 1000 -- disable merges
-  create table test_1m (key Int, value Int) engine=MergeTree() order by key settings merge_selector_base = 1000, index_granularity=8192, index_granularity_bytes=10e9, min_bytes_for_wide_part=1e9, distributed_index_analysis_min_parts_to_activate=0, distributed_index_analysis_min_indexes_size_to_activate=0;
+  create table test_1m (key Int, value Int) engine=MergeTree() order by key settings merge_selector_base = 1000, index_granularity=8192, index_granularity_bytes=10e9, min_bytes_for_wide_part=1e9, distributed_index_analysis_min_parts_to_activate=0, distributed_index_analysis_min_indexes_bytes_to_activate=0;
   system stop merges test_1m;
   insert into test_1m select number, number*100 from numbers(100e3) settings max_block_size=10000, min_insert_block_size_rows=10000, max_insert_threads=1;
   select count(), sum(marks) from system.parts where database = currentDatabase() and table = 'test_1m' and active;

--- a/tests/queries/0_stateless/03622_explain_indexes_distributed_index_analysis_pushdown.sh
+++ b/tests/queries/0_stateless/03622_explain_indexes_distributed_index_analysis_pushdown.sh
@@ -16,7 +16,7 @@ $CLICKHOUSE_CLIENT -nm -q "
   drop table if exists test_1m;
   -- -min_bytes_for_wide_part -- wide parts are different (they respect index_granularity completely, unlike compact parts) -- FIXME
   -- -merge_selector_base = 1000 -- disable merges
-  create table test_1m (key Int, value Int) engine=MergeTree() order by key settings merge_selector_base = 1000, index_granularity=8192, index_granularity_bytes=10e9, min_bytes_for_wide_part=1e9, distributed_index_analysis_min_parts_to_activate=0, distributed_index_analysis_min_indexes_size_to_activate=0;
+  create table test_1m (key Int, value Int) engine=MergeTree() order by key settings merge_selector_base = 1000, index_granularity=8192, index_granularity_bytes=10e9, min_bytes_for_wide_part=1e9, distributed_index_analysis_min_parts_to_activate=0, distributed_index_analysis_min_indexes_bytes_to_activate=0;
   system stop merges test_1m;
   insert into test_1m select number, number*100 from numbers(1e6) settings max_block_size=10000, min_insert_block_size_rows=10000, max_insert_threads=1;
   select count() from system.parts where database = currentDatabase() and table = 'test_1m' and active;

--- a/tests/queries/0_stateless/03623_distributed_index_analysis_for_non_shared_merge_tree.sql
+++ b/tests/queries/0_stateless/03623_distributed_index_analysis_for_non_shared_merge_tree.sql
@@ -1,5 +1,5 @@
 drop table if exists test_10m;
-create table test_10m (key Int, value Int) engine=MergeTree() order by key settings distributed_index_analysis_min_parts_to_activate=0, distributed_index_analysis_min_indexes_size_to_activate=0;
+create table test_10m (key Int, value Int) engine=MergeTree() order by key settings distributed_index_analysis_min_parts_to_activate=0, distributed_index_analysis_min_indexes_bytes_to_activate=0;
 insert into test_10m select number, number*100 from numbers(1e6);
 
 set allow_experimental_parallel_reading_from_replicas=0;

--- a/tests/queries/0_stateless/03623_distributed_index_analysis_merge_tree_settings.sql
+++ b/tests/queries/0_stateless/03623_distributed_index_analysis_merge_tree_settings.sql
@@ -4,38 +4,38 @@ set allow_experimental_parallel_reading_from_replicas=0;
 set cluster_for_parallel_replicas='test_cluster_one_shard_two_replicas';
 
 drop table if exists dist_idx;
-create table dist_idx (key Int, value Int) engine=MergeTree() order by key settings distributed_index_analysis_min_parts_to_activate=0, distributed_index_analysis_min_indexes_size_to_activate=0;
+create table dist_idx (key Int, value Int) engine=MergeTree() order by key settings distributed_index_analysis_min_parts_to_activate=0, distributed_index_analysis_min_indexes_bytes_to_activate=0;
 insert into dist_idx select number, number*100 from numbers(1e6);
 select sum(key) from dist_idx settings distributed_index_analysis=1 format Null;
 drop table dist_idx;
 
 drop table if exists no_dist_idx_not_enough_indexes;
-create table no_dist_idx_not_enough_indexes (key Int, value Int) engine=MergeTree() order by key settings distributed_index_analysis_min_parts_to_activate=0, distributed_index_analysis_min_indexes_size_to_activate=1e12;
+create table no_dist_idx_not_enough_indexes (key Int, value Int) engine=MergeTree() order by key settings distributed_index_analysis_min_parts_to_activate=0, distributed_index_analysis_min_indexes_bytes_to_activate=1e12;
 insert into no_dist_idx_not_enough_indexes select number, number*100 from numbers(1e6);
 select sum(key) from no_dist_idx_not_enough_indexes settings distributed_index_analysis=1 format Null;
 drop table no_dist_idx_not_enough_indexes;
 
 drop table if exists no_dist_idx_min_not_enough_parts;
-create table no_dist_idx_min_not_enough_parts (key Int, value Int) engine=MergeTree() order by key settings distributed_index_analysis_min_parts_to_activate=1e9, distributed_index_analysis_min_indexes_size_to_activate=0;
+create table no_dist_idx_min_not_enough_parts (key Int, value Int) engine=MergeTree() order by key settings distributed_index_analysis_min_parts_to_activate=1e9, distributed_index_analysis_min_indexes_bytes_to_activate=0;
 insert into no_dist_idx_min_not_enough_parts select number, number*100 from numbers(1e6);
 select sum(key) from no_dist_idx_min_not_enough_parts settings distributed_index_analysis=1 format Null;
 drop table no_dist_idx_min_not_enough_parts;
 
 drop table if exists no_dist_idx;
-create table no_dist_idx (key Int, value Int) engine=MergeTree() order by key settings distributed_index_analysis_min_parts_to_activate=1e9, distributed_index_analysis_min_indexes_size_to_activate=1e12;
+create table no_dist_idx (key Int, value Int) engine=MergeTree() order by key settings distributed_index_analysis_min_parts_to_activate=1e9, distributed_index_analysis_min_indexes_bytes_to_activate=1e12;
 insert into no_dist_idx select number, number*100 from numbers(1e6);
 select sum(key) from no_dist_idx settings distributed_index_analysis=1 format Null;
 drop table no_dist_idx;
 
 drop table if exists dist_idx_parts;
-create table dist_idx_parts (key Int, value Int) engine=MergeTree() order by key settings merge_selector_base=1000, index_granularity=8192, min_bytes_for_wide_part=1e9, index_granularity_bytes=10e6, distributed_index_analysis_min_parts_to_activate=10, distributed_index_analysis_min_indexes_size_to_activate=0;
+create table dist_idx_parts (key Int, value Int) engine=MergeTree() order by key settings merge_selector_base=1000, index_granularity=8192, min_bytes_for_wide_part=1e9, index_granularity_bytes=10e6, distributed_index_analysis_min_parts_to_activate=10, distributed_index_analysis_min_indexes_bytes_to_activate=0;
 system stop merges dist_idx_parts;
 insert into dist_idx_parts select number, number*100 from numbers(1e6) settings max_block_size=10000, min_insert_block_size_rows=10000, max_insert_threads=1;
 select sum(key) from dist_idx_parts settings distributed_index_analysis=1 format Null;
 drop table dist_idx_parts;
 
 drop table if exists dist_idx_pk_size;
-create table dist_idx_pk_size (key String, value String) engine=MergeTree() order by (key, value) settings index_granularity=200, min_bytes_for_wide_part=0, index_granularity_bytes=10e6, distributed_index_analysis_min_parts_to_activate=0, distributed_index_analysis_min_indexes_size_to_activate=500e3, compress_primary_key=0;
+create table dist_idx_pk_size (key String, value String) engine=MergeTree() order by (key, value) settings index_granularity=200, min_bytes_for_wide_part=0, index_granularity_bytes=10e6, distributed_index_analysis_min_parts_to_activate=0, distributed_index_analysis_min_indexes_bytes_to_activate=500e3, compress_primary_key=0;
 system stop merges dist_idx_pk_size;
 insert into dist_idx_pk_size select number::String, repeat('a', 100) from numbers(1e6);
 select table, sum(primary_key_size) from system.parts where database = currentDatabase() AND table = 'dist_idx_pk_size' group by 1;
@@ -43,7 +43,7 @@ select key from dist_idx_pk_size settings distributed_index_analysis=1 format Nu
 drop table dist_idx_pk_size;
 
 drop table if exists dist_idx_skipping_idx_size;
-create table dist_idx_skipping_idx_size (key String, value String, index key_val_idx (key, value) type set(100000)) engine=MergeTree() settings index_granularity=100000, min_bytes_for_wide_part=0, index_granularity_bytes=10e6, distributed_index_analysis_min_parts_to_activate=0, distributed_index_analysis_min_indexes_size_to_activate='10M';
+create table dist_idx_skipping_idx_size (key String, value String, index key_val_idx (key, value) type set(100000)) engine=MergeTree() settings index_granularity=100000, min_bytes_for_wide_part=0, index_granularity_bytes=10e6, distributed_index_analysis_min_parts_to_activate=0, distributed_index_analysis_min_indexes_bytes_to_activate='10M';
 system stop merges dist_idx_skipping_idx_size;
 insert into dist_idx_skipping_idx_size select number::String, repeat('a', 100) from numbers(1e6);
 select table, sum(data_uncompressed_bytes) from system.data_skipping_indices where database = currentDatabase() AND table = 'dist_idx_skipping_idx_size' group by 1;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changes
- Rename `distributed_index_analysis_min_indexes_size_to_activate` to `distributed_index_analysis_min_indexes_bytes_to_activate`
- Mark `distributed_index_analysis_*` `MergeTree` settings as **experimental**

Reported-by: @rschu1ze


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.596`
<!-- ch-version-info:end -->