### PR TITLE
Fix logical error (bad cast to ASTLiteral) in mergeTreeAnalyzeIndexes

### DIFF
--- a/src/TableFunctions/TableFunctionMergeTreeAnalyzeIndexes.cpp
+++ b/src/TableFunctions/TableFunctionMergeTreeAnalyzeIndexes.cpp
@@ -66,7 +66,13 @@ std::vector<String> extractParts(const ASTPtr & argument, const ContextPtr & con
         {
             std::vector<String> result;
             for (const auto & element : expr_list->children)
-                result.push_back(evaluateConstantExpressionAsLiteral(element, context)->as<ASTLiteral &>().value.safeGet<String>());
+            {
+                auto evaluated = evaluateConstantExpressionAsLiteral(element, context);
+                const auto * literal = evaluated->as<ASTLiteral>();
+                if (!literal)
+                    throw Exception(ErrorCodes::BAD_ARGUMENTS, "Parts array element must be a string literal, got: {}", element->formatForLogging());
+                result.push_back(literal->value.safeGet<String>());
+            }
             return result;
         }
     }

--- a/tests/queries/0_stateless/04031_mergetree_analyze_indexes_bad_cast.sql
+++ b/tests/queries/0_stateless/04031_mergetree_analyze_indexes_bad_cast.sql
@@ -1,0 +1,7 @@
+DROP TABLE IF EXISTS data;
+CREATE TABLE data (key Int) ENGINE = MergeTree ORDER BY key;
+INSERT INTO data VALUES (1);
+
+SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), data, materialize(0), array('all_1_1_0', toUInt128(9))); -- { serverError BAD_ARGUMENTS }
+
+DROP TABLE data;


### PR DESCRIPTION
Fix logical error (bad cast to `ASTLiteral`) in `mergeTreeAnalyzeIndexes` table function.

The AST fuzzer found that passing non-literal elements in the parts array (e.g. `toUInt128(9)`) caused an unchecked `typeid_cast` to `ASTLiteral` which threw a logical error instead of a proper user-facing exception.

Use a safe cast and throw `BAD_ARGUMENTS` when the element cannot be evaluated to a literal.

Failing query: `SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), data, materialize(0), array('all_1_1_0', toUInt128(9)))`

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=8d7c4f730c2701fb4b3909f5c77ab3e2796f4807&name_0=MasterCI&name_1=AST%20fuzzer%20%28amd_debug%29

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix logical error "Bad cast from type A to B" in `mergeTreeAnalyzeIndexes` table function when parts array contains non-literal elements.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: tight change to argument validation/error handling in a niche table function, plus a regression test; behavior only differs for invalid inputs.
> 
> **Overview**
> Fixes `mergeTreeAnalyzeIndexes` parts-array parsing to **avoid an unsafe cast** when evaluating array elements: it now checks the evaluated node is an `ASTLiteral` and throws a user-facing `BAD_ARGUMENTS` error with a clear message for non-string literals.
> 
> Adds a stateless regression test that passes a non-literal (`toUInt128(9)`) in the parts array and asserts `BAD_ARGUMENTS` instead of a logical-error crash.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19c2dfa14e67ec66ff0191a21a13b6c0570b1822. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->