### PR TITLE
Fix `LOGICAL_ERROR` when S3Queue ordered mode processed pointer is concurrently advanced  

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -97,6 +97,7 @@ static struct InitFiu
     REGULAR(keepermap_fail_drop_data) \
     REGULAR(lazy_pipe_fds_fail_close) \
     PAUSEABLE(infinite_sleep) \
+    PAUSEABLE_ONCE(object_storage_queue_pause_before_commit) \
     PAUSEABLE(stop_moving_part_before_swap_with_active) \
     REGULAR(replicated_merge_tree_all_replicas_stale) \
     REGULAR(zero_copy_lock_zk_fail_before_op) \

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueOrderedFileMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueOrderedFileMetadata.cpp
@@ -671,12 +671,16 @@ void ObjectStorageQueueOrderedFileMetadata::doPrepareProcessedRequests(
     {
         if (state.is_processed)
         {
-            LOG_TRACE(
+            LOG_WARNING(
                 log, "File {} is already processed, current max processed file: {}",
                 path, *state.last_processed_path);
 
             if (ignore_if_exists)
+            {
+                if (created_processing_node)
+                    requests.push_back(zkutil::makeRemoveRequest(processing_node_path, -1));
                 return;
+            }
 
             throw Exception(
                 ErrorCodes::LOGICAL_ERROR,
@@ -743,7 +747,7 @@ void ObjectStorageQueueOrderedFileMetadata::prepareProcessedRequestsImpl(
     LastProcessedFileInfoMapPtr created_nodes)
 {
     chassert(created_processing_node);
-    doPrepareProcessedRequests(requests, processed_node_path, /* ignore_if_exists */false, created_nodes);
+    doPrepareProcessedRequests(requests, processed_node_path, /* ignore_if_exists */true, created_nodes);
 }
 
 void ObjectStorageQueueOrderedFileMetadata::preparePartitionProcessedMap(PartitionLastProcessedFileInfoMap & last_processed_file_per_partition)

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueOrderedFileMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueOrderedFileMetadata.cpp
@@ -6,7 +6,6 @@
 #include <Common/logger_useful.h>
 #include <Interpreters/Context.h>
 #include <Poco/JSON/Parser.h>
-#include <numeric>
 
 #include <boost/algorithm/string/replace.hpp>
 

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
@@ -73,6 +73,7 @@ namespace FailPoints
     extern const char object_storage_queue_fail_commit_once[];
     extern const char object_storage_queue_fail_after_insert[];
     extern const char object_storage_queue_fail_startup[];
+    extern const char object_storage_queue_pause_before_commit[];
 }
 
 namespace ServerSetting
@@ -955,6 +956,8 @@ bool StorageObjectStorageQueue::streamToViews(size_t streaming_tasks_index)
         fiu_do_on(FailPoints::object_storage_queue_fail_after_insert, {
             throw Exception(ErrorCodes::FAULT_INJECTED, "Failed after insert");
         });
+
+        FailPointInjection::pauseFailPoint(FailPoints::object_storage_queue_pause_before_commit);
 
         commit(/*insert_succeeded=*/ true, rows, sources, transaction_start_time);
         file_iterator->releaseFinishedBuckets();

--- a/tests/integration/test_storage_s3_queue/test_5.py
+++ b/tests/integration/test_storage_s3_queue/test_5.py
@@ -1858,3 +1858,68 @@ def test_deduplication_with_multiple_chunks(started_cluster, mode):
     assert files_num * num_rows == int(
         node.query(f"SELECT count() FROM {dst_table_name}")
     )
+
+
+def test_ordered_mode_commit_race_condition(started_cluster):
+    """
+    Reproduce the race condition where the ZK processed pointer is advanced past a file between its processing and commit.
+
+    A single streaming task processes test_0.csv and pauses before commit via a PAUSEABLE_ONCE failpoint. While paused, the test directly
+    writes test_1.csv to the ZK processed pointer (simulating a concurrent commit from another replica or task). When the paused task
+    resumes, it finds test_0.csv <= test_1.csv.
+    """
+    node = started_cluster.instances["instance"]
+
+    table_name = f"test_commit_race_{generate_random_string()}"
+    dst_table_name = f"{table_name}_dst"
+    keeper_path = f"/clickhouse/test_{table_name}"
+    files_path = f"{table_name}_data"
+
+    create_table(
+        started_cluster,
+        node,
+        table_name,
+        "ordered",
+        files_path,
+        additional_settings={
+            "keeper_path": keeper_path,
+            "s3queue_processing_threads_num": 1,
+            "polling_max_timeout_ms": 1000,
+        },
+    )
+
+    node.query("SYSTEM ENABLE FAILPOINT object_storage_queue_pause_before_commit")
+
+    generate_random_files(started_cluster, files_path, count=1)
+    create_mv(node, table_name, dst_table_name)
+
+    node.query("SYSTEM WAIT FAILPOINT object_storage_queue_pause_before_commit PAUSE", timeout=60)
+
+    # While the task is paused, advance the ZK processed pointer to test_1.csv, simulating a concurrent commit from another replica
+    zk = started_cluster.get_kazoo_client("zoo1")
+    processed_path = f"{keeper_path}/processed"
+    advanced_metadata = json.dumps(
+        {
+            "file_path": f"{files_path}/test_1.csv",
+            "last_processed_timestamp": 0,
+            "last_exception": "",
+            "retries": 0,
+            "processor_id": "",
+        }
+    )
+    zk.create(processed_path, advanced_metadata.encode())
+
+    # Resume the paused task, which is now behind the pointer (test_1.csv) and wait for the resumed task to complete its commit attempt
+    node.query("SYSTEM NOTIFY FAILPOINT object_storage_queue_pause_before_commit")
+    time.sleep(5)
+    node.query("SYSTEM DISABLE FAILPOINT object_storage_queue_pause_before_commit")
+
+    node.query("SYSTEM FLUSH LOGS")
+    error_count = int(
+        node.query(
+            f"SELECT count() FROM system.text_log "
+            f"WHERE message LIKE '%is already processed, while expected it not to be%' "
+            f"AND logger_name LIKE '%{table_name}%'"
+        )
+    )
+    assert error_count == 0, ("LOGICAL_ERROR: file reported as already processed due to commit race condition")


### PR DESCRIPTION
In ordered mode, ZK processed pointer is a high-water mark. All files with paths <= the pointer are considered processed. When multiple actors commit concurrently, one may advance the pointer past a file that another actor is about to commit. This is legitimate because the high-water mark already covers that file, so there is nothing to update. Previously this threw a `LOGICAL_ERROR`. Now it gracefully skips the pointer update and cleans up the processing node.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `LOGICAL_ERROR` exception in S3Queue ordered mode when multiple actors advance the processed pointer between file processing and commit.