### PR TITLE
Fix exit status of clickhouse-client after server error

### DIFF
--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -443,7 +443,7 @@ try
 
         if (exception)
         {
-            return exception->code() != 0 ? exception->code() : -1;
+            return static_cast<UInt8>(exception->code()) ? exception->code() : -1;
         }
 
         if (have_error)

--- a/tests/queries/0_stateless/03916_set_non_granted_role.reference
+++ b/tests/queries/0_stateless/03916_set_non_granted_role.reference
@@ -1,0 +1,2 @@
+Failed
+SET_NON_GRANTED_ROLE

--- a/tests/queries/0_stateless/03916_set_non_granted_role.sh
+++ b/tests/queries/0_stateless/03916_set_non_granted_role.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+user_name="user_${CLICKHOUSE_DATABASE}"
+role_name="role_${CLICKHOUSE_DATABASE}"
+
+$CLICKHOUSE_CLIENT --query "
+    DROP USER IF EXISTS ${user_name};
+    DROP ROLE IF EXISTS ${role_name};
+"
+
+$CLICKHOUSE_CLIENT --query "
+    CREATE USER ${user_name};
+    CREATE ROLE ${role_name};
+"
+
+output=$($CLICKHOUSE_CLIENT --query "SET DEFAULT ROLE ${role_name} TO ${user_name}" 2>&1)
+status=$?
+
+[ $status -eq 0 ] && echo "Successful" || echo "Failed"
+echo "$output" | grep -o 'SET_NON_GRANTED_ROLE' | uniq
+
+$CLICKHOUSE_CLIENT --query "
+    DROP USER ${user_name};
+    DROP ROLE ${role_name};
+"


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix exit status of clickhouse-client after server error


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.788`
<!-- ch-version-info:end -->