### PR TITLE
Fix race condition causing 'ReadBuffer is canceled' exception

### DIFF
--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -2691,20 +2691,34 @@ void TCPHandler::receivePacketsExpectCancel(QueryState & state)
     /// During request execution the only packet that can come from the client is stopping the query.
     if (in->poll(0))
     {
-        if (in->isCanceled() || in->eof())
-            throw NetException(ErrorCodes::ABORTED, "Client has dropped the connection, cancel the query.");
-
-        UInt64 packet_type = 0;
-        readVarUInt(packet_type, *in);
-
-        switch (packet_type)
+        try
         {
-            case Protocol::Client::Cancel:
-                processCancel(state);
-                break;
+            if (in->isCanceled() || in->eof())
+                throw NetException(ErrorCodes::ABORTED, "Client has dropped the connection, cancel the query.");
 
-            default:
-                throw NetException(ErrorCodes::UNKNOWN_PACKET_FROM_CLIENT, "Unknown packet from client {}", toString(packet_type));
+            UInt64 packet_type = 0;
+            readVarUInt(packet_type, *in);
+
+            switch (packet_type)
+            {
+                case Protocol::Client::Cancel:
+                    processCancel(state);
+                    break;
+
+                default:
+                    throw NetException(ErrorCodes::UNKNOWN_PACKET_FROM_CLIENT, "Unknown packet from client {}", toString(packet_type));
+            }
+        }
+        catch (...)
+        {
+            /// Mark the query as stopped so that other callbacks (e.g. ClusterFunctionReadTaskCallback)
+            /// that are waiting on callback_mutex will see the cancellation via checkIfQueryCanceled()
+            /// before attempting to read from the now-broken connection.
+            /// Without this, a race condition exists: when this function throws while holding callback_mutex,
+            /// the mutex is released during stack unwinding, and a pipeline worker thread can acquire it
+            /// and attempt to read from the canceled ReadBuffer before the executor is canceled.
+            state.stop_query = true;
+            throw;
         }
     }
 }


### PR DESCRIPTION
## Summary

- Fixed a race condition in `TCPHandler` where `receivePacketsExpectCancel` could cancel the TCP `ReadBuffer` and then release `callback_mutex` during exception stack unwinding, allowing a pipeline worker thread to acquire the mutex and attempt to read from the canceled buffer before the executor is canceled
- The worker thread passes `checkIfQueryCanceled` because `stop_query` hasn't been set yet, then hits `chassert(!isCanceled())` in `ReadBuffer::next`
- Fix: set `state.stop_query = true` in `receivePacketsExpectCancel`'s catch block before re-throwing, so callbacks see the cancellation immediately

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=98895&sha=d7e87bb2b7ecb3490ad63a12113fbc92fc8e488e&name_0=PR&name_1=BuzzHouse%20%28amd_msan%29
https://github.com/ClickHouse/ClickHouse/pull/98895

Closes #98866

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a race condition that could cause a "ReadBuffer is canceled" exception in queries using `urlCluster` or similar cluster table functions.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches TCP query-cancellation/error paths and changes how cancellation is signaled across threads, which could affect query termination behavior under network failures.
> 
> **Overview**
> Fixes a race in `TCPHandler::receivePacketsExpectCancel()` by wrapping cancel-packet polling/reading in a `try/catch` and **setting `state.stop_query = true` before rethrowing** on any read/parsing error or disconnect.
> 
> This ensures other callback-driven worker threads see cancellation via `checkIfQueryCanceled()` immediately after the connection breaks, avoiding reads from a canceled `ReadBuffer` that previously could trigger "ReadBuffer is canceled" exceptions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e858e333acc06ad8721eda0325092ad67aa33db8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.496`
<!-- ch-version-info:end -->