### PR TITLE
Allow `CAST(... AS Nullable(T))` monotonicity to enable read-in-order optimization and primary key pruning

### DIFF
--- a/src/Functions/FunctionsConversion.cpp
+++ b/src/Functions/FunctionsConversion.cpp
@@ -2228,8 +2228,23 @@ FunctionBasePtr createFunctionBaseCast(
 
     detail::FunctionCast::MonotonicityForRange monotonicity;
 
+    auto monotonicity_result_type = recursiveRemoveLowCardinality(return_type);
+
+    /// Monotonicity for CAST is determined by conversion to the nested target type.
+    /// Nullable only wraps the conversion result and does not change the order of successfully converted values.
+    /// We remove Nullable here so CAST(..., Nullable(T)) can reuse T monotonicity metadata in optimizeReadInOrder
+    /// and KeyCondition function-chain analysis. This is not a problem because both of them still validate monotonicity
+    /// on actual argument types/ranges using getMonotonicityForRange.
+    /// We do not do this for accurateCastOrNull because failed conversions can produce NULL from non-NULL input values.
+    /// For example, ordered Float64 values (1.0, 1.1, 1.2, 1.25, 1.3, 1.5) become
+    /// (1.0, NULL, NULL, 1.25, NULL, 1.5) with accurateCastOrNull(..., 'Float32').
+    /// This can violate monotonicity assumptions used by optimizeReadInOrder/KeyCondition
+    /// and can produce incorrect ORDER BY results.
+    if (cast_type != CastType::accurateOrNull)
+        monotonicity_result_type = removeNullable(monotonicity_result_type);
+
     if (isEnum(arguments.front().type)
-        && castTypeToEither<DataTypeEnum8, DataTypeEnum16>(return_type.get(), [&](auto & type)
+        && castTypeToEither<DataTypeEnum8, DataTypeEnum16>(monotonicity_result_type.get(), [&](auto & type)
         {
             monotonicity = detail::FunctionTo<std::decay_t<decltype(type)>>::Type::Monotonic::get;
             return true;
@@ -2241,7 +2256,7 @@ FunctionBasePtr createFunctionBaseCast(
         DataTypeInt8, DataTypeInt16, DataTypeInt32, DataTypeInt64, DataTypeInt128, DataTypeInt256,
         DataTypeFloat32, DataTypeFloat64,
         DataTypeDate, DataTypeDate32, DataTypeDateTime, DataTypeDateTime64, DataTypeTime, DataTypeTime64,
-        DataTypeString>(recursiveRemoveLowCardinality(return_type).get(), [&](auto & type)
+        DataTypeString>(monotonicity_result_type.get(), [&](auto & type)
         {
             monotonicity = detail::FunctionTo<std::decay_t<decltype(type)>>::Type::Monotonic::get;
             return true;

--- a/tests/performance/cast_nullable_read_in_order.xml
+++ b/tests/performance/cast_nullable_read_in_order.xml
@@ -1,0 +1,13 @@
+<test>
+    <settings>
+        <optimize_read_in_order>1</optimize_read_in_order>
+    </settings>
+
+    <create_query>CREATE TABLE IF NOT EXISTS test_nullable_order_by (x UInt32, y UInt32) ENGINE=MergeTree ORDER BY x</create_query>
+    <fill_query>INSERT INTO test_nullable_order_by SELECT number, number FROM numbers(30000000)</fill_query>
+
+    <query>SELECT y FROM test_nullable_order_by ORDER BY x::UInt64 LIMIT 100000 FORMAT Null</query>
+    <query>SELECT y FROM test_nullable_order_by ORDER BY x::Nullable(UInt64) LIMIT 100000 FORMAT Null</query>
+
+    <drop_query>DROP TABLE IF EXISTS test_nullable_order_by</drop_query>
+</test>

--- a/tests/queries/0_stateless/04002_cast_nullable_read_in_order.reference
+++ b/tests/queries/0_stateless/04002_cast_nullable_read_in_order.reference
@@ -1,0 +1,66 @@
+-- { echo }
+
+SET optimize_read_in_order = 1;
+DROP TABLE IF EXISTS test_nullable_order_by;
+CREATE TABLE test_nullable_order_by (x UInt32, y UInt32) ENGINE=MergeTree ORDER BY x;
+INSERT INTO test_nullable_order_by SELECT number, number FROM numbers(1e6);
+SELECT sum(y) FROM
+(
+    SELECT y FROM test_nullable_order_by ORDER BY x::UInt64 LIMIT 1000000000
+);
+499999500000
+SELECT sum(y) FROM
+(
+    SELECT y FROM test_nullable_order_by ORDER BY x::Nullable(UInt64) LIMIT 1000000000
+);
+499999500000
+DROP TABLE IF EXISTS test_accurate_cast_or_null;
+CREATE TABLE test_accurate_cast_or_null (x Date32, y UInt32) ENGINE=MergeTree ORDER BY x;
+INSERT INTO test_accurate_cast_or_null SELECT toDate32('1969-12-29') + number, number FROM numbers(6);
+SELECT x, accurateCastOrNull(x, 'Date') AS d
+FROM test_accurate_cast_or_null
+ORDER BY accurateCastOrNull(x, 'Date'), x
+LIMIT 10;
+1970-01-01	1970-01-01
+1970-01-02	1970-01-02
+1970-01-03	1970-01-03
+1969-12-29	2149-06-04
+1969-12-30	2149-06-05
+1969-12-31	2149-06-06
+SELECT x, accurateCastOrNull(toInt64(x), 'Date') AS d, toTypeName(d)
+FROM test_accurate_cast_or_null
+ORDER BY accurateCastOrNull(toInt64(x), 'Date'), x
+LIMIT 10;
+1970-01-01	1970-01-01	Nullable(Date)
+1970-01-02	1970-01-02	Nullable(Date)
+1970-01-03	1970-01-03	Nullable(Date)
+1969-12-29	\N	Nullable(Date)
+1969-12-30	\N	Nullable(Date)
+1969-12-31	\N	Nullable(Date)
+DROP TABLE IF EXISTS test_accurate_cast_or_null_float;
+CREATE TABLE test_accurate_cast_or_null_float (x Float64, y UInt32) ENGINE=MergeTree ORDER BY x;
+INSERT INTO test_accurate_cast_or_null_float VALUES
+    (1.0, 1), (1.1, 2), (1.2, 3), (1.25, 4), (1.3, 5), (1.5, 6);
+SELECT x, accurateCastOrNull(x, 'Float32') AS d
+FROM test_accurate_cast_or_null_float
+ORDER BY accurateCastOrNull(x, 'Float32'), x
+LIMIT 10;
+1	1
+1.25	1.25
+1.5	1.5
+1.1	\N
+1.2	\N
+1.3	\N
+DROP TABLE IF EXISTS test_nullable_sorting_key_order_by;
+CREATE TABLE test_nullable_sorting_key_order_by (x UInt32, y UInt32) ENGINE=MergeTree ORDER BY x::Nullable(UInt32) SETTINGS allow_nullable_key = 1;
+INSERT INTO test_nullable_sorting_key_order_by SELECT number, number FROM numbers(1e6);
+SELECT sum(y) FROM
+(
+    SELECT y FROM test_nullable_sorting_key_order_by ORDER BY x::UInt32 LIMIT 1000000000
+);
+499999500000
+SELECT sum(y) FROM
+(
+    SELECT y FROM test_nullable_sorting_key_order_by ORDER BY x::Nullable(UInt32) LIMIT 1000000000
+);
+499999500000

--- a/tests/queries/0_stateless/04002_cast_nullable_read_in_order.sql
+++ b/tests/queries/0_stateless/04002_cast_nullable_read_in_order.sql
@@ -1,0 +1,60 @@
+-- { echo }
+
+SET optimize_read_in_order = 1;
+
+DROP TABLE IF EXISTS test_nullable_order_by;
+CREATE TABLE test_nullable_order_by (x UInt32, y UInt32) ENGINE=MergeTree ORDER BY x;
+INSERT INTO test_nullable_order_by SELECT number, number FROM numbers(1e6);
+
+SELECT sum(y) FROM
+(
+    SELECT y FROM test_nullable_order_by ORDER BY x::UInt64 LIMIT 1000000000
+);
+
+
+SELECT sum(y) FROM
+(
+    SELECT y FROM test_nullable_order_by ORDER BY x::Nullable(UInt64) LIMIT 1000000000
+);
+
+
+DROP TABLE IF EXISTS test_accurate_cast_or_null;
+CREATE TABLE test_accurate_cast_or_null (x Date32, y UInt32) ENGINE=MergeTree ORDER BY x;
+INSERT INTO test_accurate_cast_or_null SELECT toDate32('1969-12-29') + number, number FROM numbers(6);
+
+SELECT x, accurateCastOrNull(x, 'Date') AS d
+FROM test_accurate_cast_or_null
+ORDER BY accurateCastOrNull(x, 'Date'), x
+LIMIT 10;
+
+SELECT x, accurateCastOrNull(toInt64(x), 'Date') AS d, toTypeName(d)
+FROM test_accurate_cast_or_null
+ORDER BY accurateCastOrNull(toInt64(x), 'Date'), x
+LIMIT 10;
+
+
+DROP TABLE IF EXISTS test_accurate_cast_or_null_float;
+CREATE TABLE test_accurate_cast_or_null_float (x Float64, y UInt32) ENGINE=MergeTree ORDER BY x;
+INSERT INTO test_accurate_cast_or_null_float VALUES
+    (1.0, 1), (1.1, 2), (1.2, 3), (1.25, 4), (1.3, 5), (1.5, 6);
+
+SELECT x, accurateCastOrNull(x, 'Float32') AS d
+FROM test_accurate_cast_or_null_float
+ORDER BY accurateCastOrNull(x, 'Float32'), x
+LIMIT 10;
+
+
+DROP TABLE IF EXISTS test_nullable_sorting_key_order_by;
+CREATE TABLE test_nullable_sorting_key_order_by (x UInt32, y UInt32) ENGINE=MergeTree ORDER BY x::Nullable(UInt32) SETTINGS allow_nullable_key = 1;
+INSERT INTO test_nullable_sorting_key_order_by SELECT number, number FROM numbers(1e6);
+
+SELECT sum(y) FROM
+(
+    SELECT y FROM test_nullable_sorting_key_order_by ORDER BY x::UInt32 LIMIT 1000000000
+);
+
+
+SELECT sum(y) FROM
+(
+    SELECT y FROM test_nullable_sorting_key_order_by ORDER BY x::Nullable(UInt32) LIMIT 1000000000
+);

--- a/tests/queries/0_stateless/04003_cast_nullable_read_in_order_explain.reference
+++ b/tests/queries/0_stateless/04003_cast_nullable_read_in_order_explain.reference
@@ -1,0 +1,83 @@
+-- { echo }
+
+SET optimize_read_in_order = 1;
+DROP TABLE IF EXISTS test_nullable_order_by;
+CREATE TABLE test_nullable_order_by (x UInt32, y UInt32) ENGINE=MergeTree ORDER BY x;
+INSERT INTO test_nullable_order_by SELECT number, number FROM numbers(1e6);
+SELECT ltrim(explain)
+FROM
+(
+    EXPLAIN actions=1
+    SELECT y FROM test_nullable_order_by ORDER BY x::UInt64 LIMIT 1000000000
+)
+WHERE explain LIKE '%ReadType%';
+ReadType: InOrder
+SELECT ltrim(explain)
+FROM
+(
+    EXPLAIN actions = 1
+    SELECT y FROM test_nullable_order_by ORDER BY x::Nullable(UInt64) LIMIT 1000000000
+)
+WHERE explain LIKE '%ReadType%';
+ReadType: InOrder
+DROP TABLE IF EXISTS test_accurate_cast_or_null;
+CREATE TABLE test_accurate_cast_or_null (x Date32, y UInt32) ENGINE=MergeTree ORDER BY x;
+INSERT INTO test_accurate_cast_or_null SELECT toDate32('1969-12-29') + number, number FROM numbers(6);
+-- Should not use read in order optimization because of `accurateCastOrNull`
+SELECT ltrim(explain)
+FROM
+(
+    EXPLAIN actions = 1
+    SELECT x, accurateCastOrNull(x, 'Date') AS d
+    FROM test_accurate_cast_or_null
+    ORDER BY accurateCastOrNull(x, 'Date')
+    LIMIT 10
+)
+WHERE explain LIKE '%ReadType%';
+ReadType: Default
+SELECT ltrim(explain)
+FROM
+(
+    EXPLAIN actions = 1
+    SELECT x, accurateCastOrNull(toInt64(x), 'Date') AS d, toTypeName(d)
+    FROM test_accurate_cast_or_null
+    ORDER BY accurateCastOrNull(toInt64(x), 'Date')
+    LIMIT 10
+)
+WHERE explain LIKE '%ReadType%';
+ReadType: Default
+DROP TABLE IF EXISTS test_accurate_cast_or_null_float;
+CREATE TABLE test_accurate_cast_or_null_float (x Float64, y UInt32) ENGINE=MergeTree ORDER BY x;
+INSERT INTO test_accurate_cast_or_null_float VALUES
+    (1.0, 1), (1.1, 2), (1.2, 3), (1.25, 4), (1.3, 5), (1.5, 6);
+-- Should not use read in order optimization because of `accurateCastOrNull`
+SELECT ltrim(explain)
+FROM
+(
+    EXPLAIN actions = 1
+    SELECT x, accurateCastOrNull(x, 'Float32') AS d
+    FROM test_accurate_cast_or_null_float
+    ORDER BY accurateCastOrNull(x, 'Float32')
+    LIMIT 10
+)
+WHERE explain LIKE '%ReadType%';
+ReadType: Default
+DROP TABLE IF EXISTS test_nullable_sorting_key_order_by;
+CREATE TABLE test_nullable_sorting_key_order_by (x UInt32, y UInt32) ENGINE=MergeTree ORDER BY x::Nullable(UInt32) SETTINGS allow_nullable_key = 1;
+INSERT INTO test_nullable_sorting_key_order_by SELECT number, number FROM numbers(1e6);
+SELECT ltrim(explain)
+FROM
+(
+    EXPLAIN actions=1
+    SELECT y FROM test_nullable_sorting_key_order_by ORDER BY x::UInt32 LIMIT 1000000000
+)
+WHERE explain LIKE '%ReadType%';
+ReadType: Default
+SELECT ltrim(explain)
+FROM
+(
+    EXPLAIN actions = 1
+    SELECT y FROM test_nullable_sorting_key_order_by ORDER BY x::Nullable(UInt32) LIMIT 1000000000
+)
+WHERE explain LIKE '%ReadType%';
+ReadType: InOrder

--- a/tests/queries/0_stateless/04003_cast_nullable_read_in_order_explain.sql
+++ b/tests/queries/0_stateless/04003_cast_nullable_read_in_order_explain.sql
@@ -1,0 +1,91 @@
+-- { echo }
+
+SET optimize_read_in_order = 1;
+
+DROP TABLE IF EXISTS test_nullable_order_by;
+CREATE TABLE test_nullable_order_by (x UInt32, y UInt32) ENGINE=MergeTree ORDER BY x;
+INSERT INTO test_nullable_order_by SELECT number, number FROM numbers(1e6);
+
+SELECT ltrim(explain)
+FROM
+(
+    EXPLAIN actions=1
+    SELECT y FROM test_nullable_order_by ORDER BY x::UInt64 LIMIT 1000000000
+)
+WHERE explain LIKE '%ReadType%';
+
+
+SELECT ltrim(explain)
+FROM
+(
+    EXPLAIN actions = 1
+    SELECT y FROM test_nullable_order_by ORDER BY x::Nullable(UInt64) LIMIT 1000000000
+)
+WHERE explain LIKE '%ReadType%';
+
+DROP TABLE IF EXISTS test_accurate_cast_or_null;
+CREATE TABLE test_accurate_cast_or_null (x Date32, y UInt32) ENGINE=MergeTree ORDER BY x;
+INSERT INTO test_accurate_cast_or_null SELECT toDate32('1969-12-29') + number, number FROM numbers(6);
+
+-- Should not use read in order optimization because of `accurateCastOrNull`
+SELECT ltrim(explain)
+FROM
+(
+    EXPLAIN actions = 1
+    SELECT x, accurateCastOrNull(x, 'Date') AS d
+    FROM test_accurate_cast_or_null
+    ORDER BY accurateCastOrNull(x, 'Date')
+    LIMIT 10
+)
+WHERE explain LIKE '%ReadType%';
+
+SELECT ltrim(explain)
+FROM
+(
+    EXPLAIN actions = 1
+    SELECT x, accurateCastOrNull(toInt64(x), 'Date') AS d, toTypeName(d)
+    FROM test_accurate_cast_or_null
+    ORDER BY accurateCastOrNull(toInt64(x), 'Date')
+    LIMIT 10
+)
+WHERE explain LIKE '%ReadType%';
+
+
+DROP TABLE IF EXISTS test_accurate_cast_or_null_float;
+CREATE TABLE test_accurate_cast_or_null_float (x Float64, y UInt32) ENGINE=MergeTree ORDER BY x;
+INSERT INTO test_accurate_cast_or_null_float VALUES
+    (1.0, 1), (1.1, 2), (1.2, 3), (1.25, 4), (1.3, 5), (1.5, 6);
+
+-- Should not use read in order optimization because of `accurateCastOrNull`
+SELECT ltrim(explain)
+FROM
+(
+    EXPLAIN actions = 1
+    SELECT x, accurateCastOrNull(x, 'Float32') AS d
+    FROM test_accurate_cast_or_null_float
+    ORDER BY accurateCastOrNull(x, 'Float32')
+    LIMIT 10
+)
+WHERE explain LIKE '%ReadType%';
+
+
+DROP TABLE IF EXISTS test_nullable_sorting_key_order_by;
+CREATE TABLE test_nullable_sorting_key_order_by (x UInt32, y UInt32) ENGINE=MergeTree ORDER BY x::Nullable(UInt32) SETTINGS allow_nullable_key = 1;
+INSERT INTO test_nullable_sorting_key_order_by SELECT number, number FROM numbers(1e6);
+
+SELECT ltrim(explain)
+FROM
+(
+    EXPLAIN actions=1
+    SELECT y FROM test_nullable_sorting_key_order_by ORDER BY x::UInt32 LIMIT 1000000000
+)
+WHERE explain LIKE '%ReadType%';
+
+
+SELECT ltrim(explain)
+FROM
+(
+    EXPLAIN actions = 1
+    SELECT y FROM test_nullable_sorting_key_order_by ORDER BY x::Nullable(UInt32) LIMIT 1000000000
+)
+WHERE explain LIKE '%ReadType%';

--- a/tests/queries/0_stateless/04004_cast_nullable_monotonicity_key_condition.reference
+++ b/tests/queries/0_stateless/04004_cast_nullable_monotonicity_key_condition.reference
@@ -1,0 +1,16 @@
+499
+Expression ((Project names + Projection))
+  AggregatingProjection
+    Expression (Before GROUP BY)
+      Filter ((WHERE + Change column names to column identifiers))
+        ReadFromMergeTree (default.test_nullable_filter)
+        Indexes:
+          PrimaryKey
+            Keys:
+              x
+            Condition: (CAST(x, \'Nullable(UInt64)\') in [501, +Inf))
+            Parts: 1/1
+            Granules: 500/1000
+            Search Algorithm: binary search
+          Ranges: 1
+    ReadFromPreparedSource (_exact_count_projection)

--- a/tests/queries/0_stateless/04004_cast_nullable_monotonicity_key_condition.sql
+++ b/tests/queries/0_stateless/04004_cast_nullable_monotonicity_key_condition.sql
@@ -1,0 +1,15 @@
+-- Tags: no-replicated-database, no-parallel-replicas, no-random-merge-tree-settings
+-- EXPLAIN output may differ
+
+DROP TABLE IF EXISTS test_nullable_filter;
+CREATE TABLE test_nullable_filter (x UInt32, y UInt32) ENGINE=MergeTree ORDER BY x SETTINGS index_granularity = 1;
+INSERT INTO test_nullable_filter SELECT number, number FROM numbers(1000);
+
+SELECT count()
+FROM test_nullable_filter
+WHERE x::Nullable(UInt64) > 500;
+
+EXPLAIN indexes = 1
+SELECT count()
+FROM test_nullable_filter
+WHERE x::Nullable(UInt64) > 500;


### PR DESCRIPTION
Given,

```sql
CREATE TABLE test_nullable_order_by (x UInt32, y UInt32) ENGINE=MergeTree ORDER BY x;
INSERT INTO test_nullable_order_by SELECT number, number FROM numbers(1e6);
```

We do not use `read-in-order` optimization for such query but we should:

```sql
EXPLAIN actions = 1
SELECT y FROM test_nullable_order_by ORDER BY x::Nullable(UInt64) LIMIT 1000000000;
```

We do not use primary key pruning, but we should:
```sql
EXPLAIN indexes = 1
SELECT count()
FROM test_nullable_order_by
WHERE x::Nullable(UInt64) > 500000;
```

### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Allow read-in-order optimization and primary-key pruning when the `CAST` target type is `Nullable` and the conversion is monotonic; for example, with `PRIMARY KEY x`, ClickHouse can use read-in-order optimization for `ORDER BY x::Nullable(UInt64)` and can apply primary-key pruning for predicates such as `WHERE x::Nullable(UInt64) > 500000`.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.261`
- Backported to: `26.2.5.8`, `26.1.5.18`, `25.12.9.20`
<!-- ch-version-info:end -->