### PR TITLE
Fix empty reverse_flags access in convertSortingKeyToInputOrder

### DIFF
--- a/src/Processors/QueryPlan/ReadFromObjectStorageStep.cpp
+++ b/src/Processors/QueryPlan/ReadFromObjectStorageStep.cpp
@@ -177,7 +177,7 @@ static InputOrderInfoPtr convertSortingKeyToInputOrder(const KeyDescription & ke
     SortDescription sort_description_for_merging;
     for (size_t i = 0; i < key_description.column_names.size(); ++i)
         sort_description_for_merging.push_back(
-            SortColumnDescription(key_description.column_names[i], key_description.reverse_flags[i] ? -1 : 1));
+            SortColumnDescription(key_description.column_names[i], (!key_description.reverse_flags.empty() && key_description.reverse_flags[i]) ? -1 : 1));
     return std::make_shared<const InputOrderInfo>(sort_description_for_merging, sort_description_for_merging.size(), 1, 0);
 }
 


### PR DESCRIPTION
## Summary
- Fix out-of-bounds access in `convertSortingKeyToInputOrder` when `KeyDescription::reverse_flags` is empty
- `reverse_flags` is empty when all sorting key columns use default ASC direction (i.e., no `ASTStorageOrderByElement` wrappers are present)
- Apply the same guard pattern (`!reverse_flags.empty() && reverse_flags[i]`) used throughout the codebase (`ReadFromMergeTree`, `KeyDescription`, `Iceberg/Utils`, etc.)
- Without this fix, `SELECT ... ORDER BY` on iceberg tables with ASC-only sorting keys crashes the server

Found while working on #70661.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.948`
<!-- ch-version-info:end -->