### PR TITLE
Skip slow integration tests under LLVM coverage builds

### DIFF
--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -8,7 +8,11 @@ from typing import List, Tuple
 from more_itertools import tail
 
 from ci.jobs.scripts.find_tests import Targeting
-from ci.jobs.scripts.integration_tests_configs import IMAGES_ENV, get_optimal_test_batch
+from ci.jobs.scripts.integration_tests_configs import (
+    IMAGES_ENV,
+    LLVM_COVERAGE_SKIP_PREFIXES,
+    get_optimal_test_batch,
+)
 from ci.praktika.info import Info
 from ci.praktika.result import Result, ResultTranslator
 from ci.praktika.utils import ContextManager, Shell, Utils
@@ -192,6 +196,17 @@ def get_parallel_sequential_tests_to_run(
         str(p.relative_to("./tests/integration/"))
         for p in Path("./tests/integration/").glob("test_*/test*.py")
     ]
+
+    if "amd_llvm_coverage" in (job_options or ""):
+        before = len(test_files)
+        test_files = [
+            f
+            for f in test_files
+            if not any(f.startswith(prefix) for prefix in LLVM_COVERAGE_SKIP_PREFIXES)
+        ]
+        print(
+            f"LLVM coverage: skipped {before - len(test_files)} test files matching LLVM_COVERAGE_SKIP_PREFIXES"
+        )
 
     assert len(test_files) > 100
 

--- a/ci/jobs/scripts/integration_tests_configs.py
+++ b/ci/jobs/scripts/integration_tests_configs.py
@@ -12,6 +12,15 @@ class TC:
     comment: str
 
 
+# Tests that are too slow to run under LLVM coverage instrumentation.
+# They either timeout (900s per-test or 7200s session) or cause ClickHouse
+# to get stuck during shutdown while writing .profraw coverage data.
+LLVM_COVERAGE_SKIP_PREFIXES = [
+    "test_storage_s3_queue/test_6.py",
+    "test_named_collections_encrypted2/",
+    "test_multiple_disks/",
+]
+
 TEST_CONFIGS = [
     TC("test_dns_cache/", True, "no idea why i'm sequential"),
     TC("test_global_overcommit_tracker/", True, "no idea why i'm sequential"),


### PR DESCRIPTION
## Summary

- Skip `test_storage_s3_queue/test_6.py`, `test_named_collections_encrypted2/`, and `test_multiple_disks/` from LLVM coverage integration test runs
- These tests cause cascading timeouts in `Integration tests (amd_llvm_coverage)` because coverage instrumentation makes queries 10-30x slower
- Additionally, ClickHouse processes get stuck during shutdown while writing `.profraw` coverage data, becoming immune to `SIGKILL` and breaking all subsequent tests on the same worker

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=55eacdedafea443faf6fa59afdf033b5f072764b&name_0=MasterCI&name_1=Integration%20tests%20%28amd_llvm_coverage%2C%204%2F5%29

## Test plan

- [ ] Verify that LLVM coverage integration test batches no longer include the skipped tests
- [ ] Verify that non-coverage integration test runs still include these tests

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.755`
<!-- ch-version-info:end -->