### PR TITLE
Allow partition pruning for all comparison operators when predicate key is wrapped by deterministic function chains

### DIFF
--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -2250,7 +2250,7 @@ bool KeyCondition::isKeyPossiblyWrappedByMonotonicFunctions(
         if (!func || !func->isDeterministicInScopeOfQuery() || (!assume_function_monotonicity && !func->hasInformationAboutMonotonicity()))
             return false;
 
-        if (!isFunctionReallyMonotonic(*func, *key_column_type))
+        if (!assume_function_monotonicity && !isFunctionReallyMonotonic(*func, *key_column_type))
             return false;
 
         key_column_type = func->getResultType();
@@ -2789,6 +2789,21 @@ bool KeyCondition::extractAtomFromTree(const RPNBuilderTreeNode & node, const Bu
 
             bool condition_is_relaxed = false;
 
+            /// If the table sorting key is `x` and the query predicate is `f(x) <op> const`, we try to analyze `f`.
+            /// If `f` is a monotonic function chain, we store the chain and later, in `checkInRange`, apply it to
+            /// the left and right mark bounds before comparing with `const` to decide whether the mark can be skipped.
+            /// Monotonicity is required because `checkInRange` does not inspect every value in the mark.
+            /// It only inspects the left and right bounds and decides from those bounds whether the mark
+            /// can satisfy the predicate. This is correct only when the function is monotonic on that range,
+            /// because then all intermediate values stay between the transformed bounds (up to direction).
+            /// If the function is not monotonic, intermediate values can behave differently from both bounds,
+            /// and pruning based only on bounds can drop rows that actually match.
+            /// For example, suppose the sorting key is `x`, the current mark covers values from `-2` to `3`,
+            /// and the predicate is `x*x < 1`. At the two bounds, `x*x` is `4` and `9`, which do not satisfy
+            /// the predicate, but inside the same mark at `x = 0`, `x*x` is `0`, which does satisfy it.
+            /// So if we looked only at the bounds, we would incorrectly skip this mark.
+            /// If `single_point` is true (`left mark == right mark`), `f` can be any deterministic function, not necessarily
+            /// monotonic, because we evaluate only one value. In that case, monotonicity direction does not matter.
             if (isKeyPossiblyWrappedByMonotonicFunctions(
                     key_arg,
                     info,
@@ -2796,7 +2811,7 @@ bool KeyCondition::extractAtomFromTree(const RPNBuilderTreeNode & node, const Bu
                     argument_num_of_space_filling_curve,
                     key_expr_type,
                     chain,
-                    single_point && func_name == "equals"))
+                    single_point))
             {
             }
             else if (

--- a/tests/queries/0_stateless/04002_deterministic_filter_chain_partition_pruning_key_condition.reference
+++ b/tests/queries/0_stateless/04002_deterministic_filter_chain_partition_pruning_key_condition.reference
@@ -201,3 +201,31 @@ SET date_time_overflow_behavior = 'ignore';
 SET session_timezone = 'UTC';
 SELECT d FROM test_monotonic_datetime WHERE toDateTime(d) = toDateTime('2026-01-02');
 2026-01-02
+DROP TABLE IF EXISTS test_partition_key_to_year_month;
+CREATE TABLE test_partition_key_to_year_month (d Date)
+ENGINE = MergeTree ORDER BY tuple() PARTITION BY toYYYYMM(d)
+SETTINGS index_granularity = 1;
+INSERT INTO test_partition_key_to_year_month VALUES
+    ('2024-01-15'),
+    ('2024-02-15'),
+    ('2024-03-15'),
+    ('2024-04-15');
+SELECT d
+FROM test_partition_key_to_year_month
+WHERE addMonths(toDate(concat(toString(toYYYYMM(d)), '01')), 1) > toDate('2024-03-01')
+ORDER BY d;
+2024-03-15
+2024-04-15
+SELECT d
+FROM test_partition_key_to_year_month
+WHERE addMonths(toDate(concat(toString(toYYYYMM(d)), '01')), 1) < toDate('2024-04-01')
+ORDER BY d;
+2024-01-15
+2024-02-15
+SELECT d
+FROM test_partition_key_to_year_month
+WHERE addMonths(toDate(concat(toString(toYYYYMM(d)), '01')), 1) != toDate('2024-03-01')
+ORDER BY d;
+2024-01-15
+2024-03-15
+2024-04-15

--- a/tests/queries/0_stateless/04002_deterministic_filter_chain_partition_pruning_key_condition.reference
+++ b/tests/queries/0_stateless/04002_deterministic_filter_chain_partition_pruning_key_condition.reference
@@ -1,0 +1,203 @@
+-- { echo }
+
+DROP TABLE IF EXISTS test_simple_key;
+CREATE TABLE test_simple_key (x Int32)
+ENGINE = MergeTree ORDER BY tuple() PARTITION BY x
+SETTINGS index_granularity = 1;
+INSERT INTO test_simple_key SELECT number FROM numbers(15);
+SELECT x FROM test_simple_key WHERE x + 2 = 9 ORDER BY x;
+7
+SELECT x FROM test_simple_key WHERE x + 2 > 9 ORDER BY x;
+8
+9
+10
+11
+12
+13
+14
+SELECT x FROM test_simple_key WHERE x + 2 < 9 ORDER BY x;
+0
+1
+2
+3
+4
+5
+6
+SELECT x FROM test_simple_key WHERE x + 2 != 9 ORDER BY x;
+0
+1
+2
+3
+4
+5
+6
+8
+9
+10
+11
+12
+13
+14
+DROP TABLE IF EXISTS test_composite_key;
+CREATE TABLE test_composite_key (x Int32)
+ENGINE = MergeTree ORDER BY tuple() PARTITION BY x * x
+SETTINGS index_granularity = 1;
+INSERT INTO test_composite_key SELECT number FROM numbers(15);
+SELECT x FROM test_composite_key WHERE x * x + 2 = 11 ORDER BY x;
+3
+SELECT x FROM test_composite_key WHERE x * x + 2 > 11 ORDER BY x;
+4
+5
+6
+7
+8
+9
+10
+11
+12
+13
+14
+SELECT x FROM test_composite_key WHERE x * x + 2 < 11 ORDER BY x;
+0
+1
+2
+SELECT x FROM test_composite_key WHERE x * x + 2 != 11 ORDER BY x;
+0
+1
+2
+4
+5
+6
+7
+8
+9
+10
+11
+12
+13
+14
+DROP TABLE IF EXISTS test_composite_key2;
+CREATE TABLE test_composite_key2 (x Int32)
+ENGINE = MergeTree ORDER BY tuple() PARTITION BY if(x >= 0, -x, x)
+SETTINGS index_granularity = 1;
+INSERT INTO test_composite_key2 SELECT -number FROM numbers(10);
+INSERT INTO test_composite_key2 SELECT number FROM numbers(10);
+SELECT x FROM test_composite_key2 WHERE if(x >= 0, -x, x) + 2 = 1 ORDER BY x;
+-1
+1
+SELECT x FROM test_composite_key2 WHERE if(x >= 0, -x, x) + 2 > 1 ORDER BY x;
+0
+0
+SELECT x FROM test_composite_key2 WHERE if(x >= 0, -x, x) + 2 < -1 ORDER BY x;
+-9
+-8
+-7
+-6
+-5
+-4
+4
+5
+6
+7
+8
+9
+SELECT x FROM test_composite_key2 WHERE if(x >= 0, -x, x) + 2 != -1 ORDER BY x;
+-9
+-8
+-7
+-6
+-5
+-4
+-2
+-1
+0
+0
+1
+2
+4
+5
+6
+7
+8
+9
+DROP TABLE IF EXISTS test_det_function;
+CREATE TABLE test_det_function (x Int32)
+ENGINE = MergeTree ORDER BY tuple() PARTITION BY x
+SETTINGS index_granularity = 1;
+INSERT INTO test_det_function SELECT number FROM numbers(15);
+SELECT x FROM test_det_function WHERE cityHash64(x) % 5 = 3 ORDER BY x;
+4
+7
+SELECT x FROM test_det_function WHERE cityHash64(x) % 5 > 3 ORDER BY x;
+2
+3
+11
+13
+SELECT x FROM test_det_function WHERE cityHash64(x) % 5 < 3 ORDER BY x;
+0
+1
+5
+6
+8
+9
+10
+12
+14
+SELECT x FROM test_det_function WHERE cityHash64(x) % 5 != 3 ORDER BY x;
+0
+1
+2
+3
+5
+6
+8
+9
+10
+11
+12
+13
+14
+SELECT x FROM test_det_function WHERE cityHash64(x) % 5 != cityHash64(3) % 5 ORDER BY x;
+0
+1
+4
+5
+6
+7
+8
+9
+10
+12
+14
+DROP TABLE IF EXISTS test_strings;
+CREATE TABLE test_strings (p String)
+ENGINE = MergeTree ORDER BY tuple() PARTITION BY p
+SETTINGS index_granularity = 1;
+INSERT INTO test_strings VALUES ('abc'), ('def'), ('ghi'), ('jkl'), ('mnop'), ('q');
+SELECT p FROM test_strings WHERE reverse(p) = 'cba' ORDER BY p;
+abc
+SELECT p FROM test_strings WHERE hex(p) > '646566' ORDER BY p;
+ghi
+jkl
+mnop
+q
+SELECT p FROM test_strings WHERE length(p) < 3 ORDER BY p;
+q
+SELECT p FROM test_strings WHERE length(p) != 3 ORDER BY p;
+mnop
+q
+SELECT p FROM test_strings WHERE reverse(p) > 'lkj' ORDER BY p;
+mnop
+q
+-- We only support deterministic function chain for now.
+-- Even though it is mathematically correct for any arbitrary dag as well.
+SELECT p FROM test_strings WHERE (left(p, length(p) - length(substringIndex(p, '-', -1)) - 1)) = 'abc';
+DROP TABLE IF EXISTS test_monotonic_datetime;
+CREATE TABLE test_monotonic_datetime (d Date, y String)
+ENGINE = MergeTree ORDER BY tuple() PARTITION BY d
+SETTINGS index_granularity = 1;
+INSERT INTO test_monotonic_datetime VALUES ('2026-01-01', 'a'), ('2026-01-02', 'b'), ('2026-01-03', 'c');
+SET date_time_overflow_behavior = 'ignore';
+SET session_timezone = 'UTC';
+SELECT d FROM test_monotonic_datetime WHERE toDateTime(d) = toDateTime('2026-01-02');
+2026-01-02

--- a/tests/queries/0_stateless/04002_deterministic_filter_chain_partition_pruning_key_condition.sql
+++ b/tests/queries/0_stateless/04002_deterministic_filter_chain_partition_pruning_key_condition.sql
@@ -1,0 +1,102 @@
+-- { echo }
+
+DROP TABLE IF EXISTS test_simple_key;
+CREATE TABLE test_simple_key (x Int32)
+ENGINE = MergeTree ORDER BY tuple() PARTITION BY x
+SETTINGS index_granularity = 1;
+
+INSERT INTO test_simple_key SELECT number FROM numbers(15);
+
+SELECT x FROM test_simple_key WHERE x + 2 = 9 ORDER BY x;
+
+SELECT x FROM test_simple_key WHERE x + 2 > 9 ORDER BY x;
+
+SELECT x FROM test_simple_key WHERE x + 2 < 9 ORDER BY x;
+
+SELECT x FROM test_simple_key WHERE x + 2 != 9 ORDER BY x;
+
+
+DROP TABLE IF EXISTS test_composite_key;
+CREATE TABLE test_composite_key (x Int32)
+ENGINE = MergeTree ORDER BY tuple() PARTITION BY x * x
+SETTINGS index_granularity = 1;
+
+INSERT INTO test_composite_key SELECT number FROM numbers(15);
+
+SELECT x FROM test_composite_key WHERE x * x + 2 = 11 ORDER BY x;
+
+SELECT x FROM test_composite_key WHERE x * x + 2 > 11 ORDER BY x;
+
+SELECT x FROM test_composite_key WHERE x * x + 2 < 11 ORDER BY x;
+
+SELECT x FROM test_composite_key WHERE x * x + 2 != 11 ORDER BY x;
+
+
+DROP TABLE IF EXISTS test_composite_key2;
+CREATE TABLE test_composite_key2 (x Int32)
+ENGINE = MergeTree ORDER BY tuple() PARTITION BY if(x >= 0, -x, x)
+SETTINGS index_granularity = 1;
+
+INSERT INTO test_composite_key2 SELECT -number FROM numbers(10);
+INSERT INTO test_composite_key2 SELECT number FROM numbers(10);
+
+SELECT x FROM test_composite_key2 WHERE if(x >= 0, -x, x) + 2 = 1 ORDER BY x;
+
+SELECT x FROM test_composite_key2 WHERE if(x >= 0, -x, x) + 2 > 1 ORDER BY x;
+
+SELECT x FROM test_composite_key2 WHERE if(x >= 0, -x, x) + 2 < -1 ORDER BY x;
+
+SELECT x FROM test_composite_key2 WHERE if(x >= 0, -x, x) + 2 != -1 ORDER BY x;
+
+
+DROP TABLE IF EXISTS test_det_function;
+CREATE TABLE test_det_function (x Int32)
+ENGINE = MergeTree ORDER BY tuple() PARTITION BY x
+SETTINGS index_granularity = 1;
+
+INSERT INTO test_det_function SELECT number FROM numbers(15);
+
+SELECT x FROM test_det_function WHERE cityHash64(x) % 5 = 3 ORDER BY x;
+
+SELECT x FROM test_det_function WHERE cityHash64(x) % 5 > 3 ORDER BY x;
+
+SELECT x FROM test_det_function WHERE cityHash64(x) % 5 < 3 ORDER BY x;
+
+SELECT x FROM test_det_function WHERE cityHash64(x) % 5 != 3 ORDER BY x;
+
+SELECT x FROM test_det_function WHERE cityHash64(x) % 5 != cityHash64(3) % 5 ORDER BY x;
+
+
+DROP TABLE IF EXISTS test_strings;
+CREATE TABLE test_strings (p String)
+ENGINE = MergeTree ORDER BY tuple() PARTITION BY p
+SETTINGS index_granularity = 1;
+
+INSERT INTO test_strings VALUES ('abc'), ('def'), ('ghi'), ('jkl'), ('mnop'), ('q');
+
+SELECT p FROM test_strings WHERE reverse(p) = 'cba' ORDER BY p;
+
+SELECT p FROM test_strings WHERE hex(p) > '646566' ORDER BY p;
+
+SELECT p FROM test_strings WHERE length(p) < 3 ORDER BY p;
+
+SELECT p FROM test_strings WHERE length(p) != 3 ORDER BY p;
+
+SELECT p FROM test_strings WHERE reverse(p) > 'lkj' ORDER BY p;
+
+-- We only support deterministic function chain for now.
+-- Even though it is mathematically correct for any arbitrary dag as well.
+SELECT p FROM test_strings WHERE (left(p, length(p) - length(substringIndex(p, '-', -1)) - 1)) = 'abc';
+
+
+DROP TABLE IF EXISTS test_monotonic_datetime;
+CREATE TABLE test_monotonic_datetime (d Date, y String)
+ENGINE = MergeTree ORDER BY tuple() PARTITION BY d
+SETTINGS index_granularity = 1;
+
+INSERT INTO test_monotonic_datetime VALUES ('2026-01-01', 'a'), ('2026-01-02', 'b'), ('2026-01-03', 'c');
+
+SET date_time_overflow_behavior = 'ignore';
+SET session_timezone = 'UTC';
+
+SELECT d FROM test_monotonic_datetime WHERE toDateTime(d) = toDateTime('2026-01-02');

--- a/tests/queries/0_stateless/04002_deterministic_filter_chain_partition_pruning_key_condition.sql
+++ b/tests/queries/0_stateless/04002_deterministic_filter_chain_partition_pruning_key_condition.sql
@@ -100,3 +100,30 @@ SET date_time_overflow_behavior = 'ignore';
 SET session_timezone = 'UTC';
 
 SELECT d FROM test_monotonic_datetime WHERE toDateTime(d) = toDateTime('2026-01-02');
+
+
+DROP TABLE IF EXISTS test_partition_key_to_year_month;
+CREATE TABLE test_partition_key_to_year_month (d Date)
+ENGINE = MergeTree ORDER BY tuple() PARTITION BY toYYYYMM(d)
+SETTINGS index_granularity = 1;
+
+INSERT INTO test_partition_key_to_year_month VALUES
+    ('2024-01-15'),
+    ('2024-02-15'),
+    ('2024-03-15'),
+    ('2024-04-15');
+
+SELECT d
+FROM test_partition_key_to_year_month
+WHERE addMonths(toDate(concat(toString(toYYYYMM(d)), '01')), 1) > toDate('2024-03-01')
+ORDER BY d;
+
+SELECT d
+FROM test_partition_key_to_year_month
+WHERE addMonths(toDate(concat(toString(toYYYYMM(d)), '01')), 1) < toDate('2024-04-01')
+ORDER BY d;
+
+SELECT d
+FROM test_partition_key_to_year_month
+WHERE addMonths(toDate(concat(toString(toYYYYMM(d)), '01')), 1) != toDate('2024-03-01')
+ORDER BY d;

--- a/tests/queries/0_stateless/04003_deterministic_filter_chain_partition_pruning_key_condition_explain.reference
+++ b/tests/queries/0_stateless/04003_deterministic_filter_chain_partition_pruning_key_condition_explain.reference
@@ -1,0 +1,495 @@
+-- { echo }
+
+DROP TABLE IF EXISTS test_simple_key;
+CREATE TABLE test_simple_key (x Int32)
+ENGINE = MergeTree ORDER BY tuple() PARTITION BY x
+SETTINGS index_granularity = 1;
+INSERT INTO test_simple_key SELECT number FROM numbers(15);
+EXPLAIN indexes = 1
+SELECT x FROM test_simple_key WHERE x + 2 = 9 ORDER BY x;
+Expression (Project names)
+  Sorting (Sorting for ORDER BY)
+    Expression ((Before ORDER BY + Projection))
+      Filter ((WHERE + Change column names to column identifiers))
+        ReadFromMergeTree (default.test_simple_key)
+        Indexes:
+          MinMax
+            Keys:
+              x
+            Condition: (plus(x, 2) in [9, 9])
+            Parts: 1/15
+            Granules: 1/15
+          Partition
+            Keys:
+              x
+            Condition: (plus(x, 2) in [9, 9])
+            Parts: 1/1
+            Granules: 1/1
+          Ranges: 1
+EXPLAIN indexes = 1
+SELECT x FROM test_simple_key WHERE x + 2 > 9 ORDER BY x;
+Expression (Project names)
+  Sorting (Sorting for ORDER BY)
+    Expression ((Before ORDER BY + Projection))
+      Filter ((WHERE + Change column names to column identifiers))
+        ReadFromMergeTree (default.test_simple_key)
+        Indexes:
+          MinMax
+            Keys:
+              x
+            Condition: (plus(x, 2) in [10, +Inf))
+            Parts: 7/15
+            Granules: 7/15
+          Partition
+            Keys:
+              x
+            Condition: (plus(x, 2) in [10, +Inf))
+            Parts: 7/7
+            Granules: 7/7
+          Ranges: 7
+EXPLAIN indexes = 1
+SELECT x FROM test_simple_key WHERE x + 2 < 9 ORDER BY x;
+Expression (Project names)
+  Sorting (Sorting for ORDER BY)
+    Expression ((Before ORDER BY + Projection))
+      Filter ((WHERE + Change column names to column identifiers))
+        ReadFromMergeTree (default.test_simple_key)
+        Indexes:
+          MinMax
+            Keys:
+              x
+            Condition: (plus(x, 2) in (-Inf, 8])
+            Parts: 7/15
+            Granules: 7/15
+          Partition
+            Keys:
+              x
+            Condition: (plus(x, 2) in (-Inf, 8])
+            Parts: 7/7
+            Granules: 7/7
+          Ranges: 7
+EXPLAIN indexes = 1
+SELECT x FROM test_simple_key WHERE x + 2 != 9 ORDER BY x;
+Expression (Project names)
+  Sorting (Sorting for ORDER BY)
+    Expression ((Before ORDER BY + Projection))
+      Filter ((WHERE + Change column names to column identifiers))
+        ReadFromMergeTree (default.test_simple_key)
+        Indexes:
+          MinMax
+            Keys:
+              x
+            Condition: (plus(x, 2) not in [9, 9])
+            Parts: 14/15
+            Granules: 14/15
+          Partition
+            Keys:
+              x
+            Condition: (plus(x, 2) not in [9, 9])
+            Parts: 14/14
+            Granules: 14/14
+          Ranges: 14
+DROP TABLE IF EXISTS test_composite_key;
+CREATE TABLE test_composite_key (x Int32)
+ENGINE = MergeTree ORDER BY tuple() PARTITION BY x * x
+SETTINGS index_granularity = 1;
+INSERT INTO test_composite_key SELECT number FROM numbers(15);
+EXPLAIN indexes = 1
+SELECT x FROM test_composite_key WHERE x * x + 2 = 11 ORDER BY x;
+Expression (Project names)
+  Sorting (Sorting for ORDER BY)
+    Expression ((Before ORDER BY + Projection))
+      Filter ((WHERE + Change column names to column identifiers))
+        ReadFromMergeTree (default.test_composite_key)
+        Indexes:
+          MinMax
+            Condition: true
+            Parts: 15/15
+            Granules: 15/15
+          Partition
+            Keys:
+              multiply(x, x)
+            Condition: (plus(multiply(x, x), 2) in [11, 11])
+            Parts: 1/15
+            Granules: 1/15
+          Ranges: 1
+EXPLAIN indexes = 1
+SELECT x FROM test_composite_key WHERE x * x + 2 > 11 ORDER BY x;
+Expression (Project names)
+  Sorting (Sorting for ORDER BY)
+    Expression ((Before ORDER BY + Projection))
+      Filter ((WHERE + Change column names to column identifiers))
+        ReadFromMergeTree (default.test_composite_key)
+        Indexes:
+          MinMax
+            Condition: true
+            Parts: 15/15
+            Granules: 15/15
+          Partition
+            Keys:
+              multiply(x, x)
+            Condition: (plus(multiply(x, x), 2) in [12, +Inf))
+            Parts: 11/15
+            Granules: 11/15
+          Ranges: 11
+EXPLAIN indexes = 1
+SELECT x FROM test_composite_key WHERE x * x + 2 < 11 ORDER BY x;
+Expression (Project names)
+  Sorting (Sorting for ORDER BY)
+    Expression ((Before ORDER BY + Projection))
+      Filter ((WHERE + Change column names to column identifiers))
+        ReadFromMergeTree (default.test_composite_key)
+        Indexes:
+          MinMax
+            Condition: true
+            Parts: 15/15
+            Granules: 15/15
+          Partition
+            Keys:
+              multiply(x, x)
+            Condition: (plus(multiply(x, x), 2) in (-Inf, 10])
+            Parts: 3/15
+            Granules: 3/15
+          Ranges: 3
+EXPLAIN indexes = 1
+SELECT x FROM test_composite_key WHERE x * x + 2 != 11 ORDER BY x;
+Expression (Project names)
+  Sorting (Sorting for ORDER BY)
+    Expression ((Before ORDER BY + Projection))
+      Filter ((WHERE + Change column names to column identifiers))
+        ReadFromMergeTree (default.test_composite_key)
+        Indexes:
+          MinMax
+            Condition: true
+            Parts: 15/15
+            Granules: 15/15
+          Partition
+            Keys:
+              multiply(x, x)
+            Condition: (plus(multiply(x, x), 2) not in [11, 11])
+            Parts: 14/15
+            Granules: 14/15
+          Ranges: 14
+DROP TABLE IF EXISTS test_composite_key2;
+CREATE TABLE test_composite_key2 (x Int32)
+ENGINE = MergeTree ORDER BY tuple() PARTITION BY if(x >= 0, -x, x)
+SETTINGS index_granularity = 1;
+INSERT INTO test_composite_key2 SELECT -number FROM numbers(10);
+INSERT INTO test_composite_key2 SELECT number FROM numbers(10);
+EXPLAIN indexes = 1
+SELECT x FROM test_composite_key2 WHERE if(x >= 0, -x, x) + 2 = 1 ORDER BY x;
+Expression (Project names)
+  Sorting (Sorting for ORDER BY)
+    Expression ((Before ORDER BY + Projection))
+      Filter ((WHERE + Change column names to column identifiers))
+        ReadFromMergeTree (default.test_composite_key2)
+        Indexes:
+          MinMax
+            Condition: true
+            Parts: 20/20
+            Granules: 20/20
+          Partition
+            Keys:
+              if(greaterOrEquals(x, 0), negate(x), x)
+            Condition: (plus(if(greaterOrEquals(x, 0), negate(x), x), 2) in [1, 1])
+            Parts: 2/20
+            Granules: 2/20
+          Ranges: 2
+EXPLAIN indexes = 1
+SELECT x FROM test_composite_key2 WHERE if(x >= 0, -x, x) + 2 > 1 ORDER BY x;
+Expression (Project names)
+  Sorting (Sorting for ORDER BY)
+    Expression ((Before ORDER BY + Projection))
+      Filter ((WHERE + Change column names to column identifiers))
+        ReadFromMergeTree (default.test_composite_key2)
+        Indexes:
+          MinMax
+            Condition: true
+            Parts: 20/20
+            Granules: 20/20
+          Partition
+            Keys:
+              if(greaterOrEquals(x, 0), negate(x), x)
+            Condition: (plus(if(greaterOrEquals(x, 0), negate(x), x), 2) in [2, +Inf))
+            Parts: 2/20
+            Granules: 2/20
+          Ranges: 2
+EXPLAIN indexes = 1
+SELECT x FROM test_composite_key2 WHERE if(x >= 0, -x, x) + 2 < -1 ORDER BY x;
+Expression (Project names)
+  Sorting (Sorting for ORDER BY)
+    Expression ((Before ORDER BY + Projection))
+      Filter ((WHERE + Change column names to column identifiers))
+        ReadFromMergeTree (default.test_composite_key2)
+        Indexes:
+          MinMax
+            Condition: true
+            Parts: 20/20
+            Granules: 20/20
+          Partition
+            Keys:
+              if(greaterOrEquals(x, 0), negate(x), x)
+            Condition: (plus(if(greaterOrEquals(x, 0), negate(x), x), 2) in (-Inf, -2])
+            Parts: 12/20
+            Granules: 12/20
+          Ranges: 12
+EXPLAIN indexes = 1
+SELECT x FROM test_composite_key2 WHERE if(x >= 0, -x, x) + 2 != -1 ORDER BY x;
+Expression (Project names)
+  Sorting (Sorting for ORDER BY)
+    Expression ((Before ORDER BY + Projection))
+      Filter ((WHERE + Change column names to column identifiers))
+        ReadFromMergeTree (default.test_composite_key2)
+        Indexes:
+          MinMax
+            Condition: true
+            Parts: 20/20
+            Granules: 20/20
+          Partition
+            Keys:
+              if(greaterOrEquals(x, 0), negate(x), x)
+            Condition: (plus(if(greaterOrEquals(x, 0), negate(x), x), 2) not in [-1, -1])
+            Parts: 18/20
+            Granules: 18/20
+          Ranges: 18
+DROP TABLE IF EXISTS test_det_function;
+CREATE TABLE test_det_function (x Int32)
+ENGINE = MergeTree ORDER BY tuple() PARTITION BY x
+SETTINGS index_granularity = 1;
+INSERT INTO test_det_function SELECT number FROM numbers(15);
+EXPLAIN indexes = 1
+SELECT x FROM test_det_function WHERE cityHash64(x) % 5 = 3 ORDER BY x;
+Expression (Project names)
+  Sorting (Sorting for ORDER BY)
+    Expression ((Before ORDER BY + Projection))
+      Filter ((WHERE + Change column names to column identifiers))
+        ReadFromMergeTree (default.test_det_function)
+        Indexes:
+          MinMax
+            Condition: true
+            Parts: 15/15
+            Granules: 15/15
+          Partition
+            Keys:
+              x
+            Condition: (modulo(cityHash64(x), 5) in [3, 3])
+            Parts: 2/15
+            Granules: 2/15
+          Ranges: 2
+EXPLAIN indexes = 1
+SELECT x FROM test_det_function WHERE cityHash64(x) % 5 > 3 ORDER BY x;
+Expression (Project names)
+  Sorting (Sorting for ORDER BY)
+    Expression ((Before ORDER BY + Projection))
+      Filter ((WHERE + Change column names to column identifiers))
+        ReadFromMergeTree (default.test_det_function)
+        Indexes:
+          MinMax
+            Condition: true
+            Parts: 15/15
+            Granules: 15/15
+          Partition
+            Keys:
+              x
+            Condition: (modulo(cityHash64(x), 5) in [4, +Inf))
+            Parts: 4/15
+            Granules: 4/15
+          Ranges: 4
+EXPLAIN indexes = 1
+SELECT x FROM test_det_function WHERE cityHash64(x) % 5 < 3 ORDER BY x;
+Expression (Project names)
+  Sorting (Sorting for ORDER BY)
+    Expression ((Before ORDER BY + Projection))
+      Filter ((WHERE + Change column names to column identifiers))
+        ReadFromMergeTree (default.test_det_function)
+        Indexes:
+          MinMax
+            Condition: true
+            Parts: 15/15
+            Granules: 15/15
+          Partition
+            Keys:
+              x
+            Condition: (modulo(cityHash64(x), 5) in (-Inf, 2])
+            Parts: 9/15
+            Granules: 9/15
+          Ranges: 9
+EXPLAIN indexes = 1
+SELECT x FROM test_det_function WHERE cityHash64(x) % 5 != 3 ORDER BY x;
+Expression (Project names)
+  Sorting (Sorting for ORDER BY)
+    Expression ((Before ORDER BY + Projection))
+      Filter ((WHERE + Change column names to column identifiers))
+        ReadFromMergeTree (default.test_det_function)
+        Indexes:
+          MinMax
+            Condition: true
+            Parts: 15/15
+            Granules: 15/15
+          Partition
+            Keys:
+              x
+            Condition: (modulo(cityHash64(x), 5) not in [3, 3])
+            Parts: 13/15
+            Granules: 13/15
+          Ranges: 13
+EXPLAIN indexes = 1
+SELECT x FROM test_det_function WHERE cityHash64(x) % 5 != cityHash64(3) % 5 ORDER BY x;
+Expression (Project names)
+  Sorting (Sorting for ORDER BY)
+    Expression ((Before ORDER BY + Projection))
+      Filter ((WHERE + Change column names to column identifiers))
+        ReadFromMergeTree (default.test_det_function)
+        Indexes:
+          MinMax
+            Condition: true
+            Parts: 15/15
+            Granules: 15/15
+          Partition
+            Keys:
+              x
+            Condition: (modulo(cityHash64(x), 5) not in [4, 4])
+            Parts: 11/15
+            Granules: 11/15
+          Ranges: 11
+DROP TABLE IF EXISTS test_strings;
+CREATE TABLE test_strings (p String)
+ENGINE = MergeTree ORDER BY tuple() PARTITION BY p
+SETTINGS index_granularity = 1;
+INSERT INTO test_strings VALUES ('abc'), ('def'), ('ghi'), ('jkl'), ('mnop'), ('q');
+EXPLAIN indexes = 1
+SELECT p FROM test_strings WHERE reverse(p) = 'cba' ORDER BY p;
+Expression (Project names)
+  Sorting (Sorting for ORDER BY)
+    Expression ((Before ORDER BY + Projection))
+      Filter ((WHERE + Change column names to column identifiers))
+        ReadFromMergeTree (default.test_strings)
+        Indexes:
+          MinMax
+            Condition: true
+            Parts: 6/6
+            Granules: 6/6
+          Partition
+            Keys:
+              p
+            Condition: (reverse(p) in [\'cba\', \'cba\'])
+            Parts: 1/6
+            Granules: 1/6
+          Ranges: 1
+EXPLAIN indexes = 1
+SELECT p FROM test_strings WHERE hex(p) > '646566' ORDER BY p;
+Expression (Project names)
+  Sorting (Sorting for ORDER BY)
+    Expression ((Before ORDER BY + Projection))
+      Filter ((WHERE + Change column names to column identifiers))
+        ReadFromMergeTree (default.test_strings)
+        Indexes:
+          MinMax
+            Condition: true
+            Parts: 6/6
+            Granules: 6/6
+          Partition
+            Keys:
+              p
+            Condition: (hex(p) in (\'646566\', +Inf))
+            Parts: 4/6
+            Granules: 4/6
+          Ranges: 4
+EXPLAIN indexes = 1
+SELECT p FROM test_strings WHERE length(p) < 3 ORDER BY p;
+Expression (Project names)
+  Sorting (Sorting for ORDER BY)
+    Expression ((Before ORDER BY + Projection))
+      Filter ((WHERE + Change column names to column identifiers))
+        ReadFromMergeTree (default.test_strings)
+        Indexes:
+          MinMax
+            Condition: true
+            Parts: 6/6
+            Granules: 6/6
+          Partition
+            Keys:
+              p
+            Condition: (length(p) in (-Inf, 2])
+            Parts: 1/6
+            Granules: 1/6
+          Ranges: 1
+EXPLAIN indexes = 1
+SELECT p FROM test_strings WHERE length(p) != 3 ORDER BY p;
+Expression (Project names)
+  Sorting (Sorting for ORDER BY)
+    Expression ((Before ORDER BY + Projection))
+      Filter ((WHERE + Change column names to column identifiers))
+        ReadFromMergeTree (default.test_strings)
+        Indexes:
+          MinMax
+            Condition: true
+            Parts: 6/6
+            Granules: 6/6
+          Partition
+            Keys:
+              p
+            Condition: (length(p) not in [3, 3])
+            Parts: 2/6
+            Granules: 2/6
+          Ranges: 2
+EXPLAIN indexes = 1
+SELECT p FROM test_strings WHERE reverse(p) > 'lkj' ORDER BY p;
+Expression (Project names)
+  Sorting (Sorting for ORDER BY)
+    Expression ((Before ORDER BY + Projection))
+      Filter ((WHERE + Change column names to column identifiers))
+        ReadFromMergeTree (default.test_strings)
+        Indexes:
+          MinMax
+            Condition: true
+            Parts: 6/6
+            Granules: 6/6
+          Partition
+            Keys:
+              p
+            Condition: (reverse(p) in (\'lkj\', +Inf))
+            Parts: 2/6
+            Granules: 2/6
+          Ranges: 2
+-- We only support deterministic function chain for now.
+-- Even though it is mathematically correct for any arbitrary dag as well.
+EXPLAIN indexes = 1
+SELECT p FROM test_strings WHERE (left(p, length(p) - length(substringIndex(p, '-', -1)) - 1)) = 'abc';
+Expression ((Project names + Projection))
+  Filter ((WHERE + Change column names to column identifiers))
+    ReadFromMergeTree (default.test_strings)
+    Indexes:
+      MinMax
+        Condition: true
+        Parts: 6/6
+        Granules: 6/6
+      Partition
+        Condition: true
+        Parts: 6/6
+        Granules: 6/6
+      Ranges: 6
+DROP TABLE IF EXISTS test_monotonic_datetime;
+CREATE TABLE test_monotonic_datetime (d Date, y String)
+ENGINE = MergeTree ORDER BY tuple() PARTITION BY d
+SETTINGS index_granularity = 1;
+INSERT INTO test_monotonic_datetime VALUES ('2026-01-01', 'a'), ('2026-01-02', 'b'), ('2026-01-03', 'c');
+SET date_time_overflow_behavior = 'ignore';
+SET session_timezone = 'UTC';
+EXPLAIN indexes = 1
+SELECT d FROM test_monotonic_datetime WHERE toDateTime(d) = toDateTime('2026-01-02');
+Expression ((Project names + Projection))
+  Filter ((WHERE + Change column names to column identifiers))
+    ReadFromMergeTree (default.test_monotonic_datetime)
+    Indexes:
+      MinMax
+        Condition: true
+        Parts: 3/3
+        Granules: 3/3
+      Partition
+        Keys:
+          d
+        Condition: (toDateTime(d) in [1767312000, 1767312000])
+        Parts: 1/3
+        Granules: 1/3
+      Ranges: 1

--- a/tests/queries/0_stateless/04003_deterministic_filter_chain_partition_pruning_key_condition_explain.reference
+++ b/tests/queries/0_stateless/04003_deterministic_filter_chain_partition_pruning_key_condition_explain.reference
@@ -493,3 +493,101 @@ Expression ((Project names + Projection))
         Parts: 1/3
         Granules: 1/3
       Ranges: 1
+DROP TABLE IF EXISTS test_partition_key_to_year_month;
+CREATE TABLE test_partition_key_to_year_month (d Date)
+ENGINE = MergeTree ORDER BY tuple() PARTITION BY toYYYYMM(d)
+SETTINGS index_granularity = 1;
+INSERT INTO test_partition_key_to_year_month VALUES
+    ('2024-01-15'),
+    ('2024-02-15'),
+    ('2024-03-15'),
+    ('2024-04-15');
+EXPLAIN indexes = 1
+SELECT d
+FROM test_partition_key_to_year_month
+WHERE addMonths(toDate(concat(toString(toYYYYMM(d)), '01')), 1) > toDate('2024-03-01')
+ORDER BY d;
+Expression (Project names)
+  Sorting (Sorting for ORDER BY)
+    Expression ((Before ORDER BY + Projection))
+      Filter ((WHERE + Change column names to column identifiers))
+        ReadFromMergeTree (default.test_partition_key_to_year_month)
+        Indexes:
+          MinMax
+            Condition: true
+            Parts: 4/4
+            Granules: 4/4
+          Partition
+            Keys:
+              toYYYYMM(d)
+            Condition: (addMonths(toDate(concat(toString(toYYYYMM(d)), \'01\')), 1) in [19784, +Inf))
+            Parts: 2/4
+            Granules: 2/4
+          Ranges: 2
+EXPLAIN indexes = 1
+SELECT d
+FROM test_partition_key_to_year_month
+WHERE addMonths(toDate(concat(toString(toYYYYMM(d)), '01')), 1) < toDate('2024-04-01')
+ORDER BY d;
+Expression (Project names)
+  Sorting (Sorting for ORDER BY)
+    Expression ((Before ORDER BY + Projection))
+      Filter ((WHERE + Change column names to column identifiers))
+        ReadFromMergeTree (default.test_partition_key_to_year_month)
+        Indexes:
+          MinMax
+            Condition: true
+            Parts: 4/4
+            Granules: 4/4
+          Partition
+            Keys:
+              toYYYYMM(d)
+            Condition: (addMonths(toDate(concat(toString(toYYYYMM(d)), \'01\')), 1) in (-Inf, 19813])
+            Parts: 2/4
+            Granules: 2/4
+          Ranges: 2
+EXPLAIN indexes = 1
+SELECT d
+FROM test_partition_key_to_year_month
+WHERE addMonths(toDate(concat(toString(toYYYYMM(d)), '01')), 1) != toDate('2024-03-01')
+ORDER BY d;
+Expression (Project names)
+  Sorting (Sorting for ORDER BY)
+    Expression ((Before ORDER BY + Projection))
+      Filter ((WHERE + Change column names to column identifiers))
+        ReadFromMergeTree (default.test_partition_key_to_year_month)
+        Indexes:
+          MinMax
+            Condition: true
+            Parts: 4/4
+            Granules: 4/4
+          Partition
+            Keys:
+              toYYYYMM(d)
+            Condition: (addMonths(toDate(concat(toString(toYYYYMM(d)), \'01\')), 1) not in [19783, 19783])
+            Parts: 3/4
+            Granules: 3/4
+          Ranges: 3
+DROP TABLE IF EXISTS test_nondeterministic_function;
+CREATE TABLE test_nondeterministic_function (x Int32)
+ENGINE = MergeTree ORDER BY tuple() PARTITION BY x
+SETTINGS index_granularity = 1;
+INSERT INTO test_nondeterministic_function SELECT number FROM numbers(15);
+-- No atom created for partition pruning
+EXPLAIN indexes = 1
+SELECT count() FROM test_nondeterministic_function WHERE x + rand() = 9;
+Expression ((Project names + Projection))
+  Aggregating
+    Expression (Before GROUP BY)
+      Filter ((WHERE + Change column names to column identifiers))
+        ReadFromMergeTree (default.test_nondeterministic_function)
+        Indexes:
+          MinMax
+            Condition: true
+            Parts: 15/15
+            Granules: 15/15
+          Partition
+            Condition: true
+            Parts: 15/15
+            Granules: 15/15
+          Ranges: 15

--- a/tests/queries/0_stateless/04003_deterministic_filter_chain_partition_pruning_key_condition_explain.sql
+++ b/tests/queries/0_stateless/04003_deterministic_filter_chain_partition_pruning_key_condition_explain.sql
@@ -1,0 +1,128 @@
+-- Tags: no-replicated-database, no-parallel-replicas, no-random-merge-tree-settings
+-- EXPLAIN output may differ
+
+-- { echo }
+
+DROP TABLE IF EXISTS test_simple_key;
+CREATE TABLE test_simple_key (x Int32)
+ENGINE = MergeTree ORDER BY tuple() PARTITION BY x
+SETTINGS index_granularity = 1;
+
+INSERT INTO test_simple_key SELECT number FROM numbers(15);
+
+EXPLAIN indexes = 1
+SELECT x FROM test_simple_key WHERE x + 2 = 9 ORDER BY x;
+
+EXPLAIN indexes = 1
+SELECT x FROM test_simple_key WHERE x + 2 > 9 ORDER BY x;
+
+EXPLAIN indexes = 1
+SELECT x FROM test_simple_key WHERE x + 2 < 9 ORDER BY x;
+
+EXPLAIN indexes = 1
+SELECT x FROM test_simple_key WHERE x + 2 != 9 ORDER BY x;
+
+
+DROP TABLE IF EXISTS test_composite_key;
+CREATE TABLE test_composite_key (x Int32)
+ENGINE = MergeTree ORDER BY tuple() PARTITION BY x * x
+SETTINGS index_granularity = 1;
+
+INSERT INTO test_composite_key SELECT number FROM numbers(15);
+
+EXPLAIN indexes = 1
+SELECT x FROM test_composite_key WHERE x * x + 2 = 11 ORDER BY x;
+
+EXPLAIN indexes = 1
+SELECT x FROM test_composite_key WHERE x * x + 2 > 11 ORDER BY x;
+
+EXPLAIN indexes = 1
+SELECT x FROM test_composite_key WHERE x * x + 2 < 11 ORDER BY x;
+
+EXPLAIN indexes = 1
+SELECT x FROM test_composite_key WHERE x * x + 2 != 11 ORDER BY x;
+
+DROP TABLE IF EXISTS test_composite_key2;
+CREATE TABLE test_composite_key2 (x Int32)
+ENGINE = MergeTree ORDER BY tuple() PARTITION BY if(x >= 0, -x, x)
+SETTINGS index_granularity = 1;
+
+INSERT INTO test_composite_key2 SELECT -number FROM numbers(10);
+INSERT INTO test_composite_key2 SELECT number FROM numbers(10);
+
+EXPLAIN indexes = 1
+SELECT x FROM test_composite_key2 WHERE if(x >= 0, -x, x) + 2 = 1 ORDER BY x;
+
+EXPLAIN indexes = 1
+SELECT x FROM test_composite_key2 WHERE if(x >= 0, -x, x) + 2 > 1 ORDER BY x;
+
+EXPLAIN indexes = 1
+SELECT x FROM test_composite_key2 WHERE if(x >= 0, -x, x) + 2 < -1 ORDER BY x;
+
+EXPLAIN indexes = 1
+SELECT x FROM test_composite_key2 WHERE if(x >= 0, -x, x) + 2 != -1 ORDER BY x;
+
+
+DROP TABLE IF EXISTS test_det_function;
+CREATE TABLE test_det_function (x Int32)
+ENGINE = MergeTree ORDER BY tuple() PARTITION BY x
+SETTINGS index_granularity = 1;
+
+INSERT INTO test_det_function SELECT number FROM numbers(15);
+
+EXPLAIN indexes = 1
+SELECT x FROM test_det_function WHERE cityHash64(x) % 5 = 3 ORDER BY x;
+
+EXPLAIN indexes = 1
+SELECT x FROM test_det_function WHERE cityHash64(x) % 5 > 3 ORDER BY x;
+
+EXPLAIN indexes = 1
+SELECT x FROM test_det_function WHERE cityHash64(x) % 5 < 3 ORDER BY x;
+
+EXPLAIN indexes = 1
+SELECT x FROM test_det_function WHERE cityHash64(x) % 5 != 3 ORDER BY x;
+
+EXPLAIN indexes = 1
+SELECT x FROM test_det_function WHERE cityHash64(x) % 5 != cityHash64(3) % 5 ORDER BY x;
+
+
+DROP TABLE IF EXISTS test_strings;
+CREATE TABLE test_strings (p String)
+ENGINE = MergeTree ORDER BY tuple() PARTITION BY p
+SETTINGS index_granularity = 1;
+
+INSERT INTO test_strings VALUES ('abc'), ('def'), ('ghi'), ('jkl'), ('mnop'), ('q');
+
+EXPLAIN indexes = 1
+SELECT p FROM test_strings WHERE reverse(p) = 'cba' ORDER BY p;
+
+EXPLAIN indexes = 1
+SELECT p FROM test_strings WHERE hex(p) > '646566' ORDER BY p;
+
+EXPLAIN indexes = 1
+SELECT p FROM test_strings WHERE length(p) < 3 ORDER BY p;
+
+EXPLAIN indexes = 1
+SELECT p FROM test_strings WHERE length(p) != 3 ORDER BY p;
+
+EXPLAIN indexes = 1
+SELECT p FROM test_strings WHERE reverse(p) > 'lkj' ORDER BY p;
+
+-- We only support deterministic function chain for now.
+-- Even though it is mathematically correct for any arbitrary dag as well.
+EXPLAIN indexes = 1
+SELECT p FROM test_strings WHERE (left(p, length(p) - length(substringIndex(p, '-', -1)) - 1)) = 'abc';
+
+
+DROP TABLE IF EXISTS test_monotonic_datetime;
+CREATE TABLE test_monotonic_datetime (d Date, y String)
+ENGINE = MergeTree ORDER BY tuple() PARTITION BY d
+SETTINGS index_granularity = 1;
+
+INSERT INTO test_monotonic_datetime VALUES ('2026-01-01', 'a'), ('2026-01-02', 'b'), ('2026-01-03', 'c');
+
+SET date_time_overflow_behavior = 'ignore';
+SET session_timezone = 'UTC';
+
+EXPLAIN indexes = 1
+SELECT d FROM test_monotonic_datetime WHERE toDateTime(d) = toDateTime('2026-01-02');

--- a/tests/queries/0_stateless/04003_deterministic_filter_chain_partition_pruning_key_condition_explain.sql
+++ b/tests/queries/0_stateless/04003_deterministic_filter_chain_partition_pruning_key_condition_explain.sql
@@ -126,3 +126,45 @@ SET session_timezone = 'UTC';
 
 EXPLAIN indexes = 1
 SELECT d FROM test_monotonic_datetime WHERE toDateTime(d) = toDateTime('2026-01-02');
+
+
+DROP TABLE IF EXISTS test_partition_key_to_year_month;
+CREATE TABLE test_partition_key_to_year_month (d Date)
+ENGINE = MergeTree ORDER BY tuple() PARTITION BY toYYYYMM(d)
+SETTINGS index_granularity = 1;
+
+INSERT INTO test_partition_key_to_year_month VALUES
+    ('2024-01-15'),
+    ('2024-02-15'),
+    ('2024-03-15'),
+    ('2024-04-15');
+
+EXPLAIN indexes = 1
+SELECT d
+FROM test_partition_key_to_year_month
+WHERE addMonths(toDate(concat(toString(toYYYYMM(d)), '01')), 1) > toDate('2024-03-01')
+ORDER BY d;
+
+EXPLAIN indexes = 1
+SELECT d
+FROM test_partition_key_to_year_month
+WHERE addMonths(toDate(concat(toString(toYYYYMM(d)), '01')), 1) < toDate('2024-04-01')
+ORDER BY d;
+
+EXPLAIN indexes = 1
+SELECT d
+FROM test_partition_key_to_year_month
+WHERE addMonths(toDate(concat(toString(toYYYYMM(d)), '01')), 1) != toDate('2024-03-01')
+ORDER BY d;
+
+
+DROP TABLE IF EXISTS test_nondeterministic_function;
+CREATE TABLE test_nondeterministic_function (x Int32)
+ENGINE = MergeTree ORDER BY tuple() PARTITION BY x
+SETTINGS index_granularity = 1;
+
+INSERT INTO test_nondeterministic_function SELECT number FROM numbers(15);
+
+-- No atom created for partition pruning
+EXPLAIN indexes = 1
+SELECT count() FROM test_nondeterministic_function WHERE x + rand() = 9;


### PR DESCRIPTION
Given,

```sql
CREATE TABLE test (x Int32)
ENGINE = MergeTree ORDER BY tuple() PARTITION BY x
SETTINGS index_granularity = 1;

INSERT INTO test SELECT number FROM numbers(15);
```

We prune `=` cases.
```sql
EXPLAIN indexes = 1
SELECT x FROM test WHERE x % 10 = 9 ORDER BY x;
```

But do not for `<`, `>`, `!=`.

```sql
EXPLAIN indexes = 1
SELECT x FROM test WHERE x % 10 > 9 ORDER BY x;

EXPLAIN indexes = 1
SELECT x FROM test WHERE x % 10 < 9 ORDER BY x;

EXPLAIN indexes = 1
SELECT x FROM test WHERE x % 10 != 9 ORDER BY x;
```

But mathematically all comparison partition pruning is possible.

### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Allow partition pruning when the predicate contains any comparison operator (`=`, `<`, `>`, `!=`) and the partition key is wrapped in a deterministic function chain (e.g. `PARTITION BY x` and predicates like `cityHash64(x) % 5 > 2`, `toYYYYMM(x) < 2026`, `toYYYYMM(x) = 2026`, or `toYYYYMM(x) != 2026` will all use the partition key for pruning). Closes https://github.com/ClickHouse/ClickHouse/issues/28800.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.237`
<!-- ch-version-info:end -->