### PR TITLE
Partially revert #88096

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,1 @@
-# Code of Conduct
-
-We welcome everyone to contribute to our product. For detailed contribution guidelines, please see [CONTRIBUTING.md](CONTRIBUTING.md).
+We welcome everyone to contribute to our product, see CONTRIBUTING.md.


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)


The PR #88096 does:

> Add proper markdown formatting to CODE_OF_CONDUCT.md

But it didn't get the original intent of minimalism - that we specifically made a code of conduct this way to emphasize the minimalism to the maximum. Revert this change.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.122`
<!-- ch-version-info:end -->