### PR TITLE
Fix DatabaseReplicated metadata digest mismatch during SYSTEM RESTART REPLICA

### DIFF
--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -927,8 +927,6 @@ LoadTaskPtr DatabaseReplicated::startupDatabaseAsync(AsyncLoader & async_loader,
                 tables_metadata_digest = digest;
             }
 
-            digest_initialized = true;
-
             if (is_probably_dropped)
             {
                 LOG_TRACE(log, "Cannot startup database {} because it is probably dropped.", getDatabaseName());
@@ -1022,7 +1020,6 @@ void DatabaseReplicated::restoreTablesMetadataInKeeper()
     {
         std::lock_guard lock{metadata_mutex};
         tables_metadata_digest = tables_digest;
-        digest_initialized = true;
         if (!checkDigestValid(local_context))
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Digest does not match");
     }
@@ -1266,6 +1263,11 @@ bool DatabaseReplicated::checkDigestValid(const ContextPtr & local_context) cons
 
     /// Database is probably being dropped
     if (!local_context->getZooKeeperMetadataTransaction() && (!ddl_worker || !ddl_worker->isCurrentlyActive()))
+        return true;
+
+    /// SYSTEM RESTART REPLICA temporarily removes a table from the in-memory tables map
+    /// without updating tables_metadata_digest, so the check would produce a false mismatch.
+    if (tables_being_restarted.load() > 0)
         return true;
 
     UInt64 local_digest = 0;
@@ -2287,35 +2289,6 @@ bool DatabaseReplicated::canExecuteReplicatedMetadataAlter() const
     return ddl_worker_initialized && ddl_worker->isCurrentlyActive();
 }
 
-StoragePtr DatabaseReplicated::detachTable(ContextPtr local_context, const String & table_name)
-{
-    /// SYSTEM RESTART REPLICA calls detachTable and then attachTable without updating the digest.
-    /// We need to keep tables_metadata_digest consistent with the tables map to prevent
-    /// "Digest does not match" errors in concurrent DDL operations.
-    std::lock_guard lock{metadata_mutex};
-    UInt64 new_digest = tables_metadata_digest;
-    if (digest_initialized)
-        new_digest -= getMetadataHash(table_name);
-
-    auto table = DatabaseAtomic::detachTable(local_context, table_name);
-
-    if (digest_initialized)
-        tables_metadata_digest = new_digest;
-
-    return table;
-}
-
-void DatabaseReplicated::attachTable(ContextPtr local_context, const String & table_name, const StoragePtr & table, const String & relative_table_path)
-{
-    /// Counterpart of the detachTable override: re-add the table's hash to the digest
-    /// when the table is re-attached (e.g., after SYSTEM RESTART REPLICA).
-    std::lock_guard lock{metadata_mutex};
-    DatabaseAtomic::attachTable(local_context, table_name, table, relative_table_path);
-
-    if (digest_initialized)
-        tables_metadata_digest += getMetadataHash(table_name);
-}
-
 void DatabaseReplicated::detachTablePermanently(ContextPtr local_context, const String & table_name)
 {
     waitDatabaseStarted();
@@ -2339,31 +2312,7 @@ void DatabaseReplicated::detachTablePermanently(ContextPtr local_context, const 
     if (txn && !is_recovering)
         txn->addOp(zkutil::makeSetRequest(replica_path + "/digest", toString(new_digest), -1));
 
-    /// Cannot call DatabaseAtomic::detachTablePermanently here because it inherits
-    /// DatabaseOnDisk::detachTablePermanently which calls virtual this->detachTable(),
-    /// and our detachTable override locks metadata_mutex — causing a deadlock.
-    /// Instead, call DatabaseAtomic::detachTable directly and inline the permanently-detached flag logic.
-    DatabaseAtomic::detachTable(local_context, table_name);
-
-    String detached_permanently_flag = getObjectMetadataPath(table_name) + detached_suffix;
-    try
-    {
-        auto db_disk = getDisk();
-        db_disk->createFile(detached_permanently_flag);
-
-        std::lock_guard tlock(mutex);
-        const auto it = snapshot_detached_tables.find(table_name);
-        if (it == snapshot_detached_tables.end())
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "Snapshot doesn't contain info about detached table `{}`", table_name);
-        it->second.is_permanently = true;
-    }
-    catch (Exception & e)
-    {
-        e.addMessage("while trying to set permanently detached flag. Table {}.{} may be reattached during server restart.",
-            backQuote(getDatabaseName()), backQuote(table_name));
-        throw;
-    }
-
+    DatabaseAtomic::detachTablePermanently(local_context, table_name);
     tables_metadata_digest = new_digest;
     assertDigestInTransactionOrInline(local_context, txn);
 }

--- a/src/Interpreters/InterpreterSystemQuery.cpp
+++ b/src/Interpreters/InterpreterSystemQuery.cpp
@@ -1106,6 +1106,14 @@ StoragePtr InterpreterSystemQuery::doRestartReplica(const StorageID & replica, C
     });
     table->is_being_restarted = true;
     table->flushAndShutdown();
+
+    /// For DatabaseReplicated, suppress digest checks while the table is temporarily detached.
+    /// The table is removed from the in-memory tables map between detach and attach, making it
+    /// inconsistent with tables_metadata_digest (which stays correct and is not modified).
+    std::optional<DatabaseReplicated::RestartReplicaGuard> restart_guard;
+    if (auto * replicated_db = typeid_cast<DatabaseReplicated *>(database.get()))
+        restart_guard.emplace(*replicated_db);
+
     {
         /// If table was already dropped by anyone, an exception will be thrown
         auto table_lock = table->lockExclusively(getContext()->getCurrentQueryId(), getContext()->getSettingsRef()[Setting::lock_acquire_timeout]);
@@ -1159,6 +1167,7 @@ StoragePtr InterpreterSystemQuery::doRestartReplica(const StorageID & replica, C
     }
 
     database->attachTable(system_context, replica.table_name, new_table, data_path);
+    restart_guard.reset();
     if (new_table->getStorageID().uuid != replica_table_id.uuid)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Tables UUID does not match after RESTART REPLICA (old: {}, new: {})", replica_table_id.uuid, new_table->getStorageID().uuid);
 


### PR DESCRIPTION
## Summary

`SYSTEM RESTART REPLICA` temporarily detaches a table from the in-memory `tables` map and re-attaches it, without updating `tables_metadata_digest`. This creates a window where a concurrent DDL operation can call `checkDigestValid` (in debug/sanitizer builds) and observe the `tables` map missing a table while `tables_metadata_digest` still includes its hash, causing a false "Digest does not match" `LOGICAL_ERROR` exception.

The fix adds an atomic counter `tables_being_restarted` and a RAII `RestartReplicaGuard` in `InterpreterSystemQuery::doRestartReplica`. While any table restart is in progress, `checkDigestValid` returns `true` without checking, similar to the existing `is_recovering` skip. The `tables_metadata_digest` value stays correct throughout (it reflects the full set of tables) — only the in-memory `tables` map is temporarily inconsistent.

Closes #77233

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=cfb29a38cf387ff4253f8f74d54a353676aefeaa&name_0=MasterCI&name_1=Stress%20test%20%28amd_ubsan%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.691`
<!-- ch-version-info:end -->