### PR TITLE
Fix timeout in 03144_parallel_alter_add_drop_column_zookeeper_on_steroids

### DIFF
--- a/tests/queries/0_stateless/03144_parallel_alter_add_drop_column_zookeeper_on_steroids.sh
+++ b/tests/queries/0_stateless/03144_parallel_alter_add_drop_column_zookeeper_on_steroids.sh
@@ -109,6 +109,11 @@ wait
 
 echo "Finishing alters"
 
+# Sync replicas to help them process pending ALTER_METADATA entries from the alter storm
+for i in $(seq $REPLICAS); do
+    timeout 120 $CLICKHOUSE_CLIENT --query "SYSTEM SYNC REPLICA concurrent_alter_add_drop_steroids_$i" 2>/dev/null ||:
+done
+
 columns1=$($CLICKHOUSE_CLIENT --query "select count() from system.columns where table='concurrent_alter_add_drop_steroids_1' and database='$CLICKHOUSE_DATABASE'" 2> /dev/null)
 columns2=$($CLICKHOUSE_CLIENT --query "select count() from system.columns where table='concurrent_alter_add_drop_steroids_2' and database='$CLICKHOUSE_DATABASE'" 2> /dev/null)
 columns3=$($CLICKHOUSE_CLIENT --query "select count() from system.columns where table='concurrent_alter_add_drop_steroids_3' and database='$CLICKHOUSE_DATABASE'" 2> /dev/null)
@@ -129,7 +134,11 @@ done
 echo "Equal number of columns"
 
 # This alter will finish all previous, but replica 1 maybe still not up-to-date
+SYNC_TIMELIMIT=$((SECONDS + 300))
 while [[ $(timeout 120 ${CLICKHOUSE_CLIENT} --query "ALTER TABLE concurrent_alter_add_drop_steroids_1 MODIFY COLUMN value0 String SETTINGS replication_alter_partitions_sync=2" 2>&1) ]]; do
+    if [ $SECONDS -ge "$SYNC_TIMELIMIT" ]; then
+        break
+    fi
     sleep 1
 done
 

--- a/tests/queries/0_stateless/03144_parallel_alter_add_drop_column_zookeeper_on_steroids.sh
+++ b/tests/queries/0_stateless/03144_parallel_alter_add_drop_column_zookeeper_on_steroids.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 # Tags: zookeeper, no-parallel, no-fasttest
 
+# Regression test for https://github.com/ClickHouse/ClickHouse/pull/63353
+# A LOGICAL_ERROR "Unexpected return type from materialize" could occur during SELECT
+# after concurrent ALTERs, because `IMergeTreeReader::evaluateMissingDefaults` used the
+# column type from storage metadata instead of from the data part. During concurrent
+# MODIFY COLUMN (e.g. UInt8 -> String), a SELECT could read a part whose column type
+# didn't match the current metadata, causing a type mismatch when materializing columns.
+# The test reproduces this by running an intense concurrent workload of ADD/DROP/MODIFY
+# COLUMN, SELECT, OPTIMIZE, and INSERT across 3 replicas, then verifies replication consistency.
+
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix flaky timeout in test `03144_parallel_alter_add_drop_column_zookeeper_on_steroids`

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

---

The test was timing out (600s) in the `amd_debug, distributed plan, s3 storage, sequential` CI configuration. After the 10-second ALTER storm, the replicas had many pending `ALTER_METADATA` entries in their replication queues. The while loop that retries `ALTER TABLE ... MODIFY COLUMN ... replication_alter_partitions_sync=2` kept getting `CANNOT_ASSIGN_ALTER` (code 517) because replicas hadn't finished processing the backlog of metadata changes.

Fix by:
- Adding `SYSTEM SYNC REPLICA` calls after the ALTER storm to help replicas process pending metadata changes before convergence checks
- Adding a 300s time limit to the final ALTER retry loop to prevent indefinite hanging (the subsequent `check_replication_consistency` handles sync and consistency verification anyway)
- Adding a comment explaining the original purpose of the test (regression test for https://github.com/ClickHouse/ClickHouse/pull/63353)

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=cff01220ca0f01325fa912a1ceaa6c2cc956fe8d&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_debug%2C%20distributed%20plan%2C%20s3%20storage%2C%20sequential%29


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.608`
<!-- ch-version-info:end -->