### PR TITLE
Fix heap-use-after-free in GraphiteRollupSortedAlgorithm

### DIFF
--- a/src/Processors/Merges/Algorithms/GraphiteRollupSortedAlgorithm.cpp
+++ b/src/Processors/Merges/Algorithms/GraphiteRollupSortedAlgorithm.cpp
@@ -69,6 +69,11 @@ GraphiteRollupSortedAlgorithm::GraphiteRollupSortedAlgorithm(
     columns_definition = defineColumns(*header_, params);
 }
 
+GraphiteRollupSortedAlgorithm::~GraphiteRollupSortedAlgorithm()
+{
+    merged_data.reset();
+}
+
 UInt32 GraphiteRollupSortedAlgorithm::selectPrecision(const Graphite::Retentions & retentions, time_t time) const
 {
     static_assert(is_signed_v<time_t>, "time_t must be signed type");

--- a/src/Processors/Merges/Algorithms/GraphiteRollupSortedAlgorithm.h
+++ b/src/Processors/Merges/Algorithms/GraphiteRollupSortedAlgorithm.h
@@ -31,6 +31,10 @@ public:
         Graphite::Params params_,
         time_t time_of_merge_);
 
+    /// Reset merged_data before params is destroyed, because GraphiteRollupMergedData
+    /// holds raw pointers into params.patterns and its destructor accesses them.
+    ~GraphiteRollupSortedAlgorithm() override;
+
     const char * getName() const override { return "GraphiteRollupSortedAlgorithm"; }
     Status merge() override;
 

--- a/tests/queries/0_stateless/04010_graphite_rollup_uaf.sql
+++ b/tests/queries/0_stateless/04010_graphite_rollup_uaf.sql
@@ -1,0 +1,49 @@
+-- Regression test for heap-use-after-free in GraphiteRollupSortedAlgorithm.
+-- Ticket: https://github.com/ClickHouse/ClickHouse/issues/98523
+-- When the Time column uses a non-DateTime type (e.g. Int128), an exception
+-- during mergeBlock leaves an aggregate state created. On destruction,
+-- GraphiteRollupMergedData accessed freed memory from already-destroyed params.
+
+SET joined_subquery_requires_alias = 0;
+SET allow_suspicious_low_cardinality_types = 1;
+
+DROP TABLE IF EXISTS test_graphite_fuzz;
+
+CREATE TABLE test_graphite_fuzz
+(
+    `key` LowCardinality(UInt256),
+    `Path` LowCardinality(String),
+    `Time` Int128,
+    `Value` Float64,
+    `Version` UInt32,
+    `col` Int64
+)
+ENGINE = GraphiteMergeTree('graphite_rollup')
+ORDER BY key
+SETTINGS index_granularity = 10;
+
+INSERT INTO test_graphite_fuzz
+WITH dates AS
+(
+    SELECT
+        toStartOfDay(toDateTime(now('UTC'), 'UTC')) AS today,
+        today - INTERVAL 3 DAY AS older_date
+)
+SELECT 1 AS key, 'sum_1' AS s, today - number * 60 - 30, number, 1, number FROM dates, numbers(300)
+UNION ALL SELECT 2, 'sum_1', today - number * 60 - 30, number, 1, number FROM dates, numbers(300)
+UNION ALL SELECT 1, 'sum_2', today - number * 60 - 30, number, 1, number FROM dates, numbers(300)
+UNION ALL SELECT 2, 'sum_2', today - number * 60 - 30, number, 1, number FROM dates, numbers(300)
+UNION ALL SELECT 1, 'max_1', today - number * 60 - 30, number, 1, number FROM dates, numbers(300)
+UNION ALL SELECT 2, 'max_1', today - number * 60 - 30, number, 1, number FROM dates, numbers(300)
+UNION ALL SELECT 1, 'max_2', today - number * 60 - 30, number, 1, number FROM dates, numbers(300)
+UNION ALL SELECT 2, 'max_2', today - number * 60 - 30, number, 1, number FROM dates, numbers(300)
+UNION ALL SELECT 1 AS key, 'sum_1' AS s, older_date - number * 60 - 30, number, 1, number FROM dates, numbers(1200)
+UNION ALL SELECT 2, 'sum_1', older_date - number * 60 - 30, number, 1, number FROM dates, numbers(1200)
+UNION ALL SELECT 1, 'sum_2', older_date - number * 60 - 30, number, 1, number FROM dates, numbers(1200)
+UNION ALL SELECT 2, 'sum_2', older_date - number * 60 - 30, number, 1, number FROM dates, numbers(1200)
+UNION ALL SELECT 1, 'max_1', older_date - number * 60 - 30, number, 1, number FROM dates, numbers(1200)
+UNION ALL SELECT 2, 'max_1', older_date - number * 60 - 30, number, 1, number FROM dates, numbers(1200)
+UNION ALL SELECT 1, 'max_2', older_date - number * 60 - 30, number, 1, number FROM dates, numbers(1200)
+UNION ALL SELECT 2, 'max_2', older_date - number * 60 - 30, number, 1, number FROM dates, numbers(1200); -- { serverError BAD_GET }
+
+DROP TABLE IF EXISTS test_graphite_fuzz;


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix heap-use-after-free in GraphiteRollupSortedAlgorithm

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

---

When an exception occurs during `mergeBlock` with a `GraphiteMergeTree` table (e.g. fuzzed column types like `Int128` for the `Time` column), the aggregate state in `GraphiteRollupMergedData` can be left active. On destruction, the derived class member `params` (owning the patterns vector with `AggregateFunctionPtr`) is destroyed before the base class member `merged_data`, whose destructor then dereferences dangling pointers into the already-freed patterns.

Fix by resetting `merged_data` in the derived destructor, ensuring `~GraphiteRollupMergedData` runs while `params` is still alive.

ASan report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=98204&sha=b003cfb861b70b7461035f2ac3d5438cffefdc24&name_0=PR&name_1=AST%20fuzzer%20%28arm_asan%29
https://github.com/ClickHouse/ClickHouse/pull/98204

Closes https://github.com/ClickHouse/ClickHouse/issues/98523


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.482`
<!-- ch-version-info:end -->