### PR TITLE
updating CLAUDE.md to name tests correctly

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -98,6 +98,11 @@ When writing tests, do not add "no-*" tags (like "no-parallel") unless strictly 
 
 When writing tests in tests/queries, prefer adding a new test instead of extending existing ones.
 
+When adding a new test, first run the following command to find the current test with the last prefix index, then increment the resulting index by 1, and use this as the prefix for the new test name:
+```
+ls tests/queries/0_stateless/[0-9]*.reference | tail -n 1
+```
+
 When writing C++ code, always use Allman-style braces (opening brace on a new line). This is enforced by the style check in CI.
 
 Never use sleep in C++ code to fix race conditions - this is stupid and not acceptable!


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no code or test behavior is modified.
> 
> **Overview**
> Updates `.claude/CLAUDE.md` with a new guideline for naming new `tests/queries/0_stateless` tests: run a command to find the latest numeric prefix in `.reference` files and increment it when creating a new test name.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c4ecc2411e183b605c61aea8726f83b4eefedee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.447`
<!-- ch-version-info:end -->