### PR TITLE
Forbid empty part name in detached part operations

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -7646,6 +7646,9 @@ DetachedPartsInfo MergeTreeData::getDetachedParts() const
 
 void MergeTreeData::validateDetachedPartName(const String & name)
 {
+    if (name.empty())
+        throw DB::Exception(ErrorCodes::BAD_DATA_PART_NAME, "Empty part name");
+
     if (name.contains('/') || name == "." || name == "..")
         throw DB::Exception(ErrorCodes::INCORRECT_FILE_NAME, "Invalid part name '{}'", name);
 

--- a/tests/queries/0_stateless/04005_empty_part_name.sql
+++ b/tests/queries/0_stateless/04005_empty_part_name.sql
@@ -1,0 +1,10 @@
+SET allow_drop_detached = 1;
+
+DROP TABLE IF EXISTS t;
+CREATE TABLE t (x UInt8) ENGINE = MergeTree ORDER BY x;
+INSERT INTO t VALUES (1);
+
+ALTER TABLE t DROP DETACHED PART ''; -- { serverError BAD_DATA_PART_NAME }
+ALTER TABLE t ATTACH PART ''; -- { serverError BAD_DATA_PART_NAME }
+
+DROP TABLE t;


### PR DESCRIPTION
Closes #98052

## Summary
- Added an empty name check to `validateDetachedPartName` so that `ALTER TABLE ... DROP DETACHED PART ''` and `ALTER TABLE ... ATTACH PART ''` throw a proper `BAD_DATA_PART_NAME` error instead of a `LOGICAL_ERROR` exception
- Added a test for empty part names

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=0c6b9571104017f6a5811dba92571887b1a62e15&name_0=MasterCI&name_1=BuzzHouse%20%28amd_debug%29

### Changelog category (leave one):
- CI Fix or Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Forbid empty part name in `ALTER TABLE ... DROP DETACHED PART` and `ALTER TABLE ... ATTACH PART` to avoid a `LOGICAL_ERROR` exception.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.152`
<!-- ch-version-info:end -->