### PR TITLE
Enable positional arguments for projections in upgrade check

### DIFF
--- a/tests/docker_scripts/upgrade_runner.sh
+++ b/tests/docker_scripts/upgrade_runner.sh
@@ -265,6 +265,8 @@ echo "<clickhouse>
     <profiles>
         <default>
             <compatibility>$old_major_version</compatibility>
+            <!-- Allow loading projections with positional arguments (e.g., GROUP BY 1, 2) created by the old server. -->
+            <enable_positional_arguments_for_projections>1</enable_positional_arguments_for_projections>
         </default>
     </profiles>
 </clickhouse>" > /etc/clickhouse-server/users.d/compatibility.xml


### PR DESCRIPTION
## Summary
- The old server may store projections with unresolved positional arguments (e.g., `GROUP BY 1, 2`) in table metadata
- When the new server loads these during startup, it fails with `NOT_AN_AGGREGATE` because `enable_positional_arguments_for_projections` is `false` by default
- Enable the setting in the upgrade check configuration so old projections can be loaded successfully

The breakage was introduced by:
- #92007 — introduced the `enable_positional_arguments_for_projections` setting (default `false`), which disabled positional argument resolution when loading projections

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96863&sha=9434b56df0ebb3c31c7f55dbb631655bedeb070b&name_0=PR&name_1=Upgrade%20check%20%28amd_release%29
https://github.com/ClickHouse/ClickHouse/pull/96863

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.719`
<!-- ch-version-info:end -->