### PR TITLE
Fix flaky test `01079_parallel_alter_detach_table_zookeeper`

### DIFF
--- a/tests/queries/0_stateless/01079_parallel_alter_detach_table_zookeeper.sh
+++ b/tests/queries/0_stateless/01079_parallel_alter_detach_table_zookeeper.sh
@@ -117,8 +117,8 @@ for i in $(seq $REPLICAS); do
     $CLICKHOUSE_CLIENT --query "SELECT SUM(toUInt64(value1)) > $INITIAL_SUM FROM concurrent_alter_detach_$i"
 
     # Wait for all mutations and replication queue entries to finish.
-    # SYSTEM SYNC REPLICA may return while a MUTATE_PART entry is postponed
-    # (e.g. waiting for an in-progress MERGE_PARTS on the same part to complete).
+    # In this case, it might be more robust than SYSTEM SYNC REPLICA
+    # for unclear reasons.
     for _ in {1..120}; do
         mutations_count=$($CLICKHOUSE_CLIENT --query "SELECT count() FROM system.mutations WHERE database = '$CLICKHOUSE_DATABASE' AND is_done = 0 AND table = 'concurrent_alter_detach_$i'")
         queue_count=$($CLICKHOUSE_CLIENT --query "SELECT count() FROM system.replication_queue WHERE database = '$CLICKHOUSE_DATABASE' AND table = 'concurrent_alter_detach_$i' AND (type = 'ALTER_METADATA' OR type = 'MUTATE_PART')")

--- a/tests/queries/0_stateless/01079_parallel_alter_detach_table_zookeeper.sh
+++ b/tests/queries/0_stateless/01079_parallel_alter_detach_table_zookeeper.sh
@@ -115,8 +115,19 @@ done
 for i in $(seq $REPLICAS); do
     $CLICKHOUSE_CLIENT --receive_timeout 120 --query "SYSTEM SYNC REPLICA concurrent_alter_detach_$i"
     $CLICKHOUSE_CLIENT --query "SELECT SUM(toUInt64(value1)) > $INITIAL_SUM FROM concurrent_alter_detach_$i"
+
+    # Wait for all mutations and replication queue entries to finish.
+    # SYSTEM SYNC REPLICA may return while a MUTATE_PART entry is postponed
+    # (e.g. waiting for an in-progress MERGE_PARTS on the same part to complete).
+    for _ in {1..120}; do
+        mutations_count=$($CLICKHOUSE_CLIENT --query "SELECT count() FROM system.mutations WHERE database = '$CLICKHOUSE_DATABASE' AND is_done = 0 AND table = 'concurrent_alter_detach_$i'")
+        queue_count=$($CLICKHOUSE_CLIENT --query "SELECT count() FROM system.replication_queue WHERE database = '$CLICKHOUSE_DATABASE' AND table = 'concurrent_alter_detach_$i' AND (type = 'ALTER_METADATA' OR type = 'MUTATE_PART')")
+        [[ "$mutations_count" == "0" && "$queue_count" == "0" ]] && break
+        sleep 1
+    done
+
     $CLICKHOUSE_CLIENT --query "SELECT COUNT() FROM system.mutations WHERE database = '$CLICKHOUSE_DATABASE' and is_done=0 and table = 'concurrent_alter_detach_$i'" # all mutations have to be done
     $CLICKHOUSE_CLIENT --query "SELECT * FROM system.mutations WHERE database = '$CLICKHOUSE_DATABASE' and is_done=0 and table = 'concurrent_alter_detach_$i'" # all mutations have to be done
-    $CLICKHOUSE_CLIENT --query "SELECT * FROM system.replication_queue WHERE table = 'concurrent_alter_detach_$i' and (type = 'ALTER_METADATA' or type = 'MUTATE_PART')" # all mutations and alters have to be done
+    $CLICKHOUSE_CLIENT --query "SELECT * FROM system.replication_queue WHERE database = '$CLICKHOUSE_DATABASE' AND table = 'concurrent_alter_detach_$i' and (type = 'ALTER_METADATA' or type = 'MUTATE_PART')" # all mutations and alters have to be done
     $CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS concurrent_alter_detach_$i" 2>&1 | grep -Fv "TIMEOUT_EXCEEDED" ||:
 done


### PR DESCRIPTION
## Summary
- Add a retry loop after `SYSTEM SYNC REPLICA` that waits for pending mutations and replication queue entries (`ALTER_METADATA`/`MUTATE_PART`) to drain before asserting they're empty
- `SYSTEM SYNC REPLICA` may return while a `MUTATE_PART` entry is still postponed (e.g. waiting for an in-progress `MERGE_PARTS` on the same part to complete), causing a spurious diff
- Add `database` filtering to the `system.replication_queue` query for proper test isolation

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96874&sha=7d053394dc3bdd556f989a8546389fdab344aa41&name_0=PR&name_1=Stateless%20tests%20%28amd_debug%2C%20AsyncInsert%2C%20s3%20storage%2C%20sequential%29
https://github.com/ClickHouse/ClickHouse/pull/96874

Closes #91413

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.676`
<!-- ch-version-info:end -->