### PR TITLE
Disable test 03781 under MSan and TSan

### DIFF
--- a/tests/queries/0_stateless/03781_json_max_dynamic_subcolumns_control_on_parsing.sql
+++ b/tests/queries/0_stateless/03781_json_max_dynamic_subcolumns_control_on_parsing.sql
@@ -1,3 +1,5 @@
+-- Tags: no-msan, no-tsan
+
 drop table if exists test;
 create table test (json JSON) engine=MergeTree order by tuple();
 insert into test select toJSONString(arrayMap(x -> tuple('a' || x, x), range(20))::Map(String, UInt32)) from numbers(1000000) settings max_dynamic_subcolumns_in_json_type_parsing=10;


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or improvement (CI only)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
- Not for changelog.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

## Summary
Test `03781_json_max_dynamic_subcolumns_control_on_parsing` inserts 1M rows of complex JSON data (20 keys per row), which is too slow under MSan and TSan, causing timeouts in CI.

Added `no-msan` and `no-tsan` tags, consistent with other heavy JSON tests (`03554`, `03555`, `03207`, `03208`).

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96870&sha=130a2363e698f758c4d584fe6ba6c0ffdc9c0a95&name_0=PR&name_1=Stateless%20tests%20%28amd_msan%2C%20parallel%2C%201%2F2%29
https://github.com/ClickHouse/ClickHouse/pull/96870

## Test plan
- [x] Verify the test still runs on non-sanitizer builds
- [x] Verify it is skipped under MSan/TSan

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.714`
<!-- ch-version-info:end -->