### PR TITLE
Apply data skipping indexes during distributed index analysis

### DIFF
--- a/src/Interpreters/ClusterProxy/distributedIndexAnalysis.h
+++ b/src/Interpreters/ClusterProxy/distributedIndexAnalysis.h
@@ -30,7 +30,7 @@ using LocalIndexAnalysisCallback = std::function<IndexAnalysisPartsRanges(const 
 DistributedIndexAnalysisPartsRanges distributedIndexAnalysisOnReplicas(
     const StorageID & storage_id,
     const ActionsDAG * filter_actions_dag,
-    const Names & primary_key_column_names,
+    const NameSet & indexes_column_names,
     const RangesInDataParts & parts_with_ranges,
     const OptionalVectorSearchParameters & vector_search_parameters,
     LocalIndexAnalysisCallback local_index_analysis_callback,

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -2267,6 +2267,10 @@ ReadFromMergeTree::AnalysisResultPtr ReadFromMergeTree::selectRangesToRead(
             query_info_,
             metadata_snapshot);
 
+    Names primary_key_and_useful_skip_indexes_column_names = primary_key_column_names;
+    for (const auto & skip_index : indexes->skip_indexes.useful_indices)
+        primary_key_and_useful_skip_indexes_column_names.append_range(skip_index.index->getColumnsRequiredForIndexCalc());
+
     indexes->use_skip_indexes_on_data_read = supports_skip_indexes_on_data_read;
     if (indexes->part_values && indexes->part_values->empty())
         return std::make_shared<AnalysisResult>(std::move(result));
@@ -2410,7 +2414,7 @@ ReadFromMergeTree::AnalysisResultPtr ReadFromMergeTree::selectRangesToRead(
                 return filterPartsNamesByPrimaryKeyAndSkipIndexes(filter_context, parts_ranges_map, parts_to_analyze);
             };
 
-            DistributedIndexAnalysisPartsRanges distributed_index_analysis = distributedIndexAnalysisOnReplicas(data.getStorageID(), query_info_.filter_actions_dag.get(), primary_key_column_names, res_parts, vector_search_parameters, local_index_analysis_callback, context_);
+            DistributedIndexAnalysisPartsRanges distributed_index_analysis = distributedIndexAnalysisOnReplicas(data.getStorageID(), query_info_.filter_actions_dag.get(), primary_key_and_useful_skip_indexes_column_names, res_parts, vector_search_parameters, local_index_analysis_callback, context_);
             IndexAnalysisPartsRanges analyzed_parts_ranges;
 
             /// Index stats

--- a/tests/queries/0_stateless/03622_distributed_index_analysis_applies_skip_indexes.reference
+++ b/tests/queries/0_stateless/03622_distributed_index_analysis_applies_skip_indexes.reference
@@ -1,0 +1,39 @@
+100	200
+-- { echo }
+explain indexes=1 select * from test_1m where value > 800_000*100 settings distributed_index_analysis=0;
+Expression ((Project names + Projection))
+  Expression ((WHERE + Change column names to column identifiers))
+    ReadFromMergeTree (default.test_1m)
+    Indexes:
+      PrimaryKey
+        Condition: true
+        Parts: 100/100
+        Granules: 100/100
+      Skip
+        Name: value_idx
+        Description: minmax GRANULARITY 1
+        Condition: (value in [80000001, +Inf))
+        Parts: 20/100
+        Granules: 20/100
+      Ranges: 20
+explain indexes=1 select * from test_1m where value > 800_000*100 settings distributed_index_analysis=1;
+Expression ((Project names + Projection))
+  Expression ((WHERE + Change column names to column identifiers))
+    ReadFromMergeTree (default.test_1m)
+    Indexes:
+      PrimaryKey
+        Condition: true
+        Parts: 20/100
+        Granules: 20/100
+        Distributed:
+          Address: 127.0.0.1:9000
+          Parts send: 56
+          Parts received: 8
+          Granules send: 56
+          Granules received: 8
+          Address: 127.0.0.2:9000
+          Parts send: 44
+          Parts received: 12
+          Granules send: 44
+          Granules received: 12
+      Ranges: 20

--- a/tests/queries/0_stateless/03622_distributed_index_analysis_applies_skip_indexes.sql
+++ b/tests/queries/0_stateless/03622_distributed_index_analysis_applies_skip_indexes.sql
@@ -1,0 +1,20 @@
+-- Tags: long
+
+drop table if exists test_1m;
+-- -min_bytes_for_wide_part -- wide parts are different (they respect index_granularity completely, unlike compact parts) -- FIXME
+-- -index_granularity* -- test relies on number of granulas
+create table test_1m (key Int, value Int, index value_idx value type minmax granularity 1) engine=MergeTree() order by key settings index_granularity=8192, min_bytes_for_wide_part=1e9, index_granularity_bytes=10e6, distributed_index_analysis_min_parts_to_activate=0, distributed_index_analysis_min_indexes_bytes_to_activate=0;
+system stop merges test_1m;
+insert into test_1m select number, number*100 from numbers(1e6) settings max_block_size=10000, min_insert_block_size_rows=10000, max_insert_threads=1;
+select count(), sum(marks) from system.parts where database = currentDatabase() and table = 'test_1m' and active;
+
+set cluster_for_parallel_replicas='test_cluster_one_shard_two_replicas';
+set max_parallel_replicas=2;
+set use_query_condition_cache=0;
+-- Parallel replicas changes EXPLAIN output
+set allow_experimental_parallel_reading_from_replicas=0;
+set allow_experimental_analyzer=1;
+
+-- { echo }
+explain indexes=1 select * from test_1m where value > 800_000*100 settings distributed_index_analysis=0;
+explain indexes=1 select * from test_1m where value > 800_000*100 settings distributed_index_analysis=1;


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Apply data skipping indexes during distributed index analysis

Follow-up for: https://github.com/ClickHouse/ClickHouse/pull/86786


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.16`
- Backported to: `26.2.1.1114`
<!-- ch-version-info:end -->