### PR TITLE
Fix mysql_dotnet_client Docker image: add missing dotnet restore

### DIFF
--- a/ci/docker/integration/mysql_dotnet_client/Dockerfile
+++ b/ci/docker/integration/mysql_dotnet_client/Dockerfile
@@ -8,5 +8,7 @@ RUN apt-get update \
     && apt-get install -y software-properties-common build-essential dotnet-sdk-8.0 curl
 
 ARG ver=42.2.12
-COPY Program.cs Program.cs
 COPY testapp.csproj testapp.csproj
+RUN dotnet restore
+
+COPY Program.cs Program.cs


### PR DESCRIPTION
## Summary
- The `mysql_dotnet_client` Docker image was missing `dotnet restore`, so NuGet packages (`MySql.Data`, `CommandLineParser`) were not downloaded during image build
- This caused `test_mysql_dotnet_client` to fail with "The build failed. Fix the build errors and run again." when `dotnet run` tried to build without the packages
- The `dotnet add package` commands that previously performed the restore were removed in 080300f7ab5 without replacement

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=98251&sha=8b74075c1edba83ee5cfaa4a852ad804b6fe82de&name_0=PR&name_1=Integration%20tests%20%28amd_asan%2C%20db%20disk%2C%20old%20analyzer%2C%203%2F6%29
https://github.com/ClickHouse/ClickHouse/pull/98251

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.174`
<!-- ch-version-info:end -->