### PR TITLE
Increase soft timeout margin for flaky check from 5 minutes to 1 hour

### DIFF
--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -515,9 +515,10 @@ def main():
 
         # For flaky check, set a soft time limit so that the test runner stops
         # gracefully before the job hard timeout, allowing results to be posted.
-        # The job timeout is 2.5 hours (9000s); leave a 5-minute margin.
+        # The job timeout is 2.5 hours (9000s); leave a 1-hour margin for cleanup
+        # (server shutdown, system table export, log collection — all slow under sanitizers).
         job_timeout = int(3600 * 2.5)
-        soft_limit_margin = 300
+        soft_limit_margin = 3600
         global_time_limit = 0
         if is_flaky_check or is_targeted_check:
             global_time_limit = max(


### PR DESCRIPTION
The 5-minute margin introduced in #97214 is not enough for the cleanup phase, which includes server shutdown, system table export via `clickhouse local`, and log collection — all significantly slower under sanitizers (ASan, TSan, etc.).

For example, in #96130 the `amd_asan` flaky check hit the hard timeout during `aggregated_zookeeper_log` export, killing the process before results could be uploaded (0 test results in the report). The ClickHouse server shutdown alone took ~80 seconds, and each system table export took ~50 seconds under ASan.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.1016`
<!-- ch-version-info:end -->