### PR TITLE
Fix flaky timeout in 00534_functions_bad_arguments tests

### DIFF
--- a/tests/queries/0_stateless/00534_functions_bad_arguments.lib
+++ b/tests/queries/0_stateless/00534_functions_bad_arguments.lib
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 function test_variant {
-    perl -E "say \$_ for map {chomp; (qq{$1})} qx{$CLICKHOUSE_CLIENT -q 'SELECT name FROM system.functions ORDER BY name;'}" | $CLICKHOUSE_CLIENT --calculate_text_stack_trace=0 --max_execution_time=3 -n --ignore-error >/dev/null 2>&1
+    perl -E "say \$_ for map {chomp; (qq{$1})} qx{$CLICKHOUSE_CLIENT -q 'SELECT name FROM system.functions ORDER BY name;'}" | $CLICKHOUSE_CLIENT --calculate_text_stack_trace=0 --compile_expressions=0 --compile_aggregate_expressions=0 -n --ignore-error >/dev/null 2>&1
     $CLICKHOUSE_CLIENT -q "SELECT 'Still alive'"
 }
 

--- a/tests/queries/0_stateless/00534_functions_bad_arguments.lib
+++ b/tests/queries/0_stateless/00534_functions_bad_arguments.lib
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 function test_variant {
-    perl -E "say \$_ for map {chomp; (qq{$1})} qx{$CLICKHOUSE_CLIENT -q 'SELECT name FROM system.functions ORDER BY name;'}" | $CLICKHOUSE_CLIENT --calculate_text_stack_trace=0 -n --ignore-error >/dev/null 2>&1
+    perl -E "say \$_ for map {chomp; (qq{$1})} qx{$CLICKHOUSE_CLIENT -q 'SELECT name FROM system.functions ORDER BY name;'}" | $CLICKHOUSE_CLIENT --calculate_text_stack_trace=0 --max_execution_time=3 -n --ignore-error >/dev/null 2>&1
     $CLICKHOUSE_CLIENT -q "SELECT 'Still alive'"
 }
 


### PR DESCRIPTION
## Summary
- The `00534_functions_bad_arguments` tests send ~1800 queries (one per system function with bad arguments) through a single `clickhouse-client -n --ignore-error` invocation
- On ARM ASan with randomized settings that enable JIT compilation (`compile_aggregate_expressions=1`, `min_count_to_compile_aggregate_expression=0`), each aggregate function triggers LLVM compilation, adding ~0.4s overhead per query under ASan
- The cumulative time exceeds the 10-minute timeout: the CI server log shows 1590/1767 queries processed in 607 seconds before the test was killed
- Fix: disable JIT compilation (`--compile_expressions=0 --compile_aggregate_expressions=0`) in the shared test library. JIT is irrelevant to what the test checks (that bad arguments don't crash the server) and is the main source of the slowdown

Closes #92355

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.742`
<!-- ch-version-info:end -->