### PR TITLE
trace-visualizer: fix colors when span.color is numeric

### DIFF
--- a/utils/trace-visualizer/index.html
+++ b/utils/trace-visualizer/index.html
@@ -660,11 +660,12 @@ SETTINGS output_format_json_named_tuples_as_objects = 1, skip_unavailable_shards
             let span = rows[i];
             let band = Object.values(span.group).join(' ');
             bands.add(band);
+            const colorKey = span.color == null ? '' : String(span.color);
             result.push({
                 t1: convertTime(+span.start_time_us),
                 t2: convertTime(+span.finish_time_us),
                 band,
-                color: d3.interpolateRainbow((strHash(span.color) % 1024) / 1024),
+                color: d3.interpolateRainbow((strHash(colorKey) % 1024) / 1024),
                 text: span.operation_name
             });
         }


### PR DESCRIPTION
### Changelog category (leave one):

* Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description]

fix tiny issue in trace-visualizer causing all spans to be presented in one color.

### Documentation entry for user-facing changes

The [example query in README](https://github.com/ClickHouse/ClickHouse/blob/a1ffe58f2f3a0e988b34d15eb1590c35e3ccdcda/utils/trace-visualizer/README.md?plain=1#L42) does siphash for a base of colors. SipHash returns an int value which is written into JSON.

The int from JSON becomes a number in JavaScript. The `strHash` function in JavaScript expects a string and returns 0 for numbers, so all spans get the same color.

This fix adds an explicit cast of `color` to a (JavaScript) string, so `strHash` works correctly and spans get different colors.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.1080`
<!-- ch-version-info:end -->