### PR TITLE
Fix null pointer dereference in dictGetOrDefault with nullable key

### DIFF
--- a/src/Functions/FunctionsExternalDictionaries.h
+++ b/src/Functions/FunctionsExternalDictionaries.h
@@ -721,9 +721,9 @@ private:
                 result = dictionary->getColumn(attribute_names[0], attribute_type, key_columns, key_types, default_mask);
 
                 auto [defaults_column, mask_column] =
-                    getDefaultsShortCircuit(std::move(default_mask), result_type, last_argument);
+                    getDefaultsShortCircuit(std::move(default_mask), attribute_type, last_argument);
 
-                restoreShortCircuitColumn(result, defaults_column, mask_column, result_type);
+                restoreShortCircuitColumn(result, defaults_column, mask_column, attribute_type);
             }
             else
             {

--- a/tests/queries/0_stateless/04009_dict_get_or_default_nullable_key_short_circuit.reference
+++ b/tests/queries/0_stateless/04009_dict_get_or_default_nullable_key_short_circuit.reference
@@ -1,0 +1,2 @@
+Android
+Android

--- a/tests/queries/0_stateless/04009_dict_get_or_default_nullable_key_short_circuit.sql
+++ b/tests/queries/0_stateless/04009_dict_get_or_default_nullable_key_short_circuit.sql
@@ -1,0 +1,40 @@
+-- Regression test: dictGetOrDefault with nullable key and short-circuit evaluation
+-- caused UBSan error (member call on null pointer) in the `if` function because
+-- restoreShortCircuitColumn passed a non-nullable column with a Nullable type to `if`.
+
+DROP TABLE IF EXISTS regexp_dictionary_source_table;
+CREATE TABLE regexp_dictionary_source_table
+(
+    id UInt64,
+    parent_id UInt64,
+    regexp String,
+    keys   Array(String),
+    values Array(String),
+) ENGINE=TinyLog;
+
+INSERT INTO regexp_dictionary_source_table VALUES (1, 0, 'Linux/(\d+[\.\d]*).+tlinux', ['name', 'version'], ['TencentOS', '\1']);
+INSERT INTO regexp_dictionary_source_table VALUES (2, 0, '(\d+)/tclwebkit(\d+[\.\d]*)', ['name', 'version', 'comment'], ['Android', '$1', 'test $1 and $2']);
+INSERT INTO regexp_dictionary_source_table VALUES (3, 2, '33/tclwebkit', ['version'], ['13']);
+INSERT INTO regexp_dictionary_source_table VALUES (4, 2, '3[12]/tclwebkit', ['version'], ['12']);
+INSERT INTO regexp_dictionary_source_table VALUES (5, 2, '3[12]/tclwebkit', ['version'], ['11']);
+INSERT INTO regexp_dictionary_source_table VALUES (6, 2, '3[12]/tclwebkit', ['version'], ['10']);
+
+DROP DICTIONARY IF EXISTS regexp_dict;
+CREATE DICTIONARY regexp_dict
+(
+    regexp String,
+    name String,
+    version Nullable(UInt64),
+    comment String default 'nothing'
+)
+PRIMARY KEY(regexp)
+SOURCE(CLICKHOUSE(TABLE 'regexp_dictionary_source_table'))
+LIFETIME(0)
+LAYOUT(regexp_tree);
+
+-- The toNullable makes the key nullable, which triggers a different code path
+-- where result_type is Nullable but the dictionary column is not.
+SELECT dictGetOrDefault('regexp_dict', 'name', concat(toString(number), toNullable('/tclwebkit'), toString(number)), intDiv(1, number)) FROM numbers(2);
+
+DROP DICTIONARY regexp_dict;
+DROP TABLE regexp_dictionary_source_table;


### PR DESCRIPTION
<!-- Fixes issue link part, do not remove -->
## Linked issues
- fixes https://github.com/ClickHouse/clickhouse-core-incidents/issues/1765
<!-- End of fixes issue link part, do not remove -->

## Summary
- Fixed UBSan error / assertion failure in `dictGetOrDefault` with nullable key and short-circuit evaluation
- `restoreShortCircuitColumn` was passing a non-nullable dictionary result column with a `Nullable` type to the `if` function, causing `executeForNullableThenElse` to dereference a null pointer when extracting the null map
- Changed to use `attribute_type` (non-nullable) instead of `result_type` (nullable) for the short-circuit merge; the nullable wrapping is already handled by the outer `wrapInNullable` call

Closes #97968

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=5a0a680930b0e1ff01cb47763825105938bad5b9&name_0=MasterCI&name_1=AST%20fuzzer%20%28amd_ubsan%29&name_1=AST%20fuzzer%20%28amd_ubsan%29

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Fix null pointer dereference in `dictGetOrDefault` when the key argument is `Nullable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.258`
- Backported to: `26.2.19.32`, `25.8.24.18`
<!-- ch-version-info:end -->