### PR TITLE
Revert "Set `MALLOC_MIN_ALIGNMENT` to the value from standard library"

### DIFF
--- a/src/Common/Allocator.h
+++ b/src/Common/Allocator.h
@@ -19,7 +19,7 @@
 
 extern const size_t POPULATE_THRESHOLD;
 
-static constexpr size_t MALLOC_MIN_ALIGNMENT = alignof(std::max_align_t);
+static constexpr size_t MALLOC_MIN_ALIGNMENT = 8;
 
 /** Previously there was a code which tried to use manual mmap and mremap (clickhouse_mremap.h) for large allocations/reallocations (64MB+).
   * Most modern allocators (including jemalloc) don't use mremap, so the idea was to take advantage from mremap system call for large reallocs.

--- a/src/IO/tests/gtest_memory_resize.cpp
+++ b/src/IO/tests/gtest_memory_resize.cpp
@@ -233,8 +233,7 @@ TEST(MemoryResizeTest, BigInitAndSmallResizeOverflowWhenPadding)
 TEST(MemoryResizeTest, AlignmentWithRealAllocator)
 {
     {
-        auto memory
-            = Memory<>(0, 3); // not the power of 2 but less than MALLOC_MIN_ALIGNMENT so user-defined alignment is ignored at Allocator
+        auto memory = Memory<>(0, 3); // not the power of 2 but less than MALLOC_MIN_ALIGNMENT 8 so user-defined alignment is ignored at Allocator
         ASSERT_EQ(memory.m_data, nullptr);
         ASSERT_EQ(memory.m_capacity, 0);
         ASSERT_EQ(memory.m_size, 0);


### PR DESCRIPTION
Reverts ClickHouse/ClickHouse#96547

It broke one unit test: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=e91859b7262920286246e2904689c062e9c2acdf&name_0=MasterCI&name_1=Unit%20tests%20%28amd_llvm_coverage%29&name_1=Unit%20tests%20%28amd_llvm_coverage%29


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.649`
<!-- ch-version-info:end -->