### PR TITLE
Ignore DATABASE_REPLICATION_FAILED in stress test smoke check

### DIFF
--- a/ci/jobs/scripts/stress/stress.py
+++ b/ci/jobs/scripts/stress/stress.py
@@ -279,7 +279,8 @@ def run_func_test(
                 "Fault injection",
                 "Query memory tracker: fault injected",
                 "KEEPER_EXCEPTION",
-                "QUERY_WAS_CANCELLED"
+                "DATABASE_REPLICATION_FAILED",
+                "QUERY_WAS_CANCELLED",
             ]
             if any(err in e.stdout or err in e.stderr for err in ignored_errors):
                 logging.warning(


### PR DESCRIPTION
## Summary
- The stress test smoke check runs simple tests across all randomization configurations
- In replicated database mode with ZooKeeper fault injection enabled, the session can expire, causing `DATABASE_REPLICATION_FAILED` errors
- The existing `KEEPER_EXCEPTION` in the ignored errors list doesn't match because that string only appears in the server's internal log, not in the client-facing error output
- Added `DATABASE_REPLICATION_FAILED` to the ignored transient errors list

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=5a0a680930b0e1ff01cb47763825105938bad5b9&name_0=MasterCI&name_1=Stress%20test%20%28amd_msan%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.251`
<!-- ch-version-info:end -->