### PR TITLE
Fix upgrade check false positive from kill_mutation test

### DIFF
--- a/tests/docker_scripts/upgrade_runner.sh
+++ b/tests/docker_scripts/upgrade_runner.sh
@@ -305,11 +305,16 @@ cp /var/log/clickhouse-server/clickhouse-server.upgrade.log /test_output/clickho
 
 # Error messages (we should ignore some errors)
 # FIXME https://github.com/ClickHouse/ClickHouse/issues/38643 ("Unknown index: idx.")
-# FIXME https://github.com/ClickHouse/ClickHouse/issues/39174 ("Cannot parse string 'Hello' as UInt64")
 # FIXME Not sure if it's expected, but some tests from stress test may not be finished yet when we restarting server.
 #       Let's just ignore all errors from queries ("} <Error> TCPHandler: Code:", "} <Error> executeQuery: Code:")
 # FIXME https://github.com/ClickHouse/ClickHouse/issues/39197 ("Missing columns: 'v3' while processing query: 'v3, k, v1, v2, p'")
-# FIXME https://github.com/ClickHouse/ClickHouse/issues/39174 - bad mutation does not indicate backward incompatibility
+# FIXME https://github.com/ClickHouse/ClickHouse/issues/39174 - bad mutation does not indicate backward incompatibility:
+#       stress tests may leave behind intentionally-broken mutations that retry after upgrade.
+#       `CANNOT_PARSE_TEXT` errors come from:
+#       - 00834_kill_mutation{,_replicated_zookeeper}: `DELETE WHERE toUInt32(s) = 1` on String data ('a', 'b')
+#       - 01414_mutations_and_errors_zookeeper: `MODIFY COLUMN value UInt64` on String data ('Hello')
+#       `MutateFromLogEntryTask` is also excluded for the same reason, but only catches the first log line;
+#       the wrapping `MergeTreeBackgroundExecutor` line also needs to be excluded.
 # `NO_SUCH_INTERSERVER_IO_ENDPOINT` is expected during upgrades because replicated tables try to fetch parts
 # from replicas that are being restarted and whose interserver endpoints are temporarily unavailable.
 echo "Check for Error messages in server log:"
@@ -341,6 +346,8 @@ rg -Fav -e "Code: 236. DB::Exception: Cancelled merging parts" \
            -e "Cannot parse string 'Hello' as UInt32" \
            -e "Cannot parse string \'Hello\' as UInt32" \
            -e "Cannot parse string \\'Hello\\' as UInt32" \
+           -e "Cannot parse string 'a' as UInt32" \
+           -e "Cannot parse string 'b' as UInt32" \
            -e "} <Error> TCPHandler: Code:" \
            -e "} <Error> executeQuery: Code:" \
            -e "Missing columns: 'v3' while processing query: 'v3, k, v1, v2, p'" \


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

The upgrade check was failing with a false positive because `MergeTreeBackgroundExecutor` error lines from intentionally-broken mutations were not being filtered out.

Each failed mutation produces two `<Error>` log lines:
1. `MutateFromLogEntryTask: ...` — already excluded
2. `MergeTreeBackgroundExecutor: Exception while executing background task ...` — was **not** excluded

The `Cannot parse string 'a'/'b' as UInt32` errors come from test `00834_kill_mutation_replicated_zookeeper`, which issues `DELETE WHERE toUInt32(s) = 1` on String data. When the stress test is interrupted before cleanup, these mutations survive in ZooKeeper and retry after upgrade.

The existing exclusions only covered `Cannot parse string 'Hello'` (from test `01414_mutations_and_errors_zookeeper`), not the `'a'`/`'b'` variants.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96847&sha=36a6cf3caf488dd84af6c7ada4a1ade3c202428c&name_0=PR&name_1=Upgrade%20check%20%28amd_release%29
https://github.com/ClickHouse/ClickHouse/pull/96847

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.716`
<!-- ch-version-info:end -->