### PR TITLE
Fix row policy bypass via `loop` table function

### DIFF
--- a/src/Processors/QueryPlan/ReadFromLoopStep.cpp
+++ b/src/Processors/QueryPlan/ReadFromLoopStep.cpp
@@ -116,7 +116,7 @@ public:
 
         if (DatabaseCatalog::instance().isTableExist(inner_storage->getStorageID(), context))
         {
-            auto inner_context = Context::createCopy(context);
+            inner_context = Context::createCopy(context);
             const auto & storage_id = inner_storage->getStorageID();
             buildInterpreterQueryPlan(
                 plan, storage_id.database_name, storage_id.table_name,
@@ -142,6 +142,7 @@ public:
             QueryPlanResourceHolder resources;
             auto pipe = QueryPipelineBuilder::getPipe(std::move(*builder), resources);
             query_pipeline = QueryPipeline(std::move(pipe));
+            query_pipeline.addResources(std::move(resources));
             executor = std::make_unique<PullingPipelineExecutor>(query_pipeline);
         }
         loop = true;
@@ -193,6 +194,7 @@ private:
     StoragePtr inner_storage;
     size_t max_block_size;
     size_t num_streams;
+    ContextPtr inner_context;
     // add retries. If inner_storage failed to pull X times in a row we'd better to fail here not to hang
     size_t retries_count = 0;
     size_t max_retries_count = 3;

--- a/src/Processors/QueryPlan/ReadFromLoopStep.cpp
+++ b/src/Processors/QueryPlan/ReadFromLoopStep.cpp
@@ -116,10 +116,11 @@ public:
 
         if (DatabaseCatalog::instance().isTableExist(inner_storage->getStorageID(), context))
         {
+            auto inner_context = Context::createCopy(context);
             const auto & storage_id = inner_storage->getStorageID();
             buildInterpreterQueryPlan(
                 plan, storage_id.database_name, storage_id.table_name,
-                column_names, query_info, context);
+                column_names, query_info, inner_context);
         }
         else
         {

--- a/src/Processors/QueryPlan/ReadFromLoopStep.cpp
+++ b/src/Processors/QueryPlan/ReadFromLoopStep.cpp
@@ -1,5 +1,13 @@
 #include <Columns/IColumn.h>
+#include <Core/Settings.h>
 #include <Interpreters/Context.h>
+#include <Interpreters/InterpreterSelectQueryAnalyzer.h>
+#include <Interpreters/InterpreterSelectWithUnionQuery.h>
+#include <Interpreters/SelectQueryOptions.h>
+#include <Parsers/ASTExpressionList.h>
+#include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTSelectQuery.h>
+#include <Parsers/ASTSelectWithUnionQuery.h>
 #include <Processors/Executors/PullingPipelineExecutor.h>
 #include <Processors/ISource.h>
 #include <Processors/QueryPlan/BuildQueryPipelineSettings.h>
@@ -11,168 +19,235 @@
 #include <QueryPipeline/QueryPipelineBuilder.h>
 #include <QueryPipeline/QueryPlanResourceHolder.h>
 #include <Storages/IStorage.h>
+#include <Interpreters/DatabaseCatalog.h>
 
 
 namespace DB
 {
-    namespace ErrorCodes
-    {
-        extern const int TOO_MANY_RETRIES_TO_FETCH_PARTS;
-    }
-    class PullingPipelineExecutor;
 
-    class LoopSource : public ISource
-    {
-    public:
+namespace Setting
+{
+    extern const SettingsBool allow_experimental_analyzer;
+}
 
-        LoopSource(
-                const Names & column_names_,
-                const SelectQueryInfo & query_info_,
-                const StorageSnapshotPtr & storage_snapshot_,
-                ContextPtr & context_,
-                QueryProcessingStage::Enum processed_stage_,
-                StoragePtr inner_storage_,
-                size_t max_block_size_,
-                size_t num_streams_)
-                : ISource(std::make_shared<const Block>(storage_snapshot_->getSampleBlockForColumns(column_names_)))
-                , column_names(column_names_)
-                , query_info(query_info_)
-                , storage_snapshot(storage_snapshot_)
-                , processed_stage(processed_stage_)
-                , context(context_)
-                , inner_storage(std::move(inner_storage_))
-                , max_block_size(max_block_size_)
-                , num_streams(num_streams_)
+namespace ErrorCodes
+{
+    extern const int TOO_MANY_RETRIES_TO_FETCH_PARTS;
+}
+
+class PullingPipelineExecutor;
+
+namespace
+{
+    void buildInterpreterQueryPlan(
+        QueryPlan & plan,
+        const String & database,
+        const String & table,
+        const Names & column_names,
+        const SelectQueryInfo & query_info,
+        ContextPtr context)
+    {
+        auto select_query = make_intrusive<ASTSelectQuery>();
+
+        auto select_expr_list = make_intrusive<ASTExpressionList>();
+        for (const auto & col_name : column_names)
+            select_expr_list->children.push_back(make_intrusive<ASTIdentifier>(col_name));
+        select_query->setExpression(ASTSelectQuery::Expression::SELECT, std::move(select_expr_list));
+
+        select_query->replaceDatabaseAndTable(database, table);
+
+        auto select_ast = make_intrusive<ASTSelectWithUnionQuery>();
+        select_ast->list_of_selects = make_intrusive<ASTExpressionList>();
+        select_ast->list_of_selects->children.push_back(select_query);
+        select_ast->children.push_back(select_ast->list_of_selects);
+
+        auto options = SelectQueryOptions(QueryProcessingStage::Complete, 0, false);
+
+        if (context->getSettingsRef()[Setting::allow_experimental_analyzer])
         {
+            InterpreterSelectQueryAnalyzer interpreter(select_ast, context, options, column_names);
+            if (query_info.storage_limits)
+                interpreter.addStorageLimits(*query_info.storage_limits);
+            plan = std::move(interpreter).extractQueryPlan();
         }
-
-        String getName() const override { return "Loop"; }
-
-        Chunk generate() override
+        else
         {
-            while (true)
-            {
-                if (!loop)
-                {
-                    QueryPlan plan;
-                    auto storage_snapshot_ = inner_storage->getStorageSnapshot(inner_storage->getInMemoryMetadataPtr(), context);
-                    inner_storage->read(
-                            plan,
-                            column_names,
-                            storage_snapshot_,
-                            query_info,
-                            context,
-                            processed_stage,
-                            max_block_size,
-                            num_streams);
-                    if (plan.isInitialized())
-                    {
-                        auto builder = plan.buildQueryPipeline(QueryPlanOptimizationSettings(context), BuildQueryPipelineSettings(context));
-                        QueryPlanResourceHolder resources;
-                        auto pipe = QueryPipelineBuilder::getPipe(std::move(*builder), resources);
-                        query_pipeline = QueryPipeline(std::move(pipe));
-                        executor = std::make_unique<PullingPipelineExecutor>(query_pipeline);
-                    }
-                    loop = true;
-                }
-                Chunk chunk;
-
-                if (query_info.trivial_limit > 0 && rows_read >= query_info.trivial_limit)
-                    return chunk;
-
-                if (executor && executor->pull(chunk))
-                {
-                    rows_read += chunk.getNumRows();
-                    retries_count = 0;
-                    if (query_info.trivial_limit == 0 || rows_read <= query_info.trivial_limit)
-                        return chunk;
-
-                    size_t remaining_rows = query_info.trivial_limit + chunk.getNumRows() - rows_read;
-                    auto columns = chunk.detachColumns();
-                    for (auto & col : columns)
-                    {
-                        col = col->cut(0, remaining_rows);
-                    }
-                    return {std::move(columns), remaining_rows};
-                }
-                else
-                {
-                    ++retries_count;
-                    if (retries_count > max_retries_count)
-                        throw Exception(ErrorCodes::TOO_MANY_RETRIES_TO_FETCH_PARTS, "Too many retries to pull from storage");
-                    loop = false;
-                    executor.reset();
-                    query_pipeline.reset();
-                }
-            }
+            InterpreterSelectWithUnionQuery interpreter(select_ast, context, options, column_names);
+            if (query_info.storage_limits)
+                interpreter.addStorageLimits(*query_info.storage_limits);
+            interpreter.buildQueryPlan(plan);
         }
-
-    private:
-
-        const Names column_names;
-        SelectQueryInfo query_info;
-        const StorageSnapshotPtr storage_snapshot;
-        QueryProcessingStage::Enum processed_stage;
-        ContextPtr context;
-        StoragePtr inner_storage;
-        size_t max_block_size;
-        size_t num_streams;
-        // add retries. If inner_storage failed to pull X times in a row we'd better to fail here not to hang
-        size_t retries_count = 0;
-        size_t max_retries_count = 3;
-        size_t rows_read = 0;
-        bool loop = false;
-        QueryPipeline query_pipeline;
-        std::unique_ptr<PullingPipelineExecutor> executor;
-    };
-
-    static ContextPtr disableParallelReplicas(ContextPtr context)
-    {
-        auto modified_context = Context::createCopy(context);
-        modified_context->setSetting("allow_experimental_parallel_reading_from_replicas", Field(0));
-        return modified_context;
     }
+}
 
-    ReadFromLoopStep::ReadFromLoopStep(
+class LoopSource : public ISource
+{
+public:
+
+    LoopSource(
             const Names & column_names_,
             const SelectQueryInfo & query_info_,
             const StorageSnapshotPtr & storage_snapshot_,
-            const ContextPtr & context_,
+            ContextPtr & context_,
             QueryProcessingStage::Enum processed_stage_,
             StoragePtr inner_storage_,
             size_t max_block_size_,
             size_t num_streams_)
-            : SourceStepWithFilter(
-            std::make_shared<const Block>(storage_snapshot_->getSampleBlockForColumns(column_names_)),
-            column_names_,
-            query_info_,
-            storage_snapshot_,
-            disableParallelReplicas(context_))
+            : ISource(std::make_shared<const Block>(storage_snapshot_->getSampleBlockForColumns(column_names_)))
             , column_names(column_names_)
+            , query_info(query_info_)
+            , storage_snapshot(storage_snapshot_)
             , processed_stage(processed_stage_)
+            , context(context_)
             , inner_storage(std::move(inner_storage_))
             , max_block_size(max_block_size_)
             , num_streams(num_streams_)
     {
     }
 
-    Pipe ReadFromLoopStep::makePipe()
-    {
-        return Pipe(std::make_shared<LoopSource>(
-                column_names, query_info, storage_snapshot, context, processed_stage, inner_storage, max_block_size, num_streams));
-    }
+    String getName() const override { return "Loop"; }
 
-    void ReadFromLoopStep::initializePipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings &)
+    void initLoop()
     {
-        auto pipe = makePipe();
+        if (loop)
+            return;
 
-        if (pipe.empty())
+        QueryPlan plan;
+
+        if (DatabaseCatalog::instance().isTableExist(inner_storage->getStorageID(), context))
         {
-            chassert(output_header != nullptr);
-            pipe = Pipe(std::make_shared<NullSource>(output_header));
+            const auto & storage_id = inner_storage->getStorageID();
+            buildInterpreterQueryPlan(
+                plan, storage_id.database_name, storage_id.table_name,
+                column_names, query_info, context);
+        }
+        else
+        {
+            auto storage_snapshot_ = inner_storage->getStorageSnapshot(inner_storage->getInMemoryMetadataPtr(), context);
+            inner_storage->read(
+                    plan,
+                    column_names,
+                    storage_snapshot_,
+                    query_info,
+                    context,
+                    processed_stage,
+                    max_block_size,
+                    num_streams);
         }
 
-        pipeline.init(std::move(pipe));
+        if (plan.isInitialized())
+        {
+            auto builder = plan.buildQueryPipeline(QueryPlanOptimizationSettings(context), BuildQueryPipelineSettings(context));
+            QueryPlanResourceHolder resources;
+            auto pipe = QueryPipelineBuilder::getPipe(std::move(*builder), resources);
+            query_pipeline = QueryPipeline(std::move(pipe));
+            executor = std::make_unique<PullingPipelineExecutor>(query_pipeline);
+        }
+        loop = true;
     }
+
+    Chunk generate() override
+    {
+        while (true)
+        {
+            if (!loop)
+                initLoop();
+
+            Chunk chunk;
+
+            if (query_info.trivial_limit > 0 && rows_read >= query_info.trivial_limit)
+                return chunk;
+
+            if (executor && executor->pull(chunk))
+            {
+                rows_read += chunk.getNumRows();
+                retries_count = 0;
+                if (query_info.trivial_limit == 0 || rows_read <= query_info.trivial_limit)
+                    return chunk;
+
+                size_t remaining_rows = query_info.trivial_limit + chunk.getNumRows() - rows_read;
+                auto columns = chunk.detachColumns();
+                for (auto & col : columns)
+                    col = col->cut(0, remaining_rows);
+
+                return {std::move(columns), remaining_rows};
+            }
+
+            ++retries_count;
+            if (retries_count > max_retries_count)
+                throw Exception(ErrorCodes::TOO_MANY_RETRIES_TO_FETCH_PARTS, "Too many retries to pull from storage");
+
+            loop = false;
+            executor.reset();
+            query_pipeline.reset();
+        }
+    }
+
+private:
+    const Names column_names;
+    SelectQueryInfo query_info;
+    const StorageSnapshotPtr storage_snapshot;
+    QueryProcessingStage::Enum processed_stage;
+    ContextPtr context;
+    StoragePtr inner_storage;
+    size_t max_block_size;
+    size_t num_streams;
+    // add retries. If inner_storage failed to pull X times in a row we'd better to fail here not to hang
+    size_t retries_count = 0;
+    size_t max_retries_count = 3;
+    size_t rows_read = 0;
+    bool loop = false;
+    QueryPipeline query_pipeline;
+    std::unique_ptr<PullingPipelineExecutor> executor;
+};
+
+static ContextPtr disableParallelReplicas(ContextPtr context)
+{
+    auto modified_context = Context::createCopy(context);
+    modified_context->setSetting("allow_experimental_parallel_reading_from_replicas", Field(0));
+    return modified_context;
+}
+
+ReadFromLoopStep::ReadFromLoopStep(
+        const Names & column_names_,
+        const SelectQueryInfo & query_info_,
+        const StorageSnapshotPtr & storage_snapshot_,
+        const ContextPtr & context_,
+        QueryProcessingStage::Enum processed_stage_,
+        StoragePtr inner_storage_,
+        size_t max_block_size_,
+        size_t num_streams_)
+        : SourceStepWithFilter(
+        std::make_shared<const Block>(storage_snapshot_->getSampleBlockForColumns(column_names_)),
+        column_names_,
+        query_info_,
+        storage_snapshot_,
+        disableParallelReplicas(context_))
+        , column_names(column_names_)
+        , processed_stage(processed_stage_)
+        , inner_storage(std::move(inner_storage_))
+        , max_block_size(max_block_size_)
+        , num_streams(num_streams_)
+{
+}
+
+Pipe ReadFromLoopStep::makePipe()
+{
+    return Pipe(std::make_shared<LoopSource>(
+            column_names, query_info, storage_snapshot, context, processed_stage, inner_storage, max_block_size, num_streams));
+}
+
+void ReadFromLoopStep::initializePipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings &)
+{
+    auto pipe = makePipe();
+
+    if (pipe.empty())
+    {
+        chassert(output_header != nullptr);
+        pipe = Pipe(std::make_shared<NullSource>(output_header));
+    }
+
+    pipeline.init(std::move(pipe));
+}
 
 }

--- a/src/TableFunctions/TableFunctionLoop.cpp
+++ b/src/TableFunctions/TableFunctionLoop.cpp
@@ -134,6 +134,7 @@ namespace DB
             storage = database->tryGetTable(loop_table_name, context);
             if (!storage)
                 throw Exception(ErrorCodes::UNKNOWN_TABLE, "Table '{}' not found in database '{}'", loop_table_name, database_name);
+            context->checkAccess(AccessType::SELECT, database_name, loop_table_name);
         }
         else
         {

--- a/src/TableFunctions/TableFunctionLoop.cpp
+++ b/src/TableFunctions/TableFunctionLoop.cpp
@@ -134,7 +134,6 @@ namespace DB
             storage = database->tryGetTable(loop_table_name, context);
             if (!storage)
                 throw Exception(ErrorCodes::UNKNOWN_TABLE, "Table '{}' not found in database '{}'", loop_table_name, database_name);
-            context->checkAccess(AccessType::SELECT, database_name, loop_table_name);
         }
         else
         {

--- a/tests/queries/0_stateless/03928_loop_row_policy.reference
+++ b/tests/queries/0_stateless/03928_loop_row_policy.reference
@@ -1,8 +1,6 @@
---- Direct SELECT (row policy should filter everything) ---
-0
+--- Direct SELECT (row policy should filter to one row) ---
+1	flag1
 --- loop() must also respect row policy ---
-0
---- Verify with a permissive policy ---
 1	flag1
 1	flag1
 1	flag1

--- a/tests/queries/0_stateless/03928_loop_row_policy.reference
+++ b/tests/queries/0_stateless/03928_loop_row_policy.reference
@@ -1,0 +1,9 @@
+--- Direct SELECT (row policy should filter everything) ---
+0
+--- loop() must also respect row policy ---
+0
+--- Verify with a permissive policy ---
+1	flag1
+1	flag1
+1	flag1
+1	flag1

--- a/tests/queries/0_stateless/03928_loop_row_policy.sh
+++ b/tests/queries/0_stateless/03928_loop_row_policy.sh
@@ -18,23 +18,17 @@ GRANT SELECT ON $db.secret TO $user;
 GRANT CREATE TEMPORARY TABLE ON *.* TO $user;
 
 DROP ROW POLICY IF EXISTS rp_secret ON $db.secret;
-CREATE ROW POLICY rp_secret ON $db.secret FOR SELECT USING id = 0 TO $user;
+CREATE ROW POLICY rp_secret ON $db.secret FOR SELECT USING id = 1 TO $user;
 EOF
 
-echo "--- Direct SELECT (row policy should filter everything) ---"
-${CLICKHOUSE_CLIENT} --user $user --query "SELECT count() FROM $db.secret"
+echo "--- Direct SELECT (row policy should filter to one row) ---"
+${CLICKHOUSE_CLIENT} --user $user --query "SELECT * FROM $db.secret"
 
 echo "--- loop() must also respect row policy ---"
-${CLICKHOUSE_CLIENT} --user $user --query "SELECT count() FROM loop('$db', 'secret') LIMIT 10"
-
-echo "--- Verify with a permissive policy ---"
-${CLICKHOUSE_CLIENT} --query "DROP ROW POLICY rp_secret ON $db.secret"
-${CLICKHOUSE_CLIENT} --query "CREATE ROW POLICY rp_secret_allow ON $db.secret FOR SELECT USING id = 1 TO $user"
 ${CLICKHOUSE_CLIENT} --user $user --query "SELECT * FROM loop('$db', 'secret') LIMIT 4"
 
 ${CLICKHOUSE_CLIENT} <<EOF
 DROP ROW POLICY IF EXISTS rp_secret ON $db.secret;
-DROP ROW POLICY IF EXISTS rp_secret_allow ON $db.secret;
 DROP USER IF EXISTS $user;
 DROP TABLE IF EXISTS $db.secret;
 EOF

--- a/tests/queries/0_stateless/03928_loop_row_policy.sh
+++ b/tests/queries/0_stateless/03928_loop_row_policy.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Tags: no-replicated-database
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+user="user03928_${CLICKHOUSE_DATABASE}_$RANDOM"
+db=${CLICKHOUSE_DATABASE}
+
+${CLICKHOUSE_CLIENT} <<EOF
+CREATE TABLE $db.secret (id UInt32, secret String) ENGINE = MergeTree ORDER BY id;
+INSERT INTO $db.secret VALUES (1, 'flag1'), (2, 'flag2');
+
+DROP USER IF EXISTS $user;
+CREATE USER $user IDENTIFIED WITH no_password;
+GRANT SELECT ON $db.secret TO $user;
+GRANT CREATE TEMPORARY TABLE ON *.* TO $user;
+
+DROP ROW POLICY IF EXISTS rp_secret ON $db.secret;
+CREATE ROW POLICY rp_secret ON $db.secret FOR SELECT USING id = 0 TO $user;
+EOF
+
+echo "--- Direct SELECT (row policy should filter everything) ---"
+${CLICKHOUSE_CLIENT} --user $user --query "SELECT count() FROM $db.secret"
+
+echo "--- loop() must also respect row policy ---"
+${CLICKHOUSE_CLIENT} --user $user --query "SELECT count() FROM loop('$db', 'secret') LIMIT 10"
+
+echo "--- Verify with a permissive policy ---"
+${CLICKHOUSE_CLIENT} --query "DROP ROW POLICY rp_secret ON $db.secret"
+${CLICKHOUSE_CLIENT} --query "CREATE ROW POLICY rp_secret_allow ON $db.secret FOR SELECT USING id = 1 TO $user"
+${CLICKHOUSE_CLIENT} --user $user --query "SELECT * FROM loop('$db', 'secret') LIMIT 4"
+
+${CLICKHOUSE_CLIENT} <<EOF
+DROP ROW POLICY IF EXISTS rp_secret ON $db.secret;
+DROP ROW POLICY IF EXISTS rp_secret_allow ON $db.secret;
+DROP USER IF EXISTS $user;
+DROP TABLE IF EXISTS $db.secret;
+EOF


### PR DESCRIPTION
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
The `loop` table function was calling `inner_storage->read()` directly, bypassing the interpreter layer where row policies, column-level grants, and other security checks are applied. This allowed a user restricted by row policies to read all rows via `loop(table)` even when a direct SELECT returned zero rows.

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.198` (included in `26.3` and later)
- Backported to: `25.8.29.12`
<!-- ch-version-info:end -->