### PR TITLE
Add named collection support for DataLakeCatalog

### DIFF
--- a/docs/en/engines/database-engines/datalake.md
+++ b/docs/en/engines/database-engines/datalake.md
@@ -62,7 +62,14 @@ The following settings are supported:
 | `dlf_access_key_id`     | Access key ID for DLF access                                                            |
 | `dlf_access_key_secret` | Access key Secret for DLF access                                                        |
 
-Named collections could also be used.
+Named collections could also be used:
+
+```sql
+CREATE NAMED COLLECTION unity_catalog_settings AS CREATE NAMED COLLECTION collection_name AS url = 'http://localhost:8080/api/2.1/unity-catalog', warehouse = 'unity', catalog_type = 'unity', catalog_credential = 'my_token';
+
+CREATE DATABASE delta_lake_catalog_database_name
+ENGINE = DataLakeCatalog(unity_catalog_settings);
+```
 
 ## Examples {#examples}
 

--- a/docs/en/engines/database-engines/datalake.md
+++ b/docs/en/engines/database-engines/datalake.md
@@ -62,6 +62,8 @@ The following settings are supported:
 | `dlf_access_key_id`     | Access key ID for DLF access                                                            |
 | `dlf_access_key_secret` | Access key Secret for DLF access                                                        |
 
+Named collections could also be used.
+
 ## Examples {#examples}
 
 See below sections for examples of using the `DataLakeCatalog` engine:

--- a/docs/en/engines/database-engines/datalake.md
+++ b/docs/en/engines/database-engines/datalake.md
@@ -65,7 +65,7 @@ The following settings are supported:
 Named collections could also be used:
 
 ```sql
-CREATE NAMED COLLECTION collection_name AS
+CREATE NAMED COLLECTION unity_catalog_settings AS
    url = 'http://localhost:8080/api/2.1/unity-catalog',
    warehouse = 'unity',
    catalog_type = 'unity',

--- a/docs/en/engines/database-engines/datalake.md
+++ b/docs/en/engines/database-engines/datalake.md
@@ -65,7 +65,11 @@ The following settings are supported:
 Named collections could also be used:
 
 ```sql
-CREATE NAMED COLLECTION unity_catalog_settings AS CREATE NAMED COLLECTION collection_name AS url = 'http://localhost:8080/api/2.1/unity-catalog', warehouse = 'unity', catalog_type = 'unity', catalog_credential = 'my_token';
+CREATE NAMED COLLECTION collection_name AS
+   url = 'http://localhost:8080/api/2.1/unity-catalog',
+   warehouse = 'unity',
+   catalog_type = 'unity',
+   catalog_credential = 'my_token';
 
 CREATE DATABASE delta_lake_catalog_database_name
 ENGINE = DataLakeCatalog(unity_catalog_settings);

--- a/src/Databases/DataLake/DatabaseDataLake.cpp
+++ b/src/Databases/DataLake/DatabaseDataLake.cpp
@@ -47,6 +47,11 @@
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTDataType.h>
 #include <Common/FailPoint.h>
+<<<<<<< HEAD
+=======
+#include <Common/SettingsChanges.h>
+#include <Storages/NamedCollectionsHelpers.h>
+>>>>>>> 587ccddcc66 (Add named collection support for DataLakeCatalog)
 
 namespace DB
 {
@@ -943,6 +948,45 @@ void registerDatabaseDataLake(DatabaseFactory & factory)
         if (database_engine_define->settings)
             database_settings.loadFromQuery(*database_engine_define, args.create_query.attach);
 
+        const ASTFunction * function_define = database_engine_define->engine;
+
+        ASTs engine_args;
+        if (function_define->arguments)
+            engine_args = function_define->arguments->children;
+
+        std::string url;
+        bool from_named_collection = false;
+
+        if (auto named_collection = tryGetNamedCollectionWithOverrides(engine_args, args.context, false))
+        {
+            from_named_collection = true;
+            url = named_collection->getOrDefault<String>("url", "");
+
+            SettingsChanges collection_changes;
+            for (const auto & key : named_collection->getKeys())
+            {
+                if (key == "url")
+                    continue;
+                collection_changes.emplace_back(key, named_collection->get<String>(key));
+            }
+            /// Named collection values are applied first, then SETTINGS clause overrides them
+            /// (loadFromQuery was already called above).
+            /// To achieve the correct precedence we: apply collection, then re-apply SETTINGS.
+            auto settings_overrides = database_settings.allChanged();
+            database_settings.applyChanges(collection_changes);
+            database_settings.applyChanges(settings_overrides);
+
+            engine_args.clear();
+        }
+        else
+        {
+            for (auto & engine_arg : engine_args)
+                engine_arg = evaluateConstantExpressionOrIdentifierAsLiteral(engine_arg, args.context);
+
+            if (!engine_args.empty())
+                url = engine_args[0]->as<ASTLiteral>()->value.safeGet<String>();
+        }
+
         auto catalog_type = database_settings[DB::DatabaseDataLakeSetting::catalog_type].value;
         /// Glue catalog is one per region, so it's fully identified by aws keys and region
         /// There is no URL you need to provide in constructor, even if we would want it
@@ -952,27 +996,8 @@ void registerDatabaseDataLake(DatabaseFactory & factory)
         ///  mock glue catalog in tests only.
         bool requires_arguments = catalog_type != DatabaseDataLakeCatalogType::GLUE;
 
-        const ASTFunction * function_define = database_engine_define->engine;
-
-        ASTs engine_args;
-        if (requires_arguments && !function_define->arguments)
-        {
+        if (!from_named_collection && requires_arguments && engine_args.empty())
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Engine `{}` must have arguments", database_engine_name);
-        }
-
-        if (function_define->arguments)
-        {
-            engine_args = function_define->arguments->children;
-            if (requires_arguments && engine_args.empty())
-                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Engine `{}` must have arguments", database_engine_name);
-        }
-
-        for (auto & engine_arg : engine_args)
-            engine_arg = evaluateConstantExpressionOrIdentifierAsLiteral(engine_arg, args.context);
-
-        std::string url;
-        if (!engine_args.empty())
-            url = engine_args[0]->as<ASTLiteral>()->value.safeGet<String>();
 
         auto engine_for_tables = database_engine_define->clone();
         ASTFunction * engine_func = engine_for_tables->as<ASTStorage &>().engine;
@@ -980,6 +1005,12 @@ void registerDatabaseDataLake(DatabaseFactory & factory)
         {
             engine_func->arguments = make_intrusive<ASTExpressionList>();
         }
+
+        /// When using a named collection, the cloned engine AST still contains
+        /// the named collection reference in its arguments. Clear them so that
+        /// per-table engine gets only the table endpoint filled by tryGetTableImpl.
+        if (from_named_collection)
+            engine_func->arguments->children.clear();
 
         switch (catalog_type)
         {

--- a/src/Databases/DataLake/DatabaseDataLake.cpp
+++ b/src/Databases/DataLake/DatabaseDataLake.cpp
@@ -47,11 +47,8 @@
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTDataType.h>
 #include <Common/FailPoint.h>
-<<<<<<< HEAD
-=======
 #include <Common/SettingsChanges.h>
 #include <Storages/NamedCollectionsHelpers.h>
->>>>>>> 587ccddcc66 (Add named collection support for DataLakeCatalog)
 
 namespace DB
 {
@@ -957,7 +954,7 @@ void registerDatabaseDataLake(DatabaseFactory & factory)
         std::string url;
         bool from_named_collection = false;
 
-        if (auto named_collection = tryGetNamedCollectionWithOverrides(engine_args, args.context, false))
+        if (auto named_collection = tryGetNamedCollectionWithOverrides(engine_args, args.context, /* throw_unknown_collection */false))
         {
             from_named_collection = true;
             url = named_collection->getOrDefault<String>("url", "");
@@ -975,8 +972,6 @@ void registerDatabaseDataLake(DatabaseFactory & factory)
             auto settings_overrides = database_settings.allChanged();
             database_settings.applyChanges(collection_changes);
             database_settings.applyChanges(settings_overrides);
-
-            engine_args.clear();
         }
         else
         {

--- a/src/Databases/DataLake/DatabaseDataLake.cpp
+++ b/src/Databases/DataLake/DatabaseDataLake.cpp
@@ -991,8 +991,9 @@ void registerDatabaseDataLake(DatabaseFactory & factory)
         ///  mock glue catalog in tests only.
         bool requires_arguments = catalog_type != DatabaseDataLakeCatalogType::GLUE;
 
-        if (!from_named_collection && requires_arguments && engine_args.empty())
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Engine `{}` must have arguments", database_engine_name);
+        if (requires_arguments && url.empty())
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Engine `{}` requires URL as argument", database_engine_name);
+
 
         auto engine_for_tables = database_engine_define->clone();
         ASTFunction * engine_func = engine_for_tables->as<ASTStorage &>().engine;

--- a/src/Parsers/FunctionSecretArgumentsFinder.h
+++ b/src/Parsers/FunctionSecretArgumentsFinder.h
@@ -737,10 +737,21 @@ protected:
 
     void findDataLakeCatalogSecretArguments()
     {
-        /// datalake catalog should support different storage types,
-        /// we need a function to check if the url is S3 or Azure.
-        /// right now we assume it's a S3 url
-        findS3DatabaseSecretArguments();
+        if (isNamedCollectionName(0))
+        {
+            /// DataLakeCatalog(named_collection, ..., catalog_credential = 'secret', ...)
+            findSecretNamedArgument("secret_access_key", 1);
+            findSecretNamedArgument("catalog_credential", 1);
+            findSecretNamedArgument("aws_secret_access_key", 1);
+            findSecretNamedArgument("onelake_client_secret", 1);
+            findSecretNamedArgument("dlf_access_key_secret", 1);
+            findSecretNamedArgument("auth_header", 1);
+        }
+        else
+        {
+            /// DataLakeCatalog('url', 'access_key_id', 'secret_access_key')
+            markSecretArgument(2);
+        }
     }
 
     void findBackupDatabaseSecretArguments()

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -82,7 +82,8 @@ def with_default_target_node(default_target_node):
 
         @wraps(func)
         def wrapper(*args, **kwargs):
-            if kwargs.get("target_node") is None:
+            bound = sig.bind_partial(*args, **kwargs)
+            if bound.arguments.get("target_node") is None:
                 kwargs["target_node"] = default_target_node
             return func(*args, **kwargs)
 

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -84,8 +84,8 @@ def with_default_target_node(default_target_node):
         def wrapper(*args, **kwargs):
             bound = sig.bind_partial(*args, **kwargs)
             if bound.arguments.get("target_node") is None:
-                kwargs["target_node"] = default_target_node
-            return func(*args, **kwargs)
+                bound.arguments["target_node"] = default_target_node
+            return func(*bound.args, **bound.kwargs)
 
         return wrapper
 

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -2,6 +2,7 @@ import base64
 import concurrent
 import errno
 import http.client
+import inspect
 import json
 import logging
 import os
@@ -21,7 +22,7 @@ import traceback
 import urllib.parse
 import uuid
 from contextlib import contextmanager
-from functools import cache
+from functools import cache, wraps
 from pathlib import Path
 from typing import Any, List, Sequence, Tuple, Union
 
@@ -62,6 +63,33 @@ from .kazoo_client import KazooClientWithImplicitRetries
 from .random_settings import write_random_settings_config
 from .retry_decorator import retry
 from .test_tools import assert_eq_with_retry, exec_query_with_retry
+
+def with_default_target_node(default_target_node):
+    """Decorator that injects a default value for the ``target_node`` parameter.
+
+    The decorated function **must** declare a ``target_node`` keyword
+    argument.  The wrapper makes it optional: when the caller omits it
+    (or passes ``None``), ``default_target_node`` is used instead.
+    """
+
+    def decorator(func):
+        sig = inspect.signature(func)
+        if "target_node" not in sig.parameters:
+            raise TypeError(
+                f"Function {func.__name__} must accept a 'target_node' argument "
+                f"to be decorated with @with_default_target_node"
+            )
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            if kwargs.get("target_node") is None:
+                kwargs["target_node"] = default_target_node
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
 
 HELPERS_DIR = p.dirname(__file__)
 CLICKHOUSE_ROOT_DIR = p.join(p.dirname(__file__), "../../..")

--- a/tests/integration/helpers/unity_catalog.py
+++ b/tests/integration/helpers/unity_catalog.py
@@ -1,0 +1,8 @@
+def start_unity_catalog(node):
+    node.exec_in_container(
+        [
+            "bash",
+            "-c",
+            f"""cp -r /unitycatalog /var/lib/clickhouse/user_files/ && cd /var/lib/clickhouse/user_files/unitycatalog && nohup bin/start-uc-server > uc.log 2>&1 &""",
+        ]
+    )

--- a/tests/integration/test_database_delta/test.py
+++ b/tests/integration/test_database_delta/test.py
@@ -22,16 +22,7 @@ from datetime import date
 import uuid
 
 from helpers.test_tools import TSV
-
-
-def start_unity_catalog(node):
-    node.exec_in_container(
-        [
-            "bash",
-            "-c",
-            f"""cp -r /unitycatalog /var/lib/clickhouse/user_files/ && cd /var/lib/clickhouse/user_files/unitycatalog && nohup bin/start-uc-server > uc.log 2>&1 &""",
-        ]
-    )
+from helpers.unity_catalog import start_unity_catalog
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_database_delta/test.py
+++ b/tests/integration/test_database_delta/test.py
@@ -188,6 +188,93 @@ def test_embedded_database_and_tables(started_cluster, use_delta_kernel):
             assert data_clickhouse == data_spark
 
 
+def test_named_collection(started_cluster):
+    test_uuid = str(uuid.uuid4()).replace("-", "_")
+    node1 = started_cluster.instances["node1"]
+    db_name = f"nc_test_{test_uuid}"
+    collection_name = f"nc_{test_uuid}"
+
+    node1.query(f"drop database if exists {db_name}")
+    node1.query(
+        f"CREATE NAMED COLLECTION {collection_name} AS "
+        f"url = 'http://localhost:8080/api/2.1/unity-catalog', "
+        f"warehouse = 'unity', catalog_type = 'unity', vended_credentials = false"
+    )
+    node1.query(
+        f"CREATE DATABASE {db_name} ENGINE = DataLakeCatalog({collection_name})",
+        settings={"allow_experimental_database_unity_catalog": "1"},
+    )
+    default_tables = list(
+        sorted(
+            node1.query(
+                f"SHOW TABLES FROM {db_name} LIKE 'default%'",
+                settings={"use_hive_partitioning": "0"},
+            )
+            .strip()
+            .split("\n")
+        )
+    )
+    print("Default tables (named collection)", default_tables)
+    assert default_tables == [
+        "default.marksheet",
+        "default.marksheet_uniform",
+        "default.numbers",
+        "default.user_countries",
+    ]
+
+    data = node1.query(
+        f"SELECT * FROM {db_name}.`default.marksheet` ORDER BY 1,2,3"
+    )
+    assert len(data.strip()) > 0
+
+    node1.query(f"DROP DATABASE {db_name}")
+    node1.query(f"DROP NAMED COLLECTION {collection_name}")
+
+
+def test_named_collection_with_overrides(started_cluster):
+    test_uuid = str(uuid.uuid4()).replace("-", "_")
+    node1 = started_cluster.instances["node1"]
+    db_name = f"nc_override_test_{test_uuid}"
+    collection_name = f"nc_override_{test_uuid}"
+
+    node1.query(f"drop database if exists {db_name}")
+    node1.query(
+        f"CREATE NAMED COLLECTION {collection_name} AS "
+        f"url = 'http://localhost:8080/api/2.1/unity-catalog', "
+        f"warehouse = 'unity', catalog_type = 'unity', vended_credentials = true"
+    )
+    # Override vended_credentials from true to false via inline key-value override
+    node1.query(
+        f"CREATE DATABASE {db_name} ENGINE = DataLakeCatalog({collection_name}, vended_credentials = false)",
+        settings={"allow_experimental_database_unity_catalog": "1"},
+    )
+    default_tables = list(
+        sorted(
+            node1.query(
+                f"SHOW TABLES FROM {db_name} LIKE 'default%'",
+                settings={"use_hive_partitioning": "0"},
+            )
+            .strip()
+            .split("\n")
+        )
+    )
+    print("Default tables (named collection with overrides)", default_tables)
+    assert default_tables == [
+        "default.marksheet",
+        "default.marksheet_uniform",
+        "default.numbers",
+        "default.user_countries",
+    ]
+
+    data = node1.query(
+        f"SELECT * FROM {db_name}.`default.marksheet` ORDER BY 1,2,3"
+    )
+    assert len(data.strip()) > 0
+
+    node1.query(f"DROP DATABASE {db_name}")
+    node1.query(f"DROP NAMED COLLECTION {collection_name}")
+
+
 def test_multiple_schemes_tables(started_cluster):
     test_uuid = str(uuid.uuid4()).replace("-", "_")
     node1 = started_cluster.instances["node1"]

--- a/tests/integration/test_mask_sensitive_info/test.py
+++ b/tests/integration/test_mask_sensitive_info/test.py
@@ -1,3 +1,4 @@
+import os
 import random
 import re
 import string
@@ -20,6 +21,9 @@ node = cluster.add_instance(
     with_azurite=True,
     # Disable `with_remote_database_disk` as `test_create_table` might access minIO and expect `DNS_ERROR`. However, minIO might be enabled when `with_remote_database_disk` is enabled;
     with_remote_database_disk=False,
+    image="clickhouse/integration-test-with-unity-catalog",
+    with_installed_binary=False,
+    tag=os.environ.get("DOCKER_BASE_WITH_UNITY_CATALOG_TAG", "latest"),
 )
 base_search_query = "SELECT COUNT() FROM system.query_log WHERE query LIKE "
 
@@ -459,6 +463,86 @@ def test_create_database():
     for database_name, query, error in test_cases:
         if not error:
             node.query(f"DROP DATABASE {database_name}")
+
+
+def test_create_database_datalake():
+    password = new_password()
+    password2 = new_password()
+
+    settings = {"allow_experimental_database_unity_catalog": "1"}
+
+    # Scenario A: Secrets as named collection key-value overrides.
+    # Create a named collection with non-secret base config.
+    node.query(
+        "CREATE NAMED COLLECTION IF NOT EXISTS datalake_nc AS "
+        "url = 'http://localhost:12345', "
+        "catalog_type = 'unity', "
+        "warehouse = 'my_warehouse', "
+        "vended_credentials = false"
+    )
+
+    secret_keys = [
+        "catalog_credential",
+        "aws_secret_access_key",
+        "onelake_client_secret",
+        "dlf_access_key_secret",
+        "auth_header",
+    ]
+
+    database_engines_a = [
+        f"DataLakeCatalog(datalake_nc, {key} = '{password}')"
+        for key in secret_keys
+    ]
+
+    def make_test_case_a(i):
+        database_name = f"datalake_db_a{i}"
+        database_engine = database_engines_a[i]
+        query = f"CREATE DATABASE {database_name} ENGINE = {database_engine}"
+        return database_name, query
+
+    test_cases_a = [make_test_case_a(i) for i in range(len(database_engines_a))]
+
+    for database_name, query in test_cases_a:
+        node.query(query, settings=settings)
+
+    must_contain_a = [
+        f"CREATE DATABASE datalake_db_a{i} ENGINE = DataLakeCatalog(datalake_nc, {key} = '[HIDDEN]')"
+        for i, key in enumerate(secret_keys)
+    ]
+
+    check_logs(
+        must_contain=must_contain_a,
+        must_not_contain=[password],
+    )
+
+    for database_name, query in test_cases_a:
+        node.query(f"DROP DATABASE IF EXISTS {database_name}")
+
+    # Scenario B: Secrets stored inside the named collection.
+    node.query(
+        f"CREATE NAMED COLLECTION IF NOT EXISTS datalake_nc_secrets AS "
+        f"url = 'http://localhost:12345', "
+        f"catalog_type = 'unity', "
+        f"warehouse = 'my_warehouse', "
+        f"vended_credentials = false, "
+        f"catalog_credential = '{password2}'"
+    )
+
+    node.query(
+        "CREATE DATABASE datalake_db_b0 ENGINE = DataLakeCatalog(datalake_nc_secrets)",
+        settings=settings,
+    )
+
+    check_logs(
+        must_contain=[
+            "CREATE NAMED COLLECTION",
+        ],
+        must_not_contain=[password2],
+    )
+
+    node.query("DROP DATABASE IF EXISTS datalake_db_b0")
+    node.query("DROP NAMED COLLECTION IF EXISTS datalake_nc")
+    node.query("DROP NAMED COLLECTION IF EXISTS datalake_nc_secrets")
 
 
 def test_table_functions():

--- a/tests/integration/test_mask_sensitive_info/test.py
+++ b/tests/integration/test_mask_sensitive_info/test.py
@@ -1,3 +1,4 @@
+from itertools import product
 import os
 import random
 import re
@@ -514,6 +515,29 @@ def test_create_database_datalake():
         must_contain=must_contain_a,
         must_not_contain=[password],
     )
+
+    for secret_key, password_toggle in product(enumerate(secret_keys), enumerate(["[HIDDEN]", password])):
+        i, key = secret_key
+        toggle, secret = password_toggle
+        assert (
+            node.query(f"SHOW CREATE DATABASE datalake_db_a{i} {show_secrets}={toggle}")
+            == f"CREATE DATABASE datalake_db_a{i}\\n"
+            f"ENGINE = DataLakeCatalog(datalake_nc, {key} = \\'{secret}\\')\n"
+        )
+
+        assert (
+            node.query(
+                f"SELECT engine_full FROM system.databases WHERE name = 'datalake_db_a{i}' "
+                f"{show_secrets}={toggle}"
+            )
+            == TSV(
+                [
+                    [
+                        "",
+                    ],
+                ]
+            )
+        )
 
     for database_name, query in test_cases_a:
         node.query(f"DROP DATABASE IF EXISTS {database_name}")

--- a/tests/integration/test_mask_sensitive_info/test.py
+++ b/tests/integration/test_mask_sensitive_info/test.py
@@ -3,6 +3,7 @@ import os
 import random
 import re
 import string
+import time
 
 import pytest
 
@@ -1137,18 +1138,19 @@ def test_on_cluster():
     )
 
     # Check logs of DDLWorker during executing of this query.
-    assert node.contains_in_log(
-        "DDLWorker: Processing task .*CREATE TABLE default\\.table_oncl UUID '[0-9a-fA-F-]*' (\\`x\\` Int32) ENGINE = MySQL('mysql80:3307', 'mysql_db', 'mysql_table', 'mysql_user', '\\[HIDDEN\\]')"
-    )
-    assert node.contains_in_log(
-        "DDLWorker: Executing query: .*CREATE TABLE default\\.table_oncl UUID '[0-9a-fA-F-]*' (\\`x\\` Int32) ENGINE = MySQL('mysql80:3307', 'mysql_db', 'mysql_table', 'mysql_user', '\\[HIDDEN\\]')"
-    )
-    assert node.contains_in_log(
-        "executeQuery: .*CREATE TABLE default\\.table_oncl UUID '[0-9a-fA-F-]*' (\\`x\\` Int32) ENGINE = MySQL('mysql80:3307', 'mysql_db', 'mysql_table', 'mysql_user', '\\[HIDDEN\\]')"
-    )
-    assert node.contains_in_log(
-        "DDLWorker: Executed query: .*CREATE TABLE default\\.table_oncl UUID '[0-9a-fA-F-]*' (\\`x\\` Int32) ENGINE = MySQL('mysql80:3307', 'mysql_db', 'mysql_table', 'mysql_user', '\\[HIDDEN\\]')"
-    )
+    # Log lines may not be flushed immediately, so retry.
+    ddl_log_patterns = [
+        "DDLWorker: Processing task .*CREATE TABLE default\\.table_oncl UUID '[0-9a-fA-F-]*' (\\`x\\` Int32) ENGINE = MySQL('mysql80:3307', 'mysql_db', 'mysql_table', 'mysql_user', '\\[HIDDEN\\]')",
+        "DDLWorker: Executing query: .*CREATE TABLE default\\.table_oncl UUID '[0-9a-fA-F-]*' (\\`x\\` Int32) ENGINE = MySQL('mysql80:3307', 'mysql_db', 'mysql_table', 'mysql_user', '\\[HIDDEN\\]')",
+        "executeQuery: .*CREATE TABLE default\\.table_oncl UUID '[0-9a-fA-F-]*' (\\`x\\` Int32) ENGINE = MySQL('mysql80:3307', 'mysql_db', 'mysql_table', 'mysql_user', '\\[HIDDEN\\]')",
+        "DDLWorker: Executed query: .*CREATE TABLE default\\.table_oncl UUID '[0-9a-fA-F-]*' (\\`x\\` Int32) ENGINE = MySQL('mysql80:3307', 'mysql_db', 'mysql_table', 'mysql_user', '\\[HIDDEN\\]')",
+    ]
+    for pattern in ddl_log_patterns:
+        for _ in range(10):
+            if node.contains_in_log(pattern):
+                break
+            time.sleep(0.5)
+        assert node.contains_in_log(pattern)
     assert system_query_log_contains_search_pattern(
         "%CREATE TABLE default.table_oncl UUID \\'%\\' (`x` Int32) ENGINE = MySQL(\\'mysql80:3307\\', \\'mysql_db\\', \\'mysql_table\\', \\'mysql_user\\', \\'[HIDDEN]\\')"
     )
@@ -1188,8 +1190,8 @@ def test_query_masking_rule_with_ddl():
         f"CREATE TABLE {table_name} ON CLUSTER 'test_shard_localhost' (s String, sensetive_data UInt32) ENGINE = MergeTree ORDER BY s"
     )
 
-    assert_eq_with_retry(node, "SELECT count(*) FROM system.distribution_queue", "0\n")
+    assert_eq_with_retry(node, f"SELECT count() FROM system.tables WHERE table='{table_name}'", "1\n")
     assert "sensetive_data" in node.query(
         f"SELECT create_table_query FROM system.tables WHERE table='{table_name}' {show_secrets}"
     )
-    node.query("DROP TABLE IF EXISTS test_table")
+    node.query(f"DROP TABLE IF EXISTS {table_name}")

--- a/tests/integration/test_mask_sensitive_info/test.py
+++ b/tests/integration/test_mask_sensitive_info/test.py
@@ -575,6 +575,25 @@ def test_create_database_datalake():
         target_node=node_unity,
     )
 
+    for toggle, secret in enumerate(["[HIDDEN]", password2]):
+        assert (
+            node_unity.query(f"SHOW CREATE DATABASE datalake_db_b0 {show_secrets}={toggle}")
+            == f"CREATE DATABASE datalake_db_b0\\nENGINE = DataLakeCatalog(datalake_nc_secrets)\n"
+        )
+        assert (
+            node_unity.query(
+            f"SELECT engine_full FROM system.databases WHERE name = 'datalake_db_b0' "
+            f"{show_secrets}={toggle}"
+            )
+            == TSV(
+            [
+                [
+                    "",
+                ],
+            ]
+            )
+        )
+
     node_unity.query("DROP DATABASE IF EXISTS datalake_db_b0")
     node_unity.query("DROP NAMED COLLECTION IF EXISTS datalake_nc")
     node_unity.query("DROP NAMED COLLECTION IF EXISTS datalake_nc_secrets")

--- a/tests/integration/test_mask_sensitive_info/test.py
+++ b/tests/integration/test_mask_sensitive_info/test.py
@@ -1126,6 +1126,7 @@ def test_backup_table_azure_named_collection():
 def test_on_cluster():
     password = new_password()
 
+    node.query("DROP TABLE IF EXISTS table_oncl ON CLUSTER 'test_shard_localhost'")
     node.query(
         f"CREATE TABLE table_oncl ON CLUSTER 'test_shard_localhost' (x int) ENGINE = MySQL('mysql80:3307', 'mysql_db', 'mysql_table', 'mysql_user', '{password}')"
     )
@@ -1155,7 +1156,7 @@ def test_on_cluster():
         "%CREATE TABLE default.table_oncl UUID \\'%\\' (`x` Int32) ENGINE = MySQL(\\'mysql80:3307\\', \\'mysql_db\\', \\'mysql_table\\', \\'mysql_user\\', \\'[HIDDEN]\\')"
     )
 
-    node.query("DROP TABLE table_oncl")
+    node.query("DROP TABLE IF EXISTS table_oncl ON CLUSTER 'test_shard_localhost'")
 
 
 def test_iceberg_cluster_function():
@@ -1185,7 +1186,7 @@ def test_iceberg_cluster_function():
 
 def test_query_masking_rule_with_ddl():
     table_name = "test_ddl_masking"
-    node.query(f"DROP TABLE IF EXISTS {table_name}")
+    node.query(f"DROP TABLE IF EXISTS {table_name} ON CLUSTER 'test_shard_localhost'")
     node.query(
         f"CREATE TABLE {table_name} ON CLUSTER 'test_shard_localhost' (s String, sensetive_data UInt32) ENGINE = MergeTree ORDER BY s"
     )
@@ -1194,4 +1195,4 @@ def test_query_masking_rule_with_ddl():
     assert "sensetive_data" in node.query(
         f"SELECT create_table_query FROM system.tables WHERE table='{table_name}' {show_secrets}"
     )
-    node.query(f"DROP TABLE IF EXISTS {table_name}")
+    node.query(f"DROP TABLE IF EXISTS {table_name} ON CLUSTER 'test_shard_localhost'")

--- a/tests/integration/test_mask_sensitive_info/test.py
+++ b/tests/integration/test_mask_sensitive_info/test.py
@@ -3,7 +3,6 @@ import os
 import random
 import re
 import string
-import time
 
 import pytest
 
@@ -30,7 +29,6 @@ node_unity = cluster.add_instance(
         "configs/overrides.xml",
     ],
     user_configs=["configs/users.xml"],
-    with_zookeeper=True,
     with_azurite=True,
     with_remote_database_disk=False,
     image="clickhouse/integration-test-with-unity-catalog",
@@ -1126,7 +1124,6 @@ def test_backup_table_azure_named_collection():
 def test_on_cluster():
     password = new_password()
 
-    node.query("DROP TABLE IF EXISTS table_oncl ON CLUSTER 'test_shard_localhost'")
     node.query(
         f"CREATE TABLE table_oncl ON CLUSTER 'test_shard_localhost' (x int) ENGINE = MySQL('mysql80:3307', 'mysql_db', 'mysql_table', 'mysql_user', '{password}')"
     )
@@ -1139,24 +1136,23 @@ def test_on_cluster():
     )
 
     # Check logs of DDLWorker during executing of this query.
-    # Log lines may not be flushed immediately, so retry.
-    ddl_log_patterns = [
-        "DDLWorker: Processing task .*CREATE TABLE default\\.table_oncl UUID '[0-9a-fA-F-]*' (\\`x\\` Int32) ENGINE = MySQL('mysql80:3307', 'mysql_db', 'mysql_table', 'mysql_user', '\\[HIDDEN\\]')",
-        "DDLWorker: Executing query: .*CREATE TABLE default\\.table_oncl UUID '[0-9a-fA-F-]*' (\\`x\\` Int32) ENGINE = MySQL('mysql80:3307', 'mysql_db', 'mysql_table', 'mysql_user', '\\[HIDDEN\\]')",
-        "executeQuery: .*CREATE TABLE default\\.table_oncl UUID '[0-9a-fA-F-]*' (\\`x\\` Int32) ENGINE = MySQL('mysql80:3307', 'mysql_db', 'mysql_table', 'mysql_user', '\\[HIDDEN\\]')",
-        "DDLWorker: Executed query: .*CREATE TABLE default\\.table_oncl UUID '[0-9a-fA-F-]*' (\\`x\\` Int32) ENGINE = MySQL('mysql80:3307', 'mysql_db', 'mysql_table', 'mysql_user', '\\[HIDDEN\\]')",
-    ]
-    for pattern in ddl_log_patterns:
-        for _ in range(10):
-            if node.contains_in_log(pattern):
-                break
-            time.sleep(0.5)
-        assert node.contains_in_log(pattern)
+    assert node.contains_in_log(
+        "DDLWorker: Processing task .*CREATE TABLE default\\.table_oncl UUID '[0-9a-fA-F-]*' (\\`x\\` Int32) ENGINE = MySQL('mysql80:3307', 'mysql_db', 'mysql_table', 'mysql_user', '\\[HIDDEN\\]')"
+    )
+    assert node.contains_in_log(
+        "DDLWorker: Executing query: .*CREATE TABLE default\\.table_oncl UUID '[0-9a-fA-F-]*' (\\`x\\` Int32) ENGINE = MySQL('mysql80:3307', 'mysql_db', 'mysql_table', 'mysql_user', '\\[HIDDEN\\]')"
+    )
+    assert node.contains_in_log(
+        "executeQuery: .*CREATE TABLE default\\.table_oncl UUID '[0-9a-fA-F-]*' (\\`x\\` Int32) ENGINE = MySQL('mysql80:3307', 'mysql_db', 'mysql_table', 'mysql_user', '\\[HIDDEN\\]')"
+    )
+    assert node.contains_in_log(
+        "DDLWorker: Executed query: .*CREATE TABLE default\\.table_oncl UUID '[0-9a-fA-F-]*' (\\`x\\` Int32) ENGINE = MySQL('mysql80:3307', 'mysql_db', 'mysql_table', 'mysql_user', '\\[HIDDEN\\]')"
+    )
     assert system_query_log_contains_search_pattern(
         "%CREATE TABLE default.table_oncl UUID \\'%\\' (`x` Int32) ENGINE = MySQL(\\'mysql80:3307\\', \\'mysql_db\\', \\'mysql_table\\', \\'mysql_user\\', \\'[HIDDEN]\\')"
     )
 
-    node.query("DROP TABLE IF EXISTS table_oncl ON CLUSTER 'test_shard_localhost'")
+    node.query("DROP TABLE table_oncl")
 
 
 def test_iceberg_cluster_function():
@@ -1186,13 +1182,13 @@ def test_iceberg_cluster_function():
 
 def test_query_masking_rule_with_ddl():
     table_name = "test_ddl_masking"
-    node.query(f"DROP TABLE IF EXISTS {table_name} ON CLUSTER 'test_shard_localhost'")
+    node.query(f"DROP TABLE IF EXISTS {table_name}")
     node.query(
         f"CREATE TABLE {table_name} ON CLUSTER 'test_shard_localhost' (s String, sensetive_data UInt32) ENGINE = MergeTree ORDER BY s"
     )
 
-    assert_eq_with_retry(node, f"SELECT count() FROM system.tables WHERE table='{table_name}'", "1\n")
+    assert_eq_with_retry(node, "SELECT count(*) FROM system.distribution_queue", "0\n")
     assert "sensetive_data" in node.query(
         f"SELECT create_table_query FROM system.tables WHERE table='{table_name}' {show_secrets}"
     )
-    node.query(f"DROP TABLE IF EXISTS {table_name} ON CLUSTER 'test_shard_localhost'")
+    node.query(f"DROP TABLE IF EXISTS {table_name}")

--- a/tests/integration/test_mask_sensitive_info/test.py
+++ b/tests/integration/test_mask_sensitive_info/test.py
@@ -6,7 +6,7 @@ import string
 
 import pytest
 
-from helpers.cluster import ClickHouseCluster
+from helpers.cluster import ClickHouseCluster, with_default_target_node
 from helpers.test_tools import TSV
 from helpers.config_cluster import minio_secret_key
 from helpers.test_tools import assert_eq_with_retry
@@ -21,6 +21,16 @@ node = cluster.add_instance(
     with_zookeeper=True,
     with_azurite=True,
     # Disable `with_remote_database_disk` as `test_create_table` might access minIO and expect `DNS_ERROR`. However, minIO might be enabled when `with_remote_database_disk` is enabled;
+    with_remote_database_disk=False,
+)
+node_unity = cluster.add_instance(
+    "node_unity",
+    main_configs=[
+        "configs/overrides.xml",
+    ],
+    user_configs=["configs/users.xml"],
+    with_zookeeper=True,
+    with_azurite=True,
     with_remote_database_disk=False,
     image="clickhouse/integration-test-with-unity-catalog",
     with_installed_binary=False,
@@ -39,8 +49,9 @@ def started_cluster():
         cluster.shutdown()
 
 
-def check_logs(must_contain=[], must_not_contain=[]):
-    node.query("SYSTEM FLUSH LOGS")
+@with_default_target_node(node)
+def check_logs(must_contain=[], must_not_contain=[], target_node=None):
+    target_node.query("SYSTEM FLUSH LOGS")
 
     for str in must_contain:
         escaped_str = (
@@ -49,7 +60,7 @@ def check_logs(must_contain=[], must_not_contain=[]):
             .replace("]", "\\]")
             .replace("*", "\\*")
         )
-        assert node.contains_in_log(escaped_str, exclusion_substring=base_search_query)
+        assert target_node.contains_in_log(escaped_str, exclusion_substring=base_search_query)
 
     for str in must_not_contain:
         escaped_str = (
@@ -58,24 +69,25 @@ def check_logs(must_contain=[], must_not_contain=[]):
             .replace("]", "\\]")
             .replace("*", "\\*")
         )
-        assert not node.contains_in_log(
+        assert not target_node.contains_in_log(
             escaped_str, exclusion_substring=base_search_query
         )
 
     for str in must_contain:
         escaped_str = str.replace("'", "\\'")
-        assert system_query_log_contains_search_pattern(escaped_str)
+        assert system_query_log_contains_search_pattern(escaped_str, target_node=target_node)
 
     for str in must_not_contain:
         escaped_str = str.replace("'", "\\'")
-        assert not system_query_log_contains_search_pattern(escaped_str)
+        assert not system_query_log_contains_search_pattern(escaped_str, target_node=target_node)
 
 
 # Returns true if "system.query_log" has a query matching a specified pattern.
-def system_query_log_contains_search_pattern(search_pattern):
+@with_default_target_node(node)
+def system_query_log_contains_search_pattern(search_pattern, target_node=None):
     return (
         int(
-            node.query(
+            target_node.query(
                 f"{base_search_query}'%{search_pattern}%' AND query NOT LIKE '{base_search_query}%'"
             ).strip()
         )
@@ -474,7 +486,7 @@ def test_create_database_datalake():
 
     # Scenario A: Secrets as named collection key-value overrides.
     # Create a named collection with non-secret base config.
-    node.query(
+    node_unity.query(
         "CREATE NAMED COLLECTION IF NOT EXISTS datalake_nc AS "
         "url = 'http://localhost:12345', "
         "catalog_type = 'unity', "
@@ -504,7 +516,7 @@ def test_create_database_datalake():
     test_cases_a = [make_test_case_a(i) for i in range(len(database_engines_a))]
 
     for database_name, query in test_cases_a:
-        node.query(query, settings=settings)
+        node_unity.query(query, settings=settings)
 
     must_contain_a = [
         f"CREATE DATABASE datalake_db_a{i} ENGINE = DataLakeCatalog(datalake_nc, {key} = '[HIDDEN]')"
@@ -514,19 +526,20 @@ def test_create_database_datalake():
     check_logs(
         must_contain=must_contain_a,
         must_not_contain=[password],
+        target_node=node_unity,
     )
 
     for secret_key, password_toggle in product(enumerate(secret_keys), enumerate(["[HIDDEN]", password])):
         i, key = secret_key
         toggle, secret = password_toggle
         assert (
-            node.query(f"SHOW CREATE DATABASE datalake_db_a{i} {show_secrets}={toggle}")
+            node_unity.query(f"SHOW CREATE DATABASE datalake_db_a{i} {show_secrets}={toggle}")
             == f"CREATE DATABASE datalake_db_a{i}\\n"
             f"ENGINE = DataLakeCatalog(datalake_nc, {key} = \\'{secret}\\')\n"
         )
 
         assert (
-            node.query(
+            node_unity.query(
                 f"SELECT engine_full FROM system.databases WHERE name = 'datalake_db_a{i}' "
                 f"{show_secrets}={toggle}"
             )
@@ -540,10 +553,10 @@ def test_create_database_datalake():
         )
 
     for database_name, query in test_cases_a:
-        node.query(f"DROP DATABASE IF EXISTS {database_name}")
+        node_unity.query(f"DROP DATABASE IF EXISTS {database_name}")
 
     # Scenario B: Secrets stored inside the named collection.
-    node.query(
+    node_unity.query(
         f"CREATE NAMED COLLECTION IF NOT EXISTS datalake_nc_secrets AS "
         f"url = 'http://localhost:12345', "
         f"catalog_type = 'unity', "
@@ -552,7 +565,7 @@ def test_create_database_datalake():
         f"catalog_credential = '{password2}'"
     )
 
-    node.query(
+    node_unity.query(
         "CREATE DATABASE datalake_db_b0 ENGINE = DataLakeCatalog(datalake_nc_secrets)",
         settings=settings,
     )
@@ -562,11 +575,12 @@ def test_create_database_datalake():
             "CREATE NAMED COLLECTION",
         ],
         must_not_contain=[password2],
+        target_node=node_unity,
     )
 
-    node.query("DROP DATABASE IF EXISTS datalake_db_b0")
-    node.query("DROP NAMED COLLECTION IF EXISTS datalake_nc")
-    node.query("DROP NAMED COLLECTION IF EXISTS datalake_nc_secrets")
+    node_unity.query("DROP DATABASE IF EXISTS datalake_db_b0")
+    node_unity.query("DROP NAMED COLLECTION IF EXISTS datalake_nc")
+    node_unity.query("DROP NAMED COLLECTION IF EXISTS datalake_nc_secrets")
 
 
 def test_table_functions():

--- a/tests/integration/test_mask_sensitive_info/test.py
+++ b/tests/integration/test_mask_sensitive_info/test.py
@@ -8,7 +8,6 @@ import pytest
 
 from helpers.cluster import ClickHouseCluster, with_default_target_node
 from helpers.test_tools import TSV
-from helpers.config_cluster import minio_secret_key
 from helpers.test_tools import assert_eq_with_retry
 
 cluster = ClickHouseCluster(__file__)
@@ -32,7 +31,6 @@ node_unity = cluster.add_instance(
     with_azurite=True,
     with_remote_database_disk=False,
     image="clickhouse/integration-test-with-unity-catalog",
-    with_installed_binary=False,
     tag=os.environ.get("DOCKER_BASE_WITH_UNITY_CATALOG_TAG", "latest"),
 )
 base_search_query = "SELECT COUNT() FROM system.query_log WHERE query LIKE "


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add named collection support for DataLakeCatalog arguments

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes database engine argument parsing and settings precedence for `DataLakeCatalog`, plus extends secret-masking logic; mistakes here could break database creation or expose/misapply credentials. Coverage is improved with new integration tests, reducing but not eliminating risk.
> 
> **Overview**
> Adds **named collection support** for `ENGINE = DataLakeCatalog(...)`, allowing the catalog `url` and other engine settings to be sourced from a named collection with inline overrides, while ensuring `SETTINGS` still take precedence.
> 
> Updates secret-masking to treat `DataLakeCatalog` named-collection overrides as sensitive (e.g. `catalog_credential`, `aws_secret_access_key`, `auth_header`), and adds integration tests (including a Unity Catalog-based node) validating named-collection usage and that secrets are hidden in logs/`SHOW CREATE` unless explicitly requested. Documentation is updated with a named-collection example.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ec99050454bd7eed8014e7033c6c0fc50383d18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->