### PR TITLE
Optimise `INTERSECT ALL` and `EXCEPT ALL`

### DIFF
--- a/src/Processors/Transforms/IntersectOrExceptTransform.cpp
+++ b/src/Processors/Transforms/IntersectOrExceptTransform.cpp
@@ -211,19 +211,13 @@ void IntersectOrExceptTransform::filter(Chunk & chunk)
             auto key = hashRow(column_ptrs, i);
             auto * it = counts.find(key);
 
-            if (it != nullptr && it->getMapped() > 0)
-            {
+            /// Check if this row has remaining occurrences in the right side.
+            bool matched = (it != nullptr && it->getMapped() > 0);
+            if (matched)
                 --it->getMapped();
-                /// EXCEPT ALL: found in right side, exclude this row.
-                /// INTERSECT ALL: found in right side, include this row.
-                row_filter[i] = is_except ? 0 : 1;
-            }
-            else
-            {
-                /// EXCEPT ALL: not in right side, include this row.
-                /// INTERSECT ALL: not in right side, exclude this row.
-                row_filter[i] = is_except ? 1 : 0;
-            }
+
+            /// EXCEPT ALL keeps unmatched rows; INTERSECT ALL keeps matched rows.
+            row_filter[i] = matched != is_except;
 
             if (row_filter[i])
                 ++new_rows_num;

--- a/src/Processors/Transforms/IntersectOrExceptTransform.cpp
+++ b/src/Processors/Transforms/IntersectOrExceptTransform.cpp
@@ -1,5 +1,6 @@
 #include <Processors/Port.h>
 #include <Processors/Transforms/IntersectOrExceptTransform.h>
+#include <Common/SipHash.h>
 
 namespace DB
 {

--- a/src/Processors/Transforms/IntersectOrExceptTransform.h
+++ b/src/Processors/Transforms/IntersectOrExceptTransform.h
@@ -5,7 +5,6 @@
 #include <Interpreters/SetVariants.h>
 #include <Core/ColumnNumbers.h>
 #include <Common/HashTable/HashMap.h>
-#include <Common/SipHash.h>
 #include <Parsers/ASTSelectIntersectExceptQuery.h>
 
 


### PR DESCRIPTION
... by removing branches.

```sql
SELECT count()
FROM
(
    SELECT bitAnd(number, 65535) AS x FROM numbers(100000000)
    EXCEPT ALL
    SELECT bitAnd(rand64(), 65535) AS x FROM numbers(100000000)
)
```

Before: `Elapsed: 11.826 sec`
After: `Elapsed: 10.207 sec`

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Optimise `INTERSECT ALL` and `EXCEPT ALL`



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.554`
<!-- ch-version-info:end -->