### PR TITLE
Increase wait_for_queries_to_finish timeout in 01169_old_alter_partition_isolation_stress

### DIFF
--- a/tests/queries/0_stateless/01169_old_alter_partition_isolation_stress.sh
+++ b/tests/queries/0_stateless/01169_old_alter_partition_isolation_stress.sh
@@ -111,7 +111,7 @@ wait $PID_3 && wait $PID_4
 kill -TERM $PID_1
 kill -TERM $PID_2
 wait
-wait_for_queries_to_finish
+wait_for_queries_to_finish 40
 
 $CLICKHOUSE_CLIENT --implicit_transaction=1 --throw_on_unsupported_query_inside_transaction=0 -q "SELECT type, count(n) = countDistinct(n) FROM merge(currentDatabase(), '') GROUP BY type ORDER BY type"
 $CLICKHOUSE_CLIENT --implicit_transaction=1 --throw_on_unsupported_query_inside_transaction=0 -q "SELECT DISTINCT arraySort(groupArrayIf(n, type=1)) = arraySort(groupArrayIf(n, type=2)) FROM merge(currentDatabase(), '') GROUP BY _table ORDER BY _table"


### PR DESCRIPTION
## Summary
- The test `01169_old_alter_partition_isolation_stress` was flaky in the amd_debug + distributed plan + S3 storage configuration
- The `thread_select` query spent ~8 seconds in query plan optimization in debug mode, causing `wait_for_queries_to_finish` to time out with its default 10-second limit
- On timeout, it dumps `system.processes` to stdout, polluting the output and causing a reference mismatch
- Increased the timeout from 20 retries (10s) to 40 retries (20s), matching the newer version of this test (`01169_alter_partition_isolation_stress.sh`)

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=caae6d378b492d978a29b5143be67d7078d1a7c2&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_debug%2C%20distributed%20plan%2C%20s3%20storage%2C%20parallel%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)