### PR TITLE
Add `KeeperRequestTotalWithSubrequests` profile event

### DIFF
--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -933,6 +933,7 @@ The server successfully detected this situation and will download merged part fr
     M(KeeperPacketsSent, "Packets sent by keeper server", ValueType::Number) \
     M(KeeperPacketsReceived, "Packets received by keeper server", ValueType::Number) \
     M(KeeperRequestTotal, "Total requests number on keeper server", ValueType::Number) \
+    M(KeeperRequestTotalWithSubrequests, "Total requests number on keeper server, counting each subrequest within a multi request", ValueType::Number) \
     M(KeeperLatency, "Keeper latency", ValueType::Milliseconds) \
     M(KeeperTotalElapsedMicroseconds, "Keeper total latency for a single request", ValueType::Microseconds) \
     M(KeeperProcessElapsedMicroseconds, "Keeper commit latency for a single request", ValueType::Microseconds) \

--- a/src/Coordination/KeeperConnectionStats.cpp
+++ b/src/Coordination/KeeperConnectionStats.cpp
@@ -7,6 +7,7 @@ namespace ProfileEvents
     extern const Event KeeperPacketsSent;
     extern const Event KeeperPacketsReceived;
     extern const Event KeeperRequestTotal;
+    extern const Event KeeperRequestTotalWithSubrequests;
     extern const Event KeeperLatency;
 }
 
@@ -58,13 +59,14 @@ void KeeperConnectionStats::incrementPacketsSent()
     ProfileEvents::increment(ProfileEvents::KeeperPacketsSent, 1);
 }
 
-void KeeperConnectionStats::updateLatency(uint64_t latency_ms)
+void KeeperConnectionStats::updateLatency(uint64_t latency_ms, uint64_t subrequests)
 {
     last_latency.store(latency_ms, std::memory_order_relaxed);
     total_latency.fetch_add(latency_ms, std::memory_order_relaxed);
     ProfileEvents::increment(ProfileEvents::KeeperLatency, latency_ms);
     count.fetch_add(1, std::memory_order_relaxed);
     ProfileEvents::increment(ProfileEvents::KeeperRequestTotal, 1);
+    ProfileEvents::increment(ProfileEvents::KeeperRequestTotalWithSubrequests, subrequests);
 
     uint64_t prev_val = min_latency.load(std::memory_order_relaxed);
     while (prev_val > latency_ms && !min_latency.compare_exchange_weak(prev_val, latency_ms, std::memory_order_relaxed)) {}

--- a/src/Coordination/KeeperConnectionStats.h
+++ b/src/Coordination/KeeperConnectionStats.h
@@ -29,7 +29,7 @@ public:
     void incrementPacketsReceived();
     void incrementPacketsSent();
 
-    void updateLatency(uint64_t latency_ms);
+    void updateLatency(uint64_t latency_ms, uint64_t subrequests = 1);
     void reset();
 
 private:

--- a/src/Coordination/KeeperConstants.cpp
+++ b/src/Coordination/KeeperConstants.cpp
@@ -237,6 +237,7 @@
     M(KeeperPacketsSent) \
     M(KeeperPacketsReceived) \
     M(KeeperRequestTotal) \
+    M(KeeperRequestTotalWithSubrequests) \
     M(KeeperLatency) \
     M(KeeperTotalElapsedMicroseconds) \
     M(KeeperProcessElapsedMicroseconds) \

--- a/src/Coordination/KeeperDispatcher.cpp
+++ b/src/Coordination/KeeperDispatcher.cpp
@@ -1105,9 +1105,9 @@ void KeeperDispatcher::updateConfiguration(const Poco::Util::AbstractConfigurati
     keeper_context->updateKeeperMemorySoftLimit(config);
 }
 
-void KeeperDispatcher::updateKeeperStatLatency(uint64_t process_time_ms)
+void KeeperDispatcher::updateKeeperStatLatency(uint64_t process_time_ms, uint64_t subrequests)
 {
-    keeper_stats.updateLatency(process_time_ms);
+    keeper_stats.updateLatency(process_time_ms, subrequests);
 }
 
 static uint64_t getTotalSize(const DiskPtr & disk, const std::string & path = "")

--- a/src/Coordination/KeeperDispatcher.h
+++ b/src/Coordination/KeeperDispatcher.h
@@ -166,7 +166,7 @@ public:
     void finishSession(int64_t session_id);
 
     /// Invoked when a request completes.
-    void updateKeeperStatLatency(uint64_t process_time_ms);
+    void updateKeeperStatLatency(uint64_t process_time_ms, uint64_t subrequests = 1);
 
     /// Are we leader
     bool isLeader() const

--- a/src/Server/KeeperTCPHandler.cpp
+++ b/src/Server/KeeperTCPHandler.cpp
@@ -827,10 +827,18 @@ void KeeperTCPHandler::updateStats(Coordination::ZooKeeperResponsePtr & response
                 request->toString(/*short_format=*/true));
         }
 
-        conn_stats.updateLatency(elapsed_ms);
+        uint64_t subrequest_count = 1;
+        if (request)
+        {
+            auto op_num = request->getOpNum();
+            if (op_num == Coordination::OpNum::Multi || op_num == Coordination::OpNum::MultiRead)
+                subrequest_count = static_cast<const Coordination::ZooKeeperMultiRequest &>(*request).requests.size();
+        }
+
+        conn_stats.updateLatency(elapsed_ms, subrequest_count);
 
         operations.erase(response->xid);
-        keeper_dispatcher->updateKeeperStatLatency(elapsed_ms);
+        keeper_dispatcher->updateKeeperStatLatency(elapsed_ms, subrequest_count);
 
         last_op.set(std::make_unique<LastOp>(LastOp{
             .name = Coordination::toString(response->getOpNum()),

--- a/tests/integration/test_keeper_request_total_with_subrequests/configs/enable_keeper.xml
+++ b/tests/integration/test_keeper_request_total_with_subrequests/configs/enable_keeper.xml
@@ -1,0 +1,27 @@
+<clickhouse>
+    <keeper_server>
+        <use_cluster>false</use_cluster>
+        <tcp_port>9181</tcp_port>
+        <server_id>1</server_id>
+        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
+        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
+
+        <coordination_settings>
+            <operation_timeout_ms>5000</operation_timeout_ms>
+            <session_timeout_ms>10000</session_timeout_ms>
+            <raft_logs_level>trace</raft_logs_level>
+            <force_sync>false</force_sync>
+            <heart_beat_interval_ms>0</heart_beat_interval_ms>
+            <election_timeout_lower_bound_ms>0</election_timeout_lower_bound_ms>
+            <election_timeout_upper_bound_ms>0</election_timeout_upper_bound_ms>
+        </coordination_settings>
+
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>localhost</hostname>
+                <port>9234</port>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+</clickhouse>

--- a/tests/integration/test_keeper_request_total_with_subrequests/test.py
+++ b/tests/integration/test_keeper_request_total_with_subrequests/test.py
@@ -1,0 +1,98 @@
+import uuid
+
+import pytest
+
+import helpers.keeper_utils as keeper_utils
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+
+node = cluster.add_instance(
+    "node",
+    main_configs=["configs/enable_keeper.xml"],
+    stay_alive=True,
+    with_remote_database_disk=False,
+)
+
+
+def get_fake_zk():
+    return keeper_utils.get_fake_zk(cluster, "node")
+
+
+def stop_zk(zk):
+    try:
+        if zk:
+            zk.stop()
+            zk.close()
+    except:
+        pass
+
+
+def get_event_value(event_name):
+    result = node.query(
+        f"SELECT value FROM system.events WHERE event = '{event_name}'"
+    ).strip()
+    return int(result) if result else 0
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_keeper_request_total_with_subrequests(started_cluster):
+    zk = None
+    try:
+        zk = get_fake_zk()
+
+        test_root = f"/test_subrequests_{uuid.uuid4().hex[:8]}"
+
+        # Warm up: create a root node for the test so Keeper connection is fully established
+        zk.create(test_root)
+
+        # Capture baseline
+        total_before = get_event_value("KeeperRequestTotal")
+        total_sub_before = get_event_value("KeeperRequestTotalWithSubrequests")
+
+        # 1) Single requests: 5 creates (each counts as 1 for both metrics)
+        num_single = 5
+        for i in range(num_single):
+            zk.create(f"{test_root}/single_{i}", b"data")
+
+        # 2) Multi-request (transaction) with 10 subrequests
+        num_multi_ops = 10
+        txn = zk.transaction()
+        for i in range(num_multi_ops):
+            txn.create(f"{test_root}/multi_{i}", b"data")
+        txn.commit()
+
+        # Capture after
+        total_after = get_event_value("KeeperRequestTotal")
+        total_sub_after = get_event_value("KeeperRequestTotalWithSubrequests")
+
+        total_diff = total_after - total_before
+        total_sub_diff = total_sub_after - total_sub_before
+
+        # KeeperRequestTotal: 5 single + 1 multi = 6 requests minimum
+        # (there may be background keeper requests, so use >=)
+        assert total_diff >= num_single + 1, (
+            f"KeeperRequestTotal diff {total_diff} < expected {num_single + 1}"
+        )
+
+        # KeeperRequestTotalWithSubrequests: 5 single + 10 subrequests = 15 minimum
+        assert total_sub_diff >= num_single + num_multi_ops, (
+            f"KeeperRequestTotalWithSubrequests diff {total_sub_diff} < expected {num_single + num_multi_ops}"
+        )
+
+        # The difference between the two metrics should be at least (num_multi_ops - 1),
+        # because the multi-request contributes 1 to Total but num_multi_ops to WithSubrequests
+        assert total_sub_diff - total_diff >= num_multi_ops - 1, (
+            f"Difference between metrics ({total_sub_diff - total_diff}) "
+            f"< expected ({num_multi_ops - 1})"
+        )
+    finally:
+        stop_zk(zk)


### PR DESCRIPTION
`KeeperRequestTotal` counts each top-level request as 1, regardless of whether it is a multi-request containing many subrequests. The new `KeeperRequestTotalWithSubrequests` event counts 1 for regular requests and N (the number of subrequests) for `Multi`/`MultiRead` requests, giving better visibility into the actual Keeper workload.

### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Added a new profile event `KeeperRequestTotalWithSubrequests` that counts each subrequest within a multi-request individually, providing better visibility into the actual Keeper workload. The existing `KeeperRequestTotal` event continues to count each multi-request as a single request.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.260`
- Backported to: `26.2.4.4`
<!-- ch-version-info:end -->