### PR TITLE
Fix segfault in system.iceberg_history when iterator returns null storage

### DIFF
--- a/src/Databases/DataLake/DatabaseDataLake.cpp
+++ b/src/Databases/DataLake/DatabaseDataLake.cpp
@@ -819,9 +819,12 @@ DatabaseTablesIteratorPtr DatabaseDataLake::getTablesIterator(
         if (filter_by_table_name && !filter_by_table_name(table_name))
             continue;
 
-        [[maybe_unused]] bool inserted = tables.emplace(table_name, futures[future_index].get()).second;
+        auto storage = futures[future_index++].get();
+        if (!storage)
+            continue;
+
+        [[maybe_unused]] bool inserted = tables.emplace(table_name, std::move(storage)).second;
         chassert(inserted);
-        future_index++;
     }
     return std::make_unique<DatabaseTablesSnapshotIterator>(tables, getDatabaseName());
 }

--- a/src/Storages/System/StorageSystemIcebergHistory.cpp
+++ b/src/Storages/System/StorageSystemIcebergHistory.cpp
@@ -27,11 +27,6 @@ static constexpr auto TIME_SCALE = 3;
 namespace DB
 {
 
-namespace ErrorCodes
-{
-    extern const int LOGICAL_ERROR;
-}
-
 namespace Setting
 {
     extern const SettingsSeconds lock_acquire_timeout;
@@ -105,7 +100,7 @@ void StorageSystemIcebergHistory::fillData([[maybe_unused]] MutableColumns & res
             {
                 StoragePtr storage = iterator->table();
                 if (!storage)
-                    throw Exception(ErrorCodes::LOGICAL_ERROR, "Database iterator returned nullptr for the table, which is a bug");
+                    continue;
 
                 TableLockHolder lock = storage->tryLockForShare(context_copy->getCurrentQueryId(), context_copy->getSettingsRef()[Setting::lock_acquire_timeout]);
                 if (!lock)

--- a/src/Storages/System/StorageSystemIcebergHistory.cpp
+++ b/src/Storages/System/StorageSystemIcebergHistory.cpp
@@ -1,5 +1,4 @@
 #include <Storages/System/StorageSystemIcebergHistory.h>
-#include <mutex>
 #include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypeMap.h>
@@ -100,6 +99,8 @@ void StorageSystemIcebergHistory::fillData([[maybe_unused]] MutableColumns & res
             for (auto iterator = db.second->getTablesIterator(context_copy, {}, true); iterator->isValid(); iterator->next())
             {
                 StoragePtr storage = iterator->table();
+                if (!storage)
+                    continue;
 
                 TableLockHolder lock = storage->tryLockForShare(context_copy->getCurrentQueryId(), context_copy->getSettingsRef()[Setting::lock_acquire_timeout]);
                 if (!lock)

--- a/src/Storages/System/StorageSystemIcebergHistory.cpp
+++ b/src/Storages/System/StorageSystemIcebergHistory.cpp
@@ -27,6 +27,11 @@ static constexpr auto TIME_SCALE = 3;
 namespace DB
 {
 
+namespace ErrorCodes
+{
+    extern const int LOGICAL_ERROR;
+}
+
 namespace Setting
 {
     extern const SettingsSeconds lock_acquire_timeout;
@@ -100,7 +105,7 @@ void StorageSystemIcebergHistory::fillData([[maybe_unused]] MutableColumns & res
             {
                 StoragePtr storage = iterator->table();
                 if (!storage)
-                    continue;
+                    throw Exception(ErrorCodes::LOGICAL_ERROR, "Database iterator returned nullptr for the table, which is a bug");
 
                 TableLockHolder lock = storage->tryLockForShare(context_copy->getCurrentQueryId(), context_copy->getSettingsRef()[Setting::lock_acquire_timeout]);
                 if (!lock)

--- a/src/Storages/System/StorageSystemObjectStorageQueueSettings.cpp
+++ b/src/Storages/System/StorageSystemObjectStorageQueueSettings.cpp
@@ -64,6 +64,8 @@ void StorageSystemObjectStorageQueueSettings<type>::fillData(
             for (auto iterator = db.second->getTablesIterator(context); iterator->isValid(); iterator->next())
             {
                 StoragePtr storage = iterator->table();
+                if (!storage)
+                    continue;
                 if (auto * queue_table = dynamic_cast<StorageObjectStorageQueue *>(storage.get()))
                 {
                     add_table(iterator, *queue_table);

--- a/src/Storages/System/StorageSystemObjectStorageQueueSettings.cpp
+++ b/src/Storages/System/StorageSystemObjectStorageQueueSettings.cpp
@@ -10,10 +10,16 @@
 #include <Storages/System/StorageSystemObjectStorageQueueSettings.h>
 #include <Access/SettingsConstraintsAndProfileIDs.h>
 #include <Storages/ObjectStorageQueue/StorageObjectStorageQueue.h>
+#include <Common/Exception.h>
 
 
 namespace DB
 {
+
+namespace ErrorCodes
+{
+    extern const int LOGICAL_ERROR;
+}
 
 template <ObjectStorageType type>
 ColumnsDescription StorageSystemObjectStorageQueueSettings<type>::getColumnsDescription()
@@ -65,7 +71,7 @@ void StorageSystemObjectStorageQueueSettings<type>::fillData(
             {
                 StoragePtr storage = iterator->table();
                 if (!storage)
-                    continue;
+                    throw Exception(ErrorCodes::LOGICAL_ERROR, "Database iterator returned nullptr for the table, which is a bug");
                 if (auto * queue_table = dynamic_cast<StorageObjectStorageQueue *>(storage.get()))
                 {
                     add_table(iterator, *queue_table);

--- a/src/Storages/System/StorageSystemObjectStorageQueueSettings.cpp
+++ b/src/Storages/System/StorageSystemObjectStorageQueueSettings.cpp
@@ -10,16 +10,10 @@
 #include <Storages/System/StorageSystemObjectStorageQueueSettings.h>
 #include <Access/SettingsConstraintsAndProfileIDs.h>
 #include <Storages/ObjectStorageQueue/StorageObjectStorageQueue.h>
-#include <Common/Exception.h>
 
 
 namespace DB
 {
-
-namespace ErrorCodes
-{
-    extern const int LOGICAL_ERROR;
-}
 
 template <ObjectStorageType type>
 ColumnsDescription StorageSystemObjectStorageQueueSettings<type>::getColumnsDescription()
@@ -71,7 +65,7 @@ void StorageSystemObjectStorageQueueSettings<type>::fillData(
             {
                 StoragePtr storage = iterator->table();
                 if (!storage)
-                    throw Exception(ErrorCodes::LOGICAL_ERROR, "Database iterator returned nullptr for the table, which is a bug");
+                    continue;
                 if (auto * queue_table = dynamic_cast<StorageObjectStorageQueue *>(storage.get()))
                 {
                     add_table(iterator, *queue_table);


### PR DESCRIPTION
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR

### Changelog entry:
Fixed a segfault when querying `system.iceberg_history`. `iterator->table()` can return a null `StoragePtr` for tables being dropped or not yet attached, and the null pointer was dereferenced without a check.

### What changed

`StorageSystemIcebergHistory::fillData` called `storage->tryLockForShare(...)` without first checking whether `iterator->table()` returned a non-null pointer, causing a segmentation fault (access at address `0x1c0`).

The same missing null check was fixed in `StorageSystemObjectStorageQueueSettings` where `dynamic_cast` was called on a potentially null pointer.

Both are now consistent with the pattern used across all other system tables (`StorageSystemPartsBase`, `StorageSystemDistributionQueue`, `StorageSystemGraphite`, etc.).

### Reproduction

```sql
SELECT * FROM system.iceberg_history;
-- Segmentation fault: 11
```

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk defensive changes that prevent segfaults when system tables iterate over databases while tables are being dropped or not yet attached. Behavior changes are limited to skipping null storages during iteration.
> 
> **Overview**
> Prevents crashes in system tables when `DatabaseTablesIterator::table()` returns a null `StoragePtr` (e.g., during concurrent drop/attach).
> 
> `system.iceberg_history` and `system.object_storage_queue_settings` now skip null storages before locking or `dynamic_cast`, and `DatabaseDataLake::getTablesIterator` similarly skips null results from async table-loading futures instead of inserting them into the snapshot.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d7f99c09b3f318fd50ba3f9ad1d094bd1916b80. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->