### PR TITLE
Fix targeted check ignoring soft timeout on subsequent iterations

### DIFF
--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -545,6 +545,11 @@ def main():
                 global_time_limit = max(
                     job_timeout - soft_limit_margin - int(stop_watch.duration), 0
                 )
+                if global_time_limit <= 0:
+                    print(
+                        "NOTE: Soft time limit exhausted; stopping before next iteration"
+                    )
+                    break
 
             run_tests(
                 batch_num=batch_num if not tests_to_run else 0,
@@ -602,12 +607,15 @@ def main():
 
                 # On final run, replace results with collected ones
                 if is_final_run or stop_by_elapsed_time:
-                    test_result.results = collected_test_results
-                    # Set overall status to failed if any collected test cases failed
-                    has_failures = any(not t.is_ok() for t in collected_test_results)
-                    if has_failures and test_result.is_ok():
-                        test_result.set_failed()
                     break
+
+        # Apply collected results from multi-run mode
+        if run_sets_cnt > 1 and collected_test_results:
+            test_result.results = collected_test_results
+            # Set overall status to failed if any collected test cases failed
+            has_failures = any(not t.is_ok() for t in collected_test_results)
+            if has_failures and test_result.is_ok():
+                test_result.set_failed()
 
         if not info.is_local_run:
             CH.stop_log_exports()


### PR DESCRIPTION
## Summary
- When the soft time limit was exhausted after the first iteration of a targeted check, `global_time_limit` was recalculated to 0. But `run_tests` was still called with 0, which means "no limit" (the `--global_time_limit` flag is omitted). The `stop_by_elapsed_time` check only ran after `run_tests` returned, but it never returned because the hard job timeout killed the process first.
- The fix breaks out of the loop immediately when the recalculated `global_time_limit` reaches 0, before starting another `run_tests` invocation.
- Also moves the "apply collected results" logic after the loop so it works regardless of which break path is taken.

Example timeout: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96130&sha=047958c845559867d3fabeda146823fa07a46649&name_0=PR&name_1=Stateless%20tests%20%28arm_asan%2C%20targeted%29
https://github.com/ClickHouse/ClickHouse/pull/96130

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)