### PR TITLE
[Draft] "user_query_log" view.

### DIFF
--- a/cmake/tools.cmake
+++ b/cmake/tools.cmake
@@ -13,7 +13,7 @@ execute_process(COMMAND ${CMAKE_CXX_COMPILER} --version --target=${CMAKE_CXX_COM
 message (STATUS "Using compiler:\n${COMPILER_SELF_IDENTIFICATION}")
 
 # Require minimum compiler versions
-set (CLANG_MINIMUM_VERSION 21)
+set (CLANG_MINIMUM_VERSION 20)
 if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS ${CLANG_MINIMUM_VERSION})
     message (FATAL_ERROR "Compilation with Clang version ${CMAKE_CXX_COMPILER_VERSION} is unsupported, the minimum required version is ${CLANG_MINIMUM_VERSION}.")
 endif ()

--- a/contrib/corrosion-cmake/CMakeLists.txt
+++ b/contrib/corrosion-cmake/CMakeLists.txt
@@ -35,7 +35,9 @@ endmacro()
 
 # Keep in sync with toolchain in docker images
 # (must be called before find_package(Rust) and inclusion of Corrosion.cmake)
-set(Rust_TOOLCHAIN "nightly-2025-07-07")
+# set(Rust_TOOLCHAIN "nightly-2025-07-07")
+set(Rust_FIND_QUIETLY TRUE)
+set(ENABLE_RUST FALSE)
 
 macro(find_rust)
     set_rust_target()

--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -18,7 +18,7 @@
 #include <Databases/DatabaseAtomic.h>
 #include <Databases/DatabaseOverlay.h>
 #include <Storages/System/attachSystemTables.h>
-#include <Storages/System/attachInformationSchemaTables.h>
+#include <Storages/System/attachViews.h>
 #include <Interpreters/DatabaseCatalog.h>
 #include <Interpreters/JIT/CompiledExpressionCache.h>
 #include <Interpreters/ProcessList.h>

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -85,7 +85,7 @@
 #include <Storages/MergeTree/MergeTreeBackgroundExecutor.h>
 #include <Storages/MergeTree/MergeTreeSettings.h>
 #include <Storages/System/attachSystemTables.h>
-#include <Storages/System/attachInformationSchemaTables.h>
+#include <Storages/System/attachViews.h>
 #include <Storages/Cache/registerRemoteFileMetadatas.h>
 #include <AggregateFunctions/registerAggregateFunctions.h>
 #include <Functions/UserDefined/IUserDefinedSQLObjectsStorage.h>

--- a/src/Storages/System/attachSystemTables.cpp
+++ b/src/Storages/System/attachSystemTables.cpp
@@ -6,6 +6,7 @@
 #include <Storages/System/attachSystemTables.h>
 #include <Storages/System/attachSystemTablesImpl.h>
 
+#include <Storages/System/attachViews.h>
 #include <Storages/System/StorageSystemAggregateFunctionCombinators.h>
 #include <Storages/System/StorageSystemAsynchronousMetrics.h>
 #include <Storages/System/StorageSystemAsyncLoader.h>
@@ -143,7 +144,7 @@
 namespace DB
 {
 
-void attachSystemTablesServer(ContextPtr context, IDatabase & system_database, bool has_zookeeper)
+void attachSystemTablesServer(ContextMutablePtr context, IDatabase & system_database, bool has_zookeeper)
 {
     auto component_guard = Coordination::setCurrentComponent("attachSystemTablesServer");
     attachNoDescription<StorageSystemOne>(context, system_database, "one", "This table contains a single row with a single dummy UInt8 column containing the value 0. Used when the table is not specified explicitly, for example in queries like `SELECT 1`.");
@@ -293,6 +294,8 @@ void attachSystemTablesServer(ContextPtr context, IDatabase & system_database, b
         attach<StorageSystemWasmModules>(context, system_database, "webassembly_modules", "Allows to load Webassembly modules into ClickHouse to create User Defined Functions from them.",
             context->getWasmModuleManager());
     }
+
+    attachSystemViews(context, system_database);
 }
 
 void attachSystemTablesAsync(ContextPtr context, IDatabase & system_database, AsynchronousMetrics & async_metrics)

--- a/src/Storages/System/attachSystemTables.h
+++ b/src/Storages/System/attachSystemTables.h
@@ -9,7 +9,7 @@ namespace DB
 class AsynchronousMetrics;
 class IDatabase;
 
-void attachSystemTablesServer(ContextPtr context, IDatabase & system_database, bool has_zookeeper);
+void attachSystemTablesServer(ContextMutablePtr context, IDatabase & system_database, bool has_zookeeper);
 void attachSystemTablesAsync(ContextPtr context, IDatabase & system_database, AsynchronousMetrics & async_metrics);
 
 }

--- a/src/Storages/System/attachViews.cpp
+++ b/src/Storages/System/attachViews.cpp
@@ -1,8 +1,10 @@
 #include <Databases/DatabaseOnDisk.h>
-#include <Storages/System/attachInformationSchemaTables.h>
-#include <Storages/System/attachSystemTablesImpl.h>
+#include <Storages/System/attachViews.h>
+
 #include <Parsers/ParserCreateQuery.h>
 #include <Parsers/parseQuery.h>
+#include <Storages/System/attachSystemTablesImpl.h>
+#include "Interpreters/SystemLog.h"
 
 
 namespace DB
@@ -517,17 +519,22 @@ static constexpr std::string_view collations = R"(
     FROM system.collations
 )";
 
+static constexpr std::string_view system_user_query_log = R"(
+    ATTACH VIEW user_query_log
+    (
+        hostname String,
+        current_database String,
+        query String
+    )
+    AS SELECT hostname, current_database, query FROM system.query_log PREWHERE user = currentUser()
+)";
+
 /// View structures are taken from http://www.contrib.andrew.cmu.edu/~shadow/sql/sql1992.txt
 
-static void createInformationSchemaView(ContextMutablePtr context, IDatabase & database, const String & view_name, std::string_view query)
+static void createView(ContextMutablePtr context, IDatabase & database, const String & view_name, std::string_view query, const bool is_system_db = false)
 {
     try
     {
-        assert(database.getDatabaseName() == DatabaseCatalog::INFORMATION_SCHEMA ||
-               database.getDatabaseName() == DatabaseCatalog::INFORMATION_SCHEMA_UPPERCASE);
-        if (database.getEngineName() != "Memory")
-            return;
-
         String metadata_resource_name = view_name + ".sql";
         if (query.empty())
             return;
@@ -542,6 +549,12 @@ static void createInformationSchemaView(ContextMutablePtr context, IDatabase & d
         ast_create.attach = false;
         ast_create.setDatabase(database.getDatabaseName());
 
+        if (is_system_db)
+        {
+            ast_create.uuid = UUIDHelpers::makeUUIDv4FromHash({query.data(), query.size()});
+            DatabaseCatalog::instance().addUUIDMapping(ast_create.uuid);
+        }
+
         StoragePtr view = createTableFromAST(ast_create, database.getDatabaseName(),
                                              database.getTableDataPath(ast_create), context, LoadingStrictnessLevel::FORCE_RESTORE).second;
         database.createTable(context, ast_create.getTable(), view, ast);
@@ -551,8 +564,10 @@ static void createInformationSchemaView(ContextMutablePtr context, IDatabase & d
         StoragePtr view_upper = createTableFromAST(ast_create_upper, database.getDatabaseName(),
                                              database.getTableDataPath(ast_create_upper), context, LoadingStrictnessLevel::FORCE_RESTORE).second;
 
-        database.createTable(context, ast_create_upper.getTable(), view_upper, ast_upper);
-
+        if (!is_system_db)
+        {
+            database.createTable(context, ast_create_upper.getTable(), view_upper, ast_upper);
+        }
     }
     catch (...)
     {
@@ -562,16 +577,27 @@ static void createInformationSchemaView(ContextMutablePtr context, IDatabase & d
 
 void attachInformationSchema(ContextMutablePtr context, IDatabase & information_schema_database)
 {
-    createInformationSchemaView(context, information_schema_database, "schemata", schemata);
-    createInformationSchemaView(context, information_schema_database, "tables", tables);
-    createInformationSchemaView(context, information_schema_database, "views", views);
-    createInformationSchemaView(context, information_schema_database, "columns", columns);
-    createInformationSchemaView(context, information_schema_database, "key_column_usage", key_column_usage);
-    createInformationSchemaView(context, information_schema_database, "referential_constraints", referential_constraints);
-    createInformationSchemaView(context, information_schema_database, "statistics", statistics);
-    createInformationSchemaView(context, information_schema_database, "engines", engines);
-    createInformationSchemaView(context, information_schema_database, "character_sets", character_sets);
-    createInformationSchemaView(context, information_schema_database, "collations", collations);
+    assert(information_schema_database.getDatabaseName() == DatabaseCatalog::INFORMATION_SCHEMA ||
+              information_schema_database.getDatabaseName() == DatabaseCatalog::INFORMATION_SCHEMA_UPPERCASE);
+    if (information_schema_database.getEngineName() != "Memory")
+        return;
+
+    createView(context, information_schema_database, "schemata", schemata);
+    createView(context, information_schema_database, "tables", tables);
+    createView(context, information_schema_database, "views", views);
+    createView(context, information_schema_database, "columns", columns);
+    createView(context, information_schema_database, "key_column_usage", key_column_usage);
+    createView(context, information_schema_database, "referential_constraints", referential_constraints);
+    createView(context, information_schema_database, "statistics", statistics);
+    createView(context, information_schema_database, "engines", engines);
+    createView(context, information_schema_database, "character_sets", character_sets);
+    createView(context, information_schema_database, "collations", collations);
+}
+
+void attachSystemViews(ContextMutablePtr context, IDatabase & system_database)
+{
+    assert(system_database.getDatabaseName() == DatabaseCatalog::SYSTEM_DATABASE);
+    createView(context, system_database, "user_query_log", system_user_query_log, true /*is_system_db=*/);
 }
 
 }

--- a/src/Storages/System/attachViews.h
+++ b/src/Storages/System/attachViews.h
@@ -7,5 +7,6 @@ namespace DB
 class IDatabase;
 
 void attachInformationSchema(ContextMutablePtr context, IDatabase & information_schema_database);
+void attachSystemViews(ContextMutablePtr context, IDatabase & system_database);
 
 }

--- a/tests/queries/0_stateless/01161_information_schema.reference
+++ b/tests/queries/0_stateless/01161_information_schema.reference
@@ -72,3 +72,5 @@ def	default	PRIMARY	def	default	kcu2	u	1	\N	\N	\N	\N	def	default	PRIMARY	def	def
 -- information_schema.statistics
 1
 1
+-- system.user_query_log
+1

--- a/tests/queries/0_stateless/01161_information_schema.sql
+++ b/tests/queries/0_stateless/01161_information_schema.sql
@@ -49,6 +49,9 @@ SELECT count() FROM information_schema.TABLES WHERE table_schema = currentDataba
 SELECT count() FROM INFORMATION_SCHEMA.tables WHERE table_schema = currentDatabase() AND table_name = 't';
 SELECT count() FROM information_schema.taBLES WHERE table_schema  =currentDatabase() AND table_name = 't'; -- { serverError UNKNOWN_TABLE }
 
+SELECT '-- system.user_query_log';
+SELECT count(*) > 10 FROM system.user_query_log;
+
 DROP VIEW mv;
 DROP VIEW v;
 DROP TABLE t;


### PR DESCRIPTION
Resolves #82539

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core system-log initialization/creation paths (including switching `SystemLog` to `ContextMutablePtr` and adding view-backed log handling), which could affect startup and log table availability. Also changes build defaults by disabling Rust integration and lowering the minimum supported Clang version.
> 
> **Overview**
> Adds a new `system.user_query_log` system log that is implemented as a **view over** `system.query_log` filtered to `currentUser()`, plus a `Context::getUserQueryLog()` accessor and a new `user_query_log` config section in `config.xml`.
> 
> Updates the system-log framework to better support non-table logs by introducing `SystemLog::isView()` and skipping `prepareTable()` for views, and switches `SystemLog`/`SystemLogs` constructors to use `ContextMutablePtr` (with a few signature updates in derived logs). `QueryLog` is now forced to be prepared at startup to ensure the view can be created.
> 
> Build/config tweaks: lowers the minimum Clang requirement from 21 to 20, and disables Rust support by default in `corrosion-cmake` (quieting Rust discovery).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83775f6fef234fd68d60a01af16812038c683f17. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->