### PR TITLE
Fix dataset size in test 03554_json_shared_data_tuple_map_with_buckets_serialization_compact_part_big to avoid timeouts

### DIFF
--- a/tests/queries/0_stateless/03554_json_shared_data_tuple_map_with_buckets_serialization_compact_part_big.sql
+++ b/tests/queries/0_stateless/03554_json_shared_data_tuple_map_with_buckets_serialization_compact_part_big.sql
@@ -1,11 +1,8 @@
--- Tags: long, no-msan
+-- Tags: long
 -- Random settings limits: index_granularity=(100, None); index_granularity_bytes=(100000, None)
 
-SET max_threads = 'auto';
-SET max_block_size = 65000;
-
 drop table if exists test_compact_map_with_buckets_tuple;
-create table test_compact_map_with_buckets_tuple (json Tuple(data JSON(max_dynamic_paths=8))) engine=MergeTree order by tuple() settings min_bytes_for_wide_part='200G', min_rows_for_wide_part=1, write_marks_for_substreams_in_compact_parts=1, object_serialization_version='v3', object_shared_data_serialization_version='map_with_buckets', object_shared_data_serialization_version_for_zero_level_parts='map_with_buckets', object_shared_data_buckets_for_compact_part=2, index_granularity=8192, index_granularity_bytes='10Mi';
+create table test_compact_map_with_buckets_tuple (json Tuple(data JSON(max_dynamic_paths=8))) engine=MergeTree order by tuple() settings min_bytes_for_wide_part='200G', min_rows_for_wide_part=1, write_marks_for_substreams_in_compact_parts=1, object_serialization_version='v3', object_shared_data_serialization_version='map_with_buckets', object_shared_data_serialization_version_for_zero_level_parts='map_with_buckets', object_shared_data_buckets_for_compact_part=2;
 insert into test_compact_map_with_buckets_tuple select tuple(multiIf(
 number < 15000,
 '{"?1" : 1, "?2" : 1, "?3" : 1, "?4" : 1, "?5" : 1, "?6" : 1, "?7" : 1, "?8" : 1}',
@@ -20,7 +17,7 @@ number < 35000,
 number < 40000,
 '{"arr" : [{"arr1" : 11, "arr2" : 12, "arr3" : 13, "arr4" : 14}]}',
 '{"a" : {"a1" : 5, "a2" : 6}}'
-)) from numbers(450000);
+)) from numbers(45000);
 
 select 'select json.data';
 select json.data from test_compact_map_with_buckets_tuple format Null;


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only a stateless SQL test by reducing inserted rows and removing some tuning settings, with no production code impact.
> 
> **Overview**
> Reduces runtime of `03554_json_shared_data_tuple_map_with_buckets_serialization_compact_part_big.sql` by cutting the inserted dataset from `numbers(450000)` to `numbers(45000)`.
> 
> Simplifies the test setup by dropping the `no-msan` tag and removing explicit `SET max_threads`/`max_block_size` and extra `index_granularity*` table settings, keeping only the serialization-related settings under test.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 355f2a5401a5be85a3094932b8fab49091e58cbc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.526`
<!-- ch-version-info:end -->