### PR TITLE
Fix `ActiveDataPartSet::hasPartitionId`

### DIFF
--- a/src/Storages/MergeTree/ActiveDataPartSet.cpp
+++ b/src/Storages/MergeTree/ActiveDataPartSet.cpp
@@ -337,7 +337,13 @@ bool ActiveDataPartSet::hasPartitionId(const String & partition_id) const
 {
     MergeTreePartInfo info;
     info.setPartitionId(partition_id);
-    return part_info_to_name.lower_bound(info) != part_info_to_name.end();
+
+    if (auto it = part_info_to_name.lower_bound(info); it == part_info_to_name.end())
+        return false;
+    else if (it->first.getPartitionId() != partition_id)
+        return false;
+    else
+        return true;
 }
 
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
After this patch, `hasPartitionId` will return false if another partition with a higher partition ID exists in the data part set.



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.291`
- Backported to: `26.1.5.3`, `25.12.9.8`
<!-- ch-version-info:end -->