### PR TITLE
Fix flaky test `00563_shard_insert_into_remote`

### DIFF
--- a/tests/queries/0_stateless/00563_shard_insert_into_remote.sql
+++ b/tests/queries/0_stateless/00563_shard_insert_into_remote.sql
@@ -1,5 +1,7 @@
 -- Tags: shard
 
+SET handshake_timeout_ms = 60000;
+
 drop table if exists tab;
 create table tab (val UInt8) engine = MergeTree order by val;
 insert into function remote('127.0.0.2', currentDatabase(), tab) values (1);


### PR DESCRIPTION
## Summary
- Increase `handshake_timeout_ms` to 60 seconds in `00563_shard_insert_into_remote` to fix sporadic `SOCKET_TIMEOUT` failures under sanitizer builds (TSan, etc.)
- The test inserts via `remote('127.0.0.{2|3|4}', ...)` which opens TCP connections to multiple addresses; the default 10-second handshake timeout is too short when the server is slow under sanitizers

## Root cause
The `handshake_timeout_ms` setting (default 10s) governs the `receiveHello` phase during TCP connection establishment. Under TSan, the hello handshake to `127.0.0.3:9000` exceeded 10 seconds (took ~10.8s), causing error code 209 (`SOCKET_TIMEOUT`).

Closes #82041

### Changelog category
- CI Fix or improvement

### Changelog entry
- Fix flaky test `00563_shard_insert_into_remote` by increasing `handshake_timeout_ms`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.736`
<!-- ch-version-info:end -->