### PR TITLE
Fix LOGICAL_ERROR due to patch parts column order mismatch

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -155,7 +155,8 @@ static struct InitFiu
     REGULAR(lightweight_show_tables) \
     REGULAR(datalake_try_get_table_return_nullptr) \
     PAUSEABLE_ONCE(drop_database_before_exclusive_ddl_lock) \
-    REGULAR(storage_merge_tree_background_schedule_merge_fail)
+    REGULAR(storage_merge_tree_background_schedule_merge_fail) \
+    REGULAR(patch_parts_reverse_column_order)
 
 namespace FailPoints
 {

--- a/src/Storages/MergeTree/MergeTreeBlockReadUtils.cpp
+++ b/src/Storages/MergeTree/MergeTreeBlockReadUtils.cpp
@@ -19,7 +19,6 @@
 #include <IO/Operators.h>
 #include <Interpreters/ExpressionActions.h>
 
-
 #include <algorithm>
 #include <unordered_set>
 

--- a/src/Storages/MergeTree/MergeTreeBlockReadUtils.cpp
+++ b/src/Storages/MergeTree/MergeTreeBlockReadUtils.cpp
@@ -9,6 +9,7 @@
 #include <DataTypes/NestedUtils.h>
 #include <Core/NamesAndTypes.h>
 #include <Common/checkStackSize.h>
+#include <Common/FailPoint.h>
 #include <Common/typeid_cast.h>
 #include <Storages/MergeTree/MergeTreeVirtualColumns.h>
 #include <Storages/MergeTree/MergeTreeSelectProcessor.h>
@@ -17,6 +18,7 @@
 #include <IO/WriteBufferFromString.h>
 #include <IO/Operators.h>
 #include <Interpreters/ExpressionActions.h>
+
 
 #include <algorithm>
 #include <unordered_set>
@@ -29,6 +31,11 @@ namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
     extern const int NO_SUCH_COLUMN_IN_TABLE;
+}
+
+namespace FailPoints
+{
+    extern const char patch_parts_reverse_column_order[];
 }
 
 namespace
@@ -397,13 +404,13 @@ void addPatchPartsColumns(
         /// The sort in getUpdatedHeader also normalizes order before cross-patch comparison.
         std::sort(patch_columns_to_read_names.begin(), patch_columns_to_read_names.end());
 
-#ifdef DEBUG_OR_SANITIZER_BUILD
-        /// In debug builds, reverse the order for odd-indexed patches to expose any code
-        /// that incorrectly relies on positional column matching between different patches.
-        /// This ensures getUpdatedHeader (and any future comparison) handles arbitrary ordering.
-        if (i % 2 == 1)
-            std::reverse(patch_columns_to_read_names.begin(), patch_columns_to_read_names.end());
-#endif
+        fiu_do_on(FailPoints::patch_parts_reverse_column_order,
+        {
+            /// Reverse the order for odd-indexed patches to expose any code
+            /// that incorrectly relies on positional column matching between different patches.
+            if (i % 2 == 1)
+                std::reverse(patch_columns_to_read_names.begin(), patch_columns_to_read_names.end());
+        });
 
         result.patch_columns[i] = storage_snapshot->getColumnsByNames(options, patch_columns_to_read_names);
     }

--- a/src/Storages/MergeTree/MergeTreeBlockReadUtils.cpp
+++ b/src/Storages/MergeTree/MergeTreeBlockReadUtils.cpp
@@ -396,17 +396,13 @@ void addPatchPartsColumns(
         required_virtuals.insert(patch_system_columns.begin(), patch_system_columns.end());
 
         Names patch_columns_to_read_names(patch_columns_to_read_set.begin(), patch_columns_to_read_set.end());
-        /// Sort the column names to ensure deterministic column order in patch blocks.
-        /// Without sorting, the iteration order of NameSet (unordered_set) is non-deterministic,
-        /// and different patch parts reading the same columns can produce blocks with different
-        /// column orderings, depending on the standard library's hash table implementation.
-        /// The sort in getUpdatedHeader also normalizes order before cross-patch comparison.
-        std::sort(patch_columns_to_read_names.begin(), patch_columns_to_read_names.end());
 
         fiu_do_on(FailPoints::patch_parts_reverse_column_order,
         {
-            /// Reverse the order for odd-indexed patches to expose any code
-            /// that incorrectly relies on positional column matching between different patches.
+            /// Simulate non-deterministic NameSet iteration producing different column
+            /// orderings for different patches. This reproduces the bug fixed in
+            /// getUpdatedHeader (applyPatches.cpp) where sortColumns() normalizes order
+            /// before the positional assertCompatibleHeader comparison.
             if (i % 2 == 1)
                 std::reverse(patch_columns_to_read_names.begin(), patch_columns_to_read_names.end());
         });

--- a/src/Storages/MergeTree/MergeTreeBlockReadUtils.cpp
+++ b/src/Storages/MergeTree/MergeTreeBlockReadUtils.cpp
@@ -393,9 +393,18 @@ void addPatchPartsColumns(
         /// Sort the column names to ensure deterministic column order in patch blocks.
         /// Without sorting, the iteration order of NameSet (unordered_set) is non-deterministic,
         /// and different patch parts reading the same columns can produce blocks with different
-        /// column orderings. This causes LOGICAL_ERROR in assertCompatibleHeader when
-        /// getUpdatedHeader compares patch headers positionally.
+        /// column orderings, depending on the standard library's hash table implementation.
+        /// The sort in getUpdatedHeader also normalizes order before cross-patch comparison.
         std::sort(patch_columns_to_read_names.begin(), patch_columns_to_read_names.end());
+
+#ifdef DEBUG_OR_SANITIZER_BUILD
+        /// In debug builds, reverse the order for odd-indexed patches to expose any code
+        /// that incorrectly relies on positional column matching between different patches.
+        /// This ensures getUpdatedHeader (and any future comparison) handles arbitrary ordering.
+        if (i % 2 == 1)
+            std::reverse(patch_columns_to_read_names.begin(), patch_columns_to_read_names.end());
+#endif
+
         result.patch_columns[i] = storage_snapshot->getColumnsByNames(options, patch_columns_to_read_names);
     }
 

--- a/src/Storages/MergeTree/MergeTreeBlockReadUtils.cpp
+++ b/src/Storages/MergeTree/MergeTreeBlockReadUtils.cpp
@@ -390,6 +390,12 @@ void addPatchPartsColumns(
         required_virtuals.insert(patch_system_columns.begin(), patch_system_columns.end());
 
         Names patch_columns_to_read_names(patch_columns_to_read_set.begin(), patch_columns_to_read_set.end());
+        /// Sort the column names to ensure deterministic column order in patch blocks.
+        /// Without sorting, the iteration order of NameSet (unordered_set) is non-deterministic,
+        /// and different patch parts reading the same columns can produce blocks with different
+        /// column orderings. This causes LOGICAL_ERROR in assertCompatibleHeader when
+        /// getUpdatedHeader compares patch headers positionally.
+        std::sort(patch_columns_to_read_names.begin(), patch_columns_to_read_names.end());
         result.patch_columns[i] = storage_snapshot->getColumnsByNames(options, patch_columns_to_read_names);
     }
 

--- a/src/Storages/MergeTree/PatchParts/applyPatches.cpp
+++ b/src/Storages/MergeTree/PatchParts/applyPatches.cpp
@@ -275,11 +275,12 @@ Block getUpdatedHeader(const PatchesToApply & patches, const NameSet & updated_c
                 header.erase(column.name);
         }
 
-        /// Sort columns by name to ensure deterministic order for cross-patch comparison.
-        /// Different patch parts (e.g., Merge vs Join mode) may read columns in different
-        /// orders due to non-deterministic NameSet iteration in addPatchPartsColumns.
-        /// The downstream consumers (createPatchForColumn, applyPatchesToBlockRaw) use
-        /// name-based lookups, so column order does not affect correctness.
+        /// Sort columns by name so that assertCompatibleHeader below compares
+        /// matching columns at the same positions. Patch blocks may arrive with
+        /// different column orderings because addPatchPartsColumns collects names
+        /// from a NameSet (unordered_set) whose iteration order is non-deterministic.
+        /// Downstream consumers use name-based lookups, so order does not matter
+        /// for correctness — only for this positional compatibility check.
         headers.push_back(header.sortColumns());
     }
 

--- a/src/Storages/MergeTree/PatchParts/applyPatches.cpp
+++ b/src/Storages/MergeTree/PatchParts/applyPatches.cpp
@@ -275,7 +275,12 @@ Block getUpdatedHeader(const PatchesToApply & patches, const NameSet & updated_c
                 header.erase(column.name);
         }
 
-        headers.push_back(std::move(header));
+        /// Sort columns by name to ensure deterministic order for cross-patch comparison.
+        /// Different patch parts (e.g., Merge vs Join mode) may read columns in different
+        /// orders due to non-deterministic NameSet iteration in addPatchPartsColumns.
+        /// The downstream consumers (createPatchForColumn, applyPatchesToBlockRaw) use
+        /// name-based lookups, so column order does not affect correctness.
+        headers.push_back(header.sortColumns());
     }
 
     for (size_t i = 1; i < headers.size(); ++i)

--- a/tests/queries/0_stateless/04034_patch_parts_column_order_mismatch.reference
+++ b/tests/queries/0_stateless/04034_patch_parts_column_order_mismatch.reference
@@ -1,0 +1,6 @@
+1	updated1	99	9.9	999	upd1
+2	updated1	99	9.9	999	upd1
+1	updated2	88	8.8	888	upd2
+2	updated2	88	8.8	888	upd2
+1	updated2	88	8.8	888	upd2
+2	updated2	88	8.8	888	upd2

--- a/tests/queries/0_stateless/04034_patch_parts_column_order_mismatch.sql
+++ b/tests/queries/0_stateless/04034_patch_parts_column_order_mismatch.sql
@@ -1,49 +1,47 @@
--- Tags: no-parallel-replicas, no-replicated-database, long
--- no-parallel-replicas: profile events may differ with parallel replicas.
--- no-replicated-database: fails due to additional shard.
-
 -- Regression test for https://github.com/ClickHouse/clickhouse-core-incidents/issues/1021
 -- When multiple patch parts (Merge + Join mode) update the same columns,
 -- the column ordering in patch blocks must be deterministic to avoid
 -- LOGICAL_ERROR "Block structure mismatch in patch parts stream".
+--
+-- In debug builds, addPatchPartsColumns deliberately reverses column order
+-- for odd-indexed patches to expose any code relying on positional column
+-- matching. Without the sort in getUpdatedHeader, this triggers the bug.
 
-SET insert_keeper_fault_injection_probability = 0.0;
 SET enable_lightweight_update = 1;
 
-DROP TABLE IF EXISTS t_patch_order SYNC;
+DROP TABLE IF EXISTS t_patch_order;
 
--- Create a table with several columns (more columns = more likely to trigger non-deterministic ordering)
 CREATE TABLE t_patch_order (id UInt64, a_col String, b_col UInt64, c_col Float64, d_col UInt32, e_col String)
-ENGINE = ReplicatedMergeTree('/zookeeper/{database}/t_patch_order/', '1')
-ORDER BY id
+ENGINE = MergeTree ORDER BY id
 SETTINGS
     enable_block_number_column = 1,
     enable_block_offset_column = 1,
     apply_patches_on_merge = 0;
 
--- Insert two separate blocks to create two base parts
+-- Insert two separate blocks to create two base parts.
 INSERT INTO t_patch_order VALUES (1, 'hello', 10, 1.5, 100, 'world');
 INSERT INTO t_patch_order VALUES (2, 'foo', 20, 2.5, 200, 'bar');
 
--- First UPDATE: creates Merge-mode patch parts for both base parts
+-- First UPDATE: creates Merge-mode patch parts for both base parts.
 UPDATE t_patch_order SET a_col = 'updated1', b_col = 99, c_col = 9.9, d_col = 999, e_col = 'upd1' WHERE 1;
 
--- Verify before merge
+-- Verify patch application works in Merge mode.
 SELECT * FROM t_patch_order ORDER BY id;
 
--- Merge base parts into one part; patches become Join-mode
-OPTIMIZE TABLE t_patch_order PARTITION ID 'all' FINAL;
+-- Merge base parts; patches become Join-mode (apply_patches_on_merge = 0).
+OPTIMIZE TABLE t_patch_order FINAL;
 
--- Second UPDATE: creates new Merge-mode patch parts for the merged base part
+-- Second UPDATE: creates new Merge-mode patch parts for the merged base part.
 UPDATE t_patch_order SET a_col = 'updated2', b_col = 88, c_col = 8.8, d_col = 888, e_col = 'upd2' WHERE 1;
 
--- This SELECT must apply both Join-mode (from before merge) and Merge-mode (after merge) patches.
--- Before the fix, this could fail with LOGICAL_ERROR due to non-deterministic column ordering
--- in patch blocks from different modes.
+-- This SELECT must apply both Join-mode and Merge-mode patches simultaneously.
+-- In debug builds, patch column order is deliberately reversed for odd-indexed
+-- patches. Without the fix, getUpdatedHeader throws LOGICAL_ERROR because it
+-- compares patch headers positionally.
 SELECT * FROM t_patch_order ORDER BY id;
 
--- Also verify with APPLY PATCHES
+-- Materialize patches and verify final state.
 ALTER TABLE t_patch_order APPLY PATCHES SETTINGS mutations_sync = 2;
 SELECT * FROM t_patch_order ORDER BY id SETTINGS apply_patch_parts = 0;
 
-DROP TABLE t_patch_order SYNC;
+DROP TABLE t_patch_order;

--- a/tests/queries/0_stateless/04034_patch_parts_column_order_mismatch.sql
+++ b/tests/queries/0_stateless/04034_patch_parts_column_order_mismatch.sql
@@ -3,11 +3,13 @@
 -- the column ordering in patch blocks must be deterministic to avoid
 -- LOGICAL_ERROR "Block structure mismatch in patch parts stream".
 --
--- In debug builds, addPatchPartsColumns deliberately reverses column order
--- for odd-indexed patches to expose any code relying on positional column
--- matching. Without the sort in getUpdatedHeader, this triggers the bug.
+-- The failpoint reverses column order for odd-indexed patches to expose any
+-- code relying on positional column matching. Without the sort in
+-- getUpdatedHeader, this triggers the bug.
 
 SET enable_lightweight_update = 1;
+
+SYSTEM ENABLE FAILPOINT patch_parts_reverse_column_order;
 
 DROP TABLE IF EXISTS t_patch_order;
 
@@ -35,13 +37,14 @@ OPTIMIZE TABLE t_patch_order FINAL;
 UPDATE t_patch_order SET a_col = 'updated2', b_col = 88, c_col = 8.8, d_col = 888, e_col = 'upd2' WHERE 1;
 
 -- This SELECT must apply both Join-mode and Merge-mode patches simultaneously.
--- In debug builds, patch column order is deliberately reversed for odd-indexed
--- patches. Without the fix, getUpdatedHeader throws LOGICAL_ERROR because it
--- compares patch headers positionally.
+-- The failpoint reverses column order for odd-indexed patches. Without the fix,
+-- getUpdatedHeader throws LOGICAL_ERROR because it compares patch headers positionally.
 SELECT * FROM t_patch_order ORDER BY id;
 
 -- Materialize patches and verify final state.
 ALTER TABLE t_patch_order APPLY PATCHES SETTINGS mutations_sync = 2;
 SELECT * FROM t_patch_order ORDER BY id SETTINGS apply_patch_parts = 0;
+
+SYSTEM DISABLE FAILPOINT patch_parts_reverse_column_order;
 
 DROP TABLE t_patch_order;

--- a/tests/queries/0_stateless/04034_patch_parts_column_order_mismatch.sql
+++ b/tests/queries/0_stateless/04034_patch_parts_column_order_mismatch.sql
@@ -1,0 +1,49 @@
+-- Tags: no-parallel-replicas, no-replicated-database, long
+-- no-parallel-replicas: profile events may differ with parallel replicas.
+-- no-replicated-database: fails due to additional shard.
+
+-- Regression test for https://github.com/ClickHouse/clickhouse-core-incidents/issues/1021
+-- When multiple patch parts (Merge + Join mode) update the same columns,
+-- the column ordering in patch blocks must be deterministic to avoid
+-- LOGICAL_ERROR "Block structure mismatch in patch parts stream".
+
+SET insert_keeper_fault_injection_probability = 0.0;
+SET enable_lightweight_update = 1;
+
+DROP TABLE IF EXISTS t_patch_order SYNC;
+
+-- Create a table with several columns (more columns = more likely to trigger non-deterministic ordering)
+CREATE TABLE t_patch_order (id UInt64, a_col String, b_col UInt64, c_col Float64, d_col UInt32, e_col String)
+ENGINE = ReplicatedMergeTree('/zookeeper/{database}/t_patch_order/', '1')
+ORDER BY id
+SETTINGS
+    enable_block_number_column = 1,
+    enable_block_offset_column = 1,
+    apply_patches_on_merge = 0;
+
+-- Insert two separate blocks to create two base parts
+INSERT INTO t_patch_order VALUES (1, 'hello', 10, 1.5, 100, 'world');
+INSERT INTO t_patch_order VALUES (2, 'foo', 20, 2.5, 200, 'bar');
+
+-- First UPDATE: creates Merge-mode patch parts for both base parts
+UPDATE t_patch_order SET a_col = 'updated1', b_col = 99, c_col = 9.9, d_col = 999, e_col = 'upd1' WHERE 1;
+
+-- Verify before merge
+SELECT * FROM t_patch_order ORDER BY id;
+
+-- Merge base parts into one part; patches become Join-mode
+OPTIMIZE TABLE t_patch_order PARTITION ID 'all' FINAL;
+
+-- Second UPDATE: creates new Merge-mode patch parts for the merged base part
+UPDATE t_patch_order SET a_col = 'updated2', b_col = 88, c_col = 8.8, d_col = 888, e_col = 'upd2' WHERE 1;
+
+-- This SELECT must apply both Join-mode (from before merge) and Merge-mode (after merge) patches.
+-- Before the fix, this could fail with LOGICAL_ERROR due to non-deterministic column ordering
+-- in patch blocks from different modes.
+SELECT * FROM t_patch_order ORDER BY id;
+
+-- Also verify with APPLY PATCHES
+ALTER TABLE t_patch_order APPLY PATCHES SETTINGS mutations_sync = 2;
+SELECT * FROM t_patch_order ORDER BY id SETTINGS apply_patch_parts = 0;
+
+DROP TABLE t_patch_order SYNC;


### PR DESCRIPTION
<!-- Fixes issue link part, do not remove -->
## Linked issues
- fixes https://github.com/ClickHouse/clickhouse-core-incidents/issues/1021
<!-- End of fixes issue link part, do not remove -->

## Issue
In `addPatchPartsColumns`, patch column names are collected into a `NameSet` (std::unordered_set) and then converted to a Names vector. The iteration order of std::unordered_set is non-deterministic and depends on the standard library's hash table implementation. When two patch parts have different system column sets (Merge mode uses `{_part, _part_offset, _data_version}`, Join mode uses `{_block_number, _block_offset, _data_version})`, the different hash table layouts can cause user columns to iterate in different orders. `getUpdatedHeader` then compares patch headers positionally via `assertCompatibleHeader`, which throws LOGICAL_ERROR on column name mismatch.

## The fix
Sort columns via `header.sortColumns()` in `getUpdatedHeader` before the cross-patch assertCompatibleHeader comparison — a defensive second layer, since the downstream consumers (`createPatchForColumn`, `applyPatchesToBlockRaw`) use name-based lookups and are unaffected by column order.

## The test
Add a `patch_parts_reverse_column_order` failpoint that deliberately reverses column order for odd-indexed patches, making the bug reproducible regardless of the standard library's hash table behavior. The regression test creates a scenario with both Merge and Join mode patches and verifies correct query results.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix LOGICAL_ERROR due to patch parts column order mismatch

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches MergeTree patch-part read/apply paths; while intended to be order-only, it affects how patch blocks are constructed/compared and could impact lightweight update/query behavior if assumptions change.
> 
> **Overview**
> Fixes a `LOGICAL_ERROR` when applying multiple patch parts by making patch-block column ordering deterministic.
> 
> Patch-part column lists are now sorted before reading, and `getUpdatedHeader` defensively sorts filtered patch headers prior to cross-patch `assertCompatibleHeader` checks. A new `patch_parts_reverse_column_order` failpoint and stateless regression test reproduce the prior mismatch between Merge- and Join-mode patches and verify stable results.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 232c29bfeadedf927b1a1cc8d44cf157ad4ad060. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.830`
- Backported to: `26.2.5.45`, `26.1.5.44`, `25.12.9.52`, `25.8.20.4`
<!-- ch-version-info:end -->