### PR TITLE
Fix flaky `04023_rollup_totals_memory_limit` in parallel replicas check

### DIFF
--- a/tests/queries/0_stateless/04023_rollup_totals_memory_limit.sql
+++ b/tests/queries/0_stateless/04023_rollup_totals_memory_limit.sql
@@ -1,3 +1,6 @@
+-- Tags: no-parallel-replicas
+-- With parallel replicas the memory usage is distributed across replicas,
+-- so the coordinator may not exceed the 10 MB limit and the test becomes flaky.
 -- https://github.com/ClickHouse/ClickHouse/issues/93465
 CREATE TABLE t0 (c0 Int, c1 Int128) ENGINE = MergeTree ORDER BY tuple();
 INSERT INTO t0 SELECT 1, number FROM numbers(40000);


### PR DESCRIPTION
With parallel replicas enabled, the query distributes work across replicas so the coordinator node may not exceed the 10 MB `max_memory_usage` limit, causing the expected `MEMORY_LIMIT_EXCEEDED` error to not be thrown.

Add `no-parallel-replicas` tag to skip this test in parallel replicas mode.

Flaky test history: [play.clickhouse.com query](https://play.clickhouse.com/play?user=play#CldJVEgKICAgICcwNDAyM19yb2xsdXBfdG90YWxzX21lbW9yeV9saW1pdCcgQVMgbmFtZV9zdWJzdHIsCiAgICA5MCBBUyBpbnRlcnZhbF9kYXlzLAogICAgKCdTdGF0ZWxlc3MgdGVzdHMgKGFzYW4pJywgJ1N0YXRlbGVzcyB0ZXN0cyAoYWRkcmVzcyknLCAnU3RhdGVsZXNzIHRlc3RzIChhZGRyZXNzLCBhY3Rpb25zKScpIEFTIGJhY2twb3J0X2FuZF9yZWxlYXNlX3NwZWNpZmljX2NoZWNrcwpTRUxFQ1QKICAgIGNoZWNrX3N0YXJ0X3RpbWUsIHB1bGxfcmVxdWVzdF9udW1iZXIsIGNoZWNrX25hbWUsIHJlcG9ydF91cmwKRlJPTSBjaGVja3MKV0hFUkUgKChub3coKSAtIHRvSW50ZXJ2YWxEYXkoaW50ZXJ2YWxfZGF5cykpIDw9IGNoZWNrX3N0YXJ0X3RpbWUpIEFORCAocHVsbF9yZXF1ZXN0X251bWJlciBOT1QgSU4gKAogICAgU0VMRUNUIHB1bGxfcmVxdWVzdF9udW1iZXIgQVMgcHJuCiAgICBGUk9NIGNoZWNrcwogICAgV0hFUkUgKHBybiAhPSAwKSBBTkQgKChub3coKSAtIHRvSW50ZXJ2YWxEYXkoaW50ZXJ2YWxfZGF5cykpIDw9IGNoZWNrX3N0YXJ0X3RpbWUpIEFORCAoY2hlY2tfbmFtZSBJTiAoYmFja3BvcnRfYW5kX3JlbGVhc2Vfc3BlY2lmaWNfY2hlY2tzKSkKKSkgQU5EIChwb3NpdGlvbih0ZXN0X25hbWUsIG5hbWVfc3Vic3RyKSA+IDApIEFORCAodGVzdF9zdGF0dXMgSU4gKCdGQUlMJywgJ0VSUk9SJywgJ0ZMQUtZJykpCk9SREVSIEJZIGNoZWNrX3N0YXJ0X3RpbWUgREVTQw==)

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)