### PR TITLE
tests: disable 04034_parquet_v3_metadata_cache_no_query_context for replicated database

### DIFF
--- a/tests/queries/0_stateless/04034_parquet_v3_metadata_cache_no_query_context.sh
+++ b/tests/queries/0_stateless/04034_parquet_v3_metadata_cache_no_query_context.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest
+# Tags: no-fasttest, no-replicated-database
 # Tag no-fasttest: Depends on S3
+# Tag no-replicated-database: the data can be inserted on a different node
 
 # Regression test: S3Queue background threads read Parquet files without a
 # query context on CurrentThread. Before the fix, the format factory lambda


### PR DESCRIPTION
In ReplicatedDatabase the data can be inserted on a different node.

CI: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=69f4658643f9a101aa99b5a8efca11ba3175a46a&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_llvm_coverage%2C%20old%20analyzer%2C%20s3%20storage%2C%20DatabaseReplicated%2C%20WasmEdge%2C%20parallel%29&name_1=Stateless%20tests%20%28amd_llvm_coverage%2C%20old%20analyzer%2C%20s3%20storage%2C%20DatabaseReplicated%2C%20WasmEdge%2C%20parallel%29

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts test tagging to skip this stateless S3Queue/Parquet regression test when running with `ReplicatedDatabase`, without changing product code or test logic.
> 
> **Overview**
> Marks `04034_parquet_v3_metadata_cache_no_query_context.sh` with the `no-replicated-database` tag (and documents why) so it is skipped in replicated-database CI runs where inserts may land on a different node and make the test unreliable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b74a29f4011f4722df4ea1d159e52f4787fd07b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.609`
<!-- ch-version-info:end -->