### PR TITLE
Allow ALTER TABLE MODIFY COLUMN TTL without type

### DIFF
--- a/src/Parsers/ParserCreateQuery.h
+++ b/src/Parsers/ParserCreateQuery.h
@@ -222,6 +222,7 @@ bool IParserColumnDeclaration<NameParser>::parseImpl(Pos & pos, ASTPtr & node, E
         && !s_ephemeral.checkWithoutMoving(pos, expected)
         && !s_alias.checkWithoutMoving(pos, expected)
         && !s_auto_increment.checkWithoutMoving(pos, expected)
+        && !s_ttl.checkWithoutMoving(pos, expected)
         && !s_primary_key.checkWithoutMoving(pos, expected)
         && (require_type
             || (!s_comment.checkWithoutMoving(pos, expected)

--- a/src/Parsers/ParserDataType.cpp
+++ b/src/Parsers/ParserDataType.cpp
@@ -227,7 +227,7 @@ bool ParserDataType::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     {
         String n = type_name;
         boost::to_upper(n);
-        if (n == "NOT" || n == "NULL" || n == "DEFAULT" || n == "MATERIALIZED" || n == "EPHEMERAL" || n == "ALIAS" || n == "AUTO" || n == "PRIMARY" || n == "COMMENT" || n == "CODEC")
+        if (n == "NOT" || n == "NULL" || n == "DEFAULT" || n == "MATERIALIZED" || n == "EPHEMERAL" || n == "ALIAS" || n == "AUTO" || n == "PRIMARY" || n == "TTL" || n == "COMMENT" || n == "CODEC")
         {
             expected.add(pos, "type name");
             return false;

--- a/tests/queries/0_stateless/04004_alter_modify_column_ttl_without_type.reference
+++ b/tests/queries/0_stateless/04004_alter_modify_column_ttl_without_type.reference
@@ -7,3 +7,5 @@ CREATE TABLE default.alter_modify_column_ttl_without_type
 ENGINE = MergeTree
 ORDER BY uid
 SETTINGS index_granularity = 8192
+1	
+2	valid

--- a/tests/queries/0_stateless/04004_alter_modify_column_ttl_without_type.reference
+++ b/tests/queries/0_stateless/04004_alter_modify_column_ttl_without_type.reference
@@ -1,0 +1,9 @@
+CREATE TABLE default.alter_modify_column_ttl_without_type
+(
+    `uid` Int16,
+    `name` String TTL age + toIntervalDay(1),
+    `age` Date
+)
+ENGINE = MergeTree
+ORDER BY uid
+SETTINGS index_granularity = 8192

--- a/tests/queries/0_stateless/04004_alter_modify_column_ttl_without_type.sql
+++ b/tests/queries/0_stateless/04004_alter_modify_column_ttl_without_type.sql
@@ -11,7 +11,13 @@ CREATE TABLE alter_modify_column_ttl_without_type
 ENGINE = MergeTree
 ORDER BY uid;
 
+INSERT INTO alter_modify_column_ttl_without_type VALUES (1, 'expired', '2000-01-01'), (2, 'valid', today());
+
 ALTER TABLE alter_modify_column_ttl_without_type MODIFY COLUMN name TTL age + INTERVAL 1 DAY;
 SHOW CREATE TABLE alter_modify_column_ttl_without_type FORMAT TSVRaw;
+
+OPTIMIZE TABLE alter_modify_column_ttl_without_type FINAL;
+
+SELECT uid, name FROM alter_modify_column_ttl_without_type ORDER BY uid;
 
 DROP TABLE alter_modify_column_ttl_without_type;

--- a/tests/queries/0_stateless/04004_alter_modify_column_ttl_without_type.sql
+++ b/tests/queries/0_stateless/04004_alter_modify_column_ttl_without_type.sql
@@ -1,0 +1,17 @@
+DROP TABLE IF EXISTS alter_modify_column_ttl_without_type;
+
+SET allow_suspicious_ttl_expressions = 1;
+
+CREATE TABLE alter_modify_column_ttl_without_type
+(
+    uid Int16,
+    name String,
+    age Date
+)
+ENGINE = MergeTree
+ORDER BY uid;
+
+ALTER TABLE alter_modify_column_ttl_without_type MODIFY COLUMN name TTL age + INTERVAL 1 DAY;
+SHOW CREATE TABLE alter_modify_column_ttl_without_type FORMAT TSVRaw;
+
+DROP TABLE alter_modify_column_ttl_without_type;


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Allow `ALTER TABLE MODIFY COLUMN x TTL ...` command without specifying column type.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk parser change limited to `ALTER TABLE ... MODIFY COLUMN` column-declaration parsing; main risk is unintended ambiguity with type-name parsing around `TTL` and related keywords.
> 
> **Overview**
> Allows `ALTER TABLE ... MODIFY COLUMN <col> TTL <expr>` to be parsed without requiring a type by treating `TTL` as a column-attribute keyword (so it won’t be consumed as a would-be type).
> 
> Keeps keyword handling consistent between `IParserColumnDeclaration` and `ParserDataType` by adding `TTL` to the shared “attribute keywords” set, and adds a stateless test verifying `SHOW CREATE TABLE` and TTL-driven row expiration after `MODIFY COLUMN ... TTL ...`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e060288a96746b68186ad7806fbdd20adab7c85e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.700`
<!-- ch-version-info:end -->