### PR TITLE
Implement equivalent sets optimization for multiple joins

### DIFF
--- a/src/Interpreters/JoinExpressionActions.cpp
+++ b/src/Interpreters/JoinExpressionActions.cpp
@@ -401,6 +401,13 @@ bool JoinActionRef::fromNone() const
     return getSourceRelations().none();
 }
 
+bool JoinActionRef::isFromSameActions(const JoinActionRef & other) const
+{
+    auto data_ptr = getData();
+    auto other_data_ptr = other.getData();
+    return data_ptr.get() == other_data_ptr.get();
+}
+
 std::tuple<JoinConditionOperator, JoinActionRef, JoinActionRef> JoinActionRef::asBinaryPredicate() const
 {
     auto data_ptr = getData();

--- a/src/Interpreters/JoinExpressionActions.h
+++ b/src/Interpreters/JoinExpressionActions.h
@@ -227,6 +227,7 @@ public:
     bool fromLeft() const;
     bool fromRight() const;
     bool fromNone() const;
+    bool isFromSameActions(const JoinActionRef & other) const;
 
     bool isFunction(JoinConditionOperator op) const;
     std::tuple<JoinConditionOperator, JoinActionRef, JoinActionRef> asBinaryPredicate() const;

--- a/src/Processors/QueryPlan/JoinStepLogical.cpp
+++ b/src/Processors/QueryPlan/JoinStepLogical.cpp
@@ -1484,6 +1484,15 @@ JoinStepLogical::preCalculateKeys(const SharedHeader & left_header, const Shared
     });
 }
 
+std::vector<JoinActionRef> JoinStepLogical::getInputActions() const
+{
+    std::vector<JoinActionRef> input_actions;
+    const auto & raw_inputs = expression_actions.getActionsDAG()->getInputs();
+    for (const auto * node : raw_inputs)
+        input_actions.emplace_back(node, expression_actions);
+    return input_actions;
+}
+
 
 std::vector<JoinActionRef> JoinStepLogical::getOutputActions() const
 {

--- a/src/Processors/QueryPlan/JoinStepLogical.h
+++ b/src/Processors/QueryPlan/JoinStepLogical.h
@@ -91,6 +91,7 @@ public:
 
     const ActionsDAG & getActionsDAG() const { return *expression_actions.getActionsDAG(); }
 
+    std::vector<JoinActionRef> getInputActions() const;
     std::vector<JoinActionRef> getOutputActions() const;
 
     std::pair<JoinExpressionActions, JoinOperator> detachExpressions()

--- a/tests/queries/0_stateless/03913_multijoin_equivalent_sets.reference
+++ b/tests/queries/0_stateless/03913_multijoin_equivalent_sets.reference
@@ -1,0 +1,14 @@
+Prewhere filter column: less(__table1.id, 10000_UInt16) (removed)
+Prewhere filter column: less(__table2.id, 10000_UInt16) (removed)
+Prewhere filter column: less(__table3.id, 10000_UInt16) (removed)
+Prewhere filter column: less(__table4.id, 10000_UInt16) (removed)
+Prewhere filter column: less(__table5.id, 10000_UInt16) (removed)
+--
+Prewhere filter column: less(__table1.id, 10000_UInt16) (removed)
+Prewhere filter column: less(__table2.id, 10000_UInt16) (removed)
+Prewhere filter column: less(__table3.id, 10000_UInt16) (removed)
+Prewhere filter column: less(__table4.id, 10000_UInt16) (removed)
+Prewhere filter column: less(__table5.id, 10000_UInt16) (removed)
+--
+Prewhere filter column: less(__table1.id, 10000_UInt16) (removed)
+Prewhere filter column: less(__table2.id, 10000_UInt16) (removed)

--- a/tests/queries/0_stateless/03913_multijoin_equivalent_sets.sql
+++ b/tests/queries/0_stateless/03913_multijoin_equivalent_sets.sql
@@ -1,0 +1,59 @@
+DROP TABLE IF EXISTS t1;
+DROP TABLE IF EXISTS t2;
+DROP TABLE IF EXISTS t3;
+DROP TABLE IF EXISTS t4;
+DROP TABLE IF EXISTS t5;
+
+CREATE TABLE t1 ( id UInt32, `value` String ) ENGINE = MergeTree() ORDER BY id;
+CREATE TABLE t2 ( id UInt32, `value` String ) ENGINE = MergeTree() ORDER BY id;
+CREATE TABLE t3 ( id UInt32, `value` String ) ENGINE = MergeTree() ORDER BY id;
+CREATE TABLE t4 ( id UInt32, `value` String ) ENGINE = MergeTree() ORDER BY id;
+CREATE TABLE t5 ( id UInt32, `value` String ) ENGINE = MergeTree() ORDER BY id;
+
+INSERT INTO t1 SELECT number, toString(number) AS value FROM numbers(100_000);
+INSERT INTO t2 SELECT number, toString(number) AS value FROM numbers(100_000);
+INSERT INTO t3 SELECT number, toString(number) AS value FROM numbers(100_000);
+INSERT INTO t4 SELECT number, toString(number) AS value FROM numbers(100_000);
+INSERT INTO t5 SELECT number, toString(number) AS value FROM numbers(100_000);
+
+SET enable_analyzer = 1;
+SET query_plan_join_swap_table = 0;
+SET query_plan_optimize_join_order_limit = 0;
+SET optimize_move_to_prewhere = 1;
+SET enable_join_runtime_filters = 0;
+SET enable_parallel_replicas = 0;
+
+SELECT trim(explain) FROM (
+    EXPLAIN PLAN actions = 1, keep_logical_steps = 1
+    SELECT * FROM t1
+    JOIN t2 ON t1.id = t2.id
+    JOIN t3 ON t2.id = t3.id
+    JOIN t4 ON t3.id = t4.id
+    JOIN t5 ON t4.id = t5.id
+    WHERE t1.id < 10_000
+) WHERE trim(explain) like '%Prewhere filter column%'
+;
+
+SELECT '--';
+
+SELECT trim(explain) FROM (
+    EXPLAIN PLAN actions = 1, keep_logical_steps = 1
+    SELECT * FROM t1
+    JOIN t2 ON t1.id = t2.id
+    JOIN t3 ON t2.id = t3.id
+    JOIN t4 ON t3.id = t4.id
+    JOIN t5 ON t4.id = t5.id
+    WHERE t5.id < 10_000
+) WHERE trim(explain) like '%Prewhere filter column%'
+;
+
+SELECT '--';
+
+SELECT trim(explain) FROM (
+    EXPLAIN PLAN actions = 1, keep_logical_steps = 1
+    SELECT * FROM t1
+    LEFT JOIN t2 ON t1.id = t2.id
+    JOIN t3 ON t2.id = t3.id
+    WHERE t1.id < 10_000
+) WHERE trim(explain) like '%Prewhere filter column%'
+;


### PR DESCRIPTION
### Changelog category (leave one):

- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

* Implement equivalent sets optimization for multiple joins. Queries with multiple consecutive `INNER JOIN` operations now benefit from improved filter pushdown optimization. When tables are joined on equivalent columns (e.g., `t1 JOIN t2 ON t1.id = t2.id JOIN t3 ON t2.id = t3.id WHERE t1.id > 10`), filters applied to any table in the chain are automatically pushed down to all tables. Close https://github.com/ClickHouse/ClickHouse/issues/96550


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.791`
<!-- ch-version-info:end -->