### PR TITLE
Wrap complex tuple expressions with indexes in parentheses

### DIFF
--- a/src/Parsers/ASTFunction.cpp
+++ b/src/Parsers/ASTFunction.cpp
@@ -529,10 +529,10 @@ void ASTFunction::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSetting
                     }
                 }
 
-                // It can be printed in a form of 'x.1' only if right hand side
-                // is an unsigned integer lineral. We also allow nonnegative
-                // signed integer literals, because the fuzzer sometimes inserts
-                // them, and we want to have consistent formatting.
+                /// It can be printed in a form of 'x.1' only if right hand side
+                /// is an unsigned integer lineral. We also allow nonnegative
+                /// signed integer literals, because the fuzzer sometimes inserts
+                /// them, and we want to have consistent formatting.
                 if (tuple_arguments_valid && lit_right)
                 {
                     if (isInt64OrUInt64FieldType(lit_right->value.getType())
@@ -541,10 +541,23 @@ void ASTFunction::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSetting
                         if (frame.need_parens)
                             ostr << '(';
 
+                        /// Little hack: Expression like this: (tab.*).1 (tab contains single tuple column)
+                        /// causes inconsistent formatting because it is formatted as tab.*.1 which is invalid.
+                        /// So when child 0 has more than one element, we surround it with parens.
+                        if (arguments->children[0]->size() > 1)
+                        {
+                            nested_need_parens.need_parens = false; /// Don't want duplicate parens
+                            ostr << '(';
+                        }
+
                         /// Don't allow moving operators like '-' before parents,
                         /// otherwise (-(42)).1 will be formatted as -(42).1 that will be parsed as -((42).1)
                         nested_need_parens.allow_moving_operators_before_parens = false;
                         arguments->children[0]->format(ostr, settings, state, nested_need_parens);
+
+                        if (arguments->children[0]->size() > 1)
+                            ostr << ')';
+
                         ostr << ".";
                         arguments->children[1]->format(ostr, settings, state, nested_dont_need_parens);
                         written = true;

--- a/tests/queries/0_stateless/01852_cast_operator_4.reference
+++ b/tests/queries/0_stateless/01852_cast_operator_4.reference
@@ -14,10 +14,10 @@ WITH _CAST([3, 4, 5], \'Array(UInt8)\') AS x
 SELECT CAST(x[1], \'Int32\')
 FROM system.one
 3
-SELECT CAST(tuple(3, 4, 5).1, \'Int32\')
+SELECT CAST((tuple(3, 4, 5)).1, \'Int32\')
 FROM system.one
 4
-SELECT CAST(CAST(tuple(3, 4, 5), \'Tuple(UInt64, UInt64, UInt64)\').1, \'Int32\')
+SELECT CAST((CAST(tuple(3, 4, 5), \'Tuple(UInt64, UInt64, UInt64)\')).1, \'Int32\')
 FROM system.one
 3
 WITH tuple(3, 4, 5) AS x

--- a/tests/queries/0_stateless/02560_tuple_format.reference
+++ b/tests/queries/0_stateless/02560_tuple_format.reference
@@ -1,4 +1,4 @@
 SELECT tuple(1, 2, 3)
 SELECT tuple(1, 2, 3) AS x
-SELECT tuple(1, 2, 3).1
+SELECT (tuple(1, 2, 3)).1
 SELECT (tuple(1, 2, 3) AS x).1

--- a/tests/queries/0_stateless/03780_AST_formatting_inconsistencies_in_debug_check.reference
+++ b/tests/queries/0_stateless/03780_AST_formatting_inconsistencies_in_debug_check.reference
@@ -15,3 +15,6 @@ Alias in ON clause of JOIN:
 Test repeated alias for tuple after NOT fails cleanly:
 Test that INSERT INTO with EXCEPT does not crash debug build:
 Test weird SELECT/EXCEPT/SELECT statement:
+Testing complex tuple expressions with indexes:
+1
+1

--- a/tests/queries/0_stateless/03780_AST_formatting_inconsistencies_in_debug_check.sql
+++ b/tests/queries/0_stateless/03780_AST_formatting_inconsistencies_in_debug_check.sql
@@ -42,3 +42,11 @@ DROP TABLE tab2;
 
 SELECT 'Test weird SELECT/EXCEPT/SELECT statement:';
 SELECT 1,2,3 EXCEPT SELECT 1,2,3;
+
+SELECT 'Testing complex tuple expressions with indexes:';
+CREATE TABLE tab (c1 Tuple(int, int));
+INSERT INTO tab VALUES (tuple(1,1));
+SELECT (tab.*).2 FROM tab;
+DROP TABLE tab;
+
+WITH (((1,1),1),1) AS t1 SELECT t1.1.1.1;

--- a/tests/queries/0_stateless/03786_AST_formatting_inconsistencies_in_debug_check.reference
+++ b/tests/queries/0_stateless/03786_AST_formatting_inconsistencies_in_debug_check.reference
@@ -62,3 +62,11 @@ Original:          ALTER TABLE `t55` (MODIFY ORDER BY ((`c0` AS `a0`)));
 format(original):  ALTER TABLE t55 (MODIFY ORDER BY c0 AS a0)
 format(formatted): ALTER TABLE t55 (MODIFY ORDER BY c0 AS a0)
 
+Original:          select (tab.*).2 from tab;
+format(original):  SELECT (tab.*).2 FROM tab
+format(formatted): SELECT (tab.*).2 FROM tab
+
+Original:          with (((1,1),1),1) as t1 select t1.1.1.1;
+format(original):  WITH (((1, 1), 1), 1) AS t1 SELECT ((t1.1).1).1
+format(formatted): WITH (((1, 1), 1), 1) AS t1 SELECT ((t1.1).1).1
+

--- a/tests/queries/0_stateless/03786_AST_formatting_inconsistencies_in_debug_check.sh
+++ b/tests/queries/0_stateless/03786_AST_formatting_inconsistencies_in_debug_check.sh
@@ -54,3 +54,7 @@ format_query "SELECT 1,2,3 EXCEPT SELECT 1,2,3;"
 
 # Allow alias in MODIFY ORDER BY
 format_query "ALTER TABLE \`t55\` (MODIFY ORDER BY ((\`c0\` AS \`a0\`)));"
+
+# Complex tuple expression with index
+format_query "select (tab.*).2 from tab;"
+format_query "with (((1,1),1),1) as t1 select t1.1.1.1;"


### PR DESCRIPTION
Fix issues with complex tuple expressions, such as:

SELECT (tab.*).2 FROM tab;

See [this failure](https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=a5c1e3e27d0564dfbcdfbe84bc1ec7f5a2314703&name_0=MasterCI&name_1=BuzzHouse%20%28amd_debug%29&name_1=BuzzHouse%20%28amd_debug%29).

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.659`
<!-- ch-version-info:end -->