### PR TITLE
Fix dead quick-start docs link

### DIFF
--- a/docs/en/development/build-osx.md
+++ b/docs/en/development/build-osx.md
@@ -11,7 +11,7 @@ doc_type: 'guide'
 # How to Build ClickHouse on macOS for macOS
 
 :::info You don't need to build ClickHouse yourself!
-You can install pre-built ClickHouse as described in [Quick Start](https://clickhouse.com/#quick-start).
+You can install pre-built ClickHouse as described in [Quick Start](https://clickhouse.com/docs/get-started/quick-start).
 :::
 
 ClickHouse can be compiled on macOS x86_64 (Intel) and arm64 (Apple Silicon) using on macOS 10.15 (Catalina) or higher.

--- a/docs/en/development/build.md
+++ b/docs/en/development/build.md
@@ -10,7 +10,7 @@ doc_type: 'guide'
 # How to Build ClickHouse on Linux
 
 :::info You don't have to build ClickHouse yourself!
-You can install pre-built ClickHouse as described in [Quick Start](https://clickhouse.com/#quick-start).
+You can install pre-built ClickHouse as described in [Quick Start](https://clickhouse.com/docs/get-started/quick-start).
 :::
 
 ClickHouse can be build on the following platforms:


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not required.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

Fixes broken Quick Start links in development docs by replacing `https://clickhouse.com/#quick-start` with `https://clickhouse.com/docs/get-started/quick-start`.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.410`
<!-- ch-version-info:end -->