### PR TITLE
Fix DateTime64 pre-epoch partition filtering bug

### DIFF
--- a/tests/queries/0_stateless/03979_datetime64_preepoch_partition_pruning.reference
+++ b/tests/queries/0_stateless/03979_datetime64_preepoch_partition_pruning.reference
@@ -14,3 +14,7 @@ DateTime64 upper: data beyond Date max, filter also beyond
 1
 Date32 upper: data beyond Date max
 1
+DateTime64 timezone shift: pre-epoch after tz conversion
+1
+toDateTime(DateTime64): pre-epoch filter
+[1]

--- a/tests/queries/0_stateless/03979_datetime64_preepoch_partition_pruning.reference
+++ b/tests/queries/0_stateless/03979_datetime64_preepoch_partition_pruning.reference
@@ -1,0 +1,10 @@
+DateTime64: without filter
+p1	a
+DateTime64: with pre-epoch filter
+p1	a
+DateTime64: with epoch filter
+p1	a
+Date32: without filter
+a
+Date32: with pre-epoch filter
+a

--- a/tests/queries/0_stateless/03979_datetime64_preepoch_partition_pruning.reference
+++ b/tests/queries/0_stateless/03979_datetime64_preepoch_partition_pruning.reference
@@ -8,3 +8,9 @@ Date32: without filter
 a
 Date32: with pre-epoch filter
 a
+DateTime64 upper: data beyond Date max, filter at boundary
+1
+DateTime64 upper: data beyond Date max, filter also beyond
+1
+Date32 upper: data beyond Date max
+1

--- a/tests/queries/0_stateless/03979_datetime64_preepoch_partition_pruning.sql
+++ b/tests/queries/0_stateless/03979_datetime64_preepoch_partition_pruning.sql
@@ -39,3 +39,38 @@ SELECT 'Date32: with pre-epoch filter';
 SELECT id FROM t_date32_preepoch WHERE id = 'a' AND d >= '1969-12-31';
 
 DROP TABLE t_date32_preepoch;
+
+DROP TABLE IF EXISTS t_dt64_upper;
+
+CREATE TABLE t_dt64_upper (
+    id UInt8,
+    ts DateTime64(0)
+) ENGINE = MergeTree()
+PARTITION BY toDate(ts)
+ORDER BY id;
+
+INSERT INTO t_dt64_upper VALUES (1, '2149-06-07 00:00:00');
+
+SELECT 'DateTime64 upper: data beyond Date max, filter at boundary';
+SELECT id FROM t_dt64_upper WHERE ts >= '2149-06-06 00:00:00';
+
+SELECT 'DateTime64 upper: data beyond Date max, filter also beyond';
+SELECT id FROM t_dt64_upper WHERE ts >= '2149-06-07 00:00:00';
+
+DROP TABLE t_dt64_upper;
+
+DROP TABLE IF EXISTS t_date32_upper;
+
+CREATE TABLE t_date32_upper (
+    id UInt8,
+    d Date32
+) ENGINE = MergeTree()
+PARTITION BY toDate(d)
+ORDER BY id;
+
+INSERT INTO t_date32_upper VALUES (1, '2299-12-31');
+
+SELECT 'Date32 upper: data beyond Date max';
+SELECT id FROM t_date32_upper WHERE d >= '2149-06-06';
+
+DROP TABLE t_date32_upper;

--- a/tests/queries/0_stateless/03979_datetime64_preepoch_partition_pruning.sql
+++ b/tests/queries/0_stateless/03979_datetime64_preepoch_partition_pruning.sql
@@ -1,0 +1,41 @@
+DROP TABLE IF EXISTS t_dt64_preepoch;
+
+CREATE TABLE t_dt64_preepoch (
+    project_id String,
+    id String,
+    timestamp DateTime64(3)
+) ENGINE = MergeTree()
+PARTITION BY toDate(timestamp)
+ORDER BY (project_id, timestamp);
+
+INSERT INTO t_dt64_preepoch VALUES ('p1', 'a', '2026-02-21 18:05:58.394');
+
+SELECT 'DateTime64: without filter';
+SELECT project_id, id FROM t_dt64_preepoch WHERE project_id = 'p1' AND id = 'a';
+
+SELECT 'DateTime64: with pre-epoch filter';
+SELECT project_id, id FROM t_dt64_preepoch WHERE project_id = 'p1' AND id = 'a' AND timestamp >= '1969-12-31 12:00:00';
+
+SELECT 'DateTime64: with epoch filter';
+SELECT project_id, id FROM t_dt64_preepoch WHERE project_id = 'p1' AND id = 'a' AND timestamp >= '1970-01-01 00:00:00';
+
+DROP TABLE t_dt64_preepoch;
+
+DROP TABLE IF EXISTS t_date32_preepoch;
+
+CREATE TABLE t_date32_preepoch (
+    id String,
+    d Date32
+) ENGINE = MergeTree()
+PARTITION BY toDate(d)
+ORDER BY id;
+
+INSERT INTO t_date32_preepoch VALUES ('a', '2026-02-21');
+
+SELECT 'Date32: without filter';
+SELECT id FROM t_date32_preepoch WHERE id = 'a';
+
+SELECT 'Date32: with pre-epoch filter';
+SELECT id FROM t_date32_preepoch WHERE id = 'a' AND d >= '1969-12-31';
+
+DROP TABLE t_date32_preepoch;

--- a/tests/queries/0_stateless/03979_datetime64_preepoch_partition_pruning.sql
+++ b/tests/queries/0_stateless/03979_datetime64_preepoch_partition_pruning.sql
@@ -1,3 +1,6 @@
+-- toDate(DateTime64/Date32) overflows for pre-epoch and post-2149 values,
+-- which broke partition pruning and silently returned incomplete results
+
 DROP TABLE IF EXISTS t_dt64_preepoch;
 
 CREATE TABLE t_dt64_preepoch (

--- a/tests/queries/0_stateless/03980_datetime64_preepoch_partition_pruning_explain.reference
+++ b/tests/queries/0_stateless/03980_datetime64_preepoch_partition_pruning_explain.reference
@@ -71,3 +71,47 @@ Expression ((Project names + Projection))
         Granules: 3/3
         Search Algorithm: generic exclusion search
       Ranges: 3
+upper bound: no pruning (beyond Date max, overflow wraps)
+Expression ((Project names + Projection))
+  Expression ((WHERE + Change column names to column identifiers))
+    ReadFromMergeTree (default.t_dt64_explain)
+    Indexes:
+      MinMax
+        Keys:
+          ts
+        Condition: (ts in [\'5662310400\', +Inf))
+        Parts: 0/3
+        Granules: 0/3
+      Partition
+        Condition: true
+        Parts: 0/0
+        Granules: 0/0
+      PrimaryKey
+        Keys:
+          ts
+        Condition: (ts in [\'5662310400\', +Inf))
+        Parts: 0/0
+        Granules: 0/0
+      Ranges: 0
+at Date max: no pruning (boundary value, next wraps)
+Expression ((Project names + Projection))
+  Expression ((WHERE + Change column names to column identifiers))
+    ReadFromMergeTree (default.t_dt64_explain)
+    Indexes:
+      MinMax
+        Keys:
+          ts
+        Condition: (ts in [\'5662224000\', +Inf))
+        Parts: 0/3
+        Granules: 0/3
+      Partition
+        Condition: true
+        Parts: 0/0
+        Granules: 0/0
+      PrimaryKey
+        Keys:
+          ts
+        Condition: (ts in [\'5662224000\', +Inf))
+        Parts: 0/0
+        Granules: 0/0
+      Ranges: 0

--- a/tests/queries/0_stateless/03980_datetime64_preepoch_partition_pruning_explain.reference
+++ b/tests/queries/0_stateless/03980_datetime64_preepoch_partition_pruning_explain.reference
@@ -115,3 +115,65 @@ Expression ((Project names + Projection))
         Parts: 0/0
         Granules: 0/0
       Ranges: 0
+Date32 post-epoch: prunes partitions
+Expression ((Project names + Projection))
+  Expression ((WHERE + Change column names to column identifiers))
+    ReadFromMergeTree (default.t_d32_explain)
+    Indexes:
+      MinMax
+        Keys:
+          d
+        Condition: (d in [20505, +Inf))
+        Parts: 2/3
+        Granules: 2/3
+      Partition
+        Keys:
+          toDate(d)
+        Condition: (toDate(d) in [20505, +Inf))
+        Parts: 2/2
+        Granules: 2/2
+      PrimaryKey
+        Condition: true
+        Parts: 2/2
+        Granules: 2/2
+      Ranges: 2
+Date32 pre-epoch: no pruning
+Expression ((Project names + Projection))
+  Expression ((WHERE + Change column names to column identifiers))
+    ReadFromMergeTree (default.t_d32_explain)
+    Indexes:
+      MinMax
+        Keys:
+          d
+        Condition: (d in [-1, +Inf))
+        Parts: 3/3
+        Granules: 3/3
+      Partition
+        Condition: true
+        Parts: 3/3
+        Granules: 3/3
+      PrimaryKey
+        Condition: true
+        Parts: 3/3
+        Granules: 3/3
+      Ranges: 3
+Date32 upper bound: no pruning
+Expression ((Project names + Projection))
+  Expression ((WHERE + Change column names to column identifiers))
+    ReadFromMergeTree (default.t_d32_explain)
+    Indexes:
+      MinMax
+        Keys:
+          d
+        Condition: (d in [65536, +Inf))
+        Parts: 0/3
+        Granules: 0/3
+      Partition
+        Condition: true
+        Parts: 0/0
+        Granules: 0/0
+      PrimaryKey
+        Condition: true
+        Parts: 0/0
+        Granules: 0/0
+      Ranges: 0

--- a/tests/queries/0_stateless/03980_datetime64_preepoch_partition_pruning_explain.reference
+++ b/tests/queries/0_stateless/03980_datetime64_preepoch_partition_pruning_explain.reference
@@ -1,0 +1,73 @@
+post-epoch: prunes partitions
+Expression ((Project names + Projection))
+  Expression ((WHERE + Change column names to column identifiers))
+    ReadFromMergeTree (default.t_dt64_explain)
+    Indexes:
+      MinMax
+        Keys:
+          ts
+        Condition: (ts in [\'1771632000\', +Inf))
+        Parts: 2/3
+        Granules: 2/3
+      Partition
+        Keys:
+          toDate(ts)
+        Condition: (toDate(ts) in [20505, +Inf))
+        Parts: 2/2
+        Granules: 2/2
+      PrimaryKey
+        Keys:
+          ts
+        Condition: (ts in [\'1771632000\', +Inf))
+        Parts: 2/2
+        Granules: 2/2
+        Search Algorithm: generic exclusion search
+      Ranges: 2
+pre-epoch: no pruning (overflow would give wrong result)
+Expression ((Project names + Projection))
+  Expression ((WHERE + Change column names to column identifiers))
+    ReadFromMergeTree (default.t_dt64_explain)
+    Indexes:
+      MinMax
+        Keys:
+          ts
+        Condition: (ts in [\'-43200\', +Inf))
+        Parts: 3/3
+        Granules: 3/3
+      Partition
+        Condition: true
+        Parts: 3/3
+        Granules: 3/3
+      PrimaryKey
+        Keys:
+          ts
+        Condition: (ts in [\'-43200\', +Inf))
+        Parts: 3/3
+        Granules: 3/3
+        Search Algorithm: generic exclusion search
+      Ranges: 3
+epoch boundary: pruning with correct range
+Expression ((Project names + Projection))
+  Expression ((WHERE + Change column names to column identifiers))
+    ReadFromMergeTree (default.t_dt64_explain)
+    Indexes:
+      MinMax
+        Keys:
+          ts
+        Condition: (ts in [\'0\', +Inf))
+        Parts: 3/3
+        Granules: 3/3
+      Partition
+        Keys:
+          toDate(ts)
+        Condition: (toDate(ts) in [0, +Inf))
+        Parts: 3/3
+        Granules: 3/3
+      PrimaryKey
+        Keys:
+          ts
+        Condition: (ts in [\'0\', +Inf))
+        Parts: 3/3
+        Granules: 3/3
+        Search Algorithm: generic exclusion search
+      Ranges: 3

--- a/tests/queries/0_stateless/03980_datetime64_preepoch_partition_pruning_explain.sql
+++ b/tests/queries/0_stateless/03980_datetime64_preepoch_partition_pruning_explain.sql
@@ -1,7 +1,7 @@
 -- Tags: no-replicated-database, no-parallel-replicas, no-parallel, no-random-merge-tree-settings
 -- EXPLAIN output may differ
 
-SET optimize_use_implicit_projections = 0;
+SET optimize_use_implicit_projections = 0, session_timezone = 'UTC';
 
 DROP TABLE IF EXISTS t_dt64_explain;
 

--- a/tests/queries/0_stateless/03980_datetime64_preepoch_partition_pruning_explain.sql
+++ b/tests/queries/0_stateless/03980_datetime64_preepoch_partition_pruning_explain.sql
@@ -23,4 +23,10 @@ EXPLAIN indexes = 1 SELECT id FROM t_dt64_explain WHERE ts >= '1969-12-31 12:00:
 SELECT 'epoch boundary: pruning with correct range';
 EXPLAIN indexes = 1 SELECT id FROM t_dt64_explain WHERE ts >= '1970-01-01 00:00:00';
 
+SELECT 'upper bound: no pruning (beyond Date max, overflow wraps)';
+EXPLAIN indexes = 1 SELECT id FROM t_dt64_explain WHERE ts >= '2149-06-07 00:00:00';
+
+SELECT 'at Date max: no pruning (boundary value, next wraps)';
+EXPLAIN indexes = 1 SELECT id FROM t_dt64_explain WHERE ts >= '2149-06-06 00:00:00';
+
 DROP TABLE t_dt64_explain;

--- a/tests/queries/0_stateless/03980_datetime64_preepoch_partition_pruning_explain.sql
+++ b/tests/queries/0_stateless/03980_datetime64_preepoch_partition_pruning_explain.sql
@@ -1,0 +1,26 @@
+-- Tags: no-replicated-database, no-parallel-replicas, no-parallel, no-random-merge-tree-settings
+-- EXPLAIN output may differ
+
+SET optimize_use_implicit_projections = 0;
+
+DROP TABLE IF EXISTS t_dt64_explain;
+
+CREATE TABLE t_dt64_explain (id String, ts DateTime64(3))
+ENGINE = MergeTree() PARTITION BY toDate(ts) ORDER BY (id, ts);
+
+SYSTEM STOP MERGES t_dt64_explain;
+
+INSERT INTO t_dt64_explain VALUES ('a', '2026-02-20 10:00:00');
+INSERT INTO t_dt64_explain VALUES ('b', '2026-02-21 10:00:00');
+INSERT INTO t_dt64_explain VALUES ('c', '2026-02-22 10:00:00');
+
+SELECT 'post-epoch: prunes partitions';
+EXPLAIN indexes = 1 SELECT id FROM t_dt64_explain WHERE ts >= '2026-02-21 00:00:00';
+
+SELECT 'pre-epoch: no pruning (overflow would give wrong result)';
+EXPLAIN indexes = 1 SELECT id FROM t_dt64_explain WHERE ts >= '1969-12-31 12:00:00';
+
+SELECT 'epoch boundary: pruning with correct range';
+EXPLAIN indexes = 1 SELECT id FROM t_dt64_explain WHERE ts >= '1970-01-01 00:00:00';
+
+DROP TABLE t_dt64_explain;

--- a/tests/queries/0_stateless/03980_datetime64_preepoch_partition_pruning_explain.sql
+++ b/tests/queries/0_stateless/03980_datetime64_preepoch_partition_pruning_explain.sql
@@ -30,3 +30,25 @@ SELECT 'at Date max: no pruning (boundary value, next wraps)';
 EXPLAIN indexes = 1 SELECT id FROM t_dt64_explain WHERE ts >= '2149-06-06 00:00:00';
 
 DROP TABLE t_dt64_explain;
+
+DROP TABLE IF EXISTS t_d32_explain;
+
+CREATE TABLE t_d32_explain (id String, d Date32)
+ENGINE = MergeTree() PARTITION BY toDate(d) ORDER BY id;
+
+SYSTEM STOP MERGES t_d32_explain;
+
+INSERT INTO t_d32_explain VALUES ('a', '2026-02-20');
+INSERT INTO t_d32_explain VALUES ('b', '2026-02-21');
+INSERT INTO t_d32_explain VALUES ('c', '2026-02-22');
+
+SELECT 'Date32 post-epoch: prunes partitions';
+EXPLAIN indexes = 1 SELECT id FROM t_d32_explain WHERE d >= '2026-02-21';
+
+SELECT 'Date32 pre-epoch: no pruning';
+EXPLAIN indexes = 1 SELECT id FROM t_d32_explain WHERE d >= '1969-12-31';
+
+SELECT 'Date32 upper bound: no pruning';
+EXPLAIN indexes = 1 SELECT id FROM t_d32_explain WHERE d >= '2149-06-07';
+
+DROP TABLE t_d32_explain;

--- a/tests/queries/0_stateless/03980_datetime64_preepoch_partition_pruning_explain.sql
+++ b/tests/queries/0_stateless/03980_datetime64_preepoch_partition_pruning_explain.sql
@@ -1,5 +1,7 @@
 -- Tags: no-replicated-database, no-parallel-replicas, no-parallel, no-random-merge-tree-settings
 -- EXPLAIN output may differ
+-- Verify that partition pruning is disabled when toDate() would overflow (pre-epoch / post-2149),
+-- but still works for normal in-range values
 
 SET optimize_use_implicit_projections = 0, session_timezone = 'UTC';
 


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixes incorrect partition pruning in cases of using pre-epoch DateTime64 with `toDate()` function

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.43`
<!-- ch-version-info:end -->