### PR TITLE
Do not attribute `poll()` idle time to Keeper connection operations

### DIFF
--- a/src/Server/KeeperTCPHandler.cpp
+++ b/src/Server/KeeperTCPHandler.cpp
@@ -512,6 +512,10 @@ void KeeperTCPHandler::runImpl()
             using namespace std::chrono_literals;
 
             PollResult result = poll_wrapper->poll(session_timeout, *in);
+            /// Restart the stopwatch after poll() returns so that the time spent
+            /// waiting inside poll() (which can be up to session_timeout, e.g. 10s
+            /// between heartbeats) is not attributed to the next operation.
+            logging_stopwatch.restart();
             if (result.has_requests && !close_received)
             {
                 if (in->eof())

--- a/tests/integration/test_keeper_slow_connection_log/configs/keeper_config.xml
+++ b/tests/integration/test_keeper_slow_connection_log/configs/keeper_config.xml
@@ -1,0 +1,29 @@
+<clickhouse>
+    <keeper_server>
+        <tcp_port>9181</tcp_port>
+        <server_id>1</server_id>
+        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
+        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
+
+        <coordination_settings>
+            <operation_timeout_ms>5000</operation_timeout_ms>
+            <session_timeout_ms>5000</session_timeout_ms>
+            <raft_logs_level>trace</raft_logs_level>
+            <force_sync>false</force_sync>
+            <!-- Low threshold so any poll() time leakage triggers the log -->
+            <log_slow_connection_operation_threshold_ms>500</log_slow_connection_operation_threshold_ms>
+            <!-- For instant start in single node configuration -->
+            <heart_beat_interval_ms>0</heart_beat_interval_ms>
+            <election_timeout_lower_bound_ms>0</election_timeout_lower_bound_ms>
+            <election_timeout_upper_bound_ms>0</election_timeout_upper_bound_ms>
+        </coordination_settings>
+
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>localhost</hostname>
+                <port>9234</port>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+</clickhouse>

--- a/tests/integration/test_keeper_slow_connection_log/test.py
+++ b/tests/integration/test_keeper_slow_connection_log/test.py
@@ -1,0 +1,66 @@
+import pytest
+import time
+
+from helpers.cluster import ClickHouseCluster
+from helpers.keeper_utils import get_fake_zk
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance(
+    "node",
+    main_configs=["configs/keeper_config.xml"],
+    with_zookeeper=False,
+    use_keeper=False,
+    stay_alive=True,
+)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_no_slow_log_from_poll_idle_time(started_cluster):
+    """
+    Verify that time spent waiting in poll() is not attributed to subsequent
+    operations like "Receiving request".
+
+    Before the fix, the logging_stopwatch was started before poll() and not
+    restarted after it returned. When poll() blocked for a long time (e.g.
+    between heartbeats), the elapsed time was incorrectly attributed to
+    "Receiving request", producing noisy and misleading INFO messages.
+    """
+    zk = get_fake_zk(cluster, "node", timeout=5)
+
+    try:
+        # Perform some operations to establish the session
+        zk.ensure_path("/test_slow_log")
+        zk.set("/test_slow_log", b"data")
+        zk.get("/test_slow_log")
+
+        # Wait for several heartbeat/poll cycles.
+        # With session_timeout=5000ms, the client sends heartbeats roughly
+        # every ~1.6s. Between heartbeats poll() blocks. Without the fix,
+        # each heartbeat receipt after a long poll() would log
+        # "Receiving request for session X took ~1600ms" (exceeding the
+        # 500ms threshold we configured).
+        time.sleep(5)
+
+        # More operations after the idle period
+        zk.set("/test_slow_log", b"updated")
+        zk.get("/test_slow_log")
+
+        # Give a bit of time for log to flush
+        time.sleep(1)
+
+        # With the fix, poll() idle time is not attributed to "Receiving
+        # request", so this message should not appear for normal operations.
+        assert not node.contains_in_log(
+            "Receiving request for session"
+        ), "poll() idle time leaked into 'Receiving request' log message"
+    finally:
+        zk.stop()
+        zk.close()


### PR DESCRIPTION
The `logging_stopwatch` in `KeeperTCPHandler` was not restarted after `poll()` returned, so the time spent blocking inside `poll()` (which can be up to `session_timeout`, e.g. 10 seconds between heartbeats) was incorrectly attributed to the next operation, producing misleading INFO messages like "Receiving request for session X took 9963 ms".

Restart the stopwatch immediately after `poll()` returns so only the actual operation time is measured.

https://github.com/ClickHouse/ClickHouse/issues/79026

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed misleading Keeper log messages like "Receiving request for session X took 9963 ms" where the reported time was actually spent waiting idle in `poll()` between heartbeats, not performing the operation itself. Fixes [#79026](https://github.com/ClickHouse/ClickHouse/issues/79026)

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.293`
<!-- ch-version-info:end -->