### PR TITLE
Miscellaneous changes in Poco::Exception::extendedMessage

### DIFF
--- a/base/poco/Foundation/src/Exception.cpp
+++ b/base/poco/Foundation/src/Exception.cpp
@@ -28,7 +28,7 @@ Exception::Exception(const std::string& msg, int code): _msg(msg), _pNested(0), 
 {
 }
 
-Exception::Exception(std::string&& msg, int code): _msg(msg), _pNested(0), _code(code)
+Exception::Exception(std::string&& msg, int code): _msg(std::move(msg)), _pNested(0), _code(code)
 {
 }
 

--- a/src/Common/Exception.cpp
+++ b/src/Common/Exception.cpp
@@ -136,7 +136,7 @@ Exception::Exception(const MessageMasked & msg_masked, int code, bool remote_)
 }
 
 Exception::Exception(MessageMasked && msg_masked, int code, bool remote_)
-    : Poco::Exception(msg_masked.msg, code)
+    : Poco::Exception(std::move(msg_masked.msg), code)
     , remote(remote_)
 {
     if (terminate_on_any_exception)


### PR DESCRIPTION
## Summary
- Fix missing `std::move` in `Poco::Exception(std::string&&, int)` constructor: `_msg(msg)` → `_msg(std::move(msg))`
- Fix `DB::Exception(MessageMasked&&, int, bool)` to move `msg_masked.msg` into the Poco base class instead of copying

The `Poco::Exception` rvalue reference constructor had `_msg(msg)` instead of `_msg(std::move(msg))`, causing a copy instead of a move (classic C++ gotcha — named rvalue references are lvalues). Similarly, `DB::Exception` passed `msg_masked.msg` as an lvalue to the Poco base, selecting the copy overload.

This caused an MSan false positive when exceptions were transferred across threads (e.g., from the Parquet Prefetcher thread to the ReadManager thread via `std::exception_ptr`). The unnecessary heap copy created a new allocation whose MSan shadow tracking was lost across the thread boundary. With the move, the original `fmt::format` buffer is transferred by pointer without any new allocation.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=97639&sha=3e25ded422dee46b456dc4583ae1575b1116cf6e&name_0=PR&name_1=Stress%20test%20%28amd_msan%29
https://github.com/ClickHouse/ClickHouse/pull/97639

## Test plan
- [x] Build succeeds (verified locally)
- [ ] MSan stress test passes in CI

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.117`
<!-- ch-version-info:end -->