### PR TITLE
Cancel WriteBuffer in IcebergStorageSink on query cancellation

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
@@ -815,7 +815,10 @@ void IcebergStorageSink::consume(Chunk & chunk)
 void IcebergStorageSink::onFinish()
 {
     if (isCancelled())
+    {
+        cancelBuffers();
         return;
+    }
 
     finalizeBuffers();
     releaseBuffers();


### PR DESCRIPTION
## Summary
- Fix logical error exception `"WriteBuffer is neither finalized nor canceled in destructor."` in `IcebergStorageSink` during stress tests
- When a query is cancelled, `onFinish` detected `isCancelled()` and returned immediately without finalizing or cancelling the write buffers. Since `onException` is not called on cancellation, the `WriteBuffer` reached its destructor in a bad state
- Fix by calling `cancelBuffers()` on the cancellation path in `onFinish`

CI reports:
- https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=d80ab8d9ab5feaf66b160ba6b626b7fb11d1c170&name_0=MasterCI&name_1=Stress%20test%20%28arm_asan%29
- https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=02494568f66fc9564136dcfd3dff2c4387caa178&name_0=MasterCI&name_1=Stress%20test%20%28arm_asan%2C%20s3%29

## Test plan
- [x] Verified `WriteBuffer::cancel` is safe to call on already-finalized buffers (returns immediately)
- [ ] Stress test (arm_asan) should pass without the logical error

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, minimal control-flow change in `IcebergStorageSink::onFinish` to ensure buffers are canceled on query cancellation, reducing destructor-time logical errors without changing normal write finalization behavior.
> 
> **Overview**
> Ensures `IcebergStorageSink::onFinish()` cancels in-flight write buffers when the query has been cancelled, instead of returning early and leaving buffers neither finalized nor canceled.
> 
> Normal completion behavior is unchanged: non-cancelled writes still `finalizeBuffers()` and `releaseBuffers()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e9e3dd5c94dd61a4d48d49b09adebdf2a7dfbd1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.620`
<!-- ch-version-info:end -->