### PR TITLE
Fix `EXCEPT ALL` and `INTERSECT ALL` returning incorrect results

### DIFF
--- a/tests/queries/0_stateless/03916_except_intersect_all_multiset.reference
+++ b/tests/queries/0_stateless/03916_except_intersect_all_multiset.reference
@@ -20,8 +20,8 @@
 -- EXCEPT ALL: empty left side
 -- INTERSECT ALL: empty right side
 -- EXCEPT ALL with strings
-b
 a
+b
 -- INTERSECT ALL with strings
 a
 b

--- a/tests/queries/0_stateless/03916_except_intersect_all_multiset.reference
+++ b/tests/queries/0_stateless/03916_except_intersect_all_multiset.reference
@@ -1,0 +1,31 @@
+-- EXCEPT ALL: basic (subtract one from two duplicates)
+1
+-- EXCEPT ALL: subtract one occurrence per right-side row
+0
+1
+2
+3
+4
+-- EXCEPT ALL: from the issue report
+1
+-- EXCEPT ALL: right side has more duplicates than left
+-- INTERSECT ALL: min of counts
+1
+1
+-- INTERSECT ALL: no common rows
+-- EXCEPT ALL: empty right side
+0
+1
+2
+-- EXCEPT ALL: empty left side
+-- INTERSECT ALL: empty right side
+-- EXCEPT ALL with strings
+b
+a
+-- INTERSECT ALL with strings
+a
+b
+-- EXCEPT DISTINCT still works (removes all matching)
+2
+-- INTERSECT DISTINCT still works
+1

--- a/tests/queries/0_stateless/03916_except_intersect_all_multiset.sql
+++ b/tests/queries/0_stateless/03916_except_intersect_all_multiset.sql
@@ -9,11 +9,13 @@ EXCEPT ALL
 SELECT 1;
 
 SELECT '-- EXCEPT ALL: subtract one occurrence per right-side row';
-SELECT number FROM numbers(5)
-UNION ALL
-SELECT number FROM numbers(5)
-EXCEPT ALL
-SELECT number FROM numbers(5);
+SELECT * FROM (
+    SELECT number FROM numbers(5)
+    UNION ALL
+    SELECT number FROM numbers(5)
+    EXCEPT ALL
+    SELECT number FROM numbers(5)
+) ORDER BY number;
 
 SELECT '-- EXCEPT ALL: from the issue report';
 SELECT 1 AS x UNION ALL SELECT 1 EXCEPT ALL SELECT 1;
@@ -34,9 +36,11 @@ INTERSECT ALL
 (SELECT 2 UNION ALL SELECT 2);
 
 SELECT '-- EXCEPT ALL: empty right side';
-SELECT number FROM numbers(3)
-EXCEPT ALL
-SELECT number FROM numbers(0);
+SELECT * FROM (
+    SELECT number FROM numbers(3)
+    EXCEPT ALL
+    SELECT number FROM numbers(0)
+) ORDER BY number;
 
 SELECT '-- EXCEPT ALL: empty left side';
 SELECT number FROM numbers(0)
@@ -49,14 +53,18 @@ INTERSECT ALL
 SELECT number FROM numbers(0);
 
 SELECT '-- EXCEPT ALL with strings';
-(SELECT 'a' AS x UNION ALL SELECT 'a' UNION ALL SELECT 'b')
-EXCEPT ALL
-(SELECT 'a');
+SELECT * FROM (
+    (SELECT 'a' AS x UNION ALL SELECT 'a' UNION ALL SELECT 'b')
+    EXCEPT ALL
+    (SELECT 'a')
+) ORDER BY x;
 
 SELECT '-- INTERSECT ALL with strings';
-(SELECT 'a' AS x UNION ALL SELECT 'a' UNION ALL SELECT 'b')
-INTERSECT ALL
-(SELECT 'a' UNION ALL SELECT 'b' UNION ALL SELECT 'b');
+SELECT * FROM (
+    (SELECT 'a' AS x UNION ALL SELECT 'a' UNION ALL SELECT 'b')
+    INTERSECT ALL
+    (SELECT 'a' UNION ALL SELECT 'b' UNION ALL SELECT 'b')
+) ORDER BY x;
 
 SELECT '-- EXCEPT DISTINCT still works (removes all matching)';
 (SELECT 1 AS x UNION ALL SELECT 1 UNION ALL SELECT 2)

--- a/tests/queries/0_stateless/03916_except_intersect_all_multiset.sql
+++ b/tests/queries/0_stateless/03916_except_intersect_all_multiset.sql
@@ -1,0 +1,69 @@
+-- Test that EXCEPT ALL and INTERSECT ALL correctly handle row multiplicities.
+-- https://github.com/ClickHouse/ClickHouse/issues/96801
+
+SELECT '-- EXCEPT ALL: basic (subtract one from two duplicates)';
+SELECT 1 AS x
+UNION ALL
+SELECT 1
+EXCEPT ALL
+SELECT 1;
+
+SELECT '-- EXCEPT ALL: subtract one occurrence per right-side row';
+SELECT number FROM numbers(5)
+UNION ALL
+SELECT number FROM numbers(5)
+EXCEPT ALL
+SELECT number FROM numbers(5);
+
+SELECT '-- EXCEPT ALL: from the issue report';
+SELECT 1 AS x UNION ALL SELECT 1 EXCEPT ALL SELECT 1;
+
+SELECT '-- EXCEPT ALL: right side has more duplicates than left';
+(SELECT 1 AS x)
+EXCEPT ALL
+(SELECT 1 UNION ALL SELECT 1 UNION ALL SELECT 1);
+
+SELECT '-- INTERSECT ALL: min of counts';
+(SELECT 1 AS x UNION ALL SELECT 1 UNION ALL SELECT 1)
+INTERSECT ALL
+(SELECT 1 UNION ALL SELECT 1);
+
+SELECT '-- INTERSECT ALL: no common rows';
+(SELECT 1 AS x UNION ALL SELECT 1)
+INTERSECT ALL
+(SELECT 2 UNION ALL SELECT 2);
+
+SELECT '-- EXCEPT ALL: empty right side';
+SELECT number FROM numbers(3)
+EXCEPT ALL
+SELECT number FROM numbers(0);
+
+SELECT '-- EXCEPT ALL: empty left side';
+SELECT number FROM numbers(0)
+EXCEPT ALL
+SELECT number FROM numbers(3);
+
+SELECT '-- INTERSECT ALL: empty right side';
+SELECT number FROM numbers(3)
+INTERSECT ALL
+SELECT number FROM numbers(0);
+
+SELECT '-- EXCEPT ALL with strings';
+(SELECT 'a' AS x UNION ALL SELECT 'a' UNION ALL SELECT 'b')
+EXCEPT ALL
+(SELECT 'a');
+
+SELECT '-- INTERSECT ALL with strings';
+(SELECT 'a' AS x UNION ALL SELECT 'a' UNION ALL SELECT 'b')
+INTERSECT ALL
+(SELECT 'a' UNION ALL SELECT 'b' UNION ALL SELECT 'b');
+
+SELECT '-- EXCEPT DISTINCT still works (removes all matching)';
+(SELECT 1 AS x UNION ALL SELECT 1 UNION ALL SELECT 2)
+EXCEPT DISTINCT
+(SELECT 1);
+
+SELECT '-- INTERSECT DISTINCT still works';
+(SELECT 1 AS x UNION ALL SELECT 1 UNION ALL SELECT 2)
+INTERSECT DISTINCT
+(SELECT 1 UNION ALL SELECT 3);


### PR DESCRIPTION
## Summary
- `EXCEPT ALL` and `INTERSECT ALL` ignored row multiplicities because `IntersectOrExceptTransform` used a `HashSet` (via `SetVariants`) to track right-side rows — only recording presence, not count
- This made `EXCEPT ALL` act like `EXCEPT DISTINCT` and `INTERSECT ALL` act like `INTERSECT DISTINCT`
- Fix uses a `HashMap<UInt128, UInt64>` for ALL variants, keyed by SipHash128 of each row, with occurrence counts that are decremented during filtering to implement correct multiset semantics

Closes https://github.com/ClickHouse/ClickHouse/issues/96801

## Test plan
- [x] New test `03916_except_intersect_all_multiset` covers basic EXCEPT ALL/INTERSECT ALL with duplicates, edge cases (empty sides, right > left), strings, and DISTINCT regression checks
- [x] Existing tests `02004_intersect_except_const_column`, `03312_analyzer_unused_projection_fix`, `03550_variant_extend_union` pass unchanged
- [x] Verified the exact query from the issue: `SELECT 1 AS x UNION ALL SELECT 1 EXCEPT ALL SELECT 1` now returns `1`

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `EXCEPT ALL` and `INTERSECT ALL` ignoring row multiplicities and behaving like their `DISTINCT` counterparts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.683`
<!-- ch-version-info:end -->