### PR TITLE
Fix column rollback in StorageBuffer::appendBlock

### DIFF
--- a/src/Storages/StorageBuffer.cpp
+++ b/src/Storages/StorageBuffer.cpp
@@ -38,6 +38,7 @@
 #include <Storages/IStorage.h>
 #include <base/getThreadId.h>
 #include <base/range.h>
+#include <Columns/IColumn.h>
 #include <Common/CurrentMetrics.h>
 #include <Common/FieldVisitorConvertToNumber.h>
 #include <Common/MemoryTrackerBlockerInThread.h>
@@ -563,7 +564,6 @@ void StorageBuffer::read(
 static void appendBlock(LoggerPtr log, const Block & from, Block & to)
 {
     size_t rows = from.rows();
-    size_t old_rows = to.rows();
     size_t old_bytes = to.bytes();
 
     if (to.empty())
@@ -574,7 +574,15 @@ static void appendBlock(LoggerPtr log, const Block & from, Block & to)
     from.checkNumberOfRows();
     to.checkNumberOfRows();
 
+    /// Take checkpoints of all destination columns before any modifications
+    /// to be able to rollback in case of an exception in the middle of insertion.
+    ColumnCheckpoints checkpoints;
+    checkpoints.reserve(to.columns());
+    for (size_t column_no = 0; column_no < to.columns(); ++column_no)
+        checkpoints.push_back(to.getByPosition(column_no).column->getCheckpoint());
+
     MutableColumnPtr last_col;
+    size_t mutated_columns = 0;
     try
     {
         MemoryTrackerBlockerInThread temporarily_disable_memory_tracker;
@@ -600,6 +608,7 @@ static void appendBlock(LoggerPtr log, const Block & from, Block & to)
                 LockMemoryExceptionInThread temporarily_ignore_any_memory_limits(VariableContext::Global);
                 last_col = IColumn::mutate(std::move(to.getByPosition(column_no).column));
             }
+            ++mutated_columns;
 
             /// In case of ColumnAggregateFunction aggregate states will
             /// be allocated from the query context but can be destroyed from the
@@ -632,10 +641,11 @@ static void appendBlock(LoggerPtr log, const Block & from, Block & to)
 
         try
         {
-            for (size_t column_no = 0, columns = to.columns(); column_no < columns; ++column_no)
+            for (size_t column_no = 0; column_no < mutated_columns; ++column_no)
             {
                 ColumnPtr & col_to = to.getByPosition(column_no).column;
-                /// If there is no column, then the exception was thrown in the middle of append, in the insertRangeFrom()
+                /// If there is no column, the exception was thrown in the middle of append,
+                /// during insertRangeFrom() — move last_col back so we can roll it back.
                 if (!col_to)
                 {
                     col_to = std::move(last_col);
@@ -645,8 +655,11 @@ static void appendBlock(LoggerPtr log, const Block & from, Block & to)
                 /// But if there is still nothing, abort
                 if (!col_to)
                     throw Exception(ErrorCodes::LOGICAL_ERROR, "No column to rollback");
-                if (col_to->size() != old_rows)
-                    col_to = col_to->cut(0, old_rows);
+
+                /// Rollback to the state before the exception.
+                auto mutable_col = IColumn::mutate(std::move(col_to));
+                mutable_col->rollback(*checkpoints[column_no]);
+                col_to = std::move(mutable_col);
             }
         }
         catch (...)


### PR DESCRIPTION
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix column rollback in Buffer engine during handling an exception during appending a new block. Old logic could lead to corrupted in-memory state of columns. 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.313`
- Backported to: `26.2.4.11`, `26.1.5.12`, `25.12.9.16`, `25.8.19.5`, `25.3.15.18`
<!-- ch-version-info:end -->