### PR TITLE
Fix flaky test `03100_lwu_40_cleanup_race`

### DIFF
--- a/tests/queries/0_stateless/03100_lwu_40_cleanup_race.reference
+++ b/tests/queries/0_stateless/03100_lwu_40_cleanup_race.reference
@@ -7,6 +7,7 @@ all_0_0_0_2	3	v3_updated
 t_lwu_cleanup_1	all_0_0_0
 t_lwu_cleanup_1	patch-9834becdf7e2e15ad7c410ffd6a5a63c-all_0_0_0_1
 t_lwu_cleanup_2	all_0_0_0_2
+t_lwu_cleanup_2	patch-9834becdf7e2e15ad7c410ffd6a5a63c-all_0_0_0_1
 all_0_0_0_2	1	v1_updated
 all_0_0_0_2	2	u2_updated
 all_0_0_0_2	3	v3_updated

--- a/tests/queries/0_stateless/03100_lwu_40_cleanup_race.sh
+++ b/tests/queries/0_stateless/03100_lwu_40_cleanup_race.sh
@@ -34,22 +34,35 @@ $CLICKHOUSE_CLIENT --query "
         max_cleanup_delay_period = 1,
         cleanup_delay_period_random_add = 0;
 
+    -- Stop cleanup on both replicas to prevent premature patch part removal.
+    -- SYSTEM STOP MERGES does not stop the cleanup thread, which can race
+    -- by cleaning up patch parts before the mutation incorporates them.
+    SYSTEM STOP CLEANUP t_lwu_cleanup_1;
+    SYSTEM STOP CLEANUP t_lwu_cleanup_2;
+
     SET enable_lightweight_update = 1;
     SET insert_keeper_fault_injection_probability = 0.0;
 
     INSERT INTO t_lwu_cleanup_1 VALUES (1, 'v1') (2, 'v2') (3, 'v3');
     SYSTEM SYNC REPLICA t_lwu_cleanup_1;
     SYSTEM STOP MERGES t_lwu_cleanup_1;
+    -- Stop fetches on replica 1 to prevent it from fetching all_0_0_0_2
+    -- from replica 2 before the first set of assertions.
+    SYSTEM STOP FETCHES t_lwu_cleanup_1;
 
     UPDATE t_lwu_cleanup_1 SET v = 'u2' WHERE k = 2;
     SYSTEM SYNC REPLICA t_lwu_cleanup_2;
 
     ALTER TABLE t_lwu_cleanup_2 UPDATE v = v || '_updated' WHERE 1 SETTINGS mutations_sync = 1;
     SYSTEM SYNC REPLICA t_lwu_cleanup_1 PULL;
+
+    -- Start cleanup on replica 2 only after the mutation has completed,
+    -- so the cleanup cannot remove the patch before the mutation incorporates it.
+    SYSTEM START CLEANUP t_lwu_cleanup_2;
 "
 
 for _ in {0..50}; do
-    res=`$CLICKHOUSE_CLIENT --query "SELECT count() FROM system.parts WHERE database = currentDatabase() AND table = 't_lwu_cleanup_2' AND active AND startsWith(name, 'patch')"`
+    res=$($CLICKHOUSE_CLIENT --query "SELECT count() FROM system.parts WHERE database = currentDatabase() AND table = 't_lwu_cleanup_2' AND active AND startsWith(name, 'patch')")
     if [[ $res == "0" ]]; then
         break
     fi
@@ -66,13 +79,21 @@ $CLICKHOUSE_CLIENT --query "
     WHERE database = currentDatabase() AND table IN ('t_lwu_cleanup_1', 't_lwu_cleanup_2') AND active
     ORDER BY table, name;
 
+    SYSTEM START FETCHES t_lwu_cleanup_1;
     SYSTEM START MERGES t_lwu_cleanup_1;
 "
 
+# Ensure that the GET_PART entry for the patch part is processed before
+# the MUTATE_PART entry can be selected. Use LIGHTWEIGHT mode because
+# DEFAULT would also wait for the MUTATE_PART entry which may be blocked.
+$CLICKHOUSE_CLIENT --query "SYSTEM SYNC REPLICA t_lwu_cleanup_1 LIGHTWEIGHT"
+
 wait_for_mutation "t_lwu_cleanup_1" "0000000000"
 
+$CLICKHOUSE_CLIENT --query "SYSTEM START CLEANUP t_lwu_cleanup_1"
+
 for _ in {0..50}; do
-    res=`$CLICKHOUSE_CLIENT --query "SELECT count() FROM system.parts WHERE database = currentDatabase() AND table = 't_lwu_cleanup_1' AND active AND startsWith(name, 'patch')"`
+    res=$($CLICKHOUSE_CLIENT --query "SELECT count() FROM system.parts WHERE database = currentDatabase() AND table = 't_lwu_cleanup_1' AND active AND startsWith(name, 'patch')")
     if [[ $res == "0" ]]; then
         break
     fi


### PR DESCRIPTION
## Summary
- The previous fix started cleanup on replica 2 before the mutation on replica 1 was processed, which caused a three-way deadlock in replica 1's replication queue
- The cleanup's `DROP_PART` log entry for the patch part caused: `GET_PART` blocked by `DROP_PART` (via `isAffectedByDropPart`), `MUTATE_PART` blocked by `GET_PART` ("patch not fetched"), `DROP_PART` blocked by `MUTATE_PART` ("mutation not executed")
- `SYSTEM SYNC REPLICA ... LIGHTWEIGHT` waited for `DROP_PART` (which LIGHTWEIGHT considers), creating a permanent timeout
- Fix by keeping cleanup stopped on both replicas until the mutation completes on both, then starting cleanup together

Closes #87397

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=97012&sha=61cb118895cfd593904e36f71b9b572f24be4118&name_0=PR&name_1=Fast%20test
https://github.com/ClickHouse/ClickHouse/pull/97012

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- ...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.762`
<!-- ch-version-info:end -->