### PR TITLE
Fix use-after-free in StorageKeeperMap backup

### DIFF
--- a/src/Storages/StorageKeeperMap.cpp
+++ b/src/Storages/StorageKeeperMap.cpp
@@ -1162,10 +1162,11 @@ void StorageKeeperMap::backupData(BackupEntriesCollector & backup_entries_collec
 
         auto tmp_data = std::make_shared<TemporaryDataOnDiskScope>(backup_entries_collector.getContext()->getTempDataOnDisk(), tmp_data_settings);
 
+        auto self = std::static_pointer_cast<StorageKeeperMap>(shared_from_this());
         auto with_retries = std::make_shared<WithRetries>
         (
             getLogger(fmt::format("StorageKeeperMapBackup ({})", getStorageID().getNameForLogs())),
-            [&] { return getClient(); },
+            [self] { return self->getClient(); },
             BackupKeeperSettings(backup_entries_collector.getContext()),
             backup_entries_collector.getContext()->getProcessListElement()
         );


### PR DESCRIPTION
## Summary

Fix a segfault (NULL pointer dereference) in `StorageKeeperMap::getClient` during backup, found by BuzzHouse fuzzer.

**Root cause:** `StorageKeeperMap::backupData` creates a lazy backup batch (`KeeperMapBackup`, which is an `IBackupEntriesLazyBatch`) whose `WithRetries` callback captures `this` as a raw `StorageKeeperMap*` via `[&]`. The lazy batch's `generate` method is called later during `buildFileInfosForBackupEntries` (`BackupsWorker.cpp:697`), but by that point the `BackupEntriesCollector` — which held the only `StoragePtr` to the table — has already been destroyed (`BackupsWorker.cpp:691`). If the table was dropped concurrently (as BuzzHouse does), the raw `this` pointer is dangling, causing a segfault in `getClient` → `ZooKeeper::expired` → `impl->isExpired()`.

**Why other storages are not affected:** Normal tables (MergeTree, Memory, etc.) create their backup entries **eagerly** during `backupData` — the entries are self-contained (holding file paths, `DiskPtr`, or `TemporaryDataBuffer`) and don't reference the storage object afterward. `StorageKeeperMap` is the **only** user of `IBackupEntriesLazyBatch` in the entire codebase, so it's the only storage that defers work to after the `BackupEntriesCollector` is destroyed.

**Fix:** Change the lambda from `[&] { return getClient(); }` to `[self] { return self->getClient(); }` where `self = std::static_pointer_cast<StorageKeeperMap>(shared_from_this())`. This keeps the storage alive as long as the lazy batch needs it.

**Stack trace from the crash:**
```
3. zkutil::ZooKeeper::expired() @ ZooKeeper.cpp:1427
4. DB::StorageKeeperMap::getClient() @ StorageKeeperMap.cpp:1304
5. DB::WithRetries::renewZooKeeper() @ WithRetries.cpp:41
6. DB::KeeperMapBackup::generate() @ StorageKeeperMap.cpp:1083
7. DB::IBackupEntriesLazyBatch::generateIfNecessary() @ IBackupEntriesLazyBatch.cpp:74
8-9. DB::IBackupEntriesLazyBatch::BackupEntryFromBatch::isReference/getInternalBackupEntry()
10. DB::buildFileInfoForBackupEntry() @ BackupFileInfo.cpp:118
```

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=97313&sha=2ba6a430a121c781bf352ddfd17a1118d9f30697&name_0=PR&name_1=BuzzHouse%20%28amd_debug%29
https://github.com/ClickHouse/ClickHouse/pull/97313

## Test plan
- [x] The fix addresses a crash found by BuzzHouse fuzzer with `BACKUP DATABASE ... ASYNC` on a database containing KeeperMap tables
- [x] Debug build compiles successfully

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix segfault in `StorageKeeperMap` backup due to use-after-free of dangling storage pointer in lazy backup batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.922`
- Backported to: `26.1.5.29`, `25.12.9.34`, `25.11.10.9`, `25.8.19.12`
<!-- ch-version-info:end -->