### PR TITLE
Fix flaky 03803_insert_on_connection_drop test

### DIFF
--- a/tests/queries/0_stateless/03803_insert_on_connection_drop.sh
+++ b/tests/queries/0_stateless/03803_insert_on_connection_drop.sh
@@ -36,7 +36,9 @@ sleep 15
 
 kill -9 $PIPELINE_PID 2>/dev/null
 
-wait $PIPELINE_PID 2>/dev/null
+# Wait for all background processes (both the data-generating subshell and curl)
+# to suppress "Broken pipe" and "Killed" messages on stderr.
+wait 2>/dev/null
 
 
 sleep 5


### PR DESCRIPTION
## Summary
- Fix flaky `03803_insert_on_connection_drop` test that failed intermittently with "having stderror"
- The test runs a background pipeline `(data-generator) | curl` and kills curl to simulate connection drop. The original `wait $PIPELINE_PID` only waited for curl, leaving the data-generating subshell's SIGPIPE termination unreported until script exit, when bash printed "Broken pipe" to stderr
- Changed `wait $PIPELINE_PID` to `wait` (no args) to wait for all background processes, suppressing their termination messages via `2>/dev/null`

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=ec70e869c1a666809a8016553e3677d246b654c4&name_0=MasterCI&name_1=Stateless%20tests%20%28arm_asan%2C%20azure%2C%20parallel%29&name_1=Stateless%20tests%20%28arm_asan%2C%20azure%2C%20parallel%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)