### PR TITLE
Fix flaky test `test_refreshable_mv/test.py::test_backup_outer_table`

### DIFF
--- a/tests/integration/test_refreshable_mv/test.py
+++ b/tests/integration/test_refreshable_mv/test.py
@@ -511,9 +511,18 @@ def do_test_backup(to_table):
         # A refresh may EXCHANGE the target table via the DDL log. The EXCHANGE propagates
         # asynchronously; SYNC REPLICA may run against the pre-EXCHANGE table, then the
         # EXCHANGE swaps in the new table whose data hasn't replicated yet → empty SELECT.
-        # Fix: stop the view, sync DDL, sync data.
+        # Fix: stop the view, wait for any in-flight refresh to fully complete (including
+        # the EXCHANGE DDL), sync DDL, sync data.
         for node in nodes:
             node.query("SYSTEM STOP VIEW re.rmv")
+        # WAIT VIEW ensures any in-flight refresh finishes, including the EXCHANGE DDL.
+        # For coordinated views it also waits for the EXCHANGE to be visible locally.
+        # If the refresh was cancelled by STOP VIEW, WAIT VIEW throws — that's expected.
+        for node in nodes:
+            try:
+                node.query("SYSTEM WAIT VIEW re.rmv")
+            except Exception:
+                pass
         for node in nodes:
             node.query("SYSTEM SYNC DATABASE REPLICA re")
         node1.query_with_retry(f"SYSTEM SYNC REPLICA re.{target}")


### PR DESCRIPTION
## Summary
- Fixed a race condition in `test_backup_outer_table` where `SYSTEM STOP VIEW` doesn't wait for an in-flight refresh to complete — if the INSERT phase finished and passed the `interrupt_execution` check before the stop signal arrived, the EXCHANGE DDL still proceeds asynchronously, replacing the target table with an empty (locally unreplicated) one between `SYNC REPLICA` and `SELECT`.
- Added `SYSTEM WAIT VIEW` after `SYSTEM STOP VIEW` to ensure any in-flight refresh fully completes, including the EXCHANGE DDL propagation to the local node (for coordinated views, `wait` polls until the table UUID matches).
- If the refresh was cancelled by `STOP VIEW`, `WAIT VIEW` throws an expected exception which is caught.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96351&sha=a7c43c721e68f1e3043bd29a9a175b66b60fc1ee&name_0=PR&name_1=Integration%20tests%20%28amd_tsan%2C%204%2F6%29
https://github.com/ClickHouse/ClickHouse/pull/96351

## Test plan
- [x] Ran `test_refreshable_mv` integration test suite locally — all 11 tests passed

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.165`
<!-- ch-version-info:end -->