### PR TITLE
Add no-parallel tag to 03912_encrypted_s3_cache_smoke

### DIFF
--- a/tests/queries/0_stateless/03912_encrypted_s3_cache_smoke.sql
+++ b/tests/queries/0_stateless/03912_encrypted_s3_cache_smoke.sql
@@ -1,4 +1,4 @@
--- Tags: no-fasttest
+-- Tags: no-fasttest, no-parallel
 
 -- Smoke test for encrypted disk over cached S3 storage.
 -- Verifies the `s3_cache_encrypted` disk and storage policy are configured and functional.


### PR DESCRIPTION
## Summary
- Test `03912_encrypted_s3_cache_smoke` runs `SYSTEM DROP FILESYSTEM CACHE 's3_cache'` which clears the shared filesystem cache, causing flaky failures in other parallel tests like `03411_dynamic_resize_filesystem_cache_3`
- The sibling tests (`03912_encrypted_s3_cache_concurrent_reads`, `03912_encrypted_s3_cache_prefetch`) already have `no-parallel`
- CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=a2433534b57319f96b26743c9f0714b64ba91e90&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_debug%2C%20parallel%29&name_1=Stateless%20tests%20%28amd_debug%2C%20parallel%29

## Test plan
- [x] Verified the root cause: `03912` drops `s3_cache` while running in parallel, causing `03411`'s `current_size > 0` check to fail
- [x] Added `no-parallel` tag, consistent with sibling test files

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.697`
<!-- ch-version-info:end -->