### PR TITLE
Fix TSan data race on fault_probability in MemoryTracker

### DIFF
--- a/src/Common/MemoryTracker.cpp
+++ b/src/Common/MemoryTracker.cpp
@@ -317,8 +317,9 @@ AllocationTrace MemoryTracker::allocImpl(Int64 size, bool throw_if_memory_exceed
         allocation_traced = true;
     }
 
-    std::bernoulli_distribution fault(fault_probability);
-    if (unlikely(fault_probability > 0.0 && fault(thread_local_rng)))
+    double current_fault_probability = fault_probability.load(std::memory_order_relaxed);
+    std::bernoulli_distribution fault(current_fault_probability);
+    if (unlikely(current_fault_probability > 0.0 && fault(thread_local_rng)))
     {
         if (memoryTrackerCanThrow(level, true) && throw_if_memory_exceeded)
         {

--- a/src/Common/MemoryTracker.h
+++ b/src/Common/MemoryTracker.h
@@ -67,7 +67,7 @@ private:
     Int64 profiler_step = 0;
 
     /// To test exception safety of calling code, memory tracker throws an exception on each memory allocation with specified probability.
-    double fault_probability = 0;
+    std::atomic<double> fault_probability = 0;
 
     /// To randomly sample allocations and deallocations in trace_log.
     double sample_probability = -1;
@@ -172,7 +172,7 @@ public:
 
     void setFaultProbability(double value)
     {
-        fault_probability = value;
+        fault_probability.store(value, std::memory_order_relaxed);
     }
 
     void injectFault() const;


### PR DESCRIPTION
## Summary

- Fix a data race detected by ThreadSanitizer in the TSan stress test: `ProcessList::insert` writes `fault_probability` (via `setFaultProbability`) on the thread group's `MemoryTracker` while another thread reads it in `MemoryTracker::allocImpl`.
- Make `fault_probability` an `std::atomic<double>` with relaxed memory ordering, consistent with how other `MemoryTracker` fields (`soft_limit`, `hard_limit`, etc.) are already handled.
- Load the value once into a local variable on the read side to avoid redundant atomic loads.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=3b39cb74b3dd824e53a1699fe275df79bee80333&name_0=MasterCI&name_1=Stress%20test%20%28amd_tsan%29&name_1=Stress%20test%20%28amd_tsan%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.607`
<!-- ch-version-info:end -->