### PR TITLE
Fix TSan data race in UnifiedSchedulerNode::removeChild

### DIFF
--- a/src/Common/Scheduler/Nodes/UnifiedSchedulerNode.h
+++ b/src/Common/Scheduler/Nodes/UnifiedSchedulerNode.h
@@ -557,8 +557,8 @@ protected: // Hide all the ISchedulerNode interface methods as an implementation
     {
         if (immediate_child.get() == child)
         {
-            child_active = false; // deactivate
-            immediate_child->setParent(nullptr); // detach
+            immediate_child->setParent(nullptr); // detach first: cancels pending activations and waits for any in-progress activateChild
+            child_active = false; // deactivate (safe: no concurrent activateChild after cancelActivation)
             immediate_child.reset();
         }
     }


### PR DESCRIPTION
## Summary
- Fix a data race in `UnifiedSchedulerNode::removeChild` between the destructor (running in TCPHandler thread during `DROP WORKLOAD`) and the scheduler thread processing activations
- The race was on `child_active`: `removeChild` wrote `child_active = false` concurrently with `activateChild` writing via `std::exchange(child_active, true)`
- Fix by reordering: call `setParent(nullptr)` first (which calls `cancelActivation` and waits for any in-progress `activateChild` to complete), then safely write `child_active = false`

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96754&sha=5da1e6c0643f89d773e77f355e173b3b223826de&name_0=PR&name_1=Integration%20tests%20%28amd_tsan%2C%202%2F6%29
https://github.com/ClickHouse/ClickHouse/pull/96754

## Test plan
- [x] Existing unit test `ActivationCancelRace` in `gtest_event_queue.cpp` validates the correct ordering pattern
- [ ] CI integration tests `test_scheduler_cpu_preemptive` pass without TSan warnings

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.731`
<!-- ch-version-info:end -->