### PR TITLE
Increase stress/fuzzer runtime for feature/improvement/performance PRs

### DIFF
--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -142,7 +142,7 @@ common_stress_job_config = Job.Config(
             "./ci/jobs/scripts/log_parser.py",
         ],
     ),
-    timeout=3600 * 2,
+    timeout=3600 * 3,
 )
 common_integration_test_job_config = Job.Config(
     name=JobNames.INTEGRATION,

--- a/ci/jobs/ast_fuzzer_job.py
+++ b/ci/jobs/ast_fuzzer_job.py
@@ -25,8 +25,12 @@ def get_run_command(
     image: DockerImage,
     buzzhouse: bool,
 ) -> str:
+    from ci.jobs.ci_utils import is_extended_run
+
+    minutes = 60 if is_extended_run() else 30
     envs = [
         f"-e FUZZER_TO_RUN='{'BuzzHouse' if buzzhouse else 'AST Fuzzer'}'",
+        f"-e FUZZ_TIME_LIMIT='{minutes}m'",
     ]
 
     env_str = " ".join(envs)

--- a/ci/jobs/buzzhouse_job.py
+++ b/ci/jobs/buzzhouse_job.py
@@ -4,6 +4,7 @@ import random
 from pathlib import Path
 
 from ci.jobs.ast_fuzzer_job import run_fuzz_job
+from ci.jobs.ci_utils import is_extended_run
 from ci.praktika.utils import Utils
 
 
@@ -222,8 +223,8 @@ def main():
         "allow_transactions": allow_transactions,
         # Run query oracles sometimes
         "allow_query_oracles": random.randint(1, 4) == 1,
-        # Run for 30 minutes max
-        "time_to_run": 30,
+        # Run for 30 minutes by default, or 60 minutes for feature/improvement/performance PRs
+        "time_to_run": 60 if is_extended_run() else 30,
         "remote_servers": ["localhost:9000"],
         "remote_secure_servers": ["localhost:9440"],
         "http_servers": ["localhost:8123"],

--- a/ci/jobs/ci_utils.py
+++ b/ci/jobs/ci_utils.py
@@ -1,0 +1,11 @@
+from ci.praktika.info import Info
+
+EXTENDED_RUN_LABELS = {"pr-feature", "pr-improvement", "pr-performance"}
+
+
+def is_extended_run() -> bool:
+    try:
+        info = Info()
+        return bool(set(info.pr_labels) & EXTENDED_RUN_LABELS)
+    except Exception:
+        return False

--- a/ci/jobs/scripts/fuzzer/run-fuzzer.sh
+++ b/ci/jobs/scripts/fuzzer/run-fuzzer.sh
@@ -203,7 +203,7 @@ function fuzz
     # Allow the fuzzer to run for some time, giving it a grace period of 5m to finish once the time
     # out triggers. After that, it'll send a SIGKILL to the fuzzer to make sure it finishes within
     # a reasonable time.
-    timeout --verbose --signal TERM --kill-after=5m --preserve-status 30m clickhouse-client \
+    timeout --verbose --signal TERM --kill-after=5m --preserve-status "${FUZZ_TIME_LIMIT:-30m}" clickhouse-client \
         --max_memory_usage_in_client=1000000000 \
         --receive_timeout=10 \
         --receive_data_timeout_ms=10000 \

--- a/ci/jobs/stress_job.py
+++ b/ci/jobs/stress_job.py
@@ -59,6 +59,8 @@ def read_test_results(results_path: Path, with_raw_logs: bool = True):
 
 
 def get_additional_envs(info, check_name: str) -> List[str]:
+    from ci.jobs.ci_utils import is_extended_run
+
     result = []
     if not info.is_local_run:
         azure_connection_string = Shell.get_output(
@@ -76,6 +78,10 @@ def get_additional_envs(info, check_name: str) -> List[str]:
 
     if "s3" in check_name:
         result.append("USE_S3_STORAGE_FOR_MERGE_TREE=1")
+
+    result.append(
+        f"STRESS_GLOBAL_TIME_LIMIT={'3600' if is_extended_run() else '1200'}"
+    )
 
     return result
 

--- a/tests/docker_scripts/stress_runner.sh
+++ b/tests/docker_scripts/stress_runner.sh
@@ -265,7 +265,7 @@ fi
 start_server || { echo "Failed to start server"; exit 1; }
 
 cd /repo/tests/ || exit 1  # clickhouse-test can find queries dir from there
-python3 /repo/ci/jobs/scripts/stress/stress.py --hung-check --drop-databases --output-folder /test_output --skip-func-tests "$SKIP_TESTS_OPTION" --global-time-limit 1200 --encrypted-storage "$USE_ENCRYPTED_STORAGE" \
+python3 /repo/ci/jobs/scripts/stress/stress.py --hung-check --drop-databases --output-folder /test_output --skip-func-tests "$SKIP_TESTS_OPTION" --global-time-limit "${STRESS_GLOBAL_TIME_LIMIT:-1200}" --encrypted-storage "$USE_ENCRYPTED_STORAGE" \
     && echo -e "Test script exit code$OK" >> /test_output/test_results.tsv \
     || echo -e "Test script failed$FAIL script exit code: $?" >> /test_output/test_results.tsv
 


### PR DESCRIPTION
## Summary

- PRs labeled `pr-feature`, `pr-improvement`, or `pr-performance` now run stress tests and fuzzers for **1 hour** instead of the default 20-30 minutes, to get better coverage on code changes that are more likely to introduce subtle bugs
- A shared helper `is_extended_run` in `ci/jobs/ci_utils.py` checks `Info().pr_labels` for these labels
- Default runtimes are unchanged for all other PR categories
- Stress job timeout increased from 2h to 3h to accommodate the longer run plus setup/teardown

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.688`
<!-- ch-version-info:end -->