### PR TITLE
Add `is_subrequest` column to aggregated zookeeper log

### DIFF
--- a/ci/jobs/scripts/check_style/aspell-ignore/en/aspell-dict.txt
+++ b/ci/jobs/scripts/check_style/aspell-ignore/en/aspell-dict.txt
@@ -3169,6 +3169,7 @@ subqueries
 subquery
 subranges
 subreddits
+subrequest
 subsecond
 subseconds
 subsequence

--- a/ci/jobs/scripts/check_style/aspell-ignore/en/aspell-dict.txt
+++ b/ci/jobs/scripts/check_style/aspell-ignore/en/aspell-dict.txt
@@ -1132,6 +1132,8 @@ Subcolumns
 Subexpression
 Submodules
 Subqueries
+Subrequest
+Subrequests
 Substrings
 SummingMergeTree
 SuperSet

--- a/docs/en/operations/system-tables/aggregated_zookeeper_log.md
+++ b/docs/en/operations/system-tables/aggregated_zookeeper_log.md
@@ -1,0 +1,35 @@
+---
+description: 'System table containing aggregated statistics of ZooKeeper operations
+  grouped by session, path, operation type, component, and subrequest flag.'
+keywords: ['system table', 'aggregated_zookeeper_log']
+slug: /operations/system-tables/aggregated_zookeeper_log
+title: 'system.aggregated_zookeeper_log'
+doc_type: 'reference'
+---
+
+# system.aggregated_zookeeper_log
+
+This table contains aggregated statistics of ZooKeeper operations (e.g. number of operations, average latency, errors) grouped by `(session_id, parent_path, operation, component, is_subrequest)` and periodically flushed to disk.
+
+Unlike [system.zookeeper_log](zookeeper_log.md) which logs every individual request and response, this table aggregates operations into groups, making it much more lightweight and therefore more suitable for production workloads.
+
+Operations that are part of a `Multi` or `MultiRead` batch are tracked separately via the `is_subrequest` column. Subrequests have zero latency because the total latency is attributed to the enclosing `Multi`/`MultiRead` operation.
+
+Columns:
+
+- `hostname` ([LowCardinality(String)](../../sql-reference/data-types/string.md)) — Hostname of the server.
+- `event_date` ([Date](../../sql-reference/data-types/date.md)) — Date the group was flushed.
+- `event_time` ([DateTime](../../sql-reference/data-types/datetime.md)) — Time the group was flushed.
+- `session_id` ([Int64](../../sql-reference/data-types/int-uint.md)) — Session id.
+- `parent_path` ([String](../../sql-reference/data-types/string.md)) — Prefix of the path.
+- `operation` ([Enum](../../sql-reference/data-types/enum.md)) — Type of ZooKeeper operation.
+- `is_subrequest` ([UInt8](../../sql-reference/data-types/int-uint.md)) — Whether this operation was a subrequest inside a `Multi` or `MultiRead` operation.
+- `count` ([UInt32](../../sql-reference/data-types/int-uint.md)) — Number of operations in the group.
+- `errors` ([Map(Enum, UInt32)](../../sql-reference/data-types/map.md)) — Errors in the group, mapping error code to count.
+- `average_latency` ([Float64](../../sql-reference/data-types/float.md)) — Average latency across all operations in the group, in microseconds. Subrequests have zero latency because the latency is attributed to the enclosing `Multi` or `MultiRead` operation.
+- `component` ([LowCardinality(String)](../../sql-reference/data-types/string.md)) — Component that caused the event.
+
+**See Also**
+
+- [system.zookeeper_log](zookeeper_log.md) — Detailed per-request ZooKeeper log.
+- [ZooKeeper](../../operations/tips.md#zookeeper)

--- a/src/Common/ZooKeeper/ZooKeeperImpl.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperImpl.cpp
@@ -2008,7 +2008,7 @@ void ZooKeeper::logOperationIfNeeded(const ZooKeeperRequestPtr &, const ZooKeepe
 {}
 #endif
 
-void ZooKeeper::observeOperation(const ZooKeeperRequest * request, const Response * response, UInt64 elapsed_microseconds, StaticString component)
+void ZooKeeper::observeOperation(const ZooKeeperRequest * request, const Response * response, UInt64 elapsed_microseconds, StaticString component, bool is_subrequest)
 {
     chassert(response);
 
@@ -2021,7 +2021,7 @@ void ZooKeeper::observeOperation(const ZooKeeperRequest * request, const Respons
         if (const auto * watch_response = dynamic_cast<const ZooKeeperWatchResponse *>(response))
         {
             current_aggregated_zookeeper_log->observe(
-                session_id, watch_response->tryGetOpNum(), watch_response->path, elapsed_microseconds, watch_response->error, component);
+                session_id, watch_response->tryGetOpNum(), watch_response->path, elapsed_microseconds, watch_response->error, component, is_subrequest);
         }
         else
         {
@@ -2030,7 +2030,7 @@ void ZooKeeper::observeOperation(const ZooKeeperRequest * request, const Respons
         return;
     }
 
-    current_aggregated_zookeeper_log->observe(session_id, request->tryGetOpNum(), request->getPath(), elapsed_microseconds, response->error, component);
+    current_aggregated_zookeeper_log->observe(session_id, request->tryGetOpNum(), request->getPath(), elapsed_microseconds, response->error, component, is_subrequest);
 
     const auto * multi_response = dynamic_cast<const ZooKeeperMultiResponse *>(response);
 
@@ -2044,7 +2044,7 @@ void ZooKeeper::observeOperation(const ZooKeeperRequest * request, const Respons
 
     for (const auto [subrequest, subresponse] : std::views::zip(multi_request.requests, multi_response->responses))
     {
-        observeOperation(subrequest.get(), subresponse.get(), elapsed_microseconds, component);
+        observeOperation(subrequest.get(), subresponse.get(), /*elapsed_microseconds=*/0, component, /*is_subrequest=*/true);
     }
 }
 

--- a/src/Common/ZooKeeper/ZooKeeperImpl.h
+++ b/src/Common/ZooKeeper/ZooKeeperImpl.h
@@ -358,7 +358,7 @@ private:
     void logOperationIfNeeded(const ZooKeeperRequestPtr & request, const ZooKeeperResponsePtr & response = nullptr, bool finalize = false, UInt64 elapsed_microseconds = 0);
 
     /// Observes the operation in Aggregated ZooKeeper Log.
-    void observeOperation(const ZooKeeperRequest * request, const Response * response, UInt64 elapsed_microseconds, StaticString component);
+    void observeOperation(const ZooKeeperRequest * request, const Response * response, UInt64 elapsed_microseconds, StaticString component, bool is_subrequest = false);
 
     std::optional<String> tryGetSystemZnode(const std::string & path, const std::string & description);
 

--- a/src/Interpreters/AggregatedZooKeeperLog.cpp
+++ b/src/Interpreters/AggregatedZooKeeperLog.cpp
@@ -48,17 +48,21 @@ ColumnsDescription AggregatedZooKeeperLogElement::getColumnsDescription()
                 Coordination::SystemTablesDataTypes::operationEnum(),
                 "Type of ZooKeeper operation."});
 
+    result.add({"is_subrequest",
+                std::make_shared<DataTypeUInt8>(),
+                "Whether this operation was a subrequest inside a Multi or MultiRead operation."});
+
     result.add({"count",
                 std::make_shared<DataTypeUInt32>(),
-                "Number of operations in the (session_id, parent_path, operation) group."});
+                "Number of operations in the (session_id, parent_path, operation, component, is_subrequest) group."});
 
     result.add({"errors",
                 std::make_shared<DataTypeMap>(Coordination::SystemTablesDataTypes::errorCodeEnum(), std::make_shared<DataTypeUInt32>()),
-                "Errors in the (session_id, parent_path, operation) group."});
+                "Errors in the (session_id, parent_path, operation, component, is_subrequest) group."});
 
     result.add({"average_latency",
                 std::make_shared<DataTypeFloat64>(),
-                "Average latency across all operations in (session_id, parent_path, operation) group, in microseconds."});
+                "Average latency across all operations in (session_id, parent_path, operation, component, is_subrequest) group, in microseconds. Subrequests have zero latency because the latency is attributed to the enclosing Multi or MultiRead operation."});
 
     result.add({"component",
                 std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>()),
@@ -75,6 +79,7 @@ void AggregatedZooKeeperLogElement::appendToBlock(MutableColumns & columns) cons
     columns[i++]->insert(session_id);
     columns[i++]->insert(parent_path);
     columns[i++]->insert(operation);
+    columns[i++]->insert(static_cast<UInt8>(is_subrequest));
     columns[i++]->insert(count);
     errors->dumpToMapColumn(&typeid_cast<DB::ColumnMap &>(*columns[i++]));
     columns[i++]->insert(static_cast<Float64>(total_latency_microseconds) / count);
@@ -97,6 +102,7 @@ void AggregatedZooKeeperLog::stepFunction(TimePoint current_time)
             .parent_path = entry_key.parent_path,
             .operation = entry_key.operation,
             .component = entry_key.component,
+            .is_subrequest = entry_key.is_subrequest,
             .count = entry_stats.count,
             .errors = std::move(entry_stats.errors),
             .total_latency_microseconds = entry_stats.total_latency_microseconds,
@@ -111,7 +117,8 @@ void AggregatedZooKeeperLog::observe(
     const std::filesystem::path & path,
     UInt64 latency_microseconds,
     Coordination::Error error,
-    StaticString component)
+    StaticString component,
+    bool is_subrequest)
 {
     std::lock_guard lock(stats_mutex);
 
@@ -119,7 +126,8 @@ void AggregatedZooKeeperLog::observe(
         .session_id = session_id,
         .operation = operation,
         .parent_path = path.parent_path(),
-        .component = component
+        .component = component,
+        .is_subrequest = is_subrequest
     };
     stats[std::move(entry_key)].observe(latency_microseconds, error);
 }
@@ -129,7 +137,7 @@ size_t AggregatedZooKeeperLog::EntryKeyHash::operator()(const EntryKey & entry_k
     return CityHash_v1_0_2::CityHash64WithSeed(
         entry_key.parent_path.data(),
         entry_key.parent_path.size(),
-        static_cast<uint64_t>(entry_key.operation) ^ static_cast<uint64_t>(entry_key.session_id));
+        static_cast<uint64_t>(entry_key.operation) ^ static_cast<uint64_t>(entry_key.session_id) ^ entry_key.is_subrequest);
 }
 
 void AggregatedZooKeeperLog::EntryStats::observe(UInt64 latency_microseconds, Coordination::Error error)

--- a/src/Interpreters/AggregatedZooKeeperLog.h
+++ b/src/Interpreters/AggregatedZooKeeperLog.h
@@ -19,6 +19,7 @@ struct AggregatedZooKeeperLogElement
     String parent_path;
     Int32 operation;
     StaticString component;
+    bool is_subrequest = false;
 
     /// Group statistics.
     UInt32 count;
@@ -45,7 +46,8 @@ public:
         const std::filesystem::path & path,
         UInt64 latency_microseconds,
         Coordination::Error error,
-        StaticString component);
+        StaticString component,
+        bool is_subrequest = false);
 
 private:
     struct EntryKey
@@ -54,6 +56,7 @@ private:
         Int32 operation;
         String parent_path;
         StaticString component;
+        bool is_subrequest = false;
 
         bool operator==(const EntryKey & other) const = default;
     };

--- a/tests/queries/0_stateless/01158_zookeeper_log_long.reference
+++ b/tests/queries/0_stateless/01158_zookeeper_log_long.reference
@@ -45,6 +45,6 @@ Response	0	Get	/test/01158/default/rmt/blocks/all_6308706741995381342_2495791770
 duration_microseconds
 1
 aggregated_zookeeper_log
-1	0	1	1
+1	1
+0	1	1
 1	1	0
-1

--- a/tests/queries/0_stateless/01158_zookeeper_log_long.reference
+++ b/tests/queries/0_stateless/01158_zookeeper_log_long.reference
@@ -45,4 +45,6 @@ Response	0	Get	/test/01158/default/rmt/blocks/all_6308706741995381342_2495791770
 duration_microseconds
 1
 aggregated_zookeeper_log
-1	1
+1	0	1	1
+1	1	0
+1

--- a/tests/queries/0_stateless/01158_zookeeper_log_long.sql
+++ b/tests/queries/0_stateless/01158_zookeeper_log_long.sql
@@ -69,3 +69,5 @@ select count()>0 from system.zookeeper_log where event_date >= yesterday() AND e
 system flush logs aggregated_zookeeper_log;
 select 'aggregated_zookeeper_log';
 select sum(errors[0]) > 0, sum(average_latency) > 0 from system.aggregated_zookeeper_log where parent_path = '/test/01158/' || currentDatabase() || '/rmt' and operation = 'Create';
+
+select is_subrequest, count() > 0, sum(average_latency) > 0 from system.aggregated_zookeeper_log where parent_path like '/test/01158/' || currentDatabase() || '/rmt%' and operation = 'Create' group by is_subrequest order by is_subrequest;


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add `is_subrequest` column to `system.aggregated_zookeeper_log` to separate standalone requests from sub-requests inside Multi/MultiRead requests. Previously, sub-requests were aggregated into the same buckets as standalone requests, and since each sub-operation was logged with the total multi-request duration, the average latency became misleading. Sub-requests now have zero latency.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `system.aggregated_zookeeper_log` schema and aggregation key, which can affect monitoring queries and test expectations; also tweaks latency attribution for `Multi`/`MultiRead` sub-operations.
> 
> **Overview**
> Adds an `is_subrequest` column to `system.aggregated_zookeeper_log` and includes it in the aggregation key so sub-operations from `Multi`/`MultiRead` are tracked separately from standalone requests.
> 
> Updates ZooKeeper client observation so subrequests are recorded with `is_subrequest=1` and `elapsed_microseconds=0` (latency attributed only to the enclosing multi op), and extends the log element/key/hash accordingly.
> 
> Introduces new user documentation for `system.aggregated_zookeeper_log`, adjusts the existing stateless test to assert presence/latency behavior for both `is_subrequest` values, and adds `Subrequest`/`subrequest` to the aspell ignore list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4934c19a630d8e2c9c48ef49351c315d07a42e99. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.586`
<!-- ch-version-info:end -->