### PR TITLE
Add missing OpNum values to zookeeper_log system table enum

### DIFF
--- a/src/Common/ZooKeeper/SystemTablesDataTypes.cpp
+++ b/src/Common/ZooKeeper/SystemTablesDataTypes.cpp
@@ -63,15 +63,21 @@ DB::DataTypePtr SystemTablesDataTypes::operationEnum()
             {"List",                static_cast<Int16>(OpNum::List)},
             {"Check",               static_cast<Int16>(OpNum::Check)},
             {"Multi",               static_cast<Int16>(OpNum::Multi)},
+            {"Create2",             static_cast<Int16>(OpNum::Create2)},
+            {"CheckWatch",          static_cast<Int16>(OpNum::CheckWatch)},
+            {"RemoveWatch",         static_cast<Int16>(OpNum::RemoveWatch)},
             {"MultiRead",           static_cast<Int16>(OpNum::MultiRead)},
             {"Auth",                static_cast<Int16>(OpNum::Auth)},
+            {"SetWatch",            static_cast<Int16>(OpNum::SetWatch)},
+            {"SetWatch2",           static_cast<Int16>(OpNum::SetWatch2)},
+            {"AddWatch",            static_cast<Int16>(OpNum::AddWatch)},
             {"SessionID",           static_cast<Int16>(OpNum::SessionID)},
             {"FilteredList",        static_cast<Int16>(OpNum::FilteredList)},
             {"CheckNotExists",      static_cast<Int16>(OpNum::CheckNotExists)},
             {"CreateIfNotExists",   static_cast<Int16>(OpNum::CreateIfNotExists)},
             {"RemoveRecursive",     static_cast<Int16>(OpNum::RemoveRecursive)},
             {"CheckStat",           static_cast<Int16>(OpNum::CheckStat)},
-            {"Create2",             static_cast<Int16>(OpNum::Create2)},
+            {"FilteredListWithStatsAndData", static_cast<Int16>(OpNum::FilteredListWithStatsAndData)},
         });
     return result;
 }


### PR DESCRIPTION
## Summary

- The `operationEnum()` in `SystemTablesDataTypes.cpp` was missing several `OpNum` values that exist in `ZooKeeperConstants.h`, causing sporadic `UNKNOWN_ELEMENT_OF_ENUM` exceptions when scraping system tables in CI
- Added `FilteredListWithStatsAndData` (506) — the immediate cause of the failure — along with `CheckWatch`, `RemoveWatch`, `SetWatch`, `SetWatch2`, and `AddWatch` which were also missing

## Test plan

- [x] Build compiles successfully
- [ ] CI passes without `UNKNOWN_ELEMENT_OF_ENUM` errors when scraping `zookeeper_log` / `aggregated_zookeeper_log`

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=97110&sha=44610176ba100f485f6d5d832f205f5e3ae217ca&name_0=PR&name_1=Stateless%20tests%20%28amd_tsan%2C%20parallel%2C%202%2F2%29
https://github.com/ClickHouse/ClickHouse/pull/97110

### Changelog category (leave one):
- CI Fix or improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add missing `FilteredListWithStatsAndData` and other `OpNum` values to `zookeeper_log` system table enum, fixing sporadic `UNKNOWN_ELEMENT_OF_ENUM` exceptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.817`
<!-- ch-version-info:end -->