### PR TITLE
Suppress expected errors in stdout for race condition tests

### DIFF
--- a/tests/queries/0_stateless/01019_alter_materialized_view_consistent.sh
+++ b/tests/queries/0_stateless/01019_alter_materialized_view_consistent.sh
@@ -38,7 +38,7 @@ function insert_thread() {
         # trigger 50 concurrent inserts at a time
         for _ in {0..50}; do
             # ignore `Possible deadlock avoided. Client should retry`
-            ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}" -d "${INSERT[$RANDOM % 2]}" 2>/dev/null &
+            ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}" -d "${INSERT[$RANDOM % 2]}" &>/dev/null &
         done
         wait
 

--- a/tests/queries/0_stateless/03791_system_parts_race_condition_drop_part.sh
+++ b/tests/queries/0_stateless/03791_system_parts_race_condition_drop_part.sh
@@ -23,7 +23,7 @@ function thread_insert()
     local i=0
     while [ $SECONDS -lt "$TIMELIMIT" ]
     do
-        ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}" -d "INSERT INTO part_race SELECT $i" 2>/dev/null
+        ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}" -d "INSERT INTO part_race SELECT $i" &>/dev/null
         ((i++)) || true
     done
 }
@@ -33,7 +33,7 @@ function thread_drop_partition()
     local TIMELIMIT=$((SECONDS+TIMEOUT))
     while [ $SECONDS -lt "$TIMELIMIT" ]
     do
-        ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}" -d "ALTER TABLE part_race DROP PARTITION ID '$((RANDOM % 10))'" 2>/dev/null
+        ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}" -d "ALTER TABLE part_race DROP PARTITION ID '$((RANDOM % 10))'" &>/dev/null
         sleep 0.0$RANDOM
     done
 }
@@ -43,7 +43,7 @@ function thread_select_parts()
     local TIMELIMIT=$((SECONDS+TIMEOUT))
     while [ $SECONDS -lt "$TIMELIMIT" ]
     do
-        ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}" -d "SELECT name, path FROM system.parts WHERE database = '${CLICKHOUSE_DATABASE}' AND table = 'part_race' FORMAT Null" 2>/dev/null
+        ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}" -d "SELECT name, path FROM system.parts WHERE database = '${CLICKHOUSE_DATABASE}' AND table = 'part_race' FORMAT Null" &>/dev/null
     done
 }
 


### PR DESCRIPTION
## Summary
- Race condition tests use curl to fire concurrent requests at the ClickHouse HTTP API. Some of these tests only redirected stderr (`2>/dev/null`), but ClickHouse returns error messages in the HTTP response body (stdout). On S3 storage, transient `S3_ERROR` (e.g. Access Denied from MinIO) can leak into stdout, causing the test framework to flag "having exception in stdout".
- Changed `2>/dev/null` to `&>/dev/null` for concurrent curl commands in `03791_system_parts_race_condition_drop_part` and `01019_alter_materialized_view_consistent`. All affected commands produce no useful stdout on success (INSERT, ALTER, SELECT FORMAT Null).

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=7483b17981b8fae78e555baf881e0e3b5dcc5cd9&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_binary%2C%20ParallelReplicas%2C%20s3%20storage%2C%20sequential%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.721`
<!-- ch-version-info:end -->