### PR TITLE
Remove TABLE_UUID_MISMATCH check for non-analyzer

### DIFF
--- a/src/Interpreters/DatabaseCatalog.cpp
+++ b/src/Interpreters/DatabaseCatalog.cpp
@@ -83,6 +83,7 @@ namespace ErrorCodes
 namespace Setting
 {
     extern const SettingsBool fsync_metadata;
+    extern const SettingsBool allow_experimental_analyzer;
 }
 
 namespace MergeTreeSetting
@@ -377,6 +378,7 @@ DatabaseAndTable DatabaseCatalog::getTableImpl(
         return {};
     }
 
+    bool analyzer = context_->getSettingsRef()[Setting::allow_experimental_analyzer];
     if (table_id.hasUUID())
     {
         /// Shortcut for tables which have persistent UUID
@@ -395,7 +397,8 @@ DatabaseAndTable DatabaseCatalog::getTableImpl(
             }
             return {};
         }
-        else
+        /// In old analyzer resolving done in multiple places, so we ignore TABLE_UUID_MISMATCH error.
+        else if (!analyzer)
         {
             const auto & table_storage_id = db_and_table.second->getStorageID();
             if (db_and_table.first->getDatabaseName() != table_id.database_name ||


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Remove TABLE_UUID_MISMATCH check for non-analyzer

In non-analyzer we resolve storages in multiple places and you may get `TABLE_UUID_MISMATCH` from time to time, and this may create problems for refresh-able materialized views, since tables are renamed frequently there.

Note, that in analyzer w/o https://github.com/ClickHouse/ClickHouse/issues/94746 resolving is also not atomic.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.942`
- Backported to: `26.1.4.5`, `25.12.7.4`, `25.11.10.10`, `25.8.17.23`
<!-- ch-version-info:end -->