### PR TITLE
A bit nicer fix on top of #96373

### DIFF
--- a/src/Processors/LimitTransform.cpp
+++ b/src/Processors/LimitTransform.cpp
@@ -152,23 +152,10 @@ LimitTransform::Status LimitTransform::preparePair(PortsData & data)
     if (output.isFinished())
     {
         output_finished = true;
-        if (!always_read_till_end)
+        if (!always_read_till_end || rows_read == 0)
         {
-            input.close();
-            return Status::Finished;
-        }
-
-        /// When always_read_till_end is set and the output is already finished,
-        /// we should only continue reading if the limit was already reached
-        /// (to count remaining rows for rows_before_limit_at_least).
-        /// If the limit hasn't been reached yet, there's no point in continuing
-        /// to read since the output is already closed and the row count won't be used.
-        /// This also prevents a bug where the pipeline shuts down due to a downstream
-        /// constant-false filter, aborting set creation via DelayedPortsProcessor,
-        /// but the Limit keeps pulling data through a FilterTransform that needs the unbuilt set.
-        bool limit_is_unreachable = (limit > std::numeric_limits<UInt64>::max() - offset);
-        if (limit_is_unreachable || rows_read < offset + limit)
-        {
+            /// The rows_read == 0 is a corner case. If no wors were read before the output is closed,
+            /// do not read data even with always_read_till_end to avoid Not-ready Set (sets might be not built).
             input.close();
             return Status::Finished;
         }

--- a/src/Processors/LimitTransform.cpp
+++ b/src/Processors/LimitTransform.cpp
@@ -154,8 +154,8 @@ LimitTransform::Status LimitTransform::preparePair(PortsData & data)
         output_finished = true;
         if (!always_read_till_end || rows_read == 0)
         {
-            /// The rows_read == 0 is a corner case. If no wors were read before the output is closed,
-            /// do not read data even with always_read_till_end to avoid Not-ready Set (sets might be not built).
+            /// The rows_read == 0 is a corner case. If no rows were read before the output is closed,
+            /// do not read data even with always_read_till_end to avoid Not-ready Set (sets might not be built).
             input.close();
             return Status::Finished;
         }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes control flow in a core query execution processor, which can affect LIMIT correctness and pipeline shutdown behavior under early-finished downstream stages.
> 
> **Overview**
> Adjusts `LimitTransform::preparePair` behavior when the downstream `output` is already finished.
> 
> The transform now stops pulling more input unless `always_read_till_end` is enabled *and* some rows have already been read, replacing the prior more complex “continue only if limit reached/counting needed” logic; this reduces unnecessary reads and avoids edge cases where continued reads could interact badly with not-yet-built sets in the pipeline.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99600b0c526267db4092ecc5f38e8e42d2a8a321. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.655`
<!-- ch-version-info:end -->