### PR TITLE
Gracefully handle failure to fetch historical thresholds in perf tests

### DIFF
--- a/ci/jobs/performance_tests.py
+++ b/ci/jobs/performance_tests.py
@@ -452,10 +452,25 @@ def main():
             cidb = CIDBCluster(
                 url="https://play.clickhouse.com?user=play", user="", pwd=""
             )
-            assert cidb.is_ready()
+            if not cidb.is_ready():
+                print(
+                    "WARNING: CIDB is not ready, will proceed without historical thresholds"
+                )
+                Shell.check(
+                    f"touch {perf_wd}/historical-thresholds.tsv", verbose=True
+                )
+                return True
             result = cidb.do_select_query(
                 query=GET_HISTORICAL_TRESHOLDS_QUERY, timeout=10, retries=3
             )
+            if result is None:
+                print(
+                    "WARNING: Failed to fetch historical thresholds, will proceed without them"
+                )
+                Shell.check(
+                    f"touch {perf_wd}/historical-thresholds.tsv", verbose=True
+                )
+                return True
             with open(
                 f"{perf_wd}/historical-thresholds.tsv", "w", encoding="utf-8"
             ) as f:


### PR DESCRIPTION
## Summary
- Performance tests fail with "Cannot select historical data" when `play.clickhouse.com` is unreachable or times out
- The `prepare_historical_data` step crashes with `AssertionError` or `TypeError: write() argument must be str, not None`, blocking all subsequent stages
- Historical thresholds are only used as a `LEFT JOIN` in `compare.sh`, so an empty file is perfectly valid — now we fall back gracefully with a warning instead of failing

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=98361&sha=3b164e8c122fa4ed2bda483b19cae8a0b54af329&name_0=PR&name_1=Performance%20Comparison%20%28amd_release%2C%20master_head%2C%202%2F6%29
https://github.com/ClickHouse/ClickHouse/pull/98361

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.247`
<!-- ch-version-info:end -->