### PR TITLE
Fix distributed insert select with CTE

### DIFF
--- a/src/Interpreters/InterpreterInsertQuery.cpp
+++ b/src/Interpreters/InterpreterInsertQuery.cpp
@@ -924,6 +924,9 @@ BlockIO InterpreterInsertQuery::execute()
     {
         if (settings[Setting::parallel_distributed_insert_select])
         {
+            /// distributed write paths may mutate the SELECT AST (CTE expansion), so keep a backup
+            auto saved_select = query.select->clone();
+
             auto distributed = table->distributedWrite(query, context);
             if (distributed)
             {
@@ -940,6 +943,9 @@ BlockIO InterpreterInsertQuery::execute()
                 if (pipeline)
                     res.pipeline = std::move(*pipeline);
             }
+
+            if (!res.pipeline.initialized())
+                query.select = std::move(saved_select);
         }
         if (!res.pipeline.initialized())
             res.pipeline = buildInsertSelectPipeline(query, table);

--- a/src/Interpreters/InterpreterInsertQuery.cpp
+++ b/src/Interpreters/InterpreterInsertQuery.cpp
@@ -944,8 +944,7 @@ BlockIO InterpreterInsertQuery::execute()
                     res.pipeline = std::move(*pipeline);
             }
 
-            if (!res.pipeline.initialized())
-                query.select = std::move(saved_select);
+            query.select = std::move(saved_select);
         }
         if (!res.pipeline.initialized())
             res.pipeline = buildInsertSelectPipeline(query, table);

--- a/tests/queries/0_stateless/03990_distributed_insert_select_cte.reference
+++ b/tests/queries/0_stateless/03990_distributed_insert_select_cte.reference
@@ -1,0 +1,6 @@
+value1
+value2
+value1
+value2
+value1
+value2

--- a/tests/queries/0_stateless/03990_distributed_insert_select_cte.sql
+++ b/tests/queries/0_stateless/03990_distributed_insert_select_cte.sql
@@ -1,0 +1,39 @@
+-- Tags: distributed
+
+SET send_logs_level = 'fatal';
+SET prefer_localhost_replica = 1;
+SET parallel_distributed_insert_select = 2;
+
+DROP TABLE IF EXISTS local_03826_src;
+DROP TABLE IF EXISTS local_03826_dst;
+DROP TABLE IF EXISTS distributed_03826_src;
+DROP TABLE IF EXISTS distributed_03826_dst;
+
+CREATE TABLE local_03826_src (col String) ENGINE = MergeTree ORDER BY col;
+CREATE TABLE local_03826_dst (col String) ENGINE = MergeTree ORDER BY col;
+CREATE TABLE distributed_03826_src AS local_03826_src ENGINE = Distributed('test_shard_localhost', currentDatabase(), local_03826_src);
+CREATE TABLE distributed_03826_dst AS local_03826_dst ENGINE = Distributed('test_shard_localhost', currentDatabase(), local_03826_dst);
+
+INSERT INTO local_03826_src VALUES ('value1'), ('value2');
+
+INSERT INTO distributed_03826_dst
+WITH cte AS (SELECT * FROM distributed_03826_src) SELECT cte.col FROM cte AS c;
+
+SELECT * FROM local_03826_dst ORDER BY col;
+TRUNCATE TABLE local_03826_dst;
+
+INSERT INTO distributed_03826_dst
+WITH cte AS (SELECT * FROM distributed_03826_src) SELECT c.col FROM cte AS c;
+
+SELECT * FROM local_03826_dst ORDER BY col;
+TRUNCATE TABLE local_03826_dst;
+
+INSERT INTO distributed_03826_dst
+WITH cte AS (SELECT * FROM distributed_03826_src) SELECT cte.col FROM cte;
+
+SELECT * FROM local_03826_dst ORDER BY col;
+
+DROP TABLE local_03826_src;
+DROP TABLE local_03826_dst;
+DROP TABLE distributed_03826_src;
+DROP TABLE distributed_03826_dst;

--- a/tests/queries/0_stateless/03990_distributed_insert_select_cte.sql
+++ b/tests/queries/0_stateless/03990_distributed_insert_select_cte.sql
@@ -4,36 +4,36 @@ SET send_logs_level = 'fatal';
 SET prefer_localhost_replica = 1;
 SET parallel_distributed_insert_select = 2;
 
-DROP TABLE IF EXISTS local_03826_src;
-DROP TABLE IF EXISTS local_03826_dst;
-DROP TABLE IF EXISTS distributed_03826_src;
-DROP TABLE IF EXISTS distributed_03826_dst;
+DROP TABLE IF EXISTS local_03990_src;
+DROP TABLE IF EXISTS local_03990_dst;
+DROP TABLE IF EXISTS distributed_03990_src;
+DROP TABLE IF EXISTS distributed_03990_dst;
 
-CREATE TABLE local_03826_src (col String) ENGINE = MergeTree ORDER BY col;
-CREATE TABLE local_03826_dst (col String) ENGINE = MergeTree ORDER BY col;
-CREATE TABLE distributed_03826_src AS local_03826_src ENGINE = Distributed('test_shard_localhost', currentDatabase(), local_03826_src);
-CREATE TABLE distributed_03826_dst AS local_03826_dst ENGINE = Distributed('test_shard_localhost', currentDatabase(), local_03826_dst);
+CREATE TABLE local_03990_src (col String) ENGINE = MergeTree ORDER BY col;
+CREATE TABLE local_03990_dst (col String) ENGINE = MergeTree ORDER BY col;
+CREATE TABLE distributed_03990_src AS local_03990_src ENGINE = Distributed('test_shard_localhost', currentDatabase(), local_03990_src);
+CREATE TABLE distributed_03990_dst AS local_03990_dst ENGINE = Distributed('test_shard_localhost', currentDatabase(), local_03990_dst);
 
-INSERT INTO local_03826_src VALUES ('value1'), ('value2');
+INSERT INTO local_03990_src VALUES ('value1'), ('value2');
 
-INSERT INTO distributed_03826_dst
-WITH cte AS (SELECT * FROM distributed_03826_src) SELECT cte.col FROM cte AS c;
+INSERT INTO distributed_03990_dst
+WITH cte AS (SELECT * FROM distributed_03990_src) SELECT cte.col FROM cte AS c;
 
-SELECT * FROM local_03826_dst ORDER BY col;
-TRUNCATE TABLE local_03826_dst;
+SELECT * FROM local_03990_dst ORDER BY col;
+TRUNCATE TABLE local_03990_dst;
 
-INSERT INTO distributed_03826_dst
-WITH cte AS (SELECT * FROM distributed_03826_src) SELECT c.col FROM cte AS c;
+INSERT INTO distributed_03990_dst
+WITH cte AS (SELECT * FROM distributed_03990_src) SELECT c.col FROM cte AS c;
 
-SELECT * FROM local_03826_dst ORDER BY col;
-TRUNCATE TABLE local_03826_dst;
+SELECT * FROM local_03990_dst ORDER BY col;
+TRUNCATE TABLE local_03990_dst;
 
-INSERT INTO distributed_03826_dst
-WITH cte AS (SELECT * FROM distributed_03826_src) SELECT cte.col FROM cte;
+INSERT INTO distributed_03990_dst
+WITH cte AS (SELECT * FROM distributed_03990_src) SELECT cte.col FROM cte;
 
-SELECT * FROM local_03826_dst ORDER BY col;
+SELECT * FROM local_03990_dst ORDER BY col;
 
-DROP TABLE local_03826_src;
-DROP TABLE local_03826_dst;
-DROP TABLE distributed_03826_src;
-DROP TABLE distributed_03826_dst;
+DROP TABLE local_03990_src;
+DROP TABLE local_03990_dst;
+DROP TABLE distributed_03990_src;
+DROP TABLE distributed_03990_dst;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixes a bug where it was not possible to use CTE with distributed insert selects. Continuation of https://github.com/ClickHouse/ClickHouse/pull/87789. Closes https://github.com/ClickHouse/ClickHouse/issues/95837.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.104`
<!-- ch-version-info:end -->