### PR TITLE
Skip throttling integration tests under sanitizers

### DIFF
--- a/tests/integration/test_throttling/test.py
+++ b/tests/integration/test_throttling/test.py
@@ -144,11 +144,20 @@ def node_update_config(mode, setting, value=None, restart=True):
         node.restart_clickhouse()
 
 
+def skip_if_sanitizer(instance):
+    if (
+        instance.is_built_with_thread_sanitizer()
+        or instance.is_built_with_address_sanitizer()
+        or instance.is_built_with_memory_sanitizer()
+    ):
+        pytest.skip("throttling tests are unreliable under sanitizers")
+
+
 def assert_took(took, should_take):
     # we need to decrease the lower limit because the server limits could
     # be enforced by throttling some server background IO instead of query IO
     # and we have no control over it
-    assert took >= should_take * 0.85
+    assert took >= should_take * 0.80
 
 
 @pytest.mark.parametrize(
@@ -292,6 +301,7 @@ def assert_took(took, should_take):
     ],
 )
 def test_backup_throttling(policy, backup_storage, mode, setting, value, should_take):
+    skip_if_sanitizer(node)
     node_update_config(mode, setting, value)
     node.query(
         f"""
@@ -305,6 +315,7 @@ def test_backup_throttling(policy, backup_storage, mode, setting, value, should_
 
 
 def test_backup_throttling_override():
+    skip_if_sanitizer(node)
     node_update_config("user", "max_backup_bandwidth", "1M")
     node.query(
         """
@@ -376,6 +387,7 @@ def test_backup_throttling_override():
     ],
 )
 def test_read_throttling(policy, mode, setting, value, should_take):
+    skip_if_sanitizer(node)
     node_update_config(mode, setting, value)
     node.query(
         f"""
@@ -389,6 +401,7 @@ def test_read_throttling(policy, mode, setting, value, should_take):
 
 
 def test_remote_read_throttling_reload():
+    skip_if_sanitizer(node)
     node.query(
         f"""
         drop table if exists data;
@@ -420,6 +433,7 @@ def test_remote_read_throttling_reload():
     assert took < 3
 
 def test_local_read_throttling_reload():
+    skip_if_sanitizer(node)
     node.query(
         f"""
         drop table if exists data;
@@ -500,6 +514,7 @@ def test_local_read_throttling_reload():
     ],
 )
 def test_write_throttling(policy, mode, setting, value, should_take):
+    skip_if_sanitizer(node)
     node_update_config(mode, setting, value)
     node.query(
         f"""
@@ -512,6 +527,7 @@ def test_write_throttling(policy, mode, setting, value, should_take):
 
 
 def test_remote_write_throttling_reload():
+    skip_if_sanitizer(node)
     node.query(
         f"""
         drop table if exists data;
@@ -543,6 +559,7 @@ def test_remote_write_throttling_reload():
     assert took < 3
 
 def test_local_write_throttling_reload():
+    skip_if_sanitizer(node)
     node.query(
         f"""
         drop table if exists data;
@@ -574,6 +591,7 @@ def test_local_write_throttling_reload():
     assert took < 3
 
 def test_max_mutations_bandwidth_for_server():
+    skip_if_sanitizer(node)
     node.query(
         """
         drop table if exists data;
@@ -590,6 +608,7 @@ def test_max_mutations_bandwidth_for_server():
 
 
 def test_max_merges_bandwidth_for_server():
+    skip_if_sanitizer(node)
     node.query(
         """
         drop table if exists data;


### PR DESCRIPTION
The `test_throttling` integration tests are timing-sensitive and unreliable under sanitizers. Under MSan, throttled operations complete at ~84.5% of the expected time instead of the required 85%, causing flaky failures:

- `test_write_throttling[local_server_throttling]`: took 2.539s, expected >= 2.55s
- `test_local_write_throttling_reload`: took 2.536s, expected >= 2.55s

This PR:
1. Skips all throttling tests under ASan/TSan/MSan
2. Relaxes the tolerance from 0.85 to 0.80 for non-sanitizer runs

CI reports:
- https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=1a70136a2bd20ad0e80b6280a786a75f0228d644&name_0=MasterCI&name_1=Integration%20tests%20%28amd_msan%2C%205%2F6%29
- https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=641a7adfd96fd2b6ceb2697bc3c7fe886beb7750&name_0=MasterCI&name_1=Integration%20tests%20%28amd_msan%2C%205%2F6%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.252`
<!-- ch-version-info:end -->