### PR TITLE
Update Supported Replicated* Tables in Docs

### DIFF
--- a/docs/en/engines/table-engines/mergetree-family/replication.md
+++ b/docs/en/engines/table-engines/mergetree-family/replication.md
@@ -35,6 +35,7 @@ Replication is only supported for tables in the MergeTree family:
 - ReplicatedCollapsingMergeTree
 - ReplicatedVersionedCollapsingMergeTree
 - ReplicatedGraphiteMergeTree
+- ReplicatedCoalescingMergeTree
 
 Replication works at the level of an individual table, not the entire server. A server can store both replicated and non-replicated tables at the same time.
 


### PR DESCRIPTION
### Changelog category:
- Documentation (changelog entry is not required)


### Documentation entry for user-facing changes

ReplicatedCoalescingMergeTree is marked as supported on versions ^25.6 but missing in docs

SELECT *
FROM system.table_engines
WHERE name LIKE '%Coalescing%'
   ┌─name──────────────────────────┬─supports_settings─┬─supports_skipping_indices─┬─supports_projections─┬─supports_sort_order─┬─supports_ttl─┬─supports_replication─┬─supports_deduplication─┬─supports_parallel_insert─┐
1. │ ReplicatedCoalescingMergeTree │                 1 │                         1 │                    1 │                   1 │            1 │                    1 │                      1 │                        1 │
2. │ CoalescingMergeTree           │                 1 │                         1 │                    1 │                   1 │            1 │                    0 │                      0 │                        1 │
   └───────────────────────────────┴───────────────────┴───────────────────────────┴──────────────────────┴─────────────────────┴──────────────┴──────────────────────┴────────────────────────┴──────────────────────────┘
