### PR TITLE
Sync files in OSS from private repo

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -68,6 +68,7 @@ static struct InitFiu
     REGULAR(file_cache_stall_free_space_ratio_keeping_thread) \
     REGULAR(distributed_cache_fail_connect_non_retriable) \
     REGULAR(distributed_cache_fail_connect_retriable) \
+    REGULAR(write_through_cache_fail) \
     REGULAR(object_storage_queue_fail_commit) \
     REGULAR(object_storage_queue_fail_after_insert) \
     REGULAR(object_storage_queue_fail_startup) \

--- a/src/Core/ServerSettings.cpp
+++ b/src/Core/ServerSettings.cpp
@@ -1273,6 +1273,11 @@ The policy on how to perform a scheduling of CPU slots specified by `concurrent_
 
     Possible values: -20 to 19.
     )", 0) \
+    DECLARE(UInt64, max_zookeeper_pooled_connections, 0, R"(
+    Maximum number of lazily initialized ZooKeeper sessions per ZooKeeper cluster in the shared pool.
+
+    A value of `0` disables pooled connections and keeps using a single session.
+    )", 0) \
     DECLARE(Int32, os_threads_nice_value_distributed_cache_tcp_handler, 0, R"(
     Linux nice value for the threads of distributed cache TCP handler. Lower values mean higher CPU priority.
 

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -1084,17 +1084,20 @@ const VersionToSettingsChangesMap & getMergeTreeSettingsChangesHistory()
         {
             {"vertical_merge_optimize_ttl_delete", false, true, "Allow vertical merge algorithm for merges that need to remove rows expired by TTL"},
             {"shared_merge_tree_replica_set_max_lifetime_seconds", 300, 300, "New setting"},
+            {"auto_statistics_types", "", "minmax, uniq", "Enable auto statistics by default"},
             {"table_readonly", false, false, "New setting to mark table as read-only, preventing inserts and modifications"},
             {"propagate_types_serialization_versions_to_nested_types", false, true, "Propagate data types serialization version to nested types by default"},
         });
         addSettingsChanges(merge_tree_settings_changes_history, "26.2",
         {
+            {"shared_merge_tree_use_zookeeper_connection_pool", false, false, "New setting"},
             {"clone_replica_zookeeper_create_get_part_batch_size", 1, 100, "New setting"},
             {"add_minmax_index_for_temporal_columns", false, false, "New setting"},
             {"distributed_index_analysis_min_parts_to_activate", 10, 10, "New setting"},
             {"distributed_index_analysis_min_indexes_bytes_to_activate", 1_GiB, 1_GiB, "New setting"},
             {"refresh_statistics_interval", 0, 300, "Enable statistics cache"},
             {"enable_max_bytes_limit_for_min_age_to_force_merge", false, true, "Limit part sizes even with min_age_to_force_merge_seconds by default"},
+            {"auto_statistics_types", "", "minmax, uniq", "Enable auto statistics by default"},
             {"shared_merge_tree_replica_set_max_lifetime_seconds", 300, 300, "New setting"},
             {"shared_merge_tree_enable_automatic_empty_partitions_cleanup", false, true, "Enable by default"},
         });

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -1084,7 +1084,6 @@ const VersionToSettingsChangesMap & getMergeTreeSettingsChangesHistory()
         {
             {"vertical_merge_optimize_ttl_delete", false, true, "Allow vertical merge algorithm for merges that need to remove rows expired by TTL"},
             {"shared_merge_tree_replica_set_max_lifetime_seconds", 300, 300, "New setting"},
-            {"auto_statistics_types", "", "minmax, uniq", "Enable auto statistics by default"},
             {"table_readonly", false, false, "New setting to mark table as read-only, preventing inserts and modifications"},
             {"propagate_types_serialization_versions_to_nested_types", false, true, "Propagate data types serialization version to nested types by default"},
             {"shared_merge_tree_use_zookeeper_connection_pool", false, false, "New setting"},
@@ -1097,7 +1096,6 @@ const VersionToSettingsChangesMap & getMergeTreeSettingsChangesHistory()
             {"distributed_index_analysis_min_indexes_bytes_to_activate", 1_GiB, 1_GiB, "New setting"},
             {"refresh_statistics_interval", 0, 300, "Enable statistics cache"},
             {"enable_max_bytes_limit_for_min_age_to_force_merge", false, true, "Limit part sizes even with min_age_to_force_merge_seconds by default"},
-            {"auto_statistics_types", "", "minmax, uniq", "Enable auto statistics by default"},
             {"shared_merge_tree_replica_set_max_lifetime_seconds", 300, 300, "New setting"},
             {"shared_merge_tree_enable_automatic_empty_partitions_cleanup", false, true, "Enable by default"},
         });

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -1087,10 +1087,10 @@ const VersionToSettingsChangesMap & getMergeTreeSettingsChangesHistory()
             {"auto_statistics_types", "", "minmax, uniq", "Enable auto statistics by default"},
             {"table_readonly", false, false, "New setting to mark table as read-only, preventing inserts and modifications"},
             {"propagate_types_serialization_versions_to_nested_types", false, true, "Propagate data types serialization version to nested types by default"},
+            {"shared_merge_tree_use_zookeeper_connection_pool", false, false, "New setting"},
         });
         addSettingsChanges(merge_tree_settings_changes_history, "26.2",
         {
-            {"shared_merge_tree_use_zookeeper_connection_pool", false, false, "New setting"},
             {"clone_replica_zookeeper_create_get_part_batch_size", 1, 100, "New setting"},
             {"add_minmax_index_for_temporal_columns", false, false, "New setting"},
             {"distributed_index_analysis_min_parts_to_activate", 10, 10, "New setting"},

--- a/src/Parsers/ParserBackupQuery.h
+++ b/src/Parsers/ParserBackupQuery.h
@@ -13,7 +13,20 @@ namespace DB
   *          ALL [EXCEPT {TABLES|DATABASES}...] } [,...]
   *        [ON CLUSTER 'cluster_name']
   *        TO { File('path/') |
-  *             Disk('disk_name', 'path/') }
+  *             Disk('disk_name', 'path/') |
+  *             S3('path/' [, 'aws_access_key_id', 'aws_secret_access_key']) |
+  *             AzureBlobStorage(
+  *                 'connection_string' | 'storage_account_url', 'container_name', 'blobpath'
+  *             )
+  *           }
+  *        [SETTINGS ...]
+  *
+  * BACKUP FROM SNAPSHOT { S3(...) | AzureBlobStorage(...) }
+  *        TO { File('path/') |
+  *             Disk('disk_name', 'path/') |
+  *             S3(...) |
+  *             AzureBlobStorage(...)
+  *           }
   *        [SETTINGS ...]
   *
   * RESTORE { TABLE [db.]table_name_in_backup [AS [db.]table_name] [PARTITION[S] partition_expr [,...]] |

--- a/src/Parsers/ParserQueryWithOutput.cpp
+++ b/src/Parsers/ParserQueryWithOutput.cpp
@@ -22,6 +22,7 @@
 #include <Parsers/ParserShowFunctionsQuery.h>
 #include <Parsers/ParserShowIndexesQuery.h>
 #include <Parsers/ParserShowSettingQuery.h>
+#include <Parsers/ParserSnapshotQuery.h>
 #include <Parsers/ParserTablePropertiesQuery.h>
 #include <Parsers/ParserWatchQuery.h>
 #include <Parsers/ParserDescribeCacheQuery.h>
@@ -66,6 +67,7 @@ bool ParserQueryWithOutput::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
     ParserShowPrivilegesQuery show_privileges_p;
     ParserExplainQuery explain_p(end, allow_settings_after_format_in_insert);
     ParserBackupQuery backup_p;
+    ParserSnapshotQuery snapshot_p;
 
     ASTPtr query;
 
@@ -96,7 +98,8 @@ bool ParserQueryWithOutput::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
         || show_access_entities_p.parse(pos, query, expected)
         || show_grants_p.parse(pos, query, expected)
         || show_privileges_p.parse(pos, query, expected)
-        || backup_p.parse(pos, query, expected);
+        || backup_p.parse(pos, query, expected)
+        || snapshot_p.parse(pos, query, expected);
 
     if (!parsed)
         return false;

--- a/src/Parsers/ParserSnapshotQuery.cpp
+++ b/src/Parsers/ParserSnapshotQuery.cpp
@@ -1,0 +1,149 @@
+#include <Parsers/ASTFunction.h>
+#include <Parsers/ASTSnapshotQuery.h>
+#include <Parsers/CommonParsers.h>
+#include <Parsers/ExpressionElementParsers.h>
+#include <Parsers/ExpressionListParsers.h>
+#include <Parsers/ParserSnapshotQuery.h>
+#include <Parsers/parseDatabaseAndTableName.h>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+extern const int SYNTAX_ERROR;
+}
+namespace
+{
+using Element = ASTSnapshotQuery::Element;
+using ElementType = ASTSnapshotQuery::ElementType;
+
+bool parseExceptDatabases(IParser::Pos & pos, Expected & expected, std::set<String> & except_databases)
+{
+    return IParserBase::wrapParseImpl(
+        pos,
+        [&]
+        {
+            if (!ParserKeyword(Keyword::EXCEPT_DATABASE).ignore(pos, expected)
+                && !ParserKeyword(Keyword::EXCEPT_DATABASES).ignore(pos, expected))
+                return false;
+
+            std::set<String> result;
+            auto parse_list_element = [&]
+            {
+                ASTPtr ast;
+                if (!ParserIdentifier{}.parse(pos, ast, expected))
+                    return false;
+                result.insert(getIdentifierName(ast));
+                return true;
+            };
+            if (!ParserList::parseUtil(pos, expected, parse_list_element, false))
+                return false;
+
+            except_databases = std::move(result);
+            return true;
+        });
+}
+
+bool parseExceptTables(
+    IParser::Pos & pos, Expected & expected, const std::optional<String> & database_name, std::set<DatabaseAndTableName> & except_tables)
+{
+    return IParserBase::wrapParseImpl(
+        pos,
+        [&]
+        {
+            if (!ParserKeyword(Keyword::EXCEPT_TABLE).ignore(pos, expected) && !ParserKeyword(Keyword::EXCEPT_TABLES).ignore(pos, expected))
+                return false;
+
+            std::set<DatabaseAndTableName> result;
+            auto parse_list_element = [&]
+            {
+                DatabaseAndTableName table_name;
+
+                if (!parseDatabaseAndTableName(pos, expected, table_name.first, table_name.second))
+                    return false;
+
+                if (database_name && table_name.first.empty())
+                    table_name.first = *database_name;
+
+                if (database_name && table_name.first != *database_name)
+                    throw Exception(
+                        ErrorCodes::SYNTAX_ERROR,
+                        "Database name in EXCEPT TABLES clause doesn't match the database name in DATABASE clause: {} != {}",
+                        table_name.first,
+                        *database_name);
+
+                result.emplace(std::move(table_name));
+                return true;
+            };
+            if (!ParserList::parseUtil(pos, expected, parse_list_element, false))
+                return false;
+
+            except_tables = std::move(result);
+            return true;
+        });
+}
+
+bool parseElement(IParser::Pos & pos, Expected & expected, Element & element)
+{
+    return IParserBase::wrapParseImpl(
+        pos,
+        [&]
+        {
+            if (ParserKeyword(Keyword::TABLE).ignore(pos, expected))
+            {
+                element.type = ElementType::TABLE;
+                if (!parseDatabaseAndTableName(pos, expected, element.database_name, element.table_name))
+                    return false;
+
+                return true;
+            }
+            if (ParserKeyword(Keyword::ALL).ignore(pos, expected))
+            {
+                element.type = ElementType::ALL;
+                parseExceptDatabases(pos, expected, element.except_databases);
+                parseExceptTables(pos, expected, {}, element.except_tables);
+                return true;
+            }
+            return false;
+        });
+}
+
+bool parseSnapshotDestination(IParser::Pos & pos, Expected & expected, ASTPtr & snapshot_destination)
+{
+    if (!ParserIdentifierWithOptionalParameters{}.parse(pos, snapshot_destination, expected))
+        return false;
+
+    snapshot_destination->as<ASTFunction &>().setKind(ASTFunction::Kind::BACKUP_NAME);
+    return true;
+}
+}
+
+bool ParserSnapshotQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+{
+    if (!ParserKeyword(Keyword::SNAPSHOT).ignore(pos, expected))
+        return false;
+
+    Element element;
+    if (!parseElement(pos, expected, element))
+        return false;
+
+    if (!ParserKeyword(Keyword::TO).ignore(pos, expected))
+        return false;
+
+    ASTPtr snapshot_destination;
+    if (!parseSnapshotDestination(pos, expected, snapshot_destination))
+        return false;
+
+    auto query = make_intrusive<ASTSnapshotQuery>();
+    node = query;
+
+    query->element = std::move(element);
+
+    if (snapshot_destination)
+        query->set(query->snapshot_destination, snapshot_destination);
+
+    return true;
+}
+
+}

--- a/src/Parsers/ParserSnapshotQuery.h
+++ b/src/Parsers/ParserSnapshotQuery.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <Parsers/IParserBase.h>
+
+
+namespace DB
+{
+/**
+ * Parses queries like
+ * SNAPSHOT {
+ *     TABLE [db.]table_name
+ *   | ALL
+ *         [EXCEPT
+ *             { TABLE table_name
+ *             | TABLES table_name [, ...]
+ *             | DATABASE database_name
+ *             | DATABASES database_name [, ...]
+ *             }
+ *             [, ...]
+ *         ]
+ * } [, ...]
+ * TO {
+ *     S3('path/', ['aws_access_key_id', 'aws_secret_access_key'])
+ *   | AzureBlobStorage('connection_string'|'storage_account_url', 'container_name', 'blobpath')
+ * }
+ */
+class ParserSnapshotQuery : public IParserBase
+{
+protected:
+    const char * getName() const override { return "SNAPSHOT"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+};
+
+}

--- a/src/Storages/MergeTree/MergeTreeSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeSettings.cpp
@@ -1356,6 +1356,9 @@ namespace ErrorCodes
     Stop merges assignment for shared merge tree. Only available in ClickHouse
     Cloud
     )", 0) \
+    DECLARE(Bool, shared_merge_tree_use_zookeeper_connection_pool, false, R"(
+    If enabled, SharedMergeTree uses one of server-level pooled ZooKeeper sessions.
+    )", 0) \
     DECLARE(Bool, shared_merge_tree_enable_outdated_parts_check, true, R"(
     Enable outdated parts check. Only available in ClickHouse Cloud
     )", 0) \


### PR DESCRIPTION
Follow-up on https://github.com/ClickHouse/ClickHouse/pull/99098
Sync critical files to match private PR https://github.com/ClickHouse/clickhouse-private/pull/42472 and others.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new top-level `SNAPSHOT ... TO ...` SQL statement and introduces new ZooKeeper connection pooling knobs, which could affect parsing and coordination behavior if enabled/misconfigured.
> 
> **Overview**
> Adds support for a new `SNAPSHOT` SQL statement by introducing `ParserSnapshotQuery`/`ASTSnapshotQuery` and wiring it into `ParserQueryWithOutput` (including support for `ALL` and `EXCEPT TABLES/DATABASES` clauses and `TO` destinations).
> 
> Introduces ZooKeeper connection pooling configuration via a new server setting `max_zookeeper_pooled_connections` and a new MergeTree setting `shared_merge_tree_use_zookeeper_connection_pool` (recorded in `SettingsChangesHistory`). Also adds a new failpoint `write_through_cache_fail` and updates backup parser documentation comments to mention additional destinations (e.g., S3/Azure) and “BACKUP FROM SNAPSHOT” syntax.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 89828e5c1e0321b3ecc181b567f8235d13627bc9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->