### PR TITLE
Bug: String query parameters containing tab or newline fail via native TCP protocol

### DIFF
--- a/tests/queries/0_stateless/04029_query_param_string_special_chars.reference
+++ b/tests/queries/0_stateless/04029_query_param_string_special_chars.reference
@@ -1,0 +1,7 @@
+hello world
+11
+isn't parsed completely
+isn't parsed completely
+hello	world
+hello
+world

--- a/tests/queries/0_stateless/04029_query_param_string_special_chars.sh
+++ b/tests/queries/0_stateless/04029_query_param_string_special_chars.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Bug: named String query parameters containing tab (0x09) or newline (0x0a) bytes
+# fail via the native TCP protocol with "isn't parsed completely".
+#
+# Root cause: Settings::toNameToNameMap() fully decodes Field dump values to raw
+# bytes via readQuoted, but visitQueryParameter then calls deserializeTextEscaped
+# which treats raw tab/newline as TSV field delimiters, stopping the parse early.
+#
+# Workaround: double-escape the character (e.g. pass \\t instead of a literal tab).
+# The extra backslash survives the Field dump round-trip as a single backslash,
+# giving deserializeTextEscaped the two-char \t sequence it expects.
+#
+# The same bug exists for the HTTP interface when using %09 or %0A URL-encoding.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# Baseline: a String parameter with no special characters works fine.
+$CLICKHOUSE_CLIENT --param_s='hello world' -q "SELECT {s:String}"
+
+# Workaround: \\t (double-escaped backslash+t in bash $'...' syntax = literal \t on
+# the wire). The server decodes \\ -> \, leaving \t in query_parameters, which
+# deserializeTextEscaped then correctly converts to a tab. Length of the result
+# is 11: len("hello") + 1 (tab) + len("world").
+$CLICKHOUSE_CLIENT --param_s=$'hello\\tworld' -q "SELECT length({s:String})"
+
+# Bug: literal tab (0x09) -- fails because raw 0x09 stops deserializeTextEscaped.
+$CLICKHOUSE_CLIENT --param_s=$'hello\tworld' -q "SELECT {s:String}" 2>&1 | grep -om 1 "isn't parsed completely"
+
+# Bug: literal newline (0x0a) -- same root cause, same failure.
+$CLICKHOUSE_CLIENT --param_s=$'hello\nworld' -q "SELECT {s:String}" 2>&1 | grep -om 1 "isn't parsed completely"
+
+# The following two cases should pass once the bug is fixed.
+# A literal tab passed as a String parameter should round-trip and be returned as-is.
+$CLICKHOUSE_CLIENT --param_s=$'hello\tworld' -q "SELECT {s:String}"
+# A literal newline passed as a String parameter should round-trip and be returned as-is.
+$CLICKHOUSE_CLIENT --param_s=$'hello\nworld' -q "SELECT {s:String}"


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry:
Named `String` query parameters containing literal tab (0x09) or newline (0x0a) bytes fail with `BAD_QUERY_PARAMETER` ("isn't parsed completely") when sent via the native TCP protocol.

---

## Bug description

When a `String` named query parameter contains a literal tab or newline character, the server throws:

```
Value hello	world cannot be parsed as String for query parameter 'param_x'
because it isn't parsed completely: only 5 of 11 bytes was parsed: hello
```

### Root cause

There is a format mismatch across three layers in the native TCP parameter path:

1. **`Settings::toNameToNameMap()`** (`src/Core/Settings.cpp:8217`) decodes the `Field` dump format to raw bytes via `readQuoted` — so a tab stored as `\t` in the dump becomes a literal 0x09 byte in `query_parameters`.

2. **`ReplaceQueryParameterVisitor::visitQueryParameter()`** (`src/Interpreters/ReplaceQueryParameterVisitor.cpp:143`) then passes this raw value to `deserializeTextEscaped`.

3. **`deserializeTextEscaped`** → `readEscapedStringIntoImpl` (`src/IO/ReadHelpers.cpp:659`) treats raw 0x09 (tab) and 0x0a (newline) as TSV field delimiters, stopping the parse early. The remaining bytes cause the `!read_buffer.eof()` check at line 151 to throw.

The same bug exists for the HTTP interface when the parameter value is URL-encoded as `%09` or `%0A`.

### Workaround

Double-escape the character on the client side — pass `\\t` (backslash + t) instead of a literal tab. The extra backslash survives the `Field` dump round-trip as a single backslash, giving `deserializeTextEscaped` the two-char `\t` sequence it expects.

### Proposed fix area

`Settings::toNameToNameMap()` should re-encode the decoded raw value in TSV-escaped format before storing in `query_parameters`, so that `deserializeTextEscaped` receives the format it expects.

## Test

`tests/queries/0_stateless/04029_query_param_string_special_chars.sh`

The test includes:
- A baseline (simple string, works)
- The `\\t` workaround (works)
- Two cases demonstrating the bug (tab and newline, currently fail with the error above)
- Two cases showing the **expected behaviour after the fix** (currently failing — these should pass once the server-side bug is fixed)