### PR TITLE
Fix DROP DATABASE hung check caused by ignore_drop_queries_probability

### DIFF
--- a/src/Interpreters/InterpreterDropQuery.cpp
+++ b/src/Interpreters/InterpreterDropQuery.cpp
@@ -594,10 +594,17 @@ BlockIO InterpreterDropQuery::executeToDatabaseImpl(const ASTDropQuery & query, 
                 });
             }
 
+            /// Save original values that may be modified by ignore_drop_queries_probability
+            /// inside executeToTableImpl (it may set sync=false and kind=Truncate via non-const reference).
+            const auto original_kind = query_for_table.kind;
+            const auto original_sync = query_for_table.sync;
+
             for (const auto & table : tables_to_drop)
             {
                 query_for_table.setTable(table.first.getTableName());
                 query_for_table.is_dictionary = table.second;
+                query_for_table.kind = original_kind;
+                query_for_table.sync = original_sync;
                 DatabasePtr db;
                 UUID table_to_wait = UUIDHelpers::Nil;
                 /// Note: if this throws exception, the remaining tables won't be dropped and will stay in a


### PR DESCRIPTION
## Summary

- The `ignore_drop_queries_probability` handler in `executeToTableImpl` modifies `query_for_table.sync` and `query_for_table.kind` via non-const reference. Since `query_for_table` is shared across loop iterations in `executeToDatabaseImpl`, these modifications persist: after one table triggers the probability check, all subsequent tables get `sync=false` and potentially `kind=Truncate` instead of `Drop`.
- This causes tables to be truncated instead of dropped, `detachDatabase` to fail with `DATABASE_NOT_EMPTY`, and the query to hang forever in `waitTableFinallyDropped`.
- Fix: save original `kind`/`sync` before the loop and restore them at the beginning of each iteration.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=98251&sha=d83ec181cd967fac3fe0d13985b408c549b20d68&name_0=PR&name_1=Stress%20test%20%28amd_tsan%29
https://github.com/ClickHouse/ClickHouse/pull/98251

## Test plan

- [x] Verified fix compiles
- [ ] CI stress test should no longer show hung check failures from `DROP DATABASE` stuck in `waitTableFinallyDropped`

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.167`
<!-- ch-version-info:end -->