### PR TITLE
Add Allman-style brace convention note to CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -41,6 +41,8 @@ When writing tests, do not add "no-*" tags (like "no-parallel") unless strictly 
 
 When writing tests in tests/queries, prefer adding a new test instead of extending existing ones.
 
+When writing C++ code, always use Allman-style braces (opening brace on a new line). This is enforced by the style check in CI.
+
 Never use sleep in C++ code to fix race conditions - this is stupid and not acceptable!
 
 When writing messages, say ASan, not ASAN, and similar (because there are two words: Address Sanitizer).


### PR DESCRIPTION
Add a note to `CLAUDE.md` that ClickHouse C++ code always uses Allman-style braces (opening brace on a new line), which is enforced by the CI style check.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.556`
<!-- ch-version-info:end -->