### PR TITLE
Fix WriteBufferDecorator::cancelImpl writing to finalized buffer

### DIFF
--- a/src/IO/WriteBufferDecorator.h
+++ b/src/IO/WriteBufferDecorator.h
@@ -53,16 +53,24 @@ public:
         {
             /// Try to flush compression buffers before cancelling.
             /// Such buffers don't guarantee that they are flushed on next(), although callers may expect so
-            /// But if the out buffer is cancelled - it will get stuck
-            bool out_buffer_still_valid = !out->isCanceled();
+            /// But if the out buffer is cancelled or finalized - it will get stuck
+            bool out_buffer_still_valid = !out->isCanceled() && !out->isFinalized();
             if (out_buffer_still_valid)
+            {
                 finalFlushBefore();
-            this->next();
+                this->next();
+            }
             Base::cancelImpl();
-            out->next();
-            out->cancel();
             if (out_buffer_still_valid)
+            {
+                out->next();
+                out->cancel();
                 finalFlushAfter();
+            }
+            else
+            {
+                out->cancel();
+            }
         }
         catch (...)
         {

--- a/tests/queries/0_stateless/04006_cancel_write_buffer_decorator_with_compressed_error.reference
+++ b/tests/queries/0_stateless/04006_cancel_write_buffer_decorator_with_compressed_error.reference
@@ -1,0 +1,6 @@
+lz4: error returned
+gzip: error returned
+zstd: error returned
+br: error returned
+deflate: error returned
+alive

--- a/tests/queries/0_stateless/04006_cancel_write_buffer_decorator_with_compressed_error.sh
+++ b/tests/queries/0_stateless/04006_cancel_write_buffer_decorator_with_compressed_error.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Regression test for WriteBufferDecorator::cancelImpl writing to a finalized buffer.
+#
+# When an HTTP request with response compression (Accept-Encoding: lz4/gzip/...)
+# fails during query analysis (before any data is sent), cancelWithException
+# finalizes the HTTP response buffer but leaves intermediate compression buffers
+# un-finalized. The subsequent Output::cancel then calls cancel on those buffers,
+# and WriteBufferDecorator::cancelImpl must not attempt to flush data to the
+# already-finalized downstream buffer.
+#
+# In debug builds this caused: Logical error 'Cannot write to finalized buffer'.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# Send queries that fail during analysis (type errors) via HTTP with various
+# compression encodings. The server must return an error without crashing.
+for encoding in lz4 gzip zstd br deflate; do
+    # Use -o /dev/null to discard compressed body, check HTTP status code
+    http_code=$(${CLICKHOUSE_CURL} -sS -o /dev/null -w "%{http_code}" \
+        "${CLICKHOUSE_URL}&enable_http_compression=1" \
+        -H "Accept-Encoding: $encoding" \
+        -d "SELECT negate('not a number')")
+
+    # Query analysis errors return HTTP 400
+    if [ "$http_code" -ge 400 ] 2>/dev/null; then
+        echo "$encoding: error returned"
+    else
+        echo "$encoding: unexpected http_code=$http_code"
+    fi
+done
+
+# Verify server is still alive after all the error queries with compression
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}" -d "SELECT 'alive'"


### PR DESCRIPTION
## Summary
- Fix `WriteBufferDecorator::cancelImpl` attempting to flush data to an already-finalized downstream buffer, causing a "Cannot write to finalized buffer" logical error

When an HTTP request with compression (LZ4/gzip) encounters an error, the error handling path in `cancelWithException` finalizes the HTTP response buffer (`out_holder`) after sending the error response. However, the intermediate compression buffer (`wrap_compressed_holder`) is left un-finalized. When `Output::cancel` is subsequently called, it invokes `cancel` on the compression buffer, whose `WriteBufferDecorator::cancelImpl` only checked `!out->isCanceled()` before attempting to flush remaining data to the downstream buffer. Since the downstream buffer was finalized (not canceled), the flush triggered "Cannot write to finalized buffer" — a logical error that aborts the server in debug builds.

The fix adds `&& !out->isFinalized()` to the validity check, and restructures the code to skip `this->next()` and `out->next()` calls when the downstream buffer is not writable.

Found via SQLancer testing (PR #98390).

### Changelog category (leave one):
- CI Fix or Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix exception "Cannot write to finalized buffer" in `WriteBufferDecorator::cancelImpl` when HTTP requests with compression encounter errors.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.241`
- Backported to: `26.2.7.11`, `26.1.8.4`
<!-- ch-version-info:end -->