### PR TITLE
Reintroduce 96547

### DIFF
--- a/src/Common/Allocator.cpp
+++ b/src/Common/Allocator.cpp
@@ -75,13 +75,6 @@ void * allocNoTrack(size_t size, size_t alignment)
     void * buf;
     if (likely(alignment <= MALLOC_MIN_ALIGNMENT))
     {
-        if (alignment > 8 && (!isPowerOf2(alignment) || (alignment % sizeof(void *) != 0)))
-            throw DB::Exception(
-                DB::ErrorCodes::CANNOT_ALLOCATE_MEMORY,
-                "This would fail with posix_memalign: alignment ({}) must be a power of two and a multiple of {}.",
-                alignment,
-                sizeof(void *));
-
         if constexpr (clear_memory)
             buf = __real_calloc(size, 1);
         else

--- a/src/Common/Allocator.h
+++ b/src/Common/Allocator.h
@@ -19,7 +19,7 @@
 
 extern const size_t POPULATE_THRESHOLD;
 
-static constexpr size_t MALLOC_MIN_ALIGNMENT = 8;
+static constexpr size_t MALLOC_MIN_ALIGNMENT = alignof(std::max_align_t);
 
 /** Previously there was a code which tried to use manual mmap and mremap (clickhouse_mremap.h) for large allocations/reallocations (64MB+).
   * Most modern allocators (including jemalloc) don't use mremap, so the idea was to take advantage from mremap system call for large reallocs.

--- a/src/IO/tests/gtest_memory_resize.cpp
+++ b/src/IO/tests/gtest_memory_resize.cpp
@@ -233,7 +233,8 @@ TEST(MemoryResizeTest, BigInitAndSmallResizeOverflowWhenPadding)
 TEST(MemoryResizeTest, AlignmentWithRealAllocator)
 {
     {
-        auto memory = Memory<>(0, 3); // not the power of 2 but less than MALLOC_MIN_ALIGNMENT 8 so user-defined alignment is ignored at Allocator
+        auto memory
+            = Memory<>(0, 3); // not the power of 2 but less than MALLOC_MIN_ALIGNMENT so user-defined alignment is ignored at Allocator
         ASSERT_EQ(memory.m_data, nullptr);
         ASSERT_EQ(memory.m_capacity, 0);
         ASSERT_EQ(memory.m_size, 0);

--- a/src/IO/tests/gtest_memory_resize.cpp
+++ b/src/IO/tests/gtest_memory_resize.cpp
@@ -234,7 +234,7 @@ TEST(MemoryResizeTest, AlignmentWithRealAllocator)
 {
     {
         auto memory
-            = Memory<>(0, 3); // not the power of 2 but less than MALLOC_MIN_ALIGNMENT so user-defined alignment is ignored at Allocator
+            = Memory<>(0, 3); // not a power of 2 but less than MALLOC_MIN_ALIGNMENT so user-defined alignment is ignored at Allocator
         ASSERT_EQ(memory.m_data, nullptr);
         ASSERT_EQ(memory.m_capacity, 0);
         ASSERT_EQ(memory.m_size, 0);
@@ -272,7 +272,7 @@ TEST(MemoryResizeTest, AlignmentWithRealAllocator)
 
 #if !defined(ADDRESS_SANITIZER) && !defined(THREAD_SANITIZER) && !defined(MEMORY_SANITIZER) && !defined(UNDEFINED_BEHAVIOR_SANITIZER)
     {
-        auto memory = Memory<>(0, 10); // not the power of 2
+        auto memory = Memory<>(0, 20); // not a power of 2, but more than MALLOC_MIN_ALIGNMENT
         ASSERT_EQ(memory.m_data, nullptr);
         ASSERT_EQ(memory.m_capacity, 0);
         ASSERT_EQ(memory.m_size, 0);


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Reverts https://github.com/ClickHouse/ClickHouse/pull/96814



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.805`
<!-- ch-version-info:end -->