### PR TITLE
Fix flaky test test_under_max_waiting_queries_limit

### DIFF
--- a/src/Interpreters/InterpreterDropQuery.cpp
+++ b/src/Interpreters/InterpreterDropQuery.cpp
@@ -40,7 +40,6 @@ namespace Setting
     extern const SettingsBool database_atomic_wait_for_drop_and_detach_synchronously;
     extern const SettingsFloat ignore_drop_queries_probability;
     extern const SettingsSeconds lock_acquire_timeout;
-    extern const SettingsBool throw_on_unsupported_query_inside_transaction;
 }
 
 namespace ErrorCodes
@@ -94,16 +93,6 @@ BlockIO InterpreterDropQuery::executeSingleDropQuery(const ASTPtr & drop_query_p
 
     if (getContext()->getSettingsRef()[Setting::database_atomic_wait_for_drop_and_detach_synchronously])
         drop.sync = true;
-
-    /// Synchronous wait for DROP/DETACH inside a transaction creates a deadlock:
-    /// the transaction holds StoragePtr references preventing the background cleanup
-    /// from finalizing the dropped tables, while the query waits for that cleanup.
-    if (drop.sync && getContext()->getCurrentTransaction())
-    {
-        if (getContext()->getSettingsRef()[Setting::throw_on_unsupported_query_inside_transaction])
-            throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Synchronous DROP or DETACH inside transactions is not supported");
-        drop.sync = false;
-    }
 
     if (drop.table)
         return executeToTable(drop);

--- a/src/Interpreters/InterpreterDropQuery.cpp
+++ b/src/Interpreters/InterpreterDropQuery.cpp
@@ -40,6 +40,7 @@ namespace Setting
     extern const SettingsBool database_atomic_wait_for_drop_and_detach_synchronously;
     extern const SettingsFloat ignore_drop_queries_probability;
     extern const SettingsSeconds lock_acquire_timeout;
+    extern const SettingsBool throw_on_unsupported_query_inside_transaction;
 }
 
 namespace ErrorCodes
@@ -93,6 +94,16 @@ BlockIO InterpreterDropQuery::executeSingleDropQuery(const ASTPtr & drop_query_p
 
     if (getContext()->getSettingsRef()[Setting::database_atomic_wait_for_drop_and_detach_synchronously])
         drop.sync = true;
+
+    /// Synchronous wait for DROP/DETACH inside a transaction creates a deadlock:
+    /// the transaction holds StoragePtr references preventing the background cleanup
+    /// from finalizing the dropped tables, while the query waits for that cleanup.
+    if (drop.sync && getContext()->getCurrentTransaction())
+    {
+        if (getContext()->getSettingsRef()[Setting::throw_on_unsupported_query_inside_transaction])
+            throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Synchronous DROP or DETACH inside transactions is not supported");
+        drop.sync = false;
+    }
 
     if (drop.table)
         return executeToTable(drop);

--- a/tests/integration/test_scheduler_query/test.py
+++ b/tests/integration/test_scheduler_query/test.py
@@ -226,7 +226,7 @@ def test_under_max_waiting_queries_limit() -> None:
     node.query(
         f"""
         create resource query (query);
-        create workload all settings max_concurrent_queries=1, max_waiting_queries=6;
+        create workload all settings max_concurrent_queries=1, max_waiting_queries=100;
         """
     )
 


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

The test `test_under_max_waiting_queries_limit` has a race condition: with `max_concurrent_queries=1`, `max_waiting_queries=6`, and 7 threads, the queue is at its exact boundary. Since `ResourceRequest::finish` is asynchronous (it posts an activation event to the scheduler's `EventQueue`), there is a window between a query finishing and the scheduler dequeuing the next waiting request from `FifoQueue`. During this window, the freed thread can loop and try to enqueue a new request while the queue still has 6 entries, causing a `SERVER_OVERLOADED` exception.

Increase `max_waiting_queries` to 100 to provide headroom for the async scheduler processing. The test still verifies that queries can wait successfully when there is sufficient queue capacity.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=8c2e90020b4a9507478da3ebfa1c31226ffc8da4&name_0=MasterCI&name_1=Integration%20tests%20%28amd_binary%2C%204%2F5%29

🤖 Generated with [Claude Code](https://claude.com/claude-code)