### PR TITLE
Make CI log export failure non-fatal in ClickBench job

### DIFF
--- a/ci/jobs/clickbench.py
+++ b/ci/jobs/clickbench.py
@@ -32,9 +32,10 @@ def main():
 
         def start():
             res = ch.start_light()
-            if info.is_local_run:
-                return res
-            return res and ch.start_log_exports(check_start_time=stop_watch.start_time)
+            if not info.is_local_run:
+                if not ch.start_log_exports(check_start_time=stop_watch.start_time):
+                    print("WARNING: Failed to start log export")
+            return res
 
         results.append(
             Result.from_commands_run(


### PR DESCRIPTION
## Summary
- ClickBench CI job fails when the CI logs cluster is overloaded (`TOO_MANY_SIMULTANEOUS_QUERIES`), even though ClickHouse server starts fine
- Log export failure now produces a warning instead of aborting the entire benchmark
- Aligns with `functional_tests.py` and `fuzzers_job.py`, which already treat log export failure as non-fatal

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=10d13a79d8749007581008e8fb26957445a64c38&name_0=MasterCI&name_1=ClickBench%20%28arm_release%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.91`
<!-- ch-version-info:end -->