### PR TITLE
Fix filter push-down losing column constness after AND short-circuit

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/filterPushDown.cpp
+++ b/src/Processors/QueryPlan/Optimizations/filterPushDown.cpp
@@ -123,11 +123,11 @@ void materializeFilterColumnIfNeededAfterPushDown(FilterStep & filter, const boo
 /// but the remaining expression after extracting the constant parts is non-const, we must constify it back.
 /// Otherwise, parent steps that cached the original (const) output header will see a non-const column, causing
 /// a "Block structure mismatch" exception or "non constant in source stream but must be constant in result" error.
-void constifyFilterColumnAfterPushDown(ActionsDAG & expression, const String & filter_column_name, const ColumnPtr & original_const_column)
+bool constifyFilterColumnAfterPushDown(ActionsDAG & expression, const String & filter_column_name, const ColumnPtr & original_const_column)
 {
     auto * filter_node = const_cast<ActionsDAG::Node *>(expression.tryFindInOutputs(filter_column_name));
     if (!filter_node || filter_node->type == ActionsDAG::ActionType::INPUT)
-        return;
+        return false;
 
     ActionsDAG::Node const_node;
     const_node.type = ActionsDAG::ActionType::COLUMN;
@@ -136,6 +136,7 @@ void constifyFilterColumnAfterPushDown(ActionsDAG & expression, const String & f
     const_node.column = filter_node->result_type->createColumnConst(0, (*original_const_column)[0]);
 
     *filter_node = std::move(const_node);
+    return true;
 }
 }
 
@@ -169,8 +170,8 @@ static std::optional<ActionsDAG::ActionsForFilterPushDown> splitFilter(QueryPlan
         {
             /// The filter column was const before push-down (e.g., AND short-circuits to constant false)
             /// but became non-const after extracting the constant parts. Restore constness.
-            constifyFilterColumnAfterPushDown(expression, filter_column_name, original_filter_const_column);
-            result->is_filter_const_after_push_down = true;
+            result->is_filter_const_after_push_down
+                = constifyFilterColumnAfterPushDown(expression, filter_column_name, original_filter_const_column);
         }
         else
         {
@@ -709,8 +710,8 @@ static size_t tryPushDownOverJoinStep(QueryPlan::Node * parent_node, QueryPlan::
 
     if (is_filter_column_const_before && !join_filter_push_down_actions.is_filter_const_after_all_push_downs)
     {
-        constifyFilterColumnAfterPushDown(filter->getExpression(), filter->getFilterColumnName(), original_filter_const_column);
-        join_filter_push_down_actions.is_filter_const_after_all_push_downs = true;
+        join_filter_push_down_actions.is_filter_const_after_all_push_downs
+            = constifyFilterColumnAfterPushDown(filter->getExpression(), filter->getFilterColumnName(), original_filter_const_column);
     }
     else
     {

--- a/src/Processors/QueryPlan/Optimizations/filterPushDown.cpp
+++ b/src/Processors/QueryPlan/Optimizations/filterPushDown.cpp
@@ -118,6 +118,25 @@ void materializeFilterColumnIfNeededAfterPushDown(FilterStep & filter, const boo
     const auto & non_const_filter_node = expression.materializeNode(filter_node, false);
     expression.addOrReplaceInOutputs(non_const_filter_node);
 }
+
+/// When the filter column was const before push-down (e.g., `and(const_false, ..., aggregate)` short-circuits to 0)
+/// but the remaining expression after extracting the constant parts is non-const, we must constify it back.
+/// Otherwise, parent steps that cached the original (const) output header will see a non-const column, causing
+/// a "Block structure mismatch" exception or "non constant in source stream but must be constant in result" error.
+void constifyFilterColumnAfterPushDown(ActionsDAG & expression, const String & filter_column_name, const ColumnPtr & original_const_column)
+{
+    auto * filter_node = const_cast<ActionsDAG::Node *>(expression.tryFindInOutputs(filter_column_name));
+    if (!filter_node || filter_node->type == ActionsDAG::ActionType::INPUT)
+        return;
+
+    ActionsDAG::Node const_node;
+    const_node.type = ActionsDAG::ActionType::COLUMN;
+    const_node.result_name = filter_node->result_name;
+    const_node.result_type = filter_node->result_type;
+    const_node.column = filter_node->result_type->createColumnConst(0, (*original_const_column)[0]);
+
+    *filter_node = std::move(const_node);
+}
 }
 
 static std::optional<ActionsDAG::ActionsForFilterPushDown> splitFilter(QueryPlan::Node * parent_node, bool step_changes_the_number_of_rows, const Names & available_inputs, size_t child_idx = 0)
@@ -136,10 +155,28 @@ static std::optional<ActionsDAG::ActionsForFilterPushDown> splitFilter(QueryPlan
     const auto & all_inputs = child->getInputHeaders()[child_idx]->getColumnsWithTypeAndName();
     const bool allow_deterministic_functions = !step_changes_the_number_of_rows;
     const bool is_filter_column_const_before = isFilterColumnConst(*filter);
+
+    /// Capture the original constant column value before push-down modifies the expression DAG.
+    ColumnPtr original_filter_const_column;
+    if (is_filter_column_const_before)
+        original_filter_const_column = filter->getOutputHeader()->getByName(filter_column_name).column;
+
     auto result = expression.splitActionsForFilterPushDown(
         filter_column_name, removes_filter, available_inputs, all_inputs, allow_deterministic_functions);
     if (result)
-        materializeFilterColumnIfNeededAfterPushDown(*filter, is_filter_column_const_before, result->is_filter_const_after_push_down);
+    {
+        if (is_filter_column_const_before && !result->is_filter_const_after_push_down)
+        {
+            /// The filter column was const before push-down (e.g., AND short-circuits to constant false)
+            /// but became non-const after extracting the constant parts. Restore constness.
+            constifyFilterColumnAfterPushDown(expression, filter_column_name, original_filter_const_column);
+            result->is_filter_const_after_push_down = true;
+        }
+        else
+        {
+            materializeFilterColumnIfNeededAfterPushDown(*filter, is_filter_column_const_before, result->is_filter_const_after_push_down);
+        }
+    }
     return result;
 }
 
@@ -653,6 +690,12 @@ static size_t tryPushDownOverJoinStep(QueryPlan::Node * parent_node, QueryPlan::
     }
 
     const bool is_filter_column_const_before = isFilterColumnConst(*filter);
+
+    /// Capture the original constant column value before push-down modifies the expression DAG.
+    ColumnPtr original_filter_const_column;
+    if (is_filter_column_const_before)
+        original_filter_const_column = filter->getOutputHeader()->getByName(filter->getFilterColumnName()).column;
+
     auto join_filter_push_down_actions = filter->getExpression().splitActionsForJOINFilterPushDown(
         filter->getFilterColumnName(),
         filter->removesFilterColumn(),
@@ -664,8 +707,16 @@ static size_t tryPushDownOverJoinStep(QueryPlan::Node * parent_node, QueryPlan::
         equivalent_left_stream_column_to_right_stream_column,
         equivalent_right_stream_column_to_left_stream_column);
 
-    materializeFilterColumnIfNeededAfterPushDown(
-        *filter, is_filter_column_const_before, join_filter_push_down_actions.is_filter_const_after_all_push_downs);
+    if (is_filter_column_const_before && !join_filter_push_down_actions.is_filter_const_after_all_push_downs)
+    {
+        constifyFilterColumnAfterPushDown(filter->getExpression(), filter->getFilterColumnName(), original_filter_const_column);
+        join_filter_push_down_actions.is_filter_const_after_all_push_downs = true;
+    }
+    else
+    {
+        materializeFilterColumnIfNeededAfterPushDown(
+            *filter, is_filter_column_const_before, join_filter_push_down_actions.is_filter_const_after_all_push_downs);
+    }
 
     size_t updated_steps = 0;
 

--- a/tests/queries/0_stateless/04032_filter_push_down_const_having.sql
+++ b/tests/queries/0_stateless/04032_filter_push_down_const_having.sql
@@ -1,0 +1,31 @@
+-- Regression test: filter push-down through aggregation must preserve filter column constness.
+-- When an AND expression short-circuits to a constant (e.g., and(LowCardinality(0), 1, aggregate))
+-- and parts of it are pushed below aggregation, the remaining expression above must keep the
+-- same constness to avoid "Block structure mismatch" or "non constant in source but must be constant" errors.
+
+DROP TABLE IF EXISTS t_const_having;
+CREATE TABLE t_const_having (c0 Int32) ENGINE = MergeTree ORDER BY c0;
+INSERT INTO t_const_having VALUES (1), (2), (3);
+
+-- Minimal reproduction: toLowCardinality constant makes AND short-circuit to Const(0),
+-- but after push-down the remaining expression was non-const, causing header mismatch.
+SELECT
+    -c0 AS g,
+    toLowCardinality(toUInt8(0)) AND 1 AND MAX(c0) AS h
+FROM t_const_having
+GROUP BY GROUPING SETS ((g))
+HAVING h;
+
+-- Original fuzzer query (simplified)
+SELECT
+    -c0 AS g,
+    greater(isNull(6), toUInt16(toLowCardinality(toUInt256(6))))
+        AND 1
+        AND sqrt(MAX(c0) OR MAX(c0)) AS h,
+    h IS NULL
+FROM t_const_having
+GROUP BY GROUPING SETS ((g))
+HAVING h
+ORDER BY g DESC;
+
+DROP TABLE t_const_having;


### PR DESCRIPTION
## Summary

- When an AND expression short-circuits to a constant (e.g., `and(toLowCardinality(0), 1, MAX(c0))` evaluates to `Const(0)`), and parts of it are pushed below aggregation, `removeUnusedConjunctions` replaces the predicate with an `ALIAS` of the remaining expression which is non-const. Parent steps that cached the original (const) output header then see a non-const column, causing "Block structure mismatch" or "non constant in source stream but must be constant" errors.
- Added `constifyFilterColumnAfterPushDown` that restores the original constant value when the filter column was const before push-down but became non-const after. Applied in both the regular `splitFilter` path and the JOIN filter push-down path.
- Found by AST fuzzer: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=98964&sha=54b6d00ff502fc981c69219e83b6c4fc12aa31c9&name_0=PR&name_1=AST%20fuzzer%20%28amd_tsan%29
https://github.com/ClickHouse/ClickHouse/pull/98964

## Test plan

- [x] Added regression test `04032_filter_push_down_const_having` with minimal reproduction and original fuzzer query
- [ ] CI: AST fuzzer passes
- [ ] CI: Stateless tests pass

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Fix "Block structure mismatch" exception when filter push-down optimization encounters an AND expression that short-circuits to a constant with `GROUPING SETS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches query-plan filter push-down logic in `filterPushDown.cpp`, which can affect query correctness/headers for aggregation and JOIN plans if mis-handled. Change is localized and guarded, plus covered by a new regression test.
> 
> **Overview**
> Fixes a bug where filter push-down could change a previously-constant filter predicate into a non-const column (notably after `AND` short-circuiting and partial push-down past aggregation/JOIN), leading to header mismatches and runtime exceptions.
> 
> Adds `constifyFilterColumnAfterPushDown` to restore the original constant predicate value when push-down extraction leaves a non-const remainder, and applies this in both the general `splitFilter` path and JOIN filter push-down. Includes a new stateless regression test `04032_filter_push_down_const_having` reproducing the failing `GROUPING SETS ... HAVING` case.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ffb5ff625a8f53dd298b52945e4c9f2380802467. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.666`
<!-- ch-version-info:end -->