### PR TITLE
Fix flaky 01675_distributed_bytes_to_delay_insert under MSan

### DIFF
--- a/tests/queries/0_stateless/01675_distributed_bytes_to_delay_insert.sh
+++ b/tests/queries/0_stateless/01675_distributed_bytes_to_delay_insert.sh
@@ -46,7 +46,7 @@ function test_max_delay_to_insert_will_throw()
 #
 function test_max_delay_to_insert_will_succeed_once()
 {
-    local max_delay_to_insert=4
+    local max_delay_to_insert=20
     local flush_delay=2
 
     drop_tables


### PR DESCRIPTION
## Summary
- The test `01675_distributed_bytes_to_delay_insert` is flaky under MSan due to tight timing margins
- It uses `max_delay_to_insert=4` with `flush_delay=2`, giving only ~1 second of effective headroom before the retry threshold (`diff >= max_delay_to_insert - 1 = 3`)
- Under MSan, overhead consistently pushes total time past 3 seconds, exhausting all 20 retries
- Increase `max_delay_to_insert` from 4 to 20, giving ~17 seconds of headroom while still testing the same behavior

## Test plan
- [ ] Verify the test passes under MSan CI

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.591`
<!-- ch-version-info:end -->