### PR TITLE
Fix test test_storage_delta/test.py::test_struct_dotted_field_names

### DIFF
--- a/tests/integration/test_storage_delta/test.py
+++ b/tests/integration/test_storage_delta/test.py
@@ -4701,13 +4701,13 @@ def test_struct_dotted_field_names(started_cluster):
     table_function2 = f"deltaLakeLocal('{path2}')"
 
     result2_d2 = instance.query(f"SELECT d2.inner.`a.foo` FROM {table_function2}").strip()
-    assert result2_d2 == "afoo2", f"Unexpected d2.inner.`a.foo` result: {result_d2!r}"
+    assert result2_d2 == "afoo2", f"Unexpected d2.inner.`a.foo` result: {result2_d2!r}"
 
     result2_d3 = instance.query(f"SELECT d3.l2.l3.`a.foo` FROM {table_function2}").strip()
-    assert result2_d3 == "afoo3", f"Unexpected d3.l2.l3.`a.foo` result: {result_d3!r}"
+    assert result2_d3 == "afoo3", f"Unexpected d3.l2.l3.`a.foo` result: {result2_d3!r}"
 
     result2_d4 = instance.query(f"SELECT d4.l2.l3.l4.`a.foo` FROM {table_function2}").strip()
-    assert result2_d4 == "afoo4", f"Unexpected d4.l2.l3.l4.`a.foo` result: {result_d4!r}"
+    assert result2_d4 == "afoo4", f"Unexpected d4.l2.l3.l4.`a.foo` result: {result2_d4!r}"
 
 
 def test_snapshot_consistency(started_cluster):

--- a/tests/integration/test_storage_delta/test.py
+++ b/tests/integration/test_storage_delta/test.py
@@ -4700,13 +4700,13 @@ def test_struct_dotted_field_names(started_cluster):
 
     table_function2 = f"deltaLakeLocal('{path2}')"
 
-    result2_d2 = instance.query(f"SELECT d2.inner.`a.foo` FROM {table_function}").strip()
+    result2_d2 = instance.query(f"SELECT d2.inner.`a.foo` FROM {table_function2}").strip()
     assert result2_d2 == "afoo2", f"Unexpected d2.inner.`a.foo` result: {result_d2!r}"
 
-    result2_d3 = instance.query(f"SELECT d3.l2.l3.`a.foo` FROM {table_function}").strip()
+    result2_d3 = instance.query(f"SELECT d3.l2.l3.`a.foo` FROM {table_function2}").strip()
     assert result2_d3 == "afoo3", f"Unexpected d3.l2.l3.`a.foo` result: {result_d3!r}"
 
-    result2_d4 = instance.query(f"SELECT d4.l2.l3.l4.`a.foo` FROM {table_function}").strip()
+    result2_d4 = instance.query(f"SELECT d4.l2.l3.l4.`a.foo` FROM {table_function2}").strip()
     assert result2_d4 == "afoo4", f"Unexpected d4.l2.l3.l4.`a.foo` result: {result_d4!r}"
 
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that corrects a copy/paste mistake in integration assertions; no production code paths are modified.
> 
> **Overview**
> Fixes `test_struct_dotted_field_names` to query the *second* local Delta table (`table_function2`) when validating deep sub-field access, instead of accidentally reusing the first table function.
> 
> This also corrects assertion failure messages to reference the right result variables, reducing false failures and improving debuggability of the regression test.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 73eccb90cf87e7e497cabeb187b1937bf1e8a3e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.558`
<!-- ch-version-info:end -->