### PR TITLE
Backport #98797 to 25.10: Fix `SYSTEM START REPLICATED VIEW` not waking up the refresh task

### DIFF
--- a/src/Storages/MaterializedView/RefreshTask.cpp
+++ b/src/Storages/MaterializedView/RefreshTask.cpp
@@ -168,6 +168,7 @@ OwnedRefreshTask RefreshTask::create(
     task->refresh_task_watch_callback = std::make_shared<Coordination::WatchCallback>([w = task->coordination.watches, task_waker = task->refresh_task->getWatchCallback()](const Coordination::WatchResponse & response)
     {
         w->root_watch_active.store(false);
+        w->children_watch_active.store(false);
         w->should_reread_znodes.store(true);
         (*task_waker)(response);
     });

--- a/tests/queries/0_stateless/04027_system_start_replicated_view.reference
+++ b/tests/queries/0_stateless/04027_system_start_replicated_view.reference
@@ -1,0 +1,4 @@
+<1: running>	1
+<2: stopped>	Disabled
+<3: restarted>	1
+<4: new rows>	1

--- a/tests/queries/0_stateless/04027_system_start_replicated_view.sh
+++ b/tests/queries/0_stateless/04027_system_start_replicated_view.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Tags: zookeeper
+
+# Regression test: SYSTEM START REPLICATED VIEW did not wake the refresh task
+# because the ZooKeeper children watch was not re-registered after the first fire.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+CLICKHOUSE_CLIENT=$(echo "$CLICKHOUSE_CLIENT" | sed 's/--session_timezone[= ][^ ]*//g')
+CLICKHOUSE_CLIENT="$CLICKHOUSE_CLIENT --session_timezone Etc/UTC"
+
+db="rdb_$CLICKHOUSE_DATABASE"
+
+function cleanup()
+{
+    $CLICKHOUSE_CLIENT --distributed_ddl_output_mode=none -q "drop database if exists $db" 2>/dev/null
+}
+trap cleanup EXIT
+
+$CLICKHOUSE_CLIENT --distributed_ddl_output_mode=none -nq "
+    create database $db engine=Replicated('/test/$CLICKHOUSE_DATABASE/rdb', 's1', 'r1');
+    create view ${db}.refreshes as
+        select * from system.view_refreshes where database = '$db' order by view;
+    create materialized view ${db}.rmv
+        refresh after 1 second append
+        (x Int64) engine MergeTree order by x
+        empty
+        as select 1 as x;
+"
+
+# Wait for the first refresh to succeed.
+for _ in $(seq 1 60); do
+    if [ "$($CLICKHOUSE_CLIENT -q "select last_success_time is null from ${db}.refreshes -- $LINENO" | xargs)" = '0' ]; then
+        break
+    fi
+    sleep 0.5
+done
+$CLICKHOUSE_CLIENT -q "select '<1: running>', status != 'Disabled' from ${db}.refreshes"
+
+# Stop the view globally via Keeper.
+$CLICKHOUSE_CLIENT -q "system stop replicated view ${db}.rmv"
+for _ in $(seq 1 60); do
+    if [ "$($CLICKHOUSE_CLIENT -q "select status from ${db}.refreshes -- $LINENO" | xargs)" = 'Disabled' ]; then
+        break
+    fi
+    sleep 0.5
+done
+$CLICKHOUSE_CLIENT -q "select '<2: stopped>', status from ${db}.refreshes"
+
+# Remember the current row count.
+cnt_before=$($CLICKHOUSE_CLIENT -q "select count() from ${db}.rmv")
+
+# Start the view back up.
+$CLICKHOUSE_CLIENT -q "system start replicated view ${db}.rmv"
+
+# The bug: the view stayed Disabled forever here because the children watch
+# was not re-registered after the stop event consumed it.
+# Wait for the view to leave Disabled state and complete at least one more refresh.
+for _ in $(seq 1 30); do
+    cnt_after=$($CLICKHOUSE_CLIENT -q "select count() from ${db}.rmv")
+    if [ "$cnt_after" -gt "$cnt_before" ]; then
+        break
+    fi
+    sleep 0.5
+done
+
+$CLICKHOUSE_CLIENT -q "select '<3: restarted>', status != 'Disabled' from ${db}.refreshes"
+$CLICKHOUSE_CLIENT -q "select '<4: new rows>', count() > $cnt_before from ${db}.rmv"


### PR DESCRIPTION
## Summary
Backport of #98797 to 25.10.

The ZooKeeper watch callback used by `RefreshTask` only reset `root_watch_active` but not `children_watch_active`. Since both `existsWatch` and `getChildrenWatch` share the same one-shot callback, the children watch was never re-registered after firing once. This meant that `SYSTEM START REPLICATED VIEW` could not wake up the refresh task after a stop/start cycle.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `SYSTEM START REPLICATED VIEW` not waking up the refresh task

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small, targeted change to the refresh task watch callback plus a regression test; the main impact is on replicated refresh scheduling/wakeups via ZooKeeper watches.
> 
> **Overview**
> Fixes a replicated refreshable materialized view stop/start hang where `SYSTEM START REPLICATED VIEW` could leave the refresh task stuck *Disabled* after a ZooKeeper watch fired once.
> 
> `RefreshTask` now resets both `root_watch_active` and `children_watch_active` in the shared watch callback so `getChildrenWatch` is re-registered on subsequent reads.
> 
> Adds a stateless ZooKeeper regression test (`04027_system_start_replicated_view`) that creates a replicated MV, runs `SYSTEM STOP REPLICATED VIEW` then `SYSTEM START REPLICATED VIEW`, and asserts the view resumes refreshing and produces new rows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19f90eabe8115a1a8ade9ce9e757bc1712cc8a2d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->