### PR TITLE
Handle patch-diff.githubusercontent.com outages in targeted test runs

### DIFF
--- a/ci/jobs/scripts/find_symbols.py
+++ b/ci/jobs/scripts/find_symbols.py
@@ -22,7 +22,7 @@ class DiffToSymbols:
         ).is_file(), f"clickhouse binary not found at {self.clickhouse_path}"
 
     @staticmethod
-    def fetch(url: str, retries: int = 3, delay: float = 5.0) -> bytes:
+    def fetch(url: str, retries: int = 5, delay: float = 5.0) -> bytes:
         for attempt in range(retries):
             try:
                 with urllib.request.urlopen(url) as resp:

--- a/ci/jobs/scripts/find_tests.py
+++ b/ci/jobs/scripts/find_tests.py
@@ -291,9 +291,22 @@ class Targeting:
 
         # TODO: Add coverage supoort for Integration tests
         if self.job_type == self.STATELESS_JOB_TYPE:
-            covering_tests, result = self.get_most_relevant_tests(ch_path)
-            tests.update(covering_tests)
-            results.append(result)
+            try:
+                covering_tests, result = self.get_most_relevant_tests(ch_path)
+                tests.update(covering_tests)
+                results.append(result)
+            except Exception as e:
+                print(
+                    f"WARNING: Failed to get coverage-based tests (best effort): {e}",
+                    file=sys.stderr,
+                )
+                results.append(
+                    Result(
+                        name="tests found by coverage",
+                        status=Result.StatusExtended.OK,
+                        info=f"Skipped: {e}",
+                    )
+                )
 
         return tests, Result(
             name="Fetch relevant tests",


### PR DESCRIPTION
## Summary
- The targeted test runner fetches the PR diff from `patch-diff.githubusercontent.com` to find coverage-based tests. When this service returns HTTP 503 (as seen in the linked CI report), the entire job crashes, losing even the changed-test and previously-failed-test results that were already collected.
- Increase fetch retries from 3 to 5 (total wait up to ~75s with exponential backoff) in `find_symbols.py`
- Wrap coverage-based test finding in try/except in `find_tests.py` so the job continues with changed tests and previously-failed tests on failure

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=97166&sha=36432163d055f59ebcfb04f0d1d74acd3b42ad24&name_0=PR&name_1=Stateless%20tests%20%28arm_asan%2C%20targeted%29
https://github.com/ClickHouse/ClickHouse/pull/97166

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.873`
<!-- ch-version-info:end -->