### PR TITLE
Fix flaky `03593_backup_with_broken_projection`

### DIFF
--- a/tests/queries/0_stateless/03593_backup_with_broken_projection.sql
+++ b/tests/queries/0_stateless/03593_backup_with_broken_projection.sql
@@ -21,12 +21,12 @@ ORDER BY time1;
 INSERT INTO 03593_backup_with_broken_projection
 SETTINGS max_block_size = 10000000, min_insert_block_size_rows = 10000000
 SELECT
-    number = 4000000,
+    number = 40000,
     'test',
     '2025-08-11',
     '2025-08-11'
 FROM system.numbers
-LIMIT 5000000;
+LIMIT 50000;
 
 ALTER TABLE 03593_backup_with_broken_projection
     (UPDATE _row_exists = 0 WHERE id = 0) SETTINGS mutations_sync=1;


### PR DESCRIPTION
The test timed out (300s) in ASan CI with randomized settings including `index_granularity = 8`, creating ~625,000 granules for 5M rows. The mutation had to process all of them under ASan, exceeding the timeout.

Reduce row count from 5,000,000 to 50,000 — the test only needs to verify that backups work with broken projections, not stress-test mutation performance.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=73bc08666a51af5ccb03d37526c2d2dcf700f7cc&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_asan%2C%20distributed%20plan%2C%20parallel%2C%201%2F2%29


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.559`
<!-- ch-version-info:end -->