### PR TITLE
CI: skip all jobs for release PRs in filter_job hook

### DIFF
--- a/ci/jobs/scripts/workflow_hooks/filter_job.py
+++ b/ci/jobs/scripts/workflow_hooks/filter_job.py
@@ -68,6 +68,12 @@ def should_skip_job(job_name):
         _info_cache = Info()
         print(f"INFO: PR labels: {_info_cache.pr_labels}")
 
+    if (
+        Labels.RELEASE in _info_cache.pr_labels
+        or Labels.RELEASE_LTS in _info_cache.pr_labels
+    ):
+        return True, "Skipped for release PR"
+
     changed_files = _info_cache.get_kv_data("changed_files")
     if not changed_files:
         print("WARNING: no changed files found for PR - do not filter jobs")

--- a/ci/jobs/scripts/workflow_hooks/filter_job.py
+++ b/ci/jobs/scripts/workflow_hooks/filter_job.py
@@ -68,6 +68,9 @@ def should_skip_job(job_name):
         _info_cache = Info()
         print(f"INFO: PR labels: {_info_cache.pr_labels}")
 
+    # There is no way to prevent GitHub Actions from running the PR workflow on
+    # release branches, so we skip all jobs here. The ReleaseCI workflow is used
+    # for testing on release branches instead.
     if (
         Labels.RELEASE in _info_cache.pr_labels
         or Labels.RELEASE_LTS in _info_cache.pr_labels


### PR DESCRIPTION
## Summary

There is no way to prevent GitHub Actions from running the PR workflow on release branches. As a result, the `ReleaseCI` workflow and the PR workflow both run on release PRs, wasting resources. Since the `ReleaseCI` workflow is the one used for testing on release branches, we skip all PR CI jobs when the PR is labeled `release` or `release-lts`.

Follow-up to https://github.com/ClickHouse/ClickHouse/pull/98246.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.383`
- Backported to: `26.2.4.16`, `26.1.5.9`, `25.12.9.15`, `25.8.19.6`
<!-- ch-version-info:end -->