### PR TITLE
Add a CI workflow to build PGO+BOLT optimized clang toolchain (4)

### DIFF
--- a/ci/jobs/build_toolchain.py
+++ b/ci/jobs/build_toolchain.py
@@ -481,14 +481,15 @@ def main():
 
     # Stage 5: Package
     if res and JobStages.PACKAGE in stages:
-        # Strip executables and shared libraries to reduce archive size
-        # (relocations from --emit-relocs and LTO symbols are no longer needed)
+        # Strip ELF executables and shared libraries to reduce archive size
+        # (relocations from --emit-relocs and LTO symbols are no longer needed).
+        # Use "file" to skip scripts (Python, Perl, shell) that strip cannot handle.
         results.append(
             Result.from_commands_run(
                 name="Strip binaries",
                 command=(
                     f"find {STAGE2_INSTALL_DIR}/bin -type f -executable"
-                    f" -exec strip --strip-unneeded {{}} +"
+                    f" -exec sh -c 'file \"$1\" | grep -q ELF && strip --strip-unneeded \"$1\"' _ {{}} \\;"
                     f" && find {STAGE2_INSTALL_DIR}/lib -name '*.so*' -type f"
                     f" -exec strip --strip-unneeded {{}} +"
                 ),


### PR DESCRIPTION
The strip step failed on aarch64 because several LLVM tools (`run-clang-tidy`, `git-clang-format`, `scan-build`, etc.) are Python/Perl scripts, not ELF binaries. Use `file` to check each executable before stripping.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.770`
<!-- ch-version-info:end -->