### PR TITLE
Cap per-test run time at 10 min in targeted check

### DIFF
--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -505,12 +505,16 @@ def main():
         # Track collected test results across multiple runs (only used when run_sets_cnt > 1)
         collected_test_results = []
         seen_test_names = set()
+        # Track accumulated run time per test for the targeted check per-test time cap
+        test_time_accumulated: dict[str, float] = {}
+        TIME_CAP_PER_TEST_SEC = 10 * 60
+        tests_to_run = list(tests) if tests else tests
 
         for cnt in range(run_sets_cnt):
             run_tests(
-                batch_num=batch_num if not tests else 0,
-                batch_total=total_batches if not tests else 0,
-                tests=tests,
+                batch_num=batch_num if not tests_to_run else 0,
+                batch_total=total_batches if not tests_to_run else 0,
+                tests=tests_to_run,
                 extra_args=runner_options,
                 random_order=is_flaky_check
                 or is_targeted_check
@@ -523,6 +527,27 @@ def main():
             # or all results on the final attempt
             if run_sets_cnt > 1:
                 is_final_run = cnt == run_sets_cnt - 1
+
+                # Accumulate per-test run time and filter tests that exceeded the time cap
+                if is_targeted_check:
+                    for test_case_result in test_result.results:
+                        if test_case_result.duration is not None:
+                            test_time_accumulated[test_case_result.name] = (
+                                test_time_accumulated.get(test_case_result.name, 0.0)
+                                + test_case_result.duration
+                            )
+                    if not is_final_run:
+                        tests_to_run = [
+                            t
+                            for t in tests_to_run
+                            if test_time_accumulated.get(t, 0.0)
+                            < TIME_CAP_PER_TEST_SEC
+                        ]
+                        if not tests_to_run:
+                            print(
+                                "NOTE: All tests exceeded the time cap; stopping early"
+                            )
+                            is_final_run = True
 
                 for test_case_result in test_result.results:
                     # Only collect each test once (first failure or final result)


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


---

In the targeted check, each test case is run up to 5 times. Add a 10-minute per-test time cap: after each run, accumulate the total elapsed time per test and exclude any test whose cumulative time has reached `TIME_CAP_PER_TEST_SEC` (600 s) from subsequent runs.

If all remaining tests are capped out before the final scheduled iteration, force a final-run collection and stop early.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.914`
<!-- ch-version-info:end -->