### PR TITLE
Support SAMPLE clause in distributed index analysis

### DIFF
--- a/src/Interpreters/ClusterProxy/distributedIndexAnalysis.cpp
+++ b/src/Interpreters/ClusterProxy/distributedIndexAnalysis.cpp
@@ -224,6 +224,7 @@ namespace DB
 DistributedIndexAnalysisPartsRanges distributedIndexAnalysisOnReplicas(
     const StorageID & storage_id,
     const ActionsDAG * filter_actions_dag,
+    ASTPtr sampling_filter,
     const NameSet & indexes_column_names,
     const RangesInDataParts & parts_with_ranges,
     const OptionalVectorSearchParameters & vector_search_parameters,
@@ -319,9 +320,16 @@ DistributedIndexAnalysisPartsRanges distributedIndexAnalysisOnReplicas(
     auto external_tables = execution_context->getExternalTables();
 
     std::optional<std::string> filter_query = std::nullopt;
-    if (filter_actions_dag)
     {
-        auto filter_ast = getFilterAST(*filter_actions_dag, indexes_column_names, execution_context, &external_tables);
+        ASTPtr filter_ast;
+        if (filter_actions_dag)
+            filter_ast = getFilterAST(*filter_actions_dag, indexes_column_names, execution_context, &external_tables);
+
+        if (filter_ast && sampling_filter)
+            filter_ast = makeASTForLogicalAnd({filter_ast, sampling_filter});
+        else if (sampling_filter)
+            filter_ast = sampling_filter;
+
         if (filter_ast)
             filter_query = filter_ast->formatWithSecretsOneLine();
     }

--- a/src/Interpreters/ClusterProxy/distributedIndexAnalysis.h
+++ b/src/Interpreters/ClusterProxy/distributedIndexAnalysis.h
@@ -30,6 +30,7 @@ using LocalIndexAnalysisCallback = std::function<IndexAnalysisPartsRanges(const 
 DistributedIndexAnalysisPartsRanges distributedIndexAnalysisOnReplicas(
     const StorageID & storage_id,
     const ActionsDAG * filter_actions_dag,
+    ASTPtr sampling_filter,
     const NameSet & indexes_column_names,
     const RangesInDataParts & parts_with_ranges,
     const OptionalVectorSearchParameters & vector_search_parameters,

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -2478,7 +2478,14 @@ ReadFromMergeTree::AnalysisResultPtr ReadFromMergeTree::selectRangesToRead(
                 return filterPartsNamesByPrimaryKeyAndSkipIndexes(filter_context, parts_ranges_map, parts_to_analyze);
             };
 
-            DistributedIndexAnalysisPartsRanges distributed_index_analysis = distributedIndexAnalysisOnReplicas(data.getStorageID(), query_info_.filter_actions_dag.get(), indexes_column_names, res_parts, vector_search_parameters, local_index_analysis_callback, context_);
+            DistributedIndexAnalysisPartsRanges distributed_index_analysis = distributedIndexAnalysisOnReplicas(data.getStorageID(),
+                query_info_.filter_actions_dag.get(),
+                result.sampling.filter_function,
+                indexes_column_names,
+                res_parts,
+                vector_search_parameters,
+                local_index_analysis_callback,
+                context_);
             IndexAnalysisPartsRanges analyzed_parts_ranges;
 
             /// Index stats

--- a/tests/queries/0_stateless/04029_distributed_index_analysis_sampling.reference
+++ b/tests/queries/0_stateless/04029_distributed_index_analysis_sampling.reference
@@ -1,0 +1,37 @@
+20086
+20086
+-- { echo }
+EXPLAIN indexes = 1 SELECT * FROM t_dia_sampling SAMPLE 0.1 SETTINGS distributed_index_analysis = 0;
+Expression ((Project names + (Projection + Change column names to column identifiers)))
+  ReadFromMergeTree (default.t_dia_sampling)
+  Indexes:
+    PrimaryKey
+      Keys:
+        intHash32(key)
+      Condition: (intHash32(key) in (-Inf, 429496728])
+      Parts: 20/20
+      Granules: 86/780
+      Search Algorithm: binary search
+    Ranges: 20
+EXPLAIN indexes = 1 SELECT * FROM t_dia_sampling SAMPLE 0.1 SETTINGS distributed_index_analysis = 1;
+Expression ((Project names + (Projection + Change column names to column identifiers)))
+  ReadFromMergeTree (default.t_dia_sampling)
+  Indexes:
+    PrimaryKey
+      Keys:
+        intHash32(key)
+      Condition: (intHash32(key) in (-Inf, 429496728])
+      Parts: 20/20
+      Granules: 86/780
+      Distributed:
+        Address: 127.0.0.1:9000
+        Parts send: 15
+        Parts received: 15
+        Granules send: 585
+        Granules received: 65
+        Address: 127.0.0.2:9000
+        Parts send: 5
+        Parts received: 5
+        Granules send: 195
+        Granules received: 21
+    Ranges: 20

--- a/tests/queries/0_stateless/04029_distributed_index_analysis_sampling.sql
+++ b/tests/queries/0_stateless/04029_distributed_index_analysis_sampling.sql
@@ -1,0 +1,37 @@
+-- Tags: no-random-settings, no-random-merge-tree-settings
+
+-- Verify that SAMPLE clause is passed to remote replicas during distributed index analysis,
+-- so they can prune granules by the sampling range.
+
+SET send_logs_level = 'error';
+
+DROP TABLE IF EXISTS t_dia_sampling;
+
+CREATE TABLE t_dia_sampling (key UInt64, value UInt64)
+ENGINE = MergeTree ORDER BY intHash32(key) SAMPLE BY intHash32(key)
+SETTINGS index_granularity = 256,
+  min_bytes_for_wide_part = '1G',
+  index_granularity_bytes = '10M',
+  distributed_index_analysis_min_parts_to_activate = 0,
+  distributed_index_analysis_min_indexes_bytes_to_activate = 0;
+
+SYSTEM STOP MERGES t_dia_sampling;
+INSERT INTO t_dia_sampling SELECT number, number FROM numbers(100000) SETTINGS max_block_size = 10000, min_insert_block_size_rows = 10000, max_insert_threads = 1;
+INSERT INTO t_dia_sampling SELECT number + 100000, number FROM numbers(100000) SETTINGS max_block_size = 10000, min_insert_block_size_rows = 10000, max_insert_threads = 1;
+
+SET cluster_for_parallel_replicas = 'test_cluster_one_shard_two_replicas';
+SET max_parallel_replicas = 2;
+SET use_query_condition_cache = 0;
+SET allow_experimental_parallel_reading_from_replicas = 0;
+SET allow_experimental_analyzer = 1;
+
+-- Results must be identical with and without distributed index analysis
+SELECT count() FROM t_dia_sampling SAMPLE 0.1 SETTINGS distributed_index_analysis = 0;
+SELECT count() FROM t_dia_sampling SAMPLE 0.1 SETTINGS distributed_index_analysis = 1;
+
+-- { echo }
+EXPLAIN indexes = 1 SELECT * FROM t_dia_sampling SAMPLE 0.1 SETTINGS distributed_index_analysis = 0;
+EXPLAIN indexes = 1 SELECT * FROM t_dia_sampling SAMPLE 0.1 SETTINGS distributed_index_analysis = 1;
+
+-- { echoOff }
+DROP TABLE t_dia_sampling;


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Support SAMPLE clause in distributed index analysis

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches distributed index analysis filtering by combining the sampling predicate with the existing WHERE/PREWHERE-derived filter; mistakes could change which granules/parts are pruned on replicas for sampled queries.
> 
> **Overview**
> Adds support for `SAMPLE` in distributed index analysis by threading a `sampling_filter` AST into `distributedIndexAnalysisOnReplicas()` and AND-ing it with the existing filter before formatting the remote `mergeTreeAnalyzeIndexesUUID()` query.
> 
> Updates `ReadFromMergeTree` to pass the computed sampling predicate (`result.sampling.filter_function`) into distributed analysis, and adds a stateless test verifying identical results and `EXPLAIN indexes` output for sampled queries with distributed index analysis enabled/disabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7137df1bdfc6dd46e0bbf3d3d3eee0622e0b1fab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.522`
- Backported to: `26.2.5.9`
<!-- ch-version-info:end -->