### PR TITLE
Fix flaky test 03917_blockio_move_query_metadata_cache in DatabaseReplicated

### DIFF
--- a/tests/queries/0_stateless/03917_blockio_move_query_metadata_cache.sh
+++ b/tests/queries/0_stateless/03917_blockio_move_query_metadata_cache.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: long
+# Tags: long, no-replicated-database
 
 # Regression test for https://github.com/ClickHouse/ClickHouse/issues/95742
 #


### PR DESCRIPTION
## Summary

- Add `no-replicated-database` tag to `03917_blockio_move_query_metadata_cache` test
- The test does `DETACH`/`ATTACH`/`DROP`/`CREATE` in tight loops, which causes DDL queue timeouts (`Code: 341 UNFINISHED`) in `DatabaseReplicated` mode, leading to flaky failures

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=97240&sha=e91567580c9bca2c7d102a49903c9e2172c0953b&name_0=PR&name_1=Stateless%20tests%20%28amd_binary%2C%20old%20analyzer%2C%20s3%20storage%2C%20DatabaseReplicated%2C%20parallel%29
https://github.com/ClickHouse/ClickHouse/pull/97240

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.912`
<!-- ch-version-info:end -->