### PR TITLE
Allow Bug Fix PRs without new tests if PR has a CI report link

### DIFF
--- a/ci/jobs/scripts/workflow_hooks/new_tests_check.py
+++ b/ci/jobs/scripts/workflow_hooks/new_tests_check.py
@@ -33,6 +33,10 @@ def has_new_unit_tests(changed_files):
     return False
 
 
+def has_ci_report_link(pr_body):
+    return "s3.amazonaws.com/clickhouse-test-reports" in pr_body
+
+
 def check():
     # read actual PR body from GH API - fallback to workflow context if failed
     title, body, labels = GH.get_pr_title_body_labels()
@@ -52,6 +56,11 @@ def check():
         and not has_new_functional_tests(changed_files)
         and not has_new_integration_tests(changed_files)
     ):
+        if has_ci_report_link(pr_body):
+            print(
+                "No new tests have been added, but the PR description has a link to a CI report - pass"
+            )
+            return True
         print(f"No new tests have been added")
         return False
     return True


### PR DESCRIPTION
## Summary
- The "Finish workflow" check requires Bug Fix PRs to include new or changed tests
- This is too strict for PRs that fix CI failures — the existing CI already serves as the test
- Allow the check to pass if the PR description contains a link to a CI report (`s3.amazonaws.com/clickhouse-test-reports`)
- Example PR that would benefit: https://github.com/ClickHouse/ClickHouse/pull/97554

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.1012`
<!-- ch-version-info:end -->