### PR TITLE
Disable 03237_insert_sparse_columns_mem under debug and sanitizers

### DIFF
--- a/tests/queries/0_stateless/03237_insert_sparse_columns_mem.sh
+++ b/tests/queries/0_stateless/03237_insert_sparse_columns_mem.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, long, no-azure-blob-storage
+# Tags: no-fasttest, long, no-azure-blob-storage, no-debug, no-asan, no-tsan, no-msan, no-ubsan
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
## Summary

- Disable `03237_insert_sparse_columns_mem` under debug and sanitizer builds to fix CI timeouts
- The test creates 250 columns and with randomized `min_bytes_for_wide_part = 0` forcing wide parts on S3 storage, it creates 250+ S3 PUT operations per part per INSERT, which is too slow in debug/sanitizer builds
- CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=09ee7799763cd06a72debdc3bb0424a61a9abc90&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_debug%2C%20distributed%20plan%2C%20s3%20storage%2C%20parallel%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts test `Tags` to stop running a slow stateless test in debug/ASan/TSan/MSan/UBSan builds; no production code changes.
> 
> **Overview**
> Marks `03237_insert_sparse_columns_mem.sh` as ineligible for debug and sanitizer builds by adding `no-debug`, `no-asan`, `no-tsan`, `no-msan`, and `no-ubsan` tags, reducing CI timeouts from this heavy S3/column-count test.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 80edf2e1a67df6afea249f10305911bf95680939. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.420`
<!-- ch-version-info:end -->