### PR TITLE
Add trace logging to Throttler to diagnose under-throttling

### DIFF
--- a/src/Common/Throttler.cpp
+++ b/src/Common/Throttler.cpp
@@ -3,6 +3,7 @@
 #include <Common/Exception.h>
 #include <Common/Stopwatch.h>
 #include <Common/CurrentThread.h>
+#include <Common/logger_useful.h>
 #include <IO/WriteHelpers.h>
 
 #include <base/scope_guard.h>
@@ -26,6 +27,19 @@ namespace ErrorCodes
 /// Just 10^9.
 static constexpr auto NS = 1000000000UL;
 
+static auto & getLogger()
+{
+    static auto logger = ::getLogger("Throttler");
+    return logger;
+}
+
+void Throttler::logCreation()
+{
+    std::lock_guard lock(mutex);
+    LOG_TRACE(getLogger(), "Create throttler: this={}, speed={}, burst={}, limit={}, parent={}",
+        fmt::ptr(this), max_speed, max_burst, limit, fmt::ptr(parent.get()));
+}
+
 Throttler::Throttler(size_t max_speed_, const ThrottlerPtr & parent_,
         ProfileEvents::Event event_amount_,
         ProfileEvents::Event event_sleep_us_)
@@ -36,13 +50,16 @@ Throttler::Throttler(size_t max_speed_, const ThrottlerPtr & parent_,
     , parent(parent_)
     , event_amount(event_amount_)
     , event_sleep_us(event_sleep_us_)
-{}
+{
+    logCreation();
+}
 
 Throttler::Throttler(size_t max_speed_,
         ProfileEvents::Event event_amount_,
         ProfileEvents::Event event_sleep_us_)
     : Throttler(max_speed_, nullptr, event_amount_, event_sleep_us_)
-{}
+{
+}
 
 Throttler::Throttler(size_t max_speed_, size_t limit_, const char * limit_exceeded_exception_message_, const ThrottlerPtr & parent_)
     : max_speed(max_speed_)
@@ -51,7 +68,9 @@ Throttler::Throttler(size_t max_speed_, size_t limit_, const char * limit_exceed
     , limit_exceeded_exception_message(limit_exceeded_exception_message_)
     , tokens(static_cast<double>(max_burst))
     , parent(parent_)
-{}
+{
+    logCreation();
+}
 
 bool Throttler::throttle(size_t amount, size_t max_block_ns)
 {
@@ -90,8 +109,18 @@ bool Throttler::throttle(size_t amount, size_t max_block_ns)
             ? std::numeric_limits<UInt64>::max()
             : static_cast<UInt64>(block_ns_double);
 
+        UInt64 sleep_ns = std::min<UInt64>(max_block_ns, block_ns);
+
+        LOG_TRACE(getLogger(), "Throttle sleep: this={}, amount={}, tokens={:.0f}, count={}, speed={}, burst={}, sleep={:.3f}ms",
+            fmt::ptr(this), amount, tokens_value, count_value, max_speed_value, max_speed_value * default_burst_seconds, static_cast<double>(sleep_ns) / 1e6);
+
         // Note that throwing exception from the following blocking call is safe. It is important for query cancellation.
-        sleepForNanoseconds(std::min<UInt64>(max_block_ns, block_ns));
+        sleepForNanoseconds(sleep_ns);
+    }
+    else if (max_speed_value > 0)
+    {
+        LOG_TEST(getLogger(), "Throttle pass: this={}, amount={}, tokens={:.0f}, count={}, speed={}",
+            fmt::ptr(this), amount, tokens_value, count_value, max_speed_value);
     }
 
     bool parent_block = false;
@@ -164,6 +193,9 @@ UInt64 Throttler::getMaxBurst() const
 void Throttler::setMaxSpeed(size_t max_speed_)
 {
     std::lock_guard lock(mutex);
+
+    LOG_TRACE(getLogger(), "Set max speed: this={}, old_speed={}, new_speed={}, tokens={:.0f}, count={}",
+        fmt::ptr(this), max_speed, max_speed_, tokens, count);
 
     max_speed = max_speed_;
     max_burst = max_speed_ * default_burst_seconds;

--- a/src/Common/Throttler.h
+++ b/src/Common/Throttler.h
@@ -25,14 +25,14 @@ public:
             ProfileEvents::Event event_sleep_us_ = ProfileEvents::end())
         : max_speed(max_speed_), max_burst(max_burst_), limit_exceeded_exception_message(""), tokens(static_cast<double>(max_burst)), parent(parent_)
         , event_amount(event_amount_), event_sleep_us(event_sleep_us_)
-    {}
+    { logCreation(); }
 
     Throttler(size_t max_speed_, size_t max_burst_,
             ProfileEvents::Event event_amount_ = ProfileEvents::end(),
             ProfileEvents::Event event_sleep_us_ = ProfileEvents::end())
         : max_speed(max_speed_), max_burst(max_burst_), limit_exceeded_exception_message(""), tokens(static_cast<double>(max_burst))
         , event_amount(event_amount_), event_sleep_us(event_sleep_us_)
-    {}
+    { logCreation(); }
 
     explicit Throttler(size_t max_speed_, const ThrottlerPtr & parent_ = nullptr,
         ProfileEvents::Event event_amount_ = ProfileEvents::end(),
@@ -44,7 +44,7 @@ public:
 
     Throttler(size_t max_speed_, size_t max_burst_, size_t limit_, const char * limit_exceeded_exception_message_,
               const ThrottlerPtr & parent_ = nullptr)
-        : max_speed(max_speed_), max_burst(max_burst_), limit(limit_), limit_exceeded_exception_message(limit_exceeded_exception_message_), tokens(static_cast<double>(max_burst)), parent(parent_) {}
+        : max_speed(max_speed_), max_burst(max_burst_), limit(limit_), limit_exceeded_exception_message(limit_exceeded_exception_message_), tokens(static_cast<double>(max_burst)), parent(parent_) { logCreation(); }
 
     Throttler(size_t max_speed_, size_t limit_, const char * limit_exceeded_exception_message_,
               const ThrottlerPtr & parent_ = nullptr);
@@ -72,6 +72,7 @@ public:
     void setMaxSpeed(size_t max_speed_);
 
 private:
+    void logCreation();
     void throttleImpl(size_t amount, size_t & count_value, double & tokens_value);
     void throttleImpl(size_t amount, size_t & count_value, double & tokens_value, size_t & max_speed_value);
 

--- a/tests/integration/test_throttling/test.py
+++ b/tests/integration/test_throttling/test.py
@@ -35,7 +35,7 @@ def elapsed(node, query, **kwargs):
     # Flush logs to ensure the query appears in system.query_log
     node.query("SYSTEM FLUSH LOGS query_log")
 
-    # Get the server-side query duration from system.query_log using the query_id
+    # Get the server-side query duration and throttling profile events from system.query_log
     duration_result = node.query(
         f"""
         SELECT query_duration_ms / 1000.0 as duration
@@ -45,6 +45,28 @@ def elapsed(node, query, **kwargs):
         LIMIT 1
         """
     )
+
+    # Log throttling-related ProfileEvents for diagnosis
+    throttle_info = node.query(
+        f"""
+        SELECT
+            ProfileEvents['LocalWriteThrottlerBytes'] AS write_throttled_bytes,
+            ProfileEvents['LocalWriteThrottlerSleepMicroseconds'] AS write_sleep_us,
+            ProfileEvents['LocalReadThrottlerBytes'] AS read_throttled_bytes,
+            ProfileEvents['LocalReadThrottlerSleepMicroseconds'] AS read_sleep_us,
+            ProfileEvents['RemoteWriteThrottlerBytes'] AS remote_write_throttled_bytes,
+            ProfileEvents['RemoteWriteThrottlerSleepMicroseconds'] AS remote_write_sleep_us,
+            ProfileEvents['RemoteReadThrottlerBytes'] AS remote_read_throttled_bytes,
+            ProfileEvents['RemoteReadThrottlerSleepMicroseconds'] AS remote_read_sleep_us
+        FROM system.query_log
+        WHERE type = 'QueryFinish'
+          AND query_id = '{query_id}'
+        LIMIT 1
+        """
+    )
+    print(f"Query: {query[:80]}...")
+    print(f"  Throttle profile events: {throttle_info.strip()}")
+
     duration = float(duration_result.strip())
     return ret, duration
 


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/ClickHouse/ClickHouse/pull/98451#pullrequestreview-3875832974

The `test_throttling` integration tests sometimes fail because throttled operations complete faster than the Token Bucket Filter algorithm should allow. As @serxa pointed out, the TBF algorithm inserts sleeps, so execution time should always be >= the cumulative sleep time — but this invariant sometimes fails.

This PR adds trace-level logging to the `Throttler` class to help diagnose the root cause:

- **Throttler creation**: logs address, speed, burst, limit, and parent pointer — to identify which throttler objects exist
- **Blocking throttle calls**: logs amount, token state, cumulative count, speed, and sleep duration — to trace how much data passes through each throttler
- **`setMaxSpeed` calls**: logs old/new speed and current token state — to track dynamic config reloads
- **Non-blocking throttle calls**: at Test log level for full tracing when needed
- **Test `ProfileEvents` output**: prints `LocalWriteThrottlerBytes`, sleep microseconds, etc. for each measured query

With this logging, we can verify:
1. Whether the total bytes passing through the throttler match the expected ~8MB
2. Whether the throttler parameters (speed=2000000, burst=2000000) are correct
3. Whether any writes bypass the throttler

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)