### PR TITLE
ci: trigger rebuild of client Docker images with SBOM/provenance attestations

### DIFF
--- a/ci/docker/integration/arrowflight/Dockerfile
+++ b/ci/docker/integration/arrowflight/Dockerfile
@@ -1,4 +1,5 @@
 # docker build -t clickhouse/arrowflight-server-test .
+# Rebuild to enable SBOM/provenance attestations (see #97903, #98511)
 FROM python:3.9-slim
 
 ENV PYTHONDONTWRITEBYTECODE=1

--- a/ci/docker/integration/dotnet_client/Dockerfile
+++ b/ci/docker/integration/dotnet_client/Dockerfile
@@ -1,5 +1,6 @@
 # docker build .
 # docker run -it --rm --network=host 14f23e59669c dotnet run --host localhost --port 8123 --user default --database default
+# Rebuild to enable SBOM/provenance attestations (see #97903, #98511)
 
 FROM mcr.microsoft.com/dotnet/sdk:8.0
 

--- a/ci/docker/integration/mysql_dotnet_client/Dockerfile
+++ b/ci/docker/integration/mysql_dotnet_client/Dockerfile
@@ -1,4 +1,5 @@
 # docker build -t clickhouse/mysql_dotnet_client .
+# Rebuild to enable SBOM/provenance attestations (see #97903, #98511)
 
 FROM ubuntu:22.04
 

--- a/ci/docker/integration/mysql_golang_client/Dockerfile
+++ b/ci/docker/integration/mysql_golang_client/Dockerfile
@@ -1,5 +1,6 @@
 # docker build -t clickhouse/mysql-golang-client .
 # MySQL golang client docker container
+# Rebuild to enable SBOM/provenance attestations (see #97903, #98511)
 
 FROM golang:1.24-alpine
 

--- a/ci/docker/integration/mysql_java_client/Dockerfile
+++ b/ci/docker/integration/mysql_java_client/Dockerfile
@@ -1,5 +1,6 @@
 # docker build -t clickhouse/mysql-java-client .
 # MySQL Java client docker container
+# Rebuild to enable SBOM/provenance attestations (see #97903, #98511)
 
 FROM eclipse-temurin:21-jdk-alpine
 

--- a/ci/docker/integration/mysql_js_client/Dockerfile
+++ b/ci/docker/integration/mysql_js_client/Dockerfile
@@ -1,5 +1,6 @@
 # docker build -t clickhouse/mysql-js-client .
 # MySQL JavaScript client docker container
+# Rebuild to enable SBOM/provenance attestations (see #97903, #98511)
 
 FROM node:22-alpine
 

--- a/ci/docker/integration/mysql_php_client/Dockerfile
+++ b/ci/docker/integration/mysql_php_client/Dockerfile
@@ -1,5 +1,6 @@
 # docker build -t clickhouse/mysql-php-client .
 # MySQL PHP client docker container
+# Rebuild to enable SBOM/provenance attestations (see #97903, #98511)
 
 FROM php:8.4-cli-alpine
 

--- a/ci/docker/integration/postgresql_java_client/Dockerfile
+++ b/ci/docker/integration/postgresql_java_client/Dockerfile
@@ -1,5 +1,6 @@
 # docker build -t clickhouse/postgresql-java-client .
 # PostgreSQL Java client docker container
+# Rebuild to enable SBOM/provenance attestations (see #97903, #98511)
 
 FROM ubuntu:24.04
 


### PR DESCRIPTION
## Summary

- Adds a one-line comment to each client integration Dockerfile to change their digest and force a rebuild via master CI
- All 8 client images (`mysql-java-client`, `mysql-golang-client`, `mysql-js-client`, `dotnet-client`, `mysql-php-client`, `postgresql-java-client`, `mysql-dotnet-client`, `arrowflight`) currently have `latest` pointing to builds from Feb 20, 2026 — before the SBOM/provenance pipeline was fixed
- Without a Dockerfile change, master CI skips rebuilding these images indefinitely (digest-based dedup sees the tags already exist)

## Context

- #97903 enabled `--sbom=true --provenance=mode=max` and switched `merge_manifest` to `docker buildx imagetools create`
- #98511 fixed incompatible `--builder default` and `--cache-to type=inline` flags that would have caused the next build to fail

This PR triggers the first rebuild under the corrected pipeline, which will produce OCI image indices with `unknown/unknown` attestation manifests, improving Docker Scout supply chain security scores.

## Test plan

- [ ] Verify master CI rebuilds all 8 images after merge
- [ ] Confirm `latest` tags gain attestation manifests (`docker buildx imagetools inspect clickhouse/mysql-java-client:latest` should show 4 manifests including `unknown/unknown`)
- [ ] Verify Docker Scout scores improve

### Changelog category (leave one):

- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.458`
<!-- ch-version-info:end -->