### PR TITLE
Add retry for pulling Let's Encrypt Pebble Docker images in integration tests

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -3837,6 +3837,10 @@ class ClickHouseCluster:
                 self.wait_ytsaurus_to_start()
 
             if self.with_letsencrypt_pebble and self.base_letsencrypt_pebble_cmd:
+                letsencrypt_pebble_pull_cmd = self.base_letsencrypt_pebble_cmd + ["pull"]
+                retry(log_function=logging_pulling_images, retries=3, delay=8, jitter=8)(
+                    run_and_check, letsencrypt_pebble_pull_cmd, nothrow=True, timeout=600
+                )
                 letsencrypt_pebble_start_cmd = self.base_letsencrypt_pebble_cmd + common_opts
                 run_and_check(letsencrypt_pebble_start_cmd)
                 self.wait_letsencrypt_pebble_to_start()


### PR DESCRIPTION
## Summary
- `test_acme_tls` integration test fails when `ghcr.io` is temporarily unreachable, because the `docker compose up -d` command for pebble services doesn't retry image pulls
- Added a separate `docker compose pull` with retry logic (3 retries, 8s delay + jitter) for the pebble compose before starting the services
- Follows the same pattern already used for the main image pull at the beginning of `ClickHouseCluster.start`

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=94d0eaca0806b9424c7a00216a3acc3847855da0&name_0=MasterCI&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%201%2F4%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.97`
<!-- ch-version-info:end -->