### PR TITLE
Fix flaky test_move_failover by adding PUT method filter

### DIFF
--- a/tests/integration/test_merge_tree_s3_failover/test.py
+++ b/tests/integration/test_merge_tree_s3_failover/test.py
@@ -205,8 +205,10 @@ def test_move_failover(cluster):
         """
     )
 
-    # Fail a request to S3 to break first TTL move.
-    fail_request(cluster, 1)
+    # Fail the first PUT request to S3 to break first TTL move.
+    # Use PUT method filter to avoid counting background GET/DELETE
+    # requests that could consume the fail counter and make the test flaky.
+    fail_request(cluster, 1, "PUT")
 
     node.query(
         "INSERT INTO s3_failover_test VALUES (now() - 1, 0, 'data'), (now() - 1, 1, 'data')"


### PR DESCRIPTION
## Summary
- `test_move_failover` in `test_merge_tree_s3_failover` was flaky because `fail_request(cluster, 1)` without a method filter could be consumed by background S3 GET/DELETE requests (e.g., cleanup operations from previous tests using the module-shared cluster) before the TTL move issued its first PUT request
- This caused the move to succeed on the first attempt, producing only 1 `MovePart` event instead of the expected 2
- Added a `"PUT"` method filter to `fail_request`, consistent with how `test_write_failover` in the same file already handles this

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=9dd29640b3f54684b6b38ea0457d99b0848fa023&name_0=MasterCI&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%204%2F4%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.945`
<!-- ch-version-info:end -->