### PR TITLE
Fix sporadic ZooKeeper startup hang in integration tests

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -3016,7 +3016,12 @@ class ClickHouseCluster:
         while time.time() - start < timeout:
             try:
                 for node in nodes:
-                    conn = self.get_kazoo_client(node)
+                    # Use low retries/timeout per attempt since the outer loop
+                    # already retries. This avoids kazoo's internal thread join
+                    # hanging indefinitely (a known kazoo bug where
+                    # ConnectionHandler.stop joins the connection thread
+                    # without a timeout).
+                    conn = self.get_kazoo_client(node, timeout=5.0, retries=1)
                     conn.get_children("/")
                     conn.stop()
                 logging.debug("All instances of ZooKeeper started: %s", nodes)
@@ -4101,7 +4106,7 @@ class ClickHouseCluster:
             certfile=self.zookeeper_certfile,
             keyfile=self.zookeeper_keyfile,
         )
-        zk.start()
+        zk.start(timeout=timeout)
         return zk
 
     def run_kazoo_commands_with_retries(


### PR DESCRIPTION
## Summary

- Fix `wait_zookeeper_nodes_to_start` hanging indefinitely when kazoo's `ConnectionHandler.stop` blocks on `_connection_routine.join()` without a timeout
- Use `timeout=5.0, retries=1` per kazoo attempt since the outer loop already retries, bounding worst-case hang to ~10s per attempt
- Pass `timeout` to `zk.start(timeout=timeout)` in `get_kazoo_client` for consistency with the session timeout

The kazoo bug: [`ConnectionHandler.stop`](https://github.com/python-zk/kazoo/blob/master/kazoo/protocol/connection.py) calls `_connection_routine.join()` without a timeout after `connection_stopped.wait(timeout)`, so when `zk.start()` fails and triggers cleanup, the thread join can hang forever.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96718&sha=6e5d03ac02d30848b36176946589a764b088640c&name_0=PR&name_1=Integration%20tests%20%28amd_binary%2C%202%2F5%29
https://github.com/ClickHouse/ClickHouse/pull/96718

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.717`
<!-- ch-version-info:end -->