### PR TITLE
Fix UInt64 overflow in ParserSampleRatio for large denominators

### DIFF
--- a/src/Parsers/ParserSampleRatio.cpp
+++ b/src/Parsers/ParserSampleRatio.cpp
@@ -1,17 +1,24 @@
 #include <IO/ReadHelpers.h>
 #include <Parsers/ASTSampleRatio.h>
 #include <Parsers/ParserSampleRatio.h>
-#include <Common/intExp10.h>
 
 
 namespace DB
 {
 
 
+static ASTSampleRatio::BigNum bigIntExp10(int x)
+{
+    ASTSampleRatio::BigNum result = 1;
+    for (int i = 0; i < x; ++i)
+        result *= 10;
+    return result;
+}
+
 static bool parseDecimal(const char * pos, const char * end, ASTSampleRatio::Rational & res)
 {
-    UInt64 num_before = 0;
-    UInt64 num_after = 0;
+    ASTSampleRatio::BigNum num_before = 0;
+    ASTSampleRatio::BigNum num_after = 0;
     Int32 exponent = 0;
 
     const char * pos_after_first_num = tryReadIntText(num_before, pos, end);
@@ -46,13 +53,13 @@ static bool parseDecimal(const char * pos, const char * end, ASTSampleRatio::Rat
             return false;
     }
 
-    res.numerator = num_before * intExp10(number_of_digits_after_point) + num_after;
-    res.denominator = intExp10(number_of_digits_after_point);
+    res.numerator = num_before * bigIntExp10(number_of_digits_after_point) + num_after;
+    res.denominator = bigIntExp10(number_of_digits_after_point);
 
     if (exponent > 0)
-        res.numerator *= intExp10(exponent);
+        res.numerator *= bigIntExp10(exponent);
     if (exponent < 0)
-        res.denominator *= intExp10(-exponent);
+        res.denominator *= bigIntExp10(-exponent);
 
     /// NOTE You do not need to remove the common power of ten from the numerator and denominator.
     return true;

--- a/src/Parsers/ParserSampleRatio.cpp
+++ b/src/Parsers/ParserSampleRatio.cpp
@@ -1,17 +1,68 @@
 #include <IO/ReadHelpers.h>
 #include <Parsers/ASTSampleRatio.h>
 #include <Parsers/ParserSampleRatio.h>
+#include <base/extended_types.h>
 
 
 namespace DB
 {
 
 
-static ASTSampleRatio::BigNum bigIntExp10(int x)
+static constexpr int MAX_128BIT_EXPONENT = 38; /// 10^38 < 2^128 < 10^39.
+static constexpr auto MAX_BIG_NUM = std::numeric_limits<unsigned __int128>::max();
+
+/// Returns 10^x as __uint128_t. Saturates to max for x > 38.
+static ASTSampleRatio::BigNum bigIntExp10(Int64 x)
 {
+    if (x < 0)
+        return 0;
+    if (x > MAX_128BIT_EXPONENT)
+        return MAX_BIG_NUM;
+
     ASTSampleRatio::BigNum result = 1;
-    for (int i = 0; i < x; ++i)
+    for (Int64 i = 0; i < x; ++i)
         result *= 10;
+    return result;
+}
+
+/// Saturating multiplication for __uint128_t.
+static ASTSampleRatio::BigNum saturatingMultiply(ASTSampleRatio::BigNum a, ASTSampleRatio::BigNum b)
+{
+    if (a == 0 || b == 0)
+        return 0;
+    if (a > MAX_BIG_NUM / b)
+        return MAX_BIG_NUM;
+    return a * b;
+}
+
+/// Saturating addition for __uint128_t.
+static ASTSampleRatio::BigNum saturatingAdd(ASTSampleRatio::BigNum a, ASTSampleRatio::BigNum b)
+{
+    if (a > MAX_BIG_NUM - b)
+        return MAX_BIG_NUM;
+    return a + b;
+}
+
+/// Read unsigned integer into __uint128_t via UInt128 (wide::integer) to work around
+/// clang-tidy crash on tryReadIntText<__uint128_t> (llvm/llvm-project#186256).
+static const char * readUInt128Text(ASTSampleRatio::BigNum & x, const char * pos, const char * end)
+{
+    /// Skip leading zeros to count only significant digits.
+    const char * significant = pos;
+    while (significant < end && *significant == '0')
+        ++significant;
+
+    UInt128 tmp = 0;
+    const char * result = tryReadIntText(tmp, pos, end);
+    auto num_significant = result - significant;
+    /// tryReadIntText skips overflow checks for big-int types (is_big_int_v),
+    /// so values wrap modulo 2^128. Numbers with 40+ significant digits always overflow.
+    /// For exactly 39, compare the significant digits lexicographically against 2^128 - 1.
+    static constexpr std::string_view MAX_UINT128_STR = "340282366920938463463374607431768211455";
+    if (num_significant >= 40 || (num_significant == 39 && std::string_view(significant, 39) > MAX_UINT128_STR))
+        x = MAX_BIG_NUM;
+    else
+        x = static_cast<ASTSampleRatio::BigNum>(tmp);
     return result;
 }
 
@@ -21,7 +72,7 @@ static bool parseDecimal(const char * pos, const char * end, ASTSampleRatio::Rat
     ASTSampleRatio::BigNum num_after = 0;
     Int32 exponent = 0;
 
-    const char * pos_after_first_num = tryReadIntText(num_before, pos, end);
+    const char * pos_after_first_num = readUInt128Text(num_before, pos, end);
 
     bool has_num_before_point = pos_after_first_num > pos;
     pos = pos_after_first_num;
@@ -37,7 +88,7 @@ static bool parseDecimal(const char * pos, const char * end, ASTSampleRatio::Rat
 
     if (has_point)
     {
-        const char * pos_after_second_num = tryReadIntText(num_after, pos, end);
+        const char * pos_after_second_num = readUInt128Text(num_after, pos, end);
         number_of_digits_after_point = static_cast<int>(pos_after_second_num - pos);
         pos = pos_after_second_num;
     }
@@ -53,13 +104,15 @@ static bool parseDecimal(const char * pos, const char * end, ASTSampleRatio::Rat
             return false;
     }
 
-    res.numerator = num_before * bigIntExp10(number_of_digits_after_point) + num_after;
-    res.denominator = bigIntExp10(number_of_digits_after_point);
+    ASTSampleRatio::BigNum decimal_scale = bigIntExp10(number_of_digits_after_point);
+    auto product = saturatingMultiply(num_before, decimal_scale);
+    res.numerator = saturatingAdd(product, num_after);
+    res.denominator = decimal_scale;
 
     if (exponent > 0)
-        res.numerator *= bigIntExp10(exponent);
+        res.numerator = saturatingMultiply(res.numerator, bigIntExp10(exponent));
     if (exponent < 0)
-        res.denominator *= bigIntExp10(-exponent);
+        res.denominator = saturatingMultiply(res.denominator, bigIntExp10(-static_cast<Int64>(exponent)));
 
     /// NOTE You do not need to remove the common power of ten from the numerator and denominator.
     return true;
@@ -106,8 +159,8 @@ bool ParserSampleRatio::parseImpl(Pos & pos, ASTPtr & node, Expected &)
             return false;
         ++pos;
 
-        res.numerator = numerator.numerator * denominator.denominator;
-        res.denominator = numerator.denominator * denominator.numerator;
+        res.numerator = saturatingMultiply(numerator.numerator, denominator.denominator);
+        res.denominator = saturatingMultiply(numerator.denominator, denominator.numerator);
     }
     else
     {

--- a/tests/queries/0_stateless/04038_sample_offset_large_denominator.reference
+++ b/tests/queries/0_stateless/04038_sample_offset_large_denominator.reference
@@ -1,0 +1,11 @@
+OK
+OK
+OK
+OK
+OK
+OK
+OK
+OK
+OK
+OK
+OK

--- a/tests/queries/0_stateless/04038_sample_offset_large_denominator.reference
+++ b/tests/queries/0_stateless/04038_sample_offset_large_denominator.reference
@@ -9,3 +9,13 @@ OK
 OK
 OK
 OK
+OK
+OK
+OK
+OK
+OK
+OK
+OK
+OK
+OK
+OK

--- a/tests/queries/0_stateless/04038_sample_offset_large_denominator.sh
+++ b/tests/queries/0_stateless/04038_sample_offset_large_denominator.sh
@@ -12,8 +12,8 @@ function check_roundtrip()
 {
     local query="$1"
     local first second
-    first=$($CLICKHOUSE_FORMAT --oneline --query "$query" 2>&1)
-    second=$($CLICKHOUSE_FORMAT --oneline --query "$first" 2>&1)
+    first=$($CLICKHOUSE_FORMAT --oneline --query "$query" 2>&1) || { echo "FAIL: clickhouse-format failed for: $query"; echo "Got: $first"; return; }
+    second=$($CLICKHOUSE_FORMAT --oneline --query "$first" 2>&1) || { echo "FAIL: clickhouse-format failed on round-trip for: $query"; echo "Got: $second"; return; }
 
     if [ "$first" = "$second" ]; then
         echo "OK"
@@ -30,7 +30,7 @@ function check_not_contains()
     local query="$1"
     local forbidden="$2"
     local result
-    result=$($CLICKHOUSE_FORMAT --oneline --query "$query" 2>&1)
+    result=$($CLICKHOUSE_FORMAT --oneline --query "$query" 2>&1) || { echo "FAIL: clickhouse-format failed for: $query"; echo "Got: $result"; return; }
 
     if echo "$result" | grep -qF "$forbidden"; then
         echo "FAIL: output contains '$forbidden' for: $query"
@@ -46,7 +46,7 @@ function check_contains()
     local query="$1"
     local expected="$2"
     local result
-    result=$($CLICKHOUSE_FORMAT --oneline --query "$query" 2>&1)
+    result=$($CLICKHOUSE_FORMAT --oneline --query "$query" 2>&1) || { echo "FAIL: clickhouse-format failed for: $query"; echo "Got: $result"; return; }
 
     if echo "$result" | grep -qF "$expected"; then
         echo "OK"

--- a/tests/queries/0_stateless/04038_sample_offset_large_denominator.sh
+++ b/tests/queries/0_stateless/04038_sample_offset_large_denominator.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 
 # Regression test for AST round-trip of SAMPLE ratios.
-# Verifies that formatting a SAMPLE clause and parsing it back produces identical SQL.
-# The original bug: OFFSET 1.1920928955078125e-7 produces a denominator of 10^23,
-# which overflowed UInt64 in ParserSampleRatio, turning the denominator into 0.
+# Verifies that formatting a SAMPLE clause and parsing it back produces identical SQL,
+# and that large values saturate instead of wrapping to wrong results.
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -22,6 +21,38 @@ function check_roundtrip()
         echo "FAIL: AST round-trip mismatch for: $query"
         echo "First:  $first"
         echo "Second: $second"
+    fi
+}
+
+# Verify the formatted output does not contain a forbidden pattern.
+function check_not_contains()
+{
+    local query="$1"
+    local forbidden="$2"
+    local result
+    result=$($CLICKHOUSE_FORMAT --oneline --query "$query" 2>&1)
+
+    if echo "$result" | grep -qF "$forbidden"; then
+        echo "FAIL: output contains '$forbidden' for: $query"
+        echo "Got: $result"
+    else
+        echo "OK"
+    fi
+}
+
+# Verify the formatted output contains an expected pattern.
+function check_contains()
+{
+    local query="$1"
+    local expected="$2"
+    local result
+    result=$($CLICKHOUSE_FORMAT --oneline --query "$query" 2>&1)
+
+    if echo "$result" | grep -qF "$expected"; then
+        echo "OK"
+    else
+        echo "FAIL: output does not contain '$expected' for: $query"
+        echo "Got: $result"
     fi
 }
 
@@ -57,3 +88,33 @@ check_roundtrip "SELECT 1 FROM numbers(1) SAMPLE 0.00000001 OFFSET 0.99999999"
 
 # SAMPLE in a subquery inside a JOIN (mirrors the original fuzzer-found pattern).
 check_roundtrip "SELECT * FROM numbers(1) JOIN (SELECT number FROM numbers(1) SAMPLE 1 / 10 OFFSET 1e-8) AS sub ON sub.number = number"
+
+# Extreme exponent that would cause DoS with an unbounded loop. Must return instantly.
+check_roundtrip "SELECT 1 FROM numbers(1) SAMPLE 1e-2000000000"
+
+# Combined large fractional part + large negative exponent: denominator must not wrap to 1.
+# Before the fix, the denominator overflowed and wrapped to a small value.
+# The forbidden pattern uses a newline-terminated match via grep -x to avoid matching "SAMPLE 1 / <big>".
+check_not_contains "SELECT 1 FROM numbers(1) SAMPLE 0.000000000000000000000000000000000000001e-39" "SAMPLE 1 / 1"
+
+# Large integer.fraction where the multiply saturates but num_after > 0; must not wrap to small value.
+check_not_contains "SELECT 1 FROM numbers(1) SAMPLE 99999999999999999999999999999999999999.999999999" "SAMPLE 0"
+
+# Integer literal at 2^128 (39+ digits) must saturate to 2^128 - 1.
+check_contains "SELECT 1 FROM numbers(1) SAMPLE 1 / 340282366920938463463374607431768211456" "/ 340282366920938463463374607431768211455"
+
+# Valid 39-digit denominator below 2^128 must remain exact (no false saturation).
+check_contains "SELECT 1 FROM numbers(1) SAMPLE 1 / 100000000000000000000000000000000000000" "/ 100000000000000000000000000000000000000"
+
+# 20-digit denominator must not wrap to a small value.
+check_not_contains "SELECT 1 FROM numbers(1) SAMPLE 1 / 100000000000000000000" "/ 0"
+
+# 20-digit numerator in explicit rational must not wrap.
+check_not_contains "SELECT 1 FROM numbers(1) SAMPLE 99999999999999999999 / 100000000000000000001" "SAMPLE 0"
+
+# 39-digit value above 2^128-1 that wraps to a value >= 10^38 must still saturate.
+check_contains "SELECT 1 FROM numbers(1) SAMPLE 1 / 500000000000000000000000000000000000000" "/ 340282366920938463463374607431768211455"
+
+# Leading zeros must not inflate digit count and cause false saturation.
+check_contains "SELECT 1 FROM numbers(1) SAMPLE 0000000000000000000000000000000000000001" "SAMPLE 1"
+check_not_contains "SELECT 1 FROM numbers(1) SAMPLE 1 / 0000000000000000000000000000000000000001" "/ 340282366920938463463374607431768211455"

--- a/tests/queries/0_stateless/04038_sample_offset_large_denominator.sh
+++ b/tests/queries/0_stateless/04038_sample_offset_large_denominator.sh
@@ -93,8 +93,6 @@ check_roundtrip "SELECT * FROM numbers(1) JOIN (SELECT number FROM numbers(1) SA
 check_roundtrip "SELECT 1 FROM numbers(1) SAMPLE 1e-2000000000"
 
 # Combined large fractional part + large negative exponent: denominator must not wrap to 1.
-# Before the fix, the denominator overflowed and wrapped to a small value.
-# The forbidden pattern uses a newline-terminated match via grep -x to avoid matching "SAMPLE 1 / <big>".
 check_not_contains "SELECT 1 FROM numbers(1) SAMPLE 0.000000000000000000000000000000000000001e-39" "SAMPLE 1 / 1"
 
 # Large integer.fraction where the multiply saturates but num_after > 0; must not wrap to small value.

--- a/tests/queries/0_stateless/04038_sample_offset_large_denominator.sh
+++ b/tests/queries/0_stateless/04038_sample_offset_large_denominator.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+# Regression test for AST round-trip of SAMPLE ratios.
+# Verifies that formatting a SAMPLE clause and parsing it back produces identical SQL.
+# The original bug: OFFSET 1.1920928955078125e-7 produces a denominator of 10^23,
+# which overflowed UInt64 in ParserSampleRatio, turning the denominator into 0.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+function check_roundtrip()
+{
+    local query="$1"
+    local first second
+    first=$($CLICKHOUSE_FORMAT --oneline --query "$query" 2>&1)
+    second=$($CLICKHOUSE_FORMAT --oneline --query "$first" 2>&1)
+
+    if [ "$first" = "$second" ]; then
+        echo "OK"
+    else
+        echo "FAIL: AST round-trip mismatch for: $query"
+        echo "First:  $first"
+        echo "Second: $second"
+    fi
+}
+
+# Original fuzzer crash: denominator 10^23 overflows UInt64.
+check_roundtrip "SELECT 1 FROM numbers(1) SAMPLE 1 / 10 OFFSET 1.1920928955078125e-7"
+
+# Scientific notation with large negative exponent (denominator 10^20).
+check_roundtrip "SELECT 1 FROM numbers(1) SAMPLE 1e-20"
+
+# Decimal with 25 digits after point — denominator is 10^25.
+check_roundtrip "SELECT 1 FROM numbers(1) SAMPLE 0.0000000000000000000000001"
+
+# Both SAMPLE and OFFSET have large denominators.
+check_roundtrip "SELECT 1 FROM numbers(1) SAMPLE 1e-10 OFFSET 1e-12"
+
+# Explicit rational with numerator and denominator exceeding UInt64 max.
+check_roundtrip "SELECT 1 FROM numbers(1) SAMPLE 99999999999999999999 / 100000000000000000001"
+
+# Boundary: 20-digit denominator (10^19 fits in UInt64, 10^20 does not).
+check_roundtrip "SELECT 1 FROM numbers(1) SAMPLE 1 / 100000000000000000000"
+
+# Boundary: 19-digit denominator (10^18, fits in UInt64 — should always have worked).
+check_roundtrip "SELECT 1 FROM numbers(1) SAMPLE 1 / 1000000000000000000"
+
+# Large numerator in scientific notation.
+check_roundtrip "SELECT 1 FROM numbers(1) SAMPLE 9999999999999999.0e-30"
+
+# Many significant digits in the decimal part.
+check_roundtrip "SELECT 1 FROM numbers(1) SAMPLE 0.123456789012345678901234567890"
+
+# Fractional SAMPLE with fractional OFFSET (both as decimals).
+check_roundtrip "SELECT 1 FROM numbers(1) SAMPLE 0.00000001 OFFSET 0.99999999"
+
+# SAMPLE in a subquery inside a JOIN (mirrors the original fuzzer-found pattern).
+check_roundtrip "SELECT * FROM numbers(1) JOIN (SELECT number FROM numbers(1) SAMPLE 1 / 10 OFFSET 1e-8) AS sub ON sub.number = number"


### PR DESCRIPTION
`parseDecimal` in `ParserSampleRatio` used `UInt64` for intermediate values and `intExp10` (capped at 10^19) to compute powers of ten. When a SAMPLE ratio had a denominator exceeding `UInt64` range (e.g. `OFFSET 1.1920928955078125e-7` producing denominator 10^23), the value silently overflowed to 0, causing an inconsistent AST formatting exception in debug builds.

Fix: use `__uint128_t` (the same type as `BigNum`) for intermediate parsing variables, and replace `intExp10` with a local 128-bit `bigIntExp10` helper.

Found by AST fuzzer: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=99275&sha=02cbf439dce5a648c1742669098432168ff1ccfc&name_0=PR&name_1=AST%20fuzzer%20%28amd_debug%29
https://github.com/ClickHouse/ClickHouse/pull/99275

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes numeric parsing/normalization of `SAMPLE` ratios (including exponent handling) by switching to 128-bit saturating arithmetic, which can affect how extreme literals are interpreted and formatted.
> 
> **Overview**
> Fixes `ParserSampleRatio::parseDecimal` overflow issues for large `SAMPLE`/`OFFSET` ratios by switching intermediates to `ASTSampleRatio::BigNum` (`__uint128_t`), replacing `intExp10` with a capped 128-bit `bigIntExp10`, and using saturating add/multiply to avoid wraparound.
> 
> Adds a dedicated `0_stateless` regression test (`04038_sample_offset_large_denominator`) that round-trips `clickhouse-format` across large denominators, extreme exponents, leading zeros, and boundary/overflow cases to ensure formatting/parsing stays stable and saturates instead of producing incorrect small values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dcf7645eddebea3b2c387270ca69c26b7e41cc1e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.639`
<!-- ch-version-info:end -->