### PR TITLE
Fix undefined M_PIf32 and M_PIf64 constants in compression codec tests

### DIFF
--- a/src/Compression/tests/gtest_compressionCodec.cpp
+++ b/src/Compression/tests/gtest_compressionCodec.cpp
@@ -22,6 +22,7 @@
 #include <iostream>
 #include <iterator>
 #include <memory>
+#include <numbers>
 #include <typeinfo>
 #include <vector>
 
@@ -1614,8 +1615,8 @@ INSTANTIATE_TEST_SUITE_P(ALPExceptionsOnly,
         ::testing::Values(
             generateSeq<Float64>(G([](auto) { return std::numeric_limits<Float64>::quiet_NaN(); })),
             generateSeq<Float32>(G([](auto) { return std::numeric_limits<Float32>::quiet_NaN(); })),
-            generateSeq<Float64>(G([](auto) { return M_PIf64; })),
-            generateSeq<Float32>(G([](auto) { return M_PIf32; }))
+            generateSeq<Float64>(G([](auto) { return std::numbers::pi_v<double>; })),
+            generateSeq<Float32>(G([](auto) { return std::numbers::pi_v<float>; }))
         )
     )
 );


### PR DESCRIPTION
The constants `M_PIf32` and `M_PIf64` are not standard C++ constants and may not be available on all platforms after system upgrades.

Replace them with C++20 standard `std::numbers::pi_v<float>` and `std::numbers::pi_v<double>` respectively, which are portable and type-safe.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that replaces non-portable `M_PIf32`/`M_PIf64` usage with standard C++20 `std::numbers::pi_v`, reducing platform-dependent build failures.
> 
> **Overview**
> Updates the compression codec gtests to avoid non-standard `M_PIf32`/`M_PIf64` constants by including `<numbers>` and using `std::numbers::pi_v<float>`/`std::numbers::pi_v<double>` in the `ALPExceptionsOnly` parameterized cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce813845eb185a28e0d5c80b786650ae94e41dd3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.473`
<!-- ch-version-info:end -->