### PR TITLE
Revert "Call OpenSSL cleanup before safeExit to fix LeakSanitizer false positives"

### DIFF
--- a/programs/keeper/Keeper.cpp
+++ b/programs/keeper/Keeper.cpp
@@ -22,7 +22,6 @@
 #include <base/getMemoryAmount.h>
 #include <base/scope_guard.h>
 #include <base/safeExit.h>
-#include <Common/Crypto/OpenSSLInitializer.h>
 #include <base/Numa.h>
 #include <Poco/Net/NetException.h>
 #include <Poco/Net/TCPServerParams.h>
@@ -691,9 +690,6 @@ try
         if (current_connections)
         {
             LOG_INFO(log, "Will shutdown forcefully.");
-            /// safeExit calls _exit, which bypasses static destructors and atexit handlers.
-            /// Explicitly clean up OpenSSL to avoid LeakSanitizer false positives.
-            OpenSSLInitializer::cleanup();
             safeExit(0);
         }
     });

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -24,7 +24,6 @@
 #include <base/coverage.h>
 #include <base/getFQDNOrHostName.h>
 #include <base/safeExit.h>
-#include <Common/Crypto/OpenSSLInitializer.h>
 #include <base/Numa.h>
 #include <Common/PoolId.h>
 #include <Common/MemoryTracker.h>
@@ -3125,9 +3124,6 @@ try
                 /// Dump coverage here, because std::atexit callback would not be called.
                 dumpCoverageReportIfPossible();
                 LOG_WARNING(log, "Will shutdown forcefully.");
-                /// safeExit calls _exit, which bypasses static destructors and atexit handlers.
-                /// Explicitly clean up OpenSSL to avoid LeakSanitizer false positives.
-                OpenSSLInitializer::cleanup();
                 safeExit(0);
             }
         });


### PR DESCRIPTION
Reverts ClickHouse/ClickHouse#98296


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.173`
<!-- ch-version-info:end -->