### PR TITLE
[Draft] Add SortedStringKV data type

### DIFF
--- a/src/DataTypes/DataTypeFactory.cpp
+++ b/src/DataTypes/DataTypeFactory.cpp
@@ -363,6 +363,7 @@ DataTypeFactory::DataTypeFactory()
     registerDataTypeVariant(*this);
     registerDataTypeDynamic(*this);
     registerDataTypeJSON(*this);
+    registerDataTypeSortedStringKV(*this);
 }
 
 DataTypeFactory & DataTypeFactory::instance()

--- a/src/DataTypes/DataTypeFactory.h
+++ b/src/DataTypes/DataTypeFactory.h
@@ -104,5 +104,6 @@ void registerDataTypeDomainGeo(DataTypeFactory & factory);
 void registerDataTypeVariant(DataTypeFactory & factory);
 void registerDataTypeDynamic(DataTypeFactory & factory);
 void registerDataTypeJSON(DataTypeFactory & factory);
+void registerDataTypeSortedStringKV(DataTypeFactory & factory);
 
 }

--- a/src/DataTypes/DataTypeSortedStringKV.cpp
+++ b/src/DataTypes/DataTypeSortedStringKV.cpp
@@ -1,0 +1,36 @@
+#include <DataTypes/DataTypeSortedStringKV.h>
+#include <DataTypes/DataTypeTuple.h>
+#include <DataTypes/DataTypeString.h>
+#include <DataTypes/DataTypeFactory.h>
+#include <DataTypes/Serializations/SerializationSortedStringKV.h>
+#include <DataTypes/Serializations/SerializationNamed.h>
+#include <Parsers/IAST.h>
+
+namespace DB
+{
+
+static DataTypePtr create(const ASTPtr & /* arguments */)
+{
+    auto key_type = std::make_shared<DataTypeString>();
+    auto value_type = std::make_shared<DataTypeString>();
+
+    DataTypePtr type = std::make_shared<DataTypeTuple>(
+        DataTypes{key_type, value_type});
+
+    auto key_ser = std::make_shared<SerializationNamed>(key_type->getDefaultSerialization(), "key", SubstreamType::TupleElement);
+    auto val_ser = std::make_shared<SerializationNamed>(value_type->getDefaultSerialization(), "value", SubstreamType::TupleElement);
+    SerializationSortedStringKV::ElementSerializations elems = {key_ser, val_ser};
+
+    type->setCustomization(std::make_unique<DataTypeCustomDesc>(
+        std::make_unique<DataTypeSortedStringKV>(),
+        std::make_shared<SerializationSortedStringKV>(elems, true /* has_explicit_names */)));
+
+    return type;
+}
+
+void registerDataTypeSortedStringKV(DataTypeFactory & factory)
+{
+    factory.registerDataType("SortedStringKV", create);
+}
+
+}

--- a/src/DataTypes/DataTypeSortedStringKV.h
+++ b/src/DataTypes/DataTypeSortedStringKV.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <DataTypes/DataTypeCustom.h>
+
+namespace DB
+{
+
+class DataTypeSortedStringKV : public IDataTypeCustomName
+{
+public:
+    String getName() const override { return "SortedStringKV"; }
+};
+
+}

--- a/src/DataTypes/DataTypeTuple.cpp
+++ b/src/DataTypes/DataTypeTuple.cpp
@@ -215,7 +215,7 @@ MutableColumnPtr DataTypeTuple::createColumn(const ISerialization & serializatio
     if (const auto * serialization_replicated = typeid_cast<const SerializationReplicated *>(current_serialization))
         return ColumnReplicated::create(createColumn(*serialization_replicated->getNested()), ColumnUInt8::create());
 
-    const auto * serialization_tuple = typeid_cast<const SerializationTuple *>(current_serialization);
+    const auto * serialization_tuple = dynamic_cast<const SerializationTuple *>(current_serialization);
     if (!serialization_tuple)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected serialization to create column of type Tuple");
 
@@ -377,6 +377,10 @@ SerializationPtr DataTypeTuple::getSerialization(const SerializationInfo & info)
     auto kinds = info.getKindStack();
     /// Compatibility with older version that may propagate Sparse serialization for Tuple itself (in serialization.json)
     std::erase(kinds, ISerialization::Kind::SPARSE);
+
+    if (custom_serialization)
+        return IDataType::getSerialization(kinds, info.getSettings(), custom_serialization);
+
     return IDataType::getSerialization(
         kinds, info.getSettings(), std::make_shared<SerializationTuple>(std::move(serializations), has_explicit_names));
 }

--- a/src/DataTypes/Serializations/ISerialization.h
+++ b/src/DataTypes/Serializations/ISerialization.h
@@ -28,6 +28,8 @@ class ReadBuffer;
 class WriteBuffer;
 class ProtobufReader;
 class ProtobufWriter;
+class SSTFileWriteStream;
+class MergeTreeReaderStreamSingleColumnWholePart;
 
 class IDataType;
 using DataTypePtr = std::shared_ptr<const IDataType>;
@@ -348,6 +350,15 @@ public:
     using OutputStreamGetter = std::function<WriteBuffer*(const SubstreamPath &)>;
     using InputStreamGetter = std::function<ReadBuffer*(const SubstreamPath &)>;
     using StreamMarkGetter = std::function<MarkInCompressedFile(const SubstreamPath &)>;
+    /// Getter for SST write stream.
+    /// Injected by MergeTreeDataPartWriter and used by SST-based serializations
+    /// to obtain the SSTFileWriteStream without polluting the main stream_getter.
+    using SSTWriteStreamGetter = std::function<SSTFileWriteStream *(const SubstreamPath &)>;
+
+    /// Getter for SST read stream.
+    /// Injected by MergeTreeDataReader and used by SST-based serializations
+    /// to obtain the MergeTreeReaderStreamSingleColumnWholePart for deserialization.
+    using SSTReadStreamGetter = std::function<MergeTreeReaderStreamSingleColumnWholePart *(const SubstreamPath &)>;
 
     struct SerializeBinaryBulkSettings
     {
@@ -398,6 +409,14 @@ public:
         /// Type of MergeTree data part we serialize data from if any.
         /// Some serializations may differ from type part for more optimal deserialization.
         MergeTreeDataPartType data_part_type = MergeTreeDataPartType::Unknown;
+
+        /// Optional getter for SST file write stream.
+        /// When set, SST-based serializations use this to obtain the SSTFileWriteStream
+        SSTWriteStreamGetter sst_write_stream_getter;
+
+        /// Whether the current write starts a new granule/mark.
+        /// In Wide parts, continuation granules (where mark_on_start = false)
+        bool mark_on_start = true;
     };
 
     struct DeserializeBinaryBulkSettings
@@ -450,6 +469,11 @@ public:
         /// Type of MergeTree data part we deserialize data from if any.
         /// Some serializations may differ from type part for more optimal deserialization.
         MergeTreeDataPartType data_part_type = MergeTreeDataPartType::Unknown;
+
+        /// Optional getter for SST read stream.
+        /// When set, SST-based serializations use this to obtain the
+        /// MergeTreeReaderStreamSingleColumnWholePart
+        SSTReadStreamGetter sst_read_stream_getter;
 
         /// Usually substreams cache contains the whole column with rows from
         /// multiple ranges. But sometimes we need to read a separate column

--- a/src/DataTypes/Serializations/ISerialization.h
+++ b/src/DataTypes/Serializations/ISerialization.h
@@ -29,7 +29,7 @@ class WriteBuffer;
 class ProtobufReader;
 class ProtobufWriter;
 class SSTFileWriteStream;
-class MergeTreeReaderStreamSingleColumnWholePart;
+class SSTFileReadStream;
 
 class IDataType;
 using DataTypePtr = std::shared_ptr<const IDataType>;
@@ -357,8 +357,8 @@ public:
 
     /// Getter for SST read stream.
     /// Injected by MergeTreeDataReader and used by SST-based serializations
-    /// to obtain the MergeTreeReaderStreamSingleColumnWholePart for deserialization.
-    using SSTReadStreamGetter = std::function<MergeTreeReaderStreamSingleColumnWholePart *(const SubstreamPath &)>;
+    /// to obtain the SSTFileReadStream for deserialization.
+    using SSTReadStreamGetter = std::function<SSTFileReadStream *(const SubstreamPath &)>;
 
     struct SerializeBinaryBulkSettings
     {

--- a/src/DataTypes/Serializations/SerializationSortedStringKV.cpp
+++ b/src/DataTypes/Serializations/SerializationSortedStringKV.cpp
@@ -1,0 +1,230 @@
+#include <DataTypes/Serializations/SerializationSortedStringKV.h>
+#include <Storages/MergeTree/SSTFileUtil.h>
+#include <Storages/MergeTree/MergeTreeReaderStream.h>
+#include <Columns/ColumnTuple.h>
+#include <Columns/ColumnString.h>
+#include <Common/assert_cast.h>
+#include <Common/logger_useful.h>
+#include <IO/ReadHelpers.h>
+#include <IO/WriteHelpers.h>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+extern const int CORRUPTED_DATA;
+extern const int LOGICAL_ERROR;
+}
+
+void SerializationSortedStringKV::enumerateStreams(
+    EnumerateStreamsSettings & settings,
+    const StreamCallback & callback,
+    const SubstreamData & data) const
+{
+    /// Only enumerate the offsets stream; the SST data stream is
+    /// created independently by MergeTreeDataPartWriter.
+    settings.path.push_back(Substream::Regular);
+    settings.path.back().data = data;
+    callback(settings.path);
+    settings.path.pop_back();
+}
+
+void SerializationSortedStringKV::serializeBinaryBulkStatePrefix(
+    const IColumn & column,
+    SerializeBinaryBulkSettings & settings,
+    SerializeBinaryBulkStatePtr & state) const
+{
+    if (settings.native_format)
+    {
+        SerializationTuple::serializeBinaryBulkStatePrefix(column, settings, state);
+        return;
+    }
+    state = std::make_shared<SerializeBinaryBulkStateSST>();
+}
+
+void SerializationSortedStringKV::serializeBinaryBulkWithMultipleStreams(
+    const IColumn & column,
+    size_t offset,
+    size_t limit,
+    SerializeBinaryBulkSettings & settings,
+    SerializeBinaryBulkStatePtr & state) const
+{
+    if (settings.native_format)
+    {
+        SerializationTuple::serializeBinaryBulkWithMultipleStreams(column, offset, limit, settings, state);
+        return;
+    }
+
+    const auto & tuple_col = assert_cast<const ColumnTuple &>(column);
+    const auto & key_col = assert_cast<const ColumnString &>(tuple_col.getColumn(0));
+    const auto & value_col = assert_cast<const ColumnString &>(tuple_col.getColumn(1));
+
+    size_t size = key_col.size();
+    size_t end = limit ? std::min(offset + limit, size) : size;
+
+    settings.path.push_back(Substream::Regular);
+    WriteBuffer * offsets_stream = settings.getter(settings.path);
+    settings.path.pop_back();
+
+    /// Skip when no data to write
+    if (offset >= end)
+        return;
+
+    auto * sst_state = checkAndGetState<SerializeBinaryBulkStateSST>(state);
+
+    /// Lazy init SSTFileWriter on first actual write
+    if (!sst_state->sst_file_writer)
+    {
+        if (settings.sst_write_stream_getter)
+        {
+            auto * sst_stream = settings.sst_write_stream_getter(settings.path);
+            if (sst_stream)
+                sst_state->sst_file_writer = &sst_stream->getSSTWriter();
+        }
+
+        if (!sst_state->sst_file_writer)
+            throw Exception(ErrorCodes::LOGICAL_ERROR,
+                "Missing SST writer for SerializationSortedStringKV "
+                "(sst_write_stream_getter not set or returned nullptr)");
+    }
+
+    for (size_t i = offset; i < end; ++i)
+    {
+        const auto key = key_col.getDataAt(i);
+        const auto val = value_col.getDataAt(i);
+
+        sst_state->sst_file_writer->put(
+            rocksdb::Slice(key),
+            rocksdb::Slice(val));
+    }
+
+    /// Write row offset at granule boundary for seek
+    if (settings.mark_on_start && offsets_stream)
+        writeIntBinary(sst_state->sst_file_writer->getWrittenRowCount(), *offsets_stream);
+
+    sst_state->sst_file_writer->addWrittenRowCount(static_cast<UInt64>(end - offset));
+}
+
+void SerializationSortedStringKV::serializeBinaryBulkStateSuffix(
+    SerializeBinaryBulkSettings & settings,
+    SerializeBinaryBulkStatePtr & state) const
+{
+    if (settings.native_format)
+        SerializationTuple::serializeBinaryBulkStateSuffix(settings, state);
+}
+
+void SerializationSortedStringKV::deserializeBinaryBulkStatePrefix(
+    DeserializeBinaryBulkSettings & settings,
+    DeserializeBinaryBulkStatePtr & state,
+    SubstreamsDeserializeStatesCache * cache) const
+{
+    if (settings.native_format)
+    {
+        SerializationTuple::deserializeBinaryBulkStatePrefix(settings, state, cache);
+        return;
+    }
+    state = std::make_shared<DeserializeBinaryBulkStateSortedStringKV>();
+}
+
+void SerializationSortedStringKV::deserializeBinaryBulkWithMultipleStreams(
+    ColumnPtr & column,
+    size_t rows_offset,
+    size_t limit,
+    DeserializeBinaryBulkSettings & settings,
+    DeserializeBinaryBulkStatePtr & state,
+    SubstreamsCache * cache) const
+{
+    if (settings.native_format)
+    {
+        SerializationTuple::deserializeBinaryBulkWithMultipleStreams(column, rows_offset, limit, settings, state, cache);
+        return;
+    }
+
+    auto mutable_column = column->assumeMutable();
+    auto & tuple_col = assert_cast<ColumnTuple &>(*mutable_column);
+    auto & key_col = assert_cast<ColumnString &>(tuple_col.getColumn(0));
+    auto & value_col = assert_cast<ColumnString &>(tuple_col.getColumn(1));
+
+    auto * sst_state = checkAndGetState<DeserializeBinaryBulkStateSortedStringKV>(state);
+
+    /// Lazy init SST iterator
+    if (!sst_state->sst_file_iterator)
+    {
+        auto * sst_file_read_stream = settings.sst_read_stream_getter ? settings.sst_read_stream_getter(settings.path) : nullptr;
+        if (sst_file_read_stream)
+        {
+            auto * sst_stream = dynamic_cast<ReadBufferFromFileBase *>(sst_file_read_stream->getDataBuffer());
+            if (!sst_stream)
+                throw Exception(ErrorCodes::LOGICAL_ERROR, "SST data stream must provide a valid ReadBufferFromFileBase");
+
+            uint64_t base_offset = 0;
+            auto sst_size = sst_stream->getFileSize();
+            sst_state->sst_file_reader = std::make_shared<SSTFileReader>(sst_stream, base_offset, sst_size);
+
+            rocksdb::ReadOptions read_opts;
+            read_opts.fill_cache = true;
+            sst_state->sst_file_iterator = sst_state->sst_file_reader->newIterator(read_opts);
+            sst_state->sst_file_iterator->SeekToFirst();
+            if (!sst_state->sst_file_iterator->status().ok())
+                throw Exception(ErrorCodes::CORRUPTED_DATA,
+                    "SST iterator SeekToFirst error: {}",
+                    sst_state->sst_file_iterator->status().ToString());
+        }
+        else
+        {
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "No SST read stream available");
+        }
+    }
+
+    /// New granule: seek to offset from .offsets.bin
+    if (!settings.continuous_reading)
+    {
+        settings.path.push_back(Substream::Regular);
+        ReadBuffer * offsets_stream = settings.getter(settings.path);
+        settings.path.pop_back();
+
+        if (!offsets_stream)
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "No offsets stream available");
+
+        UInt64 target_row = 0;
+        readIntBinary(target_row, *offsets_stream);
+
+        if (target_row < sst_state->current_row_position)
+            throw Exception(ErrorCodes::LOGICAL_ERROR,
+                "Cannot seek backwards in SST iterator: current_row_position={}, target_row={}",
+                sst_state->current_row_position, target_row);
+
+        while (sst_state->current_row_position < target_row && sst_state->sst_file_iterator->Valid())
+        {
+            sst_state->sst_file_iterator->Next();
+            if (!sst_state->sst_file_iterator->status().ok())
+                throw Exception(ErrorCodes::CORRUPTED_DATA, "SST iterator seek error: {}", sst_state->sst_file_iterator->status().ToString());
+            ++sst_state->current_row_position;
+        }
+
+        if (sst_state->current_row_position < target_row)
+            throw Exception(ErrorCodes::CORRUPTED_DATA,
+                "SST iterator reached end before target row: current={}, target={}",
+                sst_state->current_row_position, target_row);
+    }
+
+    size_t rows_read = 0;
+    auto & iter = sst_state->sst_file_iterator;
+    while (iter->Valid() && rows_read < limit)
+    {
+        key_col.insertData(iter->key().data(), iter->key().size());
+        value_col.insertData(iter->value().data(), iter->value().size());
+        ++rows_read;
+        ++sst_state->current_row_position;
+
+        iter->Next();
+        if (!iter->status().ok())
+            throw Exception(ErrorCodes::CORRUPTED_DATA, "SST iterator error: {}", iter->status().ToString());
+    }
+
+    column = std::move(mutable_column);
+}
+
+}
+

--- a/src/DataTypes/Serializations/SerializationSortedStringKV.cpp
+++ b/src/DataTypes/Serializations/SerializationSortedStringKV.cpp
@@ -160,6 +160,14 @@ void SerializationSortedStringKV::deserializeBinaryBulkWithMultipleStreams(
 
             uint64_t base_offset = 0;
             auto sst_size = sst_stream->getFileSize();
+
+            /// Handle empty SST file (e.g. part with zero rows after DELETE)
+            if (sst_size == 0)
+            {
+                column = std::move(mutable_column);
+                return;
+            }
+
             sst_state->sst_file_reader = std::make_shared<SSTFileReader>(sst_stream, base_offset, sst_size);
 
             rocksdb::ReadOptions read_opts;

--- a/src/DataTypes/Serializations/SerializationSortedStringKV.h
+++ b/src/DataTypes/Serializations/SerializationSortedStringKV.h
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <DataTypes/Serializations/SerializationTuple.h>
+#include <rocksdb/db.h>
+#include <rocksdb/iterator.h>
+
+namespace DB
+{
+
+class IMergeTreeDataPart;
+class IDataPartStorage;
+class WriteBuffer;
+class ReadBuffer;
+class ReadBufferFromFileBase;
+class SeekableReadBuffer;
+class SSTFileWriter;
+class SSTFileReader;
+
+/// SortedStringKV: KV pairs stored in SST files with offset-based seeking
+///
+/// File layout:
+///   column.offsets.bin  - per-granule row offsets for seeking
+///   column.sst          - SST file with all KV pairs (global per part)
+///
+/// The SST stream is managed externally by MergeTreeDataPartWriter and injected via getters.
+class SerializationSortedStringKV final : public SerializationTuple
+{
+public:
+    /// Write state: holds reference to SSTFileWriter for streaming KV pairs
+    struct SerializeBinaryBulkStateSST : public SerializeBinaryBulkState
+    {
+        SSTFileWriter * sst_file_writer = nullptr;
+    };
+
+    /// Read state: SST reader with lazy initialization (clone-safe)
+    struct DeserializeBinaryBulkStateSortedStringKV : public DeserializeBinaryBulkState
+    {
+        std::shared_ptr<SSTFileReader> sst_file_reader;
+        std::unique_ptr<rocksdb::Iterator> sst_file_iterator;
+        UInt64 current_row_position = 0;
+
+        DeserializeBinaryBulkStatePtr clone() const override
+        {
+            /// Return empty shell - will be lazily initialized from current reader's buffer
+            return std::make_shared<DeserializeBinaryBulkStateSortedStringKV>();
+        }
+    };
+
+    SerializationSortedStringKV(const ElementSerializations & elems_, bool has_explicit_names_)
+        : SerializationTuple(elems_, has_explicit_names_)
+    {
+    }
+
+    void enumerateStreams(
+        EnumerateStreamsSettings & settings,
+        const StreamCallback & callback,
+        const SubstreamData & data) const override;
+
+    void serializeBinaryBulkStatePrefix(
+        const IColumn & column,
+        SerializeBinaryBulkSettings & settings,
+        SerializeBinaryBulkStatePtr & state) const override;
+
+    void serializeBinaryBulkWithMultipleStreams(
+        const IColumn & column,
+        size_t offset,
+        size_t limit,
+        SerializeBinaryBulkSettings & settings,
+        SerializeBinaryBulkStatePtr & state) const override;
+
+    void serializeBinaryBulkStateSuffix(
+        SerializeBinaryBulkSettings & settings,
+        SerializeBinaryBulkStatePtr & state) const override;
+
+    void deserializeBinaryBulkStatePrefix(
+        DeserializeBinaryBulkSettings & settings,
+        DeserializeBinaryBulkStatePtr & state,
+        SubstreamsDeserializeStatesCache * cache) const override;
+
+    void deserializeBinaryBulkWithMultipleStreams(
+        ColumnPtr & column,
+        size_t rows_offset,
+        size_t limit,
+        DeserializeBinaryBulkSettings & settings,
+        DeserializeBinaryBulkStatePtr & state,
+        SubstreamsCache * cache) const override;
+
+};
+
+}

--- a/src/DataTypes/Serializations/SerializationSortedStringKV.h
+++ b/src/DataTypes/Serializations/SerializationSortedStringKV.h
@@ -41,7 +41,9 @@ public:
 
         DeserializeBinaryBulkStatePtr clone() const override
         {
-            /// Return empty shell - will be lazily initialized from current reader's buffer
+            /// Return a fresh state — iterator and reader are NOT carried over.
+            /// The cloned state will lazily re-init from the SST stream getter,
+            /// starting from SeekToFirst with current_row_position = 0.
             return std::make_shared<DeserializeBinaryBulkStateSortedStringKV>();
         }
     };

--- a/src/DataTypes/Serializations/SerializationTuple.h
+++ b/src/DataTypes/Serializations/SerializationTuple.h
@@ -6,7 +6,7 @@
 namespace DB
 {
 
-class SerializationTuple final : public SimpleTextSerialization
+class SerializationTuple : public SimpleTextSerialization
 {
 public:
     using ElementSerializationPtr = std::shared_ptr<const SerializationNamed>;

--- a/src/Storages/MergeTree/IMergeTreeReader.cpp
+++ b/src/Storages/MergeTree/IMergeTreeReader.cpp
@@ -586,4 +586,26 @@ MergeTreeReaderPtr createMergeTreeReaderIndex(
     throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot create reader for index with type {}", index.index->index.type);
 }
 
+std::unique_ptr<MergeTreeReaderStreamSingleColumnWholePart> IMergeTreeReader::createSSTReadStream(
+    const String & stream_name,
+    const ReadBufferFromFileBase::ProfileCallback & profile_callback_,
+    clockid_t clock_type_)
+{
+    static constexpr size_t marks_count = 1;
+    auto stream_settings = settings;
+    stream_settings.is_compressed = false;
+    return std::make_unique<MergeTreeReaderStreamSingleColumnWholePart>(
+        data_part_info_for_read->getDataPartStorage(),
+        stream_name,
+            SST_DATA_FILE_EXTENSION,
+        marks_count,
+        MarkRanges{{0, marks_count}},
+        stream_settings,
+        /*uncompressed_cache=*/nullptr,
+        data_part_info_for_read->getFileSizeOrZero(stream_name + SST_DATA_FILE_EXTENSION),
+        /*marks_loader=*/nullptr,
+        profile_callback_,
+        clock_type_);
+}
+
 }

--- a/src/Storages/MergeTree/IMergeTreeReader.cpp
+++ b/src/Storages/MergeTree/IMergeTreeReader.cpp
@@ -586,7 +586,7 @@ MergeTreeReaderPtr createMergeTreeReaderIndex(
     throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot create reader for index with type {}", index.index->index.type);
 }
 
-std::unique_ptr<MergeTreeReaderStreamSingleColumnWholePart> IMergeTreeReader::createSSTReadStream(
+std::unique_ptr<SSTFileReadStream> IMergeTreeReader::createSSTReadStream(
     const String & stream_name,
     const ReadBufferFromFileBase::ProfileCallback & profile_callback_,
     clockid_t clock_type_)
@@ -594,7 +594,7 @@ std::unique_ptr<MergeTreeReaderStreamSingleColumnWholePart> IMergeTreeReader::cr
     static constexpr size_t marks_count = 1;
     auto stream_settings = settings;
     stream_settings.is_compressed = false;
-    return std::make_unique<MergeTreeReaderStreamSingleColumnWholePart>(
+    return std::make_unique<SSTFileReadStream>(
         data_part_info_for_read->getDataPartStorage(),
         stream_name,
             SST_DATA_FILE_EXTENSION,

--- a/src/Storages/MergeTree/IMergeTreeReader.h
+++ b/src/Storages/MergeTree/IMergeTreeReader.h
@@ -142,14 +142,14 @@ protected:
     /// Alter conversions, which must be applied on fly if required
     AlterConversionsPtr alter_conversions;
 
-    std::unordered_map<String, std::unique_ptr<MergeTreeReaderStreamSingleColumnWholePart>> sst_read_streams;
+    std::unordered_map<String, std::unique_ptr<SSTFileReadStream>> sst_read_streams;
 
     /// Returns true if the column at position @pos in columns_to_read was dropped
     /// by a pending mutation that hasn't been applied to this part yet.
     /// Such columns should not be read from the part; defaults should be used instead.
     bool isColumnDroppedByPendingMutation(size_t pos) const;
 
-    std::unique_ptr<MergeTreeReaderStreamSingleColumnWholePart> createSSTReadStream(
+    std::unique_ptr<SSTFileReadStream> createSSTReadStream(
         const String & stream_name, const ReadBufferFromFileBase::ProfileCallback & profile_callback_, clockid_t clock_type_);
 private:
     friend class MergeTreeReaderIndex;

--- a/src/Storages/MergeTree/IMergeTreeReader.h
+++ b/src/Storages/MergeTree/IMergeTreeReader.h
@@ -4,6 +4,8 @@
 #include <Storages/MergeTree/MergeTreeReaderStream.h>
 #include <Storages/MergeTree/IMergeTreeDataPart.h>
 #include <Storages/MergeTree/IMergeTreeDataPartInfoForReader.h>
+#include <Storages/MergeTree/SSTFileUtil.h>
+#include <IO/ReadBufferFromFileBase.h>
 
 namespace DB
 {
@@ -140,11 +142,15 @@ protected:
     /// Alter conversions, which must be applied on fly if required
     AlterConversionsPtr alter_conversions;
 
+    std::unordered_map<String, std::unique_ptr<MergeTreeReaderStreamSingleColumnWholePart>> sst_read_streams;
+
     /// Returns true if the column at position @pos in columns_to_read was dropped
     /// by a pending mutation that hasn't been applied to this part yet.
     /// Such columns should not be read from the part; defaults should be used instead.
     bool isColumnDroppedByPendingMutation(size_t pos) const;
 
+    std::unique_ptr<MergeTreeReaderStreamSingleColumnWholePart> createSSTReadStream(
+        const String & stream_name, const ReadBufferFromFileBase::ProfileCallback & profile_callback_, clockid_t clock_type_);
 private:
     friend class MergeTreeReaderIndex;
     friend class MergeTreeReaderTextIndex;

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterCompact.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterCompact.cpp
@@ -4,6 +4,7 @@
 #include <Storages/StorageInMemoryMetadata.h>
 #include <Formats/MarkInCompressedFile.h>
 #include <IO/NullWriteBuffer.h>
+#include <DataTypes/DataTypeSortedStringKV.h>
 
 namespace DB
 {
@@ -96,6 +97,7 @@ void MergeTreeDataPartWriterCompact::addStreams(const NameAndTypePair & name_and
             stream = std::make_shared<CompressedStream>(plain_hashing, compression_codec);
 
         compressed_streams.emplace(stream_name, stream);
+        createSSTFileStreamIfNeeded(name_and_type, stream_name);
     };
 
     ISerialization::EnumerateStreamsSettings enumerate_settings;
@@ -156,6 +158,7 @@ void writeColumnSingleGranule(
     const SerializationPtr & serialization,
     ISerialization::OutputStreamGetter stream_getter,
     ISerialization::StreamMarkGetter stream_mark_getter,
+    ISerialization::SSTWriteStreamGetter sst_write_stream_getter,
     size_t from_row,
     size_t number_of_rows,
     bool is_first_granule,
@@ -181,6 +184,7 @@ void writeColumnSingleGranule(
         serialize_settings.object_and_dynamic_write_statistics = ISerialization::SerializeBinaryBulkSettings::ObjectAndDynamicStatisticsMode::PREFIX_EMPTY;
     serialize_settings.use_specialized_prefixes_and_suffixes_substreams = true;
     serialize_settings.data_part_type = MergeTreeDataPartType::Compact;
+    serialize_settings.sst_write_stream_getter = std::move(sst_write_stream_getter);
 
     serialization->serializeBinaryBulkStatePrefix(*column.column, serialize_settings, state);
     serialization->serializeBinaryBulkWithMultipleStreams(*column.column, from_row, number_of_rows, serialize_settings, state);
@@ -307,9 +311,22 @@ void MergeTreeDataPartWriterCompact::writeDataBlock(const Block & block, const G
                 return {plain_hashing.count(), compressed_streams[stream_name]->hashing_buf.offset()};
             };
 
+            ISerialization::SSTWriteStreamGetter sst_write_stream_getter;
+            if (dynamic_cast<const DataTypeSortedStringKV *>(name_and_type->type->getCustomName()))
+            {
+                sst_write_stream_getter
+                    = [&](const ISerialization::SubstreamPath & substream_path) -> SSTFileWriteStream *
+                    {
+                        String sst_stream_name = ISerialization::getFileNameForStream(
+                            *name_and_type, substream_path, ISerialization::StreamFileNameSettings(*storage_settings));
+                        return sst_file_streams.at(sst_stream_name).get();
+                    };
+            }
+
             writeColumnSingleGranule(
                 block.getByName(name_and_type->name), getSerialization(name_and_type->name),
-                stream_getter, stream_mark_getter, granule.start_row, granule.rows_to_write, !data_written, settings);
+                stream_getter, stream_mark_getter, sst_write_stream_getter, granule.start_row, granule.rows_to_write,
+                !data_written, settings);
 
             /// Each type always have at least one substream
             prev_stream->hashing_buf.next();
@@ -410,7 +427,7 @@ void MergeTreeDataPartWriterCompact::initColumnsSubstreamsIfNeeded(const Block &
 
         auto mark_getter = [](const ISerialization::SubstreamPath &) { return MarkInCompressedFile(); };
         const auto & column = sample.getByName(name_and_type.name);
-        writeColumnSingleGranule(column, getSerialization(name_and_type.name), buffer_getter, mark_getter, column.column->size(), 0, false, settings);
+        writeColumnSingleGranule(column, getSerialization(name_and_type.name), buffer_getter, mark_getter, {}, column.column->size(), 0, false, settings);
     }
 }
 
@@ -538,6 +555,9 @@ void MergeTreeDataPartWriterCompact::fillChecksums(MergeTreeDataPartChecksums & 
     if (!columns_list.empty())
         fillDataChecksums(checksums);
 
+    for (auto & [col_name, sst_stream] : sst_file_streams)
+        sst_stream->fillSSTChecksums(checksums);
+
     if (settings.rewrite_primary_key)
         fillPrimaryIndexChecksums(checksums);
 
@@ -549,6 +569,14 @@ void MergeTreeDataPartWriterCompact::finish(bool sync)
     // If we don't have anything to write, skip finalization.
     if (!columns_list.empty())
         finishDataSerialization(sync);
+
+    for (auto & [col_name, sst_stream] : sst_file_streams)
+    {
+        sst_stream->finalize();
+        if (sync)
+            sst_stream->sync();
+    }
+    sst_file_streams.clear();
 
     if (settings.rewrite_primary_key)
         finishPrimaryIndexSerialization(sync);

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterOnDisk.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterOnDisk.cpp
@@ -8,6 +8,7 @@
 #include <Common/escapeForFileName.h>
 #include <Common/logger_useful.h>
 #include <Compression/CompressionFactory.h>
+#include <DataTypes/DataTypeSortedStringKV.h>
 
 namespace ProfileEvents
 {
@@ -82,6 +83,11 @@ void MergeTreeDataPartWriterOnDisk::cancel() noexcept
 
     for (auto & stream : skip_indices_streams_holders)
         stream->cancel();
+
+    /// Cancel all SST streams.
+    for (auto & [col_name, sst_stream] : sst_file_streams)
+        sst_stream->cancel();
+    sst_file_streams.clear();
 }
 
 size_t MergeTreeDataPartWriterOnDisk::computeIndexGranularity(const Block & block) const
@@ -414,6 +420,20 @@ Names MergeTreeDataPartWriterOnDisk::getSkipIndicesColumns() const
         std::copy(index->index.column_names.cbegin(), index->index.column_names.cend(),
                   std::inserter(skip_indexes_column_names_set, skip_indexes_column_names_set.end()));
     return Names(skip_indexes_column_names_set.begin(), skip_indexes_column_names_set.end());
+}
+
+void MergeTreeDataPartWriterOnDisk::createSSTFileStreamIfNeeded(const NameAndTypePair & name_and_type, const String & stream_name)
+{
+    if (!dynamic_cast<const DataTypeSortedStringKV *>(name_and_type.type->getCustomName()))
+        return;
+
+    sst_file_streams.emplace(
+        stream_name,
+        std::make_unique<SSTFileWriteStream>(
+            escapeForFileName(name_and_type.name),
+            data_part_storage,
+            settings.max_compress_block_size,
+            settings.query_write_settings));
 }
 
 void MergeTreeDataPartWriterOnDisk::initOrAdjustDynamicStructureIfNeeded(Block & block)

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterOnDisk.h
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterOnDisk.h
@@ -2,6 +2,7 @@
 
 #include <Storages/MergeTree/IMergeTreeDataPartWriter.h>
 #include <Storages/MergeTree/MergeTreeWriterStream.h>
+#include <Storages/MergeTree/SSTFileUtil.h>
 #include <IO/WriteBufferFromFile.h>
 #include <IO/WriteBufferFromFileBase.h>
 #include <Compression/CompressedWriteBuffer.h>
@@ -95,6 +96,9 @@ protected:
 
     virtual void addStreams(const NameAndTypePair & name_and_type, const ASTPtr & effective_codec_desc) = 0;
 
+    /// Create an SST write stream for the given column if needed.
+    void createSSTFileStreamIfNeeded(const NameAndTypePair & name_and_type, const String & stream_name);
+
     /// On first block create all required streams for columns with dynamic subcolumns and remember the block sample.
     /// On each next block check if dynamic structure of the columns equals to the dynamic structure of the same
     /// columns in the sample block. If for some column dynamic structure is different, adjust it so it matches
@@ -138,6 +142,10 @@ protected:
 
     /// List of substreams for each column in order of serialization.
     ColumnsSubstreams columns_substreams;
+
+    /// Independent SST data streams for SST-based column types.
+    /// Key: column name. SST files are separate from regular column data streams.
+    SSTFileWriteStreams sst_file_streams;
 
 private:
     void initSkipIndices();

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterWide.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterWide.cpp
@@ -16,6 +16,7 @@
 #include <Common/logger_useful.h>
 #include <Common/quoteString.h>
 #include <IO/NullWriteBuffer.h>
+#include <DataTypes/DataTypeSortedStringKV.h>
 
 namespace DB
 {
@@ -206,6 +207,8 @@ void MergeTreeDataPartWriterWide::addStreams(
             marks_compression_codec,
             settings.marks_compress_block_size,
             query_write_settings);
+
+        createSSTFileStreamIfNeeded(name_and_type, stream_name);
 
         if (columns_to_load_marks.contains(name_and_type.name))
             cached_marks.emplace(stream_name, std::make_unique<MarksInCompressedFile::PlainArray>());
@@ -543,6 +546,16 @@ void MergeTreeDataPartWriterWide::writeColumn(
         return {stream->plain_hashing.count(), stream->compressed_hashing.offset()};
     };
 
+    if (dynamic_cast<const DataTypeSortedStringKV *>(name_and_type.type->getCustomName()))
+    {
+        serialize_settings.sst_write_stream_getter
+            = [&](const ISerialization::SubstreamPath & substream_path) -> SSTFileWriteStream *
+            {
+                auto stream_name = getStreamName(name_and_type, substream_path);
+                return sst_file_streams.at(stream_name).get();
+            };
+    }
+
     for (const auto & granule : granules)
     {
         data_written = true;
@@ -556,6 +569,8 @@ void MergeTreeDataPartWriterWide::writeColumn(
                                 getCurrentMark(), index_granularity->getMarksCount(), rows_written_in_last_mark);
             last_non_written_marks[name] = getCurrentMarksForColumn(name_and_type, offset_substreams);
         }
+
+        serialize_settings.mark_on_start = granule.mark_on_start;
 
         writeSingleGranule(
             name_and_type,
@@ -812,6 +827,10 @@ void MergeTreeDataPartWriterWide::fillChecksums(MergeTreeDataPartChecksums & che
     if (!columns_list.empty())
         fillDataChecksums(checksums, checksums_to_remove);
 
+    /// SST columns are independent files — finalize and checksum them separately.
+    for (auto & [col_name, sst_stream] : sst_file_streams)
+        sst_stream->fillSSTChecksums(checksums);
+
     if (settings.rewrite_primary_key)
         fillPrimaryIndexChecksums(checksums);
 
@@ -823,6 +842,14 @@ void MergeTreeDataPartWriterWide::finish(bool sync)
     // If we don't have anything to write, skip finalization.
     if (!columns_list.empty())
         finishDataSerialization(sync);
+
+    for (auto & [col_name, sst_stream] : sst_file_streams)
+    {
+        sst_stream->finalize();
+        if (sync)
+            sst_stream->sync();
+    }
+    sst_file_streams.clear();
 
     if (settings.rewrite_primary_key)
         finishPrimaryIndexSerialization(sync);

--- a/src/Storages/MergeTree/MergeTreeReaderCompact.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderCompact.cpp
@@ -6,6 +6,7 @@
 #include <DataTypes/NestedUtils.h>
 #include <Interpreters/Context.h>
 #include <ranges>
+#include <DataTypes/DataTypeSortedStringKV.h>
 
 namespace DB
 {
@@ -207,6 +208,23 @@ void MergeTreeReaderCompact::readData(
         deserialize_settings.getter = buffer_getter;
         deserialize_settings.use_specialized_prefixes_and_suffixes_substreams = true;
         deserialize_settings.data_part_type = MergeTreeDataPartType::Compact;
+        deserialize_settings.continuous_reading = false;
+        if (dynamic_cast<const DataTypeSortedStringKV *>(name_and_type.type->getCustomName()))
+        {
+            deserialize_settings.sst_read_stream_getter
+            = [&](const ISerialization::SubstreamPath & substream_path) -> MergeTreeReaderStreamSingleColumnWholePart *
+            {
+                auto stream_name = IMergeTreeDataPart::getStreamNameForColumn(
+                    name_and_type,
+                    substream_path,
+                    SST_DATA_FILE_EXTENSION,
+                    data_part_info_for_read->getChecksums(),
+                    storage_settings);
+                chassert(stream_name);
+                return sst_read_streams.at(*stream_name).get();
+            };
+        }
+
         deserialize_settings.get_avg_value_size_hint_callback
             = [&](const ISerialization::SubstreamPath & substream_path) -> double
         {

--- a/src/Storages/MergeTree/MergeTreeReaderCompact.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderCompact.cpp
@@ -211,15 +211,10 @@ void MergeTreeReaderCompact::readData(
         deserialize_settings.continuous_reading = false;
         if (dynamic_cast<const DataTypeSortedStringKV *>(name_and_type.type->getCustomName()))
         {
-            deserialize_settings.sst_read_stream_getter
-            = [&](const ISerialization::SubstreamPath & substream_path) -> MergeTreeReaderStreamSingleColumnWholePart *
+            deserialize_settings.sst_read_stream_getter = [&](const ISerialization::SubstreamPath & substream_path) -> SSTFileReadStream *
             {
                 auto stream_name = IMergeTreeDataPart::getStreamNameForColumn(
-                    name_and_type,
-                    substream_path,
-                    SST_DATA_FILE_EXTENSION,
-                    data_part_info_for_read->getChecksums(),
-                    storage_settings);
+                    name_and_type, substream_path, SST_DATA_FILE_EXTENSION, data_part_info_for_read->getChecksums(), storage_settings);
                 chassert(stream_name);
                 return sst_read_streams.at(*stream_name).get();
             };

--- a/src/Storages/MergeTree/MergeTreeReaderCompactSingleBuffer.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderCompactSingleBuffer.cpp
@@ -4,6 +4,7 @@
 #include <DataTypes/DataTypeArray.h>
 #include <DataTypes/NestedUtils.h>
 #include <Compression/CachedCompressedReadBuffer.h>
+#include <DataTypes/DataTypeSortedStringKV.h>
 
 namespace DB
 {
@@ -133,6 +134,17 @@ try
         all_mark_ranges, stream_settings,uncompressed_cache,
         data_part_info_for_read->getFileSizeOrZero(MergeTreeDataPartCompact::DATA_FILE_NAME_WITH_EXTENSION),
         marks_loader, profile_callback, clock_type);
+
+    for (auto & column : columns_to_read)
+    {
+        if (dynamic_cast<const DataTypeSortedStringKV *>(column.type->getCustomName()))
+        {
+            auto stream_name = IMergeTreeDataPart::getStreamNameForColumn(
+                column, {}, SST_DATA_FILE_EXTENSION, data_part_info_for_read->getChecksums(), storage_settings);
+            chassert(stream_name);
+            sst_read_streams.emplace(*stream_name, createSSTReadStream(*stream_name, profile_callback, clock_type));
+        }
+    }
 
     initialized = true;
 }

--- a/src/Storages/MergeTree/MergeTreeReaderWide.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderWide.cpp
@@ -621,7 +621,7 @@ void MergeTreeReaderWide::readData(
     if (dynamic_cast<const DataTypeSortedStringKV *>(name_and_type.type->getCustomName()))
     {
         deserialize_settings.sst_read_stream_getter
-            = [&](const ISerialization::SubstreamPath & substream_path) -> MergeTreeReaderStreamSingleColumnWholePart *
+            = [&](const ISerialization::SubstreamPath & substream_path) -> SSTFileReadStream *
             {
                 auto stream_name = IMergeTreeDataPart::getStreamNameForColumn(
                     name_and_type,

--- a/src/Storages/MergeTree/MergeTreeReaderWide.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderWide.cpp
@@ -15,6 +15,7 @@
 #include <Common/typeid_cast.h>
 #include <IO/SharedThreadPools.h>
 #include <Compression/CachedCompressedReadBuffer.h>
+#include <DataTypes/DataTypeSortedStringKV.h>
 
 namespace DB
 {
@@ -274,6 +275,14 @@ void MergeTreeReaderWide::addStreams(
         {
             has_all_streams = false;
             return;
+        }
+
+        if (dynamic_cast<const DataTypeSortedStringKV *>(name_and_type.type->getCustomName()))
+        {
+            auto sst_stream_name = IMergeTreeDataPart::getStreamNameForColumn(
+                name_and_type, substream_path, SST_DATA_FILE_EXTENSION,
+                data_part_info_for_read->getChecksums(), storage_settings);
+            sst_read_streams.emplace(*sst_stream_name, createSSTReadStream(*sst_stream_name, profile_callback, clock_type));
         }
 
         if (streams.contains(*stream_name))
@@ -609,6 +618,21 @@ void MergeTreeReaderWide::readData(
     };
 
     deserialize_settings.continuous_reading = continue_reading;
+    if (dynamic_cast<const DataTypeSortedStringKV *>(name_and_type.type->getCustomName()))
+    {
+        deserialize_settings.sst_read_stream_getter
+            = [&](const ISerialization::SubstreamPath & substream_path) -> MergeTreeReaderStreamSingleColumnWholePart *
+            {
+                auto stream_name = IMergeTreeDataPart::getStreamNameForColumn(
+                    name_and_type,
+                    substream_path,
+                    SST_DATA_FILE_EXTENSION,
+                    data_part_info_for_read->getChecksums(),
+                    storage_settings);
+                chassert(stream_name);
+                return sst_read_streams.at(*stream_name).get();
+            };
+    }
     auto & deserialize_state = deserialize_binary_bulk_state_map[name_and_type.name];
 
     serialization->deserializeBinaryBulkWithMultipleStreams(

--- a/src/Storages/MergeTree/SSTFileUtil.cpp
+++ b/src/Storages/MergeTree/SSTFileUtil.cpp
@@ -1,0 +1,659 @@
+#include <Storages/MergeTree/SSTFileUtil.h>
+#include <Storages/MergeTree/IDataPartStorage.h>
+#include <Storages/MergeTree/MergeTreeDataPartChecksum.h>
+#include <rocksdb/table.h>
+#include <rocksdb/filter_policy.h>
+#include <rocksdb/file_system.h>
+#include <rocksdb/sst_file_reader.h>
+#include <rocksdb/sst_file_writer.h>
+#include <Common/logger_useful.h>
+
+namespace DB
+{
+namespace ErrorCodes
+{
+extern const int INCORRECT_DATA;
+extern const int LOGICAL_ERROR;
+}
+
+namespace
+{
+class ReadBufferBasedSequentialFile : public rocksdb::FSSequentialFile
+{
+public:
+    ReadBufferBasedSequentialFile(SeekableReadBuffer & read_buffer_, uint64_t base_offset_, uint64_t region_size_)
+        : read_buffer(read_buffer_)
+        , base_offset(base_offset_)
+        , region_size(region_size_)
+        , current_offset(0)
+    {
+        read_buffer.seek(base_offset, SEEK_SET);
+    }
+
+    rocksdb::IOStatus Read(
+        size_t n,
+        const rocksdb::IOOptions &,
+        rocksdb::Slice * result,
+        char * scratch,
+        rocksdb::IODebugContext *) override
+    {
+        size_t remaining = (current_offset < region_size) ? (region_size - current_offset) : 0;
+        size_t to_read = std::min(n, remaining);
+        auto read = read_buffer.read(scratch, to_read);
+        current_offset += read;
+        *result = rocksdb::Slice(scratch, read);
+        return rocksdb::IOStatus::OK();
+    }
+
+    rocksdb::IOStatus Skip(uint64_t n) override
+    {
+        size_t remaining = (current_offset < region_size) ? (region_size - current_offset) : 0;
+        size_t to_skip = std::min(static_cast<size_t>(n), remaining);
+        read_buffer.ignore(to_skip);
+        current_offset += to_skip;
+        return rocksdb::IOStatus::OK();
+    }
+
+private:
+    SeekableReadBuffer & read_buffer;
+    uint64_t base_offset;
+    uint64_t region_size;
+    uint64_t current_offset;
+};
+
+class ReadBufferBasedRandomAccessFile : public rocksdb::FSRandomAccessFile
+{
+public:
+    ReadBufferBasedRandomAccessFile(SeekableReadBuffer & read_buffer_, uint64_t base_offset_, uint64_t region_size_)
+        : read_buffer(read_buffer_)
+        , base_offset(base_offset_)
+        , region_size(region_size_)
+    {
+    }
+
+    rocksdb::IOStatus Read(
+        uint64_t offset,
+        size_t n,
+        const rocksdb::IOOptions &,
+        rocksdb::Slice * result,
+        char * scratch,
+        rocksdb::IODebugContext *) const override
+    {
+        size_t remaining = (offset < region_size) ? (region_size - offset) : 0;
+        size_t to_read = std::min(n, remaining);
+
+        auto & mutable_buffer = const_cast<SeekableReadBuffer &>(read_buffer);
+        mutable_buffer.seek(base_offset + offset, SEEK_SET);
+        auto read = mutable_buffer.read(scratch, to_read);
+        *result = rocksdb::Slice(scratch, read);
+        return rocksdb::IOStatus::OK();
+    }
+
+private:
+    SeekableReadBuffer & read_buffer;
+    uint64_t base_offset;
+    uint64_t region_size;
+};
+
+class WriteBufferWritableFile : public rocksdb::FSWritableFile
+{
+public:
+    explicit WriteBufferWritableFile(WriteBuffer & write_buffer_)
+        : write_buffer(write_buffer_)
+        , file_size(0)
+    {
+    }
+
+    rocksdb::IOStatus Append(
+        const rocksdb::Slice & data,
+        const rocksdb::IOOptions &,
+        rocksdb::IODebugContext *) override
+    {
+        try
+        {
+            write_buffer.write(data.data(), data.size());
+            file_size += data.size();
+            return rocksdb::IOStatus::OK();
+        }
+        catch (...)
+        {
+            auto error_msg = getCurrentExceptionMessage(true);
+            return rocksdb::IOStatus::IOError("Failed to write data: " + error_msg);
+        }
+    }
+
+    rocksdb::IOStatus Close(const rocksdb::IOOptions &, rocksdb::IODebugContext *) override
+    {
+        return rocksdb::IOStatus::OK();
+    }
+
+    rocksdb::IOStatus Flush(const rocksdb::IOOptions &, rocksdb::IODebugContext *) override
+    {
+        return rocksdb::IOStatus::OK();
+    }
+
+    rocksdb::IOStatus Sync(const rocksdb::IOOptions &, rocksdb::IODebugContext *) override
+    {
+        return rocksdb::IOStatus::OK();
+    }
+
+    uint64_t GetFileSize(const rocksdb::IOOptions &, rocksdb::IODebugContext *) override
+    {
+        return file_size;
+    }
+
+private:
+    WriteBuffer & write_buffer;
+    uint64_t file_size;
+};
+
+std::string formatToString(const char * format, va_list ap)
+{
+    va_list ap_copy;
+    va_copy(ap_copy, ap);
+
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+#endif
+
+    int size = vsnprintf(nullptr, 0, format, ap_copy);
+    va_end(ap_copy);
+
+    if (size < 0)
+        return "";
+
+    std::string result(size + 1, '\0');
+    if (vsnprintf(result.data(), size + 1, format, ap) < 0)
+        return "";
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
+    return result;
+}
+
+
+class CHLoggerWrapper : public rocksdb::Logger
+{
+public:
+    CHLoggerWrapper() : logger(getLogger("DiskBasedUniqueIndexEnv")) {}
+
+    rocksdb::Status Close() override
+    {
+        logger.reset();
+        return rocksdb::Status();
+    }
+
+    void Logv(
+        const rocksdb::InfoLogLevel log_level,
+        const char * format,
+        va_list ap) override
+    {
+        auto msg = formatToString(format, ap);
+        switch (log_level)
+        {
+            case rocksdb::InfoLogLevel::DEBUG_LEVEL:
+                LOG_DEBUG(logger, "{}", msg);
+                break;
+            case rocksdb::InfoLogLevel::INFO_LEVEL:
+                LOG_INFO(logger, "{}", msg);
+                break;
+            case rocksdb::InfoLogLevel::WARN_LEVEL:
+                LOG_WARNING(logger, "{}", msg);
+                break;
+            case rocksdb::InfoLogLevel::ERROR_LEVEL:
+                LOG_ERROR(logger, "{}", msg);
+                break;
+            case rocksdb::InfoLogLevel::FATAL_LEVEL:
+                LOG_FATAL(logger, "{}", msg);
+                break;
+            default:
+                LOG_INFO(logger, "{}", msg);
+                break;
+        }
+    }
+private:
+    LoggerPtr logger;
+};
+
+
+class ReadBufferFileSystem : public rocksdb::FileSystem
+{
+public:
+    ReadBufferFileSystem(SeekableReadBuffer * read_buffer_, uint64_t base_offset_, uint64_t region_size_)
+        : read_buffer(read_buffer_)
+        , base_offset(base_offset_)
+        , region_size(region_size_)
+    {
+    }
+
+    const char* Name() const override { return "ReadBufferFileSystem"; }
+
+    rocksdb::IOStatus NewSequentialFile(
+        const std::string &,
+        const rocksdb::FileOptions &,
+        std::unique_ptr<rocksdb::FSSequentialFile> * r,
+        rocksdb::IODebugContext *) override
+    {
+        *r = std::make_unique<ReadBufferBasedSequentialFile>(*read_buffer, base_offset, region_size);
+        return rocksdb::IOStatus::OK();
+    }
+
+    rocksdb::IOStatus NewRandomAccessFile(
+        const std::string &,
+        const rocksdb::FileOptions &,
+        std::unique_ptr<rocksdb::FSRandomAccessFile> * r,
+        rocksdb::IODebugContext *) override
+    {
+        *r = std::make_unique<ReadBufferBasedRandomAccessFile>(*read_buffer, base_offset, region_size);
+        return rocksdb::IOStatus::OK();
+    }
+
+    rocksdb::IOStatus NewLogger(
+        const std::string&,
+        const rocksdb::IOOptions&,
+        std::shared_ptr<rocksdb::Logger>* result,
+        rocksdb::IODebugContext*) override
+    {
+        *result = std::make_shared<CHLoggerWrapper>();
+        return rocksdb::IOStatus::OK();
+    }
+
+    rocksdb::IOStatus FileExists(
+        const std::string &,
+        const rocksdb::IOOptions &,
+        rocksdb::IODebugContext *) override
+    {
+        return rocksdb::IOStatus::OK();
+    }
+
+    rocksdb::IOStatus GetFileSize(
+        const std::string &,
+        const rocksdb::IOOptions &,
+        uint64_t * file_size,
+        rocksdb::IODebugContext *) override
+    {
+        if (file_size)
+            *file_size = region_size;
+        return rocksdb::IOStatus::OK();
+    }
+
+    /// Unsupported methods:
+    rocksdb::IOStatus NewWritableFile(
+        const std::string &,
+        const rocksdb::FileOptions &,
+        std::unique_ptr<rocksdb::FSWritableFile> *,
+        rocksdb::IODebugContext *) override { return rocksdb::IOStatus::NotSupported(); }
+    rocksdb::IOStatus NewDirectory(
+        const std::string &,
+        const rocksdb::IOOptions &,
+        std::unique_ptr<rocksdb::FSDirectory> *,
+        rocksdb::IODebugContext *) override { return rocksdb::IOStatus::NotSupported(); }
+    rocksdb::IOStatus GetChildren(
+        const std::string &,
+        const rocksdb::IOOptions &,
+        std::vector<std::string> *,
+        rocksdb::IODebugContext *) override { return rocksdb::IOStatus::NotSupported(); }
+    rocksdb::IOStatus DeleteFile(
+        const std::string &,
+        const rocksdb::IOOptions &,
+        rocksdb::IODebugContext *) override { return rocksdb::IOStatus::NotSupported(); }
+    rocksdb::IOStatus CreateDir(
+        const std::string &,
+        const rocksdb::IOOptions &,
+        rocksdb::IODebugContext *) override { return rocksdb::IOStatus::NotSupported(); }
+    rocksdb::IOStatus CreateDirIfMissing(
+        const std::string &,
+        const rocksdb::IOOptions &,
+        rocksdb::IODebugContext *) override { return rocksdb::IOStatus::NotSupported(); }
+    rocksdb::IOStatus DeleteDir(
+        const std::string &,
+        const rocksdb::IOOptions &,
+        rocksdb::IODebugContext *) override { return rocksdb::IOStatus::NotSupported(); }
+    rocksdb::IOStatus GetFileModificationTime(
+        const std::string &,
+        const rocksdb::IOOptions &,
+        uint64_t *,
+        rocksdb::IODebugContext *) override { return rocksdb::IOStatus::NotSupported(); }
+    rocksdb::IOStatus GetAbsolutePath(
+        const std::string &,
+        const rocksdb::IOOptions &,
+        std::string *,
+        rocksdb::IODebugContext *) override { return rocksdb::IOStatus::NotSupported(); }
+    rocksdb::IOStatus RenameFile(
+        const std::string &,
+        const std::string &,
+        const rocksdb::IOOptions &,
+        rocksdb::IODebugContext *) override { return rocksdb::IOStatus::NotSupported(); }
+    rocksdb::IOStatus LockFile(
+        const std::string &,
+        const rocksdb::IOOptions &,
+        rocksdb::FileLock **,
+        rocksdb::IODebugContext *) override { return rocksdb::IOStatus::NotSupported(); }
+    rocksdb::IOStatus UnlockFile(
+        rocksdb::FileLock *,
+        const rocksdb::IOOptions &,
+        rocksdb::IODebugContext *) override { return rocksdb::IOStatus::NotSupported(); }
+    rocksdb::IOStatus GetTestDirectory(
+        const rocksdb::IOOptions &,
+        std::string *,
+        rocksdb::IODebugContext *) override { return rocksdb::IOStatus::NotSupported(); }
+    rocksdb::IOStatus IsDirectory(
+        const std::string &,
+        const rocksdb::IOOptions &,
+        bool *,
+        rocksdb::IODebugContext *) override { return rocksdb::IOStatus::NotSupported(); }
+private:
+    SeekableReadBuffer * read_buffer = nullptr;
+    uint64_t base_offset = 0;
+    uint64_t region_size = 0;
+};
+
+class WriteBufferFileSystem : public rocksdb::FileSystem
+{
+public:
+    explicit WriteBufferFileSystem(WriteBuffer * write_buffer_)
+        : write_buffer(write_buffer_)
+    {
+    }
+
+    const char* Name() const override { return "WriteBufferFileSystem"; }
+    rocksdb::IOStatus NewWritableFile(
+        const std::string &,
+        const rocksdb::FileOptions &,
+        std::unique_ptr<rocksdb::FSWritableFile> * r,
+        rocksdb::IODebugContext *) override
+    {
+        if (!write_buffer)
+            return rocksdb::IOStatus::InvalidArgument("WriteBuffer not set");
+
+        *r = std::make_unique<WriteBufferWritableFile>(*write_buffer);
+        return rocksdb::IOStatus::OK();
+    }
+
+    rocksdb::IOStatus NewLogger(
+        const std::string&,
+        const rocksdb::IOOptions&,
+        std::shared_ptr<rocksdb::Logger>* result,
+        rocksdb::IODebugContext*) override
+    {
+        *result = std::make_shared<CHLoggerWrapper>();
+        return rocksdb::IOStatus::OK();
+    }
+
+    /// Unsupported methods:
+    rocksdb::IOStatus NewSequentialFile(
+        const std::string &,
+        const rocksdb::FileOptions &,
+        std::unique_ptr<rocksdb::FSSequentialFile> *,
+        rocksdb::IODebugContext *) override { return rocksdb::IOStatus::NotSupported(); }
+    rocksdb::IOStatus NewRandomAccessFile(
+        const std::string &,
+        const rocksdb::FileOptions &,
+        std::unique_ptr<rocksdb::FSRandomAccessFile> *,
+        rocksdb::IODebugContext *) override { return rocksdb::IOStatus::NotSupported(); }
+    rocksdb::IOStatus FileExists(
+        const std::string &,
+        const rocksdb::IOOptions &,
+        rocksdb::IODebugContext *) override { return rocksdb::IOStatus::NotSupported(); }
+    rocksdb::IOStatus GetFileSize(
+        const std::string &,
+        const rocksdb::IOOptions &,
+        uint64_t *,
+        rocksdb::IODebugContext *) override { return rocksdb::IOStatus::NotSupported(); }
+    rocksdb::IOStatus NewDirectory(
+        const std::string &,
+        const rocksdb::IOOptions &,
+        std::unique_ptr<rocksdb::FSDirectory> *,
+        rocksdb::IODebugContext *) override { return rocksdb::IOStatus::NotSupported(); }
+    rocksdb::IOStatus GetChildren(
+        const std::string &,
+        const rocksdb::IOOptions &,
+        std::vector<std::string> *,
+        rocksdb::IODebugContext *) override { return rocksdb::IOStatus::NotSupported(); }
+    rocksdb::IOStatus DeleteFile(
+        const std::string &,
+        const rocksdb::IOOptions &,
+        rocksdb::IODebugContext *) override { return rocksdb::IOStatus::NotSupported(); }
+    rocksdb::IOStatus CreateDir(
+        const std::string &,
+        const rocksdb::IOOptions &,
+        rocksdb::IODebugContext *) override { return rocksdb::IOStatus::NotSupported(); }
+    rocksdb::IOStatus CreateDirIfMissing(
+        const std::string &,
+        const rocksdb::IOOptions &,
+        rocksdb::IODebugContext *) override { return rocksdb::IOStatus::NotSupported(); }
+    rocksdb::IOStatus DeleteDir(
+        const std::string &,
+        const rocksdb::IOOptions &,
+        rocksdb::IODebugContext *) override { return rocksdb::IOStatus::NotSupported(); }
+    rocksdb::IOStatus GetFileModificationTime(
+        const std::string &,
+        const rocksdb::IOOptions &,
+        uint64_t *,
+        rocksdb::IODebugContext *) override { return rocksdb::IOStatus::NotSupported(); }
+    rocksdb::IOStatus GetAbsolutePath(
+        const std::string &,
+        const rocksdb::IOOptions &,
+        std::string *,
+        rocksdb::IODebugContext *) override { return rocksdb::IOStatus::NotSupported(); }
+    rocksdb::IOStatus RenameFile(
+        const std::string &,
+        const std::string &,
+        const rocksdb::IOOptions &,
+        rocksdb::IODebugContext *) override { return rocksdb::IOStatus::NotSupported(); }
+    rocksdb::IOStatus LockFile(
+        const std::string &,
+        const rocksdb::IOOptions &,
+        rocksdb::FileLock **,
+        rocksdb::IODebugContext *) override { return rocksdb::IOStatus::NotSupported(); }
+    rocksdb::IOStatus UnlockFile(
+        rocksdb::FileLock *,
+        const rocksdb::IOOptions &,
+        rocksdb::IODebugContext *) override { return rocksdb::IOStatus::NotSupported(); }
+    rocksdb::IOStatus GetTestDirectory(
+        const rocksdb::IOOptions &,
+        std::string *,
+        rocksdb::IODebugContext *) override { return rocksdb::IOStatus::NotSupported(); }
+    rocksdb::IOStatus IsDirectory(
+        const std::string &,
+        const rocksdb::IOOptions &,
+        bool *,
+        rocksdb::IODebugContext *) override { return rocksdb::IOStatus::NotSupported(); }
+private:
+    WriteBuffer* write_buffer = nullptr;
+};
+
+}
+
+SSTFileWriteStream::SSTFileWriteStream(
+    const String & escaped_column_name_,
+    const MutableDataPartStoragePtr & data_part_storage,
+    size_t buf_size,
+    const WriteSettings & query_write_settings)
+    : escaped_column_name(escaped_column_name_)
+    , plain_file(data_part_storage->writeFile(escaped_column_name_ + SST_DATA_FILE_EXTENSION, buf_size, query_write_settings))
+    , hashing(std::make_unique<HashingWriteBuffer>(*plain_file))
+    , sst_writer(std::make_unique<SSTFileWriter>(&getWriteBuffer()))
+{
+}
+
+SSTFileWriteStream::~SSTFileWriteStream() = default;
+
+void SSTFileWriteStream::preFinalize()
+{
+    hashing->finalize();
+    plain_file->preFinalize();
+}
+
+void SSTFileWriteStream::finalize()
+{
+    preFinalize();
+    plain_file->finalize();
+}
+
+void SSTFileWriteStream::cancel() noexcept
+{
+    hashing->cancel();
+    plain_file->cancel();
+}
+
+void SSTFileWriteStream::sync() const
+{
+    plain_file->sync();
+}
+
+SSTFileWriter & SSTFileWriteStream::getSSTWriter()
+{
+    if (!sst_writer)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "SSTFileWriter is not initialized in SSTFileWriteStream");
+    return *sst_writer;
+}
+
+void SSTFileWriteStream::fillSSTChecksums(MergeTreeDataPartChecksums & checksums)
+{
+    if (sst_writer)
+        sst_writer->finish();
+
+    preFinalize();
+    addToChecksums(checksums);
+}
+
+void SSTFileWriteStream::addToChecksums(MergeTreeDataPartChecksums & checksums)
+{
+    String name = escaped_column_name;
+
+    checksums.files[name + SST_DATA_FILE_EXTENSION].is_compressed = false;
+    checksums.files[name + SST_DATA_FILE_EXTENSION].file_size = hashing->count();
+    checksums.files[name + SST_DATA_FILE_EXTENSION].file_hash = hashing->getHash();
+}
+
+std::unique_ptr<rocksdb::Env> createWriteBufferFileSystemEnv(WriteBuffer * write_buffer)
+{
+    return rocksdb::NewCompositeEnv(std::make_shared<WriteBufferFileSystem>(write_buffer));
+}
+
+std::unique_ptr<rocksdb::Env> createReadBufferFileSystemEnv(SeekableReadBuffer * read_buffer, uint64_t base_offset, uint64_t region_size)
+{
+    return rocksdb::NewCompositeEnv(std::make_shared<ReadBufferFileSystem>(read_buffer, base_offset, region_size));
+}
+
+SSTFileReader::SSTFileReader(SeekableReadBuffer * read_buffer, uint64_t base_offset, uint64_t region_size)
+{
+    sst_env = createReadBufferFileSystemEnv(read_buffer, base_offset, region_size);
+
+    rocksdb::Options options;
+    options.env = sst_env.get();
+
+    rocksdb::BlockBasedTableOptions table_options;
+    table_options.filter_policy.reset(rocksdb::NewBloomFilterPolicy(12));
+    options.table_factory.reset(NewBlockBasedTableFactory(table_options));
+
+    auto local_reader = std::make_unique<rocksdb::SstFileReader>(options);
+    auto status = local_reader->Open("");
+    if (!status.ok())
+        throw Exception(ErrorCodes::INCORRECT_DATA, "Failed to open SST reader from ReadBuffer: {}", status.ToString());
+
+    status = local_reader->VerifyChecksum();
+    if (!status.ok())
+        throw Exception(ErrorCodes::INCORRECT_DATA, "Failed to verify SST checksum: {}", status.ToString());
+
+    index_reader = std::move(local_reader);
+
+    // Load min max key
+    rocksdb::ReadOptions read_opts;
+    read_opts.fill_cache = false;
+    auto iter = newIterator(read_opts);
+    iter->SeekToFirst();
+    if (iter->Valid())
+    {
+        auto min_key = iter->key().ToString();
+        iter->SeekToLast();
+        auto max_key = iter->key().ToString();
+        key_range = std::make_pair(std::move(min_key), std::move(max_key));
+    }
+}
+
+std::unique_ptr<rocksdb::Iterator> SSTFileReader::newIterator(const rocksdb::ReadOptions & options) const
+{
+    if (!index_reader)
+        return std::unique_ptr<rocksdb::Iterator>(rocksdb::NewEmptyIterator());
+    std::unique_ptr<rocksdb::Iterator> res;
+    res.reset(index_reader->NewIterator(options));
+    return res;
+}
+
+bool SSTFileReader::mayContainKey(std::string_view key) const
+{
+    return key >= key_range.first && key <= key_range.second;
+}
+
+void SSTFileReader::verifyChecksums() const
+{
+    auto status = index_reader->VerifyChecksum(rocksdb::ReadOptions{});
+    if (!status.ok())
+        throw Exception(ErrorCodes::INCORRECT_DATA, "Failed to verify checksums of SST: {}", status.ToString());
+}
+
+SSTFileReader::IndexPropertiesPtr SSTFileReader::getProperties() const
+{
+    return index_reader->GetTableProperties();
+}
+
+bool SSTFileReader::isEmpty() const
+{
+    return key_range.first.empty() && key_range.second.empty();
+}
+
+SSTFileWriter::SSTFileWriter(WriteBuffer * write_buffer)
+{
+    sst_env = createWriteBufferFileSystemEnv(write_buffer);
+    rocksdb::Options options;
+    options.env = sst_env.get();
+
+    rocksdb::BlockBasedTableOptions table_options;
+    table_options.filter_policy.reset(rocksdb::NewBloomFilterPolicy(12));
+    options.table_factory.reset(NewBlockBasedTableFactory(table_options));
+
+    writer = std::make_unique<rocksdb::SstFileWriter>(rocksdb::EnvOptions(), options);
+    auto status = writer->Open("");
+    if (!status.ok())
+        throw Exception(ErrorCodes::INCORRECT_DATA, "Failed to open SST writer: {}", status.ToString());
+}
+
+void SSTFileWriter::put(const rocksdb::Slice & key, const rocksdb::Slice & value)
+{
+    auto status = writer->Put(key, value);
+    if (!status.ok())
+        throw Exception(ErrorCodes::INCORRECT_DATA, "Failed to put key-value to SST: {}", status.ToString());
+    has_entries = true;
+}
+
+void SSTFileWriter::finish()
+{
+    if (finished)
+        return;
+    finished = true;
+
+    if (!writer)
+        return;
+
+    /// Skip empty SST files (RocksDB returns error for empty finish)
+    if (!has_entries)
+        return;
+
+    auto status = writer->Finish();
+    if (!status.ok())
+        throw Exception(ErrorCodes::INCORRECT_DATA, "Failed to finish SST file: {}", status.ToString());
+}
+
+uint64_t SSTFileWriter::fileSize() const
+{
+    if (!writer)
+        return 0;
+    return writer->FileSize();
+}
+
+}

--- a/src/Storages/MergeTree/SSTFileUtil.cpp
+++ b/src/Storages/MergeTree/SSTFileUtil.cpp
@@ -147,32 +147,27 @@ private:
     uint64_t file_size;
 };
 
+/// Suppress -Wformat-nonliteral for the entire helper because the format
+/// string is forwarded from rocksdb::Logger::Logv and is never a literal.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+
 std::string formatToString(const char * format, va_list ap)
 {
     va_list ap_copy;
     va_copy(ap_copy, ap);
-
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
-#endif
-
     int size = vsnprintf(nullptr, 0, format, ap_copy);
     va_end(ap_copy);
 
     if (size < 0)
-        return "";
+        return {};
 
-    std::string result(size + 1, '\0');
-    if (vsnprintf(result.data(), size + 1, format, ap) < 0)
-        return "";
-
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
-
+    std::string result(static_cast<size_t>(size), '\0');
+    vsnprintf(result.data(), static_cast<size_t>(size) + 1, format, ap);
     return result;
 }
+
+#pragma GCC diagnostic pop
 
 
 class CHLoggerWrapper : public rocksdb::Logger

--- a/src/Storages/MergeTree/SSTFileUtil.cpp
+++ b/src/Storages/MergeTree/SSTFileUtil.cpp
@@ -173,7 +173,7 @@ std::string formatToString(const char * format, va_list ap)
 class CHLoggerWrapper : public rocksdb::Logger
 {
 public:
-    CHLoggerWrapper() : logger(getLogger("DiskBasedUniqueIndexEnv")) {}
+    CHLoggerWrapper() : logger(getLogger("SSTFileEnv")) {}
 
     rocksdb::Status Close() override
     {
@@ -479,6 +479,10 @@ SSTFileWriteStream::~SSTFileWriteStream() = default;
 
 void SSTFileWriteStream::preFinalize()
 {
+    if (pre_finalized)
+        return;
+    pre_finalized = true;
+
     hashing->finalize();
     plain_file->preFinalize();
 }

--- a/src/Storages/MergeTree/SSTFileUtil.h
+++ b/src/Storages/MergeTree/SSTFileUtil.h
@@ -1,0 +1,105 @@
+#pragma once
+
+#include <IO/HashingWriteBuffer.h>
+#include <IO/WriteBufferFromFileBase.h>
+#include <IO/ReadBufferFromFileBase.h>
+#include <base/types.h>
+#include <memory>
+#include <unordered_map>
+#include <rocksdb/sst_file_reader.h>
+#include <rocksdb/iterator.h>
+#include <rocksdb/db.h>
+namespace DB
+{
+
+struct MergeTreeDataPartChecksums;
+struct WriteSettings;
+class IDataPartStorage;
+using MutableDataPartStoragePtr = std::shared_ptr<IDataPartStorage>;
+
+class SSTFileWriter;
+
+/// SST data file extension for SST-based column types.
+static constexpr auto SST_DATA_FILE_EXTENSION = ".sst";
+
+/// SST file write stream: manages FileBuffer + SSTFileWriter for a single column.
+class SSTFileWriteStream
+{
+public:
+    SSTFileWriteStream(
+        const String & escaped_column_name_,
+        const MutableDataPartStoragePtr & data_part_storage,
+        size_t buf_size,
+        const WriteSettings & query_write_settings);
+
+    ~SSTFileWriteStream();
+
+    SSTFileWriter & getSSTWriter();
+
+    /// Finalize SST writer and record checksums
+    void fillSSTChecksums(MergeTreeDataPartChecksums & checksums);
+    void preFinalize();
+    void finalize();
+    void cancel() noexcept;
+    void sync() const;
+    void addToChecksums(MergeTreeDataPartChecksums & checksums);
+
+    HashingWriteBuffer & getWriteBuffer() { return *hashing; }
+
+private:
+    String escaped_column_name;
+    std::unique_ptr<WriteBufferFromFileBase> plain_file;
+    std::unique_ptr<HashingWriteBuffer> hashing;
+    std::unique_ptr<SSTFileWriter> sst_writer;
+};
+
+using SSTFileWriteStreams = std::unordered_map<String, std::unique_ptr<SSTFileWriteStream>>;
+
+using SSTReadBuffers = std::unordered_map<String, std::unique_ptr<ReadBufferFromFileBase>>;
+
+
+/// RocksDB Env helpers
+std::unique_ptr<rocksdb::Env> createWriteBufferFileSystemEnv(WriteBuffer * write_buffer);
+std::unique_ptr<rocksdb::Env> createReadBufferFileSystemEnv(SeekableReadBuffer * read_buffer, uint64_t base_offset, uint64_t region_size);
+
+class SSTFileReader
+{
+public:
+    using IndexPropertiesPtr = std::shared_ptr<const rocksdb::TableProperties>;
+
+    SSTFileReader(SeekableReadBuffer * read_buffer, uint64_t base_offset, uint64_t region_size);
+
+    std::unique_ptr<rocksdb::Iterator> newIterator(const rocksdb::ReadOptions & options) const;
+    bool mayContainKey(std::string_view key) const;
+    void verifyChecksums() const;
+    IndexPropertiesPtr getProperties() const;
+    bool isEmpty() const;
+
+private:
+    using MinMax = std::pair<std::string, std::string>;
+    std::unique_ptr<rocksdb::Env> sst_env;
+    std::unique_ptr<rocksdb::SstFileReader> index_reader;
+    MinMax key_range;
+};
+
+class SSTFileWriter
+{
+public:
+    explicit SSTFileWriter(WriteBuffer * write_buffer);
+
+    void put(const rocksdb::Slice & key, const rocksdb::Slice & value);
+    void finish();
+    uint64_t fileSize() const;
+
+    UInt64 getWrittenRowCount() const { return written_row_counter; }
+    void addWrittenRowCount(UInt64 count) { written_row_counter += count; }
+
+private:
+    UInt64 written_row_counter = 0;
+    std::unique_ptr<rocksdb::Env> sst_env;
+    std::unique_ptr<rocksdb::SstFileWriter> writer;
+    bool finished = false;
+    bool has_entries = false;
+};
+
+}

--- a/src/Storages/MergeTree/SSTFileUtil.h
+++ b/src/Storages/MergeTree/SSTFileUtil.h
@@ -3,6 +3,7 @@
 #include <IO/HashingWriteBuffer.h>
 #include <IO/WriteBufferFromFileBase.h>
 #include <IO/ReadBufferFromFileBase.h>
+#include <Storages/MergeTree/MergeTreeReaderStream.h>
 #include <base/types.h>
 #include <memory>
 #include <unordered_map>
@@ -20,7 +21,7 @@ using MutableDataPartStoragePtr = std::shared_ptr<IDataPartStorage>;
 class SSTFileWriter;
 
 /// SST data file extension for SST-based column types.
-static constexpr auto SST_DATA_FILE_EXTENSION = ".sst";
+inline constexpr auto SST_DATA_FILE_EXTENSION = ".sst";
 
 /// SST file write stream: manages FileBuffer + SSTFileWriter for a single column.
 class SSTFileWriteStream
@@ -51,6 +52,7 @@ private:
     std::unique_ptr<WriteBufferFromFileBase> plain_file;
     std::unique_ptr<HashingWriteBuffer> hashing;
     std::unique_ptr<SSTFileWriter> sst_writer;
+    bool pre_finalized = false;
 };
 
 using SSTFileWriteStreams = std::unordered_map<String, std::unique_ptr<SSTFileWriteStream>>;
@@ -100,6 +102,16 @@ private:
     std::unique_ptr<rocksdb::SstFileWriter> writer;
     bool finished = false;
     bool has_entries = false;
+};
+
+class SSTFileReadStream : public MergeTreeReaderStreamSingleColumnWholePart
+{
+public:
+    template <typename... Args>
+    explicit SSTFileReadStream(Args &&... args)
+        : MergeTreeReaderStreamSingleColumnWholePart{std::forward<Args>(args)...}
+    {
+    }
 };
 
 }

--- a/tests/queries/0_stateless/04005_sorted_string_kv.reference
+++ b/tests/queries/0_stateless/04005_sorted_string_kv.reference
@@ -1,0 +1,49 @@
+Test 1: Compact part - multiple granules and boundary reading
+10000
+8190	key8190	value81900
+8191	key8191	value81910
+8192	key8192	value81920
+8193	key8193	value81930
+8194	key8194	value81940
+8195	key8195	value81950
+1	1	1	1
+1111
+Test 2: Wide part - multiple granules with continuous_reading
+10000
+8190	key8190	value81900
+8191	key8191	value81910
+8192	key8192	value81920
+8193	key8193	value81930
+8194	key8194	value81940
+8195	key8195	value81950
+1	1	1	1	1
+1
+0
+Test 3: Wide part - continuous_reading across multiple parts
+1	part1_key1	part1_val1
+2	part1_key2	part1_val2
+100	part2_key1	part2_val1
+200	part3_key1	part3_val1
+1	part1_key1	part1_val1
+2	part1_key2	part1_val2
+100	part2_key1	part2_val1
+200	part3_key1	part3_val1
+1	1
+Test 4: SortedStringKV with composite primary key
+1	sensor1	25.5	2024-01-01
+2	sensor2	30.0	2024-01-01
+3	sensor3	28.3	2024-01-02
+1	sensor1	25.5
+2	sensor2	30.0
+Test 5: Empty SortedStringKV column after DELETE
+0
+Test 6: Large dataset - multiple granules and filtering
+25000
+11
+1	1	1	1	1
+1
+11111
+Test 7: Multiple SortedStringKV columns in same table
+1	key1	val1	a	b
+2	key2	val2	c	d
+Test 8: NEGATIVE TEST - Wrong sort order (id instead of kv.1)

--- a/tests/queries/0_stateless/04005_sorted_string_kv.sql
+++ b/tests/queries/0_stateless/04005_sorted_string_kv.sql
@@ -1,0 +1,203 @@
+-- Tags: no-random-merge-tree-settings
+-- Test SortedStringKV data type with MergeTree engine
+
+-- Test 1: Compact part with multiple granules (kv.1 as sort key prefix)
+SELECT 'Test 1: Compact part - multiple granules and boundary reading' AS test_name;
+DROP TABLE IF EXISTS test_sorted_string_kv_compact;
+CREATE TABLE test_sorted_string_kv_compact (id UInt64, kv SortedStringKV) 
+ENGINE = MergeTree ORDER BY (kv.1, id)
+SETTINGS min_rows_for_wide_part = 1000000, min_bytes_for_wide_part = 1000000000, index_granularity = 8192;
+
+-- Insert data spanning multiple granules
+INSERT INTO test_sorted_string_kv_compact 
+SELECT number, (concat('key', toString(number)), concat('value', toString(number * 10))) 
+FROM numbers(10000);
+
+-- Test reading across granule boundaries (8192)
+SELECT count() FROM test_sorted_string_kv_compact;
+
+-- Verify data content at granule boundaries (8191, 8192 are boundary)
+-- Note: ClickHouse uses 0-based numbering for internal granule indexing
+-- Granule 1: rows 0-8191 (8192 rows), Granule 2: rows 8192-16383
+SELECT id, kv.1 AS key, kv.2 AS value FROM test_sorted_string_kv_compact 
+WHERE id BETWEEN 8190 AND 8195 ORDER BY id;
+
+-- Verify exact key-value pairs at granule boundaries
+SELECT 
+    (SELECT (kv.1, kv.2) FROM test_sorted_string_kv_compact WHERE id = 8191) = ('key8191', 'value81910') AS boundary_8191_correct,
+    (SELECT (kv.1, kv.2) FROM test_sorted_string_kv_compact WHERE id = 8192) = ('key8192', 'value81920') AS boundary_8192_correct,
+    (SELECT (kv.1, kv.2) FROM test_sorted_string_kv_compact WHERE id = 0) = ('key0', 'value0') AS first_row_correct,
+    (SELECT (kv.1, kv.2) FROM test_sorted_string_kv_compact WHERE id = 9999) = ('key9999', 'value99990') AS last_row_correct;
+
+-- Test filtering across granules
+SELECT count() FROM test_sorted_string_kv_compact WHERE kv.1 LIKE 'key1%';
+
+DROP TABLE test_sorted_string_kv_compact;
+
+-- Test 2: Wide part with continuous_reading across granules (kv.1 as sort key)
+SELECT 'Test 2: Wide part - multiple granules with continuous_reading' AS test_name;
+DROP TABLE IF EXISTS test_sorted_string_kv_wide_multi;
+CREATE TABLE test_sorted_string_kv_wide_multi (id UInt64, kv SortedStringKV) 
+ENGINE = MergeTree ORDER BY kv.1
+SETTINGS min_rows_for_wide_part = 1, min_bytes_for_wide_part = 1, index_granularity = 8192;
+
+-- Insert data in multiple batches, then merge to create wide part
+INSERT INTO test_sorted_string_kv_wide_multi 
+SELECT number, (concat('key', toString(number)), concat('value', toString(number * 10))) 
+FROM numbers(5000);
+
+INSERT INTO test_sorted_string_kv_wide_multi 
+SELECT number + 5000, (concat('key', toString(number + 5000)), concat('value', toString((number + 5000) * 10))) 
+FROM numbers(5000);
+
+OPTIMIZE TABLE test_sorted_string_kv_wide_multi FINAL;
+
+-- Test continuous reading across granules
+SELECT count() FROM test_sorted_string_kv_wide_multi;
+
+-- Verify exact values at granule boundaries in wide part
+SELECT id, kv.1 AS key, kv.2 AS value FROM test_sorted_string_kv_wide_multi 
+WHERE id BETWEEN 8190 AND 8195 ORDER BY id;
+
+-- Verify first, last, and cross-part boundary values (part boundary is at row 5000)
+SELECT 
+    (SELECT (kv.1, kv.2) FROM test_sorted_string_kv_wide_multi WHERE id = 0) = ('key0', 'value0') AS first_row_correct,
+    (SELECT (kv.1, kv.2) FROM test_sorted_string_kv_wide_multi WHERE id = 4999) = ('key4999', 'value49990') AS part_boundary_start_correct,
+    (SELECT (kv.1, kv.2) FROM test_sorted_string_kv_wide_multi WHERE id = 5000) = ('key5000', 'value50000') AS part_boundary_end_correct,
+    (SELECT (kv.1, kv.2) FROM test_sorted_string_kv_wide_multi WHERE id = 9999) = ('key9999', 'value99990') AS last_row_correct,
+    (SELECT (kv.1, kv.2) FROM test_sorted_string_kv_wide_multi WHERE id = 8191) = ('key8191', 'value81910') AS granule_boundary_correct;
+
+-- Verify that all key-value pairs match expected pattern
+SELECT count() = 10000 AS all_rows_have_correct_pattern
+FROM test_sorted_string_kv_wide_multi 
+WHERE kv.1 = concat('key', toString(id)) AND kv.2 = concat('value', toString(id * 10));
+
+-- Test sequential scan
+SELECT sum(toUInt64OrZero(kv.2)) FROM test_sorted_string_kv_wide_multi WHERE id < 100;
+
+DROP TABLE test_sorted_string_kv_wide_multi;
+
+-- Test 3: Wide part - continuous_reading with multiple parts (kv.1 as sort key)
+SELECT 'Test 3: Wide part - continuous_reading across multiple parts' AS test_name;
+DROP TABLE IF EXISTS test_sorted_string_kv_wide_parts;
+CREATE TABLE test_sorted_string_kv_wide_parts (id UInt64, kv SortedStringKV) 
+ENGINE = MergeTree ORDER BY kv.1
+SETTINGS min_rows_for_wide_part = 1, min_bytes_for_wide_part = 1, index_granularity = 8192;
+
+-- Insert multiple small parts
+INSERT INTO test_sorted_string_kv_wide_parts VALUES (1, ('part1_key1', 'part1_val1'));
+INSERT INTO test_sorted_string_kv_wide_parts VALUES (2, ('part1_key2', 'part1_val2'));
+INSERT INTO test_sorted_string_kv_wide_parts VALUES (100, ('part2_key1', 'part2_val1'));
+INSERT INTO test_sorted_string_kv_wide_parts VALUES (200, ('part3_key1', 'part3_val1'));
+
+-- Read from multiple parts
+SELECT id, kv.1 AS key, kv.2 AS value FROM test_sorted_string_kv_wide_parts ORDER BY id;
+
+-- Merge and read again
+OPTIMIZE TABLE test_sorted_string_kv_wide_parts FINAL;
+SELECT id, kv.1 AS key, kv.2 AS value FROM test_sorted_string_kv_wide_parts ORDER BY id;
+
+-- Verify data integrity after merge
+SELECT 
+    (SELECT count() FROM test_sorted_string_kv_wide_parts) = 4 AS row_count_correct,
+    (SELECT groupArray((id, kv.1, kv.2)) FROM test_sorted_string_kv_wide_parts) = [(1, 'part1_key1', 'part1_val1'), (2, 'part1_key2', 'part1_val2'), (100, 'part2_key1', 'part2_val1'), (200, 'part3_key1', 'part3_val1')] AS merged_data_correct;
+
+DROP TABLE test_sorted_string_kv_wide_parts;
+
+-- Test 4: SortedStringKV with composite primary key (date, kv.1)
+SELECT 'Test 4: SortedStringKV with composite primary key' AS test_name;
+DROP TABLE IF EXISTS test_sorted_string_kv_pk;
+CREATE TABLE test_sorted_string_kv_pk (id UInt64, kv SortedStringKV, date Date) 
+ENGINE = MergeTree ORDER BY (date, kv.1)
+SETTINGS index_granularity = 8192;
+
+INSERT INTO test_sorted_string_kv_pk VALUES 
+    (1, ('sensor1', '25.5'), '2024-01-01'),
+    (2, ('sensor2', '30.0'), '2024-01-01'),
+    (3, ('sensor3', '28.3'), '2024-01-02');
+
+SELECT id, kv.1 AS sensor, kv.2 AS reading, date FROM test_sorted_string_kv_pk ORDER BY date, id;
+
+SELECT id, kv.1 AS sensor, kv.2 AS reading FROM test_sorted_string_kv_pk WHERE date = '2024-01-01' ORDER BY id;
+
+DROP TABLE test_sorted_string_kv_pk;
+
+-- Test 5: Empty SortedStringKV column after DELETE (kv.1 as sort key)
+SELECT 'Test 5: Empty SortedStringKV column after DELETE' AS test_name;
+DROP TABLE IF EXISTS test_sorted_string_kv_empty;
+CREATE TABLE test_sorted_string_kv_empty (id UInt64, kv SortedStringKV) 
+ENGINE = MergeTree ORDER BY kv.1
+SETTINGS index_granularity = 8192;
+
+INSERT INTO test_sorted_string_kv_empty SELECT number, (toString(number), toString(number * 2)) FROM numbers(10);
+
+DELETE FROM test_sorted_string_kv_empty WHERE 1 = 1;
+
+SELECT count() FROM test_sorted_string_kv_empty;
+
+DROP TABLE test_sorted_string_kv_empty;
+
+-- Test 6: Large dataset with multiple granules (kv.1 as sort key)
+SELECT 'Test 6: Large dataset - multiple granules and filtering' AS test_name;
+DROP TABLE IF EXISTS test_sorted_string_kv_large;
+CREATE TABLE test_sorted_string_kv_large (id UInt64, kv SortedStringKV) 
+ENGINE = MergeTree ORDER BY kv.1
+SETTINGS index_granularity = 8192;
+
+-- Insert data spanning multiple granules (25000 rows = ~3 granules)
+INSERT INTO test_sorted_string_kv_large SELECT number, (concat('k', toString(number)), concat('v', toString(number * 100))) FROM numbers(25000);
+
+SELECT count() FROM test_sorted_string_kv_large;
+
+-- Test reading across multiple granules
+SELECT count() FROM test_sorted_string_kv_large WHERE id BETWEEN 8190 AND 8200;
+
+-- Verify granule boundary values in large dataset
+-- Granule 1 ends at 8191, Granule 2 ends at 16383, Granule 3 ends at 24575
+SELECT 
+    (SELECT (kv.1, kv.2) FROM test_sorted_string_kv_large WHERE id = 8191) = ('k8191', 'v819100') AS granule_1_boundary_correct,
+    (SELECT (kv.1, kv.2) FROM test_sorted_string_kv_large WHERE id = 8192) = ('k8192', 'v819200') AS granule_2_start_correct,
+    (SELECT (kv.1, kv.2) FROM test_sorted_string_kv_large WHERE id = 16383) = ('k16383', 'v1638300') AS granule_2_boundary_correct,
+    (SELECT (kv.1, kv.2) FROM test_sorted_string_kv_large WHERE id = 16384) = ('k16384', 'v1638400') AS granule_3_start_correct,
+    (SELECT (kv.1, kv.2) FROM test_sorted_string_kv_large WHERE id = 24999) = ('k24999', 'v2499900') AS last_row_correct;
+
+-- Verify random sampling of data integrity across all granules
+SELECT count() = 25000 AS all_rows_match_pattern
+FROM test_sorted_string_kv_large 
+WHERE kv.1 = concat('k', toString(id)) AND kv.2 = concat('v', toString(id * 100));
+
+-- Test filtering on large dataset
+SELECT count() FROM test_sorted_string_kv_large WHERE kv.1 LIKE 'k1%';
+
+DROP TABLE test_sorted_string_kv_large;
+
+-- Test 7: Multiple SortedStringKV columns in same table (kv1.1 as sort key)
+SELECT 'Test 7: Multiple SortedStringKV columns in same table' AS test_name;
+DROP TABLE IF EXISTS test_sorted_string_kv_multi;
+CREATE TABLE test_sorted_string_kv_multi (id UInt64, kv1 SortedStringKV, kv2 SortedStringKV) 
+ENGINE = MergeTree ORDER BY kv1.1
+SETTINGS index_granularity = 8192;
+
+INSERT INTO test_sorted_string_kv_multi VALUES 
+    (1, ('key1', 'val1'), ('a', 'b')),
+    (2, ('key2', 'val2'), ('c', 'd'));
+
+SELECT id, kv1.1 AS k1, kv1.2 AS v1, kv2.1 AS k2, kv2.2 AS v2 FROM test_sorted_string_kv_multi ORDER BY id;
+
+DROP TABLE test_sorted_string_kv_multi;
+
+-- Test 8: NEGATIVE TEST - Wrong sort order (should fail or produce incorrect results)
+-- This test intentionally uses ORDER BY id instead of kv.key to demonstrate
+-- that SortedStringKV requires the key column to be part of the sort key prefix.
+SELECT 'Test 8: NEGATIVE TEST - Wrong sort order (id instead of kv.1)' AS test_name;
+DROP TABLE IF EXISTS test_sorted_string_kv_basic;
+CREATE TABLE test_sorted_string_kv_basic (id UInt64, kv SortedStringKV) 
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_rows_for_wide_part = 1, min_bytes_for_wide_part = 1, index_granularity = 8192;
+
+INSERT INTO test_sorted_string_kv_basic VALUES 
+    (1, ('name', 'Alice')),
+    (2, ('city', 'Beijing')),
+    (3, ('country', 'China')); -- { serverError INCORRECT_DATA }
+
+DROP TABLE test_sorted_string_kv_basic;

--- a/tests/queries/0_stateless/04005_sorted_string_kv_empty_sst.reference
+++ b/tests/queries/0_stateless/04005_sorted_string_kv_empty_sst.reference
@@ -1,0 +1,13 @@
+Test 1: Empty SST after DELETE, then insert	test_name
+2
+0
+1
+3	key3	value3
+
+Test 2: Multiple parts with empty part merge	test_name
+2
+10	key10	value10
+30	key30	value30
+2
+10	key10	value10
+30	key30	value30

--- a/tests/queries/0_stateless/04005_sorted_string_kv_empty_sst.reference
+++ b/tests/queries/0_stateless/04005_sorted_string_kv_empty_sst.reference
@@ -1,10 +1,9 @@
-Test 1: Empty SST after DELETE, then insert	test_name
+Test 1: Empty SST after DELETE, then insert
 2
 0
 1
 3	key3	value3
-
-Test 2: Multiple parts with empty part merge	test_name
+Test 2: Multiple parts with empty part merge
 2
 10	key10	value10
 30	key30	value30

--- a/tests/queries/0_stateless/04005_sorted_string_kv_empty_sst.sql
+++ b/tests/queries/0_stateless/04005_sorted_string_kv_empty_sst.sql
@@ -1,0 +1,54 @@
+-- Tags: no-random-merge-tree-settings
+-- Test SortedStringKV data type with empty SST file scenarios
+
+-- Test 1: Part becomes empty after DELETE, then insert again
+-- This tests: wide part with SST file → DELETE all rows → empty SST → insert new data
+SELECT 'Test 1: Empty SST after DELETE, then insert' AS test_name;
+DROP TABLE IF EXISTS test_sorted_string_kv_empty_sst_1;
+CREATE TABLE test_sorted_string_kv_empty_sst_1 (id UInt64, kv SortedStringKV) 
+ENGINE = MergeTree ORDER BY kv.1
+SETTINGS min_rows_for_wide_part = 1, min_bytes_for_wide_part = 1, index_granularity = 8192;
+
+-- Insert rows to create wide part with SST file
+INSERT INTO test_sorted_string_kv_empty_sst_1 VALUES (1, ('key1', 'value1')), (2, ('key2', 'value2'));
+SELECT count() FROM test_sorted_string_kv_empty_sst_1;
+
+-- Delete all rows, leaving empty SST file
+DELETE FROM test_sorted_string_kv_empty_sst_1 WHERE 1 = 1;
+SELECT count() FROM test_sorted_string_kv_empty_sst_1;
+
+-- Insert again to verify table is still functional after empty SST
+INSERT INTO test_sorted_string_kv_empty_sst_1 VALUES (3, ('key3', 'value3'));
+SELECT count() FROM test_sorted_string_kv_empty_sst_1;
+SELECT id, kv.1, kv.2 FROM test_sorted_string_kv_empty_sst_1 ORDER BY id;
+
+DROP TABLE test_sorted_string_kv_empty_sst_1;
+
+-- Test 2: Multiple parts with one becoming empty, then merge
+-- This tests: multiple parts → DELETE from one part → empty part → OPTIMIZE merge
+SELECT 'Test 2: Multiple parts with empty part merge' AS test_name;
+DROP TABLE IF EXISTS test_sorted_string_kv_empty_sst_2;
+CREATE TABLE test_sorted_string_kv_empty_sst_2 (id UInt64, kv SortedStringKV) 
+ENGINE = MergeTree ORDER BY kv.1
+SETTINGS min_rows_for_wide_part = 1, min_bytes_for_wide_part = 1, index_granularity = 8192;
+
+-- Insert multiple small parts
+INSERT INTO test_sorted_string_kv_empty_sst_2 VALUES (10, ('key10', 'value10'));
+INSERT INTO test_sorted_string_kv_empty_sst_2 VALUES (20, ('key20', 'value20'));
+INSERT INTO test_sorted_string_kv_empty_sst_2 VALUES (30, ('key30', 'value30'));
+
+-- Delete one row to make one part empty
+DELETE FROM test_sorted_string_kv_empty_sst_2 WHERE id = 20;
+
+-- Verify remaining data before merge
+SELECT count() FROM test_sorted_string_kv_empty_sst_2;
+SELECT id, kv.1, kv.2 FROM test_sorted_string_kv_empty_sst_2 ORDER BY id;
+
+-- Optimize to merge parts (including the empty one)
+OPTIMIZE TABLE test_sorted_string_kv_empty_sst_2 FINAL;
+
+-- Verify data integrity after merge
+SELECT count() FROM test_sorted_string_kv_empty_sst_2;
+SELECT id, kv.1, kv.2 FROM test_sorted_string_kv_empty_sst_2 ORDER BY id;
+
+DROP TABLE test_sorted_string_kv_empty_sst_2;


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add new `SortedStringKV` data type based on `Tuple(String, String)` that stores key-value pairs as RocksDB SST files on disk, providing efficient sorted storage and point lookups.

###  Example
`CREATE TABLE test_sorted_string_kv_compact (id UInt64, kv SortedStringKV) 
ENGINE = MergeTree ORDER BY (kv.1, id)`
kv.1 mean key which must be serialized strictly in ascending order and cannot contain duplicate values.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches MergeTree on-disk serialization paths and introduces a new SST-based storage format with new stream lifecycle/checksum behavior; mistakes could corrupt parts or break reads across marks/merges.
> 
> **Overview**
> Adds a new `SortedStringKV` data type (a customized `Tuple(String,String)`) with a dedicated serialization that writes KV pairs into a per-column RocksDB SST file plus an `offsets` stream for granule seeking, and registers it in `DataTypeFactory`.
> 
> Extends MergeTree read/write plumbing to support SST-backed serializations by introducing `sst_*_stream_getter` hooks in `ISerialization` bulk settings, creating/owning SST file streams in Wide/Compact part writers (including checksums/finalization/cancel), and opening whole-part SST read streams in readers; also tweaks tuple serialization/column creation to allow custom tuple-based serializations to be used.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6b39f1d7eb399256dca268c11471e4be396c5b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->