### PR TITLE
Clear dmesg before functional and integration tests to avoid false OOM detection

### DIFF
--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -652,8 +652,13 @@ tar -czf ./ci/tmp/logs.tar.gz \
 
     failed_test_cases = []
 
-    # Clear dmesg to avoid false OOM detection from previous CI jobs on the same host
-    Shell.check("dmesg --clear", verbose=True)
+    # Clear dmesg to avoid false OOM detection from previous CI jobs on the same host.
+    # Do this only in CI (non-local runs) and via a non-interactive privileged helper.
+    if not info.is_local_run:
+        try:
+            Utils.clear_dmesg()
+        except Exception as ex:
+            print(f"Failed to clear dmesg before integration tests: {ex}")
 
     if parallel_test_modules:
         for attempt in range(module_repeat_cnt):

--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -652,6 +652,9 @@ tar -czf ./ci/tmp/logs.tar.gz \
 
     failed_test_cases = []
 
+    # Clear dmesg to avoid false OOM detection from previous CI jobs on the same host
+    Shell.check("dmesg --clear", verbose=True)
+
     if parallel_test_modules:
         for attempt in range(module_repeat_cnt):
             log_file = f"{temp_path}/pytest_parallel.log"

--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -407,6 +407,10 @@ profiles:
         )
 
     def start(self, replica_num=0):
+        if replica_num == 0:
+            # Clear dmesg to avoid false OOM detection from previous CI jobs on the same host
+            Shell.check("dmesg --clear", verbose=True)
+
         if replica_num == 1:
             pid_file = self.pid_file_replica_1
             command = self.replica_command_1


### PR DESCRIPTION
## Summary
- The host-level `dmesg` persists across Docker containers, so OOM events from earlier CI jobs on the same host appear in the current job's dmesg check, causing false "OOM in dmesg" failures
- `stress_runner.sh` and `run-fuzzer.sh` already clear dmesg before running (with the comment "Avoid overlaps with previous runs"), but functional tests and integration tests were missing this
- Added `dmesg --clear` before functional tests start (in `ClickHouseProc.start`) and before integration tests start

Example of a false positive: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=98283&sha=124c14eb44e77cca21fb20cbd019b5f3d7dfb1ff&name_0=PR&name_1=Stateless%20tests%20%28amd_msan%2C%20WasmEdge%2C%20parallel%2C%202%2F2%29
https://github.com/ClickHouse/ClickHouse/pull/98283
- All 4351 tests passed, server ran and shut down gracefully
- The OOM in dmesg was from a previous job on the same host (kernel timestamp 680s from boot, before our container started tests)

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.159`
<!-- ch-version-info:end -->