### PR TITLE
Remove flaky test_under_max_waiting_queries_limit test

### DIFF
--- a/tests/integration/test_scheduler_query/test.py
+++ b/tests/integration/test_scheduler_query/test.py
@@ -222,18 +222,3 @@ def test_max_waiting_queries_reached() -> None:
     assert "Workload limit `max_waiting_queries` has been reached: 1 of 1" in pool_all.last_error
 
 
-def test_under_max_waiting_queries_limit() -> None:
-    node.query(
-        f"""
-        create resource query (query);
-        create workload all settings max_concurrent_queries=1, max_waiting_queries=6;
-        """
-    )
-
-    pool_all = QueryPool(7, "all")
-
-    pool_all.start()
-    ensure_total_concurrency(1)
-    ensure_workload_concurrency("all", 1)
-    pool_all.stop()
-    assert pool_all.last_error is None


### PR DESCRIPTION
## Summary
- Remove `test_under_max_waiting_queries_limit` from `test_scheduler_query` integration tests due to an inherent race condition at the queue boundary

The test has a race condition: with `max_concurrent_queries=1`, `max_waiting_queries=6`, and 7 threads, the queue is at its exact boundary. Since `ResourceRequest::finish` is asynchronous, there is a window between a query finishing and the scheduler dequeuing the next waiting request, causing sporadic `SERVER_OVERLOADED` exceptions.

Reference: https://github.com/ClickHouse/ClickHouse/pull/97671

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.1085`
<!-- ch-version-info:end -->