### PR TITLE
Add `MaxAllocatedEphemeralLockSequentialNumber` metric

### DIFF
--- a/src/Common/CurrentMetrics.cpp
+++ b/src/Common/CurrentMetrics.cpp
@@ -69,6 +69,7 @@
     M(MemoryTrackingUncorrected, "Total amount of memory (bytes) allocated by the server not corrected by RSS.") \
     M(MergesMutationsMemoryTracking, "Total amount of memory (bytes) allocated by background tasks (merges and mutations).") \
     M(EphemeralNode, "Number of ephemeral nodes hold in ZooKeeper.") \
+    M(MaxAllocatedEphemeralLockSequentialNumber, "The maximum sequential number allocated for ephemeral lock znodes in ZooKeeper. Primarily influenced by the block numbers.") \
     M(ZooKeeperSession, "Number of sessions (connections) to ZooKeeper. Should be no more than one, because using more than one connection to ZooKeeper may lead to bugs due to lack of linearizability (stale reads) that ZooKeeper consistency model allows.") \
     M(ZooKeeperSessionExpired, "Number of expired global ZooKeeper sessions.") \
     M(ZooKeeperConnectionLossStartedTimestampSeconds, "Unix timestamp in seconds when ZooKeeper connection was lost, or 0 if connected successfully.") \

--- a/src/Common/CurrentMetrics.h
+++ b/src/Common/CurrentMetrics.h
@@ -64,6 +64,11 @@ namespace CurrentMetrics
         return values[metric].compare_exchange_strong(expected, desired, std::memory_order_relaxed);
     }
 
+    inline void max(Metric metric, Value value)
+    {
+        __atomic_fetch_max(reinterpret_cast<Value *>(&values[metric]), value, __ATOMIC_RELAXED);
+    }
+
     /// For lifetime of object, add amount for specified metric. Then subtract.
     class Increment
     {

--- a/src/Storages/MergeTree/EphemeralLockInZooKeeper.cpp
+++ b/src/Storages/MergeTree/EphemeralLockInZooKeeper.cpp
@@ -19,18 +19,24 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
 }
 
+namespace
+{
+
+/// Parse the sequential number suffix from a ZooKeeper path.
+UInt64 parseSequentialNodeNumber(const String & path, size_t prefix_size)
+{
+    if (path.size() <= prefix_size)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Path of the sequential node is shorter than the provided prefix size: path={}, prefix_size={}", path, prefix_size);
+    return parse<UInt64>(path.c_str() + prefix_size, path.size() - prefix_size);
+}
+
+}
+
 EphemeralLockInZooKeeper::EphemeralLockInZooKeeper(const String & path_prefix_, const ZooKeeperWithFaultInjectionPtr & zookeeper_, const String & path_, UInt64 number_, const String & conflict_path_)
     : zookeeper(zookeeper_), path_prefix(path_prefix_), path(path_), conflict_path(conflict_path_), number(number_)
 {
     if (conflict_path.empty() && path.size() <= path_prefix.size())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Name of the main node is shorter than prefix.");
-}
-
-UInt64 EphemeralLockInZooKeeper::parseNumber(const String & path, size_t prefix_size)
-{
-    if (path.size() <= prefix_size)
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Path of the sequential node is shorter than the provided prefix size: path={}, prefix_size={}", path, prefix_size);
-    return parse<UInt64>(path.c_str() + prefix_size, path.size() - prefix_size);
 }
 
 EphemeralLockInZooKeeper createEphemeralLockInZooKeeper(
@@ -86,7 +92,7 @@ EphemeralLockInZooKeeper createEphemeralLockInZooKeeper(
         path = dynamic_cast<const Coordination::CreateResponse *>(responses.back().get())->path_created;
     }
 
-    const UInt64 number = EphemeralLockInZooKeeper::parseNumber(path, path_prefix_.size());
+    const UInt64 number = parseSequentialNodeNumber(path, path_prefix_.size());
     CurrentMetrics::max(CurrentMetrics::MaxAllocatedEphemeralLockSequentialNumber, number);
     return EphemeralLockInZooKeeper{path_prefix_, zookeeper_, path, number};
 }
@@ -189,7 +195,7 @@ EphemeralLocksInAllPartitions::EphemeralLocksInAllPartitions(
             size_t prefix_size = block_numbers_path.size() + 1 + partitions[i].size() + 1 + path_prefix.size();
             const String & path = dynamic_cast<const Coordination::CreateResponse &>(*lock_responses[i]).path_created;
 
-            const UInt64 number = EphemeralLockInZooKeeper::parseNumber(path, prefix_size);
+            const UInt64 number = parseSequentialNodeNumber(path, prefix_size);
             CurrentMetrics::max(CurrentMetrics::MaxAllocatedEphemeralLockSequentialNumber, number);
             locks.push_back(LockInfo{path, partitions[i], number});
         }

--- a/src/Storages/MergeTree/EphemeralLockInZooKeeper.cpp
+++ b/src/Storages/MergeTree/EphemeralLockInZooKeeper.cpp
@@ -30,6 +30,17 @@ UInt64 parseSequentialNodeNumber(const String & path, size_t prefix_size)
     return parse<UInt64>(path.c_str() + prefix_size, path.size() - prefix_size);
 }
 
+constexpr UInt64 BLOCK_NUMBER_WARNING_THRESHOLD = 1ULL << 30;
+
+void warnIfBlockNumberIsHigh(UInt64 number, const String & path)
+{
+    if (number > BLOCK_NUMBER_WARNING_THRESHOLD)
+        LOG_WARNING(
+            getLogger("EphemeralLockInZooKeeper"),
+            "Block number {} is too high, this may lead to overflow. Path: {}",
+            number, path);
+}
+
 }
 
 EphemeralLockInZooKeeper::EphemeralLockInZooKeeper(const String & path_prefix_, const ZooKeeperWithFaultInjectionPtr & zookeeper_, const String & path_, UInt64 number_, const String & conflict_path_)
@@ -93,6 +104,7 @@ EphemeralLockInZooKeeper createEphemeralLockInZooKeeper(
     }
 
     const UInt64 number = parseSequentialNodeNumber(path, path_prefix_.size());
+    warnIfBlockNumberIsHigh(number, path);
     CurrentMetrics::max(CurrentMetrics::MaxAllocatedEphemeralLockSequentialNumber, number);
     return EphemeralLockInZooKeeper{path_prefix_, zookeeper_, path, number};
 }
@@ -196,6 +208,7 @@ EphemeralLocksInAllPartitions::EphemeralLocksInAllPartitions(
             const String & path = dynamic_cast<const Coordination::CreateResponse &>(*lock_responses[i]).path_created;
 
             const UInt64 number = parseSequentialNodeNumber(path, prefix_size);
+            warnIfBlockNumberIsHigh(number, path);
             CurrentMetrics::max(CurrentMetrics::MaxAllocatedEphemeralLockSequentialNumber, number);
             locks.push_back(LockInfo{path, partitions[i], number});
         }

--- a/src/Storages/MergeTree/EphemeralLockInZooKeeper.cpp
+++ b/src/Storages/MergeTree/EphemeralLockInZooKeeper.cpp
@@ -1,9 +1,15 @@
 #include <Storages/MergeTree/EphemeralLockInZooKeeper.h>
+#include <Common/CurrentMetrics.h>
 #include <Common/ZooKeeper/KeeperException.h>
 #include <Common/logger_useful.h>
 #include <base/types.h>
 #include <Common/ZooKeeper/ZooKeeperWithFaultInjection.h>
 #include <IO/ReadHelpers.h>
+
+namespace CurrentMetrics
+{
+    extern const Metric MaxAllocatedEphemeralLockSequentialNumber;
+}
 
 namespace DB
 {
@@ -13,11 +19,18 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
 }
 
-EphemeralLockInZooKeeper::EphemeralLockInZooKeeper(const String & path_prefix_, const ZooKeeperWithFaultInjectionPtr & zookeeper_, const String & path_, const String & conflict_path_)
-    : zookeeper(zookeeper_), path_prefix(path_prefix_), path(path_), conflict_path(conflict_path_)
+EphemeralLockInZooKeeper::EphemeralLockInZooKeeper(const String & path_prefix_, const ZooKeeperWithFaultInjectionPtr & zookeeper_, const String & path_, UInt64 number_, const String & conflict_path_)
+    : zookeeper(zookeeper_), path_prefix(path_prefix_), path(path_), conflict_path(conflict_path_), number(number_)
 {
     if (conflict_path.empty() && path.size() <= path_prefix.size())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Name of the main node is shorter than prefix.");
+}
+
+UInt64 EphemeralLockInZooKeeper::parseNumber(const String & path, size_t prefix_size)
+{
+    if (path.size() <= prefix_size)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Path of the sequential node is shorter than the provided prefix size: path={}, prefix_size={}", path, prefix_size);
+    return parse<UInt64>(path.c_str() + prefix_size, path.size() - prefix_size);
 }
 
 EphemeralLockInZooKeeper createEphemeralLockInZooKeeper(
@@ -60,7 +73,7 @@ EphemeralLockInZooKeeper createEphemeralLockInZooKeeper(
                     getLogger("createEphemeralLockInZooKeeper"),
                     "Deduplication path already exists: deduplication_path={}",
                     failed_op_path);
-                return EphemeralLockInZooKeeper{"", nullptr, "", failed_op_path};
+                return EphemeralLockInZooKeeper{"", nullptr, "", 0, failed_op_path};
             }
         }
 
@@ -73,13 +86,9 @@ EphemeralLockInZooKeeper createEphemeralLockInZooKeeper(
         path = dynamic_cast<const Coordination::CreateResponse *>(responses.back().get())->path_created;
     }
 
-    return EphemeralLockInZooKeeper{path_prefix_, zookeeper_, path};
-}
-
-UInt64 EphemeralLockInZooKeeper::getNumber() const
-{
-    checkCreated();
-    return parse<UInt64>(path.c_str() + path_prefix.size(), path.size() - path_prefix.size());
+    const UInt64 number = EphemeralLockInZooKeeper::parseNumber(path, path_prefix_.size());
+    CurrentMetrics::max(CurrentMetrics::MaxAllocatedEphemeralLockSequentialNumber, number);
+    return EphemeralLockInZooKeeper{path_prefix_, zookeeper_, path, number};
 }
 
 void EphemeralLockInZooKeeper::unlock()
@@ -179,10 +188,9 @@ EphemeralLocksInAllPartitions::EphemeralLocksInAllPartitions(
         {
             size_t prefix_size = block_numbers_path.size() + 1 + partitions[i].size() + 1 + path_prefix.size();
             const String & path = dynamic_cast<const Coordination::CreateResponse &>(*lock_responses[i]).path_created;
-            if (path.size() <= prefix_size)
-                throw Exception(ErrorCodes::LOGICAL_ERROR, "Name of the sequential node is shorter than prefix.");
 
-            UInt64 number = parse<UInt64>(path.c_str() + prefix_size, path.size() - prefix_size);
+            const UInt64 number = EphemeralLockInZooKeeper::parseNumber(path, prefix_size);
+            CurrentMetrics::max(CurrentMetrics::MaxAllocatedEphemeralLockSequentialNumber, number);
             locks.push_back(LockInfo{path, partitions[i], number});
         }
 

--- a/src/Storages/MergeTree/EphemeralLockInZooKeeper.h
+++ b/src/Storages/MergeTree/EphemeralLockInZooKeeper.h
@@ -22,9 +22,6 @@ class EphemeralLockInZooKeeper : public boost::noncopyable
         const String & path_prefix_, const String & temp_path, const ZooKeeperWithFaultInjectionPtr & zookeeper_, const std::vector<String> & deduplication_path,
         const std::optional<String> & znode_data);
 
-    /// Parse the sequential number suffix from a ZooKeeper path.
-    static UInt64 parseNumber(const String & path, size_t prefix_size);
-
 protected:
     EphemeralLockInZooKeeper(const String & path_prefix_, const ZooKeeperWithFaultInjectionPtr & zookeeper_, const String & path_, UInt64 number_, const String & conflict_path_ = "");
 

--- a/src/Storages/MergeTree/EphemeralLockInZooKeeper.h
+++ b/src/Storages/MergeTree/EphemeralLockInZooKeeper.h
@@ -22,8 +22,11 @@ class EphemeralLockInZooKeeper : public boost::noncopyable
         const String & path_prefix_, const String & temp_path, const ZooKeeperWithFaultInjectionPtr & zookeeper_, const std::vector<String> & deduplication_path,
         const std::optional<String> & znode_data);
 
+    /// Parse the sequential number suffix from a ZooKeeper path.
+    static UInt64 parseNumber(const String & path, size_t prefix_size);
+
 protected:
-    EphemeralLockInZooKeeper(const String & path_prefix_, const ZooKeeperWithFaultInjectionPtr & zookeeper_, const String & path_, const String & conflict_path_ = "");
+    EphemeralLockInZooKeeper(const String & path_prefix_, const ZooKeeperWithFaultInjectionPtr & zookeeper_, const String & path_, UInt64 number_, const String & conflict_path_ = "");
 
 public:
     EphemeralLockInZooKeeper() = delete;
@@ -45,6 +48,7 @@ public:
         path_prefix = std::move(rhs.path_prefix);
         path = std::move(rhs.path);
         conflict_path = std::move(rhs.conflict_path);
+        number = rhs.number;
         return *this;
     }
 
@@ -66,8 +70,11 @@ public:
         return conflict_path;
     }
 
-    /// Parse the number at the end of the path.
-    UInt64 getNumber() const;
+    UInt64 getNumber() const
+    {
+        checkCreated();
+        return number;
+    }
 
     void unlock();
 
@@ -90,6 +97,7 @@ private:
     String path_prefix;
     String path;
     String conflict_path;
+    UInt64 number = 0;
 };
 
 EphemeralLockInZooKeeper createEphemeralLockInZooKeeper(


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add a new `MaxAllocatedEphemeralLockSequentialNumber` metric for the maximum sequential number allocated for ephemeral lock znodes in ZooKeeper.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.445`
<!-- ch-version-info:end -->