### PR TITLE
Improve logging of failed query/global profiler initialization

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -106,6 +106,7 @@ add_headers_and_sources(clickhouse_common_io IO/S3)
 add_headers_and_sources(clickhouse_common_io IO/AzureBlobStorage)
 add_headers_and_sources(clickhouse_common_io Disks/DiskObjectStorage/ObjectStorages/AzureBlobStorage)
 list (REMOVE_ITEM clickhouse_common_io_sources Common/malloc.cpp Common/AllocationInterceptors.cpp)
+list (REMOVE_ITEM clickhouse_common_io_sources Common/ExceptionExt.cpp)
 
 
 add_headers_and_sources(clickhouse_compression Compression)
@@ -265,7 +266,10 @@ if (TARGET ch_contrib::ssh)
     add_object_library(clickhouse_access_ssh Access/SSH)
 endif()
 add_object_library(clickhouse_backups Backups)
+
 add_object_library(clickhouse_core Core)
+list (APPEND dbms_sources Common/ExceptionExt.cpp)
+
 add_object_library(clickhouse_core_mysql Core/MySQL)
 add_object_library(clickhouse_querypipeline QueryPipeline)
 add_object_library(clickhouse_datatypes DataTypes)

--- a/src/Common/Exception.h
+++ b/src/Common/Exception.h
@@ -24,6 +24,7 @@ using LoggerPtr = std::shared_ptr<Logger>;
 
 using LoggerPtr = std::shared_ptr<Poco::Logger>;
 using LoggerRawPtr = Poco::Logger *;
+class LogFrequencyLimiterImpl;
 
 namespace DB
 {
@@ -348,6 +349,7 @@ void tryLogCurrentException(const char * log_name, const std::string & start_of_
 void tryLogCurrentException(Poco::Logger * logger, const std::string & start_of_message = "", LogsLevel level = LogsLevel::error);
 void tryLogCurrentException(LoggerPtr logger, const std::string & start_of_message = "", LogsLevel level = LogsLevel::error);
 void tryLogCurrentException(const AtomicLogger & logger, const std::string & start_of_message = "", LogsLevel level = LogsLevel::error);
+void tryLogCurrentException(LogFrequencyLimiterImpl && logger, const std::string & start_of_message = "", LogsLevel level = LogsLevel::error);
 
 
 /** Prints current exception in canonical format.

--- a/src/Common/ExceptionExt.cpp
+++ b/src/Common/ExceptionExt.cpp
@@ -1,0 +1,17 @@
+#include <Core/LogsLevel.h>
+#include <Common/Exception.h>
+#include <Common/ExceptionExt.h>
+#include <Common/LockMemoryExceptionInThread.h>
+
+namespace DB
+{
+
+void tryLogCurrentException(LogFrequencyLimiterImpl && logger, const std::string & start_of_message, LogsLevel level)
+{
+    /// Explicitly block MEMORY_LIMIT_EXCEEDED
+    LockMemoryExceptionInThread lock_memory_tracker(VariableContext::Global);
+
+    tryLogCurrentExceptionImpl(std::move(logger), start_of_message, level);
+}
+
+}

--- a/src/Common/ExceptionExt.h
+++ b/src/Common/ExceptionExt.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <Common/Exception.h>
+#include <Common/logger_useful.h>
+
+namespace DB
+{
+
+template <class Logger>
+void tryLogCurrentExceptionImpl(Logger logger, const std::string & start_of_message, LogsLevel level)
+{
+    try
+    {
+        PreformattedMessage message = getCurrentExceptionMessageAndPattern(true);
+        if (start_of_message.empty())
+        {
+            switch (level)
+            {
+                case LogsLevel::none: break;
+                case LogsLevel::test: LOG_TEST(std::move(logger), message); break;
+                case LogsLevel::trace: LOG_TRACE(std::move(logger), message); break;
+                case LogsLevel::debug: LOG_DEBUG(std::move(logger), message); break;
+                case LogsLevel::information: LOG_INFO(std::move(logger), message); break;
+                case LogsLevel::warning: LOG_WARNING(std::move(logger), message); break;
+                case LogsLevel::error: LOG_ERROR(std::move(logger), message); break;
+                case LogsLevel::fatal: LOG_FATAL(std::move(logger), message); break;
+            }
+        }
+        else
+        {
+            switch (level)
+            {
+                case LogsLevel::none: break;
+                case LogsLevel::test: LOG_TEST(std::move(logger), "{}: {}", start_of_message, message.text); break;
+                case LogsLevel::trace: LOG_TRACE(std::move(logger), "{}: {}", start_of_message, message.text); break;
+                case LogsLevel::debug: LOG_DEBUG(std::move(logger), "{}: {}", start_of_message, message.text); break;
+                case LogsLevel::information: LOG_INFO(std::move(logger), "{}: {}", start_of_message, message.text); break;
+                case LogsLevel::warning: LOG_WARNING(std::move(logger), "{}: {}", start_of_message, message.text); break;
+                case LogsLevel::error: LOG_ERROR(std::move(logger), "{}: {}", start_of_message, message.text); break;
+                case LogsLevel::fatal: LOG_FATAL(std::move(logger), "{}: {}", start_of_message, message.text); break;
+            }
+        }
+    }
+    catch (...) // NOLINT(bugprone-empty-catch)
+    {
+    }
+
+    /// Mark the exception as logged.
+    try
+    {
+        throw;
+    }
+    catch (Exception & e)
+    {
+        e.markAsLogged();
+    }
+    catch (...) // NOLINT(bugprone-empty-catch)
+    {
+    }
+}
+
+}

--- a/src/Interpreters/ThreadStatusExt.cpp
+++ b/src/Interpreters/ThreadStatusExt.cpp
@@ -646,7 +646,8 @@ void ThreadStatus::initGlobalProfiler([[maybe_unused]] UInt64 global_profiler_re
     }
     catch (...)
     {
-        tryLogCurrentException("ThreadStatus", "Cannot initialize GlobalProfiler");
+        /// GlobalProfiler is optional.
+        tryLogCurrentException(LogFrequencyLimiter(log, 10), "Cannot initialize GlobalProfiler. This usually happens when RLIMIT_SIGPENDING is too low. You may tune it via pending_signals in config.");
     }
 #endif
 }
@@ -687,7 +688,7 @@ void ThreadStatus::initQueryProfiler()
     catch (...)
     {
         /// QueryProfiler is optional.
-        tryLogCurrentException("ThreadStatus", "Cannot initialize QueryProfiler");
+        tryLogCurrentException(LogFrequencyLimiter(log, 10), "Cannot initialize QueryProfiler. This usually happens when RLIMIT_SIGPENDING is too low. You may tune it via pending_signals in config.");
     }
 }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Improve logging of failed query/global profiler initialization
- Add rate limiting
- And add a hint about RLIMIT_SIGPENDING/pending_signals in the message


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.851`
<!-- ch-version-info:end -->