### PR TITLE
Do not auto-remove pr-performance label when changelog category differs

### DIFF
--- a/ci/jobs/scripts/workflow_hooks/pr_labels_and_category.py
+++ b/ci/jobs/scripts/workflow_hooks/pr_labels_and_category.py
@@ -140,11 +140,17 @@ def check_labels(category, info):
     if category in CATEGORY_TO_LABEL and CATEGORY_TO_LABEL[category] not in labels:
         pr_labels_to_add.append(CATEGORY_TO_LABEL[category])
 
+    # Labels that should not be auto-removed even if they don't match the current
+    # category, because they serve additional purposes (e.g., enabling performance
+    # tests in CI when set manually).
+    protected_labels = {Labels.PR_PERFORMANCE}
+
     for label in labels:
         if (
             label in CATEGORY_TO_LABEL.values()
             and category in CATEGORY_TO_LABEL
             and label != CATEGORY_TO_LABEL[category]
+            and label not in protected_labels
         ):
             pr_labels_to_remove.append(label)
 

--- a/utils/prepare-time-trace/prepare-time-trace.sh
+++ b/utils/prepare-time-trace/prepare-time-trace.sh
@@ -110,7 +110,7 @@ ORDER BY (date, file, symbol, pull_request_number, commit_sha, check_name);
 ///
 
 # nm does not work with LTO
-if ! grep -q -- '-flto' compile_commands.json
+if ! grep -q -- '-flto' "$INPUT_DIR/compile_commands.json"
 then
     # Find the best alternative of nm
     for name in llvm-nm-{30..18} llvm-nm nm
@@ -119,7 +119,7 @@ then
         [[ -n "${NM}" ]] && break
     done
 
-    find "$INPUT_DIR" -type f -name '*.o' | grep -v cargo | find . -name '*.o' | xargs -P $(nproc) -I {} bash -c "
+    find "$INPUT_DIR" -type f -name '*.o' | grep -v cargo | xargs -P $(nproc) -I {} bash -c "
       ${NM} --demangle --defined-only --print-size '{}' | grep -v -P '[0-9a-zA-Z] r ' | sed 's@^@{} @' > '{}.symbols'
     "
 

--- a/utils/prepare-time-trace/prepare-time-trace.sh
+++ b/utils/prepare-time-trace/prepare-time-trace.sh
@@ -110,7 +110,7 @@ ORDER BY (date, file, symbol, pull_request_number, commit_sha, check_name);
 ///
 
 # nm does not work with LTO
-if ! grep -q -- '-flto' "$INPUT_DIR/compile_commands.json"
+if ! grep -q -- '-flto' compile_commands.json
 then
     # Find the best alternative of nm
     for name in llvm-nm-{30..18} llvm-nm nm
@@ -119,7 +119,7 @@ then
         [[ -n "${NM}" ]] && break
     done
 
-    find "$INPUT_DIR" -type f -name '*.o' | grep -v cargo | xargs -P $(nproc) -I {} bash -c "
+    find "$INPUT_DIR" -type f -name '*.o' | grep -v cargo | find . -name '*.o' | xargs -P $(nproc) -I {} bash -c "
       ${NM} --demangle --defined-only --print-size '{}' | grep -v -P '[0-9a-zA-Z] r ' | sed 's@^@{} @' > '{}.symbols'
     "
 


### PR DESCRIPTION
The `pr-performance` label serves a dual purpose: it is both a changelog
category label and a signal to enable performance tests in CI. Previously,
the label management script would remove it when the PR's changelog category
was different (e.g., "CI Fix or Improvement"), even if it was set manually.

Example: https://github.com/ClickHouse/ClickHouse/pull/96646

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.612`
<!-- ch-version-info:end -->