### PR TITLE
Fix flaky 03911_limit_max_streams test timeout on object storage

### DIFF
--- a/tests/queries/0_stateless/03911_limit_max_streams_with_split_parts_ranges_into_intersecting_and_non_intersecting_final.sql
+++ b/tests/queries/0_stateless/03911_limit_max_streams_with_split_parts_ranges_into_intersecting_and_non_intersecting_final.sql
@@ -1,6 +1,7 @@
--- Tags: long, no-sanitizers
+-- Tags: long, no-sanitizers, no-s3-storage, no-azure-blob-storage
 -- long: times out in private
 -- no-sanitizers: sometimes times out in private :(
+-- no-s3-storage, no-azure-blob-storage: writing 550 small parts to object storage is too slow
 
 DROP TABLE IF EXISTS t;
 


### PR DESCRIPTION
## Summary
- Skip `03911_limit_max_streams_with_split_parts_ranges_into_intersecting_and_non_intersecting_final` on S3 and Azure Blob storage configurations
- The test creates ~550 small parts across 50 partitions. Writing each part to object storage takes ~1 second, so the INSERTs alone consume ~550 of the 600-second timeout
- The test only checks `EXPLAIN PIPELINE` output and does not need object storage

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=97582&sha=a02d9d572af76ca083d538e94cba769770ba7d9e&name_0=PR&name_1=Stateless%20tests%20%28amd_binary%2C%20old%20analyzer%2C%20s3%20storage%2C%20DatabaseReplicated%2C%20parallel%29
https://github.com/ClickHouse/ClickHouse/pull/97582

### Changelog category (leave one):
- CI Fix or improvement

### Changelog entry (a user-readable short description of the changes in this PR):
- N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)