### PR TITLE
Skip changelog checks for release PRs in CI

### DIFF
--- a/ci/jobs/scripts/workflow_hooks/pr_body_check.py
+++ b/ci/jobs/scripts/workflow_hooks/pr_body_check.py
@@ -60,6 +60,11 @@ if __name__ == "__main__":
     if not title or not body:
         print("WARNING: Failed to get PR title or body, read from environment")
         body = Info().pr_body
+        labels = Info().pr_labels
+
+    if "release" in labels or "release-lts" in labels:
+        print("NOTE: Release PR detected, skipping changelog entry check")
+        sys.exit(0)
 
     error, category = get_category(body)
     if error or not category:

--- a/ci/jobs/scripts/workflow_hooks/pr_labels_and_category.py
+++ b/ci/jobs/scripts/workflow_hooks/pr_labels_and_category.py
@@ -189,6 +189,9 @@ def check_labels(category, info):
 
 if __name__ == "__main__":
     info = Info()
+    if Labels.RELEASE in info.pr_labels or Labels.RELEASE_LTS in info.pr_labels:
+        print("NOTE: Release PR detected, skipping changelog category check")
+        sys.exit(0)
     error, category = get_category(info.pr_body)
     if not category or error:
         print(f"ERROR: {error}")


### PR DESCRIPTION
## Summary
- Release PRs (labeled `release` or `release-lts`) don't have changelog categories or entries in the PR body
- The `pr_labels_and_category.py` pre-hook was failing in Config Workflow, causing all dependent CI jobs to be marked as "dropped"
- The `pr_body_check.py` post-hook was failing in Finish Workflow
- Skip both checks for release PRs so CI jobs can run normally

See https://github.com/ClickHouse/ClickHouse/pull/97856 for an example of the broken CI comment.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a]user-readable short description of the changes that goes to CHANGELOG.md):
- Skip changelog and PR body checks for release PRs in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.123`
- Backported to: `26.2.2.2`, `26.1.4.34`
<!-- ch-version-info:end -->