### PR TITLE
Fix build: use of undeclared identifier `printHelpOnError`

### DIFF
--- a/programs/main.cpp
+++ b/programs/main.cpp
@@ -380,13 +380,13 @@ int main(int argc_, char ** argv_)
     /// If the argument looks like a file path but doesn't exist, provide a helpful error
     /// instead of the generic "Use one of the following commands" message.
     /// The check above routes existing files to clickhouse-local, but when the file
-    /// doesn't exist, we fall through to `printHelpOnError` which is confusing:
+    /// doesn't exist, we fall through to `printHelp` which is confusing:
     ///     $ clickhouse tests/queries/0_stateless/my_test.sql
     ///     Use one of the following commands: ...
     /// We detect file-like arguments by the presence of `/` (path separator)
     /// or `.` (file extension), which distinguishes them from mistyped subcommand
     /// names like "clickhouse sever" where the generic help is appropriate.
-    if (main_func == printHelpOnError && argv.size() >= 2)
+    if (main_func == printHelp && argv.size() >= 2)
     {
         std::string_view arg(argv[1]);
         if (arg.contains('/') || arg.contains('.'))


### PR DESCRIPTION
## Summary
- Commit 66aeef7f59a introduced a reference to `printHelpOnError` in `programs/main.cpp` which doesn't exist — the function is called `printHelp`
- This caused a build failure: `error: use of undeclared identifier 'printHelpOnError'`
- Fixed by replacing `printHelpOnError` with `printHelp`

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.90`
<!-- ch-version-info:end -->