### PR TITLE
Fix flaky 00601_kill_running_query test

### DIFF
--- a/tests/queries/0_stateless/00601_kill_running_query.sh
+++ b/tests/queries/0_stateless/00601_kill_running_query.sh
@@ -21,7 +21,7 @@ function wait_for_query_to_start()
 
 # Use sleep-based query that is guaranteed to run long enough to be killed,
 # unlike the previous groupArray query that could complete too quickly on fast machines.
-${CLICKHOUSE_CURL_COMMAND} -q --max-time 30 -sS "$CLICKHOUSE_URL&query_id=test_00601_$CLICKHOUSE_DATABASE" -d 'SELECT sleep(1) FROM numbers(10000) SETTINGS max_block_size = 1, max_rows_to_read = 0' > /dev/null &
+${CLICKHOUSE_CURL_COMMAND} -q --max-time 30 -sS "$CLICKHOUSE_URL&query_id=test_00601_$CLICKHOUSE_DATABASE" -d 'SELECT sleep(1) FROM numbers(10000) SETTINGS max_block_size = 1, max_rows_to_read = 0' > /dev/null 2>&1 &
 wait_for_query_to_start "test_00601_$CLICKHOUSE_DATABASE"
 $CLICKHOUSE_CURL -sS "$CLICKHOUSE_URL" -d "KILL QUERY WHERE query_id = 'test_00601_$CLICKHOUSE_DATABASE'"
 wait || true


### PR DESCRIPTION
## Summary
- Redirect stderr to `/dev/null` for the background curl command in `00601_kill_running_query` test
- When the query is killed, curl gets error 18 ("transfer closed with outstanding read data remaining") which leaks to stderr and causes the test framework to flag it as a failure
- This error is expected behavior since we intentionally kill the running query

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=40310cf12f41ba4d0ab4fb68045a9f7b10df4de9&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_debug%2C%20distributed%20plan%2C%20s3%20storage%2C%20parallel%29

## Test plan
- [x] Verify the fix redirects stderr correctly
- [ ] CI passes with the fix

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Fix flaky `00601_kill_running_query` test by suppressing expected curl error on query termination


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.208`
<!-- ch-version-info:end -->