### PR TITLE
Fix WriteBuffer exception in AST fuzzer for pushing pipelines

### DIFF
--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -2034,12 +2034,20 @@ static void executeASTFuzzerQueries(const ASTPtr & ast, const ContextMutablePtr 
 
             if (result.second.pipeline.initialized())
             {
-                if (result.second.pipeline.pulling())
+                if (result.second.pipeline.pushing())
                 {
-                    result.second.pipeline.complete(std::make_shared<NullOutputFormat>(std::make_shared<const Block>(result.second.pipeline.getHeader())));
+                    /// Cannot execute pushing pipelines (e.g. INSERT) without providing input data, just cancel.
+                    result.second.pipeline.cancel();
                 }
-                CompletedPipelineExecutor executor(result.second.pipeline);
-                executor.execute();
+                else
+                {
+                    if (result.second.pipeline.pulling())
+                    {
+                        result.second.pipeline.complete(std::make_shared<NullOutputFormat>(std::make_shared<const Block>(result.second.pipeline.getHeader())));
+                    }
+                    CompletedPipelineExecutor executor(result.second.pipeline);
+                    executor.execute();
+                }
             }
 
             base_ast = fuzzed_ast;


### PR DESCRIPTION
## Summary
- Fix `SetOrJoinSink` exception found in the stress test with the AST fuzzer enabled (PR #98138)
- The AST fuzzer generates INSERT queries (pushing pipelines) and attempted to execute them without providing input data, causing `SetOrJoinSink` to be destroyed with its write buffers neither finalized nor cancelled
- Cancel pushing pipelines in `executeASTFuzzerQueries` instead of trying to execute them
- Lazily initialize backup write buffers in `SetOrJoinSink` on first `consume` call, so no buffers exist when the sink is never used

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=98138&sha=f6eac0762f9799ea48b8e800ef4d22b08c29b699&name_0=PR&name_1=Stress%20test%20%28arm_asan%29
https://github.com/ClickHouse/ClickHouse/pull/98138

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.138`
<!-- ch-version-info:end -->