### PR TITLE
ci: switch all tests to azurite-rs

### DIFF
--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -245,18 +245,6 @@ def main():
         print(f"Rerun count set to 5 for targeted check")
         rerun_count = 5
 
-    if not info.is_local_run:
-        # TODO: find a way to work with Azure secret so it's ok for local tests as well, for now keep azure disabled
-        azure_connection_string = Shell.get_output(
-            f"aws ssm get-parameter --region us-east-1 --name azure_connection_string --with-decryption --output text --query Parameter.Value",
-            verbose=True,
-            strict=True,
-        )
-        os.environ["AZURE_CONNECTION_STRING"] = azure_connection_string
-    else:
-        print("Disable azure for a local run")
-        config_installs_args += " --no-azure"
-
     if (is_azure_storage or is_s3_storage) and is_encrypted_storage:
         config_installs_args += " --encrypted-storage"
         runner_options += f" --encrypted-storage"

--- a/ci/jobs/stress_job.py
+++ b/ci/jobs/stress_job.py
@@ -14,18 +14,6 @@ from ci.praktika.result import Result
 from ci.praktika.utils import Shell, Utils
 
 
-class SensitiveFormatter(logging.Formatter):
-    @staticmethod
-    def _filter(s):
-        return re.sub(
-            r"(.*)(AZURE_CONNECTION_STRING.*\')(.*)", r"\1AZURE_CONNECTION_STRING\3", s
-        )
-
-    def format(self, record):
-        original = logging.Formatter.format(self, record)
-        return self._filter(original)
-
-
 def read_test_results(results_path: Path, with_raw_logs: bool = True):
     results = []
     with open(results_path, "r", encoding="utf-8") as descriptor:
@@ -62,13 +50,6 @@ def get_additional_envs(info, check_name: str) -> List[str]:
     from ci.jobs.ci_utils import is_extended_run
 
     result = []
-    if not info.is_local_run:
-        azure_connection_string = Shell.get_output(
-            f"aws ssm get-parameter --region us-east-1 --name azure_connection_string --with-decryption --output text --query Parameter.Value",
-            verbose=True,
-            strict=True,
-        )
-        result.append(f"AZURE_CONNECTION_STRING='{azure_connection_string}'")
     # some cloud-specific features require feature flags enabled
     # so we need this ENV to be able to disable the randomization
     # of feature flags
@@ -156,9 +137,6 @@ def process_results(
 def run_stress_test(upgrade_check: bool = False) -> None:
     info = Info()
     logging.basicConfig(level=logging.INFO)
-    for handler in logging.root.handlers:
-        # pylint: disable=protected-access
-        handler.setFormatter(SensitiveFormatter(handler.formatter._fmt))  # type: ignore
 
     stopwatch = Utils.Stopwatch()
     temp_path = Path(Utils.cwd()) / "ci/tmp"

--- a/tests/config/config.d/azure_storage_conf.xml
+++ b/tests/config/config.d/azure_storage_conf.xml
@@ -6,8 +6,8 @@
                 <object_storage_type>azure</object_storage_type>
                 <skip_access_check>false</skip_access_check>
                 <max_single_part_upload_size>33554432</max_single_part_upload_size>
-                <container_name>openbucketforpublicci</container_name>
-                <connection_string from_env="AZURE_CONNECTION_STRING"/>
+                <container_name>clickhouse-tests</container_name>
+                <connection_string>DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;</connection_string>
             </azure>
             <cached_azure>
                 <type>cache</type>

--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -345,7 +345,7 @@ elif [[ "$USE_AZURE_STORAGE_FOR_MERGE_TREE" == "1" ]]; then
 fi
 
 if [[ "$EXPORT_S3_STORAGE_POLICIES" == "1" ]]; then
-    if [[ "$NO_AZURE" != "1" ]] && [[ -n "$AZURE_CONNECTION_STRING" ]]; then
+    if [[ "$NO_AZURE" != "1" ]]; then
         ln -sf $SRC_PATH/config.d/azure_storage_conf.xml $DEST_SERVER_PATH/config.d/
     fi
 


### PR DESCRIPTION
_Interesting, will it work?_

Sometimes real azure can give 503 errors [1], plus it is not possible to run tests locally.

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=98776&sha=e98e65358583dbe10ac317de0aa9aca927d58213&name_0=PR&name_1=Stateless%20tests%20%28arm_asan%2C%20azure%2C%20parallel%29
https://github.com/ClickHouse/ClickHouse/pull/98776

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how Azure-backed test configurations are provisioned (removing SSM secrets/env wiring) and could break Azure storage test coverage if the emulator diverges from real Azure behavior.
> 
> **Overview**
> **Moves Azure-related CI tests to `azurite-rs` instead of real Azure storage.** The functional and stress CI jobs stop fetching `AZURE_CONNECTION_STRING` from AWS SSM and no longer inject/scrub that secret in logs.
> 
> Azure storage test config is updated to use a fixed local emulator connection string and a new container (`clickhouse-tests`), and `tests/config/install.sh` now installs `azure_storage_conf.xml` whenever Azure isn’t explicitly disabled (no longer gated on `AZURE_CONNECTION_STRING` being set).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de39a4381365457af7c9500cb9f2238e11adac36. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->