### PR TITLE
Fix flaky test 03411_dynamic_resize_filesystem_cache_3

### DIFF
--- a/tests/queries/0_stateless/03411_dynamic_resize_filesystem_cache_3.sh
+++ b/tests/queries/0_stateless/03411_dynamic_resize_filesystem_cache_3.sh
@@ -18,7 +18,7 @@ CREATE TABLE ${table_name} (a String) engine=MergeTree() ORDER BY tuple() SETTIN
 INSERT INTO ${table_name} SELECT randomString(10000000);
 "
 
-$CLICKHOUSE_CLIENT --query "SELECT * FROM ${table_name} FORMAT Null"
+$CLICKHOUSE_CLIENT --enable_filesystem_cache 1 --query "SELECT * FROM ${table_name} FORMAT Null"
 
 prev_max_size=$($CLICKHOUSE_CLIENT --query "SELECT max_size FROM system.filesystem_cache_settings WHERE cache_name = '$disk_name'")
 $CLICKHOUSE_CLIENT --query "SELECT current_size > 0 FROM system.filesystem_cache_settings WHERE cache_name = '$disk_name' FORMAT TabSeparated"
@@ -34,7 +34,7 @@ function select_func {
     local TIMELIMIT=$((SECONDS+TIMEOUT))
     while [ $SECONDS -lt "$TIMELIMIT" ]
     do
-        $CLICKHOUSE_CLIENT --query "SELECT * FROM ${table_name} FORMAT Null SETTINGS filesystem_cache_segments_batch_size=1, max_read_buffer_size_remote_fs=50000"
+        $CLICKHOUSE_CLIENT --query "SELECT * FROM ${table_name} FORMAT Null SETTINGS enable_filesystem_cache=1, filesystem_cache_segments_batch_size=1, max_read_buffer_size_remote_fs=50000"
     done
 }
 


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

---

The test `03411_dynamic_resize_filesystem_cache_3` failed in TSan CI because randomized settings included `enable_filesystem_cache=0`, which prevents the filesystem cache from being populated. The test checks `current_size > 0` after a SELECT, expecting the cache to contain data, but with cache disabled it returns 0 instead of 1.

Fix by explicitly setting `enable_filesystem_cache=1` on the queries that depend on the filesystem cache being active.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=41cc63c3aa7aeded2216db9aa411d9593b34a310&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_tsan%2C%20parallel%2C%202%2F2%29


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.618`
<!-- ch-version-info:end -->