### PR TITLE
Fix race in BackupsInMemoryHolder

### DIFF
--- a/src/Backups/BackupIO_Memory.cpp
+++ b/src/Backups/BackupIO_Memory.cpp
@@ -96,18 +96,16 @@ void registerBackupEngineMemory(BackupFactory & factory)
 
         if (params.open_mode == IBackup::OpenMode::READ)
         {
-            const auto & backups_in_memory = params.context->getSessionContext()->getBackupsInMemory();
-            auto backup_in_memory = backups_in_memory.getBackup(backup_name);
+            auto backups_in_memory = params.context->getSessionContext()->getBackupsInMemory();
+            auto backup_in_memory = backups_in_memory->getBackup(backup_name);
             auto reader = std::make_shared<BackupReaderMemory>(backup_in_memory, params.read_settings, params.write_settings);
-
             return std::make_unique<BackupImpl>(params, BackupImpl::ArchiveParams{}, reader);
         }
         else
         {
-            auto & backups_in_memory = params.context->getSessionContext()->getBackupsInMemory();
-            auto backup_in_memory = backups_in_memory.createBackup(backup_name);
+            auto backups_in_memory = params.context->getSessionContext()->getBackupsInMemory();
+            auto backup_in_memory = backups_in_memory->createBackup(backup_name);
             auto writer = std::make_shared<BackupWriterMemory>(backup_in_memory, params.read_settings, params.write_settings);
-
             return std::make_unique<BackupImpl>(params, BackupImpl::ArchiveParams{}, writer);
         }
     };

--- a/src/Backups/BackupInMemory.cpp
+++ b/src/Backups/BackupInMemory.cpp
@@ -16,7 +16,7 @@ namespace ErrorCodes
 }
 
 
-BackupInMemory::BackupInMemory(const String & backup_name_, BackupsInMemoryHolder & holder_)
+BackupInMemory::BackupInMemory(const String & backup_name_, std::weak_ptr<BackupsInMemoryHolder> holder_)
     : backup_name(backup_name_), holder(holder_)
 {
 }
@@ -124,7 +124,8 @@ void BackupInMemory::copyFile(const String & from, const String & to)
 
 void BackupInMemory::drop()
 {
-    holder.dropBackup(backup_name);
+    if (auto holder_ptr = holder.lock())
+        holder_ptr->dropBackup(backup_name);
 }
 
 }

--- a/src/Backups/BackupInMemory.h
+++ b/src/Backups/BackupInMemory.h
@@ -20,7 +20,7 @@ class WriteBuffer;
 class BackupInMemory : public std::enable_shared_from_this<BackupInMemory>
 {
 public:
-    BackupInMemory(const String & backup_name_, BackupsInMemoryHolder & holder_);
+    BackupInMemory(const String & backup_name_, std::weak_ptr<BackupsInMemoryHolder> holder_);
 
     bool isEmpty() const;
     bool fileExists(const String & file_name) const;
@@ -37,7 +37,7 @@ private:
     class WriteBufferToBackupInMemory;
 
     const String backup_name;
-    BackupsInMemoryHolder & holder;
+    std::weak_ptr<BackupsInMemoryHolder> holder;
     std::unordered_map<String, String> files TSA_GUARDED_BY(mutex);
     mutable std::mutex mutex;
 };

--- a/src/Backups/BackupsInMemoryHolder.cpp
+++ b/src/Backups/BackupsInMemoryHolder.cpp
@@ -24,7 +24,7 @@ std::shared_ptr<BackupInMemory> BackupsInMemoryHolder::createBackup(const String
     auto it = backups.find(backup_name);
     if (it != backups.end())
         throw Exception(ErrorCodes::BACKUP_ALREADY_EXISTS, "Backup {} already exists", backup_name);
-    auto new_backup = std::make_shared<BackupInMemory>(backup_name, *this);
+    auto new_backup = std::make_shared<BackupInMemory>(backup_name, weak_from_this());
     backups.emplace(backup_name, new_backup);
     return new_backup;
 }

--- a/src/Backups/BackupsInMemoryHolder.h
+++ b/src/Backups/BackupsInMemoryHolder.h
@@ -2,6 +2,7 @@
 
 #include <base/defines.h>
 #include <base/types.h>
+#include <memory>
 #include <mutex>
 #include <unordered_map>
 
@@ -11,7 +12,7 @@ namespace DB
 class BackupInMemory;
 
 /// Holds all backups stored in memory during the current user's session.
-class BackupsInMemoryHolder
+class BackupsInMemoryHolder : public std::enable_shared_from_this<BackupsInMemoryHolder>
 {
 public:
     BackupsInMemoryHolder();

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -3713,14 +3713,17 @@ void Context::cancelAllBackupsAndRestores() const
         shared->backups_worker->cancelAll();
 }
 
-BackupsInMemoryHolder & Context::getBackupsInMemory()
+std::shared_ptr<BackupsInMemoryHolder> Context::getBackupsInMemory()
 {
+    std::lock_guard lock(mutex);
+    if (!backups_in_memory)
+        backups_in_memory = std::make_shared<BackupsInMemoryHolder>();
     return backups_in_memory;
 }
 
-const BackupsInMemoryHolder & Context::getBackupsInMemory() const
+std::shared_ptr<const BackupsInMemoryHolder> Context::getBackupsInMemory() const
 {
-    return backups_in_memory;
+    return const_cast<Context *>(this)->getBackupsInMemory();
 }
 
 

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -668,7 +668,7 @@ protected:
                                                         /// It's shared with all children contexts.
     MergeTreeTransactionHolder merge_tree_transaction_holder;   /// It will rollback or commit transaction on Context destruction.
 
-    BackupsInMemoryHolder backups_in_memory; /// Backups stored in memory (see "BACKUP ... TO Memory()" statement)
+    std::shared_ptr<BackupsInMemoryHolder> backups_in_memory; /// Backups stored in memory (see "BACKUP ... TO Memory()" statement)
 
     /// Use copy constructor or createGlobal() instead
     ContextData();
@@ -1134,8 +1134,8 @@ public:
     BackupsWorker & getBackupsWorker() const;
     void waitAllBackupsAndRestores() const;
     void cancelAllBackupsAndRestores() const;
-    BackupsInMemoryHolder & getBackupsInMemory();
-    const BackupsInMemoryHolder & getBackupsInMemory() const;
+    std::shared_ptr<BackupsInMemoryHolder> getBackupsInMemory();
+    std::shared_ptr<const BackupsInMemoryHolder> getBackupsInMemory() const;
 
     /// I/O formats.
     InputFormatPtr getInputFormat(


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix race in BackupsInMemoryHolder

Closes https://github.com/ClickHouse/ClickHouse/issues/97995


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.370`
<!-- ch-version-info:end -->