### PR TITLE
Include error message in HTTP 400 response body

### DIFF
--- a/src/Server/HTTP/HTTPServerConnection.h
+++ b/src/Server/HTTP/HTTPServerConnection.h
@@ -40,7 +40,7 @@ public:
     void run() override;
 
 protected:
-    static void sendErrorResponse(Poco::Net::HTTPServerSession & session, Poco::Net::HTTPResponse::HTTPStatus status);
+    static void sendErrorResponse(Poco::Net::HTTPServerSession & session, Poco::Net::HTTPResponse::HTTPStatus status, const std::string & message = {});
 
 private:
     HTTPContextPtr context;

--- a/tests/queries/0_stateless/04004_http_malformed_headers_error_message.reference
+++ b/tests/queries/0_stateless/04004_http_malformed_headers_error_message.reference
@@ -1,0 +1,1 @@
+No CRLF found

--- a/tests/queries/0_stateless/04004_http_malformed_headers_error_message.sh
+++ b/tests/queries/0_stateless/04004_http_malformed_headers_error_message.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# Test that malformed HTTP headers return 400 with an error message in the body,
+# not just an empty response. https://github.com/ClickHouse/ClickHouse/issues/98250
+#
+# We send a raw HTTP request with a bare \n (instead of \r\n) inside a header value.
+# curl cannot be used here because it normalizes headers.
+
+python3 -c "
+import socket
+
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.settimeout(5)
+s.connect(('${CLICKHOUSE_HOST}', ${CLICKHOUSE_PORT_HTTP}))
+# Note: the header 'X-Test: bad\nY: value' contains a bare LF, which is invalid HTTP.
+s.sendall(b'GET /?query=SELECT+1 HTTP/1.1\r\nHost: localhost\r\nX-Test: bad\nY: value\r\n\r\n')
+
+data = b''
+while True:
+    try:
+        chunk = s.recv(4096)
+        if not chunk:
+            break
+        data += chunk
+    except socket.timeout:
+        break
+s.close()
+
+# The response body (after the empty line) should contain the error message.
+body = data.split(b'\r\n\r\n', 1)[1] if b'\r\n\r\n' in data else b''
+print(body.decode())
+"


### PR DESCRIPTION
## Summary
- When the HTTP server received a malformed request (e.g. bare LF in headers), it returned `400 Bad Request` with an empty body, providing no explanation to the client.
- Now `sendErrorResponse` includes the parser error message (e.g. "No CRLF found", "Field name is too long") as a `text/plain` response body with proper `Content-Length`.

Closes https://github.com/ClickHouse/ClickHouse/issues/98250

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
HTTP server now returns an error message in the response body for 400 Bad Request responses caused by malformed headers, instead of an empty body.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

No documentation needed — this is a minor behavior fix that makes error responses more informative.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.134`
<!-- ch-version-info:end -->