### PR TITLE
Fuzzer fixes

### DIFF
--- a/src/Client/BuzzHouse/Generator/QueryOracle.cpp
+++ b/src/Client/BuzzHouse/Generator/QueryOracle.cpp
@@ -176,7 +176,7 @@ void QueryOracle::generateRoundtripOracleQueries(RandomGenerator & rg, Statement
     for (const auto & rel : gen.levels[gen.current_level].rels)
         for (const auto & c : rel.cols)
             all_cols.push_back(&c);
-    if (all_cols.empty())
+    if (!all_cols.empty())
     {
         const SQLRelationCol & rel_col = *rg.pickRandomly(all_cols);
 

--- a/src/Common/QueryFuzzer.cpp
+++ b/src/Common/QueryFuzzer.cpp
@@ -1080,14 +1080,7 @@ void QueryFuzzer::fuzzProjectionDeclaration(ASTProjectionDeclaration & projectio
     if (!query)
         return;
 
-    /// Toggle GROUP BY presence: removes it to convert an aggregate projection to a normal one
-    /// (or vice versa if re-added externally). This exercises both projection variants.
-    if (query->groupBy() && fuzz_rand() % 10 == 0)
-        query->setExpression(ASTProjectionSelectQuery::Expression::GROUP_BY, {});
-
-    /// Toggle ORDER BY presence: changes sort order stored in the projection data part.
-    if (query->orderBy() && fuzz_rand() % 10 == 0)
-        query->setExpression(ASTProjectionSelectQuery::Expression::ORDER_BY, {});
+    /// TODO finish this soon
 
     /// Fuzz the SELECT expression list and any remaining sub-expressions
     fuzz(query->children);

--- a/src/Common/QueryFuzzer.cpp
+++ b/src/Common/QueryFuzzer.cpp
@@ -1076,14 +1076,9 @@ void QueryFuzzer::fuzzIndexDeclaration(ASTIndexDeclaration & index)
 
 void QueryFuzzer::fuzzProjectionDeclaration(ASTProjectionDeclaration & projection)
 {
-    auto * query = projection.query ? projection.query->as<ASTProjectionSelectQuery>() : nullptr;
-    if (!query)
-        return;
+    UNUSED(projection);
 
     /// TODO finish this soon
-
-    /// Fuzz the SELECT expression list and any remaining sub-expressions
-    fuzz(query->children);
 }
 
 DataTypePtr QueryFuzzer::fuzzDataType(DataTypePtr type)


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

https://github.com/ClickHouse/ClickHouse/pull/99161 broke the AST fuzzer on projections. I am also fixing a bad check on BuzzHouse.

Closes https://github.com/ClickHouse/ClickHouse/issues/99261

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to fuzzing/oracle test code, mainly preventing invalid AST mutations and fixing an inverted empty-check that could select from an empty column list.
> 
> **Overview**
> Fixes a logic bug in BuzzHouse `QueryOracle::generateRoundtripOracleQueries` where column selection was attempted only when the collected column list was empty, now correctly selecting a real column when available and falling back to a constant otherwise.
> 
> Disables `QueryFuzzer::fuzzProjectionDeclaration`’s projection-query mutations (now a no-op with a TODO) to avoid breaking the AST fuzzer on projection declarations after recent AST changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35bf2fd581f79b99134a61d8b5d22afe941f29fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.583`
<!-- ch-version-info:end -->