### PR TITLE
Increase retry count in test_consistent_parts_after_clone_replica

### DIFF
--- a/tests/integration/test_consistent_parts_after_clone_replica/test.py
+++ b/tests/integration/test_consistent_parts_after_clone_replica/test.py
@@ -79,7 +79,7 @@ def test_inconsistent_parts_if_drop_while_replica_not_active(start_cluster):
             node2,
             "SELECT value FROM system.zookeeper WHERE path='/clickhouse/tables/test1/replicated/replicas/node1' AND name='is_lost'",
             "1",
-            retry_count=40,
+            retry_count=120,
         )
 
         node2.wait_for_log_line(


### PR DESCRIPTION
## Summary
- Increased `retry_count` from 40 to 120 in `test_inconsistent_parts_if_drop_while_replica_not_active` to fix a timing race condition
- The test waits for `is_lost=1` in ZooKeeper, which requires the ZK session to expire (15s) and then the cleanup thread to complete a full iteration. A ZK `getChildren` operation can hang for up to 10s (operation timeout), making the worst case ~25s — exceeding the previous 20s (40 × 0.5s) wait

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=1b33a069665706f4b090f6fa3e58acee96289cea&name_0=MasterCI&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%203%2F4%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.254`
<!-- ch-version-info:end -->