### PR TITLE
Fix inconsistent AST formatting for functions with NULLS modifier and noEmptyArgs

### DIFF
--- a/src/Parsers/ASTFunction.cpp
+++ b/src/Parsers/ASTFunction.cpp
@@ -704,7 +704,12 @@ void ASTFunction::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSetting
         ostr << ')';
     }
 
-    if ((arguments && !arguments->children.empty()) || !noEmptyArgs())
+    /// If the function has a NULLS modifier (IGNORE NULLS / RESPECT NULLS), we must always print
+    /// parentheses, otherwise the modifier cannot be parsed back (e.g. `count IGNORE NULLS` is not parseable).
+    bool has_nulls_action = getNullsAction() != NullsAction::EMPTY;
+    bool need_parens = (arguments && !arguments->children.empty()) || !noEmptyArgs() || has_nulls_action;
+
+    if (need_parens)
         ostr << '(';
 
     if (arguments)
@@ -780,7 +785,7 @@ void ASTFunction::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSetting
         }
     }
 
-    if ((arguments && !arguments->children.empty()) || !noEmptyArgs())
+    if (need_parens)
         ostr << ')';
 
     finishFormatWithWindow(ostr, settings, state, frame);

--- a/tests/queries/0_stateless/03989_codec_ignore_nulls_formatting.reference
+++ b/tests/queries/0_stateless/03989_codec_ignore_nulls_formatting.reference
@@ -1,0 +1,2 @@
+ALTER TABLE t\n    (MODIFY COLUMN `id` UInt64 CODEC(count() IGNORE NULLS, Delta))
+ALTER TABLE t\n    (MODIFY COLUMN `id` UInt64 CODEC(count() RESPECT NULLS, Delta))

--- a/tests/queries/0_stateless/03989_codec_ignore_nulls_formatting.sql
+++ b/tests/queries/0_stateless/03989_codec_ignore_nulls_formatting.sql
@@ -1,0 +1,4 @@
+-- Reproducer for https://github.com/ClickHouse/ClickHouse/issues/97656
+-- CODEC elements with IGNORE NULLS / RESPECT NULLS modifiers must keep parentheses in formatting.
+SELECT formatQuery('ALTER TABLE t (MODIFY COLUMN id UInt64 CODEC(count() IGNORE NULLS, Delta))');
+SELECT formatQuery('ALTER TABLE t (MODIFY COLUMN id UInt64 CODEC(count() RESPECT NULLS, Delta))');


### PR DESCRIPTION
Closes https://github.com/ClickHouse/ClickHouse/issues/97656

When a function has `noEmptyArgs` set (e.g. inside CODEC definitions) and no arguments, parentheses were suppressed. But if the function also had a NULLS modifier (`IGNORE NULLS` / `RESPECT NULLS`), the modifier was appended without parentheses, producing output like `count IGNORE NULLS` which cannot be parsed back, triggering the "Inconsistent AST formatting" exception.

Now we always print parentheses when a NULLS modifier is present.

CI report: [AST fuzzer (amd_debug)](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=97497&sha=964ed73d93e5a66626f3c8c5351644648d65b77c&name_0=PR&name_1=AST%20fuzzer%20%28amd_debug%29
https://github.com/ClickHouse/ClickHouse/pull/97497)

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.57`
<!-- ch-version-info:end -->