### PR TITLE
clickhouse-local: add `ls` meta-command (client-side rewrite to `file()` query)

### DIFF
--- a/programs/local/LocalServer.h
+++ b/programs/local/LocalServer.h
@@ -27,6 +27,7 @@ public:
     void initialize(Poco::Util::Application & self) override;
 
     int main(const std::vector<String> & /*args*/) override;
+    bool supportsLocalMetaCommands() const override { return true; }
 
 protected:
     Poco::Util::LayeredConfiguration & getClientConfiguration() override;

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -10,6 +10,7 @@
 #include <Core/SortDescription.h>
 #include <Interpreters/sortBlock.h>
 #include <boost/algorithm/string/predicate.hpp>
+#include <Client/LocalMetaCommands.h>
 
 #if USE_CLIENT_AI
 #include <Client/AI/AISQLGenerator.h>
@@ -1135,8 +1136,11 @@ bool ClientBase::processTextAsSingleQuery(const String & full_query)
 {
     /// Some parts of a query (result output and formatting) are executed
     /// client-side. Thus we need to parse the query.
+
     const char * begin = full_query.data();
-    auto parsed_query = parseQuery(begin, begin + full_query.size(),
+    const char * end = begin + full_query.size();
+
+    auto parsed_query = parseQuery(begin, end,
         client_context->getSettingsRef(),
         /*allow_multi_statements=*/ false);
 
@@ -3824,8 +3828,19 @@ void ClientBase::runNonInteractive()
                     return;
             }
             else
-            {
-                if (!processQueryText(query))
+            {   String query_to_execute = query; // copy for possible modification
+                // First handle incoming commands for clickhouse-local (i.e. ls)
+                if (supportsLocalMetaCommands())
+                {   // only clickhouse-local will be handled here
+                    const auto result = tryHandleLocalMetaCommand(query);
+
+                    if (result.kind == LocalMetaCommandResult::Kind::RewriteQuery)
+                    {   // query has been rewritten into an equivalent command
+                        query_to_execute = result.query;
+                    }
+                }
+                // default case
+                if (!processQueryText(query_to_execute))
                     return;
             }
         }

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -3740,7 +3740,7 @@ void ClientBase::runInteractive()
 
         try
         {
-            if (!processQueryText(input))
+            if (!processQueryText(rewriteLocalMetaCommandIfNeeded(input)))
                 break;
             last_input = input;
         }
@@ -3788,6 +3788,18 @@ bool ClientBase::processMultiQueryFromFile(const String & file_name)
     return executeMultiQuery(queries_from_file);
 }
 
+String ClientBase::rewriteLocalMetaCommandIfNeeded(const String & query) const
+{
+    if (!supportsLocalMetaCommands())
+        return query;
+
+    const auto result = tryHandleLocalMetaCommand(query);
+
+    if (result.kind == LocalMetaCommandResult::Kind::RewriteQuery)
+        return result.query;
+
+    return query;
+}
 
 void ClientBase::runNonInteractive()
 {
@@ -3818,7 +3830,7 @@ void ClientBase::runNonInteractive()
         if (!buzzHouse())
             return;
     }
-    else if (!buzz_house && !queries.empty())
+    else if (!queries.empty())
     {
         for (const auto & query : queries)
         {
@@ -3828,19 +3840,8 @@ void ClientBase::runNonInteractive()
                     return;
             }
             else
-            {   String query_to_execute = query; // copy for possible modification
-                // First handle incoming commands for clickhouse-local (i.e. ls)
-                if (supportsLocalMetaCommands())
-                {   // only clickhouse-local will be handled here
-                    const auto result = tryHandleLocalMetaCommand(query);
-
-                    if (result.kind == LocalMetaCommandResult::Kind::RewriteQuery)
-                    {   // query has been rewritten into an equivalent command
-                        query_to_execute = result.query;
-                    }
-                }
-                // default case
-                if (!processQueryText(query_to_execute))
+            {
+                if (!processQueryText(rewriteLocalMetaCommandIfNeeded(query)))
                     return;
             }
         }
@@ -3852,6 +3853,9 @@ void ClientBase::runNonInteractive()
         ReadBufferFromFileDescriptor in(stdin_fd);
         String text;
         readStringUntilEOF(text, in);
+
+        text = rewriteLocalMetaCommandIfNeeded(text);
+
         if (query_fuzzer_runs)
             processWithASTFuzzer(text);
         else

--- a/src/Client/ClientBase.h
+++ b/src/Client/ClientBase.h
@@ -263,6 +263,7 @@ private:
     /// Execute a query and collect all results as a single string (rows separated by newlines)
     /// Returns empty string on exception
     std::string executeQueryForSingleString(const std::string & query);
+    virtual bool supportsLocalMetaCommands() const { return false; }
 
 protected:
 

--- a/src/Client/ClientBase.h
+++ b/src/Client/ClientBase.h
@@ -264,6 +264,7 @@ private:
     /// Returns empty string on exception
     std::string executeQueryForSingleString(const std::string & query);
     virtual bool supportsLocalMetaCommands() const { return false; }
+    String rewriteLocalMetaCommandIfNeeded(const String & query) const;
 
 protected:
 

--- a/src/Client/LocalMetaCommands.cpp
+++ b/src/Client/LocalMetaCommands.cpp
@@ -1,0 +1,55 @@
+#include <Client/LocalMetaCommands.h>
+
+#include <boost/algorithm/string.hpp>
+
+namespace DB
+{
+
+namespace
+{
+
+    // Helper function to normalize the input and avoid issues
+String normalizeMetaCommand(std::string_view input)
+{
+    String s(input);
+    boost::algorithm::trim(s);
+
+    if (!s.empty() && s.back() == ';')
+    {
+        s.pop_back();
+        boost::algorithm::trim(s);
+    }
+
+    return s;
+}
+
+std::optional<String> rewriteLS(std::string_view input)
+{
+    const String normalized = normalizeMetaCommand(input);
+
+    if (!boost::iequals(normalized, "ls"))
+        return std::nullopt;
+
+    return "SELECT _file AS file FROM file('*', 'One') ORDER BY file";
+}
+
+// More commands can be added here like: 
+// std::optional<String> rewritePWD(std::string_view input)
+
+}
+
+/// Dispatcher for all local meta-commands.
+LocalMetaCommandResult tryHandleLocalMetaCommand(std::string_view input)
+{
+    if (auto rewritten = rewriteLS(input))
+    {
+        return {LocalMetaCommandResult::Kind::RewriteQuery, std::move(*rewritten)};
+    }
+    /// This can be extended for new commands
+    /// if (auto rewritten = rewritePWD(input))
+    ///     return {LocalMetaCommandResult::Kind::RewriteQuery, std::move(*rewritten)};
+
+    return {};
+}
+
+}

--- a/src/Client/LocalMetaCommands.cpp
+++ b/src/Client/LocalMetaCommands.cpp
@@ -33,9 +33,6 @@ std::optional<String> rewriteLS(std::string_view input)
     return "SELECT _file AS file FROM file('*', 'One') ORDER BY file";
 }
 
-// More commands can be added here like: 
-// std::optional<String> rewritePWD(std::string_view input)
-
 }
 
 /// Dispatcher for all local meta-commands.
@@ -45,9 +42,6 @@ LocalMetaCommandResult tryHandleLocalMetaCommand(std::string_view input)
     {
         return {LocalMetaCommandResult::Kind::RewriteQuery, std::move(*rewritten)};
     }
-    /// This can be extended for new commands
-    /// if (auto rewritten = rewritePWD(input))
-    ///     return {LocalMetaCommandResult::Kind::RewriteQuery, std::move(*rewritten)};
 
     return {};
 }

--- a/src/Client/LocalMetaCommands.h
+++ b/src/Client/LocalMetaCommands.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <base/types.h>
+
+#include <optional>
+#include <string_view>
+
+namespace DB
+{
+
+struct LocalMetaCommandResult
+{
+    enum class Kind
+    {
+        NotMatched,
+        RewriteQuery,
+    };
+
+    Kind kind = Kind::NotMatched;
+    String query;
+};
+
+/*
+Try to handle a clickhouse-local meta-command.
+
+- NotMatched: input is not a supported local meta-command
+- RewriteQuery: replace input with `query` and continue normal processing
+*/
+LocalMetaCommandResult tryHandleLocalMetaCommand(std::string_view input);
+
+}


### PR DESCRIPTION
This PR adds a small meta-command for `clickhouse-local`: `ls`.

The command is handled client-side and rewritten into an equivalent SQL query before normal parsing.

Example:

```
:) ls
```

is rewritten to

```sql
SELECT _file AS file
FROM file('*', 'One')
ORDER BY file
```

The rewritten query is then executed through the normal query pipeline.

### Scope

* Available **only in `clickhouse-local`**
* Implemented as a **client-side rewrite**
* **No SQL syntax changes**
* Accepts only standalone commands:

  * `ls`
  * `ls;`

Commands like `ls foo` or `ls FORMAT Vertical` are intentionally unsupported.

### Implementation

A small local meta-command handler is added.
Before executing a query, `clickhouse-local` checks whether the input is a supported meta-command and rewrites it if necessary.

The output column is aliased to `file` to avoid exposing `_file`.

### Motivation

When using `clickhouse-local`, listing files in the working directory is a common task.

This provides a lightweight CLI convenience similar to Unix `ls` while keeping the SQL language unchanged.

### Notes

* The feature is **not available in `clickhouse-client`** to avoid confusion between client-side and server-side files.
* No recursion or additional metadata fields are added to keep the feature minimal.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Scoped to `clickhouse-local` via an explicit opt-in flag and only performs a simple string match-and-rewrite before existing query processing.
> 
> **Overview**
> `clickhouse-local` now supports a small *client-side* meta-command: entering `ls` (or `ls;`) is rewritten to `SELECT _file AS file FROM file('*', 'One') ORDER BY file` and then executed through the normal query pipeline.
> 
> This is implemented by introducing `LocalMetaCommands` (a dispatcher that currently only matches `ls`) and plumbing a gated rewrite step into `ClientBase` so the transformation runs for interactive input, `--query`, and stdin-based non-interactive execution; `clickhouse-local` opts in via `LocalServer::supportsLocalMetaCommands()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ddde9ef64651cff9987076ea5e31245a048592f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->