### PR TITLE
Fix broken check_callback in test_restore_db_replica

### DIFF
--- a/tests/integration/test_restore_db_replica/test.py
+++ b/tests/integration/test_restore_db_replica/test.py
@@ -309,15 +309,15 @@ def test_query_after_restore_db_replica(
     if exists_table:
         assert node_1.query_with_retry(
             f"SELECT table FROM system.tables WHERE database='{exclusive_database_name}' ORDER BY table",
-            retry_count=10,
+            retry_count=30,
             sleep_time=1,
-            check_callback=lambda tables: tables == exists_table_name,
+            check_callback=lambda tables: tables.strip() == exists_table_name,
         )
         assert node_2.query_with_retry(
             f"SELECT table FROM system.tables WHERE database='{exclusive_database_name}' ORDER BY table",
-            retry_count=10,
+            retry_count=30,
             sleep_time=1,
-            check_callback=lambda tables: tables == exists_table_name,
+            check_callback=lambda tables: tables.strip() == exists_table_name,
         )
         check_contains_table(
             node_1, f"{exclusive_database_name}.{exists_table_name}", inserted_data

--- a/tests/queries/0_stateless/02835_drop_user_during_session.sh
+++ b/tests/queries/0_stateless/02835_drop_user_during_session.sh
@@ -49,7 +49,7 @@ function wait_for_queries_start()
 }
 
 ${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH LOGS session_log"
-${CLICKHOUSE_CLIENT} -q "DELETE FROM system.session_log WHERE user = '${TEST_USER}'"
+${CLICKHOUSE_CLIENT} -q "DELETE FROM system.session_log WHERE user = '${TEST_USER}' SETTINGS lightweight_deletes_sync = 0"
 
 # DROP USE CASE
 ${CLICKHOUSE_CLIENT} -q "CREATE USER IF NOT EXISTS ${TEST_USER}"


### PR DESCRIPTION
## Summary
- Fix the `check_callback` in `test_query_after_restore_db_replica` that compared raw query result (with trailing `\n`) against the expected table name (without `\n`), causing the callback to always return `False` and making retries useless
- Increase `retry_count` from 10 to 30 to give more time for the Replicated database to initialize after node restart, especially in ASan builds

Closes https://github.com/ClickHouse/ClickHouse/issues/85664

## Test plan
- [ ] Existing integration tests pass: `test_restore_db_replica/test.py::test_query_after_restore_db_replica`
- [ ] Verify with ASan build that the flaky test no longer fails

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.734`
<!-- ch-version-info:end -->