### PR TITLE
Fix flaky tests: curl + SYSTEM FLUSH LOGS race condition

### DIFF
--- a/ci/jobs/scripts/check_style/various_checks.sh
+++ b/ci/jobs/scripts/check_style/various_checks.sh
@@ -190,5 +190,35 @@ find $ROOT_PATH/tests/queries -name '*.sh' |
 
 find $ROOT_PATH/tests/queries -iname '*.sql' -or -iname '*.sh' -or -iname '*.py' -or -iname '*.j2' | xargs grep --with-filename -i -E -e 'system\s*flush\s*logs\s*(;|$|")' && echo "Please use SYSTEM FLUSH LOGS log_name over global SYSTEM FLUSH LOGS"
 
+# Shell tests that send HTTP requests via curl and then check system log tables
+# must use a retry loop around SYSTEM FLUSH LOGS, because the query_log entry is
+# written after the HTTP response is sent (see executeQuery.cpp).
+# https://github.com/ClickHouse/ClickHouse/issues/84364
+#
+# Known exceptions where the retry is not needed:
+# - 00956: checks for ABSENCE of secrets in logs, missing entries = pass
+# - 02122: curl reads FROM query_log, doesn't send queries being checked
+# - 02125: curl sends mutations, part_log is checked for merges
+# - 03229: SYSTEM FLUSH ASYNC INSERT QUEUE synchronizes before FLUSH LOGS
+# - 03760: checks for absence of error in text_log
+curl_flush_logs_tests=( $(
+    find $ROOT_PATH/tests/queries -iname '*.sh' |
+        xargs grep -l -E 'CLICKHOUSE_CURL|curl ' |
+        xargs grep -l -iE 'system\.(query_log|query_views_log|text_log|trace_log|asynchronous_insert_log|part_log)' |
+        xargs grep -l -iE 'SYSTEM\s+FLUSH\s+LOGS' |
+        grep -vP '00956_sensitive_data_masking|02122_join_group_by_timeout|02125_many_mutations|03229_async_insert_alter|03760_keep_alive_insert_select' |
+        sort -u
+) )
+for test_case in "${curl_flush_logs_tests[@]}"; do
+    has_retry=false
+    # for ... seq/range ... sleep pattern
+    if grep -qP 'for .* in .*(seq|\{)' "$test_case" && grep -q 'sleep' "$test_case"; then has_retry=true; fi
+    # while ... sleep/break pattern
+    if grep -qP 'while ' "$test_case" && (grep -q 'sleep' "$test_case" || grep -q 'break' "$test_case"); then has_retry=true; fi
+    if [ "$has_retry" = false ]; then
+        echo "$test_case uses curl and SYSTEM FLUSH LOGS without a retry loop. Add a retry loop to handle the race between HTTP response and log entry writing. See https://github.com/ClickHouse/ClickHouse/issues/84364"
+    fi
+done
+
 # CLICKHOUSE_URL already includes "?"
 git grep -P 'CLICKHOUSE_URL(|_HTTPS)(}|}/|/|)\?' $ROOT_PATH/tests/queries/0_stateless/*.sh

--- a/tests/queries/0_stateless/01526_initial_query_id.sh
+++ b/tests/queries/0_stateless/01526_initial_query_id.sh
@@ -15,8 +15,16 @@ ${CLICKHOUSE_CURL} \
     --get \
     --data-urlencode "query=select 1 format Null"
 
+# Wait for both TCP and HTTP queries to appear in query_log.
+# There is a race between HTTP response being sent and the query_log entry being written.
+for _ in $(seq 1 60); do
+    ${CLICKHOUSE_CLIENT} -q "system flush logs query_log"
+    count=$(${CLICKHOUSE_CLIENT} -q "select count() from system.query_log where current_database = currentDatabase() AND query_id = '$query_id' and type = 'QueryFinish'")
+    [ "$count" -ge 2 ] && break
+    sleep 0.5
+done
+
 ${CLICKHOUSE_CLIENT} -q "
-system flush logs query_log;
 select interface, initial_query_id = query_id
     from system.query_log
     where current_database = currentDatabase() AND query_id = '$query_id' and type = 'QueryFinish'

--- a/tests/queries/0_stateless/01661_referer.sh
+++ b/tests/queries/0_stateless/01661_referer.sh
@@ -5,5 +5,12 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../shell_config.sh
 
 ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}" -d 'SELECT 1' --referer 'https://meta.ua/'
-${CLICKHOUSE_CLIENT} --query "SYSTEM FLUSH LOGS query_log"
+# Wait for the HTTP query to appear in query_log.
+# There is a race between HTTP response being sent and the query_log entry being written.
+for _ in $(seq 1 60); do
+    ${CLICKHOUSE_CLIENT} --query "SYSTEM FLUSH LOGS query_log"
+    count=$(${CLICKHOUSE_CLIENT} --query "SELECT count() FROM system.query_log WHERE current_database = currentDatabase() AND http_referer LIKE '%meta%'")
+    [ "$count" -ge 1 ] && break
+    sleep 0.5
+done
 ${CLICKHOUSE_CLIENT} --query "SELECT http_referer FROM system.query_log WHERE current_database = currentDatabase() AND http_referer LIKE '%meta%' LIMIT 1"

--- a/tests/queries/0_stateless/02246_is_secure_query_log.sh
+++ b/tests/queries/0_stateless/02246_is_secure_query_log.sh
@@ -10,7 +10,14 @@ ${CLICKHOUSE_CLIENT_SECURE} --log_queries=1 --query_id "2246_${CLICKHOUSE_DATABA
 ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&log_queries=1&http_wait_end_of_query=1&query_id=2246_${CLICKHOUSE_DATABASE}_http_nonsecure" -d "select 'http plain'"
 ${CLICKHOUSE_CURL} -sSk "${CLICKHOUSE_URL_HTTPS}&log_queries=1&http_wait_end_of_query=1&query_id=2246_${CLICKHOUSE_DATABASE}_http_secure" -d "select 'http secure'"
 
-${CLICKHOUSE_CLIENT} -q "system flush logs query_log"
+# Wait for all 4 queries (2 native + 2 HTTP) to appear in query_log.
+# There is a race between HTTP response being sent and the query_log entry being written.
+for _ in $(seq 1 60); do
+    ${CLICKHOUSE_CLIENT} -q "system flush logs query_log"
+    count=$(${CLICKHOUSE_CLIENT} -q "select count() from system.query_log where query_id LIKE '2246_${CLICKHOUSE_DATABASE}_%' and type = 'QueryFinish' and current_database = currentDatabase()")
+    [ "$count" -ge 4 ] && break
+    sleep 0.5
+done
 
 ${CLICKHOUSE_CLIENT} -q "select interface, is_secure from system.query_log where query_id = '2246_${CLICKHOUSE_DATABASE}_client_nonsecure' and type = 'QueryFinish' and current_database = currentDatabase()"
 ${CLICKHOUSE_CLIENT} -q "select interface, is_secure from system.query_log where query_id = '2246_${CLICKHOUSE_DATABASE}_client_secure' and type = 'QueryFinish' and current_database = currentDatabase()"

--- a/tests/queries/0_stateless/02494_query_cache_http_introspection.sh
+++ b/tests/queries/0_stateless/02494_query_cache_http_introspection.sh
@@ -17,9 +17,16 @@ sleep 1 # needed for QueryCacheAgeSeconds below
 echo "Second query"
 $CLICKHOUSE_CURL -v -sS "$CLICKHOUSE_URL&query_id=${CLICKHOUSE_DATABASE}_q2&use_query_cache=1&query_cache_ttl=600&query_cache_tag=${TAG}&query=SELECT+'Test+03711'" |& grep -o -P '< (Age|Expires):'
 
-$CLICKHOUSE_CLIENT --query "
-SYSTEM FLUSH LOGS query_log;
+# Wait for both HTTP queries to appear in query_log.
+# There is a race between HTTP response being sent and the query_log entry being written.
+for _ in $(seq 1 60); do
+    $CLICKHOUSE_CLIENT --query "SYSTEM FLUSH LOGS query_log"
+    count=$($CLICKHOUSE_CLIENT --query "SELECT count() FROM system.query_log WHERE current_database = currentDatabase() AND event_date >= yesterday() AND event_time >= now() - 600 AND type = 'QueryFinish' AND query_id IN ('${CLICKHOUSE_DATABASE}_q1', '${CLICKHOUSE_DATABASE}_q2') AND Settings['query_cache_tag'] = '$TAG'")
+    [ "$count" -ge 2 ] && break
+    sleep 0.5
+done
 
+$CLICKHOUSE_CLIENT --query "
 SELECT
     replace(query_id, currentDatabase(), ''),
     ProfileEvents['QueryCacheAgeSeconds'] >= 1,

--- a/tests/queries/0_stateless/02714_async_inserts_empty_data.sh
+++ b/tests/queries/0_stateless/02714_async_inserts_empty_data.sh
@@ -11,7 +11,14 @@ ${CLICKHOUSE_CLIENT} -q "CREATE TABLE t_async_insert_empty_data (id UInt32) ENGI
 
 echo -n '' | ${CLICKHOUSE_CURL} -sS "$url&query=INSERT%20INTO%20t_async_insert_empty_data%20FORMAT%20JSONEachRow" --data-binary @-
 
-${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH LOGS asynchronous_insert_log"
+# Wait for async insert log entry.
+# There is a race between HTTP response being sent and the log entry being written.
+for _ in $(seq 1 60); do
+    ${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH LOGS asynchronous_insert_log"
+    count=$(${CLICKHOUSE_CLIENT} -q "SELECT count() FROM system.asynchronous_insert_log WHERE database = '$CLICKHOUSE_DATABASE' AND table = 't_async_insert_empty_data'")
+    [ "$count" -ge 1 ] && break
+    sleep 0.5
+done
 ${CLICKHOUSE_CLIENT} -q "SELECT count() FROM t_async_insert_empty_data"
 ${CLICKHOUSE_CLIENT} -q "SELECT status, bytes FROM system.asynchronous_insert_log WHERE database = '$CLICKHOUSE_DATABASE' AND table = 't_async_insert_empty_data'"
 


### PR DESCRIPTION
Fix flaky tests caused by a race between HTTP response being sent and the `query_log` entry being written. The code in `executeQuery.cpp:2324` explicitly documents that `query_finish_callback()` (which sends the HTTP response) runs **before** `onFinish()` (which writes the QueryFinish log entry). Under TSan this race window is wide enough for the last entry to be missing.

Fix 17 affected tests by retrying `SYSTEM FLUSH LOGS` in a loop until all expected entries appear. Add a style check to `various_checks.sh` that prevents this anti-pattern from reappearing.

Tests fixed:
`02423_insert_stats_behaviour`, `01194_http_query_id`, `01526_initial_query_id`, `01526_max_untracked_memory`, `01661_referer`, `02156_async_insert_query_log`, `02246_is_secure_query_log`, `02456_async_inserts_logs`, `02494_query_cache_http_introspection`, `02570_fallback_from_async_insert`, `02714_async_inserts_empty_data`, `02725_async_insert_table_setting`, `02841_parallel_replicas_summary`, `02908_many_requests_to_system_replicas`, `03237_insert_sparse_columns_mem`, `03338_http_compression_profile_events`, `03723_max_insert_block_size_bytes_http`

Closes https://github.com/ClickHouse/ClickHouse/issues/84364

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.760`
<!-- ch-version-info:end -->