### PR TITLE
Fix RPM install check failure with conflicting package versions

### DIFF
--- a/ci/jobs/build_clickhouse.py
+++ b/ci/jobs/build_clickhouse.py
@@ -286,7 +286,7 @@ def main():
         else:
             deb_arch = "arm64"
 
-        assert Shell.check(f"rm -f {temp_dir}/*.deb")
+        assert Shell.check(f"rm -f {temp_dir}/*.deb {temp_dir}/*.rpm {temp_dir}/*.tgz {temp_dir}/*.tgz.sha512")
 
         results.append(
             Result.from_commands_run(

--- a/ci/jobs/build_clickhouse.py
+++ b/ci/jobs/build_clickhouse.py
@@ -292,6 +292,7 @@ def main():
             Result.from_commands_run(
                 name="Build Packages",
                 command=[
+                    f"rm -rf {build_dir_normalized}/root",
                     f"DESTDIR={build_dir_normalized}/root command time -v ninja programs/install",
                     f"ln -sf {build_dir_normalized}/root {Utils.cwd()}/packages/root",
                     f"cd {Utils.cwd()}/packages/ && OUTPUT_DIR={temp_dir} BUILD_TYPE={BUILD_TYPE_TO_DEB_PACKAGE_TYPE[build_type]} VERSION_STRING={version_dict['string']} DEB_ARCH={deb_arch} ./build --deb {'--rpm --tgz' if 'release' in build_type else ''}",

--- a/ci/jobs/install_check.py
+++ b/ci/jobs/install_check.py
@@ -128,11 +128,11 @@ def test_install_rpm(image: DockerImage) -> List[Result]:
     # systemd just ignores the watchdog completely
     tests = {
         "Install server rpm": r"""#!/bin/bash -ex
-yum localinstall --disablerepo=* -y /packages/clickhouse-{server,client,common}*rpm
+yum localinstall --disablerepo=* --allowerasing -y /packages/clickhouse-{server,client,common}*rpm
 echo CLICKHOUSE_WATCHDOG_ENABLE=0 > /etc/default/clickhouse-server
 bash -ex /packages/server_test.sh""",
         "Install keeper rpm": r"""#!/bin/bash -ex
-yum localinstall --disablerepo=* -y /packages/clickhouse-keeper*rpm
+yum localinstall --disablerepo=* --allowerasing -y /packages/clickhouse-keeper*rpm
 bash -ex /packages/keeper_test.sh""",
         "Install clickhouse binary in rpm": r"bash -ex /packages/binary_test.sh",
     }


### PR DESCRIPTION
## Summary

When the build job is re-run for the same SHA (e.g. due to retries), old RPM packages with different version numbers accumulate in the same S3 prefix. The DEB install handles this gracefully via `apt-get`, but `yum localinstall` fails with "conflicting requests" because it cannot install two versions of the same package simultaneously.

- Add `--allowerasing` to `yum localinstall` commands in `install_check.py` so that yum resolves version conflicts by replacing the older version
- Clean old `*.rpm`, `*.tgz`, and `*.tgz.sha512` files in `build_clickhouse.py` before building packages, matching the existing cleanup for `*.deb` files

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=98671&sha=fc2ef957f9393b290edb63eadca1474ceeef5b88&name_0=PR&name_1=Install%20packages%20%28amd_release%29
https://github.com/ClickHouse/ClickHouse/pull/98671

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)