### PR TITLE
chore: update clickstack to 2.20.0

### DIFF
--- a/tests/queries/0_stateless/03916_clickstack.sh
+++ b/tests/queries/0_stateless/03916_clickstack.sh
@@ -5,7 +5,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../shell_config.sh
 
 # Test that clickstack UI is accessible and serves correct content
-${CLICKHOUSE_CURL} --compressed -sS "${CLICKHOUSE_PORT_HTTP_PROTO}://${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT_HTTP}/clickstack" | grep -oF 'ClickStack'
+${CLICKHOUSE_CURL} --compressed -sS "${CLICKHOUSE_PORT_HTTP_PROTO}://${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT_HTTP}/clickstack" | grep -oF 'ClickStack' | head -n 1
 
 # Test that clickstack serves with gzip encoding
 ${CLICKHOUSE_CURL} -sS -I "${CLICKHOUSE_PORT_HTTP_PROTO}://${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT_HTTP}/clickstack" | grep -oF 'Content-Encoding: gzip'


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Update clickstack to version 2.20.0


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.192`
<!-- ch-version-info:end -->