### PR TITLE
Fix RBAC bypass for DESCRIBE/CREATE TABLE AS via table functions

### DIFF
--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -968,7 +968,7 @@ InterpreterCreateQuery::TableProperties InterpreterCreateQuery::getTableProperti
         /// Table function without columns list.
         auto table_function_ast = create.as_table_function->ptr();
         auto table_function = TableFunctionFactory::instance().get(table_function_ast, getContext());
-        properties.columns = table_function->getActualTableStructure(getContext(), /*is_insert_query*/ true);
+        properties.columns = table_function->getActualTableStructureWithAccess(getContext(), /*is_insert_query*/ true);
     }
     else if (create.is_dictionary)
     {

--- a/src/Interpreters/InterpreterDescribeQuery.cpp
+++ b/src/Interpreters/InterpreterDescribeQuery.cpp
@@ -156,7 +156,7 @@ void InterpreterDescribeQuery::fillColumnsFromTableFunction(const ASTTableExpres
     auto current_context = getContext();
     TableFunctionPtr table_function_ptr = TableFunctionFactory::instance().get(table_expression.table_function, current_context);
 
-    auto column_descriptions = table_function_ptr->getActualTableStructure(getContext(), /*is_insert_query*/ true);
+    auto column_descriptions = table_function_ptr->getActualTableStructureWithAccess(current_context, /*is_insert_query*/ false);
     for (const auto & column : column_descriptions)
         columns.emplace_back(column);
 

--- a/src/Interpreters/InterpreterDescribeQuery.cpp
+++ b/src/Interpreters/InterpreterDescribeQuery.cpp
@@ -156,7 +156,7 @@ void InterpreterDescribeQuery::fillColumnsFromTableFunction(const ASTTableExpres
     auto current_context = getContext();
     TableFunctionPtr table_function_ptr = TableFunctionFactory::instance().get(table_expression.table_function, current_context);
 
-    auto column_descriptions = table_function_ptr->getActualTableStructureWithAccess(current_context, /*is_insert_query*/ false);
+    auto column_descriptions = table_function_ptr->getActualTableStructureWithAccess(current_context, /*is_insert_query*/ true);
     for (const auto & column : column_descriptions)
         columns.emplace_back(column);
 

--- a/src/Storages/getStructureOfRemoteTable.cpp
+++ b/src/Storages/getStructureOfRemoteTable.cpp
@@ -52,7 +52,7 @@ ColumnsDescription getStructureOfRemoteTableInShard(
         if (shard_info.isLocal())
         {
             TableFunctionPtr table_function_ptr = TableFunctionFactory::instance().get(table_func_ptr, context);
-            return table_function_ptr->getActualTableStructure(context, /*is_insert_query*/ true);
+            return table_function_ptr->getActualTableStructureWithAccess(context, /*is_insert_query*/ false);
         }
 
         auto table_func_name = table_func_ptr->formatWithSecretsOneLine();

--- a/src/Storages/getStructureOfRemoteTable.cpp
+++ b/src/Storages/getStructureOfRemoteTable.cpp
@@ -52,7 +52,7 @@ ColumnsDescription getStructureOfRemoteTableInShard(
         if (shard_info.isLocal())
         {
             TableFunctionPtr table_function_ptr = TableFunctionFactory::instance().get(table_func_ptr, context);
-            return table_function_ptr->getActualTableStructureWithAccess(context, /*is_insert_query*/ false);
+            return table_function_ptr->getActualTableStructureWithAccess(context, /*is_insert_query*/ true);
         }
 
         auto table_func_name = table_func_ptr->formatWithSecretsOneLine();

--- a/src/TableFunctions/ITableFunction.cpp
+++ b/src/TableFunctions/ITableFunction.cpp
@@ -33,11 +33,8 @@ std::optional<AccessTypeObjects::Source> ITableFunction::getSourceAccessObject()
     return StorageFactory::instance().getSourceAccessObject(getStorageEngineName());
 }
 
-StoragePtr ITableFunction::execute(const ASTPtr & ast_function, ContextPtr context, const std::string & table_name,
-                                   ColumnsDescription cached_columns, bool use_global_context, bool is_insert_query) const
+void ITableFunction::checkSourceAccess(ContextPtr context, bool is_insert_query) const
 {
-    ProfileEvents::increment(ProfileEvents::TableFunctionExecute);
-
     if (const auto access_object = getSourceAccessObject())
     {
         AccessType type_to_check = AccessType::READ;
@@ -46,6 +43,20 @@ StoragePtr ITableFunction::execute(const ASTPtr & ast_function, ContextPtr conte
 
         context->getAccess()->checkAccessWithFilter(type_to_check, toStringSource(*access_object), getFunctionURINormalized());
     }
+}
+
+ColumnsDescription ITableFunction::getActualTableStructureWithAccess(ContextPtr context, bool is_insert_query) const
+{
+    checkSourceAccess(context, is_insert_query);
+    return getActualTableStructure(context, is_insert_query);
+}
+
+StoragePtr ITableFunction::execute(const ASTPtr & ast_function, ContextPtr context, const std::string & table_name,
+                                   ColumnsDescription cached_columns, bool use_global_context, bool is_insert_query) const
+{
+    ProfileEvents::increment(ProfileEvents::TableFunctionExecute);
+
+    checkSourceAccess(context, is_insert_query);
 
     auto table_function_properties = TableFunctionFactory::instance().tryGetProperties(getName());
     if (is_insert_query || !(table_function_properties && table_function_properties->allow_readonly))

--- a/src/TableFunctions/ITableFunction.cpp
+++ b/src/TableFunctions/ITableFunction.cpp
@@ -47,7 +47,8 @@ void ITableFunction::checkSourceAccess(ContextPtr context, bool is_insert_query)
 
 ColumnsDescription ITableFunction::getActualTableStructureWithAccess(ContextPtr context, bool is_insert_query) const
 {
-    checkSourceAccess(context, is_insert_query);
+    /// Resolving table structure is always a read operation.
+    checkSourceAccess(context, /*is_insert_query*/ false);
     return getActualTableStructure(context, is_insert_query);
 }
 

--- a/src/TableFunctions/ITableFunction.h
+++ b/src/TableFunctions/ITableFunction.h
@@ -88,6 +88,13 @@ public:
     StoragePtr
     execute(const ASTPtr & ast_function, ContextPtr context, const std::string & table_name, ColumnsDescription cached_columns_ = {}, bool use_global_context = false, bool is_insert_query = false) const;
 
+    /// Returns actual table structure after enforcing source access checks.
+    /// Use this instead of getActualTableStructure() from outside execute().
+    ColumnsDescription getActualTableStructureWithAccess(ContextPtr context, bool is_insert_query) const;
+
+    /// Check that the user has the required source access (e.g. READ ON MYSQL, WRITE ON S3).
+    void checkSourceAccess(ContextPtr context, bool is_insert_query) const;
+
     virtual ~ITableFunction() = default;
 
 protected:

--- a/src/TableFunctions/TableFunctionFile.cpp
+++ b/src/TableFunctions/TableFunctionFile.cpp
@@ -3,7 +3,6 @@
 #include <TableFunctions/TableFunctionFile.h>
 
 #include <TableFunctions/registerTableFunctions.h>
-#include <Access/Common/AccessFlags.h>
 #include <Core/Settings.h>
 #include <Interpreters/Context.h>
 #include <Storages/ColumnsDescription.h>
@@ -106,9 +105,6 @@ ColumnsDescription TableFunctionFile::getActualTableStructure(ContextPtr context
     {
         if (fd >= 0)
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Schema inference is not supported for table function '{}' with file descriptor", getName());
-
-        if (context->getApplicationType() != Context::ApplicationType::LOCAL)
-            context->checkAccess(AccessType::READ, toStringSource(AccessTypeObjects::Source::FILE));
 
         chassert(file_source); /// TableFunctionFile::parseFirstArguments() initializes either `fd` or `file_source`.
 

--- a/src/TableFunctions/TableFunctionObjectStorage.cpp
+++ b/src/TableFunctions/TableFunctionObjectStorage.cpp
@@ -4,7 +4,6 @@
 #include <Core/Settings.h>
 #include <Core/SettingsEnums.h>
 
-#include <Access/Common/AccessFlags.h>
 #include <Analyzer/FunctionNode.h>
 #include <Analyzer/TableFunctionNode.h>
 #include <Interpreters/Context.h>
@@ -197,9 +196,6 @@ ColumnsDescription TableFunctionObjectStorage<
 {
     if (configuration->structure == "auto")
     {
-        if (const auto access_object = getSourceAccessObject())
-            context->checkAccess(AccessType::READ, toStringSource(*access_object));
-
         auto storage = getObjectStorage(context, !is_insert_query);
         configuration->lazyInitializeIfNeeded(object_storage, context);
 

--- a/src/TableFunctions/TableFunctionURL.cpp
+++ b/src/TableFunctions/TableFunctionURL.cpp
@@ -1,8 +1,6 @@
 #include <TableFunctions/TableFunctionURL.h>
 
 #include <TableFunctions/registerTableFunctions.h>
-#include <Access/Common/AccessFlags.h>
-#include <Access/ContextAccess.h>
 #include <Analyzer/FunctionNode.h>
 #include <Analyzer/TableFunctionNode.h>
 #include <Core/Settings.h>
@@ -147,8 +145,6 @@ ColumnsDescription TableFunctionURL::getActualTableStructure(ContextPtr context,
     {
         ColumnsDescription columns;
 
-        if (const auto access_object = getSourceAccessObject())
-            context->getAccess()->checkAccessWithFilter(AccessType::READ, toStringSource(*access_object), getFunctionURINormalized());
         if (format == "auto")
         {
             columns = StorageURL::getTableStructureAndFormatFromData(

--- a/tests/integration/test_storage_url/test.py
+++ b/tests/integration/test_storage_url/test.py
@@ -104,15 +104,11 @@ def test_table_function_url_access_rights():
         f"SELECT * FROM url('http://nginx:80/test_1', 'TSV')", user="u1"
     )
 
-    assert node1.query(
+    expected_error = "necessary to have the grant READ ON URL"
+    assert expected_error in node1.query_and_get_error(
         f"DESCRIBE TABLE url('http://nginx:80/test_1', 'TSV', 'column1 UInt32, column2 UInt32, column3 UInt32')",
         user="u1",
-    ) == TSV([["column1", "UInt32"], ["column2", "UInt32"], ["column3", "UInt32"]])
-
-    assert node1.query(
-        f"DESCRIBE TABLE url('http://nginx:80/not-exist', 'TSV', 'column1 UInt32, column2 UInt32, column3 UInt32')",
-        user="u1",
-    ) == TSV([["column1", "UInt32"], ["column2", "UInt32"], ["column3", "UInt32"]])
+    )
 
     expected_error = "necessary to have the grant READ ON URL"
     assert expected_error in node1.query_and_get_error(

--- a/tests/queries/0_stateless/04010_describe_remote_rbac_bypass.sh
+++ b/tests/queries/0_stateless/04010_describe_remote_rbac_bypass.sh
@@ -20,6 +20,7 @@ ${CLICKHOUSE_CLIENT} --user $user --query "DESCRIBE remote('127.0.0.1:${CLICKHOU
 ${CLICKHOUSE_CLIENT} --user $user --query "DESCRIBE clusterAllReplicas('test_shard_localhost', '$db', 'secret_table'); -- { serverError ACCESS_DENIED }"
 
 ${CLICKHOUSE_CLIENT} --query "GRANT SHOW COLUMNS ON $db.secret_table TO $user"
+${CLICKHOUSE_CLIENT} --query "GRANT READ ON REMOTE TO $user"
 
 ${CLICKHOUSE_CLIENT} --user $user --query "DESCRIBE $db.secret_table" | cut -f1
 ${CLICKHOUSE_CLIENT} --user $user --query "DESCRIBE remote('127.0.0.1:${CLICKHOUSE_PORT_TCP}', '$db', 'secret_table')" | cut -f1

--- a/tests/queries/0_stateless/04028_describe_table_function_rbac_bypass.reference
+++ b/tests/queries/0_stateless/04028_describe_table_function_rbac_bypass.reference
@@ -1,0 +1,13 @@
+--- DESCRIBE url() without READ ON URL ---
+ACCESS_DENIED
+--- DESCRIBE file() without READ ON FILE ---
+ACCESS_DENIED
+--- CREATE TABLE AS url() without READ ON URL ---
+ACCESS_DENIED
+--- Grant READ ON URL ---
+x
+secret
+--- Grant READ ON FILE ---
+x
+secret
+--- Cleanup ---

--- a/tests/queries/0_stateless/04028_describe_table_function_rbac_bypass.sh
+++ b/tests/queries/0_stateless/04028_describe_table_function_rbac_bypass.sh
@@ -18,13 +18,13 @@ ${CLICKHOUSE_CLIENT} --query "GRANT CREATE TEMPORARY TABLE ON *.* TO $user"
 ${CLICKHOUSE_CLIENT} --query "GRANT CREATE TABLE ON ${db}.* TO $user"
 
 echo "--- DESCRIBE url() without READ ON URL ---"
-${CLICKHOUSE_CLIENT} --user $user --query "DESCRIBE TABLE url('http://example.com/data.csv', 'CSV', 'x UInt32, secret String')" 2>&1 | grep -o "ACCESS_DENIED"
+${CLICKHOUSE_CLIENT} --user $user --query "DESCRIBE TABLE url('http://example.com/data.csv', 'CSV', 'x UInt32, secret String')" 2>&1 | grep -m1 -o "ACCESS_DENIED"
 
 echo "--- DESCRIBE file() without READ ON FILE ---"
-${CLICKHOUSE_CLIENT} --user $user --query "DESCRIBE TABLE file('nonexistent.csv', 'CSV', 'x UInt32, secret String')" 2>&1 | grep -o "ACCESS_DENIED"
+${CLICKHOUSE_CLIENT} --user $user --query "DESCRIBE TABLE file('nonexistent.csv', 'CSV', 'x UInt32, secret String')" 2>&1 | grep -m1 -o "ACCESS_DENIED"
 
 echo "--- CREATE TABLE AS url() without READ ON URL ---"
-${CLICKHOUSE_CLIENT} --user $user --query "CREATE TABLE ${db}.t_04028 AS url('http://example.com/data.csv', 'CSV', 'x UInt32, secret String')" 2>&1 | grep -o "ACCESS_DENIED"
+${CLICKHOUSE_CLIENT} --user $user --query "CREATE TABLE ${db}.t_04028 AS url('http://example.com/data.csv', 'CSV', 'x UInt32, secret String')" 2>&1 | grep -m1 -o "ACCESS_DENIED"
 
 echo "--- Grant READ ON URL ---"
 ${CLICKHOUSE_CLIENT} --query "GRANT READ ON URL TO $user"

--- a/tests/queries/0_stateless/04028_describe_table_function_rbac_bypass.sh
+++ b/tests/queries/0_stateless/04028_describe_table_function_rbac_bypass.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Tags: no-replicated-database
+
+# Verify that DESCRIBE TABLE and CREATE TABLE AS on table functions enforce
+# source access checks. Previously these paths bypassed RBAC — a user without
+# e.g. READ ON URL could still get schema info or trigger outbound connections.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+user="user_04028_${CLICKHOUSE_DATABASE}_$RANDOM"
+db=${CLICKHOUSE_DATABASE}
+
+${CLICKHOUSE_CLIENT} --query "DROP USER IF EXISTS $user"
+${CLICKHOUSE_CLIENT} --query "CREATE USER $user"
+${CLICKHOUSE_CLIENT} --query "GRANT CREATE TEMPORARY TABLE ON *.* TO $user"
+${CLICKHOUSE_CLIENT} --query "GRANT CREATE TABLE ON ${db}.* TO $user"
+
+echo "--- DESCRIBE url() without READ ON URL ---"
+${CLICKHOUSE_CLIENT} --user $user --query "DESCRIBE TABLE url('http://example.com/data.csv', 'CSV', 'x UInt32, secret String')" 2>&1 | grep -o "ACCESS_DENIED"
+
+echo "--- DESCRIBE file() without READ ON FILE ---"
+${CLICKHOUSE_CLIENT} --user $user --query "DESCRIBE TABLE file('nonexistent.csv', 'CSV', 'x UInt32, secret String')" 2>&1 | grep -o "ACCESS_DENIED"
+
+echo "--- CREATE TABLE AS url() without READ ON URL ---"
+${CLICKHOUSE_CLIENT} --user $user --query "CREATE TABLE ${db}.t_04028 AS url('http://example.com/data.csv', 'CSV', 'x UInt32, secret String')" 2>&1 | grep -o "ACCESS_DENIED"
+
+echo "--- Grant READ ON URL ---"
+${CLICKHOUSE_CLIENT} --query "GRANT READ ON URL TO $user"
+${CLICKHOUSE_CLIENT} --user $user --query "DESCRIBE TABLE url('http://example.com/data.csv', 'CSV', 'x UInt32, secret String')" | cut -f1
+
+echo "--- Grant READ ON FILE ---"
+${CLICKHOUSE_CLIENT} --query "GRANT READ ON FILE TO $user"
+${CLICKHOUSE_CLIENT} --user $user --query "DESCRIBE TABLE file('nonexistent.csv', 'CSV', 'x UInt32, secret String')" | cut -f1
+
+echo "--- Cleanup ---"
+${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS ${db}.t_04028"
+${CLICKHOUSE_CLIENT} --query "DROP USER IF EXISTS $user"


### PR DESCRIPTION
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix RBAC bypass that allowed users to obtain table structure via `DESCRIBE TABLE` or `CREATE TABLE AS` on table functions (`mysql()`, `postgresql()`, `sqlite()`, `arrowFlight()`, `jdbc()`, `odbc()`, etc.) without the required source access privileges. For functions that infer schema from remote servers, this also allowed triggering outbound connections (SSRF) without authorization.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

No documentation changes needed — this is a security fix that enforces existing access control semantics.

---

## Summary

`DESCRIBE TABLE table_function(...)` and `CREATE TABLE ... AS table_function(...)` resolved table structure by calling `getActualTableStructure()` without any source access check. The access check (`READ ON MYSQL`, `READ ON SQLITE`, etc.) only existed in `ITableFunction::execute()`, which these code paths never called.

### Affected table functions (SSRF + schema leak on DESCRIBE)
- `mysql()`, `postgresql()`, `arrowFlight()`, `jdbc()`, `odbc()` — outbound connection without authorization
- `sqlite()` — local file read without authorization (fixes https://github.com/ClickHouse/clickhouse-private/issues/47736)

### What changed

- Added `ITableFunction::getActualTableStructureWithAccess()` — bundles `checkSourceAccess()` + `getActualTableStructure()` into a single call
- Used it in `InterpreterDescribeQuery`, `InterpreterCreateQuery`, and `getStructureOfRemoteTable` (local shard path)
- Removed partial per-function access checks from `url()`, `s3()`/`azure()`/`hdfs()`, and `file()` — they only guarded the `structure == "auto"` path and the s3/file versions were weaker (missing URI-level filtering via `checkAccessWithFilter`)

### Test plan
- [ ] New stateless test `04028_describe_table_function_rbac_bypass` — verifies DESCRIBE and CREATE TABLE AS are denied without source grants, and succeed after granting

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches RBAC enforcement paths for table functions and remote DESCRIBE, which is security-critical and may change behavior for existing users by rejecting previously-allowed queries without proper grants.
> 
> **Overview**
> Closes an RBAC bypass where `DESCRIBE TABLE table_function(...)`, `CREATE TABLE ... AS table_function(...)`, and local-shard `remote()` structure resolution could fetch/infer table schemas (and potentially trigger outbound connections) without the required *source* privileges.
> 
> Introduces centralized access enforcement in `ITableFunction` via `checkSourceAccess()` and `getActualTableStructureWithAccess()`, updates interpreters and remote-structure helpers to use it, and removes ad-hoc per-table-function checks (e.g. `url()`, object storage, `file()`). Tests are updated/added to assert `ACCESS_DENIED` without `READ ON <SOURCE>` grants and to require `READ ON REMOTE` for remote-describe scenarios.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0af5b3325e473c0c0ea944da10b0c7c1b896fb0f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.819` (included in `26.3` and later)
- Backported to: `25.8.29.37`
<!-- ch-version-info:end -->