### PR TITLE
Disable 03998_distributed_insert_detach_race for s3 storage

### DIFF
--- a/tests/queries/0_stateless/03998_distributed_insert_detach_race.sh
+++ b/tests/queries/0_stateless/03998_distributed_insert_detach_race.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: long
+# Tags: long, no-s3-storage
 
 # Stress test for the race between async INSERT into Distributed and DETACH.
 # Before the fix, this could cause "Cannot schedule a file" LOGICAL_ERROR.


### PR DESCRIPTION
## Summary

- The test `03998_distributed_insert_detach_race` times out in s3 storage CI configurations because each distributed INSERT through s3 in debug mode is slow, and 100 iterations exceed the test timeout.
- The test does not specifically test s3 storage functionality — it tests the race between async INSERT and DETACH on Distributed tables.
- Added `no-s3-storage` tag to skip it in s3 storage runs.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=98691&sha=c88d313b2cef97759f61a3d889fcca25cbbb3fbe&name_0=PR&name_1=Stateless%20tests%20%28amd_debug%2C%20AsyncInsert%2C%20s3%20storage%2C%20parallel%29
https://github.com/ClickHouse/ClickHouse/pull/98691

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts a test tag to skip a known-slow stress test in S3-storage CI runs, with no production code changes.
> 
> **Overview**
> Marks `03998_distributed_insert_detach_race.sh` with the `no-s3-storage` tag so this long-running Distributed `INSERT`/`DETACH` race stress test is skipped when running CI with S3-backed storage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d99ee9a5ddb9be02d11c024cac0782438c789ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.492`
<!-- ch-version-info:end -->