### PR TITLE
Enable the impersonate feature by default

### DIFF
--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -863,12 +863,12 @@
              It also enables 'changeable_in_readonly' constraint type -->
         <settings_constraints_replace_previous>true</settings_constraints_replace_previous>
 
+        <!-- Enable/disable the IMPERSONATE feature (EXECUTE AS target_user). -->
+        <allow_impersonate_user>true</allow_impersonate_user>
+
         <!-- By default, for backward compatibility creating table with a specific table engine ignores grant,
              however you can change this behaviour by setting this to true -->
         <table_engines_require_grant>false</table_engines_require_grant>
-
-        <!-- Enable/disable the IMPERSONATE feature (EXECUTE AS target_user). -->
-        <allow_impersonate_user>false</allow_impersonate_user>
 
         <!-- Number of seconds since last access a role is stored in the Role Cache -->
         <role_cache_expiration_time_seconds>600</role_cache_expiration_time_seconds>

--- a/src/Access/AccessControl.cpp
+++ b/src/Access/AccessControl.cpp
@@ -300,16 +300,17 @@ void AccessControl::setupFromMainConfig(const Poco::Util::AbstractConfiguration 
     setBcryptWorkfactor(config_.getInt("bcrypt_workfactor", 12));
 
     /// Optional improvements in access control system.
-    /// The default values are false because we need to be compatible with earlier access configurations
-    setThrowOnUnmatchedRowPolicies(config_.getBool("access_control_improvements.throw_on_unmatched_row_policies", false));
     setEnabledUsersWithoutRowPoliciesCanReadRows(config_.getBool("access_control_improvements.users_without_row_policies_can_read_rows", true));
     setOnClusterQueriesRequireClusterGrant(config_.getBool("access_control_improvements.on_cluster_queries_require_cluster_grant", true));
     setSelectFromSystemDatabaseRequiresGrant(config_.getBool("access_control_improvements.select_from_system_db_requires_grant", true));
     setSelectFromInformationSchemaRequiresGrant(config_.getBool("access_control_improvements.select_from_information_schema_requires_grant", true));
     setSettingsConstraintsReplacePrevious(config_.getBool("access_control_improvements.settings_constraints_replace_previous", true));
+    setImpersonateUserAllowed(config_.getBool("access_control_improvements.allow_impersonate_user", config_.getBool("allow_impersonate_user", true)));
+
+    /// The default values of the following improvements are false because we need to be compatible with earlier access configurations
     setTableEnginesRequireGrant(config_.getBool("access_control_improvements.table_engines_require_grant", false));
     setEnableReadWriteGrants(config_.getBool("access_control_improvements.enable_read_write_grants", false));
-    setImpersonateUserAllowed(config_.getBool("access_control_improvements.allow_impersonate_user", config_.getBool("allow_impersonate_user", false)));
+    setThrowOnUnmatchedRowPolicies(config_.getBool("access_control_improvements.throw_on_unmatched_row_policies", false));
 
     /// Set `true` by default because the feature is backward incompatible only when older version replicas are in the same cluster.
     setEnableUserNameAccessType(config_.getBool("access_control_improvements.enable_user_name_access_type", true));


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Enable the impersonate feature by default (see [EXECUTE AS target_user](https://clickhouse.com/docs/sql-reference/statements/execute_as))

Special privilege `GRANT IMPERSONATE` is needed in order to use this feature.

For example:
```sql
GRANT IMPERSONATE ON target_user TO user1

-- login as user1

EXECUTE AS target_user SELECT currentUser(), authenticatedUser(); -- outputs "target_user    user1"
```



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.18`
<!-- ch-version-info:end -->