### PR TITLE
Fix flaky test_keeper_log_gap_before_committed

### DIFF
--- a/tests/integration/test_keeper_log_gap_before_committed/test.py
+++ b/tests/integration/test_keeper_log_gap_before_committed/test.py
@@ -161,6 +161,12 @@ def test_keeper_log_gap_before_committed(started_cluster):
 
         node1.restart_clickhouse()
         keeper_utils.wait_until_connected(cluster, node1)
+
+        # Reconnect after restart since the old connection is now stale
+        node1_conn.stop()
+        node1_conn.close()
+        node1_conn = get_fake_zk()
+
         verify_data()
 
     finally:


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

## Summary
- The `test_keeper_log_gap_before_committed` integration test was flaky because it reused a stale Kazoo connection after calling `restart_clickhouse`
- When the server restarts, the Kazoo session gets disconnected, but the test tried to call `verify_data` using the old `node1_conn`, resulting in `kazoo.exceptions.ConnectionClosedError: Connection has been closed`
- Fix: explicitly close the old connection and create a new one after the restart

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=97511&sha=84a6b8eb1427a30486dd2bd65c42da4cd49779d7&name_0=PR&name_1=Integration%20tests%20%28amd_msan%2C%206%2F6%29
https://github.com/ClickHouse/ClickHouse/pull/97511

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.1045`
<!-- ch-version-info:end -->