### PR TITLE
Revert "Revert "Add ALP Codec""

### DIFF
--- a/docs/en/sql-reference/statements/create/table.md
+++ b/docs/en/sql-reference/statements/create/table.md
@@ -9,6 +9,7 @@ doc_type: 'reference'
 ---
 
 import CloudNotSupportedBadge from '@theme/badges/CloudNotSupportedBadge';
+import ExperimentalBadge from '@theme/badges/ExperimentalBadge';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
@@ -426,6 +427,16 @@ These codecs are designed to make compression more effective by exploiting speci
 #### Gorilla {#gorilla}
 
 `Gorilla(bytes_size)` — Calculates XOR between current and previous floating point value and writes it in compact binary form. The smaller the difference between consecutive values is, i.e. the slower the values of the series changes, the better the compression rate. Implements the algorithm used in Gorilla TSDB, extending it to support 64-bit types. Possible `bytes_size` values: 1, 2, 4, 8, the default value is `sizeof(type)` if equal to 1, 2, 4, or 8. In all other cases, it's 1. For additional information, see section 4.1 in [Gorilla: A Fast, Scalable, In-Memory Time Series Database](https://doi.org/10.14778/2824032.2824078).
+
+#### ALP {#alp}
+
+<ExperimentalBadge/>
+
+`ALP()` — Adaptive lossless compression for floating-point data based on decimal scaling. ALP attempts to represent each value as an exact scaled integer using decimal powers, then compresses the resulting integers with Frame-of-Reference and bit-packing. Values that cannot be represented exactly are stored as raw exceptions. Works best for numbers originating from decimals (e.g., measurements, currency). Supports `Float32` and `Float64`. For details, see [ALP: Adaptive lossless floating-point compression](https://ir.cwi.nl/pub/33334).
+
+:::note
+This codec is experimental and requires `SET allow_experimental_codecs = 1` to use.
+:::
 
 #### FPC {#fpc}
 

--- a/src/Client/BuzzHouse/Proto/SQLGrammar.proto
+++ b/src/Client/BuzzHouse/Proto/SQLGrammar.proto
@@ -3259,6 +3259,7 @@ enum CompressionCodec {
     /// COMP_ZSTD_QAT = 14;
     /// COMP_DEFLATE_QPL = 15;
     /// COMP_SZ3 = 16;
+    COMP_ALP = 17;
 }
 
 message IndexKeyVal {

--- a/src/Compression/CompressionCodecALP.cpp
+++ b/src/Compression/CompressionCodecALP.cpp
@@ -1,0 +1,828 @@
+#include <Compression/CompressionFactory.h>
+#include <Compression/CompressionInfo.h>
+#include <Compression/ICompressionCodec.h>
+
+#include <DataTypes/IDataType.h>
+#include <IO/WriteHelpers.h>
+#include <Parsers/IAST.h>
+#include <base/unaligned.h>
+
+#include <Compression/FFOR.h>
+
+#include <array>
+
+namespace DB
+{
+/**
+ * ALP (Adaptive Lossless floating-Point) compression codec.
+ *
+ * This implementation is based on the ALP paper (https://ir.cwi.nl/pub/33334) and implements the main ALP variant for Float32 and Float64.
+ * It encodes floating-point values as scaled integers (plus a small set of exceptions), then applies Frame-of-Reference + bit-packing.
+ *
+ * Overall Stream Layout
+ *   [ALP codec header]
+ *   [ALP block 0]
+ *   [ALP block 1]
+ *   ...
+ *   [ALP block N-1]
+ *
+ * ALP codec header (4 bytes):
+ *   - meta byte (1 byte):
+ *     - bits 0-3: codec version (currently 1)
+ *     - bit 4:    variant flag (0 = ALP, 1 = ALP_RD; only 0 supported)
+ *     - bits 5-7: reserved (must be 0)
+ *   - float width (1 byte):
+ *     - 4 or 8 bytes (Float32 / Float64)
+ *   - block float count (2 bytes):
+ *     - number of floats per block (UInt16), currently fixed to 1024, other values are not supported.
+ *
+ * The input column is split into blocks of up to ALP_BLOCK_MAX_FLOAT_COUNT values (1024).
+ * Each block is encoded independently and can be either compressed or left raw, depending on the estimated gain.
+ *
+ * Core Idea: Decimal-Based Integerization
+ * The ALP paper observes that most stored doubles originate as decimals. For a block, we try to represent each float value as an integer:
+ *   d = (Int64) round(v * 10^e * 10^(-f))
+ * where:
+ *   - v is the original floating-point value
+ *   - d is the encoded integer
+ *   - e controls the decimal scaling up
+ *   - f controls how many trailing decimal zeros we effectively “cut off” again
+ * A value is considered exactly encodable if:
+ *   decodeValue(encodeValue(v, e, f), e, f) == v
+ * Encodable values become part of the integer stream; non-encodable values become exceptions stored verbatim.
+ * Encodable eligibility is based on bit-exact equality, not epsilon-based closeness, because the codec is lossless.
+ *
+ * Two-Level Sampling to Select (e,f)
+ * ALP’s adaptivity over a block is driven by a two-level sampling scheme:
+ *   1) Global pre-sampling over the entire column:
+ *     - Take ALP_PARAMS_ESTIMATION_SAMPLES disjoint sub-samples from the column (each up to ALP_PARAMS_ESTIMATION_SAMPLE_FLOATS values).
+ *     - For each sub-sample, brute-force over all valid (e,f) pairs with 0 <= e < |EXPONENTS| and 0 <= f <= e.
+ *     - For each (e,f), estimate the encoded size and keep track of the best (e,f) for that sub-sample.
+ *     - The result is a small, global candidate set of (e,f) pairs (up to 5) that are likely good for this column.
+ *   2) Per-block refinement
+ *     - For each block of up to 1024 values, take a local sample
+ *     - Evaluate only the global candidate (e,f) list for that sample to choose the best (e,f) for that block.
+ *
+ * Per-Block Encoding Schema (Compressed Case)
+ *   - 1 byte: exponent (e) (UInt8)
+ *   - 1 byte: fraction (f) (UInt8)
+ *   - 2 bytes: exceptions count (UInt16)
+ *   - 1 byte:  FOR bit-width (UInt8)
+ *   - 8 bytes: FOR base value (Int64)
+ *   - Compressed block payload:
+ *     * Bit-packed values: (encoded_value - FOR_base) for each successfully encoded float, using bit-width bits per value.
+ *     * Exceptions (for values that couldn't round-trip losslessly):
+ *       - UInt16 index (position in source block - offset)
+ *       - raw value (float or double)
+ *
+ * Per-Block Encoding Schema (Uncompressed Case)
+ *   - 1 byte: 255 (uncompressed block marker)
+ *   - Raw numbers for the block
+ *
+ * Notes:
+ *   - This codec implements the ALP variant only.
+ *   - ALP_RD (front-bits-based encoder for “real doubles”) is not implemented.
+ *   - Supported types: 4 and 8 bytes floating point.
+ *   - The scheme is fully lossless: all non-exception values are proven round-trip encodable; all others are stored as raw exceptions.
+ */
+class CompressionCodecALP final : public ICompressionCodec
+{
+public:
+    explicit CompressionCodecALP(UInt8 float_width_);
+    uint8_t getMethodByte() const override;
+    void updateHash(SipHash & hash) const override;
+protected:
+    UInt32 doCompressData(const char * source, UInt32 source_size, char * dest) const override;
+    UInt32 doDecompressData(const char * source, UInt32 source_size, char * dest, UInt32 uncompressed_size) const override;
+    UInt32 getMaxCompressedDataSize(UInt32 uncompressed_size) const override;
+    bool isCompression() const override { return true; }
+    bool isGenericCompression() const override { return false; }
+    bool isFloatingPointTimeSeriesCodec() const override { return true; }
+    bool isExperimental() const override { return true; }
+    String getDescription() const override;
+private:
+    UInt8 float_width;
+};
+
+namespace ErrorCodes
+{
+    extern const int CANNOT_COMPRESS;
+    extern const int CANNOT_DECOMPRESS;
+    extern const int BAD_ARGUMENTS;
+    extern const int ILLEGAL_SYNTAX_FOR_CODEC_TYPE;
+}
+
+namespace
+{
+constexpr UInt8 ALP_CODEC_VERSION = 1;
+
+/**
+ * ALP codec header size in bytes: meta (1) + float width (1) + block float count (2)
+ */
+constexpr UInt32 ALP_CODEC_HEADER_SIZE = 2 * sizeof(UInt8) + sizeof(UInt16);
+
+/**
+ * ALP block header size in bytes: exponent (1) + fraction (1) + exception count (2) + bit-width (1) + FOR base (8)
+ */
+constexpr UInt32 ALP_BLOCK_HEADER_SIZE = 3 * sizeof(UInt8) + sizeof(UInt16) + sizeof(Int64);
+
+constexpr UInt32 ALP_UNENCODED_BLOCK_HEADER_SIZE = sizeof(UInt8);
+constexpr UInt8 ALP_UNENCODED_BLOCK_EXPONENT = 255;
+
+/**
+ * Maximum number of floats per ALP block. Reference FastLanes implementation uses 1024 values only.
+ * Exactly the same size is used for FastLanes FFOR.
+ * Changing this value affects compatibility with FastLanes, and it likely won't auto-vectorise. Don't do it.
+ */
+constexpr UInt32 ALP_BLOCK_MAX_FLOAT_COUNT = Compression::FFOR::DEFAULT_VALUES;
+
+constexpr UInt32 ALP_PARAMS_ESTIMATION_SAMPLES = 8;
+constexpr UInt32 ALP_PARAMS_ESTIMATION_SAMPLE_FLOATS = 32;
+constexpr UInt32 ALP_PARAMS_ESTIMATION_CANDIDATES = 5;
+
+/**
+ * Alignment for internal ALP buffers. Used to align buffers for FFOR encoding/decoding.
+ * \note FastLanes FFOR requires 64-byte alignment for optimal performance.
+ */
+constexpr UInt8 ALP_BUFFER_ALIGNMENT = 64;
+
+template <typename T>
+concept FLOAT = std::is_same_v<T, Float32> || std::is_same_v<T, Float64>;
+
+template <FLOAT T>
+struct ALPFloatTraits;
+
+template <FLOAT T, UInt32 exponent_count, bool inverse>
+constexpr std::array<T, exponent_count> generatePowersOf10()
+{
+    std::array<T, exponent_count> arr{};
+    for (UInt64 i = 0, v = 1; i < exponent_count; ++i, v *= 10)
+        arr[i] = inverse ? static_cast<T>(1) / static_cast<T>(v) : static_cast<T>(v);
+    return arr;
+}
+
+/**
+ * ALP Float64 parameters.
+ *
+ * Float64 scaling is limited to 10^18 and inputs are clamped to ±9223372036854773760 (2^63 − 2048).
+ * In this range, a meaningful subset of values still "survives" scale by 10^e → round → cast to Int64.
+ * The reference implementation use 9223372036854774784 (2^63 − 1024), which led to integer overflow after rounding (num + magic - magic).
+ */
+template<>
+struct ALPFloatTraits<Float64>
+{
+    static constexpr UInt8 EXPONENT_COUNT = 19;
+
+    static constexpr std::array<Float64, EXPONENT_COUNT> EXPONENTS = generatePowersOf10<Float64, EXPONENT_COUNT, false>();
+    static constexpr std::array<Float64, EXPONENT_COUNT> FRACTIONS = generatePowersOf10<Float64, EXPONENT_COUNT, true>();
+
+    static constexpr Float64 UPPER = 9223372036854773760.0;
+    static constexpr Float64 LOWER = -9223372036854773760.0;
+
+    static constexpr Float64 ROUND_MAGIC = 6755399441055744.0; // 2^51 + 2^52
+};
+
+/**
+ * ALP Float32 parameters.
+ *
+ * Float32 scaling is limited to 10^9 and inputs are clamped to ±9223371487098961920.
+ * In this range, a meaningful subset of values still "survives" scale by 10^e → round → cast to Int64.
+ *
+ * The UPPER value is the largest Float32 value that has an exact Int64 representation.
+ * Higher values would overflow when cast to Int64 after Float32 rounding (num + magic - magic).
+ */
+template<>
+struct ALPFloatTraits<Float32>
+{
+    static constexpr UInt8 EXPONENT_COUNT = 10;
+
+    static constexpr std::array<Float32, EXPONENT_COUNT> EXPONENTS = generatePowersOf10<Float32, EXPONENT_COUNT, false>();
+    static constexpr std::array<Float32, EXPONENT_COUNT> FRACTIONS = generatePowersOf10<Float32, EXPONENT_COUNT, true>();
+
+    static constexpr Float32 UPPER = 9223371487098961920.0f;
+    static constexpr Float32 LOWER = -9223371487098961920.0f;
+
+    static constexpr Float32 ROUND_MAGIC = 12582912.0f; // 2^22 + 2^23
+};
+
+template<FLOAT T>
+struct ALPFloatUtils
+{
+    static Int64 encodeValue(T value, UInt8 exponent, UInt8 fraction)
+    {
+        // Scale float to integer, it is important to keep two multiplication steps to comply with the ALP paper and reference implementation
+        T value_enc = value * ALPFloatTraits<T>::EXPONENTS[exponent] * ALPFloatTraits<T>::FRACTIONS[fraction];
+
+        const bool invalid = std::isinf(value_enc) ||
+            std::isnan(value_enc) ||
+                value_enc < ALPFloatTraits<T>::LOWER || value_enc > ALPFloatTraits<T>::UPPER ||
+                    (value_enc == static_cast<T>(0.0) && std::signbit(value_enc));
+
+        if (unlikely(invalid))
+            return static_cast<Int64>(ALPFloatTraits<T>::UPPER);
+
+        // Fast rounding to integer by adding and subtracting a large constant (IEEE-754 mantissa limit)
+        value_enc = value_enc + ALPFloatTraits<T>::ROUND_MAGIC - ALPFloatTraits<T>::ROUND_MAGIC;
+        return static_cast<Int64>(value_enc);
+    }
+
+    static T decodeValue(Int64 value, UInt8 exponent, UInt8 fraction)
+    {
+        T value_float = static_cast<T>(value);
+        // Scale back to float, it is important to keep two multiplication steps to comply with the ALP paper and reference implementation
+        T value_dec = value_float * ALPFloatTraits<T>::EXPONENTS[fraction] * ALPFloatTraits<T>::FRACTIONS[exponent];
+        return value_dec;
+    }
+};
+
+template <FLOAT T>
+class ALPCodecEncoder
+{
+public:
+    ALPCodecEncoder() = default;
+
+    UInt32 encode(const char * source, const UInt32 source_size, char * dest)
+    {
+        if (source_size % sizeof(T) != 0)
+            throw Exception(ErrorCodes::CANNOT_COMPRESS, "Cannot compress with ALP codec, data size {} is not aligned to {}", source_size, sizeof(T));
+
+        UInt32 float_count = source_size / sizeof(T);
+
+        estimateParamCandidates(source, float_count);
+
+        const char * dest_start = dest;
+
+        while (float_count >= ALP_BLOCK_MAX_FLOAT_COUNT)
+        {
+            dest = encodeBlock(source, ALP_BLOCK_MAX_FLOAT_COUNT, dest);
+            source += ALP_BLOCK_MAX_FLOAT_COUNT * sizeof(T);
+            float_count -= ALP_BLOCK_MAX_FLOAT_COUNT;
+        }
+
+        if (float_count > 0)
+            dest = encodeBlock(source, static_cast<UInt16>(float_count), dest);
+
+        return static_cast<UInt32>(dest - dest_start);
+    }
+
+private:
+    struct EncodingParams
+    {
+        UInt8 exponent;
+        UInt8 fraction;
+    };
+
+    struct EncodingException
+    {
+        UInt16 index;
+        T value;
+    };
+
+    struct BlockState
+    {
+        EncodingParams params;
+
+        alignas(ALP_BUFFER_ALIGNMENT) Int64 encoded_floats[ALP_BLOCK_MAX_FLOAT_COUNT];
+        UInt32 encoded_float_count;
+
+        alignas(ALP_BUFFER_ALIGNMENT) UInt64 bitpacked[ALP_BLOCK_MAX_FLOAT_COUNT];
+        UInt32 bitpacked_bytes;
+
+        UInt8 bits;
+        Int64 frame_of_reference;
+
+        EncodingException exceptions[ALP_BLOCK_MAX_FLOAT_COUNT];
+        UInt32 exceptions_count;
+    };
+
+    std::vector<EncodingParams> param_candidates;
+    BlockState block;
+
+    char * encodeBlock(const char * source, const UInt16 float_count, char * dest)
+    {
+        encodeBlockToState(source, float_count);
+
+        // Check if encoding yields size reduction
+        const size_t total_encoded_size = ALP_BLOCK_HEADER_SIZE + block.bitpacked_bytes + block.exceptions_count * (sizeof(UInt16) + sizeof(T));
+        const size_t total_unencoded_size = ALP_UNENCODED_BLOCK_HEADER_SIZE + float_count * sizeof(T);
+        if (total_encoded_size >= total_unencoded_size) // No compression gain
+            return writeUnencoded(source, float_count, dest);
+
+        // Exponent and Fraction Indices
+        *dest++ = block.params.exponent;
+        *dest++ = block.params.fraction;
+
+        // Exception Count
+        unalignedStoreLittleEndian<UInt16>(dest, static_cast<UInt16>(block.exceptions_count));
+        dest += sizeof(UInt16);
+
+        // Encoding Bit-Width
+        *dest++ = block.bits;
+
+        // Frame of Reference Value
+        unalignedStoreLittleEndian<Int64>(dest, block.frame_of_reference);
+        dest += sizeof(Int64);
+
+        // Write Encoded Values
+        memcpy(dest, block.bitpacked, block.bitpacked_bytes);
+        dest += block.bitpacked_bytes;
+
+        // Write Exceptions
+        for (UInt32 i = 0; i < block.exceptions_count; ++i)
+        {
+            const EncodingException & exception = block.exceptions[i];
+            unalignedStoreLittleEndian<UInt16>(dest, exception.index);
+            unalignedStoreLittleEndian<T>(dest + sizeof(UInt16), exception.value);
+            dest += sizeof(UInt16) + sizeof(T);
+        }
+
+        return dest;
+    }
+
+    const char * encodeBlockToState(const char * source, const UInt16 float_count)
+    {
+        block.params = selectBlockParams(source, float_count);
+
+        block.encoded_float_count = 0;
+        block.exceptions_count = 0;
+
+        Int64 min = std::numeric_limits<Int64>::max();
+        Int64 max = std::numeric_limits<Int64>::min();
+
+        for (UInt16 i = 0; i < float_count; ++i, source += sizeof(T))
+        {
+            const T value = unalignedLoadLittleEndian<T>(source);
+            const Int64 value_enc = ALPFloatUtils<T>::encodeValue(value, block.params.exponent, block.params.fraction);
+            const T value_dec = ALPFloatUtils<T>::decodeValue(value_enc, block.params.exponent, block.params.fraction);
+
+            block.encoded_floats[block.encoded_float_count++] = value_enc;
+
+            if (likely(value == value_dec))
+            {
+                min = std::min(value_enc, min);
+                max = std::max(value_enc, max);
+            }
+            else
+                block.exceptions[block.exceptions_count++] = {i, value};
+        }
+
+        block.frame_of_reference = min;
+        block.bits = calculateEncodeBits(min, max);
+        block.bitpacked_bytes = Compression::FFOR::calculateBitpackedBytes<ALP_BLOCK_MAX_FLOAT_COUNT>(block.bits);
+
+        // Fill exceptions positions with frame_of_reference value, it becomes zero after FOR encoding
+        for (UInt32 i = 0; i < block.exceptions_count; ++i)
+            block.encoded_floats[block.exceptions[i].index] = block.frame_of_reference;
+
+        // Fill remaining positions with min value (if any), FFOR always encodes 1024 values even if block is partial
+        std::fill(block.encoded_floats + block.encoded_float_count, block.encoded_floats + ALP_BLOCK_MAX_FLOAT_COUNT, block.frame_of_reference);
+
+        bitPackEncodedFloats();
+
+        return source;
+    }
+
+    void bitPackEncodedFloats()
+    {
+        const UInt64 * __restrict in = reinterpret_cast<const UInt64 *>(block.encoded_floats);
+        UInt64 * __restrict out = block.bitpacked;
+
+        Compression::FFOR::bitPack<ALP_BLOCK_MAX_FLOAT_COUNT>(in, out, block.bits, block.frame_of_reference);
+    }
+
+    static char * writeUnencoded(const char * source, const UInt16 float_count, char * dest)
+    {
+        *dest++ = ALP_UNENCODED_BLOCK_EXPONENT; // Unencoded block marker
+
+        const size_t block_size = float_count * sizeof(T);
+        memcpy(dest, source, block_size);
+        dest += block_size;
+
+        return dest;
+    }
+
+    EncodingParams selectBlockParams(const char * source, const UInt32 float_count)
+    {
+        assert(param_candidates.size() > 0);
+        if (param_candidates.size() == 1)
+            return param_candidates[0];
+
+        // Sample up to ALP_PARAMS_ESTIMATION_SAMPLE_FLOATS values from the block for local parameter estimation.
+        // Evenly select sample values across the block and copy them into a temporary buffer for evaluation.
+        T sample[ALP_PARAMS_ESTIMATION_SAMPLE_FLOATS];
+        const UInt32 sample_count = std::min<UInt32>(float_count, ALP_PARAMS_ESTIMATION_SAMPLE_FLOATS);
+        const UInt32 sample_step = std::max(float_count / sample_count, 1u);
+        for (UInt32 i = 0; i < sample_count; ++i)
+            sample[i] = unalignedLoadLittleEndian<T>(&source[i * sample_step * sizeof(T)]);
+
+        EncodingParams best_params = {0, 0};
+        size_t best_size = std::numeric_limits<size_t>::max();
+        bool is_prev_worse = false;
+
+        for (const auto & params : param_candidates)
+        {
+            const size_t estimated_size = estimateEncodedSize(sample, sample_count, params);
+            if (estimated_size < best_size)
+            {
+                best_size = estimated_size;
+                best_params = params;
+                is_prev_worse = false;
+            }
+            else if (estimated_size == best_size)
+                is_prev_worse = false;
+            else
+            {
+                if (is_prev_worse)
+                    break; // Early stop if two consecutive candidates are worse
+                is_prev_worse = true;
+            }
+        }
+
+        return best_params;
+    }
+
+    void estimateParamCandidates(const char * source, const UInt32 float_count)
+    {
+        struct Estimation
+        {
+            EncodingParams params;
+            UInt32 occurred_times;
+        };
+        std::unordered_map<UInt16, Estimation> estimations_map;
+
+        // Take ALP_PARAMS_ESTIMATION_SAMPLES samples from the entire column for global parameter estimation.
+        // Evenly select sample positions across the column.
+        const UInt32 sample_step = float_count > ALP_PARAMS_ESTIMATION_SAMPLES * ALP_PARAMS_ESTIMATION_SAMPLE_FLOATS
+            ? (float_count - ALP_PARAMS_ESTIMATION_SAMPLES * ALP_PARAMS_ESTIMATION_SAMPLE_FLOATS) / ALP_PARAMS_ESTIMATION_SAMPLES
+            : ALP_PARAMS_ESTIMATION_SAMPLE_FLOATS;
+
+        T sample[ALP_PARAMS_ESTIMATION_SAMPLE_FLOATS];
+
+        // For each sample, brute-force over all valid (exponent, fraction) pairs to find the best parameters for that sample.
+        for (UInt32 i = 0; i < ALP_PARAMS_ESTIMATION_SAMPLES; ++i)
+        {
+            const UInt32 sample_start_index = i * sample_step;
+            if (sample_start_index >= float_count)
+                break;
+
+            const char * sample_pos = source + sample_start_index * sizeof(T);
+            const UInt32 sample_float_count = std::min<UInt32>(ALP_PARAMS_ESTIMATION_SAMPLE_FLOATS, float_count - sample_start_index);
+
+            for (UInt32 j = 0; j < sample_float_count; ++j, sample_pos += sizeof(T))
+                sample[j] = unalignedLoadLittleEndian<T>(sample_pos);
+
+            Estimation best_estimation = {{0, 0}, 0};
+            size_t best_size = std::numeric_limits<size_t>::max();
+
+            for (UInt8 exponent = 0; exponent < ALPFloatTraits<T>::EXPONENT_COUNT; ++exponent)
+            {
+                for (UInt8 fraction = 0; fraction <= exponent; ++fraction)
+                {
+                    const Estimation estimation{{exponent, fraction}, 1};
+                    const size_t estimated_size = estimateEncodedSize(sample, sample_float_count, estimation.params);
+
+                    if (estimated_size < best_size)
+                    {
+                        best_size = estimated_size;
+                        best_estimation = estimation;
+                    }
+                }
+            }
+
+            const UInt16 key = static_cast<UInt16>((best_estimation.params.exponent << 8) | best_estimation.params.fraction);
+            auto it = estimations_map.find(key);
+            if (it != estimations_map.end())
+                ++(it->second.occurred_times);
+            else
+                estimations_map[key] = best_estimation;
+        }
+
+        // Sort estimations by occurred times desc, exponent asc, fraction asc
+        std::array<Estimation, ALP_PARAMS_ESTIMATION_SAMPLES> estimations;
+        UInt32 estimation_count = 0;
+        for (const auto & [_, estimation] : estimations_map)
+            estimations[estimation_count++] = estimation;
+        std::sort(estimations.begin(), estimations.begin() + estimation_count,
+            [](const Estimation & a, const Estimation & b)
+            {
+                if (a.occurred_times == b.occurred_times)
+                {
+                    if (a.params.exponent == b.params.exponent)
+                        return a.params.fraction < b.params.fraction;
+                    return a.params.exponent < b.params.exponent;
+                }
+                return a.occurred_times > b.occurred_times;
+            });
+
+        // Keep top ALP_PARAMS_ESTIMATION_CANDIDATES candidates
+        param_candidates.clear();
+        estimation_count = std::min(estimation_count, ALP_PARAMS_ESTIMATION_CANDIDATES);
+        for (UInt32 i = 0; i < estimation_count; ++i)
+            param_candidates.push_back(estimations[i].params);
+    }
+
+    static size_t estimateEncodedSize(const T * const source, const UInt32 float_count, const EncodingParams & params)
+    {
+        Int64 min = std::numeric_limits<Int64>::max();
+        Int64 max = std::numeric_limits<Int64>::min();
+        UInt32 exception_count = 0;
+
+        for (UInt32 i = 0; i < float_count; ++i)
+        {
+            const T value = source[i];
+            const Int64 value_enc = ALPFloatUtils<T>::encodeValue(value, params.exponent, params.fraction);
+            const T value_dec = ALPFloatUtils<T>::decodeValue(value_enc, params.exponent, params.fraction);
+
+            if (likely(value == value_dec))
+            {
+                min = std::min(value_enc, min);
+                max = std::max(value_enc, max);
+            }
+            else
+                ++exception_count;
+        }
+
+        const UInt8 bits = calculateEncodeBits(min, max);
+        const size_t total_size = ALP_BLOCK_HEADER_SIZE + float_count * bits / 8 + exception_count * (sizeof(UInt16) + sizeof(T));
+        return total_size;
+    }
+
+    static UInt8 calculateEncodeBits(const Int64 min_value, const Int64 max_value)
+    {
+        if (unlikely(min_value > max_value))
+            return sizeof(Int64) * 8; // Edge case when no values are encoded or overflow happened.
+
+        // Cast to UInt64 to correctly handle the full Int64 range and potential overflow when values are close to the limits.
+        const UInt64 diff = static_cast<UInt64>(max_value) - static_cast<UInt64>(min_value);
+        if (unlikely(diff == 0))
+            return 0; // Edge case when all values are the same.
+
+        const auto bits = sizeof(Int64) * 8 - getLeadingZeroBitsUnsafe<UInt64>(diff);
+        return static_cast<UInt8>(bits);
+    }
+};
+
+template <FLOAT T>
+class ALPCodecDecoder
+{
+public:
+    explicit ALPCodecDecoder() = default;
+
+    UInt32 decode(const char * source, UInt32 source_size, char * dest, UInt32 uncompressed_size)
+    {
+        if (uncompressed_size % sizeof(T) != 0)
+            throw Exception(ErrorCodes::CANNOT_DECOMPRESS, "Cannot decompress ALP-encoded data, invalid uncompressed size");
+
+        const char * source_end = source + source_size;
+        const char * dest_start = dest;
+        const char * dest_end = dest + uncompressed_size;
+
+        while (source < source_end)
+        {
+            const UInt16 block_float_count = static_cast<UInt16>(std::min<size_t>(ALP_BLOCK_MAX_FLOAT_COUNT, (dest_end - dest) / sizeof(T)));
+            decodeBlock(source, source_end, dest, dest_end, block_float_count);
+        }
+
+        if (source != source_end || dest != dest_end)
+            throw Exception(ErrorCodes::CANNOT_DECOMPRESS, "Cannot decompress ALP-encoded data, stream size mismatch");
+
+        return static_cast<UInt32>(dest - dest_start);
+    }
+
+private:
+    struct BlockState
+    {
+        alignas(ALP_BUFFER_ALIGNMENT) Int64 encoded[ALP_BLOCK_MAX_FLOAT_COUNT];
+        alignas(ALP_BUFFER_ALIGNMENT) UInt64 bitpacked[ALP_BLOCK_MAX_FLOAT_COUNT];
+    };
+
+    BlockState block;
+
+    void decodeBlock(const char * & source, const char * source_end, char * & dest, const char * dest_end, const UInt16 float_count)
+    {
+        if (unlikely(source + ALP_UNENCODED_BLOCK_HEADER_SIZE > source_end))
+            throw Exception(ErrorCodes::CANNOT_DECOMPRESS,
+                "Cannot decompress ALP-encoded data, incomplete block header");
+
+        // Read exponent byte and check for unencoded block marker
+        const UInt8 exponent = static_cast<UInt8>(*source++);
+        if (exponent == ALP_UNENCODED_BLOCK_EXPONENT)
+        {
+            processUnencodedBlock(source, source_end, dest, dest_end, float_count);
+            return;
+        }
+        if (unlikely(exponent >= ALPFloatTraits<T>::EXPONENT_COUNT))
+            throw Exception(ErrorCodes::CANNOT_DECOMPRESS,
+                "Cannot decompress ALP-encoded data, invalid exponent value: {}, max allowed: {}",
+                static_cast<UInt32>(exponent), static_cast<UInt32>(ALPFloatTraits<T>::EXPONENT_COUNT - 1));
+
+        if (unlikely(source + (ALP_BLOCK_HEADER_SIZE - ALP_UNENCODED_BLOCK_HEADER_SIZE) > source_end))
+            throw Exception(ErrorCodes::CANNOT_DECOMPRESS,
+                "Cannot decompress ALP-encoded data, incomplete block header (encoded)");
+
+        // Read fraction
+        const UInt8 fraction = static_cast<UInt8>(*source++);
+        if (unlikely(fraction >= ALPFloatTraits<T>::EXPONENT_COUNT))
+            throw Exception(ErrorCodes::CANNOT_DECOMPRESS,
+                "Cannot decompress ALP-encoded data, invalid fraction value: {}, max allowed: {}",
+                static_cast<UInt32>(fraction), static_cast<UInt32>(ALPFloatTraits<T>::EXPONENT_COUNT - 1));
+
+        // Read exception count
+        const UInt16 exception_count = unalignedLoadLittleEndian<UInt16>(source);
+        source += sizeof(UInt16);
+
+        // Read bits
+        const UInt8 bits = static_cast<UInt8>(*source++);
+        const UInt32 bitpacked_size = Compression::FFOR::calculateBitpackedBytes<ALP_BLOCK_MAX_FLOAT_COUNT>(bits);
+
+        // Read frame of reference
+        const Int64 frame_of_reference = unalignedLoadLittleEndian<Int64>(source);
+        source += sizeof(Int64);
+
+        // Validate block payload size
+        const size_t total_encoded_size = bitpacked_size + exception_count * (sizeof(UInt16) + sizeof(T));
+        if (unlikely(source + total_encoded_size > source_end))
+            throw Exception(ErrorCodes::CANNOT_DECOMPRESS,
+                "Cannot decompress ALP-encoded data, incomplete block payload, available size: {}, bit-width: {}, exceptions: {}",
+                source_end - source, static_cast<UInt32>(bits), static_cast<UInt32>(exception_count));
+
+        // Read bit-packed values into temporary buffer and decode
+        memcpy(block.bitpacked, source, bitpacked_size);
+        source += bitpacked_size;
+        bitUnpackEncodedFloats(bits, frame_of_reference);
+
+        // Write decoded values to output buffer
+        char * dest_start = dest;
+        for (UInt16 i = 0; i < float_count; ++i, dest += sizeof(T))
+        {
+            const T decoded_value = ALPFloatUtils<T>::decodeValue(block.encoded[i], exponent, fraction);
+            unalignedStoreLittleEndian<T>(dest, decoded_value);
+        }
+
+        // Write exceptions into corresponding positions in output buffer
+        for (UInt16 i = 0; i < exception_count; ++i)
+        {
+            const UInt16 exception_index = unalignedLoadLittleEndian<UInt16>(source);
+            const T exception_value = unalignedLoadLittleEndian<T>(source + sizeof(UInt16));
+            source += sizeof(UInt16) + sizeof(T);
+
+            if (unlikely(exception_index >= float_count))
+                throw Exception(ErrorCodes::CANNOT_DECOMPRESS,
+                    "Cannot decompress ALP-encoded data, invalid exception index, index: {}, float count: {}",
+                    exception_index, float_count);
+
+            const UInt32 dest_offset = exception_index * sizeof(T);
+            unalignedStoreLittleEndian<T>(dest_start + dest_offset, exception_value);
+        }
+    }
+
+    void bitUnpackEncodedFloats(const UInt8 bits, const Int64 frame_of_reference)
+    {
+        const UInt64 * __restrict in = block.bitpacked;
+        UInt64 * __restrict out = reinterpret_cast<UInt64 *>(block.encoded);
+
+        Compression::FFOR::bitUnpack<ALP_BLOCK_MAX_FLOAT_COUNT>(in, out, bits, frame_of_reference);
+    }
+
+    static void processUnencodedBlock(const char * & source, const char * source_end, char * & dest, const char * dest_end, const UInt16 float_count)
+    {
+        const size_t block_size = float_count * sizeof(T);
+        if (source + block_size > source_end || dest + block_size > dest_end)
+            throw Exception(ErrorCodes::CANNOT_DECOMPRESS, "Cannot decompress ALP-encoded data, incomplete uncompressed block");
+
+        memcpy(dest, source, block_size);
+        source += block_size;
+        dest += block_size;
+    }
+};
+
+}
+
+CompressionCodecALP::CompressionCodecALP(UInt8 float_width_)
+    : float_width(float_width_)
+{
+    setCodecDescription("ALP", {});
+}
+
+uint8_t CompressionCodecALP::getMethodByte() const
+{
+    return static_cast<uint8_t>(CompressionMethodByte::ALP);
+}
+
+void CompressionCodecALP::updateHash(SipHash & hash) const
+{
+    getCodecDesc()->updateTreeHash(hash, /* ignore_aliases */ true);
+}
+
+String CompressionCodecALP::getDescription() const
+{
+    return "Adaptive Lossless floating-Point; suitable for time series data.";
+}
+
+UInt32 CompressionCodecALP::getMaxCompressedDataSize(UInt32 uncompressed_size) const
+{
+    // Maximum possible encoding size = uncompressed data + codec header + number of blocks * block header
+    const UInt32 num_blocks = uncompressed_size / float_width / ALP_BLOCK_MAX_FLOAT_COUNT + 1;
+    return uncompressed_size + ALP_CODEC_HEADER_SIZE + num_blocks * ALP_BLOCK_HEADER_SIZE;
+}
+
+UInt32 CompressionCodecALP::doCompressData(const char * source, UInt32 source_size, char * dest) const
+{
+    // Write ALP header
+    *dest++ = ALP_CODEC_VERSION; // meta_byte: version = 1, variant = 0
+    *dest++ = float_width;
+    unalignedStoreLittleEndian<UInt16>(dest, ALP_BLOCK_MAX_FLOAT_COUNT);
+    dest += sizeof(UInt16);
+
+    UInt32 dest_size = 0;
+
+    switch (float_width)
+    {
+    case sizeof(Float32):
+        dest_size = ALPCodecEncoder<Float32>().encode(source, source_size, dest);
+        break;
+    case sizeof(Float64):
+        dest_size = ALPCodecEncoder<Float64>().encode(source, source_size, dest);
+        break;
+    default:
+        throw Exception(ErrorCodes::CANNOT_COMPRESS,
+            "Cannot compress with codec ALP, unsupported float width {}",
+            static_cast<size_t>(float_width));
+    }
+
+    return dest_size + ALP_CODEC_HEADER_SIZE;
+}
+
+UInt32 CompressionCodecALP::doDecompressData(const char * source, UInt32 source_size, char * dest, UInt32 uncompressed_size) const
+{
+    if (source_size < ALP_CODEC_HEADER_SIZE)
+        throw Exception(ErrorCodes::CANNOT_DECOMPRESS, "Cannot decompress ALP-encoded data, data has wrong header");
+
+    const UInt8 meta_byte = static_cast<UInt8>(*source++);
+    const UInt8 codec_version = meta_byte & 0x0F;
+    const UInt8 codec_variant = meta_byte >> 4 & 0x01;
+
+    if (codec_version != ALP_CODEC_VERSION)
+        throw Exception(ErrorCodes::CANNOT_DECOMPRESS,
+            "Cannot decompress ALP-encoded data, unsupported codec version {}",
+            static_cast<UInt32>(codec_version));
+
+    if (codec_variant != 0)
+        throw Exception(ErrorCodes::CANNOT_DECOMPRESS,
+            "Cannot decompress ALP-encoded data, unsupported codec variant {}",
+            static_cast<UInt32>(codec_variant));
+
+    const UInt8 data_float_width = static_cast<UInt8>(*source++);
+
+    const UInt16 block_float_count = unalignedLoadLittleEndian<UInt16>(source);
+    source += sizeof(UInt16);
+    if (block_float_count != ALP_BLOCK_MAX_FLOAT_COUNT)
+        throw Exception(ErrorCodes::CANNOT_DECOMPRESS,
+            "Cannot decompress ALP-encoded data, supported block float count is {}, got {}",
+            ALP_BLOCK_MAX_FLOAT_COUNT, block_float_count);
+
+    source_size -= ALP_CODEC_HEADER_SIZE;
+    UInt32 dest_size;
+
+    switch (data_float_width)
+    {
+    case sizeof(Float32):
+        dest_size = ALPCodecDecoder<Float32>().decode(source, source_size, dest, uncompressed_size);
+        break;
+    case sizeof(Float64):
+        dest_size = ALPCodecDecoder<Float64>().decode(source, source_size, dest, uncompressed_size);
+        break;
+    default:
+        throw Exception(ErrorCodes::CANNOT_DECOMPRESS,
+            "Cannot decompress ALP-encoded data, unsupported float width {}",
+            static_cast<size_t>(data_float_width));
+    }
+
+    return dest_size;
+}
+
+void registerCodecALP(CompressionCodecFactory & factory)
+{
+    auto method_code = static_cast<UInt8>(CompressionMethodByte::ALP);
+    auto codec_builder = [&](const ASTPtr & arguments, const IDataType * column_type) -> CompressionCodecPtr
+    {
+        if (arguments && !arguments->children.empty())
+            throw Exception(ErrorCodes::ILLEGAL_SYNTAX_FOR_CODEC_TYPE,
+                "ALP codec must have 0 parameters, given {}",
+                arguments->children.size());
+
+        UInt8 float_width = sizeof(Float64);
+        if (column_type)
+        {
+            if (!WhichDataType(column_type).isNativeFloat())
+                throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                    "Codec ALP is not applicable for {} because the data type is not Float*",
+                    column_type->getName());
+
+            float_width = static_cast<UInt8>(column_type->getSizeOfValueInMemory());
+        }
+        return std::make_shared<CompressionCodecALP>(float_width);
+    };
+    factory.registerCompressionCodecWithType("ALP", method_code, codec_builder);
+}
+}

--- a/src/Compression/CompressionFactory.cpp
+++ b/src/Compression/CompressionFactory.cpp
@@ -206,6 +206,7 @@ void registerCodecGorilla(CompressionCodecFactory & factory);
 void registerCodecEncrypted(CompressionCodecFactory & factory);
 void registerCodecFPC(CompressionCodecFactory & factory);
 void registerCodecGCD(CompressionCodecFactory & factory);
+void registerCodecALP(CompressionCodecFactory & factory);
 
 CompressionCodecFactory::CompressionCodecFactory()
 {
@@ -221,6 +222,7 @@ CompressionCodecFactory::CompressionCodecFactory()
     registerCodecEncrypted(*this);
     registerCodecFPC(*this);
     registerCodecGCD(*this);
+    registerCodecALP(*this);
 
     default_codec = get("LZ4", {});
 }

--- a/src/Compression/CompressionInfo.h
+++ b/src/Compression/CompressionInfo.h
@@ -49,6 +49,7 @@ enum class CompressionMethodByte : uint8_t
     /// DeflateQpl      = 0x99, /// Removed, don't reuse for another codec
     GCD             = 0x9a,
     /// ZSTD_QPL        = 0x9b, /// Removed, don't reuse for another codec
+    ALP             = 0x9c,
 };
 
 }

--- a/src/Compression/FFOR.cpp
+++ b/src/Compression/FFOR.cpp
@@ -1,0 +1,12 @@
+#include <Compression/FFOR.h>
+
+namespace DB::Compression::FFOR
+{
+template void bitPack<DEFAULT_VALUES>(const UInt16 * __restrict, UInt16 * __restrict, UInt8, UInt16);
+template void bitPack<DEFAULT_VALUES>(const UInt32 * __restrict, UInt32 * __restrict, UInt8, UInt32);
+template void bitPack<DEFAULT_VALUES>(const UInt64 * __restrict, UInt64 * __restrict, UInt8, UInt64);
+
+template void bitUnpack<DEFAULT_VALUES>(const UInt16 * __restrict, UInt16 * __restrict, UInt8, UInt16);
+template void bitUnpack<DEFAULT_VALUES>(const UInt32 * __restrict, UInt32 * __restrict, UInt8, UInt32);
+template void bitUnpack<DEFAULT_VALUES>(const UInt64 * __restrict, UInt64 * __restrict, UInt8, UInt64);
+}

--- a/src/Compression/FFOR.h
+++ b/src/Compression/FFOR.h
@@ -1,0 +1,402 @@
+#pragma once
+
+/**
+ * This file implements a FFOR algorithm inspired by the FastLanes project:
+ * https://github.com/cwida/FastLanes
+ *
+ * Original work by Azim Afroozeh and the CWI Database Architectures Group, licensed under the MIT License.
+ *
+ * This implementation uses template-based C++ generator approach and adapted to the CH codebase and style.
+ *
+ * Algorithm:
+ *   1. Subtract base (minimum value) from all integers to reduce magnitude.
+ *   2. Pack resulting values using only the required number of bits (e.g. 7 bits for values [0, 127]).
+ *
+ * Important:
+ *   * Original FastLanes implementation processes 1024 values only. Avoid using values other than 1024 at all costs as code likely won't auto-vectorise!
+ *   * Input and output arrays must be aligned to 64-byte boundary for optimal access performance.
+ *   * This implementation is generic to number of values, but changing this affects compatibility with FastLanes reference implementation.
+*/
+
+#include <Common/Exception.h>
+
+namespace DB
+{
+namespace ErrorCodes
+{
+extern const int BAD_ARGUMENTS;
+}
+
+namespace Compression::FFOR
+{
+namespace Details
+{
+template <typename T>
+concept UnsignedInteger = std::is_integral_v<T> && std::is_unsigned_v<T> && !std::is_same_v<T, bool>;
+
+/**
+ * Returns bit-width of unsigned integer type T.
+ */
+template <UnsignedInteger T>
+consteval UInt8 get_width()
+{
+    return sizeof(T) * 8;
+}
+
+/**
+ * Calculates number of iterations (chunks) needed to process 'values' input values in width-sized batches.
+ */
+template <UnsignedInteger T, UInt16 values>
+consteval UInt16 get_iterations()
+{
+    constexpr UInt8 width = get_width<T>();
+    static_assert(values % width == 0, "values must be divisible by bit-width of type T");
+    return values / width;
+}
+
+/**
+ * Packs one input value. Produces compile-time step within unrolled type-width-sized chunk.
+ *
+ * Parameter 'index': Number of current iteration (chunk index).
+ * Parameter 'agg': Accumulator for partial output word, flushed when crossing word size boundary or at end of chunk.
+ * Template parameter 'step': Current step within chunk, [0, width].
+ */
+template <UnsignedInteger T, UInt8 bits, UInt8 step, UInt16 values>
+ALWAYS_INLINE void bitPackStep(const T * __restrict in, T * __restrict out, const T base, const UInt16 index, T & agg)
+{
+    constexpr UInt8 width = get_width<T>();
+    static_assert(bits <= width);
+    static_assert(step <= width);
+
+    constexpr UInt16 iterations = get_iterations<T, values>();
+
+    if constexpr (bits > 0 && bits < width)
+    {
+        constexpr UInt8 shift = (step * bits) % width;
+        constexpr T mask = (T{1} << bits) - 1;
+
+        if constexpr (step > 0 && shift < bits) // Word boundary crossed
+        {
+            // Flush accumulator to output
+            constexpr UInt16 out_offset = iterations * (((step - 1) * bits) / width);
+            out[out_offset + index] = agg;
+
+            if constexpr (step >= width) // End of iteration chunk
+                return;
+
+            // Start new accumulator with spill-over bits from previous input value
+            if constexpr (shift > 0)
+            {
+                // Carry high bits from previous value
+                constexpr UInt16 in_prev_offset = iterations * (step - 1);
+                constexpr UInt8 prev_shift = bits - shift;
+                T v = in[in_prev_offset + index] - base;
+                v &= mask;
+                v >>= prev_shift;
+                agg = v;
+            }
+            else
+                agg = 0; // Aligned, no spill-over
+        }
+        else if constexpr (step == 0)
+            agg = 0;
+
+        if constexpr (step < width)
+        {
+            // Take current value bits and add to accumulator
+            constexpr UInt16 in_offset = iterations * step;
+            T v = in[in_offset + index] - base;
+            v &= mask;
+            v <<= shift;
+            agg |= v;
+        }
+    }
+    else if constexpr (bits == width && step < width)
+    {
+        // Direct copy for full-width values
+        constexpr UInt16 offset = iterations * step;
+        out[offset + index] = in[offset + index] - base;
+    }
+}
+
+/**
+ * Packs input array into bit-packed output using strided iteration pattern.
+ *
+ * Iteration pattern:
+ *   Processes values with stride of 'iterations' (values / width).
+ *   For each chunk i in [0, iterations), processes values at positions:
+ *     [i, i + iterations, i + 2*iterations, ..., i + (width-1)*iterations]
+ *
+ *   Example (UInt64, 1024 values):
+ *     iterations = 16
+ *     Chunk 0: in[0], in[16], in[32], ..., in[1008]
+ *     Chunk 1: in[1], in[17], in[33], ..., in[1009]
+ *
+ * Chunk processing uses fold expression to unroll all steps within chunk at compile time.
+ * Compiler sees all bit positions at compile time and optimizes accordingly.
+ */
+template <UnsignedInteger T, UInt8 bits, UInt16 values>
+void bitPack(const T * __restrict in, T * __restrict out, const T base)
+{
+    if constexpr (bits == 0)
+        return;
+
+    constexpr UInt8 width = get_width<T>();
+    static_assert(bits <= width);
+
+    constexpr UInt16 iterations = get_iterations<T, values>();
+
+    for (UInt16 i = 0; i < iterations; ++i)
+    {
+        [&]<UInt8... step>(std::integer_sequence<UInt8, step ...>) ALWAYS_INLINE
+        {
+            T state = 0;
+            ((bitPackStep<T, bits, step, values>(in, out, base, i, state)), ...);
+        }(std::make_integer_sequence<UInt8, width + 1>{});
+    }
+}
+
+/**
+ * Builds compile-time dispatch table for packing.
+ * Each entry stores a function pointer to bitPack instantiation for specific bits.
+ */
+template <UnsignedInteger T, UInt16 values>
+consteval auto makeBitPackDispatchTable()
+{
+    constexpr UInt8 size = get_width<T>() + 1;
+    return [&]<UInt8... bits>(std::integer_sequence<UInt8, bits...>)
+    {
+        using fn = void(*)(const T * __restrict, T * __restrict, T);
+        return std::array<fn, size>
+        {
+            +[](const T * __restrict in, T * __restrict out, const T base)
+            {
+                bitPack<T, bits, values>(in, out, base);
+            }...
+        };
+    }(std::make_integer_sequence<UInt8, size>{});
+}
+
+/**
+ * Unpacks one output value. Produces compile-time step within unrolled type-width-sized chunk.
+ *
+ * Parameter 'index': Number of current iteration (chunk index).
+ * Parameter 'pack': Current input word being processed.
+ * Template parameter 'step': Current step within chunk, [0, width).
+ */
+template <UnsignedInteger T, UInt8 bits, UInt8 step, UInt16 values>
+ALWAYS_INLINE void bitUnpackStep(const T * __restrict in, T * __restrict out, const T base, const UInt16 index, T & pack)
+{
+    constexpr UInt8 width = get_width<T>();
+    static_assert(bits <= width);
+    static_assert(step < width);
+
+    constexpr UInt16 iterations = get_iterations<T, values>();
+    constexpr UInt16 out_offset = iterations * step;
+
+    if constexpr (bits == 0) // Zero bits: all values equal to base
+        out[index + out_offset] = base;
+    else if constexpr (bits == width) // Full-width: direct copy
+        out[index + out_offset] = in[index + out_offset] + base;
+    else
+    {
+        constexpr UInt8 shift = (step * bits) % width;
+        constexpr UInt8 bits_to_full_width = width - shift;
+        constexpr UInt16 in_offset = iterations * ((step + 1) * bits / width);
+        constexpr bool is_in_value_available = step < width - 1;
+
+        T v;
+        if constexpr (bits_to_full_width < bits) // Value spans word boundary
+        {
+            constexpr T mask1 = (T{1} << bits_to_full_width) - T{1}; // Mask for lower part of value from current word
+            constexpr T mask2 = (T{1} << (bits - bits_to_full_width)) - T{1}; // Mask for upper part of value from next word
+
+            v = (pack >> shift) & mask1;
+            if constexpr (is_in_value_available)
+            {
+                // Get next input word
+                pack = in[index + in_offset];
+                v |= (pack & mask2) << bits_to_full_width;
+            }
+        }
+        else // Value fits within current word
+        {
+            if constexpr (shift == 0)
+            {
+                if constexpr (is_in_value_available)
+                    pack = in[index + in_offset];
+                else
+                    pack = 0;
+            }
+
+            constexpr T mask = (T{1} << bits) - T{1};
+            v = (pack >> shift) & mask;
+        }
+
+        out[index + out_offset] = v + base;
+    }
+}
+
+/**
+ * Unpacks bit-packed input into output array using strided iteration pattern.
+ *
+ * Iteration pattern:
+ *   Mirrors bitPack.
+ *   For each chunk i in [0, iterations), reconstructs values at positions:
+ *     [i, i + iterations, i + 2*iterations, ...]
+ *
+ *   Example (UInt64, 1024 values):
+ *     iterations = 16
+ *     Chunk 0 reconstructs: out[0], out[16], out[32], ..., out[1008]
+ *     Chunk 1 reconstructs: out[1], out[17], out[33], ..., out[1009]
+ *
+ * Chunk processing uses fold expression to unroll all steps within chunk at compile time.
+ * Compiler sees all bit positions at compile time and optimizes accordingly.
+ */
+template <UnsignedInteger T, UInt8 bits, UInt16 values>
+void bitUnpack(const T * __restrict in, T * __restrict out, const T base)
+{
+    constexpr UInt8 width = get_width<T>();
+    static_assert(bits <= width);
+
+    constexpr UInt16 iterations = get_iterations<T, values>();
+
+    for (UInt16 i = 0; i < iterations; ++i)
+    {
+        [&]<UInt8... step>(std::integer_sequence<UInt8, step ...>) ALWAYS_INLINE
+        {
+            T pack = 0;
+            ((bitUnpackStep<T, bits, step, values>(in, out, base, i, pack)), ...);
+        }(std::make_integer_sequence<UInt8, width>{});
+    }
+}
+
+/**
+ * Builds compile-time dispatch table for unpacking.
+ * Each entry stores a function pointer to bitUnpack instantiation for specific bits.
+ */
+template <UnsignedInteger T, UInt16 values>
+consteval auto makeBitUnpackDispatchTable()
+{
+    constexpr UInt8 size = get_width<T>() + 1;
+    return [&]<UInt8... bits>(std::integer_sequence<UInt8, bits...>)
+    {
+        using fn = void(*)(const T * __restrict, T * __restrict, T);
+        return std::array<fn, size>
+        {
+            +[](const T * __restrict in, T * __restrict out, const T base)
+            {
+                bitUnpack<T, bits, values>(in, out, base);
+            }...
+        };
+    }(std::make_integer_sequence<UInt8, size>{});
+}
+}
+
+/**
+ * Default number of values processed by FFOR.
+ * The FastLanes implementation expects 1024 values.
+ * Changing this affects compatibility, and it likely won't auto-vectorise. Avoid at all cost!
+ * More context: https://www.vldb.org/pvldb/vol16/p2132-afroozeh.pdf
+ */
+constexpr UInt16 DEFAULT_VALUES = 1024;
+
+/**
+ * Packs UInt16 input values.
+ * \note Input and output arrays must be 'values' elements long and aligned to 64-byte boundary for optimal access performance.
+ */
+template <UInt16 values = DEFAULT_VALUES>
+void bitPack(const UInt16 * __restrict in, UInt16 * __restrict out, const UInt8 bits, const UInt16 base)
+{
+    static constexpr auto table = Details::makeBitPackDispatchTable<UInt16, values>();
+    if (unlikely(bits >= table.size()))
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Invalid bits for UInt16 packing: {}", static_cast<UInt32>(bits));
+    table[bits](in, out, base);
+}
+
+/**
+ * Unpacks bit-packed UInt16 input values.
+ * \note Input and output arrays must be 'values' elements long and aligned to 64-byte boundary for optimal access performance.
+ */
+template <UInt16 values = DEFAULT_VALUES>
+void bitUnpack(const UInt16 * __restrict in, UInt16 * __restrict out, const UInt8 bits, const UInt16 base)
+{
+    static constexpr auto table = Details::makeBitUnpackDispatchTable<UInt16, values>();
+    if (unlikely(bits >= table.size()))
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Invalid bits for UInt16 unpacking: {}", static_cast<UInt32>(bits));
+    table[bits](in, out, base);
+}
+
+/**
+ * Packs UInt32 input values.
+ * \note Input and output arrays must be 'values' elements long and aligned to 64-byte boundary for optimal access performance.
+ */
+template <UInt16 values = DEFAULT_VALUES>
+void bitPack(const UInt32 * __restrict in, UInt32 * __restrict out, const UInt8 bits, const UInt32 base)
+{
+    static constexpr auto table = Details::makeBitPackDispatchTable<UInt32, values>();
+    if (unlikely(bits >= table.size()))
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Invalid bits for UInt32 packing: {}", static_cast<UInt32>(bits));
+    table[bits](in, out, base);
+}
+
+/**
+ * Unpacks bit-packed UInt32 input values.
+ * \note Input and output arrays must be 'values' elements long and aligned to 64-byte boundary for optimal access performance.
+ */
+template <UInt16 values = DEFAULT_VALUES>
+void bitUnpack(const UInt32 * __restrict in, UInt32 * __restrict out, const UInt8 bits, const UInt32 base)
+{
+    static constexpr auto table = Details::makeBitUnpackDispatchTable<UInt32, values>();
+    if (unlikely(bits >= table.size()))
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Invalid bits for UInt32 unpacking: {}", static_cast<UInt32>(bits));
+    table[bits](in, out, base);
+}
+
+/**
+ * Packs UInt64 input values.
+ * \note Input and output arrays must be 'values' elements long and aligned to 64-byte boundary for optimal access performance.
+ */
+template <UInt16 values = DEFAULT_VALUES>
+void bitPack(const UInt64 * __restrict in, UInt64 * __restrict out, const UInt8 bits, const UInt64 base)
+{
+    static constexpr auto table = Details::makeBitPackDispatchTable<UInt64, values>();
+    if (unlikely(bits >= table.size()))
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Invalid bits for UInt64 packing: {}", static_cast<UInt32>(bits));
+    table[bits](in, out, base);
+}
+
+/**
+ * Unpacks bit-packed UInt64 input values.
+ * \note Input and output arrays must be 'values' elements long and aligned to 64-byte boundary for optimal access performance.
+ */
+template <UInt16 values = DEFAULT_VALUES>
+void bitUnpack(const UInt64 * __restrict in, UInt64 * __restrict out, const UInt8 bits, const UInt64 base)
+{
+    static constexpr auto table = Details::makeBitUnpackDispatchTable<UInt64, values>();
+    if (unlikely(bits >= table.size()))
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Invalid bits for UInt64 unpacking: {}", static_cast<UInt32>(bits));
+    table[bits](in, out, base);
+}
+
+/**
+ * Calculates number of bytes required to store input values bit-packed with 'bits' bits per value.
+ */
+template <UInt16 values = DEFAULT_VALUES>
+ALWAYS_INLINE UInt16 calculateBitpackedBytes(const UInt8 bits)
+{
+    return bits * values / 8;
+}
+
+// Explicit instantiations to reduce compilation times and binary size
+
+extern template void bitPack<DEFAULT_VALUES>(const UInt16 * __restrict, UInt16 * __restrict, UInt8, UInt16);
+extern template void bitPack<DEFAULT_VALUES>(const UInt32 * __restrict, UInt32 * __restrict, UInt8, UInt32);
+extern template void bitPack<DEFAULT_VALUES>(const UInt64 * __restrict, UInt64 * __restrict, UInt8, UInt64);
+
+extern template void bitUnpack<DEFAULT_VALUES>(const UInt16 * __restrict, UInt16 * __restrict, UInt8, UInt16);
+extern template void bitUnpack<DEFAULT_VALUES>(const UInt32 * __restrict, UInt32 * __restrict, UInt8, UInt32);
+extern template void bitUnpack<DEFAULT_VALUES>(const UInt64 * __restrict, UInt64 * __restrict, UInt8, UInt64);
+
+}
+}

--- a/src/Compression/tests/gtest_compressionCodec.cpp
+++ b/src/Compression/tests/gtest_compressionCodec.cpp
@@ -522,12 +522,13 @@ public:
 
 TEST_P(CodecTest, TranscodingWithDataType)
 {
-    /// Gorilla can only be applied to floating point columns
-    bool codec_is_gorilla = std::get<0>(GetParam()).codec_statement.contains("Gorilla");
-    WhichDataType which(std::get<1>(GetParam()).data_type.get());
-    bool data_is_float = which.isFloat();
-    if (codec_is_gorilla && !data_is_float)
-        GTEST_SKIP() << "Skipping Gorilla-compressed non-float column";
+    /// Gorilla and ALP can only be applied to floating point columns
+    const auto & codec_statement = std::get<0>(GetParam()).codec_statement;
+    const bool codec_is_float_point = codec_statement.contains("Gorilla") || codec_statement.contains("ALP");
+    const WhichDataType which(std::get<1>(GetParam()).data_type.get());
+    const bool data_is_float = which.isFloat();
+    if (codec_is_float_point && !data_is_float)
+        GTEST_SKIP() << "Skipping Float-point-compressed non-float column";
 
     const auto codec = makeCodec(CODEC_WITH_DATA_TYPE);
     testTranscoding(*codec);
@@ -668,7 +669,7 @@ auto SequentialGenerator = [](auto stride = 1)
     return [=](auto i)
     {
         using ValueType = decltype(i);
-        return static_cast<ValueType>(stride * i);
+        return static_cast<ValueType>(static_cast<ValueType>(stride) * i);
     };
 };
 
@@ -815,7 +816,10 @@ const auto DefaultCodecsToTest = ::testing::Values(
     Codec("DoubleDelta, ZSTD"),
     Codec("Gorilla"),
     Codec("Gorilla, LZ4"),
-    Codec("Gorilla, ZSTD")
+    Codec("Gorilla, ZSTD"),
+    Codec("ALP"),
+    Codec("ALP, LZ4"),
+    Codec("ALP, ZSTD")
 );
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -845,6 +849,8 @@ INSTANTIATE_TEST_SUITE_P(SmallSequences,
                 + generatePyramidOfSequences<UInt16>(42, G(SequentialGenerator(1)))
                 + generatePyramidOfSequences<UInt32>(42, G(SequentialGenerator(1)))
                 + generatePyramidOfSequences<UInt64>(42, G(SequentialGenerator(1)))
+                + generatePyramidOfSequences<Float32>(42, G(SequentialGenerator(1)))
+                + generatePyramidOfSequences<Float64>(42, G(SequentialGenerator(1)))
         )
     )
 );
@@ -854,14 +860,16 @@ INSTANTIATE_TEST_SUITE_P(Mixed,
     ::testing::Combine(
         DefaultCodecsToTest,
         ::testing::Values(
-            generateSeq<Int8>(G(MinMaxGenerator()), 1, 5) + generateSeq<Int8>(G(SequentialGenerator(1)), 1, 1001),
+            generateSeq<Int8>(G(MinMaxGenerator()), 1, 5) + generateSeq<Int8>(G(SequentialGenerator(1)), -128, 128),
             generateSeq<Int16>(G(MinMaxGenerator()), 1, 5) + generateSeq<Int16>(G(SequentialGenerator(1)), 1, 1001),
             generateSeq<Int32>(G(MinMaxGenerator()), 1, 5) + generateSeq<Int32>(G(SequentialGenerator(1)), 1, 1001),
             generateSeq<Int64>(G(MinMaxGenerator()), 1, 5) + generateSeq<Int64>(G(SequentialGenerator(1)), 1, 1001),
-            generateSeq<UInt8>(G(MinMaxGenerator()), 1, 5) + generateSeq<UInt8>(G(SequentialGenerator(1)), 1, 1001),
+            generateSeq<UInt8>(G(MinMaxGenerator()), 1, 5) + generateSeq<UInt8>(G(SequentialGenerator(1)), 0, 256),
             generateSeq<UInt16>(G(MinMaxGenerator()), 1, 5) + generateSeq<UInt16>(G(SequentialGenerator(1)), 1, 1001),
             generateSeq<UInt32>(G(MinMaxGenerator()), 1, 5) + generateSeq<UInt32>(G(SequentialGenerator(1)), 1, 1001),
-            generateSeq<UInt64>(G(MinMaxGenerator()), 1, 5) + generateSeq<UInt64>(G(SequentialGenerator(1)), 1, 1001)
+            generateSeq<UInt64>(G(MinMaxGenerator()), 1, 5) + generateSeq<UInt64>(G(SequentialGenerator(1)), 1, 1001),
+            generateSeq<Float32>(G(MinMaxGenerator()), 1, 5) + generateSeq<Float32>(G(SequentialGenerator(1)), 1, 1001),
+            generateSeq<Float64>(G(MinMaxGenerator()), 1, 5) + generateSeq<Float64>(G(SequentialGenerator(1)), 1, 1001)
         )
     )
 );
@@ -905,7 +913,11 @@ INSTANTIATE_TEST_SUITE_P(SameValueFloat,
     ::testing::Combine(
         ::testing::Values(
             Codec("Gorilla"),
-            Codec("Gorilla, LZ4")
+            Codec("Gorilla, LZ4"),
+            Codec("Gorilla, ZSTD"),
+            Codec("ALP"),
+            Codec("ALP, LZ4"),
+            Codec("ALP, ZSTD")
         ),
         ::testing::Values(
             generateSeq<Float32>(G(SameValueGenerator(M_E))),
@@ -919,7 +931,11 @@ INSTANTIATE_TEST_SUITE_P(SameNegativeValueFloat,
     ::testing::Combine(
         ::testing::Values(
             Codec("Gorilla"),
-            Codec("Gorilla, LZ4")
+            Codec("Gorilla, LZ4"),
+            Codec("Gorilla, ZSTD"),
+            Codec("ALP"),
+            Codec("ALP, LZ4"),
+            Codec("ALP, ZSTD")
         ),
         ::testing::Values(
             generateSeq<Float32>(G(SameValueGenerator(-1 * M_E))),
@@ -933,11 +949,11 @@ INSTANTIATE_TEST_SUITE_P(SequentialInt,
     ::testing::Combine(
         DefaultCodecsToTest,
         ::testing::Values(
-            generateSeq<Int8>(G(SequentialGenerator(1))),
+            generateSeq<Int8>(G(SequentialGenerator(1)), 1, 128),
             generateSeq<Int16 >(G(SequentialGenerator(1))),
             generateSeq<Int32 >(G(SequentialGenerator(1))),
             generateSeq<Int64 >(G(SequentialGenerator(1))),
-            generateSeq<UInt8 >(G(SequentialGenerator(1))),
+            generateSeq<UInt8 >(G(SequentialGenerator(1)), 1, 128),
             generateSeq<UInt16>(G(SequentialGenerator(1))),
             generateSeq<UInt32>(G(SequentialGenerator(1))),
             generateSeq<UInt64>(G(SequentialGenerator(1)))
@@ -952,11 +968,11 @@ INSTANTIATE_TEST_SUITE_P(SequentialReverseInt,
     ::testing::Combine(
         DefaultCodecsToTest,
         ::testing::Values(
-            generateSeq<Int8>(G(SequentialGenerator(-1))),
+            generateSeq<Int8>(G(SequentialGenerator(-1)), 1, 128),
             generateSeq<Int16 >(G(SequentialGenerator(-1))),
             generateSeq<Int32 >(G(SequentialGenerator(-1))),
             generateSeq<Int64 >(G(SequentialGenerator(-1))),
-            generateSeq<UInt8 >(G(SequentialGenerator(-1))),
+            generateSeq<UInt8 >(G(SequentialGenerator(-1)), 0, 256),
             generateSeq<UInt16>(G(SequentialGenerator(-1))),
             generateSeq<UInt32>(G(SequentialGenerator(-1))),
             generateSeq<UInt64>(G(SequentialGenerator(-1)))
@@ -969,7 +985,11 @@ INSTANTIATE_TEST_SUITE_P(SequentialFloat,
     ::testing::Combine(
         ::testing::Values(
             Codec("Gorilla"),
-            Codec("Gorilla, LZ4")
+            Codec("Gorilla, LZ4"),
+            Codec("Gorilla, ZSTD"),
+            Codec("ALP"),
+            Codec("ALP, LZ4"),
+            Codec("ALP, ZSTD")
         ),
         ::testing::Values(
             generateSeq<Float32>(G(SequentialGenerator(M_E))),
@@ -983,7 +1003,11 @@ INSTANTIATE_TEST_SUITE_P(SequentialReverseFloat,
     ::testing::Combine(
         ::testing::Values(
             Codec("Gorilla"),
-            Codec("Gorilla, LZ4")
+            Codec("Gorilla, LZ4"),
+            Codec("Gorilla, ZSTD"),
+            Codec("ALP"),
+            Codec("ALP, LZ4"),
+            Codec("ALP, ZSTD")
         ),
         ::testing::Values(
             generateSeq<Float32>(G(SequentialGenerator(-1 * M_E))),
@@ -1030,7 +1054,8 @@ INSTANTIATE_TEST_SUITE_P(MonotonicFloat,
     CodecTest,
     ::testing::Combine(
         ::testing::Values(
-            Codec("Gorilla")
+            Codec("Gorilla"),
+            Codec("ALP")
         ),
         ::testing::Values(
             generateSeq<Float32>(G(MonotonicGenerator<Float32>(static_cast<Float32>(M_E), 5))),
@@ -1043,7 +1068,8 @@ INSTANTIATE_TEST_SUITE_P(MonotonicReverseFloat,
     CodecTest,
     ::testing::Combine(
         ::testing::Values(
-            Codec("Gorilla")
+            Codec("Gorilla"),
+            Codec("ALP")
         ),
         ::testing::Values(
             generateSeq<Float32>(G(MonotonicGenerator<Float32>(static_cast<Float32>(-1 * M_E), 5))),
@@ -1113,7 +1139,11 @@ INSTANTIATE_TEST_SUITE_P(OverflowFloat,
     ::testing::Combine(
         ::testing::Values(
             Codec("Gorilla", 1.1),
-            Codec("Gorilla, LZ4", 1.0)
+            Codec("Gorilla, LZ4", 1.0),
+            Codec("Gorilla, ZSTD", 1.0),
+            Codec("ALP", 1.1),
+            Codec("ALP, LZ4", 1.0),
+            Codec("ALP, ZSTD", 1.0)
         ),
         ::testing::Values(
             generateSeq<Float32>(G(MinMaxGenerator())),
@@ -1407,6 +1437,424 @@ TEST(T64Test, TranscodeRawInput)
                 ASSERT_EQ(memory_for_decompression.data()[i], source_memory.data()[i]) << "with data type " << type->getName() << " with buffer size " << buffer_size << " at position " << i;
         }
     }
+}
+
+auto ALPSequentialGenerator = []<typename T>(T base = T{0}, T exception = T{0}, double exception_probability = 0, int decimals = 2)
+{
+    std::default_random_engine random_engine(17); /// NOLINT
+    std::uniform_real_distribution<> random_distribution(0.0, 1.0);
+
+    return [=](auto i) mutable
+    {
+        auto random_value = random_distribution(random_engine);
+        if (random_value < exception_probability)
+            return exception;
+
+        T trend_k = static_cast<T>(0.1);
+        T trend = base + trend_k * static_cast<T>(i);
+        T oscillation = std::sin(trend);
+        T round_factor = std::pow(T{10}, static_cast<T>(decimals));
+
+        T value = trend + oscillation;
+        value = std::ceil(value * round_factor) / round_factor;
+
+        return value;
+    };
+};
+
+INSTANTIATE_TEST_SUITE_P(ALPSequentialF64,
+    CodecTest,
+    ::testing::Combine(
+        ::testing::Values(Codec("ALP", 0.3)),
+        ::testing::Values(
+            generateSeq<Float64>(G(ALPSequentialGenerator.template operator()<Float64>()), 0, 1024),
+            generateSeq<Float64>(G(ALPSequentialGenerator.template operator()<Float64>()), 0, 2048),
+            generateSeq<Float64>(G(ALPSequentialGenerator.template operator()<Float64>()), 0, 2560),
+            generateSeq<Float64>(G(ALPSequentialGenerator.template operator()<Float64>(-50.0)), 0, 2048),
+            generateSeq<Float64>(G(ALPSequentialGenerator.template operator()<Float64>(-5000.0)), 0, 2048)
+        )
+    )
+);
+
+INSTANTIATE_TEST_SUITE_P(ALPSequentialF32,
+    CodecTest,
+    ::testing::Combine(
+        ::testing::Values(Codec("ALP", 0.8)),
+        ::testing::Values(
+            generateSeq<Float32>(G(ALPSequentialGenerator.template operator()<Float32>()), 0, 1024),
+            generateSeq<Float32>(G(ALPSequentialGenerator.template operator()<Float32>()), 0, 2048),
+            generateSeq<Float32>(G(ALPSequentialGenerator.template operator()<Float32>()), 0, 2560),
+            generateSeq<Float32>(G(ALPSequentialGenerator.template operator()<Float32>(-50.0)), 0, 2048),
+            generateSeq<Float32>(G(ALPSequentialGenerator.template operator()<Float32>(-5000.0)), 0, 2048)
+        )
+    )
+);
+
+INSTANTIATE_TEST_SUITE_P(ALPPyramidOfSequences,
+    CodecTest,
+    ::testing::Combine(
+        ::testing::Values(Codec("ALP")),
+        ::testing::ValuesIn(
+              generatePyramidOfSequences<Float64>(2050, G(ALPSequentialGenerator.template operator()<Float64>()))
+            + generatePyramidOfSequences<Float32>(2050, G(ALPSequentialGenerator.template operator()<Float32>()))
+        )
+    )
+);
+
+INSTANTIATE_TEST_SUITE_P(ALPLongSequencesF64,
+    CodecTest,
+    ::testing::Combine(
+        ::testing::Values(Codec("ALP", 0.3)),
+        ::testing::Values(
+            generateSeq<Float64>(G(ALPSequentialGenerator.template operator()<Float64>()), 0, 65536),
+            generateSeq<Float64>(G(ALPSequentialGenerator.template operator()<Float64>()), 0, 66000),
+            generateSeq<Float64>(G(ALPSequentialGenerator.template operator()<Float64>()), 0, 150000)
+        )
+    )
+);
+
+INSTANTIATE_TEST_SUITE_P(ALPLongSequencesF32,
+    CodecTest,
+    ::testing::Combine(
+        ::testing::Values(Codec("ALP", 0.9)),
+        ::testing::Values(
+            generateSeq<Float32>(G(ALPSequentialGenerator.template operator()<Float32>()), 0, 65536),
+            generateSeq<Float32>(G(ALPSequentialGenerator.template operator()<Float32>()), 0, 66000),
+            generateSeq<Float32>(G(ALPSequentialGenerator.template operator()<Float32>()), 0, 150000)
+        )
+    )
+);
+
+INSTANTIATE_TEST_SUITE_P(ALPHighPrecissionFloatsF64,
+    CodecTest,
+    ::testing::Combine(
+        ::testing::Values(Codec("ALP", 0.5)),
+        ::testing::Values(
+            generateSeq<Float64>(G(ALPSequentialGenerator.template operator()<Float64>(0, 0, 0, 4)), 0, 2048),
+            generateSeq<Float64>(G(ALPSequentialGenerator.template operator()<Float64>(0, 0, 0, 6)), 0, 2048)
+        )
+    )
+);
+
+INSTANTIATE_TEST_SUITE_P(ALPHighPrecissionFloatsF32,
+    CodecTest,
+    ::testing::Combine(
+        ::testing::Values(Codec("ALP", 0.999)),
+        ::testing::Values(
+            generateSeq<Float32>(G(ALPSequentialGenerator.template operator()<Float32>(0, 0, 0, 4)), 0, 2048),
+            generateSeq<Float32>(G(ALPSequentialGenerator.template operator()<Float32>(0, 0, 0, 6)), 0, 2048)
+        )
+    )
+);
+
+INSTANTIATE_TEST_SUITE_P(ALPSpecialFloatsF64,
+    CodecTest,
+    ::testing::Combine(
+        ::testing::Values(Codec("ALP", 0.4)),
+        ::testing::Values(
+            generateSeq<Float64>(G(ALPSequentialGenerator.template operator()<Float64>(0, std::numeric_limits<Float64>::infinity(), 0.1))),
+            generateSeq<Float64>(G(ALPSequentialGenerator.template operator()<Float64>(0, -std::numeric_limits<Float64>::infinity(), 0.1))),
+            generateSeq<Float64>(G(ALPSequentialGenerator.template operator()<Float64>(0, std::numeric_limits<Float64>::quiet_NaN(), 0.1))),
+            generateSeq<Float64>(G(ALPSequentialGenerator.template operator()<Float64>(0, std::numeric_limits<Float64>::signaling_NaN(), 0.1))),
+            generateSeq<Float64>(G(ALPSequentialGenerator.template operator()<Float64>(0, std::bit_cast<Float64>(0x8000000000000000ULL), 0.1))), // negative zero
+            generateSeq<Float64>(G(ALPSequentialGenerator.template operator()<Float64>(0, std::numeric_limits<Float64>::max(), 0.1))),
+            generateSeq<Float64>(G(ALPSequentialGenerator.template operator()<Float64>(0, std::numeric_limits<Float64>::min(), 0.1))),
+            generateSeq<Float64>(G(ALPSequentialGenerator.template operator()<Float64>(0, std::numeric_limits<Float64>::denorm_min(), 0.1))),
+            generateSeq<Float64>(G(ALPSequentialGenerator.template operator()<Float64>(0, 9223372036854773760.0, 0.1))),
+            generateSeq<Float64>(G(ALPSequentialGenerator.template operator()<Float64>(0, -9223372036854773760.0, 0.1)))
+        )
+    )
+);
+
+INSTANTIATE_TEST_SUITE_P(ALPSpecialFloatsF32,
+    CodecTest,
+    ::testing::Combine(
+        ::testing::Values(Codec("ALP", 0.9)),
+        ::testing::Values(
+            generateSeq<Float32>(G(ALPSequentialGenerator.template operator()<Float32>(0, std::numeric_limits<Float32>::infinity(), 0.1))),
+            generateSeq<Float32>(G(ALPSequentialGenerator.template operator()<Float32>(0, -std::numeric_limits<Float32>::infinity(), 0.1))),
+            generateSeq<Float32>(G(ALPSequentialGenerator.template operator()<Float32>(0, std::numeric_limits<Float32>::quiet_NaN(), 0.1))),
+            generateSeq<Float32>(G(ALPSequentialGenerator.template operator()<Float32>(0, std::numeric_limits<Float32>::signaling_NaN(), 0.1))),
+            generateSeq<Float32>(G(ALPSequentialGenerator.template operator()<Float32>(0, std::bit_cast<Float32>(0x80000000U), 0.1))), // negative zero
+            generateSeq<Float32>(G(ALPSequentialGenerator.template operator()<Float32>(0, std::numeric_limits<Float32>::max(), 0.1))),
+            generateSeq<Float32>(G(ALPSequentialGenerator.template operator()<Float32>(0, std::numeric_limits<Float32>::min(), 0.1))),
+            generateSeq<Float32>(G(ALPSequentialGenerator.template operator()<Float32>(0, std::numeric_limits<Float32>::denorm_min(), 0.1))),
+            generateSeq<Float32>(G(ALPSequentialGenerator.template operator()<Float32>(0, 9223371487098961920.0f, 0.1))),
+            generateSeq<Float32>(G(ALPSequentialGenerator.template operator()<Float32>(0, -9223371487098961920.0f, 0.1)))
+        )
+    )
+);
+
+INSTANTIATE_TEST_SUITE_P(ALPManyExceptionsF64,
+    CodecTest,
+    ::testing::Combine(
+        ::testing::Values(Codec("ALP", 0.99)),
+        ::testing::Values(
+            generateSeq<Float64>(G(ALPSequentialGenerator.template operator()<Float64>(0, std::numeric_limits<Float64>::quiet_NaN(), 0.4))),
+            generateSeq<Float64>(G(ALPSequentialGenerator.template operator()<Float64>(0, std::numeric_limits<Float64>::quiet_NaN(), 0.6)))
+        )
+    )
+);
+
+INSTANTIATE_TEST_SUITE_P(ALPManyExceptionsF32,
+    CodecTest,
+    ::testing::Combine(
+        ::testing::Values(Codec("ALP", 1.01)),
+        ::testing::Values(
+            generateSeq<Float32>(G(ALPSequentialGenerator.template operator()<Float32>(0, std::numeric_limits<Float32>::quiet_NaN(), 0.4))),
+            generateSeq<Float32>(G(ALPSequentialGenerator.template operator()<Float32>(0, std::numeric_limits<Float32>::quiet_NaN(), 0.6)))
+        )
+    )
+);
+
+INSTANTIATE_TEST_SUITE_P(ALPExceptionsOnly,
+    CodecTest,
+    ::testing::Combine(
+        ::testing::Values(Codec("ALP", 1.01)),
+        ::testing::Values(
+            generateSeq<Float64>(G([](auto) { return std::numeric_limits<Float64>::quiet_NaN(); })),
+            generateSeq<Float32>(G([](auto) { return std::numeric_limits<Float32>::quiet_NaN(); })),
+            generateSeq<Float64>(G([](auto) { return M_PIf64; })),
+            generateSeq<Float32>(G([](auto) { return M_PIf32; }))
+        )
+    )
+);
+
+INSTANTIATE_TEST_SUITE_P(ALPSameValuesF64,
+    CodecTest,
+    ::testing::Combine(
+        ::testing::Values(Codec("ALP", 0.1)),
+        ::testing::Values(
+            generateSeq<Float64>(G([](auto) { return 2.2; })),
+            generateSeq<Float64>(G([](auto) { return -2.2; })),
+            generateSeq<Float64>(G([](auto) { return 0.0; }))
+        )
+    )
+);
+
+INSTANTIATE_TEST_SUITE_P(ALPSameValuesF32,
+    CodecTest,
+    ::testing::Combine(
+        ::testing::Values(Codec("ALP", 0.1)),
+        ::testing::Values(
+            generateSeq<Float32>(G([](auto) { return 2.2f; })),
+            generateSeq<Float32>(G([](auto) { return -2.2f; })),
+            generateSeq<Float32>(G([](auto) { return 0.0f; }))
+        )
+    )
+);
+
+class ALPTest : public ::testing::Test
+{
+protected:
+    static std::vector<UInt8> constructSourceWithHeader(const std::vector<UInt8> & source, UInt32 dest_size)
+    {
+        UInt32 source_size = static_cast<UInt32>(source.size());
+
+        std::vector<UInt8> data = {
+            // General codec header
+            static_cast<UInt8>(CompressionMethodByte::ALP), // method byte
+            static_cast<UInt8>(source_size & 0xFF),         // compressed size (byte 0)
+            static_cast<UInt8>((source_size >> 8) & 0xFF),  // compressed size (byte 1)
+            static_cast<UInt8>((source_size >> 16) & 0xFF), // compressed size (byte 2)
+            static_cast<UInt8>((source_size >> 24) & 0xFF), // compressed size (byte 3)
+            static_cast<UInt8>(dest_size & 0xFF),           // decompressed size (byte 0)
+            static_cast<UInt8>((dest_size >> 8) & 0xFF),    // decompressed size (byte 1)
+            static_cast<UInt8>((dest_size >> 16) & 0xFF),   // decompressed size (byte 2)
+            static_cast<UInt8>((dest_size >> 24) & 0xFF),   // decompressed size (byte 3)
+        };
+        data.append_range(source);
+
+        return data;
+    }
+
+    template <typename T = DataTypeFloat64>
+    static auto verifyDecompressExpectedException(const std::vector<UInt8> & source, const std::string & expectedMessage, UInt32 dest_size = 8192)
+    {
+        try
+        {
+            std::vector<UInt8> source_with_header = constructSourceWithHeader(source, dest_size);
+            auto codec = makeCodec("ALP", std::make_shared<T>());
+            std::vector<char> dest(dest_size);
+
+            codec->decompress(reinterpret_cast<const char *>(source_with_header.data()), static_cast<UInt32>(source_with_header.size()), dest.data());
+
+            FAIL() << "Expected Exception with message: " << expectedMessage;
+        }
+        catch (const Exception& e)
+        {
+            EXPECT_EQ(expectedMessage, e.message());
+        }
+    }
+};
+
+TEST_F(ALPTest, SupportedFloatTypes)
+{
+    std::vector<DataTypePtr> supported_types = {
+        std::make_shared<DataTypeFloat32>(),
+        std::make_shared<DataTypeFloat64>()
+    };
+
+    for (const auto & type : supported_types)
+        ASSERT_NO_THROW(makeCodec("ALP", type)) << "ALP codec should accept " << type->getName();
+}
+
+TEST_F(ALPTest, UnsupportedFloatTypes)
+{
+    std::vector<DataTypePtr> unsupported_types = {
+        std::make_shared<DataTypeUInt32>(),
+        std::make_shared<DataTypeInt32>(),
+        std::make_shared<DataTypeUInt64>(),
+        std::make_shared<DataTypeInt64>(),
+        std::make_shared<DataTypeBFloat16>()
+    };
+
+    for (const auto & type : unsupported_types)
+        ASSERT_THROW(makeCodec("ALP", type), Exception) << "ALP codec should reject " << type->getName();
+}
+
+TEST_F(ALPTest, DecompressMalformedInputWithTruncatedHeader)
+{
+    const std::vector<UInt8> source = {
+        0x01, // meta byte
+        0x08  // float width
+    };
+    verifyDecompressExpectedException(source, "Cannot decompress ALP-encoded data, data has wrong header");
+}
+
+TEST_F(ALPTest, DecompressMalformedInputWithInvalidFloatWidth)
+{
+    const std::vector<UInt8> source = {
+        0x01,       // meta byte
+        0x01,       // float width (invalid, should be 4 or 8)
+        0x00, 0x04  // block float count
+    };
+    verifyDecompressExpectedException(source, "Cannot decompress ALP-encoded data, unsupported float width 1");
+}
+
+TEST_F(ALPTest, DecompressMalformedInputWithInvalidBlockFloatCount)
+{
+    const std::vector<UInt8> source = {
+        0x01,       // meta byte
+        0x08,       // float width
+        0x00, 0x08  // block float count equal to 2048 (invalid, should be 1024)
+    };
+    verifyDecompressExpectedException(source, "Cannot decompress ALP-encoded data, supported block float count is 1024, got 2048");
+}
+
+TEST_F(ALPTest, DecompressMalformedInputWithTruncatedBlockHeader)
+{
+    const std::vector<UInt8> source = {
+        0x01,       // meta byte
+        0x08,       // float width
+        0x00, 0x04, // block float count
+        0x02,       // exponent
+    };
+    verifyDecompressExpectedException(source, "Cannot decompress ALP-encoded data, incomplete block header (encoded)");
+}
+
+TEST_F(ALPTest, DecompressMalformedInputWithInvalidExponent)
+{
+    const std::vector<UInt8> source = {
+        0x01,       // meta byte
+        0x08,       // float width
+        0x00, 0x04, // block float count
+        0x7F,       // exponent
+        0x00,       // fraction
+        0x00, 0x00, // exception count = 0
+        0x01,       // bits = 1
+        // FOR base (8 bytes)
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+    };
+    verifyDecompressExpectedException(source, "Cannot decompress ALP-encoded data, invalid exponent value: 127, max allowed: 18");
+}
+
+TEST_F(ALPTest, DecompressMalformedInputWithInvalidFraction)
+{
+    const std::vector<UInt8> source = {
+        0x01,       // meta byte
+        0x08,       // float width
+        0x00, 0x04, // block float count
+        0x00,       // exponent
+        0x7F,       // fraction
+        0x00, 0x00, // exception count = 0
+        0x01,       // bits = 1
+        // FOR base (8 bytes)
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+    };
+    verifyDecompressExpectedException(source, "Cannot decompress ALP-encoded data, invalid fraction value: 127, max allowed: 18");
+}
+
+TEST_F(ALPTest, DecompressMalformedInputWithTruncatedBlockData)
+{
+    const std::vector<UInt8> source = {
+        0x01,       // meta byte
+        0x08,       // float width
+        0x00, 0x04, // block float count
+        0x02,       // exponent
+        0x00,       // fraction
+        0x00, 0x00, // exception count = 0
+        0x01,       // bits = 1
+        // FOR base (8 bytes)
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        // Bitpacked data (incomplete)
+        0xFF, 0xFF, 0xFF, 0xFF // only 2 bytes instead of 128 bytes
+    };
+    verifyDecompressExpectedException(source, "Cannot decompress ALP-encoded data, incomplete block payload, available size: 4, bit-width: 1, exceptions: 0");
+}
+
+TEST_F(ALPTest, DecompressMalformedInputWithInvalidExceptionsCount)
+{
+    const std::vector<UInt8> source = {
+        0x01,       // meta byte
+        0x08,       // float width
+        0x00, 0x04, // block float count
+        0x02,       // exponent
+        0x00,       // fraction
+        0x01, 0x00, // exception count = 1
+        0x01,       // bits = 1
+        // FOR base (8 bytes)
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        // Bitpacked data (128 bytes for 1024 values with 1 bit each)
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+        // No exceptions data, expected 1 exception
+    };
+    verifyDecompressExpectedException(source, "Cannot decompress ALP-encoded data, incomplete block payload, available size: 128, bit-width: 1, exceptions: 1");
+}
+
+TEST_F(ALPTest, DecompressMalformedInputWithInvalidExceptionIndex)
+{
+    const std::vector<UInt8> source = {
+        0x01,       // meta byte
+        0x08,       // float width
+        0x00, 0x04, // block float count
+        0x02,       // exponent
+        0x00,       // fraction
+        0x01, 0x00, // exception count = 1
+        0x01,       // bits = 1
+        // FOR base (8 bytes)
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        // Bitpacked data (128 bytes for 1024 values with 1 bit each)
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+        // Exception indices (invalid index 1025)
+        0x00, 0x04,                                     // exception index (1024 bigger than max allowed index 1023)
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00  // exception value
+    };
+    verifyDecompressExpectedException(source, "Cannot decompress ALP-encoded data, invalid exception index, index: 1024, float count: 1024");
 }
 
 }

--- a/src/Compression/tests/gtest_ffor.cpp
+++ b/src/Compression/tests/gtest_ffor.cpp
@@ -1,0 +1,115 @@
+#include <Compression/FFOR.h>
+
+#include <random>
+
+#include <gtest/gtest.h>
+
+using namespace DB;
+
+namespace
+{
+template <typename T, UInt16 values>
+using InputGeneratorFn = std::function<T(T * in, UInt8 bits)>;
+
+template <typename T>
+T calculateMaxValue(T min, UInt8 bits)
+{
+    constexpr UInt8 max_bits = sizeof(T) * 8;
+    return bits == max_bits ? ~T{0} : static_cast<T>((T{1} << bits) - T{1} + min);
+}
+
+template <typename T, UInt16 values = Compression::FFOR::DEFAULT_VALUES>
+T generateRandomInput(T * in, UInt8 bits)
+{
+    T min = T{5};
+    T max = calculateMaxValue(min, bits);
+
+    std::default_random_engine rng(17); // NOLINT
+    std::uniform_int_distribution<T> in_dist(min, max);
+    for (UInt16 i = 0; i < values; ++i)
+        in[i] = in_dist(rng);
+
+    return min;
+}
+
+template <typename T, UInt16 values = Compression::FFOR::DEFAULT_VALUES>
+T generateMinMaxInput(T * in, UInt8 bits)
+{
+    T min = T{0};
+    T max = calculateMaxValue(min, bits);
+
+    for (UInt16 i = 0; i < values; ++i)
+        in[i] = i % 2 == 0 ? max : (i % 3 == 0 ? max : min);
+
+    return min;
+}
+
+template <typename T, UInt16 values = Compression::FFOR::DEFAULT_VALUES>
+void runPackUnpackCorrectnessTest(UInt8 bits, InputGeneratorFn<T, values> generator)
+{
+    alignas(64) T in[values];
+    alignas(64) T coded[values];
+    alignas(64) T decoded[values];
+
+    // Generate input data using the provided generator
+    T base = generator(in, bits);
+
+    // Encode
+    Compression::FFOR::bitPack<values>(in, coded, bits, base);
+
+    // Set unused bytes to random values to ensure decoder does not rely on them
+    const UInt16 used_bytes = Compression::FFOR::calculateBitpackedBytes<values>(bits);
+    UInt16 total_bytes = sizeof(coded);
+    char * coded_bytes = reinterpret_cast<char *>(coded);
+    std::default_random_engine rng(13); // NOLINT
+    std::uniform_int_distribution<UInt16> byte_dist(0, 255);
+    for (auto i = used_bytes; i < total_bytes; ++i)
+        coded_bytes[i] = static_cast<char>(byte_dist(rng));
+
+    // Decode
+    Compression::FFOR::bitUnpack<values>(coded, decoded, bits, base);
+
+    // Verify
+    for (UInt16 i = 0; i < values; ++i)
+        ASSERT_EQ(decoded[i], in[i]) << "bits=" << static_cast<UInt32>(bits) << " index=" << i;
+}
+
+class FFOR16BitTest : public ::testing::TestWithParam<UInt8> { };
+class FFOR32BitTest : public ::testing::TestWithParam<UInt8> { };
+class FFOR64BitTest : public ::testing::TestWithParam<UInt8> { };
+
+TEST_P(FFOR16BitTest, RandomPackUnpackCorrectnessTest)
+{
+    runPackUnpackCorrectnessTest<UInt16>(GetParam(), generateRandomInput<UInt16>);
+}
+
+TEST_P(FFOR16BitTest, MinMaxPackUnpackCorrectnessTest)
+{
+    runPackUnpackCorrectnessTest<UInt16>(GetParam(), generateMinMaxInput<UInt16>);
+}
+
+TEST_P(FFOR32BitTest, RandomPackUnpackCorrectnessTest)
+{
+    runPackUnpackCorrectnessTest<UInt32>(GetParam(), generateRandomInput<UInt32>);
+}
+
+TEST_P(FFOR32BitTest, MinMaxPackUnpackCorrectnessTest)
+{
+    runPackUnpackCorrectnessTest<UInt32>(GetParam(), generateMinMaxInput<UInt32>);
+}
+
+TEST_P(FFOR64BitTest, RandomPackUnpackCorrectnessTest)
+{
+    runPackUnpackCorrectnessTest<UInt64>(GetParam(), generateRandomInput<UInt64>);
+}
+
+TEST_P(FFOR64BitTest, MinMaxPackUnpackCorrectnessTest)
+{
+    runPackUnpackCorrectnessTest<UInt64>(GetParam(), generateMinMaxInput<UInt64>);
+}
+
+INSTANTIATE_TEST_SUITE_P(FFOR, FFOR16BitTest, ::testing::Range<UInt8>(0, sizeof(UInt16) * 8 + 1));
+INSTANTIATE_TEST_SUITE_P(FFOR, FFOR32BitTest, ::testing::Range<UInt8>(0, sizeof(UInt32) * 8 + 1));
+INSTANTIATE_TEST_SUITE_P(FFOR, FFOR64BitTest, ::testing::Range<UInt8>(0, sizeof(UInt64) * 8 + 1));
+
+}

--- a/tests/performance/codecs_float_insert.xml
+++ b/tests/performance/codecs_float_insert.xml
@@ -1,6 +1,7 @@
 <test>
     <settings>
         <allow_suspicious_codecs>1</allow_suspicious_codecs>
+        <allow_experimental_codecs>1</allow_experimental_codecs>
     </settings>
 
     <substitutions>
@@ -13,6 +14,7 @@
                 <value>DoubleDelta</value>
                 <value>Gorilla</value>
                 <value>FPC</value>
+                <value>ALP</value>
             </values>
         </substitution>
         <substitution>
@@ -27,6 +29,7 @@
                 <value>seq</value>
                 <value>mon</value>
                 <value>rnd</value>
+                <value>rtn</value>
             </values>
         </substitution>
         <substitution>
@@ -48,6 +51,7 @@
     <query>INSERT INTO codec_seq_{type}_{codec} (n) SELECT number/pi() FROM system.numbers LIMIT {num_rows} SETTINGS max_threads=1</query>
     <query>INSERT INTO codec_mon_{type}_{codec} (n) SELECT number+sin(number) FROM system.numbers LIMIT {num_rows} SETTINGS max_threads=1</query>
     <query>INSERT INTO codec_rnd_{type}_{codec} (n) SELECT (intHash64(number) - 4294967295)/pi() FROM system.numbers LIMIT {num_rows} SETTINGS max_threads=1</query>
+    <query>INSERT INTO codec_rtn_{type}_{codec} (n) SELECT round(number/20+sin(number), 3) FROM system.numbers LIMIT {num_rows} SETTINGS max_threads=1</query>
 
     <drop_query>system start merges</drop_query>
     <drop_query>DROP TABLE IF EXISTS codec_{seq_type}_{type}_{codec}</drop_query>

--- a/tests/performance/codecs_float_select.xml
+++ b/tests/performance/codecs_float_select.xml
@@ -1,6 +1,7 @@
 <test>
     <settings>
         <allow_suspicious_codecs>1</allow_suspicious_codecs>
+        <allow_experimental_codecs>1</allow_experimental_codecs>
     </settings>
 
     <substitutions>
@@ -13,6 +14,7 @@
                 <value>DoubleDelta</value>
                 <value>Gorilla</value>
                 <value>FPC</value>
+                <value>ALP</value>
             </values>
         </substitution>
         <substitution>
@@ -27,6 +29,7 @@
                 <value>seq</value>
                 <value>mon</value>
                 <value>rnd</value>
+                <value>rtn</value>
             </values>
         </substitution>
         <substitution>
@@ -46,6 +49,7 @@
     <fill_query>INSERT INTO codec_seq_{type}_{codec} (n) SELECT number/pi() FROM system.numbers LIMIT {num_rows} SETTINGS max_threads=1</fill_query>
     <fill_query>INSERT INTO codec_mon_{type}_{codec} (n) SELECT number+sin(number) FROM system.numbers LIMIT {num_rows} SETTINGS max_threads=1</fill_query>
     <fill_query>INSERT INTO codec_rnd_{type}_{codec} (n) SELECT (intHash64(number) - 4294967295)/pi() FROM system.numbers LIMIT {num_rows} SETTINGS max_threads=1</fill_query>
+    <fill_query>INSERT INTO codec_rtn_{type}_{codec} (n) SELECT round(number/20+sin(number), 3) FROM system.numbers LIMIT {num_rows} SETTINGS max_threads=1</fill_query>
     <fill_query>optimize table codec_{seq_type}_{type}_{codec} FINAL settings optimize_throw_if_noop = 1</fill_query>
 
     <query>SELECT count(n) FROM codec_{seq_type}_{type}_{codec} WHERE ignore(n) == 0 LIMIT {num_rows} SETTINGS max_threads=1</query>

--- a/tests/queries/0_stateless/01222_system_codecs.reference
+++ b/tests/queries/0_stateless/01222_system_codecs.reference
@@ -1,5 +1,6 @@
 AES_128_GCM_SIV	150	0	0	1	0	0	Encrypts and decrypts blocks with AES-128 in GCM-SIV mode (RFC-8452).
 AES_256_GCM_SIV	151	0	0	1	0	0	Encrypts and decrypts blocks with AES-128 in GCM-SIV mode (RFC-8452).
+ALP	156	1	0	0	1	1	Adaptive Lossless floating-Point; suitable for time series data.
 Delta	146	0	0	0	0	0	Preprocessor (should be followed by some compression codec). Stores difference between neighboring values; good for monotonically increasing or decreasing data.
 DoubleDelta	148	1	0	0	0	0	Stores difference between neighboring delta values; suitable for time series data.
 FPC	152	1	0	0	1	0	High Throughput Compression of Double-Precision Floating-Point Data.
@@ -11,7 +12,7 @@ Multiple	145	0	0	0	0	0	Apply multiple codecs consecutively defined by user.
 NONE	2	0	0	0	0	0	No compression. Can be used on columns that can not be compressed anyway.
 T64	147	1	0	0	0	0	Preprocessor. Crops unused high bits; puts them into a 64x64 bit matrix; optimized for 64-bit data types.
 ZSTD	144	1	1	0	0	0	Good compression; pretty fast; best for high compression needs. Don’t use levels higher than 3.
-13
+14
 name
 method_byte
 is_compression

--- a/tests/queries/0_stateless/03743_alp_codec_aggregations.reference
+++ b/tests/queries/0_stateless/03743_alp_codec_aggregations.reference
@@ -1,0 +1,8 @@
+# Aggregations Test
+1501	1	1	1	1
+1501	1	1	1	1
+# Granule Test
+First Granule	2048	0
+Middle granules	2048	0
+Last granule	1904	0
+Sparse read	4	0

--- a/tests/queries/0_stateless/03743_alp_codec_aggregations.sql
+++ b/tests/queries/0_stateless/03743_alp_codec_aggregations.sql
@@ -1,0 +1,48 @@
+SET allow_experimental_codecs = 1;
+
+DROP TABLE IF EXISTS base32;
+CREATE TABLE base32 (i UInt32 CODEC(NONE), f Float32 CODEC(NONE)) Engine = MergeTree ORDER BY i;
+
+DROP TABLE IF EXISTS base64;
+CREATE TABLE base64 (i UInt32 CODEC(NONE), f Float64 CODEC(NONE)) Engine = MergeTree ORDER BY i;
+
+DROP TABLE IF EXISTS alp32;
+CREATE TABLE alp32 (i UInt32 CODEC(NONE), f Float32 CODEC(ALP)) Engine = MergeTree ORDER BY i;
+
+DROP TABLE IF EXISTS alp64;
+CREATE TABLE alp64 (i UInt32 CODEC(NONE), f Float64 CODEC(ALP)) Engine = MergeTree ORDER BY i;
+
+DROP TABLE IF EXISTS alp64_granule2048;
+CREATE TABLE alp64_granule2048 (i UInt64 CODEC(NONE), f Float64 CODEC(ALP)) Engine = MergeTree ORDER BY i SETTINGS index_granularity = 2048;
+
+
+SELECT '# Aggregations Test';
+TRUNCATE TABLE base64; INSERT INTO base64 SELECT number, round(number * 0.1 + cos(number), 2) FROM numbers(5000);
+TRUNCATE TABLE alp64; INSERT INTO alp64 SELECT i, f FROM base64;
+SELECT count(), abs(sum(a.f) - sum(b.f)) < 0.0001, abs(avg(a.f) - avg(b.f)) < 0.0001, min(a.f) = min(b.f), max(a.f) = max(b.f)
+FROM base64 AS b INNER JOIN alp64 AS a USING i
+WHERE a.i BETWEEN 1500 AND 3000;
+
+TRUNCATE TABLE base32; INSERT INTO base32 SELECT number, toFloat32(round(number * 0.1 + cos(number), 2)) FROM numbers(5000);
+TRUNCATE TABLE alp32; INSERT INTO alp32 SELECT i, f FROM base32;
+SELECT count(), abs(sum(a.f) - sum(b.f)) < 0.0001, abs(avg(a.f) - avg(b.f)) < 0.0001, min(a.f) = min(b.f), max(a.f) = max(b.f)
+FROM base32 AS b INNER JOIN alp32 AS a USING i
+WHERE a.i BETWEEN 1500 AND 3000;
+
+
+SELECT '# Granule Test';
+TRUNCATE TABLE alp64_granule2048;
+INSERT INTO alp64_granule2048 SELECT number, round(number * 0.1 + cos(number), 2) FROM numbers(6000);
+OPTIMIZE TABLE alp64_granule2048 FINAL;
+
+SELECT 'First Granule', count(), sum(bin(f) <> bin(round(i * 0.1 + cos(i), 2))) FROM alp64_granule2048 WHERE i < 2048;
+SELECT 'Middle granules', count(), sum(bin(f) <> bin(round(i * 0.1 + cos(i), 2))) FROM alp64_granule2048 WHERE i >= 2048 AND i < 4096;
+SELECT 'Last granule', count(), sum(bin(f) <> bin(round(i * 0.1 + cos(i), 2))) FROM alp64_granule2048 WHERE i >= 4096;
+SELECT 'Sparse read', count(), sum(bin(f) <> bin(round(i * 0.1 + cos(i), 2))) FROM alp64_granule2048 WHERE i % 1500 = 0;
+
+
+DROP TABLE base32;
+DROP TABLE base64;
+DROP TABLE alp32;
+DROP TABLE alp64;
+DROP TABLE alp64_granule2048;

--- a/tests/queries/0_stateless/03743_alp_codec_basic_roundtrip.reference
+++ b/tests/queries/0_stateless/03743_alp_codec_basic_roundtrip.reference
@@ -1,0 +1,15 @@
+# Positive Numbers Test
+3000	0
+3000	0
+# Positive and Negative Numbers Test
+3000	0
+3000	0
+# Negative Numbers Test
+3000	0
+3000	0
+# All Same Values Test
+3000	0
+3000	0
+# Mix Rational and Irrational Numbers Test
+3000	0
+3000	0

--- a/tests/queries/0_stateless/03743_alp_codec_basic_roundtrip.sql
+++ b/tests/queries/0_stateless/03743_alp_codec_basic_roundtrip.sql
@@ -1,0 +1,64 @@
+SET allow_experimental_codecs = 1;
+
+DROP TABLE IF EXISTS base32;
+CREATE TABLE base32 (i UInt32 CODEC(NONE), f Float32 CODEC(NONE)) Engine = MergeTree ORDER BY i;
+
+DROP TABLE IF EXISTS base64;
+CREATE TABLE base64 (i UInt32 CODEC(NONE), f Float64 CODEC(NONE)) Engine = MergeTree ORDER BY i;
+
+DROP TABLE IF EXISTS alp32;
+CREATE TABLE alp32 (i UInt32 CODEC(NONE), f Float32 CODEC(ALP)) Engine = MergeTree ORDER BY i;
+
+DROP TABLE IF EXISTS alp64;
+CREATE TABLE alp64 (i UInt32 CODEC(NONE), f Float64 CODEC(ALP)) Engine = MergeTree ORDER BY i;
+
+
+SELECT '# Positive Numbers Test';
+TRUNCATE TABLE base64; INSERT INTO base64 SELECT number, round(number * 0.1 + cos(number), 2) FROM numbers(3000);
+TRUNCATE TABLE alp64; INSERT INTO alp64 SELECT i, f FROM base64;
+TRUNCATE TABLE base32; INSERT INTO base32 SELECT i, toFloat32(f) FROM base64;;
+TRUNCATE TABLE alp32; INSERT INTO alp32 SELECT i, f FROM base32;
+SELECT count(), sum(bin(a.f) <> bin(b.f)) FROM base64 AS b INNER JOIN alp64 AS a USING i;
+SELECT count(), sum(bin(a.f) <> bin(b.f)) FROM base32 AS b INNER JOIN alp32 AS a USING i;
+
+
+SELECT '# Positive and Negative Numbers Test';
+TRUNCATE TABLE base64; INSERT INTO base64 SELECT number, round(number * 0.1 + cos(number), 2) * if(number % 5 == 0, -1.0, 1.0) FROM numbers(3000);
+TRUNCATE TABLE alp64; INSERT INTO alp64 SELECT i, f FROM base64;
+TRUNCATE TABLE base32; INSERT INTO base32 SELECT i, toFloat32(f) FROM base64;;
+TRUNCATE TABLE alp32; INSERT INTO alp32 SELECT i, f FROM base32;
+SELECT count(), sum(bin(a.f) <> bin(b.f)) FROM base64 AS b INNER JOIN alp64 AS a USING i;
+SELECT count(), sum(bin(a.f) <> bin(b.f)) FROM base32 AS b INNER JOIN alp32 AS a USING i;
+
+
+SELECT '# Negative Numbers Test';
+TRUNCATE TABLE base64; INSERT INTO base64 SELECT number, -round(number * 0.1 + cos(number), 2) FROM numbers(3000);
+TRUNCATE TABLE alp64; INSERT INTO alp64 SELECT i, f FROM base64;
+TRUNCATE TABLE base32; INSERT INTO base32 SELECT i, toFloat32(f) FROM base64;;
+TRUNCATE TABLE alp32; INSERT INTO alp32 SELECT i, f FROM base32;
+SELECT count(), sum(bin(a.f) <> bin(b.f)) FROM base64 AS b INNER JOIN alp64 AS a USING i;
+SELECT count(), sum(bin(a.f) <> bin(b.f)) FROM base32 AS b INNER JOIN alp32 AS a USING i;
+
+
+SELECT '# All Same Values Test';
+TRUNCATE TABLE base64; INSERT INTO base64 SELECT number, 3.14 FROM numbers(3000);
+TRUNCATE TABLE alp64; INSERT INTO alp64 SELECT i, f FROM base64;
+TRUNCATE TABLE base32; INSERT INTO base32 SELECT i, toFloat32(f) FROM base64;
+TRUNCATE TABLE alp32; INSERT INTO alp32 SELECT i, f FROM base32;
+SELECT count(), sum(bin(a.f) <> bin(b.f)) FROM base64 AS b INNER JOIN alp64 AS a USING i;
+SELECT count(), sum(bin(a.f) <> bin(b.f)) FROM base32 AS b INNER JOIN alp32 AS a USING i;
+
+
+SELECT '# Mix Rational and Irrational Numbers Test';
+TRUNCATE TABLE base64; INSERT INTO base64 SELECT number, if(number % 10 = 1, number * 0.1 + cos(number), round(number * 0.1 + cos(number), 2)) FROM numbers(3000);
+TRUNCATE TABLE alp64; INSERT INTO alp64 SELECT i, f FROM base64;
+TRUNCATE TABLE base32; INSERT INTO base32 SELECT i, toFloat32(f) FROM base64;
+TRUNCATE TABLE alp32; INSERT INTO alp32 SELECT i, f FROM base32;
+SELECT count(), sum(bin(a.f) <> bin(b.f)) FROM base64 AS b INNER JOIN alp64 AS a USING i;
+SELECT count(), sum(bin(a.f) <> bin(b.f)) FROM base32 AS b INNER JOIN alp32 AS a USING i;
+
+
+DROP TABLE base32;
+DROP TABLE base64;
+DROP TABLE alp32;
+DROP TABLE alp64;

--- a/tests/queries/0_stateless/03743_alp_codec_block_sizes.reference
+++ b/tests/queries/0_stateless/03743_alp_codec_block_sizes.reference
@@ -1,0 +1,18 @@
+# Block Size Test (Float64)
+Size 0	0	0
+Size 1	1	0
+Size 2	2	0
+Size 1023	1023	0
+Size 1024	1024	0
+Size 1025	1025	0
+Size 2047	2047	0
+Size 2048	2048	0
+Size 2049	2049	0
+# Block Size Test (Float32)
+Size 1023	1023	0
+Size 1025	1025	0
+# All Non-Rational Floats Test
+Irrational	1000	0
+NaN/Infinite	1000	0
+# Mixed Per-Blocks Parameters Test
+4096	0

--- a/tests/queries/0_stateless/03743_alp_codec_block_sizes.sql
+++ b/tests/queries/0_stateless/03743_alp_codec_block_sizes.sql
@@ -1,0 +1,88 @@
+SET allow_experimental_codecs = 1;
+
+DROP TABLE IF EXISTS base32;
+CREATE TABLE base32 (i UInt32 CODEC(NONE), f Float32 CODEC(NONE)) Engine = MergeTree ORDER BY i;
+
+DROP TABLE IF EXISTS base64;
+CREATE TABLE base64 (i UInt32 CODEC(NONE), f Float64 CODEC(NONE)) Engine = MergeTree ORDER BY i;
+
+DROP TABLE IF EXISTS alp32;
+CREATE TABLE alp32 (i UInt32 CODEC(NONE), f Float32 CODEC(ALP)) Engine = MergeTree ORDER BY i;
+
+DROP TABLE IF EXISTS alp64;
+CREATE TABLE alp64 (i UInt32 CODEC(NONE), f Float64 CODEC(ALP)) Engine = MergeTree ORDER BY i;
+
+
+SELECT '# Block Size Test (Float64)';
+TRUNCATE TABLE base64; TRUNCATE TABLE alp64;
+SELECT 'Size 0', count(), sum(bin(a.f) <> bin(b.f)) FROM base64 AS b INNER JOIN alp64 AS a USING i;
+
+TRUNCATE TABLE base64; INSERT INTO base64 SELECT 0, 3.14;
+TRUNCATE TABLE alp64; INSERT INTO alp64 SELECT i, f FROM base64;
+SELECT 'Size 1', count(), sum(bin(a.f) <> bin(b.f)) FROM base64 AS b INNER JOIN alp64 AS a USING i;
+
+TRUNCATE TABLE base64; INSERT INTO base64 SELECT number, round(number * 0.1 + cos(number), 2) FROM numbers(2);
+TRUNCATE TABLE alp64; INSERT INTO alp64 SELECT i, f FROM base64;
+SELECT 'Size 2', count(), sum(bin(a.f) <> bin(b.f)) FROM base64 AS b INNER JOIN alp64 AS a USING i;
+
+TRUNCATE TABLE base64; INSERT INTO base64 SELECT number, round(number * 0.1 + cos(number), 2) FROM numbers(1023);
+TRUNCATE TABLE alp64; INSERT INTO alp64 SELECT i, f FROM base64;
+SELECT 'Size 1023', count(), sum(bin(a.f) <> bin(b.f)) FROM base64 AS b INNER JOIN alp64 AS a USING i;
+
+TRUNCATE TABLE base64; INSERT INTO base64 SELECT number, round(number * 0.1 + cos(number), 2) FROM numbers(1024);
+TRUNCATE TABLE alp64; INSERT INTO alp64 SELECT i, f FROM base64;
+SELECT 'Size 1024', count(), sum(bin(a.f) <> bin(b.f)) FROM base64 AS b INNER JOIN alp64 AS a USING i;
+
+TRUNCATE TABLE base64; INSERT INTO base64 SELECT number, round(number * 0.1 + cos(number), 2) FROM numbers(1025);
+TRUNCATE TABLE alp64; INSERT INTO alp64 SELECT i, f FROM base64;
+SELECT 'Size 1025', count(), sum(bin(a.f) <> bin(b.f))FROM base64 AS b INNER JOIN alp64 AS a USING i;
+
+TRUNCATE TABLE base64; INSERT INTO base64 SELECT number, round(number * 0.1 + cos(number), 2) FROM numbers(2047);
+TRUNCATE TABLE alp64; INSERT INTO alp64 SELECT i, f FROM base64;
+SELECT 'Size 2047', count(), sum(bin(a.f) <> bin(b.f)) FROM base64 AS b INNER JOIN alp64 AS a USING i;
+
+TRUNCATE TABLE base64; INSERT INTO base64 SELECT number, round(number * 0.1 + cos(number), 2) FROM numbers(2048);
+TRUNCATE TABLE alp64; INSERT INTO alp64 SELECT i, f FROM base64;
+SELECT 'Size 2048', count(), sum(bin(a.f) <> bin(b.f)) FROM base64 AS b INNER JOIN alp64 AS a USING i;
+
+TRUNCATE TABLE base64; INSERT INTO base64 SELECT number, round(number * 0.1 + cos(number), 2) FROM numbers(2049);
+TRUNCATE TABLE alp64; INSERT INTO alp64 SELECT i, f FROM base64;
+SELECT 'Size 2049', count(), sum(bin(a.f) <> bin(b.f)) FROM base64 AS b INNER JOIN alp64 AS a USING i;
+
+SELECT '# Block Size Test (Float32)';
+TRUNCATE TABLE base32; INSERT INTO base32 SELECT number, toFloat32(round(number * 0.1 + cos(number), 2)) FROM numbers(1023);
+TRUNCATE TABLE alp32; INSERT INTO alp32 SELECT i, f FROM base32;
+SELECT 'Size 1023', count(), sum(bin(a.f) <> bin(b.f)) FROM base32 AS b INNER JOIN alp32 AS a USING i;
+
+TRUNCATE TABLE base32; INSERT INTO base32 SELECT number, toFloat32(round(number * 0.1 + cos(number), 2)) FROM numbers(1025);
+TRUNCATE TABLE alp32; INSERT INTO alp32 SELECT i, f FROM base32;
+SELECT 'Size 1025', count(), sum(bin(a.f) <> bin(b.f)) FROM base32 AS b INNER JOIN alp32 AS a USING i;
+
+
+SELECT '# All Non-Rational Floats Test';
+TRUNCATE TABLE base64; INSERT INTO base64 SELECT number, sin(number) + cos(number) * log(toFloat64(number + 1)) FROM numbers(1000);
+TRUNCATE TABLE alp64; INSERT INTO alp64 SELECT i, f FROM base64;
+SELECT 'Irrational', count(), sum(bin(a.f) <> bin(b.f)) FROM base64 AS b INNER JOIN alp64 AS a USING i;
+
+TRUNCATE TABLE base64; INSERT INTO base64 SELECT number, if(number % 2 = 0, nan, inf) FROM numbers(1000);
+TRUNCATE TABLE alp64; INSERT INTO alp64 SELECT i, f FROM base64;
+SELECT 'NaN/Infinite', count(), sum(bin(a.f) <> bin(b.f)) FROM base64 AS b INNER JOIN alp64 AS a USING i;
+
+
+SELECT '# Mixed Per-Blocks Parameters Test';
+TRUNCATE TABLE base64; INSERT INTO base64 SELECT number,
+    CASE(toUInt32(number / 1024))
+        WHEN 0 THEN round(number * 0.1 + cos(number), 1)
+        WHEN 1 THEN round(number * 0.1 + cos(number), 2)
+        WHEN 2 THEN round(number * 0.1 + cos(number), 4)
+        ELSE sin(number) * cos(number) * log(toFloat64(number + 1))
+    END
+FROM numbers(4096);
+TRUNCATE TABLE alp64; INSERT INTO alp64 SELECT i, f FROM base64;
+SELECT count(), sum(bin(a.f) <> bin(b.f)) FROM base64 AS b INNER JOIN alp64 AS a USING i;
+
+
+DROP TABLE base32;
+DROP TABLE base64;
+DROP TABLE alp32;
+DROP TABLE alp64;

--- a/tests/queries/0_stateless/03743_alp_codec_special_values.reference
+++ b/tests/queries/0_stateless/03743_alp_codec_special_values.reference
@@ -1,0 +1,3 @@
+# Special Values Test (NaN, Inf, Zeros, Subnormals, Clamp Bounds)
+4000	0
+4000	0

--- a/tests/queries/0_stateless/03743_alp_codec_special_values.sql
+++ b/tests/queries/0_stateless/03743_alp_codec_special_values.sql
@@ -57,7 +57,13 @@ TRUNCATE TABLE base64; INSERT INTO base64 SELECT number,
     END
 FROM numbers(4000);
 TRUNCATE TABLE alp64; INSERT INTO alp64 SELECT i, f FROM base64;
-SELECT count(), sum(bin(a.f) <> bin(b.f)) FROM base64 AS b INNER JOIN alp64 AS a USING i;
+-- Compare bit patterns, but treat -0.0 and +0.0 as equivalent (sparse serialization may normalize -0.0 to +0.0).
+-- Reason: https://github.com/ClickHouse/ClickHouse/issues/98637.
+-- We can return normal version once this issue is fixed.
+SELECT count(), sum(
+    reinterpretAsUInt64(a.f) <> reinterpretAsUInt64(b.f)
+    AND NOT (reinterpretAsUInt64(a.f) IN (0, 0x8000000000000000) AND reinterpretAsUInt64(b.f) IN (0, 0x8000000000000000))
+) FROM base64 AS b INNER JOIN alp64 AS a USING i;
 
 TRUNCATE TABLE base32; INSERT INTO base32 SELECT number,
     CASE number % 50
@@ -100,7 +106,10 @@ TRUNCATE TABLE base32; INSERT INTO base32 SELECT number,
     END
 FROM numbers(4000);
 TRUNCATE TABLE alp32; INSERT INTO alp32 SELECT * FROM base32;
-SELECT count(), sum(bin(a.f) <> bin(b.f)) FROM base32 AS b INNER JOIN alp32 AS a USING i;
+SELECT count(), sum(
+    reinterpretAsUInt32(a.f) <> reinterpretAsUInt32(b.f)
+    AND NOT (reinterpretAsUInt32(a.f) IN (0, 0x80000000) AND reinterpretAsUInt32(b.f) IN (0, 0x80000000))
+) FROM base32 AS b INNER JOIN alp32 AS a USING i;
 
 
 DROP TABLE base32;

--- a/tests/queries/0_stateless/03743_alp_codec_special_values.sql
+++ b/tests/queries/0_stateless/03743_alp_codec_special_values.sql
@@ -1,0 +1,109 @@
+SET allow_experimental_codecs = 1;
+
+DROP TABLE IF EXISTS base32;
+CREATE TABLE base32 (i UInt32 CODEC(NONE), f Float32 CODEC(NONE)) Engine = MergeTree ORDER BY i;
+
+DROP TABLE IF EXISTS base64;
+CREATE TABLE base64 (i UInt32 CODEC(NONE), f Float64 CODEC(NONE)) Engine = MergeTree ORDER BY i;
+
+DROP TABLE IF EXISTS alp32;
+CREATE TABLE alp32 (i UInt32 CODEC(NONE), f Float32 CODEC(ALP)) Engine = MergeTree ORDER BY i;
+
+DROP TABLE IF EXISTS alp64;
+CREATE TABLE alp64 (i UInt32 CODEC(NONE), f Float64 CODEC(ALP)) Engine = MergeTree ORDER BY i;
+
+
+SELECT '# Special Values Test (NaN, Inf, Zeros, Subnormals, Clamp Bounds)';
+TRUNCATE TABLE base64; INSERT INTO base64 SELECT number,
+    CASE number % 50
+        -- Multiple NaN patterns
+        WHEN 0 THEN nan
+        WHEN 1 THEN -nan
+        WHEN 2 THEN reinterpretAsFloat64(0x7FF0000000000001)  -- signaling NaN
+        WHEN 3 THEN reinterpretAsFloat64(0x7FF8000000000001)  -- quiet NaN
+        -- Infinities
+        WHEN 4 THEN inf
+        WHEN 5 THEN -inf
+        -- Zero variants
+        WHEN 6 THEN toFloat64(0.0)
+        WHEN 7 THEN -toFloat64(0.0)
+        WHEN 8 THEN 1e-324 * 0.1   -- underflow to +0.0
+        WHEN 9 THEN -1e-324 * 0.1  -- underflow to -0.0
+        -- Subnormals (below 2.2250738585072014e-308)
+        WHEN 10 THEN 4.9406564584124654e-324  -- smallest subnormal
+        WHEN 11 THEN -4.9406564584124654e-324
+        WHEN 12 THEN 2.2250738585072009e-308  -- largest subnormal
+        WHEN 13 THEN -2.2250738585072009e-308
+        -- Smallest normals
+        WHEN 14 THEN 2.2250738585072014e-308
+        WHEN 15 THEN -2.2250738585072014e-308
+        -- Largest finite values
+        WHEN 16 THEN 1.7976931348623157e308
+        WHEN 17 THEN -1.7976931348623157e308
+        -- Near clamp bounds (UPPER = 9223372036854773760.0)
+        WHEN 18 THEN 9223372036854773760.0  -- exactly at upper bound
+        WHEN 19 THEN -9223372036854773760.0 -- exactly at lower bound
+        WHEN 20 THEN 9223372036854773761.0   -- just above upper bound
+        WHEN 21 THEN -9223372036854773761.0  -- just below lower bound
+        WHEN 22 THEN 9223372036854773000.0   -- near upper bound
+        WHEN 23 THEN -9223372036854773000.0  -- near lower bound
+        -- Large values beyond clamp
+        WHEN 24 THEN 1e19
+        WHEN 25 THEN -1e19
+        WHEN 26 THEN 1e20
+        WHEN 27 THEN -1e20
+        -- Regular decimal values
+        ELSE round(number * 0.1 + cos(number), 2)
+    END
+FROM numbers(4000);
+TRUNCATE TABLE alp64; INSERT INTO alp64 SELECT i, f FROM base64;
+SELECT count(), sum(bin(a.f) <> bin(b.f)) FROM base64 AS b INNER JOIN alp64 AS a USING i;
+
+TRUNCATE TABLE base32; INSERT INTO base32 SELECT number,
+    CASE number % 50
+        -- Multiple NaN patterns
+        WHEN 0 THEN toFloat32(nan)
+        WHEN 1 THEN toFloat32(-nan)
+        WHEN 2 THEN reinterpretAsFloat32(0x7F800001)  -- signaling NaN
+        WHEN 3 THEN reinterpretAsFloat32(0x7FC00001)  -- quiet NaN
+        -- Infinities
+        WHEN 4 THEN toFloat32(inf)
+        WHEN 5 THEN toFloat32(-inf)
+        -- Zero variants
+        WHEN 6 THEN toFloat32(0.0)
+        WHEN 7 THEN -toFloat32(0.0)
+        WHEN 8 THEN toFloat32(1e-45) * toFloat32(0.001)  -- underflow
+        WHEN 9 THEN toFloat32(-1e-45) * toFloat32(0.001)
+        -- Subnormals (below 1.17549435e-38)
+        WHEN 10 THEN toFloat32(1.40129846e-45)   -- smallest subnormal
+        WHEN 11 THEN toFloat32(-1.40129846e-45)
+        WHEN 12 THEN toFloat32(1.17549421e-38)   -- largest subnormal
+        WHEN 13 THEN toFloat32(-1.17549421e-38)
+        -- Smallest normals
+        WHEN 14 THEN toFloat32(1.17549435e-38)
+        WHEN 15 THEN toFloat32(-1.17549435e-38)
+        -- Largest finite values
+        WHEN 16 THEN toFloat32(3.4028235e38)
+        WHEN 17 THEN toFloat32(-3.4028235e38)
+        -- Clamp bounds (UPPER = 9223371487098961920.0f)
+        WHEN 18 THEN 9223371487098961920.0  -- exactly at upper bound
+        WHEN 19 THEN -9223371487098961920.0 -- exactly at lower bound
+        -- Large values (testing precision)
+        WHEN 20 THEN toFloat32(1e10)
+        WHEN 21 THEN toFloat32(-1e10)
+        WHEN 22 THEN toFloat32(1e20)
+        WHEN 23 THEN toFloat32(-1e20)
+        WHEN 24 THEN toFloat32(1e-10)
+        WHEN 25 THEN toFloat32(-1e-10)
+        -- Regular decimal values
+        ELSE toFloat32(round(number * 0.1 + cos(number), 2))
+    END
+FROM numbers(4000);
+TRUNCATE TABLE alp32; INSERT INTO alp32 SELECT * FROM base32;
+SELECT count(), sum(bin(a.f) <> bin(b.f)) FROM base32 AS b INNER JOIN alp32 AS a USING i;
+
+
+DROP TABLE base32;
+DROP TABLE base64;
+DROP TABLE alp32;
+DROP TABLE alp64;


### PR DESCRIPTION
Reverts #98571 to restore #91362.

The original revert was due to a flaky test [report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=98540&sha=b597afe71823946970a04bac8023dbc2b6038389&name_0=PR&name_1=Stateless%20tests%20%28amd_debug%2C%20AsyncInsert%2C%20s3%20storage%2C%20parallel%29
https://github.com/ClickHouse/ClickHouse/pull/98540). The flakiness occurred because the test checks that a roundtrip of `-0.0` preserves `-0.0`, but when random settings force sparse serialisation (e.g. `ratio_of_defaults_for_sparse_serialization = 0.01`), `-0.0` becomes `0.0`. See https://github.com/ClickHouse/ClickHouse/issues/98637.

I've adjusted the test to account for this, fixing the flakiness.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.404`
<!-- ch-version-info:end -->