### PR TITLE
Add DWARF debug info support on macOS via dSYM bundles

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -381,6 +381,7 @@ if ("${CMAKE_BUILD_TYPE_UC}" STREQUAL "DEBUG")
     set_source_files_properties(
             Common/Elf.cpp
             Common/Dwarf.cpp
+            Common/MachO.cpp
             Common/SymbolIndex.cpp
             Common/ThreadFuzzer.cpp
             PROPERTIES COMPILE_FLAGS "-O2 ${WITHOUT_COVERAGE_FLAGS}")

--- a/src/Common/Dwarf.cpp
+++ b/src/Common/Dwarf.cpp
@@ -1,4 +1,4 @@
-#if defined(__ELF__) && !defined(OS_FREEBSD)
+#if (defined(__ELF__) && !defined(OS_FREEBSD)) || defined(OS_DARWIN)
 
 /*
  * Copyright 2012-present Facebook, Inc.
@@ -24,6 +24,10 @@
 #include <Common/Elf.h>
 #include <Common/Dwarf.h>
 #include <Common/Exception.h>
+
+#if defined(OS_DARWIN)
+#include <Common/MachO.h>
+#endif
 
 #define DW_CHILDREN_no 0
 
@@ -166,6 +170,29 @@ Dwarf::Dwarf(const std::shared_ptr<Elf> & elf)
         elf_ = nullptr;
     }
 }
+
+#if defined(OS_DARWIN)
+Dwarf::Dwarf(const std::shared_ptr<MachO> & macho)
+    : elf_(nullptr)
+    , macho_(macho)
+    , abbrev_(getSection(".debug_abbrev"))
+    , addr_(getSection(".debug_addr"))
+    , aranges_(getSection(".debug_aranges"))
+    , info_(getSection(".debug_info"))
+    , line_(getSection(".debug_line"))
+    , line_str_(getSection(".debug_line_str"))
+    , loclists_(getSection(".debug_loclists"))
+    , ranges_(getSection(".debug_ranges"))
+    , rnglists_(getSection(".debug_rnglists"))
+    , str_(getSection(".debug_str"))
+    , str_offsets_(getSection(".debug_str_offsets"))
+{
+    if (info_.empty() || abbrev_.empty() || line_.empty() || str_.empty())
+    {
+        macho_ = nullptr;
+    }
+}
+#endif
 
 Dwarf::Section::Section(std::string_view d) : is64_bit(false), data(d)
 {
@@ -449,6 +476,19 @@ bool Dwarf::Section::next(std::string_view & chunk)
 
 std::string_view Dwarf::getSection(const char * name) const
 {
+#if defined(OS_DARWIN)
+    if (macho_)
+    {
+        auto section = macho_->findSectionByName(name);
+        if (!section)
+            return {};
+        return {section->begin(), section->size()};
+    }
+#endif
+
+    if (!elf_)
+        return {};
+
     std::optional<Elf::Section> elf_section = elf_->findSectionByName(name);
     if (!elf_section)
         return {};
@@ -1460,10 +1500,14 @@ bool Dwarf::findAddress(
         return false;
     }
 
-    if (!elf_)
-    { // No file.
+    bool has_debug_info = elf_
+#if defined(OS_DARWIN)
+        || macho_
+#endif
+        ;
+
+    if (!has_debug_info)
         return false;
-    }
 
     if (!aranges_.empty())
     {

--- a/src/Common/Dwarf.h
+++ b/src/Common/Dwarf.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(__ELF__) && !defined(OS_FREEBSD)
+#if (defined(__ELF__) && !defined(OS_FREEBSD)) || defined(OS_DARWIN)
 
 /*
  * Copyright 2012-present Facebook, Inc.
@@ -35,6 +35,9 @@ namespace DB
 {
 
 class Elf;
+#if defined(OS_DARWIN)
+class MachO;
+#endif
 
 /**
  * DWARF record parser.
@@ -67,6 +70,11 @@ class Dwarf final
 public:
     /** Create a DWARF parser around an ELF file. */
     explicit Dwarf(const std::shared_ptr<Elf> & elf);
+
+#if defined(OS_DARWIN)
+    /** Create a DWARF parser around a Mach-O file (typically from a dSYM bundle). */
+    explicit Dwarf(const std::shared_ptr<MachO> & macho);
+#endif
 
     /**
      * More than one location info may exist if current frame is an inline
@@ -174,6 +182,9 @@ private:
     static bool findDebugInfoOffset(uintptr_t address, std::string_view aranges, uint64_t & offset);
 
     std::shared_ptr<const Elf> elf_; /// NOLINT
+#if defined(OS_DARWIN)
+    std::shared_ptr<const MachO> macho_; /// NOLINT
+#endif
 
     // DWARF section made up of chunks, each prefixed with a length header.
     // The length indicates whether the chunk is DWARF-32 or DWARF-64, which

--- a/src/Common/MachO.cpp
+++ b/src/Common/MachO.cpp
@@ -1,0 +1,109 @@
+#if defined(OS_DARWIN)
+
+#include <Common/MachO.h>
+#include <Common/Exception.h>
+
+#include <mach-o/loader.h>
+#include <cstring>
+
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int CANNOT_PARSE_ELF;
+}
+
+
+MachO::MachO(const std::string & path_)
+    : path(path_)
+    , in(path_, 0)
+    , file_size(in.buffer().size())
+    , mapped(in.buffer().begin())
+{
+    init();
+}
+
+
+void MachO::init()
+{
+    if (file_size < sizeof(mach_header_64))
+        throw Exception(ErrorCodes::CANNOT_PARSE_ELF,
+            "The size of Mach-O file '{}' is too small", path);
+
+    const auto * header = reinterpret_cast<const mach_header_64 *>(mapped);
+
+    if (header->magic != MH_MAGIC_64)
+        throw Exception(ErrorCodes::CANNOT_PARSE_ELF,
+            "The file '{}' is not a 64-bit Mach-O file", path);
+
+    const char * cmd_ptr = mapped + sizeof(mach_header_64);
+    for (uint32_t i = 0; i < header->ncmds; ++i)
+    {
+        if (cmd_ptr + sizeof(load_command) > mapped + file_size)
+            break;
+
+        const auto * cmd = reinterpret_cast<const load_command *>(cmd_ptr);
+
+        if (cmd->cmd == LC_SEGMENT_64)
+        {
+            const auto * seg = reinterpret_cast<const segment_command_64 *>(cmd_ptr);
+
+            if (strncmp(seg->segname, "__DWARF", 16) == 0)
+            {
+                const auto * sect = reinterpret_cast<const section_64 *>(
+                    cmd_ptr + sizeof(segment_command_64));
+
+                for (uint32_t j = 0; j < seg->nsects; ++j)
+                {
+                    if (sect[j].offset + sect[j].size > file_size)
+                        continue;
+
+                    SectionInfo info;
+                    /// sectname is a fixed 16-byte field, not necessarily null-terminated.
+                    info.name = std::string(sect[j].sectname, strnlen(sect[j].sectname, 16));
+                    info.data = mapped + sect[j].offset;
+                    info.size = sect[j].size;
+                    dwarf_sections.push_back(std::move(info));
+                }
+            }
+        }
+
+        cmd_ptr += cmd->cmdsize;
+    }
+}
+
+
+std::optional<MachO::Section> MachO::findSectionByName(const char * name) const
+{
+    /// Map ELF-style section names to Mach-O names:
+    /// ".debug_info" -> "__debug_info"
+    std::string macho_name;
+    if (name[0] == '.')
+    {
+        macho_name = "__";
+        macho_name += (name + 1);
+    }
+    else
+    {
+        macho_name = name;
+    }
+
+    /// Mach-O section names are limited to 16 characters.
+    /// Truncate for matching.
+    if (macho_name.size() > 16)
+        macho_name.resize(16);
+
+    for (const auto & section : dwarf_sections)
+    {
+        if (section.name == macho_name)
+            return Section{section.data, section.size};
+    }
+
+    return std::nullopt;
+}
+
+}
+
+#endif

--- a/src/Common/MachO.h
+++ b/src/Common/MachO.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#if defined(OS_DARWIN)
+
+#include <IO/MMapReadBufferFromFile.h>
+
+#include <string>
+#include <optional>
+#include <vector>
+
+
+namespace DB
+{
+
+/** Parse a Mach-O binary file to extract DWARF debug info sections.
+  * Used to read dSYM bundles on macOS.
+  */
+class MachO final
+{
+public:
+    struct Section
+    {
+        const char * data;
+        size_t length;
+
+        const char * begin() const { return data; }
+        const char * end() const { return data + length; }
+        size_t size() const { return length; }
+    };
+
+    explicit MachO(const std::string & path);
+
+    /// Find a section by its ELF-style name (e.g. ".debug_info").
+    /// Maps to Mach-O section names (e.g. "__debug_info" in "__DWARF" segment).
+    std::optional<Section> findSectionByName(const char * name) const;
+
+    const char * begin() const { return mapped; }
+    size_t size() const { return file_size; }
+    const std::string & getPath() const { return path; }
+
+private:
+    std::string path;
+    MMapReadBufferFromFile in;
+    size_t file_size;
+    const char * mapped;
+
+    struct SectionInfo
+    {
+        std::string name; /// Mach-O section name like "__debug_info"
+        const char * data;
+        size_t size;
+    };
+    std::vector<SectionInfo> dwarf_sections;
+
+    void init();
+};
+
+}
+
+#endif

--- a/src/Common/StackTrace.cpp
+++ b/src/Common/StackTrace.cpp
@@ -397,24 +397,59 @@ void StackTrace::forEachFrame(
         callback(current_frame);
     }
 #elif defined(OS_DARWIN)
-    UNUSED(fatal);
-
     const DB::SymbolIndex & symbol_index = DB::SymbolIndex::instance();
+    std::unordered_map<std::string, DB::Dwarf> dwarfs;
+
+    using enum DB::Dwarf::LocationInfoMode;
+    const auto mode = fatal ? FULL_WITH_INLINE : FAST;
 
     for (size_t i = offset; i < size; ++i)
     {
         StackTrace::Frame current_frame;
+        std::vector<DB::Dwarf::SymbolizedFrame> inline_frames;
         current_frame.virtual_addr = frame_pointers[i];
-        /// On macOS, SymbolIndex stores absolute virtual addresses,
-        /// so physical_addr is the same as virtual_addr for symbol lookup.
         current_frame.physical_addr = frame_pointers[i];
 
         const auto * object = symbol_index.findObject(current_frame.virtual_addr);
         if (object)
+        {
             current_frame.object = object->name;
+
+            /// If this object has a dSYM, use it for file/line resolution.
+            if (object->dsym)
+            {
+                auto dwarf_it = dwarfs.try_emplace(object->name, object->dsym).first;
+
+                DB::Dwarf::LocationInfo location;
+                /// Convert runtime address to linked (pre-ASLR) address for DWARF lookup.
+                uintptr_t dwarf_addr = uintptr_t(current_frame.virtual_addr) - object->slide;
+                if (i > 0)
+                    dwarf_addr -= 1;
+
+                if (dwarf_it->second.findAddress(dwarf_addr, location, mode, inline_frames))
+                {
+                    current_frame.file = location.file.toString();
+                    current_frame.line = location.line;
+                    current_frame.column = location.column;
+                }
+            }
+        }
 
         if (const auto * symbol = symbol_index.findSymbol(current_frame.virtual_addr))
             current_frame.symbol = demangle(symbol->name);
+
+        for (const auto & frame : inline_frames)
+        {
+            StackTrace::Frame current_inline_frame;
+            const String file_for_inline_frame = frame.location.file.toString();
+
+            current_inline_frame.file = "inlined from " + file_for_inline_frame;
+            current_inline_frame.line = frame.location.line;
+            current_inline_frame.column = frame.location.column;
+            current_inline_frame.symbol = demangle(frame.name);
+
+            callback(current_inline_frame);
+        }
 
         callback(current_frame);
     }

--- a/src/Common/SymbolIndex.cpp
+++ b/src/Common/SymbolIndex.cpp
@@ -633,6 +633,28 @@ void collectSymbolsFromMachOImage(
         object.address_end = reinterpret_cast<const void *>(max_addr);
         object.name = image_name ? image_name : "";
         /// object.elf is null on macOS (no ELF binary)
+        object.slide = static_cast<uintptr_t>(slide);
+
+        /// Look for a dSYM bundle next to the binary.
+        /// Convention: <binary>.dSYM/Contents/Resources/DWARF/<basename>
+        if (!object.name.empty())
+        {
+            try
+            {
+                std::filesystem::path binary_path(object.name);
+                std::string basename = binary_path.filename().string();
+                std::filesystem::path dsym_path = std::filesystem::path(object.name + ".dSYM")
+                    / "Contents" / "Resources" / "DWARF" / basename;
+
+                if (std::filesystem::exists(dsym_path))
+                    object.dsym = std::make_shared<MachO>(dsym_path.string());
+            }
+            catch (...)
+            {
+                /// Ignore errors when looking for dSYM
+            }
+        }
+
         objects.push_back(std::move(object));
     }
 }

--- a/src/Common/SymbolIndex.h
+++ b/src/Common/SymbolIndex.h
@@ -5,6 +5,10 @@
 #include <Common/Elf.h>
 #include <boost/noncopyable.hpp>
 
+#if defined(OS_DARWIN)
+#include <Common/MachO.h>
+#endif
+
 
 namespace DB
 {
@@ -36,6 +40,12 @@ public:
         const void * address_end;
         std::string name;
         std::shared_ptr<Elf> elf;
+#if defined(OS_DARWIN)
+        /// ASLR slide for this image. Subtract from runtime address to get linked (DWARF) address.
+        uintptr_t slide = 0;
+        /// Parsed dSYM bundle, if found next to the binary.
+        std::shared_ptr<MachO> dsym;
+#endif
     };
 
     const Symbol * findSymbol(const void * address) const;

--- a/src/Functions/addressToLine.cpp
+++ b/src/Functions/addressToLine.cpp
@@ -1,4 +1,4 @@
-#if defined(__ELF__) && !defined(OS_FREEBSD)
+#if (defined(__ELF__) && !defined(OS_FREEBSD)) || defined(OS_DARWIN)
 
 #include <Common/Dwarf.h>
 #include <Columns/ColumnString.h>

--- a/src/Functions/addressToLine.h
+++ b/src/Functions/addressToLine.h
@@ -1,5 +1,5 @@
 #pragma once
-#if defined(__ELF__) && !defined(OS_FREEBSD)
+#if (defined(__ELF__) && !defined(OS_FREEBSD)) || defined(OS_DARWIN)
 
 #include <Common/Dwarf.h>
 #include <Common/SymbolIndex.h>
@@ -92,14 +92,23 @@ protected:
 
         if (const auto * object = symbol_index.thisObject())
         {
+#if defined(OS_DARWIN)
+            if (!object->dsym)
+                return {object->name};
+            auto dwarf_it = cache.dwarfs.try_emplace(object->name, object->dsym).first;
+            /// Convert runtime address to linked (pre-ASLR) address for DWARF lookup.
+            uintptr_t dwarf_addr = addr - object->slide;
+#else
             auto dwarf_it = cache.dwarfs.try_emplace(object->name, object->elf).first;
             if (!std::filesystem::exists(object->name))
                 return {};
+            uintptr_t dwarf_addr = addr;
+#endif
 
             Dwarf::LocationInfo location;
             std::vector<Dwarf::SymbolizedFrame> frames; // NOTE: not used in FAST mode.
             ResultT result;
-            if (dwarf_it->second.findAddress(addr, location, locationInfoMode, frames))
+            if (dwarf_it->second.findAddress(dwarf_addr, location, locationInfoMode, frames))
             {
                 setResult(result, location, frames);
                 return result;

--- a/src/Functions/addressToLineWithInlines.cpp
+++ b/src/Functions/addressToLineWithInlines.cpp
@@ -1,4 +1,4 @@
-#if defined(__ELF__) && !defined(OS_FREEBSD)
+#if (defined(__ELF__) && !defined(OS_FREEBSD)) || defined(OS_DARWIN)
 
 #include <Common/Dwarf.h>
 #include <Columns/ColumnString.h>


### PR DESCRIPTION
## Summary

- Adds `MachO` class to parse Mach-O files from `.dSYM` bundles, mapping ELF-style DWARF section names (`.debug_info`) to Mach-O names (`__debug_info` in `__DWARF` segment)
- Extends the `Dwarf` class with a `MachO` constructor so it can read DWARF sections from either ELF or Mach-O files
- `SymbolIndex` on macOS now stores ASLR slide per object and auto-discovers `.dSYM` bundles next to binaries
- Enables `addressToLine`, `addressToLineWithInlines` functions and file/line info in stack traces on macOS

Depends on #99014 (`symbolindex-macos`).

## Test plan

- [x] Built and tested on macOS (arm64, RelWithDebInfo)
- [x] Generated dSYM with `dsymutil`, verified `addressToLine` resolves addresses to `file:line:column`
- [x] Verified stack traces in server logs include full source locations (e.g. `./src/Functions/throwIf.cpp:150:27`)
- [x] Verified `addressToLine` and `addressToLineWithInlines` SQL functions work via `system.stack_trace`
- [ ] Verify Linux build is not affected (all changes are guarded by `#if defined(OS_DARWIN)`)

### Changelog category (leave term term applicable)
- Improvement

### Changelog entry
Added DWARF debug info support on macOS: `addressToLine`, `addressToLineWithInlines`, and file/line information in stack traces now work when a `.dSYM` bundle is present next to the binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes macOS symbolization/stack-trace behavior and adds new Mach-O parsing logic (dSYM discovery, ASLR slide adjustment) that could affect crash reporting and introspection on that platform; non-macOS paths are largely guarded by `OS_DARWIN`.
> 
> **Overview**
> Adds macOS DWARF debug-info support by introducing a `MachO` parser that reads DWARF sections from `.dSYM` bundles (mapping ELF-style names like `.debug_info` to Mach-O `__DWARF` sections).
> 
> Extends `Dwarf` to work with either ELF or Mach-O section sources, and updates macOS `SymbolIndex` to record per-image ASLR `slide` and auto-discover/load adjacent dSYM files.
> 
> Updates macOS stack trace rendering and the `addressToLine`/`addressToLineWithInlines` functions to use dSYM-backed DWARF for `file:line:column` (including inline frames), converting runtime addresses to pre-ASLR addresses before lookup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d89f1673d5255a71d0db2d357f87bdfbf27bde55. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->