### PR TITLE
Fix race in VersionMetadata::isVisible assertion

### DIFF
--- a/src/Interpreters/MergeTreeTransaction.cpp
+++ b/src/Interpreters/MergeTreeTransaction.cpp
@@ -243,6 +243,17 @@ void MergeTreeTransaction::afterCommit(CSN assigned_csn) noexcept
 
     for (const auto & part : removed_parts)
     {
+        /// Ensure creation_csn is set before removal_csn.
+        /// The creating transaction's afterCommit may still be running on another thread,
+        /// so creation_csn might not yet be stored even though the creation is committed.
+        /// Without this, a concurrent reader could observe removal_csn != 0 with creation_csn == 0.
+        if (!part->version.creation_csn.load(std::memory_order_relaxed))
+        {
+            auto creation = TransactionLog::getCSN(part->version.creation_tid, &part->version.creation_csn);
+            if (creation)
+                part->version.creation_csn.store(creation, std::memory_order_relaxed);
+        }
+
         part->version.removal_csn.store(csn);
         part->appendCSNToVersionMetadata(VersionMetadata::WhichCSN::REMOVAL);
     }

--- a/src/Interpreters/TransactionVersionMetadata.cpp
+++ b/src/Interpreters/TransactionVersionMetadata.cpp
@@ -134,9 +134,14 @@ bool VersionMetadata::isVisible(const MergeTreeTransaction & txn)
 bool VersionMetadata::isVisible(CSN snapshot_version, TransactionID current_tid)
 {
     chassert(!creation_tid.isEmpty());
-    CSN creation = creation_csn.load(std::memory_order_relaxed);
+
+    /// Load removal_csn with acquire: if a concurrent isVisible/canBeRemovedImpl call
+    /// stored removal_csn with release after storing creation_csn,
+    /// then loading removal_csn with acquire and creation_csn after it
+    /// guarantees we see creation_csn if removal_csn is set.
+    CSN removal = removal_csn.load(std::memory_order_acquire);
     TIDHash removal_lock = removal_tid_lock.load(std::memory_order_relaxed);
-    CSN removal = removal_csn.load(std::memory_order_relaxed);
+    CSN creation = creation_csn.load(std::memory_order_relaxed);
 
     [[maybe_unused]] bool had_creation_csn = creation;
     [[maybe_unused]] bool had_removal_tid = removal_lock;
@@ -210,7 +215,7 @@ bool VersionMetadata::isVisible(CSN snapshot_version, TransactionID current_tid)
     {
         removal = TransactionLog::getCSN(removal_lock, &removal_csn);
         if (removal)
-            removal_csn.store(removal, std::memory_order_relaxed);
+            removal_csn.store(removal, std::memory_order_release);  /// Pairs with acquire load at the top of isVisible
     }
 
     return creation <= snapshot_version && (!removal || snapshot_version < removal);
@@ -268,7 +273,7 @@ bool VersionMetadata::canBeRemovedImpl(CSN oldest_snapshot_version)
         /// Part removal is not committed yet
         removal = TransactionLog::getCSN(removal_lock, &removal_csn);
         if (removal)
-            removal_csn.store(removal, std::memory_order_relaxed);
+            removal_csn.store(removal, std::memory_order_release);  /// Pairs with acquire load in isVisible
         else
             return false;
     }


### PR DESCRIPTION
## Summary
- Fix a race condition causing a `chassert(!had_removal_csn || had_creation_csn)` exception in `VersionMetadata::isVisible` during TSan stress tests

### Root cause

When two concurrent `isVisible` calls process the same part with `creation_tid = PrehistoricTID`, `creation_csn = 0` (not cached), and `removal_tid_lock = PrehistoricTID.getHash()`, `removal_csn = 0` (not cached):

1. **Thread A** enters the slow path and stores `creation_csn = 1` (relaxed), then `removal_csn = 1` (relaxed)
2. **Thread B** loads `creation_csn` (relaxed) → sees **0** (Thread A's store not yet drained from store buffer), then loads `removal_csn` (relaxed) → sees **1** (Thread A's stores have now drained)
3. The assertion `!had_removal_csn || had_creation_csn` fires: `removal_csn = 1` but `creation_csn = 0`

This is valid under x86-TSO: Thread A's stores drain from its store buffer in FIFO order (`creation_csn` first, then `removal_csn`), but Thread B's loads can straddle this drain — reading `creation_csn` before the drain and `removal_csn` after.

All parts use `PrehistoricTID` (non-transactional merges on `DatabaseReplicated`), so `creation_csn` is never set during part creation — it remains 0 until `isVisible` caches it via the slow path.

### Fix

Use `memory_order_release` on `removal_csn` stores (which happen after `creation_csn` stores in program order), and `memory_order_acquire` on the `removal_csn` load in `isVisible`, with `creation_csn` loaded after it. This establishes a happens-before relationship: if the acquire load sees the release store, all prior stores (including `creation_csn`) are visible.

Additionally, in `afterCommit`, resolve `creation_csn` before storing `removal_csn` as defense-in-depth for the transactional case.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=c72af9dc041c515b1233a29dc85fc047a645fa55&name_0=MasterCI&name_1=Stress%20test%20%28amd_tsan%29

## Test plan
- [x] Reproduces in TSan stress test on master
- [ ] CI passes with the fix

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...


🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.178`
<!-- ch-version-info:end -->