### PR TITLE
Add test for constant expression evaluation in mergeTreeAnalyzeIndexes parts array

### DIFF
--- a/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexes.reference
+++ b/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexes.reference
@@ -26,3 +26,8 @@ select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, key in (8193, 163
 all_1_1_0	[(1,3)]
 -- Corner cases
 select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, key = 8193, [materialize('all_1_1_0')]); -- { serverError BAD_ARGUMENTS }
+-- Constant expressions (non-literal) should be evaluated via evaluateConstantExpressionAsLiteral
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, key = 8193, [concat('all', '_1_1_0')]);
+all_1_1_0	[(1,2)]
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, key = 8193, [toString('all_1_1_0')]);
+all_1_1_0	[(1,2)]

--- a/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexes.sql
+++ b/tests/queries/0_stateless/03620_mergeTreeAnalyzeIndexes.sql
@@ -27,3 +27,7 @@ select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, key in (8193, 163
 
 -- Corner cases
 select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, key = 8193, [materialize('all_1_1_0')]); -- { serverError BAD_ARGUMENTS }
+
+-- Constant expressions (non-literal) should be evaluated via evaluateConstantExpressionAsLiteral
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, key = 8193, [concat('all', '_1_1_0')]);
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), data, key = 8193, [toString('all_1_1_0')]);


### PR DESCRIPTION
PR #98867 fixed extractParts to use evaluateConstantExpressionAsLiteral instead of a direct ASTLiteral cast, preventing LOGICAL_ERROR on non-literal inputs. The PR's own test only covers the error path (materialize() → BAD_ARGUMENTS).

The success path — where a non-literal constant expression like concat() is evaluated to a string — was untested. The existing array('all_1_1_0') test goes through the same code line but with a literal element, so evaluateConstantExpressionAsLiteral is a no-op and the actual evaluation logic is never exercised.

This adds two queries to 03620_mergeTreeAnalyzeIndexes.sql covering concat() and toString() in the parts array.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only extends stateless tests and expected output; no production code changes, with minimal risk beyond potential test flakiness if output changes.
> 
> **Overview**
> Extends the `03620_mergeTreeAnalyzeIndexes` stateless test to cover the *success path* for non-literal constant expressions in the `parts` array argument.
> 
> Adds new queries using `concat()` and `toString()` (and updates the `.reference`) to ensure such expressions are evaluated to string literals rather than failing or being ignored.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a6516f0e6d3fc566486afcda11ef4b8d4f04ccf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.588`
<!-- ch-version-info:end -->