### PR TITLE
ci: add `pr-must-backport-force` label to bypass rolling-out branch skip

### DIFF
--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -691,47 +691,61 @@ class BackportPRs:
     def process_pr(self, pr: PullRequest) -> None:
         pr_labels = [label.name for label in pr.labels]
 
-        is_general_backport = Labels.MUST_BACKPORT in pr_labels or bool(
+        is_force_backport = Labels.MUST_BACKPORT_FORCE in pr_labels
+        is_general_backport = is_force_backport or Labels.MUST_BACKPORT in pr_labels or bool(
             Labels.AUTO_BACKPORT & set(pr_labels)
         )
         if is_general_backport:
-            # For general backports (pr-must-backport / critical bugfix), skip
-            # release branches that are currently rolling out, unless the PR
-            # carries an explicit version-specific label for that branch.
-            rolling_out = set(self._rolling_out_branches())
-            # Build a per-branch version-specific label so we can honour explicit
-            # overrides (e.g. the PR has both pr-must-backport AND
-            # v25.10-must-backport: the 25.10 branch must be included even if it
-            # is marked rolling-out).
-            branch_specific_label = {
-                branch: f"v{branch.replace('release/', '')}-must-backport"
-                for branch in self.release_branches
-            }
-            skipped = [
-                br
-                for br in self.release_branches
-                if br in rolling_out and branch_specific_label[br] not in pr_labels
-            ]
-            if skipped:
+            if is_force_backport:
+                # pr-must-backport-force: backport to all release branches,
+                # ignoring the rolling-out restriction entirely.
                 logging.info(
-                    "PR #%s: skipping rolling-out release branches for general "
-                    "backport: %s",
+                    "PR #%s: label %r present, ignoring rolling-out branches",
                     pr.number,
-                    ", ".join(skipped),
+                    Labels.MUST_BACKPORT_FORCE,
                 )
-                for br in skipped:
-                    self._close_prs_for_rolling_out_branch(pr, br)
-            branches = [
-                ReleaseBranch(br, pr, self.repo)
-                for br in self.release_branches
-                if br not in rolling_out or branch_specific_label[br] in pr_labels
-            ]  # type: List[ReleaseBranch]
-            if not branches:
-                logging.info(
-                    "PR #%s: all release branches are rolling-out, skipping backport",
-                    pr.number,
-                )
-                return
+                branches = [
+                    ReleaseBranch(br, pr, self.repo)
+                    for br in self.release_branches
+                ]  # type: List[ReleaseBranch]
+            else:
+                # For general backports (pr-must-backport / critical bugfix), skip
+                # release branches that are currently rolling out, unless the PR
+                # carries an explicit version-specific label for that branch.
+                rolling_out = set(self._rolling_out_branches())
+                # Build a per-branch version-specific label so we can honour explicit
+                # overrides (e.g. the PR has both pr-must-backport AND
+                # v25.10-must-backport: the 25.10 branch must be included even if it
+                # is marked rolling-out).
+                branch_specific_label = {
+                    branch: f"v{branch.replace('release/', '')}-must-backport"
+                    for branch in self.release_branches
+                }
+                skipped = [
+                    br
+                    for br in self.release_branches
+                    if br in rolling_out and branch_specific_label[br] not in pr_labels
+                ]
+                if skipped:
+                    logging.info(
+                        "PR #%s: skipping rolling-out release branches for general "
+                        "backport: %s",
+                        pr.number,
+                        ", ".join(skipped),
+                    )
+                    for br in skipped:
+                        self._close_prs_for_rolling_out_branch(pr, br)
+                branches = [
+                    ReleaseBranch(br, pr, self.repo)
+                    for br in self.release_branches
+                    if br not in rolling_out or branch_specific_label[br] in pr_labels
+                ]
+                if not branches:
+                    logging.info(
+                        "PR #%s: all release branches are rolling-out, skipping backport",
+                        pr.number,
+                    )
+                    return
         else:
             branches = [
                 ReleaseBranch(

--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -592,7 +592,7 @@ class BackportPRs:
 
         since_date = since_date or self.oldest_commit_date()
         labels_to_backport = labels_to_backport or (
-            self.labels_to_backport + [Labels.MUST_BACKPORT]
+            self.labels_to_backport + [Labels.MUST_BACKPORT, Labels.MUST_BACKPORT_FORCE]
         )
         repo_name = repo_name or self.repo.full_name
         # To not have a possible TZ issues

--- a/tests/ci/pr_info.py
+++ b/tests/ci/pr_info.py
@@ -29,6 +29,7 @@ class Labels:
     CAN_BE_TESTED = "can be tested"
     DO_NOT_TEST = "do not test"
     MUST_BACKPORT = "pr-must-backport"
+    MUST_BACKPORT_FORCE = "pr-must-backport-force"
     MUST_BACKPORT_SYNCED = "pr-must-backport-synced"
     JEPSEN_TEST = "jepsen-test"
     SKIP_MERGEABLE_CHECK = "skip mergeable check"


### PR DESCRIPTION
## Summary

- Adds a new `pr-must-backport-force` label to the `Labels` class in `pr_info.py`
- When this label is present on a PR, `cherry_pick.py` skips the rolling-out branch filter and backports to **all** release branches unconditionally
- The existing `pr-must-backport` / `pr-critical-bugfix` path (with per-branch `v{ver}-must-backport` overrides and `_close_prs_for_rolling_out_branch` cleanup) is unchanged

## Test plan
- [ ] Manually verify by adding `pr-must-backport-force` to a test PR during a rolling-out period and confirming backport PRs are created for all branches including rolling-out ones
- [ ] Verify `pr-must-backport` still skips rolling-out branches as before

### Changelog category (leave one):

- CI Fix or Improvement (changelog entry is not required)

### Changelog entry
Added new `pr-must-backport-force` label that forces backport to all release branches, ignoring the rolling-out branch restriction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.21`
<!-- ch-version-info:end -->