### PR TITLE
Add error-path tests for functions refactored in PR #97672

### DIFF
--- a/tests/queries/0_stateless/03930_pr97672_validation_error_paths.reference
+++ b/tests/queries/0_stateless/03930_pr97672_validation_error_paths.reference
@@ -1,0 +1,10 @@
+hello/
+hello/
+January
+255
+FF
+1
+
+10
+10
+['Cli','lic','ick','ckH','kHo','Hou','ous','use']

--- a/tests/queries/0_stateless/03930_pr97672_validation_error_paths.sql
+++ b/tests/queries/0_stateless/03930_pr97672_validation_error_paths.sql
@@ -1,0 +1,39 @@
+-- Tests error paths for functions whose validation was refactored in PR #97672
+-- (manual validation replaced with validateFunctionArguments framework).
+-- Only functions that had NO existing error-path coverage are included.
+
+-- appendTrailingCharIfAbsent
+SELECT appendTrailingCharIfAbsent('hello', '/');
+SELECT appendTrailingCharIfAbsent('hello/', '/');
+SELECT appendTrailingCharIfAbsent(123, '/'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT appendTrailingCharIfAbsent('hello', 123); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+
+-- monthName
+SELECT monthName(toDate('2023-01-15'));
+SELECT monthName(123); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+
+-- conv
+SELECT conv('ff', 16, 10);
+SELECT conv(255, 10, 16);
+SELECT conv('ff', 'abc', 10); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+
+-- lowCardinalityIndices / lowCardinalityKeys
+SELECT lowCardinalityIndices(toLowCardinality('hello'));
+SELECT lowCardinalityKeys(toLowCardinality('hello'));
+SELECT lowCardinalityIndices('hello'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT lowCardinalityKeys('hello'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+
+-- randomPrintableASCII
+SELECT length(randomPrintableASCII(10));
+SELECT randomPrintableASCII('abc'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+
+-- randomString
+SELECT length(randomString(10));
+SELECT randomString('abc'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+
+-- ngrams
+SELECT ngrams('ClickHouse', 3);
+SELECT ngrams(123, 3); -- { serverError BAD_ARGUMENTS }
+
+-- dynamicType
+SELECT dynamicType(42); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }

--- a/tests/queries/0_stateless/03930_pr97672_validation_error_paths.sql
+++ b/tests/queries/0_stateless/03930_pr97672_validation_error_paths.sql
@@ -33,7 +33,7 @@ SELECT randomString('abc'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
 
 -- ngrams
 SELECT ngrams('ClickHouse', 3);
-SELECT ngrams(123, 3); -- { serverError BAD_ARGUMENTS }
+SELECT ngrams(123, 3); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
 
 -- dynamicType
 SELECT dynamicType(42); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }


### PR DESCRIPTION
PR #97672 mechanically replaced manual argument validation with the validateFunctionArguments / validateFunctionArgumentsWithVariadics framework across 21 function files. While the behavior is unchanged, the following functions had no existing tests verifying their error paths (wrong argument types → ILLEGAL_TYPE_OF_ARGUMENT or BAD_ARGUMENTS):
  - appendTrailingCharIfAbsent
  - monthName
  - conv
  - lowCardinalityIndices / lowCardinalityKeys
  - randomPrintableASCII
  - randomString
  - ngrams (throws BAD_ARGUMENTS, not ILLEGAL_TYPE_OF_ARGUMENT)
  - dynamicType

This adds a single test file covering both happy-path and error-path queries for each of these functions, preventing future regressions if the validation framework or these functions are changed.

Functions already covered by existing tests (tupleConcat, substringIndex, randomStringUTF8) are intentionally excluded.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds only stateless SQL tests and expected outputs, with no production code changes; risk is limited to potential test flakiness or incorrect expected error codes.
> 
> **Overview**
> Adds a new stateless query test (`03930_pr97672_validation_error_paths.sql` + `.reference`) that exercises both success and wrong-argument-type error paths for several functions whose argument validation was recently refactored (e.g., `appendTrailingCharIfAbsent`, `monthName`, `conv`, `lowCardinalityIndices/Keys`, `randomPrintableASCII`, `randomString`, `ngrams`, `dynamicType`).
> 
> The test asserts expected failures via `serverError ILLEGAL_TYPE_OF_ARGUMENT` to prevent regressions in validation behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3cb6ebcb9b517bcce0120abdbf417433cfe67ff5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.709`
<!-- ch-version-info:end -->