### PR TITLE
play: stop forcing query-cache settings in /play

### DIFF
--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -1299,9 +1299,7 @@ async function postImpl(posted_request_num, query)
     if (user) url += '&user=' + encodeURIComponent(user);
     if (password) url += '&password=' + encodeURIComponent(password);
     url += '&default_format=' + default_format + '&enable_http_compression=1';
-    /// We will put the result in the query cache, so it can be used when download is initiated later.
-    /// But we don't use cached results, so the results that we get here, are always fresh.
-    url += '&use_query_cache=1&enable_reads_from_query_cache=0&enable_writes_to_query_cache=1&query_cache_ttl=600&query_cache_nondeterministic_function_handling=save';
+    /// Keep query cache behavior at server defaults.
 
     /// Extremes only if the format is likely to be unchanged. This is imprecise.
     if (!query.match(/\bFORMAT\s+\w+/i)) url += '&extremes=1';
@@ -2661,7 +2659,6 @@ document.getElementById('download-button').addEventListener('click', async funct
         (server_address.indexOf('?') >= 0 ? '&' : '?') +
         'add_http_cors_header=1' +
         '&enable_http_compression=1' +
-        '&use_query_cache=1&enable_reads_from_query_cache=1&enable_writes_to_query_cache=0&query_cache_ttl=600&query_cache_nondeterministic_function_handling=save' +
         '&default_format=' + encodeURIComponent(format) +
         '&http_response_headers=' + encodeURIComponent(`{'Content-Disposition':'attachment; filename="result.${encodeURIComponent(format.toLowerCase())}"'}`);
     if (user) url += '&user=' + encodeURIComponent(user);


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry 
Fixed /play Web UI to stop forcing query cache settings in execute/download requests, so system.* queries no longer fail with QUERY_CACHE_USED_WITH_SYSTEM_TABLE under default server settings.

### Documentation entry for user-facing changes

- not needed

Closes #95387