### PR TITLE
Replace boost::regex_split via absl::StrSplit in ISerialization::stringToKindStack

### DIFF
--- a/src/DataTypes/Serializations/ISerialization.cpp
+++ b/src/DataTypes/Serializations/ISerialization.cpp
@@ -9,13 +9,14 @@
 #include <IO/Operators.h>
 #include <IO/ReadBufferFromString.h>
 #include <IO/WriteHelpers.h>
+#include <absl/strings/str_split.h>
 #include <base/EnumReflection.h>
 #include <base/demangle.h>
 #include <Storages/MergeTree/MergeTreeSettings.h>
 #include <Common/assert_cast.h>
 #include <Common/escapeForFileName.h>
 #include <Common/typeid_cast.h>
-#include <boost/algorithm/string_regex.hpp>
+#include <base/types.h>
 
 namespace DB
 {
@@ -108,7 +109,7 @@ String ISerialization::kindStackToString(const KindStack & kind_stack)
     return result;
 }
 
-static ISerialization::Kind stringToKind(const String & str)
+static ISerialization::Kind stringToKind(std::string_view str)
 {
     if (str == "Default")
         return ISerialization::Kind::DEFAULT;
@@ -123,8 +124,7 @@ static ISerialization::Kind stringToKind(const String & str)
 
 ISerialization::KindStack ISerialization::stringToKindStack(const String & str)
 {
-    std::vector<String> kind_strings;
-    boost::algorithm::split_regex(kind_strings, str, boost::regex("Over"));
+    std::vector<std::string_view> kind_strings = absl::StrSplit(str, absl::ByString("Over"));
     KindStack kind_stack;
     for (size_t i = 0; i != kind_strings.size(); ++i)
     {

--- a/src/DataTypes/Serializations/tests/gtest_serialization_info.cpp
+++ b/src/DataTypes/Serializations/tests/gtest_serialization_info.cpp
@@ -1,0 +1,277 @@
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <DataTypes/Serializations/ISerialization.h>
+#include <DataTypes/Serializations/SerializationInfo.h>
+#include <Poco/JSON/Object.h>
+#include <Common/Exception.h>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+extern const int LOGICAL_ERROR;
+}
+
+namespace
+{
+
+SerializationInfoSettings defaultSettings()
+{
+    SerializationInfoSettings s;
+    s.ratio_of_defaults_for_sparse = 0.9375;
+    s.choose_kind = true;
+    return s;
+}
+
+SerializationInfoSettings alwaysDefaultSettings()
+{
+    SerializationInfoSettings s;
+    s.ratio_of_defaults_for_sparse = 1.0;
+    s.choose_kind = false;
+    return s;
+}
+
+SerializationInfo::Data makeData(size_t num_rows, size_t num_defaults)
+{
+    SerializationInfo::Data d;
+    d.num_rows = num_rows;
+    d.num_defaults = num_defaults;
+    return d;
+}
+
+Poco::JSON::Object makeKindObj(const std::string & kind, size_t num_rows, size_t num_defaults)
+{
+    Poco::JSON::Object obj;
+    obj.set("kind", kind);
+    obj.set("num_rows", static_cast<Poco::UInt64>(num_rows));
+    obj.set("num_defaults", static_cast<Poco::UInt64>(num_defaults));
+    return obj;
+}
+
+void expectMalformedKindFails([[maybe_unused]] const std::string & kind)
+{
+#ifdef DEBUG_OR_SANITIZER_BUILD
+    GTEST_SKIP() << "this test trigger LOGICAL_ERROR, runs only if DEBUG_OR_SANITIZER_BUILD is not defined";
+#else
+    EXPECT_THROW(
+        {
+            try
+            {
+                SerializationInfo info({ISerialization::Kind::DEFAULT}, defaultSettings());
+                auto obj = makeKindObj(kind, 100, 10);
+                info.fromJSON(obj);
+            }
+            catch (const DB::Exception & e)
+            {
+                ASSERT_EQ(DB::ErrorCodes::LOGICAL_ERROR, e.code());
+                EXPECT_THAT(e.what(), testing::HasSubstr("Unknown serialization kind"));
+                throw;
+            }
+        },
+        DB::Exception);
+#endif
+}
+}
+
+TEST(SerializationInfoJSON, RoundTripDefault)
+{
+    ISerialization::KindStack kind_stack{ISerialization::Kind::DEFAULT};
+    SerializationInfo info(kind_stack, defaultSettings(), makeData(1000, 100));
+
+    Poco::JSON::Object obj;
+    info.toJSON(obj);
+
+    EXPECT_EQ(obj.getValue<std::string>("kind"), "Default");
+    EXPECT_EQ(obj.getValue<size_t>("num_rows"), 1000);
+    EXPECT_EQ(obj.getValue<size_t>("num_defaults"), 100);
+
+    SerializationInfo restored(kind_stack, defaultSettings());
+    restored.fromJSON(obj);
+
+    EXPECT_EQ(restored.getKindStack(), kind_stack);
+    EXPECT_EQ(restored.getData().num_rows, 1000);
+    EXPECT_EQ(restored.getData().num_defaults, 100);
+}
+
+TEST(SerializationInfoJSON, RoundTripSparse)
+{
+    ISerialization::KindStack kind_stack{ISerialization::Kind::DEFAULT, ISerialization::Kind::SPARSE};
+    SerializationInfo info(kind_stack, defaultSettings(), makeData(1000000, 950000));
+
+    Poco::JSON::Object obj;
+    info.toJSON(obj);
+
+    EXPECT_EQ(obj.getValue<std::string>("kind"), "Sparse");
+    EXPECT_EQ(obj.getValue<size_t>("num_rows"), 1000000);
+    EXPECT_EQ(obj.getValue<size_t>("num_defaults"), 950000);
+
+    SerializationInfo restored({ISerialization::Kind::DEFAULT}, defaultSettings());
+    restored.fromJSON(obj);
+
+    EXPECT_EQ(restored.getKindStack(), kind_stack);
+    EXPECT_EQ(restored.getData().num_rows, 1000000);
+    EXPECT_EQ(restored.getData().num_defaults, 950000);
+}
+
+TEST(SerializationInfoJSON, RoundTripDetachedOverSparse)
+{
+    /// kindStackToString reverses the non-Default elements:
+    ///   [Default, Sparse, Detached] -> "DetachedOverSparse"
+    /// stringToKindStack reads left-to-right:
+    ///   "DetachedOverSparse" -> [Default, Detached, Sparse]
+    /// So the round-trip reverses the inner order.
+    ISerialization::KindStack kind_stack{ISerialization::Kind::DEFAULT, ISerialization::Kind::SPARSE, ISerialization::Kind::DETACHED};
+    SerializationInfo info(kind_stack, defaultSettings(), makeData(500, 490));
+
+    Poco::JSON::Object obj;
+    info.toJSON(obj);
+
+    EXPECT_EQ(obj.getValue<std::string>("kind"), "DetachedOverSparse");
+
+    SerializationInfo restored({ISerialization::Kind::DEFAULT}, defaultSettings());
+    restored.fromJSON(obj);
+
+    ISerialization::KindStack expected_after_roundtrip{
+        ISerialization::Kind::DEFAULT, ISerialization::Kind::DETACHED, ISerialization::Kind::SPARSE};
+    EXPECT_EQ(restored.getKindStack(), expected_after_roundtrip);
+    EXPECT_EQ(restored.getData().num_rows, 500);
+    EXPECT_EQ(restored.getData().num_defaults, 490);
+}
+
+TEST(SerializationInfoJSON, RoundTripZeroRows)
+{
+    ISerialization::KindStack kind_stack{ISerialization::Kind::DEFAULT};
+    SerializationInfo info(kind_stack, defaultSettings(), makeData(0, 0));
+
+    Poco::JSON::Object obj;
+    info.toJSON(obj);
+
+    SerializationInfo restored({ISerialization::Kind::DEFAULT}, defaultSettings());
+    restored.fromJSON(obj);
+
+    EXPECT_EQ(restored.getData().num_rows, 0);
+    EXPECT_EQ(restored.getData().num_defaults, 0);
+    EXPECT_EQ(restored.getKindStack(), kind_stack);
+}
+
+TEST(SerializationInfoJSON, FromJSONMissingFieldThrows)
+{
+    SerializationInfo info({ISerialization::Kind::DEFAULT}, defaultSettings());
+
+    {
+        Poco::JSON::Object obj;
+        obj.set("kind", "Default");
+        obj.set("num_rows", 100);
+        /// missing num_defaults
+        EXPECT_THROW(info.fromJSON(obj), DB::Exception);
+    }
+
+    {
+        Poco::JSON::Object obj;
+        obj.set("kind", "Default");
+        obj.set("num_defaults", 10);
+        /// missing num_rows
+        EXPECT_THROW(info.fromJSON(obj), DB::Exception);
+    }
+
+    {
+        Poco::JSON::Object obj;
+        obj.set("num_rows", 100);
+        obj.set("num_defaults", 10);
+        /// missing kind
+        EXPECT_THROW(info.fromJSON(obj), DB::Exception);
+    }
+}
+
+TEST(SerializationInfoJSON, FromJSONOverwritesExistingData)
+{
+    ISerialization::KindStack initial_stack{ISerialization::Kind::DEFAULT};
+    SerializationInfo info(initial_stack, defaultSettings(), makeData(1, 0));
+
+    auto obj = makeKindObj("Sparse", 2000, 1999);
+    info.fromJSON(obj);
+
+    ISerialization::KindStack expected{ISerialization::Kind::DEFAULT, ISerialization::Kind::SPARSE};
+    EXPECT_EQ(info.getKindStack(), expected);
+    EXPECT_EQ(info.getData().num_rows, 2000);
+    EXPECT_EQ(info.getData().num_defaults, 1999);
+}
+
+/// Malformed kind tests.
+/// stringToKind throws LOGICAL_ERROR which aborts in debug builds
+/// but throws a catchable exception in release builds.
+
+TEST(SerializationInfoJSON, FromJSONEmptyKind)
+{
+    expectMalformedKindFails("");
+}
+TEST(SerializationInfoJSON, FromJSONUnknownKind)
+{
+    expectMalformedKindFails("FooBar");
+}
+TEST(SerializationInfoJSON, FromJSONKindWrongCase)
+{
+    expectMalformedKindFails("sparse");
+}
+TEST(SerializationInfoJSON, FromJSONKindAllCaps)
+{
+    expectMalformedKindFails("SPARSE");
+}
+TEST(SerializationInfoJSON, FromJSONKindWithTrailingOver)
+{
+    expectMalformedKindFails("SparseOver");
+}
+TEST(SerializationInfoJSON, FromJSONKindWithLeadingOver)
+{
+    expectMalformedKindFails("OverSparse");
+}
+TEST(SerializationInfoJSON, FromJSONKindDoubleOver)
+{
+    expectMalformedKindFails("DetachedOverOverSparse");
+}
+TEST(SerializationInfoJSON, FromJSONKindWithWhitespace)
+{
+    expectMalformedKindFails(" Sparse");
+}
+TEST(SerializationInfoJSON, FromJSONKindJustOver)
+{
+    expectMalformedKindFails("Over");
+}
+
+/// chooseKindStack tests
+
+TEST(SerializationInfoJSON, ChooseKindStackDefaultBelowThreshold)
+{
+    auto kind_stack = SerializationInfo::chooseKindStack(makeData(1000, 900), defaultSettings()); /// 0.9 < 0.9375
+
+    ISerialization::KindStack expected{ISerialization::Kind::DEFAULT};
+    EXPECT_EQ(kind_stack, expected);
+}
+
+TEST(SerializationInfoJSON, ChooseKindStackSparseAboveThreshold)
+{
+    auto kind_stack = SerializationInfo::chooseKindStack(makeData(1000, 950), defaultSettings()); /// 0.95 > 0.9375
+
+    ISerialization::KindStack expected{ISerialization::Kind::DEFAULT, ISerialization::Kind::SPARSE};
+    EXPECT_EQ(kind_stack, expected);
+}
+
+TEST(SerializationInfoJSON, ChooseKindStackAlwaysDefault)
+{
+    auto kind_stack = SerializationInfo::chooseKindStack(makeData(1000, 1000), alwaysDefaultSettings());
+
+    ISerialization::KindStack expected{ISerialization::Kind::DEFAULT};
+    EXPECT_EQ(kind_stack, expected);
+}
+
+TEST(SerializationInfoJSON, ChooseKindStackZeroRows)
+{
+    auto kind_stack = SerializationInfo::chooseKindStack(makeData(0, 0), defaultSettings());
+
+    ISerialization::KindStack expected{ISerialization::Kind::DEFAULT};
+    EXPECT_EQ(kind_stack, expected);
+}
+
+}


### PR DESCRIPTION
boost::regex has an global [object cache](https://original.boost.org/doc/libs/1_85_0/boost/regex/v5/object_cache.hpp) which on every call locks its mutex, replacing it via absl::StrSplit removes contention at all.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to parsing/formatting of serialization kind stacks and adds unit tests; main risk is subtle differences in tokenization for malformed kind strings affecting compatibility/error handling.
> 
> **Overview**
> Replaces `ISerialization::stringToKindStack` splitting logic from `boost::regex` to `absl::StrSplit`, and updates `stringToKind` to take `std::string_view` to avoid extra allocations/locking overhead.
> 
> Adds a new gtest suite (`gtest_serialization_info.cpp`) covering `SerializationInfo` JSON round-trips, missing-field failures, malformed `kind` strings, and `chooseKindStack` threshold behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f7017f5898ceb28be4f3f0eab8dabbd9eac3831. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.552`
<!-- ch-version-info:end -->