### PR TITLE
Cancel background merges early in DROP DATABASE for ordinary shared merge tree

### DIFF
--- a/src/Storages/MergeTree/MergeTreeBackgroundExecutor.h
+++ b/src/Storages/MergeTree/MergeTreeBackgroundExecutor.h
@@ -86,9 +86,10 @@ struct TaskRuntimeData
     TaskProfileEvents events;
     /// Guarded by MergeTreeBackgroundExecutor<>::mutex
     bool is_currently_deleting{false};
-    /// Actually autoreset=false is needed only for unit test
-    /// where multiple threads could remove tasks corresponding to the same storage
-    /// This scenario in not possible in reality.
+    /// autoreset=false allows multiple threads to wait concurrently on the same task.
+    /// This happens when two concurrent DROP DATABASE queries both call
+    /// flushAndPrepareForShutdown() -> BackgroundJobsAssignee::finish() ->
+    /// removeTasksCorrespondingToStorage() for the same storage.
     Poco::Event is_done{/*autoreset=*/false};
     /// This is equal to task->getPriority() not to do useless virtual calls in comparator
     Priority priority;

--- a/src/Storages/MergeTree/MergeTreeBackgroundExecutor.h
+++ b/src/Storages/MergeTree/MergeTreeBackgroundExecutor.h
@@ -86,10 +86,9 @@ struct TaskRuntimeData
     TaskProfileEvents events;
     /// Guarded by MergeTreeBackgroundExecutor<>::mutex
     bool is_currently_deleting{false};
-    /// autoreset=false allows multiple threads to wait concurrently on the same task.
-    /// This happens when two concurrent DROP DATABASE queries both call
-    /// flushAndPrepareForShutdown() -> BackgroundJobsAssignee::finish() ->
-    /// removeTasksCorrespondingToStorage() for the same storage.
+    /// Actually autoreset=false is needed only for unit test
+    /// where multiple threads could remove tasks corresponding to the same storage
+    /// This scenario in not possible in reality.
     Poco::Event is_done{/*autoreset=*/false};
     /// This is equal to task->getPriority() not to do useless virtual calls in comparator
     Priority priority;

--- a/src/Storages/StorageMergeTree.h
+++ b/src/Storages/StorageMergeTree.h
@@ -51,6 +51,7 @@ public:
         std::unique_ptr<MergeTreeSettings> settings_);
 
     void startup() override;
+    void flushAndPrepareForShutdown() override;
     void shutdown(bool is_drop) override;
 
     ~StorageMergeTree() override;


### PR DESCRIPTION
In InterpreterDropQuery::executeToDatabaseImpl(), currently flushAndPrepareForShutdown() is not override, so we depends StorageMergeTree::shutdown() to cancel background merges in executeToTableImpl() in sequence

So we override StorageMergeTree::flushAndPrepareForShutdown() to cancel background merges early in prepare stage in parallel.

```
            /// List the tables, then call flushAndPrepareForShutdown() on them in parallel, then call
            /// executeToTableImpl on them in sequence.

```

Note: we already override StorageReplicatedMergeTree::flushAndPrepareForShutdown() for replicated merge tree.

### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Cancel background merges early in DROP DATABASE for ordinary shared merge tree.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.120`
<!-- ch-version-info:end -->