### PR TITLE
Do not check grants for every query tree node during `InverseDictionaryLookupPass`

### DIFF
--- a/src/Analyzer/Passes/InverseDictionaryLookupPass.cpp
+++ b/src/Analyzer/Passes/InverseDictionaryLookupPass.cpp
@@ -142,12 +142,6 @@ public:
         if (getSettings()[Setting::rewrite_in_to_join])
             return;
 
-        /// This rewrite turns `dictGet(...)` predicates into `IN (SELECT ... FROM dictionary(...))`.
-        /// The `dictionary()` table function requires `CREATE TEMPORARY TABLE`; if that grant is missing,
-        /// skip the optimization to avoid `ACCESS_DENIED`.
-        if (!getContext()->getAccess()->isGranted(AccessType::CREATE_TEMPORARY_TABLE))
-            return;
-
         auto * node_function = node->as<FunctionNode>();
 
         if (!node_function)
@@ -301,6 +295,12 @@ public:
 
 void InverseDictionaryLookupPass::run(QueryTreeNodePtr & query_tree_node, ContextPtr context)
 {
+    /// This rewrite turns `dictGet(...)` predicates into `IN (SELECT ... FROM dictionary(...))`.
+    /// The `dictionary()` table function requires `CREATE TEMPORARY TABLE`; if that grant is missing,
+    /// skip the optimization to avoid `ACCESS_DENIED`.
+    if (!context->getAccess()->isGranted(AccessType::CREATE_TEMPORARY_TABLE))
+        return;
+
     InverseDictionaryLookupVisitor visitor(std::move(context));
     visitor.visit(query_tree_node);
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
This patch fixes access checks during `InverseDictionaryLookupPass`; they are apparently visible in a flame graph. Instead, check access only once before running the optimization pass.

![559179577-18a8c768-4279-4976-a1ed-72690be1f013](https://github.com/user-attachments/assets/acd96f51-34e4-41c4-94b5-5c1ee66d0a53)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk performance-focused change: moves the `CREATE_TEMPORARY_TABLE` grant check from every visited node to a single check before the pass runs, keeping behavior the same while reducing overhead.
> 
> **Overview**
> `InverseDictionaryLookupPass` now checks `CREATE TEMPORARY TABLE` permission once in `run()` before applying the inverse dictionary lookup rewrite, instead of checking the grant inside the visitor for each query tree node.
> 
> This reduces repeated access-control calls during analysis while still skipping the optimization when the required grant is missing to avoid `ACCESS_DENIED` errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d49cde18b01597a147849cea5a7a62227fc5423. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.577`
- Backported to: `26.2.5.17`, `26.1.5.23`, `25.12.9.27`
<!-- ch-version-info:end -->