### PR TITLE
Improve Praktika local run usability

### DIFF
--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -38,7 +38,7 @@ def _start_docker_in_docker():
         )
     retries = 20
     for i in range(retries):
-        if Shell.check("docker info > /dev/null", verbose=True):
+        if Shell.check("docker info > /dev/null 2>&1", verbose=True):
             break
         if i == retries - 1:
             raise RuntimeError(
@@ -506,9 +506,9 @@ tar -czf ./ci/tmp/logs.tar.gz \
                 )  # remove parametrization - does not work with test repeat with --count
         print(f"Parsed {len(targeted_tests)} test names: {targeted_tests}")
 
-    if not Shell.check("docker info > /dev/null", verbose=True):
+    if not Shell.check("docker info > /dev/null 2>&1", verbose=True):
         _start_docker_in_docker()
-    Shell.check("docker info > /dev/null", verbose=True, strict=True)
+    Shell.check("docker info > /dev/null 2>&1", verbose=True, strict=True)
 
     parallel_test_modules, sequential_test_modules = (
         get_parallel_sequential_tests_to_run(

--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -38,7 +38,9 @@ def _start_docker_in_docker():
         )
     retries = 20
     for i in range(retries):
-        if Shell.check("docker info > /dev/null 2>&1", verbose=True):
+        # On last retry, show errors; otherwise suppress them
+        cmd = "docker info > /dev/null" if i == retries - 1 else "docker info > /dev/null 2>&1"
+        if Shell.check(cmd, verbose=True):
             break
         if i == retries - 1:
             raise RuntimeError(
@@ -508,7 +510,7 @@ tar -czf ./ci/tmp/logs.tar.gz \
 
     if not Shell.check("docker info > /dev/null 2>&1", verbose=True):
         _start_docker_in_docker()
-    Shell.check("docker info > /dev/null 2>&1", verbose=True, strict=True)
+    Shell.check("docker info > /dev/null", verbose=True, strict=True)
 
     parallel_test_modules, sequential_test_modules = (
         get_parallel_sequential_tests_to_run(

--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -221,6 +221,17 @@ def get_parallel_sequential_tests_to_run(
     # 1) test suit (e.g. test_directory or test_directory/)
     # 2) test module (e.g. test_directory/test_module or test_directory/test_module.py)
     # 3) test case (e.g. test_directory/test_module.py::test_case or test_directory/test_module::test_case[test_param])
+    def normalize_test_path(test_arg: str) -> str:
+        """Normalize test path by removing integration test directory prefixes."""
+        # Handle: tests/integration/, integration/, ./tests/integration/, or full paths
+        if "tests/integration/" in test_arg:
+            # Extract everything after tests/integration/
+            test_arg = test_arg.split("tests/integration/", 1)[1]
+        elif test_arg.startswith("integration/"):
+            # Handle integration/ prefix
+            test_arg = test_arg[len("integration/"):]
+        return test_arg
+
     def test_match(test_file: str, test_arg: str) -> bool:
         if "/" not in test_arg:
             return f"{test_arg}/" in test_file
@@ -232,14 +243,16 @@ def get_parallel_sequential_tests_to_run(
     parallel_tests = []
     sequential_tests = []
     for test_arg in args_test:
+        # Normalize the test path first
+        normalized_test_arg = normalize_test_path(test_arg)
         matched = False
         for test_file in parallel_test_modules:
-            if test_match(test_file, test_arg):
-                parallel_tests.append(test_arg)
+            if test_match(test_file, normalized_test_arg):
+                parallel_tests.append(normalized_test_arg)
                 matched = True
         for test_file in sequential_test_modules:
-            if test_match(test_file, test_arg):
-                sequential_tests.append(test_arg)
+            if test_match(test_file, normalized_test_arg):
+                sequential_tests.append(normalized_test_arg)
                 matched = True
         if not no_strict:
             assert matched, f"Test [{test_arg}] not found"
@@ -249,8 +262,18 @@ def get_parallel_sequential_tests_to_run(
 
 def tail(filepath: str, buff_len: int = 1024) -> List[str]:
     with open(filepath, "rb") as f:
-        f.seek(-buff_len, os.SEEK_END)
-        f.readline()
+        # Get file size to avoid seeking before start of file
+        f.seek(0, os.SEEK_END)
+        file_size = f.tell()
+
+        if file_size <= buff_len:
+            # File is smaller than buffer, read from beginning
+            f.seek(0)
+        else:
+            # File is larger, seek from end
+            f.seek(-buff_len, os.SEEK_END)
+            f.readline()  # Skip partial line
+
         data = f.read()
         return data.decode(errors="replace")
 

--- a/ci/praktika/digest.py
+++ b/ci/praktika/digest.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import List
 
 from .docker import Docker
+from .info import Info
 from .job import Job
 from .settings import Settings
 from .utils import Shell, Utils
@@ -107,7 +108,8 @@ class Digest:
         :param docker_config: Docker.Config to calculate digest for
         :return:
         """
-        print(f"Calculate digest for docker [{docker_config.name}]")
+        if not Info().is_local_run:
+            print(f"Calculate digest for docker [{docker_config.name}]")
         paths = Utils.traverse_path(docker_config.path, sorted=True)
         if not hash_md5:
             hash_md5 = hashlib.md5()
@@ -116,9 +118,10 @@ class Digest:
         for dependency_name in docker_config.depends_on:
             for dependency_config in dependency_configs:
                 if dependency_config.name == dependency_name:
-                    print(
-                        f"Add docker [{dependency_config.name}] as dependency for docker [{docker_config.name}] digest calculation"
-                    )
+                    if not Info().is_local_run:
+                        print(
+                            f"Add docker [{dependency_config.name}] as dependency for docker [{docker_config.name}] digest calculation"
+                        )
                     dependencies.append(dependency_config)
 
         for dependency in dependencies:

--- a/ci/praktika/digest.py
+++ b/ci/praktika/digest.py
@@ -7,10 +7,19 @@ from pathlib import Path
 from typing import List
 
 from .docker import Docker
-from .info import Info
 from .job import Job
 from .settings import Settings
 from .utils import Shell, Utils
+
+
+def _is_local_run():
+    """Check if running locally. Returns False if can't determine (e.g., during workflow generation)."""
+    try:
+        from .info import Info
+        return Info().is_local_run
+    except Exception:
+        # During workflow generation, Info can't be initialized - treat as CI mode
+        return False
 
 
 class Digest:
@@ -108,7 +117,7 @@ class Digest:
         :param docker_config: Docker.Config to calculate digest for
         :return:
         """
-        if not Info().is_local_run:
+        if not _is_local_run():
             print(f"Calculate digest for docker [{docker_config.name}]")
         paths = Utils.traverse_path(docker_config.path, sorted=True)
         if not hash_md5:
@@ -118,7 +127,7 @@ class Digest:
         for dependency_name in docker_config.depends_on:
             for dependency_config in dependency_configs:
                 if dependency_config.name == dependency_name:
-                    if not Info().is_local_run:
+                    if not _is_local_run():
                         print(
                             f"Add docker [{dependency_config.name}] as dependency for docker [{docker_config.name}] digest calculation"
                         )

--- a/ci/praktika/digest.py
+++ b/ci/praktika/digest.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import List
 
 from .docker import Docker
+from .info import Info
 from .job import Job
 from .settings import Settings
 from .utils import Shell, Utils
@@ -15,7 +16,6 @@ from .utils import Shell, Utils
 def _is_local_run():
     """Check if running locally. Returns False if can't determine (e.g., during workflow generation)."""
     try:
-        from .info import Info
         return Info().is_local_run
     except Exception:
         # During workflow generation, Info can't be initialized - treat as CI mode

--- a/ci/praktika/mangle.py
+++ b/ci/praktika/mangle.py
@@ -6,6 +6,7 @@ from typing import List
 from praktika import Workflow
 
 from . import Job
+from .info import Info
 from .settings import Settings
 from .utils import Utils
 
@@ -13,7 +14,6 @@ from .utils import Utils
 def _is_local_run():
     """Check if running locally. Returns False if can't determine (e.g., during workflow generation)."""
     try:
-        from .info import Info
         return Info().is_local_run
     except Exception:
         # During workflow generation, Info can't be initialized - treat as CI mode
@@ -61,9 +61,7 @@ def _get_workflows(
                 continue
         elif py_file.name != Settings.DEFAULT_LOCAL_TEST_WORKFLOW:
             if not _is_local_run():
-                print(
-                    f"Skip [{py_file.name}]"
-                )
+                print(f"Skip [{py_file.name}]")
             continue
         module_name = py_file.name.removeprefix(".py")
         spec = importlib.util.spec_from_file_location(

--- a/ci/praktika/mangle.py
+++ b/ci/praktika/mangle.py
@@ -217,7 +217,7 @@ def _update_workflow_with_native_jobs(workflow):
     if workflow._enabled_workflow_config():
         from .native_jobs import _workflow_config_job
 
-        if not Info().is_local_run:
+        if not _is_local_run():
             print(f"Enable native job [{_workflow_config_job.name}] for [{workflow.name}]")
         aux_job = copy.deepcopy(_workflow_config_job)
         workflow.jobs.insert(0, aux_job)
@@ -232,7 +232,7 @@ def _update_workflow_with_native_jobs(workflow):
     ):
         from .native_jobs import _final_job
 
-        if not Info().is_local_run:
+        if not _is_local_run():
             print(f"Enable native job [{_final_job.name}] for [{workflow.name}]")
         aux_job = copy.deepcopy(_final_job)
         for job in workflow.jobs:

--- a/ci/praktika/mangle.py
+++ b/ci/praktika/mangle.py
@@ -6,9 +6,18 @@ from typing import List
 from praktika import Workflow
 
 from . import Job
-from .info import Info
 from .settings import Settings
 from .utils import Utils
+
+
+def _is_local_run():
+    """Check if running locally. Returns False if can't determine (e.g., during workflow generation)."""
+    try:
+        from .info import Info
+        return Info().is_local_run
+    except Exception:
+        # During workflow generation, Info can't be initialized - treat as CI mode
+        return False
 
 
 def _get_workflows(
@@ -51,7 +60,7 @@ def _get_workflows(
             if file and str(file) not in str(py_file):
                 continue
         elif py_file.name != Settings.DEFAULT_LOCAL_TEST_WORKFLOW:
-            if not Info().is_local_run:
+            if not _is_local_run():
                 print(
                     f"Skip [{py_file.name}]"
                 )
@@ -167,20 +176,20 @@ def _update_workflow_with_native_jobs(workflow):
 
         if not Settings.ENABLE_MULTIPLATFORM_DOCKER_IN_ONE_JOB:
             aux_job = copy.deepcopy(_docker_build_amd_linux_job)
-            if not Info().is_local_run:
+            if not _is_local_run():
                 print(f"Enable praktika job [{aux_job.name}] for [{workflow.name}]")
             if workflow.enable_cache:
-                if not Info().is_local_run:
+                if not _is_local_run():
                     print(f"Add automatic digest config for [{aux_job.name}] job")
                 aux_job.digest_config = docker_digest_config
             workflow.jobs.insert(len(docker_job_names), aux_job)
             docker_job_names.append(aux_job.name)
 
             aux_job = copy.deepcopy(_docker_build_arm_linux_job)
-            if not Info().is_local_run:
+            if not _is_local_run():
                 print(f"Enable praktika job [{aux_job.name}] for [{workflow.name}]")
             if workflow.enable_cache:
-                if not Info().is_local_run:
+                if not _is_local_run():
                     print(f"Add automatic digest config for [{aux_job.name}] job")
                 aux_job.digest_config = docker_digest_config
             workflow.jobs.insert(len(docker_job_names), aux_job)
@@ -191,10 +200,10 @@ def _update_workflow_with_native_jobs(workflow):
             or Settings.ENABLE_MULTIPLATFORM_DOCKER_IN_ONE_JOB
         ):
             aux_job = copy.deepcopy(_docker_build_manifest_job)
-            if not Info().is_local_run:
+            if not _is_local_run():
                 print(f"Enable praktika job [{aux_job.name}] for [{workflow.name}]")
             if workflow.enable_cache:
-                if not Info().is_local_run:
+                if not _is_local_run():
                     print(f"Add automatic digest config for [{aux_job.name}] job")
                 aux_job.digest_config = docker_digest_config
             aux_job.requires = copy.deepcopy(docker_job_names)

--- a/ci/praktika/mangle.py
+++ b/ci/praktika/mangle.py
@@ -6,6 +6,7 @@ from typing import List
 from praktika import Workflow
 
 from . import Job
+from .info import Info
 from .settings import Settings
 from .utils import Utils
 
@@ -50,9 +51,10 @@ def _get_workflows(
             if file and str(file) not in str(py_file):
                 continue
         elif py_file.name != Settings.DEFAULT_LOCAL_TEST_WORKFLOW:
-            print(
-                f"Skip [{py_file.name}]"
-            )
+            if not Info().is_local_run:
+                print(
+                    f"Skip [{py_file.name}]"
+                )
             continue
         module_name = py_file.name.removeprefix(".py")
         spec = importlib.util.spec_from_file_location(
@@ -165,17 +167,21 @@ def _update_workflow_with_native_jobs(workflow):
 
         if not Settings.ENABLE_MULTIPLATFORM_DOCKER_IN_ONE_JOB:
             aux_job = copy.deepcopy(_docker_build_amd_linux_job)
-            print(f"Enable praktika job [{aux_job.name}] for [{workflow.name}]")
+            if not Info().is_local_run:
+                print(f"Enable praktika job [{aux_job.name}] for [{workflow.name}]")
             if workflow.enable_cache:
-                print(f"Add automatic digest config for [{aux_job.name}] job")
+                if not Info().is_local_run:
+                    print(f"Add automatic digest config for [{aux_job.name}] job")
                 aux_job.digest_config = docker_digest_config
             workflow.jobs.insert(len(docker_job_names), aux_job)
             docker_job_names.append(aux_job.name)
 
             aux_job = copy.deepcopy(_docker_build_arm_linux_job)
-            print(f"Enable praktika job [{aux_job.name}] for [{workflow.name}]")
+            if not Info().is_local_run:
+                print(f"Enable praktika job [{aux_job.name}] for [{workflow.name}]")
             if workflow.enable_cache:
-                print(f"Add automatic digest config for [{aux_job.name}] job")
+                if not Info().is_local_run:
+                    print(f"Add automatic digest config for [{aux_job.name}] job")
                 aux_job.digest_config = docker_digest_config
             workflow.jobs.insert(len(docker_job_names), aux_job)
             docker_job_names.append(aux_job.name)
@@ -185,9 +191,11 @@ def _update_workflow_with_native_jobs(workflow):
             or Settings.ENABLE_MULTIPLATFORM_DOCKER_IN_ONE_JOB
         ):
             aux_job = copy.deepcopy(_docker_build_manifest_job)
-            print(f"Enable praktika job [{aux_job.name}] for [{workflow.name}]")
+            if not Info().is_local_run:
+                print(f"Enable praktika job [{aux_job.name}] for [{workflow.name}]")
             if workflow.enable_cache:
-                print(f"Add automatic digest config for [{aux_job.name}] job")
+                if not Info().is_local_run:
+                    print(f"Add automatic digest config for [{aux_job.name}] job")
                 aux_job.digest_config = docker_digest_config
             aux_job.requires = copy.deepcopy(docker_job_names)
             workflow.jobs.insert(len(docker_job_names), aux_job)
@@ -200,7 +208,8 @@ def _update_workflow_with_native_jobs(workflow):
     if workflow._enabled_workflow_config():
         from .native_jobs import _workflow_config_job
 
-        print(f"Enable native job [{_workflow_config_job.name}] for [{workflow.name}]")
+        if not Info().is_local_run:
+            print(f"Enable native job [{_workflow_config_job.name}] for [{workflow.name}]")
         aux_job = copy.deepcopy(_workflow_config_job)
         workflow.jobs.insert(0, aux_job)
         for job in workflow.jobs[1:]:
@@ -214,7 +223,8 @@ def _update_workflow_with_native_jobs(workflow):
     ):
         from .native_jobs import _final_job
 
-        print(f"Enable native job [{_final_job.name}] for [{workflow.name}]")
+        if not Info().is_local_run:
+            print(f"Enable native job [{_final_job.name}] for [{workflow.name}]")
         aux_job = copy.deepcopy(_final_job)
         for job in workflow.jobs:
             aux_job.requires.append(job.name)

--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -19,8 +19,7 @@ from .settings import Settings
 from .usage import ComputeUsage, StorageUsage
 from .utils import ContextManager, MetaClasses, Shell, Utils
 
-if TYPE_CHECKING:
-    from .info import Info
+from .info import Info
 
 
 class _Colors:
@@ -893,11 +892,6 @@ class Result(MetaClasses.Serializable):
         Returns:
             Formatted string representation of the result
         """
-        # Import here to avoid circular dependency
-        import os
-        import sys
-        from .info import Info
-
         add_frame = not output
         sub_indent = indent + "  "
 

--- a/tests/integration/pytest.ini
+++ b/tests/integration/pytest.ini
@@ -21,5 +21,7 @@ markers =
 addopts =
     -m 'not long_run'
 ; 'The asyncore module is deprecated' comes from casandra driver
+; 'TripleDES has been moved' comes from paramiko library
 filterwarnings =
     ignore:The asyncore module is deprecated:DeprecationWarning
+    ignore:TripleDES has been moved:cryptography.utils.CryptographyDeprecationWarning


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Improve Praktika local run usability


## Summary

This PR significantly improves the user experience when running Praktika (integration tests) locally by reducing noise and improving visibility of test results.

### Changes

1. **Flexible test path formats** - Accept test paths in multiple formats:
   - `test_dir/test.py` (original)
   - `tests/integration/test_dir/test.py` (full path from repo root)
   - `integration/test_dir/test.py` (relative from tests/)
   - `/absolute/path/tests/integration/test_dir/test.py` (absolute paths)
   
   This allows users to copy-paste paths directly from file explorers or error messages.

2. **Suppress noisy warnings**:
   - TripleDES deprecation warnings from `paramiko` library
   - Docker-in-Docker security warnings
   - These warnings are not actionable and clutter test output

3. **Reduce verbosity for local runs** - Hide debug messages that are only relevant in CI:
   - "Skip [workflow.py]" messages when loading workflows
   - "Enable praktika job [...]" messages
   - "Calculate digest for docker [...]" messages
   - "Add docker [...] as dependency" messages
   
   These messages are still shown in CI runs where they provide valuable debugging information.

4. **Colored output for test results** - Add visual feedback in local runs:
   - Green for successful tests
   - Red for failed/error tests
   - Yellow for other statuses
   - Capitalize status text (Success, Failed, etc.)
   - Hide empty brackets when result has no name
   - Colors only shown in local runs; CI output remains plain text

### Example

**Before:**
```
Skip [hourly.py]
Skip [optimize_toolchain.py]
...
Calculate digest for docker [clickhouse/style-test]
...
[DEPRECATION NOTICE]: API is accessible on http://0.0.0.0:2375 without encryption
...
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
success []
  | Failures: 0/1
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
```

**After:**
```
WARNING: 'requests' module is not installed. CIDB will not work - ok for local runs only.
Read workflow configs from [pull_request.py], workflow name [PR]
Going to run job [Integration tests (amd_tsan, 1/6)], workflow [PR]
...
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
Success
  | Failures: 0/1
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
```
(with green coloring on the Success line and borders)

## Test plan
- [x] Tested locally with various test path formats
- [x] Verified warnings are suppressed
- [x] Verified colored output works in local runs
- [x] Verified verbosity is reduced in local runs
- [x] CI behavior unchanged (no colors, all debug messages still present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.969`
<!-- ch-version-info:end -->