### PR TITLE
Use `libarchive` 3.8.5

### DIFF
--- a/contrib/libarchive-cmake/config.h
+++ b/contrib/libarchive-cmake/config.h
@@ -1326,10 +1326,10 @@ typedef uint64_t uintmax_t;
 #define ICONV_CONST
 
 /* Version number of libarchive as a single integer */
-#define LIBARCHIVE_VERSION_NUMBER "3007004"
+#define LIBARCHIVE_VERSION_NUMBER "3008005"
 
 /* Version number of libarchive */
-#define LIBARCHIVE_VERSION_STRING "3.7.4"
+#define LIBARCHIVE_VERSION_STRING "3.8.5"
 
 /* Define to 1 if `lstat' dereferences a symlink specified with a trailing
    slash. */
@@ -1392,7 +1392,7 @@ typedef uint64_t uintmax_t;
 #endif /* SAFE_TO_DEFINE_EXTENSIONS */
 
 /* Version number of package */
-#define VERSION "3.7.4"
+#define VERSION "3.8.5"
 
 /* Number of bits in a file offset, on hosts where this is settable. */
 /* #undef _FILE_OFFSET_BITS */

--- a/contrib/libarchive-cmake/illumos/config.h
+++ b/contrib/libarchive-cmake/illumos/config.h
@@ -334,16 +334,16 @@ typedef uint64_t uintmax_t;
 /* #undef ARCHIVE_XATTR_LINUX */
 
 /* Version number of bsdcpio */
-#define BSDCPIO_VERSION_STRING "3.8.2"
+#define BSDCPIO_VERSION_STRING "3.8.5"
 
 /* Version number of bsdtar */
-#define BSDTAR_VERSION_STRING "3.8.2"
+#define BSDTAR_VERSION_STRING "3.8.5"
 
 /* Version number of bsdcat */
-#define BSDCAT_VERSION_STRING "3.8.2"
+#define BSDCAT_VERSION_STRING "3.8.5"
 
 /* Version number of bsdunzip */
-#define BSDUNZIP_VERSION_STRING "3.8.2"
+#define BSDUNZIP_VERSION_STRING "3.8.5"
 
 /* Define to 1 if you have the `acl_create_entry' function. */
 /* #undef HAVE_ACL_CREATE_ENTRY */
@@ -1316,10 +1316,10 @@ typedef uint64_t uintmax_t;
 #define ICONV_CONST const
 
 /* Version number of libarchive as a single integer */
-#define LIBARCHIVE_VERSION_NUMBER "3008002"
+#define LIBARCHIVE_VERSION_NUMBER "3008005"
 
 /* Version number of libarchive */
-#define LIBARCHIVE_VERSION_STRING "3.8.2"
+#define LIBARCHIVE_VERSION_STRING "3.8.5"
 
 /* Define to 1 if `lstat' dereferences a symlink specified with a trailing
    slash. */
@@ -1382,7 +1382,7 @@ typedef uint64_t uintmax_t;
 #endif /* SAFE_TO_DEFINE_EXTENSIONS */
 
 /* Version number of package */
-#define VERSION "3.8.2"
+#define VERSION "3.8.5"
 
 /* Number of bits in a file offset, on hosts where this is settable. */
 /* #undef _FILE_OFFSET_BITS */


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement



### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Use `libarchive` 3.8.5.



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.822`
<!-- ch-version-info:end -->