### PR TITLE
Update Clone Table docs for clarity

### DIFF
--- a/docs/en/sql-reference/statements/create/table.md
+++ b/docs/en/sql-reference/statements/create/table.md
@@ -49,7 +49,7 @@ ClickHouse supports the ability to copy the schema and data of an existing table
 For replicating the schema of an existing table:
 
 ```sql
-CREATE TABLE [IF NOT EXISTS] [db.]table AS [db2.]new_table [ENGINE = engine]
+CREATE TABLE [IF NOT EXISTS] [db2.]table_clone AS [db.]table [ENGINE = engine]
 ```
 
 This creates a table with the same structure as another table. 

--- a/docs/en/sql-reference/statements/create/table.md
+++ b/docs/en/sql-reference/statements/create/table.md
@@ -42,7 +42,7 @@ If necessary, primary key can be specified, with one or more key expressions.
 
 Comments can be added for columns and for the table.
 
-### With Schema and Data of Existing Table {#clone-schema-data-existing-table}
+### With Schema of Existing Table {#with-a-schema-similar-to-other-table}
 
 ClickHouse supports the ability to copy the schema and data of an existing table. 
 
@@ -54,6 +54,7 @@ CREATE TABLE [IF NOT EXISTS] [db2.]table_clone AS [db.]table [ENGINE = engine]
 
 This creates a table with the same structure as another table. 
 
+### With Schema and Data of Existing Table {#with-a-schema-and-data-cloned-from-another-table}
 
 For replicating the schema and data of an existing table:
 ```sql

--- a/docs/en/sql-reference/statements/create/table.md
+++ b/docs/en/sql-reference/statements/create/table.md
@@ -22,7 +22,7 @@ By default, tables are created only on the current server. Distributed DDL queri
 ### With Explicit Schema {#with-explicit-schema}
 
 ```sql
-CREATE TABLE [IF NOT EXISTS] db.table_name [ON CLUSTER cluster]
+CREATE TABLE [IF NOT EXISTS] [db.]table_name [ON CLUSTER cluster]
 (
     name1 [type1] [NULL|NOT NULL] [DEFAULT|MATERIALIZED|EPHEMERAL|ALIAS expr1] [COMMENT 'comment for column'] [compression_codec] [TTL expr1],
     name2 [type2] [NULL|NOT NULL] [DEFAULT|MATERIALIZED|EPHEMERAL|ALIAS expr2] [COMMENT 'comment for column'] [compression_codec] [TTL expr2],
@@ -60,14 +60,14 @@ For replicating the schema and data of an existing table:
 CREATE TABLE [IF NOT EXISTS] [db2.]table_clone CLONE AS [db.]table [ENGINE = engine]
 ```
 
-This creates a table with the same schema and data as an existing table.  After the new table is created, all partitions from `db.table` are attached to it. In other words, the data of `[db.]table` is cloned into `[db2.]table_clone` upon creation. This query is equivalent to the following:
+This creates a table with the same schema and data as an existing table.  After the new table is created, all partitions from `db.table` are attached to it. In other words, the data of `db.table` is cloned into `db2.table_clone` upon creation. This query is equivalent to the following:
 
 ```sql
 CREATE TABLE [IF NOT EXISTS] [db.]table AS [db2.]table_clone [ENGINE = engine];
 ALTER TABLE [db2.]table_clone ATTACH PARTITION ALL FROM [db.]table;
 ```
 
-For both features, you can specify a different engine for the table. If the engine is not specified, the same engine will be used as for the original table (`[db.]table`).
+For both features, you can specify a different engine for the table. If the engine is not specified, the same engine will be used as for the original table (`db.table`).
 
 ### From a Table Function {#from-a-table-function}
 
@@ -80,7 +80,7 @@ Creates a table with the same result as that of the [table function](/sql-refere
 ### From SELECT query {#from-select-query}
 
 ```sql
-CREATE TABLE [IF NOT EXISTS] db.table_name[(name1 [type1], name2 [type2], ...)] ENGINE = engine AS SELECT ...
+CREATE TABLE [IF NOT EXISTS] [db.]table_name[(name1 [type1], name2 [type2], ...)] ENGINE = engine AS SELECT ...
 ```
 
 Creates a table with a structure like the result of the `SELECT` query, with the `engine` engine, and fills it with data from `SELECT`. Also you can explicitly specify columns description.
@@ -270,7 +270,7 @@ You can define a [primary key](../../../engines/table-engines/mergetree-family/m
 - Inside the column list
 
 ```sql
-CREATE TABLE db.table_name
+CREATE TABLE [db.]table_name
 (
     name1 type1, name2 type2, ...,
     PRIMARY KEY(expr1[, expr2,...])
@@ -281,7 +281,7 @@ ENGINE = engine;
 - Outside the column list
 
 ```sql
-CREATE TABLE db.table_name
+CREATE TABLE [db.]table_name
 (
     name1 type1, name2 type2, ...
 )
@@ -300,7 +300,7 @@ Along with columns descriptions constraints could be defined:
 ### CONSTRAINT {#constraint}
 
 ```sql
-CREATE TABLE [IF NOT EXISTS] db.table_name [ON CLUSTER cluster]
+CREATE TABLE [IF NOT EXISTS] [db.]table_name [ON CLUSTER cluster]
 (
     name1 [type1] [DEFAULT|MATERIALIZED|ALIAS expr1] [compression_codec] [TTL expr1],
     ...
@@ -581,7 +581,7 @@ WHERE CounterID <12345;
 ### Syntax {#syntax}
 
 ```sql
-{CREATE [OR REPLACE] | REPLACE} TABLE db.table_name
+{CREATE [OR REPLACE] | REPLACE} TABLE [db.]table_name
 ```
 
 :::note
@@ -715,7 +715,7 @@ You can add a comment to the table when creating it.
 **Syntax**
 
 ```sql
-CREATE TABLE db.table_name
+CREATE TABLE [db.]table_name
 (
     name1 type1, name2 type2, ...
 )

--- a/docs/en/sql-reference/statements/create/table.md
+++ b/docs/en/sql-reference/statements/create/table.md
@@ -49,7 +49,7 @@ ClickHouse supports the ability to copy the schema and data of an existing table
 For replicating the schema of an existing table:
 
 ```sql
-CREATE TABLE [IF NOT EXISTS] db.table AS db2.new_table [ENGINE = engine]
+CREATE TABLE [IF NOT EXISTS] [db.]table AS [db2.]new_table [ENGINE = engine]
 ```
 
 This creates a table with the same structure as another table. 
@@ -57,22 +57,22 @@ This creates a table with the same structure as another table.
 
 For replicating the schema and data of an existing table:
 ```sql
-CREATE TABLE [IF NOT EXISTS] db2.table_clone CLONE AS db.table [ENGINE = engine]
+CREATE TABLE [IF NOT EXISTS] [db2.]table_clone CLONE AS [db.]table [ENGINE = engine]
 ```
 
-This creates a table with the same schema and data as an existing table.  After the new table is created, all partitions from `db.table` are attached to it. In other words, the data of `db.table` is cloned into `db2.table_clone` upon creation. This query is equivalent to the following:
+This creates a table with the same schema and data as an existing table.  After the new table is created, all partitions from `db.table` are attached to it. In other words, the data of `[db.]table` is cloned into `[db2.]table_clone` upon creation. This query is equivalent to the following:
 
 ```sql
-CREATE TABLE [IF NOT EXISTS] db.table AS db2.table_clone [ENGINE = engine];
-ALTER TABLE db2.table_clone ATTACH PARTITION ALL FROM db.table;
+CREATE TABLE [IF NOT EXISTS] [db.]table AS [db2.]table_clone [ENGINE = engine];
+ALTER TABLE [db2.]table_clone ATTACH PARTITION ALL FROM [db.]table;
 ```
 
-For both features, you can specify a different engine for the table. If the engine is not specified, the same engine will be used as for the original table (`db.table`).
+For both features, you can specify a different engine for the table. If the engine is not specified, the same engine will be used as for the original table (`[db.]table`).
 
 ### From a Table Function {#from-a-table-function}
 
 ```sql
-CREATE TABLE [IF NOT EXISTS] db.table_name AS table_function()
+CREATE TABLE [IF NOT EXISTS] [db.]table_name AS table_function()
 ```
 
 Creates a table with the same result as that of the [table function](/sql-reference/table-functions) specified. The created table will also work in the same way as the corresponding table function that was specified.

--- a/docs/en/sql-reference/statements/create/table.md
+++ b/docs/en/sql-reference/statements/create/table.md
@@ -22,7 +22,7 @@ By default, tables are created only on the current server. Distributed DDL queri
 ### With Explicit Schema {#with-explicit-schema}
 
 ```sql
-CREATE TABLE [IF NOT EXISTS] [db.]table_name [ON CLUSTER cluster]
+CREATE TABLE [IF NOT EXISTS] db.table_name [ON CLUSTER cluster]
 (
     name1 [type1] [NULL|NOT NULL] [DEFAULT|MATERIALIZED|EPHEMERAL|ALIAS expr1] [COMMENT 'comment for column'] [compression_codec] [TTL expr1],
     name2 [type2] [NULL|NOT NULL] [DEFAULT|MATERIALIZED|EPHEMERAL|ALIAS expr2] [COMMENT 'comment for column'] [compression_codec] [TTL expr2],
@@ -42,31 +42,37 @@ If necessary, primary key can be specified, with one or more key expressions.
 
 Comments can be added for columns and for the table.
 
-### With a Schema Similar to Other Table {#with-a-schema-similar-to-other-table}
+### With Schema and Data of Existing Table {#clone-schema-data-existing-table}
+
+ClickHouse supports the ability to copy the schema and data of an existing table. 
+
+For replicating the schema of an existing table:
 
 ```sql
-CREATE TABLE [IF NOT EXISTS] [db.]table_name AS [db2.]name2 [ENGINE = engine]
+CREATE TABLE [IF NOT EXISTS] db.table AS db2.new_table [ENGINE = engine]
 ```
 
-Creates a table with the same structure as another table. You can specify a different engine for the table. If the engine is not specified, the same engine will be used as for the `db2.name2` table.
+This creates a table with the same structure as another table. 
 
-### With a Schema and Data Cloned from Another Table {#with-a-schema-and-data-cloned-from-another-table}
+
+For replicating the schema and data of an existing table:
+```sql
+CREATE TABLE [IF NOT EXISTS] db2.table_clone CLONE AS db.table [ENGINE = engine]
+```
+
+This creates a table with the same schema and data as an existing table.  After the new table is created, all partitions from `db.table` are attached to it. In other words, the data of `db.table` is cloned into `db2.table_clone` upon creation. This query is equivalent to the following:
 
 ```sql
-CREATE TABLE [IF NOT EXISTS] [db.]table_name CLONE AS [db2.]name2 [ENGINE = engine]
+CREATE TABLE [IF NOT EXISTS] db.table AS db2.table_clone [ENGINE = engine];
+ALTER TABLE db2.table_clone ATTACH PARTITION ALL FROM db.table;
 ```
 
-Creates a table with the same structure as another table. You can specify a different engine for the table. If the engine is not specified, the same engine will be used as for the `db2.name2` table. After the new table is created, all partitions from `db2.name2` are attached to it. In other words, the data of `db2.name2` is cloned into `db.table_name` upon creation. This query is equivalent to the following:
-
-```sql
-CREATE TABLE [IF NOT EXISTS] [db.]table_name AS [db2.]name2 [ENGINE = engine];
-ALTER TABLE [db.]table_name ATTACH PARTITION ALL FROM [db2].name2;
-```
+For both features, you can specify a different engine for the table. If the engine is not specified, the same engine will be used as for the original table (`db.table`).
 
 ### From a Table Function {#from-a-table-function}
 
 ```sql
-CREATE TABLE [IF NOT EXISTS] [db.]table_name AS table_function()
+CREATE TABLE [IF NOT EXISTS] db.table_name AS table_function()
 ```
 
 Creates a table with the same result as that of the [table function](/sql-reference/table-functions) specified. The created table will also work in the same way as the corresponding table function that was specified.
@@ -74,7 +80,7 @@ Creates a table with the same result as that of the [table function](/sql-refere
 ### From SELECT query {#from-select-query}
 
 ```sql
-CREATE TABLE [IF NOT EXISTS] [db.]table_name[(name1 [type1], name2 [type2], ...)] ENGINE = engine AS SELECT ...
+CREATE TABLE [IF NOT EXISTS] db.table_name[(name1 [type1], name2 [type2], ...)] ENGINE = engine AS SELECT ...
 ```
 
 Creates a table with a structure like the result of the `SELECT` query, with the `engine` engine, and fills it with data from `SELECT`. Also you can explicitly specify columns description.
@@ -294,7 +300,7 @@ Along with columns descriptions constraints could be defined:
 ### CONSTRAINT {#constraint}
 
 ```sql
-CREATE TABLE [IF NOT EXISTS] [db.]table_name [ON CLUSTER cluster]
+CREATE TABLE [IF NOT EXISTS] db.table_name [ON CLUSTER cluster]
 (
     name1 [type1] [DEFAULT|MATERIALIZED|ALIAS expr1] [compression_codec] [TTL expr1],
     ...
@@ -575,7 +581,7 @@ WHERE CounterID <12345;
 ### Syntax {#syntax}
 
 ```sql
-{CREATE [OR REPLACE] | REPLACE} TABLE [db.]table_name
+{CREATE [OR REPLACE] | REPLACE} TABLE db.table_name
 ```
 
 :::note

--- a/docs/en/sql-reference/statements/create/table.md
+++ b/docs/en/sql-reference/statements/create/table.md
@@ -63,7 +63,7 @@ CREATE TABLE [IF NOT EXISTS] [db2.]table_clone CLONE AS [db.]table [ENGINE = eng
 This creates a table with the same schema and data as an existing table.  After the new table is created, all partitions from `db.table` are attached to it. In other words, the data of `db.table` is cloned into `db2.table_clone` upon creation. This query is equivalent to the following:
 
 ```sql
-CREATE TABLE [IF NOT EXISTS] [db.]table AS [db2.]table_clone [ENGINE = engine];
+CREATE TABLE [IF NOT EXISTS] [db2.]table_clone AS [db.]table [ENGINE = engine];
 ALTER TABLE [db2.]table_clone ATTACH PARTITION ALL FROM [db.]table;
 ```
 


### PR DESCRIPTION
I updated the language for cloning a table in the docs to be a little more clear on how they map and which is the cloned table 

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Documentation entry for user-facing changes
...


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes that reword and correct example syntax/identifiers for `CREATE TABLE ... AS` and `CLONE AS`, plus minor placeholder consistency tweaks.
> 
> **Overview**
> Clarifies the `CREATE TABLE` docs around copying existing tables by renaming the section and rewriting the examples to make source vs destination tables explicit for both schema-only (`... AS ...`) and schema+data (`CLONE AS`) forms, including the equivalent `ATTACH PARTITION` sequence.
> 
> Also standardizes a few SQL snippets to use optional database placeholders (`[db.]table_name`) for consistency in the `Primary Key` and `COMMENT` sections.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7571d907cf36094a6981c7e74473466ce4d5dba5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.828`
<!-- ch-version-info:end -->