### PR TITLE
Fix `prlimit` memory limit for `qemu-x86_64-static` in tests

### DIFF
--- a/tests/queries/0_stateless/01103_check_cpu_instructions_at_startup.sh
+++ b/tests/queries/0_stateless/01103_check_cpu_instructions_at_startup.sh
@@ -21,7 +21,7 @@ function run_with_cpu()
 {
     # Limit memory to 1 GB to fail fast if a sanitized binary is run under QEMU
     # Use --data instead of -m because RLIMIT_RSS does not work since Linux 2.6.x
-    prlimit --data=1000000000 qemu-x86_64-static -cpu "$@" "$command" --query "SELECT 1" 2>&1 | \
+    prlimit --data=5000000000 qemu-x86_64-static -cpu "$@" "$command" --query "SELECT 1" 2>&1 | \
       grep -v -F "warning: TCG doesn't support requested feature" | \
       grep -v -F 'Unknown host IFA type' ||:
 }

--- a/tests/queries/0_stateless/01103_check_cpu_instructions_at_startup.sh
+++ b/tests/queries/0_stateless/01103_check_cpu_instructions_at_startup.sh
@@ -20,7 +20,8 @@ fi
 function run_with_cpu()
 {
     # Limit memory to 1 GB to fail fast if a sanitized binary is run under QEMU
-    prlimit -m1000000 qemu-x86_64-static -cpu "$@" "$command" --query "SELECT 1" 2>&1 | \
+    # Use --data instead of -m because RLIMIT_RSS does not work since Linux 2.6.x
+    prlimit --data=1000000000 qemu-x86_64-static -cpu "$@" "$command" --query "SELECT 1" 2>&1 | \
       grep -v -F "warning: TCG doesn't support requested feature" | \
       grep -v -F 'Unknown host IFA type' ||:
 }

--- a/tests/queries/0_stateless/03590_simdjson_fallback.sh
+++ b/tests/queries/0_stateless/03590_simdjson_fallback.sh
@@ -14,4 +14,5 @@ fi
 command=$(command -v ${CLICKHOUSE_LOCAL})
 # Limit memory to 1 GB to fail fast if a sanitized binary is run under QEMU
 # (sanitized binaries try to allocate ~20 TiB of virtual memory for shadow memory)
-prlimit -m1000000 qemu-x86_64-static -cpu qemu64,+ssse3,+sse4.1,+sse4.2,+popcnt "$command" --allow_simdjson=1 "select JSONExtractRaw('{\"foo\": 1}', 'foo')"
+# Use --data instead of -m because RLIMIT_RSS does not work since Linux 2.6.x
+prlimit --data=1000000000 qemu-x86_64-static -cpu qemu64,+ssse3,+sse4.1,+sse4.2,+popcnt "$command" --allow_simdjson=1 "select JSONExtractRaw('{\"foo\": 1}', 'foo')"

--- a/tests/queries/0_stateless/03590_simdjson_fallback.sh
+++ b/tests/queries/0_stateless/03590_simdjson_fallback.sh
@@ -15,4 +15,4 @@ command=$(command -v ${CLICKHOUSE_LOCAL})
 # Limit memory to 1 GB to fail fast if a sanitized binary is run under QEMU
 # (sanitized binaries try to allocate ~20 TiB of virtual memory for shadow memory)
 # Use --data instead of -m because RLIMIT_RSS does not work since Linux 2.6.x
-prlimit --data=1000000000 qemu-x86_64-static -cpu qemu64,+ssse3,+sse4.1,+sse4.2,+popcnt "$command" --allow_simdjson=1 "select JSONExtractRaw('{\"foo\": 1}', 'foo')"
+prlimit --data=5000000000 qemu-x86_64-static -cpu qemu64,+ssse3,+sse4.1,+sse4.2,+popcnt "$command" --allow_simdjson=1 "select JSONExtractRaw('{\"foo\": 1}', 'foo')"


### PR DESCRIPTION
`prlimit -m` sets `RLIMIT_RSS`, which has been a no-op on Linux since 2.6.x (the kernel ignores it). This is already documented in our own build scripts (`cmake/heavy_build_check_scripts/prlimit_generic.sh`).

Replace with `--data` (`RLIMIT_DATA`), which since Linux 4.7 also limits `mmap` anonymous private mappings, making it effective.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=9e5869ea3a97679235c424b43ea6b16955ec73ac&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_tsan%2C%20s3%20storage%2C%20parallel%2C%202%2F2%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.576`
<!-- ch-version-info:end -->