### PR TITLE
Fix `SettingsConstraints` erasing explicit settings before compatibility applies

### DIFF
--- a/src/Access/SettingsConstraints.cpp
+++ b/src/Access/SettingsConstraints.cpp
@@ -217,30 +217,11 @@ void SettingsConstraints::check(const Settings & current_settings, SettingsChang
 {
     /// When `compatibility` is present, keep all settings (even if they match current values). This ensures they're applied
     /// and marked as `changed`, preventing `compatibility` from overriding explicit user values with its own defaults.
-    bool has_compatibility = false;
-    for (const auto & change : changes)
-    {
-        if (change.name == "compatibility")
-        {
-            has_compatibility = true;
-            break;
-        }
-    }
-
-    if (has_compatibility)
-    {
+    if (changes.tryGet("compatibility") == nullptr)
+        std::erase_if(changes, [&](SettingChange & change) { return !checkImpl(current_settings, change, THROW_ON_VIOLATION, source); });
+    else
         for (auto & change : changes)
             checkImpl(current_settings, change, THROW_ON_VIOLATION, source);
-    }
-    else
-    {
-        std::erase_if(
-            changes,
-            [&](SettingChange & change) -> bool
-            {
-                return !checkImpl(current_settings, change, THROW_ON_VIOLATION, source);
-            });
-    }
 }
 
 void SettingsConstraints::check(const MergeTreeSettings & current_settings, const SettingChange & change) const

--- a/src/Access/SettingsConstraints.cpp
+++ b/src/Access/SettingsConstraints.cpp
@@ -215,17 +215,37 @@ void SettingsConstraints::check(const Settings & current_settings, const Setting
 
 void SettingsConstraints::check(const Settings & current_settings, SettingsChanges & changes, SettingSource source) const
 {
-    std::erase_if(
-        changes,
-        [&](SettingChange & change) -> bool
+    /// When `compatibility` is present, keep all settings (even if they match current values). This ensures they're applied
+    /// and marked as `changed`, preventing `compatibility` from overriding explicit user values with its own defaults.
+    bool has_compatibility = false;
+    for (const auto & change : changes)
+    {
+        if (change.name == "compatibility")
         {
-            return !checkImpl(current_settings, change, THROW_ON_VIOLATION, source);
-        });
+            has_compatibility = true;
+            break;
+        }
+    }
+
+    if (has_compatibility)
+    {
+        for (auto & change : changes)
+            checkImpl(current_settings, change, THROW_ON_VIOLATION, source);
+    }
+    else
+    {
+        std::erase_if(
+            changes,
+            [&](SettingChange & change) -> bool
+            {
+                return !checkImpl(current_settings, change, THROW_ON_VIOLATION, source);
+            });
+    }
 }
 
-void SettingsConstraints::check(const MergeTreeSettings & /* current_settings */, const SettingChange & change) const
+void SettingsConstraints::check(const MergeTreeSettings & current_settings, const SettingChange & change) const
 {
-    checkImpl(const_cast<SettingChange &>(change), THROW_ON_VIOLATION);
+    checkImpl(current_settings, const_cast<SettingChange &>(change), THROW_ON_VIOLATION);
 }
 
 void SettingsConstraints::check(const MergeTreeSettings & current_settings, const SettingsChanges & changes) const
@@ -245,8 +265,15 @@ void SettingsConstraints::clamp(const Settings & current_settings, SettingsChang
 }
 
 template <typename SettingsT>
-bool getNewValueToCheck(SettingChange & change, Field & new_value, bool throw_on_failure)
+bool getNewValueToCheck(const SettingsT & current_settings, SettingChange & change, Field & new_value, bool throw_on_failure)
 {
+    Field current_value;
+    bool has_current_value = current_settings.tryGet(change.name, current_value);
+
+    /// Setting isn't checked if value has not changed.
+    if (has_current_value && change.value == current_value)
+        return false;
+
     if (throw_on_failure)
         new_value = SettingsT::castValueUtil(change.name, change.value);
     else
@@ -260,6 +287,10 @@ bool getNewValueToCheck(SettingChange & change, Field & new_value, bool throw_on
             return false;
         }
     }
+
+    /// Setting isn't checked if value has not changed.
+    if (has_current_value && new_value == current_value)
+        return false;
 
     return true;
 }
@@ -296,16 +327,16 @@ bool SettingsConstraints::checkImpl(const Settings & current_settings,
         return false;
 
     Field new_value;
-    if (!getNewValueToCheck<Settings>(change, new_value, reaction == THROW_ON_VIOLATION))
+    if (!getNewValueToCheck(current_settings, change, new_value, reaction == THROW_ON_VIOLATION))
         return false;
 
     return getChecker(current_settings, setting_name).check(change, new_value, reaction, source);
 }
 
-bool SettingsConstraints::checkImpl(SettingChange & change, ReactionOnViolation reaction) const
+bool SettingsConstraints::checkImpl(const MergeTreeSettings & current_settings, SettingChange & change, ReactionOnViolation reaction) const
 {
     Field new_value;
-    if (!getNewValueToCheck<MergeTreeSettings>(change, new_value, reaction == THROW_ON_VIOLATION))
+    if (!getNewValueToCheck(current_settings, change, new_value, reaction == THROW_ON_VIOLATION))
         return false;
     return getMergeTreeChecker(change.name).check(change, new_value, reaction, SettingSource::QUERY);
 }

--- a/src/Access/SettingsConstraints.cpp
+++ b/src/Access/SettingsConstraints.cpp
@@ -223,9 +223,9 @@ void SettingsConstraints::check(const Settings & current_settings, SettingsChang
         });
 }
 
-void SettingsConstraints::check(const MergeTreeSettings & current_settings, const SettingChange & change) const
+void SettingsConstraints::check(const MergeTreeSettings & /* current_settings */, const SettingChange & change) const
 {
-    checkImpl(current_settings, const_cast<SettingChange &>(change), THROW_ON_VIOLATION);
+    checkImpl(const_cast<SettingChange &>(change), THROW_ON_VIOLATION);
 }
 
 void SettingsConstraints::check(const MergeTreeSettings & current_settings, const SettingsChanges & changes) const
@@ -245,15 +245,8 @@ void SettingsConstraints::clamp(const Settings & current_settings, SettingsChang
 }
 
 template <typename SettingsT>
-bool getNewValueToCheck(const SettingsT & current_settings, SettingChange & change, Field & new_value, bool throw_on_failure)
+bool getNewValueToCheck(SettingChange & change, Field & new_value, bool throw_on_failure)
 {
-    Field current_value;
-    bool has_current_value = current_settings.tryGet(change.name, current_value);
-
-    /// Setting isn't checked if value has not changed.
-    if (has_current_value && change.value == current_value)
-        return false;
-
     if (throw_on_failure)
         new_value = SettingsT::castValueUtil(change.name, change.value);
     else
@@ -267,10 +260,6 @@ bool getNewValueToCheck(const SettingsT & current_settings, SettingChange & chan
             return false;
         }
     }
-
-    /// Setting isn't checked if value has not changed.
-    if (has_current_value && new_value == current_value)
-        return false;
 
     return true;
 }
@@ -307,16 +296,16 @@ bool SettingsConstraints::checkImpl(const Settings & current_settings,
         return false;
 
     Field new_value;
-    if (!getNewValueToCheck(current_settings, change, new_value, reaction == THROW_ON_VIOLATION))
+    if (!getNewValueToCheck<Settings>(change, new_value, reaction == THROW_ON_VIOLATION))
         return false;
 
     return getChecker(current_settings, setting_name).check(change, new_value, reaction, source);
 }
 
-bool SettingsConstraints::checkImpl(const MergeTreeSettings & current_settings, SettingChange & change, ReactionOnViolation reaction) const
+bool SettingsConstraints::checkImpl(SettingChange & change, ReactionOnViolation reaction) const
 {
     Field new_value;
-    if (!getNewValueToCheck(current_settings, change, new_value, reaction == THROW_ON_VIOLATION))
+    if (!getNewValueToCheck<MergeTreeSettings>(change, new_value, reaction == THROW_ON_VIOLATION))
         return false;
     return getMergeTreeChecker(change.name).check(change, new_value, reaction, SettingSource::QUERY);
 }

--- a/src/Access/SettingsConstraints.h
+++ b/src/Access/SettingsConstraints.h
@@ -161,7 +161,7 @@ private:
                   ReactionOnViolation reaction,
                   SettingSource source) const;
 
-    bool checkImpl(SettingChange & change, ReactionOnViolation reaction) const;
+    bool checkImpl(const MergeTreeSettings & current_settings, SettingChange & change, ReactionOnViolation reaction) const;
 
     Checker getChecker(const Settings & current_settings, std::string_view setting_name) const;
     Checker getMergeTreeChecker(std::string_view short_name) const;

--- a/src/Access/SettingsConstraints.h
+++ b/src/Access/SettingsConstraints.h
@@ -161,7 +161,7 @@ private:
                   ReactionOnViolation reaction,
                   SettingSource source) const;
 
-    bool checkImpl(const MergeTreeSettings & current_settings, SettingChange & change, ReactionOnViolation reaction) const;
+    bool checkImpl(SettingChange & change, ReactionOnViolation reaction) const;
 
     Checker getChecker(const Settings & current_settings, std::string_view setting_name) const;
     Checker getMergeTreeChecker(std::string_view short_name) const;

--- a/tests/queries/0_stateless/03916_check_settings_constraints_erases_with_compatibility.reference
+++ b/tests/queries/0_stateless/03916_check_settings_constraints_erases_with_compatibility.reference
@@ -1,0 +1,10 @@
+-- compatibility alone reverts to 0
+0
+-- explicit =1 with compatibility=24.12 (compat first in URL)
+1
+-- explicit =1 with compatibility=24.12 (setting first in URL)
+1
+-- explicit =0 with compatibility=24.12 (not affected by bug)
+0
+-- TCP: explicit =1 with compatibility=24.12
+1

--- a/tests/queries/0_stateless/03916_check_settings_constraints_erases_with_compatibility.sh
+++ b/tests/queries/0_stateless/03916_check_settings_constraints_erases_with_compatibility.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Tags: no-random-settings
+# no-random-settings: because the test framework may inject the settings we are testing into the URL, which interferes with test
+
+# checkSettingsConstraints must not erase unchanged settings, since a later `compatibility` in the same batch can change the baseline.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+QUERY_SKIP="SELECT value FROM system.settings WHERE name = 'use_skip_indexes_if_final'"
+
+echo "-- compatibility alone reverts to 0"
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&compatibility=24.12" -d "$QUERY_SKIP"
+
+echo "-- explicit =1 with compatibility=24.12 (compat first in URL)"
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&compatibility=24.12&use_skip_indexes_if_final=1" -d "$QUERY_SKIP"
+
+echo "-- explicit =1 with compatibility=24.12 (setting first in URL)"
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&use_skip_indexes_if_final=1&compatibility=24.12" -d "$QUERY_SKIP"
+
+echo "-- explicit =0 with compatibility=24.12 (not affected by bug)"
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&compatibility=24.12&use_skip_indexes_if_final=0" -d "$QUERY_SKIP"
+
+echo "-- TCP: explicit =1 with compatibility=24.12"
+${CLICKHOUSE_CLIENT} --compatibility=24.12 --use_skip_indexes_if_final=1 \
+    -q "$QUERY_SKIP"


### PR DESCRIPTION
We erased settings from the changes vector when their value matches the current server value (as an optimization to skip constraint checks for unchanged values). This is wrong when the same batch contains a compatibility setting. The compatibility mechanism resets settings to historical defaults, which can change the baseline after the constraints check. Any erased setting is then lost and never re-applied.

Example: server has `use_skip_indexes_if_final=1` (default since 25.6). Client sends `compatibility=24.12&use_skip_indexes_if_final=1`. The constraints check sees `1==1`, erases it. Then `compatibility=24.12` reverts the setting to 0. The explicit `=1` is gone.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a bug where explicit settings sent alongside `compatibility` in the same request could be silently ignored when their value matched the server default.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.262`
<!-- ch-version-info:end -->