### PR TITLE
Fix flaky `03701_dictionary_logging_internal_queries`

### DIFF
--- a/tests/queries/0_stateless/03701_dictionary_logging_internal_queries.sh
+++ b/tests/queries/0_stateless/03701_dictionary_logging_internal_queries.sh
@@ -129,11 +129,21 @@ SOURCE(CLICKHOUSE(
 LIFETIME(MIN 1 MAX 1)
 LAYOUT(FLAT())"
 
-# Force initial load, then wait for auto-reloads.
+# Force initial load, then wait for at least one auto-reload by polling system.dictionaries.
 $CLICKHOUSE_CLIENT --query "SELECT dictHas('${CLICKHOUSE_DATABASE}.test_logging_internal_queries_dict', toUInt64(0)) FORMAT Null"
 
-# 5s (periodic updater check) + 3s (sleep in query) + eps
-sleep 9
+INITIAL_LOAD_TIME=$($CLICKHOUSE_CLIENT --query "SELECT last_successful_update_time FROM system.dictionaries WHERE database = '${CLICKHOUSE_DATABASE}' AND name = 'test_logging_internal_queries_dict'")
+for _ in $(seq 1 60); do
+    CURRENT_LOAD_TIME=$($CLICKHOUSE_CLIENT --query "SELECT last_successful_update_time FROM system.dictionaries WHERE database = '${CLICKHOUSE_DATABASE}' AND name = 'test_logging_internal_queries_dict'")
+    if [ "$CURRENT_LOAD_TIME" != "$INITIAL_LOAD_TIME" ]; then
+        break
+    fi
+    sleep 1
+done
+
+if [ "$CURRENT_LOAD_TIME" = "$INITIAL_LOAD_TIME" ]; then
+    echo "Dictionary did not reload within 60 seconds"
+fi
 
 $CLICKHOUSE_CLIENT --query "DROP DICTIONARY ${CLICKHOUSE_DATABASE}.test_logging_internal_queries_dict"
 $CLICKHOUSE_CLIENT --query "SYSTEM FLUSH LOGS query_log, trace_log"

--- a/tests/queries/0_stateless/03701_dictionary_logging_internal_queries.sh
+++ b/tests/queries/0_stateless/03701_dictionary_logging_internal_queries.sh
@@ -131,7 +131,9 @@ LAYOUT(FLAT())"
 
 # Force initial load, then wait for auto-reloads.
 $CLICKHOUSE_CLIENT --query "SELECT dictHas('${CLICKHOUSE_DATABASE}.test_logging_internal_queries_dict', toUInt64(0)) FORMAT Null"
-sleep 8
+
+# 5s (periodic updater check) + 3s (sleep in query) + eps
+sleep 9
 
 $CLICKHOUSE_CLIENT --query "DROP DICTIONARY ${CLICKHOUSE_DATABASE}.test_logging_internal_queries_dict"
 $CLICKHOUSE_CLIENT --query "SYSTEM FLUSH LOGS query_log, trace_log"


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix flaky `03701_dictionary_logging_internal_queries`.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this only changes test timing logic; the main impact is potentially longer waits (up to 60s) if dictionary auto-reload is slow or broken.
> 
> **Overview**
> Deflakes `03701_dictionary_logging_internal_queries.sh` by replacing a fixed `sleep 8` with a poll loop on `system.dictionaries.last_successful_update_time` to ensure at least one dictionary auto-reload happened before validating `trace_log`/`query_log` correlation.
> 
> Adds a 60s timeout with a diagnostic message when no reload is observed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95410b4d081cf9a6bb2a3b8f8aa85df8c1081569. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.484`
<!-- ch-version-info:end -->