### PR TITLE
Add has() function support for JSON type

### DIFF
--- a/src/Functions/array/arrayIndex.h
+++ b/src/Functions/array/arrayIndex.h
@@ -1,6 +1,8 @@
 #pragma once
+
 #include <cstddef>
 #include <type_traits>
+
 #include <Functions/IFunction.h>
 #include <Functions/FunctionFactory.h>
 #include <Functions/FunctionHelpers.h>
@@ -11,8 +13,6 @@
 #include <DataTypes/getLeastSupertype.h>
 #include <Columns/ColumnArray.h>
 #include <Columns/ColumnMap.h>
-#include <Columns/ColumnObject.h>
-#include <Columns/ColumnDynamic.h>
 #include <Columns/ColumnString.h>
 #include <Columns/ColumnFixedString.h>
 #include <Columns/ColumnsNumber.h>
@@ -23,8 +23,10 @@
 #include <Common/assert_cast.h>
 #include <Columns/ColumnLowCardinality.h>
 #include <DataTypes/DataTypeLowCardinality.h>
-#include <DataTypes/DataTypeObject.h>
 #include <Interpreters/castColumn.h>
+#include <Columns/ColumnObject.h>
+#include <Columns/ColumnDynamic.h>
+#include <DataTypes/DataTypeObject.h>
 
 
 namespace DB
@@ -516,16 +518,15 @@ public:
 
         const DataTypeArray * array_type = checkAndGetDataType<DataTypeArray>(first_argument_type.get());
         const DataTypeMap * map_type = checkAndGetDataType<DataTypeMap>(first_argument_type.get());
-        const DataTypeObject * object_type = checkAndGetDataType<DataTypeObject>(first_argument_type.get());
 
         DataTypePtr inner_type;
 
-        /// If map is first argument only has(map_column, key) function is supported
+        const DataTypeObject * object_type = checkAndGetDataType<DataTypeObject>(first_argument_type.get());
         if constexpr (std::is_same_v<ConcreteAction, HasAction>)
         {
             if (!array_type && !map_type && !object_type)
                 throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
-                    "First argument for function {} must be an array, map or object. Actual {}",
+                    "First argument for function {} must be an array, map or JSON. Actual {}",
                     getName(),
                     first_argument_type->getName());
 
@@ -533,7 +534,7 @@ public:
             {
                 if (!isStringOrFixedString(second_argument_type))
                     throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
-                        "Second argument for function {} must be String when the first argument is Object. Actual {}",
+                        "Second argument for function {} must be String when the first argument is JSON. Actual {}",
                         getName(), second_argument_type->getName());
 
                 return std::make_shared<DataTypeUInt8>();
@@ -918,6 +919,95 @@ private:
         return executeArrayImpl(arguments_copy, result_type);
     }
 
+    /**
+     * Helper function to check if a path or its prefix exists in shared data.
+     */
+     static bool hasPathInSharedData(
+        const String & path,
+        const String & prefix,
+        const ColumnString * shared_paths,
+        const ColumnVector<UInt64>::Container & shared_offsets,
+        size_t row)
+    {
+        if (!shared_paths)
+            return false;
+
+        size_t start = shared_offsets[static_cast<ssize_t>(row) - 1];
+        size_t end = shared_offsets[row];
+
+        if (start == end)
+            return false;
+
+        /// Check for exact match
+        size_t pos = ColumnObject::findPathLowerBoundInSharedData(path, *shared_paths, start, end);
+        if (pos < end && shared_paths->getDataAt(pos) == path)
+            return true;
+
+        /// Check for prefix match (path + ".")
+        pos = ColumnObject::findPathLowerBoundInSharedData(prefix, *shared_paths, start, end);
+        if (pos < end && shared_paths->getDataAt(pos).starts_with(prefix))
+            return true;
+
+        return false;
+    }
+
+    /**
+     * Check if a path exists in JSON object for a specific row.
+     * Returns true if the path (or any path with this prefix) exists.
+     */
+    static bool hasPathInObjectRow(
+        const ColumnObject & object_column,
+        size_t row,
+        const String & path,
+        const String & prefix,
+        const ColumnString * shared_paths,
+        const ColumnVector<UInt64>::Container & shared_offsets)
+    {
+        /// First, check for the requested path in typed paths.
+        /// Typed paths are always considered to be present in each row (even if null).
+        const auto & typed_paths = object_column.getTypedPaths();
+        if (typed_paths.contains(path))
+            return true;
+
+        for (const auto & [key, col] : typed_paths)
+        {
+            if (key.starts_with(prefix))
+                return true;
+        }
+
+        /// Second, check for the requested path in dynamic paths.
+        /// For dynamic paths, we consider null equivalent to absence of the value.
+        const auto & dynamic_paths = object_column.getDynamicPathsPtrs();
+        if (auto it = dynamic_paths.find(path); it != dynamic_paths.end() && !it->second->isNullAt(row))
+            return true;
+
+        for (const auto & [key, col] : dynamic_paths)
+        {
+            if (key.starts_with(prefix) && !col->isNullAt(row))
+                return true;
+        }
+
+        /// Third, check for the requested path in shared data.
+        return hasPathInSharedData(path, prefix, shared_paths, shared_offsets, row);
+    }
+
+    /**
+     * Execute has() function for JSON/Object type.
+     * Checks if a path exists in the JSON object.
+     *
+     * The function checks three storage tiers in order:
+     * 1. Typed paths - explicitly declared paths that are always present (even if null)
+     * 2. Dynamic paths - paths inferred at runtime, null means absence
+     * 3. Shared data - overflow storage for rare paths, uses binary search
+     *
+     * Optimizations:
+     * - For constant path: if found in typed paths, returns 1 for all rows immediately
+     * - For constant path: pre-collects relevant dynamic columns to avoid repeated lookups
+     * - For non-constant path: uses hasPathInObjectRow() helper with early returns
+     *
+     * @param arguments - [0] JSON column (or const JSON), [1] path column
+     * @return ColumnUInt8 with 1 if path exists, 0 otherwise
+    */
     ColumnPtr executeObject(const ColumnsWithTypeAndName & arguments, const DataTypePtr & /*result_type*/) const
     {
         if constexpr (!std::is_same_v<ConcreteAction, HasAction>)
@@ -941,66 +1031,54 @@ private:
         const auto [shared_paths, shared_values] = object_column.getSharedDataPathsAndValues();
         const auto & shared_offsets = object_column.getSharedDataOffsets();
 
-        auto check_shared = [&](size_t row, const String & path) -> bool
-        {
-            if (!shared_paths)
-                return false;
-
-            size_t start = (row == 0) ? 0 : shared_offsets[row - 1];
-            size_t end = shared_offsets[row];
-            if (start >= end)
-                return false;
-
-            // 1. Exact match
-            size_t pos = ColumnObject::findPathLowerBoundInSharedData(path, *shared_paths, start, end);
-            if (pos < end && shared_paths->getDataAt(pos) == path)
-                return true;
-
-            // 2. Prefix match (path + ".")
-            String prefix = path + ".";
-            pos = ColumnObject::findPathLowerBoundInSharedData(prefix, *shared_paths, start, end);
-            if (pos < end)
-            {
-                auto s = shared_paths->getDataAt(pos);
-                if (std::string_view(s).starts_with(prefix))
-                    return true;
-            }
-            return false;
-        };
-
         if (isColumnConst(path_column))
         {
-            const String path = String(path_column.getDataAt(0));
-            String prefix = path + ".";
+            const String path(path_column.getDataAt(0));
+            const String prefix = path + ".";
 
-            std::vector<const IColumn *> relevant_columns;
-
-            // Collect exact and prefix matches from Typed Paths (O(N_paths) scan due to unordered_map)
+            /// Optimization: if path or its prefix exists in typed paths,
+            /// we can return 1 for all rows since typed paths are always present.
             const auto & typed_paths = object_column.getTypedPaths();
-            if (auto it = typed_paths.find(path); it != typed_paths.end())
-                relevant_columns.push_back(it->second.get());
-
-            for (const auto & [key, col] : typed_paths)
+            bool found_in_typed = typed_paths.contains(path);
+            if (!found_in_typed)
             {
-                if (std::string_view(key).starts_with(prefix))
-                    relevant_columns.push_back(col.get());
+                for (const auto & [key, col] : typed_paths)
+                {
+                    if (key.starts_with(prefix))
+                    {
+                        found_in_typed = true;
+                        break;
+                    }
+                }
             }
 
-            // Collect exact and prefix matches from Dynamic Paths
+            if (found_in_typed)
+            {
+                /// Path exists in typed paths - return 1 for all rows
+                std::fill(res_data.begin(), res_data.end(), 1);
+                return res_col;
+            }
+
+            /// Collect columns from dynamic paths that match exact path or prefix.
+            /// These columns need to be checked for non-null values per row.
+            std::vector<const IColumn *> relevant_dynamic_columns;
             const auto & dynamic_paths = object_column.getDynamicPathsPtrs();
+
             if (auto it = dynamic_paths.find(path); it != dynamic_paths.end())
-                relevant_columns.push_back(it->second);
+                relevant_dynamic_columns.push_back(it->second);
 
             for (const auto & [key, col] : dynamic_paths)
             {
-                if (std::string_view(key).starts_with(prefix))
-                    relevant_columns.push_back(col);
+                if (key.starts_with(prefix))
+                    relevant_dynamic_columns.push_back(col);
             }
 
             for (size_t i = 0; i < input_rows_count; ++i)
             {
                 bool found = false;
-                for (const auto * col : relevant_columns)
+
+                /// Check dynamic paths - need to verify non-null for each row
+                for (const auto * col : relevant_dynamic_columns)
                 {
                     if (!col->isNullAt(i))
                     {
@@ -1009,65 +1087,23 @@ private:
                     }
                 }
 
+                /// Check shared data if not found in dynamic paths
                 if (!found)
-                    found = check_shared(i, path);
-
+                {
+                    found = hasPathInSharedData(path, prefix, shared_paths, shared_offsets, i);
+                }
                 res_data[i] = found;
             }
         }
         else
         {
-            // Non-const path: Use efficient per-row lookup
-
+            /// Non-constant path: check each row individually
             for (size_t i = 0; i < input_rows_count; ++i)
             {
-                const String path = String(path_column.getDataAt(i));
+                const String path(path_column.getDataAt(i));
+                const String prefix = path + ".";
 
-                String prefix = path + ".";
-                bool found = false;
-
-                // Typed
-                const auto & typed_paths = object_column.getTypedPaths();
-                if (auto it = typed_paths.find(path); it != typed_paths.end() && !it->second->isNullAt(i))
-                    found = true;
-
-                if (!found)
-                {
-                    for (const auto & [key, col] : typed_paths)
-                    {
-                        if (std::string_view(key).starts_with(prefix) && !col->isNullAt(i))
-                        {
-                            found = true;
-                            break;
-                        }
-                    }
-                }
-
-                // Dynamic
-                if (!found)
-                {
-                    const auto & dynamic_paths = object_column.getDynamicPathsPtrs();
-                    if (auto it = dynamic_paths.find(path); it != dynamic_paths.end() && !it->second->isNullAt(i))
-                        found = true;
-
-                    if (!found)
-                    {
-                        for (const auto & [key, col] : dynamic_paths)
-                        {
-                            if (std::string_view(key).starts_with(prefix) && !col->isNullAt(i))
-                            {
-                                found = true;
-                                break;
-                            }
-                        }
-                    }
-                }
-
-                // Shared
-                if (!found)
-                    found = check_shared(i, path);
-
-                res_data[i] = found;
+                res_data[i] = hasPathInObjectRow(object_column, i, path, prefix, shared_paths, shared_offsets);
             }
         }
 

--- a/src/Functions/array/arrayIndex.h
+++ b/src/Functions/array/arrayIndex.h
@@ -11,6 +11,8 @@
 #include <DataTypes/getLeastSupertype.h>
 #include <Columns/ColumnArray.h>
 #include <Columns/ColumnMap.h>
+#include <Columns/ColumnObject.h>
+#include <Columns/ColumnDynamic.h>
 #include <Columns/ColumnString.h>
 #include <Columns/ColumnFixedString.h>
 #include <Columns/ColumnsNumber.h>
@@ -21,6 +23,7 @@
 #include <Common/assert_cast.h>
 #include <Columns/ColumnLowCardinality.h>
 #include <DataTypes/DataTypeLowCardinality.h>
+#include <DataTypes/DataTypeObject.h>
 #include <Interpreters/castColumn.h>
 
 
@@ -513,17 +516,28 @@ public:
 
         const DataTypeArray * array_type = checkAndGetDataType<DataTypeArray>(first_argument_type.get());
         const DataTypeMap * map_type = checkAndGetDataType<DataTypeMap>(first_argument_type.get());
+        const DataTypeObject * object_type = checkAndGetDataType<DataTypeObject>(first_argument_type.get());
 
         DataTypePtr inner_type;
 
         /// If map is first argument only has(map_column, key) function is supported
         if constexpr (std::is_same_v<ConcreteAction, HasAction>)
         {
-            if (!array_type && !map_type)
+            if (!array_type && !map_type && !object_type)
                 throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
-                    "First argument for function {} must be an array or map. Actual {}",
+                    "First argument for function {} must be an array, map or object. Actual {}",
                     getName(),
                     first_argument_type->getName());
+
+            if (object_type)
+            {
+                if (!isStringOrFixedString(second_argument_type))
+                    throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
+                        "Second argument for function {} must be String when the first argument is Object. Actual {}",
+                        getName(), second_argument_type->getName());
+
+                return std::make_shared<DataTypeUInt8>();
+            }
 
             inner_type = map_type ? map_type->getKeyType() : array_type->getNestedType();
         }
@@ -556,6 +570,9 @@ public:
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t /*input_rows_count*/) const override
     {
         if (auto res = executeMap(arguments, result_type))
+            return res;
+
+        if (auto res = executeObject(arguments, result_type))
             return res;
 
         if (auto res = executeArrayLowCardinality(arguments))
@@ -899,6 +916,162 @@ private:
         arguments_copy[0].name = arguments[0].name;
 
         return executeArrayImpl(arguments_copy, result_type);
+    }
+
+    ColumnPtr executeObject(const ColumnsWithTypeAndName & arguments, const DataTypePtr & /*result_type*/) const
+    {
+        if constexpr (!std::is_same_v<ConcreteAction, HasAction>)
+            return nullptr;
+
+        const auto * object_type = checkAndGetDataType<DataTypeObject>(arguments[0].type.get());
+        if (!object_type)
+            return nullptr;
+
+        auto non_const_object_column = arguments[0].column->convertToFullColumnIfConst();
+        const auto & object_column = assert_cast<const ColumnObject &>(*non_const_object_column);
+        const auto & path_column = *arguments[1].column;
+        const size_t input_rows_count = object_column.size();
+
+        if (input_rows_count == 0)
+            return ColumnUInt8::create();
+
+        auto res_col = ColumnUInt8::create(input_rows_count);
+        auto & res_data = res_col->getData();
+
+        const auto [shared_paths, shared_values] = object_column.getSharedDataPathsAndValues();
+        const auto & shared_offsets = object_column.getSharedDataOffsets();
+
+        auto check_shared = [&](size_t row, const String & path) -> bool
+        {
+            if (!shared_paths)
+                return false;
+
+            size_t start = (row == 0) ? 0 : shared_offsets[row - 1];
+            size_t end = shared_offsets[row];
+            if (start >= end)
+                return false;
+
+            // 1. Exact match
+            size_t pos = ColumnObject::findPathLowerBoundInSharedData(path, *shared_paths, start, end);
+            if (pos < end && shared_paths->getDataAt(pos) == path)
+                return true;
+
+            // 2. Prefix match (path + ".")
+            String prefix = path + ".";
+            pos = ColumnObject::findPathLowerBoundInSharedData(prefix, *shared_paths, start, end);
+            if (pos < end)
+            {
+                auto s = shared_paths->getDataAt(pos);
+                if (std::string_view(s).starts_with(prefix))
+                    return true;
+            }
+            return false;
+        };
+
+        if (isColumnConst(path_column))
+        {
+            const String path = String(path_column.getDataAt(0));
+            String prefix = path + ".";
+
+            std::vector<const IColumn *> relevant_columns;
+
+            // Collect exact and prefix matches from Typed Paths (O(N_paths) scan due to unordered_map)
+            const auto & typed_paths = object_column.getTypedPaths();
+            if (auto it = typed_paths.find(path); it != typed_paths.end())
+                relevant_columns.push_back(it->second.get());
+
+            for (const auto & [key, col] : typed_paths)
+            {
+                if (std::string_view(key).starts_with(prefix))
+                    relevant_columns.push_back(col.get());
+            }
+
+            // Collect exact and prefix matches from Dynamic Paths
+            const auto & dynamic_paths = object_column.getDynamicPathsPtrs();
+            if (auto it = dynamic_paths.find(path); it != dynamic_paths.end())
+                relevant_columns.push_back(it->second);
+
+            for (const auto & [key, col] : dynamic_paths)
+            {
+                if (std::string_view(key).starts_with(prefix))
+                    relevant_columns.push_back(col);
+            }
+
+            for (size_t i = 0; i < input_rows_count; ++i)
+            {
+                bool found = false;
+                for (const auto * col : relevant_columns)
+                {
+                    if (!col->isNullAt(i))
+                    {
+                        found = true;
+                        break;
+                    }
+                }
+
+                if (!found)
+                    found = check_shared(i, path);
+
+                res_data[i] = found;
+            }
+        }
+        else
+        {
+            // Non-const path: Use efficient per-row lookup
+
+            for (size_t i = 0; i < input_rows_count; ++i)
+            {
+                const String path = String(path_column.getDataAt(i));
+
+                String prefix = path + ".";
+                bool found = false;
+
+                // Typed
+                const auto & typed_paths = object_column.getTypedPaths();
+                if (auto it = typed_paths.find(path); it != typed_paths.end() && !it->second->isNullAt(i))
+                    found = true;
+
+                if (!found)
+                {
+                    for (const auto & [key, col] : typed_paths)
+                    {
+                        if (std::string_view(key).starts_with(prefix) && !col->isNullAt(i))
+                        {
+                            found = true;
+                            break;
+                        }
+                    }
+                }
+
+                // Dynamic
+                if (!found)
+                {
+                    const auto & dynamic_paths = object_column.getDynamicPathsPtrs();
+                    if (auto it = dynamic_paths.find(path); it != dynamic_paths.end() && !it->second->isNullAt(i))
+                        found = true;
+
+                    if (!found)
+                    {
+                        for (const auto & [key, col] : dynamic_paths)
+                        {
+                            if (std::string_view(key).starts_with(prefix) && !col->isNullAt(i))
+                            {
+                                found = true;
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                // Shared
+                if (!found)
+                    found = check_shared(i, path);
+
+                res_data[i] = found;
+            }
+        }
+
+        return res_col;
     }
 
     static ColumnPtr executeString(const ColumnsWithTypeAndName & arguments)

--- a/src/Functions/array/has.cpp
+++ b/src/Functions/array/has.cpp
@@ -6,28 +6,31 @@ namespace DB
 {
 struct NameHas { static constexpr auto name = "has"; };
 
-/// has(arr, x) - whether there is an element x in the array.
+/// has(arr, x) - whether there is an element x in the array, map, or JSON.
 using FunctionHas = FunctionArrayIndex<HasAction, NameHas>;
 
 REGISTER_FUNCTION(Has)
 {
     FunctionDocumentation::Description description
-        = "Returns whether the array contains the specified element.\n\n"
+        = "Returns whether the array contains the specified element, the map contains the specified key, or the JSON object contains the specified path.\n\n"
+          "For JSON, nested paths are supported using dot notation (e.g., 'a.b.c').\n\n"
           "When the first argument is a constant array and the second argument is a column or expression, "
           "`has(constant_array, column)` behaves like `column IN (constant_array)` and can use primary key "
           "and data-skipping indexes for optimization. For example, `has([1, 10, 100], id)` can leverage "
           "the primary key index if `id` is part of the `PRIMARY KEY`.\n\n"
           "This optimization also applies when the column is wrapped in monotonic functions (e.g., `has([...], toDate(ts))`).";
 
-    FunctionDocumentation::Syntax syntax = "has(arr, x)";
+    FunctionDocumentation::Syntax syntax = "has(haystack, needle)";
     FunctionDocumentation::Arguments arguments = {
-        {"arr", "The source array.", {"Array(T)"}},
-        {"x", "The value to search for in the array."}
+        {"haystack", "The source array, map, or JSON.", {"Array", "Map", "JSON"}},
+        {"needle", "The value to search for (element in array, key in map, or path string in JSON)."}
     };
-    FunctionDocumentation::ReturnedValue returned_value = {"Returns `1` if the array contains the specified element, otherwise `0`.", {"UInt8"}};
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns `1` if the haystack contains the specified needle, otherwise `0`.", {"UInt8"}};
     FunctionDocumentation::Examples examples = {
-        {"Basic usage", "SELECT has([1, 2, 3], 2)", "1"},
-        {"Not found", "SELECT has([1, 2, 3], 4)", "0"}
+        {"Array basic usage", "SELECT has([1, 2, 3], 2)", "1"},
+        {"Array not found", "SELECT has([1, 2, 3], 4)", "0"},
+        {"Map basic usage", "SELECT has(map('a', 1, 'b', 2), 'b')", "1"},
+        {"JSON path", R"(SELECT has('{"a": {"b": 1}}'::JSON, 'a.b'))", "1"}
     };
     FunctionDocumentation::IntroducedIn introduced_in = {1, 1};
     FunctionDocumentation::Category category = FunctionDocumentation::Category::Array;

--- a/tests/queries/0_stateless/03435_json_has.reference
+++ b/tests/queries/0_stateless/03435_json_has.reference
@@ -1,0 +1,58 @@
+-- Basic path existence
+1	1
+2	1
+3	0
+-- Nested path with dot notation
+1	1
+2	0
+3	0
+1	1
+2	0
+3	0
+-- Non-existent paths
+1	0
+2	0
+3	0
+1	0
+2	0
+3	0
+1	0
+2	0
+3	0
+-- NULL value handling (path exists but value is null)
+1	0
+2	1
+3	0
+-- Constant JSON expressions
+1
+0
+1
+1
+0
+0
+-- Empty string key
+1	1
+-- Array values
+2	1
+4	1
+-- Empty nested object
+3	0
+-- MergeTree engine test
+1	1
+2	1
+3	0
+1	1
+2	0
+3	0
+1	0
+2	0
+3	1
+-- Variable path column
+1	a	1
+2	b	1
+3	c	0
+-- Special characters in keys
+1
+1
+1
+1

--- a/tests/queries/0_stateless/03435_json_has.reference
+++ b/tests/queries/0_stateless/03435_json_has.reference
@@ -56,3 +56,72 @@
 1
 1
 1
+-- Typed paths with constant path argument
+1	1
+2	1
+3	1
+1	1
+2	1
+3	1
+1	1
+2	1
+3	1
+1	0
+2	0
+3	0
+-- Typed paths with variable path argument
+1	x	1
+2	y.z	1
+3	y	1
+4	missing	0
+-- Shared data paths with constant path argument
+1	1
+2	1
+3	0
+1	1
+2	0
+3	0
+1	1
+2	0
+3	0
+1	1
+2	0
+3	0
+1	0
+2	1
+3	0
+1	0
+2	0
+3	1
+1	0
+2	0
+3	0
+-- Shared data paths with variable path argument
+1	a	1
+2	b.c	1
+3	b	0
+4	d	1
+5	missing	0
+-- Mixed: typed paths, dynamic paths, and shared data
+1	1
+2	1
+3	1
+1	1
+2	0
+3	0
+1	1
+2	0
+3	0
+1	0
+2	1
+3	0
+1	0
+2	0
+3	0
+-- Deeply nested paths
+1
+1
+1
+1
+1
+0

--- a/tests/queries/0_stateless/03435_json_has.sql
+++ b/tests/queries/0_stateless/03435_json_has.sql
@@ -1,0 +1,116 @@
+-- Test has() function for JSON/Object type
+SET allow_experimental_object_type = 1;
+SET allow_experimental_json_type = 1;
+
+-- ============================================
+-- Test 1: Basic functionality with Memory engine
+-- ============================================
+DROP TABLE IF EXISTS t_json_has;
+CREATE TABLE t_json_has (id UInt64, j JSON) ENGINE = Memory;
+
+INSERT INTO t_json_has VALUES (1, '{"hello": 123, "world": {"param": 456}}');
+INSERT INTO t_json_has VALUES (2, '{"hello": 456}');
+INSERT INTO t_json_has VALUES (3, '{}');
+
+SELECT '-- Basic path existence';
+SELECT id, has(j, 'hello') FROM t_json_has ORDER BY id;
+
+SELECT '-- Nested path with dot notation';
+SELECT id, has(j, 'world.param') FROM t_json_has ORDER BY id;
+SELECT id, has(j, 'world') FROM t_json_has ORDER BY id;
+
+SELECT '-- Non-existent paths';
+SELECT id, has(j, 'missing') FROM t_json_has ORDER BY id;
+SELECT id, has(j, 'world.missing') FROM t_json_has ORDER BY id;
+SELECT id, has(j, 'hello.nested') FROM t_json_has ORDER BY id;
+
+DROP TABLE t_json_has;
+
+-- ============================================
+-- Test 2: NULL value handling
+-- ============================================
+DROP TABLE IF EXISTS t_json_null;
+CREATE TABLE t_json_null (id UInt64, j JSON) ENGINE = Memory;
+
+INSERT INTO t_json_null VALUES (1, '{"a": null}');
+INSERT INTO t_json_null VALUES (2, '{"a": 1}');
+INSERT INTO t_json_null VALUES (3, '{"b": 2}');
+
+SELECT '-- NULL value handling (path exists but value is null)';
+SELECT id, has(j, 'a') FROM t_json_null ORDER BY id;
+
+DROP TABLE t_json_null;
+
+-- ============================================
+-- Test 3: Constant JSON expressions
+-- ============================================
+SELECT '-- Constant JSON expressions';
+SELECT has('{"hello": 123}'::JSON, 'hello');
+SELECT has('{"hello": 123}'::JSON, 'world');
+SELECT has('{"a": {"b": {"c": 1}}}'::JSON, 'a.b.c');
+SELECT has('{"a": {"b": {"c": 1}}}'::JSON, 'a.b');
+SELECT has('{"a": {"b": {"c": 1}}}'::JSON, 'a.b.d');
+SELECT has('{}'::JSON, 'anything');
+
+-- ============================================
+-- Test 4: Edge cases
+-- ============================================
+DROP TABLE IF EXISTS t_json_edge;
+CREATE TABLE t_json_edge (id UInt64, j JSON) ENGINE = Memory;
+
+INSERT INTO t_json_edge VALUES (1, '{"": 1}');
+INSERT INTO t_json_edge VALUES (2, '{"a": [1, 2, 3]}');
+INSERT INTO t_json_edge VALUES (3, '{"a": {}}');
+INSERT INTO t_json_edge VALUES (4, '{"a": []}');
+
+SELECT '-- Empty string key';
+SELECT id, has(j, '') FROM t_json_edge WHERE id = 1;
+
+SELECT '-- Array values';
+SELECT id, has(j, 'a') FROM t_json_edge WHERE id IN (2, 4) ORDER BY id;
+
+SELECT '-- Empty nested object';
+SELECT id, has(j, 'a') FROM t_json_edge WHERE id = 3;
+
+DROP TABLE t_json_edge;
+
+-- ============================================
+-- Test 5: MergeTree engine (for subcolumn optimization)
+-- ============================================
+DROP TABLE IF EXISTS t_json_mt;
+CREATE TABLE t_json_mt (id UInt64, j JSON) ENGINE = MergeTree ORDER BY id;
+
+INSERT INTO t_json_mt VALUES (1, '{"x": 1, "y": {"z": 2}}');
+INSERT INTO t_json_mt VALUES (2, '{"x": 2}');
+INSERT INTO t_json_mt VALUES (3, '{"w": 3}');
+
+SELECT '-- MergeTree engine test';
+SELECT id, has(j, 'x') FROM t_json_mt ORDER BY id SETTINGS allow_experimental_parallel_reading_from_replicas=0;
+SELECT id, has(j, 'y.z') FROM t_json_mt ORDER BY id SETTINGS allow_experimental_parallel_reading_from_replicas=0;
+SELECT id, has(j, 'w') FROM t_json_mt ORDER BY id SETTINGS allow_experimental_parallel_reading_from_replicas=0;
+
+DROP TABLE t_json_mt;
+
+-- ============================================
+-- Test 6: Variable path (non-constant second argument)
+-- ============================================
+DROP TABLE IF EXISTS t_json_var_path;
+CREATE TABLE t_json_var_path (id UInt64, j JSON, path String) ENGINE = Memory;
+
+INSERT INTO t_json_var_path VALUES (1, '{"a": 1, "b": 2}', 'a');
+INSERT INTO t_json_var_path VALUES (2, '{"a": 1, "b": 2}', 'b');
+INSERT INTO t_json_var_path VALUES (3, '{"a": 1, "b": 2}', 'c');
+
+SELECT '-- Variable path column';
+SELECT id, path, has(j, path) FROM t_json_var_path ORDER BY id;
+
+DROP TABLE t_json_var_path;
+
+-- ============================================
+-- Test 7: Special characters in paths
+-- ============================================
+SELECT '-- Special characters in keys';
+SELECT has('{"key-with-dash": 1}'::JSON, 'key-with-dash');
+SELECT has('{"key_with_underscore": 1}'::JSON, 'key_with_underscore');
+SELECT has('{"key.with.dots": 1}'::JSON, 'key.with.dots');  -- This may be tricky!
+SELECT has('{"123numeric": 1}'::JSON, '123numeric');

--- a/tests/queries/0_stateless/03435_json_has.sql
+++ b/tests/queries/0_stateless/03435_json_has.sql
@@ -1,6 +1,4 @@
--- Test has() function for JSON/Object type
-SET allow_experimental_object_type = 1;
-SET allow_experimental_json_type = 1;
+-- Test has() function for JSON type
 
 -- ============================================
 -- Test 1: Basic functionality with Memory engine
@@ -75,7 +73,7 @@ SELECT id, has(j, 'a') FROM t_json_edge WHERE id = 3;
 DROP TABLE t_json_edge;
 
 -- ============================================
--- Test 5: MergeTree engine (for subcolumn optimization)
+-- Test 5: MergeTree engine
 -- ============================================
 DROP TABLE IF EXISTS t_json_mt;
 CREATE TABLE t_json_mt (id UInt64, j JSON) ENGINE = MergeTree ORDER BY id;
@@ -85,9 +83,9 @@ INSERT INTO t_json_mt VALUES (2, '{"x": 2}');
 INSERT INTO t_json_mt VALUES (3, '{"w": 3}');
 
 SELECT '-- MergeTree engine test';
-SELECT id, has(j, 'x') FROM t_json_mt ORDER BY id SETTINGS allow_experimental_parallel_reading_from_replicas=0;
-SELECT id, has(j, 'y.z') FROM t_json_mt ORDER BY id SETTINGS allow_experimental_parallel_reading_from_replicas=0;
-SELECT id, has(j, 'w') FROM t_json_mt ORDER BY id SETTINGS allow_experimental_parallel_reading_from_replicas=0;
+SELECT id, has(j, 'x') FROM t_json_mt ORDER BY id;
+SELECT id, has(j, 'y.z') FROM t_json_mt ORDER BY id;
+SELECT id, has(j, 'w') FROM t_json_mt ORDER BY id;
 
 DROP TABLE t_json_mt;
 
@@ -112,5 +110,108 @@ DROP TABLE t_json_var_path;
 SELECT '-- Special characters in keys';
 SELECT has('{"key-with-dash": 1}'::JSON, 'key-with-dash');
 SELECT has('{"key_with_underscore": 1}'::JSON, 'key_with_underscore');
-SELECT has('{"key.with.dots": 1}'::JSON, 'key.with.dots');  -- This may be tricky!
+SELECT has('{"key.with" : {"dots": 1}}'::JSON, 'key.with.dots');
 SELECT has('{"123numeric": 1}'::JSON, '123numeric');
+
+-- ============================================
+-- Test 8: JSON with typed paths (constant second argument)
+-- ============================================
+DROP TABLE IF EXISTS t_json_typed;
+CREATE TABLE t_json_typed (id UInt64, j JSON(a UInt32, b.c Nullable(String))) ENGINE = Memory;
+
+INSERT INTO t_json_typed VALUES (1, '{"a": 1, "b": {"c": "hello"}}');
+INSERT INTO t_json_typed VALUES (2, '{"a": 2}');
+INSERT INTO t_json_typed VALUES (3, '{}');
+
+SELECT '-- Typed paths with constant path argument';
+-- Typed paths are always considered present (even if value is default/null)
+SELECT id, has(j, 'a') FROM t_json_typed ORDER BY id;
+SELECT id, has(j, 'b.c') FROM t_json_typed ORDER BY id;
+SELECT id, has(j, 'b') FROM t_json_typed ORDER BY id;
+SELECT id, has(j, 'missing') FROM t_json_typed ORDER BY id;
+
+DROP TABLE t_json_typed;
+
+-- ============================================
+-- Test 9: JSON with typed paths (non-constant second argument)
+-- ============================================
+DROP TABLE IF EXISTS t_json_typed_var;
+CREATE TABLE t_json_typed_var (id UInt64, j JSON(x UInt32, y.z Nullable(UInt32)), path String) ENGINE = Memory;
+
+INSERT INTO t_json_typed_var VALUES (1, '{"x": 1, "y": {"z": 2}}', 'x');
+INSERT INTO t_json_typed_var VALUES (2, '{"x": 2}', 'y.z');
+INSERT INTO t_json_typed_var VALUES (3, '{}', 'y');
+INSERT INTO t_json_typed_var VALUES (4, '{"x": 4}', 'missing');
+
+SELECT '-- Typed paths with variable path argument';
+SELECT id, path, has(j, path) FROM t_json_typed_var ORDER BY id;
+
+DROP TABLE t_json_typed_var;
+
+-- ============================================
+-- Test 10: JSON with paths in shared data (max_dynamic_paths=0)
+-- ============================================
+DROP TABLE IF EXISTS t_json_shared;
+CREATE TABLE t_json_shared (id UInt64, j JSON(max_dynamic_paths=0)) ENGINE = Memory;
+
+INSERT INTO t_json_shared VALUES (1, '{"a": 1, "b": {"c": 2}, "d": 3}');
+INSERT INTO t_json_shared VALUES (2, '{"a": 2, "e": 4}');
+INSERT INTO t_json_shared VALUES (3, '{"f": 5}');
+
+SELECT '-- Shared data paths with constant path argument';
+SELECT id, has(j, 'a') FROM t_json_shared ORDER BY id;
+SELECT id, has(j, 'b.c') FROM t_json_shared ORDER BY id;
+SELECT id, has(j, 'b') FROM t_json_shared ORDER BY id;
+SELECT id, has(j, 'd') FROM t_json_shared ORDER BY id;
+SELECT id, has(j, 'e') FROM t_json_shared ORDER BY id;
+SELECT id, has(j, 'f') FROM t_json_shared ORDER BY id;
+SELECT id, has(j, 'missing') FROM t_json_shared ORDER BY id;
+
+DROP TABLE t_json_shared;
+
+-- ============================================
+-- Test 11: JSON with paths in shared data (non-constant second argument)
+-- ============================================
+DROP TABLE IF EXISTS t_json_shared_var;
+CREATE TABLE t_json_shared_var (id UInt64, j JSON(max_dynamic_paths=0), path String) ENGINE = Memory;
+
+INSERT INTO t_json_shared_var VALUES (1, '{"a": 1, "b": {"c": 2}}', 'a');
+INSERT INTO t_json_shared_var VALUES (2, '{"a": 2, "b": {"c": 3}}', 'b.c');
+INSERT INTO t_json_shared_var VALUES (3, '{"a": 3}', 'b');
+INSERT INTO t_json_shared_var VALUES (4, '{"d": 4}', 'd');
+INSERT INTO t_json_shared_var VALUES (5, '{}', 'missing');
+
+SELECT '-- Shared data paths with variable path argument';
+SELECT id, path, has(j, path) FROM t_json_shared_var ORDER BY id;
+
+DROP TABLE t_json_shared_var;
+
+-- ============================================
+-- Test 12: Mixed typed paths and shared data
+-- ============================================
+DROP TABLE IF EXISTS t_json_mixed;
+CREATE TABLE t_json_mixed (id UInt64, j JSON(typed_field UInt32, max_dynamic_paths=1)) ENGINE = Memory;
+
+INSERT INTO t_json_mixed VALUES (1, '{"typed_field": 1, "dynamic_field": 2, "shared_field": 3}');
+INSERT INTO t_json_mixed VALUES (2, '{"typed_field": 2, "other_shared": 4}');
+INSERT INTO t_json_mixed VALUES (3, '{}');
+
+SELECT '-- Mixed: typed paths, dynamic paths, and shared data';
+SELECT id, has(j, 'typed_field') FROM t_json_mixed ORDER BY id;
+SELECT id, has(j, 'dynamic_field') FROM t_json_mixed ORDER BY id;
+SELECT id, has(j, 'shared_field') FROM t_json_mixed ORDER BY id;
+SELECT id, has(j, 'other_shared') FROM t_json_mixed ORDER BY id;
+SELECT id, has(j, 'missing') FROM t_json_mixed ORDER BY id;
+
+DROP TABLE t_json_mixed;
+
+-- ============================================
+-- Test 13: Deeply nested paths
+-- ============================================
+SELECT '-- Deeply nested paths';
+SELECT has('{"a": {"b": {"c": {"d": {"e": 1}}}}}'::JSON, 'a.b.c.d.e');
+SELECT has('{"a": {"b": {"c": {"d": {"e": 1}}}}}'::JSON, 'a.b.c.d');
+SELECT has('{"a": {"b": {"c": {"d": {"e": 1}}}}}'::JSON, 'a.b.c');
+SELECT has('{"a": {"b": {"c": {"d": {"e": 1}}}}}'::JSON, 'a.b');
+SELECT has('{"a": {"b": {"c": {"d": {"e": 1}}}}}'::JSON, 'a');
+SELECT has('{"a": {"b": {"c": {"d": {"e": 1}}}}}'::JSON, 'a.b.c.d.e.f');


### PR DESCRIPTION
Closes #96780

### Changelog category:
- New Feature

### Changelog entry:
Support `has()` function for JSON type to check path existence, similar to Map.

---

### Summary

Extends `has(json, path)` to return 1 if the path exists in JSON data, 0 otherwise.
```sql
SELECT has('{"hello":123}'::JSON, 'hello');           -- 1
SELECT has('{"a":{"b":1}}'::JSON, 'a.b');             -- 1
SELECT has('{"a":{"b":1}}'::JSON, 'a');               -- 1 (has nested children)
SELECT has('{"hello":123}'::JSON, 'missing');         -- 0
```

### Implementation

- Checks typed paths → dynamic paths → shared data (with early exit)
- Supports dot-notation for nested paths
- Prefix matching for intermediate objects (e.g., `'a'` matches when `'a.b'` exists)
- Optimizes constant path by pre-collecting relevant columns

### Testing

Added `03435_json_has.sql` covering basic paths, nested paths, NULL handling, empty objects, MergeTree engine, and variable path columns.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.350`
<!-- ch-version-info:end -->