### PR TITLE
Fix use-after-free in dumpPipeline when expandPipeline races with cancellation

### DIFF
--- a/src/Processors/Executors/ExecutingGraph.cpp
+++ b/src/Processors/Executors/ExecutingGraph.cpp
@@ -117,17 +117,22 @@ ExecutingGraph::UpdateNodeStatus ExecutingGraph::expandPipeline(boost::container
 
     {
         std::lock_guard guard(processors_mutex);
-        /// Do not add new processors to existing list, since the query was already cancelled.
+
+        /// Even if the query was already cancelled, we must still add the new processors to the list
+        /// to keep them alive, because their ports are already connected to existing processors.
+        /// Destroying them here would leave dangling port references, causing use-after-free
+        /// (e.g. pure virtual call in `dumpPipeline`).
+        processors->insert(processors->end(), new_processors.begin(), new_processors.end());
+
+        // Do not consider sources added during pipeline expansion as cancelable to avoid tricky corner cases (e.g. ConvertingAggregatedToChunksWithMergingSource cancellation)
+        source_processors.resize(source_processors.size() + new_processors.size(), false);
+
         if (cancelled)
         {
             for (auto & processor : new_processors)
                 processor->cancel();
             return UpdateNodeStatus::Cancelled;
         }
-        processors->insert(processors->end(), new_processors.begin(), new_processors.end());
-
-        // Do not consider sources added during pipeline expansion as cancelable to avoid tricky corner cases (e.g. ConvertingAggregatedToChunksWithMergingSource cancellation)
-        source_processors.resize(source_processors.size() + new_processors.size(), false);
     }
 
     uint64_t num_processors = processors->size();


### PR DESCRIPTION
## Summary

- When `ExecutingGraph::expandPipeline` was called while the pipeline was being cancelled, the new processors were not added to the `processors` vector. However, the processor's `expandPipeline` method had already connected ports between the new processors and existing ones. When the new processors were destroyed (going out of scope), their ports remained connected, leaving dangling references.
- Later, `dumpPipeline` (called in debug builds on exception) would traverse these port connections via `printPipeline` and call `getUniqID` / `getName` on the destroyed processor, triggering a pure virtual function call (`__cxa_pure_virtual`).
- The fix ensures new processors are always added to the `processors` vector to keep them alive, since their ports are already connected. The cancellation still proceeds normally.

Triggered by external sort with `max_bytes_before_external_sort=10` in stress test.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=98374&sha=ae15e2525d720b59d79598ce1d9dd06d1a787812&name_0=PR&name_1=Stress%20test%20%28amd_debug%29
https://github.com/ClickHouse/ClickHouse/pull/98374

## Test plan

- [x] Reproduces only under stress test with debug build (external sort + concurrent cancellation)
- [ ] CI stress test should pass without this crash

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix rare exception in the pipeline executor, that could manifest as a `Received signal 6` (only in debug builds), when pipeline expansion races with query cancellation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.232`
<!-- ch-version-info:end -->