### PR TITLE
Use min_size instead of max_single_size for first write buffer

### DIFF
--- a/src/Common/BufferAllocationPolicy.cpp
+++ b/src/Common/BufferAllocationPolicy.cpp
@@ -48,7 +48,7 @@ class ExpBufferAllocationPolicy : public DB::BufferAllocationPolicy
 
 public:
     explicit ExpBufferAllocationPolicy(const BufferAllocationPolicy::Settings & settings_)
-        : first_size(std::max(settings_.max_single_size, settings_.min_size))
+        : first_size(settings_.min_size)
         , second_size(settings_.min_size)
         , multiply_factor(settings_.multiply_factor)
         , multiply_threshold(settings_.multiply_parts_count_threshold)


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Reduce initial write buffer size for object storage (S3/GCS/Azure) from 32 MiB to 16 MiB, halving baseline memory usage for concurrent part writes.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

No user-facing setting changes. Internal buffer allocation strategy adjusted.

---

## Summary
- Change `ExpBufferAllocationPolicy` to use `min_size` (16 MiB) instead of `max(max_single_size, min_size)` (32 MiB) for the first buffer

## Motivation
Every object storage write stream starts with a 32 MiB buffer regardless of data size. With 16 concurrent part writes, baseline is 512 MiB. Starting at 16 MiB halves this. Exponential growth still applies for large writes.