### PR TITLE
Fix flaky tests 03652_memory_usage_headers and 03760_keep_alive_insert_select

### DIFF
--- a/tests/queries/0_stateless/03652_memory_usage_headers.sh
+++ b/tests/queries/0_stateless/03652_memory_usage_headers.sh
@@ -30,7 +30,9 @@ echo "$CURL_OUTPUT" | grep -m1 'X-ClickHouse-Summary:' | grep -q '"memory_usage"
 CURL_OUTPUT="$(
     ${CLICKHOUSE_CURL} -s -S -v -N -G "${CLICKHOUSE_URL}" \
     --data-urlencode "query=SELECT number, avg(number) FROM numbers(1e12) GROUP BY number FORMAT Null SETTINGS max_rows_to_read = 0" \
-    --data-urlencode "max_memory_usage=20000000" 2>&1
+    --data-urlencode "max_memory_usage=20000000" \
+    --data-urlencode "max_bytes_before_external_group_by=0" \
+    --data-urlencode "max_bytes_ratio_before_external_group_by=0" 2>&1
 )"
 
 echo "$CURL_OUTPUT" | grep 'X-ClickHouse-Summary:' | grep -q '"memory_usage":"[1-9][0-9]*"' && echo "Ok"

--- a/tests/queries/0_stateless/03760_keep_alive_insert_select.sh
+++ b/tests/queries/0_stateless/03760_keep_alive_insert_select.sh
@@ -23,7 +23,7 @@ ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}" \
 # Use max_threads=0 to avoid randomized max_threads limiting parallelism,
 # which can make scanning system.text_log too slow under TSan.
 ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&max_threads=0" \
-    -d "SELECT message FROM system.text_log WHERE event_date >= yesterday() AND event_time >= now() - 600 AND level='Error' AND query_id='${query_id}' AND message LIKE '%Request stream is shared by multiple threads. HTTP keep alive is not possible.%'"
+    -d "SELECT message_format_string FROM system.text_log WHERE event_date >= yesterday() AND event_time >= now() - 600 AND level='Error' AND query_id='${query_id}' AND message_format_string = 'Request stream is shared by multiple threads. HTTP keep alive is not possible. Use count {}'"
 
 ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}" -H 'Accept-Encoding: gzip' \
     -d 'DROP TABLE insert_number_table'

--- a/tests/queries/0_stateless/03760_keep_alive_insert_select.sh
+++ b/tests/queries/0_stateless/03760_keep_alive_insert_select.sh
@@ -18,10 +18,12 @@ query_id=$(
 )
 
 ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}" \
-    -d "system flush logs text_log"
+    -d "SYSTEM FLUSH LOGS text_log"
 
-${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}" \
-    -d "SELECT message FROM system.text_log WHERE level='Error' AND query_id='${query_id}' AND message LIKE '%Request stream is shared by multiple threads. HTTP keep alive is not possible.%'"
+# Use max_threads=0 to avoid randomized max_threads limiting parallelism,
+# which can make scanning system.text_log too slow under TSan.
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&max_threads=0" \
+    -d "SELECT message FROM system.text_log WHERE event_date >= yesterday() AND event_time >= now() - 600 AND level='Error' AND query_id='${query_id}' AND message LIKE '%Request stream is shared by multiple threads. HTTP keep alive is not possible.%'"
 
 ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}" -H 'Accept-Encoding: gzip' \
     -d 'DROP TABLE insert_number_table'


### PR DESCRIPTION
## Summary
- `03652_memory_usage_headers`: The OOM query expects exception code 241 at `max_memory_usage=20000000`, but randomized `max_bytes_before_external_group_by` can spill aggregation data to disk before reaching that limit, preventing the OOM. Fix: explicitly disable external group by for the OOM query.
- `03760_keep_alive_insert_select`: The diagnostic SELECT on `system.text_log` scanned 3.4M rows (485 MB) with randomized `max_threads=3` under TSan, taking 127.5s and exceeding the 120s curl timeout. Fix: override `max_threads=0` and add `event_date >= yesterday() AND event_time >= now() - 600` to prune old data via the primary key.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=21de9f93eeee2dfdf3734cdcddad0416e8437f1b&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_tsan%2C%20s3%20storage%2C%20parallel%2C%201%2F2%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.606`
<!-- ch-version-info:end -->