### PR TITLE
Fix flaky test_hedged_requests::test_send_data under MSan

### DIFF
--- a/tests/integration/test_hedged_requests/test.py
+++ b/tests/integration/test_hedged_requests/test.py
@@ -288,7 +288,13 @@ def test_send_data(started_cluster):
     if NODES["node"].is_built_with_thread_sanitizer():
         pytest.skip("Hedged requests don't work under Thread Sanitizer")
 
-    update_configs(node_1_sleep_in_send_data=sleep_time)
+    # Add a small delay to node_3 to ensure node_2 always wins the race
+    # when node_1 is slow in send_data. Without this, under heavy load (e.g., MSan builds),
+    # node_3 can occasionally respond before node_2.
+    update_configs(
+        node_1_sleep_in_send_data=sleep_time,
+        node_3_sleep_in_send_tables_status=1000,
+    )
     check_query(expected_replica="node_2")
     check_changing_replica_events(1)
 


### PR DESCRIPTION
## Summary
- `test_send_data` in `test_hedged_requests` is flaky under MSan: it delays only `node_1` in `send_data` and expects `node_2` to respond first, but `node_2` and `node_3` both have zero delay, making it a race condition under heavy load.
- Added a small `sleep_in_send_tables_status=1000` delay to `node_3`, matching the pattern already used by `test_stuck_replica` and `test_send_table_status_sleep` in the same file.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=fda8ef3fcc10f549de90aa54112aaa7dd5053b87&name_0=MasterCI&name_1=Integration%20tests%20%28amd_msan%2C%202%2F6%29

## Test plan
- [x] Verified the same pattern is already used in other tests in the file
- [ ] CI should pass without the flaky failure

### Changelog category:
- CI Fix or Improvement

### Changelog entry:
Not for changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.399`
<!-- ch-version-info:end -->