### PR TITLE
Fix logical error when using loop with cluster table functions

### DIFF
--- a/src/Processors/QueryPlan/ReadFromLoopStep.cpp
+++ b/src/Processors/QueryPlan/ReadFromLoopStep.cpp
@@ -5,8 +5,10 @@
 #include <Interpreters/InterpreterSelectWithUnionQuery.h>
 #include <Interpreters/SelectQueryOptions.h>
 #include <Parsers/ASTExpressionList.h>
+#include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTSelectQuery.h>
+#include <Parsers/ASTTablesInSelectQuery.h>
 #include <Parsers/ASTSelectWithUnionQuery.h>
 #include <Processors/Executors/PullingPipelineExecutor.h>
 #include <Processors/ISource.h>
@@ -125,11 +127,39 @@ public:
         else
         {
             auto storage_snapshot_ = inner_storage->getStorageSnapshot(inner_storage->getInMemoryMetadataPtr(), context);
+
+            /// Unwrap the `loop` wrapper from the query AST so the inner storage
+            /// sees a query with its own table function (e.g. `urlCluster(...)` instead of `loop(urlCluster(...))`).
+            /// This is needed because cluster storages extract the table function from the query
+            /// and expect it to match their own name.
+            auto modified_query_info = query_info;
+            if (modified_query_info.query)
+            {
+                modified_query_info.query = modified_query_info.query->clone();
+                auto * select_query = modified_query_info.query->as<ASTSelectQuery>();
+                if (select_query && select_query->tables())
+                {
+                    auto * tables = select_query->tables()->as<ASTTablesInSelectQuery>();
+                    if (tables && !tables->children.empty())
+                    {
+                        auto * table_expression = tables->children[0]->as<ASTTablesInSelectQueryElement>()->table_expression->as<ASTTableExpression>();
+                        if (table_expression && table_expression->table_function)
+                        {
+                            auto * func = table_expression->table_function->as<ASTFunction>();
+                            if (func && func->arguments && func->arguments->children.size() == 1)
+                            {
+                                table_expression->table_function = func->arguments->children[0];
+                            }
+                        }
+                    }
+                }
+            }
+
             inner_storage->read(
                     plan,
                     column_names,
                     storage_snapshot_,
-                    query_info,
+                    modified_query_info,
                     context,
                     processed_stage,
                     max_block_size,

--- a/tests/queries/0_stateless/04031_loop_with_cluster_table_function.sql
+++ b/tests/queries/0_stateless/04031_loop_with_cluster_table_function.sql
@@ -1,0 +1,6 @@
+-- Tags: no-fasttest
+-- Verify that loop() wrapping a cluster table function does not cause a logical error.
+
+SELECT * FROM loop(urlCluster('test_cluster_two_shards_localhost', 'http://localhost:11111/test/a.tsv')) LIMIT 1 FORMAT Null;
+SELECT * FROM loop(urlCluster('test_cluster_two_shards_localhost', 'http://localhost:11111/test/a.tsv', 'TSV')) LIMIT 1 FORMAT Null;
+SELECT * FROM loop(urlCluster('test_cluster_two_shards_localhost', 'http://localhost:11111/test/a.tsv', 'TSV', 'c1 UInt64, c2 UInt64, c3 UInt64')) LIMIT 1 FORMAT Null;


### PR DESCRIPTION
## Summary

- When `loop(urlCluster(...))` (or `fileCluster`, `s3Cluster`, etc.) is used, the inner cluster storage receives the original query AST which has `loop` as the outermost table function. The cluster storage extracts this function and expects it to match its own name, causing a logical error exception: "Unexpected table function name: loop".
- Fix by unwrapping the `loop` wrapper from the query AST in `LoopSource::initLoop` before delegating to the inner storage.
- Found by BuzzHouse fuzzer: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=5d5495fecfa4dfe7ac968fb4a837bf4c48e58380&name_0=MasterCI&name_1=BuzzHouse%20%28amd_debug%29

### Changelog category:
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry:
Fix logical error exception "Unexpected table function name" when using the `loop` table function wrapping cluster table functions like `urlCluster`, `fileCluster`, or `s3Cluster`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes query AST rewriting in `ReadFromLoopStep` before calling `inner_storage->read`, which could affect how `loop()` is interpreted for some table-function queries. Scope is small and covered by a new stateless test for `loop(urlCluster(...))` variants.
> 
> **Overview**
> Fixes a logical error when `loop()` wraps a cluster table function (e.g. `loop(urlCluster(...))`) by cloning the query AST and unwrapping the outer `loop` table function so the inner storage sees its expected function name.
> 
> Adds a stateless regression test (`04031_loop_with_cluster_table_function.sql`) covering several `urlCluster` argument forms to ensure the query no longer fails.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f8935d1727d5fcd76744bcc06a5470da67368cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->