### PR TITLE
Respect date_time_output_format in JSON serialization

### DIFF
--- a/src/DataTypes/Serializations/SerializationDateTime.cpp
+++ b/src/DataTypes/Serializations/SerializationDateTime.cpp
@@ -186,9 +186,12 @@ bool SerializationDateTime::tryDeserializeTextQuoted(IColumn & column, ReadBuffe
 void SerializationDateTime::serializeTextJSON(
     const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings & settings) const
 {
-    writeChar('"', ostr);
+    bool quote = settings.date_time_output_format != FormatSettings::DateTimeOutputFormat::UnixTimestamp;
+    if (quote)
+        writeChar('"', ostr);
     serializeText(column, row_num, ostr, settings);
-    writeChar('"', ostr);
+    if (quote)
+        writeChar('"', ostr);
 }
 
 void SerializationDateTime::deserializeTextJSON(IColumn & column, ReadBuffer & istr, const FormatSettings & settings) const

--- a/src/DataTypes/Serializations/SerializationDateTime64.cpp
+++ b/src/DataTypes/Serializations/SerializationDateTime64.cpp
@@ -173,9 +173,12 @@ bool SerializationDateTime64::tryDeserializeTextQuoted(IColumn & column, ReadBuf
 
 void SerializationDateTime64::serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings & settings) const
 {
-    writeChar('"', ostr);
+    bool quote = settings.date_time_output_format != FormatSettings::DateTimeOutputFormat::UnixTimestamp;
+    if (quote)
+        writeChar('"', ostr);
     serializeText(column, row_num, ostr, settings);
-    writeChar('"', ostr);
+    if (quote)
+        writeChar('"', ostr);
 }
 
 void SerializationDateTime64::deserializeTextJSON(IColumn & column, ReadBuffer & istr, const FormatSettings & settings) const

--- a/src/DataTypes/Serializations/SerializationDateTime64.cpp
+++ b/src/DataTypes/Serializations/SerializationDateTime64.cpp
@@ -191,7 +191,7 @@ void SerializationDateTime64::deserializeTextJSON(IColumn & column, ReadBuffer &
     }
     else
     {
-        readIntText(x, istr);
+        readText(x, scale, istr, settings, time_zone, utc_time_zone);
     }
     assert_cast<ColumnType &>(column).getData().push_back(x);
 }
@@ -206,7 +206,7 @@ bool SerializationDateTime64::tryDeserializeTextJSON(IColumn & column, ReadBuffe
     }
     else
     {
-        if (!tryReadIntText(x, istr))
+        if (!tryReadText(x, scale, istr, settings, time_zone, utc_time_zone))
             return false;
     }
     assert_cast<ColumnType &>(column).getData().push_back(x);

--- a/src/IO/WriteHelpers.h
+++ b/src/IO/WriteHelpers.h
@@ -764,6 +764,11 @@ inline void writeDateTime64FractionalText(typename DecimalType::NativeType fract
     char data[20] = {'0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0'};
     static_assert(sizeof(data) >= MaxScale);
 
+    /// Handle negative fractional part by using the absolute value for processing.
+    /// This mirrors the approach used in writeTime64FractionalText.
+    if (fractional < 0)
+        fractional = -fractional;
+
     for (Int32 pos = scale - 1; pos >= 0 && fractional; --pos, fractional /= DateTime64(10))
         data[pos] += fractional % DateTime64(10);
 
@@ -967,6 +972,16 @@ inline void writeDateTimeUnixTimestamp(DateTime64 datetime64, UInt32 scale, Writ
     scale = scale > MaxScale ? MaxScale : scale;
 
     auto components = DecimalUtils::split(datetime64, scale);
+
+    /// When whole part is zero and fractional part is negative (e.g. -0.123s),
+    /// DecimalUtils::split returns {whole=0, fractional=-123}. We need to
+    /// output "-0.123" but writeIntText(0) won't print a minus sign.
+    if (components.whole == 0 && components.fractional < 0)
+    {
+        buf.write('-');
+        components.fractional = -components.fractional;
+    }
+
     writeIntText(components.whole, buf);
 
     if (scale > 0)

--- a/tests/queries/0_stateless/04002_json_datetime_no_quotes_unix_timestamp.reference
+++ b/tests/queries/0_stateless/04002_json_datetime_no_quotes_unix_timestamp.reference
@@ -10,3 +10,17 @@ DateTime64 unix_timestamp
 {"ts":1602756000.123}
 DateTime64 iso
 {"ts":"2020-10-15T10:00:00.123Z"}
+Roundtrip DateTime unix_timestamp
+{"ts":1602756000}
+Roundtrip DateTime64 unix_timestamp
+{"ts":1602756000.123}
+Roundtrip DateTime simple
+{"ts":"2020-10-15 10:00:00"}
+Roundtrip DateTime64 simple
+{"ts":"2020-10-15 10:00:00.123"}
+DateTime64 negative unix_timestamp
+{"ts":-0.877}
+DateTime64 negative close to epoch
+{"ts":-0.123}
+DateTime64 scale0 unix_timestamp
+{"ts":1602756000}

--- a/tests/queries/0_stateless/04002_json_datetime_no_quotes_unix_timestamp.reference
+++ b/tests/queries/0_stateless/04002_json_datetime_no_quotes_unix_timestamp.reference
@@ -1,0 +1,12 @@
+DateTime simple
+{"ts":"2020-10-15 10:00:00"}
+DateTime unix_timestamp
+{"ts":1602756000}
+DateTime iso
+{"ts":"2020-10-15T10:00:00Z"}
+DateTime64 simple
+{"ts":"2020-10-15 10:00:00.123"}
+DateTime64 unix_timestamp
+{"ts":1602756000.123}
+DateTime64 iso
+{"ts":"2020-10-15T10:00:00.123Z"}

--- a/tests/queries/0_stateless/04002_json_datetime_no_quotes_unix_timestamp.sql
+++ b/tests/queries/0_stateless/04002_json_datetime_no_quotes_unix_timestamp.sql
@@ -1,0 +1,20 @@
+-- Test that JSON output of DateTime/DateTime64 respects date_time_output_format setting
+-- When unix_timestamp format is used, the value should be a JSON number, not a quoted string
+
+SELECT 'DateTime simple';
+SELECT toDateTime('2020-10-15 10:00:00', 'UTC') AS ts FORMAT JSONEachRow SETTINGS date_time_output_format = 'simple';
+
+SELECT 'DateTime unix_timestamp';
+SELECT toDateTime('2020-10-15 10:00:00', 'UTC') AS ts FORMAT JSONEachRow SETTINGS date_time_output_format = 'unix_timestamp';
+
+SELECT 'DateTime iso';
+SELECT toDateTime('2020-10-15 10:00:00', 'UTC') AS ts FORMAT JSONEachRow SETTINGS date_time_output_format = 'iso';
+
+SELECT 'DateTime64 simple';
+SELECT toDateTime64('2020-10-15 10:00:00.123', 3, 'UTC') AS ts FORMAT JSONEachRow SETTINGS date_time_output_format = 'simple';
+
+SELECT 'DateTime64 unix_timestamp';
+SELECT toDateTime64('2020-10-15 10:00:00.123', 3, 'UTC') AS ts FORMAT JSONEachRow SETTINGS date_time_output_format = 'unix_timestamp';
+
+SELECT 'DateTime64 iso';
+SELECT toDateTime64('2020-10-15 10:00:00.123', 3, 'UTC') AS ts FORMAT JSONEachRow SETTINGS date_time_output_format = 'iso';

--- a/tests/queries/0_stateless/04002_json_datetime_no_quotes_unix_timestamp.sql
+++ b/tests/queries/0_stateless/04002_json_datetime_no_quotes_unix_timestamp.sql
@@ -1,6 +1,7 @@
 -- Test that JSON output of DateTime/DateTime64 respects date_time_output_format setting
 -- When unix_timestamp format is used, the value should be a JSON number, not a quoted string
 
+-- Serialization tests
 SELECT 'DateTime simple';
 SELECT toDateTime('2020-10-15 10:00:00', 'UTC') AS ts FORMAT JSONEachRow SETTINGS date_time_output_format = 'simple';
 
@@ -18,3 +19,28 @@ SELECT toDateTime64('2020-10-15 10:00:00.123', 3, 'UTC') AS ts FORMAT JSONEachRo
 
 SELECT 'DateTime64 iso';
 SELECT toDateTime64('2020-10-15 10:00:00.123', 3, 'UTC') AS ts FORMAT JSONEachRow SETTINGS date_time_output_format = 'iso';
+
+-- Roundtrip tests: serialize to JSON and parse back, verify the value is preserved
+SELECT 'Roundtrip DateTime unix_timestamp';
+SELECT * FROM format(JSONEachRow, 'ts DateTime(\'UTC\')', '{"ts":1602756000}') SETTINGS date_time_output_format = 'unix_timestamp' FORMAT JSONEachRow;
+
+SELECT 'Roundtrip DateTime64 unix_timestamp';
+SELECT * FROM format(JSONEachRow, 'ts DateTime64(3, \'UTC\')', '{"ts":1602756000.123}') SETTINGS date_time_output_format = 'unix_timestamp' FORMAT JSONEachRow;
+
+-- Roundtrip with quoted strings (simple/iso formats should still work)
+SELECT 'Roundtrip DateTime simple';
+SELECT * FROM format(JSONEachRow, 'ts DateTime(\'UTC\')', '{"ts":"2020-10-15 10:00:00"}') SETTINGS date_time_output_format = 'simple' FORMAT JSONEachRow;
+
+SELECT 'Roundtrip DateTime64 simple';
+SELECT * FROM format(JSONEachRow, 'ts DateTime64(3, \'UTC\')', '{"ts":"2020-10-15 10:00:00.123"}') SETTINGS date_time_output_format = 'simple' FORMAT JSONEachRow;
+
+-- Negative DateTime64 timestamps (before epoch)
+SELECT 'DateTime64 negative unix_timestamp';
+SELECT toDateTime64('1969-12-31 23:59:59.123', 3, 'UTC') AS ts FORMAT JSONEachRow SETTINGS date_time_output_format = 'unix_timestamp';
+
+SELECT 'DateTime64 negative close to epoch';
+SELECT toDateTime64('1969-12-31 23:59:59.877', 3, 'UTC') AS ts FORMAT JSONEachRow SETTINGS date_time_output_format = 'unix_timestamp';
+
+-- DateTime64 with scale=0 (no fractional part)
+SELECT 'DateTime64 scale0 unix_timestamp';
+SELECT toDateTime64('2020-10-15 10:00:00', 0, 'UTC') AS ts FORMAT JSONEachRow SETTINGS date_time_output_format = 'unix_timestamp';


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Output DateTime/DateTime64 as JSON number instead of quoted string when date_time_output_format is set to unix_timestamp.


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
