### PR TITLE
Fix logical error when identifier is empty after parameter substitution

### DIFF
--- a/src/Interpreters/ReplaceQueryParameterVisitor.cpp
+++ b/src/Interpreters/ReplaceQueryParameterVisitor.cpp
@@ -195,6 +195,9 @@ void ReplaceQueryParameterVisitor::visitIdentifier(ASTPtr & ast)
         {
             const auto & ast_param = ast_identifier->children[j++]->as<ASTQueryParameter &>();
             name_parts[i] = getParamValue(ast_param.name);
+            if (name_parts[i].empty())
+                throw Exception(ErrorCodes::BAD_QUERY_PARAMETER, "Empty Identifier part after parameter {} substitution",
+                    backQuote(ast_param.name));
             replaced_parameter = true;
         }
     }

--- a/tests/queries/0_stateless/04010_empty_database_name_parameter.sql
+++ b/tests/queries/0_stateless/04010_empty_database_name_parameter.sql
@@ -1,0 +1,12 @@
+SET param_db='';
+CREATE DATABASE {db:Identifier}; -- {serverError BAD_QUERY_PARAMETER}
+DROP DATABASE {db:Identifier}; -- {serverError BAD_QUERY_PARAMETER}
+
+SET param_table='';
+DROP TABLE {db:Identifier}.{table:Identifier}; -- {serverError BAD_QUERY_PARAMETER}
+
+SET param_db='some_db_name';
+DROP TABLE {db:Identifier}.{table:Identifier}; -- {serverError BAD_QUERY_PARAMETER}
+
+SET param_table='table';
+DROP TABLE {db:Identifier}.{table:Identifier}; -- {serverError UNKNOWN_DATABASE}


### PR DESCRIPTION
Closes: #98497

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed LOGICAL_ERROR when Identifier is empty after parameter substitution


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.308`
<!-- ch-version-info:end -->