### PR TITLE
Reduce insanity of 04004_move_partition_bidirectional_deadlock test

### DIFF
--- a/tests/queries/0_stateless/04004_move_partition_bidirectional_deadlock.sh
+++ b/tests/queries/0_stateless/04004_move_partition_bidirectional_deadlock.sh
@@ -23,7 +23,7 @@ function insert_thread()
     local TIMELIMIT=$((SECONDS+TIMEOUT))
     while [ $SECONDS -lt "$TIMELIMIT" ]
     do
-        $CLICKHOUSE_CLIENT --query="INSERT INTO $table SELECT number % 2, toString(number) FROM numbers(100)"
+        $CLICKHOUSE_CLIENT --query="INSERT INTO $table SELECT number % 2, toString(number) FROM numbers(10)"
     done
 }
 
@@ -81,13 +81,11 @@ function replace_thread_backward()
     done
 }
 
-TIMEOUT=10
+TIMEOUT=3
 
 insert_thread t1 2>/dev/null &
 insert_thread t2 2>/dev/null &
 move_thread_forward 2>/dev/null &
-move_thread_forward 2>/dev/null &
-move_thread_backward 2>/dev/null &
 move_thread_backward 2>/dev/null &
 attach_thread_forward 2>/dev/null &
 attach_thread_backward 2>/dev/null &


### PR DESCRIPTION
The test `04004_move_partition_bidirectional_deadlock` timed out after 600 seconds in the S3 storage CI configuration (amd_debug, distributed plan, s3 storage, parallel).

A single `MOVE PARTITION` query accumulated 1200+ parts during the 10-second concurrent window and took ~583 seconds to process them all on S3 storage, exceeding the test timeout.

Fix by reducing the test timeout from 10 to 3 seconds, removing duplicate move threads, and inserting fewer rows per iteration. Three seconds is still sufficient to trigger the deadlock bug the test is designed to detect.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=acf6aca664cc5cf8f7b0f75e4c7094ef3b6b17bf&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_debug%2C%20distributed%20plan%2C%20s3%20storage%2C%20parallel%29&name_1=Stateless%20tests%20%28amd_debug%2C%20distributed%20plan%2C%20s3%20storage%2C%20parallel%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.242`
<!-- ch-version-info:end -->