### PR TITLE
Add test that DROP DATABASE does not remove tables from other databases

### DIFF
--- a/tests/queries/0_stateless/03920_drop_database_does_not_remove_external_tables.reference
+++ b/tests/queries/0_stateless/03920_drop_database_does_not_remove_external_tables.reference
@@ -1,0 +1,4 @@
+1	hello
+2	world
+1	hello
+2	world

--- a/tests/queries/0_stateless/03920_drop_database_does_not_remove_external_tables.sh
+++ b/tests/queries/0_stateless/03920_drop_database_does_not_remove_external_tables.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Verify that DROP DATABASE does not remove tables from other databases,
+# even when tables inside the dropped database have loading dependencies on external tables.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+$CLICKHOUSE_LOCAL --multiquery "
+    CREATE DATABASE db_to_drop;
+    CREATE DATABASE db_to_keep;
+
+    CREATE TABLE db_to_keep.join_table (id UInt64, value String) ENGINE = Join(ANY, LEFT, id);
+    INSERT INTO db_to_keep.join_table VALUES (1, 'hello'), (2, 'world');
+
+    -- This table has a loading dependency on db_to_keep.join_table via joinGet.
+    CREATE TABLE db_to_drop.dependent (id UInt64, value String DEFAULT joinGet('db_to_keep.join_table', 'value', id)) ENGINE = MergeTree ORDER BY id;
+    INSERT INTO db_to_drop.dependent (id) VALUES (1), (2);
+
+    SELECT * FROM db_to_drop.dependent ORDER BY id;
+
+    DROP DATABASE db_to_drop;
+
+    -- The table in the other database must still exist.
+    SELECT * FROM db_to_keep.join_table ORDER BY id;
+"


### PR DESCRIPTION
Verify that when a database contains tables with loading dependencies on tables in other databases (e.g., via `joinGet`), dropping the database only removes its own tables and leaves external dependencies intact.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.188`
<!-- ch-version-info:end -->