### PR TITLE
Add FINAL BY syntax for coarse-grained merge in AggregatingMergeTree and SummingMergeTree

### DIFF
--- a/docs/en/sql-reference/statements/select/from.md
+++ b/docs/en/sql-reference/statements/select/from.md
@@ -74,6 +74,151 @@ SET final = 1;
 SELECT x, y FROM mytable WHERE x > 1;
 ```
 
+## FINAL BY Modifier {#final-by-modifier}
+
+`FINAL BY` is an extension of the [`FINAL`](#final-modifier) modifier that merges rows at a **coarser granularity** than the table's sorting key. Instead of merging rows that share the exact same sorting key, `FINAL BY` lets you specify monotonic functions of the sorting key columns so that rows whose transformed keys are equal get merged together.
+
+This is only supported for [`AggregatingMergeTree`](/engines/table-engines/mergetree-family/aggregatingmergetree) and [`SummingMergeTree`](/engines/table-engines/mergetree-family/summingmergetree) engines.
+
+### Syntax {#final-by-syntax}
+
+```sql
+SELECT ... FROM table FINAL BY expr1[, expr2, ...]
+```
+
+The number of expressions in the `FINAL BY` clause must exactly match the number of columns in the table's `ORDER BY` clause. Each `FINAL BY` expression must be either:
+
+- **Identity**: the same expression as the corresponding sorting key column (e.g., `ORDER BY x` → `FINAL BY x`), or
+- **A monotonic function** of the corresponding sorting key column that preserves sort order (e.g., `ORDER BY unix_time` → `FINAL BY intDiv(unix_time, 10)`).
+
+When all `FINAL BY` expressions are identity (i.e., they match the sorting key exactly), the behavior is equivalent to plain `FINAL`.
+
+### Use Cases {#final-by-use-cases}
+
+`FINAL BY` is designed for producing **bucketed aggregates** directly from `AggregatingMergeTree` or `SummingMergeTree` tables without a separate `GROUP BY`. This is useful for time-series downsampling, where you want to aggregate fine-grained data into coarser time buckets at query time.
+
+For example, a table with per-second metrics (sorted by `unix_time`) can produce per-minute aggregates with `FINAL BY intDiv(unix_time, 60)` — the merge algorithm groups consecutive rows that fall into the same minute bucket and aggregates them.
+
+### Example: Time-Series Downsampling with AggregatingMergeTree {#final-by-example-aggregating}
+
+```sql
+CREATE TABLE metrics
+(
+    unix_time UInt64,
+    val AggregateFunction(sum, UInt64)
+)
+ENGINE = AggregatingMergeTree
+ORDER BY unix_time;
+
+-- Insert per-second data across multiple parts
+INSERT INTO metrics
+    SELECT number, sumState(toUInt64(1)) FROM numbers(100) GROUP BY number;
+INSERT INTO metrics
+    SELECT number, sumState(toUInt64(2)) FROM numbers(100) GROUP BY number;
+
+-- Query: aggregate into 10-second buckets
+SELECT
+    intDiv(unix_time, 10) AS bucket,
+    finalizeAggregation(val) AS total
+FROM metrics FINAL BY intDiv(unix_time, 10)
+ORDER BY bucket ASC
+LIMIT 5;
+```
+
+```text
+┌─bucket─┬─total─┐
+│      0 │    30 │
+│      1 │    30 │
+│      2 │    30 │
+│      3 │    30 │
+│      4 │    30 │
+└────────┴───────┘
+```
+
+Each bucket contains 10 rows (values 0–9, 10–19, etc.), each appearing twice with `sumState(1)` and `sumState(2)`, giving `10 × 3 = 30`.
+
+### Example: SummingMergeTree {#final-by-example-summing}
+
+```sql
+CREATE TABLE counters
+(
+    unix_time UInt64,
+    val UInt64
+)
+ENGINE = SummingMergeTree
+ORDER BY unix_time;
+
+INSERT INTO counters SELECT number, 1 FROM numbers(100);
+INSERT INTO counters SELECT number, 2 FROM numbers(100);
+
+SELECT
+    intDiv(unix_time, 10) AS bucket,
+    val AS total
+FROM counters FINAL BY intDiv(unix_time, 10)
+ORDER BY bucket ASC
+LIMIT 5;
+```
+
+```text
+┌─bucket─┬─total─┐
+│      0 │    30 │
+│      1 │    30 │
+│      2 │    30 │
+│      3 │    30 │
+│      4 │    30 │
+└────────┴───────┘
+```
+
+### Example: Composite Sorting Key {#final-by-example-composite}
+
+When the table has a composite sorting key, every column must be covered:
+
+```sql
+CREATE TABLE trades
+(
+    token String,
+    pair String,
+    unix_time UInt64,
+    val AggregateFunction(sum, UInt64)
+)
+ENGINE = AggregatingMergeTree
+ORDER BY (token, pair, unix_time);
+
+-- FINAL BY keeps the first two columns as identity, coarsens the last one
+SELECT
+    intDiv(unix_time, 10) AS bucket,
+    finalizeAggregation(val) AS total
+FROM trades FINAL BY token, pair, intDiv(unix_time, 10)
+PREWHERE token = 'BTC' AND pair = 'USD'
+ORDER BY bucket ASC;
+```
+
+### Example: Monotonic Function of a Sorting Key Expression {#final-by-example-expression}
+
+If the sorting key itself is an expression, `FINAL BY` can apply a monotonic function on top:
+
+```sql
+CREATE TABLE daily_stats
+(
+    ts DateTime,
+    val AggregateFunction(sum, UInt64)
+)
+ENGINE = AggregatingMergeTree
+ORDER BY toDate(ts);
+
+-- toStartOfMonth(toDate(ts)) is monotonic over toDate(ts)
+SELECT
+    toStartOfMonth(toDate(ts)) AS month,
+    finalizeAggregation(val) AS total
+FROM daily_stats FINAL BY month
+ORDER BY month ASC;
+```
+
+### Restrictions {#final-by-restrictions}
+
+- **Engine support**: Only `AggregatingMergeTree` and `SummingMergeTree`. Other engines (e.g., `ReplacingMergeTree`, `CollapsingMergeTree`) will throw a `BAD_ARGUMENTS` error.
+- **Expression count**: The number of `FINAL BY` expressions must exactly match the number of sorting key columns. Omitting tail columns or adding extra ones is not allowed.
+- **Monotonicity**: Each `FINAL BY` expression must be a monotonic function of the corresponding sorting key column that preserves sort order. Direction-reversing functions (e.g., `negate`) are rejected. Expressions that reference multiple sorting key columns (e.g., `a + b`) are also rejected.
 ## Implementation Details {#implementation-details}
 
 If the `FROM` clause is omitted, data will be read from the `system.one` table.

--- a/src/Analyzer/QueryTreeBuilder.cpp
+++ b/src/Analyzer/QueryTreeBuilder.cpp
@@ -905,7 +905,7 @@ QueryTreeNodePtr QueryTreeBuilder::buildJoinTree(bool is_subquery, const ASTSele
                     }
                 }
 
-                table_expression_modifiers = TableExpressionModifiers(has_final, sample_size_ratio, sample_offset_ratio);
+                table_expression_modifiers = TableExpressionModifiers(has_final, sample_size_ratio, sample_offset_ratio, table_expression.final_by);
             }
 
             if (table_expression.database_and_table_name)

--- a/src/Analyzer/Resolve/QueryAnalyzer.cpp
+++ b/src/Analyzer/Resolve/QueryAnalyzer.cpp
@@ -4985,6 +4985,57 @@ void QueryAnalyzer::resolveQuery(const QueryTreeNodePtr & query_node, Identifier
         resolveSortNodeList(query_node_typed.getOrderByNode(), scope);
     }
 
+    /// Resolve FINAL BY expressions after ORDER BY (so SELECT aliases are available).
+    /// Walk the join tree to find table expressions with FINAL BY and resolve each
+    /// expression through the query scope, which enables SELECT alias substitution.
+    {
+        auto resolve_final_by_modifiers = [&](std::optional<TableExpressionModifiers> & modifiers)
+        {
+            if (modifiers && modifiers->hasFinalBy())
+            {
+                const auto & final_by_ast = modifiers->getFinalBy();
+                QueryTreeNodes resolved_nodes;
+                resolved_nodes.reserve(final_by_ast->children.size());
+
+                for (const auto & expr_ast : final_by_ast->children)
+                {
+                    auto expr_node = buildQueryTree(expr_ast, scope.context);
+                    resolveExpressionNode(expr_node, scope, false /*allow_lambda_expression*/, false /*allow_table_expression*/);
+                    resolved_nodes.push_back(std::move(expr_node));
+                }
+
+                modifiers->setResolvedFinalBy(std::move(resolved_nodes));
+            }
+        };
+
+        std::stack<QueryTreeNodePtr *> nodes_to_process;
+        nodes_to_process.push(&query_node_typed.getJoinTree());
+
+        while (!nodes_to_process.empty())
+        {
+            auto * node_ptr = nodes_to_process.top();
+            nodes_to_process.pop();
+            auto & node = *node_ptr;
+
+            if (auto * table_node = node->as<TableNode>())
+                resolve_final_by_modifiers(table_node->getTableExpressionModifiers());
+            else if (auto * table_function_node = node->as<TableFunctionNode>())
+                resolve_final_by_modifiers(table_function_node->getTableExpressionModifiers());
+            else if (auto * join_node = node->as<JoinNode>())
+            {
+                nodes_to_process.push(&join_node->getLeftTableExpression());
+                nodes_to_process.push(&join_node->getRightTableExpression());
+            }
+            else if (auto * array_join_node = node->as<ArrayJoinNode>())
+                nodes_to_process.push(&array_join_node->getTableExpression());
+            else if (auto * cross_join_node = node->as<CrossJoinNode>())
+            {
+                for (auto & table_expr : cross_join_node->getTableExpressions())
+                    nodes_to_process.push(&table_expr);
+            }
+        }
+    }
+
     if (query_node_typed.hasInterpolate())
         resolveInterpolateColumnsNodeList(query_node_typed.getInterpolate(), scope);
 

--- a/src/Analyzer/TableExpressionModifiers.cpp
+++ b/src/Analyzer/TableExpressionModifiers.cpp
@@ -14,6 +14,9 @@ void TableExpressionModifiers::dump(WriteBuffer & buffer) const
 {
     buffer << "final: " << has_final;
 
+    if (final_by)
+        buffer << ", final_by: " << final_by->formatForErrorMessage();
+
     if (sample_size_ratio)
         buffer << ", sample_size: " << ASTSampleRatio::toString(*sample_size_ratio);
 
@@ -38,6 +41,13 @@ void TableExpressionModifiers::updateTreeHash(SipHash & hash_state) const
         hash_state.update(sample_offset_ratio->numerator);
         hash_state.update(sample_offset_ratio->denominator);
     }
+
+    if (final_by)
+    {
+        auto tree_hash = final_by->getTreeHash(/*ignore_aliases=*/true);
+        hash_state.update(tree_hash.low64);
+        hash_state.update(tree_hash.high64);
+    }
 }
 
 String TableExpressionModifiers::formatForErrorMessage() const
@@ -45,6 +55,12 @@ String TableExpressionModifiers::formatForErrorMessage() const
     WriteBufferFromOwnString buffer;
     if (has_final)
         buffer << "FINAL";
+
+    if (final_by)
+    {
+        chassert(has_final);
+        buffer << " BY " << final_by->formatForErrorMessage();
+    }
 
     if (sample_size_ratio)
     {

--- a/src/Analyzer/TableExpressionModifiers.h
+++ b/src/Analyzer/TableExpressionModifiers.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <Analyzer/IQueryTreeNode.h>
 #include <Parsers/ASTSampleRatio.h>
+#include <Parsers/IAST.h>
 
 namespace DB
 {
@@ -17,10 +19,12 @@ public:
     TableExpressionModifiers() = default;
     TableExpressionModifiers(bool has_final_,
         std::optional<Rational> sample_size_ratio_,
-        std::optional<Rational> sample_offset_ratio_)
+        std::optional<Rational> sample_offset_ratio_,
+        ASTPtr final_by_ = nullptr)
         : has_final(has_final_)
         , sample_size_ratio(sample_size_ratio_)
         , sample_offset_ratio(sample_offset_ratio_)
+        , final_by(std::move(final_by_))
     {}
 
     /// Returns true if final is specified, false otherwise
@@ -33,6 +37,36 @@ public:
     void setHasFinal(bool value)
     {
         has_final = value;
+    }
+
+    /// Returns true if FINAL BY expression list is specified
+    bool hasFinalBy() const
+    {
+        return final_by != nullptr;
+    }
+
+    /// Get FINAL BY expression list (may be nullptr)
+    const ASTPtr & getFinalBy() const
+    {
+        return final_by;
+    }
+
+    /// Returns true if FINAL BY has been resolved through the new analyzer
+    bool hasResolvedFinalBy() const
+    {
+        return !resolved_final_by.empty();
+    }
+
+    /// Get resolved FINAL BY expression nodes (populated by QueryAnalyzer)
+    const QueryTreeNodes & getResolvedFinalBy() const
+    {
+        return resolved_final_by;
+    }
+
+    /// Set resolved FINAL BY expression nodes
+    void setResolvedFinalBy(QueryTreeNodes nodes)
+    {
+        resolved_final_by = std::move(nodes);
     }
 
     /// Returns true if sample size ratio is specified, false otherwise
@@ -72,11 +106,23 @@ private:
     bool has_final = false;
     std::optional<Rational> sample_size_ratio;
     std::optional<Rational> sample_offset_ratio;
+    ASTPtr final_by;
+    /// Resolved FINAL BY query tree nodes (populated by QueryAnalyzer, used by Planner)
+    QueryTreeNodes resolved_final_by;
 };
 
 inline bool operator==(const TableExpressionModifiers & lhs, const TableExpressionModifiers & rhs)
 {
-    return lhs.hasFinal() == rhs.hasFinal() && lhs.getSampleSizeRatio() == rhs.getSampleSizeRatio() && lhs.getSampleOffsetRatio() == rhs.getSampleOffsetRatio();
+    if (lhs.hasFinal() != rhs.hasFinal()
+        || lhs.getSampleSizeRatio() != rhs.getSampleSizeRatio()
+        || lhs.getSampleOffsetRatio() != rhs.getSampleOffsetRatio()
+        || lhs.hasFinalBy() != rhs.hasFinalBy())
+        return false;
+
+    if (lhs.hasFinalBy() && lhs.getFinalBy()->getTreeHash(/*ignore_aliases=*/true) != rhs.getFinalBy()->getTreeHash(/*ignore_aliases=*/true))
+        return false;
+
+    return true;
 }
 
 inline bool operator!=(const TableExpressionModifiers & lhs, const TableExpressionModifiers & rhs)

--- a/src/Analyzer/Utils.cpp
+++ b/src/Analyzer/Utils.cpp
@@ -441,6 +441,9 @@ static ASTPtr convertIntoTableExpressionAST(
     {
         result_table_expression->final = table_expression_modifiers->hasFinal();
 
+        if (table_expression_modifiers->hasFinalBy())
+            result_table_expression->final_by = table_expression_modifiers->getFinalBy();
+
         const auto & sample_size_ratio = table_expression_modifiers->getSampleSizeRatio();
         if (sample_size_ratio.has_value())
             result_table_expression->sample_size = make_intrusive<ASTSampleRatio>(*sample_size_ratio);

--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -877,6 +877,12 @@ InterpreterSelectQuery::InterpreterSelectQuery(
                 throw Exception(ErrorCodes::ILLEGAL_FINAL, "Illegal FINAL");
             }
 
+            {
+                const auto table_expressions = getTableExpressions(query);
+                if (!table_expressions.empty() && table_expressions[0]->final_by)
+                    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "FINAL BY requires the new query analyzer (enable_analyzer = 1)");
+            }
+
             if (query.prewhere() && (input_pipe || !storage || !storage->supportsPrewhere()))
             {
                 if (!input_pipe && storage)

--- a/src/Parsers/ASTTablesInSelectQuery.cpp
+++ b/src/Parsers/ASTTablesInSelectQuery.cpp
@@ -35,6 +35,7 @@ ASTPtr ASTTableExpression::clone() const
     CLONE(database_and_table_name);
     CLONE(table_function);
     CLONE(subquery);
+    CLONE(final_by);
     CLONE(sample_size);
     CLONE(sample_offset);
     CLONE(column_aliases);
@@ -144,6 +145,12 @@ void ASTTableExpression::formatImpl(WriteBuffer & ostr, const FormatSettings & s
     {
         ostr << settings.nl_or_ws << indent_str
             << "FINAL";
+
+        if (final_by)
+        {
+            ostr << " BY ";
+            final_by->format(ostr, settings, state, frame);
+        }
     }
 
     if (sample_size)

--- a/src/Parsers/ASTTablesInSelectQuery.h
+++ b/src/Parsers/ASTTablesInSelectQuery.h
@@ -50,6 +50,7 @@ struct ASTTableExpression : public IAST
 
     /// Modifiers
     bool final = false;
+    ASTPtr final_by;        /// Expression list for FINAL BY (coarse-grained merge key)
     ASTPtr sample_size;
     ASTPtr sample_offset;
 

--- a/src/Parsers/ParserTablesInSelectQuery.cpp
+++ b/src/Parsers/ParserTablesInSelectQuery.cpp
@@ -94,9 +94,18 @@ bool ParserTableExpression::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
         ++pos;
     }
 
-    /// FINAL
+    /// FINAL [BY expr_list]
     if (ParserKeyword(Keyword::FINAL).ignore(pos, expected))
+    {
         res->final = true;
+
+        if (ParserKeyword(Keyword::BY).ignore(pos, expected))
+        {
+            ParserExpressionList by_parser(false);
+            if (!by_parser.parse(pos, res->final_by, expected))
+                return false;
+        }
+    }
 
     /// SAMPLE number
     if (ParserKeyword(Keyword::SAMPLE).ignore(pos, expected))
@@ -120,6 +129,8 @@ bool ParserTableExpression::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
         res->children.emplace_back(res->table_function);
     if (res->subquery)
         res->children.emplace_back(res->subquery);
+    if (res->final_by)
+        res->children.emplace_back(res->final_by);
     if (res->sample_size)
         res->children.emplace_back(res->sample_size);
     if (res->sample_offset)

--- a/src/Planner/PlannerJoinTree.cpp
+++ b/src/Planner/PlannerJoinTree.cpp
@@ -898,21 +898,42 @@ JoinTreeQueryPlan buildQueryPlanForTableExpression(QueryTreeNodePtr table_expres
         if (need_rewrite_query_with_final)
         {
             if (table_expression_query_info.table_expression_modifiers)
-            {
-                const auto & table_expression_modifiers = table_expression_query_info.table_expression_modifiers;
-                auto sample_size_ratio = table_expression_modifiers->getSampleSizeRatio();
-                auto sample_offset_ratio = table_expression_modifiers->getSampleOffsetRatio();
-
-                table_expression_query_info.table_expression_modifiers = TableExpressionModifiers(true /*has_final*/,
-                    sample_size_ratio,
-                    sample_offset_ratio);
-            }
+                table_expression_query_info.table_expression_modifiers->setHasFinal(true);
             else
-            {
                 table_expression_query_info.table_expression_modifiers = TableExpressionModifiers(true /*has_final*/,
                     {} /*sample_size_ratio*/,
                     {} /*sample_offset_ratio*/);
+        }
+
+        /// Build FINAL BY ActionsDAG from resolved query tree nodes (new analyzer path).
+        /// This replaces the old TreeRewriter/ExpressionAnalyzer-based DAG construction
+        /// inside `validateFinalBy`, using the already-resolved expressions from QueryAnalyzer.
+        if (table_expression_query_info.table_expression_modifiers
+            && table_expression_query_info.table_expression_modifiers->hasResolvedFinalBy())
+        {
+            const auto & resolved_nodes = table_expression_query_info.table_expression_modifiers->getResolvedFinalBy();
+
+            ActionsDAG final_by_dag;
+            ColumnNodePtrWithHashSet empty_correlated_columns_set;
+            PlannerActionsVisitor actions_visitor(planner_context, empty_correlated_columns_set, false /*use_column_identifier_as_action_node_name*/);
+
+            std::vector<const ActionsDAG::Node *> output_nodes;
+            for (const auto & node : resolved_nodes)
+            {
+                auto [expression_nodes, correlated_subtrees] = actions_visitor.visit(final_by_dag, node);
+                correlated_subtrees.assertEmpty("in FINAL BY expressions");
+                for (const auto * expr_node : expression_nodes)
+                    output_nodes.push_back(expr_node);
             }
+
+            /// Include all INPUT nodes as pass-through outputs, matching the behavior
+            /// of `ExpressionAnalyzer::getActionsDAG(false)`. This ensures that when
+            /// ExpressionActions runs, source columns (e.g. `unix_time`) are preserved
+            /// in the stream alongside the computed FINAL BY expressions.
+            for (const auto * input_node : final_by_dag.getInputs())
+                output_nodes.push_back(input_node);
+            final_by_dag.getOutputs() = std::move(output_nodes);
+            table_expression_query_info.final_by_actions_dag = std::make_shared<const ActionsDAG>(std::move(final_by_dag));
         }
 
         /// Apply trivial_count optimization if possible

--- a/src/Processors/Merges/AggregatingSortedTransform.h
+++ b/src/Processors/Merges/AggregatingSortedTransform.h
@@ -23,7 +23,8 @@ public:
         SortDescription description_,
         size_t max_block_size_rows,
         size_t max_block_size_bytes,
-        std::optional<size_t> max_dynamic_subcolumns_)
+        std::optional<size_t> max_dynamic_subcolumns_,
+        bool disable_part_level_shortcut_ = false)
         : IMergingTransform(
             num_inputs, header, header, /*have_all_inputs_=*/ true, /*limit_hint_=*/ 0, /*always_read_till_end_=*/ false,
             header,
@@ -31,7 +32,8 @@ public:
             std::move(description_),
             max_block_size_rows,
             max_block_size_bytes,
-            max_dynamic_subcolumns_)
+            max_dynamic_subcolumns_,
+            disable_part_level_shortcut_)
     {
     }
 

--- a/src/Processors/Merges/Algorithms/AggregatingSortedAlgorithm.cpp
+++ b/src/Processors/Merges/Algorithms/AggregatingSortedAlgorithm.cpp
@@ -260,8 +260,9 @@ AggregatingSortedAlgorithm::AggregatingSortedAlgorithm(
     SortDescription description_,
     size_t max_block_size_rows_,
     size_t max_block_size_bytes_,
-    std::optional<size_t> max_dynamic_subcolumns_)
-    : IMergingAlgorithmWithDelayedChunk(header_, num_inputs, description_)
+    std::optional<size_t> max_dynamic_subcolumns_,
+    bool disable_part_level_shortcut_)
+    : IMergingAlgorithmWithDelayedChunk(header_, num_inputs, description_, disable_part_level_shortcut_)
     , columns_definition(defineColumns(*header_, description_))
     , merged_data(max_block_size_rows_, max_block_size_bytes_, max_dynamic_subcolumns_, columns_definition)
 {

--- a/src/Processors/Merges/Algorithms/AggregatingSortedAlgorithm.h
+++ b/src/Processors/Merges/Algorithms/AggregatingSortedAlgorithm.h
@@ -25,7 +25,8 @@ public:
         SortDescription description_,
         size_t max_block_size_rows_,
         size_t max_block_size_bytes_,
-        std::optional<size_t> max_dynamic_subcolumns_);
+        std::optional<size_t> max_dynamic_subcolumns_,
+        bool disable_part_level_shortcut_ = false);
 
     const char * getName() const override { return "AggregatingSortedAlgorithm"; }
     void initialize(Inputs inputs) override;

--- a/src/Processors/Merges/Algorithms/IMergingAlgorithmWithDelayedChunk.cpp
+++ b/src/Processors/Merges/Algorithms/IMergingAlgorithmWithDelayedChunk.cpp
@@ -5,12 +5,13 @@
 namespace DB
 {
 
-IMergingAlgorithmWithDelayedChunk::IMergingAlgorithmWithDelayedChunk(SharedHeader header_, size_t num_inputs, SortDescription description_)
+IMergingAlgorithmWithDelayedChunk::IMergingAlgorithmWithDelayedChunk(SharedHeader header_, size_t num_inputs, SortDescription description_, bool disable_part_level_shortcut_)
     : description(std::move(description_))
     , header(std::move(header_))
     , current_inputs(num_inputs)
     , cursors(num_inputs)
     , inputs_origin_merge_tree_part_level(num_inputs)
+    , disable_part_level_shortcut(disable_part_level_shortcut_)
 {
 }
 

--- a/src/Processors/Merges/Algorithms/IMergingAlgorithmWithDelayedChunk.h
+++ b/src/Processors/Merges/Algorithms/IMergingAlgorithmWithDelayedChunk.h
@@ -12,7 +12,7 @@ namespace DB
 class IMergingAlgorithmWithDelayedChunk : public IMergingAlgorithm
 {
 public:
-    IMergingAlgorithmWithDelayedChunk(SharedHeader header_, size_t num_inputs, SortDescription description_);
+    IMergingAlgorithmWithDelayedChunk(SharedHeader header_, size_t num_inputs, SortDescription description_, bool disable_part_level_shortcut_ = false);
 
     size_t prev_unequal_column = 0;
 
@@ -32,8 +32,13 @@ protected:
     bool rowsHaveDifferentSortColumns(const detail::RowRef & lhs, const detail::RowRef & rhs)
     {
         /// By the time this method is called, `inputs_origin_merge_tree_part_level[lhs.source_stream_index]` must have been
-        /// initialized in either `initializeQueue` or `updateCursor`
-        if (lhs.source_stream_index == rhs.source_stream_index && inputs_origin_merge_tree_part_level[lhs.source_stream_index] > 0)
+        /// initialized in either `initializeQueue` or `updateCursor`.
+        /// When merging at coarser granularity (coarse merge key), rows within the same part may
+        /// share the coarse key even though they had distinct fine-grained keys, so this shortcut
+        /// must be disabled.
+        if (!disable_part_level_shortcut
+            && lhs.source_stream_index == rhs.source_stream_index
+            && inputs_origin_merge_tree_part_level[lhs.source_stream_index] > 0)
             return true;
 
         auto first_non_equal = lhs.firstNonEqualSortColumnsWith(prev_unequal_column, rhs);
@@ -55,6 +60,7 @@ private:
     SortCursorImpls cursors;
 
     std::vector<size_t> inputs_origin_merge_tree_part_level;
+    bool disable_part_level_shortcut = false;
 
     /// In merging algorithm, we need to compare current sort key with the last one.
     /// So, sorting columns for last row needed to be stored.

--- a/src/Processors/Merges/Algorithms/SummingSortedAlgorithm.cpp
+++ b/src/Processors/Merges/Algorithms/SummingSortedAlgorithm.cpp
@@ -830,8 +830,9 @@ SummingSortedAlgorithm::SummingSortedAlgorithm(
     const String & sum_function_name,
     const String & sum_function_map_name,
     bool remove_default_values,
-    bool aggregate_all_columns)
-    : IMergingAlgorithmWithDelayedChunk(header_, num_inputs, std::move(description_))
+    bool aggregate_all_columns,
+    bool disable_part_level_shortcut_)
+    : IMergingAlgorithmWithDelayedChunk(header_, num_inputs, std::move(description_), disable_part_level_shortcut_)
     , columns_definition(
           defineColumns(*header_, description, column_names_to_sum, partition_and_sorting_required_columns, sum_function_name, sum_function_map_name, remove_default_values, aggregate_all_columns))
     , merged_data(max_block_size_rows, max_block_size_bytes, max_dynamic_subcolumns_, columns_definition)

--- a/src/Processors/Merges/Algorithms/SummingSortedAlgorithm.h
+++ b/src/Processors/Merges/Algorithms/SummingSortedAlgorithm.h
@@ -29,7 +29,8 @@ public:
         const String & sum_function_name,
         const String & sum_function_map_name,
         bool remove_default_values,
-        bool aggregate_all_columns);
+        bool aggregate_all_columns,
+        bool disable_part_level_shortcut_ = false);
 
     const char * getName() const override { return "SummingSortedAlgorithm"; }
     void initialize(Inputs inputs) override;

--- a/src/Processors/Merges/SummingSortedTransform.h
+++ b/src/Processors/Merges/SummingSortedTransform.h
@@ -24,7 +24,8 @@ public:
         const Names & partition_key_columns,
         size_t max_block_size_rows,
         size_t max_block_size_bytes,
-        std::optional<size_t> max_dynamic_subcolumns_
+        std::optional<size_t> max_dynamic_subcolumns_,
+        bool disable_part_level_shortcut_ = false
         )
         : IMergingTransform(
             num_inputs, header, header, /*have_all_inputs_=*/ true, /*limit_hint_=*/ 0, /*always_read_till_end_=*/ false,
@@ -39,7 +40,8 @@ public:
             "sumWithOverflow",
             "sumMapWithOverflow",
             true,
-            false)
+            false,
+            disable_part_level_shortcut_)
     {
     }
 

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -8,6 +8,7 @@
 #include <Interpreters/Context.h>
 #include <Interpreters/ExpressionAnalyzer.h>
 #include <Interpreters/ExpressionActions.h>
+#include <Processors/QueryPlan/Optimizations/actionsDAGUtils.h>
 #include <Interpreters/InterpreterSelectQuery.h>
 #include <Interpreters/TreeRewriter.h>
 #include <Interpreters/Cache/QueryConditionCache.h>
@@ -52,6 +53,7 @@
 #include <Storages/MergeTree/MergeTreeSource.h>
 #include <Storages/MergeTree/RangesInDataPart.h>
 #include <Storages/MergeTree/RequestResponse.h>
+#include <Storages/MergeTree/MergeTreeFinalByValidation.h>
 #include <Storages/Statistics/ConditionSelectivityEstimator.h>
 #include <Storages/VirtualColumnUtils.h>
 #include <Common/JSONBuilder.h>
@@ -431,6 +433,22 @@ ReadFromMergeTree::ReadFromMergeTree(
     setStepDescription(description, context->getSettingsRef()[Setting::query_plan_max_step_description_length]);
     enable_vertical_final = query_info.isFinal() && context->getSettingsRef()[Setting::enable_vertical_final]
         && data.merging_params.mode == MergeTreeData::MergingParams::Replacing;
+
+    /// Validate FINAL BY and cache the result so that
+    /// `spreadMarkRangesAmongStreamsFinal` can use it without re-validating.
+    /// When every expression is identity the result is equivalent to plain FINAL.
+    if (query_info.final_by_actions_dag)
+    {
+        auto final_by_ast = query_info.finalBy();
+        auto result = validateFinalBy(
+            query_info.final_by_actions_dag->clone(),
+            final_by_ast->children.size(),
+            storage_snapshot,
+            data.merging_params.mode);
+        final_by_dag = std::make_shared<const ActionsDAG>(std::move(result.dag));
+        final_by_sort_columns = std::move(result.sort_columns);
+        use_final_by = result.has_non_identity;
+    }
 }
 
 std::unique_ptr<ReadFromMergeTree> ReadFromMergeTree::createLocalParallelReplicasReadingStep(
@@ -1495,7 +1513,8 @@ static void addMergingFinal(
     MergeTreeData::MergingParams merging_params,
     const StorageMetadataPtr & metadata_snapshot,
     size_t max_block_size_rows,
-    bool enable_vertical_final)
+    bool enable_vertical_final,
+    bool disable_part_level_shortcut = false)
 {
     auto header = pipe.getSharedHeader();
     size_t num_outputs = pipe.numOutputPorts();
@@ -1518,12 +1537,12 @@ static void addMergingFinal(
                 auto required_columns = metadata_snapshot->getPartitionKey().expression->getRequiredColumns();
                 required_columns.append_range(metadata_snapshot->getSortingKey().expression->getRequiredColumns());
                 return std::make_shared<SummingSortedTransform>(header, num_outputs,
-                            sort_description, merging_params.columns_to_sum, required_columns, max_block_size_rows, /*max_block_size_bytes=*/0, /*max_dynamic_subcolumns*/std::nullopt);
+                            sort_description, merging_params.columns_to_sum, required_columns, max_block_size_rows, /*max_block_size_bytes=*/0, /*max_dynamic_subcolumns*/std::nullopt, disable_part_level_shortcut);
             }
 
             case MergeTreeData::MergingParams::Aggregating:
                 return std::make_shared<AggregatingSortedTransform>(header, num_outputs,
-                            sort_description, max_block_size_rows, /*max_block_size_bytes=*/0, /*max_dynamic_subcolumns*/std::nullopt);
+                            sort_description, max_block_size_rows, /*max_block_size_bytes=*/0, /*max_dynamic_subcolumns*/std::nullopt, disable_part_level_shortcut);
 
             case MergeTreeData::MergingParams::Replacing:
                 return std::make_shared<ReplacingSortedTransform>(header, num_outputs,
@@ -1640,6 +1659,13 @@ Pipe ReadFromMergeTree::spreadMarkRangesAmongStreamsFinal(
     auto it = parts_with_ranges.begin();
     parts_to_merge_ranges.push_back(it);
 
+    /// Note: `doNotMergePartsAcrossPartitionsFinal` is intentionally NOT disabled for
+    /// FINAL BY.  When the user sets `do_not_merge_across_partitions_select_final = 1`
+    /// or the automatic decision fires, rows in different partitions will be merged
+    /// independently.  This means that if the partition boundary falls in the middle
+    /// of a FINAL BY bucket, the bucket will be split across partitions and aggregated
+    /// separately — which is the expected (and documented) behavior: the user opts in
+    /// to per-partition processing and accepts the boundary effect.
     bool do_not_merge_across_partitions_select_final = doNotMergePartsAcrossPartitionsFinal();
     if (do_not_merge_across_partitions_select_final)
     {
@@ -1684,7 +1710,10 @@ Pipe ReadFromMergeTree::spreadMarkRangesAmongStreamsFinal(
         /// If do_not_merge_across_partitions_select_final is true and there is only one part in partition
         /// with level > 0 then we won't post-process this part, and if num_streams > 1 we
         /// can use parallel select on such parts.
-        bool no_merging_final = do_not_merge_across_partitions_select_final &&
+        /// When FINAL BY is active, we always need to merge even single parts because
+        /// the coarsened key means rows within a part must be re-aggregated.
+        bool no_merging_final = !use_final_by &&
+            do_not_merge_across_partitions_select_final &&
             std::distance(parts_to_merge_ranges[range_index], parts_to_merge_ranges[range_index + 1]) == 1 &&
             parts_to_merge_ranges[range_index]->data_part->info.level > 0 &&
             !reader_settings.read_in_order;
@@ -1738,7 +1767,7 @@ Pipe ReadFromMergeTree::spreadMarkRangesAmongStreamsFinal(
                 /// deleted rows.
                 bool split_parts_ranges_into_intersecting_and_non_intersecting_final
                     = settings[Setting::split_parts_ranges_into_intersecting_and_non_intersecting_final] &&
-                          !reader_settings.read_in_order;
+                          !reader_settings.read_in_order && !use_final_by;
 
                 SplitPartsWithRangesByPrimaryKeyResult split_ranges_result = splitPartsWithRangesByPrimaryKey(
                     storage_snapshot->metadata->getPrimaryKey(),
@@ -1749,7 +1778,7 @@ Pipe ReadFromMergeTree::spreadMarkRangesAmongStreamsFinal(
                     context,
                     std::move(in_order_reading_step_getter),
                     split_parts_ranges_into_intersecting_and_non_intersecting_final,
-                    settings[Setting::split_intersecting_parts_ranges_into_layers_final]);
+                    settings[Setting::split_intersecting_parts_ranges_into_layers_final] && !use_final_by);
 
                 for (auto && non_intersecting_parts_range : split_ranges_result.non_intersecting_parts_ranges)
                     non_intersecting_parts_by_primary_key.push_back(std::move(non_intersecting_parts_range));
@@ -1797,14 +1826,37 @@ Pipe ReadFromMergeTree::spreadMarkRangesAmongStreamsFinal(
                 sort_description.emplace_back(sort_columns[i], 1);
         }
 
+        /// Apply FINAL BY (validated earlier) — add expression transforms and override sort description.
+        if (use_final_by)
+        {
+            auto final_by_actions = std::make_shared<ExpressionActions>(final_by_dag->clone());
+
+            for (auto & pipe : pipes)
+            {
+                pipe.addSimpleTransform([&final_by_actions](const SharedHeader & header)
+                                        { return std::make_shared<ExpressionTransform>(header, final_by_actions); });
+            }
+
+            /// Drop temporary columns introduced by the FINAL BY expression.
+            if (!pipes.empty())
+                out_projection = createProjection(pipes.front().getHeader());
+
+            sort_description.clear();
+            sort_description.insert(sort_description.end(), final_by_sort_columns.begin(), final_by_sort_columns.end());
+        }
+
         for (auto & pipe : pipes)
+            /// Note: `enable_vertical_final` is safe to pass through with FINAL BY because
+            /// it is only set to true for Replacing mode (see initializePipeline), which is
+            /// incompatible with FINAL BY (only Aggregating and Summing allowed).
             addMergingFinal(
                 pipe,
                 sort_description,
                 data.merging_params,
                 storage_snapshot->metadata,
                 block_size.max_block_size_rows,
-                enable_vertical_final);
+                enable_vertical_final,
+                use_final_by);
 
         merging_pipes.emplace_back(Pipe::unitePipes(std::move(pipes)));
     }
@@ -2798,7 +2850,6 @@ bool ReadFromMergeTree::setVirtualRowConversions(ActionsDAG virtual_row_conversi
     virtual_row_conversion = std::make_shared<ExpressionActions>(std::move(virtual_row_conversion_));
     return true;
 }
-
 
 bool ReadFromMergeTree::readsInOrder() const
 {

--- a/src/Processors/QueryPlan/ReadFromMergeTree.h
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.h
@@ -523,6 +523,15 @@ private:
     std::optional<MergeTreeAllRangesCallback> all_ranges_callback;
     std::optional<MergeTreeReadTaskCallback> read_task_callback;
     bool enable_vertical_final = false;
+
+    /// FINAL BY: cached validation result (computed in constructor).
+    /// `use_final_by` is true only when at least one FINAL BY expression is
+    /// non-identity (i.e. differs from the corresponding sorting key column);
+    /// identity FINAL BY is equivalent to plain FINAL and skipped.
+    bool use_final_by = false;
+    std::shared_ptr<const ActionsDAG> final_by_dag;
+    std::vector<SortColumnDescription> final_by_sort_columns;
+
     bool enable_remove_parts_from_snapshot_optimization = true;
     bool allow_query_condition_cache = true;
 

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -3,6 +3,7 @@
 #include <boost/rational.hpp> /// For calculations related to sampling coefficients.
 
 #include <Storages/MergeTree/MergeTreeDataSelectExecutor.h>
+#include <Storages/MergeTree/MergeTreeFinalByValidation.h>
 #include <Storages/MergeTree/MergeTreeIndices.h>
 #include <Storages/MergeTree/MergeTreeIndexReader.h>
 #include <Storages/MergeTree/MergeTreeIndexMinMax.h>
@@ -1389,6 +1390,20 @@ QueryPlanStepPtr MergeTreeDataSelectExecutor::readFromParts(
     bool enable_parallel_reading,
     std::shared_ptr<ParallelReadingExtension> extension_) const
 {
+    /// Validate FINAL BY even when the table is empty (no parts), so that
+    /// invalid queries are always rejected regardless of whether data exists.
+    /// When the table has data, validation runs in the `ReadFromMergeTree`
+    /// constructor instead (no duplication).
+    if (query_info.final_by_actions_dag)
+    {
+        auto final_by_ast = query_info.finalBy();
+        validateFinalBy(
+            query_info.final_by_actions_dag->clone(),
+            final_by_ast->children.size(),
+            storage_snapshot,
+            data.merging_params.mode);
+    }
+
     /// If merge_tree_select_result_ptr != nullptr, we use analyzed result so parts will always be empty.
     if (merge_tree_select_result_ptr)
     {

--- a/src/Storages/MergeTree/MergeTreeFinalByValidation.cpp
+++ b/src/Storages/MergeTree/MergeTreeFinalByValidation.cpp
@@ -1,0 +1,131 @@
+#include <Storages/MergeTree/MergeTreeFinalByValidation.h>
+
+#include <Interpreters/ExpressionActions.h>
+#include <Processors/QueryPlan/Optimizations/actionsDAGUtils.h>
+#include <Storages/StorageSnapshot.h>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int BAD_ARGUMENTS;
+}
+
+/// Validate FINAL BY expressions against the sorting key.
+/// `final_by_dag` is the ActionsDAG built from FINAL BY expressions (by the Planner).
+/// `final_by_count` is the number of FINAL BY expressions; the first `final_by_count`
+/// outputs of `final_by_dag` correspond to the expressions (remaining outputs are
+/// pass-through INPUT nodes).
+FinalByValidationResult validateFinalBy(
+    ActionsDAG final_by_dag,
+    size_t final_by_count,
+    const StorageSnapshotPtr & storage_snapshot,
+    MergeTreeData::MergingParams::Mode merging_mode)
+{
+    if (merging_mode != MergeTreeData::MergingParams::Aggregating
+        && merging_mode != MergeTreeData::MergingParams::Summing)
+    {
+        throw Exception(ErrorCodes::BAD_ARGUMENTS,
+            "FINAL BY is only supported for AggregatingMergeTree and SummingMergeTree engines");
+    }
+
+    const auto & sorting_key = storage_snapshot->metadata->getSortingKey();
+
+    if (final_by_count != sorting_key.column_names.size())
+        throw Exception(ErrorCodes::BAD_ARGUMENTS,
+            "FINAL BY has {} expressions but sorting key has {} columns",
+            final_by_count, sorting_key.column_names.size());
+
+    /// Match FINAL BY outputs against sorting key DAG outputs.
+    const auto & sorting_key_dag = sorting_key.expression->getActionsDAG();
+    auto matches = matchTrees(sorting_key_dag.getOutputs(), final_by_dag);
+
+    const auto & fb_outputs = final_by_dag.getOutputs();
+
+    std::vector<SortColumnDescription> final_by_sort_columns;
+    final_by_sort_columns.reserve(final_by_count);
+
+    bool has_non_identity = false;
+
+    for (size_t i = 0; i < final_by_count; ++i)
+    {
+        /// The first `final_by_count` outputs correspond to the FINAL BY expressions
+        /// (in order); remaining outputs are pass-through INPUT nodes added by the Planner.
+        const ActionsDAG::Node * fb_node = fb_outputs[i];
+
+        auto match_it = matches.find(fb_node);
+        if (match_it == matches.end() || !match_it->second.node)
+        {
+            throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                "FINAL BY expression {} ('{}') does not match any sorting key column",
+                i + 1, fb_node->result_name);
+        }
+
+        const auto & match = match_it->second;
+
+        /// Find which sorting key column this match points to.
+        /// We compare by name against `sorting_key.column_names` rather than
+        /// iterating `sorting_key_dag.getOutputs()`, because the DAG outputs
+        /// include source/input columns in addition to computed key columns
+        /// (since `getActions(false)` preserves inputs), so DAG output indices
+        /// do not correspond to key column indices.
+        size_t matched_sk_idx = SIZE_MAX;
+        for (size_t sk = 0; sk < sorting_key.column_names.size(); ++sk)
+        {
+            if (sorting_key.column_names[sk] == match.node->result_name)
+            {
+                matched_sk_idx = sk;
+                break;
+            }
+        }
+
+        if (matched_sk_idx != i)
+        {
+            if (matched_sk_idx == SIZE_MAX)
+                throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                    "FINAL BY expression {} ('{}') does not correspond to sorting key column {} ('{}')",
+                    i + 1, fb_node->result_name, i + 1, sorting_key.column_names[i]);
+            else
+                throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                    "FINAL BY expression {} ('{}') matches sorting key column {} ('{}'), expected column {} ('{}')",
+                    i + 1, fb_node->result_name,
+                    matched_sk_idx + 1, sorting_key.column_names[matched_sk_idx],
+                    i + 1, sorting_key.column_names[i]);
+        }
+
+        /// Check monotonicity direction: must not flip.
+        if (match.monotonicity && match.monotonicity->direction != 1)
+        {
+            throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                "FINAL BY expression {} ('{}') reverses the sort direction of sorting key column '{}', "
+                "which is not allowed",
+                i + 1, fb_node->result_name, sorting_key.column_names[i]);
+        }
+
+        /// Track whether any expression is not identity (has a monotonic wrapper).
+        if (match.monotonicity)
+            has_non_identity = true;
+
+        /// Direction inherited from sorting key.
+        int sk_direction = (!sorting_key.reverse_flags.empty() && sorting_key.reverse_flags[i]) ? -1 : 1;
+
+        /// For identity matches (no monotonic wrapper), use the sorting key column name
+        /// instead of the FINAL BY DAG node name.  The new analyzer may generate names
+        /// with type suffixes (e.g. `intDiv(x, 100_UInt8)`) that differ from the sorting
+        /// key column name (`intDiv(x, 100)`).  Since identity means no ExpressionTransform
+        /// is applied, the block columns keep the sorting key names.
+        const String & sort_col_name = match.monotonicity
+            ? fb_node->result_name
+            : sorting_key.column_names[i];
+        final_by_sort_columns.emplace_back(sort_col_name, sk_direction);
+    }
+
+    return FinalByValidationResult{
+        .dag = std::move(final_by_dag),
+        .sort_columns = std::move(final_by_sort_columns),
+        .has_non_identity = has_non_identity,
+    };
+}
+
+}

--- a/src/Storages/MergeTree/MergeTreeFinalByValidation.h
+++ b/src/Storages/MergeTree/MergeTreeFinalByValidation.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <Interpreters/ActionsDAG.h>
+#include <Storages/MergeTree/MergeTreeData.h>
+#include <Core/SortDescription.h>
+
+namespace DB
+{
+
+struct StorageSnapshot;
+using StorageSnapshotPtr = std::shared_ptr<StorageSnapshot>;
+
+/// Result of FINAL BY validation.
+/// Produced by `validateFinalBy` and consumed by the query pipeline builder
+/// in `ReadFromMergeTree::spreadMarkRangesAmongStreamsFinal`.
+struct FinalByValidationResult
+{
+    ActionsDAG dag;
+    std::vector<SortColumnDescription> sort_columns;
+    bool has_non_identity = false;
+};
+
+/// Validate FINAL BY expressions against the sorting key.
+///
+/// The ActionsDAG must be pre-built by the Planner from resolved query tree nodes.
+/// The first `final_by_count` outputs of the DAG correspond to the FINAL BY
+/// expressions (in order); remaining outputs are pass-through INPUT nodes.
+///
+/// Checks:
+///   1. Engine must be AggregatingMergeTree or SummingMergeTree.
+///   2. FINAL BY expression count must exactly equal the sorting key column count.
+///   3. Each FINAL BY expression must be a monotonic, same-direction function of
+///      the corresponding sorting key column (identity is accepted).
+///   4. No direction reversal is allowed.
+///
+/// Returns the validated result (DAG, sort description, identity flag).
+/// Throws `BAD_ARGUMENTS` on any validation failure.
+FinalByValidationResult validateFinalBy(
+    ActionsDAG final_by_dag,
+    size_t final_by_count,
+    const StorageSnapshotPtr & storage_snapshot,
+    MergeTreeData::MergingParams::Mode merging_mode);
+
+}

--- a/src/Storages/SelectQueryInfo.cpp
+++ b/src/Storages/SelectQueryInfo.cpp
@@ -19,6 +19,14 @@ bool SelectQueryInfo::isFinal() const
     return select.final();
 }
 
+ASTPtr SelectQueryInfo::finalBy() const
+{
+    if (table_expression_modifiers)
+        return table_expression_modifiers->getFinalBy();
+
+    return {};
+}
+
 std::unordered_map<std::string, ColumnWithTypeAndName> SelectQueryInfo::buildNodeNameToInputNodeColumn() const
 {
     std::unordered_map<std::string, ColumnWithTypeAndName> node_name_to_input_node_column;

--- a/src/Storages/SelectQueryInfo.h
+++ b/src/Storages/SelectQueryInfo.h
@@ -216,6 +216,12 @@ struct SelectQueryInfo
 
     bool isFinal() const;
 
+    /// Returns the FINAL BY expression list, or nullptr if not specified.
+    ASTPtr finalBy() const;
+
+    /// Pre-built FINAL BY ActionsDAG from the Planner.
+    std::shared_ptr<const ActionsDAG> final_by_actions_dag;
+
     /// Analyzer generates unique ColumnIdentifiers like __table1.__partition_id in filter nodes,
     /// while key analysis still requires unqualified column names.
     /// This function generates a map that maps the unique names to table column names,

--- a/tests/queries/0_stateless/04030_final_coarse_key_merge.reference
+++ b/tests/queries/0_stateless/04030_final_coarse_key_merge.reference
@@ -1,0 +1,84 @@
+0	30
+1	30
+2	30
+3	30
+4	30
+0	30
+1	30
+2	30
+3	30
+4	30
+0	30
+1	30
+2	30
+3	30
+4	30
+0	3
+1	3
+2	3
+3	3
+4	3
+5	3
+6	3
+7	3
+8	3
+9	3
+0	300
+1	300
+2024-01-01	2232
+2024-02-01	2088
+2	30
+3	30
+3	30
+4	30
+--- Part 20: SELECT alias in FINAL BY ---
+2024-01-01	17
+2024-02-01	29
+2024-03-01	14
+--- Part 21: SummingMergeTree composite key ---
+eu	0	10
+eu	1	10
+us	0	30
+us	1	30
+us	2	30
+--- Part 22: Empty table validation ---
+0
+--- Part 23: FINAL BY with LIMIT ---
+0	30
+1	30
+2	30
+--- Part 24: FINAL BY in subquery ---
+0	30
+1	30
+2	30
+3	30
+4	30
+--- Part 25: FINAL BY with do_not_merge_across_partitions ---
+0	330
+1	330
+2	330
+--- Part 26: FINAL BY with many parts ---
+0	70
+1	70
+2	70
+3	70
+4	70
+--- Part 27: optimize_read_in_order = 0 ---
+0	30
+1	30
+2	30
+3	30
+4	30
+--- Part 28: multi-threaded FINAL BY ---
+0	30
+1	30
+2	30
+3	30
+4	30
+--- Part 29: FINAL BY after OPTIMIZE ---
+0	30
+1	30
+2	30
+--- Part 30: output columns ---
+30
+30

--- a/tests/queries/0_stateless/04030_final_coarse_key_merge.sql
+++ b/tests/queries/0_stateless/04030_final_coarse_key_merge.sql
@@ -1,0 +1,734 @@
+-- Test that FINAL BY can merge rows at coarser granularity. Each FINAL BY
+-- expression must reference only the corresponding sorting key column and
+-- be a deterministic, same-direction monotonic function. The number of
+-- FINAL BY expressions must exactly match the number of sorting key columns.
+
+SET enable_analyzer = 1;
+
+-- ============================================================
+-- Part 1: Basic coarse merge with AggregatingMergeTree
+-- ORDER BY unix_time
+-- FINAL BY intDiv(unix_time, 10)
+-- ============================================================
+
+DROP TABLE IF EXISTS t_final_by;
+
+CREATE TABLE t_final_by
+(
+    unix_time UInt64,
+    val AggregateFunction(sum, UInt64)
+)
+ENGINE = AggregatingMergeTree
+ORDER BY unix_time;
+
+INSERT INTO t_final_by
+    SELECT number, sumState(toUInt64(1)) FROM numbers(100) GROUP BY number;
+INSERT INTO t_final_by
+    SELECT number, sumState(toUInt64(2)) FROM numbers(100) GROUP BY number;
+
+SELECT
+    intDiv(unix_time, 10) AS bucket,
+    finalizeAggregation(val) AS total
+FROM t_final_by FINAL BY intDiv(unix_time, 10)
+ORDER BY bucket ASC
+LIMIT 5;
+
+DROP TABLE t_final_by;
+
+-- ============================================================
+-- Part 2: Composite sorting key — prefix identity, last column coarsened
+-- ORDER BY (token, pair, unix_time)
+-- FINAL BY (token, pair, intDiv(unix_time, 10))
+-- ============================================================
+
+DROP TABLE IF EXISTS t_final_by;
+
+CREATE TABLE t_final_by
+(
+    token String,
+    pair String,
+    unix_time UInt64,
+    val AggregateFunction(sum, UInt64)
+)
+ENGINE = AggregatingMergeTree
+ORDER BY (token, pair, unix_time);
+
+INSERT INTO t_final_by
+    SELECT 'BTC', 'USD', number, sumState(toUInt64(1)) FROM numbers(100) GROUP BY number;
+INSERT INTO t_final_by
+    SELECT 'BTC', 'USD', number, sumState(toUInt64(2)) FROM numbers(100) GROUP BY number;
+INSERT INTO t_final_by
+    SELECT 'ETH', 'USD', number, sumState(toUInt64(1)) FROM numbers(50) GROUP BY number;
+
+SELECT
+    intDiv(unix_time, 10) AS bucket,
+    finalizeAggregation(val) AS total
+FROM t_final_by FINAL BY token, pair, intDiv(unix_time, 10)
+PREWHERE token = 'BTC' AND pair = 'USD'
+ORDER BY bucket ASC
+LIMIT 5;
+
+DROP TABLE t_final_by;
+
+-- ============================================================
+-- Part 3: SummingMergeTree
+-- ORDER BY unix_time
+-- FINAL BY intDiv(unix_time, 10)
+-- ============================================================
+
+DROP TABLE IF EXISTS t_final_by;
+
+CREATE TABLE t_final_by
+(
+    unix_time UInt64,
+    val UInt64
+)
+ENGINE = SummingMergeTree
+ORDER BY unix_time;
+
+INSERT INTO t_final_by SELECT number, 1 FROM numbers(100);
+INSERT INTO t_final_by SELECT number, 2 FROM numbers(100);
+
+SELECT
+    intDiv(unix_time, 10) AS bucket,
+    val AS total
+FROM t_final_by FINAL BY intDiv(unix_time, 10)
+ORDER BY bucket ASC
+LIMIT 5;
+
+DROP TABLE t_final_by;
+
+-- ============================================================
+-- Part 4: Identity FINAL BY — equivalent to plain FINAL
+-- ORDER BY unix_time
+-- FINAL BY unix_time
+-- ============================================================
+
+DROP TABLE IF EXISTS t_final_by;
+
+CREATE TABLE t_final_by
+(
+    unix_time UInt64,
+    val AggregateFunction(sum, UInt64)
+)
+ENGINE = AggregatingMergeTree
+ORDER BY unix_time;
+
+INSERT INTO t_final_by
+    SELECT number, sumState(toUInt64(1)) FROM numbers(10) GROUP BY number;
+INSERT INTO t_final_by
+    SELECT number, sumState(toUInt64(2)) FROM numbers(10) GROUP BY number;
+
+SELECT
+    unix_time,
+    finalizeAggregation(val) AS total
+FROM t_final_by FINAL BY unix_time
+ORDER BY unix_time ASC;
+
+DROP TABLE t_final_by;
+
+-- ============================================================
+-- Part 5: ORDER BY with expression — FINAL BY uses the same expression (identity)
+-- ORDER BY intDiv(unix_time, 100)
+-- FINAL BY intDiv(unix_time, 100)
+-- ============================================================
+
+DROP TABLE IF EXISTS t_final_by;
+
+CREATE TABLE t_final_by
+(
+    unix_time UInt64,
+    val AggregateFunction(sum, UInt64)
+)
+ENGINE = AggregatingMergeTree
+ORDER BY intDiv(unix_time, 100);
+
+INSERT INTO t_final_by
+    SELECT number, sumState(toUInt64(1)) FROM numbers(200) GROUP BY number;
+INSERT INTO t_final_by
+    SELECT number, sumState(toUInt64(2)) FROM numbers(200) GROUP BY number;
+
+-- Identity: FINAL BY repeats the sorting key expression exactly.
+SELECT
+    intDiv(unix_time, 100) AS bucket,
+    finalizeAggregation(val) AS total
+FROM t_final_by FINAL BY intDiv(unix_time, 100)
+ORDER BY bucket ASC;
+
+DROP TABLE t_final_by;
+
+-- ============================================================
+-- Part 6: ORDER BY with expression — FINAL BY is a monotonic function of it
+-- ORDER BY toDate(ts)
+-- FINAL BY toStartOfMonth(toDate(ts))   — monotonic over Date
+-- ============================================================
+
+DROP TABLE IF EXISTS t_final_by;
+
+CREATE TABLE t_final_by
+(
+    ts DateTime,
+    val AggregateFunction(sum, UInt64)
+)
+ENGINE = AggregatingMergeTree
+ORDER BY toDate(ts);
+
+INSERT INTO t_final_by
+    SELECT toDateTime('2024-01-01') + number * 3600, sumState(toUInt64(1))
+    FROM numbers(1440) GROUP BY number;
+INSERT INTO t_final_by
+    SELECT toDateTime('2024-01-01') + number * 3600, sumState(toUInt64(2))
+    FROM numbers(1440) GROUP BY number;
+
+-- toStartOfMonth(toDate(ts)) is a monotonic function of toDate(ts).
+SELECT
+    toStartOfMonth(toDate(ts)) AS month,
+    finalizeAggregation(val) AS total
+FROM t_final_by FINAL BY toStartOfMonth(toDate(ts))
+ORDER BY month ASC;
+
+DROP TABLE t_final_by;
+
+-- ============================================================
+-- Part 7: Error — FINAL BY count fewer than sorting key columns
+-- ORDER BY (a, b), FINAL BY a  → must specify all columns
+-- ============================================================
+
+DROP TABLE IF EXISTS t_final_by;
+
+CREATE TABLE t_final_by
+(
+    a UInt64,
+    b UInt64,
+    val AggregateFunction(sum, UInt64)
+)
+ENGINE = AggregatingMergeTree
+ORDER BY (a, b);
+
+SELECT * FROM t_final_by FINAL BY a; -- { serverError BAD_ARGUMENTS }
+
+DROP TABLE t_final_by;
+
+-- ============================================================
+-- Part 8: Error — FINAL BY count more than sorting key columns
+-- ORDER BY (a, b), FINAL BY a, b, a
+-- ============================================================
+
+DROP TABLE IF EXISTS t_final_by;
+
+CREATE TABLE t_final_by
+(
+    a UInt64,
+    b UInt64,
+    val AggregateFunction(sum, UInt64)
+)
+ENGINE = AggregatingMergeTree
+ORDER BY (a, b);
+
+SELECT * FROM t_final_by FINAL BY a, b, a; -- { serverError BAD_ARGUMENTS }
+
+DROP TABLE t_final_by;
+
+-- ============================================================
+-- Part 9: Error — columns in wrong order
+-- ORDER BY (a, b), FINAL BY b, a
+-- ============================================================
+
+DROP TABLE IF EXISTS t_final_by;
+
+CREATE TABLE t_final_by
+(
+    a UInt64,
+    b UInt64,
+    val AggregateFunction(sum, UInt64)
+)
+ENGINE = AggregatingMergeTree
+ORDER BY (a, b);
+
+SELECT * FROM t_final_by FINAL BY b, a; -- { serverError BAD_ARGUMENTS }
+
+DROP TABLE t_final_by;
+
+-- ============================================================
+-- Part 10: Error — direction reversal (negate)
+-- ORDER BY (a, b), FINAL BY negate(a), b
+-- ============================================================
+
+DROP TABLE IF EXISTS t_final_by;
+
+CREATE TABLE t_final_by
+(
+    a UInt64,
+    b UInt64,
+    val AggregateFunction(sum, UInt64)
+)
+ENGINE = AggregatingMergeTree
+ORDER BY (a, b);
+
+SELECT * FROM t_final_by FINAL BY negate(a), b; -- { serverError BAD_ARGUMENTS }
+
+DROP TABLE t_final_by;
+
+-- ============================================================
+-- Part 11: Error — constant expression (not referencing sorting key)
+-- ORDER BY a, FINAL BY 42
+-- ============================================================
+
+DROP TABLE IF EXISTS t_final_by;
+
+CREATE TABLE t_final_by
+(
+    a UInt64,
+    val AggregateFunction(sum, UInt64)
+)
+ENGINE = AggregatingMergeTree
+ORDER BY a;
+
+SELECT * FROM t_final_by FINAL BY 42; -- { serverError BAD_ARGUMENTS }
+
+DROP TABLE t_final_by;
+
+-- ============================================================
+-- Part 12: Error — expression referencing multiple columns
+-- ORDER BY (a, b), FINAL BY a + b, b
+-- ============================================================
+
+DROP TABLE IF EXISTS t_final_by;
+
+CREATE TABLE t_final_by
+(
+    a UInt64,
+    b UInt64,
+    val AggregateFunction(sum, UInt64)
+)
+ENGINE = AggregatingMergeTree
+ORDER BY (a, b);
+
+SELECT * FROM t_final_by FINAL BY a + b, b; -- { serverError BAD_ARGUMENTS }
+
+DROP TABLE t_final_by;
+
+-- ============================================================
+-- Part 13: Error — ORDER BY has expression, FINAL BY references raw column
+-- ORDER BY intDiv(a, 100), FINAL BY a  → `a` is not sorting key output
+-- ============================================================
+
+DROP TABLE IF EXISTS t_final_by;
+
+CREATE TABLE t_final_by
+(
+    a UInt64,
+    val AggregateFunction(sum, UInt64)
+)
+ENGINE = AggregatingMergeTree
+ORDER BY intDiv(a, 100);
+
+SELECT * FROM t_final_by FINAL BY a; -- { serverError BAD_ARGUMENTS }
+
+DROP TABLE t_final_by;
+
+-- ============================================================
+-- Part 14: Error — unsupported engine: ReplacingMergeTree
+-- ============================================================
+
+DROP TABLE IF EXISTS t_final_by;
+CREATE TABLE t_final_by (a UInt64, val UInt64) ENGINE = ReplacingMergeTree ORDER BY a;
+SELECT * FROM t_final_by FINAL BY a; -- { serverError BAD_ARGUMENTS }
+DROP TABLE t_final_by;
+
+-- ============================================================
+-- Part 15: Error — unsupported engine: CollapsingMergeTree
+-- ============================================================
+
+DROP TABLE IF EXISTS t_final_by;
+CREATE TABLE t_final_by (a UInt64, val UInt64, sign Int8) ENGINE = CollapsingMergeTree(sign) ORDER BY a;
+SELECT * FROM t_final_by FINAL BY a; -- { serverError BAD_ARGUMENTS }
+DROP TABLE t_final_by;
+
+-- ============================================================
+-- Part 16: Error — unsupported engine: VersionedCollapsingMergeTree
+-- ============================================================
+
+DROP TABLE IF EXISTS t_final_by;
+CREATE TABLE t_final_by (a UInt64, val UInt64, sign Int8, ver UInt64) ENGINE = VersionedCollapsingMergeTree(sign, ver) ORDER BY a;
+SELECT * FROM t_final_by FINAL BY a; -- { serverError BAD_ARGUMENTS }
+DROP TABLE t_final_by;
+
+-- ============================================================
+-- Part 17: Error — unsupported engine: MergeTree (Ordinary)
+-- ============================================================
+
+DROP TABLE IF EXISTS t_final_by;
+CREATE TABLE t_final_by (a UInt64, val UInt64) ENGINE = MergeTree ORDER BY a;
+SELECT * FROM t_final_by FINAL BY a; -- { serverError ILLEGAL_FINAL }
+DROP TABLE t_final_by;
+
+-- ============================================================
+-- Part 18: PREWHERE with coarsened FINAL BY — filter narrows rows before merge
+-- ORDER BY unix_time
+-- FINAL BY intDiv(unix_time, 10)
+-- PREWHERE unix_time >= 20 AND unix_time < 40  → keeps buckets 2, 3
+-- ============================================================
+
+DROP TABLE IF EXISTS t_final_by;
+
+CREATE TABLE t_final_by
+(
+    unix_time UInt64,
+    val AggregateFunction(sum, UInt64)
+)
+ENGINE = AggregatingMergeTree
+ORDER BY unix_time;
+
+INSERT INTO t_final_by
+    SELECT number, sumState(toUInt64(1)) FROM numbers(100) GROUP BY number;
+INSERT INTO t_final_by
+    SELECT number, sumState(toUInt64(2)) FROM numbers(100) GROUP BY number;
+
+SELECT
+    intDiv(unix_time, 10) AS bucket,
+    finalizeAggregation(val) AS total
+FROM t_final_by FINAL BY intDiv(unix_time, 10)
+PREWHERE unix_time >= 20 AND unix_time < 40
+ORDER BY bucket ASC;
+
+DROP TABLE t_final_by;
+
+-- ============================================================
+-- Part 19: WHERE on non-key column with coarsened FINAL BY
+-- ORDER BY unix_time
+-- FINAL BY intDiv(unix_time, 10)
+-- WHERE with computed column filter
+-- ============================================================
+
+DROP TABLE IF EXISTS t_final_by;
+
+CREATE TABLE t_final_by
+(
+    unix_time UInt64,
+    val AggregateFunction(sum, UInt64)
+)
+ENGINE = AggregatingMergeTree
+ORDER BY unix_time;
+
+INSERT INTO t_final_by
+    SELECT number, sumState(toUInt64(1)) FROM numbers(50) GROUP BY number;
+INSERT INTO t_final_by
+    SELECT number, sumState(toUInt64(2)) FROM numbers(50) GROUP BY number;
+
+SELECT
+    intDiv(unix_time, 10) AS bucket,
+    finalizeAggregation(val) AS total
+FROM t_final_by FINAL BY intDiv(unix_time, 10)
+WHERE intDiv(unix_time, 10) >= 3
+ORDER BY bucket ASC;
+
+DROP TABLE t_final_by;
+
+----------------------------------------------------------------------
+-- Part 20: SELECT alias in FINAL BY
+--
+-- Verifies that FINAL BY can reference a SELECT alias that wraps a
+-- monotonic function of the sorting key column. The alias `month` is
+-- defined as `toStartOfMonth(toDate(ts))` in the SELECT list, and
+-- FINAL BY uses `month` directly.
+----------------------------------------------------------------------
+SELECT '--- Part 20: SELECT alias in FINAL BY ---';
+
+CREATE TABLE t_final_by (ts DateTime, val AggregateFunction(sum, UInt64))
+ENGINE = AggregatingMergeTree ORDER BY ts;
+
+INSERT INTO t_final_by
+    SELECT
+        toDateTime('2024-01-15 10:00:00') + number * 86400 AS ts,
+        sumState(toUInt64(1))
+    FROM numbers(60)
+    GROUP BY ts;
+
+-- Use SELECT alias `month` in FINAL BY
+SELECT
+    toStartOfMonth(toDate(ts)) AS month,
+    finalizeAggregation(val) AS total
+FROM t_final_by FINAL BY month
+ORDER BY month ASC;
+
+DROP TABLE t_final_by;
+
+-- ============================================================
+-- Part 21: SummingMergeTree with composite sorting key
+-- ORDER BY (region, unix_time)
+-- FINAL BY (region, intDiv(unix_time, 10))
+-- ============================================================
+SELECT '--- Part 21: SummingMergeTree composite key ---';
+
+DROP TABLE IF EXISTS t_final_by;
+
+CREATE TABLE t_final_by
+(
+    region String,
+    unix_time UInt64,
+    val UInt64
+)
+ENGINE = SummingMergeTree
+ORDER BY (region, unix_time);
+
+INSERT INTO t_final_by SELECT 'us', number, 1 FROM numbers(30);
+INSERT INTO t_final_by SELECT 'us', number, 2 FROM numbers(30);
+INSERT INTO t_final_by SELECT 'eu', number, 1 FROM numbers(20);
+
+SELECT
+    region,
+    intDiv(unix_time, 10) AS bucket,
+    val AS total
+FROM t_final_by FINAL BY region, intDiv(unix_time, 10)
+ORDER BY region ASC, bucket ASC;
+
+DROP TABLE t_final_by;
+
+-- ============================================================
+-- Part 22: Empty table — FINAL BY is validated even with no data
+-- ============================================================
+SELECT '--- Part 22: Empty table validation ---';
+
+DROP TABLE IF EXISTS t_final_by;
+
+CREATE TABLE t_final_by (a UInt64, val AggregateFunction(sum, UInt64))
+ENGINE = AggregatingMergeTree ORDER BY a;
+
+-- Valid FINAL BY on empty table should return empty result
+SELECT count() FROM t_final_by FINAL BY a;
+
+-- Invalid FINAL BY on empty table should still error
+SELECT * FROM t_final_by FINAL BY a + 1; -- { serverError BAD_ARGUMENTS }
+
+DROP TABLE t_final_by;
+
+-- ============================================================
+-- Part 23: FINAL BY with LIMIT
+-- ============================================================
+SELECT '--- Part 23: FINAL BY with LIMIT ---';
+
+DROP TABLE IF EXISTS t_final_by;
+
+CREATE TABLE t_final_by (unix_time UInt64, val AggregateFunction(sum, UInt64))
+ENGINE = AggregatingMergeTree ORDER BY unix_time;
+
+INSERT INTO t_final_by
+    SELECT number, sumState(toUInt64(1)) FROM numbers(100) GROUP BY number;
+INSERT INTO t_final_by
+    SELECT number, sumState(toUInt64(2)) FROM numbers(100) GROUP BY number;
+
+SELECT
+    intDiv(unix_time, 10) AS bucket,
+    finalizeAggregation(val) AS total
+FROM t_final_by FINAL BY intDiv(unix_time, 10)
+ORDER BY bucket ASC
+LIMIT 3;
+
+DROP TABLE t_final_by;
+
+-- ============================================================
+-- Part 24: FINAL BY in subquery
+-- ============================================================
+SELECT '--- Part 24: FINAL BY in subquery ---';
+
+DROP TABLE IF EXISTS t_final_by;
+
+CREATE TABLE t_final_by (unix_time UInt64, val AggregateFunction(sum, UInt64))
+ENGINE = AggregatingMergeTree ORDER BY unix_time;
+
+INSERT INTO t_final_by
+    SELECT number, sumState(toUInt64(1)) FROM numbers(50) GROUP BY number;
+INSERT INTO t_final_by
+    SELECT number, sumState(toUInt64(2)) FROM numbers(50) GROUP BY number;
+
+SELECT bucket, total FROM (
+    SELECT
+        intDiv(unix_time, 10) AS bucket,
+        finalizeAggregation(val) AS total
+    FROM t_final_by FINAL BY intDiv(unix_time, 10)
+)
+ORDER BY bucket ASC;
+
+DROP TABLE t_final_by;
+
+-- ============================================================
+-- Part 25: FINAL BY with do_not_merge_across_partitions_select_final
+-- ============================================================
+SELECT '--- Part 25: FINAL BY with do_not_merge_across_partitions ---';
+
+DROP TABLE IF EXISTS t_final_by;
+
+CREATE TABLE t_final_by (part_key UInt64, unix_time UInt64, val AggregateFunction(sum, UInt64))
+ENGINE = AggregatingMergeTree PARTITION BY part_key ORDER BY unix_time;
+
+-- Two partitions, each with two parts
+INSERT INTO t_final_by
+    SELECT 1, number, sumState(toUInt64(1)) FROM numbers(30) GROUP BY number;
+INSERT INTO t_final_by
+    SELECT 1, number, sumState(toUInt64(2)) FROM numbers(30) GROUP BY number;
+INSERT INTO t_final_by
+    SELECT 2, number, sumState(toUInt64(10)) FROM numbers(30) GROUP BY number;
+INSERT INTO t_final_by
+    SELECT 2, number, sumState(toUInt64(20)) FROM numbers(30) GROUP BY number;
+
+SELECT
+    intDiv(unix_time, 10) AS bucket,
+    sum(finalizeAggregation(val)) AS total
+FROM t_final_by FINAL BY intDiv(unix_time, 10)
+GROUP BY bucket
+ORDER BY bucket ASC
+SETTINGS do_not_merge_across_partitions_select_final = 1;
+
+DROP TABLE t_final_by;
+
+-- ============================================================
+-- Part 26: FINAL BY with many parts in same partition (3 inserts)
+-- ============================================================
+SELECT '--- Part 26: FINAL BY with many parts ---';
+
+DROP TABLE IF EXISTS t_final_by;
+
+CREATE TABLE t_final_by (unix_time UInt64, val AggregateFunction(sum, UInt64))
+ENGINE = AggregatingMergeTree ORDER BY unix_time;
+
+INSERT INTO t_final_by
+    SELECT number, sumState(toUInt64(1)) FROM numbers(50) GROUP BY number;
+INSERT INTO t_final_by
+    SELECT number, sumState(toUInt64(2)) FROM numbers(50) GROUP BY number;
+INSERT INTO t_final_by
+    SELECT number, sumState(toUInt64(4)) FROM numbers(50) GROUP BY number;
+
+SELECT
+    intDiv(unix_time, 10) AS bucket,
+    sum(finalizeAggregation(val)) AS total
+FROM t_final_by FINAL BY intDiv(unix_time, 10)
+GROUP BY bucket
+ORDER BY bucket ASC;
+
+DROP TABLE t_final_by;
+
+-- ============================================================
+-- Part 27: FINAL BY with optimize_read_in_order = 0
+-- Tests the code path where read_in_order is disabled.
+-- ============================================================
+SELECT '--- Part 27: optimize_read_in_order = 0 ---';
+
+DROP TABLE IF EXISTS t_final_by;
+
+CREATE TABLE t_final_by (unix_time UInt64, val AggregateFunction(sum, UInt64))
+ENGINE = AggregatingMergeTree ORDER BY unix_time;
+
+INSERT INTO t_final_by
+    SELECT number, sumState(toUInt64(1)) FROM numbers(50) GROUP BY number;
+INSERT INTO t_final_by
+    SELECT number, sumState(toUInt64(2)) FROM numbers(50) GROUP BY number;
+
+SELECT
+    intDiv(unix_time, 10) AS bucket,
+    finalizeAggregation(val) AS total
+FROM t_final_by FINAL BY intDiv(unix_time, 10)
+ORDER BY bucket ASC
+SETTINGS optimize_read_in_order = 0;
+
+DROP TABLE t_final_by;
+
+-- ============================================================
+-- Part 28: FINAL BY with multiple final threads
+-- Tests multi-threaded merge pipeline.
+-- ============================================================
+SELECT '--- Part 28: multi-threaded FINAL BY ---';
+
+DROP TABLE IF EXISTS t_final_by;
+
+CREATE TABLE t_final_by (unix_time UInt64, val AggregateFunction(sum, UInt64))
+ENGINE = AggregatingMergeTree ORDER BY unix_time;
+
+INSERT INTO t_final_by
+    SELECT number, sumState(toUInt64(1)) FROM numbers(100) GROUP BY number;
+INSERT INTO t_final_by
+    SELECT number, sumState(toUInt64(2)) FROM numbers(100) GROUP BY number;
+
+SELECT
+    intDiv(unix_time, 10) AS bucket,
+    finalizeAggregation(val) AS total
+FROM t_final_by FINAL BY intDiv(unix_time, 10)
+ORDER BY bucket ASC
+LIMIT 5
+SETTINGS max_final_threads = 4;
+
+DROP TABLE t_final_by;
+
+-- ============================================================
+-- Part 29: FINAL BY after OPTIMIZE FINAL (single merged part with level > 0)
+-- When do_not_merge_across_partitions_select_final is set, single parts
+-- with level > 0 normally skip the merge step. FINAL BY must still
+-- trigger re-aggregation because the coarsened key differs from the
+-- stored fine-grained key.
+-- ============================================================
+SELECT '--- Part 29: FINAL BY after OPTIMIZE ---';
+
+DROP TABLE IF EXISTS t_final_by;
+
+CREATE TABLE t_final_by (unix_time UInt64, val AggregateFunction(sum, UInt64))
+ENGINE = AggregatingMergeTree ORDER BY unix_time;
+
+INSERT INTO t_final_by
+    SELECT number, sumState(toUInt64(1)) FROM numbers(30) GROUP BY number;
+INSERT INTO t_final_by
+    SELECT number, sumState(toUInt64(2)) FROM numbers(30) GROUP BY number;
+
+-- Merge all parts into one with level > 0
+OPTIMIZE TABLE t_final_by FINAL;
+
+SELECT
+    intDiv(unix_time, 10) AS bucket,
+    finalizeAggregation(val) AS total
+FROM t_final_by FINAL BY intDiv(unix_time, 10)
+ORDER BY bucket ASC
+SETTINGS do_not_merge_across_partitions_select_final = 1;
+
+DROP TABLE t_final_by;
+
+-- ============================================================
+-- Part 30: FINAL BY columns not leaked into output
+-- Verifies that SELECT with specific columns does not include
+-- intermediate FINAL BY expression columns.
+-- ============================================================
+SELECT '--- Part 30: output columns ---';
+
+DROP TABLE IF EXISTS t_final_by;
+
+CREATE TABLE t_final_by (unix_time UInt64, val AggregateFunction(sum, UInt64))
+ENGINE = AggregatingMergeTree ORDER BY unix_time;
+
+INSERT INTO t_final_by
+    SELECT number, sumState(toUInt64(1)) FROM numbers(20) GROUP BY number;
+INSERT INTO t_final_by
+    SELECT number, sumState(toUInt64(2)) FROM numbers(20) GROUP BY number;
+
+-- Only request `val`; the FINAL BY expression should not appear in output.
+SELECT finalizeAggregation(val) AS total
+FROM t_final_by FINAL BY intDiv(unix_time, 10)
+ORDER BY total ASC;
+
+DROP TABLE t_final_by;
+
+-- ============================================================
+-- Part 31: Error — non-monotonic function (xxHash64)
+-- ORDER BY a, FINAL BY xxHash64(a)
+-- ============================================================
+
+DROP TABLE IF EXISTS t_final_by;
+
+CREATE TABLE t_final_by
+(
+    a UInt64,
+    val AggregateFunction(sum, UInt64)
+)
+ENGINE = AggregatingMergeTree
+ORDER BY a;
+
+SELECT * FROM t_final_by FINAL BY xxHash64(a); -- { serverError BAD_ARGUMENTS }
+
+DROP TABLE t_final_by;


### PR DESCRIPTION
## Summary

`FINAL BY` extends the existing `FINAL` modifier to merge rows at a coarser granularity than the sorting key, using monotonic functions of the sorting key columns. This is supported for `AggregatingMergeTree` and `SummingMergeTree` only.

### Syntax

```sql
SELECT * FROM t FINAL BY toStartOfHour(timestamp), user_id
```

Each `FINAL BY` expression must be a monotonic function (in the same direction) of the corresponding sorting key column. This is validated at query time using `matchTrees`-based monotonicity checking.

### Key changes

- **Parser**: `FINAL [BY expr_list]` syntax
- **Analyzer**: Resolve `FINAL BY` expressions through query scope (supports aliases, `ArrayJoinNode`, `CrossJoinNode`)
- **Planner**: Build `ActionsDAG` for `FINAL BY` from resolved nodes
- **Validation**: New `MergeTreeFinalByValidation` module — `matchTrees`-based monotonicity check against sorting key DAG
- **Pipeline**: `disable_part_level_shortcut` flag threaded through `IMergingAlgorithmWithDelayedChunk` → `AggregatingSortedAlgorithm` / `SummingSortedAlgorithm`; expression transforms and sort description override in `ReadFromMergeTree`
- **Documentation**: `FINAL BY` section in `docs/en/sql-reference/statements/select/from.md`
- **Tests**: `04030_final_coarse_key_merge` with 31 test parts covering aggregating/summing engines, monotonic functions, error cases, identity optimization

### Changelog category
New Feature

### Changelog entry
Add `FINAL BY` syntax for `AggregatingMergeTree` and `SummingMergeTree` to merge rows at coarser granularity than the sorting key using monotonic functions.