### PR TITLE
test: disable 03791_rmt_watches for object storages (too slow)

### DIFF
--- a/tests/queries/0_stateless/03791_rmt_watches.sh
+++ b/tests/queries/0_stateless/03791_rmt_watches.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: long, no-parallel, no-shared-merge-tree
+# Tags: long, no-parallel, no-shared-merge-tree, no-object-storage
 # - SMT/MinIO cannot handle this amount of parts in reasonable time
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)


### PR DESCRIPTION
CI found [1]:

    2026.02.23 14:55:58.216849 [ 4635 ] {4f0184c4-8689-4e29-9573-e5b157457cb6} <Trace> WriteBufferFromS3: Create WriteBufferFromS3, Details: bucket test, key test/xlz/zelkeuohstlbgcqhzalgqfmshtjdg (LogSeriesLimiter: on interval from 2026-02-23 06:55:53 to 2026-02-23 06:55:58 accepted series 1 / 1632 for the logger WriteBufferFromS3)
    ...
    2026.02.23 14:56:54.918571 [ 6290 ] {4f0184c4-8689-4e29-9573-e5b157457cb6} <Information> WriteBufferFromS3: WriteBufferFromS3 was canceled.The file might not be written to S3. Details: bucket test, key test/end/xcdkdivdnbvylqqkjgcrxfvchtvfp, total size 42, count 42, hidden_size 0, offset 0, with pool: true, prefinalized: true, finalized: false.
    ...
    2026-02-23 18:57:08 [a9b3942789fb] 2026.02.23 06:56:54.769844 [ 6290 ] {4f0184c4-8689-4e29-9573-e5b157457cb6} <Error> executeQuery: Code: 159. DB::Exception: Timeout exceeded: elapsed 61282.248578 ms, maximum: 60000 ms. (TIMEOUT_EXCEEDED) (version 26.2.1.1079) (from [::1]:36796) (comment: 03791_rmt_watches.sh-test_z97fb1z0) (query 3, line 4) (in query: -- Override send_logs_level to suppress 'MergeTreeDataWriter: INSERT query from initial_user default ({}) inserted a block that created parts in 1000 partitions. This is being logged rather than throwing an exception as throw_on_max_partitions_per_insert_block=false.'

CI: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=97742&sha=7c96a88f9519df622f85db1a04648ff1a24a9b8d&name_0=PR&name_1=Stateless%20tests%20%28amd_binary%2C%20old%20analyzer%2C%20s3%20storage%2C%20DatabaseReplicated%2C%20sequential%29
https://github.com/ClickHouse/ClickHouse/pull/97742

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.1099`
<!-- ch-version-info:end -->