### PR TITLE
Allow configuring syslog program name for ClickHouse logs

### DIFF
--- a/docs/reference/settings/server-settings/_server_settings_outside_source.mdx
+++ b/docs/reference/settings/server-settings/_server_settings_outside_source.mdx
@@ -844,6 +844,7 @@ To write log messages additionally to syslog:
 <logger>
     <use_syslog>1</use_syslog>
     <syslog>
+        <programname>clickhouse-production-scc</programname>
         <address>syslog.remote:10514</address>
         <hostname>myhost.local</hostname>
         <facility>LOG_LOCAL6</facility>
@@ -859,7 +860,17 @@ Keys for `<syslog>`:
 | `address`  | The address of syslog in format `host\[:port\]`. If omitted, the local daemon is used.                                                                                                                                                                         |
 | `hostname` | The name of the host from which logs are send (optional).                                                                                                                                                                                                      |
 | `facility` | The syslog [facility keyword](https://en.wikipedia.org/wiki/Syslog#Facility). Must be specified uppercase with a "LOG_" prefix, e.g. `LOG_USER`, `LOG_DAEMON`, `LOG_LOCAL3`, etc. Default: `LOG_USER` if `address` is specified, `LOG_DAEMON` otherwise.                                           |
-| `format`   | Log message format. Possible values: `bsd` and `syslog.`                                                                                                                                                                                                       |
+| `format`   | Log message format. Possible values: `bsd` and `syslog`                                                                                                                                                                                                       |
+| `programname` | Program name used to identify ClickHouse in syslog messages. For remote syslog with `format=syslog` (RFC 5424), this is sent as `APP-NAME`. With `format=bsd` (RFC 3164), `programname` has no effect. Must be 1 to 48 printable ASCII characters without spaces, as required for RFC 5424 `APP-NAME`; other values are rejected at startup. Default: name of the ClickHouse command you started, for example `clickhouse-server` or `clickhouse-keeper`. |
+| `options`  | Options for local syslog (`logger.syslog.address` not set), passed as a `\|`-separated list (for example, `LOG_CONS\|LOG_PID`). Default: `LOG_CONS\|LOG_PID`. |
+
+**Default program name**
+
+Before `programname` was introduced, ClickHouse did not set a program name on the remote syslog channel at all, so RFC 5424 records were sent with `-` as `APP-NAME`. They now carry the default described above, for example `clickhouse-server`. If the command name is not itself a valid `APP-NAME` (for example because the binary was renamed to something longer than 48 characters), remote syslog keeps sending `-` rather than a malformed header, and you need to set `programname` explicitly to get a name.
+
+The default for local syslog also became more specific, but only for the multi-purpose binary: started as `clickhouse server` or `clickhouse keeper` it previously used the ident `clickhouse`, and now uses `clickhouse-server` or `clickhouse-keeper` respectively. Every other executable keeps the ident it used before, including dedicated binaries and symlinks such as `clickhouse-server`, and renamed binaries such as `ch-prod`. Note that the ident drops any file extension, so a binary named `clickhouse.prod` reports `clickhouse` both before and after this change.
+
+Set `programname` explicitly if you rely on the previous values in syslog filters or routing rules.
 
 **Log formats**
 

--- a/programs/keeper/Keeper.h
+++ b/programs/keeper/Keeper.h
@@ -67,6 +67,8 @@ protected:
 
     bool allowTextLog() const override;
 
+    std::string getCommandName() const override { return disambiguateCommandName("clickhouse-keeper"); }
+
 private:
     Poco::Net::SocketAddress socketBindListen(Poco::Net::ServerSocket & socket, const std::string & host, UInt16 port, [[maybe_unused]] bool secure = false) const;
 

--- a/programs/server/Server.h
+++ b/programs/server/Server.h
@@ -71,6 +71,8 @@ protected:
 
     std::string getDefaultCorePath() const override;
 
+    std::string getCommandName() const override { return disambiguateCommandName("clickhouse-server"); }
+
 private:
     ContextMutablePtr global_context;
     /// Updated/recent config, to compare http_handlers

--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -52,6 +52,11 @@
 
         <!-- <use_syslog>0</use_syslog> -->
         <!-- <syslog_level>trace</syslog_level> -->
+        <!--
+        <syslog>
+            <programname>clickhouse-production-scc</programname>
+        </syslog>
+        -->
 
         <!-- <stream_compress>0</stream_compress> -->
 

--- a/src/Daemon/BaseDaemon.cpp
+++ b/src/Daemon/BaseDaemon.cpp
@@ -128,6 +128,13 @@ void BaseDaemon::loadConfiguration()
 }
 
 
+std::string disambiguateClickHouseCommandName(
+    const std::string & executable_file_name, const std::string & command_name, const std::string & subcommand_name)
+{
+    return executable_file_name == "clickhouse" ? subcommand_name : command_name;
+}
+
+
 BaseDaemon::BaseDaemon()
     : original_working_directory(fs::current_path())
 {
@@ -401,7 +408,7 @@ void BaseDaemon::initialize(Application & self)
     }
 
     /// sensitive data masking rules are not used here
-    buildLoggers(config(), logger(), self.commandName());
+    buildLoggers(config(), logger(), getCommandName());
 
     /// After initialized loggers but before initialized signal handling.
     if (should_setup_watchdog)

--- a/src/Daemon/BaseDaemon.h
+++ b/src/Daemon/BaseDaemon.h
@@ -25,6 +25,25 @@
 class SignalListener;
 
 
+/// Chooses the name a ClickHouse daemon reports as its syslog program name.
+///
+/// `programs/main.cpp` erases the subcommand argument, so `clickhouse server` and `clickhouse keeper` both report
+/// the same command name and would otherwise share one syslog identifier. `subcommand_name` is substituted only
+/// in that genuinely ambiguous case; anything else keeps `command_name`, which is exactly what it reported before
+/// this behavior existed.
+///
+/// The ambiguity is decided from `executable_file_name` (Poco's `application.name`, the full file name of the
+/// executable) rather than from `command_name` (`commandName()`, i.e. `application.baseName`). Those differ:
+/// `Poco::Path::getBaseName` strips everything after the last dot, so a binary named `clickhouse.prod` reports
+/// `command_name == "clickhouse"` while not being the multi-purpose binary at all. Deciding on the base name
+/// would silently rewrite such a deployment's identifier.
+///
+/// This is a free function so that the mapping can be unit-tested without constructing a daemon, which would
+/// create the `Poco::Util::Application` singleton and install process-wide signal handlers.
+std::string disambiguateClickHouseCommandName(
+    const std::string & executable_file_name, const std::string & command_name, const std::string & subcommand_name);
+
+
 /// \brief Base class for applications that can run as daemons.
 ///
 /// \code
@@ -146,6 +165,17 @@ protected:
     virtual std::string getDefaultCorePath() const;
 
     virtual std::string getDefaultConfigFileName() const;
+
+    /// Name of the ClickHouse command implemented by this daemon. Used as the default syslog program name.
+    virtual std::string getCommandName() const { return commandName(); }
+
+    /// See `disambiguateClickHouseCommandName` above for why the subcommand name is not used unconditionally,
+    /// and why the decision is made on `application.name` rather than on `commandName()`.
+    std::string disambiguateCommandName(const std::string & subcommand_name) const
+    {
+        return disambiguateClickHouseCommandName(
+            config().getString("application.name", commandName()), commandName(), subcommand_name);
+    }
 
     std::optional<DB::StatusFile> pid_file;
 

--- a/src/Daemon/tests/gtest_daemon_command_name.cpp
+++ b/src/Daemon/tests/gtest_daemon_command_name.cpp
@@ -1,0 +1,66 @@
+#include <Daemon/BaseDaemon.h>
+
+#include <gtest/gtest.h>
+
+/// `BaseDaemon::initialize` passes the result of the virtual `getCommandName()` to `buildLoggers`, which is where
+/// the default syslog program name comes from. `Server` and `Keeper` override it as
+/// `disambiguateCommandName("clickhouse-server" / "clickhouse-keeper")`, which delegates to the function tested
+/// here.
+///
+/// The two name arguments are different things and the distinction is the point of most of these cases:
+/// `application.name` is the full file name of the executable, while `commandName()` is `application.baseName`,
+/// which `Poco::Path::getBaseName` truncates at the last dot.
+///
+/// The mapping is tested through the free function rather than through a daemon instance on purpose: constructing
+/// any `Poco::Util::Application` asserts that it is the only instance in the process and installs process-wide
+/// signal handlers, neither of which is acceptable inside the shared unit test binary.
+
+TEST(BaseDaemonCommandName, MultiPurposeBinaryGetsSubcommandName)
+{
+    /// `programs/main.cpp` erases the subcommand argument, so `clickhouse server` and `clickhouse keeper` both
+    /// report "clickhouse" and would otherwise share a single syslog identifier.
+    EXPECT_EQ(disambiguateClickHouseCommandName("clickhouse", "clickhouse", "clickhouse-server"), "clickhouse-server");
+    EXPECT_EQ(disambiguateClickHouseCommandName("clickhouse", "clickhouse", "clickhouse-keeper"), "clickhouse-keeper");
+}
+
+TEST(BaseDaemonCommandName, DedicatedBinaryOrSymlinkKeepsItsOwnName)
+{
+    /// These already report an unambiguous name, so nothing is substituted.
+    EXPECT_EQ(
+        disambiguateClickHouseCommandName("clickhouse-server", "clickhouse-server", "clickhouse-server"),
+        "clickhouse-server");
+    EXPECT_EQ(
+        disambiguateClickHouseCommandName("clickhouse-keeper", "clickhouse-keeper", "clickhouse-keeper"),
+        "clickhouse-keeper");
+}
+
+TEST(BaseDaemonCommandName, RenamedBinaryKeepsTheNameItReportedBefore)
+{
+    /// Regression guard for the review finding on `Server.h`: substituting the subcommand name unconditionally
+    /// would silently change the syslog identifier of deployments that run a renamed binary.
+    EXPECT_EQ(disambiguateClickHouseCommandName("ch-prod", "ch-prod", "clickhouse-server"), "ch-prod");
+    EXPECT_EQ(
+        disambiguateClickHouseCommandName("clickhouse-server-v2", "clickhouse-server-v2", "clickhouse-server"),
+        "clickhouse-server-v2");
+    EXPECT_EQ(disambiguateClickHouseCommandName("ch-keeper", "ch-keeper", "clickhouse-keeper"), "ch-keeper");
+}
+
+TEST(BaseDaemonCommandName, DottedBinaryNameIsNotTreatedAsTheMultiPurposeBinary)
+{
+    /// Regression guard for the review finding on `BaseDaemon.cpp`. `Poco::Path::getBaseName` strips everything
+    /// after the last dot, so `clickhouse.prod` arrives as `commandName() == "clickhouse"` despite not being the
+    /// multi-purpose binary. Deciding on the base name would rewrite this deployment's identifier; deciding on the
+    /// full file name keeps the `clickhouse` it reported before this change.
+    EXPECT_EQ(disambiguateClickHouseCommandName("clickhouse.prod", "clickhouse", "clickhouse-server"), "clickhouse");
+    EXPECT_EQ(disambiguateClickHouseCommandName("clickhouse.prod", "clickhouse", "clickhouse-keeper"), "clickhouse");
+    EXPECT_EQ(disambiguateClickHouseCommandName("clickhouse.test.1", "clickhouse.test", "clickhouse-server"), "clickhouse.test");
+}
+
+TEST(BaseDaemonCommandName, SubstitutionIsExactMatchOnly)
+{
+    /// Only the exact multi-purpose binary name is ambiguous. A name that merely starts with "clickhouse" is a
+    /// distinct binary and must be preserved.
+    EXPECT_EQ(disambiguateClickHouseCommandName("clickhouse2", "clickhouse2", "clickhouse-server"), "clickhouse2");
+    EXPECT_EQ(disambiguateClickHouseCommandName("Clickhouse", "Clickhouse", "clickhouse-server"), "Clickhouse");
+    EXPECT_EQ(disambiguateClickHouseCommandName("clickhouse ", "clickhouse ", "clickhouse-server"), "clickhouse ");
+}

--- a/src/Loggers/Loggers.cpp
+++ b/src/Loggers/Loggers.cpp
@@ -68,6 +68,43 @@ static std::string renderFileNameTemplate(time_t now, const std::string & file_p
     return path.replace_filename(ss.str());
 }
 
+/// RFC 5424 defines APP-NAME as 1-48 printable ASCII characters (%d33-126), which excludes space.
+/// `Poco::Net::RemoteSyslogChannel` writes the name verbatim into the message header, so a value containing
+/// whitespace would shift every following header field and produce a malformed record.
+static constexpr size_t max_syslog_program_name_length = 48;
+
+static bool isValidSyslogProgramName(const std::string & program_name)
+{
+    if (program_name.empty() || program_name.size() > max_syslog_program_name_length)
+        return false;
+
+    for (const char c : program_name)
+    {
+        if (c < '!' || c > '~')
+            return false;
+    }
+
+    return true;
+}
+
+/// Reject an explicitly configured name early instead of silently emitting broken syslog messages.
+static void validateSyslogProgramName(const std::string & program_name)
+{
+    if (program_name.empty() || program_name.size() > max_syslog_program_name_length)
+        throw DB::Exception(
+            DB::ErrorCodes::BAD_ARGUMENTS,
+            "logger.syslog.programname must be between 1 and {} characters long (RFC 5424 APP-NAME), got {}",
+            max_syslog_program_name_length,
+            program_name.size());
+
+    if (!isValidSyslogProgramName(program_name))
+        throw DB::Exception(
+            DB::ErrorCodes::BAD_ARGUMENTS,
+            "logger.syslog.programname must contain only printable ASCII characters and no whitespace "
+            "(RFC 5424 APP-NAME), got '{}'",
+            program_name);
+}
+
 Poco::AutoPtr<OwnPatternFormatter> getFormatForChannel(Poco::Util::AbstractConfiguration & config, const std::string & channel, bool color)
 {
     Poco::Util::AbstractConfiguration::Keys keys;
@@ -205,6 +242,15 @@ void Loggers::buildLoggers(Poco::Util::AbstractConfiguration & config, Poco::Log
         auto syslog_level = Poco::Logger::parseLevel(config.getString("logger.syslog_level", log_level_string));
         max_log_level = std::max(syslog_level, max_log_level);
 
+        /// Only an explicitly configured name is validated: the `cmd_name` fallback comes from the binary name
+        /// and has always been passed to local syslog as-is, so rejecting it could break existing setups.
+        std::string syslog_program_name = cmd_name;
+        if (config.has("logger.syslog.programname"))
+        {
+            syslog_program_name = config.getString("logger.syslog.programname");
+            validateSyslogProgramName(syslog_program_name);
+        }
+
         if (config.has("logger.syslog.address"))
         {
             syslog_channel = new Poco::Net::RemoteSyslogChannel();
@@ -214,6 +260,13 @@ void Loggers::buildLoggers(Poco::Util::AbstractConfiguration & config, Poco::Log
             {
                 syslog_channel->setProperty(Poco::Net::RemoteSyslogChannel::PROP_HOST, config.getString("logger.syslog.hostname"));
             }
+            /// This path never set the name before, so `Poco` kept its `-` default for RFC 5424 `APP-NAME`.
+            /// Only take that default over when the value is a valid `APP-NAME`. An explicitly configured value
+            /// is already guaranteed valid by `validateSyslogProgramName` above, so this only guards the
+            /// `cmd_name` fallback: an unusual binary name must not start producing malformed headers for a
+            /// deployment that never configured this setting.
+            if (isValidSyslogProgramName(syslog_program_name))
+                syslog_channel->setProperty(Poco::Net::RemoteSyslogChannel::PROP_NAME, syslog_program_name);
             syslog_channel->setProperty(Poco::Net::RemoteSyslogChannel::PROP_FORMAT, config.getString("logger.syslog.format", "syslog"));
             syslog_channel->setProperty(
                 Poco::Net::RemoteSyslogChannel::PROP_FACILITY, config.getString("logger.syslog.facility", "LOG_USER"));
@@ -221,7 +274,7 @@ void Loggers::buildLoggers(Poco::Util::AbstractConfiguration & config, Poco::Log
         else
         {
             syslog_channel = new Poco::SyslogChannel();
-            syslog_channel->setProperty(Poco::SyslogChannel::PROP_NAME, cmd_name);
+            syslog_channel->setProperty(Poco::SyslogChannel::PROP_NAME, syslog_program_name);
             syslog_channel->setProperty(Poco::SyslogChannel::PROP_OPTIONS, config.getString("logger.syslog.options", "LOG_CONS|LOG_PID"));
             syslog_channel->setProperty(Poco::SyslogChannel::PROP_FACILITY, config.getString("logger.syslog.facility", "LOG_DAEMON"));
         }

--- a/src/Loggers/tests/gtest_loggers_syslog.cpp
+++ b/src/Loggers/tests/gtest_loggers_syslog.cpp
@@ -1,0 +1,268 @@
+#include <Loggers/Loggers.h>
+#include <Loggers/OwnSplitChannel.h>
+
+#include <Common/Exception.h>
+#include <base/scope_guard.h>
+
+#include <gtest/gtest.h>
+
+#include <Poco/Exception.h>
+#include <Poco/Logger.h>
+#include <Poco/Net/DatagramSocket.h>
+#include <Poco/Net/SocketAddress.h>
+#include <Poco/NullChannel.h>
+#include <Poco/Timespan.h>
+#include <Poco/Util/MapConfiguration.h>
+
+#include <array>
+#include <atomic>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace
+{
+
+std::string nextTestLoggerName()
+{
+    static std::atomic<size_t> counter{0};
+    return "SyslogProgramNameTest_" + std::to_string(counter.fetch_add(1, std::memory_order_relaxed));
+}
+
+class LoggerStateGuard
+{
+public:
+    LoggerStateGuard()
+    {
+        auto & root = Poco::Logger::root();
+        root_level = root.getLevel();
+        /// `getChannel()` returns a borrowed pointer, and `AutoPtr(C *)` adopts a reference without adding one.
+        /// Take a shared reference instead, otherwise the guard releases a reference it never acquired and the
+        /// channel can be destroyed while it is still attached to the root logger.
+        root_channel.assign(root.getChannel(), /*shared=*/true);
+
+        std::vector<std::string> names;
+        Poco::Logger::names(names);
+        logger_states.reserve(names.size());
+        for (const auto & name : names)
+        {
+            auto * logger = Poco::Logger::has(name);
+            if (!logger)
+                continue;
+
+            LoggerState state;
+            state.name = name;
+            state.level = logger->getLevel();
+            /// Hold a shared reference for the same reason as the root channel above, and so that the channel
+            /// survives `buildLoggers` reassigning it below.
+            state.channel.assign(logger->getChannel(), /*shared=*/true);
+            logger_states.push_back(std::move(state));
+        }
+    }
+
+    ~LoggerStateGuard()
+    {
+        auto & root = Poco::Logger::root();
+        root.setChannel(root_channel.get());
+        root.setLevel(root_level);
+
+        /// Not `const auto &`: `Poco::AutoPtr::get() const` yields a `const Channel *`, which `setChannel` does
+        /// not accept.
+        for (auto & state : logger_states)
+        {
+            auto * logger = Poco::Logger::has(state.name);
+            if (!logger)
+                continue;
+
+            /// `buildLoggers` repoints every already-created logger at a channel owned by the `Loggers`
+            /// instance under test, which dies with the test body. Restore the exact channel each logger had
+            /// instead of the root channel: the root channel is null in a fresh process, so falling back to it
+            /// would silently mute loggers created by earlier tests in the same binary.
+            logger->setChannel(state.channel.get());
+            logger->setLevel(state.level);
+        }
+    }
+
+private:
+    struct LoggerState
+    {
+        std::string name;
+        int level = 0;
+        Poco::AutoPtr<Poco::Channel> channel;
+    };
+
+    int root_level = 0;
+    Poco::AutoPtr<Poco::Channel> root_channel;
+    std::vector<LoggerState> logger_states;
+};
+
+std::string receiveDatagram(Poco::Net::DatagramSocket & socket)
+{
+    std::array<char, 4096> buffer{};
+    Poco::Net::SocketAddress sender;
+
+    try
+    {
+        int received = socket.receiveFrom(buffer.data(), static_cast<int>(buffer.size()), sender);
+        if (received > 0)
+            return std::string(buffer.data(), static_cast<size_t>(received));
+    }
+    catch (const Poco::TimeoutException &) /// NOLINT(bugprone-empty-catch)
+    {
+        /// No packet arrived within the timeout, the caller handles the empty result.
+    }
+
+    return {};
+}
+
+std::string extractRFC5424AppName(const std::string & packet)
+{
+    std::istringstream stream(packet); // STYLE_CHECK_ALLOW_STD_STRING_STREAM
+    std::string token;
+
+    /// RFC5424: "<PRI>VERSION TIMESTAMP HOSTNAME APP-NAME PROCID MSGID ..."
+    for (size_t i = 0; i < 3; ++i)
+    {
+        if (!(stream >> token))
+            return {};
+    }
+
+    if (!(stream >> token))
+        return {};
+
+    return token;
+}
+
+std::string sendAndReceiveRemoteSyslogPacket(
+    const std::string & cmd_name,
+    const std::optional<std::string> & program_name,
+    const std::string & format)
+{
+    LoggerStateGuard logger_state_guard;
+    Loggers loggers;
+
+    Poco::Net::DatagramSocket receiver(Poco::Net::SocketAddress("127.0.0.1", 0));
+    receiver.setReceiveTimeout(Poco::Timespan(2, 0));
+
+    auto config = Poco::AutoPtr<Poco::Util::MapConfiguration>(new Poco::Util::MapConfiguration);
+    config->setString("logger", nextTestLoggerName());
+    config->setString("logger.async", "false");
+    config->setString("logger.level", "trace");
+    config->setString("logger.use_syslog", "true");
+    config->setString("logger.syslog_level", "trace");
+    config->setString("logger.syslog.address", "127.0.0.1:" + std::to_string(receiver.address().port()));
+    config->setString("logger.syslog.format", format);
+
+    if (program_name)
+        config->setString("logger.syslog.programname", *program_name);
+
+    /// `Poco::Logger` and `setChannel` both add their own reference, so the channel is held by an `AutoPtr`
+    /// here rather than handing over a raw `new` expression, which would leak a reference.
+    Poco::AutoPtr<Poco::Channel> null_channel(new Poco::NullChannel);
+    Poco::Logger & logger = Poco::Logger::create(nextTestLoggerName(), null_channel.get(), Poco::Message::PRIO_TRACE);
+    SCOPE_EXIT({
+        /// Avoid leaving a channel owned by `loggers` attached to this dedicated logger, on the throwing path too.
+        logger.setChannel(null_channel.get());
+    });
+
+    loggers.buildLoggers(*config, logger, cmd_name);
+    logger.information("syslog programname test message");
+
+    return receiveDatagram(receiver);
+}
+
+/// Builds loggers with the given `programname`, without sending anything, so that configuration
+/// validation can be exercised on its own.
+void buildLoggersWithProgramName(const std::string & program_name, bool remote)
+{
+    LoggerStateGuard logger_state_guard;
+    Loggers loggers;
+
+    auto config = Poco::AutoPtr<Poco::Util::MapConfiguration>(new Poco::Util::MapConfiguration);
+    config->setString("logger", nextTestLoggerName());
+    config->setString("logger.async", "false");
+    config->setString("logger.level", "trace");
+    config->setString("logger.use_syslog", "true");
+    config->setString("logger.syslog_level", "trace");
+    config->setString("logger.syslog.programname", program_name);
+    if (remote)
+    {
+        config->setString("logger.syslog.address", "127.0.0.1:1514");
+        config->setString("logger.syslog.format", "syslog");
+    }
+
+    Poco::AutoPtr<Poco::Channel> null_channel(new Poco::NullChannel);
+    Poco::Logger & logger = Poco::Logger::create(nextTestLoggerName(), null_channel.get(), Poco::Message::PRIO_TRACE);
+    SCOPE_EXIT({
+        /// Avoid leaving a channel owned by `loggers` attached to this dedicated logger.
+        logger.setChannel(null_channel.get());
+    });
+
+    loggers.buildLoggers(*config, logger, "clickhouse-server");
+}
+
+}
+
+TEST(Loggers, RemoteSyslogProgramNameCanBeConfigured)
+{
+    constexpr auto expected_program_name = "clickhouse-production-scc";
+    const auto packet = sendAndReceiveRemoteSyslogPacket("clickhouse-server", expected_program_name, "syslog");
+    ASSERT_FALSE(packet.empty());
+    EXPECT_EQ(extractRFC5424AppName(packet), expected_program_name);
+}
+
+TEST(Loggers, RemoteSyslogProgramNameDefaultsToCommandName)
+{
+    constexpr auto expected_program_name = "clickhouse-server";
+    const auto packet = sendAndReceiveRemoteSyslogPacket(expected_program_name, std::nullopt, "syslog");
+    ASSERT_FALSE(packet.empty());
+    EXPECT_EQ(extractRFC5424AppName(packet), expected_program_name);
+}
+
+TEST(Loggers, RemoteSyslogInvalidCommandNameFallsBackToNilAppName)
+{
+    /// The `cmd_name` fallback is derived from argv[0], so a renamed binary or symlink can produce a value that
+    /// is not a valid RFC 5424 APP-NAME. Before `programname` existed this path sent Poco's `-` default, and a
+    /// deployment that never configured the setting must keep getting a well-formed header rather than a
+    /// malformed one built from the binary name.
+    const auto overlong = sendAndReceiveRemoteSyslogPacket(std::string(49, 'a'), std::nullopt, "syslog");
+    ASSERT_FALSE(overlong.empty());
+    EXPECT_EQ(extractRFC5424AppName(overlong), "-");
+
+    const auto with_space = sendAndReceiveRemoteSyslogPacket("prod server", std::nullopt, "syslog");
+    ASSERT_FALSE(with_space.empty());
+    EXPECT_EQ(extractRFC5424AppName(with_space), "-");
+}
+
+TEST(Loggers, RemoteSyslogProgramNameIgnoredForBSDFormat)
+{
+    constexpr auto configured_program_name = "clickhouse-syslog-custom-tag";
+    const auto packet = sendAndReceiveRemoteSyslogPacket("clickhouse-server", configured_program_name, "bsd");
+    ASSERT_FALSE(packet.empty());
+    EXPECT_EQ(packet.find(configured_program_name), std::string::npos);
+}
+
+TEST(Loggers, SyslogProgramNameWithWhitespaceIsRejected)
+{
+    /// A space would be emitted verbatim as RFC 5424 APP-NAME and shift the rest of the message header.
+    EXPECT_THROW(buildLoggersWithProgramName("prod server", /*remote=*/true), DB::Exception);
+    EXPECT_THROW(buildLoggersWithProgramName("prod\tserver", /*remote=*/true), DB::Exception);
+    EXPECT_THROW(buildLoggersWithProgramName("prod server", /*remote=*/false), DB::Exception);
+}
+
+TEST(Loggers, SyslogProgramNameWithNonPrintableCharactersIsRejected)
+{
+    EXPECT_THROW(buildLoggersWithProgramName("clickhouse\nserver", /*remote=*/true), DB::Exception);
+    /// UTF-8 encoding of "clickhouse-ü": bytes outside of the printable ASCII range.
+    EXPECT_THROW(buildLoggersWithProgramName("clickhouse-\xC3\xBC", /*remote=*/true), DB::Exception);
+}
+
+TEST(Loggers, SyslogProgramNameWithInvalidLengthIsRejected)
+{
+    EXPECT_THROW(buildLoggersWithProgramName("", /*remote=*/true), DB::Exception);
+    /// RFC 5424 limits APP-NAME to 48 characters.
+    EXPECT_THROW(buildLoggersWithProgramName(std::string(49, 'a'), /*remote=*/true), DB::Exception);
+    EXPECT_NO_THROW(buildLoggersWithProgramName(std::string(48, 'a'), /*remote=*/true));
+}


### PR DESCRIPTION
### Changelog category (leave one):
- New Feature


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
You can now set a custom syslog program name for ClickHouse logs using `logger.syslog.programname`, making it easier to distinguish multiple ClickHouse instances in syslog. The default syslog identifier is now command-specific: remote syslog previously sent `-` as the RFC 5424 `APP-NAME` and now sends the command name (for example `clickhouse-server`), and the multi-purpose binary started as `clickhouse server` or `clickhouse keeper` now uses `clickhouse-server` / `clickhouse-keeper` instead of `clickhouse` for local syslog.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

Motivation:
Allow users to set a stable, custom syslog program identifier (e.g., environment-specific identifiers) instead of relying solely on the binary command name.

Parameters:
- `logger.syslog.programname`: Program name for syslog records. If not set, defaults to the name of the ClickHouse command you started (for example, `clickhouse-server` or `clickhouse-keeper`).
- `logger.syslog.format`: With `format=syslog`, `programname` is used as RFC 5424 `APP-NAME`. With `format=bsd`, `programname` has no effect.

Example use:
```xml
<logger>
    <use_syslog>1</use_syslog>
    <syslog>
        <programname>clickhouse-production-scc</programname>
        <address>syslog.remote:10514</address>
        <format>syslog</format>
    </syslog>
</logger>
```

### Design decisions and alternatives considered

It's been a long time since I last wrote C++ code. I hope the code is decent; otherwise, let me know, and I'll happily make changes! :)

1. Where to apply `programname`:
- Chosen: set both `Poco::SyslogChannel::PROP_NAME` (local syslog) and `Poco::Net::RemoteSyslogChannel::PROP_NAME` (remote syslog).
- Alternative: apply only to local syslog or only to remote syslog.
- Why not: issue scope and user expectation are the same setting for syslog output regardless of transport.

2. Default value strategy:
- Chosen: `logger.syslog.programname` defaults to `cmd_name` in `buildLoggers`, which maps to the ClickHouse command name used to start the process.
- Alternative: default to a hardcoded constant like `clickhouse`.
- Why not: command-specific defaults (`clickhouse-server`, `clickhouse-keeper`, etc.) are more informative.
- Note that this does change the default identifier in two ways, both documented in the `programname` docs section. Remote syslog never set `PROP_NAME` before, so `Poco` left its `"-"` default and every RFC 5424 record carried `-` as `APP-NAME`; those records now carry `clickhouse-server` / `clickhouse-keeper`. Local syslog already used `cmd_name`, but for the multi-purpose binary that was `clickhouse`, and it is now the subcommand-specific name. Users who filter on the old values can pin them with an explicit `programname`.

3. Where the subcommand-specific default is supplied:
- Chosen: a protected `virtual std::string BaseDaemon::getCommandName()` (defaulting to Poco's `commandName()`), overridden by `Server` and `Keeper`, used by `BaseDaemon::initialize` on the first `buildLoggers` call.
- Alternative: pass the command name at the later `buildLoggers` call sites in `Server.cpp` / `Keeper.cpp`, or include `cmd_name` in the `config_logger` cache key.
- Why not: the later `buildLoggers` calls early-return on the `config_logger` guard, so passing the name there is dead code; and widening the cache key would rebuild every channel (file, error log, console, syslog) a second time on each startup, which is a far larger behavior change than this feature needs. `commandName()` alone is also not enough, because `programs/main.cpp` erases the subcommand argument, so `clickhouse server` reports `clickhouse`.
- The substitution is applied only when the executable's full file name is exactly `clickhouse`, via `BaseDaemon::disambiguateCommandName`, which delegates to the free function `disambiguateClickHouseCommandName(executable_file_name, command_name, subcommand_name)`. The decision deliberately uses Poco's `application.name` rather than `commandName()`: `commandName()` is `application.baseName`, and `Poco::Path::getBaseName` truncates at the last dot, so a binary named `clickhouse.prod` reports `commandName() == "clickhouse"` without being the multi-purpose binary. Deciding on the base name would silently rewrite that deployment's syslog identifier. The mapping lives in a free function so it can be unit-tested directly: constructing any `Poco::Util::Application` asserts that it is the only instance in the process and installs process-wide signal handlers, which is not acceptable inside the shared `unit_tests_dbms` binary. `src/Daemon/tests/gtest_daemon_command_name.cpp` covers the multi-purpose binary, dedicated binaries and symlinks, renamed binaries, and near-miss names. Symlinks and dedicated binaries (`clickhouse-server`, `clickhouse-keeper`) already report an unambiguous name, and every other executable keeps the identifier it reported before this change, so no existing syslog identifier changes except in the genuinely ambiguous multi-tool case.

4. Test cleanup of global logger state:
- Chosen: `LoggerStateGuard` snapshots the root channel/level plus the channel and level of every pre-existing logger, holding each channel through a shared `Poco::AutoPtr` so it stays alive, and restores them exactly.
- Alternative: restore only levels and repoint every pre-existing logger at the root channel.
- Why not: `buildLoggers` repoints every already-created logger at a channel owned by the test's `Loggers` instance, so the channels do have to be restored to avoid dangling pointers. Falling back to the root channel is not a safe substitute, because the root channel is null in a fresh process and that would silently mute loggers created by earlier tests in the same binary, which is an order-dependent side effect under `--gtest_shuffle`. Taking a shared reference makes exact restoration safe, since the saved channel cannot be destroyed while the guard holds it.

5. `format=bsd` behavior:
- Chosen: document that remote BSD format has no effect on `programname`.
- Alternative: synthesize a custom identifier in the message body for BSD mode.
- Why not: out of scope for this issue and would diverge from current channel semantics.

6. Terminology in documentation:
- Chosen: use RFC 5424 term `APP-NAME` directly and avoid legacy `TAG` wording.
- Alternative: describe it as `APP-NAME`/tag or explain RFC 3164 `TAG` decomposition.
- Why not: this issue is about current behavior and config semantics; adding legacy terminology increases ambiguity without improving user outcomes.


7. Document pre-existing `logger.syslog.options`:
- Chosen: add a dedicated docs row for `logger.syslog.options`.
- Alternative: keep it undocumented or mention it only indirectly under `programname`.
- Why not: while implementing this issue, I noticed this setting already exists in code but was missing from docs. Documenting it now aligns docs with existing behavior and makes local syslog configuration easier to discover.

8. Validation of `programname`:
- Chosen: reject explicitly configured values that are not valid RFC 5424 `APP-NAME` tokens (empty, longer than 48 characters, or containing bytes outside printable ASCII `%d33-126`), raising `BAD_ARGUMENTS` at startup.
- Alternative: accept anything and let the value reach the channel, sanitize silently, or validate only for remote syslog with `format=syslog`.
- Why not: `RemoteSyslogChannel::log` writes the name verbatim between `HOSTNAME` and `PROCID`, so whitespace shifts every following header field and produces a malformed record; silent sanitization would hide the misconfiguration. Validating only in the remote/non-BSD case would mean a config that validates today starts failing after an unrelated `format` or `address` change.
- The `cmd_name` fallback is deliberately never rejected, since it derives from the binary name and refusing to start because of an unusual `argv[0]` would punish deployments that never touched this setting. It is still not allowed to produce a malformed header: on the remote path, where the name was previously never set at all, `PROP_NAME` is only assigned when the derived value is a valid `APP-NAME`, so an unusual binary name leaves Poco's `-` default in place. Local syslog keeps receiving `cmd_name` unchecked, which is exactly what it received before this PR.

### Testing

Targeted unit-test validation ran locally (not full suite):
- `ninja unit_tests_dbms` (in `build_min`)
- `./build_min/src/unit_tests_dbms --gtest_filter='Loggers.RemoteSyslogProgramName*'`
- `./build_min/src/unit_tests_dbms --gtest_filter='AccessRights.Radix:Loggers.RemoteSyslogProgramName*'`

Only the `_server_settings_outside_source.mdx` source fragment is edited. The generated page `docs/reference/settings/server-settings/settings/other.mdx` is deliberately left alone, because the `No direct edits to generated or read-only docs` check rejects edits inside autogenerated regions unless the PR carries the `pr-autogenerated-docs` label. The nightly autogen job regenerates that page from this fragment. Maintainers who want the generated page refreshed within this PR can add the label and I will commit the regenerated output.

Closes: #11784


Additional note:
While working on this change, I noticed that `logger.syslog.options` is already implemented in `Loggers::buildLoggers`, but it was not documented as a dedicated key in the syslog settings table. I added explicit documentation for it in this PR to match existing behavior and improve discoverability.


