### PR TITLE
Document --select/--search interaction in analyze-assembly.py

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -87,6 +87,8 @@ python3 .claude/tools/analyze-assembly.py <binary> "<function_name>" -v
 
 Key options: `--search` for regex matching, `--fuzzy` for substring matching, `--select N` to pick from ambiguous results, `--all` to analyze all matches, `--context N` to show surrounding symbols, `--max-instructions N` to control output size, `--mca --mcpu=<model>` for llvm-mca throughput analysis, `--perf-map <file>` for runtime-weighted scoring, `--before`/`--after` for diff mode. The tool caches symbol tables by build-id for fast repeated queries.
 
+**IMPORTANT**: `--select N` does NOT imply `--search`. When using a regex pattern with `--select`, you MUST also pass `--search`, e.g. `--search --select 1`. Without `--search`, the pattern is treated as a literal exact match and will fail.
+
 You can build multiple versions of ClickHouse inside `build_*` directories, such as `build`, `build_debug`, `build_asan`, etc.
 
 You can run integration tests as in `tests/integration/README.md` using: `python -m ci.praktika run "integration" --test <selectors>` invoked from the repository root.


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

---

## Summary
- Add a note to `.claude/CLAUDE.md` clarifying that `--select N` does not imply `--search` in `analyze-assembly.py`
- Without `--search`, regex patterns are treated as literal exact matches and silently fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.412`
<!-- ch-version-info:end -->