### PR TITLE
Fix compile_commands.json path and broken find pipe in prepare-time-trace.sh

### DIFF
--- a/utils/prepare-time-trace/prepare-time-trace.sh
+++ b/utils/prepare-time-trace/prepare-time-trace.sh
@@ -110,7 +110,7 @@ ORDER BY (date, file, symbol, pull_request_number, commit_sha, check_name);
 ///
 
 # nm does not work with LTO
-if ! grep -q -- '-flto' compile_commands.json
+if ! grep -q -- '-flto' "$INPUT_DIR/compile_commands.json"
 then
     # Find the best alternative of nm
     for name in llvm-nm-{30..18} llvm-nm nm
@@ -119,7 +119,7 @@ then
         [[ -n "${NM}" ]] && break
     done
 
-    find "$INPUT_DIR" -type f -name '*.o' | grep -v cargo | find . -name '*.o' | xargs -P $(nproc) -I {} bash -c "
+    find "$INPUT_DIR" -type f -name '*.o' | grep -v cargo | xargs -P $(nproc) -I {} bash -c "
       ${NM} --demangle --defined-only --print-size '{}' | grep -v -P '[0-9a-zA-Z] r ' | sed 's@^@{} @' > '{}.symbols'
     "
 


### PR DESCRIPTION
## Summary
- The `grep` for `-flto` used a bare relative path `compile_commands.json` instead of `$INPUT_DIR/compile_commands.json`, causing "No such file or directory" errors in CI.
- Removed a spurious second `find . -name '*.o'` piped after the first `find`, which ignored stdin and made the first `find` dead code.

https://s3.amazonaws.com/clickhouse-test-reports/REFs/master/41cc63c3aa7aeded2216db9aa411d9593b34a310/build_amd_binary/job.log

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.611`
<!-- ch-version-info:end -->