### PR TITLE
Add LDAP Follow Referrals Options

### DIFF
--- a/ci/docker/integration/runner/misc/openldap2/setup_referral.sh
+++ b/ci/docker/integration/runner/misc/openldap2/setup_referral.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -euo pipefail
+
+SLAPD_D="/opt/bitnami/openldap/etc/slapd.d"
+SUFFIX="dc=referral,dc=org"
+REF_URL="ldap://openldap:1389/"
+
+echo "Searching cn=config for database serving suffix: ${SUFFIX}"
+
+# Find the slapd.d entry file that corresponds to the MDB database for this suffix
+TARGET_LDIF="$(grep -Rsl "^olcSuffix: ${SUFFIX}$" "${SLAPD_D}/cn=config" | head -n 1 || true)"
+if [[ -z "${TARGET_LDIF}" ]]; then
+  echo "ERROR: Could not find cn=config entry with olcSuffix: ${SUFFIX}"
+  echo "DEBUG: available suffixes:"
+  grep -Rhs "^olcSuffix:" "${SLAPD_D}/cn=config" || true
+  exit 1
+fi
+
+echo "Found target config file: ${TARGET_LDIF}"
+
+# If referral already set, keep idempotent behavior
+if grep -q "^olcReferral: " "${TARGET_LDIF}"; then
+  echo "olcReferral already present, not modifying."
+else
+  echo "Adding olcReferral: ${REF_URL}"
+  tmp="$(mktemp)"
+  awk -v suffix="olcSuffix: ${SUFFIX}" -v ref="olcReferral: ${REF_URL}" '
+    { print }
+    $0 == suffix { print ref }
+  ' "${TARGET_LDIF}" > "${tmp}"
+  cat "${tmp}" > "${TARGET_LDIF}"
+  rm -f "${tmp}"
+fi
+
+echo "Verifying olcReferral was applied..."
+grep -q "^olcReferral: ${REF_URL}$" "${TARGET_LDIF}"
+
+echo "Validating slapd config..."
+/opt/bitnami/openldap/sbin/slaptest -F "${SLAPD_D}" -u
+
+touch /tmp/.openldap-initialized
+echo "openldap2 referral bootstrap complete."

--- a/docs/en/operations/external-authenticators/ldap.md
+++ b/docs/en/operations/external-authenticators/ldap.md
@@ -32,6 +32,7 @@ To define LDAP server you must add `ldap_servers` section to the `config.xml`.
             <port>636</port>
             <bind_dn>uid={user_name},ou=users,dc=example,dc=com</bind_dn>
             <verification_cooldown>300</verification_cooldown>
+            <follow_referrals>false</follow_referrals>
             <enable_tls>yes</enable_tls>
             <tls_minimum_protocol_version>tls1.2</tls_minimum_protocol_version>
             <tls_require_cert>demand</tls_require_cert>
@@ -76,6 +77,9 @@ Note, that you can define multiple LDAP servers inside the `ldap_servers` sectio
       - Note, that the special characters must be escaped properly in XML.
 - `verification_cooldown` — A period of time, in seconds, after a successful bind attempt, during which the user will be assumed to be successfully authenticated for all consecutive requests without contacting the LDAP server.
   - Specify `0` (the default) to disable caching and force contacting the LDAP server for each authentication request.
+- `follow_referrals` —  A flag to allow the LDAP client library to automatically chase LDAP referrals returned by the server. `false` by default. Note: This setting is mostly relevant for Microsoft Active Directory environments where subtree searches at a high-level base DN (e.g. `DC=example,DC=com`) can return referrals/search references (e.g. `DC=DomainDnsZones,...`).
+  - Specify `true` only when you explicitly need cross‑partition searches and your environment is configured to allow them.
+  - Specify `false` to not chase referrals. This is recommended for AD domain‑root searches.
 - `enable_tls` — A flag to trigger the use of the secure connection to the LDAP server.
   - Specify `no` for plain text `ldap://` protocol (not recommended).
   - Specify `yes` for LDAP over SSL/TLS `ldaps://` protocol (recommended, the default).

--- a/src/Access/ExternalAuthenticators.cpp
+++ b/src/Access/ExternalAuthenticators.cpp
@@ -81,6 +81,7 @@ void parseLDAPServer(LDAPClient::Params & params, const Poco::Util::AbstractConf
     const bool has_tls_ca_cert_dir = config.has(ldap_server_config + ".tls_ca_cert_dir");
     const bool has_tls_cipher_suite = config.has(ldap_server_config + ".tls_cipher_suite");
     const bool has_search_limit = config.has(ldap_server_config + ".search_limit");
+    const bool has_follow_referrals = config.has(ldap_server_config + ".follow_referrals");
 
     if (!has_host)
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Missing 'host' entry");
@@ -199,6 +200,12 @@ void parseLDAPServer(LDAPClient::Params & params, const Poco::Util::AbstractConf
 
     if (has_search_limit)
         params.search_limit = static_cast<UInt32>(config.getUInt64(ldap_server_config + ".search_limit"));
+
+    if (has_follow_referrals)
+    {
+        params.follow_referrals = config.getBool(ldap_server_config + ".follow_referrals");
+    }
+    else params.follow_referrals = false;
 }
 
 void parseKerberosParams(GSSAcceptorContext::Params & params, const Poco::Util::AbstractConfiguration & config)

--- a/src/Access/ExternalAuthenticators.cpp
+++ b/src/Access/ExternalAuthenticators.cpp
@@ -202,10 +202,7 @@ void parseLDAPServer(LDAPClient::Params & params, const Poco::Util::AbstractConf
         params.search_limit = static_cast<UInt32>(config.getUInt64(ldap_server_config + ".search_limit"));
 
     if (has_follow_referrals)
-    {
         params.follow_referrals = config.getBool(ldap_server_config + ".follow_referrals");
-    }
-    else params.follow_referrals = false;
 }
 
 void parseKerberosParams(GSSAcceptorContext::Params & params, const Poco::Util::AbstractConfiguration & config)

--- a/src/Access/LDAPClient.cpp
+++ b/src/Access/LDAPClient.cpp
@@ -64,6 +64,7 @@ void LDAPClient::Params::updateHash(SipHash & hash) const
     ::updateHash(hash, bind_dn);
     ::updateHash(hash, user);
     ::updateHash(hash, password);
+    ::updateHash(hash, static_cast<int>(follow_referrals)); // Include follow referral behavior
 
     if (user_dn_detection)
         user_dn_detection->updateHash(hash);
@@ -245,6 +246,13 @@ bool LDAPClient::openConnection()
         }
         handleError(ldap_set_option(handle, LDAP_OPT_PROTOCOL_VERSION, &value));
     }
+
+#ifdef LDAP_OPT_REFERRALS
+    handleError(ldap_set_option(
+        handle,
+        LDAP_OPT_REFERRALS,
+        params.follow_referrals ? LDAP_OPT_ON : LDAP_OPT_OFF));
+#endif
 
     handleError(ldap_set_option(handle, LDAP_OPT_RESTART, LDAP_OPT_ON));
 
@@ -518,8 +526,8 @@ LDAPClient::SearchResults LDAPClient::search(const SearchParams & search_params)
                 break;
             }
 
-            case LDAP_RES_SEARCH_REFERENCE:
-            {
+			case LDAP_RES_SEARCH_REFERENCE:
+			{
                 char ** referrals = nullptr;
                 handleError(ldap_parse_reference(handle, msg, &referrals, nullptr, 0));
 
@@ -532,12 +540,17 @@ LDAPClient::SearchResults LDAPClient::search(const SearchParams & search_params)
 
                     for (size_t i = 0; referrals[i]; ++i)
                     {
-                        LOG_WARNING(getLogger("LDAPClient"), "Received reference during LDAP search but not following it: {}", referrals[i]);
+                        if (params.follow_referrals)
+                            LOG_TRACE(getLogger("LDAPClient"), "Received LDAP search reference: {} (library referral chasing enabled)",
+                            referrals[i]);
+                        else
+                            LOG_TRACE(getLogger("LDAPClient"), "Received LDAP search reference but not following it: {}",
+                            referrals[i]);
                     }
                 }
 
-                break;
-            }
+			    break;
+        	}
 
             case LDAP_RES_SEARCH_RESULT:
             {

--- a/src/Access/LDAPClient.cpp
+++ b/src/Access/LDAPClient.cpp
@@ -526,8 +526,8 @@ LDAPClient::SearchResults LDAPClient::search(const SearchParams & search_params)
                 break;
             }
 
-			case LDAP_RES_SEARCH_REFERENCE:
-			{
+            case LDAP_RES_SEARCH_REFERENCE:
+            {
                 char ** referrals = nullptr;
                 handleError(ldap_parse_reference(handle, msg, &referrals, nullptr, 0));
 
@@ -549,8 +549,8 @@ LDAPClient::SearchResults LDAPClient::search(const SearchParams & search_params)
                     }
                 }
 
-			    break;
-        	}
+                break;
+            }
 
             case LDAP_RES_SEARCH_RESULT:
             {

--- a/src/Access/LDAPClient.h
+++ b/src/Access/LDAPClient.h
@@ -122,6 +122,8 @@ public:
         std::chrono::seconds search_timeout{20};
         UInt32 search_limit = 256; /// An arbitrary number, no particular motivation for this value.
 
+        bool follow_referrals = false; /// Whether to follow LDAP referrals for server.
+
         void updateHash(SipHash & hash) const;
     };
 

--- a/tests/integration/compose/docker_compose_ldap2.yml
+++ b/tests/integration/compose/docker_compose_ldap2.yml
@@ -1,0 +1,28 @@
+services:
+    openldap2:
+        image: bitnamilegacy/openldap:2.6.8
+        stop_grace_period: 5s
+        restart: always
+        environment:
+            LDAP_ROOT: dc=referral,dc=org
+            LDAP_ADMIN_DN: cn=admin,dc=referral,dc=org
+            LDAP_ADMIN_USERNAME: admin
+            LDAP_ADMIN_PASSWORD: clickhouse
+            LDAP_USER_DC: users
+            LDAP_USERS: janedoe,johndoe
+            LDAP_PASSWORDS: qwerty,qwertz
+            LDAP_PORT_NUMBER: ${LDAP2_INTERNAL_PORT:-1389}
+        ports:
+            - ${LDAP2_EXTERNAL_PORT:-1390}:${LDAP2_INTERNAL_PORT:-1389}
+        volumes:
+            - /misc/openldap2/setup_referral.sh:/docker-entrypoint-initdb.d/setup_referral.sh
+        healthcheck:
+            test: >
+                test -f /tmp/.openldap-initialized
+                && ldapsearch -x -H ldap://localhost:$$LDAP_PORT_NUMBER -D cn=admin,dc=referral,dc=org -w clickhouse -b dc=referral,dc=org
+                | grep -c -E "^dn: cn=j(ohn|ane)doe,ou=users,dc=referral,dc=org$$"
+                | grep 2 >> /dev/null
+            interval: 10s
+            retries: 10
+            timeout: 2s
+        cpus: 3

--- a/tests/integration/compose/docker_compose_ldap2.yml
+++ b/tests/integration/compose/docker_compose_ldap2.yml
@@ -12,8 +12,6 @@ services:
             LDAP_USERS: janedoe,johndoe
             LDAP_PASSWORDS: qwerty,qwertz
             LDAP_PORT_NUMBER: ${LDAP2_INTERNAL_PORT:-1389}
-        ports:
-            - ${LDAP2_EXTERNAL_PORT:-1390}:${LDAP2_INTERNAL_PORT:-1389}
         volumes:
             - /misc/openldap2/setup_referral.sh:/docker-entrypoint-initdb.d/setup_referral.sh
         healthcheck:

--- a/tests/integration/test_ldap_follow_referrals/configs/ldap_follow_referrals_false.xml
+++ b/tests/integration/test_ldap_follow_referrals/configs/ldap_follow_referrals_false.xml
@@ -1,0 +1,23 @@
+<clickhouse>
+    <ldap_servers>
+        <openldap2>
+            <host>openldap2</host>
+            <port>1389</port>
+            <bind_dn>cn={user_name},ou=users,dc=referral,dc=org</bind_dn>
+            <enable_tls>no</enable_tls>
+            <follow_referrals>false</follow_referrals>
+        </openldap2>
+    </ldap_servers>
+    <user_directories>
+        <ldap>
+            <server>openldap2</server>
+            <role_mapping>
+                <base_dn>dc=example,dc=org</base_dn>
+                <scope>subtree</scope>
+                <search_filter>(&amp;(objectClass=groupOfNames)(member={bind_dn}))</search_filter>
+                <attribute>cn</attribute>
+                <prefix>clickhouse-</prefix>
+            </role_mapping>
+        </ldap>
+    </user_directories>
+</clickhouse>

--- a/tests/integration/test_ldap_follow_referrals/configs/ldap_follow_referrals_true.xml
+++ b/tests/integration/test_ldap_follow_referrals/configs/ldap_follow_referrals_true.xml
@@ -1,0 +1,23 @@
+<clickhouse>
+    <ldap_servers>
+        <openldap2>
+            <host>openldap2</host>
+            <port>1389</port>
+            <bind_dn>cn={user_name},ou=users,dc=referral,dc=org</bind_dn>
+            <enable_tls>no</enable_tls>
+            <follow_referrals>true</follow_referrals>
+        </openldap2>
+    </ldap_servers>
+    <user_directories>
+        <ldap>
+            <server>openldap2</server>
+            <role_mapping>
+                <base_dn>dc=example,dc=org</base_dn>
+                <scope>subtree</scope>
+                <search_filter>(&amp;(objectClass=groupOfNames)(member={bind_dn}))</search_filter>
+                <attribute>cn</attribute>
+                <prefix>clickhouse-</prefix>
+            </role_mapping>
+        </ldap>
+    </user_directories>
+</clickhouse>

--- a/tests/integration/test_ldap_follow_referrals/configs/users.xml
+++ b/tests/integration/test_ldap_follow_referrals/configs/users.xml
@@ -1,0 +1,11 @@
+<clickhouse>
+    <users>
+        <default remove="remove">
+        </default>
+        <common_user>
+            <password>qwerty</password>
+            <access_management>1</access_management>
+            <readonly>0</readonly>
+        </common_user>
+    </users>
+</clickhouse>

--- a/tests/integration/test_ldap_follow_referrals/test.py
+++ b/tests/integration/test_ldap_follow_referrals/test.py
@@ -1,0 +1,214 @@
+import logging
+import os
+import time
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster, get_docker_compose_path, run_and_check
+from helpers.test_tools import TSV
+
+LDAP_ADMIN_BIND_DN = "cn=admin,dc=example,dc=org"
+LDAP_ADMIN_PASSWORD = "clickhouse"
+
+DOCKER_COMPOSE_PATH = get_docker_compose_path()
+
+cluster = ClickHouseCluster(__file__)
+
+# Instance with follow_referrals=true: role mapping should work via referral chasing.
+# ClickHouse connects to openldap2 for bind (users live in dc=referral,dc=org),
+# then role mapping search targets dc=example,dc=org which is NOT served by openldap2,
+# so openldap2 returns a default referral to openldap where the groups actually exist.
+instance_follow = cluster.add_instance(
+    "instance_follow",
+    main_configs=["configs/ldap_follow_referrals_true.xml"],
+    user_configs=["configs/users.xml"],
+    stay_alive=True,
+    with_ldap=True,
+)
+
+# Instance with follow_referrals=false: role mapping should NOT work (referral ignored)
+instance_no_follow = cluster.add_instance(
+    "instance_no_follow",
+    main_configs=["configs/ldap_follow_referrals_false.xml"],
+    user_configs=["configs/users.xml"],
+    stay_alive=True,
+)
+
+
+def wait_openldap2_ready(timeout=180):
+    openldap2_docker_id = cluster.get_instance_docker_id("openldap2")
+    start = time.time()
+    while time.time() - start < timeout:
+        try:
+            logging.info("Checking openldap2 readiness")
+            cluster.exec_in_container(
+                openldap2_docker_id,
+                [
+                    "bash",
+                    "-c",
+                    "test -f /tmp/.openldap-initialized"
+                    " && /opt/bitnami/openldap/bin/ldapsearch -x -H ldap://localhost:1389"
+                    " -D cn=admin,dc=referral,dc=org -w clickhouse -b dc=referral,dc=org"
+                    " | grep -c '^dn: cn=janedoe,ou=users,dc=referral,dc=org$'"
+                    " | grep 1 >> /dev/null",
+                ],
+                user="root",
+            )
+            logging.info("openldap2 is ready")
+            return
+        except Exception as ex:
+            logging.warning("openldap2 not ready yet: %s", str(ex))
+            time.sleep(1)
+    raise Exception("Timed out waiting for openldap2")
+
+
+def add_ldap_group(group_cn, member_cn):
+    """Add a group to the primary LDAP server (openldap).
+
+    The member DN uses dc=referral,dc=org because that is the bind_dn
+    that ClickHouse substitutes into the role mapping search filter
+    ({bind_dn} = cn=<user>,ou=users,dc=referral,dc=org).
+    """
+    code, (stdout, stderr) = cluster.ldap_container.exec_run(
+        [
+            "sh",
+            "-c",
+            """echo "dn: cn={group_cn},dc=example,dc=org
+objectClass: top
+objectClass: groupOfNames
+cn: {group_cn}
+member: cn={member_cn},ou=users,dc=referral,dc=org" | \
+ldapadd -H ldap://{host}:{port} -D "{admin_bind_dn}" -x -w {admin_password}
+    """.format(
+                host=cluster.ldap_host,
+                port=cluster.ldap_port,
+                admin_bind_dn=LDAP_ADMIN_BIND_DN,
+                admin_password=LDAP_ADMIN_PASSWORD,
+                group_cn=group_cn,
+                member_cn=member_cn,
+            ),
+        ],
+        demux=True,
+    )
+    logging.debug(
+        f"add_ldap_group code:{code} stdout:{stdout}, stderr:{stderr}"
+    )
+    assert code == 0
+
+
+def delete_ldap_group(group_cn):
+    code, (stdout, stderr) = cluster.ldap_container.exec_run(
+        [
+            "sh",
+            "-c",
+            """ldapdelete -r 'cn={group_cn},dc=example,dc=org' \
+-H ldap://{host}:{port} -D "{admin_bind_dn}" -x -w {admin_password}
+            """.format(
+                host=cluster.ldap_host,
+                port=cluster.ldap_port,
+                admin_bind_dn=LDAP_ADMIN_BIND_DN,
+                admin_password=LDAP_ADMIN_PASSWORD,
+                group_cn=group_cn,
+            ),
+        ],
+        demux=True,
+    )
+    logging.debug(
+        f"delete_ldap_group code:{code} stdout:{stdout}, stderr:{stderr}"
+    )
+    assert code == 0
+
+
+@pytest.fixture(scope="module", autouse=True)
+def ldap_cluster():
+    docker_compose_ldap2 = os.path.join(
+        DOCKER_COMPOSE_PATH, "docker_compose_ldap2.yml"
+    )
+    try:
+        cluster.start()
+
+        # Start the second LDAP server (referral server).
+        # openldap2 serves dc=referral,dc=org and has a default referral
+        # pointing to openldap:1389 for any DN it cannot resolve locally.
+        run_and_check(
+            cluster.compose_cmd(
+                "-f",
+                docker_compose_ldap2,
+                "up",
+                "--force-recreate",
+                "-d",
+                "--no-build",
+            )
+        )
+        wait_openldap2_ready()
+
+        yield cluster
+    finally:
+        # Tear down openldap2 explicitly since it was started outside of
+        # cluster.start() and cluster.shutdown() does not know about it.
+        run_and_check(
+            cluster.compose_cmd(
+                "-f",
+                docker_compose_ldap2,
+                "down",
+                "--volumes",
+            ),
+            nothrow=True,
+        )
+        cluster.shutdown()
+
+
+def test_follow_referrals_true(ldap_cluster):
+    """With follow_referrals=true, the role mapping search targets dc=example,dc=org
+    on openldap2 which does not serve that suffix. openldap2 returns a default referral
+    to openldap:1389. The LDAP library chases the referral and finds the group,
+    so the user authenticates and gets the mapped role."""
+    instance_follow.query(
+        "DROP ROLE IF EXISTS role_ref", user="common_user", password="qwerty"
+    )
+    try:
+        instance_follow.query(
+            "CREATE ROLE role_ref", user="common_user", password="qwerty"
+        )
+        add_ldap_group(group_cn="clickhouse-role_ref", member_cn="johndoe")
+
+        assert instance_follow.query(
+            "SELECT currentUser()", user="johndoe", password="qwertz"
+        ) == TSV([["johndoe"]])
+
+        result = instance_follow.query(
+            "SELECT role_name FROM system.current_roles ORDER BY role_name",
+            user="johndoe",
+            password="qwertz",
+        )
+        assert result == TSV([["role_ref"]])
+    finally:
+        instance_follow.query(
+            "DROP ROLE IF EXISTS role_ref", user="common_user", password="qwerty"
+        )
+        try:
+            delete_ldap_group(group_cn="clickhouse-role_ref")
+        except AssertionError:
+            logging.warning("Could not delete LDAP group clickhouse-role_ref")
+
+
+def test_follow_referrals_false(ldap_cluster):
+    """With follow_referrals=false, the role mapping search targets dc=example,dc=org
+    on openldap2 which returns a referral. The LDAP library does not chase it,
+    so the search fails and authentication is rejected."""
+    add_ldap_group(group_cn="clickhouse-role_noref", member_cn="johndoe")
+    try:
+        error = instance_no_follow.query_and_get_error(
+            "SELECT currentUser()", user="johndoe", password="qwertz"
+        )
+        err = error.lower()
+        assert "johndoe" in err and (
+            "referral" in err
+            or "authentication failed" in err
+            or "ldap" in err
+        ), f"Unexpected error message: {error}"
+    finally:
+        try:
+            delete_ldap_group(group_cn="clickhouse-role_noref")
+        except AssertionError:
+            logging.warning("Could not delete LDAP group clickhouse-role_noref")

--- a/tests/integration/test_ldap_follow_referrals/test.py
+++ b/tests/integration/test_ldap_follow_referrals/test.py
@@ -38,9 +38,11 @@ instance_no_follow = cluster.add_instance(
 def wait_openldap2_ready(timeout=180):
     openldap2_docker_id = cluster.get_instance_docker_id("openldap2")
     start = time.time()
+    attempts = 0
+    logging.info("Waiting for openldap2 readiness")
     while time.time() - start < timeout:
+        attempts += 1
         try:
-            logging.info("Checking openldap2 readiness")
             cluster.exec_in_container(
                 openldap2_docker_id,
                 [
@@ -57,7 +59,10 @@ def wait_openldap2_ready(timeout=180):
             logging.info("openldap2 is ready")
             return
         except Exception as ex:
-            logging.warning("openldap2 not ready yet: %s", str(ex))
+            if attempts % 10 == 0:
+                logging.info("openldap2 not ready after %s attempts: %s", attempts, str(ex))
+            else:
+                logging.debug("openldap2 not ready yet: %s", str(ex))
             time.sleep(1)
     raise Exception("Timed out waiting for openldap2")
 
@@ -93,7 +98,7 @@ ldapadd -H ldap://{host}:{port} -D "{admin_bind_dn}" -x -w {admin_password}
     logging.debug(
         f"add_ldap_group code:{code} stdout:{stdout}, stderr:{stderr}"
     )
-    assert code == 0
+    assert code == 0, f"ldapadd failed: code={code}, stdout={stdout!r}, stderr={stderr!r}"
 
 
 def delete_ldap_group(group_cn):
@@ -116,7 +121,7 @@ def delete_ldap_group(group_cn):
     logging.debug(
         f"delete_ldap_group code:{code} stdout:{stdout}, stderr:{stderr}"
     )
-    assert code == 0
+    assert code == 0, f"ldapdelete failed: code={code}, stdout={stdout!r}, stderr={stderr!r}"
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -196,18 +201,26 @@ def test_follow_referrals_false(ldap_cluster):
     """With follow_referrals=false, the role mapping search targets dc=example,dc=org
     on openldap2 which returns a referral. The LDAP library does not chase it,
     so the search fails and authentication is rejected."""
-    add_ldap_group(group_cn="clickhouse-role_noref", member_cn="johndoe")
+    instance_no_follow.query(
+        "DROP ROLE IF EXISTS role_noref", user="common_user", password="qwerty"
+    )
     try:
+        instance_no_follow.query(
+            "CREATE ROLE role_noref", user="common_user", password="qwerty"
+        )
+        add_ldap_group(group_cn="clickhouse-role_noref", member_cn="johndoe")
+
         error = instance_no_follow.query_and_get_error(
             "SELECT currentUser()", user="johndoe", password="qwertz"
         )
         err = error.lower()
-        assert "johndoe" in err and (
-            "referral" in err
-            or "authentication failed" in err
-            or "ldap" in err
-        ), f"Unexpected error message: {error}"
+        assert "johndoe" in err and "authentication failed" in err, (
+            f"Unexpected error message: {error}"
+        )
     finally:
+        instance_no_follow.query(
+            "DROP ROLE IF EXISTS role_noref", user="common_user", password="qwerty"
+        )
         try:
             delete_ldap_group(group_cn="clickhouse-role_noref")
         except AssertionError:


### PR DESCRIPTION
### Changelog category (leave one):
- New Feature

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Add per‑server LDAP config option `<follow_referrals>` (default `false`) to control whether the LDAP client follows referrals. Disabling referral chasing avoids timeouts and hangs when searching from an Active Directory domain‑root base DN. Also there is less noise in logs (moved from `warn` to `trace`).
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.289`
<!-- ch-version-info:end -->