### PR TITLE
Fix flaky test_keeper_http_control_readiness integration test

### DIFF
--- a/tests/integration/test_keeper_http_control_readiness/test.py
+++ b/tests/integration/test_keeper_http_control_readiness/test.py
@@ -83,3 +83,6 @@ def test_http_readiness_partitioned_cluster(started_cluster):
         assert readiness_data["status"] == "fail"
         assert readiness_data["details"]["role"] == "follower"
         assert readiness_data["details"]["hasLeader"] == False
+
+    # Wait for cluster to recover after partition is healed
+    keeper_utils.wait_nodes(cluster, [node1, node2, node3])


### PR DESCRIPTION
## Summary
- The `test_keeper_http_control_readiness` integration test partitions the Keeper cluster to verify readiness endpoint behavior during quorum loss, but does not wait for the cluster to recover after the partition heals
- When the test is retried, subsequent iterations fail with `Exception: No followers in Keeper cluster` because nodes haven't re-established their roles yet
- Added `keeper_utils.wait_nodes` after the `PartitionManager` context exits to ensure all nodes are fully connected before the next iteration

## Test plan
- [x] Verified that failed test iterations (3, 5, 6, 7, 8, 10 out of 10) all have the same root cause: `get_any_follower` called before cluster recovery
- [ ] CI should pass the `test_keeper_http_control_readiness` test without flaky failures

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.592`
<!-- ch-version-info:end -->