### PR TITLE
Fix flaky test 00284_external_aggregation on TSan

### DIFF
--- a/tests/queries/0_stateless/00284_external_aggregation.sql
+++ b/tests/queries/0_stateless/00284_external_aggregation.sql
@@ -3,6 +3,7 @@
 -- This test was split in two due to long runtimes in sanitizers.
 -- The other part is 00284_external_aggregation_2.
 
+SET max_threads = 'auto';
 SET max_bytes_before_external_group_by = 100000000;
 SET max_bytes_ratio_before_external_group_by = 0;
 SET max_memory_usage = 410000000;

--- a/tests/queries/0_stateless/00284_external_aggregation_2.sql
+++ b/tests/queries/0_stateless/00284_external_aggregation_2.sql
@@ -3,6 +3,7 @@
 -- This test was split in two due to long runtimes in sanitizers.
 -- The other part is 00284_external_aggregation.
 
+SET max_threads = 'auto';
 SET group_by_two_level_threshold_bytes = 50000000;
 SET max_memory_usage = 0;
 SET group_by_two_level_threshold = 100000;


### PR DESCRIPTION
The test timed out (315s > 300s `max_execution_time`) because randomized settings set `max_threads` to 2, which is too slow for external aggregation of 10M rows on a TSan build. Explicitly set `max_threads = 'auto'` to prevent the random override.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=97129&sha=f95835bd09f6d604e6e8333d545fec885f757466&name_0=PR&name_1=Stateless%20tests%20%28amd_tsan%2C%20parallel%2C%202%2F2%29
https://github.com/ClickHouse/ClickHouse/pull/97129

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.846`
<!-- ch-version-info:end -->