### PR TITLE
Revert "Revert "Remove unnecessary parentheses in `CREATE TABLE ... AS SELECT ... COMMENT`""

### DIFF
--- a/src/Parsers/ASTCreateQuery.cpp
+++ b/src/Parsers/ASTCreateQuery.cpp
@@ -572,19 +572,17 @@ void ASTCreateQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings & 
         sql_security->format(ostr, settings, state, frame);
     }
 
-    if (select)
-    {
-        ostr << settings.nl_or_ws;
-        ostr << "AS "
-                      << (comment ? "(" : "");
-        select->format(ostr, settings, state, frame);
-        ostr << (comment ? ")" : "");
-    }
-
     if (comment)
     {
         ostr << settings.nl_or_ws << "COMMENT ";
         comment->format(ostr, settings, state, frame);
+    }
+
+    if (select)
+    {
+        ostr << settings.nl_or_ws;
+        ostr << "AS ";
+        select->format(ostr, settings, state, frame);
     }
 }
 

--- a/src/Parsers/ParserCreateQuery.cpp
+++ b/src/Parsers/ParserCreateQuery.cpp
@@ -867,6 +867,8 @@ bool ParserCreateTableQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expe
         return ParserKeyword{Keyword::AS}.ignore(pos, expected);
     };
 
+    ASTPtr comment;
+
     /// List of columns.
     if (s_lparen.ignore(pos, expected))
     {
@@ -882,6 +884,8 @@ bool ParserCreateTableQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expe
             return false;
 
         auto storage_parse_result = parse_storage();
+
+        comment = parseComment(pos, expected);
 
         if ((storage_parse_result || is_temporary) && need_parse_as_select())
         {
@@ -904,6 +908,9 @@ bool ParserCreateTableQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expe
     else
     {
         parse_storage();
+
+        if (!comment)
+            comment = parseComment(pos, expected);
 
         /// CREATE|ATTACH TABLE ... AS ...
         if (need_parse_as_select())
@@ -932,7 +939,8 @@ bool ParserCreateTableQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expe
         }
     }
 
-    auto comment = parseComment(pos, expected);
+    if (!comment)
+        comment = parseComment(pos, expected);
 
     auto query = make_intrusive<ASTCreateQuery>();
     node = query;
@@ -1164,6 +1172,8 @@ bool ParserCreateWindowViewQuery::parseImpl(Pos & pos, ASTPtr & node, Expected &
     else if (s_empty.ignore(pos, expected))
         is_create_empty = true;
 
+    auto comment = parseComment(pos, expected);
+
     /// AS SELECT ...
     if (!s_as.ignore(pos, expected))
         return false;
@@ -1171,7 +1181,8 @@ bool ParserCreateWindowViewQuery::parseImpl(Pos & pos, ASTPtr & node, Expected &
     if (!select_p.parse(pos, select, expected))
         return false;
 
-    auto comment = parseComment(pos, expected);
+    if (!comment)
+        comment = parseComment(pos, expected);
 
     auto query = make_intrusive<ASTCreateQuery>();
     node = query;
@@ -1610,6 +1621,8 @@ bool ParserCreateViewQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
     if (!sql_security)
         sql_security_p.parse(pos, sql_security, expected);
 
+    auto comment = parseComment(pos, expected);
+
     /// AS SELECT ...
     if (!s_as.ignore(pos, expected))
         return false;
@@ -1617,7 +1630,8 @@ bool ParserCreateViewQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
     if (!select_p.parse(pos, select, expected))
         return false;
 
-    auto comment = parseComment(pos, expected);
+    if (!comment)
+        comment = parseComment(pos, expected);
 
     auto query = make_intrusive<ASTCreateQuery>();
     node = query;

--- a/tests/queries/0_stateless/03142_alter_comment_parameterized_view.reference
+++ b/tests/queries/0_stateless/03142_alter_comment_parameterized_view.reference
@@ -1,1 +1,1 @@
-CREATE VIEW default.test_table_comment AS (SELECT toString({date_from:String})) COMMENT \'test comment\'
+CREATE VIEW default.test_table_comment COMMENT \'test comment\' AS SELECT toString({date_from:String})


### PR DESCRIPTION
Reverts ClickHouse/ClickHouse#96595


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.629`
<!-- ch-version-info:end -->