### PR TITLE
Use `fast_float` v8.2.3

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -41,6 +41,10 @@ Checks: [
 
   '-clang-analyzer-core.BitwiseShift', # false positive on boost::dynamic_bitset::to_ulong
 
+  '-clang-analyzer-core.UndefinedBinaryOperatorResult', # false positive in contrib/fast_float
+
+  '-clang-analyzer-optin.core.EnumCastOutOfRange', # false positive with bitmask enums in contrib/fast_float
+
   '-clang-analyzer-optin.performance.Padding',
 
   '-clang-analyzer-security.ArrayBound', # only false positives

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -41,10 +41,6 @@ Checks: [
 
   '-clang-analyzer-core.BitwiseShift', # false positive on boost::dynamic_bitset::to_ulong
 
-  '-clang-analyzer-core.UndefinedBinaryOperatorResult', # false positive in contrib/fast_float
-
-  '-clang-analyzer-optin.core.EnumCastOutOfRange', # false positive with bitmask enums in contrib/fast_float
-
   '-clang-analyzer-optin.performance.Padding',
 
   '-clang-analyzer-security.ArrayBound', # only false positives

--- a/src/IO/examples/read_float_perf.cpp
+++ b/src/IO/examples/read_float_perf.cpp
@@ -1,3 +1,8 @@
+// NOLINTBEGIN(clang-analyzer-core.UndefinedBinaryOperatorResult,clang-analyzer-optin.core.EnumCastOutOfRange)
+// False positives: clang-analyzer traces into fast_float library headers and reports
+// UndefinedBinaryOperatorResult in ascii_number.h and EnumCastOutOfRange in float_common.h.
+// These cannot be suppressed via NOLINT at call sites because the diagnostics are reported
+// at the library header locations, not at the call site.
 #include <string>
 
 #include <iostream>
@@ -84,3 +89,4 @@ catch (const Exception & e)
     std::cerr << e.what() << ", " << e.displayText() << std::endl;
     return 1;
 }
+// NOLINTEND(clang-analyzer-core.UndefinedBinaryOperatorResult,clang-analyzer-optin.core.EnumCastOutOfRange)

--- a/src/IO/readFloatText.h
+++ b/src/IO/readFloatText.h
@@ -5,10 +5,12 @@
 #include <base/shift10.h>
 #include <Common/StringUtils.h>
 
+// NOLINTBEGIN(clang-analyzer-core.UndefinedBinaryOperatorResult,clang-analyzer-optin.core.EnumCastOutOfRange)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunneeded-internal-declaration"
 #include <fast_float/fast_float.h>
 #pragma clang diagnostic pop
+// NOLINTEND(clang-analyzer-core.UndefinedBinaryOperatorResult,clang-analyzer-optin.core.EnumCastOutOfRange)
 
 /** Methods for reading floating point numbers from text with decimal representation.
   * There are "precise", "fast" and "simple" implementations.
@@ -151,7 +153,7 @@ ReturnType readFloatTextPreciseImpl(T & x, ReadBuffer & buf)
     if (likely(!buf.eof() && (buf_from_memory || buf.position() + MAX_LENGTH <= buf.buffer().end())))
     {
         auto * initial_position = buf.position();
-        auto res = fast_float::from_chars(initial_position, buf.buffer().end(), x, fast_float::chars_format::general | fast_float::chars_format::allow_leading_plus);
+        auto res = fast_float::from_chars(initial_position, buf.buffer().end(), x, fast_float::chars_format::general | fast_float::chars_format::allow_leading_plus); // NOLINT(clang-analyzer-core.UndefinedBinaryOperatorResult,clang-analyzer-optin.core.EnumCastOutOfRange)
 
         if (unlikely(res.ec != std::errc()))
         {
@@ -238,11 +240,11 @@ ReturnType readFloatTextPreciseImpl(T & x, ReadBuffer & buf)
 
         fast_float::from_chars_result res;
         if constexpr (std::endian::native == std::endian::little)
-            res = fast_float::from_chars(tmp_buf, tmp_buf + num_copied_chars, x);
+            res = fast_float::from_chars(tmp_buf, tmp_buf + num_copied_chars, x); // NOLINT(clang-analyzer-core.UndefinedBinaryOperatorResult,clang-analyzer-optin.core.EnumCastOutOfRange)
         else
         {
             Float64 x64 = 0.0;
-            res = fast_float::from_chars(tmp_buf, tmp_buf + num_copied_chars, x64);
+            res = fast_float::from_chars(tmp_buf, tmp_buf + num_copied_chars, x64); // NOLINT(clang-analyzer-core.UndefinedBinaryOperatorResult,clang-analyzer-optin.core.EnumCastOutOfRange)
             x = static_cast<T>(x64);
         }
         if (unlikely(res.ec != std::errc() || res.ptr - tmp_buf != num_copied_chars))

--- a/src/IO/readFloatText.h
+++ b/src/IO/readFloatText.h
@@ -151,7 +151,7 @@ ReturnType readFloatTextPreciseImpl(T & x, ReadBuffer & buf)
     if (likely(!buf.eof() && (buf_from_memory || buf.position() + MAX_LENGTH <= buf.buffer().end())))
     {
         auto * initial_position = buf.position();
-        auto res = fast_float::from_chars(initial_position, buf.buffer().end(), x);
+        auto res = fast_float::from_chars(initial_position, buf.buffer().end(), x, fast_float::chars_format::general | fast_float::chars_format::allow_leading_plus);
 
         if (unlikely(res.ec != std::errc()))
         {

--- a/src/IO/readFloatText.h
+++ b/src/IO/readFloatText.h
@@ -153,7 +153,7 @@ ReturnType readFloatTextPreciseImpl(T & x, ReadBuffer & buf)
     if (likely(!buf.eof() && (buf_from_memory || buf.position() + MAX_LENGTH <= buf.buffer().end())))
     {
         auto * initial_position = buf.position();
-        auto res = fast_float::from_chars(initial_position, buf.buffer().end(), x, fast_float::chars_format::general | fast_float::chars_format::allow_leading_plus); // NOLINT(clang-analyzer-core.UndefinedBinaryOperatorResult,clang-analyzer-optin.core.EnumCastOutOfRange)
+        auto res = fast_float::from_chars(initial_position, buf.buffer().end(), x, fast_float::chars_format::general | fast_float::chars_format::allow_leading_plus);
 
         if (unlikely(res.ec != std::errc()))
         {
@@ -240,11 +240,11 @@ ReturnType readFloatTextPreciseImpl(T & x, ReadBuffer & buf)
 
         fast_float::from_chars_result res;
         if constexpr (std::endian::native == std::endian::little)
-            res = fast_float::from_chars(tmp_buf, tmp_buf + num_copied_chars, x); // NOLINT(clang-analyzer-core.UndefinedBinaryOperatorResult,clang-analyzer-optin.core.EnumCastOutOfRange)
+            res = fast_float::from_chars(tmp_buf, tmp_buf + num_copied_chars, x);
         else
         {
             Float64 x64 = 0.0;
-            res = fast_float::from_chars(tmp_buf, tmp_buf + num_copied_chars, x64); // NOLINT(clang-analyzer-core.UndefinedBinaryOperatorResult,clang-analyzer-optin.core.EnumCastOutOfRange)
+            res = fast_float::from_chars(tmp_buf, tmp_buf + num_copied_chars, x64);
             x = static_cast<T>(x64);
         }
         if (unlikely(res.ec != std::errc() || res.ptr - tmp_buf != num_copied_chars))


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Use `fast_float` v8.2.3.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.955`
<!-- ch-version-info:end -->