### PR TITLE
Cap column dump in analyzer error messages to 10 columns

### DIFF
--- a/src/Analyzer/Resolve/TableExpressionData.h
+++ b/src/Analyzer/Resolve/TableExpressionData.h
@@ -69,8 +69,18 @@ struct AnalysisTableExpressionData
 
         buffer << "   Should qualify columns " << should_qualify_columns << "\n";
         buffer << "   Columns size " << column_name_to_column_node.size() << "\n";
+        static constexpr size_t max_columns_to_dump = 10;
+        size_t columns_dumped = 0;
         for (const auto & [column_name, column_node] : column_name_to_column_node)
+        {
+            if (columns_dumped >= max_columns_to_dump)
+            {
+                buffer << "    ... and " << (column_name_to_column_node.size() - max_columns_to_dump) << " more columns\n";
+                break;
+            }
             buffer << "    { " << column_name << " : " << column_node->dumpTree() << " }\n";
+            ++columns_dumped;
+        }
     }
 
     [[maybe_unused]] String dump() const


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Analyzer error messages no longer dump all columns of a table (which could produce 150KB+ exceptions). Column lists are now capped at 10 entries.

Documentation entry for user-facing changes
- [ ] Documentation is not required (error message improvement)

---

## What this PR does

The analyzer's scope dump includes ALL columns when reporting errors like `UNKNOWN_IDENTIFIER`. For tables with many columns (e.g. `system.metric_log` with 1335 columns), this produces **150KB error messages** — unreadable and wasteful.

### Before
```
Unknown identifier 'X' inside COLUMNS matcher. In scope ...
  Columns size 1335
    { col1 : COLUMN ... }
    { col2 : COLUMN ... }
    ... 1335 entries totaling 150KB ...
```

### After
```
Unknown identifier 'X' inside COLUMNS matcher. In scope ...
  Columns size 1335
    { col1 : COLUMN ... }
    { col2 : COLUMN ... }
    ... (8 more shown) ...
    ... and 1325 more columns
```

### Fix (10 insertions, 1 file)

Cap the column dump loop in `AnalysisTableExpressionData::dump()` to 10 entries. After 10, print `"... and N more columns"`. The total column count is still shown in the `"Columns size"` header.

Fixes #83639

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Fixes `windowFunnel(..., 'strict_deduplication')` to return the actual max funnel level on duplicates, which can change query results for affected workloads; analyzer dump truncation only affects error-message output.
> 
> **Overview**
> Fixes `windowFunnel` with `strict_deduplication` to return the *current max funnel level* when a duplicate step is encountered, instead of incorrectly returning the previous sorted event’s condition index (adds a regression test covering the reported scenario).
> 
> Improves analyzer diagnostics by capping `AnalysisTableExpressionData::dump()` column listings to 10 entries and printing a summary line for the remaining columns, preventing excessively large exception messages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65d8fb04eab302af24ac509844bb3c2251c09677. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.511`
<!-- ch-version-info:end -->