### PR TITLE
Make S3Queue batch size halving global to fix flaky test

### DIFF
--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
@@ -398,7 +398,7 @@ StorageObjectStorageQueue::StorageObjectStorageQueue(
         auto task = getContext()->getSchedulePool().createTask(getStorageID(), "ObjectStorageQueueStreamingTask", [this, i]{ threadFunc(i); });
         streaming_tasks.emplace_back(std::move(task));
     }
-    max_files_override_per_task.resize(task_count, 0);
+    max_files_override = 0;
 }
 
 void StorageObjectStorageQueue::startup()
@@ -872,10 +872,12 @@ bool StorageObjectStorageQueue::streamToViews(size_t streaming_tasks_index)
     LOG_TEST(log, "Using {} processing threads (processing_threads_num: {}, parallel_inserts: {}, async deduplicate: {})",
         threads, processing_threads_num, parallel_inserts, is_deduplication_v2);
 
-    size_t & effective_max_files = max_files_override_per_task[streaming_tasks_index];
-
     while (!shutdown_called && !file_iterator->isFinished())
     {
+        /// All tasks share a single batch size override so that the halving
+        /// converges regardless of which task encounters the bad file.
+        auto effective_max_files = max_files_override.load();
+
         /// FIXME:
         /// it is possible that MV is dropped just before we start the insert,
         /// but in this case we would not throw any exception, so
@@ -958,10 +960,12 @@ bool StorageObjectStorageQueue::streamToViews(size_t streaming_tasks_index)
 
                 file_iterator->releaseFinishedBuckets();
 
-                /// Halve the batch size so that on the next iteration the bad file
+                /// Halve the global batch size so that on the next iteration the bad file
                 /// ends up in a smaller batch, eventually alone (batch size 1),
                 /// and only then its retry count will be reduced.
-                size_t current_max = effective_max_files;
+                /// The override is shared across all tasks so that the halving converges
+                /// regardless of which task encounters the bad file.
+                size_t current_max = max_files_override.load();
                 if (!current_max)
                 {
                     std::lock_guard lock(mutex);
@@ -969,7 +973,7 @@ bool StorageObjectStorageQueue::streamToViews(size_t streaming_tasks_index)
                 }
                 if (!current_max)
                     current_max = processing_progress->processed_files.load();
-                effective_max_files = std::max<size_t>(current_max / 2, 1);
+                max_files_override = std::max<size_t>(current_max / 2, 1);
             }
             catch (Exception & e)
             {
@@ -977,11 +981,7 @@ bool StorageObjectStorageQueue::streamToViews(size_t streaming_tasks_index)
                 throw;
             }
 
-            /// Continue processing the remaining files from the iterator
-            /// instead of re-throwing and waiting for a reschedule.
-            /// The failed batch was already committed with proper handling
-            /// (good files reset for retry, bad files marked appropriately).
-            continue;
+            throw;
         }
 
         fiu_do_on(FailPoints::object_storage_queue_fail_after_insert, {
@@ -990,7 +990,7 @@ bool StorageObjectStorageQueue::streamToViews(size_t streaming_tasks_index)
 
         commit(/*insert_succeeded=*/ true, rows, sources, transaction_start_time);
         file_iterator->releaseFinishedBuckets();
-        effective_max_files = 0;
+        max_files_override = 0;
         total_rows += rows;
     }
 

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
@@ -976,7 +976,12 @@ bool StorageObjectStorageQueue::streamToViews(size_t streaming_tasks_index)
                 e.addMessage("Previous exception: {}", message);
                 throw;
             }
-            throw;
+
+            /// Continue processing the remaining files from the iterator
+            /// instead of re-throwing and waiting for a reschedule.
+            /// The failed batch was already committed with proper handling
+            /// (good files reset for retry, bad files marked appropriately).
+            continue;
         }
 
         fiu_do_on(FailPoints::object_storage_queue_fail_after_insert, {

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.h
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.h
@@ -134,7 +134,7 @@ private:
     mutable std::mutex streaming_mutex;
     std::shared_ptr<StorageObjectStorageQueue::FileIterator> streaming_file_iterator;
     std::vector<BackgroundSchedulePoolTaskHolder> streaming_tasks;
-    std::vector<size_t> max_files_override_per_task;
+    std::atomic<size_t> max_files_override{0};
 
     LoggerPtr log;
 

--- a/tests/integration/test_storage_s3_queue/test_parallel_inserts.py
+++ b/tests/integration/test_storage_s3_queue/test_parallel_inserts.py
@@ -43,7 +43,7 @@ def started_cluster():
         cluster.shutdown()
 
 
-def run_with_retry(check_result, func, retries=100):
+def run_with_retry(check_result, func, retries=300):
     for _ in range(retries):
         last = func()
         if check_result(last):


### PR DESCRIPTION
## Summary
- The per-task batch halving in S3Queue `streamToViews` didn't converge with many streaming tasks (16 in the test). Different tasks encountered the bad file each time, each halving once and then resetting on the next successful batch. No single task ever reached batch size 1 to isolate the bad file.
- Replace `std::vector<size_t> max_files_override_per_task` with a single `std::atomic<size_t> max_files_override` shared across all tasks. When ANY task encounters a batch failure, ALL tasks see the halved batch size on their next iteration.
- Also increase `run_with_retry` default retries from 100 to 300 for additional MSan robustness.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=c90fedd0932aea5f5c4b4ed1a353b1255df9c759&name_0=MasterCI&name_1=Integration%20tests%20%28amd_msan%2C%206%2F6%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches concurrent error-handling logic in `StorageObjectStorageQueue::streamToViews`, which can change batching/throughput behavior under failures. Uses an atomic shared override, so concurrency semantics are improved but should be validated under load and repeated failures.
> 
> **Overview**
> Makes S3/Azure Queue streaming **batch-size backoff global**: replaces per-streaming-task `max_files_override_per_task` with a single `std::atomic<size_t> max_files_override` so any task’s failed insert halves the next batch size for all tasks until a successful commit resets it.
> 
> Also increases integration-test `run_with_retry` retries from `100` to `300` to reduce flakiness in the parallel-inserts failure scenario (notably under MSan).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba18e2cc4746c61c13dee82ac593a097f518da5e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.439`
<!-- ch-version-info:end -->