### PR TITLE
Fix inconsistent AST formatting for array/tuple with tuple element access

### DIFF
--- a/tests/queries/0_stateless/01852_cast_operator_4.reference
+++ b/tests/queries/0_stateless/01852_cast_operator_4.reference
@@ -14,7 +14,7 @@ WITH _CAST([3, 4, 5], \'Array(UInt8)\') AS x
 SELECT CAST(x[1], \'Int32\')
 FROM system.one
 3
-SELECT CAST((tuple(3, 4, 5)).1, \'Int32\')
+SELECT CAST(tuple(3, 4, 5).1, \'Int32\')
 FROM system.one
 4
 SELECT CAST((CAST(tuple(3, 4, 5), \'Tuple(UInt64, UInt64, UInt64)\')).1, \'Int32\')

--- a/tests/queries/0_stateless/02560_tuple_format.reference
+++ b/tests/queries/0_stateless/02560_tuple_format.reference
@@ -1,4 +1,4 @@
 SELECT tuple(1, 2, 3)
 SELECT tuple(1, 2, 3) AS x
-SELECT (tuple(1, 2, 3)).1
+SELECT tuple(1, 2, 3).1
 SELECT (tuple(1, 2, 3) AS x).1

--- a/tests/queries/0_stateless/03786_AST_formatting_inconsistencies_in_debug_check.reference
+++ b/tests/queries/0_stateless/03786_AST_formatting_inconsistencies_in_debug_check.reference
@@ -70,3 +70,7 @@ Original:          with (((1,1),1),1) as t1 select t1.1.1.1;
 format(original):  WITH (((1, 1), 1), 1) AS t1 SELECT ((t1.1).1).1
 format(formatted): WITH (((1, 1), 1), 1) AS t1 SELECT ((t1.1).1).1
 
+Original:          SELECT [['hello']].1;
+format(original):  SELECT [['hello']].1
+format(formatted): SELECT [['hello']].1
+

--- a/tests/queries/0_stateless/03786_AST_formatting_inconsistencies_in_debug_check.sh
+++ b/tests/queries/0_stateless/03786_AST_formatting_inconsistencies_in_debug_check.sh
@@ -58,3 +58,6 @@ format_query "ALTER TABLE \`t55\` (MODIFY ORDER BY ((\`c0\` AS \`a0\`)));"
 # Complex tuple expression with index
 format_query "select (tab.*).2 from tab;"
 format_query "with (((1,1),1),1) as t1 select t1.1.1.1;"
+
+# Array with tuple element access (should not add extra parens around array)
+format_query "SELECT [['hello']].1;"


### PR DESCRIPTION
## Summary
- Fix BuzzHouse exception "Inconsistent AST formatting between `Function_array` and `Literal_Array`" in debug builds
- PR #96799 added `size() > 1` parenthesization in `tupleElement` formatting to fix `(tab.*).N`, but it also wrapped `array` and `tuple` functions in unnecessary extra parens (e.g., `([['你们']]).3`)
- When re-parsed, the parser's fast literal path converts `[['你们']]` to `ASTLiteral` (size=1, no parens), producing `[['你们']].3` — the formatted strings differ, triggering the debug AST consistency check
- Exclude `array` and `tuple` functions from extra parenthesization since `[...]` and `(...)` syntax is already unambiguous with `.N` access
- Revert unnecessary test reference changes from #96799 where `tuple(...)` got wrapped in extra parens

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96871&sha=8c08d137d9d40503cff353ed51ec4c8cf55e9d38&name_0=PR&name_1=BuzzHouse%20%28amd_debug%29
https://github.com/ClickHouse/ClickHouse/pull/96871

### Changelog category (leave one):
- CI Fix or improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix inconsistent AST formatting for `array`/`tuple` functions with `.N` tuple element access that caused exceptions in debug builds.

## Test plan
- [x] Verified `clickhouse-format` produces consistent output for `[['hello']].1`, `tuple(1,2,3).1`, `(tab.*).2`, `((t1.1).1).1`
- [x] All affected tests pass: `01852_cast_operator_4`, `02560_tuple_format`, `03780_AST_formatting_inconsistencies_in_debug_check`, `03786_AST_formatting_inconsistencies_in_debug_check`
- [x] Added regression test for array with `.N` access in `03786`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.679`
<!-- ch-version-info:end -->