### PR TITLE
Fix UBSan SIGSEGV when calling JIT-compiled functions

### DIFF
--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -1364,7 +1364,7 @@ void NO_INLINE Aggregator::executeImplBatch(
                 if (use_compiled_functions)
                 {
                     const auto & compiled_aggregate_functions = compiled_aggregate_functions_holder->compiled_aggregate_functions;
-                    compiled_aggregate_functions.create_aggregate_states_function(aggregate_data);
+                    callJITFunction(compiled_aggregate_functions.create_aggregate_states_function, aggregate_data);
                     if (compiled_aggregate_functions.functions_count != aggregate_functions.size())
                     {
                         static constexpr bool skip_compiled_aggregate_functions = true;
@@ -1447,12 +1447,12 @@ void Aggregator::executeAggregateInstructions(
         {
             ProfileEvents::increment(ProfileEvents::AggregationOptimizedEqualRangesOfKeys);
             auto add_into_aggregate_states_function_single_place = compiled_aggregate_functions_holder->compiled_aggregate_functions.add_into_aggregate_states_function_single_place;
-            add_into_aggregate_states_function_single_place(row_begin, row_end, columns_data.data(), places[key_start]);
+            callJITFunction(add_into_aggregate_states_function_single_place, row_begin, row_end, columns_data.data(), places[key_start]);
         }
         else
         {
             auto add_into_aggregate_states_function = compiled_aggregate_functions_holder->compiled_aggregate_functions.add_into_aggregate_states_function;
-            add_into_aggregate_states_function(row_begin, row_end, columns_data.data(), places);
+            callJITFunction(add_into_aggregate_states_function, row_begin, row_end, columns_data.data(), places);
         }
     }
 #endif
@@ -1518,7 +1518,7 @@ void NO_INLINE Aggregator::executeWithoutKeyImpl(
         }
 
         auto add_into_aggregate_states_function_single_place = compiled_aggregate_functions_holder->compiled_aggregate_functions.add_into_aggregate_states_function_single_place;
-        add_into_aggregate_states_function_single_place(row_begin, row_end, columns_data.data(), res);
+        callJITFunction(add_into_aggregate_states_function_single_place, row_begin, row_end, columns_data.data(), res);
     }
 #endif
 
@@ -2390,7 +2390,7 @@ Block Aggregator::insertResultsIntoColumns(
             }
 
             auto insert_aggregates_into_columns_function = compiled_functions.insert_aggregates_into_columns_function;
-            insert_aggregates_into_columns_function(0, places.size(), columns_data.data(), places.data());
+            callJITFunction(insert_aggregates_into_columns_function, 0, places.size(), columns_data.data(), places.data());
         }
 #endif
 
@@ -2975,7 +2975,7 @@ void NO_INLINE Aggregator::mergeDataImpl(
     if (use_compiled_functions)
     {
         const auto & compiled_functions = compiled_aggregate_functions_holder->compiled_aggregate_functions;
-        compiled_functions.merge_aggregate_states_function(dst_places.data(), src_places.data(), dst_places.size());
+        callJITFunction(compiled_functions.merge_aggregate_states_function, dst_places.data(), src_places.data(), dst_places.size());
 
         for (size_t i = 0; i < params.aggregates_size; ++i)
         {

--- a/src/Interpreters/ExpressionJIT.cpp
+++ b/src/Interpreters/ExpressionJIT.cpp
@@ -91,7 +91,7 @@ public:
             columns[arguments.size()] = getColumnData(result_column.get());
 
             auto jit_compiled_function = compiled_function_holder->compiled_function.compiled_function;
-            jit_compiled_function(input_rows_count, columns.data());
+            callJITFunction(jit_compiled_function, input_rows_count, columns.data());
 
             #if defined(MEMORY_SANITIZER)
             /// Memory sanitizer doesn't know about stores from JIT-ed code.

--- a/src/Interpreters/JIT/compileFunction.h
+++ b/src/Interpreters/JIT/compileFunction.h
@@ -4,6 +4,7 @@
 
 #if USE_EMBEDDED_COMPILER
 
+#    include <base/sanitizer_defs.h>
 #    include <AggregateFunctions/IAggregateFunction_fwd.h>
 #    include <Core/SortDescription.h>
 #    include <Functions/IFunction.h>
@@ -32,6 +33,17 @@ using ColumnDataRowsOffset = size_t;
 using ColumnDataRowsSize = size_t;
 
 using JITCompiledFunction = void (*)(ColumnDataRowsSize, ColumnData *);
+
+/** Wrapper to call JIT-compiled functions.
+  * UBSan's `-fsanitize=function` reads a type signature at `function_pointer - 8` before every indirect call.
+  * JIT-compiled functions don't have this prologue, and when JIT code is at a page boundary,
+  * the read accesses unmapped memory, causing a SIGSEGV.
+  */
+template <typename F, typename... Args>
+NO_SANITIZE_UNDEFINED inline void callJITFunction(F && f, Args &&... args)
+{
+    f(std::forward<Args>(args)...);
+}
 
 struct CompiledFunction
 {


### PR DESCRIPTION
## Summary

- UBSan's `-fsanitize=function` check reads a type signature at `function_pointer - 8` before every indirect call. JIT-compiled functions don't have this prologue, and when JIT code is allocated at the start of a page by `posix_memalign`, the read accesses unmapped memory, causing a SIGSEGV.
- Add `callJITFunction` wrapper marked `NO_SANITIZE_UNDEFINED` in `compileFunction.h` and use it at all JIT indirect call sites in `ExpressionJIT` and `Aggregator`.

Closes #98580

## Test plan

- [x] UBSan build compiles successfully
- [ ] CI passes — the `AST fuzzer (amd_ubsan)` job that was hitting `ExpressionJIT.cpp:94` should no longer segfault

### Changelog category (leave one):
- CI Fix or Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.362`
<!-- ch-version-info:end -->