### PR TITLE
Fix retry_infra_failures not rerunning Config Workflow checkout failures

### DIFF
--- a/.github/workflows/retry_infra_failures.yml
+++ b/.github/workflows/retry_infra_failures.yml
@@ -59,8 +59,7 @@ jobs:
             # Each failed job emits "true" (infrastructure) or "false" (real failure).
             # A job is considered an infrastructure failure if:
             # - it is the "Config Workflow" or "Finish Workflow" job (pipeline plumbing,
-            #   not actual tests; "Finish Workflow" runs in ~15s so the <120s heuristic
-            #   would always misclassify it as infra), or
+            #   not actual tests — always treated as infrastructure failure), or
             # - it never reached its main "Run" step (failed during checkout/setup), or
             # - the "Run" step was skipped, or
             # - the "Run" step failed almost immediately (under 2 minutes), indicating
@@ -68,7 +67,7 @@ jobs:
             #   test failure
             verdicts=$(echo "$jobs_raw" | jq -r '
               .jobs[] | select(.conclusion == "failure") |
-              if .name == "Config Workflow" or .name == "Finish Workflow" then empty
+              if .name == "Config Workflow" or .name == "Finish Workflow" then true
               else
                 [.steps[] | select(.name == "Run")] |
                 if length == 0 then true


### PR DESCRIPTION
## Summary
- When `Config Workflow` was the only failed job (e.g. GitHub HTTP 500 during git fetch in [#98660](https://github.com/ClickHouse/ClickHouse/pull/98660)), the jq filter emitted `empty`, making `verdicts` an empty string — treated as "no failed jobs" instead of "all infra"
- The second code path (PR description edit check) also didn't help since it only looks for failures in the "Run" step, not checkout failures
- Fix: change `empty` to `true` so `Config Workflow` / `Finish Workflow` failures count as infrastructure verdicts and trigger a rerun

## Test plan
- [x] Verify the logic: when only Config/Finish Workflow fails → verdicts = `"true"` → no `"false"` found → `should_rerun=true`
- [x] When Config/Finish Workflow fails alongside a real test failure → verdicts contain `"false"` → no rerun (correct)

### Changelog category (leave one):
- CI Fix or improvement

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Fix `retry_infra_failures` workflow not retrying when `Config Workflow` fails during git checkout (e.g. GitHub HTTP 500).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.450`
<!-- ch-version-info:end -->