### PR TITLE
Fix 00974_text_log_table_not_empty timeout under TSan

### DIFF
--- a/tests/queries/0_stateless/00974_text_log_table_not_empty.sh
+++ b/tests/queries/0_stateless/00974_text_log_table_not_empty.sh
@@ -11,7 +11,7 @@ do
 
 ${CLICKHOUSE_CLIENT} --query="SYSTEM FLUSH LOGS text_log"
 sleep 0.1;
-if [[ $($CLICKHOUSE_CURL -sS "$CLICKHOUSE_URL" -d "SELECT 1 FROM system.text_log WHERE position(system.text_log.message, 'SELECT 6103') > 0 AND event_date >= yesterday() LIMIT 1 SETTINGS max_rows_to_read = 0") == 1 ]]; then echo 1; exit; fi;
+if [[ $($CLICKHOUSE_CLIENT --max_rows_to_read 0 --min_bytes_to_use_direct_io 0 --min_bytes_to_use_mmap_io 0 --page_cache_inject_eviction 0 --max_threads 0 --query="SELECT 1 FROM system.text_log WHERE position(system.text_log.message, 'SELECT 6103') > 0 AND event_date >= yesterday() LIMIT 1") == 1 ]]; then echo 1; exit; fi;
 
 done;
 

--- a/tests/queries/0_stateless/00974_text_log_table_not_empty.sh
+++ b/tests/queries/0_stateless/00974_text_log_table_not_empty.sh
@@ -11,6 +11,7 @@ do
 
 ${CLICKHOUSE_CLIENT} --query="SYSTEM FLUSH LOGS text_log"
 sleep 0.1;
+# Override random settings that slow down the test
 if [[ $($CLICKHOUSE_CLIENT --max_rows_to_read 0 --min_bytes_to_use_direct_io 0 --min_bytes_to_use_mmap_io 0 --page_cache_inject_eviction 0 --max_threads 0 --query="SELECT 1 FROM system.text_log WHERE position(system.text_log.message, 'SELECT 6103') > 0 AND event_date >= yesterday() LIMIT 1") == 1 ]]; then echo 1; exit; fi;
 
 done;


### PR DESCRIPTION
## Summary
- Fix `00974_text_log_table_not_empty` test timeout under TSan with randomized settings
- The test queried `system.text_log` via HTTP interface inheriting randomized settings (`min_bytes_to_use_direct_io=1`, `page_cache_inject_eviction=True`, `max_threads=1`, `http_wait_end_of_query=False`) that made the scan extremely slow under TSan
- Switch to `$CLICKHOUSE_CLIENT` and explicitly override problematic settings to ensure the `text_log` query completes quickly

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=a5c1e3e27d0564dfbcdfbe84bc1ec7f5a2314703&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_tsan%2C%20s3%20storage%2C%20parallel%2C%202%2F2%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.635`
<!-- ch-version-info:end -->