### PR TITLE
Retry ZooKeeper start in test_keeper_zookeeper_converter

### DIFF
--- a/tests/integration/test_keeper_zookeeper_converter/test.py
+++ b/tests/integration/test_keeper_zookeeper_converter/test.py
@@ -19,7 +19,16 @@ node = cluster.add_instance(
 
 
 def start_zookeeper():
-    node.exec_in_container(["bash", "-c", "/opt/zookeeper/bin/zkServer.sh start"])
+    for attempt in range(3):
+        try:
+            node.exec_in_container(
+                ["bash", "-c", "/opt/zookeeper/bin/zkServer.sh start"]
+            )
+            return
+        except Exception:
+            if attempt == 2:
+                raise
+            time.sleep(2)
 
 
 def stop_zookeeper():


### PR DESCRIPTION
## Summary
- Add retry logic (3 attempts with 2s delay) to `start_zookeeper` in `test_keeper_zookeeper_converter` to fix transient failures when ZooKeeper's port hasn't been fully released after a stop
- This is especially relevant under TSan where operations are slower

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=98369&sha=dc3702487f7d88b600a268a66072f75c4ed48005&name_0=PR&name_1=Integration%20tests%20%28amd_tsan%2C%205%2F6%29
https://github.com/ClickHouse/ClickHouse/pull/98369

Related: #43594

### Changelog category:
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry:
Not for changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)