### PR TITLE
Show chart title when query returns empty result in dashboard

### DIFF
--- a/programs/server/dashboard.html
+++ b/programs/server/dashboard.html
@@ -1274,15 +1274,19 @@ async function draw(idx, chart, url_params, query) {
 
     let error_div = chart.querySelector('.query-error');
     let title_div = chart.querySelector('.title');
+
+    /// Set title before handling errors so it is visible even when the query fails
+    const title = queries[idx] && queries[idx].title ? queries[idx].title.replaceAll(/\{(\w+)\}/g, (_, name) => params[name] ) : '';
+    title_div.firstChild.data = title;
+    title_div.style.display = 'block';
+
     if (error) {
         error_div.firstChild.data = error;
-        title_div.style.display = 'block';
         error_div.style.display = 'block';
         return false;
     } else {
         error_div.firstChild.data = '';
         error_div.style.display = 'none';
-        title_div.style.display = 'block';
     }
 
     const color_rotate = Math.abs(stringHash(query));
@@ -1373,9 +1377,6 @@ async function draw(idx, chart, url_params, query) {
     plots[idx] = new uPlot(opts, data, chart);
     sync.sub(plots[idx]);
 
-    /// Set title
-    const title = queries[idx] && queries[idx].title ? queries[idx].title.replaceAll(/\{(\w+)\}/g, (_, name) => params[name] ) : '';
-    chart.querySelector('.title').firstChild.data = title;
     return true;
 }
 

--- a/programs/server/dashboard.html
+++ b/programs/server/dashboard.html
@@ -366,6 +366,7 @@
             position: absolute;
             color: var(--error-color);
             padding: 2rem;
+            top: 2rem;
         }
 
         textarea {
@@ -1275,7 +1276,7 @@ async function draw(idx, chart, url_params, query) {
     let title_div = chart.querySelector('.title');
     if (error) {
         error_div.firstChild.data = error;
-        title_div.style.display = 'none';
+        title_div.style.display = 'block';
         error_div.style.display = 'block';
         return false;
     } else {


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry
Show chart title in dashboard even when query returns empty result or encounters an error.

Fixes #85225

### What this PR does

When a dashboard chart query returns an empty result or encounters an error, the chart title was hidden (`display: none`), making it impossible to identify which chart had the issue.

**Previous attempt:** PR #85943 was closed because it used absolute positioning that caused error messages to overlap with the title, truncating long errors ([review comment](https://github.com/ClickHouse/ClickHouse/pull/85943#pullrequestreview-2307032972)).

**This fix (2 lines):**
1. Keep `title_div.style.display = 'block'` in the error branch (instead of `'none'`)
2. Add `top: 2rem` to `.query-error` CSS to position error text below the title

This ensures the title is always visible while giving error messages the full remaining space below the title, directly addressing @serxa's feedback.

**Before:** Title hidden on empty result — user can't tell which chart failed  
**After:** Title visible, error message shown below it with full available space

### Documentation entry for user-facing changes

- [ ] Documentation is not required (minor UI improvement)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change in `dashboard.html` that adjusts chart title/error rendering; no backend, auth, or data-path logic changes.
> 
> **Overview**
> Ensures dashboard charts keep their title visible even when the query returns an empty result or other error by setting the title before error handling and no longer hiding it on failures.
> 
> Adjusts `.query-error` styling (`top: 2rem`) so error text is positioned below the title instead of overlapping it.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ea9377f066f88d1c028d4ccb7b2f8aab18ff14b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.664`
<!-- ch-version-info:end -->