### PR TITLE
Fix data race in scheduler node destruction during DROP WORKLOAD

### DIFF
--- a/src/Common/Scheduler/Nodes/WorkloadResourceManager.cpp
+++ b/src/Common/Scheduler/Nodes/WorkloadResourceManager.cpp
@@ -123,7 +123,7 @@ void WorkloadResourceManager::Resource::deleteNode(const NodeInfo & info)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Removing workload '{}' with children in resource '{}'",
         info.name, resource_name);
 
-    executeInSchedulerThread([&, n = std::move(node)]
+    executeInSchedulerThread([&, n = std::move(node)]() mutable
     {
         if (!info.parent.empty())
             node_for_workload[info.parent]->detachUnifiedChild(n);
@@ -138,9 +138,13 @@ void WorkloadResourceManager::Resource::deleteNode(const NodeInfo & info)
 
         updateCurrentVersion();
 
-        // Note: `n` is intentionally destroyed here, in the scheduler thread,
+        // Note: `n` must be explicitly destroyed here, in the scheduler thread,
         // to avoid a data race between the destructor and the scheduler thread
         // that may still process activations for this node.
+        // Without this explicit reset, `n` (a captured lambda member) would be
+        // destroyed when the lambda itself is destroyed — which happens in the
+        // caller's thread after `executeInSchedulerThread` returns, not here.
+        n.reset();
     });
 }
 


### PR DESCRIPTION
## Summary

- Fix a TSan-reported data race between the TCPHandler thread (executing `DROP WORKLOAD`) and the scheduler thread (processing activations) on `ISchedulerNode::parent`
- In `WorkloadResourceManager::Resource::deleteNode`, the lambda passed to `executeInSchedulerThread` captures `n` (a `shared_ptr<UnifiedSchedulerNode>`) by value. Despite the existing comment, `n` was destroyed in the **caller's thread** (not the scheduler thread), because `executeInSchedulerThread` captures the task by reference — the lambda lives on the caller's stack and is destroyed when `executeInSchedulerThread` returns
- Add explicit `n.reset()` inside the lambda body (with `mutable`) so the node is actually destroyed in the scheduler thread as intended

## Details

The write (`parent = nullptr` in `setParent`) happened via `~UnifiedSchedulerNode` → `removeChild` → `setParent` from the TCPHandler thread, racing with the scheduler thread reading `parent` in `processActivation`.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/REFs/master/30cbcec0ee3a8caa809dc7e94fe48f448590322d/stateless_tests_amd_tsan_s3_storage_sequential_2_2/stderr.log

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.947`
<!-- ch-version-info:end -->