### PR TITLE
Add test for text index

### DIFF
--- a/tests/queries/0_stateless/03916_text_index_multiple_blocks.reference.j2
+++ b/tests/queries/0_stateless/03916_text_index_multiple_blocks.reference.j2
@@ -1,0 +1,80 @@
+{%- for (codec, use_indexes) in [('none', 0), ('none', 1), ('bitpacking', 1)] -%}
+-- { echo on }
+
+DROP TABLE IF EXISTS text_index_multiple_blocks;
+SET enable_full_text_index = 1;
+CREATE TABLE text_index_multiple_blocks
+(
+    id UInt64,
+    s String,
+    INDEX idx_s (s) TYPE text (tokenizer = splitByNonAlpha, posting_list_block_size = 1024, posting_list_codec = '{{ codec }}')
+)
+ENGINE = MergeTree ORDER BY id;
+INSERT INTO text_index_multiple_blocks
+SELECT
+    number,
+    concatWithSeparator(
+        ' ',
+        if (number % 30000 = 12345, 'inlined', ''),
+        if (number % 10000 = 1234, 'raw', ''),
+        if (number % 300 = 123, 'single', ''),
+        if (number % 3 = 0, 'multiple', ''))
+FROM numbers(100000);
+SET use_skip_indexes = {{ use_indexes }};
+SELECT id FROM text_index_multiple_blocks WHERE hasAllTokens(s, 'inlined') ORDER BY id;
+12345
+42345
+72345
+SELECT id FROM text_index_multiple_blocks WHERE hasAllTokens(s, 'raw') ORDER BY id;
+1234
+11234
+21234
+31234
+41234
+51234
+61234
+71234
+81234
+91234
+SELECT count() FROM text_index_multiple_blocks WHERE hasAllTokens(s, 'single');
+333
+SELECT count() FROM text_index_multiple_blocks WHERE hasAllTokens(s, 'multiple');
+33334
+SELECT id FROM text_index_multiple_blocks WHERE hasAllTokens(s, 'inlined multiple') ORDER BY id;
+12345
+42345
+72345
+SELECT id FROM text_index_multiple_blocks WHERE hasAllTokens(s, 'raw multiple') ORDER BY id;
+21234
+51234
+81234
+SELECT count() FROM text_index_multiple_blocks WHERE hasAllTokens(s, 'single multiple');
+333
+SELECT count() FROM text_index_multiple_blocks WHERE hasAllTokens(s, 'inlined single multiple');
+0
+SELECT count() FROM text_index_multiple_blocks WHERE hasAllTokens(s, 'inlined single raw multiple');
+0
+SELECT count() FROM text_index_multiple_blocks WHERE hasAllTokens(s, 'inlined raw multiple');
+0
+SELECT count() FROM text_index_multiple_blocks WHERE hasAnyTokens(s, 'inlined');
+3
+SELECT count() FROM text_index_multiple_blocks WHERE hasAnyTokens(s, 'raw');
+10
+SELECT count() FROM text_index_multiple_blocks WHERE hasAnyTokens(s, 'single');
+333
+SELECT count() FROM text_index_multiple_blocks WHERE hasAnyTokens(s, 'multiple');
+33334
+SELECT count() FROM text_index_multiple_blocks WHERE hasAnyTokens(s, 'inlined multiple');
+33334
+SELECT count() FROM text_index_multiple_blocks WHERE hasAnyTokens(s, 'raw multiple');
+33341
+SELECT count() FROM text_index_multiple_blocks WHERE hasAnyTokens(s, 'single multiple');
+33334
+SELECT count() FROM text_index_multiple_blocks WHERE hasAnyTokens(s, 'inlined single multiple');
+33334
+SELECT count() FROM text_index_multiple_blocks WHERE hasAnyTokens(s, 'inlined single raw multiple');
+33341
+SELECT count() FROM text_index_multiple_blocks WHERE hasAnyTokens(s, 'inlined raw multiple');
+33341
+DROP TABLE text_index_multiple_blocks;
+{% endfor -%}

--- a/tests/queries/0_stateless/03916_text_index_multiple_blocks.sql.j2
+++ b/tests/queries/0_stateless/03916_text_index_multiple_blocks.sql.j2
@@ -1,0 +1,51 @@
+{% for (codec, use_indexes) in [('none', 0), ('none', 1), ('bitpacking', 1)] %}
+
+-- { echo on }
+
+DROP TABLE IF EXISTS text_index_multiple_blocks;
+SET enable_full_text_index = 1;
+
+CREATE TABLE text_index_multiple_blocks
+(
+    id UInt64,
+    s String,
+    INDEX idx_s (s) TYPE text (tokenizer = splitByNonAlpha, posting_list_block_size = 1024, posting_list_codec = '{{ codec }}')
+)
+ENGINE = MergeTree ORDER BY id;
+INSERT INTO text_index_multiple_blocks
+SELECT
+    number,
+    concatWithSeparator(
+        ' ',
+        if (number % 30000 = 12345, 'inlined', ''),
+        if (number % 10000 = 1234, 'raw', ''),
+        if (number % 300 = 123, 'single', ''),
+        if (number % 3 = 0, 'multiple', ''))
+FROM numbers(100000);
+
+SET use_skip_indexes = {{ use_indexes }};
+
+SELECT id FROM text_index_multiple_blocks WHERE hasAllTokens(s, 'inlined') ORDER BY id;
+SELECT id FROM text_index_multiple_blocks WHERE hasAllTokens(s, 'raw') ORDER BY id;
+SELECT count() FROM text_index_multiple_blocks WHERE hasAllTokens(s, 'single');
+SELECT count() FROM text_index_multiple_blocks WHERE hasAllTokens(s, 'multiple');
+SELECT id FROM text_index_multiple_blocks WHERE hasAllTokens(s, 'inlined multiple') ORDER BY id;
+SELECT id FROM text_index_multiple_blocks WHERE hasAllTokens(s, 'raw multiple') ORDER BY id;
+SELECT count() FROM text_index_multiple_blocks WHERE hasAllTokens(s, 'single multiple');
+SELECT count() FROM text_index_multiple_blocks WHERE hasAllTokens(s, 'inlined single multiple');
+SELECT count() FROM text_index_multiple_blocks WHERE hasAllTokens(s, 'inlined single raw multiple');
+SELECT count() FROM text_index_multiple_blocks WHERE hasAllTokens(s, 'inlined raw multiple');
+SELECT count() FROM text_index_multiple_blocks WHERE hasAnyTokens(s, 'inlined');
+SELECT count() FROM text_index_multiple_blocks WHERE hasAnyTokens(s, 'raw');
+SELECT count() FROM text_index_multiple_blocks WHERE hasAnyTokens(s, 'single');
+SELECT count() FROM text_index_multiple_blocks WHERE hasAnyTokens(s, 'multiple');
+SELECT count() FROM text_index_multiple_blocks WHERE hasAnyTokens(s, 'inlined multiple');
+SELECT count() FROM text_index_multiple_blocks WHERE hasAnyTokens(s, 'raw multiple');
+SELECT count() FROM text_index_multiple_blocks WHERE hasAnyTokens(s, 'single multiple');
+SELECT count() FROM text_index_multiple_blocks WHERE hasAnyTokens(s, 'inlined single multiple');
+SELECT count() FROM text_index_multiple_blocks WHERE hasAnyTokens(s, 'inlined single raw multiple');
+SELECT count() FROM text_index_multiple_blocks WHERE hasAnyTokens(s, 'inlined raw multiple');
+
+DROP TABLE text_index_multiple_blocks;
+
+{% endfor %}


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

I've noticed from the coverage report, that some branches of code related to splitting of posting lists are not tested. We need to think how to randomize parameters of the skip indexes.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.670`
<!-- ch-version-info:end -->