### PR TITLE
Disallow UUID columns in primary keys

### DIFF
--- a/docs/en/sql-reference/data-types/uuid.md
+++ b/docs/en/sql-reference/data-types/uuid.md
@@ -83,6 +83,16 @@ Result:
 └──────────────────────────────────────┘
 ```
 
+:::warning UUID In MergeTree Key Expressions
+In MergeTree-family tables, `UUID` is disallowed by default in key expressions (`PRIMARY KEY`, `ORDER BY`, `PARTITION BY`).
+
+This is controlled by the MergeTree setting [`allow_uuid_key`](/operations/settings/merge-tree-settings/#allow_uuid_key), which is `0` by default.
+
+The restriction exists because `UUID` values are ordered by their second half, which can reduce sparse primary-index selectivity and query pruning efficiency.
+
+Prefer using a key expression such as `toUInt128(uuid)` if you need intuitive UUID ordering.
+:::
+
 ## Generating UUIDs {#generating-uuids}
 
 ClickHouse provides the [generateUUIDv4](../../sql-reference/functions/uuid-functions.md) function to generate random UUID version 4 values.

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -205,6 +205,7 @@ namespace MergeTreeSetting
 {
     extern const MergeTreeSettingsBool allow_experimental_reverse_key;
     extern const MergeTreeSettingsBool allow_nullable_key;
+    extern const MergeTreeSettingsBool allow_uuid_key;
     extern const MergeTreeSettingsBool allow_remote_fs_zero_copy_replication;
     extern const MergeTreeSettingsBool allow_suspicious_indices;
     extern const MergeTreeSettingsBool allow_summing_columns_in_partition_or_order_key;
@@ -656,6 +657,7 @@ MergeTreeData::MergeTreeData(
     bool sanity_checks = mode <= LoadingStrictnessLevel::CREATE;
 
     allow_nullable_key = !sanity_checks || (*settings)[MergeTreeSetting::allow_nullable_key];
+    allow_uuid_key = !sanity_checks || (*settings)[MergeTreeSetting::allow_uuid_key];
     allow_reverse_key = !sanity_checks || (*settings)[MergeTreeSetting::allow_experimental_reverse_key];
 
     /// Check sanity of MergeTreeSettings. Only when table is created.
@@ -860,7 +862,7 @@ bool MergeTreeData::supportsFinal() const
         || merging_params.mode == MergingParams::VersionedCollapsing;
 }
 
-static void checkKeyExpression(const ExpressionActions & expr, const Block & sample_block, const String & key_name, bool allow_nullable_key)
+static void checkKeyExpression(const ExpressionActions & expr, const Block & sample_block, const String & key_name, bool allow_nullable_key, bool allow_uuid_key)
 {
     if (expr.hasArrayJoin())
         throw Exception(ErrorCodes::ILLEGAL_COLUMN, "{} key cannot contain array joins", key_name);
@@ -886,6 +888,12 @@ static void checkKeyExpression(const ExpressionActions & expr, const Block & sam
                             ErrorCodes::ILLEGAL_COLUMN,
                             "{} key contains nullable columns, "
                             "but merge tree setting `allow_nullable_key` is disabled", key_name);
+
+        if (!allow_uuid_key && isUUID(element.type))
+            throw Exception(
+                            ErrorCodes::ILLEGAL_COLUMN,
+                            "{} key contains uuid columns, "
+                            "but merge tree setting `allow_uuid_key` is disabled", key_name);
     }
 }
 
@@ -896,6 +904,7 @@ void MergeTreeData::checkProperties(
     bool allow_empty_sorting_key,
     bool allow_reverse_sorting_key,
     bool allow_nullable_key_,
+    bool allow_uuid_key_,
     ContextPtr local_context) const
 {
     if (!new_metadata.sorting_key.definition_ast && !allow_empty_sorting_key)
@@ -1075,6 +1084,7 @@ void MergeTreeData::checkProperties(
                 is_aggregate,
                 allow_reverse_key,
                 true /* allow_nullable_key */,
+                false /* allow_uuid_key */,
                 local_context);
 
             if (projection.index_granularity || projection.index_granularity_bytes)
@@ -1134,7 +1144,7 @@ void MergeTreeData::checkProperties(
             MergeTreeStatisticsFactory::instance().validate(col.statistics, col.type);
     }
 
-    checkKeyExpression(*new_sorting_key.expression, new_sorting_key.sample_block, "Sorting", allow_nullable_key_);
+    checkKeyExpression(*new_sorting_key.expression, new_sorting_key.sample_block, "Sorting", allow_nullable_key_, allow_uuid_key_);
 }
 
 void MergeTreeData::setProperties(
@@ -1150,6 +1160,7 @@ void MergeTreeData::setProperties(
         false,
         allow_reverse_key,
         allow_nullable_key,
+        allow_uuid_key,
         local_context);
 
     setInMemoryMetadata(new_metadata);
@@ -1222,7 +1233,7 @@ void MergeTreeData::checkPartitionKeyAndInitMinMax(const KeyDescription & new_pa
     if (new_partition_key.expression_list_ast->children.empty())
         return;
 
-    checkKeyExpression(*new_partition_key.expression, new_partition_key.sample_block, "Partition", allow_nullable_key);
+    checkKeyExpression(*new_partition_key.expression, new_partition_key.sample_block, "Partition", allow_nullable_key, allow_uuid_key);
 
     /// Add all columns used in the partition key to the min-max index.
     DataTypes minmax_idx_columns_types = getMinMaxColumnsTypes(new_partition_key);
@@ -4537,7 +4548,7 @@ void MergeTreeData::checkAlterIsPossible(const AlterCommands & commands, Context
     }
 
     checkColumnFilenamesForCollision(new_metadata, /*throw_on_error=*/ true);
-    checkProperties(new_metadata, old_metadata, false, false, allow_reverse_key, allow_nullable_key, local_context);
+    checkProperties(new_metadata, old_metadata, false, false, allow_reverse_key, allow_nullable_key, allow_uuid_key, local_context);
     checkTTLExpressions(new_metadata, old_metadata);
 
     if (!columns_to_check_conversion.empty())

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -1594,6 +1594,7 @@ protected:
         bool allow_empty_sorting_key,
         bool allow_reverse_sorting_key,
         bool allow_nullable_key_,
+        bool allow_uuid_key_,
         ContextPtr local_context) const;
 
     void setProperties(
@@ -1909,6 +1910,7 @@ private:
     virtual void startBackgroundMovesIfNeeded() = 0;
 
     bool allow_nullable_key = false;
+    bool allow_uuid_key = false;
     bool allow_reverse_key = false;
 
     void addPartContributionToDataVolume(const DataPartPtr & part);

--- a/src/Storages/MergeTree/MergeTreeSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeSettings.cpp
@@ -1633,6 +1633,9 @@ namespace ErrorCodes
     DECLARE(Bool, allow_nullable_key, false, R"(
     Allow Nullable types as primary keys.
     )", 0) \
+    DECLARE(Bool, allow_uuid_key, false, R"(
+    Allow UUID types as primary keys.
+    )", 0) \
     DECLARE(Bool, allow_part_offset_column_in_projections, true, R"(
     Allow usage of '_part_offset' column in projections select query.
     )", 0) \

--- a/tests/queries/0_stateless/02310_uuid_key_expressions.reference
+++ b/tests/queries/0_stateless/02310_uuid_key_expressions.reference
@@ -1,0 +1,6 @@
+Assert UUID primary key is not allowed by default on CREATE TABLE DDL
+Assert UUID partition key is not allowed by default on CREATE TABLE DDL
+Assert explicit UUID PRIMARY KEY clause is not allowed by default on CREATE TABLE DDL
+Assert UUID primary key is allowed when allow_uuid_key set to true
+Assert pre-existing table with UUID primary key and allow_uuid_key reset to default is allowed
+1

--- a/tests/queries/0_stateless/02310_uuid_key_expressions.sql
+++ b/tests/queries/0_stateless/02310_uuid_key_expressions.sql
@@ -1,0 +1,53 @@
+-- Tests UUID behavior in MergeTree key expressions
+
+SELECT 'Assert UUID primary key is not allowed by default on CREATE TABLE DDL';
+CREATE TABLE users (
+  uid UUID,
+  name String,
+  age Int16
+)
+ENGINE=MergeTree
+ORDER BY (uid, name); -- { serverError ILLEGAL_COLUMN }
+
+SELECT 'Assert UUID partition key is not allowed by default on CREATE TABLE DDL';
+CREATE TABLE users_partition_uuid
+(
+    uid UUID,
+    age Int16
+)
+ENGINE = MergeTree
+ORDER BY age
+PARTITION BY uid; -- { serverError ILLEGAL_COLUMN }
+
+SELECT 'Assert explicit UUID PRIMARY KEY clause is not allowed by default on CREATE TABLE DDL';
+CREATE TABLE users_explicit_primary_key_uuid
+(
+    uid UUID,
+    name String,
+    age Int16
+)
+ENGINE = MergeTree
+ORDER BY (uid, name)
+PRIMARY KEY (uid); -- { serverError ILLEGAL_COLUMN }
+
+SELECT 'Assert UUID primary key is allowed when allow_uuid_key set to true';
+DROP TABLE IF EXISTS users_uuid_attach;
+CREATE TABLE users_uuid_attach
+(
+    uid UUID,
+    age UInt8
+)
+ENGINE = MergeTree
+ORDER BY uid
+SETTINGS allow_uuid_key = 1;
+
+INSERT INTO users_uuid_attach VALUES ('00000000-0000-0000-0000-000000000001', 1);
+
+SELECT 'Assert pre-existing table with UUID primary key and allow_uuid_key reset to default is allowed';
+ALTER TABLE users_uuid_attach RESET SETTING allow_uuid_key;
+DETACH TABLE users_uuid_attach;
+ATTACH TABLE users_uuid_attach;
+
+SELECT count() FROM users_uuid_attach;
+
+DROP TABLE users_uuid_attach;


### PR DESCRIPTION
Fixes #97106

### Changelog category (leave one):
- Backward Incompatible Change

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

UUID columns are now disallowed by default in MergeTree key expressions (PRIMARY KEY, ORDER BY, PARTITION BY) because UUID values are ordered by their second half, which can reduce sparse primary-index selectivity and query pruning efficiency. This behavior can be overridden with allow_uuid_key.

### Documentation entry for user-facing changes

- [X] Documentation is written (mandatory for new features)