### PR TITLE
Try not to re-caclculate indexes in requestReadingInOrder

### DIFF
--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -2742,10 +2742,14 @@ bool ReadFromMergeTree::requestReadingInOrder(size_t prefix_size, int direction,
 
     updateSortDescription();
 
-    /// Re-calculate analysis result to have correct read_type
+    /// Set correct read_type
     /// For some reason for projection it breaks aggregation in order, so skip it
     if (analyzed_result_ptr && !analyzed_result_ptr->readFromProjection())
-        selectRangesToRead();
+    {
+        analyzed_result_ptr->read_type = (query_info.input_order_info->direction > 0)
+            ? ReadType::InOrder
+            : ReadType::InReverseOrder;
+    }
 
     return true;
 }


### PR DESCRIPTION
### Changelog category (leave one):

- Bug Fix

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

* Skip unnecessary extra index analysis when read-in-order optimization is applied.

Followup for https://github.com/ClickHouse/ClickHouse/pull/89815

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `ReadFromMergeTree::requestReadingInOrder` to stop calling `selectRangesToRead()`, which could affect how previously-computed analysis results are reused and thus impact read-order execution behavior if assumptions are wrong.
> 
> **Overview**
> Avoids re-running index/range selection when switching a `ReadFromMergeTree` step to read-in-order.
> 
> Instead of calling `selectRangesToRead()` to recompute analysis, `requestReadingInOrder()` now directly updates the existing `AnalysisResult::read_type` (when present and not reading from a projection) based on the requested sort direction.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1dcc299c5ed4577ddf878bf2b25716197105f548. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.555`
- Backported to: `26.2.5.14`, `26.1.5.22`, `25.12.9.24`
<!-- ch-version-info:end -->