### PR TITLE
Mark ZooKeeper session expired before joining send thread in finalize()

### DIFF
--- a/src/Common/ZooKeeper/ZooKeeperImpl.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperImpl.cpp
@@ -1242,17 +1242,27 @@ void ZooKeeper::finalize(bool error_send, bool error_receive, const String & rea
             catch (...)
             {
                 /// This happens for example, when "Cannot push request to queue within operation timeout".
-                /// Just mark session expired in case of error on close request, otherwise sendThread may not stop.
-                expire_session_if_not_expired();
                 tryLogCurrentException(log);
             }
-
-            /// Send thread will exit after sending close request or on expired flag
-            send_thread.join();
         }
 
-        /// Set expired flag after we sent close event
+        /// Mark session expired before joining send thread.
+        /// This is critical: isExpired() (which checks requests_queue.isFinished()) must return true
+        /// as soon as possible so that other threads calling getZooKeeper() can establish a new session
+        /// immediately, rather than waiting for the send thread to exit. The send thread may be blocked
+        /// in a socket write for minutes (e.g. if the Keeper server closed the connection but
+        /// SO_SNDTIMEO is ineffective due to signal interruptions resetting the timer — see #96601).
+        /// Without this, all Keeper-dependent operations hang until the send thread happens to unblock.
         expire_session_if_not_expired();
+
+        if (!error_send)
+        {
+            /// Send thread will exit because:
+            /// 1. requests_queue is now finished (checked in sendThread's while loop), or
+            /// 2. The close request was sent and close_xid breaks the loop, or
+            /// 3. The socket write fails with an error
+            send_thread.join();
+        }
 
         cancelWriteBuffer();
 

--- a/src/Common/ZooKeeper/ZooKeeperImpl.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperImpl.cpp
@@ -852,7 +852,7 @@ void ZooKeeper::sendThread()
                         operations[info.request->xid] = info;
                     }
 
-                    if (requests_queue.isFinished())
+                    if (requests_queue.isFinished() && info.request->xid != close_xid)
                     {
                         break;
                     }


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Mark ZooKeeper session as expired immediately when finalization starts, instead of waiting for the send thread to exit. This allows other threads to establish a new session without delay.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

---

**Problem:**

In `ZooKeeper::finalize()`, `expire_session_if_not_expired()` (which calls `requests_queue.finish()`) was called **after** `send_thread.join()`. The `isExpired()` method checks `requests_queue.isFinished()`, so until the send thread exited, all callers of `isExpired()` — including `Context::getZooKeeper()` — saw the session as "not expired" and kept returning the dying session.

If the send thread was blocked in a socket write (which can happen for extended periods when `SO_SNDTIMEO` is ineffective due to signal interruptions resetting the timer — see #96601), `finalize()` would block in `send_thread.join()` for minutes. During this time, no thread could establish a new ZK session, causing all Keeper-dependent operations to hang.

This was observed in production where ZK reconnection took 10-15 minutes instead of milliseconds, leading to pod unresponsiveness. The Keeper server closed the session within 20 seconds, but the client's send thread remained stuck due to the socket timeout not firing.

**Fix:**

Move `expire_session_if_not_expired()` before `send_thread.join()`. This ensures:
1. `isExpired()` returns `true` immediately, allowing other threads to create a new session via `getZooKeeper()`
2. The send thread exits faster because its loop condition (`!requests_queue.isFinished()`) becomes true
3. The close request (if successfully pushed by `close()`) is still in the queue and may be sent before the thread exits

This is a defense-in-depth fix that complements #96601 (which fixes the underlying socket timeout issue). Even with #96601 applied, having `isExpired()` gated behind `send_thread.join()` is a single point of failure — any future cause of send thread delays would have the same cascading effect.

cc @serxa @antonio2368

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches ZooKeeper client finalization and send-thread loop logic, which is concurrency-sensitive and could affect shutdown/reconnect behavior under error conditions. Change is localized but may introduce new edge cases around close-request delivery and thread lifecycle.
> 
> **Overview**
> Prevents ZooKeeper session finalization from blocking reconnection by marking the session expired (`requests_queue.finish()`) *before* waiting on `send_thread.join()`, so `isExpired()` flips immediately even if the send thread is stuck in a long socket write.
> 
> Adjusts `sendThread()` to still send the `close_xid` request even when the requests queue has been marked finished, avoiding an early break that could skip the close message during shutdown.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 57fa55634d0e6f5dd12df00ba0d477c1d67174e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.560`
<!-- ch-version-info:end -->