### PR TITLE
Enable apply_row_policy_after_final by default.

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -1482,7 +1482,7 @@ Split parts ranges into intersecting and non intersecting during FINAL optimizat
     DECLARE(Bool, split_intersecting_parts_ranges_into_layers_final, true, R"(
 Split intersecting parts ranges into layers during FINAL optimization
 )", 0) \
-    DECLARE(Bool, apply_row_policy_after_final, false, R"(
+    DECLARE(Bool, apply_row_policy_after_final, true, R"(
 When enabled, row policies and PREWHERE are applied after FINAL processing for *MergeTree tables. (Especially for ReplacingMergeTree)
 When disabled, row policies are applied before FINAL, which can cause different results when the policy
 filters out rows that should be used for deduplication in ReplacingMergeTree or similar engines.

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -50,6 +50,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"use_page_cache_for_local_disks", false, false, "New setting to use userspace page cache for local disks"},
             {"use_page_cache_for_object_storage", false, false, "New setting to use userspace page cache for object storage table functions"},
             {"use_statistics_cache", false, true, "Enable statistics cache"},
+            {"apply_row_policy_after_final", false, true, "Enabling apply_row_policy_after_final by default, as if was in 25.8 before #87303"},
             {"ignore_format_null_for_explain", false, true, "FORMAT Null is now ignored for EXPLAIN queries by default"},
         });
         addSettingsChanges(settings_changes_history, "26.1",

--- a/tests/queries/0_stateless/03742_apply_row_policy_after_final.sql
+++ b/tests/queries/0_stateless/03742_apply_row_policy_after_final.sql
@@ -10,6 +10,7 @@ INSERT INTO tab VALUES (1, 'aaa', 1), (2, 'bbb', 1);
 INSERT INTO tab VALUES (1, 'ccc', 2);
 
 SELECT '= no row policy =';
+SET apply_row_policy_after_final = 0;
 SELECT '--- raw';
 SELECT * FROM tab ORDER BY x, version;
 SELECT '--- final';

--- a/tests/queries/0_stateless/03915_row_policy_should_respect_final_by_default.reference
+++ b/tests/queries/0_stateless/03915_row_policy_should_respect_final_by_default.reference
@@ -1,0 +1,10 @@
+-- { echo ON }
+-- By default, POW POLICY is applied after final. Result should be empty.
+select * from final_row_policy FINAL;
+-- Setting optimize_move_to_prewhere_if_final does not affect the result anymore.
+select * from final_row_policy FINAL settings apply_row_policy_after_final = 0, optimize_move_to_prewhere_if_final=1;
+1	1	1	0	1
+select * from final_row_policy FINAL settings apply_row_policy_after_final = 0, optimize_move_to_prewhere_if_final=0;
+1	1	1	0	1
+select * from final_row_policy FINAL settings apply_row_policy_after_final = 1, optimize_move_to_prewhere_if_final=1;
+select * from final_row_policy FINAL settings apply_row_policy_after_final = 1, optimize_move_to_prewhere_if_final=0;

--- a/tests/queries/0_stateless/03915_row_policy_should_respect_final_by_default.sql
+++ b/tests/queries/0_stateless/03915_row_policy_should_respect_final_by_default.sql
@@ -1,0 +1,18 @@
+drop table if exists final_row_policy SYNC;
+create table final_row_policy (a UInt64, b UInt64, c UInt64, is_deleted UInt8, version UInt64) engine = ReplacingMergeTree(version) order by (a, b, c);
+
+insert into final_row_policy select 1, 1, 1, 0, 1;
+insert into final_row_policy select 1, 1, 1, 1, 2;
+
+DROP ROW POLICY IF EXISTS not_deleted ON final_row_policy;
+CREATE ROW POLICY not_deleted ON final_row_policy AS RESTRICTIVE FOR SELECT USING (is_deleted = 0) TO ALL;
+
+-- { echo ON }
+-- By default, POW POLICY is applied after final. Result should be empty.
+select * from final_row_policy FINAL;
+
+-- Setting optimize_move_to_prewhere_if_final does not affect the result anymore.
+select * from final_row_policy FINAL settings apply_row_policy_after_final = 0, optimize_move_to_prewhere_if_final=1;
+select * from final_row_policy FINAL settings apply_row_policy_after_final = 0, optimize_move_to_prewhere_if_final=0;
+select * from final_row_policy FINAL settings apply_row_policy_after_final = 1, optimize_move_to_prewhere_if_final=1;
+select * from final_row_policy FINAL settings apply_row_policy_after_final = 1, optimize_move_to_prewhere_if_final=0;


### PR DESCRIPTION
### Changelog category (leave one):
- Backward Incompatible Change


### Changelog entry (a [user-readable short description]
Enable `apply_row_policy_after_final` by default. Initially, when `optimize_move_to_prewhere_if_final=0`, both ROW POLICY and PREWHERE respect FINAL and were applied after FINAL. This was broken by #87303, which ignored the `optimize_move_to_prewhere_if_final` for the ROW POLICY filter. To fix this, this PR enables the setting `apply_row_policy_after_final` introduced in #91065. With `apply_row_policy_after_final` enabled, ROW POLICY would continue to respect FINAL by default, as previously. This PR is an incompatible change because it changes the behaviour for `optimize_move_to_prewhere_if_final=1`. Now, to get the ROW POLICY applied before FINAL, `apply_row_policy_after_final` should be used instead of `optimize_move_to_prewhere_if_final`.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Backported to: `25.12.7.3`
<!-- ch-version-info:end -->