### PR TITLE
Remove confusing column `type` from `system.tokenizers`

### DIFF
--- a/docs/en/operations/system-tables/tokenizers.md
+++ b/docs/en/operations/system-tables/tokenizers.md
@@ -27,14 +27,14 @@ SELECT * FROM system.tokenizers;
 ```
 
 ```text
-┌─name────────────┬─type────────────┐
-│ ngrams          │ Ngrams          │
-│ splitByNonAlpha │ SplitByNonAlpha │
-│ sparseGrams     │ SparseGrams     │
-│ tokenbf_v1      │ SplitByNonAlpha │
-│ ngrambf_v1      │ Ngrams          │
-│ array           │ Array           │
-│ splitByString   │ SplitByString   │
-│ sparse_grams    │ SparseGrams     │
-└─────────────────┴─────────────────┘
+┌─name────────────┐
+│ ngrams          │
+│ splitByNonAlpha │
+│ sparseGrams     │
+│ tokenbf_v1      │
+│ ngrambf_v1      │
+│ array           │
+│ splitByString   │
+│ sparse_grams    │
+└─────────────────┘
 ```

--- a/src/Storages/System/StorageSystemTokenizers.cpp
+++ b/src/Storages/System/StorageSystemTokenizers.cpp
@@ -11,8 +11,7 @@ ColumnsDescription StorageSystemTokenizers::getColumnsDescription()
 {
     return ColumnsDescription
     {
-        {"name", std::make_shared<DataTypeString>(), "Name of the tokenizer"},
-        {"type", std::make_shared<DataTypeString>(), "Type of the tokenizer"}
+        {"name", std::make_shared<DataTypeString>(), "Name of the tokenizer"}
     };
 }
 
@@ -27,10 +26,7 @@ void StorageSystemTokenizers::fillData(MutableColumns & res_columns, ContextPtr,
     const auto & tokenizers = tokenizer_factory.getAllTokenizers();
 
     for (const auto & tokenizer : tokenizers)
-    {
         res_columns[0]->insert(tokenizer.first);
-        res_columns[1]->insert(magic_enum::enum_name(tokenizer.second));
-    }
 }
 
 }

--- a/tests/queries/0_stateless/02346_system_tokenizers.reference
+++ b/tests/queries/0_stateless/02346_system_tokenizers.reference
@@ -1,8 +1,8 @@
-array	Array
-ngrambf_v1	Ngrams
-ngrams	Ngrams
-sparseGrams	SparseGrams
-sparse_grams	SparseGrams
-splitByNonAlpha	SplitByNonAlpha
-splitByString	SplitByString
-tokenbf_v1	SplitByNonAlpha
+array
+ngrambf_v1
+ngrams
+sparseGrams
+sparse_grams
+splitByNonAlpha
+splitByString
+tokenbf_v1


### PR DESCRIPTION
Follow-up to https://github.com/ClickHouse/ClickHouse/pull/96753

Removes column `type` which created confusion.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.79`
- Backported to: `26.2.1.1128`
<!-- ch-version-info:end -->