### PR TITLE
Validate ArrowStream first bytes to prevent huge allocations during format detection

### DIFF
--- a/src/Processors/Formats/Impl/ArrowBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ArrowBlockInputFormat.cpp
@@ -23,6 +23,7 @@ namespace ErrorCodes
 {
     extern const int UNKNOWN_EXCEPTION;
     extern const int CANNOT_READ_ALL_DATA;
+    extern const int INCORRECT_DATA;
 }
 
 ArrowBlockInputFormat::ArrowBlockInputFormat(ReadBuffer & in_, SharedHeader header_, bool stream_, const FormatSettings & format_settings_)
@@ -130,6 +131,37 @@ const BlockMissingValues * ArrowBlockInputFormat::getMissingValues() const
 
 static std::shared_ptr<arrow::RecordBatchReader> createStreamReader(ReadBuffer & in)
 {
+    /// Validate the stream before passing it to the Arrow library.
+    /// Arrow IPC streaming format interprets the first 4 bytes as either:
+    ///   - a continuation token (0xFFFFFFFF for modern format, >= v0.15.0), or
+    ///   - the metadata length directly (legacy format, < v0.15.0).
+    /// If the data is not actually Arrow IPC (e.g., JSON, CSV), these bytes get
+    /// interpreted as a huge metadata length, causing Arrow to allocate hundreds
+    /// of megabytes of memory before discovering the data is invalid.
+    /// For example, JSON starting with "{\n  " is interpreted as a ~514 MiB metadata length.
+    if (in.eof())
+        throw Exception(ErrorCodes::INCORRECT_DATA, "The Arrow stream is empty");
+
+    constexpr int32_t kIpcContinuationToken = -1; /// 0xFFFFFFFF
+    /// Even a schema with thousands of columns and extensive metadata
+    /// would have a Flatbuffer well under a megabyte. 256 MiB is an extremely
+    /// conservative upper bound — any metadata length above this is certainly
+    /// not valid Arrow IPC data and is the result of misinterpreting random bytes.
+    constexpr int32_t max_reasonable_metadata_length = 256 * 1024 * 1024;
+
+    if (in.available() >= sizeof(int32_t))
+    {
+        int32_t first_int;
+        memcpy(&first_int, in.position(), sizeof(int32_t));
+
+        /// In the modern format, the first 4 bytes must be the continuation token 0xFFFFFFFF.
+        /// In the legacy format, the first 4 bytes are the metadata length (a positive int32).
+        /// Anything else (zero is handled as EOS by Arrow, negative other than -1 is an error)
+        /// or a metadata length that is unreasonably large indicates this is not Arrow IPC data.
+        if (first_int != kIpcContinuationToken && (first_int <= 0 || first_int > max_reasonable_metadata_length))
+            throw Exception(ErrorCodes::INCORRECT_DATA, "Not an Arrow IPC stream");
+    }
+
     auto options = arrow::ipc::IpcReadOptions::Defaults();
     options.memory_pool = arrow::default_memory_pool();
     auto stream_reader_status = arrow::ipc::RecordBatchStreamReader::Open(std::make_unique<ArrowInputStreamFromReadBuffer>(in), options);

--- a/src/Processors/Formats/Impl/ArrowBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ArrowBlockInputFormat.cpp
@@ -7,6 +7,7 @@
 #include <Formats/FormatFactory.h>
 #include <Formats/SchemaInferenceUtils.h>
 #include <IO/ReadBufferFromMemory.h>
+#include <IO/NetUtils.h>
 #include <IO/WriteHelpers.h>
 #include <IO/copyData.h>
 #include <arrow/api.h>
@@ -153,6 +154,8 @@ static std::shared_ptr<arrow::RecordBatchReader> createStreamReader(ReadBuffer &
     {
         int32_t first_int;
         memcpy(&first_int, in.position(), sizeof(int32_t));
+        /// Arrow IPC uses little-endian byte order on the wire.
+        first_int = DB::fromLittleEndian(first_int);
 
         /// In the modern format, the first 4 bytes must be the continuation token 0xFFFFFFFF.
         /// In the legacy format, the first 4 bytes are the metadata length (a positive int32).

--- a/tests/queries/0_stateless/04028_arrow_stream_format_detection_memory.reference
+++ b/tests/queries/0_stateless/04028_arrow_stream_format_detection_memory.reference
@@ -1,0 +1,2 @@
+1	hello
+2	world

--- a/tests/queries/0_stateless/04028_arrow_stream_format_detection_memory.sh
+++ b/tests/queries/0_stateless/04028_arrow_stream_format_detection_memory.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+# Tag no-fasttest: Arrow format is not available in fast test builds
+
+# Regression test for https://github.com/ClickHouse/ClickHouse/issues/65036
+#
+# During format auto-detection, the ArrowStream format reader would interpret
+# the first bytes of non-Arrow data (e.g. JSON) as a metadata length in the
+# Arrow IPC framing protocol. For example, JSON starting with "{\n  " was
+# interpreted as a ~514 MiB metadata length, causing a huge allocation before
+# Arrow discovered the data was invalid. This test verifies that format
+# detection on a JSON file without a file extension does not cause excessive
+# memory usage.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# Create a JSON file without extension to trigger format auto-detection.
+DATA_FILE="${CLICKHOUSE_TMP}/test_${CLICKHOUSE_DATABASE}_json_no_ext"
+cat > "${DATA_FILE}" <<'EOF'
+[{"a": 1, "b": "hello"}, {"a": 2, "b": "world"}]
+EOF
+
+# Run the query and check that peak memory usage is reasonable.
+# Before the fix, this would allocate ~514 MiB during ArrowStream format detection.
+${CLICKHOUSE_LOCAL} --query "
+    SELECT *
+    FROM file('${DATA_FILE}')
+    ORDER BY a
+    SETTINGS max_memory_usage = '100Mi'
+"
+
+rm -f "${DATA_FILE}"


### PR DESCRIPTION
## Summary
- During format auto-detection, the ArrowStream reader interprets the first 4 bytes of non-Arrow data as a metadata length in the Arrow IPC framing protocol. For example, JSON starting with `{\n  ` is read as a ~514 MiB metadata length, causing Arrow to allocate that much memory before discovering the data is invalid.
- Add a pre-validation check in `createStreamReader` that peeks at the first 4 bytes and rejects data that is clearly not Arrow IPC: the value must be either the continuation token (`0xFFFFFFFF`) or a positive metadata length under 256 MiB.

Closes #65036

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Fix excessive memory usage (~514 MiB) during format auto-detection when reading non-Arrow data (e.g. JSON from `url()` or `file()` without explicit format), caused by the ArrowStream reader misinterpreting the first bytes as a huge metadata length.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

No documentation changes needed — this is a bug fix with no user-facing API changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds stricter pre-validation to `ArrowStream` parsing that changes failure behavior and could reject edge-case/legacy inputs if they don’t match the expected IPC framing. Otherwise it’s a targeted guardrail plus a regression test to prevent runaway memory allocations on misdetected data.
> 
> **Overview**
> Pre-validates the first 4 bytes of `ArrowStream` input in `createStreamReader` and rejects streams that clearly aren’t Arrow IPC (empty input, invalid continuation token/metadata length, or an unreasonably large metadata length), preventing Arrow from attempting huge allocations during format auto-detection on non-Arrow data.
> 
> Adds a stateless regression test that reads a JSON file without an extension via `file()` under a tight `max_memory_usage` limit to ensure autodetection no longer spikes memory.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf4a61433e100b8df84183275498d6b860d0100a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.469`
<!-- ch-version-info:end -->