### PR TITLE
Fix `ALTER MODIFY COLUMN` with statistics

### DIFF
--- a/src/Storages/MergeTree/MutateTask.cpp
+++ b/src/Storages/MergeTree/MutateTask.cpp
@@ -1082,9 +1082,6 @@ static void processStatisticsChanges(
     const IMergeTreeDataPart & source_part,
     StorageMetadataPtr metadata_snapshot)
 {
-    if (all_statistics.empty())
-        return;
-
     auto storage_settings = source_part.storage.getSettings();
     String statistics_file_name(ColumnsStatistics::FILENAME);
 
@@ -1137,6 +1134,7 @@ static void processStatisticsChanges(
     /// Remove old statistics files.
     if (isFullPartStorage(source_part.getDataPartStorage()))
     {
+        /// File with statistics is always written during mutation.bgf
         files_to_skip.emplace(statistics_file_name);
         const auto & source_checksums = source_part.checksums;
 

--- a/src/Storages/MergeTree/MutateTask.cpp
+++ b/src/Storages/MergeTree/MutateTask.cpp
@@ -1,3 +1,4 @@
+#include <Interpreters/TreeRewriter.h>
 #include <Storages/MergeTree/MutateTask.h>
 
 #include <Disks/SingleDiskVolume.h>
@@ -1081,11 +1082,11 @@ static void processStatisticsChanges(
     const IMergeTreeDataPart & source_part,
     StorageMetadataPtr metadata_snapshot)
 {
+    if (all_statistics.empty())
+        return;
+
     auto storage_settings = source_part.storage.getSettings();
     String statistics_file_name(ColumnsStatistics::FILENAME);
-
-    bool modified_statistics = false;
-    bool is_full_part_storage = isFullPartStorage(source_part.getDataPartStorage());
 
     auto process_rename = [&](const String & from_name, const String & to_name)
     {
@@ -1097,10 +1098,6 @@ static void processStatisticsChanges(
             all_statistics.emplace(to_name, it->second);
 
         all_statistics.erase(it);
-        modified_statistics = true;
-
-        if (is_full_part_storage)
-            files_to_skip.emplace(statistics_file_name);
     };
 
     for (const auto & command : commands_for_renames)
@@ -1132,18 +1129,15 @@ static void processStatisticsChanges(
 
     if (!stats_to_recalc.empty())
     {
-        modified_statistics = true;
         /// Create empty statistics for columns that are being recalculated.
         for (const auto & [stat_name, stat] : stats_to_recalc)
             all_statistics[stat_name] = stat->cloneEmpty();
-
-        if (is_full_part_storage)
-            files_to_skip.emplace(ColumnsStatistics::FILENAME);
     }
 
     /// Remove old statistics files.
     if (isFullPartStorage(source_part.getDataPartStorage()))
     {
+        files_to_skip.emplace(statistics_file_name);
         const auto & source_checksums = source_part.checksums;
 
         if (all_statistics.empty() && source_checksums.files.contains(statistics_file_name))
@@ -1151,15 +1145,12 @@ static void processStatisticsChanges(
             files_to_rename.emplace_back(statistics_file_name, "");
         }
 
-        if (modified_statistics)
+        /// Always write statistics in a new format.
+        /// Remove old statistics files.
+        for (const auto & [filename, _] : source_checksums.files)
         {
-            /// If statistics are changed, always write them in a new format.
-            /// Remove old statistics files.
-            for (const auto & [filename, _] : source_checksums.files)
-            {
-                if (filename.starts_with(STATS_FILE_PREFIX) && filename.ends_with(STATS_FILE_SUFFIX))
-                    files_to_rename.emplace_back(filename, "");
-            }
+            if (filename.starts_with(STATS_FILE_PREFIX) && filename.ends_with(STATS_FILE_SUFFIX))
+                files_to_rename.emplace_back(filename, "");
         }
     }
 }
@@ -2503,7 +2494,7 @@ void MutateTask::updateProfileEvents() const
     ProfileEvents::increment(ProfileEvents::MutationExecuteMilliseconds, execute_elapsed_ms);
 }
 
-static bool canSkipConversionToNullable(const MergeTreeDataPartPtr & part, const MutationCommand & command)
+static bool canSkipConversionToNullable(const MergeTreeDataPartPtr & part, const StorageMetadataPtr & metadata_snapshot, const MutationCommand & command)
 {
     if (command.type != MutationCommand::READ_COLUMN)
         return false;
@@ -2525,6 +2516,11 @@ static bool canSkipConversionToNullable(const MergeTreeDataPartPtr & part, const
     if (serialization->getKindStack() != ISerialization::KindStack{ISerialization::Kind::DEFAULT})
         return false;
 
+    /// We need to rewrite statistics because they have different serialization with nullable type.
+    const auto * column_desc = metadata_snapshot->getColumns().tryGet(command.column_name);
+    if (!column_desc->statistics.empty())
+        return false;
+
     return true;
 }
 
@@ -2542,7 +2538,7 @@ static bool canSkipConversionToVariant(const MergeTreeDataPartPtr & part, const 
     return isVariantExtension(part_column->type, command.data_type);
 }
 
-static bool canSkipMutationCommandForPart(const MergeTreeDataPartPtr & part, const MutationCommand & command, const ContextPtr & context)
+static bool canSkipMutationCommandForPart(const MergeTreeDataPartPtr & part, const StorageMetadataPtr & metadata_snapshot, const MutationCommand & command, const ContextPtr & context)
 {
     if (command.partition)
     {
@@ -2558,7 +2554,7 @@ static bool canSkipMutationCommandForPart(const MergeTreeDataPartPtr & part, con
     if (command.type == MutationCommand::APPLY_DELETED_MASK && !part->hasLightweightDelete())
         return true;
 
-    if (canSkipConversionToNullable(part, command))
+    if (canSkipConversionToNullable(part, metadata_snapshot, command))
         return true;
 
     if (canSkipConversionToVariant(part, command))
@@ -2673,7 +2669,7 @@ bool MutateTask::prepare()
 
     for (const auto & command : *ctx->commands)
     {
-        if (!canSkipMutationCommandForPart(ctx->source_part, command, context_for_reading))
+        if (!canSkipMutationCommandForPart(ctx->source_part, ctx->metadata_snapshot, command, context_for_reading))
             ctx->commands_for_part.emplace_back(command);
     }
 

--- a/tests/queries/0_stateless/02669_alter_modify_to_nullable.sql
+++ b/tests/queries/0_stateless/02669_alter_modify_to_nullable.sql
@@ -2,7 +2,7 @@ DROP TABLE IF EXISTS t_modify_to_nullable;
 
 CREATE TABLE t_modify_to_nullable (key UInt64, id UInt64, s String)
 ENGINE = MergeTree ORDER BY id PARTITION BY key
-SETTINGS min_bytes_for_wide_part = 0, ratio_of_defaults_for_sparse_serialization = 0.9;
+SETTINGS min_bytes_for_wide_part = 0, ratio_of_defaults_for_sparse_serialization = 0.9, auto_statistics_types = '';
 
 INSERT INTO t_modify_to_nullable SELECT 1, number, 'foo' FROM numbers(10000);
 INSERT INTO t_modify_to_nullable SELECT 2, number, if (number % 23 = 0, 'bar', '') FROM numbers(10000);

--- a/tests/queries/0_stateless/03919_modify_nullable_statistics.reference
+++ b/tests/queries/0_stateless/03919_modify_nullable_statistics.reference
@@ -1,0 +1,8 @@
+t_stat_nullable_1	B	String	['Uniq']	1
+t_stat_nullable_2	B	String	['Uniq']	1
+t_stat_nullable_1	B	String	['Uniq']	1
+t_stat_nullable_2	B	String	['Uniq']	1
+1	test1	test
+1	test1	test
+t_stat_nullable_1	B	Nullable(String)	['Uniq']	2
+t_stat_nullable_2	B	Nullable(String)	['Uniq']	2

--- a/tests/queries/0_stateless/03919_modify_nullable_statistics.sql
+++ b/tests/queries/0_stateless/03919_modify_nullable_statistics.sql
@@ -14,6 +14,7 @@ SETTINGS min_bytes_for_wide_part = 0, auto_statistics_types = 'uniq';
 set mutations_sync = 2;
 
 insert into t_stat_nullable_1 values(1, 'one', 'test');
+system sync replica t_stat_nullable_2;
 
 select table, column, type, statistics, estimates.cardinality
 from system.parts_columns

--- a/tests/queries/0_stateless/03919_modify_nullable_statistics.sql
+++ b/tests/queries/0_stateless/03919_modify_nullable_statistics.sql
@@ -1,0 +1,46 @@
+drop table if exists t_stat_nullable_1 sync;
+drop table if exists t_stat_nullable_2 sync;
+
+create table t_stat_nullable_1(A Int64, B String, C String)
+Engine = ReplicatedMergeTree('/clickhouse/{database}/tables/t_stat_nullable', '1')
+order by A
+SETTINGS min_bytes_for_wide_part = 0, auto_statistics_types = 'uniq';
+
+create table t_stat_nullable_2( A Int64, B String, C String)
+Engine = ReplicatedMergeTree('/clickhouse/{database}/tables/t_stat_nullable', '2')
+order by A
+SETTINGS min_bytes_for_wide_part = 0, auto_statistics_types = 'uniq';
+
+set mutations_sync = 2;
+
+insert into t_stat_nullable_1 values(1, 'one', 'test');
+
+select table, column, type, statistics, estimates.cardinality
+from system.parts_columns
+where database = currentDatabase() and table like 't_stat_nullable%' and column = 'B' and active;
+
+alter table t_stat_nullable_1 detach partition tuple();
+system sync replica t_stat_nullable_2;
+
+alter table t_stat_nullable_1 modify column B Nullable(String);
+system sync replica t_stat_nullable_2;
+
+alter table t_stat_nullable_1 attach partition tuple();
+system sync replica t_stat_nullable_2;
+
+select table, column, type, statistics, estimates.cardinality
+from system.parts_columns
+where database = currentDatabase() and table like 't_stat_nullable%' and column = 'B' and active;
+
+alter table t_stat_nullable_1 update B = 'test1' where 1;
+system sync replica t_stat_nullable_2;
+
+select * from t_stat_nullable_1;
+select * from t_stat_nullable_2;
+
+select table, column, type, statistics, estimates.cardinality
+from system.parts_columns
+where database = currentDatabase() and table like 't_stat_nullable%' and column = 'B' and active;
+
+drop table if exists t_stat_nullable_1 sync;
+drop table if exists t_stat_nullable_2 sync;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Bug fix for unreleased feature.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.772`
<!-- ch-version-info:end -->