### PR TITLE
Fix flaky test 03401_normal_projection_with_part_offset timeout under MSan

### DIFF
--- a/tests/queries/0_stateless/03401_normal_projection_with_part_offset.reference
+++ b/tests/queries/0_stateless/03401_normal_projection_with_part_offset.reference
@@ -16,20 +16,20 @@ CREATE TABLE test
 )
 ENGINE = MergeTree
 ORDER BY a
-SETTINGS index_granularity_bytes = 10485760, index_granularity = 8192;
+SETTINGS index_granularity_bytes = 10485760, index_granularity = 8192, merge_max_block_size = 8192;
 -- Insert enough rows so that future projection materialization test will trigger level 1 merge
-INSERT INTO test SELECT number * 3, rand() FROM numbers(360000);
-INSERT INTO test SELECT number * 3 + 1, rand() FROM numbers(360000);
-INSERT INTO test SELECT number * 3 + 2, rand() FROM numbers(360000);
+INSERT INTO test SELECT number * 3, rand() FROM numbers(10000);
+INSERT INTO test SELECT number * 3 + 1, rand() FROM numbers(10000);
+INSERT INTO test SELECT number * 3 + 2, rand() FROM numbers(10000);
 SELECT sum(l._part_offset = r._parent_part_offset) FROM test l JOIN mergeTreeProjection(currentDatabase(), test, p) r USING (a) SETTINGS enable_analyzer = 1;
-1080000
+30000
 OPTIMIZE TABLE test FINAL;
 SELECT sum(l._part_offset = r._parent_part_offset) FROM test l JOIN mergeTreeProjection(currentDatabase(), test, p) r USING (a) SETTINGS enable_analyzer = 1;
-1080000
+30000
 ALTER TABLE test ADD PROJECTION p2 (SELECT a, b, _part_offset ORDER BY b);
 ALTER TABLE test MATERIALIZE PROJECTION p2 SETTINGS mutations_sync = 2;
 SELECT sum(l._part_offset = r._parent_part_offset) FROM test l JOIN mergeTreeProjection(currentDatabase(), test, p2) r USING (a) SETTINGS enable_analyzer = 1;
-1080000
+30000
 -- Cannot add physical _part_offset, _part_index and _parent_part_offset when there exists projection that refers to its parent `_part_offset`.
 ALTER TABLE test ADD COLUMN _part_offset int; -- { serverError BAD_ARGUMENTS }
 ALTER TABLE test ADD COLUMN _part_index int; -- { serverError BAD_ARGUMENTS }

--- a/tests/queries/0_stateless/03401_normal_projection_with_part_offset.sql
+++ b/tests/queries/0_stateless/03401_normal_projection_with_part_offset.sql
@@ -17,12 +17,12 @@ CREATE TABLE test
 )
 ENGINE = MergeTree
 ORDER BY a
-SETTINGS index_granularity_bytes = 10485760, index_granularity = 8192;
+SETTINGS index_granularity_bytes = 10485760, index_granularity = 8192, merge_max_block_size = 8192;
 
 -- Insert enough rows so that future projection materialization test will trigger level 1 merge
-INSERT INTO test SELECT number * 3, rand() FROM numbers(360000);
-INSERT INTO test SELECT number * 3 + 1, rand() FROM numbers(360000);
-INSERT INTO test SELECT number * 3 + 2, rand() FROM numbers(360000);
+INSERT INTO test SELECT number * 3, rand() FROM numbers(10000);
+INSERT INTO test SELECT number * 3 + 1, rand() FROM numbers(10000);
+INSERT INTO test SELECT number * 3 + 2, rand() FROM numbers(10000);
 SELECT sum(l._part_offset = r._parent_part_offset) FROM test l JOIN mergeTreeProjection(currentDatabase(), test, p) r USING (a) SETTINGS enable_analyzer = 1;
 
 OPTIMIZE TABLE test FINAL;

--- a/tests/queries/0_stateless/03401_normal_projection_with_part_offset_no_sorting.reference
+++ b/tests/queries/0_stateless/03401_normal_projection_with_part_offset_no_sorting.reference
@@ -16,18 +16,18 @@ CREATE TABLE test
 )
 ENGINE = MergeTree
 ORDER BY ()
-SETTINGS index_granularity_bytes = 10485760, index_granularity = 8192;
+SETTINGS index_granularity_bytes = 10485760, index_granularity = 8192, merge_max_block_size = 8192;
 -- Insert enough rows so that future projection materialization test will trigger level 1 merge
-INSERT INTO test SELECT number * 3, rand() FROM numbers(360000);
-INSERT INTO test SELECT number * 3 + 1, rand() FROM numbers(360000);
-INSERT INTO test SELECT number * 3 + 2, rand() FROM numbers(360000);
+INSERT INTO test SELECT number * 3, rand() FROM numbers(10000);
+INSERT INTO test SELECT number * 3 + 1, rand() FROM numbers(10000);
+INSERT INTO test SELECT number * 3 + 2, rand() FROM numbers(10000);
 SELECT sum(l._part_offset = r._parent_part_offset) FROM test l JOIN mergeTreeProjection(currentDatabase(), test, p) r USING (a) SETTINGS enable_analyzer = 1;
-1080000
+30000
 OPTIMIZE TABLE test FINAL;
 SELECT sum(l._part_offset = r._parent_part_offset) FROM test l JOIN mergeTreeProjection(currentDatabase(), test, p) r USING (a) SETTINGS enable_analyzer = 1;
-1080000
+30000
 ALTER TABLE test ADD PROJECTION p2 (SELECT a, b, _part_offset ORDER BY b);
 ALTER TABLE test MATERIALIZE PROJECTION p2 SETTINGS mutations_sync = 2;
 SELECT sum(l._part_offset = r._parent_part_offset) FROM test l JOIN mergeTreeProjection(currentDatabase(), test, p2) r USING (a) SETTINGS enable_analyzer = 1;
-1080000
+30000
 DROP TABLE test;

--- a/tests/queries/0_stateless/03401_normal_projection_with_part_offset_no_sorting.sql
+++ b/tests/queries/0_stateless/03401_normal_projection_with_part_offset_no_sorting.sql
@@ -17,12 +17,12 @@ CREATE TABLE test
 )
 ENGINE = MergeTree
 ORDER BY ()
-SETTINGS index_granularity_bytes = 10485760, index_granularity = 8192;
+SETTINGS index_granularity_bytes = 10485760, index_granularity = 8192, merge_max_block_size = 8192;
 
 -- Insert enough rows so that future projection materialization test will trigger level 1 merge
-INSERT INTO test SELECT number * 3, rand() FROM numbers(360000);
-INSERT INTO test SELECT number * 3 + 1, rand() FROM numbers(360000);
-INSERT INTO test SELECT number * 3 + 2, rand() FROM numbers(360000);
+INSERT INTO test SELECT number * 3, rand() FROM numbers(10000);
+INSERT INTO test SELECT number * 3 + 1, rand() FROM numbers(10000);
+INSERT INTO test SELECT number * 3 + 2, rand() FROM numbers(10000);
 SELECT sum(l._part_offset = r._parent_part_offset) FROM test l JOIN mergeTreeProjection(currentDatabase(), test, p) r USING (a) SETTINGS enable_analyzer = 1;
 
 OPTIMIZE TABLE test FINAL;


### PR DESCRIPTION
## Summary
- Pin `merge_max_block_size = 8192` in test table settings to prevent randomization to tiny values (as low as 1)
- Reduce row count from 360,000 to 10,000 per insert (30,000 total), still sufficient for multi-block merges

The test timed out under MSan because a previous fix (1cc3b560cb0) pinned `index_granularity` but missed `merge_max_block_size`, which is randomized in range [1, 24576]. With a tiny block size, OPTIMIZE FINAL and JOIN on 1,080,000 rows becomes extremely slow.

Closes #96830

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.725`
<!-- ch-version-info:end -->