### PR TITLE
Fix flaky test_system_backups integration test

### DIFF
--- a/tests/integration/test_backup_restore_new/test.py
+++ b/tests/integration/test_backup_restore_new/test.py
@@ -119,7 +119,7 @@ def get_events_for_query(query_id: str) -> Dict[str, int]:
             WITH arrayJoin(ProfileEvents) as pe
             SELECT pe.1, pe.2
             FROM system.query_log
-            WHERE query_id = '{query_id}'
+            WHERE query_id = '{query_id}' AND type = 'QueryFinish'
             """
         )
     )


### PR DESCRIPTION
## Summary
- Fix flaky `test_system_backups` in `test_backup_restore_new` by filtering `system.query_log` for `type = 'QueryFinish'` only
- The `get_events_for_query` helper was querying both `QueryStart` and `QueryFinish` records, causing profile event values to be non-deterministically overwritten with zeros from `QueryStart` entries
- This caused intermittent failures in the assertions comparing `RestorePartsSkippedFiles`/`RestorePartsSkippedBytes` profile events

Closes https://github.com/ClickHouse/ClickHouse/issues/83185

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

## Test plan
- [x] Verify the fix by code review: `get_events_for_query` now correctly filters for `type = 'QueryFinish'` only, ensuring stable profile event values
- [ ] CI passes `test_backup_restore_new/test.py::test_system_backups`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.728`
<!-- ch-version-info:end -->