### PR TITLE
Add window function + sort_overflow_mode deadlock coverage

### DIFF
--- a/tests/queries/0_stateless/04019_pipeline_stuck_sort_overflow.sql
+++ b/tests/queries/0_stateless/04019_pipeline_stuck_sort_overflow.sql
@@ -1,4 +1,9 @@
 -- https://github.com/ClickHouse/ClickHouse/issues/57728
 -- Window functions require fully sorted data, so sort_overflow_mode = 'break' is overridden to 'throw'
 -- for the sorting step used by window functions. This prevents the pipeline from getting stuck.
+
+-- New analyzer path (Planner.cpp::addWindowSteps)
 SELECT sum(a[length(a)]) FROM (SELECT groupArray(number) OVER (PARTITION BY number % 11 ORDER BY number) AS a FROM numbers_mt(10000)) FORMAT Null SETTINGS max_block_size = 8, max_rows_to_sort = 100, sort_overflow_mode = 'break', max_bytes_before_external_sort = 0, max_bytes_ratio_before_external_sort = 0; -- { serverError TOO_MANY_ROWS_OR_BYTES }
+
+-- Old planner path (InterpreterSelectQuery::executeWindow), same fix must apply
+SELECT sum(a[length(a)]) FROM (SELECT groupArray(number) OVER (PARTITION BY number % 11 ORDER BY number) AS a FROM numbers_mt(10000)) FORMAT Null SETTINGS max_block_size = 8, max_rows_to_sort = 100, sort_overflow_mode = 'break', max_bytes_before_external_sort = 0, max_bytes_ratio_before_external_sort = 0, enable_analyzer = 0; -- { serverError TOO_MANY_ROWS_OR_BYTES }


### PR DESCRIPTION
PR #98543 fixed a pipeline deadlock when sort_overflow_mode = 'break' is used with window functions by overriding it to throw in both Planner.cpp (new analyzer) and InterpreterSelectQuery.cpp (old planner). Its test only covered the new analyzer path since enable_analyzer = 1 is the default.

Adds both paths to 01131_max_rows_to_sort — the existing test that already owns sort_overflow_mode behaviour — so the InterpreterSelectQuery::executeWindow fix is independently guarded.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only extends a stateless SQL regression test to cover an additional execution path, with no production code changes.
> 
> **Overview**
> Adds regression coverage for the `sort_overflow_mode='break'` + window function case that previously could cause a stuck pipeline.
> 
> The test now runs the same query twice—once via the default *new analyzer* path and once with `enable_analyzer = 0` to exercise the *old planner*—and asserts both fail with `TOO_MANY_ROWS_OR_BYTES` (i.e., overflow is forced to throw rather than break).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 176f7998f1a3975801cc956c762272cac2c58cc8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.507`
<!-- ch-version-info:end -->