### PR TITLE
Fix flaky test_zookeeper_info and data race in DatabaseMaterializedPostgreSQL

### DIFF
--- a/src/Coordination/FourLetterCommand.cpp
+++ b/src/Coordination/FourLetterCommand.cpp
@@ -37,6 +37,8 @@ String formatZxid(int64_t zxid)
     String hex = getHexUIntLowercase(zxid);
     /// without leading zeros
     trimLeft(hex, '0');
+    if (hex.empty())
+        hex = "0";
     return "0x" + hex;
 }
 

--- a/src/Databases/PostgreSQL/DatabaseMaterializedPostgreSQL.h
+++ b/src/Databases/PostgreSQL/DatabaseMaterializedPostgreSQL.h
@@ -13,6 +13,8 @@
 #include <Databases/DatabaseOnDisk.h>
 #include <Databases/DatabaseAtomic.h>
 
+#include <atomic>
+
 
 namespace DB
 {
@@ -93,7 +95,7 @@ private:
     mutable std::mutex handler_mutex;
 
     BackgroundSchedulePoolTaskHolder startup_task;
-    bool shutdown_called = false;
+    std::atomic<bool> shutdown_called = false;
 
     LoadTaskPtr startup_postgresql_database_task TSA_GUARDED_BY(mutex);
 };


### PR DESCRIPTION
## Summary
- Fix `formatZxid` producing `"0x"` instead of `"0x0"` when zxid is 0 — `trimLeft(hex, '0')` stripped all characters, then `StorageSystemZooKeeperInfo` threw `ATTEMPT_TO_READ_AFTER_EOF` trying to parse the empty string
- Fix data race on `shutdown_called` in `DatabaseMaterializedPostgreSQL` — was a plain `bool` accessed concurrently from TCPHandler (`DROP DATABASE`) and BackgroundSchedulePool (`tryStartSynchronization`). TSan detected the race and aborted the server, causing all subsequent `test_postgresql_replica_database_engine/test_3.py` tests to fail with "Connection refused". Changed to `std::atomic<bool>`

CI reports:
- test_zookeeper_info: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=97541&sha=9c54f0ea0a9a17ee5cf1bd5077ef581f6419b5c2&name_0=PR&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%201%2F4%29
https://github.com/ClickHouse/ClickHouse/pull/97541
- test_postgresql_replica_database_engine: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=97541&sha=9c54f0ea0a9a17ee5cf1bd5077ef581f6419b5c2&name_0=PR&name_1=Integration%20tests%20%28amd_tsan%2C%204%2F6%29
https://github.com/ClickHouse/ClickHouse/pull/97541

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Fix `formatZxid` producing invalid hex `"0x"` for zxid 0, and fix data race on `shutdown_called` in `DatabaseMaterializedPostgreSQL`.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)