### PR TITLE
Fix flaky test `03801_autopr_input_bytes_estimation_query_with_subqueries`

### DIFF
--- a/tests/queries/0_stateless/03801_autopr_input_bytes_estimation_query_with_subqueries.sql
+++ b/tests/queries/0_stateless/03801_autopr_input_bytes_estimation_query_with_subqueries.sql
@@ -9,6 +9,11 @@ SET enable_parallel_replicas=0, automatic_parallel_replicas_mode=2, parallel_rep
 -- External aggregation is not supported as of now
 SET max_bytes_before_external_group_by=0, max_bytes_ratio_before_external_group_by=0;
 
+-- The test compares `ReadCompressedBytes` between the subquery run standalone vs. embedded.
+-- With the uncompressed cache, the embedded subquery may read from cache (no compressed reads),
+-- while the standalone run reads from disk, making the subtraction invalid.
+SET use_uncompressed_cache=0;
+
 SET use_query_condition_cache=0;
 
 create table t(a UInt64) engine=MergeTree order by a;


### PR DESCRIPTION
## Summary
- Fix flaky test `03801_autopr_input_bytes_estimation_query_with_subqueries` that fails when randomized CI settings enable `use_uncompressed_cache`
- The test compares `ReadCompressedBytes` between a standalone subquery and the same subquery embedded in a larger query. With uncompressed cache enabled, the embedded subquery reads from cache (no compressed reads counted), but the test still subtracts the full standalone compressed bytes, producing an artificially small value
- Add `SET use_uncompressed_cache=0`, consistent with the other 3 `autopr` estimation tests

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96171&sha=1a27ec3a039a54c662a700dd8533c8f658c4578a&name_0=PR&name_1=Stateless%20tests%20%28amd_debug%2C%20parallel%29
https://github.com/ClickHouse/ClickHouse/pull/96171

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.282`
<!-- ch-version-info:end -->