### PR TITLE
Fix crash in CachedOnDiskReadBufferFromFile destructor

### DIFF
--- a/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
+++ b/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
@@ -666,7 +666,7 @@ bool CachedOnDiskReadBufferFromFile::completeFileSegmentAndGetNext()
 
 CachedOnDiskReadBufferFromFile::~CachedOnDiskReadBufferFromFile()
 {
-    if (cache_log && info.file_segments && !info.file_segments->empty())
+    if (cache_log && info.file_segments && !info.file_segments->empty() && state)
     {
         appendFilesystemCacheLog(info.file_segments->front(), state->read_type);
     }


### PR DESCRIPTION
Resolves https://github.com/ClickHouse/ClickHouse/issues/99037
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
- ClickHouse server process could crash if there was a memory limit exceeded exception thrown during a _cached disk read_. That is now fixed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a null-check before logging in a destructor, reducing crash risk without changing read/cache behavior.
> 
> **Overview**
> Prevents a potential crash in `CachedOnDiskReadBufferFromFile::~CachedOnDiskReadBufferFromFile()` by guarding filesystem cache logging with a `state` null-check before accessing `state->read_type`.
> 
> This avoids dereferencing an uninitialized read state during teardown (e.g., after exceptions) while keeping existing segment completion/cleanup logic unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39e41c4cc82f49b7fc903f0364cfc3befe20999b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.571`
- Backported to: `26.2.5.16`
<!-- ch-version-info:end -->