### PR TITLE
Improve canceling queries with MongoDB and MySQL

### DIFF
--- a/src/Processors/Sources/MongoDBSource.cpp
+++ b/src/Processors/Sources/MongoDBSource.cpp
@@ -16,6 +16,7 @@
 #include <Common/assert_cast.h>
 #include <Common/Exception.h>
 #include <Common/BSONCXXHelper.h>
+#include <Common/logger_useful.h>
 #include <base/range.h>
 
 namespace DB
@@ -202,6 +203,8 @@ MongoDBSource::~MongoDBSource() = default;
 
 Chunk MongoDBSource::generate()
 {
+    LOG_TEST(getLogger("MongoDBSource"), "Generate a chuck");
+
     if (all_read)
         return {};
 
@@ -211,6 +214,9 @@ Chunk MongoDBSource::generate()
     size_t num_rows = 0;
     for (const auto & doc : cursor)
     {
+        if (isCancelled())
+            break;
+
         for (auto idx : collections::range(0, size))
         {
             auto & sample_column = sample_block.getByPosition(idx);

--- a/src/Processors/Sources/MySQLSource.cpp
+++ b/src/Processors/Sources/MySQLSource.cpp
@@ -415,7 +415,7 @@ Chunk MySQLSource::generate()
     size_t num_rows = 0;
     size_t read_bytes_size = 0;
 
-    while (row)
+    while (row && !isCancelled())
     {
         for (size_t index = 0; index < position_mapping.size(); ++index)
         {

--- a/src/Processors/Sources/PostgreSQLSource.cpp
+++ b/src/Processors/Sources/PostgreSQLSource.cpp
@@ -138,7 +138,7 @@ Chunk PostgreSQLSource<T>::generate()
     MutableColumns columns = description.sample_block.cloneEmptyColumns();
     size_t num_rows = 0;
 
-    while (!isCancelled()  && !is_completed.load())
+    while (!isCancelled() && !is_completed.load())
     {
         const std::vector<pqxx::zview> * row{stream->read_row()};
 

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -4926,6 +4926,13 @@ class ClickHouseInstance:
 
         raise Exception("Cannot start ClickHouse, see additional info in logs")
 
+    def stop_clickhouse_client(self, signal="INT"):
+        client_pid = self.get_process_pid("clickhouse client")
+        self.exec_in_container(
+            ["bash", "-c", f"kill -{signal} {client_pid}"],
+            user="root",
+        )
+
     def wait_start(self, start_wait_sec):
         start_time = time.time()
         last_err = None

--- a/tests/integration/test_mongodb_kill_query/test.py
+++ b/tests/integration/test_mongodb_kill_query/test.py
@@ -1,0 +1,136 @@
+import pytest
+import uuid
+import threading
+import time
+import pymongo
+import urllib.parse
+from helpers.config_cluster import mongo_pass
+from helpers.cluster import ClickHouseCluster
+
+
+escaped_mongo_pass = urllib.parse.quote_plus(mongo_pass)
+
+SELECT_FROM_MONGODB = f"""SELECT
+    sleepEachRow(0.0001),
+    user_id,
+    first_name,
+    last_name,
+    age
+FROM mongodb(
+    'mongo1:27017',
+    'testdb',
+    'users',
+    'root',
+    '{mongo_pass}',
+    'user_id Int64, first_name String, last_name String, age Int64'
+)
+SETTINGS max_block_size = 1000"""
+
+cluster = ClickHouseCluster(__file__)
+node1 = cluster.add_instance(
+    "node1",
+    with_mongo=True,
+)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        mongo_conn = pymongo.MongoClient(
+            f"mongodb://root:{escaped_mongo_pass}@localhost:{cluster.mongo_port}/?authSource=admin"
+        )
+        mongo_conn.admin.command("ping")
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+@pytest.fixture(scope="module")
+def setup_mongodb_users(started_cluster):
+    mongo_conn = pymongo.MongoClient(
+        f"mongodb://root:{escaped_mongo_pass}@localhost:{cluster.mongo_port}/?authSource=admin"
+    )
+    db = mongo_conn["testdb"]
+
+    db.command("dropAllUsersFromDatabase")
+    db.command("createUser", "root", pwd=mongo_pass, roles=["readWrite"])
+
+    if "users" in db.list_collection_names():
+        db["users"].drop()
+
+    users_collection = db["users"]
+
+    batch_size = 1000
+    num_batches = 1000
+    users = []
+    for i in range(1, num_batches * batch_size + 1):
+        users.append(
+            {
+                "user_id": i,
+                "first_name": f"User{i}_first",
+                "last_name": f"User{i}_last",
+                "age": (i % 80) + 18,
+            }
+        )
+
+        if len(users) >= batch_size:
+            users_collection.insert_many(users, ordered=False)
+            users = []
+
+    if users:
+        users_collection.insert_many(users, ordered=False)
+
+    yield cluster
+
+
+def test_kill_query(setup_mongodb_users):
+    query_id = str(uuid.uuid4())
+
+    def execute_query():
+        _, error = node1.query_and_get_answer_with_error(
+            SELECT_FROM_MONGODB,
+            query_id=query_id,
+        )
+        assert "DB::Exception: Query was cancelled" in error
+
+    query_thread = threading.Thread(target=execute_query)
+    query_thread.start()
+
+    node1.wait_for_log_line("Generate a chuck")
+    time.sleep(1)
+
+    node1.query(f"KILL QUERY WHERE query_id='{query_id}' SYNC")
+
+    query_thread.join()
+
+    result = node1.query(
+        "SELECT count(*) FROM system.processes WHERE query_id='{query_id}'"
+    )
+    assert int(result.strip()) == 0
+
+    assert node1.contains_in_log("QUERY_WAS_CANCELLED")
+
+
+def test_cancel_query(setup_mongodb_users):
+    def execute_query():
+        node1.exec_in_container(
+            [
+                "bash",
+                "-c",
+                f"""/usr/bin/clickhouse client --query "{SELECT_FROM_MONGODB}" --format Null""",
+            ]
+        )
+
+    query_thread = threading.Thread(target=execute_query)
+    query_thread.start()
+
+    node1.wait_for_log_line("Generate a chuck")
+    time.sleep(1)
+
+    node1.stop_clickhouse_client()
+    node1.wait_for_log_line("DB::Exception: Received 'Cancel' packet from the client")
+    time.sleep(1)
+
+    query_thread.join()
+    assert node1.contains_in_log("QUERY_WAS_CANCELLED_BY_CLIENT")

--- a/tests/integration/test_mysql_kill_query/test.py
+++ b/tests/integration/test_mysql_kill_query/test.py
@@ -104,15 +104,6 @@ END"""
     yield mysql_conn, cluster
 
 
-# Stop clickhouse-client by SIGINT signal that is the same as pressing Ctrl+C
-def stop_clickhouse_client():
-    client_pid = node1.get_process_pid("clickhouse client")
-    node1.exec_in_container(
-        ["bash", "-c", f"kill -INT {client_pid}"],
-        user="root",
-    )
-
-
 def test_kill_infinite_query(setup_infinite_query):
     mysql_conn, cluster = setup_infinite_query
     query_id = str(uuid.uuid4())
@@ -224,7 +215,7 @@ def test_cancel_infinite_query(setup_infinite_query):
     node1.wait_for_log_line("Get data from database")
     time.sleep(2)
 
-    stop_clickhouse_client()
+    node1.stop_clickhouse_client()
     node1.wait_for_log_line("DB::Exception: Received 'Cancel' packet from the client")
     time.sleep(1)
 
@@ -260,7 +251,7 @@ SETTINGS max_block_size = 10000"""
     node1.wait_for_log_line("Generate a chuck")
     time.sleep(2)
 
-    stop_clickhouse_client()
+    node1.stop_clickhouse_client()
     node1.wait_for_log_line("DB::Exception: Received 'Cancel' packet from the client")
     time.sleep(1)
 

--- a/tests/integration/test_postgresql_kill_query/test.py
+++ b/tests/integration/test_postgresql_kill_query/test.py
@@ -65,15 +65,6 @@ SELECT generate_infinite_sequence() as counter;"""
     conn.close()
 
 
-# Stop clickhouse-client by SIGINT signal that is the same as pressing Ctrl+C
-def stop_clickhouse_client():
-    client_pid = node1.get_process_pid("clickhouse client")
-    node1.exec_in_container(
-        ["bash", "-c", f"kill -INT {client_pid}"],
-        user="root",
-    )
-
-
 @pytest.fixture(scope="module")
 def setup_big_data_table(started_cluster):
     # Connect to postgres_database database
@@ -221,7 +212,7 @@ def test_cancel_infinite_query(setup_infinite_query):
     )
     time.sleep(2)
 
-    stop_clickhouse_client()
+    node1.stop_clickhouse_client()
     node1.wait_for_log_line("DB::Exception: Received 'Cancel' packet from the client")
     time.sleep(1)
 
@@ -255,7 +246,7 @@ SETTINGS max_block_size = 10000"""
     node1.wait_for_log_line("Generate a chuck from stream")
     time.sleep(2)
 
-    stop_clickhouse_client()
+    node1.stop_clickhouse_client()
     node1.wait_for_log_line("DB::Exception: Received 'Cancel' packet from the client")
     time.sleep(1)
 

--- a/tests/integration/test_sqlite_kill_query/test.py
+++ b/tests/integration/test_sqlite_kill_query/test.py
@@ -81,15 +81,6 @@ ENGINE = SQLite('{SQLITE_DB_FILE_NAME}', 'big_data_table');
         cluster.shutdown()
 
 
-# Stop clickhouse-client by SIGINT signal that is the same as pressing Ctrl+C
-def stop_clickhouse_client():
-    client_pid = node1.get_process_pid("clickhouse client")
-    node1.exec_in_container(
-        ["bash", "-c", f"kill -INT {client_pid}"],
-        user="root",
-    )
-
-
 def test_kill_query(started_cluster):
     query_id = str(uuid.uuid4())
 
@@ -134,7 +125,7 @@ def test_cancel_query(started_cluster):
     node1.wait_for_log_line("Generate a chuck")
     time.sleep(1)
 
-    stop_clickhouse_client()
+    node1.stop_clickhouse_client()
     node1.wait_for_log_line("DB::Exception: Received 'Cancel' packet from the client")
     time.sleep(1)
 


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Improve canceling queries with MongoDB and MySQL by KILL QUERY and cancel query (Ctrl+C) in clickhouse-client.

Related: #97337


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.121`
<!-- ch-version-info:end -->