### PR TITLE
Support backward compatibility disk resolving for cache disks

### DIFF
--- a/src/Disks/StoragePolicy.cpp
+++ b/src/Disks/StoragePolicy.cpp
@@ -231,9 +231,20 @@ DiskPtr StoragePolicy::getAnyDisk() const
 DiskPtr StoragePolicy::tryGetDiskByName(const String & disk_name) const
 {
     for (auto && volume : volumes)
+    {
         for (auto && disk : volume->getDisks())
+        {
             if (disk->getName() == disk_name)
                 return disk;
+
+            /// If the requested name matches a wrapped (underlying) disk of a cache layer,
+            /// resolve to the cache disk. This provides backward compatibility for TTL TO DISK
+            /// and MOVE PARTITION TO DISK referencing base disk names (e.g. 's3' instead of 's3_cache').
+            if (disk->supportsCache() && disk->getCacheLayersNames().contains(disk_name))
+                return disk;
+        }
+    }
+
     return {};
 }
 

--- a/tests/integration/test_ttl_to_disk_wrapped_by_cache/config.d/storage_configuration.xml
+++ b/tests/integration/test_ttl_to_disk_wrapped_by_cache/config.d/storage_configuration.xml
@@ -1,0 +1,35 @@
+<clickhouse>
+    <storage_configuration>
+        <disks>
+            <s3>
+                <type>s3</type>
+                <endpoint>http://minio1:9001/root/data/</endpoint>
+                <access_key_id>minio</access_key_id>
+                <secret_access_key>ClickHouse_Minio_P@ssw0rd</secret_access_key>
+            </s3>
+
+            <s3_cache>
+                <type>cache</type>
+                <disk>s3</disk>
+                <path>/tmp/s3_cache/</path>
+                <max_size>1000000000</max_size>
+            </s3_cache>
+        </disks>
+
+        <policies>
+            <s3_cold>
+                <volumes>
+                    <main>
+                        <disk>default</disk>
+                    </main>
+
+                    <external>
+                        <disk>s3_cache</disk>
+                        <perform_ttl_move_on_insert>0</perform_ttl_move_on_insert>
+                    </external>
+                </volumes>
+                <move_factor>0.0</move_factor> <!-- Disable automatic moves -->
+            </s3_cold>
+        </policies>
+    </storage_configuration>
+</clickhouse>

--- a/tests/integration/test_ttl_to_disk_wrapped_by_cache/test.py
+++ b/tests/integration/test_ttl_to_disk_wrapped_by_cache/test.py
@@ -1,0 +1,75 @@
+import pytest
+import time
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+
+node = cluster.add_instance(
+    "node",
+    main_configs=["config.d/storage_configuration.xml"],
+    with_minio=True
+)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+# Regression test for https://github.com/ClickHouse/ClickHouse/issues/98665
+def test_ttl_to_wrapped_by_cache_disk(started_cluster):
+    try:
+        node.query(
+            """
+            CREATE TABLE test_ttl_to_wrapped_by_cache_disk
+            (
+                `id` UInt64,
+                `event_time` DateTime
+            )
+            ENGINE = MergeTree
+            PARTITION BY id
+            ORDER BY id
+            TTL event_time + toIntervalDay(14) TO DISK 's3'
+            SETTINGS storage_policy = 's3_cold'
+            """
+        )
+
+        node.query("SYSTEM STOP MOVES test_ttl_to_wrapped_by_cache_disk")
+
+        node.query("INSERT INTO test_ttl_to_wrapped_by_cache_disk VALUES (1, now() - INTERVAL 100 DAY)")
+        assert node.query("SELECT count() FROM test_ttl_to_wrapped_by_cache_disk").strip() == "1"
+
+        # Part should start on default disk.
+        assert node.query(
+            "SELECT disk_name FROM system.parts "
+            "WHERE table = 'test_ttl_to_wrapped_by_cache_disk' AND active"
+        ).strip() == "default"
+
+        node.query("SYSTEM START MOVES test_ttl_to_wrapped_by_cache_disk")
+
+        # Wait for TTL move to the cache disk.
+        for i in range(100):
+            print(f"Waiting until part will be moved: iteration: {i}")
+
+            disk = node.query(
+                "SELECT disk_name FROM system.parts "
+                "WHERE table = 'test_ttl_to_wrapped_by_cache_disk' AND active"
+            ).strip()
+
+            if disk == "s3_cache":
+                break
+
+            time.sleep(1)
+        else:
+            assert False, "TTL move did not happen within timeout"
+
+        # Data should still be intact after the move.
+        assert node.query("SELECT count() FROM test_ttl_to_wrapped_by_cache_disk").strip() == "1"
+
+    finally:
+        node.query("DROP TABLE test_ttl_to_wrapped_by_cache_disk SYNC")


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Before https://github.com/ClickHouse/ClickHouse/pull/96070 cache disk was incorrectly copying the wrapped disk name. Because of that, it was necessary to write the destination disk name in DDLs to enable TTL moves to this disk. 

This patch rolls back this functionality.

Fixes: https://github.com/ClickHouse/ClickHouse/issues/98665


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.696`
- Backported to: `26.2.5.28`
<!-- ch-version-info:end -->