### PR TITLE
Force in-source documentation for regular functions

### DIFF
--- a/src/Functions/FunctionFactory.h
+++ b/src/Functions/FunctionFactory.h
@@ -31,7 +31,7 @@ public:
     static FunctionFactory & instance();
 
     template <typename Function>
-    void registerFunction(FunctionDocumentation doc = {}, Case case_sensitiveness = Case::Sensitive)
+    void registerFunction(FunctionDocumentation doc, Case case_sensitiveness = Case::Sensitive)
     {
         registerFunction<Function>(Function::name, std::move(doc), case_sensitiveness);
     }
@@ -56,13 +56,13 @@ public:
     void registerFunction(
         const std::string & name,
         FunctionCreator creator,
-        FunctionDocumentation doc = {},
+        FunctionDocumentation doc,
         Case case_sensitiveness = Case::Sensitive);
 
     void registerFunction(
         const std::string & name,
         FunctionSimpleCreator creator,
-        FunctionDocumentation doc = {},
+        FunctionDocumentation doc,
         Case case_sensitiveness = Case::Sensitive);
 
     FunctionDocumentation getDocumentation(const std::string & name) const;
@@ -80,7 +80,7 @@ private:
     String getFactoryName() const override { return "FunctionFactory"; }
 
     template <typename Function>
-    void registerFunction(const std::string & name, FunctionDocumentation doc = {}, Case case_sensitiveness = Case::Sensitive)
+    void registerFunction(const std::string & name, FunctionDocumentation doc, Case case_sensitiveness = Case::Sensitive)
     {
         registerFunction(name, &Function::create, std::move(doc), case_sensitiveness);
     }

--- a/src/Functions/getFuzzerData.cpp
+++ b/src/Functions/getFuzzerData.cpp
@@ -53,7 +53,7 @@ public:
 
 REGISTER_FUNCTION(GetFuzzerData)
 {
-    factory.registerFunction<FunctionGetFuzzerData>();
+    factory.registerFunction<FunctionGetFuzzerData>({});
 }
 
 }


### PR DESCRIPTION
Registering a regular function without providing in-source documentation is now disallowed.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.1101`
<!-- ch-version-info:end -->