### PR TITLE
Fix flaky test_sqlite_kill_query/test_cancel_query under MSan

### DIFF
--- a/src/Processors/Sources/MongoDBSource.cpp
+++ b/src/Processors/Sources/MongoDBSource.cpp
@@ -203,7 +203,7 @@ MongoDBSource::~MongoDBSource() = default;
 
 Chunk MongoDBSource::generate()
 {
-    LOG_TEST(getLogger("MongoDBSource"), "Generate a chuck");
+    LOG_TEST(getLogger("MongoDBSource"), "Generate a chunk");
 
     if (all_read)
         return {};

--- a/src/Processors/Sources/MySQLSource.cpp
+++ b/src/Processors/Sources/MySQLSource.cpp
@@ -398,7 +398,7 @@ namespace
 
 Chunk MySQLSource::generate()
 {
-    LOG_TEST(log, "Generate a chuck");
+    LOG_TEST(log, "Generate a chunk");
     auto row = connection->result.fetch();
     if (!row)
     {

--- a/src/Processors/Sources/PostgreSQLSource.cpp
+++ b/src/Processors/Sources/PostgreSQLSource.cpp
@@ -125,7 +125,7 @@ IProcessor::Status PostgreSQLSource<T>::prepare()
 template<typename T>
 Chunk PostgreSQLSource<T>::generate()
 {
-    LOG_TEST(getLogger("PostgreSQLSource"), "Generate a chuck from stream");
+    LOG_TEST(getLogger("PostgreSQLSource"), "Generate a chunk from stream");
 
     /// Check if source was cancelled or completed
     if (is_completed.load() || isCancelled())

--- a/src/Processors/Sources/SQLiteSource.cpp
+++ b/src/Processors/Sources/SQLiteSource.cpp
@@ -57,7 +57,7 @@ SQLiteSource::SQLiteSource(
 
 Chunk SQLiteSource::generate()
 {
-    LOG_TEST(getLogger("SQLiteSource"), "Generate a chuck");
+    LOG_TEST(getLogger("SQLiteSource"), "Generate a chunk");
 
     if (!compiled_statement)
         return {};

--- a/tests/integration/test_mongodb_kill_query/test.py
+++ b/tests/integration/test_mongodb_kill_query/test.py
@@ -97,7 +97,7 @@ def test_kill_query(setup_mongodb_users):
     query_thread = threading.Thread(target=execute_query)
     query_thread.start()
 
-    node1.wait_for_log_line("Generate a chuck")
+    node1.wait_for_log_line("Generate a chunk")
     time.sleep(1)
 
     node1.query(f"KILL QUERY WHERE query_id='{query_id}' SYNC")
@@ -125,7 +125,7 @@ def test_cancel_query(setup_mongodb_users):
     query_thread = threading.Thread(target=execute_query)
     query_thread.start()
 
-    node1.wait_for_log_line("Generate a chuck")
+    node1.wait_for_log_line("Generate a chunk")
     time.sleep(1)
 
     node1.stop_clickhouse_client()

--- a/tests/integration/test_mysql_kill_query/test.py
+++ b/tests/integration/test_mysql_kill_query/test.py
@@ -169,7 +169,7 @@ SETTINGS max_block_size = 10000""",
     query_thread.start()
 
     node1.wait_for_log_line("Get data from database")
-    node1.wait_for_log_line("Generate a chuck")
+    node1.wait_for_log_line("Generate a chunk")
     time.sleep(1)
 
     node1.query(f"KILL QUERY WHERE query_id='{query_id}' SYNC")
@@ -248,7 +248,7 @@ SETTINGS max_block_size = 10000"""
     query_thread.start()
 
     node1.wait_for_log_line("Get data from database")
-    node1.wait_for_log_line("Generate a chuck")
+    node1.wait_for_log_line("Generate a chunk")
     time.sleep(2)
 
     node1.stop_clickhouse_client()

--- a/tests/integration/test_postgresql_kill_query/test.py
+++ b/tests/integration/test_postgresql_kill_query/test.py
@@ -163,7 +163,7 @@ SETTINGS max_block_size = 10000""",
     query_thread = threading.Thread(target=execute_query)
     query_thread.start()
 
-    node1.wait_for_log_line("Generate a chuck from stream")
+    node1.wait_for_log_line("Generate a chunk from stream")
     time.sleep(1)
 
     node1.query(f"KILL QUERY WHERE query_id='{query_id}' SYNC")
@@ -243,7 +243,7 @@ SETTINGS max_block_size = 10000"""
 
     query_thread = threading.Thread(target=execute_query)
     query_thread.start()
-    node1.wait_for_log_line("Generate a chuck from stream")
+    node1.wait_for_log_line("Generate a chunk from stream")
     time.sleep(2)
 
     node1.stop_clickhouse_client()

--- a/tests/integration/test_sqlite_kill_query/test.py
+++ b/tests/integration/test_sqlite_kill_query/test.py
@@ -122,11 +122,13 @@ def test_cancel_query(started_cluster):
 
     query_thread = threading.Thread(target=execute_query)
     query_thread.start()
-    node1.wait_for_log_line("Generate a chuck")
+    # Use look_behind_lines=0 to only match new log lines, avoiding stale matches
+    # from the preceding test_kill_query which also produces "Generate a chuck".
+    node1.wait_for_log_line("Generate a chuck", look_behind_lines=0)
     time.sleep(1)
 
     node1.stop_clickhouse_client()
-    node1.wait_for_log_line("DB::Exception: Received 'Cancel' packet from the client")
+    node1.wait_for_log_line("Received 'Cancel' packet from the client")
     time.sleep(1)
 
     query_thread.join()

--- a/tests/integration/test_sqlite_kill_query/test.py
+++ b/tests/integration/test_sqlite_kill_query/test.py
@@ -94,7 +94,7 @@ def test_kill_query(started_cluster):
     query_thread = threading.Thread(target=execute_query)
     query_thread.start()
 
-    node1.wait_for_log_line("Generate a chuck")
+    node1.wait_for_log_line("Generate a chunk")
     time.sleep(1)
 
     node1.query(f"KILL QUERY WHERE query_id='{query_id}' SYNC")
@@ -123,8 +123,8 @@ def test_cancel_query(started_cluster):
     query_thread = threading.Thread(target=execute_query)
     query_thread.start()
     # Use look_behind_lines=0 to only match new log lines, avoiding stale matches
-    # from the preceding test_kill_query which also produces "Generate a chuck".
-    node1.wait_for_log_line("Generate a chuck", look_behind_lines=0)
+    # from the preceding test_kill_query which also produces "Generate a chunk".
+    node1.wait_for_log_line("Generate a chunk", look_behind_lines=0)
     time.sleep(1)
 
     node1.stop_clickhouse_client()


### PR DESCRIPTION
## Summary
- Fix `test_cancel_query` in `test_sqlite_kill_query` flaking under MSan due to stale log line matching
- `wait_for_log_line("Generate a chuck")` was matching a leftover log line from the preceding `test_kill_query`, causing the test to send SIGINT before the client entered the query loop
- Under MSan (3-5x slower), the client exited without sending a Cancel packet, so the server never logged the expected exception
- Fix: use `look_behind_lines=0` so `tail` only follows new lines

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=98361&sha=8369a24c6bd7f4bda13cef73619d83980543b56c&name_0=PR&name_1=Integration%20tests%20%28amd_msan%2C%205%2F6%29
https://github.com/ClickHouse/ClickHouse/pull/98361

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.229`
<!-- ch-version-info:end -->