### PR TITLE
Add restore_access_entities_with_current_grants setting

### DIFF
--- a/src/Access/AccessBackup.cpp
+++ b/src/Access/AccessBackup.cpp
@@ -240,6 +240,7 @@ AccessRestorerFromBackup::AccessRestorerFromBackup(
     , creation_mode(restore_settings_.create_access)
     , skip_unresolved_dependencies(restore_settings_.skip_unresolved_access_dependencies)
     , update_dependents(restore_settings_.update_access_entities_dependents)
+    , restore_with_current_grants(restore_settings_.restore_access_entities_with_current_grants)
     , log(getLogger("AccessRestorerFromBackup"))
 {
 }
@@ -355,12 +356,15 @@ AccessRightsElements AccessRestorerFromBackup::getRequiredAccess() const
             {
                 const auto & user = typeid_cast<const User &>(*entity);
                 res.emplace_back(AccessType::CREATE_USER, user.getName());
-                auto elements = user.access.getElements();
-                for (auto & element : elements)
+                if (!restore_with_current_grants)
                 {
-                    if (!element.is_partial_revoke)
-                        element.grant_option = true;
-                    res.emplace_back(element);
+                    auto elements = user.access.getElements();
+                    for (auto & element : elements)
+                    {
+                        if (!element.is_partial_revoke)
+                            element.grant_option = true;
+                        res.emplace_back(element);
+                    }
                 }
                 if (!user.granted_roles.isEmpty())
                     res.emplace_back(AccessType::ROLE_ADMIN);
@@ -371,12 +375,15 @@ AccessRightsElements AccessRestorerFromBackup::getRequiredAccess() const
             {
                 const auto & role = typeid_cast<const Role &>(*entity);
                 res.emplace_back(AccessType::CREATE_ROLE, role.getName());
-                auto elements = role.access.getElements();
-                for (auto & element : elements)
+                if (!restore_with_current_grants)
                 {
-                    if (!element.is_partial_revoke)
-                        element.grant_option = true;
-                    res.emplace_back(element);
+                    auto elements = role.access.getElements();
+                    for (auto & element : elements)
+                    {
+                        if (!element.is_partial_revoke)
+                            element.grant_option = true;
+                        res.emplace_back(element);
+                    }
                 }
                 if (!role.granted_roles.isEmpty())
                     res.emplace_back(AccessType::ROLE_ADMIN);

--- a/src/Access/AccessBackup.h
+++ b/src/Access/AccessBackup.h
@@ -86,6 +86,7 @@ private:
     const RestoreAccessCreationMode creation_mode;
     const bool skip_unresolved_dependencies;
     const bool update_dependents;
+    const bool restore_with_current_grants;
     const LoggerPtr log;
 
     /// Whether loadFromBackup() finished.

--- a/src/Access/AccessRights.cpp
+++ b/src/Access/AccessRights.cpp
@@ -1553,6 +1553,23 @@ String AccessRights::toString() const
 }
 
 
+AccessRights AccessRights::getGrantableRights() const
+{
+    AccessRights result;
+    for (auto & element : getElements())
+    {
+        if (!element.grant_option && !element.is_partial_revoke)
+            continue;
+
+        if (element.is_partial_revoke)
+            result.revoke(element);
+        else
+            result.grant(element);
+    }
+    return result;
+}
+
+
 template <bool grant_option, bool wildcard, typename... Args>
 bool AccessRights::isGrantedImpl(const AccessFlags & flags, const Args &... args) const
 {

--- a/src/Access/AccessRights.h
+++ b/src/Access/AccessRights.h
@@ -38,6 +38,10 @@ public:
     /// Returns the information about all the access granted.
     AccessRightsElements getElements() const;
 
+    /// Returns the subset of access rights that can be granted to others
+    /// (i.e. rights with GRANT OPTION, with partial revokes applied).
+    AccessRights getGrantableRights() const;
+
     /// Grants access on a specified database/table/column.
     /// Does nothing if the specified access has been already granted.
     void grant(const AccessFlags & flags);

--- a/src/Backups/RestoreSettings.cpp
+++ b/src/Backups/RestoreSettings.cpp
@@ -162,6 +162,7 @@ namespace
     M(Bool, allow_non_empty_tables) \
     M(RestoreAccessCreationMode, create_access) \
     M(Bool, skip_unresolved_access_dependencies) \
+    M(Bool, restore_access_entities_with_current_grants) \
     M(Bool, update_access_entities_dependents) \
     M(RestoreUDFCreationMode, create_function) \
     M(Bool, allow_azure_native_copy) \

--- a/src/Backups/RestoreSettings.h
+++ b/src/Backups/RestoreSettings.h
@@ -111,6 +111,13 @@ struct RestoreSettings
     /// If this flag is false then RESTORE will throw an exception in that case.
     bool skip_unresolved_access_dependencies = false;
 
+    /// If true, RESTORE will not fail when the backup contains users/roles with more permissions
+    /// than the restoring user is allowed to grant. Instead, the restored grants will be limited
+    /// to what the restoring user can grant (similar to GRANT CURRENT GRANTS).
+    /// This is useful for cloud environments where the restoring user may not have all the permissions
+    /// that were present in the original system.
+    bool restore_access_entities_with_current_grants = false;
+
     /// Try to update dependents of restored access entities.
     /// For example: if a backup contains a profile assigned to a user: `CREATE PROFILE p1; CREATE USER u1 SETTINGS PROFILE p1`
     /// and now we're restoring only profile `p1` and user `u1` already exists, then

--- a/src/Backups/RestorerFromBackup.cpp
+++ b/src/Backups/RestorerFromBackup.cpp
@@ -1,6 +1,8 @@
 #include <Access/AccessBackup.h>
 #include <Access/AccessRights.h>
 #include <Access/ContextAccess.h>
+#include <Access/User.h>
+#include <Access/Role.h>
 #include <Backups/BackupCoordinationStage.h>
 #include <Backups/BackupMetadataFinder.h>
 #include <Backups/BackupSettings.h>
@@ -366,7 +368,44 @@ AccessEntitiesToRestore RestorerFromBackup::getAccessEntitiesToRestore(const Str
     if (!access_restorer)
         return {};
     access_restorer->generateRandomIDsAndResolveDependencies(context->getAccessControl());
-    return access_restorer->getEntitiesToRestore(data_path_in_backup);
+    auto entities = access_restorer->getEntitiesToRestore(data_path_in_backup);
+
+    if (restore_settings.restore_access_entities_with_current_grants)
+    {
+        /// Limit restored grants to what the current user is allowed to grant (same as GRANT CURRENT GRANTS).
+        auto current_user_grantable_rights = context->getAccess()->getAccessRights()->getGrantableRights();
+
+        for (auto & [id, entity] : entities.new_entities)
+        {
+            auto entity_type = entity->getType();
+            if (entity_type == User::TYPE)
+            {
+                const auto & user = typeid_cast<const User &>(*entity);
+                AccessRights limited_access = user.access;
+                limited_access.makeIntersection(current_user_grantable_rights);
+                if (limited_access != user.access)
+                {
+                    auto cloned = entity->clone();
+                    typeid_cast<User &>(*cloned).access = std::move(limited_access);
+                    entity = cloned;
+                }
+            }
+            else if (entity_type == Role::TYPE)
+            {
+                const auto & role = typeid_cast<const Role &>(*entity);
+                AccessRights limited_access = role.access;
+                limited_access.makeIntersection(current_user_grantable_rights);
+                if (limited_access != role.access)
+                {
+                    auto cloned = entity->clone();
+                    typeid_cast<Role &>(*cloned).access = std::move(limited_access);
+                    entity = cloned;
+                }
+            }
+        }
+    }
+
+    return entities;
 }
 
 void RestorerFromBackup::createAndCheckDatabases()

--- a/src/Interpreters/Access/InterpreterGrantQuery.cpp
+++ b/src/Interpreters/Access/InterpreterGrantQuery.cpp
@@ -390,22 +390,9 @@ namespace
         std::shared_ptr<const ContextAccessWrapper> current_user_access,
         const AccessRightsElements & elements_to_grant)
     {
-        AccessRightsElements current_user_grantable_elements;
-        auto available_grant_elements = current_user_access->getAccessRights()->getElements();
-        AccessRights current_user_rights;
-        for (auto & element : available_grant_elements)
-        {
-            if (!element.grant_option && !element.is_partial_revoke)
-                continue;
-
-            if (element.is_partial_revoke)
-                current_user_rights.revoke(element);
-            else
-                current_user_rights.grant(element);
-        }
-
+        auto current_user_grantable_rights = current_user_access->getAccessRights()->getGrantableRights();
         rights.grant(elements_to_grant);
-        rights.makeIntersection(current_user_rights);
+        rights.makeIntersection(current_user_grantable_rights);
     }
 
     /// Updates grants of a specified user or role.

--- a/tests/queries/0_stateless/04027_restore_access_entities_with_current_grants.reference
+++ b/tests/queries/0_stateless/04027_restore_access_entities_with_current_grants.reference
@@ -1,0 +1,12 @@
+--- Restore without setting (should fail) ---
+ACCESS_DENIED
+--- Restore with restore_access_entities_with_current_grants=true ---
+-- user_a grants (should only have SELECT, not INSERT/ALTER/CREATE) --
+GRANT SELECT ON *.* TO user_a
+GRANT role_b TO user_a
+-- role_b grants (should only have SELECT, not INSERT/ALTER) --
+GRANT SELECT ON *.* TO role_b
+--- Extreme case: restoring user has no GRANT OPTION ---
+-- user_a grants (should have no access grants, only role assignment) --
+GRANT role_b TO user_a
+-- role_b grants (should be empty) --

--- a/tests/queries/0_stateless/04027_restore_access_entities_with_current_grants.sh
+++ b/tests/queries/0_stateless/04027_restore_access_entities_with_current_grants.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Tags: no-parallel
+
+# Disabled parallel since RESTORE can only restore either all users or no users
+# (it can't restore only users added by the current test run),
+# so a RESTORE from a parallel test run could recreate our users before we expect that.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+user_a="user_a_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+role_b="role_b_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+restoring_user="restoring_user_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+no_grant_user="no_grant_user_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+
+${CLICKHOUSE_CLIENT} -m --query "
+DROP USER IF EXISTS ${user_a};
+DROP ROLE IF EXISTS ${role_b};
+DROP USER IF EXISTS ${restoring_user};
+DROP USER IF EXISTS ${no_grant_user};
+"
+
+# Create a user and role with broad permissions.
+${CLICKHOUSE_CLIENT} -m --query "
+CREATE ROLE ${role_b};
+GRANT SELECT, INSERT, ALTER ON *.* TO ${role_b};
+CREATE USER ${user_a} DEFAULT ROLE ${role_b};
+GRANT SELECT, INSERT, ALTER, CREATE ON *.* TO ${user_a};
+"
+
+backup_name="Disk('backups', '${CLICKHOUSE_TEST_UNIQUE_NAME}')"
+
+${CLICKHOUSE_CLIENT} --query "BACKUP TABLE system.users, TABLE system.roles TO ${backup_name} FORMAT Null"
+
+# Create a restoring user that has fewer permissions than user_a and role_b.
+# This user can create users/roles, but only has GRANT OPTION on SELECT (not INSERT, ALTER, CREATE).
+${CLICKHOUSE_CLIENT} -m --query "
+CREATE USER ${restoring_user};
+GRANT CREATE USER, CREATE ROLE ON *.* TO ${restoring_user};
+GRANT ROLE ADMIN ON *.* TO ${restoring_user};
+GRANT SELECT ON *.* TO ${restoring_user} WITH GRANT OPTION;
+"
+
+# Drop the entities we will restore.
+${CLICKHOUSE_CLIENT} -m --query "
+DROP USER ${user_a};
+DROP ROLE ${role_b};
+"
+
+# 1) Without the setting, RESTORE should fail because restoring_user can't grant INSERT/ALTER/CREATE.
+echo "--- Restore without setting (should fail) ---"
+${CLICKHOUSE_CLIENT} --user="${restoring_user}" --query "RESTORE ALL FROM ${backup_name} FORMAT Null" 2>&1 | grep -om1 "ACCESS_DENIED"
+
+# 2) With the setting, RESTORE should succeed, but grants are limited.
+echo "--- Restore with restore_access_entities_with_current_grants=true ---"
+${CLICKHOUSE_CLIENT} --user="${restoring_user}" --query "RESTORE ALL FROM ${backup_name} SETTINGS restore_access_entities_with_current_grants=true FORMAT Null"
+
+replacements="s/${user_a}/user_a/g; s/${role_b}/role_b/g"
+
+echo "-- user_a grants (should only have SELECT, not INSERT/ALTER/CREATE) --"
+${CLICKHOUSE_CLIENT} --query "SHOW GRANTS FOR ${user_a}" | sed "${replacements}"
+
+echo "-- role_b grants (should only have SELECT, not INSERT/ALTER) --"
+${CLICKHOUSE_CLIENT} --query "SHOW GRANTS FOR ${role_b}" | sed "${replacements}"
+
+# 3) Test the extreme case: restoring user has NO grant option at all.
+echo "--- Extreme case: restoring user has no GRANT OPTION ---"
+${CLICKHOUSE_CLIENT} -m --query "
+DROP USER ${user_a};
+DROP ROLE ${role_b};
+"
+
+${CLICKHOUSE_CLIENT} -m --query "
+CREATE USER ${no_grant_user};
+GRANT CREATE USER, CREATE ROLE ON *.* TO ${no_grant_user};
+GRANT ROLE ADMIN ON *.* TO ${no_grant_user};
+"
+
+${CLICKHOUSE_CLIENT} --user="${no_grant_user}" --query "RESTORE ALL FROM ${backup_name} SETTINGS restore_access_entities_with_current_grants=true FORMAT Null"
+
+echo "-- user_a grants (should have no access grants, only role assignment) --"
+${CLICKHOUSE_CLIENT} --query "SHOW GRANTS FOR ${user_a}" | sed "${replacements}"
+
+echo "-- role_b grants (should be empty) --"
+${CLICKHOUSE_CLIENT} --query "SHOW GRANTS FOR ${role_b}" | sed "${replacements}"
+
+# Cleanup
+${CLICKHOUSE_CLIENT} -m --query "
+DROP USER IF EXISTS ${user_a};
+DROP ROLE IF EXISTS ${role_b};
+DROP USER IF EXISTS ${restoring_user};
+DROP USER IF EXISTS ${no_grant_user};
+"


### PR DESCRIPTION
### Changelog category (leave one):
- New Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add `restore_access_entities_with_current_grants` server setting. When enabled, restored users/roles have their grants limited to what the restoring user is allowed to grant (same semantics as `GRANT CURRENT GRANTS`), instead of failing with `ACCESS_DENIED`.

### Documentation entry for user-facing changes

- Added new RESTORE setting `restore_access_entities_with_current_grants` (default: `false`). When enabled, RESTORE will not fail if the backup contains users or roles with more permissions than the restoring user can grant. Instead, the restored entities' grants are intersected with the restoring user's grantable rights.

Closes https://github.com/ClickHouse/clickhouse-private/issues/51509

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.500`
<!-- ch-version-info:end -->