### PR TITLE
Analyzer: it isn't new.

### DIFF
--- a/ci/jobs/scripts/fuzzer/query-fuzzer-tweaks-users.xml
+++ b/ci/jobs/scripts/fuzzer/query-fuzzer-tweaks-users.xml
@@ -27,7 +27,7 @@
                     <max>200</max>
                 </table_function_remote_max_addresses>
 
-                <!-- Don't waste cycles testing the old interpreter. Spend time in the new analyzer instead -->
+                <!-- Don't waste cycles testing the old interpreter. Spend time in the analyzer instead -->
                 <enable_analyzer>
                     <readonly/>
                 </enable_analyzer>

--- a/docs/en/sql-reference/statements/select/with.md
+++ b/docs/en/sql-reference/statements/select/with.md
@@ -182,8 +182,8 @@ SELECT sum(number) FROM test_table;
 ```
 
 :::note
-Recursive CTEs rely on the [new query analyzer](/operations/analyzer) introduced in version **`24.3`**. If you're using version **`24.3+`** and encounter a **`(UNKNOWN_TABLE)`** or **`(UNSUPPORTED_METHOD)`** exception, it suggests that the new analyzer is disabled on your instance, role, or profile. To activate the analyzer, enable the setting **`allow_experimental_analyzer`** or update the **`compatibility`** setting to a more recent version.
-Starting from version `24.8` the new analyzer has been fully promoted to production, and the setting `allow_experimental_analyzer` has been renamed to `enable_analyzer`.
+Recursive CTEs rely on the [query analyzer](/operations/analyzer) introduced in version **`24.3`**. If you're using version **`24.3+`** and encounter a **`(UNKNOWN_TABLE)`** or **`(UNSUPPORTED_METHOD)`** exception, it suggests that the analyzer is disabled on your instance, role, or profile. To activate the analyzer, enable the setting **`allow_experimental_analyzer`** or update the **`compatibility`** setting to a more recent version.
+Starting from version `24.8` the analyzer has been fully promoted to production, and the setting `allow_experimental_analyzer` has been renamed to `enable_analyzer`.
 :::
 
 The general form of a recursive `WITH` query is always a non-recursive term, then `UNION ALL`, then a recursive term, where only the recursive term can contain a reference to the query's own output. Recursive CTE query is executed as follows:

--- a/src/Client/BuzzHouse/Generator/SessionSettings.cpp
+++ b/src/Client/BuzzHouse/Generator/SessionSettings.cpp
@@ -1568,7 +1568,7 @@ void loadFuzzerServerSettings(const FuzzConfig & fc)
               CHSetting(
                   [&](RandomGenerator & rg, FuzzConfig &)
                   {
-                      /// The first release with the new analyzer enabled
+                      /// The first release with the analyzer enabled
                       const uint32_t minYear = 24;
                       const uint32_t minMonth = 3;
                       const std::chrono::year_month_day ymd{std::chrono::floor<std::chrono::days>(std::chrono::system_clock::now())};

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -4783,7 +4783,7 @@ Propagate WITH statements to UNION queries and all subqueries
     DECLARE(Bool, enable_scopes_for_with_statement, true, R"(
 If disabled, declarations in parent WITH cluases will behave the same scope as they declared in the current scope.
 
-Note that this is a compatibility setting for new analyzer to allow running some invalid queries that old analyzer could execute.
+Note that this is a compatibility setting for the analyzer to allow running some invalid queries that old analyzer could execute.
 )", 0) \
     DECLARE(Bool, aggregate_functions_null_for_empty, false, R"(
 Enables or disables rewriting all aggregate functions in a query, adding [-OrNull](/sql-reference/aggregate-functions/combinators#-ornull) suffix to them. Enable it for SQL standard compatibility.

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -547,7 +547,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"backup_restore_keeper_max_retries_while_initializing", 0, 20, "New setting."},
             {"backup_restore_keeper_max_retries_while_handling_error", 0, 20, "New setting."},
             {"backup_restore_finish_timeout_after_error_sec", 0, 180, "New setting."},
-            {"query_plan_merge_filters", false, true, "Allow to merge filters in the query plan. This is required to properly support filter-push-down with a new analyzer."},
+            {"query_plan_merge_filters", false, true, "Allow to merge filters in the query plan. This is required to properly support filter-push-down with the analyzer."},
             {"parallel_replicas_local_plan", false, true, "Use local plan for local replica in a query with parallel replicas"},
             {"merge_tree_use_v1_object_and_dynamic_serialization", true, false, "Add new serialization V2 version for JSON and Dynamic types"},
             {"min_joined_block_size_bytes", 524288, 524288, "New setting."},

--- a/src/Interpreters/ActionsVisitor.cpp
+++ b/src/Interpreters/ActionsVisitor.cpp
@@ -197,7 +197,7 @@ ColumnsWithTypeAndName createBlockForSet(
         .forbid_unknown_enum_values = context->getSettingsRef()[Setting::validate_enum_literals_in_operators],
     };
 
-    /// Reuse the new analyzer logic
+    /// Reuse the analyzer logic
     return getSetElementsForConstantValue(left_arg_type, right_arg_value, right_arg_type, params);
 }
 
@@ -217,7 +217,7 @@ ColumnsWithTypeAndName createBlockForSet(
 
     auto [right_arg_value, right_arg_type] = buildCollectionFieldAndTypeFromASTFunction(right_arg, context);
 
-    /// Reuse the new analyzer logic
+    /// Reuse the analyzer logic
     return getSetElementsForConstantValue(left_arg_type, right_arg_value, right_arg_type, params);
 }
 }
@@ -1240,10 +1240,10 @@ FutureSetPtr ActionsMatcher::makeSet(const ASTFunction & node, Data & data, bool
             /// * first, query 'SELECT count() FROM table WHERE ...' is executed to get the set of affected parts (using analyzer)
             /// * second, every part is mutated separately, where plan is build "manually", using this code as well
             /// To share the Set in between first and second stage, we should use the same hash.
-            /// New analyzer is uses a hash from query tree, so here we also build a query tree.
+            /// The analyzer uses a hash from query tree, so here we also build a query tree.
             ///
             /// Note : this code can be safely removed, but the test 02581_share_big_sets will be too slow (and fail by timeout).
-            /// Note : we should use new analyzer for mutations and remove this hack.
+            /// Note : we should use the analyzer for mutations and remove this hack.
             InterpreterSelectQueryAnalyzer interpreter(right_in_operand, data.getContext(), SelectQueryOptions().analyze(true).subquery());
             const auto & query_tree = interpreter.getQueryTree();
             if (auto * query_node = query_tree->as<QueryNode>())

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -986,7 +986,7 @@ public:
     /// For table functions s3/file/url/hdfs/input we can use structure from
     /// insertion table depending on select expression.
     StoragePtr executeTableFunction(const ASTPtr & table_expression, const ASTSelectQuery * select_query_hint = nullptr);
-    /// Overload for the new analyzer. Structure inference is performed in QueryAnalysisPass.
+    /// Overload for the analyzer. Structure inference is performed in QueryAnalysisPass.
     StoragePtr executeTableFunction(const ASTPtr & table_expression, const TableFunctionPtr & table_function_ptr);
 
     StoragePtr buildParameterizedViewStorage(const String & database_name, const String & table_name, const NameToNameMap & param_values) const;

--- a/src/Interpreters/ExecuteScalarSubqueriesVisitor.cpp
+++ b/src/Interpreters/ExecuteScalarSubqueriesVisitor.cpp
@@ -72,7 +72,7 @@ bool ExecuteScalarSubqueriesMatcher::needChildVisit(ASTPtr & node, const ASTPtr 
         /// and assign an alias for 02367_optimize_trivial_count_with_array_join to pass. Otherwise it will fail in
         /// ArrayJoinedColumnsVisitor (`No alias for non-trivial value in ARRAY JOIN: _a`)
         /// This looks 100% as a incomplete code working on top of a bug, but this code has already been made obsolete
-        /// by the new analyzer, so it's an inconvenience we can live with until we deprecate it.
+        /// by the analyzer, so it's an inconvenience we can live with until we deprecate it.
         if (child == tables->array_join)
             return true;
         return false;

--- a/src/Interpreters/ExpressionAnalyzer.cpp
+++ b/src/Interpreters/ExpressionAnalyzer.cpp
@@ -2132,7 +2132,7 @@ ExpressionAnalysisResult::ExpressionAnalysisResult(
             ///
             /// As a temporary solution, we add converting actions to the next chain.
             /// Hopefully, later we can
-            /// * use a new analyzer where this issue is absent
+            /// * use the analyzer where this issue is absent
             /// * or remove ExpressionActionsChain completely and re-implement its logic on top of the query plan
             {
                 for (auto & col : columns_before_aggregation)

--- a/src/Interpreters/IInterpreterUnionOrSelectQuery.cpp
+++ b/src/Interpreters/IInterpreterUnionOrSelectQuery.cpp
@@ -54,13 +54,13 @@ IInterpreterUnionOrSelectQuery::IInterpreterUnionOrSelectQuery(
     : query_ptr(query_ptr_), context(context_), options(options_), max_streams(context->getSettingsRef()[Setting::max_threads])
 {
     /// FIXME All code here will work with the old analyzer, however for views over Distributed tables
-    /// it's possible that new analyzer will be enabled in ::getQueryProcessingStage method
+    /// it's possible that the analyzer will be enabled in ::getQueryProcessingStage method
     /// of the underlying storage when all other parts of infrastructure are not ready for it
     /// (built with old analyzer).
     if (context->getSettingsRef()[Setting::allow_experimental_analyzer])
     {
         LOG_TRACE(getLogger("IInterpreterUnionOrSelectQuery"),
-            "The new analyzer is enabled, but the old interpreter is used. It can be a bug, please report it. Will disable 'allow_experimental_analyzer' setting (for query: {})",
+            "The analyzer is enabled, but the old interpreter is used. It can be a bug, please report it. Will disable 'allow_experimental_analyzer' setting (for query: {})",
             query_ptr->formatForLogging());
         context->setSetting("allow_experimental_analyzer", false);
     }

--- a/src/Interpreters/InterpreterExplainQuery.cpp
+++ b/src/Interpreters/InterpreterExplainQuery.cpp
@@ -546,7 +546,7 @@ QueryPipeline InterpreterExplainQuery::executeImpl()
         {
             if (!query_context->getSettingsRef()[Setting::allow_experimental_analyzer])
                 throw Exception(ErrorCodes::NOT_IMPLEMENTED,
-                    "EXPLAIN QUERY TREE is only supported with a new analyzer. SET enable_analyzer = 1.");
+                    "EXPLAIN QUERY TREE is only supported with the analyzer. SET enable_analyzer = 1.");
 
             auto settings = checkAndGetSettings<QueryTreeSettings>(ast.getSettings());
             if (!settings.dump_tree && !settings.dump_ast)

--- a/src/Interpreters/LogicalExpressionsOptimizer.cpp
+++ b/src/Interpreters/LogicalExpressionsOptimizer.cpp
@@ -120,7 +120,7 @@ void LogicalExpressionsOptimizer::collectDisjunctiveEqualityChains()
 
         auto * function = to_node->as<ASTFunction>();
         /// Optimization does not respect aliases properly, which can lead to MULTIPLE_EXPRESSION_FOR_ALIAS error.
-        /// Disable it if an expression has an alias. Proper implementation is done with the new analyzer.
+        /// Disable it if an expression has an alias. Proper implementation is done with the analyzer.
         if (function && function->alias.empty() && function->name == "or" && function->children.size() == 1)
         {
             const auto * expression_list = function->children[0]->as<ASTExpressionList>();

--- a/src/Interpreters/TreeRewriter.cpp
+++ b/src/Interpreters/TreeRewriter.cpp
@@ -1176,7 +1176,7 @@ bool TreeRewriterResult::collectUsedColumns(const ASTPtr & query, bool is_select
             else if (const auto * common_column_desc = common_virtual_columns.tryGetDescription(*it))
             {
                 /// Ephemeral common virtual columns (e.g. `_table`) are only supported
-                /// by the new analyzer which fills them via ExpressionStep.
+                /// by the analyzer which fills them via ExpressionStep.
                 /// The old analyzer has no mechanism to fill them, so skip them here
                 /// to avoid a type mismatch between the header and the actual data.
                 if (!common_column_desc->isEphemeral())

--- a/src/Parsers/ASTTablesInSelectQuery.cpp
+++ b/src/Parsers/ASTTablesInSelectQuery.cpp
@@ -250,7 +250,7 @@ void ASTTableJoin::formatImplAfterTable(WriteBuffer & ostr, const FormatSettings
        /** If there is an alias for the whole expression we wrap the ON clause in parens in two cases:
          *  1. collapse_identical_nodes_to_aliases is true (meaning old analyzer is being used) AND the alias was
          *     defined earlier in the query
-         *  2. collapse_identical_nodes_to_aliases is false (new analyzer) - because we will not make any substitutions
+         *  2. collapse_identical_nodes_to_aliases is false (the analyzer) - because we will not make any substitutions
          */
         bool on_need_parens = false;
         auto on_alias = on_expression->tryGetAlias();

--- a/src/Processors/QueryPlan/JoinStep.cpp
+++ b/src/Processors/QueryPlan/JoinStep.cpp
@@ -275,7 +275,7 @@ void JoinStep::updateOutputHeader()
     if (!use_new_analyzer)
     {
         if (swap_streams)
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot swap streams without new analyzer");
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot swap streams without the analyzer");
         output_header = join_algorithm_header;
         return;
     }

--- a/src/Processors/QueryPlan/Optimizations/useVectorSearch.cpp
+++ b/src/Processors/QueryPlan/Optimizations/useVectorSearch.cpp
@@ -145,7 +145,7 @@ size_t tryUseVectorSearch(QueryPlan::Node * parent_node, QueryPlan::Nodes & /*no
 
     for (const auto * child : sort_column_node_children)
     {
-        if (child->type == ActionsDAG::ActionType::ALIAS) /// new analyzer
+        if (child->type == ActionsDAG::ActionType::ALIAS) /// the analyzer
         {
             const auto * search_column_node = child->children.at(0);
             if (search_column_node->type == ActionsDAG::ActionType::INPUT)

--- a/src/Processors/QueryPlan/numbersLikeUtils.cpp
+++ b/src/Processors/QueryPlan/numbersLikeUtils.cpp
@@ -80,7 +80,7 @@ bool shouldPushdownLimit(const SelectQueryInfo & query_info, const InterpreterSe
         && !query.limitBy()
         && !query_info.has_order_by
         && !query_info.need_aggregate
-        /// For new analyzer, window will be deleted from AST, so we should not use query.window()
+        /// For the analyzer, window will be deleted from AST, so we should not use query.window()
         && !query_info.has_window
         && !query_info.additional_filter_ast
         && !query.limit_with_ties;

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -8612,7 +8612,7 @@ QueryProcessingStage::Enum MergeTreeData::getQueryProcessingStage(
     const StorageSnapshotPtr &,
     SelectQueryInfo &) const
 {
-    /// with new analyzer, Planner make decision regarding parallel replicas usage, and so about processing stage on reading
+    /// with the analyzer, Planner make decision regarding parallel replicas usage, and so about processing stage on reading
     if (!query_context->getSettingsRef()[Setting::allow_experimental_analyzer])
     {
         const auto & settings = query_context->getSettingsRef();

--- a/src/Storages/SelectQueryInfo.h
+++ b/src/Storages/SelectQueryInfo.h
@@ -180,7 +180,7 @@ struct SelectQueryInfo
     InputOrderInfoPtr input_order_info;
 
     /// Prepared sets are used for indices by storage engine.
-    /// New analyzer stores prepared sets in planner_context and hashes computed of QueryTree instead of AST.
+    /// The analyzer stores prepared sets in planner_context and hashes computed of QueryTree instead of AST.
     /// Example: x IN (1, 2, 3)
     PreparedSetsPtr prepared_sets;
 

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -297,7 +297,7 @@ void StorageMergeTree::read(
     size_t num_streams)
 {
     const auto & settings = local_context->getSettingsRef();
-    /// reading step for parallel replicas with new analyzer is built in Planner, so don't do it here
+    /// reading step for parallel replicas with the analyzer is built in Planner, so don't do it here
     if (local_context->canUseParallelReplicasOnInitiator() && settings[Setting::parallel_replicas_for_non_replicated_merge_tree]
         && !settings[Setting::allow_experimental_analyzer])
     {

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -6010,7 +6010,7 @@ void StorageReplicatedMergeTree::read(
         readLocalSequentialConsistencyImpl(query_plan, column_names, storage_snapshot, query_info, local_context, max_block_size, num_streams);
         return;
     }
-    /// reading step for parallel replicas with new analyzer is built in Planner, so don't do it here
+    /// reading step for parallel replicas with the analyzer is built in Planner, so don't do it here
     if (local_context->canUseParallelReplicasOnInitiator() && !settings[Setting::allow_experimental_analyzer])
     {
         readParallelReplicasImpl(query_plan, column_names, query_info, local_context, processed_stage);

--- a/src/Storages/tests/gtest_transform_query_for_external_database.cpp
+++ b/src/Storages/tests/gtest_transform_query_for_external_database.cpp
@@ -205,7 +205,7 @@ static void check(
         checkOld(state, table_num, query, expected);
     }
     {
-        SCOPED_TRACE("New analyzer");
+        SCOPED_TRACE("Analyzer");
         checkNewAnalyzer(state, column_names, query, expected_new.empty() ? expected : expected_new);
     }
 }

--- a/tests/docker_scripts/stress_tests.lib
+++ b/tests/docker_scripts/stress_tests.lib
@@ -166,7 +166,7 @@ EOL
                     <max>200</max>
                 </table_function_remote_max_addresses>
 
-                <!-- Don't waste cycles testing the old interpreter. Spend time in the new analyzer instead -->
+                <!-- Don't waste cycles testing the old interpreter. Spend time in the analyzer instead -->
                 <enable_analyzer>
                     <readonly/>
                 </enable_analyzer>

--- a/tests/performance/uniq_to_count.xml
+++ b/tests/performance/uniq_to_count.xml
@@ -2,7 +2,7 @@
     <query>select uniq(number) from (select DISTINCT number from numbers(1000000))</query>
     <query>select uniq(number) from (select number from numbers(1000000) group by number)</query>
 
-    <!--For new analyzer-->
+    <!--For the analyzer-->
     <query>select uniq(number) from (select DISTINCT number from numbers(1000000)) SETTINGS enable_analyzer=1</query>
     <query>select uniq(number) from (select number from numbers(1000000) group by number) SETTINGS enable_analyzer=1</query>
 </test>

--- a/tests/queries/0_stateless/01651_bugs_from_15889.sql
+++ b/tests/queries/0_stateless/01651_bugs_from_15889.sql
@@ -131,5 +131,5 @@ WITH (
     ) AS t)
 SELECT if(dateDiff('second', toDateTime(time_with_microseconds), toDateTime(t)) = -9223372036854775808, 'ok', '');
 
-set joined_subquery_requires_alias=0, enable_analyzer=0; -- the query is invalid with a new analyzer
+set joined_subquery_requires_alias=0, enable_analyzer=0; -- the query is invalid with the analyzer
 SELECT number, number / 2 AS n, j1, j2 FROM remote('127.0.0.{2,3}', system.numbers) GLOBAL ANY LEFT JOIN (SELECT number / 3 AS n, number AS j1, 'Hello' AS j2 FROM system.numbers LIMIT 1048577) USING (n) LIMIT 10 format Null;

--- a/tests/queries/0_stateless/02178_column_function_insert_from.sql
+++ b/tests/queries/0_stateless/02178_column_function_insert_from.sql
@@ -8,7 +8,7 @@ INSERT INTO TESTTABLE values (0,'0',['1']), (1,'1',['1']);
 
 SET max_threads = 1;
 
--- There is a bug which is fixed in new analyzer.
+-- There is a bug which is fixed in the analyzer.
 SET max_bytes_before_external_sort = 0;
 SET max_bytes_ratio_before_external_sort = 0;
 

--- a/tests/queries/0_stateless/02317_distinct_in_order_optimization_explain.reference
+++ b/tests/queries/0_stateless/02317_distinct_in_order_optimization_explain.reference
@@ -51,7 +51,7 @@ algorithm: InOrder
 algorithm: InOrder
 -- enabled, only part of distinct columns form prefix of sorting key
 algorithm: InOrder
-=== disable new analyzer ===
+=== disable analyzer ===
 -- enabled, check that sorting properties are propagated from ReadFromMergeTree till preliminary distinct
 Sorting: a ASC, b ASC
 Sorting: a ASC, b ASC
@@ -82,7 +82,7 @@ Sorting: a DESC, b DESC
 -- enabled, check that disabling other 'read in order' optimizations do not disable distinct in order optimization
 Sorting: a ASC, b ASC
 Sorting: a ASC, b ASC
-=== enable new analyzer ===
+=== enable analyzer ===
 -- enabled, check that sorting properties are propagated from ReadFromMergeTree till preliminary distinct
 Sorting: __table1.a ASC, __table1.b ASC
 Sorting: a ASC, b ASC

--- a/tests/queries/0_stateless/02317_distinct_in_order_optimization_explain.sh
+++ b/tests/queries/0_stateless/02317_distinct_in_order_optimization_explain.sh
@@ -77,7 +77,7 @@ echo "-- enabled, only part of distinct columns form prefix of sorting key"
 
 $CLICKHOUSE_CLIENT --max_threads=0 -q "$ENABLE_OPTIMIZATION;explain pipeline select distinct a, c from distinct_in_order_explain" | eval $FIND_READING_IN_ORDER | tail -n 1
 
-echo "=== disable new analyzer ==="
+echo "=== disable analyzer ==="
 DISABLE_ANALYZER="set enable_analyzer=0"
 
 echo "-- enabled, check that sorting properties are propagated from ReadFromMergeTree till preliminary distinct"
@@ -99,7 +99,7 @@ $CLICKHOUSE_CLIENT -q "$DISABLE_ANALYZER;$ENABLE_OPTIMIZATION;$ENABLE_READ_IN_OR
 echo "-- enabled, check that disabling other 'read in order' optimizations do not disable distinct in order optimization"
 $CLICKHOUSE_CLIENT -q "$DISABLE_ANALYZER;$ENABLE_OPTIMIZATION;set optimize_read_in_order=0;set optimize_aggregation_in_order=0;set optimize_read_in_window_order=0;explain plan sorting=1 select distinct a,b from distinct_in_order_explain" | eval $FIND_SORTING_PROPERTIES
 
-echo "=== enable new analyzer ==="
+echo "=== enable analyzer ==="
 ENABLE_ANALYZER="set enable_analyzer=1"
 
 echo "-- enabled, check that sorting properties are propagated from ReadFromMergeTree till preliminary distinct"

--- a/tests/queries/0_stateless/02498_storage_join_key_positions.sql
+++ b/tests/queries/0_stateless/02498_storage_join_key_positions.sql
@@ -47,7 +47,7 @@ SELECT * FROM t1 ALL INNER JOIN tj ON 1 != 1; -- { serverError INCOMPATIBLE_TYPE
 -- Here is another error code because equality is handled differently in CollectJoinOnKeysVisitor.
 -- We can change the error code, but it will become inconsistent for other cases
 -- where we actually expect AMBIGUOUS_COLUMN_NAME instead of INVALID_JOIN_ON_EXPRESSION/INCOMPATIBLE_TYPE_OF_JOIN.
--- These checks are more reliable after switching to a new analyzer, they return INCOMPATIBLE_TYPE_OF_JOIN consistent with cases above
+-- These checks are more reliable after switching to the analyzer, they return INCOMPATIBLE_TYPE_OF_JOIN consistent with cases above
 SELECT * FROM t1 ALL INNER JOIN tj ON 1 == 1; -- { serverError INCOMPATIBLE_TYPE_OF_JOIN,AMBIGUOUS_COLUMN_NAME }
 SELECT * FROM t1 ALL INNER JOIN tj ON 1 == 2; -- { serverError INCOMPATIBLE_TYPE_OF_JOIN,AMBIGUOUS_COLUMN_NAME }
 

--- a/tests/queries/0_stateless/02498_storage_join_key_positions_old_analyzer.sql.j2
+++ b/tests/queries/0_stateless/02498_storage_join_key_positions_old_analyzer.sql.j2
@@ -50,7 +50,7 @@ SELECT * FROM t1 ALL INNER JOIN tj ON 1 != 1; -- { serverError {{ expected_error
 -- Here is another error code because equality is handled differently in CollectJoinOnKeysVisitor.
 -- We can change the error code, but it will become inconsistent for other cases
 -- where we actually expect AMBIGUOUS_COLUMN_NAME instead of INVALID_JOIN_ON_EXPRESSION/INCOMPATIBLE_TYPE_OF_JOIN.
--- These checks are more reliable after switching to a new analyzer, they return INCOMPATIBLE_TYPE_OF_JOIN consistent with cases above
+-- These checks are more reliable after switching to the analyzer, they return INCOMPATIBLE_TYPE_OF_JOIN consistent with cases above
 SELECT * FROM t1 ALL INNER JOIN tj ON t1.key1 = tj.key1 AND t1.key3 = tj.key3 AND t1.key2 = tj.key2 AND 1 == 1; -- { serverError {{ expected_error }} }
 SELECT * FROM t1 ALL INNER JOIN tj ON 1 == 1; -- { serverError {{ expected_error }} }
 SELECT * FROM t1 ALL INNER JOIN tj ON 1 == 2; -- { serverError {{ expected_error }} }

--- a/tests/queries/0_stateless/02989_join_using_parent_scope.reference
+++ b/tests/queries/0_stateless/02989_join_using_parent_scope.reference
@@ -26,7 +26,7 @@ SELECT b AS a, a FROM tb JOIN tabc USING (a) ORDER BY ALL;
 2	2
 3	3
 SELECT 1 AS b FROM tb JOIN ta USING (b); -- { serverError UNKNOWN_IDENTIFIER }
--- SELECT * returns all columns from both tables in new analyzer
+-- SELECT * returns all columns from both tables in the analyzer
 SELECT 3 AS a, a, * FROM tb FULL JOIN tabc USING (a) ORDER BY ALL SETTINGS enable_analyzer = 1;
 3	3	0	3	abc3
 3	3	1	3	abc3
@@ -98,7 +98,7 @@ EXPLAIN PIPELINE SELECT (SELECT 1) AS c0 FROM (SELECT 1 AS c0, 1 AS c1) tx JOIN 
 -- so we get UNKNOWN_IDENTIFIER error.
 SELECT a + 2 AS b FROM tb JOIN tabc USING (b) ORDER BY ALL
 SETTINGS analyzer_compatibility_join_using_top_level_identifier = 1; -- { serverError UNKNOWN_IDENTIFIER }
--- In new analyzer with `analyzer_compatibility_join_using_top_level_identifier = 0` we get `b` from left table
+-- In the analyzer with `analyzer_compatibility_join_using_top_level_identifier = 0` we get `b` from left table
 SELECT a + 2 AS b FROM tb JOIN tabc USING (b) ORDER BY ALL
 SETTINGS analyzer_compatibility_join_using_top_level_identifier = 0, enable_analyzer = 1;
 2

--- a/tests/queries/0_stateless/02989_join_using_parent_scope.sql
+++ b/tests/queries/0_stateless/02989_join_using_parent_scope.sql
@@ -26,7 +26,7 @@ SELECT a + 2 AS c FROM ta JOIN tabc USING (c) ORDER BY ALL;
 SELECT b AS a, a FROM tb JOIN tabc USING (a) ORDER BY ALL;
 SELECT 1 AS b FROM tb JOIN ta USING (b); -- { serverError UNKNOWN_IDENTIFIER }
 
--- SELECT * returns all columns from both tables in new analyzer
+-- SELECT * returns all columns from both tables in the analyzer
 SELECT 3 AS a, a, * FROM tb FULL JOIN tabc USING (a) ORDER BY ALL SETTINGS enable_analyzer = 1;
 SELECT b + 1 AS a, * FROM tb JOIN tabc USING (a) ORDER BY ALL SETTINGS enable_analyzer = 1;
 
@@ -53,7 +53,7 @@ EXPLAIN PIPELINE SELECT (SELECT 1) AS c0 FROM (SELECT 1 AS c0, 1 AS c1) tx JOIN 
 SELECT a + 2 AS b FROM tb JOIN tabc USING (b) ORDER BY ALL
 SETTINGS analyzer_compatibility_join_using_top_level_identifier = 1; -- { serverError UNKNOWN_IDENTIFIER }
 
--- In new analyzer with `analyzer_compatibility_join_using_top_level_identifier = 0` we get `b` from left table
+-- In the analyzer with `analyzer_compatibility_join_using_top_level_identifier = 0` we get `b` from left table
 SELECT a + 2 AS b FROM tb JOIN tabc USING (b) ORDER BY ALL
 SETTINGS analyzer_compatibility_join_using_top_level_identifier = 0, enable_analyzer = 1;
 

--- a/tests/queries/0_stateless/03213_distributed_analyzer.sql
+++ b/tests/queries/0_stateless/03213_distributed_analyzer.sql
@@ -1,5 +1,5 @@
 SET max_threads = 8;
 
--- This triggered a nullptr dereference due to the confusion between old and new analyzers:
+-- This triggered a nullptr dereference due to the confusion between the old and the analyzer:
 SELECT sum(*) FROM remote('127.0.0.4', currentDatabase(), viewExplain('EXPLAIN PIPELINE', 'graph = 1', (SELECT * FROM remote('127.0.0.4', system, one)))); -- { serverError UNKNOWN_FUNCTION }
 SELECT groupArray(*) FROM cluster(test_cluster_two_shards, viewExplain('EXPLAIN PIPELINE', 'graph = 1', (SELECT * FROM remote('127.0.0.4', system, one))));

--- a/tests/queries/0_stateless/03631_select_replace_comprehensive.sql
+++ b/tests/queries/0_stateless/03631_select_replace_comprehensive.sql
@@ -1,4 +1,4 @@
--- Test SELECT * REPLACE with all SQL clauses using new analyzer
+-- Test SELECT * REPLACE with all SQL clauses using the analyzer
 -- This test verifies comprehensive fix for SELECT * REPLACE in all applicable clauses
 -- See issue: https://github.com/ClickHouse/ClickHouse/issues/85313
 -- See PR: https://github.com/ClickHouse/ClickHouse/pull/87630

--- a/tests/queries/0_stateless/03632_lowcard_join.sql
+++ b/tests/queries/0_stateless/03632_lowcard_join.sql
@@ -1,4 +1,4 @@
--- Force new analyzer because the old one doesn't support multiple USING clauses in a query
+-- Force the analyzer because the old one doesn't support multiple USING clauses in a query
 SET allow_suspicious_low_cardinality_types = 1, enable_analyzer = 1;
 
 DROP TABLE IF EXISTS t0;

--- a/tests/queries/0_stateless/03633_negative_limit_offset.reference
+++ b/tests/queries/0_stateless/03633_negative_limit_offset.reference
@@ -113,7 +113,7 @@ Big Tables
 899997
 899998
 899999
-New Analyzer:
+Analyzer:
 Negative Limit Only
 9
 7

--- a/tests/queries/0_stateless/03633_negative_limit_offset.sql
+++ b/tests/queries/0_stateless/03633_negative_limit_offset.sql
@@ -101,7 +101,7 @@ AS SELECT number FROM
 SELECT number FROM modified_tab;
 
 SET enable_analyzer=1;
-SELECT 'New Analyzer:';
+SELECT 'Analyzer:';
 SELECT 'Negative Limit Only';
 SELECT number FROM numbers(10) ORDER BY number LIMIT -1;
 SELECT number FROM numbers(10) ORDER BY number LIMIT -3;

--- a/tests/queries/0_stateless/03644_object_storage_correlated_subqueries.sql
+++ b/tests/queries/0_stateless/03644_object_storage_correlated_subqueries.sql
@@ -1,7 +1,7 @@
 -- Tags: no-fasttest
 -- Tag no-fasttest: needs s3
 
--- Use correlated subqueries which are supported only by the new analyzer.
+-- Use correlated subqueries which are supported only by the analyzer.
 set enable_analyzer = 1;
 
 INSERT INTO TABLE FUNCTION s3('http://localhost:11111/test/test-data-03644_object_storage.csv', 'test', 'testtest', 'CSV', 'number UInt64') SELECT number FROM numbers(10) SETTINGS s3_truncate_on_insert = 1;

--- a/tests/queries/0_stateless/03653_fractional_limit_offset.reference
+++ b/tests/queries/0_stateless/03653_fractional_limit_offset.reference
@@ -177,7 +177,7 @@ Big Tables:
 999997
 999998
 999999
-New Analyzer
+Analyzer
 Fractional Limit Only:
 0
 0

--- a/tests/queries/0_stateless/03653_fractional_limit_offset.sql
+++ b/tests/queries/0_stateless/03653_fractional_limit_offset.sql
@@ -89,7 +89,7 @@ LIMIT 10
 OFFSET 0.99999;
 
 SET enable_analyzer=1;
-SELECT 'New Analyzer';
+SELECT 'Analyzer';
 
 SELECT 'Fractional Limit Only:';
 SELECT number FROM numbers(10)    LIMIT 0.1;

--- a/tests/queries/0_stateless/03658_negative_limit_offset_distributed.reference
+++ b/tests/queries/0_stateless/03658_negative_limit_offset_distributed.reference
@@ -19,7 +19,7 @@ Old Analyzer:
 19
 19
 19
-New Analyzer:
+Analyzer:
 13
 12
 12

--- a/tests/queries/0_stateless/03658_negative_limit_offset_distributed.sql
+++ b/tests/queries/0_stateless/03658_negative_limit_offset_distributed.sql
@@ -15,7 +15,7 @@ SELECT number FROM remote('127.0.0.{1,2,3}', numbers_mt(20)) ORDER BY number LIM
 
 SET enable_analyzer=1;
 
-SELECT 'New Analyzer:';
+SELECT 'Analyzer:';
 
 SELECT number FROM remote('127.0.0.{1,2,3}', numbers_mt(20)) ORDER BY number DESC LIMIT 5 OFFSET 20;
 

--- a/tests/queries/0_stateless/03681_distributed_fractional_limit_offset.reference
+++ b/tests/queries/0_stateless/03681_distributed_fractional_limit_offset.reference
@@ -11,7 +11,7 @@ Old Analyzer
 99
 99
 99
-New Analyzer
+Analyzer
 0
 0
 0
@@ -28,7 +28,7 @@ Old Analyzer - Distributed Table
 
 0	18	1
 0	18	3
-New Analyzer - Distributed Table
+Analyzer - Distributed Table
 
 0	18	1
 0	18	3

--- a/tests/queries/0_stateless/03681_distributed_fractional_limit_offset.sql
+++ b/tests/queries/0_stateless/03681_distributed_fractional_limit_offset.sql
@@ -12,7 +12,7 @@ SELECT number from remote('127.0.0.{1,2,3}', numbers_mt(100)) ORDER BY number LI
 
 SET enable_analyzer=1;
 
-SELECT 'New Analyzer';
+SELECT 'Analyzer';
 
 SELECT number from remote('127.0.0.{1,2,3}', numbers_mt(100)) ORDER BY number LIMIT 0.01;
 
@@ -54,7 +54,7 @@ ORDER BY __table1.k DESC NULLS LAST
 LIMIT 0.9999, _CAST(100, 'UInt64');
 
 SET extremes = 0;
-SELECT 'New Analyzer - Distributed Table';
+SELECT 'Analyzer - Distributed Table';
 
 SET enable_analyzer = 1;
 SET extremes = 1;

--- a/tests/queries/0_stateless/03905_select_replace_where_same_column.sql
+++ b/tests/queries/0_stateless/03905_select_replace_where_same_column.sql
@@ -13,7 +13,7 @@ CREATE TABLE t_replace_where
 
 INSERT INTO t_replace_where VALUES (0, 'snapchat', 123, '2023-08-04'), (42, 'snapchat', 0, '2023-08-04');
 
--- With the new analyzer, the REPLACE should apply to WHERE as well,
+-- With the analyzer, the REPLACE should apply to WHERE as well,
 -- so both rows should be returned (app_id=0 becomes 1, which is != 0).
 SELECT * REPLACE (if(app_id = 0, 1, app_id) AS app_id)
 FROM t_replace_where

--- a/tests/queries/0_stateless/03911_ephemeral_virtual_column_old_analyzer.sql
+++ b/tests/queries/0_stateless/03911_ephemeral_virtual_column_old_analyzer.sql
@@ -5,6 +5,6 @@
 SELECT _table SETTINGS enable_analyzer = 0; -- { serverError UNKNOWN_IDENTIFIER }
 SELECT _table FROM system.one SETTINGS enable_analyzer = 0; -- { serverError UNKNOWN_IDENTIFIER }
 
--- With the new analyzer, _table should work fine.
+-- With the analyzer, _table should work fine.
 SELECT _table SETTINGS enable_analyzer = 1;
 SELECT _table FROM system.one SETTINGS enable_analyzer = 1;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not for changelog.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

## Summary
- Replace all occurrences of "new analyzer" with "the analyzer" or "Analyzer" across source code, tests, CI scripts, and documentation
- The analyzer has been the default since version 24.8 and is no longer "new"
- 47 files changed across `src/`, `tests/`, `ci/`, and `docs/en/`

## Test plan
- [ ] Verify no test output mismatches (reference files updated alongside SQL/shell changes)
- [ ] Confirm no functional changes — only comment/string/doc text modifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.687`
<!-- ch-version-info:end -->