### PR TITLE
Fix crash with mapContainsKey/mapContainsKeyLike

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.cpp
@@ -500,7 +500,7 @@ bool MergeTreeConditionBloomFilterText::traverseTreeEquals(
     {
         if (function_name == "has" || function_name == "mapContainsKey" || function_name == "mapContains")
         {
-            out.key_column = *key_index;
+            out.key_column = *map_key_index;
             out.function = RPNElement::FUNCTION_HAS;
             out.bloom_filter = std::make_unique<BloomFilter>(params);
             auto & value = const_value.safeGet<String>();
@@ -509,7 +509,7 @@ bool MergeTreeConditionBloomFilterText::traverseTreeEquals(
         }
         if (function_name == "mapContainsKeyLike")
         {
-            out.key_column = *key_index;
+            out.key_column = *map_key_index;
             out.function = RPNElement::FUNCTION_HAS;
             out.bloom_filter = std::make_unique<BloomFilter>(params);
             auto & value = const_value.safeGet<String>();

--- a/tests/queries/0_stateless/03988_map_contains_key_like_tokenbf.reference
+++ b/tests/queries/0_stateless/03988_map_contains_key_like_tokenbf.reference
@@ -1,0 +1,18 @@
+1
+0
+1
+1
+1
+1
+1
+1
+0
+hostname
+Verify skip index is used
+1
+1
+1
+1
+1
+1
+1

--- a/tests/queries/0_stateless/03988_map_contains_key_like_tokenbf.sql
+++ b/tests/queries/0_stateless/03988_map_contains_key_like_tokenbf.sql
@@ -1,0 +1,65 @@
+-- Test for issue https://github.com/ClickHouse/ClickHouse/issues/97792
+
+SET parallel_replicas_local_plan = 1;
+
+DROP TABLE IF EXISTS t_map_tokenbf;
+
+CREATE TABLE t_map_tokenbf
+(
+    metadata Map(String, String),
+    created_at DateTime64(3),
+    INDEX index_metadata_keys mapKeys(metadata) TYPE tokenbf_v1(32768, 3, 0) GRANULARITY 1,
+    INDEX index_metadata_vals mapValues(metadata) TYPE tokenbf_v1(32768, 3, 0) GRANULARITY 1
+)
+ENGINE = MergeTree
+ORDER BY created_at;
+
+INSERT INTO t_map_tokenbf VALUES ({'hostname': 'myhost', 'env': 'prod'}, now());
+
+SELECT count() FROM t_map_tokenbf WHERE mapContainsKeyLike(metadata, '%host%'); -- 1
+SELECT count() FROM t_map_tokenbf WHERE mapContainsKeyLike(metadata, '%bad%'); -- 0
+SELECT count() FROM t_map_tokenbf WHERE mapContains(metadata, 'hostname'); -- 1
+SELECT count() FROM t_map_tokenbf WHERE mapContainsKey(metadata, 'env'); -- 1
+SELECT count() FROM t_map_tokenbf WHERE has(mapKeys(metadata), 'env'); -- 1
+SELECT count() FROM t_map_tokenbf WHERE has(metadata, 'hostname'); -- 1
+SELECT count() FROM t_map_tokenbf WHERE mapContainsValue(metadata, 'prod'); -- 1
+SELECT count() FROM t_map_tokenbf WHERE mapContainsValueLike(metadata, '%host%'); -- 1
+SELECT count() FROM t_map_tokenbf WHERE mapContainsValueLike(metadata, '%random%'); -- 0
+
+SELECT arrayJoin(mapKeys(mapExtractKeyLike(metadata, '%host%'))) as extracted_metadata
+FROM t_map_tokenbf
+WHERE mapContainsKeyLike(metadata, '%host%')
+GROUP BY extracted_metadata;
+
+-- Verify that skip index was used - all should return 1
+SELECT 'Verify skip index is used';
+
+SELECT COUNT(*) FROM (
+        EXPLAIN indexes=1 SELECT count() FROM t_map_tokenbf WHERE mapContainsKeyLike(metadata, '%host%')
+    ) WHERE explain LIKE '%index_metadata%';
+
+SELECT COUNT(*) FROM (
+        EXPLAIN indexes=1 SELECT count() FROM t_map_tokenbf WHERE mapContains(metadata, 'hostname')
+    ) WHERE explain LIKE '%index_metadata%';
+
+SELECT COUNT(*) FROM (
+        EXPLAIN indexes=1 SELECT count() FROM t_map_tokenbf WHERE mapContainsKey(metadata, 'env')
+    ) WHERE explain LIKE '%index_metadata%';
+
+SELECT COUNT(*) FROM (
+        EXPLAIN indexes=1 SELECT count() FROM t_map_tokenbf WHERE has(mapKeys(metadata), 'env')
+    ) WHERE explain LIKE '%index_metadata%';
+
+SELECT COUNT(*) FROM (
+        EXPLAIN indexes=1 SELECT count() FROM t_map_tokenbf WHERE has(metadata, 'hostname') 
+    ) WHERE explain LIKE '%index_metadata%';
+
+SELECT COUNT(*) FROM (
+        EXPLAIN indexes=1 SELECT count() FROM t_map_tokenbf WHERE mapContainsValue(metadata, 'prod')
+    ) WHERE explain LIKE '%index_metadata%';
+
+SELECT COUNT(*) FROM (
+        EXPLAIN indexes=1 SELECT count() FROM t_map_tokenbf WHERE mapContainsValueLike(metadata, '%random%')
+    ) WHERE explain LIKE '%index_metadata%';
+
+DROP TABLE t_map_tokenbf;


### PR DESCRIPTION
Resolves https://github.com/ClickHouse/ClickHouse/issues/97792
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
- Fixed ClickHouse server crash/assert in call to `mapContainsKey/mapContainsKeyLike` with `tokenbf_v1` skip index


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.53`
- Backported to: `26.2.1.1139`, `26.1.5.27`, `25.12.9.33`, `25.8.19.11`
<!-- ch-version-info:end -->