### PR TITLE
Set thread's query id for internal queries

### DIFF
--- a/src/Common/ThreadStatus.cpp
+++ b/src/Common/ThreadStatus.cpp
@@ -196,6 +196,11 @@ ContextPtr ThreadStatus::getGlobalContext() const
     return global_context.lock();
 }
 
+void ThreadStatus::setQueryContext(ContextWeakPtr new_query_context) noexcept
+{
+    query_context = std::move(new_query_context);
+}
+
 void ThreadGroup::attachInternalTextLogsQueue(const InternalTextLogsQueuePtr & logs_queue, LogsLevel logs_level)
 {
     std::lock_guard lock(mutex);

--- a/src/Common/ThreadStatus.cpp
+++ b/src/Common/ThreadStatus.cpp
@@ -169,9 +169,10 @@ ThreadGroupPtr ThreadStatus::getThreadGroup() const
     return thread_group;
 }
 
-void ThreadStatus::setQueryId(std::string && new_query_id) noexcept
+void ThreadStatus::setQueryId(std::string && new_query_id, bool assert_empty) noexcept
 {
-    chassert(query_id.empty());
+    if (assert_empty)
+        chassert(query_id.empty());
     query_id = std::move(new_query_id);
 }
 

--- a/src/Common/ThreadStatus.h
+++ b/src/Common/ThreadStatus.h
@@ -75,8 +75,9 @@ public:
     /// The first thread created this thread group
     const UInt64 master_thread_id;
 
-    /// Set up at creation, no race when reading
-    const ContextWeakPtr query_context;
+    /// Set up at creation; may be temporarily swapped for internal queries (see executeQueryImpl).
+    /// Access is protected by `mutex` since it can be swapped.
+    ContextWeakPtr query_context;
     const ContextWeakPtr global_context;
 
     const FatalErrorCallback fatal_error_callback;
@@ -295,6 +296,8 @@ public:
 
     ContextPtr getQueryContext() const;
     ContextPtr getGlobalContext() const;
+
+    void setQueryContext(ContextWeakPtr new_query_context) noexcept;
 
     /// Attaches slave thread to existing thread group
     void attachToGroup(const ThreadGroupPtr & thread_group_, bool check_detached = true);

--- a/src/Common/ThreadStatus.h
+++ b/src/Common/ThreadStatus.h
@@ -289,7 +289,7 @@ public:
 
     ThreadGroupPtr getThreadGroup() const;
 
-    void setQueryId(std::string && new_query_id) noexcept;
+    void setQueryId(std::string && new_query_id, bool assert_empty = true) noexcept;
     void clearQueryId() noexcept;
     const String & getQueryId() const;
 

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -1084,16 +1084,37 @@ static BlockIO executeQueryImpl(
 {
     const bool internal = flags.internal;
 
-    /// For internal queries, switch the thread's query_id so that the query profiler attributes traces correctly.
-    std::function<void()> restore_query_id;
+    /// For internal queries, temporarily switch the query_id and query_context on both the current thread
+    /// and the thread group, so that the query profiler and any worker threads spawned by the pipeline
+    /// attribute traces to the internal query rather than the outer one.
+    /// The state is restored when the internal query's BlockIO calls onFinish/onException.
+    std::function<void()> restore_internal_query_state;
     if (internal && current_thread)
     {
         String prev_query_id = current_thread->getQueryId();
         current_thread->setQueryId(String(context->getCurrentQueryId()), /*assert_empty=*/ false);
-        restore_query_id = [prev_id = std::move(prev_query_id)]() mutable
+        current_thread->setQueryContext(context);
+
+        auto thread_group = CurrentThread::getGroup();
+        ContextWeakPtr prev_group_context;
+        if (thread_group)
+        {
+            prev_group_context = thread_group->query_context;
+            thread_group->query_context = context;
+        }
+
+        restore_internal_query_state = [
+            prev_query_id = std::move(prev_query_id),
+            prev_group_context = std::move(prev_group_context),
+            thread_group = std::move(thread_group)]() mutable
         {
             if (current_thread)
-                current_thread->setQueryId(std::move(prev_id));
+            {
+                current_thread->setQueryId(std::move(prev_query_id), /*assert_empty=*/ false);
+                current_thread->setQueryContext(prev_group_context);
+            }
+            if (thread_group)
+                thread_group->query_context = std::move(prev_group_context);
         };
     }
 
@@ -1906,7 +1927,7 @@ static BlockIO executeQueryImpl(
                                     // Need to be cached, since will be changed after complete()
                                     pulling_pipeline = pipeline.pulling(),
                                     query_span,
-                                    my_restore_query_id = restore_query_id](const QueryPipelineFinalizedInfo & query_pipeline_finalized_info, std::chrono::system_clock::time_point finish_time) mutable
+                                    my_restore_internal_query_state = restore_internal_query_state](const QueryPipelineFinalizedInfo & query_pipeline_finalized_info, std::chrono::system_clock::time_point finish_time) mutable
             {
                 logQueryFinishImpl(elem, context, out_ast, query_pipeline_finalized_info, pulling_pipeline, query_span, query_result_cache_usage, internal, finish_time);
 
@@ -1915,12 +1936,12 @@ static BlockIO executeQueryImpl(
                     implicit_tcl_executor->commit(context);
                 }
 
-                if (my_restore_query_id)
-                    my_restore_query_id();
+                if (my_restore_internal_query_state)
+                    my_restore_internal_query_state();
             };
 
             auto exception_callback =
-                [start_watch, elem, context, out_ast, internal, my_quota(quota), implicit_tcl_executor, query_span, my_restore_query_id = restore_query_id](bool log_error) mutable
+                [start_watch, elem, context, out_ast, internal, my_quota(quota), implicit_tcl_executor, query_span, my_restore_internal_query_state = restore_internal_query_state](bool log_error) mutable
             {
                 if (implicit_tcl_executor->transactionRunning())
                 {
@@ -1940,8 +1961,8 @@ static BlockIO executeQueryImpl(
 
                 logQueryException(elem, context, start_watch, out_ast, query_span, internal, log_error);
 
-                if (my_restore_query_id)
-                    my_restore_query_id();
+                if (my_restore_internal_query_state)
+                    my_restore_internal_query_state();
             };
 
             res.finalize_query_pipeline = std::move(finish_callback_finalize_pipeline);
@@ -1951,8 +1972,8 @@ static BlockIO executeQueryImpl(
     }
     catch (...)
     {
-        if (restore_query_id)
-            restore_query_id();
+        if (restore_internal_query_state)
+            restore_internal_query_state();
 
         if (implicit_tcl_executor->transactionRunning())
         {

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -1084,6 +1084,19 @@ static BlockIO executeQueryImpl(
 {
     const bool internal = flags.internal;
 
+    /// For internal queries, switch the thread's query_id so that the query profiler attributes traces correctly.
+    std::function<void()> restore_query_id;
+    if (internal && current_thread)
+    {
+        String prev_query_id = current_thread->getQueryId();
+        current_thread->setQueryId(String(context->getCurrentQueryId()), /*assert_empty=*/ false);
+        restore_query_id = [prev_id = std::move(prev_query_id)]() mutable
+        {
+            if (current_thread)
+                current_thread->setQueryId(std::move(prev_id));
+        };
+    }
+
     /// query_span is a special span, when this function exits, it's lifetime is not ended, but ends when the query finishes.
     /// Some internal queries might call this function recursively by setting 'internal' parameter to 'true',
     /// to make sure SpanHolders in current stack ends in correct order, we disable this span for these internal queries
@@ -1892,7 +1905,8 @@ static BlockIO executeQueryImpl(
                                     implicit_tcl_executor,
                                     // Need to be cached, since will be changed after complete()
                                     pulling_pipeline = pipeline.pulling(),
-                                    query_span](const QueryPipelineFinalizedInfo & query_pipeline_finalized_info, std::chrono::system_clock::time_point finish_time) mutable
+                                    query_span,
+                                    my_restore_query_id = restore_query_id](const QueryPipelineFinalizedInfo & query_pipeline_finalized_info, std::chrono::system_clock::time_point finish_time) mutable
             {
                 logQueryFinishImpl(elem, context, out_ast, query_pipeline_finalized_info, pulling_pipeline, query_span, query_result_cache_usage, internal, finish_time);
 
@@ -1900,10 +1914,13 @@ static BlockIO executeQueryImpl(
                 {
                     implicit_tcl_executor->commit(context);
                 }
+
+                if (my_restore_query_id)
+                    my_restore_query_id();
             };
 
             auto exception_callback =
-                [start_watch, elem, context, out_ast, internal, my_quota(quota), implicit_tcl_executor, query_span](bool log_error) mutable
+                [start_watch, elem, context, out_ast, internal, my_quota(quota), implicit_tcl_executor, query_span, my_restore_query_id = restore_query_id](bool log_error) mutable
             {
                 if (implicit_tcl_executor->transactionRunning())
                 {
@@ -1922,6 +1939,9 @@ static BlockIO executeQueryImpl(
                 }
 
                 logQueryException(elem, context, start_watch, out_ast, query_span, internal, log_error);
+
+                if (my_restore_query_id)
+                    my_restore_query_id();
             };
 
             res.finalize_query_pipeline = std::move(finish_callback_finalize_pipeline);
@@ -1931,6 +1951,9 @@ static BlockIO executeQueryImpl(
     }
     catch (...)
     {
+        if (restore_query_id)
+            restore_query_id();
+
         if (implicit_tcl_executor->transactionRunning())
         {
             implicit_tcl_executor->rollback(context);

--- a/tests/queries/0_stateless/03702_show_kill_logging_internal_queries.sh
+++ b/tests/queries/0_stateless/03702_show_kill_logging_internal_queries.sh
@@ -6,14 +6,16 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 # Test that internal queries are logged correctly
 
-$CLICKHOUSE_CLIENT --query "SHOW TABLES FORMAT Null"
-$CLICKHOUSE_CLIENT --query "SHOW ENGINES FORMAT Null"
-$CLICKHOUSE_CLIENT --query "SHOW FUNCTIONS LIKE 'plus' FORMAT Null"
-$CLICKHOUSE_CLIENT --query "SHOW SETTING max_threads FORMAT Null"
-$CLICKHOUSE_CLIENT --query "KILL QUERY WHERE query_id = 'nonexistent' SYNC" &>/dev/null
+$CLICKHOUSE_CLIENT --query "SHOW TABLES FORMAT Null" --trace_profile_events 1 --trace_profile_events_list 'Query'
+$CLICKHOUSE_CLIENT --query "SHOW ENGINES FORMAT Null" --trace_profile_events 1 --trace_profile_events_list 'Query'
+$CLICKHOUSE_CLIENT --query "SHOW FUNCTIONS LIKE 'plus' FORMAT Null" --trace_profile_events 1 --trace_profile_events_list 'Query'
+$CLICKHOUSE_CLIENT --query "SHOW SETTING max_threads FORMAT Null" --trace_profile_events 1 --trace_profile_events_list 'Query'
+$CLICKHOUSE_CLIENT --query "KILL QUERY WHERE query_id = 'nonexistent' SYNC" --trace_profile_events 1 --trace_profile_events_list 'Query' &>/dev/null
 
-$CLICKHOUSE_CLIENT --query "SYSTEM FLUSH LOGS query_log"
+$CLICKHOUSE_CLIENT --query "SYSTEM FLUSH LOGS query_log, trace_log"
 
+# Verify that the internal queries have been logged to system.query_log
+# and that trace_log entries carry the internal query's query_id (not the outer query's).
 $CLICKHOUSE_CLIENT --query "
 SELECT
     countIf(query LIKE '%system.tables%' AND type = 'QueryStart'),
@@ -27,4 +29,9 @@ SELECT
     countIf(query LIKE '%system.processes%' AND type = 'QueryStart'),
     countIf(query LIKE '%system.processes%' AND type = 'QueryFinish')
 FROM system.query_log
-WHERE is_internal = 1 AND current_database = currentDatabase()"
+WHERE is_internal = 1 AND current_database = currentDatabase()
+  AND query_id IN (
+    SELECT query_id
+    FROM system.trace_log
+    WHERE trace_type = 'ProfileEvent' AND event = 'Query'
+  )"


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
In https://github.com/ClickHouse/ClickHouse/pull/83277, we added logging of internal queries into `system.query_log`. The change, however, did not set `TheadStatus::query_id` to the internal query's id and did not initialize query profiling. This means that for internal queries, either there are no logs in `system.trace_log` at all (if internal queries don't have corresponding non-internal ones) or the logs have `query_id` equal to the corresponding non-internal query.

This change makes sure that in both cases there are logs in `system.trace_log` and that the logs have `query_id` equal to the internal query's id.


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
