### PR TITLE
Move keeper component guard from EphemeralNodeHolder to DDLWorker::shutdown

### DIFF
--- a/src/Common/ZooKeeper/ZooKeeper.h
+++ b/src/Common/ZooKeeper/ZooKeeper.h
@@ -8,7 +8,6 @@
 #include <Common/CurrentMetrics.h>
 #include <Common/ZooKeeper/ZooKeeperArgs.h>
 #include <Common/ZooKeeper/KeeperException.h>
-#include <Common/ZooKeeper/ZooKeeperCommon.h>
 #include <Coordination/KeeperConstants.h>
 
 #include <functional>
@@ -785,7 +784,6 @@ public:
             return;
         try
         {
-            auto component_guard = Coordination::setCurrentComponent("EphemeralNodeHolder::~EphemeralNodeHolder");
             if (!zookeeper.expired())
                 zookeeper.tryRemove(path);
             else

--- a/src/Interpreters/DDLWorker.cpp
+++ b/src/Interpreters/DDLWorker.cpp
@@ -165,6 +165,12 @@ void DDLWorker::shutdown()
             cleanup_thread->join();
         worker_pool.reset();
     }
+
+    /// Explicitly clear active node holders with the component guard set,
+    /// because EphemeralNodeHolder destructor calls tryRemove on ZooKeeper
+    /// which requires a component to be set when enforce_keeper_component_tracking is enabled.
+    auto component_guard = Coordination::setCurrentComponent("DDLWorker");
+    active_node_holders.clear();
 }
 
 DDLWorker::~DDLWorker()


### PR DESCRIPTION
## Summary
Follow-up to #98281 as [suggested by @antonio2368](https://github.com/ClickHouse/ClickHouse/pull/98281#issuecomment-3977401858):

- Removed the `Coordination::setCurrentComponent` guard from `EphemeralNodeHolder::~EphemeralNodeHolder` — it's too generic to put there
- Added the component guard to `DDLWorker::shutdown` instead, which explicitly clears `active_node_holders` with the guard set
- Removed the now-unnecessary `ZooKeeperCommon.h` include from `ZooKeeper.h`

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.162`
<!-- ch-version-info:end -->