### PR TITLE
Exists with mutations execute on initator

### DIFF
--- a/src/Interpreters/ExecuteScalarSubqueriesVisitor.cpp
+++ b/src/Interpreters/ExecuteScalarSubqueriesVisitor.cpp
@@ -340,6 +340,23 @@ void ExecuteScalarSubqueriesMatcher::visit(const ASTFunction & func, ASTPtr & as
                         out.push_back(&func.arguments->children[i]);
         }
     }
+    else if (func.name == "exists")
+    {
+        /// Since exists does not use parameters, and the only
+        /// argument to exists function is a subquery, out
+        /// should not have arguments. Thus, the following lines could
+        /// probably be changed with just `return`. However, we follow
+        /// the style that is provided in the first if.
+        for (auto & child : ast->children)
+        {
+            if (child != func.arguments)
+                out.push_back(&child);
+            else
+                for (size_t i = 0, size = func.arguments->children.size(); i < size; ++i)
+                    if (i != 0 || !func.arguments->children[i]->as<ASTSubquery>())
+                        out.push_back(&func.arguments->children[i]);
+        }
+    }
     else
         for (auto & child : ast->children)
             out.push_back(&child);

--- a/tests/queries/0_stateless/03925_exists_with_mutations_execute_on_initator.sql
+++ b/tests/queries/0_stateless/03925_exists_with_mutations_execute_on_initator.sql
@@ -14,7 +14,7 @@ ALTER TABLE t_mutations_nondeterministic
         SELECT count()
         FROM system.numbers
         WHERE number < 25
-    )) WHERE 1)
+    )) WHERE 1);
 
 ALTER TABLE t_mutations_nondeterministic (UPDATE v = now((exists((SELECT 1023)))) WHERE NULL);
 

--- a/tests/queries/0_stateless/03925_exists_with_mutations_execute_on_initator.sql
+++ b/tests/queries/0_stateless/03925_exists_with_mutations_execute_on_initator.sql
@@ -9,6 +9,14 @@ ORDER BY id;
 
 INSERT INTO t_mutations_nondeterministic VALUES (10, 20);
 
+ALTER TABLE t_mutations_nondeterministic
+    (UPDATE v = exists((
+        SELECT count()
+        FROM system.numbers
+        WHERE number < 25
+    )) WHERE 1)
+
 ALTER TABLE t_mutations_nondeterministic (UPDATE v = now((exists((SELECT 1023)))) WHERE NULL);
+
 
 DROP TABLE t_mutations_nondeterministic;

--- a/tests/queries/0_stateless/03925_exists_with_mutations_execute_on_initator.sql
+++ b/tests/queries/0_stateless/03925_exists_with_mutations_execute_on_initator.sql
@@ -9,6 +9,6 @@ ORDER BY id;
 
 INSERT INTO t_mutations_nondeterministic VALUES (10, 20);
 
-ALTER TABLE t_mutations_nondeterministic (UPDATE v = now((exists((SELECT 1023)))) WHERE NULL);
+ALTER TABLE t_mutations_nondeterministic (UPDATE v = exists((SELECT 1023)) WHERE NULL);
 
 DROP TABLE t_mutations_nondeterministic;

--- a/tests/queries/0_stateless/03925_exists_with_mutations_execute_on_initator.sql
+++ b/tests/queries/0_stateless/03925_exists_with_mutations_execute_on_initator.sql
@@ -1,0 +1,14 @@
+DROP TABLE IF EXISTS t_mutations_nondeterministic;
+
+SET mutations_execute_subqueries_on_initiator = 1;
+SET mutations_execute_nondeterministic_on_initiator = 1;
+
+CREATE TABLE t_mutations_nondeterministic (`id` UInt64, `v` UInt64)
+ENGINE = MergeTree()
+ORDER BY id;
+
+INSERT INTO t_mutations_nondeterministic VALUES (10, 20);
+
+ALTER TABLE t_mutations_nondeterministic (UPDATE v = now((exists((SELECT 1023)))) WHERE NULL);
+
+DROP TABLE t_mutations_nondeterministic;

--- a/tests/queries/0_stateless/03925_exists_with_mutations_execute_on_initator.sql
+++ b/tests/queries/0_stateless/03925_exists_with_mutations_execute_on_initator.sql
@@ -9,6 +9,6 @@ ORDER BY id;
 
 INSERT INTO t_mutations_nondeterministic VALUES (10, 20);
 
-ALTER TABLE t_mutations_nondeterministic (UPDATE v = exists((SELECT 1023)) WHERE NULL);
+ALTER TABLE t_mutations_nondeterministic (UPDATE v = now((exists((SELECT 1023)))) WHERE NULL);
 
 DROP TABLE t_mutations_nondeterministic;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

The problem appears when we set a setting: 

```
SET mutations_execute_subqueries_on_initiator = 1;
```

And run an `ALTER` query with a function `exists` with a scalar subquery inside. This causes the scalar subquery in `exsits` being evaluated to a number. Then, after the mutation is applied, we get either an error, or we get `OK` with mutation stored with a corrupt command, which makes table unloadable on the next server restart. The response of the server depends of the query. Test in the pull request shows two queries, that cause different errors, but a rooted in the same problem.

AST fuzzer report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96790&sha=cbdee8ffcd02bf966e588b7d06f2e39718da5486&name_0=PR&name_1=AST%20fuzzer%20%28amd_debug%29
https://github.com/ClickHouse/ClickHouse/pull/96790

Continuation of https://github.com/ClickHouse/ClickHouse/pull/96985


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.970`
<!-- ch-version-info:end -->