### PR TITLE
Defer only required filter arguments of logical operators

### DIFF
--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -1,8 +1,8 @@
 #include <Processors/QueryPlan/ReadFromMergeTree.h>
 
 #include <Analyzer/QueryNode.h>
-#include <Functions/IFunction.h>
 #include <Core/Settings.h>
+#include <Functions/IFunction.h>
 #include <IO/Operators.h>
 #include <Interpreters/Cluster.h>
 #include <Interpreters/Context.h>
@@ -103,7 +103,7 @@ bool isNodeOverSortingKey(const ActionsDAG::Node * node, const NameSet & sorting
     if (sorting_key_set.contains(node->result_name))
         return true;
     if (node->type == ActionsDAG::ActionType::COLUMN)
-        return true;
+        return true; // constants are fine
     if (node->type == ActionsDAG::ActionType::INPUT)
         return false; // already checked result_name
     for (const auto * child : node->children)

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -1,6 +1,7 @@
 #include <Processors/QueryPlan/ReadFromMergeTree.h>
 
 #include <Analyzer/QueryNode.h>
+#include <Functions/IFunction.h>
 #include <Core/Settings.h>
 #include <IO/Operators.h>
 #include <Interpreters/Cluster.h>

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -96,6 +96,21 @@ size_t countPartitions(const RangesInDataParts & parts_with_ranges)
     return countPartitions(parts_with_ranges, get_partition_id);
 }
 
+/// check if a DAG node only depends on sorting key columns (ActionsDAG version of isExpressionOverSortingKey)
+bool isNodeOverSortingKey(const ActionsDAG::Node * node, const NameSet & sorting_key_set)
+{
+    if (sorting_key_set.contains(node->result_name))
+        return true;
+    if (node->type == ActionsDAG::ActionType::COLUMN)
+        return true;
+    if (node->type == ActionsDAG::ActionType::INPUT)
+        return false; // already checked result_name
+    for (const auto * child : node->children)
+        if (!isNodeOverSortingKey(child, sorting_key_set))
+            return false;
+    return true;
+}
+
 bool restoreDAGInputs(ActionsDAG & dag, const NameSet & inputs)
 {
     std::unordered_set<const ActionsDAG::Node *> outputs(dag.getOutputs().begin(), dag.getOutputs().end());
@@ -2184,18 +2199,41 @@ void ReadFromMergeTree::applyFilters(ActionDAGNodes added_filter_nodes)
         deferFiltersAfterFinalIfNeeded();
         if (deferred_row_level_filter || deferred_prewhere_info)
         {
-            /// build a separate DAG for index analysis, without the deferred filter nodes
+            /// exclude deferred filters from index analysis, but keep sorting-key AND atoms
             NameSet deferred_column_names;
             if (deferred_row_level_filter)
                 deferred_column_names.insert(deferred_row_level_filter->column_name);
             if (deferred_prewhere_info)
                 deferred_column_names.insert(deferred_prewhere_info->prewhere_column_name);
 
+            const auto & sorting_key_columns = storage_snapshot->metadata->getSortingKeyColumns();
+            NameSet sorting_key_set(sorting_key_columns.begin(), sorting_key_columns.end());
+
             std::vector<const ActionsDAG::Node *> index_nodes;
+
+            /// collect sorting-key-only atoms from a (possibly nested) AND tree
+            std::function<void(const ActionsDAG::Node *)> collect_sorting_key_atoms =
+                [&](const ActionsDAG::Node * n)
+            {
+                if (isNodeOverSortingKey(n, sorting_key_set))
+                {
+                    index_nodes.push_back(n);
+                    return;
+                }
+                if (n->type == ActionsDAG::ActionType::FUNCTION
+                    && n->function_base && n->function_base->getName() == "and")
+                {
+                    for (const auto * child : n->children)
+                        collect_sorting_key_atoms(child);
+                }
+            };
+
             for (const auto * node : added_filter_nodes.nodes)
             {
                 if (!deferred_column_names.contains(node->result_name))
                     index_nodes.push_back(node);
+                else
+                    collect_sorting_key_atoms(node);
             }
 
             auto idx_dag = ActionsDAG::buildFilterActionsDAG(index_nodes, node_name_to_input);

--- a/tests/queries/0_stateless/03742_apply_row_policy_after_final.reference
+++ b/tests/queries/0_stateless/03742_apply_row_policy_after_final.reference
@@ -55,3 +55,85 @@
 = PARTITION BY sorting-key column is still prunable =
 --- FINAL WHERE x != 1 (partition pruning is safe here)
 2	bbb	1
+
+= compound row policy: sorting-key atom should be used for index analysis =
+--- FINAL: x>1 atom should still participate in primary key analysis
+2	eee	2
+3	ccc	1
+--- EXPLAIN indexes: x > 1 should appear in PrimaryKey condition
+Expression (Project names)
+  Sorting (Sorting for ORDER BY)
+    Expression ((Before ORDER BY + (Projection + Change column names to column identifiers)))
+      ReadFromMergeTree (default.tab_compound)
+      Indexes:
+        PrimaryKey
+          Keys:
+            x
+          Condition: (x in [2, +Inf))
+          Parts: 2/2
+          Granules: 2/2
+          Search Algorithm: binary search
+        Ranges: 2
+
+= compound PREWHERE: sorting-key atom should be used for index analysis =
+--- FINAL PREWHERE y != ddd AND x > 1: x>1 atom should still participate in primary key analysis
+2	eee	2
+3	ccc	1
+--- EXPLAIN indexes: x > 1 should appear in PrimaryKey condition
+Expression (Project names)
+  Sorting (Sorting for ORDER BY)
+    Expression ((Before ORDER BY + (Projection + Change column names to column identifiers)))
+      ReadFromMergeTree (default.tab_compound_pw)
+      Indexes:
+        PrimaryKey
+          Keys:
+            x
+          Condition: (x in [2, +Inf))
+          Parts: 2/2
+          Granules: 2/2
+          Search Algorithm: binary search
+        Ranges: 2
+--- EXPLAIN actions: prewhere should be deferred
+        Deferred filters (applied after FINAL)
+          Deferred prewhere filter column: and(notEquals(y, \'ddd\'_String), greater(x, 1_UInt8))
+
+= nested AND in row policy: both sorting-key atoms should be used for index analysis =
+--- FINAL with nested AND row policy
+2	fff	250	2
+3	ccc	300	1
+--- EXPLAIN indexes: both x > 1 and x < 5 should appear in PrimaryKey condition
+Expression (Project names)
+  Sorting (Sorting for ORDER BY)
+    Expression ((Before ORDER BY + (Projection + Change column names to column identifiers)))
+      ReadFromMergeTree (default.tab_nested_and)
+      Indexes:
+        PrimaryKey
+          Keys:
+            x
+          Condition: and((x in (-Inf, 4]), (x in [2, +Inf)))
+          Parts: 2/2
+          Granules: 2/2
+          Search Algorithm: binary search
+        Ranges: 2
+
+= nested AND in PREWHERE: both sorting-key atoms should be used for index analysis =
+--- FINAL PREWHERE (y != eee AND x > 1) AND x < 5
+2	fff	250	2
+3	ccc	300	1
+--- EXPLAIN indexes: both x > 1 and x < 5 should appear in PrimaryKey condition
+Expression (Project names)
+  Sorting (Sorting for ORDER BY)
+    Expression ((Before ORDER BY + (Projection + Change column names to column identifiers)))
+      ReadFromMergeTree (default.tab_nested_and_pw)
+      Indexes:
+        PrimaryKey
+          Keys:
+            x
+          Condition: and((x in (-Inf, 4]), (x in [2, +Inf)))
+          Parts: 2/2
+          Granules: 2/2
+          Search Algorithm: binary search
+        Ranges: 2
+--- EXPLAIN actions: prewhere should be deferred
+        Deferred filters (applied after FINAL)
+          Deferred prewhere filter column: and(and(notEquals(y, \'eee\'_String), greater(x, 1_UInt8)), less(x, 5_UInt8))

--- a/tests/queries/0_stateless/03742_apply_row_policy_after_final.sql
+++ b/tests/queries/0_stateless/03742_apply_row_policy_after_final.sql
@@ -4,6 +4,8 @@
 DROP TABLE IF EXISTS tab;
 DROP ROW POLICY IF EXISTS pol1 ON tab;
 
+SET enable_analyzer = 1;
+
 CREATE TABLE tab (x UInt32, y String, version UInt32) ENGINE = ReplacingMergeTree(version) ORDER BY x;
 
 INSERT INTO tab VALUES (1, 'aaa', 1), (2, 'bbb', 1);

--- a/tests/queries/0_stateless/03742_apply_row_policy_after_final.sql
+++ b/tests/queries/0_stateless/03742_apply_row_policy_after_final.sql
@@ -193,3 +193,107 @@ SELECT '--- FINAL WHERE x != 1 (partition pruning is safe here)';
 SELECT * FROM tab_safe FINAL WHERE x != 1 ORDER BY x;
 
 DROP TABLE tab_safe;
+
+SELECT '';
+SELECT '= compound row policy: sorting-key atom should be used for index analysis =';
+
+DROP TABLE IF EXISTS tab_compound;
+DROP ROW POLICY IF EXISTS pol_compound ON tab_compound;
+
+CREATE TABLE tab_compound (x UInt32, y String, version UInt32)
+ENGINE = ReplacingMergeTree(version) ORDER BY x;
+
+INSERT INTO tab_compound VALUES (1, 'aaa', 1), (2, 'bbb', 1), (3, 'ccc', 1);
+INSERT INTO tab_compound VALUES (1, 'ddd', 2), (2, 'eee', 2);
+
+CREATE ROW POLICY pol_compound ON tab_compound USING y != 'ddd' AND x > 1 TO ALL;
+
+SET apply_row_policy_after_final = 1;
+SELECT '--- FINAL: x>1 atom should still participate in primary key analysis';
+-- FINAL has (1,'ddd',2), (2,'eee',2), (3,'ccc',1)
+-- row policy y!='ddd' AND x>1 -> (2,'eee',2), (3,'ccc',1)
+SELECT * FROM tab_compound FINAL ORDER BY x;
+
+SELECT '--- EXPLAIN indexes: x > 1 should appear in PrimaryKey condition';
+EXPLAIN indexes = 1 SELECT * FROM tab_compound FINAL ORDER BY x FORMAT TabSeparated;
+
+DROP ROW POLICY pol_compound ON tab_compound;
+SET apply_row_policy_after_final = 0;
+DROP TABLE tab_compound;
+
+SELECT '';
+SELECT '= compound PREWHERE: sorting-key atom should be used for index analysis =';
+
+DROP TABLE IF EXISTS tab_compound_pw;
+
+CREATE TABLE tab_compound_pw (x UInt32, y String, version UInt32)
+ENGINE = ReplacingMergeTree(version) ORDER BY x;
+
+INSERT INTO tab_compound_pw VALUES (1, 'aaa', 1), (2, 'bbb', 1), (3, 'ccc', 1);
+INSERT INTO tab_compound_pw VALUES (1, 'ddd', 2), (2, 'eee', 2);
+
+SET apply_prewhere_after_final = 1;
+SELECT '--- FINAL PREWHERE y != ddd AND x > 1: x>1 atom should still participate in primary key analysis';
+-- FINAL has (1,'ddd',2), (2,'eee',2), (3,'ccc',1)
+-- PREWHERE y!='ddd' AND x>1 -> (2,'eee',2), (3,'ccc',1)
+SELECT * FROM tab_compound_pw FINAL PREWHERE y != 'ddd' AND x > 1 ORDER BY x;
+
+SELECT '--- EXPLAIN indexes: x > 1 should appear in PrimaryKey condition';
+EXPLAIN indexes = 1 SELECT * FROM tab_compound_pw FINAL PREWHERE y != 'ddd' AND x > 1 ORDER BY x FORMAT TabSeparated;
+
+SELECT '--- EXPLAIN actions: prewhere should be deferred';
+SELECT explain FROM (EXPLAIN actions=1 SELECT * FROM tab_compound_pw FINAL PREWHERE y != 'ddd' AND x > 1 ORDER BY x) WHERE explain LIKE '%Deferred%';
+
+SET apply_prewhere_after_final = 0;
+DROP TABLE tab_compound_pw;
+
+SELECT '';
+SELECT '= nested AND in row policy: both sorting-key atoms should be used for index analysis =';
+
+DROP TABLE IF EXISTS tab_nested_and;
+DROP ROW POLICY IF EXISTS pol_nested ON tab_nested_and;
+
+CREATE TABLE tab_nested_and (x UInt32, y String, z UInt32, version UInt32)
+ENGINE = ReplacingMergeTree(version) ORDER BY x;
+
+INSERT INTO tab_nested_and VALUES (1, 'aaa', 100, 1), (2, 'bbb', 200, 1), (3, 'ccc', 300, 1), (5, 'ddd', 500, 1);
+INSERT INTO tab_nested_and VALUES (1, 'eee', 150, 2), (2, 'fff', 250, 2);
+
+CREATE ROW POLICY pol_nested ON tab_nested_and USING (y != 'eee' AND x > 1) AND x < 5 TO ALL;
+
+SET apply_row_policy_after_final = 1;
+SELECT '--- FINAL with nested AND row policy';
+-- FINAL has (1,'eee',150,2), (2,'fff',250,2), (3,'ccc',300,1), (5,'ddd',500,1)
+-- row policy (y!='eee' AND x>1) AND x<5 -> (2,'fff',250,2), (3,'ccc',300,1)
+SELECT * FROM tab_nested_and FINAL ORDER BY x;
+
+SELECT '--- EXPLAIN indexes: both x > 1 and x < 5 should appear in PrimaryKey condition';
+EXPLAIN indexes = 1 SELECT * FROM tab_nested_and FINAL ORDER BY x FORMAT TabSeparated;
+
+DROP ROW POLICY pol_nested ON tab_nested_and;
+SET apply_row_policy_after_final = 0;
+DROP TABLE tab_nested_and;
+
+SELECT '';
+SELECT '= nested AND in PREWHERE: both sorting-key atoms should be used for index analysis =';
+
+DROP TABLE IF EXISTS tab_nested_and_pw;
+
+CREATE TABLE tab_nested_and_pw (x UInt32, y String, z UInt32, version UInt32)
+ENGINE = ReplacingMergeTree(version) ORDER BY x;
+
+INSERT INTO tab_nested_and_pw VALUES (1, 'aaa', 100, 1), (2, 'bbb', 200, 1), (3, 'ccc', 300, 1), (5, 'ddd', 500, 1);
+INSERT INTO tab_nested_and_pw VALUES (1, 'eee', 150, 2), (2, 'fff', 250, 2);
+
+SET apply_prewhere_after_final = 1;
+SELECT '--- FINAL PREWHERE (y != eee AND x > 1) AND x < 5';
+SELECT * FROM tab_nested_and_pw FINAL PREWHERE (y != 'eee' AND x > 1) AND x < 5 ORDER BY x;
+
+SELECT '--- EXPLAIN indexes: both x > 1 and x < 5 should appear in PrimaryKey condition';
+EXPLAIN indexes = 1 SELECT * FROM tab_nested_and_pw FINAL PREWHERE (y != 'eee' AND x > 1) AND x < 5 ORDER BY x FORMAT TabSeparated;
+
+SELECT '--- EXPLAIN actions: prewhere should be deferred';
+SELECT explain FROM (EXPLAIN actions=1 SELECT * FROM tab_nested_and_pw FINAL PREWHERE (y != 'eee' AND x > 1) AND x < 5 ORDER BY x) WHERE explain LIKE '%Deferred%';
+
+SET apply_prewhere_after_final = 0;
+DROP TABLE tab_nested_and_pw;


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
When apply_row_policy_after_final or apply_prewhere_after_final is enabled, compound AND conditions in row policies and PREWHERE are now decomposed to extract sorting-key atoms for primary key index analysis. Previously, if a deferred filter contained a mix of sorting-key and non-sorting-key predicates (e.g. x > 1 AND y != 'foo'), the entire expression was excluded from index analysis. Now sorting-key atoms (like x > 1) are extracted and used for granule pruning, even from nested AND expressions.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches MergeTree read/index-analysis logic, which can affect query correctness (granule/partition pruning) and performance, though the behavioral change is limited to cases where `apply_row_policy_after_final`/`apply_prewhere_after_final` defer compound `AND` filters.
> 
> **Overview**
> When `apply_row_policy_after_final` or `apply_prewhere_after_final` defers filters past `FINAL`, index analysis no longer drops the entire deferred predicate: it now decomposes (including nested) `and()` expressions and keeps any *sorting-key-only* atoms for primary-key condition building, while still excluding non-sorting-key deferred filters from partition/skip-index pruning.
> 
> Adds coverage in `03742_apply_row_policy_after_final` for compound and nested-`AND` row policies and PREWHERE clauses, asserting via `EXPLAIN indexes` that sorting-key atoms (e.g. `x > 1`, `x < 5`) remain in the PrimaryKey condition and that PREWHERE is still deferred.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6120cea54bbb7d3918119c498188997b372b29d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.478`
- Backported to: `26.2.19.23`
<!-- ch-version-info:end -->