### PR TITLE
Adjust some integration tests to run without add_minmax_index_for_numeric_columns

### DIFF
--- a/tests/integration/test_max_suspicious_broken_parts/test.py
+++ b/tests/integration/test_max_suspicious_broken_parts/test.py
@@ -114,7 +114,9 @@ def test_max_suspicious_broken_parts_bytes():
         max_suspicious_broken_parts = 10,
         serialization_info_version = 'basic',
         /* one part takes ~751 byte, so we allow failure of one part with these limit */
-        max_suspicious_broken_parts_bytes = 1000;
+        max_suspicious_broken_parts_bytes = 1000,
+        /* Disable implicit index as it'd change the size */
+        add_minmax_index_for_numeric_columns=0;
     """
     )
     check_table("test_max_suspicious_broken_parts_bytes")
@@ -151,7 +153,9 @@ def test_max_suspicious_broken_parts_bytes__wide():
         serialization_info_version = 'basic',
         max_suspicious_broken_parts = 10,
         /* one part takes ~750 byte, so we allow failure of one part with these limit */
-        max_suspicious_broken_parts_bytes = 1000;
+        max_suspicious_broken_parts_bytes = 1000,
+        /* Disable implicit index as it'd change the size */
+        add_minmax_index_for_numeric_columns=0;
     """
     )
     check_table("test_max_suspicious_broken_parts_bytes__wide")

--- a/tests/integration/test_partition/test.py
+++ b/tests/integration/test_partition/test.py
@@ -161,7 +161,7 @@ def partition_table_complex(started_cluster):
     q("DROP TABLE IF EXISTS test.partition_complex")
     q(
         "CREATE TABLE test.partition_complex (p Date, k Int8, v1 Int8 MATERIALIZED k + 1) "
-        "ENGINE = MergeTree PARTITION BY p ORDER BY k SETTINGS index_granularity=1, index_granularity_bytes=0, compress_marks=false, compress_primary_key=false, ratio_of_defaults_for_sparse_serialization=1, serialization_info_version='basic', replace_long_file_name_to_hash=false"
+        "ENGINE = MergeTree PARTITION BY p ORDER BY k SETTINGS index_granularity=1, index_granularity_bytes=0, compress_marks=false, compress_primary_key=false, ratio_of_defaults_for_sparse_serialization=1, serialization_info_version='basic', replace_long_file_name_to_hash=false, add_minmax_index_for_numeric_columns=0"
     )
     q("INSERT INTO test.partition_complex (p, k) VALUES(toDate(31), 1)")
     q("INSERT INTO test.partition_complex (p, k) VALUES(toDate(1), 2)")

--- a/tests/integration/test_remote_blobs_naming/test_backward_compatibility.py
+++ b/tests/integration/test_remote_blobs_naming/test_backward_compatibility.py
@@ -271,6 +271,8 @@ def test_replicated_merge_tree(cluster, test_case):
                 PARTITION BY id
                 ORDER BY (id, val)
                 SETTINGS
+                    -- Changes the number of files
+                    add_minmax_index_for_numeric_columns=0,
                     storage_policy='{storage_policy}',
                     allow_remote_fs_zero_copy_replication='{1 if zero_copy else 0}'
                 """


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Adjust some integration tests to run without add_minmax_index_for_numeric_columns

References https://github.com/ClickHouse/ClickHouse/pull/76867

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.106`
<!-- ch-version-info:end -->