### PR TITLE
Fix deadlock between synchronous DROP and transactions

### DIFF
--- a/src/Interpreters/InterpreterDropQuery.cpp
+++ b/src/Interpreters/InterpreterDropQuery.cpp
@@ -40,6 +40,7 @@ namespace Setting
     extern const SettingsBool database_atomic_wait_for_drop_and_detach_synchronously;
     extern const SettingsFloat ignore_drop_queries_probability;
     extern const SettingsSeconds lock_acquire_timeout;
+    extern const SettingsBool throw_on_unsupported_query_inside_transaction;
 }
 
 namespace ErrorCodes
@@ -93,6 +94,16 @@ BlockIO InterpreterDropQuery::executeSingleDropQuery(const ASTPtr & drop_query_p
 
     if (getContext()->getSettingsRef()[Setting::database_atomic_wait_for_drop_and_detach_synchronously])
         drop.sync = true;
+
+    /// Synchronous wait for DROP/DETACH inside a transaction creates a deadlock:
+    /// the transaction holds StoragePtr references preventing the background cleanup
+    /// from finalizing the dropped tables, while the query waits for that cleanup.
+    if (drop.sync && getContext()->getCurrentTransaction())
+    {
+        if (getContext()->getSettingsRef()[Setting::throw_on_unsupported_query_inside_transaction])
+            throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Synchronous DROP or DETACH inside transactions is not supported");
+        drop.sync = false;
+    }
 
     if (drop.table)
         return executeToTable(drop);


### PR DESCRIPTION
## Summary

- Fix a deadlock between synchronous `DROP`/`DETACH` and transactions.
- When `database_atomic_wait_for_drop_and_detach_synchronously=1` and `implicit_transaction=1` are both enabled (randomly in stress tests), `DROP DATABASE` creates a deadlock: the transaction holds `StoragePtr` references preventing the background cleanup from finalizing dropped tables (via `isSharedPtrUnique`), while the query waits for that cleanup in `waitTableFinallyDropped`.
- Now, synchronous `DROP`/`DETACH` inside a transaction either throws an exception (if `throw_on_unsupported_query_inside_transaction` is set) or silently falls back to asynchronous mode.

Related PR: #97586

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=97670&sha=709389103955ac69cec0ec90baa446fb0201870e&name_0=PR&name_1=Stress%20test%20%28arm_asan%2C%20s3%29
https://github.com/ClickHouse/ClickHouse/pull/97670

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Fix deadlock when `DROP` or `DETACH` with `database_atomic_wait_for_drop_and_detach_synchronously` is executed inside a transaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)