### PR TITLE
Fix flaky test 00944_minmax_nan

### DIFF
--- a/tests/queries/0_stateless/00944_minmax_nan.sql
+++ b/tests/queries/0_stateless/00944_minmax_nan.sql
@@ -10,7 +10,8 @@ CREATE TABLE tab (
   INDEX col_idx col TYPE minmax
 )
 ENGINE = MergeTree()
-ORDER BY id; -- This is important. We want to have additional primary index that does not use the column `col`.
+ORDER BY id -- This is important. We want to have additional primary index that does not use the column `col`.
+SETTINGS index_granularity = 8192, index_granularity_bytes = 0; -- Explicit granularity to make EXPLAIN output deterministic.
 
 INSERT INTO tab VALUES
     (1, 1.0),

--- a/tests/queries/0_stateless/00944_minmax_nan.sql
+++ b/tests/queries/0_stateless/00944_minmax_nan.sql
@@ -11,7 +11,7 @@ CREATE TABLE tab (
 )
 ENGINE = MergeTree()
 ORDER BY id -- This is important. We want to have additional primary index that does not use the column `col`.
-SETTINGS index_granularity = 8192, index_granularity_bytes = 0; -- Explicit granularity to make EXPLAIN output deterministic.
+SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi'; -- Explicit granularity to make EXPLAIN output deterministic.
 
 INSERT INTO tab VALUES
     (1, 1.0),


### PR DESCRIPTION
## Summary
- The test uses `EXPLAIN indexes=1` which outputs exact granule counts. With randomized `index_granularity=1`, each of the 7 rows becomes its own granule, producing `Granules: 0/7` instead of the expected `0/1`.
- Fix by setting `index_granularity` and `index_granularity_bytes` explicitly in the `CREATE TABLE`.

Closes https://github.com/ClickHouse/ClickHouse/issues/97217

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)