### PR TITLE
try to unflake 01038_dictionary_lifetime_min_zero_sec

### DIFF
--- a/tests/queries/0_stateless/01038_dictionary_lifetime_min_zero_sec.sh
+++ b/tests/queries/0_stateless/01038_dictionary_lifetime_min_zero_sec.sh
@@ -36,7 +36,9 @@ $CLICKHOUSE_CLIENT --query "INSERT INTO ${CLICKHOUSE_DATABASE}.table_for_dict VA
 
 function check()
 {
-    local TIMELIMIT=$((SECONDS+10))
+    # The background reload thread (PeriodicUpdater) wakes up every 5 seconds regardless of LIFETIME,
+    # so allow enough time for several check cycles plus the reload itself.
+    local TIMELIMIT=$((SECONDS+30))
     query_result=$($CLICKHOUSE_CLIENT --query "SELECT dictGetFloat64('${CLICKHOUSE_DATABASE}.dict_with_zero_min_lifetime', 'value', toUInt64(2))")
 
     while [ "$query_result" != "2.2" ] && [ $SECONDS -lt "$TIMELIMIT" ]


### PR DESCRIPTION
The check function was waiting up to 10 seconds for the dictionary to auto-reload after an INSERT. However, the background reload thread ([PeriodicUpdater](https://github.com/ClickHouse/ClickHouse/blob/36682cd285da8f16388cc005c3d76a9c9cd6c746/src/Interpreters/ExternalLoader.cpp#L1239)) wakes up  every 5 seconds regardless of the dictionary's LIFETIME setting. It looks like `LIFETIME` only controls when next_update_time expires, not how frequently the thread polls. 

I suspect that on loaded CI machines, a single check cycle plus the reload itself can easily exceed 10 seconds, causing the test to time out before the dictionary is refreshed.  Increase the timeout to 30s to give some more headroom for the check.

Closes: https://github.com/ClickHouse/ClickHouse/issues/97508

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.993`
<!-- ch-version-info:end -->