### PR TITLE
Fix flaky test `03249_dynamic_alter_consistency` timeout on MSan

### DIFF
--- a/tests/queries/0_stateless/03249_dynamic_alter_consistency.reference
+++ b/tests/queries/0_stateless/03249_dynamic_alter_consistency.reference
@@ -1,2 +1,2 @@
-400000	String	true
-600000	UInt64	false
+40000	String	true
+60000	UInt64	false

--- a/tests/queries/0_stateless/03249_dynamic_alter_consistency.sql
+++ b/tests/queries/0_stateless/03249_dynamic_alter_consistency.sql
@@ -4,7 +4,7 @@ set allow_experimental_dynamic_type=1;
 
 drop table if exists test;
 create table test (d Dynamic) engine=MergeTree order by tuple() settings min_rows_for_wide_part=1, min_bytes_for_wide_part=1;
-insert into test select number < 600000 ? number::Dynamic : ('str_' || number)::Dynamic from numbers(1000000);
+insert into test select number < 60000 ? number::Dynamic : ('str_' || number)::Dynamic from numbers(100000);
 alter table test modify column d Dynamic(max_types=1);
 select count(), dynamicType(d), isDynamicElementInSharedData(d) from test group by dynamicType(d), isDynamicElementInSharedData(d) order by count();
 drop table test;


### PR DESCRIPTION
## Summary
- Reduced dataset size in `03249_dynamic_alter_consistency` from 1M to 100K rows
- The `ALTER TABLE MODIFY COLUMN d Dynamic(max_types=1)` rewrites all data, which under MSan exceeds the 300-second timeout with 1M rows
- 100K rows still validates the same correctness behavior while running in ~0.4 seconds

Closes #93442

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96863&sha=9434b56df0ebb3c31c7f55dbb631655bedeb070b&name_0=PR&name_1=Stateless%20tests%20%28amd_msan%2C%20parallel%2C%202%2F2%29
https://github.com/ClickHouse/ClickHouse/pull/96863

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.700`
<!-- ch-version-info:end -->