### PR TITLE
*wip* Fix flaky full-text search tests

### DIFF
--- a/tests/queries/0_stateless/02346_text_index_bug90778.sql
+++ b/tests/queries/0_stateless/02346_text_index_bug90778.sql
@@ -1,5 +1,3 @@
--- Tags: no-parallel-replicas
-
 DROP TABLE IF EXISTS tab;
 
 CREATE TABLE tab

--- a/tests/queries/0_stateless/02346_text_index_direct_read.sql
+++ b/tests/queries/0_stateless/02346_text_index_direct_read.sql
@@ -1,4 +1,4 @@
--- Tags: no-parallel, no-parallel-replicas
+-- Tags: no-parallel
 -- Tag no-parallel -- due to access to the system.text_log
 -- Tag no-parallel-replicas -- direct read is not compatible with parallel replicas
 

--- a/tests/queries/0_stateless/02346_text_index_duplicate_tokens.sql
+++ b/tests/queries/0_stateless/02346_text_index_duplicate_tokens.sql
@@ -1,5 +1,3 @@
--- Tags: no-parallel-replicas
-
 -- Tests queries with duplicate tokens against a text index
 
 DROP TABLE IF EXISTS tab;

--- a/tests/queries/0_stateless/02346_text_index_function_hasAnyAllTokens.sql
+++ b/tests/queries/0_stateless/02346_text_index_function_hasAnyAllTokens.sql
@@ -1,4 +1,4 @@
--- Tags: no-parallel-replicas, long
+-- Tags: long
 
 SET enable_analyzer = 1;
 SET use_query_condition_cache = 0;

--- a/tests/queries/0_stateless/02346_text_index_header_cache.sql
+++ b/tests/queries/0_stateless/02346_text_index_header_cache.sql
@@ -1,4 +1,4 @@
--- Tags: no-parallel, no-parallel-replicas
+-- Tags: no-parallel
 -- no-parallel: looks at server-wide metrics
 
 --- These tests verify the caching of a deserialized text index header in the consecutive executions.

--- a/tests/queries/0_stateless/02346_text_index_hint.sql
+++ b/tests/queries/0_stateless/02346_text_index_hint.sql
@@ -1,5 +1,3 @@
--- Tags: no-parallel-replicas
-
 SET enable_analyzer = 1;
 SET use_skip_indexes_on_data_read = 1;
 SET query_plan_text_index_add_hint = 1;

--- a/tests/queries/0_stateless/02346_text_index_map_support.sql
+++ b/tests/queries/0_stateless/02346_text_index_map_support.sql
@@ -1,4 +1,4 @@
--- Tags: no-parallel-replicas, no-asan
+-- Tags: no-asan
 -- no-asan: too slow
 
 -- Tests that text indexes can be build on and used with Map columns.

--- a/tests/queries/0_stateless/02346_text_index_map_support.sql
+++ b/tests/queries/0_stateless/02346_text_index_map_support.sql
@@ -1,4 +1,5 @@
--- Tags: no-parallel-replicas
+-- Tags: no-parallel-replicas, no-asan
+-- no-asan: too slow
 
 -- Tests that text indexes can be build on and used with Map columns.
 
@@ -279,7 +280,7 @@ CREATE VIEW explain_index_has_all_tokens AS (
     SELECT trimLeft(explain) AS explain FROM (
         EXPLAIN indexes=1
         SELECT count() FROM tab WHERE (
-            CASE 
+            CASE
                 WHEN {use_idx_fixed:boolean} = 1 THEN hasAllTokens(mapKeys(map_fixed), {filter:String})
                 ELSE hasAllTokens(mapKeys(map), {filter:String})
             END
@@ -507,7 +508,7 @@ CREATE VIEW explain_index_has_all_tokens AS (
     SELECT trimLeft(explain) AS explain FROM (
         EXPLAIN indexes=1
         SELECT count() FROM tab WHERE (
-            CASE 
+            CASE
                 WHEN {use_idx_fixed:boolean} = 1 THEN hasAllTokens(mapValues(map_fixed), {filter:String})
                 ELSE hasAllTokens(mapValues(map), {filter:String})
             END
@@ -583,7 +584,7 @@ SELECT count() from tab WHERE mapContainsValueLike(map_fixed, '% e %');
 SELECT count() from tab WHERE mapContainsValueLike(map_fixed, '% k %');
 SELECT count() from tab WHERE mapContainsValueLike(map_fixed, '% q %');
 
--- 
+--
 
 DROP VIEW IF EXISTS explain_index_key_like;
 CREATE VIEW explain_index_key_like AS (

--- a/tests/queries/0_stateless/02346_text_index_prewhere_support.sh
+++ b/tests/queries/0_stateless/02346_text_index_prewhere_support.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# Tags: no-parallel-replicas
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/03705_alter_table_rewrite_parts_checksums.sh
+++ b/tests/queries/0_stateless/03705_alter_table_rewrite_parts_checksums.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Tags: no-msan
+# no-msan: too slow
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
This PR
- excludes some tests that failed in https://github.com/ClickHouse/ClickHouse/pull/96794 from sanitizer runs
- removes the `no-parallel-replicas` tag (not sure what will break)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)