### PR TITLE
Skip assertDeterministic in checkKeyExpression during ATTACH

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -685,7 +685,7 @@ MergeTreeData::MergeTreeData(
     {
         try
         {
-            checkPartitionKeyAndInitMinMax(metadata_.partition_key);
+            checkPartitionKeyAndInitMinMax(metadata_.partition_key, !sanity_checks);
             setProperties(metadata_, metadata_, !sanity_checks);
             if (minmax_idx_date_column_pos == -1)
                 throw Exception(ErrorCodes::BAD_TYPE_OF_FIELD, "Could not find Date column");
@@ -700,7 +700,7 @@ MergeTreeData::MergeTreeData(
     else
     {
         is_custom_partitioned = true;
-        checkPartitionKeyAndInitMinMax(metadata_.partition_key);
+        checkPartitionKeyAndInitMinMax(metadata_.partition_key, !sanity_checks);
     }
     setProperties(metadata_, metadata_, !sanity_checks);
 
@@ -874,19 +874,22 @@ bool MergeTreeData::supportsFinal() const
         || merging_params.mode == MergingParams::VersionedCollapsing;
 }
 
-static void checkKeyExpression(const ExpressionActions & expr, const Block & sample_block, const String & key_name, bool allow_nullable_key)
+static void checkKeyExpression(const ExpressionActions & expr, const Block & sample_block, const String & key_name, bool allow_nullable_key, bool attach = false)
 {
     if (expr.hasArrayJoin())
         throw Exception(ErrorCodes::ILLEGAL_COLUMN, "{} key cannot contain array joins", key_name);
 
-    try
+    if (!attach)
     {
-        expr.assertDeterministic();
-    }
-    catch (Exception & e)
-    {
-        e.addMessage(fmt::format("for {} key", key_name));
-        throw;
+        try
+        {
+            expr.assertDeterministic();
+        }
+        catch (Exception & e)
+        {
+            e.addMessage(fmt::format("for {} key", key_name));
+            throw;
+        }
     }
 
     for (const ColumnWithTypeAndName & element : sample_block)
@@ -1148,7 +1151,7 @@ void MergeTreeData::checkProperties(
             MergeTreeStatisticsFactory::instance().validate(col.statistics, col.type);
     }
 
-    checkKeyExpression(*new_sorting_key.expression, new_sorting_key.sample_block, "Sorting", allow_nullable_key_);
+    checkKeyExpression(*new_sorting_key.expression, new_sorting_key.sample_block, "Sorting", allow_nullable_key_, attach);
 }
 
 void MergeTreeData::setProperties(
@@ -1231,12 +1234,12 @@ MergeTreeData::getSortingKeyAndSkipIndicesExpression(const StorageMetadataPtr & 
 }
 
 
-void MergeTreeData::checkPartitionKeyAndInitMinMax(const KeyDescription & new_partition_key)
+void MergeTreeData::checkPartitionKeyAndInitMinMax(const KeyDescription & new_partition_key, bool attach)
 {
     if (new_partition_key.expression_list_ast->children.empty())
         return;
 
-    checkKeyExpression(*new_partition_key.expression, new_partition_key.sample_block, "Partition", allow_nullable_key);
+    checkKeyExpression(*new_partition_key.expression, new_partition_key.sample_block, "Partition", allow_nullable_key, attach);
 
     /// Add all columns used in the partition key to the min-max index.
     DataTypes minmax_idx_columns_types = getMinMaxColumnsTypes(new_partition_key);

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -1620,7 +1620,7 @@ protected:
         bool attach = false,
         ContextPtr local_context = nullptr);
 
-    void checkPartitionKeyAndInitMinMax(const KeyDescription & new_partition_key);
+    void checkPartitionKeyAndInitMinMax(const KeyDescription & new_partition_key, bool attach = false);
 
     void checkTTLExpressions(const StorageInMemoryMetadata & new_metadata, const StorageInMemoryMetadata & old_metadata) const;
 

--- a/tests/integration/test_backward_compatibility/test_attach_nondeterministic_projection.py
+++ b/tests/integration/test_backward_compatibility/test_attach_nondeterministic_projection.py
@@ -1,0 +1,104 @@
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance(
+    "node",
+    with_zookeeper=False,
+    image="clickhouse/clickhouse-server",
+    tag="26.2",
+    stay_alive=True,
+    with_installed_binary=True,
+)
+
+
+@pytest.fixture(scope="module")
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+@pytest.fixture(autouse=True)
+def cleanup():
+    yield
+    node.restart_with_original_version(clear_data_dir=True)
+
+
+def test_attach_nondeterministic_sorting_key(start_cluster):
+    """Tables whose sorting key contains a non-deterministic function must
+    still attach after upgrade.
+
+    The determinism check in ``checkKeyExpression`` is meaningful at CREATE
+    TABLE time but must be skipped during ATTACH, because the table already
+    exists on disk.  This test injects ``dictGet`` into the sorting key
+    metadata while the server is stopped, then verifies the new binary can
+    attach the table.
+
+    Background: PR #91352 added alias expansion in ``getProjectionFromAST``
+    which can resolve a column alias to a non-deterministic expression (e.g.
+    ``dictGet``).  The expanded expression ends up in the projection's sorting
+    key and previously caused ``assertDeterministic`` to reject the table on
+    attach.
+    """
+
+    # Source table for the dictionary.
+    node.query(
+        """
+        CREATE TABLE dict_source (key String, value Int64)
+        ENGINE = MergeTree ORDER BY key
+        """
+    )
+    node.query("INSERT INTO dict_source VALUES ('a', 1), ('b', 2), ('c', 3)")
+
+    node.query(
+        """
+        CREATE DICTIONARY test_dict (key String, value Int64)
+        PRIMARY KEY key
+        SOURCE(CLICKHOUSE(TABLE 'dict_source'))
+        LIFETIME(MIN 0 MAX 1000)
+        LAYOUT(COMPLEX_KEY_HASHED())
+        """
+    )
+
+    # Create a normal table and insert data.
+    node.query(
+        """
+        CREATE TABLE test_table (key String, value Int64)
+        ENGINE = MergeTree ORDER BY key
+        """
+    )
+    node.query(
+        "INSERT INTO test_table VALUES ('a', 10), ('b', 20), ('c', 30)"
+    )
+
+    assert node.query("SELECT count() FROM test_table").strip() == "3"
+
+    def inject_nondeterministic_key(instance):
+        """Replace the sorting key in the stored metadata with dictGet.
+
+        This simulates what happens when alias expansion (PR #91352) resolves
+        a column reference to a non-deterministic expression in the projection
+        sorting key.
+        """
+        instance.exec_in_container(
+            [
+                "bash",
+                "-c",
+                r"sed -i 's/ORDER BY key/ORDER BY dictGet('\''default.test_dict'\'', '\''value'\'', key)/' "
+                "/var/lib/clickhouse/metadata/default/test_table.sql",
+            ]
+        )
+
+    # Upgrade to the version under test, modifying metadata in between.
+    node.restart_with_latest_version(callback_onstop=inject_nondeterministic_key)
+
+    # The table must attach and remain queryable.
+    assert node.query("SELECT count() FROM test_table").strip() == "3"
+
+    # Verify that new inserts still work.
+    node.query("INSERT INTO test_table VALUES ('a', 40)")
+    assert node.query("SELECT count() FROM test_table").strip() == "4"


### PR DESCRIPTION
## Summary

- Skip `assertDeterministic` in `checkKeyExpression` when `attach=true`, so tables with non-deterministic functions in key expressions (e.g. `dictGet`) can be attached after upgrade
- Thread the existing `attach` flag from `checkProperties` through to `checkKeyExpression` and `checkPartitionKeyAndInitMinMax`
- Add integration test that verifies attach works with non-deterministic sorting key

## Context

PR #91352 added alias expansion in `getProjectionFromAST` which resolves `ORDER BY value` to `ORDER BY dictGet(...)` in normal projection metadata. The [upgrade check](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=99121&sha=fb39b3a52f976aba12a573c0a4a2b1a72d8989a7&name_0=PR&name_1=Upgrade%20check%20%28amd_release%29
https://github.com/ClickHouse/ClickHouse/pull/99121) creates tables with the old `03755_circular_dictionary.sql` (which had `dictGet(...) AS value ORDER BY value` in projections), then restarts with the new binary. The alias expansion exposes the non-deterministic `dictGet` in the projection's sorting key, causing `assertDeterministic` to reject the table on attach.

The determinism check is meaningful at `CREATE TABLE` time but not during `ATTACH` — the table already exists on disk with that key expression. Ref #91352.

## Test plan

- [x] Integration test `test_backward_compatibility/test_attach_nondeterministic_projection.py` — injects `dictGet` into sorting key metadata, verifies table attaches and queries work after upgrade
- [x] Verified test fails without fix (`BAD_ARGUMENTS: Expression must be deterministic`)
- [x] Verified test passes with fix

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches MergeTree key validation on startup/attach, which affects table attach behavior during upgrades. The change is gated to `ATTACH`, reducing impact on normal `CREATE TABLE` validation but still relevant to storage initialization paths.
> 
> **Overview**
> Improves MergeTree backward compatibility by **skipping `ExpressionActions::assertDeterministic()` validation for sorting/partition key expressions when `attach=true`**, so tables that already exist on disk with non-deterministic functions in keys can still be attached after upgrade.
> 
> Threads the existing `attach` flag through `checkProperties` → `checkKeyExpression` and `checkPartitionKeyAndInitMinMax` (including initial metadata setup paths), and adds an integration test that modifies stored metadata to include `dictGet` in `ORDER BY` and verifies the upgraded server can attach and continue querying/inserting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 06a3c09a1ab04acab17eeabe4c406fcc05fac450. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->