### PR TITLE
Fix flaky test `02229_client_stop_multiquery_in_SIGINT`

### DIFF
--- a/tests/queries/0_stateless/02229_client_stop_multiquery_in_SIGINT.sh
+++ b/tests/queries/0_stateless/02229_client_stop_multiquery_in_SIGINT.sh
@@ -5,12 +5,12 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
-timeout --kill-after=10s -s INT 3s $CLICKHOUSE_CLIENT --max_block_size 1 -m -q "
+timeout --foreground --kill-after=30s -s INT 6s $CLICKHOUSE_CLIENT --max_block_size 1 -m -q "
     SELECT sleep(1) FROM numbers(100) FORMAT Null;
     SELECT 'FAIL';
 "
 
-timeout --kill-after=10s -s INT 3s $CLICKHOUSE_LOCAL --max_block_size 1 -m -q "
+timeout --foreground --kill-after=30s -s INT 6s $CLICKHOUSE_LOCAL --max_block_size 1 -m -q "
     SELECT sleep(1) FROM numbers(100) FORMAT Null;
     SELECT 'FAIL';
 "


### PR DESCRIPTION
## Summary

Under ASan on ARM with parallel tests, `clickhouse-client` is slow to handle SIGINT. When it doesn't exit within the `--kill-after` timeout, `timeout` sends SIGKILL to the entire process group (including itself), causing bash to print "Killed" to stderr, which fails the test.

- Add `--foreground` so `timeout` only signals the child process, not itself — even if SIGKILL is needed, `timeout` exits normally and bash prints no "Killed" message
- Increase timeouts (3s→6s for SIGINT, 10s→30s for `--kill-after`) to give more headroom under ASan on loaded machines

Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96171&sha=be5df3810ba6d1857129f822cdb3ef6e53a0e720&name_0=PR&name_1=Stateless%20tests%20%28arm_asan%2C%20azure%2C%20parallel%29
https://github.com/ClickHouse/ClickHouse/pull/96171

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)