### PR TITLE
Avoid thundering herd effect in the query result cache

### DIFF
--- a/src/Interpreters/Cache/QueryResultCache.cpp
+++ b/src/Interpreters/Cache/QueryResultCache.cpp
@@ -416,6 +416,7 @@ QueryResultCacheWriter::QueryResultCacheWriter(const QueryResultCacheWriter & ot
     , min_query_runtime(other.min_query_runtime)
     , squash_partial_results(other.squash_partial_results)
     , max_block_size(other.max_block_size)
+    , qrc(other.qrc)
 {
 }
 
@@ -755,7 +756,7 @@ void QueryResultCache::updateConfiguration(size_t max_size_in_bytes, size_t max_
     max_entry_size_in_rows = max_entry_size_in_rows_;
 }
 
-QueryResultCache::ReaderOrToken QueryResultCache::createReaderOrAcquireToken(const Key & key)
+std::pair<QueryResultCacheReader, QueryResultCache::InFlightTokenPtr> QueryResultCache::createReaderOrAcquireToken(const Key & key)
 {
     while (true)
     {
@@ -767,7 +768,7 @@ QueryResultCache::ReaderOrToken QueryResultCache::createReaderOrAcquireToken(con
             if (reader.hasCacheEntryForKey(false))
             {
                 ProfileEvents::increment(ProfileEvents::QueryCacheHits);
-                return ReaderOrToken{std::move(reader), nullptr};
+                return {std::move(reader), nullptr};
             }
 
             auto it = in_flight_tokens.find(key);
@@ -776,7 +777,7 @@ QueryResultCache::ReaderOrToken QueryResultCache::createReaderOrAcquireToken(con
                 auto token = std::make_shared<InFlightToken>();
                 in_flight_tokens.emplace(key, token);
                 ProfileEvents::increment(ProfileEvents::QueryCacheMisses);
-                return ReaderOrToken{std::move(reader), std::move(token)};
+                return {std::move(reader), std::move(token)};
             }
 
             token_to_wait = it->second;
@@ -821,7 +822,7 @@ std::shared_ptr<QueryResultCacheWriter> QueryResultCache::createWriter(
     size_t max_block_size,
     size_t max_query_result_cache_size_in_bytes_quota,
     size_t max_query_result_cache_entries_quota,
-    InFlightTokenPtr in_flight_token)
+    bool has_in_flight_token)
 {
     /// Update the per-user cache quotas with the values stored in the query context. This happens per query which writes into the query
     /// cache. Obviously, this is overkill but I could find the good place to hook into which is called when the settings profiles in
@@ -830,7 +831,7 @@ std::shared_ptr<QueryResultCacheWriter> QueryResultCache::createWriter(
     if (key.user_id.has_value())
         cache.setQuotaForUser(*key.user_id, max_query_result_cache_size_in_bytes_quota, max_query_result_cache_entries_quota);
 
-    QueryResultCache * qrc_for_writer = in_flight_token ? this : nullptr;
+    QueryResultCache * qrc_for_writer = has_in_flight_token ? this : nullptr;
 
     std::lock_guard lock(mutex);
     return std::shared_ptr<QueryResultCacheWriter>(

--- a/src/Interpreters/Cache/QueryResultCache.cpp
+++ b/src/Interpreters/Cache/QueryResultCache.cpp
@@ -24,6 +24,7 @@
 #include <Common/quoteString.h>
 #include <Core/Settings.h>
 #include <base/defines.h> /// chassert
+#include <base/scope_guard.h>
 
 
 namespace ProfileEvents
@@ -389,7 +390,8 @@ QueryResultCacheWriter::QueryResultCacheWriter(
     size_t max_entry_size_in_rows_,
     std::chrono::milliseconds min_query_runtime_,
     bool squash_partial_results_,
-    size_t max_block_size_)
+    size_t max_block_size_,
+    QueryResultCache * qrc_)
     : cache(cache_)
     , key(key_)
     , max_entry_size_in_bytes(max_entry_size_in_bytes_)
@@ -397,6 +399,7 @@ QueryResultCacheWriter::QueryResultCacheWriter(
     , min_query_runtime(min_query_runtime_)
     , squash_partial_results(squash_partial_results_)
     , max_block_size(max_block_size_)
+    , qrc(qrc_)
 {
     if (auto entry = cache.getWithKey(key); entry.has_value() && !QueryResultCache::IsStale()(entry->key))
     {
@@ -414,6 +417,18 @@ QueryResultCacheWriter::QueryResultCacheWriter(const QueryResultCacheWriter & ot
     , squash_partial_results(other.squash_partial_results)
     , max_block_size(other.max_block_size)
 {
+}
+
+QueryResultCacheWriter::~QueryResultCacheWriter()
+{
+    signalInFlightToken();
+}
+
+void QueryResultCacheWriter::signalInFlightToken()
+{
+    if (!qrc || in_flight_token_signaled.exchange(true))
+        return;
+    qrc->signalInFlight(key);
 }
 
 void QueryResultCacheWriter::buffer(Chunk && chunk, ChunkType chunk_type)
@@ -464,6 +479,8 @@ void QueryResultCacheWriter::buffer(Chunk && chunk, ChunkType chunk_type)
 
 void QueryResultCacheWriter::finalizeWrite()
 {
+    SCOPE_EXIT({ signalInFlightToken(); });
+
     if (skip_insert)
         return;
 
@@ -738,19 +755,73 @@ void QueryResultCache::updateConfiguration(size_t max_size_in_bytes, size_t max_
     max_entry_size_in_rows = max_entry_size_in_rows_;
 }
 
+QueryResultCache::ReaderOrToken QueryResultCache::createReaderOrAcquireToken(const Key & key)
+{
+    while (true)
+    {
+        InFlightTokenPtr token_to_wait;
+        {
+            std::lock_guard lock(mutex);
+
+            QueryResultCacheReader reader(cache, key, lock);
+            if (reader.hasCacheEntryForKey(false))
+            {
+                ProfileEvents::increment(ProfileEvents::QueryCacheHits);
+                return ReaderOrToken{std::move(reader), nullptr};
+            }
+
+            auto it = in_flight_tokens.find(key);
+            if (it == in_flight_tokens.end())
+            {
+                auto token = std::make_shared<InFlightToken>();
+                in_flight_tokens.emplace(key, token);
+                ProfileEvents::increment(ProfileEvents::QueryCacheMisses);
+                return ReaderOrToken{std::move(reader), std::move(token)};
+            }
+
+            token_to_wait = it->second;
+        }
+
+        {
+            std::unique_lock token_lock(token_to_wait->mutex);
+            token_to_wait->cv.wait(token_lock, [&] { return token_to_wait->done; });
+        }
+    }
+}
+
+void QueryResultCache::signalInFlight(const Key & key)
+{
+    InFlightTokenPtr token;
+    {
+        std::lock_guard lock(mutex);
+        auto it = in_flight_tokens.find(key);
+        if (it == in_flight_tokens.end())
+            return;
+        token = std::move(it->second);
+        in_flight_tokens.erase(it);
+    }
+
+    {
+        std::lock_guard token_lock(token->mutex);
+        token->done = true;
+    }
+    token->cv.notify_all();
+}
+
 QueryResultCacheReader QueryResultCache::createReader(const Key & key)
 {
     std::lock_guard lock(mutex);
     return QueryResultCacheReader(cache, key, lock);
 }
 
-QueryResultCacheWriter QueryResultCache::createWriter(
+std::shared_ptr<QueryResultCacheWriter> QueryResultCache::createWriter(
     const Key & key,
     std::chrono::milliseconds min_query_runtime,
     bool squash_partial_results,
     size_t max_block_size,
     size_t max_query_result_cache_size_in_bytes_quota,
-    size_t max_query_result_cache_entries_quota)
+    size_t max_query_result_cache_entries_quota,
+    InFlightTokenPtr in_flight_token)
 {
     /// Update the per-user cache quotas with the values stored in the query context. This happens per query which writes into the query
     /// cache. Obviously, this is overkill but I could find the good place to hook into which is called when the settings profiles in
@@ -759,8 +830,11 @@ QueryResultCacheWriter QueryResultCache::createWriter(
     if (key.user_id.has_value())
         cache.setQuotaForUser(*key.user_id, max_query_result_cache_size_in_bytes_quota, max_query_result_cache_entries_quota);
 
+    QueryResultCache * qrc_for_writer = in_flight_token ? this : nullptr;
+
     std::lock_guard lock(mutex);
-    return QueryResultCacheWriter(cache, key, max_entry_size_in_bytes, max_entry_size_in_rows, min_query_runtime, squash_partial_results, max_block_size);
+    return std::shared_ptr<QueryResultCacheWriter>(
+        new QueryResultCacheWriter(cache, key, max_entry_size_in_bytes, max_entry_size_in_rows, min_query_runtime, squash_partial_results, max_block_size, qrc_for_writer));
 }
 
 void QueryResultCache::clear(const std::optional<String> & tag)

--- a/src/Interpreters/Cache/QueryResultCache.h
+++ b/src/Interpreters/Cache/QueryResultCache.h
@@ -11,6 +11,7 @@
 #include <Parsers/IAST_fwd.h>
 #include <base/UUID.h>
 
+#include <condition_variable>
 #include <optional>
 
 namespace DB
@@ -144,18 +145,34 @@ public:
     /// query --> query result
     using Cache = CacheBase<Key, Entry, KeyHasher, EntryWeight>;
 
+    struct InFlightToken
+    {
+        std::mutex mutex;
+        std::condition_variable cv;
+        bool done = false;
+    };
+    using InFlightTokenPtr = std::shared_ptr<InFlightToken>;
+
+    struct ReaderOrToken; /// defined after QueryResultCacheReader
+
     QueryResultCache(size_t max_size_in_bytes, size_t max_entries, size_t max_entry_size_in_bytes_, size_t max_entry_size_in_rows_);
 
     void updateConfiguration(size_t max_size_in_bytes, size_t max_entries, size_t max_entry_size_in_bytes_, size_t max_entry_size_in_rows_);
 
+    /// Returns a reader on cache hit; on miss, registers this thread as the computer and returns a token (thundering herd prevention).
+    ReaderOrToken createReaderOrAcquireToken(const Key & key);
+
+    void signalInFlight(const Key & key);
+
     QueryResultCacheReader createReader(const Key & key);
-    QueryResultCacheWriter createWriter(
+    std::shared_ptr<QueryResultCacheWriter> createWriter(
         const Key & key,
         std::chrono::milliseconds min_query_runtime,
         bool squash_partial_results,
         size_t max_block_size,
         size_t max_query_result_cache_size_in_bytes_quota,
-        size_t max_query_result_cache_entries_quota);
+        size_t max_query_result_cache_entries_quota,
+        InFlightTokenPtr in_flight_token = nullptr);
 
     void clear(const std::optional<String> & tag);
 
@@ -176,6 +193,9 @@ private:
     /// query --> query execution count
     using TimesExecuted = std::unordered_map<Key, size_t, KeyHasher>;
     TimesExecuted times_executed TSA_GUARDED_BY(mutex);
+
+    using InFlightMap = std::unordered_map<Key, InFlightTokenPtr, KeyHasher>;
+    InFlightMap in_flight_tokens TSA_GUARDED_BY(mutex);
 
     /// Cache configuration
     size_t max_entry_size_in_bytes TSA_GUARDED_BY(mutex) = 0;
@@ -201,6 +221,7 @@ class QueryResultCacheWriter
 {
 public:
     QueryResultCacheWriter(const QueryResultCacheWriter & other);
+    ~QueryResultCacheWriter();
 
     enum class ChunkType : uint8_t
     {
@@ -228,6 +249,11 @@ private:
     bool was_finalized = false;
     LoggerPtr logger = getLogger("QueryResultCache");
 
+    QueryResultCache * qrc = nullptr; /// non-null if this writer should signal the in-flight token when done
+    std::atomic<bool> in_flight_token_signaled = false;
+
+    void signalInFlightToken();
+
     QueryResultCacheWriter(
         Cache & cache_,
         const Cache::Key & key_,
@@ -235,7 +261,8 @@ private:
         size_t max_entry_size_in_rows_,
         std::chrono::milliseconds min_query_runtime_,
         bool squash_partial_results_,
-        size_t max_block_size_);
+        size_t max_block_size_,
+        QueryResultCache * qrc_);
 
     friend class QueryResultCache; /// for createWriter()
 };
@@ -276,5 +303,11 @@ private:
 
 
 using QueryResultCachePtr = std::shared_ptr<QueryResultCache>;
+
+struct QueryResultCache::ReaderOrToken
+{
+    QueryResultCacheReader reader;
+    InFlightTokenPtr token;
+};
 
 }

--- a/src/Interpreters/Cache/QueryResultCache.h
+++ b/src/Interpreters/Cache/QueryResultCache.h
@@ -153,14 +153,11 @@ public:
     };
     using InFlightTokenPtr = std::shared_ptr<InFlightToken>;
 
-    struct ReaderOrToken; /// defined after QueryResultCacheReader
-
     QueryResultCache(size_t max_size_in_bytes, size_t max_entries, size_t max_entry_size_in_bytes_, size_t max_entry_size_in_rows_);
 
     void updateConfiguration(size_t max_size_in_bytes, size_t max_entries, size_t max_entry_size_in_bytes_, size_t max_entry_size_in_rows_);
 
-    /// Returns a reader on cache hit; on miss, registers this thread as the computer and returns a token (thundering herd prevention).
-    ReaderOrToken createReaderOrAcquireToken(const Key & key);
+    std::pair<QueryResultCacheReader, InFlightTokenPtr> createReaderOrAcquireToken(const Key & key);
 
     void signalInFlight(const Key & key);
 
@@ -172,7 +169,7 @@ public:
         size_t max_block_size,
         size_t max_query_result_cache_size_in_bytes_quota,
         size_t max_query_result_cache_entries_quota,
-        InFlightTokenPtr in_flight_token = nullptr);
+        bool has_in_flight_token = false);
 
     void clear(const std::optional<String> & tag);
 
@@ -249,7 +246,7 @@ private:
     bool was_finalized = false;
     LoggerPtr logger = getLogger("QueryResultCache");
 
-    QueryResultCache * qrc = nullptr; /// non-null if this writer should signal the in-flight token when done
+    QueryResultCache * qrc = nullptr;
     std::atomic<bool> in_flight_token_signaled = false;
 
     void signalInFlightToken();
@@ -303,11 +300,5 @@ private:
 
 
 using QueryResultCachePtr = std::shared_ptr<QueryResultCache>;
-
-struct QueryResultCache::ReaderOrToken
-{
-    QueryResultCacheReader reader;
-    InFlightTokenPtr token;
-};
 
 }

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -1637,6 +1637,11 @@ static BlockIO executeQueryImpl(
 
         if (!async_insert)
         {
+            /// Non-null if this thread registered as the computer for a query result cache entry.
+            /// Transferred to the writer; if no writer is created, signaled via SCOPE_EXIT below.
+            QueryResultCache::InFlightTokenPtr qrc_in_flight_token;
+            std::unique_ptr<QueryResultCache::Key> qrc_read_key;
+
             /// If it is a non-internal SELECT, and passive (read) use of the query result cache is enabled, and the cache knows the query,
             /// then set a pipeline with a source populated by the query result cache.
             auto get_result_from_query_result_cache = [&]()
@@ -1644,7 +1649,19 @@ static BlockIO executeQueryImpl(
                 if (out_ast && can_use_query_result_cache && settings[Setting::enable_reads_from_query_cache])
                 {
                     QueryResultCache::Key key(out_ast, context->getCurrentDatabase(), *settings_copy, context->getCurrentQueryId(), context->getUserID(), context->getCurrentRoles());
-                    QueryResultCacheReader reader = query_result_cache->createReader(key);
+
+                    QueryResultCacheReader reader = [&]() -> QueryResultCacheReader
+                    {
+                        if (settings[Setting::enable_writes_to_query_cache])
+                        {
+                            qrc_read_key = std::make_unique<QueryResultCache::Key>(key);
+                            auto [r, token] = query_result_cache->createReaderOrAcquireToken(key);
+                            qrc_in_flight_token = std::move(token);
+                            return std::move(r);
+                        }
+                        return query_result_cache->createReader(key);
+                    }();
+
                     if (reader.hasCacheEntryForKey())
                     {
                         result_details.query_cache_entry_created_at = reader.entryCreatedAt();
@@ -1660,6 +1677,11 @@ static BlockIO executeQueryImpl(
                 }
                 return false;
             };
+
+            SCOPE_EXIT({
+                if (qrc_in_flight_token && qrc_read_key && query_result_cache)
+                    query_result_cache->signalInFlight(*qrc_read_key);
+            });
 
             if (!get_result_from_query_result_cache())
             {
@@ -1796,13 +1818,14 @@ static BlockIO executeQueryImpl(
                             }
                             else
                             {
-                                auto query_result_cache_writer = std::make_shared<QueryResultCacheWriter>(query_result_cache->createWriter(
+                                auto query_result_cache_writer = query_result_cache->createWriter(
                                      key,
                                      std::chrono::milliseconds(settings[Setting::query_cache_min_query_duration].totalMilliseconds()),
                                      settings[Setting::query_cache_squash_partial_results],
                                      settings[Setting::max_block_size],
                                      settings[Setting::query_cache_max_size_in_bytes],
-                                     settings[Setting::query_cache_max_entries]));
+                                     settings[Setting::query_cache_max_entries],
+                                     std::move(qrc_in_flight_token));
                                 res.pipeline.writeResultIntoQueryResultCache(query_result_cache_writer);
                                 query_result_cache_usage = QueryResultCacheUsage::Write;
                             }

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -1637,8 +1637,6 @@ static BlockIO executeQueryImpl(
 
         if (!async_insert)
         {
-            /// Non-null if this thread registered as the computer for a query result cache entry.
-            /// Transferred to the writer; if no writer is created, signaled via SCOPE_EXIT below.
             QueryResultCache::InFlightTokenPtr qrc_in_flight_token;
             std::unique_ptr<QueryResultCache::Key> qrc_read_key;
 
@@ -1650,6 +1648,7 @@ static BlockIO executeQueryImpl(
                 {
                     QueryResultCache::Key key(out_ast, context->getCurrentDatabase(), *settings_copy, context->getCurrentQueryId(), context->getUserID(), context->getCurrentRoles());
 
+                    bool profile_events_already_updated = false;
                     QueryResultCacheReader reader = [&]() -> QueryResultCacheReader
                     {
                         if (settings[Setting::enable_writes_to_query_cache])
@@ -1657,12 +1656,13 @@ static BlockIO executeQueryImpl(
                             qrc_read_key = std::make_unique<QueryResultCache::Key>(key);
                             auto [r, token] = query_result_cache->createReaderOrAcquireToken(key);
                             qrc_in_flight_token = std::move(token);
+                            profile_events_already_updated = true;
                             return std::move(r);
                         }
                         return query_result_cache->createReader(key);
                     }();
 
-                    if (reader.hasCacheEntryForKey())
+                    if (reader.hasCacheEntryForKey(!profile_events_already_updated))
                     {
                         result_details.query_cache_entry_created_at = reader.entryCreatedAt();
                         result_details.query_cache_entry_expires_at = reader.entryExpiresAt();
@@ -1825,7 +1825,8 @@ static BlockIO executeQueryImpl(
                                      settings[Setting::max_block_size],
                                      settings[Setting::query_cache_max_size_in_bytes],
                                      settings[Setting::query_cache_max_entries],
-                                     std::move(qrc_in_flight_token));
+                                     qrc_in_flight_token != nullptr);
+                                qrc_in_flight_token.reset();
                                 res.pipeline.writeResultIntoQueryResultCache(query_result_cache_writer);
                                 query_result_cache_usage = QueryResultCacheUsage::Write;
                             }


### PR DESCRIPTION
Resolves https://github.com/ClickHouse/ClickHouse/issues/99226

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches concurrency and lifecycle management in the query execution/cache path; bugs could cause deadlocks, missed wakeups, or reduced cache effectiveness under load.
> 
> **Overview**
> Prevents *thundering herd* on query-cache misses by introducing per-key **in-flight tokens**: the first request that misses registers a token and proceeds to execute/write, while concurrent requests wait until the token is signaled and then re-check the cache.
> 
> This updates the query execution path to use `createReaderOrAcquireToken()` when both cache reads and writes are enabled, and ensures tokens are always released via `SCOPE_EXIT` and a `QueryResultCacheWriter` destructor/scope guard; `createWriter()` now returns a `shared_ptr` and can be told it owns an in-flight token to signal on completion/early-exit.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a80f30bc3b4a1be87e2dfda0b56e13515cdd326. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->