### PR TITLE
Fix flaky test test_query_with_no_data_to_sample in test_hedged_requests_parallel

### DIFF
--- a/tests/integration/test_hedged_requests_parallel/configs/users.xml
+++ b/tests/integration/test_hedged_requests_parallel/configs/users.xml
@@ -7,6 +7,7 @@
             <receive_data_timeout_ms>2000</receive_data_timeout_ms>
             <async_socket_for_remote>1</async_socket_for_remote>
             <use_hedged_requests>1</use_hedged_requests>
+            <allow_changing_replica_until_first_data_packet>1</allow_changing_replica_until_first_data_packet>
         </default>
     </profiles>
 </clickhouse>


### PR DESCRIPTION
## Summary

- The test `test_query_with_no_data_to_sample` in `test_hedged_requests_parallel` was failing under MSan because a Progress packet from a slow replica arrived before the `change_replica_timeout` fired, permanently locking the replica choice and preventing hedging from switching to a faster replica. The query waited the full 30s sleep time instead of hedging.
- Added `allow_changing_replica_until_first_data_packet=1` so that only actual Data packets (not Progress) lock in the replica — the same fix previously applied to the sibling `test_hedged_requests` suite in dfaa3f2cf1c.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=1d06a37781e8843ce9d8965a3d53e3fca944a38d&name_0=MasterCI&name_1=Integration%20tests%20%28amd_msan%2C%201%2F6%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.285`
<!-- ch-version-info:end -->