### PR TITLE
Fix stuck auto-merge watchdog missing older PRs

### DIFF
--- a/.github/workflows/retry_infra_failures.yml
+++ b/.github/workflows/retry_infra_failures.yml
@@ -157,16 +157,16 @@ jobs:
           cutoff_seconds=3600  # 60 minutes
 
           # Get open PRs with auto-merge enabled that have mergeStateStatus=CLEAN
-          # (checks passed but not queued into merge queue)
+          # (checks passed but not queued into merge queue).
+          # Use --search to filter server-side, so we don't miss older PRs
+          # that fall outside a --limit window.
           stuck_prs=$(gh pr list \
             --repo "$GH_REPO" \
-            --state open \
-            --limit 50 \
-            --json number,autoMergeRequest,mergeStateStatus,isDraft \
+            --search "is:open auto-merge:enabled -is:draft" \
+            --json number,autoMergeRequest,mergeStateStatus \
             --jq '[.[] | select(
               .autoMergeRequest != null and
-              .mergeStateStatus == "CLEAN" and
-              .isDraft == false
+              .mergeStateStatus == "CLEAN"
             )]')
 
           count=$(echo "$stuck_prs" | jq 'length')


### PR DESCRIPTION
## Summary

The `fix-stuck-auto-merge` watchdog from #98574 used `gh pr list --limit 50`, which returns PRs sorted by most recently updated. PR #98486 was stuck with auto-merge enabled and `mergeStateStatus=CLEAN` since March 2, but it didn't appear in the first 50 results because newer PRs pushed it out of the window.

- Use `--search "is:open auto-merge:enabled -is:draft"` to filter server-side, so the query finds all matching PRs regardless of how old they are

## Test plan

- [x] Verified that PR #98486 currently matches `autoMergeRequest != null`, `mergeStateStatus == "CLEAN"`, `isDraft == false` but does not appear in `gh pr list --limit 50`
- [ ] Wait for the next hourly watchdog run and verify it detects and fixes PR #98486

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.365`
<!-- ch-version-info:end -->