### PR TITLE
Fix flaky test_keeper_max_append_byte_size under sanitizers

### DIFF
--- a/tests/integration/test_keeper_max_append_byte_size/test.py
+++ b/tests/integration/test_keeper_max_append_byte_size/test.py
@@ -45,7 +45,7 @@ def change_byte_limit_and_restart(node, byte_limit):
         "<max_requests_append_bytes_size>[0-9]\\+</max_requests_append_bytes_size>",
         f"<max_requests_append_bytes_size>{byte_limit}</max_requests_append_bytes_size>",
     )
-    node.restart_clickhouse(stop_start_wait_sec=10)
+    node.restart_clickhouse()
     ku.wait_until_connected(cluster, node)
 
 


### PR DESCRIPTION
## Summary

- Remove hardcoded `stop_start_wait_sec=10` in `test_keeper_max_append_byte_size` which is too tight for MSan builds
- Under MSan, Keeper shutdown takes ~9.6s and startup with log replay takes ~9.5s, exceeding the 10s budget
- Falls back to the default 60s timeout which gives sanitizer builds enough headroom

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=98609&sha=bb3e34ed8836201ce9697300bb555874d6628713&name_0=PR&name_1=Integration%20tests%20%28amd_msan%2C%201%2F6%29
https://github.com/ClickHouse/ClickHouse/pull/98609

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that relaxes a restart timeout to avoid flakiness on slower (sanitizer) builds, with no production code impact.
> 
> **Overview**
> Fixes flakiness in `test_keeper_max_append_byte_size` by removing the hardcoded `stop_start_wait_sec=10` during `node.restart_clickhouse()`, allowing the default (longer) restart timeout.
> 
> This gives sanitizer builds more headroom for slower Keeper shutdown/startup and reduces intermittent integration test failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1c68a60e0dcfedf40ae8d34ee2ee9bdbecb29bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.489`
<!-- ch-version-info:end -->