### PR TITLE
Fix undefined behavior from reading uninitialized resolved_snapshot_id in ManifestFileIterator

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFileIterator.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFileIterator.cpp
@@ -406,9 +406,8 @@ ProcessedManifestFileEntryPtr ManifestFileIterator::processRow(size_t row_index)
     {
         throw Exception(
             ErrorCodes::ICEBERG_SPECIFICATION_VIOLATION,
-            "Cannot read Iceberg table: manifest file '{}' has entry with snapshot_id '{}' for which write file schema is unknown",
-            manifest_file_name,
-            resolved_snapshot_id);
+            "Cannot read Iceberg table: manifest file '{}' has entry with snapshot_id 'null' for which write file schema is unknown",
+            manifest_file_name);
     }
     else
     {


### PR DESCRIPTION
In ManifestFileIterator::processRow, resolved_snapshot_id is declared as an uninitialized Int64. In the else if branch reached when parsed_snapshot_id is null and the entry status is EXISTING, the uninitialized variable was passed to fmt::format — undefined behavior. The error message was also misleading: it said "has entry with snapshot_id '{}'" but this branch is entered precisely because there is no snapshot_id.

Fix: Remove resolved_snapshot_id from the format call and hardcode 'null' in the message, keeping the same style as the existing error message in the same function:
"Cannot read Iceberg table: manifest file '{}' has entry with snapshot_id 'null' for which write file schema is unknown"

Found via code review on PR #98231.

### Changelog category (leave one):
- Not for changelog


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Very small change limited to an exception message in an error-only code path, reducing undefined behavior risk with minimal functional impact.
> 
> **Overview**
> Fixes an undefined-behavior error path in `ManifestFileIterator::processRow` when a manifest entry is `EXISTING` but has no `snapshot_id`.
> 
> The thrown `ICEBERG_SPECIFICATION_VIOLATION` message no longer formats an uninitialized `resolved_snapshot_id` and instead reports the snapshot id as `'null'`, making the error text accurate and safe.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92e4dd5a2bd4bc2a0f1384cd69ca59178fa4e37b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.707`
<!-- ch-version-info:end -->