### PR TITLE
Enable ProtobufList format in Kafka HTTP interface produce test

### DIFF
--- a/tests/integration/test_storage_kafka/clickhouse_path/format_schemas/string_key_value_list.proto
+++ b/tests/integration/test_storage_kafka/clickhouse_path/format_schemas/string_key_value_list.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+message Envelope {
+  message StringKeyValuePair {
+    string key = 1;
+    string value = 2;
+  }
+  repeated StringKeyValuePair row = 1;
+}

--- a/tests/integration/test_storage_kafka/test_produce_http_interface.py
+++ b/tests/integration/test_storage_kafka/test_produce_http_interface.py
@@ -125,7 +125,7 @@ def test_kafka_produce_http_interface_row_based_format(kafka_cluster):
 
     extra_settings = {
         "Protobuf": ", kafka_schema = 'string_key_value.proto:StringKeyValuePair'",
-        "ProtobufList": ", kafka_schema = 'string_key_value_list.proto:Envelope'",
+        "ProtobufList": ", kafka_schema = 'string_key_value_list.proto:StringKeyValuePair'",
         "CapnProto": ", kafka_schema='string_key_value:StringKeyValuePair'",
         "Template": ", format_template_row='string_key_value.format'",
     }

--- a/tests/integration/test_storage_kafka/test_produce_http_interface.py
+++ b/tests/integration/test_storage_kafka/test_produce_http_interface.py
@@ -125,6 +125,7 @@ def test_kafka_produce_http_interface_row_based_format(kafka_cluster):
 
     extra_settings = {
         "Protobuf": ", kafka_schema = 'string_key_value.proto:StringKeyValuePair'",
+        "ProtobufList": ", kafka_schema = 'string_key_value_list.proto:Envelope'",
         "CapnProto": ", kafka_schema='string_key_value:StringKeyValuePair'",
         "Template": ", format_template_row='string_key_value.format'",
     }
@@ -134,7 +135,6 @@ def test_kafka_produce_http_interface_row_based_format(kafka_cluster):
     #  - JSONStrings: not actually an input format
     #  - ProtobufSingle: I cannot make it work to parse the messages. Probably something is broken,
     #    because the producer can write multiple rows into a same message, which makes them impossible to parse properly. Should added after #67549 is fixed.
-    #  - ProtobufList: I didn't want to deal with the envelope and stuff
     #  - Npy: supports only single column
     #  - LineAsString: supports only single column
     #  - RawBLOB: supports only single column
@@ -170,6 +170,7 @@ def test_kafka_produce_http_interface_row_based_format(kafka_cluster):
         "BSONEachRow",
         "TSKV",
         "Protobuf",
+        "ProtobufList",
         "Avro",
         "Parquet",
         "Arrow",


### PR DESCRIPTION
Now that `ProtobufList` works with Kafka engine (fixed in 5d3ea5f4dfa), enable it in the `test_kafka_produce_http_interface_row_based_format` test.

Added an envelope proto schema (`string_key_value_list.proto`) for the test.

Ref: https://github.com/ClickHouse/ClickHouse/blob/master/tests/integration/test_storage_kafka/test_produce_http_interface.py#L137

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.150`
<!-- ch-version-info:end -->