### PR TITLE
Fix skip index not used for ALIAS columns when query plan expression merging is disabled

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/optimizePrimaryKeyConditionAndLimit.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizePrimaryKeyConditionAndLimit.cpp
@@ -22,22 +22,40 @@ void optimizePrimaryKeyConditionAndLimit(const Stack & stack)
     if (storage_prewhere_info)
         source_step_with_filter->addFilter(storage_prewhere_info->prewhere_actions.clone(), storage_prewhere_info->prewhere_column_name);
 
+    /// Collect ExpressionStep DAGs encountered while walking up the plan.
+    /// When a filter references columns produced by expressions (e.g., ALIAS
+    /// columns computed in "Compute alias columns" step, or renamed in
+    /// "Change column names to column identifiers" step), we compose the
+    /// filter through these expression DAGs so that column references are
+    /// resolved to physical columns. This is essential for correct index
+    /// analysis when plan optimizations like mergeExpressions have not
+    /// merged these steps into the filter.
+    std::vector<const ActionsDAG *> expression_dags;
+
     for (auto iter = stack.rbegin() + 1; iter != stack.rend(); ++iter)
     {
         if (auto * filter_step = typeid_cast<FilterStep *>(iter->node->step.get()))
         {
-            source_step_with_filter->addFilter(filter_step->getExpression().clone(), filter_step->getFilterColumnName());
+            auto filter_dag = filter_step->getExpression().clone();
+            auto filter_column_name = filter_step->getFilterColumnName();
+
+            /// Compose filter through accumulated expression DAGs
+            /// (in bottom-to-top order). This resolves column identifiers
+            /// to their underlying expressions, enabling correct index
+            /// matching for ALIAS columns and renamed columns.
+            for (auto it = expression_dags.rbegin(); it != expression_dags.rend(); ++it)
+                filter_dag = ActionsDAG::merge((*it)->clone(), std::move(filter_dag));
+
+            source_step_with_filter->addFilter(std::move(filter_dag), filter_column_name);
         }
         else if (auto * limit_step = typeid_cast<LimitStep *>(iter->node->step.get()))
         {
             source_step_with_filter->setLimit(limit_step->getLimitForSorting());
             break;
         }
-        else if (typeid_cast<ExpressionStep *>(iter->node->step.get()))
+        else if (auto * expression_step = typeid_cast<ExpressionStep *>(iter->node->step.get()))
         {
-            /// Note: actually, plan optimizations merge Filter and Expression steps.
-            /// Ideally, chain should look like (Expression -> ...) -> (Filter -> ...) -> ReadFromStorage,
-            /// So this is likely not needed.
+            expression_dags.push_back(&expression_step->getExpression());
             continue;
         }
         else

--- a/tests/queries/0_stateless/03822_alias_column_skip_index_no_merge.reference
+++ b/tests/queries/0_stateless/03822_alias_column_skip_index_no_merge.reference
@@ -1,0 +1,85 @@
+merge_expressions=0
+Expression (Project names)
+  Expression (Projection)
+    Filter (WHERE)
+      Expression (Change column names to column identifiers)
+        Expression (Compute alias columns)
+          ReadFromMergeTree (default.test_alias_skip_idx)
+          Indexes:
+            PrimaryKey
+              Keys:
+                c
+              Condition: (plus(c, 1) in [101, +Inf))
+              Parts: 1/2
+              Granules: 1/2
+              Search Algorithm: generic exclusion search
+            Skip
+              Name: idx_a
+              Description: minmax GRANULARITY 1
+              Condition: (plus(c, 1) in [101, +Inf))
+              Parts: 1/1
+              Granules: 1/1
+            Ranges: 1
+enable_optimizations=0
+Expression (Project names)
+  Expression (Projection)
+    Filter (WHERE)
+      Expression (Change column names to column identifiers)
+        Expression (Compute alias columns)
+          ReadFromMergeTree (default.test_alias_skip_idx)
+          Indexes:
+            PrimaryKey
+              Keys:
+                c
+              Condition: (plus(c, 1) in [101, +Inf))
+              Parts: 1/2
+              Granules: 1/2
+              Search Algorithm: generic exclusion search
+            Skip
+              Name: idx_a
+              Description: minmax GRANULARITY 1
+              Condition: (plus(c, 1) in [101, +Inf))
+              Parts: 1/1
+              Granules: 1/1
+            Ranges: 1
+nested_alias
+Expression (Project names)
+  Expression (Projection)
+    Filter (WHERE)
+      Expression (Change column names to column identifiers)
+        Expression (Compute alias columns)
+          ReadFromMergeTree (default.test_nested_alias_idx)
+          Indexes:
+            PrimaryKey
+              Keys:
+                c
+              Condition: (plus(plus(c, 1), 1) in [101, +Inf))
+              Parts: 1/2
+              Granules: 1/2
+              Search Algorithm: generic exclusion search
+            Skip
+              Name: idx_a2
+              Description: minmax GRANULARITY 1
+              Condition: (plus(plus(c, 1), 1) in [101, +Inf))
+              Parts: 1/1
+              Granules: 1/1
+            Ranges: 1
+default_settings
+Expression ((Project names + Projection))
+  Filter ((WHERE + (Change column names to column identifiers + Compute alias columns)))
+    ReadFromMergeTree (default.test_alias_skip_idx)
+    Indexes:
+      PrimaryKey
+        Keys:
+          c
+        Condition: (plus(c, 1) in [101, +Inf))
+        Parts: 1/2
+        Granules: 1/2
+        Search Algorithm: generic exclusion search
+      Skip
+        Name: idx_a
+        Description: minmax GRANULARITY 1
+        Condition: (plus(c, 1) in [101, +Inf))
+        Parts: 1/1
+        Granules: 1/1
+      Ranges: 1

--- a/tests/queries/0_stateless/03822_alias_column_skip_index_no_merge.sql
+++ b/tests/queries/0_stateless/03822_alias_column_skip_index_no_merge.sql
@@ -1,0 +1,59 @@
+-- Test that skip indexes on ALIAS columns work even when query plan
+-- expression merging is disabled, which prevents tryMergeExpressions
+-- from composing filter and expression steps.
+-- Regression test for issue #98822.
+
+SET enable_analyzer = 1;
+
+DROP TABLE IF EXISTS test_alias_skip_idx;
+
+CREATE TABLE test_alias_skip_idx
+(
+    c UInt32,
+    a ALIAS c + 1,
+    INDEX idx_a (a) TYPE minmax GRANULARITY 1
+)
+ENGINE = MergeTree
+ORDER BY c
+SETTINGS index_granularity = 8192, add_minmax_index_for_numeric_columns = 0;
+
+INSERT INTO test_alias_skip_idx SELECT number FROM numbers(10);
+INSERT INTO test_alias_skip_idx SELECT number + 200 FROM numbers(10);
+
+-- Test 1: Skip index used with merge_expressions disabled
+SELECT 'merge_expressions=0';
+EXPLAIN indexes = 1 SELECT * FROM test_alias_skip_idx WHERE a > 100
+SETTINGS query_plan_merge_expressions = 0;
+
+-- Test 2: Skip index used with all optimizations disabled
+SELECT 'enable_optimizations=0';
+EXPLAIN indexes = 1 SELECT * FROM test_alias_skip_idx WHERE a > 100
+SETTINGS query_plan_enable_optimizations = 0;
+
+-- Test 3: Nested ALIAS columns
+DROP TABLE IF EXISTS test_nested_alias_idx;
+
+CREATE TABLE test_nested_alias_idx
+(
+    c UInt32,
+    a1 ALIAS c + 1,
+    a2 ALIAS a1 + 1,
+    INDEX idx_a2 (a2) TYPE minmax GRANULARITY 1
+)
+ENGINE = MergeTree
+ORDER BY c
+SETTINGS index_granularity = 8192, add_minmax_index_for_numeric_columns = 0;
+
+INSERT INTO test_nested_alias_idx SELECT number FROM numbers(10);
+INSERT INTO test_nested_alias_idx SELECT number + 200 FROM numbers(10);
+
+SELECT 'nested_alias';
+EXPLAIN indexes = 1 SELECT * FROM test_nested_alias_idx WHERE a2 > 100
+SETTINGS query_plan_merge_expressions = 0;
+
+-- Test 4: Default settings still work (regression guard)
+SELECT 'default_settings';
+EXPLAIN indexes = 1 SELECT * FROM test_alias_skip_idx WHERE a > 100;
+
+DROP TABLE test_alias_skip_idx;
+DROP TABLE test_nested_alias_idx;

--- a/tests/queries/0_stateless/03822_alias_column_skip_index_no_merge.sql
+++ b/tests/queries/0_stateless/03822_alias_column_skip_index_no_merge.sql
@@ -1,3 +1,4 @@
+-- Tags: no-parallel-replicas
 -- Test that skip indexes on ALIAS columns work even when query plan
 -- expression merging is disabled, which prevents tryMergeExpressions
 -- from composing filter and expression steps.


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

 
### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
  Fix skip indexes (and primary key conditions) not being applied for ALIAS columns when query plan expression merging is disabled (query_plan_merge_expressions = 0
  or query_plan_enable_optimizations = 0).

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

  When query plan expression merging is disabled, ExpressionStep nodes like "Compute alias columns" and "Change column names to column identifiers" remain separate
  from filter steps. The optimizePrimaryKeyConditionAndLimit optimization previously ignored these expression steps, causing filters on ALIAS columns to reference
  unresolved column identifiers that the storage layer could not match against indexes.

  This fix composes filter DAGs through accumulated expression DAGs (in bottom-to-top order) so that ALIAS column references are resolved to their underlying physical
  column expressions, enabling correct primary key and skip index analysis regardless of whether expression merging is active.

  Fixes #98822

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches query-plan optimization that builds primary key/skip index conditions; incorrect DAG composition could change which indexes are used or filter semantics for some plans. Covered by new regression tests, but the change impacts a performance-critical path.
> 
> **Overview**
> Fixes index analysis when `query_plan_merge_expressions=0` (or optimizations are disabled) by composing `FilterStep` DAGs through intervening `ExpressionStep` DAGs in `optimizePrimaryKeyConditionAndLimit`, so filters on ALIAS/renamed columns resolve to underlying physical expressions before being applied to storage.
> 
> Adds a stateless regression test (`03822_alias_column_skip_index_no_merge`) verifying `EXPLAIN indexes=1` shows primary key and skip index conditions for ALIAS and nested-ALIAS predicates both with expression merging/optimizations disabled and under default settings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f9999043835f2cd7c3b92bdd0e020955010c412. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.516`
<!-- ch-version-info:end -->