### PR TITLE
Add merge tree output rows profile event

### DIFF
--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -377,7 +377,8 @@
     M(SelectedMarksTotal, "Number of total marks (index granules) before selecting which ones to read from a MergeTree table.", ValueType::Number) \
     M(SelectedRows, "Number of rows SELECTed from all tables.", ValueType::Number) \
     M(SelectedBytes, "Number of bytes (uncompressed; for columns as they stored in memory) SELECTed from all tables.", ValueType::Bytes) \
-    M(RowsReadByMainReader, "Number of rows read from MergeTree tables by the main reader (after PREWHERE step).", ValueType::Number) \
+    M(RowsReadByMainReader, "Number of rows read from MergeTree tables by the main reader (after PREWHERE step). Includes all rows from granules that were not fully filtered by PREWHERE, even if only some rows in those granules matched.", ValueType::Number) \
+    M(MergeTreeOutputRows, "Number of rows output by MergeTree after PREWHERE filtering. Only counts rows that survived all PREWHERE filters, unlike RowsReadByMainReader which counts full granules.", ValueType::Number) \
     M(RowsReadByPrewhereReaders, "Number of rows read from MergeTree tables (in total) by prewhere readers.", ValueType::Number) \
     M(LoadedDataParts, "Number of data parts loaded by MergeTree tables during initialization.", ValueType::Number) \
     M(LoadedDataPartsMicroseconds, "Microseconds spent by MergeTree tables for loading data parts during initialization.", ValueType::Microseconds) \

--- a/src/Storages/MergeTree/MergeTreeSource.cpp
+++ b/src/Storages/MergeTree/MergeTreeSource.cpp
@@ -6,6 +6,11 @@
 #include <Common/EventFD.h>
 #include <Common/setThreadName.h>
 
+namespace ProfileEvents
+{
+    extern const Event MergeTreeOutputRows;
+}
+
 namespace DB
 {
 
@@ -181,6 +186,8 @@ Chunk MergeTreeSource::processReadResult(ChunkAndProgress chunk)
 {
     if (chunk.num_read_rows || chunk.num_read_bytes)
         progress(chunk.num_read_rows, chunk.num_read_bytes);
+
+    ProfileEvents::increment(ProfileEvents::MergeTreeOutputRows, chunk.chunk.getNumRows());
 
     finished = chunk.is_finished;
 


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry

Add MergeTreeOutputRows profile event that counts the number of rows output by MergeTree sources after PREWHERE filtering (including WHERE conditions automatically moved to PREWHERE by optimize_move_to_prewhere). Unlike RowsReadByMainReader which counts all rows from partially-matched granules, this metric counts only the rows that survived all PREWHERE filters.


### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

Part of ProfileEvents.cpp