### PR TITLE
Fix INSERT parser failing on double-parenthesized compound SELECT

### DIFF
--- a/tests/queries/0_stateless/04004_insert_compound_select_formatting.reference
+++ b/tests/queries/0_stateless/04004_insert_compound_select_formatting.reference
@@ -1,0 +1,7 @@
+INSERT INTO t1 (\n    (\n        SELECT 1\n    )\n    EXCEPT ALL\n    (\n        SELECT 2\n    )\n)\nINTERSECT\n(\n    SELECT 3\n)
+INSERT INTO t1 (\n    (\n        SELECT 1\n    )\n    INTERSECT\n    (\n        SELECT 2\n    )\n)\nEXCEPT ALL\n(\n    SELECT 3\n)
+INSERT INTO t1 (\n    (\n        SELECT 1\n    )\n    UNION ALL\n    (\n        SELECT 2\n    )\n)\nINTERSECT\n(\n    SELECT 3\n)
+INSERT INTO t1 (\n    (\n        SELECT 1\n    )\n    EXCEPT ALL\n    (\n        SELECT 2\n    )\n)\nINTERSECT\n(\n    SELECT 3\n)
+INSERT INTO t1 (a, b, c) FORMAT Values
+INSERT INTO t1 SELECT\n    1,\n    2,\n    3
+INSERT INTO t1 SELECT\n    1,\n    2,\n    3

--- a/tests/queries/0_stateless/04004_insert_compound_select_formatting.sql
+++ b/tests/queries/0_stateless/04004_insert_compound_select_formatting.sql
@@ -1,0 +1,15 @@
+-- Test that INSERT with compound SELECT (INTERSECT/EXCEPT) formats correctly
+-- and can be re-parsed. This is a regression test for a bug where the INSERT
+-- parser failed on double parentheses like ((SELECT ...) EXCEPT ALL (SELECT ...)).
+
+SELECT formatQuery('INSERT INTO t1 ((SELECT 1) EXCEPT ALL (SELECT 2)) INTERSECT (SELECT 3)');
+SELECT formatQuery('INSERT INTO t1 ((SELECT 1) INTERSECT (SELECT 2)) EXCEPT ALL (SELECT 3)');
+SELECT formatQuery('INSERT INTO t1 ((SELECT 1) UNION ALL (SELECT 2)) INTERSECT (SELECT 3)');
+
+-- Verify round-trip consistency
+SELECT formatQuery(formatQuery('INSERT INTO t1 ((SELECT 1) EXCEPT ALL (SELECT 2)) INTERSECT (SELECT 3)'));
+
+-- Regular INSERT forms should still work
+SELECT formatQuery('INSERT INTO t1 (a, b, c) VALUES (1, 2, 3)');
+SELECT formatQuery('INSERT INTO t1 (SELECT 1, 2, 3)');
+SELECT formatQuery('INSERT INTO t1 SELECT 1, 2, 3');


### PR DESCRIPTION
## Summary
- Fix the INSERT query parser to rewind on column list parse failure, instead of returning false immediately
- This fixes "Inconsistent AST formatting" exception when INSERT queries use compound SELECT with `INTERSECT`/`EXCEPT` operators
- When the AST formatter wraps nested unions in parentheses (producing e.g., `INSERT INTO t1 ((SELECT 1) EXCEPT ALL (SELECT 2))`), the parser now correctly handles the double parentheses

The root cause: the INSERT parser consumed the first `(` for column list parsing, but when the second `(` couldn't be parsed as a column name, it returned `false` instead of rewinding `pos` to try parsing `((SELECT ...)` as a compound SELECT query.

Closes https://github.com/ClickHouse/ClickHouse/issues/90925

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=bfd26cd518682a2051429b51714e9c8c62806f45&name_0=MasterCI&name_1=BuzzHouse%20%28amd_debug%29&name_1=BuzzHouse%20%28amd_debug%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)