### PR TITLE
Fix timeout of 03822_variant_distinct_filter in MSan builds

### DIFF
--- a/tests/queries/0_stateless/03822_variant_distinct_filter.sh
+++ b/tests/queries/0_stateless/03822_variant_distinct_filter.sh
@@ -15,8 +15,8 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 CH_CLIENT="$CLICKHOUSE_CLIENT --allow_experimental_variant_type=1 --allow_suspicious_types_in_order_by=1 --use_variant_default_implementation_for_comparisons=0 --max_execution_time=10"
 
-$CH_CLIENT -q "DROP TABLE IF EXISTS test_variant_distinct"
-$CH_CLIENT -q "CREATE TABLE test_variant_distinct (v1 Variant(String, UInt64, Array(UInt32)), v2 Variant(String, UInt64, Array(UInt32))) ENGINE = Memory"
+$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS test_variant_distinct"
+$CLICKHOUSE_CLIENT -q "CREATE TABLE test_variant_distinct (v1 Variant(String, UInt64, Array(UInt32)), v2 Variant(String, UInt64, Array(UInt32))) ENGINE = Memory"
 
 # Each INSERT creates a separate block in the Memory engine.
 # Concurrent queries will share these blocks via COW pointers.
@@ -57,5 +57,5 @@ done
 
 wait
 
-$CH_CLIENT -q "DROP TABLE test_variant_distinct"
+$CLICKHOUSE_CLIENT -q "DROP TABLE test_variant_distinct"
 echo "OK"


### PR DESCRIPTION
## Summary
- The test `03822_variant_distinct_filter` fails in MSan builds because DDL statements (`DROP TABLE IF EXISTS`, `CREATE TABLE`, `DROP TABLE`) use `$CH_CLIENT` which includes `--max_execution_time=10`
- Under MSan, queries are much slower, and the final `DROP TABLE` gets killed while waiting for the table lock because previous queries may still be cleaning up on the server side
- Fix: use `$CLICKHOUSE_CLIENT` (without `--max_execution_time`) for DDL statements that don't need the Variant-specific settings or the time limit

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=65930adc230a1309eca807a6b851b1a917f35feb&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_msan%2C%20WasmEdge%2C%20parallel%2C%202%2F2%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.255`
<!-- ch-version-info:end -->