### PR TITLE
Fix flaky test test_restore_db_replica_with_diffrent_table_metadata

### DIFF
--- a/tests/integration/test_restore_db_replica/test.py
+++ b/tests/integration/test_restore_db_replica/test.py
@@ -535,12 +535,12 @@ def test_restore_db_replica_with_diffrent_table_metadata(
     )
 
     if restore_firstly_node_where_created:
-        assert node_1.query(
-            f"SELECT count(*) FROM {exclusive_database_name}.{test_table_2}"
-        ) == TSV([count_test_table_2]) 
-        assert node_2.query(
-            f"SELECT count(*) FROM {exclusive_database_name}.{test_table_2}"
-        ) == TSV([count_test_table_2]) 
+        check_contains_table(
+            node_1, f"{exclusive_database_name}.{test_table_2}", count_test_table_2
+        )
+        check_contains_table(
+            node_2, f"{exclusive_database_name}.{test_table_2}", count_test_table_2
+        )
     else:
         assert node_2.query(
             f"SELECT count(*) FROM system.databases WHERE name='{exclusive_database_name}_broken_tables'"


### PR DESCRIPTION
## Summary
- Use `check_contains_table` (which calls `SYSTEM SYNC REPLICA` before counting) instead of a plain `SELECT count(*)` query when verifying `test_table_2` data after database restore
- The test was flaky because data replication from node2 to node1 is asynchronous — with `PARTITION BY n % 10`, the 10 rows go to 10 partitions, and only some may have synced by the time of the check

Closes #88062

https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=b098cd77aff8644bb4e513e0eb53d3ba399aa7dd&name_0=MasterCI&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%203%2F4%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)