### PR TITLE
Fix flaky test 04023_rollup_totals_memory_limit

### DIFF
--- a/tests/queries/0_stateless/04023_rollup_totals_memory_limit.sql
+++ b/tests/queries/0_stateless/04023_rollup_totals_memory_limit.sql
@@ -1,3 +1,4 @@
+-- Tags: no-parallel-replicas
 -- https://github.com/ClickHouse/ClickHouse/issues/93465
 CREATE TABLE t0 (c0 Int, c1 Int128) ENGINE = MergeTree ORDER BY tuple();
 INSERT INTO t0 SELECT 1, number FROM numbers(40000);

--- a/tests/queries/0_stateless/04023_rollup_totals_memory_limit.sql
+++ b/tests/queries/0_stateless/04023_rollup_totals_memory_limit.sql
@@ -1,4 +1,4 @@
 -- https://github.com/ClickHouse/ClickHouse/issues/93465
 CREATE TABLE t0 (c0 Int, c1 Int128) ENGINE = MergeTree ORDER BY tuple();
 INSERT INTO t0 SELECT 1, number FROM numbers(40000);
-SELECT countDistinct(c1) FROM t0 GROUP BY c0 WITH ROLLUP WITH TOTALS SETTINGS max_memory_usage = 10000000; -- { serverError MEMORY_LIMIT_EXCEEDED }
+SELECT countDistinct(c1) FROM t0 GROUP BY c0 WITH ROLLUP WITH TOTALS SETTINGS max_memory_usage = 10000000, max_bytes_before_external_group_by = 0, max_bytes_ratio_before_external_group_by = 0; -- { serverError MEMORY_LIMIT_EXCEEDED }


### PR DESCRIPTION
## Summary
- The test `04023_rollup_totals_memory_limit` expects `MEMORY_LIMIT_EXCEEDED` but fails in the ParallelReplicas test suite because randomized `max_bytes_ratio_before_external_group_by` triggers external aggregation before the memory limit, causing the query to succeed.
- Fix: explicitly set `max_bytes_before_external_group_by = 0, max_bytes_ratio_before_external_group_by = 0` in the test query.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=98544&sha=f54c6023591884d99a67e1a3f6cd1b0cfaf94d35&name_0=PR&name_1=Stateless%20tests%20%28amd_binary%2C%20ParallelReplicas%2C%20s3%20storage%2C%20parallel%29
https://github.com/ClickHouse/ClickHouse/pull/98544

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.366`
<!-- ch-version-info:end -->