### PR TITLE
Fix flaky `00601_kill_running_query` test

### DIFF
--- a/tests/queries/0_stateless/00601_kill_running_query.reference
+++ b/tests/queries/0_stateless/00601_kill_running_query.reference
@@ -1,1 +1,1 @@
-waiting	test_00601_default	default	SELECT sum(ignore(*)) FROM (SELECT number % 1000 AS k, groupArray(number) FROM numbers(50000000) GROUP BY k) SETTINGS max_rows_to_read = 0
+waiting	test_00601_default	default	SELECT sleep(1) FROM numbers(10000) SETTINGS max_block_size = 1, max_rows_to_read = 0

--- a/tests/queries/0_stateless/00601_kill_running_query.sh
+++ b/tests/queries/0_stateless/00601_kill_running_query.sh
@@ -8,10 +8,20 @@ set -e -o pipefail
 
 function wait_for_query_to_start()
 {
-    while [[ $($CLICKHOUSE_CURL -sS "$CLICKHOUSE_URL" -d "SELECT count() FROM system.processes WHERE query_id = '$1'") == 0 ]]; do sleep 0.1; done
+    local timeout=30
+    local start=$EPOCHSECONDS
+    while [[ $($CLICKHOUSE_CURL -sS "$CLICKHOUSE_URL" -d "SELECT count() FROM system.processes WHERE query_id = '$1'") == 0 ]]; do
+        if ((EPOCHSECONDS - start > timeout)); then
+            echo "Timeout waiting for query $1 to start" >&2
+            exit 1
+        fi
+        sleep 0.1
+    done
 }
 
-${CLICKHOUSE_CURL_COMMAND} -q --max-time 30 -sS "$CLICKHOUSE_URL&query_id=test_00601_$CLICKHOUSE_DATABASE" -d 'SELECT sum(ignore(*)) FROM (SELECT number % 1000 AS k, groupArray(number) FROM numbers(50000000) GROUP BY k) SETTINGS max_rows_to_read = 0' > /dev/null &
+# Use sleep-based query that is guaranteed to run long enough to be killed,
+# unlike the previous groupArray query that could complete too quickly on fast machines.
+${CLICKHOUSE_CURL_COMMAND} -q --max-time 30 -sS "$CLICKHOUSE_URL&query_id=test_00601_$CLICKHOUSE_DATABASE" -d 'SELECT sleep(1) FROM numbers(10000) SETTINGS max_block_size = 1, max_rows_to_read = 0' > /dev/null &
 wait_for_query_to_start "test_00601_$CLICKHOUSE_DATABASE"
 $CLICKHOUSE_CURL -sS "$CLICKHOUSE_URL" -d "KILL QUERY WHERE query_id = 'test_00601_$CLICKHOUSE_DATABASE'"
-wait
+wait || true


### PR DESCRIPTION
The `groupArray` query on 50M rows could complete before `KILL QUERY` was sent on fast machines, causing two failure modes:
- empty KILL output (query already finished)
- infinite hang in `wait_for_query_to_start` (query finished before first poll)

Replace with a `sleep`-based query that is guaranteed to run long enough to be killed, add a timeout to the wait loop, and handle the background process exit code.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96640&sha=5160231ef660e33675f1d5aa6e9c025a10cdd29d&name_0=PR&name_1=Stateless%20tests%20%28amd_binary%2C%20old%20analyzer%2C%20s3%20storage%2C%20DatabaseReplicated%2C%20parallel%29
https://github.com/ClickHouse/ClickHouse/pull/96640

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.570`
<!-- ch-version-info:end -->