### PR TITLE
Fix WriteFileOperation::undo() incorrectly deleting pre-existing metadata files

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -123,6 +123,7 @@ static struct InitFiu
     ONCE(smt_commit_exception_before_op) \
     ONCE(disk_object_storage_fail_commit_metadata_transaction) \
     ONCE(disk_object_storage_fail_precommit_metadata_transaction) \
+    ONCE(write_file_operation_fail_on_read) \
     REGULAR(slowdown_parallel_replicas_local_plan_read) \
     ONCE(iceberg_writes_cleanup) \
     ONCE(backup_add_empty_memory_table) \

--- a/src/Disks/DiskObjectStorage/MetadataStorages/Local/MetadataStorageFromDiskTransactionOperations.cpp
+++ b/src/Disks/DiskObjectStorage/MetadataStorages/Local/MetadataStorageFromDiskTransactionOperations.cpp
@@ -8,6 +8,7 @@
 #include <IO/ReadHelpers.h>
 
 #include <Common/Exception.h>
+#include <Common/FailPoint.h>
 #include <Common/ObjectStorageKey.h>
 #include <Common/logger_useful.h>
 #include <Common/getRandomASCIIString.h>
@@ -30,6 +31,12 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
     extern const int FILE_DOESNT_EXIST;
     extern const int TOO_DEEP_RECURSION;
+    extern const int FAULT_INJECTED;
+}
+
+namespace FailPoints
+{
+    extern const char write_file_operation_fail_on_read[];
 }
 
 namespace
@@ -101,6 +108,11 @@ void WriteFileOperation::execute()
 {
     if (auto buf = disk.readFileIfExists(path, getReadSettings()))
     {
+        file_existed = true;
+        fiu_do_on(FailPoints::write_file_operation_fail_on_read,
+        {
+            throw Exception(ErrorCodes::FAULT_INJECTED, "Injected fault in WriteFileOperation read");
+        });
         std::string file_data;
         readStringUntilEOF(file_data, *buf);
         prev_data = file_data;
@@ -113,16 +125,18 @@ void WriteFileOperation::execute()
 
 void WriteFileOperation::undo()
 {
-    if (!prev_data.has_value())
+    if (prev_data.has_value())
     {
-        disk.removeFileIfExists(path);
-    }
-    else
-    {
+        chassert(file_existed);
         auto buf = disk.writeFile(path);
         writeString(prev_data.value(), *buf);
         buf->finalize();
     }
+    else if (!file_existed)
+    {
+        disk.removeFileIfExists(path);
+    }
+    // else: file existed but the file content is unchanged, leave it alone.
 }
 
 UnlinkFileOperation::UnlinkFileOperation(std::string path_, bool if_exists_, bool should_remove_objects_, const std::string & compatible_key_prefix_, IDisk & disk_, StoredObjects & objects_to_remove_)

--- a/src/Disks/DiskObjectStorage/MetadataStorages/Local/MetadataStorageFromDiskTransactionOperations.h
+++ b/src/Disks/DiskObjectStorage/MetadataStorages/Local/MetadataStorageFromDiskTransactionOperations.h
@@ -60,6 +60,12 @@ private:
     IDisk & disk;
 
     std::optional<std::string> prev_data;
+
+    // True once execute() has confirmed the file exists on disk.
+    // Used by undo() to distinguish "file was created by this operation"
+    // (safe to delete on undo) from "file already existed, execute() failed
+    // before overwriting it" (must NOT delete — the file is unchanged).
+    bool file_existed = false;
 };
 
 struct UnlinkFileOperation final : public IMetadataOperation

--- a/src/Disks/tests/gtest_disk_object_storage.cpp
+++ b/src/Disks/tests/gtest_disk_object_storage.cpp
@@ -117,6 +117,7 @@ namespace ErrorCodes
 namespace FailPoints
 {
     extern const char disk_object_storage_fail_commit_metadata_transaction[];
+    extern const char write_file_operation_fail_on_read[];
 }
 
 }
@@ -408,6 +409,50 @@ TEST_F(DiskObjectStorageTest, RewriteFileTxCommitFail)
 
     EXPECT_THROW(tx->commit(), DB::Exception);
 
+    EXPECT_TRUE(disk->existsFile(file_name));
+    EXPECT_EQ(readAll(*disk->readFile(file_name, {})), file_content);
+    waitBlobsCount(disk, 1);
+}
+
+TEST_F(DiskObjectStorageTest, AppendFileTxReadFailDoesNotDeleteFile)
+{
+    // Regression test for: WriteFileOperation::undo() incorrectly deletes a file
+    // when execute() fails after opening the file but before setting prev_data.
+    // Reproduces the bug that corrupts txn_version.txt metadata on object storage.
+    auto disk = getDiskObjectStorage();
+
+    std::string file_name = getTestName() + "_file";
+    std::string file_content = getTestName() + "_content";
+
+    // Create the initial file
+    {
+        auto wb = disk->writeFile(file_name);
+        DB::writeText(file_content, *wb);
+        wb->finalize();
+    }
+
+    EXPECT_TRUE(disk->existsFile(file_name));
+    EXPECT_EQ(readAll(*disk->readFile(file_name, {})), file_content);
+    waitBlobsCount(disk, 1);
+
+    // Enable failpoint that fires inside WriteFileOperation::execute(),
+    // after the existing file is opened but before prev_data is set.
+    // This simulates ThreadFuzzer fault injection on async ThreadPoolReader::submit().
+    DB::FailPointInjection::enableFailPoint(DB::FailPoints::write_file_operation_fail_on_read);
+
+    // Append to the file — triggers AddBlobOperation -> WriteFileOperation::execute()
+    auto tx = disk->createTransaction();
+    {
+        auto wb = tx->writeFile(file_name, DB::DBMS_DEFAULT_BUFFER_SIZE, DB::WriteMode::Append, DB::WriteSettings{});
+        DB::writeText("_appended", *wb);
+        wb->finalize();
+    }
+
+    // Commit fails because the failpoint fires during WriteFileOperation::execute()
+    EXPECT_THROW(tx->commit(), DB::Exception);
+
+    // Without the fix: WriteFileOperation::undo() sees !prev_data and deletes the file.
+    // With the fix: undo() sees file_existed==true and preserves the file.
     EXPECT_TRUE(disk->existsFile(file_name));
     EXPECT_EQ(readAll(*disk->readFile(file_name, {})), file_content);
     waitBlobsCount(disk, 1);


### PR DESCRIPTION
```
`WriteFileOperation::undo()` used `!prev_data.has_value()` as the sole
condition for deleting the file, but `prev_data` is also unset when
`readStringUntilEOF` throws after `readFileIfExists` had already opened
an existing file (e.g. via ThreadFuzzer / fault injection on an async
`ThreadPoolReader::submit()`). In that case the file existed and its
content was unchanged, but `undo()` would delete it.

Fix: add a `file_existed` flag that is set to `true` immediately after
`readFileIfExists` confirms the file is present, before any read that
can throw. `undo()` now only removes the file when both `!prev_data`
and `!file_existed` — meaning `execute()` never observed the file on
disk and therefore either created it (delete warranted) or never wrote
it at all (no-op).

The observable symptom was an `assertHasValidVersionMetadata()` exception
on `DROP TABLE` against a TTL table on Azure blob storage with
transactions enabled: fault injection caused the `txn_version.txt`
metadata file to be deleted during `appendRemovalTIDToVersionMetadata`,
then silently recreated without the required `version: 1` header.

Add a `write_file_operation_fail_on_read` failpoint that fires inside
`WriteFileOperation::execute()` after the file is opened but before
`prev_data` is set, and a regression test
`AppendFileTxReadFailDoesNotDeleteFile` that verifies the file survives
a failed append transaction.
```

Closes #94142

CI reports:
- [Stress test (azure, amd_msan)](https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=54911410bd8f61f5421394491d091f041ebc01d4&name_0=MasterCI&name_1=Stress%20test%20%28azure%2C%20amd_msan%29)
- [Stateless tests (amd_tsan, parallel, 2/2)](https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=06598f27ab378120683ccf2cc08c0632aca84f0c&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_tsan%2C%20parallel%2C%202%2F2%29)

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches transactional metadata write/undo logic for object-storage disks; a bug here could cause metadata loss or incorrect rollback behavior, but the change is narrowly scoped and covered by a new regression test.
> 
> **Overview**
> Fixes a rollback bug in object-storage metadata transactions where `WriteFileOperation::undo()` could delete a pre-existing file if `execute()` failed after opening it but before capturing `prev_data`.
> 
> The operation now tracks whether the file was observed to exist (`file_existed`) and only deletes on undo when the file was newly created, plus a new `write_file_operation_fail_on_read` failpoint and a regression test (`AppendFileTxReadFailDoesNotDeleteFile`) to ensure a failed append transaction does not remove the original file.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0be09f03158144ce0c1976080ff279c749366421. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.569`
<!-- ch-version-info:end -->