### PR TITLE
Lazy load of table function tables

### DIFF
--- a/src/Databases/DatabaseOnDisk.cpp
+++ b/src/Databases/DatabaseOnDisk.cpp
@@ -92,12 +92,17 @@ std::pair<String, StoragePtr> createTableFromAST(
     if (ast_create_query.as_table_function)
     {
         const auto & factory = TableFunctionFactory::instance();
+        const auto & storage_factory = StorageFactory::instance();
         auto table_function_ast = ast_create_query.as_table_function->ptr();
         auto table_function = factory.get(table_function_ast, context);
         ColumnsDescription columns;
         if (ast_create_query.columns_list && ast_create_query.columns_list->columns)
             columns = InterpreterCreateQuery::getColumnsDescription(*ast_create_query.columns_list->columns, context, mode);
-        bool lazy_init = StorageFactory::instance().getStorageFeatures(table_function->getStorageEngineName()).supports_schema_inference;
+
+        bool lazy_init =
+            storage_factory.getAllStorages().contains(table_function->getStorageEngineName())
+            && storage_factory.getStorageFeatures(table_function->getStorageEngineName()).supports_schema_inference;
+
         StoragePtr storage = table_function->execute(
             table_function_ast,
             context,

--- a/src/Databases/DatabaseOnDisk.cpp
+++ b/src/Databases/DatabaseOnDisk.cpp
@@ -97,7 +97,15 @@ std::pair<String, StoragePtr> createTableFromAST(
         ColumnsDescription columns;
         if (ast_create_query.columns_list && ast_create_query.columns_list->columns)
             columns = InterpreterCreateQuery::getColumnsDescription(*ast_create_query.columns_list->columns, context, mode);
-        StoragePtr storage = table_function->execute(table_function_ast, context, ast_create_query.getTable(), std::move(columns));
+        bool lazy_init = StorageFactory::instance().getStorageFeatures(table_function->getStorageEngineName()).supports_schema_inference;
+        StoragePtr storage = table_function->execute(
+            table_function_ast,
+            context,
+            ast_create_query.getTable(),
+            std::move(columns),
+            /*use_global_context=*/false,
+            /*is_insert_query=*/false,
+            lazy_init);
         storage->renameInMemory(ast_create_query);
         return {ast_create_query.getTable(), storage};
     }

--- a/src/TableFunctions/ITableFunction.cpp
+++ b/src/TableFunctions/ITableFunction.cpp
@@ -34,7 +34,7 @@ std::optional<AccessTypeObjects::Source> ITableFunction::getSourceAccessObject()
 }
 
 StoragePtr ITableFunction::execute(const ASTPtr & ast_function, ContextPtr context, const std::string & table_name,
-                                   ColumnsDescription cached_columns, bool use_global_context, bool is_insert_query) const
+                                   ColumnsDescription cached_columns, bool use_global_context, bool is_insert_query, bool force_lazy_init) const
 {
     ProfileEvents::increment(ProfileEvents::TableFunctionExecute);
 
@@ -52,12 +52,12 @@ StoragePtr ITableFunction::execute(const ASTPtr & ast_function, ContextPtr conte
         context->checkAccess(AccessType::CREATE_TEMPORARY_TABLE);
 
     auto context_to_use = use_global_context ? context->getGlobalContext() : context;
-
-    if (cached_columns.empty())
-        return executeImpl(ast_function, context, table_name, std::move(cached_columns), is_insert_query);
-
-    if (hasStaticStructure() && cached_columns == getActualTableStructure(context, is_insert_query))
-        return executeImpl(ast_function, context_to_use, table_name, std::move(cached_columns), is_insert_query);
+    if (!force_lazy_init) {
+        if (cached_columns.empty())
+            return executeImpl(ast_function, context, table_name, std::move(cached_columns), is_insert_query);
+        if (hasStaticStructure() && cached_columns == getActualTableStructure(context, is_insert_query))
+            return executeImpl(ast_function, context_to_use, table_name, std::move(cached_columns), is_insert_query);
+    }
 
     auto this_table_function = shared_from_this();
     auto get_storage = [=]() -> StoragePtr

--- a/src/TableFunctions/ITableFunction.cpp
+++ b/src/TableFunctions/ITableFunction.cpp
@@ -52,7 +52,8 @@ StoragePtr ITableFunction::execute(const ASTPtr & ast_function, ContextPtr conte
         context->checkAccess(AccessType::CREATE_TEMPORARY_TABLE);
 
     auto context_to_use = use_global_context ? context->getGlobalContext() : context;
-    if (!force_lazy_init) {
+    if (!force_lazy_init)
+    {
         if (cached_columns.empty())
             return executeImpl(ast_function, context, table_name, std::move(cached_columns), is_insert_query);
         if (hasStaticStructure() && cached_columns == getActualTableStructure(context, is_insert_query))

--- a/src/TableFunctions/ITableFunction.h
+++ b/src/TableFunctions/ITableFunction.h
@@ -41,6 +41,11 @@ class ITableFunction : public std::enable_shared_from_this<ITableFunction>
 public:
     static std::string getDatabaseName() { return "_table_function"; }
 
+    /// The name which is used in ENGINE section of the CREATE query.
+    /// This name is registered in the storage factory and used
+    /// to check privileges.
+    virtual const char * getStorageEngineName() const = 0;
+
     /// Get the main function name.
     virtual std::string getName() const = 0;
 
@@ -85,8 +90,14 @@ public:
     virtual void setPartitionBy(const ASTPtr &) {}
 
     /// Create storage according to the query.
-    StoragePtr
-    execute(const ASTPtr & ast_function, ContextPtr context, const std::string & table_name, ColumnsDescription cached_columns_ = {}, bool use_global_context = false, bool is_insert_query = false) const;
+    StoragePtr execute(
+        const ASTPtr & ast_function,
+        ContextPtr context,
+        const std::string & table_name,
+        ColumnsDescription cached_columns_ = {},
+        bool use_global_context = false,
+        bool is_insert_query = false,
+        bool force_lazy_init = false) const;
 
     virtual ~ITableFunction() = default;
 
@@ -97,10 +108,6 @@ private:
     virtual StoragePtr executeImpl(
         const ASTPtr & ast_function, ContextPtr context, const std::string & table_name, ColumnsDescription cached_columns, bool is_insert_query) const = 0;
 
-    /// The name which is used in ENGINE section of the CREATE query.
-    /// This name is registered in the storage factory and used
-    /// to check privileges.
-    virtual const char * getStorageEngineName() const = 0;
     virtual bool isClusterFunction() const { return false; }
     /// The database storage name is used to check privileges.
     /// For example for s3Cluster the database storage name is S3Cluster, and we need to check


### PR DESCRIPTION
If table is created as `CREATE TABLE table AS s3(...)`, it is possible to have a crash loop on start of the server if s3 source is currently unavailable (while trying to resolve columns or format for example). Some lazy load logic and workarounds are already present, but they are not obvious to the user. Some engines support dynamic schema inference and it can be used to load such tables lazily on start.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Tables created as table functions via `CREATE TABLE ... AS ...` are now lazily loaded at ClickHouse startup if the engine allows schema inference

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)
