### PR TITLE
Minor: Rename a variable

### DIFF
--- a/src/Functions/README.md
+++ b/src/Functions/README.md
@@ -42,8 +42,8 @@ negative number by minus one.
         {"Usage example", "SELECT gcd(12, 18)", "6"};
     };
     FunctionDocumentation::IntroducedIn introduced_in = {1, 1};
-    FunctionDocumentation::Category categories = FunctionDocumentation::Category::Arithmetic;
-    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, categories};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Arithmetic;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
 
     factory.registerFunction<FunctionGCD>(documentation);
 ```

--- a/src/Functions/abs.cpp
+++ b/src/Functions/abs.cpp
@@ -102,8 +102,8 @@ REGISTER_FUNCTION(Abs)
     FunctionDocumentation::ReturnedValue returned_value = {"The absolute value of `x`"};
     FunctionDocumentation::Examples examples = {{"Usage example", "SELECT abs(-0.5)", "0.5"}};
     FunctionDocumentation::IntroducedIn introduced_in = {1, 1};
-    FunctionDocumentation::Category categories = FunctionDocumentation::Category::Arithmetic;
-    FunctionDocumentation documentation = {description, syntax, argument, {}, returned_value, examples, introduced_in, categories};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Arithmetic;
+    FunctionDocumentation documentation = {description, syntax, argument, {}, returned_value, examples, introduced_in, category};
 
     factory.registerFunction<FunctionAbs>(documentation, FunctionFactory::Case::Insensitive);
 }

--- a/src/Functions/byteSwap.cpp
+++ b/src/Functions/byteSwap.cpp
@@ -89,8 +89,8 @@ One use case of this function is reversing IPv4s:
     FunctionDocumentation::Example example5 = {"64-bit", "SELECT byteSwap(123294967295)", "18439412204227788800"};
     FunctionDocumentation::Examples examples = {example1, example2, example3, example4, example5};
     FunctionDocumentation::IntroducedIn introduced_in = {23, 10};
-    FunctionDocumentation::Category categories = FunctionDocumentation::Category::Arithmetic;
-    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, categories};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Arithmetic;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
     factory.registerFunction<FunctionByteSwap>(documentation,FunctionFactory::Case::Insensitive);
 }
 

--- a/src/Functions/divide.cpp
+++ b/src/Functions/divide.cpp
@@ -63,8 +63,8 @@ Division by `0` returns `inf`, `-inf`, or `nan`.
     FunctionDocumentation::Example example2 = {"Dividing by zero", "SELECT divide(25,0)", "inf"};
     FunctionDocumentation::Examples examples = {example1, example2};
     FunctionDocumentation::IntroducedIn introduced_in = {1, 1};
-    FunctionDocumentation::Category categories = FunctionDocumentation::Category::Arithmetic;
-    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, categories};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Arithmetic;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
     factory.registerFunction<FunctionDivide>(documentation);
 }
@@ -85,8 +85,8 @@ Same as `divide` but returns NULL when dividing by zero.
     FunctionDocumentation::Example example1 = {"Dividing by zero", "SELECT divideOrNull(25, 0)", "\\N"};
     FunctionDocumentation::Examples examples = {example1};
     FunctionDocumentation::IntroducedIn introduced_in = {25, 5};
-    FunctionDocumentation::Category categories = FunctionDocumentation::Category::Arithmetic;
-    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, categories};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Arithmetic;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
     factory.registerFunction<FunctionDivideOrNull>(documentation);
 }

--- a/src/Functions/divideDecimal.cpp
+++ b/src/Functions/divideDecimal.cpp
@@ -94,8 +94,8 @@ SELECT toDecimal64(-12, 1) as a, toDecimal32(2.1, 1) as b, divideDecimal(a, b, 1
     )"};
     FunctionDocumentation::Examples examples = {example1, example2};
     FunctionDocumentation::IntroducedIn introduced_in = {22, 12};
-    FunctionDocumentation::Category categories = FunctionDocumentation::Category::Arithmetic;
-    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, categories};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Arithmetic;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
     factory.registerFunction<FunctionsDecimalArithmetics<DivideDecimalsImpl>>(documentation);
 }
 

--- a/src/Functions/gcd.cpp
+++ b/src/Functions/gcd.cpp
@@ -45,8 +45,8 @@ REGISTER_FUNCTION(GCD)
     FunctionDocumentation::Example example1 = {"Usage example", "SELECT gcd(12, 18)", "6"};
     FunctionDocumentation::Examples examples = {example1};
     FunctionDocumentation::IntroducedIn introduced_in = {1, 1};
-    FunctionDocumentation::Category categories = FunctionDocumentation::Category::Arithmetic;
-    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, categories};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Arithmetic;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
     factory.registerFunction<FunctionGCD>(documentation);
 }

--- a/src/Functions/ifNotFinite.cpp
+++ b/src/Functions/ifNotFinite.cpp
@@ -82,8 +82,8 @@ You can get a similar result by using the [ternary operator](/sql-reference/func
     )"};
     FunctionDocumentation::Examples examples = {{"Usage example","SELECT 1/0 AS infimum, ifNotFinite(infimum,42)","inf  42"}};
     FunctionDocumentation::IntroducedIn introduced_in = {20, 3};
-    FunctionDocumentation::Category categories = FunctionDocumentation::Category::Arithmetic;
-    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, categories};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Arithmetic;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
     factory.registerFunction<FunctionIfNotFinite>(documentation);
 }

--- a/src/Functions/intDiv.cpp
+++ b/src/Functions/intDiv.cpp
@@ -173,8 +173,8 @@ large number: While processing intDiv(1, 0.001) AS res, toTypeName(res).
     };
     FunctionDocumentation::Examples examples = {example1, example2};
     FunctionDocumentation::IntroducedIn introduced_in = {1, 1};
-    FunctionDocumentation::Category categories = FunctionDocumentation::Category::Arithmetic;
-    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, categories};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Arithmetic;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
     factory.registerFunction<FunctionIntDiv>(documentation);
 }
@@ -201,8 +201,8 @@ minimal negative number by minus one.
         {"Dividing a minimal negative number by minus 1", "SELECT intDivOrNull(-9223372036854775808, -1)", "\\N"}
     };
     FunctionDocumentation::IntroducedIn introduced_in = {25, 5};
-    FunctionDocumentation::Category categories = FunctionDocumentation::Category::Arithmetic;
-    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, categories};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Arithmetic;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
     factory.registerFunction<FunctionIntDivOrNull>(documentation);
 }

--- a/src/Functions/intDivOrZero.cpp
+++ b/src/Functions/intDivOrZero.cpp
@@ -48,8 +48,8 @@ minimal negative number by minus one.
         {"Dividing a minimal negative number by minus 1", "SELECT intDivOrZero(0.05, -1)", "0"}
     };
     FunctionDocumentation::IntroducedIn introduced_in = {1, 1};
-    FunctionDocumentation::Category categories = FunctionDocumentation::Category::Arithmetic;
-    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, categories};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Arithmetic;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
     factory.registerFunction<FunctionIntDivOrZero>(documentation);
 }

--- a/src/Functions/isFinite.cpp
+++ b/src/Functions/isFinite.cpp
@@ -52,8 +52,8 @@ otherwise this function returns `0`.
     FunctionDocumentation::ReturnedValue returned_value = {"`1` if x is not infinite and not `NaN`, otherwise `0`."};
     FunctionDocumentation::Examples examples = {{"Test if a number is finite", "SELECT isFinite(inf)", "0"}};
     FunctionDocumentation::IntroducedIn introduced_in = {1, 1};
-    FunctionDocumentation::Category categories = FunctionDocumentation::Category::Arithmetic;
-    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, categories};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Arithmetic;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
     factory.registerFunction<FunctionIsFinite>(documentation);
 }

--- a/src/Functions/isInfinite.cpp
+++ b/src/Functions/isInfinite.cpp
@@ -48,8 +48,8 @@ REGISTER_FUNCTION(IsInfinite)
     FunctionDocumentation::ReturnedValue returned_value = {"`1` if x is infinite, otherwise `0` (including for `NaN`)."};
     FunctionDocumentation::Examples examples = {{"Test if a number is infinite", "SELECT isInfinite(inf), isInfinite(NaN), isInfinite(10))", "1 0 0"}};
     FunctionDocumentation::IntroducedIn introduced_in = {1, 1};
-    FunctionDocumentation::Category categories = FunctionDocumentation::Category::Arithmetic;
-    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, categories};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Arithmetic;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
     factory.registerFunction<FunctionIsInfinite>(documentation);
 }

--- a/src/Functions/isNaN.cpp
+++ b/src/Functions/isNaN.cpp
@@ -32,8 +32,8 @@ REGISTER_FUNCTION(IsNaN)
     FunctionDocumentation::ReturnedValue returned_value = {"`1` if `NaN`, otherwise `0`"};
     FunctionDocumentation::Examples examples = {{"Usage example", "SELECT isNaN(NaN)", "1"}};
     FunctionDocumentation::IntroducedIn introduced_in = {1, 1};
-    FunctionDocumentation::Category categories = FunctionDocumentation::Category::Arithmetic;
-    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, categories};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Arithmetic;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
     factory.registerFunction<FunctionIsNaN>(documentation);
 }

--- a/src/Functions/lcm.cpp
+++ b/src/Functions/lcm.cpp
@@ -77,8 +77,8 @@ An exception is thrown when dividing by zero or when dividing a minimal negative
     FunctionDocumentation::ReturnedValue returned_value = {"Returns the least common multiple of `x` and `y`.", {"(U)Int*"}};
     FunctionDocumentation::Examples example = {{"Usage example", "SELECT lcm(6, 8)", "24"}};
     FunctionDocumentation::IntroducedIn introduced_in = {1, 1};
-    FunctionDocumentation::Category categories = FunctionDocumentation::Category::Arithmetic;
-    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, example, introduced_in, categories};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Arithmetic;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, example, introduced_in, category};
 
     factory.registerFunction<FunctionLCM>(documentation);
 }

--- a/src/Functions/max2.cpp
+++ b/src/Functions/max2.cpp
@@ -31,8 +31,8 @@ REGISTER_FUNCTION(Max2)
     FunctionDocumentation::ReturnedValue returned_value = {"Returns the bigger value of `x` and `y`.", {"Float64"}};
     FunctionDocumentation::Examples examples = {{"Usage example", "SELECT max2(-1, 2)", "2"}};
     FunctionDocumentation::IntroducedIn introduced_in = {21, 11};
-    FunctionDocumentation::Category categories = FunctionDocumentation::Category::Arithmetic;
-    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, categories};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Arithmetic;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
     factory.registerFunction<FunctionMax2>(documentation, FunctionFactory::Case::Insensitive);
 }

--- a/src/Functions/min2.cpp
+++ b/src/Functions/min2.cpp
@@ -33,8 +33,8 @@ REGISTER_FUNCTION(Min2)
     FunctionDocumentation::Example example1 = {"Usage example", "SELECT min2(-1, 2)", "-1"};
     FunctionDocumentation::Examples examples = {example1};
     FunctionDocumentation::IntroducedIn introduced_in = {21, 11};
-    FunctionDocumentation::Category categories = FunctionDocumentation::Category::Arithmetic;
-    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, categories};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Arithmetic;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
     factory.registerFunction<FunctionMin2>(documentation, FunctionFactory::Case::Insensitive);
 }

--- a/src/Functions/minus.cpp
+++ b/src/Functions/minus.cpp
@@ -65,8 +65,8 @@ Additionally, subtraction between date with time is supported, resulting in the 
         {"Subtracting an integer and a date", "SELECT minus(toDate('2025-01-01'),5)", "2024-12-27"}
     };
     FunctionDocumentation::IntroducedIn introduced_in = {1, 1};
-    FunctionDocumentation::Category categories = FunctionDocumentation::Category::Arithmetic;
-    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, categories};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Arithmetic;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
     factory.registerFunction<FunctionMinus>(documentation);
 }

--- a/src/Functions/modulo.cpp
+++ b/src/Functions/modulo.cpp
@@ -200,8 +200,8 @@ REGISTER_FUNCTION(Modulo)
     FunctionDocumentation::Example example1 = {"Usage example", "SELECT modulo(5, 2)", "1"};
     FunctionDocumentation::Examples examples = {example1};
     FunctionDocumentation::IntroducedIn introduced_in = {1, 1};
-    FunctionDocumentation::Category categories = FunctionDocumentation::Category::Arithmetic;
-    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, categories};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Arithmetic;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
     factory.registerFunction<FunctionModulo>(documentation);
     factory.registerAlias("mod", "modulo", FunctionFactory::Case::Insensitive);
 }
@@ -251,8 +251,8 @@ Returns the difference between `x` and the nearest integer not greater than
     )"};
     FunctionDocumentation::Examples example = {{"Usage example", "SELECT positiveModulo(-1, 10)", "9"}};
     FunctionDocumentation::IntroducedIn introduced_in = {22, 11};
-    FunctionDocumentation::Category categories = FunctionDocumentation::Category::Arithmetic;
-    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, example, introduced_in, categories};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Arithmetic;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, example, introduced_in, category};
 
     factory.registerFunction<FunctionPositiveModulo>(documentation,
         FunctionFactory::Case::Insensitive);

--- a/src/Functions/moduloOrNull.cpp
+++ b/src/Functions/moduloOrNull.cpp
@@ -24,8 +24,8 @@ Returns the remainder of the division of `x` by `y`, or null when the divisor is
     )"};
     FunctionDocumentation::Examples examples = {{"moduloOrNull by zero", "SELECT moduloOrNull(5, 0)", "\\N"}};
     FunctionDocumentation::IntroducedIn introduced_in = {25, 5};
-    FunctionDocumentation::Category categories = FunctionDocumentation::Category::Arithmetic;
-    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, categories};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Arithmetic;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
     factory.registerFunction<FunctionModuloOrNull>(documentation);
     factory.registerAlias("modOrNull", "moduloOrNull", FunctionFactory::Case::Insensitive);
@@ -54,8 +54,8 @@ Returns the difference between `x` and the nearest integer not greater than
     )"};
     FunctionDocumentation::Examples examples = {{"positiveModuloOrNull", "SELECT positiveModuloOrNull(5, 0)", "\\N"}};
     FunctionDocumentation::IntroducedIn introduced_in = {25, 5};
-    FunctionDocumentation::Category categories = FunctionDocumentation::Category::Arithmetic;
-    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, categories};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Arithmetic;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
     factory.registerFunction<FunctionPositiveModuloOrNll>(documentation, FunctionFactory::Case::Insensitive);
 

--- a/src/Functions/moduloOrZero.cpp
+++ b/src/Functions/moduloOrZero.cpp
@@ -56,8 +56,8 @@ exception with the modulo function.
     FunctionDocumentation::ReturnedValue returned_value = {"Returns the remainder of a % b, or `0` when the divisor is `0`."};
     FunctionDocumentation::Examples examples = {{"Usage example", "SELECT moduloOrZero(5, 0)", "0"}};
     FunctionDocumentation::IntroducedIn introduced_in = {20, 3};
-    FunctionDocumentation::Category categories = FunctionDocumentation::Category::Arithmetic;
-    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, categories};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Arithmetic;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
     factory.registerFunction<FunctionModuloOrZero>(documentation);
 }

--- a/src/Functions/multiply.cpp
+++ b/src/Functions/multiply.cpp
@@ -65,8 +65,8 @@ REGISTER_FUNCTION(Multiply)
     FunctionDocumentation::ReturnedValue returned_value = {"Returns the product of x and y"};
     FunctionDocumentation::Examples examples = {{"Multiplying two numbers", "SELECT multiply(5,5)", "25"}};
     FunctionDocumentation::IntroducedIn introduced_in = {1, 1};
-    FunctionDocumentation::Category categories = FunctionDocumentation::Category::Arithmetic;
-    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, categories};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Arithmetic;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
     factory.registerFunction<FunctionMultiply>(documentation);
 }

--- a/src/Functions/multiplyDecimal.cpp
+++ b/src/Functions/multiplyDecimal.cpp
@@ -104,8 +104,8 @@ While processing toDecimal64(-12.647987876, 9) AS a, toDecimal64(123.967645643, 
         )"}
     };
     FunctionDocumentation::IntroducedIn introduced_in = {22, 12};
-    FunctionDocumentation::Category categories = FunctionDocumentation::Category::Arithmetic;
-    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, categories};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Arithmetic;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
     factory.registerFunction<FunctionsDecimalArithmetics<MultiplyDecimalsImpl>>(documentation);
 }

--- a/src/Functions/negate.cpp
+++ b/src/Functions/negate.cpp
@@ -91,8 +91,8 @@ REGISTER_FUNCTION(Negate)
     FunctionDocumentation::Example example1 = {"Usage example", "SELECT negate(10)", "-10"};
     FunctionDocumentation::Examples examples = {example1};
     FunctionDocumentation::IntroducedIn introduced_in = {1, 1};
-    FunctionDocumentation::Category categories = FunctionDocumentation::Category::Arithmetic;
-    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, categories};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Arithmetic;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
     factory.registerFunction<FunctionNegate>(documentation);
 }

--- a/src/Functions/plus.cpp
+++ b/src/Functions/plus.cpp
@@ -64,9 +64,9 @@ increments the number of seconds in the date with time.
     FunctionDocumentation::Example example1 = {"Adding two numbers", "SELECT plus(5,5)", "10"};
     FunctionDocumentation::Example example2 = {"Adding an integer and a date", "SELECT plus(toDate('2025-01-01'),5)", "2025-01-06"};
     FunctionDocumentation::Examples examples = {example1, example2};
-    FunctionDocumentation::Category categories = FunctionDocumentation::Category::Arithmetic;
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Arithmetic;
     FunctionDocumentation::IntroducedIn introduced_in = {1, 1};
-    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, categories};
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
     factory.registerFunction<FunctionPlus>(documentation);
 }


### PR DESCRIPTION
Field `FunctionDocumentation::category` refers to a _single_ category, but many callers in src/Functions/ used a local variable called "categories" when constructing the documentation object. Rename to `category` for consistency with the field name.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.1082`
<!-- ch-version-info:end -->