### PR TITLE
Fix "Cannot schedule a file" LOGICAL_ERROR on INSERT into Distributed due to race between DROP and INSERT

### DIFF
--- a/src/Storages/Distributed/DistributedAsyncInsertDirectoryQueue.cpp
+++ b/src/Storages/Distributed/DistributedAsyncInsertDirectoryQueue.cpp
@@ -317,12 +317,6 @@ bool DistributedAsyncInsertDirectoryQueue::hasPendingFiles() const
     return fs::exists(current_batch_file_path) || !current_file.empty() || !pending_files.empty();
 }
 
-void DistributedAsyncInsertDirectoryQueue::addFile(const std::string & file_path)
-{
-    if (!pending_files.push(fs::absolute(file_path).string()))
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot schedule a file '{}'", file_path);
-}
-
 void DistributedAsyncInsertDirectoryQueue::initializeFilesFromDisk()
 {
     /// NOTE: This method does not requires to hold status_mutex (because this
@@ -341,8 +335,8 @@ void DistributedAsyncInsertDirectoryQueue::initializeFilesFromDisk()
             const auto & base_name = file_path.stem().string();
             if (!it->is_directory() && startsWith(fs::path(file_path).extension(), ".bin") && parse<UInt64>(base_name))
             {
-                const std::string & file_path_str = file_path.string();
-                addFile(file_path_str);
+                if (!pending_files.push(fs::absolute(file_path).string()))
+                    throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot schedule a file '{}'", file_path.string());
                 bytes_count += fs::file_size(file_path);
             }
             else if (base_name != "tmp" && base_name != "broken")
@@ -517,15 +511,11 @@ struct DistributedAsyncInsertDirectoryQueue::BatchHeader
 
 bool DistributedAsyncInsertDirectoryQueue::addFileAndSchedule(const std::string & file_path, size_t file_size, size_t ms)
 {
-    /// NOTE: It is better not to throw in this case, since the file is already
-    /// on disk (see DistributedSink), and it will be processed next time.
-    if (pending_files.isFinished())
+    if (!pending_files.push(fs::absolute(file_path).string()))
     {
         LOG_DEBUG(log, "File {} had not been scheduled, since the table had been detached", file_path);
         return false;
     }
-
-    addFile(file_path);
 
     {
         std::lock_guard lock(status_mutex);
@@ -652,7 +642,7 @@ void DistributedAsyncInsertDirectoryQueue::processFilesWithBatching(bool force, 
             for (const auto & file : batch.files)
             {
                 if (!pending_files.pushFront(file))
-                    throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot re-schedule a file '{}'", file);
+                    LOG_DEBUG(log, "File {} had not been scheduled, since the table had been detached", file);
             }
         }
         /// Rethrow exception

--- a/src/Storages/Distributed/DistributedAsyncInsertDirectoryQueue.h
+++ b/src/Storages/Distributed/DistributedAsyncInsertDirectoryQueue.h
@@ -101,7 +101,6 @@ private:
 
     bool hasPendingFiles() const;
 
-    void addFile(const std::string & file_path);
     void initializeFilesFromDisk();
     /// Set `force = true` if processing of files must be finished fully despite cancellation flag being set
     void processFiles(bool force, const SettingsChanges & settings_changes = {});

--- a/tests/queries/0_stateless/03998_distributed_insert_detach_race.sh
+++ b/tests/queries/0_stateless/03998_distributed_insert_detach_race.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Tags: long
+
+# Stress test for the race between async INSERT into Distributed and DETACH.
+# Before the fix, this could cause "Cannot schedule a file" LOGICAL_ERROR.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT -nmq "
+    DROP TABLE IF EXISTS dist_03998;
+    DROP TABLE IF EXISTS local_03998;
+    CREATE TABLE local_03998 (x UInt64) ENGINE = Null;
+    CREATE TABLE dist_03998 (x UInt64) ENGINE = Distributed(test_cluster_two_shards, currentDatabase(), local_03998, x);
+"
+
+function insert_thread()
+{
+    for _ in {1..100}; do
+        ${CLICKHOUSE_CURL} -sfS "$CLICKHOUSE_URL&distributed_foreground_insert=0&prefer_localhost_replica=0" -d "INSERT INTO dist_03998 VALUES (1)(2)" >& /dev/null
+    done
+}
+
+function detach_attach_thread()
+{
+    # Small delay to do some INSERTs just in case
+    sleep 0.3
+    for _ in {1..100}; do
+        ${CLICKHOUSE_CURL} -sfS "$CLICKHOUSE_URL" -d "DETACH TABLE dist_03998" >& /dev/null
+        ${CLICKHOUSE_CURL} -sfS "$CLICKHOUSE_URL" -d "ATTACH TABLE dist_03998" >& /dev/null
+    done
+}
+
+insert_thread &
+detach_attach_thread &
+
+wait
+
+# Reattach in case the table was left detached
+$CLICKHOUSE_CLIENT -q "ATTACH TABLE dist_03998" 2>/dev/null
+
+# Flush any remaining async inserts
+$CLICKHOUSE_CLIENT -q "SYSTEM FLUSH DISTRIBUTED dist_03998"
+
+$CLICKHOUSE_CLIENT -nmq "
+    DROP TABLE dist_03998;
+    DROP TABLE local_03998;
+"


### PR DESCRIPTION
CI found [1]:

    2026.02.24 00:13:52.961387 [ 1044 ] {5e384df2-8deb-4a89-a134-bb86e8ef36ab} <Debug> DatabaseAtomic (system): Trying to create a symlink for table system.aggregated_zookeeper_log_sender (6ec86c13-3744-45fa-945b-653142580b11), data_path /home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/ci/tmp/run_r0/store/6ec/6ec86c13-3744-45fa-945b-653142580b11/, link data/system/aggregated_zookeeper_log_sender
    2026.02.24 00:17:12.951551 [ 3720 ] {9605ffdf-c2ef-41fe-9ae6-31fd806c9031} <Debug> executeQuery: (from [::1]:55766) (query 1, line 1) drop table system.aggregated_zookeeper_log_sender (stage: Complete)
    2026.02.24 00:17:12.990510 [ 3720 ] {9605ffdf-c2ef-41fe-9ae6-31fd806c9031} <Debug> StorageDistributed (aggregated_zookeeper_log_sender): Background threads for async INSERT joined
    2026.02.24 00:17:12.990441 [ 1849 ] {} <Fatal> : Logical error: 'Cannot schedule a file '/home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/ci/tmp/run_r0/store/6ec/6ec86c13-3744-45fa-945b-653142580b11/shard1_replica1/1.bin''.

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=97810&sha=f832979d2162146065876dd160482dfa2f640646&name_0=PR&name_1=Stateless%20tests%20%28amd_ubsan%2C%20flaky%20check%29
https://github.com/ClickHouse/ClickHouse/pull/97810

Fixes: https://github.com/ClickHouse/ClickHouse/issues/92809

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `Cannot schedule a file` `LOGICAL_ERROR` on `INSERT` into `Distributed` due to race between `DROP` and `INSERT`


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.13`
<!-- ch-version-info:end -->