### PR TITLE
Save Spark logs to artifacts in integration tests

### DIFF
--- a/tests/integration/helpers/iceberg_utils.py
+++ b/tests/integration/helpers/iceberg_utils.py
@@ -25,14 +25,14 @@ from helpers.s3_tools import (
     S3Downloader,
     prepare_s3_bucket,
 )
-from helpers.spark_tools import ResilientSparkSession
+from helpers.spark_tools import ResilientSparkSession, write_spark_log_config
 
 from typing import Optional, Any
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 
 
-def get_spark():
+def get_spark(log_dir=None):
     builder = (
         pyspark.sql.SparkSession.builder.appName("iceberg_utils")
         .config(
@@ -48,6 +48,14 @@ def get_spark():
         )
         .master("local")
     )
+
+    if log_dir:
+        props_path = write_spark_log_config(log_dir)
+        builder = builder.config(
+            "spark.driver.extraJavaOptions",
+            f"-Dlog4j2.configurationFile=file:{props_path}",
+        )
+
     return builder.master("local").getOrCreate()
 
 
@@ -97,7 +105,9 @@ def started_cluster():
         prepare_s3_bucket(cluster)
         logging.info("S3 bucket created")
 
-        cluster.spark_session = ResilientSparkSession(get_spark)
+        cluster.spark_session = ResilientSparkSession(
+            lambda: get_spark(cluster.instances_dir)
+        )
         cluster.default_s3_uploader = S3Uploader(
             cluster.minio_client, cluster.minio_bucket
         )

--- a/tests/integration/helpers/spark_tools.py
+++ b/tests/integration/helpers/spark_tools.py
@@ -1,6 +1,41 @@
 import logging
+import os
 
 import pyspark
+
+
+def write_spark_log_config(log_dir):
+    """Create a log4j2 properties file that writes Spark logs to a file.
+
+    Returns the path to the properties file so it can be passed to Spark via
+    spark.driver.extraJavaOptions.
+    """
+    os.makedirs(log_dir, exist_ok=True)
+    spark_log_path = os.path.join(log_dir, "spark.log")
+    props_path = os.path.join(log_dir, "log4j2-spark.properties")
+    with open(props_path, "w") as f:
+        f.write(
+            f"""\
+rootLogger.level = info
+rootLogger.appenderRef.file.ref = file
+rootLogger.appenderRef.console.ref = console
+
+appender.console.type = Console
+appender.console.name = console
+appender.console.target = SYSTEM_ERR
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{{yy/MM/dd HH:mm:ss}} %p %c{{1}}: %m%n%ex
+appender.console.filter.threshold.type = ThresholdFilter
+appender.console.filter.threshold.level = warn
+
+appender.file.type = File
+appender.file.name = file
+appender.file.fileName = {spark_log_path}
+appender.file.layout.type = PatternLayout
+appender.file.layout.pattern = %d{{yy/MM/dd HH:mm:ss}} %p %c{{1}}: %m%n%ex
+"""
+        )
+    return props_path
 
 
 class ResilientSparkSession:

--- a/tests/integration/test_storage_delta/test_cdf.py
+++ b/tests/integration/test_storage_delta/test_cdf.py
@@ -47,7 +47,7 @@ from helpers.s3_tools import (
     upload_directory,
     LocalDownloader,
 )
-from helpers.spark_tools import ResilientSparkSession
+from helpers.spark_tools import ResilientSparkSession, write_spark_log_config
 
 
 SCRIPT_DIR = "/var/lib/clickhouse/user_files" + os.path.join(
@@ -60,7 +60,7 @@ S3_DATA = [
 ]
 
 
-def get_spark():
+def get_spark(log_dir=None):
     builder = (
         pyspark.sql.SparkSession.builder.appName("spark_test")
         .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
@@ -76,6 +76,13 @@ def get_spark():
         .config("spark.executor.memory", "8g")
         .master("local")
     )
+
+    if log_dir:
+        props_path = write_spark_log_config(log_dir)
+        builder = builder.config(
+            "spark.driver.extraJavaOptions",
+            f"-Dlog4j2.configurationFile=file:{props_path}",
+        )
 
     return builder.master("local").getOrCreate()
 
@@ -124,7 +131,9 @@ def started_cluster():
         # extend this if testing on other nodes becomes necessary
         cluster.local_uploader = LocalUploader(cluster.instances["instance1"])
 
-        cluster.spark_session = ResilientSparkSession(get_spark)
+        cluster.spark_session = ResilientSparkSession(
+            lambda: get_spark(cluster.instances_dir)
+        )
 
         for file in S3_DATA:
             print(f"Copying object {file}")

--- a/tests/integration/test_storage_delta/test_imds.py
+++ b/tests/integration/test_storage_delta/test_imds.py
@@ -81,7 +81,9 @@ def started_cluster():
         prepare_s3_bucket(cluster)
         start_metadata_server(cluster)
 
-        cluster.spark_session = ResilientSparkSession(get_spark)
+        cluster.spark_session = ResilientSparkSession(
+            lambda: get_spark(cluster.instances_dir)
+        )
         start_metadata_server(cluster)
 
         yield cluster

--- a/tests/integration/test_storage_delta_disks/test.py
+++ b/tests/integration/test_storage_delta_disks/test.py
@@ -16,7 +16,7 @@ from pyspark.sql.types import (
 from pyspark.sql.window import Window
 
 from helpers.cluster import ClickHouseCluster
-from helpers.spark_tools import ResilientSparkSession
+from helpers.spark_tools import ResilientSparkSession, write_spark_log_config
 from helpers.s3_tools import (
     AzureUploader,
     LocalUploader,
@@ -38,7 +38,7 @@ SCRIPT_DIR = "/var/lib/clickhouse/user_files" + os.path.join(
 cluster = ClickHouseCluster(__file__, with_spark=True)
 
 
-def get_spark():
+def get_spark(log_dir=None):
     builder = (
         pyspark.sql.SparkSession.builder.appName("test_storage_delta_disks")
         .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
@@ -54,6 +54,13 @@ def get_spark():
         .config("spark.executor.memory", "8g")
         .master("local")
     )
+
+    if log_dir:
+        props_path = write_spark_log_config(log_dir)
+        builder = builder.config(
+            "spark.driver.extraJavaOptions",
+            f"-Dlog4j2.configurationFile=file:{props_path}",
+        )
 
     return builder.getOrCreate()
 
@@ -160,7 +167,9 @@ def started_cluster():
         prepare_s3_bucket(cluster)
         logging.info("S3 bucket created")
 
-        cluster.spark_session = ResilientSparkSession(get_spark)
+        cluster.spark_session = ResilientSparkSession(
+            lambda: get_spark(cluster.instances_dir)
+        )
         cluster.default_s3_uploader = S3Uploader(
             cluster.minio_client, cluster.minio_bucket
         )

--- a/tests/integration/test_storage_hudi/test.py
+++ b/tests/integration/test_storage_hudi/test.py
@@ -32,12 +32,12 @@ from helpers.s3_tools import (
     upload_directory,
 )
 from helpers.test_tools import TSV
-from helpers.spark_tools import ResilientSparkSession
+from helpers.spark_tools import ResilientSparkSession, write_spark_log_config
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 
 
-def get_spark():
+def get_spark(log_dir=None):
     builder = (
         pyspark.sql.SparkSession.builder.appName("test_storage_hudi")
         .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
@@ -47,6 +47,14 @@ def get_spark():
         .config("spark.driver.memory", "20g")
         .master("local")
     )
+
+    if log_dir:
+        props_path = write_spark_log_config(log_dir)
+        builder = builder.config(
+            "spark.driver.extraJavaOptions",
+            f"-Dlog4j2.configurationFile=file:{props_path}",
+        )
+
     return builder.getOrCreate()
 
 
@@ -67,7 +75,9 @@ def started_cluster():
         prepare_s3_bucket(cluster)
         logging.info("S3 bucket created")
 
-        cluster.spark_session = ResilientSparkSession(get_spark)
+        cluster.spark_session = ResilientSparkSession(
+            lambda: get_spark(cluster.instances_dir)
+        )
 
         yield cluster
 

--- a/tests/integration/test_storage_iceberg_concurrent/conftest.py
+++ b/tests/integration/test_storage_iceberg_concurrent/conftest.py
@@ -13,7 +13,7 @@ from helpers.s3_tools import (
     LocalDownloader,
     prepare_s3_bucket,
 )
-from helpers.spark_tools import ResilientSparkSession
+from helpers.spark_tools import ResilientSparkSession, write_spark_log_config
 
 def check_spark(spark):
     p = subprocess.run(["echo", "hello world!"], capture_output=True, text=True)
@@ -72,6 +72,13 @@ def get_spark(cluster : ClickHouseCluster):
             .config("spark.hadoop.fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem")
                 .master("local")
             )
+
+    props_path = write_spark_log_config(cluster.instances_dir)
+    builder = builder.config(
+        "spark.driver.extraJavaOptions",
+        f"-Dlog4j2.configurationFile=file:{props_path}",
+    )
+
     return builder.getOrCreate()
 
 @pytest.fixture(scope="package")

--- a/tests/integration/test_storage_iceberg_schema_evolution/conftest.py
+++ b/tests/integration/test_storage_iceberg_schema_evolution/conftest.py
@@ -11,9 +11,9 @@ from helpers.s3_tools import (
     LocalDownloader,
     prepare_s3_bucket,
 )
-from helpers.spark_tools import ResilientSparkSession
+from helpers.spark_tools import ResilientSparkSession, write_spark_log_config
 
-def get_spark():
+def get_spark(log_dir=None):
     builder = (
         pyspark.sql.SparkSession.builder.appName("test_storage_iceberg_schema_evolution")
         .config(
@@ -29,6 +29,14 @@ def get_spark():
         )
         .master("local")
     )
+
+    if log_dir:
+        props_path = write_spark_log_config(log_dir)
+        builder = builder.config(
+            "spark.driver.extraJavaOptions",
+            f"-Dlog4j2.configurationFile=file:{props_path}",
+        )
+
     return builder.getOrCreate()
 
 @pytest.fixture(scope="package")
@@ -50,7 +58,9 @@ def started_cluster_iceberg_schema_evolution():
         prepare_s3_bucket(cluster)
         logging.info("S3 bucket created")
 
-        cluster.spark_session = ResilientSparkSession(get_spark)
+        cluster.spark_session = ResilientSparkSession(
+            lambda: get_spark(cluster.instances_dir)
+        )
         cluster.default_s3_uploader = S3Uploader(
             cluster.minio_client, cluster.minio_bucket
         )

--- a/tests/integration/test_storage_iceberg_with_spark/conftest.py
+++ b/tests/integration/test_storage_iceberg_with_spark/conftest.py
@@ -16,10 +16,10 @@ from helpers.s3_tools import (
     LocalDownloader,
     prepare_s3_bucket,
 )
-from helpers.spark_tools import ResilientSparkSession
+from helpers.spark_tools import ResilientSparkSession, write_spark_log_config
 
 
-def get_spark():
+def get_spark(log_dir=None):
     builder = (
         pyspark.sql.SparkSession.builder.appName("test_storage_iceberg_with_spark")
         .config(
@@ -35,6 +35,14 @@ def get_spark():
         )
         .master("local")
     )
+
+    if log_dir:
+        props_path = write_spark_log_config(log_dir)
+        builder = builder.config(
+            "spark.driver.extraJavaOptions",
+            f"-Dlog4j2.configurationFile=file:{props_path}",
+        )
+
     return builder.getOrCreate()
 
 
@@ -104,7 +112,9 @@ def started_cluster_iceberg_with_spark():
         prepare_s3_bucket(cluster)
         logging.info("S3 bucket created")
 
-        cluster.spark_session = ResilientSparkSession(get_spark)
+        cluster.spark_session = ResilientSparkSession(
+            lambda: get_spark(cluster.instances_dir)
+        )
         cluster.default_s3_uploader = S3Uploader(
             cluster.minio_client, cluster.minio_bucket
         )

--- a/tests/integration/test_storage_iceberg_with_spark_cache/conftest.py
+++ b/tests/integration/test_storage_iceberg_with_spark_cache/conftest.py
@@ -13,9 +13,9 @@ from helpers.s3_tools import (
     LocalDownloader,
     prepare_s3_bucket,
 )
-from helpers.spark_tools import ResilientSparkSession
+from helpers.spark_tools import ResilientSparkSession, write_spark_log_config
 
-def get_spark():
+def get_spark(log_dir=None):
     builder = (
         pyspark.sql.SparkSession.builder.appName("spark_test")
         .config(
@@ -31,6 +31,14 @@ def get_spark():
         )
         .master("local")
     )
+
+    if log_dir:
+        props_path = write_spark_log_config(log_dir)
+        builder = builder.config(
+            "spark.driver.extraJavaOptions",
+            f"-Dlog4j2.configurationFile=file:{props_path}",
+        )
+
     return builder.master("local").getOrCreate()
 
 @pytest.fixture(scope="package")
@@ -82,7 +90,9 @@ def started_cluster_iceberg_with_spark():
         prepare_s3_bucket(cluster)
         logging.info("S3 bucket created")
 
-        cluster.spark_session = ResilientSparkSession(get_spark)
+        cluster.spark_session = ResilientSparkSession(
+            lambda: get_spark(cluster.instances_dir)
+        )
         cluster.default_s3_uploader = S3Uploader(
             cluster.minio_client, cluster.minio_bucket
         )


### PR DESCRIPTION
## Summary
- Configure PySpark's log4j2 to write JVM logs to a `spark.log` file in the test instances directory, so they are collected as CI artifacts
- Previously, Spark JVM logs went to stderr only and were lost, making it difficult to debug Delta and Iceberg integration test failures
- Console output is throttled to WARN+ to reduce noise; full INFO+ logs go to the file

## Details

Added `write_spark_log_config` helper to `spark_tools.py` that generates a log4j2 properties file. Each `get_spark()` function now accepts an optional `log_dir` parameter and configures `spark.driver.extraJavaOptions` with `-Dlog4j2.configurationFile` when provided.

Updated all test suites that use local PySpark sessions:
- `test_storage_delta` (test.py, test_cdf.py, test_imds.py)
- `test_storage_delta_disks`
- `test_storage_hudi`
- `test_storage_iceberg_with_spark`
- `test_storage_iceberg_with_spark_cache`
- `test_storage_iceberg_disks`
- `test_storage_iceberg_schema_evolution`
- `test_storage_iceberg_concurrent`
- `helpers/iceberg_utils.py`

## Test plan
- [ ] Verify `spark.log` appears in `_instances_*` directory when running any Delta/Iceberg/Hudi integration test
- [ ] Verify Spark INFO-level log entries are written to the file
- [ ] Verify console output only shows WARN+ from Spark (less noise)

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)