### PR TITLE
Fix a possible logical error in ip_trie dictionary when key type is not String

### DIFF
--- a/src/Dictionaries/IPAddressDictionary.cpp
+++ b/src/Dictionaries/IPAddressDictionary.cpp
@@ -1050,12 +1050,6 @@ static auto keyViewGetter()
     return [](const Columns & columns, const std::vector<DictionaryAttribute> & dictonary_key_attributes)
     {
         const auto & key_attribute = dictonary_key_attributes.front();
-        if (!isString(key_attribute.type))
-            throw Exception(ErrorCodes::BAD_ARGUMENTS,
-                "Key attribute '{}' of ip_trie dictionary must be of type String, got {}",
-                key_attribute.name,
-                key_attribute.type->getName());
-
         auto column = ColumnString::create();
         const auto & key_ip_column = assert_cast<const KeyColumnType &>(*columns.front());
         const auto & key_mask_column = assert_cast<const ColumnVector<UInt8> &>(*columns.back());
@@ -1205,6 +1199,12 @@ void registerDictionaryTrie(DictionaryFactory & factory)
     {
         if (!dict_struct.key || dict_struct.key->size() != 1)
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Dictionary of layout 'ip_trie' has to have one 'key'");
+
+        const auto & key_type = dict_struct.key->front().type;
+        if (!isString(key_type))
+            throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                "Key attribute of ip_trie dictionary must be of type String, got {}",
+                key_type->getName());
 
         const auto dict_id = StorageID::fromDictionaryConfig(config, config_prefix);
         const DictionaryLifetime dict_lifetime{config, config_prefix + ".lifetime"};

--- a/src/Dictionaries/IPAddressDictionary.cpp
+++ b/src/Dictionaries/IPAddressDictionary.cpp
@@ -1049,6 +1049,13 @@ static auto keyViewGetter()
 {
     return [](const Columns & columns, const std::vector<DictionaryAttribute> & dictonary_key_attributes)
     {
+        const auto & key_attribute = dictonary_key_attributes.front();
+        if (!isString(key_attribute.type))
+            throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                "Key attribute '{}' of ip_trie dictionary must be of type String, got {}",
+                key_attribute.name,
+                key_attribute.type->getName());
+
         auto column = ColumnString::create();
         const auto & key_ip_column = assert_cast<const KeyColumnType &>(*columns.front());
         const auto & key_mask_column = assert_cast<const ColumnVector<UInt8> &>(*columns.back());
@@ -1065,7 +1072,7 @@ static auto keyViewGetter()
             column->insertData(buffer, str_len);
         }
         return ColumnsWithTypeAndName{
-            ColumnWithTypeAndName(std::move(column), std::make_shared<DataTypeString>(), dictonary_key_attributes.front().name)};
+            ColumnWithTypeAndName(std::move(column), std::make_shared<DataTypeString>(), key_attribute.name)};
     };
 }
 

--- a/tests/queries/0_stateless/03921_ip_trie_nullable_key.sql
+++ b/tests/queries/0_stateless/03921_ip_trie_nullable_key.sql
@@ -6,14 +6,15 @@ DROP VIEW IF EXISTS 03921_v0;
 
 CREATE VIEW 03921_v0 AS (SELECT 1 c0);
 
--- CREATE would succeed (loading is async) but SELECT should load the dictionary and must throw BAD_ARGUMENTS in this case.
+-- CREATE succeeds (loading is async/deferred)
+-- SYSTEM RELOAD DICTIONARY should trigger the load, and it must throw BAD_ARGUMENTS.
 CREATE DICTIONARY 03921_d0 (c0 Nullable(String))
 PRIMARY KEY (c0)
 SOURCE(CLICKHOUSE(DB currentDatabase() TABLE '03921_v0'))
 LAYOUT(IP_TRIE())
 LIFETIME(1);
 
-SELECT c0.null FROM 03921_d0;  -- {serverError BAD_ARGUMENTS}
+SYSTEM RELOAD DICTIONARY '03921_d0';  -- {serverError BAD_ARGUMENTS}
 
 DROP DICTIONARY IF EXISTS 03921_d0;
 DROP VIEW IF EXISTS 03921_v0;

--- a/tests/queries/0_stateless/03921_ip_trie_nullable_key.sql
+++ b/tests/queries/0_stateless/03921_ip_trie_nullable_key.sql
@@ -1,0 +1,19 @@
+-- https://github.com/ClickHouse/ClickHouse/issues/97454
+-- ip_trie key must be String; any other type could cause a logical error in the read path.
+
+DROP DICTIONARY IF EXISTS 03921_d0;
+DROP VIEW IF EXISTS 03921_v0;
+
+CREATE VIEW 03921_v0 AS (SELECT 1 c0);
+
+-- CREATE would succeed (loading is async) but SELECT should load the dictionary and must throw BAD_ARGUMENTS in this case.
+CREATE DICTIONARY 03921_d0 (c0 Nullable(String))
+PRIMARY KEY (c0)
+SOURCE(CLICKHOUSE(DB currentDatabase() TABLE '03921_v0'))
+LAYOUT(IP_TRIE())
+LIFETIME(1);
+
+SELECT c0.null FROM 03921_d0;  -- {serverError BAD_ARGUMENTS}
+
+DROP DICTIONARY IF EXISTS 03921_d0;
+DROP VIEW IF EXISTS 03921_v0;


### PR DESCRIPTION
The `ip_trie` dictionary read path always produces a plain `ColumnString` for the key regardless of the declared key type. When the key is declared as anything other than `String` (e.g. `Nullable(String)`), the mismatch between                                                                                 the block header type and actual column type causes a bad cast from `ColumnString` to `ColumnNullable` in `SerializationNullable::enumerateStreams`.                                                                                                      
                                                 
This seems to only affect direct table reads (eg. `SELECT ... FROM dict`) because:
-  `CREATE DICTIONARY`defers loading until first access
- `dictGet()`-style queries use a separate lookup path (`getColumn`) that never reaches `keyViewGetter`.

The fix validates the key type in `keyViewGetter` and rejects anything that is not `String`.

Possibly one of the related fixes for: https://github.com/ClickHouse/ClickHouse/issues/97454 ([repro](https://fiddle.clickhouse.com/6eed9e24-890b-4f49-b8dc-be1eb7425021) and check: https://github.com/ClickHouse/ClickHouse/issues/97454#issuecomment-3933184333)

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a possible logical error in `ip_trie` dictionary when key type is not String.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.1042`
<!-- ch-version-info:end -->