### PR TITLE
Fix pytest exit code handling in CI for targeted/flaky jobs

### DIFF
--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -1753,19 +1753,19 @@ class ResultTranslator:
             R = Result.create_from(name=name, results=list(test_results.values()))
 
             if session_exitstatus not in (0, 1):
-                R.status = Result.Status.ERROR
-                if session_exitstatus not in (2,):
-                    R.info = f"Test execution was interrupted (exit status: {session_exitstatus})"
-                elif session_exitstatus not in (3,):
-                    R.info = f"Internal error in pytest or a plugin (exit status: {session_exitstatus})"
-                elif session_exitstatus not in (4,):
-                    R.info = f"pytest command line usage error (exit status: {session_exitstatus})"
-                elif session_exitstatus not in (5,):
-                    R.info = (
-                        f"No tests were collected (exit status: {session_exitstatus})"
-                    )
+                if session_exitstatus == 5:
+                    R.status = Result.Status.SUCCESS
+                    R.info = "No tests were collected (exit status: 5)"
                 else:
-                    R.info = f"Unknown error (exit status: {session_exitstatus})"
+                    R.status = Result.Status.ERROR
+                    if session_exitstatus == 2:
+                        R.info = f"Test execution was interrupted (exit status: {session_exitstatus})"
+                    elif session_exitstatus == 3:
+                        R.info = f"Internal error in pytest or a plugin (exit status: {session_exitstatus})"
+                    elif session_exitstatus == 4:
+                        R.info = f"pytest command line usage error (exit status: {session_exitstatus})"
+                    else:
+                        R.info = f"Unknown error (exit status: {session_exitstatus})"
             if session_exitstatus == 1:
                 if R.status == Result.Status.SUCCESS:
                     print(


### PR DESCRIPTION
Two bugs were fixed in `from_pytest_jsonl` in `ci/praktika/result.py`:

1. The `if`/`elif` chain for pytest exit codes used inverted conditions (`not in (N,)` instead of `== N`), so every non-0/1 exit code always matched the first branch and displayed "Test execution was interrupted" regardless of the actual exit code.

2. Pytest exit code 5 ("no tests collected") was treated as an error. This is expected for targeted and flaky integration test jobs when the test selector identifies tests by name but pytest cannot collect them (e.g. parametrized test ID mismatch). Now exit code 5 sets status to SUCCESS with an informational message instead of ERROR.

Example of false error: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96351&sha=latest&name_0=PR
https://github.com/ClickHouse/ClickHouse/pull/96351

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.597`
<!-- ch-version-info:end -->