### PR TITLE
CI: close open cherry-pick/backport PRs for rolling-out branches

### DIFF
--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -641,6 +641,53 @@ class BackportPRs:
             if Labels.ROLLING_OUT in {label.name for label in release_pr.labels}
         ]
 
+    def _close_prs_for_rolling_out_branch(
+        self, pr: PullRequest, branch: str
+    ) -> None:
+        """
+        Close any open cherry-pick or backport PRs that were previously created
+        for a release branch that is now marked `rolling-out`.
+        """
+        cp_branch = ReleaseBranch.cp_branch(branch, pr.number)
+        bp_branch = ReleaseBranch.bp_branch(branch, pr.number)
+        # Search separately: label:A,B in GitHub search is AND (must have both),
+        # so we issue two queries — one per label — to find either type.
+        open_prs = []
+        for head_branch, label in (
+            (cp_branch, Labels.PR_CHERRYPICK),
+            (bp_branch, Labels.PR_BACKPORT),
+        ):
+            open_prs += self.gh.get_pulls_from_search(
+                query=f"type:pr repo:{self._repo_name} head:{head_branch}",
+                state="open",
+                label=label,
+            )
+        for open_pr in open_prs:
+            logging.info(
+                "PR #%s: closing PR #%s because release branch %s is rolling-out",
+                pr.number,
+                open_pr.number,
+                branch,
+            )
+            if self.dry_run:
+                logging.info(
+                    "DRY RUN: would close PR #%s for rolling-out branch %s",
+                    open_pr.number,
+                    branch,
+                )
+                continue
+            version = branch.replace("release/", "")
+            open_pr.create_issue_comment(
+                f"Closing this PR because the target release branch `{branch}` "
+                "is currently being rolled out. Backporting is skipped for "
+                "rolling-out branches when the original PR carries only the "
+                "generic `pr-must-backport` or `pr-critical-bugfix` label.\n\n"
+                f"If you still want to backport this change, add the "
+                f"`v{version}-must-backport` label to the original PR "
+                f"#{pr.number} — that overrides the rolling-out skip."
+            )
+            open_pr.edit(state="closed")
+
     def process_pr(self, pr: PullRequest) -> None:
         pr_labels = [label.name for label in pr.labels]
 
@@ -672,6 +719,8 @@ class BackportPRs:
                     pr.number,
                     ", ".join(skipped),
                 )
+                for br in skipped:
+                    self._close_prs_for_rolling_out_branch(pr, br)
             branches = [
                 ReleaseBranch(br, pr, self.repo)
                 for br in self.release_branches


### PR DESCRIPTION
## Summary

After #97274, a label-cycling loop was introduced: when a release branch acquired the `rolling-out` label *after* cherry-pick PRs had already been created for it, the bot would continuously remove and re-add `pr-backports-created` on every workflow run.

**Root cause:**
1. `check_open_prs` finds the open cherry-pick PR for the rolling-out branch → removes `pr-backports-created` from the original PR.
2. `process_pr` skips the rolling-out branch, sees all other branches are done → re-adds `pr-backports-created`.
3. Repeat on every run.

**Fix:** When `process_pr` identifies rolling-out branches to skip, it now calls `_close_prs_for_rolling_out_branch` for each one. That method finds any open cherry-pick or backport PRs for the skipped branch and closes them with a comment that explains why and how to override the skip (by adding a version-specific label such as `v25.10-must-backport` to the original PR).

After one run with this fix the open cherry-pick PRs are gone, `check_open_prs` no longer finds them, and the label stops cycling.

## Changelog category

CI Fix or improvement

## Changelog entry

`cherry_pick.py` now closes open cherry-pick/backport PRs for release branches newly marked `rolling-out`, preventing an infinite `pr-backports-created` label-cycling loop introduced by #97274.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.352`
<!-- ch-version-info:end -->