### PR TITLE
Add `{_schema_hash}` placeholder for S3 table engine

### DIFF
--- a/src/Storages/IPartitionStrategy.cpp
+++ b/src/Storages/IPartitionStrategy.cpp
@@ -95,6 +95,7 @@ namespace
         ContextPtr context,
         const std::string & file_format,
         bool globbed_path,
+        bool contains_partition_wildcard,
         bool partition_columns_in_data_file)
     {
         if (!partition_by)
@@ -105,6 +106,11 @@ namespace
         if (globbed_path)
         {
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Partition strategy {} can not be used with a globbed path", "hive");
+        }
+
+        if (contains_partition_wildcard)
+        {
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Partition strategy hive can not be used with a '_partition_id' wildcard in the path");
         }
 
         if (file_format.empty() || file_format == "auto")
@@ -241,6 +247,7 @@ std::shared_ptr<IPartitionStrategy> PartitionStrategyFactory::get(StrategyType s
                 context,
                 file_format,
                 globbed_path,
+                contains_partition_wildcard,
                 partition_columns_in_data_file);
         case StrategyType::NONE:
         {

--- a/src/Storages/ObjectStorage/Azure/Configuration.h
+++ b/src/Storages/ObjectStorage/Azure/Configuration.h
@@ -98,6 +98,7 @@ public:
     std::string getEngineName() const override { return engine_name; }
 
     Path getRawPath() const override { return blob_path; }
+    void setRawPath(const Path & path) override { blob_path = path; }
     const String & getRawURI() const override { return blob_path.path; }
 
     const Paths & getPaths() const override { return blobs_paths; }

--- a/src/Storages/ObjectStorage/HDFS/Configuration.h
+++ b/src/Storages/ObjectStorage/HDFS/Configuration.h
@@ -61,6 +61,7 @@ public:
     /// only by directory.
     /// Therefore in the below methods we use supports_partial_prefix=false.
     Path getRawPath() const override { return path; }
+    void setRawPath(const Path & p) override { path = p; }
     const String & getRawURI() const override { return url; }
 
     const Paths & getPaths() const override { return paths; }

--- a/src/Storages/ObjectStorage/Local/Configuration.h
+++ b/src/Storages/ObjectStorage/Local/Configuration.h
@@ -61,6 +61,7 @@ public:
     std::string getEngineName() const override { return "Local"; }
 
     Path getRawPath() const override { return path; }
+    void setRawPath(const Path & p) override { path = p; }
     const String & getRawURI() const override { return path.path; }
 
     const Paths & getPaths() const override { return paths; }

--- a/src/Storages/ObjectStorage/S3/Configuration.h
+++ b/src/Storages/ObjectStorage/S3/Configuration.h
@@ -105,6 +105,7 @@ public:
     const S3::S3AuthSettings & getAuthSettings() const { return s3_settings->auth_settings; }
 
     Path getRawPath() const override { return url.key; }
+    void setRawPath(const Path & path) override { url.key = path.path; }
     const String & getRawURI() const override { return url.uri_str; }
 
     const Paths & getPaths() const override { return keys; }

--- a/src/Storages/ObjectStorage/StorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorage.cpp
@@ -175,8 +175,16 @@ StorageObjectStorage::StorageObjectStorage(
     if (need_resolve_columns_or_format)
         resolveSchemaAndFormat(columns, configuration->format, object_storage, configuration, format_settings, sample_path, context);
 
-    if (!columns.empty() && configuration->getRawPath().hasSchemaHashWildcard())
+    if (configuration->getRawPath().hasSchemaHashWildcard())
+    {
+        if (configuration->isDataLakeConfiguration())
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "The _schema_hash placeholder is not supported for DataLake engines");
+
+        if (columns.empty())
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Cannot use _schema_hash placeholder without a known schema");
+
         configuration->setSchemaHash(StorageObjectStorageConfiguration::computeSchemaHash(columns));
+    }
 
     configuration->check(context);
 

--- a/src/Storages/ObjectStorage/StorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorage.cpp
@@ -572,7 +572,7 @@ SinkToStoragePtr StorageObjectStorage::write(
                         raw_path.path);
     }
 
-    if (raw_path.hasGlobsIgnorePartitionWildcard())
+    if (raw_path.hasGlobsIgnorePlaceholders())
     {
         throw Exception(ErrorCodes::DATABASE_ACCESS_DENIED,
                         "Non partitioned table with path '{}' that contains globs, the table is in readonly mode",
@@ -643,7 +643,7 @@ void StorageObjectStorage::truncate(
                         "Truncate is not supported for data lake engine");
     }
 
-    if (path.hasGlobs())
+    if (path.hasGlobsIgnorePlaceholders())
     {
         throw Exception(
             ErrorCodes::DATABASE_ACCESS_DENIED,

--- a/src/Storages/ObjectStorage/StorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorage.cpp
@@ -172,19 +172,23 @@ StorageObjectStorage::StorageObjectStorage(
     std::string sample_path;
 
     ColumnsDescription columns{columns_in_table_or_function_definition};
-    if (need_resolve_columns_or_format)
-        resolveSchemaAndFormat(columns, configuration->format, object_storage, configuration, format_settings, sample_path, context);
 
     if (configuration->getRawPath().hasSchemaHashWildcard())
     {
         if (configuration->isDataLakeConfiguration())
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "The _schema_hash placeholder is not supported for DataLake engines");
 
+        if (configuration->partition_strategy_type == PartitionStrategyFactory::StrategyType::HIVE)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "The _schema_hash placeholder is not supported with hive partition strategy");
+
         if (columns.empty())
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Cannot use _schema_hash placeholder without a known schema");
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Cannot use _schema_hash placeholder without explicitly specifying columns");
 
         configuration->setSchemaHash(StorageObjectStorageConfiguration::computeSchemaHash(columns));
     }
+
+    if (need_resolve_columns_or_format)
+        resolveSchemaAndFormat(columns, configuration->format, object_storage, configuration, format_settings, sample_path, context);
 
     configuration->check(context);
 

--- a/src/Storages/ObjectStorage/StorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorage.cpp
@@ -651,6 +651,14 @@ void StorageObjectStorage::truncate(
             getName(), path.path);
     }
 
+    if (path.hasPartitionWildcard())
+    {
+        throw Exception(
+            ErrorCodes::NOT_IMPLEMENTED,
+            "Truncate is not supported for partitioned tables, the path is '{}'",
+            path.path);
+    }
+
     StoredObjects objects;
     for (const auto & key : configuration->getPaths())
     {

--- a/src/Storages/ObjectStorage/StorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorage.cpp
@@ -175,6 +175,9 @@ StorageObjectStorage::StorageObjectStorage(
     if (need_resolve_columns_or_format)
         resolveSchemaAndFormat(columns, configuration->format, object_storage, configuration, format_settings, sample_path, context);
 
+    if (!columns.empty() && configuration->getRawPath().hasSchemaHashWildcard())
+        configuration->setSchemaHash(StorageObjectStorageConfiguration::computeSchemaHash(columns));
+
     configuration->check(context);
 
     /// FIXME: We need to call getPathSample() lazily on select

--- a/src/Storages/ObjectStorage/StorageObjectStorageConfiguration.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageConfiguration.cpp
@@ -163,7 +163,8 @@ void StorageObjectStorageConfiguration::setSchemaHash(const String & hash)
     schema_hash = hash;
     boost::replace_all(read_path.path, SCHEMA_HASH_WILDCARD, schema_hash);
 
-    chassert(getPaths().size() == 1);
+    if (getPaths().size() != 1)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Expected exactly one path when setting schema hash, got {}", getPaths().size());
     auto path = getRawPath();
     boost::replace_all(path.path, SCHEMA_HASH_WILDCARD, schema_hash);
     setPaths({path});

--- a/src/Storages/ObjectStorage/StorageObjectStorageConfiguration.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageConfiguration.cpp
@@ -167,6 +167,7 @@ void StorageObjectStorageConfiguration::setSchemaHash(const String & hash)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Expected exactly one path when setting schema hash, got {}", getPaths().size());
     auto path = getRawPath();
     boost::replace_all(path.path, SCHEMA_HASH_WILDCARD, schema_hash);
+    setRawPath(path);
     setPaths({path});
 }
 
@@ -178,7 +179,7 @@ void StorageObjectStorageConfiguration::initPartitionStrategy(ASTPtr partition_b
         columns.getOrdinary(),
         context,
         format,
-        getRawPath().hasGlobs(),
+        getRawPath().hasGlobsIgnorePlaceholders(),
         getRawPath().hasPartitionWildcard(),
         partition_columns_in_data_file);
 
@@ -220,7 +221,7 @@ bool StorageObjectStorageConfiguration::Path::hasSchemaHashWildcard() const
     return path.find(StorageObjectStorageConfiguration::SCHEMA_HASH_WILDCARD) != String::npos;
 }
 
-bool StorageObjectStorageConfiguration::Path::hasGlobsIgnorePartitionWildcard() const
+bool StorageObjectStorageConfiguration::Path::hasGlobsIgnorePlaceholders() const
 {
     if (!hasPartitionWildcard() && !hasSchemaHashWildcard())
         return hasGlobs();

--- a/src/Storages/ObjectStorage/StorageObjectStorageConfiguration.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageConfiguration.cpp
@@ -6,8 +6,12 @@
 #include <Storages/ObjectStorage/StorageObjectStorageSink.h>
 #include <Interpreters/Context.h>
 #include <Common/logger_useful.h>
+#include <Common/SipHash.h>
 #include <Core/Settings.h>
+#include <Storages/ColumnsDescription.h>
 #include <Storages/ObjectStorage/Common.h>
+
+#include <boost/algorithm/string/replace.hpp>
 
 namespace DB
 {
@@ -146,6 +150,25 @@ void StorageObjectStorageConfiguration::initialize(
     configuration_to_initialize.initialized = true;
 }
 
+String StorageObjectStorageConfiguration::computeSchemaHash(const ColumnsDescription & columns)
+{
+    SipHash hash;
+    auto columns_str = columns.getAllPhysical().toString();
+    hash.update(columns_str.data(), columns_str.size());
+    return getSipHash128AsHexString(hash);
+}
+
+void StorageObjectStorageConfiguration::setSchemaHash(const String & hash)
+{
+    schema_hash = hash;
+    boost::replace_all(read_path.path, SCHEMA_HASH_WILDCARD, schema_hash);
+
+    chassert(getPaths().size() == 1);
+    auto path = getRawPath();
+    boost::replace_all(path.path, SCHEMA_HASH_WILDCARD, schema_hash);
+    setPaths({path});
+}
+
 void StorageObjectStorageConfiguration::initPartitionStrategy(ASTPtr partition_by, const ColumnsDescription & columns, ContextPtr context)
 {
     partition_strategy = PartitionStrategyFactory::get(
@@ -174,6 +197,9 @@ StorageObjectStorageConfiguration::Path StorageObjectStorageConfiguration::getPa
 {
     auto raw_path = getRawPath();
 
+    if (!schema_hash.empty())
+        boost::replace_all(raw_path.path, SCHEMA_HASH_WILDCARD, schema_hash);
+
     if (!partition_strategy)
     {
         return raw_path;
@@ -188,11 +214,18 @@ bool StorageObjectStorageConfiguration::Path::hasPartitionWildcard() const
     return path.find(PARTITION_ID_WILDCARD) != String::npos;
 }
 
+bool StorageObjectStorageConfiguration::Path::hasSchemaHashWildcard() const
+{
+    return path.find(StorageObjectStorageConfiguration::SCHEMA_HASH_WILDCARD) != String::npos;
+}
+
 bool StorageObjectStorageConfiguration::Path::hasGlobsIgnorePartitionWildcard() const
 {
-    if (!hasPartitionWildcard())
+    if (!hasPartitionWildcard() && !hasSchemaHashWildcard())
         return hasGlobs();
-    return PartitionedSink::replaceWildcards(path, "").find_first_of("*?{") != std::string::npos;
+    String cleaned = PartitionedSink::replaceWildcards(path, "");
+    boost::replace_all(cleaned, StorageObjectStorageConfiguration::SCHEMA_HASH_WILDCARD, "");
+    return cleaned.find_first_of("*?{") != std::string::npos;
 }
 
 bool StorageObjectStorageConfiguration::Path::hasGlobs() const

--- a/src/Storages/ObjectStorage/StorageObjectStorageConfiguration.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorageConfiguration.h
@@ -75,7 +75,7 @@ public:
 
         bool hasPartitionWildcard() const;
         bool hasSchemaHashWildcard() const;
-        bool hasGlobsIgnorePartitionWildcard() const;
+        bool hasGlobsIgnorePlaceholders() const;
         bool hasGlobs() const;
         std::string cutGlobs(bool supports_partial_prefix) const;
     };
@@ -102,6 +102,7 @@ public:
 
     // Path provided by the user in the query
     virtual Path getRawPath() const = 0;
+    virtual void setRawPath(const Path & path) = 0;
 
     /// Raw URI, specified by a user. Used in permission check.
     virtual const String & getRawURI() const = 0;

--- a/src/Storages/ObjectStorage/StorageObjectStorageConfiguration.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorageConfiguration.h
@@ -100,7 +100,7 @@ public:
     virtual std::string getNamespaceType() const { return "namespace"; }
 
 
-    // Path provided by the user in the query
+    /// Base path for the object key. May be modified after construction by placeholder resolution.
     virtual Path getRawPath() const = 0;
     virtual void setRawPath(const Path & path) = 0;
 

--- a/src/Storages/ObjectStorage/StorageObjectStorageConfiguration.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorageConfiguration.h
@@ -62,6 +62,8 @@ public:
     StorageObjectStorageConfiguration() = default;
     virtual ~StorageObjectStorageConfiguration() = default;
 
+    static constexpr auto SCHEMA_HASH_WILDCARD = "{_schema_hash}";
+
     struct Path
     {
         Path() = default;
@@ -72,6 +74,7 @@ public:
         std::string path;
 
         bool hasPartitionWildcard() const;
+        bool hasSchemaHashWildcard() const;
         bool hasGlobsIgnorePartitionWildcard() const;
         bool hasGlobs() const;
         std::string cutGlobs(bool supports_partial_prefix) const;
@@ -175,6 +178,9 @@ public:
         bool supports_tuple_elements,
         ContextPtr local_context,
         const PrepareReadingFromFormatHiveParams & hive_parameters);
+
+    static String computeSchemaHash(const ColumnsDescription & columns);
+    void setSchemaHash(const String & hash);
 
     void initPartitionStrategy(ASTPtr partition_by, const ColumnsDescription & columns, ContextPtr context);
 
@@ -295,6 +301,7 @@ protected:
     void assertInitialized() const;
 
     bool initialized = false;
+    String schema_hash;
 
 private:
     // Path used for reading, by default it is the same as `getRawPath`

--- a/tests/queries/0_stateless/02480_s3_support_wildcard.reference
+++ b/tests/queries/0_stateless/02480_s3_support_wildcard.reference
@@ -39,5 +39,7 @@ select a, b from s3(s3_conn, filename='prefi?/test_02480_support_wildcard_*', fo
 666	g
 select a, b from s3(s3_conn, filename='p?*/test_02480_support_wildcard_{56..666}', format=Parquet) order by a;
 666	g
+-- Truncate should fail for partitioned tables with {_partition_id}, not silently succeed
+truncate table test_02480_support_wildcard_write; -- { serverError NOT_IMPLEMENTED }
 drop table test_02480_support_wildcard_write;
 drop table test_02480_support_wildcard_write2;

--- a/tests/queries/0_stateless/02480_s3_support_wildcard.sql
+++ b/tests/queries/0_stateless/02480_s3_support_wildcard.sql
@@ -25,5 +25,8 @@ select a, b from s3(s3_conn, filename='prefix/test_02480_support_wildcard_??', f
 select a, b from s3(s3_conn, filename='prefi?/test_02480_support_wildcard_*', format=Parquet) order by a;
 select a, b from s3(s3_conn, filename='p?*/test_02480_support_wildcard_{56..666}', format=Parquet) order by a;
 
+-- Truncate should fail for partitioned tables with {_partition_id}, not silently succeed
+truncate table test_02480_support_wildcard_write; -- { serverError NOT_IMPLEMENTED }
+
 drop table test_02480_support_wildcard_write;
 drop table test_02480_support_wildcard_write2;

--- a/tests/queries/0_stateless/04004_s3_schema_hash.reference
+++ b/tests/queries/0_stateless/04004_s3_schema_hash.reference
@@ -12,7 +12,7 @@ select a, b from test_04004_hash_write order by a;
 -- Test 2: Different schema, same base path pattern — writes to a different directory due to different hash
 create table test_04004_hash_write2 (x Float64) engine = S3(s3_conn, filename='test_04004/{_schema_hash}/data.parquet', format=Parquet);
 insert into test_04004_hash_write2 values (3.14), (2.72);
-select x from test_04004_hash_write2 order by x;
+select round(x, 2) from test_04004_hash_write2 order by x;
 2.72
 3.14
 -- Verify first table still reads only its own data (not cross-contaminated)
@@ -22,7 +22,7 @@ select a, b from test_04004_hash_write order by a;
 -- Test 3: Combined {_schema_hash} and {_partition_id} — write via table, read via s3() glob
 create table test_04004_hash_partitioned (a UInt64, b String) engine = S3(s3_conn, filename='test_04004/{_schema_hash}/{_partition_id}/data.parquet', format=Parquet) partition by a;
 insert into test_04004_hash_partitioned values (1, 'foo'), (2, 'bar'), (3, 'baz');
-select a, b from s3(s3_conn, filename='test_04004/*/data.parquet', format=Parquet) order by a;
+select a, b from s3(s3_conn, filename='test_04004/*/*/data.parquet', format=Parquet) order by a;
 1	foo
 2	bar
 3	baz

--- a/tests/queries/0_stateless/04004_s3_schema_hash.reference
+++ b/tests/queries/0_stateless/04004_s3_schema_hash.reference
@@ -32,7 +32,7 @@ create table test_04004_hash_no_schema engine = S3(s3_conn, filename='test_04004
 create table test_04004_hash_hive (a UInt64, b String) engine = S3(s3_conn, filename='test_04004/{_schema_hash}/data.parquet', format=Parquet, partition_strategy='hive') partition by a; -- { serverError BAD_ARGUMENTS }
 -- Test 6: Truncate should work with {_schema_hash}
 truncate table test_04004_hash_write;
-select count() from test_04004_hash_write;
+select count() from test_04004_hash_write settings s3_ignore_file_doesnt_exist=1;
 0
 drop table test_04004_hash_write;
 drop table test_04004_hash_write2;

--- a/tests/queries/0_stateless/04004_s3_schema_hash.reference
+++ b/tests/queries/0_stateless/04004_s3_schema_hash.reference
@@ -26,6 +26,14 @@ select a, b from s3(s3_conn, filename='test_04004/*/*/data.parquet', format=Parq
 1	foo
 2	bar
 3	baz
+-- Test 4: Error when using {_schema_hash} without specifying columns
+create table test_04004_hash_no_schema engine = S3(s3_conn, filename='test_04004/{_schema_hash}/data.parquet', format=Parquet); -- { serverError BAD_ARGUMENTS }
+-- Test 5: Error when combining {_schema_hash} with hive partition strategy
+create table test_04004_hash_hive (a UInt64, b String) engine = S3(s3_conn, filename='test_04004/{_schema_hash}/data.parquet', format=Parquet, partition_strategy='hive') partition by a; -- { serverError BAD_ARGUMENTS }
+-- Test 6: Truncate should work with {_schema_hash}
+truncate table test_04004_hash_write;
+select count() from test_04004_hash_write;
+0
 drop table test_04004_hash_write;
 drop table test_04004_hash_write2;
 drop table test_04004_hash_partitioned;

--- a/tests/queries/0_stateless/04004_s3_schema_hash.reference
+++ b/tests/queries/0_stateless/04004_s3_schema_hash.reference
@@ -34,6 +34,8 @@ create table test_04004_hash_hive (a UInt64, b String) engine = S3(s3_conn, file
 truncate table test_04004_hash_write;
 select count() from test_04004_hash_write settings s3_ignore_file_doesnt_exist=1;
 0
+-- Test 7: Truncate should fail for combined {_schema_hash} + {_partition_id}
+truncate table test_04004_hash_partitioned; -- { serverError NOT_IMPLEMENTED }
 drop table test_04004_hash_write;
 drop table test_04004_hash_write2;
 drop table test_04004_hash_partitioned;

--- a/tests/queries/0_stateless/04004_s3_schema_hash.reference
+++ b/tests/queries/0_stateless/04004_s3_schema_hash.reference
@@ -1,0 +1,27 @@
+-- { echo }
+drop table if exists test_04004_hash_write;
+drop table if exists test_04004_hash_write2;
+drop table if exists test_04004_hash_partitioned;
+create table test_04004_hash_write (a UInt64, b String) engine = S3(s3_conn, filename='test_04004/{_schema_hash}/data.parquet', format=Parquet);
+set s3_truncate_on_insert=1;
+insert into test_04004_hash_write values (1, 'hello'), (2, 'world');
+select a, b from test_04004_hash_write order by a;
+1	hello
+2	world
+create table test_04004_hash_write2 (x Float64) engine = S3(s3_conn, filename='test_04004/{_schema_hash}/data.parquet', format=Parquet);
+insert into test_04004_hash_write2 values (3.14), (2.72);
+select x from test_04004_hash_write2 order by x;
+2.72
+3.14
+select a, b from test_04004_hash_write order by a;
+1	hello
+2	world
+create table test_04004_hash_partitioned (a UInt64, b String) engine = S3(s3_conn, filename='test_04004/{_schema_hash}/{_partition_id}/data.parquet', format=Parquet) partition by a;
+insert into test_04004_hash_partitioned values (1, 'foo'), (2, 'bar'), (3, 'baz');
+select a, b from s3(s3_conn, filename='test_04004/*/data.parquet', format=Parquet) order by a;
+1	foo
+2	bar
+3	baz
+drop table test_04004_hash_write;
+drop table test_04004_hash_write2;
+drop table test_04004_hash_partitioned;

--- a/tests/queries/0_stateless/04004_s3_schema_hash.reference
+++ b/tests/queries/0_stateless/04004_s3_schema_hash.reference
@@ -2,20 +2,24 @@
 drop table if exists test_04004_hash_write;
 drop table if exists test_04004_hash_write2;
 drop table if exists test_04004_hash_partitioned;
+-- Test 1: Basic write and read via table with {_schema_hash}
 create table test_04004_hash_write (a UInt64, b String) engine = S3(s3_conn, filename='test_04004/{_schema_hash}/data.parquet', format=Parquet);
 set s3_truncate_on_insert=1;
 insert into test_04004_hash_write values (1, 'hello'), (2, 'world');
 select a, b from test_04004_hash_write order by a;
 1	hello
 2	world
+-- Test 2: Different schema, same base path pattern — writes to a different directory due to different hash
 create table test_04004_hash_write2 (x Float64) engine = S3(s3_conn, filename='test_04004/{_schema_hash}/data.parquet', format=Parquet);
 insert into test_04004_hash_write2 values (3.14), (2.72);
 select x from test_04004_hash_write2 order by x;
 2.72
 3.14
+-- Verify first table still reads only its own data (not cross-contaminated)
 select a, b from test_04004_hash_write order by a;
 1	hello
 2	world
+-- Test 3: Combined {_schema_hash} and {_partition_id} — write via table, read via s3() glob
 create table test_04004_hash_partitioned (a UInt64, b String) engine = S3(s3_conn, filename='test_04004/{_schema_hash}/{_partition_id}/data.parquet', format=Parquet) partition by a;
 insert into test_04004_hash_partitioned values (1, 'foo'), (2, 'bar'), (3, 'baz');
 select a, b from s3(s3_conn, filename='test_04004/*/data.parquet', format=Parquet) order by a;

--- a/tests/queries/0_stateless/04004_s3_schema_hash.sql
+++ b/tests/queries/0_stateless/04004_s3_schema_hash.sql
@@ -25,6 +25,12 @@ create table test_04004_hash_partitioned (a UInt64, b String) engine = S3(s3_con
 insert into test_04004_hash_partitioned values (1, 'foo'), (2, 'bar'), (3, 'baz');
 select a, b from s3(s3_conn, filename='test_04004/*/*/data.parquet', format=Parquet) order by a;
 
+-- Test 4: Error when using {_schema_hash} without specifying columns
+create table test_04004_hash_no_schema engine = S3(s3_conn, filename='test_04004/{_schema_hash}/data.parquet', format=Parquet); -- { serverError BAD_ARGUMENTS }
+
+-- Test 5: Error when combining {_schema_hash} with hive partition strategy
+create table test_04004_hash_hive (a UInt64, b String) engine = S3(s3_conn, filename='test_04004/{_schema_hash}/data.parquet', format=Parquet, partition_strategy='hive') partition by a; -- { serverError BAD_ARGUMENTS }
+
 drop table test_04004_hash_write;
 drop table test_04004_hash_write2;
 drop table test_04004_hash_partitioned;

--- a/tests/queries/0_stateless/04004_s3_schema_hash.sql
+++ b/tests/queries/0_stateless/04004_s3_schema_hash.sql
@@ -31,6 +31,10 @@ create table test_04004_hash_no_schema engine = S3(s3_conn, filename='test_04004
 -- Test 5: Error when combining {_schema_hash} with hive partition strategy
 create table test_04004_hash_hive (a UInt64, b String) engine = S3(s3_conn, filename='test_04004/{_schema_hash}/data.parquet', format=Parquet, partition_strategy='hive') partition by a; -- { serverError BAD_ARGUMENTS }
 
+-- Test 6: Truncate should work with {_schema_hash}
+truncate table test_04004_hash_write;
+select count() from test_04004_hash_write;
+
 drop table test_04004_hash_write;
 drop table test_04004_hash_write2;
 drop table test_04004_hash_partitioned;

--- a/tests/queries/0_stateless/04004_s3_schema_hash.sql
+++ b/tests/queries/0_stateless/04004_s3_schema_hash.sql
@@ -15,7 +15,7 @@ select a, b from test_04004_hash_write order by a;
 -- Test 2: Different schema, same base path pattern — writes to a different directory due to different hash
 create table test_04004_hash_write2 (x Float64) engine = S3(s3_conn, filename='test_04004/{_schema_hash}/data.parquet', format=Parquet);
 insert into test_04004_hash_write2 values (3.14), (2.72);
-select x from test_04004_hash_write2 order by x;
+select round(x, 2) from test_04004_hash_write2 order by x;
 
 -- Verify first table still reads only its own data (not cross-contaminated)
 select a, b from test_04004_hash_write order by a;
@@ -23,7 +23,7 @@ select a, b from test_04004_hash_write order by a;
 -- Test 3: Combined {_schema_hash} and {_partition_id} — write via table, read via s3() glob
 create table test_04004_hash_partitioned (a UInt64, b String) engine = S3(s3_conn, filename='test_04004/{_schema_hash}/{_partition_id}/data.parquet', format=Parquet) partition by a;
 insert into test_04004_hash_partitioned values (1, 'foo'), (2, 'bar'), (3, 'baz');
-select a, b from s3(s3_conn, filename='test_04004/*/data.parquet', format=Parquet) order by a;
+select a, b from s3(s3_conn, filename='test_04004/*/*/data.parquet', format=Parquet) order by a;
 
 drop table test_04004_hash_write;
 drop table test_04004_hash_write2;

--- a/tests/queries/0_stateless/04004_s3_schema_hash.sql
+++ b/tests/queries/0_stateless/04004_s3_schema_hash.sql
@@ -33,7 +33,7 @@ create table test_04004_hash_hive (a UInt64, b String) engine = S3(s3_conn, file
 
 -- Test 6: Truncate should work with {_schema_hash}
 truncate table test_04004_hash_write;
-select count() from test_04004_hash_write;
+select count() from test_04004_hash_write settings s3_ignore_file_doesnt_exist=1;
 
 drop table test_04004_hash_write;
 drop table test_04004_hash_write2;

--- a/tests/queries/0_stateless/04004_s3_schema_hash.sql
+++ b/tests/queries/0_stateless/04004_s3_schema_hash.sql
@@ -35,6 +35,9 @@ create table test_04004_hash_hive (a UInt64, b String) engine = S3(s3_conn, file
 truncate table test_04004_hash_write;
 select count() from test_04004_hash_write settings s3_ignore_file_doesnt_exist=1;
 
+-- Test 7: Truncate should fail for combined {_schema_hash} + {_partition_id}
+truncate table test_04004_hash_partitioned; -- { serverError NOT_IMPLEMENTED }
+
 drop table test_04004_hash_write;
 drop table test_04004_hash_write2;
 drop table test_04004_hash_partitioned;

--- a/tests/queries/0_stateless/04004_s3_schema_hash.sql
+++ b/tests/queries/0_stateless/04004_s3_schema_hash.sql
@@ -1,0 +1,30 @@
+-- Tags: no-parallel, no-fasttest
+-- Tag no-fasttest: Depends on AWS
+
+-- { echo }
+drop table if exists test_04004_hash_write;
+drop table if exists test_04004_hash_write2;
+drop table if exists test_04004_hash_partitioned;
+
+-- Test 1: Basic write and read via table with {_schema_hash}
+create table test_04004_hash_write (a UInt64, b String) engine = S3(s3_conn, filename='test_04004/{_schema_hash}/data.parquet', format=Parquet);
+set s3_truncate_on_insert=1;
+insert into test_04004_hash_write values (1, 'hello'), (2, 'world');
+select a, b from test_04004_hash_write order by a;
+
+-- Test 2: Different schema, same base path pattern — writes to a different directory due to different hash
+create table test_04004_hash_write2 (x Float64) engine = S3(s3_conn, filename='test_04004/{_schema_hash}/data.parquet', format=Parquet);
+insert into test_04004_hash_write2 values (3.14), (2.72);
+select x from test_04004_hash_write2 order by x;
+
+-- Verify first table still reads only its own data (not cross-contaminated)
+select a, b from test_04004_hash_write order by a;
+
+-- Test 3: Combined {_schema_hash} and {_partition_id} — write via table, read via s3() glob
+create table test_04004_hash_partitioned (a UInt64, b String) engine = S3(s3_conn, filename='test_04004/{_schema_hash}/{_partition_id}/data.parquet', format=Parquet) partition by a;
+insert into test_04004_hash_partitioned values (1, 'foo'), (2, 'bar'), (3, 'baz');
+select a, b from s3(s3_conn, filename='test_04004/*/data.parquet', format=Parquet) order by a;
+
+drop table test_04004_hash_write;
+drop table test_04004_hash_write2;
+drop table test_04004_hash_partitioned;


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add a `{_schema_hash}` placeholder for the S3 table engine that inserts a hash of the table's column definitions into the S3 path.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core object-storage path resolution (including glob/placeholder detection) and changes `TRUNCATE` behavior for partitioned paths, which could affect existing S3/Azure/HDFS/Local table configurations at runtime.
> 
> **Overview**
> Adds support for a new `{_schema_hash}` placeholder in object-storage paths, computing a SipHash from the table’s physical column definitions and substituting it into the configured read/write paths (rejecting use without explicit columns, with DataLake engines, or with `partition_strategy='hive'`).
> 
> Updates configuration implementations (S3/Azure/HDFS/Local) to allow mutating the raw path after initialization, refines glob detection to ignore `{_partition_id}`/`{_schema_hash}` placeholders, and makes `TRUNCATE` explicitly fail for partitioned tables (paths containing `{_partition_id}`) instead of silently succeeding. Tests are extended to cover the new placeholder, validation errors, and the updated truncate semantics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b46f0a1e3389fb0394fea2f18cc7a80b8d2a115. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.581`
<!-- ch-version-info:end -->