### PR TITLE
Fix data races in quantile metrics

### DIFF
--- a/src/Common/AggregatedMetrics.h
+++ b/src/Common/AggregatedMetrics.h
@@ -27,6 +27,8 @@ private:
 
 class GlobalQuantile
 {
+    void updateBuckets(std::optional<CurrentMetrics::Value> prev_value, std::optional<CurrentMetrics::Value> new_value) noexcept;
+
 public:
     explicit GlobalQuantile(CurrentMetrics::Metric destination_metric_) noexcept;
     ~GlobalQuantile() noexcept;
@@ -40,7 +42,6 @@ private:
     void * shared_buckets = nullptr;
     void * shared_update = nullptr;
 
-    bool was_accounted = false;
     std::atomic<CurrentMetrics::Value> accounted_value = 0;
 };
 

--- a/src/Common/AggregatedMetrics.h
+++ b/src/Common/AggregatedMetrics.h
@@ -38,7 +38,7 @@ public:
 private:
     const CurrentMetrics::Metric destination_metric;
 
-    double quantile;
+    double quantile = 0;
     void * shared_buckets = nullptr;
     void * shared_update = nullptr;
 

--- a/src/Common/tests/gtest_aggregated_metrics.cpp
+++ b/src/Common/tests/gtest_aggregated_metrics.cpp
@@ -89,10 +89,12 @@ TEST(AggregatedMetrics, GlobalQuantileSingleHandleMin)
 TEST(AggregatedMetrics, GlobalQuantileMultipleHandlesMax)
 {
     auto handle1 = std::make_unique<AggregatedMetrics::GlobalQuantile>(CurrentMetrics::SharedMergeTreeMaxReplicas);
-    auto handle2 = std::make_unique<AggregatedMetrics::GlobalQuantile>(CurrentMetrics::SharedMergeTreeMaxReplicas);
     ASSERT_EQ(CurrentMetrics::get(CurrentMetrics::SharedMergeTreeMaxReplicas), 0);
 
     handle1->set(5);
+    ASSERT_EQ(CurrentMetrics::get(CurrentMetrics::SharedMergeTreeMaxReplicas), 5);
+
+    auto handle2 = std::make_unique<AggregatedMetrics::GlobalQuantile>(CurrentMetrics::SharedMergeTreeMaxReplicas);
     ASSERT_EQ(CurrentMetrics::get(CurrentMetrics::SharedMergeTreeMaxReplicas), 5);
 
     handle2->set(3);
@@ -114,11 +116,13 @@ TEST(AggregatedMetrics, GlobalQuantileMultipleHandlesMax)
 TEST(AggregatedMetrics, GlobalQuantileMultipleHandlesMin)
 {
     auto handle1 = std::make_unique<AggregatedMetrics::GlobalQuantile>(CurrentMetrics::SharedMergeTreeMinReplicas);
-    auto handle2 = std::make_unique<AggregatedMetrics::GlobalQuantile>(CurrentMetrics::SharedMergeTreeMinReplicas);
     ASSERT_EQ(CurrentMetrics::get(CurrentMetrics::SharedMergeTreeMinReplicas), 0);
 
     handle1->set(5);
     ASSERT_EQ(CurrentMetrics::get(CurrentMetrics::SharedMergeTreeMinReplicas), 5);
+
+    auto handle2 = std::make_unique<AggregatedMetrics::GlobalQuantile>(CurrentMetrics::SharedMergeTreeMinReplicas);
+    ASSERT_EQ(CurrentMetrics::get(CurrentMetrics::SharedMergeTreeMinReplicas), 0);
 
     handle2->set(7);
     ASSERT_EQ(CurrentMetrics::get(CurrentMetrics::SharedMergeTreeMinReplicas), 5);


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

CI: https://d1k2gkhrlfqv31.cloudfront.net/clickhouse-test-reports-private/json.html?PR=50063&sha=59c9cf992d1d1e8b24d713fbc111aaa59bbf8f37&name_0=PR&name_1=Stateless%20tests%20%28amd_msan%2C%20SharedCatalog%2C%20meta%20storage%20in%20keeper%2C%20s3%20storage%2C%20parallel%29


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.944`
<!-- ch-version-info:end -->