### PR TITLE
Use exponential backoff for download retries in CI

### DIFF
--- a/tests/ci/build_download_helper.py
+++ b/tests/ci/build_download_helper.py
@@ -159,7 +159,13 @@ def download_build_with_progress(url: str, path: Path) -> None:
                 path.unlink()
 
             if i + 1 < DOWNLOAD_RETRIES_COUNT:
-                time.sleep(3)
+                sleep_time = 3 * (2**i)
+                logger.info(
+                    "Download attempt %i failed, retrying in %i seconds",
+                    i + 1,
+                    sleep_time,
+                )
+                time.sleep(sleep_time)
             else:
                 raise DownloadException(
                     f"Cannot download dataset from {url}, all retries exceeded"


### PR DESCRIPTION
## Summary
- The upgrade check job failed with a transient GitHub 502 Bad Gateway when downloading the previous release `clickhouse-keeper` package
- The fixed 3-second sleep between download retries totaled only ~12 seconds, not enough for CDN recovery
- Changed to exponential backoff (3s, 6s, 12s, 24s) for ~45 seconds total wait time

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=98276&sha=07a79dd5dcad48a5426bade8c9e5e5a553e2df7a&name_0=PR&name_1=Upgrade%20check%20%28amd_release%29
https://github.com/ClickHouse/ClickHouse/pull/98276

## Test plan
- [x] Verified the exponential backoff math: 3, 6, 12, 24 seconds between retries
- [x] No behavior change on success path (only affects retry sleep duration)

### Changelog category (leave one):
- CI Fix or improvement

### Changelog entry:
Use exponential backoff for CI download retries to better handle transient GitHub CDN errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)