### PR TITLE
Fix segfault in outer-to-inner join optimization with arrayJoin in filter

### DIFF
--- a/src/Interpreters/ActionsDAG.cpp
+++ b/src/Interpreters/ActionsDAG.cpp
@@ -932,6 +932,9 @@ static ColumnWithTypeAndName executeActionForPartialResult(
         case ActionsDAG::ActionType::ARRAY_JOIN:
         {
             auto key = arguments.at(0);
+            if (!key.column)
+                break;
+
             key.column = key.column->convertToFullColumnIfConst();
 
             const auto * array = getArrayJoinColumnRawPtr(key.column);

--- a/tests/queries/0_stateless/04003_array_join_in_filter_outer_to_inner_join.sql
+++ b/tests/queries/0_stateless/04003_array_join_in_filter_outer_to_inner_join.sql
@@ -1,5 +1,7 @@
 -- Regression: segfault in executeActionForPartialResult when filter expression contains arrayJoin
 -- and the convertOuterJoinToInnerJoin optimization tries to evaluate the filter with partial (null) arguments.
+
+SET enable_analyzer = 1;
 SELECT DISTINCT
     2,
     1048575

--- a/tests/queries/0_stateless/04003_array_join_in_filter_outer_to_inner_join.sql
+++ b/tests/queries/0_stateless/04003_array_join_in_filter_outer_to_inner_join.sql
@@ -1,0 +1,17 @@
+-- Regression: segfault in executeActionForPartialResult when filter expression contains arrayJoin
+-- and the convertOuterJoinToInnerJoin optimization tries to evaluate the filter with partial (null) arguments.
+SELECT DISTINCT
+    2,
+    1048575
+FROM numbers(1) AS l,
+    numbers(2, isZeroOrNull(assumeNotNull(1))) AS r
+ANY INNER JOIN r AS alias37 ON equals(alias37.number, r.number)
+RIGHT JOIN l AS alias44 ON equals(alias44.number, alias37.number)
+ANY INNER JOIN alias44 AS alias48 ON equals(alias48.number, r.number)
+ANY RIGHT JOIN r AS alias52 ON equals(alias52.number, alias37.number)
+WHERE equals(isNull(toLowCardinality(toUInt128(2))), arrayJoin([*, 13, 13, 13, toNullable(13), 13]))
+GROUP BY
+    materialize(1),
+    isNull(toUInt128(2)),
+    and(and(1048575, isZeroOrNull(1), isNullable(isNull(1))), materialize(13), isNull(toUInt256(materialize(2))), *, and(*, and(1, nan, isNull(isNull(1)), isZeroOrNull(1), 1048575), 13))
+WITH CUBE;


### PR DESCRIPTION
<!-- Fixes issue link part, do not remove -->
## Linked issues
- fixes https://github.com/ClickHouse/clickhouse-core-incidents/issues/1430
<!-- End of fixes issue link part, do not remove -->

## Summary

- Fix NULL pointer dereference in `executeActionForPartialResult` when the `ARRAY_JOIN` case receives a null column argument
- The `convertOuterJoinToInnerJoin` optimization evaluates filter expressions with `allow_unknown_function_arguments=true`, which can pass null columns. The `FUNCTION` case handles this, but `ARRAY_JOIN` did not.
- Introduced in #89403

## Test plan

- [x] Added stateless test `04003_array_join_in_filter_outer_to_inner_join` that reproduces the segfault
- [x] Verified the fix locally with the reproducer query from the AST fuzzer

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=98038&sha=e8654c51ebda0a11837caf07fc6884a26530250d&name_0=PR&name_1=AST%20fuzzer%20%28arm_asan%29
https://github.com/ClickHouse/ClickHouse/pull/98038

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix segfault in query plan optimization when converting outer join to inner join with `arrayJoin` in filter expression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.103`
- Backported to: `26.2.1.1134`, `26.1.4.33`, `25.12.8.14`, `25.8.17.36`, `25.3.15.13`
<!-- ch-version-info:end -->