### PR TITLE
Fix stale UUID in query storage cache causing UNKNOWN_TABLE for refreshable MVs

### DIFF
--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -1390,7 +1390,7 @@ String Context::getFilesystemCacheUser() const
     return shared->filesystem_cache_user;
 }
 
-DatabaseAndTable Context::getOrCacheStorage(const StorageID & id, std::function<DatabaseAndTable()> storage_getter, std::optional<Exception> * exception) const
+DatabaseAndTable Context::getOrCacheStorage(const StorageID & id, std::function<DatabaseAndTable()> storage_getter) const
 {
     auto & shard = storage_cache.shards[StorageCache::shardIndex(id)];
     std::lock_guard lock(shard.mutex);
@@ -1398,12 +1398,13 @@ DatabaseAndTable Context::getOrCacheStorage(const StorageID & id, std::function<
     if (auto it = shard.set.find(id); it != shard.set.end())
     {
         DatabaseAndTable storage = DatabaseCatalog::instance().tryGetByUUID(it->uuid);
-        if (exception && !storage.second)
-            exception->emplace(Exception(
-                ErrorCodes::UNKNOWN_TABLE,
-                "Table {} does not exist anymore - maybe it was dropped",
-                id.getNameForLogs()));
-        return storage;
+        if (storage.second)
+            return storage;
+
+        /// The table was cached but no longer exists by its UUID
+        /// (e.g. refreshable materialized view's inner table was dropped and recreated).
+        /// Remove the stale entry and fall through to a fresh lookup by name.
+        shard.set.erase(it);
     }
 
     auto storage = storage_getter();

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -725,7 +725,7 @@ public:
     String getFilesystemCachesPath() const;
     String getFilesystemCacheUser() const;
 
-    DatabaseAndTable getOrCacheStorage(const StorageID & id, std::function<DatabaseAndTable()> storage_getter, std::optional<Exception> * exception) const;
+    DatabaseAndTable getOrCacheStorage(const StorageID & id, std::function<DatabaseAndTable()> storage_getter) const;
 
     // Get the disk used by databases to store metadata files.
     std::shared_ptr<IDisk> getDatabaseDisk() const;

--- a/src/Interpreters/DatabaseCatalog.cpp
+++ b/src/Interpreters/DatabaseCatalog.cpp
@@ -1082,7 +1082,7 @@ StoragePtr DatabaseCatalog::getTable(const StorageID & table_id, ContextPtr loca
 {
     std::optional<Exception> exc;
     auto table = local_context->hasQueryContext() ?
-        local_context->getQueryContext()->getOrCacheStorage(table_id, [&](){ return getTableImpl(table_id, local_context, &exc); }, &exc).second :
+        local_context->getQueryContext()->getOrCacheStorage(table_id, [&](){ return getTableImpl(table_id, local_context, &exc); }).second :
         getTableImpl(table_id, local_context, &exc).second;
     if (!table)
         throw Exception(*exc);
@@ -1092,7 +1092,7 @@ StoragePtr DatabaseCatalog::getTable(const StorageID & table_id, ContextPtr loca
 StoragePtr DatabaseCatalog::tryGetTable(const StorageID & table_id, ContextPtr local_context) const
 {
     return local_context->hasQueryContext() ?
-        local_context->getQueryContext()->getOrCacheStorage(table_id, [&](){ return getTableImpl(table_id, local_context, nullptr); }, nullptr).second :
+        local_context->getQueryContext()->getOrCacheStorage(table_id, [&](){ return getTableImpl(table_id, local_context, nullptr); }).second :
         getTableImpl(table_id, local_context, nullptr).second;
 }
 
@@ -1100,7 +1100,7 @@ DatabaseAndTable DatabaseCatalog::getDatabaseAndTable(const StorageID & table_id
 {
     std::optional<Exception> exc;
     auto res = local_context->hasQueryContext() ?
-        local_context->getQueryContext()->getOrCacheStorage(table_id, [&](){ return getTableImpl(table_id, local_context, &exc); }, &exc) :
+        local_context->getQueryContext()->getOrCacheStorage(table_id, [&](){ return getTableImpl(table_id, local_context, &exc); }) :
         getTableImpl(table_id, local_context, &exc);
     if (!res.second)
         throw Exception(*exc);
@@ -1110,7 +1110,7 @@ DatabaseAndTable DatabaseCatalog::getDatabaseAndTable(const StorageID & table_id
 DatabaseAndTable DatabaseCatalog::tryGetDatabaseAndTable(const StorageID & table_id, ContextPtr local_context) const
 {
     return local_context->hasQueryContext() ?
-        local_context->getQueryContext()->getOrCacheStorage(table_id, [&](){ return getTableImpl(table_id, local_context, nullptr); }, nullptr) :
+        local_context->getQueryContext()->getOrCacheStorage(table_id, [&](){ return getTableImpl(table_id, local_context, nullptr); }) :
         getTableImpl(table_id, local_context, nullptr);
 }
 


### PR DESCRIPTION
## Summary
- The per-query storage cache in `Context::getOrCacheStorage` caches table lookups by name, storing the UUID for fast subsequent lookups via `tryGetByUUID`
- When a table is dropped and recreated with a new UUID (as happens with refreshable materialized view inner tables on every non-APPEND refresh), the cached UUID becomes stale
- The old code returned null and threw "Table does not exist anymore - maybe it was dropped" instead of invalidating the stale entry and retrying the lookup by name
- Fix: erase the stale cache entry and fall through to `storage_getter` which resolves the table by name and caches the new UUID

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96130&sha=eba1d6bd0c9b167be37d43e44a0b111d4088cc53&name_0=PR&name_1=Integration%20tests%20%28amd_asan%2C%20targeted%29
https://github.com/ClickHouse/ClickHouse/pull/96130

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.388`
- Backported to: `26.2.11.4`, `26.1.8.34`
<!-- ch-version-info:end -->