### PR TITLE
In Replicated database, don't update the cached cluster for every dummy query.

### DIFF
--- a/src/Databases/DatabaseReplicatedWorker.cpp
+++ b/src/Databases/DatabaseReplicatedWorker.cpp
@@ -262,10 +262,10 @@ void DatabaseReplicatedDDLWorker::scheduleTasks(bool reinitialized)
     DDLWorker::scheduleTasks(reinitialized);
     if (need_update_cached_cluster)
     {
-        need_update_cached_cluster = false;
         database->setCluster(database->getClusterImpl());
         if (!database->replica_group_name.empty())
             database->setCluster(database->getClusterImpl(/*all_groups*/ true), /*all_groups*/ true);
+        need_update_cached_cluster = false;
     }
 }
 

--- a/src/Databases/DatabaseReplicatedWorker.cpp
+++ b/src/Databases/DatabaseReplicatedWorker.cpp
@@ -257,6 +257,18 @@ void DatabaseReplicatedDDLWorker::initializeReplication()
     active_node_holder = zkutil::EphemeralNodeHolder::existing(active_path, *active_node_holder_zookeeper);
 }
 
+void DatabaseReplicatedDDLWorker::scheduleTasks(bool reinitialized)
+{
+    DDLWorker::scheduleTasks(reinitialized);
+    if (need_update_cached_cluster)
+    {
+        need_update_cached_cluster = false;
+        database->setCluster(database->getClusterImpl());
+        if (!database->replica_group_name.empty())
+            database->setCluster(database->getClusterImpl(/*all_groups*/ true), /*all_groups*/ true);
+    }
+}
+
 void DatabaseReplicatedDDLWorker::markReplicasActive(bool reinitialized)
 {
     if (reinitialized || !active_node_holder_zookeeper || active_node_holder_zookeeper->expired())
@@ -667,9 +679,7 @@ DDLTaskPtr DatabaseReplicatedDDLWorker::initAndCheckTask(const String & entry_na
     if (task->entry.query.empty())
     {
         /// Some replica is added or removed, let's update cached cluster
-        database->setCluster(database->getClusterImpl());
-        if (!database->replica_group_name.empty())
-            database->setCluster(database->getClusterImpl(/*all_groups*/ true), /*all_groups*/ true);
+        need_update_cached_cluster = true;
         out_reason = fmt::format("Entry {} is a dummy task", entry_name);
         return {};
     }

--- a/src/Databases/DatabaseReplicatedWorker.h
+++ b/src/Databases/DatabaseReplicatedWorker.h
@@ -48,6 +48,8 @@ private:
     bool initializeMainThread() override;
     void initializeReplication() override;
 
+    void scheduleTasks(bool reinitialized) override;
+
     void createReplicaDirs(const ZooKeeperPtr &, const NameSet &) override { }
     void markReplicasActive(bool reinitialized) override;
 
@@ -76,6 +78,13 @@ private:
 
     std::optional<Stopwatch> initialization_duration_timer;
     mutable std::mutex initialization_duration_timer_mutex;
+
+    // When the log entry is dummy, it indicates that a replica is added or removed.
+    // We need to update the cached cluster
+    // However, we don't update it for every dummy query.
+    // We only update after processing a batch of queries to avoid sending too many requests to Keeper.
+    // Because each update calls `getClusterImpl`, which sends a request to Keeper.
+    bool need_update_cached_cluster{false};
 };
 
 }

--- a/src/Interpreters/DDLWorker.h
+++ b/src/Interpreters/DDLWorker.h
@@ -132,7 +132,7 @@ protected:
     String enqueueQueryAttempt(DDLLogEntry & entry);
 
     /// Iterates through queue tasks in ZooKeeper, runs execution of new tasks
-    void scheduleTasks(bool reinitialized);
+    virtual void scheduleTasks(bool reinitialized);
 
     DDLTaskBase & saveTask(DDLTaskPtr && task);
 


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

In Replicated database, don't update the cached cluster for every dummy query.

When the log entry is dummy, it indicates that a replica is added or removed. We need to update the cached cluster
However, we should not update it for every dummy query.
We only update after processing a batch of queries to avoid sending too many requests to Keeper.
Because each update calls `getClusterImpl`, which sends a request to Keeper.

Escalation: https://github.com/ClickHouse/support-escalation/issues/6988

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.782`
<!-- ch-version-info:end -->