### PR TITLE
Better jemalloc introspection

### DIFF
--- a/src/Storages/System/StorageSystemJemalloc.h
+++ b/src/Storages/System/StorageSystemJemalloc.h
@@ -6,8 +6,6 @@
 namespace DB
 {
 
-class Context;
-
 class StorageSystemJemallocBins final : public IStorage
 {
 public:


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Better jemalloc introspection

### Changes
- You can look at `util` column for internal jemalloc fragmentation (see https://github.com/jemalloc/jemalloc/issues/2850, https://github.com/jemalloc/jemalloc/issues/1740)

_P.S. maybe it make sense to copy the whole `malloc_stats_print` and not only those fields_


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.672`
- Backported to: `26.1.3.38`, `25.12.7.9`, `25.11.10.13`, `25.8.17.26`
<!-- ch-version-info:end -->