### PR TITLE
Fix 01455_opentelemetry_distributed flaky test by adding few retries

### DIFF
--- a/tests/queries/0_stateless/01455_opentelemetry_distributed.sh
+++ b/tests/queries/0_stateless/01455_opentelemetry_distributed.sh
@@ -9,9 +9,29 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 function check_log
 {
+    # The gateway span (HTTPHandler / TCPHandler TracingContextHolder) is logged
+    # only when handleRequest() / runImpl() fully exits — after the response has
+    # already been sent to the client.  There is therefore a small window where
+    # the client has received the HTTP 200 but the span is not yet in the table.
+    # Retry a few times to let the background I/O thread finish.
+    # This fixes https://github.com/ClickHouse/ClickHouse/issues/67108 and https://github.com/ClickHouse/ClickHouse/issues/93452
+    for _retry in {1..20}; do
+        ${CLICKHOUSE_CLIENT} -q "system flush logs opentelemetry_span_log"
+        _gateway_count=$(${CLICKHOUSE_CLIENT} -q "
+            select count() from system.opentelemetry_span_log
+            where finish_date >= yesterday()
+              AND trace_id = UUIDNumToString(toFixedString(unhex('$trace_id'), 16))
+              and parent_span_id = reinterpretAsUInt64(unhex('73'))
+        ")
+        if [[ "$_gateway_count" -gt 0 ]]; then
+            break
+        fi
+        sleep 0.1
+    done
+
 ${CLICKHOUSE_CLIENT} --format=JSONEachRow -q "
 set enable_analyzer = 1;
-system flush logs opentelemetry_span_log;
+-- Spans are already flushed by the retry loop above.
 
 -- Show queries sorted by start time.
 select attribute['db.statement'] as query,


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

This probably fixes https://github.com/ClickHouse/ClickHouse/issues/67108 and https://github.com/ClickHouse/ClickHouse/issues/93452

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts a shell-based integration test to tolerate delayed span logging; no production code changes.
> 
> **Overview**
> Reduces flakiness in `01455_opentelemetry_distributed.sh` by adding a short retry loop that repeatedly flushes `opentelemetry_span_log` and waits until the expected gateway span appears before running assertions.
> 
> Removes the one-off `system flush logs` call inside the main query block since spans are now flushed during the retry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 622f9bb3faf48a73ec4de555c2e6f911fb306ccf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.428`
<!-- ch-version-info:end -->