### PR TITLE
Fix "RPNBuilderFunctionTreeNode has A arguments, attempted to get argument at index B" LOGICAL_ERROR

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
@@ -770,10 +770,11 @@ bool MergeTreeIndexConditionText::traverseMapElementValueNode(const RPNBuilderTr
         return false;
 
     const auto function = index_column_node.toFunctionNode();
-    const auto column_name = function.getArgumentAt(0).getColumnName();
 
     if (function.getArgumentsSize() != 2 || function.getFunctionName() != "arrayElement")
         return false;
+
+    const auto column_name = function.getArgumentAt(0).getColumnName();
 
     if (const_value.getType() != Field::Types::String || const_value.safeGet<String>().empty())
         return false;

--- a/src/Storages/MergeTree/RPNBuilder.cpp
+++ b/src/Storages/MergeTree/RPNBuilder.cpp
@@ -469,7 +469,7 @@ size_t RPNBuilderFunctionTreeNode::getArgumentsSize() const
 RPNBuilderTreeNode RPNBuilderFunctionTreeNode::getArgumentAt(size_t index) const
 {
     const size_t total_arguments = getArgumentsSize();
-    if (index >= total_arguments) /// Bug #52632
+    if (index >= total_arguments)
         throw Exception(ErrorCodes::LOGICAL_ERROR,
                 "RPNBuilderFunctionTreeNode has {} arguments, attempted to get argument at index {}",
                 total_arguments, index);

--- a/tests/queries/0_stateless/04030_text_index_condition_logical_error.sql
+++ b/tests/queries/0_stateless/04030_text_index_condition_logical_error.sql
@@ -1,0 +1,3 @@
+CREATE TABLE tab__fuzz_44 (`text` LowCardinality(String), INDEX idx_text text TYPE text(tokenizer = 'splitByNonAlpha') GRANULARITY 100000000) ENGINE = MergeTree ORDER BY tuple() SETTINGS allow_experimental_reverse_key = 1, index_granularity = 64, lightweight_mutation_projection_mode = 'drop';
+INSERT INTO tab__fuzz_44 VALUES ('foo');
+SELECT count() IGNORE NULLS FROM tab__fuzz_44 PREWHERE equals(database, toUInt128(4, toUInt32(and(notEquals(7, 1), NULL, 1), 1, greater(7, materialize(1)), NULL, 1))) WHERE hasAllTokens(text, ['Hello']) FORMAT NULL SETTINGS allow_experimental_analyzer=1;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix "RPNBuilderFunctionTreeNode has A arguments, attempted to get argument at index B" LOGICAL_ERROR

Fixes: https://github.com/ClickHouse/ClickHouse/issues/52632

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small control-flow change to avoid out-of-bounds argument access during text index condition analysis; should only change behavior from throwing to gracefully skipping unsupported expressions. Adds a regression test to cover the previously crashing query path.
> 
> **Overview**
> Fixes a crash in text index condition analysis by ensuring `arrayElement` arity/name checks happen before calling `getArgumentAt()` in `MergeTreeIndexConditionText::traverseMapElementValueNode`, preventing `RPNBuilderFunctionTreeNode has ... arguments` `LOGICAL_ERROR` for unexpected function shapes.
> 
> Adds a stateless regression test (`04030_text_index_condition_logical_error.sql`) that reproduces the issue under the experimental analyzer.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f27c643ad8143a3b74d18ec452391b3971acaa4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.479`
<!-- ch-version-info:end -->