### PR TITLE
Allow skipping last N shards when writing to Distributed table

### DIFF
--- a/src/Interpreters/Cluster.cpp
+++ b/src/Interpreters/Cluster.cpp
@@ -433,6 +433,9 @@ Cluster::Cluster(const Poco::Util::AbstractConfiguration & config,
     allow_distributed_ddl_queries = config.getBool(config_prefix + "allow_distributed_ddl_queries", true);
     std::erase(config_keys, "allow_distributed_ddl_queries");
 
+    active_insert_shard_nums = config.getInt(config_prefix + "active_insert_shard_nums", 0);
+    std::erase(config_keys, "active_insert_shard_nums");
+
     if (config_keys.empty())
         throw Exception(ErrorCodes::SHARD_HAS_NO_CONNECTIONS, "No cluster elements (shard, node) specified in config at path {}", config_prefix);
 

--- a/src/Interpreters/Cluster.h
+++ b/src/Interpreters/Cluster.h
@@ -262,6 +262,14 @@ public:
     /// The number of all shards.
     size_t getShardCount() const { return shards_info.size(); }
 
+    /// The number of active insert shards.
+    size_t getActiveInsertShardCount() const
+    {
+        if (active_insert_shard_nums == 0 || active_insert_shard_nums >= shards_info.size())
+            return shards_info.size();
+        return active_insert_shard_nums;
+    }
+
     /// Returns an array of arrays of strings in the format 'escaped_host_name:port' for all replicas of all shards in the cluster.
     std::vector<Strings> getHostIDs() const;
 
@@ -313,6 +321,9 @@ private:
 
     /// Inter-server secret
     String secret;
+
+    /// The number of active insert shards
+    size_t active_insert_shard_nums = 0;
 
     /// Description of the cluster shards.
     ShardsInfo shards_info;

--- a/src/Interpreters/createBlockSelector.cpp
+++ b/src/Interpreters/createBlockSelector.cpp
@@ -21,9 +21,12 @@ namespace ErrorCodes
 template <typename T>
 IColumn::Selector createBlockSelector(
     const IColumn & column,
-    const std::vector<UInt64> & slots)
+    const std::vector<UInt64> & slots,
+    const size_t num_shards)
 {
-    const auto total_weight = slots.size();
+    size_t total_weight = 0;
+    while(total_weight < slots.size() && slots[total_weight] < num_shards)
+        ++total_weight;
     if (total_weight == 0)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "weight is zero");
 
@@ -61,13 +64,13 @@ IColumn::Selector createBlockSelector(
 
 
 /// Explicit instantiations to avoid code bloat in headers.
-template IColumn::Selector createBlockSelector<UInt8>(const IColumn & column, const std::vector<UInt64> & slots);
-template IColumn::Selector createBlockSelector<UInt16>(const IColumn & column, const std::vector<UInt64> & slots);
-template IColumn::Selector createBlockSelector<UInt32>(const IColumn & column, const std::vector<UInt64> & slots);
-template IColumn::Selector createBlockSelector<UInt64>(const IColumn & column, const std::vector<UInt64> & slots);
-template IColumn::Selector createBlockSelector<Int8>(const IColumn & column, const std::vector<UInt64> & slots);
-template IColumn::Selector createBlockSelector<Int16>(const IColumn & column, const std::vector<UInt64> & slots);
-template IColumn::Selector createBlockSelector<Int32>(const IColumn & column, const std::vector<UInt64> & slots);
-template IColumn::Selector createBlockSelector<Int64>(const IColumn & column, const std::vector<UInt64> & slots);
+template IColumn::Selector createBlockSelector<UInt8>(const IColumn & column, const std::vector<UInt64> & slots, const size_t num_shards);
+template IColumn::Selector createBlockSelector<UInt16>(const IColumn & column, const std::vector<UInt64> & slots, const size_t num_shards);
+template IColumn::Selector createBlockSelector<UInt32>(const IColumn & column, const std::vector<UInt64> & slots, const size_t num_shards);
+template IColumn::Selector createBlockSelector<UInt64>(const IColumn & column, const std::vector<UInt64> & slots, const size_t num_shards);
+template IColumn::Selector createBlockSelector<Int8>(const IColumn & column, const std::vector<UInt64> & slots, const size_t num_shards);
+template IColumn::Selector createBlockSelector<Int16>(const IColumn & column, const std::vector<UInt64> & slots, const size_t num_shards);
+template IColumn::Selector createBlockSelector<Int32>(const IColumn & column, const std::vector<UInt64> & slots, const size_t num_shards);
+template IColumn::Selector createBlockSelector<Int64>(const IColumn & column, const std::vector<UInt64> & slots, const size_t num_shards);
 
 }

--- a/src/Interpreters/createBlockSelector.h
+++ b/src/Interpreters/createBlockSelector.h
@@ -21,6 +21,7 @@ namespace DB
 template <typename T>
 IColumn::Selector createBlockSelector(
     const IColumn & column,
-    const std::vector<UInt64> & slots);
+    const std::vector<UInt64> & slots,
+    const size_t num_shards);
 
 }

--- a/src/Storages/Distributed/DistributedSink.cpp
+++ b/src/Storages/Distributed/DistributedSink.cpp
@@ -198,7 +198,7 @@ void DistributedSink::writeAsync(const Block & block)
 {
     if (random_shard_insert)
     {
-        writeAsyncImpl(block, storage.getRandomShardIndex(cluster->getShardsInfo()));
+        writeAsyncImpl(block, storage.getRandomShardIndex(cluster));
         ++inserted_blocks;
     }
     else
@@ -478,11 +478,10 @@ void DistributedSink::writeSync(const Block & block)
     OpenTelemetry::SpanHolder span(__PRETTY_FUNCTION__);
 
     const Settings & settings = context->getSettingsRef();
-    const auto & shards_info = cluster->getShardsInfo();
     Block block_to_send = removeSuperfluousColumns(block);
 
     size_t start = 0;
-    size_t end = shards_info.size();
+    size_t end = cluster->getActiveInsertShardCount();
 
     if (settings[Setting::insert_shard_id])
     {
@@ -516,7 +515,7 @@ void DistributedSink::writeSync(const Block & block)
 
     if (random_shard_insert)
     {
-        start = storage.getRandomShardIndex(shards_info);
+        start = storage.getRandomShardIndex(cluster);
         end = start + 1;
     }
 
@@ -674,17 +673,17 @@ Blocks DistributedSink::splitBlock(const Block & block)
 
     /// Split block to num_shard smaller block, using 'selector'.
 
-    const size_t num_shards = cluster->getShardsInfo().size();
-    Blocks split_blocks(num_shards);
+    const size_t active_num_shards = cluster->getActiveInsertShardCount();
+    Blocks split_blocks(active_num_shards);
 
-    for (size_t shard_idx = 0; shard_idx < num_shards; ++shard_idx)
+    for (size_t shard_idx = 0; shard_idx < active_num_shards; ++shard_idx)
         split_blocks[shard_idx] = block.cloneEmpty();
 
     size_t columns_in_block = block.columns();
     for (size_t col_idx_in_block = 0; col_idx_in_block < columns_in_block; ++col_idx_in_block)
     {
-        MutableColumns split_columns = block.getByPosition(col_idx_in_block).column->scatter(num_shards, selector);
-        for (size_t shard_idx = 0; shard_idx < num_shards; ++shard_idx)
+        MutableColumns split_columns = block.getByPosition(col_idx_in_block).column->scatter(active_num_shards, selector);
+        for (size_t shard_idx = 0; shard_idx < active_num_shards; ++shard_idx)
             split_blocks[shard_idx].getByPosition(col_idx_in_block).column = std::move(split_columns[shard_idx]);
     }
 

--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -1724,15 +1724,16 @@ IColumn::Selector StorageDistributed::createSelector(const ClusterPtr cluster, c
 {
     const auto & slot_to_shard = cluster->getSlotToShard();
     const IColumn * column = result.column.get();
+    const auto active_num_shards = cluster->getActiveInsertShardCount();
 
 /// NOLINTBEGIN(readability-else-after-return)
 // If result.type is DataTypeLowCardinality, do shard according to its dictionaryType
 #define CREATE_FOR_TYPE(TYPE)                                                                                       \
     if (typeid_cast<const DataType##TYPE *>(result.type.get()))                                                     \
-        return createBlockSelector<TYPE>(*column, slot_to_shard);                                            \
+        return createBlockSelector<TYPE>(*column, slot_to_shard, active_num_shards);                                \
     else if (auto * type_low_cardinality = typeid_cast<const DataTypeLowCardinality *>(result.type.get()))          \
         if (typeid_cast<const DataType ## TYPE *>(type_low_cardinality->getDictionaryType().get()))                 \
-            return createBlockSelector<TYPE>(*column->convertToFullColumnIfLowCardinality(), slot_to_shard);
+            return createBlockSelector<TYPE>(*column->convertToFullColumnIfLowCardinality(), slot_to_shard, active_num_shards);
 
     CREATE_FOR_TYPE(UInt8)
     CREATE_FOR_TYPE(UInt16)
@@ -1946,12 +1947,14 @@ void StorageDistributed::rename(const String & new_path_to_table_data, const Sto
 }
 
 
-size_t StorageDistributed::getRandomShardIndex(const Cluster::ShardsInfo & shards)
+size_t StorageDistributed::getRandomShardIndex(const ClusterPtr & cluster)
 {
 
+    size_t active_num_shards = cluster->getActiveInsertShardCount();
+    auto & shards = cluster->getShardsInfo();
     UInt32 total_weight = 0;
-    for (const auto & shard : shards)
-        total_weight += shard.weight;
+    for (auto i = 0ul, s = active_num_shards; i < s; ++i)
+        total_weight += shards[i].weight;
 
     assert(total_weight > 0);
 
@@ -1961,7 +1964,7 @@ size_t StorageDistributed::getRandomShardIndex(const Cluster::ShardsInfo & shard
         res = std::uniform_int_distribution<size_t>(0, total_weight - 1)(rng);
     }
 
-    for (auto i = 0ul, s = shards.size(); i < s; ++i)
+    for (auto i = 0ul, s = active_num_shards; i < s; ++i)
     {
         if (shards[i].weight > res)
             return i;

--- a/src/Storages/StorageDistributed.h
+++ b/src/Storages/StorageDistributed.h
@@ -209,7 +209,7 @@ private:
 
     bool isShardingKeySuitsQueryTreeNodeExpression(const QueryTreeNodePtr & expr, const SelectQueryInfo & query_info) const;
 
-    size_t getRandomShardIndex(const Cluster::ShardsInfo & shards);
+    size_t getRandomShardIndex(const ClusterPtr & cluster);
     std::string getClusterName() const { return cluster_name.empty() ? "<remote>" : cluster_name; }
 
     const DistributedSettings & getDistributedSettingsRef() const { return *distributed_settings; }


### PR DESCRIPTION
### Changelog category (leave one):
- New Feature



### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

An implement in issue [#93215](https://github.com/ClickHouse/ClickHouse/issues/93215). When scaling down shards in a cluster, writes can be disabled first to allow a graceful decommission of those shards.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shard selection and block-splitting logic for `Distributed` INSERTs by allowing only a prefix of shards to receive writes, which can affect data distribution and load balancing if misconfigured. Risk is moderate because it touches core insert routing paths (random shard selection and sharding-key scatter).
> 
> **Overview**
> Adds a new cluster config option `active_insert_shard_nums` to *limit which shards receive INSERTs* (useful for gracefully decommissioning trailing shards).
> 
> Updates `Distributed` write paths to respect this limit: random-shard inserts, sync/async sharding-key splitting, and selector generation now operate on `cluster->getActiveInsertShardCount()` rather than all shards, with `createBlockSelector()` updated to accept the active shard count and ignore slot mappings beyond it.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ff2e2f672bafe08e59071c43714b3627b6d291f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->