### PR TITLE
Enable jemalloc with UBSan builds

### DIFF
--- a/contrib/jemalloc-cmake/CMakeLists.txt
+++ b/contrib/jemalloc-cmake/CMakeLists.txt
@@ -1,10 +1,10 @@
-if (SANITIZE OR NOT (
+if ((SANITIZE AND NOT SANITIZE STREQUAL "undefined") OR NOT (
     ((OS_LINUX OR OS_FREEBSD) AND (ARCH_AMD64 OR ARCH_AARCH64 OR ARCH_PPC64LE OR ARCH_RISCV64 OR ARCH_S390X OR ARCH_E2K)) OR
     (OS_DARWIN AND (CMAKE_BUILD_TYPE_UC STREQUAL "RELWITHDEBINFO" OR CMAKE_BUILD_TYPE_UC STREQUAL "DEBUG"))
 ))
     if (ENABLE_JEMALLOC)
         message (${RECONFIGURE_MESSAGE_LEVEL}
-                 "jemalloc is disabled implicitly: it doesn't work with sanitizers and can only be used with x86_64, aarch64, or ppc64le Linux or FreeBSD builds and RelWithDebInfo macOS builds. Use -DENABLE_JEMALLOC=0")
+                 "jemalloc is disabled implicitly: it doesn't work with sanitizers (except UBSan) and can only be used with x86_64, aarch64, or ppc64le Linux or FreeBSD builds and RelWithDebInfo macOS builds. Use -DENABLE_JEMALLOC=0")
     endif ()
     set (ENABLE_JEMALLOC OFF)
 else ()


### PR DESCRIPTION
## Summary
- Enable jemalloc for UBSan builds by refining the sanitizer check in `contrib/jemalloc-cmake/CMakeLists.txt`
- ASan, MSan, and TSan replace the allocator, so jemalloc is incompatible with them. UBSan only instruments arithmetic, alignment, and type operations — it does not touch the allocator
- Without jemalloc, UBSan builds fall back to glibc malloc, which retains freed pages in its arenas instead of returning them to the OS. This causes RSS to accumulate across sequential queries, eventually hitting `max_server_memory_usage` even though no single query exceeds its limit
- This has been causing flaky OOM failures in the AST fuzzer CI job for UBSan builds: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=98374&sha=e5430da027f3d7cea76984b898881c6bf8d6c978&name_0=PR&name_1=AST%20fuzzer%20%28amd_ubsan%29
https://github.com/ClickHouse/ClickHouse/pull/98374

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Enable jemalloc allocator for UBSan builds to avoid RSS accumulation from glibc malloc's poor memory reclamation behavior.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.248`
<!-- ch-version-info:end -->