### PR TITLE
Fix flaky test 03400_alter_update_with_rename

### DIFF
--- a/tests/queries/0_stateless/03400_alter_update_with_rename.sql
+++ b/tests/queries/0_stateless/03400_alter_update_with_rename.sql
@@ -1,4 +1,3 @@
--- Tags: no-replicated-database
 -- Test for issue #70678: ALTER UPDATE with RENAME unexpected behavior
 -- If the ALTER statement is atomic, both UPDATE and RENAME should either
 -- succeed together or fail together.
@@ -55,10 +54,7 @@ CREATE TABLE test_alter_atomic (key Int32, c0 Int32, c1 Int32) ENGINE = MergeTre
 INSERT INTO test_alter_atomic VALUES (1, 10, 20);
 
 -- UPDATE c0, RENAME c1 should work because they are different columns
-ALTER TABLE test_alter_atomic UPDATE c0 = 100 WHERE true, RENAME COLUMN c1 TO c2;
-
--- Wait for mutation to complete
-SELECT sleepEachRow(0.1) FROM numbers(30) SETTINGS function_sleep_max_microseconds_per_block = 10000000 FORMAT Null;
+ALTER TABLE test_alter_atomic UPDATE c0 = 100 WHERE true, RENAME COLUMN c1 TO c2 SETTINGS mutations_sync=2;
 
 SELECT key, c0, c2 FROM test_alter_atomic;
 SELECT name FROM system.columns WHERE database = currentDatabase() AND table = 'test_alter_atomic' ORDER BY position;
@@ -70,10 +66,7 @@ CREATE TABLE test_alter_atomic (key Int32, c0 Int32, c1 Int32) ENGINE = MergeTre
 INSERT INTO test_alter_atomic VALUES (1, 10, 20), (2, 30, 40);
 
 -- DELETE based on c0, RENAME c1 should work because they are different columns
-ALTER TABLE test_alter_atomic DELETE WHERE c0 = 10, RENAME COLUMN c1 TO c2;
-
--- Wait for mutation to complete
-SELECT sleepEachRow(0.1) FROM numbers(30) SETTINGS function_sleep_max_microseconds_per_block = 10000000 FORMAT Null;
+ALTER TABLE test_alter_atomic DELETE WHERE c0 = 10, RENAME COLUMN c1 TO c2 SETTINGS mutations_sync=2;
 
 SELECT * FROM test_alter_atomic;
 SELECT name FROM system.columns WHERE database = currentDatabase() AND table = 'test_alter_atomic' ORDER BY position;

--- a/tests/queries/0_stateless/03400_alter_update_with_rename.sql
+++ b/tests/queries/0_stateless/03400_alter_update_with_rename.sql
@@ -1,3 +1,6 @@
+-- Tags: no-replicated-database
+-- For Replicated databases it's not allowed to execute ALTERs of different types (replicated and non replicated) in single query. (NOT_IMPLEMENTED)
+
 -- Test for issue #70678: ALTER UPDATE with RENAME unexpected behavior
 -- If the ALTER statement is atomic, both UPDATE and RENAME should either
 -- succeed together or fail together.


### PR DESCRIPTION
## Summary

Fixes flaky test `03400_alter_update_with_rename` that was failing on ARM ASan builds.

The test was using sleep-based wait (`sleepEachRow`) hoping that mutations would complete within 3 seconds. On slower builds (especially ARM ASan), mutations can take longer, causing the test to fail with incorrect results.

This PR replaces sleep-based wait with `mutations_sync=2` setting, which properly waits for mutations to complete before the ALTER command returns. This eliminates the race condition and makes the test deterministic.

Closes https://github.com/ClickHouse/ClickHouse/issues/97265

## Changelog category (leave one):
- CI Fix or improvement

## Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix flaky test `03400_alter_update_with_rename` by using proper mutation sync instead of sleep-based wait


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.921`
<!-- ch-version-info:end -->