### PR TITLE
Add a CI workflow to build PGO+BOLT optimized clang toolchain (3)

### DIFF
--- a/ci/jobs/build_toolchain.py
+++ b/ci/jobs/build_toolchain.py
@@ -209,13 +209,15 @@ def main():
                 name="Profile collection build (ClickHouse)",
                 command=f"ninja -C {CH_PROFILE_BUILD_DIR} clickhouse",
             )
-            results.append(build_result)
             if not build_result.is_ok():
                 print(
                     "ClickHouse build finished with errors"
                     " (link failures with instrumented compiler are expected)."
                     " Profraw files from compilation steps should still be available."
                 )
+                build_result.status = Result.Status.SUCCESS
+                build_result.info = "Build failed at link step (expected); profraw files collected"
+            results.append(build_result)
 
         # Merge profraw files using system llvm-profdata (stage 1 build lacks zlib
         # support, but the profraw files may contain zlib-compressed sections)
@@ -302,6 +304,7 @@ def main():
     # toolchain which provides ~23% compilation speedup.
     if res and JobStages.BOLT_OPTIMIZATION in stages:
         bolt_ok = True
+        bolt_results = []
         clang_binary = f"{STAGE2_INSTALL_DIR}/bin/clang-21"
 
         # Find the actual clang binary (it may be clang-21, clang-20, etc.)
@@ -337,7 +340,7 @@ def main():
                 f" --instrumentation-file={BOLT_PROFILES_DIR}/prof"
             ),
         )
-        results.append(result)
+        bolt_results.append(result)
         if not result.is_ok():
             bolt_ok = False
             print(
@@ -379,7 +382,7 @@ def main():
                 name="BOLT profile collection CMake",
                 command=cmake_cmd,
             )
-            results.append(result)
+            bolt_results.append(result)
             if not result.is_ok():
                 bolt_ok = False
                 print("BOLT profile collection cmake failed. Continuing with PGO-only.")
@@ -399,7 +402,7 @@ def main():
                     f" ; exit 0'"
                 ),
             )
-            results.append(result)
+            bolt_results.append(result)
 
             # Check if we collected any profiles
             fdata_files = glob.glob(f"{BOLT_PROFILES_DIR}/prof.*")
@@ -418,7 +421,7 @@ def main():
                     f" {BOLT_PROFILES_DIR}/prof.*"
                 ),
             )
-            results.append(result)
+            bolt_results.append(result)
             if not result.is_ok():
                 bolt_ok = False
                 print("BOLT profile merge failed. Continuing with PGO-only.")
@@ -441,7 +444,7 @@ def main():
                     f" -use-gnu-stack"
                 ),
             )
-            results.append(result)
+            bolt_results.append(result)
             if not result.is_ok():
                 bolt_ok = False
                 print("BOLT optimization failed. Continuing with PGO-only.")
@@ -452,14 +455,19 @@ def main():
                 name="Install BOLTed clang",
                 command=f"mv {clang_bolted} {clang_binary}",
             )
-            results.append(result)
+            bolt_results.append(result)
             if not result.is_ok():
                 bolt_ok = False
 
         if bolt_ok:
             print("BOLT optimization applied successfully")
+            results.extend(bolt_results)
         else:
             print("Packaging PGO-only toolchain (BOLT was skipped or failed)")
+            # Mark all BOLT results as skipped so they don't fail the overall job
+            for r in bolt_results:
+                r.status = Result.Status.SKIPPED
+            results.extend(bolt_results)
 
         # Clean up BOLT intermediates
         print("Cleaning BOLT intermediate files")


### PR DESCRIPTION
Profile collection build failure (link step with instrumented compiler) and BOLT failures (ADR relaxation on aarch64) are expected and should not fail the overall job. The PGO-only toolchain is still valid and useful.

- Mark profile collection build failure as success with info message
- Collect BOLT results separately; mark as skipped if BOLT fails

https://productionresultssa17.blob.core.windows.net/actions-results/d2c9a077-ff04-4bad-aaf8-b8c8d09bd4d7/workflow-job-run-9b56959e-dc94-5d19-99eb-21cb92815e85/logs/job/job-logs.txt

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.753`
<!-- ch-version-info:end -->