### PR TITLE
Disable sanitizers for `03911_limit_max_streams_with_split_parts_ranges_into_intersecting_and_non_intersecting_final`

### DIFF
--- a/tests/queries/0_stateless/03911_limit_max_streams_with_split_parts_ranges_into_intersecting_and_non_intersecting_final.sql
+++ b/tests/queries/0_stateless/03911_limit_max_streams_with_split_parts_ranges_into_intersecting_and_non_intersecting_final.sql
@@ -1,5 +1,6 @@
--- Tags: long
+-- Tags: long, no-sanitizers
 -- long: times out in private
+-- no-sanitizers: sometimes times out in private :(
 
 DROP TABLE IF EXISTS t;
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

---

Example report: https://d1k2gkhrlfqv31.cloudfront.net/clickhouse-test-reports-private/json.html?PR=49497&sha=642e1d66970d2492ce625b885a8815620c28e92a&name_0=PR&name_1=Stateless%20tests%20%28amd_msan%2C%20distributed%20cache%2C%20meta%20storage%20in%20keeper%2C%20s3%20storage%2C%20parallel%2C%203%2F3%29&name_1=Stateless%20tests%20%28amd_msan%2C%20distributed%20cache%2C%20meta%20storage%20in%20keeper%2C%20s3%20storage%2C%20parallel%2C%203%2F3%29



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.903`
<!-- ch-version-info:end -->