### PR TITLE
temporary turn check for `async_insert` off

### DIFF
--- a/tests/docker_scripts/upgrade_runner.sh
+++ b/tests/docker_scripts/upgrade_runner.sh
@@ -157,7 +157,7 @@ then
       old_settings.value AS old_value
   FROM new_settings
   LEFT JOIN old_settings ON new_settings.name = old_settings.name
-  WHERE (old_value IS NULL OR new_value != old_value)
+  WHERE (old_value IS NULL OR new_value != old_value) AND name != 'async_insert'
       AND (name NOT IN (
       SELECT arrayJoin(tupleElement(changes, 'name'))
       FROM


### PR DESCRIPTION
In order not to bring noise to the CI 
I temporary mute the upgrade check for setting `async_insert`. 

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only tweaks the upgrade CI script to suppress noise from a single setting comparison, without affecting production code paths.
> 
> **Overview**
> The upgrade CI runner no longer flags `async_insert` as a changed/unknown session setting when comparing `system.settings` between the previous release and the new build.
> 
> This temporarily silences failures/noise from the settings-change-history check by excluding `async_insert` from the diff written to `changed_settings.txt`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c3aff3cf9aba6420240d8fdf7726f022c0b6af50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.435`
<!-- ch-version-info:end -->