### PR TITLE
Insert profile event fix for async inserts with inline data

### DIFF
--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -96,6 +96,7 @@
 namespace ProfileEvents
 {
     extern const Event Query;
+    extern const Event InsertQuery;
     extern const Event FailedQuery;
     extern const Event FailedInsertQuery;
     extern const Event FailedSelectQuery;
@@ -1564,6 +1565,8 @@ static BlockIO executeQueryImpl(
             if (http_continue_callback && !internal)
                 http_continue_callback();
 
+            //Increment InsertQuery for async insert with inline data 
+            ProfileEvents::increment(ProfileEvents::InsertQuery);
             auto result = queue->pushQueryWithInlinedData(out_ast, context);
 
             if (result.status == AsynchronousInsertQueue::PushResult::OK)

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -1565,12 +1565,13 @@ static BlockIO executeQueryImpl(
             if (http_continue_callback && !internal)
                 http_continue_callback();
 
-            //Increment InsertQuery for async insert with inline data 
-            ProfileEvents::increment(ProfileEvents::InsertQuery);
             auto result = queue->pushQueryWithInlinedData(out_ast, context);
 
             if (result.status == AsynchronousInsertQueue::PushResult::OK)
             {
+                //Increment InsertQuery for async insert with inline data
+                ProfileEvents::increment(ProfileEvents::InsertQuery);
+
                 if (settings[Setting::wait_for_async_insert])
                 {
                     auto timeout = settings[Setting::wait_for_async_insert_timeout].totalMilliseconds();

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -1569,7 +1569,7 @@ static BlockIO executeQueryImpl(
 
             if (result.status == AsynchronousInsertQueue::PushResult::OK)
             {
-                //Increment InsertQuery for async insert with inline data
+                // Increment InsertQuery for async insert with inline data
                 ProfileEvents::increment(ProfileEvents::InsertQuery);
 
                 if (settings[Setting::wait_for_async_insert])

--- a/tests/integration/test_insert_query_profile_events/configs/config.xml
+++ b/tests/integration/test_insert_query_profile_events/configs/config.xml
@@ -1,5 +1,3 @@
 <clickhouse>
-    <max_server_memory_usage>1000</max_server_memory_usage>
-    <users_to_ignore_early_memory_limit_check>default</users_to_ignore_early_memory_limit_check>
     <page_cache_size>0</page_cache_size>
 </clickhouse>

--- a/tests/integration/test_insert_query_profile_events/configs/config.xml
+++ b/tests/integration/test_insert_query_profile_events/configs/config.xml
@@ -1,0 +1,5 @@
+<clickhouse>
+    <max_server_memory_usage>1000</max_server_memory_usage>
+    <users_to_ignore_early_memory_limit_check>default</users_to_ignore_early_memory_limit_check>
+    <page_cache_size>0</page_cache_size>
+</clickhouse>

--- a/tests/integration/test_insert_query_profile_events/test.py
+++ b/tests/integration/test_insert_query_profile_events/test.py
@@ -48,17 +48,17 @@ def test_insert_query_profile_events(started_cluster):
         )
 
         node.query(
-            "INSERT INTO test_insert_query_profile_events VALUES (1,'Non Async Insert')"
+            "INSERT INTO test_insert_query_profile_events SETTINGS async_insert=0 VALUES (1,'Non Async Insert')"
         )
         node.query(
-            "INSERT INTO test_insert_query_profile_events VALUES (2,'Non Async Insert')"
+            "INSERT INTO test_insert_query_profile_events SETTINGS async_insert=0 VALUES (2,'Non Async Insert')"
         )
 
         node.query(
-            "INSERT INTO test_insert_query_profile_events SETTINGS async_insert = 1 VALUES (3,'Async Insert')"
+            "INSERT INTO test_insert_query_profile_events SETTINGS async_insert=1 VALUES (3,'Async Insert')"
         )
         node.query(
-            "INSERT INTO test_insert_query_profile_events SETTINGS async_insert = 1 VALUES (4,'Async Insert')"
+            "INSERT INTO test_insert_query_profile_events SETTINGS async_insert=1 VALUES (4,'Async Insert')"
         )
 
         insert_count = node.query(select_insert_query).strip()

--- a/tests/integration/test_insert_query_profile_events/test.py
+++ b/tests/integration/test_insert_query_profile_events/test.py
@@ -1,0 +1,73 @@
+import logging
+from time import sleep
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance(
+    "node", main_configs=["configs/config.xml"],
+)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_insert_query_profile_events(started_cluster):
+    select_insert_query = (
+        "SELECT value FROM system.events WHERE event = 'InsertQuery'"
+    )
+    select_async_insert_query = (
+        "SELECT value FROM system.events WHERE event = 'AsyncInsertQuery'"
+    )
+
+    non_async_inserts = 2
+    async_inserts = 2
+    inserts = non_async_inserts + async_inserts
+
+    insert_count = node.query(select_insert_query).strip()
+    async_insert_count = node.query(select_async_insert_query).strip()
+
+    orig_insert_count = int(insert_count) if insert_count else 0
+    orig_async_insert_count = int(async_insert_count) if async_insert_count else 0
+
+    node.query(
+        "DROP TABLE IF EXISTS test_insert_query_profile_events"
+    )
+
+    try:
+        node.query(
+            "CREATE TABLE test_insert_query_profile_events  (id UInt32, s String) ENGINE = Memory"
+        )
+
+        node.query(
+            "INSERT INTO test_insert_query_profile_events VALUES (1,'Non Async Insert')"
+        )
+        node.query(
+            "INSERT INTO test_insert_query_profile_events VALUES (2,'Non Async Insert')"
+        )
+
+        node.query(
+            "INSERT INTO test_insert_query_profile_events SETTINGS async_insert = 1 VALUES (3,'Async Insert')"
+        )
+        node.query(
+            "INSERT INTO test_insert_query_profile_events SETTINGS async_insert = 1 VALUES (4,'Async Insert')"
+        )
+
+        insert_count = node.query(select_insert_query).strip()
+        async_insert_count = node.query(select_async_insert_query).strip()
+
+        current_insert_count = int(insert_count) if insert_count else 0
+        current_async_insert_count = int(async_insert_count) if async_insert_count else 0
+
+        assert current_insert_count - orig_insert_count == inserts
+        assert current_async_insert_count - orig_async_insert_count == async_inserts
+    finally:
+        node.query("DROP TABLE IF EXISTS test_insert_query_profile_events SYNC")


### PR DESCRIPTION
### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Increment InsertQuery ProfileEvent for async inserts. Fixes the issue - https://github.com/ClickHouse/ClickHouse/issues/98626

### Documentation entry for user-facing changes

Async inserts with inline data are not being counted in InsertQuery profile event.  This fix also increments InsertQuery profile event for async inserts with inline data . 

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, metrics-only change in the async INSERT path plus a new integration test; low risk aside from potential monitoring/alerting deltas due to corrected counters.
> 
> **Overview**
> **Fixes a ProfileEvents counting gap for async INSERTs.** When an async INSERT with inlined data is successfully enqueued (`pushQueryWithInlinedData` returns `OK`), `executeQuery.cpp` now also increments `ProfileEvents::InsertQuery` (in addition to existing async-specific counters).
> 
> **Adds coverage.** New integration test `test_insert_query_profile_events` asserts `InsertQuery` increases for both sync and async inserts while `AsyncInsertQuery` increases only for async inserts, with a minimal config (`page_cache_size=0`) for deterministic runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 629aa28f68aed4bb0349d1c79ebe39fa3179cfe3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.584`
<!-- ch-version-info:end -->