### PR TITLE
Fix primary key filtering for condition "id = <blank string>"

### DIFF
--- a/src/Functions/EmptyImpl.h
+++ b/src/Functions/EmptyImpl.h
@@ -37,7 +37,7 @@ struct EmptyImpl
 
         if (!left.isNull() && left.getType() == Field::Types::String)
         {
-            const String & left_str = left.get<String>();
+            const String & left_str = left.safeGet<String>();
             if (!left_str.empty())
             {
                 /// All values in [left, right] are non-empty strings.
@@ -46,7 +46,7 @@ struct EmptyImpl
             }
 
             /// left == ''
-            if (!right.isNull() && right.getType() == Field::Types::String && right.get<String>().empty())
+            if (!right.isNull() && right.getType() == Field::Types::String && right.safeGet<String>().empty())
             {
                 /// Range is exactly ['', ''] → empty(s) = 1 everywhere, constant.
                 return {.is_monotonic = true, .is_positive = true};

--- a/src/Functions/EmptyImpl.h
+++ b/src/Functions/EmptyImpl.h
@@ -4,6 +4,9 @@
 #include <Columns/ColumnString.h>
 #include <Columns/ColumnsNumber.h>
 #include <Functions/FunctionFactory.h>
+#include <Functions/IFunction.h>
+#include <DataTypes/IDataType.h>
+#include <Core/Field.h>
 
 
 namespace DB
@@ -20,6 +23,38 @@ struct EmptyImpl
 {
     /// If the function will return constant value for FixedString data type.
     static constexpr auto is_fixed_to_constant = false;
+
+    static constexpr bool has_information_about_monotonicity = true;
+
+    /// For String type, the empty string '' is the minimum value in lexicographic order.
+    /// empty(s) = 1 iff s == ''. The function is constant (and thus monotone) on any
+    /// range that does not include '', i.e. where the left boundary is non-empty, or on
+    /// the degenerate range ['', ''].
+    static IFunction::Monotonicity getMonotonicityForRange(const IDataType & type, const Field & left, const Field & right)
+    {
+        if (!isString(type))
+            return {};
+
+        if (!left.isNull() && left.getType() == Field::Types::String)
+        {
+            const String & left_str = left.get<String>();
+            if (!left_str.empty())
+            {
+                /// All values in [left, right] are non-empty strings.
+                /// empty(s) = 0 everywhere, notEmpty(s) = 1 everywhere → constant.
+                return {.is_monotonic = true, .is_positive = true};
+            }
+
+            /// left == ''
+            if (!right.isNull() && right.getType() == Field::Types::String && right.get<String>().empty())
+            {
+                /// Range is exactly ['', ''] → empty(s) = 1 everywhere, constant.
+                return {.is_monotonic = true, .is_positive = true};
+            }
+        }
+
+        return {};
+    }
 
     static void vector(const ColumnString::Chars & /*data*/, const ColumnString::Offsets & offsets, PaddedPODArray<UInt8> & res, size_t input_rows_count)
     {

--- a/src/Functions/FunctionStringOrArrayToT.h
+++ b/src/Functions/FunctionStringOrArrayToT.h
@@ -68,6 +68,20 @@ public:
 
     bool useDefaultImplementationForConstants() const override { return true; }
 
+    bool hasInformationAboutMonotonicity() const override
+    {
+        if constexpr (requires { Impl::has_information_about_monotonicity; })
+            return Impl::has_information_about_monotonicity;
+        return false;
+    }
+
+    Monotonicity getMonotonicityForRange(const IDataType & type, const Field & left, const Field & right) const override
+    {
+        if constexpr (requires(const IDataType & t, const Field & f) { Impl::getMonotonicityForRange(t, f, f); })
+            return Impl::getMonotonicityForRange(type, left, right);
+        return {};
+    }
+
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const override
     {
         const ColumnPtr column = arguments[0].column;

--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -279,25 +279,19 @@ const KeyCondition::AtomMap KeyCondition::atom_map
         },
         {
             "empty",
-            [] (RPNElement & out, const Field & value)
+            [] (RPNElement & out, const Field &)
             {
-                if (value.getType() != Field::Types::String)
-                    return false;
-
                 out.function = RPNElement::FUNCTION_IN_RANGE;
-                out.range = Range("");
+                out.range = Range(String{});
                 return true;
             }
         },
         {
             "notEmpty",
-            [] (RPNElement & out, const Field & value)
+            [] (RPNElement & out, const Field &)
             {
-                if (value.getType() != Field::Types::String)
-                    return false;
-
                 out.function = RPNElement::FUNCTION_NOT_IN_RANGE;
-                out.range = Range("");
+                out.range = Range(String{});
                 return true;
             }
         },
@@ -2909,6 +2903,10 @@ bool KeyCondition::extractAtomFromTree(const RPNBuilderTreeNode & node, const Bu
 
             if (key_column_num == static_cast<size_t>(-1))
                 throw Exception(ErrorCodes::LOGICAL_ERROR, "`key_column_num` wasn't initialized. It is a bug.");
+
+            /// empty/notEmpty produce a meaningful range only for String key columns.
+            if ((func_name == "empty" || func_name == "notEmpty") && !isString(*key_expr_type))
+                return false;
         }
         else if (num_args == 2)
         {

--- a/tests/queries/0_stateless/04033_empty_string_pk_monotonicity.reference
+++ b/tests/queries/0_stateless/04033_empty_string_pk_monotonicity.reference
@@ -1,0 +1,62 @@
+-- With primary key skipping, searching for '' should read only the first
+-- granule (which contains '') and skip all granules that start with a
+-- non-empty string.  Searching for non-empty strings should skip the
+-- granule that starts with ''.
+
+-- { echo }
+EXPLAIN indexes = 1
+SELECT * FROM t_empty_pk WHERE empty(s);
+Expression ((Project names + Projection))
+  Filter ((WHERE + Change column names to column identifiers))
+    ReadFromMergeTree (default.t_empty_pk)
+    Indexes:
+      PrimaryKey
+        Keys:
+          s
+        Condition: (s in [\'\', \'\'])
+        Parts: 1/1
+        Granules: 1/4
+        Search Algorithm: binary search
+      Ranges: 1
+EXPLAIN indexes = 1
+SELECT * FROM t_empty_pk WHERE s = '';
+Expression ((Project names + Projection))
+  Filter ((WHERE + Change column names to column identifiers))
+    ReadFromMergeTree (default.t_empty_pk)
+    Indexes:
+      PrimaryKey
+        Keys:
+          s
+        Condition: (s in [\'\', \'\'])
+        Parts: 1/1
+        Granules: 1/4
+        Search Algorithm: binary search
+      Ranges: 1
+EXPLAIN indexes = 1
+SELECT * FROM t_empty_pk WHERE notEmpty(s);
+Expression ((Project names + Projection))
+  Filter ((WHERE + Change column names to column identifiers))
+    ReadFromMergeTree (default.t_empty_pk)
+    Indexes:
+      PrimaryKey
+        Keys:
+          s
+        Condition: (s not in [\'\', \'\'])
+        Parts: 1/1
+        Granules: 4/4
+        Search Algorithm: generic exclusion search
+      Ranges: 1
+EXPLAIN indexes = 1
+SELECT * FROM t_empty_pk WHERE s != '';
+Expression ((Project names + Projection))
+  Filter ((WHERE + Change column names to column identifiers))
+    ReadFromMergeTree (default.t_empty_pk)
+    Indexes:
+      PrimaryKey
+        Keys:
+          s
+        Condition: (s not in [\'\', \'\'])
+        Parts: 1/1
+        Granules: 4/4
+        Search Algorithm: generic exclusion search
+      Ranges: 1

--- a/tests/queries/0_stateless/04033_empty_string_pk_monotonicity.sql
+++ b/tests/queries/0_stateless/04033_empty_string_pk_monotonicity.sql
@@ -1,0 +1,37 @@
+-- Tags: no-replicated-database, no-parallel-replicas
+-- no-replicated-database: EXPLAIN output differs for replicated database.
+-- no-parallel-replicas: EXPLAIN output differs for parallel replicas.
+
+-- Test that empty() and notEmpty() use the primary key for string columns.
+-- With optimize_empty_string_comparisons=1 (default), `s = ''` is rewritten
+-- to `empty(s)`. This test verifies that empty() and notEmpty() report
+-- monotonicity for String arguments so granules can be skipped.
+
+DROP TABLE IF EXISTS t_empty_pk;
+
+CREATE TABLE t_empty_pk (s String)
+ENGINE = MergeTree ORDER BY s
+SETTINGS index_granularity = 3;
+
+INSERT INTO t_empty_pk VALUES (''), ('a'), ('b'), ('c'), ('d'), ('e'), ('f'), ('g'), ('h'), ('i');
+
+-- With primary key skipping, searching for '' should read only the first
+-- granule (which contains '') and skip all granules that start with a
+-- non-empty string.  Searching for non-empty strings should skip the
+-- granule that starts with ''.
+
+-- { echo }
+EXPLAIN indexes = 1
+SELECT count() FROM t_empty_pk WHERE empty(s);
+
+EXPLAIN indexes = 1
+SELECT count() FROM t_empty_pk WHERE s = '';
+
+EXPLAIN indexes = 1
+SELECT count() FROM t_empty_pk WHERE notEmpty(s);
+
+EXPLAIN indexes = 1
+SELECT count() FROM t_empty_pk WHERE s != '';
+-- { echoOff }
+
+DROP TABLE t_empty_pk;

--- a/tests/queries/0_stateless/04033_empty_string_pk_monotonicity.sql
+++ b/tests/queries/0_stateless/04033_empty_string_pk_monotonicity.sql
@@ -11,7 +11,10 @@ DROP TABLE IF EXISTS t_empty_pk;
 
 CREATE TABLE t_empty_pk (s String)
 ENGINE = MergeTree ORDER BY s
-SETTINGS index_granularity = 3;
+SETTINGS index_granularity = 3,
+    min_bytes_for_wide_part = 0,
+    min_bytes_for_full_part_storage = 0,
+    max_bytes_to_merge_at_max_space_in_pool = 1;
 
 INSERT INTO t_empty_pk VALUES (''), ('a'), ('b'), ('c'), ('d'), ('e'), ('f'), ('g'), ('h'), ('i');
 
@@ -22,16 +25,16 @@ INSERT INTO t_empty_pk VALUES (''), ('a'), ('b'), ('c'), ('d'), ('e'), ('f'), ('
 
 -- { echo }
 EXPLAIN indexes = 1
-SELECT count() FROM t_empty_pk WHERE empty(s);
+SELECT * FROM t_empty_pk WHERE empty(s);
 
 EXPLAIN indexes = 1
-SELECT count() FROM t_empty_pk WHERE s = '';
+SELECT * FROM t_empty_pk WHERE s = '';
 
 EXPLAIN indexes = 1
-SELECT count() FROM t_empty_pk WHERE notEmpty(s);
+SELECT * FROM t_empty_pk WHERE notEmpty(s);
 
 EXPLAIN indexes = 1
-SELECT count() FROM t_empty_pk WHERE s != '';
+SELECT * FROM t_empty_pk WHERE s != '';
 -- { echoOff }
 
 DROP TABLE t_empty_pk;


### PR DESCRIPTION
Ref : https://github.com/ClickHouse/ClickHouse/pull/82850. Reported from testing at customer. A predicate like` id = ''` will be rewritten to `empty(id)` function call, but that ends up not using primary key filtering. Workaround without the fix is to prevent the rewrite with `optimize_empty_string_comparisons = 0.` e.g

```
EXPLAIN indexes = 1
SELECT *
FROM users
WHERE id = ''

Query id: 3832de43-c26e-48f5-a655-b40bf6ad1ee8

   ┌─explain────────────────────────────────────────────────────────────┐
1. │ Expression ((Project names + Projection))                          │
2. │   Expression ((WHERE + Change column names to column identifiers)) │
3. │     ReadFromMergeTree (default.users)                              │
4. │     Indexes:                                                       │
5. │       PrimaryKey                                                   │
6. │         Condition: true                                            │
7. │         Parts: 1/1                                                 │
8. │         Granules: 1563/1563                                        │
9. │       Ranges: 1                                                    │
   └────────────────────────────────────────────────────────────────────┘

9 rows in set. Elapsed: 0.002 sec.


EXPLAIN indexes = 1
SELECT *
FROM users
WHERE id = ''
SETTINGS optimize_empty_string_comparisons = 0

Query id: 4bf16560-3f96-44b2-902c-c3c219b9e133

    ┌─explain────────────────────────────────────────────────────────────┐
 1. │ Expression ((Project names + Projection))                          │
 2. │   Expression ((WHERE + Change column names to column identifiers)) │
 3. │     ReadFromMergeTree (default.users)                              │
 4. │     Indexes:                                                       │
 5. │       PrimaryKey                                                   │
 6. │         Keys:                                                      │
 7. │           id                                                       │
 8. │         Condition: (id in ['', ''])                                │
 9. │         Parts: 1/1                                                 │
10. │         Granules: 144/1563                                         │
11. │         Search Algorithm: binary search                            │
12. │       Ranges: 1                                                    │
    └────────────────────────────────────────────────────────────────────┘
```

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

- A query like `SELECT * FROM table WHERE pk_id = ''` where `pk_id` is the primary key and of `String` type will now correctly use the primary key index for filtering granules.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches primary-key condition analysis by adding monotonicity metadata for `empty()`/`notEmpty()` and wiring it through a generic function wrapper, which could affect index pruning behavior for queries using these functions. Changes are scoped and covered by a new EXPLAIN-based regression test, but pruning logic is correctness-sensitive.
> 
> **Overview**
> Fixes primary key skipping for predicates rewritten to `empty(col)`/`notEmpty(col)` (e.g. `col = ''`) by teaching these functions to report monotonicity on String ranges and propagating that information through `FunctionStringOrArrayToT`.
> 
> Updates MergeTree key condition parsing to treat `empty`/`notEmpty` as `IN/NOT IN` the single-point range `['', '']` (only for String key columns), and adds a stateless test validating EXPLAIN shows PK range conditions and expected granule counts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54dbb8f3ee1ebbb048834321e86f0c23053c2c03. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.573`
<!-- ch-version-info:end -->