### PR TITLE
Add .info file to each LLVM Merge job

### DIFF
--- a/ci/defs/defs.py
+++ b/ci/defs/defs.py
@@ -374,6 +374,7 @@ class ArtifactNames:
     LLVM_COVERAGE_HTML_REPORT = (
         "LLVM_COVERAGE_HTML_REPORT"  # .tar.gz file with html report
     )
+    LLVM_COVERAGE_INFO_FILE = "LLVM_COVERAGE_INFO_FILE"  # .info file generated from .profdata, used for debugging coverage results
     CH_AMD_RELEASE = "CH_AMD_RELEASE"
     CH_AMD_ASAN = "CH_AMD_ASAN"
     CH_AMD_TSAN = "CH_AMD_TSAN"
@@ -503,6 +504,11 @@ class ArtifactConfigs:
         name=ArtifactNames.LLVM_COVERAGE_HTML_REPORT,
         type=Artifact.Type.S3,
         path=f"{TEMP_DIR}/llvm_coverage_html_report.tar.gz",
+    )
+    llvm_coverage_info_file = Artifact.Config(
+        name=ArtifactNames.LLVM_COVERAGE_INFO_FILE,
+        type=Artifact.Type.S3,
+        path=f"{TEMP_DIR}/llvm_coverage.info",
     )
     clickhouse_debians = Artifact.Config(
         name="*",

--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -1170,7 +1170,7 @@ class JobConfigs:
             ArtifactNames.UNITTEST_LLVM_COVERAGE,
             *LLVM_ARTIFACTS_LIST,
         ],
-        provides=[ArtifactNames.LLVM_COVERAGE_HTML_REPORT],
+        provides=[ArtifactNames.LLVM_COVERAGE_HTML_REPORT, ArtifactNames.LLVM_COVERAGE_INFO_FILE],
         command="python3 ./ci/jobs/merge_llvm_coverage_job.py",
         digest_config=Job.CacheDigestConfig(
             include_paths=["./ci/jobs/merge_llvm_coverage_job.py"],

--- a/ci/workflows/master.py
+++ b/ci/workflows/master.py
@@ -77,6 +77,7 @@ workflow = Workflow.Config(
         ArtifactConfigs.parser_memory_profiler,
         *ArtifactConfigs.llvm_profdata_file,
         ArtifactConfigs.llvm_coverage_html_report,
+        ArtifactConfigs.llvm_coverage_info_file,
     ],
     dockers=DOCKERS,
     enable_dockers_manifest_merge=True,


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

Store .info for each "Merge LLVM Coverage" job. This file is required to calculate differential coverage between 2 commits


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.636`
<!-- ch-version-info:end -->