### PR TITLE
Fix flaky test 02572_materialized_views_ignore_errors

### DIFF
--- a/tests/queries/0_stateless/02572_materialized_views_ignore_errors.reference
+++ b/tests/queries/0_stateless/02572_materialized_views_ignore_errors.reference
@@ -15,13 +15,9 @@ from system.query_views_log where
 exceptionwhileprocessing	UNKNOWN_TABLE
 SET materialized_views_ignore_errors = 0;
 insert into data_02572 values (1); -- { serverError UNKNOWN_TABLE }
-select * from data_02572 order by key;
-1
-2
 create table receiver_02572 as data_02572;
 insert into data_02572 values (3);
-select * from data_02572 order by key;
-1
+select key from data_02572 where key in (2, 3) order by key;
 2
 3
 select * from receiver_02572 order by key;

--- a/tests/queries/0_stateless/02572_materialized_views_ignore_errors.sql
+++ b/tests/queries/0_stateless/02572_materialized_views_ignore_errors.sql
@@ -1,8 +1,4 @@
 set prefer_localhost_replica=1;
--- With `use_async_executor_for_materialized_views = 1`, the pipeline task scheduling may cause
--- the MV exception to cancel the pipeline before `MemorySink::onFinish` commits the data,
--- making the source table content after a failed INSERT non-deterministic.
-set use_async_executor_for_materialized_views = 0;
 
 drop table if exists data_02572;
 drop table if exists proxy_02572;
@@ -35,10 +31,9 @@ from system.query_views_log where
 
 SET materialized_views_ignore_errors = 0;
 insert into data_02572 values (1); -- { serverError UNKNOWN_TABLE }
-select * from data_02572 order by key;
 
 create table receiver_02572 as data_02572;
 
 insert into data_02572 values (3);
-select * from data_02572 order by key;
+select key from data_02572 where key in (2, 3) order by key;
 select * from receiver_02572 order by key;


### PR DESCRIPTION
## Summary

- The new `FinalizingViewsTransform` in `InsertDependenciesBuilder` immediately pushes MV exceptions within a single `updateNode` call, which can cancel the pipeline before `MemorySink::onFinish` commits data to the source table. This makes the source table content after a failed INSERT non-deterministic.
- Remove the brittle `use_async_executor_for_materialized_views = 0` workaround — that setting only affects the inner MV SELECT executor, not the outer pipeline threading.
- Instead, don't assert on source table contents after a failed INSERT with MV errors — filter the final SELECT to only check deterministically present rows.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=13e0214b757a58057a00a57a06a23caf816acc28&name_0=MasterCI&name_1=Stateless%20tests%20%28arm_binary%2C%20parallel%29

## Test plan

- [x] `02572_materialized_views_ignore_errors` passes locally (5 consecutive runs)

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.675`
<!-- ch-version-info:end -->