### PR TITLE
Use _exit instead of exit after fork in beDaemon

### DIFF
--- a/base/poco/Util/src/ServerApplication.cpp
+++ b/base/poco/Util/src/ServerApplication.cpp
@@ -184,7 +184,7 @@ void ServerApplication::beDaemon()
 	if ((pid = fork()) < 0)
 		throw SystemException("cannot fork daemon process");
 	else if (pid != 0)
-		exit(0);
+		_exit(0);
 
 	setsid();
 	umask(027);


### PR DESCRIPTION
## Summary

In `ServerApplication::beDaemon`, after `fork()`, the parent process calls `exit(0)` to terminate. Per POSIX best practice, the non-continuing process after a `fork` should use `_exit()` instead of `exit()` to avoid flushing stdio buffers twice or running `atexit` handlers that may interfere with the child process.

Reference: http://www.unixguide.net/unix/programming/1.1.3.shtml

> *"There are some unusual cases, like daemons, where the parent should call `_exit()` rather than the child; the basic rule, applicable in the overwhelming majority of cases, is that `exit()` should be called only once for each entry into `main`."*

### Changelog category (leave one):

- Not for changelog (infrastructure/internals)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):

- N/A

### Documentation entry for user-facing changes

- [x] Documentation is not required


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.228`
<!-- ch-version-info:end -->