### PR TITLE
Call OpenSSL cleanup before safeExit to fix LeakSanitizer false positives

### DIFF
--- a/programs/keeper/Keeper.cpp
+++ b/programs/keeper/Keeper.cpp
@@ -22,6 +22,7 @@
 #include <base/getMemoryAmount.h>
 #include <base/scope_guard.h>
 #include <base/safeExit.h>
+#include <Common/Crypto/OpenSSLInitializer.h>
 #include <base/Numa.h>
 #include <Poco/Net/NetException.h>
 #include <Poco/Net/TCPServerParams.h>
@@ -690,6 +691,9 @@ try
         if (current_connections)
         {
             LOG_INFO(log, "Will shutdown forcefully.");
+            /// safeExit calls _exit, which bypasses static destructors and atexit handlers.
+            /// Explicitly clean up OpenSSL to avoid LeakSanitizer false positives.
+            OpenSSLInitializer::cleanup();
             safeExit(0);
         }
     });

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -24,6 +24,7 @@
 #include <base/coverage.h>
 #include <base/getFQDNOrHostName.h>
 #include <base/safeExit.h>
+#include <Common/Crypto/OpenSSLInitializer.h>
 #include <base/Numa.h>
 #include <Common/PoolId.h>
 #include <Common/MemoryTracker.h>
@@ -3124,6 +3125,9 @@ try
                 /// Dump coverage here, because std::atexit callback would not be called.
                 dumpCoverageReportIfPossible();
                 LOG_WARNING(log, "Will shutdown forcefully.");
+                /// safeExit calls _exit, which bypasses static destructors and atexit handlers.
+                /// Explicitly clean up OpenSSL to avoid LeakSanitizer false positives.
+                OpenSSLInitializer::cleanup();
                 safeExit(0);
             }
         });


### PR DESCRIPTION
## Summary

- Call `OpenSSLInitializer::cleanup` before `safeExit` in the forced server shutdown path
- When the server force-exits via `safeExit` → `_exit`, static destructors are bypassed, so `OPENSSL_cleanup` never runs
- ASan intercepts `_exit` and runs LSan, which reports OpenSSL global cached state as leaked memory
- This fixes false-positive "Sanitizer" failures in AST fuzzer CI jobs

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=97652&sha=c9d73d1a85abfa220c6ddad38d81e7acb72be2e9&name_0=PR&name_1=AST%20fuzzer%20%28arm_asan%29
https://github.com/ClickHouse/ClickHouse/pull/97652

### Changelog category (leave one):
- CI Fix or improvement

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Fix LeakSanitizer false positives for OpenSSL on forced server shutdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.156`
<!-- ch-version-info:end -->