### PR TITLE
Validate witness version in bech32 to avoid buffer overflow

### DIFF
--- a/tests/queries/0_stateless/03915_bech32_invalid_witness_version.reference
+++ b/tests/queries/0_stateless/03915_bech32_invalid_witness_version.reference
@@ -1,0 +1,3 @@
+bc1qw3jhxaq2azfhz
+bc1pw3jhxaqz7j562
+bc1sw3jhxaq2aj0ly

--- a/tests/queries/0_stateless/03915_bech32_invalid_witness_version.sql
+++ b/tests/queries/0_stateless/03915_bech32_invalid_witness_version.sql
@@ -1,0 +1,18 @@
+-- Test valid witness versions (0-16)
+SELECT bech32Encode('bc', 'test', 0);
+SELECT bech32Encode('bc', 'test', 1);
+SELECT bech32Encode('bc', 'test', 16);
+
+-- Test invalid witness versions (should throw BAD_ARGUMENTS exception)
+SELECT bech32Encode('bc', 'test', 17); -- { serverError BAD_ARGUMENTS }
+SELECT bech32Encode('bc', 'test', 32); -- { serverError BAD_ARGUMENTS }
+SELECT bech32Encode('bc', 'test', 40); -- { serverError BAD_ARGUMENTS }
+SELECT bech32Encode('bc', 'test', 255); -- { serverError BAD_ARGUMENTS }
+
+-- Test the original fuzzer repro case (witness version 40 causing buffer overflow)
+DROP TABLE IF EXISTS hex_data_test;
+SET allow_suspicious_low_cardinality_types=1;
+CREATE TABLE hex_data_test (hrp String, data String, witver LowCardinality(UInt8)) ENGINE = Memory;
+INSERT INTO hex_data_test VALUES ('bc', 'test_data', 0);
+SELECT bech32Encode(hrp, toFixedString('751e76e8199196d454941c45d1b3a323f1433bd6', 40), 40) FROM hex_data_test; -- { serverError BAD_ARGUMENTS }
+DROP TABLE hex_data_test;

--- a/tests/queries/0_stateless/03915_bech32_invalid_witness_version.sql
+++ b/tests/queries/0_stateless/03915_bech32_invalid_witness_version.sql
@@ -1,3 +1,4 @@
+-- Tags: no-fasttest
 -- Test valid witness versions (0-16)
 SELECT bech32Encode('bc', 'test', 0);
 SELECT bech32Encode('bc', 'test', 1);


### PR DESCRIPTION
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Validate witness version in bech32 to avoid buffer overflow

Fix https://github.com/ClickHouse/ClickHouse/issues/96668

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.593`
- Backported to: `26.1.3.33`, `25.12.6.24`, `25.11.9.31`, `25.8.17.17`
<!-- ch-version-info:end -->