### PR TITLE
Use per-worktree container names in Praktika runner

### DIFF
--- a/ci/praktika/job.py
+++ b/ci/praktika/job.py
@@ -1,8 +1,10 @@
 import copy
 import fnmatch
+import hashlib
 import json
 import os
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Iterable, List, Optional
 
 from . import Artifact
@@ -265,5 +267,10 @@ class Job:
             if self.timeout_shell_cleanup:
                 return
             if self.run_in_docker:
-                # the container name is always the same (praktika) for every image
-                self.timeout_shell_cleanup = "docker rm -f praktika"
+                container_name = (
+                    "praktika_"
+                    + hashlib.sha1(
+                        Path(os.getcwd()).resolve().as_posix().encode()
+                    ).hexdigest()[:12]
+                )
+                self.timeout_shell_cleanup = f"docker rm -f {container_name}"

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -1,5 +1,6 @@
 import dataclasses
 import glob
+import hashlib
 import json
 import os
 import re
@@ -313,6 +314,15 @@ class Runner:
 
             docker = docker or f"{docker_name}:{docker_tag}"
             current_dir = os.getcwd()
+            # Use a hash of the real worktree path as container name so
+            # multiple worktrees can run tests in parallel without conflicts.
+            # The same path always produces the same name, allowing cleanup.
+            container_name = (
+                "praktika_"
+                + hashlib.sha1(
+                    Path(current_dir).resolve().as_posix().encode()
+                ).hexdigest()[:12]
+            )
             workdir = f"--workdir={current_dir}"
             for setting in settings:
                 if setting.startswith("--volume"):
@@ -328,11 +338,11 @@ class Runner:
                     )
                     workdir = ""
             if not Shell.check(
-                "if docker ps -a --format '{{.Names}}' | grep -qx praktika; then docker rm -f praktika; fi",
+                f"if docker ps -a --format '{{{{.Names}}}}' | grep -qx {container_name}; then docker rm -f {container_name}; fi",
                 verbose=True,
             ):
                 raise RuntimeError(
-                    "Failed to remove existing docker container 'praktika'"
+                    f"Failed to remove existing docker container '{container_name}'"
                 )
             if job.enable_gh_auth:
                 # pass gh auth seamlessly into the docker container
@@ -349,7 +359,7 @@ class Runner:
             for p_ in [path, path_1]:
                 if p_ and Path(p_).exists() and p_.startswith("/"):
                     extra_mounts += f" --volume {p_}:{p_}"
-            cmd = f"docker run {tty} --rm --name praktika {'--user $(id -u):$(id -g)' if not from_root else ''} -e PYTHONUNBUFFERED=1 -e PYTHONPATH='.:./ci' --volume ./:{current_dir} {extra_mounts} {gh_mount} {workdir} {' '.join(settings)} {docker} {job.command}"
+            cmd = f"docker run {tty} --rm --name {container_name} {'--user $(id -u):$(id -g)' if not from_root else ''} -e PYTHONUNBUFFERED=1 -e PYTHONPATH='.:./ci' --volume ./:{current_dir} {extra_mounts} {gh_mount} {workdir} {' '.join(settings)} {docker} {job.command}"
         else:
             cmd = job.command
             python_path = os.getenv("PYTHONPATH", ":")


### PR DESCRIPTION
## Summary

- Derive the Praktika Docker container name from a SHA-1 hash of the resolved worktree path instead of hardcoding `praktika`
- This allows running tests from multiple worktrees in parallel without container name conflicts
- The same path always produces the same container name, so stale containers are still cleaned up on the next run

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.369`
<!-- ch-version-info:end -->