### PR TITLE
Make the left panel in /play UI clickable to toggle the database list

### DIFF
--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -153,6 +153,7 @@
             display: grid;
             grid-template-rows: auto 1fr auto;
             grid-template-areas: "databases-icon" "contents" "github-icon";
+            cursor: e-resize;
         }
 
         #main
@@ -1201,13 +1202,31 @@ async function loadTables(server_address, user, password, database, container) {
 }
 
 let databases_toggle = document.getElementById('databases-toggle');
-databases_toggle.addEventListener('click', e => {
+
+let menu_elem = document.getElementById('menu');
+
+function toggleDatabases() {
     if (!databases_toggle.dataset['opened']) {
-        loadDatabases(url_elem.value, user_elem.value, password_elem.value).then(() => databases_toggle.dataset['opened'] = 1);
+        loadDatabases(url_elem.value, user_elem.value, password_elem.value).then(() => {
+            databases_toggle.dataset['opened'] = 1;
+            menu_elem.style.cursor = 'w-resize';
+        });
     } else {
         delete databases_toggle.dataset['opened'];
+        menu_elem.style.cursor = 'e-resize';
         let databases_elem = document.getElementById('databases');
         while (databases_elem.firstChild) databases_elem.removeChild(databases_elem.firstChild);
+    }
+}
+
+databases_toggle.addEventListener('click', e => {
+    e.stopPropagation();
+    toggleDatabases();
+});
+
+document.getElementById('menu').addEventListener('click', e => {
+    if (!e.target.closest('#github-icon') && !e.target.closest('#databases-toggle')) {
+        toggleDatabases();
     }
 });
 


### PR DESCRIPTION
## Summary
- The entire left panel background in the `/play` UI now toggles the database list on click, same as the database icon
- Cursor changes to a right arrow (`e-resize`) when collapsed and left arrow (`w-resize`) when expanded
- Clicks on the GitHub icon and the database toggle icon itself are properly excluded

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Make the left panel in `/play` UI clickable to toggle the database list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.680`
<!-- ch-version-info:end -->