### PR TITLE
Fix race condition in KeeperClient.execute_query causing flaky test hangs

### DIFF
--- a/tests/integration/helpers/keeper_utils.py
+++ b/tests/integration/helpers/keeper_utils.py
@@ -143,35 +143,37 @@ class KeeperClient(object):
 
     def execute_query(self, query: str, timeout: float = 60.0) -> str:
         output = io.BytesIO()
+        error = b""
 
         self.proc.stdin.write(query.encode() + b"\n")
         self.proc.stdin.flush()
 
-        events = self.poller.poll(timeout)
-        if not events:
-            raise TimeoutError(f"Keeper client returned no output")
+        while True:
+            events = self.poller.poll(timeout)
+            if not events:
+                raise TimeoutError(f"Keeper client returned no output")
 
-        for fd_num, event in events:
-            if event & (select.EPOLLIN | select.EPOLLPRI):
-                file = self._fd_nums[fd_num]
+            for fd_num, event in events:
+                if event & (select.EPOLLIN | select.EPOLLPRI):
+                    file = self._fd_nums[fd_num]
 
-                if file == self.proc.stdout:
-                    while True:
-                        chunk = file.readline()
-                        if chunk.endswith(self.SEPARATOR):
-                            break
+                    if file == self.proc.stdout:
+                        while True:
+                            chunk = file.readline()
+                            if chunk.endswith(self.SEPARATOR):
+                                if error:
+                                    raise KeeperException(
+                                        error.strip().decode()
+                                    )
+                                return output.getvalue().strip().decode()
 
-                        output.write(chunk)
+                            output.write(chunk)
 
-                elif file == self.proc.stderr:
-                    self.proc.stdout.readline()
-                    raise KeeperException(self.proc.stderr.readline().strip().decode())
+                    elif file == self.proc.stderr:
+                        error += self.proc.stderr.readline()
 
-            else:
-                raise ValueError(f"Failed to read from pipe. Flag {event}")
-
-        data = output.getvalue().strip().decode()
-        return data
+                else:
+                    raise ValueError(f"Failed to read from pipe. Flag {event}")
 
     def cd(self, path: str, timeout: float = 60.0):
         self.execute_query(f"cd '{path}'", timeout)


### PR DESCRIPTION
## Summary
- Fix race condition in `KeeperClient.execute_query` that caused `test_keeper_availability_zone/test.py::test_get_availability_zone` to hang with a 900s timeout
- The keeper-client C++ process writes errors to stderr first, then the separator to stdout. When `epoll.poll` returned only the stderr event (stdout data hadn't arrived through the pipe yet), the error handler unconditionally called `self.proc.stdout.readline()` which blocked forever
- Restructure `execute_query` to poll in a loop, collecting stderr data when available and only returning/raising once the stdout separator is received
- This also fixes a secondary bug where errors could be missed if stdout happened to be processed before stderr in the same poll batch

Closes #80619

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.730`
<!-- ch-version-info:end -->