### PR TITLE
Remove SSH config from default server config directory

### DIFF
--- a/programs/server/config.d/ssh.xml
+++ b/programs/server/config.d/ssh.xml
@@ -1,6 +1,0 @@
-<clickhouse>
-    <tcp_ssh_port>9022</tcp_ssh_port>
-    <ssh_server>
-        <host_ed25519_key>config.d/ssh_host_ed25519_key</host_ed25519_key>
-    </ssh_server>
-</clickhouse>

--- a/programs/server/config.d/ssh_host_ed25519_key
+++ b/programs/server/config.d/ssh_host_ed25519_key
@@ -1,1 +1,0 @@
-../../../tests/config/ssh_host_ed25519_key


### PR DESCRIPTION
## Summary
- Remove `ssh.xml` and `ssh_host_ed25519_key` from `programs/server/config.d/` which were causing the ClickBench CI job (and potentially other jobs) to fail on startup
- The server crashed with `Listen [0.0.0.0]:9022 failed: Failed setting host key in sshbind` because the SSH listener was unconditionally enabled for all CI jobs that copy from `programs/server/config.d/`
- The SSH test configuration is already properly handled by `tests/config/install.sh` (lines 173-177), making these files redundant

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=7bea0b49090a3a90b545241f7b32a639d046b982&name_0=MasterCI&name_1=ClickBench%20%28amd_release%29

## Test plan
- [ ] ClickBench (amd_release) and (arm_release) CI jobs should now pass (server starts successfully without SSH listener)
- [ ] Stateless test `03918_ssh_protocol` should still pass (gets SSH config from `tests/config/install.sh`)

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.920`
<!-- ch-version-info:end -->