### PR TITLE
CI: Parse failure logs from all replicas in stress test

### DIFF
--- a/ci/jobs/stress_job.py
+++ b/ci/jobs/stress_job.py
@@ -226,9 +226,31 @@ def run_stress_test(upgrade_check: bool = False) -> None:
             failed_results.append(test_result)
 
     if server_died:
-        server_err_log = server_log_path / "clickhouse-server.err.log"
-        stderr_log = result_path / "stderr.log"
-        if not (server_err_log.exists() and stderr_log.exists()):
+        # Build log pairs for each replica: (replica_name, server_err_log, stderr_log)
+        # Main replica: all *.err.* logs without sc1/sc2 in name, paired with stderr.log
+        # sc1/sc2: their dedicated server log + matching stderr log
+        replica_log_pairs = []
+
+        main_stderr = result_path / "stderr.log"
+        if server_log_path.exists():
+            main_server_logs = sorted(
+                p
+                for p in server_log_path.iterdir()
+                if p.is_file()
+                and ".err." in p.name
+                and "sc1" not in p.name
+                and "sc2" not in p.name
+            )
+            for log_file in main_server_logs:
+                replica_log_pairs.append(("main", log_file, main_stderr))
+
+        for sc in ("sc1", "sc2"):
+            sc_server_log = server_log_path / f"clickhouse-server-{sc}.err.log"
+            sc_stderr = result_path / f"stderr-{sc}.log"
+            if sc_server_log.exists():
+                replica_log_pairs.append((sc, sc_server_log, sc_stderr))
+
+        if not replica_log_pairs:
             failed_results.append(
                 Result.create_from(
                     name="Unknown error",
@@ -237,13 +259,36 @@ def run_stress_test(upgrade_check: bool = False) -> None:
                 )
             )
         else:
-            log_parser = FuzzerLogParser(
-                server_log=server_err_log,
-                stderr_log=stderr_log if stderr_log.exists() else "",
-                fuzzer_log="",
-            )
-            try:
-                name, description, files = log_parser.parse_failure()
+            definitive_result = None
+            fallback_result = None
+
+            for replica_name, server_log_file, stderr_log in replica_log_pairs:
+                log_parser = FuzzerLogParser(
+                    server_log=server_log_file,
+                    stderr_log=str(stderr_log) if stderr_log.exists() else "",
+                    fuzzer_log="",
+                )
+                try:
+                    name, description, files = log_parser.parse_failure()
+                    file_pair_info = f"Log files: {server_log_file.name}"
+                    if stderr_log.exists():
+                        file_pair_info += f", {stderr_log.name}"
+                    description = f"{file_pair_info}\n{description}"
+                    if name != FuzzerLogParser.UNKNOWN_ERROR:
+                        definitive_result = (name, description, files)
+                        break
+                    if fallback_result is None:
+                        fallback_result = (name, description, files)
+                except Exception as e:
+                    print(
+                        f"ERROR: Failed to parse failure logs for {replica_name} "
+                        f"({server_log_file.name}): {e}\n"
+                        f"Server logs should still be collected."
+                    )
+
+            result = definitive_result or fallback_result
+            if result:
+                name, description, files = result
                 failed_results.append(
                     Result.create_from(
                         name=name,
@@ -252,14 +297,11 @@ def run_stress_test(upgrade_check: bool = False) -> None:
                         files=files,
                     )
                 )
-            except Exception as e:
-                print(
-                    f"ERROR: Failed to parse failure logs: {e}\nServer logs should still be collected."
-                )
+            else:
                 failed_results.append(
                     Result.create_from(
                         name="Parse failure error",
-                        info=f"Error parsing failure logs: {e}",
+                        info="All log parsing attempts failed",
                         status=Result.Status.FAILED,
                     )
                 )


### PR DESCRIPTION
## Description

When the stress test reports a server death, the log parser previously
only checked a single hardcoded pair (`clickhouse-server.err.log` +
`stderr.log`), missing failures on secondary replicas (`sc1`, `sc2`).

This change iterates all replica log pairs in order:

1. **Main** – all `*.err.*` server logs without `sc1`/`sc2` in the name
   (covers `clickhouse-server.err.log`, `clickhouse-server.err.stress.log`,
   etc.) paired with `stderr.log`
2. **sc1** – `clickhouse-server-sc1.err.log` + `stderr-sc1.log`
3. **sc2** – `clickhouse-server-sc2.err.log` + `stderr-sc2.log`

The parser stops at the first pair where a known error pattern is found.
If no pattern matches anywhere, the first available pair result is used
as a fallback. The failure description is prefixed with
`Log files: <server_log>, <stderr_log>` so the source replica is visible
in CI results.

## Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.273`
<!-- ch-version-info:end -->