### PR TITLE
Add projections_duration_ms column to system.part_log

### DIFF
--- a/src/Interpreters/PartLog.cpp
+++ b/src/Interpreters/PartLog.cpp
@@ -157,6 +157,8 @@ ColumnsDescription PartLogElement::getColumnsDescription()
         {"mutation_ids", std::make_shared<DataTypeArray>(std::make_shared<DataTypeString>()), "An array of mutation IDs applied to the source part (merged_from) for the event with type MUTATE_PART_START and MUTATE_PART."},
 
         {"ProfileEvents", std::make_shared<DataTypeMap>(low_cardinality_string, std::make_shared<DataTypeUInt64>()), "All the profile events captured during this operation."},
+
+        {"projections_duration_ms", std::make_shared<DataTypeMap>(low_cardinality_string, std::make_shared<DataTypeUInt64>()), "Per-projection merge/rebuild duration in milliseconds."},
     };
 }
 
@@ -233,6 +235,13 @@ void PartLogElement::appendToBlock(MutableColumns & columns) const
     else
     {
         columns[i++]->insertDefault();
+    }
+
+    {
+        Map map;
+        for (const auto & [name, duration] : projections_duration_ms)
+            map.push_back(Tuple{name, duration});
+        columns[i++]->insert(map);
     }
 }
 

--- a/src/Interpreters/PartLog.h
+++ b/src/Interpreters/PartLog.h
@@ -99,6 +99,8 @@ struct PartLogElement
 
     std::shared_ptr<ProfileEvents::Counters::Snapshot> profile_counters;
 
+    std::map<String, UInt64> projections_duration_ms;
+
     static std::string name() { return "PartLog"; }
 
     static MergeReasonType getMergeReasonType(MergeType merge_type);

--- a/src/Storages/MergeTree/MergeFromLogEntryTask.cpp
+++ b/src/Storages/MergeTree/MergeFromLogEntryTask.cpp
@@ -82,7 +82,8 @@ ReplicatedMergeMutateTaskBase::PrepareResult MergeFromLogEntryTask::prepare()
         auto profile_counters_snapshot = std::make_shared<ProfileEvents::Counters::Snapshot>(profile_counters.getPartiallyAtomicSnapshot());
         storage.writePartLog(
             PartLogElement::MERGE_PARTS, execution_status, stopwatch.elapsed(),
-            entry.new_part_name, part, parts, merge_mutate_entry.get(), std::move(profile_counters_snapshot));
+            entry.new_part_name, part, parts, merge_mutate_entry.get(), std::move(profile_counters_snapshot),
+            {}, this->projections_merge_time);
     };
 
     if ((*storage_settings_ptr)[MergeTreeSetting::always_fetch_merged_part])
@@ -358,7 +359,7 @@ ReplicatedMergeMutateTaskBase::PrepareResult MergeFromLogEntryTask::prepare()
 
     storage.writePartLog(
         PartLogElement::MERGE_PARTS_START, {}, 0,
-        entry.new_part_name, part, parts, merge_mutate_entry.get(), {});
+        entry.new_part_name, part, parts, merge_mutate_entry.get(), {}, {}, {});
 
     transaction_ptr = std::make_unique<MergeTreeData::Transaction>(storage, NO_TRANSACTION_RAW);
 
@@ -394,6 +395,7 @@ bool MergeFromLogEntryTask::finalize(ReplicatedMergeMutateTaskBase::PartLogWrite
     part = merge_task->getFuture().get();
     auto cached_marks = merge_task->releaseCachedMarks();
     auto cached_index_marks = merge_task->releaseCachedIndexMarks();
+    projections_merge_time = merge_task->grabProjectionsMergeTime();
 
     storage.merger_mutator.renameMergedTemporaryPart(part, parts, NO_TRANSACTION_PTR, *transaction_ptr);
     /// Why we reset task here? Because it holds shared pointer to part and tryRemovePartImmediately will

--- a/src/Storages/MergeTree/MergeFromLogEntryTask.h
+++ b/src/Storages/MergeTree/MergeFromLogEntryTask.h
@@ -57,6 +57,8 @@ private:
     Priority priority;
 
     MergeTaskPtr merge_task;
+
+    std::map<String, UInt64> projections_merge_time;
 };
 
 

--- a/src/Storages/MergeTree/MergePlainMergeTreeTask.cpp
+++ b/src/Storages/MergeTree/MergePlainMergeTreeTask.cpp
@@ -100,11 +100,12 @@ void MergePlainMergeTreeTask::prepare()
 
     storage.writePartLog(
         PartLogElement::MERGE_PARTS_START, {}, 0,
-        future_part->name, new_part, future_part->parts, merge_list_entry.get(), {});
+        future_part->name, new_part, future_part->parts, merge_list_entry.get(), {}, {}, {});
 
     write_part_log = [this] (const ExecutionStatus & execution_status)
     {
         auto profile_counters_snapshot = std::make_shared<ProfileEvents::Counters::Snapshot>(profile_counters.getPartiallyAtomicSnapshot());
+        auto projections_duration_ms = merge_task ? merge_task->grabProjectionsMergeTime() : std::map<String, UInt64>{};
         storage.writePartLog(
             PartLogElement::MERGE_PARTS,
             execution_status,
@@ -113,7 +114,9 @@ void MergePlainMergeTreeTask::prepare()
             new_part,
             future_part->parts,
             merge_list_entry.get(),
-            std::move(profile_counters_snapshot));
+            std::move(profile_counters_snapshot),
+            {},
+            projections_duration_ms);
     };
 
     transfer_profile_counters_to_initial_query = [this, query_thread_group = CurrentThread::getGroup()] ()

--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -1136,10 +1136,14 @@ void MergeTask::ExecuteAndFinalizeHorizontalPart::calculateProjections(const Blo
     for (size_t i = 0, size = global_ctx->projections_to_rebuild.size(); i < size; ++i)
     {
         const auto & projection = *global_ctx->projections_to_rebuild[i];
+        Stopwatch projection_watch(CLOCK_MONOTONIC_COARSE);
         Block block_to_squash = projection.calculate(block, starting_offset, global_ctx->context);
         /// Avoid replacing the projection squash header if nothing was generated (it used to return an empty block)
         if (block_to_squash.rows() == 0)
+        {
+            ctx->projections_rebuild_elapsed_ns[projection.name] += projection_watch.elapsedNanoseconds();
             continue;
+        }
 
         auto & projection_squash_plan = ctx->projection_squashes[i];
         projection_squash_plan.setHeader(block_to_squash.cloneEmpty());
@@ -1157,6 +1161,7 @@ void MergeTask::ExecuteAndFinalizeHorizontalPart::calculateProjections(const Blo
             tmp_part->part->getDataPartStorage().commitTransaction();
             ctx->projection_parts[projection.name].emplace_back(std::move(tmp_part->part));
         }
+        ctx->projections_rebuild_elapsed_ns[projection.name] += projection_watch.elapsedNanoseconds();
     }
 }
 
@@ -1215,15 +1220,34 @@ bool MergeTask::ExecuteAndFinalizeHorizontalPart::executeMergeProjections() cons
 {
     /// In case if there are no projections we didn't construct a task
     if (!ctx->merge_projection_parts_task_ptr)
+    {
+        /// Transfer accumulated rebuild timings to global context
+        for (auto & [name, elapsed_ns] : ctx->projections_rebuild_elapsed_ns)
+            global_ctx->projections_merge_time[name] += elapsed_ns / 1000000;
+        ctx->projections_rebuild_elapsed_ns.clear();
         return false;
+    }
+
+    const auto & current_projection_name = ctx->projection_parts_iterator->first;
+    Stopwatch step_watch(CLOCK_MONOTONIC_COARSE);
 
     if (ctx->merge_projection_parts_task_ptr->executeStep())
+    {
+        ctx->projections_rebuild_elapsed_ns[current_projection_name] += step_watch.elapsedNanoseconds();
         return true;
+    }
 
+    ctx->projections_rebuild_elapsed_ns[current_projection_name] += step_watch.elapsedNanoseconds();
     ++ctx->projection_parts_iterator;
 
     if (ctx->projection_parts_iterator == std::make_move_iterator(ctx->projection_parts.end()))
+    {
+        /// Transfer accumulated rebuild timings to global context
+        for (auto & [name, elapsed_ns] : ctx->projections_rebuild_elapsed_ns)
+            global_ctx->projections_merge_time[name] += elapsed_ns / 1000000;
+        ctx->projections_rebuild_elapsed_ns.clear();
         return false;
+    }
 
     constructTaskForProjectionPartsMerge();
 
@@ -1781,9 +1805,18 @@ bool MergeTask::MergeProjectionsStage::executeProjections() const
     if (global_ctx->merged_part_offsets && !(*ctx->projections_iterator)->global_ctx->merged_part_offsets)
         global_ctx->merged_part_offsets->clear();
 
-    if ((*ctx->projections_iterator)->execute())
-        return true;
+    const auto & projection_name = (*ctx->projections_iterator)->global_ctx->future_part->name;
+    Stopwatch projection_watch(CLOCK_MONOTONIC_COARSE);
 
+    if ((*ctx->projections_iterator)->execute())
+    {
+        ctx->projections_merge_elapsed_ns[projection_name] += projection_watch.elapsedNanoseconds();
+        return true;
+    }
+
+    /// Projection finished — convert accumulated nanoseconds to milliseconds.
+    ctx->projections_merge_elapsed_ns[projection_name] += projection_watch.elapsedNanoseconds();
+    global_ctx->projections_merge_time[projection_name] += ctx->projections_merge_elapsed_ns[projection_name] / 1000000;
     ++ctx->projections_iterator;
     return true;
 }

--- a/src/Storages/MergeTree/MergeTask.h
+++ b/src/Storages/MergeTree/MergeTask.h
@@ -170,6 +170,11 @@ public:
         return res;
     }
 
+    std::map<String, UInt64> grabProjectionsMergeTime()
+    {
+        return std::move(global_ctx->projections_merge_time);
+    }
+
     bool execute();
 
     void cancel() noexcept;
@@ -262,6 +267,8 @@ private:
         size_t rows_written{0};
         UInt64 watch_prev_elapsed{0};
 
+        std::map<String, UInt64> projections_merge_time;
+
         std::promise<MergeTreeData::MutableDataPartPtr> promise{};
 
         WrittenOffsetSubstreams written_offset_substreams{};
@@ -303,6 +310,7 @@ private:
         std::move_iterator<ProjectionNameToItsBlocks::iterator> projection_parts_iterator;
         std::vector<Squashing> projection_squashes;
         size_t projection_block_num = 0;
+        std::map<String, UInt64> projections_rebuild_elapsed_ns;
         ExecutableTaskPtr merge_projection_parts_task_ptr;
         BuildStatisticsTransformMap build_statistics_transforms;
 
@@ -514,6 +522,11 @@ private:
 
         LoggerPtr log{getLogger("MergeTask::MergeProjectionsStage")};
         UInt64 elapsed_execute_ns{0};
+
+        /// Accumulate per-projection merge time in nanoseconds to avoid truncation
+        /// when individual execute() steps take less than 1ms.
+        /// Converted to milliseconds only when a projection finishes.
+        std::map<String, UInt64> projections_merge_elapsed_ns;
     };
 
     using MergeProjectionsRuntimeContextPtr = std::shared_ptr<MergeProjectionsRuntimeContext>;

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -9514,7 +9514,8 @@ void MergeTreeData::writePartLog(
     const DataPartsVector & source_parts,
     const MergeListEntry * merge_entry,
     std::shared_ptr<ProfileEvents::Counters::Snapshot> profile_counters,
-    const Strings & mutation_ids)
+    const Strings & mutation_ids,
+    const std::map<String, UInt64> & projections_duration_ms)
 try
 {
     auto table_id = getStorageID();
@@ -9589,6 +9590,8 @@ try
     }
 
     part_log_elem.mutation_ids = mutation_ids;
+
+    part_log_elem.projections_duration_ms = projections_duration_ms;
 
     part_log->add(std::move(part_log_elem));
 }
@@ -9756,7 +9759,7 @@ MovePartsOutcome MergeTreeData::moveParts(const CurrentlyMovingPartsTaggerPtr & 
                 cloned_part.part,
                 {moving_part.part},
                 nullptr,
-                profile_events_scope.getSnapshot());
+                profile_events_scope.getSnapshot(), {}, {});
         };
 
         // Register in global moves list (StorageSystemMoves)

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -1706,7 +1706,8 @@ protected:
         const DataPartsVector & source_parts,
         const MergeListEntry * merge_entry,
         std::shared_ptr<ProfileEvents::Counters::Snapshot> profile_counters,
-        const Strings & mutation_ids = {});
+        const Strings & mutation_ids,
+        const std::map<String, UInt64> & projections_duration_ms);
 
     /// If part is assigned to merge or mutation (possibly replicated)
     /// Should be overridden by children, because they can have different

--- a/src/Storages/MergeTree/MutateFromLogEntryTask.cpp
+++ b/src/Storages/MergeTree/MutateFromLogEntryTask.cpp
@@ -63,7 +63,7 @@ ReplicatedMergeMutateTaskBase::PrepareResult MutateFromLogEntryTask::prepare()
         storage.writePartLog(
             PartLogElement::MUTATE_PART, execution_status, stopwatch_ptr->elapsed(),
             entry.new_part_name, new_part, future_mutated_part->parts, merge_mutate_entry.get(), std::move(profile_counters_snapshot),
-            mutation_ids_for_log);
+            mutation_ids_for_log, {});
     };
 
     MergeTreeData::DataPartPtr source_part = storage.getActiveContainingPart(source_part_name);
@@ -230,7 +230,7 @@ ReplicatedMergeMutateTaskBase::PrepareResult MutateFromLogEntryTask::prepare()
 
     storage.writePartLog(
         PartLogElement::MUTATE_PART_START, {}, 0,
-        entry.new_part_name, new_part, future_mutated_part->parts, merge_mutate_entry.get(), {}, mutation_ids_for_log);
+        entry.new_part_name, new_part, future_mutated_part->parts, merge_mutate_entry.get(), {}, mutation_ids_for_log, {});
 
     mutate_task = storage.merger_mutator.mutatePartToTemporaryPart(
             future_mutated_part, metadata_snapshot, commands, merge_mutate_entry.get(),

--- a/src/Storages/MergeTree/MutatePlainMergeTreeTask.cpp
+++ b/src/Storages/MergeTree/MutatePlainMergeTreeTask.cpp
@@ -51,7 +51,7 @@ void MutatePlainMergeTreeTask::prepare()
 
     storage.writePartLog(
         PartLogElement::MUTATE_PART_START, {}, 0,
-        future_part->name, new_part, future_part->parts, merge_list_entry.get(), {}, mutation_ids);
+        future_part->name, new_part, future_part->parts, merge_list_entry.get(), {}, mutation_ids, {});
 
     write_part_log = [this, mutation_ids] (const ExecutionStatus & execution_status)
     {
@@ -65,7 +65,7 @@ void MutatePlainMergeTreeTask::prepare()
             future_part->parts,
             merge_list_entry.get(),
             std::move(profile_counters_snapshot),
-            mutation_ids);
+            mutation_ids, {});
     };
 
     if (task_context->getSettingsRef()[Setting::enable_sharing_sets_for_mutations])

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -2444,7 +2444,7 @@ bool StorageReplicatedMergeTree::executeLogEntry(LogEntry & entry)
 
             writePartLog(PartLogElement::Type::NEW_PART, {}, 0 /** log entry is fake so we don't measure the time */,
                 part->name, part, {} /** log entry is fake so there are no initial parts */, nullptr,
-                profile_events_scope.getSnapshot());
+                profile_events_scope.getSnapshot(), {}, {});
 
             return true;
         }
@@ -5368,7 +5368,7 @@ bool StorageReplicatedMergeTree::fetchPart(
         writePartLog(
             PartLogElement::DOWNLOAD_PART, execution_status, stopwatch.elapsed(),
             part_name, part, replaced_parts, nullptr,
-            profile_events_scope.getSnapshot());
+            profile_events_scope.getSnapshot(), {}, {});
     };
 
     auto is_zero_copy_part = [&settings_ptr](const auto & data_part)
@@ -5646,7 +5646,7 @@ MergeTreeData::MutableDataPartPtr StorageReplicatedMergeTree::fetchExistsPart(
         writePartLog(
             PartLogElement::DOWNLOAD_PART, execution_status, stopwatch.elapsed(),
             part_name, part, replaced_parts, nullptr,
-            profile_events_scope.getSnapshot());
+            profile_events_scope.getSnapshot(), {}, {});
     };
 
     std::function<MutableDataPartPtr()> get_part;

--- a/tests/queries/0_stateless/04004_part_log_projections_duration_ms.reference
+++ b/tests/queries/0_stateless/04004_part_log_projections_duration_ms.reference
@@ -1,0 +1,4 @@
+scenario 1: merge projection merge	MergeParts	1	1
+scenario 1: insert has empty map	{}
+scenario 2: merge projection rebuild	MergeParts	1
+scenario 3: replicated projection merge	MergeParts	1	1

--- a/tests/queries/0_stateless/04004_part_log_projections_duration_ms.sql
+++ b/tests/queries/0_stateless/04004_part_log_projections_duration_ms.sql
@@ -1,0 +1,127 @@
+-- Tags: no-replicated-database
+
+DROP TABLE IF EXISTS t_proj_merge;
+DROP TABLE IF EXISTS t_proj_rebuild;
+
+-- ============================================================================
+-- Scenario 1: Merge — Projection Merge (Phase B)
+-- All source parts have projections, so they are merged directly.
+-- Uses plain MergeTree to test MergePlainMergeTreeTask path.
+-- ============================================================================
+CREATE TABLE t_proj_merge
+(
+    key UInt64,
+    value String,
+    PROJECTION p1 (SELECT key, value ORDER BY value),
+    PROJECTION p2 (SELECT key, count() GROUP BY key)
+)
+ENGINE = MergeTree()
+ORDER BY key;
+
+INSERT INTO t_proj_merge SELECT number, toString(number) FROM numbers(5000);
+INSERT INTO t_proj_merge SELECT number + 5000, toString(number + 5000) FROM numbers(5000);
+
+OPTIMIZE TABLE t_proj_merge FINAL;
+SYSTEM FLUSH LOGS part_log;
+
+SELECT
+    'scenario 1: merge projection merge',
+    event_type,
+    mapContains(projections_duration_ms, 'p1') AS has_p1,
+    mapContains(projections_duration_ms, 'p2') AS has_p2
+FROM system.part_log
+WHERE
+    event_date >= yesterday()
+    AND database = currentDatabase()
+    AND table = 't_proj_merge'
+    AND event_type = 'MergeParts'
+ORDER BY event_time_microseconds
+LIMIT 1;
+
+-- NewPart (INSERT) should have an empty map
+SELECT
+    'scenario 1: insert has empty map',
+    projections_duration_ms
+FROM system.part_log
+WHERE
+    event_date >= yesterday()
+    AND database = currentDatabase()
+    AND table = 't_proj_merge'
+    AND event_type = 'NewPart'
+ORDER BY event_time_microseconds
+LIMIT 1;
+
+-- ============================================================================
+-- Scenario 2: Merge — Projection Rebuild (Phase A)
+-- ReplacingMergeTree merges may reduce rows, so projections are rebuilt.
+-- ============================================================================
+CREATE TABLE t_proj_rebuild
+(
+    key UInt64,
+    value String,
+    PROJECTION p1 (SELECT key, value ORDER BY value)
+)
+ENGINE = ReplacingMergeTree()
+ORDER BY key
+SETTINGS deduplicate_merge_projection_mode = 'rebuild';
+
+INSERT INTO t_proj_rebuild SELECT number, toString(number) FROM numbers(5000);
+INSERT INTO t_proj_rebuild SELECT number, toString(number + 100000) FROM numbers(5000);
+
+OPTIMIZE TABLE t_proj_rebuild FINAL;
+SYSTEM FLUSH LOGS part_log;
+
+SELECT
+    'scenario 2: merge projection rebuild',
+    event_type,
+    mapContains(projections_duration_ms, 'p1') AS has_p1
+FROM system.part_log
+WHERE
+    event_date >= yesterday()
+    AND database = currentDatabase()
+    AND table = 't_proj_rebuild'
+    AND event_type = 'MergeParts'
+ORDER BY event_time_microseconds
+LIMIT 1;
+
+-- ============================================================================
+-- Scenario 3: ReplicatedMergeTree — Projection Merge (Phase B)
+-- Tests the MergeFromLogEntryTask path (replicated merge glue code).
+-- ============================================================================
+DROP TABLE IF EXISTS t_proj_repl;
+
+SET insert_keeper_fault_injection_probability = 0;
+
+CREATE TABLE t_proj_repl
+(
+    key UInt64,
+    value String,
+    PROJECTION p1 (SELECT key, value ORDER BY value),
+    PROJECTION p2 (SELECT key, count() GROUP BY key)
+)
+ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/04004_t_proj_repl', 'r1')
+ORDER BY key;
+
+INSERT INTO t_proj_repl SELECT number, toString(number) FROM numbers(5000);
+INSERT INTO t_proj_repl SELECT number + 5000, toString(number + 5000) FROM numbers(5000);
+
+OPTIMIZE TABLE t_proj_repl FINAL;
+SYSTEM FLUSH LOGS part_log;
+
+SELECT
+    'scenario 3: replicated projection merge',
+    event_type,
+    mapContains(projections_duration_ms, 'p1') AS has_p1,
+    mapContains(projections_duration_ms, 'p2') AS has_p2
+FROM system.part_log
+WHERE
+    event_date >= yesterday()
+    AND database = currentDatabase()
+    AND table = 't_proj_repl'
+    AND event_type = 'MergeParts'
+ORDER BY event_time_microseconds
+LIMIT 1;
+
+DROP TABLE t_proj_merge;
+DROP TABLE t_proj_rebuild;
+DROP TABLE t_proj_repl;


### PR DESCRIPTION
## Summary

Add a new `projections_duration_ms` column to `system.part_log` of type `Map(LowCardinality(String), UInt64)` that records per-projection merge/rebuild duration in milliseconds. This enables users to observe which projections are expensive during merges and optimize accordingly.

The timing is captured in two phases:
- **Phase A (projection rebuild)**: When merges reduce rows (e.g. `ReplacingMergeTree`, dedup, collapsing, TTL), projections are rebuilt from scratch. Timing is tracked in `calculateProjections` and `executeMergeProjections`.
- **Phase B (projection merge)**: When projections are merged alongside the data part. Timing is tracked in `executeProjections` within `MergeProjectionsStage`.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Add `projections_duration_ms` column to `system.part_log` that records per-projection merge/rebuild duration in milliseconds.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

New column `projections_duration_ms` of type `Map(LowCardinality(String), UInt64)` in `system.part_log`. Each key is a projection name and the value is the time in milliseconds spent merging or rebuilding that projection during the part operation.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.289`
<!-- ch-version-info:end -->