### PR TITLE
Fix Keeper ignoring `cipherList` and `dhParamsFile` openSSL settings

### DIFF
--- a/src/Coordination/KeeperServer.cpp
+++ b/src/Coordination/KeeperServer.cpp
@@ -123,6 +123,14 @@ auto getSslContextProvider(const Poco::Util::AbstractConfiguration & config, std
     params.loadDefaultCAs = config.getBool(load_default_ca_file_property, false);
     params.verificationMode = Poco::Net::Utility::convertVerificationMode(config.getString(verification_mode_property, "none"));
 
+    String cipher_list_property = fmt::format("openSSL.{}.cipherList", key);
+    if (config.has(cipher_list_property))
+        params.cipherList = config.getString(cipher_list_property);
+
+    String dh_params_file_property = fmt::format("openSSL.{}.dhParamsFile", key);
+    if (config.has(dh_params_file_property))
+        params.dhParamsFile = config.getString(dh_params_file_property);
+
     std::string disabled_protocols_list = config.getString(fmt::format("openSSL.{}.disableProtocols", key), "");
     Poco::StringTokenizer dp_tok(disabled_protocols_list, ";,", Poco::StringTokenizer::TOK_TRIM | Poco::StringTokenizer::TOK_IGNORE_EMPTY);
     int disabled_protocols = 0;

--- a/tests/integration/test_keeper_internal_secure/configs/ssl_conf_cipher.yml
+++ b/tests/integration/test_keeper_internal_secure/configs/ssl_conf_cipher.yml
@@ -1,0 +1,20 @@
+openSSL:
+  server:
+    certificateFile: '/etc/clickhouse-server/config.d/WithoutPassPhrase.crt'
+    privateKeyFile: '/etc/clickhouse-server/config.d/WithoutPassPhrase.key'
+    caConfig: '/etc/clickhouse-server/config.d/rootCA.pem'
+    loadDefaultCAFile: true
+    verificationMode: 'none'
+    cacheSessions: true
+    disableProtocols: 'sslv2,sslv3'
+    preferServerCiphers: true
+    cipherList: 'ECDHE-RSA-AES256-GCM-SHA384'
+  client:
+    certificateFile: '/etc/clickhouse-server/config.d/WithoutPassPhrase.crt'
+    caConfig: '/etc/clickhouse-server/config.d/rootCA.pem'
+    loadDefaultCAFile: true
+    verificationMode: 'none'
+    cacheSessions: true
+    disableProtocols: 'sslv2,sslv3'
+    preferServerCiphers: true
+    cipherList: 'ECDHE-RSA-AES256-GCM-SHA384'

--- a/tests/integration/test_keeper_internal_secure/test.py
+++ b/tests/integration/test_keeper_internal_secure/test.py
@@ -94,10 +94,10 @@ def run_test():
             pass
 
 
-def setupSsl(node, filename, password):
+def setupSsl(node, filename, password, ssl_conf_file="configs/ssl_conf.yml"):
     if password is None:
         node.copy_file_to_container(
-            os.path.join(CURRENT_TEST_DIR, "configs/ssl_conf.yml"),
+            os.path.join(CURRENT_TEST_DIR, ssl_conf_file),
             "/etc/clickhouse-server/config.d/ssl_conf.yml",
         )
 
@@ -152,10 +152,10 @@ def start_all_clickhouse():
         ku.wait_until_connected(cluster, node)
 
 
-def check_valid_configuration(filename, password):
+def check_valid_configuration(filename, password, ssl_conf_file="configs/ssl_conf.yml"):
     stop_all_clickhouse()
     for node in nodes:
-        setupSsl(node, filename, password)
+        setupSsl(node, filename, password, ssl_conf_file)
     start_all_clickhouse()
     nodes[0].wait_for_log_line("Raft ASIO listener initiated on :::9234, SSL enabled")
     run_test()
@@ -181,3 +181,9 @@ def test_secure_raft_works_with_password(started_cluster):
     check_invalid_configuration("WithPassPhrase", "")
     check_valid_configuration("WithPassPhrase", "test")
     check_invalid_configuration("WithPassPhrase", None)
+
+
+def test_secure_raft_works_with_cipher_list(started_cluster):
+    check_valid_configuration(
+        "WithoutPassPhrase", None, ssl_conf_file="configs/ssl_conf_cipher.yml"
+    )


### PR DESCRIPTION
Keeper's secure raft configuration read most `openSSL` settings but missed `cipherList` and `dhParamsFile`. This meant the raft port always used Poco's default cipher list and no custom DH parameters, regardless of what was configured.

Set both fields on `Poco::Net::Context::Params` before constructing the SSL context so Poco applies them automatically.

Closes https://github.com/ClickHouse/ClickHouse/issues/51188

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed Keeper's secure raft port ignoring `cipherList` and `dhParamsFile` from `openSSL` configuration, always using defaults instead of user-specified values. Close [#51188](https://github.com/ClickHouse/ClickHouse/issues/51188)

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.299`
<!-- ch-version-info:end -->