### PR TITLE
Revert "ci: fix fast limits"

### DIFF
--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -20,7 +20,6 @@ BUGFIX_VALIDATE_CHECK=0
 NO_AZURE=0
 KEEPER_INJECT_AUTH=1
 REMOTE_DATABASE_DISK=0
-USE_ENCRYPTED_STORAGE=0
 
 while [[ "$#" -gt 0 ]]; do
     case $1 in
@@ -67,16 +66,7 @@ function check_clickhouse_version()
 
 function is_fast_build()
 {
-    # Tests with MinIO/azure can be slow
-    if [[ $USE_S3_STORAGE_FOR_MERGE_TREE -eq 1 ]] || [[ $USE_AZURE_STORAGE_FOR_MERGE_TREE -eq 1 ]]; then
-        return 1
-    fi
-    # Encrypted storage is slow (but it is enabled only for object storages)
-    if [[ $USE_ENCRYPTED_STORAGE -eq 1 ]]; then
-        return 1
-    fi
-    # sanitizers and debugs builds are slow
-    [ "$(clickhouse local --query "SELECT value NOT LIKE '%-fsanitize=%' AND value LIKE '%-DNDEBUG%' FROM system.build_options WHERE name = 'CXX_FLAGS'")" -eq 1 ]
+    return $(clickhouse local --query "SELECT value NOT LIKE '%-fsanitize=%' AND value LIKE '%-DNDEBUG%' FROM system.build_options WHERE name = 'CXX_FLAGS'")
 }
 
 echo "Going to install test configs from $SRC_PATH into $DEST_SERVER_PATH"
@@ -127,7 +117,7 @@ ln -sf $SRC_PATH/config.d/top_level_domains_lists.xml $DEST_SERVER_PATH/config.d
 ln -sf $SRC_PATH/config.d/top_level_domains_path.xml $DEST_SERVER_PATH/config.d/
 
 ln -sf $SRC_PATH/config.d/transactions_info_log.xml $DEST_SERVER_PATH/config.d/
-if [[ "$USE_ENCRYPTED_STORAGE" == "0" ]]; then
+if [[ -z "$USE_ENCRYPTED_STORAGE" ]] || [[ "$USE_ENCRYPTED_STORAGE" == "0" ]]; then
     ln -sf $SRC_PATH/config.d/transactions.xml $DEST_SERVER_PATH/config.d/
 fi
 
@@ -218,7 +208,7 @@ ln -sf $SRC_PATH/users.d/limits.yaml $DEST_SERVER_PATH/users.d/
 if check_clickhouse_version 26.1; then
     ln -sf $SRC_PATH/users.d/distributed_index_analysis.yaml $DEST_SERVER_PATH/users.d/
 fi
-if is_fast_build; then
+if [[ $(is_fast_build) == 1 ]]; then
     ln -sf $SRC_PATH/users.d/limits_fast.yaml $DEST_SERVER_PATH/users.d/
 fi
 
@@ -338,13 +328,13 @@ function setup_storage_policy()
 if [[ "$USE_S3_STORAGE_FOR_MERGE_TREE" == "1" ]]; then
     setup_storage_policy
 
-    if [[ "$USE_ENCRYPTED_STORAGE" -eq 1 ]]; then
+    if [[ -n "$USE_ENCRYPTED_STORAGE" ]] && [[ "$USE_ENCRYPTED_STORAGE" -eq 1 ]]; then
         ln -sf $SRC_PATH/config.d/s3_encrypted_storage_policy_for_merge_tree_by_default.xml $DEST_SERVER_PATH/config.d/
     else
         ln -sf $SRC_PATH/config.d/s3_storage_policy_for_merge_tree_by_default.xml $DEST_SERVER_PATH/config.d/
     fi
 elif [[ "$USE_AZURE_STORAGE_FOR_MERGE_TREE" == "1" ]]; then
-    if [[ "$USE_ENCRYPTED_STORAGE" -eq 1 ]]; then
+    if [[ -n "$USE_ENCRYPTED_STORAGE" ]] && [[ "$USE_ENCRYPTED_STORAGE" -eq 1 ]]; then
         ln -sf $SRC_PATH/config.d/azure_encrypted_storage_policy_by_default.xml $DEST_SERVER_PATH/config.d/
     else
         ln -sf $SRC_PATH/config.d/azure_storage_policy_by_default.xml $DEST_SERVER_PATH/config.d/
@@ -408,7 +398,7 @@ if [[ "$USE_DATABASE_REPLICATED" == "1" ]]; then
     cat $DEST_SERVER_PATH/config.d/macros.xml | sed "s|<replica>r1</replica>|<replica>r2</replica>|" > $ch_server_1_path/config.d/macros.xml
     cat $DEST_SERVER_PATH/config.d/macros.xml | sed "s|<shard>s1</shard>|<shard>s2</shard>|" > $ch_server_2_path/config.d/macros.xml
 
-    if [[ "$USE_ENCRYPTED_STORAGE" == "0" ]]; then
+    if [[ -z "$USE_ENCRYPTED_STORAGE" ]] || [[ "$USE_ENCRYPTED_STORAGE" == "0" ]]; then
         rm $ch_server_1_path/config.d/transactions.xml
         rm $ch_server_2_path/config.d/transactions.xml
         cat $DEST_SERVER_PATH/config.d/transactions.xml | sed "s|/test/clickhouse/txn|/test/clickhouse/txn1|" > $ch_server_1_path/config.d/transactions.xml

--- a/tests/docker_scripts/stress_runner.sh
+++ b/tests/docker_scripts/stress_runner.sh
@@ -218,21 +218,22 @@ export THREAD_POOL_FAULT_INJECTION=1
 configure
 configure_limits
 
-# But we still need default disk because some tables loaded only into it
 if [[ "$USE_S3_STORAGE_FOR_MERGE_TREE" == "1" || "$USE_AZURE_STORAGE_FOR_MERGE_TREE" == "1" ]]; then
-    default_policy_paths=(
-        /etc/clickhouse-server/config.d/s3_encrypted_storage_policy_for_merge_tree_by_default.xml
-        /etc/clickhouse-server/config.d/azure_encrypted_storage_policy_by_default.xml
-        /etc/clickhouse-server/config.d/azure_storage_policy_by_default.xml
-        /etc/clickhouse-server/config.d/s3_storage_policy_by_default.xml
-    )
-    for file in "${default_policy_paths[@]}"; do
-        if [[ -e $file ]]; then
-            break
+    # But we still need default disk because some tables loaded only into it
+    if [[ $USE_S3_STORAGE_FOR_MERGE_TREE == "1" ]]; then
+        if [[ $USE_ENCRYPTED_STORAGE == "1" ]]; then
+            file=/etc/clickhouse-server/config.d/s3_encrypted_storage_policy_for_merge_tree_by_default.xml
+        else
+            file=/etc/clickhouse-server/config.d/s3_storage_policy_by_default.xml
         fi
-    done
-    if [[ ! -e $file ]]; then
-        echo "Cannot locate file with default storage policy" >&2
+    elif [[ "$USE_AZURE_STORAGE_FOR_MERGE_TREE" == "1" ]]; then
+        if [[ $USE_ENCRYPTED_STORAGE == "1" ]]; then
+            file=/etc/clickhouse-server/config.d/azure_encrypted_storage_policy_by_default.xml
+        else
+            file=/etc/clickhouse-server/config.d/azure_storage_policy_by_default.xml
+        fi
+    else
+        echo "ERROR: Failed to find azure storage policy by default file"
         exit 1
     fi
 


### PR DESCRIPTION
Reverts ClickHouse/ClickHouse#97823

```
● So the summary is:                                                                                                                                                                                                                                                                                      
                                                        
  1. PR #97823 (ci: fix fast limits) fixed the is_fast_build function so it actually works                                                                                                                                                                                                                
  2. This function now correctly detects "fast" builds (no sanitizers, with NDEBUG) and installs limits_fast.yaml                                                                                                                                                                                         
  3. limits_fast.yaml sets max_execution_time: 60                                                                                                                                                                                                                                                         
  4. The LLVM coverage build passes the "fast build" check because it uses -fprofile-instr-generate -fcoverage-mapping (not -fsanitize=) and has -DNDEBUG                                                                                                                                                 
  5. But coverage instrumentation adds significant overhead (~2-3x), so heavy tests exceed the 60s limit

  The fix should make is_fast_build also exclude coverage builds. The function should additionally check for -fprofile-instr-generate or -fcoverage-mapping in the build flags. Something like:

  function is_fast_build()
  {
      if [[ $USE_S3_STORAGE_FOR_MERGE_TREE -eq 1 ]] || [[ $USE_AZURE_STORAGE_FOR_MERGE_TREE -eq 1 ]]; then
          return 1
      fi
      if [[ $USE_ENCRYPTED_STORAGE -eq 1 ]]; then
          return 1
      fi
      # sanitizers, debug, and coverage builds are slow
      [ "$(clickhouse local --query "SELECT value NOT LIKE '%-fsanitize=%' AND value LIKE '%-DNDEBUG%' AND value NOT LIKE '%-fprofile-instr-generate%' FROM system.build_options WHERE name = 'CXX_FLAGS'")" -eq 1 ]
  }
```


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.55`
<!-- ch-version-info:end -->