### PR TITLE
Set `max_block_size` to 500 for collapsed jemalloc profile output

### DIFF
--- a/programs/server/jemalloc.html
+++ b/programs/server/jemalloc.html
@@ -2244,6 +2244,7 @@
                 }
                 if (outputFormat === 'Collapsed') {
                     settings += `, jemalloc_profile_text_collapsed_use_count = ${useCount ? 1 : 0}`;
+                    settings += `, max_block_size = 500`;
                 }
                 const query = `SELECT * FROM system.jemalloc_profile_text SETTINGS ${settings}`;
                 const response = await fetch(buildUrl(query), {


### PR DESCRIPTION
Minimize memory usage when querying `system.jemalloc_profile_text` in collapsed format by streaming results in small blocks instead of buffering up to 65K rows.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Hopefully it will reduce memory usage of the query.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.193`
- Backported to: `26.2.2.8`
<!-- ch-version-info:end -->