### PR TITLE
Disable 03711_deduplication_blocks_part_log under sanitizers

### DIFF
--- a/tests/queries/0_stateless/03711_deduplication_blocks_part_log.sql
+++ b/tests/queries/0_stateless/03711_deduplication_blocks_part_log.sql
@@ -1,4 +1,4 @@
--- Tags: no-parallel, no-parallel-replicas, no-async-insert
+-- Tags: long, no-sanitizers, no-parallel, no-parallel-replicas, no-async-insert
 
 -- no-parallel-replicas -- https://github.com/ClickHouse/ClickHouse/issues/90063
 


### PR DESCRIPTION
The test `03711_deduplication_blocks_part_log` uses `max_block_size=1` which makes MV JOIN processing extremely slow under sanitizers with ThreadFuzzer, triggering a sporadic protocol desynchronization (`Unknown packet 105 from server`).

Mark it as `long` and `no-sanitizers`.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=97522&sha=c979fdb233fa06fa7ab80fa22e6c406e09089780&name_0=PR&name_1=Stateless%20tests%20%28amd_ubsan%2C%20flaky%20check%29
https://github.com/ClickHouse/ClickHouse/pull/97522

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.1051`
<!-- ch-version-info:end -->