### PR TITLE
Fix flaky test 01676_clickhouse_client_autocomplete under TSan

### DIFF
--- a/tests/queries/0_stateless/01676_clickhouse_client_autocomplete.python
+++ b/tests/queries/0_stateless/01676_clickhouse_client_autocomplete.python
@@ -133,7 +133,9 @@ client_compwords_positive = [
     "CHANGEABLE_IN_READONLY",
     # FIXME: one may add separate case for suggestion_limit
     # system.databases
-    "system",
+    # NOTE: Do not use "system" here because the prefix "sys" (3 chars) is too
+    # short and matches many completions, causing timeouts under TSan.
+    "information_schema",
     # system.tables
     "aggregate_function_combinators",
     # system.columns

--- a/tests/queries/0_stateless/01676_clickhouse_client_autocomplete.reference
+++ b/tests/queries/0_stateless/01676_clickhouse_client_autocomplete.reference
@@ -11,7 +11,7 @@ default_path_test: OK
 default: OK
 uniqCombined64ForEach: OK
 CHANGEABLE_IN_READONLY: OK
-system: OK
+information_schema: OK
 aggregate_function_combinators: OK
 primary_key_bytes_in_memory_allocated: OK
 # clickhouse-local


### PR DESCRIPTION
## Summary
- The test `01676_clickhouse_client_autocomplete` times out on the `system` database completion under TSan because the prefix `sys` (only 3 chars) matches multiple completions, making TAB completion slow
- Replace `system` with `information_schema` as the test word for `system.databases` completion — the 15-char prefix `information_sch` uniquely matches only one completion, making it fast and reliable

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96874&sha=59022a275f998a2e2a5117f7275cbf8d9db7d268&name_0=PR&name_1=Stateless%20tests%20%28amd_tsan%2C%20s3%20storage%2C%20parallel%2C%202%2F2%29
https://github.com/ClickHouse/ClickHouse/pull/96874

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.186`
<!-- ch-version-info:end -->