### PR TITLE
Skip stale Keeper requests for finished sessions

### DIFF
--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -969,6 +969,7 @@ The server successfully detected this situation and will download merged part fr
     M(KeeperRemoveWatchRequest, "Number of remove watches requests", ValueType::Number) \
     M(KeeperCheckWatchRequest, "Number of remove watches requests", ValueType::Number) \
     M(KeeperRequestRejectedDueToSoftMemoryLimitCount, "Number requests that have been rejected due to soft memory limit exceeded", ValueType::Number) \
+    M(KeeperStaleRequestsSkipped, "Number of Keeper requests skipped because the session was already finished", ValueType::Number) \
     \
     M(OverflowBreak, "Number of times, data processing was cancelled by query complexity limitation with setting '*_overflow_mode' = 'break' and the result is incomplete.", ValueType::Number) \
     M(OverflowThrow, "Number of times, data processing was cancelled by query complexity limitation with setting '*_overflow_mode' = 'throw' and exception was thrown.", ValueType::Number) \

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -970,6 +970,7 @@ The server successfully detected this situation and will download merged part fr
     M(KeeperCheckWatchRequest, "Number of remove watches requests", ValueType::Number) \
     M(KeeperRequestRejectedDueToSoftMemoryLimitCount, "Number requests that have been rejected due to soft memory limit exceeded", ValueType::Number) \
     M(KeeperStaleRequestsSkipped, "Number of Keeper requests skipped because the session was already finished", ValueType::Number) \
+    M(KeeperFinishedSessionsCacheFull, "Number of times a finished session could not be tracked because the cache reached its size limit", ValueType::Number) \
     \
     M(OverflowBreak, "Number of times, data processing was cancelled by query complexity limitation with setting '*_overflow_mode' = 'break' and the result is incomplete.", ValueType::Number) \
     M(OverflowThrow, "Number of times, data processing was cancelled by query complexity limitation with setting '*_overflow_mode' = 'throw' and exception was thrown.", ValueType::Number) \

--- a/src/Coordination/CoordinationSettings.cpp
+++ b/src/Coordination/CoordinationSettings.cpp
@@ -42,6 +42,7 @@ namespace ErrorCodes
     DECLARE(UInt64, stale_log_gap, 10000, "When node became stale and should receive snapshots from leader", 0) \
     DECLARE(UInt64, fresh_log_gap, 200, "When node became fresh", 0) \
     DECLARE(UInt64, max_request_queue_size, 100000, "Maximum number of request that can be in queue for processing", 0) \
+    DECLARE(UInt64, max_finished_sessions_cache_size, 100000, "Maximum number of finished sessions to track for stale request filtering. Entries are normally cleaned up when the corresponding Close commits; this limit is a safety cap.", 0) \
     DECLARE(UInt64, max_requests_batch_size, 100, "Max size of batch of requests that can be sent to RAFT", 0) \
     DECLARE(UInt64, max_requests_batch_bytes_size, 100*1024, "Max size in bytes of batch of requests that can be sent to RAFT", 0) \
     DECLARE(UInt64, max_request_size, 0, "Max request size (in bytes). Zero means unlimited.", 0) \

--- a/src/Coordination/CoordinationSettings.cpp
+++ b/src/Coordination/CoordinationSettings.cpp
@@ -288,6 +288,9 @@ void KeeperConfigurationAndSettings::dump(WriteBufferFromOwnString & buf) const
     write_bool(coordination_settings[CoordinationSetting::use_xid_64]);
     writeText("check_node_acl_on_remove=", buf);
     write_bool(coordination_settings[CoordinationSetting::check_node_acl_on_remove]);
+
+    writeText("max_finished_sessions_cache_size=", buf);
+    write_int(coordination_settings[CoordinationSetting::max_finished_sessions_cache_size]);
 }
 
 KeeperConfigurationAndSettingsPtr

--- a/src/Coordination/KeeperConstants.cpp
+++ b/src/Coordination/KeeperConstants.cpp
@@ -311,6 +311,7 @@
 \
     M(KeeperRequestRejectedDueToSoftMemoryLimitCount) \
     M(KeeperStaleRequestsSkipped) \
+    M(KeeperFinishedSessionsCacheFull) \
 
 namespace ProfileEvents
 {

--- a/src/Coordination/KeeperConstants.cpp
+++ b/src/Coordination/KeeperConstants.cpp
@@ -310,6 +310,7 @@
     M(JemallocFailedDeallocationSampleTracking) \
 \
     M(KeeperRequestRejectedDueToSoftMemoryLimitCount) \
+    M(KeeperStaleRequestsSkipped) \
 
 namespace ProfileEvents
 {

--- a/src/Coordination/KeeperDispatcher.cpp
+++ b/src/Coordination/KeeperDispatcher.cpp
@@ -901,13 +901,6 @@ void KeeperDispatcher::finishSession(int64_t session_id)
     if (keeper_context->isShutdownCalled())
         return;
 
-    /// Mark session as finished FIRST to maximize the window where
-    /// requestThread can skip stale requests for this session.
-    {
-        std::lock_guard lock(finished_sessions_mutex);
-        finished_sessions.insert(session_id);
-    }
-
     ZooKeeperResponseCallback callback;
     {
         std::lock_guard lock(session_to_response_callback_mutex);
@@ -918,6 +911,21 @@ void KeeperDispatcher::finishSession(int64_t session_id)
             session_to_response_callback.erase(session_it);
             CurrentMetrics::sub(CurrentMetrics::KeeperAliveConnections);
         }
+        else
+        {
+            /// Session was already finished by another path (e.g. `sessionCleanerTask`
+            /// raced with `KeeperTCPHandler`). The `Close` request may have already
+            /// committed and erased `finished_sessions`, so inserting now would leak
+            /// the session ID with no one to clean it up.
+            return;
+        }
+    }
+
+    /// Mark session as finished so `requestThread` can skip stale requests
+    /// still sitting in the queue for this session.
+    {
+        std::lock_guard lock(finished_sessions_mutex);
+        finished_sessions.insert(session_id);
     }
 
     /// Notify the callback that session is being closed before removing it

--- a/src/Coordination/KeeperDispatcher.cpp
+++ b/src/Coordination/KeeperDispatcher.cpp
@@ -53,6 +53,7 @@ namespace ProfileEvents
     extern const Event KeeperBatchMaxTotalSize;
     extern const Event KeeperRequestRejectedDueToSoftMemoryLimitCount;
     extern const Event KeeperStaleRequestsSkipped;
+    extern const Event KeeperFinishedSessionsCacheFull;
 }
 
 namespace HistogramMetrics
@@ -69,6 +70,7 @@ namespace DB
 namespace CoordinationSetting
 {
     extern const CoordinationSettingsMilliseconds dead_session_check_period_ms;
+    extern const CoordinationSettingsUInt64 max_finished_sessions_cache_size;
     extern const CoordinationSettingsUInt64 max_request_queue_size;
     extern const CoordinationSettingsUInt64 max_requests_batch_bytes_size;
     extern const CoordinationSettingsUInt64 max_requests_batch_size;
@@ -930,7 +932,16 @@ void KeeperDispatcher::finishSession(int64_t session_id)
     /// still sitting in the queue for this session.
     {
         std::lock_guard lock(finished_sessions_mutex);
-        finished_sessions.insert(session_id);
+        if (finished_sessions.size() < configuration_and_settings->coordination_settings[CoordinationSetting::max_finished_sessions_cache_size])
+        {
+            finished_sessions.insert(session_id);
+        }
+        else
+        {
+            ProfileEvents::increment(ProfileEvents::KeeperFinishedSessionsCacheFull);
+            LOG_WARNING(log, "Finished sessions cache is full (size {}), session {} will not be tracked for stale request filtering",
+                finished_sessions.size(), session_id);
+        }
     }
 
     /// Notify the callback that session is being closed before removing it

--- a/src/Coordination/KeeperDispatcher.cpp
+++ b/src/Coordination/KeeperDispatcher.cpp
@@ -645,6 +645,21 @@ void KeeperDispatcher::initialize(const Poco::Util::AbstractConfiguration & conf
                                 if (finished_sessions.contains(read_request.session_id))
                                 {
                                     ProfileEvents::increment(ProfileEvents::KeeperStaleRequestsSkipped);
+
+                                    ZooKeeperOpentelemetrySpans::maybeFinalize(
+                                        read_request.request->spans.read_wait_for_write,
+                                        [&]
+                                        {
+                                            return std::vector<OpenTelemetry::SpanAttribute>{
+                                                {"keeper.operation", Coordination::opNumToString(read_request.request->getOpNum())},
+                                                {"keeper.session_id", read_request.session_id},
+                                                {"keeper.xid", read_request.request->xid},
+                                                {"keeper.stale", true},
+                                            };
+                                        },
+                                        OpenTelemetry::SpanStatus::ERROR,
+                                        "Session finished before read could execute");
+
                                     continue;
                                 }
                             }
@@ -946,7 +961,7 @@ void KeeperDispatcher::finishSession(int64_t session_id)
         else
         {
             ProfileEvents::increment(ProfileEvents::KeeperFinishedSessionsCacheFull);
-            LOG_WARNING(log, "Finished sessions cache is full (size {}), session {} will not be tracked for stale request filtering",
+            LOG_WARNING(LogFrequencyLimiter(log, 10), "Finished sessions cache is full (size {}), session {} will not be tracked for stale request filtering",
                 finished_sessions.size(), session_id);
         }
     }

--- a/src/Coordination/KeeperDispatcher.cpp
+++ b/src/Coordination/KeeperDispatcher.cpp
@@ -266,11 +266,13 @@ void KeeperDispatcher::requestThread()
                         {
                             CurrentMetrics::sub(CurrentMetrics::KeeperOutstandingRequests);
 
-                            handle_opentelemetery_spans(request.request, request.session_id);
-
-                            /// Skip stale requests for finished sessions during batch assembly
+                            /// Skip stale requests for finished sessions during batch assembly.
+                            /// Must be checked before span finalization to avoid leaking spans
+                            /// for requests that will be dropped without a response.
                             if (is_stale_session_request(request))
                                 return true; // consumed, keep draining
+
+                            handle_opentelemetery_spans(request.request, request.session_id);
 
                             /// Don't append read request into batch, we have to process them separately
                             if (!coordination_settings[CoordinationSetting::quorum_reads] && request.request->isReadRequest())
@@ -882,12 +884,17 @@ void KeeperDispatcher::sessionCleanerTask()
                         .request = std::move(request),
                         .digest = std::nullopt
                     };
+                    /// Mark session as finished before pushing Close to the queue.
+                    /// This prevents a race where Close commits and erases from
+                    /// `finished_sessions` before `finishSession` inserts it,
+                    /// which would permanently leak the session ID in the set.
+                    /// Close requests are exempt from stale filtering, so the
+                    /// Close will still pass through RAFT for ephemeral cleanup.
+                    finishSession(dead_session);
+
                     if (!requests_queue->push(std::move(request_info)))
                         LOG_INFO(log, "Cannot push close request to queue while cleaning outdated sessions");
                     CurrentMetrics::add(CurrentMetrics::KeeperOutstandingRequests);
-
-                    /// Remove session from registered sessions
-                    finishSession(dead_session);
                     LOG_INFO(log, "Dead session close request pushed");
                 }
             }

--- a/src/Coordination/KeeperDispatcher.cpp
+++ b/src/Coordination/KeeperDispatcher.cpp
@@ -52,6 +52,7 @@ namespace ProfileEvents
     extern const Event KeeperBatchMaxCount;
     extern const Event KeeperBatchMaxTotalSize;
     extern const Event KeeperRequestRejectedDueToSoftMemoryLimitCount;
+    extern const Event KeeperStaleRequestsSkipped;
 }
 
 namespace HistogramMetrics
@@ -204,6 +205,27 @@ void KeeperDispatcher::requestThread()
 
                 handle_opentelemetery_spans(request.request, request.session_id);
 
+                /// Skip stale requests for finished sessions.
+                /// Close must pass through RAFT (ephemeral cleanup, watch cleanup, etc.).
+                /// SessionID uses internal IDs (session_id = -1), ignore it just to be safe.
+                auto is_stale_session_request = [&](const KeeperRequestForSession & req) -> bool
+                {
+                    if (req.request->getOpNum() != Coordination::OpNum::Close
+                        && req.request->getOpNum() != Coordination::OpNum::SessionID)
+                    {
+                        std::lock_guard lock(finished_sessions_mutex);
+                        if (finished_sessions.contains(req.session_id))
+                        {
+                            ProfileEvents::increment(ProfileEvents::KeeperStaleRequestsSkipped);
+                            return true;
+                        }
+                    }
+                    return false;
+                };
+
+                if (is_stale_session_request(request))
+                    continue;
+
                 Int64 mem_soft_limit = keeper_context->getKeeperMemorySoftLimit();
                 if (configuration_and_settings->standalone_keeper && isExceedingMemorySoftLimit() && checkIfRequestIncreaseMem(request.request))
                 {
@@ -243,6 +265,10 @@ void KeeperDispatcher::requestThread()
                             CurrentMetrics::sub(CurrentMetrics::KeeperOutstandingRequests);
 
                             handle_opentelemetery_spans(request.request, request.session_id);
+
+                            /// Skip stale requests for finished sessions during batch assembly
+                            if (is_stale_session_request(request))
+                                return true; // consumed, keep draining
 
                             /// Don't append read request into batch, we have to process them separately
                             if (!coordination_settings[CoordinationSetting::quorum_reads] && request.request->isReadRequest())
@@ -365,10 +391,22 @@ void KeeperDispatcher::requestThread()
                 /// Read request always goes after write batch (last request)
                 if (has_read_request)
                 {
-                    if (server->isLeaderAlive())
-                        server->putLocalReadRequest({request});
+                    bool finished;
+                    {
+                        std::lock_guard lock(finished_sessions_mutex);
+                        finished = finished_sessions.contains(request.session_id);
+                    }
+                    if (!finished)
+                    {
+                        if (server->isLeaderAlive())
+                            server->putLocalReadRequest({request});
+                        else
+                            addErrorResponses({request}, Coordination::Error::ZCONNECTIONLOSS);
+                    }
                     else
-                        addErrorResponses({request}, Coordination::Error::ZCONNECTIONLOSS);
+                    {
+                        ProfileEvents::increment(ProfileEvents::KeeperStaleRequestsSkipped);
+                    }
                 }
             }
         }
@@ -531,6 +569,12 @@ bool KeeperDispatcher::putRequest(const Coordination::ZooKeeperRequestPtr & requ
 bool KeeperDispatcher::putLocalReadRequest(const Coordination::ZooKeeperRequestPtr & request, int64_t session_id)
 {
     {
+        std::lock_guard lock(finished_sessions_mutex);
+        if (finished_sessions.contains(session_id))
+            return false;
+    }
+
+    {
         /// If session was already disconnected than we will ignore requests
         std::lock_guard lock(session_to_response_callback_mutex);
         if (!session_to_response_callback.contains(session_id))
@@ -576,6 +620,14 @@ void KeeperDispatcher::initialize(const Poco::Util::AbstractConfiguration & conf
         snapshot_s3,
         [this](uint64_t /*log_idx*/, const KeeperRequestForSession & request_for_session)
         {
+            /// When Close commits, all prior requests for this session have been processed.
+            /// Remove from finished_sessions to reclaim memory.
+            if (request_for_session.request->getOpNum() == Coordination::OpNum::Close)
+            {
+                std::lock_guard lock(finished_sessions_mutex);
+                finished_sessions.erase(request_for_session.session_id);
+            }
+
             {
                 /// check if we have queue of read requests depending on this request to be committed
                 std::lock_guard lock(read_request_queue_mutex);
@@ -588,6 +640,16 @@ void KeeperDispatcher::initialize(const Poco::Util::AbstractConfiguration & conf
                     {
                         for (const auto & read_request : request_queue_it->second)
                         {
+                            /// Skip reads whose session has been finished
+                            {
+                                std::lock_guard flock(finished_sessions_mutex);
+                                if (finished_sessions.contains(read_request.session_id))
+                                {
+                                    ProfileEvents::increment(ProfileEvents::KeeperStaleRequestsSkipped);
+                                    continue;
+                                }
+                            }
+
                             if (!server->isLeaderAlive())
                             {
                                 addErrorResponses({read_request}, Coordination::Error::ZCONNECTIONLOSS);
@@ -838,6 +900,13 @@ void KeeperDispatcher::finishSession(int64_t session_id)
     /// shutdown() method will cleanup sessions if needed
     if (keeper_context->isShutdownCalled())
         return;
+
+    /// Mark session as finished FIRST to maximize the window where
+    /// requestThread can skip stale requests for this session.
+    {
+        std::lock_guard lock(finished_sessions_mutex);
+        finished_sessions.insert(session_id);
+    }
 
     ZooKeeperResponseCallback callback;
     {

--- a/src/Coordination/KeeperDispatcher.cpp
+++ b/src/Coordination/KeeperDispatcher.cpp
@@ -203,8 +203,6 @@ void KeeperDispatcher::requestThread()
                 if (shutdown_called)
                     break;
 
-                handle_opentelemetery_spans(request.request, request.session_id);
-
                 /// Skip stale requests for finished sessions.
                 /// Close must pass through RAFT (ephemeral cleanup, watch cleanup, etc.).
                 /// SessionID uses internal IDs (session_id = -1), ignore it just to be safe.
@@ -225,6 +223,8 @@ void KeeperDispatcher::requestThread()
 
                 if (is_stale_session_request(request))
                     continue;
+
+                handle_opentelemetery_spans(request.request, request.session_id);
 
                 Int64 mem_soft_limit = keeper_context->getKeeperMemorySoftLimit();
                 if (configuration_and_settings->standalone_keeper && isExceedingMemorySoftLimit() && checkIfRequestIncreaseMem(request.request))
@@ -571,7 +571,10 @@ bool KeeperDispatcher::putLocalReadRequest(const Coordination::ZooKeeperRequestP
     {
         std::lock_guard lock(finished_sessions_mutex);
         if (finished_sessions.contains(session_id))
+        {
+            ProfileEvents::increment(ProfileEvents::KeeperStaleRequestsSkipped);
             return false;
+        }
     }
 
     {
@@ -620,14 +623,6 @@ void KeeperDispatcher::initialize(const Poco::Util::AbstractConfiguration & conf
         snapshot_s3,
         [this](uint64_t /*log_idx*/, const KeeperRequestForSession & request_for_session)
         {
-            /// When Close commits, all prior requests for this session have been processed.
-            /// Remove from finished_sessions to reclaim memory.
-            if (request_for_session.request->getOpNum() == Coordination::OpNum::Close)
-            {
-                std::lock_guard lock(finished_sessions_mutex);
-                finished_sessions.erase(request_for_session.session_id);
-            }
-
             {
                 /// check if we have queue of read requests depending on this request to be committed
                 std::lock_guard lock(read_request_queue_mutex);
@@ -642,7 +637,7 @@ void KeeperDispatcher::initialize(const Poco::Util::AbstractConfiguration & conf
                         {
                             /// Skip reads whose session has been finished
                             {
-                                std::lock_guard flock(finished_sessions_mutex);
+                                std::lock_guard finished_lock(finished_sessions_mutex);
                                 if (finished_sessions.contains(read_request.session_id))
                                 {
                                     ProfileEvents::increment(ProfileEvents::KeeperStaleRequestsSkipped);
@@ -673,6 +668,16 @@ void KeeperDispatcher::initialize(const Poco::Util::AbstractConfiguration & conf
                         xid_to_request_queue.erase(request_queue_it);
                     }
                 }
+            }
+
+            /// When Close commits, all prior requests for this session have been processed.
+            /// Remove from finished_sessions to reclaim memory.
+            /// Done after the pending-read loop so reads queued for the closing session
+            /// are still filtered by the stale check above.
+            if (request_for_session.request->getOpNum() == Coordination::OpNum::Close)
+            {
+                std::lock_guard lock(finished_sessions_mutex);
+                finished_sessions.erase(request_for_session.session_id);
             }
         });
 

--- a/src/Coordination/KeeperDispatcher.cpp
+++ b/src/Coordination/KeeperDispatcher.cpp
@@ -217,6 +217,24 @@ void KeeperDispatcher::requestThread()
                         if (finished_sessions.contains(req.session_id))
                         {
                             ProfileEvents::increment(ProfileEvents::KeeperStaleRequestsSkipped);
+
+                            /// Finalize the dispatcher_requests_queue span that was initialized
+                            /// when the request was enqueued. Without this the span leaks because
+                            /// handle_opentelemetery_spans (which normally finalizes it) is skipped.
+                            ZooKeeperOpentelemetrySpans::maybeFinalize(
+                                req.request->spans.dispatcher_requests_queue,
+                                [&]
+                                {
+                                    return std::vector<OpenTelemetry::SpanAttribute>{
+                                        {"keeper.operation", Coordination::opNumToString(req.request->getOpNum())},
+                                        {"keeper.session_id", req.session_id},
+                                        {"keeper.xid", req.request->xid},
+                                        {"keeper.stale", true},
+                                    };
+                                },
+                                OpenTelemetry::SpanStatus::ERROR,
+                                "Session finished before request could execute");
+
                             return true;
                         }
                     }
@@ -267,8 +285,6 @@ void KeeperDispatcher::requestThread()
                             CurrentMetrics::sub(CurrentMetrics::KeeperOutstandingRequests);
 
                             /// Skip stale requests for finished sessions during batch assembly.
-                            /// Must be checked before span finalization to avoid leaking spans
-                            /// for requests that will be dropped without a response.
                             if (is_stale_session_request(request))
                                 return true; // consumed, keep draining
 
@@ -409,7 +425,12 @@ void KeeperDispatcher::requestThread()
                     }
                     else
                     {
+                        /// The session became finished after the initial stale check
+                        /// (e.g. a Close was committed in the preceding write batch).
+                        /// The dispatcher_requests_queue span was already finalized
+                        /// at handle_opentelemetery_spans above.
                         ProfileEvents::increment(ProfileEvents::KeeperStaleRequestsSkipped);
+                        LOG_TRACE(log, "Dropping stale read request for finished session {}, xid {}", request.session_id, request.request->xid);
                     }
                 }
             }

--- a/src/Coordination/KeeperDispatcher.h
+++ b/src/Coordination/KeeperDispatcher.h
@@ -9,6 +9,7 @@
 #include <Common/ConcurrentBoundedQueue.h>
 #include <Poco/Util/AbstractConfiguration.h>
 #include <functional>
+#include <unordered_set>
 #include <Coordination/KeeperServer.h>
 #include <Coordination/Keeper4LWInfo.h>
 #include <Coordination/KeeperConnectionStats.h>
@@ -37,6 +38,9 @@ private:
 
     /// More than 1k updates is definitely misconfiguration.
     ClusterUpdateQueue cluster_update_queue{1000};
+
+    mutable std::mutex finished_sessions_mutex;
+    std::unordered_set<int64_t> finished_sessions;
 
     mutable std::mutex session_to_response_callback_mutex;
     /// These two maps looks similar, but serves different purposes.


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Skip stale Keeper requests for sessions that have already disconnected, avoiding unnecessary Raft round-trips. The number of tracked finished sessions is capped by the `max_finished_sessions_cache_size` coordination setting.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Keeper request dispatch/batching and session shutdown paths, so mistakes could drop valid requests or leak/retain session IDs; changes are guarded by Close exemptions and a bounded cache but still affect coordination correctness under races.
> 
> **Overview**
> Keeper now tracks recently finished sessions and **skips stale queued requests** for those sessions (including during batch assembly and delayed local reads), avoiding extra Raft round-trips.
> 
> This introduces a new coordination setting `max_finished_sessions_cache_size` to cap tracking, adds profile events `KeeperStaleRequestsSkipped` / `KeeperFinishedSessionsCacheFull`, and adjusts session-close ordering/cleanup to avoid races and ensure OpenTelemetry spans are finalized when requests are dropped.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1a5a49d439e88e4c0ceb69d3d7c2ba97a418164. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.712`
<!-- ch-version-info:end -->