### PR TITLE
Fix infinite retry loop in `doRestartReplica` that kills the server

### DIFF
--- a/src/Interpreters/InterpreterSystemQuery.cpp
+++ b/src/Interpreters/InterpreterSystemQuery.cpp
@@ -72,6 +72,7 @@
 #include <Common/getRandomASCIIString.h>
 #include <Common/logger_useful.h>
 #include <Common/typeid_cast.h>
+#include <base/sleep.h>
 
 #if USE_PROTOBUF
 #include <Formats/ProtobufSchemas.h>
@@ -1139,11 +1140,21 @@ StoragePtr InterpreterSystemQuery::doRestartReplica(const StorageID & replica, C
 
             break;
         }
-        catch (...)
+        catch (const Coordination::Exception & e)
         {
+            /// Only retry on transient ZooKeeper errors (connection loss, session expired, etc.)
+            if (!Coordination::isHardwareError(e.code))
+                throw;
+
             tryLogCurrentException(
                 getLogger("InterpreterSystemQuery"),
                 fmt::format("Failed to restart replica {}, will retry", replica.getNameForLogs()));
+
+            /// Check if the query was cancelled (e.g. server is shutting down)
+            if (auto process_list_element = getContext()->getProcessListElementSafe())
+                process_list_element->checkTimeLimit();
+
+            sleepForSeconds(1);
         }
     }
 


### PR DESCRIPTION
The `while (true)` loop in `doRestartReplica` caught all exceptions and retried immediately with no delay and no cancellation check. When a table had a pathological sorting key (e.g. created by a fuzzer), `StorageFactory::get` threw `TOO_DEEP_RECURSION` on every attempt, causing a tight infinite loop (260K+ retries observed) that consumed the server until it died.

Fix: catch only `Coordination::Exception` with transient hardware errors (connection loss, session expired), which are the only errors that make sense to retry. All other exceptions now propagate. Also add a `checkTimeLimit` call for query cancellation and a 1-second sleep between retries.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=1b6c6730432876e520dd676cb2451f2f01752c60&name_0=MasterCI&name_1=BuzzHouse%20%28arm_asan%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.555`
<!-- ch-version-info:end -->