### PR TITLE
Fix crash on memory limit happened while applying patches

### DIFF
--- a/src/Storages/MergeTree/PatchParts/PatchJoinCache.cpp
+++ b/src/Storages/MergeTree/PatchParts/PatchJoinCache.cpp
@@ -7,6 +7,7 @@
 
 #include <Common/ThreadPool.h>
 #include <Common/ProfileEvents.h>
+#include <Common/FailPoint.h>
 #include <Columns/ColumnsNumber.h>
 #include <Common/ElapsedTimeProfileEventIncrement.h>
 
@@ -190,6 +191,11 @@ std::vector<std::shared_future<void>> PatchJoinCache::Entry::addRangesAsync(cons
         futures.clear();
         std::lock_guard lock(mutex);
 
+        /// A previous call to addBlock on this entry may have failed, leaving
+        /// hash_map in an inconsistent state. Bail out before doing more work.
+        if (error)
+            std::rethrow_exception(error);
+
         for (const auto & range : ranges)
         {
             auto it = ranges_futures.find(range);
@@ -253,6 +259,11 @@ void PatchJoinCache::Entry::addBlock(Block read_block)
 
     std::lock_guard lock(mutex);
 
+    /// If a previous addBlock call failed with an exception, the hash_map may be in an
+    /// inconsistent state. Refuse to touch it — re-throw the original error instead.
+    if (error)
+        std::rethrow_exception(error);
+
 #ifdef DEBUG_OR_SANITIZER_BUILD
     for (const auto & block : blocks)
         assertCompatibleHeader(*block_with_data, *block, "patch join cache");
@@ -277,45 +288,55 @@ void PatchJoinCache::Entry::addBlock(Block read_block)
     /// to optimize the insertion. It gives average complexity of O(1) instead of O(log n).
     PatchOffsetsMap::const_iterator last_inserted_it;
 
-    for (size_t i = 0; i < num_read_rows; ++i)
+    try
     {
-        UInt64 block_number = block_number_column[i];
-        UInt64 block_offset = block_offset_column[i];
-
-        if (block_number != prev_block_number)
+        for (size_t i = 0; i < num_read_rows; ++i)
         {
-            prev_block_number = block_number;
-            current_offsets = &hash_map[block_number];
+            UInt64 block_number = block_number_column[i];
+            UInt64 block_offset = block_offset_column[i];
 
-            min_block = std::min(min_block, block_number);
-            max_block = std::max(max_block, block_number);
-            last_inserted_it = current_offsets->end();
-        }
+            if (block_number != prev_block_number)
+            {
+                prev_block_number = block_number;
+                current_offsets = &hash_map[block_number];
 
-        /// try_emplace overload with hint doesn't return 'inserted' flag,
-        /// so we need to check size before and after emplace.
-        size_t old_size = current_offsets->size();
-        auto it = current_offsets->try_emplace(last_inserted_it, block_offset);
-        last_inserted_it = it;
-        bool inserted = current_offsets->size() > old_size;
+                min_block = std::min(min_block, block_number);
+                max_block = std::max(max_block, block_number);
+                last_inserted_it = current_offsets->end();
+            }
 
-        if (inserted)
-        {
-            it->second = std::make_pair(static_cast<UInt32>(new_block_idx), static_cast<UInt32>(i));
-        }
-        else
-        {
-            const auto & [patch_block_index, patch_row_index] = it->second;
-            const auto & existing_version_column = blocks[patch_block_index]->getByPosition(version_column_position).column;
+            /// try_emplace overload with hint doesn't return 'inserted' flag,
+            /// so we need to check size before and after emplace.
+            size_t old_size = current_offsets->size();
+            auto it = current_offsets->try_emplace(last_inserted_it, block_offset);
+            last_inserted_it = it;
+            bool inserted = current_offsets->size() > old_size;
 
-            UInt64 current_version = data_version_column[i];
-            UInt64 existing_version = assert_cast<const ColumnUInt64 &>(*existing_version_column).getData()[patch_row_index];
-            chassert(current_version != existing_version);
-
-            /// Keep only the row with the highest version.
-            if (current_version > existing_version)
+            if (inserted)
+            {
                 it->second = std::make_pair(static_cast<UInt32>(new_block_idx), static_cast<UInt32>(i));
+            }
+            else
+            {
+                const auto & [patch_block_index, patch_row_index] = it->second;
+                const auto & existing_version_column = blocks[patch_block_index]->getByPosition(version_column_position).column;
+
+                UInt64 current_version = data_version_column[i];
+                UInt64 existing_version = assert_cast<const ColumnUInt64 &>(*existing_version_column).getData()[patch_row_index];
+                chassert(current_version != existing_version);
+
+                /// Keep only the row with the highest version.
+                if (current_version > existing_version)
+                    it->second = std::make_pair(static_cast<UInt32>(new_block_idx), static_cast<UInt32>(i));
+            }
         }
+    }
+    catch (...)
+    {
+        /// Mark the entry as poisoned so that concurrent and future callers
+        /// do not touch the potentially corrupted hash_map.
+        error = std::current_exception();
+        throw;
     }
 }
 

--- a/src/Storages/MergeTree/PatchParts/PatchJoinCache.cpp
+++ b/src/Storages/MergeTree/PatchParts/PatchJoinCache.cpp
@@ -7,7 +7,6 @@
 
 #include <Common/ThreadPool.h>
 #include <Common/ProfileEvents.h>
-#include <Common/FailPoint.h>
 #include <Columns/ColumnsNumber.h>
 #include <Common/ElapsedTimeProfileEventIncrement.h>
 
@@ -170,6 +169,7 @@ std::vector<std::shared_future<void>> PatchJoinCache::Entry::addRangesAsync(cons
         /// Firstly lookup with read lock, because all needed ranges are likely read already.
         std::shared_lock lock(mutex);
 
+
         for (const auto & range : ranges)
         {
             auto it = ranges_futures.find(range);
@@ -192,7 +192,7 @@ std::vector<std::shared_future<void>> PatchJoinCache::Entry::addRangesAsync(cons
         std::lock_guard lock(mutex);
 
         /// A previous call to addBlock on this entry may have failed, leaving
-        /// hash_map in an inconsistent state. Bail out before doing more work.
+        /// hash_map in an inconsistent state. Rethrow the original error.
         if (error)
             std::rethrow_exception(error);
 
@@ -259,8 +259,8 @@ void PatchJoinCache::Entry::addBlock(Block read_block)
 
     std::lock_guard lock(mutex);
 
-    /// If a previous addBlock call failed with an exception, the hash_map may be in an
-    /// inconsistent state. Refuse to touch it — re-throw the original error instead.
+    /// A previous call to addBlock on this entry may have failed, leaving
+    /// hash_map in an inconsistent state. Rethrow the original error.
     if (error)
         std::rethrow_exception(error);
 

--- a/src/Storages/MergeTree/PatchParts/PatchJoinCache.h
+++ b/src/Storages/MergeTree/PatchParts/PatchJoinCache.h
@@ -77,6 +77,7 @@ struct PatchJoinCache
 
         UInt64 min_block = std::numeric_limits<UInt64>::max();
         UInt64 max_block = 0;
+        std::exception_ptr error;
         mutable SharedMutex mutex;
 
         void addBlock(Block read_block);


### PR DESCRIPTION
<!-- Fixes issue link part, do not remove -->
## Linked issues
- fixes https://github.com/ClickHouse/clickhouse-core-incidents/issues/1431
<!-- End of fixes issue link part, do not remove -->

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a crash triggered by a memory limit exception thrown during patch part application.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches concurrency and failure-handling around shared cached state; while localized, mistakes could cause new deadlocks or propagate exceptions more broadly during patch application.
> 
> **Overview**
> Fixes a crash when an exception (e.g., memory limit) occurs while building the patch join cache by *poisoning* the affected `PatchJoinCache::Entry`.
> 
> `Entry` now stores an `error` (`std::exception_ptr`); `addBlock()` records and rethrows on failure to prevent further mutations of a potentially corrupted `hash_map`, and both `addBlock()` and `addRangesAsync()` rethrow the stored error before doing any work so concurrent/future callers fail deterministically instead of continuing with inconsistent state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a622a7fd10bdcac9a0c8d9d19a77704cca0e0595. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.592`
- Backported to: `26.2.5.18`, `26.1.5.24`, `25.12.9.26`
<!-- ch-version-info:end -->