### PR TITLE
Run auto-release daily and look past failed commits

### DIFF
--- a/.github/workflows/auto_releases.yml
+++ b/.github/workflows/auto_releases.yml
@@ -8,7 +8,7 @@ concurrency:
 
 on:
   schedule:
-    - cron: '45 11 * * 2,4'
+    - cron: '45 11 * * *'
   workflow_dispatch:
     inputs:
       dry-run:

--- a/tests/ci/auto_release.py
+++ b/tests/ci/auto_release.py
@@ -156,14 +156,19 @@ def _prepare(token):
                 commits_to_branch_head += 1
                 continue
 
-            commit_sha = commit
-            failed_jobs = GH.get_failed_statuses(token=token, commit_sha=commit_sha)
+            failed_jobs = GH.get_failed_statuses(token=token, commit_sha=commit)
             if not failed_jobs:
+                commit_sha = commit
                 commit_ci_status = SUCCESS
+                break
             else:
-                # add failed jobs from most recent ready commit to the release info description to post it in alert
-                description = f"Failed jobs: {failed_jobs}"
-            break
+                print(
+                    f"CI failed for [{commit}]: {failed_jobs} - check previous commit"
+                )
+                # Save the description from the most recent failed commit
+                if not description:
+                    description = f"Failed jobs: {failed_jobs}"
+                commits_to_branch_head += 1
 
         ready = False
         if commit_ci_status == SUCCESS and commit_sha:


### PR DESCRIPTION
## Summary
- Run the `AutoReleases` workflow daily (`'45 11 * * *'`) instead of only on Tuesdays and Thursdays (`'45 11 * * 2,4'`), reducing the delay between a release branch going green and the patch release.
- When scanning release branch commits, continue past completed-but-failed commits to find an older green commit that hasn't been released yet. Previously the loop would `break` on the first completed commit regardless of pass/fail, meaning a single flaky CI run could block the release even when earlier commits were green.

Investigated in https://github.com/ClickHouse/ClickHouse/pull/97856 — the 26.2 branch had multiple green CI runs but the auto-release couldn't pick them up due to the Tue/Thu-only schedule.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.202`
<!-- ch-version-info:end -->