### PR TITLE
Fix flaky test 03166_optimize_row_order_during_insert

### DIFF
--- a/tests/queries/0_stateless/03166_optimize_row_order_during_insert.sql
+++ b/tests/queries/0_stateless/03166_optimize_row_order_during_insert.sql
@@ -3,6 +3,9 @@
 
 -- Below SELECTs intentionally only ORDER BY the table primary key and rely on read-in-order optimization
 SET optimize_read_in_order = 1;
+-- The "Cardinalities test" relies on physical row order (no ORDER BY in SELECT),
+-- so we must use a single insert thread to get deterministic results.
+SET max_insert_threads = 1;
 
 -- Just simple check, that optimization works correctly for table with 2 columns and 2 equivalence classes.
 SELECT 'Simple test';


### PR DESCRIPTION
The "Cardinalities test" sub-test uses `SELECT * FROM tab` without `ORDER BY` on a table with `ORDER BY ()`, relying on the physical row order produced by `optimize_row_order`. With randomized `max_insert_threads > 1`, the INSERT splits data across threads, each optimizing its own block independently, producing non-deterministic physical order.

Fix by explicitly setting `max_insert_threads = 1`.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=98347&sha=e4c1294dc3745b48faf635f2992c4242f750331d&name_0=PR&name_1=Stateless%20tests%20%28amd_binary%2C%20ParallelReplicas%2C%20s3%20storage%2C%20parallel%29
https://github.com/ClickHouse/ClickHouse/pull/98347

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.214`
<!-- ch-version-info:end -->