### PR TITLE
CI: fix HEAD^1/HEAD^2 confusion and drop SHA-1 length assumption

### DIFF
--- a/ci/jobs/performance_tests.py
+++ b/ci/jobs/performance_tests.py
@@ -771,19 +771,6 @@ def main():
             )
         )
 
-    # dmesg -T > dmesg.log
-    #
-    # ls -lath
-    #
-    # 7z a '-x!*/tmp' /output/output.7z ./*.{log,tsv,html,txt,rep,svg,columns} \
-    #    {right,left}/{performance,scripts} {{right,left}/db,db0}/preprocessed_configs \
-    #    report analyze benchmark metrics \
-    #    ./*.core.dmp ./*.core
-
-    ## If the files aren't same, copy it
-    # cmp --silent compare.log /tmp/praktika/compare.log || \
-    #  cp compare.log /output
-
     files_to_attach = []
     if res:
         files_to_attach += logs_to_attach

--- a/ci/jobs/scripts/workflow_hooks/store_data.py
+++ b/ci/jobs/scripts/workflow_hooks/store_data.py
@@ -39,17 +39,17 @@ if __name__ == "__main__":
     # store integration test diff to find: TODO: find changed test cases
     if info.pr_number:
         # store master side commits for perf tests comparison
-        # In PR CI, HEAD is a merge commit; HEAD^2 is the master parent of that merge commit
+        # In PR CI, HEAD is a merge commit; HEAD^1 is the master parent (first parent)
         master_parent = Shell.get_output(
-            "git rev-parse HEAD^2", verbose=True
+            "git rev-parse HEAD^1", verbose=True
         ).strip()
-        if master_parent and len(master_parent) == 40:
+        if master_parent:
             master_parent_commits = [
                 s.strip()
                 for s in Shell.get_output(
                     f"git rev-list --first-parent --max-count=30 {master_parent}", verbose=True
                 ).splitlines()
-                if len(s.strip()) == 40
+                if s.strip()
             ]
             if master_parent_commits:
                 info.store_kv_data("master_track_commits_sha", master_parent_commits)
@@ -58,7 +58,7 @@ if __name__ == "__main__":
                 )
         else:
             print(
-                "WARNING: Could not find master parent commit (HEAD^2), skipping perf test commit storage"
+                "WARNING: Could not find master parent commit (HEAD^1), skipping perf test commit storage"
             )
 
         file_diff = {}


### PR DESCRIPTION
Addresses post-merge review comments on #98661 by @azat and @nickitat.

**@azat**: In a GitHub PR merge commit, `HEAD^1` is the master parent (first parent) and `HEAD^2` is the PR branch head (second parent). The previous code used `HEAD^2` by mistake, which would store commits from the PR branch instead of the master track — making the perf test reference selection always fall back to the latest master build.

**@nickitat**: Remove the `len(...) == 40` guards that assumed SHA-1 object format. `git rev-parse` returns a valid hash when it succeeds (empty on failure), and `git rev-list` only outputs hashes — so filtering by fixed length is unnecessary and would break with SHA-256.

### Changelog category (leave one category that best describes this PR)
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.384`
<!-- ch-version-info:end -->