### PR TITLE
Skip `00180_no_seek_avoiding_when_reading_from_cache` on ASan builds

### DIFF
--- a/tests/queries/0_stateless/00180_no_seek_avoiding_when_reading_from_cache.sh
+++ b/tests/queries/0_stateless/00180_no_seek_avoiding_when_reading_from_cache.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: stateful, no-parallel, no-random-settings, long
+# Tags: stateful, no-parallel, no-random-settings, long, no-asan
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Skip flaky test `00180_no_seek_avoiding_when_reading_from_cache` on ASan builds due to timeouts.

## Problem

The test `00180_no_seek_avoiding_when_reading_from_cache` times out on ARM ASan while inserting data from the large S3 stateful dataset `test.hits_s3`. The test performs S3 operations which are too slow for ASan builds (3-5x slower than regular builds).

This test is also known to be flaky due to interference with `00170_s3_cache.sql` - both tests perform `SYSTEM DROP FILESYSTEM CACHE`, causing test isolation issues (see #66683).

## Solution

Added `no-asan` tag to skip this test on ASan builds:
```diff
-# Tags: stateful, no-parallel, no-random-settings, long
+# Tags: stateful, no-parallel, no-random-settings, long, no-asan
```

## References

- Flaky test issue: https://github.com/ClickHouse/ClickHouse/issues/66683
- CI timeout: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96710&sha=3eb5f0ac7159d59f983acbf034e4cb1485856731&name_0=PR&name_1=Stateless%20tests%20%28arm_asan%2C%20targeted%29
https://github.com/ClickHouse/ClickHouse/pull/96710

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.665`
<!-- ch-version-info:end -->