### PR TITLE
Consider row policy for read in order optimization

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/optimizeReadInOrder.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeReadInOrder.cpp
@@ -236,15 +236,23 @@ void buildSortingDAG(QueryPlan::Node & node, std::optional<ActionsDAG> & dag, Fi
             /// Should ignore limit if there is filtering.
             limit = 0;
 
-            //std::cerr << "====== Adding prewhere " << std::endl;
             appendExpression(dag, prewhere_info->prewhere_actions);
             if (const auto * filter_expression = dag->tryFindInOutputs(prewhere_info->prewhere_column_name))
                 appendFixedColumnsFromFilterExpression(*filter_expression, fixed_columns);
 
         }
+        if (const auto row_level_filter = reading->getRowLevelFilter())
+        {
+            /// Should ignore limit if there is filtering.
+            limit = 0;
+
+            appendExpression(dag, row_level_filter->actions);
+            if (const auto * filter_expression = dag->tryFindInOutputs(row_level_filter->column_name))
+                appendFixedColumnsFromFilterExpression(*filter_expression, fixed_columns);
+
+        }
         return;
     }
-
 
     if (typeid_cast<JoinStep *>(step) || typeid_cast<FilledJoinStep *>(step))
     {

--- a/tests/queries/0_stateless/03927_row_filter_in_read_in_order_optimization.reference
+++ b/tests/queries/0_stateless/03927_row_filter_in_read_in_order_optimization.reference
@@ -1,0 +1,4 @@
+-- Row policy only (no explicit key1 in WHERE)
+ReadType: InOrder
+-- Explicit key1 in WHERE clause
+ReadType: InOrder

--- a/tests/queries/0_stateless/03927_row_filter_in_read_in_order_optimization.sql
+++ b/tests/queries/0_stateless/03927_row_filter_in_read_in_order_optimization.sql
@@ -1,3 +1,4 @@
+SET enable_parallel_replicas = 0;
 SET optimize_read_in_order = 1;
 DROP TABLE IF EXISTS t_row_policy_rio;
 

--- a/tests/queries/0_stateless/03927_row_filter_in_read_in_order_optimization.sql
+++ b/tests/queries/0_stateless/03927_row_filter_in_read_in_order_optimization.sql
@@ -1,0 +1,39 @@
+SET optimize_read_in_order = 1;
+DROP TABLE IF EXISTS t_row_policy_rio;
+
+CREATE TABLE t_row_policy_rio
+(
+    key1 UInt64,
+    key2 UInt64
+)
+ENGINE = MergeTree
+ORDER BY (key1, key2);
+
+INSERT INTO t_row_policy_rio
+SELECT c1 % 10, c2
+FROM generateRandom('c1 UInt64, c2 UInt64', 42)
+LIMIT 1000;
+
+CREATE ROW POLICY test_policy ON t_row_policy_rio USING key1 = 0 TO ALL;
+
+SELECT '-- Row policy only (no explicit key1 in WHERE)';
+
+SELECT trim(explain) FROM (
+EXPLAIN actions = 1, indexes = 1
+SELECT key2 FROM t_row_policy_rio
+ORDER BY key2
+LIMIT 100
+) WHERE explain LIKE '%ReadType%';
+
+SELECT '-- Explicit key1 in WHERE clause';
+
+SELECT trim(explain) FROM (
+EXPLAIN actions = 1, indexes = 1
+SELECT key2 FROM t_row_policy_rio
+WHERE key1 = 0
+ORDER BY key2
+LIMIT 100
+) WHERE explain LIKE '%ReadType%';
+
+DROP ROW POLICY test_policy ON t_row_policy_rio;
+DROP TABLE t_row_policy_rio;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Allow read-in-order optimization to use row policies. For example, a table with `ORDER BY (key1, key2)` and a row policy `USING key1 = 5` can now serve `ORDER BY key2` queries without an explicit sort.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Backported to: `26.1.4.22`, `25.12.7.19`, `25.11.10.21`
<!-- ch-version-info:end -->