### PR TITLE
Fix LLVM Coverage job failure when PR has no source code changes

### DIFF
--- a/ci/jobs/llvm_coverage_job.py
+++ b/ci/jobs/llvm_coverage_job.py
@@ -218,23 +218,29 @@ if __name__ == "__main__":
             print("Coverage did not degrade.")
 
         # Compress and attach the diff HTML report archive + files to the diff result.
-        Utils.compress_gz(
-            f"{TEMP_DIR}/llvm_coverage_diff_html_report",
-            f"{TEMP_DIR}/llvm_coverage_diff_html_report.tar.gz",
-        )
-        diff_res.files.append(f"{TEMP_DIR}/llvm_coverage_diff_html_report.tar.gz")
-        # Copy index.html → index_diff.html so the diff entry-point has a unique
-        # name in S3 links. The original index.html is kept as an asset so that
-        # relative links inside the report continue to work.
-        _diff_index = Path(TEMP_DIR) / "llvm_coverage_diff_html_report" / "index.html"
-        _diff_index_copy = _diff_index.parent / "index_diff.html"
-        if _diff_index.exists():
-            shutil.copy2(_diff_index, _diff_index_copy)
-        _diff_files, _diff_assets = collect_html_report_files(
-            "llvm_coverage_diff_html_report", entry_point="index_diff.html"
-        )
-        diff_res.files.extend(_diff_files)
-        diff_res.assets.extend(_diff_assets)
+        # The directory may not exist when changed files have no coverage data
+        # (e.g. only non-source files like .sh tests were modified).
+        _diff_html_dir = Path(TEMP_DIR) / "llvm_coverage_diff_html_report"
+        if _diff_html_dir.exists():
+            Utils.compress_gz(
+                str(_diff_html_dir),
+                f"{TEMP_DIR}/llvm_coverage_diff_html_report.tar.gz",
+            )
+            diff_res.files.append(
+                f"{TEMP_DIR}/llvm_coverage_diff_html_report.tar.gz"
+            )
+            # Copy index.html → index_diff.html so the diff entry-point has a unique
+            # name in S3 links. The original index.html is kept as an asset so that
+            # relative links inside the report continue to work.
+            _diff_index = _diff_html_dir / "index.html"
+            _diff_index_copy = _diff_index.parent / "index_diff.html"
+            if _diff_index.exists():
+                shutil.copy2(_diff_index, _diff_index_copy)
+            _diff_files, _diff_assets = collect_html_report_files(
+                "llvm_coverage_diff_html_report", entry_point="index_diff.html"
+            )
+            diff_res.files.extend(_diff_files)
+            diff_res.assets.extend(_diff_assets)
         results.append(diff_res)
 
         # Generate report for changed blocks only
@@ -318,8 +324,9 @@ if __name__ == "__main__":
             )
 
     archives = [f"{TEMP_DIR}/llvm_coverage_html_report.tar.gz"]
-    if not is_master_branch:
-        archives.append(f"{TEMP_DIR}/llvm_coverage_diff_html_report.tar.gz")
+    _diff_archive = Path(TEMP_DIR) / "llvm_coverage_diff_html_report.tar.gz"
+    if _diff_archive.exists():
+        archives.append(str(_diff_archive))
 
     Result.create_from(
         results=results,

--- a/ci/jobs/llvm_coverage_job.py
+++ b/ci/jobs/llvm_coverage_job.py
@@ -221,7 +221,8 @@ if __name__ == "__main__":
         # The directory may not exist when changed files have no coverage data
         # (e.g. only non-source files like .sh tests were modified).
         _diff_html_dir = Path(TEMP_DIR) / "llvm_coverage_diff_html_report"
-        if _diff_html_dir.exists():
+        _has_diff_report = _diff_html_dir.exists()
+        if _has_diff_report:
             Utils.compress_gz(
                 str(_diff_html_dir),
                 f"{TEMP_DIR}/llvm_coverage_diff_html_report.tar.gz",
@@ -266,7 +267,11 @@ if __name__ == "__main__":
             _log_name = f"{Utils.normalize_string(print_res.name)}.log"
             uncovered_code_url = f"{_s3_base}/llvm_coverage/{Utils.normalize_string(print_res.name)}/{_log_name}"
 
-            _diff_url = f"{_s3_base}/llvm_coverage/generate_llvm_coverage_diff_report/index_diff.html"
+            _diff_url = (
+                f"{_s3_base}/llvm_coverage/generate_llvm_coverage_diff_report/index_diff.html"
+                if _has_diff_report
+                else ""
+            )
             _pr_changed_lines_info = print_res.ext.get("comment", "")
 
             # Write coverage data for the post-hook to pick up and post as a GitHub comment
@@ -318,7 +323,8 @@ if __name__ == "__main__":
         report_links.append(
             f"{_s3_base}/llvm_coverage/generate_llvm_coverage_report/index.html"
         )
-        if not is_master_branch:
+        _diff_archive = Path(TEMP_DIR) / "llvm_coverage_diff_html_report.tar.gz"
+        if not is_master_branch and _diff_archive.exists():
             report_links.append(
                 f"{_s3_base}/llvm_coverage/generate_llvm_coverage_diff_report/index_diff.html"
             )

--- a/ci/jobs/scripts/generate_diff_coverage_report.sh
+++ b/ci/jobs/scripts/generate_diff_coverage_report.sh
@@ -65,6 +65,13 @@ lcov --extract base_llvm_coverage.info "${patterns[@]}" \
   --quiet \
   -o baseline.changed.info 2>/dev/null
 
+# If lcov --extract found no coverage data for the changed files (e.g. only
+# non-source files like .sh tests were modified), skip the genhtml step.
+if ! grep -q '^SF:' current.changed.info 2>/dev/null; then
+  echo "No coverage data for changed files, skipping diff report"
+  exit 0
+fi
+
 echo Workspace path: $WORKSPACE_PATH
 
 HEADER_TITLE="differential coverage report"


### PR DESCRIPTION
## Summary
- The LLVM Coverage job fails when a PR only changes non-source files (e.g. `.sh` test scripts)
- `lcov --extract` produces empty output for non-source files, `genhtml` fails on empty input (exit code 2), and then `llvm_coverage_job.py` crashes trying to compress the non-existent `llvm_coverage_diff_html_report` directory
- Fix: early exit in `generate_diff_coverage_report.sh` when no coverage data exists for changed files, and guard compress/archive operations in `llvm_coverage_job.py`

Failing CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=99018&sha=df6f0da97c5b87721cde0190e310431d826349d5&name_0=PR&name_1=LLVM%20Coverage
https://github.com/ClickHouse/ClickHouse/pull/99018

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that adds guards/early-exits around diff coverage report generation to avoid failures when no source files are covered. Main risk is reduced visibility if the presence checks mis-detect and skip a diff report unexpectedly.
> 
> **Overview**
> Prevents the LLVM Coverage CI job from failing when changed files produce **no `lcov` coverage data** (e.g. PRs that only modify scripts/tests).
> 
> `generate_diff_coverage_report.sh` now exits early before running `genhtml` if `lcov --extract` yields an empty `.info` (no `SF:` entries). `llvm_coverage_job.py` now conditionally compresses/uploads the diff HTML report and only emits diff report links/`diff_url` when the diff report directory/archive actually exists.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12048a58159ebe7dc22e22f134c74cf89d17384a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->