### PR TITLE
Docs: fix incorrect documentation for `match` function

### DIFF
--- a/src/Functions/match.cpp
+++ b/src/Functions/match.cpp
@@ -30,9 +30,9 @@ If the haystack or the pattern are not valid UTF-8, the behavior is undefined.
 
 Unlike re2's default behavior, `.` matches line breaks. To disable this, prepend the pattern with `(?-s)`.
 
-The pattern is automatically anchored at both ends (as if the pattern started with '^' and ended with '$').
+The pattern is not anchored. To match the entire string, anchor the pattern yourself using `^` and `$`.
 
-If you only like to find substrings, you can use functions [`like`](#like) or [`position`](#position) instead - they work much faster than this function.
+If you only like to search for substrings, you can use functions [`like`](#like) or [`position`](#position) instead - they work much faster than this function.
 
 Alternative operator syntax: `haystack REGEXP pattern`.
     )";
@@ -59,6 +59,15 @@ Alternative operator syntax: `haystack REGEXP pattern`.
 ┌─match('Hello World', 'goodbye.*')─┐
 │                                 0 │
 └───────────────────────────────────┘
+        )"
+    },
+    {
+        "Matching a substring",
+        "SELECT match('abcde', 'b.*d'), match('abcde', '^b.*d$')",
+        R"(
+┌─match('abcde', 'b.*d')─┬─match('abcde', '^b.*d$')─┐
+│                       1 │                         0 │
+└─────────────────────────┴───────────────────────────┘
         )"
     }
     };

--- a/src/Functions/match.cpp
+++ b/src/Functions/match.cpp
@@ -32,7 +32,7 @@ Unlike re2's default behavior, `.` matches line breaks. To disable this, prepend
 
 The pattern is not anchored. To match the entire string, anchor the pattern yourself using `^` and `$`.
 
-If you only like to search for substrings, you can use functions [`like`](#like) or [`position`](#position) instead - they work much faster than this function.
+If you just want to search for substrings, you can use functions [`like`](#like) or [`position`](#position) instead, which work much faster than this function.
 
 Alternative operator syntax: `haystack REGEXP pattern`.
     )";


### PR DESCRIPTION
## Summary
- The `match` function documentation incorrectly stated that the regex pattern is automatically anchored at both ends
- The implementation actually uses `re2::RE2::UNANCHORED`, meaning `match` performs substring matching
- Fixed the description and added an example demonstrating unanchored behavior

Closes https://linear.app/clickhouse/issue/DOC-586

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change with no runtime/behavioral impact. Main risk is potential user confusion if the clarified semantics differ from prior expectations.
> 
> **Overview**
> Updates `match` function docs to remove the incorrect claim that patterns are implicitly anchored, and instead explains that patterns are *unanchored* unless users add `^`/`$` themselves.
> 
> Adds an example showing the difference between unanchored substring matching and fully anchored matching.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d502c583e564648bbe5cb88cda04b186067335e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.539`
<!-- ch-version-info:end -->