### PR TITLE
Add batch symbolization for jemalloc heap profiles

### DIFF
--- a/src/Parsers/examples/parser_memory_profiler.cpp
+++ b/src/Parsers/examples/parser_memory_profiler.cpp
@@ -74,8 +74,11 @@
 #include <sstream>
 #include <string>
 #include <cstdlib>
+#include <filesystem>
 #include <unistd.h>
 #include <atomic>
+
+#include <boost/program_options.hpp>
 
 #include <Common/Exception.h>
 #include <Common/Jemalloc.h>
@@ -197,21 +200,7 @@ std::string readQuery()
     );
 }
 
-void printUsage(const char * prog_name)
-{
-    std::cerr << "Usage: " << prog_name << " [--profile <prefix>] [--symbolize]\n";
-    std::cerr << "  Reads SQL query from stdin until EOF and prints memory stats.\n";
-    std::cerr << "\nOptions:\n";
-    std::cerr << "  --profile <prefix>  Dump jemalloc heap profiles to <prefix>*.heap\n";
-    std::cerr << "  --symbolize         Symbolize heap profiles (requires --profile)\n";
-    std::cerr << "\nOutput format (tab-separated):\n";
-    std::cerr << "  query_length  allocated_before  allocated_after  allocated_diff\n";
-    std::cerr << "\nExamples:\n";
-    std::cerr << "  # Memory stats only:\n";
-    std::cerr << "  echo 'SELECT 1;' | " << prog_name << "\n";
-    std::cerr << "\n  # With heap profiling and symbolization (Linux):\n";
-    std::cerr << "  MALLOC_CONF=prof:true,lg_prof_sample:0 " << prog_name << " --profile /tmp/p_ --symbolize <<< 'SELECT 1;'\n";
-}
+namespace po = boost::program_options;
 
 void printProfilingStatus()
 {
@@ -251,34 +240,63 @@ try
 {
     using namespace DB;
 
-    std::string profile_prefix;
-    bool enable_profiling = false;
-    bool enable_symbolize = false;
+    po::options_description desc("Measure memory allocations during SQL parsing.\n"
+                                 "Reads query from stdin, prints tab-separated: query_length before after diff\n\n"
+                                 "Options");
+    desc.add_options()
+        ("help,h", "Show help")
+        ("profile", po::value<std::string>(), "Dump jemalloc heap profiles with this prefix")
+        ("symbolize", "Symbolize heap profiles (requires --profile)")
+        ("symbolize-batch", po::value<std::vector<std::string>>()->multitoken(),
+         "Batch-symbolize .heap files (shared cache via global LRU)")
+    ;
 
-    for (int i = 1; i < argc; ++i)
+    po::variables_map vm;
+    po::store(po::parse_command_line(argc, argv, desc), vm);
+    po::notify(vm);
+
+    if (vm.contains("help"))
     {
-        std::string arg = argv[i];
-        if (arg == "--profile" && i + 1 < argc)
+        std::cerr << desc << "\n";
+        return 0;
+    }
+
+    /// Handle batch symbolization mode: global LRU cache is shared across calls
+    if (vm.contains("symbolize-batch"))
+    {
+        auto batch_files = vm["symbolize-batch"].as<std::vector<std::string>>();
+        if (batch_files.empty())
         {
-            profile_prefix = argv[++i];
-            enable_profiling = true;
-        }
-        else if (arg == "--symbolize")
-        {
-            enable_symbolize = true;
-        }
-        else if (arg == "--help" || arg == "-h")
-        {
-            printUsage(argv[0]);
-            return 0;
-        }
-        else
-        {
-            std::cerr << "Unknown option: " << arg << "\n";
-            printUsage(argv[0]);
+            std::cerr << "Error: --symbolize-batch requires at least one .heap file\n";
             return 1;
         }
+
+        for (const auto & file : batch_files)
+        {
+            if (!std::filesystem::exists(file))
+            {
+                std::cerr << "Error: heap file not found: " << file << "\n";
+                return 1;
+            }
+        }
+
+        std::cerr << "Batch symbolizing " << batch_files.size() << " heap files...\n";
+        for (const auto & file : batch_files)
+        {
+            std::string output = file + ".sym";
+            symbolizeJemallocHeapProfile(file, output);
+            std::cerr << "Symbolized: " << file << " -> " << output << "\n";
+        }
+        std::cerr << "Done.\n";
+        return 0;
     }
+
+    std::string profile_prefix;
+    bool enable_profiling = vm.contains("profile");
+    bool enable_symbolize = vm.contains("symbolize");
+
+    if (enable_profiling)
+        profile_prefix = vm["profile"].as<std::string>();
 
     if (enable_symbolize && !enable_profiling)
     {


### PR DESCRIPTION
### Changelog category (leave one):

- Build/Testing/Packaging Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Add --symbolize-batch mode to parser_memory_profiler tool. Refactor symbolizeHeapProfile into composable helpers and add symbolizeHeapProfilesBatch() that collects addresses from all input files, symbolizes each unique address once (single DWARF pass), then writes all output .sym files using the shared symbol table. This dramatically reduces symbolization time when processing many heap files from the same binary (e.g. CI memory checks with many queries).





### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.310`
<!-- ch-version-info:end -->