### PR TITLE
ci: fix docker buildx builder driver and remove incompatible inline cache

### DIFF
--- a/ci/praktika/docker.py
+++ b/ci/praktika/docker.py
@@ -59,7 +59,7 @@ class Docker:
                     continue
                 platforms.append(platform)
 
-            command = f"docker buildx build --builder default {tags_substr} {from_tag} --platform {','.join(platforms)} --provenance=mode=max --sbom=true --cache-to type=inline --cache-from type=registry,ref={config.name} {config.path} {'' if disable_push else ' --push'}"
+            command = f"docker buildx build {tags_substr} {from_tag} --platform {','.join(platforms)} --provenance=mode=max --sbom=true --cache-from type=registry,ref={config.name} {config.path} {'' if disable_push else ' --push'}"
 
             return Result.from_commands_run(
                 name=name,

--- a/ci/praktika/docker.py
+++ b/ci/praktika/docker.py
@@ -59,7 +59,7 @@ class Docker:
                     continue
                 platforms.append(platform)
 
-            command = f"docker buildx build {tags_substr} {from_tag} --platform {','.join(platforms)} --provenance=mode=max --sbom=true --cache-from type=registry,ref={config.name} {config.path} {'' if disable_push else ' --push'}"
+            command = f"docker buildx build {tags_substr} {from_tag} --platform {','.join(platforms)} --provenance=mode=max --sbom=true {config.path} {'' if disable_push else ' --push'}"
 
             return Result.from_commands_run(
                 name=name,


### PR DESCRIPTION
Follow up from #97903 
`--builder default` uses the `docker` driver which does not support attestations. Drop it so buildx uses the `docker-container` driver set up by `native_jobs.py`. Also remove `--cache-to type=inline` which is incompatible with `--sbom=true`.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.292`
<!-- ch-version-info:end -->