### PR TITLE
Fix 03916_ttl_minmax_projection_epoch_bug test flakiness under TSan

### DIFF
--- a/tests/queries/0_stateless/03916_ttl_minmax_projection_epoch_bug.sql
+++ b/tests/queries/0_stateless/03916_ttl_minmax_projection_epoch_bug.sql
@@ -22,8 +22,10 @@ OPTIMIZE TABLE test_ttl_minmax_epoch FINAL;
 SELECT (SELECT min(timestamp) FROM test_ttl_minmax_epoch) =
        (SELECT min(timestamp) FROM test_ttl_minmax_epoch SETTINGS optimize_use_implicit_projections = 0);
 
+-- Empty parts (all rows expired by TTL) may have epoch min_time because
+-- MinMaxIndex is never initialized; this is expected. Only check non-empty parts.
 SELECT countIf(min_time < '1971-01-01') AS parts_with_epoch_mintime
 FROM system.parts
-WHERE table = 'test_ttl_minmax_epoch' AND database = currentDatabase() AND active;
+WHERE table = 'test_ttl_minmax_epoch' AND database = currentDatabase() AND active AND rows > 0;
 
 DROP TABLE test_ttl_minmax_epoch;


### PR DESCRIPTION
## Summary

- Fix `03916_ttl_minmax_projection_epoch_bug` test failing under TSan (amd_tsan, parallel, 1/2)
- Under TSan, the merge during `OPTIMIZE TABLE FINAL` runs much slower, causing ALL rows (timestamps 1-60 seconds ago) to expire past the 1-minute TTL
- When all rows expire, `MinMaxIndex` is never initialized, so `getMinMaxTime` returns `{0, 0}` (epoch) for the empty part
- The `system.parts` query detects this empty part as having epoch `min_time`, but this is expected for empty parts — the bug being tested is about non-empty parts getting epoch values
- Added `AND rows > 0` filter to the `system.parts` check

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=97324&sha=07470f9d43b811422c4aceb38eb8d86baca8a9ee&name_0=PR&name_1=Stateless%20tests%20%28amd_tsan%2C%20parallel%2C%201%2F2%29
https://github.com/ClickHouse/ClickHouse/pull/97324

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.934`
<!-- ch-version-info:end -->