### PR TITLE
Fix estimated row count for SortingStep

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
@@ -348,6 +348,17 @@ RelationStats estimateReadRowsCount(QueryPlan::Node & node, const ActionsDAG::No
         return aggregation_stats;
     }
 
+    if (const auto * sorting_step = typeid_cast<const SortingStep *>(step))
+    {
+        auto stats = estimateReadRowsCount(*node.children.front(), filter);
+        if (sorting_step->getLimit())
+        {
+            if (!stats.estimated_rows || stats.estimated_rows > sorting_step->getLimit())
+                stats.estimated_rows = sorting_step->getLimit();
+        }
+        return stats;
+    }
+
     return {};
 }
 

--- a/tests/queries/0_stateless/03924_sorting_step_stats.reference
+++ b/tests/queries/0_stateless/03924_sorting_step_stats.reference
@@ -1,0 +1,18 @@
+-------------- Limit < table size -------------
+      JoinLogical
+      Join: t1[999] ⋈ t2[22]
+          ReadFromMergeTree (default.t)
+            Limit (preliminary LIMIT)
+            Limit 22
+              Sorting (Sorting for ORDER BY)
+              Limit 22
+                  ReadFromMergeTree (default.t)
+-------------- Limit > table size -------------
+      JoinLogical
+      Join: t1[999] ⋈ t2[999]
+          ReadFromMergeTree (default.t)
+            Limit (preliminary LIMIT)
+            Limit 5000
+              Sorting (Sorting for ORDER BY)
+              Limit 5000
+                  ReadFromMergeTree (default.t)

--- a/tests/queries/0_stateless/03924_sorting_step_stats.sql
+++ b/tests/queries/0_stateless/03924_sorting_step_stats.sql
@@ -3,7 +3,8 @@ CREATE TABLE t (c UInt64) ENGINE=MergeTree;
 INSERT INTO t SELECT * FROM numbers(999);
 
 SET enable_analyzer = 1,
-    query_plan_join_swap_table = 0;
+    query_plan_join_swap_table = 0,
+    enable_parallel_replicas = 0;
 
 
 SELECT '-------------- Limit < table size -------------';

--- a/tests/queries/0_stateless/03924_sorting_step_stats.sql
+++ b/tests/queries/0_stateless/03924_sorting_step_stats.sql
@@ -1,0 +1,30 @@
+CREATE TABLE t (c UInt64) ENGINE=MergeTree;
+
+INSERT INTO t SELECT * FROM numbers(999);
+
+SET enable_analyzer = 1,
+    query_plan_join_swap_table = 0;
+
+
+SELECT '-------------- Limit < table size -------------';
+SELECT explain FROM
+(
+    EXPLAIN keep_logical_steps=1, actions=1
+    SELECT count() FROM
+        (SELECT * FROM t) AS t1,
+        (SELECT * FROM t ORDER BY c LIMIT 22) AS t2
+    WHERE t1.c = t2.c
+)
+WHERE (explain LIKE '%Join%') OR (explain LIKE '%Sorting%') OR (explain LIKE '%Limit%') OR (explain LIKE '%ReadFromMergeTree%');
+
+
+SELECT '-------------- Limit > table size -------------';
+SELECT explain FROM
+(
+    EXPLAIN keep_logical_steps=1, actions=1
+    SELECT count() FROM
+        (SELECT * FROM t) AS t1,
+        (SELECT * FROM t ORDER BY c LIMIT 5000) AS t2
+    WHERE t1.c = t2.c
+)
+WHERE (explain LIKE '%Join%') OR (explain LIKE '%Sorting%') OR (explain LIKE '%Limit%') OR (explain LIKE '%ReadFromMergeTree%');


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Previously row count estimation wasn't done for SortingStep. Implement it as minimum of row count from previous step and limit value.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.892`
<!-- ch-version-info:end -->