### PR TITLE
Use `postgres` REL_18_3

### DIFF
--- a/contrib/postgres-cmake/pg_config.h
+++ b/contrib/postgres-cmake/pg_config.h
@@ -593,7 +593,7 @@
 #define PACKAGE_NAME "PostgreSQL"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "PostgreSQL 18.0"
+#define PACKAGE_STRING "PostgreSQL 18.3"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "postgresql"
@@ -602,7 +602,7 @@
 #define PACKAGE_URL "https://www.postgresql.org/"
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "18.0"
+#define PACKAGE_VERSION "18.3"
 
 /* Define to the name of a signed 128-bit integer type. */
 #define PG_INT128_TYPE __int128
@@ -618,19 +618,19 @@
 #define PG_MAJORVERSION_NUM 18
 
 /* PostgreSQL minor version number */
-#define PG_MINORVERSION_NUM 0
+#define PG_MINORVERSION_NUM 3
 
 /* Define to best printf format archetype, usually gnu_printf if available. */
 #define PG_PRINTF_ATTRIBUTE gnu_printf
 
 /* PostgreSQL version as a string */
-#define PG_VERSION "18.0"
+#define PG_VERSION "18.3"
 
 /* PostgreSQL version as a number */
-#define PG_VERSION_NUM 180000
+#define PG_VERSION_NUM 180003
 
 /* A string containing the version number, platform, and C compiler */
-#define PG_VERSION_STR "PostgreSQL 18.0 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 15.2.1 20250813, 64-bit"
+#define PG_VERSION_STR "PostgreSQL 18.3 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 15.2.1 20250813, 64-bit"
 
 /* Define to 1 to allow profiling output to be saved separately for each
    process. */


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement



### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Use `postgres` REL_18_3.



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.305`
- Backported to: `26.2.4.9`, `26.1.5.4`, `25.12.9.9`, `25.8.19.2`, `25.3.15.14`
<!-- ch-version-info:end -->