### PR TITLE
fix arm tidy no throw inside catch in src/Common/memory.h

### DIFF
--- a/src/Common/memory.h
+++ b/src/Common/memory.h
@@ -179,7 +179,7 @@ inline ALWAYS_INLINE size_t untrackMemory(void * ptr [[maybe_unused]], Allocatio
 #endif
         trace = CurrentMemoryTracker::free(actual_size);
     }
-    catch (...) // Ok: operator delete must not throw
+    catch (...) // NOLINT(bugprone-empty-catch) - Ok: operator delete must not throw
     {
     }
 


### PR DESCRIPTION
Empty catch block inside `src/Common/memory.h` resulted in arm tidy build failures in one of the PRs: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=97821&sha=f068c57c08c0488b59f249856b21e86e7e10f3cf&name_0=PR&name_1=Build%20%28arm_tidy%29
https://github.com/ClickHouse/ClickHouse/pull/97821

Properly suppress it using `NOLINT(bugprone-empty-catch)`. It's probably not showing up in master as pre existing violations only show up when a new translation unit first pulls them?

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: comment-only lint suppression with no behavioral change, limited to noexcept delete/untracking code path.
> 
> **Overview**
> **CI/lint fix:** adds `// NOLINT(bugprone-empty-catch)` to the intentionally empty `catch (...)` in `src/Common/memory.h` (`Memory::untrackMemory`) to prevent `arm_tidy` clang-tidy failures while preserving the required *no-throw* behavior for `operator delete`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4ceffafdee180b2bb988f2b1e05fcfc59b1bce5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->