### PR TITLE
Fix RBAC bypass for DESCRIBE via remote() table functions

### DIFF
--- a/src/Storages/getStructureOfRemoteTable.cpp
+++ b/src/Storages/getStructureOfRemoteTable.cpp
@@ -1,5 +1,6 @@
 #include <Storages/getStructureOfRemoteTable.h>
 
+#include <Access/Common/AccessFlags.h>
 #include <Columns/ColumnBLOB.h>
 #include <Columns/ColumnString.h>
 #include <Core/Settings.h>
@@ -61,6 +62,7 @@ ColumnsDescription getStructureOfRemoteTableInShard(
     {
         if (shard_info.isLocal())
         {
+            context->checkAccess(AccessType::SHOW_COLUMNS, table_id);
             auto storage_ptr = DatabaseCatalog::instance().getTable(table_id, context);
             return storage_ptr->getInMemoryMetadataPtr()->getColumns();
         }

--- a/tests/queries/0_stateless/04010_describe_remote_rbac_bypass.reference
+++ b/tests/queries/0_stateless/04010_describe_remote_rbac_bypass.reference
@@ -1,0 +1,54 @@
+Row 1:
+name:               x
+type:               UInt32
+default_type:
+default_expression:
+comment:
+codec_expression:
+ttl_expression:
+
+Row 2:
+name:               secret
+type:               String
+default_type:
+default_expression:
+comment:
+codec_expression:
+ttl_expression:
+
+Row 1:
+name:               x
+type:               UInt32
+default_type:
+default_expression:
+comment:
+codec_expression:
+ttl_expression:
+
+Row 2:
+name:               secret
+type:               String
+default_type:
+default_expression:
+comment:
+codec_expression:
+ttl_expression:
+
+Row 1:
+name:               x
+type:               UInt32
+default_type:
+default_expression:
+comment:
+codec_expression:
+ttl_expression:
+
+Row 2:
+name:               secret
+type:               String
+default_type:
+default_expression:
+comment:
+codec_expression:
+ttl_expression:
+

--- a/tests/queries/0_stateless/04010_describe_remote_rbac_bypass.reference
+++ b/tests/queries/0_stateless/04010_describe_remote_rbac_bypass.reference
@@ -1,54 +1,6 @@
-Row 1:
-name:               x
-type:               UInt32
-default_type:
-default_expression:
-comment:
-codec_expression:
-ttl_expression:
-
-Row 2:
-name:               secret
-type:               String
-default_type:
-default_expression:
-comment:
-codec_expression:
-ttl_expression:
-
-Row 1:
-name:               x
-type:               UInt32
-default_type:
-default_expression:
-comment:
-codec_expression:
-ttl_expression:
-
-Row 2:
-name:               secret
-type:               String
-default_type:
-default_expression:
-comment:
-codec_expression:
-ttl_expression:
-
-Row 1:
-name:               x
-type:               UInt32
-default_type:
-default_expression:
-comment:
-codec_expression:
-ttl_expression:
-
-Row 2:
-name:               secret
-type:               String
-default_type:
-default_expression:
-comment:
-codec_expression:
-ttl_expression:
-
+x
+secret
+x
+secret
+x
+secret

--- a/tests/queries/0_stateless/04010_describe_remote_rbac_bypass.sh
+++ b/tests/queries/0_stateless/04010_describe_remote_rbac_bypass.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Tags: no-replicated-database
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+user="user04010_${CLICKHOUSE_DATABASE}_$RANDOM"
+db=${CLICKHOUSE_DATABASE}
+
+${CLICKHOUSE_CLIENT} <<EOF
+DROP USER IF EXISTS $user;
+CREATE USER $user;
+CREATE TABLE $db.secret_table (x UInt32, secret String) ENGINE = MergeTree ORDER BY x;
+GRANT CREATE TEMPORARY TABLE ON *.* TO $user;
+EOF
+
+${CLICKHOUSE_CLIENT} --user $user --query "DESCRIBE $db.secret_table; -- { serverError ACCESS_DENIED }";
+${CLICKHOUSE_CLIENT} --user $user --query "DESCRIBE remote('127.0.0.1:${CLICKHOUSE_PORT_TCP}', '$db', 'secret_table'); -- { serverError ACCESS_DENIED }";
+${CLICKHOUSE_CLIENT} --user $user --query "DESCRIBE clusterAllReplicas('test_shard_localhost', '$db', 'secret_table'); -- { serverError ACCESS_DENIED }";
+
+${CLICKHOUSE_CLIENT} --query "GRANT SHOW COLUMNS ON $db.secret_table TO $user";
+
+${CLICKHOUSE_CLIENT} --user $user --query "DESCRIBE $db.secret_table FORMAT Vertical";
+${CLICKHOUSE_CLIENT} --user $user --query "DESCRIBE remote('127.0.0.1:${CLICKHOUSE_PORT_TCP}', '$db', 'secret_table') FORMAT Vertical";
+${CLICKHOUSE_CLIENT} --user $user --query "DESCRIBE clusterAllReplicas('test_shard_localhost', '$db', 'secret_table') FORMAT Vertical";
+
+${CLICKHOUSE_CLIENT} <<EOF
+DROP USER IF EXISTS $user;
+DROP TABLE IF EXISTS $db.secret_table;
+EOF

--- a/tests/queries/0_stateless/04010_describe_remote_rbac_bypass.sh
+++ b/tests/queries/0_stateless/04010_describe_remote_rbac_bypass.sh
@@ -15,15 +15,15 @@ CREATE TABLE $db.secret_table (x UInt32, secret String) ENGINE = MergeTree ORDER
 GRANT CREATE TEMPORARY TABLE ON *.* TO $user;
 EOF
 
-${CLICKHOUSE_CLIENT} --user $user --query "DESCRIBE $db.secret_table; -- { serverError ACCESS_DENIED }";
-${CLICKHOUSE_CLIENT} --user $user --query "DESCRIBE remote('127.0.0.1:${CLICKHOUSE_PORT_TCP}', '$db', 'secret_table'); -- { serverError ACCESS_DENIED }";
-${CLICKHOUSE_CLIENT} --user $user --query "DESCRIBE clusterAllReplicas('test_shard_localhost', '$db', 'secret_table'); -- { serverError ACCESS_DENIED }";
+${CLICKHOUSE_CLIENT} --user $user --query "DESCRIBE $db.secret_table; -- { serverError ACCESS_DENIED }"
+${CLICKHOUSE_CLIENT} --user $user --query "DESCRIBE remote('127.0.0.1:${CLICKHOUSE_PORT_TCP}', '$db', 'secret_table'); -- { serverError ACCESS_DENIED }"
+${CLICKHOUSE_CLIENT} --user $user --query "DESCRIBE clusterAllReplicas('test_shard_localhost', '$db', 'secret_table'); -- { serverError ACCESS_DENIED }"
 
-${CLICKHOUSE_CLIENT} --query "GRANT SHOW COLUMNS ON $db.secret_table TO $user";
+${CLICKHOUSE_CLIENT} --query "GRANT SHOW COLUMNS ON $db.secret_table TO $user"
 
-${CLICKHOUSE_CLIENT} --user $user --query "DESCRIBE $db.secret_table FORMAT Vertical";
-${CLICKHOUSE_CLIENT} --user $user --query "DESCRIBE remote('127.0.0.1:${CLICKHOUSE_PORT_TCP}', '$db', 'secret_table') FORMAT Vertical";
-${CLICKHOUSE_CLIENT} --user $user --query "DESCRIBE clusterAllReplicas('test_shard_localhost', '$db', 'secret_table') FORMAT Vertical";
+${CLICKHOUSE_CLIENT} --user $user --query "DESCRIBE $db.secret_table" | cut -f1
+${CLICKHOUSE_CLIENT} --user $user --query "DESCRIBE remote('127.0.0.1:${CLICKHOUSE_PORT_TCP}', '$db', 'secret_table')" | cut -f1
+${CLICKHOUSE_CLIENT} --user $user --query "DESCRIBE clusterAllReplicas('test_shard_localhost', '$db', 'secret_table')" | cut -f1
 
 ${CLICKHOUSE_CLIENT} <<EOF
 DROP USER IF EXISTS $user;


### PR DESCRIPTION
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix RBAC bypass that allowed users to DESCRIBE any table via `remote()`, `remoteSecure()`, `cluster()`, or `clusterAllReplicas()` pointed at localhost, without requiring `SHOW_COLUMNS` privilege.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

No documentation changes needed — this is a security fix that enforces existing access control semantics.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.502` (included in `26.3` and later)
- Backported to: `25.8.29.31`
<!-- ch-version-info:end -->