### PR TITLE
Fix detecting set skip index usefulness with OR with false (i.e. or(x, 0)) predicate

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexSet.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexSet.cpp
@@ -730,6 +730,14 @@ bool MergeTreeIndexConditionSet::checkDAGUseless(const ActionsDAG::Node & node, 
             bool all_useless = true;
             for (const auto & arg : arguments)
             {
+                /// For OR, skip constant false children — they are identity elements
+                /// of OR and don't affect filtering. Without this, the constant
+                /// check above returns false (not useless) for `getBool(0) == 0`,
+                /// which would incorrectly make the entire OR appear non-useless
+                /// even when no indexed columns are referenced.
+                if (function_name == "or" && arg->column && isColumnConst(*arg->column) && !arg->column->getBool(0))
+                    continue;
+
                 bool u = checkDAGUseless(*arg, context, sets_to_prepare, atomic);
                 all_useless = all_useless && u;
             }
@@ -740,7 +748,7 @@ bool MergeTreeIndexConditionSet::checkDAGUseless(const ActionsDAG::Node & node, 
         return std::any_of(
             arguments.begin(),
             arguments.end(),
-            [&](const auto & arg) { return checkDAGUseless(*arg, context, sets_to_prepare, true /*atomic*/); });
+            [&](const auto & arg) { return checkDAGUseless(*arg, context, sets_to_prepare, /*atomic=*/ true); });
     }
 
     auto column_name = tree_node.getColumnName();

--- a/tests/queries/0_stateless/04027_set_index_or_non_indexed_column.reference
+++ b/tests/queries/0_stateless/04027_set_index_or_non_indexed_column.reference
@@ -1,0 +1,12 @@
+-- { echoOn }
+
+-- Predicate with or(non_indexed, 0): set index should NOT be used.
+SELECT count() FROM t_set_index_or WHERE or(a = 5, 0);
+1
+SELECT count() FROM t_set_index_or WHERE or(a = 5, 0) SETTINGS force_data_skipping_indices='idx_b'; -- { serverError INDEX_NOT_USED }
+-- Predicate on indexed column: set index should be used.
+SELECT count() FROM t_set_index_or WHERE b = 5 SETTINGS force_data_skipping_indices='idx_b';
+100
+-- Indexed column inside or(..., 0): set index should still be used.
+SELECT count() FROM t_set_index_or WHERE or(b = 5, 0) SETTINGS force_data_skipping_indices='idx_b';
+100

--- a/tests/queries/0_stateless/04027_set_index_or_non_indexed_column.sql
+++ b/tests/queries/0_stateless/04027_set_index_or_non_indexed_column.sql
@@ -1,0 +1,38 @@
+-- Tags: no-random-merge-tree-settings
+
+-- Test that set index is not incorrectly used when the predicate doesn't
+-- reference any indexed columns but contains `or(..., 0)`.
+-- The analyzer may produce such expressions when rewriting OR of equalities
+-- on LowCardinality columns: `lc = 'a' OR lc = 'b'` → `or(in(lc, Set), 0)`.
+-- The constant `0` (identity element of OR) was incorrectly making
+-- `checkDAGUseless` return false.
+
+DROP TABLE IF EXISTS t_set_index_or;
+
+CREATE TABLE t_set_index_or
+(
+    a UInt64,
+    b UInt64,
+    INDEX idx_b (b) TYPE set(100) GRANULARITY 1
+)
+ENGINE = MergeTree
+ORDER BY a
+SETTINGS index_granularity = 100, index_granularity_bytes = '10Mi', add_minmax_index_for_numeric_columns = 0;
+
+INSERT INTO t_set_index_or SELECT number, number / 100 FROM numbers(10000);
+
+-- { echoOn }
+
+-- Predicate with or(non_indexed, 0): set index should NOT be used.
+SELECT count() FROM t_set_index_or WHERE or(a = 5, 0);
+SELECT count() FROM t_set_index_or WHERE or(a = 5, 0) SETTINGS force_data_skipping_indices='idx_b'; -- { serverError INDEX_NOT_USED }
+
+-- Predicate on indexed column: set index should be used.
+SELECT count() FROM t_set_index_or WHERE b = 5 SETTINGS force_data_skipping_indices='idx_b';
+
+-- Indexed column inside or(..., 0): set index should still be used.
+SELECT count() FROM t_set_index_or WHERE or(b = 5, 0) SETTINGS force_data_skipping_indices='idx_b';
+
+-- { echoOff }
+
+DROP TABLE t_set_index_or;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix detecting set skip index usefulness with OR with false (i.e. or(x, 0)) predicate

Fixes: https://github.com/ClickHouse/ClickHouse/pull/87781

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes set skipping-index applicability logic for OR predicates, which can alter query plans and index selection. Risk is limited to optimization behavior but could affect performance or `force_data_skipping_indices` expectations.
> 
> **Overview**
> Fixes `MergeTreeIndexConditionSet::checkDAGUseless` to treat constant-false children in `or(...)` as identity elements, preventing `or(non_indexed_predicate, 0)` from incorrectly making the set index look usable.
> 
> Adds a stateless regression test covering `or(a = 5, 0)` (index must *not* be used) and `or(b = 5, 0)` (index must still be used) when forcing `idx_b`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e854004294a66ee32645ac1e423cf732d3a66742. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.425`
- Backported to: `26.2.4.24`, `26.1.5.11`, `25.12.9.18`
<!-- ch-version-info:end -->