### PR TITLE
Fix logic for getting PR number

### DIFF
--- a/ci/jobs/llvm_coverage_job.py
+++ b/ci/jobs/llvm_coverage_job.py
@@ -113,15 +113,13 @@ def get_git_info() -> tuple[str, str, str, str, str, int]:
             "basename -s .git `git config --get remote.origin.url`", verbose=True
         ).strip()
     )
-    pr_number = (
-        info.pr_number
-        if info.pr_number > 0
-        else int(
-            Shell.get_output(
-                "gh pr view --json number -q .number", verbose=True
-            ).strip()
-        )
-    )
+    if info.pr_number > 0:
+        pr_number = info.pr_number
+    else:
+        _gh_out = Shell.get_output(
+            "gh pr view --json number -q .number", verbose=True
+        ).strip()
+        pr_number = int(_gh_out) if _gh_out else 0
     return (
         current_commit_sha,
         merge_base_commit_sha,


### PR DESCRIPTION
### Changelog category (leave one):

- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that prevents an `int('')` failure when PR metadata is unavailable; behavior changes only in edge cases where `gh pr view` returns empty output.
> 
> **Overview**
> Makes `ci/jobs/llvm_coverage_job.py` more robust when resolving `pr_number`: if `Info().pr_number` is not set and `gh pr view` returns an empty value, the job now falls back to `0` instead of throwing while casting to `int`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f812df37b84978a70ffe9b5b5adf111011d26c96. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.551`
<!-- ch-version-info:end -->