### PR TITLE
CI fix: suppress `Expression must be deterministic` error in upgrade check

### DIFF
--- a/tests/docker_scripts/upgrade_runner.sh
+++ b/tests/docker_scripts/upgrade_runner.sh
@@ -378,6 +378,7 @@ rg -Fav -e "Code: 236. DB::Exception: Cancelled merging parts" \
            -e "Mapping for table with UUID=1f474183-1403-4282-9309-21f6e3518dab already exists" \
            -e "Cannot parse projection test_projection" \
            -e "Key expressions cannot contain subqueries" \
+           -e "Expression must be deterministic but it contains non-deterministic part" \
     /test_output/clickhouse-server.upgrade.log \
     | grep -av -e "_repl_01111_.*Mapping for table with UUID" \
     | grep -Fa "<Error>" > /test_output/upgrade_error_messages.txt || true


### PR DESCRIPTION
Fix upgrade check failure. also ref #99193 


    PR #91352 (`ebd57e470fe`) introduced alias expansion in
    `fillProjectionDescriptionByQuery`, which causes `ORDER BY value` (where
    `value` is an alias for `dictGet(...)`) to expand to `ORDER BY dictGet(...)`,
    triggering `assertDeterministic` failure during `ATTACH TABLE` on upgrade.

    Tables created by the previous release binary with such projections fail to
    attach after upgrading to the new binary, producing:

    Expression must be deterministic but it contains non-deterministic part `dictGet(...)`: for Sorting key

    This is a transient upgrade-path issue: once 26.3 becomes stable (which
    includes the test fix `d15162f`), the previous stable binary will no longer
    create such tables and this filter can be removed.

    Follow the same pattern as the `"Key expressions cannot contain subqueries"`
    suppression added for PR #97421.


2026.03.11 08:26:00.527304 [ 1173571 ] {} <Error> void DB::AsyncLoader::worker(Pool &): Code: 36. DB::Exception: Expression must be deterministic but it contains non-deterministic part `dictGet(\'test_5.parts_dict\', \'value\', metric)`: for Sorting key: Cannot attach table `test_5`.`parts_metrics` from metadata file 

FAIL	[Error message in clickhouse-server.log](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=98828&sha=4bd3295d9617d36afa98876711506066c0309fb7&name_0=PR&name_1=Upgrade%20check%20%28amd_release%29
https://github.com/ClickHouse/ClickHouse/pull/98828) (see upgrade_error_messages.txt) [cidb](https://play.clickhouse.com/play?user=play&run=1#V0lUSAogICAgOTAgQVMgaW50ZXJ2YWxfZGF5cwpTRUxFQ1QKICAgIHRvU3RhcnRPZkRheShjaGVja19zdGFydF90aW1lKSBBUyBkYXksCiAgICBjb3VudCgpIEFTIGZhaWx1cmVzLAogICAgZ3JvdXBVbmlxQXJyYXkocHVsbF9yZXF1ZXN0X251bWJlcikgQVMgcHJzLAogICAgYW55KHJlcG9ydF91cmwpIEFTIHJlcG9ydF91cmwKRlJPTSBjaGVja3MKV0hFUkUgKG5vdygpIC0gdG9JbnRlcnZhbERheShpbnRlcnZhbF9kYXlzKSkgPD0gY2hlY2tfc3RhcnRfdGltZQogICAgQU5EIHRlc3RfbmFtZSA9ICdFcnJvciBtZXNzYWdlIGluIGNsaWNraG91c2Utc2VydmVyLmxvZyAoc2VlIHVwZ3JhZGVfZXJyb3JfbWVzc2FnZXMudHh0KScKICAgIC0tIEFORCBjaGVja19uYW1lID0gJ1VwZ3JhZGUgY2hlY2sgKGFtZF9yZWxlYXNlKScKICAgIEFORCB0ZXN0X3N0YXR1cyBJTiAoJ0ZBSUwnLCAnRVJST1InKQogICAgQU5EIChwdWxsX3JlcXVlc3RfbnVtYmVyID0gMCBPUiBiYXNlX3JlZiBJTiAoJ21hc3RlcicpKQogICAgQU5EIHRlc3RfY29udGV4dF9yYXcgTElLRSAnJUNvZGU6JScKR1JPVVAgQlkgZGF5Ck9SREVSIEJZIGRheSBERVNDCg==)

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only the CI upgrade log allowlist, reducing false negatives without affecting production code paths.
> 
> **Overview**
> The upgrade test runner now *ignores* server log errors matching `Expression must be deterministic but it contains non-deterministic part` when scanning `clickhouse-server.upgrade.log`, preventing known transient upgrade-path failures from failing CI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f7c4b693ae1aefa92822b270f80cc67f7e45d11. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.593`
<!-- ch-version-info:end -->