### PR TITLE
Forbid columns in PREWHERE conditions that are not specified in the Parquet schema.

### DIFF
--- a/src/Processors/Formats/Impl/Parquet/Reader.cpp
+++ b/src/Processors/Formats/Impl/Parquet/Reader.cpp
@@ -310,7 +310,7 @@ void Reader::prefilterAndInitRowGroups(const std::optional<std::unordered_set<UI
         extended_sample_block.insert(col);
     extended_sample_block_data_types = extended_sample_block.getDataTypes();
     const auto & row_level_filter = format_filter_info->row_level_filter;
-    const auto & prewhere_info = format_filter_info->prewhere_info;    
+    const auto & prewhere_info = format_filter_info->prewhere_info;
 
     /// Process schema.
     SchemaConverter schemer(file_metadata, options, &extended_sample_block);

--- a/src/Processors/Formats/Impl/Parquet/Reader.cpp
+++ b/src/Processors/Formats/Impl/Parquet/Reader.cpp
@@ -5,6 +5,7 @@
 #include <Columns/ColumnString.h>
 #include <Columns/ColumnTuple.h>
 #include <Columns/FilterDescription.h>
+#include <Common/Exception.h>
 #include <Common/FieldAccurateComparison.h>
 #include <Formats/FormatFilterInfo.h>
 #include <Interpreters/castColumn.h>
@@ -27,6 +28,7 @@
 
 namespace DB::ErrorCodes
 {
+    extern const int BAD_ARGUMENTS;
     extern const int CANNOT_DECOMPRESS;
     extern const int CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN;
     extern const int FEATURE_IS_NOT_ENABLED_AT_BUILD_TIME;
@@ -308,7 +310,7 @@ void Reader::prefilterAndInitRowGroups(const std::optional<std::unordered_set<UI
         extended_sample_block.insert(col);
     extended_sample_block_data_types = extended_sample_block.getDataTypes();
     const auto & row_level_filter = format_filter_info->row_level_filter;
-    const auto & prewhere_info = format_filter_info->prewhere_info;
+    const auto & prewhere_info = format_filter_info->prewhere_info;    
 
     /// Process schema.
     SchemaConverter schemer(file_metadata, options, &extended_sample_block);
@@ -343,6 +345,15 @@ void Reader::prefilterAndInitRowGroups(const std::optional<std::unordered_set<UI
 
     if (format_filter_info->key_condition)
     {
+        std::unordered_set<String> columns_parquet;
+        for (const auto & column : file_metadata.schema)
+            columns_parquet.insert(column.name);
+
+        for (const auto & column : format_filter_info->key_condition->getKeyColumns())
+        {
+            if (!columns_parquet.contains(column.first))
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Key condition uses column {} which is not specified in parquet schema", column.first);
+        }
         for (size_t idx_in_output_block : format_filter_info->key_condition->getUsedColumns())
         {
             const auto & output_idx = sample_block_to_output_columns_idx.at(idx_in_output_block);

--- a/tests/queries/0_stateless/03915_parquet_prewhere_columns_check.sql
+++ b/tests/queries/0_stateless/03915_parquet_prewhere_columns_check.sql
@@ -7,4 +7,4 @@ set engine_file_truncate_on_insert = 1;
 insert into function file(currentDatabase() || '_03915.parquet')
     SELECT 1;
 
-SELECT * FROM file('a.parquet', Parquet, 'c0 Int') PREWHERE c0 = 1; -- { serverError BAD_ARGUMENTS }
+SELECT * FROM file(currentDatabase() || '_03915.parquet', Parquet, 'c0 Int') PREWHERE c0 = 1; -- { serverError BAD_ARGUMENTS }

--- a/tests/queries/0_stateless/03915_parquet_prewhere_columns_check.sql
+++ b/tests/queries/0_stateless/03915_parquet_prewhere_columns_check.sql
@@ -1,0 +1,10 @@
+-- Tags: no-fasttest
+
+set input_format_parquet_use_native_reader_v3 = 1;
+set engine_file_truncate_on_insert = 1;
+
+-- Create a Parquet file with a UInt8 column containing values > 1 (and some zeros).
+insert into function file(currentDatabase() || '_03915.parquet')
+    SELECT 1;
+
+SELECT * FROM file('a.parquet', Parquet, 'c0 Int') PREWHERE c0 = 1; -- { serverError BAD_ARGUMENTS }


### PR DESCRIPTION
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Forbid columns in PREWHERE conditions that are not specified in the Parquet schema. This closes https://github.com/ClickHouse/ClickHouse/issues/96912

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)
