### PR TITLE
Make contributor documentation easier to discover from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,9 +15,18 @@ If you're interested to do so, contact us at [legal@clickhouse.com](mailto:legal
 
 ## Technical Information
 
-See [ClickHouse - Lightning Fast Analytics for Everyone](https://www.vldb.org/pvldb/vol17/p3731-schulze.pdf) and [Architecture](https://clickhouse.com/docs/development/architecture/) for an overview of ClickHouse's internals.
+For an overview of ClickHouse internals, see:
+- [VLDB 2024 research paper (PDF): ClickHouse - Lightning Fast Analytics for Everyone](https://www.vldb.org/pvldb/vol17/p3731-schulze.pdf)
+- [Architecture Overview](https://clickhouse.com/docs/development/architecture/)
 
-[This](https://clickhouse.com/docs/development/developer-instruction) and [this](https://clickhouse.com/docs/development/build) document describe how to check out and compile the source code of ClickHouse.
+For an overview of the contributor-facing development documentation, start here: [Development and contributing](https://clickhouse.com/docs/development/)
+
+Common entry points:
+- [Developer prerequisites and setup](https://clickhouse.com/docs/development/developer-instruction)
+- [Build on Linux](https://clickhouse.com/docs/development/build)
+- [Build on macOS for macOS](https://clickhouse.com/docs/development/build-osx)
+- [Testing ClickHouse](https://clickhouse.com/docs/development/tests)
+- [C++ Style Guide](https://clickhouse.com/docs/development/style)
 
 If you want to contribute to documentation, please see the [documentation repository](https://github.com/ClickHouse/clickhouse-docs).
 


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
N/A (documentation-only change to CONTRIBUTING.md)

### Documentation entry for user-facing changes

- [x] Documentation is written (not applicable, no user-facing behavior changes)

This PR only updates CONTRIBUTING.md (contributor-facing guidance).
No changes are required for docs.clickhouse.com user documentation.

## Motivation

First of all, thank you to everyone who builds and maintains the ClickHouse development documentation. It is thorough and very helpful once you are in the right place.

When I started looking for build instructions via CONTRIBUTING.md, I followed the build link and initially landed on the Linux build page. Because the link text did not explicitly mention Linux, I expected it to describe how to build ClickHouse on all supported platforms, and I briefly wondered whether building was Linux-only.

After taking a second look, I noticed the "next page" navigation and the sidebar, where I found the macOS build instructions and additional contributor guidance like testing and the style guide. Those resources already exist and are well written, but they are easier to miss if you only follow the small set of direct links in CONTRIBUTING.md.

Additionally, the VLDB paper link text in CONTRIBUTING.md was not very explicit. At a quick glance, I assumed it might be a general ClickHouse website link and did not click it right away. Making it clear that it is a research paper PDF should set better expectations.

## What changed

- Updated the VLDB paper bullet to be explicit about what it is:
  - "VLDB 2024 research paper (PDF): ClickHouse - Lightning Fast Analytics for Everyone"
- Added a prominent link to the "Development and contributing" docs hub to make it easier to discover the full set of contributor-facing documentation from one place.
- Kept a small curated list of common entry points (setup, build on Linux, build on macOS, testing, style) to make CONTRIBUTING.md immediately useful and to highlight sections that new contributors may not find on their first pass.

## Why this approach

I opted for a combination of:
- A hub link for discoverability, so contributors can quickly see what documentation exists and jump to what they need.
- A short list of frequently needed pages for convenience, so common tasks remain one click away.

This keeps CONTRIBUTING.md helpful and easy to navigate without turning it into a long, high-maintenance index.

## Alternatives considered

1) Link only to https://clickhouse.com/docs/development/
- Pros: very low maintenance and always up to date.
- Cons: less direct for common tasks, and some readers may still miss important sections unless they browse.

2) Add every link from the docs overview or sidebar into CONTRIBUTING.md
- Pros: maximum visibility of all pages.
- Cons: harder to maintain and more likely to become outdated as pages evolve.

3) Keep the current set of links unchanged
- Pros: no churn.
- Cons: some contributor resources (for example macOS build, tests, style guide) may remain less visible to people who rely on CONTRIBUTING.md as their starting point.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.373`
<!-- ch-version-info:end -->