### PR TITLE
Flush async logging buffers in case of crash

### DIFF
--- a/src/Common/SignalHandlers.cpp
+++ b/src/Common/SignalHandlers.cpp
@@ -572,7 +572,8 @@ try
             exception_trace, exception_trace_size);
     }
 
-    BaseDaemon::instance().flushTextLogs();
+    if (daemon)
+         daemon->flushTextLogs();
     Context::getGlobalContextInstance()->handleCrash();
 
     /// Send crash report to developers (if configured)

--- a/src/Common/SignalHandlers.cpp
+++ b/src/Common/SignalHandlers.cpp
@@ -572,6 +572,7 @@ try
             exception_trace, exception_trace_size);
     }
 
+    BaseDaemon::instance().flushTextLogs();
     Context::getGlobalContextInstance()->handleCrash();
 
     /// Send crash report to developers (if configured)


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Flush async logging buffers in case of crash


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.1.1116`
<!-- ch-version-info:end -->