### PR TITLE
benchmark: enable --secure by default for cloud

### DIFF
--- a/programs/benchmark/Benchmark.cpp
+++ b/programs/benchmark/Benchmark.cpp
@@ -14,6 +14,7 @@
 #include <Common/ThreadPool.h>
 #include <AggregateFunctions/ReservoirSampler.h>
 #include <AggregateFunctions/registerAggregateFunctions.h>
+#include <Client/ClientBaseHelpers.h>
 #include <base/defines.h>
 #include <boost/program_options.hpp>
 #include <Common/ConcurrentBoundedQueue.h>
@@ -171,6 +172,12 @@ public:
                 connection_arguments.password.emplace(overrides.password.value());
             if (overrides.database.has_value() && !connection_arguments.database.has_value())
                 connection_arguments.database.emplace(overrides.database.value());
+
+            if (connection_arguments.hosts.has_value())
+            {
+                if (isCloudEndpoint(connection_arguments.hosts->front()))
+                    connection_arguments.secure.emplace(true);
+            }
         }
 
         if (connection_arguments.accept_invalid_certificate.value_or(false))


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
benchmark: enable --secure by default for cloud

Otherwise it will simply timeout, and sometimes it is not easy to remember this


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.288`
<!-- ch-version-info:end -->