### PR TITLE
CI: Fix unstable config_digest causing cache invalidation

### DIFF
--- a/ci/praktika/digest.py
+++ b/ci/praktika/digest.py
@@ -75,6 +75,7 @@ class Digest:
             "requires",
             "enable_commit_status",
             "allow_merge_on_failure",
+            "digest_config",
         ]
         filtered_job_dict = {
             k: v for k, v in job_config_dict.items() if k not in drop_fields


### PR DESCRIPTION
## Changelog category (leave one):
- Not for changelog (changelog entry is not required)

fix:
The digest_config field was included in the config_digest calculation, which is redundant since it's already used to calculate the file-based digest. Since this field is dict it caused non-deterministic behavior.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.790`
<!-- ch-version-info:end -->