### PR TITLE
Fix flaky test_keeper_drop_after_update integration test

### DIFF
--- a/tests/integration/test_keeper_map/test.py
+++ b/tests/integration/test_keeper_map/test.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 
 from helpers.cluster import ClickHouseCluster
@@ -139,6 +141,13 @@ def test_keeper_drop_after_update(started_cluster):
     )
 
     run_query("DROP TABLE test_keeper_drop_after_update SYNC")
+
+    # The data might not be immediately visible as removed by an external client
+    # connected to a different Keeper node due to replication lag in the 3-node cluster.
+    for _ in range(10):
+        if zk_client.exists("/test_keeper_map/test_keeper_drop_after_update/data") is None:
+            break
+        time.sleep(0.5)
 
     assert (
         zk_client.exists("/test_keeper_map/test_keeper_drop_after_update/data")


### PR DESCRIPTION
## Summary
- The `test_keeper_drop_after_update` test verifies that `DROP TABLE` correctly cleans up ZooKeeper data when the `drop_lock_version` node is missing
- The server-side fix works correctly (confirmed by server logs: "Metadata and data was successfully removed from ZooKeeper"), but the external kazoo client used for verification connects to a potentially different Keeper node in the 3-node cluster
- Under MSan, Raft replication lag causes the kazoo `exists()` check to see stale data (~48ms after the confirmed cleanup)
- Add a retry loop before the assertion to account for cross-session read consistency delay

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=70661&sha=32c26ff5efefcfeaec476a1269087f71d9b5384e&name_0=PR&name_1=Integration%20tests%20%28amd_msan%2C%204%2F6%29
https://github.com/ClickHouse/ClickHouse/pull/70661

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.280`
<!-- ch-version-info:end -->