### PR TITLE
return user_name within AuthResult from the access storages themselves

### DIFF
--- a/src/Access/IAccessStorage.cpp
+++ b/src/Access/IAccessStorage.cpp
@@ -542,7 +542,7 @@ std::optional<AuthResult> IAccessStorage::authenticateImpl(
     {
         if (auto user = tryRead<User>(*id))
         {
-            AuthResult auth_result { .user_id = *id };
+            AuthResult auth_result { .user_id = *id, .user_name = credentials.getUserName() };
             if (!isAddressAllowed(*user, address))
                 throwAddressNotAllowed(address);
 

--- a/src/Access/IAccessStorage.h
+++ b/src/Access/IAccessStorage.h
@@ -33,6 +33,9 @@ struct AuthResult
     /// Session settings received from authentication server (if any)
     SettingsChanges settings{};
     AuthenticationData authentication_data {};
+    /// Username determined by the access storage during authentication,
+    /// should be treated as the authenticated user name
+    String user_name;
 };
 
 /// Contains entities, i.e. instances of classes derived from IAccessEntity.

--- a/src/Access/LDAPAccessStorage.cpp
+++ b/src/Access/LDAPAccessStorage.cpp
@@ -495,7 +495,7 @@ std::optional<AuthResult> LDAPAccessStorage::authenticateImpl(
     }
 
     if (id)
-        return AuthResult{ .user_id = *id, .authentication_data = AuthenticationData(AuthenticationType::LDAP) };
+        return AuthResult{ .user_id = *id, .authentication_data = AuthenticationData(AuthenticationType::LDAP), .user_name = credentials.getUserName() };
     return std::nullopt;
 }
 

--- a/src/Interpreters/Session.cpp
+++ b/src/Interpreters/Session.cpp
@@ -403,6 +403,7 @@ void Session::authenticate(const Credentials & credentials_, const Poco::Net::So
         throw;
     }
 
+    chassert(!auth_result.user_name.empty());
     prepared_client_info->current_user = auth_result.user_name;
     prepared_client_info->authenticated_user = auth_result.user_name;
     prepared_client_info->current_address = std::make_shared<Poco::Net::SocketAddress>(address);

--- a/src/Interpreters/Session.cpp
+++ b/src/Interpreters/Session.cpp
@@ -379,10 +379,10 @@ void Session::authenticate(const Credentials & credentials_, const Poco::Net::So
     LOG_DEBUG(log, "Authenticating user '{}' from {}",
             credentials_.getUserName(), address.toString());
 
+    AuthResult auth_result;
     try
     {
-        auto auth_result =
-            global_context->getAccessControl().authenticate(credentials_, address.host(), getClientInfo());
+        auth_result = global_context->getAccessControl().authenticate(credentials_, address.host(), getClientInfo());
         user_id = auth_result.user_id;
         user_authenticated_with = auth_result.authentication_data;
         settings_from_auth_server = auth_result.settings;
@@ -403,8 +403,8 @@ void Session::authenticate(const Credentials & credentials_, const Poco::Net::So
         throw;
     }
 
-    prepared_client_info->current_user = credentials_.getUserName();
-    prepared_client_info->authenticated_user = credentials_.getUserName();
+    prepared_client_info->current_user = auth_result.user_name;
+    prepared_client_info->authenticated_user = auth_result.user_name;
     prepared_client_info->current_address = std::make_shared<Poco::Net::SocketAddress>(address);
 }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
Changes for an interface in public that help maintain https://github.com/ClickHouse/clickhouse-private/pull/49187


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.52`
- Backported to: `26.2.1.1123`, `26.1.4.26`, `25.12.8.5`
<!-- ch-version-info:end -->