### PR TITLE
Disable `use_hedged_requests` when parallel replicas are enabled in test randomisers

### DIFF
--- a/ci/jobs/scripts/stress/stress.py
+++ b/ci/jobs/scripts/stress/stress.py
@@ -197,6 +197,8 @@ def get_options(i: int, upgrade_check: bool, encrypted_storage: bool) -> str:
         client_options.append("max_parallel_replicas=3")
         client_options.append("cluster_for_parallel_replicas='parallel_replicas'")
         client_options.append("parallel_replicas_for_non_replicated_merge_tree=1")
+        # Hedged requests are not compatible with parallel replicas and produce a warning on stderr
+        client_options.append("use_hedged_requests=0")
 
     if random.random() < 0.2:
         client_options.append(

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1315,6 +1315,8 @@ class SettingsRandomizer:
             random_settings["cluster_for_parallel_replicas"] = "parallel_replicas"
             random_settings["parallel_replicas_local_plan"] = 1
             random_settings["parallel_replicas_for_non_replicated_merge_tree"] = 1
+            # Hedged requests are not compatible with parallel replicas and produce a warning on stderr
+            random_settings["use_hedged_requests"] = 0
 
     @staticmethod
     def get_random_settings(args, tags):


### PR DESCRIPTION
When `use_hedged_requests=1` is combined with parallel replicas, this triggers a `LOG_WARNING` in `updateContextForParallelReplicas` and causes [red CI](https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=28cd79a24459619126bbecbd3d836afd370b333d&name_0=MasterCI&name_1=Stress%20test%20%28azure%2C%20amd_tsan%29). This PR prevents such combination.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)