### PR TITLE
remove flakiness of 03914_jemalloc_cache_arena_mark_cache

### DIFF
--- a/tests/queries/0_stateless/03914_jemalloc_cache_arena_mark_cache.reference
+++ b/tests/queries/0_stateless/03914_jemalloc_cache_arena_mark_cache.reference
@@ -2,4 +2,3 @@ before_select	0
 after_select	1
 arena_active	1
 after_clear	1
-arena_reclaimed	1

--- a/tests/queries/0_stateless/03914_jemalloc_cache_arena_mark_cache.sh
+++ b/tests/queries/0_stateless/03914_jemalloc_cache_arena_mark_cache.sh
@@ -1,36 +1,13 @@
 #!/usr/bin/env bash
 # Tags: no-parallel, no-random-settings, no-random-merge-tree-settings, use_jemalloc
 
-# Test that mark cache allocations use the dedicated jemalloc cache arena
-# and that SYSTEM DROP MARK CACHE properly reclaims arena pages.
+# Test that mark cache allocations use the dedicated jemalloc cache arena.
+# Arena pactive reclamation is tested by the integration test
+# test_userspace_page_cache::test_cache_arena_isolation in an isolated environment.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
-
-function drop_caches_and_get_pactive()
-{
-    $CLICKHOUSE_CLIENT -q "
-        SYSTEM DROP MARK CACHE;
-        SYSTEM DROP INDEX MARK CACHE;
-        SYSTEM DROP UNCOMPRESSED CACHE;
-        SYSTEM DROP INDEX UNCOMPRESSED CACHE;
-        SYSTEM DROP PAGE CACHE;
-        SYSTEM RELOAD ASYNCHRONOUS METRICS;
-        SELECT value FROM system.asynchronous_metrics
-        WHERE metric = 'jemalloc.cache_arena.pactive'"
-}
-
-function drop_caches_and_get_mark_cache_bytes()
-{
-    $CLICKHOUSE_CLIENT -q "
-        SYSTEM DROP MARK CACHE;
-        SYSTEM DROP INDEX MARK CACHE;
-        SYSTEM DROP UNCOMPRESSED CACHE;
-        SYSTEM DROP INDEX UNCOMPRESSED CACHE;
-        SYSTEM DROP PAGE CACHE;
-        SELECT value FROM system.metrics WHERE metric = 'MarkCacheBytes'"
-}
 
 $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS t_cache_arena_marks"
 
@@ -43,8 +20,14 @@ $CLICKHOUSE_CLIENT -q "
     INSERT INTO t_cache_arena_marks
     SELECT number, toString(number), number * 1.1 FROM numbers(5000000)"
 
-# Record baseline (may be non-zero due to other tables)
-before_bytes=$(drop_caches_and_get_mark_cache_bytes)
+# Drop caches and record baseline
+before_bytes=$($CLICKHOUSE_CLIENT -q "
+    SYSTEM DROP MARK CACHE;
+    SYSTEM DROP INDEX MARK CACHE;
+    SYSTEM DROP UNCOMPRESSED CACHE;
+    SYSTEM DROP INDEX UNCOMPRESSED CACHE;
+    SYSTEM DROP PAGE CACHE;
+    SELECT value FROM system.metrics WHERE metric = 'MarkCacheBytes'")
 echo "before_select	0"
 
 # Force mark loading
@@ -56,36 +39,30 @@ after_bytes=$($CLICKHOUSE_CLIENT -q "
     SELECT value FROM system.metrics WHERE metric = 'MarkCacheBytes'")
 echo "after_select	$(( after_bytes > before_bytes ? 1 : 0 ))"
 
-# Read pactive after loading marks
-$CLICKHOUSE_CLIENT -q "SYSTEM RELOAD ASYNCHRONOUS METRICS"
-pactive_loaded=$($CLICKHOUSE_CLIENT -q "
-    SELECT value FROM system.asynchronous_metrics
-    WHERE metric = 'jemalloc.cache_arena.pactive'")
+# Verify cache arena is active (marks landed in the dedicated arena)
+$CLICKHOUSE_CLIENT -q "
+    SYSTEM RELOAD ASYNCHRONOUS METRICS;
+    SELECT 'arena_active', value > 0 FROM system.asynchronous_metrics
+    WHERE metric = 'jemalloc.cache_arena.pactive'"
 
-echo "arena_active	$(( pactive_loaded > 0 ? 1 : 0 ))"
-
-# Drop our table so its background merges can't reload marks.
+# Drop the table so its background merges can't reload marks,
+# then atomically clear caches and read MarkCacheBytes.
 $CLICKHOUSE_CLIENT -q "DROP TABLE t_cache_arena_marks"
 
-# Retry loop: atomically clear caches and read metrics.
-# Other tables' background activity can reload marks between iterations,
-# so we retry a few times.
-reclaimed=0
 cache_cleared=0
 for _ in $(seq 1 5); do
-    pactive_cleared=$(drop_caches_and_get_pactive)
-    cleared_bytes=$(drop_caches_and_get_mark_cache_bytes)
+    cleared_bytes=$($CLICKHOUSE_CLIENT -q "
+        SYSTEM DROP MARK CACHE;
+        SYSTEM DROP INDEX MARK CACHE;
+        SYSTEM DROP UNCOMPRESSED CACHE;
+        SYSTEM DROP INDEX UNCOMPRESSED CACHE;
+        SYSTEM DROP PAGE CACHE;
+        SELECT value FROM system.metrics WHERE metric = 'MarkCacheBytes'")
 
-    if [ "$pactive_cleared" -lt "$pactive_loaded" ]; then
-        reclaimed=1
-    fi
     if [ "$cleared_bytes" -lt "$after_bytes" ]; then
         cache_cleared=1
-    fi
-    if [ "$reclaimed" -eq 1 ] && [ "$cache_cleared" -eq 1 ]; then
         break
     fi
 done
 
 echo "after_clear	${cache_cleared}"
-echo "arena_reclaimed	${reclaimed}"


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Details:

reduce flakiness in stateless test by removing arena reclaimed check, that is already tested by existing integration test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only changes that relax a flaky assertion by removing jemalloc arena reclamation verification and simplifying cache-drop/metric reads.
> 
> **Overview**
> Makes stateless test `03914_jemalloc_cache_arena_mark_cache` less flaky by **removing the `arena_reclaimed`/pactive-decrease assertion** and relying on an existing integration test for reclamation coverage.
> 
> Simplifies the script by inlining the cache-drop/metric queries, keeping checks for `MarkCacheBytes` growth and `jemalloc.cache_arena.pactive` being active, and updates the `.reference` output accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 91a8dbf12ee0365218c5337e8c1662a9f28eac22. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.621`
<!-- ch-version-info:end -->