### PR TITLE
Fix minio restart timeout hang in CI stateless test startup

### DIFF
--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -1,5 +1,7 @@
 import glob
+import json as json_module
 import os
+import signal
 import subprocess
 import sys
 import time
@@ -547,20 +549,38 @@ profiles:
 
         # Restart minio with a timeout to avoid hanging forever (see #97647).
         # If the restart hangs, kill minio and start it again.
+        # We use Popen with start_new_session=True so that on timeout we can
+        # kill the entire process group, avoiding orphaned child processes
+        # that would block communicate() indefinitely (see #98466).
         restart_timeout = 60
         try:
             print(f"Restarting clickminio (timeout {restart_timeout}s)")
-            result = subprocess.run(
-                "/mc admin service restart clickminio --wait --json 2>&1 | jq -r .status",
-                shell=True,
+            proc = subprocess.Popen(
+                [
+                    "/mc",
+                    "admin",
+                    "service",
+                    "restart",
+                    "clickminio",
+                    "--wait",
+                    "--json",
+                ],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
-                timeout=restart_timeout,
-                executable="/bin/bash",
+                start_new_session=True,
             )
-            status = result.stdout.strip()
-        except subprocess.TimeoutExpired:
+            try:
+                stdout, _ = proc.communicate(timeout=restart_timeout)
+            except subprocess.TimeoutExpired:
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+                proc.communicate()
+                raise
+            try:
+                status = json_module.loads(stdout).get("status", "")
+            except (json_module.JSONDecodeError, AttributeError):
+                status = stdout.strip()
+        except (subprocess.TimeoutExpired, OSError):
             print(
                 f"WARNING: minio restart timed out after {restart_timeout}s, killing and restarting"
             )


### PR DESCRIPTION
## Summary

- Fix a hang in `create_minio_log_tables` where `subprocess.run` with `shell=True` and a pipe (`mc ... | jq`) would block indefinitely on timeout because orphaned child processes kept the pipe open
- Replace with `subprocess.Popen` + `start_new_session=True` + `os.killpg` to reliably kill all child processes on timeout
- Parse JSON output in Python instead of piping through `jq`

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=98466&sha=c3be4fb90adefbcc38dcee78938ccc81945ad400&name_0=PR&name_1=Stateless%20tests%20%28amd_tsan%2C%20parallel%2C%201%2F2%29
https://github.com/ClickHouse/ClickHouse/pull/98466

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.400`
<!-- ch-version-info:end -->