### PR TITLE
Output Date as date32 in Arrow/ArrowStream formats

### DIFF
--- a/src/Client/BuzzHouse/Generator/SessionSettings.cpp
+++ b/src/Client/BuzzHouse/Generator/SessionSettings.cpp
@@ -887,6 +887,7 @@ static std::unordered_map<String, CHSetting> serverSettings2 = {
     {"output_format_arrow_string_as_string", trueOrFalseSettingNoOracle},
     {"output_format_arrow_use_64_bit_indexes_for_dictionary", trueOrFalseSettingNoOracle},
     {"output_format_arrow_use_signed_indexes_for_dictionary", trueOrFalseSettingNoOracle},
+    {"output_format_arrow_date_as_uint16", trueOrFalseSettingNoOracle},
     {"output_format_avro_codec",
      CHSetting(
          [](RandomGenerator & rg, FuzzConfig &)

--- a/src/Core/FormatFactorySettings.h
+++ b/src/Core/FormatFactorySettings.h
@@ -1402,6 +1402,9 @@ Use Arrow FIXED_SIZE_BINARY type instead of Binary for FixedString columns.
     DECLARE(ArrowCompression, output_format_arrow_compression_method, "lz4_frame", R"(
 Compression method for Arrow output format. Supported codecs: lz4_frame, zstd, none (uncompressed)
 )", 0) \
+    DECLARE(Bool, output_format_arrow_date_as_uint16, false, R"(
+Write Date values as plain 16-bit numbers (read back as UInt16), instead of converting to a 32-bit Arrow DATE32 type (read back as Date32).
+)", 0) \
     \
     DECLARE(Bool, output_format_orc_string_as_string, true, R"(
 Use ORC String type instead of Binary for String columns

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -51,6 +51,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"use_page_cache_for_object_storage", false, false, "New setting to use userspace page cache for object storage table functions"},
             {"use_statistics_cache", false, true, "Enable statistics cache"},
             {"ignore_format_null_for_explain", false, true, "FORMAT Null is now ignored for EXPLAIN queries by default"},
+            {"output_format_arrow_date_as_uint16", true, false, "Write Date as Arrow DATE32 instead of plain UInt16 by default."},
         });
         addSettingsChanges(settings_changes_history, "26.1",
         {

--- a/src/Formats/FormatFactory.cpp
+++ b/src/Formats/FormatFactory.cpp
@@ -310,6 +310,7 @@ FormatSettings getFormatSettings(const ContextPtr & context, const Settings & se
     format_settings.arrow.output_string_as_string = settings[Setting::output_format_arrow_string_as_string];
     format_settings.arrow.output_fixed_string_as_fixed_byte_array = settings[Setting::output_format_arrow_fixed_string_as_fixed_byte_array];
     format_settings.arrow.output_compression_method = settings[Setting::output_format_arrow_compression_method];
+    format_settings.arrow.output_date_as_uint16 = settings[Setting::output_format_arrow_date_as_uint16];
     format_settings.orc.allow_missing_columns = settings[Setting::input_format_orc_allow_missing_columns];
     format_settings.orc.row_batch_size = settings[Setting::input_format_orc_row_batch_size];
     format_settings.orc.skip_columns_with_unsupported_types_in_schema_inference = settings[Setting::input_format_orc_skip_columns_with_unsupported_types_in_schema_inference];

--- a/src/Formats/FormatSettings.h
+++ b/src/Formats/FormatSettings.h
@@ -162,6 +162,7 @@ struct FormatSettings
         bool output_string_as_string = false;
         bool output_fixed_string_as_fixed_byte_array = true;
         ArrowCompression output_compression_method = ArrowCompression::NONE;
+        bool output_date_as_uint16 = false;
     } arrow{};
 
     struct

--- a/src/Processors/Formats/Impl/ArrowBlockOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/ArrowBlockOutputFormat.cpp
@@ -58,11 +58,12 @@ void ArrowBlockOutputFormat::consume(Chunk chunk)
             "Arrow",
             CHColumnToArrowColumn::Settings
             {
-                format_settings.arrow.output_string_as_string,
-                format_settings.arrow.output_fixed_string_as_fixed_byte_array,
-                format_settings.arrow.low_cardinality_as_dictionary,
-                format_settings.arrow.use_signed_indexes_for_dictionary,
-                format_settings.arrow.use_64_bit_indexes_for_dictionary
+                .output_string_as_string = format_settings.arrow.output_string_as_string,
+                .output_fixed_string_as_fixed_byte_array = format_settings.arrow.output_fixed_string_as_fixed_byte_array,
+                .low_cardinality_as_dictionary = format_settings.arrow.low_cardinality_as_dictionary,
+                .use_signed_indexes_for_dictionary = format_settings.arrow.use_signed_indexes_for_dictionary,
+                .use_64_bit_indexes_for_dictionary = format_settings.arrow.use_64_bit_indexes_for_dictionary,
+                .output_date_as_uint16 = format_settings.arrow.output_date_as_uint16,
             });
     }
 

--- a/src/Processors/Formats/Impl/ArrowColumnToCHColumn.cpp
+++ b/src/Processors/Formats/Impl/ArrowColumnToCHColumn.cpp
@@ -980,9 +980,9 @@ static ColumnWithTypeAndName readNonNullableColumnFromArrowColumn(
             return readColumnWithDate32Data(arrow_column, column_name, type_hint, settings.date_time_overflow_behavior);
         case arrow::Type::DATE64:
             return readColumnWithDate64Data(arrow_column, column_name);
-        // ClickHouse writes Date as arrow UINT16 and DateTime as arrow UINT32,
-        // so, read UINT16 as Date and UINT32 as DateTime to perform correct conversion
-        // between Date and DateTime further.
+        // ClickHouse writes DateTime as arrow UINT32,
+        // so, read UINT32 as DateTime to perform correct conversion further.
+        // UINT16 is also read as Date for backward compatibility with older Arrow files.
         case arrow::Type::UINT16:
         {
             auto column = readColumnWithNumericData<UInt16>(arrow_column, column_name);

--- a/src/Processors/Formats/Impl/CHColumnToArrowColumn.cpp
+++ b/src/Processors/Formats/Impl/CHColumnToArrowColumn.cpp
@@ -622,29 +622,56 @@ namespace DB
         const String & format_name,
         arrow::ArrayBuilder* array_builder,
         size_t start,
-        size_t end)
+        size_t end,
+        bool as_uint16)
     {
         const PaddedPODArray<UInt16> & internal_data = assert_cast<const ColumnVector<UInt16> &>(*write_column).getData();
-        arrow::Date32Builder & builder = assert_cast<arrow::Date32Builder &>(*array_builder);
-        arrow::Status status;
 
-        if (null_bytemap)
+        if (as_uint16)
         {
-            for (size_t value_i = start; value_i < end; ++value_i)
+            arrow::UInt16Builder & builder = assert_cast<arrow::UInt16Builder &>(*array_builder);
+            arrow::Status status;
+
+            if (null_bytemap)
             {
-                if ((*null_bytemap)[value_i])
-                    status = builder.AppendNull();
-                else
-                    status = builder.Append(static_cast<Int32>(internal_data[value_i]));
+                for (size_t value_i = start; value_i < end; ++value_i)
+                {
+                    if ((*null_bytemap)[value_i])
+                        status = builder.AppendNull();
+                    else
+                        status = builder.Append(internal_data[value_i]);
+                    checkStatus(status, write_column->getName(), format_name);
+                }
+            }
+            else
+            {
+                status = builder.AppendValues(internal_data.data() + start, end - start);
                 checkStatus(status, write_column->getName(), format_name);
             }
         }
         else
         {
-            for (size_t value_i = start; value_i < end; ++value_i)
+            arrow::Date32Builder & builder = assert_cast<arrow::Date32Builder &>(*array_builder);
+            arrow::Status status;
+
+            if (null_bytemap)
             {
-                status = builder.Append(static_cast<Int32>(internal_data[value_i]));
-                checkStatus(status, write_column->getName(), format_name);
+                for (size_t value_i = start; value_i < end; ++value_i)
+                {
+                    if ((*null_bytemap)[value_i])
+                        status = builder.AppendNull();
+                    else
+                        status = builder.Append(static_cast<Int32>(internal_data[value_i]));
+                    checkStatus(status, write_column->getName(), format_name);
+                }
+            }
+            else
+            {
+                for (size_t value_i = start; value_i < end; ++value_i)
+                {
+                    status = builder.Append(static_cast<Int32>(internal_data[value_i]));
+                    checkStatus(status, write_column->getName(), format_name);
+                }
             }
         }
     }
@@ -820,7 +847,7 @@ namespace DB
                 fillArrowArrayWithIPv4ColumnData(column, null_bytemap, format_name, array_builder, start, end);
                 break;
             case TypeIndex::Date:
-                fillArrowArrayWithDateColumnData(column, null_bytemap, format_name, array_builder, start, end);
+                fillArrowArrayWithDateColumnData(column, null_bytemap, format_name, array_builder, start, end, settings.output_date_as_uint16);
                 break;
             case TypeIndex::DateTime:
                 fillArrowArrayWithDateTimeColumnData(column, null_bytemap, format_name, array_builder, start, end);
@@ -1052,6 +1079,9 @@ namespace DB
 
         if (isIPv4(column_type))
             return arrow::uint32();
+
+        if (isDate(column_type) && settings.output_date_as_uint16)
+            return arrow::uint16();
 
         const std::string type_name = column_type->getFamilyName();
         if (const auto * arrow_type_it = std::find_if(

--- a/src/Processors/Formats/Impl/CHColumnToArrowColumn.cpp
+++ b/src/Processors/Formats/Impl/CHColumnToArrowColumn.cpp
@@ -83,7 +83,7 @@ namespace DB
         {"Float32", arrow::float32()},
         {"Float64", arrow::float64()},
 
-        {"Date", arrow::uint16()},      /// uint16 is used instead of date32, because Apache Arrow cannot correctly serialize Date32Array.
+        {"Date", arrow::date32()},
         {"DateTime", arrow::uint32()},  /// uint32 is used instead of date64, because we don't need milliseconds.
         {"Date32", arrow::date32()},
 
@@ -625,7 +625,7 @@ namespace DB
         size_t end)
     {
         const PaddedPODArray<UInt16> & internal_data = assert_cast<const ColumnVector<UInt16> &>(*write_column).getData();
-        arrow::UInt16Builder & builder = assert_cast<arrow::UInt16Builder &>(*array_builder);
+        arrow::Date32Builder & builder = assert_cast<arrow::Date32Builder &>(*array_builder);
         arrow::Status status;
 
         if (null_bytemap)
@@ -635,14 +635,17 @@ namespace DB
                 if ((*null_bytemap)[value_i])
                     status = builder.AppendNull();
                 else
-                    status = builder.Append(internal_data[value_i]);
+                    status = builder.Append(static_cast<Int32>(internal_data[value_i]));
                 checkStatus(status, write_column->getName(), format_name);
             }
         }
         else
         {
-            status = builder.AppendValues(internal_data.data() + start, end - start);
-            checkStatus(status, write_column->getName(), format_name);
+            for (size_t value_i = start; value_i < end; ++value_i)
+            {
+                status = builder.Append(static_cast<Int32>(internal_data[value_i]));
+                checkStatus(status, write_column->getName(), format_name);
+            }
         }
     }
 

--- a/src/Processors/Formats/Impl/CHColumnToArrowColumn.h
+++ b/src/Processors/Formats/Impl/CHColumnToArrowColumn.h
@@ -31,6 +31,8 @@ public:
         bool use_signed_indexes_for_dictionary = false;
         /// Always use (U)Int64 type for indexes in Arrow::Dictionary.
         bool use_64_bit_indexes_for_dictionary = false;
+        /// Output Date as UInt16 instead of Arrow DATE32 for backward compatibility.
+        bool output_date_as_uint16 = false;
     };
 
     CHColumnToArrowColumn(const Block & header, const std::string & format_name_, const Settings & settings_);

--- a/tests/queries/0_stateless/02149_schema_inference_formats_with_schema_1.reference
+++ b/tests/queries/0_stateless/02149_schema_inference_formats_with_schema_1.reference
@@ -15,10 +15,10 @@ decimal32	Decimal(9, 5)
 decimal64	Decimal(18, 5)					
 0	0	0	0
 1.2	0.7692307692307692	3.33333	333.33333
-date	UInt16					
+date	Date32					
 date32	Date32					
-0	1970-01-01
-1	1970-01-02
+1970-01-01	1970-01-01
+1970-01-02	1970-01-02
 str	String					
 fixed_string	FixedString(3)					
 Str: 0	100
@@ -49,10 +49,10 @@ decimal32	Decimal(9, 5)
 decimal64	Decimal(18, 5)					
 0	0	0	0
 1.2	0.7692307692307692	3.33333	333.33333
-date	UInt16					
+date	Date32					
 date32	Date32					
-0	1970-01-01
-1	1970-01-02
+1970-01-01	1970-01-01
+1970-01-02	1970-01-02
 str	String					
 fixed_string	FixedString(3)					
 Str: 0	100

--- a/tests/queries/0_stateless/03831_arrow_date_as_date32.reference
+++ b/tests/queries/0_stateless/03831_arrow_date_as_date32.reference
@@ -1,14 +1,14 @@
 Arrow schema inference:
-d	Date32
+d	Date32					
 ArrowStream schema inference:
-d	Date32
+d	Date32					
 Arrow roundtrip:
 2024-01-15	2020-12-31
 ArrowStream roundtrip:
 2024-01-15	2020-12-31
 Arrow schema inference (uint16 compat):
-d	UInt16
+d	UInt16					
 ArrowStream schema inference (uint16 compat):
-d	UInt16
+d	UInt16					
 Arrow roundtrip (uint16 compat):
 19737	18627

--- a/tests/queries/0_stateless/03831_arrow_date_as_date32.reference
+++ b/tests/queries/0_stateless/03831_arrow_date_as_date32.reference
@@ -1,0 +1,8 @@
+Arrow schema inference:
+d	Date32
+ArrowStream schema inference:
+d	Date32
+Arrow roundtrip:
+2024-01-15	2020-12-31
+ArrowStream roundtrip:
+2024-01-15	2020-12-31

--- a/tests/queries/0_stateless/03831_arrow_date_as_date32.reference
+++ b/tests/queries/0_stateless/03831_arrow_date_as_date32.reference
@@ -6,3 +6,9 @@ Arrow roundtrip:
 2024-01-15	2020-12-31
 ArrowStream roundtrip:
 2024-01-15	2020-12-31
+Arrow schema inference (uint16 compat):
+d	UInt16
+ArrowStream schema inference (uint16 compat):
+d	UInt16
+Arrow roundtrip (uint16 compat):
+19737	18627

--- a/tests/queries/0_stateless/03831_arrow_date_as_date32.sh
+++ b/tests/queries/0_stateless/03831_arrow_date_as_date32.sh
@@ -8,27 +8,38 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
+DATA_FILE=$CUR_DIR/test_$CLICKHOUSE_TEST_UNIQUE_NAME.data
+
 # Schema inference should show Date32 (Arrow date32 maps to ClickHouse Date32)
 echo "Arrow schema inference:"
-$CLICKHOUSE_LOCAL -q "SELECT toDate('2024-01-15') AS d FORMAT Arrow" | $CLICKHOUSE_LOCAL --input-format=Arrow --table=test -q "SELECT name, type FROM system.columns WHERE table = 'test' AND database = currentDatabase()"
+$CLICKHOUSE_LOCAL -q "SELECT toDate('2024-01-15') AS d FORMAT Arrow" > "$DATA_FILE"
+$CLICKHOUSE_LOCAL -q "desc file('$DATA_FILE', 'Arrow')"
 
 echo "ArrowStream schema inference:"
-$CLICKHOUSE_LOCAL -q "SELECT toDate('2024-01-15') AS d FORMAT ArrowStream" | $CLICKHOUSE_LOCAL --input-format=ArrowStream --table=test -q "SELECT name, type FROM system.columns WHERE table = 'test' AND database = currentDatabase()"
+$CLICKHOUSE_LOCAL -q "SELECT toDate('2024-01-15') AS d FORMAT ArrowStream" > "$DATA_FILE"
+$CLICKHOUSE_LOCAL -q "desc file('$DATA_FILE', 'ArrowStream')"
 
 # Verify values are preserved through roundtrip
 echo "Arrow roundtrip:"
-$CLICKHOUSE_LOCAL -q "SELECT toDate('2024-01-15') AS d, toDate('2020-12-31') AS e FORMAT Arrow" | $CLICKHOUSE_LOCAL --input-format=Arrow --table=test -q "SELECT * FROM test"
+$CLICKHOUSE_LOCAL -q "SELECT toDate('2024-01-15') AS d, toDate('2020-12-31') AS e FORMAT Arrow" > "$DATA_FILE"
+$CLICKHOUSE_LOCAL -q "select * from file('$DATA_FILE', 'Arrow')"
 
 echo "ArrowStream roundtrip:"
-$CLICKHOUSE_LOCAL -q "SELECT toDate('2024-01-15') AS d, toDate('2020-12-31') AS e FORMAT ArrowStream" | $CLICKHOUSE_LOCAL --input-format=ArrowStream --table=test -q "SELECT * FROM test"
+$CLICKHOUSE_LOCAL -q "SELECT toDate('2024-01-15') AS d, toDate('2020-12-31') AS e FORMAT ArrowStream" > "$DATA_FILE"
+$CLICKHOUSE_LOCAL -q "select * from file('$DATA_FILE', 'ArrowStream')"
 
 # With output_format_arrow_date_as_uint16=1, schema inference should show UInt16
 echo "Arrow schema inference (uint16 compat):"
-$CLICKHOUSE_LOCAL --output_format_arrow_date_as_uint16=1 -q "SELECT toDate('2024-01-15') AS d FORMAT Arrow" | $CLICKHOUSE_LOCAL --input-format=Arrow --table=test -q "SELECT name, type FROM system.columns WHERE table = 'test' AND database = currentDatabase()"
+$CLICKHOUSE_LOCAL --output_format_arrow_date_as_uint16=1 -q "SELECT toDate('2024-01-15') AS d FORMAT Arrow" > "$DATA_FILE"
+$CLICKHOUSE_LOCAL -q "desc file('$DATA_FILE', 'Arrow')"
 
 echo "ArrowStream schema inference (uint16 compat):"
-$CLICKHOUSE_LOCAL --output_format_arrow_date_as_uint16=1 -q "SELECT toDate('2024-01-15') AS d FORMAT ArrowStream" | $CLICKHOUSE_LOCAL --input-format=ArrowStream --table=test -q "SELECT name, type FROM system.columns WHERE table = 'test' AND database = currentDatabase()"
+$CLICKHOUSE_LOCAL --output_format_arrow_date_as_uint16=1 -q "SELECT toDate('2024-01-15') AS d FORMAT ArrowStream" > "$DATA_FILE"
+$CLICKHOUSE_LOCAL -q "desc file('$DATA_FILE', 'ArrowStream')"
 
 # Verify values are preserved with uint16 compat mode
 echo "Arrow roundtrip (uint16 compat):"
-$CLICKHOUSE_LOCAL --output_format_arrow_date_as_uint16=1 -q "SELECT toDate('2024-01-15') AS d, toDate('2020-12-31') AS e FORMAT Arrow" | $CLICKHOUSE_LOCAL --input-format=Arrow --table=test -q "SELECT * FROM test"
+$CLICKHOUSE_LOCAL --output_format_arrow_date_as_uint16=1 -q "SELECT toDate('2024-01-15') AS d, toDate('2020-12-31') AS e FORMAT Arrow" > "$DATA_FILE"
+$CLICKHOUSE_LOCAL -q "select * from file('$DATA_FILE', 'Arrow')"
+
+rm "$DATA_FILE"

--- a/tests/queries/0_stateless/03831_arrow_date_as_date32.sh
+++ b/tests/queries/0_stateless/03831_arrow_date_as_date32.sh
@@ -21,3 +21,14 @@ $CLICKHOUSE_LOCAL -q "SELECT toDate('2024-01-15') AS d, toDate('2020-12-31') AS 
 
 echo "ArrowStream roundtrip:"
 $CLICKHOUSE_LOCAL -q "SELECT toDate('2024-01-15') AS d, toDate('2020-12-31') AS e FORMAT ArrowStream" | $CLICKHOUSE_LOCAL --input-format=ArrowStream --table=test -q "SELECT * FROM test"
+
+# With output_format_arrow_date_as_uint16=1, schema inference should show UInt16
+echo "Arrow schema inference (uint16 compat):"
+$CLICKHOUSE_LOCAL --output_format_arrow_date_as_uint16=1 -q "SELECT toDate('2024-01-15') AS d FORMAT Arrow" | $CLICKHOUSE_LOCAL --input-format=Arrow --table=test -q "SELECT name, type FROM system.columns WHERE table = 'test'"
+
+echo "ArrowStream schema inference (uint16 compat):"
+$CLICKHOUSE_LOCAL --output_format_arrow_date_as_uint16=1 -q "SELECT toDate('2024-01-15') AS d FORMAT ArrowStream" | $CLICKHOUSE_LOCAL --input-format=ArrowStream --table=test -q "SELECT name, type FROM system.columns WHERE table = 'test'"
+
+# Verify values are preserved with uint16 compat mode
+echo "Arrow roundtrip (uint16 compat):"
+$CLICKHOUSE_LOCAL --output_format_arrow_date_as_uint16=1 -q "SELECT toDate('2024-01-15') AS d, toDate('2020-12-31') AS e FORMAT Arrow" | $CLICKHOUSE_LOCAL --input-format=Arrow --table=test -q "SELECT * FROM test"

--- a/tests/queries/0_stateless/03831_arrow_date_as_date32.sh
+++ b/tests/queries/0_stateless/03831_arrow_date_as_date32.sh
@@ -10,10 +10,10 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 # Schema inference should show Date32 (Arrow date32 maps to ClickHouse Date32)
 echo "Arrow schema inference:"
-$CLICKHOUSE_LOCAL -q "SELECT toDate('2024-01-15') AS d FORMAT Arrow" | $CLICKHOUSE_LOCAL --input-format=Arrow --table=test -q "SELECT name, type FROM system.columns WHERE table = 'test'"
+$CLICKHOUSE_LOCAL -q "SELECT toDate('2024-01-15') AS d FORMAT Arrow" | $CLICKHOUSE_LOCAL --input-format=Arrow --table=test -q "SELECT name, type FROM system.columns WHERE table = 'test' AND database = currentDatabase()"
 
 echo "ArrowStream schema inference:"
-$CLICKHOUSE_LOCAL -q "SELECT toDate('2024-01-15') AS d FORMAT ArrowStream" | $CLICKHOUSE_LOCAL --input-format=ArrowStream --table=test -q "SELECT name, type FROM system.columns WHERE table = 'test'"
+$CLICKHOUSE_LOCAL -q "SELECT toDate('2024-01-15') AS d FORMAT ArrowStream" | $CLICKHOUSE_LOCAL --input-format=ArrowStream --table=test -q "SELECT name, type FROM system.columns WHERE table = 'test' AND database = currentDatabase()"
 
 # Verify values are preserved through roundtrip
 echo "Arrow roundtrip:"
@@ -24,10 +24,10 @@ $CLICKHOUSE_LOCAL -q "SELECT toDate('2024-01-15') AS d, toDate('2020-12-31') AS 
 
 # With output_format_arrow_date_as_uint16=1, schema inference should show UInt16
 echo "Arrow schema inference (uint16 compat):"
-$CLICKHOUSE_LOCAL --output_format_arrow_date_as_uint16=1 -q "SELECT toDate('2024-01-15') AS d FORMAT Arrow" | $CLICKHOUSE_LOCAL --input-format=Arrow --table=test -q "SELECT name, type FROM system.columns WHERE table = 'test'"
+$CLICKHOUSE_LOCAL --output_format_arrow_date_as_uint16=1 -q "SELECT toDate('2024-01-15') AS d FORMAT Arrow" | $CLICKHOUSE_LOCAL --input-format=Arrow --table=test -q "SELECT name, type FROM system.columns WHERE table = 'test' AND database = currentDatabase()"
 
 echo "ArrowStream schema inference (uint16 compat):"
-$CLICKHOUSE_LOCAL --output_format_arrow_date_as_uint16=1 -q "SELECT toDate('2024-01-15') AS d FORMAT ArrowStream" | $CLICKHOUSE_LOCAL --input-format=ArrowStream --table=test -q "SELECT name, type FROM system.columns WHERE table = 'test'"
+$CLICKHOUSE_LOCAL --output_format_arrow_date_as_uint16=1 -q "SELECT toDate('2024-01-15') AS d FORMAT ArrowStream" | $CLICKHOUSE_LOCAL --input-format=ArrowStream --table=test -q "SELECT name, type FROM system.columns WHERE table = 'test' AND database = currentDatabase()"
 
 # Verify values are preserved with uint16 compat mode
 echo "Arrow roundtrip (uint16 compat):"

--- a/tests/queries/0_stateless/03831_arrow_date_as_date32.sh
+++ b/tests/queries/0_stateless/03831_arrow_date_as_date32.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+
+# Verify that Date columns are output as Arrow date32 type, not uint16.
+# https://github.com/ClickHouse/ClickHouse/issues/96834
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# Schema inference should show Date32 (Arrow date32 maps to ClickHouse Date32)
+echo "Arrow schema inference:"
+$CLICKHOUSE_LOCAL -q "SELECT toDate('2024-01-15') AS d FORMAT Arrow" | $CLICKHOUSE_LOCAL --input-format=Arrow --table=test -q "SELECT name, type FROM system.columns WHERE table = 'test'"
+
+echo "ArrowStream schema inference:"
+$CLICKHOUSE_LOCAL -q "SELECT toDate('2024-01-15') AS d FORMAT ArrowStream" | $CLICKHOUSE_LOCAL --input-format=ArrowStream --table=test -q "SELECT name, type FROM system.columns WHERE table = 'test'"
+
+# Verify values are preserved through roundtrip
+echo "Arrow roundtrip:"
+$CLICKHOUSE_LOCAL -q "SELECT toDate('2024-01-15') AS d, toDate('2020-12-31') AS e FORMAT Arrow" | $CLICKHOUSE_LOCAL --input-format=Arrow --table=test -q "SELECT * FROM test"
+
+echo "ArrowStream roundtrip:"
+$CLICKHOUSE_LOCAL -q "SELECT toDate('2024-01-15') AS d, toDate('2020-12-31') AS e FORMAT ArrowStream" | $CLICKHOUSE_LOCAL --input-format=ArrowStream --table=test -q "SELECT * FROM test"


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

The `Date` type is now serialized as Arrow's native `date32` type in Arrow/ArrowStream formats, instead of `uint16`. Tools like PyArrow will now correctly see the column as a date type. The old behavior can be restored with the `output_format_arrow_date_as_uint16` setting. Reading old Arrow files that used `uint16` for `Date` columns is still supported.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

The new setting `output_format_arrow_date_as_uint16` (default: `false`) controls whether `Date` columns are written as Arrow `date32` type (default) or as plain `uint16` (old behavior). This is analogous to the existing `output_format_parquet_date_as_uint16` setting for Parquet format.

## Summary

- The `Date` type was serialized as `uint16` in Arrow/ArrowStream formats instead of Arrow's native `date32` type. This meant tools like PyArrow would see the column as a plain integer (days since epoch) instead of a proper date type.
- Added `output_format_arrow_date_as_uint16` setting (default: `false`) for backward compatibility, mirroring `output_format_parquet_date_as_uint16`.
- The read path still accepts both `UINT16` and `DATE32` for backward compatibility with older Arrow files.

Closes https://github.com/ClickHouse/ClickHouse/issues/96834

## Test plan

- [x] New test `03831_arrow_date_as_date32` verifies schema inference shows `Date32` by default and `UInt16` with `output_format_arrow_date_as_uint16=1`, and values roundtrip correctly through both Arrow and ArrowStream formats
- [x] Existing `01273_arrow` and `01273_arrow_stream` tests pass without any reference file changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.698`
<!-- ch-version-info:end -->