### PR TITLE
Fix flaky integration tests for backup/restore and refreshable mat views

### DIFF
--- a/tests/integration/test_backup_restore_new/test.py
+++ b/tests/integration/test_backup_restore_new/test.py
@@ -497,6 +497,7 @@ def test_increment_backup_without_changes():
     )
 
 
+@pytest.mark.timeout(1800)
 def test_incremental_backup_overflow():
     if (
         instance.is_built_with_thread_sanitizer()
@@ -514,10 +515,11 @@ def test_incremental_backup_overflow():
     )
     # Create a column of 4GB+10K
     instance.query(
-        "INSERT INTO test.table SELECT toString(repeat('A', 1024)) FROM numbers((4*1024*1024)+10)"
+        "INSERT INTO test.table SELECT toString(repeat('A', 1024)) FROM numbers((4*1024*1024)+10)",
+        timeout=600,
     )
     # Force one part
-    instance.query("OPTIMIZE TABLE test.table FINAL")
+    instance.query("OPTIMIZE TABLE test.table FINAL", timeout=600)
 
     # ensure that the column's size on disk is indeed greater then 4GB
     assert (
@@ -1955,12 +1957,22 @@ def test_mutation():
         "INSERT INTO test.table SELECT number, toString(number) FROM numbers(10, 5)"
     )
 
+    # Complete the first mutation synchronously so it's fully applied to all parts.
+    instance.query(
+        "ALTER TABLE test.table UPDATE x=x+1 WHERE 1 SETTINGS mutations_sync=1"
+    )
+
+    # Stop merges to prevent subsequent mutations from being applied,
+    # ensuring they remain pending and deterministically appear in the backup.
+    instance.query("SYSTEM STOP MERGES test.table")
+
     instance.query("ALTER TABLE test.table UPDATE x=x+1 WHERE 1")
-    instance.query("ALTER TABLE test.table UPDATE x=x+1+sleep(3) WHERE 1")
-    instance.query("ALTER TABLE test.table UPDATE x=x+1+sleep(3) WHERE 1")
+    instance.query("ALTER TABLE test.table UPDATE x=x+1 WHERE 1")
 
     backup_name = new_backup_name()
     instance.query(f"BACKUP TABLE test.table TO {backup_name}")
+
+    instance.query("SYSTEM START MERGES test.table")
 
     assert not has_mutation_in_backup("0000000004", backup_name, "test", "table")
     assert has_mutation_in_backup("0000000005", backup_name, "test", "table")
@@ -2104,13 +2116,11 @@ def test_tables_dependency():
         f"Table {t14} has 1 dependencies: {t2} (level 1)",
         f"Table {t15} has no dependencies (level 0)",
     ]
+    log_content = instance.grep_in_log("BackupMetadataFinder:")
     for expect in expect_in_logs:
         assert any(
-            [
-                instance.contains_in_log(f"BackupMetadataFinder: {x}")
-                for x in tuple(expect)
-            ]
-        )
+            f"BackupMetadataFinder: {x}" in log_content for x in tuple(expect)
+        ), f"Expected one of {tuple(expect)} in log, but not found"
 
     drop()
 

--- a/tests/integration/test_backup_restore_s3/configs/query_log.xml
+++ b/tests/integration/test_backup_restore_s3/configs/query_log.xml
@@ -3,6 +3,6 @@
     <query_log replace="replace">
         <database>system</database>
         <table>query_log</table>
-        <engine>Engine = MergeTree PARTITION BY event_date ORDER BY event_time TTL event_date + INTERVAL 30 day SETTINGS storage_policy='policy_s3_plain_rewritable', ttl_only_drop_parts=1, min_rows_for_wide_part=0, min_bytes_for_wide_part=0</engine>
+        <engine>Engine = MergeTree PARTITION BY event_date ORDER BY event_time TTL event_date + INTERVAL 30 day</engine>
     </query_log>
 </clickhouse>

--- a/tests/integration/test_backup_restore_s3/test.py
+++ b/tests/integration/test_backup_restore_s3/test.py
@@ -644,7 +644,7 @@ def test_backup_to_s3_copy_multipart_check_error_message(cluster, broken_s3):
 
     try:
         backup_query_id = uuid.uuid4().hex
-        broken_s3.setup_at_part_upload(after=20, count=1)
+        broken_s3.setup_at_part_upload(after=2, count=1)
         error = node.query_and_get_error(
             f"BACKUP TABLE data TO {backup_destination} {format_settings(None)}",
             query_id=backup_query_id,

--- a/tests/integration/test_backup_restore_s3/test.py
+++ b/tests/integration/test_backup_restore_s3/test.py
@@ -648,6 +648,7 @@ def test_backup_to_s3_copy_multipart_check_error_message(cluster, broken_s3):
         error = node.query_and_get_error(
             f"BACKUP TABLE data TO {backup_destination} {format_settings(None)}",
             query_id=backup_query_id,
+            settings={"s3_max_single_part_upload_size": 0},
         )
 
         assert "mock s3 injected unretryable error" in error, error

--- a/tests/integration/test_backup_restore_s3/test.py
+++ b/tests/integration/test_backup_restore_s3/test.py
@@ -184,9 +184,7 @@ def new_backup_name():
 
 
 def get_events_for_query(node, query_id: str) -> Dict[str, int]:
-    # Flush logs separately with a longer timeout because query_log is stored
-    # on S3 (policy_s3_plain_rewritable) and can be slow to flush under CI load.
-    node.query("SYSTEM FLUSH LOGS", timeout=300)
+    node.query("SYSTEM FLUSH LOGS")
     events = TSV(
         node.query(
             f"""
@@ -630,7 +628,7 @@ def broken_s3(init_broken_s3):
 
 def test_backup_to_s3_copy_multipart_check_error_message(cluster, broken_s3):
     storage_policy = "policy_s3"
-    size = 10000000
+    size = 1000000
     backup_name = new_backup_name()
     backup_destination = f"S3('http://resolver:8084/root/data/backups/multipart/{backup_name}', 'minio', '{minio_secret_key}')"
     node = cluster.instances["node"]

--- a/tests/integration/test_refreshable_mat_view/test.py
+++ b/tests/integration/test_refreshable_mat_view/test.py
@@ -345,6 +345,8 @@ def get_rmv_info(
                 if wait_status
                 else (lambda r: r.iloc[0]["status"] != "Scheduling")
             ),
+            retry_count=max_attempts,
+            sleep_time=delay,
             parse=True,
         ).to_dict("records")[0]
 
@@ -436,7 +438,9 @@ def test_long_query_cancel(fn_setup_tables):
     get_rmv_info(node, "test_rmv", delay=0.1, max_attempts=1000, wait_status="Running")
 
     node.query("SYSTEM CANCEL VIEW test_rmv")
-    rmv = get_rmv_info(node, "test_rmv", wait_status="Scheduled")
+    rmv = get_rmv_info(
+        node, "test_rmv", delay=0.1, max_attempts=1000, wait_status="Scheduled"
+    )
     assert rmv["status"] == "Scheduled"
     assert rmv["exception"] == "cancelled"
     assert rmv["last_success_time"] is None


### PR DESCRIPTION
## Summary

Fix several flaky integration tests that were causing `Integration tests (amd_binary, 3/5)` batch to timeout:

- **`test_backup_restore_new::test_mutation`**: Replace racy `sleep(3)` in mutation expressions with deterministic `SYSTEM STOP MERGES` to control which mutations are pending during backup
- **`test_backup_restore_new::test_incremental_backup_overflow`**: Add `@pytest.mark.timeout(1800)` since `OPTIMIZE TABLE FINAL` on 4GB uncompressed data exceeds the default 900s pytest timeout
- **`test_backup_restore_new::test_tables_dependency`**: Replace 18 sequential `contains_in_log` calls (each running `zgrep` via Docker exec) with a single `grep_in_log` call checked in Python
- **`test_backup_restore_s3` (4 tests)**: Remove `storage_policy='policy_s3_plain_rewritable'` from `query_log` config — no test needs it and it made every `SYSTEM FLUSH LOGS` and `TRUNCATE TABLE system.query_log` extremely slow. Also reduce data size from 10M to 1M rows in `test_backup_to_s3_copy_multipart_check_error_message`
- **`test_refreshable_mat_view::test_long_query_cancel`**: Propagate retry parameters to `query_with_retry` and increase wait time after `SYSTEM CANCEL VIEW` to account for the `Running` → `Scheduling` → `Scheduled` state transition

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96955&sha=404c092d77c264fae6f9921cdcbc428ce70040ec&name_0=PR&name_1=Integration%20tests%20%28amd_binary%2C%203%2F5%29
https://github.com/ClickHouse/ClickHouse/pull/96955

Related: #90662

## Test plan

- [x] All changes are in test code only — no production code modified
- [ ] Verify the previously failing tests pass in CI

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not for changelog — test-only changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.799`
<!-- ch-version-info:end -->