### PR TITLE
Fix Spark/JVM cascading failures and skip test_ytsaurus under coverage

### DIFF
--- a/ci/jobs/scripts/integration_tests_configs.py
+++ b/ci/jobs/scripts/integration_tests_configs.py
@@ -19,6 +19,7 @@ LLVM_COVERAGE_SKIP_PREFIXES = [
     "test_storage_s3_queue/test_6.py",
     "test_named_collections_encrypted2/",
     "test_multiple_disks/",
+    "test_ytsaurus/",
 ]
 
 TEST_CONFIGS = [

--- a/tests/integration/helpers/iceberg_utils.py
+++ b/tests/integration/helpers/iceberg_utils.py
@@ -25,6 +25,7 @@ from helpers.s3_tools import (
     S3Downloader,
     prepare_s3_bucket,
 )
+from helpers.spark_tools import ResilientSparkSession
 
 from typing import Optional, Any
 
@@ -96,7 +97,7 @@ def started_cluster():
         prepare_s3_bucket(cluster)
         logging.info("S3 bucket created")
 
-        cluster.spark_session = get_spark()
+        cluster.spark_session = ResilientSparkSession(get_spark)
         cluster.default_s3_uploader = S3Uploader(
             cluster.minio_client, cluster.minio_bucket
         )

--- a/tests/integration/helpers/spark_tools.py
+++ b/tests/integration/helpers/spark_tools.py
@@ -1,0 +1,52 @@
+import logging
+
+import pyspark
+
+
+class ResilientSparkSession:
+    """Wrapper around SparkSession that automatically restarts on JVM/py4j failures.
+
+    Under LLVM coverage instrumentation, Spark/JVM operations run significantly
+    slower and can timeout or crash.  When the JVM dies, py4j raises errors like
+    ``Py4JNetworkError`` or ``AttributeError: 'NoneType' ...``.  A dead session
+    poisons every subsequent test that shares it (module/package scope).
+
+    This wrapper detects those failures and transparently recreates the session.
+    """
+
+    def __init__(self, create_session_fn):
+        self._create = create_session_fn
+        self._session = create_session_fn()
+
+    def _restart(self):
+        logging.warning("Spark session is dead, restarting...")
+        try:
+            self._session.stop()
+        except Exception:
+            pass
+        # Clear any cached singleton so getOrCreate builds a fresh one
+        pyspark.sql.SparkSession.builder._options = {}
+        try:
+            pyspark.sql.SparkSession._instantiatedSession = None
+        except Exception:
+            pass
+        self._session = self._create()
+        logging.warning("Spark session restarted successfully")
+
+    def _is_alive(self):
+        try:
+            self._session.sparkContext._jsc.sc().defaultParallelism()
+            return True
+        except Exception:
+            return False
+
+    def __getattr__(self, name):
+        if not self._is_alive():
+            self._restart()
+        return getattr(self._session, name)
+
+    def stop(self):
+        try:
+            self._session.stop()
+        except Exception:
+            pass

--- a/tests/integration/test_storage_delta/test.py
+++ b/tests/integration/test_storage_delta/test.py
@@ -58,6 +58,7 @@ from helpers.s3_tools import (
     LocalUploader,
 )
 from helpers.test_tools import TSV
+from helpers.spark_tools import ResilientSparkSession
 
 
 SCRIPT_DIR = "/var/lib/clickhouse/user_files" + os.path.join(
@@ -220,7 +221,7 @@ def started_cluster():
         # extend this if testing on other nodes becomes necessary
         cluster.local_uploader = LocalUploader(cluster.instances["node1"])
 
-        cluster.spark_session = get_spark()
+        cluster.spark_session = ResilientSparkSession(get_spark)
 
         for file in S3_DATA:
             print(f"Copying object {file}")

--- a/tests/integration/test_storage_delta/test_cdf.py
+++ b/tests/integration/test_storage_delta/test_cdf.py
@@ -47,6 +47,7 @@ from helpers.s3_tools import (
     upload_directory,
     LocalDownloader,
 )
+from helpers.spark_tools import ResilientSparkSession
 
 
 SCRIPT_DIR = "/var/lib/clickhouse/user_files" + os.path.join(
@@ -123,7 +124,7 @@ def started_cluster():
         # extend this if testing on other nodes becomes necessary
         cluster.local_uploader = LocalUploader(cluster.instances["instance1"])
 
-        cluster.spark_session = get_spark()
+        cluster.spark_session = ResilientSparkSession(get_spark)
 
         for file in S3_DATA:
             print(f"Copying object {file}")

--- a/tests/integration/test_storage_delta/test_imds.py
+++ b/tests/integration/test_storage_delta/test_imds.py
@@ -33,6 +33,7 @@ from test_storage_delta.test import (
 from helpers.s3_tools import (
     prepare_s3_bucket,
 )
+from helpers.spark_tools import ResilientSparkSession
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 METADATA_SERVER_HOSTNAME = "resolver"
@@ -80,7 +81,7 @@ def started_cluster():
         prepare_s3_bucket(cluster)
         start_metadata_server(cluster)
 
-        cluster.spark_session = get_spark()
+        cluster.spark_session = ResilientSparkSession(get_spark)
         start_metadata_server(cluster)
 
         yield cluster

--- a/tests/integration/test_storage_delta_disks/test.py
+++ b/tests/integration/test_storage_delta_disks/test.py
@@ -16,6 +16,7 @@ from pyspark.sql.types import (
 from pyspark.sql.window import Window
 
 from helpers.cluster import ClickHouseCluster
+from helpers.spark_tools import ResilientSparkSession
 from helpers.s3_tools import (
     AzureUploader,
     LocalUploader,
@@ -159,7 +160,7 @@ def started_cluster():
         prepare_s3_bucket(cluster)
         logging.info("S3 bucket created")
 
-        cluster.spark_session = get_spark()
+        cluster.spark_session = ResilientSparkSession(get_spark)
         cluster.default_s3_uploader = S3Uploader(
             cluster.minio_client, cluster.minio_bucket
         )

--- a/tests/integration/test_storage_hudi/test.py
+++ b/tests/integration/test_storage_hudi/test.py
@@ -32,6 +32,7 @@ from helpers.s3_tools import (
     upload_directory,
 )
 from helpers.test_tools import TSV
+from helpers.spark_tools import ResilientSparkSession
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 
@@ -66,7 +67,7 @@ def started_cluster():
         prepare_s3_bucket(cluster)
         logging.info("S3 bucket created")
 
-        cluster.spark_session = get_spark()
+        cluster.spark_session = ResilientSparkSession(get_spark)
 
         yield cluster
 

--- a/tests/integration/test_storage_iceberg_concurrent/conftest.py
+++ b/tests/integration/test_storage_iceberg_concurrent/conftest.py
@@ -13,6 +13,7 @@ from helpers.s3_tools import (
     LocalDownloader,
     prepare_s3_bucket,
 )
+from helpers.spark_tools import ResilientSparkSession
 
 def check_spark(spark):
     p = subprocess.run(["echo", "hello world!"], capture_output=True, text=True)
@@ -96,7 +97,7 @@ def started_cluster_iceberg():
 
         prepare_s3_bucket(cluster)
 
-        cluster.spark_session = get_spark(cluster)
+        cluster.spark_session = ResilientSparkSession(lambda: get_spark(cluster))
 
         # check_spark(cluster.spark_session)
 

--- a/tests/integration/test_storage_iceberg_disks/test.py
+++ b/tests/integration/test_storage_iceberg_disks/test.py
@@ -13,6 +13,7 @@ from helpers.s3_tools import (
     LocalDownloader,
     prepare_s3_bucket,
 )
+from helpers.spark_tools import ResilientSparkSession
 from helpers.test_tools import TSV
 
 from helpers.iceberg_utils import (
@@ -124,7 +125,7 @@ def started_cluster():
         prepare_s3_bucket(cluster)
         logging.info("S3 bucket created")
 
-        cluster.spark_session = get_spark()
+        cluster.spark_session = ResilientSparkSession(get_spark)
         cluster.default_s3_uploader = S3Uploader(
             cluster.minio_client, cluster.minio_bucket
         )

--- a/tests/integration/test_storage_iceberg_schema_evolution/conftest.py
+++ b/tests/integration/test_storage_iceberg_schema_evolution/conftest.py
@@ -11,6 +11,7 @@ from helpers.s3_tools import (
     LocalDownloader,
     prepare_s3_bucket,
 )
+from helpers.spark_tools import ResilientSparkSession
 
 def get_spark():
     builder = (
@@ -49,7 +50,7 @@ def started_cluster_iceberg_schema_evolution():
         prepare_s3_bucket(cluster)
         logging.info("S3 bucket created")
 
-        cluster.spark_session = get_spark()
+        cluster.spark_session = ResilientSparkSession(get_spark)
         cluster.default_s3_uploader = S3Uploader(
             cluster.minio_client, cluster.minio_bucket
         )

--- a/tests/integration/test_storage_iceberg_with_spark/conftest.py
+++ b/tests/integration/test_storage_iceberg_with_spark/conftest.py
@@ -16,6 +16,7 @@ from helpers.s3_tools import (
     LocalDownloader,
     prepare_s3_bucket,
 )
+from helpers.spark_tools import ResilientSparkSession
 
 
 def get_spark():
@@ -103,7 +104,7 @@ def started_cluster_iceberg_with_spark():
         prepare_s3_bucket(cluster)
         logging.info("S3 bucket created")
 
-        cluster.spark_session = get_spark()
+        cluster.spark_session = ResilientSparkSession(get_spark)
         cluster.default_s3_uploader = S3Uploader(
             cluster.minio_client, cluster.minio_bucket
         )

--- a/tests/integration/test_storage_iceberg_with_spark_cache/conftest.py
+++ b/tests/integration/test_storage_iceberg_with_spark_cache/conftest.py
@@ -13,6 +13,7 @@ from helpers.s3_tools import (
     LocalDownloader,
     prepare_s3_bucket,
 )
+from helpers.spark_tools import ResilientSparkSession
 
 def get_spark():
     builder = (
@@ -81,7 +82,7 @@ def started_cluster_iceberg_with_spark():
         prepare_s3_bucket(cluster)
         logging.info("S3 bucket created")
 
-        cluster.spark_session = get_spark()
+        cluster.spark_session = ResilientSparkSession(get_spark)
         cluster.default_s3_uploader = S3Uploader(
             cluster.minio_client, cluster.minio_bucket
         )


### PR DESCRIPTION
## Summary
- Added `ResilientSparkSession` wrapper (`tests/integration/helpers/spark_tools.py`) that detects dead Spark JVM sessions and automatically restarts them, preventing cascading failures across module/package-scoped test fixtures
- Applied the wrapper to all 11 integration test fixtures that create Spark sessions (Delta Lake, Iceberg, Hudi)
- Added `test_ytsaurus/` to `LLVM_COVERAGE_SKIP_PREFIXES` — the YTSaurus backend container gets OOM-killed (exit code 137) under the memory pressure of coverage-instrumented builds

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=391900867a080535a9704383d08124427508ad89&name_0=MasterCI&name_1=Integration%20tests%20%28amd_llvm_coverage%2C%205%2F5%29

## Test plan
- [ ] Verify integration tests with Spark (Delta, Iceberg, Hudi) still pass in normal builds
- [ ] Verify `test_ytsaurus` is skipped in `amd_llvm_coverage` runs
- [ ] Verify Spark session restart works when JVM dies (coverage builds)

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)