### PR TITLE
Fix query tree pass order for `GROUP BY` rewrites

### DIFF
--- a/src/Analyzer/QueryTreePassManager.cpp
+++ b/src/Analyzer/QueryTreePassManager.cpp
@@ -291,6 +291,19 @@ void addQueryTreePasses(QueryTreePassManager & manager, bool only_analyze)
     // toString function.
     manager.addPass(std::make_unique<IfTransformStringsToEnumPass>());
 
+    /// These passes can rewrite a predicate so that it depends on base columns instead of
+    /// the derived expression that appears in `GROUP BY`. They must run before
+    /// `OptimizeGroupByFunctionKeysPass` and `OptimizeGroupByInjectiveFunctionsPass`,
+    /// because those passes remove grouping keys based on the current expression tree.
+    /// For example, `SELECT toYear(d), toYear(d) = 2024, count() FROM ... GROUP BY ALL`:
+    /// `OptimizeGroupByFunctionKeysPass` can keep only `toYear(d)` as the grouping key,
+    /// and if `OptimizeDateOrDateTimeConverterWithPreimagePass` runs later it rewrites
+    /// `toYear(d) = 2024` to a range on raw `d`. After aggregation only `toYear(d)` and
+    /// `count()` remain, so the final projection would need `d` that is no longer present.
+    manager.addPass(std::make_unique<InverseDictionaryLookupPass>());
+    manager.addPass(std::make_unique<OptimizeDateOrDateTimeConverterWithPreimagePass>());
+    manager.addPass(std::make_unique<ComparisonTupleEliminationPass>());
+
     manager.addPass(std::make_unique<OptimizeGroupByFunctionKeysPass>());
     manager.addPass(std::make_unique<OptimizeGroupByInjectiveFunctionsPass>());
 
@@ -300,8 +313,6 @@ void addQueryTreePasses(QueryTreePassManager & manager, bool only_analyze)
     manager.addPass(std::make_unique<IfChainToMultiIfPass>());
     manager.addPass(std::make_unique<RewriteAggregateFunctionWithIfPass>());
     manager.addPass(std::make_unique<SumIfToCountIfPass>());
-
-    manager.addPass(std::make_unique<ComparisonTupleEliminationPass>());
 
     manager.addPass(std::make_unique<OptimizeRedundantFunctionsInOrderByPass>());
 
@@ -318,11 +329,7 @@ void addQueryTreePasses(QueryTreePassManager & manager, bool only_analyze)
     manager.addPass(std::make_unique<CrossToInnerJoinPass>());
     manager.addPass(std::make_unique<ShardNumColumnToFunctionPass>());
 
-    manager.addPass(std::make_unique<OptimizeDateOrDateTimeConverterWithPreimagePass>());
-
     manager.addPass(std::make_unique<InjectRandomOrderIfNoOrderByPass>());
-
-    manager.addPass(std::make_unique<InverseDictionaryLookupPass>());
 
     manager.addPass(std::make_unique<DisableParallelReplicasPass>());
 }

--- a/tests/queries/0_stateless/03701_optimize_inverse_dictionary_lookup_basic.sql
+++ b/tests/queries/0_stateless/03701_optimize_inverse_dictionary_lookup_basic.sql
@@ -4,6 +4,7 @@
 SET enable_analyzer = 1;
 SET optimize_inverse_dictionary_lookup = 1;
 SET optimize_or_like_chain = 0;
+SET optimize_rewrite_like_perfect_affix = 0;
 
 DROP DICTIONARY IF EXISTS colors;
 DROP TABLE IF EXISTS ref_colors;

--- a/tests/queries/0_stateless/04032_query_tree_pass_order.reference
+++ b/tests/queries/0_stateless/04032_query_tree_pass_order.reference
@@ -1,0 +1,54 @@
+-- { echo }
+
+DROP DICTIONARY IF EXISTS dict;
+CREATE DICTIONARY dict
+(
+  id Int64,
+  f  Int64
+)
+PRIMARY KEY id
+SOURCE(CLICKHOUSE(QUERY 'SELECT 1 id, 2 f'))
+LAYOUT(flat())
+lifetime(0);
+SELECT
+    dictGet(dict, 'f', dummy),
+   (dictGet(dict, 'f', dummy) = 1),
+    count()
+FROM system.one
+GROUP BY all
+SETTINGS optimize_inverse_dictionary_lookup=0;
+0	0	1
+SELECT
+    dictGet(dict, 'f', dummy),
+   (dictGet(dict, 'f', dummy) = 1),
+    count()
+FROM system.one
+GROUP BY all
+SETTINGS optimize_inverse_dictionary_lookup=1;
+0	0	1
+SELECT
+    toYear(d),
+    (toYear(d) = 2024),
+    count()
+FROM values('d Date', ('2024-01-02'))
+GROUP BY ALL
+SETTINGS optimize_time_filter_with_preimage = 0;
+2024	1	1
+SELECT
+    toYear(d),
+    (toYear(d) = 2024),
+    count()
+FROM values('d Date', ('2024-01-02'))
+GROUP BY ALL
+SETTINGS optimize_time_filter_with_preimage = 1;
+2024	1	1
+SELECT tuple(dummy), (tuple(dummy) = tuple(1)), count()
+FROM system.one
+GROUP BY ALL
+SETTINGS optimize_injective_functions_in_group_by=0;
+(0)	0	1
+SELECT tuple(dummy), (tuple(dummy) = tuple(1)), count()
+FROM system.one
+GROUP BY ALL
+SETTINGS optimize_injective_functions_in_group_by=1;
+(0)	0	1

--- a/tests/queries/0_stateless/04032_query_tree_pass_order.sql
+++ b/tests/queries/0_stateless/04032_query_tree_pass_order.sql
@@ -1,0 +1,60 @@
+-- Tags: no-replicated-database, no-parallel-replicas
+-- no-parallel, no-parallel-replicas: Dictionary is not created in parallel replicas.
+
+-- { echo }
+
+DROP DICTIONARY IF EXISTS dict;
+
+CREATE DICTIONARY dict
+(
+  id Int64,
+  f  Int64
+)
+PRIMARY KEY id
+SOURCE(CLICKHOUSE(QUERY 'SELECT 1 id, 2 f'))
+LAYOUT(flat())
+lifetime(0);
+
+SELECT
+    dictGet(dict, 'f', dummy),
+   (dictGet(dict, 'f', dummy) = 1),
+    count()
+FROM system.one
+GROUP BY all
+SETTINGS optimize_inverse_dictionary_lookup=0;
+
+SELECT
+    dictGet(dict, 'f', dummy),
+   (dictGet(dict, 'f', dummy) = 1),
+    count()
+FROM system.one
+GROUP BY all
+SETTINGS optimize_inverse_dictionary_lookup=1;
+
+
+SELECT
+    toYear(d),
+    (toYear(d) = 2024),
+    count()
+FROM values('d Date', ('2024-01-02'))
+GROUP BY ALL
+SETTINGS optimize_time_filter_with_preimage = 0;
+
+SELECT
+    toYear(d),
+    (toYear(d) = 2024),
+    count()
+FROM values('d Date', ('2024-01-02'))
+GROUP BY ALL
+SETTINGS optimize_time_filter_with_preimage = 1;
+
+
+SELECT tuple(dummy), (tuple(dummy) = tuple(1)), count()
+FROM system.one
+GROUP BY ALL
+SETTINGS optimize_injective_functions_in_group_by=0;
+
+SELECT tuple(dummy), (tuple(dummy) = tuple(1)), count()
+FROM system.one
+GROUP BY ALL
+SETTINGS optimize_injective_functions_in_group_by=1;


### PR DESCRIPTION
Currently, these queries throw `NOT_FOUND_COLUMN_IN_BLOCK` because we optimize `GROUP BY` keys first based on the original expression tree, and then these passes rewrite the expression to depend on underlying columns that are no longer available after aggregation.

```sql
CREATE DICTIONARY dict
(
  id Int64,
  f  Int64
)
PRIMARY KEY id
SOURCE(CLICKHOUSE(QUERY 'SELECT 1 id, 2 f'))
LAYOUT(flat())
lifetime(0);

SELECT
    dictGet(dict, 'f', dummy),
   (dictGet(dict, 'f', dummy) = 1),
    count()
FROM system.one
GROUP BY all
SETTINGS optimize_inverse_dictionary_lookup=1;

SELECT
    toYear(d),
    (toYear(d) = 2024),
    count()
FROM values('d Date', ('2024-01-02'))
GROUP BY ALL
SETTINGS optimize_time_filter_with_preimage = 1;

SELECT tuple(dummy), (tuple(dummy) = tuple(1)), count()
FROM system.one
GROUP BY ALL
SETTINGS optimize_injective_functions_in_group_by=0;
```

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `NOT_FOUND_COLUMN_IN_BLOCK` for some queries with `GROUP BY` and expressions that include inverse dictionary lookup, `Date/DateTime` conversion comparisons, and tuple comparisons. Closes https://github.com/ClickHouse/ClickHouse/issues/98888.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reorders core query-tree optimization passes around `GROUP BY`, which can change the analyzed expression tree and thus affect query planning/performance beyond the targeted bug fix.
> 
> **Overview**
> Fixes `NOT_FOUND_COLUMN_IN_BLOCK` in some `GROUP BY ALL` queries by moving predicate-rewrite passes (`InverseDictionaryLookupPass`, `OptimizeDateOrDateTimeConverterWithPreimagePass`, `ComparisonTupleEliminationPass`) to run **before** `OptimizeGroupByFunctionKeysPass`/`OptimizeGroupByInjectiveFunctionsPass`, ensuring grouping keys aren’t removed before predicates are rewritten to base columns.
> 
> Adds a regression test `04032_query_tree_pass_order` covering dictionary lookup, date preimage time filters, and tuple comparisons under `GROUP BY ALL`, and stabilizes an existing inverse dictionary lookup test by disabling `optimize_rewrite_like_perfect_affix`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1a177294a31a0855b1df4bb25989b3d362a6f08. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.606`
- Backported to: `26.2.5.20`, `26.1.5.33`, `25.12.9.40`
<!-- ch-version-info:end -->