### PR TITLE
Skip empty ZooKeeper log files in keeper-converter

### DIFF
--- a/src/Coordination/ZooKeeperDataReader.cpp
+++ b/src/Coordination/ZooKeeperDataReader.cpp
@@ -560,6 +560,12 @@ void deserializeLogAndApplyToStorage(Storage & storage, const std::string & log_
 {
     ReadBufferFromFile reader(log_path);
 
+    if (reader.eof())
+    {
+        LOG_WARNING(log, "Log file {} is empty, skipping", log_path);
+        return;
+    }
+
     LOG_INFO(log, "Deserializing log {}", log_path);
     deserializeLogMagic(reader);
     LOG_INFO(log, "Header looks OK");


### PR DESCRIPTION
## Summary
- `keeper-converter` throws a `CANNOT_READ_ALL_DATA` exception when encountering empty ZooKeeper transaction log files
- ZooKeeper can leave behind empty log files when stopped right after creating a new log file but before writing any data to it
- The fix checks if the log file is empty before attempting to deserialize it, and skips it with a warning instead of crashing

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=7c57219767b5e90ffe64d2b709c004b0c5ed8ce9&name_0=MasterCI&name_1=Integration%20tests%20%28amd_binary%2C%204%2F5%29

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Fix `keeper-converter` exception when encountering empty ZooKeeper transaction log files.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.1070`
<!-- ch-version-info:end -->