### PR TITLE
Fix flaky 03803_insert_on_connection_drop test

### DIFF
--- a/tests/queries/0_stateless/03803_insert_on_connection_drop.sh
+++ b/tests/queries/0_stateless/03803_insert_on_connection_drop.sh
@@ -34,9 +34,12 @@ PIPELINE_PID=$!
 
 sleep 15
 
-kill -9 $PIPELINE_PID 2>/dev/null
-
-wait $PIPELINE_PID 2>/dev/null
+# Temporarily redirect the shell's own stderr to suppress expected
+# "Broken pipe" and "Killed" job notification messages from bash.
+exec {_stderr}>&2 2>/dev/null
+kill -9 $PIPELINE_PID
+wait $PIPELINE_PID
+exec 2>&$_stderr {_stderr}>&-
 
 
 sleep 5


### PR DESCRIPTION
## Summary
- Test `03803_insert_on_connection_drop` fails intermittently because bash prints "Broken pipe" and "Killed" job notification messages to stderr when the background pipeline is killed with `kill -9`
- The per-command `2>/dev/null` on `wait` doesn't suppress these because bash's job notification mechanism writes directly to the shell's fd 2
- Fix by temporarily redirecting the shell's own fd 2 to `/dev/null` around the kill/wait section using `exec {_stderr}>&2 2>/dev/null`

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=97586&sha=a66af62c33fba3f3a83e2e764ded34036a33eb6c&name_0=PR&name_1=Stateless%20tests%20%28amd_tsan%2C%20s3%20storage%2C%20parallel%2C%202%2F2%29
https://github.com/ClickHouse/ClickHouse/pull/97586

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.1054`
<!-- ch-version-info:end -->