### PR TITLE
Fix `system.merge_tree_settings.readonly` for readonly settings

### DIFF
--- a/src/Storages/MergeTree/MergeTreeSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeSettings.cpp
@@ -2551,6 +2551,10 @@ void MergeTreeSettings::dumpToSystemMergeTreeSettingsColumns(MutableColumnsAndCo
         SettingConstraintWritability writability = SettingConstraintWritability::WRITABLE;
         constraints.get(*this, setting_name, min, max, disallowed_values, writability);
 
+        /// Certain merge tree settings are unconditionally read-only
+        if (isReadonlySetting(setting_name))
+            writability = SettingConstraintWritability::CONST;
+
         /// These two columns can accept strings only.
         if (!min.isNull())
             min = MergeTreeSettings::valueToStringUtil(setting_name, min);

--- a/tests/queries/0_stateless/01221_system_settings.reference
+++ b/tests/queries/0_stateless/01221_system_settings.reference
@@ -1,4 +1,4 @@
 send_timeout	300	0	Timeout for sending data to the network, in seconds. If a client needs to send some data but is not able to send any bytes in this interval, the exception is thrown. If you set this setting on the client, the \'receive_timeout\' for the socket will also be set on the corresponding connection end on the server.	\N	\N	[]	0	Seconds	300		0	Production
-index_granularity	8192	8192	0	\n    Maximum number of data rows between the marks of an index. I.e how many rows\n    correspond to one primary key value.\n    	\N	\N	[]	0	UInt64	0	Production
+index_granularity	8192	8192	0	\n    Maximum number of data rows between the marks of an index. I.e how many rows\n    correspond to one primary key value.\n    	\N	\N	[]	1	UInt64	0	Production
 1
 1

--- a/tests/queries/0_stateless/03921_merge_tree_settings_readonly.reference
+++ b/tests/queries/0_stateless/03921_merge_tree_settings_readonly.reference
@@ -1,0 +1,1 @@
+index_granularity	1

--- a/tests/queries/0_stateless/03921_merge_tree_settings_readonly.sql
+++ b/tests/queries/0_stateless/03921_merge_tree_settings_readonly.sql
@@ -1,0 +1,3 @@
+-- Merge tree setting 'index_granularity' is unconditionally read-only (changing it would mean rewriting all parts).
+-- There was a bug that the system table wouldn't show it as read-only.
+SELECT name, readonly FROM system.merge_tree_settings WHERE name = 'index_granularity';


### PR DESCRIPTION
Reported in community Slack:
https://clickhousedb.slack.com/archives/CU478UEQZ/p1771339212410809

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Field `readonly` in `system.merge_tree_settings` now properly reflects that certain merge tree settings (e.g. `index_granularity`) are unconditionally readonly.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.904`
<!-- ch-version-info:end -->