### PR TITLE
Do not fail upgrade check when non-essential packages fail to download

### DIFF
--- a/tests/ci/download_release_packages.py
+++ b/tests/ci/download_release_packages.py
@@ -20,11 +20,19 @@ def download_packages(
 
     logging.info("Will download %s", release)
 
+    failed = []
     for pkg, url in release.assets.items():
         if not pkg.endswith("_amd64.deb") or (not debug and "-dbg_" in pkg):
             continue
         pkg_name = dest_path / pkg
-        download_build_with_progress(url, pkg_name)
+        try:
+            download_build_with_progress(url, pkg_name)
+        except DownloadException:
+            failed.append(pkg)
+            logging.warning("Failed to download %s, will skip", pkg)
+
+    if failed:
+        logging.warning("Some packages failed to download: %s", ", ".join(failed))
 
 
 def download_last_release(dest_path: Path, debug: bool = False) -> None:


### PR DESCRIPTION
## Summary
- The upgrade check downloads all release packages from GitHub, but only `clickhouse-common-static`, `clickhouse-server`, and `clickhouse-client` are actually needed
- A transient GitHub 500 error on `clickhouse-keeper` would abort the entire download before `clickhouse-server` is fetched, causing the whole check to fail
- Now individual `DownloadException`s are caught and logged as warnings, allowing the remaining packages to be downloaded
- The existing validation in `upgrade_runner.sh` already checks for essential packages and will properly fail if those are missing

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96171&sha=a50b2c30bfc8eadf85115e54a37347e8f262989c&name_0=PR&name_1=Upgrade%20check%20%28amd_release%29
https://github.com/ClickHouse/ClickHouse/pull/96171

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)