### PR TITLE
Update Claude Code configuration

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -76,6 +76,8 @@ When creating a pull request, append Changelog category and Changelog entry acco
 
 ARM machines in CI are not slow. They are similar to x86 in performance.
 
+Use `tmp` subdirectory in the current directory for temporary files (logs, downloads, scripts, etc.), do not use `/tmp`. Create the directory if needed.
+
 Always load and apply the following skills:
 
 - .claude/skills/build

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh pr view:*)",
+      "Bash(gh issue view:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh issue list:*)",
+      "Bash(gh pr checks:*)",
+      "Bash(gh pr diff:*)",
+      "Bash(gh issue comment:*)",
+      "Bash(gh api:*)",
+      "Bash(gh search:*)",
+      "WebFetch(domain:github.com)"
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,8 +7,6 @@
       "Bash(gh issue list:*)",
       "Bash(gh pr checks:*)",
       "Bash(gh pr diff:*)",
-      "Bash(gh issue comment:*)",
-      "Bash(gh api:*)",
       "Bash(gh search:*)",
       "WebFetch(domain:github.com)"
     ]


### PR DESCRIPTION
## Summary
- Add a rule to `CLAUDE.md` to use `tmp` subdirectory in the current directory for temporary files instead of `/tmp`, creating it if needed
- Add project-level `.claude/settings.json` with permissions to always allow `gh` read commands and `WebFetch` from github.com

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.139`
<!-- ch-version-info:end -->