### PR TITLE
Fix Ninja build in OptimizeToolchain with CMake 4.1

### DIFF
--- a/ci/jobs/build_toolchain.py
+++ b/ci/jobs/build_toolchain.py
@@ -196,6 +196,9 @@ def main():
             f" -DLLVM_TARGETS_TO_BUILD=Native"
             f" -DCMAKE_BUILD_TYPE=Release"
             f" -DLLVM_BUILD_INSTRUMENTED=IR"
+            f" -DCMAKE_C_COMPILER=clang-21"
+            f" -DCMAKE_CXX_COMPILER=clang++-21"
+            f" -DLLVM_ENABLE_LLD=ON"
             f" -DLLVM_ENABLE_TERMINFO=OFF"
             f" -DLLVM_ENABLE_ZLIB=OFF"
             f" -DLLVM_ENABLE_ZSTD=OFF"
@@ -227,7 +230,6 @@ def main():
                     command=(
                         f"{CUSTOM_NINJA} -C {STAGE1_BUILD_DIR}"
                         f" install-clang install-clang-resource-headers install-lld"
-                        f" install-compiler-rt-headers"
                     ),
                 )
             )

--- a/ci/jobs/build_toolchain.py
+++ b/ci/jobs/build_toolchain.py
@@ -171,7 +171,7 @@ def main():
                 Result.from_commands_run(
                     name="Build Ninja",
                     command=[
-                        f"cmake -B {NINJA_BUILD_DIR} -S {NINJA_SOURCE_DIR} -DCMAKE_BUILD_TYPE=Release",
+                        f"cmake -B {NINJA_BUILD_DIR} -S {NINJA_SOURCE_DIR} -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF",
                         f"cmake --build {NINJA_BUILD_DIR}",
                     ],
                 )


### PR DESCRIPTION
The `binary-builder` Docker image has CMake 4.1 which removed compatibility with `cmake_minimum_required` < 3.5. Ninja v1.12.1 fetches GoogleTest release-1.10.0 that requires CMake 2.x, causing a configuration error. Disable tests with `-DBUILD_TESTING=OFF` since we only need the ninja binary, not its test suite.

https://productionresultssa16.blob.core.windows.net/actions-results/73051ac6-8ef6-41f2-b55e-8561a2b164df/workflow-job-run-096d960a-9292-5b25-9459-273eef8da9c2/logs/job/job-logs.txt

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.888`
<!-- ch-version-info:end -->