### PR TITLE
Destroy task in BackgroundExecutor without lock

### DIFF
--- a/src/Storages/MergeTree/MergeTreeBackgroundExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeBackgroundExecutor.cpp
@@ -216,7 +216,9 @@ void MergeTreeBackgroundExecutor<Queue>::removeTasksCorrespondingToStorage(Stora
         tasks_to_wait.reserve(active.size());
         for (auto & item : active)
         {
-            if (item->task->getStorageID() == id)
+            /// Use cached storage_id because task may be null during destruction
+            /// (resetTask already called but item still in active queue).
+            if (item->storage_id == id)
             {
                 item->is_currently_deleting = true;
                 tasks_to_wait.push_back(item);
@@ -251,19 +253,19 @@ void MergeTreeBackgroundExecutor<Queue>::routine(TaskRuntimeDataPtr item)
         active.erase(std::remove(active.begin(), active.end(), item_), active.end());
     };
 
-    auto release_task = [this] (TaskRuntimeDataPtr && item_) TSA_REQUIRES(mutex)
+    /// Destroy the task and clean up.
+    /// The item stays in `active` during resetTask so that removeTasksCorrespondingToStorage
+    /// can discover it (via cached storage_id) and wait for is_done.
+    /// Must be called WITHOUT holding the mutex.
+    auto release_task = [this, &erase_from_active] (TaskRuntimeDataPtr && item_) TSA_NO_THREAD_SAFETY_ANALYSIS
     {
-        /// We have to call reset() under a lock, otherwise a race is possible.
-        /// Imagine, that task is finally completed (last execution returned false),
-        /// we removed the task from both queues, but still have pointer.
-        /// The thread that shutdowns storage will scan queues in order to find some tasks to wait for, but will find nothing.
-        /// So, the destructor of a task and the destructor of a storage will be executed concurrently.
         std::optional<String> captured_storage_id;
         std::optional<String> captured_query_id;
         bool captured_was_deleting = item_->is_currently_deleting;
 
         Stopwatch destruction_watch;
 
+        /// Slow part: destroy the task outside the lock.
         NOEXCEPT_SCOPE({
             ALLOW_ALLOCATIONS_IN_SCOPE;
             if (item_->task)
@@ -273,8 +275,6 @@ void MergeTreeBackgroundExecutor<Queue>::routine(TaskRuntimeDataPtr item)
             }
             item_->resetTask();
         });
-        item_->is_done.set();
-        item_.reset();
 
 #if defined(SANITIZER) || !defined(NDEBUG)
         static constexpr auto THRESHOLD_MILLISECONDS = 10 * 1000ULL;
@@ -296,6 +296,13 @@ void MergeTreeBackgroundExecutor<Queue>::routine(TaskRuntimeDataPtr item)
                     captured_was_deleting);
             }
         });
+
+        /// Fast part: clean up under the lock.
+        LockGuardWithStopWatch lock(mutex, log, __PRETTY_FUNCTION__);
+        erase_from_active(item_);
+        has_tasks.notify_one();
+        item_->is_done.set();
+        item_.reset();
     };
 
     /// No TSA because of unique_lock
@@ -303,10 +310,10 @@ void MergeTreeBackgroundExecutor<Queue>::routine(TaskRuntimeDataPtr item)
     {
         {
             LockGuardWithStopWatch lock(mutex, log, __PRETTY_FUNCTION__);
-            erase_from_active(item_);
 
             if (!item_->is_currently_deleting)
             {
+                erase_from_active(item_);
                 /// After the `guard` destruction `item` has to be in moved from state
                 /// Not to own the object it points to.
                 /// Otherwise the destruction of the task won't be ordered with the destruction of the
@@ -323,20 +330,17 @@ void MergeTreeBackgroundExecutor<Queue>::routine(TaskRuntimeDataPtr item)
             item_->cancel();
         }
 
-        LockGuardWithStopWatch lock(mutex, log, __PRETTY_FUNCTION__);
+        /// release_task handles destruction outside the lock, then cleanup under the lock.
         release_task(std::move(item_));
     };
 
     String query_id;
 
-    auto complete_task = [this, &erase_from_active, &release_task] (TaskRuntimeDataPtr && item_)
+    auto complete_task = [this, &release_task] (TaskRuntimeDataPtr && item_)
     {
-        LockGuardWithStopWatch lock(mutex, log, __PRETTY_FUNCTION__);
-
-        erase_from_active(item_);
-        has_tasks.notify_one();
-
         {
+            LockGuardWithStopWatch lock(mutex, log, __PRETTY_FUNCTION__);
+
             Stopwatch watch_on_completed;
             ALLOW_ALLOCATIONS_IN_SCOPE;
             /// In a situation of a lack of memory this method can throw an exception,
@@ -351,6 +355,7 @@ void MergeTreeBackgroundExecutor<Queue>::routine(TaskRuntimeDataPtr item)
             }
         }
 
+        /// release_task handles destruction outside the lock, then cleanup under the lock.
         release_task(std::move(item_));
     };
 
@@ -387,10 +392,8 @@ void MergeTreeBackgroundExecutor<Queue>::routine(TaskRuntimeDataPtr item)
         }
 
         /// Release the task with exception context.
-        /// An exception context is needed to proper delete write buffers without finalization
-        LockGuardWithStopWatch lock(mutex, log, __PRETTY_FUNCTION__);
-        erase_from_active(item);
-        has_tasks.notify_one();
+        /// An exception context is needed to proper delete write buffers without finalization.
+        /// release_task handles destruction outside the lock, then cleanup under the lock.
         release_task(std::move(item));
         return;
     }

--- a/src/Storages/MergeTree/MergeTreeBackgroundExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeBackgroundExecutor.cpp
@@ -261,7 +261,6 @@ void MergeTreeBackgroundExecutor<Queue>::routine(TaskRuntimeDataPtr item)
     {
         std::optional<String> captured_storage_id;
         std::optional<String> captured_query_id;
-        bool captured_was_deleting = item_->is_currently_deleting;
 
         Stopwatch destruction_watch;
 
@@ -288,12 +287,11 @@ void MergeTreeBackgroundExecutor<Queue>::routine(TaskRuntimeDataPtr item)
             if (elapsed_ms > THRESHOLD_MILLISECONDS)
             {
                 LOG_WARNING(log,
-                    "Releasing background task runtime data took {} milliseconds, executor={}, storage={}, query_id={}, deleting={}",
+                    "Releasing background task runtime data took {} milliseconds, executor={}, storage={}, query_id={}",
                     elapsed_ms,
                     name,
                     captured_storage_id.value_or("unknown"),
-                    captured_query_id.value_or("unknown"),
-                    captured_was_deleting);
+                    captured_query_id.value_or("unknown"));
             }
         });
 

--- a/src/Storages/MergeTree/MergeTreeBackgroundExecutor.h
+++ b/src/Storages/MergeTree/MergeTreeBackgroundExecutor.h
@@ -39,7 +39,8 @@ enum class ThreadName : uint8_t;
 struct TaskRuntimeData
 {
     TaskRuntimeData(ExecutableTaskPtr && task_, CurrentMetrics::Metric metric_, TaskProfileEvents events_)
-        : task(std::move(task_))
+        : storage_id(task_->getStorageID())
+        , task(std::move(task_))
         , metric(metric_)
         , events(events_)
     {
@@ -81,6 +82,9 @@ struct TaskRuntimeData
             task.reset();
     }
 
+    /// Cached at construction — valid even after resetTask() nulls the task pointer.
+    /// Used by removeTasksCorrespondingToStorage to identify items during destruction.
+    StorageID storage_id;
     ExecutableTaskPtr task;
     CurrentMetrics::Metric metric;
     TaskProfileEvents events;

--- a/src/Storages/MergeTree/tests/gtest_executor.cpp
+++ b/src/Storages/MergeTree/tests/gtest_executor.cpp
@@ -1,12 +1,14 @@
 #include <gtest/gtest.h>
 
 #include <Common/Exception.h>
+#include <Common/Stopwatch.h>
 #include <Common/setThreadName.h>
 #include <Storages/MergeTree/IExecutableTask.h>
 #include <Storages/MergeTree/MergeTreeBackgroundExecutor.h>
 
 #include <barrier>
 #include <functional>
+#include <latch>
 #include <memory>
 #include <random>
 #include <thread>
@@ -304,4 +306,87 @@ TEST(Executor, UpdatePolicy)
     barrier.arrive_and_wait(); // Do not finish until tasks are done
     executor->wait();
     ASSERT_EQ(schedule, expected_schedule);
+}
+
+
+/// Task whose destructor is artificially slow, simulating expensive cleanup
+/// (e.g. finalizing write buffers, releasing table locks).
+class SlowDestructorTask : public IExecutableTask
+{
+public:
+    SlowDestructorTask(const String & name_, std::latch & destruction_started_, std::chrono::milliseconds delay_)
+        : name(name_)
+        , destruction_started(destruction_started_)
+        , delay(delay_)
+    {}
+
+    ~SlowDestructorTask() override
+    {
+        destruction_started.count_down();
+        std::this_thread::sleep_for(delay);
+    }
+
+    bool executeStep() override { return false; }
+    void cancel() noexcept override {}
+    StorageID getStorageID() const override { return {"test", name}; }
+    void onCompleted() override {}
+    Priority getPriority() const override { return {}; }
+    String getQueryId() const override { return "test::slow_destructor"; }
+
+private:
+    String name;
+    std::latch & destruction_started;
+    std::chrono::milliseconds delay;
+};
+
+
+/// Demonstrates that slow task destruction blocks `removeTasksCorrespondingToStorage`
+/// because `resetTask` is called while holding the executor's mutex.
+///
+/// The test schedules a task with a slow destructor for storage "slow_storage",
+/// waits for destruction to begin (meaning the mutex is held), then calls
+/// `removeTasksCorrespondingToStorage` for a completely UNRELATED storage.
+/// That call should complete instantly but instead gets blocked for the
+/// entire duration of the task destructor.
+TEST(Executor, SlowTaskDestructionBlocksRemoveTasks)
+{
+    static constexpr int DESTRUCTION_DELAY_MS = 500;
+
+    /// Declared before executor so it outlives it (executor's destructor calls `wait`).
+    std::latch destruction_started(1);
+
+    auto executor = std::make_shared<MergeTreeBackgroundExecutor<RoundRobinRuntimeQueue>>
+    (
+        ThreadName::TEST_SCHEDULER,
+        1, // threads
+        10, // max_tasks
+        CurrentMetrics::BackgroundMergesAndMutationsPoolTask,
+        CurrentMetrics::BackgroundMergesAndMutationsPoolSize,
+        ProfileEvents::CommonBackgroundExecutorTaskExecuteStepMicroseconds,
+        ProfileEvents::CommonBackgroundExecutorTaskCancelMicroseconds,
+        ProfileEvents::CommonBackgroundExecutorTaskResetMicroseconds,
+        ProfileEvents::CommonBackgroundExecutorWaitMicroseconds
+    );
+
+    executor->trySchedule(std::make_shared<SlowDestructorTask>(
+        "slow_storage", destruction_started, std::chrono::milliseconds(DESTRUCTION_DELAY_MS)));
+
+    /// Wait until the worker thread enters the task's destructor,
+    /// which means the executor's mutex is held by `release_task`.
+    destruction_started.wait();
+
+    /// Call `removeTasksCorrespondingToStorage` for a completely unrelated storage.
+    /// This needs the mutex only briefly (scan queues, find nothing, return),
+    /// but will be blocked for the entire duration of the slow destructor.
+    Stopwatch watch;
+    executor->removeTasksCorrespondingToStorage({"test", "unrelated_storage"});
+    auto elapsed_ms = watch.elapsedMilliseconds();
+
+    /// After fixing the issue (moving `resetTask` outside the lock),
+    /// this should complete in under 50 ms. Currently it takes ~500 ms.
+    EXPECT_LT(elapsed_ms, 100)
+        << "removeTasksCorrespondingToStorage for an unrelated storage was blocked for "
+        << elapsed_ms << " ms by slow task destruction holding the mutex";
+
+    executor->wait();
 }


### PR DESCRIPTION
### Changelog category (leave one):

- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Reduce lock contention in MergeTreeBackgroundExecutor by making task resources release without acquiring the lock. Closes https://github.com/ClickHouse/ClickHouse/issues/93620.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.408`
<!-- ch-version-info:end -->