### PR TITLE
Fix socket timeout handling with proper EINTR tracking

### DIFF
--- a/base/poco/Net/include/Poco/Net/SocketDefs.h
+++ b/base/poco/Net/include/Poco/Net/SocketDefs.h
@@ -128,12 +128,6 @@ extern "C" {
 #    define POCO_HAVE_ADDRINFO 1
 #endif
 
-/// Without this option, Poco library will restart recv after EINTR,
-/// but it doesn't update socket receive timeout that leads to infinite wait
-/// when query profiler is activated. The issue persisted in delayed_replica_failover
-/// integration test after we enabled query profiler by default.
-#define POCO_BROKEN_TIMEOUTS 1
-
 
 #if defined(POCO_HAVE_ADDRINFO)
 #    ifndef AI_PASSIVE

--- a/base/poco/Net/include/Poco/Net/SocketImpl.h
+++ b/base/poco/Net/include/Poco/Net/SocketImpl.h
@@ -484,7 +484,6 @@ namespace Net
         Poco::Timespan _recvTimeout;
         Poco::Timespan _sndTimeout;
         bool _blocking;
-        bool _isBrokenTimeout;
 
         static constexpr size_t THROTTLER_QUANTUM = 32 * 1024;
         static constexpr size_t THROTTLER_MAX_BLOCK_NS = 20'000'000'000ull;


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Improves CPU and real-time profiler interoperability with socket timeouts.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


Replace the POCO_BROKEN_TIMEOUTS workaround with proper elapsed time tracking in SocketImpl I/O functions (sendBytes, receiveBytes, sendTo, receiveFrom).

Problem: When signals (e.g., CPU profiler) interrupt blocking send/recv, the syscall returns EINTR. Simply retrying restarts the kernel's SO_SNDTIMEO/SO_RCVTIMEO timer, making timeouts ineffective - operations could block indefinitely.

Solution: Track elapsed time manually and use poll() with remaining timeout before each syscall attempt. This ensures total wait time respects configured timeout regardless of EINTR interruptions.

Changes:
- Remove POCO_BROKEN_TIMEOUTS macro and _isBrokenTimeout member
- Add remainingTime tracking with Poco::Timespan in each I/O function
- Use pollImpl() with decreasing timeout on EINTR retries
- Simplify getSendTimeout/getReceiveTimeout to return stored values

cc @CheSema 


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.637`
<!-- ch-version-info:end -->