### PR TITLE
Fix clickhouse-test hanging for hours after server death

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -3868,6 +3868,14 @@ def do_run_tests(
                 for p in processes:
                     if p.is_alive():
                         p.terminate()
+                # Wait for processes to exit, then force-kill stragglers
+                for p in processes:
+                    p.join(timeout=10)
+                    if p.is_alive():
+                        print(f"Force killing process {p.name} (pid {p.pid})")
+                        p.kill()
+                for p in processes:
+                    p.join(timeout=5)
                 break
 
             for p in processes[:]:


### PR DESCRIPTION
## Summary

- When the ClickHouse server dies during parallel stateless tests, the `clickhouse-test` main process hangs indefinitely because `p.terminate()` is called on worker processes but `p.join()` is never called
- Python's `multiprocessing.Manager` cleanup then hangs at `sys.exit()` waiting for child process connections to finalize
- Add `join(timeout=10)` after `terminate()`, followed by `kill()` for stragglers, to ensure all workers are fully reaped

## Test plan

- [x] Verified `clickhouse-test` still works correctly by running `00001_select_1`
- [ ] The fix path is only exercised when the server dies during parallel execution — the logic is straightforward: join after terminate, kill if still alive

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.718`
<!-- ch-version-info:end -->