### PR TITLE
Disable `02481_async_insert_dedup` tests with S3 storage

### DIFF
--- a/tests/queries/0_stateless/02481_async_insert_dedup.sh
+++ b/tests/queries/0_stateless/02481_async_insert_dedup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: long, zookeeper, no-fasttest, no-shared-merge-tree, no-azure-blob-storage
+# Tags: long, zookeeper, no-fasttest, no-shared-merge-tree, no-azure-blob-storage, no-s3-storage
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/02481_async_insert_dedup_token.sh
+++ b/tests/queries/0_stateless/02481_async_insert_dedup_token.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: long, zookeeper, no-fasttest, no-shared-merge-tree, no-azure-blob-storage
+# Tags: long, zookeeper, no-fasttest, no-shared-merge-tree, no-azure-blob-storage, no-s3-storage
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
## Summary
- The `02481_async_insert_dedup` and `02481_async_insert_dedup_token` tests do 3000 async inserts with `ReplicatedMergeTree` via 3 threads through HTTP
- In the S3 storage + DatabaseReplicated configuration, write latency causes them to exceed the 600s timeout
- The tests already had `no-azure-blob-storage` for the same reason but were missing `no-s3-storage`
- This was the only failure in https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=97573&sha=dd5e5f59d7afa4898c083cb4d2e977af7fe18fec&name_0=PR&name_1=Stateless%20tests%20%28amd_binary%2C%20old%20analyzer%2C%20s3%20storage%2C%20DatabaseReplicated%2C%20parallel%29
https://github.com/ClickHouse/ClickHouse/pull/97573
- Previously reported as flaky in #75979 and #44216 (both closed)

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.1044`
<!-- ch-version-info:end -->