### PR TITLE
Fix flaky test_covered_by_broken_exists integration test

### DIFF
--- a/tests/integration/test_covered_by_broken_exists/test.py
+++ b/tests/integration/test_covered_by_broken_exists/test.py
@@ -25,10 +25,10 @@ def started_cluster():
 
 
 def wait_merged_part(table, part_name, retries=100):
-    q("OPTIMIZE TABLE {} FINAL".format(table))
     for i in range(retries):
+        q("OPTIMIZE TABLE {}".format(table))
         result = q(
-            "SELECT name FROM system.parts where table='{}' AND name='{}'".format(
+            "SELECT name FROM system.parts where table='{}' AND name='{}' AND active".format(
                 table, part_name
             )
         )


### PR DESCRIPTION
The `wait_merged_part` function used `OPTIMIZE TABLE FINAL` to trigger merges. When a background merge had already created a part (e.g., `all_0_1_1`), `OPTIMIZE TABLE FINAL` would create an unnecessary trivial re-merge bumping the level (e.g., `all_0_1_2`). This caused subsequent merges to have higher levels than expected (e.g., `all_0_2_3` instead of `all_0_2_2`), and the test would time out waiting for a part that would never appear.

Fix: use `OPTIMIZE TABLE` without `FINAL` so that single-part partitions are left alone, move the call inside the retry loop, and filter by `active` parts in the `system.parts` query.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=98320&sha=3c78626a59efff974962eea56daf1733f155d143&name_0=PR&name_1=Integration%20tests%20%28amd_tsan%2C%203%2F6%29
https://github.com/ClickHouse/ClickHouse/pull/98320

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.171`
<!-- ch-version-info:end -->