### PR TITLE
Do not merge NonJoined streams inside the ConcurrentHashJoin

### DIFF
--- a/src/Interpreters/ConcurrentHashJoin.cpp
+++ b/src/Interpreters/ConcurrentHashJoin.cpp
@@ -285,6 +285,9 @@ bool ConcurrentHashJoin::addBlockToJoin(const Block & right_block_, bool check_l
                 auto [block, selector] = std::move(dispatched_block).detachData();
                 bool limit_exceeded = !hash_join->data->addBlockToJoin(block, std::move(selector), check_limits);
 
+                cached_slot_sizes[i].row_count.store(hash_join->data->getTotalRowCount(), std::memory_order_relaxed);
+                cached_slot_sizes[i].byte_count.store(hash_join->data->getTotalByteCount(), std::memory_order_relaxed);
+
                 dispatched_block = {};
                 blocks_left--;
 
@@ -408,22 +411,16 @@ const Block & ConcurrentHashJoin::getTotals() const
 size_t ConcurrentHashJoin::getTotalRowCount() const
 {
     size_t res = 0;
-    for (const auto & hash_join : hash_joins)
-    {
-        std::lock_guard lock(hash_join->mutex);
-        res += hash_join->data->getTotalRowCount();
-    }
+    for (size_t i = 0; i < slots; ++i)
+        res += cached_slot_sizes[i].row_count.load(std::memory_order_relaxed);
     return res;
 }
 
 size_t ConcurrentHashJoin::getTotalByteCount() const
 {
     size_t res = 0;
-    for (const auto & hash_join : hash_joins)
-    {
-        std::lock_guard lock(hash_join->mutex);
-        res += hash_join->data->getTotalByteCount();
-    }
+    for (size_t i = 0; i < slots; ++i)
+        res += cached_slot_sizes[i].byte_count.load(std::memory_order_relaxed);
     return res;
 }
 
@@ -493,7 +490,6 @@ IBlocksStreamPtr ConcurrentHashJoin::getNonJoinedBlocks(
     }
 
     /// single-level maps - distribute slots round-robin across streams
-    /// each slot is independent HashJoin, no cross-slot coordination needed
     std::vector<IBlocksStreamPtr> per_slot_streams;
     for (size_t slot = stream_idx; slot < hash_joins.size(); slot += num_streams)
     {
@@ -509,6 +505,15 @@ IBlocksStreamPtr ConcurrentHashJoin::getNonJoinedBlocks(
     if (per_slot_streams.size() == 1)
         return per_slot_streams[0];
     return std::make_shared<ConcatStreams>(std::move(per_slot_streams));
+}
+
+void ConcurrentHashJoin::finalizeSlots()
+{
+    for (size_t i = 0; i < slots; ++i)
+    {
+        cached_slot_sizes[i].row_count.store(hash_joins[i]->data->getTotalRowCount(), std::memory_order_relaxed);
+        cached_slot_sizes[i].byte_count.store(hash_joins[i]->data->getTotalByteCount(), std::memory_order_relaxed);
+    }
 }
 
 template <typename HashTable>
@@ -856,6 +861,7 @@ void ConcurrentHashJoin::onBuildPhaseFinish()
         }
     }
 
+    finalizeSlots();
     build_phase_finished = true;
 }
 }

--- a/src/Interpreters/ConcurrentHashJoin.cpp
+++ b/src/Interpreters/ConcurrentHashJoin.cpp
@@ -162,6 +162,7 @@ ConcurrentHashJoin::ConcurrentHashJoin(
           /*max_free_threads_*/ 0,
           /*queue_size_*/ slots))
     , stats_collecting_params(stats_collecting_params_)
+    , cached_slot_sizes(std::make_unique<CachedSlotSize[]>(slots))
 {
     hash_joins.resize(slots);
 
@@ -445,14 +446,25 @@ IBlocksStreamPtr ConcurrentHashJoin::getNonJoinedBlocks(
 
 bool ConcurrentHashJoin::supportParallelNonJoinedBlocksProcessing() const
 {
-    return table_join->allowParallelNonJoinedRowsProcessing()
-        && JoinCommon::hasNonJoinedBlocks(*table_join)
-        && hash_joins[0]->data->twoLevelMapIsUsed();
+    if (!table_join->allowParallelNonJoinedRowsProcessing())
+        return false;
+    if (!JoinCommon::hasNonJoinedBlocks(*table_join))
+        return false;
+
+    if (hash_joins[0]->data->twoLevelMapIsUsed())
+    {
+        if (!table_join->oneDisjunct())
+            return false;
+        if (table_join->getMixedJoinExpression() && isRightOrFull(table_join->kind()))
+            return false;
+    }
+
+    return true;
 }
 
 ///   1) always-false condition (no keys): stream 0 returns all right rows
 ///   2) two-level maps - each stream scans buckets where (bucket % num_streams == stream_idx)
-///   3) single-level maps - stream 0 concatenates per-slot streams sequentially
+///   3) single-level maps - each stream handles slots (slot % num_streams == stream_idx)
 IBlocksStreamPtr ConcurrentHashJoin::getNonJoinedBlocks(
     const Block & left_sample_block, const Block & result_sample_block, UInt64 max_block_size,
     size_t stream_idx, size_t num_streams) const
@@ -480,26 +492,23 @@ IBlocksStreamPtr ConcurrentHashJoin::getNonJoinedBlocks(
         return hash_joins[0]->data->getNonJoinedBlocks(left_sample_block, result_sample_block, max_block_size, stream_idx, num_streams);
     }
 
-    /// single-level maps - each slot has its own HashJoin, only stream 0 collects them
-    if (stream_idx != 0)
-        return {};
-
-    std::vector<IBlocksStreamPtr> streams;
-    streams.reserve(slots);
-    for (const auto & hash_join : hash_joins)
+    /// single-level maps - distribute slots round-robin across streams
+    /// each slot is independent HashJoin, no cross-slot coordination needed
+    std::vector<IBlocksStreamPtr> per_slot_streams;
+    for (size_t slot = stream_idx; slot < hash_joins.size(); slot += num_streams)
     {
-        std::lock_guard lock(hash_join->mutex);
-        if (hash_join->data->hasNonJoinedRows())
+        std::lock_guard lock(hash_joins[slot]->mutex);
+        if (hash_joins[slot]->data->hasNonJoinedRows())
         {
-            if (auto s = hash_join->data->getNonJoinedBlocks(left_sample_block, result_sample_block, max_block_size))
-                streams.push_back(std::move(s));
+            if (auto s = hash_joins[slot]->data->getNonJoinedBlocks(left_sample_block, result_sample_block, max_block_size))
+                per_slot_streams.push_back(std::move(s));
         }
     }
-    if (streams.empty())
+    if (per_slot_streams.empty())
         return {};
-    if (streams.size() == 1)
-        return streams[0];
-    return std::make_shared<ConcatStreams>(std::move(streams));
+    if (per_slot_streams.size() == 1)
+        return per_slot_streams[0];
+    return std::make_shared<ConcatStreams>(std::move(per_slot_streams));
 }
 
 template <typename HashTable>

--- a/src/Interpreters/ConcurrentHashJoin.h
+++ b/src/Interpreters/ConcurrentHashJoin.h
@@ -73,6 +73,11 @@ public:
         const Block & left_sample_block, const Block & result_sample_block, UInt64 max_block_size,
         size_t stream_idx, size_t num_streams) const override;
 
+    static bool needUsedFlagsForPerLeftTableRow(const std::shared_ptr<TableJoin> & table_join)
+    {
+        return table_join->strictness() != JoinStrictness::Semi && table_join->strictness() != JoinStrictness::Asof;
+    }
+
     bool isCloneSupported() const override
     {
         return getTotals().empty() && getTotalRowCount() == 0;
@@ -100,6 +105,8 @@ public:
     friend class NotJoinedHash;
 
 private:
+    void finalizeSlots();
+
     std::shared_ptr<TableJoin> table_join;
     size_t slots;
     bool any_take_last_row;
@@ -108,6 +115,14 @@ private:
     bool build_phase_finished = false;
 
     StatsCollectingParams stats_collecting_params;
+
+    /// updated during addBlockToJoin while holding the slot mutex
+    struct CachedSlotSize
+    {
+        std::atomic<size_t> row_count{0};
+        std::atomic<size_t> byte_count{0};
+    };
+    std::unique_ptr<CachedSlotSize[]> cached_slot_sizes;
 
     std::mutex totals_mutex;
     Block totals;


### PR DESCRIPTION
Provides an optimization for ConcurrentHashJoin by processing non-joined rows accross shards separately (previously each non-joined rows stream was merged into one stream, after https://github.com/ClickHouse/ClickHouse/pull/92068 there is no need for this.

### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Follow-up to https://github.com/ClickHouse/ClickHouse/pull/92068. Optimizes the ConcurrentHashJoin algorithm in case of a big number of non-joined rows.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
