### PR TITLE
Add missing enum keys for `zookeeper_log.error`

### DIFF
--- a/src/Common/ZooKeeper/SystemTablesDataTypes.cpp
+++ b/src/Common/ZooKeeper/SystemTablesDataTypes.cpp
@@ -21,6 +21,7 @@ DB::DataTypePtr SystemTablesDataTypes::errorCodeEnum()
             {"ZOPERATIONTIMEOUT",           static_cast<Int8>(Error::ZOPERATIONTIMEOUT)},
             {"ZBADARGUMENTS",               static_cast<Int8>(Error::ZBADARGUMENTS)},
             {"ZINVALIDSTATE",               static_cast<Int8>(Error::ZINVALIDSTATE)},
+            {"ZOUTOFMEMORY",                static_cast<Int8>(Error::ZOUTOFMEMORY)},
             {"ZAPIERROR",                   static_cast<Int8>(Error::ZAPIERROR)},
             {"ZNONODE",                     static_cast<Int8>(Error::ZNONODE)},
             {"ZNOAUTH",                     static_cast<Int8>(Error::ZNOAUTH)},
@@ -36,6 +37,7 @@ DB::DataTypePtr SystemTablesDataTypes::errorCodeEnum()
             {"ZNOTHING",                    static_cast<Int8>(Error::ZNOTHING)},
             {"ZSESSIONMOVED",               static_cast<Int8>(Error::ZSESSIONMOVED)},
             {"ZNOTREADONLY",                static_cast<Int8>(Error::ZNOTREADONLY)},
+            {"ZNOWATCHER",                  static_cast<Int8>(Error::ZNOWATCHER)},
         });
     return result;
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add missing enum keys for `zookeeper_log.error`


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.836`
<!-- ch-version-info:end -->