### PR TITLE
Fix UBSan: null pointer dereference when altering version column to EPHEMERAL

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -1359,6 +1359,16 @@ void checkSpecialColumn(const std::string_view column_meta_name, const AlterComm
             column_meta_name,
             backQuoteIfNeed(command.column_name));
     }
+    else if (command.type == AlterCommand::MODIFY_COLUMN
+        && (command.default_kind == ColumnDefaultKind::Ephemeral || command.default_kind == ColumnDefaultKind::Alias))
+    {
+        throw Exception(
+            ErrorCodes::ALTER_OF_COLUMN_IS_FORBIDDEN,
+            "Cannot modify {} column ({}) to {}",
+            column_meta_name,
+            backQuoteIfNeed(command.column_name),
+            toString(command.default_kind));
+    }
 };
 
 template <typename TMustHaveDataType>
@@ -4348,11 +4358,13 @@ void MergeTreeData::checkAlterIsPossible(const AlterCommands & commands, Context
             /// Some type changes for version column is allowed despite it's a part of sorting key
             if (command.type == AlterCommand::MODIFY_COLUMN)
             {
-                const IDataType * new_type = command.data_type.get();
-                const IDataType * old_type = old_types[command.column_name];
+                checkSpecialColumn("version", command);
 
-                if (new_type)
-                    checkVersionColumnTypesConversion(old_type, new_type, command.column_name);
+                const IDataType * new_type = command.data_type.get();
+                auto it = old_types.find(command.column_name);
+
+                if (new_type && it != old_types.end())
+                    checkVersionColumnTypesConversion(it->second, new_type, command.column_name);
 
                 /// No other checks required
                 continue;

--- a/tests/queries/0_stateless/04032_alter_version_column_nonexistent.sql
+++ b/tests/queries/0_stateless/04032_alter_version_column_nonexistent.sql
@@ -1,0 +1,25 @@
+-- Regression test: special MergeTree columns (version, sign, is_deleted) must not
+-- be changed to EPHEMERAL or ALIAS. Previously, making the version column EPHEMERAL
+-- removed it from physical columns, causing a null pointer dereference (UBSan) on
+-- subsequent ALTER MODIFY COLUMN.
+
+SET allow_suspicious_low_cardinality_types = 1;
+
+-- Test version column (ReplacingMergeTree)
+DROP TABLE IF EXISTS t_special_col;
+CREATE TABLE t_special_col (a UInt64, b DateTime) ENGINE = ReplacingMergeTree(b) ORDER BY a;
+ALTER TABLE t_special_col MODIFY COLUMN b DateTime EPHEMERAL now(); -- { serverError ALTER_OF_COLUMN_IS_FORBIDDEN }
+ALTER TABLE t_special_col MODIFY COLUMN b DateTime ALIAS now(); -- { serverError ALTER_OF_COLUMN_IS_FORBIDDEN }
+DROP TABLE t_special_col;
+
+-- Test sign column (CollapsingMergeTree)
+CREATE TABLE t_special_col (a UInt64, sign Int8) ENGINE = CollapsingMergeTree(sign) ORDER BY a;
+ALTER TABLE t_special_col MODIFY COLUMN sign Int8 EPHEMERAL 1; -- { serverError ALTER_OF_COLUMN_IS_FORBIDDEN }
+ALTER TABLE t_special_col MODIFY COLUMN sign Int8 ALIAS 1; -- { serverError ALTER_OF_COLUMN_IS_FORBIDDEN }
+DROP TABLE t_special_col;
+
+-- Test is_deleted column (ReplacingMergeTree with is_deleted)
+CREATE TABLE t_special_col (a UInt64, b UInt64, deleted UInt8) ENGINE = ReplacingMergeTree(b, deleted) ORDER BY a;
+ALTER TABLE t_special_col MODIFY COLUMN deleted UInt8 EPHEMERAL 0; -- { serverError ALTER_OF_COLUMN_IS_FORBIDDEN }
+ALTER TABLE t_special_col MODIFY COLUMN deleted UInt8 ALIAS 0; -- { serverError ALTER_OF_COLUMN_IS_FORBIDDEN }
+DROP TABLE t_special_col;


### PR DESCRIPTION
## Summary
- Fixed a null pointer dereference in `checkVersionColumnTypesConversion` found by the AST fuzzer (UBSan). Making a version column `EPHEMERAL` removed it from physical columns, and a subsequent `ALTER MODIFY COLUMN` would dereference a null pointer from `old_types[column_name]`.
- Changed `operator[]` to `find()` for the `old_types` map lookup to avoid inserting null pointers.
- Added a check in `checkSpecialColumn` that prevents special MergeTree columns (version, sign, `is_deleted`, columns to sum) from being changed to `EPHEMERAL` or `ALIAS`, since these columns must remain physical.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=6f0151ba256c1a8dd90b70212dd26c6b927407b6&name_0=MasterCI&name_1=AST%20fuzzer%20%28amd_ubsan%29&name_1=AST%20fuzzer%20%28amd_ubsan%29

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed undefined behavior (null pointer dereference) when altering a version/sign/is_deleted column to `EPHEMERAL` or `ALIAS` in MergeTree engines. Such alterations are now properly rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches MergeTree ALTER validation in a core storage engine path, which could affect schema-change workflows, but the change is narrowly scoped and covered by a regression test.
> 
> **Overview**
> Prevents `ALTER MODIFY COLUMN` from changing special MergeTree columns (e.g. `version`, `sign`, `is_deleted`, `columns_to_sum`) to `EPHEMERAL` or `ALIAS`, rejecting these operations with `ALTER_OF_COLUMN_IS_FORBIDDEN`.
> 
> Fixes a UBSan null dereference during version-column type conversion checks by switching the `old_types` lookup from `operator[]` to `find()` (avoiding implicit insertion of a null entry) and adds a stateless regression test covering the forbidden alters.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b559b79f840e17b029a0150a07d4de48a0ea6e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.508`
<!-- ch-version-info:end -->