### PR TITLE
stabilize test test_http_limits

### DIFF
--- a/tests/integration/test_http_limits/configs/storage.xml
+++ b/tests/integration/test_http_limits/configs/storage.xml
@@ -9,10 +9,10 @@
                 <s3_max_single_part_upload_size>33554432</s3_max_single_part_upload_size>
                 <metadata_path>/var/lib/clickhouse/disks/custom_path</metadata_path>
             </s3>
-            <hdd>
+            <hdd_disk>
                 <type>local</type>
                 <path>/</path>
-            </hdd>
+            </hdd_disk>
         </disks>
         <policies>
             <s3>
@@ -22,8 +22,25 @@
                     </main>
                 </volumes>
             </s3>
+            <hdd>
+                <volumes>
+                    <main>
+                        <disk>hdd_disk</disk>
+                    </main>
+                </volumes>
+            </hdd>
         </policies>
     </storage_configuration>
 
     <s3_retry_attempts>10</s3_retry_attempts>
+
+
+    <query_log>
+        <database>system</database>
+        <table>query_log</table>
+        <storage_policy>hdd</storage_policy>
+    </query_log>
+    <merge_tree>
+        <storage_policy>hdd</storage_policy>
+    </merge_tree>
 </clickhouse>

--- a/tests/integration/test_http_limits/configs/users.xml
+++ b/tests/integration/test_http_limits/configs/users.xml
@@ -1,0 +1,7 @@
+<clickhouse>
+    <profiles>
+        <default>
+            <merge_tree_compact_parts_min_granules_to_multibuffer_read>1000</merge_tree_compact_parts_min_granules_to_multibuffer_read>
+        </default>
+    </profiles>
+</clickhouse>

--- a/tests/integration/test_http_limits/test_hard_limit.py
+++ b/tests/integration/test_http_limits/test_hard_limit.py
@@ -13,6 +13,7 @@ def clickhouse_cluster():
                 "configs/storage.xml",
                 "configs/disk_connection_limit.xml",
             ],
+            user_configs=["configs/users.xml"],
             with_minio=True,
             with_zookeeper=True,
         )
@@ -65,7 +66,7 @@ def test_disk_hard_limit_hit(clickhouse_cluster):
     query_id=insert_query_id
     )
 
-    node.query("SYSTEM FLUSH LOGS")
+    node.query("SYSTEM FLUSH LOGS query_log")
     puts, connections = node.query(
     f"""
         SELECT ProfileEvents['S3PutObject'], ProfileEvents['DiskConnectionsCreated'] FROM system.query_log WHERE query_id = '{insert_query_id}' AND type = 'QueryFinish'
@@ -83,7 +84,7 @@ def test_disk_hard_limit_hit(clickhouse_cluster):
     ).strip()
     assert(result == "1\t0\t1\t2\t3\t4\t5\t6\t7\t8\t9\t10\t11\t12\t13\t14\t15\t16\t17\t18\t19")
 
-    node.query("SYSTEM FLUSH LOGS")
+    node.query("SYSTEM FLUSH LOGS query_log")
     gets, connections = node.query(
     f"""
         SELECT ProfileEvents['S3GetObject'], ProfileEvents['DiskConnectionsCreated'] FROM system.query_log WHERE query_id = '{select_query_id}' AND type = 'QueryFinish'


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
select do not read with many buffers compact part in test `integration/test_http_limits`

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to integration test configuration and log flushing behavior to reduce flakiness, with no production code impact.
> 
> **Overview**
> Stabilizes `test_http_limits` by adjusting test ClickHouse configs to keep `query_log`/MergeTree data on a local `hdd` storage policy instead of S3, and by adding a user profile override (`merge_tree_compact_parts_min_granules_to_multibuffer_read`).
> 
> Updates `test_hard_limit.py` to load the new `users.xml` and to flush only `query_log` before asserting `ProfileEvents`, reducing timing/noise from flushing all logs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a9e4b1607a8e3809a50f22a87a49afdf1f6ba2e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.448`
- Backported to: `26.2.5.6`, `25.12.9.42`
<!-- ch-version-info:end -->