### PR TITLE
AST Fuzz projection definitions 

### DIFF
--- a/src/Common/QueryFuzzer.cpp
+++ b/src/Common/QueryFuzzer.cpp
@@ -1076,9 +1076,54 @@ void QueryFuzzer::fuzzIndexDeclaration(ASTIndexDeclaration & index)
 
 void QueryFuzzer::fuzzProjectionDeclaration(ASTProjectionDeclaration & projection)
 {
-    UNUSED(projection);
+    if (!projection.query)
+        return;
+    auto * select = typeid_cast<ASTProjectionSelectQuery *>(projection.query);
+    if (!select || !select->select())
+        return;
 
-    /// TODO finish this soon
+    /// Occasionally add _part_offset to SELECT before fuzzing,
+    /// so the fuzz passes can move/replace it along with other expressions.
+    /// _part_offset is valid in projection SELECT and GROUP BY, but NOT in ORDER BY.
+    if (fuzz_rand() % 20 == 0)
+    {
+        select->select()->children.emplace_back(make_intrusive<ASTIdentifier>("_part_offset"));
+    }
+    fuzzColumnLikeExpressionList(select->select().get());
+    /// GROUP BY — ASTProjectionSelectQuery has no ROLLUP/CUBE/GROUPING SETS/TOTALS/HAVING/WHERE
+    if (select->groupBy().get())
+    {
+        if (fuzz_rand() % 50 == 0)
+        {
+            select->groupBy()->children.clear();
+            select->setExpression(ASTProjectionSelectQuery::Expression::GROUP_BY, {});
+        }
+        else
+        {
+            if (fuzz_rand() % 20 == 0)
+            {
+                /// Occasionally add _part_offset to GROUP BY,
+                select->groupBy()->children.emplace_back(make_intrusive<ASTIdentifier>("_part_offset"));
+            }
+            fuzzColumnLikeExpressionList(select->groupBy().get());
+        }
+    }
+    else if (fuzz_rand() % 50 == 0)
+    {
+        select->setExpression(ASTProjectionSelectQuery::Expression::GROUP_BY, getRandomExpressionList(select->select()->children.size()));
+    }
+    if (select->orderBy())
+    {
+        if (fuzz_rand() % 50 == 0)
+        {
+            select->orderBy()->children.clear();
+            select->setExpression(ASTProjectionSelectQuery::Expression::ORDER_BY, {});
+        }
+        else
+        {
+            fuzzOrderByList(select->orderBy().get(), select->select()->children.size());
+        }
+    }
 }
 
 DataTypePtr QueryFuzzer::fuzzDataType(DataTypePtr type)
@@ -2517,8 +2562,30 @@ void QueryFuzzer::fuzz(ASTPtr & ast)
         if (fn->isWindowFunction() && fn->window_definition)
         {
             auto & def = fn->window_definition->as<ASTWindowDefinition &>();
-            fuzzColumnLikeExpressionList(def.partition_by.get());
-            fuzzOrderByList(def.order_by.get(), 0);
+            if (def.partition_by)
+            {
+                if (fuzz_rand() % 50 == 0)
+                {
+                    def.partition_by->children.clear();
+                    def.partition_by = nullptr;
+                }
+                else
+                {
+                    fuzzColumnLikeExpressionList(def.partition_by.get());
+                }
+            }
+            if (def.order_by)
+            {
+                if (fuzz_rand() % 50 == 0)
+                {
+                    def.order_by->children.clear();
+                    def.order_by = nullptr;
+                }
+                else
+                {
+                    fuzzOrderByList(def.order_by.get(), 0);
+                }
+            }
             fuzzWindowFrame(def);
         }
 
@@ -2722,7 +2789,18 @@ void QueryFuzzer::fuzz(ASTPtr & ast)
             addOrReplacePredicate(select, ASTSelectQuery::Expression::QUALIFY);
         }
 
-        fuzzOrderByList(select->orderBy().get(), select->select()->children.size());
+        if (select->orderBy())
+        {
+            if (fuzz_rand() % 50 == 0)
+            {
+                select->orderBy()->children.clear();
+                select->setExpression(ASTSelectQuery::Expression::ORDER_BY, {});
+            }
+            else
+            {
+                fuzzOrderByList(select->orderBy().get(), select->select()->children.size());
+            }
+        }
         if (select->orderBy().get() && fuzz_rand() % 50 == 0)
         {
             select->order_by_all = !select->order_by_all;
@@ -3129,8 +3207,30 @@ void QueryFuzzer::fuzz(ASTPtr & ast)
     }
     else if (auto * wdef = typeid_cast<ASTWindowDefinition *>(ast.get()))
     {
-        fuzzColumnLikeExpressionList(wdef->partition_by.get());
-        fuzzOrderByList(wdef->order_by.get(), 0);
+        if (wdef->partition_by)
+        {
+            if (fuzz_rand() % 50 == 0)
+            {
+                wdef->partition_by->children.clear();
+                wdef->partition_by = nullptr;
+            }
+            else
+            {
+                fuzzColumnLikeExpressionList(wdef->partition_by.get());
+            }
+        }
+        if (wdef->order_by)
+        {
+            if (fuzz_rand() % 50 == 0)
+            {
+                wdef->order_by->children.clear();
+                wdef->order_by = nullptr;
+            }
+            else
+            {
+                fuzzOrderByList(wdef->order_by.get(), 0);
+            }
+        }
         fuzzWindowFrame(*wdef);
         fuzz(wdef->children);
     }

--- a/src/Common/QueryFuzzer.cpp
+++ b/src/Common/QueryFuzzer.cpp
@@ -1139,7 +1139,7 @@ void QueryFuzzer::fuzzProjectionDeclaration(ASTProjectionDeclaration & projectio
     {
         select->setExpression(ASTProjectionSelectQuery::Expression::GROUP_BY, getRandomExpressionList(select->select()->children.size()));
     }
-    if (select->orderBy())
+    if (select->orderBy().get())
     {
         if (fuzz_rand() % 50 == 0)
         {

--- a/src/Common/QueryFuzzer.cpp
+++ b/src/Common/QueryFuzzer.cpp
@@ -2566,7 +2566,9 @@ void QueryFuzzer::fuzz(ASTPtr & ast)
             {
                 if (fuzz_rand() % 50 == 0)
                 {
+                    auto & ch = def.children;
                     def.partition_by->children.clear();
+                    ch.erase(std::remove(ch.begin(), ch.end(), def.partition_by), ch.end());
                     def.partition_by = nullptr;
                 }
                 else
@@ -2578,7 +2580,9 @@ void QueryFuzzer::fuzz(ASTPtr & ast)
             {
                 if (fuzz_rand() % 50 == 0)
                 {
+                    auto & ch = def.children;
                     def.order_by->children.clear();
+                    ch.erase(std::remove(ch.begin(), ch.end(), def.order_by), ch.end());
                     def.order_by = nullptr;
                 }
                 else
@@ -2795,6 +2799,7 @@ void QueryFuzzer::fuzz(ASTPtr & ast)
             {
                 select->orderBy()->children.clear();
                 select->setExpression(ASTSelectQuery::Expression::ORDER_BY, {});
+                select->order_by_all = false;
             }
             else
             {
@@ -3211,7 +3216,9 @@ void QueryFuzzer::fuzz(ASTPtr & ast)
         {
             if (fuzz_rand() % 50 == 0)
             {
+                auto & ch = wdef->children;
                 wdef->partition_by->children.clear();
+                ch.erase(std::remove(ch.begin(), ch.end(), wdef->partition_by), ch.end());
                 wdef->partition_by = nullptr;
             }
             else
@@ -3223,7 +3230,9 @@ void QueryFuzzer::fuzz(ASTPtr & ast)
         {
             if (fuzz_rand() % 50 == 0)
             {
+                auto & ch = wdef->children;
                 wdef->order_by->children.clear();
+                ch.erase(std::remove(ch.begin(), ch.end(), wdef->order_by), ch.end());
                 wdef->order_by = nullptr;
             }
             else

--- a/src/Common/QueryFuzzer.cpp
+++ b/src/Common/QueryFuzzer.cpp
@@ -509,6 +509,33 @@ NullsAction QueryFuzzer::fuzzNullsAction(NullsAction action)
     return action;
 }
 
+void QueryFuzzer::fuzzWindowDefinition(ASTWindowDefinition & def)
+{
+    auto removeChild = [](ASTWindowDefinition & wdef, ASTPtr & member)
+    {
+        auto & ch = wdef.children;
+        member->children.clear();
+        ch.erase(std::remove(ch.begin(), ch.end(), member), ch.end());
+        member = nullptr;
+    };
+
+    if (def.partition_by)
+    {
+        if (fuzz_rand() % 50 == 0)
+            removeChild(def, def.partition_by);
+        else
+            fuzzColumnLikeExpressionList(def.partition_by.get());
+    }
+    if (def.order_by)
+    {
+        if (fuzz_rand() % 50 == 0)
+            removeChild(def, def.order_by);
+        else
+            fuzzOrderByList(def.order_by.get(), 0);
+    }
+    fuzzWindowFrame(def);
+}
+
 void QueryFuzzer::fuzzWindowFrame(ASTWindowDefinition & def)
 {
     checkIterationLimit();
@@ -2562,35 +2589,7 @@ void QueryFuzzer::fuzz(ASTPtr & ast)
         if (fn->isWindowFunction() && fn->window_definition)
         {
             auto & def = fn->window_definition->as<ASTWindowDefinition &>();
-            if (def.partition_by)
-            {
-                if (fuzz_rand() % 50 == 0)
-                {
-                    auto & ch = def.children;
-                    def.partition_by->children.clear();
-                    ch.erase(std::remove(ch.begin(), ch.end(), def.partition_by), ch.end());
-                    def.partition_by = nullptr;
-                }
-                else
-                {
-                    fuzzColumnLikeExpressionList(def.partition_by.get());
-                }
-            }
-            if (def.order_by)
-            {
-                if (fuzz_rand() % 50 == 0)
-                {
-                    auto & ch = def.children;
-                    def.order_by->children.clear();
-                    ch.erase(std::remove(ch.begin(), ch.end(), def.order_by), ch.end());
-                    def.order_by = nullptr;
-                }
-                else
-                {
-                    fuzzOrderByList(def.order_by.get(), 0);
-                }
-            }
-            fuzzWindowFrame(def);
+            fuzzWindowDefinition(def);
         }
 
         fuzz(fn->children);
@@ -3212,35 +3211,7 @@ void QueryFuzzer::fuzz(ASTPtr & ast)
     }
     else if (auto * wdef = typeid_cast<ASTWindowDefinition *>(ast.get()))
     {
-        if (wdef->partition_by)
-        {
-            if (fuzz_rand() % 50 == 0)
-            {
-                auto & ch = wdef->children;
-                wdef->partition_by->children.clear();
-                ch.erase(std::remove(ch.begin(), ch.end(), wdef->partition_by), ch.end());
-                wdef->partition_by = nullptr;
-            }
-            else
-            {
-                fuzzColumnLikeExpressionList(wdef->partition_by.get());
-            }
-        }
-        if (wdef->order_by)
-        {
-            if (fuzz_rand() % 50 == 0)
-            {
-                auto & ch = wdef->children;
-                wdef->order_by->children.clear();
-                ch.erase(std::remove(ch.begin(), ch.end(), wdef->order_by), ch.end());
-                wdef->order_by = nullptr;
-            }
-            else
-            {
-                fuzzOrderByList(wdef->order_by.get(), 0);
-            }
-        }
-        fuzzWindowFrame(*wdef);
+        fuzzWindowDefinition(*wdef);
         fuzz(wdef->children);
     }
     else if (auto * with_elem = typeid_cast<ASTWithElement *>(ast.get()))

--- a/src/Common/QueryFuzzer.cpp
+++ b/src/Common/QueryFuzzer.cpp
@@ -1121,7 +1121,7 @@ void QueryFuzzer::fuzzProjectionDeclaration(ASTProjectionDeclaration & projectio
         }
         else
         {
-            fuzzOrderByList(select->orderBy().get(), select->select()->children.size());
+            fuzz(select->orderBy()->children);
         }
     }
 }
@@ -2793,7 +2793,7 @@ void QueryFuzzer::fuzz(ASTPtr & ast)
             addOrReplacePredicate(select, ASTSelectQuery::Expression::QUALIFY);
         }
 
-        if (select->orderBy())
+        if (select->orderBy().get())
         {
             if (fuzz_rand() % 50 == 0)
             {
@@ -2803,12 +2803,12 @@ void QueryFuzzer::fuzz(ASTPtr & ast)
             }
             else
             {
+                if (fuzz_rand() % 50 == 0)
+                {
+                    select->order_by_all = !select->order_by_all;
+                }
                 fuzzOrderByList(select->orderBy().get(), select->select()->children.size());
             }
-        }
-        if (select->orderBy().get() && fuzz_rand() % 50 == 0)
-        {
-            select->order_by_all = !select->order_by_all;
         }
         if (select->limitLength())
         {

--- a/src/Common/QueryFuzzer.h
+++ b/src/Common/QueryFuzzer.h
@@ -215,6 +215,7 @@ private:
     void fuzzColumnLikeExpressionList(IAST * ast);
     NullsAction fuzzNullsAction(NullsAction action);
     void fuzzWindowFrame(ASTWindowDefinition & def);
+    void fuzzWindowDefinition(ASTWindowDefinition & def);
     void fuzzCreateQuery(ASTCreateQuery & create);
     void fuzzExplainQuery(ASTExplainQuery & explain);
     ASTExplainQuery::ExplainKind fuzzExplainKind(ASTExplainQuery::ExplainKind kind = ASTExplainQuery::ExplainKind::QueryPipeline);


### PR DESCRIPTION

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

Also, remove order by and partition by clauses in some cases.

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes AST mutation logic for projections, window definitions, and `ORDER BY`, which can affect fuzzer stability and could surface new crashes if AST child removal/pointer bookkeeping is imperfect.
> 
> **Overview**
> Extends the AST query fuzzer to actively mutate projection definitions: it now fuzzes projection `SELECT`, optionally adds `_part_offset`, and can add/drop/fuzz `GROUP BY` and drop/fuzz `ORDER BY` within `ASTProjectionSelectQuery`.
> 
> Introduces `fuzzWindowDefinition()` and routes all window-function/window-definition fuzzing through it, including occasionally removing `PARTITION BY`/`ORDER BY` clauses from `ASTWindowDefinition`. Separately, `ASTSelectQuery` fuzzing can now sometimes drop the entire `ORDER BY` clause (and resets `order_by_all`) instead of only mutating its elements.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1054a4b9bb47b9de2f2555c8268ab580ff6e119d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.647`
<!-- ch-version-info:end -->