### PR TITLE
Update docs/wasm_udf.md

### DIFF
--- a/docs/en/sql-reference/functions/wasm_udf.md
+++ b/docs/en/sql-reference/functions/wasm_udf.md
@@ -263,9 +263,6 @@ void clickhouse_destroy_buffer(ClickhouseBuffer * data) { /* ... */ }
 ClickhouseBuffer * user_defined_function1(ClickhouseBuffer * span, uint32_t n) { /* ... */ }
 ClickhouseBuffer * user_defined_function2(ClickhouseBuffer * span, uint32_t n) { /* ... */ }
 ```
-<!--
-
-!!! TODO: crate is not yet published
 
 ### Note for developing UDFs in Rust
 
@@ -287,14 +284,12 @@ pub fn some_udf(data: String) -> HashMap<String, String> {
 
 Macros will generate wrapper function accepting and returning buffer structures and handle serialization/deserialization automatically using `serde`.
 
--->
-
 ## Host API available to modules
 
 The following host functions may be imported and used by modules:
 
 - `clickhouse_server_version() -> i64` — returns ClickHouse server version as integer (e.g. 25011001 for v25.11.1.1).
-- `clickhouse_terminate(ptr: i32, size: i32)` — throws an error with the provided message. Accepts pointer to the memory location containing the error message string and size of the string.
+- `clickhouse_throw(ptr: i32, size: i32)` — throws an error with the provided message. Accepts pointer to the memory location containing the error message string and size of the string.
 - `clickhouse_log(ptr: i32, size: i32)` — logs a message to ClickHouse server text log.
 - `clickhouse_random(ptr: i32, size: i32)` — fills memory with random bytes.
 
@@ -302,13 +297,13 @@ The following host functions may be imported and used by modules:
 
 The following query-level settings control WebAssembly UDF execution:
 
-- `webassembly_udf_max_fuel` (UInt64, default: 100000) — Fuel limit per WebAssembly UDF instance execution. Each WebAssembly instruction consumes some amount of fuel. Set to 0 for no limit.
+- `webassembly_udf_max_fuel` — Fuel limit per WebAssembly UDF instance execution. Each WebAssembly instruction consumes some amount of fuel. Set to 0 for no limit.
 
-- `webassembly_udf_max_memory` (UInt64, default: 128_MiB) — Memory limit in bytes per WebAssembly UDF instance.
+- `webassembly_udf_max_memory` — Memory limit in bytes per WebAssembly UDF instance.
 
-- `webassembly_udf_max_input_block_size` (UInt64, default: 0) — Maximum number of rows passed to a WebAssembly UDF in a single block. Set to 0 to process all rows at once.
+- `webassembly_udf_max_input_block_size` — Maximum number of rows passed to a WebAssembly UDF in a single block. Set to 0 to process all rows at once.
 
-- `webassembly_udf_max_instances` (UInt64, default: 128) — Maximum number of WebAssembly UDF instances that can run in parallel per function.
+- `webassembly_udf_max_instances` — Maximum number of WebAssembly UDF instances that can run in parallel per function.
 
 Example usage:
 
@@ -316,7 +311,6 @@ Example usage:
 SET webassembly_udf_max_fuel = 200000;
 SELECT my_wasm_udf(column) FROM table;
 ```
-
 
 ## See also
 


### PR DESCRIPTION
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; primary risk is minor user confusion if removed defaults/types differ from current behavior.
> 
> **Overview**
> Updates the WebAssembly UDF docs to **unhide the Rust helper-crate guidance** (including an example using `clickhouse-wasm-udf`) and removes the outdated “crate not yet published” note.
> 
> Refreshes the Host API and settings sections by documenting `clickhouse_throw` (instead of `clickhouse_terminate`) and **simplifying** the `webassembly_udf_*` setting descriptions by dropping the explicit type/default annotations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17b7cc516e1c5936adb13958e060242d082b0c51. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->