### PR TITLE
Doc improvement `input_format_max_block_wait_ms`

### DIFF
--- a/src/Core/FormatFactorySettings.h
+++ b/src/Core/FormatFactorySettings.h
@@ -1531,18 +1531,17 @@ For streaming inserts, you must also set `min_insert_block_size_rows=0` and `min
 
 **Example: streaming Wikipedia recent changes into ClickHouse**
 
-```sql
-clickhouse-client --query "CREATE TABLE wikipedia_edits (data JSON)"
+```bash
+clickhouse-client --query 'CREATE TABLE wikipedia_edits (data JSON)'
 
 curl -sS --globoff -H 'Accept: application/json' --no-buffer \
-  "https://stream.wikimedia.org/v2/stream/recentchange" \
+  'https://stream.wikimedia.org/v2/stream/recentchange' \
   | clickhouse-client \
-      --query "INSERT INTO wikipedia_edits FORMAT JSONAsObject" \
+      --query 'INSERT INTO wikipedia_edits FORMAT JSONAsObject' \
       --input_format_max_block_wait_ms 1000 \
       --input_format_connection_handling 1 \
       --min_insert_block_size_rows 0 \
       --min_insert_block_size_bytes 0
-```
 )", 0) \
     DECLARE(Bool, input_format_connection_handling, false, R"(
     When this option is enabled, if the connection closes unexpectedly, any remaining data in the buffer will be parsed and processed instead of being treated as an error

--- a/src/Core/FormatFactorySettings.h
+++ b/src/Core/FormatFactorySettings.h
@@ -1543,7 +1543,6 @@ curl -sS --globoff -H 'Accept: application/json' --no-buffer \
       --min_insert_block_size_rows 0 \
       --min_insert_block_size_bytes 0
 ```
-
 )", 0) \
     DECLARE(Bool, input_format_connection_handling, false, R"(
     When this option is enabled, if the connection closes unexpectedly, any remaining data in the buffer will be parsed and processed instead of being treated as an error

--- a/src/Core/FormatFactorySettings.h
+++ b/src/Core/FormatFactorySettings.h
@@ -1542,6 +1542,7 @@ curl -sS --globoff -H 'Accept: application/json' --no-buffer \
       --input_format_connection_handling 1 \
       --min_insert_block_size_rows 0 \
       --min_insert_block_size_bytes 0
+```
 )", 0) \
     DECLARE(Bool, input_format_connection_handling, false, R"(
     When this option is enabled, if the connection closes unexpectedly, any remaining data in the buffer will be parsed and processed instead of being treated as an error

--- a/src/Core/FormatFactorySettings.h
+++ b/src/Core/FormatFactorySettings.h
@@ -1524,6 +1524,26 @@ Limits the maximum time in milliseconds to wait before emitting a block during p
 :::note
 This option only works if `input_format_connection_handling` is enabled. Setting a value also disables parallel parsing and makes deduplication impossible.
 :::
+
+:::note
+For streaming inserts, you must also set `min_insert_block_size_rows=0` and `min_insert_block_size_bytes=0`. Otherwise, parsed blocks may still be accumulated in memory by the block squashing stage until those thresholds are reached, preventing timely inserts.
+:::
+
+**Example: streaming Wikipedia recent changes into ClickHouse**
+
+```sql
+clickhouse-client --query "CREATE TABLE wikipedia_edits (data JSON)"
+
+curl -sS --globoff -H 'Accept: application/json' --no-buffer \
+  "https://stream.wikimedia.org/v2/stream/recentchange" \
+  | clickhouse-client \
+      --query "INSERT INTO wikipedia_edits FORMAT JSONAsObject" \
+      --input_format_max_block_wait_ms 1000 \
+      --input_format_connection_handling 1 \
+      --min_insert_block_size_rows 0 \
+      --min_insert_block_size_bytes 0
+```
+
 )", 0) \
     DECLARE(Bool, input_format_connection_handling, false, R"(
     When this option is enabled, if the connection closes unexpectedly, any remaining data in the buffer will be parsed and processed instead of being treated as an error


### PR DESCRIPTION
### Changelog category (leave one):

- Documentation (changelog entry is not required)



### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.307`
<!-- ch-version-info:end -->