### PR TITLE
Fix `SYSTEM START REPLICATED VIEW` not waking up the refresh task

### DIFF
--- a/src/Storages/MaterializedView/RefreshTask.cpp
+++ b/src/Storages/MaterializedView/RefreshTask.cpp
@@ -165,6 +165,7 @@ OwnedRefreshTask RefreshTask::create(
     task->refresh_task_watch_callback = std::make_shared<Coordination::WatchCallback>([w = task->coordination.watches, task_waker = task->refresh_task->getWatchCallback()](const Coordination::WatchResponse & response)
     {
         w->root_watch_active.store(false);
+        w->children_watch_active.store(false);
         w->should_reread_znodes.store(true);
         (*task_waker)(response);
     });

--- a/tests/queries/0_stateless/04027_system_start_replicated_view.reference
+++ b/tests/queries/0_stateless/04027_system_start_replicated_view.reference
@@ -1,4 +1,4 @@
-<1: running>	Scheduled
+<1: running>	1
 <2: stopped>	Disabled
 <3: restarted>	1
 <4: new rows>	1

--- a/tests/queries/0_stateless/04027_system_start_replicated_view.reference
+++ b/tests/queries/0_stateless/04027_system_start_replicated_view.reference
@@ -1,0 +1,4 @@
+<1: running>	Scheduled
+<2: stopped>	Disabled
+<3: restarted>	1
+<4: new rows>	1

--- a/tests/queries/0_stateless/04027_system_start_replicated_view.sh
+++ b/tests/queries/0_stateless/04027_system_start_replicated_view.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Tags: zookeeper
+
+# Regression test: SYSTEM START REPLICATED VIEW did not wake the refresh task
+# because the ZooKeeper children watch was not re-registered after the first fire.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+CLICKHOUSE_CLIENT=$(echo "$CLICKHOUSE_CLIENT" | sed 's/--session_timezone[= ][^ ]*//g')
+CLICKHOUSE_CLIENT="$CLICKHOUSE_CLIENT --session_timezone Etc/UTC"
+
+db="rdb_$CLICKHOUSE_DATABASE"
+
+$CLICKHOUSE_CLIENT --distributed_ddl_output_mode=none -nq "
+    create database $db engine=Replicated('/test/$CLICKHOUSE_DATABASE/rdb', 's1', 'r1');
+    create view ${db}.refreshes as
+        select * from system.view_refreshes where database = '$db' order by view;
+    create materialized view ${db}.rmv
+        refresh after 1 second append
+        (x Int64) engine MergeTree order by x
+        empty
+        as select 1 as x;
+"
+
+# Wait for the first refresh to succeed.
+while [ "$($CLICKHOUSE_CLIENT -q "select last_success_time is null from ${db}.refreshes -- $LINENO" | xargs)" != '0' ]
+do
+    sleep 0.5
+done
+$CLICKHOUSE_CLIENT -q "select '<1: running>', status from ${db}.refreshes"
+
+# Stop the view globally via Keeper.
+$CLICKHOUSE_CLIENT -q "system stop replicated view ${db}.rmv"
+while [ "$($CLICKHOUSE_CLIENT -q "select status from ${db}.refreshes -- $LINENO" | xargs)" != 'Disabled' ]
+do
+    sleep 0.5
+done
+$CLICKHOUSE_CLIENT -q "select '<2: stopped>', status from ${db}.refreshes"
+
+# Remember the current row count.
+cnt_before=$($CLICKHOUSE_CLIENT -q "select count() from ${db}.rmv")
+
+# Start the view back up.
+$CLICKHOUSE_CLIENT -q "system start replicated view ${db}.rmv"
+
+# The bug: the view stayed Disabled forever here because the children watch
+# was not re-registered after the stop event consumed it.
+# Wait for the view to leave Disabled state and complete at least one more refresh.
+for _ in $(seq 1 30); do
+    cnt_after=$($CLICKHOUSE_CLIENT -q "select count() from ${db}.rmv")
+    if [ "$cnt_after" -gt "$cnt_before" ]; then
+        break
+    fi
+    sleep 0.5
+done
+
+$CLICKHOUSE_CLIENT -q "select '<3: restarted>', status != 'Disabled' from ${db}.refreshes"
+$CLICKHOUSE_CLIENT -q "select '<4: new rows>', count() > $cnt_before from ${db}.rmv"
+
+$CLICKHOUSE_CLIENT --distributed_ddl_output_mode=none -q "drop database $db"

--- a/tests/queries/0_stateless/04027_system_start_replicated_view.sh
+++ b/tests/queries/0_stateless/04027_system_start_replicated_view.sh
@@ -37,7 +37,7 @@ for _ in $(seq 1 60); do
     fi
     sleep 0.5
 done
-$CLICKHOUSE_CLIENT -q "select '<1: running>', status from ${db}.refreshes"
+$CLICKHOUSE_CLIENT -q "select '<1: running>', status != 'Disabled' from ${db}.refreshes"
 
 # Stop the view globally via Keeper.
 $CLICKHOUSE_CLIENT -q "system stop replicated view ${db}.rmv"

--- a/tests/queries/0_stateless/04027_system_start_replicated_view.sh
+++ b/tests/queries/0_stateless/04027_system_start_replicated_view.sh
@@ -13,6 +13,12 @@ CLICKHOUSE_CLIENT="$CLICKHOUSE_CLIENT --session_timezone Etc/UTC"
 
 db="rdb_$CLICKHOUSE_DATABASE"
 
+function cleanup()
+{
+    $CLICKHOUSE_CLIENT --distributed_ddl_output_mode=none -q "drop database if exists $db" 2>/dev/null
+}
+trap cleanup EXIT
+
 $CLICKHOUSE_CLIENT --distributed_ddl_output_mode=none -nq "
     create database $db engine=Replicated('/test/$CLICKHOUSE_DATABASE/rdb', 's1', 'r1');
     create view ${db}.refreshes as
@@ -25,16 +31,20 @@ $CLICKHOUSE_CLIENT --distributed_ddl_output_mode=none -nq "
 "
 
 # Wait for the first refresh to succeed.
-while [ "$($CLICKHOUSE_CLIENT -q "select last_success_time is null from ${db}.refreshes -- $LINENO" | xargs)" != '0' ]
-do
+for _ in $(seq 1 60); do
+    if [ "$($CLICKHOUSE_CLIENT -q "select last_success_time is null from ${db}.refreshes -- $LINENO" | xargs)" = '0' ]; then
+        break
+    fi
     sleep 0.5
 done
 $CLICKHOUSE_CLIENT -q "select '<1: running>', status from ${db}.refreshes"
 
 # Stop the view globally via Keeper.
 $CLICKHOUSE_CLIENT -q "system stop replicated view ${db}.rmv"
-while [ "$($CLICKHOUSE_CLIENT -q "select status from ${db}.refreshes -- $LINENO" | xargs)" != 'Disabled' ]
-do
+for _ in $(seq 1 60); do
+    if [ "$($CLICKHOUSE_CLIENT -q "select status from ${db}.refreshes -- $LINENO" | xargs)" = 'Disabled' ]; then
+        break
+    fi
     sleep 0.5
 done
 $CLICKHOUSE_CLIENT -q "select '<2: stopped>', status from ${db}.refreshes"
@@ -58,5 +68,3 @@ done
 
 $CLICKHOUSE_CLIENT -q "select '<3: restarted>', status != 'Disabled' from ${db}.refreshes"
 $CLICKHOUSE_CLIENT -q "select '<4: new rows>', count() > $cnt_before from ${db}.rmv"
-
-$CLICKHOUSE_CLIENT --distributed_ddl_output_mode=none -q "drop database $db"


### PR DESCRIPTION
The ZooKeeper watch callback used by `RefreshTask` only reset `root_watch_active` but not `children_watch_active`. Since both `existsWatch` and `getChildrenWatch` share the same one-shot callback, the children watch was never re-registered after firing once.

This meant that after `SYSTEM STOP REPLICATED VIEW` created the "/paused" child znode (consuming the children watch), a subsequent `SYSTEM START REPLICATED VIEW` that removed it could not wake up the task — the `existsWatch` does not fire for child changes, and `getChildrenWatch` was stale.

Closes https://github.com/ClickHouse/ClickHouse/issues/98796

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `SYSTEM START REPLICATED VIEW` not waking up the refresh task

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Keeper watch re-registration for coordinated refreshable materialized views; while the change is small, it affects distributed start/stop behavior and could impact refresh scheduling across replicas.
> 
> **Overview**
> Fixes a coordination bug where a replicated refreshable materialized view could stay *Disabled* after `SYSTEM START REPLICATED VIEW` because the one-shot Keeper children watch was never re-armed.
> 
> The refresh-task watch callback now resets both `root_watch_active` and `children_watch_active` so `getChildrenWatch` is re-registered after firing. Adds a ZooKeeper-backed stateless regression test (`04027_system_start_replicated_view`) that stops a replicated view, starts it again, and asserts refreshes resume and new rows appear.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c599653f790cd8ca95d46b7aa9a39c462e17cc2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.433`
- Backported to: `26.2.5.4`, `26.1.5.13`, `25.12.9.17`
<!-- ch-version-info:end -->