### PR TITLE
Allow custom http_handlers per protocol endpoint

### DIFF
--- a/docs/en/operations/settings/composable-protocols.md
+++ b/docs/en/operations/settings/composable-protocols.md
@@ -164,6 +164,60 @@ Additional endpoints can be defined by referencing any module and omitting the
 </protocols>
 ```
 
+### Custom HTTP handlers per endpoint {#custom-http-handlers-per-endpoint}
+
+By default, all `type=http` protocol entries share the same `<http_handlers>`
+configuration. You can override this by adding a `<handlers>` tag that points
+to a different configuration section. This allows each HTTP port to serve a
+different set of HTTP routing rules.
+
+For example, to run an alternative HTTP API on port 8124 with its own handlers:
+
+```xml
+<protocols>
+
+  <plain_http>
+    <type>http</type>
+    <host>127.0.0.1</host>
+    <port>8123</port>
+  </plain_http>
+
+  <alt_http>
+    <type>http</type>
+    <host>127.0.0.1</host>
+    <port>8124</port>
+    <handlers>http_handlers_alt</handlers>
+  </alt_http>
+
+</protocols>
+
+<!-- Default handlers used by plain_http (port 8123) -->
+<http_handlers>
+    <defaults/>
+</http_handlers>
+
+<!-- Alternative handlers used by alt_http (port 8124) -->
+<http_handlers_alt>
+    <rule>
+        <url>/custom</url>
+        <handler>
+            <type>predefined_query_handler</type>
+            <query>SELECT 'custom_endpoint'</query>
+        </handler>
+    </rule>
+    <defaults/>
+</http_handlers_alt>
+```
+
+In this example, requests to port 8123 use the standard `<http_handlers>` rules,
+while requests to port 8124 use the `<http_handlers_alt>` rules. If `<handlers>`
+is omitted, the endpoint falls back to the default `<http_handlers>`.
+
+The custom handlers section follows the same format as
+[`<http_handlers>`](/docs/en/operations/server-configuration-parameters/settings#http_handlers).
+Changes to the custom handlers section are detected during config reload, and the
+corresponding endpoint is automatically restarted.
+
 ### Specifying additional layer parameters {#some-modules-can-contain-specific-for-its-layer-parameters}
 
 Some modules can contain additional layer parameters. For example, the TLS layer

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -3174,9 +3174,16 @@ std::unique_ptr<TCPProtocolStackFactory> Server::buildProtocolStackFromConfig(
             return TCPServerConnectionFactory::Ptr(new PostgreSQLHandlerFactory(*this, server_settings[ServerSetting::postgresql_require_secure_transport], ProfileEvents::InterfacePostgreSQLReceiveBytes, ProfileEvents::InterfacePostgreSQLSendBytes));
 #endif
         if (type == "http")
+        {
+            /// Allow custom http_handlers configuration for this protocol endpoint.
+            /// E.g. <protocols><my_http><type>http</type><handlers>http_handlers_alt</handlers></my_http></protocols>
+            String handlers_config_key;
+            if (config.has(conf_name + ".handlers"))
+                handlers_config_key = config.getString(conf_name + ".handlers");
             return TCPServerConnectionFactory::Ptr(
-                new HTTPServerConnectionFactory(httpContext(), http_params, createHandlerFactory(*this, config, async_metrics, "HTTPHandler-factory"), ProfileEvents::InterfaceHTTPReceiveBytes, ProfileEvents::InterfaceHTTPSendBytes)
+                new HTTPServerConnectionFactory(httpContext(), http_params, createHandlerFactory(*this, config, async_metrics, "HTTPHandler-factory", handlers_config_key), ProfileEvents::InterfaceHTTPReceiveBytes, ProfileEvents::InterfaceHTTPSendBytes)
             );
+        }
         if (type == "prometheus")
         {
             const std::string handler_name = server_settings[ServerSetting::prometheus_keeper_metrics_only] ? "KeeperPrometheusHandler-factory" : "PrometheusHandler-factory";
@@ -3743,6 +3750,7 @@ void Server::updateServers(
             std::string port_name = server->getPortName();
             bool has_host = false;
             bool is_http = false;
+            String handlers_key = "http_handlers";
             if (port_name.starts_with("protocols."))
             {
                 std::string protocol = port_name.substr(0, port_name.find_last_of('.'));
@@ -3759,6 +3767,8 @@ void Server::updateServers(
                         if (type == "http")
                         {
                             is_http = true;
+                            if (config.has(conf_name + ".handlers"))
+                                handlers_key = config.getString(conf_name + ".handlers");
                             break;
                         }
                     }
@@ -3784,9 +3794,9 @@ void Server::updateServers(
             if (!has_host)
                 has_host = std::find(listen_hosts.begin(), listen_hosts.end(), server->getListenHost()) != listen_hosts.end();
             bool has_port = !config.getString(port_name, "").empty();
-            bool force_restart = is_http && !isSameConfiguration(previous_config, config, "http_handlers");
+            bool force_restart = is_http && !isSameConfiguration(previous_config, config, handlers_key);
             if (force_restart)
-                LOG_TRACE(log, "<http_handlers> had been changed, will reload {}", server->getDescription());
+                LOG_TRACE(log, "<{}> had been changed, will reload {}", handlers_key, server->getDescription());
 
             if (!has_host || !has_port || config.getInt(server->getPortName()) != server->portNumber() || force_restart)
             {

--- a/src/Server/HTTPHandlerFactory.cpp
+++ b/src/Server/HTTPHandlerFactory.cpp
@@ -263,11 +263,11 @@ static inline auto createHandlersFactoryFromConfig(
 }
 
 static inline HTTPRequestHandlerFactoryPtr
-createHTTPHandlerFactory(IServer & server, const Poco::Util::AbstractConfiguration & config, const std::string & name, AsynchronousMetrics & async_metrics)
+createHTTPHandlerFactory(IServer & server, const Poco::Util::AbstractConfiguration & config, const std::string & name, AsynchronousMetrics & async_metrics, const std::string & http_handlers_key = "http_handlers")
 {
-    if (config.has("http_handlers"))
+    if (config.has(http_handlers_key))
     {
-        return createHandlersFactoryFromConfig(server, config, name, "http_handlers", async_metrics);
+        return createHandlersFactoryFromConfig(server, config, name, http_handlers_key, async_metrics);
     }
 
     auto factory = std::make_shared<HTTPRequestHandlerFactoryMain>(name);
@@ -287,10 +287,10 @@ static inline HTTPRequestHandlerFactoryPtr createInterserverHTTPHandlerFactory(I
     return factory;
 }
 
-HTTPRequestHandlerFactoryPtr createHandlerFactory(IServer & server, const Poco::Util::AbstractConfiguration & config, AsynchronousMetrics & async_metrics, const std::string & name)
+HTTPRequestHandlerFactoryPtr createHandlerFactory(IServer & server, const Poco::Util::AbstractConfiguration & config, AsynchronousMetrics & async_metrics, const std::string & name, const std::string & http_handlers_key)
 {
     if (name == "HTTPHandler-factory" || name == "HTTPSHandler-factory")
-        return createHTTPHandlerFactory(server, config, name, async_metrics);
+        return createHTTPHandlerFactory(server, config, name, async_metrics, http_handlers_key.empty() ? "http_handlers" : http_handlers_key);
     if (name == "InterserverIOHTTPHandler-factory" || name == "InterserverIOHTTPSHandler-factory")
         return createInterserverHTTPHandlerFactory(server, name, config);
     if (name == "PrometheusHandler-factory")

--- a/src/Server/HTTPHandlerFactory.h
+++ b/src/Server/HTTPHandlerFactory.h
@@ -158,9 +158,11 @@ HTTPRequestHandlerFactoryPtr createReplicasStatusHandlerFactory(IServer & server
 /// @param server - used in handlers to check IServer::isCancelled()
 /// @param config - not the same as server.config(), since it can be newer
 /// @param async_metrics - used for prometheus (in case of prometheus.asynchronous_metrics=true)
+/// @param http_handlers_key - config key for custom http_handlers (default: "http_handlers")
 HTTPRequestHandlerFactoryPtr createHandlerFactory(IServer & server,
     const Poco::Util::AbstractConfiguration & config,
     AsynchronousMetrics & async_metrics,
-    const std::string & name);
+    const std::string & name,
+    const std::string & http_handlers_key = {});
 
 }

--- a/tests/integration/test_custom_http_handlers_per_protocol/configs/config.xml
+++ b/tests/integration/test_custom_http_handlers_per_protocol/configs/config.xml
@@ -1,0 +1,49 @@
+<clickhouse>
+    <listen_host>0.0.0.0</listen_host>
+    <tcp_port>9000</tcp_port>
+
+    <!-- Default http_handlers: the standard set used by port 8123 -->
+    <http_handlers>
+        <rule>
+            <url>/ping</url>
+            <handler>
+                <type>predefined_query_handler</type>
+                <query>SELECT 'default_pong'</query>
+            </handler>
+        </rule>
+        <defaults/>
+    </http_handlers>
+
+    <!-- Alternative http_handlers for the custom protocol endpoint -->
+    <http_handlers_alt>
+        <rule>
+            <url>/ping</url>
+            <handler>
+                <type>predefined_query_handler</type>
+                <query>SELECT 'alt_pong'</query>
+            </handler>
+        </rule>
+        <rule>
+            <url>/custom</url>
+            <handler>
+                <type>predefined_query_handler</type>
+                <query>SELECT 'custom_handler_works'</query>
+            </handler>
+        </rule>
+        <defaults/>
+    </http_handlers_alt>
+
+    <protocols>
+        <http>
+            <type>http</type>
+            <port>8123</port>
+            <description>default http</description>
+        </http>
+        <alt_http>
+            <type>http</type>
+            <port>8124</port>
+            <description>alternative http with custom handlers</description>
+            <handlers>http_handlers_alt</handlers>
+        </alt_http>
+    </protocols>
+</clickhouse>

--- a/tests/integration/test_custom_http_handlers_per_protocol/configs/users.xml
+++ b/tests/integration/test_custom_http_handlers_per_protocol/configs/users.xml
@@ -1,0 +1,16 @@
+<clickhouse>
+    <profiles>
+        <default>
+        </default>
+    </profiles>
+
+    <users>
+        <default>
+            <password></password>
+            <networks replace="replace">
+                <ip>::/0</ip>
+            </networks>
+            <profile>default</profile>
+        </default>
+    </users>
+</clickhouse>

--- a/tests/integration/test_custom_http_handlers_per_protocol/test.py
+++ b/tests/integration/test_custom_http_handlers_per_protocol/test.py
@@ -1,0 +1,69 @@
+import urllib.parse
+import urllib.request
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+server = cluster.add_instance(
+    "server",
+    base_config_dir="configs",
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_nodes():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def http_query(host, port, path="/", query=None):
+    """Send an HTTP request and return the response body."""
+    if query:
+        url = f"http://{host}:{port}{path}?query={urllib.parse.quote(query)}"
+    else:
+        url = f"http://{host}:{port}{path}"
+    request = urllib.request.Request(url)
+    response = urllib.request.urlopen(request).read()
+    return response.decode("utf-8").strip()
+
+
+def test_default_port_uses_default_handlers():
+    """Port 8123 should use the default http_handlers config."""
+    result = http_query(server.ip_address, 8123, "/ping")
+    assert result == "default_pong"
+
+
+def test_alt_port_uses_alt_handlers():
+    """Port 8124 should use http_handlers_alt config."""
+    result = http_query(server.ip_address, 8124, "/ping")
+    assert result == "alt_pong"
+
+
+def test_alt_port_custom_endpoint():
+    """Port 8124 should serve the /custom endpoint defined in http_handlers_alt."""
+    result = http_query(server.ip_address, 8124, "/custom")
+    assert result == "custom_handler_works"
+
+
+def test_default_port_no_custom_endpoint():
+    """Port 8123 should NOT serve the /custom endpoint (only in alt handlers)."""
+    try:
+        http_query(server.ip_address, 8123, "/custom")
+        assert False, "Expected HTTP error for /custom on default port"
+    except urllib.error.HTTPError as e:
+        # 400 or 404 expected — the default handlers don't have a /custom rule
+        assert e.code in (400, 404), f"Unexpected HTTP error code: {e.code}"
+
+
+def test_regular_queries_work_on_both_ports():
+    """Both ports should handle regular SQL queries via the <defaults/> handler."""
+    result_default = http_query(server.ip_address, 8123, query="SELECT 1")
+    assert result_default == "1"
+
+    result_alt = http_query(server.ip_address, 8124, query="SELECT 1")
+    assert result_alt == "1"


### PR DESCRIPTION
## Summary

Add an optional `<handlers>` config key to `type=http` entries in `<protocols>`, allowing each HTTP protocol endpoint to reference a different `<http_handlers>` configuration section. This enables running multiple HTTP APIs with independent routing rules on separate ports.

**Changes:**
- `Server.cpp`: Read optional `<handlers>` from protocol config and pass to handler factory; use per-protocol handlers key in `updateServers` reload logic
- `HTTPHandlerFactory.cpp`/`.h`: Accept optional `http_handlers_key` parameter in `createHandlerFactory` and `createHTTPHandlerFactory`
- New integration test with 5 test cases verifying handler isolation between ports
- Documentation in `composable-protocols.md`

**Config example:**
```xml
<protocols>
    <alt_http>
        <type>http</type>
        <port>8124</port>
        <handlers>http_handlers_alt</handlers>
    </alt_http>
</protocols>
<http_handlers_alt>
    <rule>...</rule>
</http_handlers_alt>
```

If `<handlers>` is omitted, the default `<http_handlers>` is used (fully backward compatible).

### Changelog category (leave one):
- New Feature

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):

Allow each `type=http` entry in `<protocols>` to specify a custom `<handlers>` key pointing to a separate `<http_handlers_*>` config section, enabling different HTTP routing rules per port.

### Documentation entry for user-facing changes

- [x] Documentation is written


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.218`
<!-- ch-version-info:end -->