### PR TITLE
ci/fuzzer: fix --compatibility being passed to all AST fuzzer jobs when FUZZER_COMPATIBILITY is unset

### DIFF
--- a/ci/jobs/scripts/fuzzer/run-fuzzer.sh
+++ b/ci/jobs/scripts/fuzzer/run-fuzzer.sh
@@ -199,9 +199,14 @@ function fuzz
         else
             QUERIES_FILE=$(find /repo/tests/queries/0_stateless -type f -name "*.sql" | sort -R)
         fi
-        COMPATIBILITY_SETTING="${FUZZER_COMPATIBILITY:-26.1}"
-        echo "Using AST fuzzer compatibility setting: ${COMPATIBILITY_SETTING}"
-        FUZZER_ARGS="--query-fuzzer-runs=1000 --create-query-fuzzer-runs=50 --compatibility=${COMPATIBILITY_SETTING} --queries-file $QUERIES_FILE $NEW_TESTS_OPT"
+        if [[ -n "${FUZZER_COMPATIBILITY:-}" ]];
+        then
+            COMPAT_ARG="--compatibility=${FUZZER_COMPATIBILITY}"
+            echo "Using AST fuzzer compatibility setting: ${FUZZER_COMPATIBILITY}"
+        else
+            COMPAT_ARG=""
+        fi
+        FUZZER_ARGS="--query-fuzzer-runs=1000 --create-query-fuzzer-runs=50 $COMPAT_ARG --queries-file $QUERIES_FILE $NEW_TESTS_OPT"
     elif [ "$FUZZER_TO_RUN" = "BuzzHouse" ]
     then
         FUZZER_ARGS="--buzz-house-config=fuzz.json"


### PR DESCRIPTION
## Summary

- `COMPATIBILITY_SETTING="${FUZZER_COMPATIBILITY:-26.1}"` caused `--compatibility=26.1` to be appended to every AST fuzzer invocation, including non-targeted jobs that never set `FUZZER_COMPATIBILITY`.
- This unintentionally restricted the tested feature set to an old compatibility level for all regular fuzzer runs.
- Fix: only add `--compatibility` when `FUZZER_COMPATIBILITY` is explicitly set; otherwise no flag is passed and the fuzzer tests with all features enabled.

## Test plan

- [ ] Verify non-targeted AST fuzzer jobs no longer receive `--compatibility` in their arguments.
- [ ] Verify targeted fuzzer jobs with `FUZZER_COMPATIBILITY` set still pass `--compatibility` correctly.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk CI script change that only alters AST fuzzer command-line construction; main impact is changing fuzzing coverage/behavior in CI when `FUZZER_COMPATIBILITY` is unset.
> 
> **Overview**
> AST fuzzer invocations no longer default to `--compatibility=26.1`; the `--compatibility` flag is now appended only when `FUZZER_COMPATIBILITY` is explicitly set.
> 
> This prevents non-targeted AST fuzzer CI jobs from being unintentionally constrained to an older compatibility level.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4626aad6eee0bff631a8e85147903201caf08b8a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.541`
<!-- ch-version-info:end -->