### PR TITLE
Fix std::terminate in indexOfAssumeSorted with incompatible types

### DIFF
--- a/src/Functions/array/arrayIndex.h
+++ b/src/Functions/array/arrayIndex.h
@@ -160,7 +160,8 @@ private:
 
     static bool lessOrEqual(const IColumn & left, const Result & right, size_t i, size_t) { return left[i] >= right; }
 
-    static bool lessOrEqual(const Array & arr, const Field & rhs, size_t pos, size_t) {
+    static bool lessOrEqual(const Array & arr, const Field & rhs, size_t pos, size_t)
+    {
         return accurateLessOrEqual(rhs, arr[pos]);
     }
 

--- a/src/Functions/array/arrayIndex.h
+++ b/src/Functions/array/arrayIndex.h
@@ -158,9 +158,9 @@ private:
         }
     }
 
-    static constexpr bool lessOrEqual(const IColumn & left, const Result & right, size_t i, size_t) noexcept { return left[i] >= right; }
+    static bool lessOrEqual(const IColumn & left, const Result & right, size_t i, size_t) { return left[i] >= right; }
 
-    static constexpr bool lessOrEqual(const Array& arr, const Field& rhs, size_t pos, size_t) noexcept {
+    static bool lessOrEqual(const Array & arr, const Field & rhs, size_t pos, size_t) {
         return accurateLessOrEqual(rhs, arr[pos]);
     }
 

--- a/src/Functions/array/arrayIndex.h
+++ b/src/Functions/array/arrayIndex.h
@@ -699,7 +699,7 @@ private:
      * @return {nullptr, null_map_item} if there are four arguments but the third is missing.
      * @return {null_map_data, null_map_item} if there are four arguments.
      */
-    static NullMaps getNullMaps(const ColumnsWithTypeAndName & arguments) noexcept
+    static NullMaps getNullMaps(const ColumnsWithTypeAndName & arguments)
     {
         if (arguments.size() < 3)
             return {nullptr, nullptr};

--- a/tests/queries/0_stateless/03831_index_of_assume_sorted_const_exception.sql
+++ b/tests/queries/0_stateless/03831_index_of_assume_sorted_const_exception.sql
@@ -1,3 +1,4 @@
 -- indexOfAssumeSorted with incompatible types in constant array should throw an exception, not crash (std::terminate from noexcept).
 -- https://github.com/ClickHouse/ClickHouse/issues/92975
+SELECT indexOfAssumeSorted(['1.1.1.1'::IPv4], 0); -- { serverError BAD_TYPE_OF_FIELD }
 SELECT indexOfAssumeSorted(['172.181.59.225'::IPv4], 3350671033650519441::Int8); -- { serverError BAD_TYPE_OF_FIELD }

--- a/tests/queries/0_stateless/03831_index_of_assume_sorted_const_exception.sql
+++ b/tests/queries/0_stateless/03831_index_of_assume_sorted_const_exception.sql
@@ -1,0 +1,3 @@
+-- indexOfAssumeSorted with incompatible types in constant array should throw an exception, not crash (std::terminate from noexcept).
+-- https://github.com/ClickHouse/ClickHouse/issues/92975
+SELECT indexOfAssumeSorted(['172.181.59.225'::IPv4], 3350671033650519441::Int8); -- { serverError BAD_TYPE_OF_FIELD }


### PR DESCRIPTION
## Summary
- `lessOrEqual` overloads in `arrayIndex.h` were marked `noexcept` but called `accurateLessOrEqual` and `IColumn::operator[]` which can throw exceptions
- When `indexOfAssumeSorted` was called with incompatible `Field` types (e.g., `IPv4` vs integer), the exception propagated through `noexcept`, causing `std::terminate` instead of a proper error
- Also removed bogus `noexcept` from `getNullMaps` which calls `assert_cast` (can throw in debug/sanitizer builds)

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=1cabb3028dffeef914d5cf032c13de05eb8ef1fd&name_0=MasterCI&name_1=BuzzHouse%20%28amd_msan%29

Closes #92975

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `std::terminate` exception in `indexOfAssumeSorted` when called with incompatible types (e.g., `IPv4` array with integer search value).

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.682`
- Backported to: `26.1.3.41`, `25.12.6.29`, `25.11.9.34`, `25.8.17.18`, `25.3.15.7`
<!-- ch-version-info:end -->