### PR TITLE
Fix SEGFAULT in supportsTrivialCountOptimization due to null dereference

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -10181,6 +10181,9 @@ bool MergeTreeData::supportsTrivialCountOptimization(const StorageSnapshotPtr & 
     const auto & snapshot_data = assert_cast<const MergeTreeData::SnapshotData &>(*storage_snapshot->data);
     const auto & mutations_snapshot = snapshot_data.mutations_snapshot;
 
+    if (!mutations_snapshot)
+        return !settings[Setting::apply_mutations_on_fly] && !settings[Setting::apply_patch_parts];
+
     return !mutations_snapshot->hasDataMutations() && !mutations_snapshot->hasPatchParts();
 }
 

--- a/src/Storages/MergeTree/tests/gtest_trivial_count_null_snapshot.cpp
+++ b/src/Storages/MergeTree/tests/gtest_trivial_count_null_snapshot.cpp
@@ -1,0 +1,130 @@
+#include <gtest/gtest.h>
+
+#include <Core/Settings.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <IO/SharedThreadPools.h>
+#include <Parsers/ASTFunction.h>
+#include <Storages/KeyDescription.h>
+#include <Storages/MergeTree/MergeTreeData.h>
+#include <Storages/MergeTree/MergeTreeSettings.h>
+#include <Storages/StorageMergeTree.h>
+#include <Storages/StorageSnapshot.h>
+#include <Common/ThreadStatus.h>
+#include <Common/tests/gtest_global_context.h>
+#include <Common/tests/gtest_global_register.h>
+
+namespace DB::Setting
+{
+extern const SettingsBool apply_mutations_on_fly;
+extern const SettingsBool apply_patch_parts;
+}
+
+/// Test that MergeTreeData::supportsTrivialCountOptimization does not crash
+/// when the storage snapshot has a SnapshotData with null mutations_snapshot.
+///
+/// This is a regression test for a SEGFAULT (Cloud incident #1317) where
+/// `createStorageSnapshot(metadata, context, /*without_data=*/true)` produces
+/// a SnapshotData with `mutations_snapshot = nullptr`, and a code path in the
+/// Planner (subquery building for sets) could pass such a snapshot to
+/// `supportsTrivialCountOptimization`, which dereferenced it unconditionally.
+
+TEST(SupportsTrivialCountOptimization, NullMutationsSnapshot)
+{
+    using namespace DB;
+
+    ThreadStatus thread_status;
+    tryRegisterFunctions();
+    tryRegisterAggregateFunctions();
+
+    getActivePartsLoadingThreadPool().initializeWithDefaultSettingsIfNotInitialized();
+    getOutdatedPartsLoadingThreadPool().initializeWithDefaultSettingsIfNotInitialized();
+    getUnexpectedPartsLoadingThreadPool().initializeWithDefaultSettingsIfNotInitialized();
+    getPartsCleaningThreadPool().initializeWithDefaultSettingsIfNotInitialized();
+
+    const auto & context_holder = getContext();
+    auto context = Context::createCopy(context_holder.context);
+
+    /// Build minimal StorageInMemoryMetadata for a MergeTree with one UInt64 column and tuple() ORDER BY.
+    StorageInMemoryMetadata metadata;
+
+    ColumnsDescription columns;
+    columns.add(ColumnDescription("a", std::make_shared<DataTypeUInt64>()));
+    metadata.setColumns(columns);
+
+    /// ORDER BY tuple() — empty sorting key.
+    auto order_by_ast = makeASTFunction("tuple");
+    metadata.sorting_key = KeyDescription::getSortingKeyFromAST(order_by_ast, metadata.columns, context, {});
+    metadata.primary_key = KeyDescription::getKeyFromAST(order_by_ast, metadata.columns, context);
+    metadata.primary_key.definition_ast = nullptr;
+
+    /// PARTITION BY — empty partition key.
+    metadata.partition_key = KeyDescription::getKeyFromAST(nullptr, metadata.columns, context);
+
+    auto minmax_columns = metadata.getColumnsRequiredForPartitionKey();
+    auto partition_key = metadata.partition_key.expression_list_ast->clone();
+    metadata.minmax_count_projection.emplace(
+        ProjectionDescription::getMinMaxCountProjection(columns, partition_key, minmax_columns, metadata.primary_key, context));
+
+    auto storage_settings = std::make_unique<MergeTreeSettings>(context->getMergeTreeSettings());
+
+    /// Create the StorageMergeTree with ATTACH mode to skip sanity checks.
+    auto storage = std::make_shared<StorageMergeTree>(
+        StorageID("test_db", "test_table"),
+        "store/test_trivial_count/",
+        metadata,
+        LoadingStrictnessLevel::ATTACH,
+        context,
+        /*date_column_name=*/"",
+        MergeTreeData::MergingParams{},
+        std::move(storage_settings));
+
+    auto metadata_snapshot = storage->getInMemoryMetadataPtr();
+
+    /// Case 1: Null StorageSnapshot entirely (already handled by existing code before our fix).
+    {
+        StorageSnapshotPtr null_snapshot = nullptr;
+        EXPECT_NO_THROW(storage->supportsTrivialCountOptimization(null_snapshot, context));
+    }
+
+    /// Case 2: SnapshotData with null mutations_snapshot — this is the crash scenario.
+    /// createStorageSnapshot(metadata, context, /*without_data=*/true) produces exactly this.
+    {
+        auto snapshot_data = std::make_unique<MergeTreeData::SnapshotData>();
+        /// mutations_snapshot is default-constructed to nullptr.
+        ASSERT_EQ(snapshot_data->mutations_snapshot, nullptr);
+
+        auto snapshot = std::make_shared<StorageSnapshot>(*storage, metadata_snapshot, std::move(snapshot_data));
+        EXPECT_NO_THROW(storage->supportsTrivialCountOptimization(snapshot, context));
+
+        /// With default settings (apply_mutations_on_fly=false, apply_patch_parts=true),
+        /// the function should return false because !true == false.
+        auto snapshot_data2 = std::make_unique<MergeTreeData::SnapshotData>();
+        auto snapshot2 = std::make_shared<StorageSnapshot>(*storage, metadata_snapshot, std::move(snapshot_data2));
+        EXPECT_FALSE(storage->supportsTrivialCountOptimization(snapshot2, context));
+    }
+
+    /// Case 3: SnapshotData with null mutations_snapshot and apply_patch_parts=false.
+    {
+        auto modified_context = Context::createCopy(context);
+        modified_context->setSetting("apply_patch_parts", Field(false));
+        modified_context->setSetting("apply_mutations_on_fly", Field(false));
+
+        auto snapshot_data = std::make_unique<MergeTreeData::SnapshotData>();
+        auto snapshot = std::make_shared<StorageSnapshot>(*storage, metadata_snapshot, std::move(snapshot_data));
+        EXPECT_TRUE(storage->supportsTrivialCountOptimization(snapshot, modified_context));
+    }
+
+    /// Case 4: Verify the real getStorageSnapshotWithoutData path produces the same.
+    {
+        auto without_data_snapshot = storage->getStorageSnapshotWithoutData(metadata_snapshot, context);
+        ASSERT_NE(without_data_snapshot, nullptr);
+        ASSERT_NE(without_data_snapshot->data, nullptr);
+
+        const auto & data = assert_cast<const MergeTreeData::SnapshotData &>(*without_data_snapshot->data);
+        EXPECT_EQ(data.mutations_snapshot, nullptr);
+
+        EXPECT_NO_THROW(storage->supportsTrivialCountOptimization(without_data_snapshot, context));
+    }
+
+    storage->flushAndShutdown();
+}

--- a/src/Storages/MergeTree/tests/gtest_trivial_count_null_snapshot.cpp
+++ b/src/Storages/MergeTree/tests/gtest_trivial_count_null_snapshot.cpp
@@ -9,7 +9,7 @@
 #include <Storages/MergeTree/MergeTreeSettings.h>
 #include <Storages/StorageMergeTree.h>
 #include <Storages/StorageSnapshot.h>
-#include <Common/ThreadStatus.h>
+#include <Common/CurrentThread.h>
 #include <Common/tests/gtest_global_context.h>
 #include <Common/tests/gtest_global_register.h>
 
@@ -32,7 +32,7 @@ TEST(SupportsTrivialCountOptimization, NullMutationsSnapshot)
 {
     using namespace DB;
 
-    ThreadStatus thread_status;
+    MainThreadStatus::getInstance();
     tryRegisterFunctions();
     tryRegisterAggregateFunctions();
 


### PR DESCRIPTION
<!-- Fixes issue link part, do not remove -->
## Linked issues
- fixes https://github.com/ClickHouse/clickhouse-core-incidents/issues/1317
<!-- End of fixes issue link part, do not remove -->

Fix SEGFAULT in supportsTrivialCountOptimization due to null dereference

When a StorageSnapshot is created via the 'without data' path (getStorageSnapshotWithoutData), the SnapshotData's mutations_snapshot field is left as nullptr. If supportsTrivialCountOptimization is called with such a snapshot, it dereferences nullptr and crashes.

Add a null-check on mutations_snapshot, falling back to the same settings-based logic already used when storage_snapshot itself is null.

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix SEGFAULT in supportsTrivialCountOptimization due to null dereference

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.962`
- Backported to: `26.1.4.7`, `25.12.7.5`, `25.11.10.11`, `25.8.17.24`, `25.3.15.10`
<!-- ch-version-info:end -->