### PR TITLE
Fix fix-stuck-auto-merge not handling UNKNOWN mergeStateStatus

### DIFF
--- a/.github/workflows/retry_infra_failures.yml
+++ b/.github/workflows/retry_infra_failures.yml
@@ -155,8 +155,9 @@ jobs:
           now=$(date +%s)
           cutoff_seconds=3600  # 60 minutes
 
-          # Get open PRs with auto-merge enabled that have mergeStateStatus=CLEAN
-          # (checks passed but not queued into merge queue).
+          # Get open PRs with auto-merge enabled that have mergeStateStatus CLEAN
+          # or UNKNOWN (checks passed but not queued into merge queue).
+          # UNKNOWN can happen when GitHub's merge status evaluation gets stuck.
           # We use GraphQL pagination (20 PRs per page) to avoid 502 errors
           # that occur when fetching too many PRs in a single request.
           owner="${GH_REPO%%/*}"
@@ -191,7 +192,7 @@ jobs:
             filtered=$(echo "$response" | jq '[
               .data.repository.pullRequests.nodes[] | select(
                 .autoMergeRequest != null and
-                .mergeStateStatus == "CLEAN" and
+                (.mergeStateStatus == "CLEAN" or .mergeStateStatus == "UNKNOWN") and
                 .isDraft == false
               ) | {number, autoMergeRequest, mergeStateStatus, isDraft}
             ]')


### PR DESCRIPTION
## Summary
- PR #98486 has auto-merge enabled and all checks passing, but `mergeStateStatus` is `UNKNOWN` instead of `CLEAN` — GitHub's merge status evaluation got stuck
- The `fix-stuck-auto-merge` job in `retry_infra_failures` only matched `CLEAN`, so such PRs were never retoggled
- Fix: also match `UNKNOWN` status so these stuck PRs get their auto-merge retoggled

### Changelog category (leave one):
- CI Fix or improvement

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Fix `retry_infra_failures` workflow not retoggling auto-merge for PRs with `UNKNOWN` merge state status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small GitHub Actions workflow change that only broadens the filter for “stuck auto-merge” PRs; low risk but could retoggle auto-merge on additional PRs that meet the age and auto-merge criteria.
> 
> **Overview**
> The `fix-stuck-auto-merge` job in `.github/workflows/retry_infra_failures.yml` now includes PRs whose `mergeStateStatus` is `UNKNOWN` (in addition to `CLEAN`) when searching for auto-merge-enabled PRs that are not entering the merge queue, and documents why this status can occur.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28dfac0038159e1927d4b7bd76c31870c7cba1eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.490`
<!-- ch-version-info:end -->