### PR TITLE
Int32 -> Int64 to prevent overflow in statistics and total rows count in iceberg writes

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
@@ -338,17 +338,17 @@ void generateManifestFile(
                 {
                     avro::GenericDatum record_datum(schema_element);
                     auto & record = record_datum.value<avro::GenericRecord>();
-                    record.field(Iceberg::f_key) = static_cast<Int32>(field_id);
+                    record.field(Iceberg::f_key) = static_cast<Int64>(field_id);
                     record.field(Iceberg::f_value) = dump_function(field_id, value);
                     record_values.value().push_back(record_datum);
                 }
             };
 
             auto statistics = data_file_statistics->getColumnSizes();
-            set_fields(statistics, Iceberg::f_column_sizes, [](size_t, size_t value) { return static_cast<Int32>(value); });
+            set_fields(statistics, Iceberg::f_column_sizes, [](size_t, size_t value) { return static_cast<Int64>(value); });
 
             statistics = data_file_statistics->getNullCounts();
-            set_fields(statistics, Iceberg::f_null_value_counts, [](size_t, size_t value) { return static_cast<Int32>(value); });
+            set_fields(statistics, Iceberg::f_null_value_counts, [](size_t, size_t value) { return static_cast<Int64>(value); });
 
             std::unordered_map<size_t, size_t> field_id_to_column_index;
             auto field_ids = data_file_statistics->getFieldIds();
@@ -437,7 +437,7 @@ void generateManifestList(
     ContextPtr context,
     const Strings & manifest_entry_names,
     Poco::JSON::Object::Ptr new_snapshot,
-    Int32 manifest_length,
+    Int64 manifest_length,
     WriteBuffer & buf,
     Iceberg::FileContentType content_type,
     bool use_previous_snapshots)
@@ -463,12 +463,12 @@ void generateManifestList(
 
         entry.field(Iceberg::f_manifest_path) = manifest_entry_name;
         entry.field(Iceberg::f_manifest_length) = manifest_length;
-        entry.field(Iceberg::f_partition_spec_id) = metadata->getValue<Int32>(Iceberg::f_default_spec_id);
+        entry.field(Iceberg::f_partition_spec_id) = metadata->getValue<Int64>(Iceberg::f_default_spec_id);
         if (version > 1)
         {
             entry.field(Iceberg::f_content) = static_cast<Int32>(content_type);
-            entry.field(Iceberg::f_sequence_number) = new_snapshot->getValue<Int32>(Iceberg::f_metadata_sequence_number);
-            entry.field(Iceberg::f_min_sequence_number) = new_snapshot->getValue<Int32>(Iceberg::f_metadata_sequence_number);
+            entry.field(Iceberg::f_sequence_number) = new_snapshot->getValue<Int64>(Iceberg::f_metadata_sequence_number);
+            entry.field(Iceberg::f_min_sequence_number) = new_snapshot->getValue<Int64>(Iceberg::f_metadata_sequence_number);
         }
 
         auto set_versioned_field = [&](const auto & value, const String & field_name)
@@ -874,7 +874,7 @@ bool IcebergStorageSink::initializeMetadata()
 
     Strings manifest_entries_in_storage;
     Strings manifest_entries;
-    Int32 manifest_lengths = 0;
+    Int64 manifest_lengths = 0;
 
     auto cleanup = [&] (bool retry_because_of_metadata_conflict)
     {

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.h
@@ -67,7 +67,7 @@ void generateManifestList(
     ContextPtr context,
     const Strings & manifest_entry_names,
     Poco::JSON::Object::Ptr new_snapshot,
-    Int32 manifest_length,
+    Int64 manifest_length,
     WriteBuffer & buf,
     Iceberg::FileContentType content_type,
     bool use_previous_snapshots = true);
@@ -106,8 +106,8 @@ private:
     ContextPtr context;
     std::optional<FormatSettings> format_settings;
     KeyDescription sort_description;
-    Int32 total_rows = 0;
-    Int32 total_chunks_size = 0;
+    Int64 total_rows = 0;
+    Int64 total_chunks_size = 0;
 
     void finalizeBuffers();
     void releaseBuffers();

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/MetadataGenerator.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/MetadataGenerator.cpp
@@ -106,12 +106,12 @@ MetadataGenerator::NextMetadataResult MetadataGenerator::generateNextMetadata(
     FileNamesGenerator & generator,
     const String & metadata_filename,
     Int64 parent_snapshot_id,
-    Int32 added_files,
-    Int32 added_records,
-    Int32 added_files_size,
-    Int32 num_partitions,
-    Int32 added_delete_files,
-    Int32 num_deleted_rows,
+    Int64 added_files,
+    Int64 added_records,
+    Int64 added_files_size,
+    Int64 num_partitions,
+    Int64 added_delete_files,
+    Int64 num_deleted_rows,
     std::optional<Int64> user_defined_snapshot_id,
     std::optional<Int64> user_defined_timestamp)
 {
@@ -155,9 +155,9 @@ MetadataGenerator::NextMetadataResult MetadataGenerator::generateNextMetadata(
         summary->set(Iceberg::f_changed_partition_count, std::to_string(num_partitions));
     }
 
-    auto sum_with_parent_snapshot = [&](const char * field_name, Int32 snapshot_value)
+    auto sum_with_parent_snapshot = [&](const char * field_name, Int64 snapshot_value)
     {
-        Int32 prev_value = parent_snapshot ? std::stoi(parent_snapshot->getObject(Iceberg::f_summary)->getValue<String>(field_name)) : 0;
+        Int64 prev_value = parent_snapshot ? std::stoi(parent_snapshot->getObject(Iceberg::f_summary)->getValue<String>(field_name)) : 0;
         summary->set(field_name, std::to_string(prev_value + snapshot_value));
     };
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/MetadataGenerator.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/MetadataGenerator.h
@@ -23,12 +23,12 @@ public:
         FileNamesGenerator & generator,
         const String & metadata_filename,
         Int64 parent_snapshot_id,
-        Int32 added_files,
-        Int32 added_records,
-        Int32 added_files_size,
-        Int32 num_partitions,
-        Int32 added_delete_files,
-        Int32 num_deleted_rows,
+        Int64 added_files,
+        Int64 added_records,
+        Int64 added_files_size,
+        Int64 num_partitions,
+        Int64 added_delete_files,
+        Int64 num_deleted_rows,
         std::optional<Int64> user_defined_snapshot_id = std::nullopt,
         std::optional<Int64> user_defined_timestamp = std::nullopt);
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Int32 -> Int64 to prevent overflow in statistics and total rows count in iceberg writes

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.584`
<!-- ch-version-info:end -->