### PR TITLE
Fix assertion in AST fuzzer when implicit transaction is used

### DIFF
--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -2026,9 +2026,11 @@ static void executeASTFuzzerQueries(const ASTPtr & ast, const ContextMutablePtr 
             context->getQueryContext()->getSessionContext()->setCurrentTransaction(NO_TRANSACTION_PTR);
             context->setCurrentTransaction(NO_TRANSACTION_PTR);
 
-            auto fuzz_context = Context::createCopy(context);
+            auto fuzz_session_context = Context::createCopy(context);
+            fuzz_session_context->makeSessionContext();
+
+            auto fuzz_context = Context::createCopy(fuzz_session_context);
             fuzz_context->makeQueryContext();
-            fuzz_context->makeSessionContext();
             fuzz_context->setSetting("ast_fuzzer_runs", Field(Float64(0)));
             fuzz_context->setCurrentQueryId("");
 


### PR DESCRIPTION
## Summary

The AST fuzzer created a context that served as both its own session and query context (`makeQueryContext()` + `makeSessionContext()` on the same object). When the fuzzed query triggered an implicit transaction, `InterpreterTransactionControlQuery::executeBegin` set the transaction on the session context via `initCurrentTransaction`, then tried to set it again on the query context via `setCurrentTransaction` — but they were the same object, hitting the assertion `!merge_tree_transaction || !txn`.

Fix by creating a separate session context object so that query and session contexts are distinct, matching the normal execution flow.

Stress test (amd_debug) failure: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=7a972da94a98935d46b6f2d6c98ef79117e082c4&name_0=MasterCI&name_1=Stress%20test%20%28amd_debug%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.158`
<!-- ch-version-info:end -->