### PR TITLE
CI: skip rolling-out release branches for general backports

### DIFF
--- a/tests/ci/pr_info.py
+++ b/tests/ci/pr_info.py
@@ -43,6 +43,7 @@ class Labels:
     PR_SYNC_UPSTREAM = "pr-sync-upstream"
     RELEASE = "release"
     RELEASE_LTS = "release-lts"
+    ROLLING_OUT = "rolling-out"
     SUBMODULE_CHANGED = "submodule changed"
 
     # automatic backport for critical bug fixes


### PR DESCRIPTION
## Summary

- When a release PR has the `rolling-out` label, `cherry_pick.py` now skips creating cherry-pick/backport PRs for that branch if the original PR carries only the generic `pr-must-backport` or `pr-critical-bugfix` (`AUTO_BACKPORT`) label.
- A direct version-specific label such as `v25.10-must-backport` always overrides the skip and proceeds as normal — even when the target release branch is marked `rolling-out`.
- `Labels.ROLLING_OUT = "rolling-out"` added to `pr_info.py`.
- New `BackportPRs._rolling_out_branches()` helper collects rolling-out branch names from release PR labels.
- `BackportPRs.process_pr` unified the "general backport" condition and applies the filter with a per-branch explicit-label override; logs skipped branches and returns early when all branches are filtered out.

## Test plan

- [ ] Verify that a PR with only `pr-must-backport` does not get a cherry-pick PR created for a release branch whose release PR has `rolling-out`.
- [ ] Verify that a PR with `pr-must-backport` **and** `v25.10-must-backport` still gets a cherry-pick PR for `25.10` even when `25.10` release PR is `rolling-out`.
- [ ] Verify that a PR with only `v25.10-must-backport` is unaffected regardless of `rolling-out` on the release PR.

## Changelog category

CI Fix or improvement

## Changelog entry

`cherry_pick.py` now skips creating cherry-pick/backport PRs for release branches marked `rolling-out` when the source PR uses the generic `pr-must-backport` or `pr-critical-bugfix` label; a direct version-specific label (e.g. `v25.10-must-backport`) overrides this and always proceeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.1001`
<!-- ch-version-info:end -->