### PR TITLE
Fix logical error in tuple comparison involving `NULL` type elements

### DIFF
--- a/src/Functions/FunctionsComparison.h
+++ b/src/Functions/FunctionsComparison.h
@@ -1305,9 +1305,7 @@ public:
                 return std::make_shared<DataTypeUInt8>();
             /// If any element comparison is nullable, return type will also be nullable.
             /// We useDefaultImplementationForNulls, but it doesn't work for tuples.
-            if (has_null)
-                return std::make_shared<DataTypeNullable>(std::make_shared<DataTypeNothing>());
-            if (has_nullable)
+            if (has_null || has_nullable)
                 return std::make_shared<DataTypeNullable>(std::make_shared<DataTypeUInt8>());
         }
 

--- a/tests/queries/0_stateless/03925_tuple_comparison_null_type.reference
+++ b/tests/queries/0_stateless/03925_tuple_comparison_null_type.reference
@@ -1,0 +1,3 @@
+\N
+\N
+Nullable(UInt8)

--- a/tests/queries/0_stateless/03925_tuple_comparison_null_type.sql
+++ b/tests/queries/0_stateless/03925_tuple_comparison_null_type.sql
@@ -1,0 +1,16 @@
+SET enable_analyzer = 1;
+-- Tuple comparison involving Nullable(Nothing) elements should return Nullable(UInt8), not Nullable(Nothing).
+-- This previously caused a type mismatch assertion in MergingSortedAlgorithm when merging streams from GROUPING SETS.
+
+SELECT or(equals(y, (NULL, '')), equals(x, x)), equals(y, materialize(toNullable((NULL, '')))), materialize((456, NULL))
+FROM system.one
+LEFT ARRAY JOIN [(NULL, ''), (123, 'Hello'), (456, NULL)] AS y, [1, NULL, 3] AS x
+WHERE or(equals(y, (NULL, '')), isNotDistinctFrom(x, x))
+GROUP BY GROUPING SETS ((y), (1))
+ORDER BY ALL DESC NULLS FIRST
+FORMAT Null;
+
+-- Simpler cases for tuple comparison with NULL type
+SELECT (1, 2) = (NULL, 2);
+SELECT (NULL, 'a') = (1, 'a');
+SELECT toTypeName((NULL, 'a') = (1, 'a'));


### PR DESCRIPTION
Attempt at a simpler solution of https://github.com/ClickHouse/ClickHouse/pull/97509 while trying to keep the semantics intact.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix logical error in tuple comparison involving `NULL` type elements (e.g., comparing with `NULL` tuple elements) when used with `GROUPING SETS` and `ORDER BY`.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
