### PR TITLE
Reduce lock contention in MergeTreeBackgroundExecutor during DROP TABLE

### DIFF
--- a/src/Storages/MergeTree/BackgroundJobsAssignee.cpp
+++ b/src/Storages/MergeTree/BackgroundJobsAssignee.cpp
@@ -118,6 +118,12 @@ void BackgroundJobsAssignee::start()
     holder->activateAndSchedule();
 }
 
+void BackgroundJobsAssignee::setStorageID(const StorageID & new_id)
+{
+    std::lock_guard lock(holder_mutex);
+    storage_id = new_id;
+}
+
 void BackgroundJobsAssignee::finish()
 {
     /// No lock here, because scheduled tasks could call trigger method

--- a/src/Storages/MergeTree/BackgroundJobsAssignee.h
+++ b/src/Storages/MergeTree/BackgroundJobsAssignee.h
@@ -62,6 +62,7 @@ public:
     void trigger();
     void postpone();
     void finish();
+    void setStorageID(const StorageID & new_id);
 
     bool scheduleMergeMutateTask(ExecutableTaskPtr merge_task);
     bool scheduleFetchTask(ExecutableTaskPtr fetch_task);

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -3840,6 +3840,8 @@ void MergeTreeData::renameInMemory(const StorageID & new_table_id)
 {
     IStorage::renameInMemory(new_table_id);
     log.store(new_table_id.getNameForLogs());
+    background_operations_assignee.setStorageID(new_table_id);
+    background_moves_assignee.setStorageID(new_table_id);
 }
 
 void MergeTreeData::dropAllData()


### PR DESCRIPTION
## Summary

- Move expensive task destruction (`resetTask`) and `onCompleted` callback outside the executor's mutex in `MergeTreeBackgroundExecutor::routine`, reducing lock hold time from potentially >1 second to a fast erase+notify operation
- Add cached `storage_id` field to `TaskRuntimeData` so `removeTasksCorrespondingToStorage` can identify the storage without accessing the task pointer (which may be concurrently destroyed outside the lock)
- Update `BackgroundJobsAssignee::storage_id` during table rename so that `finish` uses the correct StorageID in databases without UUIDs (Ordinary)

Items remain in the `active` queue during destruction so that `removeTasksCorrespondingToStorage` can still discover them and wait on `is_done`, preventing a race between task destruction and storage shutdown.

Closes https://github.com/ClickHouse/ClickHouse/issues/93620

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)