### PR TITLE
Add a CI workflow to build PGO+BOLT optimized clang toolchain (7)

### DIFF
--- a/ci/jobs/build_toolchain.py
+++ b/ci/jobs/build_toolchain.py
@@ -178,6 +178,31 @@ def main():
             )
             res = results[-1].is_ok()
 
+        # Install compiler-rt headers (xray, sanitizer, etc.) into the clang resource
+        # directory so that ClickHouse can find <xray/xray_interface.h> when compiled
+        # with this toolchain.
+        if res:
+            resource_dirs = glob.glob(
+                f"{STAGE1_INSTALL_DIR}/lib/clang/*/include"
+            )
+            if resource_dirs:
+                resource_include = resource_dirs[0]
+                results.append(
+                    Result.from_commands_run(
+                        name="Install compiler-rt headers",
+                        command=(
+                            f"cp -r {LLVM_SOURCE_DIR}/compiler-rt/include/xray"
+                            f" {resource_include}/xray"
+                        ),
+                    )
+                )
+                res = results[-1].is_ok()
+            else:
+                print(
+                    f"WARNING: No clang resource directory found in"
+                    f" {STAGE1_INSTALL_DIR}/lib/clang/*/include"
+                )
+
     # Stage 2: Profile collection - build ClickHouse with instrumented clang
     if res and JobStages.PROFILE_COLLECTION in stages:
         clean_dirs(CH_PROFILE_BUILD_DIR)
@@ -273,42 +298,43 @@ def main():
         )
         res = results[-1].is_ok()
 
-        builtin_targets = ";".join(t for t, _ in CROSS_BUILTIN_TARGETS)
-        builtin_cmake_args = " ".join(
-            f"-DBUILTINS_{triple}_CMAKE_SYSTEM_NAME={system}"
-            for triple, system in CROSS_BUILTIN_TARGETS
-        )
-
-        cmake_cmd = (
-            f"cmake -G Ninja"
-            f' -DLLVM_ENABLE_PROJECTS="{STAGE2_LLVM_PROJECTS}"'
-            f' -DLLVM_ENABLE_RUNTIMES="compiler-rt"'
-            f" -DLLVM_TARGETS_TO_BUILD=all"
-            f" -DCMAKE_BUILD_TYPE=Release"
-            f" -DLLVM_PROFDATA_FILE={PROFDATA_PATH}"
-            f" -DCMAKE_C_COMPILER=clang-21"
-            f" -DCMAKE_CXX_COMPILER=clang++-21"
-            f" -DLLVM_ENABLE_LLD=ON"
-            f" -DLLVM_ENABLE_LTO=Thin"
-            f' -DCMAKE_EXE_LINKER_FLAGS="-Wl,--emit-relocs,-znow"'
-            f' -DCMAKE_SHARED_LINKER_FLAGS="-Wl,--emit-relocs,-znow"'
-            f" -DLLVM_ENABLE_TERMINFO=OFF"
-            f" -DLLVM_ENABLE_ZLIB=OFF"
-            f" -DLLVM_ENABLE_ZSTD=OFF"
-            f" -DLLVM_BINUTILS_INCDIR=/usr/include"
-            f' -DLLVM_BUILTIN_TARGETS="{builtin_targets}"'
-            f" {builtin_cmake_args}"
-            f" -DCMAKE_INSTALL_PREFIX={STAGE2_INSTALL_DIR}"
-            f" -S {LLVM_SOURCE_DIR}/llvm"
-            f" -B {STAGE2_BUILD_DIR}"
-        )
-        results.append(
-            Result.from_commands_run(
-                name="Stage 2 CMake (PGO-optimized clang)",
-                command=cmake_cmd,
+        if res:
+            builtin_targets = ";".join(t for t, _ in CROSS_BUILTIN_TARGETS)
+            builtin_cmake_args = " ".join(
+                f"-DBUILTINS_{triple}_CMAKE_SYSTEM_NAME={system}"
+                for triple, system in CROSS_BUILTIN_TARGETS
             )
-        )
-        res = results[-1].is_ok()
+
+            cmake_cmd = (
+                f"cmake -G Ninja"
+                f' -DLLVM_ENABLE_PROJECTS="{STAGE2_LLVM_PROJECTS}"'
+                f' -DLLVM_ENABLE_RUNTIMES="compiler-rt"'
+                f" -DLLVM_TARGETS_TO_BUILD=all"
+                f" -DCMAKE_BUILD_TYPE=Release"
+                f" -DLLVM_PROFDATA_FILE={PROFDATA_PATH}"
+                f" -DCMAKE_C_COMPILER=clang-21"
+                f" -DCMAKE_CXX_COMPILER=clang++-21"
+                f" -DLLVM_ENABLE_LLD=ON"
+                f" -DLLVM_ENABLE_LTO=Thin"
+                f' -DCMAKE_EXE_LINKER_FLAGS="-Wl,--emit-relocs,-znow"'
+                f' -DCMAKE_SHARED_LINKER_FLAGS="-Wl,--emit-relocs,-znow"'
+                f" -DLLVM_ENABLE_TERMINFO=OFF"
+                f" -DLLVM_ENABLE_ZLIB=OFF"
+                f" -DLLVM_ENABLE_ZSTD=OFF"
+                f" -DLLVM_BINUTILS_INCDIR=/usr/include"
+                f' -DLLVM_BUILTIN_TARGETS="{builtin_targets}"'
+                f" {builtin_cmake_args}"
+                f" -DCMAKE_INSTALL_PREFIX={STAGE2_INSTALL_DIR}"
+                f" -S {LLVM_SOURCE_DIR}/llvm"
+                f" -B {STAGE2_BUILD_DIR}"
+            )
+            results.append(
+                Result.from_commands_run(
+                    name="Stage 2 CMake (PGO-optimized clang)",
+                    command=cmake_cmd,
+                )
+            )
+            res = results[-1].is_ok()
 
         if res:
             results.append(


### PR DESCRIPTION
The Stage 1 toolchain only installs clang, clang-resource-headers, and lld — but not compiler-rt headers. When ClickHouse is compiled with this toolchain for PGO profile collection, `USE_XRAY=1` is set (because LLVM contrib is enabled), and `InstrumentationManager.h` tries to include `<xray/xray_interface.h>`. System clang has this header in its resource directory, but the Stage 1 clang does not.

Fix by copying xray headers from the LLVM source tree into the Stage 1 clang's resource directory after install.

Also guard Stage 2 cmake/build with `if res:` so we don't waste time running them when `binutils-dev` install fails.

https://productionresultssa3.blob.core.windows.net/actions-results/0f96bf9e-85ec-4d3b-86b2-feb07b482593/workflow-job-run-f363c303-ec70-52a1-bd68-d9e0a1b15ec9/logs/job/job-logs.txt

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.854`
<!-- ch-version-info:end -->