### PR TITLE
Fix deprecated SummingMergeTree syntax in Kafka documentation

### DIFF
--- a/docs/en/engines/table-engines/integrations/kafka.md
+++ b/docs/en/engines/table-engines/integrations/kafka.md
@@ -168,7 +168,9 @@ Example:
     day Date,
     level String,
     total UInt64
-  ) ENGINE = SummingMergeTree(day, (day, level), 8192);
+  ) ENGINE = SummingMergeTree()
+  ORDER BY (day, level)
+  SETTINGS index_granularity = 8192;
 
   CREATE MATERIALIZED VIEW consumer TO daily
     AS SELECT toDate(toDateTime(timestamp)) AS day, level, count() AS total


### PR DESCRIPTION
Fixes #83825. Updates deprecated SummingMergeTree syntax in Kafka engine documentation to use modern ORDER BY clause and SETTINGS syntax instead of deprecated positional parameters.

### Changelog category (leave one):
- Documentation (changelog entry is not required)