### PR TITLE
Fix flaky test_kafka_sasl_settings_precedence in TSan

### DIFF
--- a/tests/integration/test_storage_kafka_sasl/test.py
+++ b/tests/integration/test_storage_kafka_sasl/test.py
@@ -74,6 +74,7 @@ def test_kafka_sasl(kafka_cluster):
     producer = get_kafka_producer(kafka_cluster.kafka_sasl_port)
     producer.send(topic="topic1", value='{"key":1, "value":"test123"}')
     producer.flush()
+    producer.close()
 
     assert_eq_with_retry(
         instance,


### PR DESCRIPTION
## Summary

- Explicitly close `KafkaProducer` after use in `test_kafka_sasl` to prevent a kafka-python race condition that causes the second producer instance (when the test is called from `test_kafka_sasl_settings_precedence`) to never deliver its message to Kafka

## Root Cause

The test was flaky under TSan because the `KafkaProducer` was not explicitly closed after use. When `test_kafka_sasl_settings_precedence` calls `test_kafka_sasl` a second time, the first producer (from the standalone test run) gets garbage collected concurrently with the second producer's operation. Evidence from the CI logs:

- **ClickHouse server logs**: the Kafka consumer connected successfully with correct SASL settings (per-table settings properly overriding wrong global config), subscribed to `topic1`, got partition assigned, but polled `offset INVALID` (zero messages) continuously for 15 minutes until timeout
- **Python test logs**: the first producer delivered its message to `topic1` offset 0 successfully; the second producer's I/O thread started, connected to Node 1, but just 7ms later the first producer's I/O thread began shutdown (garbage collected) — zero "Created produce requests" or "Produced messages" entries for the second producer

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=3d2fdaaa8539bdef8121510f55a726c0ce4b2e08&name_0=MasterCI&name_1=Integration%20tests%20%28amd_tsan%2C%206%2F6%29

## Test plan

- [ ] Integration tests (amd_tsan, 6/6) should pass without flakiness

### Changelog category (leave one):
- CI Fix or improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Fixed flaky `test_kafka_sasl_settings_precedence` integration test under TSan by explicitly closing the Kafka producer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.977`
<!-- ch-version-info:end -->