### PR TITLE
Fix flaky test test_kill_while_insert

### DIFF
--- a/tests/integration/test_multiple_disks/test.py
+++ b/tests/integration/test_multiple_disks/test.py
@@ -1662,21 +1662,21 @@ def test_kill_while_insert(start_cluster):
         start_time = time.time()
         long_select = threading.Thread(
             target=ignore_exceptions,
-            args=(node1.query, "SELECT sleep(3) FROM {name}".format(name=name)),
+            args=(node1.query, "SELECT sleep(30) FROM {name}".format(name=name)),
         )
         long_select.start()
 
         sleep_start_time = time.time()
-        time.sleep(0.5)
+        time.sleep(5)
         # long SELECT query might have finished if sleep was too long
-        assert time.time() - sleep_start_time < 1.5
+        assert time.time() - sleep_start_time < 15
 
         node1.query(
             "ALTER TABLE {name} MOVE PARTITION tuple() TO DISK 'external'".format(
                 name=name
             )
         )
-        assert time.time() - start_time < 2.5
+        assert time.time() - start_time < 25
         node1.restart_clickhouse(kill=True)
 
         try:

--- a/tests/integration/test_multiple_disks/test.py
+++ b/tests/integration/test_multiple_disks/test.py
@@ -1676,7 +1676,7 @@ def test_kill_while_insert(start_cluster):
                 name=name
             )
         )
-        assert time.time() - start_time < 2
+        assert time.time() - start_time < 2.5
         node1.restart_clickhouse(kill=True)
 
         try:


### PR DESCRIPTION
## Summary
- Fix flaky test `test_multiple_disks/test.py::test_kill_while_insert` by increasing all timing values 10x
- The test verifies that `ALTER TABLE MOVE PARTITION` does not wait for a concurrent long `SELECT` to finish
- The timing assertion (`< 2s`) was too tight for loaded CI machines (observed: 2.068s on ARM)
- Now uses `sleep(30)` instead of `sleep(3)` with proportionally scaled thresholds, still testing the same invariant

Closes https://github.com/ClickHouse/ClickHouse/issues/94657

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.709`
<!-- ch-version-info:end -->