### PR TITLE
Attribute the thread of Iceberg Iterator to query thread group

### DIFF
--- a/src/Common/setThreadName.h
+++ b/src/Common/setThreadName.h
@@ -65,6 +65,7 @@ namespace DB
     M(HASHED_DICT_DTOR, "HashedDictDtor") \
     M(HASHED_DICT_LOAD, "HashedDictLoad") \
     M(HTTP_HANDLER, "HTTPHandler") \
+    M(ICEBERG_ITERATOR, "IcebergIter") \
     M(INTERSERVER_HANDLER, "IntersrvHandler") \
     M(IO_URING_MONITOR, "IoUringMonitr") \
     M(KEEPER_HANDLER, "KeeperHandler") \

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergIterator.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergIterator.cpp
@@ -329,9 +329,12 @@ IcebergIterator::IcebergIterator(
     LOG_DEBUG(logger, "Taken {} position deletes file and {} equality deletes files in iceberg iterator", position_deletes_files.size(), equality_deletes_files.size());
     std::sort(equality_deletes_files.begin(), equality_deletes_files.end());
     std::sort(position_deletes_files.begin(), position_deletes_files.end());
+    auto group = CurrentThread::getGroup();
     producer_task.emplace(
-        [this]()
+        [this, group]()
         {
+            CurrentThread::attachToGroup(group);
+            SCOPE_EXIT(CurrentThread::detachFromGroupIfNotDetached());
             while (!blocking_queue.isFinished())
             {
                 std::optional<ManifestFileEntryPtr> entry;

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergIterator.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergIterator.cpp
@@ -210,11 +210,11 @@ std::optional<ManifestFileEntryPtr> SingleThreadIcebergKeysIterator::next()
                 case PruningReturnStatus::NOT_PRUNED:
                     return manifest_file_entry;
                 case PruningReturnStatus::MIN_MAX_INDEX_PRUNED: {
-                    ++min_max_index_pruned_files;
+                    ProfileEvents::increment(ProfileEvents::IcebergMinMaxIndexPrunedFiles, 1);
                     break;
                 }
                 case PruningReturnStatus::PARTITION_PRUNED: {
-                    ++partition_pruned_files;
+                    ProfileEvents::increment(ProfileEvents::IcebergPartitionPrunedFiles, 1);
                     break;
                 }
             }
@@ -228,14 +228,6 @@ std::optional<ManifestFileEntryPtr> SingleThreadIcebergKeysIterator::next()
     }
 
     return std::nullopt;
-}
-
-SingleThreadIcebergKeysIterator::~SingleThreadIcebergKeysIterator()
-{
-    if (partition_pruned_files > 0)
-        ProfileEvents::increment(ProfileEvents::IcebergPartitionPrunedFiles, partition_pruned_files);
-    if (min_max_index_pruned_files > 0)
-        ProfileEvents::increment(ProfileEvents::IcebergMinMaxIndexPrunedFiles, min_max_index_pruned_files);
 }
 
 SingleThreadIcebergKeysIterator::SingleThreadIcebergKeysIterator(

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergIterator.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergIterator.cpp
@@ -324,7 +324,7 @@ IcebergIterator::IcebergIterator(
     producer_task.emplace(
         [this, thread_group = CurrentThread::getGroup()]()
         {
-            DB::ThreadGroupSwitcher switcher(thread_group, DB::ThreadName::DATALAKE_TABLE_SNAPSHOT);
+            DB::ThreadGroupSwitcher switcher(thread_group, DB::ThreadName::ICEBERG_ITERATOR);
             while (!blocking_queue.isFinished())
             {
                 std::optional<ManifestFileEntryPtr> entry;

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergIterator.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergIterator.h
@@ -49,8 +49,6 @@ public:
 
     std::optional<DB::Iceberg::ManifestFileEntryPtr> next();
 
-    ~SingleThreadIcebergKeysIterator();
-
 private:
     ObjectStoragePtr object_storage;
     std::shared_ptr<const ActionsDAG> filter_dag;
@@ -72,9 +70,6 @@ private:
     std::optional<Iceberg::ManifestFilesPruner> current_pruner;
 
     const Iceberg::ManifestFileContentType manifest_file_content_type;
-
-    size_t min_max_index_pruned_files = 0;
-    size_t partition_pruned_files = 0;
 };
 
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.35`
- Backported to: `26.2.4.8`, `26.1.4.28`, `25.12.8.13`
<!-- ch-version-info:end -->