### PR TITLE
Fix remaining race conditions in DatabaseReplicated ddl_worker access

### DIFF
--- a/src/Databases/DatabaseReplicated.h
+++ b/src/Databases/DatabaseReplicated.h
@@ -243,7 +243,7 @@ private:
     std::atomic_bool is_probably_dropped = false;
     std::atomic_bool is_recovering = false;
     std::atomic_bool ddl_worker_initialized = false;
-    std::unique_ptr<DatabaseReplicatedDDLWorker> ddl_worker;
+    std::shared_ptr<DatabaseReplicatedDDLWorker> ddl_worker;
     mutable std::mutex ddl_worker_mutex;
     UInt32 max_log_ptr_at_creation = 0;
 


### PR DESCRIPTION
PR #95865 fixed the main crash in `tryEnqueueReplicatedDDL` by moving `getCommonHostID` inside the lock, but several other functions still access `ddl_worker` outside the lock after checking it, which can race with `shutdown` setting it to nullptr.

This PR changes `ddl_worker` from `unique_ptr` to `shared_ptr` and takes local copies under `ddl_worker_mutex` in functions that use it after releasing the lock:

- `tryEnqueueReplicatedDDL`: `tryEnqueueAndExecuteEntry` was still called on `ddl_worker` outside the lock
- `waitForReplicaToProcessAllEntries`: all three calls outside the lock
- `tryGetReplicasInfo`: `isUnsyncedAfterRecovery` outside the lock
- `checkDigestValid`: `isCurrentlyActive` without any lock
- `dropTable`, `commitCreateTable`, `commitAlterTable`, `detachTablePermanently`, `removeDetachedPermanentlyFlag`: assert accesses that race in debug/sanitizer builds

Closes #85774

### Changelog category (leave one):
- CI Fix or Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix remaining race conditions in `DatabaseReplicated` where `ddl_worker` could be accessed after being set to nullptr by concurrent `shutdown`.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)