### PR TITLE
Fix distributed index analysis with expressions in PK

### DIFF
--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -2312,7 +2312,10 @@ ReadFromMergeTree::AnalysisResultPtr ReadFromMergeTree::selectRangesToRead(
             query_info_,
             metadata_snapshot);
 
-    NameSet indexes_column_names(primary_key_column_names.begin(), primary_key_column_names.end());
+    NameSet indexes_column_names;
+    /// We need not only PK columns, but source columns for this PK calculation as well
+    if (auto required_columns = primary_key.expression->getRequiredColumns(); !required_columns.empty())
+        indexes_column_names.insert(required_columns.begin(), required_columns.end());
     for (const auto & skip_index : indexes->skip_indexes.useful_indices)
     {
         const auto & skip_index_required_columns = skip_index.index->getColumnsRequiredForIndexCalc();

--- a/tests/queries/0_stateless/03836_distributed_index_analysis_pk_expression.reference
+++ b/tests/queries/0_stateless/03836_distributed_index_analysis_pk_expression.reference
@@ -1,0 +1,19 @@
+100
+distributed_index_analysis=0
+{
+  "Type": "PrimaryKey",
+  "Condition": "(toStartOfMinute(timestamp) in [1704063900, 1704063900])",
+  "Initial Parts": 100,
+  "Selected Parts": 1,
+  "Initial Granules": 100,
+  "Selected Granules": 1
+}
+distributed_index_analysis=1
+{
+  "Type": "PrimaryKey",
+  "Condition": "(toStartOfMinute(timestamp) in [1704063900, 1704063900])",
+  "Initial Parts": 100,
+  "Selected Parts": 1,
+  "Initial Granules": 100,
+  "Selected Granules": 1
+}

--- a/tests/queries/0_stateless/03836_distributed_index_analysis_pk_expression.sh
+++ b/tests/queries/0_stateless/03836_distributed_index_analysis_pk_expression.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Tags: no-random-merge-tree-settings, no-random-settings
+# - no-random-merge-tree-settings -- may change number of parts
+
+# There will be warnings in logs for unavailable replicas that we have in parallel_replicas cluster.
+CLICKHOUSE_CLIENT_SERVER_LOGS_LEVEL=error
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# Test that distributed index analysis works correctly when PK contains
+# expressions over columns (e.g. toStartOfMinute(timestamp)), not just
+# plain column references.
+
+$CLICKHOUSE_CLIENT -nm -q "
+  drop table if exists test_pk_expr;
+  create table test_pk_expr (timestamp DateTime64(9), value Int)
+    engine=MergeTree()
+    order by toStartOfMinute(timestamp)
+    settings
+      distributed_index_analysis_min_parts_to_activate=0,
+      distributed_index_analysis_min_indexes_bytes_to_activate=0;
+  system stop merges test_pk_expr;
+  insert into test_pk_expr select toDateTime64('2024-01-01 00:00:00', 9) + number, number from numbers(1e6)
+    settings max_block_size=10000, min_insert_block_size_rows=10000, max_insert_threads=1;
+  select count() from system.parts where database = currentDatabase() and table = 'test_pk_expr' and active;
+"
+
+function jq_pk_filter()
+{
+  jq '.. | objects | select(has("Indexes")) | .Indexes[]? | select(.Type == "PrimaryKey") | {
+    "Type": .Type,
+    "Condition": .Condition,
+    "Initial Parts": ."Initial Parts",
+    "Selected Parts": ."Selected Parts",
+    "Initial Granules": ."Initial Granules",
+    "Selected Granules": ."Selected Granules"
+  }'
+}
+
+echo "distributed_index_analysis=0"
+$CLICKHOUSE_CLIENT --format=LineAsString -q "
+  explain indexes=1, json=1
+  select * from test_pk_expr
+  where timestamp = toDateTime64('2024-01-01 00:05:00', 9)
+" | jq_pk_filter
+
+echo "distributed_index_analysis=1"
+explain_opts=(
+  --format=LineAsString
+  --cluster_for_parallel_replicas=parallel_replicas
+  --distributed_index_analysis=1
+  --max_parallel_replicas=11
+)
+$CLICKHOUSE_CLIENT "${explain_opts[@]}" -q "
+  explain indexes=1, json=1
+  select * from test_pk_expr
+  where timestamp = toDateTime64('2024-01-01 00:05:00', 9)
+" | jq_pk_filter

--- a/tests/queries/0_stateless/03836_distributed_index_analysis_skip_index_expression.reference
+++ b/tests/queries/0_stateless/03836_distributed_index_analysis_skip_index_expression.reference
@@ -1,0 +1,19 @@
+100
+with skip index, distributed_index_analysis=0
+{
+  "Type": "Skip",
+  "Condition": "(toStartOfHour(timestamp) in [1704063600, 1704063600])",
+  "Initial Parts": 100,
+  "Selected Parts": 1,
+  "Initial Granules": 100,
+  "Selected Granules": 1
+}
+with skip index, distributed_index_analysis=1 (wrong Condition, correct Selected Granules)
+{
+  "Type": "PrimaryKey",
+  "Condition": "true",
+  "Initial Parts": 100,
+  "Selected Parts": 1,
+  "Initial Granules": 100,
+  "Selected Granules": 1
+}

--- a/tests/queries/0_stateless/03836_distributed_index_analysis_skip_index_expression.sh
+++ b/tests/queries/0_stateless/03836_distributed_index_analysis_skip_index_expression.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Tags: no-random-merge-tree-settings, no-random-settings
+# - no-random-merge-tree-settings -- may change number of parts
+
+# There will be warnings in logs for unavailable replicas that we have in parallel_replicas cluster.
+CLICKHOUSE_CLIENT_SERVER_LOGS_LEVEL=error
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# Test that distributed index analysis works correctly when skip index contains
+# expressions over columns (e.g. toStartOfMinute(timestamp)), not just plain
+# column references.
+
+explain_opts=(
+  --format=LineAsString
+  --cluster_for_parallel_replicas=parallel_replicas
+  --distributed_index_analysis=1
+  --max_parallel_replicas=11
+)
+
+function jq_pk_filter()
+{
+  jq '.. | objects | select(has("Indexes")) | .Indexes[]? | {
+    "Type": .Type,
+    "Condition": .Condition,
+    "Initial Parts": ."Initial Parts",
+    "Selected Parts": ."Selected Parts",
+    "Initial Granules": ."Initial Granules",
+    "Selected Granules": ."Selected Granules"
+  }'
+}
+
+$CLICKHOUSE_CLIENT -nm -q "
+  drop table if exists test_skip_with_expr;
+  create table test_skip_with_expr (timestamp DateTime64(9), value Int,
+    index ts_idx toStartOfHour(timestamp) type minmax granularity 1)
+    engine=MergeTree()
+    order by ()
+    settings
+      index_granularity=8192,
+      index_granularity_bytes=10e6,
+      distributed_index_analysis_min_parts_to_activate=0,
+      distributed_index_analysis_min_indexes_bytes_to_activate=0;
+  system stop merges test_skip_with_expr;
+  insert into test_skip_with_expr select toDateTime64('2024-01-01 00:00:00', 9) + number, number from numbers(1e6)
+    settings max_block_size=10000, min_insert_block_size_rows=10000, max_insert_threads=1;
+  select count() from system.parts where database = currentDatabase() and table = 'test_skip_with_expr' and active;
+"
+
+echo "with skip index, distributed_index_analysis=0"
+$CLICKHOUSE_CLIENT --format=LineAsString -q "
+  explain indexes=1, json=1
+  select * from test_skip_with_expr
+  where timestamp = toDateTime64('2024-01-01 00:05:00', 9)
+" | jq_pk_filter
+
+echo "with skip index, distributed_index_analysis=1 (wrong Condition, correct Selected Granules)"
+$CLICKHOUSE_CLIENT "${explain_opts[@]}" -q "
+  explain indexes=1, json=1
+  select * from test_skip_with_expr
+  where timestamp = toDateTime64('2024-01-01 00:05:00', 9)
+" | jq_pk_filter


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix distributed index analysis with expressions (not just columns) in PK (leads to zero filtering of redundant granules on remote replicas)

Previously we do not add source PK columns, and later tryBuildAdditionalFilterAST() ignores them, and this leads to lack of PK analysis on remote replicas.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.351`
- Backported to: `26.2.4.12`
<!-- ch-version-info:end -->