### PR TITLE
Keeper Client: do not traverse children of super nodes

### DIFF
--- a/src/Common/ZooKeeper/KeeperClientCLI/Commands.cpp
+++ b/src/Common/ZooKeeper/KeeperClientCLI/Commands.cpp
@@ -390,7 +390,11 @@ void FindSuperNodes::execute(const ASTKeeperQuery * query, KeeperClientBase * cl
         bool onListChildren(const fs::path & path, const Strings & children, const KeeperClientBase * client_) const
         {
             if (children.size() >= threshold)
+            {
                 client_->cout << static_cast<String>(path) << "\t" << children.size() << "\n";
+                /// Do not traverse children of super nodes
+                return false;
+            }
             return true;
         }
 

--- a/tests/queries/0_stateless/03135_keeper_client_find_commands.reference
+++ b/tests/queries/0_stateless/03135_keeper_client_find_commands.reference
@@ -1,7 +1,7 @@
 find_super_nodes
-/test-keeper-client-default/1	4
-/test-keeper-client-default/1/d	3
+/test-keeper-client-default/1/a	3
+/test-keeper-client-default/2	4
 find_big_family
-/test-keeper-client-default	10
+/test-keeper-client-default	15
 /test-keeper-client-default/1	9
-/test-keeper-client-default/1/d	4
+/test-keeper-client-default/1/a	7

--- a/tests/queries/0_stateless/03135_keeper_client_find_commands.sh
+++ b/tests/queries/0_stateless/03135_keeper_client_find_commands.sh
@@ -8,16 +8,37 @@ path="/test-keeper-client-$CLICKHOUSE_DATABASE"
 
 $CLICKHOUSE_KEEPER_CLIENT -q "rm '$path'" >& /dev/null
 
+# Tree structure:
+# /path
+# ├── 1
+# │   ├── a      (3 children: x, y, z) - super node
+# │   │   ├── x  (3 children: p, q, r) - nested super node
+# │   │   │   ├── p
+# │   │   │   ├── q
+# │   │   │   └── r
+# │   │   ├── y
+# │   │   └── z
+# │   └── b
+# └── 2          (4 children: a, b, c, d) - super node
+#     ├── a
+#     ├── b
+#     ├── c
+#     └── d
 $CLICKHOUSE_KEEPER_CLIENT -q "create '$path' 'foobar'"
 $CLICKHOUSE_KEEPER_CLIENT -q "create '$path/1' 'foobar'"
 $CLICKHOUSE_KEEPER_CLIENT -q "create '$path/1/a' 'foobar'"
-$CLICKHOUSE_KEEPER_CLIENT -q "create '$path/1/a/a' 'foobar'"
+$CLICKHOUSE_KEEPER_CLIENT -q "create '$path/1/a/x' 'foobar'"
+$CLICKHOUSE_KEEPER_CLIENT -q "create '$path/1/a/x/p' 'foobar'"
+$CLICKHOUSE_KEEPER_CLIENT -q "create '$path/1/a/x/q' 'foobar'"
+$CLICKHOUSE_KEEPER_CLIENT -q "create '$path/1/a/x/r' 'foobar'"
+$CLICKHOUSE_KEEPER_CLIENT -q "create '$path/1/a/y' 'foobar'"
+$CLICKHOUSE_KEEPER_CLIENT -q "create '$path/1/a/z' 'foobar'"
 $CLICKHOUSE_KEEPER_CLIENT -q "create '$path/1/b' 'foobar'"
-$CLICKHOUSE_KEEPER_CLIENT -q "create '$path/1/c' 'foobar'"
-$CLICKHOUSE_KEEPER_CLIENT -q "create '$path/1/d' 'foobar'"
-$CLICKHOUSE_KEEPER_CLIENT -q "create '$path/1/d/a' 'foobar'"
-$CLICKHOUSE_KEEPER_CLIENT -q "create '$path/1/d/b' 'foobar'"
-$CLICKHOUSE_KEEPER_CLIENT -q "create '$path/1/d/c' 'foobar'"
+$CLICKHOUSE_KEEPER_CLIENT -q "create '$path/2' 'foobar'"
+$CLICKHOUSE_KEEPER_CLIENT -q "create '$path/2/a' 'foobar'"
+$CLICKHOUSE_KEEPER_CLIENT -q "create '$path/2/b' 'foobar'"
+$CLICKHOUSE_KEEPER_CLIENT -q "create '$path/2/c' 'foobar'"
+$CLICKHOUSE_KEEPER_CLIENT -q "create '$path/2/d' 'foobar'"
 
 echo 'find_super_nodes'
 $CLICKHOUSE_KEEPER_CLIENT -q "find_super_nodes 1000000000"


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
`find_super_nodes` is a very useful command for debugging unexpected growth in the node count in Keeper.
Unfortunately, if there are multiple super nodes, it's almost impossible to find more than one, because the command gets stuck forever traversing the children of the first encountered super node. This PR forbids traversing the children of super nodes.

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.1122`
<!-- ch-version-info:end -->