### PR TITLE
ci: fix stress tests failures due to MEMORY_LIMIT_EXCEEDED (mostly for private)

### DIFF
--- a/ci/jobs/scripts/stress/stress.py
+++ b/ci/jobs/scripts/stress/stress.py
@@ -177,8 +177,7 @@ def get_options(i: int, upgrade_check: bool, encrypted_storage: bool) -> str:
     if i % 2 == 1 and not upgrade_check:
         client_options.append("group_by_use_nulls=1")
 
-    # 12 % 3 == 0, so it's Atomic database
-    if i == 12 and not upgrade_check and not encrypted_storage:
+    if i % 3 == 2 and not upgrade_check and not encrypted_storage:
         client_options.append("implicit_transaction=1")
         client_options.append("throw_on_unsupported_query_inside_transaction=0")
 

--- a/tests/docker_scripts/stress_tests.lib
+++ b/tests/docker_scripts/stress_tests.lib
@@ -117,20 +117,11 @@ function configure_limits()
     total_mem=$(awk '/MemTotal/ { print $(NF-1) }' /proc/meminfo) # KiB
     total_mem=$(( total_mem*1024 )) # bytes
 
-    # Set maximum memory usage as half of total memory (less chance of OOM).
-    #
-    # But not via max_server_memory_usage but via max_memory_usage_for_user,
-    # so that we can override this setting and execute service queries, like:
-    # - hung check
-    # - show/drop database
-    # - ...
-    #
-    # So max_memory_usage_for_user will be a soft limit, and
-    # max_server_memory_usage will be hard limit, and queries that should be
-    # executed regardless memory limits will use max_memory_usage_for_user=0,
-    # instead of relying on max_untracked_memory
+    # NOTE: the total server memory usage is capped to the memory usage of the
+    # whole cgroup, so, there is no need to take into account that we run
+    # multiple servers, so static 80% will be just fine.
 
-    max_server_memory_usage_to_ram_ratio=0.5
+    max_server_memory_usage_to_ram_ratio=0.8
     echo "Setting max_server_memory_usage_to_ram_ratio to ${max_server_memory_usage_to_ram_ratio}"
     cat > /etc/clickhouse-server/config.d/max_server_memory_usage.xml <<EOL
 <clickhouse>


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

The problem is that under memory pressure, even simple query `SELECT 1` (that is used to check that the server is alive) can fail, and this is what happens.

And the problem is that we limit the server too much, since we limit each process to 50%, but not 50% of RSS, but memory usage inside cgroup, so whenever we have more memory for other processes (like other clickhouse-server's) we will reach memory limit

For instance here:

```
2026.02.19 09:48:10.775857 [ 9318 ] {} <Error> TCPHandler: TCPHandler: Code: 241. DB::Exception: (total) memory limit exceeded: would use 2.91 GiB (attempt to allocate chunk of 1.00 MiB), current RSS: 24.69 GiB, maximum: 24.66 GiB. (MEMORY_LIMIT_EXCEEDED), Stack trace (when copying this message, always include the lines below):
```

The server itself uses 2.91GiB (it is actually not 2.91, but more, but this is not that important here) of RAM, but the cgroup usage is 24.69GiB and it stops, even though there is 64GiB of RAM on that server.

But this should not work like this, let's just limit memory usage to 80% (just to protect from real OOM), and this should work.

_P.S. see also details in private sync_

_P.P.S. another option is to introduce RSS source for syncing memory, but this will behave slightly worse, at least for stress tests, since other servers uses less RAM, and by using cgroups we can just use the same limit, instead of calculating limit per server, though maybe it still make sense to introduce it (I've been thinking about this before)_


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.957`
<!-- ch-version-info:end -->