### PR TITLE
Fix transient minio startup timeout in CI

### DIFF
--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -134,7 +134,7 @@ class ClickHouseProc:
             )
         print(f"Started setup_minio.sh asynchronously with PID {self.minio_proc.pid}")
 
-        for _ in range(20):
+        for _ in range(60):
             res = Shell.check(
                 "/mc ls clickminio/test | grep -q .",
                 verbose=True,

--- a/ci/jobs/scripts/functional_tests/setup_minio.sh
+++ b/ci/jobs/scripts/functional_tests/setup_minio.sh
@@ -84,7 +84,6 @@ start_minio() {
   nohup minio server --address ":11111" ./minio_data &
   wait_for_it
   lsof -i :11111
-  sleep 5
 }
 
 setup_minio() {


### PR DESCRIPTION
## Summary

Fix a transient CI failure where minio infrastructure setup times out before tests can run, observed in "Stateless tests (amd_debug, AsyncInsert, s3 storage, sequential)".

- Remove unnecessary `sleep 5` in `setup_minio.sh` after `wait_for_it` already confirmed minio is responsive
- Increase the readiness polling retry count from 20 to 60 in `clickhouse_proc.py`

## Observations from the failure

[CI report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96987&sha=eb763d8476e10cd6b9c1161babaf23376002dbe8&name_0=PR&name_1=Stateless%20tests%20%28amd_debug%2C%20AsyncInsert%2C%20s3%20storage%2C%20sequential%29
https://github.com/ClickHouse/ClickHouse/pull/96987)

The job failed at `Start ClickHouse Server` with `Failed to start minio`. Zero tests executed.

`setup_minio.sh` is launched asynchronously and the Python poller immediately starts checking `mc ls clickminio/test | grep -q .` every ~2s (1s sleep + ~1s for the failing command). With 20 retries this gives a ~40s total budget.

Timeline from the job log:
- **09:42:45** — `setup_minio.sh` started, polling begins
- **09:42:45 – 09:43:10** (~25s, 14 retries) — `mc` errors with `Requested path .../clickminio not found` — the `mc` alias hasn't been configured yet, meaning minio server startup + the `sleep 5` consumed all this time
- **09:43:12 – 09:43:23** (~11s, 6 retries) — error changes to `Bucket test does not exist` — alias is now set but `mc mb clickminio/test` hasn't completed
- **09:43:24** — all 20 retries exhausted, `Failed to start minio`

The `setup_minio.sh` execution sequence is: start minio server → `wait_for_it` (up to 60s) → `lsof` → **`sleep 5`** → `mc alias set` → `mc mb` → `mc cp` data. The `sleep 5` after `wait_for_it` already confirmed responsiveness is wasteful, and the 20-retry budget (~40s) cannot accommodate even the `wait_for_it` worst case (60s).

## Test plan

- [x] Verified no other callers of `setup_minio.sh` or the polling logic
- [ ] CI passes with the fix (minio-dependent s3 storage test jobs succeed)

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.745`
<!-- ch-version-info:end -->