### PR TITLE
Fix adjusting RLIMIT_SIGPENDING (via pending_signals)

### DIFF
--- a/src/Daemon/BaseDaemon.cpp
+++ b/src/Daemon/BaseDaemon.cpp
@@ -283,10 +283,23 @@ void BaseDaemon::initialize(Application & self)
         struct rlimit rlim;
         if (getrlimit(RLIMIT_SIGPENDING, &rlim))
             throw Poco::Exception("Cannot getrlimit");
-        rlim.rlim_cur = pending_signals;
-        if (setrlimit(RLIMIT_SIGPENDING, &rlim))
+
+        /// Only adjust if the current soft limit is below the requested value.
+        if (rlim.rlim_cur < pending_signals)
         {
-            std::cerr << "Cannot set pending signals to " + std::to_string(rlim.rlim_cur) << std::endl;
+            rlim_t old_cur = rlim.rlim_cur;
+            rlim_t old_max = rlim.rlim_max;
+
+            /// Raise hard limit only if needed (requires CAP_SYS_RESOURCE).
+            /// (Note it is "unlimited" compatible, since it is rlim_t(-1))
+            rlim.rlim_max = std::max<rlim_t>(rlim.rlim_max, pending_signals);
+
+            rlim.rlim_cur = pending_signals;
+
+            if (setrlimit(RLIMIT_SIGPENDING, &rlim))
+                std::cerr << "Cannot set RLIMIT_SIGPENDING (soft=" << old_cur << ", hard=" << old_max << ") to " << pending_signals << std::endl;
+            else
+                std::cerr << "Set RLIMIT_SIGPENDING from (soft=" << old_cur << ", hard=" << old_max << ") to " << pending_signals << std::endl;
         }
     }
 #endif


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix adjusting RLIMIT_SIGPENDING (via pending_signals)

You cannot set rlim_cur > rlim_max, even with CAP_SYS_RESOURCE, and usually you have both set to some value.

Fixes: https://github.com/ClickHouse/ClickHouse/pull/86760


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Change is limited to Linux daemon initialization and only affects processes that configure `pending_signals`. Risk is low but could alter startup behavior/logging on systems where raising the hard limit is not permitted.
> 
> **Overview**
> Fixes how `pending_signals` adjusts Linux `RLIMIT_SIGPENDING` during daemon startup.
> 
> The code now *only* calls `setrlimit` when the current soft limit is below the requested value, and raises the hard limit first (to at least the requested value) to avoid invalid `rlim_cur > rlim_max` failures; it also logs the old/new soft+hard limits to `stderr` on success or failure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41d5761f9f7f1d3fc901ba62cf56b5279dccdd80. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Backported to: `26.2.5.5`, `26.1.5.14`, `25.12.9.19`
<!-- ch-version-info:end -->