### PR TITLE
Revert "temporary turn check for `async_insert` off"

### DIFF
--- a/tests/docker_scripts/upgrade_runner.sh
+++ b/tests/docker_scripts/upgrade_runner.sh
@@ -157,7 +157,7 @@ then
       old_settings.value AS old_value
   FROM new_settings
   LEFT JOIN old_settings ON new_settings.name = old_settings.name
-  WHERE (old_value IS NULL OR new_value != old_value) AND name != 'async_insert'
+  WHERE (old_value IS NULL OR new_value != old_value)
       AND (name NOT IN (
       SELECT arrayJoin(tupleElement(changes, 'name'))
       FROM


### PR DESCRIPTION
Reverts ClickHouse/ClickHouse#98831

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Test-only change but it tightens upgrade validation and may reintroduce CI failures if `async_insert` defaults differ across versions without corresponding history entries.
> 
> **Overview**
> The upgrade check in `tests/docker_scripts/upgrade_runner.sh` no longer special-cases `async_insert` when diffing old vs new `system.settings` output.
> 
> As a result, `async_insert` changes will again be reported in `changed_settings.txt` unless they are accounted for in `system.settings_changes`, making the upgrade test stricter.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a54c07d9735f3c66556ea2bb95479c47632d1f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.472`
<!-- ch-version-info:end -->