### PR TITLE
Fix timeout in 00974_text_log_table_not_empty test

### DIFF
--- a/tests/queries/0_stateless/00974_text_log_table_not_empty.sh
+++ b/tests/queries/0_stateless/00974_text_log_table_not_empty.sh
@@ -11,7 +11,7 @@ do
 
 ${CLICKHOUSE_CLIENT} --query="SYSTEM FLUSH LOGS text_log"
 sleep 0.1;
-if [[ $($CLICKHOUSE_CURL -sS "$CLICKHOUSE_URL" -d "SELECT count() > 0 FROM system.text_log WHERE position(system.text_log.message, 'SELECT 6103') > 0 AND event_date >= yesterday() SETTINGS max_rows_to_read = 0") == 1 ]]; then echo 1; exit; fi;
+if [[ $($CLICKHOUSE_CURL -sS "$CLICKHOUSE_URL" -d "SELECT 1 FROM system.text_log WHERE position(system.text_log.message, 'SELECT 6103') > 0 AND event_date >= yesterday() LIMIT 1 SETTINGS max_rows_to_read = 0") == 1 ]]; then echo 1; exit; fi;
 
 done;
 


### PR DESCRIPTION
## Summary
- The `00974_text_log_table_not_empty` test timed out in TSan + S3 CI because it used `SELECT count() > 0 FROM system.text_log WHERE ...` which scans the entire `system.text_log` table before returning a result.
- Under TSan with randomized settings `max_threads=1` and `http_wait_end_of_query=True`, scanning the large `text_log` table took more than 120 seconds per HTTP request, causing curl timeouts.
- Changed the query to `SELECT 1 ... LIMIT 1` to enable early termination — the query stops scanning as soon as the first matching row is found.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=604695a5932ef013cfc1537477fc85c732041136&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_tsan%2C%20s3%20storage%2C%20parallel%2C%202%2F2%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.604`
<!-- ch-version-info:end -->