### PR TITLE
Document table function `mergeTreeTextIndex`

### DIFF
--- a/ci/jobs/scripts/check_style/aspell-ignore/en/aspell-dict.txt
+++ b/ci/jobs/scripts/check_style/aspell-ignore/en/aspell-dict.txt
@@ -2453,6 +2453,7 @@ memtables
 mergeTreeIndex
 mergeTreePartInfo
 mergeTreeProjection
+mergeTreeTextIndex
 mergeable
 mergetree
 messageID

--- a/docs/en/engines/table-engines/mergetree-family/textindexes.md
+++ b/docs/en/engines/table-engines/mergetree-family/textindexes.md
@@ -858,30 +858,34 @@ Unlike other skip indexes, text index can be merged instead of rebuilt on merge 
 
 During index creation, three files are created (per part):
 
-**Dictionary blocks file (.dct)**
+### Dictionary blocks file (.dct)
 
 The tokens in the text index are sorted and stored in dictionary blocks of 512 tokens each (the block size is configurable by parameter `dictionary_block_size`).
 A dictionary blocks file (.dct) consists all the dictionary blocks of all index granules in a part.
 
-**Index header file (.idx)**
+### Index header file (.idx)
 
 The index header file contains for each dictionary block the block's first token and its relative offset in the dictionary blocks file.
 
 This sparse index structure is similar to ClickHouse's [sparse primary key index](https://clickhouse.com/docs/guides/best-practices/sparse-primary-indexes)).
 
-**Postings lists file (.pst)**
+### Postings lists file (.pst)
 
 The posting lists for all tokens are laid out sequentially in the postings list file.
 To save space while still allowing fast intersection and union operations, the posting lists are stored as [roaring bitmaps](https://roaringbitmap.org/).
 If the posting list is larger than `posting_list_block_size`, it is split into multiple blocks that are stored sequentially to the postings lists file.
 
-**Merging of text indexes**
+### Merging of text indexes
 
 When data parts are merged, the text index does not need to be rebuilt from scratch; instead, it can be merged efficiently in a separate step of the merge process.
 During this step, the sorted dictionaries of the text indexes of each input part are read and combined into a new unified dictionary.
 The row numbers in the postings lists are also recalculated to reflect their new positions in the merged data part, using a mapping of old to new row numbers that is created during the initial merge phase.
 This method of merging text indexes is similar to how [projections](/docs/sql-reference/statements/alter/projection#normal-projection-with-part-offset-field) with `_part_offset` column are merged.
 If index is not materialized in the source part, it is built, written into a temporary file and then merged together with indexes from the other parts and from other temporary index files.
+
+### Debugging
+
+The [mergeTreeTextIndex](../../../sql-reference/table-functions/mergeTreeTextIndex.md) can be used to introspect text indexes.
 
 ## Example: Hackernews dataset {#hacker-news-dataset}
 

--- a/docs/en/engines/table-engines/mergetree-family/textindexes.md
+++ b/docs/en/engines/table-engines/mergetree-family/textindexes.md
@@ -858,24 +858,24 @@ Unlike other skip indexes, text index can be merged instead of rebuilt on merge 
 
 During index creation, three files are created (per part):
 
-### Dictionary blocks file (.dct)
+**Dictionary blocks file (.dct)**
 
 The tokens in the text index are sorted and stored in dictionary blocks of 512 tokens each (the block size is configurable by parameter `dictionary_block_size`).
 A dictionary blocks file (.dct) consists all the dictionary blocks of all index granules in a part.
 
-### Index header file (.idx)
+**Index header file (.idx)**
 
 The index header file contains for each dictionary block the block's first token and its relative offset in the dictionary blocks file.
 
 This sparse index structure is similar to ClickHouse's [sparse primary key index](https://clickhouse.com/docs/guides/best-practices/sparse-primary-indexes)).
 
-### Postings lists file (.pst)
+**Postings lists file (.pst)**
 
 The posting lists for all tokens are laid out sequentially in the postings list file.
 To save space while still allowing fast intersection and union operations, the posting lists are stored as [roaring bitmaps](https://roaringbitmap.org/).
 If the posting list is larger than `posting_list_block_size`, it is split into multiple blocks that are stored sequentially to the postings lists file.
 
-### Merging of text indexes
+**Merging of text indexes**
 
 When data parts are merged, the text index does not need to be rebuilt from scratch; instead, it can be merged efficiently in a separate step of the merge process.
 During this step, the sorted dictionaries of the text indexes of each input part are read and combined into a new unified dictionary.
@@ -883,9 +883,9 @@ The row numbers in the postings lists are also recalculated to reflect their new
 This method of merging text indexes is similar to how [projections](/docs/sql-reference/statements/alter/projection#normal-projection-with-part-offset-field) with `_part_offset` column are merged.
 If index is not materialized in the source part, it is built, written into a temporary file and then merged together with indexes from the other parts and from other temporary index files.
 
-### Debugging
+**Debugging**
 
-The [mergeTreeTextIndex](../../../sql-reference/table-functions/mergeTreeTextIndex.md) can be used to introspect text indexes.
+Table function [mergeTreeTextIndex](../../../sql-reference/table-functions/mergeTreeTextIndex.md) can be used to introspect text indexes.
 
 ## Example: Hackernews dataset {#hacker-news-dataset}
 

--- a/docs/en/sql-reference/table-functions/mergeTreeTextIndex.md
+++ b/docs/en/sql-reference/table-functions/mergeTreeTextIndex.md
@@ -8,7 +8,7 @@ title: 'mergeTreeProjection'
 doc_type: 'reference'
 ---
 
-# mergeTreeIndexText Table Function
+# mergeTreeTextIndex Table Function
 
 Represents the dictionary of a text index in MergeTree tables.
 Returns tokens with their posting list metadata.

--- a/docs/en/sql-reference/table-functions/mergeTreeTextIndex.md
+++ b/docs/en/sql-reference/table-functions/mergeTreeTextIndex.md
@@ -4,7 +4,7 @@ description: 'Represents the dictionary of a text index in a MergeTree table.
 sidebar_label: 'mergeTreeTextIndex'
 sidebar_position: 77
 slug: /sql-reference/table-functions/mergeTreeTextIndex
-title: 'mergeTreeProjection'
+title: 'mergeTreeTextIndex'
 doc_type: 'reference'
 ---
 

--- a/docs/en/sql-reference/table-functions/mergeTreeTextIndex.md
+++ b/docs/en/sql-reference/table-functions/mergeTreeTextIndex.md
@@ -50,6 +50,8 @@ INSERT INTO tab SELECT 500 + number, concatWithSeparator(' ', 'cherry', 'date') 
 SELECT * FROM mergeTreeTextIndex(currentDatabase(), tab, idx_s);
 ```
 
+Result:
+
 ```text
    ┌─part_name─┬─token──┬─dictionary_compression─┬─cardinality─┬─num_posting_blocks─┬─has_embedded_postings─┬─has_raw_postings─┬─has_compressed_postings─┐
 1. │ all_1_1_0 │ apple  │ front_coded            │         500 │                  1 │                     0 │                0 │                       0 │
@@ -58,4 +60,3 @@ SELECT * FROM mergeTreeTextIndex(currentDatabase(), tab, idx_s);
 4. │ all_2_2_0 │ date   │ front_coded            │         500 │                  1 │                     0 │                0 │                       0 │
    └───────────┴────────┴────────────────────────┴─────────────┴────────────────────┴───────────────────────┴──────────────────┴─────────────────────────┘
 ```
-

--- a/docs/en/sql-reference/table-functions/mergeTreeTextIndex.md
+++ b/docs/en/sql-reference/table-functions/mergeTreeTextIndex.md
@@ -1,0 +1,61 @@
+---
+description: 'Represents the dictionary of a text index in a MergeTree table.
+  It can be used for introspection.'
+sidebar_label: 'mergeTreeTextIndex'
+sidebar_position: 77
+slug: /sql-reference/table-functions/mergeTreeTextIndex
+title: 'mergeTreeProjection'
+doc_type: 'reference'
+---
+
+# mergeTreeIndexText Table Function
+
+Represents the dictionary of a text index in MergeTree tables.
+Returns tokens with their posting list metadata.
+It can be used for introspection.
+
+## Syntax {#syntax}
+
+```sql
+mergeTreeTextIndex(database, table, index_name)
+```
+
+## Arguments {#arguments}
+
+| Argument     | Description                                |
+|--------------|--------------------------------------------|
+| `database`   | The database name to read text index from. |
+| `table`      | The table name to read text index from.    |
+| `index_name` | The text index to read from.               |
+
+## Returned value {#returned_value}
+
+A table object with tokens and their posting list metadata.
+
+## Usage Example {#usage-example}
+
+```sql
+CREATE TABLE tab
+(
+    id UInt64,
+    s String,
+    INDEX idx_s (s) TYPE text(tokenizer = splitByNonAlpha)
+)
+ENGINE = MergeTree
+ORDER BY id;
+
+INSERT INTO tab SELECT number, concatWithSeparator(' ', 'apple', 'banana') FROM numbers(500);
+INSERT INTO tab SELECT 500 + number, concatWithSeparator(' ', 'cherry', 'date') FROM numbers(500);
+
+SELECT * FROM mergeTreeTextIndex(currentDatabase(), tab, idx_s);
+```
+
+```text
+   ┌─part_name─┬─token──┬─dictionary_compression─┬─cardinality─┬─num_posting_blocks─┬─has_embedded_postings─┬─has_raw_postings─┬─has_compressed_postings─┐
+1. │ all_1_1_0 │ apple  │ front_coded            │         500 │                  1 │                     0 │                0 │                       0 │
+2. │ all_1_1_0 │ banana │ front_coded            │         500 │                  1 │                     0 │                0 │                       0 │
+3. │ all_2_2_0 │ cherry │ front_coded            │         500 │                  1 │                     0 │                0 │                       0 │
+4. │ all_2_2_0 │ date   │ front_coded            │         500 │                  1 │                     0 │                0 │                       0 │
+   └───────────┴────────┴────────────────────────┴─────────────┴────────────────────┴───────────────────────┴──────────────────┴─────────────────────────┘
+```
+

--- a/src/TableFunctions/TableFunctionMergeTreeTextIndex.cpp
+++ b/src/TableFunctions/TableFunctionMergeTreeTextIndex.cpp
@@ -128,7 +128,7 @@ void registerTableFunctionMergeTreeTextIndex(TableFunctionFactory & factory)
     {
         .documentation =
         {
-            .description = "Reading the dictionary of a text index from a MergeTree table. Returns tokens with their posting list metadata.",
+            .description = "Reads the dictionary of a text index from a MergeTree table. Returns tokens with their posting list metadata.",
             .examples = {{"mergeTreeTextIndex", "SELECT * FROM mergeTreeTextIndex(currentDatabase(), my_table, my_text_index)", ""}},
             .category = FunctionDocumentation::Category::TableFunction
         },


### PR DESCRIPTION
This is follow-up to https://github.com/ClickHouse/ClickHouse/pull/97003

### Changelog category (leave one):
- Documentation (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.274`
<!-- ch-version-info:end -->