### PR TITLE
Fix LOGICAL_ERROR in mergeTreeAnalyzeIndexes() when the part is not literal

### DIFF
--- a/src/TableFunctions/TableFunctionMergeTreeAnalyzeIndexes.cpp
+++ b/src/TableFunctions/TableFunctionMergeTreeAnalyzeIndexes.cpp
@@ -39,7 +39,7 @@ namespace ErrorCodes
 
 /// Both `['a', 'b']` and `array('a', 'b')` are parsed as `_CAST(['a', 'b'], 'Array(String)')` with analyzer.
 /// While for non-analyzer there is no _CAST
-std::vector<String> extractParts(const ASTPtr & argument)
+std::vector<String> extractParts(const ASTPtr & argument, const ContextPtr & context)
 {
     ASTPtr array = argument;
     if (const auto * func = array->as<ASTFunction>())
@@ -66,7 +66,7 @@ std::vector<String> extractParts(const ASTPtr & argument)
         {
             std::vector<String> result;
             for (const auto & element : expr_list->children)
-                result.push_back(element->as<ASTLiteral &>().value.safeGet<String>());
+                result.push_back(evaluateConstantExpressionAsLiteral(element, context)->as<ASTLiteral &>().value.safeGet<String>());
             return result;
         }
     }
@@ -153,7 +153,7 @@ void TableFunctionMergeTreeAnalyzeIndexes::parseArgumentsUUID(const ASTs & args_
         predicate = args[1]->clone();
 
     if (args.size() > 2)
-        parts = extractParts(args[2]);
+        parts = extractParts(args[2], context);
 
     if (args.size() > 3)
         parseArgumentsForOptimizations(args, context);
@@ -178,7 +178,7 @@ void TableFunctionMergeTreeAnalyzeIndexes::parseArgumentsDatabaseTable(const AST
         predicate = args[2]->clone();
 
     if (args.size() > 3)
-        parts = extractParts(args[3]);
+        parts = extractParts(args[3], context);
 
     if (args.size() > 3)
         parseArgumentsForOptimizations(args, context);

--- a/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexes.reference
+++ b/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexes.reference
@@ -24,3 +24,5 @@ all_1_1_0	[(1,2)]
 -- Set
 select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, key in (8193, 16385));
 all_1_1_0	[(1,3)]
+-- Corner cases
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, key = 8193, [materialize('all_1_1_0')]); -- { serverError BAD_ARGUMENTS }

--- a/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexes.sql
+++ b/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexes.sql
@@ -24,3 +24,6 @@ select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, key = 8193 and va
 
 -- Set
 select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, key in (8193, 16385));
+
+-- Corner cases
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, key = 8193, [materialize('all_1_1_0')]); -- { serverError BAD_ARGUMENTS }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix LOGICAL_ERROR in mergeTreeAnalyzeIndexes() when the part is not literal

Fixes: https://github.com/ClickHouse/ClickHouse/issues/98696 (@PedroTadim thanks for the minimified repro!)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to table-function argument parsing that mainly affects error handling/constant evaluation for the `parts_array` parameter.
> 
> **Overview**
> Fixes `mergeTreeAnalyzeIndexes`/`mergeTreeAnalyzeIndexesUUID` argument parsing so `parts_array` elements are evaluated as constant expressions (using the query `context`) instead of being assumed to be raw `ASTLiteral`s, avoiding a `LOGICAL_ERROR` on non-literal inputs.
> 
> Adds a stateless regression test covering a non-literal part expression (`[materialize('...')]`) to ensure it fails with a user-facing `BAD_ARGUMENTS` error.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 87c4c64cb294fd9d5eb82923719ee752e895aef8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.467`
<!-- ch-version-info:end -->