### PR TITLE
Fix is_inner_table logic and allow LowCardinality in external TimeSeries tables

### DIFF
--- a/src/Storages/StorageTimeSeries.cpp
+++ b/src/Storages/StorageTimeSeries.cpp
@@ -160,17 +160,12 @@ StorageTimeSeries::StorageTimeSeries(
         auto & target = targets.emplace_back();
         target.kind = target_kind;
         target.table_id = initTarget(target_kind, target_info, local_context, getStorageID(), columns, *storage_settings, mode);
-        target.is_inner_table = target_info && target_info->table_id.empty();
 
-        if (target_kind == ViewTarget::Metrics && !target.is_inner_table)
-        {
-            auto table = DatabaseCatalog::instance().tryGetTable(target.table_id, getContext());
-            auto metadata = table->getInMemoryMetadataPtr();
-
-            for (const auto & column : metadata->columns)
-                if (column.type->lowCardinality())
-                    throw Exception(ErrorCodes::SUPPORT_IS_DISABLED, "External metrics table cannot have LowCardnality columns for now.");
-        }
+        /// is_inner_table should be true when we're NOT using an external table.
+        /// An external table is specified only when target_info is non-null AND has a non-empty table_id.
+        /// This must be consistent with the is_external_target logic in initTarget().
+        bool is_external_target = target_info && !target_info->table_id.empty();
+        target.is_inner_table = !is_external_target;
 
         has_inner_tables |= target.is_inner_table;
     }

--- a/tests/queries/0_stateless/03918_timeseries_lowcardinality_external_table.reference
+++ b/tests/queries/0_stateless/03918_timeseries_lowcardinality_external_table.reference
@@ -1,0 +1,1 @@
+OK: TimeSeries table with LowCardinality external tables created successfully

--- a/tests/queries/0_stateless/03918_timeseries_lowcardinality_external_table.sql
+++ b/tests/queries/0_stateless/03918_timeseries_lowcardinality_external_table.sql
@@ -1,0 +1,50 @@
+-- Tags: no-fasttest
+-- Test that external TimeSeries tables with LowCardinality columns work correctly.
+-- Previously, LowCardinality columns in external metrics tables caused an error.
+-- Also verifies that is_inner_table is correctly determined for external tables.
+
+SET allow_experimental_time_series_table = 1;
+
+DROP TABLE IF EXISTS ts_lc_test;
+DROP TABLE IF EXISTS ts_lc_test_data;
+DROP TABLE IF EXISTS ts_lc_test_tags;
+DROP TABLE IF EXISTS ts_lc_test_metrics;
+
+-- Create external tables with LowCardinality columns
+CREATE TABLE ts_lc_test_data
+(
+    id UUID,
+    timestamp DateTime64(3),
+    value Float64
+) ENGINE = MergeTree ORDER BY (id, timestamp);
+
+CREATE TABLE ts_lc_test_tags
+(
+    id UUID,
+    metric_name LowCardinality(String),
+    tags Map(LowCardinality(String), String),
+    all_tags Map(String, String),
+    min_time Nullable(DateTime64(3)),
+    max_time Nullable(DateTime64(3))
+) ENGINE = AggregatingMergeTree ORDER BY (id, metric_name);
+
+CREATE TABLE ts_lc_test_metrics
+(
+    metric_family_name LowCardinality(String),
+    type LowCardinality(String),
+    unit LowCardinality(String),
+    help String
+) ENGINE = ReplacingMergeTree ORDER BY (metric_family_name, type, unit);
+
+-- This should NOT fail (previously threw SUPPORT_IS_DISABLED error)
+CREATE TABLE ts_lc_test ENGINE = TimeSeries
+    DATA ts_lc_test_data
+    TAGS ts_lc_test_tags
+    METRICS ts_lc_test_metrics;
+
+SELECT 'OK: TimeSeries table with LowCardinality external tables created successfully';
+
+DROP TABLE ts_lc_test;
+DROP TABLE ts_lc_test_metrics;
+DROP TABLE ts_lc_test_tags;
+DROP TABLE ts_lc_test_data;


### PR DESCRIPTION
## Summary
- Fix `is_inner_table` determination: previously returned false when no target was specified (null target_info), but inner tables should be created in that case. Now uses the same `is_external_target` logic as `initTarget()`
- Remove artificial LowCardinality restriction on external metrics tables that threw `SUPPORT_IS_DISABLED`. LowCardinality types (especially for metric_name, type, unit columns) are standard practice and the column validators already accept them

### Changelog category

Bug Fix

### Changelog entry

Fix is_inner_table logic and allow LowCardinality in external TimeSeries tables

## Test plan
- [x] SQL test `03918_timeseries_lowcardinality_external_table.sql` included with reference file
- [ ] CI/CD pipeline passes