### PR TITLE
Truncate issue body to respect GitHub's 65536 char limit

### DIFF
--- a/ci/praktika/gh.py
+++ b/ci/praktika/gh.py
@@ -515,6 +515,12 @@ class GH:
         if labels is None:
             labels = []
 
+        # GitHub API limit for issue body is 65536 characters
+        max_body_length = 65536
+        if len(body) > max_body_length:
+            truncation_note = "\n\n... (truncated due to GitHub body size limit)"
+            body = body[: max_body_length - len(truncation_note)] + truncation_note
+
         temp_file_path = None
         try:
             # Create temp file for body to avoid shell escaping issues


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

`GH.create_issue` was failing with `GraphQL: Body is too long (maximum is 65536 characters) (createIssue)` when the issue body (which includes test output) exceeded GitHub's limit. Added a truncation guard that clips the body to 65536 characters with a notice.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.1014`
<!-- ch-version-info:end -->