### PR TITLE
Fix flaky test 03780_failed_ssh expect pattern

### DIFF
--- a/tests/queries/0_stateless/03780_failed_ssh.expect
+++ b/tests/queries/0_stateless/03780_failed_ssh.expect
@@ -46,7 +46,7 @@ spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CLIENT_BINARY \
 
 expect "Enter your SSH private key passphrase (leave empty for no passphrase): "
 send "\r"
-expect "Connecting to * as user user_03780_*."
+expect -re "Connecting to .+ as user user_03780_\\S+\\."
 expect "Code: 516. *"
 expect eof
 


### PR DESCRIPTION
Fix flaky test `03780_failed_ssh` where the glob pattern `"Connecting to * as user user_03780_*."` matches across newlines, greedily consuming the `Code: 516.` error message. Switching to regex (`-re`) prevents cross-line matching.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=91a0376b399e076e4492e1befdec468c81718737&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_binary%2C%20ParallelReplicas%2C%20s3%20storage%2C%20parallel%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.815`
<!-- ch-version-info:end -->