### PR TITLE
Add hex address resolution to analyze-assembly.py

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -81,13 +81,14 @@ python3 .claude/tools/analyze-assembly.py <binary> "<function_name>" --perf-map 
 # Compare codegen between two builds
 python3 .claude/tools/analyze-assembly.py --before <old_binary> --after <new_binary> "<function_name>"
 
+# Analyze function at a specific address (useful for heavily-templated symbols)
+python3 .claude/tools/analyze-assembly.py <binary> 0x0dc7c780
+
 # Verbose mode to see tool commands
 python3 .claude/tools/analyze-assembly.py <binary> "<function_name>" -v
 ```
 
-Key options: `--search` for regex matching, `--fuzzy` for substring matching, `--select N` to pick from ambiguous results, `--all` to analyze all matches, `--context N` to show surrounding symbols, `--max-instructions N` to control output size, `--mca --mcpu=<model>` for llvm-mca throughput analysis, `--perf-map <file>` for runtime-weighted scoring, `--before`/`--after` for diff mode. The tool caches symbol tables by build-id for fast repeated queries.
-
-**IMPORTANT**: `--select N` does NOT imply `--search`. When using a regex pattern with `--select`, you MUST also pass `--search`, e.g. `--search --select 1`. Without `--search`, the pattern is treated as a literal exact match and will fail.
+Key options: `--search` for regex matching, `--fuzzy` for substring matching, `--select N` to pick from ambiguous results, `--all` to analyze all matches, `--context N` to show surrounding symbols, `--max-instructions N` to control output size, `--mca --mcpu=<model>` for llvm-mca throughput analysis, `--perf-map <file>` for runtime-weighted scoring, `--before`/`--after` for diff mode. Hex addresses (e.g. `0x0dc7c780`) are resolved to the enclosing symbol automatically — useful when symbol names are too long for regex matching. The tool caches symbol tables by build-id for fast repeated queries.
 
 You can build multiple versions of ClickHouse inside `build_*` directories, such as `build`, `build_debug`, `build_asan`, etc.
 

--- a/.claude/tools/analyze-assembly.py
+++ b/.claude/tools/analyze-assembly.py
@@ -916,6 +916,65 @@ def resolve_source_location(
     return matches
 
 
+def _parse_hex_address(identifier: str) -> int | None:
+    """Return integer address if identifier looks like a hex address, else None."""
+    s = identifier.strip()
+    try:
+        if s.startswith("0x") or s.startswith("0X"):
+            return int(s, 16)
+        # Also accept plain hex if it's long enough (>= 6 hex digits) to avoid
+        # matching short symbol names that happen to be valid hex.
+        if len(s) >= 6 and all(c in "0123456789abcdefABCDEF" for c in s):
+            return int(s, 16)
+    except ValueError:
+        pass
+    return None
+
+
+def resolve_by_address(
+    binary: BinaryInfo,
+    address: int,
+    tools: dict[str, ToolInfo],
+    timeout: int,
+    no_cache: bool,
+    rebuild_cache: bool,
+    stats: RunStats,
+) -> list[SymbolCandidate]:
+    """Find the symbol that contains the given address."""
+    raw_lines, dem_lines = _load_symbol_lines(
+        binary, tools, timeout, no_cache, rebuild_cache, stats,
+    )
+    all_candidates = _parse_symbol_candidates(raw_lines, dem_lines)
+    # all_candidates is sorted by address
+    # Find the symbol whose [address, address+size) contains the target
+    best: SymbolCandidate | None = None
+    for c in all_candidates:
+        if c.address <= address < c.address + c.size:
+            # Prefer the tightest enclosing symbol
+            if best is None or c.size < best.size:
+                best = c
+        elif c.address > address:
+            break
+    if best is not None:
+        offset = address - best.address
+        verbose(f"address 0x{address:x} resolved to `{best.demangled}` +0x{offset:x}")
+        return [best]
+    # No enclosing symbol found — create a synthetic candidate using the next
+    # symbol to bound the range
+    for c in all_candidates:
+        if c.address > address:
+            size = c.address - address
+            verbose(f"address 0x{address:x}: no enclosing symbol, using {size} bytes until next symbol")
+            return [SymbolCandidate(
+                mangled=f"<0x{address:x}>",
+                demangled=f"<0x{address:x}>",
+                address=address,
+                size=size,
+            )]
+    verbose(f"address 0x{address:x}: no symbol found")
+    return []
+
+
 def resolve_identifier_candidates(
     binary: BinaryInfo,
     identifier: str,
@@ -928,6 +987,12 @@ def resolve_identifier_candidates(
     rebuild_cache: bool,
     stats: RunStats,
 ) -> list[SymbolCandidate]:
+    # Check for hex address before other resolution methods
+    addr = _parse_hex_address(identifier)
+    if addr is not None and not search_mode and not fuzzy_mode:
+        return resolve_by_address(
+            binary, addr, tools, timeout, no_cache, rebuild_cache, stats,
+        )
     if source_location and not search_mode and not fuzzy_mode:
         return resolve_source_location(
             binary,


### PR DESCRIPTION
## Summary

- The `analyze-assembly.py` tool now accepts hex addresses (e.g. `0x0dc7c780`) as identifiers
- Resolves the address to the enclosing symbol from the symbol table automatically
- Useful for heavily-templated C++ functions where demangled names are too long for regex matching — get the address from `perf report` or `llvm-nm` and pass it directly
- Updated CLAUDE.md documentation

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to a developer tooling script and only affect identifier resolution when the input looks like a hex address (and not in `--search`/`--fuzzy` modes). Potential edge case is misinterpreting long hex-like symbol names as addresses.
> 
> **Overview**
> `analyze-assembly.py` now accepts a hex address (e.g. `0x...`) as the identifier and resolves it to the tightest enclosing symbol from the binary’s symbol table before disassembly/analysis.
> 
> Adds parsing for hex-like identifiers and an address-based resolver with a fallback synthetic symbol range when no enclosing symbol is found, and updates `.claude/CLAUDE.md` to document the new address-based workflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e58cbb40c52f8e3a780b6e823daa79ceaf71ac47. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.438`
<!-- ch-version-info:end -->