### PR TITLE
Fix hung check in stress test caused by synchronous DELETE on system.session_log

### DIFF
--- a/tests/queries/0_stateless/02835_drop_user_during_session.sh
+++ b/tests/queries/0_stateless/02835_drop_user_during_session.sh
@@ -49,7 +49,7 @@ function wait_for_queries_start()
 }
 
 ${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH LOGS session_log"
-${CLICKHOUSE_CLIENT} -q "DELETE FROM system.session_log WHERE user = '${TEST_USER}'"
+${CLICKHOUSE_CLIENT} -q "DELETE FROM system.session_log WHERE user = '${TEST_USER}' SETTINGS lightweight_deletes_sync = 0"
 
 # DROP USE CASE
 ${CLICKHOUSE_CLIENT} -q "CREATE USER IF NOT EXISTS ${TEST_USER}"


### PR DESCRIPTION
## Summary
- The `DELETE FROM system.session_log` cleanup at the start of test `02835_drop_user_during_session` creates a synchronous lightweight delete mutation. In ASan stress tests, `system.session_log` receives continuous writes from all concurrent sessions, causing the mutation to get stuck in `StorageMergeTree::waitForMutation` for over 12 minutes, triggering the hung check.
- Fix by making the cleanup DELETE non-blocking with `lightweight_deletes_sync = 0`. This is safe because the test user name includes the PID, making collisions extremely unlikely.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96926&sha=724c57e90613f66e2ef897f80a644ba21e98b470&name_0=PR&name_1=Stress%20test%20%28arm_asan%2C%20s3%29
https://github.com/ClickHouse/ClickHouse/pull/96926

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.722`
<!-- ch-version-info:end -->