### PR TITLE
Cap memory_tracker_fault_probability to 0.5

### DIFF
--- a/src/Common/MemoryTracker.h
+++ b/src/Common/MemoryTracker.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <base/types.h>
@@ -172,7 +173,9 @@ public:
 
     void setFaultProbability(double value)
     {
-        fault_probability.store(value, std::memory_order_relaxed);
+        /// Cap to 0.5 to avoid infinite loops where every allocation fails
+        /// and operations that retry on memory errors can never make progress.
+        fault_probability.store(std::min(value, 0.5), std::memory_order_relaxed);
     }
 
     void injectFault() const;


### PR DESCRIPTION
## Summary
- Cap effective `memory_tracker_fault_probability` to 0.5 in `MemoryTracker::setFaultProbability` to prevent infinite retry loops when the probability is set to 1.0
- When every allocation fails, operations like `SYSTEM RESTART REPLICA` that retry on memory errors enter an infinite loop and eventually crash the server

Closes https://github.com/ClickHouse/ClickHouse/issues/94388

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.811`
<!-- ch-version-info:end -->