### PR TITLE
Fix flaky test 03716_mutations_parts_postpone_reasons_mt (2)

### DIFF
--- a/tests/queries/0_stateless/03716_mutations_parts_postpone_reasons_mt.sh
+++ b/tests/queries/0_stateless/03716_mutations_parts_postpone_reasons_mt.sh
@@ -27,6 +27,8 @@ $CLICKHOUSE_CLIENT --query "
     SYSTEM ENABLE FAILPOINT mt_select_parts_to_mutate_no_free_threads;
     SYSTEM NOTIFY FAILPOINT mt_merge_selecting_task_pause_when_scheduled;
     SYSTEM WAIT FAILPOINT mt_merge_selecting_task_pause_when_scheduled PAUSE;
+    SYSTEM NOTIFY FAILPOINT mt_merge_selecting_task_pause_when_scheduled;
+    SYSTEM WAIT FAILPOINT mt_merge_selecting_task_pause_when_scheduled PAUSE;
 "
 
 $CLICKHOUSE_CLIENT --query "
@@ -49,6 +51,8 @@ $CLICKHOUSE_CLIENT --query "
     ALTER TABLE mt UPDATE num = num + 2 WHERE 1;
     ALTER TABLE mt UPDATE num = num + 3 WHERE 1;
     SYSTEM ENABLE FAILPOINT mt_select_parts_to_mutate_no_free_threads;
+    SYSTEM NOTIFY FAILPOINT mt_merge_selecting_task_pause_when_scheduled;
+    SYSTEM WAIT FAILPOINT mt_merge_selecting_task_pause_when_scheduled PAUSE;
     SYSTEM NOTIFY FAILPOINT mt_merge_selecting_task_pause_when_scheduled;
     SYSTEM WAIT FAILPOINT mt_merge_selecting_task_pause_when_scheduled PAUSE;
 "
@@ -81,6 +85,8 @@ $CLICKHOUSE_CLIENT --query "
     SYSTEM ENABLE FAILPOINT mt_select_parts_to_mutate_max_part_size;
     SYSTEM NOTIFY FAILPOINT mt_merge_selecting_task_pause_when_scheduled;
     SYSTEM WAIT FAILPOINT mt_merge_selecting_task_pause_when_scheduled PAUSE;
+    SYSTEM NOTIFY FAILPOINT mt_merge_selecting_task_pause_when_scheduled;
+    SYSTEM WAIT FAILPOINT mt_merge_selecting_task_pause_when_scheduled PAUSE;
 "
 
 $CLICKHOUSE_CLIENT --query "
@@ -103,6 +109,8 @@ $CLICKHOUSE_CLIENT --query "
     ALTER TABLE mt UPDATE num = num + 2 WHERE 1;
     ALTER TABLE mt UPDATE num = num + 3 WHERE 1;
     SYSTEM ENABLE FAILPOINT mt_select_parts_to_mutate_max_part_size;
+    SYSTEM NOTIFY FAILPOINT mt_merge_selecting_task_pause_when_scheduled;
+    SYSTEM WAIT FAILPOINT mt_merge_selecting_task_pause_when_scheduled PAUSE;
     SYSTEM NOTIFY FAILPOINT mt_merge_selecting_task_pause_when_scheduled;
     SYSTEM WAIT FAILPOINT mt_merge_selecting_task_pause_when_scheduled PAUSE;
 "


### PR DESCRIPTION
## Summary
- Add extra NOTIFY/WAIT failpoint cycles in all 4 test cases of `03716_mutations_parts_postpone_reasons_mt` to ensure the merge-selecting background task runs enough iterations to populate `parts_postpone_reasons`.
- The test was sporadically failing because after the first NOTIFY/WAIT, `selectPartsToMutate` was not always called — the mutation may not yet have been registered in `current_mutations_by_version` at the time of the check in `scheduleDataProcessingJob`. An additional iteration makes this robust.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=97025&sha=b1c937951a048f66fe202259823cb640d8b38800&name_0=PR&name_1=Stateless%20tests%20%28amd_binary%2C%20ParallelReplicas%2C%20s3%20storage%2C%20sequential%29
https://github.com/ClickHouse/ClickHouse/pull/97025

## Test plan
- [ ] CI passes `03716_mutations_parts_postpone_reasons_mt` without flakes

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)