### PR TITLE
Fix assertion failure in server-side AST fuzzer with implicit_transaction

### DIFF
--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -2027,6 +2027,8 @@ static void executeASTFuzzerQueries(const ASTPtr & ast, const ContextMutablePtr 
             context->setCurrentTransaction(NO_TRANSACTION_PTR);
 
             auto fuzz_context = Context::createCopy(context);
+            fuzz_context->makeQueryContext();
+            fuzz_context->makeSessionContext();
             fuzz_context->setSetting("ast_fuzzer_runs", Field(Float64(0)));
             fuzz_context->setCurrentQueryId("");
 


### PR DESCRIPTION
The AST fuzzer creates a context copy via `Context::createCopy` but never
calls `makeQueryContext`/`makeSessionContext`. The copy's `query_context`
and `session_context` weak_ptrs still point to the original context.

When `implicit_transaction` is enabled (randomly during stress test),
`InterpreterTransactionControlQuery::executeBegin` calls
`setCurrentTransaction` on this copy, hitting the assertion
`this == session_context.lock().get() || this == query_context.lock().get()`
because the copy is neither its own session nor query context.

Call `makeQueryContext` and `makeSessionContext` on the fuzz context copy,
making it a fully independent context that properly isolates transactions
and other state from the original query's context.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=e36eaec2635fa46330f3d96eb47802a0ef7fc0d6&name_0=MasterCI&name_1=Stress%20test%20%28amd_debug%29&name_1=Stress%20test%20%28amd_debug%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.136`
<!-- ch-version-info:end -->