### PR TITLE
feat: Add session IDs to native protocol

### DIFF
--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -752,6 +752,9 @@ void Client::addExtraOptions(OptionsDescription & options_description)
         ("ssh-key-file", po::value<std::string>(), "File containing the SSH private key for authenticate with the server.")
         ("ssh-key-passphrase", po::value<std::string>(), "Passphrase for the SSH private key specified by --ssh-key-file.")
         ("quota_key", po::value<std::string>(), "A string to differentiate quotas when the user have keyed quotas configured on server")
+        ("session_id", po::value<std::string>(), "Session ID for native protocol. Enables session persistence across reconnections.")
+        ("session_timeout", po::value<unsigned>(), "Session timeout in seconds for native protocol named sessions (default: server decides)")
+        ("session_check", "Verify that the named session already exists; throw error if not")
         ("jwt", po::value<std::string>(), "Use JWT for authentication")
         ("one-time-password", po::value<std::string>(), "Time-based one-time password (TOTP) for two-factor authentication")
 #if USE_JWT_CPP && USE_SSL
@@ -904,6 +907,12 @@ void Client::processOptions(
         config().setString("ssh-key-passphrase", options["ssh-key-passphrase"].as<std::string>());
     if (options.contains("quota_key"))
         config().setString("quota_key", options["quota_key"].as<std::string>());
+    if (options.contains("session_id"))
+        config().setString("session_id", options["session_id"].as<std::string>());
+    if (options.contains("session_timeout"))
+        config().setUInt("session_timeout", options["session_timeout"].as<unsigned>());
+    if (options.contains("session_check"))
+        config().setBool("session_check", true);
     if (options.contains("max_client_network_bandwidth"))
         max_client_network_bandwidth = options["max_client_network_bandwidth"].as<int>();
     if (options.contains("compression"))

--- a/src/Client/Connection.cpp
+++ b/src/Client/Connection.cpp
@@ -513,6 +513,13 @@ void Connection::sendAddendum()
     if (server_revision >= DBMS_MIN_REVISION_WITH_VERSIONED_PARALLEL_REPLICAS_PROTOCOL)
         writeVarUInt(DBMS_PARALLEL_REPLICAS_PROTOCOL_VERSION, *out);
 
+    if (server_revision >= DBMS_MIN_REVISION_WITH_NAMED_SESSIONS)
+    {
+        writeStringBinary(session_id, *out);
+        writeVarUInt(session_timeout, *out);
+        writeBinary(static_cast<UInt8>(session_check ? 1 : 0), *out);
+    }
+
     out->next();
 }
 
@@ -1639,7 +1646,7 @@ void Connection::throwUnexpectedPacket(UInt64 packet_type, const char * expected
 
 ServerConnectionPtr Connection::createConnection(const ConnectionParameters & parameters, ContextPtr)
 {
-    return std::make_unique<Connection>(
+    auto connection = std::make_unique<Connection>(
         parameters.host,
         parameters.port,
         parameters.default_database,
@@ -1661,6 +1668,11 @@ ServerConnectionPtr Connection::createConnection(const ConnectionParameters & pa
         , parameters.jwt_provider
 #endif
         );
+
+    if (!parameters.session_id.empty())
+        connection->setSessionId(parameters.session_id, parameters.session_timeout, parameters.session_check);
+
+    return connection;
 }
 
 }

--- a/src/Client/Connection.h
+++ b/src/Client/Connection.h
@@ -84,6 +84,14 @@ public:
         throttler = throttler_;
     }
 
+    /// Set named session parameters for native protocol session persistence.
+    void setSessionId(const String & session_id_, UInt64 session_timeout_ = 0, bool session_check_ = false)
+    {
+        session_id = session_id_;
+        session_timeout = session_timeout_;
+        session_check = session_check_;
+    }
+
     /// Change default database. Changes will take effect on next reconnect.
     void setDefaultDatabase(const String & database) override;
 
@@ -201,6 +209,12 @@ private:
     SSHKey ssh_private_key;
 #endif
     String quota_key;
+
+    /// Named session support
+    String session_id;
+    UInt64 session_timeout = 0;
+    bool session_check = false;
+
 #if USE_JWT_CPP && USE_SSL
     String jwt;
     std::shared_ptr<JWTProvider> jwt_provider;

--- a/src/Client/ConnectionParameters.cpp
+++ b/src/Client/ConnectionParameters.cpp
@@ -153,6 +153,10 @@ ConnectionParameters::ConnectionParameters(const Poco::Util::AbstractConfigurati
 
     quota_key = config.getString("quota_key", "");
 
+    session_id = config.getString("session_id", "");
+    session_timeout = config.getUInt64("session_timeout", 0);
+    session_check = config.getBool("session_check", false);
+
     /// By default compression is disabled if address looks like localhost.
 
     /// Avoid DNS request if the host is "localhost".

--- a/src/Client/ConnectionParameters.h
+++ b/src/Client/ConnectionParameters.h
@@ -27,6 +27,9 @@ struct ConnectionParameters
     std::string proto_send_chunked = "notchunked";
     std::string proto_recv_chunked = "notchunked";
     std::string quota_key;
+    std::string session_id;
+    UInt64 session_timeout = 0;
+    bool session_check = false;
     SSHKey ssh_private_key;
     std::string jwt;
 #if USE_JWT_CPP && USE_SSL

--- a/src/Core/ProtocolDefines.h
+++ b/src/Core/ProtocolDefines.h
@@ -125,6 +125,9 @@ static constexpr auto DBMS_MIN_REVISION_WITH_REPLICATED_SERIALIZATION = 54482;
 
 static constexpr auto DBMS_MIN_REVISION_WITH_NULLABLE_SPARSE_SERIALIZATION = 54483;
 
+/// Named sessions in native protocol (session_id, session_timeout, session_check in addendum)
+static constexpr auto DBMS_MIN_REVISION_WITH_NAMED_SESSIONS = 54484;
+
 
 /// Version of ClickHouse TCP protocol.
 ///
@@ -133,5 +136,5 @@ static constexpr auto DBMS_MIN_REVISION_WITH_NULLABLE_SPARSE_SERIALIZATION = 544
 /// NOTE: DBMS_TCP_PROTOCOL_VERSION has nothing common with VERSION_REVISION,
 /// later is just a number for server version (one number instead of commit SHA)
 /// for simplicity (sometimes it may be more convenient in some use cases).
-static constexpr auto DBMS_TCP_PROTOCOL_VERSION = 54483;
+static constexpr auto DBMS_TCP_PROTOCOL_VERSION = 54484;
 }

--- a/src/Interpreters/Session.cpp
+++ b/src/Interpreters/Session.cpp
@@ -644,6 +644,67 @@ ContextMutablePtr Session::makeSessionContext(const String & session_name_, std:
     return session_context;
 }
 
+ContextMutablePtr Session::replaceWithNamedSession(const String & session_name_, std::chrono::steady_clock::duration timeout_, bool session_check_)
+{
+    if (!session_context)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "replaceWithNamedSession requires an existing session context");
+    if (query_context_created)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Session context must be replaced before any query context");
+    if (!user_id)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "replaceWithNamedSession requires authentication");
+
+    LOG_DEBUG(log, "Replacing unnamed session with named session: {}, user_id: {}",
+            session_name_, toString(*user_id));
+
+    /// Save client info from the current session context (prepared_client_info was already consumed).
+    ClientInfo current_client_info = session_context->getClientInfo();
+
+    /// Release the session tracker handle for the unnamed session.
+    session_tracker_handle = {};
+
+    /// Drop the unnamed session context.
+    session_context.reset();
+
+    /// Acquire or create the named session from storage.
+    std::shared_ptr<NamedSessionData> new_named_session;
+    bool new_named_session_created = false;
+    std::tie(new_named_session, new_named_session_created)
+        = NamedSessionsStorage::instance().acquireSession(global_context, *user_id, session_name_, timeout_, session_check_);
+
+    auto new_session_context = new_named_session->context;
+    new_session_context->makeSessionContext();
+
+    /// Restore client info (connection address, etc.) into the named session context.
+    new_session_context->setClientInfo(current_client_info);
+
+    auto access = new_session_context->getAccess();
+    UInt64 max_sessions_for_user = 0;
+    if (!access->tryGetUser())
+    {
+        new_session_context->setUser(*user_id, external_roles);
+        max_sessions_for_user = new_session_context->getSettingsRef()[Setting::max_sessions_for_user];
+    }
+    else
+    {
+        auto settings = access->getDefaultSettings();
+        const Field * max_session_for_user_field = settings.tryGet("max_sessions_for_user");
+        if (max_session_for_user_field)
+            max_sessions_for_user = max_session_for_user_field->safeGet<UInt64>();
+    }
+
+    session_context = std::move(new_session_context);
+    named_session = new_named_session;
+    named_session_created = new_named_session_created;
+    user = session_context->getUser();
+
+    session_tracker_handle = session_context->getSessionTracker().trackSession(
+        *user_id,
+        { session_name_ },
+        max_sessions_for_user);
+
+    return session_context;
+}
+
 ContextMutablePtr Session::makeQueryContext(const ClientInfo & query_client_info) const
 {
     return makeQueryContextImpl(&query_client_info, nullptr);

--- a/src/Interpreters/Session.h
+++ b/src/Interpreters/Session.h
@@ -86,6 +86,12 @@ public:
     /// The function also assigns an user to this context.
     ContextMutablePtr makeSessionContext();
     ContextMutablePtr makeSessionContext(const String & session_name_, std::chrono::steady_clock::duration timeout_, bool session_check_);
+
+    /// Replaces the current (unnamed) session context with a named session.
+    /// Used by the native protocol where the session_id arrives in the addendum,
+    /// after the unnamed session context has already been created.
+    ContextMutablePtr replaceWithNamedSession(const String & session_name_, std::chrono::steady_clock::duration timeout_, bool session_check_);
+
     ContextMutablePtr sessionContext() { return session_context; }
     ContextPtr sessionContext() const { return session_context; }
 

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -186,6 +186,24 @@ namespace DB::ErrorCodes
 
 namespace
 {
+
+/// Parse and clamp session timeout for native protocol named sessions.
+/// Uses the same config keys as the HTTP interface: default_session_timeout, max_session_timeout.
+std::chrono::steady_clock::duration parseNativeSessionTimeout(
+    const Poco::Util::AbstractConfiguration & config,
+    UInt64 requested_timeout_seconds)
+{
+    unsigned default_timeout = config.getUInt("default_session_timeout", 60);
+    unsigned max_timeout = config.getUInt("max_session_timeout", 3600);
+
+    unsigned timeout = requested_timeout_seconds > 0
+        ? static_cast<unsigned>(std::min<UInt64>(requested_timeout_seconds, std::numeric_limits<unsigned>::max()))
+        : default_timeout;
+
+    timeout = std::min(timeout, max_timeout);
+    return std::chrono::seconds(timeout);
+}
+
 // This function corrects the wrong client_name from the old client.
 // Old clients 28.7 and some intermediate versions of 28.7 were sending different ClientInfo.client_name
 // "ClickHouse client" was sent with the hello message.
@@ -338,7 +356,22 @@ TCPHandler::TCPHandler(
 }
 
 
-TCPHandler::~TCPHandler() = default;
+TCPHandler::~TCPHandler()
+{
+    /// Release the named session (if any) so it can be resumed by another connection.
+    /// For unnamed sessions this is a no-op.
+    if (session && !session_id.empty())
+    {
+        try
+        {
+            session->releaseSessionID();
+        }
+        catch (...)
+        {
+            tryLogCurrentException(__PRETTY_FUNCTION__);
+        }
+    }
+}
 
 
 void TCPHandler::runImpl()
@@ -373,14 +406,27 @@ void TCPHandler::runImpl()
         if (!default_database.empty())
             DatabaseCatalog::instance().assertDatabaseExists(default_database);
 
-        /// In interserver mode queries are executed without a session context.
-        if (!is_interserver_mode)
-            session->makeSessionContext();
-
+        /// sendHello uses sessionOrGlobalContext() for server settings, so it can be
+        /// called before makeSessionContext(). This allows us to receive the session_id
+        /// from the addendum first, then create the appropriate session context.
         sendHello();
 
         if (client_tcp_protocol_version >= DBMS_MIN_PROTOCOL_VERSION_WITH_ADDENDUM)
             receiveAddendum();
+
+        /// In interserver mode queries are executed without a session context.
+        if (!is_interserver_mode)
+        {
+            if (!session_id.empty())
+            {
+                auto timeout = parseNativeSessionTimeout(server.config(), session_timeout_seconds);
+                session->makeSessionContext(session_id, timeout, session_check);
+            }
+            else
+            {
+                session->makeSessionContext();
+            }
+        }
 
         {
             /// Server side of chunked protocol negotiation.
@@ -1987,6 +2033,15 @@ void TCPHandler::receiveAddendum()
 
     if (client_tcp_protocol_version >= DBMS_MIN_REVISION_WITH_VERSIONED_PARALLEL_REPLICAS_PROTOCOL)
         readVarUInt(client_parallel_replicas_protocol_version, *in);
+
+    if (client_tcp_protocol_version >= DBMS_MIN_REVISION_WITH_NAMED_SESSIONS)
+    {
+        readStringBinary(session_id, *in);
+        readVarUInt(session_timeout_seconds, *in);
+        UInt8 session_check_flag = 0;
+        readBinary(session_check_flag, *in);
+        session_check = (session_check_flag != 0);
+    }
 }
 
 
@@ -2049,10 +2104,10 @@ void TCPHandler::sendHello()
     if (client_tcp_protocol_version >= DBMS_MIN_REVISION_WITH_SERVER_SETTINGS)
     {
         if (is_interserver_mode ||
-            !session->sessionContext()->getSettingsRef()[Setting::apply_settings_from_server])
+            !session->sessionOrGlobalContext()->getSettingsRef()[Setting::apply_settings_from_server])
             Settings::writeEmpty(*out); // send empty list of setting changes
         else
-            session->sessionContext()->getSettingsRef().write(*out, SettingsWriteFormat::STRINGS_WITH_FLAGS);
+            session->sessionOrGlobalContext()->getSettingsRef().write(*out, SettingsWriteFormat::STRINGS_WITH_FLAGS);
     }
 
     if (client_tcp_protocol_version >= DBMS_MIN_REVISION_WITH_QUERY_PLAN_SERIALIZATION)

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -406,26 +406,21 @@ void TCPHandler::runImpl()
         if (!default_database.empty())
             DatabaseCatalog::instance().assertDatabaseExists(default_database);
 
-        /// sendHello uses sessionOrGlobalContext() for server settings, so it can be
-        /// called before makeSessionContext(). This allows us to receive the session_id
-        /// from the addendum first, then create the appropriate session context.
+        /// In interserver mode queries are executed without a session context.
+        if (!is_interserver_mode)
+            session->makeSessionContext();
+
         sendHello();
 
         if (client_tcp_protocol_version >= DBMS_MIN_PROTOCOL_VERSION_WITH_ADDENDUM)
             receiveAddendum();
 
-        /// In interserver mode queries are executed without a session context.
-        if (!is_interserver_mode)
+        /// If the client sent a session_id in the addendum, upgrade the unnamed
+        /// session to a named session so it can persist across TCP reconnects.
+        if (!is_interserver_mode && !session_id.empty())
         {
-            if (!session_id.empty())
-            {
-                auto timeout = parseNativeSessionTimeout(server.config(), session_timeout_seconds);
-                session->makeSessionContext(session_id, timeout, session_check);
-            }
-            else
-            {
-                session->makeSessionContext();
-            }
+            auto timeout = parseNativeSessionTimeout(server.config(), session_timeout_seconds);
+            session->replaceWithNamedSession(session_id, timeout, session_check);
         }
 
         {
@@ -2104,10 +2099,10 @@ void TCPHandler::sendHello()
     if (client_tcp_protocol_version >= DBMS_MIN_REVISION_WITH_SERVER_SETTINGS)
     {
         if (is_interserver_mode ||
-            !session->sessionOrGlobalContext()->getSettingsRef()[Setting::apply_settings_from_server])
-            Settings::writeEmpty(*out); // send empty list of setting changes
+            !session->sessionContext()->getSettingsRef()[Setting::apply_settings_from_server])
+            Settings::writeEmpty(*out);
         else
-            session->sessionOrGlobalContext()->getSettingsRef().write(*out, SettingsWriteFormat::STRINGS_WITH_FLAGS);
+            session->sessionContext()->getSettingsRef().write(*out, SettingsWriteFormat::STRINGS_WITH_FLAGS);
     }
 
     if (client_tcp_protocol_version >= DBMS_MIN_REVISION_WITH_QUERY_PLAN_SERIALIZATION)

--- a/src/Server/TCPHandler.h
+++ b/src/Server/TCPHandler.h
@@ -206,6 +206,11 @@ private:
     String proto_recv_chunked_cl = "notchunked";
     String quota_key;
 
+    /// Named session support (like HTTP's session_id parameter)
+    String session_id;
+    UInt64 session_timeout_seconds = 0;
+    bool session_check = false;
+
     /// Connection settings, which are extracted from a context.
     bool send_exception_with_stack_trace = true;
     Poco::Timespan send_timeout = Poco::Timespan(DBMS_DEFAULT_SEND_TIMEOUT_SEC, 0);

--- a/tests/queries/0_stateless/04032_native_protocol_named_sessions.reference
+++ b/tests/queries/0_stateless/04032_native_protocol_named_sessions.reference
@@ -17,6 +17,8 @@ A session successfully expires after a timeout:
 111
 A session successfully expires after a timeout and the session's temporary table shadows the permanent table:
 HelloWorld
+Settings persist across reconnects in a named session:
+42
 A session cannot be used by concurrent connections:
 1
 1

--- a/tests/queries/0_stateless/04032_native_protocol_named_sessions.reference
+++ b/tests/queries/0_stateless/04032_native_protocol_named_sessions.reference
@@ -1,0 +1,22 @@
+Using non-existent session with the session_check flag will throw exception:
+1
+Using non-existent session without the session_check flag will create a new session:
+1
+1
+Valid session_timeout values are accepted:
+1
+1
+1
+Sessions are local per user:
+1
+Hello
+World
+The temporary tables created in a session are not accessible without entering this session:
+1
+A session successfully expires after a timeout:
+111
+A session successfully expires after a timeout and the session's temporary table shadows the permanent table:
+HelloWorld
+A session cannot be used by concurrent connections:
+1
+1

--- a/tests/queries/0_stateless/04032_native_protocol_named_sessions.sh
+++ b/tests/queries/0_stateless/04032_native_protocol_named_sessions.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Tags: long
+
+# Native protocol equivalent of 00463_long_sessions_in_http_interface.
+# Tests named sessions over the TCP protocol (session_id in the handshake addendum).
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+echo "Using non-existent session with the session_check flag will throw exception:"
+${CLICKHOUSE_CLIENT} --session_id="nonexistent_04032" --session_check -q "SELECT 1" 2>&1 | grep -c -F 'SESSION_NOT_FOUND'
+
+echo "Using non-existent session without the session_check flag will create a new session:"
+${CLICKHOUSE_CLIENT} --session_id="${CLICKHOUSE_DATABASE}_04032_1" -q "SELECT 1"
+${CLICKHOUSE_CLIENT} --session_id="${CLICKHOUSE_DATABASE}_04032_1" -q "SELECT 1"
+
+echo "Valid session_timeout values are accepted:"
+${CLICKHOUSE_CLIENT} --session_id="${CLICKHOUSE_DATABASE}_04032_3" --session_timeout=0 -q "SELECT 1"
+${CLICKHOUSE_CLIENT} --session_id="${CLICKHOUSE_DATABASE}_04032_4" --session_timeout=3600 -q "SELECT 1"
+${CLICKHOUSE_CLIENT} --session_id="${CLICKHOUSE_DATABASE}_04032_5" --session_timeout=60 -q "SELECT 1"
+
+echo "Sessions are local per user:"
+${CLICKHOUSE_CLIENT} -q "DROP USER IF EXISTS test_04032"
+${CLICKHOUSE_CLIENT} -q "CREATE USER test_04032"
+${CLICKHOUSE_CLIENT} -q "GRANT CURRENT GRANTS(ALL ON *.*) TO test_04032"
+
+${CLICKHOUSE_CLIENT} --session_id="${CLICKHOUSE_DATABASE}_04032_6" --session_timeout=600 -q "CREATE TEMPORARY TABLE t (s String)"
+${CLICKHOUSE_CLIENT} --session_id="${CLICKHOUSE_DATABASE}_04032_6" -q "INSERT INTO t VALUES ('Hello')"
+
+# Different user with same session_id should not find the first user's session
+${CLICKHOUSE_CLIENT} --user=test_04032 --session_id="${CLICKHOUSE_DATABASE}_04032_6" --session_check -q "SELECT 1" 2>&1 | grep -c -F 'SESSION_NOT_FOUND'
+
+# Different user creates their own session with same session_id
+${CLICKHOUSE_CLIENT} --user=test_04032 --session_id="${CLICKHOUSE_DATABASE}_04032_6" --session_timeout=600 -q "CREATE TEMPORARY TABLE t (s String)"
+${CLICKHOUSE_CLIENT} --user=test_04032 --session_id="${CLICKHOUSE_DATABASE}_04032_6" -q "INSERT INTO t VALUES ('World')"
+
+# Each user sees their own temp table
+${CLICKHOUSE_CLIENT} --session_id="${CLICKHOUSE_DATABASE}_04032_6" -q "SELECT * FROM t"
+${CLICKHOUSE_CLIENT} --user=test_04032 --session_id="${CLICKHOUSE_DATABASE}_04032_6" -q "SELECT * FROM t"
+
+${CLICKHOUSE_CLIENT} -q "DROP USER test_04032";
+
+echo "The temporary tables created in a session are not accessible without entering this session:"
+${CLICKHOUSE_CLIENT} -q "SELECT * FROM t" 2>&1 | grep -c -F 'UNKNOWN_TABLE'
+
+echo "A session successfully expires after a timeout:"
+# Use a retry loop like the HTTP test to handle timing variability
+while true
+do
+    (
+        ${CLICKHOUSE_CLIENT} --session_id="${CLICKHOUSE_DATABASE}_04032_7" --session_timeout=1 -q "SELECT 1"
+        ${CLICKHOUSE_CLIENT} --session_id="${CLICKHOUSE_DATABASE}_04032_7" --session_check -q "SELECT 1"
+        sleep 3
+        ${CLICKHOUSE_CLIENT} --session_id="${CLICKHOUSE_DATABASE}_04032_7" --session_check -q "SELECT 1" 2>&1 | grep -c -F 'SESSION_NOT_FOUND'
+    ) | tr -d '\n' | grep -F '111' && break || sleep 1
+done
+
+echo "A session successfully expires after a timeout and the session's temporary table shadows the permanent table:"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS t_04032; CREATE TABLE t_04032 (s String) ENGINE = Memory; INSERT INTO t_04032 VALUES ('World');"
+while true
+do
+    (
+        ${CLICKHOUSE_CLIENT} --session_id="${CLICKHOUSE_DATABASE}_04032_8" --session_timeout=1 -q "CREATE TEMPORARY TABLE t_04032 (s String)"
+        ${CLICKHOUSE_CLIENT} --session_id="${CLICKHOUSE_DATABASE}_04032_8" -q "INSERT INTO t_04032 VALUES ('Hello')"
+        ${CLICKHOUSE_CLIENT} --session_id="${CLICKHOUSE_DATABASE}_04032_8" -q "SELECT * FROM t_04032"
+        sleep 3
+        ${CLICKHOUSE_CLIENT} --session_id="${CLICKHOUSE_DATABASE}_04032_8" -q "SELECT * FROM t_04032"
+    ) | tr -d '\n' | grep -F 'HelloWorld' && break || sleep 1
+done
+${CLICKHOUSE_CLIENT} -q "DROP TABLE t_04032"
+
+echo "A session cannot be used by concurrent connections:"
+${CLICKHOUSE_CLIENT} --session_id="${CLICKHOUSE_DATABASE}_04032_9" --session_timeout=60 --max_rows_to_read=0 --query_id="${CLICKHOUSE_DATABASE}_04032_9" -q "SELECT count() FROM system.numbers" >/dev/null 2>&1 &
+
+# Wait for the query to start
+while true
+do
+    ${CLICKHOUSE_CLIENT} -q "SELECT count() > 0 FROM system.processes WHERE query_id = '${CLICKHOUSE_DATABASE}_04032_9'" | grep -F '1' && break || sleep 1
+done
+
+${CLICKHOUSE_CLIENT} --session_id="${CLICKHOUSE_DATABASE}_04032_9" -q "SELECT 1" 2>&1 | grep -c -F 'SESSION_IS_LOCKED'
+${CLICKHOUSE_CLIENT} -q "KILL QUERY WHERE query_id = '${CLICKHOUSE_DATABASE}_04032_9' SYNC FORMAT Null";
+wait

--- a/tests/queries/0_stateless/04032_native_protocol_named_sessions.sh
+++ b/tests/queries/0_stateless/04032_native_protocol_named_sessions.sh
@@ -70,6 +70,10 @@ do
 done
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE t_04032"
 
+echo "Settings persist across reconnects in a named session:"
+${CLICKHOUSE_CLIENT} --session_id="${CLICKHOUSE_DATABASE}_04032_10" --session_timeout=60 -q "SET max_threads=42"
+${CLICKHOUSE_CLIENT} --session_id="${CLICKHOUSE_DATABASE}_04032_10" -q "SELECT getSetting('max_threads')"
+
 echo "A session cannot be used by concurrent connections:"
 ${CLICKHOUSE_CLIENT} --session_id="${CLICKHOUSE_DATABASE}_04032_9" --session_timeout=60 --max_rows_to_read=0 --query_id="${CLICKHOUSE_DATABASE}_04032_9" -q "SELECT count() FROM system.numbers" >/dev/null 2>&1 &
 


### PR DESCRIPTION
### Changelog category (leave one):
- New Feature

### Changelog entry 
Allows you to set `session-id`s on Native protocol connections in parity with HTTP connections.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

Lets you add `session-id`s on the native ClickHouse protocol. This has similar semantics to when it is specified with the HTTP protocol.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a TCP protocol bump and new handshake fields affecting client/server interoperability and session lifecycle; mistakes could break connections or leave sessions locked/leaked under reconnect/disconnect scenarios.
> 
> **Overview**
> Adds **named session support to the native (TCP) protocol** by extending the handshake addendum with `session_id`, `session_timeout`, and `session_check`, enabling session persistence (settings/temp tables) across reconnects.
> 
> Updates the CLI and `ConnectionParameters` to accept/pass these options, updates `Connection` to send them when supported, and updates `TCPHandler`/`Session` to parse them, upgrade an initial unnamed session into a named one, clamp timeouts via existing session-timeout config, and explicitly release the session on TCP handler destruction. Includes a new stateless test validating creation/check semantics, per-user isolation, timeout expiry, settings persistence, and session locking under concurrent use.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1cc4168a73853e575cf7e06c89c0af40b3ae4d5c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->