### PR TITLE
Fix flaky test `03100_lwu_27_update_after_on_fly_mutations`

### DIFF
--- a/tests/queries/0_stateless/03100_lwu_27_update_after_on_fly_mutations.sql
+++ b/tests/queries/0_stateless/03100_lwu_27_update_after_on_fly_mutations.sql
@@ -16,6 +16,10 @@ UPDATE t_lwu_on_fly SET a = 2 WHERE id = 2;
 
 ALTER TABLE t_lwu_on_fly UPDATE b = 20 WHERE a = 2 SETTINGS mutations_sync = 0;
 
+-- Ensure the mutation entry is fetched from ZooKeeper into the local replica's queue,
+-- so that `apply_mutations_on_fly` can see it when the next UPDATE evaluates its WHERE clause.
+SYSTEM SYNC REPLICA t_lwu_on_fly PULL;
+
 UPDATE t_lwu_on_fly SET c = 200 WHERE b = 20;
 
 SELECT * FROM t_lwu_on_fly ORDER BY id;


### PR DESCRIPTION
## Summary
- The test fires `ALTER TABLE ... UPDATE` with `mutations_sync = 0`, then immediately does a lightweight `UPDATE ... WHERE b = 20` that depends on the mutation being applied on-the-fly
- With `mutations_sync = 0`, the ALTER returns after writing to ZooKeeper but before the local replica fetches the mutation entry, so `apply_mutations_on_fly` doesn't know about the mutation yet
- Added `SYSTEM SYNC REPLICA ... PULL` between the two statements to ensure the mutation entry is pulled from ZooKeeper into the local replica's queue — the lightest sync mode that won't hang with stopped merges

Closes https://github.com/ClickHouse/ClickHouse/issues/84277

## Test plan
- [x] Test passes locally (20/20 runs)

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.726`
<!-- ch-version-info:end -->