### PR TITLE
Fix BuildTextIndexStep::updateOutputHeader() to preserve original output headers

### DIFF
--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -2243,6 +2243,7 @@ public:
         : ITransformingStep(input_header_, output_header_, getTraits())
         , WithContext(context_)
         , transform(std::move(transform_))
+        , original_output_header(output_header_)
     {
     }
 
@@ -2270,7 +2271,11 @@ public:
 
     void updateOutputHeader() override
     {
-        output_header = input_headers.front();
+        /// The output header must be the original header (without extra index
+        /// expression columns), not the input header which may contain extra
+        /// columns added by index expression steps. This is important to keep
+        /// all per-part plan headers compatible in the UnionStep during merge.
+        output_header = original_output_header;
     }
 
     String getName() const override { return "BuildTextIndex"; }
@@ -2292,6 +2297,7 @@ private:
     }
 
     std::shared_ptr<BuildTextIndexTransform> transform;
+    SharedHeader original_output_header;
 };
 
 void MergeTask::addSkipIndexesExpressionSteps(QueryPlan & plan, const IndicesDescription & indices_description, const GlobalRuntimeContextPtr & global_ctx)

--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -2297,7 +2297,7 @@ private:
     }
 
     std::shared_ptr<BuildTextIndexTransform> transform;
-    SharedHeader original_output_header;
+    const SharedHeader original_output_header;
 };
 
 void MergeTask::addSkipIndexesExpressionSteps(QueryPlan & plan, const IndicesDescription & indices_description, const GlobalRuntimeContextPtr & global_ctx)


### PR DESCRIPTION
Fix BuildTextIndexStep::updateOutputHeader() to preserve original output headers

BuildTextIndexStep is intentionally constructed with different input and output headers: the input includes extra columns from the index expression, while the output is the original table header (without those columns). This difference is what keeps per-part plan headers compatible when they are united in a UnionStep during merge, since only parts missing the text index get the extra expression columns.

The buggy updateOutputHeader() set output_header = input_headers.front(), which would replace the original header with the expanded one containing index expression columns. If triggered by a query plan optimization, this would cause a block structure mismatch at the UnionStep between parts that needed index materialization and parts that did not.

No current optimizer path triggers updateOutputHeader() on this step, so **the bug is latent. The fix is defensive**: it stores the original output header from construction and uses it in updateOutputHeader(), matching the documented contract at the construction site.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.42`
<!-- ch-version-info:end -->