### PR TITLE
Remove 00234 from stress test smoke check

### DIFF
--- a/ci/jobs/scripts/stress/stress.py
+++ b/ci/jobs/scripts/stress/stress.py
@@ -265,7 +265,7 @@ def run_func_test(
         commands.append(full_command)
         check_command = (
             full_command
-            + "--server-logs-level fatal --jobs 1 00001_select_1 00234_disjunctive_equality_chains_optimization"
+            + "--server-logs-level fatal --jobs 1 00001_select_1"
         )
         logging.info(check_command)
         try:


### PR DESCRIPTION
## Summary

The smoke check added in c8e57a918ece runs `00234_disjunctive_equality_chains_optimization` with every randomized setting combination before starting the actual stress test. With certain combos (parallel replicas + replicated database + old compatibility), this test hits a pre-existing `NOT_FOUND_COLUMN_IN_BLOCK` bug — a column name mismatch between coordinator and replica where the coordinator expects `sum(in(__table1.id, __set_UInt64_...))` but the replica produces `sum(in(id, tuple(3, 1, 2)))`.

Since `NOT_FOUND_COLUMN_IN_BLOCK` is not in the ignored errors list, the entire stress job aborts before any real testing begins, reporting only a generic "Test script failed" with no useful context in the report.

This removes `00234_disjunctive_equality_chains_optimization` from the smoke check, keeping only `00001_select_1` which is sufficient to validate that the server is alive and each randomization can execute queries.

Example failure: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=99325&sha=340848d7b5c89f444d1054cec72eff302bc93395&name_0=PR&name_1=Stress%20test%20%28arm_asan%2C%20s3%29
https://github.com/ClickHouse/ClickHouse/pull/99325

cc @fm4v

Closes #98605

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 85fa88dabbb4470db657b095c2349fd05fd41573. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->