### PR TITLE
Fix Iceberg crash when version-hint contains numeric value

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
@@ -1056,7 +1056,7 @@ static MetadataFileWithInfo getLatestMetadataFileAndVersion(
     for (const auto & path : metadata_files)
     {
         String filename = std::filesystem::path(path).filename();
-        if (isTemporaryMetadataFile(filename))
+        if (isTemporaryMetadataFile(filename, MetadataPathParsingMode::StrictMetadataFilePath))
             continue;
         auto [version, metadata_file_path, compression_method] = getMetadataFileAndVersion(path);
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
@@ -3,6 +3,7 @@
 #include <sstream>
 #include <string>
 #include <unordered_set>
+#include <cctype>
 #include <config.h>
 #include <Core/ColumnsWithTypeAndName.h>
 #include <Core/Settings.h>
@@ -112,13 +113,32 @@ static CompressionMethod getCompressionMethodFromMetadataFile(const String & pat
     return compression_method;
 }
 
+static bool isDigits(const String & value)
+{
+    return !value.empty() && std::all_of(value.begin(), value.end(), [](unsigned char ch) { return std::isdigit(ch); });
+}
+
+static String extractVersionStringFromMetadataFileName(const String & file_name)
+{
+    /// v<V>.metadata.json
+    if (file_name.starts_with('v'))
+    {
+        auto dot_pos = file_name.find('.');
+        return dot_pos == String::npos ? file_name.substr(1) : file_name.substr(1, dot_pos - 1);
+    }
+
+    /// <V>-<random-uuid>.metadata.json
+    auto dash_pos = file_name.find('-');
+    return dash_pos == String::npos ? file_name : file_name.substr(0, dash_pos);
+}
 
 static bool isTemporaryMetadataFile(const String & file_name)
 {
-    auto string_position = file_name.find_first_of('.');
-    if (string_position == String::npos)
-        return true;
-    String substring = String(file_name.begin(), file_name.begin() + string_position);
+    auto dot_pos = file_name.find('.');
+    if (dot_pos == String::npos || dot_pos == 0)
+        return false;
+
+    String substring = file_name.substr(0, dot_pos);
     return Poco::UUID{}.tryParse(substring);
 }
 
@@ -132,17 +152,12 @@ static Iceberg::MetadataFileWithInfo getMetadataFileAndVersion(const std::string
             "Temporary metadata file '{}' should not be used for reading. It is created during commit operation and should be ignored",
             path);
     }
-    String version_str;
-    /// v<V>.metadata.json
-    if (file_name.starts_with('v'))
-        version_str = String(file_name.begin() + 1, file_name.begin() + file_name.find_first_of('.'));
-    /// <V>-<random-uuid>.metadata.json
-    else
-        version_str = String(file_name.begin(), file_name.begin() + file_name.find_first_of('-'));
-
-    if (!std::all_of(version_str.begin(), version_str.end(), isdigit))
+    String version_str = extractVersionStringFromMetadataFileName(file_name);
+    if (!isDigits(version_str))
         throw Exception(
-            ErrorCodes::BAD_ARGUMENTS, "Bad metadata file name: '{}'. Expected vN.metadata.json where N is a number", file_name);
+            ErrorCodes::BAD_ARGUMENTS,
+            "Bad metadata file name: '{}'. Expected vN.metadata.json, N-<uuid>.metadata.json, or N where N is a number",
+            file_name);
 
     return MetadataFileWithInfo{
         .version = std::stoi(version_str),

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
@@ -118,46 +118,73 @@ static bool isDigits(const String & value)
     return !value.empty() && std::all_of(value.begin(), value.end(), [](unsigned char ch) { return std::isdigit(ch); });
 }
 
-static String extractVersionStringFromMetadataFileName(const String & file_name)
+enum class MetadataPathParsingMode
 {
+    StrictMetadataFilePath,
+    VersionHintValue,
+};
+
+static String extractVersionStringFromMetadataFileName(const String & file_name, MetadataPathParsingMode mode)
+{
+    if (mode == MetadataPathParsingMode::VersionHintValue && isDigits(file_name))
+        return file_name;
+
     /// v<V>.metadata.json
     if (file_name.starts_with('v'))
     {
         auto dot_pos = file_name.find('.');
-        return dot_pos == String::npos ? file_name.substr(1) : file_name.substr(1, dot_pos - 1);
+        if (dot_pos == String::npos || dot_pos <= 1)
+            return {};
+        return file_name.substr(1, dot_pos - 1);
     }
 
     /// <V>-<random-uuid>.metadata.json
     auto dash_pos = file_name.find('-');
-    return dash_pos == String::npos ? file_name : file_name.substr(0, dash_pos);
+    if (dash_pos == String::npos)
+        return mode == MetadataPathParsingMode::VersionHintValue ? file_name : String{};
+    if (dash_pos == 0)
+        return {};
+    return file_name.substr(0, dash_pos);
 }
 
-static bool isTemporaryMetadataFile(const String & file_name)
+static bool isTemporaryMetadataFile(const String & file_name, MetadataPathParsingMode mode)
 {
     auto dot_pos = file_name.find('.');
-    if (dot_pos == String::npos || dot_pos == 0)
+    if (dot_pos == String::npos)
+        return mode == MetadataPathParsingMode::StrictMetadataFilePath;
+    if (dot_pos == 0)
         return false;
 
     String substring = file_name.substr(0, dot_pos);
     return Poco::UUID{}.tryParse(substring);
 }
 
-static Iceberg::MetadataFileWithInfo getMetadataFileAndVersion(const std::string & path)
+static Iceberg::MetadataFileWithInfo getMetadataFileAndVersion(
+    const std::string & path,
+    MetadataPathParsingMode mode = MetadataPathParsingMode::StrictMetadataFilePath)
 {
     String file_name = std::filesystem::path(path).filename();
-    if (isTemporaryMetadataFile(file_name))
+    if (isTemporaryMetadataFile(file_name, mode))
     {
         throw Exception(
             ErrorCodes::ICEBERG_SPECIFICATION_VIOLATION,
             "Temporary metadata file '{}' should not be used for reading. It is created during commit operation and should be ignored",
             path);
     }
-    String version_str = extractVersionStringFromMetadataFileName(file_name);
+    String version_str = extractVersionStringFromMetadataFileName(file_name, mode);
     if (!isDigits(version_str))
+    {
+        if (mode == MetadataPathParsingMode::VersionHintValue)
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "Bad version hint value: '{}'. Expected N, vN.metadata.json, or N-<uuid>.metadata.json where N is a number",
+                file_name);
+
         throw Exception(
             ErrorCodes::BAD_ARGUMENTS,
-            "Bad metadata file name: '{}'. Expected vN.metadata.json, N-<uuid>.metadata.json, or N where N is a number",
+            "Bad metadata file name: '{}'. Expected vN.metadata.json or N-<uuid>.metadata.json where N is a number",
             file_name);
+    }
 
     return MetadataFileWithInfo{
         .version = std::stoi(version_str),
@@ -237,8 +264,8 @@ bool writeMetadataFileAndVersionHint(
                 write_if_none_match.clear();
             }
 
-            auto [old_version, _1, _2] = getMetadataFileAndVersion(version_hint_value);
-            auto [new_version, _3, _4] = getMetadataFileAndVersion(version_hint_content);
+            auto [old_version, _1, _2] = getMetadataFileAndVersion(version_hint_value, MetadataPathParsingMode::VersionHintValue);
+            auto [new_version, _3, _4] = getMetadataFileAndVersion(version_hint_content, MetadataPathParsingMode::VersionHintValue);
             if (old_version < new_version)
             {
                 try
@@ -1178,7 +1205,7 @@ MetadataFileWithInfo getLatestOrExplicitMetadataFileAndVersion(
         readString(metadata_file, *buf);
         if (!metadata_file.ends_with(".metadata.json"))
         {
-            if (std::all_of(metadata_file.begin(), metadata_file.end(), isdigit))
+            if (isDigits(metadata_file))
                 metadata_file = "v" + metadata_file + ".metadata.json";
             else
                 metadata_file = metadata_file + ".metadata.json";

--- a/tests/integration/test_storage_iceberg_with_spark/test_writes_create_version_hint.py
+++ b/tests/integration/test_storage_iceberg_with_spark/test_writes_create_version_hint.py
@@ -63,7 +63,9 @@ def test_writes_create_version_hint_from_numeric_with_full_path(started_cluster_
 
     version_hint_path = f"/var/lib/clickhouse/user_files/iceberg_data/default/{TABLE_NAME}/metadata/version-hint.text"
     instance.exec_in_container(["bash", "-c", f"printf '1' > {version_hint_path}"])
-    instance.restart_clickhouse()
+
+    # Exercise the read path against a numeric version-hint value before the write path updates it.
+    assert instance.query(f"SELECT * FROM {TABLE_NAME} ORDER BY ALL") == ''
 
     instance.query(
         f"INSERT INTO {TABLE_NAME} VALUES ('123', 1);",

--- a/tests/integration/test_storage_iceberg_with_spark/test_writes_create_version_hint.py
+++ b/tests/integration/test_storage_iceberg_with_spark/test_writes_create_version_hint.py
@@ -61,8 +61,9 @@ def test_writes_create_version_hint_from_numeric_with_full_path(started_cluster_
         f"/var/lib/clickhouse/user_files/iceberg_data/default/{TABLE_NAME}/",
     )
 
-    with open(f"/var/lib/clickhouse/user_files/iceberg_data/default/{TABLE_NAME}/metadata/version-hint.text", "wb") as f:
-        f.write(b"1")
+    version_hint_path = f"/var/lib/clickhouse/user_files/iceberg_data/default/{TABLE_NAME}/metadata/version-hint.text"
+    instance.exec_in_container(["bash", "-c", f"printf '1' > {version_hint_path}"])
+    instance.restart_clickhouse()
 
     instance.query(
         f"INSERT INTO {TABLE_NAME} VALUES ('123', 1);",
@@ -78,5 +79,5 @@ def test_writes_create_version_hint_from_numeric_with_full_path(started_cluster_
     )
 
     target_suffix = b"v2.metadata.json"
-    with open(f"/var/lib/clickhouse/user_files/iceberg_data/default/{TABLE_NAME}/metadata/version-hint.text", "rb") as f:
+    with open(version_hint_path, "rb") as f:
         assert f.read().strip().endswith(target_suffix)

--- a/tests/integration/test_storage_iceberg_with_spark/test_writes_create_version_hint.py
+++ b/tests/integration/test_storage_iceberg_with_spark/test_writes_create_version_hint.py
@@ -44,3 +44,39 @@ def test_writes_create_version_hint(started_cluster_iceberg_with_spark, format_v
 
     df = spark.read.format("iceberg").load(f"/var/lib/clickhouse/user_files/iceberg_data/default/{TABLE_NAME}").collect()
     assert len(df) == 1
+
+
+@pytest.mark.parametrize("format_version", [1, 2])
+@pytest.mark.parametrize("storage_type", ["local"])
+def test_writes_create_version_hint_from_numeric_with_full_path(started_cluster_iceberg_with_spark, format_version, storage_type):
+    instance = started_cluster_iceberg_with_spark.instances["node1"]
+    TABLE_NAME = "test_writes_create_version_hint_from_numeric_with_full_path_" + storage_type + "_" + get_uuid_str()
+
+    create_iceberg_table(storage_type, instance, TABLE_NAME, started_cluster_iceberg_with_spark, "(x String, y Int64)", format_version, use_version_hint=True)
+
+    default_download_directory(
+        started_cluster_iceberg_with_spark,
+        storage_type,
+        f"/var/lib/clickhouse/user_files/iceberg_data/default/{TABLE_NAME}/",
+        f"/var/lib/clickhouse/user_files/iceberg_data/default/{TABLE_NAME}/",
+    )
+
+    with open(f"/var/lib/clickhouse/user_files/iceberg_data/default/{TABLE_NAME}/metadata/version-hint.text", "wb") as f:
+        f.write(b"1")
+
+    instance.query(
+        f"INSERT INTO {TABLE_NAME} VALUES ('123', 1);",
+        settings={"allow_experimental_insert_into_iceberg": 1, "write_full_path_in_iceberg_metadata": 1},
+    )
+    assert instance.query(f"SELECT * FROM {TABLE_NAME} ORDER BY ALL") == '123\t1\n'
+
+    default_download_directory(
+        started_cluster_iceberg_with_spark,
+        storage_type,
+        f"/var/lib/clickhouse/user_files/iceberg_data/default/{TABLE_NAME}/",
+        f"/var/lib/clickhouse/user_files/iceberg_data/default/{TABLE_NAME}/",
+    )
+
+    target_suffix = b"v2.metadata.json"
+    with open(f"/var/lib/clickhouse/user_files/iceberg_data/default/{TABLE_NAME}/metadata/version-hint.text", "rb") as f:
+        assert f.read().strip().endswith(target_suffix)


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixes an exception in Iceberg engine when `version-hint.text` contains a bare numeric value.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

### Summary
Fixes Iceberg metadata resolution when `version-hint.text` stores a numeric version value without full metadata filename formatting.

Fixes #96811

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Iceberg metadata filename/version parsing used on read/write paths; incorrect parsing could cause failed table reads or wrong metadata selection, but the change is localized and covered by a new integration test.
> 
> **Overview**
> Fixes Iceberg metadata resolution when `metadata/version-hint.text` contains a bare numeric version (e.g. `1`) by adding more robust version extraction/validation and a parsing mode specifically for version-hint values.
> 
> Updates version-hint read/write logic to compare and normalize versions using the new parser, and expands integration coverage to reproduce the numeric version-hint case (including when writing full metadata paths) and assert the hint is updated to the expected `vN.metadata.json` target.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c01042f7d1f617db050ce2a95e5a4f3e9c7bf23d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->