### PR TITLE
Revert "Merge pull request #96194 from scanhex12/add_schema_s3_check"

### DIFF
--- a/src/Storages/ObjectStorage/StorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorage.cpp
@@ -3,7 +3,6 @@
 #include <Common/Exception.h>
 #include <Common/Logger.h>
 #include <Common/logger_useful.h>
-#include <Core/LogsLevel.h>
 #include <Core/Settings.h>
 #include <Formats/FormatFactory.h>
 #include <Formats/ReadSchemaUtils.h>
@@ -35,6 +34,7 @@
 #include <Storages/ColumnsDescription.h>
 #include <Storages/HivePartitioningUtils.h>
 #include <Storages/ObjectStorage/StorageObjectStorageSettings.h>
+
 
 namespace DB
 {
@@ -190,6 +190,8 @@ StorageObjectStorage::StorageObjectStorage(
 
     if (need_resolve_columns_or_format)
         resolveSchemaAndFormat(columns, configuration->format, object_storage, configuration, format_settings, sample_path, context);
+    else
+        validateSupportedColumns(columns, *configuration);
 
     configuration->check(context);
 
@@ -218,25 +220,6 @@ StorageObjectStorage::StorageObjectStorage(
         columns_in_table_or_function_definition.empty(),
         format_settings,
         context);
-
-    bool validate_schema_with_remote = !need_resolve_columns_or_format
-        && !configuration->isDataLakeConfiguration()
-        && !columns_in_table_or_function_definition.empty()
-        && !is_table_function
-        && mode == LoadingStrictnessLevel::CREATE
-        && !do_lazy_init;
-
-    validateColumns(
-        columns,
-        configuration_,
-        validate_schema_with_remote,
-        object_storage_,
-        &format_settings,
-        &sample_path,
-        context,
-        &hive_partition_columns_to_read_from_file_path,
-        &columns_in_table_or_function_definition,
-        log);
 
     // Assert file contains at least one column. The assertion only takes place if we were able to deduce the schema. The storage might be empty.
     if (!columns.empty() && file_columns.empty())

--- a/src/Storages/ObjectStorage/Utils.cpp
+++ b/src/Storages/ObjectStorage/Utils.cpp
@@ -1,8 +1,5 @@
 #include <Core/Settings.h>
-#include <Common/Exception.h>
-#include <Common/Logger.h>
 #include <Common/filesystemHelpers.h>
-#include <Core/LogsLevel.h>
 #include <Disks/IO/AsynchronousBoundedReadBuffer.h>
 #include <Disks/IO/CachedOnDiskReadBufferFromFile.h>
 #include <Disks/IO/getThreadPoolReader.h>
@@ -17,7 +14,6 @@
 #include <Interpreters/evaluateConstantExpression.h>
 #include <Storages/checkAndGetLiteralArgument.h>
 #include <Poco/UUIDGenerator.h>
-#include <fmt/format.h>
 
 namespace DB
 {
@@ -110,69 +106,19 @@ void resolveSchemaAndFormat(
         format = StorageObjectStorage::resolveFormatFromData(object_storage, configuration, format_settings, sample_path, context);
     }
 
-    validateColumns(columns, configuration);
+    validateSupportedColumns(columns, *configuration);
 }
 
-void validateColumns(
-    const ColumnsDescription & columns,
-    StorageObjectStorageConfigurationPtr configuration,
-    bool validate_schema_with_remote,
-    ObjectStoragePtr object_storage,
-    const std::optional<FormatSettings> * format_settings,
-    const std::string * sample_path,
-    ContextPtr context,
-    const NamesAndTypesList * hive_partition_columns_to_read_from_file_path,
-    const ColumnsDescription * columns_in_table_or_function_definition,
-    LoggerPtr log)
+void validateSupportedColumns(
+    ColumnsDescription & columns,
+    const StorageObjectStorageConfiguration & configuration)
 {
     if (!columns.hasOnlyOrdinary())
     {
         /// We don't allow special columns.
         throw Exception(ErrorCodes::BAD_ARGUMENTS,
             "Special columns like MATERIALIZED, ALIAS or EPHEMERAL are not supported for {} storage.",
-            configuration ? configuration->getTypeName() : "object storage");
-    }
-
-    /// If schema validation parameters are not provided, skip schema consistency check.
-    /// validateColumns is only called with full arguments from StorageObjectStorage when
-    /// resolveSchemaAndFormat was not used (validate_schema_with_remote == true).
-    if (!object_storage || !configuration || !format_settings || !sample_path || !context
-        || !hive_partition_columns_to_read_from_file_path || !columns_in_table_or_function_definition || !log)
-        return;
-
-    /// We don't check csv and tsv formats because they change column names.
-    if (!validate_schema_with_remote
-        || configuration->format == "CSV"
-        || configuration->format == "TSV")
-        return;
-
-    /// Verify that explicitly specified columns exist in the schema inferred from data.
-    String sample_path_schema = *sample_path;
-    std::optional<ColumnsDescription> schema_file;
-    try
-    {
-        schema_file = StorageObjectStorage::resolveSchemaFromData(
-            object_storage,
-            configuration,
-            *format_settings,
-            sample_path_schema,
-            context);
-    }
-    catch (...)
-    {
-        tryLogCurrentException(log, "while verifying schema consistency", LogsLevel::debug);
-    }
-    if (schema_file)
-    {
-        auto hive_partitioning_columns = hive_partition_columns_to_read_from_file_path->getNameSet();
-        for (const auto & column : *columns_in_table_or_function_definition)
-            if (!schema_file->tryGet(column.name) && !hive_partitioning_columns.contains(column.name))
-            {
-                String hive_columns;
-                for (const auto & hive_column : hive_partitioning_columns)
-                    hive_columns += hive_column + ";";
-                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Cannot find column {} in schema {}, hive columns {}", column.name, schema_file->toString(false), hive_columns);
-            }
+            configuration.getTypeName());
     }
 }
 

--- a/src/Storages/ObjectStorage/Utils.h
+++ b/src/Storages/ObjectStorage/Utils.h
@@ -1,8 +1,6 @@
 #pragma once
 #include <Storages/ObjectStorage/StorageObjectStorage.h>
 #include <Parsers/IAST_fwd.h>
-#include <Core/NamesAndTypes.h>
-#include <Common/Logger.h>
 
 namespace DB
 {
@@ -25,17 +23,9 @@ void resolveSchemaAndFormat(
     std::string & sample_path,
     const ContextPtr & context);
 
-void validateColumns(
-    const ColumnsDescription & columns,
-    StorageObjectStorageConfigurationPtr configuration = nullptr,
-    bool validate_schema_with_remote = false,
-    ObjectStoragePtr object_storage = nullptr,
-    const std::optional<FormatSettings> * format_settings = nullptr,
-    const std::string * sample_path = nullptr,
-    ContextPtr context = nullptr,
-    const NamesAndTypesList * hive_partition_columns_to_read_from_file_path = nullptr,
-    const ColumnsDescription * columns_in_table_or_function_definition = nullptr,
-    LoggerPtr log = nullptr);
+void validateSupportedColumns(
+    ColumnsDescription & columns,
+    const StorageObjectStorageConfiguration & configuration);
 
 std::unique_ptr<ReadBufferFromFileBase> createReadBuffer(
     RelativePathWithMetadata & object_info,

--- a/tests/integration/test_storage_s3/test.py
+++ b/tests/integration/test_storage_s3/test.py
@@ -1298,36 +1298,6 @@ def test_url_reconnect_in_the_middle(started_cluster):
         assert result == "1000000\t3914219105369203805\n"
 
 
-def test_check_parquet_schema(started_cluster):
-    instance = started_cluster.instances["dummy"]  # type: ClickHouseInstance
-    format_name = 'Parquet'
-    idx = random.randint(0, 1000000)
-    file_path = f'http://minio1:9001/root/test_parquet/test_check_parquet_schema_{idx}.parquet'
-    table_function = f"s3('{file_path}', structure='a Int32, b String', format='{format_name}')"
-    expected_lines = 15000
-    instance.query("DROP TABLE IF EXISTS t_s3_schema_test")
-    instance.query(f"""
-        CREATE TABLE t_s3_schema_test
-        (
-            a Int32,
-            b String
-        )
-        ENGINE = S3('{file_path}', '{format_name}')
-        SETTINGS s3_truncate_on_insert = 1
-    """)
-
-    exec_query_with_retry(
-        instance,
-        f"INSERT INTO t_s3_schema_test SELECT number, randomString(100) FROM numbers({expected_lines})",
-        timeout=300,
-    )
-
-    instance.query("DROP TABLE IF EXISTS test_check_parquet_schema")
-    instance.query_and_get_error(f"CREATE TABLE test_check_parquet_schema (a Int32, b String, c Int32) ENGINE = S3('{file_path}')")
-    instance.query_and_get_error(f"CREATE TABLE test_check_parquet_schema (d Int32, b String) ENGINE = S3('{file_path}')")
-    instance.query(f"CREATE TABLE test_check_parquet_schema (a Int32) ENGINE = S3('{file_path}')")
-
-
 # At the time of writing the actual read bytes are respectively 148 and 169, so -10% to not be flaky
 @pytest.mark.parametrize(
     "format_name,expected_bytes_read", [("Parquet", 133), ("ORC", 150)]

--- a/tests/queries/0_stateless/03363_hive_style_partition.reference
+++ b/tests/queries/0_stateless/03363_hive_style_partition.reference
@@ -34,4 +34,5 @@ test/t_03363_function/year=2025/country=/<snowflakeid>.parquet	11
 1
 3
 USA	2022	1
+0
 1

--- a/tests/queries/0_stateless/03363_hive_style_partition.sql
+++ b/tests/queries/0_stateless/03363_hive_style_partition.sql
@@ -79,12 +79,18 @@ INSERT INTO FUNCTION s3(s3_conn, filename='half_baked', format=Parquet, partitio
 -- Should fail because contains only partition columns in schema and `use_hive_partitioning=1`
 CREATE TABLE s3_table_half_schema_with_format (year UInt64) engine=S3(s3_conn, filename='half_baked/**.parquet', format=Parquet) SETTINGS use_hive_partitioning=1; -- {serverError INCORRECT_DATA}
 
--- Shouldn't succeed because hive is off and schema contains non existing parquet columns
-CREATE TABLE s3_table_half_schema_with_format (year UInt64) engine=S3(s3_conn, filename='half_baked/**.parquet', format=Parquet) SETTINGS use_hive_partitioning=0;  -- {serverError BAD_ARGUMENTS}
+-- Should succeed because hive is off
+CREATE TABLE s3_table_half_schema_with_format (year UInt64) engine=S3(s3_conn, filename='half_baked/**.parquet', format=Parquet) SETTINGS use_hive_partitioning=0;
+
+-- Should succeed and not return hive columns (as nothing else is in schema - then no columns at all). Distinct because maybe MinIO isn't cleaned up
+SELECT DISTINCT * FROM s3_table_half_schema_with_format;
 
 CREATE TABLE s3_table_half_schema_with_format_2 (key UInt64) engine=S3(s3_conn, filename='half_baked/**.parquet', format=Parquet) SETTINGS use_hive_partitioning=0;
 
 SELECT DISTINCT * FROM s3_table_half_schema_with_format_2;
+
+-- Should fail because the column year does not exist
+SELECT key, * FROM s3_table_half_schema_with_format; -- {serverError UNKNOWN_IDENTIFIER}
 
 -- hive with partition id placeholder
 CREATE TABLE t_03363_s3_sink (year UInt16, country String, counter UInt8)


### PR DESCRIPTION
This reverts commit 584f3acef8fc4df4f90b107057ac1249f8a9e221, reversing changes made to 7dbecb0eea138b2e228ae5e8faa42ae9536d03c7.

Closes: https://github.com/ClickHouse/ClickHouse/issues/99190

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes CREATE-time remote schema consistency validation for object-storage tables/functions, which can change when invalid schemas are accepted and shift errors to query time. Affects S3/Hive partitioning behavior and related test expectations.
> 
> **Overview**
> Reverts the previously-added *remote schema consistency check* for object-storage engines during `CREATE TABLE` when a structure is explicitly provided.
> 
> `validateColumns` is removed and replaced with a narrower `validateSupportedColumns` check (only rejects non-ordinary columns), and `StorageObjectStorage` now skips any remote schema probing/column-existence validation when schema/format are already specified.
> 
> Tests are updated accordingly: the integration `test_check_parquet_schema` is removed, and the hive partitioning stateless test now expects table creation with a partition-only schema to succeed when `use_hive_partitioning=0` (with follow-up query expectations adjusted).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit adcc59328247519fc98183658d1fe7577aa053a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.653`
- Backported to: `26.2.5.26`
<!-- ch-version-info:end -->