### PR TITLE
Fix flaky test `01676_clickhouse_client_autocomplete`

### DIFF
--- a/tests/queries/0_stateless/01676_clickhouse_client_autocomplete.python
+++ b/tests/queries/0_stateless/01676_clickhouse_client_autocomplete.python
@@ -20,7 +20,7 @@ STATE_MAP = {
 
 
 def run_with_timeout(func, args, timeout):
-    for _ in range(5):
+    for attempt in range(5):
         state = multiprocessing.Value("i", -1)
         process = multiprocessing.Process(
             target=func, args=args, kwargs={"state": state}
@@ -34,9 +34,11 @@ def run_with_timeout(func, args, timeout):
         if process.is_alive():
             process.terminate()
 
-            if state.value == -1:
-                continue
+        # Retry on any non-terminal state (transient timeouts on loaded machines)
+        if attempt < 4:
+            continue
 
+        if state.value in (1, 2):
             print(f"Timeout, state: {STATE_MAP[state.value]}")
             return
 


### PR DESCRIPTION
## Summary

- The `run_with_timeout` retry logic only retried when the clickhouse-client process didn't start (`state == -1`), but immediately gave up on timeouts at states 1 ("process started") and 2 ("completion search was started")
- On loaded ARM CI machines, the Tab-completion search for "system" (with its short 3-char prefix "sys") can be transiently slow, hitting the 30s timeout
- Fix by retrying on **all** non-terminal states, not just `state == -1` — the timeout message is only reported on the 5th and final attempt

Closes https://github.com/ClickHouse/ClickHouse/issues/94005

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.713`
<!-- ch-version-info:end -->