### PR TITLE
CI: Run ARM performance tests by default, gate AMD behind performance label

### DIFF
--- a/ci/jobs/scripts/workflow_hooks/filter_job.py
+++ b/ci/jobs/scripts/workflow_hooks/filter_job.py
@@ -214,8 +214,9 @@ def should_skip_job(job_name):
 
     # skip ARM perf tests for non-performance update
     if (
-        "- Performance Improvement" not in _info_cache.pr_body
+        " Performance Improvement" not in _info_cache.pr_body
         and Labels.CI_PERFORMANCE not in _info_cache.pr_labels
+        and Labels.PR_PERFORMANCE not in _info_cache.pr_labels
         and JobNames.PERFORMANCE in job_name
         and "arm" in job_name
         and _info_cache.pr_number  # run all performance jobs on master

--- a/ci/jobs/scripts/workflow_hooks/filter_job.py
+++ b/ci/jobs/scripts/workflow_hooks/filter_job.py
@@ -212,13 +212,13 @@ def should_skip_job(job_name):
     ):
         return True, "Skipped, no integration tests updates"
 
-    # skip ARM perf tests for non-performance update
+    # skip AMD perf tests for non-performance update (ARM runs by default)
     if (
         " Performance Improvement" not in _info_cache.pr_body
         and Labels.CI_PERFORMANCE not in _info_cache.pr_labels
         and Labels.PR_PERFORMANCE not in _info_cache.pr_labels
         and JobNames.PERFORMANCE in job_name
-        and "arm" in job_name
+        and "amd" in job_name
         and _info_cache.pr_number  # run all performance jobs on master
     ):
         return True, "Skipped, not labeled with 'pr-performance'"


### PR DESCRIPTION
The CI filter in `filter_job.py` skipped ARM performance tests for PRs that weren't tagged as performance improvements. This should be inverted: ARM should run by default since most Cloud usage is on ARM, while AMD perf tests should be gated.

Additionally, the previous filter had two bugs that caused ARM perf tests to be skipped even for actual performance PRs:

1. The PR body check matched `"- Performance Improvement"` literally, but PRs may use `*` as the markdown list marker. Changed to `" Performance Improvement"` (matching the `" Bug Fix"` pattern used elsewhere in the same file).

2. The label check only looked for the manually-added `ci-performance` label, ignoring the auto-assigned `pr-performance` label. Now both labels are checked.

Example of a performance PR where ARM tests were incorrectly skipped: https://github.com/ClickHouse/ClickHouse/pull/99327

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is not required for this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small CI job-filter tweak that only changes which performance jobs are skipped for PRs, with no production code impact.
> 
> **Overview**
> Updates `filter_job.py` so **AMD** performance jobs are skipped on PRs unless the PR indicates a performance change (via PR body "Performance Improvement" or either `ci-performance`/`pr-performance` labels), while **ARM** performance jobs run by default.
> 
> Also fixes the PR body check to match " Performance Improvement" (not the literal list marker `- Performance Improvement`), preventing perf PRs from being incorrectly filtered.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5aa485895cced3c1deaae9ff181aa4f5e5642bb5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.717`
<!-- ch-version-info:end -->