### PR TITLE
Minor fixes for totp auth

### DIFF
--- a/src/Access/Common/OneTimePassword.cpp
+++ b/src/Access/Common/OneTimePassword.cpp
@@ -90,14 +90,14 @@ static OneTimePasswordParams::Algorithm hashingAlgorithmFromString(const String 
     throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unknown algorithm for one-time password: '{}'", algorithm_name);
 }
 
-OneTimePasswordParams::OneTimePasswordParams(Int32 num_digits_, Int32 period_, const String & algorithm_name_)
+OneTimePasswordParams::OneTimePasswordParams(std::optional<Int32> num_digits_, std::optional<Int32> period_, std::optional<String> algorithm_name_)
 {
-    if (num_digits_)
-        num_digits = num_digits_;
-    if (period_)
-        period = period_;
-    if (!algorithm_name_.empty())
-        algorithm = hashingAlgorithmFromString(algorithm_name_);
+    if (num_digits_.has_value())
+        num_digits = num_digits_.value();
+    if (period_.has_value())
+        period = period_.value();
+    if (algorithm_name_.has_value())
+        algorithm = hashingAlgorithmFromString(algorithm_name_.value());
 
     if (num_digits < 4 || 10 < num_digits)
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Invalid number of digits for one-time password: {}", num_digits);

--- a/src/Access/Common/OneTimePassword.h
+++ b/src/Access/Common/OneTimePassword.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <base/types.h>
+#include <optional>
 
 namespace DB
 {
@@ -17,7 +18,7 @@ struct OneTimePasswordParams
         SHA512,
     } algorithm = Algorithm::SHA1;
 
-    explicit OneTimePasswordParams(Int32 num_digits_ = {}, Int32 period_ = {}, const String & algorithm_name_ = {});
+    explicit OneTimePasswordParams(std::optional<Int32> num_digits_ = {}, std::optional<Int32> period_ = {}, std::optional<String> algorithm_name_ = {});
 
     bool operator==(const OneTimePasswordParams &) const = default;
 

--- a/src/Access/UsersConfigParser.cpp
+++ b/src/Access/UsersConfigParser.cpp
@@ -165,12 +165,20 @@ namespace
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "One-time password can be used only with password based authentication for user {}.", user_name);
 
             String otp_secret_key = config.getString(user_config + ".time_based_one_time_password.secret");
-            OneTimePasswordParams otp_config(
-                config.getInt(user_config + ".time_based_one_time_password.digits", {}),
-                config.getInt(user_config + ".time_based_one_time_password.period", {}),
-                config.getString(user_config + ".time_based_one_time_password.algorithm", {}));
 
-            otp_secret.emplace(otp_secret_key, otp_config);
+            std::optional<Int32> num_digits;
+            if (config.has(user_config + ".time_based_one_time_password.digits"))
+                num_digits = config.getInt(user_config + ".time_based_one_time_password.digits");
+
+            std::optional<Int32> period;
+            if (config.has(user_config + ".time_based_one_time_password.period"))
+                period = config.getInt(user_config + ".time_based_one_time_password.period");
+
+            std::optional<String> algorithm_name;
+            if (config.has(user_config + ".time_based_one_time_password.algorithm"))
+                algorithm_name = config.getString(user_config + ".time_based_one_time_password.algorithm");
+
+            otp_secret.emplace(otp_secret_key, OneTimePasswordParams(num_digits, period, algorithm_name));
         }
 
         if (has_no_password && otp_secret)

--- a/src/Client/ConnectionParameters.cpp
+++ b/src/Client/ConnectionParameters.cpp
@@ -135,8 +135,7 @@ ConnectionParameters::ConnectionParameters(const Poco::Util::AbstractConfigurati
 
         if (config.has("one-time-password"))
         {
-            if (!password.empty())
-                password += "+";
+            password += "+";
             password += config.getString("one-time-password");
         }
         else if (config.getBool("ask-password-2fa", false))

--- a/tests/integration/test_totp_auth/test_totp.py
+++ b/tests/integration/test_totp_auth/test_totp.py
@@ -77,6 +77,13 @@ def create_config(totp_secret):
                 <secret>GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ</secret>
             </time_based_one_time_password>
         </totuser_no_password>
+
+        <totuser_empty_password>
+            <password></password>
+            <time_based_one_time_password>
+                <secret>GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ</secret>
+            </time_based_one_time_password>
+        </totuser_empty_password>
     </users>
 </clickhouse>
 """.lstrip()
@@ -255,4 +262,30 @@ def test_one_time_only_no_password(started_cluster):
     with client(command=f"{client_command} --one-time-password {get_otp()}") as c:
         c.send("SELECT currentUser() || '42' FORMAT TSVRaw;")
         c.expect("totuser_no_password42")
+        c.expect(prompt)
+
+
+def test_empty_password_with_otp_cli_option(started_cluster):
+    """Test that --one-time-password works for a user with empty plaintext password and TOTP."""
+    secret = "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ"
+    get_otp = lambda: get_one_time_password(secret=secret)
+
+    query_text = "SELECT currentUser() || toString(42)"
+
+    assert "totuser_empty_password42\n" == node.query(
+        query_text, user="totuser_empty_password", password=f"+{get_otp()}"
+    )
+
+    client_command = f"{started_cluster.get_client_cmd()} --highlight=0 --host {node.ip_address} -u totuser_empty_password"
+
+    with client(command=f"{client_command} --one-time-password {get_otp()}") as c:
+        c.send("SELECT currentUser() || '42' FORMAT TSVRaw;")
+        c.expect("totuser_empty_password42")
+        c.expect(prompt)
+
+    with client(
+        command=f'{client_command} --password "" --one-time-password {get_otp()}'
+    ) as c:
+        c.send("SELECT currentUser() || '42' FORMAT TSVRaw;")
+        c.expect("totuser_empty_password42")
         c.expect(prompt)


### PR DESCRIPTION
### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
* Fix minor issues with TOTP authentication: the `--one-time-password` CLI option with empty password, validation of `<digits>` and `<period>` configuration values.   

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication parameter parsing on both server and client: incorrect handling could block logins or mis-apply TOTP settings. Scope is small and covered by updated integration tests.
> 
> **Overview**
> Fixes TOTP configuration override handling by changing `OneTimePasswordParams` to take `std::optional` fields and updating `UsersConfigParser` to only override defaults when `<digits>`, `<period>`, or `<algorithm>` are explicitly present (so empty/missing values don’t bypass validation).
> 
> Updates the client to always append the `+` separator when `--one-time-password` is provided, allowing TOTP-only auth even when the primary password is empty, and adds an integration test user + coverage for this scenario.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6e3435ee4c9207f8a322bed3e9ca215b606c542. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.615`
<!-- ch-version-info:end -->