### PR TITLE
Fix partition pruning (indexes) for row policy/PREWHERE with FINAL

### DIFF
--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -2033,11 +2033,41 @@ void ReadFromMergeTree::buildIndexes(
     indexes->skip_indexes = std::move(skip_indexes);
 }
 
+void ReadFromMergeTree::deferFiltersAfterFinalIfNeeded()
+{
+    if (!isQueryWithFinal())
+        return;
+
+    const auto & settings = context->getSettingsRef();
+    bool defer_row_policy = settings[Setting::apply_row_policy_after_final] && query_info.row_level_filter;
+    bool defer_prewhere = settings[Setting::apply_prewhere_after_final] && query_info.prewhere_info;
+
+    /// row policy must run before prewhere. If row policy touches non-sorting-key columns, defer prewhere too
+    if (defer_row_policy && query_info.prewhere_info)
+    {
+        const auto & sorting_key_columns = storage_snapshot->metadata->getSortingKeyColumns();
+        NameSet sorting_key_columns_set(sorting_key_columns.begin(), sorting_key_columns.end());
+
+        auto required = query_info.row_level_filter->actions.getRequiredColumnsNames();
+        bool all_in_sorting_key = std::all_of(
+            required.begin(), required.end(),
+            [&](const auto & col) { return sorting_key_columns_set.contains(col); });
+        if (!all_in_sorting_key)
+            defer_prewhere = true;
+    }
+
+    if (defer_row_policy)
+        deferred_row_level_filter = query_info.row_level_filter;
+    if (defer_prewhere)
+        deferred_prewhere_info = query_info.prewhere_info;
+}
+
 void ReadFromMergeTree::applyFilters(ActionDAGNodes added_filter_nodes)
 {
     if (!indexes)
     {
-        auto dag = ActionsDAG::buildFilterActionsDAG(added_filter_nodes.nodes, query_info.buildNodeNameToInputNodeColumn());
+        auto node_name_to_input = query_info.buildNodeNameToInputNodeColumn();
+        auto dag = ActionsDAG::buildFilterActionsDAG(added_filter_nodes.nodes, node_name_to_input);
         filter_actions_dag = dag ? std::make_shared<const ActionsDAG>(std::move(*dag)) : nullptr;
 
         /// NOTE: Currently we store two DAGs for analysis:
@@ -2047,9 +2077,44 @@ void ReadFromMergeTree::applyFilters(ActionDAGNodes added_filter_nodes)
         if (filter_actions_dag)
             query_info.filter_actions_dag = filter_actions_dag;
 
+        /// don't let deferred filters participate in index analysis
+        /// otherwise partition pruning / skip indexes could drop data that FINAL still needs
+        const ActionsDAG * index_filter_dag = query_info.filter_actions_dag.get();
+        std::shared_ptr<const ActionsDAG> index_filter_dag_without_deferred;
+
+        deferFiltersAfterFinalIfNeeded();
+        if (deferred_row_level_filter || deferred_prewhere_info)
+        {
+            /// build a separate DAG for index analysis, without the deferred filter nodes
+            NameSet deferred_column_names;
+            if (deferred_row_level_filter)
+                deferred_column_names.insert(deferred_row_level_filter->column_name);
+            if (deferred_prewhere_info)
+                deferred_column_names.insert(deferred_prewhere_info->prewhere_column_name);
+
+            std::vector<const ActionsDAG::Node *> index_nodes;
+            for (const auto * node : added_filter_nodes.nodes)
+            {
+                if (!deferred_column_names.contains(node->result_name))
+                    index_nodes.push_back(node);
+            }
+
+            auto idx_dag = ActionsDAG::buildFilterActionsDAG(index_nodes, node_name_to_input);
+            if (idx_dag)
+                index_filter_dag_without_deferred = std::make_shared<const ActionsDAG>(std::move(*idx_dag));
+            /// nullptr is fine here: all filters are deferred, nothing left for indexes
+            index_filter_dag = index_filter_dag_without_deferred.get();
+
+            LOG_DEBUG(
+                log,
+                "Excluding deferred filters from index analysis: row_policy={}, prewhere={}",
+                deferred_row_level_filter != nullptr,
+                deferred_prewhere_info != nullptr);
+        }
+
         buildIndexes(
             indexes,
-            query_info.filter_actions_dag.get(),
+            index_filter_dag,
             data,
             getParts(),
             vector_search_parameters,
@@ -2991,98 +3056,57 @@ void ReadFromMergeTree::initializePipeline(QueryPipelineBuilder & pipeline, cons
         storage_snapshot->data = std::make_unique<MergeTreeData::SnapshotData>();
     }
 
-    const auto & local_settings = context->getSettingsRef();
-
     /// Check if we should apply row policy and prewhere after FINAL instead of during reading
     /// (for correct behavior with ReplacingMergeTree where row policy should not affect which row "wins" during deduplication)
     /// also PREWHERE must always be executed after row policy, so if row policy is deferred, prewhere must be too
-    FilterDAGInfoPtr deferred_row_level_filter;
-    PrewhereInfoPtr deferred_prewhere_info;
-
-    if (isQueryWithFinal())
+    if (deferred_row_level_filter || deferred_prewhere_info)
     {
-        bool defer_row_policy = local_settings[Setting::apply_row_policy_after_final] && query_info.row_level_filter;
-        bool defer_prewhere = local_settings[Setting::apply_prewhere_after_final] && query_info.prewhere_info;
+        if (deferred_row_level_filter)
+            query_info.row_level_filter = nullptr;
+        if (deferred_prewhere_info)
+            query_info.prewhere_info = nullptr;
 
-        /// If row policy is deferred and uses non-sorting-key columns, prewhere must also be deferred
-        /// to maintain correct execution order (row policy before prewhere).
-        if (defer_row_policy && query_info.prewhere_info)
+
+        /// Ensure columns required by deferred filters are included in the columns to read
+        /// Without this, SELECT x would fail if row policy uses column y
+        NameSet columns_to_read_set(result.column_names_to_read.begin(), result.column_names_to_read.end());
+        NameSet all_columns_set(all_column_names.begin(), all_column_names.end());
+
+        auto add_required_columns = [&](const Names & required_columns)
         {
-            const auto & sorting_key_columns = storage_snapshot->metadata->getSortingKeyColumns();
-            NameSet sorting_key_columns_set(sorting_key_columns.begin(), sorting_key_columns.end());
-
-            auto filter_required_columns = query_info.row_level_filter->actions.getRequiredColumnsNames();
-            bool all_columns_in_sorting_key = true;
-            for (const auto & col : filter_required_columns)
+            for (const auto & col : required_columns)
             {
-                if (!sorting_key_columns_set.contains(col))
+                if (!columns_to_read_set.contains(col))
                 {
-                    all_columns_in_sorting_key = false;
-                    break;
+                    result.column_names_to_read.push_back(col);
+                    columns_to_read_set.insert(col);
+                }
+                if (!all_columns_set.contains(col))
+                {
+                    all_column_names.push_back(col);
+                    all_columns_set.insert(col);
                 }
             }
+        };
 
-            /// If row policy uses non-sorting-key columns, we must defer prewhere too
-            if (!all_columns_in_sorting_key)
-                defer_prewhere = true;
-        }
+        if (deferred_row_level_filter)
+            add_required_columns(deferred_row_level_filter->actions.getRequiredColumnsNames());
 
-        if (defer_row_policy || defer_prewhere)
-        {
-            /// Save the filters and clear them from query_info so they won't be applied during reading
-            if (defer_row_policy)
-            {
-                deferred_row_level_filter = query_info.row_level_filter;
-                query_info.row_level_filter = nullptr;
-            }
+        if (deferred_prewhere_info)
+            add_required_columns(deferred_prewhere_info->prewhere_actions.getRequiredColumnsNames());
 
-            if (defer_prewhere)
-            {
-                deferred_prewhere_info = query_info.prewhere_info;
-                query_info.prewhere_info = nullptr;
-            }
+        /// Recreate output_header without the deferred filters since they will be applied after FINAL
+        output_header = std::make_shared<const Block>(MergeTreeSelectProcessor::transformHeader(
+            storage_snapshot->getSampleBlockForColumns(all_column_names),
+            query_info.row_level_filter,
+            query_info.prewhere_info));
 
-            /// Ensure columns required by deferred filters are included in the columns to read.
-            /// Without this, SELECT x would fail if row policy uses column y.
-            NameSet columns_to_read_set(result.column_names_to_read.begin(), result.column_names_to_read.end());
-            NameSet all_columns_set(all_column_names.begin(), all_column_names.end());
-
-            auto add_required_columns = [&](const Names & required_columns)
-            {
-                for (const auto & col : required_columns)
-                {
-                    if (!columns_to_read_set.contains(col))
-                    {
-                        result.column_names_to_read.push_back(col);
-                        columns_to_read_set.insert(col);
-                    }
-                    if (!all_columns_set.contains(col))
-                    {
-                        all_column_names.push_back(col);
-                        all_columns_set.insert(col);
-                    }
-                }
-            };
-
-            if (deferred_row_level_filter)
-                add_required_columns(deferred_row_level_filter->actions.getRequiredColumnsNames());
-
-            if (deferred_prewhere_info)
-                add_required_columns(deferred_prewhere_info->prewhere_actions.getRequiredColumnsNames());
-
-            /// Recreate output_header without the deferred filters since they will be applied after FINAL
-            output_header = std::make_shared<const Block>(MergeTreeSelectProcessor::transformHeader(
-                storage_snapshot->getSampleBlockForColumns(all_column_names),
-                defer_row_policy ? nullptr : query_info.row_level_filter,
-                defer_prewhere ? nullptr : query_info.prewhere_info));
-
-            LOG_DEBUG(
-                log,
-                "Deferring filters to after FINAL: row_policy={}, prewhere={}. columns_to_read={}",
-                defer_row_policy,
-                defer_prewhere,
-                fmt::join(result.column_names_to_read, ","));
-        }
+        LOG_DEBUG(
+            log,
+            "Deferring filters to after FINAL: row_policy={}, prewhere={}. columns_to_read={}",
+            deferred_row_level_filter != nullptr,
+            deferred_prewhere_info != nullptr,
+            fmt::join(result.column_names_to_read, ","));
     }
 
     shared_virtual_fields.emplace("_sample_factor", result.sampling.used_sample_factor);
@@ -3282,49 +3306,32 @@ void ReadFromMergeTree::initializePipeline(QueryPipelineBuilder & pipeline, cons
     }
 
     /// apply row policy after FINAL if needed (must be applied before prewhere)
-    if (deferred_row_level_filter)
+    auto add_deferred_filter = [&pipe](ActionsDAG filter_dag, const String & column_name, bool remove_column)
     {
-        /// Clone the filter DAG and add all inputs to outputs to preserve them
-        auto filter_dag = deferred_row_level_filter->actions.clone();
-
-        /// Get all input column names and add them to outputs
         NameSet input_names;
         for (const auto * input : filter_dag.getInputs())
             input_names.insert(input->result_name);
         restoreDAGInputs(filter_dag, input_names);
 
-        auto row_level_filter_actions = std::make_shared<ExpressionActions>(std::move(filter_dag));
-        pipe.addSimpleTransform([&](const SharedHeader & header)
+        auto actions = std::make_shared<ExpressionActions>(std::move(filter_dag));
+        pipe.addSimpleTransform([&, actions](const SharedHeader & header)
         {
-            return std::make_shared<FilterTransform>(
-                header,
-                row_level_filter_actions,
-                deferred_row_level_filter->column_name,
-                deferred_row_level_filter->do_remove_column);
+            return std::make_shared<FilterTransform>(header, actions, column_name, remove_column);
         });
-    }
+    };
+
+    if (deferred_row_level_filter)
+        add_deferred_filter(
+            deferred_row_level_filter->actions.clone(),
+            deferred_row_level_filter->column_name,
+            deferred_row_level_filter->do_remove_column);
 
     /// apply deferred PREWHERE after row policy
     if (deferred_prewhere_info)
-    {
-        /// Clone the prewhere DAG and add all inputs to outputs to preserve them
-        auto prewhere_dag = deferred_prewhere_info->prewhere_actions.clone();
-
-        NameSet input_names;
-        for (const auto * input : prewhere_dag.getInputs())
-            input_names.insert(input->result_name);
-        restoreDAGInputs(prewhere_dag, input_names);
-
-        auto prewhere_actions = std::make_shared<ExpressionActions>(std::move(prewhere_dag));
-        pipe.addSimpleTransform([&](const SharedHeader & header)
-        {
-            return std::make_shared<FilterTransform>(
-                header,
-                prewhere_actions,
-                deferred_prewhere_info->prewhere_column_name,
-                deferred_prewhere_info->remove_prewhere_column);
-        });
-    }
+        add_deferred_filter(
+            deferred_prewhere_info->prewhere_actions.clone(),
+            deferred_prewhere_info->prewhere_column_name,
+            deferred_prewhere_info->remove_prewhere_column);
 
     Block cur_header = pipe.getHeader();
 

--- a/src/Processors/QueryPlan/ReadFromMergeTree.h
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.h
@@ -399,6 +399,8 @@ public:
     std::unique_ptr<LazilyReadFromMergeTree> keepOnlyRequiredColumnsAndCreateLazyReadStep(const NameSet & required_outputs);
     void addStartingPartOffsetAndPartOffset(bool & added_part_starting_offset, bool & added_part_offset);
 
+    void deferFiltersAfterFinalIfNeeded();
+
 private:
     MergeTreeSettingsPtr data_settings;
     MergeTreeReaderSettings reader_settings;
@@ -425,6 +427,10 @@ private:
 
     /// Pre-computed value, needed to trigger sets creating for PK
     mutable std::optional<Indexes> indexes;
+
+    /// Row policy / prewhere deferred to after FINAL, if needed
+    FilterDAGInfoPtr deferred_row_level_filter;
+    PrewhereInfoPtr deferred_prewhere_info;
 
     LoggerPtr log;
     UInt64 selected_parts = 0;

--- a/tests/queries/0_stateless/03742_apply_row_policy_after_final.reference
+++ b/tests/queries/0_stateless/03742_apply_row_policy_after_final.reference
@@ -41,3 +41,9 @@
 --- PREWHERE before FINAL
 1
 2
+
+--- filter before FINAL
+1	aaa	1
+2	bbb	1
+--- deferred
+2	bbb	1

--- a/tests/queries/0_stateless/03742_apply_row_policy_after_final.sql
+++ b/tests/queries/0_stateless/03742_apply_row_policy_after_final.sql
@@ -132,3 +132,31 @@ SELECT '--- PREWHERE before FINAL';
 SELECT x FROM tab_final FINAL PREWHERE y != 'ccc' ORDER BY x;
 
 DROP TABLE tab_final;
+
+-- test that partition pruning works OK with row policy
+-- When row policy column in the partition key, minmax index must not prune partitions that FINAL needs for correct deduplication
+SELECT '';
+
+DROP TABLE IF EXISTS tab_part;
+DROP ROW POLICY IF EXISTS pol_part ON tab_part;
+
+CREATE TABLE tab_part (x UInt32, y String, version UInt32)
+ENGINE = ReplacingMergeTree(version) PARTITION BY y ORDER BY x;
+
+INSERT INTO tab_part VALUES (1, 'aaa', 1), (2, 'bbb', 1);
+INSERT INTO tab_part VALUES (1, 'ccc', 2);
+
+CREATE ROW POLICY pol_part ON tab_part USING y != 'ccc' TO ALL;
+
+SET apply_row_policy_after_final = 0;
+SELECT '--- filter before FINAL';
+-- partition 'ccc' pruned, FINAL sees (1,'aaa',1) and (2,'bbb',1)
+SELECT * FROM tab_part FINAL ORDER BY x;
+
+SET apply_row_policy_after_final = 1;
+SELECT '--- deferred';
+-- all partitions read, FINAL picks (1,'ccc',2) then row policy removes it
+SELECT * FROM tab_part FINAL ORDER BY x;
+
+DROP ROW POLICY pol_part ON tab_part;
+DROP TABLE tab_part;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix cases where indexes were affecting the result for queries with row policy/PREWHERE and FINAL.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.924`
- Backported to: `26.1.4.3`, `25.12.7.21`, `25.11.10.22`
<!-- ch-version-info:end -->