### PR TITLE
Fix logical error when lambda is passed as a non-lambda argument

### DIFF
--- a/src/Analyzer/Resolve/resolveFunction.cpp
+++ b/src/Analyzer/Resolve/resolveFunction.cpp
@@ -1312,6 +1312,21 @@ ProjectionNames QueryAnalyzer::resolveFunction(QueryTreeNodePtr & node, Identifi
                                 argument_types[function_lambda_argument_index]->getName(),
                                 scope.scope_node->formatASTForErrorMessage());
 
+            /** Check that getLambdaArgumentTypes actually resolved the types for this lambda.
+              * If the argument types are still null, the function did not expect a lambda at this position.
+              * This can happen when a lambda is passed where a concrete value is expected,
+              * e.g. arrayFold(lambda, array, another_lambda_instead_of_initial_value).
+              */
+            for (size_t i = 0; i < function_data_type_arguments_size; ++i)
+            {
+                if (!function_data_type_argument_types[i])
+                    throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
+                        "Function '{}' does not expect a lambda expression as argument {}. In scope {}",
+                        function_name,
+                        function_lambda_argument_index + 1,
+                        scope.scope_node->formatASTForErrorMessage());
+            }
+
             QueryTreeNodes lambda_arguments;
             lambda_arguments.reserve(lambda_arguments_size);
 

--- a/tests/queries/0_stateless/03917_arrayFold_lambda_as_accumulator.sql
+++ b/tests/queries/0_stateless/03917_arrayFold_lambda_as_accumulator.sql
@@ -1,0 +1,4 @@
+-- Regression test: arrayFold should not cause a logical error when a lambda is passed as the accumulator (initial value).
+-- Previously this caused LOGICAL_ERROR "Function 'modulo' argument is not resolved" in debug builds.
+SELECT arrayFold((acc, x) -> acc + x, [1, 2, 3], (a, b) -> a + b); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT arrayFold((acc, x) -> acc + x, range(number), ((acc, x) -> if(x % 2, arrayPushFront(acc, x), arrayPushBack(acc, x)))) FROM system.numbers LIMIT 0; -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }


### PR DESCRIPTION
## Summary

- The AST fuzzer found a `LOGICAL_ERROR` exception when `arrayFold` receives a lambda expression as its accumulator (initial value) argument instead of a concrete value
- The crash happened because `getLambdaArgumentTypes` only fills in types for lambda arguments the function expects, leaving unexpected lambda arguments with null types
- When the resolver then tried to resolve the unexpected lambda's body, its parameters had null types, causing "Function 'modulo' argument is not resolved"
- The fix adds a null-type check after `getLambdaArgumentTypes` returns, throwing a proper `ILLEGAL_TYPE_OF_ARGUMENT` error instead of a `LOGICAL_ERROR`

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96712&sha=bb986aea227938ccf326c6f86aab2923e3f63e27&name_0=PR&name_1=AST%20fuzzer%20%28amd_msan%29
https://github.com/ClickHouse/ClickHouse/pull/96712

## Test plan

- [x] New stateless test `03917_arrayFold_lambda_as_accumulator` verifies the fix returns `ILLEGAL_TYPE_OF_ARGUMENT`
- [x] Normal `arrayFold` usage verified manually

### Changelog category (leave one):
- Bug Fix

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `LOGICAL_ERROR` exception in query analyzer when a lambda expression is passed where a concrete value is expected (e.g., as the accumulator argument of `arrayFold`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.692`
<!-- ch-version-info:end -->