### PR TITLE
Enables and adds SVE support for ColumnVector, aggregate sum, function unary arithmetic and functions comparison.

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionSum.h
+++ b/src/AggregateFunctions/AggregateFunctionSum.h
@@ -140,7 +140,7 @@ struct AggregateFunctionSumData
     template <typename Value>
     void NO_INLINE addMany(const Value * __restrict ptr, size_t start, size_t end)
     {
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
         if (isArchSupported(TargetArch::x86_64_v4))
         {
             addManyImpl_x86_64_v4(ptr, start, end);
@@ -251,7 +251,7 @@ struct AggregateFunctionSumData
     template <typename Value, bool add_if_zero>
     void NO_INLINE addManyConditionalInternal(const Value * __restrict ptr, const UInt8 * __restrict condition_map, size_t start, size_t end)
     {
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
         if (isArchSupported(TargetArch::x86_64_v4))
         {
             addManyConditionalInternalImpl_x86_64_v4<Value, add_if_zero>(ptr, condition_map, start, end);

--- a/src/AggregateFunctions/AggregateFunctionSum.h
+++ b/src/AggregateFunctions/AggregateFunctionSum.h
@@ -93,7 +93,7 @@ struct AggregateFunctionSumData
     }
 
     /// Vectorized version
-    MULTITARGET_FUNCTION_X86_V4_V3(
+    MULTITARGET_FUNCTION_X86_V4_V3_SVE(
     MULTITARGET_FUNCTION_HEADER(
     template <typename Value>
     void NO_SANITIZE_UNDEFINED NO_INLINE
@@ -152,12 +152,18 @@ struct AggregateFunctionSumData
             addManyImpl_x86_64_v3(ptr, start, end);
             return;
         }
+#elif USE_ARM_MULTITARGET_CODE
+        if (isArchSupported(TargetArch::SVE))
+        {
+            addManyImpl_SVE(ptr, start, end);
+            return;
+        }
 #endif
 
         addManyImpl(ptr, start, end);
     }
 
-    MULTITARGET_FUNCTION_X86_V4_V3(
+    MULTITARGET_FUNCTION_X86_V4_V3_SVE(
     MULTITARGET_FUNCTION_HEADER(
     template <typename Value, bool add_if_zero>
     void NO_SANITIZE_UNDEFINED NO_INLINE
@@ -255,6 +261,12 @@ struct AggregateFunctionSumData
         if (isArchSupported(TargetArch::x86_64_v3))
         {
             addManyConditionalInternalImpl_x86_64_v3<Value, add_if_zero>(ptr, condition_map, start, end);
+            return;
+        }
+#elif USE_ARM_MULTITARGET_CODE
+        if (isArchSupported(TargetArch::SVE))
+        {
+            addManyConditionalInternalImpl_SVE<Value, add_if_zero>(ptr, condition_map, start, end);
             return;
         }
 #endif

--- a/src/Columns/ColumnVector.cpp
+++ b/src/Columns/ColumnVector.cpp
@@ -32,7 +32,7 @@
 
 #include "config.h"
 
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
 #    include <immintrin.h>
 #endif
 
@@ -323,7 +323,7 @@ void ColumnVector<T>::compareColumn(
         return;
     }
 
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
     if (isArchSupported(TargetArch::x86_64_v4))
     {
         compareColumnImpl_x86_64_v4<T>(data, value, compare_results, direction, nan_direction_hint);
@@ -848,7 +848,7 @@ ColumnPtr ColumnVector<T>::filter(const IColumn::Filter & filt, ssize_t result_s
     static constexpr size_t SIMD_ELEMENTS = 64;
     const UInt8 * filt_end_aligned = filt_pos + size / SIMD_ELEMENTS * SIMD_ELEMENTS;
 
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
     static constexpr bool VBMI2_CAPABLE = sizeof(T) == 1 || sizeof(T) == 2 || sizeof(T) == 4 || sizeof(T) == 8;
     if (VBMI2_CAPABLE && isArchSupported(TargetArch::x86_64_icelake))
         TargetSpecific::x86_64_icelake::doFilterAligned<T, Container, SIMD_ELEMENTS>(filt_pos, filt_end_aligned, data_pos, res_data);
@@ -1018,7 +1018,7 @@ ColumnPtr ColumnVector<T>::replicate(const IColumn::Offsets & offsets) const
     const size_t window_size = static_cast<size_t>(sqrt(1 + size / offsets.back()));
     bool use_window = window_size > 16;
 
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
     if (isArchSupported(TargetArch::x86_64_v4))
         if (use_window)
             replicateImpl_x86_64_v4<T, true>(data.data(), size, window_size, offsets, res->getData().data());
@@ -1269,7 +1269,7 @@ ColumnPtr ColumnVector<T>::indexImpl(const PaddedPODArray<Type> & indexes, size_
 
     auto res = this->create(limit);
     typename Self::Container & res_data = res->getData();
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
     if constexpr (sizeof(T) == 1 && sizeof(Type) == 1)
     {
         /// VBMI optimization only applicable for (U)Int8 types

--- a/src/Columns/ColumnVector.cpp
+++ b/src/Columns/ColumnVector.cpp
@@ -865,7 +865,7 @@ inline void doFilterAligned(const UInt8 *& filt_pos, const UInt8 *& filt_end_ali
         {
             for (size_t i = 0; i < SIMD_ELEMENTS; i += ELEMENTS_PER_VEC)
             {
-                svbool_t filt_mask = svcmpne(FILT_LOAD_PRED, 
+                svbool_t filt_mask = svcmpne(FILT_LOAD_PRED,
                                         svld1ub_u32(FILT_LOAD_PRED, reinterpret_cast<const uint8_t *>(filt_pos + i)), 0);
                 svuint32_t vec = svld1(ALL_TRUE, reinterpret_cast<const uint32_t *>(data_pos + i));
                 vec = svcompact(filt_mask, vec);

--- a/src/Columns/ColumnVector.cpp
+++ b/src/Columns/ColumnVector.cpp
@@ -240,7 +240,7 @@ llvm::Value * ColumnVector<T>::compileComparator(llvm::IRBuilderBase & builder, 
 
 #endif
 
-MULTITARGET_FUNCTION_X86_V4_V3(
+MULTITARGET_FUNCTION_X86_V4_V3_SVE(
 MULTITARGET_FUNCTION_HEADER(
 template <typename T>
 void), compareColumnImpl, MULTITARGET_FUNCTION_BODY((
@@ -955,7 +955,7 @@ ColumnPtr ColumnVector<T>::index(const IColumn & indexes, size_t limit) const
 namespace
 {
 
-MULTITARGET_FUNCTION_X86_V4_V3(
+MULTITARGET_FUNCTION_X86_V4_V3_SVE(
 MULTITARGET_FUNCTION_HEADER(template <typename ValueType, bool use_window, int padding_elements = std::min(size_t(4), ColumnVector<ValueType>::Container::pad_right / sizeof(ValueType))> void),
 replicateImpl,
 MULTITARGET_FUNCTION_BODY((const ValueType * __restrict data, size_t size, [[maybe_unused]] size_t window_size, const IColumn::Offsets & offsets, ValueType * __restrict result) /// NOLINT

--- a/src/Columns/ColumnVector.cpp
+++ b/src/Columns/ColumnVector.cpp
@@ -36,6 +36,10 @@
 #    include <immintrin.h>
 #endif
 
+#if USE_ARM_MULTITARGET_CODE
+#    include <arm_sve.h>
+#endif
+
 #if USE_EMBEDDED_COMPILER
 #include <DataTypes/Native.h>
 #include <llvm/IR/IRBuilder.h>
@@ -823,6 +827,67 @@ inline void doFilterAligned(const UInt8 *& filt_pos, const UInt8 *& filt_end_ali
 }
 )
 
+DECLARE_SVE_SPECIFIC_CODE(
+template <typename T, typename Container, size_t SIMD_ELEMENTS>
+inline void doFilterAligned(const UInt8 *& filt_pos, const UInt8 *& filt_end_aligned, const T *& data_pos, Container & res_data)
+{
+    static constexpr size_t ELEMENT_WIDTH = sizeof(T);
+    static const size_t VEC_LEN = svcntb();   /// SVE vector length
+    static const size_t ELEMENTS_PER_VEC = VEC_LEN / ELEMENT_WIDTH;
+    static const UInt64 KMASK = 0xffffffffffffffff >> (64 - ELEMENTS_PER_VEC);
+    const svbool_t ALL_TRUE = svptrue_b8();
+    const svbool_t FILT_LOAD_PRED = svwhilelt_b32(0ULL, ELEMENTS_PER_VEC);
+
+    size_t current_offset = res_data.size();
+    size_t reserve_size = res_data.size();
+    size_t alloc_size = SIMD_ELEMENTS * 2;
+
+    while (filt_pos < filt_end_aligned)
+    {
+        /// to avoid calling resize too frequently, resize to reserve buffer.
+        if (reserve_size - current_offset < SIMD_ELEMENTS)
+        {
+            reserve_size += alloc_size;
+            resize<T>(res_data, reserve_size);
+            alloc_size *= 2;
+        }
+
+        UInt64 mask = bytes64MaskToBits64Mask(filt_pos);
+
+        if (0xffffffffffffffff == mask)
+        {
+            for (size_t i = 0; i < SIMD_ELEMENTS; i += ELEMENTS_PER_VEC)
+                svst1(ALL_TRUE, reinterpret_cast<uint8_t *>(&res_data[current_offset + i]),
+                        svld1(ALL_TRUE, reinterpret_cast<const uint8_t *>(data_pos + i)));
+            current_offset += SIMD_ELEMENTS;
+        }
+        else if (mask)
+        {
+            for (size_t i = 0; i < SIMD_ELEMENTS; i += ELEMENTS_PER_VEC)
+            {
+                svbool_t filt_mask = svcmpne(FILT_LOAD_PRED, 
+                                        svld1ub_u32(FILT_LOAD_PRED, reinterpret_cast<const uint8_t *>(filt_pos + i)), 0);
+                svuint32_t vec = svld1(ALL_TRUE, reinterpret_cast<const uint32_t *>(data_pos + i));
+                vec = svcompact(filt_mask, vec);
+                svst1(ALL_TRUE, reinterpret_cast<uint32_t *>(&res_data[current_offset]), vec);
+
+                current_offset += std::popcount(mask & KMASK);
+                /// prepare mask for next iter, if ELEMENTS_PER_VEC = 64, no next iter
+                if (ELEMENTS_PER_VEC < 64)
+                {
+                    mask >>= ELEMENTS_PER_VEC;
+                }
+            }
+        }
+
+        filt_pos += SIMD_ELEMENTS;
+        data_pos += SIMD_ELEMENTS;
+    }
+    /// Resize to the real size.
+    res_data.resize_exact(current_offset);
+}
+)
+
 template <typename T>
 ColumnPtr ColumnVector<T>::filter(const IColumn::Filter & filt, ssize_t result_size_hint) const
 {
@@ -852,6 +917,11 @@ ColumnPtr ColumnVector<T>::filter(const IColumn::Filter & filt, ssize_t result_s
     static constexpr bool VBMI2_CAPABLE = sizeof(T) == 1 || sizeof(T) == 2 || sizeof(T) == 4 || sizeof(T) == 8;
     if (VBMI2_CAPABLE && isArchSupported(TargetArch::x86_64_icelake))
         TargetSpecific::x86_64_icelake::doFilterAligned<T, Container, SIMD_ELEMENTS>(filt_pos, filt_end_aligned, data_pos, res_data);
+    else
+#elif USE_ARM_MULTITARGET_CODE
+    static constexpr bool SVE_CAPABLE = sizeof(T) == 4;
+    if (SVE_CAPABLE && isArchSupported(TargetArch::SVE))
+        TargetSpecific::SVE::doFilterAligned<T, Container, SIMD_ELEMENTS>(filt_pos, filt_end_aligned, data_pos, res_data);
     else
 #endif
     {

--- a/src/Columns/FilterDescription.cpp
+++ b/src/Columns/FilterDescription.cpp
@@ -17,7 +17,7 @@ namespace ErrorCodes
 extern const int ILLEGAL_TYPE_OF_COLUMN_FOR_FILTER;
 }
 
-MULTITARGET_FUNCTION_X86_V4_V3(
+MULTITARGET_FUNCTION_X86_V4_V3_SVE(
 MULTITARGET_FUNCTION_HEADER(
 template <typename T>
 void), convertColumnToBoolImpl, MULTITARGET_FUNCTION_BODY((const typename ColumnVector<T>::Container & data, IColumnFilter & res)

--- a/src/Columns/FilterDescription.cpp
+++ b/src/Columns/FilterDescription.cpp
@@ -36,7 +36,7 @@ ALWAYS_INLINE bool tryConvertColumnToBool(const IColumn & column, IColumnFilter 
     chassert(res.size() == column.size());
 
     auto & data = column_typed->getData();
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
     if (isArchSupported(TargetArch::x86_64_v4))
     {
         convertColumnToBoolImpl_x86_64_v4<T>(data, res);

--- a/src/Common/CPUID.h
+++ b/src/Common/CPUID.h
@@ -6,6 +6,11 @@
 #include <cpuid.h>
 #endif
 
+#if defined(__aarch64__) && defined(__linux__)
+#include <sys/auxv.h>
+#include <asm/hwcap.h>
+#endif
+
 #include <cstring>
 
 #ifdef OS_LINUX
@@ -389,6 +394,21 @@ inline bool haveGenuineIntel() noexcept
 #endif
 }
 
+inline bool haveSVE() noexcept
+{
+#if defined(__aarch64__) && defined(__linux__)
+    /** "Support for the execution of SVE instructions in userspace can also be detected by reading the CPU ID register ID_AA64PFR0_EL1
+      *  using an MRS instruction, and checking that the value of the SVE field is nonzero. It does not guarantee the presence of the system
+      *  interfaces described in the following sections: software that needs to verify that those interfaces are present must check for
+      *  HWCAP_SVE instead." (c) https://www.kernel.org/doc/Documentation/arm64/sve.txt
+      */
+    const UInt64 hwcap = getauxval(AT_HWCAP);
+    return (hwcap & HWCAP_SVE) != 0;
+#else
+    return false;
+#endif
+}
+
 #define CPU_ID_ENUMERATE(OP) \
     OP(SSE) \
     OP(SSE2) \
@@ -440,7 +460,8 @@ inline bool haveGenuineIntel() noexcept
     OP(AMXBF16) \
     OP(AMXTILE) \
     OP(AMXINT8) \
-    OP(GenuineIntel)
+    OP(GenuineIntel) \
+    OP(SVE)
 
 struct CPUFlagsCache
 {

--- a/src/Common/RadixSort.h
+++ b/src/Common/RadixSort.h
@@ -591,7 +591,7 @@ private:
 
             return;
         }
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
         if (DB::isArchSupported(DB::TargetArch::GenuineIntel))
         {
             radixSortLSDInternal<DIRECT_WRITE_TO_DESTINATION, true>(arr, size, reverse, destination);
@@ -607,7 +607,7 @@ public:
       */
     static void executeLSD(Element * arr, size_t size)
     {
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
         if (DB::isArchSupported(DB::TargetArch::GenuineIntel))
         {
             radixSortLSDInternal<false, true>(arr, size, false, nullptr);
@@ -619,7 +619,7 @@ public:
 
     static void executeLSD(Element * arr, size_t size, bool reverse)
     {
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
         if (DB::isArchSupported(DB::TargetArch::GenuineIntel))
         {
             radixSortLSDInternal<false, true>(arr, size, reverse, nullptr);
@@ -637,7 +637,7 @@ public:
       */
     static void executeLSD(Element * arr, size_t size, bool reverse, Result * destination)
     {
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
         if (DB::isArchSupported(DB::TargetArch::GenuineIntel))
         {
             radixSortLSDInternal<true, true>(arr, size, reverse, destination);

--- a/src/Common/StringUtils.cpp
+++ b/src/Common/StringUtils.cpp
@@ -2,7 +2,7 @@
 
 #include <Common/TargetSpecific.h>
 
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
 #include <immintrin.h>
 #endif
 
@@ -78,7 +78,7 @@ static bool isAllASCII(const UInt8 * data, size_t size)
 
 bool isAllASCII(const UInt8 * data, size_t size)
 {
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
     if (isArchSupported(DB::TargetArch::x86_64_v3))
         return TargetSpecific::x86_64_v3::isAllASCII(data, size);
     if (isArchSupported(DB::TargetArch::x86_64_v2))

--- a/src/Common/TargetSpecific.cpp
+++ b/src/Common/TargetSpecific.cpp
@@ -77,6 +77,9 @@ UInt32 getSupportedArchs()
     if (CPU::CPUFlagsCache::have_GenuineIntel)
         result |= static_cast<UInt32>(TargetArch::GenuineIntel);
 
+    if (CPU::CPUFlagsCache::have_SVE)
+        result |= static_cast<UInt32>(TargetArch::SVE);
+
     return result;
 }
 
@@ -91,6 +94,7 @@ String toString(TargetArch arch)
         case TargetArch::x86_64_icelake:        return "x86-64-icelake";
         case TargetArch::x86_64_sapphirerapids: return "x86-64-sapphirerapids";
         case TargetArch::GenuineIntel:          return "GenuineIntel";
+        case TargetArch::SVE:                   return "sve";
     }
 
     // This should never be reached. If it is, someone added a new TargetArch

--- a/src/Common/TargetSpecific.h
+++ b/src/Common/TargetSpecific.h
@@ -112,6 +112,7 @@ String toString(TargetArch arch);
 
 
 #define USE_MULTITARGET_CODE 1
+#define USE_ARM_MULTITARGET_CODE 0
 
 /// Function-specific attributes using arch= for cleaner specification
 /// This matches -march= compiler flags and avoids long feature lists
@@ -302,7 +303,7 @@ DECLARE_SVE_SPECIFIC_CODE(
   * class TestClass
   * {
   * public:
-  *     MULTITARGET_FUNCTION_X86_V4_V3(
+  *     MULTITARGET_FUNCTION_X86_V4_V3_SVE(
   *     MULTITARGET_FUNCTION_HEADER(int), testFunctionImpl, MULTITARGET_FUNCTION_BODY((int value)
   *     {
   *          return value;
@@ -335,7 +336,7 @@ DECLARE_SVE_SPECIFIC_CODE(
 
 #if ENABLE_MULTITARGET_CODE && defined(__GNUC__) && defined(__x86_64__)
 
-#define MULTITARGET_FUNCTION_X86_V4_V3(FUNCTION_HEADER, name, FUNCTION_BODY) \
+#define MULTITARGET_FUNCTION_X86_V4_V3_SVE(FUNCTION_HEADER, name, FUNCTION_BODY) \
     FUNCTION_HEADER \
     \
     X86_64_V4_FUNCTION_SPECIFIC_ATTRIBUTE \
@@ -366,9 +367,29 @@ DECLARE_SVE_SPECIFIC_CODE(
     FUNCTION_BODY \
 
 
+#elif ENABLE_MULTITARGET_CODE && defined(__GNUC__) && defined(__aarch64__)
+
+#define MULTITARGET_FUNCTION_X86_V4_V3_SVE(FUNCTION_HEADER, name, FUNCTION_BODY) \
+    FUNCTION_HEADER \
+    \
+    SVE_FUNCTION_SPECIFIC_ATTRIBUTE \
+    name##_SVE \
+    FUNCTION_BODY \
+    \
+    FUNCTION_HEADER \
+    \
+    name \
+    FUNCTION_BODY \
+
+#define MULTITARGET_FUNCTION_X86_V3(FUNCTION_HEADER, name, FUNCTION_BODY) \
+    FUNCTION_HEADER \
+    \
+    name \
+    FUNCTION_BODY \
+
 #else
 
-#define MULTITARGET_FUNCTION_X86_V4_V3(FUNCTION_HEADER, name, FUNCTION_BODY) \
+#define MULTITARGET_FUNCTION_X86_V4_V3_SVE(FUNCTION_HEADER, name, FUNCTION_BODY) \
     FUNCTION_HEADER \
     \
     name \

--- a/src/Common/TargetSpecific.h
+++ b/src/Common/TargetSpecific.h
@@ -15,15 +15,15 @@
  * Thus, it's allowed to call functions inside these namespaces only after
  * checking platform in runtime (see isArchSupported() below).
  *
- * If compiler is not gcc/clang or target isn't x86_64 or ENABLE_MULTITARGET_CODE
+ * If compiler is not gcc/clang or target isn't x86_64/aarch64 or ENABLE_MULTITARGET_CODE
  * was set to OFF in cmake, all code inside these macros will be removed and
  * USE_MULTITARGET_CODE will be set to 0. Use #if USE_MULTITARGET_CODE whenever you
  * use anything from this namespaces.
  *
  * For similarities there is a macros DECLARE_DEFAULT_CODE, which wraps code
  * into the namespace TargetSpecific::Default but doesn't specify any additional
- * copile options. Functions and classes inside this macros are available regardless
- * of USE_MUTLITARGE_CODE.
+ * compile options. Functions and classes inside this macros are available regardless
+ * of USE_MULTITARGET_CODE.
  *
  * Example of usage:
  *
@@ -91,6 +91,7 @@ enum class TargetArch : UInt32
     x86_64_icelake = (1 << 3),
     x86_64_sapphirerapids = (1 << 4),
     GenuineIntel = (1 << 5),          /// Not an instruction set, but a CPU vendor. Used for optimizations that are only applicable for Intel CPUs, like prefetching
+    SVE = (1 << 6),
 };
 
 /// Runtime detection.
@@ -198,9 +199,48 @@ namespace TargetSpecific::x86_64_sapphirerapids { \
 } \
 END_TARGET_SPECIFIC_CODE
 
+/* Delete aarch64-specific code.
+ */
+#define DECLARE_SVE_SPECIFIC_CODE(...)
+
+#elif ENABLE_MULTITARGET_CODE && defined(__GNUC__) && defined(__aarch64__)
+
+#define USE_MULTITARGET_CODE 0
+#define USE_ARM_MULTITARGET_CODE 1
+
+#define SVE_FUNCTION_SPECIFIC_ATTRIBUTE __attribute__((target("sve")))
+
+#define BEGIN_SVE_SPECIFIC_CODE \
+    _Pragma("clang attribute push(__attribute__((target(\"sve\"))),apply_to=function)")
+#define END_TARGET_SPECIFIC_CODE \
+    _Pragma("clang attribute pop")
+
+/* Clang shows warning when there aren't any objects to apply pragma.
+ * To prevent this warning we define this function inside every macros with pragmas.
+ */
+#define DUMMY_FUNCTION_DEFINITION [[maybe_unused]] void _dummy_function_definition();
+
+#define DECLARE_SVE_SPECIFIC_CODE(...) \
+BEGIN_SVE_SPECIFIC_CODE \
+namespace TargetSpecific::SVE { \
+    DUMMY_FUNCTION_DEFINITION \
+    using namespace DB::TargetSpecific::SVE; \
+    __VA_ARGS__ \
+} \
+END_TARGET_SPECIFIC_CODE
+
+/* Delete x86_64-specific code.
+ */
+#define DECLARE_X86_64_V2_SPECIFIC_CODE(...)
+#define DECLARE_X86_64_V3_SPECIFIC_CODE(...)
+#define DECLARE_X86_64_V4_SPECIFIC_CODE(...)
+#define DECLARE_X86_ICELAKE_SPECIFIC_CODE(...)
+#define DECLARE_X86_SAPPHIRE_SPECIFIC_CODE(...)
+
 #else
 
 #define USE_MULTITARGET_CODE 0
+#define USE_ARM_MULTITARGET_CODE 0
 
 /* Multitarget code is disabled, just delete target-specific code.
  */
@@ -209,6 +249,7 @@ END_TARGET_SPECIFIC_CODE
 #define DECLARE_X86_64_V4_SPECIFIC_CODE(...)
 #define DECLARE_X86_ICELAKE_SPECIFIC_CODE(...)
 #define DECLARE_X86_SAPPHIRE_SPECIFIC_CODE(...)
+#define DECLARE_SVE_SPECIFIC_CODE(...)
 
 #endif
 
@@ -219,11 +260,12 @@ namespace TargetSpecific::Default { \
 }
 
 
-/// Only enable extra v3 and v4 by default
+/// Only enable extra v3, v4 and SVE by default
 #define DECLARE_MULTITARGET_CODE(...) \
 DECLARE_DEFAULT_CODE         (__VA_ARGS__) \
 DECLARE_X86_64_V3_SPECIFIC_CODE    (__VA_ARGS__) \
 DECLARE_X86_64_V4_SPECIFIC_CODE   (__VA_ARGS__) \
+DECLARE_SVE_SPECIFIC_CODE (__VA_ARGS__)
 
 DECLARE_DEFAULT_CODE(
     constexpr auto BuildArch = TargetArch::Default;
@@ -249,6 +291,9 @@ DECLARE_X86_SAPPHIRE_SPECIFIC_CODE(
     constexpr auto BuildArch = TargetArch::x86_64_sapphirerapids;
 )
 
+DECLARE_SVE_SPECIFIC_CODE(
+    constexpr auto BuildArch = TargetArch::SVE;
+)
 
 /** Runtime Dispatch helpers for class members.
   *

--- a/src/Common/TargetSpecific.h
+++ b/src/Common/TargetSpecific.h
@@ -17,13 +17,13 @@
  *
  * If compiler is not gcc/clang or target isn't x86_64/aarch64 or ENABLE_MULTITARGET_CODE
  * was set to OFF in cmake, all code inside these macros will be removed and
- * USE_MULTITARGET_CODE will be set to 0. Use #if USE_MULTITARGET_CODE whenever you
+ * USE_X86_MULTITARGET_CODE will be set to 0. Use #if USE_X86_MULTITARGET_CODE whenever you
  * use anything from this namespaces.
  *
  * For similarities there is a macros DECLARE_DEFAULT_CODE, which wraps code
  * into the namespace TargetSpecific::Default but doesn't specify any additional
  * compile options. Functions and classes inside this macros are available regardless
- * of USE_MULTITARGET_CODE.
+ * of USE_X86_MULTITARGET_CODE.
  *
  * Example of usage:
  *
@@ -40,7 +40,7 @@
  * ) // DECLARE_AVX2_SPECIFIC_CODE
  *
  * int func() {
- * #if USE_MULTITARGET_CODE
+ * #if USE_X86_MULTITARGET_CODE
  *     if (isArchSupported(TargetArch::x86_64_v3))
  *         return TargetSpecific::x86_64_v3::funcImpl();
  * #endif
@@ -111,7 +111,7 @@ String toString(TargetArch arch);
 #if ENABLE_MULTITARGET_CODE && defined(__GNUC__) && defined(__x86_64__)
 
 
-#define USE_MULTITARGET_CODE 1
+#define USE_X86_MULTITARGET_CODE 1
 #define USE_ARM_MULTITARGET_CODE 0
 
 /// Function-specific attributes using arch= for cleaner specification
@@ -206,7 +206,7 @@ END_TARGET_SPECIFIC_CODE
 
 #elif ENABLE_MULTITARGET_CODE && defined(__GNUC__) && defined(__aarch64__)
 
-#define USE_MULTITARGET_CODE 0
+#define USE_X86_MULTITARGET_CODE 0
 #define USE_ARM_MULTITARGET_CODE 1
 
 #define SVE_FUNCTION_SPECIFIC_ATTRIBUTE __attribute__((target("sve")))
@@ -240,7 +240,7 @@ END_TARGET_SPECIFIC_CODE
 
 #else
 
-#define USE_MULTITARGET_CODE 0
+#define USE_X86_MULTITARGET_CODE 0
 #define USE_ARM_MULTITARGET_CODE 0
 
 /* Multitarget code is disabled, just delete target-specific code.

--- a/src/Common/findExtreme.cpp
+++ b/src/Common/findExtreme.cpp
@@ -129,7 +129,7 @@ template <has_find_extreme_implementation T, class ComparatorClass, bool add_all
 static std::optional<T>
 findExtreme(const T * __restrict ptr, const UInt8 * __restrict condition_map [[maybe_unused]], size_t start, size_t end)
 {
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
     /// In some cases the compiler if able to apply the condition and still generate SIMD, so we still build both
     /// conditional and unconditional functions with multiple architectures
     /// We see no benefit from using AVX512BW or AVX512F (over AVX2), so we only declare SSE and AVX2

--- a/src/Common/iota.cpp
+++ b/src/Common/iota.cpp
@@ -17,7 +17,7 @@ MULTITARGET_FUNCTION_X86_V3(
 template <iota_supported_types T>
 void iota(T * begin, size_t count, T first_value)
 {
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
     if (isArchSupported(TargetArch::x86_64_v3))
         return iotaImpl_x86_64_v3(begin, count, first_value);
 #endif
@@ -36,7 +36,7 @@ MULTITARGET_FUNCTION_X86_V3(
 template <iota_supported_types T>
 void iotaWithStep(T * begin, size_t count, T first_value, T step)
 {
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
     if (isArchSupported(TargetArch::x86_64_v3))
         return iotaWithStepImpl_x86_64_v3(begin, count, first_value, step);
 #endif

--- a/src/Compression/CompressionCodecT64.cpp
+++ b/src/Compression/CompressionCodecT64.cpp
@@ -368,7 +368,7 @@ void clear(T * buf)
 }
 
 
-MULTITARGET_FUNCTION_X86_V4_V3(
+MULTITARGET_FUNCTION_X86_V4_V3_SVE(
 MULTITARGET_FUNCTION_HEADER(
 template <typename T, bool full>
 void), transposeImpl, MULTITARGET_FUNCTION_BODY((const T * src, char * dst, UInt32 num_bits, UInt32 tail) /// NOLINT
@@ -422,7 +422,7 @@ ALWAYS_INLINE void transpose(const T * src, char * dst, UInt32 num_bits, UInt32 
     }
 }
 
-MULTITARGET_FUNCTION_X86_V4_V3(
+MULTITARGET_FUNCTION_X86_V4_V3_SVE(
 MULTITARGET_FUNCTION_HEADER(
 template <typename T, bool full>
 void), reverseTransposeImpl, MULTITARGET_FUNCTION_BODY((const char * src, T * buf, UInt32 num_bits, UInt32 tail) /// NOLINT

--- a/src/Compression/CompressionCodecT64.cpp
+++ b/src/Compression/CompressionCodecT64.cpp
@@ -405,7 +405,7 @@ void), transposeImpl, MULTITARGET_FUNCTION_BODY((const T * src, char * dst, UInt
 template <typename T, bool full = false>
 ALWAYS_INLINE void transpose(const T * src, char * dst, UInt32 num_bits, UInt32 tail = 64)
 {
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
     if (isArchSupported(TargetArch::x86_64_v4))
     {
         transposeImpl_x86_64_v4<T, full>(src, dst, num_bits, tail);
@@ -456,7 +456,7 @@ void), reverseTransposeImpl, MULTITARGET_FUNCTION_BODY((const char * src, T * bu
 template <typename T, bool full = false>
 ALWAYS_INLINE void reverseTranspose(const char * src, T * buf, UInt32 num_bits, UInt32 tail = 64)
 {
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
     if (isArchSupported(TargetArch::x86_64_v4))
     {
         reverseTransposeImpl_x86_64_v4<T, full>(src, buf, num_bits, tail);

--- a/src/Core/DecimalComparison.h
+++ b/src/Core/DecimalComparison.h
@@ -276,7 +276,7 @@ private:
         }
     }
 
-    MULTITARGET_FUNCTION_X86_V4_V3(
+    MULTITARGET_FUNCTION_X86_V4_V3_SVE(
     MULTITARGET_FUNCTION_HEADER(
     template <bool check_overflow, bool scale_left, bool scale_right> static void NO_INLINE
     ), vectorConstantImpl, MULTITARGET_FUNCTION_BODY(( /// NOLINT

--- a/src/Core/DecimalComparison.h
+++ b/src/Core/DecimalComparison.h
@@ -298,7 +298,7 @@ private:
     template <bool check_overflow, bool scale_left, bool scale_right>
     static void NO_INLINE vectorConstant(const ArrayA & a, B b, PaddedPODArray<UInt8> & c, CompareInt scale)
     {
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
         if (isArchSupported(TargetArch::x86_64_v4))
         {
             vectorConstantImpl_x86_64_v4<check_overflow, scale_left, scale_right>(a, b, c, scale);

--- a/src/DataTypes/Serializations/SerializationQBit.cpp
+++ b/src/DataTypes/Serializations/SerializationQBit.cpp
@@ -16,7 +16,7 @@
 #include <base/BFloat16.h>
 #include <base/types.h>
 
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
 #    include <immintrin.h>
 #endif
 
@@ -526,7 +526,7 @@ DECLARE_X86_64_V4_SPECIFIC_CODE(
         }
     })
 
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
 
 /// Use explicit AVX512BW target instead of x86-64-v4 for better performance
 /// The generic x86-64-v4 arch seems to generate slower code for this specific workload
@@ -587,7 +587,7 @@ _Pragma("clang attribute pop")
 template <typename T>
 void SerializationQBit::untransposeBitPlane(const UInt8 * __restrict src, T * __restrict dst, size_t stride_len, T bit_mask)
 {
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
     if constexpr (std::is_same_v<T, UInt64>)
     {
         if (isArchSupported(TargetArch::x86_64_v4))

--- a/src/Functions/FunctionUnaryArithmetic.h
+++ b/src/Functions/FunctionUnaryArithmetic.h
@@ -42,7 +42,7 @@ struct UnaryOperationImpl
     using ArrayA = typename ColVecA::Container;
     using ArrayC = typename ColVecC::Container;
 
-    MULTITARGET_FUNCTION_X86_V4_V3(
+    MULTITARGET_FUNCTION_X86_V4_V3_SVE(
     MULTITARGET_FUNCTION_HEADER(static void NO_INLINE), vectorImpl, MULTITARGET_FUNCTION_BODY((const ArrayA & a, ArrayC & c) /// NOLINT
     {
         size_t size = a.size();
@@ -64,6 +64,12 @@ struct UnaryOperationImpl
             vectorImpl_x86_64_v3(a, c);
             return;
         }
+#elif USE_ARM_MULTITARGET_CODE
+        if (isArchSupported(TargetArch::SVE))
+        {
+            vectorImpl_SVE(a, c);
+            return;
+        }
 #endif
 
         vectorImpl(a, c);
@@ -79,7 +85,7 @@ struct UnaryOperationImpl
 template <typename Op>
 struct FixedStringUnaryOperationImpl
 {
-    MULTITARGET_FUNCTION_X86_V4_V3(
+    MULTITARGET_FUNCTION_X86_V4_V3_SVE(
     MULTITARGET_FUNCTION_HEADER(static void NO_INLINE), vectorImpl, MULTITARGET_FUNCTION_BODY((const ColumnFixedString::Chars & a, /// NOLINT
         ColumnFixedString::Chars & c)
     {
@@ -103,6 +109,12 @@ struct FixedStringUnaryOperationImpl
             vectorImpl_x86_64_v3(a, c);
             return;
         }
+#elif USE_ARM_MULTITARGET_CODE
+        if (isArchSupported(TargetArch::SVE))
+        {
+            vectorImpl_SVE(a, c);
+            return;
+        }
 #endif
 
         vectorImpl(a, c);
@@ -112,7 +124,7 @@ struct FixedStringUnaryOperationImpl
 template <typename Op>
 struct StringUnaryOperationReduceImpl
 {
-    MULTITARGET_FUNCTION_X86_V4_V3(
+    MULTITARGET_FUNCTION_X86_V4_V3_SVE(
         MULTITARGET_FUNCTION_HEADER(static UInt64 NO_INLINE),
         vectorImpl,
         MULTITARGET_FUNCTION_BODY((const UInt8 * start, const UInt8 * end) /// NOLINT
@@ -134,6 +146,11 @@ struct StringUnaryOperationReduceImpl
         if (isArchSupported(TargetArch::x86_64_v3))
         {
             return vectorImpl_x86_64_v3(start, end);
+        }
+#elif USE_ARM_MULTITARGET_CODE
+        if (isArchSupported(TargetArch::SVE))
+        {
+            return vectorImpl_SVE(start, end);
         }
 #endif
 

--- a/src/Functions/FunctionUnaryArithmetic.h
+++ b/src/Functions/FunctionUnaryArithmetic.h
@@ -52,7 +52,7 @@ struct UnaryOperationImpl
 
     static void NO_INLINE vector(const ArrayA & a, ArrayC & c)
     {
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
         if (isArchSupported(TargetArch::x86_64_v4))
         {
             vectorImpl_x86_64_v4(a, c);
@@ -97,7 +97,7 @@ struct FixedStringUnaryOperationImpl
 
     static void NO_INLINE vector(const ColumnFixedString::Chars & a, ColumnFixedString::Chars & c)
     {
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
         if (isArchSupported(TargetArch::x86_64_v4))
         {
             vectorImpl_x86_64_v4(a, c);
@@ -137,7 +137,7 @@ struct StringUnaryOperationReduceImpl
 
     static UInt64 NO_INLINE vector(const UInt8 * start, const UInt8 * end)
     {
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
         if (isArchSupported(TargetArch::x86_64_v4))
         {
             return vectorImpl_x86_64_v4(start, end);

--- a/src/Functions/FunctionsComparison.h
+++ b/src/Functions/FunctionsComparison.h
@@ -155,7 +155,7 @@ struct NumComparisonImpl
     using ContainerA = PaddedPODArray<A>;
     using ContainerB = PaddedPODArray<B>;
 
-    MULTITARGET_FUNCTION_X86_V4_V3(
+    MULTITARGET_FUNCTION_X86_V4_V3_SVE(
     MULTITARGET_FUNCTION_HEADER(static void), vectorVectorImpl, MULTITARGET_FUNCTION_BODY(( /// NOLINT
         const ContainerA & a, const ContainerB & b, PaddedPODArray<UInt8> & c)
     {
@@ -193,13 +193,19 @@ struct NumComparisonImpl
             vectorVectorImpl_x86_64_v3(a, b, c);
             return;
         }
+#elif USE_ARM_MULTITARGET_CODE
+        if (isArchSupported(TargetArch::SVE))
+        {
+            vectorVectorImpl_SVE(a, b, c);
+            return;
+        }
 #endif
 
         vectorVectorImpl(a, b, c);
     }
 
 
-    MULTITARGET_FUNCTION_X86_V4_V3(
+    MULTITARGET_FUNCTION_X86_V4_V3_SVE(
     MULTITARGET_FUNCTION_HEADER(static void), vectorConstantImpl, MULTITARGET_FUNCTION_BODY(( /// NOLINT
         const ContainerA & a, B b, PaddedPODArray<UInt8> & c)
     {
@@ -228,6 +234,12 @@ struct NumComparisonImpl
         if (isArchSupported(TargetArch::x86_64_v3))
         {
             vectorConstantImpl_x86_64_v3(a, b, c);
+            return;
+        }
+#elif USE_ARM_MULTITARGET_CODE
+        if (isArchSupported(TargetArch::SVE))
+        {
+            vectorConstantImpl_SVE(a, b, c);
             return;
         }
 #endif

--- a/src/Functions/FunctionsComparison.h
+++ b/src/Functions/FunctionsComparison.h
@@ -181,7 +181,7 @@ struct NumComparisonImpl
 
     static void NO_INLINE vectorVector(const ContainerA & a, const ContainerB & b, PaddedPODArray<UInt8> & c)
     {
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
         if (isArchSupported(TargetArch::x86_64_v4))
         {
             vectorVectorImpl_x86_64_v4(a, b, c);
@@ -224,7 +224,7 @@ struct NumComparisonImpl
 
     static void NO_INLINE vectorConstant(const ContainerA & a, B b, PaddedPODArray<UInt8> & c)
     {
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
         if (isArchSupported(TargetArch::x86_64_v4))
         {
             vectorConstantImpl_x86_64_v4(a, b, c);

--- a/src/Functions/FunctionsHashing.h
+++ b/src/Functions/FunctionsHashing.h
@@ -884,7 +884,7 @@ public:
         selector.registerImplementation<TargetArch::Default,
             TargetSpecific::Default::FunctionIntHash<Impl, Name>>();
 
-    #if USE_MULTITARGET_CODE
+    #if USE_X86_MULTITARGET_CODE
         selector.registerImplementation<TargetArch::x86_64_v3,
             TargetSpecific::x86_64_v3::FunctionIntHash<Impl, Name>>();
         selector.registerImplementation<TargetArch::x86_64_v4,
@@ -1570,7 +1570,7 @@ public:
         selector
             .registerImplementation<TargetArch::Default, TargetSpecific::Default::FunctionAnyHash<Impl, Keyed, KeyType, KeyColumnsType>>();
 
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
         selector.registerImplementation<TargetArch::x86_64_v3, TargetSpecific::x86_64_v3::FunctionAnyHash<Impl, Keyed, KeyType, KeyColumnsType>>();
         selector
             .registerImplementation<TargetArch::x86_64_v4, TargetSpecific::x86_64_v4::FunctionAnyHash<Impl, Keyed, KeyType, KeyColumnsType>>();

--- a/src/Functions/FunctionsLogical.cpp
+++ b/src/Functions/FunctionsLogical.cpp
@@ -551,7 +551,7 @@ using FastApplierImpl =
 template <typename Op, typename Type, typename ... Types>
 struct TypedExecutorInvoker<Op, Type, Types ...>
 {
-    MULTITARGET_FUNCTION_X86_V4_V3(
+    MULTITARGET_FUNCTION_X86_V4_V3_SVE(
     MULTITARGET_FUNCTION_HEADER(
     template <typename T, typename Result>
     static void

--- a/src/Functions/FunctionsLogical.cpp
+++ b/src/Functions/FunctionsLogical.cpp
@@ -414,7 +414,7 @@ struct OperationApplier
     template <typename Columns, typename ResultData>
     static void apply(Columns & in, ResultData & result_data, bool use_result_data_as_input = false)
     {
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
         if (isArchSupported(TargetArch::x86_64_v4))
         {
             if (!use_result_data_as_input)
@@ -473,7 +473,7 @@ struct OperationApplier
         BATCH_BODY(doBatchedApply)
     }
 
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
     template <bool CarryResult, typename Columns, typename Result>
     static void doBatchedApplyAVX512BW(Columns & in, Result * __restrict result_data, size_t size) X86_64_V4_FUNCTION_SPECIFIC_ATTRIBUTE
     {
@@ -500,7 +500,7 @@ struct OperationApplier<Op, OperationApplierImpl, 0>
         throw Exception(ErrorCodes::LOGICAL_ERROR, "OperationApplier<...>::apply(...): not enough arguments to run this method");
     }
 
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
     template <bool, typename Columns, typename Result>
     static void doBatchedApplyAVX512BW(Columns &, Result &, size_t)
     {
@@ -569,7 +569,7 @@ struct TypedExecutorInvoker<Op, Type, Types ...>
     {
         if (const auto column = typeid_cast<const ColumnVector<Type> *>(&y))
         {
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
             if (isArchSupported(TargetArch::x86_64_v4))
             {
                 applyImpl_x86_64_v4<T, Result>(x, *column, result);

--- a/src/Functions/FunctionsRandom.cpp
+++ b/src/Functions/FunctionsRandom.cpp
@@ -4,7 +4,7 @@
 #include <Common/HashTable/Hash.h>
 #include <Common/randomSeed.h>
 #include <base/unaligned.h>
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
 #  include <x86intrin.h>
 #endif
 

--- a/src/Functions/FunctionsRandom.h
+++ b/src/Functions/FunctionsRandom.h
@@ -96,7 +96,7 @@ public:
         selector.registerImplementation<TargetArch::Default,
             FunctionRandomImpl<TargetSpecific::Default::RandImpl, ToType, Name>>();
 
-    #if USE_MULTITARGET_CODE
+    #if USE_X86_MULTITARGET_CODE
         selector.registerImplementation<TargetArch::x86_64_v3,
             FunctionRandomImpl<TargetSpecific::x86_64_v3::RandImpl, ToType, Name>>();
     #endif

--- a/src/Functions/GatherUtils/sliceHasImplAnyAll.h
+++ b/src/Functions/GatherUtils/sliceHasImplAnyAll.h
@@ -6,7 +6,7 @@
 
 #include <Common/TargetSpecific.h>
 
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
 #include <immintrin.h>
 #endif
 
@@ -60,7 +60,7 @@ inline ALWAYS_INLINE bool hasAllIntegralLoopRemainder(
     return true;
 }
 
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
 
 DECLARE_X86_64_V3_SPECIFIC_CODE (
 
@@ -887,7 +887,7 @@ template <
     bool (*isEqual)(const FirstSliceType &, const SecondSliceType &, size_t, size_t)>
 inline ALWAYS_INLINE bool sliceHasImplAnyAll(const FirstSliceType & first, const SecondSliceType & second, const UInt8 * first_null_map, const UInt8 * second_null_map)
 {
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
     if constexpr (search_type == ArraySearchType::All && std::is_same_v<FirstSliceType, SecondSliceType>)
     {
         if (isArchSupported(TargetArch::x86_64_v3))

--- a/src/Functions/PerformanceAdaptors.h
+++ b/src/Functions/PerformanceAdaptors.h
@@ -183,7 +183,7 @@ namespace detail
  *         /// Register all implementations in constructor.
  *         /// There could be as many implementation for every target as you want.
  *         selector.registerImplementation<TargetArch::Default, MyDefaultImpl>();
- *     #if USE_MULTITARGET_CODE
+ *     #if USE_X86_MULTITARGET_CODE
  *         selector.registerImplementation<TargetArch::x86_64_v3, TargetSpecific::x86_64_v3::Myv3Impl>();
  *     #endif
  *     }

--- a/src/Functions/array/arrayDistance.cpp
+++ b/src/Functions/array/arrayDistance.cpp
@@ -10,7 +10,7 @@
 
 #include <cmath>
 
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
 #include <immintrin.h>
 #endif
 
@@ -81,7 +81,7 @@ struct L2Distance
         state.sum += other_state.sum;
     }
 
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
     template <typename ResultType>
     X86_64_V4_FUNCTION_SPECIFIC_ATTRIBUTE static void accumulateCombineF32F64(
         const ResultType * __restrict data_x,
@@ -268,7 +268,7 @@ struct CosineDistance
         state.y_squared += other_state.y_squared;
     }
 
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
     template <typename ResultType>
     X86_64_V4_FUNCTION_SPECIFIC_ATTRIBUTE static void accumulateCombineF32F64(
         const ResultType * __restrict data_x,
@@ -607,7 +607,7 @@ private:
             /// - the two most common metrics L2 and cosine distance,
             /// - the most powerful SIMD instruction set (AVX-512).
             bool processed_with_simd = false;
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
             if constexpr (std::is_same_v<Kernel, L2Distance> || std::is_same_v<Kernel, CosineDistance>)
             {
                 if constexpr ((std::is_same_v<ResultType, Float32> && std::is_same_v<LeftType, Float32> && std::is_same_v<RightType, Float32>)

--- a/src/Functions/array/arrayDotProduct.cpp
+++ b/src/Functions/array/arrayDotProduct.cpp
@@ -9,7 +9,7 @@
 #include <Functions/castTypeToEither.h>
 #include <Interpreters/Context_fwd.h>
 
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
 #include <immintrin.h>
 #endif
 
@@ -77,7 +77,7 @@ struct DotProduct
         state.sum += other_state.sum;
     }
 
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
     template <typename Type>
     X86_64_V4_FUNCTION_SPECIFIC_ATTRIBUTE static void accumulateCombine(
         const Type * __restrict data_x,
@@ -348,7 +348,7 @@ private:
             ///   10 input types x 8 output types,
             /// - const/non-const inputs instead of non-const/non-const inputs
             /// - the most powerful SIMD instruction set (AVX-512F).
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
             if constexpr ((std::is_same_v<ResultType, Float32> || std::is_same_v<ResultType, Float64>)
                             && std::is_same_v<ResultType, LeftType> && std::is_same_v<LeftType, RightType>)
             {

--- a/src/Functions/dateTimeToUUIDv7.cpp
+++ b/src/Functions/dateTimeToUUIDv7.cpp
@@ -109,7 +109,7 @@ public:
     {
         selector.registerImplementation<TargetArch::Default, Parent>();
 
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
         using ParentAVX2 = TargetSpecific::x86_64_v3::FunctionDateTimeToUUIDv7Base;
         selector.registerImplementation<TargetArch::x86_64_v3, ParentAVX2>();
 #endif

--- a/src/Functions/generateUUIDv4.cpp
+++ b/src/Functions/generateUUIDv4.cpp
@@ -71,7 +71,7 @@ public:
         selector.registerImplementation<TargetArch::Default,
             TargetSpecific::Default::FunctionGenerateUUIDv4>();
 
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
         selector.registerImplementation<TargetArch::x86_64_v3,
             TargetSpecific::x86_64_v3::FunctionGenerateUUIDv4>();
 #endif

--- a/src/Functions/generateUUIDv7.cpp
+++ b/src/Functions/generateUUIDv7.cpp
@@ -87,7 +87,7 @@ public:
     {
         selector.registerImplementation<TargetArch::Default, Parent>();
 
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
         using Parentv3 = TargetSpecific::x86_64_v3::FunctionGenerateUUIDv7Base;
         selector.registerImplementation<TargetArch::x86_64_v3, Parentv3>();
 #endif

--- a/src/Functions/greatCircleDistance.cpp
+++ b/src/Functions/greatCircleDistance.cpp
@@ -341,7 +341,7 @@ public:
         selector.registerImplementation<TargetArch::Default,
             TargetSpecific::Default::FunctionGeoDistance<method>>(context);
 
-    #if USE_MULTITARGET_CODE
+    #if USE_X86_MULTITARGET_CODE
         selector.registerImplementation<TargetArch::x86_64_v3,
             TargetSpecific::x86_64_v3::FunctionGeoDistance<method>>(context);
         selector.registerImplementation<TargetArch::x86_64_v4,

--- a/src/Functions/isNotNull.cpp
+++ b/src/Functions/isNotNull.cpp
@@ -150,7 +150,7 @@ private:
 
     static void NO_INLINE vector(const PaddedPODArray<UInt8> & null_map, PaddedPODArray<UInt8> & res)
     {
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
         if (isArchSupported(TargetArch::x86_64_v3))
         {
             vectorImpl_x86_64_v3(null_map, res);

--- a/src/Functions/mortonDecode.cpp
+++ b/src/Functions/mortonDecode.cpp
@@ -7,7 +7,7 @@
 #include <Functions/PerformanceAdaptors.h>
 
 #include <morton-nd/mortonND_LUT.h>
-#if USE_MULTITARGET_CODE && defined(__BMI2__)
+#if USE_X86_MULTITARGET_CODE && defined(__BMI2__)
 #include <morton-nd/mortonND_BMI2.h>
 #endif
 
@@ -290,7 +290,7 @@ public:
         selector.registerImplementation<TargetArch::Default,
                                         TargetSpecific::Default::FunctionMortonDecode>();
 
-#if USE_MULTITARGET_CODE && defined(MORTON_ND_BMI2_ENABLED)
+#if USE_X86_MULTITARGET_CODE && defined(MORTON_ND_BMI2_ENABLED)
         selector.registerImplementation<TargetArch::x86_64_v3,
                                         TargetSpecific::x86_64_v3::FunctionMortonDecode>();
 #endif

--- a/src/Functions/mortonEncode.cpp
+++ b/src/Functions/mortonEncode.cpp
@@ -7,7 +7,7 @@
 #include <Functions/PerformanceAdaptors.h>
 
 #include <morton-nd/mortonND_LUT.h>
-#if USE_MULTITARGET_CODE && defined(__BMI2__)
+#if USE_X86_MULTITARGET_CODE && defined(__BMI2__)
 #include <morton-nd/mortonND_BMI2.h>
 #endif
 
@@ -261,7 +261,7 @@ public:
         selector.registerImplementation<TargetArch::Default,
                                         TargetSpecific::Default::FunctionMortonEncode>();
 
-#if USE_MULTITARGET_CODE && defined(MORTON_ND_BMI2_ENABLED)
+#if USE_X86_MULTITARGET_CODE && defined(MORTON_ND_BMI2_ENABLED)
         selector.registerImplementation<TargetArch::x86_64_v3,
                                         TargetSpecific::x86_64_v3::FunctionMortonEncode>();
 #endif

--- a/src/Functions/randomFixedString.cpp
+++ b/src/Functions/randomFixedString.cpp
@@ -84,7 +84,7 @@ public:
         selector.registerImplementation<TargetArch::Default,
             FunctionRandomFixedStringImpl<TargetSpecific::Default::RandImpl>>();
 
-    #if USE_MULTITARGET_CODE
+    #if USE_X86_MULTITARGET_CODE
         selector.registerImplementation<TargetArch::x86_64_v3,
             FunctionRandomFixedStringImpl<TargetSpecific::x86_64_v3::RandImpl>>();
     #endif

--- a/src/Functions/randomString.cpp
+++ b/src/Functions/randomString.cpp
@@ -97,7 +97,7 @@ public:
         selector.registerImplementation<TargetArch::Default,
             FunctionRandomStringImpl<TargetSpecific::Default::RandImpl>>();
 
-    #if USE_MULTITARGET_CODE
+    #if USE_X86_MULTITARGET_CODE
         selector.registerImplementation<TargetArch::x86_64_v3,
             FunctionRandomStringImpl<TargetSpecific::x86_64_v3::RandImpl>>();
     #endif

--- a/src/Storages/MergeTree/MergeTreeRangeReader.cpp
+++ b/src/Storages/MergeTree/MergeTreeRangeReader.cpp
@@ -26,7 +26,7 @@
 #include <emmintrin.h>
 #endif
 
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
 #include <immintrin.h>
 #endif
 
@@ -804,7 +804,7 @@ size_t numZerosInTail(const UInt8 * begin, const UInt8 * end)
 
 size_t MergeTreeRangeReader::ReadResult::numZerosInTail(const UInt8 * begin, const UInt8 * end)
 {
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
     /// check if cpu support avx512 dynamically, haveAVX512BW contains check of haveAVX512F
     if (isArchSupported(TargetArch::x86_64_v4))
         return TargetSpecific::x86_64_v4::numZerosInTail(begin, end);
@@ -1475,7 +1475,7 @@ static ColumnPtr combineFilters(ColumnPtr first, ColumnPtr second)
     auto & first_data = typeid_cast<ColumnUInt8 *>(mut_first.get())->getData();
     const auto * second_data = second_descr.data->data();
 
-#if USE_MULTITARGET_CODE
+#if USE_X86_MULTITARGET_CODE
     if (isArchSupported(TargetArch::x86_64_icelake))
     {
         TargetSpecific::x86_64_icelake::combineFiltersImpl(first_data.begin(), first_data.end(), second_data);


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
1. Add compile-time and runtime detection of SVE on AArch64.

2. Add SVE support for Aggregate Sum, function unary arithmetic and function comparison.
Extend `MULTITARGET_FUNCTION_X86_V4_V3` to `MULTITARGET_FUNCTION_X86_V4_V3_SVE` and add dispatchers for the above functions. Performance improvements for several example functions on `m7g.4xlarge` - [pastila](https://pastila.nl/?00542865/69af88e0629f4e8606f95bfaa86ddf1e#S9IQJsAcozu1gMKFtY6fcg==GCM).

3. Optimize ColumnVector filter operation using `svcompact`.
`svcompact` only supports 4/8 byte datatypes. Testing shows performance improvement for 4-byte datatypes such as `UInt32`, `Float32` and `IPv4`. Setup and performance improvement on `m7g.4xlarge` - [pastila](https://pastila.nl/?010b0bb3/ace4871b938a05903d28f4dda070e6b7#ikaQNOW5/SM+b2u2siV+8g==GCM).