### PR TITLE
add setCurrentComponent in MergePlainMergeTreeTask

### DIFF
--- a/src/Storages/MergeTree/MergePlainMergeTreeTask.cpp
+++ b/src/Storages/MergeTree/MergePlainMergeTreeTask.cpp
@@ -193,6 +193,7 @@ void MergePlainMergeTreeTask::finish()
 
 void MergePlainMergeTreeTask::cancel() noexcept
 {
+    auto component_guard = Coordination::setCurrentComponent("MutatePlainMergeTreeTask::cancel");
     if (merge_task)
         merge_task->cancel();
 

--- a/src/Storages/MergeTree/MergePlainMergeTreeTask.cpp
+++ b/src/Storages/MergeTree/MergePlainMergeTreeTask.cpp
@@ -8,6 +8,7 @@
 #include <Common/ProfileEventsScope.h>
 #include <Common/ProfileEvents.h>
 #include <Common/ThreadFuzzer.h>
+#include <Common/ZooKeeper/ZooKeeperCommon.h>
 #include <Interpreters/Context.h>
 
 
@@ -33,6 +34,7 @@ void MergePlainMergeTreeTask::onCompleted()
 
 bool MergePlainMergeTreeTask::executeStep()
 {
+    auto component_guard = Coordination::setCurrentComponent("MutatePlainMergeTreeTask::executeStep");
     /// All metrics will be saved in the thread_group, including all scheduled tasks.
     /// In profile_counters only metrics from this thread will be saved.
     ProfileEventsScope profile_events_scope(&profile_counters);

--- a/src/Storages/MergeTree/MergePlainMergeTreeTask.cpp
+++ b/src/Storages/MergeTree/MergePlainMergeTreeTask.cpp
@@ -34,7 +34,7 @@ void MergePlainMergeTreeTask::onCompleted()
 
 bool MergePlainMergeTreeTask::executeStep()
 {
-    auto component_guard = Coordination::setCurrentComponent("MutatePlainMergeTreeTask::executeStep");
+    auto component_guard = Coordination::setCurrentComponent("MergePlainMergeTreeTask::executeStep");
     /// All metrics will be saved in the thread_group, including all scheduled tasks.
     /// In profile_counters only metrics from this thread will be saved.
     ProfileEventsScope profile_events_scope(&profile_counters);
@@ -195,7 +195,7 @@ void MergePlainMergeTreeTask::finish()
 
 void MergePlainMergeTreeTask::cancel() noexcept
 {
-    auto component_guard = Coordination::setCurrentComponent("MutatePlainMergeTreeTask::cancel");
+    auto component_guard = Coordination::setCurrentComponent("MergePlainMergeTreeTask::cancel");
     if (merge_task)
         merge_task->cancel();
 


### PR DESCRIPTION
Fix logical error https://d1k2gkhrlfqv31.cloudfront.net/clickhouse-test-reports-private/json.html?PR=50792&sha=c777321ce9087d830a7ae49ec2ba714e91fba0c2&name_0=PR&name_1=Integration+tests+%28amd_tsan%2C+4%2F6%29

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.176`
- Backported to: `26.2.4.5`
<!-- ch-version-info:end -->