### PR TITLE
Fix exception in assertHasValidVersionMetadata due to in-memory CSN caching

### DIFF
--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -2222,8 +2222,14 @@ bool IMergeTreeDataPart::assertHasValidVersionMetadata() const
         file.read(str_buf);
         bool valid_creation_tid = version.creation_tid == file.creation_tid;
         bool valid_removal_tid = version.removal_tid == file.removal_tid || version.removal_tid == Tx::PrehistoricTID;
-        bool valid_creation_csn = version.creation_csn == file.creation_csn || version.creation_csn == Tx::RolledBackCSN;
-        bool valid_removal_csn = version.removal_csn == file.removal_csn || version.removal_csn == Tx::PrehistoricCSN;
+        /// CSN may have been learned from the transaction log and cached in memory
+        /// (e.g., by VersionMetadata::isVisible) but not yet appended to the on-disk file.
+        bool valid_creation_csn = version.creation_csn == file.creation_csn
+            || version.creation_csn == Tx::RolledBackCSN
+            || file.creation_csn == Tx::UnknownCSN;
+        bool valid_removal_csn = version.removal_csn == file.removal_csn
+            || version.removal_csn == Tx::PrehistoricCSN
+            || file.removal_csn == Tx::UnknownCSN;
         bool valid_removal_tid_lock = (version.removal_tid.isEmpty() && version.removal_tid_lock == 0)
             || (version.removal_tid_lock == version.removal_tid.getHash());
         if (!valid_creation_tid || !valid_removal_tid || !valid_creation_csn || !valid_removal_csn || !valid_removal_tid_lock)


### PR DESCRIPTION
## Summary

- Fix a `chassert` failure in `assertHasValidVersionMetadata` that occurs when CSN values are cached in memory but not yet written to the on-disk version metadata file
- `VersionMetadata::isVisible` legitimately stores CSN values learned from the transaction log into memory without writing them to disk. When `assertHasValidVersionMetadata` later compares in-memory values with on-disk values, it incorrectly detects a mismatch
- The specific scenario: during a merge with transactions, after the part is committed, `isVisible` or `afterCommit` sets `creation_csn` in memory. If an exception then triggers task cancellation, `removeIfNeeded` → `assertHasValidVersionMetadata` reads the on-disk file (without the CSN) and finds it doesn't match the in-memory value (with the CSN)

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=98276&sha=2f17ecab6574a1c224f426aa57b1465978c61629&name_0=PR&name_1=Stress%20test%20%28arm_asan%2C%20s3%29
https://github.com/ClickHouse/ClickHouse/pull/98276

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.180`
<!-- ch-version-info:end -->