### PR TITLE
Fix flaky `test_write_failover` in `test_merge_tree_s3_failover`

### DIFF
--- a/tests/integration/test_merge_tree_s3_failover/test.py
+++ b/tests/integration/test_merge_tree_s3_failover/test.py
@@ -129,7 +129,7 @@ def test_write_failover(
         )
     )
 
-    is_debug_mode = False
+    first_success_request = None
     success_count = 0
 
     for request in range(request_count + debug_request_count + 1):
@@ -137,26 +137,30 @@ def test_write_failover(
         fail_request(cluster, request + 1)
 
         data = "('2020-03-01',0,'data'),('2020-03-01',1,'data')"
-        positive = request >= (
-            request_count + debug_request_count if is_debug_mode else request_count
-        )
         try:
             node.query("INSERT INTO s3_failover_test VALUES {}".format(data))
-            assert positive, "Insert query should be failed, request {}".format(request)
+
+            if first_success_request is None:
+                first_success_request = request
+
+            # INSERT must not succeed too early - all part files must have been written.
+            assert request >= request_count, (
+                "Insert query should have failed, request {} "
+                "(expected at least {} S3 requests)".format(request, request_count)
+            )
             success_count += 1
         except QueryRuntimeException as e:
-            if not is_debug_mode and positive:
-                is_debug_mode = True
-                positive = False
-
-            assert not positive, "Insert query shouldn't be failed, request {}".format(
-                request
+            # INSERT must not fail after it has already succeeded at a lower request number.
+            assert first_success_request is None, (
+                "Insert query shouldn't have failed at request {} "
+                "(first success was at request {})".format(request, first_success_request)
             )
+
             assert str(e).find("Expected Error") != -1, "Unexpected error {}".format(
                 str(e)
             )
 
-        if positive:
+        if first_success_request is not None:
             # Disable request failing.
             fail_request(cluster, 0)
 
@@ -166,9 +170,15 @@ def test_write_failover(
                 or node.query("SELECT * FROM s3_failover_test FORMAT Values") == data
             )
 
-    assert success_count == (
-        1 if is_debug_mode else debug_request_count + 1
-    ), "Insert query should be successful at least once"
+    assert first_success_request is not None, (
+        "Insert query should have succeeded at least once"
+    )
+    assert first_success_request <= request_count + debug_request_count, (
+        "Insert query succeeded too late at request {}, "
+        "expected at most {} S3 requests".format(
+            first_success_request, request_count + debug_request_count
+        )
+    )
 
 
 # Check that second data part move is ended successfully if first attempt was failed.


### PR DESCRIPTION
The test was fragile because it assumed the total number of S3 requests during an INSERT is exactly `request_count` (non-debug) or `request_count + debug_request_count` (debug). In some CI environments (e.g., ASan builds), there can be a slightly different number of S3 requests due to background operations or environment-specific behavior, causing the test's debug-mode auto-detection to misfire.

The fix replaces the brittle debug-mode detection with simpler logic:
- Track the first request number where INSERT succeeds
- Assert it's within the expected range [request_count, request_count + debug_request_count]
- Assert INSERT never fails after it has already succeeded
- Still verify each failure produces the expected "Expected Error"

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96474&sha=f721c2db641e68d3f99c83750301095ce4a3c70c&name_0=PR&name_1=Integration%20tests%20%28amd_asan%2C%20db%20disk%2C%20old%20analyzer%2C%204%2F6%29
https://github.com/ClickHouse/ClickHouse/pull/96474

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.558`
<!-- ch-version-info:end -->