### PR TITLE
Fix crash in BaseSettings::readBinary

### DIFF
--- a/src/Core/BaseSettings.h
+++ b/src/Core/BaseSettings.h
@@ -605,6 +605,10 @@ void BaseSettings<TTraits>::readBinary(ReadBuffer & in)
         size_t index = accessor.find(name);
 
         std::ignore = BaseSettingsHelpers::readFlags(in);
+
+        if (index == static_cast<size_t>(-1))
+            BaseSettingsHelpers::throwSettingNotFound(name);
+
         accessor.readBinary(*this, index, in);
     }
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
`BaseSettings::readBinary` passes the index from `accessor.find` to `field_infos[]` without checking for the not-found sentinel value (i.e., `-1`), which may cause a `std::vector` out-of-bounds access. The issue was caught thanks to libcxx hardening. This probably happened during query plan deserialization when a newer server sends a setting unknown to an older server. The string-based read method already handles this correctly; `readBinary` was missing the same check.

Fixes https://github.com/ClickHouse/clickhouse-core-incidents/issues/1376.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.1068`
- Backported to: `26.1.4.13`, `25.12.7.15`, `25.11.10.18`, `25.8.17.31`, `25.3.15.11`
<!-- ch-version-info:end -->