### PR TITLE
Disable `01103_optimize_drop_race_zookeeper` with shared catalog

### DIFF
--- a/tests/queries/0_stateless/01103_optimize_drop_race_zookeeper.sh
+++ b/tests/queries/0_stateless/01103_optimize_drop_race_zookeeper.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Tags: race, zookeeper
+# Tags: race, zookeeper, no-shared-catalog
+# no-shared-catalog: times out in private
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

[cidb](https://github.com/ClickHouse/clickhouse-private/issues/35867#issuecomment-4031194508)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only metadata change that just adjusts CI selection/skip behavior; no production code paths are affected.
> 
> **Overview**
> Marks `tests/queries/0_stateless/01103_optimize_drop_race_zookeeper.sh` with the `no-shared-catalog` tag (and documents the reason) so this ZooKeeper race/stress test is skipped in shared-catalog environments where it times out.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d6e73cbc0705e02246f5d7970c3339bd3473ff5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.580`
<!-- ch-version-info:end -->