### PR TITLE
Add aliases to the instruction

### DIFF
--- a/docs/en/development/continuous-integration.md
+++ b/docs/en/development/continuous-integration.md
@@ -94,22 +94,61 @@ python -m ci.praktika run "Style check" --test cpp
 These commands pull the `clickhouse/style-test` Docker image and run the job in a containerized environment.
 No dependencies other than Python 3 and Docker are required.
 
-## Fast test {#fast-test}
+### Running stateless tests {#running-stateless-tests}
 
-Normally this is the first check that is run for a PR.
-It builds ClickHouse and runs most of [stateless functional tests](tests.md#functional-tests), omitting some.
-If it fails, further checks are not started until it is fixed.
-Look at the report to see which tests fail, then reproduce the failure locally as described [here](/development/tests#running-a-test-locally).
+A locally installed ClickHouse with default settings may work for specific test cases, but cannot run all test queries correctly. In CI, each job installs a specific ClickHouse configuration (e.g., S3 storage, Parallel Replicas) which can be cumbersome to reproduce manually. To avoid this, you can reproduce any CI job locally using the same orchestration as CI — no manual configuration needed.
 
-#### Running fast test locally: {#running-fast-test-locally}
+#### Prerequisites
+- Python 3 (standard library only)
+- Docker
 
+Install Docker on Ubuntu if needed and re-login:
 ```sh
-python -m ci.praktika run "Fast test" [--test some_test_name]
+sudo apt-get update
+sudo apt-get install docker.io
+sudo usermod -aG docker ubuntu
+sudo tee /etc/docker/daemon.json <<'EOF'
+{
+  "ipv6": true,
+  "ip6tables": true
+}
+EOF
+sudo systemctl restart docker
 ```
 
-These commands pull the `clickhouse/fast-test` Docker image and run the job in a containerized environment.
-No dependencies other than Python 3 and Docker are required.
+#### Run a CI Job Locally
+Pick any job name from a CI report and run it locally:
+```bash
+python -m ci.praktika run "<JOB_NAME>"
+```
+- Always quote the job name exactly as it appears in the CI report (it may contain spaces and commas), e.g.: `"Stateless tests (amd_debug, parallel)"`. This sets up the same ClickHouse configuration and runs the same tests as in CI.
+- The architecture and build type in the job name (e.g., `amd_debug`) are CI-specific labels. When running locally, they have no effect — the job will use whatever binary you provide, on whatever architecture you are running. The job name only determines the ClickHouse configuration and the test set (unless overridden with `--test`).
+- In CI, functional tests are split into batches for better resource utilization. For example, `"Stateless tests (amd_debug, parallel)"` and `"Stateless tests (amd_debug, sequential)"` together cover the entire scope: parallel-safe tests run concurrently, and the rest run sequentially. The split reduces total CI time by maximizing parallelism where possible. To reproduce the full test scope locally, run both batches.
+- There is also a `"Fast test"` CI job that runs a limited scope of functional tests to verify basic ClickHouse functionality — it uses a build without all optional modules and is the quickest way to catch regressions. You can run it locally the same way. Place your ClickHouse binary in one of the default search paths (`./ci/tmp/clickhouse`, `./build/programs/clickhouse`, or `./clickhouse`) — otherwise the job will attempt to build ClickHouse first:
+  ```bash
+  python -m ci.praktika run "Fast test"
+  ```
 
+#### Run Specific Tests Within a CI Job
+With `--test`, the job prepares an identical ClickHouse setup as used in CI but runs only the selected tests:
+```bash
+python -m ci.praktika run "Stateless tests (amd_debug, parallel)" \
+  --test 00001_select1
+```
+- You can pass multiple test names:
+  ```bash
+  python -m ci.praktika run "Stateless tests (amd_debug, parallel)" \
+    --test 00001_select1 00002_log_and_exception_messages_formatting
+  ```
+- Tip: If any ClickHouse configuration is acceptable and you just need to run specific tests, use the alias `functional` instead of the full job name:
+  ```bash
+  python -m ci.praktika run functional --test 00001_select1
+  ```
+
+#### Additional Customization Options
+- `--path PATH` — custom path to the ClickHouse binary. By default, the runner searches in order: `./ci/tmp/clickhouse`, `./build/programs/clickhouse`, `./clickhouse`.
+- `--count N` — repeat each test N times.
+- `--workers N` — override the automatic calculation of parallel workers derived from machine capacity.
 ## Build check {#build-check}
 
 Builds ClickHouse in various configurations for use in further steps.

--- a/docs/en/development/continuous-integration.md
+++ b/docs/en/development/continuous-integration.md
@@ -98,7 +98,7 @@ No dependencies other than Python 3 and Docker are required.
 
 A locally installed ClickHouse with default settings may work for specific test cases, but cannot run all test queries correctly. In CI, each job installs a specific ClickHouse configuration (e.g., S3 storage, Parallel Replicas) which can be cumbersome to reproduce manually. To avoid this, you can reproduce any CI job locally using the same orchestration as CI — no manual configuration needed.
 
-#### Prerequisites
+#### Prerequisites {#ci-prerequisites}
 - Python 3 (standard library only)
 - Docker
 
@@ -116,7 +116,7 @@ EOF
 sudo systemctl restart docker
 ```
 
-#### Run a CI Job Locally
+#### Run a CI Job Locally {#run-ci-job-locally}
 Pick any job name from a CI report and run it locally:
 ```bash
 python -m ci.praktika run "<JOB_NAME>"
@@ -129,7 +129,7 @@ python -m ci.praktika run "<JOB_NAME>"
   python -m ci.praktika run "Fast test"
   ```
 
-#### Run Specific Tests Within a CI Job
+#### Run Specific Tests Within a CI Job {#run-specific-tests-within-ci-job}
 With `--test`, the job prepares an identical ClickHouse setup as used in CI but runs only the selected tests:
 ```bash
 python -m ci.praktika run "Stateless tests (amd_debug, parallel)" \
@@ -145,7 +145,7 @@ python -m ci.praktika run "Stateless tests (amd_debug, parallel)" \
   python -m ci.praktika run functional --test 00001_select1
   ```
 
-#### Additional Customization Options
+#### Additional Customization Options {#additional-customization-options}
 - `--path PATH` — custom path to the ClickHouse binary. By default, the runner searches in order: `./ci/tmp/clickhouse`, `./build/programs/clickhouse`, `./clickhouse`.
 - `--count N` — repeat each test N times.
 - `--workers N` — override the automatic calculation of parallel workers derived from machine capacity.

--- a/docs/en/development/continuous-integration.md
+++ b/docs/en/development/continuous-integration.md
@@ -93,7 +93,7 @@ python -m ci.praktika run "Style check" --test cpp
 These commands pull the `clickhouse/style-test` Docker image and run the job in a containerized environment.
 No dependencies other than Python 3 and Docker are required.
 
-### Running stateless tests {#running-stateless-tests}
+## Running stateless tests {#running-stateless-tests}
 
 A locally installed ClickHouse with default settings may work for specific test cases, but cannot run all test queries correctly. In CI, each job installs a specific ClickHouse configuration (e.g., S3 storage, Parallel Replicas) which can be cumbersome to reproduce manually. To avoid this, you can reproduce any CI job locally using the same orchestration as CI — no manual configuration needed.
 
@@ -105,7 +105,7 @@ Install Docker on Ubuntu if needed and re-login:
 ```sh
 sudo apt-get update
 sudo apt-get install docker.io
-sudo usermod -aG docker ubuntu
+sudo usermod -aG docker "$USER"
 sudo tee /etc/docker/daemon.json <<'EOF'
 {
   "ipv6": true,

--- a/docs/en/development/continuous-integration.md
+++ b/docs/en/development/continuous-integration.md
@@ -19,7 +19,6 @@ If it looks like the check failure is not related to your changes, it may be som
 Push an empty commit to the pull request to restart the CI checks:
 
 ```shell
-git reset
 git commit --allow-empty
 git push
 ```
@@ -149,6 +148,7 @@ python -m ci.praktika run "Stateless tests (amd_debug, parallel)" \
 - `--path PATH` — custom path to the ClickHouse binary. By default, the runner searches in order: `./ci/tmp/clickhouse`, `./build/programs/clickhouse`, `./clickhouse`.
 - `--count N` — repeat each test N times.
 - `--workers N` — override the automatic calculation of parallel workers derived from machine capacity.
+
 ## Build check {#build-check}
 
 Builds ClickHouse in various configurations for use in further steps.

--- a/docs/en/development/tests.md
+++ b/docs/en/development/tests.md
@@ -63,10 +63,10 @@ git clone --single-branch https://github.com/ClickHouse/ClickHouse
 cd ClickHouse
 ```
 
-3. Build code and run a subset of tests (named "Fast test").
+3. Build code and run "fast tests".
 
 ```sh
-python3 -m ci.praktika run "Fast test"
+python -m ci.praktika run fast
 ```
 
 You should get
@@ -103,19 +103,21 @@ cd ClickHouse
 
 3. Build the code.
 ```sh
-python3 -m ci.praktika run "Build (amd_debug)"
+python -m ci.praktika run build_debug
 cp ci/tmp/build/programs/clickhouse ci/tmp
 ```
 
 4. Run stateless tests which can be run in parallel.
 ```sh
-python3 -m ci.praktika run "Stateless tests (amd_debug, parallel)"
+python -m ci.praktika run functional
 ```
 
 You should get
 ```sh
 Failed: 0, Passed: 8497, Skipped: 103
 ```
+
+Note. `python -m ci.praktika run` invocations run a specific continuous integration job, you can can read more about ClickHouse CI [here](continuous-integration.md#running-stateless-tests).
 
 ### Adding a new test {#adding-a-new-test}
 

--- a/docs/en/development/tests.md
+++ b/docs/en/development/tests.md
@@ -9,6 +9,21 @@ doc_type: 'guide'
 
 # Testing ClickHouse
 
+## Test types {#test-types}
+
+There are following tests in ClickHouse:
+- [Functional tests](#functional-tests) - a set of queries and scripts which include the following subsets
+  - Fast test - the minimal subset
+  - Stateless tests which do not require populating databased with data
+  - Sequential tests which cannot be run in parallel
+- [Integration tests](#integration-tests), run by `pytest` in a cluster
+- [Unit tests](#unit-tests)
+- [Performance tests]({#performance-tests)
+- [Build tests](#build-tests)
+- [Sanitizers](#sanitizers)
+- [Fuzzers](#fuzzing)
+and some others, see the sections below.
+
 ## Functional tests {#functional-tests}
 
 Functional tests are the most simple and convenient to use.
@@ -53,7 +68,7 @@ You may need a decently powerful machine to run a subset of tests (called "Fast 
 ```sh
 sudo apt-get update
 sudo apt-get install docker.io
-sudo usermod -aG docker ubuntu
+sudo usermod -aG docker "$USER"
 ```
 
 2. Get the source code.
@@ -84,7 +99,7 @@ You may need a decently powerful machine to run stateless tests. The following w
 ```sh
 sudo apt-get update
 sudo apt-get install docker.io
-sudo usermod -aG docker ubuntu
+sudo usermod -aG docker "$USER"
 sudo tee /etc/docker/daemon.json <<'EOF'
 {
   "ipv6": true,
@@ -117,7 +132,7 @@ You should get
 Failed: 0, Passed: 8497, Skipped: 103
 ```
 
-Note. `python -m ci.praktika run` invocations run a specific continuous integration job, you can can read more about ClickHouse CI [here](continuous-integration.md#running-stateless-tests).
+Note. `python -m ci.praktika run` invocations run a specific continuous integration job, you can read more about ClickHouse CI [here](continuous-integration.md#running-stateless-tests).
 
 ### Adding a new test {#adding-a-new-test}
 
@@ -181,8 +196,8 @@ List of available tags:
 | `global` | Same as `shard`. Prefer `shard` ||
 | `zookeeper` | Test requires Zookeeper or ClickHouse Keeper to run | Test uses `ReplicatedMergeTree` |
 | `replica` | Same as `zookeeper`. Prefer `zookeeper` ||
-| `no-fasttest`|  Test is not run under [Fast test](continuous-integration.md#fast-test) | Test uses `MySQL` table engine which is disabled in Fast test|
-| `fasttest-only`|  Test is only run under [Fast test](continuous-integration.md#fast-test) ||
+| `no-fasttest`|  Test is not run under [Fast test](#test-types) | Test uses `MySQL` table engine which is disabled in Fast test|
+| `fasttest-only`|  Test is only run under [Fast test](#test-types) ||
 | `no-[asan, tsan, msan, ubsan]` | Disables tests in build with [sanitizers](#sanitizers) | Test is run under QEMU which doesn't work with sanitizers |
 | `no-replicated-database` |||
 | `no-ordinary-database` |||

--- a/docs/en/development/tests.md
+++ b/docs/en/development/tests.md
@@ -12,9 +12,9 @@ doc_type: 'guide'
 ## Test types {#test-types}
 
 There are following tests in ClickHouse:
-- [Functional tests](#functional-tests) - a set of queries and scripts which include the following subsets
-  - Fast test - the minimal subset
-  - Stateless tests which do not require populating databased with data
+- [Functional tests](#functional-tests) - a set of queries and scripts which include the following intersecting subsets
+  - [Fast test](#running-stateless-tests) - the minimal subset
+  - [Stateless tests](#running-stateless-tests) which do not require populating databased with data
   - Sequential tests which cannot be run in parallel
 - [Integration tests](#integration-tests), run by `pytest` in a cluster
 - [Unit tests](#unit-tests)

--- a/docs/en/development/tests.md
+++ b/docs/en/development/tests.md
@@ -13,7 +13,7 @@ doc_type: 'guide'
 
 There are following tests in ClickHouse:
 - [Functional tests](#functional-tests) - a set of queries and scripts which include the following intersecting subsets
-  - [Fast test](#running-stateless-tests) - the minimal subset
+  - [Fast test](#running-fast-tests) - the minimal subset
   - [Stateless tests](#running-stateless-tests) which do not require populating databased with data
   - Sequential tests which cannot be run in parallel
 - [Integration tests](#integration-tests), run by `pytest` in a cluster

--- a/docs/en/development/tests.md
+++ b/docs/en/development/tests.md
@@ -18,7 +18,7 @@ There are following tests in ClickHouse:
   - Sequential tests which cannot be run in parallel
 - [Integration tests](#integration-tests), run by `pytest` in a cluster
 - [Unit tests](#unit-tests)
-- [Performance tests]({#performance-tests)
+- [Performance tests](#performance-tests)
 - [Build tests](#build-tests)
 - [Sanitizers](#sanitizers)
 - [Fuzzers](#fuzzing)

--- a/docs/en/development/tests.md
+++ b/docs/en/development/tests.md
@@ -14,7 +14,7 @@ doc_type: 'guide'
 There are following tests in ClickHouse:
 - [Functional tests](#functional-tests) - a set of queries and scripts which include the following intersecting subsets
   - [Fast test](#running-fast-tests) - the minimal subset
-  - [Stateless tests](#running-stateless-tests) which do not require populating databased with data
+  - [Stateless tests](#running-stateless-tests) which do not require populating databases with data
   - Sequential tests which cannot be run in parallel
 - [Integration tests](#integration-tests), run by `pytest` in a cluster
 - [Unit tests](#unit-tests)

--- a/docs/en/development/tests.md
+++ b/docs/en/development/tests.md
@@ -199,21 +199,14 @@ List of available tags:
 | `no-fasttest`|  Test is not run under [Fast test](#test-types) | Test uses `MySQL` table engine which is disabled in Fast test|
 | `fasttest-only`|  Test is only run under [Fast test](#test-types) ||
 | `no-[asan, tsan, msan, ubsan]` | Disables tests in build with [sanitizers](#sanitizers) | Test is run under QEMU which doesn't work with sanitizers |
-| `no-replicated-database` |||
-| `no-ordinary-database` |||
+| `no-replicated-database` | Disables test when the default database uses `ReplicatedDatabaseEngine` ||
+| `no-ordinary-database` | Disables test when the default database engine is `Ordinary` ||
 | `no-parallel` | Disables running other tests in parallel with this one | Test reads from `system` tables and invariants may be broken|
-| `no-parallel-replicas` |||
+| `no-parallel-replicas` | Disables test when parallel replicas are enabled ||
 | `no-debug` | Disables tests in Debug builds ||
 | `no-release` | Disables tests in Release builds ||
-| `no-stress` |||
-| `no-polymorphic-parts` |||
-| `no-random-settings` |||
-| `no-random-merge-tree-settings` |||
-| `no-backward-compatibility-check` |||
-| `no-cpu-x86_64` |||
-| `no-cpu-aarch64` |||
-| `no-cpu-ppc64le` |||
-| `no-s3-storage` |||
+
+The following options are also supported: `no-stress`, `no-polymorphic-parts`, `no-random-settings`, `no-random-merge-tree-settings`, `no-backward-compatibility-check`, `no-cpu-x86_64`, `no-cpu-aarch64`, `no-cpu-ppc64le`, `no-s3-storage`.
 
 In addition to above settings, you can use `USE_*` flags from `system.build_options` to define usage of particular ClickHouse features.
 For example, if your test uses a MySQL table, you should add a tag `use-mysql`.
@@ -335,13 +328,8 @@ You can use these kind of tools as a code examples and for exploration and manua
 There are tests for machine learned models in `tests/external_models`.
 These tests are not updated and must be transferred to integration tests.
 
-There is separate test for quorum inserts.
-This test run ClickHouse cluster on separate servers and emulate various failure cases: network split, packet drop (between ClickHouse nodes, between ClickHouse and ZooKeeper, between ClickHouse server and client, etc.), `kill -9`, `kill -STOP` and `kill -CONT` , like [Jepsen](https://aphyr.com/tags/Jepsen). Then the test checks that all acknowledged inserts was written and all rejected inserts was not.
-
-Quorum test was written by separate team before ClickHouse was open-sourced.
-This team no longer work with ClickHouse.
-Test was accidentally written in Java.
-For these reasons, quorum test must be rewritten and moved to integration tests.
+There is a separate test for quorum inserts.
+This test runs a ClickHouse cluster on separate servers and emulates various failure cases: network split, packet drop (between ClickHouse nodes, between ClickHouse and ZooKeeper, between ClickHouse server and client, etc.), `kill -9`, `kill -STOP` and `kill -CONT`, like [Jepsen](https://aphyr.com/tags/Jepsen). Then the test checks that all acknowledged inserts were written and all rejected inserts were not.
 
 ## Manual Testing {#manual-testing}
 


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Motivation
A user requested to use aliases to job names, also fixed the regression in the fast test job

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes, mainly renaming sections and updating command examples/links for running CI jobs and test subsets locally.
> 
> **Overview**
> Clarifies how to reproduce CI test environments locally by running CI jobs via `python -m ci.praktika run`, including prerequisites, how to pick job names from CI reports, and how to run subsets of tests with `--test`.
> 
> Updates testing docs to introduce a *Test types* overview and switches examples to the newer `ci.praktika` aliases (`fast`, `functional`, `build_debug`) instead of full job names, plus minor wording/links and tag table improvements.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 74e8a63802a242881eebdc9e932140d8346c857e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.590`
<!-- ch-version-info:end -->