### PR TITLE
Fix flaky test `03702_alter_column_update_and_delete_with_secondary_index_drop`

### DIFF
--- a/tests/queries/0_stateless/03702_alter_column_update_and_delete_with_secondary_index_drop.reference
+++ b/tests/queries/0_stateless/03702_alter_column_update_and_delete_with_secondary_index_drop.reference
@@ -8,7 +8,7 @@ CREATE TABLE test_table
     ENGINE = MergeTree()
     ORDER BY id
     PARTITION BY intDiv(id, 100)
-    SETTINGS alter_column_secondary_index_mode = 'drop', min_bytes_for_wide_part = 0, min_bytes_for_full_part_storage=0, index_granularity=8192;
+    SETTINGS alter_column_secondary_index_mode = 'drop', min_bytes_for_wide_part = 0, min_bytes_for_full_part_storage=0, index_granularity=8192, index_granularity_bytes=0;
 INSERT INTO test_table SELECT number, number FROM numbers(10);
 SYSTEM STOP MERGES test_table;
 SET alter_sync = 0, mutations_sync = 0;

--- a/tests/queries/0_stateless/03702_alter_column_update_and_delete_with_secondary_index_drop.sh
+++ b/tests/queries/0_stateless/03702_alter_column_update_and_delete_with_secondary_index_drop.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Tags: no-parallel-replicas
+# Tags: no-parallel-replicas, no-random-merge-tree-settings
 # no-parallel-replicas: The EXPLAIN output is completely different
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
@@ -41,7 +41,7 @@ do
     ENGINE = MergeTree()
     ORDER BY id
     PARTITION BY intDiv(id, 100)
-    SETTINGS alter_column_secondary_index_mode = 'drop', ${part_type_setting}, index_granularity=8192;
+    SETTINGS alter_column_secondary_index_mode = 'drop', ${part_type_setting}, index_granularity=8192, index_granularity_bytes=0;
 
     INSERT INTO test_table SELECT number, number FROM numbers(10);
 


### PR DESCRIPTION
## Summary

- Fix flaky test `03702_alter_column_update_and_delete_with_secondary_index_drop` that fails intermittently with `Granules: 3/3` instead of expected `Granules: 1/1` in `EXPLAIN indexes = 1` output
- Root cause: `MergeTreeSettingsRandomizer` injects random `index_granularity_bytes` (as low as 1024) into the CREATE TABLE, causing adaptive index granularity to produce variable granule counts during mutation part rewrites
- Fix: add `no-random-merge-tree-settings` tag and explicitly set `index_granularity_bytes=0` to disable adaptive granularity

Closes https://github.com/ClickHouse/ClickHouse/issues/96809

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.724`
<!-- ch-version-info:end -->