### PR TITLE
Fix sccache startup flakes in CI

### DIFF
--- a/ci/jobs/build_clickhouse.py
+++ b/ci/jobs/build_clickhouse.py
@@ -209,14 +209,11 @@ def main():
             )
         elif build_type in (BuildTypes.AMD_TIDY, BuildTypes.ARM_TIDY):
             run_shell("clang-tidy-cache stats", "clang-tidy-cache.py --show-stats")
-        # The sccache server sometimes fails to start because of issues with S3
-        # It should start before cmake, since cmake can precompile binaries during
-        # configuration stage
-        results.append(
-            Result.from_commands_run(
-                name="Start sccache server", command="sccache --start-server", retries=3
-            )
-        )
+        # The sccache server sometimes fails to start because of issues with S3.
+        # Start it explicitly with retries before cmake, since cmake can invoke
+        # the compiler during configuration. Non-fatal: build can proceed without it.
+        if not Shell.check("sccache --start-server", retries=3):
+            print("WARNING: sccache server failed to start, build will proceed without it")
         run_shell("sccache stats", "sccache --show-stats")
         results.append(
             Result.from_commands_run(

--- a/ci/jobs/fast_test.py
+++ b/ci/jobs/fast_test.py
@@ -204,6 +204,11 @@ def main():
     os.makedirs(build_dir, exist_ok=True)
 
     if res and JobStages.CMAKE in stages:
+        # The sccache server sometimes fails to start because of issues with S3.
+        # Start it explicitly with retries before cmake, since cmake can invoke
+        # the compiler during configuration. Non-fatal: build can proceed without it.
+        if not Shell.check("sccache --start-server", retries=3):
+            print("WARNING: sccache server failed to start, build will proceed without it")
         results.append(
             # TODO: commented out to make job platform agnostic
             #   -DCMAKE_TOOLCHAIN_FILE={current_directory}/cmake/linux/toolchain-x86_64-musl.cmake \


### PR DESCRIPTION
## Summary

- Add explicit `sccache --start-server` with `retries=3` in `fast_test.py` before cmake, matching what `build_clickhouse.py` already does
- Make sccache startup non-fatal in both files: use `Shell.check` with retries and log a warning on failure instead of failing the pipeline

The Fast Test CI job fails when the `sccache` server can't start due to transient S3 errors (`cache storage failed to read: Unexpected (temporary) at read`). `build_clickhouse.py` already had a retry workaround but it was fatal — a persistent failure blocked the entire build. `fast_test.py` lacked any explicit startup, letting sccache start lazily with no retry.

Since sccache is a cache (nice-to-have), neither job should fail if it can't start.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.367`
<!-- ch-version-info:end -->