### PR TITLE
Fix exception when reading Nested subcolumns from Log engine

### DIFF
--- a/src/Storages/StorageLog.cpp
+++ b/src/Storages/StorageLog.cpp
@@ -117,6 +117,12 @@ protected:
 private:
     NameAndTypePair getColumnOnDisk(const NameAndTypePair & column) const;
 
+    /// Returns the cache key for the SubstreamsCache and DeserializeStatesCache.
+    /// All columns from the same Nested group must share the same cache
+    /// so that shared substreams (like Nested array offsets) are read only once
+    /// from the underlying file stream.
+    String getCacheKey(const NameAndTypePair & name_and_type_on_disk) const;
+
     const size_t block_size;
     const NamesAndTypesList columns;
     const std::shared_ptr<const StorageLog> storage;
@@ -180,6 +186,20 @@ NameAndTypePair LogSource::getColumnOnDisk(const NameAndTypePair & column) const
     return column;
 }
 
+String LogSource::getCacheKey(const NameAndTypePair & name_and_type_on_disk) const
+{
+    auto name_in_storage = name_and_type_on_disk.getNameInStorage();
+
+    /// If this column is part of a Nested group, use the Nested name as the cache key.
+    /// This ensures that all subcolumns of the same Nested (e.g. "c1.c2.64" and "c1.size0")
+    /// share the same SubstreamsCache, so that shared substreams like Nested array offsets
+    /// are read only once from the underlying file stream.
+    if (Nested::isSubcolumnOfNested(name_in_storage, storage->columns_with_collected_nested))
+        return Nested::splitName(name_in_storage).first;
+
+    return name_in_storage;
+}
+
 Chunk LogSource::generate()
 {
     if (isFinished())
@@ -201,7 +221,8 @@ Chunk LogSource::generate()
     for (const auto & name_and_type : columns)
     {
         auto name_and_type_on_disk = getColumnOnDisk(name_and_type);
-        readPrefix(name_and_type_on_disk, caches[name_and_type_on_disk.getNameInStorage()], deserialize_states_caches[name_and_type_on_disk.getNameInStorage()]);
+        auto cache_key = getCacheKey(name_and_type_on_disk);
+        readPrefix(name_and_type_on_disk, caches[cache_key], deserialize_states_caches[cache_key]);
     }
 
     /// Second, read the data of all columns/subcolumns.
@@ -213,7 +234,7 @@ Chunk LogSource::generate()
         try
         {
             column = name_type_on_disk.type->createColumn();
-            readData(name_type_on_disk, column, max_rows_to_read, caches[name_type_on_disk.getNameInStorage()]);
+            readData(name_type_on_disk, column, max_rows_to_read, caches[getCacheKey(name_type_on_disk)]);
         }
         catch (Exception & e)
         {

--- a/tests/queries/0_stateless/04008_log_engine_nested_subcolumn_cache.sql
+++ b/tests/queries/0_stateless/04008_log_engine_nested_subcolumn_cache.sql
@@ -1,0 +1,23 @@
+-- Regression test: reading different subcolumns of a Nested column from Log engine
+-- could produce chunks with inconsistent column sizes because the shared Nested
+-- offsets file was read twice from different stream positions.
+
+DROP TABLE IF EXISTS t_log_nested;
+CREATE TABLE t_log_nested
+(
+    id UInt64,
+    n Nested(a UInt64, b Nullable(FixedString(1)))
+) ENGINE = Log;
+
+INSERT INTO t_log_nested SELECT number, [number, number + 1], [NULL, 'x'] FROM numbers(32);
+
+-- This query reads n.a.size0 (shared Nested offsets) and n.b subcolumn
+-- from the same Nested group. They must share the SubstreamsCache
+-- to avoid reading the shared offsets file twice.
+SELECT n.a.size0, n.b FROM t_log_nested FORMAT Null;
+
+-- Also test with multiple inserts (marks-based reading)
+INSERT INTO t_log_nested SELECT number, [number], [NULL] FROM numbers(32);
+SELECT n.a.size0, n.b FROM t_log_nested FORMAT Null;
+
+DROP TABLE t_log_nested;


### PR DESCRIPTION
## Summary

- When `LogSource` reads different subcolumns of a Nested column (e.g. `n.a.size0` and `n.b`), each column used a separate `SubstreamsCache` keyed by `getNameInStorage`
- For `n.size0` this was `"n"`, but for `n.b` it was `"n.b"` — different cache instances despite both needing to read from the same shared Nested offsets file
- The first column consumed the offsets stream; the second tried to read from the same stream at the wrong position, producing fewer rows and triggering "Invalid number of rows in Chunk" exception
- Fix: add `getCacheKey` that maps all columns belonging to the same Nested group to a single cache key (the Nested name), so the shared offsets are read once and then served from cache

Found by BuzzHouse fuzzer: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=98355&sha=5183838a81ab41b4f3434e73aaca3fe02f3d3c59&name_0=PR&name_1=BuzzHouse%20%28amd_debug%29
https://github.com/ClickHouse/ClickHouse/pull/98355

### Changelog category (leave one):
- CI Fix or Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix exception "Invalid number of rows in Chunk" when reading different Nested subcolumns from `Log` engine tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)