### PR TITLE
Update Boost from 1.83 to 1.90

### DIFF
--- a/contrib/boost-cmake/CMakeLists.txt
+++ b/contrib/boost-cmake/CMakeLists.txt
@@ -82,9 +82,6 @@ target_include_directories (_boost_program_options SYSTEM BEFORE PUBLIC ${LIBRAR
 
 set (SRCS_REGEX
     "${LIBRARY_DIR}/libs/regex/src/posix_api.cpp"
-    "${LIBRARY_DIR}/libs/regex/src/regex_debug.cpp"
-    "${LIBRARY_DIR}/libs/regex/src/regex.cpp"
-    "${LIBRARY_DIR}/libs/regex/src/static_mutex.cpp"
     "${LIBRARY_DIR}/libs/regex/src/wide_posix_api.cpp"
 )
 
@@ -92,15 +89,11 @@ add_library (_boost_regex ${SRCS_REGEX})
 add_library (boost::regex ALIAS _boost_regex)
 target_include_directories (_boost_regex PRIVATE ${LIBRARY_DIR})
 
-# system
+# system (header-only since Boost 1.69)
 
-set (SRCS_SYSTEM
-    "${LIBRARY_DIR}/libs/system/src/error_code.cpp"
-)
-
-add_library (_boost_system ${SRCS_SYSTEM})
+add_library (_boost_system INTERFACE)
 add_library (boost::system ALIAS _boost_system)
-target_include_directories (_boost_system PRIVATE ${LIBRARY_DIR})
+target_include_directories (_boost_system SYSTEM BEFORE INTERFACE ${LIBRARY_DIR})
 
 # context
 option (BOOST_USE_UCONTEXT "Use ucontext_t for context switching of boost::fiber within boost::context" OFF)
@@ -110,6 +103,7 @@ SET(ASM_OPTIONS "-x assembler-with-cpp")
 
 set (SRCS_CONTEXT
     "${LIBRARY_DIR}/libs/context/src/dummy.cpp"
+    "${LIBRARY_DIR}/libs/context/src/fcontext.cpp"
     "${LIBRARY_DIR}/libs/context/src/posix/stack_traits.cpp"
 )
 


### PR DESCRIPTION
## Summary

Update the vendored Boost library from 1.83 to 1.90.0.

This fixes an assertion failure in `boost::container::devector::insert_range_slow_path` ([boostorg/container#285](https://github.com/boostorg/container/issues/285)) that was causing AST fuzzer crashes in debug builds via `MergeTreeReadPoolParallelReplicasInOrder::getTask`.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96995&sha=5e707452dacf706640a7f6810eff0ce286834d0d&name_0=PR&name_1=AST%20fuzzer%20%28amd_debug%29
https://github.com/ClickHouse/ClickHouse/pull/96995

### Notable upstream fixes included
- `devector::insert_range_slow_path` assertion fix — the assertion `should_move_back(p) ? (back_free_cap < n) : (front_free_cap < n)` was incorrect when `insert(begin(), ...)` was called on a devector with `size() == 1`
- s390x context: store entry point arguments in fiber's own stack
- PPC64 context: save/restore TOC pointer (r2) during context switch
- Phoenix ODR violation fix

### ClickHouse patches dropped (fixed upstream)
- Apple M1 ARM64 ASM guards (upstream has proper MACH-O support)
- `boost::geometry` rescaling (rescaling mechanism removed entirely)
- Phoenix ODR `const` fix (disabled upstream)
- s390x fiber stack fix (merged upstream)
- PPC64 TOC pointer fix (merged upstream)

### ClickHouse patches re-applied (9 of 12)
- `BOOST_FILESYSTEM_NO_CXX20_ATOMIC_REF`
- PowerPC SSE2 shim cross-build fix
- MSan epoll `__msan_unpoison` annotation
- Fiber destructor `is_started` guard
- clang-tidy NOLINT warnings (2 patches)
- SIMD PPC+x86 architecture check disable
- `std::unary_function`/`std::binary_function` removal
- illumos `DS` macro conflict fix

### CMake changes
- Add `fcontext.cpp` to context sources (new C-to-C++ bridge in Boost 1.90)
- Remove deleted regex source files (became header-only)
- Convert `boost::system` to interface library (header-only since Boost 1.69)

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Update Boost from 1.83 to 1.90, fixing a `devector` assertion failure in debug builds.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.773`
<!-- ch-version-info:end -->