### PR TITLE
Docs: update TODO in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 # 2026 Changelog
 
-### <a id="262"></a> ClickHouse release 26.2, 2026-02-26. [Presentation](https://presentations.clickhouse.com/2026-release-26.2/), [Video](TODO)
+### <a id="262"></a> ClickHouse release 26.2, 2026-02-26. [Presentation](https://presentations.clickhouse.com/2026-release-26.2/), [Video](https://www.youtube.com/watch?v=7qHba08vNfo)
 
 #### Backward Incompatible Change
 * Deduplication is turned ON for all inserts by default. It was OFF before for async inserts and for MV's, but it was ON for sync inserts. The goal is to have the same defaults for both ways of inserts. If you have deduplication explicitly disabled on your cluster, you have to explicitly set `deduplicate_insert='backward_compatible_choice'` to keep the old behavior. The same with `deduplicate_blocks_in_dependent_materialized_views`. [#95970](https://github.com/ClickHouse/ClickHouse/pull/95970) ([Sema Checherinda](https://github.com/CheSema)).


### PR DESCRIPTION
Update the TODO with link to release webinar
### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change updating a placeholder URL to the published YouTube video; no code or behavior changes.
> 
> **Overview**
> Updates the `CHANGELOG.md` entry for the 26.2 (2026-02-26) release by replacing the `TODO` placeholder with the actual YouTube link for the release video.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24c78c9c52119ec2b62f4683e5e6208ed347d2f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.564`
<!-- ch-version-info:end -->