### PR TITLE
Improvements for LLVM Coverage Job

### DIFF
--- a/ci/jobs/llvm_coverage_job.py
+++ b/ci/jobs/llvm_coverage_job.py
@@ -77,9 +77,9 @@ def collect_html_report_files(
     return files, assets
 
 
-def get_git_info() -> tuple[str, str, str, str, str, int]:
+def get_git_info() -> tuple[str, list[str], str, str, str, int]:
     # Get git info from Info singleton, if not present, get it from shell commands
-    # merge_base_commit_sha, branch, base_branch, repo_name, pr_number
+    # Returns: current_commit_sha, master_track_commits, branch, base_branch, repo_name, pr_number
     info = Info()
 
     current_commit_sha = info.sha
@@ -88,24 +88,33 @@ def get_git_info() -> tuple[str, str, str, str, str, int]:
             "git rev-parse HEAD", verbose=True
         ).strip()
 
-    merge_base_commit_sha = info.get_kv_data("merge_base_commit_sha")
-    if merge_base_commit_sha is None:
-        # Use gh api to get the merge base commit between master and HEAD
-        merge_base_commit_sha = Shell.get_output(
+    # master_track_commits is a list of master-side commits (nearest first) stored by
+    # store_data.py.  The first entry doubles as the base commit for diff comparisons.
+    # In a local run (or when the hook has not populated the key) we fall back to
+    # deriving the merge base via the GitHub API and walking back 30 commits from it.
+    master_track_commits: list[str] = info.get_kv_data("master_track_commits_sha") or []
+    if not master_track_commits:
+        merge_base = Shell.get_output(
             f"gh api repos/ClickHouse/ClickHouse/compare/master...{current_commit_sha} -q .merge_base_commit.sha",
             verbose=True,
         ).strip()
+        if merge_base:
+            raw = Shell.get_output(
+                f"gh api 'repos/ClickHouse/ClickHouse/commits?sha={merge_base}&per_page=30' -q '.[].sha'",
+                verbose=True,
+            )
+            master_track_commits = raw.splitlines()
 
     branch = (
         info.git_branch
         or Shell.get_output("git branch --show-current", verbose=True).strip()
     )
-    base_branch = info.base_branch or (
-        Shell.get_output(
+    base_branch = (
+        info.base_branch
+        or Shell.get_output(
             "gh pr view --json baseRefName --template '{{.baseRefName}}'", verbose=True
-        )
-        .strip()
-        .replace("origin/", "")
+        ).strip().replace("origin/", "")
+        or "master"
     )
     repo_name = (
         info.repo_name
@@ -122,7 +131,7 @@ def get_git_info() -> tuple[str, str, str, str, str, int]:
         pr_number = int(_gh_out) if _gh_out else 0
     return (
         current_commit_sha,
-        merge_base_commit_sha,
+        master_track_commits,
         branch,
         base_branch,
         repo_name,
@@ -138,30 +147,23 @@ if __name__ == "__main__":
 
     (
         current_commit_sha,
-        merge_base_commit_sha,
+        master_track_commits,
         branch,
         base_branch,
         repo_name,
         pr_number,
     ) = get_git_info()
 
-    prev_30_commits = []
-    if pr_number > 0:
-        # Get 30 commits starting from merge base commit and walking backwards.
-        raw = Shell.get_output(
-            f"gh api 'repos/ClickHouse/ClickHouse/commits?sha={merge_base_commit_sha}&per_page=30' -q '.[].sha'",
-            verbose=True,
-        )
-        prev_30_commits = raw.splitlines()
+    # Use the nearest master-side commit as the base for diff comparisons.
+    base_commit_sha = master_track_commits[0] if master_track_commits else ""
 
     os.environ["BRANCH"] = branch
     os.environ["CURRENT_COMMIT"] = current_commit_sha
-    print("base_branch = ", base_branch)
     os.environ["BASE_BRANCH"] = base_branch
-    os.environ["BASE_COMMIT"] = merge_base_commit_sha
+    os.environ["BASE_COMMIT"] = base_commit_sha
     os.environ["REPO_NAME"] = repo_name
     os.environ["PR_NUMBER"] = str(pr_number)
-    os.environ["PREV_30_COMMITS"] = ",".join(prev_30_commits)
+    os.environ["PREV_30_COMMITS"] = ",".join(master_track_commits)
 
     is_master_branch = branch == "master"
     _diff_ran = False
@@ -214,14 +216,18 @@ if __name__ == "__main__":
             print(f"Current coverage  : {c_line_cov:.2f}%")
             print(f"Delta             : {delta:+.2f}%")
 
-            if c_line_cov < b_line_cov:
-                diff_res.set_failed()
-                diff_res.set_comment(
-                    f"Coverage in main branch: {b_line_cov:.2f}%, coverage in PR: {c_line_cov:.2f}%. Coverage degraded by {delta:.2f} percentage points."
+            TOLERANCE = 0.3
+            if b_line_cov - c_line_cov > TOLERANCE:
+                _failure_msg = (
+                    f"Coverage degraded: master {b_line_cov:.2f}% → PR {c_line_cov:.2f}%"
+                    f" (dropped {b_line_cov - c_line_cov:.2f} pp, tolerance {TOLERANCE} pp)"
                 )
-                print("Coverage degraded.")
+                print(_failure_msg)
+                diff_res.info = _failure_msg
+                diff_res.set_comment(_failure_msg)
+                diff_res.set_failed()
             else:
-                print("Coverage did not degrade.")
+                print(f"Coverage did not degrade beyond tolerance (delta {delta:+.2f}%).")
 
             # Compress and attach the diff HTML report archive + files to the diff result.
             Utils.compress_gz(
@@ -307,7 +313,7 @@ if __name__ == "__main__":
                     ),
                     "pull_request_number": pr_number,
                     "commit_sha": current_commit_sha,
-                    "base_commit_sha": merge_base_commit_sha,
+                    "base_commit_sha": base_commit_sha,
                     "branch": branch,
                     "base_branch": base_branch,
                     "status": diff_res.status,

--- a/ci/jobs/scripts/print_uncovered_code.py
+++ b/ci/jobs/scripts/print_uncovered_code.py
@@ -8,6 +8,42 @@ from ci.praktika.result import Result
 repo_root = Utils.cwd()
 temp_dir = f"{repo_root}/ci/tmp/"
 
+# Lines matching any of these patterns are excluded from the uncovered report:
+# they represent code paths that are intentionally never executed in normal runs
+# (error paths, logical impossibilities, unreachable markers).
+_NOISE_PATTERNS = [
+    re.compile(r"\bthrow\b"),               # any throw statement
+    re.compile(r"\bLOGICAL_ERROR\b"),        # ErrorCodes::LOGICAL_ERROR (impossible conditions)
+    re.compile(r"\bUNREACHABLE\s*\("),       # UNREACHABLE() macro
+    re.compile(r"__builtin_unreachable\s*\("),
+    re.compile(r"\babort\s*\(\s*\)"),        # abort()
+    re.compile(r"\bstd::terminate\s*\("),    # std::terminate()
+    re.compile(r"\babortOnFailedAssertion\s*\("),  # chassert failure handler
+]
+
+# Lazily-loaded source file cache: relpath -> list of raw lines
+_source_cache: dict[str, list[str]] = {}
+
+
+def _load_source(relpath: str) -> list[str]:
+    if relpath not in _source_cache:
+        abs_path = os.path.join(repo_root, relpath)
+        try:
+            with open(abs_path, encoding="utf-8", errors="replace") as f:
+                _source_cache[relpath] = f.readlines()
+        except FileNotFoundError:
+            _source_cache[relpath] = []
+    return _source_cache[relpath]
+
+
+def _is_noise(relpath: str, lineno: int) -> bool:
+    lines = _load_source(relpath)
+    if not (1 <= lineno <= len(lines)):
+        return False
+    text = lines[lineno - 1].strip()
+    return any(p.search(text) for p in _NOISE_PATTERNS)
+
+
 if __name__ == "__main__":
     DIFF = f"{temp_dir}/changes.diff"
     INFO = f"{temp_dir}/current.changed.info"
@@ -49,7 +85,7 @@ if __name__ == "__main__":
         return sf.endswith("/" + rel) or sf.endswith(rel)
 
     # --- stream parse LCOV .info: only DA lines; count only changed lines
-    total = covered = 0
+    total = covered = noise_skipped = 0
     uncovered = []  # (relpath, line)
 
     active_rel = None
@@ -83,6 +119,11 @@ if __name__ == "__main__":
                 if not in_changed:
                     continue
 
+                # Skip lines that are not meant to be executed (error paths, etc.)
+                if _is_noise(active_rel, ln):
+                    noise_skipped += 1
+                    continue
+
                 total += 1
                 if cnt > 0:
                     covered += 1
@@ -106,7 +147,7 @@ if __name__ == "__main__":
     CONTEXT = 2  # lines before/after
     MAX_PRINT = 200  # max uncovered lines to print total
 
-    msg = f"PR changed-lines coverage: {pct:.2f}% ({covered}/{total})"
+    msg = f"PR changed-lines coverage: {pct:.2f}% ({covered}/{total}, {noise_skipped} noise lines excluded)"
     print(msg)
 
     if uncovered:
@@ -118,18 +159,16 @@ if __name__ == "__main__":
             by_file[rel].append(ln)
 
         for rel in sorted(by_file.keys()):
-            abs_path = os.path.join(repo_root, rel)
+            lines = _load_source(rel)  # already cached
 
             print("=" * 80)
             print(rel)
             print("=" * 80)
 
-            if not os.path.exists(abs_path):
+            if not lines:
+                abs_path = os.path.join(repo_root, rel)
                 print(f"  [source file not found: {abs_path}]")
                 continue
-
-            with open(abs_path, encoding="utf-8", errors="replace") as f:
-                lines = f.readlines()
 
             # sort + deduplicate
             file_lines = sorted(set(by_file[rel]))

--- a/ci/jobs/scripts/print_uncovered_code.py
+++ b/ci/jobs/scripts/print_uncovered_code.py
@@ -12,7 +12,6 @@ temp_dir = f"{repo_root}/ci/tmp/"
 # they represent code paths that are intentionally never executed in normal runs
 # (error paths, logical impossibilities, unreachable markers).
 _NOISE_PATTERNS = [
-    re.compile(r"\bthrow\b"),               # any throw statement
     re.compile(r"\bLOGICAL_ERROR\b"),        # ErrorCodes::LOGICAL_ERROR (impossible conditions)
     re.compile(r"\bUNREACHABLE\s*\("),       # UNREACHABLE() macro
     re.compile(r"__builtin_unreachable\s*\("),


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the baseline commit selection and pass/fail threshold for LLVM coverage checks, which can affect CI gating outcomes. Also alters changed-lines uncovered reporting by excluding certain patterns, potentially hiding real misses if patterns are too broad.
> 
> **Overview**
> Updates the LLVM coverage CI job to derive its baseline from `master_track_commits_sha` (falling back to GitHub API when missing), and uses the nearest master-side commit as `BASE_COMMIT` while passing the full list via `PREV_30_COMMITS`.
> 
> Adjusts coverage regression handling by adding a `0.3` percentage-point tolerance and improving failure messaging, and refines changed-lines uncovered reporting by caching source files and excluding “noise” lines (e.g., `LOGICAL_ERROR`, `UNREACHABLE`, `abort`, `std::terminate`) from the report and percentage calculation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff54ad17c079126a38b2c81265de5873fb9a871d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.631`
<!-- ch-version-info:end -->