### PR TITLE
Fix flaky test_interactive_totp_authentication timeout under ASan

### DIFF
--- a/tests/integration/helpers/uclient.py
+++ b/tests/integration/helpers/uclient.py
@@ -21,7 +21,7 @@ class client(object):
         self.client.eol("\r")
         self.client.logger(log, prefix=name)
         self.client.timeout(20)
-        self.client.expect("[#\\$] ", timeout=10)
+        self.client.expect("[#\\$] ", timeout=60)
         self.client.send(command)
 
     def __enter__(self):

--- a/tests/integration/helpers/uexpect.py
+++ b/tests/integration/helpers/uexpect.py
@@ -107,6 +107,7 @@ class IO(object):
             self.process.kill()
         else:
             self.process.terminate()
+        self.process.wait()
         os.close(self.master)
         if self._logger:
             self._logger.write("\n")


### PR DESCRIPTION
## Summary
- The `test_interactive_totp_authentication` integration test creates 10 consecutive interactive client connections, each spawning bash + clickhouse-client via `uclient.client`
- Under ASan with heavy system load, the hardcoded 10-second timeout for the bash shell prompt in `uclient.py` was too tight, causing `ExpectTimeoutError` on the 8th connection
- Increased the bash prompt timeout from 10s to 60s (only affects maximum wait for failures — normal startup takes <1s)
- Added `process.wait()` in `uexpect.IO.close` to properly reap zombie processes between client connections, preventing resource accumulation

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96847&sha=3325178d93d3d2248f37ddc8a277f331aa329657&name_0=PR&name_1=Integration%20tests%20%28amd_asan%2C%20db%20disk%2C%20old%20analyzer%2C%201%2F6%29
https://github.com/ClickHouse/ClickHouse/pull/96847

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
- Fix flaky `test_interactive_totp_authentication` integration test under ASan

🤖 Generated with [Claude Code](https://claude.com/claude-code)