### PR TITLE
Fix incorrect result of FINAL queries when mixing primary key and non primary key skip indexes

### DIFF
--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -1885,6 +1885,30 @@ ReadFromMergeTree::AnalysisResultPtr ReadFromMergeTree::selectRangesToRead(bool 
     return analyzed_result_ptr;
 }
 
+namespace
+{
+
+/// Check if all columns of all useful skip indexes are also part of the primary key.
+/// When true, skip indexes cannot cause incorrect FINAL results (since PK-based filtering cannot drop parts with overlapping key ranges),
+/// so the `findPKRangesForFinalAfterSkipIndex` recovery pass can be skipped.
+bool areAllSkipIndexColumnsInPrimaryKey(const Names & primary_key_columns, const UsefulSkipIndexes & skip_indexes)
+{
+    NameSet primary_key_columns_set(primary_key_columns.begin(), primary_key_columns.end());
+
+    for (const auto & skip_index : skip_indexes.useful_indices)
+    {
+        for (const auto & column : skip_index.index->index.column_names)
+        {
+            if (!primary_key_columns_set.contains(column))
+                return false;
+        }
+    }
+
+    return true;
+}
+
+}
+
 void ReadFromMergeTree::buildIndexes(
     std::optional<ReadFromMergeTree::Indexes> & indexes,
     const ActionsDAG * filter_actions_dag_,
@@ -2027,8 +2051,7 @@ void ReadFromMergeTree::buildIndexes(
     indexes->use_skip_indexes_if_final_exact_mode = indexes->use_skip_indexes && !skip_indexes.empty()
                                                         && query_info_.isFinal()
                                                         && settings[Setting::use_skip_indexes_if_final_exact_mode]
-                                                        && !areSkipIndexColumnsInPrimaryKey(primary_key_column_names, skip_indexes,
-                                                                indexes->key_condition_rpn_template->hasOnlyConjunctions());
+                                                        && !areAllSkipIndexColumnsInPrimaryKey(primary_key_column_names, skip_indexes);
     {
         std::vector<size_t> index_sizes;
         index_sizes.reserve(skip_indexes.useful_indices.size());
@@ -3969,24 +3992,6 @@ bool ReadFromMergeTree::isSkipIndexAvailableForTopK(const String & sort_column) 
     return false;
 }
 
-/// Check if any/all columns with the given skip indexes are also part of the primary key
-bool ReadFromMergeTree::areSkipIndexColumnsInPrimaryKey(const Names & primary_key_columns, const UsefulSkipIndexes & skip_indexes, bool any_one)
-{
-    NameSet primary_key_columns_set(primary_key_columns.begin(), primary_key_columns.end());
-
-    for (const auto & skip_index : skip_indexes.useful_indices)
-    {
-        for (const auto & column : skip_index.index->index.column_names)
-        {
-            if (primary_key_columns_set.contains(column) && any_one)
-                return true;
-            else if (!primary_key_columns_set.contains(column) && !any_one)
-                return false;
-        }
-    }
-
-    return !any_one;
-}
 
 ConditionSelectivityEstimatorPtr ReadFromMergeTree::getConditionSelectivityEstimator(const Names & required_columns) const
 {

--- a/src/Processors/QueryPlan/ReadFromMergeTree.h
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.h
@@ -320,7 +320,6 @@ public:
         bool allow_query_condition_cache_,
         bool supports_skip_indexes_on_data_read);
 
-    static bool areSkipIndexColumnsInPrimaryKey(const Names & primary_key_columns, const UsefulSkipIndexes & skip_indexes, bool any_one);
 
     AnalysisResultPtr selectRangesToRead(bool find_exact_ranges = false) const;
 

--- a/tests/queries/0_stateless/03400_auto_minmax_final_sign_bug.sql
+++ b/tests/queries/0_stateless/03400_auto_minmax_final_sign_bug.sql
@@ -1,0 +1,38 @@
+-- Reproduces a bug where mixed PK and non-PK minmax skip indexes break FINAL queries.
+--
+-- The minmax index on `sign` evaluates the `sign = 1` filter and drops the part
+-- containing the delete marker (sign = -1). The recovery mechanism
+-- (`findPKRangesForFinalAfterSkipIndex`) is disabled because the minmax index on
+-- `key` (a PK column) is also useful, causing `areSkipIndexColumnsInPrimaryKey`
+-- to return true.
+
+DROP TABLE IF EXISTS t_final_minmax;
+
+CREATE TABLE t_final_minmax
+(
+    key Int32,
+    value String,
+    sign Int8,
+    ver UInt64,
+    INDEX idx_key key TYPE minmax,
+    INDEX idx_sign sign TYPE minmax
+)
+ENGINE = ReplacingMergeTree(ver)
+PARTITION BY key
+ORDER BY key;
+
+SYSTEM STOP MERGES t_final_minmax;
+
+-- Part 1: original row
+INSERT INTO t_final_minmax VALUES (2, 'original', 1, 1);
+
+-- Part 2: delete marker (higher version, sign = -1)
+INSERT INTO t_final_minmax VALUES (2, '', -1, 2);
+
+-- FINAL should keep only the row with highest version (ver=2, sign=-1).
+-- Then sign = 1 filter should exclude it, returning empty result.
+-- Bug: idx_sign drops the delete-marker part, and the recovery is disabled
+-- because idx_key (on a PK column) is also useful.
+SELECT value FROM t_final_minmax FINAL WHERE key = 2 AND sign = 1;
+
+DROP TABLE t_final_minmax;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix incorrect result of FINAL queries when mixing primary key and non primary key skip indexes


Strangely enough, references https://github.com/ClickHouse/ClickHouse/pull/76867 (it appeared in an integration test when enabling implicit indices)
References https://github.com/ClickHouse/ClickHouse/pull/93899
I think we should consider backporting it to any release that include the bug, since it means producing invalid results

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.81`
- Backported to: `26.2.2.4`, `26.1.4.35`, `25.12.8.12`
<!-- ch-version-info:end -->