### PR TITLE
Replace link to unmaintained clickhouse-speedscope

### DIFF
--- a/docs/en/operations/optimizing-performance/sampling-query-profiler.md
+++ b/docs/en/operations/optimizing-performance/sampling-query-profiler.md
@@ -52,7 +52,7 @@ To analyze the `trace_log` system table:
 
 - Use the `addressToLine`, `addressToLineWithInlines`, `addressToSymbol` and `demangle` [introspection functions](../../sql-reference/functions/introspection.md) to get function names and their positions in ClickHouse code. To get a profile for some query, you need to aggregate data from the `trace_log` table. You can aggregate data by individual functions or by the whole stack traces.
 
-If you need to visualize `trace_log` info, try [flamegraph](/interfaces/third-party/gui#clickhouse-flamegraph) and [speedscope](https://github.com/laplab/clickhouse-speedscope).
+If you need to visualize `trace_log` info, try [flamegraph](/interfaces/third-party/gui#clickhouse-flamegraph) and [speedscope](https://www.speedscope.app).
 
 ## Example {#example}
 


### PR DESCRIPTION
Replace link to unmaintained clickhouse-speedscope:
- Repository https://github.com/laplab/clickhouse-speedscope is archived and no longer maintained.
- Replaced by https://www.speedscope.app.

### Changelog category (leave one):
- Documentation


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.1011`
<!-- ch-version-info:end -->