### PR TITLE
Add jemalloc link to server index page and update allocation profiling docs

### DIFF
--- a/docs/en/operations/allocation-profiling.md
+++ b/docs/en/operations/allocation-profiling.md
@@ -192,7 +192,7 @@ You can also fetch global and per-query heap profiles directly from the UI.
 
 To access it, open in your browser:
 
-```
+```text
 http://localhost:8123/jemalloc
 ```
 

--- a/docs/en/operations/allocation-profiling.md
+++ b/docs/en/operations/allocation-profiling.md
@@ -11,9 +11,14 @@ import TabItem from '@theme/TabItem';
 
 # Allocation profiling
 
-ClickHouse uses [jemalloc](https://github.com/jemalloc/jemalloc) as its global allocator. Jemalloc comes with some tools for allocation sampling and profiling.  
-To make allocation profiling more convenient, ClickHouse and Keeper allow you to control sampling using configs, query settings,`SYSTEM` commands and four letter word (4LW) commands in Keeper.   
-Additionally, samples can be collected into `system.trace_log` table under `JemallocSample` type.
+ClickHouse uses [jemalloc](https://github.com/jemalloc/jemalloc) as its global allocator. Jemalloc comes with tools for allocation sampling and profiling.
+
+ClickHouse and Keeper allow you to control sampling using configs, query settings, `SYSTEM` commands and four letter word (4LW) commands in Keeper. There are several ways to inspect the results:
+
+- Collect samples into `system.trace_log` under the `JemallocSample` type for per-query analysis.
+- View live memory statistics and fetch heap profiles through the built-in [jemalloc web UI](#jemalloc-web-ui) (26.2+).
+- Query the current heap profile directly from SQL using [`system.jemalloc_profile_text`](#fetching-heap-profiles-from-sql) (26.2+).
+- Flush heap profiles to disk and analyze them with [`jeprof`](#analyzing-heap-profile-files-with-jeprof).
 
 :::note
 
@@ -24,7 +29,7 @@ For older versions, please check [allocation profiling for versions before 25.9]
 
 ## Sampling allocations {#sampling-allocations}
 
-If you want to sample and profile allocations in `jemalloc`, you need to start ClickHouse/Keeper with config `jemalloc_enable_global_profiler` enabled.
+To sample and profile allocations, start ClickHouse/Keeper with the `jemalloc_enable_global_profiler` config enabled:
 
 ```xml
 <clickhouse>
@@ -34,7 +39,7 @@ If you want to sample and profile allocations in `jemalloc`, you need to start C
 
 `jemalloc` will sample allocations and store the information internally.
 
-You can also enable allocations per query by using `jemalloc_enable_profiler` setting.
+You can also enable sampling per query using the `jemalloc_enable_profiler` setting.
 
 :::warning Warning
 Because ClickHouse is an allocation-heavy application, jemalloc sampling may incur performance overhead.
@@ -42,8 +47,8 @@ Because ClickHouse is an allocation-heavy application, jemalloc sampling may inc
 
 ## Storing jemalloc samples in `system.trace_log` {#storing-jemalloc-samples-in-system-trace-log}
 
-You can store all the jemalloc samples in `system.trace_log` under `JemallocSample` type.
-To enable it globally you can use config `jemalloc_collect_global_profile_samples_in_trace_log`.
+You can store jemalloc samples in `system.trace_log` under the `JemallocSample` type.
+To enable it globally, use the `jemalloc_collect_global_profile_samples_in_trace_log` config:
 
 ```xml
 <clickhouse>
@@ -55,11 +60,11 @@ To enable it globally you can use config `jemalloc_collect_global_profile_sample
 Because ClickHouse is an allocation-heavy application, collecting all samples in system.trace_log may incur high load.
 :::
 
-You can also enable it per query by using `jemalloc_collect_profile_samples_in_trace_log` setting.
+You can also enable it per query using the `jemalloc_collect_profile_samples_in_trace_log` setting.
 
-### Example of analyzing memory usage of a query using `system.trace_log` {#example-analyzing-memory-usage-trace-log}
+### Example: analyzing memory usage of a query {#example-analyzing-memory-usage-trace-log}
 
-First, we need to run the query with enabled jemalloc profiler and collect the samples for it into `system.trace_log`:
+First, run a query with the jemalloc profiler enabled and collect the samples into `system.trace_log`:
 
 ```sql
 SELECT *
@@ -78,16 +83,18 @@ Peak memory usage: 12.65 MiB.
 ```
 
 :::note
-If ClickHouse was started with `jemalloc_enable_global_profiler`, you don't have to enable `jemalloc_enable_profiler`.   
+If ClickHouse was started with `jemalloc_enable_global_profiler`, you don't have to enable `jemalloc_enable_profiler`.
 Same is true for `jemalloc_collect_global_profile_samples_in_trace_log` and `jemalloc_collect_profile_samples_in_trace_log`.
 :::
 
-We will flush the `system.trace_log`:
+Flush the `system.trace_log`:
 
 ```sql
 SYSTEM FLUSH LOGS trace_log
 ```
-and query it to get memory usage of the query we run for each time point:
+
+Then query it to get cumulative memory usage over time:
+
 ```sql
 WITH per_bucket AS
 (
@@ -110,7 +117,7 @@ FROM per_bucket
 ORDER BY bucket_time
 ```
 
-We can also find the time where the memory usage was the highest:
+Find the time where memory usage was the highest:
 
 ```sql
 SELECT
@@ -140,7 +147,7 @@ FROM
 )
 ```
 
-We can use that result to see from where did we have the most active allocations at that time point:
+Using that result, see which allocation stacks were most active at the peak:
 
 ```sql
 SELECT
@@ -173,16 +180,95 @@ GROUP BY ALL
 ORDER BY per_trace_sum ASC
 ```
 
-## Flushing heap profiles {#flushing-heap-profiles}
+## Jemalloc web UI {#jemalloc-web-ui}
 
-By default, the heap profile file will be generated in `/tmp/jemalloc_clickhouse._pid_._seqnum_.heap` where `_pid_` is the PID of ClickHouse and `_seqnum_` is the global sequence number for the current heap profile.  
+:::note
+This section is applicable for versions 26.2+.
+:::
+
+ClickHouse provides a built-in web UI for viewing jemalloc memory statistics at the `/jemalloc` HTTP endpoint.
+It displays live memory metrics with charts, including allocated, active, resident, and mapped memory, as well as per-arena and per-bin statistics.
+You can also fetch global and per-query heap profiles directly from the UI.
+
+To access it, open in your browser:
+
+```
+http://localhost:8123/jemalloc
+```
+
+## Fetching heap profiles from SQL {#fetching-heap-profiles-from-sql}
+
+:::note
+This section is applicable for versions 26.2+.
+:::
+
+The `system.jemalloc_profile_text` system table lets you fetch and view the current jemalloc heap profile directly from SQL, without needing external tools or flushing to disk first.
+
+The table has a single column:
+
+| Column | Type   | Description                                      |
+|--------|--------|--------------------------------------------------|
+| `line` | String | Line from the symbolized jemalloc heap profile.  |
+
+You can query the table directly — there is no need to flush a heap profile beforehand:
+
+```sql
+SELECT * FROM system.jemalloc_profile_text
+```
+
+### Output format {#output-format}
+
+The output format is controlled by the `jemalloc_profile_text_output_format` setting, which supports three values:
+
+- `raw` — raw heap profile as produced by jemalloc.
+- `symbolized` — jeprof-compatible format with embedded function symbols. Since symbols are already embedded, `jeprof` can analyze the output without requiring the ClickHouse binary.
+- `collapsed` (default) — FlameGraph-compatible collapsed stacks, one stack per line with the byte count.
+
+For example, to get the raw profile:
+
+```sql
+SELECT * FROM system.jemalloc_profile_text
+SETTINGS jemalloc_profile_text_output_format = 'raw'
+```
+
+To get symbolized output:
+
+```sql
+SELECT * FROM system.jemalloc_profile_text
+SETTINGS jemalloc_profile_text_output_format = 'symbolized'
+```
+
+### Additional settings {#fetching-heap-profiles-settings}
+
+- `jemalloc_profile_text_symbolize_with_inline` (Bool, default: `true`) — Whether to include inline frames when symbolizing. Disabling this speeds up symbolization significantly but loses precision as inlined function calls will not appear in the stacks. Only affects `symbolized` and `collapsed` formats.
+- `jemalloc_profile_text_collapsed_use_count` (Bool, default: `false`) — When using the `collapsed` format, aggregate by allocation count instead of bytes.
+
+### Example: generating a flame graph from SQL {#example-flamegraph-from-sql}
+
+Since the default output format is `collapsed`, you can pipe the output directly to FlameGraph:
+
+```sh
+clickhouse-client -q "SELECT * FROM system.jemalloc_profile_text" | flamegraph.pl --color=mem --title="Allocation Flame Graph" --width 2400 > result.svg
+```
+
+To generate a flame graph by allocation count instead of bytes:
+
+```sh
+clickhouse-client -q "SELECT * FROM system.jemalloc_profile_text SETTINGS jemalloc_profile_text_collapsed_use_count = 1" | flamegraph.pl --color=mem --title="Allocation Count Flame Graph" --width 2400 > result.svg
+```
+
+## Flushing heap profiles to disk {#flushing-heap-profiles}
+
+If you need to save heap profiles as files for offline analysis with `jeprof`, you can flush them to disk.
+
+By default, the heap profile file will be generated in `/tmp/jemalloc_clickhouse._pid_._seqnum_.heap` where `_pid_` is the PID of ClickHouse and `_seqnum_` is the global sequence number for the current heap profile.
 For Keeper, the default file is `/tmp/jemalloc_keeper._pid_._seqnum_.heap`, and follows the same rules.
 
-You can tell `jemalloc` to flush the current profile by running:
+To flush the current profile:
 
 <Tabs groupId="binary">
 <TabItem value="clickhouse" label="ClickHouse">
-    
+
 ```sql
 SYSTEM JEMALLOC FLUSH PROFILE
 ```
@@ -191,7 +277,7 @@ It will return the location of the flushed profile.
 
 </TabItem>
 <TabItem value="keeper" label="Keeper">
-    
+
 ```sh
 echo jmfp | nc localhost 9181
 ```
@@ -199,7 +285,7 @@ echo jmfp | nc localhost 9181
 </TabItem>
 </Tabs>
 
-A different location can be defined by appending the `MALLOC_CONF` environment variable with the `prof_prefix` option.  
+A different location can be defined by appending the `MALLOC_CONF` environment variable with the `prof_prefix` option.
 For example, if you want to generate profiles in the `/data` folder where the filename prefix will be `my_current_profile`, you can run ClickHouse/Keeper with the following environment variable:
 
 ```sh
@@ -208,15 +294,13 @@ MALLOC_CONF=prof_prefix:/data/my_current_profile
 
 The generated file will be appended to the prefix PID and sequence number.
 
-## Analyzing heap profiles {#analyzing-heap-profiles}
+## Analyzing heap profile files with `jeprof` {#analyzing-heap-profile-files-with-jeprof}
 
-After heap profiles have been generated, they need to be analyzed.
-For that, `jemalloc`'s tool called [jeprof](https://github.com/jemalloc/jemalloc/blob/dev/bin/jeprof.in) can be used. It can be installed in multiple ways:
+After flushing heap profiles to disk, they can be analyzed using `jemalloc`'s tool called [jeprof](https://github.com/jemalloc/jemalloc/blob/dev/bin/jeprof.in). It can be installed in multiple ways:
 - Using the system's package manager
 - Cloning the [jemalloc repo](https://github.com/jemalloc/jemalloc) and running `autogen.sh` from the root folder. This will provide you with the `jeprof` script inside the `bin` folder
 
-There are many different formats to generate from the heap profile using `jeprof`.
-You can run `jeprof --help` for information on the usage and the various options the tool provides.
+There are many different output formats available. Run `jeprof --help` for the full list of options.
 
 ### Symbolized heap profiles {#symbolized-heap-profiles}
 
@@ -332,8 +416,8 @@ Another interesting tool is [speedscope](https://www.speedscope.app/) that allow
 ## Additional options for the profiler {#additional-options-for-profiler}
 
 `jemalloc` has many different options available, which are related to the profiler. They can be controlled by modifying the `MALLOC_CONF` environment variable.
-For example, the interval between allocation samples can be controlled with `lg_prof_sample`.  
-If you want to dump the heap profile every N bytes you can enable it using `lg_prof_interval`.  
+For example, the interval between allocation samples can be controlled with `lg_prof_sample`.
+If you want to dump the heap profile every N bytes you can enable it using `lg_prof_interval`.
 
 It is recommended to check `jemalloc`s [reference page](https://jemalloc.net/jemalloc.3.html) for a complete list of options.
 
@@ -361,6 +445,14 @@ FORMAT Vertical
 Contains information about memory allocations done via the jemalloc allocator in different size classes (bins) aggregated from all arenas.
 
 [Reference](/operations/system-tables/jemalloc_bins)
+
+### System table `jemalloc_stats` (26.2+) {#system-table-jemalloc_stats}
+
+Returns the full output of `malloc_stats_print()` as a single string. Equivalent to the `SYSTEM JEMALLOC STATS` command.
+
+```sql
+SELECT * FROM system.jemalloc_stats
+```
 
 ### Prometheus {#prometheus}
 

--- a/programs/server/index.html
+++ b/programs/server/index.html
@@ -143,6 +143,7 @@
         <br/>
         <a href="/binary">Binary visualizer</a>
         <a href="/merges">Merges visualizer</a>
+        <a href="/jemalloc">Jemalloc</a>
     </p>
 
     <!-- https://github.com/logos -->


### PR DESCRIPTION
  ### Changelog category (leave one):
  - Documentation (changelog entry is not required)

  ### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
  Add a link to the `/jemalloc` web UI on the server index page. Update allocation profiling documentation with new sections for the jemalloc web UI,
  `system.jemalloc_profile_text`, and `system.jemalloc_stats` (26.2+).

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.108`
- Backported to: `26.2.1.1133`
<!-- ch-version-info:end -->