### PR TITLE
Scatter transform memory footprint

### DIFF
--- a/src/Columns/ColumnAggregateFunction.cpp
+++ b/src/Columns/ColumnAggregateFunction.cpp
@@ -727,12 +727,11 @@ MutableColumns ColumnAggregateFunction::scatter(size_t num_columns, const IColum
 
     size_t num_rows = size();
 
+    const auto counts = countColumnsSizeInSelector(num_columns, selector);
+    for (size_t i = 0; i < num_columns; ++i)
     {
-        size_t reserve_size = static_cast<size_t>(static_cast<double>(num_rows) / static_cast<double>(num_columns) * 1.1); /// 1.1 is just a guess. Better to use n-sigma rule.
-
-        if (reserve_size > 1)
-            for (auto & column : columns)
-                column->reserve(reserve_size);
+        if (counts[i] > 1)
+            columns[i]->reserve(counts[i]);
     }
 
     for (size_t i = 0; i < num_rows; ++i)

--- a/src/Columns/ColumnTuple.cpp
+++ b/src/Columns/ColumnTuple.cpp
@@ -553,9 +553,7 @@ MutableColumns ColumnTuple::scatter(size_t num_columns, const Selector & selecto
         if (column_length != selector.size())
             throw Exception(ErrorCodes::SIZES_OF_COLUMNS_DOESNT_MATCH, "Size of selector doesn't match size of column");
 
-        std::vector<size_t> counts(num_columns);
-        for (auto idx : selector)
-            ++counts[idx];
+        std::vector<size_t> counts = countColumnsSizeInSelector(num_columns, selector);
 
         MutableColumns res(num_columns);
         for (size_t i = 0; i < num_columns; ++i)

--- a/src/Columns/IColumn.cpp
+++ b/src/Columns/IColumn.cpp
@@ -20,6 +20,7 @@
 #include <Columns/ColumnTuple.h>
 #include <Columns/ColumnVariant.h>
 #include <Columns/ColumnVector.h>
+#include <Columns/ColumnsCommon.h>
 #include <Columns/IColumnDummy.h>
 #include <Columns/IColumn_fwd.h>
 #include <Core/Field.h>
@@ -324,12 +325,11 @@ MutableColumns IColumnHelper<Derived, Parent>::scatter(size_t num_columns, const
     for (auto & column : columns)
         column = self.cloneEmpty();
 
+    const auto counts = countColumnsSizeInSelector(num_columns, selector);
+    for (size_t i = 0; i < num_columns; ++i)
     {
-        size_t reserve_size = static_cast<size_t>(static_cast<double>(num_rows) * 1.1 / static_cast<double>(num_columns));    /// 1.1 is just a guess. Better to use n-sigma rule.
-
-        if (reserve_size > 1)
-            for (auto & column : columns)
-                column->reserve(reserve_size);
+        if (counts[i] > 1)
+            columns[i]->reserve(counts[i]);
     }
 
     for (size_t i = 0; i < num_rows; ++i)

--- a/src/Columns/IColumnDummy.cpp
+++ b/src/Columns/IColumnDummy.cpp
@@ -112,9 +112,7 @@ MutableColumns IColumnDummy::scatter(size_t num_columns, const Selector & select
     if (s != selector.size())
         throw Exception(ErrorCodes::SIZES_OF_COLUMNS_DOESNT_MATCH, "Size of selector doesn't match size of column.");
 
-    std::vector<size_t> counts(num_columns);
-    for (auto idx : selector)
-        ++counts[idx];
+    std::vector<size_t> counts = countColumnsSizeInSelector(num_columns, selector);
 
     MutableColumns res(num_columns);
     for (size_t i = 0; i < num_columns; ++i)

--- a/src/Processors/Transforms/ScatterByPartitionTransform.cpp
+++ b/src/Processors/Transforms/ScatterByPartitionTransform.cpp
@@ -85,6 +85,13 @@ void ScatterByPartitionTransform::work()
         if (output.isFinished())
             continue;
 
+        if (output_chunk.getNumRows() == 0 && output_chunk.getChunkInfos().empty())
+        {
+            /// Avoid pushing empty data chunks downstream.
+            was_processed = true;
+            continue;
+        }
+
         if (!output.canPush())
         {
             all_outputs_processed = false;

--- a/tests/queries/0_stateless/04029_window_parallel_arrow_memory_guard.reference
+++ b/tests/queries/0_stateless/04029_window_parallel_arrow_memory_guard.reference
@@ -1,0 +1,4 @@
+--- explain pipeline ---
+1
+--- query execution ---
+OK

--- a/tests/queries/0_stateless/04029_window_parallel_arrow_memory_guard.sql
+++ b/tests/queries/0_stateless/04029_window_parallel_arrow_memory_guard.sql
@@ -2,41 +2,8 @@
 -- Regression guard for window-partition scatter memory overhead.
 -- This should pass with the fix and fail on unpatched binary under the same memory limit.
 
-DROP TABLE IF EXISTS window_parallel_arrow_memory_guard;
-
-CREATE TABLE window_parallel_arrow_memory_guard
-(
-    F001 Nullable(String),
-    F022 Nullable(UInt64),
-    F046 Nullable(String),
-    F047 Nullable(String),
-    F016 Nullable(Int64),
-    F040 Nullable(Int64),
-    F021 Nullable(Int64),
-    F028 Nullable(Float64),
-    F026 Nullable(String),
-    F025 Nullable(String)
-)
-ENGINE = File(Arrow);
-
--- Use medium Arrow record batches to keep memory pressure CI-friendly.
-SET max_block_size = 32;
-
-INSERT INTO window_parallel_arrow_memory_guard
-SELECT
-    CAST(NULL, 'Nullable(String)'),
-    CAST(NULL, 'Nullable(UInt64)'),
-    CAST(NULL, 'Nullable(String)'),
-    CAST(NULL, 'Nullable(String)'),
-    toNullable(toInt64(number % 100000)),
-    toNullable(toInt64(number % 1000)),
-    toNullable(toInt64(number % 50000)),
-    toNullable(toFloat64(number % 1000) / 10),
-    toNullable(if(number % 2 = 0, 'some', 'other')),
-    toNullable(toString(number % 100000))
-FROM numbers(100000);
-
-SET max_block_size = 65505;
+-- Avoid storage overhead in flaky checks and force tiny source blocks.
+SET max_block_size = 8;
 SET max_threads = 8, max_memory_usage = 80000000;
 
 SELECT '--- explain pipeline ---';
@@ -48,7 +15,22 @@ FROM
         LEAST(F016 - F040, F021) AS AQ,
         F028 * IF(F026 = 'some', 1, -1) AS SBP,
         SUM(AQ) OVER (PARTITION BY F047, F022, F001, F046 ORDER BY SBP ASC, F025 ASC) AS CSF
-    FROM window_parallel_arrow_memory_guard
+    FROM
+    (
+        SELECT
+            CAST(NULL, 'Nullable(String)') AS F001,
+            CAST(NULL, 'Nullable(UInt64)') AS F022,
+            CAST(NULL, 'Nullable(String)') AS F046,
+            CAST(NULL, 'Nullable(String)') AS F047,
+            toNullable(toInt64(number % 100000)) AS F016,
+            toNullable(toInt64(number % 1000)) AS F040,
+            toNullable(toInt64(number % 50000)) AS F021,
+            toNullable(toFloat64(number % 1000) / 10) AS F028,
+            toNullable(if(number % 2 = 0, 'some', 'other')) AS F026,
+            toNullable(toString(number % 100000)) AS F025
+        FROM system.numbers_mt
+        LIMIT 100000
+    )
     LIMIT 1
 )
 WHERE explain LIKE '%ScatterByPartitionTransform%';
@@ -58,10 +40,23 @@ SELECT
     LEAST(F016 - F040, F021) AS AQ,
     F028 * IF(F026 = 'some', 1, -1) AS SBP,
     SUM(AQ) OVER (PARTITION BY F047, F022, F001, F046 ORDER BY SBP ASC, F025 ASC) AS CSF
-FROM window_parallel_arrow_memory_guard
+FROM
+(
+    SELECT
+        CAST(NULL, 'Nullable(String)') AS F001,
+        CAST(NULL, 'Nullable(UInt64)') AS F022,
+        CAST(NULL, 'Nullable(String)') AS F046,
+        CAST(NULL, 'Nullable(String)') AS F047,
+        toNullable(toInt64(number % 100000)) AS F016,
+        toNullable(toInt64(number % 1000)) AS F040,
+        toNullable(toInt64(number % 50000)) AS F021,
+        toNullable(toFloat64(number % 1000) / 10) AS F028,
+        toNullable(if(number % 2 = 0, 'some', 'other')) AS F026,
+        toNullable(toString(number % 100000)) AS F025
+    FROM system.numbers_mt
+    LIMIT 100000
+)
 LIMIT 1
 FORMAT Null;
 
 SELECT 'OK';
-
-DROP TABLE window_parallel_arrow_memory_guard;

--- a/tests/queries/0_stateless/04029_window_parallel_arrow_memory_guard.sql
+++ b/tests/queries/0_stateless/04029_window_parallel_arrow_memory_guard.sql
@@ -19,8 +19,8 @@ CREATE TABLE window_parallel_arrow_memory_guard
 )
 ENGINE = File(Arrow);
 
--- Force many small Arrow record batches.
-SET max_block_size = 1;
+-- Use medium Arrow record batches to keep memory pressure CI-friendly.
+SET max_block_size = 32;
 
 INSERT INTO window_parallel_arrow_memory_guard
 SELECT
@@ -34,10 +34,10 @@ SELECT
     toNullable(toFloat64(number % 1000) / 10),
     toNullable(if(number % 2 = 0, 'some', 'other')),
     toNullable(toString(number % 100000))
-FROM numbers(12000);
+FROM numbers(100000);
 
 SET max_block_size = 65505;
-SET max_threads = 32, max_memory_usage = 1500000000;
+SET max_threads = 8, max_memory_usage = 80000000;
 
 SELECT '--- explain pipeline ---';
 SELECT toUInt8(count() > 0)

--- a/tests/queries/0_stateless/04029_window_parallel_arrow_memory_guard.sql
+++ b/tests/queries/0_stateless/04029_window_parallel_arrow_memory_guard.sql
@@ -1,0 +1,67 @@
+-- Tags: no-random-settings
+-- Regression guard for window-partition scatter memory overhead.
+-- This should pass with the fix and fail on unpatched binary under the same memory limit.
+
+DROP TABLE IF EXISTS window_parallel_arrow_memory_guard;
+
+CREATE TABLE window_parallel_arrow_memory_guard
+(
+    F001 Nullable(String),
+    F022 Nullable(UInt64),
+    F046 Nullable(String),
+    F047 Nullable(String),
+    F016 Nullable(Int64),
+    F040 Nullable(Int64),
+    F021 Nullable(Int64),
+    F028 Nullable(Float64),
+    F026 Nullable(String),
+    F025 Nullable(String)
+)
+ENGINE = File(Arrow);
+
+-- Force many small Arrow record batches.
+SET max_block_size = 1;
+
+INSERT INTO window_parallel_arrow_memory_guard
+SELECT
+    CAST(NULL, 'Nullable(String)'),
+    CAST(NULL, 'Nullable(UInt64)'),
+    CAST(NULL, 'Nullable(String)'),
+    CAST(NULL, 'Nullable(String)'),
+    toNullable(toInt64(number % 100000)),
+    toNullable(toInt64(number % 1000)),
+    toNullable(toInt64(number % 50000)),
+    toNullable(toFloat64(number % 1000) / 10),
+    toNullable(if(number % 2 = 0, 'some', 'other')),
+    toNullable(toString(number % 100000))
+FROM numbers(12000);
+
+SET max_block_size = 65505;
+SET max_threads = 32, max_memory_usage = 1500000000;
+
+SELECT '--- explain pipeline ---';
+SELECT toUInt8(count() > 0)
+FROM
+(
+    EXPLAIN PIPELINE
+    SELECT
+        LEAST(F016 - F040, F021) AS AQ,
+        F028 * IF(F026 = 'some', 1, -1) AS SBP,
+        SUM(AQ) OVER (PARTITION BY F047, F022, F001, F046 ORDER BY SBP ASC, F025 ASC) AS CSF
+    FROM window_parallel_arrow_memory_guard
+    LIMIT 1
+)
+WHERE explain LIKE '%ScatterByPartitionTransform%';
+
+SELECT '--- query execution ---';
+SELECT
+    LEAST(F016 - F040, F021) AS AQ,
+    F028 * IF(F026 = 'some', 1, -1) AS SBP,
+    SUM(AQ) OVER (PARTITION BY F047, F022, F001, F046 ORDER BY SBP ASC, F025 ASC) AS CSF
+FROM window_parallel_arrow_memory_guard
+LIMIT 1
+FORMAT Null;
+
+SELECT 'OK';
+
+DROP TABLE window_parallel_arrow_memory_guard;

--- a/tests/queries/0_stateless/04029_window_parallel_arrow_memory_guard.sql
+++ b/tests/queries/0_stateless/04029_window_parallel_arrow_memory_guard.sql
@@ -1,4 +1,4 @@
--- Tags: no-random-settings
+-- Tags: no-random-settings, no-fasttest
 -- Regression guard for window-partition scatter memory overhead.
 -- This should pass with the fix and fail on unpatched binary under the same memory limit.
 

--- a/tests/queries/0_stateless/04030_array_fold_memory_peak_guard.sql
+++ b/tests/queries/0_stateless/04030_array_fold_memory_peak_guard.sql
@@ -1,0 +1,17 @@
+-- Tags: no-fasttest, no-random-settings
+
+SET max_threads = 8;
+SET max_block_size = 65536;
+
+SELECT arrayFold((acc, x, y, z) -> (((acc + x) + y) + z), a, b, c, seed)
+FROM
+(
+    SELECT
+        arrayMap(x -> toUInt64(x + (number % 31)), range((number % 128) + 32)) AS a,
+        arrayMap(x -> toUInt64(x + (number % 17)), range((number % 128) + 32)) AS b,
+        arrayMap(x -> toUInt64(x + (number % 7)), range((number % 128) + 32)) AS c,
+        toUInt64(number % 97) AS seed
+    FROM numbers_mt(60000)
+)
+SETTINGS max_memory_usage = 430000000
+FORMAT Null;


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Improves performance and reduces memory usage for parallel window functions in certain scenarios, and for arrayFold workloads with large arrays. This can also reduce page-fault pressure and improve stability under tight memory limits for affected queries.

### Documentation entry for user-facing changes

This change improves memory usage and performance for some high-concurrency analytical queries, especially:

- window queries with OVER (PARTITION BY ...) on highly skewed data,
- heavy arrayFold workloads with large arrays.

Reduced unnecessary downstream traffic in the partition fan-out stage by avoiding forwarding non-informative empty outputs.
Improved per-output memory preallocation by using exact row counts during data split/fan-out instead of average-size heuristics.

Observed results:

- Window repro from issue #97284:
   - MemoryTrackerPeakUsage: 5.54 GiB -> 2.40 GiB (about 2.3x lower),
   - elapsed time: 2.619s -> 1.815s (about 31% faster).
- 06_array_fold benchmark (3 runs):
   - peak memory: 243.2 MB -> 183.2 MB (about 25% lower),
   - SoftPageFaults: 116k -> 98k (about 15% lower),
   - elapsed time: 1.47s -> 1.33s (about 9% faster).

I've also tested several other scenarios which can potentially be impacted by changes in scatter (grace_hash / parallel_hash joins, GROUPING SETS, functions over Variant / Dynamic columns, but did not observe significant improvements or degradation). 

Helps with #97284.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `scatter` paths used across many operators and adjusts output-chunk emission in `ScatterByPartitionTransform`, so while changes are intended to be allocation-only, any edge-case reliance on empty chunks or reserve behavior could surface.
> 
> **Overview**
> Reduces memory overhead during `scatter` by precomputing exact per-bucket row counts (`countColumnsSizeInSelector`) and reserving capacity per output column instead of using an average-size heuristic in `IColumnHelper::scatter` and `ColumnAggregateFunction::scatter` (and reuses the helper for empty `ColumnTuple`/`IColumnDummy` cases).
> 
> Updates `ScatterByPartitionTransform` to **not push fully empty output chunks** (no rows and no chunk infos) downstream, reducing useless fan-out traffic. Adds stateless regression tests guarding memory usage for parallel window partition scattering and an `arrayFold` memory peak scenario.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d61bf26d365189397f9c8f403996bfe91b2d8609. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.665`
<!-- ch-version-info:end -->