### PR TITLE
CI: fix macOS infra deployment and Slack worker reliability

### DIFF
--- a/ci/infra/cloud.py
+++ b/ci/infra/cloud.py
@@ -91,7 +91,6 @@ CLOUD = CloudInfrastructure.Config(
             auto_placement="on",
             quantity_per_az=2,
             praktika_resource_tag="mac",
-            runner_type=RunnerLabels.MACOS_ARM_SMALL[1],
         ),
     ],
     ec2_instances=[

--- a/ci/infra/scripts/user_data_macos.txt
+++ b/ci/infra/scripts/user_data_macos.txt
@@ -87,8 +87,10 @@ else
   wget --directory-prefix=/tmp "https://s3.amazonaws.com/amazoncloudwatch-agent/darwin/${CLOUDWATCH_ARCH}/latest/amazon-cloudwatch-agent.pkg"
   sudo installer -pkg /tmp/amazon-cloudwatch-agent.pkg -target /
 
-  # Download and configure CloudWatch agent config
-  aws ssm get-parameter --region us-east-1 --name AmazonCloudWatch-github-runners --query 'Parameter.Value' --output text | sudo tee /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json > /dev/null
+  # Download and configure CloudWatch agent config, replacing Linux log path with macOS equivalent
+  aws ssm get-parameter --region us-east-1 --name AmazonCloudWatch-github-runners --query 'Parameter.Value' --output text \
+    | jq 'walk(if type == "object" and .file_path == "/var/log/cloud-init-output.log" then .file_path = "/var/log/amazon/ec2/ec2-macos-init.log" else . end)' \
+    | sudo tee /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json > /dev/null
 
   # Start CloudWatch agent service
   sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl \

--- a/ci/praktika/infrastructure/dedicated_host.py
+++ b/ci/praktika/infrastructure/dedicated_host.py
@@ -15,9 +15,6 @@ class DedicatedHost:
         praktika_resource_tag: str = (
             ""  # Praktika resource tag (e.g., "mac") - tagged as "praktika"
         )
-        runner_type: str = (
-            ""  # GitHub runner type (e.g., "arm_macos_small") - tagged as "github:runner-type"
-        )
 
         # If set, allocate hosts in all availability zones in the region.
         all_availability_zones: bool = False
@@ -89,8 +86,6 @@ class DedicatedHost:
             # Add resource tag if specified
             if self.praktika_resource_tag:
                 merged_tags["praktika_resource_tag"] = self.praktika_resource_tag
-            if self.runner_type:
-                merged_tags["github:runner-type"] = self.runner_type
             # Add user-defined tags
             merged_tags.update(self.tags or {})
 
@@ -146,8 +141,6 @@ class DedicatedHost:
             # Add resource tag if specified
             if self.praktika_resource_tag:
                 merged_tags["praktika_resource_tag"] = self.praktika_resource_tag
-            if self.runner_type:
-                merged_tags["github:runner-type"] = self.runner_type
             # Add user-defined tags
             merged_tags.update(self.tags or {})
 
@@ -235,8 +228,6 @@ class DedicatedHost:
             # Add resource tag if specified
             if self.praktika_resource_tag:
                 merged_tags["praktika_resource_tag"] = self.praktika_resource_tag
-            if self.runner_type:
-                merged_tags["github:runner-type"] = self.runner_type
             # Add user-defined tags
             merged_tags.update(self.tags or {})
 

--- a/ci/praktika/infrastructure/iam_instance_profile.py
+++ b/ci/praktika/infrastructure/iam_instance_profile.py
@@ -27,6 +27,90 @@ class IAMInstanceProfile:
             default_factory=dict
         )  # Runtime/fetched fields (ARNs, etc.)
 
+        def _is_up_to_date(self, iam) -> bool:
+            """Return True if the role, policies, and instance profile all match the desired config."""
+            from urllib.parse import unquote
+
+            try:
+                iam.get_role(RoleName=self.role_name)
+            except Exception:
+                print(f"  Role '{self.role_name}' does not exist yet")
+                return False
+
+            try:
+                current_arns: set = set()
+                paginator = iam.get_paginator("list_attached_role_policies")
+                for page in paginator.paginate(RoleName=self.role_name):
+                    for attached in page.get("AttachedPolicies") or []:
+                        arn = attached.get("PolicyArn")
+                        if arn:
+                            current_arns.add(arn)
+                desired_arns = {p for p in (self.policy_arns or []) if p}
+                if current_arns != desired_arns:
+                    print(
+                        f"  Managed policies differ:"
+                        f" added={desired_arns - current_arns},"
+                        f" removed={current_arns - desired_arns}"
+                    )
+                    return False
+            except Exception as e:
+                print(f"  Failed to check managed policies: {e}")
+                return False
+
+            try:
+                desired_inline = {
+                    n: d
+                    for n, d in (self.inline_policies or {}).items()
+                    if n and d
+                }
+                current_inline_names: set = set()
+                paginator = iam.get_paginator("list_role_policies")
+                for page in paginator.paginate(RoleName=self.role_name):
+                    for policy_name in page.get("PolicyNames") or []:
+                        if policy_name:
+                            current_inline_names.add(policy_name)
+                if current_inline_names != set(desired_inline.keys()):
+                    print(
+                        f"  Inline policy names differ:"
+                        f" current={current_inline_names},"
+                        f" desired={set(desired_inline.keys())}"
+                    )
+                    return False
+                for policy_name, desired_doc in desired_inline.items():
+                    resp = iam.get_role_policy(
+                        RoleName=self.role_name, PolicyName=policy_name
+                    )
+                    raw = resp.get("PolicyDocument", "{}")
+                    current_doc = (
+                        raw if isinstance(raw, dict) else json.loads(unquote(raw))
+                    )
+                    if current_doc != desired_doc:
+                        print(f"  Inline policy '{policy_name}' content differs")
+                        return False
+            except Exception as e:
+                print(f"  Failed to check inline policies: {e}")
+                return False
+
+            try:
+                ip = iam.get_instance_profile(
+                    InstanceProfileName=self.name
+                ).get("InstanceProfile", {})
+                role_names = [
+                    r.get("RoleName")
+                    for r in (ip.get("Roles") or [])
+                    if r.get("RoleName")
+                ]
+                if self.role_name not in role_names:
+                    print(
+                        f"  Role '{self.role_name}' not yet attached to instance profile '{self.name}'"
+                    )
+                    return False
+            except Exception as e:
+                print(f"  Instance profile '{self.name}' check failed: {e}")
+                return False
+
+            return True
+
         def deploy(self):
             import time
 
@@ -42,6 +126,12 @@ class IAMInstanceProfile:
             instance_profile_name = self.name
 
             iam = boto3.client("iam")
+
+            if self._is_up_to_date(iam):
+                print(
+                    f"IAM instance profile '{instance_profile_name}' is already up to date, skipping"
+                )
+                return self
 
             assume_role_policy = {
                 "Version": "2012-10-17",

--- a/ci/praktika/infrastructure/lambda_function.py
+++ b/ci/praktika/infrastructure/lambda_function.py
@@ -347,6 +347,7 @@ class Lambda:
                 ).decode("utf-8")
 
                 # Compare code hashes
+                code_updated = False
                 if existing_code_sha256 == new_code_sha256:
                     print(
                         f"Code unchanged for Lambda function: {function_name} (SHA256: {new_code_sha256})"
@@ -362,14 +363,22 @@ class Lambda:
                     lambda_client.update_function_code(
                         FunctionName=function_name, ZipFile=zip_data
                     )
-
+                    code_updated = True
                     print(f"Successfully updated Lambda function code: {function_name}")
 
-                # Update function configuration if secrets are provided
-                if self.secrets:
-                    print(f"Waiting for code update to complete...")
-                    waiter = lambda_client.get_waiter("function_updated")
-                    waiter.wait(FunctionName=function_name)
+                # Update function configuration only if something changed
+                current_env = self.ext.get("environment", {})
+                config_changed = (
+                    self.ext.get("handler") != handler
+                    or self.ext.get("timeout") != timeout
+                    or self.ext.get("memory_size") != memory_size
+                    or current_env != environment
+                )
+                if config_changed:
+                    if code_updated:
+                        print(f"Waiting for code update to complete...")
+                        waiter = lambda_client.get_waiter("function_updated")
+                        waiter.wait(FunctionName=function_name)
 
                     print(
                         f"Updating Lambda configuration (timeout={timeout}s, memory={memory_size}MB, handler={handler})..."
@@ -384,6 +393,10 @@ class Lambda:
                     )
                     print(
                         f"Successfully updated Lambda function configuration: {function_name}"
+                    )
+                elif not code_updated:
+                    print(
+                        f"Lambda '{function_name}' is already up to date, skipping"
                     )
 
             except lambda_client.exceptions.ResourceNotFoundException:
@@ -583,7 +596,7 @@ lambda_worker_config = Lambda.Config(
     secrets={
         "praktika_slack_app_token": "SLACK_BOT_TOKEN",
     },
-    timeout_ms=10 * 1000,
+    timeout_ms=30 * 1000,
     memory_size_mb=128,
 )
 

--- a/ci/praktika/infrastructure/native/lambda_slack_worker.py
+++ b/ci/praktika/infrastructure/native/lambda_slack_worker.py
@@ -670,6 +670,28 @@ def publish_home_view(
             }
         )
 
+    # Slack home views are limited to 100 blocks total.
+    # Truncate before the limit, leaving room for a notice block.
+    SLACK_BLOCK_LIMIT = 100
+    if len(blocks) > SLACK_BLOCK_LIMIT:
+        blocks = blocks[: SLACK_BLOCK_LIMIT - 1]
+        blocks.append(
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "_Some events were truncated (view limit reached)._",
+                },
+            }
+        )
+
+    # Slack section text is capped at 3000 characters.
+    for block in blocks:
+        if block.get("type") == "section":
+            txt = block.get("text", {})
+            if isinstance(txt, dict) and len(txt.get("text", "")) > 3000:
+                txt["text"] = txt["text"][:2997] + "…"
+
     view_data = {
         "user_id": user_id,
         "view": {
@@ -708,6 +730,11 @@ def lambda_handler(event, context):
 
     Note: 'github_login' parameter now contains user email addresses for email-based subscriptions.
     """
+    # Clear the per-container cache at the start of every invocation so that
+    # preference changes saved to S3 by a previous invocation (e.g. toggle_pref)
+    # are always reflected in subsequent invocations running in the same container.
+    SUBSCRIPTION_CACHE.clear()
+
     print(f"Worker Lambda invoked with event: {json.dumps(event)}")
 
     action = event.get("action", "")


### PR DESCRIPTION
## Summary

A series of fixes to the `praktika` CI infrastructure deployment tooling and Slack worker Lambda:

- **macOS CloudWatch agent config**: fix config path and remove unused `runner_type` from `DedicatedHost`
- **`IAMInstanceProfile` deploy**: skip with message when role, policies and instance profile already match desired state — avoids unnecessary API calls and eventual-consistency wait
- **`Lambda` deploy**: skip code/config update when nothing has changed; waiter and config update only run when actually needed
- **Slack worker — preference toggle reverting**: clear `SUBSCRIPTION_CACHE` at the start of each Lambda invocation so warm containers don't serve stale prefs after a `toggle_pref` write
- **Slack worker — `invalid_arguments` from `views.publish`**: cap home view blocks at Slack's 100-block limit and trim section text to 3000 characters
- **Slack worker — Lambda timeout**: increase worker timeout from 10 s to 30 s to avoid AWS hard timeout when processing multiple users with sequential Slack API calls
- **`DedicatedHost` deploy**: handle `HostLimitExceeded` gracefully instead of crashing; print diagnostic listing any hosts not matched by pool tags
- **`EC2Instance` deploy**: fix `quantity > 1` — when existing instances were found, deploy skipped creation entirely without comparing against desired quantity; now computes the shortfall and creates only the missing instances; also remove debug print that dumped full `RunInstances` JSON (including entire `user_data`) to stdout

## Test plan

- Deployed all infrastructure components against the live AWS account and verified each fix
- `IAMInstanceProfile`: confirmed "already up to date" message on re-deploy
- `Lambda`: confirmed "already up to date" message on re-deploy with unchanged code/config
- `EC2Instance`: confirmed 2nd instance was created when `quantity=2` and only 1 existed

## Changelog category

CI Fix or improvement

## Changelog entry

Fix several bugs in the `praktika` CI infrastructure deployment tooling: idempotent IAM/Lambda deploys, Slack worker preference persistence, home view block limit, Lambda timeout, and EC2 instance quantity handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.997`
<!-- ch-version-info:end -->