### PR TITLE
Include job name in Praktika container name, fail if already running

### DIFF
--- a/ci/praktika/job.py
+++ b/ci/praktika/job.py
@@ -270,7 +270,7 @@ class Job:
                 container_name = (
                     "praktika_"
                     + hashlib.sha1(
-                        Path(os.getcwd()).resolve().as_posix().encode()
+                        (Path(os.getcwd()).resolve().as_posix() + ":" + self.name).encode()
                     ).hexdigest()[:12]
                 )
                 self.timeout_shell_cleanup = f"docker rm -f {container_name}"

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -314,15 +314,18 @@ class Runner:
 
             docker = docker or f"{docker_name}:{docker_tag}"
             current_dir = os.getcwd()
-            # Use a hash of the real worktree path as container name so
-            # multiple worktrees can run tests in parallel without conflicts.
-            # The same path always produces the same name, allowing cleanup.
+            # Derive a stable container name from the worktree path and job name
+            # so that different jobs (or the same job in different worktrees)
+            # never share a name, while the name is deterministic enough to
+            # allow cleanup of stale containers from previous runs.
             container_name = (
                 "praktika_"
                 + hashlib.sha1(
-                    Path(current_dir).resolve().as_posix().encode()
+                    (Path(current_dir).resolve().as_posix() + ":" + job.name).encode()
                 ).hexdigest()[:12]
             )
+            if not job.timeout_shell_cleanup:
+                job.timeout_shell_cleanup = f"docker rm -f {container_name}"
             workdir = f"--workdir={current_dir}"
             for setting in settings:
                 if setting.startswith("--volume"):
@@ -337,13 +340,25 @@ class Runner:
                         f"NOTE: Job [{job.name}] use custom workdir - praktika won't control workdir"
                     )
                     workdir = ""
-            if not Shell.check(
-                f"if docker ps -a --format '{{{{.Names}}}}' | grep -qx {container_name}; then docker rm -f {container_name}; fi",
-                verbose=True,
+            if Shell.check(
+                f"docker ps --format '{{{{.Names}}}}' | grep -qx {container_name}",
+                verbose=False,
             ):
                 raise RuntimeError(
-                    f"Failed to remove existing docker container '{container_name}'"
+                    f"Docker container '{container_name}' is already running. "
+                    f"Another instance of job [{job.name}] may be active in this worktree."
                 )
+            if Shell.check(
+                f"docker ps -a --format '{{{{.Names}}}}' | grep -qx {container_name}",
+                verbose=False,
+            ):
+                print(
+                    f"Found stopped container '{container_name}' from a previous run — removing it"
+                )
+                if not Shell.check(f"docker rm {container_name}", verbose=True):
+                    raise RuntimeError(
+                        f"Failed to remove stopped container '{container_name}'"
+                    )
             if job.enable_gh_auth:
                 # pass gh auth seamlessly into the docker container
                 gh_mount = "--volume ~/.config/gh:/ghconfig -e GH_CONFIG_DIR=/ghconfig"


### PR DESCRIPTION
## Summary

Follow-up to #98610, addressing the [review comment](https://github.com/ClickHouse/ClickHouse/pull/98610#issuecomment-4001834800) by @RinChanNOWWW.

Previously the Docker container name was a SHA-1 hash of the worktree path only, so two jobs running simultaneously in the same worktree (e.g. fast test + stateless) would collide on the same name.

- The container name is now a SHA-1 hash of `<resolved-worktree-path>:<job-name>`, making it unique per (worktree, job) pair while remaining fully deterministic.
- If a container with that name is **already running** → explicit error, so the user knows another instance is active.
- If a container exists but is **stopped** (stale from a previous run or timeout) → it is cleaned up automatically before starting a new one.
- `job.__post_init__` is updated to use the same naming scheme so `timeout_shell_cleanup` targets the correct container.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the container lifecycle logic used to run jobs in Docker; this can alter parallelism and failure modes (now hard-fails if the expected container name is already running) but is limited to CI runner behavior.
> 
> **Overview**
> Praktika Docker container names are now derived from a deterministic hash of `<resolved-worktree-path>:<job-name>` (instead of path-only), preventing collisions when multiple jobs run in the same worktree.
> 
> Runner startup now **fails fast** if a container with the computed name is currently running, and **auto-removes** a stopped stale container before launching; `Job.__post_init__` is updated to generate matching `timeout_shell_cleanup` so timeouts clean up the correct container.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eaa7263dbec7e8e79ca30a2477db32a4e2257d3c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.436`
<!-- ch-version-info:end -->