### PR TITLE
Fix hash/equality consistency in DataTypeDateTime64 and WindowNode

### DIFF
--- a/src/Analyzer/WindowNode.cpp
+++ b/src/Analyzer/WindowNode.cpp
@@ -2,6 +2,7 @@
 #include <IO/Operators.h>
 #include <IO/WriteBufferFromString.h>
 #include <Parsers/ASTWindowDefinition.h>
+#include <Common/FieldVisitorHash.h>
 #include <Common/SipHash.h>
 #include <Common/assert_cast.h>
 
@@ -90,8 +91,10 @@ void WindowNode::updateTreeHashImpl(HashState & hash_state, CompareOptions) cons
     hash_state.update(window_frame.is_default);
     hash_state.update(window_frame.type);
     hash_state.update(window_frame.begin_type);
+    applyVisitor(FieldVisitorHash(hash_state), window_frame.begin_offset);
     hash_state.update(window_frame.begin_preceding);
     hash_state.update(window_frame.end_type);
+    applyVisitor(FieldVisitorHash(hash_state), window_frame.end_offset);
     hash_state.update(window_frame.end_preceding);
 
     hash_state.update(parent_window_name);

--- a/src/DataTypes/DataTypeDateTime64.cpp
+++ b/src/DataTypes/DataTypeDateTime64.cpp
@@ -50,8 +50,8 @@ std::string DataTypeDateTime64::doGetName() const
 void DataTypeDateTime64::updateHashImpl(SipHash & hash) const
 {
     Base::updateHashImpl(hash);
-    if (has_explicit_time_zone)
-        hash.update(getDateLUTTimeZone(time_zone));
+    /// Do not include timezone in hash: equals() considers types with different
+    /// timezones as equal (only scale matters), and hash must be consistent with equality.
 }
 
 bool DataTypeDateTime64::equals(const IDataType & rhs) const


### PR DESCRIPTION
## Summary
- `DataTypeDateTime64::updateHashImpl` included timezone in the hash, but `equals` only compares scale. This violates the invariant that equal objects must have equal hashes (`a == b` ⟹ `hash(a) == hash(b)`).
- `WindowNode::updateTreeHashImpl` did not hash `begin_offset` and `end_offset`, but `isEqualImpl` compares them via `WindowFrame::operator==`. This could cause hash collisions for window frames differing only in offset values.

Found while investigating https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=a2bc1f5fe8433b6e5d5c6655f20d94ef7502b947&name_0=MasterCI&name_1=AST%20fuzzer%20%28amd_msan%29 (issue #98903).

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts hashing for `WindowNode` and `DataTypeDateTime64`, which can change query tree/type hash values used in caches or hash-based containers; behavior should be more correct but may affect cache hit rates and any code relying on previous hashes.
> 
> **Overview**
> Fixes hash/equality inconsistencies in two places.
> 
> `WindowNode::updateTreeHashImpl` now includes `window_frame.begin_offset` and `window_frame.end_offset` in the tree hash (via `FieldVisitorHash`) to avoid treating different window frames as identical in hashed structures.
> 
> `DataTypeDateTime64::updateHashImpl` no longer hashes the timezone so the hash matches `equals()` semantics (which compare only `scale`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4627fc00c67b69c8c9a469779c2b07570c1140f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.504`
<!-- ch-version-info:end -->