### PR TITLE
Add a CI workflow to build PGO+BOLT optimized clang toolchain (5)

### DIFF
--- a/.github/workflows/optimize_toolchain.yml
+++ b/.github/workflows/optimize_toolchain.yml
@@ -8,6 +8,8 @@ on:
 env:
   PYTHONUNBUFFERED: 1
   CHECKOUT_REF: ""
+# Allow updating GH commit statuses and PR comments to post an actual job reports link
+permissions: write-all
 
 jobs:
 

--- a/ci/praktika/yaml_generator.py
+++ b/ci/praktika/yaml_generator.py
@@ -99,6 +99,7 @@ on:
 env:
   PYTHONUNBUFFERED: 1
 {ENV_CHECKOUT_REFERENCE}
+{GH_TOKEN_PERMISSIONS}
 
 jobs:
 {JOBS}\
@@ -425,7 +426,12 @@ class PullRequestPushYamlGen:
             )
         elif self.workflow_config.event in (Workflow.Event.DISPATCH,):
             base_template = YamlGenerator.Templates.TEMPLATE_DISPATCH_WORKFLOW
-            format_kwargs = {"DISPATCH_INPUTS": dispatch_inputs}
+            format_kwargs = {
+                "DISPATCH_INPUTS": dispatch_inputs,
+                "GH_TOKEN_PERMISSIONS": (
+                    YamlGenerator.Templates.TEMPLATE_GH_TOKEN_PERMISSIONS
+                ),
+            }
             ENV_CHECKOUT_REFERENCE = (
                 YamlGenerator.Templates.TEMPLATE_ENV_CHECKOUT_REF_DEFAULT
             )


### PR DESCRIPTION
The OptimizeToolchain workflow (which uses `Workflow.Event.DISPATCH`) was missing `permissions: write-all`, causing `github-actions[bot]` to get "Permission denied" when trying to push. The PULL_REQUEST and PUSH templates already had this, but the DISPATCH template did not.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.797`
<!-- ch-version-info:end -->