### PR TITLE
More consistent naming of some variables

### DIFF
--- a/src/Functions/JSONArrayLength.cpp
+++ b/src/Functions/JSONArrayLength.cpp
@@ -100,16 +100,16 @@ namespace
 REGISTER_FUNCTION(JSONArrayLength)
 {
     /// JSONArrayLength documentation
-    FunctionDocumentation::Description description_JSONArrayLength = R"(
+    FunctionDocumentation::Description description = R"(
 Returns the number of elements in the outermost JSON array.
 The function returns `NULL` if input JSON string is invalid.
     )";
-    FunctionDocumentation::Syntax syntax_JSONArrayLength = "JSONArrayLength(json)";
-    FunctionDocumentation::Arguments arguments_JSONArrayLength = {
+    FunctionDocumentation::Syntax syntax = "JSONArrayLength(json)";
+    FunctionDocumentation::Arguments arguments = {
         {"json", "String with valid JSON.", {"String"}}
     };
-    FunctionDocumentation::ReturnedValue returned_value_JSONArrayLength = {"Returns the number of array elements if `json` is a valid JSON array string, otherwise returns `NULL`.", {"Nullable(UInt64)"}};
-    FunctionDocumentation::Examples examples_JSONArrayLength = {
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the number of array elements if `json` is a valid JSON array string, otherwise returns `NULL`.", {"Nullable(UInt64)"}};
+    FunctionDocumentation::Examples examples = {
     {
         "Usage example",
         R"(
@@ -124,11 +124,11 @@ SELECT
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in_JSONArrayLength = {23, 2};
-    FunctionDocumentation::Category category_JSONArrayLength = FunctionDocumentation::Category::JSON;
-    FunctionDocumentation documentation_JSONArrayLength = {description_JSONArrayLength, syntax_JSONArrayLength, arguments_JSONArrayLength, {}, returned_value_JSONArrayLength, examples_JSONArrayLength, introduced_in_JSONArrayLength, category_JSONArrayLength};
+    FunctionDocumentation::IntroducedIn introduced_in = {23, 2};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::JSON;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
-    factory.registerFunction<FunctionJSONArrayLength>(documentation_JSONArrayLength);
+    factory.registerFunction<FunctionJSONArrayLength>(documentation);
 
     /// For Spark compatibility.
     factory.registerAlias("JSON_ARRAY_LENGTH", "JSONArrayLength", FunctionFactory::Case::Insensitive);

--- a/src/Functions/ULIDStringToDateTime.cpp
+++ b/src/Functions/ULIDStringToDateTime.cpp
@@ -171,16 +171,16 @@ public:
 REGISTER_FUNCTION(ULIDStringToDateTime)
 {
     /// ULIDStringToDateTime documentation
-    FunctionDocumentation::Description description_ULIDStringToDateTime = R"(
+    FunctionDocumentation::Description description = R"(
 This function extracts the timestamp from a [ULID](https://github.com/ulid/spec).
     )";
-    FunctionDocumentation::Syntax syntax_ULIDStringToDateTime = "ULIDStringToDateTime(ulid[, timezone])";
-    FunctionDocumentation::Arguments arguments_ULIDStringToDateTime = {
+    FunctionDocumentation::Syntax syntax = "ULIDStringToDateTime(ulid[, timezone])";
+    FunctionDocumentation::Arguments arguments = {
         {"ulid", "Input ULID.", {"String", "FixedString(26)"}},
         {"timezone", "Optional. Timezone name for the returned value.", {"String"}}
     };
-    FunctionDocumentation::ReturnedValue returned_value_ULIDStringToDateTime = {"Timestamp with milliseconds precision.", {"DateTime64(3)"}};
-    FunctionDocumentation::Examples examples_ULIDStringToDateTime = {
+    FunctionDocumentation::ReturnedValue returned_value = {"Timestamp with milliseconds precision.", {"DateTime64(3)"}};
+    FunctionDocumentation::Examples examples = {
     {
         "Usage example",
         R"(
@@ -193,11 +193,11 @@ SELECT ULIDStringToDateTime('01GNB2S2FGN2P93QPXDNB4EN2R')
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in_ULIDStringToDateTime = {23, 3};
-    FunctionDocumentation::Category category_ULIDStringToDateTime = FunctionDocumentation::Category::ULID;
-    FunctionDocumentation documentation_ULIDStringToDateTime = {description_ULIDStringToDateTime, syntax_ULIDStringToDateTime, arguments_ULIDStringToDateTime, {}, returned_value_ULIDStringToDateTime, examples_ULIDStringToDateTime, introduced_in_ULIDStringToDateTime, category_ULIDStringToDateTime};
+    FunctionDocumentation::IntroducedIn introduced_in = {23, 3};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::ULID;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
-    factory.registerFunction<FunctionULIDStringToDateTime>(documentation_ULIDStringToDateTime);
+    factory.registerFunction<FunctionULIDStringToDateTime>(documentation);
 }
 
 }

--- a/src/Functions/UTCTimestamp.cpp
+++ b/src/Functions/UTCTimestamp.cpp
@@ -107,17 +107,17 @@ public:
 /// UTC_timestamp for MySQL interface support
 REGISTER_FUNCTION(UTCTimestamp)
 {
-    FunctionDocumentation::Description description_UTCTimestamp = R"(
+    FunctionDocumentation::Description description = R"(
 Returns the current date and time at the moment of query analysis. The function is a constant expression.
 
 This function gives the same result that `now('UTC')` would. It was added only for MySQL support. [`now`](#now) is the preferred usage.
     )";
-    FunctionDocumentation::Syntax syntax_UTCTimestamp = R"(
+    FunctionDocumentation::Syntax syntax = R"(
 UTCTimestamp()
     )";
-    FunctionDocumentation::Arguments arguments_UTCTimestamp = {};
-    FunctionDocumentation::ReturnedValue returned_value_UTCTimestamp = {"Returns the current date and time at the moment of query analysis.", {"DateTime"}};
-    FunctionDocumentation::Examples examples_UTCTimestamp = {
+    FunctionDocumentation::Arguments arguments = {};
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the current date and time at the moment of query analysis.", {"DateTime"}};
+    FunctionDocumentation::Examples examples = {
         {"Get current UTC timestamp", R"(
 SELECT UTCTimestamp()
         )",
@@ -127,11 +127,11 @@ SELECT UTCTimestamp()
 └─────────────────────┘
         )"}
     };
-    FunctionDocumentation::IntroducedIn introduced_in_UTCTimestamp = {22, 11};
-    FunctionDocumentation::Category category_UTCTimestamp = FunctionDocumentation::Category::DateAndTime;
-    FunctionDocumentation documentation_UTCTimestamp = {description_UTCTimestamp, syntax_UTCTimestamp, arguments_UTCTimestamp, {}, returned_value_UTCTimestamp, examples_UTCTimestamp, introduced_in_UTCTimestamp,category_UTCTimestamp};
+    FunctionDocumentation::IntroducedIn introduced_in = {22, 11};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::DateAndTime;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in,category};
 
-    factory.registerFunction<UTCTimestampOverloadResolver>(documentation_UTCTimestamp, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<UTCTimestampOverloadResolver>(documentation, FunctionFactory::Case::Insensitive);
     factory.registerAlias("UTC_timestamp", UTCTimestampOverloadResolver::name, FunctionFactory::Case::Insensitive);
 }
 

--- a/src/Functions/blockSerializedSize.cpp
+++ b/src/Functions/blockSerializedSize.cpp
@@ -70,15 +70,15 @@ public:
 
 REGISTER_FUNCTION(BlockSerializedSize)
 {
-    FunctionDocumentation::Description description_blockSerializedSize = R"(
+    FunctionDocumentation::Description description = R"(
 Returns the uncompressed size in bytes of a block of values on disk.
 )";
-    FunctionDocumentation::Syntax syntax_blockSerializedSize = "blockSerializedSize(x1[, x2[, ...]])";
-    FunctionDocumentation::Arguments arguments_blockSerializedSize = {
+    FunctionDocumentation::Syntax syntax = "blockSerializedSize(x1[, x2[, ...]])";
+    FunctionDocumentation::Arguments arguments = {
         {"x1[, x2, ...]", "Any number of values for which to get the uncompressed size of the block.", {"Any"}}
     };
-    FunctionDocumentation::ReturnedValue returned_value_blockSerializedSize = {"Returns the number of bytes that will be written to disk for a block of values without compression.", {"UInt64"}};
-    FunctionDocumentation::Examples examples_blockSerializedSize = {
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the number of bytes that will be written to disk for a block of values without compression.", {"UInt64"}};
+    FunctionDocumentation::Examples examples = {
     {
         "Usage example",
         R"(
@@ -91,11 +91,11 @@ SELECT blockSerializedSize(maxState(1)) AS x;
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in_blockSerializedSize = {20, 3};
-    FunctionDocumentation::Category category_blockSerializedSize = FunctionDocumentation::Category::Other;
-    FunctionDocumentation documentation_blockSerializedSize = {description_blockSerializedSize, syntax_blockSerializedSize, arguments_blockSerializedSize, {}, returned_value_blockSerializedSize, examples_blockSerializedSize, introduced_in_blockSerializedSize, category_blockSerializedSize};
+    FunctionDocumentation::IntroducedIn introduced_in = {20, 3};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Other;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
-    factory.registerFunction<FunctionBlockSerializedSize>(documentation_blockSerializedSize);
+    factory.registerFunction<FunctionBlockSerializedSize>(documentation);
 }
 
 }

--- a/src/Functions/countDigits.cpp
+++ b/src/Functions/countDigits.cpp
@@ -155,7 +155,7 @@ private:
 
 REGISTER_FUNCTION(CountDigits)
 {
-    FunctionDocumentation::Description description_countDigits = R"(
+    FunctionDocumentation::Description description = R"(
 Returns the number of decimal digits needed to represent a value.
 
 :::note
@@ -172,12 +172,12 @@ You can check decimal overflow for `Decimal64` with `countDigits(x) > 18`,
 although it is slower than [`isDecimalOverflow`](#isDecimalOverflow).
 :::
 )";
-    FunctionDocumentation::Syntax syntax_countDigits = "countDigits(x)";
-    FunctionDocumentation::Arguments arguments_countDigits = {
+    FunctionDocumentation::Syntax syntax = "countDigits(x)";
+    FunctionDocumentation::Arguments arguments = {
         {"x", "An integer or decimal value.", {"(U)Int*", "Decimal"}}
     };
-    FunctionDocumentation::ReturnedValue returned_value_countDigits = {"Returns the number of digits needed to represent `x`.", {"UInt8"}};
-    FunctionDocumentation::Examples examples_countDigits = {
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the number of digits needed to represent `x`.", {"UInt8"}};
+    FunctionDocumentation::Examples examples = {
     {
         "Usage example",
         R"(
@@ -192,11 +192,11 @@ SELECT countDigits(toDecimal32(1, 9)), countDigits(toDecimal32(-1, 9)),
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in_countDigits = {20, 8};
-    FunctionDocumentation::Category category_countDigits = FunctionDocumentation::Category::Other;
-    FunctionDocumentation documentation_countDigits = {description_countDigits, syntax_countDigits, arguments_countDigits, {}, returned_value_countDigits, examples_countDigits, introduced_in_countDigits, category_countDigits};
+    FunctionDocumentation::IntroducedIn introduced_in = {20, 8};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Other;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
-    factory.registerFunction<FunctionCountDigits>(documentation_countDigits);
+    factory.registerFunction<FunctionCountDigits>(documentation);
 }
 
 }

--- a/src/Functions/dateTimeToUUIDv7.cpp
+++ b/src/Functions/dateTimeToUUIDv7.cpp
@@ -133,7 +133,7 @@ private:
 REGISTER_FUNCTION(DateTimeToUUIDv7)
 {
     /// dateTimeToUUIDv7 documentation
-    FunctionDocumentation::Description description_dateTimeToUUIDv7 = R"(
+    FunctionDocumentation::Description description = R"(
 Converts a [DateTime](../data-types/datetime.md) value to a [UUIDv7](https://en.wikipedia.org/wiki/UUID#Version_7) at the given time.
 
 See section ["UUIDv7 generation"](#uuidv7-generation) for details on UUID structure, counter management, and concurrency guarantees.
@@ -142,12 +142,12 @@ See section ["UUIDv7 generation"](#uuidv7-generation) for details on UUID struct
 As of September 2025, version 7 UUIDs are in draft status and their layout may change in future.
 :::
     )";
-    FunctionDocumentation::Syntax syntax_dateTimeToUUIDv7 = "dateTimeToUUIDv7(value)";
-    FunctionDocumentation::Arguments arguments_dateTimeToUUIDv7 = {
+    FunctionDocumentation::Syntax syntax = "dateTimeToUUIDv7(value)";
+    FunctionDocumentation::Arguments arguments = {
         {"value", "Date with time.", {"DateTime"}}
     };
-    FunctionDocumentation::ReturnedValue returned_value_dateTimeToUUIDv7 = {"Returns a UUIDv7.", {"UUID"}};
-    FunctionDocumentation::Examples examples_dateTimeToUUIDv7 = {
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns a UUIDv7.", {"UUID"}};
+    FunctionDocumentation::Examples examples = {
     {
         "Usage example",
         R"(
@@ -175,11 +175,11 @@ SELECT dateTimeToUUIDv7(toDateTime('2021-08-15 18:57:56'));
        )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in_dateTimeToUUIDv7 = {25, 9};
-    FunctionDocumentation::Category category_dateTimeToUUIDv7 = FunctionDocumentation::Category::UUID;
-    FunctionDocumentation documentation_dateTimeToUUIDv7 = {description_dateTimeToUUIDv7, syntax_dateTimeToUUIDv7, arguments_dateTimeToUUIDv7, {}, returned_value_dateTimeToUUIDv7, examples_dateTimeToUUIDv7, introduced_in_dateTimeToUUIDv7, category_dateTimeToUUIDv7};
+    FunctionDocumentation::IntroducedIn introduced_in = {25, 9};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::UUID;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
-    factory.registerFunction<FunctionDateTimeToUUIDv7>(documentation_dateTimeToUUIDv7);
+    factory.registerFunction<FunctionDateTimeToUUIDv7>(documentation);
 
 }
 }

--- a/src/Functions/defaultValueOfArgumentType.cpp
+++ b/src/Functions/defaultValueOfArgumentType.cpp
@@ -59,16 +59,16 @@ public:
 
 REGISTER_FUNCTION(DefaultValueOfArgumentType)
 {
-    FunctionDocumentation::Description description_defaultValueOfArgumentType = R"(
+    FunctionDocumentation::Description description = R"(
 Returns the default value for a given data type.
 Does not include default values for custom columns set by the user.
 )";
-    FunctionDocumentation::Syntax syntax_defaultValueOfArgumentType = "defaultValueOfArgumentType(expression)";
-    FunctionDocumentation::Arguments arguments_defaultValueOfArgumentType = {
+    FunctionDocumentation::Syntax syntax = "defaultValueOfArgumentType(expression)";
+    FunctionDocumentation::Arguments arguments = {
         {"expression", "Arbitrary type of value or an expression that results in a value of an arbitrary type.", {"Any"}}
     };
-    FunctionDocumentation::ReturnedValue returned_value_defaultValueOfArgumentType = {"Returns `0` for numbers, an empty string for strings or `NULL` for Nullable types.", {"UInt8", "String", "NULL"}};
-    FunctionDocumentation::Examples examples_defaultValueOfArgumentType = {
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns `0` for numbers, an empty string for strings or `NULL` for Nullable types.", {"UInt8", "String", "NULL"}};
+    FunctionDocumentation::Examples examples = {
     {
         "Usage example",
         R"(
@@ -92,11 +92,11 @@ SELECT defaultValueOfArgumentType(CAST(1 AS Nullable(Int8)));
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in_defaultValueOfArgumentType = {1, 1};
-    FunctionDocumentation::Category category_defaultValueOfArgumentType = FunctionDocumentation::Category::Other;
-    FunctionDocumentation documentation_defaultValueOfArgumentType = {description_defaultValueOfArgumentType, syntax_defaultValueOfArgumentType, arguments_defaultValueOfArgumentType, {}, returned_value_defaultValueOfArgumentType, examples_defaultValueOfArgumentType, introduced_in_defaultValueOfArgumentType, category_defaultValueOfArgumentType};
+    FunctionDocumentation::IntroducedIn introduced_in = {1, 1};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Other;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
-    factory.registerFunction<FunctionDefaultValueOfArgumentType>(documentation_defaultValueOfArgumentType);
+    factory.registerFunction<FunctionDefaultValueOfArgumentType>(documentation);
 }
 
 }

--- a/src/Functions/defaultValueOfTypeName.cpp
+++ b/src/Functions/defaultValueOfTypeName.cpp
@@ -66,15 +66,15 @@ public:
 
 REGISTER_FUNCTION(DefaultValueOfTypeName)
 {
-    FunctionDocumentation::Description description_defaultValueOfTypeName = R"(
+    FunctionDocumentation::Description description = R"(
 Returns the default value for the given type name.
     )";
-    FunctionDocumentation::Syntax syntax_defaultValueOfTypeName = "defaultValueOfTypeName(type)";
-    FunctionDocumentation::Arguments arguments_defaultValueOfTypeName = {
+    FunctionDocumentation::Syntax syntax = "defaultValueOfTypeName(type)";
+    FunctionDocumentation::Arguments arguments = {
         {"type", "A string representing a type name.", {"String"}}
     };
-    FunctionDocumentation::ReturnedValue returned_value_defaultValueOfTypeName = {"Returns the default value for the given type name: `0` for numbers, an empty string for strings, or `NULL` for Nullable", {"UInt8", "String", "NULL"}};
-    FunctionDocumentation::Examples examples_defaultValueOfTypeName = {
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the default value for the given type name: `0` for numbers, an empty string for strings, or `NULL` for Nullable", {"UInt8", "String", "NULL"}};
+    FunctionDocumentation::Examples examples = {
     {
         "Usage example",
         R"(
@@ -98,11 +98,11 @@ SELECT defaultValueOfTypeName('Nullable(Int8)');
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in_defaultValueOfTypeName = {1, 1};
-    FunctionDocumentation::Category category_defaultValueOfTypeName = FunctionDocumentation::Category::Other;
-    FunctionDocumentation documentation_defaultValueOfTypeName = {description_defaultValueOfTypeName, syntax_defaultValueOfTypeName, arguments_defaultValueOfTypeName, {}, returned_value_defaultValueOfTypeName, examples_defaultValueOfTypeName, introduced_in_defaultValueOfTypeName, category_defaultValueOfTypeName};
+    FunctionDocumentation::IntroducedIn introduced_in = {1, 1};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Other;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
-    factory.registerFunction<FunctionDefaultValueOfTypeName>(documentation_defaultValueOfTypeName);
+    factory.registerFunction<FunctionDefaultValueOfTypeName>(documentation);
 }
 
 }

--- a/src/Functions/dumpColumnStructure.cpp
+++ b/src/Functions/dumpColumnStructure.cpp
@@ -57,15 +57,15 @@ public:
 
 REGISTER_FUNCTION(DumpColumnStructure)
 {
-    FunctionDocumentation::Description description_dumpColumnStructure = R"(
+    FunctionDocumentation::Description description = R"(
 Outputs a detailed description of the internal structure of a column and its data type.
 )";
-    FunctionDocumentation::Syntax syntax_dumpColumnStructure = "dumpColumnStructure(x)";
-    FunctionDocumentation::Arguments arguments_dumpColumnStructure = {
+    FunctionDocumentation::Syntax syntax = "dumpColumnStructure(x)";
+    FunctionDocumentation::Arguments arguments = {
         {"x", "Value for which to get the description of.", {"Any"}}
     };
-    FunctionDocumentation::ReturnedValue returned_value_dumpColumnStructure = {"Returns a description of the column structure used for representing the value.", {"String"}};
-    FunctionDocumentation::Examples examples_dumpColumnStructure = {
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns a description of the column structure used for representing the value.", {"String"}};
+    FunctionDocumentation::Examples examples = {
     {
         "Usage example",
         R"(
@@ -78,11 +78,11 @@ SELECT dumpColumnStructure(CAST('2018-01-01 01:02:03', 'DateTime'));
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in_dumpColumnStructure = {1, 1};
-    FunctionDocumentation::Category category_dumpColumnStructure = FunctionDocumentation::Category::Other;
-    FunctionDocumentation documentation_dumpColumnStructure = {description_dumpColumnStructure, syntax_dumpColumnStructure, arguments_dumpColumnStructure, {}, returned_value_dumpColumnStructure, examples_dumpColumnStructure, introduced_in_dumpColumnStructure, category_dumpColumnStructure};
+    FunctionDocumentation::IntroducedIn introduced_in = {1, 1};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Other;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
-    factory.registerFunction<FunctionDumpColumnStructure>(documentation_dumpColumnStructure);
+    factory.registerFunction<FunctionDumpColumnStructure>(documentation);
 }
 
 }

--- a/src/Functions/dynamicElement.cpp
+++ b/src/Functions/dynamicElement.cpp
@@ -139,25 +139,25 @@ private:
 
 REGISTER_FUNCTION(DynamicElement)
 {
-    FunctionDocumentation::Description dynamicElement_description = R"(
+    FunctionDocumentation::Description description = R"(
 Extracts a column with specified type from a `Dynamic` column.
 
 This function allows you to extract values of a specific type from a Dynamic column. If a row contains a value
 of the requested type, it returns that value. If the row contains a different type or NULL, it returns NULL
 for scalar types or an empty array for array types.
     )";
-    FunctionDocumentation::Syntax dynamicElement_syntax = "dynamicElement(dynamic, type_name)";
-    FunctionDocumentation::Arguments dynamicElement_arguments =
+    FunctionDocumentation::Syntax syntax = "dynamicElement(dynamic, type_name)";
+    FunctionDocumentation::Arguments arguments =
     {
         {"dynamic", "Dynamic column to extract from.", {"Dynamic"}},
         {"type_name", "The name of the variant type to extract (e.g., 'String', 'Int64', 'Array(Int64)')."}
     };
-    FunctionDocumentation::ReturnedValue dynamicElement_returned_value =
+    FunctionDocumentation::ReturnedValue returned_value =
     {
         "Returns values of the specified type from the Dynamic column. Returns NULL for non-matching types (or empty array for array types).",
         {"Any"}
     };
-    FunctionDocumentation::Examples dynamicElement_examples =
+    FunctionDocumentation::Examples examples =
     {
     {
         "Extracting different types from Dynamic column",
@@ -176,11 +176,11 @@ SELECT d, dynamicType(d), dynamicElement(d, 'String'), dynamicElement(d, 'Int64'
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn dynamicElement_introduced_in = {24, 1};
-    FunctionDocumentation::Category dynamicElement_category = FunctionDocumentation::Category::JSON;
-    FunctionDocumentation dynamicElement_documentation = {dynamicElement_description, dynamicElement_syntax, dynamicElement_arguments, {}, dynamicElement_returned_value, dynamicElement_examples, dynamicElement_introduced_in, dynamicElement_category};
+    FunctionDocumentation::IntroducedIn introduced_in = {24, 1};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::JSON;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
-    factory.registerFunction<FunctionDynamicElement>(dynamicElement_documentation);
+    factory.registerFunction<FunctionDynamicElement>(documentation);
 }
 
 }

--- a/src/Functions/errorCodeToName.cpp
+++ b/src/Functions/errorCodeToName.cpp
@@ -57,16 +57,16 @@ public:
 
 REGISTER_FUNCTION(ErrorCodeToName)
 {
-    FunctionDocumentation::Description description_errorCodeToName = R"(
+    FunctionDocumentation::Description description = R"(
 Returns the textual name of a numeric ClickHouse error code.
 The mapping from numeric error codes to error names is available [here](https://github.com/ClickHouse/ClickHouse/blob/master/src/Common/ErrorCodes.cpp).
 )";
-    FunctionDocumentation::Syntax syntax_errorCodeToName = "errorCodeToName(error_code)";
-    FunctionDocumentation::Arguments arguments_errorCodeToName = {
+    FunctionDocumentation::Syntax syntax = "errorCodeToName(error_code)";
+    FunctionDocumentation::Arguments arguments = {
         {"error_code", "ClickHouse error code.", {"(U)Int*", "Float*", "Decimal"}}
     };
-    FunctionDocumentation::ReturnedValue returned_value_errorCodeToName = {"Returns the textual name of `error_code`.", {"String"}};
-    FunctionDocumentation::Examples examples_errorCodeToName = {
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the textual name of `error_code`.", {"String"}};
+    FunctionDocumentation::Examples examples = {
     {
         "Usage example",
         R"(
@@ -79,11 +79,11 @@ SELECT errorCodeToName(252);
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in_errorCodeToName = {20, 12};
-    FunctionDocumentation::Category category_errorCodeToName = FunctionDocumentation::Category::Other;
-    FunctionDocumentation documentation_errorCodeToName = {description_errorCodeToName, syntax_errorCodeToName, arguments_errorCodeToName, {}, returned_value_errorCodeToName, examples_errorCodeToName, introduced_in_errorCodeToName, category_errorCodeToName};
+    FunctionDocumentation::IntroducedIn introduced_in = {20, 12};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Other;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
-    factory.registerFunction<FunctionErrorCodeToName>(documentation_errorCodeToName);
+    factory.registerFunction<FunctionErrorCodeToName>(documentation);
 }
 
 }

--- a/src/Functions/finalizeAggregation.cpp
+++ b/src/Functions/finalizeAggregation.cpp
@@ -73,15 +73,15 @@ public:
 
 REGISTER_FUNCTION(FinalizeAggregation)
 {
-    FunctionDocumentation::Description description_finalizeAggregation = R"(
+    FunctionDocumentation::Description description = R"(
 Given an aggregation state, this function returns the result of aggregation (or the finalized state when using a [-State](../../sql-reference/aggregate-functions/combinators.md#-state) combinator).
 )";
-    FunctionDocumentation::Syntax syntax_finalizeAggregation = "finalizeAggregation(state)";
-    FunctionDocumentation::Arguments arguments_finalizeAggregation = {
+    FunctionDocumentation::Syntax syntax = "finalizeAggregation(state)";
+    FunctionDocumentation::Arguments arguments = {
         {"state", "State of aggregation.", {"AggregateFunction"}}
     };
-    FunctionDocumentation::ReturnedValue returned_value_finalizeAggregation = {"Returns the finalized result of aggregation.", {"Any"}};
-    FunctionDocumentation::Examples examples_finalizeAggregation = {
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the finalized result of aggregation.", {"Any"}};
+    FunctionDocumentation::Examples examples = {
     {
         "Usage example",
         R"(
@@ -114,11 +114,11 @@ FROM numbers(5);
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in_finalizeAggregation = {1, 1};
-    FunctionDocumentation::Category category_finalizeAggregation = FunctionDocumentation::Category::Other;
-    FunctionDocumentation documentation_finalizeAggregation = {description_finalizeAggregation, syntax_finalizeAggregation, arguments_finalizeAggregation, {}, returned_value_finalizeAggregation, examples_finalizeAggregation, introduced_in_finalizeAggregation, category_finalizeAggregation};
+    FunctionDocumentation::IntroducedIn introduced_in = {1, 1};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Other;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
-    factory.registerFunction<FunctionFinalizeAggregation>(documentation_finalizeAggregation);
+    factory.registerFunction<FunctionFinalizeAggregation>(documentation);
 }
 
 }

--- a/src/Functions/fromUnixTimestamp64Micro.cpp
+++ b/src/Functions/fromUnixTimestamp64Micro.cpp
@@ -7,18 +7,18 @@ namespace DB
 REGISTER_FUNCTION(FromUnixTimestamp64Micro)
 {
     /// fromUnixTimestamp64Micro documentation
-    FunctionDocumentation::Description description_fromUnixTimestamp64Micro = R"(
+    FunctionDocumentation::Description description = R"(
 Converts a Unix timestamp in microseconds to a `DateTime64` value with microsecond precision.
 
 The input value is treated as a Unix timestamp with microsecond precision (number of microseconds since 1970-01-01 00:00:00 UTC).
     )";
-    FunctionDocumentation::Syntax syntax_fromUnixTimestamp64Micro = "fromUnixTimestamp64Micro(value[, timezone])";
-    FunctionDocumentation::Arguments arguments_fromUnixTimestamp64Micro = {
+    FunctionDocumentation::Syntax syntax = "fromUnixTimestamp64Micro(value[, timezone])";
+    FunctionDocumentation::Arguments arguments = {
         {"value", "Unix timestamp in microseconds.", {"Int64"}},
         {"timezone", "Optional. Timezone for the returned value.", {"String"}}
     };
-    FunctionDocumentation::ReturnedValue returned_value_fromUnixTimestamp64Micro = {"Returns a `DateTime64` value with microsecond precision.", {"DateTime64(6)"}};
-    FunctionDocumentation::Examples examples_fromUnixTimestamp64Micro = {
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns a `DateTime64` value with microsecond precision.", {"DateTime64(6)"}};
+    FunctionDocumentation::Examples examples = {
     {
         "Usage example",
         R"(
@@ -31,12 +31,12 @@ SELECT fromUnixTimestamp64Micro(1640995200123456)
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in_fromUnixTimestamp64Micro = {20, 5};
-    FunctionDocumentation::Category category_fromUnixTimestamp64Micro = FunctionDocumentation::Category::TypeConversion;
-    FunctionDocumentation documentation_fromUnixTimestamp64Micro = {description_fromUnixTimestamp64Micro, syntax_fromUnixTimestamp64Micro, arguments_fromUnixTimestamp64Micro, {}, returned_value_fromUnixTimestamp64Micro, examples_fromUnixTimestamp64Micro, introduced_in_fromUnixTimestamp64Micro, category_fromUnixTimestamp64Micro};
+    FunctionDocumentation::IntroducedIn introduced_in = {20, 5};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::TypeConversion;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
     factory.registerFunction("fromUnixTimestamp64Micro",
-        [](ContextPtr context){ return std::make_shared<FunctionFromUnixTimestamp64>(6, "fromUnixTimestamp64Micro", context); }, documentation_fromUnixTimestamp64Micro);
+        [](ContextPtr context){ return std::make_shared<FunctionFromUnixTimestamp64>(6, "fromUnixTimestamp64Micro", context); }, documentation);
 }
 
 }

--- a/src/Functions/fromUnixTimestamp64Milli.cpp
+++ b/src/Functions/fromUnixTimestamp64Milli.cpp
@@ -7,18 +7,18 @@ namespace DB
 REGISTER_FUNCTION(FromUnixTimestamp64Milli)
 {
     /// fromUnixTimestamp64Milli documentation
-    FunctionDocumentation::Description description_fromUnixTimestamp64Milli = R"(
+    FunctionDocumentation::Description description = R"(
 Converts a Unix timestamp in milliseconds to a `DateTime64` value with millisecond precision.
 
 The input value is treated as a Unix timestamp with millisecond precision (number of milliseconds since 1970-01-01 00:00:00 UTC).
     )";
-    FunctionDocumentation::Syntax syntax_fromUnixTimestamp64Milli = "fromUnixTimestamp64Milli(value[, timezone])";
-    FunctionDocumentation::Arguments arguments_fromUnixTimestamp64Milli = {
+    FunctionDocumentation::Syntax syntax = "fromUnixTimestamp64Milli(value[, timezone])";
+    FunctionDocumentation::Arguments arguments = {
         {"value", "Unix timestamp in milliseconds.", {"Int64"}},
         {"timezone", "Optional. Timezone for the returned value.", {"String"}}
     };
-    FunctionDocumentation::ReturnedValue returned_value_fromUnixTimestamp64Milli = {"A `DateTime64` value with millisecond precision.", {"DateTime64(3)"}};
-    FunctionDocumentation::Examples examples_fromUnixTimestamp64Milli = {
+    FunctionDocumentation::ReturnedValue returned_value = {"A `DateTime64` value with millisecond precision.", {"DateTime64(3)"}};
+    FunctionDocumentation::Examples examples = {
     {
         "Usage example",
         R"(
@@ -31,12 +31,12 @@ SELECT fromUnixTimestamp64Milli(1640995200123)
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in_fromUnixTimestamp64Milli = {20, 5};
-    FunctionDocumentation::Category category_fromUnixTimestamp64Milli = FunctionDocumentation::Category::TypeConversion;
-    FunctionDocumentation documentation_fromUnixTimestamp64Milli = {description_fromUnixTimestamp64Milli, syntax_fromUnixTimestamp64Milli, arguments_fromUnixTimestamp64Milli, {}, returned_value_fromUnixTimestamp64Milli, examples_fromUnixTimestamp64Milli, introduced_in_fromUnixTimestamp64Milli, category_fromUnixTimestamp64Milli};
+    FunctionDocumentation::IntroducedIn introduced_in = {20, 5};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::TypeConversion;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
     factory.registerFunction("fromUnixTimestamp64Milli",
-        [](ContextPtr context){ return std::make_shared<FunctionFromUnixTimestamp64>(3, "fromUnixTimestamp64Milli", context); }, documentation_fromUnixTimestamp64Milli);
+        [](ContextPtr context){ return std::make_shared<FunctionFromUnixTimestamp64>(3, "fromUnixTimestamp64Milli", context); }, documentation);
 }
 
 }

--- a/src/Functions/fromUnixTimestamp64Nano.cpp
+++ b/src/Functions/fromUnixTimestamp64Nano.cpp
@@ -7,7 +7,7 @@ namespace DB
 REGISTER_FUNCTION(FromUnixTimestamp64Nano)
 {
     /// fromUnixTimestamp64Nano documentation
-    FunctionDocumentation::Description description_fromUnixTimestamp64Nano = R"(
+    FunctionDocumentation::Description description = R"(
 Converts a Unix timestamp in nanoseconds to a [`DateTime64`](/sql-reference/data-types/datetime64) value with nanosecond precision.
 
 The input value is treated as a Unix timestamp with nanosecond precision (number of nanoseconds since 1970-01-01 00:00:00 UTC).
@@ -16,13 +16,13 @@ The input value is treated as a Unix timestamp with nanosecond precision (number
 Please note that the input value is treated as a UTC timestamp, not the timezone of the input value.
 :::
     )";
-    FunctionDocumentation::Syntax syntax_fromUnixTimestamp64Nano = "fromUnixTimestamp64Nano(value[, timezone])";
-    FunctionDocumentation::Arguments arguments_fromUnixTimestamp64Nano = {
+    FunctionDocumentation::Syntax syntax = "fromUnixTimestamp64Nano(value[, timezone])";
+    FunctionDocumentation::Arguments arguments = {
         {"value", "Unix timestamp in nanoseconds.", {"Int64"}},
         {"timezone", "Optional. Timezone for the returned value.", {"String"}}
     };
-    FunctionDocumentation::ReturnedValue returned_value_fromUnixTimestamp64Nano = {"Returns a `DateTime64` value with nanosecond precision.", {"DateTime64(9)"}};
-    FunctionDocumentation::Examples examples_fromUnixTimestamp64Nano = {
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns a `DateTime64` value with nanosecond precision.", {"DateTime64(9)"}};
+    FunctionDocumentation::Examples examples = {
     {
         "Usage example",
         R"(
@@ -35,12 +35,12 @@ SELECT fromUnixTimestamp64Nano(1640995200123456789)
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in_fromUnixTimestamp64Nano = {20, 5};
-    FunctionDocumentation::Category category_fromUnixTimestamp64Nano = FunctionDocumentation::Category::TypeConversion;
-    FunctionDocumentation documentation_fromUnixTimestamp64Nano = {description_fromUnixTimestamp64Nano, syntax_fromUnixTimestamp64Nano, arguments_fromUnixTimestamp64Nano, {}, returned_value_fromUnixTimestamp64Nano, examples_fromUnixTimestamp64Nano, introduced_in_fromUnixTimestamp64Nano, category_fromUnixTimestamp64Nano};
+    FunctionDocumentation::IntroducedIn introduced_in = {20, 5};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::TypeConversion;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
     factory.registerFunction("fromUnixTimestamp64Nano",
-        [](ContextPtr context){ return std::make_shared<FunctionFromUnixTimestamp64>(9, "fromUnixTimestamp64Nano", context); }, documentation_fromUnixTimestamp64Nano);
+        [](ContextPtr context){ return std::make_shared<FunctionFromUnixTimestamp64>(9, "fromUnixTimestamp64Nano", context); }, documentation);
 }
 
 }

--- a/src/Functions/fromUnixTimestamp64Second.cpp
+++ b/src/Functions/fromUnixTimestamp64Second.cpp
@@ -7,18 +7,18 @@ namespace DB
 REGISTER_FUNCTION(FromUnixTimestamp64)
 {
     /// fromUnixTimestamp64Second documentation
-    FunctionDocumentation::Description description_fromUnixTimestamp64Second = R"(
+    FunctionDocumentation::Description description = R"(
 Converts a Unix timestamp in seconds to a `DateTime64` value with second precision.
 
 The input value is treated as a Unix timestamp with second precision (number of seconds since 1970-01-01 00:00:00 UTC).
     )";
-    FunctionDocumentation::Syntax syntax_fromUnixTimestamp64Second = "fromUnixTimestamp64Second(value[, timezone])";
-    FunctionDocumentation::Arguments arguments_fromUnixTimestamp64Second = {
+    FunctionDocumentation::Syntax syntax = "fromUnixTimestamp64Second(value[, timezone])";
+    FunctionDocumentation::Arguments arguments = {
         {"value", "Unix timestamp in seconds.", {"Int64"}},
         {"timezone", "Optional. Timezone for the returned value.", {"String"}}
     };
-    FunctionDocumentation::ReturnedValue returned_value_fromUnixTimestamp64Second = {"Returns a `DateTime64` value with second precision.", {"DateTime64(0)"}};
-    FunctionDocumentation::Examples examples_fromUnixTimestamp64Second = {
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns a `DateTime64` value with second precision.", {"DateTime64(0)"}};
+    FunctionDocumentation::Examples examples = {
     {
         "Usage example",
         R"(
@@ -31,12 +31,12 @@ SELECT fromUnixTimestamp64Second(1640995200)
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in_fromUnixTimestamp64Second = {24, 12};
-    FunctionDocumentation::Category category_fromUnixTimestamp64Second = FunctionDocumentation::Category::TypeConversion;
-    FunctionDocumentation documentation_fromUnixTimestamp64Second = {description_fromUnixTimestamp64Second, syntax_fromUnixTimestamp64Second, arguments_fromUnixTimestamp64Second, {}, returned_value_fromUnixTimestamp64Second, examples_fromUnixTimestamp64Second, introduced_in_fromUnixTimestamp64Second, category_fromUnixTimestamp64Second};
+    FunctionDocumentation::IntroducedIn introduced_in = {24, 12};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::TypeConversion;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
     factory.registerFunction("fromUnixTimestamp64Second",
-        [](ContextPtr context){ return std::make_shared<FunctionFromUnixTimestamp64>(0, "fromUnixTimestamp64Second", context); }, documentation_fromUnixTimestamp64Second);
+        [](ContextPtr context){ return std::make_shared<FunctionFromUnixTimestamp64>(0, "fromUnixTimestamp64Second", context); }, documentation);
 }
 
 }

--- a/src/Functions/generateSnowflakeID.cpp
+++ b/src/Functions/generateSnowflakeID.cpp
@@ -224,20 +224,20 @@ public:
 REGISTER_FUNCTION(GenerateSnowflakeID)
 {
     /// generateSnowflakeID documentation
-    FunctionDocumentation::Description description_generateSnowflakeID = R"(
+    FunctionDocumentation::Description description = R"(
 Generates a [Snowflake ID](https://en.wikipedia.org/wiki/Snowflake_ID).
 
 Function `generateSnowflakeID` guarantees that the counter field within a timestamp increments monotonically across all function invocations in concurrently running threads and queries.
 
 See section ["Snowflake ID generation"](#snowflake-id-generation) for implementation details.
     )";
-    FunctionDocumentation::Syntax syntax_generateSnowflakeID = "generateSnowflakeID([expr, [machine_id]])";
-    FunctionDocumentation::Arguments arguments_generateSnowflakeID = {
+    FunctionDocumentation::Syntax syntax = "generateSnowflakeID([expr, [machine_id]])";
+    FunctionDocumentation::Arguments arguments = {
         {"expr", "An arbitrary [expression](/sql-reference/syntax#expressions) used to bypass [common subexpression elimination](/sql-reference/functions/overview#common-subexpression-elimination) if the function is called multiple times in a query. The value of the expression has no effect on the returned Snowflake ID. Optional."},
         {"machine_id", "A machine ID, the lowest 10 bits are used. [Int64](../data-types/int-uint.md). Optional."}
     };
-    FunctionDocumentation::ReturnedValue returned_value_generateSnowflakeID = {"Returns the Snowflake ID.", {"UInt64"}};
-    FunctionDocumentation::Examples examples_generateSnowflakeID = {
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the Snowflake ID.", {"UInt64"}};
+    FunctionDocumentation::Examples examples = {
     {
         "Usage example",
         R"(
@@ -278,11 +278,11 @@ SELECT generateSnowflakeID('expr', 1);
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in_generateSnowflakeID = {24, 6};
-    FunctionDocumentation::Category category_generateSnowflakeID = FunctionDocumentation::Category::UUID;
-    FunctionDocumentation documentation_generateSnowflakeID = {description_generateSnowflakeID, syntax_generateSnowflakeID, arguments_generateSnowflakeID, {}, returned_value_generateSnowflakeID, examples_generateSnowflakeID, introduced_in_generateSnowflakeID, category_generateSnowflakeID};
+    FunctionDocumentation::IntroducedIn introduced_in = {24, 6};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::UUID;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
-    factory.registerFunction<FunctionGenerateSnowflakeID>(documentation_generateSnowflakeID);
+    factory.registerFunction<FunctionGenerateSnowflakeID>(documentation);
 
 }
 

--- a/src/Functions/generateULID.cpp
+++ b/src/Functions/generateULID.cpp
@@ -75,15 +75,15 @@ public:
 REGISTER_FUNCTION(GenerateULID)
 {
     /// generateULID documentation
-    FunctionDocumentation::Description description_generateULID = R"(
+    FunctionDocumentation::Description description = R"(
 Generates a [Universally Unique Lexicographically Sortable Identifier (ULID)](https://github.com/ulid/spec).
     )";
-    FunctionDocumentation::Syntax syntax_generateULID = "generateULID([x])";
-    FunctionDocumentation::Arguments arguments_generateULID = {
+    FunctionDocumentation::Syntax syntax = "generateULID([x])";
+    FunctionDocumentation::Arguments arguments = {
         {"x", "Optional. An expression resulting in any of the supported data types. The resulting value is discarded, but the expression itself if used for bypassing [common subexpression elimination](/sql-reference/functions/overview#common-subexpression-elimination) if the function is called multiple times in one query.", {"Any"}}
     };
-    FunctionDocumentation::ReturnedValue returned_value_generateULID = {"Returns a ULID.", {"FixedString(26)"}};
-    FunctionDocumentation::Examples examples_generateULID = {
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns a ULID.", {"FixedString(26)"}};
+    FunctionDocumentation::Examples examples = {
     {
         "Usage example",
         R"(
@@ -107,11 +107,11 @@ SELECT generateULID(1), generateULID(2)
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in_generateULID = {23, 2};
-    FunctionDocumentation::Category category_generateULID = FunctionDocumentation::Category::ULID;
-    FunctionDocumentation documentation_generateULID = {description_generateULID, syntax_generateULID, arguments_generateULID, {}, returned_value_generateULID, examples_generateULID, introduced_in_generateULID, category_generateULID};
+    FunctionDocumentation::IntroducedIn introduced_in = {23, 2};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::ULID;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
-    factory.registerFunction<FunctionGenerateULID>(documentation_generateULID);
+    factory.registerFunction<FunctionGenerateULID>(documentation);
 }
 
 }

--- a/src/Functions/generateUUIDv4.cpp
+++ b/src/Functions/generateUUIDv4.cpp
@@ -94,13 +94,13 @@ private:
 REGISTER_FUNCTION(GenerateUUIDv4)
 {
     /// generateUUIDv4 documentation
-    FunctionDocumentation::Description description_generateUUIDv4 = R"(Generates a [version 4](https://tools.ietf.org/html/rfc4122#section-4.4) [UUID](../data-types/uuid.md).)";
-    FunctionDocumentation::Syntax syntax_generateUUIDv4 = "generateUUIDv4([expr])";
-    FunctionDocumentation::Arguments arguments_generateUUIDv4 = {
+    FunctionDocumentation::Description description = R"(Generates a [version 4](https://tools.ietf.org/html/rfc4122#section-4.4) [UUID](../data-types/uuid.md).)";
+    FunctionDocumentation::Syntax syntax = "generateUUIDv4([expr])";
+    FunctionDocumentation::Arguments arguments = {
         {"expr", "Optional. An arbitrary expression used to bypass [common subexpression elimination](/sql-reference/functions/overview#common-subexpression-elimination) if the function is called multiple times in a query. The value of the expression has no effect on the returned UUID."}
     };
-    FunctionDocumentation::ReturnedValue returned_value_generateUUIDv4 = {"Returns a UUIDv4.", {"UUID"}};
-    FunctionDocumentation::Examples examples_generateUUIDv4 = {
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns a UUIDv4.", {"UUID"}};
+    FunctionDocumentation::Examples examples = {
     {
         "Usage example",
         R"(
@@ -126,11 +126,11 @@ SELECT generateUUIDv4(1), generateUUIDv4(1);
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in_generateUUIDv4 = {1, 1};
-    FunctionDocumentation::Category category_generateUUIDv4 = FunctionDocumentation::Category::UUID;
-    FunctionDocumentation documentation_generateUUIDv4 = {description_generateUUIDv4, syntax_generateUUIDv4, arguments_generateUUIDv4, {}, returned_value_generateUUIDv4, examples_generateUUIDv4, introduced_in_generateUUIDv4, category_generateUUIDv4};
+    FunctionDocumentation::IntroducedIn introduced_in = {1, 1};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::UUID;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
-    factory.registerFunction<FunctionGenerateUUIDv4>(documentation_generateUUIDv4);
+    factory.registerFunction<FunctionGenerateUUIDv4>(documentation);
 }
 
 }

--- a/src/Functions/generateUUIDv7.cpp
+++ b/src/Functions/generateUUIDv7.cpp
@@ -110,7 +110,7 @@ private:
 REGISTER_FUNCTION(GenerateUUIDv7)
 {
     /// generateUUIDv7 documentation
-    FunctionDocumentation::Description description_generateUUIDv7 = R"(
+    FunctionDocumentation::Description description = R"(
 Generates a [version 7](https://datatracker.ietf.org/doc/html/draft-peabody-dispatch-new-uuid-format-04) [UUID](../data-types/uuid.md).
 
 See section ["UUIDv7 generation"](#uuidv7-generation) for details on UUID structure, counter management, and concurrency guarantees.
@@ -119,12 +119,12 @@ See section ["UUIDv7 generation"](#uuidv7-generation) for details on UUID struct
 As of September 2025, version 7 UUIDs are in draft status and their layout may change in future.
 :::
     )";
-    FunctionDocumentation::Syntax syntax_generateUUIDv7 = "generateUUIDv7([expr])";
-    FunctionDocumentation::Arguments arguments_generateUUIDv7 = {
+    FunctionDocumentation::Syntax syntax = "generateUUIDv7([expr])";
+    FunctionDocumentation::Arguments arguments = {
         {"expr", "Optional. An arbitrary expression used to bypass [common subexpression elimination](/sql-reference/functions/overview#common-subexpression-elimination) if the function is called multiple times in a query. The value of the expression has no effect on the returned UUID.", {"Any"}}
     };
-    FunctionDocumentation::ReturnedValue returned_value_generateUUIDv7 = {"Returns a UUIDv7.", {"UUID"}};
-    FunctionDocumentation::Examples examples_generateUUIDv7 = {
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns a UUIDv7.", {"UUID"}};
+    FunctionDocumentation::Examples examples = {
     {
         "Usage example",
         R"(
@@ -150,11 +150,11 @@ SELECT generateUUIDv7(1), generateUUIDv7(1);
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in_generateUUIDv7 = {24, 5};
-    FunctionDocumentation::Category category_generateUUIDv7 = FunctionDocumentation::Category::UUID;
-    FunctionDocumentation documentation_generateUUIDv7 = {description_generateUUIDv7, syntax_generateUUIDv7, arguments_generateUUIDv7, {}, returned_value_generateUUIDv7, examples_generateUUIDv7, introduced_in_generateUUIDv7, category_generateUUIDv7};
+    FunctionDocumentation::IntroducedIn introduced_in = {24, 5};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::UUID;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
-    factory.registerFunction<FunctionGenerateUUIDv7Base>(documentation_generateUUIDv7);
+    factory.registerFunction<FunctionGenerateUUIDv7Base>(documentation);
 }
 }
 }

--- a/src/Functions/getServerPort.cpp
+++ b/src/Functions/getServerPort.cpp
@@ -133,15 +133,15 @@ private:
 
 REGISTER_FUNCTION(GetServerPort)
 {
-    FunctionDocumentation::Description description_getServerPort = R"(
+    FunctionDocumentation::Description description = R"(
 Returns the server's port number for a given protocol.
     )";
-    FunctionDocumentation::Syntax syntax_getServerPort = "getServerPort(port_name)";
-    FunctionDocumentation::Arguments arguments_getServerPort = {
+    FunctionDocumentation::Syntax syntax = "getServerPort(port_name)";
+    FunctionDocumentation::Arguments arguments = {
         {"port_name", "The name of the port.", {"String"}}
     };
-    FunctionDocumentation::ReturnedValue returned_value_getServerPort = {"Returns the server port number.", {"UInt16"}};
-    FunctionDocumentation::Examples examples_getServerPort = {
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the server port number.", {"UInt16"}};
+    FunctionDocumentation::Examples examples = {
     {
         "Usage example",
         R"(
@@ -154,11 +154,11 @@ SELECT getServerPort('tcp_port');
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in_getServerPort = {21, 10};
-    FunctionDocumentation::Category category_getServerPort = FunctionDocumentation::Category::Other;
-    FunctionDocumentation documentation_getServerPort = {description_getServerPort, syntax_getServerPort, arguments_getServerPort, {}, returned_value_getServerPort, examples_getServerPort, introduced_in_getServerPort, category_getServerPort};
+    FunctionDocumentation::IntroducedIn introduced_in = {21, 10};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Other;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
-    factory.registerFunction<GetServerPortOverloadResolver>(documentation_getServerPort);
+    factory.registerFunction<GetServerPortOverloadResolver>(documentation);
 }
 
 }

--- a/src/Functions/getSizeOfEnumType.cpp
+++ b/src/Functions/getSizeOfEnumType.cpp
@@ -77,15 +77,15 @@ private:
 
 REGISTER_FUNCTION(GetSizeOfEnumType)
 {
-    FunctionDocumentation::Description description_getSizeOfEnumType = R"(
+    FunctionDocumentation::Description description = R"(
 Returns the number of fields in the given [`Enum`](../../sql-reference/data-types/enum.md).
 )";
-    FunctionDocumentation::Syntax syntax_getSizeOfEnumType = "getSizeOfEnumType(x)";
-    FunctionDocumentation::Arguments arguments_getSizeOfEnumType = {
+    FunctionDocumentation::Syntax syntax = "getSizeOfEnumType(x)";
+    FunctionDocumentation::Arguments arguments = {
         {"x", "Value of type `Enum`.", {"Enum"}}
     };
-    FunctionDocumentation::ReturnedValue returned_value_getSizeOfEnumType = {"Returns the number of fields with `Enum` input values.", {"UInt8/16"}};
-    FunctionDocumentation::Examples examples_getSizeOfEnumType = {
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the number of fields with `Enum` input values.", {"UInt8/16"}};
+    FunctionDocumentation::Examples examples = {
     {
         "Usage example",
         R"(
@@ -98,11 +98,11 @@ SELECT getSizeOfEnumType(CAST('a' AS Enum8('a' = 1, 'b' = 2))) AS x;
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in_getSizeOfEnumType = {1, 1};
-    FunctionDocumentation::Category category_getSizeOfEnumType = FunctionDocumentation::Category::Other;
-    FunctionDocumentation documentation_getSizeOfEnumType = {description_getSizeOfEnumType, syntax_getSizeOfEnumType, arguments_getSizeOfEnumType, {}, returned_value_getSizeOfEnumType, examples_getSizeOfEnumType, introduced_in_getSizeOfEnumType, category_getSizeOfEnumType};
+    FunctionDocumentation::IntroducedIn introduced_in = {1, 1};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Other;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
-    factory.registerFunction<FunctionGetSizeOfEnumType>(documentation_getSizeOfEnumType);
+    factory.registerFunction<FunctionGetSizeOfEnumType>(documentation);
 }
 
 }

--- a/src/Functions/indexHint.cpp
+++ b/src/Functions/indexHint.cpp
@@ -8,7 +8,7 @@ namespace DB
 
 REGISTER_FUNCTION(IndexHint)
 {
-    FunctionDocumentation::Description description_indexHint = R"(
+    FunctionDocumentation::Description description = R"(
 This function is intended for debugging and introspection.
 It ignores its argument and always returns 1.
 The arguments are not evaluated.
@@ -52,12 +52,12 @@ It returns all 8,192 rows, including rows where `key = 456`, `key = 789`, etc. (
 
 Note: It is not possible to optimize a query with the `indexHint` function. The `indexHint` function does not optimize the query, as it does not provide any additional information for the query analysis. Having an expression inside the `indexHint` function is not anyhow better than without the `indexHint` function. The `indexHint` function can be used only for introspection and debugging purposes and it does not improve performance. If you see the usage of `indexHint` by anyone other than ClickHouse contributors, it is likely a mistake and you should remove it.
     )";
-    FunctionDocumentation::Syntax syntax_indexHint = "indexHint(expression)";
-    FunctionDocumentation::Arguments arguments_indexHint = {
+    FunctionDocumentation::Syntax syntax = "indexHint(expression)";
+    FunctionDocumentation::Arguments arguments = {
         {"expression", "Any expression for index range selection.", {"Expression"}}
     };
-    FunctionDocumentation::ReturnedValue returned_value_indexHint = {"Returns `1` in all cases.", {"UInt8"}};
-    FunctionDocumentation::Examples examples_indexHint = {
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns `1` in all cases.", {"UInt8"}};
+    FunctionDocumentation::Examples examples = {
     {
         "Usage example with date filtering",
         R"(
@@ -73,11 +73,11 @@ SELECT FlightDate AS k, count() FROM ontime WHERE indexHint(k = '2025-09-15') GR
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in_indexHint = {1, 1};
-    FunctionDocumentation::Category category_indexHint = FunctionDocumentation::Category::Other;
-    FunctionDocumentation documentation_indexHint = {description_indexHint, syntax_indexHint, arguments_indexHint, {}, returned_value_indexHint, examples_indexHint, introduced_in_indexHint, category_indexHint};
+    FunctionDocumentation::IntroducedIn introduced_in = {1, 1};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Other;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
-    factory.registerFunction<FunctionIndexHint>(documentation_indexHint);
+    factory.registerFunction<FunctionIndexHint>(documentation);
 }
 
 }

--- a/src/Functions/initialQueryID.cpp
+++ b/src/Functions/initialQueryID.cpp
@@ -40,16 +40,16 @@ public:
 
 REGISTER_FUNCTION(InitialQueryID)
 {
-    FunctionDocumentation::Description description_initialQueryID = R"(
+    FunctionDocumentation::Description description = R"(
 Returns the ID of the initial current query.
 Other parameters of a query can be extracted from field `initial_query_id` in [`system.query_log`](../../operations/system-tables/query_log.md).
 
 In contrast to [`queryID`](/sql-reference/functions/other-functions#queryID) function, `initialQueryID` returns the same results on different shards.
 )";
-    FunctionDocumentation::Syntax syntax_initialQueryID = "initialQueryID()";
-    FunctionDocumentation::Arguments arguments_initialQueryID = {};
-    FunctionDocumentation::ReturnedValue returned_value_initialQueryID = {"Returns the ID of the initial current query.", {"String"}};
-    FunctionDocumentation::Examples examples_initialQueryID = {
+    FunctionDocumentation::Syntax syntax = "initialQueryID()";
+    FunctionDocumentation::Arguments arguments = {};
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the ID of the initial current query.", {"String"}};
+    FunctionDocumentation::Examples examples = {
     {
         "Usage example",
         R"(
@@ -64,11 +64,11 @@ SELECT count(DISTINCT t) FROM (SELECT initialQueryID() AS t FROM remote('127.0.0
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in_initialQueryID = {1, 1};
-    FunctionDocumentation::Category category_initialQueryID = FunctionDocumentation::Category::Other;
-    FunctionDocumentation documentation_initialQueryID = {description_initialQueryID, syntax_initialQueryID, arguments_initialQueryID, {}, returned_value_initialQueryID, examples_initialQueryID, introduced_in_initialQueryID, category_initialQueryID};
+    FunctionDocumentation::IntroducedIn introduced_in = {1, 1};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Other;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
-    factory.registerFunction<FunctionInitialQueryID>(documentation_initialQueryID);
+    factory.registerFunction<FunctionInitialQueryID>(documentation);
     factory.registerAlias("initial_query_id", FunctionInitialQueryID::name, FunctionFactory::Case::Insensitive);
 }
 }

--- a/src/Functions/initializeAggregation.cpp
+++ b/src/Functions/initializeAggregation.cpp
@@ -165,18 +165,18 @@ ColumnPtr FunctionInitializeAggregation::executeImpl(const ColumnsWithTypeAndNam
 
 REGISTER_FUNCTION(InitializeAggregation)
 {
-    FunctionDocumentation::Description description_initializeAggregation = R"(
+    FunctionDocumentation::Description description = R"(
 Calculates the result of an aggregate function based on a single value.
 This function can be used to initialize aggregate functions with combinator [-State](../../sql-reference/aggregate-functions/combinators.md#-state).
 You can create states of aggregate functions and insert them to columns of type [`AggregateFunction`](../../sql-reference/data-types/aggregatefunction.md) or use initialized aggregates as default values.
     )";
-    FunctionDocumentation::Syntax syntax_initializeAggregation = "initializeAggregation(aggregate_function, arg1[, arg2, ...])";
-    FunctionDocumentation::Arguments arguments_initializeAggregation = {
+    FunctionDocumentation::Syntax syntax = "initializeAggregation(aggregate_function, arg1[, arg2, ...])";
+    FunctionDocumentation::Arguments arguments = {
         {"aggregate_function", "Name of the aggregation function to initialize.", {"String"}},
         {"arg1[, arg2, ...]", "Arguments of the aggregate function.", {"Any"}}
     };
-    FunctionDocumentation::ReturnedValue returned_value_initializeAggregation = {"Returns the result of aggregation for every row passed to the function. The return type is the same as the return type of the function that `initializeAggregation` takes as a first argument.", {"Any"}};
-    FunctionDocumentation::Examples examples_initializeAggregation = {
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the result of aggregation for every row passed to the function. The return type is the same as the return type of the function that `initializeAggregation` takes as a first argument.", {"Any"}};
+    FunctionDocumentation::Examples examples = {
     {
         "Basic usage with uniqState",
         R"(
@@ -204,11 +204,11 @@ SELECT finalizeAggregation(state), toTypeName(state) FROM (SELECT initializeAggr
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in_initializeAggregation = {20, 6};
-    FunctionDocumentation::Category category_initializeAggregation = FunctionDocumentation::Category::Other;
-    FunctionDocumentation documentation_initializeAggregation = {description_initializeAggregation, syntax_initializeAggregation, arguments_initializeAggregation, {}, returned_value_initializeAggregation, examples_initializeAggregation, introduced_in_initializeAggregation, category_initializeAggregation};
+    FunctionDocumentation::IntroducedIn introduced_in = {20, 6};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Other;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
-    factory.registerFunction<FunctionInitializeAggregation>(documentation_initializeAggregation);
+    factory.registerFunction<FunctionInitializeAggregation>(documentation);
 }
 
 }

--- a/src/Functions/isDecimalOverflow.cpp
+++ b/src/Functions/isDecimalOverflow.cpp
@@ -155,16 +155,16 @@ private:
 
 REGISTER_FUNCTION(IsDecimalOverflow)
 {
-    FunctionDocumentation::Description description_isDecimalOverflow = R"(
+    FunctionDocumentation::Description description = R"(
 Checks if a decimal number has too many digits to fit properly in a Decimal data type with given precision.
     )";
-    FunctionDocumentation::Syntax syntax_isDecimalOverflow = "isDecimalOverflow(value[, precision])";
-    FunctionDocumentation::Arguments arguments_isDecimalOverflow = {
+    FunctionDocumentation::Syntax syntax = "isDecimalOverflow(value[, precision])";
+    FunctionDocumentation::Arguments arguments = {
         {"value", "Decimal value to check.", {"Decimal"}},
         {"precision", "Optional. The precision of the Decimal type. If omitted, the initial precision of the first argument is used.", {"UInt8"}}
     };
-    FunctionDocumentation::ReturnedValue returned_value_isDecimalOverflow = {"Returns `1` if the decimal value has more digits than allowed by its precision, `0` if the decimal value satisfies the specified precision.", {"UInt8"}};
-    FunctionDocumentation::Examples examples_isDecimalOverflow = {
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns `1` if the decimal value has more digits than allowed by its precision, `0` if the decimal value satisfies the specified precision.", {"UInt8"}};
+    FunctionDocumentation::Examples examples = {
     {
         "Usage example",
         R"(
@@ -180,11 +180,11 @@ SELECT isDecimalOverflow(toDecimal32(1000000000, 0), 9),
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in_isDecimalOverflow = {20, 8};
-    FunctionDocumentation::Category category_isDecimalOverflow = FunctionDocumentation::Category::Other;
-    FunctionDocumentation documentation_isDecimalOverflow = {description_isDecimalOverflow, syntax_isDecimalOverflow, arguments_isDecimalOverflow, {}, returned_value_isDecimalOverflow, examples_isDecimalOverflow, introduced_in_isDecimalOverflow, category_isDecimalOverflow};
+    FunctionDocumentation::IntroducedIn introduced_in = {20, 8};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Other;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
-    factory.registerFunction<FunctionIsDecimalOverflow>(documentation_isDecimalOverflow);
+    factory.registerFunction<FunctionIsDecimalOverflow>(documentation);
 }
 
 }

--- a/src/Functions/jsonMergePatch.cpp
+++ b/src/Functions/jsonMergePatch.cpp
@@ -168,15 +168,15 @@ namespace
 REGISTER_FUNCTION(JSONMergePatch)
 {
     /// jsonMergePatch documentation
-    FunctionDocumentation::Description description_jsonMergePatch = R"(
+    FunctionDocumentation::Description description = R"(
 Returns the merged JSON object string which is formed by merging multiple JSON objects.
     )";
-    FunctionDocumentation::Syntax syntax_jsonMergePatch = "jsonMergePatch(json1[, json2, ...])";
-    FunctionDocumentation::Arguments arguments_jsonMergePatch = {
+    FunctionDocumentation::Syntax syntax = "jsonMergePatch(json1[, json2, ...])";
+    FunctionDocumentation::Arguments arguments = {
         {"json1[, json2, ...]", "One or more strings with valid JSON.", {"String"}}
     };
-    FunctionDocumentation::ReturnedValue returned_value_jsonMergePatch = {"Returns the merged JSON object string, if the JSON object strings are valid.", {"String"}};
-    FunctionDocumentation::Examples examples_jsonMergePatch = {
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the merged JSON object string, if the JSON object strings are valid.", {"String"}};
+    FunctionDocumentation::Examples examples = {
     {
         "Usage example",
         R"(
@@ -189,11 +189,11 @@ SELECT jsonMergePatch('{"a":1}', '{"name": "joey"}', '{"name": "tom"}', '{"name"
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in_jsonMergePatch = {23, 10};
-    FunctionDocumentation::Category category_jsonMergePatch = FunctionDocumentation::Category::JSON;
-    FunctionDocumentation documentation_jsonMergePatch = {description_jsonMergePatch, syntax_jsonMergePatch, arguments_jsonMergePatch, {}, returned_value_jsonMergePatch, examples_jsonMergePatch, introduced_in_jsonMergePatch, category_jsonMergePatch};
+    FunctionDocumentation::IntroducedIn introduced_in = {23, 10};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::JSON;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
-    factory.registerFunction<FunctionJSONMergePatch>(documentation_jsonMergePatch);
+    factory.registerFunction<FunctionJSONMergePatch>(documentation);
 
     factory.registerAlias("jsonMergePatch", "JSONMergePatch");
 }

--- a/src/Functions/queryID.cpp
+++ b/src/Functions/queryID.cpp
@@ -41,16 +41,16 @@ public:
 
 REGISTER_FUNCTION(QueryID)
 {
-    FunctionDocumentation::Description description_queryID = R"(
+    FunctionDocumentation::Description description = R"(
 Returns the ID of the current query.
 Other parameters of a query can be extracted from field `query_id` in the [`system.query_log`](../../operations/system-tables/query_log.md) table.
 
 In contrast to [`initialQueryID`](#initialQueryID) function, `queryID` can return different results on different shards.
 )";
-    FunctionDocumentation::Syntax syntax_queryID = "queryID()";
-    FunctionDocumentation::Arguments arguments_queryID = {};
-    FunctionDocumentation::ReturnedValue returned_value_queryID = {"Returns the ID of the current query.", {"String"}};
-    FunctionDocumentation::Examples examples_queryID = {
+    FunctionDocumentation::Syntax syntax = "queryID()";
+    FunctionDocumentation::Arguments arguments = {};
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the ID of the current query.", {"String"}};
+    FunctionDocumentation::Examples examples = {
     {
         "Usage example",
         R"(
@@ -65,11 +65,11 @@ SELECT count(DISTINCT t) FROM (SELECT queryID() AS t FROM remote('127.0.0.{1..3}
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in_queryID = {21, 9};
-    FunctionDocumentation::Category category_queryID = FunctionDocumentation::Category::Other;
-    FunctionDocumentation documentation_queryID = {description_queryID, syntax_queryID, arguments_queryID, {}, returned_value_queryID, examples_queryID, introduced_in_queryID, category_queryID};
+    FunctionDocumentation::IntroducedIn introduced_in = {21, 9};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Other;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
-    factory.registerFunction<FunctionQueryID>(documentation_queryID);
+    factory.registerFunction<FunctionQueryID>(documentation);
     factory.registerAlias("query_id", FunctionQueryID::name, FunctionFactory::Case::Insensitive);
 }
 }

--- a/src/Functions/replicate.cpp
+++ b/src/Functions/replicate.cpp
@@ -53,16 +53,16 @@ ColumnPtr FunctionReplicate::executeImpl(const ColumnsWithTypeAndName & argument
 
 REGISTER_FUNCTION(Replicate)
 {
-    FunctionDocumentation::Description description_replicate = R"(
+    FunctionDocumentation::Description description = R"(
 Creates an array with a single value.
 )";
-    FunctionDocumentation::Syntax syntax_replicate = "replicate(x, arr)";
-    FunctionDocumentation::Arguments arguments_replicate = {
+    FunctionDocumentation::Syntax syntax = "replicate(x, arr)";
+    FunctionDocumentation::Arguments arguments = {
         {"x", "The value to fill the result array with.", {"Any"}},
         {"arr", "An array.", {"Array(T)"}}
     };
-    FunctionDocumentation::ReturnedValue returned_value_replicate = {"Returns an array of the same length as `arr` filled with value `x`.", {"Array(T)"}};
-    FunctionDocumentation::Examples examples_replicate = {
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns an array of the same length as `arr` filled with value `x`.", {"Array(T)"}};
+    FunctionDocumentation::Examples examples = {
     {
         "Usage example",
         R"(
@@ -75,11 +75,11 @@ SELECT replicate(1, ['a', 'b', 'c']);
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in_replicate = {1, 1};
-    FunctionDocumentation::Category category_replicate = FunctionDocumentation::Category::Array;
-    FunctionDocumentation documentation_replicate = {description_replicate, syntax_replicate, arguments_replicate, {}, returned_value_replicate, examples_replicate, introduced_in_replicate, category_replicate};
+    FunctionDocumentation::IntroducedIn introduced_in = {1, 1};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Array;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
-    factory.registerFunction<FunctionReplicate>(documentation_replicate);
+    factory.registerFunction<FunctionReplicate>(documentation);
 }
 
 }

--- a/src/Functions/runningAccumulate.cpp
+++ b/src/Functions/runningAccumulate.cpp
@@ -159,7 +159,7 @@ public:
 
 REGISTER_FUNCTION(RunningAccumulate)
 {
-    FunctionDocumentation::Description description_runningAccumulate = R"(
+    FunctionDocumentation::Description description = R"(
 Accumulates the states of an aggregate function for each row of a data block.
 
 :::warning Deprecated
@@ -168,13 +168,13 @@ Due to this error-prone behavior the function has been deprecated, and you are a
 You can use setting [`allow_deprecated_error_prone_window_functions`](/operations/settings/settings#allow_deprecated_error_prone_window_functions) to allow usage of this function.
 :::
 )";
-    FunctionDocumentation::Syntax syntax_runningAccumulate = "runningAccumulate(agg_state[, grouping])";
-    FunctionDocumentation::Arguments arguments_runningAccumulate = {
+    FunctionDocumentation::Syntax syntax = "runningAccumulate(agg_state[, grouping])";
+    FunctionDocumentation::Arguments arguments = {
         {"agg_state", "State of the aggregate function.", {"AggregateFunction"}},
         {"grouping", "Optional. Grouping key. The state of the function is reset if the `grouping` value is changed. It can be any of the supported data types for which the equality operator is defined.", {"Any"}}
     };
-    FunctionDocumentation::ReturnedValue returned_value_runningAccumulate = {"Returns the accumulated result for each row.", {"Any"}};
-    FunctionDocumentation::Examples examples_runningAccumulate = {
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the accumulated result for each row.", {"Any"}};
+    FunctionDocumentation::Examples examples = {
     {
         "Usage example with initializeAggregation",
         R"(
@@ -196,11 +196,11 @@ FROM numbers(5);
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in_runningAccumulate = {1, 1};
-    FunctionDocumentation::Category category_runningAccumulate = FunctionDocumentation::Category::Other;
-    FunctionDocumentation documentation_runningAccumulate = {description_runningAccumulate, syntax_runningAccumulate, arguments_runningAccumulate, {}, returned_value_runningAccumulate, examples_runningAccumulate, introduced_in_runningAccumulate, category_runningAccumulate};
+    FunctionDocumentation::IntroducedIn introduced_in = {1, 1};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Other;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
-    factory.registerFunction<FunctionRunningAccumulate>(documentation_runningAccumulate);
+    factory.registerFunction<FunctionRunningAccumulate>(documentation);
 }
 
 }

--- a/src/Functions/runningConcurrency.cpp
+++ b/src/Functions/runningConcurrency.cpp
@@ -204,7 +204,7 @@ namespace DB
 
     REGISTER_FUNCTION(RunningConcurrency)
     {
-        FunctionDocumentation::Description description_runningConcurrency = R"(
+        FunctionDocumentation::Description description = R"(
 Calculates the number of concurrent events.
 Each event has a start time and an end time.
 The start time is included in the event, while the end time is excluded.
@@ -222,13 +222,13 @@ If events from different data blocks overlap then they can not be processed corr
 It is advised to use [window functions](/sql-reference/window-functions) instead.
 :::
 )";
-        FunctionDocumentation::Syntax syntax_runningConcurrency = "runningConcurrency(start, end)";
-        FunctionDocumentation::Arguments arguments_runningConcurrency = {
+        FunctionDocumentation::Syntax syntax = "runningConcurrency(start, end)";
+        FunctionDocumentation::Arguments arguments = {
             {"start", "A column with the start time of events.", {"Date", "DateTime", "DateTime64"}},
             {"end", "A column with the end time of events.", {"Date", "DateTime", "DateTime64"}}
         };
-        FunctionDocumentation::ReturnedValue returned_value_runningConcurrency = {"Returns the number of concurrent events at each event start time.", {"UInt32"}};
-        FunctionDocumentation::Examples examples_runningConcurrency = {
+        FunctionDocumentation::ReturnedValue returned_value = {"Returns the number of concurrent events at each event start time.", {"UInt32"}};
+        FunctionDocumentation::Examples examples = {
         {
             "Usage example",
             R"(
@@ -244,10 +244,10 @@ SELECT start, runningConcurrency(start, end) FROM example_table;
             )"
         }
         };
-        FunctionDocumentation::IntroducedIn introduced_in_runningConcurrency = {21, 3};
-        FunctionDocumentation::Category category_runningConcurrency = FunctionDocumentation::Category::Other;
-        FunctionDocumentation documentation_runningConcurrency = {description_runningConcurrency, syntax_runningConcurrency, arguments_runningConcurrency, {}, returned_value_runningConcurrency, examples_runningConcurrency, introduced_in_runningConcurrency, category_runningConcurrency};
+        FunctionDocumentation::IntroducedIn introduced_in = {21, 3};
+        FunctionDocumentation::Category category = FunctionDocumentation::Category::Other;
+        FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
-        factory.registerFunction<RunningConcurrencyOverloadResolver>(documentation_runningConcurrency);
+        factory.registerFunction<RunningConcurrencyOverloadResolver>(documentation);
     }
 }

--- a/src/Functions/runningDifference.cpp
+++ b/src/Functions/runningDifference.cpp
@@ -7,7 +7,7 @@ namespace DB
 
 REGISTER_FUNCTION(RunningDifference)
 {
-    FunctionDocumentation::Description description_runningDifference = R"(
+    FunctionDocumentation::Description description = R"(
 Calculates the difference between two consecutive row values in the data block.
 Returns `0` for the first row, and for subsequent rows the difference to the previous row.
 
@@ -25,10 +25,10 @@ To prevent that you can create a subquery with [`ORDER BY`](../../sql-reference/
 Please note that the block size affects the result.
 The internal state of `runningDifference` state is reset for each new block.
 )";
-    FunctionDocumentation::Syntax syntax_runningDifference = "runningDifference(x)";
-    FunctionDocumentation::Arguments arguments_runningDifference = {{"x", "Column for which to calculate the running difference.", {"Any"}}};
-    FunctionDocumentation::ReturnedValue returned_value_runningDifference = {"Returns the difference between consecutive values, with 0 for the first row.", {}};
-    FunctionDocumentation::Examples examples_runningDifference = {{"Usage example",
+    FunctionDocumentation::Syntax syntax = "runningDifference(x)";
+    FunctionDocumentation::Arguments arguments = {{"x", "Column for which to calculate the running difference.", {"Any"}}};
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the difference between consecutive values, with 0 for the first row.", {}};
+    FunctionDocumentation::Examples examples = {{"Usage example",
         R"(
 SELECT
     EventID,
@@ -74,11 +74,11 @@ WHERE diff != 1;
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in_runningDifference = {1, 1};
-    FunctionDocumentation::Category category_runningDifference = FunctionDocumentation::Category::Other;
-    FunctionDocumentation documentation_runningDifference = {description_runningDifference, syntax_runningDifference, arguments_runningDifference, {}, returned_value_runningDifference, examples_runningDifference, introduced_in_runningDifference, category_runningDifference};
+    FunctionDocumentation::IntroducedIn introduced_in = {1, 1};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Other;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
-    factory.registerFunction<FunctionRunningDifferenceImpl<true>>(documentation_runningDifference);
+    factory.registerFunction<FunctionRunningDifferenceImpl<true>>(documentation);
 }
 
 }

--- a/src/Functions/runningDifferenceStartingWithFirstValue.cpp
+++ b/src/Functions/runningDifferenceStartingWithFirstValue.cpp
@@ -7,7 +7,7 @@ namespace DB
 
 REGISTER_FUNCTION(RunningDifferenceStartingWithFirstValue)
 {
-    FunctionDocumentation::Description description_runningDifferenceStartingWithFirstValue = R"(
+    FunctionDocumentation::Description description = R"(
 Calculates the difference between consecutive row values in a data block, but unlike [`runningDifference`](#runningDifference), it returns the actual value of the first row instead of `0`.
 
 :::warning Deprecated
@@ -18,10 +18,10 @@ It is advised to use [window functions](/sql-reference/window-functions) instead
 You can use setting `allow_deprecated_error_prone_window_functions` to allow usage of this function.
 :::
 )";
-    FunctionDocumentation::Syntax syntax_runningDifferenceStartingWithFirstValue = "runningDifferenceStartingWithFirstValue(x)";
-    FunctionDocumentation::Arguments arguments_runningDifferenceStartingWithFirstValue = {{"x", "Column for which to calculate the running difference.", {"Any"}}};
-    FunctionDocumentation::ReturnedValue returned_value_runningDifferenceStartingWithFirstValue = {"Returns the difference between consecutive values, with the first row's value for the first row.", {"Any"}};
-    FunctionDocumentation::Examples examples_runningDifferenceStartingWithFirstValue = {{"Usage example",
+    FunctionDocumentation::Syntax syntax = "runningDifferenceStartingWithFirstValue(x)";
+    FunctionDocumentation::Arguments arguments = {{"x", "Column for which to calculate the running difference.", {"Any"}}};
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the difference between consecutive values, with the first row's value for the first row.", {"Any"}};
+    FunctionDocumentation::Examples examples = {{"Usage example",
         R"(
 SELECT
     number,
@@ -39,11 +39,11 @@ FROM numbers(5);
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in_runningDifferenceStartingWithFirstValue = {1, 1};
-    FunctionDocumentation::Category category_runningDifferenceStartingWithFirstValue = FunctionDocumentation::Category::Other;
-    FunctionDocumentation documentation_runningDifferenceStartingWithFirstValue = {description_runningDifferenceStartingWithFirstValue, syntax_runningDifferenceStartingWithFirstValue, arguments_runningDifferenceStartingWithFirstValue, {}, returned_value_runningDifferenceStartingWithFirstValue, examples_runningDifferenceStartingWithFirstValue, introduced_in_runningDifferenceStartingWithFirstValue, category_runningDifferenceStartingWithFirstValue};
+    FunctionDocumentation::IntroducedIn introduced_in = {1, 1};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Other;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
-    factory.registerFunction<FunctionRunningDifferenceImpl<false>>(documentation_runningDifferenceStartingWithFirstValue);
+    factory.registerFunction<FunctionRunningDifferenceImpl<false>>(documentation);
 }
 
 }

--- a/src/Functions/toColumnTypeName.cpp
+++ b/src/Functions/toColumnTypeName.cpp
@@ -58,16 +58,16 @@ public:
 
 REGISTER_FUNCTION(ToColumnTypeName)
 {
-    FunctionDocumentation::Description description_toColumnTypeName = R"(
+    FunctionDocumentation::Description description = R"(
 Returns the internal name of the data type of the given value.
 Unlike function [`toTypeName`](#toTypeName), the returned data type potentially includes internal wrapper columns like `Const` and `LowCardinality`.
 )";
-    FunctionDocumentation::Syntax syntax_toColumnTypeName = "toColumnTypeName(value)";
-    FunctionDocumentation::Arguments arguments_toColumnTypeName = {
+    FunctionDocumentation::Syntax syntax = "toColumnTypeName(value)";
+    FunctionDocumentation::Arguments arguments = {
         {"value", "Value for which to return the internal data type.", {"Any"}}
     };
-    FunctionDocumentation::ReturnedValue returned_value_toColumnTypeName = {"Returns the internal data type used to represent the value.", {"String"}};
-    FunctionDocumentation::Examples examples_toColumnTypeName = {
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the internal data type used to represent the value.", {"String"}};
+    FunctionDocumentation::Examples examples = {
     {
         "Usage example",
         R"(
@@ -80,11 +80,11 @@ SELECT toColumnTypeName(CAST('2025-01-01 01:02:03' AS DateTime));
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in_toColumnTypeName = {1, 1};
-    FunctionDocumentation::Category category_toColumnTypeName = FunctionDocumentation::Category::Other;
-    FunctionDocumentation documentation_toColumnTypeName = {description_toColumnTypeName, syntax_toColumnTypeName, arguments_toColumnTypeName, {}, returned_value_toColumnTypeName, examples_toColumnTypeName, introduced_in_toColumnTypeName, category_toColumnTypeName};
+    FunctionDocumentation::IntroducedIn introduced_in = {1, 1};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Other;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
-    factory.registerFunction<FunctionToColumnTypeName>(documentation_toColumnTypeName);
+    factory.registerFunction<FunctionToColumnTypeName>(documentation);
 }
 
 }

--- a/src/Functions/toDecimalString.cpp
+++ b/src/Functions/toDecimalString.cpp
@@ -265,21 +265,21 @@ private:
 
 REGISTER_FUNCTION(ToDecimalString)
 {
-    FunctionDocumentation::Description description_toDecimalString = R"(
+    FunctionDocumentation::Description description = R"(
 Converts a numeric value to a String with specified number of fractional digits.
 
 The function rounds the input value to the specified number of decimal places. If the input value has fewer fractional
 digits than requested, the result is padded with zeros to achieve the exact number of fractional digits specified.
     )";
-    FunctionDocumentation::Syntax syntax_toDecimalString = R"(
+    FunctionDocumentation::Syntax syntax = R"(
 toDecimalString(number, scale)
     )";
-    FunctionDocumentation::Arguments arguments_toDecimalString = {
+    FunctionDocumentation::Arguments arguments = {
         {"number", "The numeric value to convert to a string. Can be any numeric type (Int, UInt, Float, Decimal).", {"Int8", "Int16", "Int32", "Int64", "UInt8", "UInt16", "UInt32", "UInt64", "Float32", "Float64", "Decimal"}},
         {"scale", "The number of digits to display in the fractional part. The result will be rounded if necessary.", {"UInt8"}}
     };
-    FunctionDocumentation::ReturnedValue returned_value_toDecimalString = {"Returns a String representation of the number with exactly the specified number of fractional digits.", {"String"}};
-    FunctionDocumentation::Examples examples_toDecimalString = {
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns a String representation of the number with exactly the specified number of fractional digits.", {"String"}};
+    FunctionDocumentation::Examples examples = {
         {"Round and format a number", R"(
 SELECT toDecimalString(2.1456, 2)
         )",
@@ -306,11 +306,11 @@ SELECT toDecimalString(CAST(123.456 AS Decimal(10,3)), 2) AS decimal_val,
 └─────────────┴───────────┘
         )"}
     };
-    FunctionDocumentation::IntroducedIn introduced_in_toDecimalString = {23, 3};
-    FunctionDocumentation::Category category_toDecimalString = FunctionDocumentation::Category::TypeConversion;
-    FunctionDocumentation documentation_toDecimalString = {description_toDecimalString, syntax_toDecimalString, arguments_toDecimalString, {}, returned_value_toDecimalString, examples_toDecimalString, introduced_in_toDecimalString, category_toDecimalString};
+    FunctionDocumentation::IntroducedIn introduced_in = {23, 3};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::TypeConversion;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
-    factory.registerFunction<FunctionToDecimalString>(documentation_toDecimalString, FunctionFactory::Case::Insensitive);
+    factory.registerFunction<FunctionToDecimalString>(documentation, FunctionFactory::Case::Insensitive);
 }
 
 }

--- a/src/Functions/toFixedString.cpp
+++ b/src/Functions/toFixedString.cpp
@@ -8,19 +8,19 @@ namespace DB
 REGISTER_FUNCTION(FixedString)
 {
     /// toFixedString documentation
-    FunctionDocumentation::Description toFixedString_description = R"(
+    FunctionDocumentation::Description description = R"(
 Converts a [`String`](/sql-reference/data-types/string) argument to a [`FixedString(N)`](/sql-reference/data-types/fixedstring) type (a string of fixed length N).
 
 If the string has fewer bytes than N, it is padded with null bytes to the right.
 If the string has more bytes than N, an exception is thrown.
     )";
-    FunctionDocumentation::Syntax toFixedString_syntax = "toFixedString(s, N)";
-    FunctionDocumentation::Arguments toFixedString_arguments = {
+    FunctionDocumentation::Syntax syntax = "toFixedString(s, N)";
+    FunctionDocumentation::Arguments arguments = {
         {"s", "String to convert.", {"String"}},
         {"N", "Length of the resulting FixedString.", {"const UInt*"}}
     };
-    FunctionDocumentation::ReturnedValue toFixedString_returned_value = {"Returns a FixedString of length N.", {"FixedString(N)"}};
-    FunctionDocumentation::Examples toFixedString_examples = {
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns a FixedString of length N.", {"FixedString(N)"}};
+    FunctionDocumentation::Examples examples = {
     {
         "Usage example",
         R"(
@@ -33,11 +33,11 @@ SELECT toFixedString('foo', 8) AS s;
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn toFixedString_introduced_in = {1, 1};
-    FunctionDocumentation::Category toFixedString_category = FunctionDocumentation::Category::TypeConversion;
-    FunctionDocumentation toFixedString_documentation = {toFixedString_description, toFixedString_syntax, toFixedString_arguments, {}, toFixedString_returned_value, toFixedString_examples, toFixedString_introduced_in, toFixedString_category};
+    FunctionDocumentation::IntroducedIn introduced_in = {1, 1};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::TypeConversion;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
-    factory.registerFunction<FunctionToFixedString>(toFixedString_documentation);
+    factory.registerFunction<FunctionToFixedString>(documentation);
 }
 
 }

--- a/src/Functions/toISOWeek.cpp
+++ b/src/Functions/toISOWeek.cpp
@@ -11,7 +11,7 @@ using FunctionToISOWeek = FunctionDateOrDateTimeToSomething<DataTypeUInt8, ToISO
 
 REGISTER_FUNCTION(ToISOWeek)
 {
-    FunctionDocumentation::Description description_toISOWeek = R"(
+    FunctionDocumentation::Description description = R"(
 Returns the ISO week number of a date or date with time.
 
 This is a compatibility function that is equivalent to `toWeek(date, 3)`.
@@ -21,15 +21,15 @@ According to ISO 8601, week numbers are in the range from 1 to 53.
 Note that dates near the beginning or end of a year may return a week number from the previous or next year. For example,
 December 29, 2025 returns week 1 because it falls in the first week that contains January 4, 2026.
     )";
-    FunctionDocumentation::Syntax syntax_toISOWeek = R"(
+    FunctionDocumentation::Syntax syntax = R"(
 toISOWeek(datetime[, timezone])
     )";
-    FunctionDocumentation::Arguments arguments_toISOWeek = {
+    FunctionDocumentation::Arguments arguments = {
         {"datetime", "Date or date with time to get the ISO week number from.", {"Date", "DateTime", "Date32", "DateTime64"}},
         {"timezone", "Optional. Time zone.", {"String"}}
     };
-    FunctionDocumentation::ReturnedValue returned_value_toISOWeek = {"Returns the ISO week number according to ISO 8601 standard. Returns a number between 1 and 53.", {"UInt8"}};
-    FunctionDocumentation::Examples examples_toISOWeek = {
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the ISO week number according to ISO 8601 standard. Returns a number between 1 and 53.", {"UInt8"}};
+    FunctionDocumentation::Examples examples = {
         {"Get ISO week numbers", R"(
 SELECT toDate('2016-12-27') AS date, toISOWeek(date) AS isoWeek
         )",
@@ -47,11 +47,11 @@ SELECT toDate('2025-12-29') AS date, toISOWeek(date) AS isoWeek, toYear(date) AS
 └────────────┴─────────┴──────┘
         )"}
     };
-    FunctionDocumentation::IntroducedIn introduced_in_toISOWeek = {20, 1};
-    FunctionDocumentation::Category category_toISOWeek = FunctionDocumentation::Category::DateAndTime;
-    FunctionDocumentation documentation_toISOWeek = {description_toISOWeek, syntax_toISOWeek, arguments_toISOWeek, {}, returned_value_toISOWeek, examples_toISOWeek, introduced_in_toISOWeek, category_toISOWeek};
+    FunctionDocumentation::IntroducedIn introduced_in = {20, 1};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::DateAndTime;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
-    factory.registerFunction<FunctionToISOWeek>(documentation_toISOWeek);
+    factory.registerFunction<FunctionToISOWeek>(documentation);
 }
 
 }

--- a/src/Functions/toInterval.cpp
+++ b/src/Functions/toInterval.cpp
@@ -78,7 +78,7 @@ private:
 
 REGISTER_FUNCTION(ToInterval)
 {
-    FunctionDocumentation::Description description_toInterval = R"(
+    FunctionDocumentation::Description description = R"(
 Creates an Interval value from a numeric value and a unit string.
 
 This function provides a unified way to create intervals of different types (seconds, minutes, hours, days, weeks, months, quarters, years)
@@ -87,15 +87,15 @@ from a single function by specifying the unit as a string argument. The unit str
 This is equivalent to calling type-specific functions like `toIntervalSecond`, `toIntervalMinute`, `toIntervalDay`, etc.,
 but allows the unit to be specified dynamically as a string parameter.
     )";
-    FunctionDocumentation::Syntax syntax_toInterval = R"(
+    FunctionDocumentation::Syntax syntax = R"(
 toInterval(value, unit)
     )";
-    FunctionDocumentation::Arguments arguments_toInterval = {
+    FunctionDocumentation::Arguments arguments = {
         {"value", "The numeric value representing the number of units. Can be any numeric type.", {"Int8", "Int16", "Int32", "Int64", "UInt8", "UInt16", "UInt32", "UInt64", "Float32", "Float64"}},
         {"unit", R"(The unit of time. Must be a constant string. Valid values: 'nanosecond', 'microsecond', 'millisecond', 'second', 'minute', 'hour', 'day', 'week', 'month', 'quarter', 'year'.)", {"String"}}
     };
-    FunctionDocumentation::ReturnedValue returned_value_toInterval = {R"(Returns an Interval value of the specified type. The result type depends on the unit: IntervalNanosecond, IntervalMicrosecond, IntervalMillisecond, IntervalSecond, IntervalMinute, IntervalHour, IntervalDay, IntervalWeek, IntervalMonth, IntervalQuarter, or IntervalYear.)", {"Interval"}};
-    FunctionDocumentation::Examples examples_toInterval = {
+    FunctionDocumentation::ReturnedValue returned_value = {R"(Returns an Interval value of the specified type. The result type depends on the unit: IntervalNanosecond, IntervalMicrosecond, IntervalMillisecond, IntervalSecond, IntervalMinute, IntervalHour, IntervalDay, IntervalWeek, IntervalMonth, IntervalQuarter, or IntervalYear.)", {"Interval"}};
+    FunctionDocumentation::Examples examples = {
         {"Create intervals with different units", R"(
 SELECT
     toInterval(5, 'second') AS seconds,
@@ -132,11 +132,11 @@ FROM numbers(5)
 └────────────┘
         )"}
     };
-    FunctionDocumentation::IntroducedIn introduced_in_toInterval = {25, 4};
-    FunctionDocumentation::Category category_toInterval = FunctionDocumentation::Category::TypeConversion;
-    FunctionDocumentation documentation_toInterval = {description_toInterval, syntax_toInterval, arguments_toInterval, {}, returned_value_toInterval, examples_toInterval, introduced_in_toInterval, category_toInterval};
+    FunctionDocumentation::IntroducedIn introduced_in = {25, 4};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::TypeConversion;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
-    factory.registerFunction<FunctionToInterval>(documentation_toInterval);
+    factory.registerFunction<FunctionToInterval>(documentation);
 }
 
 }

--- a/src/Functions/toJSONString.cpp
+++ b/src/Functions/toJSONString.cpp
@@ -62,7 +62,7 @@ namespace
 REGISTER_FUNCTION(ToJSONString)
 {
     /// toJSONString documentation
-    FunctionDocumentation::Description description_toJSONString = R"(
+    FunctionDocumentation::Description description = R"(
 Serializes a value to its JSON representation. Various data types and nested structures are supported.
 64-bit [integers](../data-types/int-uint.md) or bigger (like `UInt64` or `Int128`) are enclosed in quotes by default. [output_format_json_quote_64bit_integers](/operations/settings/formats#output_format_json_quote_64bit_integers) controls this behavior.
 Special values `NaN` and `inf` are replaced with `null`. Enable [output_format_json_quote_denormals](/operations/settings/formats#output_format_json_quote_denormals) setting to show them.
@@ -72,12 +72,12 @@ See also:
 - [output_format_json_quote_64bit_integers](/operations/settings/formats#output_format_json_quote_64bit_integers)
 - [output_format_json_quote_denormals](/operations/settings/formats#output_format_json_quote_denormals)
     )";
-    FunctionDocumentation::Syntax syntax_toJSONString = "toJSONString(value)";
-    FunctionDocumentation::Arguments arguments_toJSONString = {
+    FunctionDocumentation::Syntax syntax = "toJSONString(value)";
+    FunctionDocumentation::Arguments arguments = {
         {"value", "Value to serialize. Value may be of any data type.", {"Any"}}
     };
-    FunctionDocumentation::ReturnedValue returned_value_toJSONString = {"Returns the JSON representation of the value.", {"String"}};
-    FunctionDocumentation::Examples examples_toJSONString = {
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the JSON representation of the value.", {"String"}};
+    FunctionDocumentation::Examples examples = {
     {
         "Map serialization",
         R"(
@@ -101,11 +101,11 @@ SELECT toJSONString(tuple(1.25, NULL, NaN, +inf, -inf, [])) SETTINGS output_form
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in_toJSONString = {21, 7};
-    FunctionDocumentation::Category category_toJSONString = FunctionDocumentation::Category::JSON;
-    FunctionDocumentation documentation_toJSONString = {description_toJSONString, syntax_toJSONString, arguments_toJSONString, {}, returned_value_toJSONString, examples_toJSONString, introduced_in_toJSONString, category_toJSONString};
+    FunctionDocumentation::IntroducedIn introduced_in = {21, 7};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::JSON;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
-    factory.registerFunction<FunctionToJSONString>(documentation_toJSONString);
+    factory.registerFunction<FunctionToJSONString>(documentation);
 }
 
 }

--- a/src/Functions/toLowCardinality.cpp
+++ b/src/Functions/toLowCardinality.cpp
@@ -61,7 +61,7 @@ public:
 REGISTER_FUNCTION(ToLowCardinality)
 {
     /// toLowCardinality documentation
-    FunctionDocumentation::Description toLowCardinality_description = R"(
+    FunctionDocumentation::Description description = R"(
 Converts the input argument to the [LowCardinality](../data-types/lowcardinality.md) version of same data type.
 
 :::tip
@@ -69,12 +69,12 @@ To convert from the `LowCardinality` data type to a regular data type, use the [
 For example: `CAST(x AS String)`.
 :::
     )";
-    FunctionDocumentation::Syntax toLowCardinality_syntax = "toLowCardinality(expr)";
-    FunctionDocumentation::Arguments toLowCardinality_arguments = {
+    FunctionDocumentation::Syntax syntax = "toLowCardinality(expr)";
+    FunctionDocumentation::Arguments arguments = {
         {"expr", "Expression resulting in one of the supported data types.", {"String", "FixedString", "Date", "DateTime", "(U)Int*", "Float*"}}
     };
-    FunctionDocumentation::ReturnedValue toLowCardinality_returned_value = {"Returns the input value converted to the `LowCardinality` data type.", {"LowCardinality"}};
-    FunctionDocumentation::Examples toLowCardinality_examples = {
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the input value converted to the `LowCardinality` data type.", {"LowCardinality"}};
+    FunctionDocumentation::Examples examples = {
     {
         "Usage example",
         R"(
@@ -87,11 +87,11 @@ SELECT toLowCardinality('1')
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn toLowCardinality_introduced_in = {18, 12};
-    FunctionDocumentation::Category toLowCardinality_category = FunctionDocumentation::Category::TypeConversion;
-    FunctionDocumentation toLowCardinality_documentation = {toLowCardinality_description, toLowCardinality_syntax, toLowCardinality_arguments, {}, toLowCardinality_returned_value, toLowCardinality_examples, toLowCardinality_introduced_in, toLowCardinality_category};
+    FunctionDocumentation::IntroducedIn introduced_in = {18, 12};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::TypeConversion;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
-    factory.registerFunction<FunctionToLowCardinality>(toLowCardinality_documentation);
+    factory.registerFunction<FunctionToLowCardinality>(documentation);
 }
 
 }

--- a/src/Functions/toStringCutToZero.cpp
+++ b/src/Functions/toStringCutToZero.cpp
@@ -147,18 +147,18 @@ public:
 REGISTER_FUNCTION(ToStringCutToZero)
 {
     /// toStringCutToZero documentation
-    FunctionDocumentation::Description toStringCutToZero_description = R"(
+    FunctionDocumentation::Description description = R"(
 Accepts a [String](/sql-reference/data-types/string) or [FixedString](/sql-reference/data-types/fixedstring) argument and returns a String that contains a copy of the original string truncated at the first null byte.
 
 Null bytes (\\0) are considered as string terminators.
 This function is useful for processing C-style strings or binary data where null bytes mark the end of meaningful content.
     )";
-    FunctionDocumentation::Syntax toStringCutToZero_syntax = "toStringCutToZero(s)";
-    FunctionDocumentation::Arguments toStringCutToZero_arguments = {
+    FunctionDocumentation::Syntax syntax = "toStringCutToZero(s)";
+    FunctionDocumentation::Arguments arguments = {
         {"s", "String or FixedString to process.", {"String", "FixedString"}}
     };
-    FunctionDocumentation::ReturnedValue toStringCutToZero_returned_value = {"Returns a String containing the characters before the first null byte.", {"String"}};
-    FunctionDocumentation::Examples toStringCutToZero_examples = {
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns a String containing the characters before the first null byte.", {"String"}};
+    FunctionDocumentation::Examples examples = {
     {
         "Usage example",
         R"(
@@ -173,11 +173,11 @@ SELECT
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn toStringCutToZero_introduced_in = {1, 1};
-    FunctionDocumentation::Category toStringCutToZero_category = FunctionDocumentation::Category::TypeConversion;
-    FunctionDocumentation toStringCutToZero_documentation = {toStringCutToZero_description, toStringCutToZero_syntax, toStringCutToZero_arguments, {}, toStringCutToZero_returned_value, toStringCutToZero_examples, toStringCutToZero_introduced_in, toStringCutToZero_category};
+    FunctionDocumentation::IntroducedIn introduced_in = {1, 1};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::TypeConversion;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
-    factory.registerFunction<FunctionToStringCutToZero>(toStringCutToZero_documentation);
+    factory.registerFunction<FunctionToStringCutToZero>(documentation);
 }
 
 }

--- a/src/Functions/toUnixTimestamp64Micro.cpp
+++ b/src/Functions/toUnixTimestamp64Micro.cpp
@@ -7,7 +7,7 @@ namespace DB
 REGISTER_FUNCTION(ToUnixTimestamp64Micro)
 {
     /// toUnixTimestamp64Micro documentation
-    FunctionDocumentation::Description description_toUnixTimestamp64Micro = R"(
+    FunctionDocumentation::Description description = R"(
 Converts a [`DateTime64`](/sql-reference/data-types/datetime64) to a [`Int64`](/sql-reference/data-types/int-uint) value with fixed microsecond precision.
 The input value is scaled up or down appropriately depending on its precision.
 
@@ -15,12 +15,12 @@ The input value is scaled up or down appropriately depending on its precision.
 The output value is relative to UTC, not to the timezone of the input value.
 :::
     )";
-    FunctionDocumentation::Syntax syntax_toUnixTimestamp64Micro = "toUnixTimestamp64Micro(value)";
-    FunctionDocumentation::Arguments arguments_toUnixTimestamp64Micro = {
+    FunctionDocumentation::Syntax syntax = "toUnixTimestamp64Micro(value)";
+    FunctionDocumentation::Arguments arguments = {
         {"value", "DateTime64 value with any precision.", {"DateTime64"}}
     };
-    FunctionDocumentation::ReturnedValue returned_value_toUnixTimestamp64Micro = {"Returns a Unix timestamp in microseconds.", {"Int64"}};
-    FunctionDocumentation::Examples examples_toUnixTimestamp64Micro = {
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns a Unix timestamp in microseconds.", {"Int64"}};
+    FunctionDocumentation::Examples examples = {
     {
         "Usage example",
         R"(
@@ -34,12 +34,12 @@ SELECT toUnixTimestamp64Micro(dt64);
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in_toUnixTimestamp64Micro = {20, 5};
-    FunctionDocumentation::Category category_toUnixTimestamp64Micro = FunctionDocumentation::Category::TypeConversion;
-    FunctionDocumentation documentation_toUnixTimestamp64Micro = {description_toUnixTimestamp64Micro, syntax_toUnixTimestamp64Micro, arguments_toUnixTimestamp64Micro, {}, returned_value_toUnixTimestamp64Micro, examples_toUnixTimestamp64Micro, introduced_in_toUnixTimestamp64Micro, category_toUnixTimestamp64Micro};
+    FunctionDocumentation::IntroducedIn introduced_in = {20, 5};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::TypeConversion;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
     factory.registerFunction("toUnixTimestamp64Micro",
-        [](ContextPtr){ return std::make_shared<FunctionToUnixTimestamp64>(6, "toUnixTimestamp64Micro"); }, documentation_toUnixTimestamp64Micro);
+        [](ContextPtr){ return std::make_shared<FunctionToUnixTimestamp64>(6, "toUnixTimestamp64Micro"); }, documentation);
 }
 
 }

--- a/src/Functions/toUnixTimestamp64Milli.cpp
+++ b/src/Functions/toUnixTimestamp64Milli.cpp
@@ -7,7 +7,7 @@ namespace DB
 REGISTER_FUNCTION(ToUnixTimestamp64Milli)
 {
     /// toUnixTimestamp64Milli documentation
-    FunctionDocumentation::Description description_toUnixTimestamp64Milli = R"(
+    FunctionDocumentation::Description description = R"(
 Converts a [`DateTime64`](/sql-reference/data-types/datetime64) to a [`Int64`](/sql-reference/data-types/int-uint) value with fixed millisecond precision.
 The input value is scaled up or down appropriately depending on its precision.
 
@@ -15,12 +15,12 @@ The input value is scaled up or down appropriately depending on its precision.
 The output value is relative to UTC, not to the timezone of the input value.
 :::
     )";
-    FunctionDocumentation::Syntax syntax_toUnixTimestamp64Milli = "toUnixTimestamp64Milli(value)";
-    FunctionDocumentation::Arguments arguments_toUnixTimestamp64Milli = {
+    FunctionDocumentation::Syntax syntax = "toUnixTimestamp64Milli(value)";
+    FunctionDocumentation::Arguments arguments = {
         {"value", "DateTime64 value with any precision.", {"DateTime64"}}
     };
-    FunctionDocumentation::ReturnedValue returned_value_toUnixTimestamp64Milli = {"Returns a Unix timestamp in milliseconds.", {"Int64"}};
-    FunctionDocumentation::Examples examples_toUnixTimestamp64Milli = {
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns a Unix timestamp in milliseconds.", {"Int64"}};
+    FunctionDocumentation::Examples examples = {
     {
         "Usage example",
         R"(
@@ -34,12 +34,12 @@ SELECT toUnixTimestamp64Milli(dt64);
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in_toUnixTimestamp64Milli = {20, 5};
-    FunctionDocumentation::Category category_toUnixTimestamp64Milli = FunctionDocumentation::Category::TypeConversion;
-    FunctionDocumentation documentation_toUnixTimestamp64Milli = {description_toUnixTimestamp64Milli, syntax_toUnixTimestamp64Milli, arguments_toUnixTimestamp64Milli, {}, returned_value_toUnixTimestamp64Milli, examples_toUnixTimestamp64Milli, introduced_in_toUnixTimestamp64Milli, category_toUnixTimestamp64Milli};
+    FunctionDocumentation::IntroducedIn introduced_in = {20, 5};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::TypeConversion;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
     factory.registerFunction("toUnixTimestamp64Milli",
-        [](ContextPtr){ return std::make_shared<FunctionToUnixTimestamp64>(3, "toUnixTimestamp64Milli"); }, documentation_toUnixTimestamp64Milli);
+        [](ContextPtr){ return std::make_shared<FunctionToUnixTimestamp64>(3, "toUnixTimestamp64Milli"); }, documentation);
 }
 
 }

--- a/src/Functions/toUnixTimestamp64Nano.cpp
+++ b/src/Functions/toUnixTimestamp64Nano.cpp
@@ -7,7 +7,7 @@ namespace DB
 REGISTER_FUNCTION(ToUnixTimestamp64Nano)
 {
     /// toUnixTimestamp64Nano documentation
-    FunctionDocumentation::Description description_toUnixTimestamp64Nano = R"(
+    FunctionDocumentation::Description description = R"(
 Converts a [`DateTime64`](/sql-reference/data-types/datetime64) to a [`Int64`](/sql-reference/functions/type-conversion-functions#toInt64) value with fixed nanosecond precision.
 The input value is scaled up or down appropriately depending on its precision.
 
@@ -15,12 +15,12 @@ The input value is scaled up or down appropriately depending on its precision.
 The output value is relative to UTC, not to the timezone of the input value.
 :::
     )";
-    FunctionDocumentation::Syntax syntax_toUnixTimestamp64Nano = "toUnixTimestamp64Nano(value)";
-    FunctionDocumentation::Arguments arguments_toUnixTimestamp64Nano = {
+    FunctionDocumentation::Syntax syntax = "toUnixTimestamp64Nano(value)";
+    FunctionDocumentation::Arguments arguments = {
         {"value", "DateTime64 value with any precision.", {"DateTime64"}}
     };
-    FunctionDocumentation::ReturnedValue returned_value_toUnixTimestamp64Nano = {"Returns a Unix timestamp in nanoseconds.", {"Int64"}};
-    FunctionDocumentation::Examples examples_toUnixTimestamp64Nano = {
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns a Unix timestamp in nanoseconds.", {"Int64"}};
+    FunctionDocumentation::Examples examples = {
     {
         "Usage example",
         R"(
@@ -34,12 +34,12 @@ SELECT toUnixTimestamp64Nano(dt64);
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in_toUnixTimestamp64Nano = {20, 5};
-    FunctionDocumentation::Category category_toUnixTimestamp64Nano = FunctionDocumentation::Category::TypeConversion;
-    FunctionDocumentation documentation_toUnixTimestamp64Nano = {description_toUnixTimestamp64Nano, syntax_toUnixTimestamp64Nano, arguments_toUnixTimestamp64Nano, {}, returned_value_toUnixTimestamp64Nano, examples_toUnixTimestamp64Nano, introduced_in_toUnixTimestamp64Nano, category_toUnixTimestamp64Nano};
+    FunctionDocumentation::IntroducedIn introduced_in = {20, 5};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::TypeConversion;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
     factory.registerFunction("toUnixTimestamp64Nano",
-        [](ContextPtr){ return std::make_shared<FunctionToUnixTimestamp64>(9, "toUnixTimestamp64Nano"); }, documentation_toUnixTimestamp64Nano);
+        [](ContextPtr){ return std::make_shared<FunctionToUnixTimestamp64>(9, "toUnixTimestamp64Nano"); }, documentation);
 }
 
 }

--- a/src/Functions/toUnixTimestamp64Second.cpp
+++ b/src/Functions/toUnixTimestamp64Second.cpp
@@ -7,7 +7,7 @@ namespace DB
 REGISTER_FUNCTION(ToUnixTimestamp64Second)
 {
     /// toUnixTimestamp64Second documentation
-    FunctionDocumentation::Description description_toUnixTimestamp64Second = R"(
+    FunctionDocumentation::Description description = R"(
 Converts a [`DateTime64`](/sql-reference/data-types/datetime64) to a [`Int64`](/sql-reference/data-types/int-uint) value with fixed second precision.
 The input value is scaled up or down appropriately depending on its precision.
 
@@ -15,12 +15,12 @@ The input value is scaled up or down appropriately depending on its precision.
 The output value is relative to UTC, not to the timezone of the input value.
 :::
     )";
-    FunctionDocumentation::Syntax syntax_toUnixTimestamp64Second = "toUnixTimestamp64Second(value)";
-    FunctionDocumentation::Arguments arguments_toUnixTimestamp64Second = {
+    FunctionDocumentation::Syntax syntax = "toUnixTimestamp64Second(value)";
+    FunctionDocumentation::Arguments arguments = {
         {"value", "DateTime64 value with any precision.", {"DateTime64"}}
     };
-    FunctionDocumentation::ReturnedValue returned_value_toUnixTimestamp64Second = {"Returns a Unix timestamp in seconds.", {"Int64"}};
-    FunctionDocumentation::Examples examples_toUnixTimestamp64Second = {
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns a Unix timestamp in seconds.", {"Int64"}};
+    FunctionDocumentation::Examples examples = {
     {
         "Usage example",
         R"(
@@ -34,12 +34,12 @@ SELECT toUnixTimestamp64Second(dt64);
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in_toUnixTimestamp64Second = {24, 12};
-    FunctionDocumentation::Category category_toUnixTimestamp64Second = FunctionDocumentation::Category::TypeConversion;
-    FunctionDocumentation documentation_toUnixTimestamp64Second = {description_toUnixTimestamp64Second, syntax_toUnixTimestamp64Second, arguments_toUnixTimestamp64Second, {}, returned_value_toUnixTimestamp64Second, examples_toUnixTimestamp64Second, introduced_in_toUnixTimestamp64Second, category_toUnixTimestamp64Second};
+    FunctionDocumentation::IntroducedIn introduced_in = {24, 12};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::TypeConversion;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
     factory.registerFunction("toUnixTimestamp64Second",
-        [](ContextPtr){ return std::make_shared<FunctionToUnixTimestamp64>(0, "toUnixTimestamp64Second"); }, documentation_toUnixTimestamp64Second);
+        [](ContextPtr){ return std::make_shared<FunctionToUnixTimestamp64>(0, "toUnixTimestamp64Second"); }, documentation);
 }
 
 }


### PR DESCRIPTION
When in-source function documentation was introduced a long time ago, lots of copypasting took place. In particular, the most generic form to name variables was used in many places, e.g. `syntax_JSONArrayLength` for the syntax description of function `JSONArrayLength`. This is useful for disambiguation if _multiple_ functions are registered within a source file but in the majority of cases only a single function is registered per file. We can write `syntax` and simplify.

This PR is proudly brought to you by Claude.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.1090`
<!-- ch-version-info:end -->