### PR TITLE
Clamp settings constraints in DDL worker for distributed DDL queries

### DIFF
--- a/src/Interpreters/DDLTask.cpp
+++ b/src/Interpreters/DDLTask.cpp
@@ -318,7 +318,13 @@ ContextMutablePtr DDLTaskBase::makeQueryContext(ContextPtr from_context, const Z
     }
 
     if (entry.settings)
+    {
+        /// Clamp settings to the constraints of the local node, similar to how
+        /// TCPHandler handles secondary queries. Without this, settings from the
+        /// initiator node could bypass stricter constraints on worker nodes.
+        query_context->clampToSettingsConstraints(*entry.settings, SettingSource::QUERY);
         query_context->applySettingsChanges(*entry.settings);
+    }
 
     return query_context;
 }

--- a/src/Interpreters/DDLTask.cpp
+++ b/src/Interpreters/DDLTask.cpp
@@ -322,8 +322,11 @@ ContextMutablePtr DDLTaskBase::makeQueryContext(ContextPtr from_context, const Z
         /// Clamp settings to the constraints of the local node, similar to how
         /// TCPHandler handles secondary queries. Without this, settings from the
         /// initiator node could bypass stricter constraints on worker nodes.
-        query_context->clampToSettingsConstraints(*entry.settings, SettingSource::QUERY);
-        query_context->applySettingsChanges(*entry.settings);
+        /// Work on a copy to avoid mutating the entry, which may be read later
+        /// (e.g. by DatabaseReplicatedTask::createSyncedNodeIfNeed) or retried.
+        auto settings_changes = *entry.settings;
+        query_context->clampToSettingsConstraints(settings_changes, SettingSource::QUERY);
+        query_context->applySettingsChanges(settings_changes);
     }
 
     return query_context;

--- a/tests/integration/test_settings_constraints_distributed_ddl/configs/node2_users.xml
+++ b/tests/integration/test_settings_constraints_distributed_ddl/configs/node2_users.xml
@@ -1,0 +1,13 @@
+<clickhouse>
+    <profiles>
+        <default>
+            <max_memory_usage>10000000000</max_memory_usage>
+            <constraints>
+                <max_memory_usage>
+                    <min>5000000000</min>
+                    <max>20000000000</max>
+                </max_memory_usage>
+            </constraints>
+        </default>
+    </profiles>
+</clickhouse>

--- a/tests/integration/test_settings_constraints_distributed_ddl/configs/remote_servers.xml
+++ b/tests/integration/test_settings_constraints_distributed_ddl/configs/remote_servers.xml
@@ -1,0 +1,18 @@
+<clickhouse>
+    <remote_servers>
+        <test_cluster>
+            <shard>
+                <replica>
+                    <host>node1</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+            <shard>
+                <replica>
+                    <host>node2</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </test_cluster>
+    </remote_servers>
+</clickhouse>

--- a/tests/integration/test_settings_constraints_distributed_ddl/test.py
+++ b/tests/integration/test_settings_constraints_distributed_ddl/test.py
@@ -1,0 +1,109 @@
+"""
+Test that settings constraints are respected (or at least clamped) when
+distributed DDL entries are replayed on worker nodes that have stricter
+constraints than the initiator node.
+
+Scenario
+--------
+- node1 (initiator): NO constraints on max_memory_usage
+- node2 (worker):    max_memory_usage constrained to MIN 5_000_000_000
+
+The initiator sets max_memory_usage = 1 in its session and then issues
+CREATE TABLE ... ON CLUSTER. The DDL entry serializes max_memory_usage = 1.
+When node2 replays this entry, it should ideally clamp or reject the
+setting, not silently apply it in violation of local constraints.
+
+We verify by checking the query_log on node2 to see what effective
+max_memory_usage was applied when the DDL worker replayed the entry.
+"""
+
+import uuid
+import pytest
+from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import assert_eq_with_retry
+
+cluster = ClickHouseCluster(__file__)
+
+# node1: no constraints on max_memory_usage (unconstrained initiator)
+node1 = cluster.add_instance(
+    "node1",
+    main_configs=["configs/remote_servers.xml"],
+    with_zookeeper=True,
+    macros={"shard": "1", "replica": "1"},
+)
+
+# node2: strict constraint on max_memory_usage (min=5_000_000_000)
+node2 = cluster.add_instance(
+    "node2",
+    main_configs=["configs/remote_servers.xml"],
+    user_configs=["configs/node2_users.xml"],
+    with_zookeeper=True,
+    macros={"shard": "2", "replica": "1"},
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_ddl_worker_bypasses_settings_constraints():
+    """
+    Verify that the DDL worker on node2 clamps settings constraints
+    when replaying a DDL entry from node1 that carries a setting
+    violating node2's local constraints.
+    """
+    table_name = f"test_ddl_constraints_{uuid.uuid4().hex[:8]}"
+
+    # Verify the constraint is active on node2
+    assert "shouldn't be less" in node2.query_and_get_error(
+        "SET max_memory_usage = 1"
+    ), "Constraint should be active on node2"
+
+    # Verify no constraint on node1
+    node1.query("SET max_memory_usage = 1")  # Should succeed
+
+    # From node1: run ON CLUSTER DDL with max_memory_usage=1
+    # This creates the DDL entry with the setting serialized in it
+    node1.query(
+        f"CREATE TABLE {table_name} ON CLUSTER test_cluster (x Int64) ENGINE = MergeTree ORDER BY x",
+        settings={
+            "max_memory_usage": "1",
+            "distributed_ddl_entry_format_version": "2",
+            "distributed_ddl_task_timeout": "60",
+        },
+    )
+
+    # Both nodes should have the table
+    assert node1.query(f"SELECT count() FROM system.tables WHERE name = '{table_name}'").strip() == "1"
+    assert node2.query(f"SELECT count() FROM system.tables WHERE name = '{table_name}'").strip() == "1"
+
+    # Wait for the DDL worker's query to appear in query_log on node2.
+    assert_eq_with_retry(
+        node2,
+        f"SELECT count() FROM system.query_log WHERE query LIKE '%CREATE TABLE%{table_name}%'"
+        "AND type = 'QueryFinish' AND is_initial_query = 0",
+        "1\n",
+        retry_count=30,
+        sleep_time=1,
+    )
+
+    # Now that the entry exists, verify the effective max_memory_usage was
+    # clamped to at least the minimum constraint (5_000_000_000).
+    result = int(
+        node2.query(
+            f"SELECT Settings['max_memory_usage'] FROM system.query_log WHERE query LIKE '%CREATE TABLE%{table_name}%' AND type = 'QueryFinish' AND is_initial_query = 0"
+        ).strip()
+    )
+    assert result >= 5_000_000_000, (
+        f"DDL worker on node2 applied max_memory_usage={result}, "
+        f"which violates the local constraint (min=5000000000)"
+    )
+
+    # Cleanup
+    for node in [node1, node2]:
+        node.query(f"DROP TABLE IF EXISTS {table_name} SYNC")

--- a/tests/integration/test_settings_constraints_distributed_ddl/test.py
+++ b/tests/integration/test_settings_constraints_distributed_ddl/test.py
@@ -51,7 +51,7 @@ def started_cluster():
         cluster.shutdown()
 
 
-def test_ddl_worker_bypasses_settings_constraints():
+def test_ddl_worker_clamps_settings_constraints():
     """
     Verify that the DDL worker on node2 clamps settings constraints
     when replaying a DDL entry from node1 that carries a setting
@@ -85,8 +85,7 @@ def test_ddl_worker_bypasses_settings_constraints():
     # Wait for the DDL worker's query to appear in query_log on node2.
     assert_eq_with_retry(
         node2,
-        f"SELECT count() FROM system.query_log WHERE query LIKE '%CREATE TABLE%{table_name}%'"
-        "AND type = 'QueryFinish' AND is_initial_query = 0",
+        f"SELECT count() FROM system.query_log WHERE query LIKE '%CREATE TABLE%{table_name}%' AND type = 'QueryFinish' AND is_initial_query = 0",
         "1\n",
         retry_count=30,
         sleep_time=1,


### PR DESCRIPTION
`DDLTask::makeQueryContext` applied settings from the DDL entry (serialized by the initiator node) without checking or clamping them against the local node's settings constraints. This allowed settings that violate stricter constraints on worker nodes to be silently applied.

For example, if node1 has no constraint on `max_memory_usage` and node2 has min=5000000000, a DDL ON CLUSTER from node1 with max_memory_usage=1 would apply that value on node2, bypassing its constraint entirely.

The fix adds `clampToSettingsConstraints` before `applySettingsChanges`, consistent with how TCPHandler handles secondary queries.

An integration test is added to verify the behavior with a two-node cluster where nodes have different constraint profiles.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Clamp settings constraints in DDL worker for distributed DDL queries

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how distributed DDL workers apply initiator-provided settings; incorrect clamping could alter query behavior or mask misconfigurations, but scope is limited to secondary DDL execution context.
> 
> **Overview**
> Fixes a distributed DDL settings bypass: `DDLTaskBase::makeQueryContext` now **clamps DDL-entry `settings` to the local node’s settings constraints** before applying them, using a copied `SettingsChanges` to avoid mutating/reusing the stored entry.
> 
> Adds an integration test with a 2-node cluster where the worker has stricter `max_memory_usage` constraints, asserting the replayed DDL on the worker records a clamped effective setting in `system.query_log`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5639cd83f725e873828f9e662a11830a84e4c64c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.614`
- Backported to: `26.2.5.22`
<!-- ch-version-info:end -->