### PR TITLE
Add missing component guard in EphemeralNodeHolder destructor

### DIFF
--- a/src/Common/ZooKeeper/ZooKeeper.h
+++ b/src/Common/ZooKeeper/ZooKeeper.h
@@ -8,6 +8,7 @@
 #include <Common/CurrentMetrics.h>
 #include <Common/ZooKeeper/ZooKeeperArgs.h>
 #include <Common/ZooKeeper/KeeperException.h>
+#include <Common/ZooKeeper/ZooKeeperCommon.h>
 #include <Coordination/KeeperConstants.h>
 
 #include <functional>
@@ -784,6 +785,7 @@ public:
             return;
         try
         {
+            auto component_guard = Coordination::setCurrentComponent("EphemeralNodeHolder::~EphemeralNodeHolder");
             if (!zookeeper.expired())
                 zookeeper.tryRemove(path);
             else

--- a/src/DataTypes/Native.h
+++ b/src/DataTypes/Native.h
@@ -7,6 +7,13 @@
 #    include <Common/Exception.h>
 #    include <Core/ValueWithType.h>
 #    include <DataTypes/IDataType.h>
+/// On PPC64LE, termios.h defines CR1, CR2, CR3 as macros which conflict
+/// with parameter names in llvm/IR/ConstantRange.h (included transitively).
+#    if defined(__powerpc64__)
+#        undef CR1
+#        undef CR2
+#        undef CR3
+#    endif
 #    include <llvm/IR/IRBuilder.h>
 
 


### PR DESCRIPTION
## Summary

- `EphemeralNodeHolder::~EphemeralNodeHolder` calls `zookeeper.tryRemove` to clean up ephemeral nodes but was missing a `Coordination::setCurrentComponent` guard
- When `enforce_keeper_component_tracking` is enabled (as in all integration tests), this causes a `LOGICAL_ERROR` exception during server shutdown when `DDLWorker` destructor destroys its `active_node_holders` map
- The stack trace: `ContextSharedPart::shutdown` -> `DDLWorker::~DDLWorker` -> `EphemeralNodeHolder::~EphemeralNodeHolder` -> `tryRemove` -> `pushRequest` -> LOGICAL_ERROR

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=97680&sha=ef14c2bc89824fe54625f946a6efb638d54b6207&name_0=PR&name_1=Integration%20tests%20%28amd_tsan%2C%205%2F6%29
https://github.com/ClickHouse/ClickHouse/pull/97680

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)