### PR TITLE
Properly return column stats from sub-queries with joins so that parent query can use them to join reordering

### DIFF
--- a/src/Processors/QueryPlan/JoinStepLogical.h
+++ b/src/Processors/QueryPlan/JoinStepLogical.h
@@ -11,6 +11,7 @@
 #include <Processors/QueryPlan/JoinStep.h>
 #include <Processors/QueryPlan/SortingStep.h>
 #include <Processors/QueryPlan/QueryPlan.h>
+#include <Storages/Statistics/ConditionSelectivityEstimator.h>
 #include <Core/Joins.h>
 #include <Interpreters/JoinExpressionActions.h>
 
@@ -134,12 +135,18 @@ public:
 
     bool isOptimized() const { return optimized; }
     std::optional<UInt64> getResultRowsEstimation() const { return result_rows_estimation; }
-    void setOptimized(std::optional<UInt64> estimated_rows_ = {}, std::optional<UInt64> left_rows_ = {}, std::optional<UInt64> right_rows_ = {})
+    const std::unordered_map<String, ColumnStats> & getResultColumnStats() const { return result_column_stats; }
+    void setOptimized(
+        std::optional<UInt64> estimated_rows_ = {},
+        std::optional<UInt64> left_rows_ = {},
+        std::optional<UInt64> right_rows_ = {},
+        std::unordered_map<String, ColumnStats> column_stats_ = {})
     {
         optimized = true;
         result_rows_estimation = estimated_rows_;
         left_rows_estimation = left_rows_;
         right_rows_estimation = right_rows_;
+        result_column_stats = std::move(column_stats_);
     }
 
     void setInputLabels(String left_table_label_, String right_table_label_)
@@ -195,6 +202,7 @@ protected:
     std::optional<UInt64> result_rows_estimation = {};
     std::optional<UInt64> left_rows_estimation = {};
     std::optional<UInt64> right_rows_estimation = {};
+    std::unordered_map<String, ColumnStats> result_column_stats = {};
     UInt64 right_hash_table_cache_key = 0;
 
     String left_table_label;

--- a/src/Processors/QueryPlan/Optimizations/joinOrder.cpp
+++ b/src/Processors/QueryPlan/Optimizations/joinOrder.cpp
@@ -36,10 +36,11 @@ namespace ErrorCodes
     extern const int EXPERIMENTAL_FEATURE_ERROR;
 }
 
-DPJoinEntry::DPJoinEntry(size_t id, std::optional<UInt64> rows)
+DPJoinEntry::DPJoinEntry(size_t id, std::optional<UInt64> rows, std::unordered_map<String, ColumnStats> column_stats_)
     : relations()
     , cost(0.0)
     , estimated_rows(rows)
+    , column_stats(std::move(column_stats_))
     , relation_id(static_cast<int>(id))
 {
     relations.set(id);
@@ -59,6 +60,40 @@ DPJoinEntry::DPJoinEntry(DPJoinEntryPtr lhs,
     , join_operator(std::move(join_operator_))
     , join_method(join_method_)
 {
+    /// Merge column stats from both children, then update NDVs for equi-join key columns.
+    column_stats = left->column_stats;
+    column_stats.insert(right->column_stats.begin(), right->column_stats.end());
+
+    for (const auto & predicate : join_operator.expression)
+    {
+        auto [op, left_node, right_node] = predicate.asBinaryPredicate();
+        if (op != JoinConditionOperator::Equals)
+            continue;
+
+        if (left_node.fromRight() && right_node.fromLeft())
+            std::swap(left_node, right_node);
+        if (!left_node.fromLeft() || !right_node.fromRight())
+            continue;
+
+        const auto & left_col = left_node.getColumnName();
+        const auto & right_col = right_node.getColumnName();
+        auto left_it = column_stats.find(left_col);
+        auto right_it = column_stats.find(right_col);
+
+        if (left_it != column_stats.end() && right_it != column_stats.end())
+        {
+            UInt64 min_ndv = std::min(left_it->second.num_distinct_values, right_it->second.num_distinct_values);
+            left_it->second.num_distinct_values = min_ndv;
+            right_it->second.num_distinct_values = min_ndv;
+        }
+    }
+
+    /// Cap all NDVs at the estimated output rows.
+    if (cardinality_)
+    {
+        for (auto & [_, stats] : column_stats)
+            stats.num_distinct_values = std::min(stats.num_distinct_values, *cardinality_);
+    }
 }
 
 bool DPJoinEntry::isLeaf() const { return !left && !right; }
@@ -130,15 +165,20 @@ size_t JoinOrderOptimizer::getColumnStats(BitSet rels, const String & column_nam
     auto rel_id = rels.getSingleBit();
     if (!rel_id.has_value())
     {
-        /// Assume all keys are distinct
+        /// Look up NDV from the dp_table entry's column_stats (propagated through joins).
         if (auto it = dp_table.find(rels); it != dp_table.end())
+        {
+            auto col_it = it->second->column_stats.find(column_name);
+            if (col_it != it->second->column_stats.end())
+                return col_it->second.num_distinct_values;
             return it->second->estimated_rows.value_or(0);
+        }
         return 0;
     }
 
     const auto & relation_stat = relation_stats.at(rel_id.value());
-    const auto & column_stats = relation_stat.column_stats;
-    if (auto it = column_stats.find(column_name); it != column_stats.end())
+    const auto & col_stats = relation_stat.column_stats;
+    if (auto it = col_stats.find(column_name); it != col_stats.end())
         return it->second.num_distinct_values;
     return relation_stat.estimated_rows.value_or(0);
 }
@@ -286,7 +326,7 @@ std::shared_ptr<DPJoinEntry> JoinOrderOptimizer::solveGreedy()
     for (size_t i = 0; i < query_graph.relation_stats.size(); ++i)
     {
         const auto & rel = query_graph.relation_stats[i];
-        components.push_back(std::make_shared<DPJoinEntry>(i, rel.estimated_rows));
+        components.push_back(std::make_shared<DPJoinEntry>(i, rel.estimated_rows, rel.column_stats));
     }
 
     std::vector<JoinActionRef *> applied_edge;
@@ -417,7 +457,7 @@ std::shared_ptr<DPJoinEntry> JoinOrderOptimizer::solveDPsize()
     for (size_t i = 0; i < total_relations_count; ++i)
     {
         const auto & rel = query_graph.relation_stats[i];
-        auto entry = std::make_shared<DPJoinEntry>(i, rel.estimated_rows);
+        auto entry = std::make_shared<DPJoinEntry>(i, rel.estimated_rows, rel.column_stats);
         components[1][entry->relations] = entry;
         dp_table[entry->relations] = entry;
     }

--- a/src/Processors/QueryPlan/Optimizations/joinOrder.h
+++ b/src/Processors/QueryPlan/Optimizations/joinOrder.h
@@ -28,6 +28,7 @@ struct DPJoinEntry
 
     double cost = 0.0;
     std::optional<UInt64> estimated_rows = {};
+    std::unordered_map<String, ColumnStats> column_stats = {};
 
     /// For join nodes
     JoinOperator join_operator;
@@ -37,7 +38,7 @@ struct DPJoinEntry
     int relation_id = -1;
 
     /// Constructor for a leaf node (base relation)
-    explicit DPJoinEntry(size_t id, std::optional<UInt64> rows);
+    DPJoinEntry(size_t id, std::optional<UInt64> rows, std::unordered_map<String, ColumnStats> column_stats_ = {});
 
     /// Constructor for a join node
     DPJoinEntry(DPJoinEntryPtr lhs,

--- a/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
@@ -309,7 +309,7 @@ RelationStats estimateReadRowsCount(QueryPlan::Node & node, const ActionsDAG::No
     {
         return RelationStats{
             .estimated_rows = join_step->getResultRowsEstimation(),
-            .column_stats = {},
+            .column_stats = join_step->getResultColumnStats(),
             .table_name = join_step->getReadableRelationName()};
     }
 
@@ -576,22 +576,40 @@ size_t addChildQueryGraph(QueryGraphBuilder & graph, QueryPlan::Node * node, Que
     if (isTrivialStep(node))
         node = node->children[0];
 
-    auto * child_join_step = typeid_cast<JoinStepLogical *>(node->step.get());
-    if (child_join_step && !child_join_step->isOptimized())
     {
-        auto child_join_kind = child_join_step->getJoinOperator().kind;
-        bool allow_child_join_kind = isInnerOrCross(child_join_kind) || isLeft(child_join_kind) || isRight(child_join_kind);
-        allow_child_join_kind = allow_child_join_kind && child_join_step->getJoinOperator().strictness == JoinStrictness::All;
-        if (graph.hasCompatibleSettings(*child_join_step) && join_steps_limit > 1 && allow_child_join_kind)
+        auto * child_join_step = typeid_cast<JoinStepLogical *>(node->step.get());
+        if (child_join_step && !child_join_step->isOptimized())
         {
-            QueryGraphBuilder child_graph(graph.context);
-            buildQueryGraph(child_graph, *node, nodes, join_steps_limit);
-            size_t count = child_graph.inputs.size();
-            uniteGraphs(graph, std::move(child_graph));
-            return count;
+            auto child_join_kind = child_join_step->getJoinOperator().kind;
+            bool allow_child_join_kind = isInnerOrCross(child_join_kind) || isLeft(child_join_kind) || isRight(child_join_kind);
+            allow_child_join_kind = allow_child_join_kind && child_join_step->getJoinOperator().strictness == JoinStrictness::All;
+            if (graph.hasCompatibleSettings(*child_join_step) && join_steps_limit > 1 && allow_child_join_kind)
+            {
+                QueryGraphBuilder child_graph(graph.context);
+                buildQueryGraph(child_graph, *node, nodes, join_steps_limit);
+                size_t count = child_graph.inputs.size();
+                uniteGraphs(graph, std::move(child_graph));
+                return count;
+            }
+            /// Optimize child subplan before continuing to get size estimation
+            optimizeJoinLogicalImpl(child_join_step, *node, nodes, graph.context->optimization_settings);
         }
-        /// Optimize child subplan before continuing to get size estimation
-        optimizeJoinLogicalImpl(child_join_step, *node, nodes, graph.context->optimization_settings);
+    }
+
+    /// When the leaf is a subquery with Join-s wrapped in Expression/Aggregating steps, we cannot Joins to the graph, but we want to optimize
+    /// those child Join to get proper statistics to use in the parent Join reordering.
+    {
+        auto * child_node = node;
+        while (child_node->children.size() == 1)
+        {
+            child_node = child_node->children[0];
+        }
+
+        auto * child_join_step = typeid_cast<JoinStepLogical *>(child_node->step.get());
+        if (child_join_step && !child_join_step->isOptimized())
+        {
+            optimizeJoinLogicalImpl(child_join_step, *child_node, nodes, graph.context->optimization_settings);
+        }
     }
 
     graph.inputs.push_back(node);
@@ -1132,7 +1150,7 @@ QueryPlan::Node chooseJoinOrder(QueryGraphBuilder query_graph_builder, QueryPlan
             join_step->setInputLabels(std::move(left_label), std::move(right_label));
             relation_names[entry->relations] = join_step->getReadableRelationName();
 
-            join_step->setOptimized(entry->estimated_rows, lhs_estimation, rhs_estimation);
+            join_step->setOptimized(entry->estimated_rows, lhs_estimation, rhs_estimation, entry->column_stats);
 
             auto right_table_key = query_graph_builder.context->statistics_context.getCachedKey(right_child_node);
             if (right_table_key)

--- a/tests/queries/0_stateless/03545_analyzer_correlated_subquery_exists_asterisk.reference
+++ b/tests/queries/0_stateless/03545_analyzer_correlated_subquery_exists_asterisk.reference
@@ -10,7 +10,7 @@ Positions: 2
     Join (JOIN FillRightFirst)
     Type: LEFT
     Strictness: SEMI
-    Algorithm: ConcurrentHashJoin
+    Algorithm: HashJoin
     Clauses: [(__table1.i1) = (exists(__table2).__table1.i1)]
       Expression (Left Pre Join Actions)
       Actions: INPUT :: 0 -> __table1.i1 Int64 : 0

--- a/tests/queries/0_stateless/03837_subquery_ndv_propagation_join_order.reference
+++ b/tests/queries/0_stateless/03837_subquery_ndv_propagation_join_order.reference
@@ -1,0 +1,14 @@
+  JoinLogical
+  Join: sq[50000] ⋈ pc[300] ⋈ rs[200]
+  ResultRows: 60000
+    JoinLogical
+    Join: sq[50000] ⋈ pc[300]
+    ResultRows: 1500
+        Aggregating
+            JoinLogical
+            Join: s[50000] ⋈ p[10000]
+            ResultRows: 50000
+                ReadFromMergeTree (default.test_sales)
+                ReadFromMergeTree (default.test_partners)
+        ReadFromMergeTree (default.test_product_catalog)
+      ReadFromMergeTree (default.test_region_subsidies)

--- a/tests/queries/0_stateless/03837_subquery_ndv_propagation_join_order.sql
+++ b/tests/queries/0_stateless/03837_subquery_ndv_propagation_join_order.sql
@@ -56,10 +56,12 @@ OPTIMIZE TABLE test_product_catalog FINAL;
 
 SET enable_analyzer = 1;
 SET allow_statistic_optimize = 1;
+SET enable_parallel_replicas = 0;
 SET query_plan_optimize_join_order_limit = 10;
 SET query_plan_optimize_join_order_algorithm = 'dpsize,greedy';
 SET query_plan_join_swap_table = 0;
 SET enable_join_runtime_filters = 0;
+
 
 -- This query join order depends on whether statts for product_id (NDV=10K) and region_id (NDV=5) are properly propagated from subquery
 SELECT explain FROM

--- a/tests/queries/0_stateless/03837_subquery_ndv_propagation_join_order.sql
+++ b/tests/queries/0_stateless/03837_subquery_ndv_propagation_join_order.sql
@@ -1,0 +1,83 @@
+SET allow_experimental_statistics = 1;
+
+DROP TABLE IF EXISTS test_sales;
+DROP TABLE IF EXISTS test_partners;
+DROP TABLE IF EXISTS test_region_subsidies;
+DROP TABLE IF EXISTS test_product_catalog;
+
+CREATE TABLE test_sales (
+    sale_id UInt64,
+    product_id UInt64 STATISTICS(uniq),
+    region_id UInt32 STATISTICS(uniq),
+    amount Float64
+) ENGINE = MergeTree ORDER BY sale_id;
+
+CREATE TABLE test_partners (
+    product_id UInt64 STATISTICS(uniq),
+    partner_name String
+) ENGINE = MergeTree ORDER BY product_id;
+
+CREATE TABLE test_region_subsidies (
+    region_id UInt32 STATISTICS(uniq),
+    subsidy_type String,
+    subsidy_amount Float64
+) ENGINE = MergeTree ORDER BY region_id;
+
+CREATE TABLE test_product_catalog (
+    product_id UInt64 STATISTICS(uniq),
+    catalog_info String
+) ENGINE = MergeTree ORDER BY product_id;
+
+-- sales: 50K rows, region_id NDV=5, product_id NDV=10K
+INSERT INTO test_sales
+    SELECT number, (number % 10000) + 1, (number % 5) + 1, number * 1.5
+    FROM numbers(50000);
+
+-- partners: 10K rows, product_id NDV=10K
+INSERT INTO test_partners
+    SELECT number + 1, concat('partner_', toString(number))
+    FROM numbers(10000);
+
+-- region_subsidies: 200 rows, region_id NDV=5 (40 per region)
+INSERT INTO test_region_subsidies
+    SELECT (number % 5) + 1, concat('subsidy_', toString(number)), number * 100.0
+    FROM numbers(200);
+
+-- product_catalog: 300 rows, product_id NDV=300
+INSERT INTO test_product_catalog
+    SELECT number + 1, concat('catalog_', toString(number))
+    FROM numbers(300);
+
+-- Merge parts to materialize column statistics
+OPTIMIZE TABLE test_sales FINAL;
+OPTIMIZE TABLE test_partners FINAL;
+OPTIMIZE TABLE test_region_subsidies FINAL;
+OPTIMIZE TABLE test_product_catalog FINAL;
+
+SET enable_analyzer = 1;
+SET allow_statistic_optimize = 1;
+SET query_plan_optimize_join_order_limit = 10;
+SET query_plan_optimize_join_order_algorithm = 'dpsize,greedy';
+SET query_plan_join_swap_table = 0;
+SET enable_join_runtime_filters = 0;
+
+-- This query join order depends on whether statts for product_id (NDV=10K) and region_id (NDV=5) are properly propagated from subquery
+SELECT explain FROM
+(
+EXPLAIN keep_logical_steps=1, actions=1
+SELECT sq.region_id, rs.subsidy_type, sq.product_id, sq.total_amount, pc.catalog_info
+FROM (
+    SELECT s.region_id, s.product_id, sum(s.amount) AS total_amount
+    FROM test_sales s
+    JOIN test_partners p ON s.product_id = p.product_id
+    GROUP BY s.region_id, s.product_id
+) sq
+JOIN test_region_subsidies rs ON sq.region_id = rs.region_id
+JOIN test_product_catalog pc ON sq.product_id = pc.product_id
+)
+WHERE explain LIKE '% Join%' OR explain LIKE '% ResultRows:%' OR explain LIKE '% ReadFromMergeTree%' OR explain LIKE '% Aggregating%';
+
+DROP TABLE test_sales;
+DROP TABLE test_partners;
+DROP TABLE test_region_subsidies;
+DROP TABLE test_product_catalog;


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Properly return column stats from sub-queries with joins so that parent query can use them for join reordering.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes join-order optimization to carry and update per-column NDV statistics across joined subplans, which can alter chosen join orders/algorithms and impact performance characteristics.
> 
> **Overview**
> **Join-order optimization now propagates column statistics.** `JoinStepLogical` stores and exposes `result_column_stats`, and `optimizeJoin` returns these stats when an optimized logical join is used as an input to higher-level planning.
> 
> **DP join enumeration carries NDVs through join trees.** `DPJoinEntry` now tracks `column_stats`, merges child stats when building join nodes, normalizes NDVs for equi-join keys, and caps NDVs by estimated output rows; selectivity estimation for multi-relation components now consults these propagated stats.
> 
> **Subquery joins are optimized for stats even when not flattened into the query graph.** `addChildQueryGraph` additionally optimizes nested `JoinStepLogical` nodes hidden under single-child wrappers to ensure their stats feed parent join reordering, with updated/added stateless tests covering the new behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 607070210d48036cdfe476268ad0ba7fa9304144. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.622`
<!-- ch-version-info:end -->