### PR TITLE
Fix exception in tryExecuteFunctionsAfterSorting when sort column missing from DAG

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/liftUpFunctions.cpp
+++ b/src/Processors/QueryPlan/Optimizations/liftUpFunctions.cpp
@@ -66,7 +66,16 @@ size_t tryExecuteFunctionsAfterSorting(QueryPlan::Node * parent_node, QueryPlan:
     NameSet sort_columns;
     for (const auto & col : sorting_step->getSortDescription())
         sort_columns.insert(col.column_name);
-    auto [needed_for_sorting, unneeded_for_sorting, _] = expression_step->getExpression().splitActionsBySortingDescription(sort_columns);
+
+    /// Check that all sort columns are present in the expression DAG's outputs.
+    /// A sort column might not be in the DAG outputs if it is a pass-through column
+    /// not referenced by the expression, e.g. after convertJoinToIn optimization.
+    const auto & expression_dag = expression_step->getExpression();
+    for (const auto & col : sort_columns)
+        if (!expression_dag.tryFindInOutputs(col))
+            return 0;
+
+    auto [needed_for_sorting, unneeded_for_sorting, _] = expression_dag.splitActionsBySortingDescription(sort_columns);
 
     // No calculations can be postponed.
     if (unneeded_for_sorting.trivial())


### PR DESCRIPTION
## Summary
- Fix a logical error exception in `tryExecuteFunctionsAfterSorting` (the `liftUpFunctions` query plan optimization) where `splitActionsBySortingDescription` throws when a sort column referenced by the parent `SortingStep` is not found in the child `ExpressionStep`'s DAG outputs
- This can happen when other optimizations (like `convertJoinToIn`) restructure the query plan, creating `ExpressionStep`s whose DAGs don't contain all columns from the sort description
- The fix adds a check that all sort columns are present in the expression DAG outputs before calling `splitActionsBySortingDescription`; if any are missing, the optimization is skipped

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=98529&sha=9774a7da6f158cfa5af8376be0a0df37bacab4cb&name_0=PR&name_1=Stress%20test%20%28amd_debug%29
https://github.com/ClickHouse/ClickHouse/pull/98529

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix logical error exception "Sorting column wasn't found in the ActionsDAG's outputs" in `tryExecuteFunctionsAfterSorting` optimization triggered by certain query plan structures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)