### PR TITLE
Fix data race on DROP WORKLOAD

### DIFF
--- a/src/Common/Scheduler/ISchedulerNode.h
+++ b/src/Common/Scheduler/ISchedulerNode.h
@@ -328,6 +328,8 @@ public:
     void enqueueActivation(ISchedulerNode * node)
     {
         std::unique_lock lock{mutex};
+        if (node->is_linked()) // already scheduled
+            return;
         bool was_empty = events.empty() && activations.empty();
         node->activation_event_id = ++last_event_id;
         activations.push_back(*node);

--- a/src/Common/Scheduler/Nodes/tests/ResourceTest.h
+++ b/src/Common/Scheduler/Nodes/tests/ResourceTest.h
@@ -114,6 +114,12 @@ class ResourceTestClass : public ResourceTestBase
         }
     };
 
+    EventQueue event_queue;
+    EventQueue::SchedulerThread scheduler_thread{&event_queue};
+    SchedulerNodePtr root_node;
+    std::unordered_map<String, ResourceCost> consumed_cost;
+    ResourceCost failed_cost = 0;
+
 public:
     ~ResourceTestClass()
     {
@@ -281,12 +287,6 @@ public:
     {
         while (event_queue.tryProcess()) {}
     }
-
-private:
-    EventQueue event_queue;
-    SchedulerNodePtr root_node;
-    std::unordered_map<String, ResourceCost> consumed_cost;
-    ResourceCost failed_cost = 0;
 };
 
 enum EnqueueOnlyEnum { EnqueueOnly };

--- a/src/Common/Scheduler/Nodes/tests/gtest_event_queue.cpp
+++ b/src/Common/Scheduler/Nodes/tests/gtest_event_queue.cpp
@@ -1,4 +1,5 @@
 #include <chrono>
+#include <thread>
 #include <gtest/gtest.h>
 
 #include <Common/Scheduler/ISchedulerNode.h>
@@ -146,4 +147,90 @@ TEST(SchedulerEventQueue, Smoke)
     t.event("E2");
     t.activate(node2);
     t.process(start + 300s, " E1 A1 E2 A2");
+}
+
+// Test for data race between processActivation() and cancelActivation() during node destruction.
+// Original race from TSAN:
+// - Thread 1 (scheduler): activateChild() writes to child_active
+// - Thread 2 (destroyer): removeChild() writes to child_active
+// Fix: cancelActivation() must wait for any in-progress activateChild() to complete.
+// Any code that modifies state accessed by activateChild must call cancelActivation() first.
+TEST(SchedulerEventQueue, ActivationCancelRace)
+{
+    constexpr int iterations = 1000;
+
+    for (int i = 0; i < iterations; ++i)
+    {
+        String log;
+        EventQueue event_queue;
+
+        std::atomic<bool> race_detected{false};
+        std::atomic<bool> child_active{false};
+        std::atomic<bool> in_activate_child{false};
+
+        // Parent node that simulates the race scenario
+        struct RaceDetectorNode : public FakeSchedulerNode
+        {
+            std::atomic<bool> & race;
+            std::atomic<bool> & active;
+            std::atomic<bool> & in_activate;
+
+            RaceDetectorNode(String & log_, EventQueue * eq,
+                             std::atomic<bool> & r, std::atomic<bool> & a, std::atomic<bool> & ia)
+                : FakeSchedulerNode(log_, eq), race(r), active(a), in_activate(ia) {}
+
+            void activateChild(ISchedulerNode *) override
+            {
+                in_activate.store(true, std::memory_order_release);
+                // Simulate some work to widen the race window
+                std::this_thread::yield();
+                active.store(true, std::memory_order_relaxed); // Like UnifiedSchedulerNode::activateChild
+                in_activate.store(false, std::memory_order_release);
+            }
+        };
+
+        RaceDetectorNode root_node(log, &event_queue, race_detected, child_active, in_activate_child);
+
+        std::atomic<bool> stop{false};
+
+        // Scheduler thread - processes activations
+        std::thread processor([&]
+        {
+            while (!stop.load(std::memory_order_relaxed))
+                event_queue.tryProcess();
+            while (event_queue.tryProcess()) {}
+        });
+
+        // Create nodes and simulate the race scenario
+        for (int j = 0; j < 50; ++j)
+        {
+            child_active.store(false, std::memory_order_relaxed);
+
+            auto node = std::make_shared<FakeSchedulerNode>(log, &event_queue);
+            node->basename = std::to_string(j);
+            node->setParent(&root_node);
+            event_queue.enqueueActivation(node.get());
+
+            // Simulate what a correct removeChild should do:
+            // 1. First cancel activation and wait for any in-progress activateChild
+            event_queue.cancelActivation(node.get());
+
+            // 2. Now check if activateChild is still running - it shouldn't be!
+            if (in_activate_child.load(std::memory_order_acquire))
+                race_detected.store(true, std::memory_order_release);
+
+            // 3. Now safe to modify child_active (like removeChild does)
+            child_active.store(false, std::memory_order_relaxed);
+
+            node->setParent(nullptr); // detach (calls cancelActivation again, which is idempotent)
+        }
+
+        stop.store(true, std::memory_order_relaxed);
+        processor.join();
+
+        // With the fix: after cancelActivation() returns, activateChild() is guaranteed
+        // to have completed, so in_activate_child should never be true at that point
+        EXPECT_FALSE(race_detected.load())
+            << "activateChild() was still in progress after cancelActivation() returned";
+    }
 }

--- a/src/Common/Scheduler/SchedulerRoot.h
+++ b/src/Common/Scheduler/SchedulerRoot.h
@@ -80,6 +80,8 @@ public:
             scheduler.join();
             if (graceful)
             {
+                // Attach to event queue for graceful shutdown processing
+                EventQueue::SchedulerThread scheduler_thread(&events);
                 // Do the same cycle as schedulerThread() but never block or wait postponed events
                 bool has_work = true;
                 while (has_work)
@@ -235,6 +237,7 @@ private:
     void schedulerThread(ThreadName name)
     {
         DB::setThreadName(name);
+        EventQueue::SchedulerThread scheduler_thread(&events);
 
         while (!stop_flag.load())
         {


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixes a datarace on DROP WORKLOAD

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

The race occurred when:
1. processActivation() dequeued a node and released queue mutex
2. cancelActivation() acquired mutex, saw node not linked, released mutex, acquired/released activation_mutex, and returned
3. processActivation() then called activateChild() on a node that was being destroyed

Fix: Acquire activation_mutex (newly introduced) BEFORE releasing queue mutex in processActivation(). This ensures cancelActivation() blocks until activateChild() completes, preventing use-after-free.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.694`
<!-- ch-version-info:end -->