### PR TITLE
trace-visualizer improvements

### DIFF
--- a/utils/trace-visualizer/css/d3-gantt.css
+++ b/utils/trace-visualizer/css/d3-gantt.css
@@ -73,6 +73,11 @@ rect.zoom-panel {
     stroke-dasharray:0;
 }
 
+.bar {
+    stroke-width: 1px;
+    stroke: rgba(0, 0, 0, 0.3);
+}
+
 .bar-u {
     opacity: 0.2;
 }

--- a/utils/trace-visualizer/css/d3-gantt.css
+++ b/utils/trace-visualizer/css/d3-gantt.css
@@ -42,6 +42,12 @@ rect.zoom-panel {
     background: rgba(0, 0, 0, 0.8);
     color: #fff;
     border-radius: 2px;
+    pointer-events: none !important;
+    user-select: text;
+}
+
+.d3-tip.pinned {
+    pointer-events: auto !important;
 }
 
 .d3-tip table {
@@ -82,7 +88,8 @@ rect.zoom-panel {
     opacity: 0.2;
 }
 
-.bar:hover {
+.bar:hover,
+.bar[data-pinned] {
     stroke-width: 1px;
     stroke: black;
 }

--- a/utils/trace-visualizer/index.html
+++ b/utils/trace-visualizer/index.html
@@ -454,7 +454,7 @@ SETTINGS output_format_json_named_tuples_as_objects = 1, skip_unavailable_shards
         if (pattern != '') {
             const runtime = chart.filteredRuntime();
             const total = chart.totalRuntime();
-            $("#status-text").text(`
+            $("#status-text").css("color", "").text(`
                 ${chart.filteredCount()}/${chart.totalCount()} spans
                 ${runtime.toFixed(1)}/${total.toFixed(1)} runtime (${(runtime*100/total).toFixed(1)}%)
                 matching
@@ -462,7 +462,7 @@ SETTINGS output_format_json_named_tuples_as_objects = 1, skip_unavailable_shards
         }
         else
         {
-            $("#status-text").text(`
+            $("#status-text").css("color", "").text(`
                 ${chart.totalCount()} spans
                 ${chart.totalRuntime().toFixed(1)} runtime
                 total

--- a/utils/trace-visualizer/index.html
+++ b/utils/trace-visualizer/index.html
@@ -448,7 +448,6 @@ SETTINGS output_format_json_named_tuples_as_objects = 1, skip_unavailable_shards
     example_json.bands = new Set(example_json.map(x => x.band));
     example_json.max_time_ms = Math.max(...example_json.map(x => x.t2));
 
-    var data = null;
     var chart = null;
 
     function updateStatus(pattern = '') {
@@ -472,7 +471,6 @@ SETTINGS output_format_json_named_tuples_as_objects = 1, skip_unavailable_shards
     }
 
     function renderChart(parsed) {
-        data = parsed;
         if (chart != null) {
             chart.destroy();
         }
@@ -484,56 +482,19 @@ SETTINGS output_format_json_named_tuples_as_objects = 1, skip_unavailable_shards
             .selector("#placeholder")
             .timeDomain([0, parsed.max_time_ms])
         ;
-        chart(data);
+        chart(parsed);
         updateStatus();
     }
 
-    $("<div id='errmsg'></div>").css({
-        position: "absolute",
-        display: "none",
-        border: "1px solid #faa",
-        padding: "2px",
-        "background-color": "#fcc",
-        opacity: 0.80
-    }).appendTo("body");
-
-    function fetchData(dataurl, parser = x => x) {
-        function onDataReceived(json, textStatus, xhr) {
-            $("#errmsg").hide();
-            renderChart(parser(json));
-        }
-
-        function onDataError(xhr, error) {
-            console.log(arguments);
-            $("#errmsg").text("Fetch data error: " + error + (xhr.status == 200? xhr.responseText: ""))
-            .css({bottom: "5px", left: "25%", width: "50%"})
-            .fadeIn(200);
-        }
-
-        if (dataurl) {
-            $.ajax({
-                url: dataurl,
-                type: "GET",
-                dataType: "json",
-                success: function (json, textStatus, xhr) { onDataReceived(json, textStatus, xhr); },
-                error: onDataError
-            });
+    // Show correct button depending on active tab
+    $('a[data-bs-toggle="tab"]').on('shown.bs.tab', function (e) {
+        if ($(e.target).attr('href') === '#tabClickhouse') {
+            $('#btnDoLoad').hide();
+            $('#btnQueryClickhouse').show();
         } else {
-            onDataReceived(example_json, "textStatus", "xhr");
+            $('#btnDoLoad').show();
+            $('#btnQueryClickhouse').hide();
         }
-    }
-
-    // Show correct button depending on tab
-    $('#loadModal').on('shown.bs.modal', function () {
-        $('a[data-bs-toggle="tab"]').on('shown.bs.tab', function (e) {
-            if ($(e.target).attr('href') === '#tabClickhouse') {
-                $('#btnDoLoad').hide();
-                $('#btnQueryClickhouse').show();
-            } else {
-                $('#btnDoLoad').show();
-                $('#btnQueryClickhouse').hide();
-            }
-        });
     });
 
     // Handle ClickHouse query
@@ -601,7 +562,6 @@ SETTINGS output_format_json_named_tuples_as_objects = 1, skip_unavailable_shards
         }
         let fr = new FileReader();
         fr.onload = function(e) {
-            $("#errmsg").hide();
             renderChart(parseClickHouseTrace(JSON.parse(e.target.result).data));
         }
         fr.readAsText(files.item(0));
@@ -677,6 +637,20 @@ SETTINGS output_format_json_named_tuples_as_objects = 1, skip_unavailable_shards
         return result;
     }
 
-    fetchData(); // do not fetch, just draw example_json w/o parsing
-    //fetchData("your-traces.json", json => parseClickHouseTrace(json.data));
+    // On startup, try to load trace.json. If unavailable, fall back to example data.
+    // This is all optional, the user can always open a trace file from ui instead.
+    fetch("trace.json").then(function(response) {
+        if (response.status === 404 || response.status === 0)
+            throw null; // File not found, silently fall back to example data
+        if (!response.ok)
+            throw new Error("Failed to load trace.json: " + response.status + " " + response.statusText);
+        return response.json();
+    }).then(function(json) {
+        renderChart(parseClickHouseTrace(json.data));
+    }).catch(function(err) {
+        if (err) {
+            $("#status-text").text(err.message).css("color", "red");
+        }
+        renderChart(example_json);
+    });
 </script>

--- a/utils/trace-visualizer/js/d3-gantt.js
+++ b/utils/trace-visualizer/js/d3-gantt.js
@@ -12,6 +12,20 @@
         filtered_count = total_count;
         filtered_runtime = total_runtime;
 
+        // Compute left margin based on widest band name, capped at 1/4 page width
+        var measureSvg = d3.select("body").append("svg").attr("class", "chart").style("position", "absolute").style("visibility", "hidden");
+        var maxTextWidth = 0;
+        data.bands.forEach(function(name) {
+            var textEl = measureSvg.append("text").attr("class", "axis y").text(name);
+            var w = textEl.node().getBBox().width;
+            if (w > maxTextWidth) maxTextWidth = w;
+            textEl.remove();
+        });
+        measureSvg.remove();
+        var maxMarginLeft = Math.floor(document.body.clientWidth / 4);
+        margin.left = Math.min(maxMarginLeft, Math.max(30, Math.ceil(maxTextWidth + 15)));
+        width = document.body.clientWidth - margin.right - margin.left - 5;
+
         initAxis();
 
         // create svg element
@@ -44,6 +58,13 @@
                 if (tipShown != null) {
                     tip.hide(tipShown);
                     tipShown = null;
+                    tipPinned = false;
+                    if (tipPinnedRect) {
+                        tipPinnedRect.removeAttribute("data-pinned");
+                        tipPinnedRect = null;
+                    }
+                    var cls = tip.attr("class") || "";
+                    tip.attr("class", cls.replace(/\s*pinned/g, ""));
                 }
                 var tr = d3.event.transform;
                 xZoomed = tr.rescaleX(x);
@@ -82,8 +103,8 @@
             .attr("class", "zoom-panel")
             .attr("width", width)
             .attr("height", height)
-            .call(zoom)
         ;
+        svgChart.call(zoom);
 
         zoomContainer2 = svgChart.append("g");
         bandsSvg = zoomContainer2.append("g");
@@ -124,7 +145,7 @@
 
         bandsSvg.call(tip);
 
-        render();
+        createRects();
 
         // container for non-zoomable elements
         fixedContainer = svg.append("g")
@@ -173,8 +194,8 @@
                     // rearange y scale and axis
                     svg.select("g.y.axis").transition().call(yAxis);
 
-                    // rearange other stuff
-                    render(-1, true);
+                    // rearrange other stuff
+                    repositionBands(true);
                 }
             })
             .on("start", function(d) {
@@ -270,6 +291,9 @@
         svg.select("g.x.axis").call(xAxis);
         svg.select("g.y.axis").call(yAxis);
 
+        // Add native tooltip to y-axis labels for full text on hover
+        svg.selectAll("g.y.axis .tick").append("title").text(function(d) { return d; });
+
         // update to initiale state
         window.onscroll(0);
 
@@ -278,58 +302,146 @@
 
 // private:
 
-    var keyFunction = function(d) {
-        return d.t1.toString() + d.t2.toString() + d.band.toString();
-    }
+    var SVG_NS = "http://www.w3.org/2000/svg";
 
-    var bandTransform = function(d) {
-        return "translate(" + x(d.t1) + "," + y(d.band) + ")";
-    }
+    // Array of rect DOM elements, parallel to data[]
+    var rects = null;
+
+    // Whether tooltip is pinned (click to keep visible)
+    var tipPinned = false;
+    var tipPinnedRect = null;
 
     var filterMatch = function(d) {
         return filter == '' || d.text.toLowerCase().includes(filter);
     }
 
-    var render = function(t0, smooth) {
-        // Save/restore last t0 value
-        if (!arguments.length || t0 == -1) {
-            t0 = render.t0;
+    var createRects = function() {
+        var container = bandsSvg.node();
+        // Clear previous content
+        while (container.firstChild) container.removeChild(container.firstChild);
+
+        if (data.length == 0) {
+            var text = document.createElementNS(SVG_NS, "text");
+            text.textContent = "no data to show";
+            container.appendChild(text);
+            rects = [];
+            return;
         }
-        render.t0 = t0;
-        smooth = smooth || false;
 
-        // Create rectangles for bands
-        bands = bandsSvg.selectAll("rect.bar")
-          .data(data, keyFunction);
-        bands.exit().remove();
-        bands.enter().append("rect")
-            .attr("class", "bar")
-            .attr("vector-effect", "non-scaling-stroke")
-            .style("fill", d => d.color)
-            .on('mouseover', function(d) {
-                if (tipShown != d) {
-                    tipShown = d;
-                    tip.show(d);
-                } else {
-                    tipShown = null;
-                    tip.hide(d);
+        var bw = y.bandwidth();
+        var frag = document.createDocumentFragment();
+        rects = new Array(data.length);
+        for (var i = 0; i < data.length; i++) {
+            var d = data[i];
+            var r = document.createElementNS(SVG_NS, "rect");
+            r.setAttribute("class", "bar bar-f");
+            r.setAttribute("vector-effect", "non-scaling-stroke");
+            r.setAttribute("fill", d.color);
+            r.setAttribute("y", 0);
+            r.setAttribute("transform", "translate(" + x(d.t1) + "," + y(d.band) + ")");
+            r.setAttribute("width", x(d.t2) - x(d.t1));
+            r.setAttribute("height", bw);
+            r.__data__ = d;
+            rects[i] = r;
+            frag.appendChild(r);
+        }
+        container.appendChild(frag);
+
+        // Delegated mouse handlers for tooltips
+        tipPinned = false;
+        tipPinnedRect = null;
+        var setTipPinned = function(pinned, rectEl) {
+            tipPinned = pinned;
+            // Remove highlight from previous pinned rect
+            if (tipPinnedRect) {
+                tipPinnedRect.removeAttribute("data-pinned");
+                tipPinnedRect = null;
+            }
+            // Toggle 'pinned' class on tooltip node for pointer-events control
+            var cls = tip.attr("class") || "";
+            if (pinned) {
+                if (cls.indexOf("pinned") === -1)
+                    tip.attr("class", cls + " pinned");
+                if (rectEl) {
+                    rectEl.setAttribute("data-pinned", "true");
+                    tipPinnedRect = rectEl;
                 }
-            })
-          .merge(bands)
-            .attr("class", d => "bar " + (filterMatch(d) ? " bar-f" : " bar-u"))
-          .transition().duration(smooth? 250: 0)
-            .attr("y", 0)
-            .attr("transform", bandTransform)
-            .attr("height", y.bandwidth())
-            .attr("width", d => x(d.t2) - x(d.t1))
-        ;
+            } else {
+                tip.attr("class", cls.replace(/\s*pinned/g, ""));
+            }
+        };
+        container.addEventListener("mouseover", function(evt) {
+            var target = evt.target;
+            if (target.tagName === "rect" && target.__data__ && !tipPinned) {
+                var d = target.__data__;
+                tipShown = d;
+                tip.show(d, target);
+            }
+        });
+        container.addEventListener("mouseout", function(evt) {
+            var target = evt.target;
+            if (target.tagName === "rect" && tipShown != null && !tipPinned) {
+                tip.hide(tipShown);
+                tipShown = null;
+            }
+        });
+        container.addEventListener("click", function(evt) {
+            evt.stopPropagation(); // prevent document click handler from immediately dismissing
+            var target = evt.target;
+            if (target.tagName === "rect" && target.__data__) {
+                if (tipPinned && tipShown === target.__data__) {
+                    // Unpin on click of same rect
+                    setTipPinned(false, null);
+                    tip.hide(tipShown);
+                    tipShown = null;
+                } else {
+                    // Pin tooltip
+                    tipShown = target.__data__;
+                    tip.show(target.__data__, target);
+                    setTipPinned(true, target);
+                }
+            }
+        });
+        // Click anywhere outside a rect or tooltip dismisses pinned tooltip
+        document.addEventListener("click", function(evt) {
+            if (tipPinned) {
+                // Don't dismiss if click is inside the tooltip
+                var tipNode = document.querySelector(".d3-tip");
+                if (tipNode && tipNode.contains(evt.target)) return;
+                setTipPinned(false, null);
+                if (tipShown != null) {
+                    tip.hide(tipShown);
+                    tipShown = null;
+                }
+            }
+        });
+    }
 
-        var emptyMarker = bandsSvg.selectAll("text")
-          .data(data.length == 0? ["no data to show"]: []);
-        emptyMarker.exit().remove();
-        emptyMarker.enter().append("text")
-            .text(d => d)
-        ;
+    var updateFilter = function() {
+        if (!rects) return;
+        for (var i = 0; i < rects.length; i++) {
+            var cls = filterMatch(rects[i].__data__) ? "bar bar-f" : "bar bar-u";
+            if (rects[i].getAttribute("class") !== cls)
+                rects[i].setAttribute("class", cls);
+        }
+    }
+
+    var repositionBands = function(smooth) {
+        if (!rects) return;
+        var bw = y.bandwidth();
+        if (smooth) {
+            // Use D3 transition for smooth band reordering
+            bandsSvg.selectAll("rect.bar")
+              .transition().duration(250)
+                .attr("transform", function() { var d = this.__data__; return "translate(" + x(d.t1) + "," + y(d.band) + ")"; })
+                .attr("height", bw);
+        } else {
+            for (var i = 0; i < rects.length; i++) {
+                var d = rects[i].__data__;
+                rects[i].setAttribute("transform", "translate(" + x(d.t1) + "," + y(d.band) + ")");
+                rects[i].setAttribute("height", bw);
+            }
+        }
     }
 
     function initAxis() {
@@ -429,8 +541,6 @@
             .attr("width", textWidth + (xpadding*2))
             .attr("height", positionRuler.bbox.height + (ypadding*2))
         ;
-
-        render(tpos);
     }
 
 // public:
@@ -485,7 +595,7 @@
             }
         }
 
-        render();
+        updateFilter();
         return gantt;
     }
 
@@ -547,7 +657,6 @@
         fixedContainer = null,
         zoom = null,
         bandsSvg = null,
-        bands = null,
         tip = null,
         tipShown = null,
         ruler = null

--- a/utils/trace-visualizer/js/d3-gantt.js
+++ b/utils/trace-visualizer/js/d3-gantt.js
@@ -310,6 +310,7 @@
     // Whether tooltip is pinned (click to keep visible)
     var tipPinned = false;
     var tipPinnedRect = null;
+    var docClickHandler = null;
 
     var filterMatch = function(d) {
         return filter == '' || d.text.toLowerCase().includes(filter);
@@ -403,7 +404,7 @@
             }
         });
         // Click anywhere outside a rect or tooltip dismisses pinned tooltip
-        document.addEventListener("click", function(evt) {
+        docClickHandler = function(evt) {
             if (tipPinned) {
                 // Don't dismiss if click is inside the tooltip
                 var tipNode = document.querySelector(".d3-tip");
@@ -414,7 +415,8 @@
                     tipShown = null;
                 }
             }
-        });
+        };
+        document.addEventListener("click", docClickHandler);
     }
 
     var updateFilter = function() {
@@ -620,6 +622,10 @@
     }
 
     gantt.destroy = function() {
+        if (docClickHandler) {
+            document.removeEventListener("click", docClickHandler);
+            docClickHandler = null;
+        }
         tip.destroy();
         d3.select(selector).selectAll("svg").remove();
     }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

(Note: changes made mostly by claude, I didn't review them very carefully, just skimmed. If you see something terrible, lmk and I'll spend more time on it and adjust my level of trust to opus 4.6 :) .)

* Fix performance, it now runs smooth for 5k spans instead of previous 15 fps.
* Add 1px outlines to all rects, so that very narrow spans are visible at all zoom levels.
* Show tooltip on hover, hide on mouseout.
* Pin tooltip on click, dismiss on click outside or on same span.
* Mouse wheel zoom works when cursor is over a span (but still doesn't work when over tooltip, this seems too awkward to fix).
* Make long Y axis labels readable: set left margin to the longest title width so it fits, capped at 1/4 of the screen; add (native) tooltips in case label is still too long.
* Try to load `trace.json` on startup, fall back to example trace if the file is missing. Similar to uncommenting the `//fetchData("your-traces.json", ...)` line that was previously there. (I have trace-visualizer on a local webserver next to a trace file. Then I usually just replace the file and refresh the page instead of clicking through the "open file" dialogs.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to a sizable refactor of `d3-gantt.js` rendering/event handling (switching to manual SVG rect management and new tooltip pinning logic), which could introduce UI regressions in zoom/filter/reorder behavior.
> 
> **Overview**
> Improves the trace visualizer’s interactivity and performance by refactoring `d3-gantt.js` to pre-create SVG span rects, update filtering via class toggles, and only reposition bands on reorder (instead of re-binding/re-rendering on every change).
> 
> Enhances UX with **click-to-pin tooltips** (dismiss on outside click/zoom), hover-only tooltips when not pinned, better zoom hit-target behavior, and clearer span visibility via 1px bar outlines plus pinned/hover styling.
> 
> Makes long band labels more readable by dynamically sizing the left margin based on the widest label (capped) and adding native hover `title` tooltips on y-axis ticks, and updates startup behavior to auto-load `trace.json` when present with a fallback to example data (removing the old `#errmsg` ajax error UI).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de6a4f851d486626257b060c6223310a2ec9fef9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.659`
<!-- ch-version-info:end -->