### PR TITLE
Move keeper_multiread_batch_size test config from private to public

### DIFF
--- a/tests/config/config.d/keeper_multiread_batch_size.xml
+++ b/tests/config/config.d/keeper_multiread_batch_size.xml
@@ -1,0 +1,3 @@
+<clickhouse>
+    <keeper_multiread_batch_size>300</keeper_multiread_batch_size>
+</clickhouse>

--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -163,6 +163,7 @@ ln -sf $SRC_PATH/config.d/storage_conf_03008.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/memory_access.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/jemalloc_flush_profile.yaml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/wait_remaining_connections.xml $DEST_SERVER_PATH/config.d/
+ln -sf $SRC_PATH/config.d/keeper_multiread_batch_size.xml $DEST_SERVER_PATH/config.d/
 
 if [ "$FAST_TEST" != "1" ]; then
     ln -sf $SRC_PATH/config.d/abort_on_logical_error.yaml $DEST_SERVER_PATH/config.d/


### PR DESCRIPTION
## Summary
- Add `keeper_multiread_batch_size` test config to the public repository
- The setting is already declared in public code (`src/Core/ServerSettings.cpp`, default 10,000)
- The test config sets it to 300 to exercise Keeper MultiRead batching logic more thoroughly in CI

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Move `keeper_multiread_batch_size` test configuration from private to public repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)