### PR TITLE
Fix incorrect or missed pruning when `startsWith`, `LIKE`, `NOT LIKE ` used with `FixedString` column

### DIFF
--- a/src/Functions/FunctionsConversion.h
+++ b/src/Functions/FunctionsConversion.h
@@ -3761,8 +3761,17 @@ struct ToStringMonotonicity
             type_ptr = low_cardinality_type->getDictionaryType().get();
 
         /// Order on enum values (which is the order on integers) is completely arbitrary in respect to the order on strings.
-        if (WhichDataType(type).isEnum())
+        if (WhichDataType(*type_ptr).isEnum())
             return not_monotonic;
+
+        if (checkDataTypes<DataTypeFixedString>(type_ptr))
+        {
+            /// `toString(FixedString(N))` removes trailing zero bytes. For example, with `N = 4`,
+            /// `['a', 'b', '\0', '\0']` becomes `'ab'`, and `['a', 'b', '\1', '\0']` becomes `'ab\1'`.
+            /// This preserves lexicographic order on `FixedString(N)`, so the transformation is
+            /// strictly monotonic on the whole type range.
+            return {.is_monotonic = true, .is_always_monotonic = true, .is_strict = true};
+        }
 
         /// `toString` function is monotonous if the argument is Date or Date32 or DateTime or String, or non-negative numbers with the same number of symbols.
         if (checkDataTypes<DataTypeDate, DataTypeDate32, DataTypeDateTime, DataTypeTime, DataTypeString>(type_ptr))

--- a/src/Functions/tests/gtest_conversion_monotonic.cpp
+++ b/src/Functions/tests/gtest_conversion_monotonic.cpp
@@ -1,5 +1,8 @@
 #include <gtest/gtest.h>
+
 #include <Functions/FunctionsConversion.h>
+#include <DataTypes/DataTypeFixedString.h>
+#include <DataTypes/DataTypeLowCardinality.h>
 #include <DataTypes/DataTypesNumber.h>
 
 using namespace DB;
@@ -46,4 +49,28 @@ TEST(ConversionMonotonic, toDateTime)
 
     /// The range of from_type exceeds the range of to_type
     ASSERT_EQ(ToDateTimeMonotonicity<DataTypeDateTime>::get(DataTypeUInt64(), {}, {}).is_strict, false);
+}
+
+TEST(ConversionMonotonic, toStringFixedString)
+{
+    DataTypeFixedString fixed_string_type(4);
+
+    const auto monotonicity = ToStringMonotonicity::get(fixed_string_type, {}, {});
+
+    ASSERT_EQ(monotonicity.is_monotonic, true);
+    ASSERT_EQ(monotonicity.is_positive, true);
+    ASSERT_EQ(monotonicity.is_always_monotonic, true);
+    ASSERT_EQ(monotonicity.is_strict, true);
+}
+
+TEST(ConversionMonotonic, toStringLowCardinalityFixedString)
+{
+    DataTypeLowCardinality low_cardinality_fixed_string_type(std::make_shared<DataTypeFixedString>(4));
+
+    const auto monotonicity = ToStringMonotonicity::get(low_cardinality_fixed_string_type, {}, {});
+
+    ASSERT_EQ(monotonicity.is_monotonic, true);
+    ASSERT_EQ(monotonicity.is_positive, true);
+    ASSERT_EQ(monotonicity.is_always_monotonic, true);
+    ASSERT_EQ(monotonicity.is_strict, true);
 }

--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -3080,10 +3080,32 @@ bool KeyCondition::extractAtomFromTree(const RPNBuilderTreeNode & node, const Bu
             {
                 if (const_value.getType() == Field::Types::String)
                 {
-                    const_value = convertFieldToType(const_value, *key_expr_type_not_null);
-                    if (const_value.isNull())
-                        return false;
-                    /// No need to set condition_is_relaxed because we're doing exact conversion
+                    /// These functions use the constant as a string pattern or prefix. 
+                    /// For example, if column is `FixedString` type, then in `startsWith(column, 'ab')` 
+                    /// and `column LIKE 'ab%'`, `'ab'` is used to build the prefix range `['ab', 'ac')`.
+                    //  The literal must not be converted to the column type which is `FixedString`. If we
+                    /// first convert it to `FixedString(N)`, it becomes `'ab\0...'`, and the range is built from
+                    /// the padded value instead of from `'ab'`. This can lead to the upper bound being set to the 
+                    /// next padded value, for example `['ab\0...', 'ab\0...\1')`, instead of to the next prefix
+                    /// range `['ab', 'ac')`. The padded range is too small and can miss values such as `'abc...'` that still
+                    /// satisfy `startsWith(column, 'ab')` and `column LIKE 'ab%'`.
+                    /// New functions should be added to this list only if their constant argument is used as a
+                    /// pattern or prefix in the same way.
+                    const bool should_keep_original_string_constant
+                        = isStringOrFixedString(key_expr_type_not_null)
+                        && (func_name == "like"
+                        || func_name == "notLike"
+                        || func_name == "startsWith"
+                        || func_name == "startsWithUTF8"
+                        || func_name == "match");
+
+                    if (!should_keep_original_string_constant)
+                    {
+                        const_value = convertFieldToType(const_value, *key_expr_type_not_null);
+                        if (const_value.isNull())
+                            return false;
+                        /// No need to set condition_is_relaxed because we're doing exact conversion
+                    }
                 }
                 else
                 {

--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -3080,12 +3080,12 @@ bool KeyCondition::extractAtomFromTree(const RPNBuilderTreeNode & node, const Bu
             {
                 if (const_value.getType() == Field::Types::String)
                 {
-                    /// These functions use the constant as a string pattern or prefix. 
-                    /// For example, if column is `FixedString` type, then in `startsWith(column, 'ab')` 
+                    /// These functions use the constant as a string pattern or prefix.
+                    /// For example, if column is `FixedString` type, then in `startsWith(column, 'ab')`
                     /// and `column LIKE 'ab%'`, `'ab'` is used to build the prefix range `['ab', 'ac')`.
                     //  The literal must not be converted to the column type which is `FixedString`. If we
                     /// first convert it to `FixedString(N)`, it becomes `'ab\0...'`, and the range is built from
-                    /// the padded value instead of from `'ab'`. This can lead to the upper bound being set to the 
+                    /// the padded value instead of from `'ab'`. This can lead to the upper bound being set to the
                     /// next padded value, for example `['ab\0...', 'ab\0...\1')`, instead of to the next prefix
                     /// range `['ab', 'ac')`. The padded range is too small and can miss values such as `'abc...'` that still
                     /// satisfy `startsWith(column, 'ab')` and `column LIKE 'ab%'`.

--- a/tests/queries/0_stateless/04032_fixedstring_prefix_key_condition.reference
+++ b/tests/queries/0_stateless/04032_fixedstring_prefix_key_condition.reference
@@ -1,0 +1,247 @@
+-- { echo }
+
+DROP TABLE IF EXISTS test;
+CREATE TABLE test
+(
+    fixed_string_col FixedString(40),
+    text String
+)
+ENGINE = MergeTree
+ORDER BY fixed_string_col
+SETTINGS index_granularity = 1;
+INSERT INTO test VALUES
+    ('11',  'plain-11'),
+    ('110', 'plain-110'),
+    ('11z', 'plain-11z'),
+    ('12',  'plain-12'),
+    ('21',  'plain-21'),
+    ('999',  'plain-999');
+SELECT text
+FROM test
+WHERE startsWith(fixed_string_col, '11')
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+plain-11
+plain-110
+plain-11z
+SELECT text
+FROM test
+WHERE startsWith(CAST(fixed_string_col, 'String'), '11')
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+plain-11
+plain-110
+plain-11z
+SELECT text
+FROM test
+WHERE fixed_string_col LIKE '11%'
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+plain-11
+plain-110
+plain-11z
+SELECT text
+FROM test
+WHERE CAST(fixed_string_col, 'String') LIKE '11%'
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+plain-11
+plain-110
+plain-11z
+SELECT text
+FROM test
+WHERE fixed_string_col NOT LIKE '99%'
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 5;
+plain-11
+plain-110
+plain-11z
+plain-12
+plain-21
+SELECT text
+FROM test
+WHERE CAST(fixed_string_col, 'String') NOT LIKE '99%'
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 5;
+plain-11
+plain-110
+plain-11z
+plain-12
+plain-21
+SELECT text
+FROM test
+WHERE match(fixed_string_col, '^11.')
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+plain-11
+plain-110
+plain-11z
+SELECT text
+FROM test
+WHERE match(CAST(fixed_string_col, 'String'), '^11.')
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+plain-110
+plain-11z
+-- Fixed String Liteal tests
+
+SELECT text
+FROM test
+WHERE startsWith(fixed_string_col, toFixedString('11', 2))
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+plain-11
+plain-110
+plain-11z
+SELECT text
+FROM test
+WHERE startsWith(CAST(fixed_string_col, 'String'), toFixedString('11', 2))
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+plain-11
+plain-110
+plain-11z
+SELECT text
+FROM test
+WHERE fixed_string_col LIKE toFixedString('11%', 3) -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+SELECT text
+FROM test
+WHERE CAST(fixed_string_col, 'String') LIKE toFixedString('11%', 3) -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+SELECT text
+FROM test
+WHERE fixed_string_col NOT LIKE toFixedString('99%', 3) -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 5;
+SELECT text
+FROM test
+WHERE CAST(fixed_string_col, 'String') NOT LIKE toFixedString('99%', 3) -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 5;
+SELECT text
+FROM test
+WHERE match(fixed_string_col, toFixedString('^11.', 4)) -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+SELECT text
+FROM test
+WHERE match(CAST(fixed_string_col, 'String'), toFixedString('^11.', 4)) -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+DROP TABLE IF EXISTS test_string;
+CREATE TABLE test_string
+(
+    string_col String,
+    text String
+)
+ENGINE = MergeTree
+ORDER BY string_col
+SETTINGS index_granularity = 1;
+INSERT INTO test_string
+SELECT
+    CAST(fixed_string_col, 'String'),
+    text
+FROM test;
+-- String key tests
+
+SELECT text
+FROM test_string
+WHERE startsWith(string_col, '11')
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+plain-11
+plain-110
+plain-11z
+SELECT text
+FROM test_string
+WHERE startsWith(CAST(string_col, 'FixedString(40)'), '11')
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;  -- { serverError INDEX_NOT_USED }
+SELECT text
+FROM test_string
+WHERE string_col LIKE '11%'
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+plain-11
+plain-110
+plain-11z
+SELECT text
+FROM test_string
+WHERE CAST(string_col, 'FixedString(40)') LIKE '11%' -- { serverError INDEX_NOT_USED }
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+SELECT text
+FROM test_string
+WHERE string_col NOT LIKE '99%'
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 5;
+plain-11
+plain-110
+plain-11z
+plain-12
+plain-21
+SELECT text
+FROM test_string
+WHERE CAST(string_col, 'FixedString(40)') NOT LIKE '99%' -- { serverError INDEX_NOT_USED }
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 5;
+SELECT text
+FROM test_string
+WHERE match(string_col, '^11.')
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+plain-110
+plain-11z
+SELECT text
+FROM test_string
+WHERE match(CAST(string_col, 'FixedString(40)'), '^11.') -- { serverError INDEX_NOT_USED }
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+-- String key with FixedString literal tests
+
+SELECT text
+FROM test_string
+WHERE startsWith(string_col, toFixedString('11', 2))
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+plain-11
+plain-110
+plain-11z
+SELECT text
+FROM test_string
+WHERE startsWith(CAST(string_col, 'FixedString(40)'), toFixedString('11', 2)) -- { serverError INDEX_NOT_USED }
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+SELECT text
+FROM test_string
+WHERE string_col LIKE toFixedString('11%', 3) -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+SELECT text
+FROM test_string
+WHERE CAST(string_col, 'FixedString(40)') LIKE toFixedString('11%', 3) -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+SELECT text
+FROM test_string
+WHERE string_col NOT LIKE toFixedString('99%', 3) -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 5;
+SELECT text
+FROM test_string
+WHERE CAST(string_col, 'FixedString(40)') NOT LIKE toFixedString('99%', 3) -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 5;
+SELECT text
+FROM test_string
+WHERE match(string_col, toFixedString('^11.', 4)) -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+SELECT text
+FROM test_string
+WHERE match(CAST(string_col, 'FixedString(40)'), toFixedString('^11.', 4)) -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;

--- a/tests/queries/0_stateless/04032_fixedstring_prefix_key_condition.sql
+++ b/tests/queries/0_stateless/04032_fixedstring_prefix_key_condition.sql
@@ -1,0 +1,236 @@
+-- { echo }
+
+DROP TABLE IF EXISTS test;
+
+CREATE TABLE test
+(
+    fixed_string_col FixedString(40),
+    text String
+)
+ENGINE = MergeTree
+ORDER BY fixed_string_col
+SETTINGS index_granularity = 1;
+
+INSERT INTO test VALUES
+    ('11',  'plain-11'),
+    ('110', 'plain-110'),
+    ('11z', 'plain-11z'),
+    ('12',  'plain-12'),
+    ('21',  'plain-21'),
+    ('999',  'plain-999');
+
+SELECT text
+FROM test
+WHERE startsWith(fixed_string_col, '11')
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+
+SELECT text
+FROM test
+WHERE startsWith(CAST(fixed_string_col, 'String'), '11')
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+
+SELECT text
+FROM test
+WHERE fixed_string_col LIKE '11%'
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+
+SELECT text
+FROM test
+WHERE CAST(fixed_string_col, 'String') LIKE '11%'
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+
+SELECT text
+FROM test
+WHERE fixed_string_col NOT LIKE '99%'
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 5;
+
+SELECT text
+FROM test
+WHERE CAST(fixed_string_col, 'String') NOT LIKE '99%'
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 5;
+
+SELECT text
+FROM test
+WHERE match(fixed_string_col, '^11.')
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+
+SELECT text
+FROM test
+WHERE match(CAST(fixed_string_col, 'String'), '^11.')
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+
+
+-- Fixed String Liteal tests
+
+SELECT text
+FROM test
+WHERE startsWith(fixed_string_col, toFixedString('11', 2))
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+
+SELECT text
+FROM test
+WHERE startsWith(CAST(fixed_string_col, 'String'), toFixedString('11', 2))
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+
+SELECT text
+FROM test
+WHERE fixed_string_col LIKE toFixedString('11%', 3) -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+
+SELECT text
+FROM test
+WHERE CAST(fixed_string_col, 'String') LIKE toFixedString('11%', 3) -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+
+SELECT text
+FROM test
+WHERE fixed_string_col NOT LIKE toFixedString('99%', 3) -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 5;
+
+SELECT text
+FROM test
+WHERE CAST(fixed_string_col, 'String') NOT LIKE toFixedString('99%', 3) -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 5;
+
+SELECT text
+FROM test
+WHERE match(fixed_string_col, toFixedString('^11.', 4)) -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+
+SELECT text
+FROM test
+WHERE match(CAST(fixed_string_col, 'String'), toFixedString('^11.', 4)) -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+
+DROP TABLE IF EXISTS test_string;
+
+CREATE TABLE test_string
+(
+    string_col String,
+    text String
+)
+ENGINE = MergeTree
+ORDER BY string_col
+SETTINGS index_granularity = 1;
+
+INSERT INTO test_string
+SELECT
+    CAST(fixed_string_col, 'String'),
+    text
+FROM test;
+
+-- String key tests
+
+SELECT text
+FROM test_string
+WHERE startsWith(string_col, '11')
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+
+SELECT text
+FROM test_string
+WHERE startsWith(CAST(string_col, 'FixedString(40)'), '11')
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;  -- { serverError INDEX_NOT_USED }
+
+SELECT text
+FROM test_string
+WHERE string_col LIKE '11%'
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+
+SELECT text
+FROM test_string
+WHERE CAST(string_col, 'FixedString(40)') LIKE '11%' -- { serverError INDEX_NOT_USED }
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+
+SELECT text
+FROM test_string
+WHERE string_col NOT LIKE '99%'
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 5;
+
+SELECT text
+FROM test_string
+WHERE CAST(string_col, 'FixedString(40)') NOT LIKE '99%' -- { serverError INDEX_NOT_USED }
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 5;
+
+SELECT text
+FROM test_string
+WHERE match(string_col, '^11.')
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+
+SELECT text
+FROM test_string
+WHERE match(CAST(string_col, 'FixedString(40)'), '^11.') -- { serverError INDEX_NOT_USED }
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+
+-- String key with FixedString literal tests
+
+SELECT text
+FROM test_string
+WHERE startsWith(string_col, toFixedString('11', 2))
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+
+SELECT text
+FROM test_string
+WHERE startsWith(CAST(string_col, 'FixedString(40)'), toFixedString('11', 2)) -- { serverError INDEX_NOT_USED }
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+
+SELECT text
+FROM test_string
+WHERE string_col LIKE toFixedString('11%', 3) -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+
+SELECT text
+FROM test_string
+WHERE CAST(string_col, 'FixedString(40)') LIKE toFixedString('11%', 3) -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+
+SELECT text
+FROM test_string
+WHERE string_col NOT LIKE toFixedString('99%', 3) -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 5;
+
+SELECT text
+FROM test_string
+WHERE CAST(string_col, 'FixedString(40)') NOT LIKE toFixedString('99%', 3) -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 5;
+
+SELECT text
+FROM test_string
+WHERE match(string_col, toFixedString('^11.', 4)) -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+
+SELECT text
+FROM test_string
+WHERE match(CAST(string_col, 'FixedString(40)'), toFixedString('^11.', 4)) -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;


### PR DESCRIPTION
Given,

```sql
CREATE TABLE test (fixed_string_col FixedString(40), text String) ENGINE = MergeTree ORDER BY fixed_string_col SETTINGS index_granularity = 1;

INSERT INTO test VALUES ('11','plain-11'),('110','plain-110'),('11z','plain-11z'),('12','plain-12'),('21','plain-21'),('999','plain-999');
```

Wrong answer:

```sql
SELECT count()
FROM test
WHERE startsWith(fixed_string_col, '11'); -- returns 1 but should be 3
```

```sql
SELECT count()
FROM test
WHERE fixed_string_col LIKE '11%'; -- returns 1 but should be 3
```

```sql
SELECT text
FROM test
WHERE fixed_string_col NOT LIKE '99%'; -- Read more than needed because `LIKE` internval was incorrectly small so `NOT LIKE` became larger
```

Addtionally, `FixedString` to `String` cast function monotonicity added. As a result, we prune for cases like these:

```sql
SELECT text
FROM test
WHERE startsWith(CAST(fixed_string_col, 'String'), '11');
```

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix incorrect or less pruning when `startsWith`, `LIKE`, `NOT LIKE ` used with `FixedString` column. Additionally, `FixedString` to `String` cast function can now prune granules when wrapped around key column. Closes https://github.com/ClickHouse/ClickHouse/issues/98940.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes predicate-to-range conversion in `KeyCondition` and function monotonicity metadata, which can affect query correctness and index pruning behavior for MergeTree scans.
> 
> **Overview**
> Fixes incorrect/overly-narrow primary-key range construction when `startsWith`, `LIKE`/`NOT LIKE`, or `match` are applied to `FixedString` key columns by **preserving string literals** instead of converting them to padded `FixedString(N)` during key-condition analysis.
> 
> Marks `toString(FixedString)` (including `LowCardinality(FixedString)`) as **always strict monotonic**, allowing MergeTree pruning when casts wrap the key column. Adds unit tests for the new monotonicity and stateless query tests covering the FixedString prefix/pattern pruning regressions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30ae7ae3ed706b451161f2fd734b7e569f5133c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.534`
<!-- ch-version-info:end -->