### PR TITLE
stoi -> stoll in iceberg writes for proper count stats

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
@@ -496,7 +496,7 @@ void generateManifestList(
         if (version == 1)
         {
             set_versioned_field(1, Iceberg::f_added_files_count);
-            set_versioned_field(std::stoll(summary->getValue<String>(Iceberg::f_total_data_files)), Iceberg::f_existing_files_count);
+            set_versioned_field(std::stoi(summary->getValue<String>(Iceberg::f_total_data_files)), Iceberg::f_existing_files_count);
             set_versioned_field(0, Iceberg::f_deleted_files_count);
             if (summary->has(Iceberg::f_added_position_deletes))
                 set_versioned_field(summary->getValue<Int32>(Iceberg::f_added_position_deletes), Iceberg::f_deleted_rows_count);

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
@@ -496,7 +496,7 @@ void generateManifestList(
         if (version == 1)
         {
             set_versioned_field(1, Iceberg::f_added_files_count);
-            set_versioned_field(std::stoi(summary->getValue<String>(Iceberg::f_total_data_files)), Iceberg::f_existing_files_count);
+            set_versioned_field(std::stoll(summary->getValue<String>(Iceberg::f_total_data_files)), Iceberg::f_existing_files_count);
             set_versioned_field(0, Iceberg::f_deleted_files_count);
             if (summary->has(Iceberg::f_added_position_deletes))
                 set_versioned_field(summary->getValue<Int32>(Iceberg::f_added_position_deletes), Iceberg::f_deleted_rows_count);

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/MetadataGenerator.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/MetadataGenerator.cpp
@@ -157,7 +157,7 @@ MetadataGenerator::NextMetadataResult MetadataGenerator::generateNextMetadata(
 
     auto sum_with_parent_snapshot = [&](const char * field_name, Int64 snapshot_value)
     {
-        Int64 prev_value = parent_snapshot ? std::stoll(parent_snapshot->getObject(Iceberg::f_summary)->getValue<String>(field_name)) : 0;
+        Int64 prev_value = parent_snapshot ? parse<Int64>(parent_snapshot->getObject(Iceberg::f_summary)->getValue<String>(field_name)) : 0;
         summary->set(field_name, std::to_string(prev_value + snapshot_value));
     };
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/MetadataGenerator.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/MetadataGenerator.cpp
@@ -157,7 +157,7 @@ MetadataGenerator::NextMetadataResult MetadataGenerator::generateNextMetadata(
 
     auto sum_with_parent_snapshot = [&](const char * field_name, Int64 snapshot_value)
     {
-        Int64 prev_value = parent_snapshot ? std::stoi(parent_snapshot->getObject(Iceberg::f_summary)->getValue<String>(field_name)) : 0;
+        Int64 prev_value = parent_snapshot ? std::stoll(parent_snapshot->getObject(Iceberg::f_summary)->getValue<String>(field_name)) : 0;
         summary->set(field_name, std::to_string(prev_value + snapshot_value));
     };
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
stoi -> stoll in iceberg writes for proper count stats

Forgot to push, but it should work now:

```
INSERT INTO wikistat_iceberg7
SETTINGS max_insert_threads = 6
WITH
    parseDateTimeBestEffort(extract(_file, '^pageviews-([\\d\\-]+)\\.gz$')) AS time,
    splitByChar(' ', line) AS values,
    splitByChar('.', values[1]) AS projects
SELECT
    time,
    projects[1] AS project,
    projects[2] AS subproject,
    decodeURLComponent(values[2]) AS path,
    CAST(values[3], 'UInt64') AS hits
FROM s3('https://clickhouse-public-datasets.s3.amazonaws.com/wikistat/original/pageviews*.gz', 'LineAsString')
WHERE length(values) >= 3
LIMIT 2500000000
SETTINGS max_insert_threads = 6

Query id: 725e2b5a-18d5-4f40-bf00-b17c8c2eb735

Ok.

2500000000 rows in set. Elapsed: 569.398 sec. Processed 2.50 billion rows, 21.43 GB (4.39 million rows/s., 37.64 MB/s.)
Peak memory usage: 650.78 MiB.

:) select count() from wikistat_iceberg7;

SELECT count()
FROM wikistat_iceberg7

Query id: d1bacb07-ec6f-433e-8c8b-803bf855014a

   ┌────count()─┐
1. │ 2500000000 │ -- 2.50 billion
   └────────────┘

1 row in set. Elapsed: 1.302 sec. 

```

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.605`
<!-- ch-version-info:end -->