### PR TITLE
Allow alias in MODIFY ORDER BY to fix AST Inconsistency

### DIFF
--- a/src/Parsers/ParserAlterQuery.cpp
+++ b/src/Parsers/ParserAlterQuery.cpp
@@ -142,7 +142,7 @@ bool ParserAlterCommand::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
     ParserProjectionDeclaration parser_projection_decl;
     ParserCompoundColumnDeclaration parser_modify_col_decl(false, false, true);
     ParserPartition parser_partition;
-    ParserExpression parser_exp_elem;
+    ParserExpressionWithOptionalAlias parser_exp_elem(false);
     ParserList parser_assignment_list(
         std::make_unique<ParserAssignment>(), std::make_unique<ParserToken>(TokenType::Comma),
         /* allow_empty = */ false);

--- a/tests/queries/0_stateless/03786_AST_formatting_inconsistencies_in_debug_check.reference
+++ b/tests/queries/0_stateless/03786_AST_formatting_inconsistencies_in_debug_check.reference
@@ -58,3 +58,7 @@ Original:          SELECT 1,2,3 EXCEPT SELECT 1,2,3;
 format(original):  (SELECT 1, 2, 3) EXCEPT (SELECT 1, 2, 3)
 format(formatted): (SELECT 1, 2, 3) EXCEPT (SELECT 1, 2, 3)
 
+Original:          ALTER TABLE `t55` (MODIFY ORDER BY ((`c0` AS `a0`)));
+format(original):  ALTER TABLE t55 (MODIFY ORDER BY c0 AS a0)
+format(formatted): ALTER TABLE t55 (MODIFY ORDER BY c0 AS a0)
+

--- a/tests/queries/0_stateless/03786_AST_formatting_inconsistencies_in_debug_check.sh
+++ b/tests/queries/0_stateless/03786_AST_formatting_inconsistencies_in_debug_check.sh
@@ -51,3 +51,6 @@ format_query "INSERT INTO tab2 SELECT * FROM tab EXCEPT SELECT * FROM tab;"
 
 # Test weird SELECT/EXCEPT/SELECT statement
 format_query "SELECT 1,2,3 EXCEPT SELECT 1,2,3;"
+
+# Allow alias in MODIFY ORDER BY
+format_query "ALTER TABLE \`t55\` (MODIFY ORDER BY ((\`c0\` AS \`a0\`)));"


### PR DESCRIPTION
Resolves https://github.com/ClickHouse/ClickHouse/issues/93861. Allow alias in MODIFY ORDER BY, e.g.:

```
ALTER TABLE t55 (MODIFY ORDER BY c0 AS a0)
```

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.600`
<!-- ch-version-info:end -->