### PR TITLE
Add dns_allow_resolve_names_to_ipv4/ipv6 to changeable settings

### DIFF
--- a/src/Common/DNSResolver.cpp
+++ b/src/Common/DNSResolver.cpp
@@ -276,6 +276,16 @@ void DNSResolver::setFilterSettings(bool dns_allow_resolve_names_to_ipv4, bool d
     addressFilter->setSettings(dns_allow_resolve_names_to_ipv4, dns_allow_resolve_names_to_ipv6);
 }
 
+bool DNSResolver::getFilterIPv4() const
+{
+    return addressFilter->settings.get()->dns_allow_resolve_names_to_ipv4;
+}
+
+bool DNSResolver::getFilterIPv6() const
+{
+    return addressFilter->settings.get()->dns_allow_resolve_names_to_ipv6;
+}
+
 DNSResolver::IPAddresses DNSResolver::resolveHostAllInOriginOrder(const std::string & host)
 {
     if (impl->disable_cache)

--- a/src/Common/DNSResolver.h
+++ b/src/Common/DNSResolver.h
@@ -72,6 +72,9 @@ public:
 
     void setFilterSettings(bool dns_allow_resolve_names_to_ipv4, bool dns_allow_resolve_names_to_ipv6);
 
+    bool getFilterIPv4() const;
+    bool getFilterIPv6() const;
+
     /// Returns a copy of cache entries
     std::vector<std::pair<std::string, CacheEntry>> cacheEntries() const;
 

--- a/src/Core/ServerSettings.cpp
+++ b/src/Core/ServerSettings.cpp
@@ -19,6 +19,8 @@
 #include <Common/Config/ConfigReloader.h>
 #include <Common/MemoryTracker.h>
 
+#include <Common/DNSResolver.h>
+
 #include <Poco/Util/AbstractConfiguration.h>
 
 
@@ -1768,6 +1770,9 @@ void ServerSettings::dumpToSystemServerSettingsColumns(ServerSettingColumnsParam
              {getFormatParsingThreadPool().isInitialized() ? std::to_string(getFormatParsingThreadPool().get().getQueueSize()) : "0", ChangeableWithoutRestart::Yes}},
 
             {"abort_on_logical_error", {std::to_string(DB::abort_on_logical_error), ChangeableWithoutRestart::Yes}},
+
+            {"dns_allow_resolve_names_to_ipv4", {std::to_string(DNSResolver::instance().getFilterIPv4()), ChangeableWithoutRestart::Yes}},
+            {"dns_allow_resolve_names_to_ipv6", {std::to_string(DNSResolver::instance().getFilterIPv6()), ChangeableWithoutRestart::Yes}},
     };
 
     if (context->areBackgroundExecutorsInitialized())


### PR DESCRIPTION
Whilst rolling one of these settings out in Cloudflare, I saw from behaviour and preprocessed_configs that the change had been applied without a Clickhouse restart, but system.server_settings still showed the default values and that the setting hadn't changed:

```
SELECT
    name,
    value,
    default,
    changed,
    description,
    type
FROM system.server_settings
WHERE name = 'dns_allow_resolve_names_to_ipv4'

Query id: b51e15e1-c854-49de-929e-a30ed5ce1c91

   ┌─name────────────────────────────┬─value─┬─default─┬─changed─┬─description─────────────────────────────┬─type─┐
1. │ dns_allow_resolve_names_to_ipv4 │ 1     │ 1       │       0 │ Allows resolve names to ipv4 addresses. │ Bool │
   └─────────────────────────────────┴───────┴─────────┴─────────┴─────────────────────────────────────────┴──────┘

1 row in set. Elapsed: 0.003 sec.
```

This adds these settings to changeable settings so system tables look correct.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)





<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.915`
<!-- ch-version-info:end -->