### PR TITLE
Fix race condition in KeeperClient test helper causing flaky test_rm_with_version

### DIFF
--- a/programs/keeper-client/KeeperClient.cpp
+++ b/programs/keeper-client/KeeperClient.cpp
@@ -362,8 +362,8 @@ void KeeperClient::runInteractiveInputStream()
         if (!processQueryText(input, /*is_interactive=*/true))
             break;
 
-        cout << "\a\a\a\a" << std::endl;
         cerr << std::flush;
+        cout << "\a\a\a\a" << std::endl;
     }
 }
 

--- a/programs/keeper-client/KeeperClient.cpp
+++ b/programs/keeper-client/KeeperClient.cpp
@@ -355,6 +355,12 @@ void KeeperClient::runInteractiveReplxx()
     cout << std::endl;
 }
 
+/// In tests-mode, commands are read line by line from stdin.
+/// After each command, a separator (four BEL characters + newline) is written
+/// to stdout so the test harness can detect where one command's output ends.
+/// Errors from failed commands go to stderr.
+/// We must flush stderr before writing the separator to stdout, otherwise
+/// the test harness may see the separator first and miss the error.
 void KeeperClient::runInteractiveInputStream()
 {
     for (String input; std::getline(std::cin, input);)

--- a/tests/integration/helpers/keeper_utils.py
+++ b/tests/integration/helpers/keeper_utils.py
@@ -76,6 +76,10 @@ class KeeperException(Exception):
 
 
 class KeeperClient(object):
+    # In tests-mode, the keeper-client writes this separator to stdout after
+    # each command so we can detect where one command's output ends.
+    # Four BEL (0x07) characters were chosen because they never appear in
+    # normal command output.
     SEPARATOR = b"\a\a\a\a\n"
 
     def __init__(

--- a/tests/integration/test_keeper_client/test.py
+++ b/tests/integration/test_keeper_client/test.py
@@ -151,40 +151,46 @@ def test_four_letter_word_commands(client: KeeperClient):
 
 def test_rm_with_version(client: KeeperClient):
     node_path = "/test_rm_with_version_node"
-    client.create(node_path, "value")
-    assert client.get(node_path) == "value"
+    try:
+        client.create(node_path, "value")
+        assert client.get(node_path) == "value"
 
-    with pytest.raises(KeeperException) as ex:
-        client.rm(node_path, 1)
+        with pytest.raises(KeeperException) as ex:
+            client.rm(node_path, 1)
 
-    ex_as_str = str(ex)
-    assert "Coordination error: Bad version" in ex_as_str
-    assert node_path in ex_as_str
-    assert client.get(node_path) == "value"
+        ex_as_str = str(ex)
+        assert "Coordination error: Bad version" in ex_as_str
+        assert node_path in ex_as_str
+        assert client.get(node_path) == "value"
 
-    client.rm(node_path, 0)
+        client.rm(node_path, 0)
 
-    with pytest.raises(KeeperException) as ex:
-        client.get(node_path)
+        with pytest.raises(KeeperException) as ex:
+            client.get(node_path)
 
-    ex_as_str = str(ex)
-    assert "node doesn't exist" in ex_as_str
-    assert node_path in ex_as_str
+        ex_as_str = str(ex)
+        assert "node doesn't exist" in ex_as_str
+        assert node_path in ex_as_str
+    finally:
+        drop_node_if_exists(client, node_path)
 
 
 def test_rm_without_version(client: KeeperClient):
-    node_path = "/test_rm_with_version_node"
-    client.create(node_path, "value")
-    assert client.get(node_path) == "value"
+    node_path = "/test_rm_without_version_node"
+    try:
+        client.create(node_path, "value")
+        assert client.get(node_path) == "value"
 
-    client.rm(node_path)
+        client.rm(node_path)
 
-    with pytest.raises(KeeperException) as ex:
-        client.get(node_path)
+        with pytest.raises(KeeperException) as ex:
+            client.get(node_path)
 
-    ex_as_str = str(ex)
-    assert "node doesn't exist" in ex_as_str
-    assert node_path in ex_as_str
+        ex_as_str = str(ex)
+        assert "node doesn't exist" in ex_as_str
+        assert node_path in ex_as_str
+    finally:
+        drop_node_if_exists(client, node_path)
 
 
 def test_set_with_version(client: KeeperClient):


### PR DESCRIPTION
## Summary
- Fixed a race condition in `KeeperClient.execute_query` where `epoll` could process the stdout separator before reading stderr error data, causing exceptions to be silently swallowed
- C++ side: flush `cerr` before writing the stdout separator in `runInteractiveInputStream` to ensure error data reaches the pipe buffer first
- Python side: split the event loop into two passes — process stderr events first, then stdout — so errors are always collected before the separator check
- Added `try/finally` cleanup and unique node paths to `test_rm_with_version` / `test_rm_without_version`

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=97554&sha=3f86a6142c6920239c1b3adedfe82ccb5fcd6515&name_0=PR&name_1=Integration%20tests%20%28amd_binary%2C%204%2F5%29
https://github.com/ClickHouse/ClickHouse/pull/97554

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.1058`
<!-- ch-version-info:end -->