### PR TITLE
Fix max_execution_time not being applied for backup/restore

### DIFF
--- a/src/Backups/BackupsWorker.cpp
+++ b/src/Backups/BackupsWorker.cpp
@@ -19,6 +19,7 @@
 #if CLICKHOUSE_CLOUD
 #include <Backups/BackupsHelper.h>
 #endif
+#include <Common/FailPoint.h>
 #include <Interpreters/Cluster.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/BackupLog.h>
@@ -68,6 +69,12 @@ namespace Setting
 namespace ServerSetting
 {
     extern const ServerSettingsBool shutdown_wait_backups_and_restores;
+}
+
+namespace FailPoints
+{
+    extern const char backup_pause_before_main_loop[];
+    extern const char restore_pause_before_main_loop[];
 }
 
 namespace ErrorCodes
@@ -463,6 +470,8 @@ struct BackupsWorker::BackupStarter
 
     void doBackup()
     {
+        FailPointInjection::pauseFailPoint(FailPoints::backup_pause_before_main_loop);
+
         chassert(!backup_coordination);
         if (on_cluster && !is_internal_backup)
         {
@@ -920,6 +929,8 @@ struct BackupsWorker::RestoreStarter
 
     void doRestore()
     {
+        FailPointInjection::pauseFailPoint(FailPoints::restore_pause_before_main_loop);
+
         chassert(!restore_coordination);
         if (on_cluster && !is_internal_restore)
         {

--- a/src/Backups/BackupsWorker.cpp
+++ b/src/Backups/BackupsWorker.cpp
@@ -73,8 +73,8 @@ namespace ServerSetting
 
 namespace FailPoints
 {
-    extern const char backup_pause_before_main_loop[];
-    extern const char restore_pause_before_main_loop[];
+    extern const char backup_pause_on_start[];
+    extern const char restore_pause_on_start[];
 }
 
 namespace ErrorCodes
@@ -391,10 +391,7 @@ struct BackupsWorker::BackupStarter
         , backup_context(Context::createCopy(query_context))
     {
         backup_settings = BackupSettings::fromBackupQuery(*backup_query);
-
         backup_context->makeQueryContext();
-        backup_context->checkSettingsConstraints(backup_settings.core_settings, SettingSource::QUERY);
-        backup_context->applySettingsChanges(backup_settings.core_settings);
 
         backup_info = BackupInfo::fromAST(*backup_query->backup_name);
         backup_name_for_logging = backup_info.toStringForLogging();
@@ -470,7 +467,7 @@ struct BackupsWorker::BackupStarter
 
     void doBackup()
     {
-        FailPointInjection::pauseFailPoint(FailPoints::backup_pause_before_main_loop);
+        FailPointInjection::pauseFailPoint(FailPoints::backup_pause_on_start);
 
         chassert(!backup_coordination);
         if (on_cluster && !is_internal_backup)
@@ -870,10 +867,7 @@ struct BackupsWorker::RestoreStarter
         , restore_context(Context::createCopy(query_context))
     {
         restore_settings = RestoreSettings::fromRestoreQuery(*restore_query);
-
         restore_context->makeQueryContext();
-        restore_context->checkSettingsConstraints(restore_settings.core_settings, SettingSource::QUERY);
-        restore_context->applySettingsChanges(restore_settings.core_settings);
 
         backup_info = BackupInfo::fromAST(*restore_query->backup_name);
         backup_name_for_logging = backup_info.toStringForLogging();
@@ -929,7 +923,7 @@ struct BackupsWorker::RestoreStarter
 
     void doRestore()
     {
-        FailPointInjection::pauseFailPoint(FailPoints::restore_pause_before_main_loop);
+        FailPointInjection::pauseFailPoint(FailPoints::restore_pause_on_start);
 
         chassert(!restore_coordination);
         if (on_cluster && !is_internal_restore)

--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -126,6 +126,8 @@ static struct InitFiu
     REGULAR(slowdown_parallel_replicas_local_plan_read) \
     ONCE(iceberg_writes_cleanup) \
     ONCE(backup_add_empty_memory_table) \
+    PAUSEABLE_ONCE(backup_pause_before_main_loop) \
+    PAUSEABLE_ONCE(restore_pause_before_main_loop) \
     PAUSEABLE(sc_state_application_pause) \
     PAUSEABLE(sc_state_application_pause_after_fetch) \
     REGULAR(sc_intentions_commit_fail) \

--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -126,8 +126,8 @@ static struct InitFiu
     REGULAR(slowdown_parallel_replicas_local_plan_read) \
     ONCE(iceberg_writes_cleanup) \
     ONCE(backup_add_empty_memory_table) \
-    PAUSEABLE_ONCE(backup_pause_before_main_loop) \
-    PAUSEABLE_ONCE(restore_pause_before_main_loop) \
+    PAUSEABLE_ONCE(backup_pause_on_start) \
+    PAUSEABLE_ONCE(restore_pause_on_start) \
     PAUSEABLE(sc_state_application_pause) \
     PAUSEABLE(sc_state_application_pause_after_fetch) \
     REGULAR(sc_intentions_commit_fail) \

--- a/src/Interpreters/InterpreterSetQuery.cpp
+++ b/src/Interpreters/InterpreterSetQuery.cpp
@@ -164,7 +164,10 @@ void InterpreterSetQuery::applySettingsFromQuery(const ASTPtr & ast, ContextMuta
                 : RestoreSettings::fromRestoreQuery(*backup_query).core_settings;
 
             if (!core_settings.empty())
+            {
+                context_->checkSettingsConstraints(core_settings, SettingSource::QUERY);
                 context_->applySettingsChanges(core_settings);
+            }
         }
     }
 }

--- a/src/Interpreters/InterpreterSetQuery.cpp
+++ b/src/Interpreters/InterpreterSetQuery.cpp
@@ -1,7 +1,10 @@
+#include <Backups/BackupSettings.h>
+#include <Backups/RestoreSettings.h>
 #include <Core/Settings.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/InterpreterFactory.h>
 #include <Interpreters/InterpreterSetQuery.h>
+#include <Parsers/ASTBackupQuery.h>
 #include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTExplainQuery.h>
 #include <Parsers/ASTFunction.h>
@@ -145,6 +148,24 @@ void InterpreterSetQuery::applySettingsFromQuery(const ASTPtr & ast, ContextMuta
         context_->setInsertFormat(insert_query->format);
         if (insert_query->settings_ast)
             InterpreterSetQuery(insert_query->settings_ast, context_).executeForCurrentContext(/* ignore_setting_constraints= */ false);
+    }
+    else if (const auto * backup_query = ast->as<ASTBackupQuery>())
+    {
+        /// BACKUP/RESTORE queries store their settings in ASTBackupQuery::settings (not settings_ast),
+        /// so they are not handled by the settings_ast branch above.
+        /// We apply only the core query settings here, before ProcessList::insert,
+        /// so that the ProcessListElement and CancellationChecker see the correct
+        /// limits from the start. BACKUP/RESTORE-specific settings (async, password, etc.)
+        /// are filtered out by BackupSettings/RestoreSettings and are not applied to the context.
+        if (backup_query->settings)
+        {
+            SettingsChanges core_settings = (backup_query->kind == ASTBackupQuery::Kind::BACKUP)
+                ? BackupSettings::fromBackupQuery(*backup_query).core_settings
+                : RestoreSettings::fromRestoreQuery(*backup_query).core_settings;
+
+            if (!core_settings.empty())
+                context_->applySettingsChanges(core_settings);
+        }
     }
 }
 

--- a/tests/integration/test_backup_restore_new/configs/max_execution_time.xml
+++ b/tests/integration/test_backup_restore_new/configs/max_execution_time.xml
@@ -1,0 +1,7 @@
+<clickhouse>
+    <profiles>
+        <default>
+            <max_execution_time>0.5</max_execution_time>
+        </default>
+    </profiles>
+</clickhouse>

--- a/tests/integration/test_backup_restore_new/test.py
+++ b/tests/integration/test_backup_restore_new/test.py
@@ -24,6 +24,12 @@ instance = cluster.add_instance(
     user_configs=["configs/zookeeper_retries.xml"],
     external_dirs=["/backups/"],
 )
+instance_with_short_timeout = cluster.add_instance(
+    "instance_with_short_timeout",
+    main_configs=["configs/backups_disk.xml"],
+    user_configs=["configs/max_execution_time.xml"],
+    external_dirs=["/backups/"],
+)
 
 
 def create_and_fill_table(engine="MergeTree", n=100):
@@ -2232,3 +2238,70 @@ def test_incremental_backup_with_checksum_data_file_name():
         f"RESTORE TABLE test.table AS test.table2 FROM {incremental_backup_name}"
     )
     assert instance.query("SELECT count(), sum(x) FROM test.table2") == "102\t5081\n"
+
+
+def test_async_backup_restore_with_max_execution_time_zero():
+    """
+    Regression test: async BACKUP/RESTORE with max_execution_time = 0 in query SETTINGS
+    was incorrectly cancelled by the max_execution_time from the user's profile, even when
+    the query explicitly set max_execution_time = 0 to disable the timeout.
+
+    Root cause: QueryStatus cached limits.max_execution_time at construction time from the
+    original query settings (profile value). BackupsWorker called applySettingsChanges()
+    to apply BACKUP/RESTORE SETTINGS, updating the context — but not the cached
+    ProcessListElement, so the old profile-level timeout still fired via checkTimeLimit().
+    CancellationChecker was also registered with the old timeout at insert time.
+
+    The test uses a PAUSEABLE_ONCE failpoint to stall the background task long enough
+    for the profile-level timeout (500ms) to fire, which reliably triggers the bug.
+    The instance_with_short_timeout node has max_execution_time = 0.5 in its default profile.
+    """
+    import time
+
+    inst = instance_with_short_timeout
+    backup_name = new_backup_name()
+    inst.query("CREATE DATABASE IF NOT EXISTS test")
+    inst.query("CREATE TABLE test.table(x UInt32, y String) ENGINE=MergeTree ORDER BY y PARTITION BY x%10")
+    inst.query("INSERT INTO test.table SELECT number, toString(number) FROM numbers(100)")
+
+    try:
+        # Pause backup before it starts so the 500ms profile-level timeout fires.
+        inst.query("SYSTEM ENABLE FAILPOINT backup_pause_before_main_loop")
+        [backup_id, _] = inst.query(
+            f"BACKUP TABLE test.table TO {backup_name}"
+            " SETTINGS async = 1, max_execution_time = 0",
+        ).split("\t")
+
+        inst.query("SYSTEM WAIT FAILPOINT backup_pause_before_main_loop PAUSE")
+        time.sleep(0.7)  # exceed the 500ms profile-level timeout
+        inst.query("SYSTEM NOTIFY FAILPOINT backup_pause_before_main_loop")
+
+        assert_eq_with_retry(
+            inst,
+            f"SELECT status, error FROM system.backups WHERE id='{backup_id}'",
+            TSV([["BACKUP_CREATED", ""]]),
+        )
+
+        # Same for RESTORE.
+        inst.query("DROP TABLE test.table")
+        inst.query("SYSTEM ENABLE FAILPOINT restore_pause_before_main_loop")
+        [restore_id, _] = inst.query(
+            f"RESTORE TABLE test.table FROM {backup_name}"
+            " SETTINGS async = 1, max_execution_time = 0",
+        ).split("\t")
+
+        inst.query("SYSTEM WAIT FAILPOINT restore_pause_before_main_loop PAUSE")
+        time.sleep(0.7)
+        inst.query("SYSTEM NOTIFY FAILPOINT restore_pause_before_main_loop")
+
+        assert_eq_with_retry(
+            inst,
+            f"SELECT status, error FROM system.backups WHERE id='{restore_id}'",
+            TSV([["RESTORED", ""]]),
+        )
+
+        assert inst.query("SELECT count(), sum(x) FROM test.table") == "100\t4950\n"
+    finally:
+        inst.query("SYSTEM DISABLE FAILPOINT backup_pause_before_main_loop")
+        inst.query("SYSTEM DISABLE FAILPOINT restore_pause_before_main_loop")
+        inst.query("DROP DATABASE IF EXISTS test")

--- a/tests/integration/test_backup_restore_new/test.py
+++ b/tests/integration/test_backup_restore_new/test.py
@@ -2266,15 +2266,15 @@ def test_async_backup_restore_with_max_execution_time_zero():
 
     try:
         # Pause backup before it starts so the 500ms profile-level timeout fires.
-        inst.query("SYSTEM ENABLE FAILPOINT backup_pause_before_main_loop")
+        inst.query("SYSTEM ENABLE FAILPOINT backup_pause_on_start")
         [backup_id, _] = inst.query(
             f"BACKUP TABLE test.table TO {backup_name}"
             " SETTINGS async = 1, max_execution_time = 0",
         ).split("\t")
 
-        inst.query("SYSTEM WAIT FAILPOINT backup_pause_before_main_loop PAUSE")
+        inst.query("SYSTEM WAIT FAILPOINT backup_pause_on_start PAUSE")
         time.sleep(0.7)  # exceed the 500ms profile-level timeout
-        inst.query("SYSTEM NOTIFY FAILPOINT backup_pause_before_main_loop")
+        inst.query("SYSTEM NOTIFY FAILPOINT backup_pause_on_start")
 
         assert_eq_with_retry(
             inst,
@@ -2284,15 +2284,15 @@ def test_async_backup_restore_with_max_execution_time_zero():
 
         # Same for RESTORE.
         inst.query("DROP TABLE test.table")
-        inst.query("SYSTEM ENABLE FAILPOINT restore_pause_before_main_loop")
+        inst.query("SYSTEM ENABLE FAILPOINT restore_pause_on_start")
         [restore_id, _] = inst.query(
             f"RESTORE TABLE test.table FROM {backup_name}"
             " SETTINGS async = 1, max_execution_time = 0",
         ).split("\t")
 
-        inst.query("SYSTEM WAIT FAILPOINT restore_pause_before_main_loop PAUSE")
+        inst.query("SYSTEM WAIT FAILPOINT restore_pause_on_start PAUSE")
         time.sleep(0.7)
-        inst.query("SYSTEM NOTIFY FAILPOINT restore_pause_before_main_loop")
+        inst.query("SYSTEM NOTIFY FAILPOINT restore_pause_on_start")
 
         assert_eq_with_retry(
             inst,
@@ -2302,6 +2302,6 @@ def test_async_backup_restore_with_max_execution_time_zero():
 
         assert inst.query("SELECT count(), sum(x) FROM test.table") == "100\t4950\n"
     finally:
-        inst.query("SYSTEM DISABLE FAILPOINT backup_pause_before_main_loop")
-        inst.query("SYSTEM DISABLE FAILPOINT restore_pause_before_main_loop")
+        inst.query("SYSTEM DISABLE FAILPOINT backup_pause_on_start")
+        inst.query("SYSTEM DISABLE FAILPOINT restore_pause_on_start")
         inst.query("DROP DATABASE IF EXISTS test")


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix max_execution_time not being applied for backup/restore.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when/where BACKUP/RESTORE query settings are applied, which can affect timeouts/limits and cancellation behavior for long-running backup/restore operations. Adds new failpoints used by integration tests; low runtime impact unless explicitly enabled.
> 
> **Overview**
> Fixes BACKUP/RESTORE query `SETTINGS` handling so core execution limits (e.g. `max_execution_time=0`) are applied to the query context *before* the `ProcessList` entry and cancellation checker are created, preventing async backups/restores from being cancelled using profile-level timeouts.
> 
> Adds pauseable failpoints (`backup_pause_on_start`, `restore_pause_on_start`) and an integration regression test that stalls async backup/restore on a node with a short profile timeout to verify the timeout-disable setting is honored.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f36922fd4810308bce842100a7e5a561775864e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.591`
- Backported to: `26.2.5.19`, `26.1.5.25`
<!-- ch-version-info:end -->