### PR TITLE
Add fields to support to keeper-client config

### DIFF
--- a/docs/en/operations/utilities/clickhouse-keeper-client.md
+++ b/docs/en/operations/utilities/clickhouse-keeper-client.md
@@ -16,6 +16,8 @@ A client application to interact with clickhouse-keeper by its native protocol.
 -   `-h HOST`, `--host=HOST` — Server host. Default value: `localhost`.
 -   `-p N`, `--port=N` — Server port. Default value: 9181
 -   `-c FILE_PATH`, `--config-file=FILE_PATH` — Set path of config file to get the connection string. Default value: `config.xml`.
+-   `--password=PASSWORD` — Password for authentication. Can also be set via the `CLICKHOUSE_KEEPER_PASSWORD` environment variable or in the XML config file under `<zookeeper><password>`.
+-   `--identity=IDENTITY` — Identity for `digest` authentication scheme. Can also be set via the `CLICKHOUSE_KEEPER_IDENTITY` environment variable or in the XML config file under `<zookeeper><identity>`.
 -   `--connection-timeout=TIMEOUT` — Set connection timeout in seconds. Default value: 10s.
 -   `--session-timeout=TIMEOUT` — Set session timeout in seconds. Default value: 10s.
 -   `--operation-timeout=TIMEOUT` — Set operation timeout in seconds. Default value: 10s.
@@ -23,6 +25,35 @@ A client application to interact with clickhouse-keeper by its native protocol.
 -   `--log-level=LEVEL` — Set log level. Default value: `information`.
 -   `--no-confirmation` — If set, will not require a confirmation on several commands. Default value `false` for interactive and `true` for query
 -   `--help` — Shows the help message.
+
+## Environment Variables {#clickhouse-keeper-client-env}
+
+-   `CLICKHOUSE_KEEPER_PASSWORD` — Used as the default password if `--password` is not provided on the command line.
+-   `CLICKHOUSE_KEEPER_IDENTITY` — Used as the default identity if `--identity` is not provided on the command line.
+
+## Authentication {#clickhouse-keeper-client-auth}
+
+When connecting to a Keeper server that requires authentication, the password is resolved in the following priority order (first match wins):
+
+1. `--password` command-line argument
+2. `CLICKHOUSE_KEEPER_PASSWORD` environment variable
+3. `<zookeeper><password>` in the XML config file specified by `--config-file`
+
+The same priority applies to `--identity` / `CLICKHOUSE_KEEPER_IDENTITY` / `<zookeeper><identity>`.
+
+Example XML config file with authentication settings:
+
+```xml
+<clickhouse>
+    <zookeeper>
+        <password>secret</password>
+        <node index="1">
+            <host>localhost</host>
+            <port>9181</port>
+        </node>
+    </zookeeper>
+</clickhouse>
+```
 
 ## Example {#clickhouse-keeper-client-example}
 

--- a/programs/keeper-client/KeeperClient.cpp
+++ b/programs/keeper-client/KeeperClient.cpp
@@ -377,6 +377,14 @@ void KeeperClient::initialize(Poco::Util::Application & /* self */)
     Poco::Logger::root().setLevel(config().getString("log-level", default_log_level));
 
     EventNotifier::init();
+
+    const char * env_password = getenv("CLICKHOUSE_KEEPER_PASSWORD"); // NOLINT(concurrency-mt-unsafe)
+    if (env_password && !config().has("password"))
+        config().setString("password", env_password);
+
+    const char * env_identity = getenv("CLICKHOUSE_KEEPER_IDENTITY"); // NOLINT(concurrency-mt-unsafe)
+    if (env_identity && !config().has("identity"))
+        config().setString("identity", env_identity);
 }
 
 bool KeeperClient::processQueryText(const String & text, bool is_interactive)
@@ -611,10 +619,17 @@ void KeeperClient::connectToKeeper()
     new_zk_args.session_timeout_ms = config().getInt("session-timeout", 10) * 1000;
     new_zk_args.operation_timeout_ms = config().getInt("operation-timeout", 10) * 1000;
     new_zk_args.use_xid_64 = config().hasOption("use-xid-64");
-    new_zk_args.password = config().getString("password", "");
-    new_zk_args.identity = config().getString("identity", "");
+    new_zk_args.password = config().has("password")
+        ? config().getString("password")
+        : clickhouse_config.configuration->getString("zookeeper.password", "");
+
+    new_zk_args.identity = config().has("identity")
+        ? config().getString("identity")
+        : clickhouse_config.configuration->getString("zookeeper.identity", "");
+
     if (!new_zk_args.identity.empty())
         new_zk_args.auth_scheme = "digest";
+
     zk_args = new_zk_args;
     auto component_guard = Coordination::setCurrentComponent("KeeperClient::connectToKeeper");
     zookeeper = zkutil::ZooKeeper::createWithoutKillingPreviousSessions(std::move(new_zk_args));

--- a/tests/integration/test_keeper_client_config/configs/keeper_client_config.xml
+++ b/tests/integration/test_keeper_client_config/configs/keeper_client_config.xml
@@ -1,0 +1,9 @@
+<clickhouse>
+    <zookeeper>
+        <password>foobar</password>
+        <node index="1">
+            <host>node1</host>
+            <port>9181</port>
+        </node>
+    </zookeeper>
+</clickhouse>

--- a/tests/integration/test_keeper_client_config/configs/keeper_client_config_with_identity.xml
+++ b/tests/integration/test_keeper_client_config/configs/keeper_client_config_with_identity.xml
@@ -1,0 +1,10 @@
+<clickhouse>
+    <zookeeper>
+        <password>foobar</password>
+        <identity>testuser:testpass</identity>
+        <node index="1">
+            <host>node1</host>
+            <port>9181</port>
+        </node>
+    </zookeeper>
+</clickhouse>

--- a/tests/integration/test_keeper_client_config/configs/keeper_config.xml
+++ b/tests/integration/test_keeper_client_config/configs/keeper_config.xml
@@ -1,0 +1,19 @@
+<clickhouse>
+    <keeper_server>
+        <tcp_port>9181</tcp_port>
+        <server_id>1</server_id>
+        <client_password>foobar</client_password>
+        <coordination_settings>
+            <operation_timeout_ms>5000</operation_timeout_ms>
+            <session_timeout_ms>10000</session_timeout_ms>
+            <raft_logs_level>trace</raft_logs_level>
+        </coordination_settings>
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>node1</hostname>
+                <port>9234</port>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+</clickhouse>

--- a/tests/integration/test_keeper_client_config/test.py
+++ b/tests/integration/test_keeper_client_config/test.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+
+import pytest
+import os
+
+from kazoo.security import make_acl
+
+from helpers import keeper_utils
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+node1 = cluster.add_instance(
+    "node1",
+    main_configs=["configs/keeper_config.xml"],
+    with_zookeeper=True,
+    use_keeper=False,
+    stay_alive=True,
+)
+
+KEEPER_PASSWORD = "foobar"
+KEEPER_IDENTITY = "testuser:testpass"
+KEEPER_CLIENT_CONFIG_PATH = "/tmp/keeper_client_config.xml"
+KEEPER_CLIENT_CONFIG_WITH_IDENTITY_PATH = "/tmp/keeper_client_config_with_identity.xml"
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        password = KEEPER_PASSWORD
+        p = (password + "".join([chr(0)] * (16 - len(password)))).encode("ascii")
+        keeper_utils.wait_until_connected(cluster, node1, password=p)
+
+        # Copy keeper-client XML configs into the container
+        local_config = os.path.join(
+            os.path.dirname(__file__), "configs", "keeper_client_config.xml"
+        )
+        node1.copy_file_to_container(local_config, KEEPER_CLIENT_CONFIG_PATH)
+
+        local_config_with_identity = os.path.join(
+            os.path.dirname(__file__),
+            "configs",
+            "keeper_client_config_with_identity.xml",
+        )
+        node1.copy_file_to_container(
+            local_config_with_identity, KEEPER_CLIENT_CONFIG_WITH_IDENTITY_PATH
+        )
+
+        # Create an ACL-protected node for identity tests
+        fake_zk = keeper_utils.get_fake_zk(cluster, "node1", password=p)
+        fake_zk.add_auth("digest", KEEPER_IDENTITY)
+        fake_zk.create(
+            "/test_identity_node",
+            b"protected_data",
+            acl=[make_acl("auth", "", all=True)],
+        )
+        fake_zk.stop()
+
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_password_from_xml_config(started_cluster):
+    """Keeper-client reads password from XML config <zookeeper><password>."""
+    data = node1.exec_in_container(
+        [
+            "bash",
+            "-c",
+            f"clickhouse keeper-client -c {KEEPER_CLIENT_CONFIG_PATH} -q \"ls '/keeper'\"",
+        ],
+        privileged=True,
+    )
+    assert "api_version" in data
+
+
+def test_password_from_env_var(started_cluster):
+    """Keeper-client reads password from CLICKHOUSE_KEEPER_PASSWORD env var."""
+    data = node1.exec_in_container(
+        [
+            "bash",
+            "-c",
+            "clickhouse keeper-client -h node1 -p 9181 -q \"ls '/keeper'\"",
+        ],
+        privileged=True,
+        environment={"CLICKHOUSE_KEEPER_PASSWORD": KEEPER_PASSWORD},
+    )
+    assert "api_version" in data
+
+
+def test_wrong_password_fails(started_cluster):
+    """Keeper-client fails with a wrong password."""
+    data = node1.exec_in_container(
+        [
+            "bash",
+            "-c",
+            "clickhouse keeper-client -h node1 -p 9181 --password wrong -q \"ls '/keeper'\"",
+        ],
+        privileged=True,
+        nothrow=True,
+    )
+    assert "api_version" not in data
+
+
+def test_no_password_fails(started_cluster):
+    """Keeper-client fails without any password."""
+    data = node1.exec_in_container(
+        [
+            "bash",
+            "-c",
+            "clickhouse keeper-client -h node1 -p 9181 -q \"ls '/keeper'\"",
+        ],
+        privileged=True,
+        nothrow=True,
+    )
+    assert "api_version" not in data
+
+
+def test_cli_password_overrides_env(started_cluster):
+    """CLI --password takes priority over CLICKHOUSE_KEEPER_PASSWORD env var."""
+    data = node1.exec_in_container(
+        [
+            "bash",
+            "-c",
+            f"clickhouse keeper-client -h node1 -p 9181 --password {KEEPER_PASSWORD} -q \"ls '/keeper'\"",
+        ],
+        privileged=True,
+        environment={"CLICKHOUSE_KEEPER_PASSWORD": "wrong_password"},
+    )
+    assert "api_version" in data
+
+
+def test_identity_from_xml_config(started_cluster):
+    """Keeper-client reads identity from XML config <zookeeper><identity>."""
+    data = node1.exec_in_container(
+        [
+            "bash",
+            "-c",
+            f"clickhouse keeper-client -c {KEEPER_CLIENT_CONFIG_WITH_IDENTITY_PATH} -q \"get '/test_identity_node'\"",
+        ],
+        privileged=True,
+    )
+    assert "protected_data" in data
+
+
+def test_identity_from_env_var(started_cluster):
+    """Keeper-client reads identity from CLICKHOUSE_KEEPER_IDENTITY env var."""
+    data = node1.exec_in_container(
+        [
+            "bash",
+            "-c",
+            f"clickhouse keeper-client -h node1 -p 9181 --password {KEEPER_PASSWORD} -q \"get '/test_identity_node'\"",
+        ],
+        privileged=True,
+        environment={"CLICKHOUSE_KEEPER_IDENTITY": KEEPER_IDENTITY},
+    )
+    assert "protected_data" in data
+
+
+def test_wrong_identity_fails(started_cluster):
+    """Keeper-client fails to read ACL-protected node with wrong identity."""
+    data = node1.exec_in_container(
+        [
+            "bash",
+            "-c",
+            f"clickhouse keeper-client -h node1 -p 9181 --password {KEEPER_PASSWORD} --identity wrong:wrong -q \"get '/test_identity_node'\"",
+        ],
+        privileged=True,
+        nothrow=True,
+    )
+    assert "protected_data" not in data
+
+
+def test_no_identity_fails(started_cluster):
+    """Keeper-client fails to read ACL-protected node without identity."""
+    data = node1.exec_in_container(
+        [
+            "bash",
+            "-c",
+            f"clickhouse keeper-client -c {KEEPER_CLIENT_CONFIG_PATH} -q \"get '/test_identity_node'\"",
+        ],
+        privileged=True,
+        nothrow=True,
+    )
+    assert "protected_data" not in data
+
+
+def test_cli_identity_overrides_env(started_cluster):
+    """CLI --identity takes priority over CLICKHOUSE_KEEPER_IDENTITY env var."""
+    data = node1.exec_in_container(
+        [
+            "bash",
+            "-c",
+            f"clickhouse keeper-client -h node1 -p 9181 --password {KEEPER_PASSWORD} --identity {KEEPER_IDENTITY} -q \"get '/test_identity_node'\"",
+        ],
+        privileged=True,
+        environment={"CLICKHOUSE_KEEPER_IDENTITY": "wrong:wrong"},
+    )
+    assert "protected_data" in data


### PR DESCRIPTION
I'm running clickhouse-keeper in k8s and using `clickhouse-keeper-client -q ls` for health checks.
According to our policies, it should be secured by password.
Now I achieved the authentication by wrapping the client with a script, but it would be much more handy and transparent to just mount `keeper-client-config.xml` from a secret or set up an environment variable.

### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Add support of `password` and `identity` fields to keeper-client XML config.

More over, those parameters could be passed via CLICKHOUSE_KEEPER_PASSWORD and CLICKHOUSE_KEEPER_IDENTITY environment variables.

The priority is the following: CMD PARAMS > ENVIRONMENT VARIABLES > CONFIG FILE.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `keeper-client` resolves authentication credentials (CLI/env/XML), which can affect connectivity and security expectations if precedence or config parsing is wrong, though scope is limited and covered by integration tests.
> 
> **Overview**
> `clickhouse-keeper-client` can now source authentication credentials from `CLICKHOUSE_KEEPER_PASSWORD` / `CLICKHOUSE_KEEPER_IDENTITY` env vars and from the XML config file (`<zookeeper><password>` / `<zookeeper><identity>`), with precedence **CLI flags → env vars → config**.
> 
> Adds integration tests to validate success/failure cases and override priority, and updates the utility docs to describe the new options, env vars, and resolution order.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a5e8c4d35de93b74647a493066c2062805e469e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.125`
<!-- ch-version-info:end -->