### PR TITLE
[WIP] Fix heap-use-after-free in consumer lag timer

### DIFF
--- a/tests/integration/test_storage_kafka/test_batch_slow_4.py
+++ b/tests/integration/test_storage_kafka/test_batch_slow_4.py
@@ -141,9 +141,9 @@ def test_kafka_consumer_failover(kafka_cluster, create_query_generator):
         producer.flush()
 
         count_query = "SELECT count() FROM test.destination"
-        prev_count = instance.query_with_retry(
+        prev_count = int(instance.query_with_retry(
             count_query, check_callback=lambda res: int(res) > 0
-        )
+        ))
 
         ## 2 attached, 2 working
         instance.query("DETACH TABLE test.kafka1")
@@ -158,9 +158,9 @@ def test_kafka_consumer_failover(kafka_cluster, create_query_generator):
             partition=1,
         )
         producer.flush()
-        prev_count = instance.query_with_retry(
+        prev_count = int(instance.query_with_retry(
             count_query, check_callback=lambda res: int(res) > prev_count
-        )
+        ))
 
         ## 1 attached, 1 working
         instance.query("DETACH TABLE test.kafka2")
@@ -175,9 +175,9 @@ def test_kafka_consumer_failover(kafka_cluster, create_query_generator):
             partition=1,
         )
         producer.flush()
-        prev_count = instance.query_with_retry(
+        prev_count = int(instance.query_with_retry(
             count_query, check_callback=lambda res: int(res) > prev_count
-        )
+        ))
 
         ## 2 attached, 2 working
         instance.query("ATTACH TABLE test.kafka1")
@@ -192,9 +192,9 @@ def test_kafka_consumer_failover(kafka_cluster, create_query_generator):
             partition=1,
         )
         producer.flush()
-        prev_count = instance.query_with_retry(
+        prev_count = int(instance.query_with_retry(
             count_query, check_callback=lambda res: int(res) > prev_count
-        )
+        ))
 
         ## 1 attached, 1 working
         instance.query("DETACH TABLE test.kafka3")
@@ -209,9 +209,9 @@ def test_kafka_consumer_failover(kafka_cluster, create_query_generator):
             partition=1,
         )
         producer.flush()
-        prev_count = instance.query_with_retry(
+        prev_count = int(instance.query_with_retry(
             count_query, check_callback=lambda res: int(res) > prev_count
-        )
+        ))
 
         ## 2 attached, 2 working
         instance.query("ATTACH TABLE test.kafka2")
@@ -226,9 +226,9 @@ def test_kafka_consumer_failover(kafka_cluster, create_query_generator):
             partition=1,
         )
         producer.flush()
-        prev_count = instance.query_with_retry(
+        prev_count = int(instance.query_with_retry(
             count_query, check_callback=lambda res: int(res) > prev_count
-        )
+        ))
 
         ## 3 attached, 2 working
         instance.query("ATTACH TABLE test.kafka3")
@@ -243,9 +243,9 @@ def test_kafka_consumer_failover(kafka_cluster, create_query_generator):
             partition=1,
         )
         producer.flush()
-        prev_count = instance.query_with_retry(
+        prev_count = int(instance.query_with_retry(
             count_query, check_callback=lambda res: int(res) > prev_count
-        )
+        ))
 
         ## 2 attached, same 2 working
         instance.query("DETACH TABLE test.kafka3")
@@ -260,6 +260,6 @@ def test_kafka_consumer_failover(kafka_cluster, create_query_generator):
             partition=1,
         )
         producer.flush()
-        prev_count = instance.query_with_retry(
+        prev_count = int(instance.query_with_retry(
             count_query, check_callback=lambda res: int(res) > prev_count
-        )
+        ))

--- a/tests/integration/test_storage_kafka/test_batch_slow_4.py
+++ b/tests/integration/test_storage_kafka/test_batch_slow_4.py
@@ -263,3 +263,20 @@ def test_kafka_consumer_failover(kafka_cluster, create_query_generator):
         prev_count = int(instance.query_with_retry(
             count_query, check_callback=lambda res: int(res) > prev_count
         ))
+
+        # Clean up Kafka tables while the topic still exists, so that
+        # consumer group LeaveGroup works correctly. If tables are dropped
+        # after the topic is deleted (by the context manager exit), the
+        # consumer close can hang.
+        instance.query(
+            """
+            DROP TABLE IF EXISTS test.kafka1_mv;
+            DROP TABLE IF EXISTS test.kafka2_mv;
+            DROP TABLE IF EXISTS test.kafka3_mv;
+            DROP TABLE IF EXISTS test.kafka1;
+            DROP TABLE IF EXISTS test.kafka2;
+            ATTACH TABLE IF NOT EXISTS test.kafka3;
+            DROP TABLE IF EXISTS test.kafka3;
+            DROP TABLE IF EXISTS test.destination;
+            """
+        )

--- a/tests/integration/test_storage_kafka/test_batch_slow_6.py
+++ b/tests/integration/test_storage_kafka/test_batch_slow_6.py
@@ -292,8 +292,8 @@ def test_kafka_rebalance(kafka_cluster, create_query_generator, log_line):
         # I leave last one working by intent (to finish consuming after all rebalances)
         for consumer_index in range(NUMBER_OF_CONCURRENT_CONSUMERS - 1):
             table_name = f"{table_name_prefix}_{suffix}_{consumer_index}"
-            logging.debug(f"Dropping test.{table_name}_consumer{consumer_index}")
-            instance.query(f"DROP TABLE IF EXISTS test.{table_name}_consumer{consumer_index} SYNC")
+            logging.debug(f"Dropping test.{table_name}")
+            instance.query(f"DROP TABLE IF EXISTS test.{table_name} SYNC")
 
         def check_callback(res):
             logging.debug(f"Waiting for finishing consuming (have {res}, should be {msg_index[0]})")
@@ -308,8 +308,8 @@ def test_kafka_rebalance(kafka_cluster, create_query_generator, log_line):
         for consumer_index in range(NUMBER_OF_CONCURRENT_CONSUMERS):
             table_name = f"{table_name_prefix}_{suffix}_{consumer_index}"
             instance.query(f"""
-                DROP TABLE IF EXISTS test.{table_name}_consumer{consumer_index};
-                DROP TABLE IF EXISTS test.{table_name}_consumer{consumer_index}_mv;
+                DROP TABLE IF EXISTS test.{table_name};
+                DROP TABLE IF EXISTS test.{table_name}_mv;
             """)
 
         instance.query(f"DROP TABLE IF EXISTS test.kafka_destination_{suffix}")


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


---

The failure example: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=97943&sha=d9c41220fc4185d8e330e9af40ca4414cb29589a&name_0=PR&name_1=Integration%20tests%20%28amd_asan%2C%20db%20disk%2C%20old%20analyzer%2C%201%2F6%29
https://github.com/ClickHouse/ClickHouse/pull/97943