### PR TITLE
Fix flaky test test_database_delta::test_timestamp_ntz timeout

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -2507,8 +2507,15 @@ class ClickHouseCluster:
             exec_cmd += [container_id]
             exec_cmd += list(cmd)
 
+            timeout = kwargs.get("timeout", None)
+            extra_kwargs = {}
+            if env is not None:
+                extra_kwargs["env"] = env
+            if timeout is not None:
+                extra_kwargs["timeout"] = timeout
+
             result = subprocess_check_call(
-                exec_cmd, detach=detach, nothrow=nothrow, env=env
+                exec_cmd, detach=detach, nothrow=nothrow, **extra_kwargs
             )
             return result
         else:

--- a/tests/integration/test_database_delta/test.py
+++ b/tests/integration/test_database_delta/test.py
@@ -100,6 +100,7 @@ def execute_spark_query(node, query_text):
         -S -e "{query_text}"
     """,
             ],
+            timeout=600,
         )
     except subprocess.CalledProcessError as e:
         print("Command failed with exit code:", e.returncode)
@@ -345,11 +346,6 @@ settings warehouse = 'unity', catalog_type='unity', vended_credentials=false, al
 
     assert len(ntz_tables) == 1
 
-    def get_schemas():
-        return execute_spark_query(node1, f"SHOW SCHEMAS")
-
-    assert schema_name in get_schemas()
-
     ntz_data = ""
     for i in range(10):
         try:
@@ -365,9 +361,10 @@ settings warehouse = 'unity', catalog_type='unity', vended_credentials=false, al
         except Exception as ex:
             if "Schema not found" not in str(ex):
                 raise ex
-            print(f"Retry {i + 1}, existing schemas: {get_schemas()}")
+            print(f"Retry {i + 1}")
+            time.sleep(1)
 
-    assert len(ntz_data) != 0, f"Schemas: {get_schemas()}"
+    assert len(ntz_data) != 0
     print(ntz_data)
     assert ntz_data[0] == "2024-10-01"
     assert ntz_data[1] == "2024-10-01 00:12:00.000000"


### PR DESCRIPTION
## Summary
- Increase Spark command timeout from 300s to 600s in `execute_spark_query` by threading the `timeout` kwarg through `exec_in_container` to `subprocess_check_call`
- Remove redundant `get_schemas()` calls from `test_timestamp_ntz` that spawned extra Spark JVMs just for diagnostics, adding minutes of overhead to the test

Closes https://github.com/ClickHouse/ClickHouse/issues/97087

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...