### PR TITLE
Fix sporadic failure of 03634_autopr_input_bytes_estimation_compact

### DIFF
--- a/tests/queries/0_stateless/03634_autopr_input_bytes_estimation_compact.sql
+++ b/tests/queries/0_stateless/03634_autopr_input_bytes_estimation_compact.sql
@@ -1,3 +1,5 @@
+-- Tags: no-random-merge-tree-settings
+
 SET use_uncompressed_cache=0;
 
 SET enable_parallel_replicas=0, automatic_parallel_replicas_mode=2, parallel_replicas_local_plan=1, parallel_replicas_index_analysis_only_on_coordinator=1,


### PR DESCRIPTION
## Summary
- Add `no-random-merge-tree-settings` tag to `03634_autopr_input_bytes_estimation_compact` test
- The test verifies that `ReadCompressedBytes` and `RuntimeDataflowStatisticsInputBytes` stay within 2x ratio. The estimation uses Native protocol serialization + default LZ4, which diverges from actual on-disk format when randomized MergeTree settings change serialization/compression parameters
- Observed `query_8` failing with 3.5x ratio due to randomized settings like `string_serialization_version`, `enable_block_number_column`, `index_granularity_bytes`, etc.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=97554&sha=f982a7b4463f8b8a7e49d937bb688028b6ab6d26&name_0=PR&name_1=Stateless%20tests%20%28amd_debug%2C%20parallel%29
https://github.com/ClickHouse/ClickHouse/pull/97554

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.1021`
<!-- ch-version-info:end -->