### PR TITLE
Skip qemu-based tests under LLVM coverage builds

### DIFF
--- a/tests/queries/0_stateless/01103_check_cpu_instructions_at_startup.sh
+++ b/tests/queries/0_stateless/01103_check_cpu_instructions_at_startup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-tsan, no-asan, no-ubsan, no-msan, no-debug, no-fasttest, no-cpu-aarch64
+# Tags: no-tsan, no-asan, no-ubsan, no-msan, no-debug, no-fasttest, no-cpu-aarch64, no-llvm-coverage
 # Tag no-fasttest: avoid dependency on qemu -- inconvenient when running locally
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)

--- a/tests/queries/0_stateless/03590_simdjson_fallback.sh
+++ b/tests/queries/0_stateless/03590_simdjson_fallback.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-tsan, no-asan, no-ubsan, no-msan, no-debug, no-fasttest, no-cpu-aarch64
+# Tags: no-tsan, no-asan, no-ubsan, no-msan, no-debug, no-fasttest, no-cpu-aarch64, no-llvm-coverage
 # Tag no-fasttest: avoid dependency on qemu -- inconvenient when running locally
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)


### PR DESCRIPTION
## Summary
- Tests `01103_check_cpu_instructions_at_startup` and `03590_simdjson_fallback` run ClickHouse under `qemu-x86_64-static` to verify behavior with reduced CPU instruction sets
- Under LLVM coverage instrumentation, qemu execution becomes extremely slow, causing 600s timeouts
- Added the `no-llvm-coverage` tag to both tests to skip them in coverage builds

CI reports:
- https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=c45224e3f0a6dd9a9217e5d75723f378ffe0a86a&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_llvm_coverage%2C%203%2F3%29
- https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=c45224e3f0a6dd9a9217e5d75723f378ffe0a86a&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_llvm_coverage%2C%202%2F3%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.603`
<!-- ch-version-info:end -->