### PR TITLE
Fix bugs in Iceberg writing

### DIFF
--- a/src/Disks/IO/ReadBufferFromAzureBlobStorage.cpp
+++ b/src/Disks/IO/ReadBufferFromAzureBlobStorage.cpp
@@ -1,4 +1,5 @@
 #include "config.h"
+#include "config.h"
 
 #if USE_AZURE_BLOB_STORAGE
 
@@ -375,7 +376,7 @@ size_t ReadBufferFromAzureBlobStorage::readBigAt(char * to, size_t n, size_t ran
 
 ObjectMetadata ReadBufferFromAzureBlobStorage::getObjectMetadataFromTheLastRequest() const
 {
-    if (last_object_metadata.get()->has_value())
+    if (!last_object_metadata.get()->has_value())
         throw Exception(ErrorCodes::NOT_INITIALIZED, "No Azure object metadata available because there were no successful requests");
 
     return last_object_metadata.get()->value();

--- a/src/Disks/IO/ReadBufferFromAzureBlobStorage.cpp
+++ b/src/Disks/IO/ReadBufferFromAzureBlobStorage.cpp
@@ -1,5 +1,4 @@
 #include "config.h"
-#include "config.h"
 
 #if USE_AZURE_BLOB_STORAGE
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Compaction.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Compaction.cpp
@@ -442,14 +442,14 @@ void writeMetadataFiles(
         auto initial_manifest_entries = plan.manifest_list_to_manifest_files[initial_manifest_list_name];
         auto renamed_manifest_list = manifest_list_renamings[initial_manifest_list_name];
         std::vector<String> renamed_manifest_entries;
-        Int32 total_manifest_file_sizes = 0;
+        std::vector<Int64> per_manifest_sizes;
         for (const auto & initial_manifest_entry : initial_manifest_entries)
         {
             auto renamed_manifest_entry = manifest_file_renamings[initial_manifest_entry];
             if (!renamed_manifest_entry.empty())
             {
                 renamed_manifest_entries.push_back(renamed_manifest_entry);
-                total_manifest_file_sizes += manifest_file_sizes[renamed_manifest_entry];
+                per_manifest_sizes.push_back(manifest_file_sizes[renamed_manifest_entry]);
             }
         }
         auto buffer_manifest_list = object_storage->writeObject(
@@ -461,7 +461,7 @@ void writeMetadataFiles(
             context,
             renamed_manifest_entries,
             new_snapshots[i].snapshot,
-            total_manifest_file_sizes,
+            per_manifest_sizes,
             *buffer_manifest_list,
             Iceberg::FileContentType::DATA,
             false);

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Compaction.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Compaction.cpp
@@ -32,6 +32,11 @@ namespace DB::ErrorCodes
     extern const int BAD_ARGUMENTS;
 }
 
+namespace DB::Setting
+{
+    extern const SettingsBool write_full_path_in_iceberg_metadata;
+}
+
 namespace DB::Iceberg
 {
 
@@ -119,9 +124,9 @@ Plan getPlan(
 {
     LoggerPtr log = getLogger("IcebergCompaction::getPlan");
 
+    auto [compact_config_path, compact_storage_path] = getConfigAndStoragePaths(persistent_table_components.table_path);
+
     Plan plan;
-    plan.generator = FileNamesGenerator(
-        persistent_table_components.table_path, persistent_table_components.table_path, false, compression_method, write_format);
 
     const auto [metadata_version, metadata_file_path, _] = getLatestOrExplicitMetadataFileAndVersion(
         object_storage,
@@ -134,6 +139,17 @@ Plan getPlan(
 
     Poco::JSON::Object::Ptr initial_metadata_object
         = getMetadataJSONObject(metadata_file_path, object_storage, persistent_table_components.metadata_cache, context, log, compression_method, persistent_table_components.table_uuid);
+
+    bool write_full = context->getSettingsRef()[Setting::write_full_path_in_iceberg_metadata];
+    auto compact_metadata_dir = getMetadataDir(
+        persistent_table_components.table_path,
+        persistent_table_components.table_location,
+        write_full);
+    LOG_DEBUG(log, "Compaction: write_full_path={}, table_path={}, table_location={}, metadata_dir={}, storage_path={}",
+        write_full, persistent_table_components.table_path, persistent_table_components.table_location,
+        compact_metadata_dir, compact_storage_path);
+    plan.generator = FileNamesGenerator(
+        compact_metadata_dir, compact_storage_path, false, compression_method, write_format);
 
     if (initial_metadata_object->getValue<Int32>(Iceberg::f_format_version) < 2)
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Compaction is supported only for format_version 2.");
@@ -155,7 +171,9 @@ Plan getPlan(
     std::unordered_map<String, std::shared_ptr<ManifestFilePlan>> manifest_files;
     for (const auto & snapshot : snapshots_info)
     {
-        auto manifest_list = getManifestList(object_storage, persistent_table_components, context, snapshot.manifest_list_path, log);
+        auto resolved_manifest_list_path = getProperFilePathFromMetadataInfo(
+            snapshot.manifest_list_path, persistent_table_components.table_path, persistent_table_components.table_location);
+        auto manifest_list = getManifestList(object_storage, persistent_table_components, context, resolved_manifest_list_path, log);
         for (const auto & manifest_file : manifest_list)
         {
             plan.manifest_list_to_manifest_files[snapshot.manifest_list_path].push_back(manifest_file.manifest_file_path);
@@ -419,8 +437,12 @@ void writeMetadataFiles(
                 *buffer_manifest_entry,
                 Iceberg::FileContentType::DATA);
 
-            manifest_file_sizes[manifest_entry->patched_path.path_in_metadata] += buffer_manifest_entry->count();
+            auto pre_finalize_count = buffer_manifest_entry->count();
             buffer_manifest_entry->finalize();
+            auto post_finalize_count = buffer_manifest_entry->count();
+            LOG_DEBUG(log, "Compaction manifest entry {}: pre_finalize_count={}, post_finalize_count={}",
+                manifest_entry->patched_path.path_in_metadata, pre_finalize_count, post_finalize_count);
+            manifest_file_sizes[manifest_entry->patched_path.path_in_metadata] += post_finalize_count;
         }
     }
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Compaction.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Compaction.cpp
@@ -437,12 +437,14 @@ void writeMetadataFiles(
                 *buffer_manifest_entry,
                 Iceberg::FileContentType::DATA);
 
-            auto pre_finalize_count = buffer_manifest_entry->count();
             buffer_manifest_entry->finalize();
-            auto post_finalize_count = buffer_manifest_entry->count();
-            LOG_DEBUG(log, "Compaction manifest entry {}: pre_finalize_count={}, post_finalize_count={}",
-                manifest_entry->patched_path.path_in_metadata, pre_finalize_count, post_finalize_count);
-            manifest_file_sizes[manifest_entry->patched_path.path_in_metadata] += post_finalize_count;
+            auto manifest_bytes = buffer_manifest_entry->count();
+            if (manifest_bytes == 0)
+            {
+                auto file_metadata = object_storage->getObjectMetadata(manifest_entry->patched_path.path_in_storage, /*with_tags=*/ false);
+                manifest_bytes = file_metadata.size_bytes;
+            }
+            manifest_file_sizes[manifest_entry->patched_path.path_in_metadata] += manifest_bytes;
         }
     }
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/FileNamesGenerator.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/FileNamesGenerator.cpp
@@ -141,9 +141,23 @@ FileNamesGenerator::Result FileNamesGenerator::generatePositionDeleteFile()
 
 String FileNamesGenerator::convertMetadataPathToStoragePath(const String & metadata_path) const
 {
-    if (!metadata_path.starts_with(table_dir))
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Paths in Iceberg must use a consistent format — either /your/path or s3://your/path. Use the write_full_path_in_iceberg_metadata setting to control this behavior {} {}", metadata_path, table_dir);
-    return storage_dir + metadata_path.substr(table_dir.size());
+    if (metadata_path.starts_with(table_dir))
+        return storage_dir + metadata_path.substr(table_dir.size());
+
+    /// The metadata_path may use a full URI (e.g. wasb://container@account/path/...)
+    /// while table_dir is a relative path (e.g. /path/...). This happens when another
+    /// engine (like Spark) wrote the metadata with full URIs. Try to find table_dir
+    /// as a substring in metadata_path and strip everything before it.
+    auto pos = metadata_path.find(table_dir);
+    if (pos != String::npos)
+        return storage_dir + metadata_path.substr(pos + table_dir.size());
+
+    throw Exception(
+        ErrorCodes::BAD_ARGUMENTS,
+        "Paths in Iceberg must use a consistent format — either /your/path or s3://your/path. "
+        "Use the write_full_path_in_iceberg_metadata setting to control this behavior {} {}",
+        metadata_path,
+        table_dir);
 }
 
 }

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/FileNamesGenerator.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/FileNamesGenerator.h
@@ -63,6 +63,41 @@ private:
     Int32 initial_version = 0;
 };
 
+/// Returns {config_path, storage_path} for FileNamesGenerator construction.
+/// config_path: path for Iceberg metadata (starts with '/').
+/// storage_path: path for actual object storage operations (no leading '/').
+inline std::pair<String, String> getConfigAndStoragePaths(const String & table_path)
+{
+    auto config_path = table_path;
+    if (config_path.empty() || config_path.back() != '/')
+        config_path += "/";
+    if (!config_path.starts_with('/'))
+        config_path = '/' + config_path;
+
+    auto storage_path = table_path;
+    if (storage_path.empty() || storage_path.back() != '/')
+        storage_path += "/";
+
+    return {config_path, storage_path};
+}
+
+/// Returns the directory prefix for paths written into Iceberg metadata files.
+/// When write_full_path is true, uses table_location (e.g. wasb://container@host/path/)
+/// so that other engines like Spark can resolve the paths.
+/// Otherwise, uses config_path (e.g. /path/) for local/relative paths.
+inline String getMetadataDir(const String & table_path, const String & table_location, bool write_full_path)
+{
+    if (write_full_path)
+    {
+        auto bucket = table_location;
+        if (bucket.empty() || bucket.back() != '/')
+            bucket += "/";
+        return bucket;
+    }
+    auto [config_path, _] = getConfigAndStoragePaths(table_path);
+    return config_path;
+}
+
 #endif
 
 }

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
@@ -696,7 +696,7 @@ void IcebergMetadata::createInitial(
     if (configuration_ptr->getDataLakeSettings()[DataLakeStorageSetting::iceberg_use_version_hint].value)
     {
         auto filename_version_hint = configuration_ptr->getRawPath().path + "metadata/version-hint.text";
-        writeMessageToFile(filename, filename_version_hint, object_storage, local_context, "*", "");
+        writeMessageToFile("1", filename_version_hint, object_storage, local_context, "*", "");
     }
 
     if (catalog)

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
@@ -664,6 +664,8 @@ void IcebergMetadata::createInitial(
     }
 
     String location_path = configuration_ptr->getRawPath().path;
+    if (location_path.find("://") == String::npos && !location_path.starts_with('/'))
+        location_path = "/" + location_path;
     if (local_context->getSettingsRef()[Setting::write_full_path_in_iceberg_metadata].value)
         location_path
             = configuration_ptr->getTypeName() + "://" + configuration_ptr->getNamespace() + "/" + configuration_ptr->getRawPath().path;

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
@@ -654,34 +654,14 @@ IcebergStorageSink::IcebergStorageSink(
         compression_method,
         persistent_table_components.table_uuid);
     metadata_compression_method = compression_method;
-    /// config_path is used for paths written into Iceberg metadata (table_dir).
-    /// It follows the Iceberg convention of starting with '/'.
-    auto config_path = persistent_table_components.table_path;
-    if (config_path.empty() || config_path.back() != '/')
-        config_path += "/";
-    if (!config_path.starts_with('/'))
-        config_path = '/' + config_path;
+    auto [_, storage_path] = getConfigAndStoragePaths(persistent_table_components.table_path);
+    auto metadata_dir = getMetadataDir(
+        persistent_table_components.table_path,
+        persistent_table_components.table_location,
+        context_->getSettingsRef()[Setting::write_full_path_in_iceberg_metadata]);
 
-    /// storage_path is used for actual object storage operations.
-    /// It should match the blob path convention of the storage backend
-    /// (e.g. no leading '/' for Azure/S3).
-    auto storage_path = persistent_table_components.table_path;
-    if (storage_path.empty() || storage_path.back() != '/')
-        storage_path += "/";
-
-    if (!context_->getSettingsRef()[Setting::write_full_path_in_iceberg_metadata])
-    {
-        filename_generator = FileNamesGenerator(
-            config_path, storage_path, (catalog != nullptr && catalog->isTransactional()), metadata_compression_method, write_format);
-    }
-    else
-    {
-        auto bucket = metadata->getValue<String>(Iceberg::f_location);
-        if (bucket.empty() || bucket.back() != '/')
-            bucket += "/";
-        filename_generator = FileNamesGenerator(
-            bucket, storage_path, (catalog != nullptr && catalog->isTransactional()), metadata_compression_method, write_format);
-    }
+    filename_generator = FileNamesGenerator(
+        metadata_dir, storage_path, (catalog != nullptr && catalog->isTransactional()), metadata_compression_method, write_format);
 
     filename_generator.setVersion(last_version + 1);
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
@@ -437,7 +437,7 @@ void generateManifestList(
     ContextPtr context,
     const Strings & manifest_entry_names,
     Poco::JSON::Object::Ptr new_snapshot,
-    Int64 manifest_length,
+    const std::vector<Int64> & manifest_entry_sizes,
     WriteBuffer & buf,
     Iceberg::FileContentType content_type,
     bool use_previous_snapshots)
@@ -456,13 +456,13 @@ void generateManifestList(
     auto adapter = std::make_unique<OutputStreamWriteBufferAdapter>(buf);
     avro::DataFileWriter<avro::GenericDatum> writer(std::move(adapter), schema);
 
-    for (const auto & manifest_entry_name : manifest_entry_names)
+    for (size_t entry_idx = 0; entry_idx < manifest_entry_names.size(); ++entry_idx)
     {
         avro::GenericDatum entry_datum(schema.root());
         avro::GenericRecord & entry = entry_datum.value<avro::GenericRecord>();
 
-        entry.field(Iceberg::f_manifest_path) = manifest_entry_name;
-        entry.field(Iceberg::f_manifest_length) = manifest_length;
+        entry.field(Iceberg::f_manifest_path) = manifest_entry_names[entry_idx];
+        entry.field(Iceberg::f_manifest_length) = manifest_entry_sizes[entry_idx];
         entry.field(Iceberg::f_partition_spec_id) = metadata->getValue<Int64>(Iceberg::f_default_spec_id);
         if (version > 1)
         {
@@ -654,16 +654,25 @@ IcebergStorageSink::IcebergStorageSink(
         compression_method,
         persistent_table_components.table_uuid);
     metadata_compression_method = compression_method;
+    /// config_path is used for paths written into Iceberg metadata (table_dir).
+    /// It follows the Iceberg convention of starting with '/'.
     auto config_path = persistent_table_components.table_path;
     if (config_path.empty() || config_path.back() != '/')
         config_path += "/";
     if (!config_path.starts_with('/'))
         config_path = '/' + config_path;
 
+    /// storage_path is used for actual object storage operations.
+    /// It should match the blob path convention of the storage backend
+    /// (e.g. no leading '/' for Azure/S3).
+    auto storage_path = persistent_table_components.table_path;
+    if (storage_path.empty() || storage_path.back() != '/')
+        storage_path += "/";
+
     if (!context_->getSettingsRef()[Setting::write_full_path_in_iceberg_metadata])
     {
         filename_generator = FileNamesGenerator(
-            config_path, config_path, (catalog != nullptr && catalog->isTransactional()), metadata_compression_method, write_format);
+            config_path, storage_path, (catalog != nullptr && catalog->isTransactional()), metadata_compression_method, write_format);
     }
     else
     {
@@ -671,7 +680,7 @@ IcebergStorageSink::IcebergStorageSink(
         if (bucket.empty() || bucket.back() != '/')
             bucket += "/";
         filename_generator = FileNamesGenerator(
-            bucket, config_path, (catalog != nullptr && catalog->isTransactional()), metadata_compression_method, write_format);
+            bucket, storage_path, (catalog != nullptr && catalog->isTransactional()), metadata_compression_method, write_format);
     }
 
     filename_generator.setVersion(last_version + 1);
@@ -879,7 +888,7 @@ bool IcebergStorageSink::initializeMetadata()
 
     Strings manifest_entries_in_storage;
     Strings manifest_entries;
-    Int64 manifest_lengths = 0;
+    std::vector<Int64> manifest_entry_sizes;
 
     auto cleanup = [&] (bool retry_because_of_metadata_conflict)
     {
@@ -974,7 +983,9 @@ bool IcebergStorageSink::initializeMetadata()
                     *buffer_manifest_entry,
                     Iceberg::FileContentType::DATA);
                 buffer_manifest_entry->finalize();
-                manifest_lengths += buffer_manifest_entry->count();
+                auto manifest_storage_path = manifest_entries_in_storage.back();
+                auto manifest_metadata = object_storage->getObjectMetadata(manifest_storage_path, /*with_tags=*/ false);
+                manifest_entry_sizes.push_back(manifest_metadata.size_bytes);
             }
             catch (...)
             {
@@ -989,7 +1000,7 @@ bool IcebergStorageSink::initializeMetadata()
             try
             {
                 generateManifestList(
-                    filename_generator, metadata, object_storage, context, manifest_entries, new_snapshot, manifest_lengths, *buffer_manifest_list, Iceberg::FileContentType::DATA);
+                    filename_generator, metadata, object_storage, context, manifest_entries, new_snapshot, manifest_entry_sizes, *buffer_manifest_list, Iceberg::FileContentType::DATA);
                 buffer_manifest_list->finalize();
             }
             catch (...)

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.h
@@ -67,7 +67,7 @@ void generateManifestList(
     ContextPtr context,
     const Strings & manifest_entry_names,
     Poco::JSON::Object::Ptr new_snapshot,
-    Int64 manifest_length,
+    const std::vector<Int64> & manifest_entry_sizes,
     WriteBuffer & buf,
     Iceberg::FileContentType content_type,
     bool use_previous_snapshots = true);

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/MultipleFileWriter.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/MultipleFileWriter.cpp
@@ -41,7 +41,8 @@ void MultipleFileWriter::startNewFile()
     current_file_num_bytes = 0;
     auto filename = filename_generator.generateDataFileName();
 
-    data_file_names.push_back(filename.path_in_storage);
+    data_file_names.push_back(filename.path_in_metadata);
+    data_file_storage_paths.push_back(filename.path_in_storage);
     buffer = object_storage->writeObject(
         StoredObject(filename.path_in_storage), WriteMode::Rewrite, std::nullopt, DBMS_DEFAULT_BUFFER_SIZE, context->getWriteSettings());
 
@@ -78,11 +79,11 @@ void MultipleFileWriter::finalize()
     {
         total_bytes += buffer_bytes;
     }
-    else if (!data_file_names.empty())
+    else if (!data_file_storage_paths.empty())
     {
         /// Some storage backends (e.g. Azure) don't track bytes in the write buffer.
         /// Fall back to querying the actual object size.
-        auto metadata = object_storage->getObjectMetadata(data_file_names.back(), /*with_tags=*/ false);
+        auto metadata = object_storage->getObjectMetadata(data_file_storage_paths.back(), /*with_tags=*/ false);
         total_bytes += metadata.size_bytes;
     }
 }
@@ -103,7 +104,7 @@ void MultipleFileWriter::cancel()
 
 void MultipleFileWriter::clearAllDataFiles() const
 {
-    for (const auto & data_filename : data_file_names)
+    for (const auto & data_filename : data_file_storage_paths)
         object_storage->removeObjectIfExists(StoredObject(data_filename));
 }
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/MultipleFileWriter.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/MultipleFileWriter.cpp
@@ -73,7 +73,18 @@ void MultipleFileWriter::finalize()
     output_format->flush();
     output_format->finalize();
     buffer->finalize();
-    total_bytes += buffer->count();
+    auto buffer_bytes = buffer->count();
+    if (buffer_bytes > 0)
+    {
+        total_bytes += buffer_bytes;
+    }
+    else if (!data_file_names.empty())
+    {
+        /// Some storage backends (e.g. Azure) don't track bytes in the write buffer.
+        /// Fall back to querying the actual object size.
+        auto metadata = object_storage->getObjectMetadata(data_file_names.back(), /*with_tags=*/ false);
+        total_bytes += metadata.size_bytes;
+    }
 }
 
 void MultipleFileWriter::release()

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/MultipleFileWriter.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/MultipleFileWriter.h
@@ -48,7 +48,10 @@ private:
     DataFileStatistics stats;
     std::optional<size_t> current_file_num_rows = std::nullopt;
     std::optional<size_t> current_file_num_bytes = std::nullopt;
+    /// Metadata paths (for writing into Iceberg manifests).
     std::vector<String> data_file_names;
+    /// Storage paths (for actual object storage operations and cleanup).
+    std::vector<String> data_file_storage_paths;
     std::unique_ptr<WriteBufferFromFileBase> buffer;
     OutputFormatPtr output_format;
     FileNamesGenerator & filename_generator;

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Mutations.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Mutations.cpp
@@ -1,6 +1,7 @@
 #include <Columns/ColumnNullable.h>
 #include <Columns/ColumnString.h>
 #include <Core/ColumnsWithTypeAndName.h>
+#include <Core/Settings.h>
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <Databases/DataLake/Common.h>
@@ -35,6 +36,11 @@ namespace DB::ErrorCodes
 extern const int BAD_ARGUMENTS;
 extern const int LOGICAL_ERROR;
 extern const int LIMIT_EXCEEDED;
+}
+
+namespace DB::Setting
+{
+extern const SettingsBool write_full_path_in_iceberg_metadata;
 }
 
 namespace DB::DataLakeStorageSetting
@@ -549,14 +555,16 @@ void mutate(
     const String & blob_storage_type_name,
     const String & blob_storage_namespace_name)
 {
-    auto common_path = persistent_table_components.table_path;
-    if (!common_path.starts_with('/'))
-        common_path = "/" + common_path;
+    auto [_, storage_path] = getConfigAndStoragePaths(persistent_table_components.table_path);
+    auto metadata_dir = getMetadataDir(
+        persistent_table_components.table_path,
+        persistent_table_components.table_location,
+        context->getSettingsRef()[Setting::write_full_path_in_iceberg_metadata]);
 
     int max_retries = MAX_TRANSACTION_RETRIES;
     while (--max_retries > 0)
     {
-        FileNamesGenerator filename_generator(common_path, common_path, false, CompressionMethod::None, write_format);
+        FileNamesGenerator filename_generator(metadata_dir, storage_path, false, CompressionMethod::None, write_format);
         auto log = getLogger("IcebergMutations");
         auto [last_version, metadata_path, compression_method] = getLatestOrExplicitMetadataFileAndVersion(
             object_storage,
@@ -684,11 +692,16 @@ void alter(
     if (params.size() != 1)
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Params with size 1 is not supported");
 
+    auto [alter_unused_, alter_storage_path] = getConfigAndStoragePaths(persistent_table_components.table_path);
+    auto alter_metadata_dir = getMetadataDir(
+        persistent_table_components.table_path,
+        persistent_table_components.table_location,
+        context->getSettingsRef()[Setting::write_full_path_in_iceberg_metadata]);
+
     size_t i = 0;
     while (i++ < MAX_TRANSACTION_RETRIES)
     {
-        FileNamesGenerator filename_generator(
-            persistent_table_components.table_path, persistent_table_components.table_path, false, CompressionMethod::None, write_format);
+        FileNamesGenerator filename_generator(alter_metadata_dir, alter_storage_path, false, CompressionMethod::None, write_format);
         auto log = getLogger("IcebergMutations");
         auto [last_version, metadata_path, compression_method] = getLatestOrExplicitMetadataFileAndVersion(
             object_storage,
@@ -1169,14 +1182,16 @@ ExpireSnapshotsResult expireSnapshots(
     const String & blob_storage_namespace_name,
     const String & table_name)
 {
-    auto common_path = persistent_table_components.table_path;
-    if (!common_path.starts_with('/'))
-        common_path = "/" + common_path;
+    auto [_, storage_path] = getConfigAndStoragePaths(persistent_table_components.table_path);
+    auto metadata_dir = getMetadataDir(
+        persistent_table_components.table_path,
+        persistent_table_components.table_location,
+        context->getSettingsRef()[Setting::write_full_path_in_iceberg_metadata]);
 
     int max_retries = MAX_TRANSACTION_RETRIES;
     while (--max_retries > 0)
     {
-        FileNamesGenerator filename_generator(common_path, common_path, false, CompressionMethod::None, write_format);
+        FileNamesGenerator filename_generator(metadata_dir, storage_path, false, CompressionMethod::None, write_format);
         auto log = getLogger("IcebergExpireSnapshots");
         auto [last_version, metadata_path, compression_method] = getLatestOrExplicitMetadataFileAndVersion(
             object_storage,

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Mutations.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Mutations.cpp
@@ -225,13 +225,19 @@ static std::optional<WriteDataFilesResult> writeDataFiles(
                     Field cur_value;
                     col_data_filename.column->get(i, cur_value);
 
-                    String path_without_namespace;
-                    if (cur_value.safeGet<String>().starts_with(blob_storage_namespace_name))
-                        path_without_namespace = cur_value.safeGet<String>().substr(blob_storage_namespace_name.size());
-
-                    if (!path_without_namespace.starts_with('/'))
-                        path_without_namespace = "/" + path_without_namespace;
-                    col_data_filename_without_namespaces->insert(path_without_namespace);
+                    /// Transform storage path to metadata path format.
+                    /// The _path column contains the storage path (e.g. iceberg_data/default/TABLE/data/xxx.parquet).
+                    /// For position deletes, we need the metadata path format that matches
+                    /// what's stored in the manifest for the data file.
+                    auto raw_path = cur_value.safeGet<String>();
+                    if (raw_path.starts_with(blob_storage_namespace_name))
+                        raw_path = raw_path.substr(blob_storage_namespace_name.size());
+                    /// Strip the storage_path prefix to get the relative suffix
+                    if (raw_path.starts_with(storage_path))
+                        raw_path = raw_path.substr(storage_path.size());
+                    else if (raw_path.starts_with("/" + storage_path))
+                        raw_path = raw_path.substr(storage_path.size() + 1);
+                    col_data_filename_without_namespaces->insert(metadata_dir + raw_path);
                 }
                 col_data_filename.column = std::move(col_data_filename_without_namespaces);
                 Columns chunk_pos_delete;
@@ -254,7 +260,10 @@ static std::optional<WriteDataFilesResult> writeDataFiles(
             delete_data_writers[partition_key]->flush();
             delete_data_writers[partition_key]->finalize();
             delete_data_write_buffers[partition_key]->finalize();
-            delete_data_result[partition_key].total_bytes = static_cast<Int32>(delete_data_write_buffers[partition_key]->count());
+            auto delete_bytes = delete_data_write_buffers[partition_key]->count();
+            if (delete_bytes == 0)
+                delete_bytes = object_storage->getObjectMetadata(delete_data_result[partition_key].path.path_in_storage, /*with_tags=*/ false).size_bytes;
+            delete_data_result[partition_key].total_bytes = static_cast<Int32>(delete_bytes);
         }
     }
 
@@ -312,7 +321,10 @@ static std::optional<WriteDataFilesResult> writeDataFiles(
             update_data_writers[partition_key]->flush();
             update_data_writers[partition_key]->finalize();
             update_data_write_buffers[partition_key]->finalize();
-            update_data_result[partition_key].total_bytes = static_cast<Int32>(update_data_write_buffers[partition_key]->count());
+            auto update_bytes = update_data_write_buffers[partition_key]->count();
+            if (update_bytes == 0)
+                update_bytes = object_storage->getObjectMetadata(update_data_result[partition_key].path.path_in_storage, /*with_tags=*/ false).size_bytes;
+            update_data_result[partition_key].total_bytes = static_cast<Int32>(update_bytes);
         }
     }
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Mutations.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Mutations.cpp
@@ -393,7 +393,7 @@ static bool writeMetadataFiles(
     }
     auto manifest_entries_in_storage = std::make_shared<Strings>();
     Strings manifest_entries;
-    Int32 manifest_lengths = 0;
+    std::vector<Int64> manifest_entry_sizes;
 
     auto cleanup = [object_storage, delete_filenames, manifest_entries_in_storage, storage_manifest_list_name, storage_metadata_name]()
     {
@@ -444,7 +444,11 @@ static bool writeMetadataFiles(
                     *buffer_manifest_entry,
                     content_type);
                 buffer_manifest_entry->finalize();
-                manifest_lengths += buffer_manifest_entry->count();
+                {
+                    auto manifest_storage_path = manifest_entries_in_storage->back();
+                    auto manifest_metadata = object_storage->getObjectMetadata(manifest_storage_path, /*with_tags=*/ false);
+                    manifest_entry_sizes.push_back(manifest_metadata.size_bytes);
+                }
             }
             catch (...)
             {
@@ -470,7 +474,7 @@ static bool writeMetadataFiles(
                     context,
                     manifest_entries,
                     new_snapshot,
-                    manifest_lengths,
+                    manifest_entry_sizes,
                     *buffer_manifest_list,
                     content_type);
                 buffer_manifest_list->finalize();

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
@@ -207,6 +207,22 @@ bool writeMetadataFileAndVersionHint(
         if (version_hint_content.starts_with('/'))
             version_hint_content = version_hint_content.substr(1);
 
+        /// Normalize version-hint content: it may be just a number (Spark format)
+        /// or a full metadata file path (ClickHouse format). Ensure it's a valid
+        /// metadata filename before parsing.
+        auto normalizeVersionHint = [](std::string & hint)
+        {
+            if (hint.empty())
+                return;
+            if (!hint.ends_with(".metadata.json"))
+            {
+                if (std::all_of(hint.begin(), hint.end(), isdigit))
+                    hint = "v" + hint + ".metadata.json";
+                else
+                    hint = hint + ".metadata.json";
+            }
+        };
+
         size_t i = 0;
         while (i < MAX_TRANSACTION_RETRIES)
         {
@@ -222,13 +238,19 @@ bool writeMetadataFileAndVersionHint(
                 write_if_none_match.clear();
             }
 
-            auto [old_version, _1, _2] = getMetadataFileAndVersion(version_hint_value);
-            auto [new_version, _3, _4] = getMetadataFileAndVersion(version_hint_content);
+            normalizeVersionHint(version_hint_value);
+            normalizeVersionHint(version_hint_content);
+
+            Int32 old_version = 0;
+            if (!version_hint_value.empty())
+                old_version = getMetadataFileAndVersion(version_hint_value).version;
+            auto new_version = getMetadataFileAndVersion(version_hint_content).version;
             if (old_version < new_version)
             {
                 try
                 {
-                    Iceberg::writeMessageToFile(version_hint_content, version_hint_path, object_storage, context, write_if_none_match, /* write-if-match */ etag);
+                    /// Write just the version number for Spark/spec compatibility.
+                    Iceberg::writeMessageToFile(std::to_string(new_version), version_hint_path, object_storage, context, write_if_none_match, /* write-if-match */ etag);
                     break;
                 }
                 catch (...)

--- a/tests/integration/test_storage_iceberg_azure/configs/config.d/cluster.xml
+++ b/tests/integration/test_storage_iceberg_azure/configs/config.d/cluster.xml
@@ -1,0 +1,19 @@
+<clickhouse>
+    <remote_servers>
+        <cluster_simple>
+            <shard>
+                <replica>
+                    <host>node1</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </cluster_simple>
+    </remote_servers>
+
+    <!-- increase for concurrency test -->
+    <background_schedule_pool_size>150</background_schedule_pool_size>
+    <background_pool_size>50</background_pool_size>
+    <max_thread_pool_size>1800</max_thread_pool_size>
+    <thread_pool_queue_size>1800</thread_pool_queue_size>
+
+</clickhouse>

--- a/tests/integration/test_storage_iceberg_azure/configs/config.d/named_collections.xml
+++ b/tests/integration/test_storage_iceberg_azure/configs/config.d/named_collections.xml
@@ -1,0 +1,8 @@
+<clickhouse>
+  <named_collections>
+    <azure>
+        <account_name>devstoreaccount1</account_name>
+        <account_key>Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==</account_key>
+    </azure>
+  </named_collections>
+</clickhouse>

--- a/tests/integration/test_storage_iceberg_azure/configs/config.d/query_log.xml
+++ b/tests/integration/test_storage_iceberg_azure/configs/config.d/query_log.xml
@@ -1,0 +1,6 @@
+<clickhouse>
+    <query_log>
+      <database>system</database>
+      <table>query_log</table>
+    </query_log>
+</clickhouse>

--- a/tests/integration/test_storage_iceberg_azure/configs/users.d/users.xml
+++ b/tests/integration/test_storage_iceberg_azure/configs/users.d/users.xml
@@ -1,0 +1,9 @@
+<clickhouse>
+    <users>
+        <default>
+            <password></password>
+            <profile>default</profile>
+            <named_collection_control>1</named_collection_control>
+        </default>
+    </users>
+</clickhouse>

--- a/tests/integration/test_storage_iceberg_azure/conftest.py
+++ b/tests/integration/test_storage_iceberg_azure/conftest.py
@@ -1,0 +1,96 @@
+import pytest
+import logging
+import pyspark
+import os
+import os.path as p
+
+from helpers.cluster import ClickHouseCluster
+from helpers.spark_tools import ResilientSparkSession, write_spark_log_config
+
+
+AZURE_ACCOUNT_NAME = "devstoreaccount1"
+AZURE_ACCOUNT_KEY = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
+AZURE_CONTAINER = "testcontainer"
+
+
+def get_spark(log_dir=None):
+    """
+    Configure Spark to write Iceberg tables to Azurite via WASB (HTTP).
+
+    Key insight: hadoop-azure's emulator mode config must use the FQDN
+    (devstoreaccount1.blob.core.windows.net) because it does an exact match
+    with the account name extracted from the WASB URI.
+    """
+    hadoop_version = "3.3.4"
+
+    builder = (
+        pyspark.sql.SparkSession.builder
+            .appName("IcebergAzureConcurrent")
+            .config("spark.jars.repositories", "https://repo1.maven.org/maven2")
+            .config("spark.jars.packages",
+                    f"org.apache.hadoop:hadoop-azure:{hadoop_version},"
+                    f"com.microsoft.azure:azure-storage:8.6.6")
+            .config("spark.sql.extensions",
+                    "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions")
+            .config("spark.sql.catalog.spark_catalog",
+                    "org.apache.iceberg.spark.SparkSessionCatalog")
+            .config("spark.sql.catalog.spark_catalog.type", "hadoop")
+            .config("spark.sql.catalog.spark_catalog.warehouse",
+                    f"wasb://{AZURE_CONTAINER}@{AZURE_ACCOUNT_NAME}.blob.core.windows.net"
+                    f"/iceberg_data")
+            # Enable emulator mode with FQDN — this makes hadoop-azure
+            # connect to http://127.0.0.1:10000 using dev storage credentials.
+            .config("spark.hadoop.fs.azure.storage.emulator.account.name",
+                    f"{AZURE_ACCOUNT_NAME}.blob.core.windows.net")
+            .master("local")
+    )
+
+    if log_dir:
+        props_path = write_spark_log_config(log_dir)
+        builder = builder.config(
+            "spark.driver.extraJavaOptions",
+            f"-Dlog4j2.configurationFile=file:{props_path}",
+        )
+
+    return builder.getOrCreate()
+
+
+@pytest.fixture(scope="package")
+def started_cluster_iceberg():
+    try:
+        # Force Azurite to port 10000 — the emulator mode hardcodes this port.
+        cluster = ClickHouseCluster(
+            __file__, with_spark=True, azurite_default_port=10000
+        )
+        cluster.add_instance(
+            "node1",
+            main_configs=[
+                "configs/config.d/query_log.xml",
+                "configs/config.d/cluster.xml",
+                "configs/config.d/named_collections.xml",
+            ],
+            user_configs=["configs/users.d/users.xml"],
+            with_azurite=True,
+            stay_alive=True,
+            mem_limit="15g",
+        )
+
+        logging.info("Starting cluster...")
+        cluster.start()
+
+        # Create test container
+        container_client = cluster.blob_service_client.get_container_client(
+            AZURE_CONTAINER
+        )
+        if not container_client.exists():
+            container_client.create_container()
+        cluster.azure_container_name = AZURE_CONTAINER
+
+        cluster.spark_session = ResilientSparkSession(
+            lambda: get_spark(cluster.instances_dir)
+        )
+
+        yield cluster
+
+    finally:
+        cluster.shutdown()

--- a/tests/integration/test_storage_iceberg_azure/test_spark_interop.py
+++ b/tests/integration/test_storage_iceberg_azure/test_spark_interop.py
@@ -172,3 +172,73 @@ def test_ch_write_spark_read_simple(started_cluster_iceberg):
     spark_values = sorted([row.number for row in df])
     assert 42 in spark_values
     assert 123 in spark_values
+
+
+def test_ch_write_delete_optimize(started_cluster_iceberg):
+    """Verify CH write, delete, and optimize (compaction) produce correct
+    manifest sizes so Spark can read the result."""
+    instance = started_cluster_iceberg.instances["node1"]
+    spark = started_cluster_iceberg.spark_session
+
+    TABLE_NAME = "test_ch_compaction_" + get_uuid_str()
+    azurite_url = started_cluster_iceberg.env_variables["AZURITE_STORAGE_ACCOUNT_URL"]
+    blob_path = f"iceberg_data/default/{TABLE_NAME}/"
+
+    # Spark creates the table
+    spark.sql(
+        f"""
+            CREATE TABLE {TABLE_NAME} (
+                number INT
+            )
+            USING iceberg
+            OPTIONS('format-version'='2');
+        """
+    )
+
+    # CH table pointing to the same Azurite location
+    instance.query(
+        f"""
+        CREATE TABLE {TABLE_NAME}
+        ENGINE=IcebergAzure(azure,
+            container = '{AZURE_CONTAINER}',
+            storage_account_url = '{azurite_url}',
+            blob_path = '{blob_path}')
+        SETTINGS iceberg_use_version_hint = 1
+        """
+    )
+
+    insert_settings = {
+        "allow_insert_into_iceberg": 1,
+        "write_full_path_in_iceberg_metadata": 1,
+    }
+
+    instance.query(
+        f"INSERT INTO {TABLE_NAME} VALUES (1), (2), (3), (4), (5)",
+        settings=insert_settings,
+    )
+    assert int(instance.query(f"SELECT count() FROM {TABLE_NAME}")) == 5
+
+    instance.query(
+        f"DELETE FROM {TABLE_NAME} WHERE number = 3",
+        settings=insert_settings,
+    )
+    assert int(instance.query(f"SELECT count() FROM {TABLE_NAME}")) == 4
+
+    instance.query(
+        f"OPTIMIZE TABLE {TABLE_NAME}",
+        settings={
+            "allow_insert_into_iceberg": 1,
+            "write_full_path_in_iceberg_metadata": 1,
+            "allow_experimental_iceberg_compaction": 1,
+        },
+    )
+    assert int(instance.query(f"SELECT count() FROM {TABLE_NAME}")) == 4
+
+    # Spark reads the compacted result
+    started_cluster_iceberg.spark_session._restart()
+    spark = started_cluster_iceberg.spark_session
+
+    df = spark.sql(f"SELECT * FROM {TABLE_NAME}").collect()
+    assert len(df) == 4, f"Spark expected 4 rows, got {len(df)}"
+    spark_values = sorted([row.number for row in df])
+    assert spark_values == [1, 2, 4, 5], f"Unexpected values: {spark_values}"

--- a/tests/integration/test_storage_iceberg_azure/test_spark_interop.py
+++ b/tests/integration/test_storage_iceberg_azure/test_spark_interop.py
@@ -1,0 +1,174 @@
+import logging
+
+from helpers.iceberg_utils import get_uuid_str
+
+AZURE_CONTAINER = "testcontainer"
+
+
+def test_spark_write_and_read(started_cluster_iceberg):
+    """Verify Spark can write to and read from Azurite via WASB emulator mode."""
+    spark = started_cluster_iceberg.spark_session
+
+    TABLE_NAME = "test_spark_roundtrip_" + get_uuid_str()
+
+    # Write
+    spark.sql(
+        f"""
+            CREATE TABLE {TABLE_NAME} (
+                number INT
+            )
+            USING iceberg
+            OPTIONS('format-version'='2');
+        """
+    )
+
+    spark.sql(
+        f"""
+            INSERT INTO {TABLE_NAME}
+            SELECT id as number FROM range(100)
+        """
+    )
+
+    # Read back
+    df = spark.sql(f"SELECT count(*) as cnt FROM {TABLE_NAME}").collect()
+    count = df[0].cnt
+    logging.info(f"Spark read back {count} rows")
+    assert count == 100, f"Expected 100 rows, got {count}"
+
+    # List blobs to see what paths Spark actually wrote
+    blob_client = started_cluster_iceberg.blob_service_client
+    container_client = blob_client.get_container_client(AZURE_CONTAINER)
+    blobs = list(container_client.list_blobs())
+    print(f"Blobs in container ({len(blobs)}):")
+    for blob in blobs[:20]:
+        print(f"  {blob.name}")
+
+    assert len(blobs) > 0, "No blobs written to Azurite!"
+
+    # Now try ClickHouse reading the same data
+    instance = started_cluster_iceberg.instances["node1"]
+    azurite_url = started_cluster_iceberg.env_variables["AZURITE_STORAGE_ACCOUNT_URL"]
+
+    # Try both with and without leading slash
+    blob_prefix = blobs[0].name.split("/default/")[0] if "/default/" in blobs[0].name else "iceberg_data"
+    table_path = f"{blob_prefix}/default/{TABLE_NAME}/"
+    print(f"Using blob_path: {table_path}")
+
+    instance.query(
+        f"""
+        CREATE TABLE {TABLE_NAME}
+        ENGINE=IcebergAzure(azure,
+            container = '{AZURE_CONTAINER}',
+            storage_account_url = '{azurite_url}',
+            blob_path = '{table_path}')
+        """
+    )
+
+    rows = int(instance.query(f"SELECT count() FROM {TABLE_NAME}"))
+    assert rows == 100, f"Expected 100 rows, got {rows}"
+
+
+def test_spark_write_ch_read_append(started_cluster_iceberg):
+    """Spark writes, CH reads, Spark appends, CH reads updated data."""
+    instance = started_cluster_iceberg.instances["node1"]
+    spark = started_cluster_iceberg.spark_session
+
+    TABLE_NAME = "test_spark_append_" + get_uuid_str()
+    azurite_url = started_cluster_iceberg.env_variables["AZURITE_STORAGE_ACCOUNT_URL"]
+    blob_path = f"iceberg_data/default/{TABLE_NAME}/"
+
+    # Spark creates the table and inserts initial data
+    spark.sql(
+        f"""
+            CREATE TABLE {TABLE_NAME} (
+                number INT
+            )
+            USING iceberg
+            OPTIONS('format-version'='2');
+        """
+    )
+    spark.sql(f"INSERT INTO {TABLE_NAME} SELECT id as number FROM range(100)")
+
+    # Create ClickHouse table pointing to the same Azurite location
+    instance.query(
+        f"""
+        CREATE TABLE {TABLE_NAME}
+        ENGINE=IcebergAzure(azure,
+            container = '{AZURE_CONTAINER}',
+            storage_account_url = '{azurite_url}',
+            blob_path = '{blob_path}')
+        """
+    )
+
+    # CH reads Spark's data
+    rows = int(instance.query(f"SELECT count() FROM {TABLE_NAME}"))
+    assert rows == 100, f"Expected 100 rows, got {rows}"
+
+    result = instance.query(f"SELECT sum(number) FROM {TABLE_NAME}")
+    assert int(result) == 4950, f"Expected sum 4950, got {result.strip()}"
+
+    # Spark appends more data
+    spark.sql(f"INSERT INTO {TABLE_NAME} SELECT id + 100 as number FROM range(50)")
+
+    # CH reads the updated data
+    rows = int(instance.query(f"SELECT count() FROM {TABLE_NAME}"))
+    assert rows == 150, f"Expected 150 rows after append, got {rows}"
+
+
+def test_ch_write_spark_read_simple(started_cluster_iceberg):
+    """Spark creates a table, CH appends data, Spark reads all data back."""
+    instance = started_cluster_iceberg.instances["node1"]
+    spark = started_cluster_iceberg.spark_session
+
+    TABLE_NAME = "test_ch_write_simple_" + get_uuid_str()
+    azurite_url = started_cluster_iceberg.env_variables["AZURITE_STORAGE_ACCOUNT_URL"]
+    blob_path = f"iceberg_data/default/{TABLE_NAME}/"
+
+    # Spark creates the table and inserts initial data
+    spark.sql(
+        f"""
+            CREATE TABLE {TABLE_NAME} (
+                number INT
+            )
+            USING iceberg
+            OPTIONS('format-version'='2');
+        """
+    )
+    spark.sql(f"INSERT INTO {TABLE_NAME} SELECT id as number FROM range(10)")
+
+    # ClickHouse table pointing to the same Azurite location
+    instance.query(
+        f"""
+        CREATE TABLE {TABLE_NAME}
+        ENGINE=IcebergAzure(azure,
+            container = '{AZURE_CONTAINER}',
+            storage_account_url = '{azurite_url}',
+            blob_path = '{blob_path}')
+        SETTINGS iceberg_use_version_hint = 1
+        """
+    )
+
+    # CH reads Spark's data
+    assert int(instance.query(f"SELECT count() FROM {TABLE_NAME}")) == 10
+
+    # CH writes more data
+    insert_settings = {
+        "allow_insert_into_iceberg": 1,
+        "write_full_path_in_iceberg_metadata": 1,
+    }
+    instance.query(f"INSERT INTO {TABLE_NAME} VALUES (42)", settings=insert_settings)
+    instance.query(f"INSERT INTO {TABLE_NAME} VALUES (123)", settings=insert_settings)
+
+    # CH reads its own writes
+    assert int(instance.query(f"SELECT count() FROM {TABLE_NAME}")) == 12
+    assert int(instance.query(f"SELECT sum(number) FROM {TABLE_NAME}")) == sum(range(10)) + 42 + 123
+
+    # Spark reads all data (restart session to clear HadoopCatalog metadata cache)
+    started_cluster_iceberg.spark_session._restart()
+    spark = started_cluster_iceberg.spark_session
+
+    df = spark.sql(f"SELECT * FROM {TABLE_NAME}").collect()
+    assert len(df) == 12, f"Spark expected 12 rows, got {len(df)}"
+    spark_values = sorted([row.number for row in df])
+    assert 42 in spark_values
+    assert 123 in spark_values

--- a/tests/integration/test_storage_iceberg_azure/test_spark_interop.py
+++ b/tests/integration/test_storage_iceberg_azure/test_spark_interop.py
@@ -222,7 +222,30 @@ def test_ch_write_delete_optimize(started_cluster_iceberg):
         f"DELETE FROM {TABLE_NAME} WHERE number = 3",
         settings=insert_settings,
     )
+
+    # CH reads after DELETE with metadata logging
+    query_id_after_delete = f"after_delete_{TABLE_NAME}"
+    ch_after_delete = instance.query(
+        f"SELECT * FROM {TABLE_NAME} ORDER BY number",
+        query_id=query_id_after_delete,
+        settings={"iceberg_metadata_log_level": "manifest_file_entry"},
+    )
+    logging.info(f"CH after DELETE:\n{ch_after_delete}")
     assert int(instance.query(f"SELECT count() FROM {TABLE_NAME}")) == 4
+
+    instance.query("SYSTEM FLUSH LOGS")
+    log_after_delete = instance.query(
+        f"SELECT content_type, file_path, row_in_file, content FROM system.iceberg_metadata_log "
+        f"WHERE query_id = '{query_id_after_delete}' ORDER BY event_time FORMAT Vertical",
+    )
+    logging.info(f"=== iceberg_metadata_log after DELETE ===\n{log_after_delete}")
+
+    # Check if Spark sees the delete before OPTIMIZE
+    started_cluster_iceberg.spark_session._restart()
+    spark = started_cluster_iceberg.spark_session
+
+    df = spark.sql(f"SELECT * FROM {TABLE_NAME}").collect()
+    logging.info(f"Spark after DELETE: {len(df)} rows, values={sorted([r.number for r in df])}")
 
     instance.query(
         f"OPTIMIZE TABLE {TABLE_NAME}",
@@ -232,13 +255,29 @@ def test_ch_write_delete_optimize(started_cluster_iceberg):
             "allow_experimental_iceberg_compaction": 1,
         },
     )
+
+    # CH reads after OPTIMIZE with metadata logging
+    query_id_after_optimize = f"after_optimize_{TABLE_NAME}"
+    ch_after_optimize = instance.query(
+        f"SELECT * FROM {TABLE_NAME} ORDER BY number",
+        query_id=query_id_after_optimize,
+        settings={"iceberg_metadata_log_level": "manifest_file_entry"},
+    )
+    logging.info(f"CH after OPTIMIZE:\n{ch_after_optimize}")
     assert int(instance.query(f"SELECT count() FROM {TABLE_NAME}")) == 4
+
+    instance.query("SYSTEM FLUSH LOGS")
+    log_after_optimize = instance.query(
+        f"SELECT content_type, file_path, row_in_file, content FROM system.iceberg_metadata_log "
+        f"WHERE query_id = '{query_id_after_optimize}' ORDER BY event_time FORMAT Vertical",
+    )
+    logging.info(f"=== iceberg_metadata_log after OPTIMIZE ===\n{log_after_optimize}")
 
     # Spark reads the compacted result
     started_cluster_iceberg.spark_session._restart()
     spark = started_cluster_iceberg.spark_session
 
     df = spark.sql(f"SELECT * FROM {TABLE_NAME}").collect()
-    assert len(df) == 4, f"Spark expected 4 rows, got {len(df)}"
-    spark_values = sorted([row.number for row in df])
-    assert spark_values == [1, 2, 4, 5], f"Unexpected values: {spark_values}"
+    logging.info(f"Spark after OPTIMIZE: {len(df)} rows, values={sorted([r.number for r in df])}")
+
+    assert False, f"DEBUG: Spark got {len(df)} rows, values={sorted([r.number for r in df])}"

--- a/tests/integration/test_storage_iceberg_local/configs/config.d/cluster.xml
+++ b/tests/integration/test_storage_iceberg_local/configs/config.d/cluster.xml
@@ -1,0 +1,19 @@
+<clickhouse>
+    <remote_servers>
+        <cluster_simple>
+            <shard>
+                <replica>
+                    <host>node1</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </cluster_simple>
+    </remote_servers>
+
+    <!-- increase for concurrency test -->
+    <background_schedule_pool_size>150</background_schedule_pool_size>
+    <background_pool_size>50</background_pool_size>
+    <max_thread_pool_size>1800</max_thread_pool_size>
+    <thread_pool_queue_size>1800</thread_pool_queue_size>
+
+</clickhouse>

--- a/tests/integration/test_storage_iceberg_local/configs/config.d/named_collections.xml
+++ b/tests/integration/test_storage_iceberg_local/configs/config.d/named_collections.xml
@@ -1,0 +1,6 @@
+<clickhouse>
+  <named_collections>
+    <local>
+    </local>
+  </named_collections>
+</clickhouse>

--- a/tests/integration/test_storage_iceberg_local/configs/config.d/query_log.xml
+++ b/tests/integration/test_storage_iceberg_local/configs/config.d/query_log.xml
@@ -1,0 +1,6 @@
+<clickhouse>
+    <query_log>
+      <database>system</database>
+      <table>query_log</table>
+    </query_log>
+</clickhouse>

--- a/tests/integration/test_storage_iceberg_local/configs/users.d/users.xml
+++ b/tests/integration/test_storage_iceberg_local/configs/users.d/users.xml
@@ -1,0 +1,9 @@
+<clickhouse>
+    <users>
+        <default>
+            <password></password>
+            <profile>default</profile>
+            <named_collection_control>1</named_collection_control>
+        </default>
+    </users>
+</clickhouse>

--- a/tests/integration/test_storage_iceberg_local/conftest.py
+++ b/tests/integration/test_storage_iceberg_local/conftest.py
@@ -1,0 +1,128 @@
+import pytest
+import logging
+import pyspark
+import os
+
+from helpers.cluster import ClickHouseCluster
+from helpers.spark_tools import ResilientSparkSession, write_spark_log_config
+
+
+# Each node gets its own iceberg data directory so they don't see each other's writes.
+# external_dirs mounts <cluster.instances_dir>/<path> (host) → <path> (container).
+# We then create symlinks on the host so that the container path also resolves
+# on the host — this way Iceberg metadata with absolute paths works for both
+# Spark (host) and ClickHouse (container).
+ICEBERG_DIR_NODE1 = "/var/lib/clickhouse/user_files/iceberg_node1"
+ICEBERG_DIR_NODE2 = "/var/lib/clickhouse/user_files/iceberg_node2"
+
+
+def create_host_symlink(container_path, host_path):
+    """
+    Create a symlink on the host from container_path → host_path.
+    After this, both Spark (on host) and ClickHouse (in container)
+    can use the same absolute path to access the data.
+    """
+    os.makedirs(os.path.dirname(container_path), exist_ok=True)
+    if os.path.exists(container_path):
+        if os.path.islink(container_path):
+            os.remove(container_path)
+        else:
+            return  # Real directory exists (e.g., actual ClickHouse installation), don't touch it
+    os.symlink(host_path, container_path)
+    logging.info(f"Created symlink: {container_path} → {host_path}")
+
+
+def cleanup_host_symlink(container_path):
+    """Remove symlink created by create_host_symlink."""
+    if os.path.islink(container_path):
+        os.remove(container_path)
+        logging.info(f"Removed symlink: {container_path}")
+
+
+def get_spark(warehouse_node1, warehouse_node2, log_dir=None):
+    builder = (
+        pyspark.sql.SparkSession.builder
+            .appName("IcebergLocalTwoNodes")
+            .config("spark.sql.extensions",
+                    "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions")
+            # Catalog for node1
+            .config("spark.sql.catalog.node1_catalog",
+                    "org.apache.iceberg.spark.SparkCatalog")
+            .config("spark.sql.catalog.node1_catalog.type", "hadoop")
+            .config("spark.sql.catalog.node1_catalog.warehouse", warehouse_node1)
+            # Catalog for node2
+            .config("spark.sql.catalog.node2_catalog",
+                    "org.apache.iceberg.spark.SparkCatalog")
+            .config("spark.sql.catalog.node2_catalog.type", "hadoop")
+            .config("spark.sql.catalog.node2_catalog.warehouse", warehouse_node2)
+            .master("local")
+    )
+
+    if log_dir:
+        props_path = write_spark_log_config(log_dir)
+        builder = builder.config(
+            "spark.driver.extraJavaOptions",
+            f"-Dlog4j2.configurationFile=file:{props_path}",
+        )
+
+    return builder.getOrCreate()
+
+
+@pytest.fixture(scope="package")
+def started_cluster_iceberg():
+    symlinks = []
+    try:
+        cluster = ClickHouseCluster(__file__, with_spark=True)
+        cluster.add_instance(
+            "node1",
+            main_configs=[
+                "configs/config.d/query_log.xml",
+                "configs/config.d/cluster.xml",
+                "configs/config.d/named_collections.xml",
+            ],
+            user_configs=["configs/users.d/users.xml"],
+            stay_alive=True,
+            mem_limit="15g",
+            external_dirs=[ICEBERG_DIR_NODE1],
+        )
+        cluster.add_instance(
+            "node2",
+            main_configs=[
+                "configs/config.d/query_log.xml",
+                "configs/config.d/cluster.xml",
+                "configs/config.d/named_collections.xml",
+            ],
+            user_configs=["configs/users.d/users.xml"],
+            stay_alive=True,
+            mem_limit="15g",
+            external_dirs=[ICEBERG_DIR_NODE2],
+        )
+
+        logging.info("Starting cluster...")
+        cluster.start()
+
+        # external_dirs creates:
+        #   host: <instances_dir>/var/lib/clickhouse/user_files/iceberg_node1
+        #   container: /var/lib/clickhouse/user_files/iceberg_node1
+        #
+        # Create symlinks on the host so the container path resolves to the
+        # host path. Now both Spark and ClickHouse use the same absolute paths.
+        for iceberg_dir in [ICEBERG_DIR_NODE1, ICEBERG_DIR_NODE2]:
+            host_path = os.path.join(
+                cluster.instances_dir, iceberg_dir.lstrip("/")
+            )
+            create_host_symlink(iceberg_dir, host_path)
+            symlinks.append(iceberg_dir)
+
+        # Both Spark and ClickHouse use the container paths.
+        # On the host, these resolve via symlinks to the actual data.
+        cluster.spark_session = ResilientSparkSession(
+            lambda: get_spark(ICEBERG_DIR_NODE1, ICEBERG_DIR_NODE2, cluster.instances_dir)
+        )
+
+        yield cluster
+
+    finally:
+        for link in symlinks:
+            cleanup_host_symlink(link)
+        cluster.shutdown()

--- a/tests/integration/test_storage_iceberg_local/test_spark_interop.py
+++ b/tests/integration/test_storage_iceberg_local/test_spark_interop.py
@@ -1,0 +1,142 @@
+from helpers.iceberg_utils import get_uuid_str
+
+
+def test_nodes_dont_see_each_other(started_cluster_iceberg):
+    """
+    Spark writes different data to each node's local directory.
+    Each node only sees its own data.
+    """
+    node1 = started_cluster_iceberg.instances["node1"]
+    node2 = started_cluster_iceberg.instances["node2"]
+    spark = started_cluster_iceberg.spark_session
+
+    TABLE_NAME = "test_isolation_" + get_uuid_str()
+
+    # Create Iceberg tables via Spark — one per node catalog
+    spark.sql(
+        f"""
+            CREATE TABLE node1_catalog.default.{TABLE_NAME} (
+                number INT
+            )
+            USING iceberg
+            OPTIONS('format-version'='2');
+        """
+    )
+
+    spark.sql(
+        f"""
+            CREATE TABLE node2_catalog.default.{TABLE_NAME} (
+                number INT
+            )
+            USING iceberg
+            OPTIONS('format-version'='2');
+        """
+    )
+
+    # Write 100 rows to node1, 200 rows to node2
+    spark.sql(
+        f"""
+            INSERT INTO node1_catalog.default.{TABLE_NAME}
+            SELECT id as number FROM range(100)
+        """
+    )
+
+    spark.sql(
+        f"""
+            INSERT INTO node2_catalog.default.{TABLE_NAME}
+            SELECT id as number FROM range(200)
+        """
+    )
+
+    # Create ClickHouse tables — each node reads from its own iceberg directory
+    node1.query(
+        f"""
+        CREATE TABLE {TABLE_NAME}
+        ENGINE=IcebergLocal(local,
+            path = '/var/lib/clickhouse/user_files/iceberg_node1/default/{TABLE_NAME}')
+        """
+    )
+    node2.query(
+        f"""
+        CREATE TABLE {TABLE_NAME}
+        ENGINE=IcebergLocal(local,
+            path = '/var/lib/clickhouse/user_files/iceberg_node2/default/{TABLE_NAME}')
+        """
+    )
+
+    # Each node should only see its own data
+    rows_node1 = int(node1.query(f"SELECT count() FROM {TABLE_NAME}"))
+    rows_node2 = int(node2.query(f"SELECT count() FROM {TABLE_NAME}"))
+
+    assert rows_node1 == 100, f"node1: expected 100 rows, got {rows_node1}"
+    assert rows_node2 == 200, f"node2: expected 200 rows, got {rows_node2}"
+
+    # Append more data to node1 only
+    spark.sql(
+        f"""
+            INSERT INTO node1_catalog.default.{TABLE_NAME}
+            SELECT id + 100 as number FROM range(50)
+        """
+    )
+
+    rows_node1 = int(node1.query(f"SELECT count() FROM {TABLE_NAME}"))
+    rows_node2 = int(node2.query(f"SELECT count() FROM {TABLE_NAME}"))
+
+    assert rows_node1 == 150, f"node1: expected 150 rows after append, got {rows_node1}"
+    assert rows_node2 == 200, f"node2: should still have 200 rows, got {rows_node2}"
+
+
+def test_ch_write_spark_read(started_cluster_iceberg):
+    """
+    Spark creates a table, ClickHouse writes to it, Spark reads back.
+    Validates that the external_dirs mount works bidirectionally.
+    """
+    node1 = started_cluster_iceberg.instances["node1"]
+    spark = started_cluster_iceberg.spark_session
+
+    TABLE_NAME = "test_ch_write_spark_read_" + get_uuid_str()
+
+    # Spark creates the table structure
+    spark.sql(
+        f"""
+            CREATE TABLE node1_catalog.default.{TABLE_NAME} (
+                number INT
+            )
+            USING iceberg
+            OPTIONS('format-version'='2');
+        """
+    )
+
+    # Create ClickHouse table pointing to the same location
+    node1.query(
+        f"""
+        CREATE TABLE {TABLE_NAME}
+        ENGINE=IcebergLocal(local,
+            path = '/var/lib/clickhouse/user_files/iceberg_node1/default/{TABLE_NAME}')
+        """
+    )
+
+    # ClickHouse writes data
+    node1.query(
+        f"INSERT INTO {TABLE_NAME} VALUES (42)",
+        settings={"allow_insert_into_iceberg": 1},
+    )
+    node1.query(
+        f"INSERT INTO {TABLE_NAME} VALUES (123)",
+        settings={"allow_insert_into_iceberg": 1},
+    )
+
+    # ClickHouse can read its own writes
+    assert int(node1.query(f"SELECT count() FROM {TABLE_NAME}")) == 2
+
+    # Spark should also see the data written by ClickHouse.
+    # Spark's catalog caches metadata, so we need to refresh it first.
+    spark.sql(f"REFRESH TABLE node1_catalog.default.{TABLE_NAME}")
+
+    df = spark.sql(
+        f"SELECT * FROM node1_catalog.default.{TABLE_NAME}"
+    ).collect()
+    assert len(df) == 2, f"Spark expected 2 rows, got {len(df)}"
+
+    spark_values = sorted([row.number for row in df])
+    assert spark_values == [42, 123], f"Spark got unexpected values: {spark_values}"

--- a/tests/integration/test_storage_iceberg_with_spark/test_writes_create_version_hint.py
+++ b/tests/integration/test_storage_iceberg_with_spark/test_writes_create_version_hint.py
@@ -24,9 +24,8 @@ def test_writes_create_version_hint(started_cluster_iceberg_with_spark, format_v
         f"/var/lib/clickhouse/user_files/iceberg_data/default/{TABLE_NAME}/",
     )
 
-    target_suffix = b'v1.metadata.json'
     with open(f"/var/lib/clickhouse/user_files/iceberg_data/default/{TABLE_NAME}/metadata/version-hint.text", "rb") as f:
-        assert f.read()[-len(target_suffix):] == target_suffix
+        assert f.read().strip() == b'1'
 
     instance.query(f"INSERT INTO {TABLE_NAME} VALUES ('123', 1);", settings={"allow_insert_into_iceberg": 1})
     assert instance.query(f"SELECT * FROM {TABLE_NAME} ORDER BY ALL", ) == '123\t1\n'
@@ -38,9 +37,8 @@ def test_writes_create_version_hint(started_cluster_iceberg_with_spark, format_v
         f"/var/lib/clickhouse/user_files/iceberg_data/default/{TABLE_NAME}/",
     )
 
-    target_suffix = b'v2.metadata.json'
     with open(f"/var/lib/clickhouse/user_files/iceberg_data/default/{TABLE_NAME}/metadata/version-hint.text", "rb") as f:
-        assert f.read()[-len(target_suffix):] == target_suffix
+        assert f.read().strip() == b'2'
 
     df = spark.read.format("iceberg").load(f"/var/lib/clickhouse/user_files/iceberg_data/default/{TABLE_NAME}").collect()
     assert len(df) == 1


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixes some inconsistencies and bugs (primarly with Azure) in writing Iceberg metadata and manifests

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Iceberg commit/manifest logic and path translation, which can affect snapshot correctness and cross-engine compatibility; mitigated by targeted fixes and updated integration coverage.
> 
> **Overview**
> Fixes several Iceberg write-path inconsistencies across inserts, mutations, and compaction to improve compatibility with Spark/other engines and object stores.
> 
> Manifest list generation now records **per-manifest file sizes** (queried from object storage) instead of a single aggregated/WriteBuffer-derived length, and `MultipleFileWriter` falls back to `getObjectMetadata()` when a backend (e.g. Azure) doesn’t report `WriteBuffer::count()`.
> 
> Path handling is tightened by separating *metadata paths* (Iceberg-convention leading `/`) from *storage paths* (backend-convention), and `FileNamesGenerator::convertMetadataPathToStoragePath()` now tolerates full-URI paths by locating `table_dir` as a substring. Version-hint writing/updates are changed to write just the numeric version (and normalize incoming hint formats), with the Spark integration test updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c51825646b20da882facf3b745af825ef61ac18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->