### PR TITLE
Detect short-lived job failures as infrastructure errors in CI retry workflow

### DIFF
--- a/.github/workflows/retry_infra_failures.yml
+++ b/.github/workflows/retry_infra_failures.yml
@@ -49,26 +49,39 @@ jobs:
             run_url="https://github.com/$GH_REPO/actions/runs/$run_id"
             echo "Checking run $run_url ..."
 
-            # A run is an infrastructure failure if every failed job either:
-            # - never reached its main "Run" step (failed during checkout/setup), or
-            # - is the "Config Workflow" job (pipeline configuration, not actual tests)
-            is_infra=$(gh api "repos/$GH_REPO/actions/runs/$run_id/jobs?per_page=100" \
-              --jq '
-                [.jobs[] | select(.conclusion == "failure")] as $failed |
-                if ($failed | length) == 0 then
-                  false
+            # Collect per-job verdicts across all pages (runs can have >100 jobs).
+            # Each failed job emits "true" (infrastructure) or "false" (real failure).
+            # A job is considered an infrastructure failure if:
+            # - it is the "Config Workflow" job (pipeline configuration, not actual tests), or
+            # - it never reached its main "Run" step (failed during checkout/setup), or
+            # - the "Run" step was skipped, or
+            # - the "Run" step failed almost immediately (under 2 minutes), indicating
+            #   a setup/download issue (e.g. missing S3 credentials) rather than a real
+            #   test failure
+            verdicts=$(gh api "repos/$GH_REPO/actions/runs/$run_id/jobs?per_page=100" \
+              --paginate --jq '
+                .jobs[] | select(.conclusion == "failure") |
+                if .name == "Config Workflow" then true
                 else
-                  [$failed[] |
-                    if .name == "Config Workflow" then true
-                    else
-                      [.steps[] | select(.name == "Run")] |
-                      if length == 0 then true
-                      else .[0].conclusion == "skipped"
-                      end
-                    end
-                  ] | all
+                  [.steps[] | select(.name == "Run")] |
+                  if length == 0 then true
+                  elif .[0].conclusion == "skipped" then true
+                  elif .[0].conclusion == "failure" then
+                    ((.[0].completed_at | fromdateiso8601) -
+                     (.[0].started_at | fromdateiso8601)) < 120
+                  else false
+                  end
                 end
               ')
+
+            # Infrastructure failure = at least one failed job, and all of them are infra
+            if [ -z "$verdicts" ]; then
+              is_infra=false
+            elif echo "$verdicts" | grep -q "false"; then
+              is_infra=false
+            else
+              is_infra=true
+            fi
 
             if [ "$is_infra" = "true" ]; then
               echo "  Infrastructure failure detected, rerunning..."


### PR DESCRIPTION
## Summary

- Detect jobs where the "Run" step fails almost immediately (under 2 minutes) as infrastructure failures — this covers cases like missing S3 credentials on CI runners where the pre-run script fails before the actual test starts
- Fix pagination: CI runs can have 140+ jobs but the API returns 100 per page; use `--paginate` so failures beyond page 1 are not missed

Example: [Stress test (amd_msan) in PR #96882](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96882&sha=3c048f936e0f23365d2422fc8e9595c23b20aaa0&name_0=PR
https://github.com/ClickHouse/ClickHouse/pull/96882) failed because the runner had `NoCredentialsError: Unable to locate credentials` — the "Run" step completed in 5 seconds without ever starting the stress test.

## Test plan

Verified the new jq logic against real CI runs:
- Run 22082646932 (S3 credential failure, "Run" step took 5s) → correctly detected as infrastructure
- Run 22089690498 (real build failure, "Run" step took ~20min) → correctly not detected

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...


🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.874`
<!-- ch-version-info:end -->