### PR TITLE
Do not fail targeted integration checks on session timeout

### DIFF
--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -675,6 +675,11 @@ tar -czf ./ci/tmp/logs.tar.gz \
                 )
                 attached_files.append("./ci/tmp/dmesg.log")
 
+    # For targeted checks, session-timeout is an expected risk (because of --count N
+    # overloading), so do not propagate the synthetic "Timeout" result as a failure.
+    if is_targeted_check:
+        test_results = [r for r in test_results if r.name != "Timeout"]
+
     R = Result.create_from(results=test_results, stopwatch=sw, files=attached_files)
 
     if is_llvm_coverage:


### PR DESCRIPTION
## Summary
- Targeted integration checks run previously-failed tests with `--count 10` to detect flakiness
- For slow test suites like `test_database_delta` (Spark/Unity Catalog, ~30-60s per test), the 1200s session timeout is easily exceeded even when all completed tests pass
- The code already avoids setting the `has_error` flag for targeted checks (recognizing session-timeout as an expected risk), but the synthetic `Timeout` FAIL result was still propagated into the final results, causing the job to be reported as failed
- Filter out the `Timeout` pseudo-result for targeted checks so the job status reflects only actual test outcomes

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96506&sha=ea37810a1e3427e90315554d5cab63fc080a50a3&name_0=PR&name_1=Integration%20tests%20%28amd_asan%2C%20targeted%29
https://github.com/ClickHouse/ClickHouse/pull/96506

### Changelog category (leave one):
- CI Fix or improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Do not fail targeted integration checks on session timeout when all completed tests have passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.634`
<!-- ch-version-info:end -->