### PR TITLE
Fix dashboard loading (via Reload button) after unsuccessfull load

### DIFF
--- a/programs/server/dashboard.html
+++ b/programs/server/dashboard.html
@@ -1406,38 +1406,40 @@ async function drawAll() {
     if (is_drawing) return;
     is_drawing = true;
 
-    let params = getParamsForURL();
-    const chartsArray = document.getElementsByClassName('chart');
-
-    if (!firstLoad) {
+    try {
         hideError();
-    }
-    await Promise.all([...Array(queries.length)].map(async (_, i) => {
-        return draw(i, chartsArray[i], params, queries[i].query).catch((e) => {
-            if (!firstLoad) {
+
+        let params = getParamsForURL();
+        const chartsArray = document.getElementsByClassName('chart');
+
+        let had_global_error = false;
+        const results = await Promise.all([...Array(queries.length)].map(async (_, i) => {
+            return draw(i, chartsArray[i], params, queries[i].query).catch((e) => {
                 showError(e.message);
-            }
-            return false;
-        });
-    })).then((results) => {
+                had_global_error = true;
+                return false;
+            });
+        }));
+
         if (firstLoad) {
             firstLoad = false;
         } else {
             enableButtons();
         }
-        if (results.includes(true)) {
+
+        if (!had_global_error && results.length > 0) {
+            /// At least one chart was processed without a global error
+            /// (auth/connection).  Show the connected UI.  Individual charts
+            /// may still have per-chart query errors displayed in their divs.
             const element = document.querySelector('.inputs');
             element.classList.remove('unconnected');
             document.getElementById('add').style.display = 'inline-block';
             document.getElementById('edit').style.display = 'inline-block';
             document.getElementById('search-span').style.display = '';
-            hideError();
-        } else {
-            document.getElementById('charts').style.height = '0px';
         }
-    });
-
-    is_drawing = false;
+    } finally {
+        is_drawing = false;
+    }
 }
 
 function resize() {


### PR DESCRIPTION
Previously it was always hanged on the main screen with Reload button, but it does send requests.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/control-flow change confined to client-side dashboard rendering; main risk is altered error/connected-state transitions during chart loading.
> 
> **Overview**
> Fixes dashboard reload behavior after a failed load by hardening `drawAll()`.
> 
> Chart rendering is now wrapped in `try/finally` to always clear the `is_drawing` lock, and global connection/auth failures are tracked separately so the UI only exits the *unconnected* state when at least one chart completes without a global error.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f73aade9b956da48f11e756aa1025b1979b8a7e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.641`
<!-- ch-version-info:end -->