### PR TITLE
Docs: document that dots in column names are reserved for Nested semantics

### DIFF
--- a/docs/en/sql-reference/data-types/nested-data-structures/index.md
+++ b/docs/en/sql-reference/data-types/nested-data-structures/index.md
@@ -13,8 +13,8 @@ doc_type: 'guide'
 
 A nested data structure is like a table inside a cell. The parameters of a nested data structure – the column names and types – are specified the same way as in a [CREATE TABLE](../../../sql-reference/statements/create/table.md) query. Each table row can correspond to any number of rows in a nested data structure.
 
-:::warning Dots in column names are reserved for `Nested` sub-column access
-The dot (`.`) character in column names is reserved for accessing sub-columns of `Nested` data structures. Columns whose names share a common dot-prefix (e.g., `foo.a` and `foo.b`) are treated as belonging to an implicit `Nested` structure when [`flatten_nested`](/operations/settings/settings#flatten_nested) is set to `1` (the default). This causes type coercion to `Array`, insert-time array-length validation across columns sharing the same prefix, and restrictions on renaming — even if `Nested` was not intended.
+:::warning[Dots in column names are reserved for `Nested` sub-column access]
+The dot (`.`) character in column names is reserved for accessing sub-columns of `Nested` data structures. Columns whose names share a common dot-prefix (e.g., `foo.a` and `foo.b`) are treated as belonging to an implicit `Nested` structure when [`flatten_nested`](/operations/settings/settings#flatten_nested) is set to `1` (the default). This causes type coercion to `Array`, insert-time array-length validation across columns sharing the same prefix, and restrictions on renaming, even if `Nested` was not intended.
 
 Avoid dots in column names unless you are intentionally using `Nested`. Use underscores (`_`) or another separator instead.
 :::

--- a/docs/en/sql-reference/data-types/nested-data-structures/index.md
+++ b/docs/en/sql-reference/data-types/nested-data-structures/index.md
@@ -13,6 +13,12 @@ doc_type: 'guide'
 
 A nested data structure is like a table inside a cell. The parameters of a nested data structure – the column names and types – are specified the same way as in a [CREATE TABLE](../../../sql-reference/statements/create/table.md) query. Each table row can correspond to any number of rows in a nested data structure.
 
+:::warning Dots in column names are reserved for `Nested` sub-column access
+The dot (`.`) character in column names is reserved for accessing sub-columns of `Nested` data structures. Columns whose names share a common dot-prefix (e.g., `foo.a` and `foo.b`) are treated as belonging to an implicit `Nested` structure when [`flatten_nested`](/operations/settings/settings#flatten_nested) is set to `1` (the default). This causes type coercion to `Array`, insert-time array-length validation across columns sharing the same prefix, and restrictions on renaming — even if `Nested` was not intended.
+
+Avoid dots in column names unless you are intentionally using `Nested`. Use underscores (`_`) or another separator instead.
+:::
+
 Example:
 
 ```sql

--- a/docs/en/sql-reference/data-types/nested-data-structures/index.md
+++ b/docs/en/sql-reference/data-types/nested-data-structures/index.md
@@ -13,10 +13,11 @@ doc_type: 'guide'
 
 A nested data structure is like a table inside a cell. The parameters of a nested data structure – the column names and types – are specified the same way as in a [CREATE TABLE](../../../sql-reference/statements/create/table.md) query. Each table row can correspond to any number of rows in a nested data structure.
 
-:::warning[Dots in column names are reserved for `Nested` sub-column access]
-The dot (`.`) character in column names is reserved for accessing sub-columns of `Nested` data structures. Columns whose names share a common dot-prefix (e.g., `foo.a` and `foo.b`) are treated as belonging to an implicit `Nested` structure when [`flatten_nested`](/operations/settings/settings#flatten_nested) is set to `1` (the default). This causes type coercion to `Array`, insert-time array-length validation across columns sharing the same prefix, and restrictions on renaming, even if `Nested` was not intended.
+:::tip[Avoid using dots in column names]
+Column names containing dots, columns sharing a common dot-prefix, and columns with the `Array` type can each be interpreted as part of a flattened Nested structure when `flatten_nested = 1` (the default). This can cause unexpected array-length validation on inserts and renaming restrictions.
 
-Avoid dots in column names unless you are intentionally using `Nested`. Use underscores (`_`) or another separator instead.
+Avoid using dots in column names if possible.
+Use underscores (`_`) or another separator instead of dots in column names unless you intentionally need `Nested` semantics.
 :::
 
 Example:

--- a/docs/en/sql-reference/statements/alter/column.md
+++ b/docs/en/sql-reference/statements/alter/column.md
@@ -337,6 +337,8 @@ SELECT groupArray(x), groupArray(s) FROM tmp;
 
 The `ALTER` query lets you create and delete separate elements (columns) in nested data structures, but not whole nested data structures. To add a nested data structure, you can add columns with a name like `name.nested_name` and the type `Array(T)`. A nested data structure is equivalent to multiple array columns with a name that has the same prefix before the dot.
 
+Renaming a column to or from a name containing a dot is not supported because dots are reserved for [`Nested`](/sql-reference/data-types/nested-data-structures/nested) sub-column access.
+
 There is no support for deleting columns in the primary key or the sampling key (columns that are used in the `ENGINE` expression). Changing the type for columns that are included in the primary key is only possible if this change does not cause the data to be modified (for example, you are allowed to add values to an Enum or to change a type from `DateTime` to `UInt32`).
 
 If the `ALTER` query is not sufficient to make the table changes you need, you can create a new table, copy the data to it using the [INSERT SELECT](/sql-reference/statements/insert-into.md/#inserting-the-results-of-select) query, then switch the tables using the [RENAME](/sql-reference/statements/rename.md/#rename-table) query and delete the old table.

--- a/docs/en/sql-reference/statements/alter/column.md
+++ b/docs/en/sql-reference/statements/alter/column.md
@@ -337,7 +337,7 @@ SELECT groupArray(x), groupArray(s) FROM tmp;
 
 The `ALTER` query lets you create and delete separate elements (columns) in nested data structures, but not whole nested data structures. To add a nested data structure, you can add columns with a name like `name.nested_name` and the type `Array(T)`. A nested data structure is equivalent to multiple array columns with a name that has the same prefix before the dot.
 
-Renaming a column to or from a name containing a dot is not supported because dots are reserved for [`Nested`](/sql-reference/data-types/nested-data-structures/nested) sub-column access.
+Renaming columns with dots in their names is partially supported. Dots are reserved for [Nested](/sql-reference/data-types/nested-data-structures/nested) sub-column access, so the prefix (parent name) must remain the same. Only the suffix (sub-column name) can be changed. For example, `a.b` can be renamed to `a.c`, but renaming `a.b` to `b.d` is not allowed because it changes the Nested parent prefix.
 
 There is no support for deleting columns in the primary key or the sampling key (columns that are used in the `ENGINE` expression). Changing the type for columns that are included in the primary key is only possible if this change does not cause the data to be modified (for example, you are allowed to add values to an Enum or to change a type from `DateTime` to `UInt32`).
 

--- a/docs/en/sql-reference/syntax.md
+++ b/docs/en/sql-reference/syntax.md
@@ -115,9 +115,10 @@ If you want to use identifiers the same as keywords or you want to use other sym
 The same rules that apply for escaping in quoted identifiers also apply for string literals. See [String](#string) for more details.
 :::
 
-:::warning[Dots in column names]
-The dot (`.`) character has special meaning in column names and is used internally to denote sub-columns of the [`Nested`](/sql-reference/data-types/nested-data-structures/nested) data type. Even when quoted (e.g., `` `my.column` ``), dots in column names can cause unexpected behavior: columns sharing a common dot-prefix (e.g., `foo.a` and `foo.b`) may be implicitly grouped into a `Nested` structure when [`flatten_nested`](/operations/settings/settings#flatten_nested) is enabled (the default), leading to type-cast errors on insert, array-length enforcement, and inability to rename such columns.
+:::tip[Avoid using dots in column names]
+Column names containing dots, columns sharing a common dot-prefix, and columns with the `Array` type can each be interpreted as part of a flattened Nested structure when `flatten_nested = 1` (the default). This can cause unexpected array-length validation on inserts and renaming restrictions. 
 
+Avoid using dots in column names if possible.
 Use underscores (`_`) or another separator instead of dots in column names unless you intentionally need `Nested` semantics.
 :::
 

--- a/docs/en/sql-reference/syntax.md
+++ b/docs/en/sql-reference/syntax.md
@@ -115,6 +115,12 @@ If you want to use identifiers the same as keywords or you want to use other sym
 The same rules that apply for escaping in quoted identifiers also apply for string literals. See [String](#string) for more details.
 :::
 
+:::warning Dots in column names
+The dot (`.`) character has special meaning in column names — it is used internally to denote sub-columns of the [`Nested`](/sql-reference/data-types/nested-data-structures/nested) data type. Even when quoted (e.g., `` `my.column` ``), dots in column names can cause unexpected behavior: columns sharing a common dot-prefix (e.g., `foo.a` and `foo.b`) may be implicitly grouped into a `Nested` structure when [`flatten_nested`](/operations/settings/settings#flatten_nested) is enabled (the default), leading to type-cast errors on insert, array-length enforcement, and inability to rename such columns.
+
+Use underscores (`_`) or another separator instead of dots in column names unless you intentionally need `Nested` semantics.
+:::
+
 ## Literals {#literals}
 
 In ClickHouse, a literal is a value which is directly represented in a query.

--- a/docs/en/sql-reference/syntax.md
+++ b/docs/en/sql-reference/syntax.md
@@ -115,8 +115,8 @@ If you want to use identifiers the same as keywords or you want to use other sym
 The same rules that apply for escaping in quoted identifiers also apply for string literals. See [String](#string) for more details.
 :::
 
-:::warning Dots in column names
-The dot (`.`) character has special meaning in column names — it is used internally to denote sub-columns of the [`Nested`](/sql-reference/data-types/nested-data-structures/nested) data type. Even when quoted (e.g., `` `my.column` ``), dots in column names can cause unexpected behavior: columns sharing a common dot-prefix (e.g., `foo.a` and `foo.b`) may be implicitly grouped into a `Nested` structure when [`flatten_nested`](/operations/settings/settings#flatten_nested) is enabled (the default), leading to type-cast errors on insert, array-length enforcement, and inability to rename such columns.
+:::warning[Dots in column names]
+The dot (`.`) character has special meaning in column names and is used internally to denote sub-columns of the [`Nested`](/sql-reference/data-types/nested-data-structures/nested) data type. Even when quoted (e.g., `` `my.column` ``), dots in column names can cause unexpected behavior: columns sharing a common dot-prefix (e.g., `foo.a` and `foo.b`) may be implicitly grouped into a `Nested` structure when [`flatten_nested`](/operations/settings/settings#flatten_nested) is enabled (the default), leading to type-cast errors on insert, array-length enforcement, and inability to rename such columns.
 
 Use underscores (`_`) or another separator instead of dots in column names unless you intentionally need `Nested` semantics.
 :::


### PR DESCRIPTION
## Summary
- Add `:::warning` admonition to the **Identifiers** section of `syntax.md` explaining that dots in column names are reserved for `Nested` sub-column access and can cause unexpected behavior even when quoted.
- Add `:::warning` admonition to the **Nested data type** docs explaining implicit `Nested` grouping when `flatten_nested = 1`.
- Add a note to the **ALTER COLUMN Limitations** section that renaming columns to/from dot-containing names is not supported.

Relates to #55452, #8193.
Closes https://github.com/ClickHouse/clickhouse-docs/issues/3028

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.407`
<!-- ch-version-info:end -->