### PR TITLE
a more proper fix for test_ttl_move flakyness ??

### DIFF
--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -4209,6 +4209,9 @@ void StorageReplicatedMergeTree::mergeSelectingTask()
 
     auto try_assign_merge = [&]() -> AttemptStatus
     {
+        if (merger_mutator.merges_blocker.isCancelled())
+            return AttemptStatus::CannotSelect;
+
         /// We must select parts for merge under merge_selecting_mutex because other threads
         /// (OPTIMIZE queries) can assign new merges.
         std::lock_guard merge_selecting_lock(merge_selecting_mutex);
@@ -9560,7 +9563,15 @@ void StorageReplicatedMergeTree::onActionLockRemove(StorageActionBlockType actio
     if (action_type == ActionLocks::PartsMerge || action_type == ActionLocks::PartsTTLMerge
         || action_type == ActionLocks::PartsFetch || action_type == ActionLocks::PartsSend
         || action_type == ActionLocks::ReplicationQueue)
+    {
         background_operations_assignee.trigger();
+        /// When merges are re-enabled, also wake up the merge-selecting task so it
+        /// runs promptly instead of waiting for its next scheduled interval (which can
+        /// be up to `max_merge_selecting_sleep_ms` after an extended period of STOP MERGES
+        /// where the task accumulated backoff from repeated `CannotSelect` results).
+        if (action_type == ActionLocks::PartsMerge || action_type == ActionLocks::PartsTTLMerge)
+            merge_selecting_task->schedule();
+    }
     else if (action_type == ActionLocks::PartsMove)
         background_moves_assignee.trigger();
     else if (action_type == ActionLocks::Cleanup)

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -4269,7 +4269,11 @@ void StorageReplicatedMergeTree::mergeSelectingTask()
         if ((*storage_settings.get())[MergeTreeSetting::assign_part_uuids])
             future_merged_part->uuid = UUIDHelpers::generateV4();
 
-        bool can_assign_merge = max_source_parts_bytes_for_merge > 0;
+        /// Do not schedule new merges while merges are blocked (e.g. via SYSTEM STOP MERGES).
+        /// This prevents pending merge queue entries from marking parts as virtual, which would
+        /// cause selectPartsForMove to skip them and silently block TTL moves.
+        /// Mutations are handled separately below and are intentionally not gated here.
+        bool can_assign_merge = !merger_mutator.merges_blocker.isCancelled() && max_source_parts_bytes_for_merge > 0;
         PartitionIdsHint partitions_to_merge_in;
         if (can_assign_merge)
         {


### PR DESCRIPTION
Probably a more proper fix to `test_ttl_move/test.py::test_inserts_and_moves`? For example see: https://github.com/ClickHouse/ClickHouse/issues/97521.

It looks like after `SYSTEM STOP MERGES` on a `ReplicatedMergeTree` table, merge execution should immediately stop. But `mergeSelectingTask` could continue the scheduling/select of merge entries in Zookeeper i.e. merge execution will stop  but not merge scheduling. These pending entries mark parts as virtual (assigned to a background merge as it can 
 be seen [here](https://github.com/ClickHouse/ClickHouse/blob/d5a5d4f0989d360f9ba013bce3432f1afbf1e14f/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp#L400)), so `selectPartsForMove` skips them. This creates a race scenario if and when `mergeSelectingTask` runs after inserts but before `SYSTEM START MOVES`, TTL-expired parts are permanently stuck and cannot be moved.


For a potential fix to address the flakyness of this test:
- Check `merges_blocker.isCancelled()` inside `try_assign_merge` to skip scheduling when merges are stopped. 
- Trigger `merge_selecting_task` immediately on `SYSTEM START MERGES` to avoid a slow resume due to accumulated backlog of merges.



### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
