### PR TITLE
Fix flaky test 02572_materialized_views_ignore_errors

### DIFF
--- a/tests/queries/0_stateless/02572_materialized_views_ignore_errors.reference
+++ b/tests/queries/0_stateless/02572_materialized_views_ignore_errors.reference
@@ -13,7 +13,7 @@ from system.query_views_log where
     order by event_date, event_time
 ;
 exceptionwhileprocessing	UNKNOWN_TABLE
--- materialized_views_ignore_errors=0
+SET materialized_views_ignore_errors = 0;
 insert into data_02572 values (1); -- { serverError UNKNOWN_TABLE }
 select * from data_02572 order by key;
 1

--- a/tests/queries/0_stateless/02572_materialized_views_ignore_errors.reference
+++ b/tests/queries/0_stateless/02572_materialized_views_ignore_errors.reference
@@ -15,13 +15,12 @@ from system.query_views_log where
 exceptionwhileprocessing	UNKNOWN_TABLE
 -- materialized_views_ignore_errors=0
 insert into data_02572 values (1); -- { serverError UNKNOWN_TABLE }
-select * from data_02572 order by key;
-1
-2
+-- Note: whether value 1 ends up in the source table after a failed INSERT is non-deterministic.
+-- With `use_async_executor_for_materialized_views = 1`, the pipeline task scheduling order changes,
+-- and the MV exception may cancel the pipeline before `MemorySink::onFinish` commits the data.
 create table receiver_02572 as data_02572;
 insert into data_02572 values (3);
-select * from data_02572 order by key;
-1
+select * from data_02572 where key in (2, 3) order by key;
 2
 3
 select * from receiver_02572 order by key;

--- a/tests/queries/0_stateless/02572_materialized_views_ignore_errors.reference
+++ b/tests/queries/0_stateless/02572_materialized_views_ignore_errors.reference
@@ -15,12 +15,13 @@ from system.query_views_log where
 exceptionwhileprocessing	UNKNOWN_TABLE
 -- materialized_views_ignore_errors=0
 insert into data_02572 values (1); -- { serverError UNKNOWN_TABLE }
--- Note: whether value 1 ends up in the source table after a failed INSERT is non-deterministic.
--- With `use_async_executor_for_materialized_views = 1`, the pipeline task scheduling order changes,
--- and the MV exception may cancel the pipeline before `MemorySink::onFinish` commits the data.
+select * from data_02572 order by key;
+1
+2
 create table receiver_02572 as data_02572;
 insert into data_02572 values (3);
-select * from data_02572 where key in (2, 3) order by key;
+select * from data_02572 order by key;
+1
 2
 3
 select * from receiver_02572 order by key;

--- a/tests/queries/0_stateless/02572_materialized_views_ignore_errors.sql
+++ b/tests/queries/0_stateless/02572_materialized_views_ignore_errors.sql
@@ -1,4 +1,8 @@
 set prefer_localhost_replica=1;
+-- With `use_async_executor_for_materialized_views = 1`, the pipeline task scheduling may cause
+-- the MV exception to cancel the pipeline before `MemorySink::onFinish` commits the data,
+-- making the source table content after a failed INSERT non-deterministic.
+set use_async_executor_for_materialized_views = 0;
 
 drop table if exists data_02572;
 drop table if exists proxy_02572;
@@ -31,12 +35,10 @@ from system.query_views_log where
 
 -- materialized_views_ignore_errors=0
 insert into data_02572 values (1); -- { serverError UNKNOWN_TABLE }
--- Note: whether value 1 ends up in the source table after a failed INSERT is non-deterministic.
--- With `use_async_executor_for_materialized_views = 1`, the pipeline task scheduling order changes,
--- and the MV exception may cancel the pipeline before `MemorySink::onFinish` commits the data.
+select * from data_02572 order by key;
 
 create table receiver_02572 as data_02572;
 
 insert into data_02572 values (3);
-select * from data_02572 where key in (2, 3) order by key;
+select * from data_02572 order by key;
 select * from receiver_02572 order by key;

--- a/tests/queries/0_stateless/02572_materialized_views_ignore_errors.sql
+++ b/tests/queries/0_stateless/02572_materialized_views_ignore_errors.sql
@@ -33,7 +33,7 @@ from system.query_views_log where
     order by event_date, event_time
 ;
 
--- materialized_views_ignore_errors=0
+SET materialized_views_ignore_errors = 0;
 insert into data_02572 values (1); -- { serverError UNKNOWN_TABLE }
 select * from data_02572 order by key;
 

--- a/tests/queries/0_stateless/02572_materialized_views_ignore_errors.sql
+++ b/tests/queries/0_stateless/02572_materialized_views_ignore_errors.sql
@@ -31,10 +31,12 @@ from system.query_views_log where
 
 -- materialized_views_ignore_errors=0
 insert into data_02572 values (1); -- { serverError UNKNOWN_TABLE }
-select * from data_02572 order by key;
+-- Note: whether value 1 ends up in the source table after a failed INSERT is non-deterministic.
+-- With `use_async_executor_for_materialized_views = 1`, the pipeline task scheduling order changes,
+-- and the MV exception may cancel the pipeline before `MemorySink::onFinish` commits the data.
 
 create table receiver_02572 as data_02572;
 
 insert into data_02572 values (3);
-select * from data_02572 order by key;
+select * from data_02572 where key in (2, 3) order by key;
 select * from receiver_02572 order by key;


### PR DESCRIPTION
## Summary
- Fix flaky test `02572_materialized_views_ignore_errors` that fails with randomized setting `use_async_executor_for_materialized_views = 1`
- With `use_async_executor_for_materialized_views = 1`, the pipeline task scheduling may cause the MV exception to cancel the pipeline before `MemorySink::onFinish` commits the data to the source table. This makes the content of the source Memory table after a failed INSERT non-deterministic — value 1 from the failed INSERT may or may not end up in the table.
- Explicitly set `use_async_executor_for_materialized_views = 0` for this test since it relies on data being committed to the source table before the MV error propagates.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=84eb34f32f31077fd3461399bfdd5053d5f6f277&name_0=MasterCI&name_1=Stateless%20tests%20%28arm_binary%2C%20parallel%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.615`
<!-- ch-version-info:end -->