### PR TITLE
Fix stuck auto-merge watchdog: --search auto-merge:enabled silently returns empty

### DIFF
--- a/.github/workflows/retry_infra_failures.yml
+++ b/.github/workflows/retry_infra_failures.yml
@@ -158,15 +158,18 @@ jobs:
 
           # Get open PRs with auto-merge enabled that have mergeStateStatus=CLEAN
           # (checks passed but not queued into merge queue).
-          # Use --search to filter server-side, so we don't miss older PRs
-          # that fall outside a --limit window.
+          # Note: --search "auto-merge:enabled" does not work with gh pr list
+          # (silently returns empty results), so we fetch a large window and
+          # filter client-side via the GraphQL autoMergeRequest field.
           stuck_prs=$(gh pr list \
             --repo "$GH_REPO" \
-            --search "is:open auto-merge:enabled -is:draft" \
-            --json number,autoMergeRequest,mergeStateStatus \
+            --state open \
+            --limit 200 \
+            --json number,autoMergeRequest,mergeStateStatus,isDraft \
             --jq '[.[] | select(
               .autoMergeRequest != null and
-              .mergeStateStatus == "CLEAN"
+              .mergeStateStatus == "CLEAN" and
+              .isDraft == false
             )]')
 
           count=$(echo "$stuck_prs" | jq 'length')


### PR DESCRIPTION
The `auto-merge:enabled` search qualifier does not work with `gh pr list --search` — it silently returns zero results. This made #98690 worse than the original: the old `--limit 50` at least found recent PRs, while `--search` finds nothing at all.

Replace with `--limit 200 --state open` and client-side filtering on the GraphQL `autoMergeRequest` field, which works reliably.

Evidence:
```
# --search returns nothing despite PR #98486 having auto-merge enabled:
$ gh pr list --search "is:open auto-merge:enabled -is:draft" --json number
[]

# But the GraphQL field works:
$ gh pr list --json number,autoMergeRequest --limit 100 | python3 -c "..."
[98570, 98486]
```

https://github.com/ClickHouse/ClickHouse/pull/98690
https://github.com/ClickHouse/ClickHouse/pull/98486

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.409`
<!-- ch-version-info:end -->