### PR TITLE
Fix logical error in caseWithExpression with Nullable(Nothing) arguments

### DIFF
--- a/src/Functions/caseWithExpression.cpp
+++ b/src/Functions/caseWithExpression.cpp
@@ -86,7 +86,7 @@ public:
         auto equals_result = function_base->execute(equals_args, equals_return_type, input_rows_count, false);
 
         // convert nullable equals result to non-nullable
-        if (isColumnNullable(*equals_result))
+        if (equals_return_type->isNullable())
         {
             auto if_null_func = FunctionFactory::instance().get("ifNull", context);
             auto zero_const = DataTypeUInt8().createColumnConst(input_rows_count, 0u);

--- a/tests/queries/0_stateless/04005_case_with_expression_nullable_nothing.sql
+++ b/tests/queries/0_stateless/04005_case_with_expression_nullable_nothing.sql
@@ -1,0 +1,13 @@
+-- Reproducer for logical error in caseWithExpression with Nullable(Nothing) arguments.
+-- The issue was that equals() returning ColumnConst(ColumnNullable(ColumnNothing)) was not detected
+-- as nullable by isColumnNullable(), causing a type mismatch in the if() function.
+
+SELECT DISTINCT
+    caseWithExpression(1, *, 1, materialize(NULL)),
+    assumeNotNull(1),
+    and(caseWithExpression(materialize(toNullable(1)), materialize(NULL), assumeNotNull(isNull(1)), 1), 1, *)
+FROM numbers(10)
+WHERE isNotNull(1)
+QUALIFY assumeNotNull(assumeNotNull(isNotNull(1)))
+ORDER BY ALL DESC
+OFFSET 1048577;

--- a/tests/queries/0_stateless/04005_case_with_expression_nullable_nothing.sql
+++ b/tests/queries/0_stateless/04005_case_with_expression_nullable_nothing.sql
@@ -2,6 +2,8 @@
 -- The issue was that equals() returning ColumnConst(ColumnNullable(ColumnNothing)) was not detected
 -- as nullable by isColumnNullable(), causing a type mismatch in the if() function.
 
+SET enable_analyzer = 1;
+
 SELECT DISTINCT
     caseWithExpression(1, *, 1, materialize(NULL)),
     assumeNotNull(1),


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix logical error exception in `caseWithExpression` when `CASE` expression involves `materialize(NULL)` or other `Nullable(Nothing)` arguments.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

---

## Summary

The `caseWhenEquals` helper in `caseWithExpression` calls `equals(expr, when_value)` to compare the expression with each WHEN value. When `when_value` has type `Nullable(Nothing)` (e.g., `materialize(NULL)`), the `equals` function returns a `ColumnConst(ColumnNullable(ColumnNothing))` — a const column wrapping a nullable column.

The code then checks `isColumnNullable(*equals_result)` to decide whether to apply `ifNull` to convert the result to non-nullable `UInt8`. However, `isColumnNullable` only checks the outermost column type, which is `ColumnConst`, not `ColumnNullable`. This causes the `ifNull` conversion to be skipped, and the nullable column is passed with a declared type of `UInt8` to the downstream `if` function, triggering `assertTypeEquality` in debug builds.

**Fix:** Check `equals_return_type->isNullable()` instead of `isColumnNullable(*equals_result)`, which correctly detects the nullable return type regardless of `ColumnConst` wrapping.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=98272&sha=d3274382ab4584e1802d03ee44ee7e57884882e0&name_0=PR&name_1=AST%20fuzzer%20%28amd_debug%29
https://github.com/ClickHouse/ClickHouse/pull/98272


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.172`
<!-- ch-version-info:end -->