### PR TITLE
Add deferred filters info to EXPLAIN (in case of row policy/PREWHERE with FINAL)

### DIFF
--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -3530,6 +3530,15 @@ void ReadFromMergeTree::describeActions(FormatSettings & format_settings) const
         expression->describeActions(format_settings.out, prefix);
     }
 
+    if (deferred_prewhere_info || deferred_row_level_filter)
+    {
+        format_settings.out << prefix << "Deferred filters (applied after FINAL)" << '\n';
+        if (deferred_row_level_filter)
+            format_settings.out << prefix << "  Deferred row level filter column: " << deferred_row_level_filter->column_name << '\n';
+        if (deferred_prewhere_info)
+            format_settings.out << prefix << "  Deferred prewhere filter column: " << deferred_prewhere_info->prewhere_column_name << '\n';
+    }
+
     if (virtual_row_conversion)
     {
         format_settings.out << prefix << "Virtual row conversions" << '\n';
@@ -3577,6 +3586,16 @@ void ReadFromMergeTree::describeActions(JSONBuilder::JSONMap & map) const
 
     if (prewhere_info_map)
         map.add("Prewhere info", std::move(prewhere_info_map));
+
+    if (deferred_prewhere_info || deferred_row_level_filter)
+    {
+        auto deferred_map = std::make_unique<JSONBuilder::JSONMap>();
+        if (deferred_row_level_filter)
+            deferred_map->add("Deferred row level filter column", deferred_row_level_filter->column_name);
+        if (deferred_prewhere_info)
+            deferred_map->add("Deferred prewhere filter column", deferred_prewhere_info->prewhere_column_name);
+        map.add("Deferred filters (applied after FINAL)", std::move(deferred_map));
+    }
 
     if (virtual_row_conversion)
         map.add("Virtual row conversions", virtual_row_conversion->toTree());

--- a/tests/queries/0_stateless/03928_deferred_filters_after_final_in_explain.reference
+++ b/tests/queries/0_stateless/03928_deferred_filters_after_final_in_explain.reference
@@ -1,3 +1,38 @@
+= full plan: both deferred =
+Expression (Project names)
+  Sorting (Sorting for ORDER BY)
+  Prefix sort description: __table1.x ASC
+  Result sort description: __table1.x ASC
+    Expression ((Before ORDER BY + (Projection + Change column names to column identifiers)))
+      ReadFromMergeTree (default.tab)
+      ReadType: InOrder
+      Parts: 3
+      Granules: 3
+      Prewhere info
+      Need filter: 1
+        Prewhere filter
+        Prewhere filter column: notEquals(y, \'ccc\'_String) (removed)
+        Row level filter
+        Row level filter column: notEquals(y, \'ccc\'_String) (removed)
+        Deferred filters (applied after FINAL)
+          Deferred row level filter column: notEquals(y, \'ccc\'_String)
+          Deferred prewhere filter column: notEquals(y, \'ccc\'_String)
+= full plan: nothing deferred =
+Expression (Project names)
+  Sorting (Sorting for ORDER BY)
+  Prefix sort description: __table1.x ASC
+  Result sort description: __table1.x ASC
+    Expression ((Before ORDER BY + (Projection + Change column names to column identifiers)))
+      ReadFromMergeTree (default.tab)
+      ReadType: InOrder
+      Parts: 3
+      Granules: 3
+      Prewhere info
+      Need filter: 1
+        Prewhere filter
+        Prewhere filter column: notEquals(y, \'ccc\'_String) (removed)
+        Row level filter
+        Row level filter column: notEquals(y, \'ccc\'_String) (removed)
 = row policy deferred =
         Deferred filters (applied after FINAL)
           Deferred row level filter column: notEquals(y, \'ccc\'_String)

--- a/tests/queries/0_stateless/03928_deferred_filters_after_final_in_explain.reference
+++ b/tests/queries/0_stateless/03928_deferred_filters_after_final_in_explain.reference
@@ -1,0 +1,17 @@
+= row policy deferred =
+        Deferred filters (applied after FINAL)
+          Deferred row level filter column: notEquals(y, \'ccc\'_String)
+= row policy not deferred =
+= prewhere deferred =
+        Deferred filters (applied after FINAL)
+          Deferred prewhere filter column: notEquals(y, \'ccc\'_String)
+= prewhere not deferred =
+= both deferred =
+        Deferred filters (applied after FINAL)
+          Deferred row level filter column: notEquals(y, \'ccc\'_String)
+          Deferred prewhere filter column: notEquals(y, \'ccc\'_String)
+= row policy on non-sorting-key defers prewhere =
+        Deferred filters (applied after FINAL)
+          Deferred row level filter column: notEquals(y, \'ccc\'_String)
+          Deferred prewhere filter column: notEquals(y, \'ccc\'_String)
+= no FINAL - no deferred =

--- a/tests/queries/0_stateless/03928_deferred_filters_after_final_in_explain.reference
+++ b/tests/queries/0_stateless/03928_deferred_filters_after_final_in_explain.reference
@@ -1,9 +1,23 @@
 = full plan: both deferred =
 Expression (Project names)
+Actions: INPUT : 0 -> __table1.y String : 0
+         INPUT : 1 -> __table1.x UInt32 : 1
+         INPUT : 2 -> __table1.version UInt32 : 2
+         ALIAS __table1.y :: 0 -> y String : 3
+         ALIAS __table1.x :: 1 -> x UInt32 : 0
+         ALIAS __table1.version :: 2 -> version UInt32 : 1
+Positions: 0 3 1
   Sorting (Sorting for ORDER BY)
   Prefix sort description: __table1.x ASC
   Result sort description: __table1.x ASC
     Expression ((Before ORDER BY + (Projection + Change column names to column identifiers)))
+    Actions: INPUT : 0 -> y String : 0
+             INPUT : 1 -> x UInt32 : 1
+             INPUT : 2 -> version UInt32 : 2
+             ALIAS y :: 0 -> __table1.y String : 3
+             ALIAS x :: 1 -> __table1.x UInt32 : 0
+             ALIAS version :: 2 -> __table1.version UInt32 : 1
+    Positions: 0 3 1
       ReadFromMergeTree (default.tab)
       ReadType: InOrder
       Parts: 3
@@ -12,17 +26,39 @@ Expression (Project names)
       Need filter: 1
         Prewhere filter
         Prewhere filter column: notEquals(y, \'ccc\'_String) (removed)
+        Actions: INPUT : 0 -> y String : 0
+                 COLUMN Const(String) -> \'ccc\'_String String : 1
+                 FUNCTION notEquals(y : 0, \'ccc\'_String :: 1) -> notEquals(y, \'ccc\'_String) UInt8 : 2
+        Positions: 2 0
         Row level filter
         Row level filter column: notEquals(y, \'ccc\'_String) (removed)
+        Actions: INPUT : 0 -> y String : 0
+                 COLUMN Const(String) -> \'ccc\'_String String : 1
+                 FUNCTION notEquals(y : 0, \'ccc\'_String :: 1) -> notEquals(y, \'ccc\'_String) UInt8 : 2
+        Positions: 2 0
         Deferred filters (applied after FINAL)
           Deferred row level filter column: notEquals(y, \'ccc\'_String)
           Deferred prewhere filter column: notEquals(y, \'ccc\'_String)
 = full plan: nothing deferred =
 Expression (Project names)
+Actions: INPUT : 0 -> __table1.y String : 0
+         INPUT : 1 -> __table1.x UInt32 : 1
+         INPUT : 2 -> __table1.version UInt32 : 2
+         ALIAS __table1.y :: 0 -> y String : 3
+         ALIAS __table1.x :: 1 -> x UInt32 : 0
+         ALIAS __table1.version :: 2 -> version UInt32 : 1
+Positions: 0 3 1
   Sorting (Sorting for ORDER BY)
   Prefix sort description: __table1.x ASC
   Result sort description: __table1.x ASC
     Expression ((Before ORDER BY + (Projection + Change column names to column identifiers)))
+    Actions: INPUT : 0 -> y String : 0
+             INPUT : 1 -> x UInt32 : 1
+             INPUT : 2 -> version UInt32 : 2
+             ALIAS y :: 0 -> __table1.y String : 3
+             ALIAS x :: 1 -> __table1.x UInt32 : 0
+             ALIAS version :: 2 -> __table1.version UInt32 : 1
+    Positions: 0 3 1
       ReadFromMergeTree (default.tab)
       ReadType: InOrder
       Parts: 3
@@ -31,8 +67,16 @@ Expression (Project names)
       Need filter: 1
         Prewhere filter
         Prewhere filter column: notEquals(y, \'ccc\'_String) (removed)
+        Actions: INPUT : 0 -> y String : 0
+                 COLUMN Const(String) -> \'ccc\'_String String : 1
+                 FUNCTION notEquals(y : 0, \'ccc\'_String :: 1) -> notEquals(y, \'ccc\'_String) UInt8 : 2
+        Positions: 2 0
         Row level filter
         Row level filter column: notEquals(y, \'ccc\'_String) (removed)
+        Actions: INPUT : 0 -> y String : 0
+                 COLUMN Const(String) -> \'ccc\'_String String : 1
+                 FUNCTION notEquals(y : 0, \'ccc\'_String :: 1) -> notEquals(y, \'ccc\'_String) UInt8 : 2
+        Positions: 2 0
 = row policy deferred =
         Deferred filters (applied after FINAL)
           Deferred row level filter column: notEquals(y, \'ccc\'_String)

--- a/tests/queries/0_stateless/03928_deferred_filters_after_final_in_explain.sql
+++ b/tests/queries/0_stateless/03928_deferred_filters_after_final_in_explain.sql
@@ -1,0 +1,37 @@
+-- Tags: no-parallel
+-- test that EXPLAIN shows deferred filter information for apply_prewhere_after_final / apply_row_policy_after_final
+
+DROP TABLE IF EXISTS tab;
+DROP ROW POLICY IF EXISTS pol1 ON tab;
+
+CREATE TABLE tab (x UInt32, y String, version UInt32) ENGINE = ReplacingMergeTree(version) ORDER BY x;
+
+INSERT INTO tab SELECT 1, 'aaa', 1;
+INSERT INTO tab SELECT 2, 'bbb', 1;
+INSERT INTO tab SELECT 1, 'ccc', 2;
+
+CREATE ROW POLICY pol1 ON tab USING y != 'ccc' TO ALL;
+
+SELECT '= row policy deferred =';
+SELECT explain FROM (EXPLAIN actions=1 SELECT * FROM tab FINAL ORDER BY x SETTINGS apply_row_policy_after_final=1) WHERE explain LIKE '%Deferred%';
+
+SELECT '= row policy not deferred =';
+SELECT explain FROM (EXPLAIN actions=1 SELECT * FROM tab FINAL ORDER BY x SETTINGS apply_row_policy_after_final=0) WHERE explain LIKE '%Deferred%';
+
+SELECT '= prewhere deferred =';
+SELECT explain FROM (EXPLAIN actions=1 SELECT * FROM tab FINAL PREWHERE y != 'ccc' ORDER BY x SETTINGS apply_prewhere_after_final=1) WHERE explain LIKE '%Deferred%';
+
+SELECT '= prewhere not deferred =';
+SELECT explain FROM (EXPLAIN actions=1 SELECT * FROM tab FINAL PREWHERE y != 'ccc' ORDER BY x SETTINGS apply_prewhere_after_final=0) WHERE explain LIKE '%Deferred%';
+
+SELECT '= both deferred =';
+SELECT explain FROM (EXPLAIN actions=1 SELECT * FROM tab FINAL PREWHERE y != 'ccc' ORDER BY x SETTINGS apply_row_policy_after_final=1, apply_prewhere_after_final=1) WHERE explain LIKE '%Deferred%';
+
+SELECT '= row policy on non-sorting-key defers prewhere =';
+SELECT explain FROM (EXPLAIN actions=1 SELECT * FROM tab FINAL PREWHERE y != 'ccc' ORDER BY x SETTINGS apply_row_policy_after_final=1, apply_prewhere_after_final=0) WHERE explain LIKE '%Deferred%';
+
+SELECT '= no FINAL - no deferred =';
+SELECT explain FROM (EXPLAIN actions=1 SELECT * FROM tab ORDER BY x SETTINGS apply_row_policy_after_final=1) WHERE explain LIKE '%Deferred%';
+
+DROP ROW POLICY pol1 ON tab;
+DROP TABLE tab;

--- a/tests/queries/0_stateless/03928_deferred_filters_after_final_in_explain.sql
+++ b/tests/queries/0_stateless/03928_deferred_filters_after_final_in_explain.sql
@@ -13,22 +13,12 @@ INSERT INTO tab SELECT 1, 'ccc', 2;
 CREATE ROW POLICY pol1 ON tab USING y != 'ccc' TO ALL;
 
 SELECT '= full plan: both deferred =';
-SELECT explain FROM (
-    EXPLAIN actions=1 SELECT * FROM tab FINAL PREWHERE y != 'ccc' ORDER BY x
-    SETTINGS apply_row_policy_after_final=1, apply_prewhere_after_final=1
-) WHERE
-    explain NOT LIKE '%Actions%' AND explain NOT LIKE '%Positions%'
-    AND explain NOT LIKE '%INPUT%' AND explain NOT LIKE '%FUNCTION%'
-    AND explain NOT LIKE '%COLUMN%' AND explain NOT LIKE '%ALIAS%';
+EXPLAIN actions=1 SELECT * FROM tab FINAL PREWHERE y != 'ccc' ORDER BY x
+SETTINGS apply_row_policy_after_final=1, apply_prewhere_after_final=1, optimize_read_in_order=1;
 
 SELECT '= full plan: nothing deferred =';
-SELECT explain FROM (
-    EXPLAIN actions=1 SELECT * FROM tab FINAL PREWHERE y != 'ccc' ORDER BY x
-    SETTINGS apply_row_policy_after_final=0, apply_prewhere_after_final=0
-) WHERE
-    explain NOT LIKE '%Actions%' AND explain NOT LIKE '%Positions%'
-    AND explain NOT LIKE '%INPUT%' AND explain NOT LIKE '%FUNCTION%'
-    AND explain NOT LIKE '%COLUMN%' AND explain NOT LIKE '%ALIAS%';
+EXPLAIN actions=1 SELECT * FROM tab FINAL PREWHERE y != 'ccc' ORDER BY x
+SETTINGS apply_row_policy_after_final=0, apply_prewhere_after_final=0, optimize_read_in_order=1;
 
 SELECT '= row policy deferred =';
 SELECT explain FROM (EXPLAIN actions=1 SELECT * FROM tab FINAL ORDER BY x SETTINGS apply_row_policy_after_final=1) WHERE explain LIKE '%Deferred%';

--- a/tests/queries/0_stateless/03928_deferred_filters_after_final_in_explain.sql
+++ b/tests/queries/0_stateless/03928_deferred_filters_after_final_in_explain.sql
@@ -12,6 +12,24 @@ INSERT INTO tab SELECT 1, 'ccc', 2;
 
 CREATE ROW POLICY pol1 ON tab USING y != 'ccc' TO ALL;
 
+SELECT '= full plan: both deferred =';
+SELECT explain FROM (
+    EXPLAIN actions=1 SELECT * FROM tab FINAL PREWHERE y != 'ccc' ORDER BY x
+    SETTINGS apply_row_policy_after_final=1, apply_prewhere_after_final=1
+) WHERE
+    explain NOT LIKE '%Actions%' AND explain NOT LIKE '%Positions%'
+    AND explain NOT LIKE '%INPUT%' AND explain NOT LIKE '%FUNCTION%'
+    AND explain NOT LIKE '%COLUMN%' AND explain NOT LIKE '%ALIAS%';
+
+SELECT '= full plan: nothing deferred =';
+SELECT explain FROM (
+    EXPLAIN actions=1 SELECT * FROM tab FINAL PREWHERE y != 'ccc' ORDER BY x
+    SETTINGS apply_row_policy_after_final=0, apply_prewhere_after_final=0
+) WHERE
+    explain NOT LIKE '%Actions%' AND explain NOT LIKE '%Positions%'
+    AND explain NOT LIKE '%INPUT%' AND explain NOT LIKE '%FUNCTION%'
+    AND explain NOT LIKE '%COLUMN%' AND explain NOT LIKE '%ALIAS%';
+
 SELECT '= row policy deferred =';
 SELECT explain FROM (EXPLAIN actions=1 SELECT * FROM tab FINAL ORDER BY x SETTINGS apply_row_policy_after_final=1) WHERE explain LIKE '%Deferred%';
 

--- a/tests/queries/0_stateless/03928_deferred_filters_after_final_in_explain.sql
+++ b/tests/queries/0_stateless/03928_deferred_filters_after_final_in_explain.sql
@@ -21,16 +21,16 @@ EXPLAIN actions=1 SELECT * FROM tab FINAL PREWHERE y != 'ccc' ORDER BY x
 SETTINGS apply_row_policy_after_final=0, apply_prewhere_after_final=0, optimize_read_in_order=1;
 
 SELECT '= row policy deferred =';
-SELECT explain FROM (EXPLAIN actions=1 SELECT * FROM tab FINAL ORDER BY x SETTINGS apply_row_policy_after_final=1) WHERE explain LIKE '%Deferred%';
+SELECT explain FROM (EXPLAIN actions=1 SELECT * FROM tab FINAL ORDER BY x SETTINGS apply_row_policy_after_final=1, apply_prewhere_after_final=0) WHERE explain LIKE '%Deferred%';
 
 SELECT '= row policy not deferred =';
-SELECT explain FROM (EXPLAIN actions=1 SELECT * FROM tab FINAL ORDER BY x SETTINGS apply_row_policy_after_final=0) WHERE explain LIKE '%Deferred%';
+SELECT explain FROM (EXPLAIN actions=1 SELECT * FROM tab FINAL ORDER BY x SETTINGS apply_row_policy_after_final=0, apply_prewhere_after_final=0) WHERE explain LIKE '%Deferred%';
 
 SELECT '= prewhere deferred =';
-SELECT explain FROM (EXPLAIN actions=1 SELECT * FROM tab FINAL PREWHERE y != 'ccc' ORDER BY x SETTINGS apply_prewhere_after_final=1) WHERE explain LIKE '%Deferred%';
+SELECT explain FROM (EXPLAIN actions=1 SELECT * FROM tab FINAL PREWHERE y != 'ccc' ORDER BY x SETTINGS apply_prewhere_after_final=1, apply_row_policy_after_final=0) WHERE explain LIKE '%Deferred%';
 
 SELECT '= prewhere not deferred =';
-SELECT explain FROM (EXPLAIN actions=1 SELECT * FROM tab FINAL PREWHERE y != 'ccc' ORDER BY x SETTINGS apply_prewhere_after_final=0) WHERE explain LIKE '%Deferred%';
+SELECT explain FROM (EXPLAIN actions=1 SELECT * FROM tab FINAL PREWHERE y != 'ccc' ORDER BY x SETTINGS apply_prewhere_after_final=0, apply_row_policy_after_final=0) WHERE explain LIKE '%Deferred%';
 
 SELECT '= both deferred =';
 SELECT explain FROM (EXPLAIN actions=1 SELECT * FROM tab FINAL PREWHERE y != 'ccc' ORDER BY x SETTINGS apply_row_policy_after_final=1, apply_prewhere_after_final=1) WHERE explain LIKE '%Deferred%';
@@ -39,7 +39,7 @@ SELECT '= row policy on non-sorting-key defers prewhere =';
 SELECT explain FROM (EXPLAIN actions=1 SELECT * FROM tab FINAL PREWHERE y != 'ccc' ORDER BY x SETTINGS apply_row_policy_after_final=1, apply_prewhere_after_final=0) WHERE explain LIKE '%Deferred%';
 
 SELECT '= no FINAL - no deferred =';
-SELECT explain FROM (EXPLAIN actions=1 SELECT * FROM tab ORDER BY x SETTINGS apply_row_policy_after_final=1) WHERE explain LIKE '%Deferred%';
+SELECT explain FROM (EXPLAIN actions=1 SELECT * FROM tab ORDER BY x SETTINGS apply_row_policy_after_final=1, apply_prewhere_after_final=0) WHERE explain LIKE '%Deferred%';
 
 DROP ROW POLICY pol1 ON tab;
 DROP TABLE tab;

--- a/tests/queries/0_stateless/03928_deferred_filters_after_final_in_explain.sql
+++ b/tests/queries/0_stateless/03928_deferred_filters_after_final_in_explain.sql
@@ -12,6 +12,8 @@ INSERT INTO tab SELECT 1, 'ccc', 2;
 
 CREATE ROW POLICY pol1 ON tab USING y != 'ccc' TO ALL;
 
+SET enable_analyzer = 1;
+
 SELECT '= full plan: both deferred =';
 EXPLAIN actions=1 SELECT * FROM tab FINAL PREWHERE y != 'ccc' ORDER BY x
 SETTINGS apply_row_policy_after_final=1, apply_prewhere_after_final=1, optimize_read_in_order=1;


### PR DESCRIPTION

### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add information about deferred filters as a separate item to EXPLAIN query output (when using Row Policies/PREWHERE with FINAL). Related: https://github.com/ClickHouse/ClickHouse/pull/91065

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.64`
- Backported to: `26.2.1.1125`, `26.1.4.29`, `25.12.8.6`, `25.11.10.25`
<!-- ch-version-info:end -->