### PR TITLE
Fix server crash on backup to full disk

### DIFF
--- a/src/IO/Archives/LibArchiveWriter.cpp
+++ b/src/IO/Archives/LibArchiveWriter.cpp
@@ -31,19 +31,43 @@ void checkResultCodeImpl(int code, const String & filename)
 }
 }
 
-// this is a thin wrapper for libarchive to be able to write the archive to a WriteBuffer
+/// This is a thin wrapper for libarchive to be able to write the archive to a WriteBuffer.
+///
+/// C++ exceptions must not propagate through the libarchive C library (undefined behavior).
+/// The callback catches exceptions and stores them for later re-throwing in C++ code.
 class LibArchiveWriter::StreamInfo
 {
 public:
     explicit StreamInfo(std::unique_ptr<WriteBuffer> archive_write_buffer_) : archive_write_buffer(std::move(archive_write_buffer_)) { }
+
     static ssize_t memory_write(struct archive *, void * client_data, const void * buff, size_t length)
     {
         auto * stream_info = reinterpret_cast<StreamInfo *>(client_data);
-        stream_info->archive_write_buffer->write(reinterpret_cast<const char *>(buff), length);
-        return length;
+        try
+        {
+            stream_info->archive_write_buffer->write(reinterpret_cast<const char *>(buff), length);
+            return length;
+        }
+        catch (...)
+        {
+            if (!stream_info->stored_exception)
+                stream_info->stored_exception = std::current_exception();
+            return -1;
+        }
+    }
+
+    void rethrowIfNeeded()
+    {
+        if (stored_exception)
+        {
+            auto ex = stored_exception;
+            stored_exception = nullptr;
+            std::rethrow_exception(ex);
+        }
     }
 
     std::unique_ptr<WriteBuffer> archive_write_buffer;
+    std::exception_ptr stored_exception;
 };
 
 class LibArchiveWriter::WriteBufferFromLibArchive : public WriteBufferFromFileBase
@@ -131,7 +155,10 @@ private:
         archive_entry_set_size(entry, expected_size);
         archive_entry_set_filetype(entry, static_cast<__LA_MODE_T>(0100000));
         archive_entry_set_perm(entry, 0644);
-        checkResult(archive_write_header(archive, entry));
+        int code = archive_write_header(archive, entry);
+        if (auto writer = archive_writer.lock())
+            writer->rethrowStoredException();
+        checkResult(code);
     }
 
     void writeDataChunk()
@@ -140,6 +167,8 @@ private:
             writeEntry();
         ssize_t to_write = offset();
         ssize_t written = archive_write_data(archive, working_buffer.begin(), offset());
+        if (auto writer = archive_writer.lock())
+            writer->rethrowStoredException();
         if (written != to_write)
         {
             throw Exception(
@@ -285,6 +314,7 @@ void LibArchiveWriter::finalize()
         return;
     if (archive)
         archive_write_close(archive);
+    rethrowStoredExceptionLocked();
     if (stream_info)
     {
         stream_info->archive_write_buffer->finalize();
@@ -318,6 +348,18 @@ LibArchiveWriter::Archive LibArchiveWriter::getArchive()
 {
     std::lock_guard lock{mutex};
     return archive;
+}
+
+void LibArchiveWriter::rethrowStoredException()
+{
+    std::lock_guard lock{mutex};
+    rethrowStoredExceptionLocked();
+}
+
+void LibArchiveWriter::rethrowStoredExceptionLocked()
+{
+    if (stream_info)
+        stream_info->rethrowIfNeeded();
 }
 }
 #endif

--- a/src/IO/Archives/LibArchiveWriter.cpp
+++ b/src/IO/Archives/LibArchiveWriter.cpp
@@ -335,6 +335,7 @@ void LibArchiveWriter::cancel() noexcept
         stream_info->archive_write_buffer->cancel();
         stream_info.reset();
     }
+    finalized = true;
 }
 
 void LibArchiveWriter::setPassword(const String & password_)

--- a/src/IO/Archives/LibArchiveWriter.h
+++ b/src/IO/Archives/LibArchiveWriter.h
@@ -80,6 +80,10 @@ private:
     void startWritingFile();
     void endWritingFile();
 
+    /// Re-throws a stored exception from a libarchive C callback, if any.
+    void rethrowStoredException();
+    void rethrowStoredExceptionLocked() TSA_REQUIRES(mutex);
+
     std::unique_ptr<StreamInfo> stream_info TSA_GUARDED_BY(mutex);
     bool is_writing_file TSA_GUARDED_BY(mutex) = false;
     bool finalized TSA_GUARDED_BY(mutex) = false;

--- a/src/IO/Archives/ZipArchiveWriter.cpp
+++ b/src/IO/Archives/ZipArchiveWriter.cpp
@@ -389,6 +389,8 @@ void ZipArchiveWriter::cancel() noexcept
         stream_info->getWriteBuffer().cancel();
         stream_info.reset();
     }
+
+    finalized = true;
 }
 
 void ZipArchiveWriter::setCompression(const String & compression_method_, int compression_level_)

--- a/src/IO/Archives/ZipArchiveWriter.cpp
+++ b/src/IO/Archives/ZipArchiveWriter.cpp
@@ -88,6 +88,7 @@ public:
             password_cstr,
             /* crc_for_crypting= */ 0,
             /* zip64= */ true);
+        archive_writer_->rethrowStoredException();
         checkResultCode(code);
     }
 
@@ -121,6 +122,8 @@ private:
             return;
         chassert(zip_handle);
         int code = zipWriteInFileInZip(zip_handle, working_buffer.begin(), static_cast<uint32_t>(offset()));
+        if (auto writer = archive_writer.lock())
+            writer->rethrowStoredException();
         checkResultCode(code);
     }
 
@@ -131,7 +134,11 @@ private:
             int code = zipCloseFileInZip(zip_handle);
             zip_handle = nullptr;
             if (throw_if_error)
+            {
+                if (auto writer = archive_writer.lock())
+                    writer->rethrowStoredException();
                 checkResultCode(code);
+            }
         }
     }
 
@@ -154,6 +161,9 @@ private:
 
 /// Provides a set of functions allowing the minizip library to write its output
 /// to a WriteBuffer instead of an ordinary file in the local filesystem.
+///
+/// C++ exceptions must not propagate through the minizip C library (undefined behavior).
+/// All callbacks catch exceptions and store them for later re-throwing in C++ code.
 class ZipArchiveWriter::StreamInfo
 {
 public:
@@ -185,7 +195,24 @@ public:
 
     WriteBuffer & getWriteBuffer() { return *write_buffer; }
 
+    /// Re-throws a stored exception from a callback, if any.
+    void rethrowIfNeeded()
+    {
+        if (stored_exception)
+        {
+            auto ex = stored_exception;
+            stored_exception = nullptr;
+            std::rethrow_exception(ex);
+        }
+    }
+
 private:
+    void storeException()
+    {
+        if (!stored_exception)
+            stored_exception = std::current_exception();
+    }
+
     /// We do nothing in openFileFunc() and in closeFileFunc() because we already have `write_buffer` (file is already opened).
     static void * openFileFunc(void * opaque, const void *, int) { return opaque; }
     static int closeFileFunc(void *, void *) { return ZIP_OK; }
@@ -193,31 +220,60 @@ private:
     static unsigned long writeFileFunc(void * opaque, void *, const void * buf, unsigned long size) // NOLINT(google-runtime-int)
     {
         auto * stream_info = reinterpret_cast<StreamInfo *>(opaque);
-        stream_info->write_buffer->write(reinterpret_cast<const char *>(buf), size);
-        return size;
+        try
+        {
+            stream_info->write_buffer->write(reinterpret_cast<const char *>(buf), size);
+            return size;
+        }
+        catch (...)
+        {
+            stream_info->storeException();
+            return 0;
+        }
     }
 
-    static int testErrorFunc(void *, void *) { return ZIP_OK; }
+    static int testErrorFunc(void * opaque, void *)
+    {
+        auto * stream_info = reinterpret_cast<StreamInfo *>(opaque);
+        return stream_info->stored_exception ? ZIP_ERRNO : ZIP_OK;
+    }
 
     static ZPOS64_T tellFunc(void * opaque, void *)
     {
         auto * stream_info = reinterpret_cast<StreamInfo *>(opaque);
-        auto pos = stream_info->write_buffer->count() - stream_info->start_offset;
-        return pos;
+        try
+        {
+            auto pos = stream_info->write_buffer->count() - stream_info->start_offset;
+            return pos;
+        }
+        catch (...)
+        {
+            stream_info->storeException();
+            return static_cast<ZPOS64_T>(-1);
+        }
     }
 
-    static long seekFunc(void *, void *, ZPOS64_T, int) // NOLINT(google-runtime-int)
+    static long seekFunc(void * opaque, void *, ZPOS64_T, int) // NOLINT(google-runtime-int)
     {
-        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "StreamInfo::seek is not implemented");
+        auto * stream_info = reinterpret_cast<StreamInfo *>(opaque);
+        if (!stream_info->stored_exception)
+            stream_info->stored_exception = std::make_exception_ptr(
+                Exception(ErrorCodes::NOT_IMPLEMENTED, "StreamInfo::seek is not implemented"));
+        return -1;
     }
 
-    static unsigned long readFileFunc(void *, void *, void *, unsigned long) // NOLINT(google-runtime-int)
+    static unsigned long readFileFunc(void * opaque, void *, void *, unsigned long) // NOLINT(google-runtime-int)
     {
-        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "StreamInfo::readFile is not implemented");
+        auto * stream_info = reinterpret_cast<StreamInfo *>(opaque);
+        if (!stream_info->stored_exception)
+            stream_info->stored_exception = std::make_exception_ptr(
+                Exception(ErrorCodes::NOT_IMPLEMENTED, "StreamInfo::readFile is not implemented"));
+        return 0;
     }
 
     std::unique_ptr<WriteBuffer> write_buffer;
     UInt64 start_offset;
+    std::exception_ptr stored_exception;
 };
 
 
@@ -303,6 +359,7 @@ void ZipArchiveWriter::finalize()
     {
         int code = zipClose(zip_handle, /* global_comment= */ nullptr);
         zip_handle = nullptr;
+        rethrowStoredExceptionLocked();
         checkResultCode(code);
     }
 
@@ -451,6 +508,18 @@ void ZipArchiveWriter::endWritingFile()
 void ZipArchiveWriter::checkResultCode(int code) const
 {
     checkResultCodeImpl(code, path_to_archive);
+}
+
+void ZipArchiveWriter::rethrowStoredException()
+{
+    std::lock_guard lock{mutex};
+    rethrowStoredExceptionLocked();
+}
+
+void ZipArchiveWriter::rethrowStoredExceptionLocked()
+{
+    if (stream_info)
+        stream_info->rethrowIfNeeded();
 }
 
 }

--- a/src/IO/Archives/ZipArchiveWriter.h
+++ b/src/IO/Archives/ZipArchiveWriter.h
@@ -91,6 +91,10 @@ private:
 
     void checkResultCode(int code) const;
 
+    /// Re-throws a stored exception from a minizip C callback, if any.
+    void rethrowStoredException();
+    void rethrowStoredExceptionLocked() TSA_REQUIRES(mutex);
+
     const String path_to_archive;
     std::unique_ptr<StreamInfo> TSA_GUARDED_BY(mutex) stream_info;
     int compression_method TSA_GUARDED_BY(mutex); /// By default the compression method is "deflate".

--- a/src/IO/tests/gtest_archive_reader_and_writer.cpp
+++ b/src/IO/tests/gtest_archive_reader_and_writer.cpp
@@ -21,6 +21,7 @@
 
 namespace DB::ErrorCodes
 {
+    extern const int CANNOT_PACK_ARCHIVE;
     extern const int CANNOT_UNPACK_ARCHIVE;
     extern const int LOGICAL_ERROR;
     extern const int NOT_IMPLEMENTED;
@@ -776,6 +777,55 @@ TEST(SevenZipArchiveReaderTest, ReadTwoFiles)
     readStringUntilEOF(str, *in);
     EXPECT_EQ(str, contents2);
     fs::remove(archive_path);
+}
+
+
+/// A WriteBuffer that throws after a specified number of bytes, simulating a disk-full condition.
+class ThrowAfterNBytesWriteBuffer : public WriteBufferFromFileBase
+{
+public:
+    explicit ThrowAfterNBytesWriteBuffer(size_t throw_after_bytes_)
+        : WriteBufferFromFileBase(DBMS_DEFAULT_BUFFER_SIZE, nullptr, 0)
+        , throw_after_bytes(throw_after_bytes_)
+    {
+    }
+
+    void sync() override { }
+    std::string getFileName() const override { return "ThrowAfterNBytesWriteBuffer"; }
+
+private:
+    void nextImpl() override
+    {
+        size_t to_write = offset();
+        if (bytes_written + to_write > throw_after_bytes)
+            throw Exception(ErrorCodes::CANNOT_PACK_ARCHIVE, "Simulated disk full error after {} bytes", bytes_written);
+        bytes_written += to_write;
+    }
+
+    size_t throw_after_bytes;
+    size_t bytes_written = 0;
+};
+
+
+/// Test that write errors in the underlying buffer during archive creation produce
+/// a proper exception instead of std::terminate (which happens if C++ exceptions
+/// propagate through C library code like minizip or libarchive).
+TEST_P(ArchiveReaderAndWriterTest, WriteErrorProducesException)
+{
+    /// Allow writing some data so the archive header gets created, then fail.
+    auto failing_buffer = std::make_unique<ThrowAfterNBytesWriteBuffer>(1024);
+    auto writer = createArchiveWriter(getPathToArchive(), std::move(failing_buffer));
+
+    auto out = writer->writeFile("a.txt");
+    /// Write enough data to trigger the underlying buffer flush failure.
+    String large_content(1024 * 1024, 'x');
+    EXPECT_THROW(
+        {
+            writeString(large_content, *out);
+            out->finalize();
+            writer->finalize();
+        },
+        Exception);
 }
 
 


### PR DESCRIPTION
## Summary
- C++ exceptions thrown in callbacks passed to minizip/libarchive C libraries propagate through C code, which is undefined behavior
- With newer compilers (clang 19+), this causes `std::terminate` and server abort (exit code 134) instead of the exception being caught
- The fix catches exceptions in all C callbacks, stores them via `std::exception_ptr`, and re-throws them when control returns to C++ code

Closes https://github.com/ClickHouse/ClickHouse/issues/79698

### Changelog category (leave one):
- Bug Fix

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix server crash when backup fails due to full disk or other I/O errors on the destination filesystem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.684`
<!-- ch-version-info:end -->