### PR TITLE
Add a test for cache reuse between different queries for AutoPR

### DIFF
--- a/tests/queries/0_stateless/04034_autopr_dataflow_cache_reuse_between_different_queries.reference
+++ b/tests/queries/0_stateless/04034_autopr_dataflow_cache_reuse_between_different_queries.reference
@@ -1,0 +1,4 @@
+query	stats_collected	pr_used
+04034_autopr_dataflow_cache_reuse_between_different_queries_query_0	1	0
+04034_autopr_dataflow_cache_reuse_between_different_queries_query_1	0	1
+04034_autopr_dataflow_cache_reuse_between_different_queries_query_2	0	1

--- a/tests/queries/0_stateless/04034_autopr_dataflow_cache_reuse_between_different_queries.sql
+++ b/tests/queries/0_stateless/04034_autopr_dataflow_cache_reuse_between_different_queries.sql
@@ -1,0 +1,48 @@
+-- Tags: no-sanitizers
+-- no-sanitizers: too slow
+
+-- Verify that statistics are reused between queries with identical "distributed to replicas" sub-plans.
+
+DROP TABLE IF EXISTS t;
+
+CREATE TABLE t(WatchID UInt64, ClientIP UInt32, ResolutionWidth UInt16) ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity=128;
+
+SET enable_parallel_replicas=0, automatic_parallel_replicas_mode=1, parallel_replicas_local_plan=1, parallel_replicas_index_analysis_only_on_coordinator=1,
+    parallel_replicas_for_non_replicated_merge_tree=1, max_parallel_replicas=3, cluster_for_parallel_replicas='parallel_replicas';
+
+SET enable_analyzer=1;
+
+-- max_block_size is set explicitly to ensure enough blocks will be fed to the statistics collector
+SET max_threads=4, max_block_size=128;
+
+-- May disable the usage of parallel replicas
+SET automatic_parallel_replicas_min_bytes_per_replica=0;
+
+-- External aggregation is not supported at the moment, i.e., no statistics will be reported
+SET max_bytes_before_external_group_by=0, max_bytes_ratio_before_external_group_by=0;
+
+INSERT INTO t SELECT number % 1000, number % 500, number % 200 FROM numbers(5e5);
+
+-- Query 0: GROUP BY without HAVING — empty cache, collect stats
+SELECT WatchID, ClientIP, COUNT(*) AS c, AVG(ResolutionWidth) FROM t GROUP BY WatchID, ClientIP ORDER BY c DESC LIMIT 10 FORMAT Null
+    SETTINGS log_comment='04034_autopr_dataflow_cache_reuse_between_different_queries_query_0';
+
+-- Query 1: GROUP BY with HAVING — should reuse stats from query 0 (same replica sub-plan) and enable parallel replicas
+SELECT WatchID, ClientIP, COUNT(*) AS c, AVG(ResolutionWidth) FROM t GROUP BY WatchID, ClientIP HAVING c > 1 ORDER BY c DESC LIMIT 10 FORMAT Null
+    SETTINGS log_comment='04034_autopr_dataflow_cache_reuse_between_different_queries_query_1';
+
+-- Query 2: Repeat query without HAVING — stats already available, should also enable parallel replicas
+SELECT WatchID, ClientIP, COUNT(*) AS c, AVG(ResolutionWidth) FROM t GROUP BY WatchID, ClientIP ORDER BY c DESC LIMIT 10 FORMAT Null
+    SETTINGS log_comment='04034_autopr_dataflow_cache_reuse_between_different_queries_query_2';
+
+SET enable_parallel_replicas=0, automatic_parallel_replicas_mode=0;
+
+SYSTEM FLUSH LOGS query_log;
+
+SELECT log_comment query, ProfileEvents['RuntimeDataflowStatisticsInputBytes'] > 0 stats_collected, ProfileEvents['ParallelReplicasUsedCount'] > 0 pr_used
+FROM system.query_log
+WHERE (event_date >= yesterday()) AND (event_time >= (NOW() - toIntervalMinute(15))) AND (current_database = currentDatabase()) AND (log_comment LIKE '04034_autopr_dataflow_cache_reuse_between_different_queries_query_%') AND (type = 'QueryFinish')
+ORDER BY log_comment
+FORMAT TSVWithNames;
+
+DROP TABLE t;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new stateless test only; risk is limited to potential CI flakiness/latency due to reliance on `system.query_log` timing and parallel replica behavior.
> 
> **Overview**
> Adds a new stateless SQL test (`04034_autopr_dataflow_cache_reuse_between_different_queries`) to verify AutoPR reuses `RuntimeDataflowStatistics` between different but replica-subplan-identical queries (e.g., `GROUP BY` with/without `HAVING`).
> 
> The test runs three queries with distinct `log_comment`s, then asserts via `system.query_log` that stats are collected only on the first run and that `ParallelReplicasUsedCount` becomes non-zero for subsequent runs; expected output is captured in a new `.reference` file.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2bb697c22721e35b98e2d221ef346764c096bbb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.582`
<!-- ch-version-info:end -->