### PR TITLE
Lazy-init subcolumns_sizes_cache to reduce per-part memory overhead

### DIFF
--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -2715,13 +2715,19 @@ const IMergeTreeDataPart::ColumnSizeByName & IMergeTreeDataPart::getColumnSizes(
 
 ColumnSize IMergeTreeDataPart::getSubcolumnSize(const String & subcolumn_name) const
 {
+    /// Lazy-init: only allocate the LRU cache on first use (typically only needed
+    /// for tables with dynamic JSON subcolumns). Avoids per-part overhead for the
+    /// common case where subcolumn size lookups never happen.
+    if (!subcolumns_sizes_cache)
+        subcolumns_sizes_cache = std::make_unique<Poco::LRUCache<String, ColumnSize>>(1024);
+
     /// First, check if we already calculated the size of this subcolumn and have it in cache.
-    if (auto size = subcolumns_sizes_cache.get(subcolumn_name))
+    if (auto size = subcolumns_sizes_cache->get(subcolumn_name))
         return *size;
 
     /// If not, calculate the size of the subcolumn on disk and put it to cache.
     auto size = calculateSubcolumnSize(subcolumn_name);
-    subcolumns_sizes_cache.add(subcolumn_name, size);
+    subcolumns_sizes_cache->add(subcolumn_name, size);
     return size;
 }
 

--- a/src/Storages/MergeTree/IMergeTreeDataPart.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.h
@@ -681,7 +681,7 @@ private:
     /// Sometimes we need to calculate the size of all files required to read a specific subcolumn.
     /// We do it on the first request and save it in the subcolumns_sizes_cache.
     /// The number of subcolumns can be infinite due to dynamic subcolumns in JSON, so we use LRU cache here.
-    mutable Poco::LRUCache<String, ColumnSize> subcolumns_sizes_cache = Poco::LRUCache<String, ColumnSize>(1024);
+    mutable std::unique_ptr<Poco::LRUCache<String, ColumnSize>> subcolumns_sizes_cache;
 
     /// PackedFilesReader for statistics archive.
     /// Lazily loaded on first access to loadStatistics when packed format is used.


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Lazy-initialize per-part subcolumns_sizes_cache to avoid unnecessary memory allocation for tables without dynamic JSON subcolumns.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

No user-facing changes. Internal memory optimization.

---

## Summary
- Replace unconditional `Poco::LRUCache<String, ColumnSize>(1024)` in `IMergeTreeDataPart` with lazy-initialized `std::unique_ptr`

## Motivation
Every data part allocated this cache unconditionally, even without JSON columns. With 50,000+ parts, this wastes ~15-50 MiB. Deferring allocation to first use eliminates overhead for the common case.