### PR TITLE
Add CI job to create PR updating `binary-builder` Dockerfile with PGO+BOLT toolchain

### DIFF
--- a/.github/workflows/optimize_toolchain.yml
+++ b/.github/workflows/optimize_toolchain.yml
@@ -210,9 +210,49 @@ jobs:
           prefix=lambda: datetime.datetime.now().strftime("[%Y-%m-%d %H:%M:%S]")
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
+  update_toolchain_dockerfile:
+    runs-on: [self-hosted, style-checker]
+    needs: [config_workflow, dockers_build_amd, dockers_build_arm, build_toolchain_pgo_bolt_amd64, build_toolchain_pgo_bolt_aarch64]
+    if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'VXBkYXRlIFRvb2xjaGFpbiBEb2NrZXJmaWxl') }}
+    name: "Update Toolchain Dockerfile"
+    outputs:
+      data: ${{ steps.run.outputs.DATA }}
+      pipeline_status: ${{ steps.run.outputs.pipeline_status || 'undefined' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - name: Prepare env script
+        run: |
+          rm -rf ./ci/tmp
+          mkdir -p ./ci/tmp
+          cat > ./ci/tmp/praktika_setup_env.sh << 'ENV_SETUP_SCRIPT_EOF'
+          export PYTHONPATH=./ci:.:
+          cat > ./ci/tmp/workflow_inputs.json << 'EOF'
+          ${{ toJson(github.event.inputs) }}
+          EOF
+          cat > ./ci/tmp/workflow_job.json << 'EOF'
+          ${{ toJson(job) }}
+          EOF
+          cat > ./ci/tmp/workflow_status.json << 'EOF'
+          ${{ toJson(needs) }}
+          EOF
+          ENV_SETUP_SCRIPT_EOF
+
+      - name: Run
+        id: run
+        run: |
+          . ./ci/tmp/praktika_setup_env.sh
+          set -o pipefail
+          PYTHONUNBUFFERED=1 python3 -m praktika run 'Update Toolchain Dockerfile' --workflow "OptimizeToolchain" --ci 2>&1 | python3 -u -c 'import sys,datetime
+          prefix=lambda: datetime.datetime.now().strftime("[%Y-%m-%d %H:%M:%S]")
+          for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
+
   finish_workflow:
     runs-on: [self-hosted, style-checker-aarch64]
-    needs: [config_workflow, dockers_build_amd, dockers_build_arm, build_toolchain_pgo_bolt_amd64, build_toolchain_pgo_bolt_aarch64]
+    needs: [config_workflow, dockers_build_amd, dockers_build_arm, build_toolchain_pgo_bolt_amd64, build_toolchain_pgo_bolt_aarch64, update_toolchain_dockerfile]
     if: ${{ always() }}
     name: "Finish Workflow"
     outputs:

--- a/ci/defs/defs.py
+++ b/ci/defs/defs.py
@@ -356,6 +356,7 @@ class JobNames:
     JEPSEN_SERVER = "ClickHouse Server Jepsen"
     LIBFUZZER_TEST = "libFuzzer tests"
     BUILD_TOOLCHAIN = "Build Toolchain (PGO, BOLT)"
+    UPDATE_TOOLCHAIN_DOCKERFILE = "Update Toolchain Dockerfile"
 
 
 class ToolSet:

--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -1198,6 +1198,12 @@ class JobConfigs:
             provides=[ArtifactNames.TOOLCHAIN_PGO_BOLT_ARM],
         ),
     )
+    update_toolchain_dockerfile_job = Job.Config(
+        name=JobNames.UPDATE_TOOLCHAIN_DOCKERFILE,
+        runs_on=RunnerLabels.STYLE_CHECK_AMD,
+        command="python3 ./ci/jobs/update_toolchain_dockerfile.py",
+        enable_gh_auth=True,
+    )
     vector_search_stress_job = Job.Config(
         name="Vector Search Stress",
         runs_on=RunnerLabels.ARM_MEDIUM,

--- a/ci/docker/binary-builder/Dockerfile
+++ b/ci/docker/binary-builder/Dockerfile
@@ -36,6 +36,19 @@ RUN add-apt-repository ppa:ubuntu-toolchain-r/test --yes \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /var/cache/debconf /tmp/*
 
+# Optional PGO+BOLT optimized toolchain override
+ARG TOOLCHAIN_COMMIT=none
+RUN if [ "$TOOLCHAIN_COMMIT" != "none" ]; then \
+    arch=${TARGETARCH:-amd64} && \
+    case $arch in \
+        amd64) tarch=amd64 ;; \
+        arm64) tarch=aarch64 ;; \
+    esac && \
+    curl -fsSL "https://clickhouse-builds.s3.amazonaws.com/REFs/master/${TOOLCHAIN_COMMIT}/build_toolchain_pgo_bolt_${tarch}/clang-pgo-bolt.tar.zst" \
+      | zstd -d | tar -xf - -C /usr/local/ && \
+    echo "Installed PGO+BOLT toolchain from commit ${TOOLCHAIN_COMMIT}" \
+    ; fi
+
 # Download and install mold for s390x build
 ARG MOLD_VERSION=2.40.4
 RUN arch=${TARGETARCH:-amd64} \

--- a/ci/jobs/update_toolchain_dockerfile.py
+++ b/ci/jobs/update_toolchain_dockerfile.py
@@ -1,0 +1,102 @@
+import re
+import shlex
+
+from praktika._environment import _Environment
+from praktika.result import Result
+from praktika.utils import Shell
+
+DOCKERFILE_PATH = "ci/docker/binary-builder/Dockerfile"
+S3_BUCKET = "clickhouse-builds.s3.amazonaws.com"
+
+
+def update_dockerfile(sha):
+    with open(DOCKERFILE_PATH, "r") as f:
+        content = f.read()
+
+    new_content = re.sub(
+        r"^(ARG TOOLCHAIN_COMMIT=).*$",
+        rf"\g<1>{sha}",
+        content,
+        flags=re.MULTILINE,
+    )
+
+    if new_content == content:
+        print("TOOLCHAIN_COMMIT ARG not found in the Dockerfile")
+        return False
+
+    with open(DOCKERFILE_PATH, "w") as f:
+        f.write(new_content)
+
+    return True
+
+
+def create_pr(sha):
+    short_sha = sha[:8]
+    branch = f"update-toolchain-{short_sha}"
+    amd_url = f"https://{S3_BUCKET}/REFs/master/{sha}/build_toolchain_pgo_bolt_amd64/clang-pgo-bolt.tar.zst"
+    arm_url = f"https://{S3_BUCKET}/REFs/master/{sha}/build_toolchain_pgo_bolt_aarch64/clang-pgo-bolt.tar.zst"
+
+    body = f"""\
+## Summary
+- Update `binary-builder` Dockerfile to use PGO+BOLT optimized toolchain from commit `{short_sha}`
+- Artifact URLs:
+  - amd64: {amd_url}
+  - aarch64: {arm_url}
+
+### Changelog category (leave one):
+- Build/Testing/Packaging Improvement
+
+### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
+- Use PGO+BOLT optimized clang toolchain for CI builds
+"""
+
+    commands = [
+        f"git checkout -b {branch}",
+        f"git add {DOCKERFILE_PATH}",
+        f'git commit -m "Update PGO+BOLT toolchain to {short_sha}"',
+        f"git push origin {branch}",
+    ]
+
+    if not Shell.check(
+        " && ".join(commands),
+        verbose=True,
+    ):
+        return False
+
+    if not Shell.check(
+        f'gh pr create --title "Update PGO+BOLT toolchain to {short_sha}" '
+        f"--body {shlex.quote(body)} "
+        f"--base master --head {branch}",
+        verbose=True,
+    ):
+        return False
+
+    return True
+
+
+if __name__ == "__main__":
+    env = _Environment.get()
+    sha = env.SHA
+
+    results = []
+    res = True
+
+    if res:
+        results.append(
+            Result.from_commands_run(
+                name="Update Dockerfile",
+                command=lambda: update_dockerfile(sha),
+            )
+        )
+        res = results[-1].is_ok()
+
+    if res:
+        results.append(
+            Result.from_commands_run(
+                name="Create PR",
+                command=lambda: create_pr(sha),
+            )
+        )
+        res = results[-1].is_ok()
+
+    Result.create_from(results=results).complete_job()

--- a/ci/workflows/optimize_toolchain.py
+++ b/ci/workflows/optimize_toolchain.py
@@ -9,6 +9,9 @@ workflow = Workflow.Config(
     branches=[BASE_BRANCH],
     jobs=[
         *JobConfigs.toolchain_build_jobs,
+        JobConfigs.update_toolchain_dockerfile_job.set_dependency(
+            [j.name for j in JobConfigs.toolchain_build_jobs]
+        ),
     ],
     dockers=DOCKERS,
     secrets=SECRETS,


### PR DESCRIPTION
After the OptimizeToolchain workflow builds PGO+BOLT optimized clang for both amd64 and aarch64, a new job now automatically creates a PR that updates `TOOLCHAIN_COMMIT` in the `binary-builder` Dockerfile.

The Dockerfile gains a conditional download block: when `TOOLCHAIN_COMMIT` is set to a commit SHA, it fetches the optimized toolchain from S3 and extracts to `/usr/local/`, where it shadows the apt-installed `clang-21` via PATH priority. The default value `none` preserves backward compatibility.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Use the PGO-optimized LLVM/Clang build in CI, which should give 20..30% build speed improvement.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.771`
<!-- ch-version-info:end -->