### PR TITLE
add Coordination::setCurrentComponent("MergeTreeCleanupThread");

### DIFF
--- a/src/Storages/MergeTree/MergeTreeCleanupThread.cpp
+++ b/src/Storages/MergeTree/MergeTreeCleanupThread.cpp
@@ -1,5 +1,6 @@
 #include <Storages/MergeTree/MergeTreeCleanupThread.h>
 
+#include <Common/ZooKeeper/ZooKeeperCommon.h>
 #include <Storages/MergeTree/MergeTreeSettings.h>
 #include <Storages/StorageMergeTree.h>
 
@@ -29,6 +30,7 @@ void MergeTreeCleanupThread::start()
 
 Float32 MergeTreeCleanupThread::iterate()
 {
+    auto component_guard = Coordination::setCurrentComponent("MergeTreeCleanupThread");
     size_t cleaned_other = 0;
     size_t cleaned_part_like = 0;
     size_t cleaned_parts = 0;


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
fix https://d1k2gkhrlfqv31.cloudfront.net/clickhouse-test-reports-private/json.html?PR=51786&sha=50d330ae518f881ae9533720d087063f48be03bf&name_0=PR&name_1=Integration+tests+%28amd_asan%2C+db+disk%2C+3%2F6%29

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a scoped `Coordination::setCurrentComponent` guard and an include, without changing cleanup logic or data handling.
> 
> **Overview**
> Sets a per-iteration Coordination context in `MergeTreeCleanupThread::iterate()` by adding a scoped `Coordination::setCurrentComponent("MergeTreeCleanupThread")` guard (and including `ZooKeeperCommon.h`). This makes ZooKeeper/coordination operations executed during background cleanup attributable to this component, aiding diagnostics and addressing flaky integration test expectations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 475b00a7cf58220e5cca7121d0dd9a2204e87881. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.491`
<!-- ch-version-info:end -->