### PR TITLE
Fix flaky test 03716_mutations_parts_postpone_reasons_mt (1)

### DIFF
--- a/tests/queries/0_stateless/03716_mutations_parts_postpone_reasons_mt.sh
+++ b/tests/queries/0_stateless/03716_mutations_parts_postpone_reasons_mt.sh
@@ -11,6 +11,28 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 set -e
 
+# Wait until at least one non-done mutation for the given table has non-empty
+# parts_postpone_reasons. The failpoints that block mutation selection keep the
+# state stable once set, so polling is safe.
+function wait_for_postpone_reasons()
+{
+    local table=$1
+    for _ in $(seq 1 300); do
+        result=$($CLICKHOUSE_CLIENT --query "
+            SELECT count()
+            FROM system.mutations
+            WHERE database = '$CLICKHOUSE_DATABASE' AND table = '$table'
+              AND NOT is_done AND notEmpty(parts_postpone_reasons)
+        ")
+        if [ "$result" -gt 0 ]; then
+            return 0
+        fi
+        sleep 0.1
+    done
+    echo "Timed out waiting for parts_postpone_reasons" >&2
+    return 1
+}
+
 $CLICKHOUSE_CLIENT --query "
     CREATE TABLE mt (id UInt64, num UInt64)
     ENGINE = MergeTree()
@@ -20,14 +42,15 @@ $CLICKHOUSE_CLIENT --query "
 "
 
 #test1 'all_parts'->no thread in pool for one mutation
+# Enable the failpoint before creating the mutation to guarantee every
+# selectPartsToMutate call sees it. No pause failpoint needed: since the
+# failpoint blocks mutation selection, the state is stable once set.
 $CLICKHOUSE_CLIENT --query "
-    SYSTEM ENABLE FAILPOINT mt_merge_selecting_task_pause_when_scheduled;
-    SYSTEM WAIT FAILPOINT mt_merge_selecting_task_pause_when_scheduled PAUSE;
-    ALTER TABLE mt UPDATE num = num + 1 WHERE 1;
     SYSTEM ENABLE FAILPOINT mt_select_parts_to_mutate_no_free_threads;
-    SYSTEM NOTIFY FAILPOINT mt_merge_selecting_task_pause_when_scheduled;
-    SYSTEM WAIT FAILPOINT mt_merge_selecting_task_pause_when_scheduled PAUSE;
+    ALTER TABLE mt UPDATE num = num + 1 WHERE 1;
 "
+
+wait_for_postpone_reasons "mt"
 
 $CLICKHOUSE_CLIENT --query "
     SELECT mutation_id, command, parts_to_do_names, parts_in_progress_names, parts_postpone_reasons, \
@@ -36,7 +59,6 @@ $CLICKHOUSE_CLIENT --query "
 "
 
 $CLICKHOUSE_CLIENT --query "
-    SYSTEM DISABLE FAILPOINT mt_merge_selecting_task_pause_when_scheduled;
     SYSTEM DISABLE FAILPOINT mt_select_parts_to_mutate_no_free_threads;
 "
 
@@ -44,14 +66,12 @@ wait_for_mutation "mt" "mutation_2.txt"
 
 #test2 'all_parts'->no thread in pool for multiple mutations
 $CLICKHOUSE_CLIENT --query "
-    SYSTEM ENABLE FAILPOINT mt_merge_selecting_task_pause_when_scheduled;
-    SYSTEM WAIT FAILPOINT mt_merge_selecting_task_pause_when_scheduled PAUSE;
+    SYSTEM ENABLE FAILPOINT mt_select_parts_to_mutate_no_free_threads;
     ALTER TABLE mt UPDATE num = num + 2 WHERE 1;
     ALTER TABLE mt UPDATE num = num + 3 WHERE 1;
-    SYSTEM ENABLE FAILPOINT mt_select_parts_to_mutate_no_free_threads;
-    SYSTEM NOTIFY FAILPOINT mt_merge_selecting_task_pause_when_scheduled;
-    SYSTEM WAIT FAILPOINT mt_merge_selecting_task_pause_when_scheduled PAUSE;
 "
+
+wait_for_postpone_reasons "mt"
 
 $CLICKHOUSE_CLIENT --query "
     SELECT mutation_id, command, parts_to_do_names, parts_in_progress_names, parts_postpone_reasons, \
@@ -60,7 +80,6 @@ $CLICKHOUSE_CLIENT --query "
 "
 
 $CLICKHOUSE_CLIENT --query "
-    SYSTEM DISABLE FAILPOINT mt_merge_selecting_task_pause_when_scheduled;
     SYSTEM DISABLE FAILPOINT mt_select_parts_to_mutate_no_free_threads;
     DROP TABLE mt SYNC;
 "
@@ -75,13 +94,11 @@ $CLICKHOUSE_CLIENT --query "
 
 #test3 part->postpone reasons in pool for one mutation
 $CLICKHOUSE_CLIENT --query "
-    SYSTEM ENABLE FAILPOINT mt_merge_selecting_task_pause_when_scheduled;
-    SYSTEM WAIT FAILPOINT mt_merge_selecting_task_pause_when_scheduled PAUSE;
-    ALTER TABLE mt UPDATE num = num + 1 WHERE 1;
     SYSTEM ENABLE FAILPOINT mt_select_parts_to_mutate_max_part_size;
-    SYSTEM NOTIFY FAILPOINT mt_merge_selecting_task_pause_when_scheduled;
-    SYSTEM WAIT FAILPOINT mt_merge_selecting_task_pause_when_scheduled PAUSE;
+    ALTER TABLE mt UPDATE num = num + 1 WHERE 1;
 "
+
+wait_for_postpone_reasons "mt"
 
 $CLICKHOUSE_CLIENT --query "
     SELECT mutation_id, command, parts_to_do_names, parts_in_progress_names, parts_postpone_reasons, \
@@ -90,7 +107,6 @@ $CLICKHOUSE_CLIENT --query "
 "
 
 $CLICKHOUSE_CLIENT --query "
-    SYSTEM DISABLE FAILPOINT mt_merge_selecting_task_pause_when_scheduled;
     SYSTEM DISABLE FAILPOINT mt_select_parts_to_mutate_max_part_size;
 "
 
@@ -98,14 +114,12 @@ wait_for_mutation "mt" "mutation_2.txt"
 
 #test4 part->postpone reasons for multiple mutations
 $CLICKHOUSE_CLIENT --query "
-    SYSTEM ENABLE FAILPOINT mt_merge_selecting_task_pause_when_scheduled;
-    SYSTEM WAIT FAILPOINT mt_merge_selecting_task_pause_when_scheduled PAUSE;
+    SYSTEM ENABLE FAILPOINT mt_select_parts_to_mutate_max_part_size;
     ALTER TABLE mt UPDATE num = num + 2 WHERE 1;
     ALTER TABLE mt UPDATE num = num + 3 WHERE 1;
-    SYSTEM ENABLE FAILPOINT mt_select_parts_to_mutate_max_part_size;
-    SYSTEM NOTIFY FAILPOINT mt_merge_selecting_task_pause_when_scheduled;
-    SYSTEM WAIT FAILPOINT mt_merge_selecting_task_pause_when_scheduled PAUSE;
 "
+
+wait_for_postpone_reasons "mt"
 
 $CLICKHOUSE_CLIENT --query "
     SELECT mutation_id, command, parts_to_do_names, parts_in_progress_names, parts_postpone_reasons, \
@@ -114,7 +128,6 @@ $CLICKHOUSE_CLIENT --query "
 "
 
 $CLICKHOUSE_CLIENT --query "
-    SYSTEM DISABLE FAILPOINT mt_merge_selecting_task_pause_when_scheduled;
     SYSTEM DISABLE FAILPOINT mt_select_parts_to_mutate_max_part_size;
     DROP TABLE mt SYNC;
 "


### PR DESCRIPTION
## Summary
- The `mt_merge_selecting_task_pause_when_scheduled` failpoint is global and hit by ALL `MergeTree` tables, including system log tables (`system.query_log`, `system.trace_log`, etc.)
- When the test does `SYSTEM NOTIFY FAILPOINT`, it wakes all paused threads; the subsequent `SYSTEM WAIT FAILPOINT ... PAUSE` may catch a system table's background task pausing before the test table's `selectPartsToMutate` has run, leaving `current_parts_postpone_reasons` empty
- Replace the fragile pause-notify-wait synchronization with simple polling: enable the blocking failpoint before creating mutations, then poll `system.mutations` until `parts_postpone_reasons` is populated

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=97025&sha=b1c937951a048f66fe202259823cb640d8b38800&name_0=PR&name_1=Stateless%20tests%20%28amd_binary%2C%20ParallelReplicas%2C%20s3%20storage%2C%20sequential%29
https://github.com/ClickHouse/ClickHouse/pull/97025

## Test plan
- [x] Verified locally with 5 consecutive clean runs
- [ ] CI stateless tests pass

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.796`
<!-- ch-version-info:end -->