### PR TITLE
S3Queue ordered mode better bucket assignment when bucketing with partition key

### DIFF
--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
@@ -273,6 +273,18 @@ bool ObjectStorageQueueMetadata::useBucketsForProcessing() const
 
 ObjectStorageQueueMetadata::Bucket ObjectStorageQueueMetadata::getBucketForPath(const std::string & path) const
 {
+    /// For PARTITION mode, use an optimal approach by scanning existing buckets and claim free buckets first.
+    /// This ensures optimal distribution (1:1 mapping when num_partitions <= num_buckets). When num_partitions >=
+    /// num_buckets switch to a hash-based assignment without causing errors.
+    if (bucketing_mode == ObjectStorageQueueBucketingMode::PARTITION
+        && partitioning_mode != ObjectStorageQueuePartitioningMode::NONE)
+    {
+        auto partition_key = ObjectStorageQueueOrderedFileMetadata::getPartitionKey(
+            path, partitioning_mode, filename_parser.get());
+        return findOrClaimBucketForPartition(partition_key);
+    }
+
+    /// For other modes, use default hash-based assignment
     return getBucketForPath(path, buckets_num, bucketing_mode, partitioning_mode, filename_parser.get());
 }
 
@@ -284,6 +296,61 @@ ObjectStorageQueueMetadata::Bucket ObjectStorageQueueMetadata::getBucketForPath(
     const ObjectStorageQueueFilenameParser * parser)
 {
     return ObjectStorageQueueOrderedFileMetadata::getBucketForPath(path, buckets_num, bucketing_mode, partitioning_mode, parser);
+}
+
+ObjectStorageQueueMetadata::Bucket ObjectStorageQueueMetadata::findOrClaimBucketForPartition(const std::string & partition_key) const
+{
+    /// Check cache first
+    {
+        std::lock_guard lock(partition_bucket_cache_mutex);
+        if (auto it = partition_bucket_cache.find(partition_key); it != partition_bucket_cache.end())
+            return it->second;
+    }
+
+    /// Scan existing buckets to find where this partition already exists
+    auto zk = getZooKeeper();
+    for (Bucket bucket_id = 0; bucket_id < buckets_num; ++bucket_id)
+    {
+        const auto processed_path = zookeeper_path / "buckets" / toString(bucket_id) / "processed";
+
+        /// Check if this partition key exists in this bucket
+        if (zk->exists(processed_path / partition_key))
+        {
+            LOG_TRACE(log, "Found existing partition '{}' in bucket {}", partition_key, bucket_id);
+
+            std::lock_guard lock(partition_bucket_cache_mutex);
+            partition_bucket_cache[partition_key] = bucket_id;
+            return bucket_id;
+        }
+    }
+
+    /// If partitionis  not found, claim next available bucket
+    for (Bucket bucket_id = 0; bucket_id < buckets_num; ++bucket_id)
+    {
+        const auto processed_path = zookeeper_path / "buckets" / toString(bucket_id) / "processed";
+
+        /// Check if this bucket is free (no partitions assigned yet)
+        Coordination::Stat stat;
+        auto children = zk->getChildren(processed_path, &stat);
+
+        if (children.empty())
+        {
+            LOG_INFO(log, "Claiming free bucket {} for new partition '{}'", bucket_id, partition_key);
+
+            std::lock_guard lock(partition_bucket_cache_mutex);
+            partition_bucket_cache[partition_key] = bucket_id;
+            return bucket_id;
+        }
+    }
+
+    /// If all buckets have partitions, use hash as fallback.
+    Bucket bucket_id = sipHash64(partition_key) % buckets_num;
+    LOG_INFO(log, "All buckets occupied, using hash fallback for partition '{}' -> bucket {}", partition_key, bucket_id);
+
+    /// update cache before returning
+    std::lock_guard lock(partition_bucket_cache_mutex);
+    partition_bucket_cache[partition_key] = bucket_id;
+    return bucket_id;
 }
 
 ObjectStorageQueueOrderedFileMetadata::BucketHolderPtr

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
@@ -324,18 +324,29 @@ ObjectStorageQueueMetadata::Bucket ObjectStorageQueueMetadata::findOrClaimBucket
         }
     }
 
-    /// If partitionis  not found, claim next available bucket
+    /// If partition is not found, claim next available bucket
     for (Bucket bucket_id = 0; bucket_id < buckets_num; ++bucket_id)
     {
         const auto processed_path = zookeeper_path / "buckets" / toString(bucket_id) / "processed";
 
         /// Check if this bucket is free (no partitions assigned yet)
+        /// If the processed path doesn't exist, the bucket is definitely free
+        if (!zk->exists(processed_path))
+        {
+            LOG_INFO(log, "Claiming free bucket {} (no processed dir) for new partition '{}'", bucket_id, partition_key);
+
+            std::lock_guard lock(partition_bucket_cache_mutex);
+            partition_bucket_cache[partition_key] = bucket_id;
+            return bucket_id;
+        }
+
+        /// If processed path exists, check if it has any children (partitions)
         Coordination::Stat stat;
         auto children = zk->getChildren(processed_path, &stat);
 
         if (children.empty())
         {
-            LOG_INFO(log, "Claiming free bucket {} for new partition '{}'", bucket_id, partition_key);
+            LOG_INFO(log, "Claiming empty bucket {} for new partition '{}'", bucket_id, partition_key);
 
             std::lock_guard lock(partition_bucket_cache_mutex);
             partition_bucket_cache[partition_key] = bucket_id;

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
@@ -273,18 +273,15 @@ bool ObjectStorageQueueMetadata::useBucketsForProcessing() const
 
 ObjectStorageQueueMetadata::Bucket ObjectStorageQueueMetadata::getBucketForPath(const std::string & path) const
 {
-    /// For PARTITION mode, use an optimal approach by scanning existing buckets and claim free buckets first.
-    /// This ensures optimal distribution (1:1 mapping when num_partitions <= num_buckets). When num_partitions >=
-    /// num_buckets switch to a hash-based assignment without causing errors.
     if (bucketing_mode == ObjectStorageQueueBucketingMode::PARTITION
         && partitioning_mode != ObjectStorageQueuePartitioningMode::NONE)
     {
         auto partition_key = ObjectStorageQueueOrderedFileMetadata::getPartitionKey(
             path, partitioning_mode, filename_parser.get());
+
         return findOrClaimBucketForPartition(partition_key);
     }
 
-    /// For other modes, use default hash-based assignment
     return getBucketForPath(path, buckets_num, bucketing_mode, partitioning_mode, filename_parser.get());
 }
 
@@ -300,65 +297,64 @@ ObjectStorageQueueMetadata::Bucket ObjectStorageQueueMetadata::getBucketForPath(
 
 ObjectStorageQueueMetadata::Bucket ObjectStorageQueueMetadata::findOrClaimBucketForPartition(const std::string & partition_key) const
 {
-    /// Check cache first
     {
         std::lock_guard lock(partition_bucket_cache_mutex);
         if (auto it = partition_bucket_cache.find(partition_key); it != partition_bucket_cache.end())
             return it->second;
     }
 
-    /// Scan existing buckets to find where this partition already exists
-    auto zk = getZooKeeper();
-    for (Bucket bucket_id = 0; bucket_id < buckets_num; ++bucket_id)
+    Bucket result_bucket = buckets_num;
+    auto retry_ctrl = getKeeperRetriesControl(log);
+
+    retry_ctrl.retryLoop([&]
     {
-        const auto processed_path = zookeeper_path / "buckets" / toString(bucket_id) / "processed";
+        auto zk = getZooKeeper();
 
-        /// Check if this partition key exists in this bucket
-        if (zk->exists(processed_path / partition_key))
+        for (Bucket bucket_id = 0; bucket_id < buckets_num; ++bucket_id)
         {
-            LOG_TRACE(log, "Found existing partition '{}' in bucket {}", partition_key, bucket_id);
+            const auto claimed_dir = zookeeper_path / "buckets" / toString(bucket_id) / "claimed";
 
-            std::lock_guard lock(partition_bucket_cache_mutex);
-            partition_bucket_cache[partition_key] = bucket_id;
-            return bucket_id;
+            Strings claimed_children;
+            auto code = zk->tryGetChildren(claimed_dir, claimed_children);
+
+            if (code != Coordination::Error::ZOK && code != Coordination::Error::ZNONODE)
+                throw zkutil::KeeperException::fromPath(code, claimed_dir);
+
+            if (code == Coordination::Error::ZNONODE)
+                claimed_children.clear();
+
+            if (std::find(claimed_children.begin(), claimed_children.end(), partition_key) != claimed_children.end())
+            {
+                result_bucket = bucket_id;
+                return;
+            }
+
+            if (!claimed_children.empty())
+                continue;
+
+            code = zk->tryCreate(claimed_dir / partition_key, "", zkutil::CreateMode::Persistent);
+
+            if (code == Coordination::Error::ZOK)
+            {
+                result_bucket = bucket_id;
+                return;
+            }
+
+            if (code != Coordination::Error::ZNODEEXISTS)
+                throw zkutil::KeeperException::fromPath(code, claimed_dir / partition_key);
         }
+    });
+
+    if (result_bucket < buckets_num)
+    {
+        std::lock_guard lock(partition_bucket_cache_mutex);
+        partition_bucket_cache[partition_key] = result_bucket;
+        return result_bucket;
     }
 
-    /// If partition is not found, claim next available bucket
-    for (Bucket bucket_id = 0; bucket_id < buckets_num; ++bucket_id)
-    {
-        const auto processed_path = zookeeper_path / "buckets" / toString(bucket_id) / "processed";
-
-        /// Check if this bucket is free (no partitions assigned yet)
-        /// If the processed path doesn't exist, the bucket is definitely free
-        if (!zk->exists(processed_path))
-        {
-            LOG_INFO(log, "Claiming free bucket {} (no processed dir) for new partition '{}'", bucket_id, partition_key);
-
-            std::lock_guard lock(partition_bucket_cache_mutex);
-            partition_bucket_cache[partition_key] = bucket_id;
-            return bucket_id;
-        }
-
-        /// If processed path exists, check if it has any children (partitions)
-        Coordination::Stat stat;
-        auto children = zk->getChildren(processed_path, &stat);
-
-        if (children.empty())
-        {
-            LOG_INFO(log, "Claiming empty bucket {} for new partition '{}'", bucket_id, partition_key);
-
-            std::lock_guard lock(partition_bucket_cache_mutex);
-            partition_bucket_cache[partition_key] = bucket_id;
-            return bucket_id;
-        }
-    }
-
-    /// If all buckets have partitions, use hash as fallback.
     Bucket bucket_id = sipHash64(partition_key) % buckets_num;
-    LOG_INFO(log, "All buckets occupied, using hash fallback for partition '{}' -> bucket {}", partition_key, bucket_id);
+    LOG_WARNING(log, "All buckets occupied, using hash fallback for partition '{}'", partition_key);
 
-    /// update cache before returning
     std::lock_guard lock(partition_bucket_cache_mutex);
     partition_bucket_cache[partition_key] = bucket_id;
     return bucket_id;

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
@@ -279,6 +279,10 @@ ObjectStorageQueueMetadata::Bucket ObjectStorageQueueMetadata::getBucketForPath(
         auto partition_key = ObjectStorageQueueOrderedFileMetadata::getPartitionKey(
             path, partitioning_mode, filename_parser.get());
 
+        // Use full path when regex doesn't match
+        if (partition_key.empty())
+            partition_key = path;
+
         return findOrClaimBucketForPartition(partition_key);
     }
 
@@ -297,66 +301,144 @@ ObjectStorageQueueMetadata::Bucket ObjectStorageQueueMetadata::getBucketForPath(
 
 ObjectStorageQueueMetadata::Bucket ObjectStorageQueueMetadata::findOrClaimBucketForPartition(const std::string & partition_key) const
 {
+    /// Optimal bucket assignment with linear probing
+    ///
+    /// When num_partitions <= num_buckets, assign each partition to a unique bucket
+    /// to avoid hash collisions. This is critical for partition-based bucketing where we want
+    /// perfect distribution when possible.
+    ///
+    /// Algorithm:
+    /// 1. Check local cache first for performance
+    /// 2. Use linear probing starting from hash(partition_key) to find/claim a bucket
+    /// 3. Each bucket has a single `/claimed/owner` node storing the partition_key as data
+    /// 4. Atomic ZooKeeper create guarantees only one partition can claim a bucket
+    /// 5. If all buckets occupied, fall back to hash-based assignment.
+    ///
+    /// Race safety: When ZNODEEXISTS occurs, re-read the owner node to check if the stored
+    /// value matches partition_key (concurrent instance of same table claimed it), avoiding
+    /// unnecessary bucket consumption.
+
+    /// Check cache first to avoid ZooKeeper round trips
     {
         std::lock_guard lock(partition_bucket_cache_mutex);
         if (auto it = partition_bucket_cache.find(partition_key); it != partition_bucket_cache.end())
             return it->second;
     }
 
-    Bucket result_bucket = buckets_num;
+    /// Caller guarantees non-empty (uses full path as fallback when regex doesn't match)
+    chassert(!partition_key.empty());
+
+    Bucket result_bucket = buckets_num; /// Sentinel value meaning "not found"
     auto retry_ctrl = getKeeperRetriesControl(log);
 
-    retry_ctrl.retryLoop([&]
-    {
-        auto zk = getZooKeeper();
+    /// Linear probing starting point. Deterministic but spreads load across buckets
+    const Bucket start_bucket = sipHash64(partition_key) % buckets_num;
+    static constexpr auto OWNER_NODE = "owner";
 
-        for (Bucket bucket_id = 0; bucket_id < buckets_num; ++bucket_id)
+    retry_ctrl.retryLoop(
+        [&]
         {
-            const auto claimed_dir = zookeeper_path / "buckets" / toString(bucket_id) / "claimed";
+            const auto zk = getZooKeeper();
 
-            Strings claimed_children;
-            auto code = zk->tryGetChildren(claimed_dir, claimed_children);
-
-            if (code != Coordination::Error::ZOK && code != Coordination::Error::ZNONODE)
-                throw zkutil::KeeperException::fromPath(code, claimed_dir);
-
-            if (code == Coordination::Error::ZNONODE)
-                claimed_children.clear();
-
-            if (std::find(claimed_children.begin(), claimed_children.end(), partition_key) != claimed_children.end())
+            /// Linear probe buckets in order (start_bucket, start_bucket+1, ..., start_bucket-1)
+            for (size_t probe = 0; probe < buckets_num; ++probe)
             {
-                result_bucket = bucket_id;
-                return;
+                const Bucket bucket_id = (start_bucket + probe) % buckets_num;
+                const auto owner_path = zookeeper_path / "buckets" / toString(bucket_id) / "claimed" / OWNER_NODE;
+
+                /// Step 1: Check if bucket is already claimed
+                std::string owner;
+                auto get_code = Coordination::Error::ZOK;
+                const bool owner_exists = zk->tryGet(owner_path, owner, /*stat*/ nullptr, /*watch*/ nullptr, &get_code);
+
+                if (owner_exists)
+                {
+                    /// Bucket is claimed - check if the owner matches the partition_key
+                    if (owner == partition_key)
+                    {
+                        /// Found the bucket for this partition_key (already claimed by this or another instance)
+                        result_bucket = bucket_id;
+                        return;
+                    }
+                    /// Bucket owned by different partition - try next bucket
+                    continue;
+                }
+
+                /// Node doesn't exist - verify it's ZNONODE (not a ZK error)
+                if (get_code != Coordination::Error::ZNONODE)
+                    throw zkutil::KeeperException::fromPath(get_code, owner_path);
+
+                /// Step 2: Bucket is free - try to claim it atomically
+                Coordination::Error create_code = zk->tryCreate(owner_path, partition_key, zkutil::CreateMode::Persistent);
+
+                if (create_code == Coordination::Error::ZOK)
+                {
+                    /// Successfully claimed the bucket
+                    result_bucket = bucket_id;
+                    return;
+                }
+
+                if (create_code == Coordination::Error::ZNONODE)
+                {
+                    /// Parent directory missing - can happen during upgrades or if metadata
+                    /// initialization was incomplete. Create ancestors and retry.
+                    zk->createAncestors(owner_path);
+
+                    create_code = zk->tryCreate(owner_path, partition_key, zkutil::CreateMode::Persistent);
+                    if (create_code == Coordination::Error::ZOK)
+                    {
+                        result_bucket = bucket_id;
+                        return;
+                    }
+                }
+
+                if (create_code == Coordination::Error::ZNODEEXISTS)
+                {
+                    /// Race condition scenario: likely another process claimed the bucket between tryGet and tryCreate.
+                    /// Re-read to check if it was another instance claiming for the same partition_key.
+                    owner.clear();
+                    get_code = Coordination::Error::ZOK;
+                    const bool exists_after_race = zk->tryGet(owner_path, owner, nullptr, nullptr, &get_code);
+
+                    if (exists_after_race && owner == partition_key)
+                    {
+                        /// The partition_key matches (claimed by concurrent instance) - success!
+                        result_bucket = bucket_id;
+                        return;
+                    }
+
+                    if (get_code != Coordination::Error::ZOK && get_code != Coordination::Error::ZNONODE)
+                        throw zkutil::KeeperException::fromPath(get_code, owner_path);
+
+                    /// Different partition won the race - continue probing
+                    continue;
+                }
+
+                /// Unexpected error - throw to trigger retry loop
+                throw zkutil::KeeperException::fromPath(create_code, owner_path);
             }
+        });
 
-            if (!claimed_children.empty())
-                continue;
-
-            code = zk->tryCreate(claimed_dir / partition_key, "", zkutil::CreateMode::Persistent);
-
-            if (code == Coordination::Error::ZOK)
-            {
-                result_bucket = bucket_id;
-                return;
-            }
-
-            if (code != Coordination::Error::ZNODEEXISTS)
-                throw zkutil::KeeperException::fromPath(code, claimed_dir / partition_key);
-        }
-    });
-
+    /// Determine final bucket assignment
+    Bucket bucket_id;
     if (result_bucket < buckets_num)
     {
-        std::lock_guard lock(partition_bucket_cache_mutex);
-        partition_bucket_cache[partition_key] = result_bucket;
-        return result_bucket;
+        /// Successfully found or claimed a bucket
+        bucket_id = result_bucket;
+    }
+    else
+    {
+        /// All buckets occupied (num_partitions > num_buckets) - fall back to hash
+        bucket_id = sipHash64(partition_key) % buckets_num;
+        LOG_WARNING(log, "All buckets occupied, using hash fallback for partition '{}'", partition_key);
     }
 
-    Bucket bucket_id = sipHash64(partition_key) % buckets_num;
-    LOG_WARNING(log, "All buckets occupied, using hash fallback for partition '{}'", partition_key);
+    /// Cache the result to avoid ZooKeeper round trips on subsequent calls
+    {
+        std::lock_guard lock(partition_bucket_cache_mutex);
+        partition_bucket_cache[partition_key] = bucket_id;
+    }
 
-    std::lock_guard lock(partition_bucket_cache_mutex);
-    partition_bucket_cache[partition_key] = bucket_id;
     return bucket_id;
 }
 

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.h
@@ -237,6 +237,13 @@ private:
 
     FileStatusesCache local_file_statuses;
 
+    /// Cache for partition -> bucket mappings (for optimal distribution in PARTITION mode)
+    mutable std::mutex partition_bucket_cache_mutex;
+    mutable std::unordered_map<std::string, Bucket> partition_bucket_cache;
+
+    /// Find or claim buckets only when using bucketing mode = PARTITION. Scans existing buckets, then claims a free one.
+    Bucket findOrClaimBucketForPartition(const std::string & partition_key) const;
+
     /// A set of currently known "active" servers.
     /// The set is updated by updateRegistryFunc().
     NameSet active_servers;

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.h
@@ -237,11 +237,11 @@ private:
 
     FileStatusesCache local_file_statuses;
 
-    /// Cache for partition -> bucket mappings (for optimal distribution in PARTITION mode)
+    /// Cache for partition -> bucket mappings in PARTITION bucketing mode
     mutable std::mutex partition_bucket_cache_mutex;
     mutable std::unordered_map<std::string, Bucket> partition_bucket_cache;
 
-    /// Find or claim buckets only when using bucketing mode = PARTITION. Scans existing buckets, then claims a free one.
+    /// Scan existing bucket assignments or claim a free bucket for the partition
     Bucket findOrClaimBucketForPartition(const std::string & partition_key) const;
 
     /// A set of currently known "active" servers.

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueOrderedFileMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueOrderedFileMetadata.cpp
@@ -6,6 +6,7 @@
 #include <Common/logger_useful.h>
 #include <Interpreters/Context.h>
 #include <Poco/JSON/Parser.h>
+#include <limits>
 #include <numeric>
 
 #include <boost/algorithm/string/replace.hpp>
@@ -81,6 +82,45 @@ namespace
         return partitioning_mode != ObjectStorageQueuePartitioningMode::NONE;
     }
 
+    /// Consistent hashing implementation to reduce collision probability
+    /// Uses a hash ring with virtual nodes for better distribution
+    ObjectStorageQueueOrderedFileMetadata::Bucket consistentHash(
+        const std::string & key,
+        size_t buckets_num)
+    {
+        /// Number of virtual nodes per bucket for better distribution
+        /// Higher values = better distribution but more computation
+        constexpr size_t VIRTUAL_NODES_PER_BUCKET = 500;
+
+        uint64_t key_hash = sipHash64(key);
+        uint64_t min_distance = std::numeric_limits<uint64_t>::max();
+        size_t selected_bucket = 0;
+
+        /// Find the closest virtual node on the ring
+        for (size_t bucket = 0; bucket < buckets_num; ++bucket)
+        {
+            for (size_t vnode = 0; vnode < VIRTUAL_NODES_PER_BUCKET; ++vnode)
+            {
+                /// Create virtual node identifier: "bucket_id:vnode_id"
+                std::string vnode_id = std::to_string(bucket) + ":" + std::to_string(vnode);
+                uint64_t vnode_hash = sipHash64(vnode_id);
+
+                /// Calculate distance on the ring (with wraparound)
+                uint64_t distance = (vnode_hash >= key_hash)
+                    ? (vnode_hash - key_hash)
+                    : (std::numeric_limits<uint64_t>::max() - key_hash + vnode_hash);
+
+                if (distance < min_distance)
+                {
+                    min_distance = distance;
+                    selected_bucket = bucket;
+                }
+            }
+        }
+
+        return selected_bucket;
+    }
+
     ObjectStorageQueueOrderedFileMetadata::Bucket getBucketForPathImpl(
         const std::string & path,
         size_t buckets_num,
@@ -92,11 +132,11 @@ namespace
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Buckets number cannot be zero");
 
         /// Use partition key for bucketing when bucketing_mode is PARTITION
-        /// This ensures files from the same partition always go to the same bucket
+        /// With consistent hashing to minimize collision probability
         if (bucketing_mode == ObjectStorageQueueBucketingMode::PARTITION)
         {
             auto partition_key = getPartitionKey(path, partitioning_mode, parser);
-            return sipHash64(partition_key) % buckets_num;
+            return consistentHash(partition_key, buckets_num);
         }
 
         /// Default hash the full file path

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueOrderedFileMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueOrderedFileMetadata.cpp
@@ -6,7 +6,6 @@
 #include <Common/logger_useful.h>
 #include <Interpreters/Context.h>
 #include <Poco/JSON/Parser.h>
-#include <limits>
 #include <numeric>
 
 #include <boost/algorithm/string/replace.hpp>
@@ -252,7 +251,7 @@ ObjectStorageQueueOrderedFileMetadata::ObjectStorageQueueOrderedFileMetadata(
         path_,
         zookeeper_name_,
         /* processing_node_path */zk_path_ / "processing" / getNodeName(path_),
-        /* processed_node_path */getProcessedPath(zk_path_, path_, buckets_num_, bucketing_mode_, partitioning_mode_, parser_),
+        /* processed_node_path */bucket_info_ ? getProcessedPathWithBucket(zk_path_, bucket_info_->bucket) : getProcessedPath(zk_path_, path_, buckets_num_, bucketing_mode_, partitioning_mode_, parser_),
         /* failed_node_path */zk_path_ / "failed" / getNodeName(path_),
         file_status_,
         max_loading_retries_,
@@ -282,7 +281,10 @@ std::vector<std::string> ObjectStorageQueueOrderedFileMetadata::getMetadataPaths
     {
         std::vector<std::string> paths{"buckets", "failed", "processing", "persistent_processing"};
         for (size_t i = 0; i < buckets_num; ++i)
+        {
             paths.push_back("buckets/" + toString(i));
+            paths.push_back("buckets/" + toString(i) + "/claimed");  /// For atomic bucket claiming
+        }
         return paths;
     }
     /// We do not return "processed" node here,

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueOrderedFileMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueOrderedFileMetadata.cpp
@@ -82,45 +82,6 @@ namespace
         return partitioning_mode != ObjectStorageQueuePartitioningMode::NONE;
     }
 
-    /// Consistent hashing implementation to reduce collision probability
-    /// Uses a hash ring with virtual nodes for better distribution
-    ObjectStorageQueueOrderedFileMetadata::Bucket consistentHash(
-        const std::string & key,
-        size_t buckets_num)
-    {
-        /// Number of virtual nodes per bucket for better distribution
-        /// Higher values = better distribution but more computation
-        constexpr size_t VIRTUAL_NODES_PER_BUCKET = 500;
-
-        uint64_t key_hash = sipHash64(key);
-        uint64_t min_distance = std::numeric_limits<uint64_t>::max();
-        size_t selected_bucket = 0;
-
-        /// Find the closest virtual node on the ring
-        for (size_t bucket = 0; bucket < buckets_num; ++bucket)
-        {
-            for (size_t vnode = 0; vnode < VIRTUAL_NODES_PER_BUCKET; ++vnode)
-            {
-                /// Create virtual node identifier: "bucket_id:vnode_id"
-                std::string vnode_id = std::to_string(bucket) + ":" + std::to_string(vnode);
-                uint64_t vnode_hash = sipHash64(vnode_id);
-
-                /// Calculate distance on the ring (with wraparound)
-                uint64_t distance = (vnode_hash >= key_hash)
-                    ? (vnode_hash - key_hash)
-                    : (std::numeric_limits<uint64_t>::max() - key_hash + vnode_hash);
-
-                if (distance < min_distance)
-                {
-                    min_distance = distance;
-                    selected_bucket = bucket;
-                }
-            }
-        }
-
-        return selected_bucket;
-    }
-
     ObjectStorageQueueOrderedFileMetadata::Bucket getBucketForPathImpl(
         const std::string & path,
         size_t buckets_num,
@@ -132,11 +93,12 @@ namespace
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Buckets number cannot be zero");
 
         /// Use partition key for bucketing when bucketing_mode is PARTITION
-        /// With consistent hashing to minimize collision probability
+        /// Note: The hybrid optimal assignment is handled in ObjectStorageQueueMetadata::getBucketForPath()
+        /// This is only used as a fallback for static calls
         if (bucketing_mode == ObjectStorageQueueBucketingMode::PARTITION)
         {
             auto partition_key = getPartitionKey(path, partitioning_mode, parser);
-            return consistentHash(partition_key, buckets_num);
+            return sipHash64(partition_key) % buckets_num;
         }
 
         /// Default hash the full file path
@@ -506,6 +468,14 @@ ObjectStorageQueueOrderedFileMetadata::getBucketForPath(
     const ObjectStorageQueueFilenameParser * parser)
 {
     return getBucketForPathImpl(path_, buckets_num, bucketing_mode, partitioning_mode, parser);
+}
+
+std::string ObjectStorageQueueOrderedFileMetadata::getPartitionKey(
+    const std::string & file_path,
+    ObjectStorageQueuePartitioningMode partitioning_mode,
+    const ObjectStorageQueueFilenameParser * parser)
+{
+    return DB::getPartitionKey(file_path, partitioning_mode, parser);
 }
 
 ObjectStorageQueueOrderedFileMetadata::BucketHolderPtr ObjectStorageQueueOrderedFileMetadata::tryAcquireBucket(

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueOrderedFileMetadata.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueOrderedFileMetadata.h
@@ -62,6 +62,11 @@ public:
         ObjectStorageQueuePartitioningMode partitioning_mode,
         const ObjectStorageQueueFilenameParser * parser);
 
+    static std::string getPartitionKey(
+        const std::string & file_path,
+        ObjectStorageQueuePartitioningMode partitioning_mode,
+        const ObjectStorageQueueFilenameParser * parser);
+
     static std::vector<std::string> getMetadataPaths(size_t buckets_num);
 
     static void migrateToBuckets(

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.cpp
@@ -571,12 +571,7 @@ void ObjectStorageQueueSource::FileIterator::returnForRetry(ObjectInfoPtr object
 
     if (use_buckets_for_processing)
     {
-        const auto bucket = ObjectStorageQueueMetadata::getBucketForPath(
-            object_info->getPath(),
-            buckets_num,
-            metadata->getBucketingMode(),
-            metadata->getPartitioningMode(),
-            metadata->getFilenameParser());
+        const auto bucket = metadata->getBucketForPath(object_info->getPath());
         std::lock_guard lock(mutex);
         keys_cache_per_bucket.at(bucket)->keys.emplace_front(object_info, file_metadata);
     }
@@ -837,12 +832,7 @@ ObjectStorageQueueSource::FileIterator::getNextKeyFromAcquiredBucket(size_t proc
 
             chassert(!file_metadata);
 
-            const auto bucket = ObjectStorageQueueMetadata::getBucketForPath(
-                object_info->getPath(),
-                buckets_num,
-                metadata->getBucketingMode(),
-                metadata->getPartitioningMode(),
-                metadata->getFilenameParser());
+            const auto bucket = metadata->getBucketForPath(object_info->getPath());
             auto bucket_it = keys_cache_per_bucket.find(bucket);
             if (bucket_it == keys_cache_per_bucket.end())
             {

--- a/tests/integration/test_storage_s3_queue/test_6.py
+++ b/tests/integration/test_storage_s3_queue/test_6.py
@@ -843,7 +843,7 @@ def test_optimal_bucket_assignment_with_regex_partitioning(started_cluster, engi
     num_buckets = 16
     processing_threads_num = num_buckets
 
-    # Each of these hostnames will get a unique bucket via hybrid assignment which are selected in a way that
+    # Each of these hostnames will get a unique bucket via optimal assignment which are selected in a way that
     # they will collide if we used hash-based assignment.
     hostnames = [
         'c-cluster-01-server-xscp10r-0',
@@ -950,4 +950,4 @@ def test_optimal_bucket_assignment_with_regex_partitioning(started_cluster, engi
     assert len(buckets_with_data) == len(hostnames), \
         f"Expected {len(hostnames)} unique buckets (one per hostname with optimal distribution), " \
         f"but got {len(buckets_with_data)} buckets: {buckets_with_data}. " \
-        f"This indicates the hybrid bucket assignment is not working correctly."
+        f"This indicates the optimal bucket assignment is not working correctly."

--- a/tests/integration/test_storage_s3_queue/test_6.py
+++ b/tests/integration/test_storage_s3_queue/test_6.py
@@ -833,10 +833,8 @@ def test_optimal_bucket_assignment_with_regex_partitioning(started_cluster, engi
     files_path = f"{table_name}_data"
     keeper_path = f"/clickhouse/test_{table_name}_{generate_random_string()}"
 
-    # Use production-like hostnames
     # Filename pattern: hostname_timestamp_sequence.csv
     # Example: c-cluster-01-server-xscp10r-0_20251217T100000.000000Z_0001.csv
-    # Extract hostname: everything before first underscore
     partition_regex = r'(?P<hostname>[^_]+)_(?P<timestamp>\d{8}T\d{6}\.\d{6}Z)_(?P<sequence>\d+)'
     partition_component = 'hostname'
 

--- a/tests/integration/test_storage_s3_queue/test_6.py
+++ b/tests/integration/test_storage_s3_queue/test_6.py
@@ -807,3 +807,146 @@ def test_bucketing_mode_with_regex_partitioning(started_cluster, engine_name, bu
         # With 3 partitions and 4 buckets, we should use EXACTLY 3 buckets (one per partition)
         assert len(buckets_used) == num_hostnames, \
             f"Expected EXACTLY {num_hostnames} buckets to be used (one per partition), but {len(buckets_used)} were used: {buckets_used}"
+
+
+@pytest.mark.parametrize("engine_name", ["S3Queue"])
+def test_collision_in_bucketing_mode_with_regex_partitioning(started_cluster, engine_name):
+    """
+    Test that consistent hashing reduces collision probability compared to simple modulo.
+
+    This test uses production-like hostnames that had collisions with simple modulo hashing:
+    - c-cluster-01-server-xscp10r-0  → bucket 0 (old approach)
+    - c-cluster-01-server-u1s3cbc-0  → bucket 0 (old approach) (COLLISION)
+    - c-cluster-01-server-f00dva3-0  → bucket 13 (old approach)
+
+    Old approach: Simple modulo of siphash64(hostname).
+    New approach: Consistent hashing with 500 virtual nodes per bucket.
+    Collision probability is significantly reduced, and each hostname should get its own bucket.
+    """
+    instance = started_cluster.instances["instance"]
+
+    table_name = f"test_consistent_hashing_{engine_name}_{generate_random_string()}"
+    dst_table_name = f"{table_name}_dst"
+    files_path = f"{table_name}_data"
+    keeper_path = f"/clickhouse/test_{table_name}_{generate_random_string()}"
+
+    # Use production-like hostnames that would collide with simple siphash64 of hostname.
+    # Filename pattern: hostname_timestamp_sequence.csv
+    # Example: c-cluster-01-server-xscp10r-0_20251217T100000.000000Z_0001.csv
+    # Extract hostname: everything before first underscore
+    partition_regex = r'(?P<hostname>[^_]+)_(?P<timestamp>\d{8}T\d{6}\.\d{6}Z)_(?P<sequence>\d+)'
+    partition_component = 'hostname'
+
+    num_buckets = 16
+    processing_threads_num = num_buckets
+
+    # Production-like hostnames with random suffixes that collide with simple modulo % 16
+    # These specific hostnames both hash to bucket 0 with simple modulo
+    hostnames = [
+        'c-cluster-01-server-xscp10r-0',  # Old: bucket 0
+        'c-cluster-01-server-u1s3cbc-0',  # Old: bucket 0 (COLLISION!)
+        'c-cluster-01-server-f00dva3-0',  # Old: bucket 13
+    ]
+
+    # Create files for each hostname
+    expected_data = []
+    for idx, hostname in enumerate(hostnames):
+        for seq in range(1, 4):  # 3 files per hostname
+            value = (idx + 1) * 100 + seq
+            filename = f"{files_path}/{hostname}_{20251217}T100000.000000Z_{seq:04d}.csv"
+            content = f"{value},{idx + 1},{seq}\n".encode()
+            put_file_content(started_cluster, engine_name, filename, content)
+            expected_data.append(f"{value},{idx + 1},{seq}")
+
+    # Create table with bucketing_mode='partition'
+    create_table(
+        started_cluster,
+        instance,
+        table_name,
+        "ordered",
+        files_path,
+        additional_settings={
+            "s3queue_loading_retries": 3,
+            "keeper_path": keeper_path,
+            "polling_max_timeout_ms": 5000,
+            "polling_backoff_ms": 1000,
+            "processing_threads_num": processing_threads_num,
+            "buckets": num_buckets,
+            "bucketing_mode": "partition",  # Uses consistent hashing
+        },
+        engine_name=engine_name,
+        partitioning_mode="regex",
+        partition_regex=partition_regex,
+        partition_component=partition_component,
+    )
+    create_mv(instance, table_name, dst_table_name)
+
+    # Wait for table to be created
+    for _ in range(10):
+        try:
+            instance.query(f"EXISTS TABLE {table_name}_mv")
+            break
+        except:
+            time.sleep(0.5)
+
+    # Wait for all files to be processed
+    expected_count = len(hostnames) * 3  # 3 files per hostname
+    for i in range(30):
+        count = int(instance.query(f"SELECT count() FROM {dst_table_name}"))
+        print(f"Progress: {count}/{expected_count}")
+        if count >= expected_count:
+            break
+        time.sleep(1)
+
+    # Verify all files were processed
+    total_count = int(instance.query(f"SELECT count() FROM {dst_table_name}"))
+    assert total_count == expected_count, f"Expected {expected_count} rows, got {total_count}"
+
+    # Verify data correctness
+    data = instance.query(f"SELECT column1, column2, column3 FROM {dst_table_name} ORDER BY column1 FORMAT CSV")
+    data_lines = data.strip().split("\n")
+    data_lines.sort()
+    expected_data.sort()
+    assert data_lines == expected_data, f"Data mismatch"
+
+    # Check bucket distribution in ZooKeeper
+    zk = started_cluster.get_kazoo_client("zoo1")
+
+    # Collect which bucket each hostname was assigned to
+    hostname_to_buckets = {}
+    buckets_with_data = set()
+
+    for bucket_id in range(num_buckets):
+        bucket_path = f"{keeper_path}/buckets/{bucket_id}/processed"
+        if not zk.exists(bucket_path):
+            continue
+
+        buckets_with_data.add(bucket_id)
+        partition_keys = zk.get_children(bucket_path)
+        for partition_key in partition_keys:
+            # partition_key is the extracted hostname (without -0 suffix and timestamp)
+            if partition_key not in hostname_to_buckets:
+                hostname_to_buckets[partition_key] = []
+            hostname_to_buckets[partition_key].append(bucket_id)
+
+    print(f"\nConsistent hashing bucket assignment:")
+    for hostname, bucket_ids in sorted(hostname_to_buckets.items()):
+        print(f"  {hostname} → bucket(s) {bucket_ids}")
+
+    # Verify all hostnames are present as partition keys
+    assert len(hostname_to_buckets) == len(hostnames), \
+        f"Expected {len(hostnames)} partitions, got {len(hostname_to_buckets)}: {list(hostname_to_buckets.keys())}"
+
+    # With consistent hashing, each hostname should map to EXACTLY ONE bucket
+    # (no collisions within the same partition key)
+    for hostname, bucket_ids in hostname_to_buckets.items():
+        assert len(bucket_ids) == 1, \
+            f"Hostname '{hostname}' found in multiple buckets {bucket_ids}. " \
+            f"This should not happen - each partition should map to exactly one bucket."
+
+    # With 3 hostnames and 16 buckets using consistent hashing,
+    # collision probability is very low (~1%), so we expect 3 unique buckets
+    assert len(buckets_with_data) == len(hostnames), \
+        f"Expected {len(hostnames)} unique buckets (one per hostname with consistent hashing), " \
+        f"but got {len(buckets_with_data)} buckets: {buckets_with_data}. " \
+        f"This suggests a collision occurred, which is unexpected with consistent hashing."

--- a/tests/integration/test_storage_s3_queue/test_6.py
+++ b/tests/integration/test_storage_s3_queue/test_6.py
@@ -810,27 +810,30 @@ def test_bucketing_mode_with_regex_partitioning(started_cluster, engine_name, bu
 
 
 @pytest.mark.parametrize("engine_name", ["S3Queue"])
-def test_collision_in_bucketing_mode_with_regex_partitioning(started_cluster, engine_name):
+def test_optimal_bucket_assignment_with_regex_partitioning(started_cluster, engine_name):
     """
-    Test that consistent hashing reduces collision probability compared to simple modulo.
+    Test that optimal bucket assignment achieves optimal distribution for partitions.
 
-    This test uses production-like hostnames that had collisions with simple modulo hashing:
-    - c-cluster-01-server-xscp10r-0  → bucket 0 (old approach)
-    - c-cluster-01-server-u1s3cbc-0  → bucket 0 (old approach) (COLLISION)
-    - c-cluster-01-server-f00dva3-0  → bucket 13 (old approach)
+    With bucketing_mode='partition', the algorithm:
+    1. Scans existing buckets to find where partition is already assigned
+    2. For NEW partitions: claims next available free bucket
+    3. Fallback to hash when all buckets occupied
 
-    Old approach: Simple modulo of siphash64(hostname).
-    New approach: Consistent hashing with 500 virtual nodes per bucket.
-    Collision probability is significantly reduced, and each hostname should get its own bucket.
+    This ensures:
+    - Each partition always maps to exactly ONE bucket
+    - When num_partitions <= num_buckets: each partition gets its own bucket
+    - When num_partitions > num_buckets: gracefully degrades to hash distribution
+
+    This test verifies: 3 hostnames + 16 buckets → 3 buckets used (one per hostname).
     """
     instance = started_cluster.instances["instance"]
 
-    table_name = f"test_consistent_hashing_{engine_name}_{generate_random_string()}"
+    table_name = f"test_optimal_partition_distribution_{engine_name}_{generate_random_string()}"
     dst_table_name = f"{table_name}_dst"
     files_path = f"{table_name}_data"
     keeper_path = f"/clickhouse/test_{table_name}_{generate_random_string()}"
 
-    # Use production-like hostnames that would collide with simple siphash64 of hostname.
+    # Use production-like hostnames
     # Filename pattern: hostname_timestamp_sequence.csv
     # Example: c-cluster-01-server-xscp10r-0_20251217T100000.000000Z_0001.csv
     # Extract hostname: everything before first underscore
@@ -840,12 +843,12 @@ def test_collision_in_bucketing_mode_with_regex_partitioning(started_cluster, en
     num_buckets = 16
     processing_threads_num = num_buckets
 
-    # Production-like hostnames with random suffixes that collide with simple modulo % 16
-    # These specific hostnames both hash to bucket 0 with simple modulo
+    # Each of these hostnames will get a unique bucket via hybrid assignment which are selected in a way that
+    # they will collide if we used hash-based assignment.
     hostnames = [
-        'c-cluster-01-server-xscp10r-0',  # Old: bucket 0
-        'c-cluster-01-server-u1s3cbc-0',  # Old: bucket 0 (COLLISION!)
-        'c-cluster-01-server-f00dva3-0',  # Old: bucket 13
+        'c-cluster-01-server-xscp10r-0',
+        'c-cluster-01-server-u1s3cbc-0',
+        'c-cluster-01-server-f00dva3-0',
     ]
 
     # Create files for each hostname
@@ -872,7 +875,7 @@ def test_collision_in_bucketing_mode_with_regex_partitioning(started_cluster, en
             "polling_backoff_ms": 1000,
             "processing_threads_num": processing_threads_num,
             "buckets": num_buckets,
-            "bucketing_mode": "partition",  # Uses consistent hashing
+            "bucketing_mode": "partition",
         },
         engine_name=engine_name,
         partitioning_mode="regex",
@@ -929,7 +932,7 @@ def test_collision_in_bucketing_mode_with_regex_partitioning(started_cluster, en
                 hostname_to_buckets[partition_key] = []
             hostname_to_buckets[partition_key].append(bucket_id)
 
-    print(f"\nConsistent hashing bucket assignment:")
+    print(f"\nHybrid bucket assignment:")
     for hostname, bucket_ids in sorted(hostname_to_buckets.items()):
         print(f"  {hostname} → bucket(s) {bucket_ids}")
 
@@ -937,16 +940,14 @@ def test_collision_in_bucketing_mode_with_regex_partitioning(started_cluster, en
     assert len(hostname_to_buckets) == len(hostnames), \
         f"Expected {len(hostnames)} partitions, got {len(hostname_to_buckets)}: {list(hostname_to_buckets.keys())}"
 
-    # With consistent hashing, each hostname should map to EXACTLY ONE bucket
-    # (no collisions within the same partition key)
+    # Each partition MUST map to EXACTLY ONE bucket (consistency guarantee)
     for hostname, bucket_ids in hostname_to_buckets.items():
         assert len(bucket_ids) == 1, \
             f"Hostname '{hostname}' found in multiple buckets {bucket_ids}. " \
             f"This should not happen - each partition should map to exactly one bucket."
 
-    # With 3 hostnames and 16 buckets using consistent hashing,
-    # collision probability is very low (~1%), so we expect 3 unique buckets
+    # With 3 partitions and 16 buckets, expect optimal distribution: 3 unique buckets
     assert len(buckets_with_data) == len(hostnames), \
-        f"Expected {len(hostnames)} unique buckets (one per hostname with consistent hashing), " \
+        f"Expected {len(hostnames)} unique buckets (one per hostname with optimal distribution), " \
         f"but got {len(buckets_with_data)} buckets: {buckets_with_data}. " \
-        f"This suggests a collision occurred, which is unexpected with consistent hashing."
+        f"This indicates the hybrid bucket assignment is not working correctly."


### PR DESCRIPTION
While using `S3Queue` with `bucketing_mode='partition'` and regex-based partitioning,  scan for existing bucket assignments and assign empty buckets first. The current approach of a simple modulo and `sipHash64` of `partition_component` in practice has a good probability of multiple partition_keys colliding into the same bucket. With the new approach as long as partition_keys <= num buckets, a new bucket is assigned for each partition_key, and then fallback to using the hashing approach when partition_keys >= num buckets.
 
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Better bucket assignment for partition based bucketing in S3Queue ordered mode.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
