### PR TITLE
Update formats.mdx

### DIFF
--- a/docs/en/sql-reference/formats.mdx
+++ b/docs/en/sql-reference/formats.mdx
@@ -1,4 +1,65 @@
----
+---Get started
+Get started
+Migrations
+Account and profile
+Subscriptions & notifications
+Authentication
+Billing and payments
+Site policy
+Collaborative coding
+Codespaces
+Repositories
+Pull requests
+GitHub Discussions
+Integrations
+GitHub Copilot
+GitHub Copilot
+Plans
+Coding agent
+Tutorials
+GitHub Copilot Chat Cookbook
+Customization library
+Copilot CLI
+CI/CD and DevOps
+GitHub Actions
+GitHub Packages
+GitHub Pages
+Security and quality
+Secure your secrets
+Secure your supply chain
+Scan code for vulnerabilities
+Maintain quality code
+Client apps
+GitHub CLI
+GitHub Mobile
+GitHub Desktop
+Project management
+GitHub Issues
+Projects
+Search on GitHub
+Enterprise and teams
+Organizations
+Secure at scale
+Enterprise onboarding
+Enterprise administrators
+Developers
+Apps
+REST API
+GraphQL API
+Webhooks
+GitHub Models
+Community
+Building communities
+GitHub Sponsors
+GitHub Education
+GitHub for Nonprofits
+GitHub Support
+Contribute to GitHub Docs
+More docs
+CodeQL query writing
+Electron
+npm
+GitHub Well-Architected
 slug: /sql-reference/formats
 sidebar_position: 50
 sidebar_label: 'Input and Output Formats'


### PR DESCRIPTION
Pools Luck
99.31%

Pools Count
22

Blocks (1w)
1001



View more »

### Changelog category (leave one):
- New Feature
- Experimental Feature
- Improvement
- Performance Improvement
- Backward Incompatible Change
- Build/Testing/Packaging Improvement
- Documentation (changelog entry is not required)
- Critical Bug Fix (crash, data loss, RBAC)
- Bug Fix (user-visible misbehavior in an official stable release)
- CI Fix or Improvement (changelog entry is not required)
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Docs-only change, but it prepends a large block of plain text before the frontmatter delimiter, which may break MDX/frontmatter parsing and site builds for this page.
> 
> **Overview**
> Updates `docs/en/sql-reference/formats.mdx` by prepending a long list of section titles ahead of the page metadata.
> 
> This also effectively corrupts the frontmatter opening (`---` becomes `---Get started`), which may prevent the `formats` page metadata from being parsed and render/build correctly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1aa0209ba186ecaa0a1fe95a0a796d1c990db595. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->