### PR TITLE
Log Cannot initialize GlobalProfiler/QueryProfiler as a warning

### DIFF
--- a/src/Interpreters/ThreadStatusExt.cpp
+++ b/src/Interpreters/ThreadStatusExt.cpp
@@ -647,7 +647,7 @@ void ThreadStatus::initGlobalProfiler([[maybe_unused]] UInt64 global_profiler_re
     catch (...)
     {
         /// GlobalProfiler is optional.
-        tryLogCurrentException(LogFrequencyLimiter(log, 10), "Cannot initialize GlobalProfiler. This usually happens when RLIMIT_SIGPENDING is too low. You may tune it via pending_signals in config.");
+        tryLogCurrentException(LogFrequencyLimiter(log, 10), "Cannot initialize GlobalProfiler. This usually happens when RLIMIT_SIGPENDING is too low. You may tune it via pending_signals in config.", LogsLevel::warning);
     }
 #endif
 }
@@ -688,7 +688,7 @@ void ThreadStatus::initQueryProfiler()
     catch (...)
     {
         /// QueryProfiler is optional.
-        tryLogCurrentException(LogFrequencyLimiter(log, 10), "Cannot initialize QueryProfiler. This usually happens when RLIMIT_SIGPENDING is too low. You may tune it via pending_signals in config.");
+        tryLogCurrentException(LogFrequencyLimiter(log, 10), "Cannot initialize QueryProfiler. This usually happens when RLIMIT_SIGPENDING is too low. You may tune it via pending_signals in config.", LogsLevel::warning);
     }
 }
 


### PR DESCRIPTION
It does not affect the server, and in case of small RLIMIT_SIGPENDING it is possible to have such errors.

Changing it, since people tend to mis-interpret it.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only log severity for optional profiler initialization failures, so behavior is unaffected aside from log level/alerting impact.
> 
> **Overview**
> Updates `ThreadStatus::initGlobalProfiler` and `ThreadStatus::initQueryProfiler` to log "Cannot initialize GlobalProfiler/QueryProfiler" exceptions at `LogsLevel::warning` (instead of the default error), reflecting that these profilers are optional and failures (e.g., low `RLIMIT_SIGPENDING`) do not impact server operation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 684615e9c2d12f2ac16c3885fee5e8d77623fbf9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.650`
<!-- ch-version-info:end -->