### PR TITLE
Make targeted check timeouts the same as regular jobs

### DIFF
--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -537,10 +537,7 @@ def main():
                             collected_test_results.append(test_case_result)
                             seen_test_names.add(test_case_result.name)
 
-                # Control elapsed time for targeted checks: exit if >30 minutes
                 stop_by_elapsed_time = False
-                if is_targeted_check and cnt > 0:
-                    stop_by_elapsed_time = stop_watch_.duration / 60 > 30
 
                 # On final run, replace results with collected ones
                 if is_final_run or stop_by_elapsed_time:

--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -522,15 +522,8 @@ tar -czf ./ci/tmp/logs.tar.gz \
     failed_tests_files = []
 
     has_error = False
-    if not is_targeted_check:
-        session_timeout_parallel = 3600 * 2
-        session_timeout_sequential = 3600
-    else:
-        # For targeted jobs, use a shorter session timeout to keep feedback fast.
-        # If this timeout is exceeded but all completed tests have passed, the
-        # targeted check will not fail solely because the session timed out.
-        session_timeout_parallel = 1200
-        session_timeout_sequential = 1200
+    session_timeout_parallel = 3600 * 2
+    session_timeout_sequential = 3600
 
     if is_llvm_coverage:
         session_timeout_parallel = 7200


### PR DESCRIPTION
Targeted checks often time out because they had much shorter session timeouts than regular jobs:
- Integration tests: 20 min vs 2h (parallel) / 1h (sequential) for regular jobs
- Functional tests: 30 min elapsed time limit vs no limit for regular jobs

Example: https://github.com/ClickHouse/ClickHouse/pull/93384

This PR removes the special shorter timeouts for targeted checks so they use the same timeouts as regular jobs.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.660`
<!-- ch-version-info:end -->