### PR TITLE
Fix 00755_avg_value_size_hint_passing flakiness

### DIFF
--- a/tests/queries/0_stateless/00755_avg_value_size_hint_passing.sql
+++ b/tests/queries/0_stateless/00755_avg_value_size_hint_passing.sql
@@ -1,7 +1,7 @@
 -- Tags: no-parallel-replicas
 
 DROP TABLE IF EXISTS size_hint;
-CREATE TABLE size_hint (s Array(String)) ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity = 1000, index_granularity_bytes = '10Mi';
+CREATE TABLE size_hint (s Array(String)) ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity = 1000, index_granularity_bytes = '10Mi', string_serialization_version='basic';
 
 SET max_block_size = 1000;
 SET max_memory_usage = 1000000000;

--- a/tests/queries/0_stateless/00755_avg_value_size_hint_passing.sql
+++ b/tests/queries/0_stateless/00755_avg_value_size_hint_passing.sql
@@ -1,7 +1,7 @@
 -- Tags: no-parallel-replicas
 
 DROP TABLE IF EXISTS size_hint;
-CREATE TABLE size_hint (s Array(String)) ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity = 1000, index_granularity_bytes = '10Mi', string_serialization_version='basic';
+CREATE TABLE size_hint (s Array(String)) ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity = 1000, index_granularity_bytes = '10Mi', string_serialization_version='single_stream';
 
 SET max_block_size = 1000;
 SET max_memory_usage = 1000000000;


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that just tweaks table settings to make results deterministic; no production code paths are modified.
> 
> **Overview**
> Stabilizes the stateless test `00755_avg_value_size_hint_passing.sql` by adding `string_serialization_version='single_stream'` to the `MergeTree` table settings used in the test setup.
> 
> This pins the on-disk string serialization format to reduce variability and prevent intermittent failures under tight memory/thread limits.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0487b1759e761bc2f5c6962cb6da69a62476a23a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.568`
<!-- ch-version-info:end -->