### PR TITLE
Fix flaky 00062_replicated_merge_tree_alter_zookeeper_long test

### DIFF
--- a/tests/queries/0_stateless/00062_replicated_merge_tree_alter_zookeeper_long.sql
+++ b/tests/queries/0_stateless/00062_replicated_merge_tree_alter_zookeeper_long.sql
@@ -88,6 +88,7 @@ DESC TABLE replicated_alter2;
 SHOW CREATE TABLE replicated_alter2;
 SELECT * FROM replicated_alter1 ORDER BY k;
 
+OPTIMIZE TABLE replicated_alter1 FINAL;
 ALTER TABLE replicated_alter1 ADD COLUMN n.s Array(String), ADD COLUMN n.d Array(Date);
 
 DESC TABLE replicated_alter1;

--- a/tests/queries/0_stateless/00974_text_log_table_not_empty.sh
+++ b/tests/queries/0_stateless/00974_text_log_table_not_empty.sh
@@ -11,7 +11,7 @@ do
 
 ${CLICKHOUSE_CLIENT} --query="SYSTEM FLUSH LOGS text_log"
 sleep 0.1;
-if [[ $($CLICKHOUSE_CURL -sS "$CLICKHOUSE_URL" -d "SELECT count() > 0 FROM system.text_log WHERE position(system.text_log.message, 'SELECT 6103') > 0 AND event_date >= yesterday() SETTINGS max_rows_to_read = 0") == 1 ]]; then echo 1; exit; fi;
+if [[ $($CLICKHOUSE_CURL -sS "$CLICKHOUSE_URL" -d "SELECT 1 FROM system.text_log WHERE position(system.text_log.message, 'SELECT 6103') > 0 AND event_date >= yesterday() LIMIT 1 SETTINGS max_rows_to_read = 0") == 1 ]]; then echo 1; exit; fi;
 
 done;
 


### PR DESCRIPTION
## Summary
- Add `OPTIMIZE TABLE FINAL` before re-adding previously dropped nested columns to ensure old data files are cleaned up
- After dropping columns `n.ui8`, `n.d`, `n.s` and re-adding `n.s` and `n.d`, stale data files may persist in unmerged parts, causing the re-added columns to read old values instead of empty defaults
- The test was non-deterministic because it depended on whether a background merge happened between the drop and re-add operations

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=7effd50e10a8dbbc66fd15b45370bb6bfe9b5e92&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_debug%2C%20distributed%20plan%2C%20s3%20storage%2C%20parallel%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)