### PR TITLE
ci: ignore warnings/errors in the pre-check of stress tests

### DIFF
--- a/ci/jobs/scripts/stress/stress.py
+++ b/ci/jobs/scripts/stress/stress.py
@@ -265,7 +265,7 @@ def run_func_test(
         commands.append(full_command)
         check_command = (
             full_command
-            + "--jobs 1 00001_select_1 00234_disjunctive_equality_chains_optimization"
+            + "--server-logs-level fatal --jobs 1 00001_select_1 00234_disjunctive_equality_chains_optimization"
         )
         logging.info(check_command)
         try:


### PR DESCRIPTION
Otherwise it fails stress tests [1].

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=98474&sha=bfa018533f662e31b4a5cfa5b2edd56f5752ff8d&name_0=PR&name_1=Stress%20test%20%28amd_release%29
https://github.com/ClickHouse/ClickHouse/pull/98474

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.278`
<!-- ch-version-info:end -->