### PR TITLE
Increase retry count when updating ACL objects in Keeper

### DIFF
--- a/src/Access/ZooKeeperReplicator.cpp
+++ b/src/Access/ZooKeeperReplicator.cpp
@@ -144,7 +144,7 @@ bool ZooKeeperReplicator::insertEntity(const UUID & id, const AccessEntityPtr & 
 
     auto zookeeper = getZooKeeper();
     bool ok = false;
-    retryOnZooKeeperUserError(10, [&]{ ok = insertZooKeeper(zookeeper, id, new_entity, replace_if_exists, throw_if_exists, conflicting_id); });
+    retryOnZooKeeperUserError(1000, [&]{ ok = insertZooKeeper(zookeeper, id, new_entity, replace_if_exists, throw_if_exists, conflicting_id); });
 
     if (!ok)
         return false;
@@ -299,7 +299,7 @@ bool ZooKeeperReplicator::removeEntity(const UUID & id, bool throw_if_not_exists
 
     auto zookeeper = getZooKeeper();
     bool ok = false;
-    retryOnZooKeeperUserError(10, [&] { ok = removeZooKeeper(zookeeper, id, throw_if_not_exists); });
+    retryOnZooKeeperUserError(1000, [&] { ok = removeZooKeeper(zookeeper, id, throw_if_not_exists); });
 
     if (!ok)
         return false;
@@ -350,7 +350,7 @@ bool ZooKeeperReplicator::updateEntity(const UUID & id, const IAccessStorage::Up
 
     auto zookeeper = getZooKeeper();
     bool ok = false;
-    retryOnZooKeeperUserError(10, [&] { ok = updateZooKeeper(zookeeper, id, update_func, throw_if_not_exists); });
+    retryOnZooKeeperUserError(1000, [&] { ok = updateZooKeeper(zookeeper, id, update_func, throw_if_not_exists); });
 
     if (!ok)
         return false;

--- a/tests/queries/0_stateless/04010_concurrent_grants.sh
+++ b/tests/queries/0_stateless/04010_concurrent_grants.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Tags: zookeeper, long
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# with Atomic engine
+$CLICKHOUSE_CLIENT --query "CREATE USER u1"
+$CLICKHOUSE_CLIENT --query "CREATE ROLE r1"
+
+function run_concurrent_grants
+{
+    for _ in {1..20}; do
+        ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}" -d "GRANT r1 TO u1"
+        ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}" -d "REVOKE r1 FROM u1"
+    done
+}
+export -f run_concurrent_grants
+
+for _ in {1..20}; do
+    bash -c run_concurrent_grants &
+done
+
+wait
+
+$CLICKHOUSE_CLIENT --query "DROP ROLE r1"
+$CLICKHOUSE_CLIENT --query "DROP USER u1"
+

--- a/tests/queries/0_stateless/04010_concurrent_grants.sh
+++ b/tests/queries/0_stateless/04010_concurrent_grants.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: zookeeper, long
+# Tags: zookeeper, long, no-parallel
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
Reference : Internal Ticket https://github.com/ClickHouse/support-escalation/issues/7001

Increases the Keeper retry attempts count when updating ACL objects (ACL update of a user object could fail if multiple connections are concurrently updating the same user object)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.414`
- Backported to: `26.2.6.21`, `25.12.9.32`
<!-- ch-version-info:end -->