### PR TITLE
Add functions getKeeperConfig and zookeeperFourLetterWordCommand.

### DIFF
--- a/src/Functions/getKeeperConfig.cpp
+++ b/src/Functions/getKeeperConfig.cpp
@@ -1,0 +1,161 @@
+#include <Functions/IFunction.h>
+#include <Functions/FunctionFactory.h>
+#include <Functions/FunctionHelpers.h>
+#include <DataTypes/DataTypeString.h>
+#include <Interpreters/Context.h>
+#include <Common/ZooKeeper/ZooKeeper.h>
+
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int ILLEGAL_TYPE_OF_ARGUMENT;
+    extern const int ILLEGAL_COLUMN;
+    extern const int BAD_ARGUMENTS;
+}
+
+namespace
+{
+
+/// Get the keeper configuration by executing get('/keeper/config')
+class FunctionGetKeeperConfig : public IFunction, WithContext
+{
+public:
+    static constexpr auto name = "getKeeperConfig";
+
+    static FunctionPtr create(ContextPtr context_) { return std::make_shared<FunctionGetKeeperConfig>(context_); }
+    explicit FunctionGetKeeperConfig(ContextPtr context_) : WithContext(context_) {}
+
+    String getName() const override { return name; }
+    bool isDeterministic() const override { return false; }
+    bool isDeterministicInScopeOfQuery() const override { return false; }
+    bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return false; }
+    size_t getNumberOfArguments() const override { return 0; }
+    bool isVariadic() const override { return true; }
+    ColumnNumbers getArgumentsThatAreAlwaysConstant() const override { return {0}; }
+
+    DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override
+    {
+        if (arguments.size() > 1)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                            "Function {} accepts at most 1 argument (keeper_name), got {}",
+                            String{name}, arguments.size());
+
+        if (!arguments.empty() && !isString(arguments[0].type))
+            throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
+                            "The argument of function {} should be a string with the name of a keeper",
+                            String{name});
+
+        return std::make_shared<DataTypeString>();
+    }
+
+    ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const override
+    {
+        String config_value = getConfigValue(arguments);
+        return result_type->createColumnConst(input_rows_count, config_value);
+    }
+
+private:
+    String getConfigValue(const ColumnsWithTypeAndName & arguments) const
+    {
+        String keeper_name = "default";
+
+        // If argument is provided, use it as keeper name
+        if (!arguments.empty())
+        {
+            if (!isString(arguments[0].type))
+                throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
+                                "The argument of function {} should be a constant string with the name of a keeper",
+                                String{name});
+
+            const auto * column = arguments[0].column.get();
+            if (!column || !checkAndGetColumnConstStringOrFixedString(column))
+                throw Exception(ErrorCodes::ILLEGAL_COLUMN,
+                                "The argument of function {} should be a constant string with the name of a keeper",
+                                String{name});
+
+            keeper_name = String{column->getDataAt(0).toView()};
+        }
+
+        // Get the keeper session from context
+        zkutil::ZooKeeperPtr keeper;
+        if (keeper_name == "default")
+        {
+            keeper = getContext()->getZooKeeper();
+        }
+        else
+        {
+            keeper = getContext()->getAuxiliaryZooKeeper(keeper_name);
+        }
+
+        if (!keeper)
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "Cannot get keeper session for '{}'",
+                keeper_name);
+
+        // Execute get('/keeper/config')
+        String config_value;
+        try
+        {
+            config_value = keeper->get("/keeper/config");
+        }
+        catch (...)
+        {
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "Failed to get '/keeper/config' from keeper '{}': {}",
+                keeper_name,
+                getCurrentExceptionMessage(false));
+        }
+
+        return config_value;
+    }};
+
+}
+
+REGISTER_FUNCTION(GetKeeperConfig)
+{
+    FunctionDocumentation::Description description = R"(
+Returns the configuration from the specified keeper by executing get('/keeper/config').
+If no keeper name is provided, uses the default keeper.
+)";
+    FunctionDocumentation::Syntax syntax = "getKeeperConfig([keeper_name])";
+    FunctionDocumentation::Arguments arguments = {
+        {"keeper_name", "The name of the keeper (e.g., 'default' or auxiliary keeper name). Optional, defaults to 'default'.", {"String"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the keeper configuration as a string.", {"String"}};
+    FunctionDocumentation::Examples examples = {
+    {
+        "Usage with default keeper",
+        R"(
+SELECT getKeeperConfig();
+        )",
+        R"(
+┌─getKeeperConfig()─┐
+│ server_id=1       │
+└───────────────────┘
+        )"
+    },
+    {
+        "Usage with specified keeper",
+        R"(
+SELECT getKeeperConfig('default');
+        )",
+        R"(
+┌─getKeeperConfig('default')─┐
+│ server_id=1                │
+└────────────────────────────┘
+        )"
+    }
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {24, 1};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Other;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
+
+    factory.registerFunction<FunctionGetKeeperConfig>(documentation, FunctionFactory::Case::Sensitive);
+}
+
+}

--- a/src/Functions/zookeeperFourLetterWordCommand.cpp
+++ b/src/Functions/zookeeperFourLetterWordCommand.cpp
@@ -1,0 +1,192 @@
+#include <Columns/ColumnString.h>
+#include <DataTypes/DataTypeString.h>
+#include <Functions/FunctionFactory.h>
+#include <Functions/IFunction.h>
+#include <Functions/FunctionHelpers.h>
+#include <IO/ReadBufferFromPocoSocket.h>
+#include <IO/WriteBufferFromPocoSocket.h>
+#include <IO/ReadHelpers.h>
+#include <Poco/Net/StreamSocket.h>
+#include <Poco/Net/SocketAddress.h>
+#include <Common/Exception.h>
+
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int ILLEGAL_TYPE_OF_ARGUMENT;
+    extern const int BAD_ARGUMENTS;
+    extern const int ILLEGAL_COLUMN;
+    extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
+}
+
+namespace
+{
+
+class FunctionZookeeperFourLetterWordCommand : public IFunction
+{
+public:
+    static constexpr auto name = "zookeeperFourLetterWordCommand";
+
+    static FunctionPtr create(ContextPtr) { return std::make_shared<FunctionZookeeperFourLetterWordCommand>(); }
+
+    String getName() const override { return name; }
+    bool isDeterministic() const override { return false; }
+    bool isDeterministicInScopeOfQuery() const override { return false; }
+    bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return false; }
+    size_t getNumberOfArguments() const override { return 2; }
+    ColumnNumbers getArgumentsThatAreAlwaysConstant() const override { return {0, 1}; }
+
+    DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override
+    {
+        if (arguments.size() != 2)
+            throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH,
+                            "Function {} requires exactly 2 arguments (keeper_host:port, command), got {}",
+                            String{name}, arguments.size());
+
+        if (!isString(arguments[0].type))
+            throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
+                            "The first argument of function {} should be a string with keeper host:port",
+                            String{name});
+
+        if (!isString(arguments[1].type))
+            throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
+                            "The second argument of function {} should be a string with the command",
+                            String{name});
+
+        return std::make_shared<DataTypeString>();
+    }
+
+    ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t input_rows_count) const override
+    {
+        const auto * host_port_column = checkAndGetColumnConstStringOrFixedString(arguments[0].column.get());
+        if (!host_port_column)
+            throw Exception(ErrorCodes::ILLEGAL_COLUMN,
+                            "The first argument of function {} should be a constant string with keeper host:port",
+                            String{name});
+
+        const auto * command_column = checkAndGetColumnConstStringOrFixedString(arguments[1].column.get());
+        if (!command_column)
+            throw Exception(ErrorCodes::ILLEGAL_COLUMN,
+                            "The second argument of function {} should be a constant string with the command",
+                            String{name});
+
+        String host_port = String{host_port_column->getDataAt(0).toView()};
+        String command = String{command_column->getDataAt(0).toView()};
+
+        String result = executeFourLetterCommand(host_port, command);
+
+        auto result_column = ColumnString::create();
+        for (size_t i = 0; i < input_rows_count; ++i)
+            result_column->insert(result);
+
+        return result_column;
+    }
+
+private:
+    String executeFourLetterCommand(const String & host_port, const String & command) const
+    {
+        try
+        {
+            // Parse host:port
+            auto colon_pos = host_port.find(':');
+            if (colon_pos == String::npos)
+                throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                                "Invalid host:port format '{}', expected format: 'host:port'",
+                                host_port);
+
+            // Create socket connection
+            Poco::Net::StreamSocket socket;
+
+            // Default timeouts: 10 seconds (10000 ms)
+            constexpr int default_timeout_ms = 10000;
+
+            socket.connect(Poco::Net::SocketAddress{host_port}, default_timeout_ms * 1000);
+            socket.setReceiveTimeout(default_timeout_ms * 1000);
+            socket.setSendTimeout(default_timeout_ms * 1000);
+            socket.setNoDelay(true);
+
+            ReadBufferFromPocoSocket in(socket);
+            WriteBufferFromPocoSocket out(socket);
+
+            // Send command
+            out.write(command.data(), command.size());
+            out.next();
+            out.finalize();
+
+            // Read response
+            String result;
+            readStringUntilEOF(result, in);
+            in.next();
+
+            return result;
+        }
+        catch (const Exception &)
+        {
+            throw;
+        }
+        catch (const Poco::Exception & e)
+        {
+            throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                            "Failed to execute four letter word command '{}' on '{}': {}",
+                            command, host_port, e.displayText());
+        }
+        catch (...)
+        {
+            throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                            "Failed to execute four letter word command '{}' on '{}': {}",
+                            command, host_port, getCurrentExceptionMessage(false));
+        }
+    }
+};
+
+}
+
+REGISTER_FUNCTION(ZookeeperFourLetterWordCommand)
+{
+    FunctionDocumentation::Description description = R"(
+Executes a four-letter word command on the specified ZooKeeper/Keeper server.
+Four-letter word commands are special administrative commands that ZooKeeper supports.
+)";
+    FunctionDocumentation::Syntax syntax = "zookeeperFourLetterWordCommand(keeper_host_port, command)";
+    FunctionDocumentation::Arguments arguments = {
+        {"keeper_host_port", "The keeper server address in format 'host:port' (e.g., 'localhost:9181').", {"String"}},
+        {"command", "The four-letter word command to execute (e.g., 'ruok', 'stat', 'conf').", {"String"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the command response as a string.", {"String"}};
+    FunctionDocumentation::Examples examples = {
+    {
+        "Check if keeper is running",
+        R"(
+SELECT zookeeperFourLetterWordCommand('localhost:9181', 'ruok');
+        )",
+        R"(
+┌─zookeeperFourLetterWordCommand('localhost:9181', 'ruok')─┐
+│ imok                                                      │
+└───────────────────────────────────────────────────────────┘
+        )"
+    },
+    {
+        "Get keeper statistics",
+        R"(
+SELECT zookeeperFourLetterWordCommand('localhost:9181', 'stat');
+        )",
+        R"(
+┌─zookeeperFourLetterWordCommand('localhost:9181', 'stat')─┐
+│ ZooKeeper version: 3.8.0                                 │
+│ Latency min/avg/max: 0/0/0                               │
+│ ...                                                       │
+└───────────────────────────────────────────────────────────┘
+        )"
+    }
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {24, 1};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Other;
+    FunctionDocumentation documentation = {description, syntax, arguments, returned_value, examples, introduced_in, category};
+
+    factory.registerFunction<FunctionZookeeperFourLetterWordCommand>(documentation, FunctionFactory::Case::Sensitive);
+}
+
+}

--- a/tests/integration/test_keeper_functions/configs/zookeeper_config.xml
+++ b/tests/integration/test_keeper_functions/configs/zookeeper_config.xml
@@ -1,0 +1,17 @@
+
+<clickhouse>
+    <zookeeper>
+        <node index="1">
+            <host>zoo1</host>
+            <port>2181</port>
+        </node>
+    </zookeeper>
+    <auxiliary_zookeepers>
+        <zookeeper2>
+            <node index="1">
+                <host>zoo2</host>
+                <port>2181</port>
+            </node>
+        </zookeeper2>
+    </auxiliary_zookeepers>
+</clickhouse>

--- a/tests/integration/test_keeper_functions/test.py
+++ b/tests/integration/test_keeper_functions/test.py
@@ -1,0 +1,176 @@
+import re
+import pytest
+from helpers.cluster import ClickHouseCluster
+from helpers.client import QueryRuntimeException
+
+
+cluster = ClickHouseCluster(__file__, with_zookeeper=True)
+node1 = cluster.add_instance(
+    "node1",
+    main_configs=["configs/zookeeper_config.xml"],
+    with_zookeeper=True,
+)
+
+node2 = cluster.add_instance(
+    "node2",
+    main_configs=["configs/zookeeper_config.xml"],
+    with_zookeeper=True,
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+# =====================================================================
+# Tests for getKeeperConfig
+# =====================================================================
+
+def test_get_keeper_config_default():
+    """Test getKeeperConfig() with default keeper (no arguments).
+    The return value looks like:
+        server.1=zoo1:9234;participant;1
+        server.2=zoo2:9234;participant;1
+        ...
+    """
+    result = node1.query("SELECT getKeeperConfig()").strip()
+    assert len(result) > 0, "getKeeperConfig() should return a non-empty config string"
+    # Each line should match the pattern: server.<id>=<host>:<port>;participant;<weight>
+    lines = result.split("\n")
+    for line in lines:
+        assert re.match(r"server\.\d+=.+:\d+;participant;\d+", line.strip()), \
+            f"Unexpected config line format: '{line}'"
+
+
+def test_get_keeper_config_explicit_default():
+    """Test getKeeperConfig('default') with explicitly specified default keeper."""
+    result = node1.query("SELECT getKeeperConfig('default')").strip()
+    assert len(result) > 0, "getKeeperConfig('default') should return a non-empty config string"
+    # Verify the result contains server entries in the expected format
+    assert "server." in result, "Config should contain 'server.' entries"
+    assert "participant" in result, "Config should contain 'participant' entries"
+
+
+def test_get_keeper_config_default_consistency():
+    """Test that getKeeperConfig() and getKeeperConfig('default') return the same result."""
+    result_no_arg = node1.query("SELECT getKeeperConfig()").strip()
+    result_default = node1.query("SELECT getKeeperConfig('default')").strip()
+    assert result_no_arg == result_default, \
+        "getKeeperConfig() and getKeeperConfig('default') should return the same result"
+
+
+def test_get_keeper_config_auxiliary_keeper():
+    """Test getKeeperConfig('zookeeper2') with the auxiliary keeper."""
+    result = node1.query("SELECT getKeeperConfig('zookeeper2')").strip()
+    assert len(result) > 0, "getKeeperConfig('zookeeper2') should return a non-empty config string"
+    # Verify the result follows the server.N=host:port;participant;weight format
+    assert "server." in result, "Auxiliary keeper config should contain 'server.' entries"
+    assert "participant" in result, "Auxiliary keeper config should contain 'participant' entries"
+
+
+def test_get_keeper_config_different_keepers():
+    """Test that default and auxiliary keepers may return different configs."""
+    result_default = node1.query("SELECT getKeeperConfig()").strip()
+    result_aux = node1.query("SELECT getKeeperConfig('zookeeper2')").strip()
+    # Both should be non-empty and follow the server.N=... format
+    assert len(result_default) > 0
+    assert len(result_aux) > 0
+    assert "server." in result_default
+    assert "server." in result_aux
+
+
+def test_get_keeper_config_nonexistent_keeper():
+    """Test getKeeperConfig with a non-existent keeper name raises an error."""
+    with pytest.raises(QueryRuntimeException):
+        node1.query("SELECT getKeeperConfig('nonexistent_keeper')")
+
+
+def test_get_keeper_config_on_different_workers():
+    """Test that getKeeperConfig() returns the same result on different workers."""
+    result_w1 = node1.query("SELECT getKeeperConfig()").strip()
+    result_w2 = node2.query("SELECT getKeeperConfig()").strip()
+    assert result_w1 == result_w2, \
+        "getKeeperConfig() should return the same config from different workers"
+
+
+# =====================================================================
+# Tests for zookeeperFourLetterWordCommand
+# =====================================================================
+
+def test_four_letter_word_ruok():
+    """Test the 'ruok' four-letter word command on the default keeper."""
+    keeper_host_port = "zoo1:2181"
+    result = node1.query(
+        f"SELECT zookeeperFourLetterWordCommand('{keeper_host_port}', 'ruok')"
+    ).strip()
+    assert result == "imok", f"Expected 'imok', got '{result}'"
+
+
+def test_four_letter_word_ruok_auxiliary_keeper():
+    """Test the 'ruok' four-letter word command on the auxiliary keeper."""
+    keeper_host_port = "zoo2:2181"
+    result = node1.query(
+        f"SELECT zookeeperFourLetterWordCommand('{keeper_host_port}', 'ruok')"
+    ).strip()
+    assert result == "imok", f"Expected 'imok', got '{result}'"
+
+
+def test_four_letter_word_conf():
+    """Test the 'conf' four-letter word command."""
+    keeper_host_port = "zoo1:2181"
+    result = node1.query(
+        f"SELECT zookeeperFourLetterWordCommand('{keeper_host_port}', 'conf')"
+    ).strip()
+    # The 'conf' command returns configuration info, should be non-empty
+    assert len(result) > 0, "'conf' command should return a non-empty string"
+
+
+def test_four_letter_word_stat():
+    """Test the 'stat' four-letter word command."""
+    keeper_host_port = "zoo1:2181"
+    result = node1.query(
+        f"SELECT zookeeperFourLetterWordCommand('{keeper_host_port}', 'stat')"
+    ).strip()
+    assert len(result) > 0, "'stat' command should return a non-empty string"
+
+
+def test_four_letter_word_mntr():
+    """Test the 'mntr' four-letter word command."""
+    keeper_host_port = "zoo1:2181"
+    result = node1.query(
+        f"SELECT zookeeperFourLetterWordCommand('{keeper_host_port}', 'mntr')"
+    ).strip()
+    assert len(result) > 0, "'mntr' command should return a non-empty string"
+
+
+def test_four_letter_word_invalid_host():
+    """Test zookeeperFourLetterWordCommand with invalid host:port raises an error."""
+    with pytest.raises(QueryRuntimeException):
+        node1.query(
+            "SELECT zookeeperFourLetterWordCommand('invalid_host:9999', 'ruok')"
+        )
+
+
+def test_four_letter_word_invalid_format():
+    """Test zookeeperFourLetterWordCommand with invalid address format (no port) raises an error."""
+    with pytest.raises(QueryRuntimeException):
+        node1.query(
+            "SELECT zookeeperFourLetterWordCommand('zoo1', 'ruok')"
+        )
+
+
+def test_four_letter_word_on_different_workers():
+    """Test that zookeeperFourLetterWordCommand returns the same result from different workers."""
+    keeper_host_port = "zoo1:2181"
+    result_w1 = node1.query(
+        f"SELECT zookeeperFourLetterWordCommand('{keeper_host_port}', 'ruok')"
+    ).strip()
+    result_w2 = node2.query(
+        f"SELECT zookeeperFourLetterWordCommand('{keeper_host_port}', 'ruok')"
+    ).strip()
+    assert result_w1 == result_w2 == "imok"


### PR DESCRIPTION
Add two new functions to interact with keeper.
- getKeeperConfig("keeper_name"): execute "get '/keeper/config'".
- zookeeperFourLetterWordCommand('host:port', 'command'): execute four letter word command.

Closes #95350.

### Changelog category (leave one):
- New Feature

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Add two new functions to interact with keeper: `getKeeperConfig` and `zookeeperFourLetterWordCommand`.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
