### PR TITLE
Stop using system compiler-rt headers; build compiler-rt from source by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -378,7 +378,7 @@ include(cmake/limit_jobs.cmake)
 option(ENABLE_LIBRARIES "Enable all external libraries by default" ON)
 
 # Don't use the system compiler-rt library even if it is available. Instead build it directly
-option(USE_SYSTEM_COMPILER_RT "Use the system compiler-rt if available. If disabled it will be built from sources (supported for Linux and FreeBSD)" ON)
+option(USE_SYSTEM_COMPILER_RT "Use the system compiler-rt if available. If disabled it will be built from sources (supported for Linux and FreeBSD)" OFF)
 
 # Increase stack size on Musl. We need big stack for our recursive-descend parser.
 if (USE_MUSL)

--- a/cmake/sanitize.cmake
+++ b/cmake/sanitize.cmake
@@ -62,6 +62,16 @@ if (WITH_COVERAGE)
     set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fprofile-instr-generate -fcoverage-mapping")
 endif()
 
+# Use our bundled compiler-rt headers (sanitizer/ and xray/ interfaces) instead of the ones
+# from the compiler's resource directory. This avoids depending on the host compiler's headers:
+# for example, sanitizer builds need <sanitizer/asan_interface.h> etc., but XRay is disabled
+# for sanitizer builds, so those headers would otherwise come from the system compiler.
+#
+# The compiler searches -isystem paths before its implicit resource directory, so putting our
+# bundled path here ensures it takes precedence without disrupting #include_next chains (which
+# libcxx relies on to reach the compiler's own stddef.h, stdarg.h, etc.).
+include_directories (SYSTEM "${CMAKE_SOURCE_DIR}/contrib/llvm-project/compiler-rt/include")
+
 option (SANITIZE_COVERAGE "Instrumentation for code coverage with custom callbacks" OFF)
 
 if (SANITIZE_COVERAGE)

--- a/cmake/sanitize.cmake
+++ b/cmake/sanitize.cmake
@@ -70,7 +70,7 @@ endif()
 # The compiler searches -isystem paths before its implicit resource directory, so putting our
 # bundled path here ensures it takes precedence without disrupting #include_next chains (which
 # libcxx relies on to reach the compiler's own stddef.h, stdarg.h, etc.).
-include_directories (SYSTEM "${CMAKE_SOURCE_DIR}/contrib/llvm-project/compiler-rt/include")
+include_directories (SYSTEM "${ClickHouse_SOURCE_DIR}/contrib/llvm-project/compiler-rt/include")
 
 option (SANITIZE_COVERAGE "Instrumentation for code coverage with custom callbacks" OFF)
 

--- a/cmake/xray_instrumentation.cmake
+++ b/cmake/xray_instrumentation.cmake
@@ -9,10 +9,6 @@ if (TARGET ch_contrib::llvm)
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${XRAY_FLAGS}")
     set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${XRAY_FLAGS}")
 
-    # Add the XRay headers globally so that all targets (not just those linking ch_contrib::llvm)
-    # can include <xray/xray_interface.h> when USE_XRAY is enabled.
-    include_directories (SYSTEM "${ClickHouse_SOURCE_DIR}/contrib/llvm-project/compiler-rt/include")
-
     message (STATUS "Using LLVM XRay")
 else()
     message (STATUS "Not using LLVM XRay because LLVM is not built along")


### PR DESCRIPTION
Always use bundled `compiler-rt` headers for sanitizer and XRay interfaces, and build `compiler-rt` libraries from source by default.

## Problem

`<sanitizer/asan_interface.h>`, `<sanitizer/msan_interface.h>`, `<xray/xray_interface.h>` and similar headers were taken from the host compiler's resource directory. When sanitizers are enabled, XRay is disabled, so the include path that `cmake/xray_instrumentation.cmake` added was absent and the compiler's own headers were used silently — exactly the scenario described in #91475.

## Changes

- **`cmake/sanitize.cmake`**: Adds `contrib/llvm-project/compiler-rt/include` as a global `-isystem` path. This file is always included, so the bundled headers are in the search path for every build configuration (including sanitizer builds where XRay is off). The compiler searches `-isystem` paths before its implicit resource directory, so our bundled headers take precedence without disrupting `#include_next` chains that libcxx relies on.

- **`cmake/xray_instrumentation.cmake`**: Removes the now-redundant `include_directories` call, which previously only covered the case when XRay was enabled.

- **`CMakeLists.txt`**: Changes the default of `USE_SYSTEM_COMPILER_RT` from `ON` to `OFF` so that compiler-rt libraries are always built from our bundled source instead of whatever the host compiler ships.

Related: https://github.com/ClickHouse/ClickHouse/issues/91475

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Always use bundled `compiler-rt` headers (sanitizer and XRay interfaces) instead of the host compiler's headers, and build `compiler-rt` libraries from source by default.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.1007`
<!-- ch-version-info:end -->