### PR TITLE
compareTrackAt() - devirtualization for IColumn::compareAt() for merge sorted

### DIFF
--- a/src/Columns/ColumnVector.h
+++ b/src/Columns/ColumnVector.h
@@ -160,12 +160,12 @@ public:
 
         if (res < 0)
         {
-            while (n < size() && (compareAt(++n, m, rhs, nan_direction_hint) < 0))
+            while ((++n) < size() && (compareAt(n, m, rhs, nan_direction_hint) < 0))
                 --res;
         }
         else if (res > 0)
         {
-            while (m < assert_cast<const Self &>(rhs).size() && (compareAt(n, ++m, rhs, nan_direction_hint) > 0))
+            while ((++m) < assert_cast<const Self &>(rhs).size() && (compareAt(n, m, rhs, nan_direction_hint) > 0))
                 ++res;
         }
         return res;

--- a/src/Columns/ColumnVector.h
+++ b/src/Columns/ColumnVector.h
@@ -51,7 +51,7 @@ private:
 public:
     bool isNumeric() const override { return is_arithmetic_v<T>; }
 
-    size_t size() const override
+    size_t size() const override final
     {
         return data.size();
     }
@@ -146,12 +146,29 @@ public:
 
     /// This method implemented in header because it could be possibly devirtualized.
 #if !defined(DEBUG_OR_SANITIZER_BUILD)
-    int compareAt(size_t n, size_t m, const IColumn & rhs_, int nan_direction_hint) const override
+    int compareAt(size_t n, size_t m, const IColumn & rhs_, int nan_direction_hint) const override final
 #else
     int doCompareAt(size_t n, size_t m, const IColumn & rhs_, int nan_direction_hint) const override
 #endif
     {
         return CompareHelper<T>::compare(data[n], assert_cast<const Self &>(rhs_).data[m], nan_direction_hint);
+    }
+
+    [[nodiscard]] Int64 compareTrackAt(size_t n, size_t m, const IColumn & rhs, int nan_direction_hint) const override final
+    {
+        Int64 res = compareAt(n, m, rhs, nan_direction_hint);
+
+        if (res < 0)
+        {
+            while (n < size() && (compareAt(++n, m, rhs, nan_direction_hint) < 0))
+                --res;
+        }
+        else if (res > 0)
+        {
+            while (m < assert_cast<const Self &>(rhs).size() && (compareAt(n, ++m, rhs, nan_direction_hint) > 0))
+                ++res;
+        }
+        return res;
     }
 
 #if USE_EMBEDDED_COMPILER

--- a/src/Columns/ColumnVector.h
+++ b/src/Columns/ColumnVector.h
@@ -156,19 +156,33 @@ public:
 
     [[nodiscard]] Int64 compareTrackAt(size_t n, size_t m, const IColumn & rhs, int nan_direction_hint) const final
     {
+#if defined(DEBUG_OR_SANITIZER_BUILD)
+    #define compareAt doCompareAt
+#endif
         Int64 res = compareAt(n, m, rhs, nan_direction_hint);
 
         if (res < 0)
         {
-            while ((++n) < size() && (compareAt(n, m, rhs, nan_direction_hint) < 0))
+            ++n;
+            while (n < size() && (compareAt(n, m, rhs, nan_direction_hint) < 0))
+            {
                 --res;
+                ++n;
+            }
         }
         else if (res > 0)
         {
-            while ((++m) < assert_cast<const Self &>(rhs).size() && (compareAt(n, m, rhs, nan_direction_hint) > 0))
+            ++m;
+            while (m < assert_cast<const Self &>(rhs).size() && (compareAt(n, m, rhs, nan_direction_hint) > 0))
+            {
                 ++res;
+                ++m;
+            }
         }
         return res;
+#if defined(DEBUG_OR_SANITIZER_BUILD)
+    #undef compareAt
+#endif
     }
 
 #if USE_EMBEDDED_COMPILER

--- a/src/Columns/ColumnVector.h
+++ b/src/Columns/ColumnVector.h
@@ -51,7 +51,7 @@ private:
 public:
     bool isNumeric() const override { return is_arithmetic_v<T>; }
 
-    size_t size() const override final
+    size_t size() const final
     {
         return data.size();
     }
@@ -146,7 +146,7 @@ public:
 
     /// This method implemented in header because it could be possibly devirtualized.
 #if !defined(DEBUG_OR_SANITIZER_BUILD)
-    int compareAt(size_t n, size_t m, const IColumn & rhs_, int nan_direction_hint) const override final
+    int compareAt(size_t n, size_t m, const IColumn & rhs_, int nan_direction_hint) const final
 #else
     int doCompareAt(size_t n, size_t m, const IColumn & rhs_, int nan_direction_hint) const override
 #endif
@@ -154,7 +154,7 @@ public:
         return CompareHelper<T>::compare(data[n], assert_cast<const Self &>(rhs_).data[m], nan_direction_hint);
     }
 
-    [[nodiscard]] Int64 compareTrackAt(size_t n, size_t m, const IColumn & rhs, int nan_direction_hint) const override final
+    [[nodiscard]] Int64 compareTrackAt(size_t n, size_t m, const IColumn & rhs, int nan_direction_hint) const final
     {
         Int64 res = compareAt(n, m, rhs, nan_direction_hint);
 

--- a/src/Columns/IColumn.cpp
+++ b/src/Columns/IColumn.cpp
@@ -237,12 +237,12 @@ Int64 IColumn::compareTrackAt(size_t n, size_t m, const IColumn & rhs, int nan_d
 
     if (res < 0)
     {
-        while (n < size() && (compareAt(++n, m, rhs, nan_direction_hint) < 0))
+        while ((++n) < size() && (compareAt(n, m, rhs, nan_direction_hint) < 0))
             --res;
     }
     else if (res > 0)
     {
-        while (m < rhs.size() && (compareAt(n, ++m, rhs, nan_direction_hint) > 0))
+        while ((++m) < rhs.size() && (compareAt(n, m, rhs, nan_direction_hint) > 0))
             ++res;
     }
     return res;

--- a/src/Columns/IColumn.cpp
+++ b/src/Columns/IColumn.cpp
@@ -231,6 +231,23 @@ void IColumn::updateAt(const IColumn &, size_t, size_t)
     throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method updateAt is not supported for {}", getName());
 }
 
+Int64 IColumn::compareTrackAt(size_t n, size_t m, const IColumn & rhs, int nan_direction_hint) const
+{
+    Int64 res = compareAt(n, m, rhs, nan_direction_hint);
+
+    if (res < 0)
+    {
+        while (n < size() && (compareAt(++n, m, rhs, nan_direction_hint) < 0))
+            --res;
+    }
+    else if (res > 0)
+    {
+        while (m < rhs.size() && (compareAt(n, ++m, rhs, nan_direction_hint) > 0))
+            ++res;
+    }
+    return res;
+}
+
 #if USE_EMBEDDED_COMPILER
 llvm::Value * IColumn::compileComparator(
     llvm::IRBuilderBase & /*builder*/, llvm::Value * /*lhs*/, llvm::Value * /*rhs*/, llvm::Value * /*nan_direction_hint*/) const

--- a/src/Columns/IColumn.cpp
+++ b/src/Columns/IColumn.cpp
@@ -233,19 +233,33 @@ void IColumn::updateAt(const IColumn &, size_t, size_t)
 
 Int64 IColumn::compareTrackAt(size_t n, size_t m, const IColumn & rhs, int nan_direction_hint) const
 {
+#if defined(DEBUG_OR_SANITIZER_BUILD)
+    #define compareAt doCompareAt
+#endif
     Int64 res = compareAt(n, m, rhs, nan_direction_hint);
 
     if (res < 0)
     {
-        while ((++n) < size() && (compareAt(n, m, rhs, nan_direction_hint) < 0))
+        ++n;
+        while (n < size() && (compareAt(n, m, rhs, nan_direction_hint) < 0))
+        {
             --res;
+            ++n;
+        }
     }
     else if (res > 0)
     {
-        while ((++m) < rhs.size() && (compareAt(n, m, rhs, nan_direction_hint) > 0))
+        ++m;
+        while (m < rhs.size() && (compareAt(n, m, rhs, nan_direction_hint) > 0))
+        {
             ++res;
+            ++m;
+        }
     }
     return res;
+#if defined(DEBUG_OR_SANITIZER_BUILD)
+    #undef compareAt
+#endif
 }
 
 #if USE_EMBEDDED_COMPILER

--- a/src/Columns/IColumn.h
+++ b/src/Columns/IColumn.h
@@ -434,6 +434,15 @@ public:
     }
 #endif
 
+    /** Compares and returns inequal track. It extends compareAt() to return how many values are not equal.
+      * Returns -N if current N left values are less then the right comparing value.
+      * Returns N if current N right values are less then the left comparing value.
+      * Returns 0 if current left and right values are equal.
+      *
+      * The main reason for the function is compareAt() devirtualization.
+      */
+    [[nodiscard]] virtual Int64 compareTrackAt(size_t n, size_t m, const IColumn & rhs, int nan_direction_hint) const;
+
 #if USE_EMBEDDED_COMPILER
 
     [[nodiscard]] virtual bool isComparatorCompilable() const { return false; }

--- a/src/Interpreters/MergeJoin.cpp
+++ b/src/Interpreters/MergeJoin.cpp
@@ -78,8 +78,8 @@ ColumnWithTypeAndName condtitionColumnToJoinable(const Block & block, const Stri
     return {res_col, res_col_type, res_name};
 }
 
-template <bool has_left_nulls, bool has_right_nulls>
-int nullableCompareAt(const IColumn & left_column, const IColumn & right_column, size_t lhs_pos, size_t rhs_pos)
+template <bool has_left_nulls, bool has_right_nulls, bool track = false>
+Int64 nullableCompareAt(const IColumn & left_column, const IColumn & right_column, size_t lhs_pos, size_t rhs_pos)
 {
     static constexpr int null_direction_hint = 1;
 
@@ -122,7 +122,10 @@ int nullableCompareAt(const IColumn & left_column, const IColumn & right_column,
         }
     }
 
-    return left_column.compareAt(lhs_pos, rhs_pos, right_column, null_direction_hint);
+    if constexpr (track)
+        return left_column.compareTrackAt(lhs_pos, rhs_pos, right_column, null_direction_hint);
+    else
+        return left_column.compareAt(lhs_pos, rhs_pos, right_column, null_direction_hint);
 }
 
 /// Get first and last row from sorted block
@@ -285,8 +288,8 @@ public:
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected block size");
 
         size_t last_position = end() - 1;
-        int first_vs_max = 0;
-        int last_vs_min = 0;
+        Int64 first_vs_max = 0;
+        Int64 last_vs_min = 0;
 
         for (size_t i = 0; i < impl.sort_columns_size; ++i)
         {
@@ -321,39 +324,34 @@ private:
 
         while (true)
         {
-            int cmp = compareAtCursor<left_nulls, right_nulls>(rhs);
+            Int64 cmp = nullableCompareAt<left_nulls, right_nulls, true>(
+                *impl.sort_columns[0], *rhs.impl.sort_columns[0], position(), rhs.position());
+
+            for (size_t i = 1; (!cmp) && i < impl.sort_columns_size; ++i)
+            {
+                const auto * left_column = impl.sort_columns[i];
+                const auto * right_column = rhs.impl.sort_columns[i];
+
+                cmp = nullableCompareAt<left_nulls, right_nulls>(*left_column, *right_column, position(), rhs.position());
+            }
+
             if (cmp < 0)
             {
-                next();
+                nextN(-cmp);
                 if (atEnd())
                     break;
             }
             else if (cmp > 0)
             {
-                rhs.next();
+                rhs.nextN(cmp);
                 if (rhs.atEnd())
                     break;
             }
-            else if (!cmp)
+            else
                 return MergeJoinEqualRange{position(), rhs.position(), getEqualLength(), rhs.getEqualLength()};
         }
 
         return MergeJoinEqualRange{position(), rhs.position(), 0, 0};
-    }
-
-    template <bool left_nulls, bool right_nulls>
-    int ALWAYS_INLINE compareAtCursor(const MergeJoinCursor & rhs) const
-    {
-        int res = nullableCompareAt<left_nulls, right_nulls>(*impl.sort_columns[0], *rhs.impl.sort_columns[0], position(), rhs.position());
-
-        for (size_t i = 1; (!res) && i < impl.sort_columns_size; ++i)
-        {
-            const auto * left_column = impl.sort_columns[i];
-            const auto * right_column = rhs.impl.sort_columns[i];
-
-            res = nullableCompareAt<left_nulls, right_nulls>(*left_column, *right_column, position(), rhs.position());
-        }
-        return res;
     }
 
     /// Expects !atEnd()


### PR DESCRIPTION
`IColumn::compareAt()` is too slow when colled as virtual function in cycle. PR makes a tracked version of it. IColumn::compareTrackAt() return {-N, 0, N} instead of {-1, 0, 1}. It passes a cycle inside virtual call. Then it's possible for compiler to devirtualize `compareAt()` inside the function.

### Changelog category (leave one):
- Performance improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
add IColumn::compareTrackAt() for sorted merges



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core `IColumn` comparison API and changes `MergeJoin` cursor advancement logic to skip multiple rows at once, so subtle ordering/null/NaN edge cases could affect join correctness even though behavior is intended to be equivalent.
> 
> **Overview**
> Adds a new virtual `IColumn::compareTrackAt()` API that extends `compareAt()` to return a signed *run length* (e.g., `-N/0/+N`) so callers can advance over multiple strictly-less/greater rows in one call, enabling better devirtualization and fewer virtual calls.
> 
> Updates `MergeJoin`’s sorted-range matching to use `compareTrackAt()` on the first sort key and advance cursors via `nextN()` based on the returned magnitude, while keeping remaining key comparisons unchanged; also adjusts helper comparison code to return `Int64` and removes the old per-step cursor compare helper. `ColumnVector` marks `size()`/`compareAt()` as `final` and provides a `final` override of `compareTrackAt()` for the devirtualization path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5c39947af074ba04868fa5876184cb1db448e75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.685`
<!-- ch-version-info:end -->