### PR TITLE
Set CLICKHOUSE_CLIENT_SERVER_LOGS_LEVEL=fatal in flaky replicated tests

### DIFF
--- a/tests/queries/0_stateless/01079_parallel_alter_detach_table_zookeeper.sh
+++ b/tests/queries/0_stateless/01079_parallel_alter_detach_table_zookeeper.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Tags: zookeeper, no-parallel, no-fasttest
 
+CLICKHOUSE_CLIENT_SERVER_LOGS_LEVEL=fatal
+
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh

--- a/tests/queries/0_stateless/01111_create_drop_replicated_db_stress.sh
+++ b/tests/queries/0_stateless/01111_create_drop_replicated_db_stress.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Tags: race, zookeeper, no-parallel, long, no-msan
 
+CLICKHOUSE_CLIENT_SERVER_LOGS_LEVEL=fatal
+
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh


### PR DESCRIPTION
## Summary
- Set `CLICKHOUSE_CLIENT_SERVER_LOGS_LEVEL=fatal` in `01079_parallel_alter_detach_table_zookeeper` and `01111_create_drop_replicated_db_stress` tests
- When `DROP TABLE IF EXISTS` gets `TIMEOUT_EXCEEDED` in `DatabaseReplicated` mode, the server logs an error-level exception with a full stack trace. The client receives this multi-line log entry via `--send_logs_level`. The test's `grep -Fv "TIMEOUT_EXCEEDED"` only filters the first line, but stack trace continuation lines pass through containing `Poco::Exception::Exception`, which triggers the test runner's exception detection
- Setting the log level to `fatal` prevents server log messages below Fatal level from being sent to the client

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96928&sha=1d2423087f0e2e9e8e3c80d5c554f1c50b2ec065&name_0=PR&name_1=Stateless%20tests%20%28amd_binary%2C%20old%20analyzer%2C%20s3%20storage%2C%20DatabaseReplicated%2C%20sequential%29
https://github.com/ClickHouse/ClickHouse/pull/96928

## Test plan
- [x] Verified both test files have `CLICKHOUSE_CLIENT_SERVER_LOGS_LEVEL=fatal` set before sourcing `shell_config.sh`
- [x] Checked all other tests using `TIMEOUT_EXCEEDED` filtering — they either already have the fix or use safe patterns (counting/extracting rather than filtering)

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.757`
<!-- ch-version-info:end -->