### PR TITLE
Disable 03100_lwu_30_join_cache test under UBSan

### DIFF
--- a/tests/queries/0_stateless/03100_lwu_30_join_cache.sql
+++ b/tests/queries/0_stateless/03100_lwu_30_join_cache.sql
@@ -1,4 +1,4 @@
--- Tags: no-tsan, no-asan, no-msan, no-parallel, no-debug
+-- Tags: no-tsan, no-asan, no-msan, no-ubsan, no-parallel, no-debug
 
 DROP TABLE IF EXISTS t_patch_join_cache;
 


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Test `03100_lwu_30_join_cache` times out (300s) in `Stateless tests (amd_ubsan, sequential)` because `OPTIMIZE TABLE ... FINAL` on 3M rows is too slow under UBSan instrumentation, especially with randomized small `index_granularity` values (e.g. 2).

The test already excludes TSan, ASan, MSan, and debug builds; this adds `no-ubsan` for consistency.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=089da1c00c06114464bc1d6555e07cba80671df2&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_ubsan%2C%20sequential%29


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.677`
<!-- ch-version-info:end -->