### PR TITLE
Fix flaky `00365_statistics_in_formats` with parallel replicas

### DIFF
--- a/tests/queries/0_stateless/00365_statistics_in_formats.sh
+++ b/tests/queries/0_stateless/00365_statistics_in_formats.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Tags: no-parallel-replicas
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
The test checks `rows_read` statistics in JSON/JSONCompact/XML output formats. With parallel replicas, there is a race condition where the output format's `finalizeImpl` writes the statistics footer before all progress from connection draining has been reported, resulting in `rows_read` being 0 instead of 10.

Add the `no-parallel-replicas` tag to avoid the flakiness.

Closes https://github.com/ClickHouse/ClickHouse/issues/85785

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.766`
<!-- ch-version-info:end -->