### PR TITLE
Fix CI tools failing when latest bot comment has no report URL

### DIFF
--- a/.claude/tools/fetch_ci_report.js
+++ b/.claude/tools/fetch_ci_report.js
@@ -301,12 +301,13 @@ async function getCIReportsFromPR(prUrl) {
 
   // Fetch PR comments to find CI bot comment
   try {
-    const commentsJson = execSync(`gh api repos/ClickHouse/ClickHouse/issues/${prNumber}/comments --jq '[.[] | select(.user.login == "clickhouse-gh[bot]") | {body, created_at}] | sort_by(.created_at) | reverse'`, {
+    const commentsJson = execSync(`gh api repos/ClickHouse/ClickHouse/issues/${prNumber}/comments --paginate --jq '.[] | select(.user.login == "clickhouse-gh[bot]") | {body, created_at}'`, {
       encoding: 'utf8',
       stdio: ['pipe', 'pipe', 'pipe']
     });
 
-    const comments = JSON.parse(commentsJson);
+    const comments = commentsJson.trim().split('\n').filter(l => l.trim()).map(l => JSON.parse(l));
+    comments.sort((a, b) => (b.created_at || '').localeCompare(a.created_at || ''));
     if (!comments || comments.length === 0) {
       throw new Error('No CI bot comment found');
     }

--- a/.claude/tools/fetch_ci_report.js
+++ b/.claude/tools/fetch_ci_report.js
@@ -301,25 +301,27 @@ async function getCIReportsFromPR(prUrl) {
 
   // Fetch PR comments to find CI bot comment
   try {
-    const commentsJson = execSync(`gh api repos/ClickHouse/ClickHouse/issues/${prNumber}/comments --jq '[.[] | select(.user.login == "clickhouse-gh[bot]") | {body, created_at}] | sort_by(.created_at) | reverse | .[0]'`, {
+    const commentsJson = execSync(`gh api repos/ClickHouse/ClickHouse/issues/${prNumber}/comments --jq '[.[] | select(.user.login == "clickhouse-gh[bot]") | {body, created_at}] | sort_by(.created_at) | reverse'`, {
       encoding: 'utf8',
       stdio: ['pipe', 'pipe', 'pipe']
     });
 
-    const comment = JSON.parse(commentsJson);
-    if (!comment || !comment.body) {
+    const comments = JSON.parse(commentsJson);
+    if (!comments || comments.length === 0) {
       throw new Error('No CI bot comment found');
     }
 
-    // Extract CI report URLs from comment
+    // Search through all bot comments for CI report URLs (not just the latest)
     const reportUrlPattern = /https:\/\/s3\.amazonaws\.com\/clickhouse-test-reports\/json\.html\?[^\s)]+/g;
-    const urls = comment.body.match(reportUrlPattern);
-
-    if (!urls || urls.length === 0) {
-      throw new Error('No CI report URLs found in bot comment');
+    for (const comment of comments) {
+      if (!comment.body) continue;
+      const urls = comment.body.match(reportUrlPattern);
+      if (urls && urls.length > 0) {
+        return urls;
+      }
     }
 
-    return urls;
+    throw new Error('No CI report URLs found in bot comments');
   } catch (error) {
     if (error.message.includes('No CI bot comment found') || error.message.includes('No CI report URLs found')) {
       throw error;

--- a/.claude/tools/fetch_perf_report.py
+++ b/.claude/tools/fetch_perf_report.py
@@ -93,14 +93,15 @@ def resolve_pr(pr_url):
         comments_json = subprocess.check_output(
             [
                 "gh", "api", f"repos/{gh_repo}/issues/{pr_number}/comments",
+                "--paginate",
                 "--jq",
-                '[.[] | select(.user.login == "clickhouse-gh[bot]") | {body, created_at}]'
-                " | sort_by(.created_at) | reverse",
+                '.[] | select(.user.login == "clickhouse-gh[bot]") | {body, created_at}',
             ],
             text=True,
             stderr=subprocess.PIPE,
         )
-        comments = json.loads(comments_json)
+        comments = [json.loads(line) for line in comments_json.strip().splitlines() if line.strip()]
+        comments.sort(key=lambda c: c.get("created_at", ""), reverse=True)
         if not comments:
             raise RuntimeError("No CI bot comment found")
 

--- a/.claude/tools/fetch_perf_report.py
+++ b/.claude/tools/fetch_perf_report.py
@@ -95,22 +95,27 @@ def resolve_pr(pr_url):
                 "gh", "api", f"repos/{gh_repo}/issues/{pr_number}/comments",
                 "--jq",
                 '[.[] | select(.user.login == "clickhouse-gh[bot]") | {body, created_at}]'
-                " | sort_by(.created_at) | reverse | .[0]",
+                " | sort_by(.created_at) | reverse",
             ],
             text=True,
             stderr=subprocess.PIPE,
         )
-        comment = json.loads(comments_json)
-        if not comment or not comment.get("body"):
+        comments = json.loads(comments_json)
+        if not comments:
             raise RuntimeError("No CI bot comment found")
 
         url_pattern = re.compile(
             r"https://s3\.amazonaws\.com/clickhouse(?:-private)?-test-reports/json\.html\?[^\s)]+"
         )
-        urls = url_pattern.findall(comment["body"])
-        if not urls:
-            raise RuntimeError("No CI report URLs found in bot comment")
-        ci_url = urls[0]
+        ci_url = None
+        for comment in comments:
+            body = comment.get("body", "")
+            urls = url_pattern.findall(body)
+            if urls:
+                ci_url = urls[0]
+                break
+        if not ci_url:
+            raise RuntimeError("No CI report URLs found in bot comments")
     except (subprocess.CalledProcessError, json.JSONDecodeError) as e:
         raise RuntimeError(f"Failed to get CI info for PR #{pr_number}: {e}")
 


### PR DESCRIPTION
## Summary
- The `clickhouse-gh[bot]` posts multiple comments on PRs (CI report, LLVM coverage, etc.)
- Both `fetch_perf_report.py` and `fetch_ci_report.js` assumed the most recent bot comment contains the CI report URL
- When a newer comment (e.g. coverage report) exists, the tools failed with "No CI report URLs found in bot comment"
- Fix by iterating through all bot comments (newest first) until one with a CI report URL is found

## Test plan
- [x] Verified fix works: `python3 .claude/tools/fetch_perf_report.py "https://github.com/ClickHouse/ClickHouse/pull/90043"` now succeeds

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to local CLI tooling and only adjust how PR comments are paginated and scanned for existing CI report links.
> 
> **Overview**
> Fixes `.claude/tools/fetch_ci_report.js` and `.claude/tools/fetch_perf_report.py` to **no longer assume the newest `clickhouse-gh[bot]` comment contains CI report links**.
> 
> Both tools now fetch *all* bot comments via `gh api --paginate`, sort by `created_at`, and iterate newest-first until a matching S3 `json.html` CI report URL is found (with updated error messaging when none exist).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98a32a69a8ae5bdd5566466895d8ab6e8e8480fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.603`
<!-- ch-version-info:end -->