### PR TITLE
Fix implicit indices with alias columns and do full validation before creating them

### DIFF
--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -971,7 +971,9 @@ void AlterCommand::apply(StorageInMemoryMetadata & metadata, ContextPtr context)
 
         for (auto & index : metadata.secondary_indices)
         {
-            if (index.isImplicitlyCreated() && index.column_names.front() == column_name)
+            /// For implicit indices, check the index name rather than column_names because
+            /// for ALIAS columns, column_names contains the underlying expression columns.
+            if (index.isImplicitlyCreated() && index.name == IMPLICITLY_ADDED_MINMAX_INDEX_PREFIX + column_name)
                 index.definition_ast = createImplicitMinMaxIndexAST(rename_to);
             else
                 rename_visitor.visit(index.definition_ast);

--- a/src/Storages/MergeTree/MergeTreeIndices.h
+++ b/src/Storages/MergeTree/MergeTreeIndices.h
@@ -356,7 +356,6 @@ public:
 
     using Validator = std::function<void(const IndexDescription & index, bool attach)>;
 
-    static void implicitValidation(const IndexDescription & index);
     void validate(const IndexDescription & index, bool attach) const;
 
     MergeTreeIndexPtr get(const IndexDescription & index) const;

--- a/tests/queries/0_stateless/03166_optimize_row_order_during_insert.sql
+++ b/tests/queries/0_stateless/03166_optimize_row_order_during_insert.sql
@@ -34,7 +34,8 @@ CREATE TABLE tab (
     flag String
 ) ENGINE = MergeTree
 ORDER BY ()
-SETTINGS optimize_row_order = True;
+    -- Disable add_minmax_index_for_numeric_columns since it affects the order
+SETTINGS optimize_row_order = True, add_minmax_index_for_numeric_columns=0;
 INSERT INTO tab VALUES ('Bob', 4, 100, '1'), ('Nikita', 2, 54, '1'), ('Nikita', 1, 228, '1'), ('Alex', 4, 83, '1'), ('Alex', 4, 134, '1'), ('Alex', 1, 65, '0'), ('Alex', 4, 134, '1'), ('Bob', 2, 53, '0'), ('Alex', 4, 83, '0'), ('Alex', 1, 63, '1'), ('Bob', 2, 53, '1'), ('Alex', 4, 192, '1'), ('Alex', 2, 128, '1'), ('Nikita', 2, 148, '0'), ('Bob', 4, 177, '0'), ('Nikita', 1, 173, '0'), ('Alex', 1, 239, '0'), ('Alex', 1, 63, '0'), ('Alex', 2, 224, '1'), ('Bob', 4, 177, '0'), ('Alex', 2, 128, '1'), ('Alex', 4, 134, '0'), ('Alex', 4, 83, '1'), ('Bob', 4, 100, '0'), ('Nikita', 2, 54, '1'), ('Alex', 1, 239, '1'), ('Bob', 2, 187, '1'), ('Alex', 1, 65, '1'), ('Bob', 2, 53, '1'), ('Alex', 2, 224, '0'), ('Alex', 4, 192, '0'), ('Nikita', 1, 173, '1'), ('Nikita', 2, 148, '1'), ('Bob', 2, 187, '1'), ('Nikita', 2, 208, '1'), ('Nikita', 2, 208, '0'), ('Nikita', 1, 228, '0'), ('Nikita', 2, 148, '0');
 
 SELECT * FROM tab SETTINGS max_threads=1;
@@ -58,7 +59,8 @@ CREATE TABLE tab (
     flag Nullable(Int32)
 ) ENGINE = MergeTree
 ORDER BY (flag, money)
-SETTINGS optimize_row_order = True, allow_nullable_key = True;
+   -- Disable add_minmax_index_for_numeric_columns since it affects the order
+SETTINGS optimize_row_order = True, allow_nullable_key = True, add_minmax_index_for_numeric_columns=0;
 INSERT INTO tab VALUES ('AB', 0, 42, Null), ('AB', 0, 42, Null), ('A', 1, 42, Null), ('AB', 1, 9.81, 0), ('B', 0, 42, Null), ('B', -1, 3.14, Null), ('B', 1, 2.7, 1), ('B', 0, 42, 1), ('A', 1, 42, 1), ('B', 1, 42, Null), ('B', 0, 2.7, 1), ('A', 0, 2.7, 1), ('B', 2, 3.14, Null), ('A', 0, 3.14, Null), ('A', 1, 2.7, 1), ('A', 1, 42, Null);
 
 SELECT * FROM tab ORDER BY (flag, money) SETTINGS max_threads=1;

--- a/tests/queries/0_stateless/03767_implicit_minmax_index_dynamic_variant.reference
+++ b/tests/queries/0_stateless/03767_implicit_minmax_index_dynamic_variant.reference
@@ -1,0 +1,2 @@
+auto_minmax_index_regular_col	minmax	regular_col
+42	100

--- a/tests/queries/0_stateless/03767_implicit_minmax_index_dynamic_variant.sql
+++ b/tests/queries/0_stateless/03767_implicit_minmax_index_dynamic_variant.sql
@@ -1,0 +1,28 @@
+-- Test that implicit minmax indices correctly skip ALIAS columns
+-- with Dynamic underlying type (JSON subcolumns)
+
+DROP TABLE IF EXISTS test_implicit_minmax;
+
+-- Test with JSON ALIAS columns (Dynamic subcolumns should be skipped)
+-- and regular columns to verify the feature still works
+CREATE TABLE test_implicit_minmax (
+    json_col JSON,
+    regular_col UInt64,
+    alias_json UInt64 ALIAS json_col.field
+) ENGINE = MergeTree
+ORDER BY tuple()
+SETTINGS add_minmax_index_for_numeric_columns = true;
+
+-- Verify implicit index created only for regular_col, not for alias_json
+SELECT name, type, expr
+FROM system.data_skipping_indices
+WHERE database = currentDatabase() AND table = 'test_implicit_minmax'
+ORDER BY name;
+
+-- Verify table works correctly
+INSERT INTO test_implicit_minmax (json_col, regular_col)
+VALUES ('{"field": 42}', 100);
+
+SELECT alias_json, regular_col FROM test_implicit_minmax;
+
+DROP TABLE test_implicit_minmax;

--- a/tests/queries/0_stateless/03768_rename_alias_column_implicit_index.reference
+++ b/tests/queries/0_stateless/03768_rename_alias_column_implicit_index.reference
@@ -1,0 +1,7 @@
+auto_minmax_index_alias_col	minmax	value > 0
+auto_minmax_index_value	minmax	value
+auto_minmax_index_alias_renamed	minmax	value > 0
+auto_minmax_index_value	minmax	value
+0
+0
+1

--- a/tests/queries/0_stateless/03768_rename_alias_column_implicit_index.sql
+++ b/tests/queries/0_stateless/03768_rename_alias_column_implicit_index.sql
@@ -1,0 +1,32 @@
+-- Test that renaming ALIAS columns correctly updates implicit minmax indices
+
+DROP TABLE IF EXISTS test_rename_alias;
+
+CREATE TABLE test_rename_alias (
+    value Int32,
+    alias_col UInt8 ALIAS value > 0
+) ENGINE = MergeTree
+ORDER BY tuple()
+SETTINGS add_minmax_index_for_numeric_columns = true;
+
+INSERT INTO test_rename_alias VALUES (1), (-1), (0);
+
+-- Verify implicit index exists for alias_col
+SELECT name, type, expr
+FROM system.data_skipping_indices
+WHERE database = currentDatabase() AND table = 'test_rename_alias'
+ORDER BY name;
+
+-- Test renaming the ALIAS column
+ALTER TABLE test_rename_alias RENAME COLUMN alias_col TO alias_renamed;
+
+-- Verify implicit index was renamed
+SELECT name, type, expr
+FROM system.data_skipping_indices
+WHERE database = currentDatabase() AND table = 'test_rename_alias'
+ORDER BY name;
+
+-- Verify the renamed column works correctly
+SELECT alias_renamed FROM test_rename_alias ORDER BY value;
+
+DROP TABLE test_rename_alias;

--- a/tests/queries/0_stateless/03769_implicit_index_alias_simple_reference.reference
+++ b/tests/queries/0_stateless/03769_implicit_index_alias_simple_reference.reference
@@ -1,0 +1,5 @@
+auto_minmax_index_a	minmax	a
+auto_minmax_index_d	minmax	a > 0
+0	0	0	0
+10	10	10	1
+20	20	20	1

--- a/tests/queries/0_stateless/03769_implicit_index_alias_simple_reference.sql
+++ b/tests/queries/0_stateless/03769_implicit_index_alias_simple_reference.sql
@@ -1,0 +1,31 @@
+-- Test that implicit minmax indices are only created for ALIAS columns with expressions,
+-- not for simple column references or alias-of-alias chains.
+
+DROP TABLE IF EXISTS test_alias_reference;
+
+-- Create table with:
+-- a: regular column (should get implicit index)
+-- b ALIAS a: simple alias to column (should NOT get implicit index)
+-- c ALIAS b: alias-of-alias (should NOT get implicit index)
+-- d ALIAS a > 0: alias with expression (should get implicit index)
+CREATE TABLE test_alias_reference (
+    a UInt64,
+    b ALIAS a,
+    c ALIAS b,
+    d ALIAS a > 0
+) ENGINE = MergeTree
+ORDER BY tuple()
+SETTINGS add_minmax_index_for_numeric_columns = true;
+
+-- Verify only 'a' and 'd' have implicit indices, not 'b' or 'c'
+SELECT name, type, expr
+FROM system.data_skipping_indices
+WHERE database = currentDatabase() AND table = 'test_alias_reference'
+ORDER BY name;
+
+-- Verify the table works correctly with all aliases
+INSERT INTO test_alias_reference VALUES (10), (20), (0);
+
+SELECT a, b, c, d FROM test_alias_reference ORDER BY a;
+
+DROP TABLE test_alias_reference;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix implicit indices with alias columns and do full validation before creating them

This fixes several existing test with implicit indexes by:
*  Validation for Dynamic/Variant Types: Run full validate() instead of implicitValidation(). This also checks exact error codes instead of everything to prevent catching and ignoring critical errors (like OOMs).
* Changed how we detect indices to drop. We used the first column of the index, but this doesn't work with alias to expressions.
* Disabled implicit indices with alias to simple columns. It doesn't make sense as the other table will get their index anyway, and it solves issues with alias of alias columns.
* Also tunes `03166_optimize_row_order_during_insert.sql` which failed because indices affect the sort order.

References https://github.com/ClickHouse/ClickHouse/pull/76867

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.1083`
<!-- ch-version-info:end -->