### PR TITLE
Quote argument-hint values in skill YAML front-matter

### DIFF
--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: build
 description: Build ClickHouse with various configurations (Release, Debug, ASAN, TSAN, etc.). Use when the user wants to compile ClickHouse.
-argument-hint: [build-type] [target] [options]
+argument-hint: "[build-type] [target] [options]"
 disable-model-invocation: false
 allowed-tools: Task, Bash(ninja:*), Bash(cd:*), Bash(ls:*), Bash(pgrep:*), Bash(ps:*), Bash(pkill:*), Bash(mktemp:*), Bash(sleep:*)
 ---

--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: test
 description: Run ClickHouse stateless or integration tests. Use when the user wants to run or execute tests.
-argument-hint: [test-name] [--flags]
+argument-hint: "[test-name] [--flags]"
 disable-model-invocation: false
 allowed-tools: Task, Bash(./tests/clickhouse-test:*), Bash(pgrep:*), Bash(./build/*/programs/clickhouse:*), Bash(./build*/programs/clickhouse:*), Bash(python:*), Bash(python3:*), Bash(mktemp:*), Bash(export:*), Bash(ls:*), Bash(test:*)
 ---


### PR DESCRIPTION
Copilot CLI depends on these values being valid YAML strings. Unquoted `[...]` is parsed as a YAML array instead of a literal string, which breaks Copilot CLI's skill argument handling.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.83`
<!-- ch-version-info:end -->