### PR TITLE
CI: Improve bugfix validation job filtering and behavior

### DIFF
--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -13,6 +13,7 @@ from ci.jobs.scripts.integration_tests_configs import (
     LLVM_COVERAGE_SKIP_PREFIXES,
     get_optimal_test_batch,
 )
+from ci.jobs.scripts.workflow_hooks.pr_labels_and_category import Labels
 from ci.praktika.info import Info
 from ci.praktika.result import Result, ResultTranslator
 from ci.praktika.utils import ContextManager, Shell, Utils
@@ -412,16 +413,22 @@ tar -czf ./ci/tmp/logs.tar.gz \
                 args.test
             ), "--test must be provided for flaky or bugfix job flavor with local run"
         else:
-            # TODO: reduce scope to modified test cases instead of entire modules
-            changed_files = info.get_changed_files()
-            for file in changed_files:
-                if (
-                    file.startswith("tests/integration/test")
-                    and Path(file).name.startswith("test")
-                    and file.endswith(".py")
-                    and Path(file).is_file()
-                ):
-                    changed_test_modules.append(file.removeprefix("tests/integration/"))
+            if is_bugfix_validation and Labels.PR_BUGFIX not in info.pr_labels:
+                # Not a bugfix PR - run a simple sanity test
+                changed_test_modules = ["test_accept_invalid_certificate/test.py"]
+            else:
+                # TODO: reduce scope to modified test cases instead of entire modules
+                changed_files = info.get_changed_files()
+                for file in changed_files:
+                    if (
+                        file.startswith("tests/integration/test")
+                        and Path(file).name.startswith("test")
+                        and file.endswith(".py")
+                        and Path(file).is_file()
+                    ):
+                        changed_test_modules.append(
+                            file.removeprefix("tests/integration/")
+                        )
 
     if is_bugfix_validation:
         if Utils.is_arm():
@@ -713,7 +720,7 @@ tar -czf ./ci/tmp/logs.tar.gz \
     if has_error:
         R.set_error().set_info("\n".join(error_info))
 
-    if is_bugfix_validation:
+    if is_bugfix_validation and Labels.PR_BUGFIX in info.pr_labels:
         assert (
             is_llvm_coverage is False
         ), "Bugfix validation with LLVM coverage is not supported"

--- a/ci/jobs/scripts/workflow_hooks/filter_job.py
+++ b/ci/jobs/scripts/workflow_hooks/filter_job.py
@@ -162,7 +162,19 @@ def should_skip_job(job_name):
         )
 
     if " Bug Fix" not in _info_cache.pr_body and "Bugfix" in job_name:
-        return True, "Skipped, not a bug-fix PR"
+        # Don't skip if the corresponding test job file was changed
+        skip = True
+        if job_name == JobNames.BUGFIX_VALIDATE_FT and any(
+            f.endswith("jobs/functional_tests.py") for f in changed_files
+        ):
+            skip = False
+        elif job_name == JobNames.BUGFIX_VALIDATE_IT and any(
+            f.endswith("jobs/integration_test_job.py") for f in changed_files
+        ):
+            skip = False
+
+        if skip:
+            return True, "Skipped, not a bug-fix PR"
 
     if "flaky" in job_name.lower():
         changed_files = _info_cache.get_changed_files()


### PR DESCRIPTION
## Summary
This PR improves the bugfix validation jobs (`BUGFIX_VALIDATE_FT` and `BUGFIX_VALIDATE_IT`) to:

1. **Run when test job files are modified**: Allow these jobs to run even for non-bugfix PRs if their corresponding test job files (`ci/jobs/functional_tests.py` or `ci/jobs/integration_test_job.py`) are changed
2. **Use sanity tests for non-bugfix PRs**: When running on non-bugfix PRs, execute simple sanity tests (`00001_select_1` for functional, `test_accept_invalid_certificate/test.py` for integration) instead of searching for changed tests
3. **Skip result inversion for non-bugfix PRs**: Only invert test results (treating failures as expected) when the PR actually has the `pr-bugfix` label

This ensures that CI changes to test job files are properly validated without incorrectly treating test failures as expected behavior.

## Test plan
- Modified test job files and verified bugfix validation jobs run with sanity tests
- Verified actual bugfix PRs continue to work as before with result inversion

## Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.832`
<!-- ch-version-info:end -->