### PR TITLE
Use QueryPlanStepPtr consistently

### DIFF
--- a/src/Processors/QueryPlan/AggregatingStep.cpp
+++ b/src/Processors/QueryPlan/AggregatingStep.cpp
@@ -815,7 +815,7 @@ void AggregatingStep::serialize(Serialization & ctx) const
         writeIntBinary(params.stats_collecting_params.key, ctx.out);
 }
 
-std::unique_ptr<IQueryPlanStep> AggregatingStep::deserialize(Deserialization & ctx)
+QueryPlanStepPtr AggregatingStep::deserialize(Deserialization & ctx)
 {
     if (ctx.input_headers.size() != 1)
         throw Exception(ErrorCodes::INCORRECT_DATA, "AggregatingStep must have one input stream");

--- a/src/Processors/QueryPlan/AggregatingStep.h
+++ b/src/Processors/QueryPlan/AggregatingStep.h
@@ -84,7 +84,7 @@ public:
         return sort_description_for_merging.empty() && !explicit_sorting_required_for_aggregation_in_order;
     }
 
-    static std::unique_ptr<IQueryPlanStep> deserialize(Deserialization & ctx);
+    static QueryPlanStepPtr deserialize(Deserialization & ctx);
 
     QueryPlanStepPtr clone() const override;
 

--- a/src/Processors/QueryPlan/ArrayJoinStep.cpp
+++ b/src/Processors/QueryPlan/ArrayJoinStep.cpp
@@ -107,7 +107,7 @@ void ArrayJoinStep::serialize(Serialization & ctx) const
         writeStringBinary(column, ctx.out);
 }
 
-std::unique_ptr<IQueryPlanStep> ArrayJoinStep::deserialize(Deserialization & ctx)
+QueryPlanStepPtr ArrayJoinStep::deserialize(Deserialization & ctx)
 {
     UInt8 flags;
     readIntBinary(flags, ctx.in);

--- a/src/Processors/QueryPlan/ArrayJoinStep.h
+++ b/src/Processors/QueryPlan/ArrayJoinStep.h
@@ -26,7 +26,7 @@ public:
     void serialize(Serialization & ctx) const override;
     bool isSerializable() const override { return true; }
 
-    static std::unique_ptr<IQueryPlanStep> deserialize(Deserialization & ctx);
+    static QueryPlanStepPtr deserialize(Deserialization & ctx);
 
 private:
     void updateOutputHeader() override;

--- a/src/Processors/QueryPlan/BlocksMarshallingStep.cpp
+++ b/src/Processors/QueryPlan/BlocksMarshallingStep.cpp
@@ -65,7 +65,7 @@ void BlocksMarshallingStep::transformPipeline(QueryPipelineBuilder & pipeline, c
         pipeline.addTransform(std::make_shared<SortChunksBySequenceNumber>(pipeline.getHeader(), num_threads));
 }
 
-std::unique_ptr<IQueryPlanStep> BlocksMarshallingStep::deserialize(Deserialization & ctx)
+QueryPlanStepPtr BlocksMarshallingStep::deserialize(Deserialization & ctx)
 {
     chassert(ctx.input_headers.size() == 1);
     return std::make_unique<BlocksMarshallingStep>(ctx.input_headers.front());

--- a/src/Processors/QueryPlan/BlocksMarshallingStep.h
+++ b/src/Processors/QueryPlan/BlocksMarshallingStep.h
@@ -18,7 +18,7 @@ public:
     void serialize(Serialization &) const override { }
     bool isSerializable() const override { return true; }
 
-    static std::unique_ptr<IQueryPlanStep> deserialize(Deserialization & ctx);
+    static QueryPlanStepPtr deserialize(Deserialization & ctx);
 
 private:
     void updateOutputHeader() override;

--- a/src/Processors/QueryPlan/DistinctStep.cpp
+++ b/src/Processors/QueryPlan/DistinctStep.cpp
@@ -196,7 +196,7 @@ void DistinctStep::serialize(Serialization & ctx) const
         writeStringBinary(column, ctx.out);
 }
 
-std::unique_ptr<IQueryPlanStep> DistinctStep::deserialize(Deserialization & ctx, bool pre_distinct_)
+QueryPlanStepPtr DistinctStep::deserialize(Deserialization & ctx, bool pre_distinct_)
 {
     if (ctx.input_headers.size() != 1)
         throw Exception(ErrorCodes::INCORRECT_DATA, "DistinctStep must have one input stream");
@@ -216,11 +216,11 @@ std::unique_ptr<IQueryPlanStep> DistinctStep::deserialize(Deserialization & ctx,
         ctx.input_headers.front(), size_limits, 0, column_names, pre_distinct_);
 }
 
-std::unique_ptr<IQueryPlanStep> DistinctStep::deserializeNormal(Deserialization & ctx)
+QueryPlanStepPtr DistinctStep::deserializeNormal(Deserialization & ctx)
 {
     return DistinctStep::deserialize(ctx, false);
 }
-std::unique_ptr<IQueryPlanStep> DistinctStep::deserializePre(Deserialization & ctx)
+QueryPlanStepPtr DistinctStep::deserializePre(Deserialization & ctx)
 {
     return DistinctStep::deserialize(ctx, true);
 }

--- a/src/Processors/QueryPlan/DistinctStep.h
+++ b/src/Processors/QueryPlan/DistinctStep.h
@@ -36,9 +36,9 @@ public:
     void serialize(Serialization & ctx) const override;
     bool isSerializable() const override { return true; }
 
-    static std::unique_ptr<IQueryPlanStep> deserialize(Deserialization & ctx, bool pre_distinct_);
-    static std::unique_ptr<IQueryPlanStep> deserializeNormal(Deserialization & ctx);
-    static std::unique_ptr<IQueryPlanStep> deserializePre(Deserialization & ctx);
+    static QueryPlanStepPtr deserialize(Deserialization & ctx, bool pre_distinct_);
+    static QueryPlanStepPtr deserializeNormal(Deserialization & ctx);
+    static QueryPlanStepPtr deserializePre(Deserialization & ctx);
 
     const SizeLimits & getSetSizeLimits() const { return set_size_limits; }
 

--- a/src/Processors/QueryPlan/ExpressionStep.cpp
+++ b/src/Processors/QueryPlan/ExpressionStep.cpp
@@ -120,7 +120,7 @@ void ExpressionStep::serialize(Serialization & ctx) const
     actions_dag.serialize(ctx.out, ctx.registry);
 }
 
-std::unique_ptr<IQueryPlanStep> ExpressionStep::deserialize(Deserialization & ctx)
+QueryPlanStepPtr ExpressionStep::deserialize(Deserialization & ctx)
 {
     ActionsDAG actions_dag = ActionsDAG::deserialize(ctx.in, ctx.registry, ctx.context);
     if (ctx.input_headers.size() != 1)

--- a/src/Processors/QueryPlan/ExtremesStep.cpp
+++ b/src/Processors/QueryPlan/ExtremesStep.cpp
@@ -36,7 +36,7 @@ void ExtremesStep::serialize(Serialization & ctx) const
     (void)ctx;
 }
 
-std::unique_ptr<IQueryPlanStep> ExtremesStep::deserialize(Deserialization & ctx)
+QueryPlanStepPtr ExtremesStep::deserialize(Deserialization & ctx)
 {
     return std::make_unique<ExtremesStep>(ctx.input_headers.front());
 }

--- a/src/Processors/QueryPlan/ExtremesStep.h
+++ b/src/Processors/QueryPlan/ExtremesStep.h
@@ -16,7 +16,7 @@ public:
     void serialize(Serialization & ctx) const override;
     bool isSerializable() const override { return true; }
 
-    static std::unique_ptr<IQueryPlanStep> deserialize(Deserialization & ctx);
+    static QueryPlanStepPtr deserialize(Deserialization & ctx);
 
 private:
     void updateOutputHeader() override

--- a/src/Processors/QueryPlan/FractionalLimitStep.cpp
+++ b/src/Processors/QueryPlan/FractionalLimitStep.cpp
@@ -87,7 +87,7 @@ void FractionalLimitStep::serialize(Serialization & ctx) const
         serializeSortDescription(description, ctx.out);
 }
 
-std::unique_ptr<IQueryPlanStep> FractionalLimitStep::deserialize(Deserialization & ctx)
+QueryPlanStepPtr FractionalLimitStep::deserialize(Deserialization & ctx)
 {
     UInt8 flags;
     readIntBinary(flags, ctx.in);

--- a/src/Processors/QueryPlan/FractionalLimitStep.h
+++ b/src/Processors/QueryPlan/FractionalLimitStep.h
@@ -32,7 +32,7 @@ public:
     void serialize(Serialization & ctx) const override;
     bool isSerializable() const override { return true; }
 
-    static std::unique_ptr<IQueryPlanStep> deserialize(Deserialization & ctx);
+    static QueryPlanStepPtr deserialize(Deserialization & ctx);
 
     bool hasCorrelatedExpressions() const override { return false; }
 

--- a/src/Processors/QueryPlan/FractionalOffsetStep.cpp
+++ b/src/Processors/QueryPlan/FractionalOffsetStep.cpp
@@ -57,7 +57,7 @@ void FractionalOffsetStep::serialize(Serialization & ctx) const
     writeFloatBinary(fractional_offset, ctx.out);
 }
 
-std::unique_ptr<IQueryPlanStep> FractionalOffsetStep::deserialize(Deserialization & ctx)
+QueryPlanStepPtr FractionalOffsetStep::deserialize(Deserialization & ctx)
 {
     Float64 offset;
     readFloatBinary(offset, ctx.in);

--- a/src/Processors/QueryPlan/FractionalOffsetStep.h
+++ b/src/Processors/QueryPlan/FractionalOffsetStep.h
@@ -22,7 +22,7 @@ public:
     void serialize(Serialization & ctx) const override;
     bool isSerializable() const override { return true; }
 
-    static std::unique_ptr<IQueryPlanStep> deserialize(Deserialization & ctx);
+    static QueryPlanStepPtr deserialize(Deserialization & ctx);
 
 private:
     void updateOutputHeader() override { output_header = input_headers.front(); }

--- a/src/Processors/QueryPlan/JoinStepLogical.cpp
+++ b/src/Processors/QueryPlan/JoinStepLogical.cpp
@@ -1549,7 +1549,7 @@ static ActionsDAG::NodeRawConstPtrs deserializeNodeList(ReadBuffer & in, const A
     return nodes;
 }
 
-std::unique_ptr<IQueryPlanStep> JoinStepLogical::deserialize(Deserialization & ctx)
+QueryPlanStepPtr JoinStepLogical::deserialize(Deserialization & ctx)
 {
     if (ctx.input_headers.size() != 2)
         throw Exception(ErrorCodes::INCORRECT_DATA, "JoinStepLogical must have two input streams");

--- a/src/Processors/QueryPlan/JoinStepLogical.h
+++ b/src/Processors/QueryPlan/JoinStepLogical.h
@@ -103,7 +103,7 @@ public:
     void serializeSettings(QueryPlanSerializationSettings & settings) const override;
     void serialize(Serialization & ctx) const override;
 
-    static std::unique_ptr<IQueryPlanStep> deserialize(Deserialization & ctx);
+    static QueryPlanStepPtr deserialize(Deserialization & ctx);
 
     QueryPlanStepPtr clone() const override;
 

--- a/src/Processors/QueryPlan/LimitByStep.cpp
+++ b/src/Processors/QueryPlan/LimitByStep.cpp
@@ -96,7 +96,7 @@ void LimitByStep::serialize(Serialization & ctx) const
         writeStringBinary(column, ctx.out);
 }
 
-std::unique_ptr<IQueryPlanStep> LimitByStep::deserialize(Deserialization & ctx)
+QueryPlanStepPtr LimitByStep::deserialize(Deserialization & ctx)
 {
     UInt64 group_length;
     UInt64 group_offset;

--- a/src/Processors/QueryPlan/LimitByStep.h
+++ b/src/Processors/QueryPlan/LimitByStep.h
@@ -22,7 +22,7 @@ public:
     void serialize(Serialization & ctx) const override;
     bool isSerializable() const override { return true; }
 
-    static std::unique_ptr<IQueryPlanStep> deserialize(Deserialization & ctx);
+    static QueryPlanStepPtr deserialize(Deserialization & ctx);
 
     void applyOrder(SortDescription sort_desc);
 private:

--- a/src/Processors/QueryPlan/LimitStep.cpp
+++ b/src/Processors/QueryPlan/LimitStep.cpp
@@ -102,7 +102,7 @@ void LimitStep::serialize(Serialization & ctx) const
         serializeSortDescription(description, ctx.out);
 }
 
-std::unique_ptr<IQueryPlanStep> LimitStep::deserialize(Deserialization & ctx)
+QueryPlanStepPtr LimitStep::deserialize(Deserialization & ctx)
 {
     UInt8 flags;
     readIntBinary(flags, ctx.in);

--- a/src/Processors/QueryPlan/LimitStep.h
+++ b/src/Processors/QueryPlan/LimitStep.h
@@ -38,7 +38,7 @@ public:
     void serialize(Serialization & ctx) const override;
     bool isSerializable() const override { return true; }
 
-    static std::unique_ptr<IQueryPlanStep> deserialize(Deserialization & ctx);
+    static QueryPlanStepPtr deserialize(Deserialization & ctx);
 
     bool hasCorrelatedExpressions() const override { return false; }
 

--- a/src/Processors/QueryPlan/MergingAggregatedStep.cpp
+++ b/src/Processors/QueryPlan/MergingAggregatedStep.cpp
@@ -240,7 +240,7 @@ void MergingAggregatedStep::serialize(Serialization & ctx) const
         writeIntBinary(params.stats_collecting_params.key, ctx.out);
 }
 
-std::unique_ptr<IQueryPlanStep> MergingAggregatedStep::deserialize(Deserialization & ctx)
+QueryPlanStepPtr MergingAggregatedStep::deserialize(Deserialization & ctx)
 {
     if (ctx.input_headers.size() != 1)
         throw Exception(ErrorCodes::INCORRECT_DATA, "MergingAggregatedStep must have one input stream");

--- a/src/Processors/QueryPlan/MergingAggregatedStep.h
+++ b/src/Processors/QueryPlan/MergingAggregatedStep.h
@@ -45,7 +45,7 @@ public:
     void serializeSettings(QueryPlanSerializationSettings & settings) const override;
     void serialize(Serialization & ctx) const override;
     bool isSerializable() const override { return true; }
-    static std::unique_ptr<IQueryPlanStep> deserialize(Deserialization & ctx);
+    static QueryPlanStepPtr deserialize(Deserialization & ctx);
 
 private:
     void updateOutputHeader() override;

--- a/src/Processors/QueryPlan/NegativeLimitStep.cpp
+++ b/src/Processors/QueryPlan/NegativeLimitStep.cpp
@@ -68,7 +68,7 @@ void NegativeLimitStep::serialize(Serialization & ctx) const
     writeVarUInt(offset, ctx.out);
 }
 
-std::unique_ptr<IQueryPlanStep> NegativeLimitStep::deserialize(Deserialization & ctx)
+QueryPlanStepPtr NegativeLimitStep::deserialize(Deserialization & ctx)
 {
     UInt8 flags;
     readIntBinary(flags, ctx.in); // reserved, ignored for now

--- a/src/Processors/QueryPlan/NegativeLimitStep.h
+++ b/src/Processors/QueryPlan/NegativeLimitStep.h
@@ -32,7 +32,7 @@ public:
     void serialize(Serialization & ctx) const override;
     bool isSerializable() const override { return true; }
 
-    static std::unique_ptr<IQueryPlanStep> deserialize(Deserialization & ctx);
+    static QueryPlanStepPtr deserialize(Deserialization & ctx);
 
     bool hasCorrelatedExpressions() const override { return false; }
 

--- a/src/Processors/QueryPlan/NegativeOffsetStep.cpp
+++ b/src/Processors/QueryPlan/NegativeOffsetStep.cpp
@@ -53,7 +53,7 @@ void NegativeOffsetStep::serialize(Serialization & ctx) const
     writeVarUInt(offset, ctx.out);
 }
 
-std::unique_ptr<IQueryPlanStep> NegativeOffsetStep::deserialize(Deserialization & ctx)
+QueryPlanStepPtr NegativeOffsetStep::deserialize(Deserialization & ctx)
 {
     UInt64 offset;
     readVarUInt(offset, ctx.in);

--- a/src/Processors/QueryPlan/NegativeOffsetStep.h
+++ b/src/Processors/QueryPlan/NegativeOffsetStep.h
@@ -21,7 +21,7 @@ public:
     void serialize(Serialization & ctx) const override;
     bool isSerializable() const override { return true; }
 
-    static std::unique_ptr<IQueryPlanStep> deserialize(Deserialization & ctx);
+    static QueryPlanStepPtr deserialize(Deserialization & ctx);
 
 private:
     void updateOutputHeader() override { output_header = input_headers.front(); }

--- a/src/Processors/QueryPlan/OffsetStep.cpp
+++ b/src/Processors/QueryPlan/OffsetStep.cpp
@@ -54,7 +54,7 @@ void OffsetStep::serialize(Serialization & ctx) const
     writeVarUInt(offset, ctx.out);
 }
 
-std::unique_ptr<IQueryPlanStep> OffsetStep::deserialize(Deserialization & ctx)
+QueryPlanStepPtr OffsetStep::deserialize(Deserialization & ctx)
 {
     UInt64 offset;
     readVarUInt(offset, ctx.in);

--- a/src/Processors/QueryPlan/OffsetStep.h
+++ b/src/Processors/QueryPlan/OffsetStep.h
@@ -21,7 +21,7 @@ public:
     void serialize(Serialization & ctx) const override;
     bool isSerializable() const override { return true; }
 
-    static std::unique_ptr<IQueryPlanStep> deserialize(Deserialization & ctx);
+    static QueryPlanStepPtr deserialize(Deserialization & ctx);
 
 private:
     void updateOutputHeader() override

--- a/src/Processors/QueryPlan/ReadFromTableFunctionStep.cpp
+++ b/src/Processors/QueryPlan/ReadFromTableFunctionStep.cpp
@@ -68,7 +68,7 @@ void ReadFromTableFunctionStep::serialize(Serialization & ctx) const
         serializeRational(*table_expression_modifiers.getSampleOffsetRatio(), ctx.out);
 }
 
-std::unique_ptr<IQueryPlanStep> ReadFromTableFunctionStep::deserialize(Deserialization & ctx)
+QueryPlanStepPtr ReadFromTableFunctionStep::deserialize(Deserialization & ctx)
 {
     UInt8 kind;
     readIntBinary(kind, ctx.in);

--- a/src/Processors/QueryPlan/ReadFromTableFunctionStep.h
+++ b/src/Processors/QueryPlan/ReadFromTableFunctionStep.h
@@ -15,7 +15,7 @@ public:
     void initializePipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings &) override;
 
     void serialize(Serialization & ctx) const override;
-    static std::unique_ptr<IQueryPlanStep> deserialize(Deserialization & ctx);
+    static QueryPlanStepPtr deserialize(Deserialization & ctx);
 
     const std::string & getSerializedAST() const { return serialized_ast; }
     TableExpressionModifiers getTableExpressionModifiers() const { return table_expression_modifiers; }

--- a/src/Processors/QueryPlan/ReadFromTableStep.cpp
+++ b/src/Processors/QueryPlan/ReadFromTableStep.cpp
@@ -61,7 +61,7 @@ void ReadFromTableStep::serialize(Serialization & ctx) const
         serializeRational(*table_expression_modifiers.getSampleOffsetRatio(), ctx.out);
 }
 
-std::unique_ptr<IQueryPlanStep> ReadFromTableStep::deserialize(Deserialization & ctx)
+QueryPlanStepPtr ReadFromTableStep::deserialize(Deserialization & ctx)
 {
     String table_name;
     readStringBinary(table_name, ctx.in);

--- a/src/Processors/QueryPlan/ReadFromTableStep.h
+++ b/src/Processors/QueryPlan/ReadFromTableStep.h
@@ -15,7 +15,7 @@ public:
     void initializePipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings &) override;
 
     void serialize(Serialization & ctx) const override;
-    static std::unique_ptr<IQueryPlanStep> deserialize(Deserialization & ctx);
+    static QueryPlanStepPtr deserialize(Deserialization & ctx);
 
     const String & getTable() const { return table_name; }
     TableExpressionModifiers getTableExpressionModifiers() const { return table_expression_modifiers; }

--- a/src/Processors/QueryPlan/SortingStep.cpp
+++ b/src/Processors/QueryPlan/SortingStep.cpp
@@ -593,7 +593,7 @@ void SortingStep::serialize(Serialization & ctx) const
     writeVarUInt(partition_by_description.size(), ctx.out);
 }
 
-std::unique_ptr<IQueryPlanStep> SortingStep::deserialize(Deserialization & ctx)
+QueryPlanStepPtr SortingStep::deserialize(Deserialization & ctx)
 {
     if (ctx.input_headers.size() != 1)
         throw Exception(ErrorCodes::INCORRECT_DATA, "SortingStep must have one input stream");

--- a/src/Processors/QueryPlan/SortingStep.h
+++ b/src/Processors/QueryPlan/SortingStep.h
@@ -123,7 +123,7 @@ public:
     void serialize(Serialization & ctx) const override;
     bool isSerializable() const override { return type == Type::Full && partition_by_description.empty(); }
 
-    static std::unique_ptr<IQueryPlanStep> deserialize(Deserialization & ctx);
+    static QueryPlanStepPtr deserialize(Deserialization & ctx);
 
     bool supportsDataflowStatisticsCollection() const override { return true; }
     void setTopKThresholdTracker(TopKThresholdTrackerPtr threshold_tracker_) { threshold_tracker = threshold_tracker_; }

--- a/src/Processors/QueryPlan/TotalsHavingStep.cpp
+++ b/src/Processors/QueryPlan/TotalsHavingStep.cpp
@@ -191,7 +191,7 @@ void TotalsHavingStep::serialize(Serialization & ctx) const
     }
 }
 
-std::unique_ptr<IQueryPlanStep> TotalsHavingStep::deserialize(Deserialization & ctx)
+QueryPlanStepPtr TotalsHavingStep::deserialize(Deserialization & ctx)
 {
     if (ctx.input_headers.size() != 1)
         throw Exception(ErrorCodes::INCORRECT_DATA, "TotalsHaving must have one input stream");

--- a/src/Processors/QueryPlan/TotalsHavingStep.h
+++ b/src/Processors/QueryPlan/TotalsHavingStep.h
@@ -36,7 +36,7 @@ public:
     void serialize(Serialization & ctx) const override;
     bool isSerializable() const override { return true; }
 
-    static std::unique_ptr<IQueryPlanStep> deserialize(Deserialization & ctx);
+    static QueryPlanStepPtr deserialize(Deserialization & ctx);
 
 private:
     void updateOutputHeader() override;

--- a/src/Processors/QueryPlan/UnionStep.cpp
+++ b/src/Processors/QueryPlan/UnionStep.cpp
@@ -94,7 +94,7 @@ void UnionStep::serialize(Serialization & ctx) const
     (void)ctx;
 }
 
-std::unique_ptr<IQueryPlanStep> UnionStep::deserialize(Deserialization & ctx)
+QueryPlanStepPtr UnionStep::deserialize(Deserialization & ctx)
 {
     return std::make_unique<UnionStep>(ctx.input_headers);
 }

--- a/src/Processors/QueryPlan/UnionStep.h
+++ b/src/Processors/QueryPlan/UnionStep.h
@@ -22,7 +22,7 @@ public:
     void serialize(Serialization & ctx) const override;
     bool isSerializable() const override { return true; }
 
-    static std::unique_ptr<IQueryPlanStep> deserialize(Deserialization & ctx);
+    static QueryPlanStepPtr deserialize(Deserialization & ctx);
 
     bool hasCorrelatedExpressions() const override { return false; }
 


### PR DESCRIPTION
We use `QueryPlanStepPtr` in some places and `std::unique_ptr<IQueryPlanStep>` in others.
This is just a code cleanup to facilitate refactoring, no changes in the logic. 

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.575`
<!-- ch-version-info:end -->