### PR TITLE
Make external sort/group by randomization per-test

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1115,21 +1115,24 @@ def auto_statistics_generator():
 
 
 def randomize_external_sort_group_by():
+    """Returns a dict of 4 settings for external sort/group by.
+    The Bytes-vs-Ratio choice is made per call (not per process),
+    so each test run gets an independent choice."""
     if random.choice(["Bytes", "Ratio"]) == "Bytes":
         generator = threshold_generator(0.3, 0.5, 0, 10 * 1024 * 1024 * 1024)
         return {
-            "max_bytes_before_external_sort": generator,
-            "max_bytes_before_external_group_by": generator,
-            "max_bytes_ratio_before_external_sort": lambda: 0,
-            "max_bytes_ratio_before_external_group_by": lambda: 0,
+            "max_bytes_before_external_sort": generator(),
+            "max_bytes_before_external_group_by": generator(),
+            "max_bytes_ratio_before_external_sort": 0,
+            "max_bytes_ratio_before_external_group_by": 0,
         }
 
     generator = threshold_generator(0.3, 0.5, 0.0, 0.20)
     return {
-        "max_bytes_before_external_sort": lambda: 0,
-        "max_bytes_before_external_group_by": lambda: 0,
-        "max_bytes_ratio_before_external_sort": lambda: round(generator(), 2),
-        "max_bytes_ratio_before_external_group_by": lambda: round(generator(), 2),
+        "max_bytes_before_external_sort": 0,
+        "max_bytes_before_external_group_by": 0,
+        "max_bytes_ratio_before_external_sort": round(generator(), 2),
+        "max_bytes_ratio_before_external_group_by": round(generator(), 2),
     }
 
 
@@ -1297,7 +1300,6 @@ class SettingsRandomizer:
         # dpsize' - implements DPsize algorithm currently only for Inner joins. So it may not work in some tests.
         # That is why we use it with fallback to 'greedy'.
         "query_plan_optimize_join_order_algorithm": lambda: random.choice(['greedy', 'dpsize,greedy', 'greedy,dpsize']),
-        **randomize_external_sort_group_by(),
     }
 
     dependent_settings = {
@@ -1328,6 +1330,8 @@ class SettingsRandomizer:
                 random_settings[setting] = 0
             else:
                 random_settings[setting] = generator()
+        # Bytes-vs-Ratio choice is made per test, not per process
+        random_settings.update(randomize_external_sort_group_by())
         for setting, other_setting in SettingsRandomizer.dependent_settings.items():
             random_settings[setting] = random_settings[other_setting]
         SettingsRandomizer.adjust_settings_for_autopr(args, tags, random_settings)


### PR DESCRIPTION
## Summary
- `randomize_external_sort_group_by()` was called once at class definition time via `**randomize_external_sort_group_by()` in the `SettingsRandomizer.settings` dict. This meant the Bytes-vs-Ratio choice was fixed for the entire process.
- In the flaky check (50 runs per test), there was a 50% chance of never testing the Ratio mode at all — which is how test `04023_rollup_totals_memory_limit` passed the flaky check but failed in ParallelReplicas runs.
- Now the function returns concrete values (not lambdas) and is called per-test inside `get_random_settings`, so each test run independently chooses between Bytes and Ratio mode.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=98544&sha=f54c6023591884d99a67e1a3f6cd1b0cfaf94d35&name_0=PR&name_1=Stateless%20tests%20%28amd_binary%2C%20ParallelReplicas%2C%20s3%20storage%2C%20parallel%29
https://github.com/ClickHouse/ClickHouse/pull/98544

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.363`
<!-- ch-version-info:end -->