### PR TITLE
Fix inconsistent AST formatting for NOT with subquery operand

### DIFF
--- a/src/Parsers/ASTFunction.cpp
+++ b/src/Parsers/ASTFunction.cpp
@@ -356,7 +356,11 @@ void ASTFunction::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSetting
                 /// We DO need parentheses around a single literal
                 /// For example, SELECT (NOT 0) + (NOT 0) cannot be transformed into SELECT NOT 0 + NOT 0, since
                 /// this is equal to SELECT NOT (0 + NOT 0)
-                bool outside_parens = frame.need_parens && (!frame.allow_moving_operators_before_parens || !inside_parens);
+                /// Only negate (-) can safely move before parentheses: -(x + y) is unambiguous.
+                /// NOT cannot: NOT (subquery) NOT LIKE x would be parsed as NOT ((subquery) NOT LIKE x),
+                /// because boolean NOT has lower precedence than comparison operators.
+                bool can_move_before_parens = frame.allow_moving_operators_before_parens && (name == "negate");
+                bool outside_parens = frame.need_parens && (!can_move_before_parens || !inside_parens);
 
                 /// Do not add extra parentheses for functions inside negate, i.e. -(-toUInt64(-(1)))
                 if (inside_parens)

--- a/tests/queries/0_stateless/04006_not_subquery_not_like_formatting.reference
+++ b/tests/queries/0_stateless/04006_not_subquery_not_like_formatting.reference
@@ -1,0 +1,7 @@
+SELECT (NOT ((\n        SELECT 1\n    ))) NOT LIKE \'x\'
+SELECT (NOT ((\n        SELECT 1\n    ))) LIKE \'x\'
+SELECT (NOT ((\n        SELECT 1\n    ))) NOT ILIKE \'x\'
+SELECT (NOT ((\n        SELECT 1\n    ))) ILIKE \'x\'
+SELECT (NOT ((\n        SELECT 1\n    ))) IN (1, 2, 3)
+SELECT (NOT ((\n        SELECT 1\n    ))) NOT IN (1, 2, 3)
+SELECT (NOT ((\n        SELECT 1\n    ))) = 1

--- a/tests/queries/0_stateless/04006_not_subquery_not_like_formatting.sql
+++ b/tests/queries/0_stateless/04006_not_subquery_not_like_formatting.sql
@@ -1,0 +1,12 @@
+-- Verify that NOT (subquery) as operand of a comparison operator gets proper parentheses.
+-- The issue was that NOT has lower precedence than comparison operators,
+-- so NOT (subquery) NOT LIKE x was reparsed as NOT ((subquery) NOT LIKE x).
+-- With the fix, the formatter produces (NOT (subquery)) NOT LIKE x which is stable.
+
+SELECT formatQuery('SELECT (NOT (SELECT 1)) NOT LIKE \'x\'');
+SELECT formatQuery('SELECT (NOT (SELECT 1)) LIKE \'x\'');
+SELECT formatQuery('SELECT (NOT (SELECT 1)) NOT ILIKE \'x\'');
+SELECT formatQuery('SELECT (NOT (SELECT 1)) ILIKE \'x\'');
+SELECT formatQuery('SELECT (NOT (SELECT 1)) IN (1, 2, 3)');
+SELECT formatQuery('SELECT (NOT (SELECT 1)) NOT IN (1, 2, 3)');
+SELECT formatQuery('SELECT (NOT (SELECT 1)) = 1');


### PR DESCRIPTION
## Summary

- Fix inconsistent AST formatting when `NOT (subquery)` is used as an operand of a binary comparison operator (`NOT LIKE`, `LIKE`, `=`, `IN`, etc.)
- The `allow_moving_operators_before_parens` optimization suppressed outer parentheses for `NOT`, but this is only safe for `negate` (`-`) which has higher precedence than binary operators
- `NOT` has lower precedence than comparison operators, so `NOT (subquery) NOT LIKE x` was reparsed as `NOT ((subquery) NOT LIKE x)`, triggering the debug assertion

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=98288&sha=5f38f1dc25b5473a79c581e3f00b3f0d1a7d7fb1&name_0=PR&name_1=BuzzHouse%20%28amd_debug%29
https://github.com/ClickHouse/ClickHouse/pull/98288

## Test plan

- [x] New test `04006_not_subquery_not_like_formatting` verifies `(NOT (SELECT 1))` preserves outer parens for `NOT LIKE`, `LIKE`, `NOT ILIKE`, `ILIKE`, `IN`, `NOT IN`, `=`
- [x] Existing tests `02990_format_not_precedence`, `03987_not_operator_precedence`, `03168_inconsistent_ast_formatting`, `03760_consistent-in-formatting` all pass unchanged
- [x] Verified format-parse-format consistency with `formatQuery(x) = formatQuery(formatQuery(x))`

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.212`
<!-- ch-version-info:end -->