### PR TITLE
Cancel write buffers in IcebergStorageSink on exception

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
@@ -821,6 +821,11 @@ void IcebergStorageSink::onFinish()
     releaseBuffers();
 }
 
+void IcebergStorageSink::onException(std::exception_ptr /* exception */)
+{
+    cancelBuffers();
+}
+
 void IcebergStorageSink::finalizeBuffers()
 {
     for (auto & [partition_key, writer] : writer_per_partition_key)

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.h
@@ -92,6 +92,7 @@ public:
     void consume(Chunk & chunk) override;
 
     void onFinish() override;
+    void onException(std::exception_ptr exception) override;
 
 private:
     LoggerPtr log = getLogger("IcebergStorageSink");

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/MultipleFileWriter.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/MultipleFileWriter.cpp
@@ -84,8 +84,10 @@ void MultipleFileWriter::release()
 
 void MultipleFileWriter::cancel()
 {
-    output_format->cancel();
-    buffer->cancel();
+    if (output_format)
+        output_format->cancel();
+    if (buffer)
+        buffer->cancel();
 }
 
 void MultipleFileWriter::clearAllDataFiles() const


### PR DESCRIPTION
## Summary
- Override `onException` in `IcebergStorageSink` to call `cancelBuffers`, ensuring write buffers are properly canceled when an error occurs during INSERT into an Iceberg table
- Add null checks in `MultipleFileWriter::cancel` since buffers may not exist if no data was consumed or may already have been released after successful `onFinish`
- Fixes assertion "WriteBuffer is neither finalized nor canceled in destructor" found by AST fuzzer in stress tests

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96613&sha=89c8476a82ec00b6007e1def0608e4d049445a79&name_0=PR&name_1=Stress%20test%20%28arm_asan%29
https://github.com/ClickHouse/ClickHouse/pull/96613

## Test plan
- [x] Verified the fix compiles without errors or warnings
- [ ] CI stress tests should pass without the WriteBuffer assertion failure

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.756`
<!-- ch-version-info:end -->