### PR TITLE
Reduce excessive debug logging in skip indices and statistics serialization

### DIFF
--- a/src/Storages/MergeTree/MergeTreeDataPartWriterOnDisk.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterOnDisk.cpp
@@ -377,8 +377,47 @@ void MergeTreeDataPartWriterOnDisk::finishStatisticsSerialization(bool sync)
             stream->sync();
     }
 
-    for (size_t i = 0; i < stats.size(); ++i)
-        LOG_DEBUG(log, "Spent {} ms calculating statistics {} for the part {}", execution_stats.statistics_build_us[i] / 1000, stats[i]->getColumnName(), data_part_name);
+    if (!stats.empty() && log->is(Poco::Message::PRIO_DEBUG))
+    {
+        UInt64 total_us = 0;
+        std::string stats_str;
+
+        /// Create pairs of (index, time_us) for sorting
+        std::vector<std::pair<size_t, UInt64>> stat_times;
+        stat_times.reserve(stats.size());
+
+        for (size_t i = 0; i < stats.size(); ++i)
+        {
+            stat_times.emplace_back(i, execution_stats.statistics_build_us[i]);
+            total_us += execution_stats.statistics_build_us[i];
+        }
+
+        /// If there are many statistics, show only the slowest ones
+        constexpr size_t max_stats_to_show = 10;
+        if (stats.size() > max_stats_to_show)
+        {
+            std::partial_sort(
+                stat_times.begin(),
+                stat_times.begin() + max_stats_to_show,
+                stat_times.end(),
+                [](const auto & a, const auto & b) { return a.second > b.second; });
+            stat_times.resize(max_stats_to_show);
+        }
+
+        for (size_t i = 0; i < stat_times.size(); ++i)
+        {
+            if (i > 0)
+                stats_str += ", ";
+            auto [idx, time_us] = stat_times[i];
+            stats_str += fmt::format("{}: {} ms", stats[idx]->getColumnName(), time_us / 1000);
+        }
+
+        if (stats.size() > max_stats_to_show)
+            stats_str += fmt::format(" (showing {} slowest out of {})", max_stats_to_show, stats.size());
+
+        LOG_DEBUG(
+            log, "Spent {} ms calculating {} statistics for the part {}: [{}]", total_us / 1000, stats.size(), data_part_name, stats_str);
+    }
 }
 
 void MergeTreeDataPartWriterOnDisk::fillStatisticsChecksums(MergeTreeData::DataPart::Checksums & checksums)
@@ -401,8 +440,52 @@ void MergeTreeDataPartWriterOnDisk::finishSkipIndicesSerialization(bool sync)
             stream->sync();
     }
 
-    for (size_t i = 0; i < skip_indices.size(); ++i)
-        LOG_DEBUG(log, "Spent {} ms calculating index {} for the part {}", execution_stats.skip_indices_build_us[i] / 1000, skip_indices[i]->index.name, data_part_name);
+    if (!skip_indices.empty() && log->is(Poco::Message::PRIO_DEBUG))
+    {
+        UInt64 total_us = 0;
+        std::string indices_str;
+
+        /// Create pairs of (index, time_us) for sorting
+        std::vector<std::pair<size_t, UInt64>> index_times;
+        index_times.reserve(skip_indices.size());
+
+        for (size_t i = 0; i < skip_indices.size(); ++i)
+        {
+            index_times.emplace_back(i, execution_stats.skip_indices_build_us[i]);
+            total_us += execution_stats.skip_indices_build_us[i];
+        }
+
+        /// If there are many indices, show only the slowest ones
+        constexpr size_t max_indices_to_show = 10;
+        if (skip_indices.size() > max_indices_to_show)
+        {
+            std::partial_sort(
+                index_times.begin(),
+                index_times.begin() + max_indices_to_show,
+                index_times.end(),
+                [](const auto & a, const auto & b) { return a.second > b.second; });
+            index_times.resize(max_indices_to_show);
+        }
+
+        for (size_t i = 0; i < index_times.size(); ++i)
+        {
+            if (i > 0)
+                indices_str += ", ";
+            auto [idx, time_us] = index_times[i];
+            indices_str += fmt::format("{}: {} ms", skip_indices[idx]->index.name, time_us / 1000);
+        }
+
+        if (skip_indices.size() > max_indices_to_show)
+            indices_str += fmt::format(" (showing {} slowest out of {})", max_indices_to_show, skip_indices.size());
+
+        LOG_DEBUG(
+            log,
+            "Spent {} ms calculating {} skip indices for the part {}: [{}]",
+            total_us / 1000,
+            skip_indices.size(),
+            data_part_name,
+            indices_str);
+    }
 
     skip_indices_streams.clear();
     skip_indices_streams_holders.clear();


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Reduce excessive debug logging in skip indices and statistics serialization

With implicit indices you started to see too many messages about indices materialization, since many columns would have them:

```
2026.02.10 20:44:05.247624 [ 37538 ] {} <Debug> system.zookeeper_log (ba780dc6-0f37-4e0e-9cfb-8636646af90b) (DataPartWriter): Spent 0 ms calculating index auto_minmax_index_thread_id for the part 1770750000_113_113_0
2026.02.10 20:44:05.247630 [ 37538 ] {} <Debug> system.zookeeper_log (ba780dc6-0f37-4e0e-9cfb-8636646af90b) (DataPartWriter): Spent 0 ms calculating index auto_minmax_index_port for the part 1770750000_113_113_0
2026.02.10 20:44:05.247631 [ 37538 ] {} <Debug> system.zookeeper_log (ba780dc6-0f37-4e0e-9cfb-8636646af90b) (DataPartWriter): Spent 0 ms calculating index auto_minmax_index_session_id for the part 1770750000_113_113_0
2026.02.10 20:44:05.247632 [ 37538 ] {} <Debug> system.zookeeper_log (ba780dc6-0f37-4e0e-9cfb-8636646af90b) (DataPartWriter): Spent 0 ms calculating index auto_minmax_index_duration_microseconds for the part 1770750000_113_113_0
2026.02.10 20:44:05.247634 [ 37538 ] {} <Debug> system.zookeeper_log (ba780dc6-0f37-4e0e-9cfb-8636646af90b) (DataPartWriter): Spent 0 ms calculating index auto_minmax_index_xid for the part 1770750000_113_113_0
2026.02.10 20:44:05.247635 [ 37538 ] {} <Debug> system.zookeeper_log (ba780dc6-0f37-4e0e-9cfb-8636646af90b) (DataPartWriter): Spent 0 ms calculating index auto_minmax_index_has_watch for the part 1770750000_113_113_0
2026.02.10 20:44:05.247636 [ 37538 ] {} <Debug> system.zookeeper_log (ba780dc6-0f37-4e0e-9cfb-8636646af90b) (DataPartWriter): Spent 0 ms calculating index auto_minmax_index_is_ephemeral for the part 1770750000_113_113_0
2026.02.10 20:44:05.247637 [ 37538 ] {} <Debug> system.zookeeper_log (ba780dc6-0f37-4e0e-9cfb-8636646af90b) (DataPartWriter): Spent 0 ms calculating index auto_minmax_index_is_sequential for the part 1770750000_113_113_0
2026.02.10 20:44:05.247638 [ 37538 ] {} <Debug> system.zookeeper_log (ba780dc6-0f37-4e0e-9cfb-8636646af90b) (DataPartWriter): Spent 0 ms calculating index auto_minmax_index_requests_size for the part 1770750000_113_113_0
2026.02.10 20:44:05.247639 [ 37538 ] {} <Debug> system.zookeeper_log (ba780dc6-0f37-4e0e-9cfb-8636646af90b) (DataPartWriter): Spent 0 ms calculating index auto_minmax_index_request_idx for the part 1770750000_113_113_0
2026.02.10 20:44:05.247640 [ 37538 ] {} <Debug> system.zookeeper_log (ba780dc6-0f37-4e0e-9cfb-8636646af90b) (DataPartWriter): Spent 0 ms calculating index auto_minmax_index_zxid for the part 1770750000_113_113_0
2026.02.10 20:44:05.247641 [ 37538 ] {} <Debug> system.zookeeper_log (ba780dc6-0f37-4e0e-9cfb-8636646af90b) (DataPartWriter): Spent 0 ms calculating index auto_minmax_index_stat_czxid for the part 1770750000_113_113_0
2026.02.10 20:44:05.247642 [ 37538 ] {} <Debug> system.zookeeper_log (ba780dc6-0f37-4e0e-9cfb-8636646af90b) (DataPartWriter): Spent 0 ms calculating index auto_minmax_index_stat_mzxid for the part 1770750000_113_113_0
2026.02.10 20:44:05.247643 [ 37538 ] {} <Debug> system.zookeeper_log (ba780dc6-0f37-4e0e-9cfb-8636646af90b) (DataPartWriter): Spent 0 ms calculating index auto_minmax_index_stat_pzxid for the part 1770750000_113_113_0
2026.02.10 20:44:05.247645 [ 37538 ] {} <Debug> system.zookeeper_log (ba780dc6-0f37-4e0e-9cfb-8636646af90b) (DataPartWriter): Spent 0 ms calculating index auto_minmax_index_stat_version for the part 1770750000_113_113_0
2026.02.10 20:44:05.247646 [ 37538 ] {} <Debug> system.zookeeper_log (ba780dc6-0f37-4e0e-9cfb-8636646af90b) (DataPartWriter): Spent 0 ms calculating index auto_minmax_index_stat_cversion for the part 1770750000_113_113_0
2026.02.10 20:44:05.247647 [ 37538 ] {} <Debug> system.zookeeper_log (ba780dc6-0f37-4e0e-9cfb-8636646af90b) (DataPartWriter): Spent 0 ms calculating index auto_minmax_index_stat_dataLength for the part 1770750000_113_113_0
2026.02.10 20:44:05.247649 [ 37538 ] {} <Debug> system.zookeeper_log (ba780dc6-0f37-4e0e-9cfb-8636646af90b) (DataPartWriter): Spent 0 ms calculating index auto_minmax_index_stat_numChildren for the part 1770750000_113_113_0
```

Instead now we'll group them into a single message and show, at most, the top 10 slowest ones:
```
2026.02.10 20:49:12.658494 [ 86306 ] {77caeccf-db0b-4c74-949a-1f40790da376::20260208_34_215_40} <Debug> system.query_log (77caeccf-db0b-4c74-949a-1f40790da376) (DataPartWriter): Spent 0 ms calculating 27 skip indices for the part 20260208_34_215_40: [auto_minmax_index_query_duration_ms: 0 ms, auto_minmax_index_result_rows: 0 ms, auto_minmax_index_result_bytes: 0 ms, auto_minmax_index_normalized_query_hash: 0 ms, auto_minmax_index_read_bytes: 0 ms, auto_minmax_index_exception_code: 0 ms, auto_minmax_index_written_bytes: 0 ms, auto_minmax_index_read_rows: 0 ms, auto_minmax_index_written_rows: 0 ms, auto_minmax_index_memory_usage: 0 ms (showing 10 slowest out of 27)]
```

Doing the same for statistics since I expect a similar issue will happen once they are on by default

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.554`
<!-- ch-version-info:end -->