### PR TITLE
Disable `02908_table_ttl_dependency` in replicated databases

### DIFF
--- a/tests/queries/0_stateless/02908_table_ttl_dependency.sh
+++ b/tests/queries/0_stateless/02908_table_ttl_dependency.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-ordinary-database
+# Tags: no-ordinary-database, no-replicated-database
 # Tag no-ordinary-database: requires UUID
+# Tag no-replicated-database: in replicated databases with database_replicated_always_detach_permanently, DROP TABLE
+# becomes a local permanent detach bypassing the DDL queue, which breaks the dependency tracking and can leave
+# orphaned table metadata that prevents server restart after stress tests
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
In stress tests, thread 5 uses `DatabaseReplicated` with `database_replicated_always_detach_permanently=1`. This causes `DROP TABLE` to become a local permanent detach bypassing the DDL queue, which breaks dependency tracking between `02908_main` and `02908_dependent`. After the stress test, the server fails to restart because `02908_dependent` references the now-missing `02908_main` in its TTL expression.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96616&sha=785b8d3e40f5f4fc710b29f7a3f91b0334e4dcb2&name_0=PR&name_1=Stress%20test%20%28amd_tsan%29
https://github.com/ClickHouse/ClickHouse/pull/96616

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.560`
<!-- ch-version-info:end -->