### PR TITLE
Fix flaky test_short_disconnection backup/restore tests

### DIFF
--- a/tests/integration/test_backup_restore_on_cluster/test_cancel_backup.py
+++ b/tests/integration/test_backup_restore_on_cluster/test_cancel_backup.py
@@ -679,6 +679,9 @@ def test_short_disconnection_doesnt_stop_backup():
         assert get_num_system_processes(initiator, backup_id=backup_id) >= 1
 
         # Dropping connection for less than `failure_after_host_disconnected_for_seconds`
+        # When using faster_zk_disconnect_detect.xml (session_timeout_ms=5000),
+        # the drop duration must be short enough to avoid ZK session expiry.
+        max_drop_seconds = 1 if use_faster_zk_disconnect_detect else 4
         with PartitionManager() as pm:
             random_sleep(4)
             node_to_drop_zk_connection = random_node()
@@ -686,7 +689,7 @@ def test_short_disconnection_doesnt_stop_backup():
                 f"Dropping connection between {get_node_name(node_to_drop_zk_connection)} and ZooKeeper at {format_current_time()}"
             )
             pm.drop_instance_zk_connections(node_to_drop_zk_connection)
-            random_sleep(4)
+            random_sleep(max_drop_seconds)
             print(
                 f"Restoring connection between {get_node_name(node_to_drop_zk_connection)} and ZooKeeper at {format_current_time()}"
             )
@@ -733,6 +736,9 @@ def test_short_disconnection_doesnt_stop_restore():
         assert get_num_system_processes(initiator, restore_id=restore_id) >= 1
 
         # Dropping connection for less than `failure_after_host_disconnected_for_seconds`
+        # When using faster_zk_disconnect_detect.xml (session_timeout_ms=5000),
+        # the drop duration must be short enough to avoid ZK session expiry.
+        max_drop_seconds = 1 if use_faster_zk_disconnect_detect else 3
         with PartitionManager() as pm:
             random_sleep(3)
             node_to_drop_zk_connection = random_node()
@@ -740,7 +746,7 @@ def test_short_disconnection_doesnt_stop_restore():
                 f"Dropping connection between {get_node_name(node_to_drop_zk_connection)} and ZooKeeper at {format_current_time()}"
             )
             pm.drop_instance_zk_connections(node_to_drop_zk_connection)
-            random_sleep(3)
+            random_sleep(max_drop_seconds)
             print(
                 f"Restoring connection between {get_node_name(node_to_drop_zk_connection)} and ZooKeeper at {format_current_time()}"
             )


### PR DESCRIPTION
## Summary

- Fix `test_short_disconnection_doesnt_stop_backup` and `test_short_disconnection_doesnt_stop_restore` by limiting ZK connection drop duration when `faster_zk_disconnect_detect.xml` is used
- When this config is active (`session_timeout_ms=5000`), the iptables drop lasting up to 3-4 seconds can cause ZK session expiry due to total heartbeat silence exceeding 5 seconds (drop duration + time since last heartbeat + reconnection overhead)
- The fix limits drop duration to 1 second with faster detection, keeping original timing otherwise

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96758&sha=d29b41fbe684f8c90ace4fd71828ce0d4ac8b88f&name_0=PR&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%204%2F4%29
https://github.com/ClickHouse/ClickHouse/pull/96758

Closes #80359

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.661`
<!-- ch-version-info:end -->