### PR TITLE
Docs: add missing LDAP configuration parameters and reorganize as tables

### DIFF
--- a/docs/en/operations/external-authenticators/ldap.md
+++ b/docs/en/operations/external-authenticators/ldap.md
@@ -66,6 +66,9 @@ Note, that you can define multiple LDAP servers inside the `ldap_servers` sectio
 - `port` — LDAP server port, default is `636` if `enable_tls` is set to `true`, `389` otherwise.
 - `bind_dn` — Template used to construct the DN to bind to.
   - The resulting DN will be constructed by replacing all `{user_name}` substrings of the template with the actual user name during each authentication attempt.
+- `auth_dn_prefix` and `auth_dn_suffix` — Deprecated. Used as an alternative to `bind_dn`.
+  - These two parameters cannot be used together with `bind_dn`. When specified, the bind DN is constructed as `auth_dn_prefix + {user_name} + auth_dn_suffix`.
+  - For example, setting `auth_dn_prefix` to `uid=` and `auth_dn_suffix` to `,ou=users,dc=example,dc=com` is equivalent to setting `bind_dn` to `uid={user_name},ou=users,dc=example,dc=com`.
 - `user_dn_detection` — Section with LDAP search parameters for detecting the actual user DN of the bound user.
   - This is mainly used in search filters for further role mapping when the server is Active Directory. The resulting user DN will be used when replacing `{user_dn}` substrings wherever they are allowed. By default, user DN is set equal to bind DN, but once search is performed, it will be updated with to the actual detected user DN value.
     - `base_dn` — Template used to construct the base DN for the LDAP search.
@@ -93,6 +96,7 @@ Note, that you can define multiple LDAP servers inside the `ldap_servers` sectio
 - `tls_ca_cert_file` — Path to CA certificate file.
 - `tls_ca_cert_dir` — Path to the directory containing CA certificates.
 - `tls_cipher_suite` — Allowed cipher suite (in OpenSSL notation).
+- `search_limit` — Maximum number of entries that can be returned by LDAP search queries performed by this server definition (for user DN detection and role mapping). Default is `256`.
 
 ## LDAP external authenticator {#ldap-external-authenticator}
 

--- a/docs/en/operations/external-authenticators/ldap.md
+++ b/docs/en/operations/external-authenticators/ldap.md
@@ -62,41 +62,34 @@ Note, that you can define multiple LDAP servers inside the `ldap_servers` sectio
 
 **Parameters**
 
-- `host` — LDAP server hostname or IP, this parameter is mandatory and cannot be empty.
-- `port` — LDAP server port, default is `636` if `enable_tls` is set to `true`, `389` otherwise.
-- `bind_dn` — Template used to construct the DN to bind to.
-  - The resulting DN will be constructed by replacing all `{user_name}` substrings of the template with the actual user name during each authentication attempt.
-- `auth_dn_prefix` and `auth_dn_suffix` — Deprecated. Used as an alternative to `bind_dn`.
-  - These two parameters cannot be used together with `bind_dn`. When specified, the bind DN is constructed as `auth_dn_prefix + {user_name} + auth_dn_suffix`.
-  - For example, setting `auth_dn_prefix` to `uid=` and `auth_dn_suffix` to `,ou=users,dc=example,dc=com` is equivalent to setting `bind_dn` to `uid={user_name},ou=users,dc=example,dc=com`.
-- `user_dn_detection` — Section with LDAP search parameters for detecting the actual user DN of the bound user.
-  - This is mainly used in search filters for further role mapping when the server is Active Directory. The resulting user DN will be used when replacing `{user_dn}` substrings wherever they are allowed. By default, user DN is set equal to bind DN, but once search is performed, it will be updated with to the actual detected user DN value.
-    - `base_dn` — Template used to construct the base DN for the LDAP search.
-      - The resulting DN will be constructed by replacing all `{user_name}` and `{bind_dn}` substrings of the template with the actual user name and bind DN during the LDAP search.
-    - `scope` — Scope of the LDAP search.
-      - Accepted values are: `base`, `one_level`, `children`, `subtree` (the default).
-    - `search_filter` — Template used to construct the search filter for the LDAP search.
-      - The resulting filter will be constructed by replacing all `{user_name}`, `{bind_dn}`, and `{base_dn}` substrings of the template with the actual user name, bind DN, and base DN during the LDAP search.
-      - Note, that the special characters must be escaped properly in XML.
-- `verification_cooldown` — A period of time, in seconds, after a successful bind attempt, during which the user will be assumed to be successfully authenticated for all consecutive requests without contacting the LDAP server.
-  - Specify `0` (the default) to disable caching and force contacting the LDAP server for each authentication request.
-- `follow_referrals` —  A flag to allow the LDAP client library to automatically chase LDAP referrals returned by the server. `false` by default. Note: This setting is mostly relevant for Microsoft Active Directory environments where subtree searches at a high-level base DN (e.g. `DC=example,DC=com`) can return referrals/search references (e.g. `DC=DomainDnsZones,...`).
-  - Specify `true` only when you explicitly need cross‑partition searches and your environment is configured to allow them.
-  - Specify `false` to not chase referrals. This is recommended for AD domain‑root searches.
-- `enable_tls` — A flag to trigger the use of the secure connection to the LDAP server.
-  - Specify `no` for plain text `ldap://` protocol (not recommended).
-  - Specify `yes` for LDAP over SSL/TLS `ldaps://` protocol (recommended, the default).
-  - Specify `starttls` for legacy StartTLS protocol (plain text `ldap://` protocol, upgraded to TLS).
-- `tls_minimum_protocol_version` — The minimum protocol version of SSL/TLS.
-  - Accepted values are: `ssl2`, `ssl3`, `tls1.0`, `tls1.1`, `tls1.2` (the default).
-- `tls_require_cert` — SSL/TLS peer certificate verification behavior.
-  - Accepted values are: `never`, `allow`, `try`, `demand` (the default).
-- `tls_cert_file` — Path to certificate file.
-- `tls_key_file` — Path to certificate key file.
-- `tls_ca_cert_file` — Path to CA certificate file.
-- `tls_ca_cert_dir` — Path to the directory containing CA certificates.
-- `tls_cipher_suite` — Allowed cipher suite (in OpenSSL notation).
-- `search_limit` — Maximum number of entries that can be returned by LDAP search queries performed by this server definition (for user DN detection and role mapping). Default is `256`.
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `host` | — | LDAP server hostname or IP. This parameter is mandatory and cannot be empty. |
+| `port` | `636` / `389` | LDAP server port. Defaults to `636` if `enable_tls` is set to `yes`, `389` otherwise. |
+| `bind_dn` | — | Template used to construct the DN to bind to. The resulting DN will be constructed by replacing all `{user_name}` substrings of the template with the actual user name during each authentication attempt. |
+| `auth_dn_prefix` | — | **Deprecated.** An alternative to `bind_dn`. Cannot be used together with `bind_dn`. When specified, the bind DN is constructed as `auth_dn_prefix + {user_name} + auth_dn_suffix`. For example, setting `auth_dn_prefix` to `uid=` and `auth_dn_suffix` to `,ou=users,dc=example,dc=com` is equivalent to setting `bind_dn` to `uid={user_name},ou=users,dc=example,dc=com`. |
+| `auth_dn_suffix` | — | **Deprecated.** See `auth_dn_prefix`. |
+| `verification_cooldown` | `0` | A period of time, in seconds, after a successful bind attempt, during which the user will be assumed to be successfully authenticated for all consecutive requests without contacting the LDAP server. Specify `0` to disable caching and force contacting the LDAP server for each authentication request. |
+| `follow_referrals` | `false` | A flag to allow the LDAP client library to automatically chase LDAP referrals returned by the server. Mostly relevant for Microsoft Active Directory environments where subtree searches at a high-level base DN (e.g. `DC=example,DC=com`) can return referrals/search references (e.g. `DC=DomainDnsZones,...`). Set to `true` only when you explicitly need cross-partition searches. |
+| `enable_tls` | `yes` | A flag to trigger the use of the secure connection to the LDAP server. Specify `no` for plain text `ldap://` protocol (not recommended), `yes` for LDAP over SSL/TLS `ldaps://` protocol (recommended), or `starttls` for legacy StartTLS protocol (plain text `ldap://` protocol, upgraded to TLS). |
+| `tls_minimum_protocol_version` | `tls1.2` | The minimum protocol version of SSL/TLS. Accepted values: `ssl2`, `ssl3`, `tls1.0`, `tls1.1`, `tls1.2`. |
+| `tls_require_cert` | `demand` | SSL/TLS peer certificate verification behavior. Accepted values: `never`, `allow`, `try`, `demand`. |
+| `tls_cert_file` | — | Path to certificate file. |
+| `tls_key_file` | — | Path to certificate key file. |
+| `tls_ca_cert_file` | — | Path to CA certificate file. |
+| `tls_ca_cert_dir` | — | Path to the directory containing CA certificates. |
+| `tls_cipher_suite` | — | Allowed cipher suite (in OpenSSL notation). |
+| `search_limit` | `256` | Maximum number of entries that can be returned by LDAP search queries performed by this server definition (for user DN detection and role mapping). |
+
+**`user_dn_detection` sub-parameters**
+
+Section with LDAP search parameters for detecting the actual user DN of the bound user. This is mainly used in search filters for further role mapping when the server is Active Directory. The resulting user DN will be used when replacing `{user_dn}` substrings wherever they are allowed. By default, user DN is set equal to bind DN, but once search is performed, it will be updated to the actual detected user DN value.
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `base_dn` | — | Template used to construct the base DN for the LDAP search. The resulting DN will be constructed by replacing all `{user_name}` and `{bind_dn}` substrings of the template with the actual user name and bind DN during the LDAP search. |
+| `scope` | `subtree` | Scope of the LDAP search. Accepted values: `base`, `one_level`, `children`, `subtree`. |
+| `search_filter` | — | Template used to construct the search filter for the LDAP search. The resulting filter will be constructed by replacing all `{user_name}`, `{bind_dn}`, and `{base_dn}` substrings of the template with the actual user name, bind DN, and base DN during the LDAP search. Note that special characters must be escaped properly in XML. |
 
 ## LDAP external authenticator {#ldap-external-authenticator}
 
@@ -180,18 +173,19 @@ Note that `my_ldap_server` referred in the `ldap` section inside the `user_direc
 
 **Parameters**
 
-- `server` — One of LDAP server names defined in the `ldap_servers` config section above. This parameter is mandatory and cannot be empty.
-- `roles` — Section with a list of locally defined roles that will be assigned to each user retrieved from the LDAP server.
-  - If no roles are specified here or assigned during role mapping (below), user will not be able to perform any actions after authentication.
-- `role_mapping` — Section with LDAP search parameters and mapping rules.
-  - When a user authenticates, while still bound to LDAP, an LDAP search is performed using `search_filter` and the name of the logged-in user. For each entry found during that search, the value of the specified attribute is extracted. For each attribute value that has the specified prefix, the prefix is removed, and the rest of the value becomes the name of a local role defined in ClickHouse, which is expected to be created beforehand by the [CREATE ROLE](/sql-reference/statements/create/role) statement.
-  - There can be multiple `role_mapping` sections defined inside the same `ldap` section. All of them will be applied.
-    - `base_dn` — Template used to construct the base DN for the LDAP search.
-      - The resulting DN will be constructed by replacing all `{user_name}`, `{bind_dn}`, and `{user_dn}` substrings of the template with the actual user name, bind DN, and user DN during each LDAP search.
-    - `scope` — Scope of the LDAP search.
-      - Accepted values are: `base`, `one_level`, `children`, `subtree` (the default).
-    - `search_filter` — Template used to construct the search filter for the LDAP search.
-      - The resulting filter will be constructed by replacing all `{user_name}`, `{bind_dn}`, `{user_dn}`, and `{base_dn}` substrings of the template with the actual user name, bind DN, user DN, and base DN during each LDAP search.
-      - Note, that the special characters must be escaped properly in XML.
-    - `attribute` — Attribute name whose values will be returned by the LDAP search. `cn`, by default.
-    - `prefix` — Prefix, that will be expected to be in front of each string in the original list of strings returned by the LDAP search. The prefix will be removed from the original strings and the resulting strings will be treated as local role names. Empty by default.
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `server` | — | One of LDAP server names defined in the `ldap_servers` config section above. This parameter is mandatory and cannot be empty. |
+| `roles` | — | Section with a list of locally defined roles that will be assigned to each user retrieved from the LDAP server. If no roles are specified here or assigned during role mapping (below), user will not be able to perform any actions after authentication. |
+
+**`role_mapping` sub-parameters**
+
+Section with LDAP search parameters and mapping rules. When a user authenticates, while still bound to LDAP, an LDAP search is performed using `search_filter` and the name of the logged-in user. For each entry found during that search, the value of the specified attribute is extracted. For each attribute value that has the specified prefix, the prefix is removed, and the rest of the value becomes the name of a local role defined in ClickHouse, which is expected to be created beforehand by the [CREATE ROLE](/sql-reference/statements/create/role) statement. There can be multiple `role_mapping` sections defined inside the same `ldap` section. All of them will be applied.
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `base_dn` | — | Template used to construct the base DN for the LDAP search. The resulting DN will be constructed by replacing all `{user_name}`, `{bind_dn}`, and `{user_dn}` substrings of the template with the actual user name, bind DN, and user DN during each LDAP search. |
+| `scope` | `subtree` | Scope of the LDAP search. Accepted values: `base`, `one_level`, `children`, `subtree`. |
+| `search_filter` | — | Template used to construct the search filter for the LDAP search. The resulting filter will be constructed by replacing all `{user_name}`, `{bind_dn}`, `{user_dn}`, and `{base_dn}` substrings of the template with the actual user name, bind DN, user DN, and base DN during each LDAP search. Note that special characters must be escaped properly in XML. |
+| `attribute` | `cn` | Attribute name whose values will be returned by the LDAP search. |
+| `prefix` | empty | Prefix expected in front of each string in the original list of strings returned by the LDAP search. The prefix will be removed from the original strings and the resulting strings will be treated as local role names. |


### PR DESCRIPTION
## Summary
- Document three missing LDAP server definition parameters: `auth_dn_prefix`, `auth_dn_suffix` (deprecated alternatives to `bind_dn`), and `search_limit` (max LDAP search results, default `256`).
- Reorganize parameter lists in both the LDAP server definition and LDAP external user directory sections from nested bullet lists into tables with Parameter / Default / Description columns for easier scanning.

Closes https://github.com/ClickHouse/clickhouse-docs/issues/2302

### Changelog category:
- Documentation (changelog entry is not required)

### Changelog entry:
Add missing `auth_dn_prefix`, `auth_dn_suffix`, and `search_limit` parameters to the LDAP configuration documentation and reorganize parameter lists as tables.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that add/clarify LDAP configuration parameters and restructure the page; no runtime behavior is modified.
> 
> **Overview**
> Updates `docs/en/operations/external-authenticators/ldap.md` to **document previously missing LDAP server definition parameters**: deprecated `auth_dn_prefix`/`auth_dn_suffix` (as alternatives to `bind_dn`) and `search_limit` (default `256`).
> 
> Reformats the LDAP server definition and LDAP external user directory parameter sections from nested bullet lists into **scan-friendly tables** (including dedicated tables for `user_dn_detection` and `role_mapping` sub-parameters) with explicit defaults and clearer descriptions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit edb693e7efcb866a841c114b579cf5b8075f36fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->