### PR TITLE
ci: use ext fields for PR/Run links in HTML report, add per-job run URL

### DIFF
--- a/ci/praktika/hook_html.py
+++ b/ci/praktika/hook_html.py
@@ -221,6 +221,12 @@ class HtmlRunnerHooks:
     @classmethod
     def post_run(cls, _workflow, _job, info_errors):
         result = Result.from_fs(_job.name)
+        env = _Environment.get()
+        if env.WORKFLOW_JOB_DATA:
+            result.add_ext_key_value(
+                "run_url",
+                f"{env.RUN_URL}/job/{env.WORKFLOW_JOB_DATA['check_run_id']}",
+            )
         _ResultS3.upload_result_files_to_s3(result).dump()
         storage_usage = None
         if StorageUsage.exist():
@@ -231,8 +237,6 @@ class HtmlRunnerHooks:
             storage_usage = StorageUsage.from_fs()
             result.ext["storage_usage"] = storage_usage
         _ResultS3.copy_result_to_s3(result)
-
-        env = _Environment.get()
 
         new_sub_results = [result]
         new_result_info = ""

--- a/ci/praktika/hook_html.py
+++ b/ci/praktika/hook_html.py
@@ -136,8 +136,6 @@ class HtmlRunnerHooks:
             _workflow.name, Result.Status.RUNNING, results=results
         )
         summary_result.start_time = Utils.timestamp()
-        summary_result.links.append(env.CHANGE_URL)
-        summary_result.links.append(env.RUN_URL)
         info = Info()
         report_url_current_sha = info.get_report_url(latest=False)
         summary_result.add_ext_key_value("pr_title", info.pr_title).add_ext_key_value(

--- a/ci/praktika/json.html
+++ b/ci/praktika/json.html
@@ -1695,6 +1695,7 @@
 
     function renderFooter(nameParams) {
         const footerRight = document.querySelector('#footer .right');
+        footerRight.innerHTML = '';
         function createLinkElement(href, textContent, footer) {
             const a = document.createElement('a');
             a.href = href;

--- a/ci/praktika/json.html
+++ b/ci/praktika/json.html
@@ -1702,10 +1702,11 @@
             a.target = '_blank';
             footer.appendChild(a);
         }
+        const result = getTargetResults(nameParams);
         if (runtimeCache.prLink) createLinkElement(runtimeCache.prLink, 'PR', footerRight);
         if (runtimeCache.commitLink) createLinkElement(runtimeCache.commitLink, 'Commit', footerRight);
-        if (runtimeCache.runLink) createLinkElement(runtimeCache.runLink, 'Run', footerRight);
-        const result = getTargetResults(nameParams)
+        const runLink = result?.ext?.run_url || runtimeCache.runLink;
+        if (runLink) createLinkElement(runLink, 'Run', footerRight);
         let i = 1;
         for (const name of nameParams) {
             if (name === result.name) {
@@ -1881,8 +1882,9 @@
         if (updated) {
             runtimeCache.json0 = data;
             hasNewData = true;
-            if (data && data.links) {
-                data.links.forEach(storeLink);
+            if (data && data.ext) {
+                if (data.ext.change_url) storeLink(data.ext.change_url);
+                if (data.ext.run_url) storeLink(data.ext.run_url);
             }
         }
 

--- a/ci/praktika/mangle.py
+++ b/ci/praktika/mangle.py
@@ -216,7 +216,9 @@ def _update_workflow_with_native_jobs(workflow):
         from .native_jobs import _workflow_config_job
 
         if not _is_local_run():
-            print(f"Enable native job [{_workflow_config_job.name}] for [{workflow.name}]")
+            print(
+                f"Enable native job [{_workflow_config_job.name}] for [{workflow.name}]"
+            )
         aux_job = copy.deepcopy(_workflow_config_job)
         workflow.jobs.insert(0, aux_job)
         for job in workflow.jobs[1:]:

--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -24,6 +24,7 @@ from .info import Info
 
 class _Colors:
     """ANSI color codes for terminal output"""
+
     RESET = "\033[0m"
     BOLD = "\033[1m"
     GREEN = "\033[92m"

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -158,6 +158,10 @@ class Runner:
             status=Result.Status.RUNNING,
             start_time=Utils.timestamp(),
         )
+        if env.WORKFLOW_JOB_DATA:
+            result.add_ext_key_value(
+                "run_url", f"{env.RUN_URL}/job/{env.WORKFLOW_JOB_DATA['check_run_id']}"
+            )
         result.dump()
 
         if not local_run:
@@ -327,7 +331,9 @@ class Runner:
                 "if docker ps -a --format '{{.Names}}' | grep -qx praktika; then docker rm -f praktika; fi",
                 verbose=True,
             ):
-                raise RuntimeError("Failed to remove existing docker container 'praktika'")
+                raise RuntimeError(
+                    "Failed to remove existing docker container 'praktika'"
+                )
             if job.enable_gh_auth:
                 # pass gh auth seamlessly into the docker container
                 gh_mount = "--volume ~/.config/gh:/ghconfig -e GH_CONFIG_DIR=/ghconfig"


### PR DESCRIPTION
## Summary

- In `hook_html.py`: remove `summary_result.links.append` calls for `CHANGE_URL`/`RUN_URL` — these are now stored as `ext.change_url` and `ext.run_url` instead
- In `runner.py`: store per-job GitHub Actions URL (`{RUN_URL}/job/{check_run_id}`) in `result.ext.run_url` so each job result links to its own run page
- In `json.html`: read PR/commit/run links from `data.ext.change_url` and `data.ext.run_url` instead of `data.links`; in the footer Run link, prefer the per-job `result.ext.run_url` over the workflow-level fallback

## Test plan

- [ ] Open a CI report and verify the PR / Commit footer link resolves correctly
- [ ] Navigate into a specific job result and verify Run links to that job page rather than the top-level workflow run

### Changelog category (leave one)
- CI Fix or improvement

### Changelog entry
Use `ext.change_url` / `ext.run_url` fields for navigation links in the Praktika HTML report, and show per-job GitHub Actions URLs when viewing individual job results.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.1002`
<!-- ch-version-info:end -->