### PR TITLE
Only "alive" replicas (that is connectable) participate in distributed index analysis

### DIFF
--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -386,7 +386,8 @@
     M(FilteringMarksWithSecondaryKeysMicroseconds, "Time spent filtering parts by skip indexes.", ValueType::Microseconds) \
     M(DistributedIndexAnalysisMicroseconds, "Total time spent during distributed index analysis", ValueType::Microseconds) \
     M(DistributedIndexAnalysisScheduledReplicas, "Number of replicas (local replica will be accounted once) to which distributed index analysis has been scheduled", ValueType::Number) \
-    M(DistributedIndexAnalysisFailedReplicas, "Number of times distributed index analysis failed on one of replicas", ValueType::Number) \
+    M(DistributedIndexAnalysisReplicaUnavailable, "Number of times distributed index analysis failed on one of replicas without fallback (failed during connect)", ValueType::Number) \
+    M(DistributedIndexAnalysisReplicaFallback, "Number of times distributed index analysis failed on one of replicas with fallback to local replica", ValueType::Number) \
     M(DistributedIndexAnalysisParts, "Number of parts send for distributed index analysis", ValueType::Number) \
     M(DistributedIndexAnalysisMissingParts, "Number of missing parts during distributed index analysis that will be resolved locally", ValueType::Number) \
     \

--- a/src/Interpreters/ClusterProxy/distributedIndexAnalysis.cpp
+++ b/src/Interpreters/ClusterProxy/distributedIndexAnalysis.cpp
@@ -21,6 +21,7 @@
 #include <Common/logger_useful.h>
 #include <Common/threadPoolCallbackRunner.h>
 #include <Common/setThreadName.h>
+#include <IO/ConnectionTimeouts.h>
 #include <Columns/ColumnString.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTSelectQuery.h>
@@ -55,7 +56,8 @@ namespace DB::Setting
 namespace ProfileEvents
 {
     extern const Event DistributedIndexAnalysisMicroseconds;
-    extern const Event DistributedIndexAnalysisFailedReplicas;
+    extern const Event DistributedIndexAnalysisReplicaFallback;
+    extern const Event DistributedIndexAnalysisReplicaUnavailable;
     extern const Event DistributedIndexAnalysisMissingParts;
     extern const Event DistributedIndexAnalysisScheduledReplicas;
 }
@@ -137,7 +139,7 @@ std::vector<ConnectionPoolPtr> prepareConnectionPools(const ContextPtr & context
 
 IndexAnalysisPartsRanges getIndexAnalysisFromReplica(const LoggerPtr & logger, const StorageID & storage_id, const std::optional<std::string> & filter,
                                                      const OptionalVectorSearchParameters & vector_search_parameters, ContextPtr context, const Tables & external_tables,
-                                                     const std::vector<std::string_view> & parts, ConnectionPoolPtr pool)
+                                                     const std::vector<std::string_view> & parts, ConnectionPool::Entry connection)
 {
     std::string analyze_index_query = fmt::format("SELECT * FROM mergeTreeAnalyzeIndexesUUID('{}', {}, '^({})$'",
         storage_id.uuid,
@@ -170,10 +172,6 @@ IndexAnalysisPartsRanges getIndexAnalysisFromReplica(const LoggerPtr & logger, c
           })),
           "ranges" },
     });
-
-    const auto & settings = context->getSettingsRef();
-    auto timeouts = ConnectionTimeouts::getTCPTimeoutsWithFailover(settings);
-    auto connection = pool->get(timeouts, settings);
 
     auto remote_query_executor = std::make_shared<RemoteQueryExecutor>(*connection, analyze_index_query, sample_block, context, ThrottlerPtr{}, Scalars{}, external_tables);
     remote_query_executor->setLogger(logger);
@@ -236,7 +234,6 @@ DistributedIndexAnalysisPartsRanges distributedIndexAnalysisOnReplicas(
 
     const auto & settings = context->getSettingsRef();
     auto logger = getLogger("DistributedIndexAnalysis");
-    LOG_DEBUG(logger, "Distributed index analysis for {}", storage_id.getNameForLogs());
 
     auto cluster = context->getClusterForParallelReplicas();
     const auto & shard = cluster->getShardsInfo().at(0);
@@ -244,6 +241,31 @@ DistributedIndexAnalysisPartsRanges distributedIndexAnalysisOnReplicas(
     size_t local_replica_index = findLocalReplica(connection_pools, shard.local_addresses);
     size_t total_replicas = shard.getAllNodeCount();
     size_t active_replicas = std::min<size_t>(settings[Setting::max_parallel_replicas], total_replicas);
+
+    /// Establish connections to remote replicas upfront, before distributing parts
+    /// with consistent hashing. This lets us detect dead replicas early and avoid
+    /// assigning parts to them (which would require a timeout + local fallback).
+    auto timeouts = ConnectionTimeouts::getTCPTimeoutsWithFailover(settings);
+    std::vector<ConnectionPool::Entry> connections(active_replicas);
+    for (size_t i = 0; i < active_replicas; ++i)
+    {
+        if (i == local_replica_index)
+            continue;
+        try
+        {
+            connections[i] = connection_pools[i]->get(timeouts, settings);
+        }
+        catch (...)
+        {
+            ProfileEvents::increment(ProfileEvents::DistributedIndexAnalysisReplicaUnavailable);
+            const auto & replica_address = connection_pools[i]->getAddress();
+            tryLogCurrentException(logger, fmt::format("Cannot connect to {} (index {}). Its will not be participate in distributed index analysis", replica_address, i), LogsLevel::warning);
+            --active_replicas;
+        }
+    }
+    LOG_DEBUG(logger, "Distributed index analysis for {} (total replicas: {}, local replica index: {}, active replicas: {})",
+              storage_id.getNameForLogs(),
+              total_replicas, local_replica_index, active_replicas);
 
     chassert(active_replicas <= connection_pools.size());
 
@@ -312,13 +334,16 @@ DistributedIndexAnalysisPartsRanges distributedIndexAnalysisOnReplicas(
         }
         else
         {
+            if (connections[i].isNull())
+                continue;
+
             /// Passing references here is fine. All of them will outlive the runner
-            runner.enqueueAndKeepTrack([i, replica_address, connection_pool, &logger, &replica_parts, &replicas_marks, &replicas_rows, &storage_id, &filter_query, &vector_search_parameters, &execution_context, &external_tables, &res]()
+            runner.enqueueAndKeepTrack([i, replica_address, connection = std::move(connections[i]), &logger, &replica_parts, &replicas_marks, &replicas_rows, &storage_id, &filter_query, &vector_search_parameters, &execution_context, &external_tables, &res]() mutable
             {
                 try
                 {
                     LOG_TRACE(logger, "Sending {} parts ({} marks, {} rows) to {} (index {}): {}", replica_parts.size(), replicas_marks[i], replicas_rows[i], replica_address, i, replica_parts);
-                    auto parts_ranges = getIndexAnalysisFromReplica(logger, storage_id, filter_query, vector_search_parameters, execution_context, external_tables, replica_parts, connection_pool);
+                    auto parts_ranges = getIndexAnalysisFromReplica(logger, storage_id, filter_query, vector_search_parameters, execution_context, external_tables, replica_parts, std::move(connection));
                     LOG_TRACE(logger, "Received {} parts from {} (index {}): {}", parts_ranges.size(), replica_address, i, parts_ranges);
                     res[i].second = std::move(parts_ranges);
                 }
@@ -326,13 +351,13 @@ DistributedIndexAnalysisPartsRanges distributedIndexAnalysisOnReplicas(
                 {
                     if (e.code() == ErrorCodes::QUERY_WAS_CANCELLED)
                         throw;
-                    ProfileEvents::increment(ProfileEvents::DistributedIndexAnalysisFailedReplicas);
+                    ProfileEvents::increment(ProfileEvents::DistributedIndexAnalysisReplicaFallback);
                     /// Ignore any exceptions, everything will be analyzed on a local replica
                     tryLogCurrentException(logger, fmt::format("Cannot analyze parts on {} replica (index {}). They will be analyzed on initiator", replica_address, i), LogsLevel::warning);
                 }
                 catch (...)
                 {
-                    ProfileEvents::increment(ProfileEvents::DistributedIndexAnalysisFailedReplicas);
+                    ProfileEvents::increment(ProfileEvents::DistributedIndexAnalysisReplicaFallback);
                     /// Ignore any exceptions, everything will be analyzed on a local replica
                     tryLogCurrentException(logger, fmt::format("Cannot analyze parts on {} replica (index {}). They will be analyzed on initiator", replica_address, i), LogsLevel::warning);
                 }

--- a/src/Interpreters/ClusterProxy/distributedIndexAnalysis.cpp
+++ b/src/Interpreters/ClusterProxy/distributedIndexAnalysis.cpp
@@ -243,36 +243,52 @@ DistributedIndexAnalysisPartsRanges distributedIndexAnalysisOnReplicas(
     size_t total_replicas = shard.getAllNodeCount();
     size_t max_active_replicas = std::min<size_t>(settings[Setting::max_parallel_replicas], total_replicas);
 
-    /// Establish connections to remote replicas upfront, before distributing parts
-    /// with consistent hashing. This lets us detect dead replicas early and avoid
-    /// assigning parts to them (which would require a timeout + local fallback).
+    ThreadPool pool(CurrentMetrics::DistributedIndexAnalysisThreads,
+                    CurrentMetrics::DistributedIndexAnalysisThreadsActive,
+                    CurrentMetrics::DistributedIndexAnalysisThreadsScheduled,
+                    /// TODO: limit amount of threads (maybe shared thread pool)
+                    total_replicas);
+
+    /// Establish connections to remote replicas upfront in parallel, before
+    /// distributing parts with consistent hashing. This lets us detect dead
+    /// replicas early and avoid assigning parts to them.
     auto timeouts = ConnectionTimeouts::getTCPTimeoutsWithFailover(settings);
     std::vector<ConnectionPool::Entry> connections(total_replicas);
+    {
+        ThreadPoolCallbackRunnerLocal<void> connect_runner(pool, DB::ThreadName::DISTRIBUTED_INDEX_ANALYSIS);
+        for (size_t i = 0; i < total_replicas; ++i)
+        {
+            if (i == local_replica_index)
+                continue;
+            /// Each thread writes to its own connections[i] slot, no synchronization needed.
+            connect_runner.enqueueAndKeepTrack([i, &connections, &connection_pools, &timeouts, &settings, &logger]()
+            {
+                try
+                {
+                    connections[i] = connection_pools[i]->get(timeouts, settings);
+                }
+                catch (...)
+                {
+                    ProfileEvents::increment(ProfileEvents::DistributedIndexAnalysisReplicaUnavailable);
+                    const auto & replica_address = connection_pools[i]->getAddress();
+                    tryLogCurrentException(logger, fmt::format("Cannot connect to {} (index {}). It will not participate in distributed index analysis", replica_address, i), LogsLevel::warning);
+                }
+            }, Priority{});
+        }
+        connect_runner.waitForAllToFinishAndRethrowFirstError();
+    }
 
     /// Local replica is always active (no connection needed).
+    /// Fill remaining slots with the first successfully connected remote replicas (by index order).
     std::vector<size_t> active_replica_indexes;
     active_replica_indexes.reserve(max_active_replicas);
     active_replica_indexes.push_back(local_replica_index);
-
-    /// Fill remaining slots with successfully connected remote replicas.
     for (size_t i = 0; i < total_replicas && active_replica_indexes.size() < max_active_replicas; ++i)
     {
-        if (i == local_replica_index)
-            continue;
-        try
-        {
-            connections[i] = connection_pools[i]->get(timeouts, settings);
+        if (i != local_replica_index && !connections[i].isNull())
             active_replica_indexes.push_back(i);
-        }
-        catch (...)
-        {
-            ProfileEvents::increment(ProfileEvents::DistributedIndexAnalysisReplicaUnavailable);
-            const auto & replica_address = connection_pools[i]->getAddress();
-            tryLogCurrentException(logger, fmt::format("Cannot connect to {} (index {}). It will not participate in distributed index analysis", replica_address, i), LogsLevel::warning);
-        }
     }
-
-    /// Sort to maintain deterministic part distribution regardless of connection order.
+    /// Sort because local_replica_index may not be the smallest.
     std::sort(active_replica_indexes.begin(), active_replica_indexes.end());
 
     LOG_DEBUG(logger, "Distributed index analysis for {} (total replicas: {}, local replica index: {}, active replicas: {} ({}))",
@@ -311,11 +327,6 @@ DistributedIndexAnalysisPartsRanges distributedIndexAnalysisOnReplicas(
             filter_query = filter_ast->formatWithSecretsOneLine();
     }
 
-    ThreadPool pool(CurrentMetrics::DistributedIndexAnalysisThreads,
-                    CurrentMetrics::DistributedIndexAnalysisThreadsActive,
-                    CurrentMetrics::DistributedIndexAnalysisThreadsScheduled,
-                    /// TODO: limit amount of threads (maybe shared thread pool)
-                    active_replica_indexes.size());
     ThreadPoolCallbackRunnerLocal<void> runner(pool, DB::ThreadName::DISTRIBUTED_INDEX_ANALYSIS);
     for (const auto i : active_replica_indexes)
     {

--- a/src/Interpreters/ClusterProxy/distributedIndexAnalysis.cpp
+++ b/src/Interpreters/ClusterProxy/distributedIndexAnalysis.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <unordered_map>
 #include <Columns/ColumnArray.h>
 #include <Columns/ColumnBLOB.h>
@@ -240,42 +241,47 @@ DistributedIndexAnalysisPartsRanges distributedIndexAnalysisOnReplicas(
     auto connection_pools = prepareConnectionPools(context, shard);
     size_t local_replica_index = findLocalReplica(connection_pools, shard.local_addresses);
     size_t total_replicas = shard.getAllNodeCount();
-    size_t active_replicas = std::min<size_t>(settings[Setting::max_parallel_replicas], total_replicas);
+    size_t max_active_replicas = std::min<size_t>(settings[Setting::max_parallel_replicas], total_replicas);
 
     /// Establish connections to remote replicas upfront, before distributing parts
     /// with consistent hashing. This lets us detect dead replicas early and avoid
     /// assigning parts to them (which would require a timeout + local fallback).
     auto timeouts = ConnectionTimeouts::getTCPTimeoutsWithFailover(settings);
-    std::vector<ConnectionPool::Entry> connections(active_replicas);
-    for (size_t i = 0; i < active_replicas; ++i)
+    std::vector<ConnectionPool::Entry> connections(total_replicas);
+
+    /// Local replica is always active (no connection needed).
+    std::vector<size_t> active_replica_indexes;
+    active_replica_indexes.reserve(max_active_replicas);
+    active_replica_indexes.push_back(local_replica_index);
+
+    /// Fill remaining slots with successfully connected remote replicas.
+    for (size_t i = 0; i < total_replicas && active_replica_indexes.size() < max_active_replicas; ++i)
     {
         if (i == local_replica_index)
             continue;
         try
         {
             connections[i] = connection_pools[i]->get(timeouts, settings);
+            active_replica_indexes.push_back(i);
         }
         catch (...)
         {
             ProfileEvents::increment(ProfileEvents::DistributedIndexAnalysisReplicaUnavailable);
             const auto & replica_address = connection_pools[i]->getAddress();
-            tryLogCurrentException(logger, fmt::format("Cannot connect to {} (index {}). Its will not be participate in distributed index analysis", replica_address, i), LogsLevel::warning);
-            --active_replicas;
+            tryLogCurrentException(logger, fmt::format("Cannot connect to {} (index {}). It will not participate in distributed index analysis", replica_address, i), LogsLevel::warning);
         }
     }
-    LOG_DEBUG(logger, "Distributed index analysis for {} (total replicas: {}, local replica index: {}, active replicas: {})",
+
+    /// Sort to maintain deterministic part distribution regardless of connection order.
+    std::sort(active_replica_indexes.begin(), active_replica_indexes.end());
+
+    LOG_DEBUG(logger, "Distributed index analysis for {} (total replicas: {}, local replica index: {}, active replicas: {} ({}))",
               storage_id.getNameForLogs(),
-              total_replicas, local_replica_index, active_replicas);
+              total_replicas, local_replica_index, active_replica_indexes.size(), fmt::join(active_replica_indexes, ", "));
 
-    chassert(active_replicas <= connection_pools.size());
-
-    std::vector<std::vector<std::string_view>> replicas_parts;
-    replicas_parts.resize(active_replicas);
-
-    std::vector<size_t> replicas_marks;
-    replicas_marks.resize(active_replicas);
-    std::vector<size_t> replicas_rows;
-    replicas_rows.resize(active_replicas);
+    std::vector<std::vector<std::string_view>> replicas_parts(total_replicas);
+    std::vector<size_t> replicas_marks(total_replicas, 0);
+    std::vector<size_t> replicas_rows(total_replicas, 0);
 
     for (const auto & part_ranges : parts_with_ranges)
     {
@@ -283,11 +289,12 @@ DistributedIndexAnalysisPartsRanges distributedIndexAnalysisOnReplicas(
         chassert(part_ranges.exact_ranges.empty());
 
         const auto & part_name = part_ranges.data_part->name;
-        const auto & part_replica_index = partReplica(part_name, active_replicas);
-        replicas_parts[part_replica_index].push_back(part_name);
+        const auto hash_index = partReplica(part_name, active_replica_indexes.size());
+        const auto replica_index = active_replica_indexes[hash_index];
+        replicas_parts[replica_index].push_back(part_name);
 
-        replicas_marks[part_replica_index] += part_ranges.getMarksCount();
-        replicas_rows[part_replica_index] += part_ranges.getRowsCount();
+        replicas_marks[replica_index] += part_ranges.getMarksCount();
+        replicas_rows[replica_index] += part_ranges.getRowsCount();
     }
 
     DistributedIndexAnalysisPartsRanges res;
@@ -308,9 +315,9 @@ DistributedIndexAnalysisPartsRanges distributedIndexAnalysisOnReplicas(
                     CurrentMetrics::DistributedIndexAnalysisThreadsActive,
                     CurrentMetrics::DistributedIndexAnalysisThreadsScheduled,
                     /// TODO: limit amount of threads (maybe shared thread pool)
-                    replicas_parts.size());
+                    active_replica_indexes.size());
     ThreadPoolCallbackRunnerLocal<void> runner(pool, DB::ThreadName::DISTRIBUTED_INDEX_ANALYSIS);
-    for (size_t i = 0; i < replicas_parts.size(); ++i)
+    for (const auto i : active_replica_indexes)
     {
         const auto & replica_parts = replicas_parts[i];
         const auto & connection_pool = connection_pools.at(i);

--- a/tests/queries/0_stateless/02354_vector_search_distributed_index_analysis.reference
+++ b/tests/queries/0_stateless/02354_vector_search_distributed_index_analysis.reference
@@ -13,5 +13,5 @@ ANN results - distributed
 30	[0.3,0.3]
 30	[0.3,0.3]
 30	[0.3,0.3]
-distributed_index_analysis=1, DistributedIndexAnalysisMicroseconds>0=1, DistributedIndexAnalysisMissingParts=0, DistributedIndexAnalysisScheduledReplicas=3, DistributedIndexAnalysisFailedReplicas>0=0
+distributed_index_analysis=1, DistributedIndexAnalysisMicroseconds>0=1, DistributedIndexAnalysisScheduledReplicas=3
 1

--- a/tests/queries/0_stateless/02354_vector_search_distributed_index_analysis.sql
+++ b/tests/queries/0_stateless/02354_vector_search_distributed_index_analysis.sql
@@ -2,6 +2,8 @@
 
 set allow_experimental_parallel_reading_from_replicas=0;
 set enable_analyzer = 1;
+--- Ignore warnings when replica does not respond, and analysis is done on initiator
+set send_logs_level='error';
 
 DROP TABLE IF EXISTS tab;
 

--- a/tests/queries/0_stateless/02354_vector_search_distributed_index_analysis.sql
+++ b/tests/queries/0_stateless/02354_vector_search_distributed_index_analysis.sql
@@ -45,12 +45,10 @@ SETTINGS distributed_index_analysis_for_non_shared_merge_tree = 1, distributed_i
 -- Common from 03620_distributed_index_analysis.sql
 system flush logs query_log;
 select format(
-  'distributed_index_analysis={}, DistributedIndexAnalysisMicroseconds>0={}, DistributedIndexAnalysisMissingParts={}, DistributedIndexAnalysisScheduledReplicas={}, DistributedIndexAnalysisFailedReplicas>0={}',
+  'distributed_index_analysis={}, DistributedIndexAnalysisMicroseconds>0={}, DistributedIndexAnalysisScheduledReplicas={}',
   Settings['distributed_index_analysis'],
   ProfileEvents['DistributedIndexAnalysisMicroseconds'] > 0,
-  ProfileEvents['DistributedIndexAnalysisMissingParts'],
-  ProfileEvents['DistributedIndexAnalysisScheduledReplicas'],
-  ProfileEvents['DistributedIndexAnalysisFailedReplicas'] > 0
+  ProfileEvents['DistributedIndexAnalysisScheduledReplicas']
 )
 from system.query_log
 where

--- a/tests/queries/0_stateless/03620_distributed_index_analysis.reference
+++ b/tests/queries/0_stateless/03620_distributed_index_analysis.reference
@@ -3,5 +3,5 @@ select groupArraySortedDistinct(10)(_part), sum(key) from test_10m settings dist
 ['all_1_1_0','all_2_2_0','all_3_3_0','all_4_4_0','all_5_5_0','all_6_6_0','all_7_7_0','all_8_8_0','all_9_9_0']	49999995000000
 select groupArraySortedDistinct(10)(_part), sum(key) from test_10m settings cluster_for_parallel_replicas='parallel_replicas', distributed_index_analysis=1;
 ['all_1_1_0','all_2_2_0','all_3_3_0','all_4_4_0','all_5_5_0','all_6_6_0','all_7_7_0','all_8_8_0','all_9_9_0']	49999995000000
-distributed_index_analysis=0, DistributedIndexAnalysisMicroseconds>0=0, DistributedIndexAnalysisMissingParts=0, DistributedIndexAnalysisScheduledReplicas=0, DistributedIndexAnalysisFailedReplicas>0=0
-distributed_index_analysis=1, DistributedIndexAnalysisMicroseconds>0=1, DistributedIndexAnalysisMissingParts=0, DistributedIndexAnalysisScheduledReplicas=6, DistributedIndexAnalysisFailedReplicas>0=0
+distributed_index_analysis=0, DistributedIndexAnalysisMicroseconds>0=0, DistributedIndexAnalysisMissingParts=0, DistributedIndexAnalysisScheduledReplicas=0, DistributedIndexAnalysisReplicaUnavailable=0, DistributedIndexAnalysisReplicaFallback=0
+distributed_index_analysis=1, DistributedIndexAnalysisMicroseconds>0=1, DistributedIndexAnalysisMissingParts=0, DistributedIndexAnalysisScheduledReplicas=6, DistributedIndexAnalysisReplicaUnavailable=1, DistributedIndexAnalysisReplicaFallback=0

--- a/tests/queries/0_stateless/03620_distributed_index_analysis.sql
+++ b/tests/queries/0_stateless/03620_distributed_index_analysis.sql
@@ -8,6 +8,7 @@ insert into test_10m select number, number*100 from numbers(10e6);
 
 set allow_experimental_parallel_reading_from_replicas=0;
 set cluster_for_parallel_replicas='';
+set max_parallel_replicas=100;
 
 select groupArraySortedDistinct(10)(_part), sum(key) from test_10m settings distributed_index_analysis=1; -- { serverError CLUSTER_DOESNT_EXIST }
 

--- a/tests/queries/0_stateless/03620_distributed_index_analysis.sql
+++ b/tests/queries/0_stateless/03620_distributed_index_analysis.sql
@@ -21,12 +21,13 @@ select groupArraySortedDistinct(10)(_part), sum(key) from test_10m settings clus
 -- { echoOff }
 system flush logs query_log;
 select format(
-  'distributed_index_analysis={}, DistributedIndexAnalysisMicroseconds>0={}, DistributedIndexAnalysisMissingParts={}, DistributedIndexAnalysisScheduledReplicas={}, DistributedIndexAnalysisFailedReplicas>0={}',
+  'distributed_index_analysis={}, DistributedIndexAnalysisMicroseconds>0={}, DistributedIndexAnalysisMissingParts={}, DistributedIndexAnalysisScheduledReplicas={}, DistributedIndexAnalysisReplicaUnavailable={}, DistributedIndexAnalysisReplicaFallback={}',
   Settings['distributed_index_analysis'],
   ProfileEvents['DistributedIndexAnalysisMicroseconds'] > 0,
   ProfileEvents['DistributedIndexAnalysisMissingParts'],
   ProfileEvents['DistributedIndexAnalysisScheduledReplicas'],
-  ProfileEvents['DistributedIndexAnalysisFailedReplicas'] > 0
+  ProfileEvents['DistributedIndexAnalysisReplicaUnavailable'],
+  ProfileEvents['DistributedIndexAnalysisReplicaFallback']
 )
 from system.query_log
 where

--- a/tests/queries/0_stateless/03622_distributed_index_analysis_all_replicas.reference
+++ b/tests/queries/0_stateless/03622_distributed_index_analysis_all_replicas.reference
@@ -1,11 +1,16 @@
 -- { echo }
-select sum(key) from test_10m;
+select sum(key) from test_10m settings cluster_for_parallel_replicas='parallel_replicas';
 499999500000
-select sum(key) from test_10m where key = 1;
+select sum(key) from test_10m where key = 1 settings cluster_for_parallel_replicas='parallel_replicas';
+1
+select sum(key) from test_10m settings cluster_for_parallel_replicas='parallel_replicas_unavailable_first';
+499999500000
+select sum(key) from test_10m where key = 1 settings cluster_for_parallel_replicas='parallel_replicas_unavailable_first';
 1
 Row 1:
 ──────
-q:                   select sum(key) from test_10m;
+q:                   select sum(key) from test_10m settings cluster_for_parallel_replicas=?;
+cluster:             parallel_replicas
 not_blazingly_fast:  1
 missing_parts:       0
 replicas:            10
@@ -14,7 +19,28 @@ replica_fallback:    0
 
 Row 2:
 ──────
-q:                   select sum(key) from test_10m where key = ?;
+q:                   select sum(key) from test_10m where key = ? settings cluster_for_parallel_replicas=?;
+cluster:             parallel_replicas
+not_blazingly_fast:  1
+missing_parts:       0
+replicas:            1
+replica_unavailable: 1
+replica_fallback:    0
+
+Row 3:
+──────
+q:                   select sum(key) from test_10m settings cluster_for_parallel_replicas=?;
+cluster:             parallel_replicas_unavailable_first
+not_blazingly_fast:  1
+missing_parts:       0
+replicas:            10
+replica_unavailable: 1
+replica_fallback:    0
+
+Row 4:
+──────
+q:                   select sum(key) from test_10m where key = ? settings cluster_for_parallel_replicas=?;
+cluster:             parallel_replicas_unavailable_first
 not_blazingly_fast:  1
 missing_parts:       0
 replicas:            1

--- a/tests/queries/0_stateless/03622_distributed_index_analysis_all_replicas.reference
+++ b/tests/queries/0_stateless/03622_distributed_index_analysis_all_replicas.reference
@@ -5,16 +5,18 @@ select sum(key) from test_10m where key = 1;
 1
 Row 1:
 ──────
-q:                  select sum(key) from test_10m;
-not_blazingly_fast: 1
-missing_parts:      1
-replicas:           11
-failed_replicas:    1
+q:                   select sum(key) from test_10m;
+not_blazingly_fast:  1
+missing_parts:       0
+replicas:            10
+replica_unavailable: 1
+replica_fallback:    0
 
 Row 2:
 ──────
-q:                  select sum(key) from test_10m where key = ?;
-not_blazingly_fast: 1
-missing_parts:      0
-replicas:           1
-failed_replicas:    0
+q:                   select sum(key) from test_10m where key = ?;
+not_blazingly_fast:  1
+missing_parts:       0
+replicas:            1
+replica_unavailable: 1
+replica_fallback:    0

--- a/tests/queries/0_stateless/03622_distributed_index_analysis_all_replicas.sql
+++ b/tests/queries/0_stateless/03622_distributed_index_analysis_all_replicas.sql
@@ -30,7 +30,8 @@ select
   ProfileEvents['DistributedIndexAnalysisMicroseconds'] > 0 not_blazingly_fast,
   ProfileEvents['DistributedIndexAnalysisMissingParts'] missing_parts,
   ProfileEvents['DistributedIndexAnalysisScheduledReplicas'] replicas,
-  ProfileEvents['DistributedIndexAnalysisFailedReplicas'] > 0 failed_replicas
+  ProfileEvents['DistributedIndexAnalysisReplicaUnavailable'] > 0 replica_unavailable,
+  ProfileEvents['DistributedIndexAnalysisReplicaFallback'] > 0 replica_fallback
 from system.query_log
 where
   current_database = currentDatabase()

--- a/tests/queries/0_stateless/03622_distributed_index_analysis_all_replicas.sql
+++ b/tests/queries/0_stateless/03622_distributed_index_analysis_all_replicas.sql
@@ -15,18 +15,20 @@ set parallel_replicas_index_analysis_only_on_coordinator=1;
 set parallel_replicas_local_plan=1;
 set distributed_index_analysis=1;
 set max_parallel_replicas=100;
-set cluster_for_parallel_replicas='parallel_replicas';
 --- Ignore warnings when replica does not respond, and analysis is done on initiator
 set send_logs_level='error';
 
 -- { echo }
-select sum(key) from test_10m;
-select sum(key) from test_10m where key = 1;
+select sum(key) from test_10m settings cluster_for_parallel_replicas='parallel_replicas';
+select sum(key) from test_10m where key = 1 settings cluster_for_parallel_replicas='parallel_replicas';
+select sum(key) from test_10m settings cluster_for_parallel_replicas='parallel_replicas_unavailable_first';
+select sum(key) from test_10m where key = 1 settings cluster_for_parallel_replicas='parallel_replicas_unavailable_first';
 
 -- { echoOff }
 system flush logs query_log;
 select
   normalizeQuery(query) q,
+  Settings['cluster_for_parallel_replicas'] cluster,
   ProfileEvents['DistributedIndexAnalysisMicroseconds'] > 0 not_blazingly_fast,
   ProfileEvents['DistributedIndexAnalysisMissingParts'] missing_parts,
   ProfileEvents['DistributedIndexAnalysisScheduledReplicas'] replicas,

--- a/tests/queries/0_stateless/03622_explain_indexes_distributed_index_analysis.reference
+++ b/tests/queries/0_stateless/03622_explain_indexes_distributed_index_analysis.reference
@@ -25,6 +25,13 @@ distributed_index_analysis=1
   "Selected Granules": 90,
   "Distributed": [
     {
+      "Address": "",
+      "Parts send": 0,
+      "Parts received": 0,
+      "Granules send": 0,
+      "Granules received": 0
+    },
+    {
       "Address": "127.0.0.10:9000",
       "Parts send": 8,
       "Parts received": 8,
@@ -32,25 +39,18 @@ distributed_index_analysis=1
       "Granules received": 8
     },
     {
-      "Address": "127.0.0.11:1234",
-      "Parts send": 0,
-      "Parts received": 0,
-      "Granules send": 0,
-      "Granules received": 0
-    },
-    {
       "Address": "127.0.0.1:9000",
-      "Parts send": 20,
-      "Parts received": 18,
-      "Granules send": 20,
-      "Granules received": 18
+      "Parts send": 14,
+      "Parts received": 12,
+      "Granules send": 14,
+      "Granules received": 12
     },
     {
       "Address": "127.0.0.2:9000",
-      "Parts send": 15,
-      "Parts received": 13,
-      "Granules send": 15,
-      "Granules received": 13
+      "Parts send": 16,
+      "Parts received": 14,
+      "Granules send": 16,
+      "Granules received": 14
     },
     {
       "Address": "127.0.0.3:9000",
@@ -61,31 +61,31 @@ distributed_index_analysis=1
     },
     {
       "Address": "127.0.0.4:9000",
-      "Parts send": 13,
-      "Parts received": 13,
-      "Granules send": 13,
-      "Granules received": 13
+      "Parts send": 14,
+      "Parts received": 14,
+      "Granules send": 14,
+      "Granules received": 14
     },
     {
       "Address": "127.0.0.5:9000",
-      "Parts send": 4,
-      "Parts received": 3,
-      "Granules send": 4,
-      "Granules received": 3
+      "Parts send": 6,
+      "Parts received": 5,
+      "Granules send": 6,
+      "Granules received": 5
     },
     {
       "Address": "127.0.0.6:9000",
-      "Parts send": 8,
-      "Parts received": 7,
-      "Granules send": 8,
-      "Granules received": 7
+      "Parts send": 9,
+      "Parts received": 8,
+      "Granules send": 9,
+      "Granules received": 8
     },
     {
       "Address": "127.0.0.7:9000",
-      "Parts send": 12,
-      "Parts received": 10,
-      "Granules send": 12,
-      "Granules received": 10
+      "Parts send": 13,
+      "Parts received": 11,
+      "Granules send": 13,
+      "Granules received": 11
     },
     {
       "Address": "127.0.0.8:9000",

--- a/tests/queries/0_stateless/03622_explain_indexes_distributed_index_analysis_pushdown.reference
+++ b/tests/queries/0_stateless/03622_explain_indexes_distributed_index_analysis_pushdown.reference
@@ -25,6 +25,13 @@ distributed_index_analysis=1
   "Selected Granules": 90,
   "Distributed": [
     {
+      "Address": "",
+      "Parts send": 0,
+      "Parts received": 0,
+      "Granules send": 0,
+      "Granules received": 0
+    },
+    {
       "Address": "127.0.0.10:9000",
       "Parts send": 8,
       "Parts received": 8,
@@ -32,25 +39,18 @@ distributed_index_analysis=1
       "Granules received": 8
     },
     {
-      "Address": "127.0.0.11:1234",
-      "Parts send": 0,
-      "Parts received": 0,
-      "Granules send": 0,
-      "Granules received": 0
-    },
-    {
       "Address": "127.0.0.1:9000",
-      "Parts send": 20,
-      "Parts received": 18,
-      "Granules send": 20,
-      "Granules received": 18
+      "Parts send": 14,
+      "Parts received": 12,
+      "Granules send": 14,
+      "Granules received": 12
     },
     {
       "Address": "127.0.0.2:9000",
-      "Parts send": 15,
-      "Parts received": 13,
-      "Granules send": 15,
-      "Granules received": 13
+      "Parts send": 16,
+      "Parts received": 14,
+      "Granules send": 16,
+      "Granules received": 14
     },
     {
       "Address": "127.0.0.3:9000",
@@ -61,31 +61,31 @@ distributed_index_analysis=1
     },
     {
       "Address": "127.0.0.4:9000",
-      "Parts send": 13,
-      "Parts received": 13,
-      "Granules send": 13,
-      "Granules received": 13
+      "Parts send": 14,
+      "Parts received": 14,
+      "Granules send": 14,
+      "Granules received": 14
     },
     {
       "Address": "127.0.0.5:9000",
-      "Parts send": 4,
-      "Parts received": 3,
-      "Granules send": 4,
-      "Granules received": 3
+      "Parts send": 6,
+      "Parts received": 5,
+      "Granules send": 6,
+      "Granules received": 5
     },
     {
       "Address": "127.0.0.6:9000",
-      "Parts send": 8,
-      "Parts received": 7,
-      "Granules send": 8,
-      "Granules received": 7
+      "Parts send": 9,
+      "Parts received": 8,
+      "Granules send": 9,
+      "Granules received": 8
     },
     {
       "Address": "127.0.0.7:9000",
-      "Parts send": 12,
-      "Parts received": 10,
-      "Granules send": 12,
-      "Granules received": 10
+      "Parts send": 13,
+      "Parts received": 11,
+      "Granules send": 13,
+      "Granules received": 11
     },
     {
       "Address": "127.0.0.8:9000",


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Only "alive" replicas (that is connectable) participate in distributed index analysis


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.374`
- Backported to: `26.2.4.18`
<!-- ch-version-info:end -->