### PR TITLE
CAST mutation protection

### DIFF
--- a/src/Functions/FunctionsConversion.cpp
+++ b/src/Functions/FunctionsConversion.cpp
@@ -2720,6 +2720,12 @@ FunctionCast::WrapperType FunctionCast::prepareRemoveNullable(const DataTypePtr 
     {
         /// Conversion from Nullable to non-Nullable.
 
+        if (settings.inside_validated_mutation)
+            throw Exception(
+                ErrorCodes::CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN,
+                "Prevent converting Nullable type to non-Nullable type inside mutation. Use assumeNotNull() or set "
+                "validate_mutation_query to 0 to allow.");
+
         bool accurate_or_null = cast_type == CastType::accurateOrNull;
 
         return [wrapper, skip_not_null_check, accurate_or_null]

--- a/src/Functions/FunctionsConversion.h
+++ b/src/Functions/FunctionsConversion.h
@@ -93,6 +93,7 @@ namespace Setting
     extern const SettingsBool check_conversion_from_numbers_to_enum;
     extern const SettingsBool precise_float_parsing;
     extern const SettingsBool date_time_64_output_format_cut_trailing_zeros_align_to_groups_of_thousands;
+    extern const SettingsBool validate_mutation_query;
     extern const SettingsDateTimeInputFormat cast_string_to_date_time_mode;
 }
 
@@ -132,6 +133,7 @@ struct FunctionConvertSettings
     const bool check_conversion_from_numbers_to_enum;
     const bool date_time_64_output_format_cut_trailing_zeros_align_to_groups_of_thousands;
     const bool cast_keep_nullable;
+    const bool inside_validated_mutation;
     const FormatSettings::DateTimeInputFormat cast_string_to_date_time_mode;
     const FormatSettings format_settings;
 
@@ -148,6 +150,7 @@ struct FunctionConvertSettings
         , check_conversion_from_numbers_to_enum(context && context->getSettingsRef()[Setting::check_conversion_from_numbers_to_enum])
         , date_time_64_output_format_cut_trailing_zeros_align_to_groups_of_thousands(context && context->getSettingsRef()[Setting::date_time_64_output_format_cut_trailing_zeros_align_to_groups_of_thousands])
         , cast_keep_nullable(context && context->getSettingsRef()[Setting::cast_keep_nullable])
+        , inside_validated_mutation(context && context->isMutation() && context->getSettingsRef()[Setting::validate_mutation_query])
         , cast_string_to_date_time_mode(context ? context->getSettingsRef()[Setting::cast_string_to_date_time_mode] : FormatSettings::DateTimeInputFormat::Basic)
         , format_settings(context ? getFormatSettings(context) : FormatSettings{})
     {

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -1300,6 +1300,7 @@ ContextData::ContextData(const ContextData &o) :
     normalized_query_hash(o.normalized_query_hash),
     insertion_table_info(o.insertion_table_info),
     is_distributed(o.is_distributed),
+    is_mutation(o.is_mutation),
     default_format(o.default_format),
     insert_format(o.insert_format),
     external_tables_mapping(o.external_tables_mapping),

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -393,6 +393,7 @@ protected:
 
     InsertionTableInfo insertion_table_info;  /// Saved information about insertion table in query context
     bool is_distributed = false;  /// Whether the current context it used for distributed query
+    bool is_mutation = false;  /// Whether the current context is inside a mutation
 
     String default_format;  /// Format, used when server formats data by itself and if query does not have FORMAT specification.
                             /// Thus, used in HTTP interface. If not specified - then some globally default format is used.
@@ -1141,6 +1142,9 @@ public:
 
     void setDistributed(bool is_distributed_) { is_distributed = is_distributed_; }
     bool isDistributed() const { return is_distributed; }
+
+    bool isMutation() const { return is_mutation; }
+    void setMutation(bool is_mutation_) { is_mutation = is_mutation_; }
 
     bool isUnderRestore() const { return is_under_restore; }
     void setUnderRestore(bool under_restore) { is_under_restore = under_restore; }

--- a/src/Interpreters/MutationsInterpreter.cpp
+++ b/src/Interpreters/MutationsInterpreter.cpp
@@ -526,6 +526,8 @@ MutationsInterpreter::MutationsInterpreter(
     /// so parallel replicas must not be used for them.
     new_context->setSetting("enable_parallel_replicas", Field(0));
 
+    new_context->setMutation(true);
+
     context = std::move(new_context);
 }
 

--- a/tests/integration/test_alter_update_cast_keep_nullable/test.py
+++ b/tests/integration/test_alter_update_cast_keep_nullable/test.py
@@ -40,7 +40,7 @@ def test_cast_keep_nullable(started_cluster):
         ALTER TABLE t UPDATE x = x % 3 = 0 ? NULL : x WHERE x % 2 = 1;　
     """
     )
-    assert "DB::Exception: Cannot convert NULL value to non-Nullable type" in error
+    assert "DB::Exception: Prevent converting Nullable type to non-Nullable type inside mutation" in error
 
     result = node1.query("SELECT * FROM t;")
     assert result.strip() == "0\n1\n2\n3\n4\n5\n6\n7\n8\n9"

--- a/tests/queries/0_stateless/01111_create_drop_replicated_db_stress.sh
+++ b/tests/queries/0_stateless/01111_create_drop_replicated_db_stress.sh
@@ -70,7 +70,7 @@ function alter_table()
         table=$($CLICKHOUSE_CLIENT -q "select database || '.' || name from system.tables where database like '${CLICKHOUSE_DATABASE}%' order by rand() limit 1")
         if [ -z "$table" ]; then continue; fi
         $CLICKHOUSE_CLIENT --max_execution_time 300 --lock_acquire_timeout=120 --distributed_ddl_task_timeout=0 -q \
-        "alter table $table update n = n + (select max(n) from merge(REGEXP('${CLICKHOUSE_DATABASE}.*'), '.*')) where 1 settings allow_nondeterministic_mutations=1" \
+        "alter table $table update n = n + assumeNotNull( (select max(n) from merge(REGEXP('${CLICKHOUSE_DATABASE}.*'), '.*')) ) where 1 settings allow_nondeterministic_mutations=1" \
         2>&1| grep -Fa "Exception: " | grep -Fv "Cannot enqueue query" | grep -Fv "ZooKeeper session expired" | grep -Fv UNKNOWN_DATABASE | grep -Fv UNKNOWN_TABLE | grep -Fv TABLE_IS_READ_ONLY | grep -Fv TABLE_IS_DROPPED | grep -Fv ABORTED | grep -Fv "There are no tables satisfied provided regexp" | grep -Fv UNFINISHED | grep -Fv TIMEOUT_EXCEEDED | grep -Fv QUERY_WAS_CANCELLED
         sleep 0.$RANDOM
     done

--- a/tests/queries/0_stateless/02436_system_zookeeper_context.sql
+++ b/tests/queries/0_stateless/02436_system_zookeeper_context.sql
@@ -2,6 +2,6 @@ DROP TABLE IF EXISTS mt;
 create table mt (n int, s String) engine=MergeTree order by n;
 insert into mt values (1, '');
 set allow_nondeterministic_mutations=1;
-alter table mt update s = (select toString(groupArray((*,))) from system.zookeeper where path='/') where n=1 settings mutations_sync=2;
+alter table mt update s = assumeNotNull( (select toString(groupArray((*,))) from system.zookeeper where path='/') ) where n=1 settings mutations_sync=2;
 select distinct n from mt;
 DROP TABLE mt;

--- a/tests/queries/0_stateless/02842_mutations_replace_non_deterministic.reference
+++ b/tests/queries/0_stateless/02842_mutations_replace_non_deterministic.reference
@@ -1,10 +1,10 @@
 10	4950
-(UPDATE v = _CAST(4950, \'Nullable(UInt64)\') WHERE 1)
+(UPDATE v = assumeNotNull(_CAST(4950, \'Nullable(UInt64)\')) WHERE 1)
 10	[0,1,2,3,4,5,6,7,8,9]
-(UPDATE v = _CAST([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], \'Array(UInt64)\') WHERE 1)
+(UPDATE v = assumeNotNull(_CAST([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], \'Array(UInt64)\')) WHERE 1)
 10	5
-(UPDATE v = _CAST(\'\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\', \'AggregateFunction(uniqExact, UInt64)\') WHERE 1)
+(UPDATE v = assumeNotNull(_CAST(\'\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\', \'AggregateFunction(uniqExact, UInt64)\')) WHERE 1)
 10	1
 (UPDATE v = _CAST(timestamp, \'DateTime\') WHERE 1)
-(UPDATE v = (SELECT sum(number) FROM numbers(1000) WHERE number > randConstant()) WHERE 1)
+(UPDATE v = assumeNotNull((SELECT sum(number) FROM numbers(1000) WHERE number > randConstant())) WHERE 1)
 20	2100-10-10 00:00:00

--- a/tests/queries/0_stateless/02842_mutations_replace_non_deterministic.sql
+++ b/tests/queries/0_stateless/02842_mutations_replace_non_deterministic.sql
@@ -14,7 +14,7 @@ ORDER BY id;
 
 INSERT INTO t_mutations_nondeterministic VALUES (10, 20);
 
-ALTER TABLE t_mutations_nondeterministic UPDATE v = (SELECT sum(number) FROM numbers(100)) WHERE 1;
+ALTER TABLE t_mutations_nondeterministic UPDATE v = assumeNotNull( (SELECT sum(number) FROM numbers(100)) ) WHERE 1;
 
 SELECT id, v FROM t_mutations_nondeterministic ORDER BY id;
 
@@ -32,12 +32,12 @@ ORDER BY id;
 
 INSERT INTO t_mutations_nondeterministic VALUES (10, [20]);
 
-ALTER TABLE t_mutations_nondeterministic UPDATE v = (SELECT groupArray(number) FROM numbers(10)) WHERE 1;
+ALTER TABLE t_mutations_nondeterministic UPDATE v = assumeNotNull( (SELECT groupArray(number) FROM numbers(10)) ) WHERE 1;
 
 SELECT id, v FROM t_mutations_nondeterministic ORDER BY id;
 
 -- Too big result.
-ALTER TABLE t_mutations_nondeterministic UPDATE v = (SELECT groupArray(number) FROM numbers(10000)) WHERE 1; -- { serverError BAD_ARGUMENTS }
+ALTER TABLE t_mutations_nondeterministic UPDATE v = assumeNotNull( (SELECT groupArray(number) FROM numbers(10000)) ) WHERE 1; -- { serverError BAD_ARGUMENTS }
 
 SELECT command FROM system.mutations
 WHERE database = currentDatabase() AND table = 't_mutations_nondeterministic' AND is_done
@@ -53,7 +53,7 @@ ORDER BY id;
 
 INSERT INTO t_mutations_nondeterministic VALUES (10, initializeAggregation('uniqExactState', 1::UInt64));
 
-ALTER TABLE t_mutations_nondeterministic UPDATE v = (SELECT uniqExactState(number) FROM numbers(5)) WHERE 1;
+ALTER TABLE t_mutations_nondeterministic UPDATE v = assumeNotNull( (SELECT uniqExactState(number) FROM numbers(5)) ) WHERE 1;
 
 SELECT id, finalizeAggregation(v) FROM t_mutations_nondeterministic ORDER BY id;
 
@@ -103,10 +103,10 @@ INSERT INTO t_mutations_nondeterministic VALUES (10, 10);
 
 -- Check that function in subquery is not rewritten.
 ALTER TABLE t_mutations_nondeterministic
-UPDATE v =
+UPDATE v = assumeNotNull(
 (
     SELECT sum(number) FROM numbers(1000) WHERE number > randConstant()
-) WHERE 1
+) ) WHERE 1
 SETTINGS mutations_execute_subqueries_on_initiator = 0, allow_nondeterministic_mutations = 1;
 
 SELECT command FROM system.mutations

--- a/tests/queries/0_stateless/03047_on_fly_mutations_non_deterministic.sql
+++ b/tests/queries/0_stateless/03047_on_fly_mutations_non_deterministic.sql
@@ -16,7 +16,7 @@ SELECT count() FROM system.mutations WHERE database = currentDatabase() AND tabl
 KILL MUTATION WHERE database = currentDatabase() AND table = 't_lightweight_mut_2' FORMAT Null;
 SELECT count() FROM system.mutations WHERE database = currentDatabase() AND table = 't_lightweight_mut_2' AND NOT is_done AND NOT is_killed;
 
-ALTER TABLE t_lightweight_mut_2 UPDATE v = (SELECT sum(number) FROM numbers(100)) WHERE 1;
+ALTER TABLE t_lightweight_mut_2 UPDATE v = assumeNotNull( (SELECT sum(number) FROM numbers(100)) ) WHERE 1;
 
 SELECT * FROM t_lightweight_mut_2; -- { serverError BAD_ARGUMENTS }
 SELECT * FROM t_lightweight_mut_2 SETTINGS apply_mutations_on_fly = 0;

--- a/tests/queries/0_stateless/03047_on_fly_mutations_non_deterministic_replace.reference
+++ b/tests/queries/0_stateless/03047_on_fly_mutations_non_deterministic_replace.reference
@@ -1,16 +1,16 @@
 10	4950
-(UPDATE v = _CAST(4950, \'Nullable(UInt64)\') WHERE 1)
+(UPDATE v = assumeNotNull(_CAST(4950, \'Nullable(UInt64)\')) WHERE 1)
 10	[0,1,2,3,4,5,6,7,8,9]
-(UPDATE v = (SELECT groupArray(number) FROM numbers(10000)) WHERE 1)
-(UPDATE v = _CAST([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], \'Array(UInt64)\') WHERE 1)
+(UPDATE v = assumeNotNull((SELECT groupArray(number) FROM numbers(10000))) WHERE 1)
+(UPDATE v = assumeNotNull(_CAST([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], \'Array(UInt64)\')) WHERE 1)
 10	10000
 10	5
-(UPDATE v = _CAST(\'\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\', \'AggregateFunction(uniqExact, UInt64)\') WHERE 1)
+(UPDATE v = assumeNotNull(_CAST(\'\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\', \'AggregateFunction(uniqExact, UInt64)\')) WHERE 1)
 10	1
 (UPDATE v = _CAST(timestamp, \'DateTime\') WHERE 1)
 10	10
 (UPDATE v = filesystemCapacity(materialize(\'default\')) WHERE 1)
-(UPDATE v = (SELECT sum(number) FROM numbers(1000) WHERE number > randConstant()) WHERE 1)
+(UPDATE v = assumeNotNull((SELECT sum(number) FROM numbers(1000) WHERE number > randConstant())) WHERE 1)
 10	2000-10-10 00:00:00
 20	2100-10-10 00:00:00
 20	2100-10-10 00:00:00

--- a/tests/queries/0_stateless/03047_on_fly_mutations_non_deterministic_replace.sql
+++ b/tests/queries/0_stateless/03047_on_fly_mutations_non_deterministic_replace.sql
@@ -11,7 +11,7 @@ CREATE TABLE t_lightweight_mut_5 (id UInt64, v UInt64) ENGINE = MergeTree ORDER 
 SYSTEM STOP MERGES t_lightweight_mut_5;
 INSERT INTO t_lightweight_mut_5 VALUES (10, 20);
 
-ALTER TABLE t_lightweight_mut_5 UPDATE v = (SELECT sum(number) FROM numbers(100)) WHERE 1;
+ALTER TABLE t_lightweight_mut_5 UPDATE v = assumeNotNull( (SELECT sum(number) FROM numbers(100)) ) WHERE 1;
 
 SELECT id, v FROM t_lightweight_mut_5 ORDER BY id;
 
@@ -28,11 +28,11 @@ CREATE TABLE t_lightweight_mut_5 (id UInt64, v Array(UInt64)) ENGINE = MergeTree
 SYSTEM STOP MERGES t_lightweight_mut_5;
 INSERT INTO t_lightweight_mut_5 VALUES (10, [20]);
 
-ALTER TABLE t_lightweight_mut_5 UPDATE v = (SELECT groupArray(number) FROM numbers(10)) WHERE 1;
+ALTER TABLE t_lightweight_mut_5 UPDATE v = assumeNotNull( (SELECT groupArray(number) FROM numbers(10)) ) WHERE 1;
 
 SELECT id, v FROM t_lightweight_mut_5 ORDER BY id;
 
-ALTER TABLE t_lightweight_mut_5 UPDATE v = (SELECT groupArray(number) FROM numbers(10000)) WHERE 1;
+ALTER TABLE t_lightweight_mut_5 UPDATE v = assumeNotNull( (SELECT groupArray(number) FROM numbers(10000)) ) WHERE 1;
 
 SELECT id, length(v) FROM t_lightweight_mut_5 ORDER BY id; -- { serverError BAD_ARGUMENTS }
 
@@ -56,7 +56,7 @@ CREATE TABLE t_lightweight_mut_5 (id UInt64, v AggregateFunction(uniqExact, UInt
 SYSTEM STOP MERGES t_lightweight_mut_5;
 INSERT INTO t_lightweight_mut_5 VALUES (10, initializeAggregation('uniqExactState', 1::UInt64));
 
-ALTER TABLE t_lightweight_mut_5 UPDATE v = (SELECT uniqExactState(number) FROM numbers(5)) WHERE 1;
+ALTER TABLE t_lightweight_mut_5 UPDATE v = assumeNotNull( (SELECT uniqExactState(number) FROM numbers(5)) ) WHERE 1;
 
 SELECT id, finalizeAggregation(v) FROM t_lightweight_mut_5 ORDER BY id;
 
@@ -112,10 +112,10 @@ INSERT INTO t_lightweight_mut_5 VALUES (10, 10);
 
 -- Check that function in subquery is not rewritten.
 ALTER TABLE t_lightweight_mut_5
-UPDATE v =
+UPDATE v = assumeNotNull(
 (
     SELECT sum(number) FROM numbers(1000) WHERE number > randConstant()
-) WHERE 1 SETTINGS mutations_execute_subqueries_on_initiator = 0;
+) ) WHERE 1 SETTINGS mutations_execute_subqueries_on_initiator = 0;
 
 SELECT command FROM system.mutations
 WHERE database = currentDatabase() AND table = 't_lightweight_mut_5' AND NOT is_done

--- a/tests/queries/0_stateless/03789_mutation_prevent_nullable_cast.sql
+++ b/tests/queries/0_stateless/03789_mutation_prevent_nullable_cast.sql
@@ -1,0 +1,63 @@
+DROP TABLE IF EXISTS warden_a;
+CREATE TABLE warden_a
+(
+    `salary` Nullable(String)
+)
+ENGINE = MergeTree
+ORDER BY tuple();
+
+INSERT INTO warden_a
+VALUES
+    ('1,  2 , 3'),
+    ('wrong'),
+    (NULL);
+
+ALTER TABLE warden_a
+ADD COLUMN IF NOT EXISTS `parsed_salary` Array(Int64);
+ALTER TABLE
+    warden_a
+UPDATE
+    `parsed_salary` = multiIf(
+        salary IS NULL, CAST('[]', 'Array(Int64)'),
+        CAST(
+            coalesce(
+                arrayCompact(
+                    arrayMap(
+                        x -> toInt64OrNull(trimBoth(x)),
+                        splitByString(',', ifNull(salary, ''))
+                    )
+                ),
+                []
+            ),
+            'Array(Int64)'
+        )
+    )
+WHERE
+    1
+SETTINGS validate_mutation_query = 1; -- { serverError 349 }
+
+TRUNCATE TABLE warden_a;
+
+ALTER TABLE warden_a
+ADD COLUMN IF NOT EXISTS `parsed_salary` Array(Int64);
+ALTER TABLE
+    warden_a
+UPDATE
+    `parsed_salary` = multiIf(
+        salary IS NULL, CAST('[]', 'Array(Int64)'),
+        CAST(
+            coalesce(
+                arrayCompact(
+                    arrayMap(
+                        x -> toInt64OrNull(trimBoth(x)),
+                        splitByString(',', ifNull(salary, ''))
+                    )
+                ),
+                []
+            ),
+            'Array(Int64)'
+        )
+    )
+WHERE
+    1
+SETTINGS validate_mutation_query = 0;


### PR DESCRIPTION
Closes #92911

### Changelog category (leave one):
- Backward Incompatible Change

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
prevent CAST from Nullable to not Nullable type in mutations

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

Do not start mutation with CAST operation from Nullable to not Nullable type if `validate_mutation_query` is set. User could use `assumeNotNull()` or `validate_mutation_query = 0` to avoid protection.

It's an expansion of `validate_mutation_query` setting introduced in #71300 to function's prepare state.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mutation query validation to reject `CAST`-style conversions from Nullable to non-Nullable types when `validate_mutation_query` is enabled, which can break existing mutation queries relying on implicit/explicit null dropping.
> 
> **Overview**
> Prevents mutations from starting when they include a conversion from `Nullable` to a non-`Nullable` type while `validate_mutation_query` is enabled, raising `CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN` with guidance to use `assumeNotNull()` or disable validation.
> 
> This introduces mutation-awareness in `Context` (`isMutation` / `setMutation`) and threads it into `FunctionConvertSettings`, so `CAST`/conversion wrappers can enforce the new rule. Tests are updated to wrap mutation subquery results with `assumeNotNull()` and a new stateless test asserts the validation error when attempting a nullable-to-nonnullable cast in a mutation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e26fa90a85b55de5af6b60cbecdbd836d1be2e82. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->