### PR TITLE
Re-enable and fix 01103_optimize_drop_race_zookeeper with Shared Catalog

### DIFF
--- a/tests/queries/0_stateless/01103_optimize_drop_race_zookeeper.sh
+++ b/tests/queries/0_stateless/01103_optimize_drop_race_zookeeper.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
-# Tags: race, zookeeper, no-shared-catalog
-# no-shared-catalog: times out in private
+# Tags: race, zookeeper
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -32,7 +31,7 @@ function thread3()
     while [ $SECONDS -lt "$TIMELIMIT" ]; do
         $CLICKHOUSE_CLIENT -n -q "DROP TABLE IF EXISTS concurrent_optimize_table;
             CREATE TABLE concurrent_optimize_table (a UInt8, b Int16, c Float32, d String, e Array(UInt8), f Nullable(UUID), g Tuple(UInt8, UInt16))
-            ENGINE = ReplicatedMergeTree('/clickhouse/tables/$CLICKHOUSE_TEST_ZOOKEEPER_PREFIX/concurrent_optimize_table', '1') ORDER BY a PARTITION BY b % 10
+            ENGINE = ReplicatedMergeTree('/clickhouse/tables/$CLICKHOUSE_TEST_ZOOKEEPER_PREFIX/concurrent_optimize_table', '$1') ORDER BY a PARTITION BY b % 10
             SETTINGS old_parts_lifetime = 1, cleanup_delay_period = 0, cleanup_delay_period_random_add = 0, cleanup_thread_preferred_points_per_iteration=0;";
         sleep 0.$RANDOM;
         sleep 0.$RANDOM;
@@ -45,19 +44,19 @@ TIMEOUT=15
 
 thread1 2> /dev/null &
 thread2 2> /dev/null &
-thread3 2> /dev/null &
+thread3 1 2> /dev/null &
 
 thread1 2> /dev/null &
 thread2 2> /dev/null &
-thread3 2> /dev/null &
+thread3 2 2> /dev/null &
 
 thread1 2> /dev/null &
 thread2 2> /dev/null &
-thread3 2> /dev/null &
+thread3 3 2> /dev/null &
 
 thread1 2> /dev/null &
 thread2 2> /dev/null &
-thread3 2> /dev/null &
+thread3 4 2> /dev/null &
 
 wait
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that adjusts how replicas are named in a Zookeeper race test; low impact outside CI, with small risk of changing test flakiness/coverage.
> 
> **Overview**
> Updates the `01103_optimize_drop_race_zookeeper.sh` stateless test to run `thread3` with **distinct ReplicatedMergeTree replica ids** (passing `1`–`4`) instead of always using `'1'`, reducing replica-name collisions during concurrent DROP/CREATE.
> 
> Removes the `no-shared-catalog` tag annotation from the test metadata.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 901bc54d039ead6d99c313a3c8df55a3892e9668. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.640`
<!-- ch-version-info:end -->