### PR TITLE
Fix race condition causing spurious Finish Workflow failure in backport PRs

### DIFF
--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -378,6 +378,15 @@ class Runner:
             cmd += f" --workers {workers}"
         print(f"--- Run command [{cmd}]")
 
+        # Clean up stale experimental result file before starting the subprocess.
+        # This must happen before TeePopen.__enter__ which sleeps 1s after spawning
+        # the process — if the subprocess completes during that sleep (common for
+        # fast native jobs like Finish Workflow in backport PRs), deleting the file
+        # afterwards would remove the subprocess's own output, causing a spurious
+        # "Job killed or terminated" error.
+        if Path((Result.experimental_file_name_static())).exists():
+            Path(Result.experimental_file_name_static()).unlink()
+
         with TeePopen(
             cmd,
             timeout=job.timeout,
@@ -385,10 +394,6 @@ class Runner:
             timeout_shell_cleanup=job.timeout_shell_cleanup,
         ) as process:
             start_time = Utils.timestamp()
-
-            if Path((Result.experimental_file_name_static())).exists():
-                # experimental mode to let job write results into fixed result.json file instead of result_job_name.json
-                Path(Result.experimental_file_name_static()).unlink()
 
             exit_code = process.wait()
 


### PR DESCRIPTION
## Summary

- Fix a race condition in `ci/praktika/runner.py` where the stale experimental result file cleanup runs **after** `TeePopen.__enter__` (which sleeps 1s after spawning the subprocess), instead of before it
- For fast native jobs like `Finish Workflow` in backport PRs, the subprocess can complete during that 1-second sleep, creating `result_job.json` on disk — which the cleanup then deletes, leaving the job result stuck in `RUNNING` status and causing a spurious `ERROR: Job killed or terminated, no Result provided`
- Move the cleanup before the `TeePopen` context manager so it only removes genuinely stale files

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=98134&sha=acb0529e9298aa69121da4ccd45c949b8d3e238f&name_0=BackportPR&name_1=Finish%20Workflow
https://github.com/ClickHouse/ClickHouse/pull/98134

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.118`
<!-- ch-version-info:end -->