### PR TITLE
CI: use merge-base master build as perf test reference for PRs

### DIFF
--- a/ci/jobs/performance_tests.py
+++ b/ci/jobs/performance_tests.py
@@ -276,13 +276,11 @@ def parse_args():
 
 
 def find_prev_build(info, build_type):
-    commits = info.get_kv_data("previous_commits_sha") or []
-    assert commits, "No commits found to fetch reference build"
+    commits = info.get_kv_data("master_track_commits_sha") or []
     for sha in commits:
         link = f"https://clickhouse-builds.s3.us-east-1.amazonaws.com/REFs/master/{sha}/{build_type}/clickhouse"
         if Shell.check(f"curl -sfI {link} > /dev/null"):
             return link
-
     return None
 
 
@@ -323,10 +321,9 @@ def main():
 
     if Utils.is_arm():
         if compare_against_master:
-            if info.git_branch == "master":
-                link_for_ref_ch = find_prev_build(info, "build_arm_release")
-                assert link_for_ref_ch, "previous clickhouse build has not been found"
-            else:
+            link_for_ref_ch = find_prev_build(info, "build_arm_release")
+            if not link_for_ref_ch:
+                print("WARNING: No build found for master track commits, falling back to latest master build")
                 link_for_ref_ch = "https://clickhouse-builds.s3.us-east-1.amazonaws.com/master/aarch64/clickhouse"
         elif compare_against_release:
             link_for_ref_ch = find_base_release_build(info, "build_arm_release")
@@ -335,10 +332,9 @@ def main():
             assert False
     elif Utils.is_amd():
         if compare_against_master:
-            if info.git_branch == "master":
-                link_for_ref_ch = find_prev_build(info, "build_amd_release")
-                assert link_for_ref_ch, "previous clickhouse build has not been found"
-            else:
+            link_for_ref_ch = find_prev_build(info, "build_amd_release")
+            if not link_for_ref_ch:
+                print("WARNING: No build found for master track commits, falling back to latest master build")
                 link_for_ref_ch = "https://clickhouse-builds.s3.us-east-1.amazonaws.com/master/amd64/clickhouse"
         elif compare_against_release:
             link_for_ref_ch = find_base_release_build(info, "build_amd_release")

--- a/ci/jobs/scripts/workflow_hooks/store_data.py
+++ b/ci/jobs/scripts/workflow_hooks/store_data.py
@@ -31,9 +31,7 @@ if __name__ == "__main__":
         )
         commits = raw.splitlines()
 
-        for sha in commits:
-            if sha == info.sha:
-                break
+        while commits and commits[0] != info.sha:
             commits.pop(0)
 
         info.store_kv_data("master_track_commits_sha", commits)
@@ -49,7 +47,7 @@ if __name__ == "__main__":
             master_parent_commits = [
                 s.strip()
                 for s in Shell.get_output(
-                    f"git rev-list --max-count=30 {master_parent}", verbose=True
+                    f"git rev-list --first-parent --max-count=30 {master_parent}", verbose=True
                 ).splitlines()
                 if len(s.strip()) == 40
             ]

--- a/ci/jobs/scripts/workflow_hooks/store_data.py
+++ b/ci/jobs/scripts/workflow_hooks/store_data.py
@@ -36,10 +36,33 @@ if __name__ == "__main__":
                 break
             commits.pop(0)
 
-        info.store_kv_data("previous_commits_sha", commits)
+        info.store_kv_data("master_track_commits_sha", commits)
 
     # store integration test diff to find: TODO: find changed test cases
     if info.pr_number:
+        # store master side commits for perf tests comparison
+        # In PR CI, HEAD is a merge commit; HEAD^2 is the master parent of that merge commit
+        master_parent = Shell.get_output(
+            "git rev-parse HEAD^2", verbose=True
+        ).strip()
+        if master_parent and len(master_parent) == 40:
+            master_parent_commits = [
+                s.strip()
+                for s in Shell.get_output(
+                    f"git rev-list --max-count=30 {master_parent}", verbose=True
+                ).splitlines()
+                if len(s.strip()) == 40
+            ]
+            if master_parent_commits:
+                info.store_kv_data("master_track_commits_sha", master_parent_commits)
+                print(
+                    f"Stored {len(master_parent_commits)} master parent commits for perf test comparison, starting from {master_parent}"
+                )
+        else:
+            print(
+                "WARNING: Could not find master parent commit (HEAD^2), skipping perf test commit storage"
+            )
+
         file_diff = {}
         for file in changed_files:
             if file.startswith("tests/integration/test") and file.endswith(".py"):


### PR DESCRIPTION
For PR workflows, CI runs on a merge commit. Walk back along the master parent (`HEAD^2`) to find the first available build, instead of always using the latest master build. Falls back to the latest master build if no suitable build is found. Rename `previous_commits_sha` to `master_track_commits_sha` to clarify these are master-track commits.

### Changelog category (leave one category that best describes this PR)
- Not for changelog (changelog entry is not required)



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.372`
<!-- ch-version-info:end -->