### PR TITLE
Revert "Revert "Fix `SettingsConstraints` erasing explicit settings before compatibility applies""

### DIFF
--- a/src/Access/SettingsConstraints.cpp
+++ b/src/Access/SettingsConstraints.cpp
@@ -216,12 +216,13 @@ void SettingsConstraints::check(const Settings & current_settings, const Setting
 
 void SettingsConstraints::check(const Settings & current_settings, SettingsChanges & changes, SettingSource source) const
 {
-    std::erase_if(
-        changes,
-        [&](SettingChange & change) -> bool
-        {
-            return !checkImpl(current_settings, change, THROW_ON_VIOLATION, source);
-        });
+    /// When `compatibility` is present, keep all settings (even if they match current values). This ensures they're applied
+    /// and marked as `changed`, preventing `compatibility` from overriding explicit user values with its own defaults.
+    if (changes.tryGet("compatibility") == nullptr)
+        std::erase_if(changes, [&](SettingChange & change) { return !checkImpl(current_settings, change, THROW_ON_VIOLATION, source); });
+    else
+        for (auto & change : changes)
+            checkImpl(current_settings, change, THROW_ON_VIOLATION, source);
 }
 
 void SettingsConstraints::check(const MergeTreeSettings & current_settings, const SettingChange & change) const

--- a/tests/queries/0_stateless/03916_check_settings_constraints_erases_with_compatibility.reference
+++ b/tests/queries/0_stateless/03916_check_settings_constraints_erases_with_compatibility.reference
@@ -1,0 +1,10 @@
+-- compatibility alone reverts to 0
+0
+-- explicit =1 with compatibility=24.12 (compat first in URL)
+1
+-- explicit =1 with compatibility=24.12 (setting first in URL)
+1
+-- explicit =0 with compatibility=24.12 (not affected by bug)
+0
+-- TCP: explicit =1 with compatibility=24.12
+1

--- a/tests/queries/0_stateless/03916_check_settings_constraints_erases_with_compatibility.sh
+++ b/tests/queries/0_stateless/03916_check_settings_constraints_erases_with_compatibility.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Tags: no-random-settings
+# no-random-settings: because the test framework may inject the settings we are testing into the URL, which interferes with test
+
+# checkSettingsConstraints must not erase unchanged settings, since a later `compatibility` in the same batch can change the baseline.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+QUERY_SKIP="SELECT value FROM system.settings WHERE name = 'use_skip_indexes_if_final'"
+
+echo "-- compatibility alone reverts to 0"
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&compatibility=24.12" -d "$QUERY_SKIP"
+
+echo "-- explicit =1 with compatibility=24.12 (compat first in URL)"
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&compatibility=24.12&use_skip_indexes_if_final=1" -d "$QUERY_SKIP"
+
+echo "-- explicit =1 with compatibility=24.12 (setting first in URL)"
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&use_skip_indexes_if_final=1&compatibility=24.12" -d "$QUERY_SKIP"
+
+echo "-- explicit =0 with compatibility=24.12 (not affected by bug)"
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&compatibility=24.12&use_skip_indexes_if_final=0" -d "$QUERY_SKIP"
+
+echo "-- TCP: explicit =1 with compatibility=24.12"
+${CLICKHOUSE_CLIENT} --compatibility=24.12 --use_skip_indexes_if_final=1 \
+    -q "$QUERY_SKIP"


### PR DESCRIPTION
Reverts ClickHouse/ClickHouse#98515 to restore ClickHouse/ClickHouse#97078. Flaky CI possibly caused by this PR fixed here ClickHouse/ClickHouse#98689

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `SettingsConstraints::check(SettingsChanges&)` filters/retains settings when `compatibility` is present, which can affect which query/session settings are considered changed and ultimately applied. The impact is limited but touches core settings processing and could alter behavior for clients relying on previous ordering/override semantics.
> 
> **Overview**
> Fixes an ordering bug where `SettingsConstraints::check(SettingsChanges&)` could erase “unchanged” explicit settings before a later `compatibility` change adjusts the baseline, allowing compatibility defaults to incorrectly override user-provided values.
> 
> Adds a stateless regression test (`03916_check_settings_constraints_erases_with_compatibility`) covering HTTP URL parameter ordering and TCP client flags to ensure explicit settings remain effective when `compatibility=24.12` is used.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd023229c0584b1bab230c32cc9a908fea63a634. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.607`
<!-- ch-version-info:end -->