### PR TITLE
Mark internal functions in `system.functions` as internal

### DIFF
--- a/src/Common/FunctionDocumentation.cpp
+++ b/src/Common/FunctionDocumentation.cpp
@@ -270,6 +270,8 @@ String FunctionDocumentation::categoryAsString() const
         {Category::UUID, "UUID"},
         {Category::UniqTheta, "UniqTheta"},
 
+        {Category::Internal, "Internal"},
+
         {Category::AggregateFunction, "Aggregate Functions"},
         {Category::TableFunction, "Table Functions"}
     };
@@ -279,4 +281,7 @@ String FunctionDocumentation::categoryAsString() const
     else
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Category has no mapping to string");
 }
+
+FunctionDocumentation FunctionDocumentation::INTERNAL_FUNCTION_DOCS = {"", "", {}, {}, {"", {}}, {}, FunctionDocumentation::VERSION_UNKNOWN, FunctionDocumentation::Category::Internal};
+
 }

--- a/src/Common/FunctionDocumentation.h
+++ b/src/Common/FunctionDocumentation.h
@@ -127,6 +127,9 @@ struct FunctionDocumentation
         UniqTheta,
         Variant,
 
+        /// Internal utility functions, not documented in the user docs
+        Internal,
+
         /// Other types of functions
         AggregateFunction,
         TableFunction
@@ -151,5 +154,10 @@ struct FunctionDocumentation
     String examplesAsString() const;
     String introducedInAsString() const;
     String categoryAsString() const;
+
+    /// Use as a placeholder for internal functions that have no public documentation
+    static FunctionDocumentation INTERNAL_FUNCTION_DOCS;
+
 };
+
 }

--- a/src/Functions/CastOverloadResolver.cpp
+++ b/src/Functions/CastOverloadResolver.cpp
@@ -165,7 +165,7 @@ FunctionBasePtr createInternalCast(ColumnWithTypeAndName from, DataTypePtr to, C
 
 REGISTER_FUNCTION(CastOverloadResolvers)
 {
-    factory.registerFunction("_CAST", [](ContextPtr context){ return CastOverloadResolverImpl::create(context, CastType::nonAccurate, true, {}); }, {}, FunctionFactory::Case::Insensitive);
+    factory.registerFunction("_CAST", [](ContextPtr context){ return CastOverloadResolverImpl::create(context, CastType::nonAccurate, true, {}); }, FunctionDocumentation::INTERNAL_FUNCTION_DOCS, FunctionFactory::Case::Insensitive);
     /// Note: "internal" (not affected by null preserving setting) versions of accurate cast functions are unneeded.
 
     /// CAST documentation

--- a/src/Functions/FunctionApplyFilter.cpp
+++ b/src/Functions/FunctionApplyFilter.cpp
@@ -11,6 +11,7 @@
 #include <Processors/QueryPlan/RuntimeFilterLookup.h>
 #include <IO/WriteHelpers.h>
 #include <Common/CurrentThread.h>
+#include <Common/FunctionDocumentation.h>
 
 namespace DB
 {
@@ -22,16 +23,18 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
 }
 
+/// Special function for JOIN runtime filtering
+/// Syntax: __applyFilter(filter_name, key)
+/// - filter_name: Internal name of runtime filter. It is built by BuildRuntimeFilterStep. String
+/// - key: Value of any type that is checked to be present in the filter.
+/// Returns false if the key should be filtered
 class FunctionApplyFilter : public IFunction
 {
 public:
     static constexpr auto name = "__applyFilter";
     static FunctionPtr create(ContextPtr) { return std::make_shared<FunctionApplyFilter>(); }
 
-    String getName() const override
-    {
-        return name;
-    }
+    String getName() const override { return name; }
 
     bool isVariadic() const override { return false; }
     bool isInjective(const ColumnsWithTypeAndName &) const override { return false; }
@@ -102,18 +105,7 @@ public:
 
 REGISTER_FUNCTION(FilterContains)
 {
-    FunctionDocumentation::Description description = R"(Special function for JOIN runtime filtering.)";
-    FunctionDocumentation::Syntax syntax = "__applyFilter(filter_name, key)";
-    FunctionDocumentation::Arguments arguments = {
-        {"filter_name", "Internal name of runtime filter. It is built by BuildRuntimeFilterStep.", {"String"}},
-        {"key", "Value of any type that is checked to be present in the filter", {}}
-    };
-    FunctionDocumentation::ReturnedValue returned_value = {"False if the key should be filtered", {"Bool"}};
-    FunctionDocumentation::Examples examples = {{"Example", "This function is not supposed to be used in user queries. It might be added to query plan during optimization. ", ""}};
-    FunctionDocumentation::IntroducedIn introduced_in = {25, 10};
-    FunctionDocumentation::Category category = FunctionDocumentation::Category::Other;
-
-    factory.registerFunction<FunctionApplyFilter>({description, syntax, arguments, {}, returned_value, examples, introduced_in, category}, FunctionFactory::Case::Sensitive);
+    factory.registerFunction<FunctionApplyFilter>(FunctionDocumentation::INTERNAL_FUNCTION_DOCS, FunctionFactory::Case::Sensitive);
 }
 
 }

--- a/src/Functions/bitBoolMaskAnd.cpp
+++ b/src/Functions/bitBoolMaskAnd.cpp
@@ -49,7 +49,7 @@ using FunctionBitBoolMaskAnd = BinaryArithmeticOverloadResolver<BitBoolMaskAndIm
 
 REGISTER_FUNCTION(BitBoolMaskAnd)
 {
-    factory.registerFunction<FunctionBitBoolMaskAnd>();
+    factory.registerFunction<FunctionBitBoolMaskAnd>(FunctionDocumentation::INTERNAL_FUNCTION_DOCS);
 }
 
 }

--- a/src/Functions/bitBoolMaskOr.cpp
+++ b/src/Functions/bitBoolMaskOr.cpp
@@ -1,6 +1,7 @@
 #include <Functions/FunctionFactory.h>
 #include <Functions/FunctionBinaryArithmetic.h>
 #include <DataTypes/NumberTraits.h>
+#include <Common/FunctionDocumentation.h>
 
 
 namespace DB
@@ -49,7 +50,7 @@ using FunctionBitBoolMaskOr = BinaryArithmeticOverloadResolver<BitBoolMaskOrImpl
 
 REGISTER_FUNCTION(BitBoolMaskOr)
 {
-    factory.registerFunction<FunctionBitBoolMaskOr>();
+    factory.registerFunction<FunctionBitBoolMaskOr>(FunctionDocumentation::INTERNAL_FUNCTION_DOCS);
 }
 
 }

--- a/src/Functions/bitSwapLastTwo.cpp
+++ b/src/Functions/bitSwapLastTwo.cpp
@@ -77,7 +77,7 @@ template <> struct FunctionUnaryArithmeticMonotonicity<NameBitSwapLastTwo>
 
 REGISTER_FUNCTION(BitSwapLastTwo)
 {
-    factory.registerFunction<FunctionBitSwapLastTwo>();
+    factory.registerFunction<FunctionBitSwapLastTwo>(FunctionDocumentation::INTERNAL_FUNCTION_DOCS);
 }
 
 }

--- a/src/Functions/bitWrapperFunc.cpp
+++ b/src/Functions/bitWrapperFunc.cpp
@@ -66,6 +66,6 @@ template <> struct FunctionUnaryArithmeticMonotonicity<NameBitWrapperFunc>
 
 REGISTER_FUNCTION(BitWrapperFunc)
 {
-    factory.registerFunction<FunctionBitWrapperFunc>();
+    factory.registerFunction<FunctionBitWrapperFunc>(FunctionDocumentation::INTERNAL_FUNCTION_DOCS);
 }
 }

--- a/src/Functions/getScalar.cpp
+++ b/src/Functions/getScalar.cpp
@@ -142,7 +142,7 @@ private:
 
 REGISTER_FUNCTION(GetScalar)
 {
-    factory.registerFunction<FunctionGetScalar>();
+    factory.registerFunction<FunctionGetScalar>(FunctionDocumentation::INTERNAL_FUNCTION_DOCS);
 
     FunctionDocumentation::Description description_shardNum = R"(
 Returns the index of a shard which processes a part of data in a distributed query.

--- a/src/Functions/identity.cpp
+++ b/src/Functions/identity.cpp
@@ -1,5 +1,6 @@
 #include <Functions/identity.h>
 #include <Functions/FunctionFactory.h>
+#include <Common/FunctionDocumentation.h>
 
 namespace DB
 {
@@ -25,12 +26,12 @@ This function returns the argument you pass to it, which is useful for debugging
 
 REGISTER_FUNCTION(ScalarSubqueryResult)
 {
-    factory.registerFunction("__scalarSubqueryResult", [](ContextPtr){ return FunctionIdentityBase::create({}, "__scalarSubqueryResult", false); });
+    factory.registerFunction("__scalarSubqueryResult", [](ContextPtr){ return FunctionIdentityBase::create({}, "__scalarSubqueryResult", false); }, FunctionDocumentation::INTERNAL_FUNCTION_DOCS);
 }
 
 REGISTER_FUNCTION(ActionName)
 {
-    factory.registerFunction("__actionName", [](ContextPtr){ return FunctionActionName::create({}); });
+    factory.registerFunction("__actionName", [](ContextPtr){ return FunctionActionName::create({}); }, FunctionDocumentation::INTERNAL_FUNCTION_DOCS);
 }
 
 }

--- a/src/Functions/patchPartitionID.cpp
+++ b/src/Functions/patchPartitionID.cpp
@@ -96,14 +96,7 @@ public:
 
 REGISTER_FUNCTION(PatchPartitionID)
 {
-    factory.registerFunction<FunctionPatchPartitionID>(FunctionDocumentation
-    {
-        .description = R"(
-Internal function. Receives the name of a part and a hash of patch part's column names. Returns the name of partition of patch part. The argument must be a correct name of part, the behaviour is undefined otherwise.
-        )",
-        .introduced_in = {25, 5},
-        .category = FunctionDocumentation::Category::Other,
-    });
+    factory.registerFunction<FunctionPatchPartitionID>(FunctionDocumentation::INTERNAL_FUNCTION_DOCS);
 }
 
 }

--- a/tests/queries/0_stateless/02415_all_new_functions_must_be_documented.reference
+++ b/tests/queries/0_stateless/02415_all_new_functions_must_be_documented.reference
@@ -4,11 +4,13 @@ URLHierarchy
 URLPathHierarchy
 _CAST
 __actionName
+__applyFilter
 __bitBoolMaskAnd
 __bitBoolMaskOr
 __bitSwapLastTwo
 __bitWrapperFunc
 __getScalar
+__patchPartitionID
 __scalarSubqueryResult
 caseWithExpression
 dotProduct

--- a/tests/queries/0_stateless/02415_all_new_functions_must_be_documented.sql
+++ b/tests/queries/0_stateless/02415_all_new_functions_must_be_documented.sql
@@ -1,5 +1,6 @@
 -- This outputs the list of undocumented functions.
 -- No new items in the list should appear. Please help shorten this list down to zero elements.
+-- Internal functions (= functions starting with __ prefix) are not documented externally and an exception from the rule.
 SELECT name FROM system.functions WHERE NOT is_aggregate AND origin = 'System' AND alias_to = '' AND length(description) < 10
 AND name NOT IN (
      -- these functions are not enabled in fast test

--- a/tests/queries/0_stateless/02415_all_new_functions_must_have_version_information.reference
+++ b/tests/queries/0_stateless/02415_all_new_functions_must_have_version_information.reference
@@ -4,11 +4,13 @@ URLHierarchy
 URLPathHierarchy
 _CAST
 __actionName
+__applyFilter
 __bitBoolMaskAnd
 __bitBoolMaskOr
 __bitSwapLastTwo
 __bitWrapperFunc
 __getScalar
+__patchPartitionID
 __scalarSubqueryResult
 caseWithExpression
 currentQueryID

--- a/tests/queries/0_stateless/02415_all_new_functions_must_have_version_information.sql
+++ b/tests/queries/0_stateless/02415_all_new_functions_must_have_version_information.sql
@@ -1,5 +1,6 @@
 -- This outputs the list of functions without version information.
 -- No new items in the list should appear. Please help shorten this list down to zero elements.
+-- Internal functions (= functions starting with __ prefix) are not documented externally and an exception from the rule.
 SELECT name FROM system.functions WHERE NOT is_aggregate AND origin = 'System' AND alias_to = '' AND introduced_in == ''
 AND name NOT IN (
      -- these functions are not enabled in fast test

--- a/tests/queries/0_stateless/03921_internal_functions_have_internal_category.sql
+++ b/tests/queries/0_stateless/03921_internal_functions_have_internal_category.sql
@@ -1,0 +1,6 @@
+-- Internal SQL functions are functions with a `__` prefix.
+-- Test that system.functions shows categories = 'Internal' for them
+SELECT name, throwIf(categories <> 'Internal')
+FROM system.functions
+WHERE startsWith(name, '__')
+FORMAT Null


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
System table `system.functions` now shows for internal functions `categories = 'Internal'` instead of `categories = ''`.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.907`
<!-- ch-version-info:end -->