### PR TITLE
skip empty deduplication tokens

### DIFF
--- a/src/Interpreters/InsertDeduplication.cpp
+++ b/src/Interpreters/InsertDeduplication.cpp
@@ -712,6 +712,9 @@ void DeduplicationInfo::setUserToken(const String & token, size_t count)
 {
     chassert(level == Level::SOURCE);
 
+    if (count == 0)
+        return;
+
     tokens.push_back(TokenDefinition::asUserToken(token));
     offsets.push_back(getRows() + count);
 


### PR DESCRIPTION
Due to this injected exception
```
2026.02.19 23:40:16.383165 [ 8263 ] {95dfe8f2-17fa-4b36-aea9-b31ed884412b} <Error> AsynchronousInsertQueue: Failed parsing for query 'INSERT INTO test_1.async_inserts_native (m) FORMAT Native' with query id 4e00b9b9-6852-4902-a9cc-accb959ce24c. DB::Exception: Query memory tracker: fault injected. Would use 19.29 MiB (attempt to allocate chunk of 4.02 MiB), maximum: 9.31 GiB
```

A token with 0 rows is added
```
2026.02.19 23:40:16.392908 [ 8263 ] {95dfe8f2-17fa-4b36-aea9-b31ed884412b} <Test> DedupInfo: setUserToken: token= count=0, instance_id: 4514, async, enabled, level SOURCE,
 rows/tokens 1000/2, in block: null, tokens: 2:[-::1000,-::1000], visited views: 0:[], retried view id: <empty>, original block id: <empty>, unification_stage OLD_SEPARATE
_HASHES
```

After first token has been filtered we have empty block but 1 token is left.
And this chassert is triggered

```
if (removed_rows == block.rows())
    {
        chassert(removed_tokens == getCount());
```

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
skip empty deduplication tokens 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.990`
<!-- ch-version-info:end -->