### PR TITLE
Speed up LZ4 decompression of 16 byte blocks in ARM

### DIFF
--- a/src/Compression/LZ4_decompress_faster.cpp
+++ b/src/Compression/LZ4_decompress_faster.cpp
@@ -38,7 +38,8 @@ ALWAYS_INLINE void copyFromOutput(UInt8 * dst, UInt8 * src)
 template <size_t block_size>
 ALWAYS_INLINE void wildCopyFromInput(UInt8 * __restrict dst, const UInt8 * __restrict src, size_t size)
 {
-    /// Unrolling with clang is doing >10% performance degrade.
+    /// Unrolling with clang is doing >10% performance degrade on x86.
+    /// On ARM (Graviton 4) the pragma has no measurable effect.
     size_t i = 0;
     #pragma nounroll
     do
@@ -54,7 +55,8 @@ ALWAYS_INLINE void wildCopyFromInput(UInt8 * __restrict dst, const UInt8 * __res
 template <size_t block_size>
 ALWAYS_INLINE void wildCopyFromOutput(UInt8 * dst, const UInt8 * src, size_t size)
 {
-    /// Unrolling with clang is doing >10% performance degrade.
+    /// Unrolling with clang is doing >10% performance degrade on x86.
+    /// On ARM (Graviton 4) the pragma has no measurable effect.
     size_t i = 0;
     #pragma nounroll
     do

--- a/src/Compression/LZ4_decompress_faster.cpp
+++ b/src/Compression/LZ4_decompress_faster.cpp
@@ -16,6 +16,7 @@
 #include <arm_neon.h>
 #endif
 
+
 namespace LZ4
 {
 
@@ -175,6 +176,10 @@ template <>
 
 #elif defined(__aarch64__) && defined(__ARM_NEON)
 
+    /// Single `vtbl1_u8` is a native 8-byte D-register operation on ARM — measured 6% faster
+    /// than the scalar fallback on Graviton 4 (geo mean 0.940x across test.hits columns).
+    /// Unlike `copyOverlap<16>` and `copyOverlap<32>` where NEON `vtbl2_u8` was slower
+    /// than scalar due to needing multiple calls, this single-instruction path is a clear win.
     static constexpr UInt8 __attribute__((__aligned__(8))) masks[] =
     {
         0, 1, 2, 2, 4, 3, 2, 1, /* offset = 0, not used as mask, but for shift amount instead */

--- a/src/Compression/LZ4_decompress_faster.cpp
+++ b/src/Compression/LZ4_decompress_faster.cpp
@@ -251,6 +251,10 @@ template <>
     /// MSAN does not recognize the store as initializing the memory
     __msan_unpoison(op, 16);
 
+    /// Note: an ARM NEON path using `vqtbl1q_u8` (Q-register 16-byte table lookup) was tested
+    /// on Graviton 4 but showed no improvement over the scalar fallback (geo mean 1.0000x across
+    /// test.hits columns). The previous `vtbl2_u8` (D-register) path was actively slower.
+
 #else
     /// 4 % n.
     static constexpr UInt8 shift1[] = {0, 1, 2, 1, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4};
@@ -376,6 +380,11 @@ template <>
     }
 
     match += shifts[offset];
+
+    /// Note: an ARM NEON path using two `vqtbl1q_u8` calls (Q-register 16-byte table lookup)
+    /// was tested on Graviton 4 but showed no improvement over the scalar fallback (geo mean
+    /// 1.0000x across test.hits columns). The previous `vtbl2_u8` (D-register) path was also
+    /// slower due to needing four calls per 32 bytes.
 
 #else
     /** Fallback implementation without SIMD instructions.

--- a/src/Compression/LZ4_decompress_faster.cpp
+++ b/src/Compression/LZ4_decompress_faster.cpp
@@ -620,8 +620,10 @@ bool decompress(
     if (source_size == 0 || dest_size == 0)
         return true;
 
-    /// Don't run timer if the block is too small.
-    if (dest_size >= 32768)
+    /// When a specific method is forced, always use it regardless of block size.
+    /// The size threshold below only applies to the adaptive bandit algorithm
+    /// where timing very small blocks would add too much noise.
+    if (statistics.choose_method >= 0 || dest_size >= 32768)
     {
         size_t variant_size = 3;
         size_t best_variant = statistics.select(variant_size);

--- a/src/Compression/LZ4_decompress_faster.cpp
+++ b/src/Compression/LZ4_decompress_faster.cpp
@@ -651,6 +651,10 @@ bool decompress(
     /// Timing such small blocks would add too much noise to the bandit's statistics.
     /// Variant 0 is the right default here: it has the lowest per-iteration overhead
     /// and wins the majority of files (57% on test.hits), especially smaller ones.
+    /// Note: the exact threshold value is not performance-sensitive. On test.hits columns
+    /// (AMD 7950X3D), sweeping it from 0 to 32K changes the oracle total by only 0.003%,
+    /// because variant 0 is available in the bandit anyway and would be selected for
+    /// the same files. The threshold is purely a noise-reduction measure.
     return decompressImpl<8>(source, dest, source_size, dest_size);
 }
 

--- a/src/Compression/LZ4_decompress_faster.cpp
+++ b/src/Compression/LZ4_decompress_faster.cpp
@@ -244,36 +244,6 @@ template <>
     /// MSAN does not recognize the store as initializing the memory
     __msan_unpoison(op, 16);
 
-#elif defined(__aarch64__) && defined(__ARM_NEON)
-
-    static constexpr UInt8 __attribute__((__aligned__(16))) masks[] =
-    {
-        0,  1,  2,  1,  4,  1,  4,  2,  8,  7,  6,  5,  4,  3,  2,  1, /* offset = 0, not used as mask, but for shift amount instead */
-        0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, /* offset = 1 */
-        0,  1,  0,  1,  0,  1,  0,  1,  0,  1,  0,  1,  0,  1,  0,  1,
-        0,  1,  2,  0,  1,  2,  0,  1,  2,  0,  1,  2,  0,  1,  2,  0,
-        0,  1,  2,  3,  0,  1,  2,  3,  0,  1,  2,  3,  0,  1,  2,  3,
-        0,  1,  2,  3,  4,  0,  1,  2,  3,  4,  0,  1,  2,  3,  4,  0,
-        0,  1,  2,  3,  4,  5,  0,  1,  2,  3,  4,  5,  0,  1,  2,  3,
-        0,  1,  2,  3,  4,  5,  6,  0,  1,  2,  3,  4,  5,  6,  0,  1,
-        0,  1,  2,  3,  4,  5,  6,  7,  0,  1,  2,  3,  4,  5,  6,  7,
-        0,  1,  2,  3,  4,  5,  6,  7,  8,  0,  1,  2,  3,  4,  5,  6,
-        0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  0,  1,  2,  3,  4,  5,
-        0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10,  0,  1,  2,  3,  4,
-        0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11,  0,  1,  2,  3,
-        0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12,  0,  1,  2,
-        0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13,  0,  1,
-        0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,  0,
-    };
-
-    unalignedStore<uint8x8_t>(op,
-        vtbl2_u8(unalignedLoad<uint8x8x2_t>(match), unalignedLoad<uint8x8_t>(masks + 16 * offset)));
-
-    unalignedStore<uint8x8_t>(op + 8,
-        vtbl2_u8(unalignedLoad<uint8x8x2_t>(match), unalignedLoad<uint8x8_t>(masks + 16 * offset + 8)));
-
-    match += masks[offset];
-
 #else
     /// 4 % n.
     static constexpr UInt8 shift1[] = {0, 1, 2, 1, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4};


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Speed up LZ4 decompression of 16 byte blocks in ARM

- Adds a bunch of comments about things tested on ARM to verify that the assumptions made in x86 hold in that platform too.
- Most notably it removes the `copyOverlap<16>` NEON implementation which was worse  when measured in Graviton 4, where `vtbl2_u8` is slower than using the scalar code in the cases where the oracle/bandit algorithm would choose this variant. Note that by using `vqtbl1q_u8` instead you get the same performance as the scalar code, so I didn't include it (less code to maintain).

Raw measurements: https://pastila.nl/?0001509d/f94f435dfd3a2320c600a7eff3bebc9e#BM29UdAAK5SAfL847z8qdg==GCM

Here's the summary:  
```                                                                                                                
  Graviton 3 (c7gd.16xlarge) — Variant 1 improves:                                                                                        
  - -1.06% total, geo mean 0.990x. 73 faster, 16 slower, 82 neutral.                                                                      
  - Large files (-3.26%) are the big win: 20/20 faster, 0 slower.
  - 5 regressions are in Huge files (rows 8, 36, 111, 23, 167: +18-19% each).                                                             
                  
  Graviton 4 (c8g.8xlarge) — Variant 1 improves:
  - -0.72% total. 58 faster, 31 slower, 82 neutral.
  - Large files (-3.86%) again the sweet spot: 25/25 faster, 0 slower.
  - G4 Small regressions (+2.17%) are noise — rows with ~6-8K cycles gaining ~1.5K each.
  - Meaningful regressions are again in Huge files.

  The regressions are concentrated in files where the NEON vtbl2_u8 table lookup was genuinely helping (high-repetition huge blocks). But from the earlier c8g.metal oracle analysis, we know these files are handled by variant 0 or variant 2 in the bandit — oracle impact was only 0.005%. The bandit never needs to rely on variant 1 for these files.
```


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.87`
<!-- ch-version-info:end -->