### PR TITLE
RFC: Escape statistics filenames in packed archive

### DIFF
--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -935,7 +935,7 @@ static const ColumnDescription * getColumnForStatisticsFile(const String & filen
     chassert(filename.ends_with(STATS_FILE_SUFFIX));
 
     size_t num_chars_to_truncate = STATS_FILE_PREFIX.size() + STATS_FILE_SUFFIX.size();
-    String column_name = filename.substr(STATS_FILE_PREFIX.size(), filename.size() - num_chars_to_truncate);
+    String column_name = unescapeForFileName(filename.substr(STATS_FILE_PREFIX.size(), filename.size() - num_chars_to_truncate));
 
     if (!required_columns.empty() && !required_columns.contains(column_name))
         return nullptr;

--- a/src/Storages/MergeTree/StatisticsSerialization.cpp
+++ b/src/Storages/MergeTree/StatisticsSerialization.cpp
@@ -1,16 +1,19 @@
+#include <Storages/MergeTree/MergeTreeData.h>
 #include <Storages/MergeTree/StatisticsSerialization.h>
 #include <IO/WriteBuffer.h>
 #include <IO/PackedFilesWriter.h>
 #include <IO/HashingWriteBuffer.h>
 #include <Compression/CompressedWriteBuffer.h>
 #include <Storages/MergeTree/IDataPartStorage.h>
+#include <Common/escapeForFileName.h>
 
 namespace DB
 {
 
 static String getStatisticsFilename(const String & column_name)
 {
-    return String(STATS_FILE_PREFIX) + column_name + String(STATS_FILE_SUFFIX);
+    /// Note, we cannot use replaceFileNameToHashIfNeeded(), since we do not handle hashes->column names for statistics in getColumnForStatisticsFile()
+    return String(STATS_FILE_PREFIX) + escapeForFileName(column_name) + String(STATS_FILE_SUFFIX);
 }
 
 std::unique_ptr<WriteBufferFromFileBase> serializeStatisticsPacked(


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Escape statistics filenames in packed archive

It should not affect the logic, but all other files are escaped properly there

Follow-up for https://github.com/ClickHouse/ClickHouse/pull/93414