### PR TITLE
Fix runtime filter with anti join multi key

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/joinRuntimeFilter.cpp
+++ b/src/Processors/QueryPlan/Optimizations/joinRuntimeFilter.cpp
@@ -15,6 +15,8 @@
 #include <Common/Exception.h>
 #include <Common/thread_local_rng.h>
 #include <Common/logger_useful.h>
+#include <DataTypes/DataTypeTuple.h>
+#include <Functions/tuple.h>
 #include <DataTypes/getLeastSupertype.h>
 #include <fmt/format.h>
 
@@ -110,13 +112,6 @@ bool tryAddJoinRuntimeFilter(QueryPlan::Node & node, QueryPlan::Nodes & nodes, c
     /// that would have matches in the right table. This means we need to add something like NOT IN filter.
     const bool check_left_does_not_contain = (join_operator.kind == JoinKind::Left && join_operator.strictness == JoinStrictness::Anti);
 
-    /// For LEFT ANTI JOIN with multiple join keys, per-column NOT IN filters are incorrect.
-    /// For example, for ON t1.a = t2.aa AND t1.b = t2.bb, combining NOT_IN(t1.a, {t2.aa}) AND NOT_IN(t1.b, {t2.bb})
-    /// incorrectly drops rows like (a=0, b=2) where a=0 is in t2.aa but the full tuple (0, 2) has no match in t2.
-    /// A per-column NOT IN filter cannot check for exact tuple membership, so disable the optimization in this case.
-    if (check_left_does_not_contain && join_operator.expression.size() > 1)
-        return false;
-
     QueryPlan::Node * apply_filter_node = node.children[0];
     QueryPlan::Node * build_filter_node = node.children[1];
 
@@ -179,41 +174,137 @@ bool tryAddJoinRuntimeFilter(QueryPlan::Node & node, QueryPlan::Nodes & nodes, c
 
     const String filter_name_prefix = fmt::format("{}_runtime_filter_{}", check_left_does_not_contain ? "_exclusion_" : "", thread_local_rng());
 
+    /// Compute common types for each key pair
+    DataTypes common_types;
+    common_types.reserve(join_keys_build_side.size());
+    for (size_t i = 0; i < join_keys_build_side.size(); ++i)
     {
-        /// Pass all columns on probe side
+        const auto & join_key_build_side = join_keys_build_side[i];
+        const auto & join_key_probe_side = join_keys_probe_side[i];
+
+        if (!join_key_build_side.type->equals(*join_key_probe_side.type))
+        {
+            try
+            {
+                common_types.push_back(getLeastSupertype(DataTypes{join_key_build_side.type, join_key_probe_side.type}));
+            }
+            catch (Exception & ex)
+            {
+                ex.addMessage("JOIN cannot infer common type in ON section for keys. Left key '{}' type {}. Right key '{}' type {}",
+                    join_key_probe_side.name, join_key_probe_side.type->getName(),
+                    join_key_build_side.name, join_key_build_side.type->getName());
+                throw;
+            }
+        }
+        else
+        {
+            common_types.push_back(join_key_build_side.type);
+        }
+    }
+
+    /// For LEFT ANTI JOIN with multiple keys, per-column NOT IN filters combined with AND are incorrect:
+    /// NOT_IN(a, set_a) AND NOT_IN(b, set_b) would incorrectly drop rows where one key is in its per-column set
+    /// but the full tuple has no match in the right table.
+    /// Instead, wrap all keys into a single Tuple and build one NOT IN filter on the tuple for exact tuple membership check.
+    const bool use_tuple_filter = check_left_does_not_contain && join_keys_build_side.size() > 1;
+
+    if (use_tuple_filter)
+    {
+        const String filter_name = filter_name_prefix + "_0";
+        auto tuple_type = std::make_shared<DataTypeTuple>(common_types);
+        FunctionOverloadResolverPtr tuple_func = std::make_shared<FunctionToOverloadResolverAdaptor>(std::make_shared<FunctionTuple>());
+
+        /// Build side: compute tuple(key1, key2, ...) and build a single runtime filter on the tuple column.
+        /// The tuple column is a temporary column that must be stripped before the join step sees the right-side header.
+        {
+            /// Remember the original header before adding the tuple column
+            auto original_build_header = build_filter_node->step->getOutputHeader();
+
+            ActionsDAG build_tuple_dag(build_filter_node->step->getOutputHeader()->getColumnsWithTypeAndName(), false);
+            ActionsDAG::NodeRawConstPtrs key_nodes;
+            for (size_t i = 0; i < join_keys_build_side.size(); ++i)
+            {
+                const auto * key_node = &build_tuple_dag.findInOutputs(join_keys_build_side[i].name);
+                if (!join_keys_build_side[i].type->equals(*common_types[i]))
+                    key_node = &build_tuple_dag.addCast(*key_node, common_types[i], {}, nullptr);
+                key_nodes.push_back(key_node);
+            }
+            const auto & tuple_node = build_tuple_dag.addFunction(tuple_func, key_nodes, {});
+            build_tuple_dag.addOrReplaceInOutputs(tuple_node);
+
+            makeExpressionNodeOnTopOf(*build_filter_node, std::move(build_tuple_dag), nodes, makeDescription("Calculate right join key tuple"));
+
+            LOG_TRACE(getLogger("joinRuntimeFilter"), "Runtime filter '{}' will be built from tuple of right keys and applied to tuple of left keys", filter_name);
+
+            QueryPlan::Node * new_build_filter_node = &nodes.emplace_back();
+            new_build_filter_node->step = std::make_unique<BuildRuntimeFilterStep>(
+                build_filter_node->step->getOutputHeader(),
+                tuple_node.result_name,
+                tuple_type,
+                filter_name,
+                optimization_settings.join_runtime_filter_exact_values_limit,
+                optimization_settings.join_runtime_bloom_filter_bytes,
+                optimization_settings.join_runtime_bloom_filter_hash_functions,
+                optimization_settings.join_runtime_filter_pass_ratio_threshold_for_disabling,
+                optimization_settings.join_runtime_filter_blocks_to_skip_before_reenabling,
+                optimization_settings.join_runtime_bloom_filter_max_ratio_of_set_bits,
+                /*allow_to_use_not_exact_filter_=*/false);
+            new_build_filter_node->step->setStepDescription("Build runtime join filter on key tuple", 200);
+            new_build_filter_node->children = {build_filter_node};
+            build_filter_node = new_build_filter_node;
+
+            /// Strip the temporary tuple column so the join step sees only the original columns
+            ActionsDAG strip_tuple_dag(build_filter_node->step->getOutputHeader()->getColumnsWithTypeAndName(), false);
+            strip_tuple_dag.removeUnusedActions(original_build_header->getNames(), /*allow_remove_inputs=*/false);
+            makeExpressionNodeOnTopOf(*build_filter_node, std::move(strip_tuple_dag), nodes, makeDescription("Remove temporary tuple column"));
+        }
+
+        /// Apply side: compute tuple(key1, key2, ...) and apply the filter
+        {
+            ActionsDAG filter_dag(apply_filter_node->step->getOutputHeader()->getColumnsWithTypeAndName(), false);
+            ActionsDAG::NodeRawConstPtrs key_nodes;
+            for (size_t i = 0; i < join_keys_probe_side.size(); ++i)
+            {
+                const auto * key_node = &filter_dag.findInOutputs(join_keys_probe_side[i].name);
+                if (!join_keys_probe_side[i].type->equals(*common_types[i]))
+                    key_node = &filter_dag.addCast(*key_node, common_types[i], {}, nullptr);
+                key_nodes.push_back(key_node);
+            }
+            const auto & tuple_node = filter_dag.addFunction(tuple_func, key_nodes, {});
+
+            /// Build __applyFilter(filter_name, tuple_node) condition directly,
+            /// since the tuple node is freshly created and not yet in the DAG outputs
+            const auto & filter_name_node = filter_dag.addColumn(
+                ColumnWithTypeAndName(
+                    DataTypeString().createColumnConst(0, filter_name),
+                    std::make_shared<DataTypeString>(),
+                    filter_name));
+            auto filter_function = FunctionFactory::instance().get("__applyFilter", /*query_context*/nullptr);
+            const auto & condition = filter_dag.addFunction(filter_function, {&filter_name_node, &tuple_node}, {});
+            filter_dag.addOrReplaceInOutputs(condition);
+
+            QueryPlan::Node * new_apply_filter_node = &nodes.emplace_back();
+            new_apply_filter_node->step = std::make_unique<FilterStep>(
+                apply_filter_node->step->getOutputHeader(), std::move(filter_dag), condition.result_name, true);
+            new_apply_filter_node->step->setStepDescription("Apply runtime join filter");
+            new_apply_filter_node->children = {apply_filter_node};
+            apply_filter_node = new_apply_filter_node;
+        }
+    }
+    else
+    {
+        /// Standard per-column runtime filters (for INNER, SEMI, RIGHT, and single-key ANTI joins)
         ActionsDAG filter_dag(apply_filter_node->step->getOutputHeader()->getColumnsWithTypeAndName(), false);
 
         String filter_column_name;
         ActionsDAG::NodeRawConstPtrs all_filter_conditions;
         for (size_t i = 0; i < join_keys_build_side.size(); ++i)
         {
-            /// Make unique filter name for each of the predicates. If will be used at runtime to "connect" build side and apply side
             const String filter_name = filter_name_prefix + "_" + toString(i);
 
             const auto & join_key_build_side = join_keys_build_side[i];
             const auto & join_key_probe_side = join_keys_probe_side[i];
-
-            /// If types of left and right columns do not match then we need to deduce common super type for them
-            /// and add CAST-s to this type to build and apply sides
-            DataTypePtr common_type;
-            if (!join_key_build_side.type->equals(*join_key_probe_side.type))
-            {
-                try
-                {
-                    common_type = getLeastSupertype(DataTypes{join_key_build_side.type, join_key_probe_side.type});
-                }
-                catch (Exception & ex)
-                {
-                    ex.addMessage("JOIN cannot infer common type in ON section for keys. Left key '{}' type {}. Right key '{}' type {}",
-                        join_key_probe_side.name, join_key_probe_side.type->getName(),
-                        join_key_build_side.name, join_key_build_side.type->getName());
-                    throw;
-                }
-            }
-            else
-            {
-                common_type = join_key_build_side.type;
-            }
+            const auto & common_type = common_types[i];
 
             LOG_TRACE(getLogger("joinRuntimeFilter"), "Runtime filter '{}' will be built from `{}` and applied to `{}`",
                 filter_name, join_key_build_side.name, join_key_probe_side.name);
@@ -223,8 +314,7 @@ bool tryAddJoinRuntimeFilter(QueryPlan::Node & node, QueryPlan::Nodes & nodes, c
 
             /// Add building filter to the build subtree of join
             {
-                QueryPlan::Node * new_build_filter_node = nullptr;
-                new_build_filter_node = &nodes.emplace_back();
+                QueryPlan::Node * new_build_filter_node = &nodes.emplace_back();
                 new_build_filter_node->step = std::make_unique<BuildRuntimeFilterStep>(
                     build_filter_node->step->getOutputHeader(),
                     join_key_build_side.name,

--- a/src/Processors/QueryPlan/Optimizations/joinRuntimeFilter.cpp
+++ b/src/Processors/QueryPlan/Optimizations/joinRuntimeFilter.cpp
@@ -110,6 +110,13 @@ bool tryAddJoinRuntimeFilter(QueryPlan::Node & node, QueryPlan::Nodes & nodes, c
     /// that would have matches in the right table. This means we need to add something like NOT IN filter.
     const bool check_left_does_not_contain = (join_operator.kind == JoinKind::Left && join_operator.strictness == JoinStrictness::Anti);
 
+    /// For LEFT ANTI JOIN with multiple join keys, per-column NOT IN filters are incorrect.
+    /// For example, for ON t1.a = t2.aa AND t1.b = t2.bb, combining NOT_IN(t1.a, {t2.aa}) AND NOT_IN(t1.b, {t2.bb})
+    /// incorrectly drops rows like (a=0, b=2) where a=0 is in t2.aa but the full tuple (0, 2) has no match in t2.
+    /// A per-column NOT IN filter cannot check for exact tuple membership, so disable the optimization in this case.
+    if (check_left_does_not_contain && join_operator.expression.size() > 1)
+        return false;
+
     QueryPlan::Node * apply_filter_node = node.children[0];
     QueryPlan::Node * build_filter_node = node.children[1];
 

--- a/src/Processors/QueryPlan/Optimizations/joinRuntimeFilter.cpp
+++ b/src/Processors/QueryPlan/Optimizations/joinRuntimeFilter.cpp
@@ -208,6 +208,10 @@ bool tryAddJoinRuntimeFilter(QueryPlan::Node & node, QueryPlan::Nodes & nodes, c
     /// Instead, wrap all keys into a single Tuple and build one NOT IN filter on the tuple for exact tuple membership check.
     const bool use_tuple_filter = check_left_does_not_contain && join_keys_build_side.size() > 1;
 
+    /// Filter that will be applied on the probe side
+    ActionsDAG filter_dag(apply_filter_node->step->getOutputHeader()->getColumnsWithTypeAndName(), false);
+    String filter_column_name;
+
     if (use_tuple_filter)
     {
         const String filter_name = filter_name_prefix + "_0";
@@ -261,7 +265,7 @@ bool tryAddJoinRuntimeFilter(QueryPlan::Node & node, QueryPlan::Nodes & nodes, c
 
         /// Apply side: compute tuple(key1, key2, ...) and apply the filter
         {
-            ActionsDAG filter_dag(apply_filter_node->step->getOutputHeader()->getColumnsWithTypeAndName(), false);
+
             ActionsDAG::NodeRawConstPtrs key_nodes;
             for (size_t i = 0; i < join_keys_probe_side.size(); ++i)
             {
@@ -283,20 +287,12 @@ bool tryAddJoinRuntimeFilter(QueryPlan::Node & node, QueryPlan::Nodes & nodes, c
             const auto & condition = filter_dag.addFunction(filter_function, {&filter_name_node, &tuple_node}, {});
             filter_dag.addOrReplaceInOutputs(condition);
 
-            QueryPlan::Node * new_apply_filter_node = &nodes.emplace_back();
-            new_apply_filter_node->step = std::make_unique<FilterStep>(
-                apply_filter_node->step->getOutputHeader(), std::move(filter_dag), condition.result_name, true);
-            new_apply_filter_node->step->setStepDescription("Apply runtime join filter");
-            new_apply_filter_node->children = {apply_filter_node};
-            apply_filter_node = new_apply_filter_node;
+            filter_column_name = condition.result_name;
         }
     }
     else
     {
         /// Standard per-column runtime filters (for INNER, SEMI, RIGHT, and single-key ANTI joins)
-        ActionsDAG filter_dag(apply_filter_node->step->getOutputHeader()->getColumnsWithTypeAndName(), false);
-
-        String filter_column_name;
         ActionsDAG::NodeRawConstPtrs all_filter_conditions;
         for (size_t i = 0; i < join_keys_build_side.size(); ++i)
         {
@@ -347,14 +343,14 @@ bool tryAddJoinRuntimeFilter(QueryPlan::Node & node, QueryPlan::Nodes & nodes, c
             filter_dag.addOrReplaceInOutputs(combined_filter_condition);
             filter_column_name = combined_filter_condition.result_name;
         }
-
-        QueryPlan::Node * new_apply_filter_node = &nodes.emplace_back();
-        new_apply_filter_node->step = std::make_unique<FilterStep>(apply_filter_node->step->getOutputHeader(), std::move(filter_dag), filter_column_name, true);
-        new_apply_filter_node->step->setStepDescription("Apply runtime join filter");
-        new_apply_filter_node->children = {apply_filter_node};
-
-        apply_filter_node = new_apply_filter_node;
     }
+
+    QueryPlan::Node * new_apply_filter_node = &nodes.emplace_back();
+    new_apply_filter_node->step = std::make_unique<FilterStep>(
+        apply_filter_node->step->getOutputHeader(), std::move(filter_dag), filter_column_name, true);
+    new_apply_filter_node->step->setStepDescription("Apply runtime join filter");
+    new_apply_filter_node->children = {apply_filter_node};
+    apply_filter_node = new_apply_filter_node;
 
     node.children = {apply_filter_node, build_filter_node};
 

--- a/src/Processors/QueryPlan/Optimizations/joinRuntimeFilter.cpp
+++ b/src/Processors/QueryPlan/Optimizations/joinRuntimeFilter.cpp
@@ -32,6 +32,24 @@ namespace ErrorCodes
 namespace QueryPlanOptimizations
 {
 
+/// Build a `tuple(key1, key2, ...)` node in the given DAG, casting each key to the corresponding common type if needed.
+const ActionsDAG::Node & addTupleOfKeys(
+    ActionsDAG & dag,
+    const ColumnsWithTypeAndName & keys,
+    const DataTypes & common_types,
+    const FunctionOverloadResolverPtr & tuple_func)
+{
+    ActionsDAG::NodeRawConstPtrs key_nodes;
+    for (size_t i = 0; i < keys.size(); ++i)
+    {
+        const auto * key_node = &dag.findInOutputs(keys[i].name);
+        if (!keys[i].type->equals(*common_types[i]))
+            key_node = &dag.addCast(*key_node, common_types[i], {}, nullptr);
+        key_nodes.push_back(key_node);
+    }
+    return dag.addFunction(tuple_func, key_nodes, {});
+}
+
 const ActionsDAG::Node & createRuntimeFilterCondition(
     ActionsDAG & actions_dag,
     const String & filter_name,
@@ -225,15 +243,7 @@ bool tryAddJoinRuntimeFilter(QueryPlan::Node & node, QueryPlan::Nodes & nodes, c
             auto original_build_header = build_filter_node->step->getOutputHeader();
 
             ActionsDAG build_tuple_dag(build_filter_node->step->getOutputHeader()->getColumnsWithTypeAndName(), false);
-            ActionsDAG::NodeRawConstPtrs key_nodes;
-            for (size_t i = 0; i < join_keys_build_side.size(); ++i)
-            {
-                const auto * key_node = &build_tuple_dag.findInOutputs(join_keys_build_side[i].name);
-                if (!join_keys_build_side[i].type->equals(*common_types[i]))
-                    key_node = &build_tuple_dag.addCast(*key_node, common_types[i], {}, nullptr);
-                key_nodes.push_back(key_node);
-            }
-            const auto & tuple_node = build_tuple_dag.addFunction(tuple_func, key_nodes, {});
+            const auto & tuple_node = addTupleOfKeys(build_tuple_dag, join_keys_build_side, common_types, tuple_func);
             build_tuple_dag.addOrReplaceInOutputs(tuple_node);
 
             makeExpressionNodeOnTopOf(*build_filter_node, std::move(build_tuple_dag), nodes, makeDescription("Calculate right join key tuple"));
@@ -265,16 +275,7 @@ bool tryAddJoinRuntimeFilter(QueryPlan::Node & node, QueryPlan::Nodes & nodes, c
 
         /// Apply side: compute tuple(key1, key2, ...) and apply the filter
         {
-
-            ActionsDAG::NodeRawConstPtrs key_nodes;
-            for (size_t i = 0; i < join_keys_probe_side.size(); ++i)
-            {
-                const auto * key_node = &filter_dag.findInOutputs(join_keys_probe_side[i].name);
-                if (!join_keys_probe_side[i].type->equals(*common_types[i]))
-                    key_node = &filter_dag.addCast(*key_node, common_types[i], {}, nullptr);
-                key_nodes.push_back(key_node);
-            }
-            const auto & tuple_node = filter_dag.addFunction(tuple_func, key_nodes, {});
+            const auto & tuple_node = addTupleOfKeys(filter_dag, join_keys_probe_side, common_types, tuple_func);
 
             /// Build __applyFilter(filter_name, tuple_node) condition directly,
             /// since the tuple node is freshly created and not yet in the DAG outputs

--- a/src/Processors/QueryPlan/Optimizations/joinRuntimeFilter.cpp
+++ b/src/Processors/QueryPlan/Optimizations/joinRuntimeFilter.cpp
@@ -272,6 +272,7 @@ bool tryAddJoinRuntimeFilter(QueryPlan::Node & node, QueryPlan::Nodes & nodes, c
 
             ActionsDAG build_tuple_dag(build_filter_node->step->getOutputHeader()->getColumnsWithTypeAndName(), false);
             const auto & tuple_node = addTupleOfKeys(build_tuple_dag, join_keys_build_side, common_types, tuple_func);
+            const String tuple_column_name = tuple_node.result_name;
             build_tuple_dag.addOrReplaceInOutputs(tuple_node);
 
             makeExpressionNodeOnTopOf(*build_filter_node, std::move(build_tuple_dag), nodes, makeDescription("Calculate right join key tuple"));
@@ -281,7 +282,7 @@ bool tryAddJoinRuntimeFilter(QueryPlan::Node & node, QueryPlan::Nodes & nodes, c
             QueryPlan::Node * new_build_filter_node = &nodes.emplace_back();
             new_build_filter_node->step = std::make_unique<BuildRuntimeFilterStep>(
                 build_filter_node->step->getOutputHeader(),
-                tuple_node.result_name,
+                tuple_column_name,
                 tuple_type,
                 filter_name,
                 optimization_settings.join_runtime_filter_exact_values_limit,

--- a/src/Processors/QueryPlan/Optimizations/joinRuntimeFilter.cpp
+++ b/src/Processors/QueryPlan/Optimizations/joinRuntimeFilter.cpp
@@ -46,7 +46,7 @@ const ActionsDAG::Node & addNullBypassForAntiJoin(
     FunctionOverloadResolverPtr is_null_func = std::make_shared<FunctionToOverloadResolverAdaptor>(std::make_shared<FunctionIsNull>(/*use_analyzer=*/true));
     for (const auto & key : keys)
     {
-        if (key.type->isNullable())
+        if (isNullableOrLowCardinalityNullable(key.type))
         {
             const auto * key_node = &dag.findInOutputs(key.name);
             or_conditions.push_back(&dag.addFunction(is_null_func, {key_node}, {}));

--- a/src/Processors/QueryPlan/Optimizations/joinRuntimeFilter.cpp
+++ b/src/Processors/QueryPlan/Optimizations/joinRuntimeFilter.cpp
@@ -17,6 +17,7 @@
 #include <Common/logger_useful.h>
 #include <DataTypes/DataTypeTuple.h>
 #include <Functions/tuple.h>
+#include <Functions/isNull.h>
 #include <DataTypes/getLeastSupertype.h>
 #include <fmt/format.h>
 
@@ -31,6 +32,33 @@ namespace ErrorCodes
 
 namespace QueryPlanOptimizations
 {
+
+/// For ANTI JOIN exclusion filters, rows with any NULL key can never match in the join (since NULL = NULL is false in SQL)
+/// and must always pass the runtime filter. This wraps the filter condition with OR isNull(key1) OR isNull(key2) OR ...
+const ActionsDAG::Node & addNullBypassForAntiJoin(
+    ActionsDAG & dag,
+    const ActionsDAG::Node & filter_condition,
+    const ColumnsWithTypeAndName & keys)
+{
+    ActionsDAG::NodeRawConstPtrs or_conditions;
+    or_conditions.push_back(&filter_condition);
+
+    FunctionOverloadResolverPtr is_null_func = std::make_shared<FunctionToOverloadResolverAdaptor>(std::make_shared<FunctionIsNull>(/*use_analyzer=*/true));
+    for (const auto & key : keys)
+    {
+        if (key.type->isNullable())
+        {
+            const auto * key_node = &dag.findInOutputs(key.name);
+            or_conditions.push_back(&dag.addFunction(is_null_func, {key_node}, {}));
+        }
+    }
+
+    if (or_conditions.size() == 1)
+        return filter_condition;
+
+    FunctionOverloadResolverPtr or_func = std::make_unique<FunctionToOverloadResolverAdaptor>(std::make_shared<FunctionOr>());
+    return dag.addFunction(or_func, std::move(or_conditions), {});
+}
 
 /// Build a `tuple(key1, key2, ...)` node in the given DAG, casting each key to the corresponding common type if needed.
 const ActionsDAG::Node & addTupleOfKeys(
@@ -286,9 +314,11 @@ bool tryAddJoinRuntimeFilter(QueryPlan::Node & node, QueryPlan::Nodes & nodes, c
                     filter_name));
             auto filter_function = FunctionFactory::instance().get("__applyFilter", /*query_context*/nullptr);
             const auto & condition = filter_dag.addFunction(filter_function, {&filter_name_node, &tuple_node}, {});
-            filter_dag.addOrReplaceInOutputs(condition);
 
-            filter_column_name = condition.result_name;
+            const auto & final_condition = addNullBypassForAntiJoin(filter_dag, condition, join_keys_probe_side);
+            filter_dag.addOrReplaceInOutputs(final_condition);
+
+            filter_column_name = final_condition.result_name;
         }
     }
     else
@@ -307,7 +337,10 @@ bool tryAddJoinRuntimeFilter(QueryPlan::Node & node, QueryPlan::Nodes & nodes, c
                 filter_name, join_key_build_side.name, join_key_probe_side.name);
 
             /// Add filter lookup to the probe subtree
-            all_filter_conditions.push_back(&createRuntimeFilterCondition(filter_dag, filter_name, join_key_probe_side, common_type));
+            const auto & filter_condition = createRuntimeFilterCondition(filter_dag, filter_name, join_key_probe_side, common_type);
+            all_filter_conditions.push_back(check_left_does_not_contain
+                ? &addNullBypassForAntiJoin(filter_dag, filter_condition, {join_key_probe_side})
+                : &filter_condition);
 
             /// Add building filter to the build subtree of join
             {

--- a/src/Processors/QueryPlan/Optimizations/joinRuntimeFilter.cpp
+++ b/src/Processors/QueryPlan/Optimizations/joinRuntimeFilter.cpp
@@ -35,13 +35,13 @@ namespace QueryPlanOptimizations
 
 /// For ANTI JOIN exclusion filters, rows with any NULL key can never match in the join (since NULL = NULL is false in SQL)
 /// and must always pass the runtime filter. This wraps the filter condition with OR isNull(key1) OR isNull(key2) OR ...
-const ActionsDAG::Node & addNullBypassForAntiJoin(
+const ActionsDAG::Node * addNullBypassForAntiJoin(
     ActionsDAG & dag,
-    const ActionsDAG::Node & filter_condition,
+    const ActionsDAG::Node * filter_condition,
     const ColumnsWithTypeAndName & keys)
 {
     ActionsDAG::NodeRawConstPtrs or_conditions;
-    or_conditions.push_back(&filter_condition);
+    or_conditions.push_back(filter_condition);
 
     FunctionOverloadResolverPtr is_null_func = std::make_shared<FunctionToOverloadResolverAdaptor>(std::make_shared<FunctionIsNull>(/*use_analyzer=*/true));
     for (const auto & key : keys)
@@ -57,7 +57,7 @@ const ActionsDAG::Node & addNullBypassForAntiJoin(
         return filter_condition;
 
     FunctionOverloadResolverPtr or_func = std::make_unique<FunctionToOverloadResolverAdaptor>(std::make_shared<FunctionOr>());
-    return dag.addFunction(or_func, std::move(or_conditions), {});
+    return &dag.addFunction(or_func, std::move(or_conditions), {});
 }
 
 /// Build a `tuple(key1, key2, ...)` node in the given DAG, casting each key to the corresponding common type if needed.
@@ -316,10 +316,10 @@ bool tryAddJoinRuntimeFilter(QueryPlan::Node & node, QueryPlan::Nodes & nodes, c
             auto filter_function = FunctionFactory::instance().get("__applyFilter", /*query_context*/nullptr);
             const auto & condition = filter_dag.addFunction(filter_function, {&filter_name_node, &tuple_node}, {});
 
-            const auto & final_condition = addNullBypassForAntiJoin(filter_dag, condition, join_keys_probe_side);
-            filter_dag.addOrReplaceInOutputs(final_condition);
+            const auto * final_condition = addNullBypassForAntiJoin(filter_dag, &condition, join_keys_probe_side);
+            filter_dag.addOrReplaceInOutputs(*final_condition);
 
-            filter_column_name = final_condition.result_name;
+            filter_column_name = final_condition->result_name;
         }
     }
     else
@@ -340,7 +340,7 @@ bool tryAddJoinRuntimeFilter(QueryPlan::Node & node, QueryPlan::Nodes & nodes, c
             /// Add filter lookup to the probe subtree
             const auto & filter_condition = createRuntimeFilterCondition(filter_dag, filter_name, join_key_probe_side, common_type);
             all_filter_conditions.push_back(check_left_does_not_contain
-                ? &addNullBypassForAntiJoin(filter_dag, filter_condition, {join_key_probe_side})
+                ? addNullBypassForAntiJoin(filter_dag, &filter_condition, {join_key_probe_side})
                 : &filter_condition);
 
             /// Add building filter to the build subtree of join

--- a/src/Processors/QueryPlan/Optimizations/joinRuntimeFilter.cpp
+++ b/src/Processors/QueryPlan/Optimizations/joinRuntimeFilter.cpp
@@ -17,7 +17,6 @@
 #include <Common/logger_useful.h>
 #include <DataTypes/DataTypeTuple.h>
 #include <Functions/tuple.h>
-#include <Functions/isNull.h>
 #include <DataTypes/getLeastSupertype.h>
 #include <fmt/format.h>
 
@@ -43,7 +42,7 @@ const ActionsDAG::Node * addNullBypassForAntiJoin(
     ActionsDAG::NodeRawConstPtrs or_conditions;
     or_conditions.push_back(filter_condition);
 
-    FunctionOverloadResolverPtr is_null_func = std::make_shared<FunctionToOverloadResolverAdaptor>(std::make_shared<FunctionIsNull>(/*use_analyzer=*/true));
+    auto is_null_func = FunctionFactory::instance().get("isNull", Context::getGlobalContextInstance());
     for (const auto & key : keys)
     {
         if (isNullableOrLowCardinalityNullable(key.type))

--- a/tests/queries/0_stateless/04000_anti_join_runtime_filter_multi_key.reference
+++ b/tests/queries/0_stateless/04000_anti_join_runtime_filter_multi_key.reference
@@ -1,4 +1,26 @@
-Without runtime filters:
+--- Test 1: Basic 2-key LEFT ANTI JOIN ---
 0	2
-With runtime filters (must match):
 0	2
+--- Test 2: 3-key LEFT ANTI JOIN ---
+1	2	4
+1	2	4
+--- Test 3: Mixed types (Int32 vs Int64) ---
+2	20
+2	20
+--- Test 4: Empty right side ---
+1	2
+3	4
+1	2
+3	4
+--- Test 5: All rows match ---
+--- Test 6: Single-key LEFT ANTI JOIN ---
+2	20
+2	20
+--- Test 7: Multi-key INNER JOIN ---
+0	0
+1	1
+0	0
+1	1
+--- Test 8: Large right side (filter overflow) ---
+0	999
+0	999

--- a/tests/queries/0_stateless/04000_anti_join_runtime_filter_multi_key.reference
+++ b/tests/queries/0_stateless/04000_anti_join_runtime_filter_multi_key.reference
@@ -1,0 +1,4 @@
+Without runtime filters:
+0	2
+With runtime filters (must match):
+0	2

--- a/tests/queries/0_stateless/04000_anti_join_runtime_filter_multi_key.reference
+++ b/tests/queries/0_stateless/04000_anti_join_runtime_filter_multi_key.reference
@@ -43,3 +43,17 @@
 \N	5
 3	\N
 \N	5
+--- Test 11: LowCardinality(Nullable) single-key ---
+\N	2
+z	3
+\N	2
+z	3
+--- Test 12: LowCardinality(Nullable) multi-key ---
+x	\N
+y	b
+\N	a
+\N	\N
+x	\N
+y	b
+\N	a
+\N	\N

--- a/tests/queries/0_stateless/04000_anti_join_runtime_filter_multi_key.reference
+++ b/tests/queries/0_stateless/04000_anti_join_runtime_filter_multi_key.reference
@@ -16,6 +16,11 @@
 --- Test 6: Single-key LEFT ANTI JOIN ---
 2	20
 2	20
+--- Test 6b: Single-key nullable LEFT ANTI JOIN ---
+\N	20
+3	30
+\N	20
+3	30
 --- Test 7: Multi-key INNER JOIN ---
 0	0
 1	1
@@ -24,3 +29,17 @@
 --- Test 8: Large right side (filter overflow) ---
 0	999
 0	999
+--- Test 9: Nullable multi-key LEFT ANTI JOIN ---
+1	\N
+3	4
+\N	2
+\N	\N
+1	\N
+3	4
+\N	2
+\N	\N
+--- Test 10: Nullable mixed types ---
+3	\N
+\N	5
+3	\N
+\N	5

--- a/tests/queries/0_stateless/04000_anti_join_runtime_filter_multi_key.sql
+++ b/tests/queries/0_stateless/04000_anti_join_runtime_filter_multi_key.sql
@@ -1,0 +1,25 @@
+-- Regression test: LEFT ANTI JOIN with multiple join keys and enable_join_runtime_filters=1
+-- The runtime filter optimization incorrectly applied per-column NOT IN filters combined with AND,
+-- which dropped rows that should appear in the result.
+
+SET enable_analyzer = 1;
+SET enable_parallel_replicas = 0;
+
+CREATE TABLE t1 (a Int64, b Int64) ENGINE = MergeTree ORDER BY a;
+CREATE TABLE t2 (aa Int64, bb Int64) ENGINE = MergeTree ORDER BY aa;
+
+INSERT INTO t1 SELECT number % 2, number % 3 FROM numbers(3);
+INSERT INTO t2 SELECT number % 3, number % 2 FROM numbers(3);
+
+-- t1 = {(0,0), (1,1), (0,2)}, t2 = {(0,0), (1,1), (2,0)}
+-- Correct ANTI JOIN result: (0,2) — no row in t2 has aa=0 AND bb=2 simultaneously
+
+SELECT 'Without runtime filters:';
+SELECT t1.a, t1.b FROM t1 LEFT ANTI JOIN t2 ON t1.a = t2.aa AND t1.b = t2.bb
+ORDER BY t1.a, t1.b
+SETTINGS enable_join_runtime_filters = 0;
+
+SELECT 'With runtime filters (must match):';
+SELECT t1.a, t1.b FROM t1 LEFT ANTI JOIN t2 ON t1.a = t2.aa AND t1.b = t2.bb
+ORDER BY t1.a, t1.b
+SETTINGS enable_join_runtime_filters = 1;

--- a/tests/queries/0_stateless/04000_anti_join_runtime_filter_multi_key.sql
+++ b/tests/queries/0_stateless/04000_anti_join_runtime_filter_multi_key.sql
@@ -1,9 +1,16 @@
--- Regression test: LEFT ANTI JOIN with multiple join keys and enable_join_runtime_filters=1
--- The runtime filter optimization incorrectly applied per-column NOT IN filters combined with AND,
--- which dropped rows that should appear in the result.
+-- Tests for LEFT ANTI JOIN with multiple join keys and runtime filters.
+-- The runtime filter uses a Tuple-based NOT IN filter for exact tuple membership.
 
 SET enable_analyzer = 1;
 SET enable_parallel_replicas = 0;
+
+-- ==========================================================================
+-- Test 1: Basic 2-key regression test
+-- Per-column NOT IN filters combined with AND were incorrect: they dropped
+-- rows where one key was in its per-column set but the full tuple had no match.
+-- ==========================================================================
+
+SELECT '--- Test 1: Basic 2-key LEFT ANTI JOIN ---';
 
 CREATE TABLE t1 (a Int64, b Int64) ENGINE = MergeTree ORDER BY a;
 CREATE TABLE t2 (aa Int64, bb Int64) ENGINE = MergeTree ORDER BY aa;
@@ -14,12 +21,182 @@ INSERT INTO t2 SELECT number % 3, number % 2 FROM numbers(3);
 -- t1 = {(0,0), (1,1), (0,2)}, t2 = {(0,0), (1,1), (2,0)}
 -- Correct ANTI JOIN result: (0,2) — no row in t2 has aa=0 AND bb=2 simultaneously
 
-SELECT 'Without runtime filters:';
 SELECT t1.a, t1.b FROM t1 LEFT ANTI JOIN t2 ON t1.a = t2.aa AND t1.b = t2.bb
 ORDER BY t1.a, t1.b
 SETTINGS enable_join_runtime_filters = 0;
 
-SELECT 'With runtime filters (must match):';
 SELECT t1.a, t1.b FROM t1 LEFT ANTI JOIN t2 ON t1.a = t2.aa AND t1.b = t2.bb
 ORDER BY t1.a, t1.b
 SETTINGS enable_join_runtime_filters = 1;
+
+DROP TABLE t1;
+DROP TABLE t2;
+
+-- ==========================================================================
+-- Test 2: 3-key LEFT ANTI JOIN
+-- Verifies tuple filter generalizes beyond 2 keys.
+-- ==========================================================================
+
+SELECT '--- Test 2: 3-key LEFT ANTI JOIN ---';
+
+CREATE TABLE t1 (a Int64, b Int64, c Int64) ENGINE = MergeTree ORDER BY a;
+CREATE TABLE t2 (aa Int64, bb Int64, cc Int64) ENGINE = MergeTree ORDER BY aa;
+
+INSERT INTO t1 VALUES (1, 2, 3), (1, 2, 4), (5, 6, 7);
+INSERT INTO t2 VALUES (1, 2, 3), (5, 6, 7);
+
+-- (1,2,3) matches, (5,6,7) matches, only (1,2,4) survives
+
+SELECT t1.a, t1.b, t1.c FROM t1 LEFT ANTI JOIN t2 ON t1.a = t2.aa AND t1.b = t2.bb AND t1.c = t2.cc
+ORDER BY t1.a, t1.b, t1.c
+SETTINGS enable_join_runtime_filters = 0;
+
+SELECT t1.a, t1.b, t1.c FROM t1 LEFT ANTI JOIN t2 ON t1.a = t2.aa AND t1.b = t2.bb AND t1.c = t2.cc
+ORDER BY t1.a, t1.b, t1.c
+SETTINGS enable_join_runtime_filters = 1;
+
+DROP TABLE t1;
+DROP TABLE t2;
+
+-- ==========================================================================
+-- Test 3: Mixed types requiring cast (Int32 vs Int64)
+-- Verifies that per-key type casting works correctly with tuple filter.
+-- ==========================================================================
+
+SELECT '--- Test 3: Mixed types (Int32 vs Int64) ---';
+
+CREATE TABLE t1 (a Int32, b Int32) ENGINE = MergeTree ORDER BY a;
+CREATE TABLE t2 (aa Int64, bb Int64) ENGINE = MergeTree ORDER BY aa;
+
+INSERT INTO t1 VALUES (1, 10), (2, 20), (3, 30);
+INSERT INTO t2 VALUES (1, 10), (3, 30);
+
+-- (1,10) and (3,30) match, only (2,20) survives
+
+SELECT t1.a, t1.b FROM t1 LEFT ANTI JOIN t2 ON t1.a = t2.aa AND t1.b = t2.bb
+ORDER BY t1.a, t1.b
+SETTINGS enable_join_runtime_filters = 0;
+
+SELECT t1.a, t1.b FROM t1 LEFT ANTI JOIN t2 ON t1.a = t2.aa AND t1.b = t2.bb
+ORDER BY t1.a, t1.b
+SETTINGS enable_join_runtime_filters = 1;
+
+DROP TABLE t1;
+DROP TABLE t2;
+
+-- ==========================================================================
+-- Test 4: Empty right side — all left rows survive
+-- ==========================================================================
+
+SELECT '--- Test 4: Empty right side ---';
+
+CREATE TABLE t1 (a Int64, b Int64) ENGINE = MergeTree ORDER BY a;
+CREATE TABLE t2 (aa Int64, bb Int64) ENGINE = MergeTree ORDER BY aa;
+
+INSERT INTO t1 VALUES (1, 2), (3, 4);
+
+SELECT t1.a, t1.b FROM t1 LEFT ANTI JOIN t2 ON t1.a = t2.aa AND t1.b = t2.bb
+ORDER BY t1.a, t1.b
+SETTINGS enable_join_runtime_filters = 0;
+
+SELECT t1.a, t1.b FROM t1 LEFT ANTI JOIN t2 ON t1.a = t2.aa AND t1.b = t2.bb
+ORDER BY t1.a, t1.b
+SETTINGS enable_join_runtime_filters = 1;
+
+DROP TABLE t1;
+DROP TABLE t2;
+
+-- ==========================================================================
+-- Test 5: All rows match — empty result
+-- ==========================================================================
+
+SELECT '--- Test 5: All rows match ---';
+
+CREATE TABLE t1 (a Int64, b Int64) ENGINE = MergeTree ORDER BY a;
+CREATE TABLE t2 (aa Int64, bb Int64) ENGINE = MergeTree ORDER BY aa;
+
+INSERT INTO t1 VALUES (1, 2), (3, 4);
+INSERT INTO t2 VALUES (1, 2), (3, 4), (5, 6);
+
+SELECT t1.a, t1.b FROM t1 LEFT ANTI JOIN t2 ON t1.a = t2.aa AND t1.b = t2.bb
+ORDER BY t1.a, t1.b
+SETTINGS enable_join_runtime_filters = 0;
+
+SELECT t1.a, t1.b FROM t1 LEFT ANTI JOIN t2 ON t1.a = t2.aa AND t1.b = t2.bb
+ORDER BY t1.a, t1.b
+SETTINGS enable_join_runtime_filters = 1;
+
+DROP TABLE t1;
+DROP TABLE t2;
+
+-- ==========================================================================
+-- Test 6: Single-key LEFT ANTI JOIN still works (uses per-column path)
+-- ==========================================================================
+
+SELECT '--- Test 6: Single-key LEFT ANTI JOIN ---';
+
+CREATE TABLE t1 (a Int64, b Int64) ENGINE = MergeTree ORDER BY a;
+CREATE TABLE t2 (aa Int64) ENGINE = MergeTree ORDER BY aa;
+
+INSERT INTO t1 VALUES (1, 10), (2, 20), (3, 30);
+INSERT INTO t2 VALUES (1), (3);
+
+SELECT t1.a, t1.b FROM t1 LEFT ANTI JOIN t2 ON t1.a = t2.aa
+ORDER BY t1.a, t1.b
+SETTINGS enable_join_runtime_filters = 0;
+
+SELECT t1.a, t1.b FROM t1 LEFT ANTI JOIN t2 ON t1.a = t2.aa
+ORDER BY t1.a, t1.b
+SETTINGS enable_join_runtime_filters = 1;
+
+DROP TABLE t1;
+DROP TABLE t2;
+
+-- ==========================================================================
+-- Test 7: Multi-key INNER JOIN still uses per-column path correctly
+-- ==========================================================================
+
+SELECT '--- Test 7: Multi-key INNER JOIN ---';
+
+CREATE TABLE t1 (a Int64, b Int64) ENGINE = MergeTree ORDER BY a;
+CREATE TABLE t2 (aa Int64, bb Int64) ENGINE = MergeTree ORDER BY aa;
+
+INSERT INTO t1 SELECT number % 2, number % 3 FROM numbers(3);
+INSERT INTO t2 SELECT number % 3, number % 2 FROM numbers(3);
+
+SELECT t1.a, t1.b FROM t1 INNER JOIN t2 ON t1.a = t2.aa AND t1.b = t2.bb
+ORDER BY t1.a, t1.b
+SETTINGS enable_join_runtime_filters = 0;
+
+SELECT t1.a, t1.b FROM t1 INNER JOIN t2 ON t1.a = t2.aa AND t1.b = t2.bb
+ORDER BY t1.a, t1.b
+SETTINGS enable_join_runtime_filters = 1;
+
+DROP TABLE t1;
+DROP TABLE t2;
+
+-- ==========================================================================
+-- Test 8: Large right side exceeding exact_values_limit
+-- When the set overflows, the filter is disabled and results must stay correct.
+-- ==========================================================================
+
+SELECT '--- Test 8: Large right side (filter overflow) ---';
+
+CREATE TABLE t1 (a Int64, b Int64) ENGINE = MergeTree ORDER BY a;
+CREATE TABLE t2 (aa Int64, bb Int64) ENGINE = MergeTree ORDER BY aa;
+
+INSERT INTO t1 VALUES (0, 999), (1, 1), (2, 2);
+INSERT INTO t2 SELECT number, number FROM numbers(200);
+
+-- (1,1) and (2,2) match, (0,999) does not since t2 has (0,0) not (0,999)
+
+SELECT t1.a, t1.b FROM t1 LEFT ANTI JOIN t2 ON t1.a = t2.aa AND t1.b = t2.bb
+ORDER BY t1.a, t1.b
+SETTINGS enable_join_runtime_filters = 0;
+
+SELECT t1.a, t1.b FROM t1 LEFT ANTI JOIN t2 ON t1.a = t2.aa AND t1.b = t2.bb
+ORDER BY t1.a, t1.b
+SETTINGS enable_join_runtime_filters = 1, join_runtime_filter_exact_values_limit = 10;
+
+DROP TABLE t1;
+DROP TABLE t2;

--- a/tests/queries/0_stateless/04000_anti_join_runtime_filter_multi_key.sql
+++ b/tests/queries/0_stateless/04000_anti_join_runtime_filter_multi_key.sql
@@ -287,3 +287,61 @@ SETTINGS enable_join_runtime_filters = 1;
 
 DROP TABLE t1;
 DROP TABLE t2;
+
+-- ==========================================================================
+-- Test 11: LowCardinality(Nullable(...)) single-key
+-- isNullable() returns false for LowCardinality(Nullable(T)), but NULLs
+-- still exist and must bypass the exclusion filter.
+-- ==========================================================================
+
+SELECT '--- Test 11: LowCardinality(Nullable) single-key ---';
+
+CREATE TABLE t1 (a LowCardinality(Nullable(String)), b Int64) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE t2 (aa LowCardinality(Nullable(String))) ENGINE = MergeTree ORDER BY tuple();
+
+INSERT INTO t1 VALUES ('x', 1), (NULL, 2), ('z', 3);
+INSERT INTO t2 VALUES ('x'), (NULL);
+
+-- ('x') matches -> filtered out
+-- (NULL): NULL != NULL -> survives
+-- ('z'): no match -> survives
+
+SELECT t1.a, t1.b FROM t1 LEFT ANTI JOIN t2 ON t1.a = t2.aa
+ORDER BY t1.b
+SETTINGS enable_join_runtime_filters = 0;
+
+SELECT t1.a, t1.b FROM t1 LEFT ANTI JOIN t2 ON t1.a = t2.aa
+ORDER BY t1.b
+SETTINGS enable_join_runtime_filters = 1;
+
+DROP TABLE t1;
+DROP TABLE t2;
+
+-- ==========================================================================
+-- Test 12: LowCardinality(Nullable(...)) multi-key
+-- ==========================================================================
+
+SELECT '--- Test 12: LowCardinality(Nullable) multi-key ---';
+
+CREATE TABLE t1 (a LowCardinality(Nullable(String)), b LowCardinality(Nullable(String))) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE t2 (aa LowCardinality(Nullable(String)), bb LowCardinality(Nullable(String))) ENGINE = MergeTree ORDER BY tuple();
+
+INSERT INTO t1 VALUES ('x', 'a'), (NULL, 'a'), ('x', NULL), (NULL, NULL), ('y', 'b');
+INSERT INTO t2 VALUES ('x', 'a'), (NULL, 'a'), (NULL, NULL);
+
+-- ('x','a') matches -> filtered out
+-- (NULL,'a'): NULL key -> survives
+-- ('x',NULL): NULL key -> survives
+-- (NULL,NULL): NULL keys -> survives
+-- ('y','b'): no match -> survives
+
+SELECT t1.a, t1.b FROM t1 LEFT ANTI JOIN t2 ON t1.a = t2.aa AND t1.b = t2.bb
+ORDER BY t1.a NULLS LAST, t1.b NULLS LAST
+SETTINGS enable_join_runtime_filters = 0;
+
+SELECT t1.a, t1.b FROM t1 LEFT ANTI JOIN t2 ON t1.a = t2.aa AND t1.b = t2.bb
+ORDER BY t1.a NULLS LAST, t1.b NULLS LAST
+SETTINGS enable_join_runtime_filters = 1;
+
+DROP TABLE t1;
+DROP TABLE t2;

--- a/tests/queries/0_stateless/04000_anti_join_runtime_filter_multi_key.sql
+++ b/tests/queries/0_stateless/04000_anti_join_runtime_filter_multi_key.sql
@@ -153,6 +153,34 @@ DROP TABLE t1;
 DROP TABLE t2;
 
 -- ==========================================================================
+-- Test 6b: Single-key nullable LEFT ANTI JOIN
+-- NULL key rows must survive because NULL = NULL is false in SQL.
+-- ==========================================================================
+
+SELECT '--- Test 6b: Single-key nullable LEFT ANTI JOIN ---';
+
+CREATE TABLE t1 (a Nullable(Int64), b Int64) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE t2 (aa Nullable(Int64)) ENGINE = MergeTree ORDER BY tuple();
+
+INSERT INTO t1 VALUES (1, 10), (NULL, 20), (3, 30);
+INSERT INTO t2 VALUES (1), (NULL);
+
+-- (1) matches -> filtered out
+-- (NULL) from t1: NULL != NULL -> survives
+-- (3) from t1: no match -> survives
+
+SELECT t1.a, t1.b FROM t1 LEFT ANTI JOIN t2 ON t1.a = t2.aa
+ORDER BY t1.b
+SETTINGS enable_join_runtime_filters = 0;
+
+SELECT t1.a, t1.b FROM t1 LEFT ANTI JOIN t2 ON t1.a = t2.aa
+ORDER BY t1.b
+SETTINGS enable_join_runtime_filters = 1;
+
+DROP TABLE t1;
+DROP TABLE t2;
+
+-- ==========================================================================
 -- Test 7: Multi-key INNER JOIN still uses per-column path correctly
 -- ==========================================================================
 
@@ -197,6 +225,65 @@ SETTINGS enable_join_runtime_filters = 0;
 SELECT t1.a, t1.b FROM t1 LEFT ANTI JOIN t2 ON t1.a = t2.aa AND t1.b = t2.bb
 ORDER BY t1.a, t1.b
 SETTINGS enable_join_runtime_filters = 1, join_runtime_filter_exact_values_limit = 10;
+
+DROP TABLE t1;
+DROP TABLE t2;
+
+-- ==========================================================================
+-- Test 9: Nullable multi-key LEFT ANTI JOIN
+-- NULL handling with tuple-based exclusion is subtle: tuples containing NULL
+-- never match via equality, so rows with any NULL key must always survive.
+-- ==========================================================================
+
+SELECT '--- Test 9: Nullable multi-key LEFT ANTI JOIN ---';
+
+CREATE TABLE t1 (a Nullable(Int64), b Nullable(Int64)) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE t2 (aa Nullable(Int64), bb Nullable(Int64)) ENGINE = MergeTree ORDER BY tuple();
+
+INSERT INTO t1 VALUES (1, 2), (NULL, 2), (1, NULL), (NULL, NULL), (3, 4);
+INSERT INTO t2 VALUES (1, 2), (NULL, 2), (NULL, NULL);
+
+-- (1,2) matches exactly -> filtered out
+-- (NULL,2) from t1: NULL != NULL in equality, so no match -> survives
+-- (1,NULL) from t1: NULL in second key, no match -> survives
+-- (NULL,NULL) from t1: NULL != NULL, no match -> survives
+-- (3,4) from t1: no match in t2 -> survives
+
+SELECT t1.a, t1.b FROM t1 LEFT ANTI JOIN t2 ON t1.a = t2.aa AND t1.b = t2.bb
+ORDER BY t1.a NULLS LAST, t1.b NULLS LAST
+SETTINGS enable_join_runtime_filters = 0;
+
+SELECT t1.a, t1.b FROM t1 LEFT ANTI JOIN t2 ON t1.a = t2.aa AND t1.b = t2.bb
+ORDER BY t1.a NULLS LAST, t1.b NULLS LAST
+SETTINGS enable_join_runtime_filters = 1;
+
+DROP TABLE t1;
+DROP TABLE t2;
+
+-- ==========================================================================
+-- Test 10: Nullable multi-key with mixed types (Nullable(Int32) vs Nullable(Int64))
+-- Ensures casting + NULL handling work together in tuple-based exclusion.
+-- ==========================================================================
+
+SELECT '--- Test 10: Nullable mixed types ---';
+
+CREATE TABLE t1 (a Nullable(Int32), b Nullable(Int32)) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE t2 (aa Nullable(Int64), bb Nullable(Int64)) ENGINE = MergeTree ORDER BY tuple();
+
+INSERT INTO t1 VALUES (1, 2), (NULL, 5), (3, NULL);
+INSERT INTO t2 VALUES (1, 2), (NULL, 5);
+
+-- (1,2) matches -> filtered out
+-- (NULL,5): NULL key -> survives
+-- (3,NULL): NULL key -> survives
+
+SELECT t1.a, t1.b FROM t1 LEFT ANTI JOIN t2 ON t1.a = t2.aa AND t1.b = t2.bb
+ORDER BY t1.a NULLS LAST, t1.b NULLS LAST
+SETTINGS enable_join_runtime_filters = 0;
+
+SELECT t1.a, t1.b FROM t1 LEFT ANTI JOIN t2 ON t1.a = t2.aa AND t1.b = t2.bb
+ORDER BY t1.a NULLS LAST, t1.b NULLS LAST
+SETTINGS enable_join_runtime_filters = 1;
 
 DROP TABLE t1;
 DROP TABLE t2;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
LEFT ANTI JOIN with multiple join key columns returned wrong results when `enable_join_runtime_filters=1` (which is default).

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes join runtime-filter construction for `LEFT ANTI JOIN`, which is correctness-critical and could affect query results/performance for anti-joins and NULLable keys. Scope is contained to runtime-filter planning plus new stateless regression coverage.
> 
> **Overview**
> Fixes incorrect results when `enable_join_runtime_filters=1` for multi-key `LEFT ANTI JOIN` by switching from per-column `NOT IN` filters combined with `AND` to a single tuple-based runtime filter (build/apply `tuple(key1, key2, ...)` with inferred common supertypes and casts).
> 
> Adds NULL-safe behavior for ANTI JOIN runtime filters by OR-ing the filter condition with `isNull()` checks for any nullable/LowCardinality-nullable join keys so rows containing NULL keys always bypass the exclusion filter. Adds a comprehensive stateless regression test suite covering multi-key, mixed-type casts, NULL/LowCardinality NULLs, overflow/disabled filter behavior, and non-ANTI joins.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d6899df9d855958c5f8eb8252c491e9f5ab76de4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.589`
<!-- ch-version-info:end -->