### PR TITLE
CI: Migrate praktika S3 versioned uploads from AWS CLI to boto3 with metadata

### DIFF
--- a/ci/praktika/hook_html.py
+++ b/ci/praktika/hook_html.py
@@ -161,6 +161,8 @@ class HtmlRunnerHooks:
         )
 
         summary_result.dump()
+        # Use version 0 for initial workflow report creation (destructive reset)
+        # This is safe here as it runs once at workflow start before any concurrent updates
         assert _ResultS3.copy_result_to_s3_with_version(summary_result, version=0)
         print(f"CI Status page url [{report_url_current_sha}]")
 

--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -1042,51 +1042,26 @@ class _ResultS3:
     def copy_result_from_s3_with_version(cls, local_path):
         env = _Environment.get()
         file_name = Path(local_path).name
-        local_dir = Path(local_path).parent
         s3_path = f"{Settings.HTML_S3_PATH}/{env.get_s3_prefix()}"
-        latest_result_file = Shell.get_output(
-            f"set -o pipefail && aws s3 ls {s3_path}/{file_name}_ | awk '{{print $4}}' | sort -r | head -n 1",
-            strict=True,
-            verbose=True,
-        )
-        version = int(latest_result_file.split("_")[-1])
-        S3.copy_file_from_s3(
-            s3_path=f"{s3_path}/{latest_result_file}", local_path=local_dir
-        )
-        Shell.check(
-            f"cp {local_dir}/{latest_result_file} {local_path}",
-            strict=True,
-            verbose=True,
-        )
-        return version
+        s3_file = f"{s3_path}/{file_name}"
+
+        return S3.copy_file_from_s3_with_version(s3_path=s3_file, local_path=local_path)
 
     @classmethod
     def copy_result_to_s3_with_version(cls, result, version, no_strict=False):
         result.dump()
         filename = Path(result.file_name()).name
-        file_name_versioned = f"{filename}_{str(version).zfill(3)}"
         env = _Environment.get()
         s3_path = f"{Settings.HTML_S3_PATH}/{env.get_s3_prefix()}/"
-        s3_path_versioned = f"{s3_path}{file_name_versioned}"
-        if version == 0:
-            S3.clean_s3_directory(s3_path=s3_path, include=f"{filename}*")
-        if not S3.put(
-            s3_path=s3_path_versioned,
+        s3_file = f"{s3_path}{filename}"
+
+        return S3.copy_file_to_s3_with_version(
+            s3_path=s3_file,
             local_path=result.file_name(),
-            if_none_matched=True,
-            no_strict=no_strict,
+            version=version,
             text=True,
-        ):
-            print("Failed to put versioned Result")
-            return False
-        if not S3.put(
-            s3_path=s3_path,
-            local_path=result.file_name(),
             no_strict=no_strict,
-            text=True,
-        ):
-            print("Failed to put non-versioned Result")
-        return True
+        )
 
     @classmethod
     def upload_result_files_to_s3(

--- a/ci/praktika/s3.py
+++ b/ci/praktika/s3.py
@@ -565,12 +565,12 @@ class S3:
                                 )
                                 return False
 
-                            # Read file content for put_object (needed for If-Match)
+                            # Stream file content for put_object (needed for If-Match)
                             with open(local_path, "rb") as f:
                                 client.put_object(
                                     Bucket=bucket,
                                     Key=key,
-                                    Body=f.read(),
+                                    Body=f,
                                     ContentType=(
                                         "text/plain"
                                         if text

--- a/ci/praktika/s3.py
+++ b/ci/praktika/s3.py
@@ -130,7 +130,9 @@ class S3:
                     )
 
             except NoCredentialsError as e:
-                print(f"ERROR: Failed to upload to S3 using boto3 (no credentials): {e}")
+                print(
+                    f"ERROR: Failed to upload to S3 using boto3 (no credentials): {e}"
+                )
                 if not no_strict:
                     raise
             except ClientError as e:
@@ -182,6 +184,7 @@ class S3:
         text=False,
         metadata=None,
         if_none_matched=False,
+        if_match=None,
         no_strict=False,
     ):
         """
@@ -191,6 +194,7 @@ class S3:
         :param text:
         :param metadata:
         :param if_none_matched:
+        :param if_match: ETag value for conditional PUT (use with version checking)
         :param no_strict:
         :return:
         """
@@ -211,6 +215,8 @@ class S3:
         )
         if if_none_matched:
             command += f' --if-none-match "*"'
+        if if_match:
+            command += f' --if-match "{if_match}"'
         if metadata:
             for k, v in metadata.items():
                 command += f" --metadata {k}={v}"
@@ -436,3 +442,209 @@ class S3:
 
         print("Execute:", cmd)
         cls.run_command_with_retries(cmd, retries=3)
+
+    @classmethod
+    def copy_file_from_s3_with_version(cls, s3_path, local_path):
+        """
+        Downloads a file from S3 and returns its version from object metadata.
+
+        :param s3_path: S3 path (with or without s3:// prefix)
+        :param local_path: Local path to save the file
+        :return: Version number from object metadata
+        """
+        # Use boto3 if available, otherwise AWS CLI
+        if BOTO3_AVAILABLE:
+            client = cls._get_boto3_client()
+            if client:
+                # boto3 approach: single file with version in metadata
+                s3_path_clean = str(s3_path).removeprefix("s3://")
+                bucket, key = s3_path_clean.split("/", maxsplit=1)
+
+                # Get object metadata to extract version
+                response = client.head_object(Bucket=bucket, Key=key)
+                version = int(response.get("Metadata", {}).get("version", "0"))
+
+                # Download the file
+                Path(local_path).parent.mkdir(parents=True, exist_ok=True)
+                client.download_file(bucket, key, str(local_path))
+
+                print(f"Downloaded file from S3 with version {version} using boto3")
+                return version
+
+        # AWS CLI approach: single file with version in metadata
+        s3_path_clean = str(s3_path).removeprefix("s3://")
+        bucket, key = s3_path_clean.split("/", maxsplit=1)
+
+        # Get object metadata to extract version
+        output = Shell.get_output(
+            f"aws s3api head-object --bucket {bucket} --key {key}",
+            strict=True,
+            verbose=True,
+        )
+        metadata = json.loads(output)
+        version = int(metadata.get("Metadata", {}).get("version", "0"))
+
+        # Download the file
+        cls.copy_file_from_s3(s3_path=s3_path, local_path=local_path)
+
+        print(f"Downloaded file from S3 with version {version} using AWS CLI")
+        return version
+
+    @classmethod
+    def copy_file_to_s3_with_version(
+        cls, s3_path, local_path, version, text=True, no_strict=False
+    ):
+        """
+        Uploads a file to S3 with version tracking in object metadata.
+        Uses conditional PUT with ETag matching for concurrent write safety (optimistic locking).
+
+        :param s3_path: S3 path (with or without s3:// prefix)
+        :param local_path: Local file path to upload
+        :param version: Version number to set in metadata
+        :param text: Whether to set content-type as text/plain
+        :param no_strict: Whether to suppress unexpected errors (returns False instead of raising exception)
+        :return: True if successful, False if concurrent write detected (object was modified by another process).
+                 On unexpected errors: raises exception if no_strict=False, returns False if no_strict=True.
+        """
+        assert Path(local_path).exists(), f"Path [{local_path}] does not exist"
+        assert Path(
+            local_path
+        ).is_file(), f"Path [{local_path}] is not file. Only files are supported"
+
+        # Use boto3 if available, otherwise AWS CLI
+        if BOTO3_AVAILABLE:
+            client = cls._get_boto3_client()
+            if client:
+                # boto3 approach: single file with version in metadata
+                s3_path_clean = str(s3_path).removeprefix("s3://")
+                bucket, key = s3_path_clean.split("/", maxsplit=1)
+
+                try:
+                    extra_args = {
+                        "ContentType": (
+                            "text/plain" if text else "application/octet-stream"
+                        ),
+                        "Metadata": {"version": str(version)},
+                    }
+
+                    if version == 0:
+                        # For version 0, just overwrite (clean start)
+                        print(
+                            f"Uploading file with version 0 (clean start) using boto3"
+                        )
+                        client.upload_file(
+                            str(local_path), bucket, key, ExtraArgs=extra_args
+                        )
+                    else:
+                        # For version > 0, use conditional PUT with If-Match (ETag check)
+                        # First get current ETag
+                        try:
+                            head_response = client.head_object(Bucket=bucket, Key=key)
+                            current_etag = head_response.get("ETag", "").strip('"')
+                            current_version = int(
+                                head_response.get("Metadata", {}).get("version", "0")
+                            )
+
+                            # Verify we're updating from expected version
+                            if current_version != version - 1:
+                                print(
+                                    f"Version mismatch: expected {version - 1}, found {current_version} (concurrent write detected)"
+                                )
+                                return False
+
+                            # Read file content for put_object (needed for If-Match)
+                            with open(local_path, "rb") as f:
+                                client.put_object(
+                                    Bucket=bucket,
+                                    Key=key,
+                                    Body=f.read(),
+                                    ContentType=(
+                                        "text/plain"
+                                        if text
+                                        else "application/octet-stream"
+                                    ),
+                                    Metadata={"version": str(version)},
+                                    IfMatch=current_etag,
+                                )
+                        except ClientError as e:
+                            error_code = e.response.get("Error", {}).get("Code", "")
+                            if error_code == "PreconditionFailed":
+                                print(
+                                    f"Precondition failed: object was modified by another process"
+                                )
+                                return False
+                            raise
+
+                    print(f"Uploaded file with version {version} using boto3")
+                    StorageUsage.add_uploaded(local_path)
+                    return True
+
+                except ClientError as e:
+                    error_code = e.response.get("Error", {}).get("Code", "")
+                    if error_code == "PreconditionFailed":
+                        print("Precondition failed (concurrent write detected)")
+                        return False
+                    print(f"ERROR: Failed to upload file using boto3: {error_code}")
+                    if not no_strict:
+                        raise
+                    return False
+                except Exception as e:
+                    print(f"ERROR: Failed to upload file using boto3: {e}")
+                    if not no_strict:
+                        raise
+                    return False
+
+        # AWS CLI approach: single file with version in metadata
+        s3_path_clean = str(s3_path).removeprefix("s3://")
+        bucket, key = s3_path_clean.split("/", maxsplit=1)
+
+        try:
+            if version == 0:
+                # For version 0, just upload without conditions (clean start)
+                print(f"Uploading file with version 0 (clean start) using AWS CLI")
+                result_uploaded = cls.put(
+                    s3_path=s3_path,
+                    local_path=local_path,
+                    metadata={"version": str(version)},
+                    no_strict=no_strict,
+                    text=text,
+                )
+                if not result_uploaded:
+                    print("Failed to put file")
+                    return False
+            else:
+                # For version > 0, use conditional PUT with If-Match (ETag check)
+                # First get current ETag and verify version
+                head_output = Shell.get_output(
+                    f"aws s3api head-object --bucket {bucket} --key {key}",
+                    strict=True,
+                    verbose=True,
+                )
+                head_data = json.loads(head_output)
+                current_etag = head_data.get("ETag", "").strip('"')
+                current_version = int(head_data.get("Metadata", {}).get("version", "0"))
+
+                # Verify we're updating from expected version
+                if current_version != version - 1:
+                    print(
+                        f"Version mismatch: expected {version - 1}, found {current_version} (concurrent write detected)"
+                    )
+                    return False
+
+                # Upload with If-Match condition
+                content_type = "text/plain" if text else "application/octet-stream"
+                command = f'aws s3api put-object --bucket {bucket} --key {key} --body {local_path} --content-type {content_type} --metadata version={version} --if-match "{current_etag}"'
+                res = cls.run_command_with_retries(command, no_strict=no_strict)
+                if not res:
+                    print("Failed to put file (precondition failed or other error)")
+                    return False
+
+            print(f"Uploaded file with version {version} using AWS CLI")
+            StorageUsage.add_uploaded(local_path)
+            return True
+
+        except Exception as e:
+            print(f"ERROR: Failed to upload file using AWS CLI: {e}")
+            if not no_strict:
+                raise
+            return False

--- a/ci/praktika/s3.py
+++ b/ci/praktika/s3.py
@@ -614,7 +614,9 @@ class S3:
         try:
             if version == 0:
                 # DESTRUCTIVE: Version 0 uploads without conditions (NOT safe for concurrent use)
-                print(f"Uploading file with version 0 (destructive reset) using AWS CLI")
+                print(
+                    f"Uploading file with version 0 (destructive reset) using AWS CLI"
+                )
                 result_uploaded = cls.put(
                     s3_path=s3_path,
                     local_path=local_path,

--- a/src/Columns/Collator.cpp
+++ b/src/Columns/Collator.cpp
@@ -92,7 +92,7 @@ Collator::Collator(const std::string & locale_)
 #if USE_ICU
     /// ICU locales can have settings and keywords, e.g. 'tr-u-kn-true-ka-shifted' is 'Turkish' with keywords.
     /// See https://peter.eisentraut.org/blog/2023/05/16/overview-of-icu-collation-settings for details.
-    /// Remove these as AvailableCollationLocales only knows the the base names.
+    /// Remove these as AvailableCollationLocales only knows the base names.
     static const size_t MAX_BASE_NAME_LENGTH = 128;
     char base_name_buf[MAX_BASE_NAME_LENGTH];
     UErrorCode status = U_ZERO_ERROR;


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

## Technical Description

Reimplemented `copy_result_to_s3_with_version` and `copy_result_from_s3_with_version` in praktika to use boto3 instead of AWS CLI, with improved version tracking via object metadata.

### Changes:
- **boto3 support**: Uses boto3 when available, falls back to AWS CLI if not installed
- **Metadata-based versioning**: Stores version in S3 object metadata instead of file name suffixes (eliminates `result.json_001`, `result.json_002`, etc.)
- **ETag-based optimistic locking**: Uses `IfMatch` condition for concurrent write safety
- **Better architecture**: Moved S3 version logic from `result.py` to `s3.py` for better separation of concerns

### Benefits:
- Single result file instead of proliferation of versioned files in S3
- Cleaner S3 bucket structure  
- Better code organization and reusability
- Same concurrent write safety guarantees via ETag matching

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.581`
<!-- ch-version-info:end -->