### PR TITLE
Fix flaky test 01018_dictionaries_from_dictionaries

### DIFF
--- a/tests/queries/0_stateless/01018_dictionaries_from_dictionaries.sql
+++ b/tests/queries/0_stateless/01018_dictionaries_from_dictionaries.sql
@@ -27,7 +27,7 @@ CREATE DICTIONARY database_for_dict.dict1
 )
 PRIMARY KEY key_column
 SOURCE(CLICKHOUSE(HOST 'localhost' PORT tcpPort() USER 'default' TABLE 'table_for_dict' DB 'database_for_dict'))
-LIFETIME(MIN 1 MAX 10)
+LIFETIME(0)
 LAYOUT(FLAT());
 
 SELECT count(*) from database_for_dict.dict1;
@@ -41,14 +41,16 @@ CREATE DICTIONARY database_for_dict.dict2
 )
 PRIMARY KEY key_column
 SOURCE(CLICKHOUSE(HOST 'localhost' PORT tcpPort() USER 'default' TABLE 'dict1' DB 'database_for_dict'))
-LIFETIME(MIN 1 MAX 10)
+LIFETIME(0)
 LAYOUT(HASHED());
 
 SELECT count(*) FROM database_for_dict.dict2;
 
 INSERT INTO database_for_dict.table_for_dict SELECT number, number % 17, toString(number * number), number / 2.0 from numbers(100, 100);
 
-SYSTEM RELOAD DICTIONARIES;
+-- Reload dictionaries in dependency order: table -> dict1 -> dict2
+SYSTEM RELOAD DICTIONARY database_for_dict.dict1;
+SYSTEM RELOAD DICTIONARY database_for_dict.dict2;
 
 SELECT count(*) from database_for_dict.dict2;
 SELECT count(*) from database_for_dict.dict1;
@@ -62,14 +64,17 @@ CREATE DICTIONARY database_for_dict.dict3
 )
 PRIMARY KEY key_column
 SOURCE(CLICKHOUSE(HOST 'localhost' PORT tcpPort() USER 'default' TABLE 'dict2' DB 'database_for_dict'))
-LIFETIME(MIN 1 MAX 10)
+LIFETIME(0)
 LAYOUT(HASHED());
 
 SELECT count(*) FROM database_for_dict.dict3;
 
 INSERT INTO database_for_dict.table_for_dict SELECT number, number % 17, toString(number * number), number / 2.0 from numbers(200, 100);
 
-SYSTEM RELOAD DICTIONARIES;
+-- Reload dictionaries in dependency order: table -> dict1 -> dict2 -> dict3
+SYSTEM RELOAD DICTIONARY database_for_dict.dict1;
+SYSTEM RELOAD DICTIONARY database_for_dict.dict2;
+SYSTEM RELOAD DICTIONARY database_for_dict.dict3;
 
 SELECT count(*) from database_for_dict.dict3;
 SELECT count(*) from database_for_dict.dict2;
@@ -85,7 +90,7 @@ CREATE DICTIONARY database_for_dict.dict4
 )
 PRIMARY KEY key_column
 SOURCE(CLICKHOUSE(HOST 'localhost' PORT tcpPort() USER 'default' TABLE 'non_existing_table' DB 'database_for_dict'))
-LIFETIME(MIN 1 MAX 10)
+LIFETIME(0)
 LAYOUT(HASHED());
 
 SELECT count(*) FROM database_for_dict.dict4; -- {serverError UNKNOWN_TABLE}


### PR DESCRIPTION
## Summary

- Fix flaky test `01018_dictionaries_from_dictionaries` which creates a chain of dictionaries (`table -> dict1 -> dict2 -> dict3`) and uses `SYSTEM RELOAD DICTIONARIES` to reload all at once. The reload order is not guaranteed, so if `dict2` reloads before `dict1`, it reads stale data.
- Changed `LIFETIME(MIN 1 MAX 10)` to `LIFETIME(0)` to prevent background auto-reload interference.
- Replaced `SYSTEM RELOAD DICTIONARIES` with individual `SYSTEM RELOAD DICTIONARY` calls in dependency order.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=98334&sha=d9f1fcebd688dacdbc6d01c02b1bb630c11f205e&name_0=PR&name_1=Stateless%20tests%20%28arm_asan%2C%20azure%2C%20sequential%29
https://github.com/ClickHouse/ClickHouse/pull/98334

### Changelog category (leave one):
- CI Fix or improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Not for changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.177`
<!-- ch-version-info:end -->