### PR TITLE
Fix crash when attaching table to MaterializedPostgreSQL database

### DIFF
--- a/src/Storages/PostgreSQL/PostgreSQLReplicationHandler.cpp
+++ b/src/Storages/PostgreSQL/PostgreSQLReplicationHandler.cpp
@@ -74,7 +74,14 @@ public:
 
     ~TemporaryReplicationSlot()
     {
-        handler->dropReplicationSlot(*tx, /* temporary */true);
+        try
+        {
+            handler->dropReplicationSlot(*tx, /* temporary */true);
+        }
+        catch (...)
+        {
+            tryLogCurrentException("TemporaryReplicationSlot");
+        }
     }
 
 private:


### PR DESCRIPTION
## Summary
- Fix fatal server crash (`std::terminate`) when attaching a table to a `MaterializedPostgreSQL` database
- The `TemporaryReplicationSlot` destructor called `dropReplicationSlot` without exception handling; if an exception was already in flight (e.g. from `loadFromSnapshot`) and `dropReplicationSlot` also threw (`pqxx::sql_error`: replication slot does not exist), having two exceptions caused `std::terminate`
- Wrap the destructor body in try-catch, following the C++ rule that destructors must not throw

Closes https://github.com/ClickHouse/ClickHouse/issues/62711

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix crash when attaching a table to a `MaterializedPostgreSQL` database if `dropReplicationSlot` throws during stack unwinding.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.686`
<!-- ch-version-info:end -->