### PR TITLE
Add custom Ninja with timing-based critical path scheduling to toolchain

### DIFF
--- a/ci/jobs/build_clickhouse.py
+++ b/ci/jobs/build_clickhouse.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import shutil
 
 from ci.defs.defs import BuildTypes, ToolSet, chcache_secret
 from ci.jobs.scripts.clickhouse_version import CHVersion
@@ -225,6 +226,14 @@ def main():
             )
         )
         res = results[-1].is_ok()
+
+        # Pre-seed .ninja_log from toolchain for timing-based scheduling
+        if res:
+            ninja_log_seed = "/usr/local/share/clickhouse-build/ninja_log"
+            if os.path.exists(ninja_log_seed):
+                shutil.copy2(ninja_log_seed, f"{build_dir}/.ninja_log")
+                print(f"Pre-seeded .ninja_log from {ninja_log_seed}")
+            Shell.check("ninja --version", verbose=True)
 
     # Activate FIPS-permissive config for OpenSSL
     os.environ["OPENSSL_CONF"] = "/etc/ssl/openssl.cnf"

--- a/ci/jobs/build_toolchain.py
+++ b/ci/jobs/build_toolchain.py
@@ -9,6 +9,9 @@ from ci.praktika.utils import MetaClasses, Shell, Utils
 
 TEMP = "/tmp"
 LLVM_SOURCE_DIR = f"{TEMP}/llvm-project"
+NINJA_SOURCE_DIR = f"{TEMP}/ninja-src"
+NINJA_BUILD_DIR = f"{TEMP}/ninja-build"
+NINJA_LOG_SHARE_DIR = "share/clickhouse-build"
 STAGE1_BUILD_DIR = f"{TEMP}/toolchain-stage1"
 STAGE1_INSTALL_DIR = f"{TEMP}/toolchain-stage1-install"
 STAGE2_BUILD_DIR = f"{TEMP}/toolchain-stage2"
@@ -50,6 +53,7 @@ CROSS_BUILTIN_TARGETS = [
 
 class JobStages(metaclass=MetaClasses.WithIter):
     CLONE_LLVM = "clone_llvm"
+    BUILD_NINJA = "build_ninja"
     STAGE1_BUILD = "stage1_build"
     PROFILE_COLLECTION = "profile_collection"
     STAGE2_BUILD = "stage2_build"
@@ -129,6 +133,56 @@ def main():
         )
         res = results[-1].is_ok()
 
+    # Stage 0.5: Build custom Ninja with timing-based scheduling
+    # Ninja 1.12.1 has prev_elapsed_time_millis on Edge (populated from .ninja_log).
+    # We patch EdgeWeightHeuristic to use historical build times as edge weights,
+    # giving 11-21% build time reduction via critical path scheduling.
+    CUSTOM_NINJA = f"{NINJA_BUILD_DIR}/ninja"
+    if res and JobStages.BUILD_NINJA in stages:
+        clean_dirs(NINJA_SOURCE_DIR, NINJA_BUILD_DIR)
+        results.append(
+            Result.from_commands_run(
+                name="Clone Ninja v1.12.1",
+                command=(
+                    f"git clone --depth 1 --branch v1.12.1"
+                    f" https://github.com/ninja-build/ninja.git {NINJA_SOURCE_DIR}"
+                ),
+                retries=3,
+            )
+        )
+        res = results[-1].is_ok()
+
+        if res:
+            # Patch EdgeWeightHeuristic to use .ninja_log timing data
+            results.append(
+                Result.from_commands_run(
+                    name="Patch Ninja EdgeWeightHeuristic",
+                    command=(
+                        f"sed -i 's/return edge->is_phony() ? 0 : 1;/"
+                        f"int64_t w = edge->prev_elapsed_time_millis < 0 ? 1 : edge->prev_elapsed_time_millis;\\n"
+                        f"  return edge->is_phony() ? 0 : w;/' {NINJA_SOURCE_DIR}/src/build.cc"
+                    ),
+                )
+            )
+            res = results[-1].is_ok()
+
+        if res:
+            results.append(
+                Result.from_commands_run(
+                    name="Build Ninja",
+                    command=[
+                        f"cmake -B {NINJA_BUILD_DIR} -S {NINJA_SOURCE_DIR} -DCMAKE_BUILD_TYPE=Release",
+                        f"cmake --build {NINJA_BUILD_DIR}",
+                    ],
+                )
+            )
+            res = results[-1].is_ok()
+
+        if res:
+            print(f"Custom Ninja built at {CUSTOM_NINJA}")
+            # Clean up source dir to save space
+            clean_dirs(NINJA_SOURCE_DIR)
+
     # Stage 1: Build instrumented clang for PGO profile collection
     # Only needs clang + lld (for compilation/linking) and compiler-rt (profiling runtime)
     if res and JobStages.STAGE1_BUILD in stages:
@@ -161,7 +215,7 @@ def main():
             results.append(
                 Result.from_commands_run(
                     name="Stage 1 Build (instrumented clang)",
-                    command=f"ninja -C {STAGE1_BUILD_DIR} clang lld",
+                    command=f"{CUSTOM_NINJA} -C {STAGE1_BUILD_DIR} clang lld",
                 )
             )
             res = results[-1].is_ok()
@@ -171,7 +225,7 @@ def main():
                 Result.from_commands_run(
                     name="Stage 1 Install",
                     command=(
-                        f"ninja -C {STAGE1_BUILD_DIR}"
+                        f"{CUSTOM_NINJA} -C {STAGE1_BUILD_DIR}"
                         f" install-clang install-clang-resource-headers install-lld"
                     ),
                 )
@@ -248,7 +302,7 @@ def main():
             # steps are still useful for PGO
             build_result = Result.from_commands_run(
                 name="Profile collection build (ClickHouse)",
-                command=f"ninja -C {CH_PROFILE_BUILD_DIR} clickhouse",
+                command=f"{CUSTOM_NINJA} -C {CH_PROFILE_BUILD_DIR} clickhouse",
             )
             if not build_result.is_ok():
                 print(
@@ -278,6 +332,15 @@ def main():
         else:
             print(f"ERROR: No profraw files found in {profraw_dir}")
             res = False
+
+        # Save .ninja_log for packaging (contains build timing data for scheduling)
+        ninja_log_src = f"{CH_PROFILE_BUILD_DIR}/.ninja_log"
+        ninja_log_saved = f"{TEMP}/clickhouse-ninja-log"
+        if os.path.exists(ninja_log_src):
+            shutil.copy2(ninja_log_src, ninja_log_saved)
+            print(f"Saved .ninja_log ({os.path.getsize(ninja_log_saved)} bytes)")
+        else:
+            print("WARNING: .ninja_log not found after profile collection build")
 
         # Clean up to free disk space (~80 GB)
         print("Cleaning Stage 1 build and CH profile build to free disk space")
@@ -340,7 +403,7 @@ def main():
             results.append(
                 Result.from_commands_run(
                     name="Stage 2 Build",
-                    command=f"ninja -C {STAGE2_BUILD_DIR}",
+                    command=f"{CUSTOM_NINJA} -C {STAGE2_BUILD_DIR}",
                 )
             )
             res = results[-1].is_ok()
@@ -349,7 +412,7 @@ def main():
             results.append(
                 Result.from_commands_run(
                     name="Stage 2 Install",
-                    command=f"ninja -C {STAGE2_BUILD_DIR} install",
+                    command=f"{CUSTOM_NINJA} -C {STAGE2_BUILD_DIR} install",
                 )
             )
             res = results[-1].is_ok()
@@ -458,7 +521,7 @@ def main():
                 command=(
                     f"bash -c 'timeout --signal=INT --kill-after=120"
                     f" {BOLT_PROFILE_TIMEOUT}"
-                    f" ninja -j{BOLT_PROFILE_PARALLELISM} -k0"
+                    f" {CUSTOM_NINJA} -j{BOLT_PROFILE_PARALLELISM} -k0"
                     f" -C {CH_BOLT_BUILD_DIR} clickhouse"
                     f" ; exit 0'"
                 ),
@@ -542,6 +605,21 @@ def main():
 
     # Stage 5: Package
     if res and JobStages.PACKAGE in stages:
+        # Copy custom Ninja binary into the toolchain
+        if os.path.exists(CUSTOM_NINJA):
+            ninja_dest = f"{STAGE2_INSTALL_DIR}/bin/ninja"
+            shutil.copy2(CUSTOM_NINJA, ninja_dest)
+            os.chmod(ninja_dest, 0o755)
+            print(f"Installed custom Ninja to {ninja_dest}")
+
+        # Copy .ninja_log for pre-seeding CI builds
+        ninja_log_saved = f"{TEMP}/clickhouse-ninja-log"
+        if os.path.exists(ninja_log_saved):
+            ninja_log_dir = f"{STAGE2_INSTALL_DIR}/{NINJA_LOG_SHARE_DIR}"
+            os.makedirs(ninja_log_dir, exist_ok=True)
+            shutil.copy2(ninja_log_saved, f"{ninja_log_dir}/ninja_log")
+            print(f"Installed .ninja_log to {ninja_log_dir}/ninja_log")
+
         # Strip ELF executables and shared libraries to reduce archive size
         # (relocations from --emit-relocs and LTO symbols are no longer needed).
         # Use "file" to skip scripts (Python, Perl, shell) that strip cannot handle.


### PR DESCRIPTION
Implement https://github.com/ninja-build/ninja/issues/2157

## Summary

- Builds a custom Ninja 1.12.1 in the toolchain build job, patched to use `.ninja_log` historical build times as edge weights in `EdgeWeightHeuristic` (instead of uniform weight 1), enabling true critical path scheduling
- Packages the custom ninja binary and a pre-seeded `.ninja_log` (from the ClickHouse profile collection build) into the toolchain tarball
- In CI ClickHouse builds, pre-seeds the build directory with the `.ninja_log` from the toolchain so timing data is available from the first ninja invocation

Based on [ninja-build/ninja#2686](https://github.com/ninja-build/ninja/pull/2686), this is expected to give 11-21% wall-clock build time reduction by prioritizing long-running compilation units on the critical path.

## Test plan

- [ ] Toolchain build job succeeds with the new `BUILD_NINJA` stage
- [ ] `/usr/local/bin/ninja --version` outputs `1.12.1` in CI containers
- [ ] `/usr/local/share/clickhouse-build/ninja_log` exists and contains timing data
- [ ] ClickHouse build logs show `Pre-seeded .ninja_log` and `Ninja version: 1.12.1`
- [ ] Compare build times before/after to measure improvement

### Changelog category (leave one):
- Not for changelog

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.880`
<!-- ch-version-info:end -->