### PR TITLE
Fix flaky test_inserts_and_moves[rmt_volume] in test_ttl_move

### DIFF
--- a/tests/integration/test_ttl_move/test.py
+++ b/tests/integration/test_ttl_move/test.py
@@ -83,17 +83,13 @@ def get_disks_state(node, table_name, partition=None):
 def get_disk_names(node, table_name, partition=None):
     return set(get_disks_state(node, table_name, partition).keys())
 
-def wait_if_moving_then_assert_disks(node, table_name, partition=None, retries=10, sleep_sec=1, target_state=None):
+def wait_if_moving_then_assert_disks(node, table_name, partition=None, retries=30, sleep_sec=1, target_state=None):
 
     for _ in range(retries):
         moves = int(node.query(f"SELECT count() FROM system.moves WHERE table = '{table_name}'").strip())
 
-        if moves > 0:
-            # just waiting until the moves are actually finished
-            continue
-
-        elif get_disks_state(node, table_name, partition) == target_state:
-            # if there's no active move happenning, and we're in the target state - this is success
+        if moves == 0 and get_disks_state(node, table_name, partition) == target_state:
+            # if there's no active move happening, and we're in the target state - this is success
             return
 
         time.sleep(sleep_sec)


### PR DESCRIPTION
## Summary
- Fixed a bug in `wait_if_moving_then_assert_disks` where `continue` skipped `time.sleep` when active moves were detected, rapidly exhausting retries without actually waiting
- Increased the default timeout from 10 to 30 seconds to provide more headroom for ReplicatedMergeTree background moves under CI load

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=b25e7f1fad41dd3316e717098fb5f9f1a9a52397&name_0=MasterCI&name_1=Integration%20tests%20%28amd_binary%2C%202%2F5%29

## Test plan
- [x] Verified the logic change is correct: always sleep between retries, check both conditions together
- [ ] CI passes with the fix

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.881`
<!-- ch-version-info:end -->