### PR TITLE
Fix flaky test test_async_connect_to_multiple_ips

### DIFF
--- a/tests/integration/test_async_connect_to_multiple_ips/configs/listen_host.xml
+++ b/tests/integration/test_async_connect_to_multiple_ips/configs/listen_host.xml
@@ -1,4 +1,0 @@
-<clickhouse>
-    <listen_host>::</listen_host>
-</clickhouse>
-

--- a/tests/integration/test_async_connect_to_multiple_ips/test.py
+++ b/tests/integration/test_async_connect_to_multiple_ips/test.py
@@ -22,14 +22,12 @@ def cluster_without_dns_cache_update():
 
 node1 = cluster.add_instance(
     "node1",
-    main_configs=["configs/listen_host.xml"],
     user_configs=["configs/enable_hedged.xml"],
     with_zookeeper=True,
 )
 
 node2 = cluster.add_instance(
     "node2",
-    main_configs=["configs/listen_host.xml"],
     user_configs=["configs/enable_hedged.xml"],
     with_zookeeper=True,
 )

--- a/tests/integration/test_async_connect_to_multiple_ips/test.py
+++ b/tests/integration/test_async_connect_to_multiple_ips/test.py
@@ -25,7 +25,6 @@ node1 = cluster.add_instance(
     main_configs=["configs/listen_host.xml"],
     user_configs=["configs/enable_hedged.xml"],
     with_zookeeper=True,
-    ipv4_address="10.5.95.11",
 )
 
 node2 = cluster.add_instance(
@@ -33,7 +32,6 @@ node2 = cluster.add_instance(
     main_configs=["configs/listen_host.xml"],
     user_configs=["configs/enable_hedged.xml"],
     with_zookeeper=True,
-    ipv4_address="10.5.95.12",
 )
 
 
@@ -56,7 +54,7 @@ def test(cluster_without_dns_cache_update):
             [
                 "bash",
                 "-c",
-                "echo '{} {}' >> /etc/hosts".format(node1.ipv4_address, node1.name),
+                "echo '{} {}' >> /etc/hosts".format(node1.ip_address, node1.name),
             ]
         )
     )


### PR DESCRIPTION
Remove hard-coded IPv4 addresses that can conflict with other integration tests running in parallel. Use dynamically assigned `ip_address` from Docker instead.

Closes https://github.com/ClickHouse/ClickHouse/issues/85431

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.711`
<!-- ch-version-info:end -->