### PR TITLE
Minor perf improvement in partial_merge_join

### DIFF
--- a/src/Core/SortCursor.h
+++ b/src/Core/SortCursor.h
@@ -114,6 +114,7 @@ struct SortCursorImpl
 
     /// We need a possibility to change pos (see MergeJoin).
     size_t & getPosRef() { return pos; }
+    size_t getPos() const { return pos; }
 
     bool isFirst() const { return pos == 0; }
     bool isLast() const { return pos + 1 >= rows; }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Minor perf improvement in partial_merge_join.

Improvement is visible in `in_memory` variant with non-composite join keys. I've testeted it over some TPC-H queries with these options
```
SET join_algorithm = 'partial_merge';
SET max_rows_in_join = 100000000000000;
SET max_bytes_in_join = 100000000000000;
```


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.759`
<!-- ch-version-info:end -->