### PR TITLE
Fix global search mode in text index with combined conditions

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.h
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.h
@@ -139,7 +139,11 @@ private:
     std::vector<String> stringLikeToTokens(const Field & field) const;
 
     bool tryPrepareSetForTextSearch(const RPNBuilderTreeNode & lhs, const RPNBuilderTreeNode & rhs, const String & function_name, RPNElement & out) const;
-    static TextSearchMode getTextSearchMode(const RPNElement & element);
+
+    /// Returns true if all tokens must be read for text index analysis
+    /// and we cannot exit analysis earlier if some of the tokens are missing in granule.
+    /// E.g. "hasAnyTokens(s, 'tokens')" or "hasAllTokens(s, 'tokens1') OR hasAllTokens(s, 'tokens2')""
+    static bool requiresReadingAllTokens(const RPNElement & element);
 
     Block header;
     TokenizerPtr tokenizer;

--- a/tests/queries/0_stateless/04003_text_index_search_mode.reference
+++ b/tests/queries/0_stateless/04003_text_index_search_mode.reference
@@ -1,0 +1,8 @@
+300
+Condition: (mode: All; tokens: ["12", "23"])
+580
+Condition: (mode: Any; tokens: ["12", "23", "34"])
+20
+Condition: (mode: All; tokens: ["12", "23", "34"])
+280
+Condition: (mode: All; tokens: ["12", "23"])

--- a/tests/queries/0_stateless/04003_text_index_search_mode.sql
+++ b/tests/queries/0_stateless/04003_text_index_search_mode.sql
@@ -1,0 +1,21 @@
+SET optimize_or_like_chain = 0;
+
+DROP TABLE IF EXISTS t_search_mode;
+
+CREATE TABLE t_search_mode (a UInt64, s String, index idx_s (s) type text(tokenizer = ngrams(2))) ENGINE = MergeTree ORDER BY tuple();
+
+INSERT INTO t_search_mode SELECT number, toString(number) FROM numbers(100000);
+
+SELECT count() FROM t_search_mode WHERE s LIKE '%123%';
+SELECT trim(explain) FROM (EXPLAIN indexes = 1 SELECT count() FROM t_search_mode WHERE s LIKE '%123%') WHERE explain like '%Condition%';
+
+SELECT count() FROM t_search_mode WHERE s LIKE '%123%' OR s LIKE '%234%';
+SELECT trim(explain) FROM (EXPLAIN indexes = 1 SELECT count() FROM t_search_mode WHERE s LIKE '%123%' OR s LIKE '%234%') WHERE explain like '%Condition%';
+
+SELECT count() FROM t_search_mode WHERE s LIKE '%123%' AND s LIKE '%234%';
+SELECT trim(explain) FROM (EXPLAIN indexes = 1 SELECT count() FROM t_search_mode WHERE s LIKE '%123%' AND s LIKE '%234%') WHERE explain like '%Condition%';
+
+SELECT count() FROM t_search_mode WHERE s LIKE '%123%' AND a > 10000;
+SELECT trim(explain) FROM (EXPLAIN indexes = 1 SELECT count() FROM t_search_mode WHERE s LIKE '%123%' AND a > 10000) WHERE explain like '%Condition%';
+
+DROP TABLE t_search_mode;

--- a/tests/queries/0_stateless/04003_text_index_search_mode.sql
+++ b/tests/queries/0_stateless/04003_text_index_search_mode.sql
@@ -1,3 +1,5 @@
+-- Tags: no-parallel-replicas
+
 SET optimize_or_like_chain = 0;
 
 DROP TABLE IF EXISTS t_search_mode;


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Improved performance of text index analysis for queries with combined conditions involving both indexed and non-indexed columns. Previously, early exit optimization during index analysis was incorrectly disabled in such cases.

Fixes #95994.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.100`
- Backported to: `26.2.1.1136`, `25.12.9.7`
<!-- ch-version-info:end -->