### PR TITLE
Unflake test_cancel_backup.py::test_short_disconnection_doesnt_stop_backup

### DIFF
--- a/tests/integration/test_backup_restore_on_cluster/test_cancel_backup.py
+++ b/tests/integration/test_backup_restore_on_cluster/test_cancel_backup.py
@@ -666,6 +666,18 @@ def test_short_disconnection_doesnt_stop_backup():
             break
         time.sleep(1)
 
+    backup_process_counts = {
+        get_node_name(node): int(
+            node.query("SELECT count() FROM system.processes WHERE query_kind = 'Backup'")
+        )
+        for node in nodes
+    }
+    total_backup_processes = sum(backup_process_counts.values())
+    assert total_backup_processes == 0, (
+        "Backup queries still running after pre-test wait in "
+        "test_short_disconnection_doesnt_stop_backup: "
+        + ", ".join(f"{name}={count}" for name, count in backup_process_counts.items())
+    )
     create_and_fill_table(random_node())
 
     with NoTrashChecker() as no_trash_checker, ConfigManager() as config_manager:

--- a/tests/integration/test_backup_restore_on_cluster/test_cancel_backup.py
+++ b/tests/integration/test_backup_restore_on_cluster/test_cancel_backup.py
@@ -656,6 +656,16 @@ def test_long_disconnection_stops_backup():
 
 # A backup must NOT be stopped if Zookeeper is disconnected shorter than `failure_after_host_disconnected_for_seconds`.
 def test_short_disconnection_doesnt_stop_backup():
+    # Wait for any backup processes from the previous test to finish their ZooKeeper cleanup
+    # before creating the NoTrashChecker, so residual errors don't fall in its time window.
+    for _ in range(30):
+        if not any(
+            int(node.query("SELECT count() FROM system.processes WHERE query_kind = 'Backup'")) > 0
+            for node in nodes
+        ):
+            break
+        time.sleep(1)
+
     create_and_fill_table(random_node())
 
     with NoTrashChecker() as no_trash_checker, ConfigManager() as config_manager:
@@ -711,6 +721,16 @@ def test_short_disconnection_doesnt_stop_backup():
 
 # A restore must NOT be stopped if Zookeeper is disconnected shorter than `failure_after_host_disconnected_for_seconds`.
 def test_short_disconnection_doesnt_stop_restore():
+    # Wait for any backup processes from the previous test to finish their ZooKeeper cleanup
+    # before creating the NoTrashChecker, so residual errors don't fall in its time window.
+    for _ in range(30):
+        if not any(
+            int(node.query("SELECT count() FROM system.processes WHERE query_kind = 'Backup'")) > 0
+            for node in nodes
+        ):
+            break
+        time.sleep(1)
+
     # Make a backup.
     backup_id = get_backup_id_of_successful_backup()
 

--- a/tests/integration/test_backup_restore_on_cluster/test_cancel_backup.py
+++ b/tests/integration/test_backup_restore_on_cluster/test_cancel_backup.py
@@ -678,6 +678,7 @@ def test_short_disconnection_doesnt_stop_backup():
         "test_short_disconnection_doesnt_stop_backup: "
         + ", ".join(f"{name}={count}" for name, count in backup_process_counts.items())
     )
+
     create_and_fill_table(random_node())
 
     with NoTrashChecker() as no_trash_checker, ConfigManager() as config_manager:
@@ -742,6 +743,19 @@ def test_short_disconnection_doesnt_stop_restore():
         ):
             break
         time.sleep(1)
+
+    backup_process_counts = {
+        get_node_name(node): int(
+            node.query("SELECT count() FROM system.processes WHERE query_kind = 'Backup'")
+        )
+        for node in nodes
+    }
+    total_backup_processes = sum(backup_process_counts.values())
+    assert total_backup_processes == 0, (
+        "Backup queries still running after pre-test wait in "
+        "test_short_disconnection_doesnt_stop_backup: "
+        + ", ".join(f"{name}={count}" for name, count in backup_process_counts.items())
+    )
 
     # Make a backup.
     backup_id = get_backup_id_of_successful_backup()


### PR DESCRIPTION
Make sure the previous backup processes finish their Zookeeper cleanup, so the `FAILED_TO_SYNC_BACKUP_OR_RESTORE` error won't be thrown where it is not expected.  

Closes https://github.com/ClickHouse/ClickHouse/issues/98611

### Changelog category (leave one):

- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.398`
<!-- ch-version-info:end -->