### PR TITLE
Enable parallel reads from YTsaurus table engine

### DIFF
--- a/src/Core/YTsaurus/YTsaurusClient.cpp
+++ b/src/Core/YTsaurus/YTsaurusClient.cpp
@@ -158,11 +158,11 @@ ReadBufferPtr YTsaurusClient::executeQuery(const YTsaurusQueryPtr query, const R
     {
         size_t url_index = (recently_used_url_index + num_try) % connection_info.http_proxy_urls.size();
         URI host_for_request(connection_info.http_proxy_urls[url_index].c_str());
-        if (connection_info.enable_heavy_proxy_redirection && query->isHeavyQuery())
-            host_for_request = getHeavyProxyURI(host_for_request);
-
         try
         {
+            if (connection_info.enable_heavy_proxy_redirection && query->isHeavyQuery())
+                host_for_request = getHeavyProxyURI(host_for_request);
+
             host_for_request.setPath(fmt::format("/api/{}/{}", connection_info.api_version, query->getQueryName()));
 
             for (const auto & query_param : query->getQueryParameters())

--- a/src/Core/YTsaurus/YTsaurusClient.cpp
+++ b/src/Core/YTsaurus/YTsaurusClient.cpp
@@ -349,7 +349,16 @@ YTsaurusTableLock::YTsaurusTableLock(YTsaurusClientPtr client_, const String & c
 YTsaurusTableLock::~YTsaurusTableLock()
 {
     if (!transaction_id.empty())
-        client->commitTx(transaction_id);
+    {
+        try {
+            client->commitTx(transaction_id);
+        }
+        catch (Exception & e)
+        {
+            LOG_WARNING(getLogger("YTsaurusTableLock"), "Can't commit transaction {}. Leave it. Exception: {}",
+                transaction_id, e.displayText());
+        }
+    }
 }
 
 }

--- a/src/Core/YTsaurus/YTsaurusClient.cpp
+++ b/src/Core/YTsaurus/YTsaurusClient.cpp
@@ -42,8 +42,14 @@ YTsaurusClient::YTsaurusClient(ContextPtr context_, const ConnectionInfo & conne
 {
 }
 
+YTsaurusClient::YTsaurusClient(const YTsaurusClient & other)
+    : context(other.context)
+    , connection_info(other.connection_info)
+    , log(getLogger("YTsaurusClient"))
+{
+}
 
-ReadBufferPtr YTsaurusClient::readTable(const String & cypress_path, const std::pair<size_t, size_t>& rows_range)
+ReadBufferPtr YTsaurusClient::readTable(const String & cypress_path, const std::pair<size_t, size_t> & rows_range)
 {
     YTsaurusQueryPtr read_table_query(new YTsaurusReadTableQuery(cypress_path, rows_range));
     return executeQuery(read_table_query);
@@ -55,31 +61,30 @@ String YTsaurusClient::startTx(size_t timeout_ms)
     auto read_buff = executeQuery(start_tx_query);
     String res;
     // Generally the result of each YTsaurus query should be json.
-    // But... for start_tx query the result always doble quoted string.
+    // But... for start_tx query the result always double quoted string.
     readDoubleQuotedString(res, *read_buff);
     return res;
 }
 
-void YTsaurusClient::commitTx(const String& transaction_id)
+void YTsaurusClient::commitTx(const String & transaction_id)
 {
     YTsaurusQueryPtr commit_tx_query(new YTsaurusCommitTxQuery(transaction_id));
     executeQuery(commit_tx_query);
 }
 
-String YTsaurusClient::lock(const String& cypress_path, const String& transaction_id)
+String YTsaurusClient::lock(const String & cypress_path, const String & transaction_id)
 {
     YTsaurusQueryPtr lock_query(new YTsaurusLockQuery(cypress_path, transaction_id));
     auto read_buff = executeQuery(lock_query);
     String res;
     // Generally the result of each YTsaurus query should be json.
-    // But... for start_tx query the result always doble quoted string.
+    // But... for start_tx query the result always double quoted string.
     readDoubleQuotedString(res, *read_buff);
     return res;
 }
 
 String YTsaurusClient::getNodeIdFromLock(const String & lock_id)
 {
-
     String lock_metadata_path = fmt::format("{}/{}/@node_id", LOCKS_STORAGE_CYPRESS_PATH, lock_id);
     YTsaurusQueryPtr get_query(new YTsaurusGetQuery(lock_metadata_path));
     auto read_buff = executeQuery(get_query);
@@ -322,7 +327,7 @@ bool YTsaurusClient::checkSchemaCompatibility(const String & table_path, const S
     return true;
 }
 
-size_t YTsaurusClient::getTableNumberOfRows(const String& table_path)
+size_t YTsaurusClient::getTableNumberOfRows(const String & table_path)
 {
     String lock_metadata_path = fmt::format("{}/@row_count", table_path);
     YTsaurusQueryPtr get_query(new YTsaurusGetQuery(lock_metadata_path));
@@ -332,7 +337,7 @@ size_t YTsaurusClient::getTableNumberOfRows(const String& table_path)
     return row_count;
 }
 
-YTsaurusTableLock::YTsaurusTableLock(YTsaurusClientPtr client_, const String& cypress_path_, size_t transaction_timeout_ms)
+YTsaurusTableLock::YTsaurusTableLock(YTsaurusClientPtr client_, const String & cypress_path_, size_t transaction_timeout_ms)
     : client(client_)
 {
     transaction_id = client->startTx(transaction_timeout_ms);

--- a/src/Core/YTsaurus/YTsaurusClient.cpp
+++ b/src/Core/YTsaurus/YTsaurusClient.cpp
@@ -20,6 +20,7 @@
 
 
 #include <memory>
+#include <utility>
 
 
 namespace DB
@@ -42,15 +43,54 @@ YTsaurusClient::YTsaurusClient(ContextPtr context_, const ConnectionInfo & conne
 }
 
 
-ReadBufferPtr YTsaurusClient::readTable(const String & cypress_path)
+ReadBufferPtr YTsaurusClient::readTable(const String & cypress_path, const std::pair<size_t, size_t>& rows_range)
 {
-    YTsaurusQueryPtr read_table_query(new YTsaurusReadTableQuery(cypress_path));
+    YTsaurusQueryPtr read_table_query(new YTsaurusReadTableQuery(cypress_path, rows_range));
     return executeQuery(read_table_query);
+}
+
+String YTsaurusClient::startTx(size_t timeout_ms)
+{
+    YTsaurusQueryPtr start_tx_query(new YTsaurusStartTxQuery(timeout_ms));
+    auto read_buff = executeQuery(start_tx_query);
+    String res;
+    // Generally the result of each YTsaurus query should be json.
+    // But... for start_tx query the result always doble quoted string.
+    readDoubleQuotedString(res, *read_buff);
+    return res;
+}
+
+void YTsaurusClient::commitTx(const String& transaction_id)
+{
+    YTsaurusQueryPtr commit_tx_query(new YTsaurusCommitTxQuery(transaction_id));
+    executeQuery(commit_tx_query);
+}
+
+String YTsaurusClient::lock(const String& cypress_path, const String& transaction_id)
+{
+    YTsaurusQueryPtr lock_query(new YTsaurusLockQuery(cypress_path, transaction_id));
+    auto read_buff = executeQuery(lock_query);
+    String res;
+    // Generally the result of each YTsaurus query should be json.
+    // But... for start_tx query the result always doble quoted string.
+    readDoubleQuotedString(res, *read_buff);
+    return res;
+}
+
+String YTsaurusClient::getNodeIdFromLock(const String & lock_id)
+{
+
+    String lock_metadata_path = fmt::format("{}/{}/@node_id", LOCKS_STORAGE_CYPRESS_PATH, lock_id);
+    YTsaurusQueryPtr get_query(new YTsaurusGetQuery(lock_metadata_path));
+    auto read_buff = executeQuery(get_query);
+    String res;
+    readDoubleQuotedString(res, *read_buff);
+    return res;
 }
 
 YTsaurusNodeType YTsaurusClient::getNodeType(const String & cypress_path)
 {
-    auto json_ptr = getTableInfo(cypress_path);
+    auto json_ptr = getNodeMetadata(cypress_path);
     return getNodeTypeFromAttributes(json_ptr);
 }
 
@@ -197,21 +237,21 @@ Poco::Dynamic::Var YTsaurusClient::getMetadata(const String & path)
     auto buf = executeQuery(get_query);
 
     String json_str;
-    readJSONObjectPossiblyInvalid(json_str, *buf);
 
+    readStringUntilEOF(json_str, *buf);
     Poco::JSON::Parser parser;
     Poco::Dynamic::Var json = parser.parse(json_str);
     return json;
 }
 
-Poco::JSON::Object::Ptr YTsaurusClient::getTableInfo(const String & cypress_path)
+Poco::JSON::Object::Ptr YTsaurusClient::getNodeMetadata(const String & cypress_path)
 {
     String attributes_path = cypress_path + "/@";
     auto json = getMetadata(attributes_path);
     return json.extract<Poco::JSON::Object::Ptr>();
 }
 
-Poco::Dynamic::Var YTsaurusClient::getTableAttribute(const String & cypress_path, const String & attribute_name)
+Poco::Dynamic::Var YTsaurusClient::getNodeAttribute(const String & cypress_path, const String & attribute_name)
 {
     String attribute_path = cypress_path + "/@" + attribute_name;
     auto json = getMetadata(attribute_path);
@@ -220,7 +260,7 @@ Poco::Dynamic::Var YTsaurusClient::getTableAttribute(const String & cypress_path
 
 YTsaurusClient::SchemaDescription YTsaurusClient::getTableSchema(const String & cypress_path)
 {
-    auto schema = getTableAttribute(cypress_path, "schema");
+    auto schema = getNodeAttribute(cypress_path, "schema");
     const auto & schema_json = schema.extract<Poco::JSON::Object::Ptr>();
 
     if (!schema_json->has("$attributes"))
@@ -280,6 +320,31 @@ bool YTsaurusClient::checkSchemaCompatibility(const String & table_path, const S
         }
     }
     return true;
+}
+
+size_t YTsaurusClient::getTableNumberOfRows(const String& table_path)
+{
+    String lock_metadata_path = fmt::format("{}/@row_count", table_path);
+    YTsaurusQueryPtr get_query(new YTsaurusGetQuery(lock_metadata_path));
+    auto read_buff = executeQuery(get_query);
+    size_t row_count;
+    DB::readIntText(row_count, *read_buff);
+    return row_count;
+}
+
+YTsaurusTableLock::YTsaurusTableLock(YTsaurusClientPtr client_, const String& cypress_path_, size_t transaction_timeout_ms)
+    : client(client_)
+{
+    transaction_id = client->startTx(transaction_timeout_ms);
+    lock_id = client->lock(cypress_path_, transaction_id);
+    auto node_id = client->getNodeIdFromLock(lock_id);
+    node_cypress_path = fmt::format("#{}",node_id);
+}
+
+YTsaurusTableLock::~YTsaurusTableLock()
+{
+    if (!transaction_id.empty())
+        client->commitTx(transaction_id);
 }
 
 }

--- a/src/Core/YTsaurus/YTsaurusClient.h
+++ b/src/Core/YTsaurus/YTsaurusClient.h
@@ -1,6 +1,4 @@
 #pragma once
-#include <unordered_map>
-#include <utility>
 #include "config.h"
 
 #if USE_YTSAURUS
@@ -19,6 +17,9 @@
 #include <Poco/JSON/Parser.h>
 #include <IO/ReadWriteBufferFromHTTP.h>
 
+#include <memory>
+#include <unordered_map>
+#include <utility>
 
 #include <boost/noncopyable.hpp>
 
@@ -56,14 +57,25 @@ public:
 
     const ConnectionInfo & getConnectionInfo() { return connection_info; }
 
-    ReadBufferPtr readTable(const String & cypress_path);
+    ReadBufferPtr readTable(const String & cypress_path, const std::pair<size_t, size_t>& rows_range);
 
     ReadBufferPtr lookupRows(const String & cypress_path, const Block & lookup_block_input);
 
     ReadBufferPtr selectRows(const String & cypress_path, const String& column_names_str);
+
     ReadBufferPtr selectRows(const String & cypress_path, const ColumnsWithTypeAndName& columns);
 
     YTsaurusNodeType getNodeType(const String & cypress_path);
+
+    String startTx(size_t timeout_ms);
+
+    void commitTx(const String & transaction_id);
+
+    String getNodeIdFromLock(const String & lock_id);
+
+    String lock(const String& cypress_path, const String & transaction_id);
+
+    size_t getTableNumberOfRows(const String& table_path);
 
     struct SchemaDescription
     {
@@ -75,9 +87,9 @@ public:
 
     bool checkSchemaCompatibility(const String & table_path, const SharedHeader & sample_block, String & reason, bool allow_nullable);
 private:
-    Poco::JSON::Object::Ptr getTableInfo(const String & cypress_path);
+    Poco::JSON::Object::Ptr getNodeMetadata(const String & cypress_path);
 
-    Poco::Dynamic::Var getTableAttribute(const String & cypress_path, const String & attribute_name);
+    Poco::Dynamic::Var getNodeAttribute(const String & cypress_path, const String & attribute_name);
 
     YTsaurusNodeType getNodeTypeFromAttributes(const Poco::JSON::Object::Ptr & json_ptr);
 
@@ -94,9 +106,28 @@ private:
     const ConnectionInfo connection_info;
     LoggerPtr log;
     size_t recently_used_url_index = 0;
+    constexpr static String LOCKS_STORAGE_CYPRESS_PATH = "//sys/locks";
 };
 
 using YTsaurusClientPtr = std::shared_ptr<YTsaurusClient>;
+
+class YTsaurusTableLock
+{
+public:
+    YTsaurusTableLock(YTsaurusClientPtr client_, const String& cypress_path_, size_t transaction_timeout_ms);
+    String getNodePath() const
+    {
+        return node_cypress_path;
+    }
+    ~YTsaurusTableLock();
+private:
+    YTsaurusClientPtr client;
+    String transaction_id;
+    String lock_id;
+    String node_cypress_path;
+};
+
+using YTsaurusTableLockPtr = std::shared_ptr<YTsaurusTableLock>;
 
 }
 

--- a/src/Core/YTsaurus/YTsaurusClient.h
+++ b/src/Core/YTsaurus/YTsaurusClient.h
@@ -55,9 +55,11 @@ public:
 
     explicit YTsaurusClient(ContextPtr context_, const ConnectionInfo & connection_info_);
 
+    YTsaurusClient(const YTsaurusClient & other);
+
     const ConnectionInfo & getConnectionInfo() { return connection_info; }
 
-    ReadBufferPtr readTable(const String & cypress_path, const std::pair<size_t, size_t>& rows_range);
+    ReadBufferPtr readTable(const String & cypress_path, const std::pair<size_t, size_t> & rows_range);
 
     ReadBufferPtr lookupRows(const String & cypress_path, const Block & lookup_block_input);
 
@@ -73,7 +75,7 @@ public:
 
     String getNodeIdFromLock(const String & lock_id);
 
-    String lock(const String& cypress_path, const String & transaction_id);
+    String lock(const String & cypress_path, const String & transaction_id);
 
     size_t getTableNumberOfRows(const String& table_path);
 

--- a/src/Dictionaries/YTsaurusDictionarySource.cpp
+++ b/src/Dictionaries/YTsaurusDictionarySource.cpp
@@ -144,12 +144,17 @@ YTsarususDictionarySource::~YTsarususDictionarySource() = default;
 BlockIO YTsarususDictionarySource::loadAll()
 {
     BlockIO io;
-    io.pipeline = QueryPipeline(YTsaurusSourceFactory::createSource(client, {
-        .cypress_path = configuration->cypress_path,
-        .settings = configuration->settings,
-        .select_rows_columns = configuration->ytsaurus_columns_description,
-        .check_types_allow_nullable = true,
-    }, sample_block, max_block_size));
+    io.pipeline = QueryPipeline(YTsaurusSourceFactory::createPipe(
+          client
+        , configuration->cypress_path
+        , { .settings = configuration->settings,
+            .select_rows_columns = configuration->ytsaurus_columns_description,
+            .check_types_allow_nullable = true,
+        }
+        , sample_block
+        , max_block_size
+        // TODO enable parallelization for reads from dictionary
+        , 1));
     return io;
 }
 
@@ -164,7 +169,15 @@ BlockIO YTsarususDictionarySource::loadIds(const std::vector<UInt64> & ids)
     auto block = blockForIds(dict_struct, ids);
 
     BlockIO io;
-    io.pipeline = QueryPipeline(YTsaurusSourceFactory::createSource(client, {.cypress_path = configuration->cypress_path, .settings = configuration->settings, .lookup_input_block = std::move(block), .check_types_allow_nullable = true}, sample_block, max_block_size));
+    io.pipeline = QueryPipeline(YTsaurusSourceFactory::createPipe(
+        client
+        , configuration->cypress_path
+        , {.settings = configuration->settings, .lookup_input_block = std::move(block), .check_types_allow_nullable = true}
+        , sample_block
+        , max_block_size
+        // Parallel reads supported only for static tables
+        , 1
+    ));
     return io;
 }
 
@@ -182,7 +195,15 @@ BlockIO YTsarususDictionarySource::loadKeys(const Columns & key_columns, const s
     auto block = blockForKeys(dict_struct, key_columns, requested_rows);
 
     BlockIO io;
-    io.pipeline = QueryPipeline(YTsaurusSourceFactory::createSource(client, {.cypress_path = configuration->cypress_path, .settings = configuration->settings, .lookup_input_block = std::move(block), .check_types_allow_nullable = true}, sample_block, max_block_size));
+    io.pipeline = QueryPipeline(YTsaurusSourceFactory::createPipe(
+          client
+        , configuration->cypress_path
+        , {.settings = configuration->settings, .lookup_input_block = std::move(block), .check_types_allow_nullable = true}
+         , sample_block
+         , max_block_size
+         // Parallel reads supported only for static tables
+         , 1
+    ));
     return io;
 }
 

--- a/src/Processors/Sources/YTsaurusSource.cpp
+++ b/src/Processors/Sources/YTsaurusSource.cpp
@@ -4,6 +4,9 @@
 #include <Processors/Sources/YTsaurusSource.h>
 #include <Storages/YTsaurus/YTsaurusSettings.h>
 
+#include <cstddef>
+#include <memory>
+#include <utility>
 
 namespace DB
 {
@@ -20,41 +23,60 @@ namespace YTsaurusSetting
     extern const YTsaurusSettingsBool check_table_schema;
     extern const YTsaurusSettingsBool skip_unknown_columns;
     extern const YTsaurusSettingsBool force_read_table;
+    extern const YTsaurusSettingsBool use_lock;
+    extern const YTsaurusSettingsMilliseconds transaction_timeout_ms;
+    extern const YTsaurusSettingsUInt64 min_rows_for_spawn_stream;
+    extern const YTsaurusSettingsUInt64 max_streams;
 }
 
 YTsaurusTableSourceStaticTable::YTsaurusTableSourceStaticTable(
-    YTsaurusClientPtr client_, const YTsaurusTableSourceOptions & source_options_, const SharedHeader & sample_block_, const UInt64 & max_block_size_)
-    : ISource(sample_block_), client(std::move(client_)), sample_block(sample_block_), max_block_size(max_block_size_)
-{
-    read_buffer = client->readTable(source_options_.cypress_path);
-    FormatSettings format_settings{.skip_unknown_fields = source_options_.settings[YTsaurusSetting::skip_unknown_columns]};
-    format_settings.json.read_map_as_array_of_tuples = true;
-
-    json_row_format = std::make_unique<JSONEachRowRowInputFormat>(
-        *read_buffer.get(), sample_block, IRowInputFormat::Params({.max_block_size_rows = max_block_size}), format_settings, false);
-}
-
-
-YTsaurusTableSourceDynamicTable::YTsaurusTableSourceDynamicTable(
-    YTsaurusClientPtr client_, const YTsaurusTableSourceOptions & source_options_, const SharedHeader & sample_block_, const UInt64 & max_block_size_)
+    YTsaurusClientPtr client_,  const String & cypress_path_, std::pair<size_t, size_t> rows_range_, const YTsaurusTableSourceOptions & source_options_, const SharedHeader & sample_block_, const UInt64 & max_block_size_)
     : ISource(sample_block_)
     , client(std::move(client_))
+    , cypress_path(cypress_path_)
+    , rows_range(std::move(rows_range_))
     , source_options(source_options_)
     , sample_block(sample_block_)
     , max_block_size(max_block_size_)
-    , format_settings({.skip_unknown_fields = source_options.settings[YTsaurusSetting::skip_unknown_columns]})
-    , use_lookups(!source_options.settings[YTsaurusSetting::force_read_table] && source_options.lookup_input_block)
+    , json_row_format(nullptr)
+{
+}
+
+Chunk YTsaurusTableSourceStaticTable::generate()
+{
+    if (!json_row_format)
+    {
+        FormatSettings format_settings{.skip_unknown_fields = source_options.settings[YTsaurusSetting::skip_unknown_columns]};
+        format_settings.json.read_map_as_array_of_tuples = true;
+        read_buffer = client->readTable(cypress_path, rows_range);
+
+        json_row_format = std::make_unique<JSONEachRowRowInputFormat>(
+            *read_buffer.get(), sample_block, IRowInputFormat::Params({.max_block_size_rows = max_block_size}), format_settings, false);
+
+    }
+    return json_row_format->read();
+}
+
+YTsaurusTableSourceDynamicTable::YTsaurusTableSourceDynamicTable(
+    YTsaurusClientPtr client_, const String & cypress_path, const YTsaurusTableSourceOptions & source_options_, const SharedHeader & sample_block_, const UInt64 & max_block_size_)
+    : ISource(sample_block_)
+    , client(std::move(client_))
+    , sample_block(sample_block_)
+    , max_block_size(max_block_size_)
+    , format_settings({.skip_unknown_fields = source_options_.settings[YTsaurusSetting::skip_unknown_columns]})
+    , use_lookups(!source_options_.settings[YTsaurusSetting::force_read_table] && source_options_.lookup_input_block)
+    , table_lock(source_options_.table_lock)
 {
     if (use_lookups)
     {
-        read_buffer = client->lookupRows(source_options.cypress_path, *source_options.lookup_input_block);
+        read_buffer = client->lookupRows(cypress_path, *source_options_.lookup_input_block);
     }
     else
     {
-        if (source_options.select_rows_columns)
-            read_buffer = client->selectRows(source_options.cypress_path, *source_options.select_rows_columns);
+        if (source_options_.select_rows_columns)
+            read_buffer = client->selectRows(cypress_path, *source_options_.select_rows_columns);
         else
-            read_buffer = client->selectRows(source_options.cypress_path, sample_block->getColumnsWithTypeAndName());
+            read_buffer = client->selectRows(cypress_path, sample_block->getColumnsWithTypeAndName());
     }
 
     format_settings.json.read_map_as_array_of_tuples = true;
@@ -62,29 +84,74 @@ YTsaurusTableSourceDynamicTable::YTsaurusTableSourceDynamicTable(
         *read_buffer.get(), sample_block, IRowInputFormat::Params({.max_block_size_rows = max_block_size}), format_settings, false);
 }
 
-std::shared_ptr<ISource> YTsaurusSourceFactory::createSource(YTsaurusClientPtr client, const YTsaurusTableSourceOptions source_options, const SharedHeader & sample_block, const UInt64 max_block_size)
+Pipe YTsaurusSourceFactory::createPipe(
+      YTsaurusClientPtr client
+    , const String & table_cypress_path
+    , YTsaurusTableSourceOptions source_options
+    , const SharedHeader & sample_block
+    , const UInt64 max_block_size
+    , UInt64 max_streams)
 {
-    if (source_options.cypress_path.empty())
+    if (table_cypress_path.empty())
     {
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Cypress path are empty for ytsarurus source factory.");
     }
     String reason;
-    if (source_options.settings[YTsaurusSetting::check_table_schema] && !client->checkSchemaCompatibility(source_options.cypress_path, sample_block, reason, source_options.check_types_allow_nullable))
+    const YTsaurusSettings& settings = source_options.settings;
+    String cypress_path;
+    if (settings[YTsaurusSetting::use_lock])
     {
-        throw Exception(ErrorCodes::INCORRECT_DATA, "ClickHouse table schema doesn't match with yt table. Reason: {}", reason);
-    }
-    auto yt_node_type = client->getNodeType(source_options.cypress_path);
-    if (yt_node_type == YTsaurusNodeType::STATIC_TABLE)
-    {
-        return std::make_shared<YTsaurusTableSourceStaticTable>(client, source_options, sample_block, max_block_size);
-    }
-    else if (yt_node_type == YTsaurusNodeType::DYNAMIC_TABLE)
-    {
-        return std::make_shared<YTsaurusTableSourceDynamicTable>(client, source_options, sample_block, max_block_size);
+        source_options.table_lock = std::make_shared<YTsaurusTableLock>(client, table_cypress_path, source_options.settings[YTsaurusSetting::transaction_timeout_ms].totalMilliseconds());
+        cypress_path = source_options.table_lock->getNodePath();
     }
     else
     {
-        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Node {} has unsupported type.", source_options.cypress_path);
+        cypress_path = table_cypress_path;
+    }
+
+    if (source_options.settings[YTsaurusSetting::check_table_schema] && !client->checkSchemaCompatibility(cypress_path, sample_block, reason, source_options.check_types_allow_nullable))
+    {
+        throw Exception(ErrorCodes::INCORRECT_DATA, "ClickHouse table schema doesn't match with yt table. Reason: {}", reason);
+    }
+    auto yt_node_type = client->getNodeType(cypress_path);
+    if (yt_node_type == YTsaurusNodeType::STATIC_TABLE)
+    {
+        auto rows_count = client->getTableNumberOfRows(cypress_path);
+        size_t max_streams_allowed;
+
+        if (!max_streams)
+            max_streams_allowed = settings[YTsaurusSetting::max_streams];
+        else
+            max_streams_allowed = std::min<size_t>(settings[YTsaurusSetting::max_streams], max_streams);
+
+        auto pipes_num = std::min(max_streams_allowed,
+            std::max<size_t>(1u, rows_count / settings[YTsaurusSetting::min_rows_for_spawn_stream]
+        ));
+
+        size_t rows_batch_count = rows_count / pipes_num;
+        Pipes pipes;
+        LOG_DEBUG(::getLogger("YTsaurusSourceFactory"), "Will read static table {} with {} streams and rows {} in each", table_cypress_path, pipes_num, rows_batch_count);
+
+        for (auto i = 0u; i < pipes_num; ++i)
+        {
+            size_t row_from = i * rows_batch_count;
+            size_t row_to = (i + 1 == pipes_num) ? rows_count :  (i + 1) * rows_batch_count;
+
+            pipes.emplace_back(std::make_shared<YTsaurusTableSourceStaticTable>(
+               client, cypress_path, std::make_pair(row_from, row_to), source_options, sample_block, max_block_size
+            ));
+        }
+        auto pipe = Pipe::unitePipes(std::move(pipes));
+        pipe.resize(pipes_num);
+        return pipe;
+    }
+    else if (yt_node_type == YTsaurusNodeType::DYNAMIC_TABLE)
+    {
+        return Pipe(std::make_shared<YTsaurusTableSourceDynamicTable>(client, cypress_path, source_options, sample_block, max_block_size));
+    }
+    else
+    {
+        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Node {} has unsupported type.", cypress_path);
     }
 }
 

--- a/src/Processors/Sources/YTsaurusSource.h
+++ b/src/Processors/Sources/YTsaurusSource.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include "config.h"
 
 #if USE_YTSAURUS
@@ -8,6 +9,7 @@
 #include <Core/YTsaurus/YTsaurusClient.h>
 #include <Processors/Formats/Impl/JSONEachRowRowInputFormat.h>
 #include <Storages/YTsaurus/YTsaurusSettings.h>
+#include <QueryPipeline/Pipe.h>
 #include <optional>
 #include <memory>
 
@@ -16,10 +18,10 @@ namespace DB
 
 struct YTsaurusTableSourceOptions
 {
-    const String cypress_path;
     YTsaurusSettings settings;
     std::optional<Block> lookup_input_block = std::nullopt;
     std::optional<String> select_rows_columns = std::nullopt;
+    YTsaurusTableLockPtr table_lock = nullptr;
     bool check_types_allow_nullable = false;
 };
 
@@ -27,26 +29,30 @@ class YTsaurusTableSourceStaticTable final : public ISource
 {
 public:
     YTsaurusTableSourceStaticTable(
-        YTsaurusClientPtr client_, const YTsaurusTableSourceOptions & source_options_, const SharedHeader & sample_block_, const UInt64 & max_block_size_);
+        YTsaurusClientPtr client_, const String & cypress_path, std::pair<size_t, size_t> rows_range_, const YTsaurusTableSourceOptions & source_options_, const SharedHeader & sample_block_, const UInt64 & max_block_size_);
     ~YTsaurusTableSourceStaticTable() override = default;
 
     String getName() const override { return "YTsaurusTableSourceStaticTable"; }
 
 private:
-    Chunk generate() override { return json_row_format->read(); }
+    Chunk generate() override;
 
     YTsaurusClientPtr client;
+    const String cypress_path;
+    std::pair<size_t, size_t> rows_range;
+    const YTsaurusTableSourceOptions source_options;
     const SharedHeader sample_block;
-    UInt64 max_block_size;
-    ReadBufferPtr read_buffer;
+    const UInt64 max_block_size;
+
     std::unique_ptr<JSONEachRowRowInputFormat> json_row_format;
+    ReadBufferPtr read_buffer;
 };
 
 class YTsaurusTableSourceDynamicTable final : public ISource
 {
 public:
     YTsaurusTableSourceDynamicTable(
-        YTsaurusClientPtr client_, const YTsaurusTableSourceOptions & source_options_, const SharedHeader & sample_block_, const UInt64 & max_block_size_);
+        YTsaurusClientPtr client_, const String & cypress_path, const YTsaurusTableSourceOptions & source_options_, const SharedHeader & sample_block_, const UInt64 & max_block_size_);
     ~YTsaurusTableSourceDynamicTable() override = default;
 
     String getName() const override { return "YTsaurusTableSourceDynamicTable"; }
@@ -55,20 +61,20 @@ private:
     Chunk generate() override { return json_row_format->read(); }
 
     YTsaurusClientPtr client;
-    const YTsaurusTableSourceOptions & source_options;
     const SharedHeader sample_block;
     UInt64 max_block_size;
     FormatSettings format_settings;
+    bool use_lookups;
+    YTsaurusTableLockPtr table_lock;
     ReadBufferPtr read_buffer;
     std::unique_ptr<JSONEachRowRowInputFormat> json_row_format;
 
-    bool use_lookups;
 };
 
 struct YTsaurusSourceFactory
 {
-    static std::shared_ptr<ISource>
-    createSource(YTsaurusClientPtr client, YTsaurusTableSourceOptions source_options, const SharedHeader & sample_block, UInt64 max_block_size);
+    static Pipe
+    createPipe(YTsaurusClientPtr client, const String & cypress_path, YTsaurusTableSourceOptions source_options, const SharedHeader & sample_block, UInt64 max_block_size, size_t max_streams);
 };
 
 }

--- a/src/Processors/Sources/YTsaurusSource.h
+++ b/src/Processors/Sources/YTsaurusSource.h
@@ -74,7 +74,7 @@ private:
 struct YTsaurusSourceFactory
 {
     static Pipe
-    createPipe(YTsaurusClientPtr client, const String & cypress_path, YTsaurusTableSourceOptions source_options, const SharedHeader & sample_block, UInt64 max_block_size, size_t max_streams);
+    createPipe(YTsaurusClientPtr client, const String & cypress_path, YTsaurusTableSourceOptions source_options, const SharedHeader & sample_block, UInt64 max_block_size, UInt64 max_streams);
 };
 
 }

--- a/src/Storages/YTsaurus/StorageYTsaurus.cpp
+++ b/src/Storages/YTsaurus/StorageYTsaurus.cpp
@@ -69,7 +69,7 @@ Pipe StorageYTsaurus::read(
     ContextPtr context,
     QueryProcessingStage::Enum /*processed_stage*/,
     size_t max_block_size,
-    size_t /*num_streams*/)
+    size_t num_streams)
 {
     storage_snapshot->check(column_names);
 
@@ -82,9 +82,7 @@ Pipe StorageYTsaurus::read(
     }
 
     YTsaurusClientPtr client(new YTsaurusClient(context, client_connection_info));
-    auto ptr = YTsaurusSourceFactory::createSource(client, {.cypress_path = cypress_path, .settings = settings}, sample_block, max_block_size);
-
-    return Pipe(ptr);
+    return YTsaurusSourceFactory::createPipe(client, cypress_path, {.settings = settings}, sample_block, max_block_size, num_streams);
 }
 
 YTsaurusStorageConfiguration StorageYTsaurus::processNamedCollectionResult(

--- a/src/Storages/YTsaurus/StorageYTsaurus.h
+++ b/src/Storages/YTsaurus/StorageYTsaurus.h
@@ -24,7 +24,8 @@ struct YTsaurusStorageConfiguration
 
 /**
  *  Read only.
- *  One stream only.
+ *  One stream for dynamic table source.
+ *  Multiple stream for static table source.
  */
 class StorageYTsaurus final : public IStorage
 {

--- a/src/Storages/YTsaurus/YTsaurusSettings.cpp
+++ b/src/Storages/YTsaurus/YTsaurusSettings.cpp
@@ -22,6 +22,10 @@ namespace ErrorCodes
     DECLARE(Bool, force_read_table, false, "Force the use of read table instead of lookups for dynamic tables.", 0) \
     DECLARE(Bool, encode_utf8, false, "Enable the utf8 encoding in ytsaurus responses.", 0) \
     DECLARE(Bool, enable_heavy_proxy_redirection, true, "Enable redirection to heavy proxies for heavy queries. See: https://ytsaurus.tech/docs/en/user-guide/proxy/http-reference#hosts", 0) \
+    DECLARE(Bool, use_lock, true, "Lock table to do request, to get consistent snapshot. See: https://ytsaurus.tech/docs/en/user-guide/storage/transactions#locks", 0) \
+    DECLARE(Milliseconds, transaction_timeout_ms, 150000, "Timeout for YTSaurus transaction.", 0) \
+    DECLARE(UInt64, min_rows_for_spawn_stream, 1000, "Min number of rows to spawn the new stream. To use 8 streams the table must hold at least 8 * `min_rows_for_spawn_stream` rows.", 0) \
+    DECLARE(UInt64, max_streams, 4, "Max number of streams to read from static table.", 0) \
 
 DECLARE_SETTINGS_TRAITS(YTsaurusSettingsTraits, LIST_OF_YTSAURUS_SETTINGS)
 IMPLEMENT_SETTINGS_TRAITS(YTsaurusSettingsTraits, LIST_OF_YTSAURUS_SETTINGS)

--- a/src/Storages/YTsaurus/YTsaurusSettings.h
+++ b/src/Storages/YTsaurus/YTsaurusSettings.h
@@ -18,7 +18,9 @@ class NamedCollection;
 struct YTsaurusSettingsImpl;
 
 #define YTSAURUS_SETTINGS_SUPPORTED_TYPES(CLASS_NAME, M) \
-    M(CLASS_NAME, Bool)
+    M(CLASS_NAME, Bool) \
+    M(CLASS_NAME, Milliseconds) \
+    M(CLASS_NAME, UInt64) \
 
 YTSAURUS_SETTINGS_SUPPORTED_TYPES(YTsaurusSettings, DECLARE_SETTING_TRAIT)
 

--- a/tests/integration/test_ytsaurus/test_tables.py
+++ b/tests/integration/test_ytsaurus/test_tables.py
@@ -568,7 +568,7 @@ def test_yt_parallelization(started_cluster):
         SETTINGS max_streams = 4, min_rows_for_spawn_stream = 25
         """
     )
-    expected_sum = (0 + (N - 1)) * N / 2
+    expected_sum = (0 + (N - 1)) * N // 2
     assert int(instance.query("SELECT sum(a) FROM t0")) == expected_sum
     instance.query("DROP TABLE t0 SYNC")
     yt.remove_table(table)

--- a/tests/integration/test_ytsaurus/test_tables.py
+++ b/tests/integration/test_ytsaurus/test_tables.py
@@ -552,3 +552,23 @@ def test_yt_named_collection(started_cluster):
     instance.query("DROP NAMED COLLECTION ytsaurus_nc")
 
     yt.remove_table(table)
+
+
+def test_yt_parallelization(started_cluster):
+    table = "//tmp/table"
+    yt = YTsaurusCLI(started_cluster, instance, yt_uri_helper.host, yt_uri_helper.port)
+    N = 111
+    data = "".join([f'{{"a" : {i} }}' for i in range(0, N)])
+
+    yt.create_table(table, data)
+    instance.query(
+        f"""
+        CREATE TABLE t0(a Int32)
+        ENGINE=YTsaurus('{yt_uri_helper.uri}', '//tmp/table', '{yt_uri_helper.token}')
+        SETTINGS max_streams = 4, min_rows_for_spawn_stream = 25
+        """
+    )
+    expected_sum = (0 + (N - 1)) * N / 2
+    assert int(instance.query("SELECT sum(a) FROM t0")) == expected_sum
+    instance.query("DROP TABLE t0 SYNC")
+    yt.remove_table(table)


### PR DESCRIPTION
Actually the PR contains several improvements:
* Enable creating several  streams to read from ytsaurus, to improve performance 
* Enable reading from YTsaurus tables over transaction + lock  to work with the consistent snapshot of table.

Execution comparison with the 300MB YTsaurus table:
|               | min         | max    | median |
| ------------- | ----------- | ------ | -------|
| thread 1 | 15.245      | 16.648 | 15.614 |
| thread 2   | 9.004      | 11.101 | 9.313 |
| threads 4       | 6.704         | 8.027   | 6.902 |
| thread 8   | 4.911      | 6.265 | 5.608 |
| thread 16   | 3.248      | 5.104 | 4.512 |

### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Enable parallel reads from YTsaurus table engine.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.37`
<!-- ch-version-info:end -->