### PR TITLE
Fix 03998_distributed_insert_detach_race timeout in AsyncInsert+s3 CI

### DIFF
--- a/tests/queries/0_stateless/03998_distributed_insert_detach_race.sh
+++ b/tests/queries/0_stateless/03998_distributed_insert_detach_race.sh
@@ -40,9 +40,6 @@ wait
 # Reattach in case the table was left detached
 $CLICKHOUSE_CLIENT -q "ATTACH TABLE dist_03998" 2>/dev/null
 
-# Flush any remaining async inserts
-$CLICKHOUSE_CLIENT -q "SYSTEM FLUSH DISTRIBUTED dist_03998"
-
 $CLICKHOUSE_CLIENT -nmq "
     DROP TABLE dist_03998;
     DROP TABLE local_03998;


### PR DESCRIPTION
## Summary

- Remove unnecessary `SYSTEM FLUSH DISTRIBUTED` from `03998_distributed_insert_detach_race` test cleanup that was causing a 309-second hang in the AsyncInsert+s3+debug CI configuration
- The flush iterated over ~200 pending distributed `.bin` files, each taking ~5 seconds to send through s3 storage under debug+contention, far exceeding the test timeout
- The flush is not needed: the test only checks for no LOGICAL_ERROR (empty reference file), the target table is `ENGINE = Null`, and `DROP TABLE` handles cleanup

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=98408&sha=279d8f584a9d894f2300efce54b9ea2ebb85dc08&name_0=PR&name_1=Stateless%20tests%20%28amd_debug%2C%20AsyncInsert%2C%20s3%20storage%2C%20parallel%29
https://github.com/ClickHouse/ClickHouse/pull/98408

### Changelog category (leave one):

- CI Fix or improvement

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):

- N/A

### Documentation entry for user-facing changes

- [x] Documentation is not required

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.227`
<!-- ch-version-info:end -->