### PR TITLE
Fix flaky test 03208_array_of_json_read_subcolumns_2_memory timeout

### DIFF
--- a/tests/queries/0_stateless/03208_array_of_json_read_subcolumns_2_memory.sql
+++ b/tests/queries/0_stateless/03208_array_of_json_read_subcolumns_2_memory.sql
@@ -1,5 +1,6 @@
--- Tags: no-asan, no-tsan, no-msan, no-flaky-check
+-- Tags: no-asan, no-tsan, no-msan, no-flaky-check, long, no-random-merge-tree-settings
 -- too slow for sanitizers and flaky check
+-- index_granularity=1 with 40K rows of complex JSON causes timeout
 
 SET enable_json_type = 1;
 set allow_experimental_variant_type = 1;


### PR DESCRIPTION
## Summary

- Fix timeout in `03208_array_of_json_read_subcolumns_2_memory` caused by randomized `--index_granularity 1` creating 40K granules for 40K rows of complex JSON data, combined with `--max_threads 1`
- Add `no-random-merge-tree-settings` tag to prevent catastrophic MergeTree settings randomization
- Add `long` tag to match the sister tests (`_compact_merge_tree` and `_wide_merge_tree` variants)

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=98693&sha=e7a635e1db0a7bd6283a09bfb751744e5a0dc5ca&name_0=PR&name_1=Stateless%20tests%20%28arm_binary%2C%20parallel%29
https://github.com/ClickHouse/ClickHouse/pull/98693

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)