### PR TITLE
Add NOLINT(bugprone-empty-catch) to empty catch blocks annotated with // Ok: by #96171

### DIFF
--- a/src/Common/Exception.cpp
+++ b/src/Common/Exception.cpp
@@ -488,7 +488,7 @@ PreformattedMessage getCurrentExceptionMessageAndPattern(
             if (with_version)
                 stream << " (version " << VERSION_STRING << VERSION_OFFICIAL << ")";
         }
-        catch (...) {} // Ok: best-effort exception formatting, must not throw
+        catch (...) {} // NOLINT(bugprone-empty-catch) Ok: best-effort exception formatting, must not throw
     }
     catch (const std::exception & e)
     {
@@ -506,7 +506,7 @@ PreformattedMessage getCurrentExceptionMessageAndPattern(
             if (with_version)
                 stream << " (version " << VERSION_STRING << VERSION_OFFICIAL << ")";
         }
-        catch (...) {} // Ok: best-effort exception formatting, must not throw
+        catch (...) {} // NOLINT(bugprone-empty-catch) Ok: best-effort exception formatting, must not throw
 
         if (debug_or_sanitizer_build || abort_on_logical_error.load(std::memory_order_relaxed))
         {
@@ -521,7 +521,7 @@ PreformattedMessage getCurrentExceptionMessageAndPattern(
 
                 abortOnFailedAssertion(stream.str());
             }
-            catch (...) {} // Ok: best-effort exception formatting, must not throw
+            catch (...) {} // NOLINT(bugprone-empty-catch) Ok: best-effort exception formatting, must not throw
         }
     }
     catch (...) // Ok: unknown exception type, format what we can
@@ -538,7 +538,7 @@ PreformattedMessage getCurrentExceptionMessageAndPattern(
             if (with_version)
                 stream << " (version " << VERSION_STRING << VERSION_OFFICIAL << ")";
         }
-        catch (...) {} // Ok: best-effort exception formatting, must not throw
+        catch (...) {} // NOLINT(bugprone-empty-catch) Ok: best-effort exception formatting, must not throw
     }
 
     return PreformattedMessage{stream.str(), message_format_string, message_format_string_args};
@@ -664,7 +664,7 @@ PreformattedMessage getExceptionMessageAndPattern(const Exception & e, bool with
         if (with_stacktrace && !has_embedded_stack_trace)
             stream << ", Stack trace (when copying this message, always include the lines below):\n\n" << e.getStackTraceString();
     }
-    catch (...) {} // Ok: best-effort exception formatting, must not throw
+    catch (...) {} // NOLINT(bugprone-empty-catch) Ok: best-effort exception formatting, must not throw
 
     return PreformattedMessage{stream.str(), e.tryGetMessageFormatString(), e.getMessageFormatStringArgs()};
 }

--- a/src/Common/ExceptionExt.h
+++ b/src/Common/ExceptionExt.h
@@ -41,7 +41,7 @@ void tryLogCurrentExceptionImpl(Logger logger, const std::string & start_of_mess
             }
         }
     }
-    catch (...) // Ok: logging itself failed, nothing more to do
+    catch (...) // NOLINT(bugprone-empty-catch) Ok: logging itself failed, nothing more to do
     {
     }
 
@@ -54,7 +54,7 @@ void tryLogCurrentExceptionImpl(Logger logger, const std::string & start_of_mess
     {
         e.markAsLogged();
     }
-    catch (...) // Ok: only DB::Exception can be marked as logged
+    catch (...) // NOLINT(bugprone-empty-catch) Ok: only DB::Exception can be marked as logged
     {
     }
 }

--- a/src/Common/SignalHandlers.cpp
+++ b/src/Common/SignalHandlers.cpp
@@ -183,7 +183,7 @@ static void signalHandler(int sig, siginfo_t * info, void * context)
             for (size_t i = 0; i < terminate_current_exception_trace_size; ++i)
                 terminate_current_exception_trace[i] = stack_trace_frames[i];
         }
-        catch (...) {} // Ok: best-effort in terminate handler
+        catch (...) {} // NOLINT(bugprone-empty-catch) Ok: best-effort in terminate handler
     }
     else
     {

--- a/src/Common/memory.h
+++ b/src/Common/memory.h
@@ -179,7 +179,7 @@ inline ALWAYS_INLINE size_t untrackMemory(void * ptr [[maybe_unused]], Allocatio
 #endif
         trace = CurrentMemoryTracker::free(actual_size);
     }
-    catch (...) // Ok: operator delete must not throw
+    catch (...) // NOLINT(bugprone-empty-catch) Ok: operator delete must not throw
     {
     }
 


### PR DESCRIPTION
### Summary

PR #96171 replaced `// NOLINT(bugprone-empty-catch)` with `// Ok:` comments on 9 empty `catch (...)` blocks across 4 files. The `// Ok:` comment satisfies the ClickHouse custom style check (`catch_all` in `ci/jobs/check_style.py`) but does **not** suppress clang-tidy's `bugprone-empty-catch` diagnostic.

The bug was latent because clang-tidy-cache computes digests from preprocessed output (`-E` mode), which strips comments. Changing `// NOLINT` → `// Ok:` produces identical preprocessed output, so the cache always hits and clang-tidy never re-runs on those files.

### Fix

Add `NOLINT(bugprone-empty-catch)` **alongside** the existing `// Ok:` marker on each empty catch block, so both checks are satisfied:

```cpp
catch (...) // NOLINT(bugprone-empty-catch) Ok: reason
```

### Affected files (9 catch blocks, 4 files)

- `src/Common/Exception.cpp` — 5 empty catch blocks
- `src/Common/ExceptionExt.h` — 2 empty catch blocks
- `src/Common/SignalHandlers.cpp` — 1 empty catch block
- `src/Common/memory.h` — 1 empty catch block

### Changelog category (leave one):
- CI Fix or improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Add `NOLINT(bugprone-empty-catch)` to empty catch blocks that only had `// Ok:` comments after #96171, preventing latent clang-tidy violations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: comment-only changes that re-add `NOLINT(bugprone-empty-catch)` to intentional empty `catch (...)` blocks, affecting only static analysis/CI behavior.
> 
> **Overview**
> Restores `// NOLINT(bugprone-empty-catch)` on several intentionally empty `catch (...)` blocks in exception formatting/logging, terminate handling, and memory untracking code.
> 
> This is a **CI/static-analysis fix** to suppress clang-tidy’s `bugprone-empty-catch` warnings where empty catches are deliberate best-effort/no-throw paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 87cb28cf54506037cd0d89f120f0d618470180ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.536`
<!-- ch-version-info:end -->