### PR TITLE
Fix Docker server image test failing when git clone fails silently

### DIFF
--- a/ci/jobs/docker_server.py
+++ b/ci/jobs/docker_server.py
@@ -281,7 +281,12 @@ def test_docker_library(test_results) -> None:
         config_override = (
             Path(Utils.cwd()) / "ci/jobs/scripts/docker_server/config.sh"
         ).absolute()
-        Shell.check(f"{GIT_PREFIX} clone {GITHUB_SERVER_URL}/{repo} {repo_path}")
+        if not Shell.check(
+            f"git clone --depth 1 {GITHUB_SERVER_URL}/{repo} {repo_path}",
+            verbose=True,
+            retries=3,
+        ):
+            raise RuntimeError(f"Failed to clone {repo}")
         run_sh = (repo_path / "test/run.sh").absolute()
         for image in check_images:
             cmd = f"{run_sh} {image} -c {repo_path / 'test/config.sh'} -c {config_override}"


### PR DESCRIPTION
## Summary
- The `Shell.check` return value for cloning `docker-library/official-images` was not checked, so when the clone failed (e.g. due to transient network issues), the code continued and tried to run a non-existent `run.sh`, producing a confusing "No such file or directory" error
- Fix: check the return value, add retries, use `--depth 1` for faster cloning, enable verbose output, and drop unnecessary `GIT_PREFIX` (SSH config not needed for cloning a public HTTPS repo)

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=98391&sha=59241b3ca6c320f6495a95754fc78852781a8435&name_0=PR&name_1=Docker%20server%20image
https://github.com/ClickHouse/ClickHouse/pull/98391

## Test plan
- [x] Verified `docker-library/official-images` still has `test/run.sh`
- [x] Verified `Shell.check` returns `False` on failure and that the `except` block properly handles the raised `RuntimeError`

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.361`
<!-- ch-version-info:end -->