### PR TITLE
AST Fuzzer check: add targeted job and add compatibility setting randomization

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1347,6 +1347,82 @@ jobs:
           prefix=lambda: datetime.datetime.now().strftime("[%Y-%m-%d %H:%M:%S]")
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
+  ast_fuzzer_amd_debug_targeted:
+    runs-on: [self-hosted, amd-medium]
+    needs: [build_amd_debug, build_arm_tidy, config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, fast_test, style_check]
+    if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QVNUIGZ1enplciAoYW1kX2RlYnVnLCB0YXJnZXRlZCk=') }}
+    name: "AST fuzzer (amd_debug, targeted)"
+    outputs:
+      data: ${{ steps.run.outputs.DATA }}
+      pipeline_status: ${{ steps.run.outputs.pipeline_status || 'undefined' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - name: Prepare env script
+        run: |
+          rm -rf ./ci/tmp
+          mkdir -p ./ci/tmp
+          cat > ./ci/tmp/praktika_setup_env.sh << 'ENV_SETUP_SCRIPT_EOF'
+          export PYTHONPATH=./ci:.:
+
+          cat > ./ci/tmp/workflow_job.json << 'EOF'
+          ${{ toJson(job) }}
+          EOF
+          cat > ./ci/tmp/workflow_status.json << 'EOF'
+          ${{ toJson(needs) }}
+          EOF
+          ENV_SETUP_SCRIPT_EOF
+
+      - name: Run
+        id: run
+        run: |
+          . ./ci/tmp/praktika_setup_env.sh
+          set -o pipefail
+          PYTHONUNBUFFERED=1 python3 -m praktika run 'AST fuzzer (amd_debug, targeted)' --workflow "PR" --ci 2>&1 | python3 -u -c 'import sys,datetime
+          prefix=lambda: datetime.datetime.now().strftime("[%Y-%m-%d %H:%M:%S]")
+          for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
+
+  ast_fuzzer_amd_debug_targeted_old_compatibility:
+    runs-on: [self-hosted, amd-medium]
+    needs: [build_amd_debug, build_arm_tidy, config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, fast_test, style_check]
+    if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QVNUIGZ1enplciAoYW1kX2RlYnVnLCB0YXJnZXRlZCwgb2xkX2NvbXBhdGliaWxpdHkp') }}
+    name: "AST fuzzer (amd_debug, targeted, old_compatibility)"
+    outputs:
+      data: ${{ steps.run.outputs.DATA }}
+      pipeline_status: ${{ steps.run.outputs.pipeline_status || 'undefined' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - name: Prepare env script
+        run: |
+          rm -rf ./ci/tmp
+          mkdir -p ./ci/tmp
+          cat > ./ci/tmp/praktika_setup_env.sh << 'ENV_SETUP_SCRIPT_EOF'
+          export PYTHONPATH=./ci:.:
+
+          cat > ./ci/tmp/workflow_job.json << 'EOF'
+          ${{ toJson(job) }}
+          EOF
+          cat > ./ci/tmp/workflow_status.json << 'EOF'
+          ${{ toJson(needs) }}
+          EOF
+          ENV_SETUP_SCRIPT_EOF
+
+      - name: Run
+        id: run
+        run: |
+          . ./ci/tmp/praktika_setup_env.sh
+          set -o pipefail
+          PYTHONUNBUFFERED=1 python3 -m praktika run 'AST fuzzer (amd_debug, targeted, old_compatibility)' --workflow "PR" --ci 2>&1 | python3 -u -c 'import sys,datetime
+          prefix=lambda: datetime.datetime.now().strftime("[%Y-%m-%d %H:%M:%S]")
+          for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
+
   stateless_tests_amd_asan_flaky_check:
     runs-on: [self-hosted, amd-medium]
     needs: [build_amd_asan, build_arm_tidy, config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, fast_test, style_check]
@@ -5909,7 +5985,7 @@ jobs:
 
   finish_workflow:
     runs-on: [self-hosted, style-checker-aarch64]
-    needs: [ast_fuzzer_amd_debug, ast_fuzzer_amd_msan, ast_fuzzer_amd_tsan, ast_fuzzer_amd_ubsan, ast_fuzzer_arm_asan, bugfix_validation_functional_tests, bugfix_validation_integration_tests, build_amd_asan, build_amd_binary, build_amd_compat, build_amd_darwin, build_amd_debug, build_amd_freebsd, build_amd_msan, build_amd_musl, build_amd_release, build_amd_tsan, build_amd_ubsan, build_arm_asan, build_arm_binary, build_arm_darwin, build_arm_fuzzers, build_arm_release, build_arm_tidy, build_arm_tsan, build_arm_v80compat, build_llvm_coverage_build, build_loongarch64, build_ppc64le, build_riscv64, build_s390x, build_toolchain_pgo_bolt_aarch64, build_toolchain_pgo_bolt_amd64, buzzhouse_amd_debug, buzzhouse_amd_msan, buzzhouse_amd_tsan, buzzhouse_amd_ubsan, buzzhouse_arm_asan, compatibility_check_amd_release, compatibility_check_arm_release, config_workflow, docker_keeper_image, docker_server_image, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, docs_check, fast_test, install_packages_amd_release, install_packages_arm_release, integration_tests_amd_asan_db_disk_old_analyzer_1_6, integration_tests_amd_asan_db_disk_old_analyzer_2_6, integration_tests_amd_asan_db_disk_old_analyzer_3_6, integration_tests_amd_asan_db_disk_old_analyzer_4_6, integration_tests_amd_asan_db_disk_old_analyzer_5_6, integration_tests_amd_asan_db_disk_old_analyzer_6_6, integration_tests_amd_asan_flaky, integration_tests_amd_asan_targeted, integration_tests_amd_binary_1_5, integration_tests_amd_binary_2_5, integration_tests_amd_binary_3_5, integration_tests_amd_binary_4_5, integration_tests_amd_binary_5_5, integration_tests_amd_llvm_coverage_1_5, integration_tests_amd_llvm_coverage_2_5, integration_tests_amd_llvm_coverage_3_5, integration_tests_amd_llvm_coverage_4_5, integration_tests_amd_llvm_coverage_5_5, integration_tests_amd_msan_1_6, integration_tests_amd_msan_2_6, integration_tests_amd_msan_3_6, integration_tests_amd_msan_4_6, integration_tests_amd_msan_5_6, integration_tests_amd_msan_6_6, integration_tests_amd_tsan_1_6, integration_tests_amd_tsan_2_6, integration_tests_amd_tsan_3_6, integration_tests_amd_tsan_4_6, integration_tests_amd_tsan_5_6, integration_tests_amd_tsan_6_6, integration_tests_arm_binary_distributed_plan_1_4, integration_tests_arm_binary_distributed_plan_2_4, integration_tests_arm_binary_distributed_plan_3_4, integration_tests_arm_binary_distributed_plan_4_4, llvm_coverage, performance_comparison_amd_release_master_head_1_6, performance_comparison_amd_release_master_head_2_6, performance_comparison_amd_release_master_head_3_6, performance_comparison_amd_release_master_head_4_6, performance_comparison_amd_release_master_head_5_6, performance_comparison_amd_release_master_head_6_6, performance_comparison_arm_release_master_head_1_6, performance_comparison_arm_release_master_head_2_6, performance_comparison_arm_release_master_head_3_6, performance_comparison_arm_release_master_head_4_6, performance_comparison_arm_release_master_head_5_6, performance_comparison_arm_release_master_head_6_6, quick_functional_tests, smoke_test_amd_darwin, sqllogic_test, stateless_tests_amd_asan_db_disk_distributed_plan_sequential, stateless_tests_amd_asan_distributed_plan_parallel_1_2, stateless_tests_amd_asan_distributed_plan_parallel_2_2, stateless_tests_amd_asan_flaky_check, stateless_tests_amd_binary_flaky_check, stateless_tests_amd_debug_distributed_plan_s3_storage_parallel, stateless_tests_amd_debug_distributed_plan_s3_storage_sequential, stateless_tests_amd_debug_flaky_check, stateless_tests_amd_debug_parallel, stateless_tests_amd_debug_sequential, stateless_tests_amd_llvm_coverage_1_3, stateless_tests_amd_llvm_coverage_2_3, stateless_tests_amd_llvm_coverage_3_3, stateless_tests_amd_llvm_coverage_asyncinsert_s3_storage_parallel, stateless_tests_amd_llvm_coverage_asyncinsert_s3_storage_sequential, stateless_tests_amd_llvm_coverage_old_analyzer_s3_storage_databasereplicated_wasmedge_parallel, stateless_tests_amd_llvm_coverage_old_analyzer_s3_storage_databasereplicated_wasmedge_sequential, stateless_tests_amd_llvm_coverage_parallelreplicas_s3_storage_parallel, stateless_tests_amd_llvm_coverage_parallelreplicas_s3_storage_sequential, stateless_tests_amd_msan_flaky_check, stateless_tests_amd_msan_wasmedge_parallel_1_2, stateless_tests_amd_msan_wasmedge_parallel_2_2, stateless_tests_amd_msan_wasmedge_sequential_1_2, stateless_tests_amd_msan_wasmedge_sequential_2_2, stateless_tests_amd_tsan_flaky_check, stateless_tests_amd_tsan_parallel_1_2, stateless_tests_amd_tsan_parallel_2_2, stateless_tests_amd_tsan_s3_storage_parallel_1_2, stateless_tests_amd_tsan_s3_storage_parallel_2_2, stateless_tests_amd_tsan_s3_storage_sequential_1_2, stateless_tests_amd_tsan_s3_storage_sequential_2_2, stateless_tests_amd_tsan_sequential_1_2, stateless_tests_amd_tsan_sequential_2_2, stateless_tests_amd_ubsan_flaky_check, stateless_tests_amd_ubsan_parallel, stateless_tests_amd_ubsan_sequential, stateless_tests_arm_asan_azure_parallel, stateless_tests_arm_asan_azure_sequential, stateless_tests_arm_asan_targeted, stateless_tests_arm_binary_parallel, stateless_tests_arm_binary_sequential, stress_test_amd_debug, stress_test_amd_msan, stress_test_amd_release, stress_test_amd_tsan, stress_test_amd_ubsan, stress_test_arm_asan, stress_test_arm_asan_s3, style_check, unit_tests_amd_llvm_coverage, unit_tests_asan, unit_tests_msan, unit_tests_tsan, unit_tests_ubsan, upgrade_check_amd_release]
+    needs: [ast_fuzzer_amd_debug, ast_fuzzer_amd_debug_targeted, ast_fuzzer_amd_debug_targeted_old_compatibility, ast_fuzzer_amd_msan, ast_fuzzer_amd_tsan, ast_fuzzer_amd_ubsan, ast_fuzzer_arm_asan, bugfix_validation_functional_tests, bugfix_validation_integration_tests, build_amd_asan, build_amd_binary, build_amd_compat, build_amd_darwin, build_amd_debug, build_amd_freebsd, build_amd_msan, build_amd_musl, build_amd_release, build_amd_tsan, build_amd_ubsan, build_arm_asan, build_arm_binary, build_arm_darwin, build_arm_fuzzers, build_arm_release, build_arm_tidy, build_arm_tsan, build_arm_v80compat, build_llvm_coverage_build, build_loongarch64, build_ppc64le, build_riscv64, build_s390x, build_toolchain_pgo_bolt_aarch64, build_toolchain_pgo_bolt_amd64, buzzhouse_amd_debug, buzzhouse_amd_msan, buzzhouse_amd_tsan, buzzhouse_amd_ubsan, buzzhouse_arm_asan, compatibility_check_amd_release, compatibility_check_arm_release, config_workflow, docker_keeper_image, docker_server_image, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, docs_check, fast_test, install_packages_amd_release, install_packages_arm_release, integration_tests_amd_asan_db_disk_old_analyzer_1_6, integration_tests_amd_asan_db_disk_old_analyzer_2_6, integration_tests_amd_asan_db_disk_old_analyzer_3_6, integration_tests_amd_asan_db_disk_old_analyzer_4_6, integration_tests_amd_asan_db_disk_old_analyzer_5_6, integration_tests_amd_asan_db_disk_old_analyzer_6_6, integration_tests_amd_asan_flaky, integration_tests_amd_asan_targeted, integration_tests_amd_binary_1_5, integration_tests_amd_binary_2_5, integration_tests_amd_binary_3_5, integration_tests_amd_binary_4_5, integration_tests_amd_binary_5_5, integration_tests_amd_llvm_coverage_1_5, integration_tests_amd_llvm_coverage_2_5, integration_tests_amd_llvm_coverage_3_5, integration_tests_amd_llvm_coverage_4_5, integration_tests_amd_llvm_coverage_5_5, integration_tests_amd_msan_1_6, integration_tests_amd_msan_2_6, integration_tests_amd_msan_3_6, integration_tests_amd_msan_4_6, integration_tests_amd_msan_5_6, integration_tests_amd_msan_6_6, integration_tests_amd_tsan_1_6, integration_tests_amd_tsan_2_6, integration_tests_amd_tsan_3_6, integration_tests_amd_tsan_4_6, integration_tests_amd_tsan_5_6, integration_tests_amd_tsan_6_6, integration_tests_arm_binary_distributed_plan_1_4, integration_tests_arm_binary_distributed_plan_2_4, integration_tests_arm_binary_distributed_plan_3_4, integration_tests_arm_binary_distributed_plan_4_4, llvm_coverage, performance_comparison_amd_release_master_head_1_6, performance_comparison_amd_release_master_head_2_6, performance_comparison_amd_release_master_head_3_6, performance_comparison_amd_release_master_head_4_6, performance_comparison_amd_release_master_head_5_6, performance_comparison_amd_release_master_head_6_6, performance_comparison_arm_release_master_head_1_6, performance_comparison_arm_release_master_head_2_6, performance_comparison_arm_release_master_head_3_6, performance_comparison_arm_release_master_head_4_6, performance_comparison_arm_release_master_head_5_6, performance_comparison_arm_release_master_head_6_6, quick_functional_tests, smoke_test_amd_darwin, sqllogic_test, stateless_tests_amd_asan_db_disk_distributed_plan_sequential, stateless_tests_amd_asan_distributed_plan_parallel_1_2, stateless_tests_amd_asan_distributed_plan_parallel_2_2, stateless_tests_amd_asan_flaky_check, stateless_tests_amd_binary_flaky_check, stateless_tests_amd_debug_distributed_plan_s3_storage_parallel, stateless_tests_amd_debug_distributed_plan_s3_storage_sequential, stateless_tests_amd_debug_flaky_check, stateless_tests_amd_debug_parallel, stateless_tests_amd_debug_sequential, stateless_tests_amd_llvm_coverage_1_3, stateless_tests_amd_llvm_coverage_2_3, stateless_tests_amd_llvm_coverage_3_3, stateless_tests_amd_llvm_coverage_asyncinsert_s3_storage_parallel, stateless_tests_amd_llvm_coverage_asyncinsert_s3_storage_sequential, stateless_tests_amd_llvm_coverage_old_analyzer_s3_storage_databasereplicated_wasmedge_parallel, stateless_tests_amd_llvm_coverage_old_analyzer_s3_storage_databasereplicated_wasmedge_sequential, stateless_tests_amd_llvm_coverage_parallelreplicas_s3_storage_parallel, stateless_tests_amd_llvm_coverage_parallelreplicas_s3_storage_sequential, stateless_tests_amd_msan_flaky_check, stateless_tests_amd_msan_wasmedge_parallel_1_2, stateless_tests_amd_msan_wasmedge_parallel_2_2, stateless_tests_amd_msan_wasmedge_sequential_1_2, stateless_tests_amd_msan_wasmedge_sequential_2_2, stateless_tests_amd_tsan_flaky_check, stateless_tests_amd_tsan_parallel_1_2, stateless_tests_amd_tsan_parallel_2_2, stateless_tests_amd_tsan_s3_storage_parallel_1_2, stateless_tests_amd_tsan_s3_storage_parallel_2_2, stateless_tests_amd_tsan_s3_storage_sequential_1_2, stateless_tests_amd_tsan_s3_storage_sequential_2_2, stateless_tests_amd_tsan_sequential_1_2, stateless_tests_amd_tsan_sequential_2_2, stateless_tests_amd_ubsan_flaky_check, stateless_tests_amd_ubsan_parallel, stateless_tests_amd_ubsan_sequential, stateless_tests_arm_asan_azure_parallel, stateless_tests_arm_asan_azure_sequential, stateless_tests_arm_asan_targeted, stateless_tests_arm_binary_parallel, stateless_tests_arm_binary_sequential, stress_test_amd_debug, stress_test_amd_msan, stress_test_amd_release, stress_test_amd_tsan, stress_test_amd_ubsan, stress_test_arm_asan, stress_test_arm_asan_s3, style_check, unit_tests_amd_llvm_coverage, unit_tests_asan, unit_tests_msan, unit_tests_tsan, unit_tests_ubsan, upgrade_check_amd_release]
     if: ${{ always() }}
     name: "Finish Workflow"
     outputs:

--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -977,6 +977,29 @@ class JobConfigs:
             requires=[ArtifactNames.CH_AMD_UBSAN],
         ),
     )
+    ast_fuzzer_targeted_pr_jobs = Job.Config(
+        name=JobNames.ASTFUZZER,
+        runs_on=[],  # from parametrize()
+        command="python3 ./ci/jobs/ast_fuzzer_job.py",
+        digest_config=Job.CacheDigestConfig(
+            include_paths=[
+                "./ci/docker/fuzzer",
+                "./ci/jobs/ast_fuzzer_job.py",
+                "./ci/jobs/scripts/find_symbols.py",
+                "./ci/jobs/scripts/find_tests.py",
+                "./ci/jobs/scripts/log_parser.py",
+                "./ci/jobs/scripts/functional_tests/setup_log_cluster.sh",
+                "./ci/jobs/scripts/fuzzer/",
+                "./ci/docker/fuzzer",
+            ],
+        ),
+    ).parametrize(
+        Job.ParamSet(
+            parameter="arm_asan, targeted",
+            runs_on=RunnerLabels.FUNC_TESTER_ARM,
+            requires=[ArtifactNames.CH_ARM_ASAN],
+        ),
+    )
     buzz_fuzzer_jobs = Job.Config(
         name=JobNames.BUZZHOUSE,
         runs_on=[],  # from parametrize()

--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -995,10 +995,16 @@ class JobConfigs:
         ),
     ).parametrize(
         Job.ParamSet(
-            parameter="arm_asan, targeted",
-            runs_on=RunnerLabels.FUNC_TESTER_ARM,
-            requires=[ArtifactNames.CH_ARM_ASAN],
+            parameter="amd_debug, targeted",
+            runs_on=RunnerLabels.FUNC_TESTER_AMD,
+            requires=[ArtifactNames.CH_AMD_DEBUG],
         ),
+        Job.ParamSet(
+            parameter="amd_debug, targeted, old_compatibility",
+            runs_on=RunnerLabels.FUNC_TESTER_AMD,
+            requires=[ArtifactNames.CH_AMD_DEBUG],
+        ),
+
     )
     buzz_fuzzer_jobs = Job.Config(
         name=JobNames.BUZZHOUSE,

--- a/ci/jobs/ast_fuzzer_job.py
+++ b/ci/jobs/ast_fuzzer_job.py
@@ -127,12 +127,21 @@ def run_fuzz_job(check_name: str):
             ).complete_job()
         targeted_queries_file = workspace_path / "ci-targeted-queries.txt"
 
+    is_old_compatibility = "old_compatibility" in check_name.lower()
     compatibility_setting: str | None = None
     if not buzzhouse:
-        compatibility_setting = (
-            f"{random.randint(20, 27)}.{random.randint(1, 12)}"
-        )
-        logging.info("AST fuzzer compatibility setting: %s", compatibility_setting)
+        if is_old_compatibility:
+            compatibility_setting = "22.1"
+        elif is_targeted:
+            compatibility_setting = None
+        else:
+            compatibility_setting = (
+                f"{random.randint(22, 27)}.{random.randint(1, 12)}"
+            )
+        if compatibility_setting:
+            logging.info("AST fuzzer compatibility setting: %s", compatibility_setting)
+        else:
+            logging.info("AST fuzzer compatibility setting is not set")
 
     run_command = get_run_command(
         workspace_path,

--- a/ci/jobs/ast_fuzzer_job.py
+++ b/ci/jobs/ast_fuzzer_job.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import logging
 import os
+import random
 import subprocess
 import sys
 import traceback
@@ -26,6 +27,7 @@ def get_run_command(
     image: DockerImage,
     buzzhouse: bool,
     targeted_queries_file: Path | None = None,
+    compatibility_setting: str | None = None,
 ) -> str:
     from ci.jobs.ci_utils import is_extended_run
 
@@ -36,6 +38,8 @@ def get_run_command(
     ]
     if targeted_queries_file:
         envs.append(f"-e TARGETED_QUERIES_FILE='{targeted_queries_file}'")
+    if compatibility_setting:
+        envs.append(f"-e FUZZER_COMPATIBILITY='{compatibility_setting}'")
 
     env_str = " ".join(envs)
 
@@ -123,11 +127,19 @@ def run_fuzz_job(check_name: str):
             ).complete_job()
         targeted_queries_file = workspace_path / "ci-targeted-queries.txt"
 
+    compatibility_setting: str | None = None
+    if not buzzhouse:
+        compatibility_setting = (
+            f"{random.randint(20, 27)}.{random.randint(1, 12)}"
+        )
+        logging.info("AST fuzzer compatibility setting: %s", compatibility_setting)
+
     run_command = get_run_command(
         workspace_path,
         docker_image,
         buzzhouse,
         targeted_queries_file=targeted_queries_file,
+        compatibility_setting=compatibility_setting,
     )
     logging.info("Going to run %s", run_command)
 

--- a/ci/jobs/ast_fuzzer_job.py
+++ b/ci/jobs/ast_fuzzer_job.py
@@ -64,9 +64,12 @@ def _test_name_to_basename(test_name: str) -> str:
 
 def _collect_targeted_queries(workspace_path: Path, info: Info) -> tuple[list[str], Result]:
     targeter = Targeting(info=info)
-    # AST fuzzer targets stateless tests only.
     targeter.job_type = Targeting.STATELESS_JOB_TYPE
     tests, relevant_tests_result = targeter.get_all_relevant_tests_with_info(f"{cwd}/ci/tmp")
+
+    logging.info("Found %d relevant tests for targeted AST fuzzer:", len(tests))
+    for test in sorted(tests):
+        logging.info("  %s", test)
 
     stateless_tests_dir = Path(cwd) / "tests/queries/0_stateless"
     available_queries: dict[str, list[str]] = {}
@@ -90,7 +93,11 @@ def _collect_targeted_queries(workspace_path: Path, info: Info) -> tuple[list[st
         targeted_queries_file = workspace_path / "ci-targeted-queries.txt"
         with open(targeted_queries_file, "w", encoding="utf-8") as f:
             f.write("\n".join(targeted_queries))
-        logging.info("Prepared %d targeted queries for AST fuzzer", len(targeted_queries))
+        logging.info(
+            "Prepared %d targeted queries for AST fuzzer:", len(targeted_queries)
+        )
+        for qf in targeted_queries:
+            logging.info("  %s", qf)
     else:
         logging.info("No targeted queries resolved for AST fuzzer")
 
@@ -103,7 +110,9 @@ def run_fuzz_job(check_name: str):
     buzzhouse: bool = check_name.lower().startswith("buzzhouse")
 
     temp_dir = Path(f"{cwd}/ci/tmp/")
-    assert Path(f"{temp_dir}/clickhouse").exists(), "ClickHouse binary not found"
+    clickhouse_binary = temp_dir / "clickhouse"
+    assert clickhouse_binary.exists(), "ClickHouse binary not found"
+    clickhouse_binary.chmod(clickhouse_binary.stat().st_mode | 0o111)
 
     docker_image = DockerImage.get_docker_image(IMAGE_NAME).pull_image()
 

--- a/ci/jobs/ast_fuzzer_job.py
+++ b/ci/jobs/ast_fuzzer_job.py
@@ -6,6 +6,7 @@ import sys
 import traceback
 from pathlib import Path
 
+from ci.jobs.scripts.find_tests import Targeting
 from ci.jobs.scripts.docker_image import DockerImage
 from ci.jobs.scripts.log_parser import FuzzerLogParser
 from ci.praktika.info import Info
@@ -24,6 +25,7 @@ def get_run_command(
     workspace_path: Path,
     image: DockerImage,
     buzzhouse: bool,
+    targeted_queries_file: Path | None = None,
 ) -> str:
     from ci.jobs.ci_utils import is_extended_run
 
@@ -32,6 +34,8 @@ def get_run_command(
         f"-e FUZZER_TO_RUN='{'BuzzHouse' if buzzhouse else 'AST Fuzzer'}'",
         f"-e FUZZ_TIME_LIMIT='{minutes}m'",
     ]
+    if targeted_queries_file:
+        envs.append(f"-e TARGETED_QUERIES_FILE='{targeted_queries_file}'")
 
     env_str = " ".join(envs)
 
@@ -50,8 +54,48 @@ def get_run_command(
     )
 
 
+def _test_name_to_basename(test_name: str) -> str:
+    return test_name[:-1] if test_name.endswith(".") else test_name
+
+
+def _collect_targeted_queries(workspace_path: Path, info: Info) -> tuple[list[str], Result]:
+    targeter = Targeting(info=info)
+    # AST fuzzer targets stateless tests only.
+    targeter.job_type = Targeting.STATELESS_JOB_TYPE
+    tests, relevant_tests_result = targeter.get_all_relevant_tests_with_info(f"{cwd}/ci/tmp")
+
+    stateless_tests_dir = Path(cwd) / "tests/queries/0_stateless"
+    available_queries: dict[str, list[str]] = {}
+
+    for query_file in stateless_tests_dir.rglob("*.sql"):
+        base_name = query_file.name.removesuffix(".sql")
+        available_queries.setdefault(base_name, []).append(
+            f"/repo/{query_file.relative_to(cwd)}"
+        )
+
+    targeted_queries: list[str] = []
+    seen_queries = set()
+    for test in tests:
+        base_name = _test_name_to_basename(test)
+        for query_path in available_queries.get(base_name, []):
+            if query_path not in seen_queries:
+                seen_queries.add(query_path)
+                targeted_queries.append(query_path)
+
+    if targeted_queries:
+        targeted_queries_file = workspace_path / "ci-targeted-queries.txt"
+        with open(targeted_queries_file, "w", encoding="utf-8") as f:
+            f.write("\n".join(targeted_queries))
+        logging.info("Prepared %d targeted queries for AST fuzzer", len(targeted_queries))
+    else:
+        logging.info("No targeted queries resolved for AST fuzzer")
+
+    return targeted_queries, relevant_tests_result
+
+
 def run_fuzz_job(check_name: str):
     logging.basicConfig(level=logging.INFO)
+    is_targeted = "targeted" in check_name.lower()
     buzzhouse: bool = check_name.lower().startswith("buzzhouse")
 
     temp_dir = Path(f"{cwd}/ci/tmp/")
@@ -62,10 +106,31 @@ def run_fuzz_job(check_name: str):
     workspace_path = temp_dir / "workspace"
     workspace_path.mkdir(parents=True, exist_ok=True)
 
-    run_command = get_run_command(workspace_path, docker_image, buzzhouse)
+    info = Info()
+    extra_results = []
+    targeted_queries_file: Path | None = None
+
+    if is_targeted and not buzzhouse:
+        targeted_queries, relevant_tests_result = _collect_targeted_queries(
+            workspace_path=workspace_path, info=info
+        )
+        extra_results.append(relevant_tests_result)
+        if not targeted_queries:
+            Result.create_from(
+                status=Result.Status.SKIPPED,
+                info="No relevant tests found for targeted AST fuzzer",
+                results=extra_results,
+            ).complete_job()
+        targeted_queries_file = workspace_path / "ci-targeted-queries.txt"
+
+    run_command = get_run_command(
+        workspace_path,
+        docker_image,
+        buzzhouse,
+        targeted_queries_file=targeted_queries_file,
+    )
     logging.info("Going to run %s", run_command)
 
-    info = Info()
     is_sanitized = "san" in info.job_name
 
     changed_files_path = workspace_path / "ci-changed-files.txt"
@@ -209,7 +274,9 @@ def run_fuzz_job(check_name: str):
             )
 
     result = Result.create_from(
-        results=results, status=status if not results else None, info=info
+        results=extra_results + results,
+        status=status if not results else None,
+        info=info,
     )
 
     if is_failed:

--- a/ci/jobs/ast_fuzzer_job.py
+++ b/ci/jobs/ast_fuzzer_job.py
@@ -37,7 +37,8 @@ def get_run_command(
         f"-e FUZZ_TIME_LIMIT='{minutes}m'",
     ]
     if targeted_queries_file:
-        envs.append(f"-e TARGETED_QUERIES_FILE='{targeted_queries_file}'")
+        container_queries_file = f"/workspace/{targeted_queries_file.name}"
+        envs.append(f"-e TARGETED_QUERIES_FILE='{container_queries_file}'")
     if compatibility_setting:
         envs.append(f"-e FUZZER_COMPATIBILITY='{compatibility_setting}'")
 

--- a/ci/jobs/scripts/find_tests.py
+++ b/ci/jobs/scripts/find_tests.py
@@ -307,6 +307,7 @@ class Targeting:
                         info=f"Skipped: {e}",
                     )
                 )
+                raise
 
         return tests, Result(
             name="Fetch relevant tests",

--- a/ci/jobs/scripts/fuzzer/run-fuzzer.sh
+++ b/ci/jobs/scripts/fuzzer/run-fuzzer.sh
@@ -199,7 +199,9 @@ function fuzz
         else
             QUERIES_FILE=$(find /repo/tests/queries/0_stateless -type f -name "*.sql" | sort -R)
         fi
-        FUZZER_ARGS="--query-fuzzer-runs=1000 --create-query-fuzzer-runs=50 --queries-file $QUERIES_FILE $NEW_TESTS_OPT"
+        COMPATIBILITY_SETTING="${FUZZER_COMPATIBILITY:-26.1}"
+        echo "Using AST fuzzer compatibility setting: ${COMPATIBILITY_SETTING}"
+        FUZZER_ARGS="--query-fuzzer-runs=1000 --create-query-fuzzer-runs=50 --compatibility=${COMPATIBILITY_SETTING} --queries-file $QUERIES_FILE $NEW_TESTS_OPT"
     elif [ "$FUZZER_TO_RUN" = "BuzzHouse" ]
     then
         FUZZER_ARGS="--buzz-house-config=fuzz.json"

--- a/ci/jobs/scripts/fuzzer/run-fuzzer.sh
+++ b/ci/jobs/scripts/fuzzer/run-fuzzer.sh
@@ -192,7 +192,13 @@ function fuzz
 
     if [[ "$FUZZER_TO_RUN" = "AST Fuzzer" ]];
     then
-        QUERIES_FILE=$(find /repo/tests/queries/0_stateless -type f -name "*.sql" | sort -R)
+        if [[ -n "${TARGETED_QUERIES_FILE:-}" ]] && [[ -f "${TARGETED_QUERIES_FILE}" ]];
+        then
+            QUERIES_FILE="$(cat "${TARGETED_QUERIES_FILE}")"
+            echo "Using targeted AST fuzzer corpus from ${TARGETED_QUERIES_FILE}"
+        else
+            QUERIES_FILE=$(find /repo/tests/queries/0_stateless -type f -name "*.sql" | sort -R)
+        fi
         FUZZER_ARGS="--query-fuzzer-runs=1000 --create-query-fuzzer-runs=50 --queries-file $QUERIES_FILE $NEW_TESTS_OPT"
     elif [ "$FUZZER_TO_RUN" = "BuzzHouse" ]
     then

--- a/ci/workflows/pull_request.py
+++ b/ci/workflows/pull_request.py
@@ -68,6 +68,7 @@ workflow = Workflow.Config(
         JobConfigs.lightweight_functional_tests_job,
         JobConfigs.stateless_tests_targeted_pr_jobs[0].set_allow_merge_on_failure(),
         JobConfigs.integration_test_targeted_pr_jobs[0].set_allow_merge_on_failure(),
+        JobConfigs.ast_fuzzer_targeted_pr_jobs[0].set_allow_merge_on_failure(),
         *JobConfigs.stateless_tests_flaky_pr_jobs,
         *JobConfigs.integration_test_asan_flaky_pr_jobs,
         JobConfigs.bugfix_validation_ft_pr_job,

--- a/ci/workflows/pull_request.py
+++ b/ci/workflows/pull_request.py
@@ -69,6 +69,7 @@ workflow = Workflow.Config(
         JobConfigs.stateless_tests_targeted_pr_jobs[0].set_allow_merge_on_failure(),
         JobConfigs.integration_test_targeted_pr_jobs[0].set_allow_merge_on_failure(),
         JobConfigs.ast_fuzzer_targeted_pr_jobs[0].set_allow_merge_on_failure(),
+        JobConfigs.ast_fuzzer_targeted_pr_jobs[1].set_allow_merge_on_failure(),
         *JobConfigs.stateless_tests_flaky_pr_jobs,
         *JobConfigs.integration_test_asan_flaky_pr_jobs,
         JobConfigs.bugfix_validation_ft_pr_job,


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

---

## Summary

Adds a **targeted AST fuzzer** CI job for pull requests. Instead of fuzzing random queries, this job:

1. Detects which C++ source files changed in the PR via the diff.
2. Resolves changed lines to function symbols using DWARF debug info.
3. Queries the coverage database to find stateless `.sql` tests that exercise those symbols.
4. Runs the AST fuzzer only on the targeted query corpus.

Two new job variants are added:
- `amd_debug, targeted` — targeted AST fuzzer with default compatibility settings.
- `amd_debug, targeted, old_compatibility` — targeted AST fuzzer with `compatibility = '22.1'`.

Additionally, non-targeted AST fuzzer runs now randomize the `--compatibility` setting.

The latest commit adds trivial whitespace changes across 41 C++ source files (Interpreters, Storages, Functions, Parsers, Processors, Columns, Core, Common, Databases, Server, IO, Analyzer, Planner, TableFunctions) to exercise the targeted AST fuzzer's symbol-to-test resolution pipeline end-to-end in CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI behavior changes add two new AST fuzzer PR jobs and alter how the fuzzer selects queries/compatibility, which may impact CI stability and runtime. The change to `find_tests.py` now re-raises on coverage lookup failures, potentially turning previously best-effort behavior into hard failures for any job that relies on it.
> 
> **Overview**
> Adds two new PR checks for a *targeted* AST fuzzer (`amd_debug, targeted` and `amd_debug, targeted, old_compatibility`) and wires them into the PR workflow (including `finish_workflow`).
> 
> Updates the AST fuzzer runner to optionally build a targeted corpus from relevant stateless tests and pass it into the dockerized fuzzer via `TARGETED_QUERIES_FILE`; the `old_compatibility` variant forces compatibility `22.1`.
> 
> Non-targeted AST fuzzer runs now randomize the `--compatibility` setting (plumbed through `FUZZER_COMPATIBILITY` and applied in `run-fuzzer.sh`), and `find_tests.py` now re-raises when coverage-based test discovery fails.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d514506e71d7bbcebc3c28ce30909855ace7bf11. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.510`
<!-- ch-version-info:end -->