### PR TITLE
Fix flaky test_build_sets_from_multiple_threads under ASan

### DIFF
--- a/tests/integration/test_build_sets_from_multiple_threads/test.py
+++ b/tests/integration/test_build_sets_from_multiple_threads/test.py
@@ -70,4 +70,6 @@ def test_set():
         node.query(
             "ALTER TABLE `02581_trips` UPDATE description = 'a' WHERE id IN (SELECT CAST(number * 10, 'UInt32') FROM numbers(10e9)) SETTINGS mutations_sync = 2"
         )
-    node.query("DROP TABLE IF EXISTS 02581_trips")
+    node.query(
+        "DROP TABLE IF EXISTS 02581_trips SETTINGS max_execution_time = 0"
+    )


### PR DESCRIPTION
## Summary
- The `test_build_sets_from_multiple_threads` integration test sets `max_execution_time=3` globally in the profile to trigger a mutation timeout
- The cleanup `DROP TABLE` at the end of the test could also get killed with `QUERY_WAS_CANCELLED` when it takes longer than 3 seconds under ASan
- Override `max_execution_time` for the cleanup query to ensure it always completes

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=60b55239168eff7e5a3778102eab2138dd4c3754&name_0=MasterCI&name_1=Integration%20tests%20%28amd_asan%2C%20db%20disk%2C%20old%20analyzer%2C%201%2F6%29

### Changelog category (leave one):
- CI Fix or improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Fix flaky `test_build_sets_from_multiple_threads` integration test under ASan

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.705`
<!-- ch-version-info:end -->