### PR TITLE
Support weights in concurrent queue

### DIFF
--- a/src/Common/ConcurrentBoundedQueue.h
+++ b/src/Common/ConcurrentBoundedQueue.h
@@ -8,11 +8,30 @@
 #include <base/MoveOrCopyIfThrow.h>
 #include <base/defines.h>
 
+namespace detail
+{
+template <typename T>
+struct UnitWeight
+{
+    size_t operator()(const T &) const { return 1; }
+};
+}
+
 /** A very simple thread-safe queue of limited size.
   * If you try to pop an item from an empty queue, the thread is blocked until the queue becomes nonempty or queue is finished.
   * If you try to push an element into an overflowed queue, the thread is blocked until space appears in the queue or queue is finished.
+  *
+  * WeightFunction maps each element to its weight; the default assigns weight 1 to every element,
+  * preserving the original "bounded by element count" behaviour.
+  * max_fill is the capacity limit expressed in total weight units.
+  *
+  * Push admission policy: a thread is admitted to push as soon as the current total weight
+  * drops below max_fill (i.e. the predicate is current_weight < max_fill, not
+  * current_weight + item_weight <= max_fill). As a consequence, after a push the total
+  * weight may transiently exceed max_fill by at most one item's weight. This matches the
+  * original element-count semantics and avoids starvation of high-weight items.
   */
-template <typename T>
+template <typename T, typename WeightFunction = detail::UnitWeight<T>>
 class ConcurrentBoundedQueue
 {
 private:
@@ -26,6 +45,8 @@ private:
     bool is_finished = false;
 
     size_t max_fill = 0;
+    size_t current_weight = 0;
+    WeightFunction weight_function;
 
     template <bool back, typename ... Args>
     bool emplaceImpl(std::optional<UInt64> timeout_milliseconds, Args &&...args)
@@ -33,7 +54,7 @@ private:
         {
             std::unique_lock<std::mutex> queue_lock(queue_mutex);
 
-            auto predicate = [&]() { return is_finished || queue.size() < max_fill; };
+            auto predicate = [&]() { return is_finished || current_weight < max_fill; };
 
             if (timeout_milliseconds.has_value())
             {
@@ -51,9 +72,15 @@ private:
                 return false;
 
             if constexpr (back)
+            {
                 queue.emplace_back(std::forward<Args>(args)...);
+                current_weight += weight_function(queue.back());
+            }
             else
+            {
                 queue.emplace_front(std::forward<Args>(args)...);
+                current_weight += weight_function(queue.front());
+            }
         }
 
         pop_condition.notify_one();
@@ -85,11 +112,13 @@ private:
 
             if constexpr (front)
             {
+                current_weight -= weight_function(queue.front());
                 detail::moveOrCopyIfThrow(std::move(queue.front()), x);
                 queue.pop_front();
             }
             else
             {
+                current_weight -= weight_function(queue.back());
                 detail::moveOrCopyIfThrow(std::move(queue.back()), x);
                 queue.pop_back();
             }
@@ -101,8 +130,9 @@ private:
 
 public:
 
-    explicit ConcurrentBoundedQueue(size_t max_fill_)
+    explicit ConcurrentBoundedQueue(size_t max_fill_, WeightFunction weight_function_ = WeightFunction{})
         : max_fill(max_fill_)
+        , weight_function(std::move(weight_function_))
     {
     }
 
@@ -171,6 +201,7 @@ public:
             if (queue.empty())
                 return false;
 
+            current_weight -= weight_function(queue.front());
             detail::moveOrCopyIfThrow(std::move(queue.front()), x);
             queue.pop_front();
         }
@@ -239,6 +270,7 @@ public:
 
             Container empty_queue;
             queue.swap(empty_queue);
+            current_weight = 0;
         }
 
         push_condition.notify_all();
@@ -252,6 +284,7 @@ public:
 
             Container empty_queue;
             queue.swap(empty_queue);
+            current_weight = 0;
             is_finished = true;
         }
 

--- a/src/Common/ThreadStatus.h
+++ b/src/Common/ThreadStatus.h
@@ -3,14 +3,14 @@
 #include <Core/LogsLevel.h>
 #include <IO/Progress.h>
 #include <Interpreters/Context_fwd.h>
+#include <Common/ConcurrentBoundedQueue.h>
 #include <Common/IThrottler.h>
 #include <Common/Logger_fwd.h>
+#include <Common/MemorySpillScheduler.h>
 #include <Common/MemoryTracker.h>
 #include <Common/ProfileEvents.h>
-#include <Common/Stopwatch.h>
 #include <Common/Scheduler/ResourceLink.h>
-#include <Common/MemorySpillScheduler.h>
-#include <Common/ConcurrentBoundedQueue.h>
+#include <Common/Stopwatch.h>
 
 #include <boost/noncopyable.hpp>
 
@@ -18,14 +18,6 @@
 #include <functional>
 #include <mutex>
 #include <unordered_set>
-
-// namespace detail
-// {
-// template <typename T>
-// struct UnitWeight;
-// }
-// template <class T, class WeightFunction = detail::UnitWeight<T>>
-// class ConcurrentBoundedQueue;
 
 namespace DB
 {

--- a/src/Common/ThreadStatus.h
+++ b/src/Common/ThreadStatus.h
@@ -10,6 +10,7 @@
 #include <Common/Stopwatch.h>
 #include <Common/Scheduler/ResourceLink.h>
 #include <Common/MemorySpillScheduler.h>
+#include <Common/ConcurrentBoundedQueue.h>
 
 #include <boost/noncopyable.hpp>
 
@@ -18,9 +19,13 @@
 #include <mutex>
 #include <unordered_set>
 
-
-template <class T>
-class ConcurrentBoundedQueue;
+// namespace detail
+// {
+// template <typename T>
+// struct UnitWeight;
+// }
+// template <class T, class WeightFunction = detail::UnitWeight<T>>
+// class ConcurrentBoundedQueue;
 
 namespace DB
 {


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Support weights in concurrent bounded queue implementation

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

Preliminary PR before asyncronous Iceberg metadata iteration

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.419`
<!-- ch-version-info:end -->