### PR TITLE
Fix exception in financial functions with BFloat16 arguments

### DIFF
--- a/src/DataTypes/IDataType.cpp
+++ b/src/DataTypes/IDataType.cpp
@@ -443,6 +443,7 @@ bool isDecimal(TYPE data_type) { return WhichDataType(data_type).isDecimal(); } 
 bool isDecimal64(TYPE data_type) { return WhichDataType(data_type).isDecimal64(); } \
 \
 bool isFloat(TYPE data_type) { return WhichDataType(data_type).isFloat(); } \
+bool isNativeFloat(TYPE data_type) { return WhichDataType(data_type).isNativeFloat(); } \
 \
 bool isIntegerOrDecimal(TYPE data_type) { return WhichDataType(data_type).isIntegerOrDecimal(); } \
 bool isNativeNumber(TYPE data_type) { return WhichDataType(data_type).isNativeNumber(); } \

--- a/src/DataTypes/IDataType.h
+++ b/src/DataTypes/IDataType.h
@@ -499,6 +499,7 @@ bool isDecimal(TYPE data_type); \
 bool isDecimal64(TYPE data_type); \
 \
 bool isFloat(TYPE data_type); \
+bool isNativeFloat(TYPE data_type); \
 \
 bool isIntegerOrDecimal(TYPE data_type); \
 bool isNativeNumber(TYPE data_type); \

--- a/src/Functions/financial.cpp
+++ b/src/Functions/financial.cpp
@@ -339,7 +339,7 @@ bool isCashFlowColumn(const IDataType & type)
     if (isArray(type))
     {
         const auto & nested = checkAndGetDataType<DataTypeArray>(type).getNestedType();
-        return isNativeInt(nested) || isFloat(nested);
+        return isNativeInt(nested) || isNativeFloat(nested);
     }
     return false;
 }
@@ -404,7 +404,7 @@ public:
         };
 
         auto optional_args = FunctionArgumentDescriptors{
-            {"guess", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isFloat), nullptr, "Float32|Float64"},
+            {"guess", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isNativeFloat), nullptr, "Float32|Float64"},
             {"daycount", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isString), nullptr, "String"},
         };
 
@@ -521,7 +521,7 @@ public:
         };
 
         auto optional_args = FunctionArgumentDescriptors{
-            {"guess", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isFloat), nullptr, "Float32|Float64"},
+            {"guess", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isNativeFloat), nullptr, "Float32|Float64"},
         };
 
         validateFunctionArguments(*this, arguments, mandatory_args, optional_args);
@@ -611,7 +611,7 @@ public:
     DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override
     {
         auto mandatory_args = FunctionArgumentDescriptors{
-            {"rate", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isFloat), nullptr, "Float32|Float64"},
+            {"rate", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isNativeFloat), nullptr, "Float32|Float64"},
             {"cashflow",
              static_cast<FunctionArgumentDescriptor::TypeValidator>(&isCashFlowColumn),
              nullptr,
@@ -728,7 +728,7 @@ public:
     DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override
     {
         auto mandatory_args = FunctionArgumentDescriptors{
-            {"rate", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isFloat), nullptr, "Float32|Float64"},
+            {"rate", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isNativeFloat), nullptr, "Float32|Float64"},
             {"cashflow",
              static_cast<FunctionArgumentDescriptor::TypeValidator>(&isCashFlowColumn),
              nullptr,

--- a/tests/queries/0_stateless/04031_financial_functions_bfloat16.sql
+++ b/tests/queries/0_stateless/04031_financial_functions_bfloat16.sql
@@ -1,0 +1,15 @@
+-- Test that BFloat16 arguments are rejected by financial functions (they only support Float32/Float64).
+-- Previously this caused a LOGICAL_ERROR exception because the type validator accepted BFloat16
+-- but the execution dispatch only handled Float32 and Float64.
+
+SELECT financialNetPresentValue(toBFloat16(0.1), [-100., 110.]); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT financialNetPresentValue(0.1, [toBFloat16(-100), toBFloat16(110)]); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+
+SELECT financialNetPresentValueExtended(toBFloat16(0.1), [-10000., 5750.], [toDate('2020-01-01'), toDate('2020-03-01')]); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT financialNetPresentValueExtended(0.1, [toBFloat16(-10000), toBFloat16(5750)], [toDate('2020-01-01'), toDate('2020-03-01')]); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+
+SELECT financialInternalRateOfReturn([toBFloat16(-100), toBFloat16(110)]); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT financialInternalRateOfReturn([-100., 110.], toBFloat16(0.5)); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+
+SELECT financialInternalRateOfReturnExtended([toBFloat16(-10000), toBFloat16(5750)], [toDate('2020-01-01'), toDate('2020-03-01')]); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT financialInternalRateOfReturnExtended([-10000., 5750.], [toDate('2020-01-01'), toDate('2020-03-01')], toBFloat16(0.5)); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }


### PR DESCRIPTION
Fix exception in financial functions when `BFloat16` arguments are passed.

The type validators in financial functions (`financialNetPresentValue`, `financialInternalRateOfReturn`, `financialInternalRateOfReturnExtended`, `financialNetPresentValueExtended`) used `isFloat` which accepts `BFloat16`, but the execution dispatch only handles `Float32` and `Float64`, causing a `LOGICAL_ERROR` exception.

Fix by using `isNativeFloat` (Float32/Float64 only) instead of `isFloat` in the type validators. Also add `isNativeFloat` as a free function in `IDataType` alongside the existing type checker functions.

AST fuzzer report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=d8593537b9feba25cb51c8665eb36ce4a3da0051&name_0=MasterCI&name_1=AST%20fuzzer%20%28amd_tsan%29

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `LOGICAL_ERROR` exception in financial functions (`financialNetPresentValue`, `financialInternalRateOfReturn`, etc.) when `BFloat16` type arguments are passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: tightens type validation for financial functions to match existing execution dispatch (Float32/Float64 only) and adds a simple `IDataType` helper; main risk is unintended rejection of previously-accepted BFloat16 inputs.
> 
> **Overview**
> Fixes a crash path in financial functions when `BFloat16` arguments are provided by tightening validators to accept only *native* floats (`Float32`/`Float64`).
> 
> Adds an `isNativeFloat` free helper alongside existing `IDataType` type-checkers and updates `financialNetPresentValue*`/`financialInternalRateOfReturn*` argument validation (including cashflow array element checks) to use it, plus a new stateless query test ensuring `BFloat16` now fails with `ILLEGAL_TYPE_OF_ARGUMENT` instead of `LOGICAL_ERROR`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d2237e396c55a18c783f9d07373743bef40bf866. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Closes https://github.com/ClickHouse/ClickHouse/issues/98905


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.495`
<!-- ch-version-info:end -->