### PR TITLE
Mark `MergeTreeSource` with coordination components

### DIFF
--- a/src/Storages/MergeTree/MergeTreeSource.cpp
+++ b/src/Storages/MergeTree/MergeTreeSource.cpp
@@ -1,6 +1,7 @@
 #include <Storages/MergeTree/MergeTreeSource.h>
 #include <Storages/MergeTree/MergeTreeSelectProcessor.h>
 #include <Common/OpenTelemetryTraceContext.h>
+#include <Common/ZooKeeper/ZooKeeperCommon.h>
 #include <Common/threadPoolCallbackRunner.h>
 #include <IO/SharedThreadPools.h>
 #include <Common/EventFD.h>
@@ -211,6 +212,7 @@ std::optional<Chunk> MergeTreeSource::tryGenerate()
 
             try
             {
+                Coordination::ComponentGuard component_guard = Coordination::setCurrentComponent("MergeTreeSource::tryGenerate");
                 OpenTelemetry::SpanHolder span{fmt::format("MergeTreeSource({})::tryGenerate", log_name)};
                 holder->setResult(processor->read());
             }
@@ -226,6 +228,7 @@ std::optional<Chunk> MergeTreeSource::tryGenerate()
     }
 #endif
 
+    Coordination::ComponentGuard component_guard = Coordination::setCurrentComponent("MergeTreeSource::tryGenerate");
     OpenTelemetry::SpanHolder span{fmt::format("MergeTreeSource({})::tryGenerate", log_name)};
     return processReadResult(processor->read());
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixes 

```
2026.02.26 19:43:18.397712 [ 821562 ] {595ad7fd-3386-4013-ab8a-64991aacfa71} <Fatal> : Logical error: 'Current component is empty, please set it for your scope using Coordination::setCurrentComponent'.

2026.02.26 19:43:18.432700 [ 1603 ] {} <Fatal> BaseDaemon: 5. ./ci/tmp/build/./src/Common/Exception.cpp:60:5: DB::abortOnFailedAssertion(String const&, std::basic_string_view<char, std::char_traits<char>>, void* const*, unsigned long, unsigned long) @ 0x000000001705ae3f
2026.02.26 19:43:18.441708 [ 1603 ] {} <Fatal> BaseDaemon: 6.0. inlined from ./ci/tmp/build/./src/Common/Exception.cpp:93: DB::handle_error_code(String const&, std::basic_string_view<char, std::char_traits<char>>, int, bool, std::vector<void*, std::allocator<void*>> const&)
2026.02.26 19:43:18.441771 [ 1603 ] {} <Fatal> BaseDaemon: 6. ./ci/tmp/build/./src/Common/Exception.cpp:146:13: DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x000000001705bd7b
2026.02.26 19:43:18.444065 [ 1603 ] {} <Fatal> BaseDaemon: 7. ./src/Common/Exception.h:171:100: DB::Exception::Exception(String&&, int, String, bool) @ 0x000000000f11660e
2026.02.26 19:43:18.445763 [ 1603 ] {} <Fatal> BaseDaemon: 8. ./src/Common/Exception.h:57:54: DB::Exception::Exception(PreformattedMessage&&, int) @ 0x000000000f115f49
2026.02.26 19:43:18.454492 [ 1603 ] {} <Fatal> BaseDaemon: 9. ./src/Common/Exception.h:189:77: DB::Exception::Exception<>(int, FormatStringHelperImpl<>) @ 0x0000000017059fb6
2026.02.26 19:43:18.487541 [ 1603 ] {} <Fatal> BaseDaemon: 10. ./ci/tmp/build/./src/Common/ZooKeeper/ZooKeeperImpl.cpp:1403:27: Coordination::ZooKeeper::pushRequest(Coordination::ZooKeeper::RequestInfo&&) @ 0x000000001efb5196
2026.02.26 19:43:18.510065 [ 1603 ] {} <Fatal> BaseDaemon: 11. ./ci/tmp/build/./src/Common/ZooKeeper/ZooKeeperImpl.cpp:1866:5: Coordination::ZooKeeper::multi(std::span<std::shared_ptr<Coordination::Request> const, 18446744073709551615ul>, std::function<void (Coordination::MultiResponse const&)>) @ 0x000000001efbdd22
2026.02.26 19:43:18.538461 [ 1603 ] {} <Fatal> BaseDaemon: 12. ./ci/tmp/build/./src/Common/ZooKeeper/ZooKeeper.cpp:1715:11: zkutil::ZooKeeper::asyncTryMultiNoThrow(std::span<std::shared_ptr<Coordination::Request> const, 18446744073709551615ul>) @ 0x000000001eff9d71
2026.02.26 19:43:18.571347 [ 1603 ] {} <Fatal> BaseDaemon: 13.0. inlined from ./ci/tmp/build/./src/Common/ZooKeeper/ZooKeeper.cpp:1702: zkutil::ZooKeeper::asyncTryMultiNoThrow(std::vector<std::shared_ptr<Coordination::Request>, std::allocator<std::shared_ptr<Coordination::Request>>> const&)
2026.02.26 19:43:18.571388 [ 1603 ] {} <Fatal> BaseDaemon: 13. ./ci/tmp/build/./src/Common/ZooKeeper/ZooKeeper.cpp:887:12: zkutil::ZooKeeper::multiImpl(std::vector<std::shared_ptr<Coordination::Request>, std::allocator<std::shared_ptr<Coordination::Request>>> const&, std::vector<std::shared_ptr<Coordination::Response>, std::allocator<std::shared_ptr<Coordination::Response>>>&, bool) @ 0x000000001efe54bd
2026.02.26 19:43:18.604032 [ 1603 ] {} <Fatal> BaseDaemon: 14. ./ci/tmp/build/./src/Common/ZooKeeper/ZooKeeper.cpp:945:43: zkutil::ZooKeeper::tryMulti(std::vector<std::shared_ptr<Coordination::Request>, std::allocator<std::shared_ptr<Coordination::Request>>> const&, std::vector<std::shared_ptr<Coordination::Response>, std::allocator<std::shared_ptr<Coordination::Response>>>&, bool) @ 0x000000001efeb61d
2026.02.26 19:43:18.675831 [ 1603 ] {} <Fatal> BaseDaemon: 15.0. inlined from ./ci/tmp/build/./src/Disks/DiskObjectStorage/MetadataStorages/Keeper/MetadataStorageFromKeeper.cpp:364: operator()
2026.02.26 19:43:18.675876 [ 1603 ] {} <Fatal> BaseDaemon: 15. ./ci/tmp/build/./src/Disks/DiskObjectStorage/MetadataStorages/Keeper/MetadataStorageFromKeeper.cpp:494:32: Coordination::Error DB::KeeperConnection::runWithReconnects<Coordination::Error, DB::KeeperConnection::tryMulti(std::vector<std::shared_ptr<Coordination::Request>, std::allocator<std::shared_ptr<Coordination::Request>>> const&, std::vector<std::shared_ptr<Coordination::Response>, std::allocator<std::shared_ptr<Coordination::Response>>>&) const::'lambda'(std::shared_ptr<zkutil::ZooKeeper>)>(DB::KeeperConnection::tryMulti(std::vector<std::shared_ptr<Coordination::Request>, std::allocator<std::shared_ptr<Coordination::Request>>> const&, std::vector<std::shared_ptr<Coordination::Response>, std::allocator<std::shared_ptr<Coordination::Response>>>&) const::'lambda'(std::shared_ptr<zkutil::ZooKeeper>)&&) const @ 0x000000001b4e772d
2026.02.26 19:43:18.738855 [ 1603 ] {} <Fatal> BaseDaemon: 16.0. inlined from ./ci/tmp/build/./src/Disks/DiskObjectStorage/MetadataStorages/Keeper/MetadataStorageFromKeeper.cpp:360: DB::KeeperConnection::tryMulti(std::vector<std::shared_ptr<Coordination::Request>, std::allocator<std::shared_ptr<Coordination::Request>>> const&, std::vector<std::shared_ptr<Coordination::Response>, std::allocator<std::shared_ptr<Coordination::Response>>>&) const
2026.02.26 19:43:18.738901 [ 1603 ] {} <Fatal> BaseDaemon: 16. ./ci/tmp/build/./src/Disks/DiskObjectStorage/MetadataStorages/Keeper/MetadataStorageFromKeeper.cpp:291:16: DB::KeeperConnection::tryGet(String const&, String&, long&, Coordination::Stat*, Coordination::Error*) const @ 0x000000001b43ccad
2026.02.26 19:43:18.807367 [ 1603 ] {} <Fatal> BaseDaemon: 17. ./ci/tmp/build/./src/Disks/DiskObjectStorage/MetadataStorages/Keeper/MetadataStorageFromKeeper.cpp:2684:21: DB::MetadataStorageFromKeeper::Impl::readChild(unsigned long, String const&) const @ 0x000000001b44c57f
2026.02.26 19:43:18.907926 [ 1603 ] {} <Fatal> BaseDaemon: 18.0. inlined from ./ci/tmp/build/./src/Disks/DiskObjectStorage/MetadataStorages/Keeper/MetadataStorageFromKeeper.cpp:2676: DB::MetadataStorageFromKeeper::Impl::findChild(unsigned long, String const&) const
2026.02.26 19:43:18.908007 [ 1603 ] {} <Fatal> BaseDaemon: 18. ./ci/tmp/build/./src/Disks/DiskObjectStorage/MetadataStorages/Keeper/MetadataStorageFromKeeper.cpp:2710:12: DB::MetadataStorageFromKeeper::Impl::findObjectByPath(String const&) const @ 0x000000001b4389ae
2026.02.26 19:43:19.011090 [ 1603 ] {} <Fatal> BaseDaemon: 19. ./ci/tmp/build/./src/Disks/DiskObjectStorage/MetadataStorages/Keeper/MetadataStorageFromKeeper.cpp:1964:21: DB::MetadataStorageFromKeeper::Impl::isFile(String const&) const @ 0x000000001b439000
2026.02.26 19:43:19.027198 [ 1603 ] {} <Fatal> BaseDaemon: 20. ./src/Disks/DiskEncrypted.h:40:26: DB::DiskEncrypted::existsFile(String const&) const @ 0x000000001b3f2283
2026.02.26 19:43:19.034913 [ 1603 ] {} <Fatal> BaseDaemon: 21. ./ci/tmp/build/./src/Storages/MergeTree/DataPartStorageOnDiskFull.cpp:53:31: DB::DataPartStorageOnDiskFull::existsFile(String const&) const @ 0x000000001d702407
2026.02.26 19:43:19.099777 [ 1603 ] {} <Fatal> BaseDaemon: 22. ./ci/tmp/build/./src/Storages/MergeTree/IMergeTreeDataPart.cpp:2832:18: DB::IMergeTreeDataPart::getStreamNameOrHash(String const&, String const&, DB::IDataPartStorage const&) @ 0x000000001d76fb2c
2026.02.26 19:43:19.124932 [ 1603 ] {} <Fatal> BaseDaemon: 23. ./ci/tmp/build/./src/Storages/MergeTree/TextIndexUtils.cpp:506:31: DB::makeTextIndexInputStream(std::shared_ptr<DB::IDataPartStorage const>, String const&, String const&, DB::MergeTreeReaderSettings const&) @ 0x000000001dd232d1
2026.02.26 19:43:19.141097 [ 1603 ] {} <Fatal> BaseDaemon: 24. ./ci/tmp/build/./src/Storages/MergeTree/MergeTreeReaderTextIndex.cpp:68:16: _ZZN2DB24MergeTreeReaderTextIndexC1EPKNS_16IMergeTreeReaderENS_27MergeTreeIndexWithConditionENS_17NamesAndTypesListEbENK3$_0clINS_23MergeTreeIndexSubstreamEEEDaRKT_ @ 0x000000001db26231
2026.02.26 19:43:19.154732 [ 1603 ] {} <Fatal> BaseDaemon: 25. ./ci/tmp/build/./src/Storages/MergeTree/MergeTreeReaderTextIndex.cpp:75:27: DB::MergeTreeReaderTextIndex::MergeTreeReaderTextIndex(DB::IMergeTreeReader const*, DB::MergeTreeIndexWithCondition, DB::NamesAndTypesList, bool) @ 0x000000001db257fb
2026.02.26 19:43:19.170042 [ 1603 ] {} <Fatal> BaseDaemon: 26.0. inlined from ./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:773: std::unique_ptr<DB::MergeTreeReaderTextIndex, std::default_delete<DB::MergeTreeReaderTextIndex>> std::make_unique[abi:fe210105]<DB::MergeTreeReaderTextIndex, DB::IMergeTreeReader const*&, DB::MergeTreeIndexWithCondition const&, DB::NamesAndTypesList const&, bool&, 0>(DB::IMergeTreeReader const*&, DB::MergeTreeIndexWithCondition const&, DB::NamesAndTypesList const&, bool&)
2026.02.26 19:43:19.170098 [ 1603 ] {} <Fatal> BaseDaemon: 26. ./ci/tmp/build/./src/Storages/MergeTree/MergeTreeReaderTextIndex.cpp:614:30: DB::createMergeTreeReaderTextIndex(DB::IMergeTreeReader const*, DB::MergeTreeIndexWithCondition const&, DB::NamesAndTypesList const&, bool) @ 0x000000001db312cb
2026.02.26 19:43:19.179547 [ 1603 ] {} <Fatal> BaseDaemon: 27. ./ci/tmp/build/./src/Storages/MergeTree/MergeTreeReadTask.cpp:185:44: DB::MergeTreeReadTask::createReaders(std::shared_ptr<DB::MergeTreeReadTaskInfo const> const&, DB::MergeTreeReadTask::Extras const&, DB::MarkRanges const&, std::vector<DB::MarkRanges, std::allocator<DB::MarkRanges>> const&) @ 0x000000001dafa542
2026.02.26 19:43:19.191990 [ 1603 ] {} <Fatal> BaseDaemon: 28.0. inlined from ./ci/tmp/build/./src/Storages/MergeTree/MergeTreePrefetchedReadPool.cpp:172: DB::MergeTreePrefetchedReadPool::createPrefetchedReadersForTask(DB::MergeTreePrefetchedReadPool::ThreadTask&)
2026.02.26 19:43:19.192048 [ 1603 ] {} <Fatal> BaseDaemon: 28.1. inlined from ./ci/tmp/build/./src/Storages/MergeTree/MergeTreePrefetchedReadPool.cpp:192: DB::MergeTreePrefetchedReadPool::startPrefetches()
2026.02.26 19:43:19.192059 [ 1603 ] {} <Fatal> BaseDaemon: 28. ./ci/tmp/build/./src/Storages/MergeTree/MergeTreePrefetchedReadPool.cpp:218:20: DB::MergeTreePrefetchedReadPool::getTask(unsigned long, DB::MergeTreeReadTask*) @ 0x000000001eb08b25
2026.02.26 19:43:19.203058 [ 1603 ] {} <Fatal> BaseDaemon: 29. ./ci/tmp/build/./src/Storages/MergeTree/MergeTreeSelectProcessor.cpp:310:35: DB::MergeTreeSelectProcessor::read() @ 0x000000001db4ba73
2026.02.26 19:43:19.208060 [ 1603 ] {} <Fatal> BaseDaemon: 30. ./ci/tmp/build/./src/Storages/MergeTree/MergeTreeSource.cpp:230:41: DB::MergeTreeSource::tryGenerate() @ 0x000000001eb44fda
2026.02.26 19:43:19.211859 [ 1603 ] {} <Fatal> BaseDaemon: 31. ./ci/tmp/build/./src/Processors/ISource.cpp:110:26: DB::ISource::work() @ 0x000000001e4c1f81
```


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.111`
<!-- ch-version-info:end -->