### PR TITLE
Fix /play UI throwing on system table queries due to query cache

### DIFF
--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -1301,7 +1301,7 @@ async function postImpl(posted_request_num, query)
     url += '&default_format=' + default_format + '&enable_http_compression=1';
     /// We will put the result in the query cache, so it can be used when download is initiated later.
     /// But we don't use cached results, so the results that we get here, are always fresh.
-    url += '&use_query_cache=1&enable_reads_from_query_cache=0&enable_writes_to_query_cache=1&query_cache_ttl=600&query_cache_nondeterministic_function_handling=save';
+    url += '&use_query_cache=1&enable_reads_from_query_cache=0&enable_writes_to_query_cache=1&query_cache_ttl=600&query_cache_nondeterministic_function_handling=save&query_cache_system_table_handling=ignore';
 
     /// Extremes only if the format is likely to be unchanged. This is imprecise.
     if (!query.match(/\bFORMAT\s+\w+/i)) url += '&extremes=1';
@@ -2661,7 +2661,7 @@ document.getElementById('download-button').addEventListener('click', async funct
         (server_address.indexOf('?') >= 0 ? '&' : '?') +
         'add_http_cors_header=1' +
         '&enable_http_compression=1' +
-        '&use_query_cache=1&enable_reads_from_query_cache=1&enable_writes_to_query_cache=0&query_cache_ttl=600&query_cache_nondeterministic_function_handling=save' +
+        '&use_query_cache=1&enable_reads_from_query_cache=1&enable_writes_to_query_cache=0&query_cache_ttl=600&query_cache_nondeterministic_function_handling=save&query_cache_system_table_handling=ignore' +
         '&default_format=' + encodeURIComponent(format) +
         '&http_response_headers=' + encodeURIComponent(`{'Content-Disposition':'attachment; filename="result.${encodeURIComponent(format.toLowerCase())}"'}`);
     if (user) url += '&user=' + encodeURIComponent(user);


### PR DESCRIPTION
## Summary
- The `/play` Web UI unconditionally enables query cache for all requests
- When a query touches `system.*` tables, ClickHouse throws `QUERY_CACHE_USED_WITH_SYSTEM_TABLE` (Code 719)
- Add `query_cache_system_table_handling=ignore` to both the execute and download URL parameter strings so that system table queries silently skip caching instead of throwing

## Test plan
- [ ] Open `/play` UI and run `SELECT count() FROM system.tables` — should succeed without error
- [ ] Run a normal non-system query — should still be cached as before
- [ ] Download results for a system table query — should work without error

Closes https://github.com/ClickHouse/ClickHouse/issues/95387

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `/play` Web UI throwing `QUERY_CACHE_USED_WITH_SYSTEM_TABLE` when querying system tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.666`
<!-- ch-version-info:end -->