### PR TITLE
Fix flaky test_keeper_java_client integration tests

### DIFF
--- a/tests/integration/test_keeper_java_client/java_client/src/main/java/KeeperJavaClientTest.java
+++ b/tests/integration/test_keeper_java_client/java_client/src/main/java/KeeperJavaClientTest.java
@@ -289,10 +289,12 @@ public class KeeperJavaClientTest
         {
             ensurePath(zk, path);
 
-            // Add a persistent watch
+            // Add a persistent watch — only count data change events,
+            // not watch removal notifications from the client
             AtomicInteger watchCount = new AtomicInteger(0);
             Watcher testWatcher = event -> {
-                watchCount.incrementAndGet();
+                if (event.getType() == Watcher.Event.EventType.NodeDataChanged)
+                    watchCount.incrementAndGet();
             };
             zk.addWatch(path, testWatcher, AddWatchMode.PERSISTENT);
 

--- a/tests/integration/test_keeper_java_client/test.py
+++ b/tests/integration/test_keeper_java_client/test.py
@@ -42,6 +42,7 @@ def started_cluster():
 def run_java_test(test_name):
     """Copy JAR to container and run a specific Java test."""
     instance_id = cluster.get_instance_docker_id("node")
+    instance_ip = cluster.get_instance_ip("node")
     jar_path = os.path.join(SCRIPT_DIR, "java_client", "keeper-java-client-test.jar")
 
     run_and_check(
@@ -57,8 +58,9 @@ def run_java_test(test_name):
 
     result = run_and_check(
         [
-            'docker exec {cont_id} bash -lc "java -jar /tmp/keeper-java-client-test.jar localhost:9181 {test}"'.format(
+            'docker exec {cont_id} bash -lc "java -jar /tmp/keeper-java-client-test.jar {ip}:9181 {test}"'.format(
                 cont_id=instance_id,
+                ip=instance_ip,
                 test=test_name,
             )
         ],


### PR DESCRIPTION
## Summary
- Fix `test_remove_watches` race condition: the Java watcher was counting asynchronous `PersistentWatchRemoved` notifications from the ZK 3.8 client, causing a race between the EventThread and the main thread. Now only counts `NodeDataChanged` events.
- Fix `test_addwatch` (and all tests) IPv6 connection failure: `localhost` resolved to `[::1]` first in Docker, but Keeper wasn't reachable on IPv6. Use `cluster.get_instance_ip` instead, matching the pattern used by `test_paimon_rest_catalog`.

CI reports:
- https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=d67a6f693a4deabb3f90936c12c35cd5ced61bf3&name_0=MasterCI&name_1=Integration%20tests%20%28amd_binary%2C%203%2F5%29
- https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=4fe25262e1c78bd7b61df6ca18df0fd1586742b1&name_0=MasterCI&name_1=Integration%20tests%20%28amd_binary%2C%202%2F5%29

## Test plan
- [ ] All 5 `test_keeper_java_client` tests pass locally (`test_addwatch`, `test_check_watches`, `test_remove_watches`, `test_set_watches`, `test_set_watches2`)

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.379`
<!-- ch-version-info:end -->