### PR TITLE
Fix link creation when run fast test locally

### DIFF
--- a/ci/jobs/fast_test.py
+++ b/ci/jobs/fast_test.py
@@ -235,7 +235,7 @@ def main():
         )
         res = results[-1].is_ok()
 
-    if Info().is_local_run:
+    if res and Info().is_local_run:
         resolved_clickhouse_bin_path = clickhouse_bin_path.resolve()
         Shell.check(
             f"ln -sf {resolved_clickhouse_bin_path} {resolved_clickhouse_bin_path.parent}/clickhouse-server",

--- a/ci/jobs/fast_test.py
+++ b/ci/jobs/fast_test.py
@@ -155,6 +155,16 @@ def main():
                 f"NOTE: It's a local run and clickhouse binary is found [{clickhouse_bin_path}] - skip the build"
             )
             stages = [JobStages.CONFIG, JobStages.TEST]
+            resolved_clickhouse_bin_path = clickhouse_bin_path.resolve()
+            Shell.check(
+                f"ln -sf {resolved_clickhouse_bin_path} {resolved_clickhouse_bin_path.parent}/clickhouse-server",
+                strict=True,
+            )
+            Shell.check(
+                f"ln -sf {resolved_clickhouse_bin_path} {resolved_clickhouse_bin_path.parent}/clickhouse-client",
+                strict=True,
+            )
+            Shell.check(f"chmod +x {resolved_clickhouse_bin_path}", strict=True)
         else:
             print(
                 f"NOTE: It's a local run and clickhouse binary is not found [{clickhouse_bin_path}] - will be built"
@@ -220,18 +230,6 @@ def main():
         Shell.check(f"{build_dir}/rust/chcache/chcache stats")
         Shell.check("sccache --show-stats")
         res = results[-1].is_ok()
-
-    if res and Info().is_local_run:
-        resolved_clickhouse_bin_path = clickhouse_bin_path.resolve()
-        Shell.check(
-            f"ln -sf {resolved_clickhouse_bin_path} {resolved_clickhouse_bin_path.parent}/clickhouse-server",
-            strict=True,
-        )
-        Shell.check(
-            f"ln -sf {resolved_clickhouse_bin_path} {resolved_clickhouse_bin_path.parent}/clickhouse-client",
-            strict=True,
-        )
-        Shell.check(f"chmod +x {resolved_clickhouse_bin_path}", strict=True)
 
     if res and JobStages.BUILD in stages:
         commands = [

--- a/ci/jobs/fast_test.py
+++ b/ci/jobs/fast_test.py
@@ -160,16 +160,6 @@ def main():
                 f"NOTE: It's a local run and clickhouse binary is not found [{clickhouse_bin_path}] - will be built"
             )
             time.sleep(5)
-        resolved_clickhouse_bin_path = clickhouse_bin_path.resolve()
-        Shell.check(
-            f"ln -sf {resolved_clickhouse_bin_path} {resolved_clickhouse_bin_path.parent}/clickhouse-server",
-            strict=True,
-        )
-        Shell.check(
-            f"ln -sf {resolved_clickhouse_bin_path} {resolved_clickhouse_bin_path.parent}/clickhouse-client",
-            strict=True,
-        )
-        Shell.check(f"chmod +x {resolved_clickhouse_bin_path}", strict=True)
     else:
         os.environ["CH_HOSTNAME"] = (
             "https://build-cache.eu-west-1.aws.clickhouse-staging.com"
@@ -244,6 +234,18 @@ def main():
             )
         )
         res = results[-1].is_ok()
+
+    if Info().is_local_run:
+        resolved_clickhouse_bin_path = clickhouse_bin_path.resolve()
+        Shell.check(
+            f"ln -sf {resolved_clickhouse_bin_path} {resolved_clickhouse_bin_path.parent}/clickhouse-server",
+            strict=True,
+        )
+        Shell.check(
+            f"ln -sf {resolved_clickhouse_bin_path} {resolved_clickhouse_bin_path.parent}/clickhouse-client",
+            strict=True,
+        )
+        Shell.check(f"chmod +x {resolved_clickhouse_bin_path}", strict=True)
 
     if res and JobStages.CONFIG in stages:
         commands = [

--- a/ci/jobs/fast_test.py
+++ b/ci/jobs/fast_test.py
@@ -221,6 +221,18 @@ def main():
         Shell.check("sccache --show-stats")
         res = results[-1].is_ok()
 
+    if res and Info().is_local_run:
+        resolved_clickhouse_bin_path = clickhouse_bin_path.resolve()
+        Shell.check(
+            f"ln -sf {resolved_clickhouse_bin_path} {resolved_clickhouse_bin_path.parent}/clickhouse-server",
+            strict=True,
+        )
+        Shell.check(
+            f"ln -sf {resolved_clickhouse_bin_path} {resolved_clickhouse_bin_path.parent}/clickhouse-client",
+            strict=True,
+        )
+        Shell.check(f"chmod +x {resolved_clickhouse_bin_path}", strict=True)
+
     if res and JobStages.BUILD in stages:
         commands = [
             "sccache --show-stats",
@@ -234,18 +246,6 @@ def main():
             )
         )
         res = results[-1].is_ok()
-
-    if res and Info().is_local_run:
-        resolved_clickhouse_bin_path = clickhouse_bin_path.resolve()
-        Shell.check(
-            f"ln -sf {resolved_clickhouse_bin_path} {resolved_clickhouse_bin_path.parent}/clickhouse-server",
-            strict=True,
-        )
-        Shell.check(
-            f"ln -sf {resolved_clickhouse_bin_path} {resolved_clickhouse_bin_path.parent}/clickhouse-client",
-            strict=True,
-        )
-        Shell.check(f"chmod +x {resolved_clickhouse_bin_path}", strict=True)
 
     if res and JobStages.CONFIG in stages:
         commands = [

--- a/ci/workflows/pull_request.py
+++ b/ci/workflows/pull_request.py
@@ -170,7 +170,9 @@ workflow = Workflow.Config(
         "integration": JobConfigs.integration_test_jobs_non_required[
             0
         ].name,  # plain integration test job, no old analyzer, no dist plan
+        "fast": "Fast test",
         "functional": PLAIN_FUNCTIONAL_TEST_JOB.name,
+        "build_debug": "Build (amd_debug)",
         "build": "Build (amd_binary)",
     },
 )


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Motivation

Moved link creation after the build. Otherwise I get an error (there is no such folder),

```
>>>
ln: failed to create symbolic link '/Users/dataved/ClickHouse/ci/tmp/fast_build/programs/clickhouse-server': No such file or directory
<<<
```


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.973`
<!-- ch-version-info:end -->