### PR TITLE
Build parser_memory_profiler as non-PIE on Linux

### DIFF
--- a/src/Parsers/examples/CMakeLists.txt
+++ b/src/Parsers/examples/CMakeLists.txt
@@ -11,3 +11,8 @@ target_link_libraries(create_parser PRIVATE dbms)
 
 clickhouse_add_executable(parser_memory_profiler parser_memory_profiler.cpp ${SRCS} "../../Server/ServerType.cpp")
 target_link_libraries(parser_memory_profiler PRIVATE dbms)
+if (OS_LINUX)
+    # Build as non-PIE so jemalloc heap profile addresses are stable across processes,
+    # enabling cross-process batch symbolization with --symbolize-batch.
+    target_link_options(parser_memory_profiler PRIVATE -no-pie -Wl,-no-pie)
+endif()


### PR DESCRIPTION
The parser_memory_profiler tool uses jemalloc heap profiling with batch symbolization (--symbolize-batch). Batch mode runs a second process to resolve addresses from heap profiles generated in earlier runs. This requires stable virtual addresses across processes.

On Linux with ASLR, PIE executables get randomized base addresses, making cross-process address resolution impossible. Adding -no-pie ensures the binary loads at a fixed address, so heap profile addresses from one invocation are valid in another.

### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build-system tweak scoped to the `parser_memory_profiler` example binary on Linux; main risk is potential linker/packaging incompatibility on some toolchains due to disabling PIE.
> 
> **Overview**
> Builds `parser_memory_profiler` as a **non-PIE executable on Linux** by adding `-no-pie` linker options.
> 
> This keeps jemalloc heap profile addresses stable across runs, enabling cross-process batch symbolization (e.g., `--symbolize-batch`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9cc6f08836488bca7932bdb214c9630b2289fa37. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.535`
<!-- ch-version-info:end -->