### PR TITLE
restart statistics cache by alter ... settings ...

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -2547,7 +2547,9 @@ void MergeTreeData::startStatisticsCache()
 {
     const auto settings = getSettings();
     UInt64 refresh_statistics_seconds = (*settings)[MergeTreeSetting::refresh_statistics_interval].totalSeconds();
-    if (refresh_statistics_seconds && !refresh_stats_task)
+    if (refresh_stats_task)
+        refresh_stats_task->deactivate();
+    if (refresh_statistics_seconds)
     {
         LOG_INFO(log, "Start to refresh statistics");
         refresh_stats_task = getContext()->getSchedulePool().createTask(
@@ -4833,6 +4835,9 @@ void MergeTreeData::changeSettings(
         bool has_escape_index_filenames_changed
             = (*storage_settings.get())[MergeTreeSetting::escape_index_filenames] != (*copy)[MergeTreeSetting::escape_index_filenames];
 
+        UInt64 has_refresh_statistics_interval_changed
+            = (*storage_settings.get())[MergeTreeSetting::refresh_statistics_interval].totalSeconds() != (*copy)[MergeTreeSetting::refresh_statistics_interval].totalSeconds();
+
         storage_settings.set(std::move(copy));
         StorageInMemoryMetadata new_metadata = getInMemoryMetadata();
         new_metadata.setSettingsChanges(new_settings);
@@ -4850,6 +4855,11 @@ void MergeTreeData::changeSettings(
 
         if (has_storage_policy_changed)
             startBackgroundMovesIfNeeded();
+
+        if (has_refresh_statistics_interval_changed)
+        {
+            startStatisticsCache();
+        }
     }
 }
 

--- a/tests/integration/test_statistics_cache/test.py
+++ b/tests/integration/test_statistics_cache/test.py
@@ -286,12 +286,14 @@ def test_alter_interval_requires_detach_attach():
     _query(ch1, "SELECT count() FROM alt_tbl WHERE v>0.99 AND k>=0 SETTINGS use_statistics_cache=1, log_comment='alt-pre' FORMAT Null")
     _assert_load(ch1, "alt-pre")
     _query_retry(ch1, "ALTER TABLE alt_tbl MODIFY SETTING refresh_statistics_interval = 1")
-    _query(ch1, "SELECT count() FROM alt_tbl WHERE v>0.99 AND k>=0 SETTINGS use_statistics_cache=1, log_comment='alt-now' FORMAT Null")
-    _assert_load(ch1, "alt-now")
-    _query_retry(ch1, "DETACH TABLE alt_tbl; ATTACH TABLE alt_tbl")
     _wait_hit(
         ch1, "alt-post",
         "SELECT count() FROM alt_tbl WHERE v>0.99 AND k>=0 SETTINGS use_statistics_cache=1, log_comment='alt-post' FORMAT Null"
+    )
+    _query_retry(ch1, "DETACH TABLE alt_tbl; ATTACH TABLE alt_tbl")
+    _wait_hit(
+        ch1, "detach-attach-post",
+        "SELECT count() FROM alt_tbl WHERE v>0.99 AND k>=0 SETTINGS use_statistics_cache=1, log_comment='detach-attach-post' FORMAT Null"
     )
 
 def test_types_smoke_and_nullable():
@@ -353,31 +355,6 @@ def test_drop_statistics_means_no_load_and_bypass_still_loads():
            "SETTINGS use_statistics_cache=0, log_comment='drop-bypass' FORMAT Null")
     # after optimization, there is no load after `drop statistics`
     _assert_hit(ch1, "drop-bypass")
-
-def test_per_replica_cache_and_restart_needed():
-    table = _create_rep(0)
-    _query(r1, f"SELECT count() FROM {table} WHERE v>0.99 AND id>=0 SETTINGS use_statistics_cache=1, log_comment='rep-r1-pre' FORMAT Null")
-    _assert_load(r1, "rep-r1-pre")
-    _query(r2, f"SELECT count() FROM {table} WHERE v>0.99 AND id>=0 SETTINGS use_statistics_cache=1, log_comment='rep-r2-pre' FORMAT Null")
-    _assert_load(r2, "rep-r2-pre")
-
-    for n in (r1, r2):
-        _query_retry(n, f"ALTER TABLE {table} MODIFY SETTING refresh_statistics_interval = 1")
-
-    _query(r1, f"SELECT count() FROM {table} WHERE v>0.99 AND id>=0 SETTINGS use_statistics_cache=1, log_comment='rep-now' FORMAT Null")
-    _assert_load(r1, "rep-now")
-
-    _query_retry(r1, f"SYSTEM RESTART REPLICA {table}")
-    _query_retry(r2, f"SYSTEM RESTART REPLICA {table}")
-
-    _wait_hit(
-        r1, "rep-post-r1",
-        f"SELECT count() FROM {table} WHERE v>0.99 AND id>=0 SETTINGS use_statistics_cache=1, log_comment='rep-post-r1' FORMAT Null"
-    )
-    _wait_hit(
-        r2, "rep-post-r2",
-        f"SELECT count() FROM {table} WHERE v>0.99 AND id>=0 SETTINGS use_statistics_cache=1, log_comment='rep-post-r2' FORMAT Null"
-    )
 
 def test_replication_inserts_keep_hit():
     table = _create_rep(1)


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement



### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
restart the statistics cache after change the merge tree setting

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.290`
<!-- ch-version-info:end -->