### PR TITLE
Make test_vertical_merges_from_compact_parts repeatable

### DIFF
--- a/tests/integration/test_backward_compatibility/test_vertical_merges_from_compact_parts.py
+++ b/tests/integration/test_backward_compatibility/test_vertical_merges_from_compact_parts.py
@@ -36,6 +36,10 @@ def start_cluster():
 
 
 def test_vertical_merges_from_compact_parts(start_cluster):
+    # Clean up from any previous iteration (when test is repeated with --count).
+    for node in [node_new, node_old]:
+        node.query("DROP TABLE IF EXISTS t_vertical_merges SYNC")
+
     for i, node in enumerate([node_old, node_new]):
         node.query(
             """
@@ -125,5 +129,8 @@ def test_vertical_merges_from_compact_parts(start_cluster):
     assert node_new.query(check_query.format("all_0_3_3")) == "Vertical\tWide\n"
     assert node_old.query(check_query.format("all_0_3_3")) == "Vertical\tWide\n"
 
-    for i, node in enumerate([node_old, node_new]):
-        node.query("DROP TABLE t_vertical_merges")
+    for node in [node_new, node_old]:
+        node.query("DROP TABLE t_vertical_merges SYNC")
+
+    # Restore node_old to the original version so repeated runs still test backward compatibility.
+    node_old.restart_with_original_version()

--- a/tests/integration/test_backward_compatibility/test_vertical_merges_from_compact_parts.py
+++ b/tests/integration/test_backward_compatibility/test_vertical_merges_from_compact_parts.py
@@ -39,6 +39,7 @@ def test_vertical_merges_from_compact_parts(start_cluster):
     # Clean up from any previous iteration (when test is repeated with --count).
     for node in [node_new, node_old]:
         node.query("DROP TABLE IF EXISTS t_vertical_merges SYNC")
+        node.query("TRUNCATE TABLE IF EXISTS system.part_log")
 
     for i, node in enumerate([node_old, node_new]):
         node.query(
@@ -133,4 +134,5 @@ def test_vertical_merges_from_compact_parts(start_cluster):
         node.query("DROP TABLE t_vertical_merges SYNC")
 
     # Restore node_old to the original version so repeated runs still test backward compatibility.
-    node_old.restart_with_original_version()
+    # clear_data_dir is needed because the old binary cannot start with system tables written by the new version.
+    node_old.restart_with_original_version(clear_data_dir=True)


### PR DESCRIPTION
## Summary

- The integration test `test_vertical_merges_from_compact_parts` fails when run with `--count 10` (as targeted CI does) because:
  - `DROP TABLE` without `SYNC` leaves ZK paths not fully cleaned up by the time the next iteration tries to `CREATE TABLE`, causing `REPLICA_ALREADY_EXISTS`
  - `restart_with_latest_version` on `node_old` is never undone, so subsequent iterations run both nodes on the latest version instead of testing backward compatibility
- Fix: add `DROP TABLE IF EXISTS ... SYNC` at test start, use `SYNC` for end-of-test drops, and call `restart_with_original_version` to restore `node_old` for the next iteration

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96712&sha=5e02a5a206acbe99e5d4a840dff58405922ffb21&name_0=PR&name_1=Integration%20tests%20%28amd_asan%2C%20targeted%29
https://github.com/ClickHouse/ClickHouse/pull/96712

## Test plan

- [x] Verified the first iteration [8-10] passes and all subsequent iterations [1-10] through [10-10] fail with `REPLICA_ALREADY_EXISTS` without this fix
- [ ] CI passes with this fix

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.662`
<!-- ch-version-info:end -->