### PR TITLE
CI: fix targeted AST fuzzer not resolving any queries

### DIFF
--- a/ci/jobs/ast_fuzzer_job.py
+++ b/ci/jobs/ast_fuzzer_job.py
@@ -82,7 +82,7 @@ def _collect_targeted_queries(workspace_path: Path, info: Info) -> tuple[list[st
     targeted_queries: list[str] = []
     seen_queries = set()
     for test in tests:
-        base_name = Path(test).stem
+        base_name = Path(test).stem.rstrip(".")
         matches = available_queries.get(base_name, [])
         if matches:
             logging.debug("  %s -> %s", test, matches)

--- a/ci/jobs/ast_fuzzer_job.py
+++ b/ci/jobs/ast_fuzzer_job.py
@@ -59,10 +59,6 @@ def get_run_command(
     )
 
 
-def _test_name_to_basename(test_name: str) -> str:
-    return test_name[:-1] if test_name.endswith(".") else test_name
-
-
 def _collect_targeted_queries(workspace_path: Path, info: Info) -> tuple[list[str], Result]:
     targeter = Targeting(info=info)
     targeter.job_type = Targeting.STATELESS_JOB_TYPE
@@ -76,16 +72,23 @@ def _collect_targeted_queries(workspace_path: Path, info: Info) -> tuple[list[st
     available_queries: dict[str, list[str]] = {}
 
     for query_file in stateless_tests_dir.rglob("*.sql"):
-        base_name = query_file.name.removesuffix(".sql")
+        base_name = query_file.stem
         available_queries.setdefault(base_name, []).append(
             f"/repo/{query_file.relative_to(cwd)}"
         )
 
+    logging.debug("Indexed %d unique SQL query base names from %s", len(available_queries), stateless_tests_dir)
+
     targeted_queries: list[str] = []
     seen_queries = set()
     for test in tests:
-        base_name = _test_name_to_basename(test)
-        for query_path in available_queries.get(base_name, []):
+        base_name = Path(test).stem
+        matches = available_queries.get(base_name, [])
+        if matches:
+            logging.debug("  %s -> %s", test, matches)
+        else:
+            logging.debug("  %s -> no .sql file found (stem: %r)", test, base_name)
+        for query_path in matches:
             if query_path not in seen_queries:
                 seen_queries.add(query_path)
                 targeted_queries.append(query_path)


### PR DESCRIPTION
## Summary
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=99205&sha=f36922fd4810308bce842100a7e5a561775864e1&name_0=PR&name_1=AST+fuzzer+%28amd_debug%2C+targeted%29
https://github.com/ClickHouse/ClickHouse/pull/99205

- `_test_name_to_basename` only stripped a trailing `.` but never stripped the file extension (`.sh`, `.sql`, `.expect`) from test names
- When looking up matching `.sql` files in `available_queries`, the stem-based key never matched because the test name still carried its extension (e.g. `03113_analyzer_not_found_column_in_block_2.sql` vs key `03113_analyzer_not_found_column_in_block_2`)
- Result: "No targeted queries resolved for AST fuzzer" was always logged even when 50 relevant tests were found, and the job was skipped

**Fix:** use `Path(test).stem` to strip the extension before lookup, and `query_file.stem` instead of `removesuffix(".sql")` for consistency. Also adds `DEBUG`-level logging to show per-test resolution results.

## Test plan

- [ ] Verify targeted AST fuzzer job resolves queries from the relevant test list and proceeds to run

### Changelog category (leave one)
- CI Fix or improvement

### Changelog entry
Fix targeted AST fuzzer job always skipping due to test name extension not being stripped during `.sql` file lookup.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that adjusts filename matching for targeted AST fuzzer query selection and adds debug logging; main risk is over/under-selecting queries due to stem parsing differences.
> 
> **Overview**
> Fixes targeted AST fuzzer query resolution by matching relevant test names to `.sql` files using `Path(...).stem` (and trimming trailing `.`) instead of relying on the raw test name.
> 
> Also switches `.sql` indexing to use `query_file.stem` and adds `DEBUG` logging to show how tests map to query files (or why they don’t), preventing the job from being incorrectly skipped due to zero resolved targeted queries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b5b9dbd9ce4c4911e150c6938c8d1718e8771b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.611`
<!-- ch-version-info:end -->