### PR TITLE
Auto-size background thread pool defaults based on CPU cores

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -1751,7 +1751,10 @@ try
             CancellationChecker::getInstance().terminateThread();
     });
 
-    if (server_settings[ServerSetting::background_schedule_pool_size] > 1)
+    if (resolveAutoPoolSize(
+            server_settings[ServerSetting::background_schedule_pool_size],
+            background_schedule_pool_auto.min_threads,
+            background_schedule_pool_auto.cores_ratio) > 1)
     {
         auto cancellation_task_holder = global_context->getSchedulePool().createTask(
             StorageID::createEmpty(), "CancellationChecker",
@@ -2287,7 +2290,9 @@ try
             /// This is done for backward compatibility.
             if (global_context->areBackgroundExecutorsInitialized())
             {
-                const auto & new_pool_size = new_server_settings[ServerSetting::background_pool_size];
+                auto new_pool_size = resolveAutoPoolSize(
+                    new_server_settings[ServerSetting::background_pool_size],
+                    background_pool_auto.min_threads, background_pool_auto.cores_ratio);
                 const auto & new_ratio = new_server_settings[ServerSetting::background_merges_mutations_concurrency_ratio];
                 global_context->getMergeMutateExecutor()->increaseThreadsAndMaxTasksCount(new_pool_size, static_cast<size_t>(static_cast<double>(new_pool_size) * new_ratio));
                 global_context->getMergeMutateExecutor()->updateSchedulingPolicy(new_server_settings[ServerSetting::background_merges_mutations_scheduling_policy].toString());
@@ -2295,26 +2300,40 @@ try
 
             if (global_context->areBackgroundExecutorsInitialized())
             {
-                const auto & new_pool_size = new_server_settings[ServerSetting::background_move_pool_size];
+                auto new_pool_size = resolveAutoPoolSize(
+                    new_server_settings[ServerSetting::background_move_pool_size],
+                    background_move_pool_auto.min_threads, background_move_pool_auto.cores_ratio);
                 global_context->getMovesExecutor()->increaseThreadsAndMaxTasksCount(new_pool_size, new_pool_size);
             }
 
             if (global_context->areBackgroundExecutorsInitialized())
             {
-                const auto & new_pool_size = new_server_settings[ServerSetting::background_fetches_pool_size];
+                auto new_pool_size = resolveAutoPoolSize(
+                    new_server_settings[ServerSetting::background_fetches_pool_size],
+                    background_fetches_pool_auto.min_threads, background_fetches_pool_auto.cores_ratio);
                 global_context->getFetchesExecutor()->increaseThreadsAndMaxTasksCount(new_pool_size, new_pool_size);
             }
 
             if (global_context->areBackgroundExecutorsInitialized())
             {
-                const auto & new_pool_size = new_server_settings[ServerSetting::background_common_pool_size];
+                auto new_pool_size = resolveAutoPoolSize(
+                    new_server_settings[ServerSetting::background_common_pool_size],
+                    background_common_pool_auto.min_threads, background_common_pool_auto.cores_ratio);
                 global_context->getCommonExecutor()->increaseThreadsAndMaxTasksCount(new_pool_size, new_pool_size);
             }
 
-            global_context->getBufferFlushSchedulePool().increaseThreadsCount(new_server_settings[ServerSetting::background_buffer_flush_schedule_pool_size]);
-            global_context->getSchedulePool().increaseThreadsCount(new_server_settings[ServerSetting::background_schedule_pool_size]);
-            global_context->getMessageBrokerSchedulePool().increaseThreadsCount(new_server_settings[ServerSetting::background_message_broker_schedule_pool_size]);
-            global_context->getDistributedSchedulePool().increaseThreadsCount(new_server_settings[ServerSetting::background_distributed_schedule_pool_size]);
+            global_context->getBufferFlushSchedulePool().increaseThreadsCount(resolveAutoPoolSize(
+                new_server_settings[ServerSetting::background_buffer_flush_schedule_pool_size],
+                background_buffer_flush_pool_auto.min_threads, background_buffer_flush_pool_auto.cores_ratio));
+            global_context->getSchedulePool().increaseThreadsCount(resolveAutoPoolSize(
+                new_server_settings[ServerSetting::background_schedule_pool_size],
+                background_schedule_pool_auto.min_threads, background_schedule_pool_auto.cores_ratio));
+            global_context->getMessageBrokerSchedulePool().increaseThreadsCount(resolveAutoPoolSize(
+                new_server_settings[ServerSetting::background_message_broker_schedule_pool_size],
+                background_message_broker_pool_auto.min_threads, background_message_broker_pool_auto.cores_ratio));
+            global_context->getDistributedSchedulePool().increaseThreadsCount(resolveAutoPoolSize(
+                new_server_settings[ServerSetting::background_distributed_schedule_pool_size],
+                background_distributed_pool_auto.min_threads, background_distributed_pool_auto.cores_ratio));
 
             global_context->getAsyncLoader().setMaxThreads(TablesLoaderForegroundPoolId, new_server_settings[ServerSetting::tables_loader_foreground_pool_size]);
             global_context->getAsyncLoader().setMaxThreads(TablesLoaderBackgroundLoadPoolId, new_server_settings[ServerSetting::tables_loader_background_pool_size]);

--- a/src/Common/getNumberOfCPUCoresToUse.cpp
+++ b/src/Common/getNumberOfCPUCoresToUse.cpp
@@ -10,6 +10,7 @@
 #include <base/cgroupsv2.h>
 #include <base/range.h>
 
+#include <algorithm>
 #include <filesystem>
 #include <thread>
 #include <set>
@@ -194,4 +195,12 @@ unsigned getNumberOfCPUCoresToUse()
     /// Calculate once.
     static const unsigned cores = getNumberOfCPUCoresToUseImpl();
     return cores;
+}
+
+size_t resolveAutoPoolSize(size_t configured_size, size_t min_threads, double cores_ratio)
+{
+    if (configured_size > 0)
+        return configured_size;
+    size_t cores = getNumberOfCPUCoresToUse();
+    return std::max(min_threads, static_cast<size_t>(cores * cores_ratio));
 }

--- a/src/Common/getNumberOfCPUCoresToUse.h
+++ b/src/Common/getNumberOfCPUCoresToUse.h
@@ -1,6 +1,38 @@
 #pragma once
 
+#include <cstddef>
+
 /// Get the number of CPU cores to use. Depending on the machine size we choose
 /// between the number of physical and logical cores.
 /// Also under cgroups we respect possible cgroups limits.
 unsigned getNumberOfCPUCoresToUse();
+
+/// Resolve a thread pool size: if configured_size > 0, use it as-is.
+/// If configured_size == 0 (auto), compute max(min_threads, cores * cores_ratio)
+/// using getNumberOfCPUCoresToUse().
+size_t resolveAutoPoolSize(size_t configured_size, size_t min_threads, double cores_ratio);
+
+/// Default auto-sizing parameters for each background thread pool.
+/// Used in Context.cpp (pool creation) and Server.cpp (config reload).
+struct PoolAutoConfig
+{
+    size_t min_threads;
+    double cores_ratio;
+};
+
+/// background_pool_size (merges and mutations)
+static constexpr PoolAutoConfig background_pool_auto{16, 0.5};
+/// background_move_pool_size
+static constexpr PoolAutoConfig background_move_pool_auto{8, 0.25};
+/// background_fetches_pool_size
+static constexpr PoolAutoConfig background_fetches_pool_auto{16, 0.5};
+/// background_common_pool_size
+static constexpr PoolAutoConfig background_common_pool_auto{8, 0.25};
+/// background_buffer_flush_schedule_pool_size
+static constexpr PoolAutoConfig background_buffer_flush_pool_auto{16, 0.5};
+/// background_schedule_pool_size
+static constexpr PoolAutoConfig background_schedule_pool_auto{128, 4.0};
+/// background_message_broker_schedule_pool_size
+static constexpr PoolAutoConfig background_message_broker_pool_auto{16, 0.5};
+/// background_distributed_schedule_pool_size
+static constexpr PoolAutoConfig background_distributed_pool_auto{16, 0.5};

--- a/src/Core/ServerSettings.cpp
+++ b/src/Core/ServerSettings.cpp
@@ -835,8 +835,8 @@ The policy on how to perform a scheduling of CPU slots specified by `concurrent_
     - `fair_round_robin` — Every query with setting `use_concurrency_control` = 1 allocates up to `max_threads - 1` CPU slots. Variation of `round_robin` that does not require a CPU slot for the first thread of every query. This way queries having `max_threads` = 1 do not require any slot and could not unfairly allocate all slots. There are no slots granted unconditionally.
     - `max_min_fair` — Every query with setting `use_concurrency_control` = 1 allocates up to `max_threads - 1` CPU slots. Similar to `fair_round_robin`, but released slots are always granted to the query with the minimum number of currently allocated slots. This provides better fairness under high oversubscription, where many queries compete for limited CPU slots. Short-running queries are not penalized by long-running queries that have accumulated more slots over time.
     )", 0) \
-    DECLARE(UInt64, background_pool_size, 16, R"(
-    Sets the number of threads performing background merges and mutations for tables with MergeTree engines.
+    DECLARE(UInt64, background_pool_size, 0, R"(
+    Sets the number of threads performing background merges and mutations for tables with MergeTree engines. A value of 0 means auto: max(16, cpu_cores / 2).
 
     :::note
     - This setting could also be applied at server startup from the `default` profile configuration for backward compatibility at the ClickHouse server start.
@@ -882,14 +882,14 @@ The policy on how to perform a scheduling of CPU slots specified by `concurrent_
     - `round_robin` — Every concurrent merge and mutation is executed in round-robin order to ensure starvation-free operation. Smaller merges are completed faster than bigger ones just because they have fewer blocks to merge.
     - `shortest_task_first` — Always execute smaller merge or mutation. Merges and mutations are assigned priorities based on their resulting size. Merges with smaller sizes are strictly preferred over bigger ones. This policy ensures the fastest possible merge of small parts but can lead to indefinite starvation of big merges in partitions heavily overloaded by `INSERT`s.
     )", 0) \
-    DECLARE(UInt64, background_move_pool_size, 8, R"(The maximum number of threads that will be used for moving data parts to another disk or volume for *MergeTree-engine tables in a background.)", 0) \
-    DECLARE(UInt64, background_fetches_pool_size, 16, R"(The maximum number of threads that will be used for fetching data parts from another replica for [*MergeTree-engine](/engines/table-engines/mergetree-family) tables in the background.)", 0) \
-    DECLARE(UInt64, background_common_pool_size, 8, R"(The maximum number of threads that will be used for performing a variety of operations (mostly garbage collection) for [*MergeTree-engine](/engines/table-engines/mergetree-family) tables in the background.)", 0) \
-    DECLARE(UInt64, background_buffer_flush_schedule_pool_size, 16, R"(The maximum number of threads that will be used for performing flush operations for [Buffer-engine tables](/engines/table-engines/special/buffer) in the background.)", 0) \
-    DECLARE(UInt64, background_schedule_pool_size, 512, R"(The maximum number of threads that will be used for constantly executing some lightweight periodic operations for replicated tables, Kafka streaming, and DNS cache updates.)", 0) \
+    DECLARE(UInt64, background_move_pool_size, 0, R"(The maximum number of threads that will be used for moving data parts to another disk or volume for *MergeTree-engine tables in a background. A value of 0 means auto: max(8, cpu_cores / 4).)", 0) \
+    DECLARE(UInt64, background_fetches_pool_size, 0, R"(The maximum number of threads that will be used for fetching data parts from another replica for [*MergeTree-engine](/engines/table-engines/mergetree-family) tables in the background. A value of 0 means auto: max(16, cpu_cores / 2).)", 0) \
+    DECLARE(UInt64, background_common_pool_size, 0, R"(The maximum number of threads that will be used for performing a variety of operations (mostly garbage collection) for [*MergeTree-engine](/engines/table-engines/mergetree-family) tables in the background. A value of 0 means auto: max(8, cpu_cores / 4).)", 0) \
+    DECLARE(UInt64, background_buffer_flush_schedule_pool_size, 0, R"(The maximum number of threads that will be used for performing flush operations for [Buffer-engine tables](/engines/table-engines/special/buffer) in the background. A value of 0 means auto: max(16, cpu_cores / 2).)", 0) \
+    DECLARE(UInt64, background_schedule_pool_size, 0, R"(The maximum number of threads that will be used for constantly executing some lightweight periodic operations for replicated tables, Kafka streaming, and DNS cache updates. A value of 0 means auto: max(128, cpu_cores * 4).)", 0) \
     DECLARE(Float, background_schedule_pool_max_parallel_tasks_per_type_ratio, 0.8f, R"(The maximum ratio of threads in the pool that can execute tasks of the same type simultaneously.)", 0) \
-    DECLARE(UInt64, background_message_broker_schedule_pool_size, 16, R"(The maximum number of threads that will be used for executing background operations for message streaming.)", 0) \
-    DECLARE(UInt64, background_distributed_schedule_pool_size, 16, R"(The maximum number of threads that will be used for executing distributed sends.)", 0) \
+    DECLARE(UInt64, background_message_broker_schedule_pool_size, 0, R"(The maximum number of threads that will be used for executing background operations for message streaming. A value of 0 means auto: max(16, cpu_cores / 2).)", 0) \
+    DECLARE(UInt64, background_distributed_schedule_pool_size, 0, R"(The maximum number of threads that will be used for executing distributed sends. A value of 0 means auto: max(16, cpu_cores / 2).)", 0) \
     DECLARE(UInt64, tables_loader_foreground_pool_size, 0, R"(
     Sets the number of threads performing load jobs in foreground pool. The foreground pool is used for loading table synchronously before server start listening on a port and for loading tables that are waited for. Foreground pool has higher priority than background pool. It means that no job starts in background pool while there are jobs running in foreground pool.
 

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -4442,7 +4442,8 @@ BackgroundSchedulePool & Context::getBufferFlushSchedulePool() const
 {
     callOnce(shared->buffer_flush_schedule_pool_initialized, [&] {
         shared->buffer_flush_schedule_pool = BackgroundSchedulePool::create(
-            shared->server_settings[ServerSetting::background_buffer_flush_schedule_pool_size],
+            resolveAutoPoolSize(shared->server_settings[ServerSetting::background_buffer_flush_schedule_pool_size],
+                background_buffer_flush_pool_auto.min_threads, background_buffer_flush_pool_auto.cores_ratio),
             /*max_parallel_tasks_per_type*/ 0,
             CurrentMetrics::BackgroundBufferFlushSchedulePoolTask,
             CurrentMetrics::BackgroundBufferFlushSchedulePoolSize,
@@ -4485,15 +4486,17 @@ BackgroundTaskSchedulingSettings Context::getBackgroundMoveTaskSchedulingSetting
 
 BackgroundSchedulePool & Context::getSchedulePool() const
 {
-    size_t max_parallel_tasks_per_type = static_cast<size_t>(
-        static_cast<double>(shared->server_settings[ServerSetting::background_schedule_pool_size])
-        * shared->server_settings[ServerSetting::background_schedule_pool_max_parallel_tasks_per_type_ratio]);
     callOnce(
         shared->schedule_pool_initialized,
         [&]
         {
+            size_t pool_size = resolveAutoPoolSize(shared->server_settings[ServerSetting::background_schedule_pool_size],
+                background_schedule_pool_auto.min_threads, background_schedule_pool_auto.cores_ratio);
+            size_t max_parallel_tasks_per_type = static_cast<size_t>(
+                static_cast<double>(pool_size)
+                * shared->server_settings[ServerSetting::background_schedule_pool_max_parallel_tasks_per_type_ratio]);
             shared->schedule_pool = BackgroundSchedulePool::create(
-                shared->server_settings[ServerSetting::background_schedule_pool_size],
+                pool_size,
                 max_parallel_tasks_per_type,
                 CurrentMetrics::BackgroundSchedulePoolTask,
                 CurrentMetrics::BackgroundSchedulePoolSize,
@@ -4507,7 +4510,8 @@ BackgroundSchedulePool & Context::getDistributedSchedulePool() const
 {
     callOnce(shared->distributed_schedule_pool_initialized, [&] {
         shared->distributed_schedule_pool = BackgroundSchedulePool::create(
-            shared->server_settings[ServerSetting::background_distributed_schedule_pool_size],
+            resolveAutoPoolSize(shared->server_settings[ServerSetting::background_distributed_schedule_pool_size],
+                background_distributed_pool_auto.min_threads, background_distributed_pool_auto.cores_ratio),
             /*max_parallel_tasks_per_type*/ 0,
             CurrentMetrics::BackgroundDistributedSchedulePoolTask,
             CurrentMetrics::BackgroundDistributedSchedulePoolSize,
@@ -4521,7 +4525,8 @@ BackgroundSchedulePool & Context::getMessageBrokerSchedulePool() const
 {
     callOnce(shared->message_broker_schedule_pool_initialized, [&] {
         shared->message_broker_schedule_pool = BackgroundSchedulePool::create(
-            shared->server_settings[ServerSetting::background_message_broker_schedule_pool_size],
+            resolveAutoPoolSize(shared->server_settings[ServerSetting::background_message_broker_schedule_pool_size],
+                background_message_broker_pool_auto.min_threads, background_message_broker_pool_auto.cores_ratio),
             /*max_parallel_tasks_per_type*/ 0,
             CurrentMetrics::BackgroundMessageBrokerSchedulePoolTask,
             CurrentMetrics::BackgroundMessageBrokerSchedulePoolSize,
@@ -7116,13 +7121,17 @@ void Context::initializeBackgroundExecutorsIfNeeded()
         return;
 
     const ServerSettings & server_settings = shared->server_settings;
-    size_t background_pool_size = server_settings[ServerSetting::background_pool_size];
+    size_t background_pool_size = resolveAutoPoolSize(server_settings[ServerSetting::background_pool_size],
+        background_pool_auto.min_threads, background_pool_auto.cores_ratio);
     auto background_merges_mutations_concurrency_ratio = server_settings[ServerSetting::background_merges_mutations_concurrency_ratio];
     size_t background_pool_max_tasks_count = static_cast<size_t>(static_cast<double>(background_pool_size) * background_merges_mutations_concurrency_ratio);
     String background_merges_mutations_scheduling_policy = server_settings[ServerSetting::background_merges_mutations_scheduling_policy];
-    size_t background_move_pool_size = server_settings[ServerSetting::background_move_pool_size];
-    size_t background_fetches_pool_size = server_settings[ServerSetting::background_fetches_pool_size];
-    size_t background_common_pool_size = server_settings[ServerSetting::background_common_pool_size];
+    size_t background_move_pool_size = resolveAutoPoolSize(server_settings[ServerSetting::background_move_pool_size],
+        background_move_pool_auto.min_threads, background_move_pool_auto.cores_ratio);
+    size_t background_fetches_pool_size = resolveAutoPoolSize(server_settings[ServerSetting::background_fetches_pool_size],
+        background_fetches_pool_auto.min_threads, background_fetches_pool_auto.cores_ratio);
+    size_t background_common_pool_size = resolveAutoPoolSize(server_settings[ServerSetting::background_common_pool_size],
+        background_common_pool_auto.min_threads, background_common_pool_auto.cores_ratio);
 
     /// With this executor we can execute more tasks than threads we have
     shared->merge_mutate_executor = std::make_shared<MergeMutateBackgroundExecutor>


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Background thread pool sizes now default to 0 (auto-detect), scaling with CPU cores via `max(min_threads, cpu_cores * ratio)`. Explicit config values are respected as-is.

---

## Summary

Addresses #93710. Makes 8 background thread pool settings auto-detect their size based on CPU cores instead of using hard-coded defaults.

When set to 0 (the new default), pool sizes are computed as `max(min_threads, cpu_cores * ratio)` using `getNumberOfCPUCoresToUse()`, which already respects cgroups limits and physical core count.

### Formulas (based on discussion in #93710 with @serxa)

| Setting | Old default | Formula when 0 |
|---|---|---|
| `background_pool_size` | 16 | `max(16, cores / 2)` |
| `background_move_pool_size` | 8 | `max(8, cores / 4)` |
| `background_fetches_pool_size` | 16 | `max(16, cores / 2)` |
| `background_common_pool_size` | 8 | `max(8, cores / 4)` |
| `background_buffer_flush_schedule_pool_size` | 16 | `max(16, cores / 2)` |
| `background_schedule_pool_size` | 512 | `max(128, cores * 4)` |
| `background_message_broker_schedule_pool_size` | 16 | `max(16, cores / 2)` |
| `background_distributed_schedule_pool_size` | 16 | `max(16, cores / 2)` |

### Backward compatibility
- Any explicit user-configured value (> 0) is respected as-is
- On a 32-core machine the formulas produce exactly the old hard-coded defaults
- On small machines (4-8 cores) pools shrink proportionally
- On large machines (128+ cores) pools scale up

### Changes
- **`getNumberOfCPUCoresToUse.h/cpp`**: Added `resolveAutoPoolSize()` helper and `PoolAutoConfig` constants (shared between Context.cpp and Server.cpp to avoid magic number duplication)
- **`ServerSettings.cpp`**: Changed 8 pool defaults to 0, updated setting descriptions with auto-sizing formulas
- **`Context.cpp`**: Applied `resolveAutoPoolSize()` at all pool creation sites
- **`Server.cpp`**: Applied `resolveAutoPoolSize()` in config reload path and CancellationChecker guard

### Related
- Supersedes our earlier PR #98272 (which only addressed `background_schedule_pool_size`)
- Follows the existing pattern used by `tables_loader_*_pool_size` (AsyncLoader.cpp)