### PR TITLE
keeper: respect priority adding multiple keeper nodes

### DIFF
--- a/src/Coordination/KeeperDispatcher.cpp
+++ b/src/Coordination/KeeperDispatcher.cpp
@@ -28,6 +28,7 @@
 #include <IO/ReadHelpers.h>
 #include <Disks/IDisk.h>
 
+#include <algorithm>
 #include <atomic>
 #include <future>
 #include <chrono>
@@ -1060,6 +1061,20 @@ void KeeperDispatcher::clusterUpdateThread()
 void KeeperDispatcher::pushClusterUpdates(ClusterUpdateActions && actions)
 {
     if (keeper_context->isShutdownCalled()) return;
+
+    /// Sort AddRaftServer actions by priority (higher priority first).
+    /// When adding multiple servers at once, we should start with the higher priority servers.
+    std::stable_sort(actions.begin(), actions.end(), [](const ClusterUpdateAction & a, const ClusterUpdateAction & b)
+    {
+        const auto * add_a = std::get_if<AddRaftServer>(&a);
+        const auto * add_b = std::get_if<AddRaftServer>(&b);
+
+        if (add_a && add_b)
+            return add_a->priority > add_b->priority;
+
+        return false;
+    });
+
     for (auto && action : actions)
     {
         if (!cluster_update_queue.push(std::move(action)))
@@ -1096,9 +1111,7 @@ void KeeperDispatcher::updateConfiguration(const Poco::Util::AbstractConfigurati
         LOG_DEBUG(log, "Configuration change size ({})", diff.size());
 
     if (!reconfigEnabled())
-        for (auto & change : diff)
-            if (!cluster_update_queue.push(change))
-                throw Exception(ErrorCodes::SYSTEM_ERROR, "Cannot push configuration update to queue");
+        pushClusterUpdates(std::move(diff));
 
     snapshot_s3.updateS3Configuration(config, macros);
 

--- a/tests/integration/test_keeper_nodes_add/configs/enable_keeper_three_nodes_with_priority_1.xml
+++ b/tests/integration/test_keeper_nodes_add/configs/enable_keeper_three_nodes_with_priority_1.xml
@@ -1,0 +1,39 @@
+<clickhouse>
+    <keeper_server>
+        <use_cluster>false</use_cluster>
+
+        <tcp_port>9181</tcp_port>
+        <server_id>1</server_id>
+        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
+        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
+
+        <coordination_settings>
+            <operation_timeout_ms>5000</operation_timeout_ms>
+            <session_timeout_ms>10000</session_timeout_ms>
+            <raft_logs_level>trace</raft_logs_level>
+        </coordination_settings>
+
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>node1</hostname>
+                <port>9234</port>
+                <priority>100</priority>
+            </server>
+            <server>
+                <id>2</id>
+                <hostname>node2</hostname>
+                <port>9234</port>
+                <priority>90</priority>
+                <start_as_follower>true</start_as_follower>
+            </server>
+            <server>
+                <id>3</id>
+                <hostname>node3</hostname>
+                <port>9234</port>
+                <priority>80</priority>
+                <start_as_follower>true</start_as_follower>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+</clickhouse>

--- a/tests/integration/test_keeper_nodes_add/configs/enable_keeper_three_nodes_with_priority_2.xml
+++ b/tests/integration/test_keeper_nodes_add/configs/enable_keeper_three_nodes_with_priority_2.xml
@@ -1,0 +1,39 @@
+<clickhouse>
+    <keeper_server>
+        <use_cluster>false</use_cluster>
+
+        <tcp_port>9181</tcp_port>
+        <server_id>2</server_id>
+        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
+        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
+
+        <coordination_settings>
+            <operation_timeout_ms>5000</operation_timeout_ms>
+            <session_timeout_ms>10000</session_timeout_ms>
+            <raft_logs_level>trace</raft_logs_level>
+        </coordination_settings>
+
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>node1</hostname>
+                <port>9234</port>
+                <priority>100</priority>
+            </server>
+            <server>
+                <id>2</id>
+                <hostname>node2</hostname>
+                <port>9234</port>
+                <priority>90</priority>
+                <start_as_follower>true</start_as_follower>
+            </server>
+            <server>
+                <id>3</id>
+                <hostname>node3</hostname>
+                <port>9234</port>
+                <priority>80</priority>
+                <start_as_follower>true</start_as_follower>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+</clickhouse>

--- a/tests/integration/test_keeper_nodes_add/configs/enable_keeper_three_nodes_with_priority_3.xml
+++ b/tests/integration/test_keeper_nodes_add/configs/enable_keeper_three_nodes_with_priority_3.xml
@@ -1,0 +1,39 @@
+<clickhouse>
+    <keeper_server>
+        <use_cluster>false</use_cluster>
+
+        <tcp_port>9181</tcp_port>
+        <server_id>3</server_id>
+        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
+        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
+
+        <coordination_settings>
+            <operation_timeout_ms>5000</operation_timeout_ms>
+            <session_timeout_ms>10000</session_timeout_ms>
+            <raft_logs_level>trace</raft_logs_level>
+        </coordination_settings>
+
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>node1</hostname>
+                <port>9234</port>
+                <priority>100</priority>
+            </server>
+            <server>
+                <id>2</id>
+                <hostname>node2</hostname>
+                <port>9234</port>
+                <priority>90</priority>
+                <start_as_follower>true</start_as_follower>
+            </server>
+            <server>
+                <id>3</id>
+                <hostname>node3</hostname>
+                <port>9234</port>
+                <priority>80</priority>
+                <start_as_follower>true</start_as_follower>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+</clickhouse>

--- a/tests/integration/test_keeper_nodes_add/test.py
+++ b/tests/integration/test_keeper_nodes_add/test.py
@@ -49,6 +49,9 @@ def test_nodes_add(started_cluster):
         zk_conn = get_fake_zk(node1)
 
         for i in range(100):
+            # Cleanup existing znodes from previous runs
+            if zk_conn.exists("/test_two_" + str(i)):
+                zk_conn.delete("/test_two_" + str(i))
             zk_conn.create("/test_two_" + str(i), b"somedata")
 
         p = Pool(3)
@@ -77,6 +80,9 @@ def test_nodes_add(started_cluster):
         zk_conn = get_fake_zk(node1)
 
         for i in range(100):
+            # Cleanup existing znodes from previous runs
+            if zk_conn.exists("/test_three_" + str(i)):
+                zk_conn.delete("/test_three_" + str(i))
             zk_conn.create("/test_three_" + str(i), b"somedata")
 
         node3.stop_clickhouse()
@@ -132,7 +138,6 @@ def test_nodes_add_respect_priority(started_cluster):
         node2.stop_clickhouse()
         node3.stop_clickhouse()
 
-        # Clear coordination data on all nodes to reset cluster state
         for node in (node1, node2, node3):
             node.exec_in_container(
                 ["bash", "-c", "rm -rf /var/lib/clickhouse/coordination"]

--- a/tests/integration/test_keeper_nodes_add/test.py
+++ b/tests/integration/test_keeper_nodes_add/test.py
@@ -125,36 +125,100 @@ def test_nodes_add(started_cluster):
 
 
 def test_nodes_add_respect_priority(started_cluster):
-    """
-    Test that when adding multiple servers at once, they are added in priority order
-    """
-    node1.stop_clickhouse()
-    node1.copy_file_to_container(
-        os.path.join(CONFIG_DIR, "enable_keeper1.xml"),
-        "/etc/clickhouse-server/config.d/enable_keeper1.xml",
-    )
-    node1.start_clickhouse()
-    keeper_utils.wait_until_connected(cluster, node1)
+    zk_conn = None
 
-    # Update config to add node2 (priority 90) and node3 (priority 80) at once
-    node1.copy_file_to_container(
-        os.path.join(CONFIG_DIR, "enable_keeper_three_nodes_with_priority_1.xml"),
-        "/etc/clickhouse-server/config.d/enable_keeper1.xml",
-    )
+    try:
+        node1.stop_clickhouse()
+        node2.stop_clickhouse()
+        node3.stop_clickhouse()
 
-    # Wait for both servers to be added
-    node1.wait_for_log_line(
-        "Processing config update.*Add server", repetitions=2, timeout=30
-    )
+        # Clear coordination data on all nodes to reset cluster state
+        for node in (node1, node2, node3):
+            node.exec_in_container(
+                ["bash", "-c", "rm -rf /var/lib/clickhouse/coordination"]
+            )
 
-    # Verify that server 2 is pushed before server 3
-    log = node1.grep_in_log("Processing config update")
-    add_server_2_pos = log.find("(Add server 2)")
-    add_server_3_pos = log.find("(Add server 3)")
+        node1.copy_file_to_container(
+            os.path.join(CONFIG_DIR, "enable_keeper1.xml"),
+            "/etc/clickhouse-server/config.d/enable_keeper1.xml",
+        )
+        node1.start_clickhouse()
+        keeper_utils.wait_until_connected(cluster, node1)
+        zk_conn = get_fake_zk(node1)
 
-    assert add_server_2_pos != -1, "Server 2 add not found in log"
-    assert add_server_3_pos != -1, "Server 3 add not found in log"
-    assert add_server_2_pos < add_server_3_pos, (
-        f"Server 2 (priority 90) should be added before server 3 (priority 80), "
-        f"but found server 2 at pos {add_server_2_pos} and server 3 at pos {add_server_3_pos}"
-    )
+        # Verify initial config has only node1
+        initial_config = zk_conn.get("/keeper/config")[0].decode()
+        assert "server.1=" in initial_config
+        assert "server.2=" not in initial_config
+        assert "server.3=" not in initial_config
+
+        p = Pool(3)
+
+        node2.stop_clickhouse()
+        node2.copy_file_to_container(
+            os.path.join(CONFIG_DIR, "enable_keeper_three_nodes_with_priority_2.xml"),
+            "/etc/clickhouse-server/config.d/enable_keeper2.xml",
+        )
+        node3.stop_clickhouse()
+        node3.copy_file_to_container(
+            os.path.join(CONFIG_DIR, "enable_keeper_three_nodes_with_priority_3.xml"),
+            "/etc/clickhouse-server/config.d/enable_keeper3.xml",
+        )
+
+        waiter2 = p.apply_async(start, (node2,))
+        waiter3 = p.apply_async(start, (node3,))
+
+        # Update node1 config to add node2 (priority 90) and node3 (priority 80)
+        node1.copy_file_to_container(
+            os.path.join(CONFIG_DIR, "enable_keeper_three_nodes_with_priority_1.xml"),
+            "/etc/clickhouse-server/config.d/enable_keeper1.xml",
+        )
+        # Monitor config changes by collecting raw configs
+        configs = []
+        start_time = time.time()
+        timeout = 30.0
+        poll_interval = 0.1
+
+        while time.time() - start_time < timeout:
+            try:
+                config = zk_conn.get("/keeper/config")[0].decode()
+
+                # Record config if it changed
+                if not configs or configs[-1] != config:
+                    configs.append(config)
+
+                # Stop when both servers appear
+                if "server.2=" in config and "server.3=" in config:
+                    break
+
+                time.sleep(poll_interval)
+            except Exception:
+                # Config might be temporarily unavailable during update
+                time.sleep(poll_interval)
+
+        waiter2.wait()
+        waiter3.wait()
+
+        assert len(configs) == 3, (
+            f"Expected exactly 3 config states, got {len(configs)}. "
+            f"Config sequence:\n" + "\n---\n".join(configs)
+        )
+
+        # initial state with only server.1
+        assert "server.1=" in configs[0]
+        assert "server.2=" not in configs[0]
+        assert "server.3=" not in configs[0]
+
+        # server.2 added (higher priority)
+        assert "server.1=" in configs[1]
+        assert "server.2=" in configs[1]
+        assert "server.3=" not in configs[1]
+
+        # server.3 added (lower priority)
+        assert "server.1=" in configs[2]
+        assert "server.2=" in configs[2]
+        assert "server.3=" in configs[2]
+    finally:
+        if zk_conn:
+            zk_conn.stop()
+            zk_conn.close()

--- a/tests/integration/test_keeper_nodes_add/test.py
+++ b/tests/integration/test_keeper_nodes_add/test.py
@@ -122,3 +122,39 @@ def test_nodes_add(started_cluster):
             if zk:
                 zk.stop()
                 zk.close()
+
+
+def test_nodes_add_respect_priority(started_cluster):
+    """
+    Test that when adding multiple servers at once, they are added in priority order
+    """
+    node1.stop_clickhouse()
+    node1.copy_file_to_container(
+        os.path.join(CONFIG_DIR, "enable_keeper1.xml"),
+        "/etc/clickhouse-server/config.d/enable_keeper1.xml",
+    )
+    node1.start_clickhouse()
+    keeper_utils.wait_until_connected(cluster, node1)
+
+    # Update config to add node2 (priority 90) and node3 (priority 80) at once
+    node1.copy_file_to_container(
+        os.path.join(CONFIG_DIR, "enable_keeper_three_nodes_with_priority_1.xml"),
+        "/etc/clickhouse-server/config.d/enable_keeper1.xml",
+    )
+
+    # Wait for both servers to be added
+    node1.wait_for_log_line(
+        "Processing config update.*Add server", repetitions=2, timeout=30
+    )
+
+    # Verify that server 2 is pushed before server 3
+    log = node1.grep_in_log("Processing config update")
+    add_server_2_pos = log.find("(Add server 2)")
+    add_server_3_pos = log.find("(Add server 3)")
+
+    assert add_server_2_pos != -1, "Server 2 add not found in log"
+    assert add_server_3_pos != -1, "Server 3 add not found in log"
+    assert add_server_2_pos < add_server_3_pos, (
+        f"Server 2 (priority 90) should be added before server 3 (priority 80), "
+        f"but found server 2 at pos {add_server_2_pos} and server 3 at pos {add_server_3_pos}"
+    )


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Keeper: respect server priority when adding multiple Keeper nodes (higher priority first)

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

Previously the order was undefined. With this patch, when multiple servers are added to keeper cluster at once, sort `AddRaftServer` actions by priority (higher first) before processing.